### PR TITLE
fix(web): use box glyph for Skills origin tag

### DIFF
--- a/apps/web/src/domains/intelligence/components/skills/skill-origin-badge.tsx
+++ b/apps/web/src/domains/intelligence/components/skills/skill-origin-badge.tsx
@@ -1,11 +1,11 @@
-import { Globe, Package, Puzzle, Terminal, User } from "lucide-react";
+import { Box, Globe, Puzzle, Terminal, User } from "lucide-react";
 import { createElement } from "react";
 
 import { Tag } from "@vellum/design-library";
 import type { SkillOrigin } from "@/domains/intelligence/skills/types";
 
 const ORIGIN_META: Record<SkillOrigin, { label: string; icon: typeof Globe }> = {
-  vellum: { label: "Vellum", icon: Package },
+  vellum: { label: "Vellum", icon: Box },
   clawhub: { label: "Clawhub", icon: Globe },
   skillssh: { label: "skills.sh", icon: Terminal },
   custom: { label: "Custom", icon: User },


### PR DESCRIPTION
## Summary
- Swap Vellum origin tag icon from Package to Box to match the iOS Figma mock

Part of plan: ios-skills-figma-mock.md (PR 2 of 4)