### PR TITLE
fix(cli): stop Colima VM when retiring the last Docker instance

### DIFF
--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -14,6 +14,7 @@ import cliPkg from "../../package.json";
 
 import {
   findAssistantByName,
+  loadAllAssistants,
   saveAssistantEntry,
   setActiveAssistant,
 } from "./assistant-config";
@@ -475,6 +476,19 @@ export async function retireDocker(name: string): Promise<void> {
       await exec("docker", ["volume", "rm", vol]);
     } catch {
       // volume may not exist
+    }
+  }
+
+  // Stop Colima VM if no other Docker instances remain (macOS only).
+  const hasOtherDockerInstances = loadAllAssistants().some(
+    (a) => a.cloud === "docker" && a.assistantId !== name,
+  );
+  if (!hasOtherDockerInstances && platform() !== "linux") {
+    try {
+      await exec("colima", ["stop"]);
+      console.log("\ud83d\uded1 Colima VM stopped (no remaining Docker instances).");
+    } catch {
+      // Colima may not be running or not installed
     }
   }
 


### PR DESCRIPTION
## Summary
- After Docker retire removes containers/volumes/network, check for remaining Docker instances
- If no other Docker instances remain, stop the Colima VM to reclaim resources
- Skips Colima cleanup on Linux (uses native Docker daemon)
- Swallows errors if Colima is not installed or already stopped

Part of plan: container-runtime-gaps.md (PR 5 of 5)