### PR TITLE
fix(cli): forward `remote` parameter in client.ts hatch handler

### DIFF
--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -434,11 +434,16 @@ async function handleLocalEndpoints(
     if (req.method !== "POST") return new Response(null, { status: 405 });
 
     let species = "vellum";
+    let remote: string | undefined;
     const contentType = req.headers.get("content-type") ?? "";
     if (contentType.includes("json")) {
       try {
-        const body = (await req.json()) as { species?: string };
+        const body = (await req.json()) as {
+          species?: string;
+          remote?: string;
+        };
         if (body.species) species = body.species;
+        if (body.remote) remote = body.remote;
       } catch {
         return Response.json(
           { ok: false, error: "Invalid JSON body" },
@@ -457,7 +462,11 @@ async function handleLocalEndpoints(
       );
     }
 
-    const result = await runHatch(invocation, species);
+    const result = await runHatch(
+      invocation,
+      species,
+      remote ? { remote } : undefined,
+    );
     if (result.ok) {
       return Response.json({ ok: true, assistantId: result.assistantId });
     }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for container-runtime-gaps.md.

**Gap:** client.ts hatch handler does not forward the remote parameter
**What was expected:** Production vellum client HTTP server should parse remote from POST body and pass to runHatch()
**What was found:** Only species was parsed; remote was silently dropped, causing Docker hatch to fall back to local mode