### PR TITLE
feat(web): add fullscreen toggle button to app nav bar

### DIFF
--- a/apps/web/src/components/app-nav-bar.test.tsx
+++ b/apps/web/src/components/app-nav-bar.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * Tests for `AppNavBar`.
+ *
+ * Focuses on the optional fullscreen toggle button: it only renders when an
+ * `onToggleFullscreen` callback is supplied, and clicking it invokes that
+ * callback. We mount via `@testing-library/react` (backed by happy-dom — see
+ * `apps/web/test-setup.ts`).
+ *
+ * The design-library `Button` renders its tooltip via a Radix tooltip that only
+ * adds an accessible name while open, so we locate the fullscreen button by its
+ * `Maximize2` glyph (lucide adds a `lucide-maximize2` class to the rendered
+ * SVG) rather than by accessible name.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import { AppNavBar } from "@/components/app-nav-bar";
+
+afterEach(() => {
+  cleanup();
+});
+
+function getFullscreenButton(): HTMLButtonElement | null {
+  const glyph = document.querySelector("svg.lucide-maximize2");
+  return glyph?.closest("button") ?? null;
+}
+
+describe("AppNavBar fullscreen toggle", () => {
+  test("omits the fullscreen button when onToggleFullscreen is not provided", () => {
+    render(<AppNavBar appName="My App" onClose={() => {}} />);
+    expect(getFullscreenButton()).toBeNull();
+  });
+
+  test("renders the fullscreen button and invokes onToggleFullscreen on click", () => {
+    const onToggleFullscreen = mock(() => {});
+    render(
+      <AppNavBar
+        appName="My App"
+        onClose={() => {}}
+        onToggleFullscreen={onToggleFullscreen}
+      />,
+    );
+
+    const button = getFullscreenButton();
+    expect(button).not.toBeNull();
+
+    fireEvent.click(button as HTMLButtonElement);
+    expect(onToggleFullscreen).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/app-nav-bar.tsx
+++ b/apps/web/src/components/app-nav-bar.tsx
@@ -1,5 +1,5 @@
 
-import { ArrowUp, ChevronUp, Globe, Loader2, Pencil, X } from "lucide-react";
+import { ArrowUp, ChevronUp, Globe, Loader2, Maximize2, Pencil, X } from "lucide-react";
 
 import { Button } from "@vellum/design-library";
 import { Typography } from "@vellum/design-library";
@@ -19,10 +19,12 @@ export interface AppNavBarProps {
   isSharing?: boolean;
   onDeploy?: () => void;
   isDeploying?: boolean;
+  /** When provided, renders a fullscreen toggle button in the right group. */
+  onToggleFullscreen?: () => void;
   onClose: () => void;
 }
 
-export function AppNavBar({ appName, onEdit, isEditing, onShare, isSharing, onDeploy, isDeploying, onClose }: AppNavBarProps) {
+export function AppNavBar({ appName, onEdit, isEditing, onShare, isSharing, onDeploy, isDeploying, onToggleFullscreen, onClose }: AppNavBarProps) {
   const isMobile = useIsMobile();
   // While the bar is acting as the minimized strip on mobile, tapping the
   // title is the primary "open app" affordance — same callback as the
@@ -66,6 +68,14 @@ export function AppNavBar({ appName, onEdit, isEditing, onShare, isSharing, onDe
             onClick={onShare}
             disabled={isSharing}
             tooltip={isSharing ? "Sharing…" : "Share"}
+          />
+        )}
+        {onToggleFullscreen != null && (
+          <Button
+            variant="outlined"
+            iconOnly={<Maximize2 />}
+            onClick={onToggleFullscreen}
+            tooltip="Fullscreen"
           />
         )}
         {onEdit != null && (


### PR DESCRIPTION
## Summary
- Add an optional Maximize2 'Fullscreen' button to AppNavBar's right button group (between Share and Close), gated on a new optional onToggleFullscreen prop.
- Add colocated app-nav-bar.test.tsx covering presence/absence and click behavior.

Part of plan: library-app-fullscreen.md (PR 1 of 3)