### PR TITLE
fix(web): space credits card from menu + smaller balance text

### DIFF
--- a/apps/web/src/domains/chat/components/credits-card.tsx
+++ b/apps/web/src/domains/chat/components/credits-card.tsx
@@ -28,7 +28,7 @@ export function CreditsCard({
               className="h-3.5 w-3.5 text-[color:var(--credits-accent)]"
               aria-hidden
             />
-            <span className="text-body-large-default max-md:text-title-medium text-[color:var(--content-default)]">
+            <span className="text-body-medium-default max-md:text-title-medium text-[color:var(--content-default)]">
               {balance} credits
             </span>
           </div>

--- a/apps/web/src/domains/chat/components/credits-card.tsx
+++ b/apps/web/src/domains/chat/components/credits-card.tsx
@@ -20,7 +20,7 @@ export function CreditsCard({
   onEarnCredits,
 }: CreditsCardProps) {
   return (
-    <div className="flex flex-col gap-4 rounded-lg border border-[var(--surface-base)] bg-[var(--surface-overlay)] px-3 pt-3 pb-4 w-full">
+    <div className="flex flex-col gap-2 max-md:gap-4 rounded-lg border border-[var(--surface-base)] bg-[var(--surface-overlay)] px-3 pt-3 pb-2 max-md:pb-4 w-full">
       {balance !== null && (
         <div className="flex items-center justify-between gap-2 rounded-[10px] bg-[var(--surface-base)] py-2 pl-1.5 pr-2 w-full">
           <div className="flex items-center gap-2">

--- a/apps/web/src/domains/chat/components/credits-card.tsx
+++ b/apps/web/src/domains/chat/components/credits-card.tsx
@@ -20,7 +20,7 @@ export function CreditsCard({
   onEarnCredits,
 }: CreditsCardProps) {
   return (
-    <div className="flex flex-col gap-4 rounded-lg border border-[var(--surface-base)] bg-[var(--surface-overlay)] px-3 pt-3 pb-4 w-full">
+    <div className="flex flex-col rounded-lg border border-[var(--surface-base)] bg-[var(--surface-overlay)] px-3 pt-3 pb-4 w-full">
       {balance !== null && (
         <div className="flex items-center justify-between gap-2 rounded-[10px] bg-[var(--surface-base)] py-2 pl-1.5 pr-2 w-full">
           <div className="flex items-center gap-2">

--- a/apps/web/src/domains/chat/components/credits-card.tsx
+++ b/apps/web/src/domains/chat/components/credits-card.tsx
@@ -20,7 +20,7 @@ export function CreditsCard({
   onEarnCredits,
 }: CreditsCardProps) {
   return (
-    <div className="flex flex-col rounded-lg border border-[var(--surface-base)] bg-[var(--surface-overlay)] px-3 pt-3 pb-4 w-full">
+    <div className="flex flex-col gap-4 rounded-lg border border-[var(--surface-base)] bg-[var(--surface-overlay)] px-3 pt-3 pb-4 w-full">
       {balance !== null && (
         <div className="flex items-center justify-between gap-2 rounded-[10px] bg-[var(--surface-base)] py-2 pl-1.5 pr-2 w-full">
           <div className="flex items-center gap-2">
@@ -52,6 +52,7 @@ export function CreditsCard({
 
       <Button
         variant="ghost"
+        size="compact"
         fullWidth
         tintColor="var(--content-secondary)"
         onClick={onEarnCredits}

--- a/apps/web/src/domains/chat/components/credits-card.tsx
+++ b/apps/web/src/domains/chat/components/credits-card.tsx
@@ -52,7 +52,6 @@ export function CreditsCard({
 
       <Button
         variant="ghost"
-        size="compact"
         fullWidth
         tintColor="var(--content-secondary)"
         onClick={onEarnCredits}

--- a/apps/web/src/domains/chat/components/preferences-menu.tsx
+++ b/apps/web/src/domains/chat/components/preferences-menu.tsx
@@ -169,8 +169,6 @@ function PreferencesMenuContent({
       <ThemeToggle className="px-2 py-0" />
 
       {showBillingRows ? (
-        // 8px gap above and below the credits card, separating it from the
-        // theme switcher and the menu rows.
         <div className="my-2">
           <CreditsCard
             balance={

--- a/apps/web/src/domains/chat/components/preferences-menu.tsx
+++ b/apps/web/src/domains/chat/components/preferences-menu.tsx
@@ -169,8 +169,9 @@ function PreferencesMenuContent({
       <ThemeToggle className="px-2 py-0" />
 
       {showBillingRows ? (
-        // 8px gap separating the credits card from the menu rows below it.
-        <div className="mb-2">
+        // 8px gap above and below the credits card, separating it from the
+        // theme switcher and the menu rows.
+        <div className="my-2">
           <CreditsCard
             balance={
               effectiveBalance !== null

--- a/apps/web/src/domains/chat/components/preferences-menu.tsx
+++ b/apps/web/src/domains/chat/components/preferences-menu.tsx
@@ -166,7 +166,7 @@ function PreferencesMenuContent({
 
   return (
     <>
-      <ThemeToggle className="px-2 pt-0" />
+      <ThemeToggle className="px-2 py-0" />
 
       {showBillingRows ? (
         // 8px gap separating the credits card from the menu rows below it.

--- a/apps/web/src/domains/chat/components/preferences-menu.tsx
+++ b/apps/web/src/domains/chat/components/preferences-menu.tsx
@@ -169,21 +169,24 @@ function PreferencesMenuContent({
       <ThemeToggle className="px-2 pt-0" />
 
       {showBillingRows ? (
-        <CreditsCard
-          balance={
-            effectiveBalance !== null
-              ? formatWholeCredits(effectiveBalance)
-              : null
-          }
-          onAddCredits={() => {
-            onClose();
-            navigate(routes.settings.billing);
-          }}
-          onEarnCredits={() => {
-            onClose();
-            onEarnCredits();
-          }}
-        />
+        // 8px gap separating the credits card from the menu rows below it.
+        <div className="mb-2">
+          <CreditsCard
+            balance={
+              effectiveBalance !== null
+                ? formatWholeCredits(effectiveBalance)
+                : null
+            }
+            onAddCredits={() => {
+              onClose();
+              navigate(routes.settings.billing);
+            }}
+            onEarnCredits={() => {
+              onClose();
+              onEarnCredits();
+            }}
+          />
+        </div>
       ) : null}
 
       <PanelItem


### PR DESCRIPTION
## Summary
Two small preferences-drawer tweaks (from design feedback on the desktop popover):

- **Spacing** — wrap the credits card in an 8px bottom-margin (`mb-2`) div so it's clearly separated from the Settings row below it (previously flush after the dividers were removed in #33257).
- **Balance text size** — reduce the credits balance on desktop from `text-body-large-default` (16px) to `text-body-medium-default` (14px). Mobile keeps `text-title-medium` (20px) to match the iOS mock.

## Testing
- className-only changes using existing design tokens; no test asserts these classes (credits-card test checks text content, preferences-menu test mocks the card). typecheck + lint run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)