### PR TITLE
feat(web): gate integrations OAuth on platform session

### DIFF
--- a/apps/web/src/domains/settings/components/integration-detail-modal.tsx
+++ b/apps/web/src/domains/settings/components/integration-detail-modal.tsx
@@ -212,6 +212,8 @@ export function IntegrationDetailModal({
     async (
       baselineSignatures: ReadonlyMap<string, string>,
     ): Promise<boolean> => {
+      if (!managedAvailable) return false;
+
       for (let attempt = 0; attempt < 8; attempt += 1) {
         if (attempt > 0) {
           await wait(750);
@@ -242,7 +244,7 @@ export function IntegrationDetailModal({
 
       return false;
     },
-    [assistantId, connectionsQueryKey, providerKey, queryClient],
+    [assistantId, connectionsQueryKey, managedAvailable, providerKey, queryClient],
   );
 
   useEffect(() => {
@@ -423,6 +425,8 @@ export function IntegrationDetailModal({
   });
 
   const handleConnect = useCallback(() => {
+    if (!managedAvailable) return;
+
     const requestId = crypto.randomUUID();
 
     if (isNative) {
@@ -594,6 +598,7 @@ export function IntegrationDetailModal({
     waitForProviderConnection,
     startOAuth,
     isNative,
+    managedAvailable,
   ]);
 
   const handleDisconnect = (connection: OAuthConnection) => {

--- a/apps/web/src/domains/settings/components/integration-detail-modal.tsx
+++ b/apps/web/src/domains/settings/components/integration-detail-modal.tsx
@@ -126,7 +126,7 @@ export function IntegrationDetailModal({
   const isNative = useIsNativePlatform();
   const managedAvailable = platformGate === "full";
   const [activeTab, setActiveTab] = useState<ModalTab>(
-    managedAvailable ? "managed" : "your-own",
+    platformGate === "gated" ? "your-own" : "managed",
   );
   const [pendingDisconnectId, setPendingDisconnectId] = useState<string | null>(
     null,

--- a/apps/web/src/domains/settings/components/integration-detail-modal.tsx
+++ b/apps/web/src/domains/settings/components/integration-detail-modal.tsx
@@ -12,6 +12,7 @@ import { useCallback, useEffect, useRef, useState, type ReactNode } from "react"
 
 import { Card } from "@vellum/design-library/components/card";
 import { ConfirmDialog } from "@vellum/design-library/components/confirm-dialog";
+import { Notice } from "@vellum/design-library/components/notice";
 import { toast } from "@vellum/design-library/components/toast";
 import { Button } from "@vellum/design-library/components/button";
 import { Input } from "@vellum/design-library/components/input";
@@ -49,6 +50,7 @@ import {
   getOAuthCompleteStoragePayload,
 } from "@/lib/auth/oauth-popup";
 
+import type { PlatformGateState } from "@/hooks/use-platform-gate";
 import { extractErrorMessage } from "@/utils/api-errors";
 
 function wait(ms: number): Promise<void> {
@@ -101,6 +103,7 @@ interface IntegrationDetailModalProps {
   displayName: string;
   description: string | null;
   logoUrl: string | null;
+  platformGate: PlatformGateState;
   onClose: () => void;
 }
 
@@ -116,11 +119,15 @@ export function IntegrationDetailModal({
   displayName,
   description,
   logoUrl,
+  platformGate,
   onClose,
 }: IntegrationDetailModalProps) {
   const queryClient = useQueryClient();
   const isNative = useIsNativePlatform();
-  const [activeTab, setActiveTab] = useState<ModalTab>("managed");
+  const managedAvailable = platformGate === "full";
+  const [activeTab, setActiveTab] = useState<ModalTab>(
+    managedAvailable ? "managed" : "your-own",
+  );
   const [pendingDisconnectId, setPendingDisconnectId] = useState<string | null>(
     null,
   );
@@ -376,11 +383,12 @@ export function IntegrationDetailModal({
     };
   }, []);
 
-  const { data: allConnections, isLoading: connectionsLoading } = useQuery(
-    assistantsOauthConnectionsListOptions({
+  const { data: allConnections, isLoading: connectionsLoading } = useQuery({
+    ...assistantsOauthConnectionsListOptions({
       path: { assistant_id: assistantId },
     }),
-  );
+    enabled: managedAvailable,
+  });
 
   const providerConnections: OAuthConnection[] = (allConnections ?? []).filter(
     (c) => c.provider === providerKey && c.connected,
@@ -646,40 +654,48 @@ export function IntegrationDetailModal({
         </div>
 
         <div className="space-y-4 px-5 py-4">
-          <div
-            role="tablist"
-            aria-label="OAuth mode"
-            className="flex w-full rounded-md border border-[var(--border-base)] bg-[var(--surface-base)] p-0.5 dark:border-[var(--border-base)] dark:bg-[var(--surface-base)]/40"
-          >
-            <TabButton
-              active={activeTab === "managed"}
-              onClick={() => setActiveTab("managed")}
+          {platformGate !== "gated" && (
+            <div
+              role="tablist"
+              aria-label="OAuth mode"
+              className="flex w-full rounded-md border border-[var(--border-base)] bg-[var(--surface-base)] p-0.5 dark:border-[var(--border-base)] dark:bg-[var(--surface-base)]/40"
             >
-              Managed
-            </TabButton>
-            <TabButton
-              active={activeTab === "your-own"}
-              onClick={() => setActiveTab("your-own")}
-            >
-              Your Own
-            </TabButton>
-          </div>
+              <TabButton
+                active={activeTab === "managed"}
+                onClick={() => setActiveTab("managed")}
+              >
+                Managed
+              </TabButton>
+              <TabButton
+                active={activeTab === "your-own"}
+                onClick={() => setActiveTab("your-own")}
+              >
+                Your Own
+              </TabButton>
+            </div>
+          )}
 
-          {activeTab === "managed" ? (
-            <ManagedTab
-              displayName={displayName}
-              providerKey={providerKey}
-              logoUrl={logoUrl}
-              connections={providerConnections}
-              connectionsLoading={connectionsLoading}
-              startPending={startOAuth.isPending}
-              oauthInProgress={oauthInProgress}
-              disconnectingId={
-                disconnectOAuth.isPending ? pendingDisconnectId : null
-              }
-              onConnect={handleConnect}
-              onDisconnect={handleDisconnect}
-            />
+          {activeTab === "managed" && platformGate !== "gated" ? (
+            platformGate === "disabled" ? (
+              <Notice tone="info">
+                Log in to the Vellum platform to manage OAuth connections.
+              </Notice>
+            ) : (
+              <ManagedTab
+                displayName={displayName}
+                providerKey={providerKey}
+                logoUrl={logoUrl}
+                connections={providerConnections}
+                connectionsLoading={connectionsLoading}
+                startPending={startOAuth.isPending}
+                oauthInProgress={oauthInProgress}
+                disconnectingId={
+                  disconnectOAuth.isPending ? pendingDisconnectId : null
+                }
+                onConnect={handleConnect}
+                onDisconnect={handleDisconnect}
+              />
+            )
           ) : (
             <YourOwnTab
               assistantId={assistantId}

--- a/apps/web/src/domains/settings/components/integration-row.tsx
+++ b/apps/web/src/domains/settings/components/integration-row.tsx
@@ -17,6 +17,7 @@ import {
 import type { OAuthConnection } from "@/generated/api/types.gen";
 
 import { IntegrationIcon } from "@/domains/settings/components/integration-icon";
+import type { PlatformGateState } from "@/hooks/use-platform-gate";
 
 import { extractErrorMessage } from "@/utils/api-errors";
 
@@ -27,6 +28,7 @@ interface IntegrationRowProps {
   description: string | null;
   logoUrl: string | null;
   connection: OAuthConnection | null;
+  platformGate: PlatformGateState;
   onConfigure: () => void;
 }
 
@@ -46,6 +48,7 @@ export function IntegrationRow({
   description,
   logoUrl,
   connection,
+  platformGate,
   onConfigure,
 }: IntegrationRowProps) {
   const queryClient = useQueryClient();
@@ -118,7 +121,7 @@ export function IntegrationRow({
               </p>
             )}
           </div>
-          {isConnected ? (
+          {isConnected && platformGate === "full" ? (
             <div className="shrink-0">
               <IntegrationConfigureMenu
                 displayName={displayName}

--- a/apps/web/src/domains/settings/pages/integrations-page.tsx
+++ b/apps/web/src/domains/settings/pages/integrations-page.tsx
@@ -22,6 +22,7 @@ import {
   fetchOAuthProviders,
   type OAuthProviderSummary,
 } from "@/domains/settings/api/oauth-providers";
+import { usePlatformGate } from "@/hooks/use-platform-gate";
 import { captureError } from "@/lib/sentry/capture-error";
 import { routes } from "@/utils/routes";
 
@@ -50,6 +51,7 @@ function connectionForProvider(
 function IntegrationsPanelInner() {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
+  const platformGate = usePlatformGate();
 
   const [assistant, setAssistant] = useState<Assistant | null>(null);
   const [assistantLoading, setAssistantLoading] = useState(true);
@@ -110,7 +112,7 @@ function IntegrationsPanelInner() {
     ...assistantsOauthConnectionsListOptions({
       path: { assistant_id: assistant?.id ?? "" },
     }),
-    enabled: !!assistant,
+    enabled: !!assistant && platformGate === "full",
   });
 
   // Handle OAuth callback query params.
@@ -343,6 +345,7 @@ function IntegrationsPanelInner() {
                   connections,
                   provider.provider_key,
                 )}
+                platformGate={platformGate}
                 onConfigure={() =>
                   setSelectedProviderKey(provider.provider_key)
                 }
@@ -361,6 +364,7 @@ function IntegrationsPanelInner() {
           }
           description={selectedProvider.description}
           logoUrl={selectedProvider.logo_url}
+          platformGate={platformGate}
           onClose={() => setSelectedProviderKey(null)}
         />
       )}


### PR DESCRIPTION
## Summary

- Gate the `assistantsOauthConnectionsListOptions` query on `platformGate === "full"` so org-scoped requests don't fire without a platform session
- Hide the "Managed" tab entirely when gated (self-hosted + FF off), show a login Notice when disabled (no platform session), default to the "Your Own" tab
- Gate the managed Configure dropdown on integration rows so disconnect actions aren't exposed without platform access

## Original prompt

Part of the Web UI Platform Decoupling initiative. The Notion spec defines per-surface behavior across five user states (platform-hosted logged in/out, self-hosted with platform features on/off). For integrations, the page container and "Your Own" tab stay fully functional in all states, but the "Managed" tab and its org-scoped connect/disconnect actions need platform gating. This follows the same `usePlatformGate()` pattern established in PR #32935 (billing) but without `platformHostedOnly` since managed integrations are useful for self-hosted + FF on + logged in (Case 3).

## Test plan

- [ ] **Platform-hosted + logged in** → integrations page unchanged, both tabs work, Configure dropdown visible
- [ ] **No platform session** → integrations page visible, Managed tab shows login Notice, "Your Own" tab works, rows show Enable (not Configure)
- [ ] **Self-hosted + FF off** → integrations page visible, tab selector hidden, only "Your Own" content shown
- [ ] **Mid-session transition** (platform session expires while modal open) → managed content gracefully switches to "Your Own"

🤖 Generated with [Claude Code](https://claude.com/claude-code)