### PR TITLE
fix(local-mode): parse both local and Docker hatch banners in `runHatch()`

### DIFF
--- a/apps/macos/src/main/local-mode.test.ts
+++ b/apps/macos/src/main/local-mode.test.ts
@@ -262,6 +262,18 @@ describe("vellum:localMode:hatch handler", () => {
     expect(result.error).toContain("ENOENT");
   });
 
+  test("parses the assistant id from a Docker hatch banner", async () => {
+    const pending = hatch("vellum");
+    await tick();
+    lastChild.stdout.emit(
+      "data",
+      Buffer.from("🥚 Hatching Docker assistant: asst-docker\n"),
+    );
+    lastChild.emit("close", 0);
+
+    expect(await pending).toEqual({ ok: true, assistantId: "asst-docker" });
+  });
+
   test("a zero exit whose stdout has no parseable id fails instead of returning a blank id", async () => {
     const pending = hatch("vellum");
     await tick();

--- a/packages/local-mode/src/__tests__/hatch.test.ts
+++ b/packages/local-mode/src/__tests__/hatch.test.ts
@@ -45,6 +45,21 @@ describe("runHatch", () => {
     expect(spawnArgs[0]).toEqual(["bun", ["run", "cli", "hatch", "vellum"]]);
   });
 
+  test("parses the assistant id from a Docker hatch banner", async () => {
+    const pending = runHatch(invocation, "vellum", { remote: "docker" });
+    lastChild.stdout.emit(
+      "data",
+      Buffer.from("🥚 Hatching Docker assistant: asst-docker\n"),
+    );
+    lastChild.emit("close", 0);
+
+    expect(await pending).toEqual({ ok: true, assistantId: "asst-docker" });
+    expect(spawnArgs[0]).toEqual([
+      "bun",
+      ["run", "cli", "hatch", "vellum", "--remote", "docker"],
+    ]);
+  });
+
   test("a non-zero exit resolves to a failure carrying the CLI's output", async () => {
     const pending = runHatch(invocation, "vellum");
     lastChild.stderr.emit("data", Buffer.from("daemon already running"));

--- a/packages/local-mode/src/hatch.ts
+++ b/packages/local-mode/src/hatch.ts
@@ -63,7 +63,7 @@ export function runHatch(
         return;
       }
       const assistantId = stdout
-        .match(/Hatching local assistant:\s+(.+)/)?.[1]
+        .match(/Hatching (?:local|Docker) assistant:\s+(.+)/)?.[1]
         ?.trim();
       if (!assistantId) {
         finish({


### PR DESCRIPTION
## Summary
Fixes P1 review feedback: `runHatch()` only matched 'Hatching local assistant:' but Docker hatch logs 'Hatching Docker assistant:', causing successful Docker hatches to report failure.

- Generalize regex to match both banner formats
- Update Docker remote test to emit the correct Docker banner string