### PR TITLE
fix(gmail): address review feedback on auto-filter generation

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -238,7 +238,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T17:39:03.000Z"
+      "updatedAt": "2026-06-03T17:40:47.000Z"
     },
     {
       "id": "google-calendar",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -18,7 +18,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "api-mapping",
@@ -33,7 +33,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "assistant-migration",
@@ -60,7 +60,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "chatgpt-import",
@@ -74,7 +74,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "cli-discover",
@@ -88,7 +88,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:01:09.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "conversation-launcher",
@@ -102,7 +102,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "deploy-fullstack-vercel",
@@ -116,7 +116,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "discord-app-setup",
@@ -131,7 +131,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "doordash",
@@ -146,7 +146,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "elevenlabs-voice",
@@ -161,7 +161,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "email-setup",
@@ -175,7 +175,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "fish-audio",
@@ -189,7 +189,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "frontend-design",
@@ -204,7 +204,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "geo-writing",
@@ -222,7 +222,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "gmail",
@@ -238,7 +238,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T17:39:03.000Z"
     },
     {
       "id": "google-calendar",
@@ -254,7 +254,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "guardian-verify-setup",
@@ -276,7 +276,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:01:09.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "headless-claude-code",
@@ -290,7 +290,7 @@
         }
       },
       "compatibility": "Any environment running Claude Code headlessly",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "inbox-cleanup",
@@ -314,7 +314,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "inbox-management",
@@ -343,7 +343,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "influencer",
@@ -360,7 +360,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "linear-app-setup",
@@ -376,7 +376,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "llm-cost-optimizer",
@@ -389,7 +389,7 @@
           "display-name": "LLM Cost Optimizer"
         }
       },
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "macos-automation",
@@ -410,7 +410,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "mailgun-setup",
@@ -426,7 +426,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "mcp-setup",
@@ -440,7 +440,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "meet-join",
@@ -455,7 +455,7 @@
           "feature-flag": "meet"
         }
       },
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "meme-generator",
@@ -481,7 +481,7 @@
         }
       },
       "compatibility": "Requires curl and python3. Works on macOS and Linux.",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "notifications",
@@ -495,7 +495,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:01:09.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "notion",
@@ -510,7 +510,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "oura",
@@ -527,7 +527,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:01:09.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "oura-setup",
@@ -541,7 +541,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "outlook",
@@ -557,7 +557,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "outlook-calendar",
@@ -573,7 +573,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "public-ingress",
@@ -594,7 +594,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "resend-setup",
@@ -609,7 +609,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "restaurant-reservation",
@@ -626,7 +626,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "screen-recording",
@@ -640,7 +640,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "self-upgrade",
@@ -654,7 +654,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "sentry-app-setup",
@@ -670,7 +670,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "slack",
@@ -685,7 +685,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "slack-app-setup",
@@ -702,7 +702,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "start-the-day",
@@ -717,7 +717,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "stripe-app-setup",
@@ -733,7 +733,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "stripe-link-wallet",
@@ -748,7 +748,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "tasks",
@@ -770,7 +770,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "telegram-setup",
@@ -792,7 +792,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "time-based-actions",
@@ -806,7 +806,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "twilio-setup",
@@ -824,7 +824,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "typescript-eval",
@@ -838,7 +838,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "vellum-avatar",
@@ -852,7 +852,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "vellum-browser-use",
@@ -869,7 +869,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "vellum-conversation-management",
@@ -883,7 +883,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "vellum-github-app-setup",
@@ -900,7 +900,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants. Requires Python 3, bun, and the assistant credentials CLI.",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "vellum-heartbeat",
@@ -920,7 +920,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "vellum-memory-v2-migration",
@@ -943,7 +943,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "vellum-oauth-integrations",
@@ -957,7 +957,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "vellum-self-knowledge",
@@ -980,7 +980,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "vellum-skills-catalog",
@@ -1005,7 +1005,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "vellum-sounds",
@@ -1019,7 +1019,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:05:10.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "vellum-terminal-sessions",
@@ -1046,7 +1046,7 @@
         }
       },
       "compatibility": "Sandbox mode works without any host dependencies. Host mode requires tmux installed on the user's machine. Works on macOS and Linux.",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "vercel-token-setup",
@@ -1064,7 +1064,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "voice-setup",
@@ -1089,7 +1089,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "watch-together",
@@ -1103,7 +1103,7 @@
           "emoji": "📺"
         }
       },
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "watcher",
@@ -1117,7 +1117,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
       "id": "weather",
@@ -1130,7 +1130,7 @@
           "category": "productivity"
         }
       },
-      "updatedAt": "2026-06-03T02:57:53.000Z"
+      "updatedAt": "2026-06-03T03:10:07.000Z"
     }
   ]
 }

--- a/skills/gmail/scripts/gmail-auto-filters.ts
+++ b/skills/gmail/scripts/gmail-auto-filters.ts
@@ -125,14 +125,25 @@ async function requestConfirmation(opts: {
  * Only extracts patterns that the SKILL.md explicitly marks as safe for
  * permanent auto-archiving. Patterns like generic phrases or name/company
  * subject patterns are intentionally excluded — they're too broad.
+ *
+ * Detection is primarily phase-based because the cleanup archive writer
+ * does not populate `from` or `subject` on staged entries — it only logs
+ * `phase`, `reason`, and `message_ids`. When `from` is available (e.g.
+ * enriched logs), it's used as a secondary signal for finer-grained filters.
  */
-function deriveFilterCandidates(entries: OpEntry[]): FilterCandidate[] {
+function deriveFilterCandidates(
+  entries: OpEntry[],
+  safelist: string[] = [],
+): FilterCandidate[] {
   const candidates: FilterCandidate[] = [];
 
-  const noReplySenders = new Set<string>();
+  let noReplyCount = 0;
   let calendarCount = 0;
-  const sketchyTldDomains = new Map<string, number>();
+  const sketchyTldCounts = new Map<string, number>();
+  let newsletterCount = 0;
   const newsletterSenders = new Map<string, number>();
+
+  const safelistLower = new Set(safelist.map((s) => s.toLowerCase()));
 
   for (const entry of entries) {
     if (entry.status !== "staged" || entry.op !== "archive") continue;
@@ -140,17 +151,18 @@ function deriveFilterCandidates(entries: OpEntry[]): FilterCandidate[] {
     const phase = entry.phase ?? "";
     const from = entry.from?.toLowerCase() ?? "";
 
-    // Track no-reply senders (Pass 4)
+    // Track no-reply senders (Pass 4) — phase is the primary signal since
+    // the cleanup archive writer doesn't populate `from`.
     if (
       phase.includes("no_reply") ||
       phase.includes("noreply") ||
-      /\bno[-_]?reply\b/i.test(from) ||
-      /\bdonotreply\b/i.test(from)
+      (from && /\bno[-_]?reply\b/i.test(from)) ||
+      (from && /\bdonotreply\b/i.test(from))
     ) {
-      noReplySenders.add(from);
+      noReplyCount++;
     }
 
-    // Track calendar noise (Pass 5)
+    // Track calendar noise (Pass 5) — phase-based; `subject` is rarely populated.
     if (
       phase.includes("calendar") ||
       /\b(accepted|declined|tentative):/i.test(entry.subject ?? "")
@@ -158,16 +170,29 @@ function deriveFilterCandidates(entries: OpEntry[]): FilterCandidate[] {
       calendarCount++;
     }
 
-    // Track sketchy TLDs (Pass 7)
+    // Track sketchy TLDs (Pass 7) — phase-based detection.
+    // When `from` is available, extract the domain for per-TLD filters.
+    // Otherwise, count by phase to still produce the aggregate filter.
     if (phase.includes("sketchy") || phase.includes("tld")) {
-      const domain = extractDomain(from);
+      const domain = from ? extractDomain(from) : undefined;
       if (domain && isSketchyTld(domain)) {
-        sketchyTldDomains.set(domain, (sketchyTldDomains.get(domain) ?? 0) + 1);
+        const tld = SKETCHY_TLDS_LIST.find((t) => domain.endsWith(t));
+        if (tld) {
+          sketchyTldCounts.set(tld, (sketchyTldCounts.get(tld) ?? 0) + 1);
+        }
+      } else {
+        // No domain info — count toward a generic sketchy-TLD bucket
+        sketchyTldCounts.set(
+          "_generic",
+          (sketchyTldCounts.get("_generic") ?? 0) + 1,
+        );
       }
     }
 
-    // Track newsletters (Pass 4)
+    // Track newsletters (Pass 4) — phase-based detection.
+    // When `from` is available, track per-sender for finer filters.
     if (phase.includes("newsletter") || phase.includes("digest")) {
+      newsletterCount++;
       if (from) {
         newsletterSenders.set(from, (newsletterSenders.get(from) ?? 0) + 1);
       }
@@ -177,12 +202,12 @@ function deriveFilterCandidates(entries: OpEntry[]): FilterCandidate[] {
   // --- Build candidates from collected patterns ---
 
   // 1. No-reply / do-not-reply senders
-  if (noReplySenders.size > 0) {
+  if (noReplyCount > 0) {
     candidates.push({
       category: "no-reply senders",
       labelName: "auto/no-reply",
       criteria: { from: "noreply OR no-reply OR donotreply" },
-      matchCount: noReplySenders.size,
+      matchCount: noReplyCount,
     });
   }
 
@@ -199,33 +224,53 @@ function deriveFilterCandidates(entries: OpEntry[]): FilterCandidate[] {
     });
   }
 
-  // 3. Sketchy TLD domains (one filter per TLD)
-  const sketchyTlds = [".shop", ".biz", ".xyz", ".info", ".club", ".online"];
-  for (const tld of sketchyTlds) {
-    const tldDomains = [...sketchyTldDomains.entries()].filter(([d]) =>
-      d.endsWith(tld),
-    );
-    const totalCount = tldDomains.reduce((sum, [, c]) => sum + c, 0);
-    if (totalCount > 0) {
+  // 3. Sketchy TLD domains (one filter per TLD when domain data is available)
+  const genericSketchyCount = sketchyTldCounts.get("_generic") ?? 0;
+  for (const tld of SKETCHY_TLDS_LIST) {
+    const count = sketchyTldCounts.get(tld) ?? 0;
+    if (count > 0) {
       candidates.push({
         category: `sketchy TLD (${tld})`,
         labelName: "auto/sketchy-tld",
         criteria: { from: `*${tld}` },
-        matchCount: totalCount,
+        matchCount: count,
+      });
+    }
+  }
+  // If we had phase-tagged sketchy entries but no domain info, produce
+  // per-TLD filters for all known sketchy TLDs as a catchall.
+  if (genericSketchyCount > 0 && candidates.every((c) => c.labelName !== "auto/sketchy-tld")) {
+    for (const tld of SKETCHY_TLDS_LIST) {
+      candidates.push({
+        category: `sketchy TLD (${tld})`,
+        labelName: "auto/sketchy-tld",
+        criteria: { from: `*${tld}` },
+        matchCount: genericSketchyCount,
       });
     }
   }
 
-  // 4. Confirmed newsletter senders (only those with 2+ emails during cleanup)
+  // 4. Newsletter senders — per-sender when `from` is available and not safelisted,
+  //    otherwise a generic Unsubscribe-header filter.
   const confirmedNewsletters = [...newsletterSenders.entries()].filter(
-    ([, count]) => count >= 2,
+    ([sender, count]) => count >= 2 && !safelistLower.has(sender),
   );
-  for (const [sender] of confirmedNewsletters) {
+  if (confirmedNewsletters.length > 0) {
+    for (const [sender] of confirmedNewsletters) {
+      candidates.push({
+        category: "newsletter",
+        labelName: "auto/newsletter",
+        criteria: { from: sender },
+        matchCount: newsletterSenders.get(sender) ?? 0,
+      });
+    }
+  } else if (newsletterCount > 0 && newsletterSenders.size === 0) {
+    // No per-sender data available — use a header-based heuristic
     candidates.push({
-      category: "newsletter",
+      category: "newsletter (header-based)",
       labelName: "auto/newsletter",
-      criteria: { from: sender },
-      matchCount: newsletterSenders.get(sender) ?? 0,
+      criteria: { query: "list:* OR unsubscribe" },
+      matchCount: newsletterCount,
     });
   }
 
@@ -242,14 +287,8 @@ function extractDomain(email: string): string | undefined {
   return email.slice(atIndex + 1).toLowerCase();
 }
 
-const SKETCHY_TLDS = new Set([
-  ".shop",
-  ".biz",
-  ".xyz",
-  ".info",
-  ".club",
-  ".online",
-]);
+const SKETCHY_TLDS_LIST = [".shop", ".biz", ".xyz", ".info", ".club", ".online"];
+const SKETCHY_TLDS = new Set(SKETCHY_TLDS_LIST);
 
 function isSketchyTld(domain: string): boolean {
   for (const tld of SKETCHY_TLDS) {
@@ -331,12 +370,26 @@ async function getOrCreateLabel(
 // Find latest completed cleanup run
 // ---------------------------------------------------------------------------
 
+/**
+ * Find the most recent completed cleanup run that contains archive ops.
+ *
+ * Skips filter-creation runs (produced by this script's `generate` command)
+ * so that auto-detection doesn't pick up its own output as input.
+ */
 function findLatestCleanupRun(): string | null {
   const runs = listRuns();
   for (const runId of runs) {
     const summary = summarizeRun(runId);
     if (!summary) continue;
-    if (summary.status === "completed" && summary.total_committed > 0) {
+    if (summary.status !== "completed" || summary.total_committed <= 0) continue;
+
+    // A cleanup run must contain at least one staged archive op.
+    // Filter-creation runs only contain filter_create ops, so they're skipped.
+    const entries = readLog(runId);
+    const hasArchiveOps = entries.some(
+      (e) => e.status === "staged" && e.op === "archive",
+    );
+    if (hasArchiveOps) {
       return runId;
     }
   }
@@ -367,8 +420,11 @@ async function handleGenerate(
     printError(`No op-log entries found for run ${sourceRunId}.`);
   }
 
-  // Derive safe filter candidates
-  const candidates = deriveFilterCandidates(entries);
+  // Load preferences for safelist cross-referencing
+  const prefs = loadPreferences();
+
+  // Derive safe filter candidates (safelist excludes user-protected senders)
+  const candidates = deriveFilterCandidates(entries, prefs.safelist);
   if (candidates.length === 0) {
     ok({
       message: "No safe filter candidates found in cleanup run.",

--- a/skills/gmail/scripts/gmail-auto-filters.ts
+++ b/skills/gmail/scripts/gmail-auto-filters.ts
@@ -239,7 +239,10 @@ function deriveFilterCandidates(
   }
   // If we had phase-tagged sketchy entries but no domain info, produce
   // per-TLD filters for all known sketchy TLDs as a catchall.
-  if (genericSketchyCount > 0 && candidates.every((c) => c.labelName !== "auto/sketchy-tld")) {
+  if (
+    genericSketchyCount > 0 &&
+    candidates.every((c) => c.labelName !== "auto/sketchy-tld")
+  ) {
     for (const tld of SKETCHY_TLDS_LIST) {
       candidates.push({
         category: `sketchy TLD (${tld})`,
@@ -287,7 +290,14 @@ function extractDomain(email: string): string | undefined {
   return email.slice(atIndex + 1).toLowerCase();
 }
 
-const SKETCHY_TLDS_LIST = [".shop", ".biz", ".xyz", ".info", ".club", ".online"];
+const SKETCHY_TLDS_LIST = [
+  ".shop",
+  ".biz",
+  ".xyz",
+  ".info",
+  ".club",
+  ".online",
+];
 const SKETCHY_TLDS = new Set(SKETCHY_TLDS_LIST);
 
 function isSketchyTld(domain: string): boolean {
@@ -381,7 +391,8 @@ function findLatestCleanupRun(): string | null {
   for (const runId of runs) {
     const summary = summarizeRun(runId);
     if (!summary) continue;
-    if (summary.status !== "completed" || summary.total_committed <= 0) continue;
+    if (summary.status !== "completed" || summary.total_committed <= 0)
+      continue;
 
     // A cleanup run must contain at least one staged archive op.
     // Filter-creation runs only contain filter_create ops, so they're skipped.


### PR DESCRIPTION
## Summary
- Fixes `findLatestCleanupRun` to verify runs contain archive ops before selecting them, preventing the script from picking its own filter-creation runs as input
- Updates `deriveFilterCandidates` to rely on phase-based detection since the cleanup archive writer doesn't populate `from`/`subject` fields
- Wires up the previously-unused `loadPreferences` import to cross-reference the safelist when generating newsletter filters
- Adds fallback heuristics for newsletter and sketchy-TLD categories when per-sender data is unavailable

Addresses review feedback from #29123.

## Test plan
- [ ] Verify `findLatestCleanupRun` skips filter-creation runs and selects the most recent cleanup run with archive ops
- [ ] Verify newsletter candidates are excluded when the sender is on the safelist
- [ ] Verify phase-based detection produces candidates even without `from`/`subject` fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)