### PR TITLE
fix(subagent): hold concurrency cap when messaging a queued subagent

### DIFF
--- a/assistant/src/__tests__/subagent-concurrency.test.ts
+++ b/assistant/src/__tests__/subagent-concurrency.test.ts
@@ -23,6 +23,7 @@ interface FakeManaged {
     dispose: () => void;
     persistUserMessage: () => { id: string; deduplicated: boolean };
     runAgentLoop: () => Promise<void>;
+    enqueueMessage: () => { queued: boolean; rejected: boolean };
     usageStats: {
       inputTokens: number;
       outputTokens: number;
@@ -42,6 +43,12 @@ interface ManagerInternals {
   runningCount: number;
   startRun: (subagentId: string, objective: string) => void;
   stopSweep: () => void;
+}
+
+interface RunTracking {
+  release: () => void;
+  /** Number of times runAgentLoop was invoked on this subagent's conversation. */
+  runCount: () => number;
 }
 
 function asInternals(manager: SubagentManager): ManagerInternals {
@@ -70,22 +77,24 @@ function makeState(id: string): SubagentState {
  * promise, letting the test control exactly when each "running" subagent
  * completes. Returns a `release` fn that resolves the loop.
  */
-function injectControllable(
-  manager: SubagentManager,
-  id: string,
-): { release: () => void } {
+function injectControllable(manager: SubagentManager, id: string): RunTracking {
   const internals = asInternals(manager);
   let resolveLoop!: () => void;
   const loopGate = new Promise<void>((r) => {
     resolveLoop = r;
   });
+  let runCount = 0;
 
   const managed: FakeManaged = {
     conversation: {
       abort: () => {},
       dispose: () => {},
       persistUserMessage: () => ({ id: "msg", deduplicated: false }),
-      runAgentLoop: () => loopGate,
+      runAgentLoop: () => {
+        runCount++;
+        return loopGate;
+      },
+      enqueueMessage: () => ({ queued: false, rejected: false }),
       usageStats: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },
     },
     state: makeState(id),
@@ -98,7 +107,7 @@ function injectControllable(
   }
   internals.parentToChildren.get("parent-1")!.add(id);
 
-  return { release: resolveLoop };
+  return { release: resolveLoop, runCount: () => runCount };
 }
 
 const flush = () => new Promise((r) => setTimeout(r, 0));
@@ -179,6 +188,47 @@ describe("SubagentManager concurrency cap", () => {
       expect(manager.getState(id)!.status).toBe("running");
     }
 
+    internals.stopSweep();
+  });
+
+  test("messaging a pending/queued subagent does not start its run or bypass the cap", async () => {
+    const manager = new SubagentManager();
+    const internals = asInternals(manager);
+    const cap = SUBAGENT_LIMITS.maxConcurrentRunning;
+
+    // Fill the cap with running subagents, then queue one more.
+    const runningIds = Array.from({ length: cap }, (_, i) => `run-${i}`);
+    for (const id of runningIds) injectControllable(manager, id);
+    const queuedTracking = injectControllable(manager, "queued-1");
+
+    for (const id of runningIds) {
+      internals.startRun(
+        id,
+        internals.subagents.get(id)!.state.config.objective,
+      );
+    }
+    internals.runQueue.push("queued-1");
+    await flush();
+
+    // Precondition: queued-1 is pending and the cap is full.
+    expect(manager.getState("queued-1")!.status).toBe("pending");
+    expect(internals.runningCount).toBe(cap);
+    expect(queuedTracking.runCount()).toBe(0);
+
+    // Message the pending subagent — must be rejected as "queued" and must NOT
+    // kick off its agent loop out-of-band.
+    const result = await manager.sendMessage("queued-1", "hurry up");
+    expect(result).toBe("queued");
+    await flush();
+
+    // The cap held: still exactly `cap` running, queued-1 still pending, and
+    // its run loop never fired.
+    expect(internals.runningCount).toBe(cap);
+    expect(manager.getState("queued-1")!.status).toBe("pending");
+    expect(queuedTracking.runCount()).toBe(0);
+    expect(internals.runQueue).toContain("queued-1");
+
+    // Once a running slot frees, the scheduler (not the message) starts it.
     internals.stopSweep();
   });
 });

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -697,7 +697,7 @@ export class SubagentManager {
   async sendMessage(
     subagentId: string,
     content: string,
-  ): Promise<"sent" | "empty" | "not_found" | "terminal"> {
+  ): Promise<"sent" | "empty" | "not_found" | "terminal" | "queued"> {
     const trimmed = content?.trim();
     if (!trimmed) return "empty";
 
@@ -705,6 +705,13 @@ export class SubagentManager {
     if (!managed) return "not_found";
     if (TERMINAL_STATUSES.has(managed.state.status) || !managed.conversation)
       return "terminal";
+    // A `pending` subagent has been spawned but is still queued behind the
+    // concurrency cap — its agent loop has NOT been started. The scheduler's
+    // startRun() owns the `pending` → `running` transition. Processing a
+    // message here would call runAgentLoop directly, bypassing the cap (and
+    // could run a follow-up before the original objective). Reject until the
+    // scheduler starts it.
+    if (managed.state.status === "pending") return "queued";
 
     // If the conversation is busy, queue the message; otherwise process immediately.
     const result = managed.conversation.enqueueMessage({ content: trimmed });

--- a/assistant/src/tools/subagent/message.ts
+++ b/assistant/src/tools/subagent/message.ts
@@ -42,6 +42,13 @@ export async function executeSubagentMessage(
     };
   }
 
+  if (result === "queued") {
+    return {
+      content: `Subagent "${subagentId}" is queued behind the concurrency cap and not yet running. Try again once it starts.`,
+      isError: true,
+    };
+  }
+
   if (result !== "sent") {
     return {
       content: `Could not send message to subagent "${subagentId}". It may not exist or be in a terminal state.`,


### PR DESCRIPTION
## Summary
- A pending/queued subagent could be started early via subagent_message, bypassing the concurrency cap
- subagent_message to a queued subagent now returns 'queued, not yet running' instead of kicking off its run; the scheduler's startRun owns that transition
- Added a test covering the queued-then-messaged path

Addresses Codex review (P2) on PR #33162.