### PR TITLE
feat(web+assistant): validate openai-compatible endpoint during onboarding

### DIFF
--- a/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -133,6 +133,10 @@ export function HatchingScreen() {
   }, [hatchTraits]);
   const [phase, setPhase] = useState<HatchPhase>("initializing");
   const [error, setError] = useState<string | null>(null);
+  // Non-blocking notice when the openai-compatible endpoint probe fails. Unlike
+  // `error`, this does not replace the screen or halt onboarding — the flow
+  // proceeds and the user can fix the connection in Settings.
+  const [providerWarning, setProviderWarning] = useState<string | null>(null);
   const [platformHostedDisabled, setPlatformHostedDisabled] = useState(false);
   const [attempt, setAttempt] = useState(0);
   const [displayProgress, setDisplayProgress] = useState<number>(0);
@@ -299,7 +303,14 @@ export function HatchingScreen() {
           // proceeds and the user can fix it in Settings.
           if (result.assistantId) {
             try {
-              await applyPendingProviderKey(result.assistantId);
+              const applyResult = await applyPendingProviderKey(
+                result.assistantId,
+              );
+              if (applyResult?.validation && !applyResult.validation.ok) {
+                setProviderWarning(
+                  `Your assistant is ready, but we couldn't verify your OpenAI-compatible endpoint: ${applyResult.validation.reason ?? "the endpoint did not respond"}. You can update the connection in Settings.`,
+                );
+              }
             } catch (err) {
               captureError(err, { context: "onboarding_apply_provider_key" });
             }
@@ -570,6 +581,21 @@ export function HatchingScreen() {
         <p className="mt-3 text-body-small-default text-[var(--content-tertiary)]">
           {PHASE_LABEL[phase]}
         </p>
+        {providerWarning && (
+          <div
+            role="alert"
+            className="mt-6 flex w-full max-w-sm flex-col gap-2 rounded-lg border border-[var(--border-warning)] bg-[var(--background-warning)] p-4 text-left text-body-small-default text-[var(--content-warning)]"
+          >
+            <p>{providerWarning}</p>
+            <button
+              type="button"
+              className="self-end text-body-small-default underline"
+              onClick={() => setProviderWarning(null)}
+            >
+              Dismiss
+            </button>
+          </div>
+        )}
       </div>
     </OnboardingLayout>
   );

--- a/apps/web/src/domains/onboarding/provider-key.test.ts
+++ b/apps/web/src/domains/onboarding/provider-key.test.ts
@@ -12,6 +12,8 @@ type QueuedResponse = {
   status: number;
   /** Daemon error envelope surfaced by the generated client on `result.error`. */
   error?: unknown;
+  /** Parsed JSON body surfaced by the generated client on `result.data`. */
+  data?: unknown;
 };
 
 const calls: ClientCall[] = [];
@@ -55,8 +57,8 @@ const postMock = mock(
       path: args.path,
       body: args.body,
     });
-    const { ok, status, error } = nextResponse(args.url);
-    return { response: { ok, status }, error };
+    const { ok, status, error, data } = nextResponse(args.url);
+    return { response: { ok, status }, error, data };
   },
 );
 
@@ -75,6 +77,9 @@ const CONNECTIONS_URL =
   "/v1/assistants/{assistant_id}/inference/provider-connections";
 const FLAG_URL =
   "/v1/assistants/asst-1/feature-flags/openai-compatible-endpoints";
+// Probe route: connection name === provider id (openai-compatible).
+const TEST_URL =
+  "/v1/assistants/asst-1/inference/provider-connections/openai-compatible/test";
 
 beforeEach(() => {
   sessionStorage.clear();
@@ -143,6 +148,8 @@ describe("pending provider key", () => {
 
 describe("applyPendingProviderKey", () => {
   test("openai-compatible enables the flag before creating the connection", async () => {
+    responseQueues[TEST_URL] = [{ ok: true, status: 200, data: { ok: true } }];
+
     setPendingProviderKey({
       provider: "openai-compatible",
       key: "",
@@ -150,7 +157,7 @@ describe("applyPendingProviderKey", () => {
       models: ["model-a"],
     });
 
-    await applyPendingProviderKey("asst-1");
+    const result = await applyPendingProviderKey("asst-1");
 
     // Flag PATCH must precede the connection POST.
     const flagIdx = calls.findIndex(
@@ -169,12 +176,36 @@ describe("applyPendingProviderKey", () => {
     expect(connectionBody.provider).toBe("openai-compatible");
     expect(connectionBody.base_url).toBe("http://localhost:1234/v1");
     expect(connectionBody.models).toEqual([{ id: "model-a" }]);
+
+    // The probe runs after the connection POST and its result is surfaced.
+    const testIdx = calls.findIndex(
+      (c) => c.method === "post" && c.url === TEST_URL,
+    );
+    expect(testIdx).toBeGreaterThan(connectionIdx);
+    expect(result.validation).toEqual({ ok: true, reason: undefined });
   });
 
-  test("non-openai-compatible provider issues no flag PATCH and a single POST", async () => {
+  test("openai-compatible surfaces a failing probe as validation", async () => {
+    responseQueues[TEST_URL] = [
+      { ok: true, status: 200, data: { ok: false, reason: "bad endpoint" } },
+    ];
+
+    setPendingProviderKey({
+      provider: "openai-compatible",
+      key: "",
+      baseUrl: "http://localhost:1234/v1",
+      models: ["model-a"],
+    });
+
+    const result = await applyPendingProviderKey("asst-1");
+
+    expect(result.validation).toEqual({ ok: false, reason: "bad endpoint" });
+  });
+
+  test("non-openai-compatible provider issues no flag PATCH, a single POST, no probe, and no validation", async () => {
     setPendingProviderKey({ provider: "anthropic", key: "sk-ant-test" });
 
-    await applyPendingProviderKey("asst-1");
+    const result = await applyPendingProviderKey("asst-1");
 
     expect(patchMock).not.toHaveBeenCalled();
 
@@ -186,6 +217,10 @@ describe("applyPendingProviderKey", () => {
     expect(body.provider).toBe("anthropic");
     expect(body.base_url).toBeUndefined();
     expect(body.models).toBeUndefined();
+
+    // No probe for keyed non-openai-compatible providers.
+    expect(calls.some((c) => c.url === TEST_URL)).toBe(false);
+    expect(result.validation).toBeUndefined();
   });
 
   test("openai-compatible retries the connection POST on the flag-disabled 400 then succeeds", async () => {

--- a/apps/web/src/domains/onboarding/provider-key.ts
+++ b/apps/web/src/domains/onboarding/provider-key.ts
@@ -171,16 +171,57 @@ async function createProviderConnection(
 }
 
 /**
+ * Probe a freshly created provider connection via the daemon's test route.
+ * Raw template-literal URL (gateway route), matching enableAssistantFeatureFlag
+ * above; the generated client has no typed path for this endpoint. A probe
+ * failure is informational, never thrown: a non-ok HTTP response or a thrown
+ * error becomes `{ ok: false, reason }`. `skipped` (non-openai-compatible
+ * providers) is treated as ok.
+ */
+async function testProviderConnection(
+  assistantId: string,
+  name: string,
+): Promise<{ ok: boolean; reason?: string }> {
+  try {
+    const result = await client.post({
+      url: `/v1/assistants/${assistantId}/inference/provider-connections/${name}/test`,
+      headers: { "Content-Type": "application/json" },
+    });
+    if (!result.response?.ok) {
+      return {
+        ok: false,
+        reason: "Could not reach the daemon to test the connection.",
+      };
+    }
+    const body = (result.data ?? {}) as {
+      ok?: boolean;
+      reason?: string;
+      skipped?: boolean;
+    };
+    return { ok: body.skipped === true || body.ok === true, reason: body.reason };
+  } catch {
+    return {
+      ok: false,
+      reason: "Could not reach the daemon to test the connection.",
+    };
+  }
+}
+
+/**
  * Apply the API key collected during onboarding to the freshly hatched local
  * assistant: store the secret (when a key was entered) and create the provider
  * connection so the daemon can use it. Consumes the pending key; no-op when
  * nothing was collected (e.g. Vellum Cloud, which skips the API-key step).
+ *
+ * For openai-compatible providers, the connection is probed after creation and
+ * the result returned as `validation` so the caller can surface a non-blocking
+ * warning when the endpoint is unreachable or the key is bad.
  */
 export async function applyPendingProviderKey(
   assistantId: string,
-): Promise<void> {
+): Promise<{ validation?: { ok: boolean; reason?: string } }> {
   const pending = consumePendingProviderKey();
-  if (!pending) return;
+  if (!pending) return {};
   const trimmed = pending.key.trim();
   const hasKey = trimmed.length > 0;
   if (pending.provider === "openai-compatible") {
@@ -196,4 +237,13 @@ export async function applyPendingProviderKey(
     pending.baseUrl?.trim() || undefined,
     pending.models,
   );
+  if (pending.provider === "openai-compatible") {
+    // Connection name === provider id (see createProviderConnection's `name`).
+    const validation = await testProviderConnection(
+      assistantId,
+      pending.provider,
+    );
+    return { validation };
+  }
+  return {};
 }

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -13456,6 +13456,40 @@ paths:
               required:
                 - auth
               additionalProperties: false
+  /v1/inference/provider-connections/{name}/test:
+    post:
+      operationId: inference_providerconnections_by_name_test_post
+      summary: Test a provider connection
+      description:
+        "Probe a connection's endpoint to verify it is reachable and the credential works. Only openai-compatible
+        connections are probed (via models.list); other providers return { ok: true, skipped: true }."
+      tags:
+        - inference
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  reason:
+                    type: string
+                  skipped:
+                    type: boolean
+                required:
+                  - ok
+                additionalProperties: false
+        "404":
+          description: Connection not found
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
   /v1/inference/send:
     post:
       operationId: inference_send_post

--- a/assistant/src/providers/inference/__tests__/inference-provider-connection-test-route.test.ts
+++ b/assistant/src/providers/inference/__tests__/inference-provider-connection-test-route.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Route-level tests for the provider-connection test/probe handler
+ * (POST inference/provider-connections/:name/test).
+ *
+ * Mocks the DB, feature flags, config, secure-keys (credential lookup), and the
+ * openai client's `probeOpenAICompatibleEndpoint` so the probe result is
+ * controllable without any network access. Mirrors the mocking patterns in the
+ * sibling base-url-route-validation.test.ts.
+ */
+import { Database } from "bun:sqlite";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import { migrateCreateProviderConnections } from "../../../memory/migrations/243-provider-connections.js";
+import { migrateProviderConnectionStatusLabel } from "../../../memory/migrations/244-provider-connection-status-label.js";
+import { migrateProviderConnectionBaseUrlAndModels } from "../../../memory/migrations/250-provider-connection-base-url-and-models.js";
+import * as schema from "../../../memory/schema.js";
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA journal_mode=WAL");
+  return drizzle(sqlite, { schema });
+}
+
+function bootDb() {
+  const db = createTestDb();
+  migrateCreateProviderConnections(db);
+  migrateProviderConnectionStatusLabel(db);
+  migrateProviderConnectionBaseUrlAndModels(db);
+  return db;
+}
+
+const testDb = bootDb();
+
+mock.module("../../../memory/db-connection.js", () => ({
+  getDb: () => testDb,
+}));
+
+mock.module("../../../config/assistant-feature-flags.js", () => ({
+  isAssistantFeatureFlagEnabled: (flag: string) =>
+    flag === "openai-compatible-endpoints",
+}));
+
+mock.module("../../../config/loader.js", () => ({
+  getConfig: () => ({ llm: {} }),
+  getConfigReadOnly: () => ({ llm: {} }),
+}));
+
+mock.module("../../../config/env-registry.js", () => ({
+  getIsPlatform: () => false,
+}));
+
+// Credential lookup for api_key auth: any credential resolves to a stub token.
+// getProviderKeyAsync is exported for static-import linking only (the provider
+// registry, pulled in transitively via connections.js, imports it); the test
+// never exercises that path.
+mock.module("../../../security/secure-keys.js", () => ({
+  getSecureKeyAsync: async () => "stub-secret",
+  getProviderKeyAsync: async () => null,
+}));
+
+// Controllable probe result. Each test sets `probeResult` and asserts the
+// route returns it (or the skipped/ok branches) without hitting the network.
+let probeResult: { ok: true } | { ok: false; reason: string } = { ok: true };
+const probeMock = mock(
+  async (_opts: { baseURL: string; apiKey?: string }) => probeResult,
+);
+
+mock.module("../../../providers/openai/client.js", () => ({
+  probeOpenAICompatibleEndpoint: probeMock,
+}));
+
+const { ROUTES } =
+  await import("../../../runtime/routes/inference-provider-connection-routes.js");
+
+const handleTest = ROUTES.find(
+  (r) => r.operationId === "inference_provider_connections_test",
+)!.handler;
+
+const handleCreate = ROUTES.find(
+  (r) => r.operationId === "inference_provider_connections_create",
+)!.handler;
+
+beforeEach(() => {
+  probeResult = { ok: true };
+  probeMock.mockClear();
+});
+
+describe("test connection route", () => {
+  test("throws NotFoundError for a missing connection", async () => {
+    await expect(
+      handleTest({ pathParams: { name: "does-not-exist" } }),
+    ).rejects.toThrow(/not found/);
+  });
+
+  test("openai-compatible: a successful probe returns { ok: true }", async () => {
+    await handleCreate({
+      body: {
+        name: "probe-ok",
+        provider: "openai-compatible",
+        auth: { type: "api_key", credential: "credential/probe-ok/api_key" },
+        base_url: "https://api.example.com/v1",
+        models: [{ id: "m" }],
+      },
+    });
+
+    probeResult = { ok: true };
+    const result = await handleTest({ pathParams: { name: "probe-ok" } });
+    expect(result).toEqual({ ok: true });
+
+    // The bearer is derived from the resolved Authorization header.
+    expect(probeMock).toHaveBeenCalledTimes(1);
+    const arg = probeMock.mock.calls[0][0];
+    expect(arg.baseURL).toBe("https://api.example.com/v1");
+    expect(arg.apiKey).toBe("stub-secret");
+  });
+
+  test("openai-compatible: a failing probe returns { ok: false, reason }", async () => {
+    await handleCreate({
+      body: {
+        name: "probe-fail",
+        provider: "openai-compatible",
+        auth: { type: "none" },
+        base_url: "https://unreachable.example.com/v1",
+        models: [{ id: "m" }],
+      },
+    });
+
+    probeResult = { ok: false, reason: "Could not reach the endpoint." };
+    const result = await handleTest({ pathParams: { name: "probe-fail" } });
+    expect(result).toEqual({
+      ok: false,
+      reason: "Could not reach the endpoint.",
+    });
+
+    // Keyless connection: no bearer derived.
+    expect(probeMock.mock.calls[0][0].apiKey).toBe("");
+  });
+
+  test("non-openai-compatible connection returns { ok: true, skipped: true } and does not probe", async () => {
+    await handleCreate({
+      body: {
+        name: "probe-anthropic",
+        provider: "anthropic",
+        auth: { type: "api_key", credential: "credential/anthropic/api_key" },
+      },
+    });
+
+    const result = await handleTest({ pathParams: { name: "probe-anthropic" } });
+    expect(result).toEqual({ ok: true, skipped: true });
+    expect(probeMock).not.toHaveBeenCalled();
+  });
+});

--- a/assistant/src/providers/openai/client.ts
+++ b/assistant/src/providers/openai/client.ts
@@ -74,3 +74,50 @@ export async function validateOpenAIApiKey(
     return { valid: true };
   }
 }
+
+/**
+ * Probe an openai-compatible endpoint by listing models. Strict: only a
+ * successful response counts as reachable. Used by the provider-connection
+ * test route.
+ */
+export async function probeOpenAICompatibleEndpoint(opts: {
+  baseURL: string;
+  apiKey?: string;
+}): Promise<{ ok: true } | { ok: false; reason: string }> {
+  try {
+    const client = new OpenAI({
+      apiKey: opts.apiKey || "not-needed",
+      baseURL: opts.baseURL,
+      timeout: VALIDATION_TIMEOUT_MS,
+      maxRetries: 0,
+    });
+    await client.models.list();
+    return { ok: true };
+  } catch (error) {
+    if (error instanceof OpenAI.APIError) {
+      if (error.status === 401 || error.status === 403) {
+        return {
+          ok: false,
+          reason: "Authentication failed — check your API key.",
+        };
+      }
+      if (error.status === 404) {
+        // Endpoint reachable but no /v1/models — many openai-compatible servers
+        // still serve it; treat as a soft failure with a clear hint.
+        return {
+          ok: false,
+          reason: "Endpoint reachable but did not expose /v1/models.",
+        };
+      }
+      return {
+        ok: false,
+        reason: `Endpoint returned an error (${error.status}).`,
+      };
+    }
+    return {
+      ok: false,
+      reason:
+        "Could not reach the endpoint. Check the base URL and that the server is running.",
+    };
+  }
+}

--- a/assistant/src/runtime/routes/inference-provider-connection-routes.ts
+++ b/assistant/src/runtime/routes/inference-provider-connection-routes.ts
@@ -31,6 +31,8 @@ import {
   PROVIDERS_REQUIRING_BASE_URL_AND_MODELS,
   updateConnection,
 } from "../../providers/inference/connections.js";
+import { resolveAuth } from "../../providers/inference/resolve-auth.js";
+import { probeOpenAICompatibleEndpoint } from "../../providers/openai/client.js";
 import {
   isCloudMetadataOrLinkLocalHost,
   isPrivateOrLocalHost,
@@ -226,6 +228,56 @@ function handleGetConnection({ pathParams = {} }: RouteHandlerArgs) {
   }
 
   return conn;
+}
+
+/**
+ * Probe a connection's endpoint to verify it is reachable and the credential
+ * works. Currently only openai-compatible connections are probed (via
+ * `models.list`); for every other provider we return `{ ok: true, skipped: true }`
+ * so callers can invoke this uniformly without special-casing — there is
+ * nothing to probe for managed/keyed first-party providers here.
+ */
+async function handleTestConnection({ pathParams = {} }: RouteHandlerArgs) {
+  const { name } = pathParams;
+  if (!name) throw new BadRequestError("name is required");
+
+  const conn = getConnection(getDb(), name);
+  if (!conn) throw new NotFoundError(`Connection "${name}" not found.`);
+  if (
+    conn.provider === "openai-compatible" &&
+    !openAICompatibleEndpointsEnabled()
+  ) {
+    throw new NotFoundError(`Connection "${name}" not found.`);
+  }
+
+  if (conn.provider !== "openai-compatible") {
+    return { ok: true as const, skipped: true as const };
+  }
+
+  const baseURL = conn.baseUrl ?? undefined;
+  if (!baseURL) {
+    return { ok: false as const, reason: "No base URL configured." };
+  }
+
+  const resolvedResult = await resolveAuth(conn.auth, conn.provider, {
+    baseUrl: conn.baseUrl,
+  });
+  if (!resolvedResult.ok) {
+    if (resolvedResult.error.code === "credential_not_found") {
+      return { ok: false as const, reason: "Stored credential not found." };
+    }
+    return { ok: false as const, reason: "Could not resolve credentials." };
+  }
+
+  // Derive the apiKey exactly as the adapter does: bearer from the resolved
+  // Authorization header, or empty for keyless connections.
+  const resolved = resolvedResult.resolved;
+  const apiKey =
+    resolved.kind === "header"
+      ? (resolved.headers.Authorization ?? "").replace(/^Bearer /, "")
+      : "";
+
+  return probeOpenAICompatibleEndpoint({ baseURL, apiKey });
 }
 
 async function handleCreateConnection({ body = {} }: RouteHandlerArgs) {
@@ -488,6 +540,27 @@ export const ROUTES: RouteDefinition[] = [
     responseBody: providerConnectionResponseSchema,
     additionalResponses: { "404": { description: "Connection not found" } },
     handler: handleGetConnection,
+  },
+  {
+    operationId: "inference_provider_connections_test",
+    endpoint: "inference/provider-connections/:name/test",
+    method: "POST",
+    policy: {
+      requiredScopes: ["settings.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Test a provider connection",
+    description:
+      "Probe a connection's endpoint to verify it is reachable and the credential works. Only openai-compatible connections are probed (via models.list); other providers return { ok: true, skipped: true }.",
+    tags: ["inference"],
+    pathParams: [{ name: "name", description: "Connection name" }],
+    responseBody: z.object({
+      ok: z.boolean(),
+      reason: z.string().optional(),
+      skipped: z.boolean().optional(),
+    }),
+    additionalResponses: { "404": { description: "Connection not found" } },
+    handler: handleTestConnection,
   },
   {
     operationId: "inference_provider_connections_create",


### PR DESCRIPTION
## Summary
- Add a daemon test route (POST inference/provider-connections/:name/test) that probes an openai-compatible endpoint via models.list, supporting keyless and keyed connections.
- After onboarding creates the connection, probe it and surface a non-blocking warning on the hatching screen if the endpoint is unreachable or the key is bad, so users aren't left with a silently-broken provider.

Builds on the keyless adapter support. Part of the openai-compatible onboarding feature branch.