### PR TITLE
fix(cli): resolve daemon/gateway for npm-installed packaged builds (LUM-2206)

### DIFF
--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -230,8 +230,10 @@ function resolveAssistantIndexPath(): string | undefined {
   }
 
   try {
-    const vellumPkgPath = _require.resolve("vellum/package.json");
-    const resolved = join(dirname(vellumPkgPath), "src", "index.ts");
+    const assistantPkgPath = _require.resolve(
+      "@vellumai/assistant/package.json",
+    );
+    const resolved = join(dirname(assistantPkgPath), "src", "index.ts");
     if (existsSync(resolved)) {
       return resolved;
     }
@@ -416,13 +418,13 @@ async function startDaemonFromSource(
   writeFileSync(pidFile, "starting", "utf-8");
 
   const child = foreground
-    ? spawn("bun", ["run", daemonMainPath], {
+    ? spawn(process.execPath, ["run", daemonMainPath], {
         stdio: "inherit",
         env,
       })
     : (() => {
         const daemonLogFd = openLogFile("hatch.log");
-        const c = spawn("bun", ["run", daemonMainPath], {
+        const c = spawn(process.execPath, ["run", daemonMainPath], {
           detached: true,
           stdio: ["ignore", "pipe", "pipe"],
           env,
@@ -486,7 +488,7 @@ async function startDaemonWatchFromSource(
   writeFileSync(pidFile, "starting", "utf-8");
 
   const daemonLogFd = openLogFile("hatch.log");
-  const child = spawn("bun", ["--watch", "run", mainPath], {
+  const child = spawn(process.execPath, ["--watch", "run", mainPath], {
     detached: true,
     stdio: ["ignore", "pipe", "pipe"],
     env,
@@ -512,6 +514,18 @@ function resolveGatewayDir(): string {
   const sourceDir = join(import.meta.dir, "..", "..", "..", "gateway");
   if (isGatewaySourceDir(sourceDir)) {
     return sourceDir;
+  }
+
+  // npm-installed: @vellumai/cli and @vellumai/vellum-gateway are siblings
+  const npmGatewayDir = join(
+    import.meta.dir,
+    "..",
+    "..",
+    "..",
+    "vellum-gateway",
+  );
+  if (isGatewaySourceDir(npmGatewayDir)) {
+    return npmGatewayDir;
   }
 
   // Compiled binary: gateway/ bundled adjacent to the CLI executable.
@@ -1135,7 +1149,7 @@ export async function startGateway(
       ? ["--watch", "run", "src/index.ts", "--vellum-gateway"]
       : ["run", "src/index.ts", "--vellum-gateway"];
     const gwLogFd = openLogFile("hatch.log");
-    gateway = spawn("bun", bunArgs, {
+    gateway = spawn(process.execPath, bunArgs, {
       cwd: gatewayDir,
       detached: true,
       stdio: ["ignore", "pipe", "pipe"],


### PR DESCRIPTION
## Summary
- Replace bare `"bun"` spawn calls with `process.execPath` in daemon/gateway source-mode launchers so the packaged Electron app's bundled bun is used instead of requiring bun on the system PATH
- Add npm-layout resolution step for `@vellumai/vellum-gateway` in `resolveGatewayDir()` — the package name differs from the source tree directory name (`vellum-gateway` vs `gateway`)
- Fix `resolveAssistantIndexPath()` fallback to resolve `@vellumai/assistant/package.json` instead of `vellum/package.json` (the meta-package has no `src/`)

## Original prompt
The CLI's daemon/gateway resolution in `cli/src/lib/local.ts` doesn't work when the CLI is lazily installed as an npm package in the packaged Electron app. `process.execPath` points to the bundled bun in `Contents/Resources/`, so binary-adjacent resolution fails, and the source-mode spawners use bare `"bun"` which isn't on the Electron app's PATH. This was flagged in [PR #33149 review feedback](https://github.com/vellum-ai/vellum-assistant/pull/33149#discussion_r3344961604) and tracked as LUM-2206.