### PR TITLE
fix(web): match iOS Skills page to Figma mock

### DIFF
--- a/apps/web/src/domains/intelligence/components/skills/skill-filters.tsx
+++ b/apps/web/src/domains/intelligence/components/skills/skill-filters.tsx
@@ -1,7 +1,7 @@
 import {
   ArrowDownToLine,
   CheckCircle,
-  ChevronDown,
+  Filter,
   Globe,
   LayoutGrid,
   Loader2,
@@ -17,10 +17,7 @@ import {
   useState,
 } from "react";
 
-import { Input, Popover } from "@vellum/design-library";
-import {
-  MobileSidebarTrigger,
-} from "@/components/mobile-sidebar-drawer";
+import { Button, Input, Popover } from "@vellum/design-library";
 import type { SkillFilter } from "@/domains/intelligence/skills/types";
 
 interface FilterOption {
@@ -44,15 +41,12 @@ const ORIGIN_FILTERS: FilterOption[] = [
   { value: "custom", label: "Custom", icon: User },
 ];
 
-const FILTERS: FilterOption[] = [...STATUS_FILTERS, ...ORIGIN_FILTERS];
-
 interface FilterBarProps {
   search: string;
   onSearchChange: Dispatch<SetStateAction<string>>;
   filter: SkillFilter;
   onFilterChange: (f: SkillFilter) => void;
   isSearching: boolean;
-  onOpenDrawer: () => void;
 }
 
 export function FilterBar({
@@ -61,7 +55,6 @@ export function FilterBar({
   filter,
   onFilterChange,
   isSearching,
-  onOpenDrawer,
 }: FilterBarProps) {
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     onSearchChange(e.target.value);
@@ -69,13 +62,12 @@ export function FilterBar({
 
   return (
     <div className="flex items-center gap-3">
-      <MobileSidebarTrigger onClick={onOpenDrawer} />
       <Input
         type="search"
         value={search}
         onChange={handleChange}
-        placeholder="Search Skills"
-        aria-label="Search Skills"
+        placeholder="Search skills"
+        aria-label="Search skills"
         leftIcon={<Search className="h-4 w-4" aria-hidden />}
         rightIcon={
           isSearching ? (
@@ -100,32 +92,18 @@ function FilterDropdown({
 }) {
   const [open, setOpen] = useState(false);
 
-  const current = FILTERS.find((f) => f.value === value) ?? ALL_FILTER;
-  const CurrentIcon = current.icon;
-
   return (
     <Popover.Root open={open} onOpenChange={setOpen}>
       <Popover.Trigger asChild>
-        <button
+        <Button
           type="button"
+          variant="outlined"
+          iconOnly={<Filter aria-hidden />}
+          aria-label="Filter skills"
           aria-haspopup="listbox"
           aria-expanded={open}
-          className="inline-flex w-40 items-center justify-between gap-2 rounded-lg border bg-[var(--surface-active)] px-3 py-2 text-body-medium-lighter transition-colors hover:bg-[var(--surface-hover)]"
-          style={{
-            borderColor: "var(--border-base)",
-            color: "var(--content-default)",
-          }}
-        >
-          <span className="flex items-center gap-2 truncate">
-            <CurrentIcon className="h-4 w-4" aria-hidden />
-            <span className="truncate">{current.label}</span>
-          </span>
-          <ChevronDown
-            className="h-4 w-4"
-            style={{ color: "var(--content-tertiary)" }}
-            aria-hidden
-          />
-        </button>
+          tintColor="var(--primary-base)"
+        />
       </Popover.Trigger>
       <Popover.Content
         align="end"

--- a/apps/web/src/domains/intelligence/components/skills/skill-filters.tsx
+++ b/apps/web/src/domains/intelligence/components/skills/skill-filters.tsx
@@ -1,11 +1,11 @@
 import {
   ArrowDownToLine,
+  Box,
   CheckCircle,
   Filter,
   Globe,
   LayoutGrid,
   Loader2,
-  Package,
   Search,
   Terminal,
   User,
@@ -35,7 +35,7 @@ const STATUS_FILTERS: FilterOption[] = [
 ];
 
 const ORIGIN_FILTERS: FilterOption[] = [
-  { value: "vellum", label: "Vellum", icon: Package },
+  { value: "vellum", label: "Vellum", icon: Box },
   { value: "clawhub", label: "Clawhub", icon: Globe },
   { value: "skillssh", label: "skills.sh", icon: Terminal },
   { value: "custom", label: "Custom", icon: User },

--- a/apps/web/src/domains/intelligence/components/skills/skill-filters.tsx
+++ b/apps/web/src/domains/intelligence/components/skills/skill-filters.tsx
@@ -1,6 +1,7 @@
 import {
   ArrowDownToLine,
   Box,
+  Check,
   CheckCircle,
   Filter,
   Globe,
@@ -13,12 +14,16 @@ import {
 import {
   type ChangeEvent,
   type Dispatch,
+  type ReactNode,
   type SetStateAction,
   useState,
 } from "react";
 
-import { Button, Input, Popover } from "@vellum/design-library";
+import { BottomSheet, Button, Input, PanelItem, Popover } from "@vellum/design-library";
+import { resolveCategoryIcon } from "@/domains/intelligence/skills/category-icon-map";
 import type { SkillFilter } from "@/domains/intelligence/skills/types";
+import type { CategoryInfo } from "@/domains/intelligence/skills/use-skill-categories";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 
 interface FilterOption {
   value: SkillFilter;
@@ -47,6 +52,17 @@ interface FilterBarProps {
   filter: SkillFilter;
   onFilterChange: (f: SkillFilter) => void;
   isSearching: boolean;
+  /** Available skill categories — surfaced inside the mobile filter sheet. */
+  categories: CategoryInfo[];
+  /** Currently selected category slug, or `null` for "All". */
+  category: string | null;
+  onCategoryChange: (category: string | null) => void;
+  /** Per-category result counts keyed by slug. */
+  counts: Record<string, number>;
+  /** Total result count across all categories (the "All" row badge). */
+  totalCount: number;
+  /** Hide counts while a search is in flight (they'd be stale mid-query). */
+  showCounts: boolean;
 }
 
 export function FilterBar({
@@ -55,6 +71,12 @@ export function FilterBar({
   filter,
   onFilterChange,
   isSearching,
+  categories,
+  category,
+  onCategoryChange,
+  counts,
+  totalCount,
+  showCounts,
 }: FilterBarProps) {
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     onSearchChange(e.target.value);
@@ -78,33 +100,63 @@ export function FilterBar({
         wrapperClassName="flex-1"
       />
 
-      <FilterDropdown value={filter} onChange={onFilterChange} />
+      <FilterControl
+        filter={filter}
+        onFilterChange={onFilterChange}
+        categories={categories}
+        category={category}
+        onCategoryChange={onCategoryChange}
+        counts={counts}
+        totalCount={totalCount}
+        showCounts={showCounts}
+      />
     </div>
   );
 }
 
-function FilterDropdown({
-  value,
-  onChange,
-}: {
-  value: SkillFilter;
-  onChange: (v: SkillFilter) => void;
-}) {
+interface FilterControlProps {
+  filter: SkillFilter;
+  onFilterChange: (v: SkillFilter) => void;
+  categories: CategoryInfo[];
+  category: string | null;
+  onCategoryChange: (category: string | null) => void;
+  counts: Record<string, number>;
+  totalCount: number;
+  showCounts: boolean;
+}
+
+/**
+ * Filter affordance for the Skills page. On mobile the outlined filter button
+ * opens a bottom sheet exposing Status, Source, AND Categories (the category
+ * sidebar is desktop-only, so the sheet is mobile's sole category surface). On
+ * desktop the same button opens a compact popover with Status + Source; the
+ * always-visible sidebar owns category selection there.
+ */
+function FilterControl(props: FilterControlProps) {
+  const isMobile = useIsMobile();
   const [open, setOpen] = useState(false);
+
+  const trigger = (
+    <Button
+      type="button"
+      variant="outlined"
+      iconOnly={<Filter aria-hidden />}
+      aria-label="Filter skills"
+      aria-haspopup={isMobile ? "dialog" : "listbox"}
+      aria-expanded={open}
+      tintColor="var(--primary-base)"
+    />
+  );
+
+  if (isMobile) {
+    return (
+      <FilterSheet {...props} open={open} onOpenChange={setOpen} trigger={trigger} />
+    );
+  }
 
   return (
     <Popover.Root open={open} onOpenChange={setOpen}>
-      <Popover.Trigger asChild>
-        <Button
-          type="button"
-          variant="outlined"
-          iconOnly={<Filter aria-hidden />}
-          aria-label="Filter skills"
-          aria-haspopup="listbox"
-          aria-expanded={open}
-          tintColor="var(--primary-base)"
-        />
-      </Popover.Trigger>
+      <Popover.Trigger asChild>{trigger}</Popover.Trigger>
       <Popover.Content
         align="end"
         sideOffset={4}
@@ -114,9 +166,9 @@ function FilterDropdown({
           <FilterGroup
             label="Status"
             options={STATUS_FILTERS}
-            selected={value}
+            selected={props.filter}
             onSelect={(v) => {
-              onChange(v);
+              props.onFilterChange(v);
               setOpen(false);
             }}
           />
@@ -127,15 +179,171 @@ function FilterDropdown({
           <FilterGroup
             label="Source"
             options={ORIGIN_FILTERS}
-            selected={value}
+            selected={props.filter}
             onSelect={(v) => {
-              onChange(v);
+              props.onFilterChange(v);
               setOpen(false);
             }}
           />
         </ul>
       </Popover.Content>
     </Popover.Root>
+  );
+}
+
+interface FilterSheetProps extends FilterControlProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  trigger: ReactNode;
+}
+
+/**
+ * Mobile bottom sheet. Status/Source and Categories are independent axes that
+ * both stay applied, so selecting a row updates the results live behind the
+ * sheet without closing it — the user dials in both, then taps Done (or
+ * outside) to dismiss.
+ */
+function FilterSheet({
+  filter,
+  onFilterChange,
+  categories,
+  category,
+  onCategoryChange,
+  counts,
+  totalCount,
+  showCounts,
+  open,
+  onOpenChange,
+  trigger,
+}: FilterSheetProps) {
+  const sortedCategories = [...categories].sort((a, b) =>
+    a.label.localeCompare(b.label),
+  );
+
+  return (
+    <BottomSheet.Root open={open} onOpenChange={onOpenChange}>
+      <BottomSheet.Trigger asChild>{trigger}</BottomSheet.Trigger>
+      <BottomSheet.Content className="max-h-[85dvh]" aria-describedby={undefined}>
+        <div
+          aria-hidden
+          className="mx-auto mb-3 h-1 w-9 shrink-0 rounded-full bg-[var(--border-element)]"
+        />
+        <BottomSheet.Header>
+          <BottomSheet.Title>Filters</BottomSheet.Title>
+        </BottomSheet.Header>
+        <BottomSheet.Body className="flex flex-col gap-3 pt-2">
+          <SheetSection label="Status">
+            {STATUS_FILTERS.map((option) => (
+              <FilterRow
+                key={option.value}
+                icon={option.icon}
+                label={option.label}
+                active={filter === option.value}
+                onSelect={() => onFilterChange(option.value)}
+              />
+            ))}
+          </SheetSection>
+
+          <SheetSection label="Source">
+            {ORIGIN_FILTERS.map((option) => (
+              <FilterRow
+                key={option.value}
+                icon={option.icon}
+                label={option.label}
+                active={filter === option.value}
+                onSelect={() => onFilterChange(option.value)}
+              />
+            ))}
+          </SheetSection>
+
+          <SheetSection label="Categories">
+            <FilterRow
+              icon={LayoutGrid}
+              label="All"
+              active={category === null}
+              badge={showCounts ? totalCount : undefined}
+              onSelect={() => onCategoryChange(null)}
+            />
+            {sortedCategories.map((cat) => (
+              <FilterRow
+                key={cat.slug}
+                icon={resolveCategoryIcon(cat.icon) ?? LayoutGrid}
+                label={cat.label}
+                active={category === cat.slug}
+                badge={showCounts ? (counts[cat.slug] ?? 0) : undefined}
+                onSelect={() => onCategoryChange(cat.slug)}
+              />
+            ))}
+          </SheetSection>
+        </BottomSheet.Body>
+        <BottomSheet.Footer>
+          <Button
+            type="button"
+            variant="primary"
+            fullWidth
+            onClick={() => onOpenChange(false)}
+          >
+            Done
+          </Button>
+        </BottomSheet.Footer>
+      </BottomSheet.Content>
+    </BottomSheet.Root>
+  );
+}
+
+/** Section grouping inside the mobile filter sheet. */
+function SheetSection({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <div>
+      <div
+        className="px-2 pb-1 text-body-small-default uppercase tracking-wide"
+        style={{ color: "var(--content-tertiary)" }}
+      >
+        {label}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+/**
+ * One selectable row inside the filter sheet. `badge` carries a result count
+ * (categories); the trailing check marks the active row on the count-less
+ * Status/Source axes where the branded highlight alone is easy to miss.
+ */
+function FilterRow({
+  icon,
+  label,
+  active,
+  badge,
+  onSelect,
+}: {
+  icon: typeof LayoutGrid;
+  label: string;
+  active: boolean;
+  badge?: ReactNode;
+  onSelect: () => void;
+}) {
+  return (
+    <PanelItem
+      icon={icon}
+      label={label}
+      active={active}
+      activeVariant="branded"
+      badge={badge}
+      trailingAction={
+        active && badge == null ? (
+          <Check className="h-4 w-4 text-[var(--primary-base)]" aria-hidden />
+        ) : undefined
+      }
+      onSelect={onSelect}
+    />
   );
 }
 

--- a/apps/web/src/domains/intelligence/components/skills/skill-origin-badge.tsx
+++ b/apps/web/src/domains/intelligence/components/skills/skill-origin-badge.tsx
@@ -1,11 +1,11 @@
-import { Globe, Package, Puzzle, Terminal, User } from "lucide-react";
+import { Box, Globe, Puzzle, Terminal, User } from "lucide-react";
 import { createElement } from "react";
 
 import { Tag } from "@vellum/design-library";
 import type { SkillOrigin } from "@/domains/intelligence/skills/types";
 
 const ORIGIN_META: Record<SkillOrigin, { label: string; icon: typeof Globe }> = {
-  vellum: { label: "Vellum", icon: Package },
+  vellum: { label: "Vellum", icon: Box },
   clawhub: { label: "Clawhub", icon: Globe },
   skillssh: { label: "skills.sh", icon: Terminal },
   custom: { label: "Custom", icon: User },

--- a/apps/web/src/domains/intelligence/components/skills/skill-row.test.tsx
+++ b/apps/web/src/domains/intelligence/components/skills/skill-row.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * Tests for `SkillRow` action controls.
+ *
+ * The row is a `role="button"` whose primary click fires `onSelect`. The
+ * trailing icon-only action button (remove for installed skills, install
+ * for catalog skills) must:
+ *   - expose the correct `aria-label`
+ *   - fire its own handler (`onRemove` / `onInstall`)
+ *   - NOT also bubble up to `onSelect` (stopPropagation)
+ *
+ * Mounted via `@testing-library/react` (happy-dom — see
+ * `apps/web/test-setup.ts`).
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import { SkillRow } from "@/domains/intelligence/components/skills/skill-row.js";
+import type { SkillInfo } from "@/domains/intelligence/skills/types.js";
+
+afterEach(() => {
+  cleanup();
+});
+
+function makeSkill(overrides: Partial<SkillInfo> = {}): SkillInfo {
+  return {
+    id: "skill-1",
+    name: "Test Skill",
+    description: "A skill used in tests",
+    emoji: "\u{1F9E9}",
+    kind: "installed",
+    status: "enabled",
+    origin: "custom",
+    category: "general",
+    ...overrides,
+  };
+}
+
+function getButton(label: string): HTMLButtonElement {
+  const match = document.querySelector<HTMLButtonElement>(
+    `button[aria-label="${label}"]`,
+  );
+  if (!match) {
+    throw new Error(`expected a button with aria-label="${label}"`);
+  }
+  return match;
+}
+
+describe("SkillRow", () => {
+  test("removable skill: trash control removes without selecting", () => {
+    const onSelect = mock(() => {});
+    const onRemove = mock(() => {});
+
+    render(
+      <SkillRow
+        skill={makeSkill({ kind: "installed" })}
+        onSelect={onSelect}
+        onRemove={onRemove}
+      />,
+    );
+
+    const remove = getButton("Remove skill");
+    fireEvent.click(remove);
+
+    expect(onRemove).toHaveBeenCalledTimes(1);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  test("catalog skill: install control installs without selecting", () => {
+    const onSelect = mock(() => {});
+    const onInstall = mock(() => {});
+
+    render(
+      <SkillRow
+        skill={makeSkill({ kind: "catalog", status: "available" })}
+        onSelect={onSelect}
+        onInstall={onInstall}
+      />,
+    );
+
+    const install = getButton("Install skill");
+    fireEvent.click(install);
+
+    expect(onInstall).toHaveBeenCalledTimes(1);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/domains/intelligence/components/skills/skill-row.tsx
+++ b/apps/web/src/domains/intelligence/components/skills/skill-row.tsx
@@ -44,16 +44,16 @@ export function SkillRow({
         tabIndex={0}
         onClick={onSelect}
         onKeyDown={handleRowKeyDown}
-        className="flex cursor-pointer items-center gap-4 px-5 py-4 text-left transition-colors hover:bg-[var(--surface-hover)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
+        className="flex cursor-pointer items-center gap-3 px-3 py-2 text-left transition-colors hover:bg-[var(--surface-hover)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
       >
-      <div className="flex h-10 w-10 shrink-0 items-center justify-center text-2xl">
+      <div className="flex shrink-0 items-center justify-center text-[28px] leading-none">
         <SkillIcon skill={skill} className="h-7 w-7" />
       </div>
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
           <span
             className="truncate text-body-medium-default"
-            style={{ color: "var(--content-default)" }}
+            style={{ color: "var(--content-emphasised)" }}
           >
             {skill.name}
           </span>
@@ -61,7 +61,7 @@ export function SkillRow({
         </div>
         <p
           className="mt-1 truncate text-body-medium-lighter"
-          style={{ color: "var(--content-secondary)" }}
+          style={{ color: "var(--content-tertiary)" }}
         >
           {skill.description}
         </p>
@@ -69,29 +69,37 @@ export function SkillRow({
 
       {available ? (
         isInstalling ? (
-          <div className="flex h-9 items-center px-3" aria-label="Installing">
-            <Loader2
-              className="h-4 w-4 animate-spin"
-              style={{ color: "var(--content-tertiary)" }}
-            />
-          </div>
+          <Button
+            type="button"
+            iconOnly={<Loader2 className="animate-spin" aria-hidden />}
+            disabled
+            aria-label="Installing"
+            expandOnMobile={false}
+          />
         ) : (
           <Button
             type="button"
+            iconOnly={<ArrowDownToLine aria-hidden />}
             onClick={(e) => {
               e.stopPropagation();
               onInstall?.();
             }}
             disabled={!onInstall}
-            leftIcon={<ArrowDownToLine aria-hidden />}
-          >
-            Install
-          </Button>
+            aria-label="Install skill"
+            expandOnMobile={false}
+          />
         )
       ) : (
         <Button
           type="button"
-          variant={removable ? "dangerOutline" : "outlined"}
+          variant="dangerOutline"
+          iconOnly={
+            isRemoving ? (
+              <Loader2 className="animate-spin" aria-hidden />
+            ) : (
+              <Trash2 aria-hidden />
+            )
+          }
           onClick={(e) => {
             e.stopPropagation();
             onRemove?.();
@@ -99,16 +107,8 @@ export function SkillRow({
           disabled={!removable || isRemoving || !onRemove}
           aria-label={removable ? "Remove skill" : "Bundled skill cannot be removed"}
           title={removable ? undefined : "Bundled skills cannot be removed"}
-          leftIcon={
-            isRemoving ? (
-              <Loader2 className="animate-spin" aria-hidden />
-            ) : (
-              <Trash2 aria-hidden />
-            )
-          }
-        >
-          Remove
-        </Button>
+          expandOnMobile={false}
+        />
       )}
       </div>
     </Card.Root>

--- a/apps/web/src/domains/intelligence/components/skills/skills-tab.tsx
+++ b/apps/web/src/domains/intelligence/components/skills/skills-tab.tsx
@@ -223,6 +223,12 @@ export function SkillsTab({ assistantId, initialSkillId }: SkillsTabProps) {
         filter={filter}
         onFilterChange={setFilter}
         isSearching={isSearching}
+        categories={categories}
+        category={category}
+        onCategoryChange={setCategory}
+        counts={counts}
+        totalCount={totalCount}
+        showCounts={!isSearching}
       />
 
       <div className="flex min-h-0 flex-1 gap-6">

--- a/apps/web/src/domains/intelligence/components/skills/skills-tab.tsx
+++ b/apps/web/src/domains/intelligence/components/skills/skills-tab.tsx
@@ -19,9 +19,6 @@ import { useCallback, useMemo, useState } from "react";
 import { Button, Card, ConfirmDialog } from "@vellum/design-library";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import { getLocalBool, setLocalBool } from "@/utils/local-settings";
-import {
-  MobileSidebarDrawer,
-} from "@/components/mobile-sidebar-drawer";
 import { CategorySidebar } from "@/domains/intelligence/components/skills/category-sidebar";
 import { FilterBar } from "@/domains/intelligence/components/skills/skill-filters";
 import { SkillDetail } from "@/domains/intelligence/components/skills/skill-detail";
@@ -65,7 +62,6 @@ export function SkillsTab({ assistantId, initialSkillId }: SkillsTabProps) {
   const [installingSkillId, setInstallingSkillId] = useState<string | null>(null);
   const [removingSkillId, setRemovingSkillId] = useState<string | null>(null);
   const [skillPendingRemoval, setSkillPendingRemoval] = useState<SkillInfo | null>(null);
-  const [drawerOpen, setDrawerOpen] = useState(false);
   const [tipDismissed, setTipDismissed] = useState(() =>
     getLocalBool(TIP_STORAGE_KEY, false),
   );
@@ -227,7 +223,6 @@ export function SkillsTab({ assistantId, initialSkillId }: SkillsTabProps) {
         filter={filter}
         onFilterChange={setFilter}
         isSearching={isSearching}
-        onOpenDrawer={() => setDrawerOpen(true)}
       />
 
       <div className="flex min-h-0 flex-1 gap-6">
@@ -241,24 +236,6 @@ export function SkillsTab({ assistantId, initialSkillId }: SkillsTabProps) {
             categories={categories}
           />
         </aside>
-
-        <MobileSidebarDrawer
-          open={drawerOpen}
-          onClose={() => setDrawerOpen(false)}
-          title="Categories"
-        >
-          <CategorySidebar
-            selected={category}
-            onSelect={(c) => {
-              setCategory(c);
-              setDrawerOpen(false);
-            }}
-            counts={counts}
-            totalCount={totalCount}
-            showCounts={!isSearching}
-            categories={categories}
-          />
-        </MobileSidebarDrawer>
 
         <div className="min-w-0 flex-1 overflow-y-auto">
           {skillsQuery.isLoading ? (

--- a/apps/web/src/domains/intelligence/components/skills/skills-tab.tsx
+++ b/apps/web/src/domains/intelligence/components/skills/skills-tab.tsx
@@ -317,11 +317,10 @@ function useDerivedCounts(
 function TipBanner({ onDismiss }: { onDismiss: () => void }) {
   return (
     <div
-      className="flex items-center gap-2 rounded-lg border px-4 py-2.5 text-body-medium-lighter"
+      className="flex items-center gap-2 rounded-lg px-4 py-2.5 text-body-small-default"
       style={{
-        borderColor: "color-mix(in oklab, var(--primary-base) 25%, transparent)",
-        backgroundColor: "color-mix(in oklab, var(--primary-base) 8%, transparent)",
-        color: "var(--content-default)",
+        backgroundColor: "var(--surface-base)",
+        color: "var(--content-secondary)",
       }}
     >
       <Sparkles
@@ -329,8 +328,7 @@ function TipBanner({ onDismiss }: { onDismiss: () => void }) {
         style={{ color: "var(--primary-base)" }}
       />
       <p className="flex-1">
-        <span className="text-body-medium-default">Tip:</span> You can create a new custom
-        skill by describing what you want in chat.
+        You can create a new custom skill by describing what you want in chat.
       </p>
       <Button
         type="button"
@@ -340,6 +338,7 @@ function TipBanner({ onDismiss }: { onDismiss: () => void }) {
         onClick={onDismiss}
         aria-label="Dismiss tip"
         tintColor="var(--content-tertiary)"
+        expandOnMobile={false}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
Brings the Skills page (rendered on iOS via the Capacitor webview over `apps/web`) into visual alignment with the Figma mock (node 4502:121045): denser white skill rows with emphasised titles and an icon-only outlined trash button, a box-glyph origin tag, a flat borderless neutral tip banner, and a simplified filter row (search + a single outlined icon-only filter button).

## Self-review result
PASS — 1 gap found and fixed across 1 fix PR (Vellum origin icon drift between the row badge and the filter dropdown).

## PRs merged into feature branch
- #33297: fix(web): match Skills row layout to iOS Figma mock
- #33295: fix(web): use box glyph for Skills origin tag
- #33296: fix(web): restyle Skills tip banner to neutral surface
- #33304: fix(web): outlined filter button + simplified Skills filter row

### Fix PRs
- #33308: fix(web): align Vellum filter icon with origin badge (Box)

## Note
PR #33304 intentionally removes the mobile category drawer per the mock and explicit design direction; the desktop category sidebar is retained. Codex flagged this as P2 — resolved as an accepted trade-off.

Part of plan: ios-skills-figma-mock.md