### PR TITLE
feat(web): pass hosting mode as `remote` parameter through hatch flow

### DIFF
--- a/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -239,7 +239,8 @@ export function HatchingScreen() {
       if (useLocalHatch) {
         try {
           if (!localHatchPromise) {
-            localHatchPromise = hatchLocalAssistant();
+            const remote = hostingParam === "docker" ? "docker" : undefined;
+            localHatchPromise = hatchLocalAssistant(undefined, remote);
           }
           const result = await localHatchPromise;
           localHatchPromise = null;

--- a/apps/web/src/runtime/local-mode-host.test.ts
+++ b/apps/web/src/runtime/local-mode-host.test.ts
@@ -57,6 +57,21 @@ describe("hatchLocalAssistant", () => {
     expect(JSON.parse(init.body as string)).toEqual({ species: "vellum" });
   });
 
+  test("web/dev host forwards the remote parameter when provided", async () => {
+    const fetchMock = mock(async () => ({
+      json: async () => ({ ok: true, assistantId: "docker-1" }),
+    }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await hatchLocalAssistant(undefined, "docker");
+
+    const [, init] = fetchMock.mock.calls[0] as unknown as [
+      string,
+      RequestInit,
+    ];
+    expect(JSON.parse(init.body as string)).toEqual({ species: "vellum", remote: "docker" });
+  });
+
   test("Electron host routes to the main-process bridge and never touches fetch", async () => {
     runningInElectron = true;
     const hatch = mock(async () => ({ ok: true, assistantId: "electron-1" }));
@@ -70,7 +85,24 @@ describe("hatchLocalAssistant", () => {
     const result = await hatchLocalAssistant("vellum");
 
     expect(result).toEqual({ ok: true, assistantId: "electron-1" });
-    expect(hatch).toHaveBeenCalledWith("vellum");
+    expect(hatch).toHaveBeenCalledWith("vellum", undefined);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("Electron host forwards remote to the bridge", async () => {
+    runningInElectron = true;
+    const hatch = mock(async () => ({ ok: true, assistantId: "electron-docker-1" }));
+    const fetchMock = mock(async () => {
+      throw new Error("fetch must not run on the Electron branch");
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    (window as unknown as { vellum: { localMode: { hatch: typeof hatch } } }).vellum =
+      { localMode: { hatch } };
+
+    const result = await hatchLocalAssistant("vellum", "docker");
+
+    expect(result).toEqual({ ok: true, assistantId: "electron-docker-1" });
+    expect(hatch).toHaveBeenCalledWith("vellum", "docker");
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/runtime/local-mode-host.ts
+++ b/apps/web/src/runtime/local-mode-host.ts
@@ -94,15 +94,16 @@ export class GuardianTokenError extends Error {
  */
 export async function hatchLocalAssistant(
   species: string = "vellum",
+  remote?: string,
 ): Promise<LocalHatchResult> {
   if (isElectron()) {
-    return window.vellum!.localMode.hatch(species);
+    return window.vellum!.localMode.hatch(species, remote);
   }
 
   const res = await fetch("/assistant/__local/hatch", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ species }),
+    body: JSON.stringify({ species, remote }),
   });
   return res.json() as Promise<LocalHatchResult>;
 }

--- a/apps/web/vite-plugin-local-mode.ts
+++ b/apps/web/vite-plugin-local-mode.ts
@@ -194,12 +194,15 @@ function hatchMiddleware(baseDir: string): Connect.NextHandleFunction {
     req.on("data", (chunk: Buffer) => chunks.push(chunk));
     req.on("end", () => {
       let species = "vellum";
+      let remote: string | undefined;
       if (chunks.length > 0) {
         try {
           const body = JSON.parse(Buffer.concat(chunks).toString()) as {
             species?: string;
+            remote?: string;
           };
           if (body.species) species = body.species;
+          if (body.remote) remote = body.remote;
         } catch {
           res.statusCode = 400;
           res.setHeader("Content-Type", "application/json");
@@ -223,7 +226,7 @@ function hatchMiddleware(baseDir: string): Connect.NextHandleFunction {
         return;
       }
 
-      runHatch(invocation, species).then((result) => {
+      runHatch(invocation, species, remote ? { remote } : undefined).then((result) => {
         res.statusCode = result.ok ? 200 : result.status;
         res.setHeader("Content-Type", "application/json");
         res.end(


### PR DESCRIPTION
## Summary
- Add optional `remote` parameter to `hatchLocalAssistant()`
- Thread `remote` through both Electron IPC and dev-mode fetch paths
- Map `hosting=docker` query param to `--remote docker` in hatching screen
- Update vite dev server middleware to parse and forward `remote` from request body

Part of plan: container-runtime-gaps.md (PR 3 of 5)