### PR TITLE
feat(web): fire post-pre-chat hook to choose first task

### DIFF
--- a/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
+++ b/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
@@ -11,6 +11,7 @@ import { useNavigate, useSearchParams } from "react-router";
 import { useIsIOSWeb } from "@/runtime/platform-detection";
 import { readIOSAppDownloaded } from "@/hooks/use-ios-app-nudge";
 import { fetchOnboardingRecipe } from "@/domains/onboarding/recipe-client.js";
+import { chooseFirstTask } from "@/domains/onboarding/choose-first-task.js";
 import {
   emitOnboardingFunnelStepCompleted,
   onboardingFunnelVariantFromCondensedFlag,
@@ -102,6 +103,8 @@ export function PreChatFlow() {
     useClientFeatureFlagStore.use.prechatOnboardingCondensedFlow();
   const selfIntroGreetingEnabled =
     useClientFeatureFlagStore.use.selfIntroGreeting();
+  const activationFlowEnabled =
+    useClientFeatureFlagStore.use.experimentActivationFlow20260603();
   const preferredFunnelVariant =
     onboardingFunnelVariantFromCondensedFlag(condensedPrechatFlag);
   const webFunnelVariant =
@@ -328,6 +331,10 @@ export function PreChatFlow() {
       googleScopes,
       connectedScopes: args?.connectedScopes,
     });
+
+    if (activationFlowEnabled) {
+      context.firstTask = chooseFirstTask(context);
+    }
 
     setPendingPreChatContext(context);
     const trimmedAssistant = assistantName.trim();


### PR DESCRIPTION
## Summary
- In pre-chat finish(), when the activation-flow flag is on, set context.firstTask via chooseFirstTask(context)
- Hands the chosen first task off to the chat for the inbox-cleanup offer card

Part of plan: inbox-cleanup-activation-spike.md (PR 5 of 7)