### PR TITLE
fix(memory-v3): wire up L1/L2 prefix caching (preserve cache_control, 1h TTL)

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -102,6 +102,7 @@ mock.module("@anthropic-ai/sdk", () => ({
 }));
 
 // Import after mocking
+import { cachedTextBlock } from "../memory/v3/provider-blocks.js";
 import { AnthropicProvider } from "../providers/anthropic/client.js";
 import {
   isPlaceholderSentinelText,
@@ -321,6 +322,98 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     }>;
     expect(tools).toHaveLength(1);
     expect(tools[0].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+  });
+
+  test("preserves a caller's 1h block cache_control and sends the extended-cache beta (non-Haiku)", async () => {
+    // v3's `cachedTextBlock` stamps a stable prefix block with a 1h TTL; the
+    // non-Haiku path must forward it unchanged and send the beta header.
+    await provider.sendMessage([
+      {
+        role: "user",
+        content: [
+          cachedTextBlock("stable pages block"),
+          { type: "text", text: "volatile current message" },
+        ],
+      },
+    ]);
+
+    const messages = lastStreamParams!.messages as Array<{
+      content: Array<{ cache_control?: { type: string; ttl?: string } }>;
+    }>;
+    expect(messages[0].content[0].cache_control).toEqual({
+      type: "ephemeral",
+      ttl: "1h",
+    });
+    expect(lastStreamParams!.betas).toContain("extended-cache-ttl-2025-04-11");
+  });
+
+  test("strips ttl from a caller's block cache_control and omits the beta for Haiku", async () => {
+    // Haiku doesn't support the extended-cache-ttl beta, so a caller-stamped
+    // 1h ttl (e.g. from `cachedTextBlock`) must be stripped before sending.
+    const haiku = new AnthropicProvider(
+      "sk-ant-test",
+      "claude-haiku-4-5-20251001",
+    );
+    await haiku.sendMessage([
+      {
+        role: "user",
+        content: [
+          cachedTextBlock("stable pages block"),
+          { type: "text", text: "volatile current message" },
+        ],
+      },
+    ]);
+
+    const messages = lastStreamParams!.messages as Array<{
+      content: Array<{ cache_control?: { type: string; ttl?: string } }>;
+    }>;
+    expect(messages[0].content[0].cache_control).toEqual({ type: "ephemeral" });
+    expect(messages[0].content[0].cache_control).not.toHaveProperty("ttl");
+    expect(
+      (lastStreamParams!.betas as string[] | undefined) ?? [],
+    ).not.toContain("extended-cache-ttl-2025-04-11");
+  });
+
+  test("v3-shape call (system + tools + cached prefix block) stays within the 4-breakpoint cap", async () => {
+    // Mirrors a v3 L2 selector call: a system prompt, a forced tool, and a user
+    // message whose stable <pages> block carries a cache_control breakpoint
+    // followed by the volatile current-message block. The preserved prefix
+    // breakpoint plus the client's system/tools/turn-start anchors must total
+    // exactly Anthropic's max of 4.
+    await provider.sendMessage(
+      [
+        {
+          role: "user",
+          content: [
+            cachedTextBlock("stable pages block"),
+            { type: "text", text: "volatile current message" },
+          ],
+        },
+      ],
+      { systemPrompt: "Select relevant pages.", tools: [sampleTools[0]] },
+    );
+
+    let breakpoints = 0;
+    const system = lastStreamParams!.system as
+      | Array<{ cache_control?: unknown }>
+      | undefined;
+    for (const b of system ?? []) if (b.cache_control) breakpoints++;
+    const tools = lastStreamParams!.tools as
+      | Array<{ cache_control?: unknown }>
+      | undefined;
+    for (const t of tools ?? []) if (t.cache_control) breakpoints++;
+    const messages = lastStreamParams!.messages as Array<{
+      content: Array<{ cache_control?: { type: string; ttl?: string } }>;
+    }>;
+    for (const m of messages)
+      for (const b of m.content) if (b.cache_control) breakpoints++;
+
+    expect(breakpoints).toBe(4);
+    // The stable pages block specifically must hold the preserved breakpoint.
+    expect(messages[0].content[0].cache_control).toEqual({
+      type: "ephemeral",
+      ttl: "1h",
+    });
   });
 
   test("no tools param when tools are omitted", async () => {

--- a/assistant/src/memory/v3/__tests__/provider-blocks.test.ts
+++ b/assistant/src/memory/v3/__tests__/provider-blocks.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+
+import { cachedTextBlock } from "../provider-blocks.js";
+
+describe("cachedTextBlock", () => {
+  test("stamps an ephemeral cache_control with a 1h TTL", () => {
+    const block = cachedTextBlock("stable leaf block");
+    expect(block).toMatchObject({ type: "text", text: "stable leaf block" });
+    expect(
+      (block as unknown as { cache_control?: unknown }).cache_control,
+    ).toEqual({ type: "ephemeral", ttl: "1h" });
+  });
+});

--- a/assistant/src/memory/v3/provider-blocks.ts
+++ b/assistant/src/memory/v3/provider-blocks.ts
@@ -1,16 +1,26 @@
 import type { ContentBlock } from "../../providers/types.js";
 
 /**
- * Text content block carrying an ephemeral `cache_control` breakpoint. Our
- * internal `TextContent` type omits the field (only the Anthropic provider
- * transforms it onto the wire), so we reach through a `Record` cast — this
- * keeps the core types provider-agnostic. Shared by the v3 router and selector,
- * whose STATIC numbered blocks are stable across turns and so cache well.
+ * Text content block carrying a `cache_control` breakpoint with a 1-hour TTL.
+ * Shared by the v3 router (the static leaf-tree block) and selector (each
+ * leaf's static `<pages>` block): these prefixes are stable across turns — the
+ * leaf tree is byte-identical every turn, and a leaf's pages block changes only
+ * when its pages/summaries do — while v3 turns are frequently more than the
+ * default 5-minute cache window apart. A 1h TTL keeps the prefix warm across
+ * those gaps so it is read from cache rather than re-created every turn; the
+ * volatile current-message block is rendered after this one and left un-cached.
+ * Haiku does not support the extended-cache-ttl beta, so the Anthropic provider
+ * strips this `ttl` for Haiku models.
+ *
+ * Our internal `TextContent` type omits `cache_control` (only the Anthropic
+ * provider transforms it onto the wire), so we reach through a `Record` cast to
+ * keep the core types provider-agnostic.
  */
 export function cachedTextBlock(text: string): ContentBlock {
   const block: ContentBlock = { type: "text", text };
   (block as unknown as Record<string, unknown>).cache_control = {
     type: "ephemeral",
+    ttl: "1h",
   };
   return block;
 }

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -1208,6 +1208,23 @@ export class AnthropicProvider implements Provider {
         sentMessages = params.messages;
       }
 
+      // Haiku does not support the extended-cache-ttl beta, so it must never
+      // receive a `ttl` on any cache_control. The client's own breakpoints
+      // already omit it for Haiku, but callers (e.g. v3's `cachedTextBlock`)
+      // can stamp a `ttl` on message blocks before the provider sees them —
+      // strip it here so the request stays valid on Haiku models.
+      if (isHaiku) {
+        for (const msg of sentMessages) {
+          if (!Array.isArray(msg.content)) continue;
+          for (const block of msg.content) {
+            if (typeof block === "string") continue;
+            const cc = (block as { cache_control?: { ttl?: unknown } })
+              .cache_control;
+            if (cc && "ttl" in cc) delete cc.ttl;
+          }
+        }
+      }
+
       const { signal: timeoutSignal, cleanup: cleanupTimeout } =
         createStreamTimeout(this.streamTimeoutMs, signal);
       innerTimeoutSignal = timeoutSignal;
@@ -1628,8 +1645,21 @@ export class AnthropicProvider implements Provider {
     block: ContentBlock,
   ): Anthropic.ContentBlockParam | null {
     switch (block.type) {
-      case "text":
-        return { type: "text", text: block.text };
+      case "text": {
+        // Preserve a caller-stamped cache_control breakpoint (e.g. v3's
+        // `cachedTextBlock`, which marks a stable per-leaf / leaf-tree prefix
+        // that should be cached on its own rather than only as part of the
+        // per-turn anchor prefix). The internal ContentBlock type omits the
+        // field, so reach for it via cast. The Haiku ttl-strip downstream still
+        // applies. Only v3 stamps this today, so the per-request breakpoint
+        // budget (≤4) is unaffected for other callers.
+        const cacheControl = (
+          block as { cache_control?: Anthropic.CacheControlEphemeral }
+        ).cache_control;
+        return cacheControl
+          ? { type: "text", text: block.text, cache_control: cacheControl }
+          : { type: "text", text: block.text };
+      }
       case "thinking":
         if (!block.signature) {
           return null;


### PR DESCRIPTION
## Summary
- The Anthropic block transform (`toAnthropicBlockSafe`) dropped `cache_control` when serializing text blocks to the wire, so v3's `cachedTextBlock` breakpoint — the L1 leaf-tree block and each L2 leaf's `<pages>` block — never reached Anthropic. The stable prefix was only ever cached as part of the volatile per-turn anchor prefix, which is unique every call and re-created every time (this is most of v3's cache_creation). Now a caller-stamped `cache_control` is preserved, so the prefix is cached on its own and read back when a leaf recurs.
- `cachedTextBlock` now stamps `ttl: "1h"` so the stable prefix survives v3's turn cadence (frequently >5 min apart, past the default 5-minute cache window).
- Haiku does not support the `extended-cache-ttl-2025-04-11` beta, so the Anthropic client strips `ttl` from any block `cache_control` for Haiku models.
- A v3-shape call lands exactly 4 cache breakpoints (system + tools + pages + turn-start) — Anthropic's per-request cap. Only v3 stamps block `cache_control` today, so other callers are unaffected.

## Original prompt
Investigating poor v3 prompt-cache hit rates (high cache_creation, low cache_read on the L1 Router and L2 Selector). The deployed-side cause traced to v3's stable prefix blocks never getting their own cache breakpoint on the wire, plus a default 5-minute TTL that cannot survive v3's >5-minute turn gaps. Asked to give L1 and L2 a 1-hour cache TTL.

Note: daemon change — requires an app rebuild to take effect on running instances.