### PR TITLE
feat(flags): add experiment-activation-flow-2026-06-03 client flag

### DIFF
--- a/apps/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/apps/web/src/lib/feature-flags/feature-flag-registry.json
@@ -456,6 +456,14 @@
       "label": "Self-intro first message",
       "description": "On the first conversation, send a natural self-introduction (e.g. \"Hi Vela, I'm alex. Nice to meet you.\") on the user's behalf and route it through real LLM inference, instead of serving the canned first greeting. Names come from the onboarding context; falls back to the canned greeting when no name is known. Exposed to clients so pre-hatch onboarding can compute the source-of-truth initial message, and to the assistant so older clients can still be gated server-side. See assistant/src/daemon/first-greeting.ts (buildSelfIntroMessage).",
       "defaultEnabled": false
+    },
+    {
+      "id": "experiment-activation-flow-2026-06-03",
+      "scope": "client",
+      "key": "experiment-activation-flow-2026-06-03",
+      "label": "Experiment: Activation Flow (2026-06-03)",
+      "description": "Day-1 activation spike: post-pre-chat hook offers a hardcoded inbox-cleanup first task to new users. Allowlist / 1% cohort.",
+      "defaultEnabled": false
     }
   ]
 }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -456,6 +456,14 @@
       "label": "Self-intro first message",
       "description": "On the first conversation, send a natural self-introduction (e.g. \"Hi Vela, I'm alex. Nice to meet you.\") on the user's behalf and route it through real LLM inference, instead of serving the canned first greeting. Names come from the onboarding context; falls back to the canned greeting when no name is known. Exposed to clients so pre-hatch onboarding can compute the source-of-truth initial message, and to the assistant so older clients can still be gated server-side. See assistant/src/daemon/first-greeting.ts (buildSelfIntroMessage).",
       "defaultEnabled": false
+    },
+    {
+      "id": "experiment-activation-flow-2026-06-03",
+      "scope": "client",
+      "key": "experiment-activation-flow-2026-06-03",
+      "label": "Experiment: Activation Flow (2026-06-03)",
+      "description": "Day-1 activation spike: post-pre-chat hook offers a hardcoded inbox-cleanup first task to new users. Allowlist / 1% cohort.",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Register `experiment-activation-flow-2026-06-03` (client scope, defaultEnabled false) in the canonical feature-flag registry
- Regenerate the three bundled registry copies via sync-bundled-copies.ts

Part of plan: inbox-cleanup-activation-spike.md (PR 1 of 7)