### PR TITLE
fix(web): match Skills row layout to iOS Figma mock

### DIFF
--- a/apps/web/src/domains/intelligence/components/skills/skill-row.test.tsx
+++ b/apps/web/src/domains/intelligence/components/skills/skill-row.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * Tests for `SkillRow` action controls.
+ *
+ * The row is a `role="button"` whose primary click fires `onSelect`. The
+ * trailing icon-only action button (remove for installed skills, install
+ * for catalog skills) must:
+ *   - expose the correct `aria-label`
+ *   - fire its own handler (`onRemove` / `onInstall`)
+ *   - NOT also bubble up to `onSelect` (stopPropagation)
+ *
+ * Mounted via `@testing-library/react` (happy-dom — see
+ * `apps/web/test-setup.ts`).
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import { SkillRow } from "@/domains/intelligence/components/skills/skill-row.js";
+import type { SkillInfo } from "@/domains/intelligence/skills/types.js";
+
+afterEach(() => {
+  cleanup();
+});
+
+function makeSkill(overrides: Partial<SkillInfo> = {}): SkillInfo {
+  return {
+    id: "skill-1",
+    name: "Test Skill",
+    description: "A skill used in tests",
+    emoji: "\u{1F9E9}",
+    kind: "installed",
+    status: "enabled",
+    origin: "custom",
+    category: "general",
+    ...overrides,
+  };
+}
+
+function getButton(label: string): HTMLButtonElement {
+  const match = document.querySelector<HTMLButtonElement>(
+    `button[aria-label="${label}"]`,
+  );
+  if (!match) {
+    throw new Error(`expected a button with aria-label="${label}"`);
+  }
+  return match;
+}
+
+describe("SkillRow", () => {
+  test("removable skill: trash control removes without selecting", () => {
+    const onSelect = mock(() => {});
+    const onRemove = mock(() => {});
+
+    render(
+      <SkillRow
+        skill={makeSkill({ kind: "installed" })}
+        onSelect={onSelect}
+        onRemove={onRemove}
+      />,
+    );
+
+    const remove = getButton("Remove skill");
+    fireEvent.click(remove);
+
+    expect(onRemove).toHaveBeenCalledTimes(1);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  test("catalog skill: install control installs without selecting", () => {
+    const onSelect = mock(() => {});
+    const onInstall = mock(() => {});
+
+    render(
+      <SkillRow
+        skill={makeSkill({ kind: "catalog", status: "available" })}
+        onSelect={onSelect}
+        onInstall={onInstall}
+      />,
+    );
+
+    const install = getButton("Install skill");
+    fireEvent.click(install);
+
+    expect(onInstall).toHaveBeenCalledTimes(1);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/domains/intelligence/components/skills/skill-row.tsx
+++ b/apps/web/src/domains/intelligence/components/skills/skill-row.tsx
@@ -44,16 +44,16 @@ export function SkillRow({
         tabIndex={0}
         onClick={onSelect}
         onKeyDown={handleRowKeyDown}
-        className="flex cursor-pointer items-center gap-4 px-5 py-4 text-left transition-colors hover:bg-[var(--surface-hover)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
+        className="flex cursor-pointer items-center gap-3 px-3 py-2 text-left transition-colors hover:bg-[var(--surface-hover)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
       >
-      <div className="flex h-10 w-10 shrink-0 items-center justify-center text-2xl">
+      <div className="flex shrink-0 items-center justify-center text-[28px] leading-none">
         <SkillIcon skill={skill} className="h-7 w-7" />
       </div>
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
           <span
             className="truncate text-body-medium-default"
-            style={{ color: "var(--content-default)" }}
+            style={{ color: "var(--content-emphasised)" }}
           >
             {skill.name}
           </span>
@@ -61,7 +61,7 @@ export function SkillRow({
         </div>
         <p
           className="mt-1 truncate text-body-medium-lighter"
-          style={{ color: "var(--content-secondary)" }}
+          style={{ color: "var(--content-tertiary)" }}
         >
           {skill.description}
         </p>
@@ -69,29 +69,37 @@ export function SkillRow({
 
       {available ? (
         isInstalling ? (
-          <div className="flex h-9 items-center px-3" aria-label="Installing">
-            <Loader2
-              className="h-4 w-4 animate-spin"
-              style={{ color: "var(--content-tertiary)" }}
-            />
-          </div>
+          <Button
+            type="button"
+            iconOnly={<Loader2 className="animate-spin" aria-hidden />}
+            disabled
+            aria-label="Installing"
+            expandOnMobile={false}
+          />
         ) : (
           <Button
             type="button"
+            iconOnly={<ArrowDownToLine aria-hidden />}
             onClick={(e) => {
               e.stopPropagation();
               onInstall?.();
             }}
             disabled={!onInstall}
-            leftIcon={<ArrowDownToLine aria-hidden />}
-          >
-            Install
-          </Button>
+            aria-label="Install skill"
+            expandOnMobile={false}
+          />
         )
       ) : (
         <Button
           type="button"
-          variant={removable ? "dangerOutline" : "outlined"}
+          variant="dangerOutline"
+          iconOnly={
+            isRemoving ? (
+              <Loader2 className="animate-spin" aria-hidden />
+            ) : (
+              <Trash2 aria-hidden />
+            )
+          }
           onClick={(e) => {
             e.stopPropagation();
             onRemove?.();
@@ -99,16 +107,8 @@ export function SkillRow({
           disabled={!removable || isRemoving || !onRemove}
           aria-label={removable ? "Remove skill" : "Bundled skill cannot be removed"}
           title={removable ? undefined : "Bundled skills cannot be removed"}
-          leftIcon={
-            isRemoving ? (
-              <Loader2 className="animate-spin" aria-hidden />
-            ) : (
-              <Trash2 aria-hidden />
-            )
-          }
-        >
-          Remove
-        </Button>
+          expandOnMobile={false}
+        />
       )}
       </div>
     </Card.Root>


### PR DESCRIPTION
## Summary
- Densify skill row (12px gap, 12/8 padding, 28px icon), emphasised title, tertiary description
- Icon-only outlined trash (remove) and icon-only install buttons
- Add skill-row test for remove/install aria-labels and stopPropagation

Part of plan: ios-skills-figma-mock.md (PR 1 of 4)