### PR TITLE
Track Slack threads only after successful assistant delivery

### DIFF
--- a/assistant/src/__tests__/access-request-decision.test.ts
+++ b/assistant/src/__tests__/access-request-decision.test.ts
@@ -33,6 +33,7 @@ mock.module("../runtime/gateway-client.js", () => ({
     }
     deliverReplyCalls.push({ url, payload });
   },
+  trackSlackActiveThread: async () => true,
 }));
 
 import { getDb } from "../memory/db-connection.js";

--- a/assistant/src/__tests__/channel-inbound-disk-pressure.test.ts
+++ b/assistant/src/__tests__/channel-inbound-disk-pressure.test.ts
@@ -19,6 +19,7 @@ mock.module("../util/logger.js", () => ({
 
 mock.module("../runtime/gateway-client.js", () => ({
   deliverChannelReply: deliverChannelReplyMock,
+  trackSlackActiveThread: async () => true,
 }));
 
 const lockedDiskPressureStatus: DiskPressureStatus = {

--- a/assistant/src/__tests__/channel-reply-delivery.test.ts
+++ b/assistant/src/__tests__/channel-reply-delivery.test.ts
@@ -63,6 +63,7 @@ const renderedHistoryContentQueue: RenderedHistoryStub[] = [];
 
 let deliveryFailAtIndex = -1;
 let failOnRecordedMessageTs: string | null = null;
+let slackThreadActivationShouldSucceed = true;
 
 mock.module("../runtime/gateway-client.js", () => ({
   deliverChannelReply: async (
@@ -97,7 +98,7 @@ mock.module("../runtime/gateway-client.js", () => ({
     ttlMs?: number,
   ) => {
     slackThreadActivationCalls.push({ channelId, threadTs, ttlMs });
-    return true;
+    return slackThreadActivationShouldSucceed;
   },
 }));
 
@@ -175,6 +176,7 @@ describe("channel-reply-delivery", () => {
     slackThreadActivationCalls.length = 0;
     deliveryFailAtIndex = -1;
     failOnRecordedMessageTs = null;
+    slackThreadActivationShouldSucceed = true;
     conversationMessages.length = 0;
     attachmentsByMessageId.clear();
     updateMessageMetadataCalls.length = 0;
@@ -686,6 +688,34 @@ describe("channel-reply-delivery", () => {
     });
 
     expect(deliveryCalls).toHaveLength(0);
+    expect(slackThreadActivationCalls).toEqual([
+      {
+        channelId: "C123THREAD",
+        threadTs: "1700000000.000001",
+        ttlMs: undefined,
+      },
+    ]);
+  });
+
+  it("surfaces Slack thread activation failures so delivery retries can finish activation later", async () => {
+    slackThreadActivationShouldSucceed = false;
+    const deliveredCounts: number[] = [];
+
+    await expect(
+      deliverRenderedReplyViaCallback({
+        callbackUrl:
+          "http://gateway/deliver/slack?channel=C123THREAD&threadTs=1700000000.000001",
+        chatId: "C123THREAD",
+        textSegments: ["Part 1."],
+        interSegmentDelayMs: 0,
+        onSegmentDelivered: (count) => deliveredCounts.push(count),
+      }),
+    ).rejects.toThrow(
+      "Slack active thread activation failed after reply delivery",
+    );
+
+    expect(deliveryCalls).toHaveLength(1);
+    expect(deliveredCounts).toEqual([1]);
     expect(slackThreadActivationCalls).toEqual([
       {
         channelId: "C123THREAD",

--- a/assistant/src/__tests__/channel-reply-delivery.test.ts
+++ b/assistant/src/__tests__/channel-reply-delivery.test.ts
@@ -8,6 +8,12 @@ type DeliveryCall = {
 };
 
 const deliveryCalls: DeliveryCall[] = [];
+type SlackThreadActivationCall = {
+  channelId: string;
+  threadTs: string;
+  ttlMs?: number;
+};
+const slackThreadActivationCalls: SlackThreadActivationCall[] = [];
 type MockMessageRow = {
   id: string;
   role: string;
@@ -85,6 +91,14 @@ mock.module("../runtime/gateway-client.js", () => ({
     }
     return { ok: true };
   },
+  trackSlackActiveThread: async (
+    channelId: string,
+    threadTs: string,
+    ttlMs?: number,
+  ) => {
+    slackThreadActivationCalls.push({ channelId, threadTs, ttlMs });
+    return true;
+  },
 }));
 
 mock.module("../memory/conversation-crud.js", () => ({
@@ -158,6 +172,7 @@ const {
 describe("channel-reply-delivery", () => {
   beforeEach(() => {
     deliveryCalls.length = 0;
+    slackThreadActivationCalls.length = 0;
     deliveryFailAtIndex = -1;
     failOnRecordedMessageTs = null;
     conversationMessages.length = 0;
@@ -638,6 +653,58 @@ describe("channel-reply-delivery", () => {
     expect(deliveryCalls[0].callbackUrl).toContain("threadTs=");
     expect(deliveryCalls[0].payload.chatId).toBe("C123THREAD");
     expect(deliveryCalls[0].payload.messageTs).toBe(failOnRecordedMessageTs);
+  });
+
+  it("activates a Slack thread after the first successful threaded delivery", async () => {
+    await deliverRenderedReplyViaCallback({
+      callbackUrl:
+        "http://gateway/deliver/slack?channel=C123THREAD&threadTs=1700000000.000001",
+      chatId: "C123THREAD",
+      textSegments: ["Part 1.", "Part 2."],
+      interSegmentDelayMs: 0,
+    });
+
+    expect(deliveryCalls).toHaveLength(2);
+    expect(slackThreadActivationCalls).toEqual([
+      {
+        channelId: "C123THREAD",
+        threadTs: "1700000000.000001",
+        ttlMs: undefined,
+      },
+    ]);
+  });
+
+  it("re-activates a Slack thread when a resumed delivery has no segments left to send", async () => {
+    await deliverRenderedReplyViaCallback({
+      callbackUrl:
+        "http://gateway/deliver/slack?channel=C123THREAD&threadTs=1700000000.000001",
+      chatId: "C123THREAD",
+      textSegments: ["Already delivered."],
+      interSegmentDelayMs: 0,
+      startFromSegment: 1,
+      messageTs: "1700000000.000055",
+    });
+
+    expect(deliveryCalls).toHaveLength(0);
+    expect(slackThreadActivationCalls).toEqual([
+      {
+        channelId: "C123THREAD",
+        threadTs: "1700000000.000001",
+        ttlMs: undefined,
+      },
+    ]);
+  });
+
+  it("does not activate Slack thread tracking for non-Slack callbacks", async () => {
+    await deliverRenderedReplyViaCallback({
+      callbackUrl: "http://gateway/deliver/telegram?channel=C123THREAD",
+      chatId: "chat-telegram",
+      textSegments: ["Telegram reply."],
+      interSegmentDelayMs: 0,
+    });
+
+    expect(deliveryCalls).toHaveLength(1);
+    expect(slackThreadActivationCalls).toHaveLength(0);
   });
 
   it("passes ephemeral and user through to each delivery call", async () => {

--- a/assistant/src/__tests__/channel-retry-sweep.test.ts
+++ b/assistant/src/__tests__/channel-retry-sweep.test.ts
@@ -94,6 +94,7 @@ mock.module("../runtime/gateway-client.js", () => ({
     liveDeliveryCalls.push({ callbackUrl, payload });
     return deliverChannelReplyImpl(callbackUrl, payload);
   },
+  trackSlackActiveThread: async () => true,
 }));
 
 import { getDb } from "../memory/db-connection.js";

--- a/assistant/src/__tests__/dm-backfill.test.ts
+++ b/assistant/src/__tests__/dm-backfill.test.ts
@@ -38,6 +38,7 @@ mock.module("../tools/credentials/metadata-store.js", () => ({
 
 mock.module("../runtime/gateway-client.js", () => ({
   deliverChannelReply: async () => {},
+  trackSlackActiveThread: async () => true,
 }));
 
 mock.module("../messaging/providers/slack/adapter.js", () => ({

--- a/assistant/src/__tests__/guardian-action-late-reply.test.ts
+++ b/assistant/src/__tests__/guardian-action-late-reply.test.ts
@@ -9,6 +9,7 @@ mock.module("../util/logger.js", () => ({
 
 mock.module("../runtime/gateway-client.js", () => ({
   deliverChannelReply: async () => {},
+  trackSlackActiveThread: async () => true,
 }));
 
 import { isTerminalState } from "../calls/call-state-machine.js";

--- a/assistant/src/__tests__/guardian-action-sweep.test.ts
+++ b/assistant/src/__tests__/guardian-action-sweep.test.ts
@@ -16,6 +16,7 @@ mock.module("../runtime/gateway-client.js", () => ({
   deliverChannelReply: async (url: string, body: Record<string, unknown>) => {
     deliveredMessages.push({ url, body });
   },
+  trackSlackActiveThread: async () => true,
 }));
 
 import {

--- a/assistant/src/__tests__/inbound-invite-redemption.test.ts
+++ b/assistant/src/__tests__/inbound-invite-redemption.test.ts
@@ -57,6 +57,7 @@ mock.module("../runtime/gateway-client.js", () => ({
   ) => {
     deliverReplyCalls.push({ url, payload });
   },
+  trackSlackActiveThread: async () => true,
 }));
 
 mock.module("../runtime/approval-message-composer.js", () => ({

--- a/assistant/src/__tests__/non-member-access-request.test.ts
+++ b/assistant/src/__tests__/non-member-access-request.test.ts
@@ -59,6 +59,7 @@ mock.module("../runtime/gateway-client.js", () => ({
   ) => {
     deliverReplyCalls.push({ url, payload });
   },
+  trackSlackActiveThread: async () => true,
 }));
 
 import {

--- a/assistant/src/__tests__/outbound-slack-persistence.test.ts
+++ b/assistant/src/__tests__/outbound-slack-persistence.test.ts
@@ -170,6 +170,7 @@ mock.module("../runtime/gateway-client.js", () => ({
     ok: true,
     ...(nextDeliveryTs ? { ts: nextDeliveryTs } : {}),
   }),
+  trackSlackActiveThread: async () => true,
 }));
 
 mock.module("../memory/attachments-store.js", () => ({

--- a/assistant/src/__tests__/reaction-persistence.test.ts
+++ b/assistant/src/__tests__/reaction-persistence.test.ts
@@ -40,6 +40,7 @@ mock.module("../tools/credentials/metadata-store.js", () => ({
 
 mock.module("../runtime/gateway-client.js", () => ({
   deliverChannelReply: async () => {},
+  trackSlackActiveThread: async () => true,
 }));
 
 import { eq } from "drizzle-orm";

--- a/assistant/src/__tests__/slack-inbound-verification.test.ts
+++ b/assistant/src/__tests__/slack-inbound-verification.test.ts
@@ -53,6 +53,7 @@ mock.module("../runtime/gateway-client.js", () => ({
   ) => {
     deliverReplyCalls.push({ url, payload });
   },
+  trackSlackActiveThread: async () => true,
 }));
 
 import { getDb } from "../memory/db-connection.js";

--- a/assistant/src/__tests__/stale-approval-dedup.test.ts
+++ b/assistant/src/__tests__/stale-approval-dedup.test.ts
@@ -25,6 +25,7 @@ mock.module("../runtime/gateway-client.js", () => ({
     }
     deliveredMessages.push({ url, body });
   },
+  trackSlackActiveThread: async () => true,
 }));
 
 mock.module("../runtime/approval-message-composer.js", () => ({

--- a/assistant/src/__tests__/thread-backfill.test.ts
+++ b/assistant/src/__tests__/thread-backfill.test.ts
@@ -49,6 +49,7 @@ mock.module("../tools/credentials/metadata-store.js", () => ({
 
 mock.module("../runtime/gateway-client.js", () => ({
   deliverChannelReply: async () => {},
+  trackSlackActiveThread: async () => true,
 }));
 
 type DownloadedSlackFile = {

--- a/assistant/src/__tests__/tool-grant-request-escalation.test.ts
+++ b/assistant/src/__tests__/tool-grant-request-escalation.test.ts
@@ -86,6 +86,7 @@ mock.module("../runtime/gateway-client.js", () => ({
   ) => {
     deliveredReplies.push(payload);
   },
+  trackSlackActiveThread: async () => true,
 }));
 
 import { applyCanonicalGuardianDecision } from "../approvals/guardian-decision-primitive.js";

--- a/assistant/src/__tests__/trusted-contact-approval-notifier.test.ts
+++ b/assistant/src/__tests__/trusted-contact-approval-notifier.test.ts
@@ -54,6 +54,7 @@ mock.module("../runtime/gateway-client.js", () => ({
     deliveredReplies.push({ url, payload });
     return { ok: true };
   },
+  trackSlackActiveThread: async () => true,
 }));
 
 // ── Guardian binding mock ──

--- a/assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts
+++ b/assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts
@@ -121,6 +121,7 @@ mock.module("../runtime/gateway-client.js", () => ({
     deliveredReplies.push({ url, payload });
     return { ok: true };
   },
+  trackSlackActiveThread: async () => true,
 }));
 
 // Mock pending interactions (channel-approvals)
@@ -1087,4 +1088,3 @@ describe("cross-milestone integration checks", () => {
     expect(freshReq?.followupState).toBeNull();
   });
 });
-

--- a/assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts
+++ b/assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts
@@ -56,6 +56,7 @@ mock.module("../runtime/gateway-client.js", () => ({
   ) => {
     deliverReplyCalls.push({ url, payload });
   },
+  trackSlackActiveThread: async () => true,
 }));
 
 // Mock the approval conversation / copy generators so they return canned text.

--- a/assistant/src/__tests__/trusted-contact-multichannel.test.ts
+++ b/assistant/src/__tests__/trusted-contact-multichannel.test.ts
@@ -65,6 +65,7 @@ mock.module("../runtime/gateway-client.js", () => ({
   ) => {
     deliverReplyCalls.push({ url, payload });
   },
+  trackSlackActiveThread: async () => true,
 }));
 
 mock.module("../runtime/approval-message-composer.js", () => ({

--- a/assistant/src/runtime/channel-reply-delivery.ts
+++ b/assistant/src/runtime/channel-reply-delivery.ts
@@ -128,6 +128,17 @@ async function activateSlackThreadIfNeeded(
   return tracked ? null : target;
 }
 
+function throwIfSlackThreadActivationPending(
+  target: SlackActiveThreadTarget | null,
+): void {
+  if (!target) {
+    return;
+  }
+  throw new Error(
+    `Slack active thread activation failed after reply delivery (${target.channelId}:${target.threadTs})`,
+  );
+}
+
 export async function deliverRenderedReplyViaCallback(
   params: DeliverRenderedReplyParams,
 ): Promise<void> {
@@ -180,6 +191,7 @@ export async function deliverRenderedReplyViaCallback(
       pendingSlackThreadActivation = await activateSlackThreadIfNeeded(
         pendingSlackThreadActivation,
       );
+      throwIfSlackThreadActivationPending(pendingSlackThreadActivation);
     }
     return;
   }
@@ -212,6 +224,7 @@ export async function deliverRenderedReplyViaCallback(
         pendingSlackThreadActivation,
       );
     }
+    throwIfSlackThreadActivationPending(pendingSlackThreadActivation);
     return;
   }
 
@@ -256,6 +269,8 @@ export async function deliverRenderedReplyViaCallback(
       await sleep(interSegmentDelayMs);
     }
   }
+
+  throwIfSlackThreadActivationPending(pendingSlackThreadActivation);
 }
 
 export type DeliverReplyOptions = {

--- a/assistant/src/runtime/channel-reply-delivery.ts
+++ b/assistant/src/runtime/channel-reply-delivery.ts
@@ -6,10 +6,17 @@ import {
   getMessages,
   updateMessageMetadata,
 } from "../memory/conversation-crud.js";
+import {
+  extractChannelFromCallbackUrl,
+  extractThreadTsFromCallbackUrl,
+} from "../memory/slack-thread-store.js";
 import { readSlackMetadata } from "../messaging/providers/slack/message-metadata.js";
 import { getLogger } from "../util/logger.js";
 import type { ChannelDeliveryResult } from "./gateway-client.js";
-import { deliverChannelReply } from "./gateway-client.js";
+import {
+  deliverChannelReply,
+  trackSlackActiveThread,
+} from "./gateway-client.js";
 import type { RuntimeAttachmentMetadata } from "./http-types.js";
 import {
   isSlackCallbackUrl,
@@ -89,6 +96,38 @@ function hasDeliverableReply(
   );
 }
 
+type SlackActiveThreadTarget = {
+  channelId: string;
+  threadTs: string;
+};
+
+function getSlackActiveThreadTarget(
+  callbackUrl: string,
+): SlackActiveThreadTarget | null {
+  if (!isSlackCallbackUrl(callbackUrl)) {
+    return null;
+  }
+
+  const channelId = extractChannelFromCallbackUrl(callbackUrl);
+  const threadTs = extractThreadTsFromCallbackUrl(callbackUrl);
+  if (!channelId || !threadTs) {
+    return null;
+  }
+
+  return { channelId, threadTs };
+}
+
+async function activateSlackThreadIfNeeded(
+  target: SlackActiveThreadTarget | null,
+): Promise<SlackActiveThreadTarget | null> {
+  if (!target) {
+    return null;
+  }
+
+  const tracked = await trackSlackActiveThread(target.channelId, target.threadTs);
+  return tracked ? null : target;
+}
+
 export async function deliverRenderedReplyViaCallback(
   params: DeliverRenderedReplyParams,
 ): Promise<void> {
@@ -114,6 +153,7 @@ export async function deliverRenderedReplyViaCallback(
   );
   const replyAttachments =
     attachments && attachments.length > 0 ? attachments : undefined;
+  let pendingSlackThreadActivation = getSlackActiveThreadTarget(callbackUrl);
 
   // If the model output <no_response/> and no other deliverable text remains,
   // suppress all delivery — including attachments — so nothing is posted.
@@ -137,6 +177,9 @@ export async function deliverRenderedReplyViaCallback(
       if (result.ts) {
         onMessageTs?.(result.ts);
       }
+      pendingSlackThreadActivation = await activateSlackThreadIfNeeded(
+        pendingSlackThreadActivation,
+      );
     }
     return;
   }
@@ -158,8 +201,16 @@ export async function deliverRenderedReplyViaCallback(
       if (deliveredTs) {
         onMessageTs?.(deliveredTs);
       }
+      pendingSlackThreadActivation = await activateSlackThreadIfNeeded(
+        pendingSlackThreadActivation,
+      );
     } else if (messageTs) {
       onMessageTs?.(messageTs);
+    }
+    if (startFromSegment > 0) {
+      pendingSlackThreadActivation = await activateSlackThreadIfNeeded(
+        pendingSlackThreadActivation,
+      );
     }
     return;
   }
@@ -194,6 +245,9 @@ export async function deliverRenderedReplyViaCallback(
       onMessageTs?.(result.ts);
     }
 
+    pendingSlackThreadActivation = await activateSlackThreadIfNeeded(
+      pendingSlackThreadActivation,
+    );
     onSegmentDelivered?.(i + 1);
 
     // Send split messages in-order with a short gap so downstream channel

--- a/assistant/src/runtime/gateway-client.ts
+++ b/assistant/src/runtime/gateway-client.ts
@@ -19,6 +19,7 @@ import {
   deliverChannelReply as _deliverChannelReply,
 } from "@vellumai/gateway-client/http-delivery";
 
+import { ipcCall } from "../ipc/gateway-client.js";
 import {
   deliverDirect,
   isDirectDelivery,
@@ -27,6 +28,7 @@ import { getLogger } from "../util/logger.js";
 import type { ApprovalUIMetadata } from "./channel-approval-types.js";
 
 const log = getLogger("gateway-client");
+const SLACK_ACTIVE_THREAD_IPC_TIMEOUT_MS = 1_000;
 
 // Re-export the error class and types so existing import sites are unchanged.
 export { ChannelDeliveryError };
@@ -62,4 +64,25 @@ export async function deliverApprovalPrompt(
     undefined,
     log,
   );
+}
+
+export async function trackSlackActiveThread(
+  channelId: string,
+  threadTs: string,
+  ttlMs?: number,
+): Promise<boolean> {
+  const result = await ipcCall(
+    "track_slack_active_thread",
+    { channelId, threadTs, ttlMs },
+    SLACK_ACTIVE_THREAD_IPC_TIMEOUT_MS,
+  );
+  if (!result || typeof result !== "object" || Array.isArray(result)) {
+    log.warn(
+      { channelId, threadTs, result },
+      "Failed to activate Slack thread after successful reply delivery",
+    );
+    return false;
+  }
+
+  return (result as { tracked?: unknown }).tracked === true;
 }

--- a/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
+++ b/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
@@ -407,7 +407,7 @@ describe("SlackSocketModeClient thread tracking", () => {
     }
   });
 
-  test("accepts unmentioned thread replies immediately after an app mention", async () => {
+  test("does not accept unmentioned thread replies after an app mention until the assistant replies", async () => {
     const { rawDb, store } = createSlackStore();
     const emitted: NormalizedSlackEvent[] = [];
     const client = createHarness(store, (event) => emitted.push(event));
@@ -443,6 +443,69 @@ describe("SlackSocketModeClient thread tracking", () => {
       expect(emitted[0].event.source.updateId).toBe("Ev-mention");
       expect(emitted[0].threadTs).toBe("1700000000.000000");
       expect(emitted[0].event.source.threadId).toBe("1700000000.000000");
+      expect(store.hasThread("1700000000.000000")).toBe(false);
+
+      client.handleMessage(
+        JSON.stringify({
+          envelope_id: "env-reply",
+          type: "events_api",
+          payload: {
+            event_id: "Ev-reply",
+            event: {
+              type: "message",
+              user: "U-reply",
+              text: "following up without mentioning the bot",
+              ts: "1700000000.000200",
+              channel: "C-thread",
+              channel_type: "channel",
+              thread_ts: "1700000000.000000",
+            },
+          },
+        }),
+        ws,
+      );
+      await flushAsyncEventEmission();
+
+      expect(emitted).toHaveLength(1);
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("accepts unmentioned thread replies after a successful assistant reply activates the thread", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+
+    try {
+      await Promise.all([
+        resolveSlackUser("U-mentioned", "xoxb-test"),
+        resolveSlackUser("U-reply", "xoxb-test"),
+      ]);
+
+      client.handleMessage(
+        JSON.stringify({
+          envelope_id: "env-mention",
+          type: "events_api",
+          payload: {
+            event_id: "Ev-mention",
+            event: {
+              type: "app_mention",
+              user: "U-mentioned",
+              text: "<@UBOT> can you help here?",
+              ts: "1700000000.000100",
+              channel: "C-thread",
+              thread_ts: "1700000000.000000",
+            },
+          },
+        }),
+        ws,
+      );
+      await flushAsyncEventEmission();
+
+      expect(emitted).toHaveLength(1);
+      store.trackThread("1700000000.000000", "C-thread", 60_000);
 
       client.handleMessage(
         JSON.stringify({
@@ -478,7 +541,7 @@ describe("SlackSocketModeClient thread tracking", () => {
     }
   });
 
-  test("emits a slow app mention before its immediate thread reply", async () => {
+  test("does not admit an immediate thread reply while a slow app mention is still resolving", async () => {
     const { rawDb, store } = createSlackStore();
     const emitted: NormalizedSlackEvent[] = [];
     const client = createHarness(store, (event) => emitted.push(event));
@@ -543,15 +606,12 @@ describe("SlackSocketModeClient thread tracking", () => {
       resolveDelayedMention!(makeSlackUserResponse());
       await flushAsyncEventEmission();
 
-      expect(emitted).toHaveLength(2);
+      expect(emitted).toHaveLength(1);
       expect(emitted[0].event.source.updateId).toBe("Ev-race-mention");
       expect(emitted[0].event.message.content).toBe(
         "@Example User @Example User can you help here?",
       );
-      expect(emitted[1].event.source.updateId).toBe("Ev-race-reply");
-      expect(emitted[1].event.message.content).toBe(
-        "following up while lookup is still pending",
-      );
+      expect(store.hasThread("1700000000.000140")).toBe(false);
     } finally {
       rawDb.close();
     }
@@ -628,7 +688,7 @@ describe("SlackSocketModeClient thread tracking", () => {
     }
   });
 
-  test("accepts unmentioned thread replies after a top-level app mention", async () => {
+  test("does not accept thread replies after a top-level app mention until the assistant replies", async () => {
     const { rawDb, store } = createSlackStore();
     const emitted: NormalizedSlackEvent[] = [];
     const client = createHarness(store, (event) => emitted.push(event));
@@ -663,6 +723,68 @@ describe("SlackSocketModeClient thread tracking", () => {
       expect(emitted[0].event.source.updateId).toBe("Ev-top-level-mention");
       expect(emitted[0].threadTs).toBe("1700000000.000300");
       expect(emitted[0].event.source.threadId).toBeUndefined();
+      expect(store.hasThread("1700000000.000300")).toBe(false);
+
+      client.handleMessage(
+        JSON.stringify({
+          envelope_id: "env-top-level-reply",
+          type: "events_api",
+          payload: {
+            event_id: "Ev-top-level-reply",
+            event: {
+              type: "message",
+              user: "U-reply",
+              text: "following up in the new thread",
+              ts: "1700000000.000400",
+              channel: "C-thread",
+              channel_type: "channel",
+              thread_ts: "1700000000.000300",
+            },
+          },
+        }),
+        ws,
+      );
+      await flushAsyncEventEmission();
+
+      expect(emitted).toHaveLength(1);
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("accepts thread replies after a top-level app mention once the assistant activates the new thread", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+
+    try {
+      await Promise.all([
+        resolveSlackUser("U-mentioned", "xoxb-test"),
+        resolveSlackUser("U-reply", "xoxb-test"),
+      ]);
+
+      client.handleMessage(
+        JSON.stringify({
+          envelope_id: "env-top-level-mention",
+          type: "events_api",
+          payload: {
+            event_id: "Ev-top-level-mention",
+            event: {
+              type: "app_mention",
+              user: "U-mentioned",
+              text: "<@UBOT> can you help here?",
+              ts: "1700000000.000300",
+              channel: "C-thread",
+            },
+          },
+        }),
+        ws,
+      );
+      await flushAsyncEventEmission();
+
+      expect(emitted).toHaveLength(1);
+      store.trackThread("1700000000.000300", "C-thread", 60_000);
 
       client.handleMessage(
         JSON.stringify({

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -6,7 +6,6 @@ import { getLogger } from "../logger.js";
 import { fetchImpl } from "../fetch.js";
 import type { GatewayConfig } from "../config.js";
 import { SlackStore } from "../db/slack-store.js";
-import { isRejection, resolveAssistant } from "../routing/resolve-assistant.js";
 import {
   SLACK_THREAD_ALREADY_MUTED,
   SLACK_THREAD_MUTE_SUCCESS,
@@ -796,23 +795,6 @@ export class SlackSocketModeClient {
       return;
     }
 
-    if (isAppMention) {
-      const appMentionEvent = event as SlackAppMentionEvent;
-      const threadTs = appMentionEvent.thread_ts ?? appMentionEvent.ts;
-      const routing = resolveAssistant(
-        this.config.gatewayConfig,
-        appMentionEvent.channel,
-        appMentionEvent.user,
-      );
-      if (threadTs && !isRejection(routing) && appMentionEvent.channel) {
-        this.store.trackThread(
-          threadTs,
-          appMentionEvent.channel,
-          ACTIVE_THREAD_TTL_MS,
-        );
-      }
-    }
-
     this.enqueueNormalizeAndEmit(
       event,
       eventId,
@@ -1088,13 +1070,12 @@ export class SlackSocketModeClient {
       return;
     }
 
-    // Track threads only for real participation signals so follow-up replies
-    // continue after app mentions and admitted messages, without reactions,
-    // edits, or deletes arming unrelated threads.
+    // Track threads only after the assistant has already participated.
+    // App mentions alone are not enough; assistant-side delivery activates
+    // threads via IPC after a successful Slack send/update.
     const threadTs = normalized.threadTs;
     const channelId = normalized.event.message.conversationExternalId;
-    const shouldTrackActiveThread = isAppMention || isActiveThreadReply;
-    if (shouldTrackActiveThread && threadTs && channelId) {
+    if (isActiveThreadReply && threadTs && channelId) {
       this.store.trackThread(threadTs, channelId, ACTIVE_THREAD_TTL_MS);
     }
 


### PR DESCRIPTION
## Summary
- stop Slack app mentions from activating channel threads before the assistant successfully replies
- activate Slack threads from the assistant delivery path after a successful send or update, including resumed deliveries
- cover the delayed follow-up regression with gateway and assistant tests

Part of JARVIS-1046