### PR TITLE
fix(web): tighten iOS preferences drawer spacing

### DIFF
--- a/apps/web/src/components/theme-toggle.tsx
+++ b/apps/web/src/components/theme-toggle.tsx
@@ -61,7 +61,7 @@ export function ThemeToggle({ className }: { className?: string } = {}) {
   return (
     <div
       className={cn(
-        "flex items-center justify-between gap-3 px-4 py-2 max-md:py-3",
+        "flex items-center justify-between gap-3 px-4 py-2",
         className,
       )}
     >

--- a/apps/web/src/domains/chat/components/preferences-menu.tsx
+++ b/apps/web/src/domains/chat/components/preferences-menu.tsx
@@ -93,7 +93,7 @@ export function PreferencesMenu({
       {isMobile ? (
         <BottomSheet.Root open={isOpen} onOpenChange={setIsOpen}>
           <BottomSheet.Trigger asChild>{trigger}</BottomSheet.Trigger>
-          <BottomSheet.Content>
+          <BottomSheet.Content className="max-h-[85dvh]">
             <BottomSheet.Header className="sr-only">
               <BottomSheet.Title>Preferences</BottomSheet.Title>
             </BottomSheet.Header>


### PR DESCRIPTION
## Summary
Addresses spacing issues in the mobile (Capacitor iOS) preferences drawer reported from the TestFlight build:
- **Less top padding above Theme / the theme switcher**: removed the theme row's mobile-only `py-3` bump (`theme-toggle.tsx`). Combined with the existing `pt-0`, the only top spacing above 'Theme' is now the sheet container's 16px padding.
- **Outer container stays 16px**: `BottomSheet.Content`'s inner padding is already `px-4 pt-4` (16px); preserved.
- **No more cut-off / scroll**: raised the preferences sheet's height cap from `max-h-[50dvh]` to `max-h-[85dvh]` via a per-usage `className` override (shared `BottomSheet` component untouched), so Log Out and all rows fit.

## Validation
- `bun test` theme-toggle + preferences-menu: 8 pass
- `bun run typecheck`: clean
- `bun run lint`: no new warnings in touched files