### PR TITLE
fix(web): keep openai-compatible endpoint warning visible after hatching

### DIFF
--- a/apps/web/src/domains/onboarding/hatching-provider-warning.test.tsx
+++ b/apps/web/src/domains/onboarding/hatching-provider-warning.test.tsx
@@ -1,0 +1,245 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type { ReactNode } from "react";
+
+import { routes } from "@/utils/routes";
+
+// Drives the openai-compatible local-hatch path: when applyPendingProviderKey
+// reports a failed probe, the screen must hold on the ready state with the
+// warning (no auto-navigate within the delay) and only navigate when Continue
+// is clicked.
+
+let searchParams = new URLSearchParams("hosting=local");
+const navigateMock = mock(() => {});
+const checkAssistantMock = mock(async () => {});
+
+let applyResult: { validation?: { ok: boolean; reason?: string } } = {};
+const applyPendingProviderKeyMock = mock(async () => applyResult);
+
+const getAssistantMock = mock(async () => ({
+  ok: true,
+  status: 200,
+  data: {
+    id: "local-1",
+    status: "active",
+    is_local: true,
+    maintenance_mode: { enabled: false },
+  },
+}));
+
+const fetchCharacterTraitsMock = mock(async () => null);
+const saveCharacterTraitsMock = mock(async () => undefined);
+const setOnboardingCompletedMock = mock(() => {});
+
+mock.module("react-router", () => ({
+  useNavigate: () => navigateMock,
+  useSearchParams: () => [searchParams],
+}));
+
+mock.module("@/assistant/lifecycle-service", () => ({
+  lifecycleService: {
+    checkAssistant: checkAssistantMock,
+    markExpectingFirstMessage: () => {},
+  },
+}));
+
+mock.module("@/assistant/api", () => ({
+  hatchAssistant: mock(async () => ({ ok: true, status: 201, data: {} })),
+  getAssistant: getAssistantMock,
+}));
+
+mock.module("@/domains/onboarding/provider-key", () => ({
+  applyPendingProviderKey: applyPendingProviderKeyMock,
+}));
+
+mock.module("@/assistant/avatar-api", () => ({
+  fetchCharacterTraits: fetchCharacterTraitsMock,
+  saveCharacterTraits: saveCharacterTraitsMock,
+}));
+
+mock.module("@/utils/avatar-bundled-components", () => ({
+  BUNDLED_COMPONENTS: {},
+}));
+
+mock.module("@/utils/avatar-random", () => ({
+  randomCharacterTraits: () => ({
+    bodyShape: "round",
+    eyeStyle: "dot",
+    color: "green",
+  }),
+}));
+
+mock.module("@/utils/avatar-svg-compositor", () => ({
+  composeSvg: () => "<svg />",
+}));
+
+mock.module("@/domains/onboarding/components/onboarding-layout", () => ({
+  OnboardingLayout: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+mock.module("@vellum/design-library/components/button", () => ({
+  Button: ({
+    children,
+    onClick,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+  }) => (
+    <button type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+mock.module("@vellum/design-library/components/progress-bar", () => ({
+  ProgressBar: ({ value }: { value: number }) => (
+    <div data-testid="progress" data-value={value} />
+  ),
+}));
+
+mock.module("@sentry/browser", () => ({
+  captureException: mock(() => {}),
+  captureMessage: mock(() => {}),
+  setContext: () => {},
+}));
+mock.module("@sentry/react", () => ({
+  captureException: mock(() => {}),
+  captureMessage: mock(() => {}),
+  setContext: () => {},
+}));
+
+mock.module("@/domains/onboarding/prefs", () => ({
+  readAiDataConsent: () => true,
+  readOnboardingCompleted: () => false,
+  readSelectedVersion: () => null,
+  readShareAnalytics: () => true,
+  readTosAccepted: () => true,
+  clearOnboardingCompleted: mock(() => {}),
+  useOnboardingCompleted: () => [false, setOnboardingCompletedMock] as const,
+  writeSelectedVersion: mock(() => {}),
+}));
+
+mock.module("@/domains/onboarding/signals", () => ({
+  clearPrivacyConsent: mock(() => {}),
+  hasRecentPrivacyConsent: () => true,
+  markPrivacyConsent: mock(() => {}),
+}));
+
+mock.module("@/runtime/native-auth", () => ({
+  isNativePlatform: () => false,
+  useIsNativePlatform: () => false,
+}));
+
+mock.module("@/lib/local-mode", () => ({
+  isLocalMode: () => true,
+  hasAssistants: () => false,
+  getPlatformAssistants: () => [],
+  getSelectedAssistant: () => undefined,
+  loadLockfile: async () => ({ assistants: [], activeAssistant: null }),
+  setSelectedAssistantId: () => {},
+  saveLockfileAssistant: async () => {},
+  primeLocalGatewayConnection: async () => {},
+  getLocalGatewayUrl: () => "http://localhost:4242",
+}));
+
+mock.module("@/runtime/local-mode-host", () => ({
+  hatchLocalAssistant: async () => ({ ok: true, assistantId: "local-1" }),
+}));
+
+mock.module("@/stores/auth-store", () => ({
+  useAuthStore: {
+    use: {
+      user: () => ({ id: "user-1", firstName: "Alice", lastName: "" }),
+      isLoggedIn: () => true,
+      isLoading: () => false,
+      hasPlatformSession: () => false,
+    },
+  },
+}));
+
+const originalFetch = globalThis.fetch;
+
+const { HatchingScreen } = await import(
+  "@/domains/onboarding/pages/hatching-screen"
+);
+
+beforeEach(() => {
+  searchParams = new URLSearchParams("hosting=local");
+  applyResult = {};
+  sessionStorage.clear();
+  localStorage.clear();
+
+  navigateMock.mockClear();
+  checkAssistantMock.mockClear();
+  applyPendingProviderKeyMock.mockClear();
+  getAssistantMock.mockClear();
+  setOnboardingCompletedMock.mockClear();
+
+  // Local-hatch polls the gateway /readyz before applying the provider key.
+  globalThis.fetch = mock(async () => ({
+    ok: true,
+    json: async () => ({ status: "ok" }),
+  })) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  cleanup();
+  globalThis.fetch = originalFetch;
+});
+
+describe("hatching openai-compatible provider warning", () => {
+  test("a failed probe holds on the ready screen with the warning and does not auto-navigate", async () => {
+    applyResult = { validation: { ok: false, reason: "endpoint timed out" } };
+
+    render(<HatchingScreen />);
+
+    await waitFor(() =>
+      expect(applyPendingProviderKeyMock).toHaveBeenCalled(),
+    );
+    await waitFor(() =>
+      expect(screen.getByText(/couldn't verify your OpenAI-compatible/i)).toBeTruthy(),
+    );
+
+    // The auto-navigate timer is 800ms; give it well past that and confirm we
+    // stay put because the failed probe held for acknowledgement.
+    await new Promise((r) => setTimeout(r, 1200));
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  test("clicking Continue navigates forward", async () => {
+    applyResult = { validation: { ok: false, reason: "endpoint timed out" } };
+
+    render(<HatchingScreen />);
+
+    const continueButton = await screen.findByText("Continue");
+    fireEvent.click(continueButton);
+
+    await waitFor(() =>
+      expect(navigateMock).toHaveBeenCalledWith(routes.onboarding.prechat, {
+        replace: true,
+      }),
+    );
+    expect(checkAssistantMock).toHaveBeenCalled();
+  });
+
+  test("a successful probe auto-navigates without a warning", async () => {
+    applyResult = { validation: { ok: true } };
+
+    render(<HatchingScreen />);
+
+    await waitFor(() =>
+      expect(navigateMock).toHaveBeenCalledWith(routes.onboarding.prechat, {
+        replace: true,
+      }),
+    );
+    expect(screen.queryByText(/couldn't verify your OpenAI-compatible/i)).toBeNull();
+  });
+});

--- a/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -146,6 +146,11 @@ export function HatchingScreen() {
   const segmentStartRef = useRef(0);
   const segmentStartTimeRef = useRef(0);
   const displayProgressRef = useRef(0);
+  // Set inside the hatch effect to the forward-navigation step. The provider
+  // warning's Continue button calls it to navigate when the failed-probe path
+  // held on the ready screen instead of auto-navigating. Null when no hatch
+  // effect is active or after navigation has been triggered.
+  const proceedRef = useRef<(() => void) | null>(null);
 
   const transitionPhase = useCallback((next: HatchPhase) => {
     segmentStartRef.current = displayProgressRef.current;
@@ -183,7 +188,45 @@ export function HatchingScreen() {
 
     const pinnedVersion = readSelectedVersion();
 
-    const handleHatchReady = () => {
+    const proceedToNextScreen = async () => {
+      await lifecycleService.checkAssistant();
+      if (cancelled) return;
+      if (isNativePlatform()) {
+        try {
+          setOnboardingCompleted(true);
+        } catch (err) {
+          captureError(err, { context: "hatching_mark_onboarding_completed_native" });
+        }
+        clearPrivacyConsent();
+        // Native flow skips the pre-chat screen, so there's no
+        // typed message to drive the auto-greet gate. Mark the
+        // lifecycle one-shot so the destination chat mount shows
+        // the loading gate until the server greeting arrives.
+        lifecycleService.markExpectingFirstMessage();
+        void navigate(`${routes.assistant}?onboarding=1`, {
+          replace: true,
+        });
+        return;
+      }
+      void navigate(
+        isReplay
+          ? `${routes.onboarding.prechat}?replay=1`
+          : routes.onboarding.prechat,
+        { replace: true },
+      );
+    };
+
+    // Exposed to the warning's Continue button: navigate forward once, then
+    // detach so rapid clicks can't navigate twice.
+    proceedRef.current = () => {
+      if (cancelled) return;
+      proceedRef.current = null;
+      void proceedToNextScreen();
+    };
+
+    // `holdForAck` keeps the user on the ready screen (no auto-navigate) so the
+    // provider warning stays visible until they click Continue.
+    const handleHatchReady = (holdForAck = false) => {
       try {
         writeSelectedVersion("");
       } catch (err) {
@@ -195,35 +238,10 @@ export function HatchingScreen() {
       segmentStartRef.current = 1;
       setPhase("ready");
       phaseRef.current = "ready";
+      if (holdForAck) return;
       navigateTimer = setTimeout(() => {
         if (cancelled) return;
-        void (async () => {
-          await lifecycleService.checkAssistant();
-          if (cancelled) return;
-          if (isNativePlatform()) {
-            try {
-              setOnboardingCompleted(true);
-            } catch (err) {
-              captureError(err, { context: "hatching_mark_onboarding_completed_native" });
-            }
-            clearPrivacyConsent();
-            // Native flow skips the pre-chat screen, so there's no
-            // typed message to drive the auto-greet gate. Mark the
-            // lifecycle one-shot so the destination chat mount shows
-            // the loading gate until the server greeting arrives.
-            lifecycleService.markExpectingFirstMessage();
-            void navigate(`${routes.assistant}?onboarding=1`, {
-              replace: true,
-            });
-            return;
-          }
-          void navigate(
-            isReplay
-              ? `${routes.onboarding.prechat}?replay=1`
-              : routes.onboarding.prechat,
-            { replace: true },
-          );
-        })();
+        void proceedToNextScreen();
       }, COMPLETION_NAVIGATE_DELAY_MS);
     };
 
@@ -301,14 +319,18 @@ export function HatchingScreen() {
           // Apply the model-provider key collected on the API-key step to the
           // freshly hatched assistant. Non-blocking on failure — onboarding
           // proceeds and the user can fix it in Settings.
+          let validationFailed = false;
           if (result.assistantId) {
             try {
               const applyResult = await applyPendingProviderKey(
                 result.assistantId,
               );
-              if (applyResult?.validation && !applyResult.validation.ok) {
+              validationFailed = !!(
+                applyResult?.validation && !applyResult.validation.ok
+              );
+              if (validationFailed) {
                 setProviderWarning(
-                  `Your assistant is ready, but we couldn't verify your OpenAI-compatible endpoint: ${applyResult.validation.reason ?? "the endpoint did not respond"}. You can update the connection in Settings.`,
+                  `Your assistant is ready, but we couldn't verify your OpenAI-compatible endpoint: ${applyResult.validation?.reason ?? "the endpoint did not respond"}. You can update the connection in Settings.`,
                 );
               }
             } catch (err) {
@@ -316,7 +338,9 @@ export function HatchingScreen() {
             }
           }
 
-          handleHatchReady();
+          // On a failed probe, hold on the ready screen so the warning stays
+          // visible; the user navigates forward via Continue.
+          handleHatchReady(validationFailed);
         } catch {
           localHatchPromise = null;
           if (cancelled) return;
@@ -406,7 +430,7 @@ export function HatchingScreen() {
             }
           }
 
-          handleHatchReady();
+          handleHatchReady(false);
           return;
         }
         if (next.kind === "error") {
@@ -428,6 +452,7 @@ export function HatchingScreen() {
 
     return () => {
       cancelled = true;
+      proceedRef.current = null;
       if (pollTimer) clearTimeout(pollTimer);
       if (navigateTimer) clearTimeout(navigateTimer);
       if (readyPollTimer) clearTimeout(readyPollTimer);
@@ -587,13 +612,15 @@ export function HatchingScreen() {
             className="mt-6 flex w-full max-w-sm flex-col gap-2 rounded-lg border border-[var(--border-warning)] bg-[var(--background-warning)] p-4 text-left text-body-small-default text-[var(--content-warning)]"
           >
             <p>{providerWarning}</p>
-            <button
-              type="button"
-              className="self-end text-body-small-default underline"
-              onClick={() => setProviderWarning(null)}
+            <Button
+              variant="primary"
+              size="regular"
+              fullWidth
+              className="mt-2 h-11 text-base"
+              onClick={() => proceedRef.current?.()}
             >
-              Dismiss
-            </button>
+              Continue
+            </Button>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- When the onboarding openai-compatible endpoint probe fails, hold on the hatching screen (assistant is ready) and show the warning with a Continue button, instead of auto-navigating away after 800ms so the warning only flashed.
- Successful/skipped probes and non-openai-compatible providers navigate automatically as before.

Addresses Codex P2 on the openai-compatible onboarding feature branch.