### PR TITLE
fix(memory-v3): snapshot carry-forward before recording the turn; tighten L2 selection

### DIFF
--- a/assistant/src/memory/v3/__tests__/orchestrate.test.ts
+++ b/assistant/src/memory/v3/__tests__/orchestrate.test.ts
@@ -217,6 +217,43 @@ describe("orchestrate — fixture sequence (carry-forward)", () => {
     expect(t2.currentSelections.map((s) => s.slug)).not.toContain("page-a");
     expect(t2.finalInjection).toContain("page-a");
   });
+
+  test("carry-forward survives a turn whose selections fill the cap", async () => {
+    const tree = makeTree();
+    // Cap of 1: under a naive record-then-cap order this turn's own selection
+    // would evict the carried page before injection. Snapshotting the carry
+    // BEFORE recording this turn keeps the earlier page in the injection.
+    const workingSet = new WorkingSet(1);
+    const needle = fakeNeedle([]);
+    const stub = (selectIds: number[]): Provider => ({
+      name: "stub",
+      sendMessage: async (_messages, options) =>
+        options?.tools?.[0]?.name === "open_leaves"
+          ? toolUseResponse("open_leaves", { ids: [1] })
+          : toolUseResponse("select_pages", { ids: selectIds, pinned_ids: [] }),
+    });
+
+    providerStub = stub([1]); // turn 1 → page-a
+    await orchestrate(makeTurn(1, "page a"), {
+      tree,
+      core: new Set(),
+      needle,
+      workingSet,
+      pageSummary: summaryOf,
+    });
+
+    providerStub = stub([2]); // turn 2 → page-b, never re-selects page-a
+    const t2 = await orchestrate(makeTurn(2, "page b"), {
+      tree,
+      core: new Set(),
+      needle,
+      workingSet,
+      pageSummary: summaryOf,
+    });
+
+    expect(t2.currentSelections.map((s) => s.slug)).toEqual(["page-b"]);
+    expect(t2.finalInjection).toContain("page-a"); // carried despite the cap
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/memory/v3/orchestrate.ts
+++ b/assistant/src/memory/v3/orchestrate.ts
@@ -13,11 +13,16 @@
  *      then dedup by slug (a page assigned to multiple opened leaves comes back
  *      once per leaf) ORing the pinned flag so a page pinned anywhere stays
  *      pinned.
- *   4. Record each deduped selection into the carry-forward working set and
- *      evict (core slugs, stale non-pinned entries, then the cap).
- *   5. Final injection = unique union of this turn's selected slugs and the
- *      working-set union, so pages selected on earlier turns carry forward even
- *      when this turn does not re-select them.
+ *   4. Age the carry-forward working set to this turn (evict core slugs, stale
+ *      non-pinned entries, then the cap) and snapshot it — the pages carried in
+ *      from EARLIER turns.
+ *   5. Final injection = unique union of this turn's selected slugs and that
+ *      carried-forward set, so pages selected on earlier turns carry forward
+ *      even when this turn does not re-select them.
+ *   6. Record this turn's selections into the working set for LATER turns. This
+ *      runs AFTER the snapshot so the cap is spent on genuinely carried pages,
+ *      not on this turn's selections (which are injected directly) — otherwise a
+ *      turn selecting more pages than the cap would evict the entire carry.
  */
 
 import type { NeedleIndex } from "./needle.js";
@@ -48,7 +53,8 @@ export interface OrchestrateResult {
   openedLeaves: LeafPath[];
   /** This turn's L2 selections, deduped by slug (pinned flags ORed). */
   currentSelections: SelectedPage[];
-  /** Snapshot of the working-set union after record + evict. */
+  /** The carried-forward set: selections from EARLIER turns, aged to this turn
+   *  (snapshotted before this turn's selections are recorded). */
   workingSetUnion: Set<Slug>;
   /** Slugs to inject: this turn's selections ∪ the carried-forward working set. */
   finalInjection: Slug[];
@@ -95,20 +101,26 @@ export async function orchestrate(
   }
   const currentSelections = [...bySlug.values()];
 
-  // Step 4: record this turn's selections into the carry-forward working set.
-  for (const sel of currentSelections) {
-    deps.workingSet.recordSelection(sel.slug, turn.turnNumber, sel.pinned);
-  }
-
-  // Step 5: evict. Core slugs are owned by core, not the working set.
+  // Step 4: age the carry-forward set to this turn (drop core slugs, stale
+  // non-pinned entries, then the cap) and snapshot it. This is the set carried
+  // in from EARLIER turns; recording this turn happens afterward (step 6) so the
+  // cap is spent on genuinely carried pages, not on this turn's selections
+  // (which are injected directly anyway).
   deps.workingSet.evict(turn.turnNumber, coreSlugs(deps.tree, deps.core));
-
-  // Step 6: final injection = this turn's selections ∪ carried-forward set.
   const workingSetUnion = deps.workingSet.union();
+
+  // Step 5: final injection = this turn's selections ∪ the carried-forward set,
+  // so pages selected on earlier turns carry forward even when this turn does
+  // not re-select them.
   const finalInjection = unique<Slug>([
     ...currentSelections.map((s) => s.slug),
     ...workingSetUnion,
   ]);
+
+  // Step 6: record this turn's selections so they carry forward to LATER turns.
+  for (const sel of currentSelections) {
+    deps.workingSet.recordSelection(sel.slug, turn.turnNumber, sel.pinned);
+  }
 
   return { openedLeaves, currentSelections, workingSetUnion, finalInjection };
 }

--- a/assistant/src/memory/v3/selector.ts
+++ b/assistant/src/memory/v3/selector.ts
@@ -55,11 +55,13 @@ const SelectPagesSchema = z.object({
 const SELECT_PAGES_TOOL: ToolDefinition = {
   name: SELECT_PAGES_TOOL_NAME,
   description:
-    "Select the pages in this leaf whose content is relevant or useful for " +
-    "the next reply. Lean toward inclusion — a missed relevant page is a " +
-    "worse error than an unused one. Pass `pinned_ids` for pages the " +
-    "conversation is centrally about. Omit `ids` entirely to select every " +
-    "page; return `[]` only when none of the pages could possibly help.",
+    "Select the pages in this leaf whose content the reply would directly " +
+    "draw on. Be selective — prefer a few precisely-relevant pages over many " +
+    "loosely-related ones; a leaf opened on a weak signal may yield none. " +
+    "Pass `pinned_ids` for pages the conversation is centrally about. Omit " +
+    "`ids` only as a recall-safe fallback when you cannot judge the leaf " +
+    "(selects every page); return `[]` when pages are present but none are " +
+    "directly relevant.",
   input_schema: {
     type: "object",
     properties: {
@@ -75,11 +77,11 @@ const SELECT_PAGES_TOOL: ToolDefinition = {
   },
 };
 
-const SYSTEM_PROMPT = `This leaf of the topic tree is potentially relevant to the conversation. Select the pages whose content is relevant or useful for responding.
+const SYSTEM_PROMPT = `This leaf of the topic tree is potentially relevant to the conversation. Select ONLY the pages whose content the reply to THIS message would directly draw on.
 
-Be inclusive — include frame and affect matches, not just literal-topic matches. A page that shares the conversation's mode or register can be as useful as one that names the same entity. Missing a relevant page is a worse error than selecting an unused one.
+Be selective: exclude pages that are merely topically adjacent, part of the ever-present background, or only loosely related. Most opened leaves should contribute a few precisely-relevant pages, not most of their contents — a leaf opened on a weak signal may yield none.
 
-If the conversation is centrally ABOUT a page (rather than only peripherally relevant to it), mark that page as pinned. Call \`select_pages\` with the chosen IDs. Omit \`ids\` to select every page; return \`[]\` only when none of the pages could possibly help.`;
+If the conversation is centrally ABOUT a page (rather than only peripherally relevant to it), mark that page as pinned. Call \`select_pages\` with the chosen IDs. Omit \`ids\` only as a recall-safe fallback when you cannot judge the leaf (selects every page); return \`[]\` when the pages are present but none are directly relevant.`;
 
 /**
  * Render the STATIC numbered `<pages>` block for a leaf from its member slugs.


### PR DESCRIPTION
## Summary
- **Carry-forward order fix (`orchestrate.ts`):** snapshot the working-set union (pages carried from earlier turns) *before* recording this turn's selections, not after. Previously a turn whose L2 selection exceeded the 150-page working-set cap recorded its own selections first, evicting the entire carry-forward — so carry-forward was a silent no-op whenever a turn injected more than the cap. Now the cap is spent on genuinely carried pages; this turn's selections inject directly and record for *later* turns.
- **Tighten L2 selection (`selector.ts`):** the per-leaf selector moves from "lean toward inclusion — a missed relevant page is worse than an unused one" to "select only what the reply would directly draw on." Offline eval (as-of-T, real modules) shows this cuts per-turn fresh selection ~3.5× and brings it below the cap, so carry-forward actually engages and recovers recall via carried context instead of fresh over-selection. The recall-safe omit-ids fallback is preserved.
- Adds a regression test pinning that a turn whose selections fill the cap still carries an earlier turn's page forward.

memory-v3 is shadow-only / flag-gated, so this changes only what the shadow path logs — no impact on live memory injection. To be measured in shadow before any live cutover.

## Original prompt
Investigating why memory-v3's shadow path injects ~390 pages/turn (~1/5 of the corpus). Single-turn prompt-tightening trades recall steeply, but tight L2 + the working-set carry-forward recovers recall at ~3.5× smaller injection — except carry-forward was disabled because per-turn selection volume saturated the cap. This tightens selection and fixes the carry-forward ordering so the mechanism engages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)