### PR TITLE
feat(web): show BYO email configured state in settings

### DIFF
--- a/apps/web/src/domains/settings/ai/email-service-card.tsx
+++ b/apps/web/src/domains/settings/ai/email-service-card.tsx
@@ -43,6 +43,7 @@ import { captureError } from "@/lib/sentry/capture-error";
 import { useEnvironmentStore } from "@/stores/environment-store";
 import { routes } from "@/utils/routes";
 import { getLocalSetting, setLocalSetting } from "@/utils/local-settings";
+import { useAssistantSelectionStore } from "@/assistant/selection-store";
 import { usePlatformGate } from "@/hooks/use-platform-gate";
 import { extractErrorMessage } from "@/utils/api-errors";
 
@@ -65,6 +66,8 @@ export function EmailServiceCard({ assistantId, assistantHandle }: EmailServiceC
   const [searchParams, setSearchParams] = useSearchParams();
   const emailRootDomain = useEnvironmentStore.use.emailRootDomain();
   const platformGate = usePlatformGate();
+  const activeAssistantId = useAssistantSelectionStore.use.activeAssistantId();
+  const byoAssistantId = assistantId ?? activeAssistantId;
   const [mode, setMode] = useState<ServiceMode>(
     () => platformGate === "gated" ? "your-own" : getLocalSetting(LS_EMAIL_MODE, "managed") as ServiceMode,
   );
@@ -86,17 +89,19 @@ export function EmailServiceCard({ assistantId, assistantHandle }: EmailServiceC
   const [removeAddressConfirmOpen, setRemoveAddressConfirmOpen] = useState(false);
 
   // -- BYO credential check (your-own mode) ----------------------------------
+  // Use byoAssistantId (lifecycle-backed fallback) so the check works in
+  // local/self-hosted mode where the platform assistant list may be empty.
   const byoCredentialQuery = useQuery({
-    queryKey: ["byoEmailCredential", assistantId, byoProviderId],
+    queryKey: ["byoEmailCredential", byoAssistantId, byoProviderId],
     queryFn: async () => {
       const { data } = await credentialsInspectPost({
-        path: { assistant_id: assistantId! },
+        path: { assistant_id: byoAssistantId! },
         body: { service: byoProviderId, field: "api_key" },
         throwOnError: true,
       });
       return data;
     },
-    enabled: !!assistantId && mode === "your-own",
+    enabled: !!byoAssistantId && mode === "your-own",
     staleTime: 60_000,
     retry: false,
   });

--- a/apps/web/src/domains/settings/ai/email-service-card.tsx
+++ b/apps/web/src/domains/settings/ai/email-service-card.tsx
@@ -1,4 +1,5 @@
 import {
+  CircleCheck,
   Crown,
   ExternalLink,
   Info,
@@ -37,6 +38,7 @@ import {
   assistantsListQueryKey,
   organizationsBillingSubscriptionRetrieveOptions,
 } from "@/generated/api/@tanstack/react-query.gen";
+import { credentialsInspectPost } from "@/generated/daemon/sdk.gen";
 import { captureError } from "@/lib/sentry/capture-error";
 import { useEnvironmentStore } from "@/stores/environment-store";
 import { routes } from "@/utils/routes";
@@ -82,6 +84,23 @@ export function EmailServiceCard({ assistantId, assistantHandle }: EmailServiceC
   const [registerConfirmOpen, setRegisterConfirmOpen] = useState(false);
   const [releaseConfirmOpen, setReleaseConfirmOpen] = useState(false);
   const [removeAddressConfirmOpen, setRemoveAddressConfirmOpen] = useState(false);
+
+  // -- BYO credential check (your-own mode) ----------------------------------
+  const byoCredentialQuery = useQuery({
+    queryKey: ["byoEmailCredential", assistantId, byoProviderId],
+    queryFn: async () => {
+      const { data } = await credentialsInspectPost({
+        path: { assistant_id: assistantId! },
+        body: { service: byoProviderId, field: "api_key" },
+        throwOnError: true,
+      });
+      return data;
+    },
+    enabled: !!assistantId && mode === "your-own",
+    staleTime: 60_000,
+    retry: false,
+  });
+  const byoConfigured = byoCredentialQuery.data?.hasSecret === true;
 
   useEffect(() => {
     if (subdomainPrefilled || !assistantHandle || subdomainDraft) return;
@@ -317,6 +336,32 @@ export function EmailServiceCard({ assistantId, assistantHandle }: EmailServiceC
     [byoProviderId],
   );
 
+  const byoSetupInstructions = (
+    <div className="flex items-start gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-sunken)] p-3 text-body-small-default text-[var(--content-tertiary)]">
+      <Info className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[var(--system-positive-strong)]" />
+      <div className="flex flex-col gap-1">
+        <span>
+          Configure {selectedByoProvider.displayName} via the assistant
+          CLI: ask the assistant to run the{" "}
+          <code className="rounded bg-[var(--surface-active)] px-1 py-0.5 text-[12px]">
+            {selectedByoProvider.setupSkill}
+          </code>{" "}
+          skill. It walks you through storing the API key, detecting the
+          domain, and (optionally) wiring up an inbound webhook.
+        </span>
+        <a
+          href={selectedByoProvider.docsUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1 text-[var(--system-positive-strong)] underline hover:opacity-80"
+        >
+          Open {selectedByoProvider.displayName}
+          <ExternalLink className="h-3 w-3" />
+        </a>
+      </div>
+    </div>
+  );
+
   const yourOwnContent = (
     <div className="space-y-4">
       <div className="space-y-1">
@@ -335,29 +380,30 @@ export function EmailServiceCard({ assistantId, assistantHandle }: EmailServiceC
         />
       </div>
 
-      <div className="flex items-start gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-sunken)] p-3 text-body-small-default text-[var(--content-tertiary)]">
-        <Info className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[var(--system-positive-strong)]" />
-        <div className="flex flex-col gap-1">
-          <span>
-            Configure {selectedByoProvider.displayName} via the assistant
-            CLI: ask the assistant to run the{" "}
-            <code className="rounded bg-[var(--surface-active)] px-1 py-0.5 text-[12px]">
-              {selectedByoProvider.setupSkill}
-            </code>{" "}
-            skill. It walks you through storing the API key, detecting the
-            domain, and (optionally) wiring up an inbound webhook.
-          </span>
+      {byoConfigured ? (
+        <div className="space-y-3">
+          <div className="flex items-center gap-2 rounded-lg border border-[var(--system-positive-subtle)] bg-[var(--surface-sunken)] p-3 text-body-small-default text-[var(--content-default)]">
+            <CircleCheck className="h-4 w-4 shrink-0 text-[var(--system-positive-strong)]" />
+            <span>
+              {selectedByoProvider.displayName} API key configured.
+              To reconfigure, run the{" "}
+              <code className="rounded bg-[var(--surface-active)] px-1 py-0.5 text-[12px]">
+                {selectedByoProvider.setupSkill}
+              </code>{" "}
+              skill.
+            </span>
+          </div>
           <a
             href={selectedByoProvider.docsUrl}
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center gap-1 text-[var(--system-positive-strong)] underline hover:opacity-80"
+            className="inline-flex items-center gap-1 text-body-small-default text-[var(--system-positive-strong)] underline hover:opacity-80"
           >
             Open {selectedByoProvider.displayName}
             <ExternalLink className="h-3 w-3" />
           </a>
         </div>
-      </div>
+      ) : byoSetupInstructions}
 
       <div className="flex items-center gap-2">
         <SaveButton onClick={handleSaveMode} disabled={savingMode} />

--- a/apps/web/src/domains/settings/ai/email-service-card.tsx
+++ b/apps/web/src/domains/settings/ai/email-service-card.tsx
@@ -101,7 +101,7 @@ export function EmailServiceCard({ assistantId, assistantHandle }: EmailServiceC
       });
       return data;
     },
-    enabled: !!byoAssistantId && mode === "your-own",
+    enabled: !!byoAssistantId && (mode === "your-own" || platformGate === "gated"),
     staleTime: 60_000,
     retry: false,
   });


### PR DESCRIPTION
## Summary
- Query the daemon's `credentialsInspect` endpoint to detect whether the selected BYO email provider (Mailgun/Resend) has an API key configured
- When configured, replace the generic "run the setup skill" instructions with a green confirmation banner showing the provider is active
- Gracefully falls back to setup instructions when no credentials are found (or daemon is unreachable)

## Original prompt
The "Your Own" email tab in Settings > Models & Services shows static setup instructions regardless of whether the user has already completed setup. Users who have run the `mailgun-setup` or `resend-setup` skill get no visual confirmation in the web UI that their provider is configured. This PR closes that gap by querying the daemon's credential store to detect configured state and showing a "configured" banner when the API key exists — the bare minimum UI improvement before the full BYO email backend work (see `docs/proposals/byo-email-parity.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)