### PR TITLE
Prevent Slack update failures from falling back to new postMessage replies

### DIFF
--- a/assistant/src/__tests__/channel-reply-delivery.test.ts
+++ b/assistant/src/__tests__/channel-reply-delivery.test.ts
@@ -56,6 +56,7 @@ let renderedHistoryContent: RenderedHistoryStub = {
 const renderedHistoryContentQueue: RenderedHistoryStub[] = [];
 
 let deliveryFailAtIndex = -1;
+let failOnRecordedMessageTs: string | null = null;
 
 mock.module("../runtime/gateway-client.js", () => ({
   deliverChannelReply: async (
@@ -69,6 +70,12 @@ mock.module("../runtime/gateway-client.js", () => ({
       throw new Error("Simulated delivery failure (502)");
     }
     deliveryCalls.push({ callbackUrl, payload });
+    if (
+      failOnRecordedMessageTs !== null &&
+      payload.messageTs === failOnRecordedMessageTs
+    ) {
+      throw new Error("Simulated Slack update failure");
+    }
     if (nextDeliveryTs !== null) {
       const ts = nextDeliveryTs;
       // Only the first segment of a multi-segment delivery should carry
@@ -152,6 +159,7 @@ describe("channel-reply-delivery", () => {
   beforeEach(() => {
     deliveryCalls.length = 0;
     deliveryFailAtIndex = -1;
+    failOnRecordedMessageTs = null;
     conversationMessages.length = 0;
     attachmentsByMessageId.clear();
     updateMessageMetadataCalls.length = 0;
@@ -612,6 +620,26 @@ describe("channel-reply-delivery", () => {
     expect(seenTs).toEqual(["1700000000.000055"]);
   });
 
+  it("does not retry a failed Slack thread update as a second assistant message", async () => {
+    failOnRecordedMessageTs = "1700000000.000077";
+
+    await expect(
+      deliverRenderedReplyViaCallback({
+        callbackUrl:
+          "http://gateway/deliver/slack?threadTs=1700000000.000001",
+        chatId: "C123THREAD",
+        textSegments: ["Updated threaded reply."],
+        interSegmentDelayMs: 0,
+        messageTs: failOnRecordedMessageTs,
+      }),
+    ).rejects.toThrow("Simulated Slack update failure");
+
+    expect(deliveryCalls).toHaveLength(1);
+    expect(deliveryCalls[0].callbackUrl).toContain("threadTs=");
+    expect(deliveryCalls[0].payload.chatId).toBe("C123THREAD");
+    expect(deliveryCalls[0].payload.messageTs).toBe(failOnRecordedMessageTs);
+  });
+
   it("passes ephemeral and user through to each delivery call", async () => {
     await deliverRenderedReplyViaCallback({
       callbackUrl: "http://gateway/deliver/slack",
@@ -1052,6 +1080,30 @@ describe("channel-reply-delivery", () => {
       expect(parsed?.channelId).toBe("C222");
       expect(parsed?.source).toBe("slack");
       expect(parsed?.eventKind).toBe("message");
+    });
+
+    it("does not reconcile channelTs when a Slack DM update fails", async () => {
+      const messageTs = "1700000800.000444";
+      failOnRecordedMessageTs = messageTs;
+      pushPartialAssistantRow("conv-dm-update", "msg-dm-update", "D123DM");
+
+      await expect(
+        deliverReplyViaCallback(
+          "conv-dm-update",
+          "D123DM",
+          "http://gateway/deliver/slack",
+          "assistant-dm-update",
+          {
+            messageId: "msg-dm-update",
+            messageTs,
+          },
+        ),
+      ).rejects.toThrow("Simulated Slack update failure");
+
+      expect(deliveryCalls).toHaveLength(1);
+      expect(deliveryCalls[0].payload.chatId).toBe("D123DM");
+      expect(deliveryCalls[0].payload.messageTs).toBe(messageTs);
+      expect(updateMessageMetadataCalls).toHaveLength(0);
     });
   });
 });

--- a/assistant/src/messaging/providers/slack/send.ts
+++ b/assistant/src/messaging/providers/slack/send.ts
@@ -150,33 +150,51 @@ export async function sendSlackReply(
     typeof options?.messageTs === "string" && options.messageTs.length > 0;
 
   if (isUpdate) {
+    const messageTs = options!.messageTs;
     const updateBody: Record<string, unknown> = {
       channel: chatId,
       text,
-      ts: options!.messageTs,
+      ts: messageTs,
     };
     if (blocks.length > 0) updateBody.blocks = blocks;
 
     try {
       const result = await callSlackApi("chat.update", updateBody);
-      log.info(
-        { chatId, messageTs: options!.messageTs },
-        "Slack message updated",
-      );
-      return { ok: true, ts: result.ts };
+      log.info({ chatId, messageTs }, "Slack message updated");
+      return { ok: true, ts: result.ts ?? messageTs };
     } catch (err) {
-      if (err instanceof SlackApiError && err.slackError === "invalid_blocks") {
+      if (
+        err instanceof SlackApiError &&
+        err.slackError === "invalid_blocks" &&
+        Array.isArray(updateBody.blocks) &&
+        updateBody.blocks.length > 0
+      ) {
         log.warn(
-          { chatId, messageTs: options!.messageTs },
-          "chat.update returned invalid_blocks; falling back to chat.postMessage without blocks",
+          { chatId, messageTs },
+          "chat.update returned invalid_blocks; retrying chat.update without blocks",
         );
-        delete slackBody.blocks;
-      } else {
-        log.warn(
-          { chatId, messageTs: options!.messageTs },
-          "Slack chat.update failed, falling back to chat.postMessage",
-        );
+        delete updateBody.blocks;
+        try {
+          const retryResult = await callSlackApi("chat.update", updateBody);
+          log.info(
+            { chatId, messageTs },
+            "Slack message updated without blocks after invalid_blocks",
+          );
+          return { ok: true, ts: retryResult.ts ?? messageTs };
+        } catch (retryErr) {
+          log.warn(
+            { err: retryErr, chatId, messageTs },
+            "Slack chat.update retry without blocks failed",
+          );
+          throw retryErr;
+        }
       }
+
+      log.warn(
+        { err, chatId, messageTs },
+        "Slack chat.update failed",
+      );
+      throw err;
     }
   }
 


### PR DESCRIPTION
## Summary
- stop Slack update attempts from degrading into new postMessage replies
- keep safe invalid_blocks retry behavior for updates
- add regression coverage for duplicate-reply prevention

Part of plan: slack-messaging-reliability.md (PR 4 of 6)