### PR TITLE
feat(web): mount per-turn combined progress card and attach task-progress surface

### DIFF
--- a/apps/web/src/domains/chat/transcript/transcript-message-body.test.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.test.tsx
@@ -49,6 +49,7 @@ mock.module(
 );
 
 import type { DisplayMessage } from "@/domains/chat/utils/reconcile";
+import type { Surface } from "@/domains/chat/types/types";
 
 import { TranscriptMessageBody } from "@/domains/chat/transcript/transcript-message-body";
 import { buildTurnActivity } from "@/domains/chat/transcript/turn-activity";
@@ -1179,5 +1180,174 @@ describe("TranscriptMessageBody", () => {
 
     expect(projectedAnchorIds(message)).toEqual([]);
     expect(renderedAnchorIds(container)).toEqual([]);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Combined activity-summary card (web-activity-summary flag)
+  // ---------------------------------------------------------------------------
+
+  /** A task-progress surface fixture, as produced by a `task_progress` card. */
+  function taskProgressSurface(surfaceId: string): Surface {
+    return {
+      surfaceId,
+      surfaceType: "card",
+      data: {
+        template: "task_progress",
+        templateData: {
+          steps: [{ id: "s1", label: "Do the thing", status: "completed" }],
+        },
+      },
+    };
+  }
+
+  /** Assistant message with thinking + a tool call + a task-progress surface. */
+  function activityMessage(surfaceId = "tps-1"): DisplayMessage {
+    return {
+      id: "m-activity",
+      role: "assistant",
+      textSegments: ["all done"],
+      thinkingSegments: ["reasoning"],
+      contentOrder: [
+        { type: "thinking", id: "0" },
+        { type: "toolCall", id: "0" },
+        { type: "surface", id: surfaceId },
+        { type: "text", id: "0" },
+      ],
+      toolCalls: [
+        { id: "tc-1", toolName: "bash", input: {}, status: "completed" },
+      ],
+      surfaces: [taskProgressSurface(surfaceId)],
+      timestamp: 1_000,
+    };
+  }
+
+  test("flag ON: renders one combined card at the top with the task-progress surface hoisted, not inline", () => {
+    const message = activityMessage();
+    const { container, getByTestId } = render(
+      <TranscriptMessageBody
+        message={message}
+        expandedToolCallIds={new Set()}
+        expandedCardIds={new Map()}
+        expandedThinkingKeys={new Map()}
+        onSurfaceAction={noop}
+        activitySummaryEnabled
+      />,
+    );
+
+    // Exactly one combined-card header block renders, and it is the first child
+    // of the assistant content column (above the inline tool card).
+    const header = getByTestId("turn-activity-header");
+    expect(header).not.toBeNull();
+    expect(
+      container.querySelectorAll("[data-testid='turn-activity-header']").length,
+    ).toBe(1);
+
+    const toolCard = container.querySelector(
+      "[data-testid='tool-progress-card']",
+    );
+    expect(toolCard).not.toBeNull();
+    expect(
+      header.compareDocumentPosition(toolCard!) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+
+    // The task-progress surface renders exactly once, and it lives INSIDE the
+    // header block (hoisted) — not in its inline position.
+    const surfaces = container.querySelectorAll(
+      "[data-testid='surface'][data-surface-id='tps-1']",
+    );
+    expect(surfaces.length).toBe(1);
+    expect(header.contains(surfaces[0]!)).toBe(true);
+
+    // Inline tool/thinking cards still render with their activity anchors.
+    expect(renderedAnchorIds(container)).toEqual(projectedAnchorIds(message));
+  });
+
+  test("flag ON: clicking a pill calls onActivityStepClick with a matching inline anchorId", () => {
+    const message = activityMessage();
+    const clicked: string[] = [];
+    const { container } = render(
+      <TranscriptMessageBody
+        message={message}
+        expandedToolCallIds={new Set()}
+        expandedCardIds={new Map()}
+        expandedThinkingKeys={new Map()}
+        onSurfaceAction={noop}
+        activitySummaryEnabled
+        onActivityStepClick={(id) => clicked.push(id)}
+      />,
+    );
+
+    // The combined card starts collapsed; expand it so the step pills mount.
+    const expandToggle = container.querySelector(
+      "[aria-label='Expand steps']",
+    );
+    expect(expandToggle).not.toBeNull();
+    fireEvent.click(expandToggle!);
+
+    const pill = container.querySelector("[data-testid='turn-progress-pill']");
+    expect(pill).not.toBeNull();
+    // The pill wraps the actual clickable; click the inner button/element.
+    fireEvent.click(pill!.querySelector("button") ?? pill!);
+
+    expect(clicked.length).toBe(1);
+    // The clicked anchor matches one of the message's inline anchors.
+    expect(renderedAnchorIds(container)).toContain(clicked[0]!);
+  });
+
+  test("flag OFF (default): no combined card; task-progress surface renders inline", () => {
+    const message = activityMessage();
+    const { container } = render(
+      <TranscriptMessageBody
+        message={message}
+        expandedToolCallIds={new Set()}
+        expandedCardIds={new Map()}
+        expandedThinkingKeys={new Map()}
+        onSurfaceAction={noop}
+      />,
+    );
+
+    expect(
+      container.querySelector("[data-testid='turn-activity-header']"),
+    ).toBeNull();
+    // The task-progress surface renders once, in its original inline position.
+    const surfaces = container.querySelectorAll(
+      "[data-testid='surface'][data-surface-id='tps-1']",
+    );
+    expect(surfaces.length).toBe(1);
+  });
+
+  test("flag ON but no tool/thinking activity: no combined card; surface renders inline", () => {
+    const message: DisplayMessage = {
+      id: "m-no-activity",
+      role: "assistant",
+      textSegments: ["here is a plan"],
+      contentOrder: [
+        { type: "text", id: "0" },
+        { type: "surface", id: "tps-2" },
+      ],
+      surfaces: [taskProgressSurface("tps-2")],
+      timestamp: 1_000,
+    };
+
+    const { container } = render(
+      <TranscriptMessageBody
+        message={message}
+        expandedToolCallIds={new Set()}
+        expandedCardIds={new Map()}
+        expandedThinkingKeys={new Map()}
+        onSurfaceAction={noop}
+        activitySummaryEnabled
+      />,
+    );
+
+    // No steps → no combined card, and the surface is NOT hoisted.
+    expect(
+      container.querySelector("[data-testid='turn-activity-header']"),
+    ).toBeNull();
+    const surfaces = container.querySelectorAll(
+      "[data-testid='surface'][data-surface-id='tps-2']",
+    );
+    expect(surfaces.length).toBe(1);
   });
 });

--- a/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -17,12 +17,16 @@ import { SubagentInlineProgressCard } from "@/domains/chat/components/subagent-i
 import { SurfaceRouter } from "@/domains/chat/components/surfaces/surface-router";
 import { ThinkingBlock } from "@/domains/chat/components/thinking-block";
 import { ToolCallProgressCard } from "@/domains/chat/components/tool-call-progress-card/tool-call-progress-card";
+import { TurnProgressCard } from "@/domains/chat/components/turn-progress-card/turn-progress-card";
 import {
   getLeadingThinkingText,
   getLegacyLeadingThinkingText,
 } from "@/domains/chat/components/tool-progress-card/get-leading-thinking-text";
 import type { DisplayMessage } from "@/domains/chat/utils/reconcile";
-import { activityAnchorId } from "@/domains/chat/transcript/turn-activity";
+import {
+  activityAnchorId,
+  buildTurnActivity,
+} from "@/domains/chat/transcript/turn-activity";
 import { parseInlineSurfaces } from "@/domains/chat/utils/parse-inline-surfaces";
 import { segmentsToPlainText } from "@/domains/chat/utils/segments-to-plain-text";
 import {
@@ -38,6 +42,23 @@ import {
 import type { ConfirmationDecision } from "@/types/event-types";
 import type { AllowlistOption, DirectoryScopeOption, RiskScopeOption, ScopeOption } from "@/types/interaction-ui-types";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
+
+/**
+ * Detect a task-progress card surface — mirrors `CardSurface`'s `hasSteps`
+ * discrimination (`template === "task_progress"` with a non-empty `steps`
+ * array). Used by the activity-summary path to hoist this surface beneath the
+ * combined progress card and suppress it from its inline position.
+ */
+function isTaskProgressSurface(surface: Surface): boolean {
+  const data = surface.data as
+    | { template?: string; templateData?: { steps?: unknown } }
+    | undefined;
+  return (
+    data?.template === "task_progress" &&
+    Array.isArray(data.templateData?.steps) &&
+    (data.templateData!.steps as unknown[]).length > 0
+  );
+}
 
 export interface OpenRuleEditorContext {
   toolName: string;
@@ -352,10 +373,8 @@ export function TranscriptMessageBody({
   assistantId,
   onSubagentClick,
   onStopSubagent,
-  // Accepted but not yet read in render — the activity-summary card render
-  // path lands in a follow-up. Aliased to `_` so the unused props are explicit.
-  activitySummaryEnabled: _activitySummaryEnabled,
-  onActivityStepClick: _onActivityStepClick,
+  activitySummaryEnabled,
+  onActivityStepClick,
   isStreaming = false,
 }: TranscriptMessageBodyProps) {
   const hasInterleavedToolCalls = message.contentOrder?.some(
@@ -580,6 +599,61 @@ export function TranscriptMessageBody({
     );
   };
 
+  // Per-turn activity projection driving the combined progress card. Pure,
+  // cheap projection (no hook) — `buildTurnActivity` returns an empty activity
+  // for non-assistant messages, so it's safe to compute unconditionally. The
+  // card only renders below when the flag is on AND there's at least one step.
+  const activity = buildTurnActivity(message);
+  const renderActivityCard =
+    !isUser &&
+    Boolean(activitySummaryEnabled) &&
+    activity.steps.length > 0;
+
+  // Hoist the most recent task-progress surface beneath the combined card. Only
+  // when the card actually renders — with no steps there's nothing to attach to,
+  // so the task-progress surface renders inline as usual (see edge cases).
+  const hoistedTaskSurface = renderActivityCard
+    ? [...(message.surfaces ?? [])].reverse().find(isTaskProgressSurface)
+    : undefined;
+
+  // Suppress a surface from its INLINE position only when it's the hoisted
+  // task-progress surface (i.e. only when the combined card renders). Flag-off
+  // and no-step turns never suppress, keeping those paths byte-identical.
+  const isSuppressedInlineSurface = (surface: Surface): boolean =>
+    hoistedTaskSurface != null &&
+    surface.surfaceId === hoistedTaskSurface.surfaceId;
+
+  // Header block rendered as the FIRST child of the assistant content column in
+  // BOTH branches (interleaved + legacy). The combined card carousels through
+  // all tool/thinking steps; clicking a pill calls `onActivityStepClick` to
+  // scroll the matching inline card into view. The hoisted task-progress
+  // surface renders attached directly beneath, always expanded.
+  //
+  // Placement note: per the design screenshot the leading assistant text can
+  // appear above this card, but the plan specifies the combined card at the TOP
+  // of the assistant body. We render it at the top of the assistant content
+  // column (above the interleaved/legacy content); this is intentional and
+  // adjustable if the leading-text-above treatment is chosen later.
+  const activityHeader: ReactNode = renderActivityCard ? (
+    <div data-testid="turn-activity-header" className="flex w-full flex-col">
+      <TurnProgressCard
+        activity={activity}
+        onStepClick={(id) => onActivityStepClick?.(id)}
+        attachedBelow={Boolean(hoistedTaskSurface)}
+      />
+      {hoistedTaskSurface && (
+        <SurfaceRouter
+          surface={hoistedTaskSurface}
+          onAction={onSurfaceAction}
+          onOpenApp={onOpenApp}
+          onOpenDocument={onOpenDocument}
+          assistantId={assistantId}
+          toolCalls={message.toolCalls}
+        />
+      )}
+    </div>
+  ) : null;
+
   // Render the user-message content from an ordered, tagged list. Walks the
   // items in canonical `contentOrder` sequence, grouping CONTIGUOUS runs of
   // text into one `userBubbleClass` bubble while each non-text element (surface
@@ -793,6 +867,11 @@ export function TranscriptMessageBody({
               if (!surface) {
                 return null;
               }
+              // The hoisted task-progress surface renders only in the header
+              // block above — skip its inline position so it isn't duplicated.
+              if (isSuppressedInlineSurface(surface)) {
+                return null;
+              }
               return (
                 <div key={`surface-${gi}`} className="w-full">
                   <SurfaceRouter
@@ -853,6 +932,7 @@ export function TranscriptMessageBody({
             renderUserContent(interleavedUserItems)
           ) : (
             <>
+              {activityHeader}
               {interleavedGroupElements}
               {interleavedFallback}
               {hasAttachments && (
@@ -945,7 +1025,7 @@ export function TranscriptMessageBody({
         });
       } else if (entry.type === "surface") {
         const surface = resolveSurface(entry.id);
-        if (surface) {
+        if (surface && !isSuppressedInlineSurface(surface)) {
           contentEntries.push({
             type: "surface",
             node: (
@@ -1015,6 +1095,7 @@ export function TranscriptMessageBody({
       <div
         className={`flex w-full flex-col gap-2 ${message.role === "user" ? "items-end" : "items-start"}`}
       >
+        {activityHeader}
         {legacyToolCalls.length > 0 && (
           <>
             {/* Anchor the tool card only when a renderable (non-spawn) tool
@@ -1094,7 +1175,9 @@ export function TranscriptMessageBody({
               .map((e) => e.id) ?? [],
           );
           const unrendered = message.surfaces.filter(
-            (s) => !renderedSurfaceIds.has(s.surfaceId),
+            (s) =>
+              !renderedSurfaceIds.has(s.surfaceId) &&
+              !isSuppressedInlineSurface(s),
           );
           if (unrendered.length === 0) return null;
           return unrendered.map((surface) => (


### PR DESCRIPTION
## Summary
- Render a combined `TurnProgressCard` at the top of each assistant turn (behind the `web-activity-summary` flag) that carousels through all tool/thinking steps; pills call scrollToActivity to scroll to + highlight the inline card.
- Hoist the turn's task-progress surface to render attached beneath the card, always expanded, and suppress it from its inline position.
- Flag-off path is unchanged.

Part of plan: web-activity-summary.md (PR 7 of 7)