### PR TITLE
feat(local-mode): accept optional `remote` parameter in `runHatch()`

### DIFF
--- a/packages/local-mode/src/hatch.ts
+++ b/packages/local-mode/src/hatch.ts
@@ -8,14 +8,24 @@ export type HatchResult =
   | { ok: true; assistantId: string }
   | { ok: false; status: number; error: string };
 
+export interface RunHatchOptions {
+  remote?: string;
+}
+
 export function runHatch(
   invocation: CliInvocation,
   species: string,
+  options?: RunHatchOptions,
 ): Promise<HatchResult> {
   return new Promise((resolve) => {
+    const args = [...invocation.baseArgs, "hatch", species];
+    if (options?.remote) {
+      args.push("--remote", options.remote);
+    }
+
     const child = spawn(
       invocation.command,
-      [...invocation.baseArgs, "hatch", species],
+      args,
       { stdio: ["ignore", "pipe", "pipe"] },
     );
 

--- a/packages/local-mode/src/index.ts
+++ b/packages/local-mode/src/index.ts
@@ -29,7 +29,7 @@ export type {
   LockfileWriteResult,
 } from "./lockfile-contract";
 export { runHatch } from "./hatch";
-export type { HatchResult } from "./hatch";
+export type { HatchResult, RunHatchOptions } from "./hatch";
 export { runRetire } from "./retire";
 export type { RetireResult } from "./retire";
 export { getGuardianAccessToken } from "./guardian-token";


### PR DESCRIPTION
## Summary
- Add optional `options` parameter to `runHatch()` with `remote` field
- When `remote` is provided, appends `--remote <value>` to CLI args
- Backward compatible: existing callers without the third arg are unaffected

Part of plan: container-runtime-gaps.md (PR 1 of 5)