### PR TITLE
Add redacted Slack history-tail diagnostics for ordering recovery

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -11,6 +11,7 @@ import type {
 import type { ContextWindowResult } from "../context/window-manager.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
 import { defaultCompactionTerminal } from "../plugins/defaults/compaction/terminal.js";
+import type { HistoryTailSnapshot } from "../plugins/defaults/history-repair/terminal.js";
 import { resetPluginRegistryAndRegisterDefaults } from "../plugins/defaults/index.js";
 import { DEFAULT_TIMEOUTS, runPipeline } from "../plugins/pipeline.js";
 import { getMiddlewaresFor } from "../plugins/registry.js";
@@ -36,9 +37,21 @@ let mockUiConfig: { userTimezone?: string; detectedTimezone?: string } = {};
 
 // ── Module mocks (must precede imports of the module under test) ─────
 
+const mockLoggerWarn = mock(() => {});
+const mockLoggerError = mock(() => {});
+const mockLoggerInfo = mock(() => {});
+const mockLoggerDebug = mock(() => {});
+const testLogger = {
+  warn: mockLoggerWarn,
+  error: mockLoggerError,
+  info: mockLoggerInfo,
+  debug: mockLoggerDebug,
+  trace: () => {},
+  child: () => testLogger,
+};
+
 mock.module("../util/logger.js", () => ({
-  getLogger: () =>
-    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+  getLogger: () => testLogger,
 }));
 
 mock.module("../config/loader.js", () => ({
@@ -419,17 +432,117 @@ mock.module("../daemon/date-context.js", () => ({
   resolveTurnTimezoneContext: resolveTurnTimezoneContextMock,
 }));
 
-mock.module("../plugins/defaults/history-repair/terminal.js", () => ({
-  repairHistory: (msgs: Message[]) => ({
-    messages: msgs,
+const repairHistoryMock = mock((msgs: Message[]) => ({
+  messages: msgs,
+  stats: {
+    assistantToolResultsMigrated: 0,
+    missingToolResultsInserted: 0,
+    orphanToolResultsDowngraded: 0,
+    consecutiveSameRoleMerged: 0,
+  },
+  diagnostics: {
     stats: {
       assistantToolResultsMigrated: 0,
       missingToolResultsInserted: 0,
       orphanToolResultsDowngraded: 0,
       consecutiveSameRoleMerged: 0,
     },
-  }),
-  deepRepairHistory: (msgs: Message[]) => ({ messages: msgs, stats: {} }),
+    actions: {
+      migratedAssistantToolResults: false,
+      insertedSyntheticToolResults: false,
+      repairedOrphanToolResults: false,
+      mergedSameRoleMessages: false,
+    },
+  },
+}));
+const deepRepairHistoryMock = mock((msgs: Message[]) => ({
+  messages: msgs,
+  stats: {
+    assistantToolResultsMigrated: 0,
+    missingToolResultsInserted: 0,
+    orphanToolResultsDowngraded: 0,
+    consecutiveSameRoleMerged: 0,
+  },
+  diagnostics: {
+    stats: {
+      assistantToolResultsMigrated: 0,
+      missingToolResultsInserted: 0,
+      orphanToolResultsDowngraded: 0,
+      consecutiveSameRoleMerged: 0,
+    },
+    actions: {
+      migratedAssistantToolResults: false,
+      insertedSyntheticToolResults: false,
+      repairedOrphanToolResults: false,
+      mergedSameRoleMessages: false,
+    },
+  },
+}));
+const getHistoryRepairDiagnosticsMock = mock(
+  (): {
+    stats: {
+      assistantToolResultsMigrated: number;
+      missingToolResultsInserted: number;
+      orphanToolResultsDowngraded: number;
+      consecutiveSameRoleMerged: number;
+    };
+    actions: {
+      migratedAssistantToolResults: boolean;
+      insertedSyntheticToolResults: boolean;
+      repairedOrphanToolResults: boolean;
+      mergedSameRoleMessages: boolean;
+    };
+  } | null => null,
+);
+const describeHistoryTailMock = mock(
+  (): {
+    totalMessages: number;
+    tailLength: number;
+    roleSequence: Message["role"][];
+    endsWithUser: boolean;
+    consecutiveSameRoleTransitions: number;
+    pairingStats: {
+      toolUseCount: number;
+      toolResultCount: number;
+      toolUsesWithoutResult: number;
+      toolResultsWithoutUse: number;
+      syntheticToolResultCount: number;
+      assistantMessagesWithToolResults: number;
+      orphanToolResultTextCount: number;
+    };
+    tail: Array<{
+      role: Message["role"];
+      blockTypes: string[];
+      textBlockCount: number;
+      toolUseCount: number;
+      toolResultCount: number;
+      syntheticToolResultCount: number;
+      orphanToolResultTextCount: number;
+      serverToolUseCount: number;
+      webSearchToolResultCount: number;
+    }>;
+  } => ({
+  totalMessages: 0,
+  tailLength: 0,
+  roleSequence: [],
+  endsWithUser: false,
+  consecutiveSameRoleTransitions: 0,
+  pairingStats: {
+    toolUseCount: 0,
+    toolResultCount: 0,
+    toolUsesWithoutResult: 0,
+    toolResultsWithoutUse: 0,
+    syntheticToolResultCount: 0,
+    assistantMessagesWithToolResults: 0,
+    orphanToolResultTextCount: 0,
+  },
+  tail: [],
+}));
+mock.module("../plugins/defaults/history-repair/terminal.js", () => ({
+  repairHistory: repairHistoryMock,
+  deepRepairHistory: deepRepairHistoryMock,
+  getHistoryRepairDiagnostics: getHistoryRepairDiagnosticsMock,
+  describeHistoryTail: describeHistoryTailMock,
 }));
 
 const recordUsageMock = mock(() => {});
@@ -853,8 +966,16 @@ beforeEach(() => {
   mockReducerStepFn = null;
   mockOverflowAction = "fail_gracefully";
   mockDiskPressureDecision = { action: "allow-normal" };
+  mockLoggerWarn.mockClear();
+  mockLoggerError.mockClear();
+  mockLoggerInfo.mockClear();
+  mockLoggerDebug.mockClear();
   classifyDiskPressureTurnPolicyMock.mockClear();
   mockInjectionBlocks = {};
+  repairHistoryMock.mockClear();
+  deepRepairHistoryMock.mockClear();
+  getHistoryRepairDiagnosticsMock.mockClear();
+  describeHistoryTailMock.mockClear();
   recordUsageMock.mockClear();
   recordRequestLogMock.mockClear();
   backfillMessageIdOnLogsMock.mockClear();
@@ -2572,6 +2693,164 @@ describe("session-agent-loop", () => {
       await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
 
       expect(callCount).toBe(2);
+    });
+
+    test("logs redacted Slack tail diagnostics for final-assistant ordering failures", async () => {
+      const events: ServerMessage[] = [];
+      let callCount = 0;
+      const rawUserText = "SLACK USER SECRET SHOULD NOT APPEAR";
+      const rawAssistantText = "assistant trailing text should stay redacted";
+      const redactedTailSnapshot: HistoryTailSnapshot = {
+        totalMessages: 3,
+        tailLength: 3,
+        roleSequence: ["user", "assistant", "assistant"],
+        endsWithUser: false,
+        consecutiveSameRoleTransitions: 1,
+        pairingStats: {
+          toolUseCount: 1,
+          toolResultCount: 0,
+          toolUsesWithoutResult: 1,
+          toolResultsWithoutUse: 0,
+          syntheticToolResultCount: 0,
+          assistantMessagesWithToolResults: 0,
+          orphanToolResultTextCount: 0,
+        },
+        tail: [
+          {
+            role: "user",
+            blockTypes: ["text"],
+            textBlockCount: 1,
+            toolUseCount: 0,
+            toolResultCount: 0,
+            syntheticToolResultCount: 0,
+            orphanToolResultTextCount: 0,
+            serverToolUseCount: 0,
+            webSearchToolResultCount: 0,
+          },
+          {
+            role: "assistant",
+            blockTypes: ["tool_use"],
+            textBlockCount: 0,
+            toolUseCount: 1,
+            toolResultCount: 0,
+            syntheticToolResultCount: 0,
+            orphanToolResultTextCount: 0,
+            serverToolUseCount: 0,
+            webSearchToolResultCount: 0,
+          },
+          {
+            role: "assistant",
+            blockTypes: ["text"],
+            textBlockCount: 1,
+            toolUseCount: 0,
+            toolResultCount: 0,
+            syntheticToolResultCount: 0,
+            orphanToolResultTextCount: 0,
+            serverToolUseCount: 0,
+            webSearchToolResultCount: 0,
+          },
+        ],
+      };
+
+      getHistoryRepairDiagnosticsMock.mockReturnValue({
+        stats: {
+          assistantToolResultsMigrated: 1,
+          missingToolResultsInserted: 1,
+          orphanToolResultsDowngraded: 0,
+          consecutiveSameRoleMerged: 1,
+        },
+        actions: {
+          migratedAssistantToolResults: true,
+          insertedSyntheticToolResults: true,
+          repairedOrphanToolResults: false,
+          mergedSameRoleMessages: true,
+        },
+      });
+      describeHistoryTailMock.mockReturnValue(redactedTailSnapshot);
+
+      const agentLoopRun: AgentLoopRun = async (messages, onEvent) => {
+        await onEvent({ type: "llm_call_started" });
+        callCount++;
+        if (callCount === 1) {
+          onEvent({
+            type: "error",
+            error: new Error(
+              "Anthropic API error (400): messages invalid order: conversation must end with a user message",
+            ),
+          });
+          onEvent({
+            type: "usage",
+            inputTokens: 100,
+            outputTokens: 0,
+            model: "test-model",
+            providerDurationMs: 50,
+          });
+          return messages;
+        }
+        onEvent({
+          type: "message_complete",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "fixed" }],
+          },
+        });
+        onEvent({
+          type: "usage",
+          inputTokens: 50,
+          outputTokens: 25,
+          model: "test-model",
+          providerDurationMs: 100,
+        });
+        return [
+          ...messages,
+          {
+            role: "assistant" as const,
+            content: [{ type: "text", text: "fixed" }] as ContentBlock[],
+          },
+        ];
+      };
+
+      const ctx = makeCtx({
+        messages: [
+          { role: "user", content: [{ type: "text", text: rawUserText }] },
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: "tool-secret",
+                name: "bash",
+                input: { cmd: "echo hidden" },
+              },
+            ],
+          },
+          {
+            role: "assistant",
+            content: [{ type: "text", text: rawAssistantText }],
+          },
+        ],
+        agentLoopRun,
+        channelCapabilities: {
+          channel: "slack",
+          dashboardCapable: false,
+          supportsDynamicUi: false,
+          supportsVoiceInput: false,
+          chatType: "im",
+        },
+        getTurnChannelContext: () => ({
+          userMessageChannel: "slack",
+          assistantMessageChannel: "slack",
+        }),
+      });
+      await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
+
+      expect(callCount).toBe(2);
+      expect(getHistoryRepairDiagnosticsMock).toHaveBeenCalledTimes(1);
+      expect(describeHistoryTailMock).toHaveBeenCalledTimes(1);
+      expect(JSON.stringify(redactedTailSnapshot)).not.toContain(rawUserText);
+      expect(JSON.stringify(redactedTailSnapshot)).not.toContain(
+        rawAssistantText,
+      );
     });
 
     test("emits deferred ordering error when retry also fails", async () => {

--- a/assistant/src/__tests__/history-repair.test.ts
+++ b/assistant/src/__tests__/history-repair.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
-import { deepRepairHistory } from "../plugins/defaults/history-repair/terminal.js";
-import { repairHistory } from "../plugins/defaults/history-repair/terminal.js";
+import {
+  deepRepairHistory,
+  describeHistoryTail,
+  getHistoryRepairDiagnostics,
+  repairHistory,
+} from "../plugins/defaults/history-repair/terminal.js";
 import type { Message } from "../providers/types.js";
 
 describe("repairHistory", () => {
@@ -928,6 +932,129 @@ describe("repairHistory", () => {
       tool_use_id: "tu_1",
       is_error: true,
     });
+  });
+
+  test("exposes structural diagnostics for repaired actions without message text", () => {
+    const userSecretA = "user secret alpha";
+    const userSecretB = "user secret beta";
+    const messages: Message[] = [
+      { role: "user", content: [{ type: "text", text: userSecretA }] },
+      { role: "user", content: [{ type: "text", text: userSecretB }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "tool_use", id: "tu_1", name: "bash", input: { cmd: "ls" } },
+          {
+            type: "tool_result",
+            tool_use_id: "tu_1",
+            content: "already captured",
+          },
+          {
+            type: "tool_use",
+            id: "tu_2",
+            name: "read",
+            input: { path: "/tmp/file.txt" },
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Trailing assistant" }],
+      },
+    ];
+
+    const result = repairHistory(messages);
+    const rememberedDiagnostics = getHistoryRepairDiagnostics(result.messages);
+
+    expect(result.diagnostics).toEqual({
+      stats: {
+        assistantToolResultsMigrated: 1,
+        missingToolResultsInserted: 1,
+        orphanToolResultsDowngraded: 0,
+        consecutiveSameRoleMerged: 1,
+      },
+      actions: {
+        migratedAssistantToolResults: true,
+        insertedSyntheticToolResults: true,
+        repairedOrphanToolResults: false,
+        mergedSameRoleMessages: true,
+      },
+    });
+    expect(rememberedDiagnostics).toEqual(result.diagnostics);
+    expect(rememberedDiagnostics).not.toBe(result.diagnostics);
+    expect(JSON.stringify(result.diagnostics)).not.toContain(userSecretA);
+    expect(JSON.stringify(result.diagnostics)).not.toContain(userSecretB);
+  });
+
+  test("describes malformed trailing assistant tails structurally without raw text", () => {
+    const rawUserText = "slack user content that should stay redacted";
+    const rawAssistantText = "assistant trailing content should stay redacted";
+    const messages: Message[] = [
+      { role: "user", content: [{ type: "text", text: rawUserText }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "tool_use", id: "tu_1", name: "bash", input: { cmd: "ls" } },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: rawAssistantText }],
+      },
+    ];
+
+    const snapshot = describeHistoryTail(messages);
+
+    expect(snapshot).toMatchObject({
+      totalMessages: 3,
+      tailLength: 3,
+      roleSequence: ["user", "assistant", "assistant"],
+      endsWithUser: false,
+      consecutiveSameRoleTransitions: 1,
+      pairingStats: {
+        toolUseCount: 1,
+        toolResultCount: 0,
+        toolUsesWithoutResult: 1,
+        toolResultsWithoutUse: 0,
+      },
+    });
+    expect(snapshot.tail).toEqual([
+      {
+        role: "user",
+        blockTypes: ["text"],
+        textBlockCount: 1,
+        toolUseCount: 0,
+        toolResultCount: 0,
+        syntheticToolResultCount: 0,
+        orphanToolResultTextCount: 0,
+        serverToolUseCount: 0,
+        webSearchToolResultCount: 0,
+      },
+      {
+        role: "assistant",
+        blockTypes: ["tool_use"],
+        textBlockCount: 0,
+        toolUseCount: 1,
+        toolResultCount: 0,
+        syntheticToolResultCount: 0,
+        orphanToolResultTextCount: 0,
+        serverToolUseCount: 0,
+        webSearchToolResultCount: 0,
+      },
+      {
+        role: "assistant",
+        blockTypes: ["text"],
+        textBlockCount: 1,
+        toolUseCount: 0,
+        toolResultCount: 0,
+        syntheticToolResultCount: 0,
+        orphanToolResultTextCount: 0,
+        serverToolUseCount: 0,
+        webSearchToolResultCount: 0,
+      },
+    ]);
+    expect(JSON.stringify(snapshot)).not.toContain(rawUserText);
+    expect(JSON.stringify(snapshot)).not.toContain(rawAssistantText);
   });
 });
 

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -97,7 +97,12 @@ import type { PermissionPrompter } from "../permissions/prompter.js";
 import { HOOKS } from "../plugin-api/constants.js";
 import type { UserPromptSubmitContext } from "../plugin-api/types.js";
 import { defaultCompactionTerminal } from "../plugins/defaults/compaction/terminal.js";
-import { deepRepairHistory } from "../plugins/defaults/history-repair/terminal.js";
+import {
+  deepRepairHistory,
+  describeHistoryTail,
+  getHistoryRepairDiagnostics,
+  type HistoryRepairDiagnostics,
+} from "../plugins/defaults/history-repair/terminal.js";
 import {
   asDefaultGraphPayload,
   type DefaultMemoryRetrievalDeps,
@@ -222,6 +227,48 @@ import type { TrustContext } from "./trust-context.js";
 import { stripHistoricalWebSearchResults } from "./web-search-history.js";
 
 const log = getLogger("conversation-agent-loop");
+
+const INVALID_FINAL_ASSISTANT_TAIL_PATTERNS = [
+  /must end with a user message/i,
+  /final message.*user/i,
+  /assistant message in the final position/i,
+  /pre-?fill(?:ed)? the assistant response/i,
+];
+
+function isInvalidFinalAssistantTailError(message: string): boolean {
+  return INVALID_FINAL_ASSISTANT_TAIL_PATTERNS.some((pattern) =>
+    pattern.test(message),
+  );
+}
+
+function logSlackHistoryTailDiagnostics(args: {
+  conversationId: string;
+  requestId: string;
+  provider: string | undefined;
+  errorMessage: string;
+  matchesInvalidFinalAssistantTail: boolean;
+  phase: "initial_provider_rejection" | "deep_repair_retry_rejection";
+  logger: ReturnType<typeof getLogger>;
+  messages: Message[];
+  repairDiagnostics: HistoryRepairDiagnostics | null;
+  turnChannelContext: TurnChannelContext | null;
+}): void {
+  args.logger.warn(
+    {
+      phase: args.phase,
+      conversationId: args.conversationId,
+      requestId: args.requestId,
+      provider: args.provider,
+      providerErrorMessage: redactSecrets(args.errorMessage),
+      matchesInvalidFinalAssistantTail: args.matchesInvalidFinalAssistantTail,
+      userMessageChannel: args.turnChannelContext?.userMessageChannel,
+      assistantMessageChannel: args.turnChannelContext?.assistantMessageChannel,
+      repairDiagnostics: args.repairDiagnostics,
+      historyTail: describeHistoryTail(args.messages),
+    },
+    "Provider rejected repaired history tail during ordering recovery",
+  );
+}
 
 /**
  * Best-effort persistence of the history-stripped marker after an
@@ -2060,6 +2107,8 @@ export async function runAgentLoopImpl(
       userPromptCtx,
     );
     runMessages = finalUserPromptCtx.latestMessages;
+    let historyRepairDiagnostics =
+      getHistoryRepairDiagnostics(runMessages) ?? null;
 
     let preRunHistoryLength = runMessages.length;
 
@@ -2240,6 +2289,25 @@ export async function runAgentLoopImpl(
       state.orderingErrorDetected &&
       updatedHistory.length === preRunHistoryLength
     ) {
+      const orderingErrorMessage = state.deferredOrderingError;
+      const matchesInvalidFinalAssistantTail =
+        orderingErrorMessage != null &&
+        isInvalidFinalAssistantTailError(orderingErrorMessage);
+      if (orderingErrorMessage && (isSlackConversation || matchesInvalidFinalAssistantTail)) {
+        logSlackHistoryTailDiagnostics({
+          phase: "initial_provider_rejection",
+          conversationId: ctx.conversationId,
+          requestId: reqId,
+          provider: state.exchangeProviderName ?? ctx.provider.name,
+          errorMessage: orderingErrorMessage,
+          matchesInvalidFinalAssistantTail,
+          logger: rlog,
+          messages: runMessages,
+          repairDiagnostics: historyRepairDiagnostics,
+          turnChannelContext: capturedTurnChannelContext,
+        });
+      }
+
       rlog.warn(
         { phase: "retry" },
         "Provider ordering error detected, attempting one-shot deep-repair retry",
@@ -2255,6 +2323,7 @@ export async function runAgentLoopImpl(
       // intentionally deferred until there's a concrete plugin-level use case.
       const retryRepair = deepRepairHistory(runMessages);
       runMessages = retryRepair.messages;
+      historyRepairDiagnostics = retryRepair.diagnostics;
       const retryStrip = stripHistoricalWebSearchResults(runMessages);
       runMessages = retryStrip.messages;
       preRepairMessages = runMessages;
@@ -2265,6 +2334,28 @@ export async function runAgentLoopImpl(
       updatedHistory = await runAgentLoop(runMessages);
 
       if (state.orderingErrorDetected) {
+        const retryOrderingErrorMessage = state.deferredOrderingError;
+        const retryMatchesInvalidFinalAssistantTail =
+          retryOrderingErrorMessage != null &&
+          isInvalidFinalAssistantTailError(retryOrderingErrorMessage);
+        if (
+          retryOrderingErrorMessage &&
+          (isSlackConversation || retryMatchesInvalidFinalAssistantTail)
+        ) {
+          logSlackHistoryTailDiagnostics({
+            phase: "deep_repair_retry_rejection",
+            conversationId: ctx.conversationId,
+            requestId: reqId,
+            provider: state.exchangeProviderName ?? ctx.provider.name,
+            errorMessage: retryOrderingErrorMessage,
+            matchesInvalidFinalAssistantTail:
+              retryMatchesInvalidFinalAssistantTail,
+            logger: rlog,
+            messages: runMessages,
+            repairDiagnostics: historyRepairDiagnostics,
+            turnChannelContext: capturedTurnChannelContext,
+          });
+        }
         rlog.error(
           { phase: "retry" },
           "Deep-repair retry also failed with ordering error. Consider starting a new conversation if this persists.",

--- a/assistant/src/plugins/defaults/history-repair/terminal.ts
+++ b/assistant/src/plugins/defaults/history-repair/terminal.ts
@@ -19,16 +19,59 @@ import type {
   ToolUseContent,
 } from "../../../providers/types.js";
 
-interface RepairStats {
+export interface RepairStats {
   assistantToolResultsMigrated: number;
   missingToolResultsInserted: number;
   orphanToolResultsDowngraded: number;
   consecutiveSameRoleMerged: number;
 }
 
-interface RepairResult {
+export interface HistoryRepairActions {
+  migratedAssistantToolResults: boolean;
+  insertedSyntheticToolResults: boolean;
+  repairedOrphanToolResults: boolean;
+  mergedSameRoleMessages: boolean;
+}
+
+export interface HistoryRepairDiagnostics {
+  stats: RepairStats;
+  actions: HistoryRepairActions;
+}
+
+export interface HistoryTailMessageSummary {
+  role: Message["role"];
+  blockTypes: string[];
+  textBlockCount: number;
+  toolUseCount: number;
+  toolResultCount: number;
+  syntheticToolResultCount: number;
+  orphanToolResultTextCount: number;
+  serverToolUseCount: number;
+  webSearchToolResultCount: number;
+}
+
+export interface HistoryTailSnapshot {
+  totalMessages: number;
+  tailLength: number;
+  roleSequence: Message["role"][];
+  endsWithUser: boolean;
+  consecutiveSameRoleTransitions: number;
+  pairingStats: {
+    toolUseCount: number;
+    toolResultCount: number;
+    toolUsesWithoutResult: number;
+    toolResultsWithoutUse: number;
+    syntheticToolResultCount: number;
+    assistantMessagesWithToolResults: number;
+    orphanToolResultTextCount: number;
+  };
+  tail: HistoryTailMessageSummary[];
+}
+
+export interface RepairResult {
   messages: Message[];
   stats: RepairStats;
+  diagnostics: HistoryRepairDiagnostics;
 }
 
 const SYNTHETIC_RESULT =
@@ -38,6 +81,205 @@ const SYNTHETIC_WEB_SEARCH_ERROR = {
   type: "web_search_tool_result_error",
   error_code: "unavailable",
 };
+
+const historyRepairDiagnosticsByMessages = new WeakMap<
+  Message[],
+  HistoryRepairDiagnostics
+>();
+
+function cloneRepairStats(stats: RepairStats): RepairStats {
+  return {
+    assistantToolResultsMigrated: stats.assistantToolResultsMigrated,
+    missingToolResultsInserted: stats.missingToolResultsInserted,
+    orphanToolResultsDowngraded: stats.orphanToolResultsDowngraded,
+    consecutiveSameRoleMerged: stats.consecutiveSameRoleMerged,
+  };
+}
+
+function buildHistoryRepairDiagnostics(
+  stats: RepairStats,
+): HistoryRepairDiagnostics {
+  const clonedStats = cloneRepairStats(stats);
+  return {
+    stats: clonedStats,
+    actions: {
+      migratedAssistantToolResults: clonedStats.assistantToolResultsMigrated > 0,
+      insertedSyntheticToolResults: clonedStats.missingToolResultsInserted > 0,
+      repairedOrphanToolResults: clonedStats.orphanToolResultsDowngraded > 0,
+      mergedSameRoleMessages: clonedStats.consecutiveSameRoleMerged > 0,
+    },
+  };
+}
+
+function rememberHistoryRepairDiagnostics(
+  messages: Message[],
+  diagnostics: HistoryRepairDiagnostics,
+): void {
+  historyRepairDiagnosticsByMessages.set(messages, diagnostics);
+}
+
+export function getHistoryRepairDiagnostics(
+  messages: ReadonlyArray<Message>,
+): HistoryRepairDiagnostics | null {
+  const diagnostics = historyRepairDiagnosticsByMessages.get(
+    messages as Message[],
+  );
+  if (!diagnostics) return null;
+  return {
+    stats: cloneRepairStats(diagnostics.stats),
+    actions: { ...diagnostics.actions },
+  };
+}
+
+function isSyntheticToolResultBlock(block: ToolResultContent): boolean {
+  return (
+    typeof block.content === "string" &&
+    block.content === SYNTHETIC_RESULT &&
+    block.is_error === true
+  );
+}
+
+function isToolResultBlock(block: ContentBlock): block is ToolResultContent {
+  return block.type === "tool_result";
+}
+
+function isSyntheticWebSearchToolResultBlock(block: ContentBlock): boolean {
+  return (
+    block.type === "web_search_tool_result" &&
+    block.content != null &&
+    typeof block.content === "object" &&
+    (block.content as { type?: unknown }).type ===
+      SYNTHETIC_WEB_SEARCH_ERROR.type &&
+    (block.content as { error_code?: unknown }).error_code ===
+      SYNTHETIC_WEB_SEARCH_ERROR.error_code
+  );
+}
+
+function isOrphanToolResultDowngradeText(text: string): boolean {
+  return text.startsWith("[orphaned tool_result for ");
+}
+
+export function describeHistoryTail(
+  messages: ReadonlyArray<Message>,
+  tailLength = 6,
+): HistoryTailSnapshot {
+  const normalizedTailLength = Math.max(tailLength, 0);
+  const tailMessages =
+    normalizedTailLength === 0
+      ? []
+      : messages.slice(-normalizedTailLength);
+  const roleSequence = tailMessages.map((message) => message.role);
+
+  let consecutiveSameRoleTransitions = 0;
+  for (let i = 1; i < roleSequence.length; i++) {
+    if (roleSequence[i] === roleSequence[i - 1]) {
+      consecutiveSameRoleTransitions++;
+    }
+  }
+
+  const pendingToolUseIds = new Set<string>();
+  const pendingServerToolUseIds = new Set<string>();
+  let toolUseCount = 0;
+  let toolResultCount = 0;
+  let toolResultsWithoutUse = 0;
+  let syntheticToolResultCount = 0;
+  let assistantMessagesWithToolResults = 0;
+  let orphanToolResultTextCount = 0;
+
+  const tail = tailMessages.map((message): HistoryTailMessageSummary => {
+    const summary: HistoryTailMessageSummary = {
+      role: message.role,
+      blockTypes: [],
+      textBlockCount: 0,
+      toolUseCount: 0,
+      toolResultCount: 0,
+      syntheticToolResultCount: 0,
+      orphanToolResultTextCount: 0,
+      serverToolUseCount: 0,
+      webSearchToolResultCount: 0,
+    };
+    let sawAssistantToolResult = false;
+
+    for (const block of message.content) {
+      summary.blockTypes.push(block.type);
+      if (block.type === "text") {
+        summary.textBlockCount++;
+        if (isOrphanToolResultDowngradeText(block.text)) {
+          summary.orphanToolResultTextCount++;
+          orphanToolResultTextCount++;
+        }
+        continue;
+      }
+      if (block.type === "tool_use") {
+        toolUseCount++;
+        summary.toolUseCount++;
+        pendingToolUseIds.add(block.id);
+        continue;
+      }
+      if (
+        block.type === "tool_result" ||
+        block.type === "web_search_tool_result"
+      ) {
+        toolResultCount++;
+        summary.toolResultCount++;
+        if (message.role === "assistant") {
+          sawAssistantToolResult = true;
+        }
+        if (isToolResultBlock(block)) {
+          if (isSyntheticToolResultBlock(block)) {
+            syntheticToolResultCount++;
+            summary.syntheticToolResultCount++;
+          }
+          if (message.role === "assistant") {
+            toolResultsWithoutUse++;
+          } else if (!pendingToolUseIds.delete(block.tool_use_id)) {
+            toolResultsWithoutUse++;
+          }
+        } else {
+          summary.webSearchToolResultCount++;
+          if (isSyntheticWebSearchToolResultBlock(block)) {
+            syntheticToolResultCount++;
+            summary.syntheticToolResultCount++;
+          }
+          if (!pendingServerToolUseIds.delete(block.tool_use_id)) {
+            toolResultsWithoutUse++;
+          }
+        }
+        continue;
+      }
+      if (block.type === "server_tool_use") {
+        toolUseCount++;
+        summary.serverToolUseCount++;
+        pendingServerToolUseIds.add(block.id);
+      }
+    }
+
+    if (sawAssistantToolResult) {
+      assistantMessagesWithToolResults++;
+    }
+
+    return summary;
+  });
+
+  return {
+    totalMessages: messages.length,
+    tailLength: tail.length,
+    roleSequence,
+    endsWithUser: tailMessages.at(-1)?.role === "user",
+    consecutiveSameRoleTransitions,
+    pairingStats: {
+      toolUseCount,
+      toolResultCount,
+      toolUsesWithoutResult:
+        pendingToolUseIds.size + pendingServerToolUseIds.size,
+      toolResultsWithoutUse,
+      syntheticToolResultCount,
+      assistantMessagesWithToolResults,
+      orphanToolResultTextCount,
+    },
+    tail,
+  };
+}
 
 export function repairHistory(messages: Message[]): RepairResult {
   const stats: RepairStats = {
@@ -266,7 +508,9 @@ export function repairHistory(messages: Message[]): RepairResult {
     }
   }
 
-  return { messages: merged, stats };
+  const diagnostics = buildHistoryRepairDiagnostics(stats);
+  rememberHistoryRepairDiagnostics(merged, diagnostics);
+  return { messages: merged, stats, diagnostics };
 }
 
 function buildResultMessage(


### PR DESCRIPTION
Part of JARVIS-1046

## Summary
- add structural history-repair diagnostics that can be attached to repaired message arrays without retaining message text
- log redacted Slack ordering-recovery tail diagnostics when provider retries still see a trailing assistant tail
- cover the new diagnostics with focused history-repair and conversation-agent-loop tests

## Testing
- cd assistant && bun test src/__tests__/history-repair.test.ts
- cd assistant && bun test src/__tests__/conversation-agent-loop.test.ts
- cd assistant && bunx tsc --noEmit
