### PR TITLE
Shore up container runtime gaps (bare metal + Docker)

### DIFF
--- a/apps/macos/src/main/local-mode.test.ts
+++ b/apps/macos/src/main/local-mode.test.ts
@@ -262,6 +262,18 @@ describe("vellum:localMode:hatch handler", () => {
     expect(result.error).toContain("ENOENT");
   });
 
+  test("parses the assistant id from a Docker hatch banner", async () => {
+    const pending = hatch("vellum");
+    await tick();
+    lastChild.stdout.emit(
+      "data",
+      Buffer.from("🥚 Hatching Docker assistant: asst-docker\n"),
+    );
+    lastChild.emit("close", 0);
+
+    expect(await pending).toEqual({ ok: true, assistantId: "asst-docker" });
+  });
+
   test("a zero exit whose stdout has no parseable id fails instead of returning a blank id", async () => {
     const pending = hatch("vellum");
     await tick();

--- a/apps/macos/src/main/local-mode.ts
+++ b/apps/macos/src/main/local-mode.ts
@@ -90,14 +90,14 @@ async function resolveCliInvocation(): Promise<CliInvocation> {
  * failures resolve with `{ ok: false, error }` so the renderer renders the
  * same error UI it shows for the web/dev middleware path.
  */
-async function hatch(species: string): Promise<HatchResult> {
+async function hatch(species: string, remote?: string): Promise<HatchResult> {
   let invocation: CliInvocation;
   try {
     invocation = await resolveCliInvocation();
   } catch (err) {
     return { ok: false, error: (err as Error).message };
   }
-  const result = await runHatch(invocation, species);
+  const result = await runHatch(invocation, species, { remote });
   return result.ok
     ? { ok: true, assistantId: result.assistantId }
     : { ok: false, error: result.error };
@@ -144,8 +144,12 @@ export const installLocalMode = (): void => {
   // falls back to the default rather than being rejected.
   handle(
     "vellum:localMode:hatch",
-    z.tuple([z.string().optional()]),
-    ([species]) => hatch(species && species.length > 0 ? species : DEFAULT_SPECIES),
+    z.tuple([z.string().optional(), z.string().optional()]),
+    ([species, remote]) =>
+      hatch(
+        species && species.length > 0 ? species : DEFAULT_SPECIES,
+        remote || undefined,
+      ),
   );
 
   handle("vellum:localMode:readLockfile", z.tuple([]), () => {

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -128,7 +128,7 @@ export interface VellumBridge {
      * (rather than rejecting) so the renderer renders the same error UI it
      * shows for the web/dev middleware path.
      */
-    hatch(species: string): Promise<{
+    hatch(species: string, remote?: string): Promise<{
       ok: boolean;
       assistantId?: string;
       error?: string;
@@ -266,8 +266,8 @@ const bridge: VellumBridge = {
       ipcRenderer.invoke("vellum:dock:setSignedIn", signedIn) as Promise<void>,
   },
   localMode: {
-    hatch: (species: string) =>
-      ipcRenderer.invoke("vellum:localMode:hatch", species) as Promise<{
+    hatch: (species: string, remote?: string) =>
+      ipcRenderer.invoke("vellum:localMode:hatch", species, remote) as Promise<{
         ok: boolean;
         assistantId?: string;
         error?: string;

--- a/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -239,7 +239,8 @@ export function HatchingScreen() {
       if (useLocalHatch) {
         try {
           if (!localHatchPromise) {
-            localHatchPromise = hatchLocalAssistant();
+            const remote = hostingParam === "docker" ? "docker" : undefined;
+            localHatchPromise = hatchLocalAssistant(undefined, remote);
           }
           const result = await localHatchPromise;
           localHatchPromise = null;

--- a/apps/web/src/runtime/is-electron.ts
+++ b/apps/web/src/runtime/is-electron.ts
@@ -59,7 +59,7 @@ declare global {
         setSignedIn(signedIn: boolean): Promise<void>;
       };
       localMode: {
-        hatch(species: string): Promise<{
+        hatch(species: string, remote?: string): Promise<{
           ok: boolean;
           assistantId?: string;
           error?: string;

--- a/apps/web/src/runtime/local-mode-host.test.ts
+++ b/apps/web/src/runtime/local-mode-host.test.ts
@@ -57,6 +57,21 @@ describe("hatchLocalAssistant", () => {
     expect(JSON.parse(init.body as string)).toEqual({ species: "vellum" });
   });
 
+  test("web/dev host forwards the remote parameter when provided", async () => {
+    const fetchMock = mock(async () => ({
+      json: async () => ({ ok: true, assistantId: "docker-1" }),
+    }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await hatchLocalAssistant(undefined, "docker");
+
+    const [, init] = fetchMock.mock.calls[0] as unknown as [
+      string,
+      RequestInit,
+    ];
+    expect(JSON.parse(init.body as string)).toEqual({ species: "vellum", remote: "docker" });
+  });
+
   test("Electron host routes to the main-process bridge and never touches fetch", async () => {
     runningInElectron = true;
     const hatch = mock(async () => ({ ok: true, assistantId: "electron-1" }));
@@ -70,7 +85,24 @@ describe("hatchLocalAssistant", () => {
     const result = await hatchLocalAssistant("vellum");
 
     expect(result).toEqual({ ok: true, assistantId: "electron-1" });
-    expect(hatch).toHaveBeenCalledWith("vellum");
+    expect(hatch).toHaveBeenCalledWith("vellum", undefined);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("Electron host forwards remote to the bridge", async () => {
+    runningInElectron = true;
+    const hatch = mock(async () => ({ ok: true, assistantId: "electron-docker-1" }));
+    const fetchMock = mock(async () => {
+      throw new Error("fetch must not run on the Electron branch");
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    (window as unknown as { vellum: { localMode: { hatch: typeof hatch } } }).vellum =
+      { localMode: { hatch } };
+
+    const result = await hatchLocalAssistant("vellum", "docker");
+
+    expect(result).toEqual({ ok: true, assistantId: "electron-docker-1" });
+    expect(hatch).toHaveBeenCalledWith("vellum", "docker");
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/runtime/local-mode-host.ts
+++ b/apps/web/src/runtime/local-mode-host.ts
@@ -94,15 +94,16 @@ export class GuardianTokenError extends Error {
  */
 export async function hatchLocalAssistant(
   species: string = "vellum",
+  remote?: string,
 ): Promise<LocalHatchResult> {
   if (isElectron()) {
-    return window.vellum!.localMode.hatch(species);
+    return window.vellum!.localMode.hatch(species, remote);
   }
 
   const res = await fetch("/assistant/__local/hatch", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ species }),
+    body: JSON.stringify({ species, remote }),
   });
   return res.json() as Promise<LocalHatchResult>;
 }

--- a/apps/web/vite-plugin-local-mode.ts
+++ b/apps/web/vite-plugin-local-mode.ts
@@ -194,12 +194,15 @@ function hatchMiddleware(baseDir: string): Connect.NextHandleFunction {
     req.on("data", (chunk: Buffer) => chunks.push(chunk));
     req.on("end", () => {
       let species = "vellum";
+      let remote: string | undefined;
       if (chunks.length > 0) {
         try {
           const body = JSON.parse(Buffer.concat(chunks).toString()) as {
             species?: string;
+            remote?: string;
           };
           if (body.species) species = body.species;
+          if (body.remote) remote = body.remote;
         } catch {
           res.statusCode = 400;
           res.setHeader("Content-Type", "application/json");
@@ -223,7 +226,7 @@ function hatchMiddleware(baseDir: string): Connect.NextHandleFunction {
         return;
       }
 
-      runHatch(invocation, species).then((result) => {
+      runHatch(invocation, species, remote ? { remote } : undefined).then((result) => {
         res.statusCode = result.ok ? 200 : result.status;
         res.setHeader("Content-Type", "application/json");
         res.end(

--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -434,11 +434,16 @@ async function handleLocalEndpoints(
     if (req.method !== "POST") return new Response(null, { status: 405 });
 
     let species = "vellum";
+    let remote: string | undefined;
     const contentType = req.headers.get("content-type") ?? "";
     if (contentType.includes("json")) {
       try {
-        const body = (await req.json()) as { species?: string };
+        const body = (await req.json()) as {
+          species?: string;
+          remote?: string;
+        };
         if (body.species) species = body.species;
+        if (body.remote) remote = body.remote;
       } catch {
         return Response.json(
           { ok: false, error: "Invalid JSON body" },
@@ -457,7 +462,11 @@ async function handleLocalEndpoints(
       );
     }
 
-    const result = await runHatch(invocation, species);
+    const result = await runHatch(
+      invocation,
+      species,
+      remote ? { remote } : undefined,
+    );
     if (result.ok) {
       return Response.json({ ok: true, assistantId: result.assistantId });
     }

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -1137,7 +1137,20 @@ export async function hatchDocker(
           await loadImageViaHost(HOST_IMAGE_LOADER_URL, ref, log);
         } else {
           log(`   ↪ pulling ${ref}`);
-          await exec("docker", ["pull", ref]);
+          const MAX_PULL_RETRIES = 3;
+          for (let attempt = 1; attempt <= MAX_PULL_RETRIES; attempt++) {
+            try {
+              await exec("docker", ["pull", ref]);
+              break;
+            } catch (err) {
+              if (attempt === MAX_PULL_RETRIES) throw err;
+              const delaySec = 2 ** attempt;
+              log(
+                `   ⚠ pull failed (attempt ${attempt}/${MAX_PULL_RETRIES}), retrying in ${delaySec}s...`,
+              );
+              await new Promise((r) => setTimeout(r, delaySec * 1000));
+            }
+          }
         }
       }
       log("✅ Docker images acquired");

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -14,7 +14,6 @@ import cliPkg from "../../package.json";
 
 import {
   findAssistantByName,
-  loadAllAssistants,
   saveAssistantEntry,
   setActiveAssistant,
 } from "./assistant-config";
@@ -479,18 +478,16 @@ export async function retireDocker(name: string): Promise<void> {
     }
   }
 
-  // Stop Colima VM if no other Docker instances remain (macOS only).
-  const hasOtherDockerInstances = loadAllAssistants().some(
-    (a) => a.cloud === "docker" && a.assistantId !== name,
-  );
-  if (!hasOtherDockerInstances && platform() !== "linux") {
-    try {
-      await exec("colima", ["stop"]);
-      console.log("\ud83d\uded1 Colima VM stopped (no remaining Docker instances).");
-    } catch {
-      // Colima may not be running or not installed
-    }
-  }
+  // Future: consider stopping Colima VM when no Docker instances remain.
+  // Considerations:
+  // - Use loadAllAssistantsAcrossEnvs() instead of loadAllAssistants() to
+  //   avoid stopping Colima while another VELLUM_ENVIRONMENT still has a
+  //   running Docker instance.
+  // - Track whether Vellum started Colima (vs. the user already had it
+  //   running for non-Vellum workloads) \u2014 e.g. via a dedicated Colima
+  //   profile (`colima start --profile vellum`) or a sentinel file.
+  // - Only stop if both conditions are met: no cross-env Docker instances
+  //   AND Vellum owns the Colima lifecycle.
 
   console.log(`\u2705 Docker instance retired.`);
 }

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -14,6 +14,7 @@ import cliPkg from "../../package.json";
 
 import {
   findAssistantByName,
+  loadAllAssistants,
   saveAssistantEntry,
   setActiveAssistant,
 } from "./assistant-config";
@@ -475,6 +476,19 @@ export async function retireDocker(name: string): Promise<void> {
       await exec("docker", ["volume", "rm", vol]);
     } catch {
       // volume may not exist
+    }
+  }
+
+  // Stop Colima VM if no other Docker instances remain (macOS only).
+  const hasOtherDockerInstances = loadAllAssistants().some(
+    (a) => a.cloud === "docker" && a.assistantId !== name,
+  );
+  if (!hasOtherDockerInstances && platform() !== "linux") {
+    try {
+      await exec("colima", ["stop"]);
+      console.log("\ud83d\uded1 Colima VM stopped (no remaining Docker instances).");
+    } catch {
+      // Colima may not be running or not installed
     }
   }
 

--- a/packages/local-mode/src/__tests__/hatch.test.ts
+++ b/packages/local-mode/src/__tests__/hatch.test.ts
@@ -45,6 +45,21 @@ describe("runHatch", () => {
     expect(spawnArgs[0]).toEqual(["bun", ["run", "cli", "hatch", "vellum"]]);
   });
 
+  test("parses the assistant id from a Docker hatch banner", async () => {
+    const pending = runHatch(invocation, "vellum", { remote: "docker" });
+    lastChild.stdout.emit(
+      "data",
+      Buffer.from("🥚 Hatching Docker assistant: asst-docker\n"),
+    );
+    lastChild.emit("close", 0);
+
+    expect(await pending).toEqual({ ok: true, assistantId: "asst-docker" });
+    expect(spawnArgs[0]).toEqual([
+      "bun",
+      ["run", "cli", "hatch", "vellum", "--remote", "docker"],
+    ]);
+  });
+
   test("a non-zero exit resolves to a failure carrying the CLI's output", async () => {
     const pending = runHatch(invocation, "vellum");
     lastChild.stderr.emit("data", Buffer.from("daemon already running"));

--- a/packages/local-mode/src/hatch.ts
+++ b/packages/local-mode/src/hatch.ts
@@ -63,7 +63,7 @@ export function runHatch(
         return;
       }
       const assistantId = stdout
-        .match(/Hatching local assistant:\s+(.+)/)?.[1]
+        .match(/Hatching (?:local|Docker) assistant:\s+(.+)/)?.[1]
         ?.trim();
       if (!assistantId) {
         finish({

--- a/packages/local-mode/src/hatch.ts
+++ b/packages/local-mode/src/hatch.ts
@@ -8,14 +8,24 @@ export type HatchResult =
   | { ok: true; assistantId: string }
   | { ok: false; status: number; error: string };
 
+export interface RunHatchOptions {
+  remote?: string;
+}
+
 export function runHatch(
   invocation: CliInvocation,
   species: string,
+  options?: RunHatchOptions,
 ): Promise<HatchResult> {
   return new Promise((resolve) => {
+    const args = [...invocation.baseArgs, "hatch", species];
+    if (options?.remote) {
+      args.push("--remote", options.remote);
+    }
+
     const child = spawn(
       invocation.command,
-      [...invocation.baseArgs, "hatch", species],
+      args,
       { stdio: ["ignore", "pipe", "pipe"] },
     );
 

--- a/packages/local-mode/src/hatch.ts
+++ b/packages/local-mode/src/hatch.ts
@@ -3,6 +3,8 @@ import { spawn } from "node:child_process";
 import type { CliInvocation } from "./util";
 
 const HATCH_TIMEOUT_MS = 120_000;
+// Docker hatches pull images and wait up to 5 min for container readiness.
+const DOCKER_HATCH_TIMEOUT_MS = 10 * 60 * 1000;
 
 export type HatchResult =
   | { ok: true; assistantId: string }
@@ -40,10 +42,16 @@ export function runHatch(
       resolve(result);
     };
 
+    const timeoutMs =
+      options?.remote === "docker" ? DOCKER_HATCH_TIMEOUT_MS : HATCH_TIMEOUT_MS;
     const timeout = setTimeout(() => {
       child.kill("SIGTERM");
-      finish({ ok: false, status: 500, error: "Hatch timed out after 120 seconds" });
-    }, HATCH_TIMEOUT_MS);
+      finish({
+        ok: false,
+        status: 500,
+        error: `Hatch timed out after ${timeoutMs / 1000} seconds`,
+      });
+    }, timeoutMs);
 
     child.stdout.on("data", (data: Buffer) => {
       stdout += data.toString();

--- a/packages/local-mode/src/index.ts
+++ b/packages/local-mode/src/index.ts
@@ -29,7 +29,7 @@ export type {
   LockfileWriteResult,
 } from "./lockfile-contract";
 export { runHatch } from "./hatch";
-export type { HatchResult, RunHatchOptions } from "./hatch";
+export type { HatchResult } from "./hatch";
 export { runRetire } from "./retire";
 export type { RetireResult } from "./retire";
 export { getGuardianAccessToken } from "./guardian-token";

--- a/packages/local-mode/src/index.ts
+++ b/packages/local-mode/src/index.ts
@@ -29,7 +29,7 @@ export type {
   LockfileWriteResult,
 } from "./lockfile-contract";
 export { runHatch } from "./hatch";
-export type { HatchResult } from "./hatch";
+export type { HatchResult, RunHatchOptions } from "./hatch";
 export { runRetire } from "./retire";
 export type { RetireResult } from "./retire";
 export { getGuardianAccessToken } from "./guardian-token";


### PR DESCRIPTION
## Summary
Wire Docker mode end-to-end through the Electron app's hatch IPC boundary, add Docker pull retry logic, and clean up Colima lifecycle documentation.

- Thread `--remote` parameter from `runHatch()` through Electron IPC, preload bridge, web UI, Vite dev middleware, and production `vellum client` server
- Generalize hatch output parsing to match both local and Docker banners
- Add 3-attempt exponential backoff retry for `docker pull` on transient network failures
- Document Colima VM lifecycle considerations for future cleanup implementation

## Self-review result
GAPS FOUND — 4 gaps fixed across 4 fix PRs (2 rounds)

## PRs merged into feature branch
- #33282: feat(local-mode): accept optional `remote` parameter in `runHatch()`
- #33284: fix(cli): retry `docker pull` on transient failures
- #33283: fix(cli): stop Colima VM when retiring the last Docker instance
- #33287: feat(macos): thread `remote` parameter through Electron hatch IPC
- #33288: feat(web): pass hosting mode as `remote` parameter through hatch flow

### Fix PRs (round 1 — self-review)
- #33290: fix(cli): forward `remote` parameter in client.ts hatch handler
- #33291: fix(local-mode): remove unused `RunHatchOptions` barrel export

### Fix PRs (round 2 — Codex review feedback)
- #33314: fix(local-mode): parse both local and Docker hatch banners in `runHatch()`
- #33311: fix(cli): remove Colima auto-stop, document considerations for future

Part of plan: container-runtime-gaps.md