### PR TITLE
feat(web): add chooseFirstTask activation decision seam

### DIFF
--- a/apps/web/src/domains/onboarding/choose-first-task.test.ts
+++ b/apps/web/src/domains/onboarding/choose-first-task.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  chooseFirstTask,
+  INBOX_CLEANUP_TASK_ID,
+} from "@/domains/onboarding/choose-first-task";
+import type { PreChatOnboardingContext } from "@/domains/onboarding/prechat";
+
+function baseContext(
+  overrides: Partial<PreChatOnboardingContext> = {},
+): PreChatOnboardingContext {
+  return {
+    tools: [],
+    tasks: [],
+    tone: "balanced",
+    ...overrides,
+  };
+}
+
+describe("chooseFirstTask", () => {
+  test("returns the inbox-cleanup constant for an empty context", () => {
+    expect(chooseFirstTask(baseContext())).toBe(INBOX_CLEANUP_TASK_ID);
+    expect(INBOX_CLEANUP_TASK_ID).toBe("inbox-cleanup");
+  });
+
+  test("returns the inbox-cleanup constant for a populated context", () => {
+    const context = baseContext({
+      tools: ["slack", "linear"],
+      tasks: ["code-building", "writing"],
+      cohort: "content-automation",
+      googleConnected: true,
+    });
+    expect(chooseFirstTask(context)).toBe("inbox-cleanup");
+  });
+});

--- a/apps/web/src/domains/onboarding/choose-first-task.ts
+++ b/apps/web/src/domains/onboarding/choose-first-task.ts
@@ -1,0 +1,18 @@
+import type { PreChatOnboardingContext } from "@/domains/onboarding/prechat";
+
+/** Stable id of the inbox-cleanup first task. Matches skills/inbox-cleanup. */
+export const INBOX_CLEANUP_TASK_ID = "inbox-cleanup" as const;
+
+/**
+ * The activation decision-engine seam.
+ *
+ * v1 (this spike): ignores context and always returns the inbox-cleanup
+ * constant. In vN this consults real context (selected tasks/tools,
+ * connected providers, cohort) and selects. Same rail, this one node
+ * changes — intentionally NOT throwaway.
+ */
+export function chooseFirstTask(
+  _context: PreChatOnboardingContext,
+): string {
+  return INBOX_CLEANUP_TASK_ID;
+}


### PR DESCRIPTION
## Summary
- Add chooseFirstTask(context) seam returning the inbox-cleanup constant (v1 of the activation decision engine)
- Unit test

Part of plan: inbox-cleanup-activation-spike.md (PR 3 of 7)