### PR TITLE
fix(memory-v3): expect 1h ttl on cache breakpoint in router/selector tests

### DIFF
--- a/assistant/src/memory/v3/__tests__/router.test.ts
+++ b/assistant/src/memory/v3/__tests__/router.test.ts
@@ -213,11 +213,11 @@ describe("routeL1 — request shape", () => {
     const [blockA, blockB] = providerCalls[0].messages[0].content as Array<{
       type: string;
       text: string;
-      cache_control?: { type: string };
+      cache_control?: { type: string; ttl?: string };
     }>;
     expect(blockA.type).toBe("text");
     expect(blockA.text).toContain("<leaves>");
-    expect(blockA.cache_control).toEqual({ type: "ephemeral" });
+    expect(blockA.cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
 
     expect(blockB.type).toBe("text");
     expect(blockB.text).toContain("<current_message>alice?</current_message>");

--- a/assistant/src/memory/v3/__tests__/selector.test.ts
+++ b/assistant/src/memory/v3/__tests__/selector.test.ts
@@ -298,13 +298,13 @@ describe("selectFromLeaf — request shape", () => {
     const [blockA, blockB] = providerCalls[0].messages[0].content as Array<{
       type: string;
       text: string;
-      cache_control?: { type: string };
+      cache_control?: { type: string; ttl?: string };
     }>;
     expect(blockA.type).toBe("text");
     expect(blockA.text).toContain("<leaf>people/alice</leaf>");
     expect(blockA.text).toContain("<pages>");
     expect(blockA.text).toContain("[1] alice-bio — summary of alice-bio");
-    expect(blockA.cache_control).toEqual({ type: "ephemeral" });
+    expect(blockA.cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
 
     expect(blockB.type).toBe("text");
     expect(blockB.text).toContain("<current_message>alice?</current_message>");


### PR DESCRIPTION
## Summary
- PR #33258 added a 1h `ttl` to the L1/L2 prefix-cache breakpoint in `provider-blocks.ts`, but the router and selector request-shape tests still asserted the old `{ type: "ephemeral" }` cache_control, which broke the Test job on `main`.
- Update both assertions to expect `{ type: "ephemeral", ttl: "1h" }` and widen the inline block type annotation to include the optional `ttl` field.

## Original prompt
Fix only the specific failing CI job — the "Test" step on the main CI run (run 26899124830) — without touching anything else. The job failed because two memory-v3 tests (`router.test.ts`, `selector.test.ts`) asserted a stale cache_control shape after the 1h-TTL prefix-caching change (#33258) landed on main; the fix realigns the test expectations with the new production behavior.