### PR TITLE
app-builder v2: tiered planner/worker subagent builds (JARVIS-1060)

### DIFF
--- a/assistant/knip.json
+++ b/assistant/knip.json
@@ -5,7 +5,8 @@
     "scripts/**/*.ts",
     "src/daemon/main.ts!",
     "src/plugin-api/index.ts!",
-    "src/api/index.ts!"
+    "src/api/index.ts!",
+    "src/config/bundled-skills/app-builder/__evals__/index.ts!"
   ],
   "project": ["src/**/*.ts!", "src/**/*.tsx!", "scripts/**/*.ts"],
   "ignoreDependencies": [

--- a/assistant/src/__tests__/app-builder-skill-instructions.test.ts
+++ b/assistant/src/__tests__/app-builder-skill-instructions.test.ts
@@ -1,16 +1,21 @@
 import { readFile } from "node:fs/promises";
 import { describe, expect, test } from "bun:test";
 
+const readSkill = () =>
+  readFile(
+    new URL("../config/bundled-skills/app-builder/SKILL.md", import.meta.url),
+    "utf8",
+  );
+
 describe("app-builder skill instructions", () => {
   test("uses non-CLI UI confirmation for optional profile switch", async () => {
-    const skillText = await readFile(
-      new URL("../config/bundled-skills/app-builder/SKILL.md", import.meta.url),
-      "utf8",
-    );
+    const skillText = await readSkill();
     const preflightStart = skillText.indexOf("### Step 0");
     const preflightEnd = skillText.indexOf("### Step 1");
     const preflight = skillText.slice(preflightStart, preflightEnd);
 
+    expect(preflightStart).toBeGreaterThan(-1);
+    expect(preflightEnd).toBeGreaterThan(preflightStart);
     expect(preflight).not.toContain("assistant ui confirm --message");
     expect(preflight).toContain("Use the `ui_show` tool");
     expect(preflight).toContain('surface_type: "confirmation"');
@@ -18,5 +23,28 @@ describe("app-builder skill instructions", () => {
     expect(preflight).toContain(
       "Do not call the shell command `assistant ui confirm`",
     );
+  });
+
+  test("dispatches coder workers via subagent_spawn with override_profile", async () => {
+    const skillText = await readSkill();
+
+    // The tiered workflow routes parallel workers through subagent_spawn,
+    // and the per-spawn override_profile is what tier-routes them.
+    expect(skillText).toContain("subagent_spawn");
+    expect(skillText).toContain("override_profile");
+    expect(skillText.indexOf("override_profile")).toBeGreaterThan(
+      skillText.indexOf("subagent_spawn"),
+    );
+    // Workers land on the balanced tier; the planner/repair on quality.
+    expect(skillText).toContain('override_profile: "balanced"');
+  });
+
+  test("states the compile-once rule (parent compiles, workers never compile)", async () => {
+    const skillText = await readSkill();
+
+    // Only the parent calls app_refresh, exactly once.
+    expect(skillText).toContain("only the parent calls `app_refresh`");
+    // Workers must never compile.
+    expect(skillText).toContain("Workers NEVER compile");
   });
 });

--- a/assistant/src/__tests__/app-executors.test.ts
+++ b/assistant/src/__tests__/app-executors.test.ts
@@ -14,18 +14,8 @@ let compileResultOverride: CompileResult = {
   durationMs: 0,
 };
 
-/**
- * Optional hook letting a test observe and gate each compileApp invocation.
- * When set, compileApp awaits whatever it returns before resolving, so a test
- * can assert serialization by counting concurrently-running compiles.
- */
-let compileGate: ((appDir: string) => Promise<void>) | undefined;
-
 mock.module("../bundler/app-compiler.js", () => ({
-  compileApp: async (appDir: string) => {
-    if (compileGate) await compileGate(appDir);
-    return compileResultOverride;
-  },
+  compileApp: async () => compileResultOverride,
 }));
 
 beforeEach(() => {
@@ -35,7 +25,6 @@ beforeEach(() => {
     warnings: [],
     durationMs: 0,
   };
-  compileGate = undefined;
 });
 
 import type { AppDefinition } from "../memory/app-store.js";
@@ -417,81 +406,5 @@ describe("executeAppRefresh", () => {
     expect(result.isError).toBe(true);
     const parsed = JSON.parse(result.content);
     expect(parsed.error).toContain("not found");
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Per-app-slug write/compile serialization
-//
-// getAppDirPath(id) is deterministic per id (falls back to <appsDir>/<id> when
-// no on-disk definition exists), so distinct ids map to distinct lock keys and
-// the same id always maps to the same key — exactly the slug-keying contract.
-// ---------------------------------------------------------------------------
-
-describe("app-slug compile serialization", () => {
-  /** A deferred promise plus its resolver. */
-  function defer(): { promise: Promise<void>; resolve: () => void } {
-    let resolve!: () => void;
-    const promise = new Promise<void>((r) => {
-      resolve = r;
-    });
-    return { promise, resolve };
-  }
-
-  test("serializes concurrent refreshes for the SAME app", async () => {
-    let running = 0;
-    let maxConcurrent = 0;
-    const release = defer();
-    compileGate = async () => {
-      running++;
-      maxConcurrent = Math.max(maxConcurrent, running);
-      await release.promise;
-      running--;
-    };
-
-    const app = makeMultifileApp({ id: "same-slug-app" });
-    const store = mockStore(app);
-
-    const first = executeAppRefresh({ app_id: app.id }, store);
-    const second = executeAppRefresh({ app_id: app.id }, store);
-
-    // Let both kick off. Only the first compile may be running; the second is
-    // queued behind the per-slug lock.
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(maxConcurrent).toBe(1);
-
-    release.resolve();
-    await Promise.all([first, second]);
-    // Never more than one compile in flight for this slug.
-    expect(maxConcurrent).toBe(1);
-  });
-
-  test("runs refreshes for DIFFERENT apps concurrently", async () => {
-    let running = 0;
-    let maxConcurrent = 0;
-    const release = defer();
-    compileGate = async () => {
-      running++;
-      maxConcurrent = Math.max(maxConcurrent, running);
-      await release.promise;
-      running--;
-    };
-
-    const appA = makeMultifileApp({ id: "slug-a" });
-    const appB = makeMultifileApp({ id: "slug-b" });
-    const storeA = mockStore(appA);
-    const storeB = mockStore(appB);
-
-    const first = executeAppRefresh({ app_id: appA.id }, storeA);
-    const second = executeAppRefresh({ app_id: appB.id }, storeB);
-
-    // Different slugs must not block each other — both compiles run at once.
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(maxConcurrent).toBe(2);
-
-    release.resolve();
-    await Promise.all([first, second]);
   });
 });

--- a/assistant/src/__tests__/app-executors.test.ts
+++ b/assistant/src/__tests__/app-executors.test.ts
@@ -14,8 +14,18 @@ let compileResultOverride: CompileResult = {
   durationMs: 0,
 };
 
+/**
+ * Optional hook letting a test observe and gate each compileApp invocation.
+ * When set, compileApp awaits whatever it returns before resolving, so a test
+ * can assert serialization by counting concurrently-running compiles.
+ */
+let compileGate: ((appDir: string) => Promise<void>) | undefined;
+
 mock.module("../bundler/app-compiler.js", () => ({
-  compileApp: async () => compileResultOverride,
+  compileApp: async (appDir: string) => {
+    if (compileGate) await compileGate(appDir);
+    return compileResultOverride;
+  },
 }));
 
 beforeEach(() => {
@@ -25,6 +35,7 @@ beforeEach(() => {
     warnings: [],
     durationMs: 0,
   };
+  compileGate = undefined;
 });
 
 import type { AppDefinition } from "../memory/app-store.js";
@@ -406,5 +417,81 @@ describe("executeAppRefresh", () => {
     expect(result.isError).toBe(true);
     const parsed = JSON.parse(result.content);
     expect(parsed.error).toContain("not found");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-app-slug write/compile serialization
+//
+// getAppDirPath(id) is deterministic per id (falls back to <appsDir>/<id> when
+// no on-disk definition exists), so distinct ids map to distinct lock keys and
+// the same id always maps to the same key — exactly the slug-keying contract.
+// ---------------------------------------------------------------------------
+
+describe("app-slug compile serialization", () => {
+  /** A deferred promise plus its resolver. */
+  function defer(): { promise: Promise<void>; resolve: () => void } {
+    let resolve!: () => void;
+    const promise = new Promise<void>((r) => {
+      resolve = r;
+    });
+    return { promise, resolve };
+  }
+
+  test("serializes concurrent refreshes for the SAME app", async () => {
+    let running = 0;
+    let maxConcurrent = 0;
+    const release = defer();
+    compileGate = async () => {
+      running++;
+      maxConcurrent = Math.max(maxConcurrent, running);
+      await release.promise;
+      running--;
+    };
+
+    const app = makeMultifileApp({ id: "same-slug-app" });
+    const store = mockStore(app);
+
+    const first = executeAppRefresh({ app_id: app.id }, store);
+    const second = executeAppRefresh({ app_id: app.id }, store);
+
+    // Let both kick off. Only the first compile may be running; the second is
+    // queued behind the per-slug lock.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(maxConcurrent).toBe(1);
+
+    release.resolve();
+    await Promise.all([first, second]);
+    // Never more than one compile in flight for this slug.
+    expect(maxConcurrent).toBe(1);
+  });
+
+  test("runs refreshes for DIFFERENT apps concurrently", async () => {
+    let running = 0;
+    let maxConcurrent = 0;
+    const release = defer();
+    compileGate = async () => {
+      running++;
+      maxConcurrent = Math.max(maxConcurrent, running);
+      await release.promise;
+      running--;
+    };
+
+    const appA = makeMultifileApp({ id: "slug-a" });
+    const appB = makeMultifileApp({ id: "slug-b" });
+    const storeA = mockStore(appA);
+    const storeB = mockStore(appB);
+
+    const first = executeAppRefresh({ app_id: appA.id }, storeA);
+    const second = executeAppRefresh({ app_id: appB.id }, storeB);
+
+    // Different slugs must not block each other — both compiles run at once.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(maxConcurrent).toBe(2);
+
+    release.resolve();
+    await Promise.all([first, second]);
   });
 });

--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -1878,6 +1878,7 @@ function makeSubagentState(
     },
     status: overrides.status ?? "running",
     conversationId: `conv-${overrides.id}`,
+    resolvedRole: overrides.resolvedRole ?? "general",
     isFork: overrides.isFork ?? false,
     createdAt: overrides.createdAt ?? Date.now() - 60_000,
     startedAt: overrides.startedAt ?? Date.now() - 55_000,

--- a/assistant/src/__tests__/subagent-concurrency.test.ts
+++ b/assistant/src/__tests__/subagent-concurrency.test.ts
@@ -23,6 +23,7 @@ interface FakeManaged {
     dispose: () => void;
     persistUserMessage: () => { id: string; deduplicated: boolean };
     runAgentLoop: () => Promise<void>;
+    enqueueMessage: () => { queued: boolean; rejected: boolean };
     usageStats: {
       inputTokens: number;
       outputTokens: number;
@@ -42,6 +43,12 @@ interface ManagerInternals {
   runningCount: number;
   startRun: (subagentId: string, objective: string) => void;
   stopSweep: () => void;
+}
+
+interface RunTracking {
+  release: () => void;
+  /** Number of times runAgentLoop was invoked on this subagent's conversation. */
+  runCount: () => number;
 }
 
 function asInternals(manager: SubagentManager): ManagerInternals {
@@ -70,22 +77,24 @@ function makeState(id: string): SubagentState {
  * promise, letting the test control exactly when each "running" subagent
  * completes. Returns a `release` fn that resolves the loop.
  */
-function injectControllable(
-  manager: SubagentManager,
-  id: string,
-): { release: () => void } {
+function injectControllable(manager: SubagentManager, id: string): RunTracking {
   const internals = asInternals(manager);
   let resolveLoop!: () => void;
   const loopGate = new Promise<void>((r) => {
     resolveLoop = r;
   });
+  let runCount = 0;
 
   const managed: FakeManaged = {
     conversation: {
       abort: () => {},
       dispose: () => {},
       persistUserMessage: () => ({ id: "msg", deduplicated: false }),
-      runAgentLoop: () => loopGate,
+      runAgentLoop: () => {
+        runCount++;
+        return loopGate;
+      },
+      enqueueMessage: () => ({ queued: false, rejected: false }),
       usageStats: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },
     },
     state: makeState(id),
@@ -98,7 +107,7 @@ function injectControllable(
   }
   internals.parentToChildren.get("parent-1")!.add(id);
 
-  return { release: resolveLoop };
+  return { release: resolveLoop, runCount: () => runCount };
 }
 
 const flush = () => new Promise((r) => setTimeout(r, 0));
@@ -179,6 +188,47 @@ describe("SubagentManager concurrency cap", () => {
       expect(manager.getState(id)!.status).toBe("running");
     }
 
+    internals.stopSweep();
+  });
+
+  test("messaging a pending/queued subagent does not start its run or bypass the cap", async () => {
+    const manager = new SubagentManager();
+    const internals = asInternals(manager);
+    const cap = SUBAGENT_LIMITS.maxConcurrentRunning;
+
+    // Fill the cap with running subagents, then queue one more.
+    const runningIds = Array.from({ length: cap }, (_, i) => `run-${i}`);
+    for (const id of runningIds) injectControllable(manager, id);
+    const queuedTracking = injectControllable(manager, "queued-1");
+
+    for (const id of runningIds) {
+      internals.startRun(
+        id,
+        internals.subagents.get(id)!.state.config.objective,
+      );
+    }
+    internals.runQueue.push("queued-1");
+    await flush();
+
+    // Precondition: queued-1 is pending and the cap is full.
+    expect(manager.getState("queued-1")!.status).toBe("pending");
+    expect(internals.runningCount).toBe(cap);
+    expect(queuedTracking.runCount()).toBe(0);
+
+    // Message the pending subagent — must be rejected as "queued" and must NOT
+    // kick off its agent loop out-of-band.
+    const result = await manager.sendMessage("queued-1", "hurry up");
+    expect(result).toBe("queued");
+    await flush();
+
+    // The cap held: still exactly `cap` running, queued-1 still pending, and
+    // its run loop never fired.
+    expect(internals.runningCount).toBe(cap);
+    expect(manager.getState("queued-1")!.status).toBe("pending");
+    expect(queuedTracking.runCount()).toBe(0);
+    expect(internals.runQueue).toContain("queued-1");
+
+    // Once a running slot frees, the scheduler (not the message) starts it.
     internals.stopSweep();
   });
 });

--- a/assistant/src/__tests__/subagent-concurrency.test.ts
+++ b/assistant/src/__tests__/subagent-concurrency.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Concurrency-cap behavior for SubagentManager.
+ *
+ * Verifies that spawns beyond SUBAGENT_LIMITS.maxConcurrentRunning are accepted
+ * immediately but held in `pending`, and that queued subagents are started as
+ * running ones reach a terminal state — until all have run.
+ *
+ * Drives the manager via its private internals (matching the layout of
+ * subagent-disposal.test.ts) so the test never needs a real Conversation,
+ * provider, or daemon.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { ServerMessage } from "../daemon/message-protocol.js";
+import { SubagentManager } from "../subagent/manager.js";
+import { SUBAGENT_LIMITS, type SubagentState } from "../subagent/types.js";
+
+/** Minimal stand-in for the private ManagedSubagent the manager stores. */
+interface FakeManaged {
+  conversation: {
+    abort: () => void;
+    dispose: () => void;
+    persistUserMessage: () => { id: string; deduplicated: boolean };
+    runAgentLoop: () => Promise<void>;
+    usageStats: {
+      inputTokens: number;
+      outputTokens: number;
+      estimatedCost: number;
+    };
+  } | null;
+  state: SubagentState;
+  parentSendToClient: (msg: ServerMessage) => void;
+  retainedUntil?: number;
+  hadEnqueuedMessages?: boolean;
+}
+
+interface ManagerInternals {
+  subagents: Map<string, FakeManaged>;
+  parentToChildren: Map<string, Set<string>>;
+  runQueue: string[];
+  runningCount: number;
+  startRun: (subagentId: string, objective: string) => void;
+  stopSweep: () => void;
+}
+
+function asInternals(manager: SubagentManager): ManagerInternals {
+  return manager as unknown as ManagerInternals;
+}
+
+function makeState(id: string): SubagentState {
+  return {
+    config: {
+      id,
+      parentConversationId: "parent-1",
+      label: id,
+      objective: `objective-${id}`,
+    },
+    status: "pending",
+    conversationId: `conv-${id}`,
+    isFork: false,
+    createdAt: Date.now(),
+    usage: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },
+  };
+}
+
+/**
+ * Inject a fake subagent whose runAgentLoop blocks on a manually-resolved
+ * promise, letting the test control exactly when each "running" subagent
+ * completes. Returns a `release` fn that resolves the loop.
+ */
+function injectControllable(
+  manager: SubagentManager,
+  id: string,
+): { release: () => void } {
+  const internals = asInternals(manager);
+  let resolveLoop!: () => void;
+  const loopGate = new Promise<void>((r) => {
+    resolveLoop = r;
+  });
+
+  const managed: FakeManaged = {
+    conversation: {
+      abort: () => {},
+      dispose: () => {},
+      persistUserMessage: () => ({ id: "msg", deduplicated: false }),
+      runAgentLoop: () => loopGate,
+      usageStats: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },
+    },
+    state: makeState(id),
+    parentSendToClient: () => {},
+  };
+  internals.subagents.set(id, managed);
+
+  if (!internals.parentToChildren.has("parent-1")) {
+    internals.parentToChildren.set("parent-1", new Set());
+  }
+  internals.parentToChildren.get("parent-1")!.add(id);
+
+  return { release: resolveLoop };
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+describe("SubagentManager concurrency cap", () => {
+  test("spawns beyond the cap queue and drain as running ones complete", async () => {
+    const manager = new SubagentManager();
+    const internals = asInternals(manager);
+    const cap = SUBAGENT_LIMITS.maxConcurrentRunning;
+    const total = cap + 3;
+
+    const ids = Array.from({ length: total }, (_, i) => `sub-${i}`);
+    const gates = ids.map((id) => injectControllable(manager, id));
+
+    // Mimic spawn()'s cap-gating: start up to `cap`, queue the rest.
+    for (const id of ids) {
+      const objective = internals.subagents.get(id)!.state.config.objective;
+      if (internals.runningCount < cap) {
+        internals.startRun(id, objective);
+      } else {
+        internals.runQueue.push(id);
+      }
+    }
+    await flush();
+
+    // Exactly `cap` are running; the excess sit pending in the queue.
+    expect(internals.runningCount).toBe(cap);
+    expect(internals.runQueue.length).toBe(total - cap);
+    const running = ids.filter(
+      (id) => manager.getState(id)!.status === "running",
+    );
+    expect(running.length).toBe(cap);
+    for (const id of ids.slice(cap)) {
+      expect(manager.getState(id)!.status).toBe("pending");
+    }
+
+    // Complete running subagents one at a time; each completion should pull
+    // exactly one queued subagent into the running set.
+    for (let i = 0; i < total; i++) {
+      const runningNow = ids.filter(
+        (id) => manager.getState(id)!.status === "running",
+      );
+      expect(runningNow.length).toBeGreaterThan(0);
+      // Release the first currently-running subagent.
+      const idx = ids.indexOf(runningNow[0]!);
+      gates[idx]!.release();
+      await flush();
+      await flush();
+    }
+
+    // All eventually ran to completion; queue drained; no slots leaked.
+    for (const id of ids) {
+      expect(manager.getState(id)!.status).toBe("completed");
+    }
+    expect(internals.runQueue.length).toBe(0);
+    expect(internals.runningCount).toBe(0);
+
+    internals.stopSweep();
+  });
+
+  test("low-count spawns (under cap) all start immediately, none queued", async () => {
+    const manager = new SubagentManager();
+    const internals = asInternals(manager);
+
+    const ids = ["a", "b"]; // typical 1–2 subagent flow
+    for (const id of ids) injectControllable(manager, id);
+    for (const id of ids) {
+      internals.startRun(
+        id,
+        internals.subagents.get(id)!.state.config.objective,
+      );
+    }
+    await flush();
+
+    expect(internals.runQueue.length).toBe(0);
+    expect(internals.runningCount).toBe(ids.length);
+    for (const id of ids) {
+      expect(manager.getState(id)!.status).toBe("running");
+    }
+
+    internals.stopSweep();
+  });
+});

--- a/assistant/src/__tests__/subagent-concurrency.test.ts
+++ b/assistant/src/__tests__/subagent-concurrency.test.ts
@@ -58,6 +58,7 @@ function makeState(id: string): SubagentState {
     },
     status: "pending",
     conversationId: `conv-${id}`,
+    resolvedRole: "general",
     isFork: false,
     createdAt: Date.now(),
     usage: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },

--- a/assistant/src/__tests__/subagent-disposal.test.ts
+++ b/assistant/src/__tests__/subagent-disposal.test.ts
@@ -90,6 +90,7 @@ function makeState(
     },
     status: "running",
     conversationId: "conv-sub-1",
+    resolvedRole: "general",
     isFork: false,
     createdAt: Date.now(),
     usage: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },

--- a/assistant/src/__tests__/subagent-fork-notifications.test.ts
+++ b/assistant/src/__tests__/subagent-fork-notifications.test.ts
@@ -114,6 +114,7 @@ function makeState(
     },
     status: "running",
     conversationId: "conv-sub-1",
+    resolvedRole: "general",
     isFork: false,
     createdAt: Date.now(),
     usage: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },

--- a/assistant/src/__tests__/subagent-fork-spawn.test.ts
+++ b/assistant/src/__tests__/subagent-fork-spawn.test.ts
@@ -102,6 +102,7 @@ function makeState(
     config: makeConfig({ id: subagentId, ...configOverrides }),
     status: "running",
     conversationId: "conv-sub-1",
+    resolvedRole: "general",
     isFork: false,
     createdAt: Date.now(),
     usage: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },

--- a/assistant/src/__tests__/subagent-manager-notify.test.ts
+++ b/assistant/src/__tests__/subagent-manager-notify.test.ts
@@ -118,6 +118,7 @@ function makeState(
     },
     status: "running",
     conversationId: "conv-sub-1",
+    resolvedRole: "general",
     isFork: false,
     createdAt: Date.now(),
     usage: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },

--- a/assistant/src/__tests__/subagent-notify-parent.test.ts
+++ b/assistant/src/__tests__/subagent-notify-parent.test.ts
@@ -95,6 +95,7 @@ function injectSubagent(
     },
     status,
     conversationId: `conv-${subagentId}`,
+    resolvedRole: "general",
     isFork: false,
     createdAt: Date.now(),
     usage: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },

--- a/assistant/src/__tests__/subagent-telemetry.test.ts
+++ b/assistant/src/__tests__/subagent-telemetry.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Per-phase build telemetry for subagents.
+ *
+ * Two layers under test:
+ *  1. The pure event builders (`buildSubagentSpawnEvent` /
+ *     `buildSubagentTerminalEvent`) — assert the structured event shape,
+ *     that the tier (overrideProfile) is recorded per subagent, that role →
+ *     build-phase mapping is correct, and the silent-context-starvation signal.
+ *  2. The manager integration — drive a controllable fake subagent through
+ *     spawn → completion and assert the established telemetry sink
+ *     (`recordLifecycleEvent`) is hit with the per-subagent tier, with no
+ *     regression to spawn/concurrency accounting.
+ *
+ * Note: this file mocks `../memory/lifecycle-events-store.js`. Per the repo's
+ * bun-mock isolation gotcha, run it on its own (single-file `bun test`).
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+// Capture every lifecycle event name the manager records, before importing the
+// modules under test so the mock is in place at import time.
+const recordedLifecycleEvents: string[] = [];
+mock.module("../memory/lifecycle-events-store.js", () => ({
+  recordLifecycleEvent: (eventName: string) => {
+    recordedLifecycleEvents.push(eventName);
+    return { id: "evt", eventName, createdAt: Date.now() };
+  },
+}));
+
+import type { ServerMessage } from "../daemon/message-protocol.js";
+import { SubagentManager } from "../subagent/manager.js";
+import {
+  buildSubagentSpawnEvent,
+  buildSubagentTerminalEvent,
+} from "../subagent/telemetry.js";
+import type { SubagentState } from "../subagent/types.js";
+
+// ── Pure builders ───────────────────────────────────────────────────────
+
+describe("subagent telemetry — event builders", () => {
+  test("spawn event records role, phase, and tier (overrideProfile)", () => {
+    const evt = buildSubagentSpawnEvent({
+      subagentId: "sub-1",
+      label: "Build the worker",
+      role: "coder",
+      overrideProfile: "worker-cheap",
+      isFork: false,
+    });
+
+    expect(evt).toMatchObject({
+      event: "subagent_build_spawned",
+      subagentId: "sub-1",
+      label: "Build the worker",
+      role: "coder",
+      phase: "worker", // coder → worker phase
+      overrideProfile: "worker-cheap",
+      isFork: false,
+    });
+    // Lifecycle name encodes phase + tier so platform aggregation can group.
+    expect(evt.lifecycleEventName).toBe(
+      "subagent_build:worker:worker-cheap:spawned",
+    );
+  });
+
+  test("planner maps to the plan phase; missing tier becomes 'default'", () => {
+    const evt = buildSubagentSpawnEvent({
+      subagentId: "sub-2",
+      label: "Plan",
+      role: "planner",
+      isFork: false,
+    });
+    expect(evt.phase).toBe("plan");
+    expect(evt.overrideProfile).toBeNull();
+    expect(evt.lifecycleEventName).toBe("subagent_build:plan:default:spawned");
+  });
+
+  test("terminal event carries tier, duration, tokens, and outcome", () => {
+    const evt = buildSubagentTerminalEvent({
+      subagentId: "sub-3",
+      label: "Worker",
+      role: "coder",
+      overrideProfile: "tier-a",
+      isFork: false,
+      outcome: "completed",
+      durationMs: 4200,
+      inputTokens: 1000,
+      outputTokens: 500,
+      estimatedCost: 0.012,
+    });
+
+    expect(evt).toMatchObject({
+      event: "subagent_build_terminal",
+      outcome: "completed",
+      overrideProfile: "tier-a",
+      durationMs: 4200,
+      inputTokens: 1000,
+      outputTokens: 500,
+      estimatedCost: 0.012,
+      suspiciousZeroOutput: false,
+    });
+    expect(evt.lifecycleEventName).toBe(
+      "subagent_build:worker:tier-a:completed",
+    );
+    expect(evt.zeroOutputLifecycleEventName).toBeUndefined();
+  });
+
+  test("overrideProfile (tier) is recorded distinctly per subagent", () => {
+    const cheap = buildSubagentTerminalEvent({
+      subagentId: "a",
+      label: "a",
+      role: "coder",
+      overrideProfile: "cheap",
+      isFork: false,
+      outcome: "completed",
+      inputTokens: 1,
+      outputTokens: 1,
+      estimatedCost: 0,
+    });
+    const premium = buildSubagentTerminalEvent({
+      subagentId: "b",
+      label: "b",
+      role: "coder",
+      overrideProfile: "premium",
+      isFork: false,
+      outcome: "completed",
+      inputTokens: 1,
+      outputTokens: 1,
+      estimatedCost: 0,
+    });
+    expect(cheap.overrideProfile).toBe("cheap");
+    expect(premium.overrideProfile).toBe("premium");
+    expect(cheap.lifecycleEventName).not.toBe(premium.lifecycleEventName);
+  });
+
+  test("silent-context-starvation: completed coder with zero output is flagged", () => {
+    const starved = buildSubagentTerminalEvent({
+      subagentId: "sub-x",
+      label: "Worker",
+      role: "coder",
+      overrideProfile: "tier-a",
+      isFork: false,
+      outcome: "completed",
+      inputTokens: 5000,
+      outputTokens: 0,
+      estimatedCost: 0,
+    });
+    expect(starved.suspiciousZeroOutput).toBe(true);
+    expect(starved.zeroOutputLifecycleEventName).toBe(
+      "subagent_build:worker:tier-a:zero_output",
+    );
+
+    // Non-coder roles, failures, and non-zero output do NOT trip the signal.
+    const planner = buildSubagentTerminalEvent({
+      subagentId: "sub-y",
+      label: "Plan",
+      role: "planner",
+      isFork: false,
+      outcome: "completed",
+      inputTokens: 1,
+      outputTokens: 0,
+      estimatedCost: 0,
+    });
+    expect(planner.suspiciousZeroOutput).toBe(false);
+
+    const failed = buildSubagentTerminalEvent({
+      subagentId: "sub-z",
+      label: "Worker",
+      role: "coder",
+      isFork: false,
+      outcome: "failed",
+      inputTokens: 1,
+      outputTokens: 0,
+      estimatedCost: 0,
+    });
+    expect(failed.suspiciousZeroOutput).toBe(false);
+  });
+});
+
+// ── Manager integration ─────────────────────────────────────────────────
+
+interface FakeManaged {
+  conversation: {
+    abort: () => void;
+    dispose: () => void;
+    persistUserMessage: () => { id: string; deduplicated: boolean };
+    runAgentLoop: () => Promise<void>;
+    usageStats: {
+      inputTokens: number;
+      outputTokens: number;
+      estimatedCost: number;
+    };
+  } | null;
+  state: SubagentState;
+  parentSendToClient: (msg: ServerMessage) => void;
+  retainedUntil?: number;
+  hadEnqueuedMessages?: boolean;
+}
+
+interface ManagerInternals {
+  subagents: Map<string, FakeManaged>;
+  parentToChildren: Map<string, Set<string>>;
+  runQueue: string[];
+  runningCount: number;
+  startRun: (subagentId: string, objective: string) => void;
+  stopSweep: () => void;
+}
+
+function asInternals(manager: SubagentManager): ManagerInternals {
+  return manager as unknown as ManagerInternals;
+}
+
+function makeState(id: string, overrideProfile?: string): SubagentState {
+  return {
+    config: {
+      id,
+      parentConversationId: "parent-1",
+      label: id,
+      objective: `objective-${id}`,
+      role: "coder",
+      ...(overrideProfile ? { overrideProfile } : {}),
+    },
+    status: "pending",
+    conversationId: `conv-${id}`,
+    resolvedRole: "coder",
+    isFork: false,
+    createdAt: Date.now(),
+    usage: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },
+  };
+}
+
+function injectControllable(
+  manager: SubagentManager,
+  id: string,
+  overrideProfile?: string,
+): { release: () => void } {
+  const internals = asInternals(manager);
+  let resolveLoop!: () => void;
+  const loopGate = new Promise<void>((r) => {
+    resolveLoop = r;
+  });
+  const managed: FakeManaged = {
+    conversation: {
+      abort: () => {},
+      dispose: () => {},
+      persistUserMessage: () => ({ id: "msg", deduplicated: false }),
+      runAgentLoop: () => loopGate,
+      usageStats: { inputTokens: 10, outputTokens: 20, estimatedCost: 0.01 },
+    },
+    state: makeState(id, overrideProfile),
+    parentSendToClient: () => {},
+  };
+  internals.subagents.set(id, managed);
+  if (!internals.parentToChildren.has("parent-1")) {
+    internals.parentToChildren.set("parent-1", new Set());
+  }
+  internals.parentToChildren.get("parent-1")!.add(id);
+  return { release: resolveLoop };
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+describe("subagent telemetry — manager integration", () => {
+  test("completion records a per-tier terminal lifecycle event", async () => {
+    recordedLifecycleEvents.length = 0;
+
+    const manager = new SubagentManager();
+    const internals = asInternals(manager);
+
+    const gate = injectControllable(manager, "sub-int-1", "tier-fast");
+    internals.startRun(
+      "sub-int-1",
+      internals.subagents.get("sub-int-1")!.state.config.objective,
+    );
+    await flush();
+
+    gate.release();
+    await flush();
+    await flush();
+
+    // The completed coder ran on tier-fast → its terminal event is recorded
+    // with the worker phase + tier encoded.
+    expect(recordedLifecycleEvents).toContain(
+      "subagent_build:worker:tier-fast:completed",
+    );
+    // Concurrency accounting did not leak.
+    expect(internals.runningCount).toBe(0);
+    expect(internals.runQueue.length).toBe(0);
+
+    internals.stopSweep();
+  });
+});

--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -86,6 +86,7 @@ function injectSubagent(
     },
     status,
     conversationId: `conv-${subagentId}`,
+    resolvedRole: "general",
     isFork: false,
     createdAt: Date.now(),
     usage: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },

--- a/assistant/src/__tests__/subagent-types.test.ts
+++ b/assistant/src/__tests__/subagent-types.test.ts
@@ -68,6 +68,7 @@ describe("SubagentState type shape", () => {
       },
       status: "pending" as SubagentStatus,
       conversationId: "conv-id",
+      resolvedRole: "general",
       isFork: false,
       createdAt: Date.now(),
       usage: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },

--- a/assistant/src/__tests__/tier-routing.test.ts
+++ b/assistant/src/__tests__/tier-routing.test.ts
@@ -189,6 +189,7 @@ function makeWorkerState(
       overrideProfile,
     },
     status: "running",
+    resolvedRole: "coder",
     conversationId: `conv-${subagentId}`,
     isFork: false,
     createdAt: Date.now(),

--- a/assistant/src/__tests__/tier-routing.test.ts
+++ b/assistant/src/__tests__/tier-routing.test.ts
@@ -1,0 +1,265 @@
+/**
+ * End-to-end tier-routing proof for per-subagent `override_profile`.
+ *
+ * This is the load-bearing claim of app-builder v2: a worker subagent must be
+ * able to RUN on a different inference tier than its parent. PR 1 made
+ * `override_profile` a real, model-settable param on `subagent_spawn`; PR 2
+ * (this test) proves that param actually reaches the provider-config seam where
+ * tier selection happens — it is not silently dropped or overwritten by the
+ * parent's pinned profile.
+ *
+ * Seam under test
+ * ───────────────
+ * `SubagentManager.runSubagent` forwards `SubagentConfig.overrideProfile` into
+ * `conversation.runAgentLoop(message, messageId, { overrideProfile })`
+ * (manager.ts ~509-513). Inside conversation-agent-loop.ts that option is read
+ * as `options.overrideProfile`, becomes `turnOverrideProfile`, and is handed to
+ * `ctx.agentLoop.run({ overrideProfile })` — i.e. it is THE value that sets the
+ * provider config's effective inference tier for every LLM call the subagent
+ * issues. Capturing the options that reach `runAgentLoop` therefore captures
+ * exactly what the subagent's provider config will route on.
+ *
+ * We stub the conversation at that seam (no real provider, mirroring the
+ * subagent-manager-notify mocking pattern) and assert the captured override
+ * profile is the worker's tier, NOT the parent's.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * MANUAL SPIKE CHECKLIST (run once to validate the real path end-to-end)
+ * ─────────────────────────────────────────────────────────────────────────
+ * The automated test below stubs the provider at the agent-loop seam. To prove
+ * the claim against the LIVE inference stack, run a real 2-worker app build and
+ * confirm the tiers diverge in logs/telemetry:
+ *
+ *   1. Pin the PARENT conversation to `quality-optimized`
+ *      (switch_inference_profile tool, or set the conversation's override
+ *      profile so getConversationOverrideProfileFromRow returns it).
+ *   2. Ask the assistant to build a small app that fans out to TWO `coder`
+ *      workers, each spawned with `override_profile: "balanced"`.
+ *   3. Tail the daemon logs and grep for the resolved profile per conversation:
+ *        - the PARENT conversationId should log `overrideProfile: "quality-optimized"`
+ *          (look for the agent-loop / provider-call log lines, e.g. the
+ *          `{ overrideProfile }` record around conversation-agent-loop.ts:663).
+ *        - EACH worker conversationId should log `overrideProfile: "balanced"`.
+ *   4. Cross-check telemetry/usage: the workers' LLM calls should resolve to the
+ *      model under `llm.profiles.balanced`, while the parent resolves to
+ *      `llm.profiles["quality-optimized"]`. Confirm the model strings differ.
+ *   5. PASS = both workers ran on balanced AND the parent ran on quality,
+ *      concurrently, with no cross-contamination.
+ * ─────────────────────────────────────────────────────────────────────────
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+// ── Module mocks ──────────────────────────────────────────────────
+// Mirror subagent-manager-notify.test.ts: stub the conversation store so the
+// manager never touches a real Conversation/provider. The parent-notification
+// path runs through findConversation → enqueueMessage; we only need it to not
+// throw.
+
+mock.module("../daemon/conversation-store.js", () => ({
+  findConversation: () => ({
+    enqueueMessage: () => ({ queued: true }),
+  }),
+  addConversation: () => {},
+  removeConversation: () => {},
+}));
+
+mock.module("../runtime/assistant-event-hub.js", () => ({
+  broadcastMessage: () => {},
+}));
+
+import type { ServerMessage } from "../daemon/message-protocol.js";
+import { SubagentManager } from "../subagent/manager.js";
+import type { SubagentState } from "../subagent/types.js";
+
+// ── Test plumbing (private-internals access, per existing tests) ──────────
+
+/**
+ * Options object handed to `conversation.runAgentLoop`. We only care about the
+ * `overrideProfile` field — that is the value that flows into the provider
+ * config's effective tier inside conversation-agent-loop.ts.
+ */
+interface CapturedRunAgentLoopOptions {
+  callSite?: string;
+  overrideProfile?: string;
+}
+
+interface FakeConversation {
+  abort: () => void;
+  dispose: () => void;
+  messages: Array<{ role: string; content: Array<{ type: string }> }>;
+  sendToClient: (msg: ServerMessage) => void;
+  usageStats: {
+    inputTokens: number;
+    outputTokens: number;
+    estimatedCost: number;
+  };
+  persistUserMessage: () => { id: string; deduplicated: boolean };
+  runAgentLoop: (
+    message: string,
+    messageId: string,
+    options?: CapturedRunAgentLoopOptions,
+  ) => Promise<void>;
+}
+
+interface FakeManagedSubagent {
+  conversation: FakeConversation | null;
+  state: SubagentState;
+  parentSendToClient: (msg: ServerMessage) => void;
+}
+
+interface ManagerInternals {
+  subagents: Map<string, FakeManagedSubagent>;
+  parentToChildren: Map<string, Set<string>>;
+  runSubagent: (subagentId: string, objective: string) => Promise<void>;
+  stopSweep: () => void;
+}
+
+function asInternals(manager: SubagentManager): ManagerInternals {
+  return manager as unknown as ManagerInternals;
+}
+
+/** Records what reached the provider-config seam for a single worker run. */
+interface ProfileCapture {
+  called: boolean;
+  overrideProfile?: string;
+}
+
+/**
+ * Inject a fake managed subagent whose `runAgentLoop` records the
+ * provider-config-bound override profile it was invoked with, then resolves
+ * immediately (no real LLM turn). Returns the capture the run will populate.
+ */
+function injectWorker(
+  manager: SubagentManager,
+  subagentId: string,
+  state: SubagentState,
+): ProfileCapture {
+  const capture: ProfileCapture = { called: false };
+  const conversation: FakeConversation = {
+    abort: () => {},
+    dispose: () => {},
+    messages: [],
+    sendToClient: () => {},
+    usageStats: { inputTokens: 1, outputTokens: 1, estimatedCost: 0 },
+    persistUserMessage: () => ({ id: "msg-1", deduplicated: false }),
+    runAgentLoop: async (
+      _message: string,
+      _messageId: string,
+      options?: CapturedRunAgentLoopOptions,
+    ) => {
+      capture.called = true;
+      capture.overrideProfile = options?.overrideProfile;
+    },
+  };
+
+  const internals = asInternals(manager);
+  internals.subagents.set(subagentId, {
+    conversation,
+    state,
+    parentSendToClient: () => {},
+  });
+
+  const parentId = state.config.parentConversationId;
+  if (!internals.parentToChildren.has(parentId)) {
+    internals.parentToChildren.set(parentId, new Set());
+  }
+  internals.parentToChildren.get(parentId)!.add(subagentId);
+
+  return capture;
+}
+
+/**
+ * Build worker subagent state. `overrideProfile` is the worker's spawn-time
+ * tier (set by the model via `subagent_spawn`'s `override_profile`, validated
+ * in PR 1). The parent's pinned tier is intentionally NOT modelled here: the
+ * whole point is that the worker carries its OWN tier independent of the
+ * parent.
+ */
+function makeWorkerState(
+  subagentId: string,
+  overrideProfile: string | undefined,
+): SubagentState {
+  return {
+    config: {
+      id: subagentId,
+      parentConversationId: "parent-conv-1",
+      label: "Coder worker",
+      objective: "Implement the feature",
+      overrideProfile,
+    },
+    status: "running",
+    conversationId: `conv-${subagentId}`,
+    isFork: false,
+    createdAt: Date.now(),
+    usage: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe("per-subagent tier routing reaches the provider-config seam", () => {
+  test("parent pinned to quality-optimized: worker resolves to balanced (not the parent's tier)", async () => {
+    // The parent in this scenario is pinned to "quality-optimized". A worker
+    // spawned with override_profile: "balanced" must NOT inherit the parent's
+    // tier — it must carry its own. We assert the value forwarded to
+    // runAgentLoop (the provider-config seam) is the worker's, not the parent's.
+    const PARENT_TIER = "quality-optimized";
+    const WORKER_TIER = "balanced";
+
+    const manager = new SubagentManager();
+    const capture = injectWorker(
+      manager,
+      "worker-1",
+      makeWorkerState("worker-1", WORKER_TIER),
+    );
+
+    await asInternals(manager).runSubagent("worker-1", "Implement the feature");
+
+    expect(capture.called).toBe(true);
+    expect(capture.overrideProfile).toBe(WORKER_TIER);
+    expect(capture.overrideProfile).not.toBe(PARENT_TIER);
+
+    asInternals(manager).stopSweep();
+  });
+
+  test("parent unpinned (no profile): worker still resolves to balanced", async () => {
+    // Even when the parent has no pinned profile at all, an explicit worker
+    // override must still reach the provider config — it does not require a
+    // parent tier to anchor against.
+    const WORKER_TIER = "balanced";
+
+    const manager = new SubagentManager();
+    const capture = injectWorker(
+      manager,
+      "worker-2",
+      makeWorkerState("worker-2", WORKER_TIER),
+    );
+
+    await asInternals(manager).runSubagent("worker-2", "Implement the feature");
+
+    expect(capture.called).toBe(true);
+    expect(capture.overrideProfile).toBe(WORKER_TIER);
+
+    asInternals(manager).stopSweep();
+  });
+
+  test("worker with no override carries no profile to the provider config", async () => {
+    // Control: when the spawn carries no override_profile, nothing is forwarded
+    // to the seam (the field is omitted, not coerced) — so the subagent falls
+    // back to the workspace/active profile rather than a stray tier.
+    const manager = new SubagentManager();
+    const capture = injectWorker(
+      manager,
+      "worker-3",
+      makeWorkerState("worker-3", undefined),
+    );
+
+    await asInternals(manager).runSubagent("worker-3", "Implement the feature");
+
+    expect(capture.called).toBe(true);
+    expect(capture.overrideProfile).toBeUndefined();
+
+    asInternals(manager).stopSweep();
+  });
+});

--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -45,6 +45,8 @@ All new apps use `formatVersion: 2` (multi-file TSX). Do NOT create root-level `
 
 ## Responsive baseline
 
+(`{baseDir}` resolves to this skill's directory at load time; read references with `host_file_read`.)
+
 Every app works phone (~360px) to desktop. Full mobile-first / desktop-first decision tree and universal baseline (16px form font, 44pt touch targets, `100dvh`, safe-area-inset padding) in `{baseDir}/references/RESPONSIVE.md` (read with `host_file_read`).
 
 The conversation `<turn_context>` block carries an `interface:` field.
@@ -169,7 +171,9 @@ This is the tiered core. The order is fixed: **plan → scaffold → dispatch wo
 
 **3b. Scaffold (parent).** `skill_load("app-builder")` then `app_create` ONCE with the 4-file self-contained scaffold (`src/index.html`, `src/main.tsx`, a placeholder `src/components/App.tsx`, an empty `src/styles.css`). Pass `auto_open: false`. The placeholders make the initial compile clean. See the `app_create` parameter rules below.
 
-**3c. Dispatch (`coder` workers @ balanced).** Spawn one `coder` subagent per partition row with `subagent_spawn({ label, role: "coder", override_profile: "balanced", objective })`, **in bounded waves of ≤3–4 at a time**. Each worker's objective carries its partition slice plus the verbatim §2 Visual direction and the §3 component-tree context for its files. Workers use `file_write` / `file_edit` ONLY — never `app_refresh` / `app_create` / `app_open`. Read ORCHESTRATION.md (a)–(c) for the verbatim spawn shape and the wave/collect (`subagent_read`) protocol.
+**3c. Dispatch (`coder` workers @ balanced).** Spawn one `coder` subagent per partition row with `subagent_spawn({ label, role: "coder", override_profile: "balanced", objective })`, in bounded waves: **3 workers per wave for partitions of ≥7 files, 4 for ≤6.** Each worker's objective carries its partition slice plus the verbatim §2 Visual direction and the §3 component-tree context for its files. Workers use `file_write` / `file_edit` ONLY — never `app_refresh` / `app_create` / `app_open`. Read ORCHESTRATION.md (a)–(c) for the verbatim spawn shape and the wave/collect (`subagent_read`) protocol.
+
+**If a worker fails or times out →** re-spawn that row once on a fresh worker; if it fails again, fold its files into the repair scope (Step 4).
 
 ⚠️ **Compile-once rule: only the parent calls `app_refresh`, exactly once, after every worker across every wave has finished. Workers NEVER compile** (no `app_refresh`, `app_create`, or `app_open`). A worker that compiles corrupts the shared build cache and races the others.
 
@@ -295,10 +299,9 @@ render(<App />, document.getElementById("app")!);`,
   }
 })
 
-// 3c — dispatch coder workers @ balanced in bounded waves (see ORCHESTRATION.md)
-subagent_spawn({ label: "W1 — shell & data", role: "coder", override_profile: "balanced", objective: "<App.tsx + styles.css + types.ts row + §2 verbatim; file_write only, do NOT app_refresh>" })
-subagent_spawn({ label: "W2 — header & form", role: "coder", override_profile: "balanced", objective: "..." })
-subagent_spawn({ label: "W3 — board & columns", role: "coder", override_profile: "balanced", objective: "..." })
+// 3c — dispatch coder workers @ balanced in bounded waves
+// → See {baseDir}/references/ORCHESTRATION.md §(b) for the verbatim worker
+//   subagent_spawn shape. Do NOT invent objectives from shorthand.
 // collect each via subagent_read on completion, then next wave
 
 // 3d / Step 4 — parent compiles ONCE after all workers finish
@@ -341,7 +344,7 @@ app_refresh(app_id)
 
 The reload is cheap and idempotent — call it every time.
 
-**On compile failure → repair subagent @ quality.** Spawn a single repair `coder` subagent on the **quality-optimized** profile via `subagent_spawn` + `override_profile` (fixing cross-file type and import errors is judgment work). Its objective carries the `app_refresh` errors verbatim, the PLAN.md path, and the failing files. The repair agent uses `file_edit` only and does NOT compile. After it reports done, the parent reloads and `app_refresh`es again. **Bound to ≤2 repair attempts**, then surface the remaining errors to the user. The verbatim repair spawn is in ORCHESTRATION.md (e).
+**On compile failure → repair subagent @ quality.** Spawn a single repair `coder` subagent on the **quality-optimized** profile via `subagent_spawn` + `override_profile` (fixing cross-file type and import errors is judgment work). Its objective carries the `app_refresh` errors verbatim, the PLAN.md path, and the failing files. The repair agent uses `file_edit` only and does NOT compile. After it reports done, the parent reloads and `app_refresh`es again. **Bound to ≤2 repair attempts.** After the 2nd repair attempt fails → call `app_open(app_id, open_mode: "preview")` to surface the last good state, THEN post a chat message listing the failing files and unresolved errors. The verbatim repair spawn is in ORCHESTRATION.md (e).
 
 In the single-tier fallback (no worker profiles available), the parent fixes errors inline with `file_edit` and recompiles, same ≤2 bound — no repair subagent.
 
@@ -355,8 +358,6 @@ app_open(app_id, open_mode: "preview")
 ```
 
 ⚠️ **Do not skip this step.** Without it, the user sees no Open button, only your text description. `app_open` with `open_mode: "preview"` is the canonical surfacing path — it fires after all file_writes complete, so the card shows final content, not the scaffold placeholder.
-
-⚠️ **This step assumes you passed `auto_open: false` to `app_create` in Step 3.** If you forgot, `app_create` has already surfaced a card showing the placeholder, and this step adds a second card. Result: two duplicate previews in chat. Always pass `auto_open: false` to `app_create`.
 
 ⚠️ **`skill_load` is mandatory before `app_open`.** Same auto-unload risk as Step 4. The reload is idempotent — call it every time.
 
@@ -408,66 +409,9 @@ assistant inference session close
 
 ---
 
-## SKILL COMPLETE WHEN
+## Conventions
 
-- [ ] **PLAN.md written** to `/workspace/data/apps/<slug>/PLAN.md` (planner @ quality, five sections, disjoint partition table)
-- [ ] **Scaffold created** — `app_create` called ONCE with the 4-file scaffold and `auto_open: false`
-- [ ] **All workers completed** — every partition row dispatched as a `coder` subagent @ balanced (`override_profile`) and collected via `subagent_read`; each wrote only its own files
-- [ ] **`app_refresh` ran ONCE** from the parent, after all workers finished, with no remaining compile errors (repair subagent @ quality used if needed, ≤2 attempts)
-- [ ] **`app_open(app_id, open_mode: "preview")` rendered the preview** — inline card with an Open button is in chat
-- [ ] **User told what was built** (brief feature list, 3-6 bullets)
-- [ ] Iterations reflected in the live app (`app_refresh` called once after all edits, fresh preview card if substantial)
-- [ ] Inference session closed if one was opened in Step 0
-
----
-
-## Interaction standards
-
-Every app must meet these baselines:
-
-- **Feedback for every action** — use `vellum.widgets.toast()` after creates, deletes, updates, and errors
-- **Confirmation for destructive actions** — use `window.vellum.confirm(title, message)` before deleting or resetting. Returns `Promise<boolean>`
-- **Form validation** — validate before submit, show errors inline, disable submit during async operations
-- **Loading states** — never show a blank screen while data loads. Use skeleton shimmer or spinners
-- **Keyboard navigation** — `Tab` between elements, `Enter` to submit, `Escape` to close/cancel. De-prioritized on mobile-first builds
-
----
-
-## Error handling
-
-- Wrap every `window.vellum.fetch()` call in `try/catch` with user-friendly feedback. Check `res.ok` before parsing the body
-- Never let a failed operation pass silently — always show a toast or inline error
-- Show a designed empty state (`.v-empty-state`) when there's no data
-- Show validation errors inline next to the relevant form field
-
----
-
-## App interaction hooks
-
-Proactively wire `window.vellum.sendAction()` so the assistant stays aware of meaningful user interactions. Two patterns:
-
-- **Reactive hooks** — trigger an assistant response. Use for selections that warrant explanation, level completions, form submissions
-- **Silent hooks** (`state_update`) — accumulate context without interrupting. Use for tab navigation, filter changes, score updates
-
-Wire hooks during the initial build, not after the user asks. Full examples and per-app-type guidance in `{baseDir}/references/INTERACTION_HOOKS.md` (read with `host_file_read`).
-
----
-
-## Actionable UI
-
-When the user wants to triage or bulk-act on items, render an interactive UI with selectable items and action buttons:
-
-1. Fetch data with relevant tools
-2. Render a `dynamic_page` with selectable items and action buttons
-3. User selects + clicks action → UI sends `surfaceAction` with action ID and selected IDs
-4. Execute tools, update UI with `ui_update`, show feedback via `widgets.toast()`
-5. Use `window.vellum.confirm()` for destructive actions
-
----
-
-## External links
-
-Use `vellum.openLink(url, metadata)` to make items clickable. Construct deep-link URLs when possible. Include `metadata.provider` and `metadata.type` for context.
+The interaction baselines every app must meet (feedback, confirmation, validation, loading/keyboard) plus error handling, app interaction hooks (`sendAction`), actionable UI, and external links live in `{baseDir}/references/CONVENTIONS.md` (read with `host_file_read`). Meet them on every build and iteration.
 
 ---
 
@@ -488,4 +432,18 @@ Read these with the **`host_file_read`** tool when relevant — NOT `file_read` 
 - `{baseDir}/references/WIDGETS.md` — widget classes, chart utilities, formatting helpers
 - `{baseDir}/references/CUSTOM_ROUTES.md` — server-side persistence and custom API routes
 - `{baseDir}/references/INTERACTION_HOOKS.md` — sendAction patterns, reactive vs silent
+- `{baseDir}/references/CONVENTIONS.md` — interaction baselines, error handling, hooks, actionable UI, external links
 - `{baseDir}/references/SLIDES.md` — presentation slide design
+
+---
+
+## SKILL COMPLETE WHEN
+
+- [ ] **PLAN.md written** to `/workspace/data/apps/<slug>/PLAN.md` (planner @ quality, five sections, disjoint partition table)
+- [ ] **Scaffold created** — `app_create` called ONCE with the 4-file scaffold and `auto_open: false`
+- [ ] **All workers completed** — every partition row dispatched as a `coder` subagent @ balanced (`override_profile`) and collected via `subagent_read`; each wrote only its own files
+- [ ] **`app_refresh` ran ONCE** from the parent, after all workers finished, with no remaining compile errors (repair subagent @ quality used if needed, ≤2 attempts)
+- [ ] **`app_open(app_id, open_mode: "preview")` rendered the preview** — inline card with an Open button is in chat
+- [ ] **User told what was built** — posted a feature-list message (3-6 bullets) AFTER the preview card rendered
+- [ ] Iterations reflected in the live app (`app_refresh` called once after all edits, fresh preview card if substantial)
+- [ ] Inference session closed if one was opened in Step 0

--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -67,9 +67,13 @@ A widget library is auto-injected alongside the design system. Use `.v-*` classe
 
 ## Workflow
 
-### Step 0 — Pin to a high-quality model
+A non-trivial build runs as **three tiers**: a **planner** on the quality profile writes the build plan, a wave of **`coder` workers** on the balanced profile each implement a disjoint slice of files in parallel, then the **parent** compiles ONCE and surfaces the result. A quality-tier repair subagent fixes compile errors. This keeps judgment work (planning, repair) on the strong model and mechanical work (writing a component against a fixed spec) on the cheaper model.
 
-App building is design-heavy judgment work. A stronger model produces meaningfully better apps: more creative visual directions, cleaner component boundaries, fewer generic patterns.
+This SKILL.md is the map. The **exact** spawn sequence — every `subagent_spawn` shape, the bounded-wave dispatch, the compile-once rule, the repair loop, and the single-tier fallback — lives in `{baseDir}/references/ORCHESTRATION.md`. The shape of the plan artifact lives in `{baseDir}/references/BUILD_PLAN.md`. Read both with `host_file_read` before you dispatch. Do NOT paraphrase them from memory.
+
+### Step 0 — Put the planner on the quality profile
+
+App building is design-heavy judgment work. Partitioning a component tree into clean, disjoint, independently-buildable slices and choosing a distinctive visual direction needs a strong model. The **planner tier runs on `quality-optimized`**; workers run on `balanced` (routed per-spawn via `override_profile` — see ORCHESTRATION.md).
 
 Check the active inference session:
 
@@ -77,7 +81,7 @@ Check the active inference session:
 assistant inference session list
 ```
 
-**If a session is already active at quality-optimized** → skip this step.
+**If a session is already active at quality-optimized** → skip the rest of this step; you're already on the planner tier.
 
 **If the active profile is `balanced`, `cost-optimized`, or any non-quality profile** → ask the user before switching. Do NOT open a session without explicit confirmation. Use the `ui_show` tool to present an inline `confirmation` surface and wait for the action. Do not call the shell command `assistant ui confirm`; that CLI-mediated confirmation can block the build flow before the app work starts.
 
@@ -111,9 +115,11 @@ assistant config get llm.profiles
 assistant inference session open <highest-quality-profile> --ttl 1h
 ```
 
-**If user declines** → proceed with the current profile. Skip the session close in Step 7.
+**If user declines** → proceed with the current profile. The planner is then whatever profile is active. Skip the session close in Step 7.
 
 **If `assistant inference session` is unavailable on this binary** → proceed without it.
+
+**Profile availability gates the tiering.** If the workspace has neither a `balanced` nor a `quality-optimized` profile, the tiered worker dispatch degrades to a single-tier sequential build — the parent writes every file itself in partition-table order. The exact degrade rules are in ORCHESTRATION.md's "Fallback" section.
 
 ### Step 1 — Gather requirements (default: just build)
 
@@ -155,9 +161,23 @@ Example for a project tracker:
 
 Apps without persistence (calculators, single-page tools, landing pages, slide decks) skip this step. Pass an empty `schema_json` or omit it.
 
-### Step 3 — Build the app
+### Step 3 — Plan, then build in parallel
 
-⚠️ **`app_create` is ONE-SHOT per build task.** Call it exactly once. Once it returns an `app_id`, that's your app for the rest of this task — all further changes go through `file_write` / `file_edit` + `app_refresh` (Step 4 and Step 6). Do NOT call `app_create` again:
+This is the tiered core. The order is fixed: **plan → scaffold → dispatch workers → compile once → repair → surface**. The exact spawn shapes live in ORCHESTRATION.md; read it now.
+
+**3a. Plan (planner @ quality).** Following `{baseDir}/references/BUILD_PLAN.md`, write the build plan to `/workspace/data/apps/<slug>/PLAN.md` with `file_write`, ONCE, fully — its five sections (data schema, visual direction, component tree, file-partition table, invariants). The §2 Visual direction is the single source of truth every worker reads to stay consistent. The §4 file-partition table is the orchestration core: **one row per worker, every source file in exactly one row** (disjoint). Shared files (`styles.css`, `types.ts`, `main.tsx`, `index.html`) get exactly one owner. Source the visual direction from the `frontend-design` skill and `{baseDir}/references/DESIGN_SYSTEM.md`.
+
+**3b. Scaffold (parent).** `skill_load("app-builder")` then `app_create` ONCE with the 4-file self-contained scaffold (`src/index.html`, `src/main.tsx`, a placeholder `src/components/App.tsx`, an empty `src/styles.css`). Pass `auto_open: false`. The placeholders make the initial compile clean. See the `app_create` parameter rules below.
+
+**3c. Dispatch (`coder` workers @ balanced).** Spawn one `coder` subagent per partition row with `subagent_spawn({ label, role: "coder", override_profile: "balanced", objective })`, **in bounded waves of ≤3–4 at a time**. Each worker's objective carries its partition slice plus the verbatim §2 Visual direction and the §3 component-tree context for its files. Workers use `file_write` / `file_edit` ONLY — never `app_refresh` / `app_create` / `app_open`. Read ORCHESTRATION.md (a)–(c) for the verbatim spawn shape and the wave/collect (`subagent_read`) protocol.
+
+⚠️ **Compile-once rule: only the parent calls `app_refresh`, exactly once, after every worker across every wave has finished. Workers NEVER compile** (no `app_refresh`, `app_create`, or `app_open`). A worker that compiles corrupts the shared build cache and races the others.
+
+**3d. Compile, repair, surface.** Steps 4–6 below own these: the parent compiles ONCE (Step 4), spawns a quality-tier repair subagent on failure (per ORCHESTRATION.md (e), bounded to ≤2 attempts), then surfaces the preview card (Step 5).
+
+The remainder of this Step 3 — the `app_create` one-shot rule, project structure, technical constraints, and persistence — applies to the scaffold (3b) and to every worker's `file_write`.
+
+⚠️ **`app_create` is ONE-SHOT per build task.** Call it exactly once, at scaffold time (3b). Once it returns an `app_id`, that's your app for the rest of this task — all further changes go through `file_write` / `file_edit` (workers, or the parent on iteration) + `app_refresh` (Step 4 and Step 6). Do NOT call `app_create` again:
 
 - To rename → edit `/workspace/data/apps/<slug>.json` directly (Step 6)
 - To "try fresh" or "start over" → call `app_delete(first_app_id)` FIRST, then `app_create`
@@ -220,38 +240,37 @@ Import CSS directly in TSX: `import "./styles.css"`.
 - Custom route handlers — persistent app records, server-side logic, file access. Call via `window.vellum.fetch("/v1/x/...")`. Full guide in `{baseDir}/references/CUSTOM_ROUTES.md` (read with `host_file_read`). **Never use raw `fetch()` for `/v1/x/` routes** — it fails in the sandboxed origin.
 - Legacy `window.vellum.data.*` — deprecated, only for editing pre-existing legacy apps. Prefer custom routes for everything new.
 
-#### File workflow: scaffold then expand
+#### File workflow: scaffold, then parallel workers
 
 Default pattern for ALL non-trivial apps (anything beyond a single small page):
 
-1. **`skill_load("app-builder")`** then **`app_create`** with `source_files` containing a 4-file self-contained scaffold:
+1. **`skill_load("app-builder")`** then **`app_create`** with `source_files` containing a 4-file self-contained scaffold (parent, step 3b):
    - `src/index.html` — entry shell
    - `src/main.tsx` — entry point that renders `<App />`
-   - `src/components/App.tsx` — **placeholder** `<div>Loading...</div>` (overwritten in Step 2)
-   - `src/styles.css` — **empty** (overwritten in Step 2)
+   - `src/components/App.tsx` — **placeholder** `<div>Loading...</div>` (overwritten by a worker)
+   - `src/styles.css` — **empty** (overwritten by its owning worker)
 
-2. **`file_write`** each remaining file in its own tool call, one per turn:
-   - `src/components/App.tsx` — the real component (overwrites placeholder)
-   - `src/components/Header.tsx`, `RecordList.tsx`, etc.
-   - `src/styles.css` — the real styles (overwrites empty)
-   - `src/types.ts` if shared
+2. **Dispatch `coder` workers** (step 3c, ORCHESTRATION.md). Each worker `file_write`s the files in its own partition-table row — the real `App.tsx`, `Header.tsx`, the real `styles.css`, `types.ts`, etc. — overwriting the placeholders. Workers run in bounded waves and write ONLY their own files.
 
-3. **`skill_load("app-builder")`** then **`app_refresh`** ONCE at the end to compile.
+3. **`skill_load("app-builder")`** then **`app_refresh`** ONCE, from the parent, after every worker has finished (Step 4).
 
-**Why the 4-file scaffold:** A 2-file scaffold (just `index.html` + `main.tsx`) leaves broken imports because `main.tsx` references `./components/App` and `./styles.css`. The initial compile then returns `Could not resolve "./components/App"` errors. Those errors don't fail app creation (you still get an `app_id`), but they can trigger a panic-retry of `app_create`. Placeholders make the scaffold compile clean.
+**Why the 4-file scaffold:** A 2-file scaffold (just `index.html` + `main.tsx`) leaves broken imports because `main.tsx` references `./components/App` and `./styles.css`. The initial compile then returns `Could not resolve "./components/App"` errors. Those errors don't fail app creation (you still get an `app_id`), but they can trigger a panic-retry of `app_create`. Placeholders make the scaffold compile clean and give workers a stable shell to overwrite.
 
-**Why scaffold-then-expand at all:** A single `app_create` call carrying 5+ inline TSX files blows the response token budget mid-emit (each character of source counts as output). Splitting across tool calls spreads cost across LLM turns, each with a fresh budget. The inline-everything pattern is only safe for trivial single-file apps (under ~150 lines total).
+**Why scaffold then dispatch:** A single `app_create` call carrying 5+ inline TSX files blows the response token budget mid-emit (each character of source counts as output). Spreading the files across parallel workers spreads cost across independent subagents, each with a fresh budget — and they write concurrently. The inline-everything pattern is only safe for trivial single-file apps (under ~150 lines total), which skip the worker dispatch.
 
-⚠️ **Correct app path is `/workspace/data/apps/<slug>/src/`.** Never write to `/workspace/apps/` — that path does not exist. Confirm the path starts with `/workspace/data/apps/` before every `file_write` and `file_edit`.
+⚠️ **Correct app path is `/workspace/data/apps/<slug>/src/`.** Never write to `/workspace/apps/` — that path does not exist. Confirm the path starts with `/workspace/data/apps/` before every `file_write` and `file_edit` (in the scaffold, in every worker, on iteration).
 
-⚠️ **`compile_errors` in the `app_create` response is NOT a retry signal.** The response also contains an `app_id` — the app was created. Proceed to Step 4. Calling `app_create` again creates a duplicate app (see the one-shot rule above).
+⚠️ **`compile_errors` in the `app_create` response is NOT a retry signal.** The response also contains an `app_id` — the app was created. The placeholder scaffold may report unresolved imports; that's expected before workers fill it in. Proceed to dispatch. Calling `app_create` again creates a duplicate app (see the one-shot rule above).
 
 #### Concrete example
 
-Scaffold a project tracker, expand it, compile it:
+Plan a project tracker, scaffold it, dispatch workers, compile it ONCE:
 
 ```
-// Tool call 1 — reload the skill, then app_create with the 4-file scaffold
+// 3a — planner @ quality writes the plan (BUILD_PLAN.md shape)
+file_write("/workspace/data/apps/project-tracker/PLAN.md", "<five-section build plan>")
+
+// 3b — parent scaffolds ONCE: reload, then app_create with the 4-file scaffold
 skill_load("app-builder")
 app_create({
   name: "Project Tracker",
@@ -276,85 +295,55 @@ render(<App />, document.getElementById("app")!);`,
   }
 })
 
-// Tool calls 2..N — file_write each remaining file, one per turn
-file_write("/workspace/data/apps/<slug>/src/components/App.tsx", "...")  // overwrites the placeholder
-file_write("/workspace/data/apps/<slug>/src/components/Header.tsx", "...")
-file_write("/workspace/data/apps/<slug>/src/styles.css", "...")          // overwrites the empty file
+// 3c — dispatch coder workers @ balanced in bounded waves (see ORCHESTRATION.md)
+subagent_spawn({ label: "W1 — shell & data", role: "coder", override_profile: "balanced", objective: "<App.tsx + styles.css + types.ts row + §2 verbatim; file_write only, do NOT app_refresh>" })
+subagent_spawn({ label: "W2 — header & form", role: "coder", override_profile: "balanced", objective: "..." })
+subagent_spawn({ label: "W3 — board & columns", role: "coder", override_profile: "balanced", objective: "..." })
+// collect each via subagent_read on completion, then next wave
 
-// Tool call N+1 — reload, then app_refresh ONCE to compile
+// 3d / Step 4 — parent compiles ONCE after all workers finish
 skill_load("app-builder")
 app_refresh("<app_id>")
 ```
 
 ⚠️ **`skill_load("app-builder")` is mandatory before EVERY `app_*` tool call**, including the very first `app_create`. The skill can auto-unload between activation and use. The reload is idempotent — call it every time.
 
-⚠️ **Do NOT cram all components into the initial `app_create` source_files map.** That pattern blows the response budget for any non-trivial app. Scaffold with the 4-file minimum, expand with `file_write`.
+⚠️ **Do NOT cram all components into the initial `app_create` source_files map.** That pattern blows the response budget for any non-trivial app. Scaffold with the 4-file minimum; workers write the rest.
 
-⚠️ **Do NOT pass file paths as top-level `app_create` parameters.** Only these top-level keys are valid: `name`, `description`, `schema_json`, `source_files`, `preview`, `auto_open`, `change_summary`. All file content goes INSIDE the `source_files` object. If you find yourself writing a path like `"src/components/Header.tsx": "..."` as a top-level key, stop — that file belongs in a separate `file_write` call after `app_create`.
-
-❌ **Wrong — file path as a top-level key:**
-
-```
-app_create({
-  name: "Project Tracker",
-  source_files: {
-    "src/index.html": "...",
-    "src/main.tsx": "...",
-    "src/components/App.tsx": "...",
-    "src/styles.css": ""
-  },
-  "src/components/Header.tsx": "..."   // INVALID — must be one of the 7 keys above
-})
-```
-
-This fails with: `Invalid input for tool "app_create": Unknown parameter "src/components/Header.tsx". Supported: "name", "description", "schema_json", "auto_open", "preview", "source_files", "change_summary".`
-
-✅ **Right — extra files go in separate `file_write` calls after `app_create`:**
-
-```
-app_create({
-  name: "Project Tracker",
-  source_files: {
-    "src/index.html": "...",
-    "src/main.tsx": "...",
-    "src/components/App.tsx": "...",
-    "src/styles.css": ""
-  }
-})
-
-file_write("/workspace/data/apps/<slug>/src/components/Header.tsx", "...")
-```
+⚠️ **Do NOT pass file paths as top-level `app_create` parameters.** Only these top-level keys are valid: `name`, `description`, `schema_json`, `source_files`, `preview`, `auto_open`, `change_summary`. All scaffold file content goes INSIDE the `source_files` object — exactly the 4 scaffold files. A path like `"src/components/Header.tsx": "..."` as a top-level key is INVALID; that file is a worker's `file_write`, not a scaffold key. It fails with: `Invalid input for tool "app_create": Unknown parameter "src/components/Header.tsx". Supported: "name", "description", "schema_json", "auto_open", "preview", "source_files", "change_summary".`
 
 #### `app_create` parameters
 
 - `name` (string, required) — Short descriptive name
 - `description` (string, optional) — One-sentence summary
 - `schema_json` (string, optional) — JSON schema as string
-- `source_files` (object, optional) — Map of relative paths to contents. For the scaffold step, include exactly 4 files: `src/index.html`, `src/main.tsx`, a placeholder `src/components/App.tsx`, and an empty `src/styles.css`. The placeholders make the initial compile clean — `file_write` calls in Step 2 of the workflow overwrite them with the real content
+- `source_files` (object, optional) — Map of relative paths to contents. For the scaffold step (3b), include exactly 4 files: `src/index.html`, `src/main.tsx`, a placeholder `src/components/App.tsx`, and an empty `src/styles.css`. The placeholders make the initial compile clean — the `coder` workers (3c) overwrite them with the real content
 - `preview` (object, optional but always include) — `title` (required), `subtitle`, `description`, `icon` (image URL preferred, emoji fallback), `metrics` (up to 3)
 - `auto_open` (boolean, optional, defaults `true`) — **Always pass `auto_open: false`.** When true, a preview card fires immediately after `app_create`. Combined with the explicit `app_open(open_mode: "preview")` call in Step 5, that produces TWO preview cards in chat — one showing the scaffold placeholder, one showing the final content. Set this to `false` and let Step 5 own the surfacing moment.
 - `change_summary` (string, optional) — Conventional commit message
 
 Do NOT pass `html` or `pages` to `app_create` — those single-file shortcuts are retired.
 
-### Step 4 — Compile
+### Step 4 — Compile ONCE (parent), then repair @ quality on failure
 
-After all `file_write` calls are complete, reload the skill and compile:
+After every worker across every wave has finished and you've collected each with `subagent_read`, the **parent** reloads the skill and compiles — exactly once:
 
 ```
 skill_load("app-builder")
 app_refresh(app_id)
 ```
 
-⚠️ **The `skill_load` call is mandatory, not conditional.** The scaffold-then-expand pattern puts 4-6 generic `file_write` turns between `app_create` and `app_refresh`. On some platforms, the skill auto-unloads during that window because none of its own tools fired. Without the reload, `app_refresh` returns:
+⚠️ **Compile-once: only the parent calls `app_refresh`, exactly once, after all workers finish. Workers NEVER compile.** Calling it per-worker or per-file races the build and corrupts the shared cache.
+
+⚠️ **The `skill_load` call is mandatory, not conditional.** The worker dispatch puts many generic subagent turns between `app_create` and `app_refresh`. On some platforms, the skill auto-unloads during that window because none of its own tools fired. Without the reload, `app_refresh` returns:
 
 > Tool "app_refresh" is not currently active. Load the "app-builder" skill that provides this tool first.
 
 The reload is cheap and idempotent — call it every time.
 
-⚠️ **Call `app_refresh` ONCE, after ALL file changes.** Calling it per-file is wrong — batching is required. The build is cached on success.
+**On compile failure → repair subagent @ quality.** Spawn a single repair `coder` subagent on the **quality-optimized** profile via `subagent_spawn` + `override_profile` (fixing cross-file type and import errors is judgment work). Its objective carries the `app_refresh` errors verbatim, the PLAN.md path, and the failing files. The repair agent uses `file_edit` only and does NOT compile. After it reports done, the parent reloads and `app_refresh`es again. **Bound to ≤2 repair attempts**, then surface the remaining errors to the user. The verbatim repair spawn is in ORCHESTRATION.md (e).
 
-If compilation fails, the response includes error details. Fix the errors with `file_edit`, then `skill_load("app-builder")` again, then `app_refresh`.
+In the single-tier fallback (no worker profiles available), the parent fixes errors inline with `file_edit` and recompiles, same ≤2 bound — no repair subagent.
 
 ### Step 5 — Show the inline preview card
 
@@ -421,11 +410,12 @@ assistant inference session close
 
 ## SKILL COMPLETE WHEN
 
-- [ ] App built and `app_create` returned successfully
-- [ ] All source files written via `file_write` (one tool call per file)
-- [ ] `app_refresh` ran ONCE without compile errors
-- [ ] `app_open(app_id, open_mode: "preview")` rendered the inline preview card with Open button
-- [ ] User has been told what was built (brief feature list, 3-6 bullets)
+- [ ] **PLAN.md written** to `/workspace/data/apps/<slug>/PLAN.md` (planner @ quality, five sections, disjoint partition table)
+- [ ] **Scaffold created** — `app_create` called ONCE with the 4-file scaffold and `auto_open: false`
+- [ ] **All workers completed** — every partition row dispatched as a `coder` subagent @ balanced (`override_profile`) and collected via `subagent_read`; each wrote only its own files
+- [ ] **`app_refresh` ran ONCE** from the parent, after all workers finished, with no remaining compile errors (repair subagent @ quality used if needed, ≤2 attempts)
+- [ ] **`app_open(app_id, open_mode: "preview")` rendered the preview** — inline card with an Open button is in chat
+- [ ] **User told what was built** (brief feature list, 3-6 bullets)
 - [ ] Iterations reflected in the live app (`app_refresh` called once after all edits, fresh preview card if substantial)
 - [ ] Inference session closed if one was opened in Step 0
 
@@ -491,6 +481,8 @@ Slides are a different domain from apps — skip app-specific patterns (contextu
 
 Read these with the **`host_file_read`** tool when relevant — NOT `file_read` (they live outside the `/workspace` sandbox). `{baseDir}` resolves to this skill's directory at load time:
 
+- `{baseDir}/references/ORCHESTRATION.md` — exact planner/worker spawn sequence (waves, compile-once, repair, fallback)
+- `{baseDir}/references/BUILD_PLAN.md` — PLAN.md artifact shape: five sections + partition-table invariants
 - `{baseDir}/references/RESPONSIVE.md` — mobile-first vs desktop, universal baseline, safe areas
 - `{baseDir}/references/DESIGN_SYSTEM.md` — full design token table, utility classes, theme detection JS
 - `{baseDir}/references/WIDGETS.md` — widget classes, chart utilities, formatting helpers

--- a/assistant/src/config/bundled-skills/app-builder/__evals__/README.md
+++ b/assistant/src/config/bundled-skills/app-builder/__evals__/README.md
@@ -1,0 +1,76 @@
+# app-builder eval / golden-set harness
+
+A standalone harness for measuring whether a change to the app-builder flow
+improves taste and latency, instead of guessing. It runs a fixed set of prompts
+through one or more **build variants** and emits an A/B-comparable **scorecard**.
+
+The immediate motivation is app-builder v2 (a tiered planner/worker flow). This
+harness lets us baseline the current **single-model** skill now, then A/B it
+against the **planner/worker** flow once that lands.
+
+> This is **not** wired into the default test / CI gate. It is meant to be run
+> by hand when evaluating a change.
+
+## What it measures
+
+Per build (one prompt under one variant), three independent dimensions:
+
+| Dimension          | What it checks                                                               | Where               |
+| ------------------ | ---------------------------------------------------------------------------- | ------------------- |
+| **compile**        | Did the produced source compile?                                             | `runner.ts`         |
+| **plan-adherence** | Did the output use the expected design tokens / files? (static, best-effort) | `plan-adherence.ts` |
+| **design rubric**  | LLM-scored aesthetic/quality judgment                                        | `rubric.ts`         |
+
+These roll up into a `Scorecard` (`types.ts`) with one column per variant and
+columns reserved for **latency** and **cost** — to be filled in by PR 7
+telemetry.
+
+## Run it
+
+```bash
+cd assistant
+bun run src/config/bundled-skills/app-builder/__evals__/index.ts
+```
+
+Prints a scorecard table. Out of the box both columns use a deterministic
+**stub** build driver and a **stub** design judge, so the numbers are
+placeholders that prove the pipeline runs end-to-end.
+
+Run the smoke test:
+
+```bash
+cd assistant
+bun test src/config/bundled-skills/app-builder/__evals__/__tests__/harness.test.ts
+```
+
+## Files
+
+- `prompts.ts` — the fixed golden prompt set (habit tracker, finance dashboard,
+  slide deck, calculator). **Append-only** — editing existing prompts breaks
+  comparability across runs.
+- `types.ts` — shared types and the two key interfaces: `AppBuildDriver` and
+  `DesignJudge`.
+- `build-driver.ts` — `AppBuildDriver` impls. Ships `StubBuildDriver`; real
+  single-model and planner/worker drivers slot in here.
+- `rubric.ts` — the design rubric, the LLM-judge interface (`LLMDesignJudge`),
+  and `StubDesignJudge`.
+- `plan-adherence.ts` — best-effort static token/file checks.
+- `runner.ts` — drives builds, scores them, aggregates the scorecard. Compile
+  and judge steps are injectable.
+- `index.ts` — CLI entry + scorecard formatter.
+
+## Wiring real signal (later)
+
+The harness depends only on the `AppBuildDriver` and `DesignJudge` interfaces,
+so making it real is a matter of swapping stubs for live impls:
+
+1. **Live build driver** — implement `AppBuildDriver.build()` to run the actual
+   app-builder skill (single-model) and the planner/worker flow, returning the
+   real source files (and the planner/worker's committed plan).
+2. **Live design judge** — implement `DesignJudge.score()` to render the built
+   app, send `buildJudgePrompt()` + a screenshot to a model, and parse the
+   rubric scores (`scoreToOverall()` does the weighting).
+3. **Real compile** — pass `compile` to `runEvals` backed by the esbuild
+   `compileApp` from `assistant/src/bundler/app-compiler.ts`.
+4. **Telemetry** — populate `BuildResult.telemetry` (latency/cost) once PR 7
+   lands; the scorecard already has the columns.

--- a/assistant/src/config/bundled-skills/app-builder/__evals__/__tests__/harness.test.ts
+++ b/assistant/src/config/bundled-skills/app-builder/__evals__/__tests__/harness.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+
+import { StubBuildDriver } from "../build-driver.js";
+import { checkPlanAdherence } from "../plan-adherence.js";
+import { GOLDEN_PROMPTS } from "../prompts.js";
+import { DESIGN_RUBRIC, scoreToOverall, StubDesignJudge } from "../rubric.js";
+import { runEvals } from "../runner.js";
+import type { BuildArtifact } from "../types.js";
+
+describe("app-builder eval harness", () => {
+  test("ships a non-empty fixed prompt set with unique ids", () => {
+    expect(GOLDEN_PROMPTS.length).toBeGreaterThan(0);
+    const ids = GOLDEN_PROMPTS.map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test("scoreToOverall maps a perfect rubric to 1 and a floor to 0", () => {
+    const perfect = DESIGN_RUBRIC.map((c) => ({
+      criterionId: c.id,
+      score: 5,
+      rationale: "",
+    }));
+    const floor = DESIGN_RUBRIC.map((c) => ({
+      criterionId: c.id,
+      score: 1,
+      rationale: "",
+    }));
+    expect(scoreToOverall(perfect)).toBeCloseTo(1);
+    expect(scoreToOverall(floor)).toBeCloseTo(0);
+  });
+
+  test("plan-adherence rewards expected tokens/files and flags misses", async () => {
+    const prompt = GOLDEN_PROMPTS[0];
+    const good = await new StubBuildDriver("single-model").build(prompt);
+    const goodResult = checkPlanAdherence(good, prompt);
+    expect(goodResult.fileCoverage).toBe(1);
+    expect(goodResult.tokenCoverage).toBeGreaterThan(0);
+
+    const empty: BuildArtifact = { sourceFiles: {} };
+    const emptyResult = checkPlanAdherence(empty, prompt);
+    expect(emptyResult.fileCoverage).toBe(0);
+    expect(emptyResult.missingFiles.length).toBeGreaterThan(0);
+  });
+
+  test("stub design judge returns one score per rubric criterion", async () => {
+    const prompt = GOLDEN_PROMPTS[0];
+    const artifact = await new StubBuildDriver("single-model").build(prompt);
+    const result = await new StubDesignJudge().score(artifact, prompt);
+    expect(result.scores.length).toBe(DESIGN_RUBRIC.length);
+    expect(result.overall).toBeGreaterThanOrEqual(0);
+    expect(result.overall).toBeLessThanOrEqual(1);
+  });
+
+  test("runEvals produces an A/B scorecard with one column per driver", async () => {
+    const card = await runEvals({
+      prompts: GOLDEN_PROMPTS,
+      drivers: [
+        new StubBuildDriver("single-model"),
+        new StubBuildDriver("planner-worker"),
+      ],
+    });
+
+    expect(card.promptSetSize).toBe(GOLDEN_PROMPTS.length);
+    expect(card.columns.map((c) => c.variant)).toEqual([
+      "single-model",
+      "planner-worker",
+    ]);
+    for (const col of card.columns) {
+      expect(col.rows.length).toBe(GOLDEN_PROMPTS.length);
+      expect(col.compileRate).toBe(1); // stub scaffold always compiles
+      // Telemetry columns are present but empty until PR 7 wires them.
+      expect(col.meanLatencyMs).toBeUndefined();
+      expect(col.meanCostUsd).toBeUndefined();
+    }
+  });
+});

--- a/assistant/src/config/bundled-skills/app-builder/__evals__/build-driver.ts
+++ b/assistant/src/config/bundled-skills/app-builder/__evals__/build-driver.ts
@@ -1,0 +1,47 @@
+/**
+ * Build drivers: the seam between the harness and an actual app-build flow.
+ *
+ * A driver takes a golden prompt and returns the source files (and optional
+ * plan) the flow produced. Two real drivers are expected to land:
+ *
+ *  - single-model (baseline) — runs the current app-builder skill once.
+ *  - planner-worker (v2)      — runs the tiered flow from this plan.
+ *
+ * Actually invoking the skill end-to-end (spinning up a conversation, calling
+ * the model, executing app-create) is heavier than this scaffolding PR. So we
+ * ship {@link StubBuildDriver}: it returns a representative scaffold so the
+ * harness produces a scorecard today. Replace with a live driver that wires the
+ * real flow — the harness only depends on the {@link AppBuildDriver} interface.
+ */
+
+import type {
+  AppBuildDriver,
+  BuildArtifact,
+  GoldenPrompt,
+  Variant,
+} from "./types.js";
+
+/**
+ * Deterministic placeholder driver. Emits the standard formatVersion-2
+ * scaffold using a handful of design tokens so compile + plan-adherence checks
+ * have something real to run against. It does NOT call a model.
+ */
+export class StubBuildDriver implements AppBuildDriver {
+  constructor(readonly variant: Variant) {}
+
+  async build(prompt: GoldenPrompt): Promise<BuildArtifact> {
+    const main = [
+      `// stub build for "${prompt.label}" (${this.variant})`,
+      "export default function App() {",
+      "  return (",
+      '    <main style={{ background: "var(--v-bg)", color: "var(--v-text)" }}>',
+      `      <h1 style={{ color: "var(--v-accent)" }}>${prompt.label}</h1>`,
+      "    </main>",
+      "  );",
+      "}",
+      "",
+    ].join("\n");
+
+    return { sourceFiles: { "src/main.tsx": main } };
+  }
+}

--- a/assistant/src/config/bundled-skills/app-builder/__evals__/index.ts
+++ b/assistant/src/config/bundled-skills/app-builder/__evals__/index.ts
@@ -1,0 +1,70 @@
+/**
+ * Standalone CLI entry for the app-builder eval harness.
+ *
+ *   bun run assistant/src/config/bundled-skills/app-builder/__evals__/index.ts
+ *
+ * Runs the golden prompt set through the registered build drivers and prints an
+ * A/B scorecard. This is intentionally NOT wired into the default test/CI gate.
+ *
+ * Today both columns use the stub driver + stub judge (see build-driver.ts /
+ * rubric.ts), so the numbers are placeholders that prove the pipeline works.
+ * Swap in a live single-model driver and the planner/worker driver to get real
+ * A/B signal once PR 7 (telemetry) and the v2 flow land.
+ */
+
+import { StubBuildDriver } from "./build-driver.js";
+import { GOLDEN_PROMPTS } from "./prompts.js";
+import { runEvals } from "./runner.js";
+import type { Scorecard } from "./types.js";
+
+function fmt(n: number | undefined): string {
+  return n === undefined ? "—" : n.toFixed(2);
+}
+
+export function formatScorecard(card: Scorecard): string {
+  const lines: string[] = [];
+  lines.push(`app-builder eval scorecard — ${card.generatedAt}`);
+  lines.push(`prompts: ${card.promptSetSize}`);
+  lines.push("");
+  lines.push(
+    [
+      "variant".padEnd(16),
+      "compile",
+      "tokens",
+      "files",
+      "design",
+      "lat(ms)",
+      "cost($)",
+    ].join("  "),
+  );
+  for (const col of card.columns) {
+    lines.push(
+      [
+        col.variant.padEnd(16),
+        fmt(col.compileRate).padStart(7),
+        fmt(col.meanTokenCoverage).padStart(6),
+        fmt(col.meanFileCoverage).padStart(5),
+        fmt(col.meanDesignScore).padStart(6),
+        fmt(col.meanLatencyMs).padStart(7),
+        fmt(col.meanCostUsd).padStart(7),
+      ].join("  "),
+    );
+  }
+  return lines.join("\n");
+}
+
+export async function main(): Promise<void> {
+  const card = await runEvals({
+    prompts: GOLDEN_PROMPTS,
+    // Two columns wired for A/B; both stubbed until the live flows land.
+    drivers: [
+      new StubBuildDriver("single-model"),
+      new StubBuildDriver("planner-worker"),
+    ],
+  });
+  console.log(formatScorecard(card));
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/assistant/src/config/bundled-skills/app-builder/__evals__/plan-adherence.ts
+++ b/assistant/src/config/bundled-skills/app-builder/__evals__/plan-adherence.ts
@@ -1,0 +1,91 @@
+/**
+ * Best-effort static plan-adherence checks.
+ *
+ * "Plan adherence" asks: did the build actually use the design tokens and
+ * files it was supposed to? We can't run the app here, so we do cheap static
+ * checks over the produced source — token presence and file presence.
+ *
+ * Expectations come from the build's own plan when available (planner/worker
+ * emits one), otherwise from {@link DEFAULT_EXPECTATIONS} keyed by prompt, then
+ * a generic baseline. This keeps the check meaningful for the single-model
+ * variant (which has no explicit plan) while letting the v2 flow be graded
+ * against what it claimed it would do.
+ */
+
+import type {
+  BuildArtifact,
+  GoldenPrompt,
+  PlanAdherenceResult,
+  PlanExpectations,
+} from "./types.js";
+
+/** Tokens every well-formed app should lean on (design-system surface). */
+const BASELINE_TOKENS = ["--v-bg", "--v-text", "--v-accent"];
+
+/** The multi-file (formatVersion 2) scaffold every app should produce. */
+const BASELINE_FILES = ["src/main.tsx"];
+
+/**
+ * Per-prompt expectations layered on top of the baseline. Best-effort — these
+ * encode "a faithful X build tends to use Y", not a hard spec.
+ */
+export const DEFAULT_EXPECTATIONS: Record<string, PlanExpectations> = {
+  "habit-tracker": {
+    designTokens: [...BASELINE_TOKENS, "--v-success"],
+    files: BASELINE_FILES,
+  },
+  "finance-dashboard": {
+    designTokens: [...BASELINE_TOKENS, "--v-surface"],
+    files: BASELINE_FILES,
+  },
+  "slide-deck": {
+    designTokens: [...BASELINE_TOKENS],
+    files: BASELINE_FILES,
+  },
+  calculator: {
+    designTokens: [...BASELINE_TOKENS, "--v-font-mono"],
+    files: BASELINE_FILES,
+  },
+};
+
+function resolveExpectations(
+  artifact: BuildArtifact,
+  prompt: GoldenPrompt,
+): PlanExpectations {
+  return (
+    artifact.plan ??
+    prompt.expects ??
+    DEFAULT_EXPECTATIONS[prompt.id] ?? {
+      designTokens: BASELINE_TOKENS,
+      files: BASELINE_FILES,
+    }
+  );
+}
+
+function coverage<T>(expected: T[], isPresent: (item: T) => boolean) {
+  if (expected.length === 0) return { fraction: 1, missing: [] as T[] };
+  const missing = expected.filter((item) => !isPresent(item));
+  return {
+    fraction: (expected.length - missing.length) / expected.length,
+    missing,
+  };
+}
+
+export function checkPlanAdherence(
+  artifact: BuildArtifact,
+  prompt: GoldenPrompt,
+): PlanAdherenceResult {
+  const expected = resolveExpectations(artifact, prompt);
+  const allSource = Object.values(artifact.sourceFiles).join("\n");
+  const presentFiles = new Set(Object.keys(artifact.sourceFiles));
+
+  const tokens = coverage(expected.designTokens, (t) => allSource.includes(t));
+  const files = coverage(expected.files, (f) => presentFiles.has(f));
+
+  return {
+    tokenCoverage: tokens.fraction,
+    fileCoverage: files.fraction,
+    missingTokens: tokens.missing,
+    missingFiles: files.missing,
+  };
+}

--- a/assistant/src/config/bundled-skills/app-builder/__evals__/prompts.ts
+++ b/assistant/src/config/bundled-skills/app-builder/__evals__/prompts.ts
@@ -1,0 +1,33 @@
+/**
+ * The fixed golden prompt set. Keep this stable — changing prompts breaks
+ * comparability across runs. Add new prompts; don't edit existing ones.
+ */
+
+import type { GoldenPrompt } from "./types.js";
+
+export const GOLDEN_PROMPTS: readonly GoldenPrompt[] = [
+  {
+    id: "habit-tracker",
+    label: "Habit tracker",
+    prompt:
+      "Build me a habit tracker where I can add daily habits and check them off, with a streak counter.",
+  },
+  {
+    id: "finance-dashboard",
+    label: "Finance dashboard",
+    prompt:
+      "Build a personal finance dashboard showing spending by category with a chart and a recent-transactions list.",
+  },
+  {
+    id: "slide-deck",
+    label: "Slide deck",
+    prompt:
+      "Build a 5-slide deck pitching a coffee subscription startup, with a title slide and presenter navigation.",
+  },
+  {
+    id: "calculator",
+    label: "Calculator",
+    prompt:
+      "Build a calculator with the standard arithmetic operations and a clean keypad layout.",
+  },
+] as const;

--- a/assistant/src/config/bundled-skills/app-builder/__evals__/rubric.ts
+++ b/assistant/src/config/bundled-skills/app-builder/__evals__/rubric.ts
@@ -1,0 +1,121 @@
+/**
+ * Design rubric definition + the LLM-judge interface.
+ *
+ * The rubric is the spec we hand an LLM (alongside a render of the built app)
+ * to score design quality. The criteria mirror the aesthetic principles the
+ * `frontend-design` skill enforces — these are what "whoa, this looks
+ * designed" decomposes into.
+ *
+ * `LLMDesignJudge` is the real interface a live judge implements. Wiring an
+ * actual model (screenshot the built app, send rubric + image, parse scores)
+ * is out of scope for this scaffolding PR, so we also ship
+ * {@link StubDesignJudge}: a deterministic placeholder that lets the full
+ * pipeline run and produce a scorecard today. Swap it for a live judge when
+ * available — the harness depends only on the {@link DesignJudge} interface.
+ */
+
+import type {
+  BuildArtifact,
+  DesignJudge,
+  GoldenPrompt,
+  RubricCriterion,
+  RubricResult,
+  RubricScore,
+} from "./types.js";
+
+/** The scored dimensions. Weights need not sum to 1; we normalize. */
+export const DESIGN_RUBRIC: readonly RubricCriterion[] = [
+  {
+    id: "visual-identity",
+    label: "Visual identity",
+    description:
+      "Does the app have a distinctive, domain-matched look (palette, atmosphere) rather than a generic branded template?",
+    weight: 2,
+  },
+  {
+    id: "typography",
+    label: "Typography & hierarchy",
+    description:
+      "Clear type scale, readable body, intentional emphasis. Nothing cramped or default-looking.",
+    weight: 1,
+  },
+  {
+    id: "layout",
+    label: "Layout & composition",
+    description:
+      "Balanced spacing, aligned grids, sensible density. Looks composed, not auto-generated.",
+    weight: 1,
+  },
+  {
+    id: "polish",
+    label: "Polish & micro-interactions",
+    description:
+      "Empty states, hover/focus states, motion, and finishing touches that make it feel crafted.",
+    weight: 1,
+  },
+  {
+    id: "prompt-fit",
+    label: "Prompt fit",
+    description:
+      "Does the result actually satisfy what the user asked for, including implied features?",
+    weight: 2,
+  },
+] as const;
+
+/** Build the prompt text a live judge would send to the model. */
+export function buildJudgePrompt(prompt: GoldenPrompt): string {
+  const criteria = DESIGN_RUBRIC.map(
+    (c) => `- ${c.label} (id: ${c.id}): ${c.description}`,
+  ).join("\n");
+  return [
+    "You are a senior product designer scoring a generated app.",
+    `The user asked: "${prompt.prompt}"`,
+    "Score each criterion 1-5 (5 = excellent) and give a one-line rationale.",
+    "Criteria:",
+    criteria,
+    'Respond as JSON: {"scores":[{"criterionId","score","rationale"}]}.',
+  ].join("\n");
+}
+
+/** Normalize per-criterion scores (1..5) into a weighted 0..1 overall. */
+export function scoreToOverall(scores: RubricScore[]): number {
+  const byId = new Map(scores.map((s) => [s.criterionId, s.score]));
+  let weighted = 0;
+  let totalWeight = 0;
+  for (const c of DESIGN_RUBRIC) {
+    const raw = byId.get(c.id);
+    if (raw === undefined) continue;
+    // map 1..5 -> 0..1
+    weighted += ((raw - 1) / 4) * c.weight;
+    totalWeight += c.weight;
+  }
+  return totalWeight === 0 ? 0 : weighted / totalWeight;
+}
+
+/**
+ * The interface a live LLM judge implements. Documented seam: an implementation
+ * renders `artifact` to an image, sends {@link buildJudgePrompt} + the image to
+ * a model, parses the JSON scores, and calls {@link scoreToOverall}.
+ */
+export type LLMDesignJudge = DesignJudge;
+
+/**
+ * Deterministic stand-in so the pipeline runs without a live model. It does NOT
+ * judge design — it derives a stable pseudo-score from the artifact so runs are
+ * reproducible. Replace with a live judge to get real design signal.
+ */
+export class StubDesignJudge implements DesignJudge {
+  async score(
+    artifact: BuildArtifact,
+    _prompt: GoldenPrompt,
+  ): Promise<RubricResult> {
+    const sourceLen = Object.values(artifact.sourceFiles).join("").length;
+    const scores: RubricScore[] = DESIGN_RUBRIC.map((c, i) => ({
+      criterionId: c.id,
+      // Stable, content-derived placeholder in the 3-5 band.
+      score: 3 + ((sourceLen + i) % 3),
+      rationale: "stub judge — no live model wired",
+    }));
+    return { scores, overall: scoreToOverall(scores) };
+  }
+}

--- a/assistant/src/config/bundled-skills/app-builder/__evals__/runner.ts
+++ b/assistant/src/config/bundled-skills/app-builder/__evals__/runner.ts
@@ -1,0 +1,102 @@
+/**
+ * The eval runner: drives each (variant, prompt) build, scores it on the three
+ * dimensions, and rolls the results up into an A/B-comparable {@link Scorecard}.
+ */
+
+import { checkPlanAdherence } from "./plan-adherence.js";
+import { StubDesignJudge } from "./rubric.js";
+import type {
+  AppBuildDriver,
+  BuildArtifact,
+  BuildResult,
+  CompileResult,
+  DesignJudge,
+  GoldenPrompt,
+  Scorecard,
+  ScorecardColumn,
+} from "./types.js";
+
+/**
+ * Compiles a build's source. The default is a lightweight static sanity check
+ * so the harness runs anywhere; a live runner can pass the real esbuild-backed
+ * `compileApp` (write files to a temp dir, call it, map the result).
+ */
+export type CompileFn = (artifact: BuildArtifact) => Promise<CompileResult>;
+
+const defaultCompile: CompileFn = async (artifact) => {
+  const errors: string[] = [];
+  const files = Object.entries(artifact.sourceFiles);
+  if (files.length === 0) errors.push("no source files produced");
+  for (const [path, contents] of files) {
+    if (!contents.trim()) errors.push(`${path}: empty file`);
+    // Cheap balance check — catches the most common truncation failures.
+    const open = (contents.match(/[({[]/g) ?? []).length;
+    const close = (contents.match(/[)}\]]/g) ?? []).length;
+    if (open !== close) errors.push(`${path}: unbalanced brackets`);
+  }
+  return { ok: errors.length === 0, errors };
+};
+
+export interface RunnerOptions {
+  prompts: readonly GoldenPrompt[];
+  drivers: readonly AppBuildDriver[];
+  /** Design judge; defaults to the deterministic stub. */
+  judge?: DesignJudge;
+  /** Compile check; defaults to a lightweight static check. */
+  compile?: CompileFn;
+}
+
+function mean(xs: number[]): number {
+  return xs.length === 0 ? 0 : xs.reduce((a, b) => a + b, 0) / xs.length;
+}
+
+function defined(xs: (number | undefined)[]): number[] {
+  return xs.filter((x): x is number => x !== undefined);
+}
+
+function summarize(
+  variant: AppBuildDriver["variant"],
+  rows: BuildResult[],
+): ScorecardColumn {
+  const latencies = defined(rows.map((r) => r.telemetry.latencyMs));
+  const costs = defined(rows.map((r) => r.telemetry.costUsd));
+  return {
+    variant,
+    rows,
+    compileRate: mean(rows.map((r) => (r.compile.ok ? 1 : 0))),
+    meanTokenCoverage: mean(rows.map((r) => r.planAdherence.tokenCoverage)),
+    meanFileCoverage: mean(rows.map((r) => r.planAdherence.fileCoverage)),
+    meanDesignScore: mean(rows.map((r) => r.rubric.overall)),
+    meanLatencyMs: latencies.length ? mean(latencies) : undefined,
+    meanCostUsd: costs.length ? mean(costs) : undefined,
+  };
+}
+
+export async function runEvals(options: RunnerOptions): Promise<Scorecard> {
+  const judge = options.judge ?? new StubDesignJudge();
+  const compile = options.compile ?? defaultCompile;
+
+  const columns: ScorecardColumn[] = [];
+  for (const driver of options.drivers) {
+    const rows: BuildResult[] = [];
+    for (const prompt of options.prompts) {
+      const artifact = await driver.build(prompt);
+      rows.push({
+        variant: driver.variant,
+        promptId: prompt.id,
+        compile: await compile(artifact),
+        planAdherence: checkPlanAdherence(artifact, prompt),
+        rubric: await judge.score(artifact, prompt),
+        // Latency/cost left empty — populated once PR 7 telemetry lands.
+        telemetry: {},
+      });
+    }
+    columns.push(summarize(driver.variant, rows));
+  }
+
+  return {
+    generatedAt: new Date().toISOString(),
+    promptSetSize: options.prompts.length,
+    columns,
+  };
+}

--- a/assistant/src/config/bundled-skills/app-builder/__evals__/types.ts
+++ b/assistant/src/config/bundled-skills/app-builder/__evals__/types.ts
@@ -1,0 +1,158 @@
+/**
+ * Shared types for the app-builder golden-set eval harness.
+ *
+ * The harness measures whether a given build *variant* (the current
+ * single-model skill, or the future tiered planner/worker flow) produces
+ * good apps. It scores three independent dimensions per build:
+ *
+ *  1. compile — did the produced source actually compile?
+ *  2. plan-adherence — did the output use the design tokens / files the
+ *     variant said it would? (best-effort static checks)
+ *  3. design rubric — an LLM-scored aesthetic/quality judgment.
+ *
+ * Results roll up into a {@link Scorecard} that is shaped for A/B comparison
+ * between variants, with latency/cost columns left ready for PR 7 telemetry.
+ */
+
+/** A single fixed prompt in the golden set. */
+export interface GoldenPrompt {
+  /** Stable id, used as a column key in the scorecard. */
+  id: string;
+  /** Human-readable label, e.g. "Habit tracker". */
+  label: string;
+  /** The user request fed to the build variant verbatim. */
+  prompt: string;
+  /**
+   * Design tokens / file paths we expect a faithful build to use. Drives the
+   * best-effort plan-adherence static checks. Optional per-prompt overrides;
+   * defaults live in {@link plan-adherence.ts}.
+   */
+  expects?: PlanExpectations;
+}
+
+/** What a faithful build is expected to contain (static, best-effort). */
+export interface PlanExpectations {
+  /** Design-system CSS variables expected to appear, e.g. "--v-accent". */
+  designTokens: string[];
+  /** Source file paths expected to exist, e.g. "src/main.tsx". */
+  files: string[];
+}
+
+/** The artifact a build variant produces for a prompt. */
+export interface BuildArtifact {
+  /** Map of file path -> file contents (the TSX/CSS the variant wrote). */
+  sourceFiles: Record<string, string>;
+  /**
+   * The plan the variant committed to, if any. The planner/worker flow emits
+   * one; the single-model baseline may leave this undefined. When present, it
+   * lets plan-adherence check intent vs. output rather than a fixed default.
+   */
+  plan?: PlanExpectations;
+}
+
+/** Identifies which build flow produced a result. */
+export type Variant = "single-model" | "planner-worker";
+
+/** Compile-check outcome for one build. */
+export interface CompileResult {
+  ok: boolean;
+  errors: string[];
+}
+
+/** Plan-adherence outcome for one build (best-effort static analysis). */
+export interface PlanAdherenceResult {
+  /** 0..1 fraction of expected design tokens found in the output. */
+  tokenCoverage: number;
+  /** 0..1 fraction of expected files present in the output. */
+  fileCoverage: number;
+  /** Tokens/files that were expected but missing (for debugging). */
+  missingTokens: string[];
+  missingFiles: string[];
+}
+
+/** A single rubric dimension's definition. */
+export interface RubricCriterion {
+  id: string;
+  label: string;
+  description: string;
+  /** Relative weight when computing the overall design score. */
+  weight: number;
+}
+
+/** An LLM's score for one rubric criterion. */
+export interface RubricScore {
+  criterionId: string;
+  /** 1..5, where 5 is excellent. */
+  score: number;
+  rationale: string;
+}
+
+/** Full design-rubric judgment for one build. */
+export interface RubricResult {
+  scores: RubricScore[];
+  /** Weighted overall, normalized to 0..1. */
+  overall: number;
+}
+
+/** Telemetry placeholders, to be populated by PR 7. */
+export interface BuildTelemetry {
+  latencyMs?: number;
+  costUsd?: number;
+}
+
+/** Everything we learned about one (variant, prompt) build. */
+export interface BuildResult {
+  variant: Variant;
+  promptId: string;
+  compile: CompileResult;
+  planAdherence: PlanAdherenceResult;
+  rubric: RubricResult;
+  telemetry: BuildTelemetry;
+}
+
+/** One column of the scorecard: a single variant's aggregate + per-prompt rows. */
+export interface ScorecardColumn {
+  variant: Variant;
+  rows: BuildResult[];
+  /** Fraction of builds that compiled. */
+  compileRate: number;
+  /** Mean token coverage across builds. */
+  meanTokenCoverage: number;
+  /** Mean file coverage across builds. */
+  meanFileCoverage: number;
+  /** Mean design rubric overall across builds. */
+  meanDesignScore: number;
+  /** Mean latency, when telemetry is present. */
+  meanLatencyMs?: number;
+  /** Mean cost, when telemetry is present. */
+  meanCostUsd?: number;
+}
+
+/** The A/B-comparable result of an eval run. */
+export interface Scorecard {
+  generatedAt: string;
+  promptSetSize: number;
+  columns: ScorecardColumn[];
+}
+
+/**
+ * Drives a single app build end-to-end for one prompt under one variant.
+ *
+ * This is the real seam between the harness and a build flow. The current
+ * single-model skill and the future planner/worker flow each implement this.
+ * See {@link build-driver.ts} for the baseline stub.
+ */
+export interface AppBuildDriver {
+  readonly variant: Variant;
+  build(prompt: GoldenPrompt): Promise<BuildArtifact>;
+}
+
+/**
+ * Scores a build's design quality. The real implementation calls an LLM with
+ * the rubric and a render/screenshot of the app; the harness ships a
+ * deterministic stub so the pipeline runs without a live model. See
+ * {@link rubric.ts}.
+ */
+export interface DesignJudge {
+  score(artifact: BuildArtifact, prompt: GoldenPrompt): Promise<RubricResult>;
+}

--- a/assistant/src/config/bundled-skills/app-builder/references/BUILD_PLAN.md
+++ b/assistant/src/config/bundled-skills/app-builder/references/BUILD_PLAN.md
@@ -1,0 +1,127 @@
+# Build Plan Artifact
+
+The planner (running on the quality tier) writes a single build plan to `/workspace/data/apps/<slug>/PLAN.md` before any worker writes code. The plan is the contract: balanced-tier `coder` workers each implement a disjoint slice of it in parallel, the parent compiles ONCE, and a repair subagent reads it on failure. A worker should be able to execute its row of the file-partition table without seeing the original user request.
+
+Write the plan with `file_write` to `/workspace/data/apps/<slug>/PLAN.md` (inside the sandbox, so `file_write`, not `host_file_read`). Write it ONCE, fully, before dispatching workers.
+
+---
+
+## Required sections
+
+A plan has exactly these five sections, in this order.
+
+### 1. Data schema
+
+The JSON Schema for one record — the same artifact passed to `app_create`'s `schema_json` (see SKILL.md Step 2). Define only user-facing fields; the system adds `id`, `appId`, `createdAt`, `updatedAt`. Keep it flat: `string` / `number` / `boolean`, with `enum` for closed sets and a `required` array. Apps without persistence (calculators, landing pages, slide decks) state "No persistence — ephemeral UI state only" here instead.
+
+### 2. Visual direction
+
+This is the single source of truth every worker reads to stay visually consistent. It is sourced from the `frontend-design` skill (aesthetic judgment) and `{baseDir}/references/DESIGN_SYSTEM.md` (concrete tokens). Pin all four of:
+
+- **Palette** — the chosen aesthetic direction (one of `frontend-design`'s extremes: editorial, brutalist, luxury, organic, etc.) expressed as **exact** token assignments. Map the build's accent and surface choices onto `--v-*` tokens: `--v-accent` / `--v-accent-hover`, `--v-bg` / `--v-surface` / `--v-surface-border`, and which `--v-{slate,emerald,violet,indigo,rose,amber}-*` palette ramp backs them. Status colors use `--v-success` / `--v-danger` / `--v-warning`. Text on filled/accent backgrounds is `--v-aux-white`; text on surfaces is `--v-text` / `--v-text-secondary` / `--v-text-muted`. Never name a raw hex — name the token. If the build uses a fully custom branded theme (hardcoded hex + `@media (prefers-color-scheme: dark)`), say so explicitly here and list the hex pairs once, so workers don't mix custom hex with auto-switching `--v-*` on the same element.
+- **Typography** — the scale, in tokens: `--v-font-family` / `--v-font-mono`, and which size steps (`--v-font-size-xs` 10px → `-2xl` 26px) map to which roles (display, heading, body, caption). Note the body default for the target interface (17px mobile-first `ios`, 14px desktop-first `macos` / `web`).
+- **Motion** — durations in tokens (`--v-duration-fast` 0.15s / `-standard` 0.25s / `-slow` 0.4s) and the high-impact moments they back (one orchestrated page-load with staggered `animation-delay`, hover affordances behind `@media (hover: hover)`).
+- **Atmosphere** — the background and depth treatment (gradient mesh, noise/grain, layered transparency, dramatic shadows via `--v-shadow-sm/md/lg`) that gives the app its identity rather than a flat fill.
+
+### 3. Component tree
+
+The Preact component hierarchy, as a tree. Each node names the component file and its responsibility in a few words. This is the map the partition table slices.
+
+### 4. File partition table
+
+The orchestration core: **one row per worker**, listing the exact file paths that worker owns, a one-line purpose per file, and the key props each component takes. Every source file in the build appears in **exactly one** row. Use this shape:
+
+| Worker | Files (disjoint) | Purpose | Key props |
+| ------ | ---------------- | ------- | --------- |
+
+Paths are absolute under the app: `/workspace/data/apps/<slug>/src/...`. A worker that owns a leaf component also owns nothing else; the parent or a designated worker owns shared files (`styles.css`, `types.ts`, `main.tsx`, `index.html`).
+
+---
+
+## Hard invariants
+
+The parallel orchestration is only correct if these hold. The planner MUST guarantee them when authoring the partition table; workers MUST respect them at execution time.
+
+1. **Partitions are disjoint.** No file path appears in two rows. Two workers writing the same file race and clobber each other — the build is non-deterministic and usually broken. If two components are too coupled to split cleanly, put them in the same worker's row, not in two rows.
+2. **Shared files have exactly one owner.** `styles.css` and any shared design-token file are written by exactly one worker (or pre-seeded by the parent in the `app_create` scaffold and then owned by no worker). Every other worker that needs a class consumes it from the agreed token names in the Visual direction section — it does not redefine or re-emit `styles.css`. `types.ts`, `main.tsx`, and `index.html` likewise each have a single owner.
+3. **Workers NEVER compile.** Only the parent calls `app_refresh`, and it calls it ONCE, after every worker has finished writing its files. A worker that calls `app_refresh` (or `app_create`, or `app_open`) breaks the single-compile contract and corrupts the shared build cache. Workers use `file_write` / `file_edit` only, strictly within the paths in their own row.
+
+---
+
+## Verbatim example
+
+A filled-in plan for a project tracker. A worker assigned a row below could execute it directly.
+
+````markdown
+# Build Plan — Project Tracker (slug: project-tracker)
+
+## 1. Data schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "title": { "type": "string" },
+    "status": {
+      "type": "string",
+      "enum": ["backlog", "in-progress", "review", "done"]
+    },
+    "priority": {
+      "type": "string",
+      "enum": ["low", "medium", "high", "critical"]
+    },
+    "tags": { "type": "string" },
+    "notes": { "type": "string" }
+  },
+  "required": ["title", "status"]
+}
+```
+
+## 2. Visual direction
+
+Aesthetic: **refined editorial**, calm and precise — a boutique studio's internal tool. Desktop-first (`interface: web`).
+
+- **Palette** — backed by the `--v-indigo-*` ramp.
+  - `--v-accent` = indigo-600, `--v-accent-hover` = indigo-700.
+  - `--v-bg` = slate-950 base with the atmosphere layer on top; `--v-surface` = slate-900; `--v-surface-border` = slate-800.
+  - Status: `backlog` → `--v-text-muted`, `in-progress` → `--v-accent`, `review` → `--v-warning`, `done` → `--v-success`. `critical` priority → `--v-danger`.
+  - Text on the indigo accent (badges, primary button) = `--v-aux-white`. Text on surfaces = `--v-text` (titles) / `--v-text-secondary` (meta) / `--v-text-muted` (empty/disabled). No raw hex anywhere.
+- **Typography** — `--v-font-family` throughout, `--v-font-mono` for the priority/ID chips.
+  - Display (board column headers): `--v-font-size-xl` (22px), weight 600.
+  - Heading (card title): `--v-font-size-lg` (17px), weight 600.
+  - Body default: `--v-font-size-base` (14px), desktop-first.
+  - Caption (tags, timestamps): `--v-font-size-sm` (11px), `--v-text-muted`.
+- **Motion** — `--v-duration-fast` (0.15s) on hover lift and button states; `--v-duration-standard` (0.25s) on card enter and column reflow. One orchestrated page load: columns fade+rise with staggered `animation-delay` (0ms / 60ms / 120ms / 180ms). Hover lift gated behind `@media (hover: hover)`.
+- **Atmosphere** — fixed full-viewport background: a subtle indigo→slate radial gradient mesh off the top-left, plus a 3% grain overlay. Cards sit on `--v-surface` with `--v-shadow-md`, lifting to `--v-shadow-lg` on hover. Not a flat fill.
+
+## 3. Component tree
+
+```
+App                      — board shell, owns records state + fetch
+├─ Header                — title, record count, "New" button
+├─ Board                 — 4 status columns, drag-to-reorder
+│  └─ Column (×4)        — one status lane, renders its cards
+│     └─ Card            — single record: title, priority chip, tags
+├─ RecordForm           — create/edit modal (side modal, desktop-first)
+└─ EmptyState           — designed empty board (.v-empty-state)
+```
+
+## 4. File partition table
+
+| Worker                                    | Files (disjoint)                                                     | Purpose                                                                                           | Key props                                                                        |
+| ----------------------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| **W1 — shell & data (owns shared files)** | `/workspace/data/apps/project-tracker/src/components/App.tsx`        | Board shell; loads records via `window.vellum.fetch`, holds state, passes records + handlers down | — (root)                                                                         |
+|                                           | `/workspace/data/apps/project-tracker/src/main.tsx`                  | Entry; renders `<App/>` into `#app`                                                               | —                                                                                |
+|                                           | `/workspace/data/apps/project-tracker/src/types.ts`                  | Shared `Record`, `Status`, `Priority` types                                                       | —                                                                                |
+|                                           | `/workspace/data/apps/project-tracker/src/styles.css`                | **Sole owner.** Tokens, atmosphere background, card/column/badge classes from §2                  | —                                                                                |
+| **W2 — header & form**                    | `/workspace/data/apps/project-tracker/src/components/Header.tsx`     | Title, live record count, "New" button                                                            | `count: number`, `onNew: () => void`                                             |
+|                                           | `/workspace/data/apps/project-tracker/src/components/RecordForm.tsx` | Create/edit side modal; validates before submit, toast on save                                    | `record?: Record`, `onSave: (r: Record) => Promise<void>`, `onClose: () => void` |
+| **W3 — board & columns**                  | `/workspace/data/apps/project-tracker/src/components/Board.tsx`      | 4 status columns, staggered page-load reveal, drag-to-reorder                                     | `records: Record[]`, `onMove: (id, status) => void`, `onEdit: (r) => void`       |
+|                                           | `/workspace/data/apps/project-tracker/src/components/Column.tsx`     | One status lane; renders its cards, accepts drops                                                 | `status: Status`, `records: Record[]`, `onEdit: (r) => void`                     |
+| **W4 — card & empty state**               | `/workspace/data/apps/project-tracker/src/components/Card.tsx`       | Single record: title, mono priority chip, tag pills, hover lift                                   | `record: Record`, `onEdit: (r) => void`                                          |
+|                                           | `/workspace/data/apps/project-tracker/src/components/EmptyState.tsx` | Designed empty board with "New" CTA                                                               | `onNew: () => void`                                                              |
+
+`src/index.html` is pre-seeded by the parent in the `app_create` scaffold and owned by no worker.
+
+**Invariants for this build:** W1 is the sole writer of `styles.css` and `types.ts`; W2–W4 import the token names and types defined there and never re-emit them. No path repeats across rows. No worker calls `app_refresh` — the parent compiles once after W1–W4 all finish.
+````

--- a/assistant/src/config/bundled-skills/app-builder/references/CONVENTIONS.md
+++ b/assistant/src/config/bundled-skills/app-builder/references/CONVENTIONS.md
@@ -1,0 +1,53 @@
+# App Conventions
+
+The interaction baselines every app must meet, and the standard patterns for wiring the app back to the assistant. These apply to all apps (not slides — see SLIDES.md for that domain). Read this when building or iterating; the SKILL.md workflow points here.
+
+---
+
+## Interaction standards
+
+Every app must meet these baselines:
+
+- **Feedback for every action** — use `vellum.widgets.toast()` after creates, deletes, updates, and errors
+- **Confirmation for destructive actions** — use `window.vellum.confirm(title, message)` before deleting or resetting. Returns `Promise<boolean>`
+- **Form validation** — validate before submit, show errors inline, disable submit during async operations
+- **Loading states** — never show a blank screen while data loads. Use skeleton shimmer or spinners
+- **Keyboard navigation** — `Tab` between elements, `Enter` to submit, `Escape` to close/cancel. De-prioritized on mobile-first builds
+
+---
+
+## Error handling
+
+- Wrap every `window.vellum.fetch()` call in `try/catch` with user-friendly feedback. Check `res.ok` before parsing the body
+- Never let a failed operation pass silently — always show a toast or inline error
+- Show a designed empty state (`.v-empty-state`) when there's no data
+- Show validation errors inline next to the relevant form field
+
+---
+
+## App interaction hooks
+
+Proactively wire `window.vellum.sendAction()` so the assistant stays aware of meaningful user interactions. Two patterns:
+
+- **Reactive hooks** — trigger an assistant response. Use for selections that warrant explanation, level completions, form submissions
+- **Silent hooks** (`state_update`) — accumulate context without interrupting. Use for tab navigation, filter changes, score updates
+
+Wire hooks during the initial build, not after the user asks. Full examples and per-app-type guidance in `{baseDir}/references/INTERACTION_HOOKS.md` (read with `host_file_read`).
+
+---
+
+## Actionable UI
+
+When the user wants to triage or bulk-act on items, render an interactive UI with selectable items and action buttons:
+
+1. Fetch data with relevant tools
+2. Render a `dynamic_page` with selectable items and action buttons
+3. User selects + clicks action → UI sends `surfaceAction` with action ID and selected IDs
+4. Execute tools, update UI with `ui_update`, show feedback via `widgets.toast()`
+5. Use `window.vellum.confirm()` for destructive actions
+
+---
+
+## External links
+
+Use `vellum.openLink(url, metadata)` to make items clickable. Construct deep-link URLs when possible. Include `metadata.provider` and `metadata.type` for context.

--- a/assistant/src/config/bundled-skills/app-builder/references/ORCHESTRATION.md
+++ b/assistant/src/config/bundled-skills/app-builder/references/ORCHESTRATION.md
@@ -1,0 +1,145 @@
+# Planner / Worker Orchestration
+
+A non-trivial build runs as three tiers: a **planner** on the quality tier writes the plan, a wave of **coder** workers on the balanced tier each implement a disjoint slice in parallel, and the **parent** compiles ONCE and surfaces the result. This file is the exact spawn sequence. The paths and tool shapes here are fragile — follow them verbatim, don't paraphrase.
+
+The contract for the plan artifact itself lives in `{baseDir}/references/BUILD_PLAN.md` (read with `host_file_read`). This file is the orchestration around it.
+
+---
+
+## The sequence
+
+### (a) PLAN — planner @ quality
+
+Run the planner on the quality tier, because partitioning a component tree into clean, disjoint, independently-buildable slices is judgment work. Either you (the parent) are already on the quality tier from Step 0 of SKILL.md, or you spawn a dedicated planner.
+
+The planner:
+
+1. Loads the `frontend-design` skill (aesthetic judgment) and reads `{baseDir}/references/DESIGN_SYSTEM.md` via `host_file_read` (concrete `--v-*` tokens).
+2. Writes the build plan to `/workspace/data/apps/<slug>/PLAN.md` with `file_write`, ONCE, fully, following BUILD_PLAN.md's five-section shape.
+3. Partitions the component tree into **disjoint file sets** — one row per worker in the §4 file-partition table, every source file in exactly one row.
+
+The plan is the only thing workers read. A worker must be able to build its row without seeing the original user request.
+
+### (b) DISPATCH — coder workers @ balanced, in bounded waves
+
+Spawn one `coder` subagent per partition row with `subagent_spawn`. Route them to the `balanced` tier — writing a component against a fixed spec is mechanical, not judgment work, so the cheaper tier is correct here.
+
+⚠️ **Spawns are uncapped. Cap them yourself.** Dispatch in **bounded waves of ≤3–4 workers at a time**. A 9-row partition is three waves, not nine simultaneous spawns. Wait for a wave to finish (step c) before starting the next.
+
+Each worker's `objective` carries **its partition slice plus the relevant excerpt of PLAN.md** — the §2 Visual direction (verbatim, every worker needs it), its own row of the §4 table, and the §3 component-tree context for its files. The worker reads PLAN.md from the sandbox if it needs more; the objective is the self-contained brief.
+
+Verbatim spawn for a worker (matches the `subagent_spawn` schema — `label`, `objective`, `role`, `override_profile`):
+
+```
+subagent_spawn({
+  label: "W3 — board & columns",
+  role: "coder",
+  override_profile: "balanced",
+  objective: "Build two files for the app at /workspace/data/apps/project-tracker, and ONLY these two files:\n  - /workspace/data/apps/project-tracker/src/components/Board.tsx\n  - /workspace/data/apps/project-tracker/src/components/Column.tsx\n\nUse file_write only. Do NOT call app_refresh, app_create, or app_open — the parent compiles. Do NOT touch any other file.\n\nProps:\n  Board:  records: Record[], onMove: (id, status) => void, onEdit: (r) => void\n  Column: status: Status, records: Record[], onEdit: (r) => void\n\nVisual direction (the single source of truth — match it exactly):\n<paste §2 Visual direction from /workspace/data/apps/project-tracker/PLAN.md verbatim>\n\nImport shared types from ./types and shared classes from styles.css — they are owned by W1; do not redefine them."
+})
+```
+
+### (c) COLLECT — completion notification + `subagent_read`
+
+You are notified when each subagent completes — do NOT poll with `subagent_status`. On completion, read the worker's work product:
+
+```
+subagent_read({ label: "W3 — board & columns", last_n: 1 })
+```
+
+Confirm the worker wrote only its own files and reported success. When the whole wave is in, dispatch the next wave (b). When all waves are in, proceed to compile.
+
+### (d) COMPILE — parent, ONCE
+
+Only the parent compiles, and only after every worker across every wave has finished:
+
+```
+skill_load("app-builder")
+app_refresh(app_id)
+```
+
+⚠️ **Workers NEVER compile.** `app_refresh` runs exactly once, here, from the parent. A worker that compiles corrupts the shared build cache and races the others.
+
+### (e) REPAIR — repair subagent @ quality-optimized, bounded retries
+
+If `app_refresh` returns compile errors, spawn a single repair subagent on the **quality-optimized** tier (fixing cross-file type and import errors is judgment work). Its objective carries the compile errors verbatim, the PLAN.md path, and the specific failing files.
+
+Verbatim spawn for the repair agent:
+
+```
+subagent_spawn({
+  label: "Repair — compile errors",
+  role: "coder",
+  override_profile: "quality-optimized",
+  objective: "The app at /workspace/data/apps/project-tracker failed to compile. Fix it with file_edit. Do NOT call app_refresh — report when done and the parent recompiles.\n\nCompile errors:\n<paste the full app_refresh error output verbatim>\n\nThe build plan is at /workspace/data/apps/project-tracker/PLAN.md — read it for the intended types, props, and token names.\n\nFailing files:\n  - /workspace/data/apps/project-tracker/src/components/Board.tsx\n  - /workspace/data/apps/project-tracker/src/types.ts\n\nEdit only what's needed to clear the errors. Stay consistent with the plan's §2 Visual direction."
+})
+```
+
+After the repair agent reports done, the parent runs `skill_load("app-builder")` + `app_refresh(app_id)` again. **Bound the loop to ≤2 repair attempts.** If it still fails after two, stop and surface the remaining compile errors to the user — do not loop indefinitely.
+
+### (f) SURFACE — `app_open`
+
+On a clean compile, render the inline preview card (SKILL.md Step 5):
+
+```
+skill_load("app-builder")
+app_open(app_id, open_mode: "preview")
+```
+
+---
+
+## Wrong vs right
+
+❌ **Wrong — a worker compiles:**
+
+```
+subagent_spawn({
+  label: "W3 — board",
+  role: "coder",
+  override_profile: "balanced",
+  objective: "Build Board.tsx and Column.tsx, then call app_refresh to check it compiles."   // NO
+})
+```
+
+The worker calling `app_refresh` breaks the compile-once contract, races the other workers, and corrupts the shared build cache.
+
+✅ **Right — the worker writes files only; the parent compiles once after the whole wave:**
+
+```
+subagent_spawn({
+  label: "W3 — board",
+  role: "coder",
+  override_profile: "balanced",
+  objective: "Build Board.tsx and Column.tsx with file_write only. Do NOT call app_refresh — the parent compiles."
+})
+```
+
+❌ **Wrong — overlapping partitions:**
+
+```
+W2 → src/components/Header.tsx, src/styles.css
+W3 → src/components/Board.tsx, src/styles.css     // styles.css in two rows — workers race and clobber
+```
+
+✅ **Right — disjoint partitions, one owner per shared file:**
+
+```
+W1 → src/styles.css, src/types.ts   (sole owner of shared files)
+W2 → src/components/Header.tsx
+W3 → src/components/Board.tsx, src/components/Column.tsx
+```
+
+Every source file appears in exactly one row (BUILD_PLAN.md hard invariant 1). Shared files (`styles.css`, `types.ts`, `main.tsx`, `index.html`) have exactly one owner; everyone else consumes the agreed token names and types.
+
+---
+
+## Fallback — single-tier sequential build
+
+The tiered sequence assumes the workspace has both a `balanced` and a `quality-optimized` profile. If it has neither (check with `assistant config get llm.profiles`), **degrade to a single-tier sequential build** rather than spawning workers on an unknown tier:
+
+1. Skip the worker dispatch entirely. The parent (already on the best available profile from SKILL.md Step 0) writes every file itself, sequentially, with `file_write` — following the same PLAN.md, in partition-table order.
+2. Compile ONCE with `app_refresh` (step d).
+3. On compile failure, the parent fixes the errors inline with `file_edit` and recompiles, bounded to ≤2 attempts, then surfaces to the user (step e, no subagent).
+4. Surface with `app_open` (step f).
+
+If exactly one of the two profiles is missing, substitute the nearest available tier — use the highest-quality profile for the planner and repair agent, and the cheapest non-quality profile for workers — rather than dropping to the sequential fallback. The sequential fallback is only for when no profile routing is available at all.

--- a/assistant/src/config/bundled-skills/app-builder/references/ORCHESTRATION.md
+++ b/assistant/src/config/bundled-skills/app-builder/references/ORCHESTRATION.md
@@ -24,7 +24,9 @@ The plan is the only thing workers read. A worker must be able to build its row 
 
 Spawn one `coder` subagent per partition row with `subagent_spawn`. Route them to the `balanced` tier — writing a component against a fixed spec is mechanical, not judgment work, so the cheaper tier is correct here.
 
-⚠️ **Spawns are uncapped. Cap them yourself.** Dispatch in **bounded waves of ≤3–4 workers at a time**. A 9-row partition is three waves, not nine simultaneous spawns. Wait for a wave to finish (step c) before starting the next.
+⚠️ **Spawns are uncapped. Cap them yourself.** Dispatch in bounded waves: **3 workers per wave for partitions of ≥7 files, 4 for ≤6.** A 9-file partition is bounded waves of 3, not nine simultaneous spawns. Wait for a wave to finish (step c) before starting the next.
+
+**If a worker fails or times out →** re-spawn that row once on a fresh worker; if it fails again, fold its files into the repair scope (step e).
 
 Each worker's `objective` carries **its partition slice plus the relevant excerpt of PLAN.md** — the §2 Visual direction (verbatim, every worker needs it), its own row of the §4 table, and the §3 component-tree context for its files. The worker reads PLAN.md from the sandbox if it needs more; the objective is the self-contained brief.
 
@@ -75,7 +77,7 @@ subagent_spawn({
 })
 ```
 
-After the repair agent reports done, the parent runs `skill_load("app-builder")` + `app_refresh(app_id)` again. **Bound the loop to ≤2 repair attempts.** If it still fails after two, stop and surface the remaining compile errors to the user — do not loop indefinitely.
+After the repair agent reports done, the parent runs `skill_load("app-builder")` + `app_refresh(app_id)` again. **Bound the loop to ≤2 repair attempts.** After the 2nd repair attempt fails → call `app_open(app_id, open_mode: "preview")` to surface the last good state, THEN post a chat message listing the failing files and unresolved errors. Do not loop indefinitely.
 
 ### (f) SURFACE — `app_open`
 

--- a/assistant/src/config/bundled-skills/subagent/TOOLS.json
+++ b/assistant/src/config/bundled-skills/subagent/TOOLS.json
@@ -33,6 +33,10 @@
             "type": "string",
             "enum": ["general", "researcher", "coder", "planner"],
             "description": "Agent specialization that controls tool access. 'researcher': read-only (web, files, memory). 'coder': file and bash access. 'planner': read-only analysis. 'general': full access (default). Ignored when fork: true (forks always use general)."
+          },
+          "override_profile": {
+            "type": "string",
+            "description": "Inference profile to run this subagent on, e.g. `quality-optimized` or `balanced`. Overrides the profile inherited from the parent. Use to route cheap, mechanical work (file-writing) to a faster tier while keeping judgment work on a strong model. Applies in both regular and fork modes."
           }
         },
         "required": ["label", "objective"]

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -28,6 +28,7 @@ import type {
   InteractiveUiResult,
 } from "../runtime/interactive-ui-types.js";
 import type { ToolExecutionResult } from "../tools/types.js";
+import { createKeyedMutex } from "../util/keyed-mutex.js";
 import { getLogger } from "../util/logger.js";
 import { isPlainObject } from "../util/object.js";
 import { buildConversationErrorMessage } from "./conversation-error.js";
@@ -544,33 +545,12 @@ export type SurfaceMutex = {
 /**
  * Per-surface async mutex using Promise chaining.
  * Operations on the same surfaceId are serialized; different surfaces run concurrently.
+ *
+ * Thin wrapper over the generic {@link createKeyedMutex} primitive, keyed by
+ * surfaceId.
  */
 export function createSurfaceMutex(): SurfaceMutex {
-  const chains = new Map<string, Promise<void>>();
-
-  const mutex = <T>(
-    surfaceId: string,
-    fn: () => T | Promise<T>,
-  ): Promise<T> => {
-    const prev = chains.get(surfaceId) ?? Promise.resolve();
-    const next = prev.then(fn, fn);
-    // Keep the chain alive but swallow errors so one failure doesn't block subsequent ops
-    const tail = next.then(
-      () => {},
-      () => {},
-    );
-    chains.set(surfaceId, tail);
-    // Clean up the map entry once the queue settles to prevent unbounded growth
-    tail.then(() => {
-      if (chains.get(surfaceId) === tail) {
-        chains.delete(surfaceId);
-      }
-    });
-    return next;
-  };
-
-  Object.defineProperty(mutex, "size", { get: () => chains.size });
-  return mutex as SurfaceMutex;
+  return createKeyedMutex() as SurfaceMutex;
 }
 
 // ── Standalone surface lifecycle ────────────────────────────────────

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -25,6 +25,11 @@ import { ProviderNotConfiguredError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import { getSandboxWorkingDir } from "../util/platform.js";
 import {
+  emitSubagentSpawnTelemetry,
+  emitSubagentTerminalTelemetry,
+  type SubagentBuildOutcome,
+} from "./telemetry.js";
+import {
   SUBAGENT_LIMITS,
   SUBAGENT_ROLE_REGISTRY,
   type SubagentConfig,
@@ -269,6 +274,7 @@ export class SubagentManager {
       },
       status: "pending",
       conversationId: conversationRecord.id,
+      resolvedRole: role,
       isFork,
       createdAt: now,
       usage: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },
@@ -387,6 +393,16 @@ export class SubagentManager {
       },
       "Subagent spawned",
     );
+
+    // Per-phase telemetry: record the spawn with its tier (overrideProfile) so
+    // the tiered app-builder flow's fan-out is measurable per tier/phase.
+    emitSubagentSpawnTelemetry({
+      subagentId,
+      label: config.label,
+      role,
+      overrideProfile: config.overrideProfile,
+      isFork,
+    });
 
     // ── Kick off the agent loop (fire-and-forget), bounded by the cap ─
     // If we're already at the concurrency cap, leave the subagent in `pending`
@@ -522,6 +538,8 @@ export class SubagentManager {
 
         log.info({ subagentId }, "Subagent completed");
 
+        this.emitTerminalTelemetry(managed, "completed");
+
         // Notify the parent conversation so the LLM can call subagent_read.
         this.notifyParentTerminal(managed, "completed");
       }
@@ -536,6 +554,7 @@ export class SubagentManager {
       // Only update status if not already terminal (e.g. aborted).
       if (!TERMINAL_STATUSES.has(managed.state.status)) {
         this.setStatus(subagentId, "failed", getSender(), errorMsg);
+        this.emitTerminalTelemetry(managed, "failed");
         this.notifyParentTerminal(managed, "failed");
       }
 
@@ -636,6 +655,11 @@ export class SubagentManager {
     } else {
       managed.state.status = "aborted";
     }
+
+    // Per-phase telemetry. Usage may be partial here (the agent loop's usage
+    // copy races the abort), but tier/phase/duration/outcome are accurate —
+    // which is what tiering + failure-rate analysis needs.
+    this.emitTerminalTelemetry(managed, "aborted");
 
     log.info({ subagentId }, "Subagent aborted");
     return true;
@@ -920,6 +944,36 @@ export class SubagentManager {
       error,
       usage: managed.state.usage,
     } as ServerMessage);
+  }
+
+  /**
+   * Emit per-phase build telemetry for a subagent that has reached a terminal
+   * state. Pulls timing/tokens off the subagent's state (already populated by
+   * the caller) and tags the event with the resolved role (build phase) and
+   * overrideProfile (tier).
+   */
+  private emitTerminalTelemetry(
+    managed: ManagedSubagent,
+    outcome: SubagentBuildOutcome,
+  ): void {
+    const { state } = managed;
+    const durationMs =
+      state.startedAt !== undefined && state.completedAt !== undefined
+        ? state.completedAt - state.startedAt
+        : undefined;
+    emitSubagentTerminalTelemetry({
+      subagentId: state.config.id,
+      label: state.config.label,
+      role: state.resolvedRole,
+      overrideProfile: state.config.overrideProfile,
+      isFork: state.isFork,
+      outcome,
+      durationMs,
+      inputTokens: state.usage.inputTokens,
+      outputTokens: state.usage.outputTokens,
+      estimatedCost: state.usage.estimatedCost,
+      ...(state.error ? { error: state.error } : {}),
+    });
   }
 
   // ── Child → Parent notification ────────────────────────────────────

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -697,7 +697,7 @@ export class SubagentManager {
   async sendMessage(
     subagentId: string,
     content: string,
-  ): Promise<"sent" | "empty" | "not_found" | "terminal"> {
+  ): Promise<"sent" | "empty" | "not_found" | "terminal" | "queued"> {
     const trimmed = content?.trim();
     if (!trimmed) return "empty";
 
@@ -705,6 +705,13 @@ export class SubagentManager {
     if (!managed) return "not_found";
     if (TERMINAL_STATUSES.has(managed.state.status) || !managed.conversation)
       return "terminal";
+    // A `pending` subagent has been spawned but is still queued behind the
+    // concurrency cap — its agent loop has NOT been started. The scheduler's
+    // startRun() owns the `pending` → `running` transition. Processing a
+    // message here would call runAgentLoop directly, bypassing the cap (and
+    // could run a follow-up before the original objective). Reject until the
+    // scheduler starts it.
+    if (managed.state.status === "pending") return "queued";
 
     // If the conversation is busy, queue the message; otherwise process immediately.
     const result = managed.conversation.enqueueMessage({ content: trimmed });

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -126,6 +126,20 @@ export class SubagentManager {
   private labelIndex = new Map<string, string>();
 
   /**
+   * FIFO queue of subagent IDs whose agent loop has NOT yet been kicked off
+   * because the concurrency cap (SUBAGENT_LIMITS.maxConcurrentRunning) was
+   * reached at spawn time. They remain in `pending` status until drained.
+   */
+  private runQueue: string[] = [];
+  /**
+   * Number of subagents whose agent loop has been kicked off and not yet
+   * reached a terminal state. Gated against SUBAGENT_LIMITS.maxConcurrentRunning.
+   * Tracked explicitly (rather than derived from status) so the cap counts only
+   * actually-started runs, never queued-but-pending ones.
+   */
+  private runningCount = 0;
+
+  /**
    * Shared rate-limit timestamps array from the daemon server.
    * Set by DaemonServer at startup so subagents share the global rate limit.
    */
@@ -374,12 +388,67 @@ export class SubagentManager {
       "Subagent spawned",
     );
 
-    // ── Kick off the agent loop (fire-and-forget) ───────────────────
-    this.runSubagent(subagentId, config.objective).catch((err) => {
-      log.error({ subagentId, err }, "Subagent run failed unexpectedly");
-    });
+    // ── Kick off the agent loop (fire-and-forget), bounded by the cap ─
+    // If we're already at the concurrency cap, leave the subagent in `pending`
+    // and queue it; it will be started by drainRunQueue() as running subagents
+    // reach a terminal state. spawn() still returns the id immediately either
+    // way, preserving the fire-and-forget public contract.
+    if (this.runningCount < SUBAGENT_LIMITS.maxConcurrentRunning) {
+      this.startRun(subagentId, config.objective);
+    } else {
+      this.runQueue.push(subagentId);
+      log.info(
+        {
+          subagentId,
+          runningCount: this.runningCount,
+          queueDepth: this.runQueue.length,
+          cap: SUBAGENT_LIMITS.maxConcurrentRunning,
+        },
+        "Subagent queued — concurrency cap reached",
+      );
+    }
 
     return subagentId;
+  }
+
+  // ── Internal: concurrency-cap scheduling ──────────────────────────────
+
+  /**
+   * Account a started run against the cap and fire its agent loop
+   * (fire-and-forget). The matching decrement happens in runSubagent's
+   * `finally`, which also drains the queue.
+   */
+  private startRun(subagentId: string, objective: string): void {
+    this.runningCount++;
+    this.runSubagent(subagentId, objective).catch((err) => {
+      log.error({ subagentId, err }, "Subagent run failed unexpectedly");
+    });
+  }
+
+  /**
+   * Release one slot held by a finished run and, if the cap now has headroom,
+   * start the next still-pending queued subagent. Called from runSubagent's
+   * `finally`, so exactly one slot frees per terminal subagent.
+   *
+   * Skips queued entries that are no longer startable (disposed, aborted, or
+   * already terminal — e.g. via abortAllForParent) so a cancelled queued
+   * subagent never consumes a slot, and keeps draining until a startable one is
+   * found or the queue empties.
+   */
+  private drainRunQueue(): void {
+    if (this.runningCount > 0) this.runningCount--;
+
+    while (
+      this.runningCount < SUBAGENT_LIMITS.maxConcurrentRunning &&
+      this.runQueue.length > 0
+    ) {
+      const nextId = this.runQueue.shift()!;
+      const managed = this.subagents.get(nextId);
+      if (!managed || TERMINAL_STATUSES.has(managed.state.status)) {
+        continue;
+      }
+      this.startRun(nextId, managed.state.config.objective);
+    }
   }
 
   // ── Internal: run the subagent ────────────────────────────────────────
@@ -493,6 +562,11 @@ export class SubagentManager {
       } else {
         this.releaseConversation(managed);
       }
+
+      // Free this run's slot and start the next queued subagent (if any).
+      // This subagent has reached a terminal state, so it no longer counts
+      // against the concurrency cap.
+      this.drainRunQueue();
     }
   }
 

--- a/assistant/src/subagent/telemetry.ts
+++ b/assistant/src/subagent/telemetry.ts
@@ -1,0 +1,219 @@
+/**
+ * Per-phase telemetry for subagent builds.
+ *
+ * Instruments the subagent lifecycle so the tiered app-builder flow's savings
+ * (which tier/profile each phase ran on) and failure rates are measurable.
+ *
+ * This deliberately reuses the two telemetry surfaces already established in
+ * the daemon rather than inventing a parallel system:
+ *
+ *  1. {@link recordLifecycleEvent} — the DB-backed, flush-to-platform sink used
+ *     by tool-permission telemetry (`events/tool-permission-telemetry-listener.ts`).
+ *     Lifecycle events only carry a string `eventName`, so we encode the
+ *     coarse, queryable dimensions (phase / role / tier / outcome) into a
+ *     stable, colon-delimited name. This is what makes cross-build aggregation
+ *     (tiering savings, failure rates) possible from the platform side.
+ *  2. The structured {@link getLogger} pino logger already used throughout
+ *     `manager.ts`. The full structured payload (ids, duration, tokens, etc.)
+ *     rides on the log record where local/aggregated log tooling can read it —
+ *     lifecycle rows are intentionally low-cardinality.
+ */
+
+import { recordLifecycleEvent } from "../memory/lifecycle-events-store.js";
+import { getLogger } from "../util/logger.js";
+import type { SubagentRole } from "./types.js";
+
+const log = getLogger("subagent-telemetry");
+
+/** Lifecycle event-name prefix for every subagent build-phase event. */
+const EVENT_PREFIX = "subagent_build";
+
+/** Terminal outcome of a subagent run, as seen by the telemetry layer. */
+export type SubagentBuildOutcome = "completed" | "failed" | "aborted";
+
+/**
+ * Map a subagent role to its app-builder build *phase* so plan / worker /
+ * repair phases are distinguishable in aggregate. Roles that don't map to a
+ * build phase fall through to the role name itself, keeping the event useful
+ * for non-app-builder subagents too.
+ *
+ *  - planner  → plan
+ *  - coder    → worker
+ *  - general  → general (e.g. forks / ad-hoc delegation)
+ */
+function phaseForRole(role: SubagentRole): string {
+  switch (role) {
+    case "planner":
+      return "plan";
+    case "coder":
+      return "worker";
+    default:
+      return role;
+  }
+}
+
+/** Sanitize a free-form label into a low-cardinality, name-safe token. */
+function safeProfileTag(overrideProfile: string | undefined): string {
+  if (!overrideProfile) return "default";
+  // Lifecycle event names are colon-delimited; keep the segment well-formed.
+  return overrideProfile.replace(/[^a-zA-Z0-9_-]/g, "_");
+}
+
+export interface SubagentSpawnTelemetry {
+  subagentId: string;
+  label: string;
+  role: SubagentRole;
+  /** The ad-hoc inference-profile override — i.e. the *tier* the phase runs on. */
+  overrideProfile?: string;
+  isFork: boolean;
+}
+
+export interface SubagentTerminalTelemetry extends SubagentSpawnTelemetry {
+  outcome: SubagentBuildOutcome;
+  /** Wall-clock duration from run start to terminal, when start was recorded. */
+  durationMs?: number;
+  inputTokens: number;
+  outputTokens: number;
+  estimatedCost: number;
+  /** Failure message, when the outcome is `failed`. */
+  error?: string;
+}
+
+/** Structured spawn event — the payload that rides the structured logger. */
+export interface SubagentSpawnEvent {
+  event: "subagent_build_spawned";
+  subagentId: string;
+  label: string;
+  role: SubagentRole;
+  /** App-builder build phase derived from the role (plan / worker / …). */
+  phase: string;
+  /** The tier the phase runs on (overrideProfile), or null for the default. */
+  overrideProfile: string | null;
+  isFork: boolean;
+  /** Stable, low-cardinality lifecycle event name for platform aggregation. */
+  lifecycleEventName: string;
+}
+
+/** Structured terminal event — the payload that rides the structured logger. */
+export interface SubagentTerminalEvent {
+  event: "subagent_build_terminal";
+  subagentId: string;
+  label: string;
+  role: SubagentRole;
+  phase: string;
+  overrideProfile: string | null;
+  isFork: boolean;
+  outcome: SubagentBuildOutcome;
+  durationMs: number | null;
+  inputTokens: number;
+  outputTokens: number;
+  estimatedCost: number;
+  /**
+   * Silent-context-starvation signal: a `coder` (worker) that *completes*
+   * having produced zero output tokens — the closest observable proxy, at this
+   * layer, for "reported success but did nothing useful". See note below.
+   */
+  suspiciousZeroOutput: boolean;
+  error?: string;
+  /** Stable lifecycle event name for the outcome (platform aggregation). */
+  lifecycleEventName: string;
+  /** Extra lifecycle name emitted when {@link suspiciousZeroOutput} is set. */
+  zeroOutputLifecycleEventName?: string;
+}
+
+/** Pure builder for the spawn event — no side effects, for unit testing. */
+export function buildSubagentSpawnEvent(
+  info: SubagentSpawnTelemetry,
+): SubagentSpawnEvent {
+  const phase = phaseForRole(info.role);
+  const tier = safeProfileTag(info.overrideProfile);
+  return {
+    event: "subagent_build_spawned",
+    subagentId: info.subagentId,
+    label: info.label,
+    role: info.role,
+    phase,
+    overrideProfile: info.overrideProfile ?? null,
+    isFork: info.isFork,
+    lifecycleEventName: `${EVENT_PREFIX}:${phase}:${tier}:spawned`,
+  };
+}
+
+/**
+ * Pure builder for the terminal event — no side effects, for unit testing.
+ *
+ * Silent-context-starvation signal: the manager does not have access to a
+ * per-subagent file-write count (the Conversation does not expose one), so we
+ * cannot assert "zero file writes" directly. We approximate with zero output
+ * tokens on a completed `coder` and surface a dedicated flag/lifecycle name for
+ * follow-up rather than over-reaching.
+ */
+export function buildSubagentTerminalEvent(
+  info: SubagentTerminalTelemetry,
+): SubagentTerminalEvent {
+  const phase = phaseForRole(info.role);
+  const tier = safeProfileTag(info.overrideProfile);
+  const suspiciousZeroOutput =
+    info.outcome === "completed" &&
+    info.role === "coder" &&
+    info.outputTokens === 0;
+  return {
+    event: "subagent_build_terminal",
+    subagentId: info.subagentId,
+    label: info.label,
+    role: info.role,
+    phase,
+    overrideProfile: info.overrideProfile ?? null,
+    isFork: info.isFork,
+    outcome: info.outcome,
+    durationMs: info.durationMs ?? null,
+    inputTokens: info.inputTokens,
+    outputTokens: info.outputTokens,
+    estimatedCost: info.estimatedCost,
+    suspiciousZeroOutput,
+    ...(info.error ? { error: info.error } : {}),
+    lifecycleEventName: `${EVENT_PREFIX}:${phase}:${tier}:${info.outcome}`,
+    ...(suspiciousZeroOutput
+      ? {
+          zeroOutputLifecycleEventName: `${EVENT_PREFIX}:${phase}:${tier}:zero_output`,
+        }
+      : {}),
+  };
+}
+
+/**
+ * Emit telemetry when a subagent's run is kicked off. The lifecycle event keys
+ * on phase + tier so spawn volume per tier is queryable; full detail rides the
+ * structured log.
+ */
+export function emitSubagentSpawnTelemetry(info: SubagentSpawnTelemetry): void {
+  try {
+    const evt = buildSubagentSpawnEvent(info);
+    recordLifecycleEvent(evt.lifecycleEventName);
+    log.info(evt, "Subagent build phase spawned");
+  } catch (err) {
+    // Telemetry must never break the spawn path.
+    log.warn({ err }, "Failed to emit subagent spawn telemetry");
+  }
+}
+
+/**
+ * Emit telemetry when a subagent reaches a terminal state, carrying the tier,
+ * timing, token usage, and outcome so tiering savings and failure rates are
+ * measurable.
+ */
+export function emitSubagentTerminalTelemetry(
+  info: SubagentTerminalTelemetry,
+): void {
+  try {
+    const evt = buildSubagentTerminalEvent(info);
+    recordLifecycleEvent(evt.lifecycleEventName);
+    if (evt.zeroOutputLifecycleEventName) {
+      recordLifecycleEvent(evt.zeroOutputLifecycleEventName);
+    }
+    log.info(evt, "Subagent build phase terminal");
+  } catch (err) {
+    // Telemetry must never break the run path.
+    log.warn({ err }, "Failed to emit subagent terminal telemetry");
+  }
+}

--- a/assistant/src/subagent/types.ts
+++ b/assistant/src/subagent/types.ts
@@ -84,6 +84,12 @@ export interface SubagentState {
   status: SubagentStatus;
   /** The subagent's own conversationId (different from parentConversationId). */
   conversationId: string;
+  /**
+   * The role the manager actually resolved at spawn time (after fork→general
+   * coercion). Distinct from `config.role`, which is the *requested* role.
+   * Used by build-phase telemetry so plan/worker phases are distinguishable.
+   */
+  resolvedRole: SubagentRole;
   /** Whether this sub-agent is a fork (inherits parent context). Defaults to `false`. */
   isFork: boolean;
   /** Error message if status is 'failed'. */

--- a/assistant/src/subagent/types.ts
+++ b/assistant/src/subagent/types.ts
@@ -101,6 +101,17 @@ export interface SubagentState {
 export const SUBAGENT_LIMITS = {
   /** Max nesting depth (1 = no nested subagents). */
   maxDepth: 1,
+  /**
+   * Max number of subagents allowed to be in the `running` state concurrently.
+   * Spawns beyond this cap are accepted immediately but held in `pending` and
+   * drained as running subagents reach a terminal state.
+   *
+   * Chosen at 8: high enough that existing single / low-count flows (which spawn
+   * 1–2 subagents) are never gated, while still bounding the burst of parallel
+   * `coder` workers app-builder v2 can fan out so they don't thrash provider
+   * rate limits.
+   */
+  maxConcurrentRunning: 8,
 } as const;
 
 // ── Roles ───────────────────────────────────────────────────────────────

--- a/assistant/src/tools/apps/executors.ts
+++ b/assistant/src/tools/apps/executors.ts
@@ -12,25 +12,6 @@ import { compileApp } from "../../bundler/app-compiler.js";
 import { generateAppIcon } from "../../media/app-icon-generator.js";
 import type { AppDefinition } from "../../memory/app-store.js";
 import { getAppDirPath } from "../../memory/app-store.js";
-import { createKeyedMutex } from "../../util/keyed-mutex.js";
-
-// ---------------------------------------------------------------------------
-// Per-app-slug write/compile serialization
-// ---------------------------------------------------------------------------
-
-/**
- * Defense-in-depth lock keyed by an app's on-disk dir (its frozen slug).
- *
- * app-builder v2 runs multiple `coder` workers that write DISJOINT files into
- * one app dir in parallel, and only the parent compiles — a layout that already
- * avoids most races. This guards the residual ones: a write landing during the
- * compile's `rm -rf dist/` + esbuild window, or two same-slug write/compile
- * batches overlapping. Operations on the SAME slug serialize; DIFFERENT slugs
- * stay fully concurrent, honoring the per-resource serialization rule in
- * CLAUDE.md. Disjoint writes within one batch share a single acquisition, so
- * workers never deadlock or queue beyond the compile boundary.
- */
-const appSlugMutex = createKeyedMutex();
 
 // ---------------------------------------------------------------------------
 // Shared result type
@@ -217,27 +198,21 @@ function App() {
 render(<App />, document.getElementById('app')!);
 `;
 
-  // Serialize the source-file writes + compile for this slug so a concurrent
-  // operation on the SAME app (e.g. another worker's app_refresh) can't
-  // interleave with these writes or the dist/ rebuild below.
   const appDir = getAppDirPath(app.id);
 
-  const mainTsxScaffolded = await appSlugMutex(appDir, () => {
-    if (input.source_files) {
-      for (const [filePath, content] of Object.entries(input.source_files)) {
-        store.writeAppFile(app.id, filePath, content);
-      }
+  if (input.source_files) {
+    for (const [filePath, content] of Object.entries(input.source_files)) {
+      store.writeAppFile(app.id, filePath, content);
     }
+  }
 
-    const scaffolded = !store.appFileExists(app.id, "src/main.tsx");
-    if (!store.appFileExists(app.id, "src/index.html")) {
-      store.writeAppFile(app.id, "src/index.html", indexHtml);
-    }
-    if (scaffolded) {
-      store.writeAppFile(app.id, "src/main.tsx", mainTsx);
-    }
-    return scaffolded;
-  });
+  const mainTsxScaffolded = !store.appFileExists(app.id, "src/main.tsx");
+  if (!store.appFileExists(app.id, "src/index.html")) {
+    store.writeAppFile(app.id, "src/index.html", indexHtml);
+  }
+  if (mainTsxScaffolded) {
+    store.writeAppFile(app.id, "src/main.tsx", mainTsx);
+  }
 
   // When the placeholder main.tsx was actually scaffolded, the tool result
   // must steer the agent toward writing the real source files instead of
@@ -251,9 +226,10 @@ render(<App />, document.getElementById('app')!);
       }
     : {};
 
-  // Compile src/ → dist/, serialized per slug so the dist/ rebuild can't race
-  // a concurrent same-slug write/compile.
-  const compileResult = await appSlugMutex(appDir, () => compileApp(appDir));
+  // Compile src/ → dist/. compileApp serialises concurrent same-appDir
+  // compiles internally (latest-wins coalescing) so the dist/ rebuild can't
+  // race another caller's compile.
+  const compileResult = await compileApp(appDir);
   if (!compileResult.ok) {
     return {
       content: JSON.stringify({
@@ -372,9 +348,10 @@ export async function executeAppRefresh(
   // stale scaffold placeholder from the initial app_create.
   if (app.formatVersion === 2) {
     const appDir = getAppDirPath(input.app_id);
-    // Serialize the dist/ rebuild per slug so a concurrent same-slug
-    // operation (e.g. another worker's app_create) can't race this compile.
-    const compileResult = await appSlugMutex(appDir, () => compileApp(appDir));
+    // compileApp serialises concurrent same-appDir compiles internally, so a
+    // concurrent operation (e.g. another worker's app_create) can't race this
+    // dist/ rebuild.
+    const compileResult = await compileApp(appDir);
     return {
       content: JSON.stringify({
         refreshed: true,

--- a/assistant/src/tools/apps/executors.ts
+++ b/assistant/src/tools/apps/executors.ts
@@ -12,6 +12,25 @@ import { compileApp } from "../../bundler/app-compiler.js";
 import { generateAppIcon } from "../../media/app-icon-generator.js";
 import type { AppDefinition } from "../../memory/app-store.js";
 import { getAppDirPath } from "../../memory/app-store.js";
+import { createKeyedMutex } from "../../util/keyed-mutex.js";
+
+// ---------------------------------------------------------------------------
+// Per-app-slug write/compile serialization
+// ---------------------------------------------------------------------------
+
+/**
+ * Defense-in-depth lock keyed by an app's on-disk dir (its frozen slug).
+ *
+ * app-builder v2 runs multiple `coder` workers that write DISJOINT files into
+ * one app dir in parallel, and only the parent compiles — a layout that already
+ * avoids most races. This guards the residual ones: a write landing during the
+ * compile's `rm -rf dist/` + esbuild window, or two same-slug write/compile
+ * batches overlapping. Operations on the SAME slug serialize; DIFFERENT slugs
+ * stay fully concurrent, honoring the per-resource serialization rule in
+ * CLAUDE.md. Disjoint writes within one batch share a single acquisition, so
+ * workers never deadlock or queue beyond the compile boundary.
+ */
+const appSlugMutex = createKeyedMutex();
 
 // ---------------------------------------------------------------------------
 // Shared result type
@@ -198,19 +217,27 @@ function App() {
 render(<App />, document.getElementById('app')!);
 `;
 
-  if (input.source_files) {
-    for (const [filePath, content] of Object.entries(input.source_files)) {
-      store.writeAppFile(app.id, filePath, content);
-    }
-  }
+  // Serialize the source-file writes + compile for this slug so a concurrent
+  // operation on the SAME app (e.g. another worker's app_refresh) can't
+  // interleave with these writes or the dist/ rebuild below.
+  const appDir = getAppDirPath(app.id);
 
-  const mainTsxScaffolded = !store.appFileExists(app.id, "src/main.tsx");
-  if (!store.appFileExists(app.id, "src/index.html")) {
-    store.writeAppFile(app.id, "src/index.html", indexHtml);
-  }
-  if (mainTsxScaffolded) {
-    store.writeAppFile(app.id, "src/main.tsx", mainTsx);
-  }
+  const mainTsxScaffolded = await appSlugMutex(appDir, () => {
+    if (input.source_files) {
+      for (const [filePath, content] of Object.entries(input.source_files)) {
+        store.writeAppFile(app.id, filePath, content);
+      }
+    }
+
+    const scaffolded = !store.appFileExists(app.id, "src/main.tsx");
+    if (!store.appFileExists(app.id, "src/index.html")) {
+      store.writeAppFile(app.id, "src/index.html", indexHtml);
+    }
+    if (scaffolded) {
+      store.writeAppFile(app.id, "src/main.tsx", mainTsx);
+    }
+    return scaffolded;
+  });
 
   // When the placeholder main.tsx was actually scaffolded, the tool result
   // must steer the agent toward writing the real source files instead of
@@ -224,9 +251,9 @@ render(<App />, document.getElementById('app')!);
       }
     : {};
 
-  // Compile src/ → dist/
-  const appDir = getAppDirPath(app.id);
-  const compileResult = await compileApp(appDir);
+  // Compile src/ → dist/, serialized per slug so the dist/ rebuild can't race
+  // a concurrent same-slug write/compile.
+  const compileResult = await appSlugMutex(appDir, () => compileApp(appDir));
   if (!compileResult.ok) {
     return {
       content: JSON.stringify({
@@ -345,7 +372,9 @@ export async function executeAppRefresh(
   // stale scaffold placeholder from the initial app_create.
   if (app.formatVersion === 2) {
     const appDir = getAppDirPath(input.app_id);
-    const compileResult = await compileApp(appDir);
+    // Serialize the dist/ rebuild per slug so a concurrent same-slug
+    // operation (e.g. another worker's app_create) can't race this compile.
+    const compileResult = await appSlugMutex(appDir, () => compileApp(appDir));
     return {
       content: JSON.stringify({
         refreshed: true,

--- a/assistant/src/tools/subagent/message.ts
+++ b/assistant/src/tools/subagent/message.ts
@@ -42,6 +42,13 @@ export async function executeSubagentMessage(
     };
   }
 
+  if (result === "queued") {
+    return {
+      content: `Subagent "${subagentId}" is queued behind the concurrency cap and not yet running. Try again once it starts.`,
+      isError: true,
+    };
+  }
+
   if (result !== "sent") {
     return {
       content: `Could not send message to subagent "${subagentId}". It may not exist or be in a terminal state.`,

--- a/assistant/src/tools/subagent/spawn.test.ts
+++ b/assistant/src/tools/subagent/spawn.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, mock, test } from "bun:test";
+
+// Mock conversation-crud so getConversationOverrideProfile is deterministic.
+// By default the inherited profile is undefined; tests that exercise
+// inheritance supply context.overrideProfile, which spawn.ts prefers over
+// the row read.
+mock.module("../../memory/conversation-crud.js", () => ({
+  getConversationOverrideProfile: () => undefined,
+}));
+
+import { getSubagentManager } from "../../subagent/index.js";
+import type { ToolContext } from "../types.js";
+import { executeSubagentSpawn } from "./spawn.js";
+
+function makeContext(
+  conversationId: string,
+  extras: Record<string, unknown> = {},
+): ToolContext {
+  return {
+    workingDir: "/tmp",
+    conversationId,
+    trustClass: "guardian" as const,
+    sendToClient: () => {},
+    ...extras,
+  } as unknown as ToolContext;
+}
+
+/**
+ * Runs executeSubagentSpawn with manager.spawn stubbed and returns the
+ * captured config passed to the manager.
+ */
+async function spawnAndCapture(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<Record<string, unknown>> {
+  const manager = getSubagentManager();
+  const originalSpawn = manager.spawn.bind(manager);
+
+  let capturedConfig: Record<string, unknown> | undefined;
+  manager.spawn = async (config: Record<string, unknown>) => {
+    capturedConfig = config;
+    return "stub-subagent-id";
+  };
+
+  try {
+    const result = await executeSubagentSpawn(input, context);
+    expect(result.isError).toBe(false);
+    expect(capturedConfig).toBeDefined();
+    return capturedConfig as Record<string, unknown>;
+  } finally {
+    manager.spawn = originalSpawn;
+  }
+}
+
+describe("subagent_spawn override_profile", () => {
+  test("explicit override_profile is forwarded to manager.spawn", async () => {
+    const config = await spawnAndCapture(
+      {
+        label: "Worker",
+        objective: "Write files",
+        override_profile: "balanced",
+      },
+      makeContext("conv-explicit"),
+    );
+
+    expect(config.overrideProfile).toBe("balanced");
+  });
+
+  test("omitted override_profile falls back to the inherited profile", async () => {
+    const config = await spawnAndCapture(
+      {
+        label: "Worker",
+        objective: "Write files",
+      },
+      makeContext("conv-inherit", { overrideProfile: "quality-optimized" }),
+    );
+
+    expect(config.overrideProfile).toBe("quality-optimized");
+  });
+
+  test("omitted override_profile with no inheritance omits the field", async () => {
+    const config = await spawnAndCapture(
+      {
+        label: "Worker",
+        objective: "Write files",
+      },
+      makeContext("conv-none"),
+    );
+
+    expect(config.overrideProfile).toBeUndefined();
+  });
+
+  test("explicit override_profile wins over a non-null inherited profile", async () => {
+    const config = await spawnAndCapture(
+      {
+        label: "Worker",
+        objective: "Write files",
+        override_profile: "balanced",
+      },
+      makeContext("conv-override", {
+        overrideProfile: "quality-optimized",
+      }),
+    );
+
+    expect(config.overrideProfile).toBe("balanced");
+  });
+});

--- a/assistant/src/tools/subagent/spawn.ts
+++ b/assistant/src/tools/subagent/spawn.ts
@@ -3,7 +3,10 @@ import { getConversationOverrideProfile } from "../../memory/conversation-crud.j
 import type { Message } from "../../providers/types.js";
 import { getSubagentManager } from "../../subagent/index.js";
 import type { SubagentRole } from "../../subagent/types.js";
+import { getLogger } from "../../util/logger.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
+
+const log = getLogger("subagent-spawn");
 
 export async function executeSubagentSpawn(
   input: Record<string, unknown>,
@@ -14,6 +17,7 @@ export async function executeSubagentSpawn(
   const extraContext = input.context as string | undefined;
   const fork = input.fork === true;
   const role = (input.role as string | undefined) ?? undefined;
+  const overrideProfile = input.override_profile as string | undefined;
 
   // For fork mode, sendResultToUser defaults to false unless explicitly set to true.
   // For regular mode, sendResultToUser defaults to true (existing behavior).
@@ -88,6 +92,18 @@ export async function executeSubagentSpawn(
     context.overrideProfile ??
     getConversationOverrideProfile(context.conversationId);
 
+  // An explicit `override_profile` from the caller wins over the inherited
+  // value; omitting it preserves the inherited-fallback behavior. Unknown
+  // profile names are tolerated — the provider resolver no-ops them.
+  const resolvedOverrideProfile = overrideProfile ?? inheritedOverrideProfile;
+
+  if (overrideProfile) {
+    log.debug(
+      { overrideProfile, label, fork },
+      "subagent_spawn override_profile set explicitly",
+    );
+  }
+
   try {
     const subagentId = await manager.spawn(
       {
@@ -99,12 +115,10 @@ export async function executeSubagentSpawn(
         // For fork mode, role is ignored by the manager (forced to general),
         // but we still omit it from the config to signal intent.
         ...(!fork && role ? { role: role as SubagentRole } : {}),
-        ...(inheritedOverrideProfile
-          ? { overrideProfile: inheritedOverrideProfile }
+        ...(resolvedOverrideProfile
+          ? { overrideProfile: resolvedOverrideProfile }
           : {}),
-        ...(context.toolUseId
-          ? { parentToolUseId: context.toolUseId }
-          : {}),
+        ...(context.toolUseId ? { parentToolUseId: context.toolUseId } : {}),
         ...forkFields,
       },
       sendToClient as (msg: unknown) => void,

--- a/assistant/src/util/__tests__/keyed-mutex.test.ts
+++ b/assistant/src/util/__tests__/keyed-mutex.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "bun:test";
+
+import { createKeyedMutex } from "../keyed-mutex.js";
+
+/** A deferred promise plus its resolver, for hand-controlling op timing. */
+function defer(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+describe("createKeyedMutex", () => {
+  test("serializes operations sharing a key (no interleaving)", async () => {
+    const mutex = createKeyedMutex();
+    const events: string[] = [];
+
+    const a = defer();
+    const b = defer();
+
+    const opA = mutex("slug", async () => {
+      events.push("A:start");
+      await a.promise;
+      events.push("A:end");
+    });
+    const opB = mutex("slug", async () => {
+      events.push("B:start");
+      await b.promise;
+      events.push("B:end");
+    });
+
+    // B must NOT start until A has fully settled, even though both were
+    // submitted synchronously and A is still awaiting.
+    await Promise.resolve();
+    expect(events).toEqual(["A:start"]);
+
+    a.resolve();
+    await opA;
+    // Now A is done; B should have begun.
+    await Promise.resolve();
+    expect(events).toEqual(["A:start", "A:end", "B:start"]);
+
+    b.resolve();
+    await opB;
+    expect(events).toEqual(["A:start", "A:end", "B:start", "B:end"]);
+  });
+
+  test("runs operations on different keys concurrently", async () => {
+    const mutex = createKeyedMutex();
+    const events: string[] = [];
+
+    const a = defer();
+    const b = defer();
+
+    const opA = mutex("slug-a", async () => {
+      events.push("A:start");
+      await a.promise;
+      events.push("A:end");
+    });
+    const opB = mutex("slug-b", async () => {
+      events.push("B:start");
+      await b.promise;
+      events.push("B:end");
+    });
+
+    // Both should have started without waiting on each other.
+    await Promise.resolve();
+    expect(events).toEqual(["A:start", "B:start"]);
+
+    b.resolve();
+    await opB;
+    a.resolve();
+    await opA;
+    expect(events).toEqual(["A:start", "B:start", "B:end", "A:end"]);
+  });
+
+  test("a rejected operation does not poison the queue for its key", async () => {
+    const mutex = createKeyedMutex();
+
+    const failed = mutex("slug", async () => {
+      throw new Error("boom");
+    });
+    await expect(failed).rejects.toThrow("boom");
+
+    const ok = await mutex("slug", async () => 42);
+    expect(ok).toBe(42);
+  });
+
+  test("preserves submission order under a same-key burst", async () => {
+    const mutex = createKeyedMutex();
+    const order: number[] = [];
+
+    const ops = [0, 1, 2, 3, 4].map((i) =>
+      mutex("slug", async () => {
+        // Yield to prove ordering comes from the mutex, not sync execution.
+        await Promise.resolve();
+        order.push(i);
+      }),
+    );
+
+    await Promise.all(ops);
+    expect(order).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  test("drops map entries once a key's queue drains", async () => {
+    const mutex = createKeyedMutex();
+    expect(mutex.size).toBe(0);
+
+    await mutex("slug", async () => {});
+    // Allow the cleanup microtask to run.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mutex.size).toBe(0);
+  });
+});

--- a/assistant/src/util/keyed-mutex.ts
+++ b/assistant/src/util/keyed-mutex.ts
@@ -3,13 +3,12 @@
  *
  * Operations submitted for the SAME key run strictly one-at-a-time in
  * submission order; operations for DIFFERENT keys proceed concurrently. This
- * is the lightweight in-process serialization primitive used to guard shared
- * mutable resources (e.g. an app's source dir + its dist/ rebuild) against
- * concurrent callers racing on `rm -rf` + write sequences, per the
- * "serialise per-resource" rule in CLAUDE.md.
+ * is the lightweight in-process serialization primitive used to guard
+ * per-resource critical sections, per the "serialise per-resource" rule in
+ * CLAUDE.md.
  *
- * The same pattern already backs `createSurfaceMutex`; this generalises it as a
- * standalone utility so other per-resource critical sections can reuse it.
+ * `createSurfaceMutex` (in conversation-surfaces.ts) is a thin wrapper over
+ * this primitive, keyed by surfaceId.
  */
 export type KeyedMutex = {
   /**

--- a/assistant/src/util/keyed-mutex.ts
+++ b/assistant/src/util/keyed-mutex.ts
@@ -1,0 +1,51 @@
+/**
+ * Per-key async mutex built on Promise chaining.
+ *
+ * Operations submitted for the SAME key run strictly one-at-a-time in
+ * submission order; operations for DIFFERENT keys proceed concurrently. This
+ * is the lightweight in-process serialization primitive used to guard shared
+ * mutable resources (e.g. an app's source dir + its dist/ rebuild) against
+ * concurrent callers racing on `rm -rf` + write sequences, per the
+ * "serialise per-resource" rule in CLAUDE.md.
+ *
+ * The same pattern already backs `createSurfaceMutex`; this generalises it as a
+ * standalone utility so other per-resource critical sections can reuse it.
+ */
+export type KeyedMutex = {
+  /**
+   * Run `fn` exclusively with respect to other `run` calls sharing `key`.
+   * Returns whatever `fn` resolves to (or rejects with `fn`'s error). A
+   * rejection does not poison the queue — subsequent operations still run.
+   */
+  <T>(key: string, fn: () => T | Promise<T>): Promise<T>;
+  /** Number of keys with an in-flight or queued operation (for tests). */
+  readonly size: number;
+};
+
+export function createKeyedMutex(): KeyedMutex {
+  const chains = new Map<string, Promise<unknown>>();
+
+  const mutex = <T>(key: string, fn: () => T | Promise<T>): Promise<T> => {
+    const prev = chains.get(key) ?? Promise.resolve();
+    // Chain off the prior op regardless of its outcome so a failure doesn't
+    // block the queue, but only start `fn` after the prior op fully settles.
+    const next = prev.then(fn, fn);
+    // The tail keeps the chain alive and swallows errors so the map entry
+    // stays a clean "previous settled" anchor for the next submission.
+    const tail = next.then(
+      () => {},
+      () => {},
+    );
+    chains.set(key, tail);
+    // Drop the entry once the queue drains to keep the map bounded.
+    tail.then(() => {
+      if (chains.get(key) === tail) {
+        chains.delete(key);
+      }
+    });
+    return next;
+  };
+
+  Object.defineProperty(mutex, "size", { get: () => chains.size });
+  return mutex as KeyedMutex;
+}


### PR DESCRIPTION
## Summary
Restructures app-builder to use the existing subagent system for a **tiered planner/worker** build: a quality-tier planner partitions the component tree, balanced-tier `coder` workers implement disjoint files in parallel via `subagent_spawn` (`override_profile`), the parent compiles **once**, and a quality-tier repair subagent fixes compile failures. Concentrates the expensive model on judgment (planning, repair) and routes mechanical file-writing to a cheaper tier — addressing the taste-vs-latency tension.

Stacked on `marina/app-builder-rewrite` (#33106); GitHub will retarget to `main` once that merges.

## Self-review result
PASS — 3 fresh-eyes passes (plan-faithfulness / repo-integration / slop). 1 round of remediation: removed a redundant compile mutex that degraded the compiler's existing `compileSlots` coalescing, and deduped a copy-pasted mutex util. Re-review confirmed resolved, no regressions.

## PRs merged into this feature branch
- #33120 — expose `override_profile` on `subagent_spawn` (keystone: per-subagent tier)
- #33154 — end-to-end proof a worker routes a different tier than its parent
- #33125 — `BUILD_PLAN.md` artifact spec (disjoint file partitions)
- #33152 — `ORCHESTRATION.md` (exact tiered spawn sequence)
- #33158 — SKILL.md rewrite to the tiered workflow (491 lines)
- #33126 — bounded subagent concurrency cap
- #33157 — per-phase telemetry (tier/timing/tokens/outcome)
- #33132 — golden-set eval harness (A/B single-model vs planner/worker)
- #33127 — per-app-slug write serialization, later reworked by:
- #33161 — fix: drop redundant compile mutex, consolidate mutex util

Part of plan: ab-planner-worker.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)