### PR TITLE
fix(memory-v3): degrade to deterministic lanes on L1/L2 model-call failure; retry; L1 never opens all leaves

### DIFF
--- a/assistant/src/memory/v3/__tests__/orchestrate.test.ts
+++ b/assistant/src/memory/v3/__tests__/orchestrate.test.ts
@@ -335,14 +335,16 @@ describe("orchestrate — edge cases", () => {
     expect(result.finalInjection).toEqual(["page-a", "page-b"]);
   });
 
-  test("L1 routing fallback (omitted ids → all leaves) still works", async () => {
+  test("omitted L1 ids opens only the deterministic lanes, not the whole tree", async () => {
     const tree = makeTree();
-    // Omitted ids → routeL1 opens ALL leaves; select everything per leaf.
+    // L1 omits ids → routeL1 opens NO routed leaves; only the needle/core lanes
+    // drive the open set, so the whole tree is never fanned out (topic-y, which
+    // nothing routes or needles to, stays closed).
     providerStub = {
       name: "stub",
       sendMessage: async (_messages, options) => {
         if (options?.tools?.[0]?.name === "open_leaves") {
-          return toolUseResponse("open_leaves", {}); // omitted ids
+          return toolUseResponse("open_leaves", {}); // omitted ids → []
         }
         return toolUseResponse("select_pages", {}); // omitted → all members
       },
@@ -350,15 +352,12 @@ describe("orchestrate — edge cases", () => {
     const result = await orchestrate(makeTurn(1, "x"), {
       tree,
       core: new Set(),
-      needle: fakeNeedle([]),
+      needle: fakeNeedle(["page-a"]), // needle opens domain-a/topic-x only
       workingSet: new WorkingSet(),
       pageSummary: summaryOf,
     });
-    expect(result.openedLeaves).toEqual([
-      "domain-a/topic-x",
-      "domain-a/topic-y",
-    ]);
-    expect(result.finalInjection).toEqual(["page-a", "page-b", "page-c"]);
+    expect(result.openedLeaves).toEqual(["domain-a/topic-x"]);
+    expect(result.finalInjection).toEqual(["page-a", "page-b"]);
   });
 
   test("pinned current-turn selections land in the working set", async () => {

--- a/assistant/src/memory/v3/__tests__/router.test.ts
+++ b/assistant/src/memory/v3/__tests__/router.test.ts
@@ -3,10 +3,13 @@
  *
  * Coverage matrix:
  *   - Returned IDs map to the right leaves by 1-based index, in model order.
- *   - Omitted `ids` → ALL leaves (recall-safe).
+ *   - Omitted `ids` → no leaves (the router must name leaves explicitly,
+ *     never open the whole tree).
  *   - Explicit `ids: []` → no leaves (deliberate abstention).
  *   - Out-of-range / duplicate IDs ignored, no throw.
- *   - No provider / missing tool_use / schema mismatch / throw → ALL leaves.
+ *   - No provider / missing tool_use / schema mismatch / throw → no leaves
+ *     (degrade to the deterministic lanes), the last three after a re-prompt
+ *     retry; a malformed response that recovers on retry returns its IDs.
  *   - The rendered leaf block is byte-identical across two calls with
  *     different queries (the cache invariant).
  *   - The system prompt mentions "register" (locks the routing commitment).
@@ -76,6 +79,45 @@ function toolUseResponse(input: Record<string, unknown>): ProviderResponse {
   };
 }
 
+/** A 200 response that carries no tool_use — the malformed-but-successful case
+ * the re-prompt retry exists to recover from. */
+function noToolResponse(): ProviderResponse {
+  return {
+    model: "stub-model",
+    stopReason: "end_turn",
+    usage: { inputTokens: 0, outputTokens: 0 },
+    content: [{ type: "text", text: "no tool call" }],
+  };
+}
+
+/** Provider returning a different response per call (the i-th call returns
+ * responses[i], or the last entry once exhausted), recording each call so a
+ * test can assert how many attempts were made. */
+function makeSequenceProvider(responses: ProviderResponse[]): Provider {
+  let i = 0;
+  return {
+    name: "sequence",
+    sendMessage: async (messages, options) => {
+      providerCalls.push({ messages, options });
+      const response = responses[Math.min(i, responses.length - 1)];
+      i += 1;
+      return response;
+    },
+  };
+}
+
+/** Provider that records each call and then throws — for the throw-after-retries
+ * path (the provider's own RetryProvider has already exhausted its backoff). */
+function makeThrowingProvider(): Provider {
+  return {
+    name: "throwing",
+    sendMessage: async (messages, options) => {
+      providerCalls.push({ messages, options });
+      throw new Error("boom");
+    },
+  };
+}
+
 function makeLeaf(path: LeafPath, description: string): LeafNode {
   return {
     path,
@@ -100,8 +142,6 @@ function makeTree(): LeafTree {
     byPage: new Map(),
   };
 }
-
-const SORTED_PATHS = ["people/alice", "people/bob", "projects/atlas"];
 
 function makeTurn(currentMessage: string): TurnContext {
   return {
@@ -128,10 +168,10 @@ describe("routeL1 — id mapping", () => {
     expect(result).toEqual(["projects/atlas", "people/alice"]);
   });
 
-  test("omitted ids opens ALL leaves (recall-safe)", async () => {
+  test("omitted ids opens no leaves (must name leaves explicitly)", async () => {
     providerStub = makeProvider(toolUseResponse({}));
     const result = await routeL1(makeTurn("anything"), makeTree());
-    expect(result).toEqual(SORTED_PATHS);
+    expect(result).toEqual([]);
   });
 
   test("explicit empty ids opens no leaves (abstention)", async () => {
@@ -157,39 +197,43 @@ describe("routeL1 — id mapping", () => {
   });
 });
 
-describe("routeL1 — recall-safe fallbacks", () => {
-  test("no provider → ALL leaves", async () => {
+describe("routeL1 — degradation on failure", () => {
+  test("no provider → no leaves, without calling the provider", async () => {
     providerStub = null;
     const result = await routeL1(makeTurn("x"), makeTree());
-    expect(result).toEqual(SORTED_PATHS);
+    expect(result).toEqual([]);
+    expect(providerCalls).toHaveLength(0);
   });
 
-  test("missing tool_use → ALL leaves", async () => {
-    providerStub = makeProvider({
-      model: "stub-model",
-      stopReason: "end_turn",
-      usage: { inputTokens: 0, outputTokens: 0 },
-      content: [{ type: "text", text: "no tool call" }],
-    });
+  test("missing tool_use → no leaves after retrying", async () => {
+    providerStub = makeProvider(noToolResponse());
     const result = await routeL1(makeTurn("x"), makeTree());
-    expect(result).toEqual(SORTED_PATHS);
+    expect(result).toEqual([]);
+    expect(providerCalls).toHaveLength(3);
   });
 
-  test("schema mismatch → ALL leaves", async () => {
+  test("schema mismatch → no leaves after retrying", async () => {
     providerStub = makeProvider(toolUseResponse({ ids: "not-an-array" }));
     const result = await routeL1(makeTurn("x"), makeTree());
-    expect(result).toEqual(SORTED_PATHS);
+    expect(result).toEqual([]);
+    expect(providerCalls).toHaveLength(3);
   });
 
-  test("provider throw → ALL leaves", async () => {
-    providerStub = {
-      name: "throwing",
-      sendMessage: async () => {
-        throw new Error("boom");
-      },
-    };
+  test("provider throw → no leaves after retrying", async () => {
+    providerStub = makeThrowingProvider();
     const result = await routeL1(makeTurn("x"), makeTree());
-    expect(result).toEqual(SORTED_PATHS);
+    expect(result).toEqual([]);
+    expect(providerCalls).toHaveLength(3);
+  });
+
+  test("a malformed response that recovers on retry returns its IDs", async () => {
+    providerStub = makeSequenceProvider([
+      noToolResponse(),
+      toolUseResponse({ ids: [2] }),
+    ]);
+    const result = await routeL1(makeTurn("bob?"), makeTree());
+    expect(result).toEqual(["people/bob"]);
+    expect(providerCalls).toHaveLength(2);
   });
 });
 

--- a/assistant/src/memory/v3/__tests__/selector.test.ts
+++ b/assistant/src/memory/v3/__tests__/selector.test.ts
@@ -4,9 +4,12 @@
  * Coverage matrix:
  *   - Returned IDs map to the right member slugs by 1-based index, with
  *     `pinned` driven by `pinned_ids`.
- *   - Omitted `ids` → ALL members of the leaf (recall-safe).
+ *   - Omitted `ids` → ALL members of the leaf (recall-safe; bounded to one
+ *     leaf, so this stays a select-all unlike the L1 router).
  *   - Explicit `ids: []` → no pages (deliberate abstention).
- *   - No provider / missing tool_use / schema mismatch / throw → ALL members.
+ *   - No provider / missing tool_use / schema mismatch / throw → no pages
+ *     (degrade to the deterministic lanes), the last three after a re-prompt
+ *     retry; a malformed response that recovers on retry returns its pages.
  *   - The per-leaf `<pages>` prefix is byte-identical across two calls with
  *     different turns (the cache invariant).
  *   - `selectAcrossLeaves` flattens per-leaf results and never exceeds the
@@ -80,6 +83,45 @@ function toolUseResponse(input: Record<string, unknown>): ProviderResponse {
     stopReason: "tool_use",
     usage: { inputTokens: 0, outputTokens: 0 },
     content: [{ type: "tool_use", id: "tu-1", name: "select_pages", input }],
+  };
+}
+
+/** A 200 response that carries no tool_use — the malformed-but-successful case
+ * the re-prompt retry exists to recover from. */
+function noToolResponse(): ProviderResponse {
+  return {
+    model: "stub-model",
+    stopReason: "end_turn",
+    usage: { inputTokens: 0, outputTokens: 0 },
+    content: [{ type: "text", text: "no tool call" }],
+  };
+}
+
+/** Provider returning a different response per call (the i-th call returns
+ * responses[i], or the last entry once exhausted), recording each call so a
+ * test can assert how many attempts were made. */
+function makeSequenceProvider(responses: ProviderResponse[]): Provider {
+  let i = 0;
+  return {
+    name: "sequence",
+    sendMessage: async (messages, options) => {
+      providerCalls.push({ messages, options });
+      const response = responses[Math.min(i, responses.length - 1)];
+      i += 1;
+      return response;
+    },
+  };
+}
+
+/** Provider that records each call and then throws — for the throw-after-retries
+ * path (the provider's own RetryProvider has already exhausted its backoff). */
+function makeThrowingProvider(): Provider {
+  return {
+    name: "throwing",
+    sendMessage: async (messages, options) => {
+      providerCalls.push({ messages, options });
+      throw new Error("boom");
+    },
   };
 }
 
@@ -206,10 +248,8 @@ describe("selectFromLeaf — id mapping", () => {
 // selectFromLeaf — recall-safe fallbacks.
 // ---------------------------------------------------------------------------
 
-describe("selectFromLeaf — recall-safe fallbacks", () => {
-  const allAlice = ALICE_MEMBERS.map((slug) => ({ slug, pinned: false }));
-
-  test("no provider → ALL members", async () => {
+describe("selectFromLeaf — degradation on failure", () => {
+  test("no provider → no pages, without calling the provider", async () => {
     providerStub = null;
     const result = await selectFromLeaf(
       "people/alice",
@@ -217,26 +257,23 @@ describe("selectFromLeaf — recall-safe fallbacks", () => {
       makeTree(),
       summaryOf,
     );
-    expect(result).toEqual(allAlice);
+    expect(result).toEqual([]);
+    expect(providerCalls).toHaveLength(0);
   });
 
-  test("missing tool_use → ALL members", async () => {
-    providerStub = makeProvider({
-      model: "stub-model",
-      stopReason: "end_turn",
-      usage: { inputTokens: 0, outputTokens: 0 },
-      content: [{ type: "text", text: "no tool call" }],
-    });
+  test("missing tool_use → no pages after retrying", async () => {
+    providerStub = makeProvider(noToolResponse());
     const result = await selectFromLeaf(
       "people/alice",
       makeTurn("x"),
       makeTree(),
       summaryOf,
     );
-    expect(result).toEqual(allAlice);
+    expect(result).toEqual([]);
+    expect(providerCalls).toHaveLength(3);
   });
 
-  test("schema mismatch → ALL members", async () => {
+  test("schema mismatch → no pages after retrying", async () => {
     providerStub = makeProvider(toolUseResponse({ ids: "not-an-array" }));
     const result = await selectFromLeaf(
       "people/alice",
@@ -244,23 +281,35 @@ describe("selectFromLeaf — recall-safe fallbacks", () => {
       makeTree(),
       summaryOf,
     );
-    expect(result).toEqual(allAlice);
+    expect(result).toEqual([]);
+    expect(providerCalls).toHaveLength(3);
   });
 
-  test("provider throw → ALL members", async () => {
-    providerStub = {
-      name: "throwing",
-      sendMessage: async () => {
-        throw new Error("boom");
-      },
-    };
+  test("provider throw → no pages after retrying", async () => {
+    providerStub = makeThrowingProvider();
     const result = await selectFromLeaf(
       "people/alice",
       makeTurn("x"),
       makeTree(),
       summaryOf,
     );
-    expect(result).toEqual(allAlice);
+    expect(result).toEqual([]);
+    expect(providerCalls).toHaveLength(3);
+  });
+
+  test("a malformed response that recovers on retry returns its pages", async () => {
+    providerStub = makeSequenceProvider([
+      noToolResponse(),
+      toolUseResponse({ ids: [2] }),
+    ]);
+    const result = await selectFromLeaf(
+      "people/alice",
+      makeTurn("the 1:1"),
+      makeTree(),
+      summaryOf,
+    );
+    expect(result).toEqual([{ slug: "alice-1on1", pinned: false }]);
+    expect(providerCalls).toHaveLength(2);
   });
 });
 

--- a/assistant/src/memory/v3/llm-retry.ts
+++ b/assistant/src/memory/v3/llm-retry.ts
@@ -1,0 +1,32 @@
+/**
+ * Memory v3 — shared retry helper for the L1 router and L2 selector model calls.
+ *
+ * The configured provider is already wrapped in `RetryProvider`
+ * (`../../providers/retry.ts`), which retries transient transport failures
+ * (network errors, 429s, 5xx, stream aborts) with exponential backoff before it
+ * ever throws. This helper therefore adds NO backoff of its own; it exists to:
+ *   (a) re-prompt on a malformed-but-successful response — a 200 whose body has
+ *       no usable forced `tool_use`, or whose tool input fails schema validation
+ *       (the provider's retry never re-runs these, since nothing threw); and
+ *   (b) cheaply re-attempt a call that threw after the provider exhausted its
+ *       own retries, before the lane degrades to its deterministic fallback.
+ *
+ * `attempt` signals "unusable, retry me" by returning `null` (or throwing). The
+ * first non-null result wins; `null` after `maxAttempts` tells the caller to
+ * degrade to the deterministic recall lanes.
+ */
+export async function retryForResult<T>(
+  attempt: () => Promise<T | null>,
+  maxAttempts = 3,
+): Promise<T | null> {
+  for (let i = 0; i < maxAttempts; i++) {
+    try {
+      const result = await attempt();
+      if (result !== null) return result;
+    } catch {
+      // Treat a throw like an unusable result and retry. The provider layer has
+      // already backed off transient errors, so there is nothing to wait for.
+    }
+  }
+  return null;
+}

--- a/assistant/src/memory/v3/router.ts
+++ b/assistant/src/memory/v3/router.ts
@@ -15,12 +15,17 @@
  * cache turn after turn. The trailing recent-context / current-message block
  * changes every turn, so it carries no breakpoint.
  *
- * Recall-safe fallbacks. The router exists to widen recall, so every failure
- * mode degrades toward opening MORE leaves, never fewer:
- *   - omitted `ids` (model didn't pass the field) → open ALL leaves,
- *   - missing/failed tool_use, provider unavailable, or any throw → ALL leaves.
- * The one path that returns nothing is an explicit empty array (`ids: []`),
- * which is the model deliberately abstaining.
+ * Failure handling. A *model-call* failure is not the same as the model
+ * choosing to open everything, so the two no longer share an outcome:
+ *   - explicit `ids` → open exactly those leaves,
+ *   - explicit empty array (`ids: []`) → open nothing (deliberate abstention),
+ *   - omitted `ids` → open nothing: the router must name the leaves it wants,
+ *     never the whole tree (~137 leaves would fan out a full L2 pass per turn),
+ *   - infrastructure failure (provider unavailable, a throw that survived the
+ *     provider's own retries, no usable `tool_use`, or a schema mismatch) →
+ *     open nothing after a short re-prompt retry, degrading to the deterministic
+ *     recall lanes (always-on core, the BM25 needle, the carry-forward working
+ *     set) that the orchestrator unions in regardless.
  */
 
 import { z } from "zod";
@@ -31,6 +36,7 @@ import {
 } from "../../providers/provider-send-message.js";
 import type { Message, ToolDefinition } from "../../providers/types.js";
 import { getLogger } from "../../util/logger.js";
+import { retryForResult } from "./llm-retry.js";
 import { cachedTextBlock } from "./provider-blocks.js";
 import type { LeafPath, LeafTree, TurnContext } from "./types.js";
 
@@ -40,8 +46,8 @@ const log = getLogger("memory-v3-router");
 const OPEN_LEAVES_TOOL_NAME = "open_leaves";
 
 const OpenLeavesSchema = z.object({
-  // Optional: an omitted `ids` field is the recall-safe "open everything"
-  // signal, distinct from an explicit empty array (deliberate abstention).
+  // Optional so the field can be absent on the wire, but an omitted `ids` opens
+  // nothing — the router must name the leaves it wants, never the whole tree.
   ids: z.array(z.number().int()).optional(),
 });
 
@@ -50,8 +56,8 @@ const OPEN_LEAVES_TOOL: ToolDefinition = {
   description:
     "Open the leaves whose contents could plausibly bear on the next reply. " +
     "Lean toward inclusion — a missed relevant leaf is a worse error than an " +
-    "unused one. Omit `ids` entirely to open every leaf; return `[]` only " +
-    "when nothing in the tree could possibly help.",
+    "unused one. Pass the chosen IDs explicitly; return `[]` only when nothing " +
+    "in the tree could possibly help.",
   input_schema: {
     type: "object",
     properties: {
@@ -72,7 +78,7 @@ Each leaf has a numbered ID, a path, and a description of what it holds. Decide 
 - Recent context — the immediately preceding exchange, which resolves references like "this", "that", or "the same thing" to concrete topics.
 - Situation — the current date and a live scratchpad of what is salient right now. A date or state cue can make a leaf relevant even when the message never names it (e.g. a person whose anniversary is today, an active thread).
 
-Include on doubt: open every leaf that could plausibly hold something useful. Missing a relevant leaf is a worse error than opening an unused one. Call \`open_leaves\` with the chosen IDs. Omit \`ids\` to open every leaf; return \`[]\` only when nothing in the tree could possibly help.`;
+Include on doubt: open every leaf that could plausibly hold something useful. Missing a relevant leaf is a worse error than opening an unused one. Call \`open_leaves\` with the chosen IDs explicitly; return \`[]\` only when nothing in the tree could possibly help.`;
 
 /** Leaves sorted deterministically by path so the numbered block is stable. */
 function sortedLeaves(tree: LeafTree): LeafPath[] {
@@ -105,10 +111,10 @@ export function renderLeafBlock(tree: LeafTree): string {
 }
 
 /**
- * Run the L1 router for one turn. Returns the leaf paths to open.
- *
- * Recall-safe: any failure to obtain an explicit selection returns ALL leaves.
- * Only an explicit empty `ids` array returns no leaves.
+ * Run the L1 router for one turn. Returns the leaf paths to open — only ever the
+ * leaves the model names explicitly. An omitted `ids`, an explicit `[]`, or an
+ * infrastructure failure (after a short re-prompt retry) all open nothing,
+ * degrading to the deterministic recall lanes the orchestrator unions in.
  */
 export async function routeL1(
   turn: TurnContext,
@@ -119,8 +125,10 @@ export async function routeL1(
 
   const provider = await getConfiguredProvider("memoryV3RouteL1");
   if (!provider) {
-    log.warn("memoryV3RouteL1 provider unavailable; opening all leaves");
-    return paths;
+    log.warn(
+      "L1 router provider unavailable; degrading to deterministic lanes",
+    );
+    return [];
   }
 
   const userMsg: Message = {
@@ -139,9 +147,12 @@ export async function routeL1(
     ],
   };
 
-  let response;
-  try {
-    response = await provider.sendMessage([userMsg], {
+  // One forced-tool call, retried a few times so a transient malformed response
+  // (no usable tool_use, or tool input that fails the schema) re-prompts before
+  // we give up. `null` from an attempt means "unusable, retry"; the provider
+  // layer already backs off transient throws, so this loop adds no delay.
+  const parsed = await retryForResult(async () => {
+    const response = await provider.sendMessage([userMsg], {
       tools: [OPEN_LEAVES_TOOL],
       systemPrompt: SYSTEM_PROMPT,
       config: {
@@ -149,37 +160,28 @@ export async function routeL1(
         tool_choice: { type: "tool" as const, name: OPEN_LEAVES_TOOL_NAME },
       },
     });
-  } catch (err) {
-    log.warn({ err }, "L1 router call threw; opening all leaves");
-    return paths;
-  }
+    const toolBlock = extractToolUse(response);
+    if (!toolBlock || toolBlock.name !== OPEN_LEAVES_TOOL_NAME) return null;
+    const result = OpenLeavesSchema.safeParse(toolBlock.input);
+    return result.success ? result.data : null;
+  });
 
-  const toolBlock = extractToolUse(response);
-  if (!toolBlock || toolBlock.name !== OPEN_LEAVES_TOOL_NAME) {
+  if (parsed === null) {
     log.warn(
-      { stopReason: response.stopReason },
-      "L1 router returned no open_leaves tool_use; opening all leaves",
+      "L1 router could not obtain a selection after retries; degrading to deterministic lanes",
     );
-    return paths;
+    return [];
   }
 
-  const parsed = OpenLeavesSchema.safeParse(toolBlock.input);
-  if (!parsed.success) {
-    log.warn(
-      { error: parsed.error.message },
-      "L1 router tool input did not match schema; opening all leaves",
-    );
-    return paths;
-  }
-
-  // Omitted `ids` is the recall-safe "open everything" signal.
-  if (parsed.data.ids === undefined) return paths;
+  // An omitted `ids` field means the model named no leaves — open nothing rather
+  // than the whole tree. Only explicitly listed IDs open leaves.
+  if (parsed.ids === undefined) return [];
 
   // Map 1-based IDs back to leaf paths, dropping out-of-range IDs without
   // throwing. De-duplicate while preserving model-returned order.
   const seen = new Set<number>();
   const selected: LeafPath[] = [];
-  for (const id of parsed.data.ids) {
+  for (const id of parsed.ids) {
     if (id < 1 || id > paths.length || seen.has(id)) continue;
     seen.add(id);
     selected.push(paths[id - 1]);

--- a/assistant/src/memory/v3/selector.ts
+++ b/assistant/src/memory/v3/selector.ts
@@ -14,11 +14,18 @@
  * turn after turn. The trailing recent-context / current-message block changes
  * every turn and carries no breakpoint. This mirrors `./router.ts`.
  *
- * Recall-safe fallbacks. Like the router, the selector exists to widen recall,
- * so every failure degrades toward selecting MORE pages, never fewer:
- *   - omitted `ids` → select ALL members of the leaf,
- *   - missing/failed tool_use, provider unavailable, or any throw → ALL members.
- * Only an explicit empty `ids: []` returns nothing (deliberate abstention).
+ * Failure handling. A deliberate "select everything" and a model-call failure
+ * are different events with different outcomes:
+ *   - explicit `ids` → select exactly those pages,
+ *   - explicit empty `ids: []` → select nothing (deliberate abstention),
+ *   - omitted `ids` → select ALL members of the leaf (the recall-safe "this
+ *     whole leaf is relevant" signal, e.g. "give me all of X"); bounded to one
+ *     leaf, so unlike the router this stays a select-all,
+ *   - infrastructure failure (provider unavailable, a throw that survived the
+ *     provider's own retries, no usable `tool_use`, or a schema mismatch) →
+ *     select nothing after a short re-prompt retry, degrading to the
+ *     deterministic recall lanes (core, needle, carry-forward working set) the
+ *     orchestrator unions in regardless.
  */
 
 import { z } from "zod";
@@ -30,6 +37,7 @@ import {
 import type { Message, ToolDefinition } from "../../providers/types.js";
 import { getLogger } from "../../util/logger.js";
 import { mapLimit } from "../../util/map-limit.js";
+import { retryForResult } from "./llm-retry.js";
 import { cachedTextBlock } from "./provider-blocks.js";
 import { membersOf } from "./tree.js";
 import type { LeafPath, LeafTree, Slug, TurnContext } from "./types.js";
@@ -107,8 +115,10 @@ async function renderPagesBlock(
 /**
  * Run the L2 selector for a single opened leaf. Returns the pages to inject.
  *
- * Recall-safe: any failure to obtain an explicit selection returns ALL members
- * of the leaf. Only an explicit empty `ids` array returns no pages.
+ * An omitted `ids` selects ALL members (the recall-safe "whole leaf is
+ * relevant" signal); an explicit `[]` selects none; an infrastructure failure
+ * (after a short re-prompt retry) selects none, degrading to the deterministic
+ * recall lanes the orchestrator unions in.
  */
 export async function selectFromLeaf(
   leaf: LeafPath,
@@ -124,8 +134,11 @@ export async function selectFromLeaf(
 
   const provider = await getConfiguredProvider("memoryV3SelectL2");
   if (!provider) {
-    log.warn({ leaf }, "memoryV3SelectL2 provider unavailable; selecting all");
-    return allMembers();
+    log.warn(
+      { leaf },
+      "L2 selector provider unavailable; degrading to deterministic lanes",
+    );
+    return [];
   }
 
   const userMsg: Message = {
@@ -147,9 +160,12 @@ export async function selectFromLeaf(
     ],
   };
 
-  let response;
-  try {
-    response = await provider.sendMessage([userMsg], {
+  // One forced-tool call, retried a few times so a transient malformed response
+  // (no usable tool_use, or tool input that fails the schema) re-prompts before
+  // we give up. `null` from an attempt means "unusable, retry"; the provider
+  // layer already backs off transient throws, so this loop adds no delay.
+  const parsed = await retryForResult(async () => {
+    const response = await provider.sendMessage([userMsg], {
       tools: [SELECT_PAGES_TOOL],
       systemPrompt: SYSTEM_PROMPT,
       config: {
@@ -157,39 +173,31 @@ export async function selectFromLeaf(
         tool_choice: { type: "tool" as const, name: SELECT_PAGES_TOOL_NAME },
       },
     });
-  } catch (err) {
-    log.warn({ err, leaf }, "L2 selector call threw; selecting all");
-    return allMembers();
-  }
+    const toolBlock = extractToolUse(response);
+    if (!toolBlock || toolBlock.name !== SELECT_PAGES_TOOL_NAME) return null;
+    const result = SelectPagesSchema.safeParse(toolBlock.input);
+    return result.success ? result.data : null;
+  });
 
-  const toolBlock = extractToolUse(response);
-  if (!toolBlock || toolBlock.name !== SELECT_PAGES_TOOL_NAME) {
+  if (parsed === null) {
     log.warn(
-      { stopReason: response.stopReason, leaf },
-      "L2 selector returned no select_pages tool_use; selecting all",
+      { leaf },
+      "L2 selector could not obtain a selection after retries; degrading to deterministic lanes",
     );
-    return allMembers();
+    return [];
   }
 
-  const parsed = SelectPagesSchema.safeParse(toolBlock.input);
-  if (!parsed.success) {
-    log.warn(
-      { error: parsed.error.message, leaf },
-      "L2 selector tool input did not match schema; selecting all",
-    );
-    return allMembers();
-  }
+  // Omitted `ids` is the recall-safe "this whole leaf is relevant" signal.
+  // Bounded to one leaf, so it stays a select-all (unlike the L1 router).
+  if (parsed.ids === undefined) return allMembers();
 
-  // Omitted `ids` is the recall-safe "select everything" signal.
-  if (parsed.data.ids === undefined) return allMembers();
-
-  const pinned = new Set(parsed.data.pinned_ids ?? []);
+  const pinned = new Set(parsed.pinned_ids ?? []);
 
   // Map 1-based IDs back to member slugs, dropping out-of-range IDs without
   // throwing. De-duplicate while preserving model-returned order.
   const seen = new Set<number>();
   const selected: SelectedPage[] = [];
-  for (const id of parsed.data.ids) {
+  for (const id of parsed.ids) {
     if (id < 1 || id > members.length || seen.has(id)) continue;
     seen.add(id);
     selected.push({ slug: members[id - 1]!, pinned: pinned.has(id) });


### PR DESCRIPTION
## Summary

- **Separate model-call failure from the model's deliberate "keep everything."** Previously both `routeL1` and `selectFromLeaf` fail-opened to the entire candidate set on *any* failure (no provider, a throw, no `tool_use`, a schema mismatch) — the same outcome as the model omitting `ids`. A single L1 router blip thus opened all ~137 leaves (a full L2 fan-out per turn), and a broad provider outage injected the whole memory corpus. Infrastructure failure now degrades to the deterministic recall lanes (routed ∪ core ∪ needle, plus the carry-forward working set, unioned in `orchestrate.ts`) instead of dumping candidates.
- **Retry before degrading.** A small shared `retryForResult` helper re-prompts up to 3 attempts so a malformed-but-successful response (no usable `tool_use`, or tool input that fails schema validation) can recover. It adds **no backoff** of its own — the provider is already wrapped in `RetryProvider`, which backs off transient throws; this loop only fills the malformed-200 gap that retry can't catch (and keeps tests fast).
- **L1 never opens all leaves.** An omitted `ids` from the router now opens *nothing* — the router must name the leaves it wants — rather than the whole tree. L2's omitted `ids` is unchanged: it still selects all members of that one leaf (the bounded, recall-safe "give me all of X" intent).

On a *full* L2 outage, injection degrades to the working set only; promoting the needle's BM25 page hits to a direct injection floor (so the needle rescues recall when L2 is down) is a clean follow-up, not in this PR.

memory-v3 is shadow-only / flag-gated, so this has **zero live-v2 impact** and needs no migration.

## Original prompt

While validating memory-v3's deployed retrieval config, we found that `routeL1` / `selectFromLeaf` treat an infrastructure failure identically to the model deliberately choosing "keep all" — both fail-open to the entire candidate set, so a router blip opens all ~137 leaves and an outage injects the whole corpus. The ask: on a model-call failure, degrade to the deterministic recall lanes (core + needle + carry-forward working set) instead of fail-opening; add a retry first; and remove the L1 "omitted ids → open all leaves" path entirely, since opening every leaf is never warranted and is a large cost/latency amplifier.