### PR TITLE
fix(assistant): resolve credential-executor for npm-installed packaged builds (LUM-2215)

### DIFF
--- a/assistant/src/credential-execution/executable-discovery.ts
+++ b/assistant/src/credential-execution/executable-discovery.ts
@@ -17,6 +17,7 @@
  */
 
 import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 
 import { getIsContainerized } from "../config/env-registry.js";
@@ -158,6 +159,21 @@ export function discoverLocalCes():
   if (existsSync(sourceEntry)) {
     log.info({ path: sourceEntry }, "Found local CES source entry point");
     return { mode: "local-source", sourcePath: sourceEntry };
+  }
+
+  // npm-layout fallback: resolve via node_modules when installed as a package
+  try {
+    const _require = createRequire(import.meta.url);
+    const pkgPath = _require.resolve(
+      "@vellumai/credential-executor/package.json",
+    );
+    const npmSourceEntry = join(dirname(pkgPath), "src", "main.ts");
+    if (existsSync(npmSourceEntry)) {
+      log.info({ path: npmSourceEntry }, "Found CES source via npm package");
+      return { mode: "local-source", sourcePath: npmSourceEntry };
+    }
+  } catch {
+    // Package not installed — fall through to unavailable
   }
 
   const reason = `CES executable not found. Searched: ${searchPaths.join(", ")}; also checked source at ${sourceEntry}`;


### PR DESCRIPTION
## Summary
- Add `require.resolve("@vellumai/credential-executor/package.json")` fallback to `discoverLocalCes()` for when the daemon runs as npm-installed source in the Electron packaged build
- Follows the same pattern as the gateway resolution fix in PR #33193 (LUM-2206)

## Original prompt
The Electron packaged build installs the `vellum` meta-package (which includes `@vellumai/credential-executor`) via npm into a per-version directory. The existing credential-executor discovery only searches for a compiled binary next to the app bundle or in the user bin dir, then falls back to a monorepo source tree path. While the monorepo fallback coincidentally resolves in npm-installed layout due to flat hoisting, an explicit `require.resolve` fallback ensures robustness regardless of hoisting behavior. Ticket: https://linear.app/vellum/issue/LUM-2215