### PR TITLE
feat(web): gate inbox-cleanup offer accept on Google OAuth

### DIFF
--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -461,6 +461,7 @@ export function ChatRouteContent({
     messages,
     activeConversationId,
     onboardingConversationId,
+    assistantId,
     sendMessage,
   });
 

--- a/apps/web/src/domains/chat/hooks/use-inbox-cleanup-offer.test.ts
+++ b/apps/web/src/domains/chat/hooks/use-inbox-cleanup-offer.test.ts
@@ -1,14 +1,59 @@
-import { afterEach, describe, expect, mock, test } from "bun:test";
-import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { createElement } from "react";
 
-import { useInboxCleanupOffer } from "@/domains/chat/hooks/use-inbox-cleanup-offer";
 import type { DisplayMessage } from "@/domains/chat/utils/reconcile";
 
 const INBOX_CLEANUP_TASK_ID = "inbox-cleanup";
-
 const CONVERSATION_ID = "conv-onboarding";
+const ASSISTANT_ID = "asst-1";
+const REQUEST_ID = "req-test-1";
 
 const greeting: DisplayMessage[] = [{ id: "m1", role: "assistant" }];
+
+// --- Controllable mocks for the generated OAuth API ------------------------
+
+// Google connection state returned by the connections query. Tests flip this.
+let googleConnected = false;
+
+mock.module("@/generated/api/@tanstack/react-query.gen", () => ({
+  assistantsOauthConnectionsListOptions: ({
+    path,
+  }: {
+    path: { assistant_id: string };
+  }) => ({
+    queryKey: ["oauth-connections", path.assistant_id],
+    queryFn: async () =>
+      googleConnected
+        ? [{ provider: "google", connected: true, scopes_granted: [] }]
+        : [],
+  }),
+  // Returned shape only needs to satisfy `useMutation({ ...mutation() })`.
+  // `mutationFn` resolves a fake connect_url; the popup never navigates in tests.
+  assistantsOauthStartCreateMutation: () => ({
+    mutationFn: async () => ({ connect_url: "https://example.test/oauth" }),
+  }),
+}));
+
+// Force the web (popup) path, never native.
+mock.module("@/runtime/native-auth", () => ({
+  useIsNativePlatform: () => false,
+}));
+
+// Bypass origin checks so tests can drive completion via a plain message event.
+mock.module("@/lib/auth/oauth-popup", () => ({
+  oauthCompletionStorageKey: (requestId: string) =>
+    `vellum:oauth-complete:${requestId}`,
+  isOAuthCompletePayloadForRequest: () => false,
+  getOAuthCompleteMessagePayload: (event: MessageEvent) => event.data,
+  getOAuthCompleteStoragePayload: () => null,
+}));
+
+const { useInboxCleanupOffer } = await import(
+  "@/domains/chat/hooks/use-inbox-cleanup-offer"
+);
 
 interface OverrideOptions {
   didOnboarding?: boolean;
@@ -17,6 +62,7 @@ interface OverrideOptions {
   messages?: DisplayMessage[];
   activeConversationId?: string | null;
   onboardingConversationId?: string | null;
+  assistantId?: string | null;
   sendMessage?: (content: string) => void;
 }
 
@@ -37,56 +83,138 @@ function baseOptions(overrides: OverrideOptions = {}) {
       overrides.onboardingConversationId === undefined
         ? CONVERSATION_ID
         : overrides.onboardingConversationId,
+    assistantId:
+      overrides.assistantId === undefined ? ASSISTANT_ID : overrides.assistantId,
     sendMessage: overrides.sendMessage ?? (() => {}),
   };
 }
 
+function withQueryClient() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+// A fake popup whose `location.href` setter is inert, so happy-dom never tries
+// to actually navigate (and fetch) the connect URL.
+function makeFakePopup(): Window {
+  return {
+    closed: false,
+    close() {
+      (this as { closed: boolean }).closed = true;
+    },
+    location: { href: "" },
+  } as unknown as Window;
+}
+
+function dispatchOAuthComplete(oauthStatus: string) {
+  act(() => {
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: {
+          type: "vellum:oauth-complete",
+          requestId: REQUEST_ID,
+          oauthStatus,
+          oauthProvider: "google",
+        },
+      }),
+    );
+  });
+}
+
+const realWindowOpen = window.open;
+
+beforeEach(() => {
+  googleConnected = false;
+  // Deterministic request id so dispatched completion events match.
+  crypto.randomUUID = (() =>
+    REQUEST_ID) as unknown as typeof crypto.randomUUID;
+  // Return an inert popup so happy-dom never navigates the connect URL.
+  window.open = (() => makeFakePopup()) as typeof window.open;
+});
+
 afterEach(() => {
   cleanup();
+  window.open = realWindowOpen;
 });
 
 describe("useInboxCleanupOffer", () => {
   test("hidden when the activation flag is off", () => {
-    const { result } = renderHook(() =>
-      useInboxCleanupOffer(baseOptions({ activationFlowEnabled: false })),
+    const { result } = renderHook(
+      () => useInboxCleanupOffer(baseOptions({ activationFlowEnabled: false })),
+      { wrapper: withQueryClient() },
     );
     expect(result.current.showInboxOffer).toBe(false);
   });
 
   test("hidden when firstTask does not match inbox-cleanup", () => {
-    const { result } = renderHook(() =>
-      useInboxCleanupOffer(baseOptions({ firstTask: "something-else" })),
+    const { result } = renderHook(
+      () => useInboxCleanupOffer(baseOptions({ firstTask: "something-else" })),
+      { wrapper: withQueryClient() },
     );
     expect(result.current.showInboxOffer).toBe(false);
   });
 
   test("hidden when the assistant greeting has not arrived", () => {
-    const { result } = renderHook(() =>
-      useInboxCleanupOffer(
-        baseOptions({ messages: [{ id: "u1", role: "user" }] }),
-      ),
+    const { result } = renderHook(
+      () =>
+        useInboxCleanupOffer(
+          baseOptions({ messages: [{ id: "u1", role: "user" }] }),
+        ),
+      { wrapper: withQueryClient() },
     );
     expect(result.current.showInboxOffer).toBe(false);
   });
 
   test("hidden when not on the onboarding conversation", () => {
-    const { result } = renderHook(() =>
-      useInboxCleanupOffer(baseOptions({ activeConversationId: "other" })),
+    const { result } = renderHook(
+      () => useInboxCleanupOffer(baseOptions({ activeConversationId: "other" })),
+      { wrapper: withQueryClient() },
     );
     expect(result.current.showInboxOffer).toBe(false);
   });
 
   test("shown when all conditions are met", () => {
-    const { result } = renderHook(() =>
-      useInboxCleanupOffer(baseOptions()),
-    );
+    const { result } = renderHook(() => useInboxCleanupOffer(baseOptions()), {
+      wrapper: withQueryClient(),
+    });
     expect(result.current.showInboxOffer).toBe(true);
   });
 
-  test("handleAccept sends exactly one message and hides the card", () => {
+  test("already connected: sends run message immediately, no popup", async () => {
+    googleConnected = true;
+    const openSpy = mock(() => makeFakePopup());
+    window.open = openSpy as typeof window.open;
     const sendMessage = mock((_content: string) => {});
-    const { result } = renderHook(() =>
-      useInboxCleanupOffer(baseOptions({ sendMessage })),
+
+    const { result } = renderHook(
+      () => useInboxCleanupOffer(baseOptions({ sendMessage })),
+      { wrapper: withQueryClient() },
+    );
+    expect(result.current.showInboxOffer).toBe(true);
+
+    act(() => {
+      result.current.handleAccept();
+    });
+    // accepting flips synchronously so both buttons disable immediately.
+    expect(result.current.accepting).toBe(true);
+
+    await waitFor(() => {
+      expect(sendMessage).toHaveBeenCalledTimes(1);
+    });
+    expect(openSpy).not.toHaveBeenCalled();
+    expect(result.current.showInboxOffer).toBe(false);
+  });
+
+  test("not connected: starts OAuth, runs only after success", async () => {
+    googleConnected = false;
+    const sendMessage = mock((_content: string) => {});
+
+    const { result } = renderHook(
+      () => useInboxCleanupOffer(baseOptions({ sendMessage })),
+      { wrapper: withQueryClient() },
     );
     expect(result.current.showInboxOffer).toBe(true);
 
@@ -94,15 +222,53 @@ describe("useInboxCleanupOffer", () => {
       result.current.handleAccept();
     });
 
-    expect(sendMessage).toHaveBeenCalledTimes(1);
+    // Connecting: buttons disabled, card still up, nothing sent yet.
+    await waitFor(() => {
+      expect(result.current.accepting).toBe(true);
+    });
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(result.current.showInboxOffer).toBe(true);
+
+    dispatchOAuthComplete("connected");
+
+    await waitFor(() => {
+      expect(sendMessage).toHaveBeenCalledTimes(1);
+    });
     expect(result.current.showInboxOffer).toBe(false);
-    expect(result.current.accepting).toBe(true);
+  });
+
+  test("not connected then cancel: re-shows card, sends nothing", async () => {
+    googleConnected = false;
+    const sendMessage = mock((_content: string) => {});
+
+    const { result } = renderHook(
+      () => useInboxCleanupOffer(baseOptions({ sendMessage })),
+      { wrapper: withQueryClient() },
+    );
+
+    act(() => {
+      result.current.handleAccept();
+    });
+    await waitFor(() => {
+      expect(result.current.accepting).toBe(true);
+    });
+
+    // Non-"connected" status models a cancel/failure.
+    dispatchOAuthComplete("cancelled");
+
+    await waitFor(() => {
+      expect(result.current.accepting).toBe(false);
+    });
+    expect(sendMessage).not.toHaveBeenCalled();
+    // Card stays visible so the user can retry.
+    expect(result.current.showInboxOffer).toBe(true);
   });
 
   test("handleDecline hides the card without sending", () => {
     const sendMessage = mock((_content: string) => {});
-    const { result } = renderHook(() =>
-      useInboxCleanupOffer(baseOptions({ sendMessage })),
+    const { result } = renderHook(
+      () => useInboxCleanupOffer(baseOptions({ sendMessage })),
+      { wrapper: withQueryClient() },
     );
     expect(result.current.showInboxOffer).toBe(true);
 
@@ -116,9 +282,9 @@ describe("useInboxCleanupOffer", () => {
   });
 
   test("dismissed card never reappears", () => {
-    const { result } = renderHook(() =>
-      useInboxCleanupOffer(baseOptions()),
-    );
+    const { result } = renderHook(() => useInboxCleanupOffer(baseOptions()), {
+      wrapper: withQueryClient(),
+    });
     expect(result.current.showInboxOffer).toBe(true);
 
     act(() => {

--- a/apps/web/src/domains/chat/hooks/use-inbox-cleanup-offer.ts
+++ b/apps/web/src/domains/chat/hooks/use-inbox-cleanup-offer.ts
@@ -6,11 +6,33 @@
  * did onboarding, the chosen first task is inbox-cleanup, greeting arrived,
  * on the onboarding conversation). Once dismissed it never reappears.
  *
- * Spike version: accept assumes Google is already connected and just runs the
- * inbox-cleanup skill (OAuth is layered in by a later PR).
+ * Accept ensures Google is connected before running the inbox-cleanup skill:
+ * if Google is already connected it runs immediately, otherwise it kicks off
+ * the existing Google OAuth flow (same start mutation + popup as the pre-chat
+ * `GoogleConnectScreen`) and only runs once the popup reports success. A
+ * cancelled/failed connect re-shows the offer and sends nothing.
  */
 
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+
+import {
+  assistantsOauthConnectionsListOptions,
+  assistantsOauthStartCreateMutation,
+} from "@/generated/api/@tanstack/react-query.gen";
+import type { OAuthConnection } from "@/generated/api/types.gen";
+import { useOAuthCompleteDeepLinkListener } from "@/hooks/use-oauth-complete-deep-link-listener";
+import {
+  getOAuthCompleteMessagePayload,
+  getOAuthCompleteStoragePayload,
+  isOAuthCompletePayloadForRequest,
+  oauthCompletionStorageKey,
+  type OAuthCompletePayload,
+} from "@/lib/auth/oauth-popup";
+import { openUrl, openUrlFinishedListener } from "@/runtime/browser";
+import type { OAuthCompleteDeepLinkPayload } from "@/runtime/native-deep-link";
+import { useIsNativePlatform } from "@/runtime/native-auth";
+import { routes } from "@/utils/routes";
 
 import type { DisplayMessage } from "@/domains/chat/utils/reconcile";
 
@@ -23,6 +45,9 @@ import type { DisplayMessage } from "@/domains/chat/utils/reconcile";
  */
 const INBOX_CLEANUP_TASK_ID = "inbox-cleanup";
 
+/** OAuth provider key, matching `GoogleConnectScreen`. */
+const GOOGLE_PROVIDER_KEY = "google";
+
 /** Run message that matches the inbox-cleanup skill's activation hints. */
 const INBOX_CLEANUP_RUN_MESSAGE =
   "Please clean up my inbox using the inbox-cleanup skill, then give me a concrete summary of how many emails you archived and by which pass.";
@@ -34,6 +59,7 @@ interface UseInboxCleanupOfferOptions {
   messages: DisplayMessage[];
   activeConversationId: string | null;
   onboardingConversationId: string | null;
+  assistantId: string | null;
   sendMessage: (content: string) => void;
 }
 
@@ -51,8 +77,12 @@ export function useInboxCleanupOffer({
   messages,
   activeConversationId,
   onboardingConversationId,
+  assistantId,
   sendMessage,
 }: UseInboxCleanupOfferOptions): UseInboxCleanupOfferReturn {
+  const queryClient = useQueryClient();
+  const isNative = useIsNativePlatform();
+
   const [phase, setPhase] = useState<"pending" | "visible" | "dismissed">(
     "pending",
   );
@@ -116,11 +146,346 @@ export function useInboxCleanupOffer({
     dismiss();
   }, [dismiss]);
 
-  const handleAccept = useCallback(() => {
-    setAccepting(true);
+  // ---------------------------------------------------------------------------
+  // Google OAuth connect-if-needed (mirrors `GoogleConnectScreen`).
+  // ---------------------------------------------------------------------------
+
+  const popupRef = useRef<Window | null>(null);
+  const pendingRequestRef = useRef<{ requestId: string } | null>(null);
+  const popupCheckIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const popupClosedGraceTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const messageListenerRef = useRef<((event: MessageEvent) => void) | null>(null);
+  const storageListenerRef = useRef<((event: StorageEvent) => void) | null>(null);
+  const nativeFinishUnsubRef = useRef<(() => void) | null>(null);
+
+  const startOAuth = useMutation({
+    ...assistantsOauthStartCreateMutation(),
+  });
+
+  // `sendMessage` is read by `runInboxCleanup`; keep it in a ref so the OAuth
+  // callbacks stay stable while always running the latest sender. Synced in the
+  // commit phase (refs must not be written during render).
+  const sendMessageRef = useRef(sendMessage);
+  useLayoutEffect(() => {
+    sendMessageRef.current = sendMessage;
+  });
+
+  const runInboxCleanup = useCallback(() => {
     dismiss();
-    sendMessage(INBOX_CLEANUP_RUN_MESSAGE);
-  }, [dismiss, sendMessage]);
+    sendMessageRef.current(INBOX_CLEANUP_RUN_MESSAGE);
+  }, [dismiss]);
+
+  const removeEventListeners = useCallback(() => {
+    if (messageListenerRef.current) {
+      window.removeEventListener("message", messageListenerRef.current);
+      messageListenerRef.current = null;
+    }
+    if (storageListenerRef.current) {
+      window.removeEventListener("storage", storageListenerRef.current);
+      storageListenerRef.current = null;
+    }
+  }, []);
+
+  const closePopupWindow = useCallback(() => {
+    if (popupRef.current && !popupRef.current.closed) {
+      popupRef.current.close();
+    }
+    popupRef.current = null;
+    if (popupCheckIntervalRef.current) {
+      clearInterval(popupCheckIntervalRef.current);
+      popupCheckIntervalRef.current = null;
+    }
+    if (popupClosedGraceTimeoutRef.current) {
+      clearTimeout(popupClosedGraceTimeoutRef.current);
+      popupClosedGraceTimeoutRef.current = null;
+    }
+  }, []);
+
+  const clearPendingRequest = useCallback(() => {
+    pendingRequestRef.current = null;
+  }, []);
+
+  // Cancel/failure: stop spinning, leave the offer visible to retry, send nothing.
+  const cancelConnect = useCallback(() => {
+    closePopupWindow();
+    clearPendingRequest();
+    removeEventListeners();
+    setAccepting(false);
+  }, [clearPendingRequest, closePopupWindow, removeEventListeners]);
+
+  useEffect(() => {
+    return () => {
+      if (popupCheckIntervalRef.current) clearInterval(popupCheckIntervalRef.current);
+      if (popupClosedGraceTimeoutRef.current) clearTimeout(popupClosedGraceTimeoutRef.current);
+      if (popupRef.current && !popupRef.current.closed) popupRef.current.close();
+      if (messageListenerRef.current) {
+        window.removeEventListener("message", messageListenerRef.current);
+      }
+      if (storageListenerRef.current) {
+        window.removeEventListener("storage", storageListenerRef.current);
+      }
+      if (nativeFinishUnsubRef.current) {
+        nativeFinishUnsubRef.current();
+        nativeFinishUnsubRef.current = null;
+      }
+    };
+  }, []);
+
+  const fetchActiveGoogleConnection =
+    useCallback(async (): Promise<OAuthConnection | null> => {
+      if (!assistantId) return null;
+      try {
+        const connections = await queryClient.fetchQuery({
+          ...assistantsOauthConnectionsListOptions({
+            path: { assistant_id: assistantId },
+          }),
+          staleTime: 0,
+        });
+        return (
+          (connections as OAuthConnection[]).find(
+            (c) => c.provider === GOOGLE_PROVIDER_KEY && c.connected,
+          ) ?? null
+        );
+      } catch {
+        return null;
+      }
+    }, [assistantId, queryClient]);
+
+  // OAuth succeeded for the pending request: tear down, then run.
+  const handleOAuthSuccess = useCallback(() => {
+    closePopupWindow();
+    clearPendingRequest();
+    removeEventListeners();
+    runInboxCleanup();
+  }, [clearPendingRequest, closePopupWindow, removeEventListeners, runInboxCleanup]);
+
+  const handleOAuthCompletePayload = useCallback(
+    (payload: OAuthCompletePayload) => {
+      if (payload.type !== "vellum:oauth-complete") return;
+      if (
+        !pendingRequestRef.current ||
+        payload.requestId !== pendingRequestRef.current.requestId
+      ) {
+        return;
+      }
+      if (payload.oauthStatus === "connected") {
+        handleOAuthSuccess();
+      } else {
+        cancelConnect();
+      }
+    },
+    [cancelConnect, handleOAuthSuccess],
+  );
+
+  const handleOAuthMessage = useCallback(
+    (event: MessageEvent) => {
+      const pendingRequest = pendingRequestRef.current;
+      if (!pendingRequest) return;
+      const payload = getOAuthCompleteMessagePayload(
+        event,
+        window.location.origin,
+        pendingRequest.requestId,
+      );
+      if (payload) handleOAuthCompletePayload(payload);
+    },
+    [handleOAuthCompletePayload],
+  );
+
+  const handleOAuthStorage = useCallback(
+    (event: StorageEvent) => {
+      const pendingRequest = pendingRequestRef.current;
+      if (!pendingRequest) return;
+      const payload = getOAuthCompleteStoragePayload(
+        event,
+        pendingRequest.requestId,
+      );
+      if (payload) {
+        handleOAuthCompletePayload(payload);
+        window.localStorage.removeItem(
+          oauthCompletionStorageKey(pendingRequest.requestId),
+        );
+      }
+    },
+    [handleOAuthCompletePayload],
+  );
+
+  const handleOAuthDeepLink = useCallback(
+    (payload: OAuthCompleteDeepLinkPayload) => {
+      const pendingRequest = pendingRequestRef.current;
+      if (!pendingRequest) return;
+      if (payload.requestId !== pendingRequest.requestId) return;
+      handleOAuthCompletePayload({
+        type: "vellum:oauth-complete",
+        requestId: payload.requestId,
+        oauthStatus: payload.oauthStatus,
+        oauthProvider: payload.oauthProvider,
+        oauthCode: payload.oauthCode,
+      });
+    },
+    [handleOAuthCompletePayload],
+  );
+  useOAuthCompleteDeepLinkListener(handleOAuthDeepLink);
+
+  const startGoogleConnect = useCallback(() => {
+    if (!assistantId) {
+      cancelConnect();
+      return;
+    }
+
+    const requestId = crypto.randomUUID();
+
+    removeEventListeners();
+    messageListenerRef.current = handleOAuthMessage;
+    storageListenerRef.current = handleOAuthStorage;
+
+    if (isNative) {
+      pendingRequestRef.current = { requestId };
+      startOAuth.mutate(
+        {
+          path: { assistant_id: assistantId, provider: GOOGLE_PROVIDER_KEY },
+          body: {
+            requested_scopes: [],
+            redirect_after_connect: `${routes.account.oauth.popupComplete}?requestId=${requestId}&native=1`,
+          },
+        },
+        {
+          onSuccess(data) {
+            void openUrl(data.connect_url);
+          },
+          onError() {
+            cancelConnect();
+          },
+        },
+      );
+
+      window.addEventListener("message", handleOAuthMessage);
+      window.addEventListener("storage", handleOAuthStorage);
+
+      if (nativeFinishUnsubRef.current) nativeFinishUnsubRef.current();
+      const unsubFinished = openUrlFinishedListener(() => {
+        const pendingRequest = pendingRequestRef.current;
+        if (!pendingRequest) {
+          unsubFinished();
+          nativeFinishUnsubRef.current = null;
+          return;
+        }
+        void (async () => {
+          const connection = await fetchActiveGoogleConnection();
+          if (!pendingRequestRef.current) return;
+          if (connection) {
+            handleOAuthSuccess();
+          } else {
+            cancelConnect();
+          }
+          unsubFinished();
+          nativeFinishUnsubRef.current = null;
+        })();
+      });
+      nativeFinishUnsubRef.current = unsubFinished;
+      return;
+    }
+
+    const popup = window.open("", "_blank", "width=500,height=600");
+    if (popup === null) {
+      cancelConnect();
+      return;
+    }
+
+    popupRef.current = popup;
+    pendingRequestRef.current = { requestId };
+
+    window.addEventListener("message", handleOAuthMessage);
+    window.addEventListener("storage", handleOAuthStorage);
+
+    popupCheckIntervalRef.current = setInterval(() => {
+      if (
+        popupRef.current &&
+        popupRef.current.closed &&
+        pendingRequestRef.current &&
+        !popupClosedGraceTimeoutRef.current
+      ) {
+        popupClosedGraceTimeoutRef.current = setTimeout(async () => {
+          popupClosedGraceTimeoutRef.current = null;
+          const pendingRequest = pendingRequestRef.current;
+          if (!pendingRequest) return;
+
+          const storedCompletion = window.localStorage.getItem(
+            oauthCompletionStorageKey(pendingRequest.requestId),
+          );
+          if (storedCompletion) {
+            try {
+              const parsed: unknown = JSON.parse(storedCompletion);
+              if (isOAuthCompletePayloadForRequest(parsed, pendingRequest.requestId)) {
+                handleOAuthCompletePayload(parsed);
+                window.localStorage.removeItem(
+                  oauthCompletionStorageKey(pendingRequest.requestId),
+                );
+                return;
+              }
+            } catch {
+              // Fall through to poll path.
+            }
+          }
+
+          const connection = await fetchActiveGoogleConnection();
+          if (!pendingRequestRef.current) return;
+
+          if (connection) {
+            handleOAuthSuccess();
+          } else {
+            cancelConnect();
+          }
+        }, 1000);
+      }
+    }, 100);
+
+    startOAuth.mutate(
+      {
+        path: { assistant_id: assistantId, provider: GOOGLE_PROVIDER_KEY },
+        body: {
+          requested_scopes: [],
+          redirect_after_connect: `${routes.account.oauth.popupComplete}?requestId=${requestId}`,
+        },
+      },
+      {
+        onSuccess(data) {
+          if (popupRef.current && !popupRef.current.closed) {
+            popupRef.current.location.href = data.connect_url;
+          } else if (pendingRequestRef.current) {
+            cancelConnect();
+          }
+        },
+        onError() {
+          cancelConnect();
+        },
+      },
+    );
+  }, [
+    assistantId,
+    cancelConnect,
+    fetchActiveGoogleConnection,
+    handleOAuthCompletePayload,
+    handleOAuthMessage,
+    handleOAuthStorage,
+    handleOAuthSuccess,
+    isNative,
+    removeEventListeners,
+    startOAuth,
+  ]);
+
+  const handleAccept = useCallback(() => {
+    if (accepting) return;
+    // Keep both buttons disabled for the whole connect→run window.
+    setAccepting(true);
+    void (async () => {
+      const connection = await fetchActiveGoogleConnection();
+      if (connection) {
+        runInboxCleanup();
+        return;
+      }
+      startGoogleConnect();
+    })();
+  }, [accepting, fetchActiveGoogleConnection, runInboxCleanup, startGoogleConnect]);
 
   return {
     showInboxOffer: phase === "visible",


### PR DESCRIPTION
## Summary
- On accept, ensure Google is connected (reusing the existing OAuth start + popup flow) before running the inbox-cleanup skill
- Buttons stay disabled during connect→run; cancel/failure re-shows the offer

Part of plan: inbox-cleanup-activation-spike.md (PR 7 of 7)