### PR TITLE
feat(web): render inbox-cleanup offer card in first chat

### DIFF
--- a/apps/web/src/domains/chat/active-chat-view.tsx
+++ b/apps/web/src/domains/chat/active-chat-view.tsx
@@ -36,6 +36,7 @@ import type { UIContext } from "@/domains/chat/turn-selectors";
 import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 
 import { peekPendingPreChatContext } from "@/domains/onboarding/prechat";
+import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 
 import { LazyBoundary } from "@/components/lazy-boundary";
 import { useChatAttachments } from "@/domains/chat/components/chat-attachments/use-chat-attachments";
@@ -153,10 +154,17 @@ export function ActiveChatView() {
   const {
     didOnboarding,
     onboardingTasksEmpty,
+    firstTask,
     onboardingConversationId,
     pendingOnboardingContextRef,
     onboardingDraftConversationIdRef,
   } = useOnboardingOrchestrator();
+
+  // Activation-flow experiment (JARVIS-1090). `firstTask` is captured at mount
+  // by the orchestrator (before the pending context is consumed on first send)
+  // and threaded down to ChatRouteContent alongside the flag.
+  const activationFlowEnabled =
+    useClientFeatureFlagStore.use.experimentActivationFlow20260603();
 
   // -------------------------------------------------------------------------
   // Reachability
@@ -443,6 +451,8 @@ export function ActiveChatView() {
     onboardingTasksEmpty,
     didOnboarding,
     onboardingConversationId,
+    firstTask,
+    activationFlowEnabled,
   };
 
   return (

--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -58,7 +58,9 @@ const ToolDetailPanel = lazy(() =>
   })),
 );
 import { OnboardingChoiceCard } from "@/domains/chat/components/onboarding-choice-card";
+import { InboxCleanupOfferCard } from "@/domains/chat/components/inbox-cleanup-offer-card";
 import { useOnboardingChoice } from "@/domains/chat/hooks/use-onboarding-choice";
+import { useInboxCleanupOffer } from "@/domains/chat/hooks/use-inbox-cleanup-offer";
 import { useEditMessage } from "@/domains/chat/hooks/use-edit-message";
 import { conversationsByIdUndoPost, subagentsByIdAbortPost } from "@/generated/daemon/sdk.gen";
 import { useIsNativePlatform } from "@/runtime/native-auth";
@@ -177,6 +179,11 @@ export interface ChatRouteContentProps {
   onboardingTasksEmpty: boolean;
   didOnboarding: boolean;
   onboardingConversationId: string | null;
+  /** Chosen first task from the pre-chat context (derived in ActiveChatView,
+   *  which owns the onboarding-domain reads). */
+  firstTask: string | null;
+  /** Whether the activation-flow experiment flag is enabled. */
+  activationFlowEnabled: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -219,6 +226,8 @@ export function ChatRouteContent({
   onboardingTasksEmpty,
   didOnboarding,
   onboardingConversationId,
+  firstTask,
+  activationFlowEnabled,
 }: ChatRouteContentProps) {
   const navigate = useNavigate();
   const isMobile = useIsMobile();
@@ -435,6 +444,21 @@ export function ChatRouteContent({
     didOnboarding,
     messages,
     onboardingTasksEmpty,
+    activeConversationId,
+    onboardingConversationId,
+    sendMessage,
+  });
+
+  const {
+    showInboxOffer,
+    handleAccept: handleInboxAccept,
+    handleDecline: handleInboxDecline,
+    accepting: inboxAccepting,
+  } = useInboxCleanupOffer({
+    didOnboarding,
+    firstTask,
+    activationFlowEnabled,
+    messages,
     activeConversationId,
     onboardingConversationId,
     sendMessage,
@@ -731,6 +755,7 @@ export function ChatRouteContent({
         autoRoutedProfileLabel,
         errorNotice: null,
         showOnboardingChoice,
+        showInboxOffer,
       }),
     [
       sanitizedMessages,
@@ -742,6 +767,7 @@ export function ChatRouteContent({
       thinkingLabel,
       autoRoutedProfileLabel,
       showOnboardingChoice,
+      showInboxOffer,
     ],
   );
 
@@ -1178,6 +1204,13 @@ export function ChatRouteContent({
       <OnboardingChoiceCard
         onSelectSpecific={handleSelectSpecific}
         onSubmitTasks={handleSubmitTasks}
+      />
+    ),
+    renderInboxOffer: () => (
+      <InboxCleanupOfferCard
+        onAccept={handleInboxAccept}
+        onDecline={handleInboxDecline}
+        busy={inboxAccepting}
       />
     ),
   };

--- a/apps/web/src/domains/chat/hooks/use-inbox-cleanup-offer.test.ts
+++ b/apps/web/src/domains/chat/hooks/use-inbox-cleanup-offer.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, renderHook } from "@testing-library/react";
+
+import { useInboxCleanupOffer } from "@/domains/chat/hooks/use-inbox-cleanup-offer";
+import type { DisplayMessage } from "@/domains/chat/utils/reconcile";
+
+const INBOX_CLEANUP_TASK_ID = "inbox-cleanup";
+
+const CONVERSATION_ID = "conv-onboarding";
+
+const greeting: DisplayMessage[] = [{ id: "m1", role: "assistant" }];
+
+interface OverrideOptions {
+  didOnboarding?: boolean;
+  firstTask?: string | null;
+  activationFlowEnabled?: boolean;
+  messages?: DisplayMessage[];
+  activeConversationId?: string | null;
+  onboardingConversationId?: string | null;
+  sendMessage?: (content: string) => void;
+}
+
+function baseOptions(overrides: OverrideOptions = {}) {
+  return {
+    didOnboarding: overrides.didOnboarding ?? true,
+    firstTask:
+      overrides.firstTask === undefined
+        ? INBOX_CLEANUP_TASK_ID
+        : overrides.firstTask,
+    activationFlowEnabled: overrides.activationFlowEnabled ?? true,
+    messages: overrides.messages ?? greeting,
+    activeConversationId:
+      overrides.activeConversationId === undefined
+        ? CONVERSATION_ID
+        : overrides.activeConversationId,
+    onboardingConversationId:
+      overrides.onboardingConversationId === undefined
+        ? CONVERSATION_ID
+        : overrides.onboardingConversationId,
+    sendMessage: overrides.sendMessage ?? (() => {}),
+  };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useInboxCleanupOffer", () => {
+  test("hidden when the activation flag is off", () => {
+    const { result } = renderHook(() =>
+      useInboxCleanupOffer(baseOptions({ activationFlowEnabled: false })),
+    );
+    expect(result.current.showInboxOffer).toBe(false);
+  });
+
+  test("hidden when firstTask does not match inbox-cleanup", () => {
+    const { result } = renderHook(() =>
+      useInboxCleanupOffer(baseOptions({ firstTask: "something-else" })),
+    );
+    expect(result.current.showInboxOffer).toBe(false);
+  });
+
+  test("hidden when the assistant greeting has not arrived", () => {
+    const { result } = renderHook(() =>
+      useInboxCleanupOffer(
+        baseOptions({ messages: [{ id: "u1", role: "user" }] }),
+      ),
+    );
+    expect(result.current.showInboxOffer).toBe(false);
+  });
+
+  test("hidden when not on the onboarding conversation", () => {
+    const { result } = renderHook(() =>
+      useInboxCleanupOffer(baseOptions({ activeConversationId: "other" })),
+    );
+    expect(result.current.showInboxOffer).toBe(false);
+  });
+
+  test("shown when all conditions are met", () => {
+    const { result } = renderHook(() =>
+      useInboxCleanupOffer(baseOptions()),
+    );
+    expect(result.current.showInboxOffer).toBe(true);
+  });
+
+  test("handleAccept sends exactly one message and hides the card", () => {
+    const sendMessage = mock((_content: string) => {});
+    const { result } = renderHook(() =>
+      useInboxCleanupOffer(baseOptions({ sendMessage })),
+    );
+    expect(result.current.showInboxOffer).toBe(true);
+
+    act(() => {
+      result.current.handleAccept();
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(result.current.showInboxOffer).toBe(false);
+    expect(result.current.accepting).toBe(true);
+  });
+
+  test("handleDecline hides the card without sending", () => {
+    const sendMessage = mock((_content: string) => {});
+    const { result } = renderHook(() =>
+      useInboxCleanupOffer(baseOptions({ sendMessage })),
+    );
+    expect(result.current.showInboxOffer).toBe(true);
+
+    act(() => {
+      result.current.handleDecline();
+    });
+
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(result.current.showInboxOffer).toBe(false);
+    expect(result.current.accepting).toBe(false);
+  });
+
+  test("dismissed card never reappears", () => {
+    const { result } = renderHook(() =>
+      useInboxCleanupOffer(baseOptions()),
+    );
+    expect(result.current.showInboxOffer).toBe(true);
+
+    act(() => {
+      result.current.handleDecline();
+    });
+    expect(result.current.showInboxOffer).toBe(false);
+  });
+});

--- a/apps/web/src/domains/chat/hooks/use-inbox-cleanup-offer.ts
+++ b/apps/web/src/domains/chat/hooks/use-inbox-cleanup-offer.ts
@@ -1,0 +1,131 @@
+/**
+ * Manages the lifecycle of the in-chat inbox-cleanup offer card.
+ *
+ * Phase transitions: `pending` → `visible` → `dismissed`.
+ * The card becomes visible when all conditions are met (activation flag on,
+ * did onboarding, the chosen first task is inbox-cleanup, greeting arrived,
+ * on the onboarding conversation). Once dismissed it never reappears.
+ *
+ * Spike version: accept assumes Google is already connected and just runs the
+ * inbox-cleanup skill (OAuth is layered in by a later PR).
+ */
+
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+
+import type { DisplayMessage } from "@/domains/chat/utils/reconcile";
+
+/**
+ * Stable id of the inbox-cleanup first task. Mirrors `INBOX_CLEANUP_TASK_ID`
+ * from `@/domains/onboarding/choose-first-task`; duplicated as a literal here
+ * because the chat domain may not import from the onboarding domain
+ * (`local/no-cross-domain-imports`). The page layer (active-chat-view) derives
+ * `firstTask` from the real onboarding constant before passing it in.
+ */
+const INBOX_CLEANUP_TASK_ID = "inbox-cleanup";
+
+/** Run message that matches the inbox-cleanup skill's activation hints. */
+const INBOX_CLEANUP_RUN_MESSAGE =
+  "Please clean up my inbox using the inbox-cleanup skill, then give me a concrete summary of how many emails you archived and by which pass.";
+
+interface UseInboxCleanupOfferOptions {
+  didOnboarding: boolean;
+  firstTask: string | null;
+  activationFlowEnabled: boolean;
+  messages: DisplayMessage[];
+  activeConversationId: string | null;
+  onboardingConversationId: string | null;
+  sendMessage: (content: string) => void;
+}
+
+interface UseInboxCleanupOfferReturn {
+  showInboxOffer: boolean;
+  handleAccept: () => void;
+  handleDecline: () => void;
+  accepting: boolean;
+}
+
+export function useInboxCleanupOffer({
+  didOnboarding,
+  firstTask,
+  activationFlowEnabled,
+  messages,
+  activeConversationId,
+  onboardingConversationId,
+  sendMessage,
+}: UseInboxCleanupOfferOptions): UseInboxCleanupOfferReturn {
+  const [phase, setPhase] = useState<"pending" | "visible" | "dismissed">(
+    "pending",
+  );
+  const [accepting, setAccepting] = useState(false);
+
+  // Latch ref: once an assistant message is seen, skip the .some() scan on
+  // subsequent renders. Only computed while phase === "pending".
+  const greetingSeenRef = useRef(false);
+  const greetingConversationIdRef = useRef<string | null>(null);
+
+  // Reset the greeting latch when the conversation changes so an assistant
+  // message in one thread can't satisfy the latch for a different thread.
+  // Sync refs in the commit phase per React 19's useRef caveats.
+  useLayoutEffect(() => {
+    if (greetingConversationIdRef.current !== activeConversationId) {
+      greetingConversationIdRef.current = activeConversationId;
+      greetingSeenRef.current = false;
+    }
+    if (!greetingSeenRef.current && phase === "pending") {
+      greetingSeenRef.current = messages.some((m) => m.role === "assistant");
+    }
+  });
+
+  // Track the conversation id when the card became visible so we can
+  // dismiss on conversation switch without racing the didOnboarding flag.
+  const visibleConversationIdRef = useRef<string | null>(null);
+
+  // Transition from pending -> visible when all conditions are met.
+  useEffect(() => {
+    if (
+      phase === "pending" &&
+      activationFlowEnabled &&
+      didOnboarding &&
+      firstTask === INBOX_CLEANUP_TASK_ID &&
+      greetingSeenRef.current &&
+      activeConversationId === onboardingConversationId
+    ) {
+      visibleConversationIdRef.current = activeConversationId;
+      setPhase("visible");
+    }
+    // `messages` is not read in the body; listed so this effect re-fires
+    // when a new message arrives and greetingSeenRef may have just latched.
+  }, [phase, activationFlowEnabled, didOnboarding, firstTask, messages, activeConversationId, onboardingConversationId]);
+
+  // Dismiss if the user switches to a different conversation.
+  useEffect(() => {
+    if (
+      phase === "visible" &&
+      visibleConversationIdRef.current !== null &&
+      activeConversationId !== visibleConversationIdRef.current
+    ) {
+      setPhase("dismissed");
+    }
+  }, [phase, activeConversationId]);
+
+  const dismiss = useCallback(() => {
+    setPhase("dismissed");
+  }, []);
+
+  const handleDecline = useCallback(() => {
+    dismiss();
+  }, [dismiss]);
+
+  const handleAccept = useCallback(() => {
+    setAccepting(true);
+    dismiss();
+    sendMessage(INBOX_CLEANUP_RUN_MESSAGE);
+  }, [dismiss, sendMessage]);
+
+  return {
+    showInboxOffer: phase === "visible",
+    handleAccept,
+    handleDecline,
+    accepting,
+  };
+}

--- a/apps/web/src/domains/chat/hooks/use-onboarding-orchestrator.ts
+++ b/apps/web/src/domains/chat/hooks/use-onboarding-orchestrator.ts
@@ -33,6 +33,9 @@ export interface UseOnboardingOrchestratorResult {
   didOnboarding: boolean;
   /** Whether the user skipped task selection during prechat. */
   onboardingTasksEmpty: boolean;
+  /** The activation-flow first task chosen during prechat (e.g. "inbox-cleanup"),
+   *  captured at mount before the pending context is consumed on first send. */
+  firstTask: string | null;
   /** The draft conversation created for the onboarding flow. */
   onboardingConversationId: string | null;
   /** Shared with `useSendMessage` — pre-chat context for the first send. */
@@ -49,6 +52,7 @@ export function useOnboardingOrchestrator(): UseOnboardingOrchestratorResult {
   const onboardingDraftConversationIdRef = useRef<string | null>(null);
   const [didOnboarding, setDidOnboarding] = useState(false);
   const [onboardingTasksEmpty, setOnboardingTasksEmpty] = useState(false);
+  const [firstTask, setFirstTask] = useState<string | null>(null);
   const [onboardingConversationId, setOnboardingConversationId] = useState<string | null>(null);
 
   // Consume the `?onboarding=1` signal left by `/onboarding/hatching` when
@@ -75,9 +79,12 @@ export function useOnboardingOrchestrator(): UseOnboardingOrchestratorResult {
     try {
       const raw = globalThis.sessionStorage?.getItem("onboarding.prechat.pendingContext");
       if (!raw) return;
-      const ctx = JSON.parse(raw) as { tasks?: string[] };
+      const ctx = JSON.parse(raw) as { tasks?: string[]; firstTask?: string };
       if (Array.isArray(ctx.tasks) && ctx.tasks.length === 0) {
         setOnboardingTasksEmpty(true);
+      }
+      if (typeof ctx.firstTask === "string") {
+        setFirstTask(ctx.firstTask);
       }
     } catch {
       // Storage or parse failure — ignore.
@@ -87,6 +94,7 @@ export function useOnboardingOrchestrator(): UseOnboardingOrchestratorResult {
   return {
     didOnboarding,
     onboardingTasksEmpty,
+    firstTask,
     onboardingConversationId,
     pendingOnboardingContextRef,
     onboardingDraftConversationIdRef,

--- a/apps/web/src/domains/chat/transcript/build-items.ts
+++ b/apps/web/src/domains/chat/transcript/build-items.ts
@@ -31,6 +31,7 @@ export interface BuildTranscriptItemsInput {
   autoRoutedProfileLabel?: string | null;
   errorNotice: string | null;
   showOnboardingChoice?: boolean;
+  showInboxOffer?: boolean;
 }
 
 /**
@@ -148,6 +149,13 @@ export function buildTranscriptItems(
     items.push({
       kind: "onboardingChoice",
       key: "onboarding-choice",
+    });
+  }
+
+  if (input.showInboxOffer) {
+    items.push({
+      kind: "inboxOffer",
+      key: "inbox-offer",
     });
   }
 

--- a/apps/web/src/domains/chat/transcript/transcript-row.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-row.tsx
@@ -44,6 +44,8 @@ export interface TranscriptRowProps {
   renderPendingContactRequest?: (requestId: string) => ReactNode;
   /** Render-prop override for `kind: "onboardingChoice"`. */
   renderOnboardingChoice?: () => ReactNode;
+  /** Render-prop override for `kind: "inboxOffer"`. */
+  renderInboxOffer?: () => ReactNode;
   onOpenRuleEditor?: (context: {
     toolName: string;
     riskLevel?: string;
@@ -94,6 +96,7 @@ export const TranscriptRow = memo(function TranscriptRow({
   renderPendingConfirmation,
   renderPendingContactRequest,
   renderOnboardingChoice,
+  renderInboxOffer,
   onOpenRuleEditor,
   unknownNudgeToolCallIds,
   onDismissUnknownNudge,
@@ -233,6 +236,12 @@ export const TranscriptRow = memo(function TranscriptRow({
     case "onboardingChoice":
       if (renderOnboardingChoice) {
         return <>{renderOnboardingChoice()}</>;
+      }
+      return null;
+
+    case "inboxOffer":
+      if (renderInboxOffer) {
+        return <>{renderInboxOffer()}</>;
       }
       return null;
 

--- a/apps/web/src/domains/chat/transcript/transcript.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript.tsx
@@ -65,6 +65,8 @@ export interface TranscriptProps {
   renderPendingContactRequest?: (requestId: string) => ReactNode;
   /** Optional renderer for `kind: "onboardingChoice"` items. */
   renderOnboardingChoice?: () => ReactNode;
+  /** Optional renderer for `kind: "inboxOffer"` items. */
+  renderInboxOffer?: () => ReactNode;
   /** Click handler on a tool-call risk badge — opens the rule editor. The
    *  ToolCallChip forwards the active tool-call's metadata so the modal can
    *  pre-fill its fields. */
@@ -236,6 +238,7 @@ export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(
       renderPendingConfirmation: rest.renderPendingConfirmation,
       renderPendingContactRequest: rest.renderPendingContactRequest,
       renderOnboardingChoice: rest.renderOnboardingChoice,
+      renderInboxOffer: rest.renderInboxOffer,
       assistantDisplayName: rest.assistantDisplayName,
       onOpenRuleEditor: rest.onOpenRuleEditor,
       unknownNudgeToolCallIds: rest.unknownNudgeToolCallIds,

--- a/apps/web/src/domains/chat/transcript/types.ts
+++ b/apps/web/src/domains/chat/transcript/types.ts
@@ -15,7 +15,8 @@ export type TranscriptItemKind =
   | "pendingContactRequest"
   | "surface"
   | "error"
-  | "onboardingChoice";
+  | "onboardingChoice"
+  | "inboxOffer";
 
 export interface TranscriptItemBase {
   key: string;
@@ -74,6 +75,10 @@ export interface OnboardingChoiceItem extends TranscriptItemBase {
   kind: "onboardingChoice";
 }
 
+export interface InboxOfferItem extends TranscriptItemBase {
+  kind: "inboxOffer";
+}
+
 export type TranscriptItem =
   | MessageItem
   | ThinkingItem
@@ -83,7 +88,8 @@ export type TranscriptItem =
   | PendingContactRequestItem
   | SurfaceItem
   | ErrorItem
-  | OnboardingChoiceItem;
+  | OnboardingChoiceItem
+  | InboxOfferItem;
 
 /** Result of splitting the transcript into stable history and the
  *  currently-in-progress turn. `anchorMessage` is the most recent user


### PR DESCRIPTION
## Summary
- Add an inboxOffer transcript item + useInboxCleanupOffer hook mirroring the onboarding-choice rail
- Show InboxCleanupOfferCard after the greeting when the activation flag is on and firstTask is inbox-cleanup; accept runs the skill, decline dismisses

Part of plan: inbox-cleanup-activation-spike.md (PR 6 of 7)