### PR TITLE
fix(web): fix skill icon SVGs missing in dev and stretched on render

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,7 @@
     "dist"
   ],
   "scripts": {
-    "predev": "bun run postinstall && bun run openapi-ts",
+    "predev": "bun run postinstall && bun run openapi-ts && node scripts/copy-skill-assets.mjs",
     "dev": "bun --bun vite",
     "prebuild": "node scripts/copy-skill-assets.mjs",
     "build": "bun --bun vite build",

--- a/apps/web/src/domains/intelligence/components/skills/skill-icon.tsx
+++ b/apps/web/src/domains/intelligence/components/skills/skill-icon.tsx
@@ -16,7 +16,7 @@ export function SkillIcon({ skill, className, fallback = "\u{1F9E9}" }: SkillIco
       <img
         src={`/assistant/skills/${skill.id}/${skill.icon}`}
         alt=""
-        className={className}
+        className={`${className} object-contain`}
         onError={() => setImgError(true)}
       />
     );


### PR DESCRIPTION
## Summary
- **Dev icon fallback**: The `copy-skill-assets.mjs` script only ran as `prebuild`, so `bun run dev` never populated `public/skills/` — skill icons 404'd and fell back to emoji. Added the copy step to `predev`.
- **Stretched logos**: `SkillIcon` rendered `<img>` without `object-contain`, so non-square SVGs (e.g. Amazon) were stretched to fill the square container. Added `object-contain` to preserve aspect ratio.

## Test plan
- [ ] Run `bun run dev` from a clean state — skill icons should render as SVGs, not emoji
- [ ] Verify wide/tall logos (Amazon, etc.) display without distortion

🤖 Generated with [Claude Code](https://claude.com/claude-code)