### PR TITLE
fix(macos): install vellum meta-package instead of @vellumai/cli

### DIFF
--- a/apps/macos/src/main/cli-installer.test.ts
+++ b/apps/macos/src/main/cli-installer.test.ts
@@ -139,7 +139,7 @@ describe("ensureCliInstalled", () => {
     expect(spawnCalls).toHaveLength(1);
     const [cmd, args, opts] = spawnCalls[0];
     expect(cmd).toBe(`${mockResourcesPath}/bun`);
-    expect(args).toEqual(["add", `@vellumai/cli@${PINNED_CLI_VERSION}`]);
+    expect(args).toEqual(["add", `vellum@${PINNED_CLI_VERSION}`]);
     expect(opts).toEqual({
       cwd: `${userDataPath}/cli/${PINNED_CLI_VERSION}`,
     });

--- a/apps/macos/src/main/cli-installer.ts
+++ b/apps/macos/src/main/cli-installer.ts
@@ -40,11 +40,12 @@ export function _resetInstallLock(): void {
 }
 
 /**
- * Install the pinned CLI version if it isn't already present.
+ * Install the pinned vellum meta-package if it isn't already present.
  *
- * Uses the bundled bun runtime to `bun add @vellumai/cli@<version>` into the
- * per-version install directory. After a successful install, stale
- * versions are cleaned up.
+ * Uses the bundled bun runtime to `bun add vellum@<version>` into the
+ * per-version install directory. The meta-package brings the full local
+ * stack (daemon, gateway, credential-executor, web). After a successful
+ * install, stale versions are cleaned up.
  */
 export async function ensureCliInstalled(): Promise<void> {
   if (isCliInstalled()) return;
@@ -58,7 +59,7 @@ export async function ensureCliInstalled(): Promise<void> {
     const bunPath = getBundledBunPath();
 
     await new Promise<void>((resolve, reject) => {
-      const child = spawn(bunPath, ["add", `@vellumai/cli@${PINNED_CLI_VERSION}`], {
+      const child = spawn(bunPath, ["add", `vellum@${PINNED_CLI_VERSION}`], {
         cwd: installDir,
       });
 


### PR DESCRIPTION
## Summary
- The Electron app's lazy CLI installer was running `bun add @vellumai/cli@<version>`, which only installs the CLI itself
- The CLI's `local.ts` resolves the daemon, gateway, and other services at runtime via `require.resolve("vellum/package.json")` — it expects the `vellum` meta-package to be present
- Changed to `bun add vellum@<version>` which installs the full local stack: daemon (`@vellumai/assistant`), gateway (`@vellumai/vellum-gateway`), credential-executor (`@vellumai/credential-executor`), and web frontend (`@vellumai/web`)

## Test plan
- [x] `cli-installer.test.ts` passes (17 tests)
- [ ] Verify packaged Electron app can `vellum hatch` successfully with the meta-package installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)