### PR TITLE
fix(messages): restore content field in history payload (legacy Swift client depends on it)

### DIFF
--- a/assistant/src/api/responses/conversation-message.ts
+++ b/assistant/src/api/responses/conversation-message.ts
@@ -208,6 +208,15 @@ export const ConversationMessageSchema = z.object({
    */
   mergedMessageIds: z.array(z.string()).optional(),
   role: z.string(),
+  /**
+   * Flat plain-text body (joined text segments). Redundant with
+   * `textSegments`/`contentOrder` for clients that render from the positional
+   * arrays (web, CLI), but the legacy Swift macOS client reads `content`
+   * directly and drops any history row missing it (its
+   * `HistoryReconstructionService` skips rows with empty text). The serializer
+   * always emits it — do not remove without updating that client.
+   */
+  content: z.string().optional(),
   /** Display timestamp as an ISO-8601 string. */
   timestamp: z.string(),
   attachments: z.array(ConversationMessageAttachmentSchema),

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -842,6 +842,9 @@ export function handleListMessages({
       id: m.id ?? "",
       ...(mergedMessageIds.length > 0 ? { mergedMessageIds } : {}),
       role: m.role,
+      // Flat plain-text body the legacy Swift client reads directly; see the
+      // `content` field on ConversationMessageSchema for why this must stay.
+      content: m.text,
       timestamp: new Date(displayTimestamp).toISOString(),
       attachments: msgAttachments,
       ...(m.toolCalls.length > 0 ? { toolCalls: m.toolCalls } : {}),


### PR DESCRIPTION
## Summary
- Re-emit the flat `content` field (the already-computed `m.text`) from the GET messages history serializer (`handleListMessages`), and re-add it as an optional field on the canonical `ConversationMessageSchema`.
- #32961 removed `content` as "redundant" (web/CLI now render from `textSegments`/`contentOrder`), but the legacy Swift macOS client still reads `content` directly — `ConversationHistoryClient` maps it to `text` (→ empty when absent) and `HistoryReconstructionService` then drops every plain-text row, so messages disappeared from many conversations in the Swift app.
- Wire-additive and backwards-compatible: web/CLI ignore the field; the Swift client renders history again. The DB and daemon API were always intact — this was purely the removed wire field. OpenAPI regen produces no diff (the messages route serializes rows as `z.unknown()`).

## Original prompt
After noticing a bunch of Velissa conversations were missing messages in the macOS **Swift** desktop app, we traced it — not to the suspected notification PR #33002, but to PR #32961, which removed the flat `content` field from the daemon history payload without updating the Swift client. The data was never lost (DB and daemon API are intact). Ship the minimal, backwards-compatible daemon fix: restore the `content` field so the legacy Swift client renders history again, rather than requiring a Swift rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)