### PR TITLE
feat: add platform gating to infrastructure settings

### DIFF
--- a/apps/web/src/domains/settings/pages/advanced-page.tsx
+++ b/apps/web/src/domains/settings/pages/advanced-page.tsx
@@ -1,19 +1,32 @@
+import { Notice } from "@vellum/design-library/components/notice";
 import { DetailCard } from "@/components/detail-card";
 import { UpdateWindowPolicy } from "@/domains/settings/components/update-window-policy";
 import { useAssistantWithHealthz } from "@/domains/settings/components/assistant-status-panel";
+import { usePlatformGate } from "@/hooks/use-platform-gate";
 
 export function AdvancedPage() {
   const { assistant } = useAssistantWithHealthz();
+  const infraGate = usePlatformGate({ platformHostedOnly: true });
   const platformAssistant = assistant?.is_local ? null : assistant;
 
   return (
     <div className="max-w-[940px] space-y-4">
-      {platformAssistant && (
+      {infraGate === "full" && platformAssistant && (
         <DetailCard
           title="Update Window"
           subtitle="Configure when automatic updates are applied."
         >
           <UpdateWindowPolicy assistantId={platformAssistant.id} />
+        </DetailCard>
+      )}
+      {infraGate === "disabled" && (
+        <DetailCard
+          title="Update Window"
+          subtitle="Configure when automatic updates are applied."
+        >
+          <Notice tone="info">
+            Log in to the Vellum platform to manage update window policy.
+          </Notice>
         </DetailCard>
       )}
     </div>

--- a/apps/web/src/domains/settings/pages/devices-page.tsx
+++ b/apps/web/src/domains/settings/pages/devices-page.tsx
@@ -1,18 +1,67 @@
 import { Loader2 } from "lucide-react";
+import { Navigate } from "react-router";
 
 import { useQuery } from "@tanstack/react-query";
 
+import { Notice } from "@vellum/design-library/components/notice";
 import { DetailCard } from "@/components/detail-card";
 import { DeviceRow } from "@/domains/settings/components/device-row";
 import { assistantsListOptions } from "@/generated/api/@tanstack/react-query.gen";
 import type { Assistant } from "@/generated/api/types.gen";
+import {
+  useActiveAssistantIsPlatformHosted,
+  useActiveAssistantLifecycleIsLoading,
+  usePlatformGate,
+} from "@/hooks/use-platform-gate";
+import { routes } from "@/utils/routes";
 
 export function DevicesPage() {
-  const { data, isLoading } = useQuery(
-    assistantsListOptions({ query: { hosting: "local" } }),
-  );
+  const platformGate = usePlatformGate({ platformHostedOnly: true });
+  const isPlatformHosted = useActiveAssistantIsPlatformHosted();
+  const isLifecycleLoading = useActiveAssistantLifecycleIsLoading();
+
+  const { data, isLoading } = useQuery({
+    ...assistantsListOptions({ query: { hosting: "local" } }),
+    enabled: platformGate === "full" && isPlatformHosted,
+  });
 
   const devices = (data?.results ?? []) as Assistant[];
+
+  if (platformGate === "gated") {
+    return <Navigate replace to={routes.settings.general} />;
+  }
+
+  if (platformGate === "disabled") {
+    return (
+      <div className="max-w-[940px] space-y-4">
+        <Notice tone="info">
+          Log in to the Vellum platform to manage self-hosted assistants.
+        </Notice>
+      </div>
+    );
+  }
+
+  if (isLifecycleLoading) {
+    return (
+      <div className="max-w-[940px] space-y-4">
+        <div className="flex items-center gap-2 py-6 text-body-medium-lighter text-[var(--content-secondary)]">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Loading devices…
+        </div>
+      </div>
+    );
+  }
+
+  if (!isPlatformHosted) {
+    return (
+      <div className="max-w-[940px] space-y-4">
+        <Notice tone="warning">
+          Self-hosted assistant management isn&apos;t available for the current
+          assistant state.
+        </Notice>
+      </div>
+    );
+  }
 
   return (
     <div className="max-w-[940px] space-y-4">

--- a/apps/web/src/domains/settings/pages/general-page.tsx
+++ b/apps/web/src/domains/settings/pages/general-page.tsx
@@ -1,6 +1,7 @@
 import { Heart, Monitor, Moon, Sun } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
+import { Notice } from "@vellum/design-library/components/notice";
 import { SegmentControl } from "@vellum/design-library/components/segment-control";
 import { AssistantPicker } from "@/domains/settings/components/assistant-picker";
 import { AssistantSleepPolicy } from "@/domains/settings/components/assistant-sleep-policy";
@@ -214,6 +215,7 @@ export function GeneralPage() {
   const settingsSleepPolicy = useAssistantFeatureFlagStore.use.settingsSleepPolicy();
   const isLoggedIn = useAuthStore.use.isLoggedIn();
   const platformGate = usePlatformGate();
+  const infraGate = usePlatformGate({ platformHostedOnly: true });
 
   const platformAssistant = assistant?.is_local && !isLocalMode() ? null : assistant;
 
@@ -245,7 +247,7 @@ export function GeneralPage() {
 
       {isLoggedIn && platformGate === "full" && <ProfileCard assistant={platformAssistant} />}
 
-      {assistant && (
+      {infraGate === "full" && assistant && (
         <ResizeCard
           assistant={assistant}
           healthz={healthz}
@@ -255,10 +257,21 @@ export function GeneralPage() {
           refetchUntilResized={refetchUntilResized}
         />
       )}
+      {infraGate === "disabled" && (
+        <DetailCard
+          id="storage-resources"
+          title="Compute & Resources"
+          subtitle="Monitor resource usage and manage your assistant's compute profile."
+        >
+          <Notice tone="info">
+            Log in to the Vellum platform to manage compute resources.
+          </Notice>
+        </DetailCard>
+      )}
 
       <ThemeCard />
 
-      {platformAssistant && (
+      {infraGate === "full" && platformAssistant && (
         <DetailCard title="Software Updates">
           <AssistantUpgrades
             assistantId={platformAssistant.id}
@@ -280,15 +293,32 @@ export function GeneralPage() {
           />
         </DetailCard>
       )}
+      {infraGate === "disabled" && (
+        <DetailCard title="Software Updates">
+          <Notice tone="info">
+            Log in to the Vellum platform to manage software updates.
+          </Notice>
+        </DetailCard>
+      )}
 
       <IOSAppCard />
 
-      {platformAssistant && settingsSleepPolicy && (
+      {infraGate === "full" && platformAssistant && settingsSleepPolicy && (
         <DetailCard
           title="Sleep Policy"
           subtitle="Control how long this assistant stays awake when idle."
         >
           <AssistantSleepPolicy assistantId={platformAssistant.id} />
+        </DetailCard>
+      )}
+      {infraGate === "disabled" && settingsSleepPolicy && (
+        <DetailCard
+          title="Sleep Policy"
+          subtitle="Control how long this assistant stays awake when idle."
+        >
+          <Notice tone="info">
+            Log in to the Vellum platform to manage sleep policy.
+          </Notice>
         </DetailCard>
       )}
 

--- a/apps/web/src/domains/settings/settings-layout.tsx
+++ b/apps/web/src/domains/settings/settings-layout.tsx
@@ -46,6 +46,9 @@ export function SettingsLayout() {
         if (item.id === "billing" && platformGate === "gated") {
           return false;
         }
+        if (item.id === "devices" && platformGate === "gated") {
+          return false;
+        }
         if (item.id === "sounds" && !sounds) {
           return false;
         }


### PR DESCRIPTION
## Summary
- Gate the **Devices page** with full page-level `platformHostedOnly: true` pattern (redirect when self-hosted, login notice when no session, lifecycle spinner, query gating with `isPlatformHosted`)
- Gate **ResizeCard**, **Software Updates** (upgrades + preview channel), and **Sleep Policy** sections on the General page with `infraGate` — hidden for self-hosted, login notice for disabled, fixes existing bug where `platformAssistant` included self-hosted assistants in local mode
- Gate **Update Window** on the Advanced page with the same pattern
- Filter **"devices"** sidebar item in settings-layout.tsx when gated

## Original prompt
Implement the "Platform-Managed Infrastructure" section of the Web UI Platform Decoupling inventory. All 7 features (devices page, assistant upgrades, update window policy, preview release channel, assistant sleep policy, resize card, version selection screen) manage platform-hosted infrastructure and are irrelevant for self-hosted assistants. All use the `platformHostedOnly: true` gate pattern: Full for Case 1, Disable for Case 2, Gate for Cases 3-5. Version selection screen was already naturally gated by the lifecycle state machine. A bug was found where `platformAssistant` in general-page.tsx included self-hosted assistants in local mode — fixed by adding `infraGate === "full"` checks to infrastructure sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)