### PR TITLE
feat(web): gate retire assistant for platform-hosted sessions

### DIFF
--- a/apps/web/src/domains/settings/pages/general-page.tsx
+++ b/apps/web/src/domains/settings/pages/general-page.tsx
@@ -28,7 +28,11 @@ import { useAuthStore } from "@/stores/auth-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { usePlatformGate } from "@/hooks/use-platform-gate";
-import { isLocalMode } from "@/lib/local-mode";
+import {
+  isLocalMode,
+  isLocalAssistant,
+  getSelectedAssistant,
+} from "@/lib/local-mode";
 import {
   applyThemePreference,
   readStoredThemePreference,
@@ -218,6 +222,8 @@ export function GeneralPage() {
   const infraGate = usePlatformGate({ platformHostedOnly: true });
 
   const platformAssistant = assistant?.is_local && !isLocalMode() ? null : assistant;
+  const canRetireLocally =
+    isLocalMode() && !!assistant && isLocalAssistant(getSelectedAssistant()!);
 
   useEffect(() => {
     if (!assistant || window.location.hash !== "#storage-resources") {
@@ -328,13 +334,24 @@ export function GeneralPage() {
 
       {multiPlatformAssistant && <AssistantPicker />}
 
-      {platformAssistant && (
+      {(platformGate === "full" || canRetireLocally) && platformAssistant && (
         <DetailCard
           variant="danger"
           title="Retire Assistant"
           subtitle="Permanently retire this assistant and delete all associated data."
         >
           <RetireAssistant assistantId={platformAssistant.id} />
+        </DetailCard>
+      )}
+      {platformGate === "disabled" && !canRetireLocally && (
+        <DetailCard
+          variant="danger"
+          title="Retire Assistant"
+          subtitle="Permanently retire this assistant and delete all associated data."
+        >
+          <Notice tone="info">
+            Log in to the Vellum platform to retire this assistant.
+          </Notice>
         </DetailCard>
       )}
 

--- a/apps/web/src/domains/settings/pages/general-page.tsx
+++ b/apps/web/src/domains/settings/pages/general-page.tsx
@@ -222,8 +222,9 @@ export function GeneralPage() {
   const infraGate = usePlatformGate({ platformHostedOnly: true });
 
   const platformAssistant = assistant?.is_local && !isLocalMode() ? null : assistant;
+  const selected = getSelectedAssistant();
   const canRetireLocally =
-    isLocalMode() && !!assistant && isLocalAssistant(getSelectedAssistant()!);
+    isLocalMode() && !!assistant && !!selected && isLocalAssistant(selected);
 
   useEffect(() => {
     if (!assistant || window.location.hash !== "#storage-resources") {


### PR DESCRIPTION
## Summary
- Gate the Retire Assistant section in `general-page.tsx` so Case 2 (platform-hosted + no login) shows a "log in" notice instead of a retire button that fails
- Self-hosted states (Cases 3-5) unaffected — `canRetireLocally` check preserves access to the local retire path (vite plugin / Electron IPC → CLI)
- Follows the same `platformGate` + `Notice` pattern used by infrastructure sections on the same page

## Original prompt
During a code audit of the Web UI Platform Decoupling inventory, we identified the Retire Assistant section as the only remaining code gap. Investigation revealed the component already has dual retire paths (platform API for hosted, local CLI for self-hosted), so `platformHostedOnly: true` gating would be wrong — it would hide retire for self-hosted users where local retire works. The only actual issue is Case 2 (platform-hosted, session expired) where the button renders but the API call fails. The fix adds a standard `platformGate` check combined with a `canRetireLocally` flag to disable with a login notice for Case 2 while preserving functionality for all other states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)