### PR TITLE
Patch Slack conversation repair for trailing assistant-tail provider failures

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -2695,6 +2695,154 @@ describe("session-agent-loop", () => {
       expect(callCount).toBe(2);
     });
 
+    test("repairs a trailing Slack assistant tail before the initial provider call", async () => {
+      const events: ServerMessage[] = [];
+      let callCount = 0;
+      const repairedDiagnostics = {
+        stats: {
+          assistantToolResultsMigrated: 0,
+          missingToolResultsInserted: 1,
+          orphanToolResultsDowngraded: 0,
+          consecutiveSameRoleMerged: 1,
+        },
+        actions: {
+          migratedAssistantToolResults: false,
+          insertedSyntheticToolResults: true,
+          repairedOrphanToolResults: false,
+          mergedSameRoleMessages: true,
+        },
+      };
+
+      repairHistoryMock.mockImplementation(() => ({
+        messages: [
+          {
+            role: "user" as const,
+            content: [{ type: "text", text: "Slack user message" }],
+          },
+          {
+            role: "assistant" as const,
+            content: [
+              {
+                type: "tool_use",
+                id: "tool-secret",
+                name: "bash",
+                input: { cmd: "echo hidden" },
+              },
+              {
+                type: "text",
+                text: "assistant trailing text should stay attached",
+              },
+            ] as ContentBlock[],
+          },
+          {
+            role: "user" as const,
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "tool-secret",
+                content:
+                  "<synthesized_result>tool result missing from history</synthesized_result>",
+                is_error: true,
+              },
+            ] as ContentBlock[],
+          },
+        ],
+        stats: repairedDiagnostics.stats,
+        diagnostics: repairedDiagnostics,
+      }));
+      getHistoryRepairDiagnosticsMock.mockReturnValue(repairedDiagnostics);
+
+      const agentLoopRun: AgentLoopRun = async (messages, onEvent) => {
+        await onEvent({ type: "llm_call_started" });
+        callCount++;
+        expect(messages.map((message) => message.role)).toEqual([
+          "user",
+          "assistant",
+          "user",
+        ]);
+        expect(messages[1].content.map((block) => block.type)).toEqual([
+          "tool_use",
+          "text",
+        ]);
+        expect(
+          messages[2].content.some(
+            (block) =>
+              block.type === "tool_result" &&
+              block.tool_use_id === "tool-secret",
+          ),
+        ).toBe(true);
+
+        onEvent({
+          type: "message_complete",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "fixed" }],
+          },
+        });
+        onEvent({
+          type: "usage",
+          inputTokens: 50,
+          outputTokens: 25,
+          model: "test-model",
+          providerDurationMs: 100,
+        });
+        return [
+          ...messages,
+          {
+            role: "assistant" as const,
+            content: [{ type: "text", text: "fixed" }] as ContentBlock[],
+          },
+        ];
+      };
+
+      const ctx = makeCtx({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "Slack user message" }],
+          },
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: "tool-secret",
+                name: "bash",
+                input: { cmd: "echo hidden" },
+              },
+            ],
+          },
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "text",
+                text: "assistant trailing text should stay attached",
+              },
+            ],
+          },
+        ],
+        agentLoopRun,
+        channelCapabilities: {
+          channel: "slack",
+          dashboardCapable: false,
+          supportsDynamicUi: false,
+          supportsVoiceInput: false,
+          chatType: "im",
+        },
+        getTurnChannelContext: () => ({
+          userMessageChannel: "slack",
+          assistantMessageChannel: "slack",
+        }),
+      });
+
+      await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
+
+      expect(callCount).toBe(1);
+      expect(repairHistoryMock).toHaveBeenCalledTimes(1);
+      expect(deepRepairHistoryMock).not.toHaveBeenCalled();
+    });
+
     test("logs redacted Slack tail diagnostics for final-assistant ordering failures", async () => {
       const events: ServerMessage[] = [];
       let callCount = 0;

--- a/assistant/src/__tests__/conversation-load-history-repair.test.ts
+++ b/assistant/src/__tests__/conversation-load-history-repair.test.ts
@@ -178,7 +178,11 @@ describe("loadFromDb history repair", () => {
     const messages = conversation.getMessages();
 
     // Repair should have inserted a synthetic user message with tool_result
-    expect(messages).toHaveLength(4);
+    expect(messages).toHaveLength(3);
+    expect(messages[1].content).toEqual([
+      { type: "tool_use", id: "tu_1", name: "bash", input: { cmd: "ls" } },
+      { type: "text", text: "Done" },
+    ]);
     expect(messages[2].role).toBe("user");
     const trBlocks = messages[2].content.filter(
       (b) => b.type === "tool_result",

--- a/assistant/src/__tests__/conversation-pre-run-repair.test.ts
+++ b/assistant/src/__tests__/conversation-pre-run-repair.test.ts
@@ -118,6 +118,51 @@ describe("pre-run history repair", () => {
     expect(stats.assistantToolResultsMigrated).toBe(1);
   });
 
+  test("merges a trailing assistant Slack tail before synthesizing the missing tool result", () => {
+    const messages: Message[] = [
+      {
+        role: "user",
+        content: [{ type: "text", text: "Slack user message" }],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "tu_slack_tail",
+            name: "bash",
+            input: { cmd: "echo hidden" },
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Assistant trailing text" }],
+      },
+    ];
+
+    const { messages: repaired, stats } = repairHistory(messages);
+
+    expect(repaired.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+      "user",
+    ]);
+    expect(repaired[1].content.map((block) => block.type)).toEqual([
+      "tool_use",
+      "text",
+    ]);
+    expect(
+      repaired[2].content.some(
+        (block) =>
+          block.type === "tool_result" &&
+          block.tool_use_id === "tu_slack_tail",
+      ),
+    ).toBe(true);
+    expect(stats.consecutiveSameRoleMerged).toBe(1);
+    expect(stats.missingToolResultsInserted).toBe(1);
+  });
+
   test("consecutive same-role messages get merged", () => {
     const messages: Message[] = [
       {

--- a/assistant/src/__tests__/history-repair.test.ts
+++ b/assistant/src/__tests__/history-repair.test.ts
@@ -120,7 +120,12 @@ describe("repairHistory", () => {
     const { messages: repaired, stats } = repairHistory(messages);
 
     expect(stats.missingToolResultsInserted).toBe(1);
-    expect(repaired).toHaveLength(4);
+    expect(stats.consecutiveSameRoleMerged).toBe(1);
+    expect(repaired).toHaveLength(3);
+    expect(repaired[1].content).toEqual([
+      { type: "tool_use", id: "tu_1", name: "bash", input: { cmd: "ls" } },
+      { type: "text", text: "Oops" },
+    ]);
     expect(repaired[2].role).toBe("user");
     expect(repaired[2].content[0].type).toBe("tool_result");
   });
@@ -314,20 +319,17 @@ describe("repairHistory", () => {
     expect(stats.assistantToolResultsMigrated).toBe(1);
     expect(stats.missingToolResultsInserted).toBe(0);
 
-    // assistant message should have tool_use only
+    // assistant message keeps the trailing text attached before the
+    // migrated tool_result user message is synthesized.
     expect(repaired[1].content).toEqual([
       { type: "tool_use", id: "tu_1", name: "bash", input: { cmd: "ls" } },
+      { type: "text", text: "Here are the files." },
     ]);
 
     // injected user message should carry the original result, not a synthetic error
     expect(repaired[2].role).toBe("user");
     expect(repaired[2].content).toEqual([
       { type: "tool_result", tool_use_id: "tu_1", content: "file1\nfile2" },
-    ]);
-
-    // original second assistant message follows
-    expect(repaired[3].content).toEqual([
-      { type: "text", text: "Here are the files." },
     ]);
   });
 
@@ -971,7 +973,7 @@ describe("repairHistory", () => {
         assistantToolResultsMigrated: 1,
         missingToolResultsInserted: 1,
         orphanToolResultsDowngraded: 0,
-        consecutiveSameRoleMerged: 1,
+        consecutiveSameRoleMerged: 2,
       },
       actions: {
         migratedAssistantToolResults: true,

--- a/assistant/src/plugins/defaults/history-repair/terminal.ts
+++ b/assistant/src/plugins/defaults/history-repair/terminal.ts
@@ -289,12 +289,18 @@ export function repairHistory(messages: Message[]): RepairResult {
     consecutiveSameRoleMerged: 0,
   };
 
+  // Merge same-role messages before tool pairing so a Slack tail like
+  // assistant(tool_use) + assistant(text) keeps the trailing text attached
+  // to the tool-calling assistant turn before synthetic tool_results are
+  // inserted. We still run a second merge pass after repair because the
+  // tool-result synthesis can introduce new adjacent user messages.
+  const normalizedInput = mergeConsecutiveSameRoleMessages(messages, stats);
   const result: Message[] = [];
   let pendingToolUseIds = new Set<string>();
   // tool_result blocks stripped from assistant messages, keyed by tool_use_id
   let recoveredResults = new Map<string, ToolResultContent>();
 
-  for (const msg of messages) {
+  for (const msg of normalizedInput) {
     if (msg.role === "assistant") {
       // If previous assistant had unfulfilled tool_use, inject user message
       // using recovered results where available, synthetic for the rest
@@ -497,8 +503,19 @@ export function repairHistory(messages: Message[]): RepairResult {
   // strict user/assistant alternation, so consecutive same-role messages must
   // always be merged. Undo semantics for mixed tool_result+text messages are
   // handled by isUndoableUserMessage in conversation.ts.
+  const merged = mergeConsecutiveSameRoleMessages(result, stats);
+
+  const diagnostics = buildHistoryRepairDiagnostics(stats);
+  rememberHistoryRepairDiagnostics(merged, diagnostics);
+  return { messages: merged, stats, diagnostics };
+}
+
+function mergeConsecutiveSameRoleMessages(
+  messages: ReadonlyArray<Message>,
+  stats: RepairStats,
+): Message[] {
   const merged: Message[] = [];
-  for (const msg of result) {
+  for (const msg of messages) {
     const prev = merged[merged.length - 1];
     if (prev && prev.role === msg.role) {
       prev.content = [...prev.content, ...msg.content];
@@ -507,10 +524,7 @@ export function repairHistory(messages: Message[]): RepairResult {
       merged.push({ role: msg.role, content: [...msg.content] });
     }
   }
-
-  const diagnostics = buildHistoryRepairDiagnostics(stats);
-  rememberHistoryRepairDiagnostics(merged, diagnostics);
-  return { messages: merged, stats, diagnostics };
+  return merged;
 }
 
 function buildResultMessage(
@@ -581,9 +595,9 @@ function formatWebSearchContent(content: unknown): string {
  * Aggressive repair pass that handles edge cases beyond repairHistory:
  * - Removes empty messages
  * - Ensures the first message is from the user
- * - Merges consecutive same-role messages (before tool-use/result repair)
- * Then applies the standard repairHistory on top (which also merges any
- * consecutive same-role messages introduced by tool-use/result repair).
+ * Then applies the standard repairHistory on top, which now pre-merges
+ * consecutive same-role messages before tool-use/result repair and merges any
+ * new adjacencies introduced by the repair itself.
  */
 export function deepRepairHistory(messages: Message[]): RepairResult {
   // 1. Remove messages with no content blocks
@@ -594,17 +608,6 @@ export function deepRepairHistory(messages: Message[]): RepairResult {
     cleaned = cleaned.slice(1);
   }
 
-  // 3. Merge consecutive same-role messages
-  const merged: Message[] = [];
-  for (const msg of cleaned) {
-    const prev = merged[merged.length - 1];
-    if (prev && prev.role === msg.role) {
-      prev.content = [...prev.content, ...msg.content];
-    } else {
-      merged.push({ role: msg.role, content: [...msg.content] });
-    }
-  }
-
-  // 4. Apply standard tool-use/tool-result repair on top
-  return repairHistory(merged);
+  // 3. Apply standard tool-use/tool-result repair on top
+  return repairHistory(cleaned);
 }


### PR DESCRIPTION
## Summary
- merge consecutive same-role messages before tool-result synthesis so Slack assistant tails repair into a provider-valid order on the normal path
- keep deep repair focused on stripping empty and leading assistant messages before delegating to the shared repair logic
- add regressions for the real repair function and the agent-loop pre-run path

Part of JARVIS-1046