### PR TITLE
fix(web): align Vellum filter icon with origin badge (Box)

### DIFF
--- a/apps/web/src/domains/intelligence/components/skills/skill-filters.tsx
+++ b/apps/web/src/domains/intelligence/components/skills/skill-filters.tsx
@@ -1,11 +1,11 @@
 import {
   ArrowDownToLine,
+  Box,
   CheckCircle,
   Filter,
   Globe,
   LayoutGrid,
   Loader2,
-  Package,
   Search,
   Terminal,
   User,
@@ -35,7 +35,7 @@ const STATUS_FILTERS: FilterOption[] = [
 ];
 
 const ORIGIN_FILTERS: FilterOption[] = [
-  { value: "vellum", label: "Vellum", icon: Package },
+  { value: "vellum", label: "Vellum", icon: Box },
   { value: "clawhub", label: "Clawhub", icon: Globe },
   { value: "skillssh", label: "skills.sh", icon: Terminal },
   { value: "custom", label: "Custom", icon: User },


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for ios-skills-figma-mock.md.

**Gap:** Vellum origin icon drift between row badge and filter dropdown
**What was expected:** consistent Vellum glyph (Box) across Skills UI
**What was found:** ORIGIN_FILTERS still used Package while the badge used Box