### PR TITLE
perf(memory-v3): make L2 selector concurrency configurable (default 16)

### DIFF
--- a/assistant/src/config/schemas/__tests__/memory-v3.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v3.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+
+import { MemoryV3ConfigSchema } from "../memory-v3.js";
+
+describe("MemoryV3ConfigSchema", () => {
+  test("parses an empty object to documented defaults", () => {
+    const parsed = MemoryV3ConfigSchema.parse({});
+    expect(parsed).toEqual({
+      workingSet: { maxPages: 150, evictWindow: 5 },
+      l2Concurrency: 16,
+    });
+  });
+
+  test("accepts an explicit l2Concurrency override", () => {
+    expect(MemoryV3ConfigSchema.parse({ l2Concurrency: 8 }).l2Concurrency).toBe(
+      8,
+    );
+  });
+
+  test("rejects a non-positive or non-integer l2Concurrency", () => {
+    expect(() => MemoryV3ConfigSchema.parse({ l2Concurrency: 0 })).toThrow();
+    expect(() => MemoryV3ConfigSchema.parse({ l2Concurrency: -4 })).toThrow();
+    expect(() => MemoryV3ConfigSchema.parse({ l2Concurrency: 1.5 })).toThrow();
+  });
+});

--- a/assistant/src/config/schemas/memory-v3.ts
+++ b/assistant/src/config/schemas/memory-v3.ts
@@ -33,6 +33,14 @@ export const MemoryV3ConfigSchema = z
     workingSet: MemoryV3WorkingSetSchema.default(
       MemoryV3WorkingSetSchema.parse({}),
     ),
+    l2Concurrency: z
+      .number({ error: "memory.v3.l2Concurrency must be a number" })
+      .int("memory.v3.l2Concurrency must be an integer")
+      .positive("memory.v3.l2Concurrency must be a positive integer")
+      .default(16)
+      .describe(
+        "Bounded fan-out for the per-leaf L2 selection (number of leaf selector calls in flight at once).",
+      ),
   })
   .describe("Memory v3 — topic-tree routing with a carry-forward working set");
 

--- a/assistant/src/memory/v3/__tests__/shadow-plugin.test.ts
+++ b/assistant/src/memory/v3/__tests__/shadow-plugin.test.ts
@@ -68,6 +68,7 @@ const orchestrateSpy = mock(async () => ({
 let treeLoads = 0;
 let coreLoads = 0;
 let needleBuilds = 0;
+let configL2Concurrency = 16;
 
 // Shared in-memory DB so writes are observable from the test. We hold the raw
 // sqlite handle alongside the drizzle wrapper so the test can both read rows
@@ -105,7 +106,12 @@ mock.module("../../../config/assistant-feature-flags.js", () => ({
 
 mock.module("../../../config/loader.js", () => ({
   getConfig: () => ({
-    memory: { v3: { workingSet: { maxPages: 150, evictWindow: 5 } } },
+    memory: {
+      v3: {
+        workingSet: { maxPages: 150, evictWindow: 5 },
+        l2Concurrency: configL2Concurrency,
+      },
+    },
   }),
 }));
 
@@ -235,6 +241,7 @@ beforeEach(() => {
   treeLoads = 0;
   coreLoads = 0;
   needleBuilds = 0;
+  configL2Concurrency = 16;
   testDb = makeDb();
   resetShadowLanesForTests();
 });
@@ -287,6 +294,18 @@ describe("memory-v3 shadow plugin", () => {
     expect(turn.conversationId).toBe("conv-1");
     expect(turn.turnNumber).toBe(0);
     expect(turn.currentMessage).toBe("hello world");
+  });
+
+  test("orchestrate receives the configured L2 concurrency", async () => {
+    shadowEnabled = true;
+    configL2Concurrency = 9;
+    await runShadowObservation("conv-1", 0);
+    const deps = (
+      orchestrateSpy.mock.calls as unknown as unknown[][]
+    )[0]![1] as {
+      l2Concurrency?: number;
+    };
+    expect(deps.l2Concurrency).toBe(9);
   });
 
   test("both flags OFF → produce returns null, no orchestrate, no writes", async () => {

--- a/assistant/src/memory/v3/shadow-plugin.ts
+++ b/assistant/src/memory/v3/shadow-plugin.ts
@@ -280,13 +280,15 @@ async function observeTurn(
     const turn = buildShadowTurn(conversationId, turnIndex);
     if (!turn) return null;
 
-    const lanes = await getLanes(getConfig());
+    const cfg = getConfig();
+    const lanes = await getLanes(cfg);
     const result = await orchestrate(turn, {
       tree: lanes.tree,
       core: lanes.core,
       needle: lanes.needle,
       workingSet: lanes.workingSet,
       pageSummary,
+      l2Concurrency: cfg.memory.v3.l2Concurrency,
     });
 
     const rows = attributeSelections(lanes.tree, lanes.core, result);


### PR DESCRIPTION
## Summary
- Add a `memory.v3.l2Concurrency` config field (default **16**) and wire it into the shadow/live orchestrate call, so the per-leaf L2 selector fan-out is no longer pinned to the hardcoded `selectAcrossLeaves` default of `4`.
- Capture `getConfig()` once in `observeTurn` and pass `l2Concurrency` through `OrchestrateDeps` (an already-supported field forwarded to `selectAcrossLeaves`).
- Tests: schema default/validation for the new field, plus an assertion that the configured value reaches `orchestrate`.

## Why
Offline measurement against a live topic tree showed the `concurrency=4` bound — **not the model** — was the dominant per-turn L2 latency: it serialized the ~25 per-leaf selector calls into ~7 sequential batches. Firing all leaf calls concurrently was **~5× faster** (e.g. Opus L2 13.4s → 2.7s, cold cache) with **zero rate-limiting** (0 errors / 0 fail-opens at 27 concurrent) and **no change to which pages were selected**. Default 16 captures most of the win while leaving headroom for multiple simultaneous turns.

The L2 model stays **Opus 4.8** deliberately: a separate recall eval against judged need-targets showed faster L2 models (Sonnet/Haiku) drop ~15 points of recall (96% → 81%) and miss real need-targets. So concurrency — not a model downgrade — is the right latency lever.

Config-only with a backward-compatible default (no migration). v3 is shadow/flag-gated, so this only affects the v3 L2 fan-out — **zero live-v2 impact**. Takes effect on deployed instances after a daemon rebuild.

## Original prompt
While tuning memory-v3 shadow retrieval, an offline comparison showed the per-leaf L2 selector's hardcoded concurrency of 4 was the main per-turn latency driver (it batched ~25 calls into ~7 waves), while a recall eval against judged need-targets showed that downgrading the L2 model to a faster one loses real recall. The ask was to make L2 concurrency configurable and raise the default so the fan-out can be parallelized without touching the model — the first follow-up from that analysis.