### PR TITLE
JARVIS-1090 — Day-1 spike: end-to-end inbox cleanup activation rail

### DIFF
--- a/apps/web/src/domains/chat/active-chat-view.tsx
+++ b/apps/web/src/domains/chat/active-chat-view.tsx
@@ -36,6 +36,7 @@ import type { UIContext } from "@/domains/chat/turn-selectors";
 import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 
 import { peekPendingPreChatContext } from "@/domains/onboarding/prechat";
+import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 
 import { LazyBoundary } from "@/components/lazy-boundary";
 import { useChatAttachments } from "@/domains/chat/components/chat-attachments/use-chat-attachments";
@@ -153,10 +154,17 @@ export function ActiveChatView() {
   const {
     didOnboarding,
     onboardingTasksEmpty,
+    firstTask,
     onboardingConversationId,
     pendingOnboardingContextRef,
     onboardingDraftConversationIdRef,
   } = useOnboardingOrchestrator();
+
+  // Activation-flow experiment (JARVIS-1090). `firstTask` is captured at mount
+  // by the orchestrator (before the pending context is consumed on first send)
+  // and threaded down to ChatRouteContent alongside the flag.
+  const activationFlowEnabled =
+    useClientFeatureFlagStore.use.experimentActivationFlow20260603();
 
   // -------------------------------------------------------------------------
   // Reachability
@@ -443,6 +451,8 @@ export function ActiveChatView() {
     onboardingTasksEmpty,
     didOnboarding,
     onboardingConversationId,
+    firstTask,
+    activationFlowEnabled,
   };
 
   return (

--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -461,6 +461,7 @@ export function ChatRouteContent({
     messages,
     activeConversationId,
     onboardingConversationId,
+    assistantId,
     sendMessage,
   });
 

--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -58,7 +58,9 @@ const ToolDetailPanel = lazy(() =>
   })),
 );
 import { OnboardingChoiceCard } from "@/domains/chat/components/onboarding-choice-card";
+import { InboxCleanupOfferCard } from "@/domains/chat/components/inbox-cleanup-offer-card";
 import { useOnboardingChoice } from "@/domains/chat/hooks/use-onboarding-choice";
+import { useInboxCleanupOffer } from "@/domains/chat/hooks/use-inbox-cleanup-offer";
 import { useEditMessage } from "@/domains/chat/hooks/use-edit-message";
 import { conversationsByIdUndoPost, subagentsByIdAbortPost } from "@/generated/daemon/sdk.gen";
 import { useIsNativePlatform } from "@/runtime/native-auth";
@@ -177,6 +179,11 @@ export interface ChatRouteContentProps {
   onboardingTasksEmpty: boolean;
   didOnboarding: boolean;
   onboardingConversationId: string | null;
+  /** Chosen first task from the pre-chat context (derived in ActiveChatView,
+   *  which owns the onboarding-domain reads). */
+  firstTask: string | null;
+  /** Whether the activation-flow experiment flag is enabled. */
+  activationFlowEnabled: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -219,6 +226,8 @@ export function ChatRouteContent({
   onboardingTasksEmpty,
   didOnboarding,
   onboardingConversationId,
+  firstTask,
+  activationFlowEnabled,
 }: ChatRouteContentProps) {
   const navigate = useNavigate();
   const isMobile = useIsMobile();
@@ -435,6 +444,21 @@ export function ChatRouteContent({
     didOnboarding,
     messages,
     onboardingTasksEmpty,
+    activeConversationId,
+    onboardingConversationId,
+    sendMessage,
+  });
+
+  const {
+    showInboxOffer,
+    handleAccept: handleInboxAccept,
+    handleDecline: handleInboxDecline,
+    accepting: inboxAccepting,
+  } = useInboxCleanupOffer({
+    didOnboarding,
+    firstTask,
+    activationFlowEnabled,
+    messages,
     activeConversationId,
     onboardingConversationId,
     sendMessage,
@@ -731,6 +755,7 @@ export function ChatRouteContent({
         autoRoutedProfileLabel,
         errorNotice: null,
         showOnboardingChoice,
+        showInboxOffer,
       }),
     [
       sanitizedMessages,
@@ -742,6 +767,7 @@ export function ChatRouteContent({
       thinkingLabel,
       autoRoutedProfileLabel,
       showOnboardingChoice,
+      showInboxOffer,
     ],
   );
 
@@ -1178,6 +1204,13 @@ export function ChatRouteContent({
       <OnboardingChoiceCard
         onSelectSpecific={handleSelectSpecific}
         onSubmitTasks={handleSubmitTasks}
+      />
+    ),
+    renderInboxOffer: () => (
+      <InboxCleanupOfferCard
+        onAccept={handleInboxAccept}
+        onDecline={handleInboxDecline}
+        busy={inboxAccepting}
       />
     ),
   };

--- a/apps/web/src/domains/chat/components/inbox-cleanup-offer-card.tsx
+++ b/apps/web/src/domains/chat/components/inbox-cleanup-offer-card.tsx
@@ -1,0 +1,65 @@
+/**
+ * Presentational in-chat offer card that proposes cleaning the user's inbox.
+ *
+ * Shows a title, a short description, and two actions: a primary "Yes, clean
+ * my inbox" button (`onAccept`) and an outlined "Not now" button (`onDecline`).
+ * Both buttons are disabled while `busy` is true (e.g. during the OAuth/skill
+ * kickoff that the accept flow triggers).
+ *
+ * Purely presentational — no data fetching, store reads, or network access.
+ */
+
+import { Sparkles } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { Button, Card } from "@vellum/design-library";
+
+export interface InboxCleanupOfferCardProps {
+  onAccept: () => void;
+  onDecline: () => void;
+  /** Disables buttons while the accept flow (OAuth/skill kickoff) is running. */
+  busy?: boolean;
+}
+
+export function InboxCleanupOfferCard({
+  onAccept,
+  onDecline,
+  busy = false,
+}: InboxCleanupOfferCardProps): ReactNode {
+  return (
+    <div className="max-w-sm" style={{ animation: "fadeInUp 0.3s ease-out both" }}>
+      <Card>
+        <div className="flex flex-col gap-3">
+          <div className="flex items-center gap-2 text-body-medium-default text-[color:var(--content-default)]">
+            <Sparkles className="h-4 w-4 text-[var(--content-secondary)]" />
+            Want me to clean your inbox?
+          </div>
+          <div className="text-label-small-default text-[color:var(--content-tertiary)]">
+            I&apos;ll connect Gmail and archive the clutter — you can undo
+            anything.
+          </div>
+          <div className="flex flex-col gap-2">
+            <Button
+              variant="primary"
+              size="regular"
+              fullWidth
+              disabled={busy}
+              onClick={onAccept}
+            >
+              Yes, clean my inbox
+            </Button>
+            <Button
+              variant="outlined"
+              size="regular"
+              fullWidth
+              disabled={busy}
+              onClick={onDecline}
+            >
+              Not now
+            </Button>
+          </div>
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/domains/chat/hooks/use-inbox-cleanup-offer.test.ts
+++ b/apps/web/src/domains/chat/hooks/use-inbox-cleanup-offer.test.ts
@@ -1,14 +1,59 @@
-import { afterEach, describe, expect, mock, test } from "bun:test";
-import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { createElement } from "react";
 
-import { useInboxCleanupOffer } from "@/domains/chat/hooks/use-inbox-cleanup-offer";
 import type { DisplayMessage } from "@/domains/chat/utils/reconcile";
 
 const INBOX_CLEANUP_TASK_ID = "inbox-cleanup";
-
 const CONVERSATION_ID = "conv-onboarding";
+const ASSISTANT_ID = "asst-1";
+const REQUEST_ID = "req-test-1";
 
 const greeting: DisplayMessage[] = [{ id: "m1", role: "assistant" }];
+
+// --- Controllable mocks for the generated OAuth API ------------------------
+
+// Google connection state returned by the connections query. Tests flip this.
+let googleConnected = false;
+
+mock.module("@/generated/api/@tanstack/react-query.gen", () => ({
+  assistantsOauthConnectionsListOptions: ({
+    path,
+  }: {
+    path: { assistant_id: string };
+  }) => ({
+    queryKey: ["oauth-connections", path.assistant_id],
+    queryFn: async () =>
+      googleConnected
+        ? [{ provider: "google", connected: true, scopes_granted: [] }]
+        : [],
+  }),
+  // Returned shape only needs to satisfy `useMutation({ ...mutation() })`.
+  // `mutationFn` resolves a fake connect_url; the popup never navigates in tests.
+  assistantsOauthStartCreateMutation: () => ({
+    mutationFn: async () => ({ connect_url: "https://example.test/oauth" }),
+  }),
+}));
+
+// Force the web (popup) path, never native.
+mock.module("@/runtime/native-auth", () => ({
+  useIsNativePlatform: () => false,
+}));
+
+// Bypass origin checks so tests can drive completion via a plain message event.
+mock.module("@/lib/auth/oauth-popup", () => ({
+  oauthCompletionStorageKey: (requestId: string) =>
+    `vellum:oauth-complete:${requestId}`,
+  isOAuthCompletePayloadForRequest: () => false,
+  getOAuthCompleteMessagePayload: (event: MessageEvent) => event.data,
+  getOAuthCompleteStoragePayload: () => null,
+}));
+
+const { useInboxCleanupOffer } = await import(
+  "@/domains/chat/hooks/use-inbox-cleanup-offer"
+);
 
 interface OverrideOptions {
   didOnboarding?: boolean;
@@ -17,6 +62,7 @@ interface OverrideOptions {
   messages?: DisplayMessage[];
   activeConversationId?: string | null;
   onboardingConversationId?: string | null;
+  assistantId?: string | null;
   sendMessage?: (content: string) => void;
 }
 
@@ -37,56 +83,138 @@ function baseOptions(overrides: OverrideOptions = {}) {
       overrides.onboardingConversationId === undefined
         ? CONVERSATION_ID
         : overrides.onboardingConversationId,
+    assistantId:
+      overrides.assistantId === undefined ? ASSISTANT_ID : overrides.assistantId,
     sendMessage: overrides.sendMessage ?? (() => {}),
   };
 }
 
+function withQueryClient() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+// A fake popup whose `location.href` setter is inert, so happy-dom never tries
+// to actually navigate (and fetch) the connect URL.
+function makeFakePopup(): Window {
+  return {
+    closed: false,
+    close() {
+      (this as { closed: boolean }).closed = true;
+    },
+    location: { href: "" },
+  } as unknown as Window;
+}
+
+function dispatchOAuthComplete(oauthStatus: string) {
+  act(() => {
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: {
+          type: "vellum:oauth-complete",
+          requestId: REQUEST_ID,
+          oauthStatus,
+          oauthProvider: "google",
+        },
+      }),
+    );
+  });
+}
+
+const realWindowOpen = window.open;
+
+beforeEach(() => {
+  googleConnected = false;
+  // Deterministic request id so dispatched completion events match.
+  crypto.randomUUID = (() =>
+    REQUEST_ID) as unknown as typeof crypto.randomUUID;
+  // Return an inert popup so happy-dom never navigates the connect URL.
+  window.open = (() => makeFakePopup()) as typeof window.open;
+});
+
 afterEach(() => {
   cleanup();
+  window.open = realWindowOpen;
 });
 
 describe("useInboxCleanupOffer", () => {
   test("hidden when the activation flag is off", () => {
-    const { result } = renderHook(() =>
-      useInboxCleanupOffer(baseOptions({ activationFlowEnabled: false })),
+    const { result } = renderHook(
+      () => useInboxCleanupOffer(baseOptions({ activationFlowEnabled: false })),
+      { wrapper: withQueryClient() },
     );
     expect(result.current.showInboxOffer).toBe(false);
   });
 
   test("hidden when firstTask does not match inbox-cleanup", () => {
-    const { result } = renderHook(() =>
-      useInboxCleanupOffer(baseOptions({ firstTask: "something-else" })),
+    const { result } = renderHook(
+      () => useInboxCleanupOffer(baseOptions({ firstTask: "something-else" })),
+      { wrapper: withQueryClient() },
     );
     expect(result.current.showInboxOffer).toBe(false);
   });
 
   test("hidden when the assistant greeting has not arrived", () => {
-    const { result } = renderHook(() =>
-      useInboxCleanupOffer(
-        baseOptions({ messages: [{ id: "u1", role: "user" }] }),
-      ),
+    const { result } = renderHook(
+      () =>
+        useInboxCleanupOffer(
+          baseOptions({ messages: [{ id: "u1", role: "user" }] }),
+        ),
+      { wrapper: withQueryClient() },
     );
     expect(result.current.showInboxOffer).toBe(false);
   });
 
   test("hidden when not on the onboarding conversation", () => {
-    const { result } = renderHook(() =>
-      useInboxCleanupOffer(baseOptions({ activeConversationId: "other" })),
+    const { result } = renderHook(
+      () => useInboxCleanupOffer(baseOptions({ activeConversationId: "other" })),
+      { wrapper: withQueryClient() },
     );
     expect(result.current.showInboxOffer).toBe(false);
   });
 
   test("shown when all conditions are met", () => {
-    const { result } = renderHook(() =>
-      useInboxCleanupOffer(baseOptions()),
-    );
+    const { result } = renderHook(() => useInboxCleanupOffer(baseOptions()), {
+      wrapper: withQueryClient(),
+    });
     expect(result.current.showInboxOffer).toBe(true);
   });
 
-  test("handleAccept sends exactly one message and hides the card", () => {
+  test("already connected: sends run message immediately, no popup", async () => {
+    googleConnected = true;
+    const openSpy = mock(() => makeFakePopup());
+    window.open = openSpy as typeof window.open;
     const sendMessage = mock((_content: string) => {});
-    const { result } = renderHook(() =>
-      useInboxCleanupOffer(baseOptions({ sendMessage })),
+
+    const { result } = renderHook(
+      () => useInboxCleanupOffer(baseOptions({ sendMessage })),
+      { wrapper: withQueryClient() },
+    );
+    expect(result.current.showInboxOffer).toBe(true);
+
+    act(() => {
+      result.current.handleAccept();
+    });
+    // accepting flips synchronously so both buttons disable immediately.
+    expect(result.current.accepting).toBe(true);
+
+    await waitFor(() => {
+      expect(sendMessage).toHaveBeenCalledTimes(1);
+    });
+    expect(openSpy).not.toHaveBeenCalled();
+    expect(result.current.showInboxOffer).toBe(false);
+  });
+
+  test("not connected: starts OAuth, runs only after success", async () => {
+    googleConnected = false;
+    const sendMessage = mock((_content: string) => {});
+
+    const { result } = renderHook(
+      () => useInboxCleanupOffer(baseOptions({ sendMessage })),
+      { wrapper: withQueryClient() },
     );
     expect(result.current.showInboxOffer).toBe(true);
 
@@ -94,15 +222,53 @@ describe("useInboxCleanupOffer", () => {
       result.current.handleAccept();
     });
 
-    expect(sendMessage).toHaveBeenCalledTimes(1);
+    // Connecting: buttons disabled, card still up, nothing sent yet.
+    await waitFor(() => {
+      expect(result.current.accepting).toBe(true);
+    });
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(result.current.showInboxOffer).toBe(true);
+
+    dispatchOAuthComplete("connected");
+
+    await waitFor(() => {
+      expect(sendMessage).toHaveBeenCalledTimes(1);
+    });
     expect(result.current.showInboxOffer).toBe(false);
-    expect(result.current.accepting).toBe(true);
+  });
+
+  test("not connected then cancel: re-shows card, sends nothing", async () => {
+    googleConnected = false;
+    const sendMessage = mock((_content: string) => {});
+
+    const { result } = renderHook(
+      () => useInboxCleanupOffer(baseOptions({ sendMessage })),
+      { wrapper: withQueryClient() },
+    );
+
+    act(() => {
+      result.current.handleAccept();
+    });
+    await waitFor(() => {
+      expect(result.current.accepting).toBe(true);
+    });
+
+    // Non-"connected" status models a cancel/failure.
+    dispatchOAuthComplete("cancelled");
+
+    await waitFor(() => {
+      expect(result.current.accepting).toBe(false);
+    });
+    expect(sendMessage).not.toHaveBeenCalled();
+    // Card stays visible so the user can retry.
+    expect(result.current.showInboxOffer).toBe(true);
   });
 
   test("handleDecline hides the card without sending", () => {
     const sendMessage = mock((_content: string) => {});
-    const { result } = renderHook(() =>
-      useInboxCleanupOffer(baseOptions({ sendMessage })),
+    const { result } = renderHook(
+      () => useInboxCleanupOffer(baseOptions({ sendMessage })),
+      { wrapper: withQueryClient() },
     );
     expect(result.current.showInboxOffer).toBe(true);
 
@@ -116,9 +282,9 @@ describe("useInboxCleanupOffer", () => {
   });
 
   test("dismissed card never reappears", () => {
-    const { result } = renderHook(() =>
-      useInboxCleanupOffer(baseOptions()),
-    );
+    const { result } = renderHook(() => useInboxCleanupOffer(baseOptions()), {
+      wrapper: withQueryClient(),
+    });
     expect(result.current.showInboxOffer).toBe(true);
 
     act(() => {

--- a/apps/web/src/domains/chat/hooks/use-inbox-cleanup-offer.test.ts
+++ b/apps/web/src/domains/chat/hooks/use-inbox-cleanup-offer.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, renderHook } from "@testing-library/react";
+
+import { useInboxCleanupOffer } from "@/domains/chat/hooks/use-inbox-cleanup-offer";
+import type { DisplayMessage } from "@/domains/chat/utils/reconcile";
+
+const INBOX_CLEANUP_TASK_ID = "inbox-cleanup";
+
+const CONVERSATION_ID = "conv-onboarding";
+
+const greeting: DisplayMessage[] = [{ id: "m1", role: "assistant" }];
+
+interface OverrideOptions {
+  didOnboarding?: boolean;
+  firstTask?: string | null;
+  activationFlowEnabled?: boolean;
+  messages?: DisplayMessage[];
+  activeConversationId?: string | null;
+  onboardingConversationId?: string | null;
+  sendMessage?: (content: string) => void;
+}
+
+function baseOptions(overrides: OverrideOptions = {}) {
+  return {
+    didOnboarding: overrides.didOnboarding ?? true,
+    firstTask:
+      overrides.firstTask === undefined
+        ? INBOX_CLEANUP_TASK_ID
+        : overrides.firstTask,
+    activationFlowEnabled: overrides.activationFlowEnabled ?? true,
+    messages: overrides.messages ?? greeting,
+    activeConversationId:
+      overrides.activeConversationId === undefined
+        ? CONVERSATION_ID
+        : overrides.activeConversationId,
+    onboardingConversationId:
+      overrides.onboardingConversationId === undefined
+        ? CONVERSATION_ID
+        : overrides.onboardingConversationId,
+    sendMessage: overrides.sendMessage ?? (() => {}),
+  };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useInboxCleanupOffer", () => {
+  test("hidden when the activation flag is off", () => {
+    const { result } = renderHook(() =>
+      useInboxCleanupOffer(baseOptions({ activationFlowEnabled: false })),
+    );
+    expect(result.current.showInboxOffer).toBe(false);
+  });
+
+  test("hidden when firstTask does not match inbox-cleanup", () => {
+    const { result } = renderHook(() =>
+      useInboxCleanupOffer(baseOptions({ firstTask: "something-else" })),
+    );
+    expect(result.current.showInboxOffer).toBe(false);
+  });
+
+  test("hidden when the assistant greeting has not arrived", () => {
+    const { result } = renderHook(() =>
+      useInboxCleanupOffer(
+        baseOptions({ messages: [{ id: "u1", role: "user" }] }),
+      ),
+    );
+    expect(result.current.showInboxOffer).toBe(false);
+  });
+
+  test("hidden when not on the onboarding conversation", () => {
+    const { result } = renderHook(() =>
+      useInboxCleanupOffer(baseOptions({ activeConversationId: "other" })),
+    );
+    expect(result.current.showInboxOffer).toBe(false);
+  });
+
+  test("shown when all conditions are met", () => {
+    const { result } = renderHook(() =>
+      useInboxCleanupOffer(baseOptions()),
+    );
+    expect(result.current.showInboxOffer).toBe(true);
+  });
+
+  test("handleAccept sends exactly one message and hides the card", () => {
+    const sendMessage = mock((_content: string) => {});
+    const { result } = renderHook(() =>
+      useInboxCleanupOffer(baseOptions({ sendMessage })),
+    );
+    expect(result.current.showInboxOffer).toBe(true);
+
+    act(() => {
+      result.current.handleAccept();
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(result.current.showInboxOffer).toBe(false);
+    expect(result.current.accepting).toBe(true);
+  });
+
+  test("handleDecline hides the card without sending", () => {
+    const sendMessage = mock((_content: string) => {});
+    const { result } = renderHook(() =>
+      useInboxCleanupOffer(baseOptions({ sendMessage })),
+    );
+    expect(result.current.showInboxOffer).toBe(true);
+
+    act(() => {
+      result.current.handleDecline();
+    });
+
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(result.current.showInboxOffer).toBe(false);
+    expect(result.current.accepting).toBe(false);
+  });
+
+  test("dismissed card never reappears", () => {
+    const { result } = renderHook(() =>
+      useInboxCleanupOffer(baseOptions()),
+    );
+    expect(result.current.showInboxOffer).toBe(true);
+
+    act(() => {
+      result.current.handleDecline();
+    });
+    expect(result.current.showInboxOffer).toBe(false);
+  });
+});

--- a/apps/web/src/domains/chat/hooks/use-inbox-cleanup-offer.ts
+++ b/apps/web/src/domains/chat/hooks/use-inbox-cleanup-offer.ts
@@ -6,11 +6,33 @@
  * did onboarding, the chosen first task is inbox-cleanup, greeting arrived,
  * on the onboarding conversation). Once dismissed it never reappears.
  *
- * Spike version: accept assumes Google is already connected and just runs the
- * inbox-cleanup skill (OAuth is layered in by a later PR).
+ * Accept ensures Google is connected before running the inbox-cleanup skill:
+ * if Google is already connected it runs immediately, otherwise it kicks off
+ * the existing Google OAuth flow (same start mutation + popup as the pre-chat
+ * `GoogleConnectScreen`) and only runs once the popup reports success. A
+ * cancelled/failed connect re-shows the offer and sends nothing.
  */
 
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+
+import {
+  assistantsOauthConnectionsListOptions,
+  assistantsOauthStartCreateMutation,
+} from "@/generated/api/@tanstack/react-query.gen";
+import type { OAuthConnection } from "@/generated/api/types.gen";
+import { useOAuthCompleteDeepLinkListener } from "@/hooks/use-oauth-complete-deep-link-listener";
+import {
+  getOAuthCompleteMessagePayload,
+  getOAuthCompleteStoragePayload,
+  isOAuthCompletePayloadForRequest,
+  oauthCompletionStorageKey,
+  type OAuthCompletePayload,
+} from "@/lib/auth/oauth-popup";
+import { openUrl, openUrlFinishedListener } from "@/runtime/browser";
+import type { OAuthCompleteDeepLinkPayload } from "@/runtime/native-deep-link";
+import { useIsNativePlatform } from "@/runtime/native-auth";
+import { routes } from "@/utils/routes";
 
 import type { DisplayMessage } from "@/domains/chat/utils/reconcile";
 
@@ -23,6 +45,9 @@ import type { DisplayMessage } from "@/domains/chat/utils/reconcile";
  */
 const INBOX_CLEANUP_TASK_ID = "inbox-cleanup";
 
+/** OAuth provider key, matching `GoogleConnectScreen`. */
+const GOOGLE_PROVIDER_KEY = "google";
+
 /** Run message that matches the inbox-cleanup skill's activation hints. */
 const INBOX_CLEANUP_RUN_MESSAGE =
   "Please clean up my inbox using the inbox-cleanup skill, then give me a concrete summary of how many emails you archived and by which pass.";
@@ -34,6 +59,7 @@ interface UseInboxCleanupOfferOptions {
   messages: DisplayMessage[];
   activeConversationId: string | null;
   onboardingConversationId: string | null;
+  assistantId: string | null;
   sendMessage: (content: string) => void;
 }
 
@@ -51,8 +77,12 @@ export function useInboxCleanupOffer({
   messages,
   activeConversationId,
   onboardingConversationId,
+  assistantId,
   sendMessage,
 }: UseInboxCleanupOfferOptions): UseInboxCleanupOfferReturn {
+  const queryClient = useQueryClient();
+  const isNative = useIsNativePlatform();
+
   const [phase, setPhase] = useState<"pending" | "visible" | "dismissed">(
     "pending",
   );
@@ -116,11 +146,346 @@ export function useInboxCleanupOffer({
     dismiss();
   }, [dismiss]);
 
-  const handleAccept = useCallback(() => {
-    setAccepting(true);
+  // ---------------------------------------------------------------------------
+  // Google OAuth connect-if-needed (mirrors `GoogleConnectScreen`).
+  // ---------------------------------------------------------------------------
+
+  const popupRef = useRef<Window | null>(null);
+  const pendingRequestRef = useRef<{ requestId: string } | null>(null);
+  const popupCheckIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const popupClosedGraceTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const messageListenerRef = useRef<((event: MessageEvent) => void) | null>(null);
+  const storageListenerRef = useRef<((event: StorageEvent) => void) | null>(null);
+  const nativeFinishUnsubRef = useRef<(() => void) | null>(null);
+
+  const startOAuth = useMutation({
+    ...assistantsOauthStartCreateMutation(),
+  });
+
+  // `sendMessage` is read by `runInboxCleanup`; keep it in a ref so the OAuth
+  // callbacks stay stable while always running the latest sender. Synced in the
+  // commit phase (refs must not be written during render).
+  const sendMessageRef = useRef(sendMessage);
+  useLayoutEffect(() => {
+    sendMessageRef.current = sendMessage;
+  });
+
+  const runInboxCleanup = useCallback(() => {
     dismiss();
-    sendMessage(INBOX_CLEANUP_RUN_MESSAGE);
-  }, [dismiss, sendMessage]);
+    sendMessageRef.current(INBOX_CLEANUP_RUN_MESSAGE);
+  }, [dismiss]);
+
+  const removeEventListeners = useCallback(() => {
+    if (messageListenerRef.current) {
+      window.removeEventListener("message", messageListenerRef.current);
+      messageListenerRef.current = null;
+    }
+    if (storageListenerRef.current) {
+      window.removeEventListener("storage", storageListenerRef.current);
+      storageListenerRef.current = null;
+    }
+  }, []);
+
+  const closePopupWindow = useCallback(() => {
+    if (popupRef.current && !popupRef.current.closed) {
+      popupRef.current.close();
+    }
+    popupRef.current = null;
+    if (popupCheckIntervalRef.current) {
+      clearInterval(popupCheckIntervalRef.current);
+      popupCheckIntervalRef.current = null;
+    }
+    if (popupClosedGraceTimeoutRef.current) {
+      clearTimeout(popupClosedGraceTimeoutRef.current);
+      popupClosedGraceTimeoutRef.current = null;
+    }
+  }, []);
+
+  const clearPendingRequest = useCallback(() => {
+    pendingRequestRef.current = null;
+  }, []);
+
+  // Cancel/failure: stop spinning, leave the offer visible to retry, send nothing.
+  const cancelConnect = useCallback(() => {
+    closePopupWindow();
+    clearPendingRequest();
+    removeEventListeners();
+    setAccepting(false);
+  }, [clearPendingRequest, closePopupWindow, removeEventListeners]);
+
+  useEffect(() => {
+    return () => {
+      if (popupCheckIntervalRef.current) clearInterval(popupCheckIntervalRef.current);
+      if (popupClosedGraceTimeoutRef.current) clearTimeout(popupClosedGraceTimeoutRef.current);
+      if (popupRef.current && !popupRef.current.closed) popupRef.current.close();
+      if (messageListenerRef.current) {
+        window.removeEventListener("message", messageListenerRef.current);
+      }
+      if (storageListenerRef.current) {
+        window.removeEventListener("storage", storageListenerRef.current);
+      }
+      if (nativeFinishUnsubRef.current) {
+        nativeFinishUnsubRef.current();
+        nativeFinishUnsubRef.current = null;
+      }
+    };
+  }, []);
+
+  const fetchActiveGoogleConnection =
+    useCallback(async (): Promise<OAuthConnection | null> => {
+      if (!assistantId) return null;
+      try {
+        const connections = await queryClient.fetchQuery({
+          ...assistantsOauthConnectionsListOptions({
+            path: { assistant_id: assistantId },
+          }),
+          staleTime: 0,
+        });
+        return (
+          (connections as OAuthConnection[]).find(
+            (c) => c.provider === GOOGLE_PROVIDER_KEY && c.connected,
+          ) ?? null
+        );
+      } catch {
+        return null;
+      }
+    }, [assistantId, queryClient]);
+
+  // OAuth succeeded for the pending request: tear down, then run.
+  const handleOAuthSuccess = useCallback(() => {
+    closePopupWindow();
+    clearPendingRequest();
+    removeEventListeners();
+    runInboxCleanup();
+  }, [clearPendingRequest, closePopupWindow, removeEventListeners, runInboxCleanup]);
+
+  const handleOAuthCompletePayload = useCallback(
+    (payload: OAuthCompletePayload) => {
+      if (payload.type !== "vellum:oauth-complete") return;
+      if (
+        !pendingRequestRef.current ||
+        payload.requestId !== pendingRequestRef.current.requestId
+      ) {
+        return;
+      }
+      if (payload.oauthStatus === "connected") {
+        handleOAuthSuccess();
+      } else {
+        cancelConnect();
+      }
+    },
+    [cancelConnect, handleOAuthSuccess],
+  );
+
+  const handleOAuthMessage = useCallback(
+    (event: MessageEvent) => {
+      const pendingRequest = pendingRequestRef.current;
+      if (!pendingRequest) return;
+      const payload = getOAuthCompleteMessagePayload(
+        event,
+        window.location.origin,
+        pendingRequest.requestId,
+      );
+      if (payload) handleOAuthCompletePayload(payload);
+    },
+    [handleOAuthCompletePayload],
+  );
+
+  const handleOAuthStorage = useCallback(
+    (event: StorageEvent) => {
+      const pendingRequest = pendingRequestRef.current;
+      if (!pendingRequest) return;
+      const payload = getOAuthCompleteStoragePayload(
+        event,
+        pendingRequest.requestId,
+      );
+      if (payload) {
+        handleOAuthCompletePayload(payload);
+        window.localStorage.removeItem(
+          oauthCompletionStorageKey(pendingRequest.requestId),
+        );
+      }
+    },
+    [handleOAuthCompletePayload],
+  );
+
+  const handleOAuthDeepLink = useCallback(
+    (payload: OAuthCompleteDeepLinkPayload) => {
+      const pendingRequest = pendingRequestRef.current;
+      if (!pendingRequest) return;
+      if (payload.requestId !== pendingRequest.requestId) return;
+      handleOAuthCompletePayload({
+        type: "vellum:oauth-complete",
+        requestId: payload.requestId,
+        oauthStatus: payload.oauthStatus,
+        oauthProvider: payload.oauthProvider,
+        oauthCode: payload.oauthCode,
+      });
+    },
+    [handleOAuthCompletePayload],
+  );
+  useOAuthCompleteDeepLinkListener(handleOAuthDeepLink);
+
+  const startGoogleConnect = useCallback(() => {
+    if (!assistantId) {
+      cancelConnect();
+      return;
+    }
+
+    const requestId = crypto.randomUUID();
+
+    removeEventListeners();
+    messageListenerRef.current = handleOAuthMessage;
+    storageListenerRef.current = handleOAuthStorage;
+
+    if (isNative) {
+      pendingRequestRef.current = { requestId };
+      startOAuth.mutate(
+        {
+          path: { assistant_id: assistantId, provider: GOOGLE_PROVIDER_KEY },
+          body: {
+            requested_scopes: [],
+            redirect_after_connect: `${routes.account.oauth.popupComplete}?requestId=${requestId}&native=1`,
+          },
+        },
+        {
+          onSuccess(data) {
+            void openUrl(data.connect_url);
+          },
+          onError() {
+            cancelConnect();
+          },
+        },
+      );
+
+      window.addEventListener("message", handleOAuthMessage);
+      window.addEventListener("storage", handleOAuthStorage);
+
+      if (nativeFinishUnsubRef.current) nativeFinishUnsubRef.current();
+      const unsubFinished = openUrlFinishedListener(() => {
+        const pendingRequest = pendingRequestRef.current;
+        if (!pendingRequest) {
+          unsubFinished();
+          nativeFinishUnsubRef.current = null;
+          return;
+        }
+        void (async () => {
+          const connection = await fetchActiveGoogleConnection();
+          if (!pendingRequestRef.current) return;
+          if (connection) {
+            handleOAuthSuccess();
+          } else {
+            cancelConnect();
+          }
+          unsubFinished();
+          nativeFinishUnsubRef.current = null;
+        })();
+      });
+      nativeFinishUnsubRef.current = unsubFinished;
+      return;
+    }
+
+    const popup = window.open("", "_blank", "width=500,height=600");
+    if (popup === null) {
+      cancelConnect();
+      return;
+    }
+
+    popupRef.current = popup;
+    pendingRequestRef.current = { requestId };
+
+    window.addEventListener("message", handleOAuthMessage);
+    window.addEventListener("storage", handleOAuthStorage);
+
+    popupCheckIntervalRef.current = setInterval(() => {
+      if (
+        popupRef.current &&
+        popupRef.current.closed &&
+        pendingRequestRef.current &&
+        !popupClosedGraceTimeoutRef.current
+      ) {
+        popupClosedGraceTimeoutRef.current = setTimeout(async () => {
+          popupClosedGraceTimeoutRef.current = null;
+          const pendingRequest = pendingRequestRef.current;
+          if (!pendingRequest) return;
+
+          const storedCompletion = window.localStorage.getItem(
+            oauthCompletionStorageKey(pendingRequest.requestId),
+          );
+          if (storedCompletion) {
+            try {
+              const parsed: unknown = JSON.parse(storedCompletion);
+              if (isOAuthCompletePayloadForRequest(parsed, pendingRequest.requestId)) {
+                handleOAuthCompletePayload(parsed);
+                window.localStorage.removeItem(
+                  oauthCompletionStorageKey(pendingRequest.requestId),
+                );
+                return;
+              }
+            } catch {
+              // Fall through to poll path.
+            }
+          }
+
+          const connection = await fetchActiveGoogleConnection();
+          if (!pendingRequestRef.current) return;
+
+          if (connection) {
+            handleOAuthSuccess();
+          } else {
+            cancelConnect();
+          }
+        }, 1000);
+      }
+    }, 100);
+
+    startOAuth.mutate(
+      {
+        path: { assistant_id: assistantId, provider: GOOGLE_PROVIDER_KEY },
+        body: {
+          requested_scopes: [],
+          redirect_after_connect: `${routes.account.oauth.popupComplete}?requestId=${requestId}`,
+        },
+      },
+      {
+        onSuccess(data) {
+          if (popupRef.current && !popupRef.current.closed) {
+            popupRef.current.location.href = data.connect_url;
+          } else if (pendingRequestRef.current) {
+            cancelConnect();
+          }
+        },
+        onError() {
+          cancelConnect();
+        },
+      },
+    );
+  }, [
+    assistantId,
+    cancelConnect,
+    fetchActiveGoogleConnection,
+    handleOAuthCompletePayload,
+    handleOAuthMessage,
+    handleOAuthStorage,
+    handleOAuthSuccess,
+    isNative,
+    removeEventListeners,
+    startOAuth,
+  ]);
+
+  const handleAccept = useCallback(() => {
+    if (accepting) return;
+    // Keep both buttons disabled for the whole connect→run window.
+    setAccepting(true);
+    void (async () => {
+      const connection = await fetchActiveGoogleConnection();
+      if (connection) {
+        runInboxCleanup();
+        return;
+      }
+      startGoogleConnect();
+    })();
+  }, [accepting, fetchActiveGoogleConnection, runInboxCleanup, startGoogleConnect]);
 
   return {
     showInboxOffer: phase === "visible",

--- a/apps/web/src/domains/chat/hooks/use-inbox-cleanup-offer.ts
+++ b/apps/web/src/domains/chat/hooks/use-inbox-cleanup-offer.ts
@@ -1,0 +1,131 @@
+/**
+ * Manages the lifecycle of the in-chat inbox-cleanup offer card.
+ *
+ * Phase transitions: `pending` → `visible` → `dismissed`.
+ * The card becomes visible when all conditions are met (activation flag on,
+ * did onboarding, the chosen first task is inbox-cleanup, greeting arrived,
+ * on the onboarding conversation). Once dismissed it never reappears.
+ *
+ * Spike version: accept assumes Google is already connected and just runs the
+ * inbox-cleanup skill (OAuth is layered in by a later PR).
+ */
+
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+
+import type { DisplayMessage } from "@/domains/chat/utils/reconcile";
+
+/**
+ * Stable id of the inbox-cleanup first task. Mirrors `INBOX_CLEANUP_TASK_ID`
+ * from `@/domains/onboarding/choose-first-task`; duplicated as a literal here
+ * because the chat domain may not import from the onboarding domain
+ * (`local/no-cross-domain-imports`). The page layer (active-chat-view) derives
+ * `firstTask` from the real onboarding constant before passing it in.
+ */
+const INBOX_CLEANUP_TASK_ID = "inbox-cleanup";
+
+/** Run message that matches the inbox-cleanup skill's activation hints. */
+const INBOX_CLEANUP_RUN_MESSAGE =
+  "Please clean up my inbox using the inbox-cleanup skill, then give me a concrete summary of how many emails you archived and by which pass.";
+
+interface UseInboxCleanupOfferOptions {
+  didOnboarding: boolean;
+  firstTask: string | null;
+  activationFlowEnabled: boolean;
+  messages: DisplayMessage[];
+  activeConversationId: string | null;
+  onboardingConversationId: string | null;
+  sendMessage: (content: string) => void;
+}
+
+interface UseInboxCleanupOfferReturn {
+  showInboxOffer: boolean;
+  handleAccept: () => void;
+  handleDecline: () => void;
+  accepting: boolean;
+}
+
+export function useInboxCleanupOffer({
+  didOnboarding,
+  firstTask,
+  activationFlowEnabled,
+  messages,
+  activeConversationId,
+  onboardingConversationId,
+  sendMessage,
+}: UseInboxCleanupOfferOptions): UseInboxCleanupOfferReturn {
+  const [phase, setPhase] = useState<"pending" | "visible" | "dismissed">(
+    "pending",
+  );
+  const [accepting, setAccepting] = useState(false);
+
+  // Latch ref: once an assistant message is seen, skip the .some() scan on
+  // subsequent renders. Only computed while phase === "pending".
+  const greetingSeenRef = useRef(false);
+  const greetingConversationIdRef = useRef<string | null>(null);
+
+  // Reset the greeting latch when the conversation changes so an assistant
+  // message in one thread can't satisfy the latch for a different thread.
+  // Sync refs in the commit phase per React 19's useRef caveats.
+  useLayoutEffect(() => {
+    if (greetingConversationIdRef.current !== activeConversationId) {
+      greetingConversationIdRef.current = activeConversationId;
+      greetingSeenRef.current = false;
+    }
+    if (!greetingSeenRef.current && phase === "pending") {
+      greetingSeenRef.current = messages.some((m) => m.role === "assistant");
+    }
+  });
+
+  // Track the conversation id when the card became visible so we can
+  // dismiss on conversation switch without racing the didOnboarding flag.
+  const visibleConversationIdRef = useRef<string | null>(null);
+
+  // Transition from pending -> visible when all conditions are met.
+  useEffect(() => {
+    if (
+      phase === "pending" &&
+      activationFlowEnabled &&
+      didOnboarding &&
+      firstTask === INBOX_CLEANUP_TASK_ID &&
+      greetingSeenRef.current &&
+      activeConversationId === onboardingConversationId
+    ) {
+      visibleConversationIdRef.current = activeConversationId;
+      setPhase("visible");
+    }
+    // `messages` is not read in the body; listed so this effect re-fires
+    // when a new message arrives and greetingSeenRef may have just latched.
+  }, [phase, activationFlowEnabled, didOnboarding, firstTask, messages, activeConversationId, onboardingConversationId]);
+
+  // Dismiss if the user switches to a different conversation.
+  useEffect(() => {
+    if (
+      phase === "visible" &&
+      visibleConversationIdRef.current !== null &&
+      activeConversationId !== visibleConversationIdRef.current
+    ) {
+      setPhase("dismissed");
+    }
+  }, [phase, activeConversationId]);
+
+  const dismiss = useCallback(() => {
+    setPhase("dismissed");
+  }, []);
+
+  const handleDecline = useCallback(() => {
+    dismiss();
+  }, [dismiss]);
+
+  const handleAccept = useCallback(() => {
+    setAccepting(true);
+    dismiss();
+    sendMessage(INBOX_CLEANUP_RUN_MESSAGE);
+  }, [dismiss, sendMessage]);
+
+  return {
+    showInboxOffer: phase === "visible",
+    handleAccept,
+    handleDecline,
+    accepting,
+  };
+}

--- a/apps/web/src/domains/chat/hooks/use-onboarding-orchestrator.ts
+++ b/apps/web/src/domains/chat/hooks/use-onboarding-orchestrator.ts
@@ -33,6 +33,9 @@ export interface UseOnboardingOrchestratorResult {
   didOnboarding: boolean;
   /** Whether the user skipped task selection during prechat. */
   onboardingTasksEmpty: boolean;
+  /** The activation-flow first task chosen during prechat (e.g. "inbox-cleanup"),
+   *  captured at mount before the pending context is consumed on first send. */
+  firstTask: string | null;
   /** The draft conversation created for the onboarding flow. */
   onboardingConversationId: string | null;
   /** Shared with `useSendMessage` — pre-chat context for the first send. */
@@ -49,6 +52,7 @@ export function useOnboardingOrchestrator(): UseOnboardingOrchestratorResult {
   const onboardingDraftConversationIdRef = useRef<string | null>(null);
   const [didOnboarding, setDidOnboarding] = useState(false);
   const [onboardingTasksEmpty, setOnboardingTasksEmpty] = useState(false);
+  const [firstTask, setFirstTask] = useState<string | null>(null);
   const [onboardingConversationId, setOnboardingConversationId] = useState<string | null>(null);
 
   // Consume the `?onboarding=1` signal left by `/onboarding/hatching` when
@@ -75,9 +79,12 @@ export function useOnboardingOrchestrator(): UseOnboardingOrchestratorResult {
     try {
       const raw = globalThis.sessionStorage?.getItem("onboarding.prechat.pendingContext");
       if (!raw) return;
-      const ctx = JSON.parse(raw) as { tasks?: string[] };
+      const ctx = JSON.parse(raw) as { tasks?: string[]; firstTask?: string };
       if (Array.isArray(ctx.tasks) && ctx.tasks.length === 0) {
         setOnboardingTasksEmpty(true);
+      }
+      if (typeof ctx.firstTask === "string") {
+        setFirstTask(ctx.firstTask);
       }
     } catch {
       // Storage or parse failure — ignore.
@@ -87,6 +94,7 @@ export function useOnboardingOrchestrator(): UseOnboardingOrchestratorResult {
   return {
     didOnboarding,
     onboardingTasksEmpty,
+    firstTask,
     onboardingConversationId,
     pendingOnboardingContextRef,
     onboardingDraftConversationIdRef,

--- a/apps/web/src/domains/chat/transcript/build-items.ts
+++ b/apps/web/src/domains/chat/transcript/build-items.ts
@@ -31,6 +31,7 @@ export interface BuildTranscriptItemsInput {
   autoRoutedProfileLabel?: string | null;
   errorNotice: string | null;
   showOnboardingChoice?: boolean;
+  showInboxOffer?: boolean;
 }
 
 /**
@@ -148,6 +149,13 @@ export function buildTranscriptItems(
     items.push({
       kind: "onboardingChoice",
       key: "onboarding-choice",
+    });
+  }
+
+  if (input.showInboxOffer) {
+    items.push({
+      kind: "inboxOffer",
+      key: "inbox-offer",
     });
   }
 

--- a/apps/web/src/domains/chat/transcript/transcript-row.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-row.tsx
@@ -44,6 +44,8 @@ export interface TranscriptRowProps {
   renderPendingContactRequest?: (requestId: string) => ReactNode;
   /** Render-prop override for `kind: "onboardingChoice"`. */
   renderOnboardingChoice?: () => ReactNode;
+  /** Render-prop override for `kind: "inboxOffer"`. */
+  renderInboxOffer?: () => ReactNode;
   onOpenRuleEditor?: (context: {
     toolName: string;
     riskLevel?: string;
@@ -94,6 +96,7 @@ export const TranscriptRow = memo(function TranscriptRow({
   renderPendingConfirmation,
   renderPendingContactRequest,
   renderOnboardingChoice,
+  renderInboxOffer,
   onOpenRuleEditor,
   unknownNudgeToolCallIds,
   onDismissUnknownNudge,
@@ -233,6 +236,12 @@ export const TranscriptRow = memo(function TranscriptRow({
     case "onboardingChoice":
       if (renderOnboardingChoice) {
         return <>{renderOnboardingChoice()}</>;
+      }
+      return null;
+
+    case "inboxOffer":
+      if (renderInboxOffer) {
+        return <>{renderInboxOffer()}</>;
       }
       return null;
 

--- a/apps/web/src/domains/chat/transcript/transcript.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript.tsx
@@ -65,6 +65,8 @@ export interface TranscriptProps {
   renderPendingContactRequest?: (requestId: string) => ReactNode;
   /** Optional renderer for `kind: "onboardingChoice"` items. */
   renderOnboardingChoice?: () => ReactNode;
+  /** Optional renderer for `kind: "inboxOffer"` items. */
+  renderInboxOffer?: () => ReactNode;
   /** Click handler on a tool-call risk badge — opens the rule editor. The
    *  ToolCallChip forwards the active tool-call's metadata so the modal can
    *  pre-fill its fields. */
@@ -236,6 +238,7 @@ export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(
       renderPendingConfirmation: rest.renderPendingConfirmation,
       renderPendingContactRequest: rest.renderPendingContactRequest,
       renderOnboardingChoice: rest.renderOnboardingChoice,
+      renderInboxOffer: rest.renderInboxOffer,
       assistantDisplayName: rest.assistantDisplayName,
       onOpenRuleEditor: rest.onOpenRuleEditor,
       unknownNudgeToolCallIds: rest.unknownNudgeToolCallIds,

--- a/apps/web/src/domains/chat/transcript/types.ts
+++ b/apps/web/src/domains/chat/transcript/types.ts
@@ -15,7 +15,8 @@ export type TranscriptItemKind =
   | "pendingContactRequest"
   | "surface"
   | "error"
-  | "onboardingChoice";
+  | "onboardingChoice"
+  | "inboxOffer";
 
 export interface TranscriptItemBase {
   key: string;
@@ -74,6 +75,10 @@ export interface OnboardingChoiceItem extends TranscriptItemBase {
   kind: "onboardingChoice";
 }
 
+export interface InboxOfferItem extends TranscriptItemBase {
+  kind: "inboxOffer";
+}
+
 export type TranscriptItem =
   | MessageItem
   | ThinkingItem
@@ -83,7 +88,8 @@ export type TranscriptItem =
   | PendingContactRequestItem
   | SurfaceItem
   | ErrorItem
-  | OnboardingChoiceItem;
+  | OnboardingChoiceItem
+  | InboxOfferItem;
 
 /** Result of splitting the transcript into stable history and the
  *  currently-in-progress turn. `anchorMessage` is the most recent user

--- a/apps/web/src/domains/onboarding/choose-first-task.test.ts
+++ b/apps/web/src/domains/onboarding/choose-first-task.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  chooseFirstTask,
+  INBOX_CLEANUP_TASK_ID,
+} from "@/domains/onboarding/choose-first-task";
+import type { PreChatOnboardingContext } from "@/domains/onboarding/prechat";
+
+function baseContext(
+  overrides: Partial<PreChatOnboardingContext> = {},
+): PreChatOnboardingContext {
+  return {
+    tools: [],
+    tasks: [],
+    tone: "balanced",
+    ...overrides,
+  };
+}
+
+describe("chooseFirstTask", () => {
+  test("returns the inbox-cleanup constant for an empty context", () => {
+    expect(chooseFirstTask(baseContext())).toBe(INBOX_CLEANUP_TASK_ID);
+    expect(INBOX_CLEANUP_TASK_ID).toBe("inbox-cleanup");
+  });
+
+  test("returns the inbox-cleanup constant for a populated context", () => {
+    const context = baseContext({
+      tools: ["slack", "linear"],
+      tasks: ["code-building", "writing"],
+      cohort: "content-automation",
+      googleConnected: true,
+    });
+    expect(chooseFirstTask(context)).toBe("inbox-cleanup");
+  });
+});

--- a/apps/web/src/domains/onboarding/choose-first-task.ts
+++ b/apps/web/src/domains/onboarding/choose-first-task.ts
@@ -1,0 +1,18 @@
+import type { PreChatOnboardingContext } from "@/domains/onboarding/prechat";
+
+/** Stable id of the inbox-cleanup first task. Matches skills/inbox-cleanup. */
+export const INBOX_CLEANUP_TASK_ID = "inbox-cleanup" as const;
+
+/**
+ * The activation decision-engine seam.
+ *
+ * v1 (this spike): ignores context and always returns the inbox-cleanup
+ * constant. In vN this consults real context (selected tasks/tools,
+ * connected providers, cohort) and selects. Same rail, this one node
+ * changes — intentionally NOT throwaway.
+ */
+export function chooseFirstTask(
+  _context: PreChatOnboardingContext,
+): string {
+  return INBOX_CLEANUP_TASK_ID;
+}

--- a/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
+++ b/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
@@ -11,6 +11,7 @@ import { useNavigate, useSearchParams } from "react-router";
 import { useIsIOSWeb } from "@/runtime/platform-detection";
 import { readIOSAppDownloaded } from "@/hooks/use-ios-app-nudge";
 import { fetchOnboardingRecipe } from "@/domains/onboarding/recipe-client.js";
+import { chooseFirstTask } from "@/domains/onboarding/choose-first-task.js";
 import {
   emitOnboardingFunnelStepCompleted,
   onboardingFunnelVariantFromCondensedFlag,
@@ -102,6 +103,8 @@ export function PreChatFlow() {
     useClientFeatureFlagStore.use.prechatOnboardingCondensedFlow();
   const selfIntroGreetingEnabled =
     useClientFeatureFlagStore.use.selfIntroGreeting();
+  const activationFlowEnabled =
+    useClientFeatureFlagStore.use.experimentActivationFlow20260603();
   const preferredFunnelVariant =
     onboardingFunnelVariantFromCondensedFlag(condensedPrechatFlag);
   const webFunnelVariant =
@@ -328,6 +331,10 @@ export function PreChatFlow() {
       googleScopes,
       connectedScopes: args?.connectedScopes,
     });
+
+    if (activationFlowEnabled) {
+      context.firstTask = chooseFirstTask(context);
+    }
 
     setPendingPreChatContext(context);
     const trimmedAssistant = assistantName.trim();

--- a/apps/web/src/domains/onboarding/prechat.test.ts
+++ b/apps/web/src/domains/onboarding/prechat.test.ts
@@ -1,8 +1,12 @@
-import { describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 
 import {
   buildPreChatInitialMessage,
+  consumePendingPreChatContext,
   DEFAULT_PRECHAT_INITIAL_MESSAGE,
+  peekPendingPreChatContext,
+  type PreChatOnboardingContext,
+  setPendingPreChatContext,
 } from "@/domains/onboarding/prechat";
 
 describe("buildPreChatInitialMessage", () => {
@@ -34,5 +38,47 @@ describe("buildPreChatInitialMessage", () => {
     expect(
       buildPreChatInitialMessage({ assistantName: "  ", userName: "  " }),
     ).toBe(DEFAULT_PRECHAT_INITIAL_MESSAGE);
+  });
+});
+
+describe("firstTask handoff through sessionStorage", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  function contextWithFirstTask(): PreChatOnboardingContext {
+    return {
+      tools: ["gmail"],
+      tasks: ["inbox"],
+      tone: "grounded",
+      firstTask: "inbox-cleanup",
+    };
+  }
+
+  test("survives a set -> peek round-trip without consuming it", () => {
+    setPendingPreChatContext(contextWithFirstTask());
+
+    const peeked = peekPendingPreChatContext();
+    expect(peeked?.firstTask).toBe("inbox-cleanup");
+
+    // Peek is non-destructive: a second peek still sees the value.
+    expect(peekPendingPreChatContext()?.firstTask).toBe("inbox-cleanup");
+  });
+
+  test("survives a set -> consume read", () => {
+    setPendingPreChatContext(contextWithFirstTask());
+
+    const consumed = consumePendingPreChatContext();
+    expect(consumed?.firstTask).toBe("inbox-cleanup");
+
+    // Consume is destructive: the value is gone afterwards.
+    expect(consumePendingPreChatContext()).toBeNull();
+  });
+
+  test("absence of firstTask round-trips as undefined", () => {
+    const { firstTask: _omit, ...withoutFirstTask } = contextWithFirstTask();
+    setPendingPreChatContext(withoutFirstTask);
+
+    expect(consumePendingPreChatContext()?.firstTask).toBeUndefined();
   });
 });

--- a/apps/web/src/domains/onboarding/prechat.ts
+++ b/apps/web/src/domains/onboarding/prechat.ts
@@ -54,6 +54,13 @@ export interface PreChatOnboardingContext {
   bootstrapTemplate?: string;
   /** Skills to eagerly load. */
   skills?: string[];
+  /**
+   * Chosen first task id for the post-pre-chat activation hook (e.g.
+   * "inbox-cleanup"). Set by chooseFirstTask() in finish() when the
+   * activation-flow experiment flag is on. Absent for users not in the
+   * experiment. Consumed by the in-chat inbox-cleanup offer card.
+   */
+  firstTask?: string;
 }
 
 export const DEFAULT_PRECHAT_INITIAL_MESSAGE = "Wake up, my friend!";
@@ -260,6 +267,9 @@ function isPreChatOnboardingContext(
   if (candidate.skills !== undefined) {
     if (!Array.isArray(candidate.skills)) return false;
     if (!candidate.skills.every((s) => typeof s === "string")) return false;
+  }
+  if (candidate.firstTask !== undefined && typeof candidate.firstTask !== "string") {
+    return false;
   }
   return true;
 }

--- a/apps/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/apps/web/src/lib/feature-flags/feature-flag-registry.json
@@ -456,6 +456,14 @@
       "label": "Self-intro first message",
       "description": "On the first conversation, send a natural self-introduction (e.g. \"Hi Vela, I'm alex. Nice to meet you.\") on the user's behalf and route it through real LLM inference, instead of serving the canned first greeting. Names come from the onboarding context; falls back to the canned greeting when no name is known. Exposed to clients so pre-hatch onboarding can compute the source-of-truth initial message, and to the assistant so older clients can still be gated server-side. See assistant/src/daemon/first-greeting.ts (buildSelfIntroMessage).",
       "defaultEnabled": false
+    },
+    {
+      "id": "experiment-activation-flow-2026-06-03",
+      "scope": "client",
+      "key": "experiment-activation-flow-2026-06-03",
+      "label": "Experiment: Activation Flow (2026-06-03)",
+      "description": "Day-1 activation spike: post-pre-chat hook offers a hardcoded inbox-cleanup first task to new users. Allowlist / 1% cohort.",
+      "defaultEnabled": false
     }
   ]
 }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -456,6 +456,14 @@
       "label": "Self-intro first message",
       "description": "On the first conversation, send a natural self-introduction (e.g. \"Hi Vela, I'm alex. Nice to meet you.\") on the user's behalf and route it through real LLM inference, instead of serving the canned first greeting. Names come from the onboarding context; falls back to the canned greeting when no name is known. Exposed to clients so pre-hatch onboarding can compute the source-of-truth initial message, and to the assistant so older clients can still be gated server-side. See assistant/src/daemon/first-greeting.ts (buildSelfIntroMessage).",
       "defaultEnabled": false
+    },
+    {
+      "id": "experiment-activation-flow-2026-06-03",
+      "scope": "client",
+      "key": "experiment-activation-flow-2026-06-03",
+      "label": "Experiment: Activation Flow (2026-06-03)",
+      "description": "Day-1 activation spike: post-pre-chat hook offers a hardcoded inbox-cleanup first task to new users. Allowlist / 1% cohort.",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
Day-1 spike (JARVIS-1090): the full activation rail for one real new user, behind the off-by-default LaunchDarkly flag `experiment-activation-flow-2026-06-03`.

Flow: pre-chat → post-pre-chat hook `chooseFirstTask(context)` (returns the hardcoded constant `inbox-cleanup` — the one intentional decision-engine seam) → in-chat "Want me to clean your inbox?" offer card → Google OAuth on accept (reuses the existing integration) → `inbox-cleanup` skill runs → the assistant's natural summary is the outcome.

## Self-review
Skipped (fast-spike mode) — flag is off by default; this is presented for manual review.

## PRs merged into this feature branch
- #33261: feat(flags): add experiment-activation-flow-2026-06-03 client flag
- #33264: feat(web): add firstTask field to PreChatOnboardingContext
- #33263: feat(web): add chooseFirstTask activation decision seam
- #33262: feat(web): add InboxCleanupOfferCard component
- #33265: feat(web): fire post-pre-chat hook to choose first task
- #33269: feat(web): render inbox-cleanup offer card in first chat
- #33272: feat(web): gate inbox-cleanup offer accept on Google OAuth

## Companion PR (separate repo)
- vellum-ai/vellum-assistant-platform#8123 — registers the LaunchDarkly flag in Terraform (NOT merged; a human owns the Terraform apply).

## Before the demo
Create + target `experiment-activation-flow-2026-06-03` in the LaunchDarkly dashboard (allowlist the demo user or a 1% cohort). The repo flag stays off by default.

Part of plan: inbox-cleanup-activation-spike.md