### PR TITLE
Add Slack retry/dead-letter diagnostics for replayed channel events

### DIFF
--- a/assistant/src/__tests__/channel-retry-sweep.test.ts
+++ b/assistant/src/__tests__/channel-retry-sweep.test.ts
@@ -2,11 +2,37 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { asc, eq } from "drizzle-orm";
 
+const logEntries: Array<{
+  level: "debug" | "error" | "info" | "warn";
+  fields?: Record<string, unknown>;
+  message?: string;
+}> = [];
+
+function recordLog(
+  level: "debug" | "error" | "info" | "warn",
+  args: unknown[],
+): void {
+  const [first, second] = args;
+  const fields =
+    first && typeof first === "object" && !Array.isArray(first)
+      ? (first as Record<string, unknown>)
+      : undefined;
+  const message =
+    typeof second === "string"
+      ? second
+      : typeof first === "string"
+        ? first
+        : undefined;
+  logEntries.push({ level, fields, message });
+}
+
 mock.module("../util/logger.js", () => ({
-  getLogger: () =>
-    new Proxy({} as Record<string, unknown>, {
-      get: () => () => {},
-    }),
+  getLogger: () => ({
+    debug: (...args: unknown[]) => recordLog("debug", args),
+    error: (...args: unknown[]) => recordLog("error", args),
+    info: (...args: unknown[]) => recordLog("info", args),
+    warn: (...args: unknown[]) => recordLog("warn", args),
+  }),
 }));
 
 const deliveryCalls: Array<{
@@ -99,6 +125,7 @@ mock.module("../runtime/gateway-client.js", () => ({
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import * as deliveryCrud from "../memory/delivery-crud.js";
+import { getRetryableEvents } from "../memory/delivery-status.js";
 import { channelInboundEvents, messages } from "../memory/schema.js";
 import { sweepFailedEvents } from "../runtime/channel-retry-sweep.js";
 
@@ -181,11 +208,32 @@ function seedFailedEventWithActorRoleOnly(
   return inbound.eventId;
 }
 
+function parseStoredPayload(
+  rawPayload: string | null,
+): Record<string, unknown> | undefined {
+  if (!rawPayload) return undefined;
+  return JSON.parse(rawPayload) as Record<string, unknown>;
+}
+
+function findReplayLog(
+  eventId: string,
+  retryClass: "delivery_retry" | "processing_retry",
+): (typeof logEntries)[number] | undefined {
+  return logEntries.find(
+    (entry) =>
+      entry.level === "info" &&
+      entry.message === "Replaying Slack channel event" &&
+      entry.fields?.inboundEventId === eventId &&
+      entry.fields?.retryClass === retryClass,
+  );
+}
+
 describe("channel-retry-sweep", () => {
   beforeEach(() => {
     resetTables();
     deliveryCalls.length = 0;
     liveDeliveryCalls.length = 0;
+    logEntries.length = 0;
     deliverReplyViaCallbackImpl = async () => {};
     deliverChannelReplyImpl = async () => ({ ok: true });
   });
@@ -877,5 +925,212 @@ describe("channel-retry-sweep", () => {
       row?.rawPayload ? JSON.parse(row.rawPayload).replyMessageId : undefined,
     ).toBe("assistant-delivery-fallback");
     expect(row?.deliveryStatus).toBe("delivered");
+  });
+
+  test("Slack replay logs and dead-letter metadata distinguish regenerated replies from delivery-only retries", async () => {
+    const processingInbound = deliveryCrud.recordInbound(
+      "slack",
+      "C-RETRY-THREAD",
+      "slack-msg-processing-retry",
+    );
+    deliveryCrud.storePayload(processingInbound.eventId, {
+      content: "retry me",
+      sourceChannel: "slack",
+      interface: "slack",
+      externalChatId: "C-RETRY-THREAD",
+      replyCallbackUrl:
+        "https://example.test/deliver/slack?channel=C-RETRY-THREAD&threadTs=1700000000.000101",
+      trustCtx: {
+        trustClass: "unknown",
+        sourceChannel: "slack",
+        requesterChatId: "C-RETRY-THREAD",
+      },
+    });
+
+    const deliveryInbound = deliveryCrud.recordInbound(
+      "slack",
+      "D-RETRY-DM",
+      "slack-msg-delivery-retry",
+    );
+    deliveryCrud.storePayload(deliveryInbound.eventId, {
+      content: "already processed",
+      sourceChannel: "slack",
+      interface: "slack",
+      externalChatId: "D-RETRY-DM",
+      replyCallbackUrl:
+        "https://example.test/deliver/slack?channel=D-RETRY-DM&messageTs=1700000000.000202",
+      replyMessageId: "assistant-delivery-only",
+    });
+
+    const db = getDb();
+    db.update(channelInboundEvents)
+      .set({
+        processingStatus: "failed",
+        processingAttempts: 1,
+        retryAfter: Date.now() - 1,
+      })
+      .where(eq(channelInboundEvents.id, processingInbound.eventId))
+      .run();
+    db.update(channelInboundEvents)
+      .set({
+        processingStatus: "processed",
+        deliveryStatus: "failed",
+        retryAfter: Date.now() - 1,
+      })
+      .where(eq(channelInboundEvents.id, deliveryInbound.eventId))
+      .run();
+
+    deliverReplyViaCallbackImpl = async (...args: unknown[]) => {
+      const externalChatId = args[1];
+      if (
+        externalChatId === "C-RETRY-THREAD" ||
+        externalChatId === "D-RETRY-DM"
+      ) {
+        throw { status: 400, message: "invalid callback payload" };
+      }
+    };
+
+    await sweepFailedEvents(async (conversationId, _content, options) => {
+      options?.onEvent?.({
+        type: "message_complete",
+        conversationId,
+        messageId: "assistant-processing-retry",
+      });
+      db.insert(messages)
+        .values({
+          id: "user-processing-retry",
+          conversationId,
+          role: "user",
+          content: JSON.stringify([{ type: "text", text: "retry me" }]),
+          createdAt: Date.now(),
+        })
+        .run();
+      return { messageId: "user-processing-retry" };
+    });
+
+    const processingLog = findReplayLog(
+      processingInbound.eventId,
+      "processing_retry",
+    );
+    const deliveryLog = findReplayLog(
+      deliveryInbound.eventId,
+      "delivery_retry",
+    );
+    expect(processingLog?.fields).toMatchObject({
+      inboundEventId: processingInbound.eventId,
+      retryClass: "processing_retry",
+      externalChatId: "C-RETRY-THREAD",
+      replyCallbackUrl:
+        "https://example.test/deliver/slack?channel=C-RETRY-THREAD&threadTs=1700000000.000101",
+      threadTs: "1700000000.000101",
+      replayMode: "regenerate_reply",
+    });
+    expect(deliveryLog?.fields).toMatchObject({
+      inboundEventId: deliveryInbound.eventId,
+      retryClass: "delivery_retry",
+      externalChatId: "D-RETRY-DM",
+      replyCallbackUrl:
+        "https://example.test/deliver/slack?channel=D-RETRY-DM&messageTs=1700000000.000202",
+      messageTs: "1700000000.000202",
+      replayMode: "redeliver_existing_reply",
+    });
+
+    const processingRow = db
+      .select()
+      .from(channelInboundEvents)
+      .where(eq(channelInboundEvents.id, processingInbound.eventId))
+      .get();
+    const deliveryRow = db
+      .select()
+      .from(channelInboundEvents)
+      .where(eq(channelInboundEvents.id, deliveryInbound.eventId))
+      .get();
+    const processingFailure = parseStoredPayload(processingRow?.rawPayload ?? null)
+      ?.lastReplayFailure as Record<string, unknown> | undefined;
+    const deliveryFailure = parseStoredPayload(deliveryRow?.rawPayload ?? null)
+      ?.lastReplayFailure as Record<string, unknown> | undefined;
+
+    expect(processingRow?.processingStatus).toBe("processed");
+    expect(processingRow?.deliveryStatus).toBe("dead_letter");
+    expect(processingFailure).toMatchObject({
+      reason: "invalid callback payload",
+      stage: "callback_delivery",
+      retryClass: "processing_retry",
+      replayMode: "regenerate_reply",
+      externalChatId: "C-RETRY-THREAD",
+      threadTs: "1700000000.000101",
+    });
+    expect(deliveryRow?.processingStatus).toBe("processed");
+    expect(deliveryRow?.deliveryStatus).toBe("dead_letter");
+    expect(deliveryFailure).toMatchObject({
+      reason: "invalid callback payload",
+      stage: "callback_delivery",
+      retryClass: "delivery_retry",
+      replayMode: "redeliver_existing_reply",
+      externalChatId: "D-RETRY-DM",
+      messageTs: "1700000000.000202",
+    });
+  });
+
+  test("fatal Slack provider validation failures dead-letter without requeueing", async () => {
+    const inbound = deliveryCrud.recordInbound(
+      "slack",
+      "C-PROVIDER-VALIDATION",
+      "slack-msg-provider-validation",
+    );
+    deliveryCrud.storePayload(inbound.eventId, {
+      content: "retry me",
+      sourceChannel: "slack",
+      interface: "slack",
+      externalChatId: "C-PROVIDER-VALIDATION",
+      replyCallbackUrl:
+        "https://example.test/deliver/slack?channel=C-PROVIDER-VALIDATION&threadTs=1700000000.000303",
+      trustCtx: {
+        trustClass: "unknown",
+        sourceChannel: "slack",
+        requesterChatId: "C-PROVIDER-VALIDATION",
+      },
+    });
+
+    const db = getDb();
+    db.update(channelInboundEvents)
+      .set({
+        processingStatus: "failed",
+        processingAttempts: 1,
+        retryAfter: Date.now() - 1,
+      })
+      .where(eq(channelInboundEvents.id, inbound.eventId))
+      .run();
+
+    let processMessageCalls = 0;
+    await sweepFailedEvents(async () => {
+      processMessageCalls++;
+      throw { status: 400, message: "invalid trailing assistant turn" };
+    });
+
+    const row = db
+      .select()
+      .from(channelInboundEvents)
+      .where(eq(channelInboundEvents.id, inbound.eventId))
+      .get();
+    const replayFailure = parseStoredPayload(row?.rawPayload ?? null)
+      ?.lastReplayFailure as Record<string, unknown> | undefined;
+
+    expect(processMessageCalls).toBe(1);
+    expect(deliveryCalls).toHaveLength(0);
+    expect(row?.processingStatus).toBe("dead_letter");
+    expect(row?.retryAfter).toBeNull();
+    expect(
+      getRetryableEvents().some((event) => event.id === inbound.eventId),
+    ).toBe(false);
+    expect(row?.lastProcessingError).toContain("provider_validation");
+    expect(replayFailure).toMatchObject({
+      reason: "invalid trailing assistant turn",
+      stage: "provider_validation",
+      retryClass: "processing_retry",
+      replayMode: "regenerate_reply",
+      externalChatId: "C-PROVIDER-VALIDATION",
+      threadTs: "1700000000.000303",
+    });
   });
 });

--- a/assistant/src/__tests__/channel-retry-sweep.test.ts
+++ b/assistant/src/__tests__/channel-retry-sweep.test.ts
@@ -2,37 +2,11 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { asc, eq } from "drizzle-orm";
 
-const logEntries: Array<{
-  level: "debug" | "error" | "info" | "warn";
-  fields?: Record<string, unknown>;
-  message?: string;
-}> = [];
-
-function recordLog(
-  level: "debug" | "error" | "info" | "warn",
-  args: unknown[],
-): void {
-  const [first, second] = args;
-  const fields =
-    first && typeof first === "object" && !Array.isArray(first)
-      ? (first as Record<string, unknown>)
-      : undefined;
-  const message =
-    typeof second === "string"
-      ? second
-      : typeof first === "string"
-        ? first
-        : undefined;
-  logEntries.push({ level, fields, message });
-}
-
 mock.module("../util/logger.js", () => ({
-  getLogger: () => ({
-    debug: (...args: unknown[]) => recordLog("debug", args),
-    error: (...args: unknown[]) => recordLog("error", args),
-    info: (...args: unknown[]) => recordLog("info", args),
-    warn: (...args: unknown[]) => recordLog("warn", args),
-  }),
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
 }));
 
 const deliveryCalls: Array<{
@@ -215,25 +189,11 @@ function parseStoredPayload(
   return JSON.parse(rawPayload) as Record<string, unknown>;
 }
 
-function findReplayLog(
-  eventId: string,
-  retryClass: "delivery_retry" | "processing_retry",
-): (typeof logEntries)[number] | undefined {
-  return logEntries.find(
-    (entry) =>
-      entry.level === "info" &&
-      entry.message === "Replaying Slack channel event" &&
-      entry.fields?.inboundEventId === eventId &&
-      entry.fields?.retryClass === retryClass,
-  );
-}
-
 describe("channel-retry-sweep", () => {
   beforeEach(() => {
     resetTables();
     deliveryCalls.length = 0;
     liveDeliveryCalls.length = 0;
-    logEntries.length = 0;
     deliverReplyViaCallbackImpl = async () => {};
     deliverChannelReplyImpl = async () => ({ ok: true });
   });
@@ -927,7 +887,7 @@ describe("channel-retry-sweep", () => {
     expect(row?.deliveryStatus).toBe("delivered");
   });
 
-  test("Slack replay logs and dead-letter metadata distinguish regenerated replies from delivery-only retries", async () => {
+  test("Slack dead-letter diagnostics distinguish regenerated replies from delivery-only retries", async () => {
     const processingInbound = deliveryCrud.recordInbound(
       "slack",
       "C-RETRY-THREAD",
@@ -1008,33 +968,6 @@ describe("channel-retry-sweep", () => {
       return { messageId: "user-processing-retry" };
     });
 
-    const processingLog = findReplayLog(
-      processingInbound.eventId,
-      "processing_retry",
-    );
-    const deliveryLog = findReplayLog(
-      deliveryInbound.eventId,
-      "delivery_retry",
-    );
-    expect(processingLog?.fields).toMatchObject({
-      inboundEventId: processingInbound.eventId,
-      retryClass: "processing_retry",
-      externalChatId: "C-RETRY-THREAD",
-      replyCallbackUrl:
-        "https://example.test/deliver/slack?channel=C-RETRY-THREAD&threadTs=1700000000.000101",
-      threadTs: "1700000000.000101",
-      replayMode: "regenerate_reply",
-    });
-    expect(deliveryLog?.fields).toMatchObject({
-      inboundEventId: deliveryInbound.eventId,
-      retryClass: "delivery_retry",
-      externalChatId: "D-RETRY-DM",
-      replyCallbackUrl:
-        "https://example.test/deliver/slack?channel=D-RETRY-DM&messageTs=1700000000.000202",
-      messageTs: "1700000000.000202",
-      replayMode: "redeliver_existing_reply",
-    });
-
     const processingRow = db
       .select()
       .from(channelInboundEvents)
@@ -1052,6 +985,11 @@ describe("channel-retry-sweep", () => {
 
     expect(processingRow?.processingStatus).toBe("processed");
     expect(processingRow?.deliveryStatus).toBe("dead_letter");
+    expect(processingRow?.lastProcessingError).toContain("processing_retry");
+    expect(processingRow?.lastProcessingError).toContain("regenerate_reply");
+    expect(processingRow?.lastProcessingError).toContain(
+      "threadTs=1700000000.000101",
+    );
     expect(processingFailure).toMatchObject({
       reason: "invalid callback payload",
       stage: "callback_delivery",
@@ -1062,6 +1000,13 @@ describe("channel-retry-sweep", () => {
     });
     expect(deliveryRow?.processingStatus).toBe("processed");
     expect(deliveryRow?.deliveryStatus).toBe("dead_letter");
+    expect(deliveryRow?.lastProcessingError).toContain("delivery_retry");
+    expect(deliveryRow?.lastProcessingError).toContain(
+      "redeliver_existing_reply",
+    );
+    expect(deliveryRow?.lastProcessingError).toContain(
+      "messageTs=1700000000.000202",
+    );
     expect(deliveryFailure).toMatchObject({
       reason: "invalid callback payload",
       stage: "callback_delivery",

--- a/assistant/src/memory/delivery-status.ts
+++ b/assistant/src/memory/delivery-status.ts
@@ -167,7 +167,12 @@ function buildDeadLetterErrorMessage(
 ): string {
   const stage = resolveReplayFailureStage(err, context);
   const labels = [stage, context?.retryClass, context?.replayMode].filter(
-    (value): value is string => typeof value === "string" && value.length > 0,
+    (
+      value,
+    ): value is Exclude<
+      ReplayFailureContext["stage"] | RetryClass | ReplayMode,
+      undefined
+    > => typeof value === "string" && value.length > 0,
   );
   if (labels.length === 0) return errorMsg;
 

--- a/assistant/src/memory/delivery-status.ts
+++ b/assistant/src/memory/delivery-status.ts
@@ -96,7 +96,16 @@ export function markDeliveryDelivered(eventId: string): void {
 }
 
 function errorMessage(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
+  if (err instanceof Error) return err.message;
+  if (
+    err != null &&
+    typeof err === "object" &&
+    "message" in err &&
+    typeof (err as { message?: unknown }).message === "string"
+  ) {
+    return (err as { message: string }).message;
+  }
+  return String(err);
 }
 
 function extractHttpStatus(err: unknown): number | undefined {

--- a/assistant/src/memory/delivery-status.ts
+++ b/assistant/src/memory/delivery-status.ts
@@ -16,6 +16,26 @@ import {
 } from "./job-utils.js";
 import { channelInboundEvents } from "./schema.js";
 
+type RetryClass = "processing_retry" | "delivery_retry";
+type ReplayMode = "regenerate_reply" | "redeliver_existing_reply";
+type ReplayFailureStage =
+  | "reply_generation"
+  | "callback_delivery"
+  | "provider_validation";
+
+export interface ReplayFailureContext {
+  sourceChannel?: string;
+  retryClass?: RetryClass;
+  replayMode?: ReplayMode;
+  stage?: Exclude<ReplayFailureStage, "provider_validation">;
+  externalChatId?: string;
+  replyCallbackUrl?: string;
+  slackThreadTs?: string;
+  slackMessageTs?: string;
+}
+
+const LAST_REPLAY_FAILURE_KEY = "lastReplayFailure";
+
 /**
  * Acknowledge delivery of an outbound message for a channel event.
  */
@@ -79,18 +99,152 @@ function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
+function extractHttpStatus(err: unknown): number | undefined {
+  if (err != null && typeof err === "object" && "status" in err) {
+    const status = (err as { status?: number }).status;
+    if (typeof status === "number") return status;
+  }
+
+  if (err instanceof Error) {
+    const statusMatch = err.message.match(/\((\d{3})\)/);
+    if (!statusMatch) return undefined;
+    const status = Number.parseInt(statusMatch[1], 10);
+    return Number.isFinite(status) ? status : undefined;
+  }
+
+  return undefined;
+}
+
+function resolveReplayFailureStage(
+  err: unknown,
+  context: ReplayFailureContext | undefined,
+): ReplayFailureStage | undefined {
+  if (!context?.stage) return undefined;
+  const status = extractHttpStatus(err);
+  if (
+    context.stage === "reply_generation" &&
+    status !== undefined &&
+    status >= 400 &&
+    status < 500
+  ) {
+    return "provider_validation";
+  }
+  return context.stage;
+}
+
+function parseRawPayload(
+  rawPayload: string | null,
+): Record<string, unknown> | undefined {
+  if (!rawPayload) return undefined;
+  try {
+    const parsed = JSON.parse(rawPayload) as unknown;
+    if (
+      parsed === null ||
+      typeof parsed !== "object" ||
+      Array.isArray(parsed)
+    ) {
+      return undefined;
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+}
+
+function buildDeadLetterErrorMessage(
+  errorMsg: string,
+  err: unknown,
+  context: ReplayFailureContext | undefined,
+): string {
+  const stage = resolveReplayFailureStage(err, context);
+  const labels = [stage, context?.retryClass, context?.replayMode].filter(
+    (value): value is string => typeof value === "string" && value.length > 0,
+  );
+  if (labels.length === 0) return errorMsg;
+
+  const suffix = [
+    context?.externalChatId
+      ? `externalChatId=${context.externalChatId}`
+      : undefined,
+    context?.slackThreadTs ? `threadTs=${context.slackThreadTs}` : undefined,
+    context?.slackMessageTs
+      ? `messageTs=${context.slackMessageTs}`
+      : undefined,
+  ].filter((value): value is string => typeof value === "string");
+
+  return `${labels.join("/")}: ${errorMsg}${
+    suffix.length > 0 ? ` [${suffix.join(" ")}]` : ""
+  }`;
+}
+
+function buildReplayFailurePayload(
+  errorMsg: string,
+  err: unknown,
+  context: ReplayFailureContext | undefined,
+): Record<string, unknown> | undefined {
+  if (!context) return undefined;
+
+  const stage = resolveReplayFailureStage(err, context);
+  const payload: Record<string, unknown> = {
+    reason: errorMsg,
+    ...(stage ? { stage } : {}),
+    ...(context.sourceChannel ? { sourceChannel: context.sourceChannel } : {}),
+    ...(context.retryClass ? { retryClass: context.retryClass } : {}),
+    ...(context.replayMode ? { replayMode: context.replayMode } : {}),
+    ...(context.externalChatId
+      ? { externalChatId: context.externalChatId }
+      : {}),
+    ...(context.replyCallbackUrl
+      ? { replyCallbackUrl: context.replyCallbackUrl }
+      : {}),
+    ...(context.slackThreadTs ? { threadTs: context.slackThreadTs } : {}),
+    ...(context.slackMessageTs ? { messageTs: context.slackMessageTs } : {}),
+  };
+
+  return Object.keys(payload).length > 0 ? payload : undefined;
+}
+
+function withReplayFailurePayload(
+  rawPayload: string | null,
+  replayFailure: Record<string, unknown> | undefined,
+): string | undefined {
+  if (!replayFailure) return undefined;
+  const payload = parseRawPayload(rawPayload);
+  if (!payload) return undefined;
+  return JSON.stringify({
+    ...payload,
+    [LAST_REPLAY_FAILURE_KEY]: replayFailure,
+  });
+}
+
+function clearReplayFailurePayload(
+  rawPayload: string | null,
+): string | undefined {
+  const payload = parseRawPayload(rawPayload);
+  if (!payload || !(LAST_REPLAY_FAILURE_KEY in payload)) return undefined;
+  const { [LAST_REPLAY_FAILURE_KEY]: _ignored, ...rest } = payload;
+  return JSON.stringify(rest);
+}
+
 /**
  * Record a processing failure. Classifies the error to decide whether
  * the event should be retried (status='failed') or dead-lettered
  * (status='dead_letter') when the error is fatal or max attempts
  * are exhausted.
  */
-export function recordProcessingFailure(eventId: string, err: unknown): void {
+export function recordProcessingFailure(
+  eventId: string,
+  err: unknown,
+  context?: ReplayFailureContext,
+): void {
   const db = getDb();
   const now = Date.now();
 
   const row = db
-    .select({ attempts: channelInboundEvents.processingAttempts })
+    .select({
+      attempts: channelInboundEvents.processingAttempts,
+      rawPayload: channelInboundEvents.rawPayload,
+    })
     .from(channelInboundEvents)
     .where(eq(channelInboundEvents.id, eventId))
     .get();
@@ -100,12 +254,21 @@ export function recordProcessingFailure(eventId: string, err: unknown): void {
   const errorMsg = errorMessage(err);
 
   if (category === "fatal" || attempts >= RETRY_MAX_ATTEMPTS) {
+    const replayFailurePayload = withReplayFailurePayload(
+      row?.rawPayload ?? null,
+      buildReplayFailurePayload(errorMsg, err, context),
+    );
     db.update(channelInboundEvents)
       .set({
         processingStatus: "dead_letter",
         processingAttempts: attempts,
-        lastProcessingError: errorMsg,
+        lastProcessingError: buildDeadLetterErrorMessage(
+          errorMsg,
+          err,
+          context,
+        ),
         retryAfter: null,
+        ...(replayFailurePayload ? { rawPayload: replayFailurePayload } : {}),
         updatedAt: now,
       })
       .where(eq(channelInboundEvents.id, eventId))
@@ -130,12 +293,19 @@ export function recordProcessingFailure(eventId: string, err: unknown): void {
  * status. Delivery uses its own retry budget so a turn that needed processing
  * retries still gets a full delivery retry window.
  */
-export function recordDeliveryFailure(eventId: string, err: unknown): void {
+export function recordDeliveryFailure(
+  eventId: string,
+  err: unknown,
+  context?: ReplayFailureContext,
+): void {
   const db = getDb();
   const now = Date.now();
 
   const row = db
-    .select({ attempts: channelInboundEvents.deliveryAttempts })
+    .select({
+      attempts: channelInboundEvents.deliveryAttempts,
+      rawPayload: channelInboundEvents.rawPayload,
+    })
     .from(channelInboundEvents)
     .where(eq(channelInboundEvents.id, eventId))
     .get();
@@ -145,12 +315,21 @@ export function recordDeliveryFailure(eventId: string, err: unknown): void {
   const errorMsg = errorMessage(err);
 
   if (category === "fatal" || attempts >= RETRY_MAX_ATTEMPTS) {
+    const replayFailurePayload = withReplayFailurePayload(
+      row?.rawPayload ?? null,
+      buildReplayFailurePayload(errorMsg, err, context),
+    );
     db.update(channelInboundEvents)
       .set({
         deliveryStatus: "dead_letter",
         deliveryAttempts: attempts,
-        lastProcessingError: errorMsg,
+        lastProcessingError: buildDeadLetterErrorMessage(
+          errorMsg,
+          err,
+          context,
+        ),
         retryAfter: null,
+        ...(replayFailurePayload ? { rawPayload: replayFailurePayload } : {}),
         updatedAt: now,
       })
       .where(eq(channelInboundEvents.id, eventId))
@@ -178,12 +357,16 @@ export function recordDeliveryFailure(eventId: string, err: unknown): void {
 export function markRetryableFailure(
   eventId: string,
   errorMessage: string,
+  context?: ReplayFailureContext,
 ): void {
   const db = getDb();
   const now = Date.now();
 
   const row = db
-    .select({ attempts: channelInboundEvents.processingAttempts })
+    .select({
+      attempts: channelInboundEvents.processingAttempts,
+      rawPayload: channelInboundEvents.rawPayload,
+    })
     .from(channelInboundEvents)
     .where(eq(channelInboundEvents.id, eventId))
     .get();
@@ -191,12 +374,21 @@ export function markRetryableFailure(
   const attempts = (row?.attempts ?? 0) + 1;
 
   if (attempts >= RETRY_MAX_ATTEMPTS) {
+    const replayFailurePayload = withReplayFailurePayload(
+      row?.rawPayload ?? null,
+      buildReplayFailurePayload(errorMessage, errorMessage, context),
+    );
     db.update(channelInboundEvents)
       .set({
         processingStatus: "dead_letter",
         processingAttempts: attempts,
-        lastProcessingError: errorMessage,
+        lastProcessingError: buildDeadLetterErrorMessage(
+          errorMessage,
+          errorMessage,
+          context,
+        ),
         retryAfter: null,
+        ...(replayFailurePayload ? { rawPayload: replayFailurePayload } : {}),
         updatedAt: now,
       })
       .where(eq(channelInboundEvents.id, eventId))
@@ -325,6 +517,7 @@ export function replayDeadLetters(eventIds: string[]): number {
         id: channelInboundEvents.id,
         processingStatus: channelInboundEvents.processingStatus,
         deliveryStatus: channelInboundEvents.deliveryStatus,
+        rawPayload: channelInboundEvents.rawPayload,
       })
       .from(channelInboundEvents)
       .where(
@@ -342,6 +535,9 @@ export function replayDeadLetters(eventIds: string[]): number {
       .get();
     if (!existing) continue;
 
+    const clearedReplayFailurePayload = clearReplayFailurePayload(
+      existing.rawPayload ?? null,
+    );
     if (existing.processingStatus === "dead_letter") {
       db.update(channelInboundEvents)
         .set({
@@ -349,6 +545,9 @@ export function replayDeadLetters(eventIds: string[]): number {
           processingAttempts: 0,
           lastProcessingError: null,
           retryAfter: now,
+          ...(clearedReplayFailurePayload
+            ? { rawPayload: clearedReplayFailurePayload }
+            : {}),
           updatedAt: now,
         })
         .where(eq(channelInboundEvents.id, id))
@@ -360,6 +559,9 @@ export function replayDeadLetters(eventIds: string[]): number {
           deliveryAttempts: 0,
           lastProcessingError: null,
           retryAfter: now,
+          ...(clearedReplayFailurePayload
+            ? { rawPayload: clearedReplayFailurePayload }
+            : {}),
           updatedAt: now,
         })
         .where(eq(channelInboundEvents.id, id))

--- a/assistant/src/runtime/channel-retry-sweep.ts
+++ b/assistant/src/runtime/channel-retry-sweep.ts
@@ -29,7 +29,12 @@ import {
   markRetryableFailure,
   recordDeliveryFailure,
   recordProcessingFailure,
+  type ReplayFailureContext,
 } from "../memory/delivery-status.js";
+import {
+  extractMessageTsFromCallbackUrl,
+  extractThreadTsFromCallbackUrl,
+} from "../memory/slack-thread-store.js";
 import { getLogger } from "../util/logger.js";
 import {
   deliverReplyViaCallback,
@@ -43,6 +48,65 @@ import { resolveRoutingStateFromRuntime } from "./trust-context-resolver.js";
 const log = getLogger("runtime-http");
 const DISK_PRESSURE_REMOTE_BLOCK_REPLY =
   "Storage is critically low, so remote messages are ignored until the guardian frees enough space. Please try again later.";
+type RetryClass = "processing_retry" | "delivery_retry";
+type ReplayMode = "regenerate_reply" | "redeliver_existing_reply";
+
+function asOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}
+
+function buildSlackReplayContext(
+  sourceChannel: string,
+  payload: Record<string, unknown>,
+  retryClass: RetryClass,
+  replayMode: ReplayMode,
+  stage: ReplayFailureContext["stage"],
+): ReplayFailureContext | undefined {
+  if (sourceChannel !== "slack") return undefined;
+
+  const replyCallbackUrl = asOptionalString(payload.replyCallbackUrl);
+  const slackThreadTs = extractThreadTsFromCallbackUrl(replyCallbackUrl);
+  const slackMessageTs = extractMessageTsFromCallbackUrl(replyCallbackUrl);
+
+  return {
+    sourceChannel,
+    retryClass,
+    replayMode,
+    stage,
+    externalChatId: asOptionalString(payload.externalChatId),
+    replyCallbackUrl,
+    ...(slackThreadTs ? { slackThreadTs } : {}),
+    ...(slackMessageTs ? { slackMessageTs } : {}),
+  };
+}
+
+function slackReplayLogFields(
+  inboundEventId: string,
+  context: ReplayFailureContext,
+): Record<string, unknown> {
+  return {
+    inboundEventId,
+    retryClass: context.retryClass,
+    externalChatId: context.externalChatId,
+    replyCallbackUrl: context.replyCallbackUrl,
+    threadTs: context.slackThreadTs,
+    messageTs: context.slackMessageTs,
+    replayMode: context.replayMode,
+  };
+}
+
+function logSlackReplayAttempt(
+  inboundEventId: string,
+  context: ReplayFailureContext | undefined,
+): void {
+  if (!context) return;
+  log.info(
+    slackReplayLogFields(inboundEventId, context),
+    "Replaying Slack channel event",
+  );
+}
 
 function parseTrustRuntimeContext(value: unknown): TrustContext | undefined {
   if (!value || typeof value !== "object") return undefined;
@@ -153,6 +217,13 @@ export async function sweepFailedEvents(
       parseInterfaceId(payload.interface) ??
       parseInterfaceId(payload.sourceChannel) ??
       "web";
+    const slackProcessingReplayContext = buildSlackReplayContext(
+      sourceChannel,
+      payload,
+      "processing_retry",
+      "regenerate_reply",
+      "reply_generation",
+    );
     const sourceMetadata = payload.sourceMetadata as
       | Record<string, unknown>
       | undefined;
@@ -174,6 +245,7 @@ export async function sweepFailedEvents(
       markRetryableFailure(
         event.id,
         "Unparseable guardian context in stored payload — refusing to process without trust classification",
+        slackProcessingReplayContext,
       );
       continue;
     }
@@ -297,6 +369,7 @@ export async function sweepFailedEvents(
     };
 
     let userMessageId: string | undefined;
+    logSlackReplayAttempt(event.id, slackProcessingReplayContext);
     try {
       const result = await processMessage(event.conversationId, content, {
         attachmentIds,
@@ -326,16 +399,28 @@ export async function sweepFailedEvents(
         "Successfully replayed failed channel event",
       );
     } catch (err) {
-      log.error({ err, eventId: event.id }, "Retry failed for channel event");
+      log.error(
+        {
+          err,
+          eventId: event.id,
+          ...(slackProcessingReplayContext
+            ? slackReplayLogFields(event.id, slackProcessingReplayContext)
+            : {}),
+        },
+        "Retry failed for channel event",
+      );
       if (slackDmTextDelivery) {
         await slackDmTextDelivery.waitForPendingDeliveries();
       }
-      recordProcessingFailure(event.id, err);
+      recordProcessingFailure(event.id, err, slackProcessingReplayContext);
       continue;
     }
 
     if (replyCallbackUrl) {
       if (externalChatId) {
+        const slackProcessingDeliveryContext = slackProcessingReplayContext
+          ? { ...slackProcessingReplayContext, stage: "callback_delivery" }
+          : undefined;
         try {
           if (slackDmTextDelivery) {
             await slackDmTextDelivery.waitForPendingDeliveries();
@@ -369,10 +454,16 @@ export async function sweepFailedEvents(
           markDeliveryDelivered(event.id);
         } catch (err) {
           log.error(
-            { err, eventId: event.id },
+            {
+              err,
+              eventId: event.id,
+              ...(slackProcessingDeliveryContext
+                ? slackReplayLogFields(event.id, slackProcessingDeliveryContext)
+                : {}),
+            },
             "Retry delivery failed for channel event",
           );
-          recordDeliveryFailure(event.id, err);
+          recordDeliveryFailure(event.id, err, slackProcessingDeliveryContext);
         }
       }
     }
@@ -398,6 +489,13 @@ export async function sweepFailedEvents(
       continue;
     }
 
+    const slackDeliveryReplayContext = buildSlackReplayContext(
+      parseChannelId(payload.sourceChannel) ?? "",
+      payload,
+      "delivery_retry",
+      "redeliver_existing_reply",
+      "callback_delivery",
+    );
     const replyCallbackUrl =
       typeof payload.replyCallbackUrl === "string"
         ? payload.replyCallbackUrl
@@ -416,6 +514,7 @@ export async function sweepFailedEvents(
       recordDeliveryFailure(
         event.id,
         new Error("Stored payload is missing delivery callback details"),
+        slackDeliveryReplayContext,
       );
       continue;
     }
@@ -432,10 +531,12 @@ export async function sweepFailedEvents(
       recordDeliveryFailure(
         event.id,
         new Error("Stored payload is missing assistant reply message id"),
+        slackDeliveryReplayContext,
       );
       continue;
     }
 
+    logSlackReplayAttempt(event.id, slackDeliveryReplayContext);
     try {
       await deliverReplyViaCallback(
         event.conversationId,
@@ -452,10 +553,16 @@ export async function sweepFailedEvents(
       markDeliveryDelivered(event.id);
     } catch (err) {
       log.error(
-        { err, eventId: event.id },
+        {
+          err,
+          eventId: event.id,
+          ...(slackDeliveryReplayContext
+            ? slackReplayLogFields(event.id, slackDeliveryReplayContext)
+            : {}),
+        },
         "Retry delivery failed for processed channel event",
       );
-      recordDeliveryFailure(event.id, err);
+      recordDeliveryFailure(event.id, err, slackDeliveryReplayContext);
     }
   }
 }

--- a/assistant/src/runtime/channel-retry-sweep.ts
+++ b/assistant/src/runtime/channel-retry-sweep.ts
@@ -418,9 +418,13 @@ export async function sweepFailedEvents(
 
     if (replyCallbackUrl) {
       if (externalChatId) {
-        const slackProcessingDeliveryContext = slackProcessingReplayContext
-          ? { ...slackProcessingReplayContext, stage: "callback_delivery" }
-          : undefined;
+        const slackProcessingDeliveryContext: ReplayFailureContext | undefined =
+          slackProcessingReplayContext
+            ? {
+                ...slackProcessingReplayContext,
+                stage: "callback_delivery",
+              }
+            : undefined;
         try {
           if (slackDmTextDelivery) {
             await slackDmTextDelivery.waitForPendingDeliveries();


### PR DESCRIPTION
## Summary
- add richer Slack retry and dead-letter diagnostics for replayed channel events
- preserve failure metadata that distinguishes generation failures from callback-delivery failures
- cover the new replay diagnostics with focused retry-sweep tests

Part of plan: slack-messaging-reliability.md (PR 1 of 6)