### PR TITLE
fix(web): respect mobile safe-area insets for fullscreen exit button

### DIFF
--- a/apps/web/src/components/app-viewer-container.test.tsx
+++ b/apps/web/src/components/app-viewer-container.test.tsx
@@ -47,9 +47,10 @@ function getMaximizeButton(): HTMLButtonElement | null {
 }
 
 function getFloatingExitButton(): HTMLButtonElement | null {
-  // The floating exit button lives inside the `absolute right-3 top-3`
-  // container; scope to that so we don't match the nav-bar close (X) button.
-  const container = document.querySelector(".absolute.right-3.top-3");
+  // The floating exit button lives inside the `absolute z-10` container (its
+  // top/right offsets are applied via inline safe-area-aware styles); scope to
+  // that so we don't match the nav-bar close (X) button.
+  const container = document.querySelector(".absolute.z-10");
   return container?.querySelector("svg.lucide-x")?.closest("button") ?? null;
 }
 

--- a/apps/web/src/components/app-viewer-container.tsx
+++ b/apps/web/src/components/app-viewer-container.tsx
@@ -104,7 +104,13 @@ export function AppViewerContainer({
 
       <div className="relative min-h-0 flex-1">
         {isFullscreen && (
-          <div className="absolute right-3 top-3 z-10">
+          <div
+            className="absolute z-10"
+            style={{
+              top: "max(0.75rem, var(--safe-area-inset-top, env(safe-area-inset-top, 0px)))",
+              right: "max(0.75rem, var(--safe-area-inset-right, env(safe-area-inset-right, 0px)))",
+            }}
+          >
             <Button
               variant="outlined"
               iconOnly={<X />}


### PR DESCRIPTION
## Summary
Fixes a gap identified during plan review for library-app-fullscreen.md.

**Gap:** The fullscreen 'Exit fullscreen' X button used a fixed top-3/right-3 offset with no safe-area padding, so on notched iOS/Capacitor devices it could sit under the status bar.
**Fix:** Offset the floating exit button by the top/right safe-area insets (max(0.75rem, env(safe-area-inset-*))), mirroring mobile-app-overlay's convention.