### PR TITLE
feat(macos): thread `remote` parameter through Electron hatch IPC

### DIFF
--- a/apps/macos/src/main/local-mode.ts
+++ b/apps/macos/src/main/local-mode.ts
@@ -90,14 +90,14 @@ async function resolveCliInvocation(): Promise<CliInvocation> {
  * failures resolve with `{ ok: false, error }` so the renderer renders the
  * same error UI it shows for the web/dev middleware path.
  */
-async function hatch(species: string): Promise<HatchResult> {
+async function hatch(species: string, remote?: string): Promise<HatchResult> {
   let invocation: CliInvocation;
   try {
     invocation = await resolveCliInvocation();
   } catch (err) {
     return { ok: false, error: (err as Error).message };
   }
-  const result = await runHatch(invocation, species);
+  const result = await runHatch(invocation, species, { remote });
   return result.ok
     ? { ok: true, assistantId: result.assistantId }
     : { ok: false, error: result.error };
@@ -144,8 +144,12 @@ export const installLocalMode = (): void => {
   // falls back to the default rather than being rejected.
   handle(
     "vellum:localMode:hatch",
-    z.tuple([z.string().optional()]),
-    ([species]) => hatch(species && species.length > 0 ? species : DEFAULT_SPECIES),
+    z.tuple([z.string().optional(), z.string().optional()]),
+    ([species, remote]) =>
+      hatch(
+        species && species.length > 0 ? species : DEFAULT_SPECIES,
+        remote || undefined,
+      ),
   );
 
   handle("vellum:localMode:readLockfile", z.tuple([]), () => {

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -128,7 +128,7 @@ export interface VellumBridge {
      * (rather than rejecting) so the renderer renders the same error UI it
      * shows for the web/dev middleware path.
      */
-    hatch(species: string): Promise<{
+    hatch(species: string, remote?: string): Promise<{
       ok: boolean;
       assistantId?: string;
       error?: string;
@@ -266,8 +266,8 @@ const bridge: VellumBridge = {
       ipcRenderer.invoke("vellum:dock:setSignedIn", signedIn) as Promise<void>,
   },
   localMode: {
-    hatch: (species: string) =>
-      ipcRenderer.invoke("vellum:localMode:hatch", species) as Promise<{
+    hatch: (species: string, remote?: string) =>
+      ipcRenderer.invoke("vellum:localMode:hatch", species, remote) as Promise<{
         ok: boolean;
         assistantId?: string;
         error?: string;


### PR DESCRIPTION
## Summary
- Update Electron IPC handler to accept optional `remote` parameter alongside `species`
- Thread `remote` through internal `hatch()` function to `runHatch()`
- Update preload script to expose `remote` parameter on `window.vellum.localMode.hatch`

Part of plan: container-runtime-gaps.md (PR 2 of 5)