### PR TITLE
feat(memory-v3): situational routing context (date + NOW.md) for L1/L2

### DIFF
--- a/assistant/src/memory/v3/__tests__/router.test.ts
+++ b/assistant/src/memory/v3/__tests__/router.test.ts
@@ -225,6 +225,34 @@ describe("routeL1 — request shape", () => {
     expect(blockB.cache_control).toBeUndefined();
   });
 
+  test("situational context renders in the per-turn block when present", async () => {
+    providerStub = makeProvider(toolUseResponse({ ids: [1] }));
+    await routeL1(
+      {
+        ...makeTurn("x"),
+        situationalContext: "Today is Saturday. Alice's anniversary is today.",
+      },
+      makeTree(),
+    );
+    const blockB = providerCalls[0].messages[0].content[1] as { text: string };
+    expect(blockB.text).toContain(
+      "<situation>Today is Saturday. Alice's anniversary is today.</situation>",
+    );
+  });
+
+  test("situational context is omitted when the turn has none", async () => {
+    providerStub = makeProvider(toolUseResponse({ ids: [1] }));
+    await routeL1(makeTurn("x"), makeTree());
+    const blockB = providerCalls[0].messages[0].content[1] as { text: string };
+    expect(blockB.text).not.toContain("<situation>");
+  });
+
+  test("system prompt mentions situation (locks the routing commitment)", async () => {
+    providerStub = makeProvider(toolUseResponse({ ids: [1] }));
+    await routeL1(makeTurn("x"), makeTree());
+    expect(providerCalls[0].options?.systemPrompt).toMatch(/[Ss]ituation/);
+  });
+
   test("system prompt mentions register (locks the routing commitment)", async () => {
     providerStub = makeProvider(toolUseResponse({ ids: [1] }));
     await routeL1(makeTurn("x"), makeTree());

--- a/assistant/src/memory/v3/__tests__/selector.test.ts
+++ b/assistant/src/memory/v3/__tests__/selector.test.ts
@@ -312,6 +312,23 @@ describe("selectFromLeaf — request shape", () => {
     expect(blockB.cache_control).toBeUndefined();
   });
 
+  test("situational context renders in the per-turn block when present", async () => {
+    providerStub = makeProvider(toolUseResponse({ ids: [1] }));
+    await selectFromLeaf(
+      "people/alice",
+      {
+        ...makeTurn("alice?"),
+        situationalContext: "Today is Saturday. Alice's anniversary is today.",
+      },
+      makeTree(),
+      summaryOf,
+    );
+    const blockB = providerCalls[0].messages[0].content[1] as { text: string };
+    expect(blockB.text).toContain(
+      "<situation>Today is Saturday. Alice's anniversary is today.</situation>",
+    );
+  });
+
   test("system prompt mentions pinned (locks the pinning commitment)", async () => {
     providerStub = makeProvider(toolUseResponse({ ids: [1] }));
     await selectFromLeaf("people/alice", makeTurn("x"), makeTree(), summaryOf);

--- a/assistant/src/memory/v3/router.ts
+++ b/assistant/src/memory/v3/router.ts
@@ -65,11 +65,12 @@ const OPEN_LEAVES_TOOL: ToolDefinition = {
 
 const SYSTEM_PROMPT = `You route a conversation turn to the leaves of a topic tree that should be opened for the next reply.
 
-Each leaf has a numbered ID, a path, and a description of what it holds. Decide which leaves to open by weighing three signals:
+Each leaf has a numbered ID, a path, and a description of what it holds. Decide which leaves to open by weighing four signals:
 
 - Topic — entities, projects, and events named or implied by the turn.
 - Register — the affect and mode of the message (e.g. playful, distressed, formal). A register signal is enough to open a leaf even when no entity is named.
 - Recent context — the immediately preceding exchange, which resolves references like "this", "that", or "the same thing" to concrete topics.
+- Situation — the current date and a live scratchpad of what is salient right now. A date or state cue can make a leaf relevant even when the message never names it (e.g. a person whose anniversary is today, an active thread).
 
 Include on doubt: open every leaf that could plausibly hold something useful. Missing a relevant leaf is a worse error than opening an unused one. Call \`open_leaves\` with the chosen IDs. Omit \`ids\` to open every leaf; return \`[]\` only when nothing in the tree could possibly help.`;
 
@@ -129,6 +130,9 @@ export async function routeL1(
       {
         type: "text",
         text:
+          (turn.situationalContext
+            ? `<situation>${turn.situationalContext}</situation>\n`
+            : "") +
           `<recent_context>${turn.recentContext}</recent_context>\n` +
           `<current_message>${turn.currentMessage}</current_message>`,
       },

--- a/assistant/src/memory/v3/selector.ts
+++ b/assistant/src/memory/v3/selector.ts
@@ -81,6 +81,8 @@ const SYSTEM_PROMPT = `This leaf of the topic tree is potentially relevant to th
 
 Be selective: exclude pages that are merely topically adjacent, part of the ever-present background, or only loosely related. Most opened leaves should contribute a few precisely-relevant pages, not most of their contents — a leaf opened on a weak signal may yield none.
 
+A page can also be directly relevant because of the current situation — the date or the live scratchpad — not only the message: keep a page the situation makes pertinent (e.g. a person whose anniversary is today).
+
 If the conversation is centrally ABOUT a page (rather than only peripherally relevant to it), mark that page as pinned. Call \`select_pages\` with the chosen IDs. Omit \`ids\` only as a recall-safe fallback when you cannot judge the leaf (selects every page); return \`[]\` when the pages are present but none are directly relevant.`;
 
 /**
@@ -136,6 +138,9 @@ export async function selectFromLeaf(
       {
         type: "text",
         text:
+          (turn.situationalContext
+            ? `<situation>${turn.situationalContext}</situation>\n`
+            : "") +
           `<recent_context>${turn.recentContext}</recent_context>\n` +
           `<current_message>${turn.currentMessage}</current_message>`,
       },

--- a/assistant/src/memory/v3/shadow-plugin.ts
+++ b/assistant/src/memory/v3/shadow-plugin.ts
@@ -29,6 +29,8 @@
  * empty selection) falls back to v2 memory rather than dropping all memory.
  */
 
+import { existsSync, readFileSync } from "node:fs";
+
 import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import { getConfig } from "../../config/loader.js";
 import type { AssistantConfig } from "../../config/schema.js";
@@ -42,7 +44,11 @@ import {
   type TurnContext as PluginTurnContext,
 } from "../../plugins/types.js";
 import { getLogger } from "../../util/logger.js";
-import { getWorkspaceDir } from "../../util/platform.js";
+import {
+  getWorkspaceDir,
+  getWorkspacePromptPath,
+} from "../../util/platform.js";
+import { stripCommentLines } from "../../util/strip-comment-lines.js";
 import { getPageIndex } from "../v2/page-index.js";
 import { injectCapabilitiesLeaf, isCapabilitySlug } from "./capabilities.js";
 import { loadCore } from "./core.js";
@@ -166,9 +172,42 @@ function getLanes(config: AssistantConfig): Promise<ShadowLanes> {
 }
 
 /**
+ * Read the live NOW.md scratchpad (the user's short "what's salient right now"
+ * file), stripped of its comment lines. Mirrors `readNowScratchpad` in the
+ * conversation-runtime assembly but reads through the light platform / strip
+ * utilities directly, so the v3 plugin does not pull the heavy conversation
+ * assembly module into its load (and its test). Returns `null` when absent,
+ * empty, or unreadable.
+ */
+function readNowContext(): string | null {
+  const nowPath = getWorkspacePromptPath("NOW.md");
+  if (!existsSync(nowPath)) return null;
+  try {
+    const stripped = stripCommentLines(readFileSync(nowPath, "utf-8")).trim();
+    return stripped.length > 0 ? stripped : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Compose the situational signal threaded into L1 routing and L2 selection: the
+ * current date plus the live NOW.md scratchpad. The date alone is a weak signal,
+ * but together with the scratchpad it lets retrieval surface a leaf the message
+ * never names (e.g. an anniversary that falls today). Always returns at least
+ * the date line — this mirrors the `c_now`/NOW.md signal the v2 retriever uses.
+ */
+function buildSituationalContext(): string {
+  const now = readNowContext();
+  const today = `Today is ${new Date().toDateString()}.`;
+  return now ? `${today}\n\n${now}` : today;
+}
+
+/**
  * Build a v3 {@link TurnContext} from the conversation's persisted messages.
  * `currentMessage` is the latest user message; `recentContext` is the tail of
- * the recent transcript. Returns `null` when there is no user message to route
+ * the recent transcript; `situationalContext` carries the current date and the
+ * live NOW.md scratchpad. Returns `null` when there is no user message to route
  * on (nothing to shadow this turn).
  */
 function buildShadowTurn(
@@ -198,6 +237,7 @@ function buildShadowTurn(
     turnNumber: turnIndex,
     currentMessage,
     recentContext,
+    situationalContext: buildSituationalContext(),
   };
 }
 

--- a/assistant/src/memory/v3/types.ts
+++ b/assistant/src/memory/v3/types.ts
@@ -46,6 +46,14 @@ export interface TurnContext {
   turnNumber: number;
   currentMessage: string;
   recentContext: string;
+  /**
+   * Optional situational signal — the current date plus the live NOW.md
+   * scratchpad — so a leaf or page can be routed/selected on a date or
+   * live-state cue the message itself never names (e.g. a person whose
+   * anniversary is today). Omitted when unavailable; the router and selector
+   * render nothing for an undefined value.
+   */
+  situationalContext?: string;
 }
 
 export type SelectionSource = "l1+l2" | "core+l2" | "needle" | "carry-forward";


### PR DESCRIPTION
## Summary
- Thread an optional `situationalContext` (current date + the live NOW.md scratchpad) into the v3 L1 router and L2 selector, rendered in the per-turn block **after** the cached prefix (no prompt-cache impact).
- Populate it in the shadow plugin's `buildShadowTurn` via a light `readNowContext()` that reuses `getWorkspacePromptPath` + `stripCommentLines` directly, so the v3 plugin doesn't drag the heavy conversation-assembly module into its load/test.
- Router/selector prompts gain a `Situation` signal so a leaf/page can be routed or kept on a date or live-state cue the message never names.

## Why
v2's retriever scores candidates partly on NOW.md similarity (`c_now · sim(NOW.md, page)`) and folds NOW.md into its router prompt, so it surfaces situationally-relevant pages even when the message doesn't name them. v3's router/selector only saw `recentContext` + the current message, leaving situational needs (e.g. an anniversary that falls today, derivable only from the date + scratchpad) structurally unreachable — an L1 routing miss that L2 tightening and carry-forward can't fix. This gives v3 the same signal.

Shadow-only (gated behind `memory-v3-shadow`/`memory-v3-live`, live default-off) — no live-v2 impact. The signal can't be measured on the historical offline eval (NOW.md is overwritten, no as-of-T history), so it's validated shadow-forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)