### PR TITLE
fix(web): CreditsCard polish — desktop balance size + center Earn Credits

### DIFF
--- a/apps/web/src/domains/chat/components/credits-card.tsx
+++ b/apps/web/src/domains/chat/components/credits-card.tsx
@@ -39,7 +39,7 @@ export function CreditsCard({
               aria-hidden
             />
             <span
-              className="text-title-medium"
+              className="text-body-large-default max-md:text-title-medium"
               style={{ color: "var(--content-default)" }}
             >
               {balance} credits

--- a/apps/web/src/domains/chat/components/credits-card.tsx
+++ b/apps/web/src/domains/chat/components/credits-card.tsx
@@ -55,7 +55,7 @@ export function CreditsCard({
       <button
         type="button"
         onClick={onEarnCredits}
-        className="flex items-center gap-2 pl-1.5 transition-colors hover:opacity-80"
+        className="flex items-center justify-center gap-2 transition-colors hover:opacity-80"
       >
         <Gift
           className="h-3.5 w-3.5"


### PR DESCRIPTION
## Summary
Two small `CreditsCard` tweaks (shared between the mobile bottom sheet and desktop popover):

1. **Desktop balance text size** — `text-title-medium` (20px, the iOS mock size) wrapped the balance to two lines in the narrow `w-64` desktop popover. Now responsive: 16px (`text-body-large-default`) on desktop, 20px (`text-title-medium`) on mobile.
2. **Center the Earn Credits row** — the full-width Earn Credits button was left-aligned (`pl-1.5`); its icon+label is now centered within the card, matching the mock (applies to iOS + desktop).

## Validation
- `bun test` credits-card: 3 pass
- `bun run typecheck`: clean