### PR TITLE
feat: add platform gating to backups and out-of-storage banner

### DIFF
--- a/apps/web/src/domains/settings/components/assistant-out-of-storage-banner.tsx
+++ b/apps/web/src/domains/settings/components/assistant-out-of-storage-banner.tsx
@@ -6,6 +6,7 @@ import { Button } from "@vellum/design-library/components/button";
 import { Notice } from "@vellum/design-library/components/notice";
 import { assistantsConnectionStatus } from "@/generated/api/sdk.gen";
 import type { AssistantsConnectionStatusResponse } from "@/generated/api/types.gen";
+import { usePlatformGate } from "@/hooks/use-platform-gate";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { VELLUM_COMMUNITY_URL } from "@/utils/external-urls";
 import { routes } from "@/utils/routes";
@@ -28,11 +29,12 @@ interface AssistantOutOfStorageBannerProps {
 export function AssistantOutOfStorageBanner({
   assistantId,
 }: AssistantOutOfStorageBannerProps) {
+  const platformGate = usePlatformGate({ platformHostedOnly: true });
   const doctorEnabled = useClientFeatureFlagStore.use.doctor();
 
   const { data } = useQuery({
     queryKey: ["assistant-out-of-storage", assistantId] as const,
-    enabled: Boolean(assistantId),
+    enabled: Boolean(assistantId) && platformGate === "full",
     refetchInterval: REFETCH_INTERVAL_MS,
     retry: false,
     queryFn: async () => {
@@ -45,7 +47,7 @@ export function AssistantOutOfStorageBanner({
     },
   });
 
-  if (!isOutOfStorageStatus(data)) {
+  if (platformGate !== "full" || !isOutOfStorageStatus(data)) {
     return null;
   }
 

--- a/apps/web/src/domains/settings/components/assistant-out-of-storage-banner.tsx
+++ b/apps/web/src/domains/settings/components/assistant-out-of-storage-banner.tsx
@@ -6,7 +6,10 @@ import { Button } from "@vellum/design-library/components/button";
 import { Notice } from "@vellum/design-library/components/notice";
 import { assistantsConnectionStatus } from "@/generated/api/sdk.gen";
 import type { AssistantsConnectionStatusResponse } from "@/generated/api/types.gen";
-import { usePlatformGate } from "@/hooks/use-platform-gate";
+import {
+  useActiveAssistantIsPlatformHosted,
+  usePlatformGate,
+} from "@/hooks/use-platform-gate";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { VELLUM_COMMUNITY_URL } from "@/utils/external-urls";
 import { routes } from "@/utils/routes";
@@ -30,11 +33,12 @@ export function AssistantOutOfStorageBanner({
   assistantId,
 }: AssistantOutOfStorageBannerProps) {
   const platformGate = usePlatformGate({ platformHostedOnly: true });
+  const isPlatformHosted = useActiveAssistantIsPlatformHosted();
   const doctorEnabled = useClientFeatureFlagStore.use.doctor();
 
   const { data } = useQuery({
     queryKey: ["assistant-out-of-storage", assistantId] as const,
-    enabled: Boolean(assistantId) && platformGate === "full",
+    enabled: Boolean(assistantId) && platformGate === "full" && isPlatformHosted,
     refetchInterval: REFETCH_INTERVAL_MS,
     retry: false,
     queryFn: async () => {

--- a/apps/web/src/domains/settings/components/panels/debug-controls-panel.tsx
+++ b/apps/web/src/domains/settings/components/panels/debug-controls-panel.tsx
@@ -9,7 +9,10 @@ import { AssistantBackups } from "@/domains/settings/components/assistant-backup
 import { RestartAssistant } from "@/domains/settings/components/restart-assistant";
 import { RecoveryModeControls } from "@/domains/settings/components/recovery-mode-controls";
 import { type Assistant, getAssistant } from "@/assistant/api";
-import { usePlatformGate } from "@/hooks/use-platform-gate";
+import {
+  useActiveAssistantIsPlatformHosted,
+  usePlatformGate,
+} from "@/hooks/use-platform-gate";
 import { useAuthStore } from "@/stores/auth-store";
 import { captureError } from "@/lib/sentry/capture-error";
 import { clearOnboardingFlags } from "@/utils/onboarding-cleanup";
@@ -24,6 +27,7 @@ export function DebugControlsPanel() {
   const navigate = useNavigate();
   const user = useAuthStore.use.user();
   const backupsGate = usePlatformGate({ platformHostedOnly: true });
+  const isPlatformHosted = useActiveAssistantIsPlatformHosted();
   const showInternalControls = isInternalUser(user?.email ?? null, user?.isStaff ?? false);
 
   const [assistant, setAssistant] = useState<Assistant | null>(null);
@@ -92,7 +96,7 @@ export function DebugControlsPanel() {
               Log in to the Vellum platform to manage backups.
             </Notice>
           )}
-          {backupsGate === "full" && (
+          {backupsGate === "full" && isPlatformHosted && (
             <div className="rounded-lg border border-[var(--border-base)] px-4 py-3 dark:border-[var(--border-base)]">
               <h3 className="mb-3 text-body-medium-default text-[var(--content-default)]">
                 Backups

--- a/apps/web/src/domains/settings/components/panels/debug-controls-panel.tsx
+++ b/apps/web/src/domains/settings/components/panels/debug-controls-panel.tsx
@@ -3,11 +3,13 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router";
 
 import { Button } from "@vellum/design-library/components/button";
+import { Notice } from "@vellum/design-library/components/notice";
 import { toast } from "@vellum/design-library/components/toast";
 import { AssistantBackups } from "@/domains/settings/components/assistant-backups";
 import { RestartAssistant } from "@/domains/settings/components/restart-assistant";
 import { RecoveryModeControls } from "@/domains/settings/components/recovery-mode-controls";
 import { type Assistant, getAssistant } from "@/assistant/api";
+import { usePlatformGate } from "@/hooks/use-platform-gate";
 import { useAuthStore } from "@/stores/auth-store";
 import { captureError } from "@/lib/sentry/capture-error";
 import { clearOnboardingFlags } from "@/utils/onboarding-cleanup";
@@ -21,6 +23,7 @@ function isInternalUser(email: string | null, isAdmin: boolean): boolean {
 export function DebugControlsPanel() {
   const navigate = useNavigate();
   const user = useAuthStore.use.user();
+  const backupsGate = usePlatformGate({ platformHostedOnly: true });
   const showInternalControls = isInternalUser(user?.email ?? null, user?.isStaff ?? false);
 
   const [assistant, setAssistant] = useState<Assistant | null>(null);
@@ -84,12 +87,19 @@ export function DebugControlsPanel() {
         </div>
       ) : assistant ? (
         <div className="space-y-4">
-          <div className="rounded-lg border border-[var(--border-base)] px-4 py-3 dark:border-[var(--border-base)]">
-            <h3 className="mb-3 text-body-medium-default text-[var(--content-default)]">
-              Backups
-            </h3>
-            <AssistantBackups assistantId={assistant.id} />
-          </div>
+          {backupsGate === "disabled" && (
+            <Notice tone="info">
+              Log in to the Vellum platform to manage backups.
+            </Notice>
+          )}
+          {backupsGate === "full" && (
+            <div className="rounded-lg border border-[var(--border-base)] px-4 py-3 dark:border-[var(--border-base)]">
+              <h3 className="mb-3 text-body-medium-default text-[var(--content-default)]">
+                Backups
+              </h3>
+              <AssistantBackups assistantId={assistant.id} />
+            </div>
+          )}
 
           <div className="flex items-center justify-between rounded-lg border border-[var(--border-base)] px-4 py-3 dark:border-[var(--border-base)]">
             <div className="min-w-0">


### PR DESCRIPTION
## Summary
- Gate the **assistant backups** section in the debug controls panel with `usePlatformGate({ platformHostedOnly: true })` — hidden for self-hosted (platform proxy can't reach local daemon), login notice for platform-hosted without session, full access when authenticated
- Gate the **out-of-storage banner** on the general settings page with the same `platformHostedOnly: true` pattern — query disabled when gate isn't `"full"`, returns null for non-full states
- **Disk pressure banner** left unchanged — already uses daemon SDK (`diskpressureStatusGet`/`diskpressureAcknowledgePost`), works in self-hosted mode via gateway, degrades gracefully when daemon unreachable

## Original prompt
Implement the "Backups & Storage" section of the Web UI Platform Decoupling inventory. The section has 3 features: assistant backups (platform SDK, debug panel), out-of-storage banner (platform connection status), and disk pressure banner (daemon SDK, chat). The first two route through the platform API proxy which can't reach self-hosted daemons, so they need `platformHostedOnly: true` gating. The third already uses the daemon SDK and works in all states — no changes needed. Cases 3 and 5 in the spec are marked "Decouple" (needs daemon API endpoints); this PR adds interim gating that hides those features until full daemon decoupling is done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)