### PR TITLE
feat(web): TurnProgressCard combined carousel card with step pills

### DIFF
--- a/apps/web/src/domains/chat/components/turn-progress-card/turn-progress-card.test.tsx
+++ b/apps/web/src/domains/chat/components/turn-progress-card/turn-progress-card.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * Tests for `TurnProgressCard`.
+ *
+ * Uses `@testing-library/react` + `bun:test` (matching the interactive web
+ * tests, e.g. `tool-step-pill.test.tsx`). The expanded body renders the step
+ * pills, so the pill-oriented tests pass `defaultExpanded` to surface them.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import { TurnProgressCard } from "@/domains/chat/components/turn-progress-card/turn-progress-card";
+import type {
+  ActivityStep,
+  TurnActivity,
+} from "@/domains/chat/transcript/turn-activity";
+
+afterEach(() => {
+  cleanup();
+});
+
+function step(overrides: Partial<ActivityStep> = {}): ActivityStep {
+  return {
+    anchorId: "anchor-1",
+    kind: "tool",
+    title: "Working (bash)",
+    info: "bun test",
+    state: "complete",
+    iconName: "code",
+    ...overrides,
+  };
+}
+
+function activity(overrides: Partial<TurnActivity> = {}): TurnActivity {
+  const steps = overrides.steps ?? [step()];
+  const last = steps[steps.length - 1];
+  return {
+    steps,
+    currentStepTitle: last?.title ?? "",
+    currentStepInfo: last?.info ?? "",
+    state: "complete",
+    stepCount: steps.length,
+    ...overrides,
+  };
+}
+
+describe("TurnProgressCard", () => {
+  test("renders null for zero steps", () => {
+    const { container } = render(
+      <TurnProgressCard
+        activity={activity({ steps: [], stepCount: 0 })}
+        onStepClick={() => {}}
+      />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  test("renders one pill per step with the step titles", () => {
+    const steps = [
+      step({ anchorId: "a", title: "Thought process", kind: "thinking" }),
+      step({ anchorId: "b", title: "Working (bash)" }),
+      step({ anchorId: "c", title: "Editing", iconName: "pen" }),
+    ];
+    const { getAllByTestId } = render(
+      <TurnProgressCard
+        activity={activity({ steps })}
+        onStepClick={() => {}}
+        defaultExpanded
+      />,
+    );
+    const pills = getAllByTestId("turn-progress-pill");
+    expect(pills).toHaveLength(3);
+    expect(pills.map((p) => p.getAttribute("data-anchor-id"))).toEqual([
+      "a",
+      "b",
+      "c",
+    ]);
+    const text = pills.map((p) => p.textContent);
+    expect(text[0]).toContain("Thought process");
+    expect(text[1]).toContain("Working (bash)");
+    expect(text[2]).toContain("Editing");
+  });
+
+  test("clicking a pill emits onStepClick with that step's anchorId", () => {
+    const clicked: string[] = [];
+    const steps = [
+      step({ anchorId: "first", title: "Reading", iconName: "file" }),
+      step({ anchorId: "second", title: "Editing", iconName: "pen" }),
+    ];
+    const { getAllByTestId } = render(
+      <TurnProgressCard
+        activity={activity({ steps })}
+        onStepClick={(id) => clicked.push(id)}
+        defaultExpanded
+      />,
+    );
+    const pills = getAllByTestId("turn-progress-pill");
+    fireEvent.click(pills[1]!.querySelector("button")!);
+    expect(clicked).toEqual(["second"]);
+  });
+
+  test("header reflects currentStepTitle and shows the step-count pill", () => {
+    const steps = [
+      step({ anchorId: "a", title: "Reading" }),
+      step({ anchorId: "b", title: "Editing" }),
+    ];
+    const { getByTestId, container } = render(
+      <TurnProgressCard
+        activity={activity({
+          steps,
+          currentStepTitle: "Editing",
+          stepCount: 2,
+        })}
+        onStepClick={() => {}}
+      />,
+    );
+    expect(container.textContent).toContain("Editing");
+    expect(getByTestId("tool-progress-card-step-count-pill").textContent).toBe(
+      "2 steps",
+    );
+  });
+
+  test("loading state renders the status indicator", () => {
+    const { getByTestId } = render(
+      <TurnProgressCard
+        activity={activity({
+          steps: [step({ state: "loading" })],
+          state: "loading",
+        })}
+        onStepClick={() => {}}
+      />,
+    );
+    expect(
+      getByTestId("tool-progress-card-status-indicator"),
+    ).toBeDefined();
+  });
+
+  test("attachedBelow wraps the card to drop bottom rounding", () => {
+    const { container } = render(
+      <TurnProgressCard
+        activity={activity()}
+        onStepClick={() => {}}
+        attachedBelow
+      />,
+    );
+    expect(
+      container.querySelector(".\\[\\&\\>\\*\\]\\:rounded-b-none"),
+    ).not.toBeNull();
+  });
+});

--- a/apps/web/src/domains/chat/components/turn-progress-card/turn-progress-card.tsx
+++ b/apps/web/src/domains/chat/components/turn-progress-card/turn-progress-card.tsx
@@ -1,0 +1,108 @@
+/**
+ * Combined per-assistant-turn progress card.
+ *
+ * Reuses `ToolProgressCardShell` for the chrome — the leading status
+ * indicator, the animated carousel header (which "carousels" through steps as
+ * `currentStepTitle` / `currentStepInfo` change), and the "N steps" pill. The
+ * expanded body renders one `ToolStepPill` per `ActivityStep` in a wrapping
+ * flex row; clicking a pill emits `onStepClick(anchorId)` so a parent can
+ * scroll the transcript to that step's anchor.
+ *
+ * Purely presentational: no store, DOM, or scroll access. The `TurnActivity`
+ * projection is built upstream (PR 2's `turn-activity.ts`); PR 7 wires
+ * `onStepClick` to the transcript's `scrollToActivity` and sets `attachedBelow`
+ * when a task-progress surface is hoisted beneath the card.
+ */
+
+import { ToolProgressCardShell } from "@/domains/chat/components/tool-progress-card/tool-progress-card-shell";
+import { ToolStepPill } from "@/domains/chat/components/tool-progress-card/tool-step-pill";
+import type { IconName } from "@/domains/chat/components/tool-progress-card/derive-step-label";
+import type {
+  ActivityStep,
+  TurnActivity,
+} from "@/domains/chat/transcript/turn-activity";
+
+export interface TurnProgressCardProps {
+  activity: TurnActivity;
+  onStepClick: (anchorId: string) => void;
+  /** Whether the card starts expanded. Defaults to collapsed. */
+  defaultExpanded?: boolean;
+  /**
+   * When `true`, the card drops its bottom rounding so a surface rendered
+   * immediately below hugs it seamlessly.
+   */
+  attachedBelow?: boolean;
+}
+
+/**
+ * Pick the pill glyph for a step. Tool steps reuse the icon derived upstream
+ * (cast to the pill's `IconName` union); thinking steps use `sparkle` — the
+ * closest valid `IconName` to the brain/thinking glyph used conceptually by
+ * the ThinkingBlock. Falls back to `bolt` for any unrecognised value (the
+ * pill itself also defaults to `Bolt` when the name misses `ICON_MAP`).
+ */
+function stepIconName(step: ActivityStep): IconName {
+  if (step.kind === "thinking") return "sparkle";
+  return (step.iconName as IconName | undefined) ?? "bolt";
+}
+
+export function TurnProgressCard({
+  activity,
+  onStepClick,
+  defaultExpanded = false,
+  attachedBelow = false,
+}: TurnProgressCardProps) {
+  if (activity.steps.length === 0) {
+    return null;
+  }
+
+  const card = (
+    <ToolProgressCardShell
+      state={activity.state}
+      currentStepTitle={activity.currentStepTitle}
+      currentStepInfo={activity.currentStepInfo}
+      stepCount={`${activity.stepCount} step${
+        activity.stepCount === 1 ? "" : "s"
+      }`}
+      defaultExpanded={defaultExpanded}
+    >
+      <div className="flex flex-wrap gap-1.5 p-3">
+        {activity.steps.map((step) => {
+          const tone =
+            step.state === "error" || step.state === "denied"
+              ? "error"
+              : "default";
+          // `ToolStepPill` accepts only its declared primitive props (no
+          // arbitrary-prop forwarding), so the test hooks live on a wrapping
+          // span rather than the pill itself.
+          return (
+            <span
+              key={step.anchorId}
+              data-testid="turn-progress-pill"
+              data-anchor-id={step.anchorId}
+              className="contents"
+            >
+              <ToolStepPill
+                iconName={stepIconName(step)}
+                label={step.title}
+                tone={tone}
+                riskLevel={step.riskLevel}
+                onClick={() => onStepClick(step.anchorId)}
+              />
+            </span>
+          );
+        })}
+      </div>
+    </ToolProgressCardShell>
+  );
+
+  // `attachedBelow` drops the shell's bottom rounding so a hoisted surface
+  // below hugs it. The shell hardcodes `rounded-[var(--radius-lg)]` on its
+  // outer wrapper and exposes no radius prop, so we target its direct child
+  // with an arbitrary variant. `rounded-b-none` zeroes the bottom corners and,
+  // at equal specificity, wins by stylesheet order over the rounded-all rule.
+  if (attachedBelow) {
+    return <div className="[&>*]:rounded-b-none">{card}</div>;
+  }
+  return card;
+}


### PR DESCRIPTION
## Summary
- Add `TurnProgressCard`: reuses `ToolProgressCardShell` chrome (carousel header + N-steps pill) and renders one `ToolStepPill` per activity step in the expanded body; clicking a pill emits `onStepClick(anchorId)`.
- Returns null for zero steps; collapsed by default; `attachedBelow` drops bottom rounding.

Part of plan: web-activity-summary.md (PR 5 of 7)