### PR TITLE
feat(tts): serve TTS provider catalog from daemon API (LUM-2209)

### DIFF
--- a/apps/web/src/domains/settings/ai/text-to-speech-card.tsx
+++ b/apps/web/src/domains/settings/ai/text-to-speech-card.tsx
@@ -9,6 +9,7 @@ import { Input } from "@vellum/design-library/components/input";
 import { toast } from "@vellum/design-library/components/toast";
 import { assistantsListOptions } from "@/generated/api/@tanstack/react-query.gen";
 import { ttsProvidersGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
+import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import { synthesizeTTS } from "@/lib/tts-synthesize";
 import { getLocalSetting, setLocalSetting } from "@/utils/local-settings";
 
@@ -29,12 +30,13 @@ export function TextToSpeechCard() {
   const { data: assistantList } = useQuery(assistantsListOptions());
   const assistantId = assistantList?.results?.[0]?.id;
   const assistantName = assistantList?.results?.[0]?.name ?? "your assistant";
+  const isOrgReady = useIsOrgReady();
 
   const { data: catalogData } = useQuery({
     ...ttsProvidersGetOptions({
       path: { assistant_id: assistantId! },
     }),
-    enabled: !!assistantId,
+    enabled: !!assistantId && isOrgReady,
     staleTime: Infinity,
   });
   const providers = catalogData?.providers ?? TTS_PROVIDERS;

--- a/apps/web/src/domains/settings/ai/text-to-speech-card.tsx
+++ b/apps/web/src/domains/settings/ai/text-to-speech-card.tsx
@@ -8,6 +8,7 @@ import { Dropdown } from "@vellum/design-library/components/dropdown";
 import { Input } from "@vellum/design-library/components/input";
 import { toast } from "@vellum/design-library/components/toast";
 import { assistantsListOptions } from "@/generated/api/@tanstack/react-query.gen";
+import { ttsProvidersGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
 import { synthesizeTTS } from "@/lib/tts-synthesize";
 import { getLocalSetting, setLocalSetting } from "@/utils/local-settings";
 
@@ -25,7 +26,20 @@ import {
 } from "@/domains/settings/ai/ai-shared-ui";
 
 export function TextToSpeechCard() {
-  const defaultProviderId = TTS_PROVIDERS[0]?.id ?? "elevenlabs";
+  const { data: assistantList } = useQuery(assistantsListOptions());
+  const assistantId = assistantList?.results?.[0]?.id;
+  const assistantName = assistantList?.results?.[0]?.name ?? "your assistant";
+
+  const { data: catalogData } = useQuery({
+    ...ttsProvidersGetOptions({
+      path: { assistant_id: assistantId! },
+    }),
+    enabled: !!assistantId,
+    staleTime: Infinity,
+  });
+  const providers = catalogData?.providers ?? TTS_PROVIDERS;
+
+  const defaultProviderId = providers[0]?.id ?? "elevenlabs";
   const [draftProvider, setDraftProvider] = useState<string>(() =>
     getLocalSetting(LS_TTS_PROVIDER, defaultProviderId),
   );
@@ -36,14 +50,10 @@ export function TextToSpeechCard() {
   const [providerHasKey, setProviderHasKey] = useState(false);
   const [saving, setSaving] = useState(false);
   const [testing, setTesting] = useState(false);
-  const { data: assistantList } = useQuery(assistantsListOptions());
-  const assistantName = assistantList?.results?.[0]?.name ?? "your assistant";
 
   const selectedProvider = useMemo(() => {
-    return (
-      TTS_PROVIDERS.find((p) => p.id === draftProvider) ?? TTS_PROVIDERS[0]!
-    );
-  }, [draftProvider]);
+    return providers.find((p) => p.id === draftProvider) ?? providers[0]!;
+  }, [draftProvider, providers]);
 
   const loadProviderState = useCallback((providerId: string) => {
     const storedKey = getLocalSetting(LS_TTS_API_KEY_PREFIX + providerId, "");
@@ -157,7 +167,7 @@ export function TextToSpeechCard() {
           <Dropdown
             value={draftProvider}
             onChange={setDraftProvider}
-            options={TTS_PROVIDERS.map((p) => ({
+            options={providers.map((p) => ({
               value: p.id,
               label: p.displayName,
             }))}

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -22622,6 +22622,61 @@ paths:
                 - currentThreshold
                 - intent
               additionalProperties: false
+  /v1/tts/providers:
+    get:
+      operationId: tts_providers_get
+      summary: List TTS providers
+      description: Return the catalog of available TTS providers with client-facing metadata.
+      tags:
+        - tts
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  providers:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        displayName:
+                          type: string
+                        subtitle:
+                          type: string
+                        supportsVoiceSelection:
+                          type: boolean
+                        apiKeyPlaceholder:
+                          type: string
+                        credentialsGuide:
+                          type: object
+                          properties:
+                            description:
+                              type: string
+                            url:
+                              type: string
+                            linkLabel:
+                              type: string
+                          required:
+                            - description
+                            - url
+                            - linkLabel
+                          additionalProperties: false
+                      required:
+                        - id
+                        - displayName
+                        - subtitle
+                        - supportsVoiceSelection
+                        - apiKeyPlaceholder
+                        - credentialsGuide
+                      additionalProperties: false
+                required:
+                  - providers
+                additionalProperties: false
   /v1/tts/synthesize:
     post:
       operationId: tts_synthesize_post

--- a/assistant/src/runtime/routes/__tests__/tts-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/tts-routes.test.ts
@@ -164,8 +164,12 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("tts-routes", () => {
-  test("exports route definitions for messages/:messageId/tts, tts/synthesize, and tts/synthesize-cli", () => {
-    expect(ROUTES).toHaveLength(3);
+  test("exports route definitions for tts/providers, messages/:messageId/tts, tts/synthesize, and tts/synthesize-cli", () => {
+    expect(ROUTES).toHaveLength(4);
+
+    const providers = getRoute("tts/providers");
+    expect(providers.method).toBe("GET");
+    expect(providers.policy?.requiredScopes).toContain("settings.read");
 
     const msgTts = getRoute("messages/:messageId/tts");
     expect(msgTts.method).toBe("POST");

--- a/assistant/src/runtime/routes/tts-routes.ts
+++ b/assistant/src/runtime/routes/tts-routes.ts
@@ -15,6 +15,7 @@ import { sanitizeForTts } from "../../calls/tts-text-sanitizer.js";
 import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import { getConfig } from "../../config/loader.js";
 import { getMessageContent } from "../../daemon/handlers/conversation-history.js";
+import { listCatalogProvidersForDisplay } from "../../tts/provider-catalog.js";
 import {
   synthesizeText,
   TtsSynthesisError,
@@ -136,6 +137,10 @@ const ttsResponseHeaders = () => ({
 // Handlers
 // ---------------------------------------------------------------------------
 
+function handleListTtsProviders() {
+  return { providers: listCatalogProvidersForDisplay() };
+}
+
 async function handleMessageTts({ pathParams, queryParams }: RouteHandlerArgs) {
   const config = getConfig();
 
@@ -226,6 +231,36 @@ async function handleSynthesizeCliTts({ body }: RouteHandlerArgs) {
 // ---------------------------------------------------------------------------
 
 export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "tts_providers",
+    endpoint: "tts/providers",
+    method: "GET",
+    policy: {
+      requiredScopes: ["settings.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "List TTS providers",
+    description:
+      "Return the catalog of available TTS providers with client-facing metadata.",
+    tags: ["tts"],
+    responseBody: z.object({
+      providers: z.array(
+        z.object({
+          id: z.string(),
+          displayName: z.string(),
+          subtitle: z.string(),
+          supportsVoiceSelection: z.boolean(),
+          apiKeyPlaceholder: z.string(),
+          credentialsGuide: z.object({
+            description: z.string(),
+            url: z.string(),
+            linkLabel: z.string(),
+          }),
+        }),
+      ),
+    }),
+    handler: handleListTtsProviders,
+  },
   {
     operationId: "messages_tts",
     endpoint: "messages/:messageId/tts",

--- a/assistant/src/tts/__tests__/provider-catalog-consistency.test.ts
+++ b/assistant/src/tts/__tests__/provider-catalog-consistency.test.ts
@@ -30,8 +30,10 @@ import {
 interface ClientCatalogProvider {
   id: string;
   displayName: string;
+  subtitle?: string;
+  supportsVoiceSelection?: boolean;
   credentialMode?: string;
-  credentialsGuide?: { url: string };
+  credentialsGuide?: { description: string; url: string; linkLabel: string };
 }
 
 interface ClientCatalog {
@@ -141,6 +143,88 @@ describe("TTS provider catalog / client artifact consistency", () => {
         ...violations.map((v) => `  - ${v}`),
       ].join("\n");
       expect(violations, message).toEqual([]);
+    }
+  });
+
+  // -- Display field parity --------------------------------------------------
+
+  test("subtitle matches between assistant catalog and client artifact", () => {
+    const violations: string[] = [];
+    for (const clientEntry of clientCatalog.providers) {
+      try {
+        const assistantEntry = getCatalogProvider(clientEntry.id as any);
+        if (clientEntry.subtitle !== assistantEntry.subtitle) {
+          violations.push(
+            `"${clientEntry.id}": client="${clientEntry.subtitle}" vs assistant="${assistantEntry.subtitle}"`,
+          );
+        }
+      } catch {
+        // Unknown ID — covered by provider ID parity tests above.
+      }
+    }
+    if (violations.length > 0) {
+      expect(violations, "Subtitle mismatch:\n" + violations.join("\n")).toEqual(
+        [],
+      );
+    }
+  });
+
+  test("supportsVoiceSelection matches between assistant catalog and client artifact", () => {
+    const violations: string[] = [];
+    for (const clientEntry of clientCatalog.providers) {
+      try {
+        const assistantEntry = getCatalogProvider(clientEntry.id as any);
+        if (
+          clientEntry.supportsVoiceSelection !==
+          assistantEntry.supportsVoiceSelection
+        ) {
+          violations.push(
+            `"${clientEntry.id}": client=${clientEntry.supportsVoiceSelection} vs assistant=${assistantEntry.supportsVoiceSelection}`,
+          );
+        }
+      } catch {
+        // Unknown ID — covered by provider ID parity tests above.
+      }
+    }
+    if (violations.length > 0) {
+      expect(
+        violations,
+        "supportsVoiceSelection mismatch:\n" + violations.join("\n"),
+      ).toEqual([]);
+    }
+  });
+
+  test("credentialsGuide matches between assistant catalog and client artifact", () => {
+    const violations: string[] = [];
+    for (const clientEntry of clientCatalog.providers) {
+      try {
+        const assistantEntry = getCatalogProvider(clientEntry.id as any);
+        const cg = clientEntry.credentialsGuide;
+        const ag = assistantEntry.credentialsGuide;
+        if (cg && ag) {
+          if (cg.url !== ag.url) {
+            violations.push(`"${clientEntry.id}": credentialsGuide.url mismatch`);
+          }
+          if (cg.description !== ag.description) {
+            violations.push(
+              `"${clientEntry.id}": credentialsGuide.description mismatch`,
+            );
+          }
+          if (cg.linkLabel !== ag.linkLabel) {
+            violations.push(
+              `"${clientEntry.id}": credentialsGuide.linkLabel mismatch`,
+            );
+          }
+        }
+      } catch {
+        // Unknown ID — covered by provider ID parity tests above.
+      }
+    }
+    if (violations.length > 0) {
+      expect(
+        violations,
+        "credentialsGuide mismatch:\n" + violations.join("\n"),
+      ).toEqual([]);
     }
   });
 

--- a/assistant/src/tts/provider-catalog.ts
+++ b/assistant/src/tts/provider-catalog.ts
@@ -56,11 +56,20 @@ interface TtsProviderCatalogCapabilities {
 }
 
 /**
+ * Link to a provider's API-key management page, shown in settings UI.
+ */
+interface TtsCredentialsGuide {
+  readonly description: string;
+  readonly url: string;
+  readonly linkLabel: string;
+}
+
+/**
  * A single entry in the TTS provider catalog.
  *
  * Captures everything the system needs to know about a provider at a
  * metadata level — identity, display name, telephony call mode,
- * capabilities, and secret requirements.
+ * capabilities, secret requirements, and client-facing display metadata.
  */
 interface TtsProviderCatalogEntry {
   /** Unique provider identifier matching {@link TtsProviderId}. */
@@ -68,6 +77,18 @@ interface TtsProviderCatalogEntry {
 
   /** Human-readable name for display in settings UI and logs. */
   readonly displayName: string;
+
+  /** Short description shown beneath the provider name in settings UI. */
+  readonly subtitle: string;
+
+  /** Whether the provider supports user-chosen voice IDs. */
+  readonly supportsVoiceSelection: boolean;
+
+  /** Placeholder text for the API-key input in settings UI. */
+  readonly apiKeyPlaceholder: string;
+
+  /** Link to the provider's API-key management page. */
+  readonly credentialsGuide: TtsCredentialsGuide;
 
   /** How this provider integrates with the telephony call path. */
   readonly callMode: TtsCallMode;
@@ -106,6 +127,16 @@ const CATALOG: readonly TtsProviderCatalogEntry[] = [
   {
     id: "elevenlabs",
     displayName: "ElevenLabs",
+    subtitle:
+      "High-quality voice synthesis for conversations and read-aloud. Requires an ElevenLabs API key.",
+    supportsVoiceSelection: true,
+    apiKeyPlaceholder: "sk_…",
+    credentialsGuide: {
+      description:
+        "Sign in to ElevenLabs, go to your Profile, and copy your API key.",
+      url: "https://elevenlabs.io/app/settings/api-keys",
+      linkLabel: "Open ElevenLabs API Keys",
+    },
     callMode: "native-twilio",
     allowNativeFallback: true,
     capabilities: {
@@ -124,6 +155,16 @@ const CATALOG: readonly TtsProviderCatalogEntry[] = [
   {
     id: "fish-audio",
     displayName: "Fish Audio",
+    subtitle:
+      "Natural-sounding voice synthesis with custom voice cloning. Requires a Fish Audio API key and voice reference ID.",
+    supportsVoiceSelection: true,
+    apiKeyPlaceholder: "Enter your Fish Audio API key",
+    credentialsGuide: {
+      description:
+        "Sign in to Fish Audio, navigate to API Keys in your dashboard, and create a new key.",
+      url: "https://fish.audio/app/api-keys/",
+      linkLabel: "Open Fish Audio API Keys",
+    },
     callMode: "synthesized-play",
     allowNativeFallback: true,
     capabilities: {
@@ -142,6 +183,16 @@ const CATALOG: readonly TtsProviderCatalogEntry[] = [
   {
     id: "deepgram",
     displayName: "Deepgram",
+    subtitle:
+      "Fast, accurate text-to-speech synthesis. Uses the same API key as Deepgram speech-to-text.",
+    supportsVoiceSelection: false,
+    apiKeyPlaceholder: "Enter your Deepgram API key",
+    credentialsGuide: {
+      description:
+        "Sign in to Deepgram, navigate to your API Keys page, and create or copy an existing key. This is the same key used for speech-to-text.",
+      url: "https://console.deepgram.com/",
+      linkLabel: "Open Deepgram Console",
+    },
     callMode: "synthesized-play",
     allowNativeFallback: false,
     capabilities: {
@@ -159,6 +210,16 @@ const CATALOG: readonly TtsProviderCatalogEntry[] = [
   {
     id: "xai",
     displayName: "xAI",
+    subtitle:
+      "Text-to-speech from xAI with expressive voices (eve, ara, rex, sal, leo). Requires an xAI API key.",
+    supportsVoiceSelection: false,
+    apiKeyPlaceholder: "Enter your xAI API key",
+    credentialsGuide: {
+      description:
+        "Sign in to the xAI console, navigate to API Keys, and create a new key.",
+      url: "https://console.x.ai/",
+      linkLabel: "Open xAI Console",
+    },
     callMode: "synthesized-play",
     allowNativeFallback: false,
     capabilities: {
@@ -197,6 +258,20 @@ export function listCatalogProviders(): readonly TtsProviderCatalogEntry[] {
  */
 export function listCatalogProviderIds(): TtsProviderId[] {
   return CATALOG.map((entry) => entry.id);
+}
+
+/**
+ * List all catalog providers projected to client-facing display fields only.
+ */
+export function listCatalogProvidersForDisplay() {
+  return CATALOG.map((e) => ({
+    id: e.id,
+    displayName: e.displayName,
+    subtitle: e.subtitle,
+    supportsVoiceSelection: e.supportsVoiceSelection,
+    apiKeyPlaceholder: e.apiKeyPlaceholder,
+    credentialsGuide: e.credentialsGuide,
+  }));
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `GET /v1/tts/providers` daemon endpoint returning display metadata (subtitle, voice selection support, credentials guide) for all TTS providers
- Extend the daemon's canonical `TtsProviderCatalogEntry` with UI display fields, making it the single source of truth for both runtime and display metadata
- Migrate the web SPA's TTS settings card to fetch providers dynamically from the daemon, with the hardcoded list as a synchronous fallback
- Extend consistency tests to guard subtitle, supportsVoiceSelection, and credentialsGuide parity between daemon catalog and client JSON artifact

## Original prompt
The TTS provider catalog existed in three independent copies (daemon TypeScript catalog, client JSON artifact, web SPA hardcoded constants) with only the first two guarded by CI consistency tests. LUM-2209 asked to serve the catalog from the daemon so the Electron web UI can render provider/voice selection dynamically. The approach follows the existing STT providers route precedent — a lightweight GET endpoint projecting display-only fields, consumed via auto-generated TanStack Query hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)