### PR TITLE
feat(web): add opt-in fullscreen mode to app viewer container

### DIFF
--- a/apps/web/src/components/app-viewer-container.test.tsx
+++ b/apps/web/src/components/app-viewer-container.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * Tests for `AppViewerContainer` fullscreen mode.
+ *
+ * We mount via `@testing-library/react` (backed by happy-dom — see
+ * `apps/web/test-setup.ts`). The sandbox fetch-proxy hook and the bridge
+ * injection are mocked to no-ops so the iframe renders without browser-only
+ * plumbing.
+ *
+ * Buttons are located by their lucide glyph class (e.g. `svg.lucide-maximize2`,
+ * `svg.lucide-x`) rather than by accessible name, because the design-library
+ * `Button` only exposes its tooltip text via a Radix tooltip while open.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
+
+mock.module("@/hooks/use-sandbox-fetch-proxy", () => ({
+  useSandboxFetchProxy: () => {},
+}));
+
+mock.module("@/utils/sandbox-bridge", () => ({
+  injectBridge: (html: string) => html,
+}));
+
+import { AppViewerContainer } from "@/components/app-viewer-container";
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderViewer(props?: { enableFullscreen?: boolean; appId?: string }) {
+  return render(
+    <AppViewerContainer
+      appId={props?.appId ?? "app-1"}
+      appName="My App"
+      html="<html><body>hi</body></html>"
+      assistantId="assistant-1"
+      onClose={() => {}}
+      enableFullscreen={props?.enableFullscreen}
+    />,
+  );
+}
+
+function getMaximizeButton(): HTMLButtonElement | null {
+  return document.querySelector("svg.lucide-maximize2")?.closest("button") ?? null;
+}
+
+function getFloatingExitButton(): HTMLButtonElement | null {
+  // The floating exit button lives inside the `absolute right-3 top-3`
+  // container; scope to that so we don't match the nav-bar close (X) button.
+  const container = document.querySelector(".absolute.right-3.top-3");
+  return container?.querySelector("svg.lucide-x")?.closest("button") ?? null;
+}
+
+function getRoot(): HTMLElement {
+  return document.querySelector("[data-testid='app-viewer-root']") as HTMLElement;
+}
+
+describe("AppViewerContainer fullscreen", () => {
+  test("toggles into fullscreen, hiding the nav bar and showing a floating exit", () => {
+    renderViewer({ enableFullscreen: true });
+
+    const maximize = getMaximizeButton();
+    expect(maximize).not.toBeNull();
+    expect(getRoot().classList.contains("rounded-xl")).toBe(true);
+    expect(getFloatingExitButton()).toBeNull();
+
+    fireEvent.click(maximize as HTMLButtonElement);
+
+    const root = getRoot();
+    expect(root.classList.contains("fixed")).toBe(true);
+    expect(root.classList.contains("inset-0")).toBe(true);
+    expect(getMaximizeButton()).toBeNull();
+    expect(getFloatingExitButton()).not.toBeNull();
+  });
+
+  test("the floating exit button restores the framed nav-bar view", () => {
+    renderViewer({ enableFullscreen: true });
+
+    fireEvent.click(getMaximizeButton() as HTMLButtonElement);
+    expect(getMaximizeButton()).toBeNull();
+
+    fireEvent.click(getFloatingExitButton() as HTMLButtonElement);
+
+    expect(getMaximizeButton()).not.toBeNull();
+    expect(getRoot().classList.contains("rounded-xl")).toBe(true);
+    expect(getRoot().classList.contains("fixed")).toBe(false);
+  });
+
+  test("Escape exits fullscreen", () => {
+    renderViewer({ enableFullscreen: true });
+
+    fireEvent.click(getMaximizeButton() as HTMLButtonElement);
+    expect(getRoot().classList.contains("fixed")).toBe(true);
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    });
+
+    expect(getRoot().classList.contains("fixed")).toBe(false);
+    expect(getMaximizeButton()).not.toBeNull();
+  });
+
+  test("without enableFullscreen there is no fullscreen button and the root stays framed", () => {
+    renderViewer();
+
+    expect(getMaximizeButton()).toBeNull();
+    expect(getRoot().classList.contains("rounded-xl")).toBe(true);
+    expect(getRoot().classList.contains("fixed")).toBe(false);
+  });
+});

--- a/apps/web/src/components/app-viewer-container.tsx
+++ b/apps/web/src/components/app-viewer-container.tsx
@@ -1,8 +1,12 @@
-import { useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
+import { X } from "lucide-react";
+
+import { Button } from "@vellum/design-library";
 import { AppNavBar } from "@/components/app-nav-bar";
 import { useSandboxFetchProxy } from "@/hooks/use-sandbox-fetch-proxy";
 import { injectBridge } from "@/utils/sandbox-bridge";
+import { cn } from "@/utils/misc";
 
 export interface AppViewerContainerProps {
   appId: string;
@@ -19,6 +23,8 @@ export interface AppViewerContainerProps {
   isDeploying?: boolean;
   /** Deep-link route passed to the app as `window.vellum.route`. */
   route?: string;
+  /** Enables the fullscreen toggle (nav-bar button + fullscreen rendering). Default false. */
+  enableFullscreen?: boolean;
 }
 
 export function AppViewerContainer({
@@ -34,8 +40,27 @@ export function AppViewerContainer({
   onDeploy,
   isDeploying,
   route,
+  enableFullscreen = false,
 }: AppViewerContainerProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
+
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  const toggleFullscreen = useCallback(() => setIsFullscreen((v) => !v), []);
+
+  // Reset fullscreen when the rendered app changes.
+  useEffect(() => {
+    setIsFullscreen(false);
+  }, [appId]);
+
+  // Escape-to-exit handler, active only while fullscreen.
+  useEffect(() => {
+    if (!isFullscreen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setIsFullscreen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [isFullscreen]);
 
   const srcdoc = useMemo(
     () => injectBridge(html, appId, { fetch: true, route }),
@@ -56,19 +81,38 @@ export function AppViewerContainer({
   });
 
   return (
-    <div className="flex h-full flex-col overflow-hidden rounded-xl bg-[var(--surface-base)]">
-      <AppNavBar
-        appName={appName}
-        onEdit={onEdit}
-        isEditing={isEditing}
-        onShare={onShare}
-        isSharing={isSharing}
-        onDeploy={onDeploy}
-        isDeploying={isDeploying}
-        onClose={onClose}
-      />
+    <div
+      data-testid="app-viewer-root"
+      className={cn(
+        "flex flex-col overflow-hidden bg-[var(--surface-base)]",
+        isFullscreen ? "fixed inset-0 z-[60]" : "h-full rounded-xl",
+      )}
+    >
+      {!isFullscreen && (
+        <AppNavBar
+          appName={appName}
+          onEdit={onEdit}
+          isEditing={isEditing}
+          onShare={onShare}
+          isSharing={isSharing}
+          onDeploy={onDeploy}
+          isDeploying={isDeploying}
+          onToggleFullscreen={enableFullscreen ? toggleFullscreen : undefined}
+          onClose={onClose}
+        />
+      )}
 
       <div className="relative min-h-0 flex-1">
+        {isFullscreen && (
+          <div className="absolute right-3 top-3 z-10">
+            <Button
+              variant="outlined"
+              iconOnly={<X />}
+              onClick={toggleFullscreen}
+              tooltip="Exit fullscreen"
+            />
+          </div>
+        )}
         <iframe
           ref={iframeRef}
           key={iframeKey}


### PR DESCRIPTION
## Summary
- Add an opt-in enableFullscreen prop to AppViewerContainer. When toggled on, the viewer root becomes fixed inset-0 z-[60] covering the whole window, the nav bar is hidden, and a single floating top-right X (plus Escape) exits fullscreen.
- The same iframe element stays mounted across toggles, preserving in-app state. Fullscreen resets when the opened app changes.
- Add colocated app-viewer-container.test.tsx.

Part of plan: library-app-fullscreen.md (PR 2 of 3)