### PR TITLE
Add pre-fill/dedup helpers for provider and profile defaults

### DIFF
--- a/apps/web/src/domains/settings/ai/profile-prefill.test.ts
+++ b/apps/web/src/domains/settings/ai/profile-prefill.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  dedupeKey,
+  deriveProfileDefaults,
+  deriveProviderDefaults,
+  slugify,
+} from "@/domains/settings/ai/profile-prefill";
+
+describe("slugify", () => {
+  test("collapses dots into hyphens", () => {
+    expect(slugify("Claude Opus 4.7")).toBe("claude-opus-4-7");
+  });
+
+  test("collapses multiple spaces into a single hyphen", () => {
+    expect(slugify("GPT   5   Mini")).toBe("gpt-5-mini");
+  });
+
+  test("collapses symbols and consecutive separators", () => {
+    expect(slugify("Hello, World!!")).toBe("hello-world");
+    expect(slugify("a---b___c")).toBe("a-b-c");
+  });
+
+  test("strips leading and trailing separators", () => {
+    expect(slugify("  Spaces  ")).toBe("spaces");
+    expect(slugify("--anthropic--")).toBe("anthropic");
+  });
+
+  test("handles empty string", () => {
+    expect(slugify("")).toBe("");
+  });
+
+  test("handles a string with no alphanumerics", () => {
+    expect(slugify("!!!")).toBe("");
+  });
+});
+
+describe("dedupeKey", () => {
+  test("returns the base when there is no collision", () => {
+    expect(dedupeKey("anthropic", [])).toBe("anthropic");
+    expect(dedupeKey("anthropic", ["openai"])).toBe("anthropic");
+  });
+
+  test("appends -2 on the first collision", () => {
+    expect(dedupeKey("anthropic", ["anthropic"])).toBe("anthropic-2");
+  });
+
+  test("walks the suffix until unique", () => {
+    expect(dedupeKey("anthropic", ["anthropic", "anthropic-2"])).toBe(
+      "anthropic-3",
+    );
+  });
+
+  test("compares case-insensitively", () => {
+    expect(dedupeKey("Anthropic", ["anthropic"])).toBe("Anthropic-2");
+  });
+});
+
+describe("deriveProviderDefaults", () => {
+  test("uses the display name and a deduped slug key", () => {
+    expect(deriveProviderDefaults("anthropic", [])).toEqual({
+      name: "Anthropic",
+      key: "anthropic",
+    });
+  });
+
+  test("dedupes the key against existing connection names", () => {
+    expect(deriveProviderDefaults("anthropic", ["anthropic"])).toEqual({
+      name: "Anthropic",
+      key: "anthropic-2",
+    });
+  });
+
+  test("falls back to the provider type when no display name exists", () => {
+    expect(deriveProviderDefaults("custom-provider", [])).toEqual({
+      name: "custom-provider",
+      key: "custom-provider",
+    });
+  });
+});
+
+describe("deriveProfileDefaults", () => {
+  test("uses the model display name and a deduped slug key", () => {
+    expect(deriveProfileDefaults("Claude Opus 4.7", [])).toEqual({
+      name: "Claude Opus 4.7",
+      key: "claude-opus-4-7",
+    });
+  });
+
+  test("dedupes the key against existing profile names", () => {
+    expect(
+      deriveProfileDefaults("Claude Opus 4.7", ["claude-opus-4-7"]),
+    ).toEqual({
+      name: "Claude Opus 4.7",
+      key: "claude-opus-4-7-2",
+    });
+  });
+});

--- a/apps/web/src/domains/settings/ai/profile-prefill.ts
+++ b/apps/web/src/domains/settings/ai/profile-prefill.ts
@@ -1,0 +1,59 @@
+import { INFERENCE_PROVIDER_DISPLAY_NAMES } from "@/domains/settings/ai/ai-types";
+import { toKebabCase } from "@/domains/settings/ai/slugify";
+
+/**
+ * Convert an arbitrary label into a URL/key-safe slug: lowercase, collapse any
+ * run of non-alphanumeric characters into a single `-`, and strip leading and
+ * trailing separators. e.g. "Claude Opus 4.7" -> "claude-opus-4-7".
+ */
+export function slugify(input: string): string {
+  return toKebabCase(input);
+}
+
+/**
+ * Return `base` if it does not already exist in `existing`, otherwise append a
+ * numeric suffix (`-2`, `-3`, ...) until the result is unique. Comparison is
+ * case-insensitive.
+ */
+export function dedupeKey(base: string, existing: string[]): string {
+  const taken = new Set(existing.map((name) => name.toLowerCase()));
+  if (!taken.has(base.toLowerCase())) {
+    return base;
+  }
+  let suffix = 2;
+  let candidate = `${base}-${suffix}`;
+  while (taken.has(candidate.toLowerCase())) {
+    suffix += 1;
+    candidate = `${base}-${suffix}`;
+  }
+  return candidate;
+}
+
+/**
+ * Derive default display name and key for a new provider connection of the
+ * given provider type, ensuring the key does not collide with existing
+ * connection names.
+ */
+export function deriveProviderDefaults(
+  providerType: string,
+  existingConnectionNames: string[],
+): { name: string; key: string } {
+  return {
+    name: INFERENCE_PROVIDER_DISPLAY_NAMES[providerType] ?? providerType,
+    key: dedupeKey(slugify(providerType), existingConnectionNames),
+  };
+}
+
+/**
+ * Derive default name and key for a new profile from a model's display name,
+ * ensuring the key does not collide with existing profile names.
+ */
+export function deriveProfileDefaults(
+  modelDisplayName: string,
+  existingProfileNames: string[],
+): { name: string; key: string } {
+  return {
+    name: modelDisplayName,
+    key: dedupeKey(slugify(modelDisplayName), existingProfileNames),
+  };
+}


### PR DESCRIPTION
## Summary
- Add slugify, dedupeKey, deriveProviderDefaults, deriveProfileDefaults pure helpers
- Unit tests for slug, dedupe collisions, and derive functions

Part of plan: provider-first-profile-quick-add.md (PR 1 of 5)