### PR TITLE
fix(web): make Earn Credits label responsive to match menu rows

### DIFF
--- a/apps/web/src/domains/chat/components/credits-card.tsx
+++ b/apps/web/src/domains/chat/components/credits-card.tsx
@@ -63,7 +63,7 @@ export function CreditsCard({
           aria-hidden
         />
         <span
-          className="text-body-large-default"
+          className="text-body-medium-lighter max-md:text-body-large-default"
           style={{ color: "var(--content-secondary)" }}
         >
           Earn Credits


### PR DESCRIPTION
## Summary
The Earn Credits label in CreditsCard was a fixed `text-body-large-default` (16px / weight 500). The sibling menu rows (`PanelItem`: Settings, Usage, Log Out, etc.) use `text-body-medium-lighter max-md:text-body-large-default` — 14px/400 on desktop, 16px/500 on mobile.

Made Earn Credits use the same responsive classes so its size **and** weight match the other rows on both desktop and iOS (previously they matched only on iOS).

## Validation
- `bun test` credits-card: 3 pass
- `bun run typecheck`: clean