### PR TITLE
Library App Fullscreen (Web + Mobile)

### DIFF
--- a/apps/web/src/components/app-nav-bar.test.tsx
+++ b/apps/web/src/components/app-nav-bar.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * Tests for `AppNavBar`.
+ *
+ * Focuses on the optional fullscreen toggle button: it only renders when an
+ * `onToggleFullscreen` callback is supplied, and clicking it invokes that
+ * callback. We mount via `@testing-library/react` (backed by happy-dom — see
+ * `apps/web/test-setup.ts`).
+ *
+ * The design-library `Button` renders its tooltip via a Radix tooltip that only
+ * adds an accessible name while open, so we locate the fullscreen button by its
+ * `Maximize2` glyph (lucide adds a `lucide-maximize2` class to the rendered
+ * SVG) rather than by accessible name.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import { AppNavBar } from "@/components/app-nav-bar";
+
+afterEach(() => {
+  cleanup();
+});
+
+function getFullscreenButton(): HTMLButtonElement | null {
+  const glyph = document.querySelector("svg.lucide-maximize2");
+  return glyph?.closest("button") ?? null;
+}
+
+describe("AppNavBar fullscreen toggle", () => {
+  test("omits the fullscreen button when onToggleFullscreen is not provided", () => {
+    render(<AppNavBar appName="My App" onClose={() => {}} />);
+    expect(getFullscreenButton()).toBeNull();
+  });
+
+  test("renders the fullscreen button and invokes onToggleFullscreen on click", () => {
+    const onToggleFullscreen = mock(() => {});
+    render(
+      <AppNavBar
+        appName="My App"
+        onClose={() => {}}
+        onToggleFullscreen={onToggleFullscreen}
+      />,
+    );
+
+    const button = getFullscreenButton();
+    expect(button).not.toBeNull();
+
+    fireEvent.click(button as HTMLButtonElement);
+    expect(onToggleFullscreen).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/app-nav-bar.tsx
+++ b/apps/web/src/components/app-nav-bar.tsx
@@ -1,5 +1,5 @@
 
-import { ArrowUp, ChevronUp, Globe, Loader2, Pencil, X } from "lucide-react";
+import { ArrowUp, ChevronUp, Globe, Loader2, Maximize2, Pencil, X } from "lucide-react";
 
 import { Button } from "@vellum/design-library";
 import { Typography } from "@vellum/design-library";
@@ -19,10 +19,12 @@ export interface AppNavBarProps {
   isSharing?: boolean;
   onDeploy?: () => void;
   isDeploying?: boolean;
+  /** When provided, renders a fullscreen toggle button in the right group. */
+  onToggleFullscreen?: () => void;
   onClose: () => void;
 }
 
-export function AppNavBar({ appName, onEdit, isEditing, onShare, isSharing, onDeploy, isDeploying, onClose }: AppNavBarProps) {
+export function AppNavBar({ appName, onEdit, isEditing, onShare, isSharing, onDeploy, isDeploying, onToggleFullscreen, onClose }: AppNavBarProps) {
   const isMobile = useIsMobile();
   // While the bar is acting as the minimized strip on mobile, tapping the
   // title is the primary "open app" affordance — same callback as the
@@ -66,6 +68,14 @@ export function AppNavBar({ appName, onEdit, isEditing, onShare, isSharing, onDe
             onClick={onShare}
             disabled={isSharing}
             tooltip={isSharing ? "Sharing…" : "Share"}
+          />
+        )}
+        {onToggleFullscreen != null && (
+          <Button
+            variant="outlined"
+            iconOnly={<Maximize2 />}
+            onClick={onToggleFullscreen}
+            tooltip="Fullscreen"
           />
         )}
         {onEdit != null && (

--- a/apps/web/src/components/app-viewer-container.test.tsx
+++ b/apps/web/src/components/app-viewer-container.test.tsx
@@ -47,9 +47,10 @@ function getMaximizeButton(): HTMLButtonElement | null {
 }
 
 function getFloatingExitButton(): HTMLButtonElement | null {
-  // The floating exit button lives inside the `absolute right-3 top-3`
-  // container; scope to that so we don't match the nav-bar close (X) button.
-  const container = document.querySelector(".absolute.right-3.top-3");
+  // The floating exit button lives inside the `absolute z-10` container (its
+  // top/right offsets are applied via inline safe-area-aware styles); scope to
+  // that so we don't match the nav-bar close (X) button.
+  const container = document.querySelector(".absolute.z-10");
   return container?.querySelector("svg.lucide-x")?.closest("button") ?? null;
 }
 

--- a/apps/web/src/components/app-viewer-container.test.tsx
+++ b/apps/web/src/components/app-viewer-container.test.tsx
@@ -7,8 +7,9 @@
  * plumbing.
  *
  * Buttons are located by their lucide glyph class (e.g. `svg.lucide-maximize2`,
- * `svg.lucide-x`) rather than by accessible name, because the design-library
- * `Button` only exposes its tooltip text via a Radix tooltip while open.
+ * `svg.lucide-minimize2`) rather than by accessible name, because the
+ * design-library `Button` only exposes its tooltip text via a Radix tooltip
+ * while open.
  */
 
 import { afterEach, describe, expect, mock, test } from "bun:test";
@@ -49,9 +50,9 @@ function getMaximizeButton(): HTMLButtonElement | null {
 function getFloatingExitButton(): HTMLButtonElement | null {
   // The floating exit button lives inside the `absolute z-10` container (its
   // top/right offsets are applied via inline safe-area-aware styles); scope to
-  // that so we don't match the nav-bar close (X) button.
+  // that so we don't match any nav-bar button.
   const container = document.querySelector(".absolute.z-10");
-  return container?.querySelector("svg.lucide-x")?.closest("button") ?? null;
+  return container?.querySelector("svg.lucide-minimize2")?.closest("button") ?? null;
 }
 
 function getRoot(): HTMLElement {

--- a/apps/web/src/components/app-viewer-container.test.tsx
+++ b/apps/web/src/components/app-viewer-container.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * Tests for `AppViewerContainer` fullscreen mode.
+ *
+ * We mount via `@testing-library/react` (backed by happy-dom — see
+ * `apps/web/test-setup.ts`). The sandbox fetch-proxy hook and the bridge
+ * injection are mocked to no-ops so the iframe renders without browser-only
+ * plumbing.
+ *
+ * Buttons are located by their lucide glyph class (e.g. `svg.lucide-maximize2`,
+ * `svg.lucide-x`) rather than by accessible name, because the design-library
+ * `Button` only exposes its tooltip text via a Radix tooltip while open.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
+
+mock.module("@/hooks/use-sandbox-fetch-proxy", () => ({
+  useSandboxFetchProxy: () => {},
+}));
+
+mock.module("@/utils/sandbox-bridge", () => ({
+  injectBridge: (html: string) => html,
+}));
+
+import { AppViewerContainer } from "@/components/app-viewer-container";
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderViewer(props?: { enableFullscreen?: boolean; appId?: string }) {
+  return render(
+    <AppViewerContainer
+      appId={props?.appId ?? "app-1"}
+      appName="My App"
+      html="<html><body>hi</body></html>"
+      assistantId="assistant-1"
+      onClose={() => {}}
+      enableFullscreen={props?.enableFullscreen}
+    />,
+  );
+}
+
+function getMaximizeButton(): HTMLButtonElement | null {
+  return document.querySelector("svg.lucide-maximize2")?.closest("button") ?? null;
+}
+
+function getFloatingExitButton(): HTMLButtonElement | null {
+  // The floating exit button lives inside the `absolute right-3 top-3`
+  // container; scope to that so we don't match the nav-bar close (X) button.
+  const container = document.querySelector(".absolute.right-3.top-3");
+  return container?.querySelector("svg.lucide-x")?.closest("button") ?? null;
+}
+
+function getRoot(): HTMLElement {
+  return document.querySelector("[data-testid='app-viewer-root']") as HTMLElement;
+}
+
+describe("AppViewerContainer fullscreen", () => {
+  test("toggles into fullscreen, hiding the nav bar and showing a floating exit", () => {
+    renderViewer({ enableFullscreen: true });
+
+    const maximize = getMaximizeButton();
+    expect(maximize).not.toBeNull();
+    expect(getRoot().classList.contains("rounded-xl")).toBe(true);
+    expect(getFloatingExitButton()).toBeNull();
+
+    fireEvent.click(maximize as HTMLButtonElement);
+
+    const root = getRoot();
+    expect(root.classList.contains("fixed")).toBe(true);
+    expect(root.classList.contains("inset-0")).toBe(true);
+    expect(getMaximizeButton()).toBeNull();
+    expect(getFloatingExitButton()).not.toBeNull();
+  });
+
+  test("the floating exit button restores the framed nav-bar view", () => {
+    renderViewer({ enableFullscreen: true });
+
+    fireEvent.click(getMaximizeButton() as HTMLButtonElement);
+    expect(getMaximizeButton()).toBeNull();
+
+    fireEvent.click(getFloatingExitButton() as HTMLButtonElement);
+
+    expect(getMaximizeButton()).not.toBeNull();
+    expect(getRoot().classList.contains("rounded-xl")).toBe(true);
+    expect(getRoot().classList.contains("fixed")).toBe(false);
+  });
+
+  test("Escape exits fullscreen", () => {
+    renderViewer({ enableFullscreen: true });
+
+    fireEvent.click(getMaximizeButton() as HTMLButtonElement);
+    expect(getRoot().classList.contains("fixed")).toBe(true);
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    });
+
+    expect(getRoot().classList.contains("fixed")).toBe(false);
+    expect(getMaximizeButton()).not.toBeNull();
+  });
+
+  test("without enableFullscreen there is no fullscreen button and the root stays framed", () => {
+    renderViewer();
+
+    expect(getMaximizeButton()).toBeNull();
+    expect(getRoot().classList.contains("rounded-xl")).toBe(true);
+    expect(getRoot().classList.contains("fixed")).toBe(false);
+  });
+});

--- a/apps/web/src/components/app-viewer-container.tsx
+++ b/apps/web/src/components/app-viewer-container.tsx
@@ -104,7 +104,13 @@ export function AppViewerContainer({
 
       <div className="relative min-h-0 flex-1">
         {isFullscreen && (
-          <div className="absolute right-3 top-3 z-10">
+          <div
+            className="absolute z-10"
+            style={{
+              top: "max(0.75rem, var(--safe-area-inset-top, env(safe-area-inset-top, 0px)))",
+              right: "max(0.75rem, var(--safe-area-inset-right, env(safe-area-inset-right, 0px)))",
+            }}
+          >
             <Button
               variant="outlined"
               iconOnly={<X />}

--- a/apps/web/src/components/app-viewer-container.tsx
+++ b/apps/web/src/components/app-viewer-container.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { X } from "lucide-react";
+import { Minimize2 } from "lucide-react";
 
 import { Button } from "@vellum/design-library";
 import { AppNavBar } from "@/components/app-nav-bar";
@@ -112,8 +112,8 @@ export function AppViewerContainer({
             }}
           >
             <Button
-              variant="outlined"
-              iconOnly={<X />}
+              variant="primary"
+              iconOnly={<Minimize2 />}
               onClick={toggleFullscreen}
               tooltip="Exit fullscreen"
             />

--- a/apps/web/src/components/app-viewer-container.tsx
+++ b/apps/web/src/components/app-viewer-container.tsx
@@ -1,8 +1,12 @@
-import { useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
+import { X } from "lucide-react";
+
+import { Button } from "@vellum/design-library";
 import { AppNavBar } from "@/components/app-nav-bar";
 import { useSandboxFetchProxy } from "@/hooks/use-sandbox-fetch-proxy";
 import { injectBridge } from "@/utils/sandbox-bridge";
+import { cn } from "@/utils/misc";
 
 export interface AppViewerContainerProps {
   appId: string;
@@ -19,6 +23,8 @@ export interface AppViewerContainerProps {
   isDeploying?: boolean;
   /** Deep-link route passed to the app as `window.vellum.route`. */
   route?: string;
+  /** Enables the fullscreen toggle (nav-bar button + fullscreen rendering). Default false. */
+  enableFullscreen?: boolean;
 }
 
 export function AppViewerContainer({
@@ -34,8 +40,27 @@ export function AppViewerContainer({
   onDeploy,
   isDeploying,
   route,
+  enableFullscreen = false,
 }: AppViewerContainerProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
+
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  const toggleFullscreen = useCallback(() => setIsFullscreen((v) => !v), []);
+
+  // Reset fullscreen when the rendered app changes.
+  useEffect(() => {
+    setIsFullscreen(false);
+  }, [appId]);
+
+  // Escape-to-exit handler, active only while fullscreen.
+  useEffect(() => {
+    if (!isFullscreen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setIsFullscreen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [isFullscreen]);
 
   const srcdoc = useMemo(
     () => injectBridge(html, appId, { fetch: true, route }),
@@ -56,19 +81,38 @@ export function AppViewerContainer({
   });
 
   return (
-    <div className="flex h-full flex-col overflow-hidden rounded-xl bg-[var(--surface-base)]">
-      <AppNavBar
-        appName={appName}
-        onEdit={onEdit}
-        isEditing={isEditing}
-        onShare={onShare}
-        isSharing={isSharing}
-        onDeploy={onDeploy}
-        isDeploying={isDeploying}
-        onClose={onClose}
-      />
+    <div
+      data-testid="app-viewer-root"
+      className={cn(
+        "flex flex-col overflow-hidden bg-[var(--surface-base)]",
+        isFullscreen ? "fixed inset-0 z-[60]" : "h-full rounded-xl",
+      )}
+    >
+      {!isFullscreen && (
+        <AppNavBar
+          appName={appName}
+          onEdit={onEdit}
+          isEditing={isEditing}
+          onShare={onShare}
+          isSharing={isSharing}
+          onDeploy={onDeploy}
+          isDeploying={isDeploying}
+          onToggleFullscreen={enableFullscreen ? toggleFullscreen : undefined}
+          onClose={onClose}
+        />
+      )}
 
       <div className="relative min-h-0 flex-1">
+        {isFullscreen && (
+          <div className="absolute right-3 top-3 z-10">
+            <Button
+              variant="outlined"
+              iconOnly={<X />}
+              onClick={toggleFullscreen}
+              tooltip="Exit fullscreen"
+            />
+          </div>
+        )}
         <iframe
           ref={iframeRef}
           key={iframeKey}

--- a/apps/web/src/domains/library/library-detail-page.tsx
+++ b/apps/web/src/domains/library/library-detail-page.tsx
@@ -120,6 +120,7 @@ export function LibraryDetailPage() {
       onEdit={handleEdit}
       onShare={handleShare}
       isSharing={isSharing}
+      enableFullscreen
     />
   );
 }


### PR DESCRIPTION
## Summary
Adds a fullscreen toggle to the viewer that renders user-created apps opened from the Library. A third button (Maximize2) appears in the app nav bar's top-right group (Share · **Fullscreen** · Close). Activating it expands the app to fill the entire window (CSS `fixed inset-0 z-[60]`, covering the sidebar), hides the nav bar, and shows a single floating top-right X (safe-area aware on iOS/Capacitor) — or Escape — to exit back to the framed view. Opt-in via `enableFullscreen`; only the Library detail route opts in, which covers both desktop and mobile-responsive web. macOS is out of scope.

## Self-review result
PASS — 1 gap fixed across 1 fix PR (mobile safe-area insets on the exit button). Two findings accepted as design decisions (Escape-inside-sandboxed-iframe relies on the always-present floating X; global overlays intentionally sit below the fullscreen layer).

## PRs merged into feature branch
- #33299: feat(web): add fullscreen toggle button to app nav bar
- #33305: feat(web): add opt-in fullscreen mode to app viewer container
- #33310: feat(web): enable fullscreen for apps opened from the library

### Fix PRs
- #33316: fix(web): respect mobile safe-area insets for fullscreen exit button

Part of plan: library-app-fullscreen.md