### PR TITLE
feat: add platform gating to logs section (system events + emails)

### DIFF
--- a/apps/web/src/domains/logs/components/emails-tab.tsx
+++ b/apps/web/src/domains/logs/components/emails-tab.tsx
@@ -14,6 +14,7 @@ import type {
   EmailAddressUsage,
   EmailMessage,
 } from "@/generated/api/types.gen";
+import type { PlatformGateState } from "@/hooks/use-platform-gate";
 import { routes } from "@/utils/routes";
 
 function formatTimestamp(iso: string): string {
@@ -187,29 +188,34 @@ function EmailRow({ email }: { email: EmailMessage }) {
 
 interface EmailsTabProps {
   assistantId: string;
+  platformGate: PlatformGateState;
 }
 
-export function EmailsTab({ assistantId }: EmailsTabProps) {
-  const addressesQuery = useQuery(
-    assistantsEmailAddressesListOptions({
+export function EmailsTab({ assistantId, platformGate }: EmailsTabProps) {
+  const gateEnabled = platformGate === "full";
+
+  const addressesQuery = useQuery({
+    ...assistantsEmailAddressesListOptions({
       path: { assistant_id: assistantId },
     }),
-  );
+    enabled: gateEnabled,
+  });
   const address = addressesQuery.data?.results?.[0];
 
   const statusQuery = useQuery({
     ...assistantsEmailAddressesStatusRetrieveOptions({
       path: { assistant_id: assistantId, id: address?.id ?? "" },
     }),
-    enabled: !!address?.id,
+    enabled: gateEnabled && !!address?.id,
   });
 
-  const emailsQuery = useQuery(
-    assistantsEmailsListOptions({
+  const emailsQuery = useQuery({
+    ...assistantsEmailsListOptions({
       path: { assistant_id: assistantId },
       query: { limit: 10 },
     }),
-  );
+    enabled: gateEnabled,
+  });
 
   const usage: EmailAddressUsage | undefined = statusQuery.data?.usage;
   const emails: EmailMessage[] = emailsQuery.data?.results ?? [];

--- a/apps/web/src/domains/logs/logs-layout.tsx
+++ b/apps/web/src/domains/logs/logs-layout.tsx
@@ -1,20 +1,30 @@
 import { useMemo } from "react";
 import { Outlet, useLocation } from "react-router";
 
+import { usePlatformGate } from "@/hooks/use-platform-gate";
 import { routes } from "@/utils/routes";
 import { LOGS_SIDEBAR } from "@/domains/logs/navigation";
 import { SidebarShell } from "@/components/sidebar-shell";
 import { SidebarTree } from "@/components/sidebar-tree";
 
-/**
- * React Router layout route for `/assistant/logs/*`.
- *
- * Renders the SidebarShell (full-screen overlay with sidebar navigation)
- * and an `<Outlet />` for the active logs tab page. Uses the same shell
- * component as Settings for visual consistency.
- */
 export function LogsLayout() {
+  const systemEventsGate = usePlatformGate({ platformHostedOnly: true });
+  const emailsGate = usePlatformGate();
   const { pathname } = useLocation();
+
+  const filteredItems = useMemo(
+    () =>
+      LOGS_SIDEBAR.filter((item) => {
+        if (item.id === "system-events" && systemEventsGate === "gated") {
+          return false;
+        }
+        if (item.id === "emails" && emailsGate === "gated") {
+          return false;
+        }
+        return true;
+      }),
+    [systemEventsGate, emailsGate],
+  );
 
   const pageTitle = useMemo(() => {
     const match = LOGS_SIDEBAR.find(
@@ -22,8 +32,6 @@ export function LogsLayout() {
         pathname === item.href || pathname.startsWith(item.href + "/"),
     );
     if (match) return match.label;
-    // Index route (/assistant/logs) renders UsagePage but doesn't match
-    // any sidebar href — use the first sidebar item's label.
     if (pathname === routes.logs.root) {
       return LOGS_SIDEBAR[0]?.label ?? "Logs & Usage";
     }
@@ -33,7 +41,7 @@ export function LogsLayout() {
   return (
     <SidebarShell
       backHref={routes.assistant}
-      sidebar={<SidebarTree items={LOGS_SIDEBAR} />}
+      sidebar={<SidebarTree items={filteredItems} />}
       title={pageTitle}
       menuRoute={routes.logs.root}
     >

--- a/apps/web/src/domains/logs/pages/emails-page.tsx
+++ b/apps/web/src/domains/logs/pages/emails-page.tsx
@@ -1,12 +1,30 @@
+import { Navigate } from "react-router";
+
+import { Notice } from "@vellum/design-library/components/notice";
+import { usePlatformGate } from "@/hooks/use-platform-gate";
 import { useCurrentPlatformAssistant } from "@/hooks/use-current-platform-assistant";
 import { EmailsTab } from "@/domains/logs/components/emails-tab";
+import { routes } from "@/utils/routes";
 
 export function EmailsPage() {
+  const platformGate = usePlatformGate();
   const { assistantId } = useCurrentPlatformAssistant();
+
+  if (platformGate === "gated") {
+    return <Navigate replace to={routes.logs.root} />;
+  }
+
+  if (platformGate === "disabled") {
+    return (
+      <Notice tone="info">
+        Log in to the Vellum platform to view emails.
+      </Notice>
+    );
+  }
 
   if (!assistantId) {
     return null;
   }
 
-  return <EmailsTab assistantId={assistantId} />;
+  return <EmailsTab assistantId={assistantId} platformGate={platformGate} />;
 }

--- a/apps/web/src/domains/logs/pages/system-events-page.tsx
+++ b/apps/web/src/domains/logs/pages/system-events-page.tsx
@@ -1,8 +1,50 @@
+import { Loader2 } from "lucide-react";
+import { Navigate } from "react-router";
+
+import { Notice } from "@vellum/design-library/components/notice";
+import {
+  useActiveAssistantIsPlatformHosted,
+  useActiveAssistantLifecycleIsLoading,
+  usePlatformGate,
+} from "@/hooks/use-platform-gate";
 import { useCurrentPlatformAssistant } from "@/hooks/use-current-platform-assistant";
 import { SystemEventsTab } from "@/domains/logs/components/system-events-tab";
+import { routes } from "@/utils/routes";
 
 export function SystemEventsPage() {
+  const platformGate = usePlatformGate({ platformHostedOnly: true });
+  const isPlatformHosted = useActiveAssistantIsPlatformHosted();
+  const isLifecycleLoading = useActiveAssistantLifecycleIsLoading();
   const { assistantId } = useCurrentPlatformAssistant();
+
+  if (platformGate === "gated") {
+    return <Navigate replace to={routes.logs.root} />;
+  }
+
+  if (platformGate === "disabled") {
+    return (
+      <Notice tone="info">
+        Log in to the Vellum platform to view system events.
+      </Notice>
+    );
+  }
+
+  if (isLifecycleLoading) {
+    return (
+      <div className="flex items-center gap-2 py-6 text-body-medium-lighter text-[var(--content-secondary)]">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Loading system events…
+      </div>
+    );
+  }
+
+  if (!isPlatformHosted) {
+    return (
+      <Notice tone="warning">
+        System events aren&apos;t available for the current assistant.
+      </Notice>
+    );
+  }
 
   if (!assistantId) {
     return null;


### PR DESCRIPTION
## Summary
- Gate **System Events** page with `platformHostedOnly: true` — redirect when self-hosted, login Notice when no platform session, lifecycle-loading spinner during race window, terminal non-hosted Notice for resolved non-hosted states. Sidebar item hidden when gated.
- Gate **Emails** page with standard `usePlatformGate()` — redirect when FF off (Case 5 "Decouple" maps to "gated" until daemon decoupling is done), login Notice when no session. All 3 email queries gated with `enabled: platformGate === "full"`. Sidebar item hidden when gated.
- Add sidebar filtering to `LogsLayout` with two independent gate hooks (system events uses `platformHostedOnly`, emails uses standard), matching the `settings-layout.tsx` pattern.

## Original prompt
Part of the Web UI Platform Decoupling effort. The Notion spec inventories all platform-dependent UI surfaces with behavior across 5 user states (platform-hosted logged in/out, self-hosted with FF on/off, self-hosted FF off). System events are lifecycle/upgrade/crash events from the platform API — only meaningful for platform-hosted assistants, so gated in all self-hosted states. Emails use platform OpenAPI endpoints but are useful in self-hosted + FF ON states; Case 5 (FF off) is spec'd as "Decouple" but maps to "gated" until daemon email routes are decoupled from the platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)