### PR TITLE
fix(web): use assistant terminology in onboarding connection-test warning

### DIFF
--- a/apps/web/src/domains/onboarding/provider-key.ts
+++ b/apps/web/src/domains/onboarding/provider-key.ts
@@ -190,7 +190,7 @@ async function testProviderConnection(
     if (!result.response?.ok) {
       return {
         ok: false,
-        reason: "Could not reach the daemon to test the connection.",
+        reason: "Could not reach your assistant to run the connection test.",
       };
     }
     const body = (result.data ?? {}) as {
@@ -202,7 +202,7 @@ async function testProviderConnection(
   } catch {
     return {
       ok: false,
-      reason: "Could not reach the daemon to test the connection.",
+      reason: "Could not reach your assistant to run the connection test.",
     };
   }
 }


### PR DESCRIPTION
## Summary
- Replace the user-facing 'Could not reach the daemon to test the connection.' warning reason with 'Could not reach your assistant to run the connection test.', per the AGENTS.md user-facing terminology rule (use 'assistant', not 'daemon'). Code comments are unchanged (internal).

Addresses Codex P2 on the openai-compatible onboarding feature branch.