### PR TITLE
feat(release): auto-stamp PINNED_CLI_VERSION in release workflow (LUM-2191)

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -242,6 +242,9 @@ jobs:
           jq --arg v "$VERSION" '.version = $v' clients/chrome-extension/manifest.json > tmp && mv tmp clients/chrome-extension/manifest.json
           jq --arg v "$VERSION" '.version = $v' clients/chrome-extension/package.json > tmp && mv tmp clients/chrome-extension/package.json
 
+          # Stamp pinned CLI version in macOS app
+          sed -i "s/export const PINNED_CLI_VERSION = \".*\"/export const PINNED_CLI_VERSION = \"$VERSION\"/" apps/macos/src/main/cli-installer.ts
+
           # Regenerate OpenAPI spec with the new version
           cd assistant && bun run generate:openapi && cd ..
 

--- a/apps/macos/src/main/cli-installer.ts
+++ b/apps/macos/src/main/cli-installer.ts
@@ -9,7 +9,7 @@ import {
 import path from "node:path";
 
 // Auto-stamped by create-release-branch workflow.
-export const PINNED_CLI_VERSION = "0.8.6";
+export const PINNED_CLI_VERSION = "0.8.7";
 
 /** Directory where the pinned CLI version is installed. */
 export function getCliInstallDir(): string {

--- a/apps/macos/src/main/cli-installer.ts
+++ b/apps/macos/src/main/cli-installer.ts
@@ -8,7 +8,7 @@ import {
 } from "node:fs";
 import path from "node:path";
 
-// TODO(LUM-2191): auto-stamp in release workflow; bump manually until then.
+// Auto-stamped by create-release-branch workflow.
 export const PINNED_CLI_VERSION = "0.8.6";
 
 /** Directory where the pinned CLI version is installed. */


### PR DESCRIPTION
## Summary

- Added a `sed` step to `.github/workflows/create-release-branch.yml` that stamps the release version into `PINNED_CLI_VERSION` in `apps/macos/src/main/cli-installer.ts`, matching the existing pattern used for other version bumps.
- Replaced the manual-bump TODO comment with a note that the value is auto-stamped.

## Original prompt

The `PINNED_CLI_VERSION` constant in `apps/macos/src/main/cli-installer.ts` was hardcoded and required a manual bump each release. The task was to add an auto-stamp step to the `create-release-branch` workflow so packaged macOS builds always install the matching CLI version, using the same `sed` pattern already used for other version bumps in that workflow.

Resolves LUM-2191