### PR TITLE
feat(plugins): expose the LLM call site on TurnContext

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -326,6 +326,7 @@ function buildPluginTurnContext(
     turnIndex: ctx.turnCount,
     trust,
     contextWindowManager: ctx.contextWindowManager,
+    callSite: ctx.currentCallSite,
   };
 }
 
@@ -359,6 +360,14 @@ export interface AgentLoopConversationContext {
   processing: boolean;
   abortController: AbortController | null;
   currentRequestId?: string;
+  /**
+   * The {@link LLMCallSite} of the in-flight turn, set at turn start from
+   * `options?.callSite ?? "mainAgent"`. Read by {@link buildPluginTurnContext}
+   * so pipeline/injector plugins can tell the main reply apart from
+   * background agent-loop work (compaction, subagents, …) on this same
+   * conversation. Per-turn mutable, mirroring {@link currentRequestId}.
+   */
+  currentCallSite?: LLMCallSite;
 
   readonly agentLoop: AgentLoop;
   readonly provider: Provider;
@@ -583,6 +592,9 @@ export async function runAgentLoopImpl(
   // `resolveCallSiteConfig`, picking up any user overrides under
   // `llm.callSites.mainAgent` (falling back to `llm.default` when absent).
   const turnCallSite: LLMCallSite = options?.callSite ?? "mainAgent";
+  // Expose the turn's call site to plugin pipeline/injector contexts (read by
+  // buildPluginTurnContext) so plugins can scope behaviour to the main reply.
+  ctx.currentCallSite = turnCallSite;
 
   // Read the conversation row once for both the override-profile derivation
   // below and the title-replaceability check at turn start. Later reads in

--- a/assistant/src/plugins/types.ts
+++ b/assistant/src/plugins/types.ts
@@ -19,6 +19,7 @@
 import type { CompactionCircuitClosedEvent } from "../api/events/compaction-circuit-closed.js";
 import type { CompactionCircuitOpenEvent } from "../api/events/compaction-circuit-open.js";
 import type { ContextWindowConfig } from "../config/schemas/inference.js";
+import type { LLMCallSite } from "../config/schemas/llm.js";
 import type {
   ContextWindowManager,
   ContextWindowResult,
@@ -925,6 +926,20 @@ export interface TurnContext {
    * a context without `injectionInputs` produces an empty injection chain.
    */
   injectionInputs?: TurnInjectionInputs;
+  /**
+   * The {@link LLMCallSite} this turn's pipeline work belongs to —
+   * `"mainAgent"` for the user-facing conversational reply, or the specific
+   * background/utility site (`"compactionAgent"`, `"subagentSpawn"`,
+   * `"memoryConsolidation"`, `"conversationTitle"`, …) when the agent loop is
+   * driving non-main work that happens to share the same `conversationId`.
+   *
+   * Lets `llmCall` middleware and {@link Injector}s scope their behaviour to
+   * the main reply and stay out of background turns, which `onEvent` presence
+   * alone cannot distinguish (compaction and subagent loops also stream).
+   * Omitted by call sites that don't tag a site (synthesized test contexts);
+   * consumers should treat absence conservatively.
+   */
+  callSite?: LLMCallSite;
 }
 
 // ─── Injectors ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Adds an optional `callSite?: LLMCallSite` to `TurnContext`, populated from the call site the agent loop already computes at turn start (`options?.callSite ?? "mainAgent"`).

## Why

Plugin `llmCall` middleware and injectors run for **every** agent-loop invocation — the user-facing reply (`mainAgent`) *and* background agent-loop work that shares the same `conversationId`: compaction agents, spawned subagents, heartbeat/filing turns. A plugin currently has no robust way to tell these apart:

- `onEvent` presence isn't a usable proxy — those background loops stream too.
- `conversationId` is shared across them.

A plugin that wants to act only on the main conversational reply (and stay out of compaction/subagent/background turns) needs the call site.

## How

- `AgentLoopConversationContext` gains a per-turn `currentCallSite` (mirrors `currentRequestId`), set at turn start from `turnCallSite`.
- The canonical `buildPluginTurnContext` reads it onto `TurnContext.callSite`. That single builder feeds **both** the injector chain and the loop's `turnContext`, and `resolveLoopTurnContext` preserves the field when the `llmCall` pipeline clones it — so one populate-site reaches both plugin surfaces.

## Risk

Purely additive — the field is optional. Existing plugins, default injectors, and synthesized test contexts are unaffected. No behaviour change for any current code path.

Focus for review: `buildPluginTurnContext` in `conversation-agent-loop.ts` (the single source of truth for plugin turn contexts) and that `resolveLoopTurnContext` in `agent/loop.ts` preserves the field on clone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)