### PR TITLE
feat(macos): serve renderer from installed @vellumai/web package

### DIFF
--- a/apps/macos/electron-builder.yml
+++ b/apps/macos/electron-builder.yml
@@ -5,7 +5,6 @@ directories:
 extraResources:
   - from: resources/bun
     to: bun
-  # TODO(LUM-2192): Stage web renderer (apps/web/dist) for packaged builds.
 afterPack: ./scripts/afterPack.js
 mac:
   category: public.app-category.productivity

--- a/apps/macos/src/main/cli-installer.test.ts
+++ b/apps/macos/src/main/cli-installer.test.ts
@@ -25,14 +25,17 @@ mock.module("electron", () => ({
 }));
 
 // Track fs calls so tests can assert on them.
-let existsSyncReturn = false;
+// Per-path overrides for existsSync. Falls back to `existsSyncDefault`.
+let existsSyncDefault = false;
+const existsSyncByPath: Record<string, boolean> = {};
 let readdirSyncReturn: Array<{ name: string; isDirectory: () => boolean }> = [];
 let readdirSyncError: Error | null = null;
 const mkdirSyncCalls: Array<[string, object]> = [];
 const rmSyncCalls: Array<[string, object]> = [];
 
 mock.module("node:fs", () => ({
-  existsSync: () => existsSyncReturn,
+  existsSync: (p: string) =>
+    p in existsSyncByPath ? existsSyncByPath[p] : existsSyncDefault,
   mkdirSync: (p: string, opts: object) => {
     mkdirSyncCalls.push([p, opts]);
   },
@@ -64,14 +67,18 @@ const {
   getCliInstallDir,
   getCliBinPath,
   getBundledBunPath,
+  getWebDistPath,
+  isWebInstalled,
   isCliInstalled,
+  ensureWebInstalled,
   ensureCliInstalled,
   cleanupOldVersions,
   _resetInstallLock,
 } = await import("./cli-installer");
 
 afterEach(() => {
-  existsSyncReturn = false;
+  existsSyncDefault = false;
+  for (const key of Object.keys(existsSyncByPath)) delete existsSyncByPath[key];
   readdirSyncReturn.length = 0;
   readdirSyncError = null;
   mkdirSyncCalls.length = 0;
@@ -104,17 +111,92 @@ describe("getBundledBunPath", () => {
   });
 });
 
+describe("getWebDistPath", () => {
+  test("returns <installDir>/node_modules/@vellumai/web/dist", () => {
+    expect(getWebDistPath()).toBe(
+      `${userDataPath}/cli/${PINNED_CLI_VERSION}/node_modules/@vellumai/web/dist`,
+    );
+  });
+});
+
+// --- isWebInstalled ---
+
+describe("isWebInstalled", () => {
+  test("returns true when web dist/index.html exists", () => {
+    existsSyncByPath[`${userDataPath}/cli/${PINNED_CLI_VERSION}/node_modules/@vellumai/web/dist/index.html`] = true;
+    expect(isWebInstalled()).toBe(true);
+  });
+
+  test("returns false when web dist is missing", () => {
+    existsSyncDefault = false;
+    expect(isWebInstalled()).toBe(false);
+  });
+});
+
 // --- isCliInstalled ---
 
 describe("isCliInstalled", () => {
   test("returns true when the bin path exists", () => {
-    existsSyncReturn = true;
+    existsSyncDefault = true;
     expect(isCliInstalled()).toBe(true);
   });
 
   test("returns false when the bin path is missing", () => {
-    existsSyncReturn = false;
+    existsSyncDefault = false;
     expect(isCliInstalled()).toBe(false);
+  });
+});
+
+// --- ensureWebInstalled ---
+
+describe("ensureWebInstalled", () => {
+  test("skips install when web dist already exists", async () => {
+    existsSyncByPath[`${userDataPath}/cli/${PINNED_CLI_VERSION}/node_modules/@vellumai/web/dist/index.html`] = true;
+    await ensureWebInstalled();
+    expect(spawnCalls).toHaveLength(0);
+  });
+
+  test("spawns bun add @vellumai/web with correct args", async () => {
+    existsSyncDefault = false;
+
+    const promise = ensureWebInstalled();
+    lastChild.emit("close", 0);
+    await promise;
+
+    expect(spawnCalls).toHaveLength(1);
+    const [cmd, args, opts] = spawnCalls[0];
+    expect(cmd).toBe(`${mockResourcesPath}/bun`);
+    expect(args).toEqual(["add", `@vellumai/web@${PINNED_CLI_VERSION}`]);
+    expect(opts).toEqual({
+      cwd: `${userDataPath}/cli/${PINNED_CLI_VERSION}`,
+    });
+  });
+
+  test("concurrent calls share a single install", async () => {
+    existsSyncDefault = false;
+
+    const p1 = ensureWebInstalled();
+    const p2 = ensureWebInstalled();
+
+    expect(spawnCalls).toHaveLength(1);
+
+    lastChild.emit("close", 0);
+    await Promise.all([p1, p2]);
+  });
+
+  test("failed install resets the lock so retries are possible", async () => {
+    existsSyncDefault = false;
+
+    const p1 = ensureWebInstalled();
+    lastChild.stderr.emit("data", Buffer.from("network error"));
+    lastChild.emit("close", 1);
+
+    await expect(p1).rejects.toThrow(/Package install failed/);
+
+    const p2 = ensureWebInstalled();
+    expect(spawnCalls).toHaveLength(2);
+    lastChild.emit("close", 0);
+    await p2;
   });
 });
 
@@ -122,13 +204,13 @@ describe("isCliInstalled", () => {
 
 describe("ensureCliInstalled", () => {
   test("skips install when already installed", async () => {
-    existsSyncReturn = true;
+    existsSyncDefault = true;
     await ensureCliInstalled();
     expect(spawnCalls).toHaveLength(0);
   });
 
   test("spawns bun add with correct args and cwd", async () => {
-    existsSyncReturn = false;
+    existsSyncDefault = false;
 
     const promise = ensureCliInstalled();
 
@@ -146,7 +228,7 @@ describe("ensureCliInstalled", () => {
   });
 
   test("creates the install directory before spawning", async () => {
-    existsSyncReturn = false;
+    existsSyncDefault = false;
 
     const promise = ensureCliInstalled();
     lastChild.emit("close", 0);
@@ -159,18 +241,18 @@ describe("ensureCliInstalled", () => {
   });
 
   test("throws on non-zero exit code", async () => {
-    existsSyncReturn = false;
+    existsSyncDefault = false;
 
     const promise = ensureCliInstalled();
     lastChild.stderr.emit("data", Buffer.from("install failed"));
     lastChild.emit("close", 1);
 
-    await expect(promise).rejects.toThrow(/CLI install failed/);
+    await expect(promise).rejects.toThrow(/Package install failed/);
     await expect(promise).rejects.toThrow(/exit code 1/);
   });
 
   test("throws on spawn error", async () => {
-    existsSyncReturn = false;
+    existsSyncDefault = false;
 
     const promise = ensureCliInstalled();
     lastChild.emit("error", new Error("ENOENT"));
@@ -180,7 +262,7 @@ describe("ensureCliInstalled", () => {
   });
 
   test("calls cleanupOldVersions after successful install", async () => {
-    existsSyncReturn = false;
+    existsSyncDefault = false;
     readdirSyncReturn = [dirEntry("0.8.5"), dirEntry(PINNED_CLI_VERSION)];
 
     const promise = ensureCliInstalled();
@@ -197,7 +279,7 @@ describe("ensureCliInstalled", () => {
   });
 
   test("concurrent calls share a single install", async () => {
-    existsSyncReturn = false;
+    existsSyncDefault = false;
 
     const p1 = ensureCliInstalled();
     const p2 = ensureCliInstalled();
@@ -210,13 +292,13 @@ describe("ensureCliInstalled", () => {
   });
 
   test("failed install resets the lock so retries are possible", async () => {
-    existsSyncReturn = false;
+    existsSyncDefault = false;
 
     const p1 = ensureCliInstalled();
     lastChild.stderr.emit("data", Buffer.from("disk full"));
     lastChild.emit("close", 1);
 
-    await expect(p1).rejects.toThrow(/CLI install failed/);
+    await expect(p1).rejects.toThrow(/Package install failed/);
 
     // Second attempt should spawn a new process.
     const p2 = ensureCliInstalled();

--- a/apps/macos/src/main/cli-installer.ts
+++ b/apps/macos/src/main/cli-installer.ts
@@ -102,14 +102,7 @@ export function _resetInstallLock(): void {
   cliInstallPromise = null;
 }
 
-/**
- * Install the `@vellumai/web` renderer package if it isn't already present.
- *
- * This is the fast path — the web package is just pre-built static assets,
- * so it installs quickly and unblocks the UI. The full meta-package
- * (`vellum`) is installed lazily by `ensureCliInstalled` when local-mode
- * needs the CLI, daemon, or gateway.
- */
+/** Install just the web renderer package — fast path to unblock the UI. */
 export async function ensureWebInstalled(): Promise<void> {
   if (isWebInstalled()) return;
 

--- a/apps/macos/src/main/cli-installer.ts
+++ b/apps/macos/src/main/cli-installer.ts
@@ -26,17 +26,106 @@ export function getBundledBunPath(): string {
   return path.join(process.resourcesPath, "bun");
 }
 
+/** Absolute path to the installed `@vellumai/web` dist directory. */
+export function getWebDistPath(): string {
+  return path.join(
+    getCliInstallDir(),
+    "node_modules",
+    "@vellumai",
+    "web",
+    "dist",
+  );
+}
+
+/** Whether the web renderer package is installed. */
+export function isWebInstalled(): boolean {
+  return existsSync(path.join(getWebDistPath(), "index.html"));
+}
+
 /** Whether the pinned CLI version is already installed on disk. */
 export function isCliInstalled(): boolean {
   return existsSync(getCliBinPath());
 }
 
-// Singleton promise prevents concurrent installs from corrupting node_modules.
-let installPromise: Promise<void> | null = null;
+function bunAdd(pkg: string): Promise<void> {
+  const installDir = getCliInstallDir();
+  mkdirSync(installDir, { recursive: true });
 
-/** Reset the install lock. Exposed for testing only. */
+  const bunPath = getBundledBunPath();
+
+  return new Promise<void>((resolve, reject) => {
+    const child = spawn(bunPath, ["add", `${pkg}@${PINNED_CLI_VERSION}`], {
+      cwd: installDir,
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (data: Buffer) => {
+      stdout += data.toString();
+    });
+
+    child.stderr.on("data", (data: Buffer) => {
+      stderr += data.toString();
+    });
+
+    child.on("error", (err: Error) => {
+      reject(
+        new Error(
+          `Failed to spawn bun for package install: ${err.message}`,
+        ),
+      );
+    });
+
+    child.on("close", (code: number | null) => {
+      if (code !== 0) {
+        const detail = (stderr || stdout).trim();
+        reject(
+          new Error(
+            `Package install failed with exit code ${code ?? "unknown"}${detail ? `: ${detail}` : ""}`,
+          ),
+        );
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+// Singleton promises prevent concurrent installs from corrupting node_modules.
+let webInstallPromise: Promise<void> | null = null;
+let cliInstallPromise: Promise<void> | null = null;
+
+/** Reset the install locks. Exposed for testing only. */
 export function _resetInstallLock(): void {
-  installPromise = null;
+  webInstallPromise = null;
+  cliInstallPromise = null;
+}
+
+/**
+ * Install the `@vellumai/web` renderer package if it isn't already present.
+ *
+ * This is the fast path — the web package is just pre-built static assets,
+ * so it installs quickly and unblocks the UI. The full meta-package
+ * (`vellum`) is installed lazily by `ensureCliInstalled` when local-mode
+ * needs the CLI, daemon, or gateway.
+ */
+export async function ensureWebInstalled(): Promise<void> {
+  if (isWebInstalled()) return;
+
+  if (webInstallPromise) return webInstallPromise;
+
+  webInstallPromise = (async () => {
+    await bunAdd("@vellumai/web");
+    cleanupOldVersions();
+  })();
+
+  try {
+    await webInstallPromise;
+  } catch (err) {
+    webInstallPromise = null;
+    throw err;
+  }
 }
 
 /**
@@ -50,59 +139,17 @@ export function _resetInstallLock(): void {
 export async function ensureCliInstalled(): Promise<void> {
   if (isCliInstalled()) return;
 
-  if (installPromise) return installPromise;
+  if (cliInstallPromise) return cliInstallPromise;
 
-  installPromise = (async () => {
-    const installDir = getCliInstallDir();
-    mkdirSync(installDir, { recursive: true });
-
-    const bunPath = getBundledBunPath();
-
-    await new Promise<void>((resolve, reject) => {
-      const child = spawn(bunPath, ["add", `vellum@${PINNED_CLI_VERSION}`], {
-        cwd: installDir,
-      });
-
-      let stdout = "";
-      let stderr = "";
-
-      child.stdout.on("data", (data: Buffer) => {
-        stdout += data.toString();
-      });
-
-      child.stderr.on("data", (data: Buffer) => {
-        stderr += data.toString();
-      });
-
-      child.on("error", (err: Error) => {
-        reject(
-          new Error(
-            `Failed to spawn bun for CLI install: ${err.message}`,
-          ),
-        );
-      });
-
-      child.on("close", (code: number | null) => {
-        if (code !== 0) {
-          const detail = (stderr || stdout).trim();
-          reject(
-            new Error(
-              `CLI install failed with exit code ${code ?? "unknown"}${detail ? `: ${detail}` : ""}`,
-            ),
-          );
-          return;
-        }
-        resolve();
-      });
-    });
-
+  cliInstallPromise = (async () => {
+    await bunAdd("vellum");
     cleanupOldVersions();
   })();
 
   try {
-    await installPromise;
+    await cliInstallPromise;
   } catch (err) {
-    installPromise = null;
+    cliInstallPromise = null;
     throw err;
   }
 }

--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -11,6 +11,7 @@ import {
 
 import { installAbout, openAboutWindow } from "./about";
 import { APP_PROTOCOL } from "./app-config";
+import { ensureWebInstalled, getWebDistPath } from "./cli-installer";
 import { handle } from "./ipc";
 import { resolveAppProtocolPath } from "./app-protocol";
 import { planGatewayForward } from "./gateway-forward";
@@ -102,11 +103,17 @@ installDeepLinks();
 // parameter so the protocol handler strips it before path resolution.
 const RENDERER_MOUNT = "/assistant";
 
+const resolveRendererRoot = (): string => {
+  if (app.isPackaged) {
+    return getWebDistPath();
+  }
+  // Dev source tree: apps/web/dist — requires `bun run build` in apps/web/.
+  const repoRoot = path.resolve(app.getAppPath(), "..", "..");
+  return path.join(repoRoot, "apps", "web", "dist");
+};
+
 const registerAppProtocol = (): void => {
-  // The packaged renderer bundle lives next to the main bundle. When this app
-  // is built into an .asar/Resources/app/ tree, apps/web/dist/ is copied to
-  // ../renderer relative to the main process bundle.
-  const rendererRoot = path.join(__dirname, "../renderer");
+  const rendererRoot = resolveRendererRoot();
   const indexHtml = path.join(rendererRoot, "index.html");
   const lockfilePaths = resolveLockfilePaths(process.env);
   const getAllowedGatewayPorts = (): Set<number> =>
@@ -225,10 +232,9 @@ const installSettingsIpc = (): void => {
 
 app
   .whenReady()
-  .then(() => {
-    if (!isDev) {
-      registerAppProtocol();
-    }
+  .then(async () => {
+    // Install tray, dock, and menu before the potentially slow CLI
+    // install so the user sees the app in the menu bar immediately.
     installPermissionHandler();
     installSettingsIpc();
     installLocalMode();
@@ -241,6 +247,15 @@ app
       ensureMainWindow: ensureMainWindowVisible,
       openAbout: openAboutWindow,
     });
+
+    if (!isDev) {
+      // The renderer is served from the installed @vellumai/web package.
+      // Install just the web package (pre-built static assets) to unblock the
+      // UI as fast as possible — the full vellum meta-package installs lazily
+      // when local-mode needs the CLI/daemon/gateway.
+      await ensureWebInstalled();
+      registerAppProtocol();
+    }
     installMainWindow();
 
     // Dock-icon click / Cmd-Tab re-activation: bring the main window

--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -234,6 +234,8 @@ app
   .whenReady()
   .then(async () => {
     if (!isDev) {
+      // TODO(LUM-2214): a deep-link or second-instance activation during
+      // this await can create a window before the protocol handler exists.
       await ensureWebInstalled();
       registerAppProtocol();
     }

--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -233,8 +233,6 @@ const installSettingsIpc = (): void => {
 app
   .whenReady()
   .then(async () => {
-    // Install tray, dock, and menu before the potentially slow CLI
-    // install so the user sees the app in the menu bar immediately.
     installPermissionHandler();
     installSettingsIpc();
     installLocalMode();
@@ -249,10 +247,6 @@ app
     });
 
     if (!isDev) {
-      // The renderer is served from the installed @vellumai/web package.
-      // Install just the web package (pre-built static assets) to unblock the
-      // UI as fast as possible — the full vellum meta-package installs lazily
-      // when local-mode needs the CLI/daemon/gateway.
       await ensureWebInstalled();
       registerAppProtocol();
     }

--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -233,6 +233,10 @@ const installSettingsIpc = (): void => {
 app
   .whenReady()
   .then(async () => {
+    if (!isDev) {
+      await ensureWebInstalled();
+      registerAppProtocol();
+    }
     installPermissionHandler();
     installSettingsIpc();
     installLocalMode();
@@ -245,11 +249,6 @@ app
       ensureMainWindow: ensureMainWindowVisible,
       openAbout: openAboutWindow,
     });
-
-    if (!isDev) {
-      await ensureWebInstalled();
-      registerAppProtocol();
-    }
     installMainWindow();
 
     // Dock-icon click / Cmd-Tab re-activation: bring the main window


### PR DESCRIPTION
## Summary
- Instead of bundling the web UI into the Electron app bundle, resolve it from the lazily-installed `@vellumai/web` npm package at runtime
- Adds a two-stage install: `ensureWebInstalled()` installs just the web package (fast — pre-built static assets) to unblock the UI, while the full `vellum` meta-package installs lazily when local-mode needs the CLI/daemon/gateway
- In dev, the renderer resolves from the source tree (`apps/web/dist`) when testing the protocol handler; the Vite dev server path remains unchanged

## Original prompt
The user wanted to implement LUM-2192 (stage web renderer for packaged builds) by leveraging the published `@vellumai/web` npm package instead of bundling a duplicate copy of the web dist into the app bundle. The goal was to keep the app bundle lean and rely on the same lazy install mechanism already used for the CLI stack, with a fast first-stage install of just the renderer package to minimize time-to-UI on first launch.