### PR TITLE
fix(config): migrate persisted heartbeat interval from 30m to 60m

### DIFF
--- a/assistant/src/workspace/migrations/095-bump-heartbeat-interval-30m-to-60m.ts
+++ b/assistant/src/workspace/migrations/095-bump-heartbeat-interval-30m-to-60m.ts
@@ -1,0 +1,51 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+const THIRTY_MINUTES_MS = 30 * 60 * 1000;
+const SIXTY_MINUTES_MS = 60 * 60 * 1000;
+
+/**
+ * Bump persisted heartbeat default from 30 minutes to 60 minutes.
+ *
+ * Migration 065 moved legacy 3h/6h defaults to 30 minutes. The schema default
+ * has since been raised to 60 minutes, but existing users whose config.json
+ * already has 1800000 persisted won't pick up the new default. This migration
+ * idempotently updates those configs.
+ */
+export const bumpHeartbeatInterval30mTo60mMigration: WorkspaceMigration = {
+  id: "095-bump-heartbeat-interval-30m-to-60m",
+  description:
+    "Bump persisted heartbeat.intervalMs from 30 minutes to 60 minutes",
+  run(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) return;
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      config = raw as Record<string, unknown>;
+    } catch {
+      return;
+    }
+
+    const heartbeat = config.heartbeat;
+    if (!heartbeat || typeof heartbeat !== "object" || Array.isArray(heartbeat))
+      return;
+
+    const heartbeatConfig = heartbeat as Record<string, unknown>;
+    const intervalMs = heartbeatConfig.intervalMs;
+    if (typeof intervalMs !== "number" || intervalMs !== THIRTY_MINUTES_MS) {
+      return;
+    }
+
+    heartbeatConfig.intervalMs = SIXTY_MINUTES_MS;
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
+  down(_workspaceDir: string): void {
+    // Forward-only: cannot distinguish users who explicitly chose 60 minutes
+    // from those migrated by this migration.
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -92,6 +92,7 @@ import { retightenMigrationOnboardingThreadMigration } from "./091-retighten-mig
 import { backfillV3LeavesMigration } from "./092-backfill-v3-leaves.js";
 import { backfillLeafIdsMigration } from "./093-backfill-leaf-ids.js";
 import { seedAvatarManifestMigration } from "./094-seed-avatar-manifest.js";
+import { bumpHeartbeatInterval30mTo60mMigration } from "./095-bump-heartbeat-interval-30m-to-60m.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -195,4 +196,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   backfillV3LeavesMigration,
   backfillLeafIdsMigration,
   seedAvatarManifestMigration,
+  bumpHeartbeatInterval30mTo60mMigration,
 ];


### PR DESCRIPTION
Codex review on #32601 noted that changing the schema default doesn't affect existing users with a persisted 30-minute value. Adds a workspace migration that idempotently updates the heartbeat interval from 1800000ms to 3600000ms.