### PR TITLE
feat(web): Skills filter bottom sheet with categories

### DIFF
--- a/apps/web/src/domains/intelligence/components/skills/skill-filters.tsx
+++ b/apps/web/src/domains/intelligence/components/skills/skill-filters.tsx
@@ -1,6 +1,7 @@
 import {
   ArrowDownToLine,
   Box,
+  Check,
   CheckCircle,
   Filter,
   Globe,
@@ -13,12 +14,16 @@ import {
 import {
   type ChangeEvent,
   type Dispatch,
+  type ReactNode,
   type SetStateAction,
   useState,
 } from "react";
 
-import { Button, Input, Popover } from "@vellum/design-library";
+import { BottomSheet, Button, Input, PanelItem, Popover } from "@vellum/design-library";
+import { resolveCategoryIcon } from "@/domains/intelligence/skills/category-icon-map";
 import type { SkillFilter } from "@/domains/intelligence/skills/types";
+import type { CategoryInfo } from "@/domains/intelligence/skills/use-skill-categories";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 
 interface FilterOption {
   value: SkillFilter;
@@ -47,6 +52,17 @@ interface FilterBarProps {
   filter: SkillFilter;
   onFilterChange: (f: SkillFilter) => void;
   isSearching: boolean;
+  /** Available skill categories — surfaced inside the mobile filter sheet. */
+  categories: CategoryInfo[];
+  /** Currently selected category slug, or `null` for "All". */
+  category: string | null;
+  onCategoryChange: (category: string | null) => void;
+  /** Per-category result counts keyed by slug. */
+  counts: Record<string, number>;
+  /** Total result count across all categories (the "All" row badge). */
+  totalCount: number;
+  /** Hide counts while a search is in flight (they'd be stale mid-query). */
+  showCounts: boolean;
 }
 
 export function FilterBar({
@@ -55,6 +71,12 @@ export function FilterBar({
   filter,
   onFilterChange,
   isSearching,
+  categories,
+  category,
+  onCategoryChange,
+  counts,
+  totalCount,
+  showCounts,
 }: FilterBarProps) {
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     onSearchChange(e.target.value);
@@ -78,33 +100,63 @@ export function FilterBar({
         wrapperClassName="flex-1"
       />
 
-      <FilterDropdown value={filter} onChange={onFilterChange} />
+      <FilterControl
+        filter={filter}
+        onFilterChange={onFilterChange}
+        categories={categories}
+        category={category}
+        onCategoryChange={onCategoryChange}
+        counts={counts}
+        totalCount={totalCount}
+        showCounts={showCounts}
+      />
     </div>
   );
 }
 
-function FilterDropdown({
-  value,
-  onChange,
-}: {
-  value: SkillFilter;
-  onChange: (v: SkillFilter) => void;
-}) {
+interface FilterControlProps {
+  filter: SkillFilter;
+  onFilterChange: (v: SkillFilter) => void;
+  categories: CategoryInfo[];
+  category: string | null;
+  onCategoryChange: (category: string | null) => void;
+  counts: Record<string, number>;
+  totalCount: number;
+  showCounts: boolean;
+}
+
+/**
+ * Filter affordance for the Skills page. On mobile the outlined filter button
+ * opens a bottom sheet exposing Status, Source, AND Categories (the category
+ * sidebar is desktop-only, so the sheet is mobile's sole category surface). On
+ * desktop the same button opens a compact popover with Status + Source; the
+ * always-visible sidebar owns category selection there.
+ */
+function FilterControl(props: FilterControlProps) {
+  const isMobile = useIsMobile();
   const [open, setOpen] = useState(false);
+
+  const trigger = (
+    <Button
+      type="button"
+      variant="outlined"
+      iconOnly={<Filter aria-hidden />}
+      aria-label="Filter skills"
+      aria-haspopup={isMobile ? "dialog" : "listbox"}
+      aria-expanded={open}
+      tintColor="var(--primary-base)"
+    />
+  );
+
+  if (isMobile) {
+    return (
+      <FilterSheet {...props} open={open} onOpenChange={setOpen} trigger={trigger} />
+    );
+  }
 
   return (
     <Popover.Root open={open} onOpenChange={setOpen}>
-      <Popover.Trigger asChild>
-        <Button
-          type="button"
-          variant="outlined"
-          iconOnly={<Filter aria-hidden />}
-          aria-label="Filter skills"
-          aria-haspopup="listbox"
-          aria-expanded={open}
-          tintColor="var(--primary-base)"
-        />
-      </Popover.Trigger>
+      <Popover.Trigger asChild>{trigger}</Popover.Trigger>
       <Popover.Content
         align="end"
         sideOffset={4}
@@ -114,9 +166,9 @@ function FilterDropdown({
           <FilterGroup
             label="Status"
             options={STATUS_FILTERS}
-            selected={value}
+            selected={props.filter}
             onSelect={(v) => {
-              onChange(v);
+              props.onFilterChange(v);
               setOpen(false);
             }}
           />
@@ -127,15 +179,171 @@ function FilterDropdown({
           <FilterGroup
             label="Source"
             options={ORIGIN_FILTERS}
-            selected={value}
+            selected={props.filter}
             onSelect={(v) => {
-              onChange(v);
+              props.onFilterChange(v);
               setOpen(false);
             }}
           />
         </ul>
       </Popover.Content>
     </Popover.Root>
+  );
+}
+
+interface FilterSheetProps extends FilterControlProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  trigger: ReactNode;
+}
+
+/**
+ * Mobile bottom sheet. Status/Source and Categories are independent axes that
+ * both stay applied, so selecting a row updates the results live behind the
+ * sheet without closing it — the user dials in both, then taps Done (or
+ * outside) to dismiss.
+ */
+function FilterSheet({
+  filter,
+  onFilterChange,
+  categories,
+  category,
+  onCategoryChange,
+  counts,
+  totalCount,
+  showCounts,
+  open,
+  onOpenChange,
+  trigger,
+}: FilterSheetProps) {
+  const sortedCategories = [...categories].sort((a, b) =>
+    a.label.localeCompare(b.label),
+  );
+
+  return (
+    <BottomSheet.Root open={open} onOpenChange={onOpenChange}>
+      <BottomSheet.Trigger asChild>{trigger}</BottomSheet.Trigger>
+      <BottomSheet.Content className="max-h-[85dvh]" aria-describedby={undefined}>
+        <div
+          aria-hidden
+          className="mx-auto mb-3 h-1 w-9 shrink-0 rounded-full bg-[var(--border-element)]"
+        />
+        <BottomSheet.Header>
+          <BottomSheet.Title>Filters</BottomSheet.Title>
+        </BottomSheet.Header>
+        <BottomSheet.Body className="flex flex-col gap-3 pt-2">
+          <SheetSection label="Status">
+            {STATUS_FILTERS.map((option) => (
+              <FilterRow
+                key={option.value}
+                icon={option.icon}
+                label={option.label}
+                active={filter === option.value}
+                onSelect={() => onFilterChange(option.value)}
+              />
+            ))}
+          </SheetSection>
+
+          <SheetSection label="Source">
+            {ORIGIN_FILTERS.map((option) => (
+              <FilterRow
+                key={option.value}
+                icon={option.icon}
+                label={option.label}
+                active={filter === option.value}
+                onSelect={() => onFilterChange(option.value)}
+              />
+            ))}
+          </SheetSection>
+
+          <SheetSection label="Categories">
+            <FilterRow
+              icon={LayoutGrid}
+              label="All"
+              active={category === null}
+              badge={showCounts ? totalCount : undefined}
+              onSelect={() => onCategoryChange(null)}
+            />
+            {sortedCategories.map((cat) => (
+              <FilterRow
+                key={cat.slug}
+                icon={resolveCategoryIcon(cat.icon) ?? LayoutGrid}
+                label={cat.label}
+                active={category === cat.slug}
+                badge={showCounts ? (counts[cat.slug] ?? 0) : undefined}
+                onSelect={() => onCategoryChange(cat.slug)}
+              />
+            ))}
+          </SheetSection>
+        </BottomSheet.Body>
+        <BottomSheet.Footer>
+          <Button
+            type="button"
+            variant="primary"
+            fullWidth
+            onClick={() => onOpenChange(false)}
+          >
+            Done
+          </Button>
+        </BottomSheet.Footer>
+      </BottomSheet.Content>
+    </BottomSheet.Root>
+  );
+}
+
+/** Section grouping inside the mobile filter sheet. */
+function SheetSection({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <div>
+      <div
+        className="px-2 pb-1 text-body-small-default uppercase tracking-wide"
+        style={{ color: "var(--content-tertiary)" }}
+      >
+        {label}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+/**
+ * One selectable row inside the filter sheet. `badge` carries a result count
+ * (categories); the trailing check marks the active row on the count-less
+ * Status/Source axes where the branded highlight alone is easy to miss.
+ */
+function FilterRow({
+  icon,
+  label,
+  active,
+  badge,
+  onSelect,
+}: {
+  icon: typeof LayoutGrid;
+  label: string;
+  active: boolean;
+  badge?: ReactNode;
+  onSelect: () => void;
+}) {
+  return (
+    <PanelItem
+      icon={icon}
+      label={label}
+      active={active}
+      activeVariant="branded"
+      badge={badge}
+      trailingAction={
+        active && badge == null ? (
+          <Check className="h-4 w-4 text-[var(--primary-base)]" aria-hidden />
+        ) : undefined
+      }
+      onSelect={onSelect}
+    />
   );
 }
 

--- a/apps/web/src/domains/intelligence/components/skills/skills-tab.tsx
+++ b/apps/web/src/domains/intelligence/components/skills/skills-tab.tsx
@@ -223,6 +223,12 @@ export function SkillsTab({ assistantId, initialSkillId }: SkillsTabProps) {
         filter={filter}
         onFilterChange={setFilter}
         isSearching={isSearching}
+        categories={categories}
+        category={category}
+        onCategoryChange={setCategory}
+        counts={counts}
+        totalCount={totalCount}
+        showCounts={!isSearching}
       />
 
       <div className="flex min-h-0 flex-1 gap-6">


### PR DESCRIPTION
## Summary
- On mobile, the outlined filter button now opens a bottom sheet (BottomSheet primitive) with Status, Source, AND Categories sections — restoring mobile category access folded into the filter button per design direction.
- Native iOS feel: grab handle, grouped sections, PanelItem rows with 44px tap targets, branded active state, trailing counts on categories, sticky Done footer. Selections apply live (independent axes) without closing the sheet.
- Desktop keeps its compact Status/Source popover; the always-visible category sidebar is unchanged.
- Wired categories/category/counts/totalCount/showCounts from skills-tab into FilterBar.

Part of plan: ios-skills-figma-mock.md (follow-up)