### PR TITLE
feat(web): plumb combined-card flag and step-click callback to message body

### DIFF
--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -231,6 +231,7 @@ export function ChatRouteContent({
   const assistantState = useAssistantLifecycleStore.use.assistantState();
   const assistantName = useAssistantIdentityStore.use.name();
   const chatPullToRefreshEnabled = useClientFeatureFlagStore.use.chatPullToRefreshEnabled();
+  const activitySummaryEnabled = useClientFeatureFlagStore.use.webActivitySummary();
   const deployToVercel = useAssistantFeatureFlagStore.use.deployToVercel();
   const doctorEnabled = useClientFeatureFlagStore.use.doctor();
 
@@ -1220,6 +1221,7 @@ export function ChatRouteContent({
     },
     onSubagentClick,
     onStopSubagent,
+    activitySummaryEnabled,
     renderOnboardingChoice: () => (
       <OnboardingChoiceCard
         onSelectSpecific={handleSelectSpecific}

--- a/apps/web/src/domains/chat/transcript/latest-turn-row.tsx
+++ b/apps/web/src/domains/chat/transcript/latest-turn-row.tsx
@@ -66,6 +66,12 @@ export interface LatestTurnRowProps {
   onSubagentClick?: (subagentId: string) => void;
   /** Callback to abort/stop a running subagent from an inline card. */
   onStopSubagent?: (subagentId: string) => void;
+  /** Whether the combined per-turn activity-summary card is enabled. Forwarded
+   *  to the rendered `TranscriptRow`s. */
+  activitySummaryEnabled?: boolean;
+  /** Click handler for an activity-summary step pill — scrolls the matching
+   *  inline card into view. Forwarded to the rendered `TranscriptRow`s. */
+  onActivityStepClick?: (anchorId: string) => void;
 }
 
 export const LatestTurnRow = memo(function LatestTurnRow({
@@ -97,6 +103,8 @@ export const LatestTurnRow = memo(function LatestTurnRow({
   assistantId,
   onSubagentClick,
   onStopSubagent,
+  activitySummaryEnabled,
+  onActivityStepClick,
 }: LatestTurnRowProps) {
   // The response cluster is "streaming" whenever the turn is in flight. This
   // keeps each response message's last tool-call group expanded for the whole
@@ -134,6 +142,8 @@ export const LatestTurnRow = memo(function LatestTurnRow({
         assistantId={assistantId}
         onSubagentClick={onSubagentClick}
         onStopSubagent={onStopSubagent}
+        activitySummaryEnabled={activitySummaryEnabled}
+        onActivityStepClick={onActivityStepClick}
       />
       {responseItems.map((response) => (
         <Fragment key={response.key}>
@@ -165,6 +175,8 @@ export const LatestTurnRow = memo(function LatestTurnRow({
             assistantId={assistantId}
             onSubagentClick={onSubagentClick}
             onStopSubagent={onStopSubagent}
+            activitySummaryEnabled={activitySummaryEnabled}
+            onActivityStepClick={onActivityStepClick}
             isStreaming={isStreaming}
           />
         </Fragment>

--- a/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -108,6 +108,12 @@ export interface TranscriptMessageBodyProps {
   onSubagentClick?: (subagentId: string) => void;
   /** Callback to abort/stop a running subagent from an inline card. */
   onStopSubagent?: (subagentId: string) => void;
+  /** Whether the combined per-turn activity-summary card is enabled
+   *  (feature-flag gated). Gates the `TurnProgressCard` render. */
+  activitySummaryEnabled?: boolean;
+  /** Click handler for an activity-summary step pill — scrolls the matching
+   *  inline card into view. Backed by the transcript's `scrollToActivity`. */
+  onActivityStepClick?: (anchorId: string) => void;
   /**
    * True when this message belongs to the turn that is actively streaming.
    * Set by `LatestTurnRow` for the in-progress response cluster; history
@@ -345,6 +351,10 @@ export function TranscriptMessageBody({
   assistantId,
   onSubagentClick,
   onStopSubagent,
+  // Accepted but not yet read in render — the activity-summary card render
+  // path lands in a follow-up. Aliased to `_` so the unused props are explicit.
+  activitySummaryEnabled: _activitySummaryEnabled,
+  onActivityStepClick: _onActivityStepClick,
   isStreaming = false,
 }: TranscriptMessageBodyProps) {
   const hasInterleavedToolCalls = message.contentOrder?.some(

--- a/apps/web/src/domains/chat/transcript/transcript-row.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-row.tsx
@@ -73,6 +73,12 @@ export interface TranscriptRowProps {
   onSubagentClick?: (subagentId: string) => void;
   /** Callback to abort/stop a running subagent from an inline card. */
   onStopSubagent?: (subagentId: string) => void;
+  /** Whether the combined per-turn activity-summary card is enabled. Forwarded
+   *  to `TranscriptMessageBody`. */
+  activitySummaryEnabled?: boolean;
+  /** Click handler for an activity-summary step pill — scrolls the matching
+   *  inline card into view. Forwarded to `TranscriptMessageBody`. */
+  onActivityStepClick?: (anchorId: string) => void;
   /** True when this row belongs to the actively-streaming turn. Forwarded to
    *  `TranscriptMessageBody` so the streaming message's last tool-call group
    *  defaults open. History rows leave it `false`. */
@@ -107,6 +113,8 @@ export const TranscriptRow = memo(function TranscriptRow({
   assistantId,
   onSubagentClick,
   onStopSubagent,
+  activitySummaryEnabled,
+  onActivityStepClick,
   isStreaming,
 }: TranscriptRowProps) {
   switch (item.kind) {
@@ -133,6 +141,8 @@ export const TranscriptRow = memo(function TranscriptRow({
           assistantId={assistantId}
           onSubagentClick={onSubagentClick}
           onStopSubagent={onStopSubagent}
+          activitySummaryEnabled={activitySummaryEnabled}
+          onActivityStepClick={onActivityStepClick}
           isStreaming={isStreaming}
         />
       );

--- a/apps/web/src/domains/chat/transcript/transcript.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript.tsx
@@ -101,6 +101,10 @@ export interface TranscriptProps {
   onSubagentClick?: (subagentId: string) => void;
   /** Callback to abort/stop a running subagent from an inline card. */
   onStopSubagent?: (subagentId: string) => void;
+  /** Whether the combined per-turn activity-summary card is enabled
+   *  (feature-flag gated). Threaded down to `TranscriptMessageBody`, which
+   *  gates the `TurnProgressCard` render on it. */
+  activitySummaryEnabled?: boolean;
   /** Optional render-prop that produces the chat avatar element to mount
    *  at the bottom of the conversation. Rendered inside the latest-edge
    *  region so the avatar pins to the bottom of the viewport while the
@@ -276,6 +280,8 @@ export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(
       assistantId: rest.assistantId,
       onSubagentClick: rest.onSubagentClick,
       onStopSubagent: rest.onStopSubagent,
+      activitySummaryEnabled: rest.activitySummaryEnabled,
+      onActivityStepClick: scrollToActivity,
     };
 
     return (


### PR DESCRIPTION
## Summary
- Thread `activitySummaryEnabled` (from the `web-activity-summary` flag) and an `onActivityStepClick` callback (backed by the transcript's `scrollToActivity`) from Transcript through the row components to TranscriptMessageBody.
- Additive plumbing only; props unused in render (PR 7 consumes them).

Part of plan: web-activity-summary.md (PR 6 of 7)