### PR TITLE
feat(skills): add skill category metadata to SKILL.md frontmatter

### DIFF
--- a/scripts/skills/lint-skill-spec.mjs
+++ b/scripts/skills/lint-skill-spec.mjs
@@ -23,6 +23,7 @@
  * Options:
  *   --dir <path>           Override the default skills directory (skills/)
  *   --skip-emoji           Skip the Vellum-specific metadata.emoji check
+ *   --skip-category        Skip the Vellum-specific metadata.vellum.category check
  *   --allow-tools-json     Skip the TOOLS.json prohibition check
  *
  * If no skill names are provided, all skills are checked.
@@ -47,6 +48,7 @@ function parseCLIArgs(argv) {
   const args = argv.slice(2);
   let skillsDir = DEFAULT_SKILLS_DIR;
   let skipEmoji = false;
+  let skipCategory = false;
   let allowToolsJson = false;
   const filterSkills = [];
 
@@ -56,6 +58,8 @@ function parseCLIArgs(argv) {
       i++; // skip next arg (the path)
     } else if (args[i] === "--skip-emoji") {
       skipEmoji = true;
+    } else if (args[i] === "--skip-category") {
+      skipCategory = true;
     } else if (args[i] === "--allow-tools-json") {
       allowToolsJson = true;
     } else {
@@ -63,10 +67,10 @@ function parseCLIArgs(argv) {
     }
   }
 
-  return { skillsDir, skipEmoji, allowToolsJson, filterSkills };
+  return { skillsDir, skipEmoji, skipCategory, allowToolsJson, filterSkills };
 }
 
-const { skillsDir: SKILLS_DIR, skipEmoji: SKIP_EMOJI, allowToolsJson: ALLOW_TOOLS_JSON, filterSkills: CLI_FILTER_SKILLS } = parseCLIArgs(process.argv);
+const { skillsDir: SKILLS_DIR, skipEmoji: SKIP_EMOJI, skipCategory: SKIP_CATEGORY, allowToolsJson: ALLOW_TOOLS_JSON, filterSkills: CLI_FILTER_SKILLS } = parseCLIArgs(process.argv);
 
 // --- Validation Rules ---
 
@@ -198,6 +202,87 @@ function validateMetadataEmoji(metadata) {
   return errors;
 }
 
+// --- Category catalog loading ---
+
+function loadCategorySlugs(skillsDir) {
+  const catalogPath = join(skillsDir, "skill-categories-catalog.yaml");
+  try {
+    const raw = readFileSync(catalogPath, "utf-8");
+    const slugs = new Set();
+    for (const line of raw.split("\n")) {
+      const match = line.match(/^\s+-?\s*slug:\s*(.+)/);
+      if (match) {
+        slugs.add(match[1].trim());
+      }
+    }
+    return slugs;
+  } catch {
+    return null;
+  }
+}
+
+function validateCategory(metadata, validSlugs) {
+  const errors = [];
+
+  if (!validSlugs) {
+    return errors;
+  }
+
+  if (typeof metadata === "string") {
+    try {
+      const parsed = JSON.parse(metadata);
+      const cat = parsed.vellum?.category;
+      if (typeof cat === "string" && cat.length > 0) {
+        if (!validSlugs.has(cat)) {
+          errors.push(
+            `"metadata.vellum.category" value "${cat}" is not a valid category slug. ` +
+              `Valid slugs: ${[...validSlugs].join(", ")}`,
+          );
+        }
+        return errors;
+      }
+    } catch {
+      // fall through
+    }
+    errors.push(
+      'Required field "metadata.vellum.category" is missing. Skills must declare a category.',
+    );
+    return errors;
+  }
+
+  if (!metadata || typeof metadata !== "object") {
+    errors.push(
+      'Required field "metadata.vellum.category" is missing. Skills must declare a category.',
+    );
+    return errors;
+  }
+
+  const vellum = metadata.vellum;
+  if (!vellum || typeof vellum !== "object") {
+    errors.push(
+      'Required field "metadata.vellum.category" is missing. Skills must declare a category.',
+    );
+    return errors;
+  }
+
+  const cat = vellum.category;
+  if (typeof cat !== "string" || cat.length === 0) {
+    errors.push(
+      'Required field "metadata.vellum.category" is missing or empty. Skills must declare a category.',
+    );
+    return errors;
+  }
+
+  if (!validSlugs.has(cat)) {
+    errors.push(
+      `"metadata.vellum.category" value "${cat}" is not a valid category slug. ` +
+        `Valid slugs: ${[...validSlugs].join(", ")}`,
+    );
+  }
+
+  return errors;
+}
+
 /**
  * Detect non-standard top-level fields and recommend migration.
  *
@@ -238,15 +323,16 @@ function validateNonStandardFields(frontmatter) {
   return errors;
 }
 
-function validateSkill(skillName, { skillsDir, skipEmoji, allowToolsJson }) {
+function validateSkill(skillName, { skillsDir, skipEmoji, skipCategory, allowToolsJson, validSlugs }) {
   const skillDir = join(skillsDir, skillName);
   const skillMdPath = join(skillDir, "SKILL.md");
   const toolsJsonPath = join(skillDir, "TOOLS.json");
   const errors = [];
+  let category = undefined;
   const prefix = `${skillName}/SKILL.md`;
 
   if (!statSync(skillDir, { throwIfNoEntry: false })?.isDirectory()) {
-    return errors;
+    return { errors, category };
   }
 
   // 0. TOOLS.json must not exist — skills should rely on CLI tools in scripts/, not custom tool definitions
@@ -263,7 +349,7 @@ function validateSkill(skillName, { skillsDir, skipEmoji, allowToolsJson }) {
   const stat = statSync(skillMdPath, { throwIfNoEntry: false });
   if (!stat || !stat.isFile()) {
     errors.push(`${prefix} is missing.`);
-    return errors;
+    return { errors, category };
   }
 
   // 2. Parse frontmatter
@@ -274,7 +360,12 @@ function validateSkill(skillName, { skillsDir, skipEmoji, allowToolsJson }) {
     frontmatter = parsed.frontmatter;
   } catch (e) {
     errors.push(`${prefix}: ${e.message}`);
-    return errors;
+    return { errors, category };
+  }
+
+  // Extract category for cross-catalog validation
+  if (typeof frontmatter.metadata === "object") {
+    category = frontmatter.metadata?.vellum?.category;
   }
 
   // 3. Validate required fields
@@ -306,14 +397,23 @@ function validateSkill(skillName, { skillsDir, skipEmoji, allowToolsJson }) {
     );
   }
 
-  // 6. Check for non-standard fields and recommend migration
+  // 6. Validate required metadata.vellum.category — skippable via --skip-category
+  if (!skipCategory && validSlugs) {
+    errors.push(
+      ...validateCategory(frontmatter.metadata, validSlugs).map(
+        (e) => `${prefix}: ${e}`,
+      ),
+    );
+  }
+
+  // 7. Check for non-standard fields and recommend migration
   errors.push(
     ...validateNonStandardFields(frontmatter).map(
       (e) => `${prefix}: ${e}`,
     ),
   );
 
-  return errors;
+  return { errors, category };
 }
 
 // --- Main ---
@@ -336,15 +436,37 @@ function getSkillDirs(skillsDir, filter) {
 }
 
 const skillDirs = getSkillDirs(SKILLS_DIR, CLI_FILTER_SKILLS);
+const validSlugs = SKIP_CATEGORY ? null : loadCategorySlugs(SKILLS_DIR);
 
 let totalErrors = 0;
+const referencedCategories = new Set();
 
 for (const skill of skillDirs) {
-  const errors = validateSkill(skill, { skillsDir: SKILLS_DIR, skipEmoji: SKIP_EMOJI, allowToolsJson: ALLOW_TOOLS_JSON });
+  const { errors, category } = validateSkill(skill, {
+    skillsDir: SKILLS_DIR,
+    skipEmoji: SKIP_EMOJI,
+    skipCategory: SKIP_CATEGORY,
+    allowToolsJson: ALLOW_TOOLS_JSON,
+    validSlugs,
+  });
   for (const err of errors) {
     console.error(err);
   }
   totalErrors += errors.length;
+
+  if (category) referencedCategories.add(category);
+}
+
+// Cross-catalog validation: every category in the catalog must be used by at least one skill
+if (!SKIP_CATEGORY && validSlugs && CLI_FILTER_SKILLS.length === 0) {
+  for (const slug of validSlugs) {
+    if (!referencedCategories.has(slug)) {
+      console.error(
+        `skill-categories-catalog.yaml: category "${slug}" is not referenced by any skill. Remove it or assign at least one skill to it.`,
+      );
+      totalErrors++;
+    }
+  }
 }
 
 if (totalErrors > 0) {

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -239,3 +239,4 @@
 
 - **Vellum-specific extensions**
   - If you must do something Vellum-system specific, use the `metadata` field to connect the skill in a structured way
+  - **`metadata.vellum.category`** (required): every skill must declare a category slug matching an entry in `skills/skill-categories-catalog.yaml`. The linter validates this in both directions — skills must reference a valid category, and every category must be used by at least one skill. Pass `--skip-category` to the linter to skip this check for external/third-party skills.

--- a/skills/amazon/SKILL.md
+++ b/skills/amazon/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   icon: assets/icon.svg
   emoji: "🛒"
   vellum:
+    category: "commerce"
     display-name: "Amazon"
     includes: ["vellum-browser-use"]
 ---

--- a/skills/api-mapping/SKILL.md
+++ b/skills/api-mapping/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   icon: assets/icon.svg
   emoji: "🗺️"
   vellum:
+    category: "development"
     display-name: "API Mapping"
 ---
 

--- a/skills/assistant-migration/SKILL.md
+++ b/skills/assistant-migration/SKILL.md
@@ -5,6 +5,7 @@ compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "🧳"
   vellum:
+    category: "system"
     display-name: "Assistant Migration"
     includes: ["chatgpt-import"]
     activation-hints:

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -88,7 +88,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:01:09.000Z"
     },
     {
       "id": "conversation-launcher",
@@ -276,7 +276,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:01:09.000Z"
     },
     {
       "id": "headless-claude-code",
@@ -495,7 +495,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:01:09.000Z"
     },
     {
       "id": "notion",
@@ -527,7 +527,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:01:09.000Z"
     },
     {
       "id": "oura-setup",
@@ -1019,7 +1019,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:01:09.000Z"
     },
     {
       "id": "vellum-terminal-sessions",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -10,6 +10,7 @@
         "icon": "assets/icon.svg",
         "emoji": "🛒",
         "vellum": {
+          "category": "commerce",
           "display-name": "Amazon",
           "includes": [
             "vellum-browser-use"
@@ -17,7 +18,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T16:56:28.000Z"
+      "updatedAt": "2026-06-02T18:03:42.000Z"
     },
     {
       "id": "api-mapping",
@@ -27,11 +28,12 @@
         "icon": "assets/icon.svg",
         "emoji": "🗺️",
         "vellum": {
+          "category": "development",
           "display-name": "API Mapping"
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T16:58:51.000Z"
+      "updatedAt": "2026-06-02T18:03:42.000Z"
     },
     {
       "id": "assistant-migration",
@@ -40,6 +42,7 @@
       "metadata": {
         "emoji": "🧳",
         "vellum": {
+          "category": "system",
           "display-name": "Assistant Migration",
           "includes": [
             "chatgpt-import"
@@ -66,6 +69,7 @@
       "metadata": {
         "emoji": "📥",
         "vellum": {
+          "category": "system",
           "display-name": "ChatGPT Import"
         }
       },
@@ -79,6 +83,7 @@
       "metadata": {
         "emoji": "🔍",
         "vellum": {
+          "category": "development",
           "display-name": "CLI Discovery"
         }
       },
@@ -92,6 +97,7 @@
       "metadata": {
         "emoji": "🧭",
         "vellum": {
+          "category": "productivity",
           "display-name": "Conversation Launcher"
         }
       },
@@ -105,6 +111,7 @@
       "metadata": {
         "emoji": "🚀",
         "vellum": {
+          "category": "development",
           "display-name": "Deploy Fullstack to Vercel"
         }
       },
@@ -119,11 +126,12 @@
         "icon": "assets/icon.svg",
         "emoji": "🎮",
         "vellum": {
+          "category": "messaging",
           "display-name": "Discord App Setup"
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T16:56:28.000Z"
+      "updatedAt": "2026-06-02T18:03:42.000Z"
     },
     {
       "id": "doordash",
@@ -133,11 +141,12 @@
         "icon": "assets/icon.svg",
         "emoji": "🍕",
         "vellum": {
+          "category": "commerce",
           "display-name": "DoorDash"
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T16:56:28.000Z"
+      "updatedAt": "2026-06-02T18:03:42.000Z"
     },
     {
       "id": "elevenlabs-voice",
@@ -147,11 +156,12 @@
         "icon": "assets/icon.svg",
         "emoji": "🗣️",
         "vellum": {
+          "category": "voice",
           "display-name": "ElevenLabs Voice"
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T16:56:28.000Z"
+      "updatedAt": "2026-06-02T18:03:42.000Z"
     },
     {
       "id": "email-setup",
@@ -160,6 +170,7 @@
       "metadata": {
         "emoji": "📧",
         "vellum": {
+          "category": "email",
           "display-name": "Email Setup"
         }
       },
@@ -173,6 +184,7 @@
       "metadata": {
         "emoji": "🎙️",
         "vellum": {
+          "category": "voice",
           "display-name": "Fish Audio TTS"
         }
       },
@@ -187,11 +199,12 @@
         "icon": "assets/icon.svg",
         "emoji": "🎨",
         "vellum": {
+          "category": "development",
           "display-name": "Frontend Design"
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T16:56:28.000Z"
+      "updatedAt": "2026-06-02T18:03:42.000Z"
     },
     {
       "id": "geo-writing",
@@ -200,6 +213,7 @@
       "metadata": {
         "emoji": "✍️",
         "vellum": {
+          "category": "content",
           "display-name": "GEO Article Writer",
           "activation-hints": [
             "GEO content writing, SEO article optimization",
@@ -218,12 +232,13 @@
         "icon": "assets/icon.svg",
         "emoji": "📨",
         "vellum": {
+          "category": "email",
           "display-name": "Gmail",
           "user-invocable": "true"
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T17:01:40.000Z"
+      "updatedAt": "2026-06-02T18:03:42.000Z"
     },
     {
       "id": "google-calendar",
@@ -233,12 +248,13 @@
         "icon": "assets/icon.svg",
         "emoji": "📅",
         "vellum": {
+          "category": "calendar",
           "display-name": "Google Calendar",
           "user-invocable": "true"
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T16:56:28.000Z"
+      "updatedAt": "2026-06-02T18:03:42.000Z"
     },
     {
       "id": "guardian-verify-setup",
@@ -247,6 +263,7 @@
       "metadata": {
         "emoji": "🔐",
         "vellum": {
+          "category": "integrations",
           "display-name": "Guardian Verify Setup",
           "activation-hints": [
             "Any guardian verification intent -> load this skill exclusively",
@@ -268,6 +285,7 @@
       "metadata": {
         "emoji": "🖥️",
         "vellum": {
+          "category": "development",
           "display-name": "Headless Claude Code"
         }
       },
@@ -282,6 +300,7 @@
         "icon": "assets/icon.svg",
         "emoji": "📭",
         "vellum": {
+          "category": "email",
           "display-name": "Inbox Cleanup",
           "activation-hints": [
             "When the user asks to clean up, organize, or triage their email inbox",
@@ -295,7 +314,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T16:58:51.000Z"
+      "updatedAt": "2026-06-02T18:03:42.000Z"
     },
     {
       "id": "inbox-management",
@@ -305,6 +324,7 @@
         "icon": "assets/icon.svg",
         "emoji": "📬",
         "vellum": {
+          "category": "email",
           "display-name": "Inbox Management",
           "includes": [
             "gmail"
@@ -323,7 +343,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T16:58:51.000Z"
+      "updatedAt": "2026-06-02T18:03:42.000Z"
     },
     {
       "id": "influencer",
@@ -332,6 +352,7 @@
       "metadata": {
         "emoji": "🔍",
         "vellum": {
+          "category": "browsing",
           "display-name": "Influencer Research",
           "includes": [
             "vellum-browser-use"
@@ -349,12 +370,13 @@
         "icon": "assets/icon.svg",
         "emoji": "🔷",
         "vellum": {
+          "category": "development",
           "display-name": "Linear App Setup",
           "user-invocable": "true"
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T16:56:28.000Z"
+      "updatedAt": "2026-06-02T18:03:42.000Z"
     },
     {
       "id": "llm-cost-optimizer",
@@ -363,6 +385,7 @@
       "metadata": {
         "emoji": "💸",
         "vellum": {
+          "category": "development",
           "display-name": "LLM Cost Optimizer"
         }
       },
@@ -376,6 +399,7 @@
         "icon": "assets/icon.svg",
         "emoji": "🍎",
         "vellum": {
+          "category": "system",
           "display-name": "macOS Automation",
           "activation-hints": [
             "Interacting with native macOS apps (Messages, Contacts, Calendar, Mail, Reminders, Music, Finder, etc.) via osascript"
@@ -386,7 +410,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T16:58:51.000Z"
+      "updatedAt": "2026-06-02T18:03:42.000Z"
     },
     {
       "id": "mailgun-setup",
@@ -396,12 +420,13 @@
         "icon": "assets/icon.svg",
         "emoji": "📬",
         "vellum": {
+          "category": "email",
           "display-name": "Mailgun Email Setup",
           "user-invocable": "true"
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T16:56:28.000Z"
+      "updatedAt": "2026-06-02T18:03:42.000Z"
     },
     {
       "id": "mcp-setup",
@@ -410,6 +435,7 @@
       "metadata": {
         "emoji": "🔌",
         "vellum": {
+          "category": "integrations",
           "display-name": "MCP Setup"
         }
       },
@@ -424,11 +450,12 @@
         "icon": "assets/icon.svg",
         "emoji": "📹",
         "vellum": {
+          "category": "voice",
           "display-name": "Meet Join",
           "feature-flag": "meet"
         }
       },
-      "updatedAt": "2026-06-02T16:56:28.000Z"
+      "updatedAt": "2026-06-02T18:03:42.000Z"
     },
     {
       "id": "meme-generator",
@@ -439,6 +466,7 @@
         "author": "vellum-ai",
         "version": "0.1",
         "vellum": {
+          "category": "content",
           "display-name": "Meme Generator",
           "activation-hints": [
             "User asks to create or generate a meme",
@@ -462,6 +490,7 @@
       "metadata": {
         "emoji": "🔔",
         "vellum": {
+          "category": "messaging",
           "display-name": "Notifications"
         }
       },
@@ -476,11 +505,12 @@
         "icon": "assets/icon.svg",
         "emoji": "📝",
         "vellum": {
+          "category": "productivity",
           "display-name": "Notion"
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T16:56:28.000Z"
+      "updatedAt": "2026-06-02T18:03:42.000Z"
     },
     {
       "id": "oura",
@@ -489,6 +519,7 @@
       "metadata": {
         "emoji": "💍",
         "vellum": {
+          "category": "health",
           "display-name": "Oura Ring",
           "includes": [
             "oura-setup"
@@ -505,6 +536,7 @@
       "metadata": {
         "emoji": "💍",
         "vellum": {
+          "category": "health",
           "display-name": "Oura Ring Setup"
         }
       },
@@ -519,12 +551,13 @@
         "icon": "assets/icon.svg",
         "emoji": "📧",
         "vellum": {
+          "category": "email",
           "display-name": "Outlook",
           "user-invocable": "true"
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T16:56:28.000Z"
+      "updatedAt": "2026-06-02T18:03:42.000Z"
     },
     {
       "id": "outlook-calendar",
@@ -534,12 +567,13 @@
         "icon": "assets/icon.svg",
         "emoji": "📅",
         "vellum": {
+          "category": "calendar",
           "display-name": "Outlook Calendar",
           "user-invocable": "true"
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T16:56:28.000Z"
+      "updatedAt": "2026-06-02T18:03:42.000Z"
     },
     {
       "id": "public-ingress",
@@ -548,6 +582,7 @@
       "metadata": {
         "emoji": "🌍",
         "vellum": {
+          "category": "system",
           "display-name": "Public Ingress",
           "activation-hints": [
             "Local assistant needs a public webhook or OAuth callback URL",
@@ -568,6 +603,7 @@
       "metadata": {
         "emoji": "📤",
         "vellum": {
+          "category": "email",
           "display-name": "Resend Email Setup",
           "user-invocable": "true"
         }
@@ -582,6 +618,7 @@
       "metadata": {
         "emoji": "🍽️",
         "vellum": {
+          "category": "commerce",
           "display-name": "Restaurant Reservation Booking",
           "includes": [
             "vellum-browser-use"
@@ -598,6 +635,7 @@
       "metadata": {
         "emoji": "🎬",
         "vellum": {
+          "category": "content",
           "display-name": "Screen Recording"
         }
       },
@@ -611,6 +649,7 @@
       "metadata": {
         "emoji": "⬆️",
         "vellum": {
+          "category": "system",
           "display-name": "Self Upgrade"
         }
       },
@@ -625,12 +664,13 @@
         "icon": "assets/icon.svg",
         "emoji": "🔺",
         "vellum": {
+          "category": "development",
           "display-name": "Sentry App Setup",
           "user-invocable": "true"
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T16:56:28.000Z"
+      "updatedAt": "2026-06-02T18:03:42.000Z"
     },
     {
       "id": "slack",
@@ -640,11 +680,12 @@
         "icon": "assets/icon.svg",
         "emoji": "💬",
         "vellum": {
+          "category": "messaging",
           "display-name": "Slack"
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T16:56:28.000Z"
+      "updatedAt": "2026-06-02T18:03:42.000Z"
     },
     {
       "id": "slack-app-setup",
@@ -653,6 +694,7 @@
       "metadata": {
         "emoji": "💬",
         "vellum": {
+          "category": "messaging",
           "display-name": "Slack App Setup",
           "includes": [
             "guardian-verify-setup"
@@ -670,11 +712,12 @@
         "icon": "assets/icon.svg",
         "emoji": "🌅",
         "vellum": {
+          "category": "productivity",
           "display-name": "Start the Day"
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T16:58:51.000Z"
+      "updatedAt": "2026-06-02T18:03:42.000Z"
     },
     {
       "id": "stripe-app-setup",
@@ -684,12 +727,13 @@
         "icon": "assets/icon.svg",
         "emoji": "💳",
         "vellum": {
+          "category": "commerce",
           "display-name": "Stripe App Setup",
           "user-invocable": "true"
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T16:56:28.000Z"
+      "updatedAt": "2026-06-02T18:03:42.000Z"
     },
     {
       "id": "stripe-link-wallet",
@@ -699,11 +743,12 @@
         "icon": "assets/icon.svg",
         "emoji": "💳",
         "vellum": {
+          "category": "commerce",
           "display-name": "Stripe Link Wallet"
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T16:56:28.000Z"
+      "updatedAt": "2026-06-02T18:03:42.000Z"
     },
     {
       "id": "tasks",
@@ -713,6 +758,7 @@
         "icon": "assets/icon.svg",
         "emoji": "✅",
         "vellum": {
+          "category": "productivity",
           "display-name": "Tasks",
           "activation-hints": [
             "User wants to add, check, or manage items on their to-do list or task queue",
@@ -724,7 +770,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T16:56:28.000Z"
+      "updatedAt": "2026-06-02T18:03:42.000Z"
     },
     {
       "id": "telegram-setup",
@@ -734,6 +780,7 @@
         "icon": "assets/icon.svg",
         "emoji": "🤖",
         "vellum": {
+          "category": "messaging",
           "display-name": "Telegram Setup",
           "activation-hints": [
             "Telegram bot setup, webhook configuration, or BotFather token",
@@ -745,7 +792,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T16:56:28.000Z"
+      "updatedAt": "2026-06-02T18:03:42.000Z"
     },
     {
       "id": "time-based-actions",
@@ -754,6 +801,7 @@
       "metadata": {
         "emoji": "⏰",
         "vellum": {
+          "category": "productivity",
           "display-name": "Time-Based Actions"
         }
       },
@@ -768,6 +816,7 @@
         "icon": "assets/icon.svg",
         "emoji": "📱",
         "vellum": {
+          "category": "integrations",
           "display-name": "Twilio Setup",
           "includes": [
             "public-ingress"
@@ -775,7 +824,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T16:56:28.000Z"
+      "updatedAt": "2026-06-02T18:03:42.000Z"
     },
     {
       "id": "typescript-eval",
@@ -784,6 +833,7 @@
       "metadata": {
         "emoji": "🧪",
         "vellum": {
+          "category": "development",
           "display-name": "TypeScript Evaluation"
         }
       },
@@ -797,6 +847,7 @@
       "metadata": {
         "emoji": "🎨",
         "vellum": {
+          "category": "content",
           "display-name": "Avatar"
         }
       },
@@ -810,6 +861,7 @@
       "metadata": {
         "emoji": "🌐",
         "vellum": {
+          "category": "browsing",
           "display-name": "Browser",
           "activation-hints": [
             "Load first if you need to browse the web (navigating, clicking, extracting web content) via `assistant browser` commands"
@@ -826,6 +878,7 @@
       "metadata": {
         "emoji": "💬",
         "vellum": {
+          "category": "productivity",
           "display-name": "Conversations"
         }
       },
@@ -842,11 +895,12 @@
         "author": "vellum-ai",
         "version": "1.0",
         "vellum": {
+          "category": "development",
           "display-name": "GitHub App Setup"
         }
       },
       "compatibility": "Designed for Vellum personal assistants. Requires Python 3, bun, and the assistant credentials CLI.",
-      "updatedAt": "2026-06-02T16:56:28.000Z"
+      "updatedAt": "2026-06-02T18:03:42.000Z"
     },
     {
       "id": "vellum-heartbeat",
@@ -855,6 +909,7 @@
       "metadata": {
         "emoji": "💓",
         "vellum": {
+          "category": "system",
           "display-name": "Heartbeat",
           "activation-hints": [
             "Set up a heartbeat, periodic checklist, background health check, or recurring background task"
@@ -874,6 +929,7 @@
       "metadata": {
         "emoji": "🧠",
         "vellum": {
+          "category": "system",
           "display-name": "Memory v2 Migration",
           "user-invocable": "true",
           "activation-hints": [
@@ -896,6 +952,7 @@
       "metadata": {
         "emoji": "🔌",
         "vellum": {
+          "category": "integrations",
           "display-name": "Vellum OAuth Integrations"
         }
       },
@@ -909,6 +966,7 @@
       "metadata": {
         "emoji": "🪞",
         "vellum": {
+          "category": "system",
           "display-name": "Vellum Self-Knowledge",
           "activation-hints": [
             "When the user asks what model the assistant is running on",
@@ -931,6 +989,7 @@
       "metadata": {
         "emoji": "🧩",
         "vellum": {
+          "category": "system",
           "display-name": "Skills Catalog",
           "activation-hints": [
             "what can you do",
@@ -955,6 +1014,7 @@
       "metadata": {
         "emoji": "🔊",
         "vellum": {
+          "category": "content",
           "display-name": "Sounds"
         }
       },
@@ -970,6 +1030,7 @@
         "author": "vellum-ai",
         "version": "0.2",
         "vellum": {
+          "category": "system",
           "display-name": "Terminal Sessions",
           "activation-hints": [
             "User asks about their running terminal sessions or processes",
@@ -995,6 +1056,7 @@
         "icon": "assets/icon.svg",
         "emoji": "▲",
         "vellum": {
+          "category": "development",
           "display-name": "Vercel Token Setup",
           "includes": [
             "vellum-browser-use"
@@ -1002,7 +1064,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T16:56:28.000Z"
+      "updatedAt": "2026-06-02T18:03:42.000Z"
     },
     {
       "id": "voice-setup",
@@ -1012,6 +1074,7 @@
         "icon": "assets/icon.svg",
         "emoji": "🎙️",
         "vellum": {
+          "category": "voice",
           "display-name": "Voice Setup",
           "includes": [
             "elevenlabs-voice"
@@ -1026,7 +1089,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T16:56:28.000Z"
+      "updatedAt": "2026-06-02T18:03:42.000Z"
     },
     {
       "id": "watch-together",
@@ -1035,6 +1098,7 @@
       "metadata": {
         "emoji": "📺",
         "vellum": {
+          "category": "content",
           "display-name": "Watch Together",
           "emoji": "📺"
         }
@@ -1048,6 +1112,7 @@
       "metadata": {
         "emoji": "👀",
         "vellum": {
+          "category": "productivity",
           "display-name": "Watcher"
         }
       },
@@ -1060,9 +1125,12 @@
       "description": "Get current weather conditions and forecasts for any location",
       "metadata": {
         "icon": "assets/icon.svg",
-        "emoji": "🌤️"
+        "emoji": "🌤️",
+        "vellum": {
+          "category": "productivity"
+        }
       },
-      "updatedAt": "2026-06-02T16:56:28.000Z"
+      "updatedAt": "2026-06-02T18:03:42.000Z"
     }
   ]
 }

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -18,7 +18,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T18:03:42.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "api-mapping",
@@ -33,7 +33,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T18:03:42.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "assistant-migration",
@@ -60,7 +60,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-29T12:58:30.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "chatgpt-import",
@@ -74,7 +74,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-19T14:29:07.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "cli-discover",
@@ -88,7 +88,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-03-17T07:13:56.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "conversation-launcher",
@@ -102,7 +102,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-18T14:09:07.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "deploy-fullstack-vercel",
@@ -116,7 +116,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-12T18:56:19.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "discord-app-setup",
@@ -131,7 +131,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T18:03:42.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "doordash",
@@ -146,7 +146,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T18:03:42.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "elevenlabs-voice",
@@ -161,7 +161,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T18:03:42.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "email-setup",
@@ -175,7 +175,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-01T15:44:38.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "fish-audio",
@@ -189,7 +189,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-11T21:51:53.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "frontend-design",
@@ -204,7 +204,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T18:03:42.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "geo-writing",
@@ -222,7 +222,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-22T13:03:09.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "gmail",
@@ -238,7 +238,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T18:03:42.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "google-calendar",
@@ -254,7 +254,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T18:03:42.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "guardian-verify-setup",
@@ -276,7 +276,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-03-20T14:49:53.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "headless-claude-code",
@@ -290,7 +290,7 @@
         }
       },
       "compatibility": "Any environment running Claude Code headlessly",
-      "updatedAt": "2026-04-24T00:58:01.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "inbox-cleanup",
@@ -314,7 +314,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T18:03:42.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "inbox-management",
@@ -343,7 +343,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T18:03:42.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "influencer",
@@ -360,7 +360,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-19T19:26:17.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "linear-app-setup",
@@ -376,7 +376,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T18:03:42.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "llm-cost-optimizer",
@@ -389,7 +389,7 @@
           "display-name": "LLM Cost Optimizer"
         }
       },
-      "updatedAt": "2026-05-28T21:37:15.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "macos-automation",
@@ -410,7 +410,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T18:03:42.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "mailgun-setup",
@@ -426,7 +426,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T18:03:42.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "mcp-setup",
@@ -440,7 +440,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-17T15:39:38.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "meet-join",
@@ -455,7 +455,7 @@
           "feature-flag": "meet"
         }
       },
-      "updatedAt": "2026-06-02T18:03:42.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "meme-generator",
@@ -481,7 +481,7 @@
         }
       },
       "compatibility": "Requires curl and python3. Works on macOS and Linux.",
-      "updatedAt": "2026-04-22T23:07:38.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "notifications",
@@ -495,7 +495,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-28T21:40:34.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "notion",
@@ -510,7 +510,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T18:03:42.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "oura",
@@ -527,7 +527,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-03T18:09:26.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "oura-setup",
@@ -541,7 +541,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-15T00:52:02.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "outlook",
@@ -557,7 +557,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T18:03:42.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "outlook-calendar",
@@ -573,7 +573,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T18:03:42.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "public-ingress",
@@ -594,7 +594,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-01T16:51:15.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "resend-setup",
@@ -609,7 +609,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-12T18:56:19.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "restaurant-reservation",
@@ -626,7 +626,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-19T19:26:17.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "screen-recording",
@@ -640,7 +640,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-03-17T07:13:56.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "self-upgrade",
@@ -654,7 +654,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-03-16T22:11:34.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "sentry-app-setup",
@@ -670,7 +670,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T18:03:42.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "slack",
@@ -685,7 +685,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T18:03:42.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "slack-app-setup",
@@ -702,7 +702,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-22T21:04:56.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "start-the-day",
@@ -717,7 +717,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T18:03:42.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "stripe-app-setup",
@@ -733,7 +733,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T18:03:42.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "stripe-link-wallet",
@@ -748,7 +748,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T18:03:42.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "tasks",
@@ -770,7 +770,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T18:03:42.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "telegram-setup",
@@ -792,7 +792,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T18:03:42.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "time-based-actions",
@@ -806,7 +806,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-23T14:19:18.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "twilio-setup",
@@ -824,7 +824,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T18:03:42.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "typescript-eval",
@@ -838,7 +838,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-03-15T16:39:46.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "vellum-avatar",
@@ -852,7 +852,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-23T22:43:45.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "vellum-browser-use",
@@ -869,7 +869,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-09T11:42:34.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "vellum-conversation-management",
@@ -883,7 +883,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-22T21:04:08.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "vellum-github-app-setup",
@@ -900,7 +900,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants. Requires Python 3, bun, and the assistant credentials CLI.",
-      "updatedAt": "2026-06-02T18:03:42.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "vellum-heartbeat",
@@ -920,7 +920,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-22T20:45:04.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "vellum-memory-v2-migration",
@@ -943,7 +943,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-10T15:35:07.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "vellum-oauth-integrations",
@@ -957,7 +957,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-27T18:02:41.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "vellum-self-knowledge",
@@ -980,7 +980,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-11T07:04:24.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "vellum-skills-catalog",
@@ -1005,7 +1005,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-22T22:15:21.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "vellum-sounds",
@@ -1019,7 +1019,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-13T05:03:23.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "vellum-terminal-sessions",
@@ -1046,7 +1046,7 @@
         }
       },
       "compatibility": "Sandbox mode works without any host dependencies. Host mode requires tmux installed on the user's machine. Works on macOS and Linux.",
-      "updatedAt": "2026-04-24T00:05:44.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "vercel-token-setup",
@@ -1064,7 +1064,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T18:03:42.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "voice-setup",
@@ -1089,7 +1089,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-02T18:03:42.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "watch-together",
@@ -1103,7 +1103,7 @@
           "emoji": "📺"
         }
       },
-      "updatedAt": "2026-05-14T15:15:31.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "watcher",
@@ -1117,7 +1117,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-19T19:12:37.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     },
     {
       "id": "weather",
@@ -1130,7 +1130,7 @@
           "category": "productivity"
         }
       },
-      "updatedAt": "2026-06-02T18:03:42.000Z"
+      "updatedAt": "2026-06-03T02:57:53.000Z"
     }
   ]
 }

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1019,7 +1019,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:01:09.000Z"
+      "updatedAt": "2026-06-03T03:05:10.000Z"
     },
     {
       "id": "vellum-terminal-sessions",

--- a/skills/chatgpt-import/SKILL.md
+++ b/skills/chatgpt-import/SKILL.md
@@ -5,6 +5,7 @@ compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "📥"
   vellum:
+    category: "system"
     display-name: "ChatGPT Import"
 ---
 

--- a/skills/cli-discover/SKILL.md
+++ b/skills/cli-discover/SKILL.md
@@ -5,6 +5,7 @@ compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "🔍"
   vellum:
+    category: "development"
     display-name: "CLI Discovery"
 ---
 

--- a/skills/cli-discover/SKILL.md
+++ b/skills/cli-discover/SKILL.md
@@ -32,17 +32,17 @@ Use a 5-second timeout to avoid hanging on unresponsive CLIs.
 
 For CLIs that support authentication, check whether the user is logged in:
 
-| CLI | Auth check command |
-|-----|-------------------|
-| `gh` | `gh auth status` |
-| `aws` | `aws sts get-caller-identity` |
-| `gcloud` | `gcloud auth list --filter=status:ACTIVE --format=value(account)` |
-| `az` | `az account show` |
-| `vercel` | `vercel whoami` |
-| `netlify` | `netlify status` |
-| `fly` | `fly auth whoami` |
-| `heroku` | `heroku auth:whoami` |
-| `railway` | `railway whoami` |
+| CLI       | Auth check command                                                |
+| --------- | ----------------------------------------------------------------- |
+| `gh`      | `gh auth status`                                                  |
+| `aws`     | `aws sts get-caller-identity`                                     |
+| `gcloud`  | `gcloud auth list --filter=status:ACTIVE --format=value(account)` |
+| `az`      | `az account show`                                                 |
+| `vercel`  | `vercel whoami`                                                   |
+| `netlify` | `netlify status`                                                  |
+| `fly`     | `fly auth whoami`                                                 |
+| `heroku`  | `heroku auth:whoami`                                              |
+| `railway` | `railway whoami`                                                  |
 
 ## Common CLIs worth checking
 

--- a/skills/conversation-launcher/SKILL.md
+++ b/skills/conversation-launcher/SKILL.md
@@ -5,6 +5,7 @@ compatibility: Designed for Vellum personal assistants
 metadata:
   emoji: "🧭"
   vellum:
+    category: "productivity"
     display-name: "Conversation Launcher"
 ---
 

--- a/skills/deploy-fullstack-vercel/SKILL.md
+++ b/skills/deploy-fullstack-vercel/SKILL.md
@@ -5,6 +5,7 @@ compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "🚀"
   vellum:
+    category: "development"
     display-name: "Deploy Fullstack to Vercel"
 ---
 

--- a/skills/discord-app-setup/SKILL.md
+++ b/skills/discord-app-setup/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   icon: assets/icon.svg
   emoji: "🎮"
   vellum:
+    category: "messaging"
     display-name: "Discord App Setup"
 ---
 

--- a/skills/doordash/SKILL.md
+++ b/skills/doordash/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   icon: assets/icon.svg
   emoji: "🍕"
   vellum:
+    category: "commerce"
     display-name: "DoorDash"
 ---
 

--- a/skills/elevenlabs-voice/SKILL.md
+++ b/skills/elevenlabs-voice/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   icon: assets/icon.svg
   emoji: "🗣️"
   vellum:
+    category: "voice"
     display-name: "ElevenLabs Voice"
 ---
 

--- a/skills/email-setup/SKILL.md
+++ b/skills/email-setup/SKILL.md
@@ -5,6 +5,7 @@ compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "📧"
   vellum:
+    category: "email"
     display-name: "Email Setup"
 ---
 

--- a/skills/fish-audio/SKILL.md
+++ b/skills/fish-audio/SKILL.md
@@ -5,6 +5,7 @@ compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "🎙️"
   vellum:
+    category: "voice"
     display-name: "Fish Audio TTS"
 ---
 

--- a/skills/frontend-design/SKILL.md
+++ b/skills/frontend-design/SKILL.md
@@ -7,6 +7,7 @@ metadata:
   icon: assets/icon.svg
   emoji: "🎨"
   vellum:
+    category: "development"
     display-name: "Frontend Design"
 ---
 

--- a/skills/geo-writing/SKILL.md
+++ b/skills/geo-writing/SKILL.md
@@ -5,6 +5,7 @@ compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "✍️"
   vellum:
+    category: "content"
     display-name: "GEO Article Writer"
     activation-hints:
       - "GEO content writing, SEO article optimization"

--- a/skills/gmail/SKILL.md
+++ b/skills/gmail/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   icon: assets/icon.svg
   emoji: "📨"
   vellum:
+    category: "email"
     display-name: "Gmail"
     user-invocable: true
 ---

--- a/skills/google-calendar/SKILL.md
+++ b/skills/google-calendar/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   icon: assets/icon.svg
   emoji: "📅"
   vellum:
+    category: "calendar"
     display-name: "Google Calendar"
     user-invocable: true
 ---

--- a/skills/guardian-verify-setup/SKILL.md
+++ b/skills/guardian-verify-setup/SKILL.md
@@ -5,6 +5,7 @@ compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "🔐"
   vellum:
+    category: "integrations"
     display-name: "Guardian Verify Setup"
     activation-hints:
       - "Any guardian verification intent -> load this skill exclusively"

--- a/skills/guardian-verify-setup/SKILL.md
+++ b/skills/guardian-verify-setup/SKILL.md
@@ -41,7 +41,6 @@ Based on the chosen channel, ask for the required destination:
   - If they know their numeric chat ID, provide it directly. The bot will send the code to that chat.
   - If they only know their @handle, the flow uses a bootstrap deep-link that they must click first.
 - **Slack**: Offer to look up the user's Slack member ID automatically to reduce friction:
-
   1. **Auto-lookup (preferred)**: Ask the user for their Slack display name or @handle, then look up their member ID using the Slack API:
 
      ```bash
@@ -62,7 +61,6 @@ Based on the chosen channel, ask for the required destination:
      ```
 
      Replace `<name>` and `<handle>` with the value the user provided (try matching against all fields).
-
      - **Single match**: Present it for confirmation: "I found @username (U01ABCDEF) — is that you?" If confirmed, use the `id` value as the destination for Step 3.
      - **Multiple matches**: Present the list (up to 5) and ask the user to pick: "I found a few matches — which one is you?" Use the confirmed `id` as the destination.
      - **No matches**: Tell the user no matches were found. Suggest they double-check the spelling, or fall back to manual entry (see below).

--- a/skills/headless-claude-code/SKILL.md
+++ b/skills/headless-claude-code/SKILL.md
@@ -5,6 +5,7 @@ compatibility: "Any environment running Claude Code headlessly"
 metadata:
   emoji: "🖥️"
   vellum:
+    category: "development"
     display-name: "Headless Claude Code"
 ---
 

--- a/skills/inbox-cleanup/SKILL.md
+++ b/skills/inbox-cleanup/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   icon: assets/icon.svg
   emoji: "📭"
   vellum:
+    category: "email"
     display-name: "Inbox Cleanup"
     activation-hints:
       - "When the user asks to clean up, organize, or triage their email inbox"

--- a/skills/inbox-management/SKILL.md
+++ b/skills/inbox-management/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   icon: assets/icon.svg
   emoji: "📬"
   vellum:
+    category: "email"
     display-name: "Inbox Management"
     includes: ["gmail"]
     activation-hints:

--- a/skills/influencer/SKILL.md
+++ b/skills/influencer/SKILL.md
@@ -5,6 +5,7 @@ compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "🔍"
   vellum:
+    category: "browsing"
     display-name: "Influencer Research"
     includes: ["vellum-browser-use"]
 ---

--- a/skills/linear-app-setup/SKILL.md
+++ b/skills/linear-app-setup/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   icon: assets/icon.svg
   emoji: "🔷"
   vellum:
+    category: "development"
     display-name: "Linear App Setup"
     user-invocable: true
 ---

--- a/skills/llm-cost-optimizer/SKILL.md
+++ b/skills/llm-cost-optimizer/SKILL.md
@@ -4,6 +4,7 @@ description: "Analyze and reduce LLM spend by mapping call-site overrides to man
 metadata:
   emoji: "💸"
   vellum:
+    category: "development"
     display-name: "LLM Cost Optimizer"
 ---
 

--- a/skills/macos-automation/SKILL.md
+++ b/skills/macos-automation/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   icon: assets/icon.svg
   emoji: "🍎"
   vellum:
+    category: "system"
     display-name: "macOS Automation"
     activation-hints:
       - "Interacting with native macOS apps (Messages, Contacts, Calendar, Mail, Reminders, Music, Finder, etc.) via osascript"

--- a/skills/mailgun-setup/SKILL.md
+++ b/skills/mailgun-setup/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   icon: assets/icon.svg
   emoji: "📬"
   vellum:
+    category: "email"
     display-name: "Mailgun Email Setup"
     user-invocable: true
 ---

--- a/skills/mcp-setup/SKILL.md
+++ b/skills/mcp-setup/SKILL.md
@@ -5,6 +5,7 @@ compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "🔌"
   vellum:
+    category: "integrations"
     display-name: "MCP Setup"
 ---
 

--- a/skills/meet-join/SKILL.md
+++ b/skills/meet-join/SKILL.md
@@ -5,6 +5,7 @@ metadata:
   icon: assets/icon.svg
   emoji: "📹"
   vellum:
+    category: "voice"
     display-name: "Meet Join"
     feature-flag: meet
 ---

--- a/skills/meme-generator/SKILL.md
+++ b/skills/meme-generator/SKILL.md
@@ -7,6 +7,7 @@ metadata:
   author: vellum-ai
   version: "0.1"
   vellum:
+    category: "content"
     display-name: "Meme Generator"
     activation-hints:
       - "User asks to create or generate a meme"

--- a/skills/notifications/SKILL.md
+++ b/skills/notifications/SKILL.md
@@ -5,6 +5,7 @@ compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "🔔"
   vellum:
+    category: "messaging"
     display-name: "Notifications"
 ---
 

--- a/skills/notifications/SKILL.md
+++ b/skills/notifications/SKILL.md
@@ -29,12 +29,12 @@ assistant notifications send --title "..." --message "..." --urgent
 
 ### Command Reference
 
-| Flag                  | Required | Description                                  |
-| --------------------- | -------- | -------------------------------------------- |
-| `--message <message>` | Yes      | Notification body. Markdown (GFM) renders in the detail panel; the OS banner shows plain text. |
+| Flag                  | Required        | Description                                                                                                                                          |
+| --------------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--message <message>` | Yes             | Notification body. Markdown (GFM) renders in the detail panel; the OS banner shows plain text.                                                       |
 | `--title <title>`     | Yes in practice | Short headline (≤ 8 words). Omitting it triggers a body-truncation fallback that shows up as a duplicate of `--message` — always write a real title. |
-| `--urgent`            | No       | Mark as needing attention now/soon           |
-| `--json`              | No       | Output machine-readable JSON                 |
+| `--urgent`            | No              | Mark as needing attention now/soon                                                                                                                   |
+| `--json`              | No              | Output machine-readable JSON                                                                                                                         |
 
 ### Title
 
@@ -98,18 +98,18 @@ Reads from the user's home feed (`~/.vellum/workspace/data/home-feed.json`) — 
 
 ### Filters
 
-| Flag | Purpose |
-| --- | --- |
-| `--all` | Include dismissed items (default: excluded — assistant cares about outstanding work) |
-| `--status <s>` | Filter by status (`new` / `seen` / `acted_on` / `dismissed`); repeatable. Overrides the `--all` default. |
-| `--before <iso>` / `--after <iso>` | ISO-8601 createdAt bounds (strict; `=` is excluded). |
-| `--urgency <u>` | Filter by urgency (`low` / `medium` / `high` / `critical`); repeatable. |
-| `--category <c>` | Filter by category (`security` / `scheduling` / `background` / `email` / `system`); repeatable. |
-| `--conversation-id <id>` | Only items tied to this conversation. |
-| `--from-assistant` | Only items the assistant herself emitted. |
-| `--noteworthy` | Only items flagged as noteworthy. |
-| `--limit <n>` | Default 20, max 200. |
-| `--offset <n>` | Pagination offset. Combine with `--limit` to walk older pages. |
+| Flag                               | Purpose                                                                                                  |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `--all`                            | Include dismissed items (default: excluded — assistant cares about outstanding work)                     |
+| `--status <s>`                     | Filter by status (`new` / `seen` / `acted_on` / `dismissed`); repeatable. Overrides the `--all` default. |
+| `--before <iso>` / `--after <iso>` | ISO-8601 createdAt bounds (strict; `=` is excluded).                                                     |
+| `--urgency <u>`                    | Filter by urgency (`low` / `medium` / `high` / `critical`); repeatable.                                  |
+| `--category <c>`                   | Filter by category (`security` / `scheduling` / `background` / `email` / `system`); repeatable.          |
+| `--conversation-id <id>`           | Only items tied to this conversation.                                                                    |
+| `--from-assistant`                 | Only items the assistant herself emitted.                                                                |
+| `--noteworthy`                     | Only items flagged as noteworthy.                                                                        |
+| `--limit <n>`                      | Default 20, max 200.                                                                                     |
+| `--offset <n>`                     | Pagination offset. Combine with `--limit` to walk older pages.                                           |
 
 ### Examples
 
@@ -135,7 +135,9 @@ assistant notifications list --limit 20 --offset 20 --json
 ```json
 {
   "ok": true,
-  "items": [ /* FeedItem records: id, title?, summary, status, urgency?, category?, conversationId?, createdAt, ... */ ],
+  "items": [
+    /* FeedItem records: id, title?, summary, status, urgency?, category?, conversationId?, createdAt, ... */
+  ],
   "total": 12,
   "returned": 3,
   "hasMore": true,
@@ -161,34 +163,45 @@ assistant notifications list --json | jq '.items[] | {id, title, summary}'
 
 ### Command Reference
 
-| Flag                | Required | Description                                                                                       |
-| ------------------- | -------- | ------------------------------------------------------------------------------------------------- |
-| `--id <id>`         | Yes      | Feed item id (`notif:<uuid>`) or bare uuid                                                        |
-| `--message <text>`  | No*      | New body — updates the home-feed summary AND the delivered channel message where supported       |
-| `--title <text>`    | No*      | New short headline (≤ 8 words)                                                                    |
-| `--urgency <level>` | No*      | Change urgency (`low`/`medium`/`high`/`critical`). **Feed-only** — does not re-push channel messages |
-| `--status <state>`  | No*      | Lifecycle transition (`new`/`seen`/`acted_on`/`dismissed`). **Feed-only**                         |
-| `--json`            | No       | Machine-readable JSON                                                                             |
+| Flag                | Required | Description                                                                                          |
+| ------------------- | -------- | ---------------------------------------------------------------------------------------------------- |
+| `--id <id>`         | Yes      | Feed item id (`notif:<uuid>`) or bare uuid                                                           |
+| `--message <text>`  | No\*     | New body — updates the home-feed summary AND the delivered channel message where supported           |
+| `--title <text>`    | No\*     | New short headline (≤ 8 words)                                                                       |
+| `--urgency <level>` | No\*     | Change urgency (`low`/`medium`/`high`/`critical`). **Feed-only** — does not re-push channel messages |
+| `--status <state>`  | No\*     | Lifecycle transition (`new`/`seen`/`acted_on`/`dismissed`). **Feed-only**                            |
+| `--json`            | No       | Machine-readable JSON                                                                                |
 
-*At least one of `--message`, `--title`, `--urgency`, or `--status` must be supplied.
+\*At least one of `--message`, `--title`, `--urgency`, or `--status` must be supplied.
 
 ### Channel behavior
 
-| Channel | Edit behavior |
-| --- | --- |
-| Home feed (macOS/iOS inbox) | Always updated when the item exists. |
-| Slack | Updated in-place via `chat.update` when the original delivery captured a Slack `ts`. Deliveries older than this feature returned `messageId: null` and report `outcome: "unsupported"`. |
-| Push, email, SMS | Cannot be edited — reported as `outcome: "unsupported"` in the result. |
+| Channel                     | Edit behavior                                                                                                                                                                           |
+| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Home feed (macOS/iOS inbox) | Always updated when the item exists.                                                                                                                                                    |
+| Slack                       | Updated in-place via `chat.update` when the original delivery captured a Slack `ts`. Deliveries older than this feature returned `messageId: null` and report `outcome: "unsupported"`. |
+| Push, email, SMS            | Cannot be edited — reported as `outcome: "unsupported"` in the result.                                                                                                                  |
 
 ### Response shape
 
 ```json
 {
   "ok": true,
-  "feedItem": { "id": "notif:...", "title": "...", "summary": "...", "status": "new", "urgency": "low" },
+  "feedItem": {
+    "id": "notif:...",
+    "title": "...",
+    "summary": "...",
+    "status": "new",
+    "urgency": "low"
+  },
   "channels": [
     { "channel": "slack", "deliveryId": "...", "outcome": "updated" },
-    { "channel": "platform", "deliveryId": "...", "outcome": "unsupported", "reason": "platform adapter does not support in-place edits" }
+    {
+      "channel": "platform",
+      "deliveryId": "...",
+      "outcome": "unsupported",
+      "reason": "platform adapter does not support in-place edits"
+    }
   ]
 }
 ```

--- a/skills/notion/SKILL.md
+++ b/skills/notion/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   icon: assets/icon.svg
   emoji: "📝"
   vellum:
+    category: "productivity"
     display-name: "Notion"
 ---
 

--- a/skills/oura-setup/SKILL.md
+++ b/skills/oura-setup/SKILL.md
@@ -5,6 +5,7 @@ compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "💍"
   vellum:
+    category: "health"
     display-name: "Oura Ring Setup"
 ---
 

--- a/skills/oura/SKILL.md
+++ b/skills/oura/SKILL.md
@@ -32,23 +32,24 @@ curl -s "https://api.ouraring.com/v2/usercollection/{endpoint}?start_date=YYYY-M
 ```
 
 Run via `bash` with:
+
 - `network_mode: "proxied"`
 - `credential_ids: ["<oura access_token credential_id>"]`
 
 ## Endpoints
 
-| Endpoint | What It Returns | Best For |
-|----------|----------------|----------|
-| `personal_info` | Age, weight, height, email | Connection test |
-| `daily_sleep` | Sleep score, duration, efficiency, stages | Morning check-in |
-| `sleep` | Detailed sleep periods — HR, HRV, movement, timestamps | Deep sleep analysis |
-| `daily_readiness` | Readiness score, HRV balance, recovery index | Morning readiness |
-| `daily_activity` | Steps, calories, movement, MET data, activity score | Daily activity summary |
-| `heartrate` | Continuous HR readings (uses `start_datetime`/`end_datetime` ISO format) | Workout HR, resting HR |
-| `workout` | Detected workouts — HR, calories, duration, type | Exercise tracking |
-| `daily_spo2` | Blood oxygen (SpO2) nightly average | Breathing/oxygen |
-| `daily_stress` | Stress score, recovery periods | Stress monitoring |
-| `ring_configuration` | Ring model, firmware, color, design | Ring info |
+| Endpoint             | What It Returns                                                          | Best For               |
+| -------------------- | ------------------------------------------------------------------------ | ---------------------- |
+| `personal_info`      | Age, weight, height, email                                               | Connection test        |
+| `daily_sleep`        | Sleep score, duration, efficiency, stages                                | Morning check-in       |
+| `sleep`              | Detailed sleep periods — HR, HRV, movement, timestamps                   | Deep sleep analysis    |
+| `daily_readiness`    | Readiness score, HRV balance, recovery index                             | Morning readiness      |
+| `daily_activity`     | Steps, calories, movement, MET data, activity score                      | Daily activity summary |
+| `heartrate`          | Continuous HR readings (uses `start_datetime`/`end_datetime` ISO format) | Workout HR, resting HR |
+| `workout`            | Detected workouts — HR, calories, duration, type                         | Exercise tracking      |
+| `daily_spo2`         | Blood oxygen (SpO2) nightly average                                      | Breathing/oxygen       |
+| `daily_stress`       | Stress score, recovery periods                                           | Stress monitoring      |
+| `ring_configuration` | Ring model, firmware, color, design                                      | Ring info              |
 
 ## Query Parameters
 
@@ -60,7 +61,9 @@ Run via `bash` with:
 ## Common Patterns
 
 ### Morning health check
+
 Pull sleep + readiness + activity for today:
+
 ```bash
 DATE=$(date +%Y-%m-%d)
 curl -s "https://api.ouraring.com/v2/usercollection/daily_sleep?start_date=$DATE&end_date=$DATE"
@@ -68,6 +71,7 @@ curl -s "https://api.ouraring.com/v2/usercollection/daily_readiness?start_date=$
 ```
 
 ### Workout details with HR
+
 ```bash
 YESTERDAY=$(date -v-1d +%Y-%m-%d)
 TODAY=$(date +%Y-%m-%d)
@@ -75,6 +79,7 @@ curl -s "https://api.ouraring.com/v2/usercollection/workout?start_date=$YESTERDA
 ```
 
 ### Heart rate during a specific window
+
 ```bash
 # Adjust the datetime range as needed (ISO 8601 with timezone offset)
 curl -s "https://api.ouraring.com/v2/usercollection/heartrate?start_datetime=YYYY-MM-DDT23:00:00-05:00&end_datetime=YYYY-MM-DDT01:00:00-05:00"

--- a/skills/oura/SKILL.md
+++ b/skills/oura/SKILL.md
@@ -5,6 +5,7 @@ compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "💍"
   vellum:
+    category: "health"
     display-name: "Oura Ring"
     includes:
       - oura-setup

--- a/skills/outlook-calendar/SKILL.md
+++ b/skills/outlook-calendar/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   icon: assets/icon.svg
   emoji: "📅"
   vellum:
+    category: "calendar"
     display-name: "Outlook Calendar"
     user-invocable: true
 ---

--- a/skills/outlook/SKILL.md
+++ b/skills/outlook/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   icon: assets/icon.svg
   emoji: "📧"
   vellum:
+    category: "email"
     display-name: "Outlook"
     user-invocable: true
 ---

--- a/skills/public-ingress/SKILL.md
+++ b/skills/public-ingress/SKILL.md
@@ -5,6 +5,7 @@ compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "🌍"
   vellum:
+    category: "system"
     display-name: "Public Ingress"
     activation-hints:
       - "Local assistant needs a public webhook or OAuth callback URL"

--- a/skills/resend-setup/SKILL.md
+++ b/skills/resend-setup/SKILL.md
@@ -5,6 +5,7 @@ compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "📤"
   vellum:
+    category: "email"
     display-name: "Resend Email Setup"
     user-invocable: true
 ---

--- a/skills/restaurant-reservation/SKILL.md
+++ b/skills/restaurant-reservation/SKILL.md
@@ -5,6 +5,7 @@ compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "🍽️"
   vellum:
+    category: "commerce"
     display-name: "Restaurant Reservation Booking"
     includes: ["vellum-browser-use"]
 ---

--- a/skills/screen-recording/SKILL.md
+++ b/skills/screen-recording/SKILL.md
@@ -5,6 +5,7 @@ compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "🎬"
   vellum:
+    category: "content"
     display-name: "Screen Recording"
 ---
 

--- a/skills/self-upgrade/SKILL.md
+++ b/skills/self-upgrade/SKILL.md
@@ -5,6 +5,7 @@ compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "⬆️"
   vellum:
+    category: "system"
     display-name: "Self Upgrade"
 ---
 

--- a/skills/sentry-app-setup/SKILL.md
+++ b/skills/sentry-app-setup/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   icon: assets/icon.svg
   emoji: "🔺"
   vellum:
+    category: "development"
     display-name: "Sentry App Setup"
     user-invocable: true
 ---

--- a/skills/skill-categories-catalog.yaml
+++ b/skills/skill-categories-catalog.yaml
@@ -1,0 +1,96 @@
+# Skill category definitions for the Vellum skills catalog.
+# Fetched from GitHub at runtime by the platform.
+
+categories:
+  - slug: email
+    label: Email
+    description: >-
+      Send, read, and manage emails across providers.
+      Your assistant handles inbox triage, drafting replies,
+      and email automation.
+    icon: mail
+
+  - slug: calendar
+    label: Calendar
+    description: >-
+      Schedule meetings, check availability, and manage
+      calendar events. Integrates with Google Calendar
+      and Outlook.
+    icon: calendar
+
+  - slug: messaging
+    label: Messaging
+    description: >-
+      Connect to Slack, Discord, Telegram, and more.
+      Your assistant can send messages, monitor channels,
+      and respond to conversations.
+    icon: message-circle
+
+  - slug: browsing
+    label: Browsing
+    description: >-
+      Browse the web, extract content, and interact with
+      pages. Give your assistant eyes on the internet.
+    icon: globe
+
+  - slug: productivity
+    label: Productivity
+    description: >-
+      Task management, note-taking, and workflow automation.
+      Streamline your daily workflows with AI-powered
+      productivity tools.
+    icon: zap
+
+  - slug: development
+    label: Development
+    description: >-
+      Code evaluation, deployment, API mapping, and developer
+      tooling. Supercharge your development workflow.
+    icon: code
+
+  - slug: voice
+    label: Voice
+    description: >-
+      Text-to-speech, voice synthesis, and audio capabilities.
+      Give your assistant a voice with ElevenLabs, Fish Audio,
+      and more.
+    icon: mic
+
+  - slug: commerce
+    label: Commerce
+    description: >-
+      E-commerce integrations for Amazon, DoorDash, Stripe,
+      and more. Automate shopping, payments, and order
+      management.
+    icon: shopping-cart
+
+  - slug: content
+    label: Content
+    description: >-
+      Content creation, social media, meme generation, and
+      screen recording. Create and publish content with AI
+      assistance.
+    icon: palette
+
+  - slug: health
+    label: Health
+    description: >-
+      Health tracking and wellness integrations. Connect Oura
+      Ring and other health devices to your assistant.
+    icon: heart
+
+  - slug: system
+    label: System
+    description: >-
+      Core assistant capabilities — self-upgrade, memory
+      management, terminal sessions, heartbeat monitoring,
+      and more.
+    icon: settings
+
+  - slug: integrations
+    label: Integrations
+    description: >-
+      Connect to third-party services like Linear, Sentry,
+      GitHub, and Notion. Extend your assistant with powerful
+      integrations.
+    icon: link-2

--- a/skills/slack-app-setup/SKILL.md
+++ b/skills/slack-app-setup/SKILL.md
@@ -5,6 +5,7 @@ compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "💬"
   vellum:
+    category: "messaging"
     display-name: "Slack App Setup"
     includes: ["guardian-verify-setup"]
 ---

--- a/skills/slack/SKILL.md
+++ b/skills/slack/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   icon: assets/icon.svg
   emoji: "💬"
   vellum:
+    category: "messaging"
     display-name: "Slack"
 ---
 

--- a/skills/start-the-day/SKILL.md
+++ b/skills/start-the-day/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   icon: assets/icon.svg
   emoji: "🌅"
   vellum:
+    category: "productivity"
     display-name: "Start the Day"
 ---
 

--- a/skills/stripe-app-setup/SKILL.md
+++ b/skills/stripe-app-setup/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   icon: assets/icon.svg
   emoji: "💳"
   vellum:
+    category: "commerce"
     display-name: "Stripe App Setup"
     user-invocable: true
 ---

--- a/skills/stripe-link-wallet/SKILL.md
+++ b/skills/stripe-link-wallet/SKILL.md
@@ -5,6 +5,7 @@ metadata:
   icon: assets/icon.svg
   emoji: "💳"
   vellum:
+    category: "commerce"
     display-name: "Stripe Link Wallet"
 compatibility: "Designed for Vellum personal assistants"
 ---

--- a/skills/tasks/SKILL.md
+++ b/skills/tasks/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   icon: assets/icon.svg
   emoji: "✅"
   vellum:
+    category: "productivity"
     display-name: "Tasks"
     activation-hints:
       - "User wants to add, check, or manage items on their to-do list or task queue"

--- a/skills/telegram-setup/SKILL.md
+++ b/skills/telegram-setup/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   icon: assets/icon.svg
   emoji: "🤖"
   vellum:
+    category: "messaging"
     display-name: "Telegram Setup"
     activation-hints:
       - "Telegram bot setup, webhook configuration, or BotFather token"

--- a/skills/time-based-actions/SKILL.md
+++ b/skills/time-based-actions/SKILL.md
@@ -5,6 +5,7 @@ compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "⏰"
   vellum:
+    category: "productivity"
     display-name: "Time-Based Actions"
 ---
 

--- a/skills/twilio-setup/SKILL.md
+++ b/skills/twilio-setup/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   icon: assets/icon.svg
   emoji: "📱"
   vellum:
+    category: "integrations"
     display-name: "Twilio Setup"
     includes: ["public-ingress"]
 ---

--- a/skills/typescript-eval/SKILL.md
+++ b/skills/typescript-eval/SKILL.md
@@ -5,6 +5,7 @@ compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "🧪"
   vellum:
+    category: "development"
     display-name: "TypeScript Evaluation"
 ---
 

--- a/skills/vellum-avatar/SKILL.md
+++ b/skills/vellum-avatar/SKILL.md
@@ -5,6 +5,7 @@ compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "🎨"
   vellum:
+    category: "content"
     display-name: "Avatar"
 ---
 

--- a/skills/vellum-browser-use/SKILL.md
+++ b/skills/vellum-browser-use/SKILL.md
@@ -5,6 +5,7 @@ compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "🌐"
   vellum:
+    category: "browsing"
     display-name: "Browser"
     activation-hints:
       - "Load first if you need to browse the web (navigating, clicking, extracting web content) via `assistant browser` commands"

--- a/skills/vellum-conversation-management/SKILL.md
+++ b/skills/vellum-conversation-management/SKILL.md
@@ -5,6 +5,7 @@ compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "💬"
   vellum:
+    category: "productivity"
     display-name: "Conversations"
 ---
 

--- a/skills/vellum-github-app-setup/SKILL.md
+++ b/skills/vellum-github-app-setup/SKILL.md
@@ -8,6 +8,7 @@ metadata:
   author: vellum-ai
   version: "1.0"
   vellum:
+    category: "development"
     display-name: "GitHub App Setup"
 ---
 

--- a/skills/vellum-heartbeat/SKILL.md
+++ b/skills/vellum-heartbeat/SKILL.md
@@ -5,6 +5,7 @@ compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "💓"
   vellum:
+    category: "system"
     display-name: "Heartbeat"
     activation-hints:
       - "Set up a heartbeat, periodic checklist, background health check, or recurring background task"

--- a/skills/vellum-memory-v2-migration/SKILL.md
+++ b/skills/vellum-memory-v2-migration/SKILL.md
@@ -5,6 +5,7 @@ compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "🧠"
   vellum:
+    category: "system"
     display-name: "Memory v2 Migration"
     user-invocable: true
     activation-hints:

--- a/skills/vellum-oauth-integrations/SKILL.md
+++ b/skills/vellum-oauth-integrations/SKILL.md
@@ -5,6 +5,7 @@ compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "🔌"
   vellum:
+    category: "integrations"
     display-name: "Vellum OAuth Integrations"
 ---
 

--- a/skills/vellum-self-knowledge/SKILL.md
+++ b/skills/vellum-self-knowledge/SKILL.md
@@ -5,6 +5,7 @@ compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "🪞"
   vellum:
+    category: "system"
     display-name: "Vellum Self-Knowledge"
     activation-hints:
       - "When the user asks what model the assistant is running on"

--- a/skills/vellum-skills-catalog/SKILL.md
+++ b/skills/vellum-skills-catalog/SKILL.md
@@ -5,6 +5,7 @@ compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "🧩"
   vellum:
+    category: "system"
     display-name: "Skills Catalog"
     activation-hints:
       - "what can you do"

--- a/skills/vellum-sounds/SKILL.md
+++ b/skills/vellum-sounds/SKILL.md
@@ -5,6 +5,7 @@ compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "🔊"
   vellum:
+    category: "content"
     display-name: "Sounds"
 ---
 

--- a/skills/vellum-sounds/SKILL.md
+++ b/skills/vellum-sounds/SKILL.md
@@ -24,17 +24,17 @@ Two stores, both under `$VELLUM_WORKSPACE_DIR/data/sounds/`:
 
 These are the only valid event keys. Other keys are ignored by the app.
 
-| Event key | Fires when |
-|---|---|
-| `app_open` | App launches (first time per session) |
-| `task_complete` | Conversation transitions processing → idle |
-| `needs_input` | Conversation enters waiting-for-input |
-| `task_failed` | Conversation enters error state |
-| `notification` | A tool-triggered notification is sent |
-| `new_conversation` | User creates a new conversation |
-| `message_sent` | User sends a message in the composer |
-| `character_poke` | User clicks the avatar |
-| `random` | Ambient timer (fires every 5–30 minutes) |
+| Event key          | Fires when                                 |
+| ------------------ | ------------------------------------------ |
+| `app_open`         | App launches (first time per session)      |
+| `task_complete`    | Conversation transitions processing → idle |
+| `needs_input`      | Conversation enters waiting-for-input      |
+| `task_failed`      | Conversation enters error state            |
+| `notification`     | A tool-triggered notification is sent      |
+| `new_conversation` | User creates a new conversation            |
+| `message_sent`     | User sends a message in the composer       |
+| `character_poke`   | User clicks the avatar                     |
+| `random`           | Ambient timer (fires every 5–30 minutes)   |
 
 ## Mode 1: Inspect current state
 
@@ -57,6 +57,7 @@ cp "<source-path>" "$VELLUM_WORKSPACE_DIR/data/sounds/<descriptive-name>.<ext>"
 ```
 
 Rules:
+
 - Extension must be one of: `aiff`, `wav`, `mp3`, `m4a`, `caf`. If the user's file is something else (e.g. `.ogg`, `.flac`), tell them — don't try to rename.
 - Keep the filename simple (no path separators, no leading dots). Spaces are fine.
 - After adding a file, it's available in the dropdown — but nothing plays until you assign it to an event (Mode 3).
@@ -97,17 +98,17 @@ Only one pool-mutation flag is allowed per invocation — mixing `--sound` and `
 
 Flag reference:
 
-| Flag | Value | Effect |
-|---|---|---|
-| `--global-enabled` | `true` or `false` | Master switch. If `false`, NOTHING plays regardless of per-event settings. |
-| `--volume` | `0.0`–`1.0` (clamped) | Master volume. `0.7` is the default. |
-| `--event` | one of the 9 keys above | Scopes the next flags to a single event. |
-| `--enabled` | `true` or `false` | Per-event on/off (requires `--event`). |
-| `--sound` | filename or `null` | Single-sound convenience (requires `--event`). **Replaces** the entire pool with one entry, or clears it when given `null`. The file must already exist in `data/sounds/`. |
-| `--sounds` | comma-separated filenames | Replaces the pool with the given list (requires `--event`). Every filename must already exist in `data/sounds/`. Use `--clear-sounds` to empty. |
-| `--add-sound` | filename | Appends one filename to the pool (requires `--event`). No-op with a warning if already present. May be repeated in a single invocation. |
-| `--remove-sound` | filename | Removes one filename from the pool (requires `--event`). No-op with a warning if not present. |
-| `--clear-sounds` | — | Empties the pool (requires `--event`). |
+| Flag               | Value                     | Effect                                                                                                                                                                     |
+| ------------------ | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--global-enabled` | `true` or `false`         | Master switch. If `false`, NOTHING plays regardless of per-event settings.                                                                                                 |
+| `--volume`         | `0.0`–`1.0` (clamped)     | Master volume. `0.7` is the default.                                                                                                                                       |
+| `--event`          | one of the 9 keys above   | Scopes the next flags to a single event.                                                                                                                                   |
+| `--enabled`        | `true` or `false`         | Per-event on/off (requires `--event`).                                                                                                                                     |
+| `--sound`          | filename or `null`        | Single-sound convenience (requires `--event`). **Replaces** the entire pool with one entry, or clears it when given `null`. The file must already exist in `data/sounds/`. |
+| `--sounds`         | comma-separated filenames | Replaces the pool with the given list (requires `--event`). Every filename must already exist in `data/sounds/`. Use `--clear-sounds` to empty.                            |
+| `--add-sound`      | filename                  | Appends one filename to the pool (requires `--event`). No-op with a warning if already present. May be repeated in a single invocation.                                    |
+| `--remove-sound`   | filename                  | Removes one filename from the pool (requires `--event`). No-op with a warning if not present.                                                                              |
+| `--clear-sounds`   | —                         | Empties the pool (requires `--event`).                                                                                                                                     |
 
 The script prints the resulting config slice so you can confirm what changed.
 
@@ -148,15 +149,15 @@ If the user inspects `config.json` directly, this is what they'll see. Defaults 
   "globalEnabled": false,
   "volume": 0.7,
   "events": {
-    "app_open":         { "enabled": false, "sounds": [] },
-    "task_complete":    { "enabled": false, "sounds": [] },
-    "needs_input":      { "enabled": false, "sounds": [] },
-    "task_failed":      { "enabled": false, "sounds": [] },
-    "notification":     { "enabled": false, "sounds": [] },
+    "app_open": { "enabled": false, "sounds": [] },
+    "task_complete": { "enabled": false, "sounds": [] },
+    "needs_input": { "enabled": false, "sounds": [] },
+    "task_failed": { "enabled": false, "sounds": [] },
+    "notification": { "enabled": false, "sounds": [] },
     "new_conversation": { "enabled": false, "sounds": [] },
-    "message_sent":     { "enabled": false, "sounds": [] },
-    "character_poke":   { "enabled": false, "sounds": [] },
-    "random":           { "enabled": false, "sounds": [] }
+    "message_sent": { "enabled": false, "sounds": [] },
+    "character_poke": { "enabled": false, "sounds": [] },
+    "random": { "enabled": false, "sounds": [] }
   }
 }
 ```

--- a/skills/vellum-sounds/scripts/update-config.ts
+++ b/skills/vellum-sounds/scripts/update-config.ts
@@ -185,7 +185,8 @@ function parseArgs(argv: string[]): ParsedArgs {
       case "--volume": {
         const raw = next();
         const n = Number(raw);
-        if (!Number.isFinite(n)) fail(`--volume must be a number (got "${raw}")`);
+        if (!Number.isFinite(n))
+          fail(`--volume must be a number (got "${raw}")`);
         out.volume = Math.max(0, Math.min(1, n));
         break;
       }
@@ -204,7 +205,11 @@ function parseArgs(argv: string[]): ParsedArgs {
         break;
       case "--sound": {
         const raw = next();
-        setPoolOp(out, { kind: "sound", value: raw === "null" ? null : raw }, arg);
+        setPoolOp(
+          out,
+          { kind: "sound", value: raw === "null" ? null : raw },
+          arg,
+        );
         break;
       }
       case "--sounds": {
@@ -276,7 +281,8 @@ function readConfig(path: string): SoundsConfig {
             sounds?: unknown;
             sound?: unknown;
           };
-          if (typeof e.enabled === "boolean") base.events[key].enabled = e.enabled;
+          if (typeof e.enabled === "boolean")
+            base.events[key].enabled = e.enabled;
           // Match the Swift decoder (SoundsConfig.swift): prefer the new
           // `sounds` array; fall back to the legacy single `sound` string;
           // otherwise leave the pool empty. Filter out non-string / empty

--- a/skills/vellum-terminal-sessions/SKILL.md
+++ b/skills/vellum-terminal-sessions/SKILL.md
@@ -7,6 +7,7 @@ metadata:
   author: vellum-ai
   version: "0.2"
   vellum:
+    category: "system"
     display-name: "Terminal Sessions"
     activation-hints:
       - "User asks about their running terminal sessions or processes"

--- a/skills/vercel-token-setup/SKILL.md
+++ b/skills/vercel-token-setup/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   icon: assets/icon.svg
   emoji: "▲"
   vellum:
+    category: "development"
     display-name: "Vercel Token Setup"
     includes: ["vellum-browser-use"]
 ---

--- a/skills/voice-setup/SKILL.md
+++ b/skills/voice-setup/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   icon: assets/icon.svg
   emoji: "🎙️"
   vellum:
+    category: "voice"
     display-name: "Voice Setup"
     includes: ["elevenlabs-voice"]
     activation-hints:

--- a/skills/watch-together/SKILL.md
+++ b/skills/watch-together/SKILL.md
@@ -4,6 +4,7 @@ description: "Watch TV shows and movies with the user in real time by processing
 metadata:
   emoji: "📺"
   vellum:
+    category: "content"
     display-name: "Watch Together"
     emoji: 📺
 ---

--- a/skills/watcher/SKILL.md
+++ b/skills/watcher/SKILL.md
@@ -5,6 +5,7 @@ compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "👀"
   vellum:
+    category: "productivity"
     display-name: "Watcher"
 ---
 

--- a/skills/weather/SKILL.md
+++ b/skills/weather/SKILL.md
@@ -4,6 +4,8 @@ description: Get current weather conditions and forecasts for any location
 metadata:
   icon: assets/icon.svg
   emoji: "🌤️"
+  vellum:
+    category: "productivity"
 ---
 
 You are a weather assistant. When the user asks about weather, use the CLI script in `scripts/` to fetch current conditions and forecasts for the requested location.


### PR DESCRIPTION
## Summary

- **New `skills/skill-categories-catalog.yaml`**: hand-maintained YAML with 12 category definitions (email, calendar, messaging, browsing, productivity, development, voice, commerce, content, health, system, integrations) transcribed from the platform's `SKILL_CATEGORIES`.
- **Added `metadata.vellum.category`** to all 66 SKILL.md files using the platform's `SKILL_CATEGORY_MAP`, and regenerated `catalog.json` so categories flow through to consumers.
- **Bidirectional linter validation** in `lint-skill-spec.mjs`: every skill must reference a valid category slug, and every category in the catalog must be used by at least one skill. New `--skip-category` flag for external/third-party contexts.

## Original prompt

Move skill category data from the platform repo into the vellum-assistant repo so categories become self-service. Each skill declares its own category in SKILL.md frontmatter (`metadata.vellum.category`), and a standalone `skill-categories-catalog.yaml` is published for the platform to fetch. This covers only the assistant-side changes; a separate follow-up will update the platform to consume from here instead of its hardcoded `categories.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)