### PR TITLE
feat(web): pure per-turn activity projection and shared anchor-id formatter

### DIFF
--- a/apps/web/src/domains/chat/transcript/turn-activity.test.ts
+++ b/apps/web/src/domains/chat/transcript/turn-activity.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
+import type { DisplayMessage } from "@/domains/chat/utils/reconcile";
+import { activityAnchorId, buildTurnActivity } from "@/domains/chat/transcript/turn-activity";
+
+function toolCall(
+  overrides: Partial<ChatMessageToolCall> & Pick<ChatMessageToolCall, "id">,
+): ChatMessageToolCall {
+  return {
+    toolName: "bash",
+    input: {},
+    status: "completed",
+    ...overrides,
+  };
+}
+
+function assistant(overrides: Partial<DisplayMessage>): DisplayMessage {
+  return {
+    id: "m1",
+    role: "assistant",
+    ...overrides,
+  };
+}
+
+describe("activityAnchorId", () => {
+  test("formatting is stable for both kinds", () => {
+    expect(activityAnchorId("m1", "thinking", "0")).toBe("activity-m1-th-0");
+    expect(activityAnchorId("m1", "tool", "tc-abc")).toBe("activity-m1-tc-tc-abc");
+  });
+});
+
+describe("buildTurnActivity", () => {
+  test("interleaved: thinking + two consecutive bash calls → 1 thinking + 1 tool step", () => {
+    const message = assistant({
+      thinkingSegments: ["reasoning..."],
+      textSegments: [],
+      toolCalls: [
+        toolCall({ id: "call-a" }),
+        toolCall({ id: "call-b" }),
+      ],
+      contentOrder: [
+        { type: "thinking", id: "0" },
+        { type: "toolCall", id: "call-a" },
+        { type: "toolCall", id: "call-b" },
+      ],
+    });
+
+    const activity = buildTurnActivity(message);
+    expect(activity.steps).toHaveLength(2);
+    expect(activity.stepCount).toBe(2);
+    expect(activity.steps[0]!.kind).toBe("thinking");
+    expect(activity.steps[0]!.anchorId).toBe("activity-m1-th-0");
+    expect(activity.steps[0]!.title).toBe("Thought process");
+    expect(activity.steps[1]!.kind).toBe("tool");
+    expect(activity.steps[1]!.anchorId).toBe("activity-m1-tc-call-a");
+  });
+
+  test("two non-consecutive tool groups separated by text → 2 tool steps", () => {
+    const message = assistant({
+      textSegments: ["some text"],
+      toolCalls: [
+        toolCall({ id: "call-a" }),
+        toolCall({ id: "call-b" }),
+      ],
+      contentOrder: [
+        { type: "toolCall", id: "call-a" },
+        { type: "text", id: "0" },
+        { type: "toolCall", id: "call-b" },
+      ],
+    });
+
+    const activity = buildTurnActivity(message);
+    expect(activity.steps).toHaveLength(2);
+    expect(activity.steps.every((s) => s.kind === "tool")).toBe(true);
+    expect(activity.steps[0]!.anchorId).toBe("activity-m1-tc-call-a");
+    expect(activity.steps[1]!.anchorId).toBe("activity-m1-tc-call-b");
+  });
+
+  test("legacy shape (toolCalls present, no interleaved contentOrder) → 1 tool step anchored on first tool id", () => {
+    const message = assistant({
+      textSegments: ["answer"],
+      toolCalls: [
+        toolCall({ id: "call-a" }),
+        toolCall({ id: "call-b" }),
+      ],
+      contentOrder: [{ type: "text", id: "0" }],
+    });
+
+    const activity = buildTurnActivity(message);
+    expect(activity.steps).toHaveLength(1);
+    expect(activity.steps[0]!.kind).toBe("tool");
+    expect(activity.steps[0]!.anchorId).toBe("activity-m1-tc-call-a");
+  });
+
+  test("subagent-spawn-only group → no tool step", () => {
+    const message = assistant({
+      toolCalls: [
+        toolCall({ id: "spawn-1", toolName: "subagent_spawn" }),
+        toolCall({
+          id: "spawn-2",
+          toolName: "skill_execute",
+          input: { tool: "subagent_spawn" },
+        }),
+      ],
+      contentOrder: [
+        { type: "toolCall", id: "spawn-1" },
+        { type: "toolCall", id: "spawn-2" },
+      ],
+    });
+
+    const activity = buildTurnActivity(message);
+    expect(activity.steps).toHaveLength(0);
+  });
+
+  test("suppressed ui_show group → no tool step", () => {
+    const message = assistant({
+      toolCalls: [toolCall({ id: "ui-1", toolName: "ui_show" })],
+      contentOrder: [{ type: "toolCall", id: "ui-1" }],
+    });
+
+    const activity = buildTurnActivity(message);
+    expect(activity.steps).toHaveLength(0);
+  });
+
+  test("empty thinking segment → no thinking step", () => {
+    const message = assistant({
+      thinkingSegments: [""],
+      toolCalls: [toolCall({ id: "call-a" })],
+      contentOrder: [
+        { type: "thinking", id: "0" },
+        { type: "toolCall", id: "call-a" },
+      ],
+    });
+
+    const activity = buildTurnActivity(message);
+    expect(activity.steps).toHaveLength(1);
+    expect(activity.steps[0]!.kind).toBe("tool");
+  });
+
+  test("a running call → aggregate state is loading", () => {
+    const message = assistant({
+      toolCalls: [
+        toolCall({ id: "call-a", status: "completed" }),
+        toolCall({ id: "call-b", status: "running" }),
+      ],
+      contentOrder: [
+        { type: "toolCall", id: "call-a" },
+        { type: "toolCall", id: "call-b" },
+      ],
+    });
+
+    const activity = buildTurnActivity(message);
+    expect(activity.state).toBe("loading");
+  });
+
+  test("an errored call with no running call → aggregate state is error", () => {
+    const message = assistant({
+      toolCalls: [
+        toolCall({ id: "call-a", status: "completed" }),
+        toolCall({ id: "call-b", status: "error" }),
+      ],
+      contentOrder: [
+        { type: "toolCall", id: "call-a" },
+        { type: "toolCall", id: "call-b" },
+      ],
+    });
+
+    const activity = buildTurnActivity(message);
+    expect(activity.state).toBe("error");
+  });
+
+  test("non-assistant message → empty TurnActivity", () => {
+    const message: DisplayMessage = {
+      id: "u1",
+      role: "user",
+      toolCalls: [toolCall({ id: "call-a" })],
+      contentOrder: [{ type: "toolCall", id: "call-a" }],
+    };
+
+    const activity = buildTurnActivity(message);
+    expect(activity.steps).toHaveLength(0);
+    expect(activity.stepCount).toBe(0);
+    expect(activity.state).toBe("complete");
+    expect(activity.currentStepTitle).toBe("");
+    expect(activity.currentStepInfo).toBe("");
+  });
+});

--- a/apps/web/src/domains/chat/transcript/turn-activity.ts
+++ b/apps/web/src/domains/chat/transcript/turn-activity.ts
@@ -1,0 +1,283 @@
+// Pure per-assistant-turn activity projection. No React/DOM imports so it can
+// be exercised with `bun test` like `build-items.ts`.
+//
+// Grouping rules MIRROR transcript-message-body.tsx; keep in lockstep —
+// cross-checked by transcript-message-body.test.tsx in PR 3.
+
+import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
+import { computeToolCallCardData } from "@/domains/chat/hooks/tool-call-card-utils";
+import type { DisplayMessage } from "@/domains/chat/utils/reconcile";
+
+export type ActivityKind = "thinking" | "tool";
+
+/**
+ * Single source of truth for activity anchor ids — used here AND by the
+ * rendered DOM in PR 3, so the render anchors and the projected anchors stay
+ * byte-identical.
+ */
+export function activityAnchorId(
+  messageId: string,
+  kind: ActivityKind,
+  firstId: string,
+): string {
+  return `activity-${messageId}-${kind === "thinking" ? "th" : "tc"}-${firstId}`;
+}
+
+export interface ActivityStep {
+  anchorId: string;
+  kind: ActivityKind;
+  title: string;
+  info: string;
+  state: "loading" | "complete" | "error" | "denied";
+  iconName?: string;
+  riskLevel?: string;
+}
+
+export interface TurnActivity {
+  steps: ActivityStep[];
+  currentStepTitle: string;
+  currentStepInfo: string;
+  state: "loading" | "complete" | "error" | "denied";
+  stepCount: number;
+}
+
+/**
+ * Grouped content shape — a pure replica of the `ContentGroup` union in the
+ * interleaved branch of `transcript-message-body.tsx`.
+ */
+export type ContentGroup =
+  | { type: "text"; id: string }
+  | { type: "toolCalls"; ids: string[] }
+  | { type: "thinking"; ids: string[] }
+  | { type: "surface"; id: string };
+
+/**
+ * Group consecutive `message.contentOrder` entries — merge adjacent
+ * `toolCall`/`tool` entries into one group, merge adjacent `thinking` entries
+ * into one group, and pass `text`/`surface` through individually. Mirrors the
+ * interleaved-branch loop in `transcript-message-body.tsx`.
+ */
+export function groupMessageContent(message: DisplayMessage): ContentGroup[] {
+  const groups: ContentGroup[] = [];
+  for (const entry of message.contentOrder ?? []) {
+    if (entry.type === "toolCall" || entry.type === "tool") {
+      const lastGroup = groups[groups.length - 1];
+      if (lastGroup?.type === "toolCalls") {
+        lastGroup.ids.push(entry.id);
+      } else {
+        groups.push({ type: "toolCalls", ids: [entry.id] });
+      }
+    } else if (entry.type === "thinking") {
+      const lastGroup = groups[groups.length - 1];
+      if (lastGroup?.type === "thinking") {
+        lastGroup.ids.push(entry.id);
+      } else {
+        groups.push({ type: "thinking", ids: [entry.id] });
+      }
+    } else if (entry.type === "text") {
+      groups.push({ type: "text", id: entry.id });
+    } else if (entry.type === "surface") {
+      groups.push({ type: "surface", id: entry.id });
+    }
+  }
+  return groups;
+}
+
+/**
+ * Resolve a tool call from a contentOrder id — find by `id`, else parse-int the
+ * id into a positional index of `message.toolCalls`. Mirrors `resolveToolCall`
+ * in `transcript-message-body.tsx`.
+ */
+function resolveToolCall(
+  message: DisplayMessage,
+  id: string,
+): ChatMessageToolCall | undefined {
+  const tc = message.toolCalls?.find((t) => t.id === id);
+  if (tc) {
+    return tc;
+  }
+  const idx = parseInt(id, 10);
+  if (!isNaN(idx) && message.toolCalls && idx < message.toolCalls.length) {
+    return message.toolCalls[idx];
+  }
+  return undefined;
+}
+
+/**
+ * Join the reasoning segments referenced by a run of `thinking` contentOrder
+ * ids into one string. Mirrors `resolveThinkingContent` in
+ * `transcript-message-body.tsx`.
+ */
+function resolveThinkingContent(message: DisplayMessage, ids: string[]): string {
+  return ids
+    .map((id) => {
+      const idx = parseInt(id, 10);
+      return !isNaN(idx) ? message.thinkingSegments?.[idx] : undefined;
+    })
+    .filter((s): s is string => Boolean(s))
+    .join("\n");
+}
+
+/**
+ * Detect a `subagent_spawn` invocation in either canonical form. Mirrors
+ * `isSubagentSpawnCall` in `transcript-message-body.tsx`.
+ */
+function isSubagentSpawnCall(toolCall: ChatMessageToolCall): boolean {
+  if (toolCall.toolName === "subagent_spawn") return true;
+  if (toolCall.toolName !== "skill_execute") return false;
+  const input = toolCall.input;
+  if (input == null || typeof input !== "object") return false;
+  return (input as Record<string, unknown>).tool === "subagent_spawn";
+}
+
+/**
+ * UI surface tools are rendered by the inline surface widget, not as tool-call
+ * chips — unless they carry a pending confirmation. Mirrors `isSuppressedUiTool`
+ * in `transcript-message-body.tsx`.
+ */
+function isSuppressedUiTool(tc: ChatMessageToolCall): boolean {
+  return (
+    !tc.pendingConfirmation &&
+    (tc.toolName === "ui_show" ||
+      tc.toolName === "ui_update" ||
+      tc.toolName === "ui_dismiss")
+  );
+}
+
+/**
+ * Aggregate card-level state across steps using the same precedence as
+ * `deriveCardState` in tool-call-card-utils.ts: denied > loading > error >
+ * complete.
+ */
+function aggregateState(
+  states: Array<"loading" | "complete" | "error" | "denied">,
+): "loading" | "complete" | "error" | "denied" {
+  if (states.includes("denied")) return "denied";
+  if (states.includes("loading")) return "loading";
+  if (states.includes("error")) return "error";
+  return "complete";
+}
+
+/** Icon name of the last `tool`-kind step in a `ToolCallCardData.steps`. */
+function lastToolIconName(
+  steps: ReturnType<typeof computeToolCallCardData>["steps"],
+): string | undefined {
+  for (let i = steps.length - 1; i >= 0; i--) {
+    const step = steps[i]!;
+    if (step.kind === "tool") return step.iconName;
+  }
+  return undefined;
+}
+
+/** Build a single `tool` step from a group's renderable tool calls. */
+function buildToolActivityStep(
+  message: DisplayMessage,
+  calls: ChatMessageToolCall[],
+): ActivityStep | null {
+  const renderable = calls.filter(
+    (tc) => !isSuppressedUiTool(tc) && !isSubagentSpawnCall(tc),
+  );
+  if (renderable.length === 0) return null;
+  const first = renderable[0]!;
+  const d = computeToolCallCardData(renderable, {}, null);
+  return {
+    kind: "tool",
+    anchorId: activityAnchorId(message.id, "tool", first.id),
+    title: d.currentStepTitle,
+    info: d.currentStepInfo,
+    state: d.state,
+    iconName: lastToolIconName(d.steps),
+    riskLevel: first.riskLevel,
+  };
+}
+
+const EMPTY_TURN_ACTIVITY: TurnActivity = {
+  steps: [],
+  currentStepTitle: "",
+  currentStepInfo: "",
+  state: "complete",
+  stepCount: 0,
+};
+
+/**
+ * Project an assistant `DisplayMessage` into the per-turn activity model that
+ * drives the combined progress card. Covers both render shapes:
+ *
+ *   - Interleaved: `contentOrder` carries `toolCall`/`tool` entries, walked via
+ *     `groupMessageContent`.
+ *   - Legacy: no interleaved tool calls — thinking runs from `contentOrder`
+ *     plus a single trailing tool step from `message.toolCalls`.
+ *
+ * Returns an empty `TurnActivity` for non-assistant messages.
+ */
+export function buildTurnActivity(message: DisplayMessage): TurnActivity {
+  if (message.role !== "assistant") {
+    return EMPTY_TURN_ACTIVITY;
+  }
+
+  const steps: ActivityStep[] = [];
+
+  const hasInterleavedToolCalls = message.contentOrder?.some(
+    (e) => e.type === "toolCall" || e.type === "tool",
+  );
+
+  if (hasInterleavedToolCalls) {
+    for (const group of groupMessageContent(message)) {
+      if (group.type === "thinking") {
+        const content = resolveThinkingContent(message, group.ids);
+        if (!content) continue;
+        steps.push({
+          kind: "thinking",
+          anchorId: activityAnchorId(message.id, "thinking", group.ids[0]!),
+          title: "Thought process",
+          info: "",
+          state: "complete",
+        });
+      } else if (group.type === "toolCalls") {
+        const calls = group.ids
+          .map((id) => resolveToolCall(message, id))
+          .filter((tc): tc is ChatMessageToolCall => tc != null);
+        const step = buildToolActivityStep(message, calls);
+        if (step) steps.push(step);
+      }
+    }
+  } else {
+    // Legacy shape: emit thinking steps by buffering consecutive `thinking`
+    // ids, then one trailing tool step from `message.toolCalls`.
+    let pendingThinkingIds: string[] = [];
+    const flushThinking = () => {
+      if (pendingThinkingIds.length === 0) return;
+      const ids = pendingThinkingIds;
+      pendingThinkingIds = [];
+      const content = resolveThinkingContent(message, ids);
+      if (!content) return;
+      steps.push({
+        kind: "thinking",
+        anchorId: activityAnchorId(message.id, "thinking", ids[0]!),
+        title: "Thought process",
+        info: "",
+        state: "complete",
+      });
+    };
+    for (const entry of message.contentOrder ?? []) {
+      if (entry.type === "thinking") {
+        pendingThinkingIds.push(entry.id);
+        continue;
+      }
+      flushThinking();
+    }
+    flushThinking();
+
+    const step = buildToolActivityStep(message, message.toolCalls ?? []);
+    if (step) steps.push(step);
+  }
+
+  const last = steps[steps.length - 1];
+  return {
+    steps,
+    currentStepTitle: last?.title ?? "",
+    currentStepInfo: last?.info ?? "",
+    state: aggregateState(steps.map((s) => s.state)),
+    stepCount: steps.length,
+  };
+}


### PR DESCRIPTION
## Summary
- Add `turn-activity.ts`: pure `buildTurnActivity(message)` projection + shared `activityAnchorId` formatter + `groupMessageContent` (mirrors transcript-message-body grouping).
- Unit tests covering interleaved/legacy shapes, suppression, and aggregate state.

Part of plan: web-activity-summary.md (PR 2 of 7)