### PR TITLE
feat(web): anchor inline thinking/tool cards for combined-card navigation

### DIFF
--- a/apps/web/src/domains/chat/transcript/transcript-message-body.test.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.test.tsx
@@ -1110,6 +1110,48 @@ describe("TranscriptMessageBody", () => {
     expect(renderedAnchorIds(container)).toEqual([]);
   });
 
+  test("legacy spawn-only turn renders no tool activity anchor (no empty wrapper)", () => {
+    // GIVEN a legacy turn (no tool entries in contentOrder) whose toolCalls are
+    // ALL subagent spawns. The tool card filters the spawns out and renders
+    // nothing, so the anchored flex wrapper must NOT render — otherwise it
+    // leaves a stray empty `gap-2` gap before the inline subagent cards/text.
+    const message: DisplayMessage = {
+      id: "m-legacy-spawn-only",
+      role: "assistant",
+      textSegments: ["the answer"],
+      contentOrder: [{ type: "text", id: "0" }],
+      toolCalls: [
+        {
+          id: "tc-spawn-1",
+          toolName: "subagent_spawn",
+          input: {},
+          status: "completed",
+        },
+        {
+          id: "tc-spawn-2",
+          toolName: "subagent_spawn",
+          input: {},
+          status: "completed",
+        },
+      ],
+      timestamp: 1_000,
+    };
+
+    const { container } = render(
+      <TranscriptMessageBody
+        message={message}
+        expandedToolCallIds={new Set()}
+        expandedCardIds={new Map()}
+        expandedThinkingKeys={new Map()}
+        onSurfaceAction={noop}
+      />,
+    );
+
+    // No tool step is projected, and no anchored tool wrapper is rendered.
+    expect(projectedAnchorIds(message)).toEqual([]);
+    expect(renderedAnchorIds(container)).toEqual([]);
+  });
+
   test("a suppressed ui_show group produces no activity anchor", () => {
     const message: DisplayMessage = {
       id: "m-ui-show",

--- a/apps/web/src/domains/chat/transcript/transcript-message-body.test.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.test.tsx
@@ -51,6 +51,7 @@ mock.module(
 import type { DisplayMessage } from "@/domains/chat/utils/reconcile";
 
 import { TranscriptMessageBody } from "@/domains/chat/transcript/transcript-message-body";
+import { buildTurnActivity } from "@/domains/chat/transcript/turn-activity";
 
 import { textBody } from "@/domains/chat/utils/message-test-helpers";
 const noop = () => {};
@@ -948,5 +949,146 @@ describe("TranscriptMessageBody", () => {
     // THEN both the thinking block and the tool-call card render
     expect(html).toContain("Thought process");
     expect(html).toContain('data-testid="tool-progress-card"');
+  });
+
+  function renderedAnchorIds(container: HTMLElement): string[] {
+    return Array.from(
+      container.querySelectorAll("[data-activity-anchor]"),
+    ).map((el) => el.getAttribute("data-activity-anchor")!);
+  }
+
+  function projectedAnchorIds(message: DisplayMessage): string[] {
+    return buildTurnActivity(message).steps.map((s) => s.anchorId);
+  }
+
+  test("interleaved render anchors exactly match buildTurnActivity step anchors", () => {
+    const message: DisplayMessage = {
+      id: "m-anchor-interleaved",
+      role: "assistant",
+      textSegments: ["done"],
+      thinkingSegments: ["why I called the tool", "more reasoning"],
+      contentOrder: [
+        { type: "thinking", id: "0" },
+        { type: "toolCall", id: "0" },
+        { type: "thinking", id: "1" },
+        { type: "toolCall", id: "1" },
+        { type: "text", id: "0" },
+      ],
+      toolCalls: [
+        { id: "tc-a", toolName: "bash", input: {}, status: "completed" },
+        { id: "tc-b", toolName: "bash", input: {}, status: "completed" },
+      ],
+      timestamp: 1_000,
+    };
+
+    const { container } = render(
+      <TranscriptMessageBody
+        message={message}
+        expandedToolCallIds={new Set()}
+        expandedCardIds={new Map()}
+        expandedThinkingKeys={new Map()}
+        onSurfaceAction={noop}
+      />,
+    );
+
+    const projected = projectedAnchorIds(message);
+    expect(projected.length).toBe(4);
+    // Interleaved DOM order matches projection order exactly.
+    expect(renderedAnchorIds(container)).toEqual(projected);
+  });
+
+  test("legacy render anchors exactly match buildTurnActivity step anchors", () => {
+    const message: DisplayMessage = {
+      id: "m-anchor-legacy",
+      role: "assistant",
+      textSegments: ["the answer"],
+      thinkingSegments: ["chain of thought"],
+      contentOrder: [{ type: "thinking", id: "0" }],
+      toolCalls: [
+        { id: "tc-legacy", toolName: "bash", input: {}, status: "completed" },
+      ],
+      timestamp: 1_000,
+    };
+
+    const { container } = render(
+      <TranscriptMessageBody
+        message={message}
+        expandedToolCallIds={new Set()}
+        expandedCardIds={new Map()}
+        expandedThinkingKeys={new Map()}
+        onSurfaceAction={noop}
+      />,
+    );
+
+    const projected = projectedAnchorIds(message);
+    expect(projected.length).toBe(2);
+    // The legacy DOM renders the trailing tool card above the reasoning block,
+    // while the projection lists thinking first then the trailing tool step —
+    // so the anchor *ids* are byte-identical but emitted in a different order.
+    // Compare as sets to assert the critical render-id === projection-id match.
+    expect(new Set(renderedAnchorIds(container))).toEqual(new Set(projected));
+  });
+
+  test("a subagent-spawn-only group produces no activity anchor", () => {
+    const message: DisplayMessage = {
+      id: "m-spawn-only",
+      role: "assistant",
+      textSegments: ["spawning"],
+      contentOrder: [
+        { type: "toolCall", id: "0" },
+        { type: "text", id: "0" },
+      ],
+      toolCalls: [
+        {
+          id: "tc-spawn",
+          toolName: "subagent_spawn",
+          input: {},
+          status: "completed",
+        },
+      ],
+      timestamp: 1_000,
+    };
+
+    const { container } = render(
+      <TranscriptMessageBody
+        message={message}
+        expandedToolCallIds={new Set()}
+        expandedCardIds={new Map()}
+        expandedThinkingKeys={new Map()}
+        onSurfaceAction={noop}
+      />,
+    );
+
+    expect(projectedAnchorIds(message)).toEqual([]);
+    expect(renderedAnchorIds(container)).toEqual([]);
+  });
+
+  test("a suppressed ui_show group produces no activity anchor", () => {
+    const message: DisplayMessage = {
+      id: "m-ui-show",
+      role: "assistant",
+      textSegments: ["showing UI"],
+      contentOrder: [
+        { type: "toolCall", id: "0" },
+        { type: "text", id: "0" },
+      ],
+      toolCalls: [
+        { id: "tc-ui", toolName: "ui_show", input: {}, status: "completed" },
+      ],
+      timestamp: 1_000,
+    };
+
+    const { container } = render(
+      <TranscriptMessageBody
+        message={message}
+        expandedToolCallIds={new Set()}
+        expandedCardIds={new Map()}
+        expandedThinkingKeys={new Map()}
+        onSurfaceAction={noop}
+      />,
+    );
+
+    expect(projectedAnchorIds(message)).toEqual([]);
+    expect(renderedAnchorIds(container)).toEqual([]);
   });
 });

--- a/apps/web/src/domains/chat/transcript/transcript-message-body.test.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.test.tsx
@@ -1029,6 +1029,53 @@ describe("TranscriptMessageBody", () => {
     expect(new Set(renderedAnchorIds(container))).toEqual(new Set(projected));
   });
 
+  test("legacy [spawn, bash] anchors the tool card on the bash call, matching buildTurnActivity", () => {
+    // GIVEN a legacy turn whose FIRST tool call is a subagent spawn followed by
+    // a renderable bash call — `buildTurnActivity` anchors the legacy tool step
+    // on the first NON-spawn (renderable) call, so the rendered DOM anchor must
+    // resolve to the bash id, not the leading spawn id.
+    const message: DisplayMessage = {
+      id: "m-anchor-legacy-spawn",
+      role: "assistant",
+      textSegments: ["the answer"],
+      thinkingSegments: ["chain of thought"],
+      contentOrder: [{ type: "thinking", id: "0" }],
+      toolCalls: [
+        {
+          id: "tc-spawn",
+          toolName: "subagent_spawn",
+          input: {},
+          status: "completed",
+        },
+        { id: "tc-bash", toolName: "bash", input: {}, status: "completed" },
+      ],
+      timestamp: 1_000,
+    };
+
+    const { container } = render(
+      <TranscriptMessageBody
+        message={message}
+        expandedToolCallIds={new Set()}
+        expandedCardIds={new Map()}
+        expandedThinkingKeys={new Map()}
+        onSurfaceAction={noop}
+      />,
+    );
+
+    const projected = projectedAnchorIds(message);
+    // Two projected steps: the thinking block and the trailing tool step.
+    expect(projected.length).toBe(2);
+    // The trailing tool step anchors on the bash call's id (the first
+    // renderable, non-spawn call) — NOT the leading spawn.
+    const toolAnchor = projected.find((id) => id.includes("-tc-"));
+    expect(toolAnchor).toBe("activity-m-anchor-legacy-spawn-tc-tc-bash");
+
+    // Render anchors are byte-identical to the projection (legacy emits the
+    // trailing tool card above the reasoning block, so order differs; compare
+    // as a set to assert id equality).
+    expect(new Set(renderedAnchorIds(container))).toEqual(new Set(projected));
+  });
+
   test("a subagent-spawn-only group produces no activity anchor", () => {
     const message: DisplayMessage = {
       id: "m-spawn-only",

--- a/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -22,6 +22,7 @@ import {
   getLegacyLeadingThinkingText,
 } from "@/domains/chat/components/tool-progress-card/get-leading-thinking-text";
 import type { DisplayMessage } from "@/domains/chat/utils/reconcile";
+import { activityAnchorId } from "@/domains/chat/transcript/turn-activity";
 import { parseInlineSurfaces } from "@/domains/chat/utils/parse-inline-surfaces";
 import { segmentsToPlainText } from "@/domains/chat/utils/segments-to-plain-text";
 import {
@@ -702,31 +703,41 @@ export function TranscriptMessageBody({
               // are filtered out of its body) and would surface just the
               // leading-thinking preamble — redundant noise, since that text
               // already renders as its own message text group.
-              const hasRenderableToolCall = toolCalls.some(
+              const firstRenderableToolCall = toolCalls.find(
                 (tc) => !isSubagentSpawnCall(tc),
               );
+              const hasRenderableToolCall = firstRenderableToolCall != null;
               return (
                 <Fragment key={`tc-${gi}`}>
                   {hasRenderableToolCall && (
-                    <ToolCallProgressCard
-                      toolCalls={toolCalls}
-                      expandedToolCallIds={expandedToolCallIds}
-                      onExpandChange={handleExpandChange}
-                      expandedCardIds={expandedCardIds}
-                      autoExpand={shouldAutoExpandToolCallGroup({
-                        isCurrentGroup: gi === groups.length - 1,
-                        isStreaming,
-                        toolCalls,
-                      })}
-                      onOpenRuleEditor={onOpenRuleEditor}
-                      isSubmittingConfirmation={isSubmittingConfirmation}
-                      onConfirmationSubmit={onConfirmationSubmit}
-                      onAllowAndCreateRule={onAllowAndCreateRule}
-                      pendingConfirmationToolCallId={pendingConfirmationToolCallId}
-                      unknownNudgeToolCallIds={unknownNudgeToolCallIds}
-                      onDismissUnknownNudge={onDismissUnknownNudge}
-                      leadingThinkingText={getLeadingThinkingText(message, gi)}
-                    />
+                    <div
+                      className="w-full scroll-mt-24"
+                      data-activity-anchor={activityAnchorId(
+                        message.id,
+                        "tool",
+                        firstRenderableToolCall.id,
+                      )}
+                    >
+                      <ToolCallProgressCard
+                        toolCalls={toolCalls}
+                        expandedToolCallIds={expandedToolCallIds}
+                        onExpandChange={handleExpandChange}
+                        expandedCardIds={expandedCardIds}
+                        autoExpand={shouldAutoExpandToolCallGroup({
+                          isCurrentGroup: gi === groups.length - 1,
+                          isStreaming,
+                          toolCalls,
+                        })}
+                        onOpenRuleEditor={onOpenRuleEditor}
+                        isSubmittingConfirmation={isSubmittingConfirmation}
+                        onConfirmationSubmit={onConfirmationSubmit}
+                        onAllowAndCreateRule={onAllowAndCreateRule}
+                        pendingConfirmationToolCallId={pendingConfirmationToolCallId}
+                        unknownNudgeToolCallIds={unknownNudgeToolCallIds}
+                        onDismissUnknownNudge={onDismissUnknownNudge}
+                        leadingThinkingText={getLeadingThinkingText(message, gi)}
+                      />
+                    </div>
                   )}
                   {renderInlineSubagentCards(toolCalls)}
                 </Fragment>
@@ -738,13 +749,22 @@ export function TranscriptMessageBody({
                 return null;
               }
               return (
-                <ThinkingBlock
+                <div
                   key={`thinking-${gi}`}
-                  content={thinkingContent}
-                  isStreaming={isStreaming && gi === groups.length - 1}
-                  expansionKey={`${message.id}-th${group.ids[0] ?? "0"}`}
-                  expandedThinkingKeys={expandedThinkingKeys}
-                />
+                  className="w-full scroll-mt-24"
+                  data-activity-anchor={activityAnchorId(
+                    message.id,
+                    "thinking",
+                    group.ids[0] ?? "0",
+                  )}
+                >
+                  <ThinkingBlock
+                    content={thinkingContent}
+                    isStreaming={isStreaming && gi === groups.length - 1}
+                    expansionKey={`${message.id}-th${group.ids[0] ?? "0"}`}
+                    expandedThinkingKeys={expandedThinkingKeys}
+                  />
+                </div>
               );
             }
             if (group.type === "text") {
@@ -880,13 +900,22 @@ export function TranscriptMessageBody({
       contentEntries.push({
         type: "thinking",
         node: (
-          <ThinkingBlock
+          <div
             key={`thinking-${ids[0]}`}
-            content={thinkingContent}
-            isStreaming={isStreaming}
-            expansionKey={`${message.id}-th${ids[0]}`}
-            expandedThinkingKeys={expandedThinkingKeys}
-          />
+            className="w-full scroll-mt-24"
+            data-activity-anchor={activityAnchorId(
+              message.id,
+              "thinking",
+              ids[0]!,
+            )}
+          >
+            <ThinkingBlock
+              content={thinkingContent}
+              isStreaming={isStreaming}
+              expansionKey={`${message.id}-th${ids[0]}`}
+              expandedThinkingKeys={expandedThinkingKeys}
+            />
+          </div>
         ),
       });
     };
@@ -969,25 +998,34 @@ export function TranscriptMessageBody({
       >
         {legacyToolCalls.length > 0 && (
           <>
-            <ToolCallProgressCard
-              toolCalls={legacyToolCalls}
-              expandedToolCallIds={expandedToolCallIds}
-              onExpandChange={handleExpandChange}
-              expandedCardIds={expandedCardIds}
-              autoExpand={shouldAutoExpandToolCallGroup({
-                isCurrentGroup: !hasVisibleLegacyContent,
-                isStreaming,
-                toolCalls: legacyToolCalls,
-              })}
-              onOpenRuleEditor={onOpenRuleEditor}
-              isSubmittingConfirmation={isSubmittingConfirmation}
-              onConfirmationSubmit={onConfirmationSubmit}
-              onAllowAndCreateRule={onAllowAndCreateRule}
-              pendingConfirmationToolCallId={pendingConfirmationToolCallId}
-              unknownNudgeToolCallIds={unknownNudgeToolCallIds}
-              onDismissUnknownNudge={onDismissUnknownNudge}
-              leadingThinkingText={getLegacyLeadingThinkingText(message)}
-            />
+            <div
+              className="w-full scroll-mt-24"
+              data-activity-anchor={activityAnchorId(
+                message.id,
+                "tool",
+                legacyToolCalls[0]!.id,
+              )}
+            >
+              <ToolCallProgressCard
+                toolCalls={legacyToolCalls}
+                expandedToolCallIds={expandedToolCallIds}
+                onExpandChange={handleExpandChange}
+                expandedCardIds={expandedCardIds}
+                autoExpand={shouldAutoExpandToolCallGroup({
+                  isCurrentGroup: !hasVisibleLegacyContent,
+                  isStreaming,
+                  toolCalls: legacyToolCalls,
+                })}
+                onOpenRuleEditor={onOpenRuleEditor}
+                isSubmittingConfirmation={isSubmittingConfirmation}
+                onConfirmationSubmit={onConfirmationSubmit}
+                onAllowAndCreateRule={onAllowAndCreateRule}
+                pendingConfirmationToolCallId={pendingConfirmationToolCallId}
+                unknownNudgeToolCallIds={unknownNudgeToolCallIds}
+                onDismissUnknownNudge={onDismissUnknownNudge}
+                leadingThinkingText={getLegacyLeadingThinkingText(message)}
+              />
+            </div>
             {renderInlineSubagentCards(legacyToolCalls)}
           </>
         )}

--- a/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -1017,38 +1017,43 @@ export function TranscriptMessageBody({
       >
         {legacyToolCalls.length > 0 && (
           <>
-            <div
-              className="w-full scroll-mt-24"
-              data-activity-anchor={
-                firstRenderableLegacyToolCall
-                  ? activityAnchorId(
-                      message.id,
-                      "tool",
-                      firstRenderableLegacyToolCall.id,
-                    )
-                  : undefined
-              }
-            >
-              <ToolCallProgressCard
-                toolCalls={legacyToolCalls}
-                expandedToolCallIds={expandedToolCallIds}
-                onExpandChange={handleExpandChange}
-                expandedCardIds={expandedCardIds}
-                autoExpand={shouldAutoExpandToolCallGroup({
-                  isCurrentGroup: !hasVisibleLegacyContent,
-                  isStreaming,
-                  toolCalls: legacyToolCalls,
-                })}
-                onOpenRuleEditor={onOpenRuleEditor}
-                isSubmittingConfirmation={isSubmittingConfirmation}
-                onConfirmationSubmit={onConfirmationSubmit}
-                onAllowAndCreateRule={onAllowAndCreateRule}
-                pendingConfirmationToolCallId={pendingConfirmationToolCallId}
-                unknownNudgeToolCallIds={unknownNudgeToolCallIds}
-                onDismissUnknownNudge={onDismissUnknownNudge}
-                leadingThinkingText={getLegacyLeadingThinkingText(message)}
-              />
-            </div>
+            {/* Anchor the tool card only when a renderable (non-spawn) tool
+                call exists. A spawn-only legacy turn has no renderable step —
+                `ToolCallProgressCard` filters the spawns out and renders
+                nothing — so wrapping it in the anchored flex child would emit
+                a stray empty `gap-2` gap before the inline subagent cards.
+                Mirrors the interleaved branch, which only renders its wrapper
+                when a renderable tool call is present. */}
+            {firstRenderableLegacyToolCall && (
+              <div
+                className="w-full scroll-mt-24"
+                data-activity-anchor={activityAnchorId(
+                  message.id,
+                  "tool",
+                  firstRenderableLegacyToolCall.id,
+                )}
+              >
+                <ToolCallProgressCard
+                  toolCalls={legacyToolCalls}
+                  expandedToolCallIds={expandedToolCallIds}
+                  onExpandChange={handleExpandChange}
+                  expandedCardIds={expandedCardIds}
+                  autoExpand={shouldAutoExpandToolCallGroup({
+                    isCurrentGroup: !hasVisibleLegacyContent,
+                    isStreaming,
+                    toolCalls: legacyToolCalls,
+                  })}
+                  onOpenRuleEditor={onOpenRuleEditor}
+                  isSubmittingConfirmation={isSubmittingConfirmation}
+                  onConfirmationSubmit={onConfirmationSubmit}
+                  onAllowAndCreateRule={onAllowAndCreateRule}
+                  pendingConfirmationToolCallId={pendingConfirmationToolCallId}
+                  unknownNudgeToolCallIds={unknownNudgeToolCallIds}
+                  onDismissUnknownNudge={onDismissUnknownNudge}
+                  leadingThinkingText={getLegacyLeadingThinkingText(message)}
+                />
+              </div>
+            )}
             {renderInlineSubagentCards(legacyToolCalls)}
           </>
         )}

--- a/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -984,6 +984,15 @@ export function TranscriptMessageBody({
   }));
   const legacyToolCalls =
     message.toolCalls?.filter((tc) => !isSuppressedUiTool(tc)) ?? [];
+  // Anchor the legacy tool card on the FIRST renderable tool call — i.e. the
+  // first call that is not a subagent spawn (suppressed UI tools are already
+  // filtered out of `legacyToolCalls`). This mirrors `buildToolActivityStep`
+  // in turn-activity.ts exactly so the DOM anchor stays byte-identical to the
+  // projected step anchor. When every call is a spawn there is no renderable
+  // step (and `buildTurnActivity` emits none), so no anchor is rendered.
+  const firstRenderableLegacyToolCall = legacyToolCalls.find(
+    (tc) => !isSubagentSpawnCall(tc),
+  );
   const hasVisibleLegacyContent = contentElements.some((el) => !!el);
 
   return (
@@ -1000,11 +1009,15 @@ export function TranscriptMessageBody({
           <>
             <div
               className="w-full scroll-mt-24"
-              data-activity-anchor={activityAnchorId(
-                message.id,
-                "tool",
-                legacyToolCalls[0]!.id,
-              )}
+              data-activity-anchor={
+                firstRenderableLegacyToolCall
+                  ? activityAnchorId(
+                      message.id,
+                      "tool",
+                      firstRenderableLegacyToolCall.id,
+                    )
+                  : undefined
+              }
             >
               <ToolCallProgressCard
                 toolCalls={legacyToolCalls}


### PR DESCRIPTION
## Summary
- Wrap inline thinking blocks and tool-call cards with `data-activity-anchor` (from shared `activityAnchorId`) + scroll offset, in both interleaved and legacy render branches.
- Cross-check test: render anchors === `buildTurnActivity` step anchors.

Part of plan: web-activity-summary.md (PR 3 of 7)