### PR TITLE
ci(release): sync feature flag registry before npm publish (LUM-2216)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1286,6 +1286,9 @@ jobs:
           node-version-file: .nvmrc
           registry-url: https://registry.npmjs.org
 
+      - name: Sync feature flag registry for publish
+        run: bun run meta/feature-flags/sync-bundled-copies.ts
+
       - name: Install and publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds an explicit `bun run meta/feature-flags/sync-bundled-copies.ts` step to the `publish-npm` job, matching the pattern Docker build jobs already use
- Ensures `feature-flag-registry.json` is present in `gateway/src/` and `assistant/src/config/` before `npm publish`, rather than relying solely on the `postinstall` lifecycle script (which swallows errors with `2>/dev/null || true`)

## Original prompt

While verifying LUM-2216 (gateway feature-flag-registry.json resolution in npm-installed packaged builds), we confirmed the file is correctly present in the published `@vellumai/vellum-gateway` package and the resolution logic works. However, the `publish-npm` CI job relies solely on the `postinstall` lifecycle script to create the gitignored registry copies before publish — unlike the Docker build jobs which have explicit `cp` steps. This adds the same explicit sync for robustness against silent lifecycle script failures.