### PR TITLE
feat(web): add firstTask field to PreChatOnboardingContext

### DIFF
--- a/apps/web/src/domains/onboarding/prechat.test.ts
+++ b/apps/web/src/domains/onboarding/prechat.test.ts
@@ -1,8 +1,12 @@
-import { describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 
 import {
   buildPreChatInitialMessage,
+  consumePendingPreChatContext,
   DEFAULT_PRECHAT_INITIAL_MESSAGE,
+  peekPendingPreChatContext,
+  type PreChatOnboardingContext,
+  setPendingPreChatContext,
 } from "@/domains/onboarding/prechat";
 
 describe("buildPreChatInitialMessage", () => {
@@ -34,5 +38,47 @@ describe("buildPreChatInitialMessage", () => {
     expect(
       buildPreChatInitialMessage({ assistantName: "  ", userName: "  " }),
     ).toBe(DEFAULT_PRECHAT_INITIAL_MESSAGE);
+  });
+});
+
+describe("firstTask handoff through sessionStorage", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  function contextWithFirstTask(): PreChatOnboardingContext {
+    return {
+      tools: ["gmail"],
+      tasks: ["inbox"],
+      tone: "grounded",
+      firstTask: "inbox-cleanup",
+    };
+  }
+
+  test("survives a set -> peek round-trip without consuming it", () => {
+    setPendingPreChatContext(contextWithFirstTask());
+
+    const peeked = peekPendingPreChatContext();
+    expect(peeked?.firstTask).toBe("inbox-cleanup");
+
+    // Peek is non-destructive: a second peek still sees the value.
+    expect(peekPendingPreChatContext()?.firstTask).toBe("inbox-cleanup");
+  });
+
+  test("survives a set -> consume read", () => {
+    setPendingPreChatContext(contextWithFirstTask());
+
+    const consumed = consumePendingPreChatContext();
+    expect(consumed?.firstTask).toBe("inbox-cleanup");
+
+    // Consume is destructive: the value is gone afterwards.
+    expect(consumePendingPreChatContext()).toBeNull();
+  });
+
+  test("absence of firstTask round-trips as undefined", () => {
+    const { firstTask: _omit, ...withoutFirstTask } = contextWithFirstTask();
+    setPendingPreChatContext(withoutFirstTask);
+
+    expect(consumePendingPreChatContext()?.firstTask).toBeUndefined();
   });
 });

--- a/apps/web/src/domains/onboarding/prechat.ts
+++ b/apps/web/src/domains/onboarding/prechat.ts
@@ -54,6 +54,13 @@ export interface PreChatOnboardingContext {
   bootstrapTemplate?: string;
   /** Skills to eagerly load. */
   skills?: string[];
+  /**
+   * Chosen first task id for the post-pre-chat activation hook (e.g.
+   * "inbox-cleanup"). Set by chooseFirstTask() in finish() when the
+   * activation-flow experiment flag is on. Absent for users not in the
+   * experiment. Consumed by the in-chat inbox-cleanup offer card.
+   */
+  firstTask?: string;
 }
 
 export const DEFAULT_PRECHAT_INITIAL_MESSAGE = "Wake up, my friend!";
@@ -260,6 +267,9 @@ function isPreChatOnboardingContext(
   if (candidate.skills !== undefined) {
     if (!Array.isArray(candidate.skills)) return false;
     if (!candidate.skills.every((s) => typeof s === "string")) return false;
+  }
+  if (candidate.firstTask !== undefined && typeof candidate.firstTask !== "string") {
+    return false;
   }
   return true;
 }


### PR DESCRIPTION
## Summary
- Add optional `firstTask?: string` to PreChatOnboardingContext for the activation post-pre-chat hook handoff
- Round-trip test through sessionStorage

Part of plan: inbox-cleanup-activation-spike.md (PR 2 of 7)