### PR TITLE
fix(notifications): use structured markdown for home feed notifications

### DIFF
--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -149,8 +149,8 @@ function buildSystemPrompt(
     `  - Avoid meta-send phrasing (e.g. "I'd like to send a notification", "May I go ahead with that?"). Write the recipient-facing message directly.`,
     `  - Avoid intermediary-instruction phrasing like "consider telling the guardian", "ask the recipient to", or "the assistant should remind them". Rewrite it as final copy the recipient can act on directly.`,
     `  - For telegram: 1-2 concise sentences.`,
-    `- \`conversationSeedMessage\` is the opening message in the internal notification conversation — it can be richer and more contextual.`,
-    `  - For vellum (desktop): 2-4 short sentences with useful context and clear next step if action is required.`,
+    `- \`conversationSeedMessage\` is the opening message in the internal notification conversation and also the expanded detail shown in the home feed. It should be richer and more contextual than the popup body.`,
+    `  - For vellum (desktop): use structured markdown for readability. Break content into bullet points, numbered lists, or short sections with **bold** labels. Avoid long unbroken paragraphs — scan-friendly formatting is preferred.`,
     `  - Never dump raw JSON. Include only human-readable context.`,
     ``,
     `Conversation reuse guidelines:`,
@@ -838,7 +838,10 @@ export async function evaluateSignal(
       selectedChannels,
       reasoningSummary: "assistant_tool pass-through",
       renderedCopy: Object.fromEntries(
-        availableChannels.map((ch) => [ch, { title, body }]),
+        availableChannels.map((ch) => [
+          ch,
+          { title, body, conversationSeedMessage: body },
+        ]),
       ) as NotificationDecision["renderedCopy"],
       conversationActions: Object.fromEntries(
         availableChannels.map((ch) => [ch, { action: "start_new" as const }]),

--- a/assistant/src/notifications/home-feed-side-effect.ts
+++ b/assistant/src/notifications/home-feed-side-effect.ts
@@ -77,8 +77,15 @@ export async function writeHomeFeedItemForSignal(
   // against `summary` in the row. Leave undefined when absent; renderers
   // fall back to `summary`.
   const resolvedTitle = payloadTitle?.trim() || undefined;
+  // Prefer conversationSeedMessage over body for the home feed: the seed
+  // message is richer and may contain structured markdown (lists, headers,
+  // bold) that the detail panel renders. The popup-oriented `body` is
+  // intentionally short (≤ 2 sentences) and loses formatting.
   const resolvedSummary =
-    renderedCopy?.body?.trim() || payloadBody?.trim() || "";
+    renderedCopy?.conversationSeedMessage?.trim() ||
+    renderedCopy?.body?.trim() ||
+    payloadBody?.trim() ||
+    "";
   if (!resolvedSummary) {
     log.warn(
       { signalId: signal.signalId, sourceEventName: signal.sourceEventName },


### PR DESCRIPTION
## Summary
- Prefer `conversationSeedMessage` over `body` for home feed detail panel — the seed message is richer and supports full GFM markdown, while `body` is intentionally short for OS popup banners
- Update the decision engine prompt to guide the LLM toward structured markdown (bullet points, numbered lists, bold labels) in `conversationSeedMessage`
- Set `conversationSeedMessage` in the pass-through path so it's available for the home feed

🤖 Generated with [Claude Code](https://claude.com/claude-code)