### PR TITLE
feat(web): scrollToActivity transcript handle with transient highlight

### DIFF
--- a/apps/web/src/domains/chat/transcript/transcript.test.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript.test.tsx
@@ -596,4 +596,38 @@ describe("Transcript scrollToActivity handle", () => {
     }).not.toThrow();
     expect(scrollIntoView).not.toHaveBeenCalled();
   });
+
+  test("uses behavior 'auto' when prefers-reduced-motion: reduce matches", () => {
+    const originalMatchMedia = window.matchMedia;
+    window.matchMedia = ((query: string) =>
+      ({
+        matches: query.includes("prefers-reduced-motion: reduce"),
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      }) as unknown as MediaQueryList) as typeof window.matchMedia;
+
+    try {
+      const handle = renderWithHandle();
+
+      const anchor = document.createElement("div");
+      anchor.setAttribute("data-activity-anchor", "step-1");
+      handle.getScrollElement()!.appendChild(anchor);
+
+      act(() => {
+        handle.scrollToActivity("step-1");
+      });
+
+      expect(scrollIntoView).toHaveBeenCalledTimes(1);
+      expect(scrollIntoView).toHaveBeenLastCalledWith(
+        expect.objectContaining({ behavior: "auto" }),
+      );
+    } finally {
+      window.matchMedia = originalMatchMedia;
+    }
+  });
 });

--- a/apps/web/src/domains/chat/transcript/transcript.test.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript.test.tsx
@@ -10,8 +10,16 @@
  * LatestTurnRow follows at the end of the DOM (visual bottom).
  */
 
-import { afterEach, describe, expect, mock, test } from "bun:test";
-import { act, useEffect } from "react";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+import { act, createRef, useEffect } from "react";
 import { cleanup, render } from "@testing-library/react";
 
 // `ChatMarkdownMessage` pulls in `react-markdown` + `remark-gfm`. They render
@@ -54,7 +62,10 @@ import { renderToStaticMarkup } from "react-dom/server";
 import type { DisplayMessage } from "@/domains/chat/utils/reconcile";
 import type { TranscriptItem } from "@/domains/chat/transcript/types";
 
-import { Transcript } from "@/domains/chat/transcript/transcript";
+import {
+  Transcript,
+  type TranscriptHandle,
+} from "@/domains/chat/transcript/transcript";
 
 import { textBody } from "@/domains/chat/utils/message-test-helpers";
 function userMessage(id: string, content: string): TranscriptItem {
@@ -521,5 +532,68 @@ describe("Transcript no-anchor → anchor transition preserves avatar DOM identi
     });
     expect(avatarMountCount).toBe(1);
     expect(avatarUnmountCount).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// `scrollToActivity` handle method — scrolls a matching `[data-activity-anchor]`
+// element into view and flashes a transient highlight.
+// ---------------------------------------------------------------------------
+describe("Transcript scrollToActivity handle", () => {
+  // jsdom/happy-dom don't implement scrollIntoView — stub it for the suite.
+  const scrollIntoView = mock(() => {});
+  const originalScrollIntoView = Element.prototype.scrollIntoView;
+
+  beforeAll(() => {
+    Element.prototype.scrollIntoView = scrollIntoView;
+  });
+  afterAll(() => {
+    Element.prototype.scrollIntoView = originalScrollIntoView;
+  });
+  afterEach(() => {
+    cleanup();
+    scrollIntoView.mockClear();
+  });
+
+  function renderWithHandle() {
+    const ref = createRef<TranscriptHandle>();
+    render(
+      <Transcript
+        ref={ref}
+        items={[assistantMessage("a1", "reply")]}
+        conversationId="conv-1"
+        onSecretSubmit={noop}
+        onConfirmationDecision={noop}
+        onSurfaceAction={noop}
+        onRetryError={noop}
+      />,
+    );
+    return ref.current!;
+  }
+
+  test("scrolls the matching anchor into view and flashes the highlight", () => {
+    const handle = renderWithHandle();
+
+    const anchor = document.createElement("div");
+    anchor.setAttribute("data-activity-anchor", "step-1");
+    handle.getScrollElement()!.appendChild(anchor);
+
+    act(() => {
+      handle.scrollToActivity("step-1");
+    });
+
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+    expect(anchor.getAttribute("data-activity-highlight")).toBe("true");
+  });
+
+  test("is a safe no-op for an unknown anchor id", () => {
+    const handle = renderWithHandle();
+
+    expect(() => {
+      act(() => {
+        handle.scrollToActivity("does-not-exist");
+      });
+    }).not.toThrow();
+    expect(scrollIntoView).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/domains/chat/transcript/transcript.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript.tsx
@@ -133,6 +133,9 @@ export interface TranscriptProps {
 
 export interface TranscriptHandle {
   scrollToLatest(opts?: { behavior?: "auto" | "smooth" }): void;
+  /** Scroll the element carrying a matching `data-activity-anchor` into
+   *  view and flash a transient highlight. Safe no-op for missing anchors. */
+  scrollToActivity(anchorId: string): void;
   getScrollElement(): HTMLDivElement | null;
   /** Inner wrapper that surrounds all rendered children. Sized to the
    *  scroll content; observable via `ResizeObserver` to detect when
@@ -178,6 +181,21 @@ export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(
 
     const partition = useMemo(() => partitionLatestTurn(items), [items]);
 
+    const scrollToActivity = useCallback((anchorId: string) => {
+      const root = scrollRef.current;
+      if (!root) return;
+      const el = root.querySelector<HTMLElement>(
+        `[data-activity-anchor="${CSS.escape(anchorId)}"]`,
+      );
+      if (!el) return;
+      el.scrollIntoView({ behavior: "smooth", block: "start" });
+      el.setAttribute("data-activity-highlight", "true");
+      window.setTimeout(
+        () => el.removeAttribute("data-activity-highlight"),
+        1600,
+      );
+    }, []);
+
     useImperativeHandle(
       ref,
       (): TranscriptHandle => ({
@@ -189,6 +207,7 @@ export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(
             behavior: opts?.behavior ?? "auto",
           });
         },
+        scrollToActivity,
         getScrollElement() {
           return scrollRef.current;
         },
@@ -220,7 +239,7 @@ export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(
           };
         },
       }),
-      [rest.scrollCoordinatorState],
+      [rest.scrollCoordinatorState, scrollToActivity],
     );
 
     const rowProps = {

--- a/apps/web/src/domains/chat/transcript/transcript.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript.tsx
@@ -188,7 +188,14 @@ export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(
         `[data-activity-anchor="${CSS.escape(anchorId)}"]`,
       );
       if (!el) return;
-      el.scrollIntoView({ behavior: "smooth", block: "start" });
+      const prefersReduced =
+        typeof window !== "undefined" &&
+        typeof window.matchMedia === "function" &&
+        window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+      el.scrollIntoView({
+        behavior: prefersReduced ? "auto" : "smooth",
+        block: "start",
+      });
       el.setAttribute("data-activity-highlight", "true");
       window.setTimeout(
         () => el.removeAttribute("data-activity-highlight"),

--- a/apps/web/src/domains/chat/transcript/use-transcript-scroll.test.ts
+++ b/apps/web/src/domains/chat/transcript/use-transcript-scroll.test.ts
@@ -110,6 +110,7 @@ function makeHandle(): TranscriptHandle & {
   }));
   return {
     scrollToLatest,
+    scrollToActivity: mock((_anchorId: string) => {}),
     getScrollElement,
     getContentElement,
     getViewportHeight,

--- a/apps/web/src/domains/chat/utils/debug-api.test.ts
+++ b/apps/web/src/domains/chat/utils/debug-api.test.ts
@@ -828,6 +828,7 @@ function makeTranscriptHandle(
 ): TranscriptHandle {
   return {
     scrollToLatest: () => {},
+    scrollToActivity: () => {},
     getScrollElement: () => scrollEl,
     getContentElement: () => null,
     getViewportHeight: () => scrollEl?.clientHeight ?? 0,

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -251,3 +251,15 @@ body {
     opacity: 0.7 !important;
   }
 }
+
+@keyframes activity-anchor-flash {
+  0%   { box-shadow: 0 0 0 2px var(--system-info-strong, #4c8bf5); }
+  100% { box-shadow: 0 0 0 2px transparent; }
+}
+[data-activity-highlight="true"] {
+  border-radius: var(--radius-lg);
+  animation: activity-anchor-flash 1.6s ease-out;
+}
+@media (prefers-reduced-motion: reduce) {
+  [data-activity-highlight="true"] { animation: none; }
+}


### PR DESCRIPTION
## Summary
- Add `scrollToActivity(anchorId)` to `TranscriptHandle`: scrolls to the element with a matching `data-activity-anchor` and flashes a transient highlight (respects prefers-reduced-motion).
- Add highlight keyframes to index.css.

Part of plan: web-activity-summary.md (PR 4 of 7)