### PR TITLE
feat(macos): harden bun bundling with codesigning, checksums, and cross-compile support

### DIFF
--- a/apps/macos/electron-builder.yml
+++ b/apps/macos/electron-builder.yml
@@ -6,6 +6,7 @@ extraResources:
   - from: resources/bun
     to: bun
   # TODO(LUM-2192): Stage web renderer (apps/web/dist) for packaged builds.
+afterPack: ./scripts/afterPack.js
 mac:
   category: public.app-category.productivity
   target:

--- a/apps/macos/package.json
+++ b/apps/macos/package.json
@@ -17,7 +17,7 @@
     "test": "bun test",
     "test:ci": "bun scripts/run-tests.ts",
     "build:fetch-bun": "bash scripts/fetch-bun.sh",
-    "pack": "bun run build:fetch-bun && electron-vite build && electron-builder"
+    "pack": "bash scripts/fetch-bun.sh --arch aarch64 && electron-vite build && electron-builder"
   },
   "devDependencies": {
     "@types/bun": "1.3.14",

--- a/apps/macos/package.json
+++ b/apps/macos/package.json
@@ -16,7 +16,8 @@
     "typecheck": "bunx tsc --noEmit",
     "test": "bun test",
     "test:ci": "bun scripts/run-tests.ts",
-    "build:fetch-bun": "bash scripts/fetch-bun.sh"
+    "build:fetch-bun": "bash scripts/fetch-bun.sh",
+    "pack": "bun run build:fetch-bun && electron-vite build && electron-builder"
   },
   "devDependencies": {
     "@types/bun": "1.3.14",

--- a/apps/macos/scripts/afterPack.js
+++ b/apps/macos/scripts/afterPack.js
@@ -1,0 +1,35 @@
+// Codesign the bundled bun binary with JIT/network entitlements (macOS hardened runtime).
+const { execSync } = require("child_process");
+const path = require("path");
+const fs = require("fs");
+
+/** @param {import("electron-builder").AfterPackContext} context */
+exports.default = async function afterPack(context) {
+  if (process.platform !== "darwin") {
+    return;
+  }
+
+  const { appOutDir, packager } = context;
+  const productName = packager.appInfo.productFilename;
+  const bunPath = path.join(
+    appOutDir,
+    `${productName}.app`,
+    "Contents",
+    "Resources",
+    "bun"
+  );
+
+  if (!fs.existsSync(bunPath)) {
+    console.warn(`afterPack: bun binary not found at ${bunPath}, skipping codesign`);
+    return;
+  }
+
+  const entitlements = path.join(__dirname, "entitlements", "bun.plist");
+  const identity = process.env.CSC_NAME || process.env.APPLE_SIGNING_IDENTITY || "-";
+
+  console.log(`afterPack: codesigning bun binary with identity="${identity}"`);
+  execSync(
+    `codesign --force --sign "${identity}" --entitlements "${entitlements}" "${bunPath}"`,
+    { stdio: "inherit" }
+  );
+};

--- a/apps/macos/scripts/bun-checksums.sha256
+++ b/apps/macos/scripts/bun-checksums.sha256
@@ -1,0 +1,6 @@
+# SHA-256 checksums for bun release zips (bun v1.3.11).
+# When bumping the bun version in .tool-versions, update these checksums
+# from the SHASUMS256.txt in the corresponding GitHub release:
+# https://github.com/oven-sh/bun/releases/tag/bun-v<VERSION>
+6f5a3467ed9caec4795bf78cd476507d9f870c7d57b86c945fcb338126772ffc  bun-darwin-aarch64.zip
+c4fe2b9247218b0295f24e895aaec8fee62e74452679a9026b67eacbd611a286  bun-darwin-x64.zip

--- a/apps/macos/scripts/entitlements/bun.plist
+++ b/apps/macos/scripts/entitlements/bun.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+</dict>
+</plist>

--- a/apps/macos/scripts/fetch-bun.sh
+++ b/apps/macos/scripts/fetch-bun.sh
@@ -125,12 +125,20 @@ fetch_single_bun() {
 
 DEST="$RESOURCES_DIR/bun"
 
-# For non-universal builds, check if existing binary already matches
+# For non-universal builds, check if existing binary matches version AND architecture
 if [ "$TARGET_ARCH" != "universal" ] && [ -x "$DEST" ]; then
   CURRENT_VERSION=$("$DEST" --version 2>/dev/null || echo "")
   if [ "$CURRENT_VERSION" = "$BUN_VERSION" ]; then
-    echo "bun $BUN_VERSION already present at $DEST — skipping download."
-    exit 0
+    CURRENT_ARCHS=$(lipo -archs "$DEST" 2>/dev/null || echo "")
+    case "$TARGET_ARCH" in
+      aarch64) EXPECTED_ARCH="arm64" ;;
+      x64)     EXPECTED_ARCH="x86_64" ;;
+    esac
+    if [ "$CURRENT_ARCHS" = "$EXPECTED_ARCH" ]; then
+      echo "bun $BUN_VERSION ($TARGET_ARCH) already present at $DEST — skipping download."
+      exit 0
+    fi
+    echo "bun $BUN_VERSION present but wrong arch (have $CURRENT_ARCHS, need $EXPECTED_ARCH) — re-fetching."
   fi
 fi
 

--- a/apps/macos/scripts/fetch-bun.sh
+++ b/apps/macos/scripts/fetch-bun.sh
@@ -3,10 +3,18 @@
 # apps/macos/resources/bun for bundling via electron-builder.
 #
 # Mirrors the pattern in clients/macos/build.sh (fetch_bundled_bun).
+#
+# Usage:
+#   bash scripts/fetch-bun.sh [--arch <aarch64|x64|universal>]
+#
+# When --arch is omitted the script detects from `uname -m` (suitable for
+# local dev where host == target). CI should pass --arch explicitly to avoid
+# shipping the wrong binary when building x64 on ARM runners (or vice versa).
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RESOURCES_DIR="$SCRIPT_DIR/../resources"
+CHECKSUMS_FILE="$SCRIPT_DIR/bun-checksums.sha256"
 
 # Parse bun version from the repo-root .tool-versions
 TOOL_VERSIONS="$SCRIPT_DIR/../../../.tool-versions"
@@ -16,61 +24,144 @@ if [ -z "$BUN_VERSION" ]; then
   exit 1
 fi
 
-# If the binary already exists and matches the expected version, skip download
-if [ -x "$RESOURCES_DIR/bun" ]; then
-  CURRENT_VERSION=$("$RESOURCES_DIR/bun" --version 2>/dev/null || echo "")
+# --- Argument parsing ---
+TARGET_ARCH=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --arch)
+      TARGET_ARCH="$2"
+      shift 2
+      ;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      echo "Usage: fetch-bun.sh [--arch <aarch64|x64|universal>]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Default to host architecture when --arch is not specified
+if [ -z "$TARGET_ARCH" ]; then
+  HOST_ARCH=$(uname -m)
+  case "$HOST_ARCH" in
+    aarch64|arm64) TARGET_ARCH="aarch64" ;;
+    x86_64)        TARGET_ARCH="x64" ;;
+    *)
+      echo "ERROR: unsupported host architecture: $HOST_ARCH" >&2
+      exit 1
+      ;;
+  esac
+fi
+
+# --- Helper functions ---
+
+verify_checksum() {
+  local zip_path="$1"
+  local platform="$2"
+
+  if [ ! -f "$CHECKSUMS_FILE" ]; then
+    echo "WARNING: checksums file not found at $CHECKSUMS_FILE — skipping verification" >&2
+    return 0
+  fi
+
+  local expected
+  expected=$(grep "bun-${platform}.zip" "$CHECKSUMS_FILE" | awk '{ print $1 }')
+  if [ -z "$expected" ]; then
+    echo "WARNING: no checksum entry for bun-${platform}.zip — skipping verification" >&2
+    return 0
+  fi
+
+  local actual
+  actual=$(shasum -a 256 "$zip_path" | awk '{ print $1 }')
+  if [ "$actual" != "$expected" ]; then
+    echo "ERROR: checksum mismatch for bun-${platform}.zip" >&2
+    echo "  expected: $expected" >&2
+    echo "  actual:   $actual" >&2
+    exit 1
+  fi
+  echo "Checksum verified for bun-${platform}.zip"
+}
+
+fetch_single_bun() {
+  local platform="$1"
+  local dest="$2"
+
+  local url="https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-${platform}.zip"
+  echo "Downloading bun ${BUN_VERSION} (${platform})..."
+
+  local tmpdir
+  tmpdir=$(mktemp -d)
+
+  local zip_path="$tmpdir/bun.zip"
+  if ! curl --fail --location --retry 3 --retry-delay 2 --connect-timeout 30 \
+          --output "$zip_path" "$url"; then
+    echo "ERROR: failed to download bun binary from $url" >&2
+    rm -rf "$tmpdir"
+    exit 1
+  fi
+
+  verify_checksum "$zip_path" "$platform"
+
+  if ! unzip -o -q "$zip_path" -d "$tmpdir"; then
+    echo "ERROR: failed to extract bun zip" >&2
+    rm -rf "$tmpdir"
+    exit 1
+  fi
+
+  local extracted="$tmpdir/bun-${platform}/bun"
+  if [ ! -f "$extracted" ]; then
+    echo "ERROR: bun binary missing after extraction at $extracted" >&2
+    rm -rf "$tmpdir"
+    exit 1
+  fi
+
+  mkdir -p "$(dirname "$dest")"
+  cp "$extracted" "$dest"
+  chmod +x "$dest"
+  rm -rf "$tmpdir"
+}
+
+# --- Main ---
+
+DEST="$RESOURCES_DIR/bun"
+
+# For non-universal builds, check if existing binary already matches
+if [ "$TARGET_ARCH" != "universal" ] && [ -x "$DEST" ]; then
+  CURRENT_VERSION=$("$DEST" --version 2>/dev/null || echo "")
   if [ "$CURRENT_VERSION" = "$BUN_VERSION" ]; then
-    echo "bun $BUN_VERSION already present at $RESOURCES_DIR/bun — skipping download."
+    echo "bun $BUN_VERSION already present at $DEST — skipping download."
     exit 0
   fi
 fi
 
-# Detect architecture from the build host. This is intentional for local-dev
-# builds where host == target. For cross-compilation (e.g. building arm64 on
-# x64 CI), this must be replaced with an explicit target-arch parameter — the
-# full pattern lives in clients/macos/build.sh (fetch_bundled_bun), which
-# accepts aarch64|x64|universal. That will be wired up alongside universal
-# build and CI packaging support.
-ARCH=$(uname -m)
-case "$ARCH" in
-  aarch64|arm64)
-    PLATFORM="darwin-aarch64"
+mkdir -p "$RESOURCES_DIR"
+
+case "$TARGET_ARCH" in
+  aarch64)
+    fetch_single_bun "darwin-aarch64" "$DEST"
     ;;
-  x86_64)
-    PLATFORM="darwin-x64"
+  x64)
+    fetch_single_bun "darwin-x64" "$DEST"
+    ;;
+  universal)
+    # Download both architectures and combine via lipo (fat Mach-O)
+    TMPDIR_LIPO=$(mktemp -d)
+    trap 'rm -rf "$TMPDIR_LIPO"' EXIT
+
+    fetch_single_bun "darwin-aarch64" "$TMPDIR_LIPO/bun-arm64"
+    fetch_single_bun "darwin-x64" "$TMPDIR_LIPO/bun-x64"
+
+    echo "Creating universal binary via lipo..."
+    if ! lipo -create "$TMPDIR_LIPO/bun-arm64" "$TMPDIR_LIPO/bun-x64" -output "$DEST"; then
+      echo "ERROR: lipo failed to create universal bun binary" >&2
+      exit 1
+    fi
+    chmod +x "$DEST"
     ;;
   *)
-    echo "ERROR: unsupported architecture: $ARCH" >&2
+    echo "ERROR: unsupported target arch: $TARGET_ARCH (use aarch64|x64|universal)" >&2
     exit 1
     ;;
 esac
 
-URL="https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-${PLATFORM}.zip"
-echo "Downloading bun ${BUN_VERSION} (${PLATFORM})..."
-
-TMPDIR_DL=$(mktemp -d)
-trap 'rm -rf "$TMPDIR_DL"' EXIT
-
-ZIP_PATH="$TMPDIR_DL/bun.zip"
-if ! curl --fail --location --retry 3 --retry-delay 2 --connect-timeout 30 \
-        --output "$ZIP_PATH" "$URL"; then
-  echo "ERROR: failed to download bun binary from $URL" >&2
-  exit 1
-fi
-
-if ! unzip -o -q "$ZIP_PATH" -d "$TMPDIR_DL"; then
-  echo "ERROR: failed to extract bun zip" >&2
-  exit 1
-fi
-
-EXTRACTED="$TMPDIR_DL/bun-${PLATFORM}/bun"
-if [ ! -f "$EXTRACTED" ]; then
-  echo "ERROR: bun binary missing after extraction at $EXTRACTED" >&2
-  exit 1
-fi
-
-mkdir -p "$RESOURCES_DIR"
-cp "$EXTRACTED" "$RESOURCES_DIR/bun"
-chmod +x "$RESOURCES_DIR/bun"
-
-echo "bun ${BUN_VERSION} installed to $RESOURCES_DIR/bun"
+echo "bun ${BUN_VERSION} (${TARGET_ARCH}) installed to $DEST"


### PR DESCRIPTION
## Summary
- Add `afterPack.js` hook that codesigns the bundled bun binary with JIT/network entitlements required for macOS hardened runtime
- Add SHA-256 checksum verification to `fetch-bun.sh` using checksums from the official bun GitHub release
- Add `--arch <aarch64|x64|universal>` argument to `fetch-bun.sh` for CI cross-compilation (defaults to host arch for local dev)
- Add `pack` script that chains `build:fetch-bun` → `electron-vite build` → `electron-builder`

## Original prompt
During an inventory of what the Electron app needs to bundle vs lazily install, we identified four gaps in the bun binary bundling approach: (1) no codesigning with entitlements — bun can't JIT under hardened runtime without them, (2) no wired-up pack script, (3) no checksum verification on the downloaded binary, (4) no cross-compilation support for CI. This PR addresses all four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)