### PR TITLE
Extract ProviderCreateForm shared by the standalone and inline provider flows

### DIFF
--- a/apps/web/src/domains/settings/ai/provider-create-form.test.tsx
+++ b/apps/web/src/domains/settings/ai/provider-create-form.test.tsx
@@ -310,6 +310,26 @@ describe("ProviderCreateForm submit sequence", () => {
     });
   });
 
+  test("defaultAuthType='api_key' seeds the API Key path (Save as New clone)", () => {
+    render(
+      <ModalWrapper>
+        <ProviderCreateForm
+          assistantId={ASSISTANT_ID}
+          existingNames={[]}
+          defaultProviderType="anthropic"
+          defaultAuthType="api_key"
+          onCreated={() => {}}
+          onCancel={() => {}}
+        />
+      </ModalWrapper>,
+    );
+
+    // The API Key field only renders for api_key auth, so its presence
+    // confirms the form initialized on the "bring your own credential" path
+    // (instead of the managed-capable provider's default `platform`).
+    expect(getInputByPlaceholder("Enter your API key")).toBeDefined();
+  });
+
   test("clicking Cancel invokes onCancel", () => {
     let cancelled = false;
     render(

--- a/apps/web/src/domains/settings/ai/provider-create-form.test.tsx
+++ b/apps/web/src/domains/settings/ai/provider-create-form.test.tsx
@@ -1,0 +1,330 @@
+/**
+ * Tests for `ProviderCreateForm` — the shared create-path form extracted
+ * from `ProviderEditorContent`.
+ *
+ * The component owns the two-step create submit sequence:
+ *   1. `secretsPost` — persist the entered API key under
+ *      `credential/<service>/<field>` (sent as `<service>:<field>`).
+ *   2. `inferenceProviderconnectionsPost` — create the connection with the
+ *      assembled `CreateConnectionInput`, then hand the returned connection
+ *      back to the consumer via `onCreated`.
+ *
+ * We mock the generated daemon SDK (sdk.gen) at module scope via
+ * module-level holders so each test can inspect the exact request bodies,
+ * mirroring the mocking style in
+ * `use-conversation-actions-archive-optimistic.test.tsx`. The credential
+ * presence / list hooks are stubbed so the form doesn't fan out real
+ * network queries during render.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Modal } from "@vellum/design-library/components/modal";
+import { createElement, type ReactNode } from "react";
+
+import * as sdkGen from "@/generated/daemon/sdk.gen";
+import type { ProviderConnection } from "@/domains/settings/ai/provider-connections-client";
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+interface SecretsPostCall {
+  path: { assistant_id: string };
+  body: { type: string; name: string; value: string };
+}
+interface CreateConnectionCall {
+  path: { assistant_id: string };
+  body: Record<string, unknown>;
+}
+
+let secretsPostCalls: SecretsPostCall[] = [];
+let createConnectionCalls: CreateConnectionCall[] = [];
+let createdConnection: ProviderConnection;
+let createResponseOk = true;
+let createResponseStatus = 200;
+
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  ...sdkGen,
+  secretsPost: (opts: SecretsPostCall) => {
+    secretsPostCalls.push(opts);
+    return Promise.resolve({ data: undefined, response: { ok: true } });
+  },
+  inferenceProviderconnectionsPost: (opts: CreateConnectionCall) => {
+    createConnectionCalls.push(opts);
+    return Promise.resolve({
+      data: createResponseOk ? createdConnection : undefined,
+      response: { ok: createResponseOk, status: createResponseStatus },
+    });
+  },
+}));
+
+// Stub the credential hooks so render doesn't issue real daemon queries.
+// `hasStoredCredential: false` matches the empty create-mode state.
+mock.module("@/domains/settings/ai/use-stored-credential-presence", () => ({
+  useStoredCredentialPresence: () => ({
+    hasStoredCredential: false,
+    isLoading: false,
+    queryKey: ["stored-credential-presence"],
+  }),
+}));
+
+mock.module("@/domains/settings/ai/use-provider-credentials-list", () => ({
+  useProviderCredentialsList: () => ({
+    credentials: [],
+    isLoading: false,
+    queryKey: ["provider-credentials-list"],
+  }),
+}));
+
+const { ProviderCreateForm } = await import(
+  "@/domains/settings/ai/provider-create-form"
+);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ASSISTANT_ID = "asst-1";
+
+function makeConnection(name: string): ProviderConnection {
+  return {
+    name,
+    label: null,
+    provider: "anthropic",
+    auth: { type: "api_key", credential: "credential/anthropic/api_key" },
+    models: null,
+  } as unknown as ProviderConnection;
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return createElement(QueryClientProvider, { client }, children);
+}
+
+/**
+ * The `variant="modal"` form renders `Modal.Content` (a Radix Dialog
+ * portal), which requires a `Modal.Root` ancestor — exactly how
+ * `ProviderEditorContent` embeds it. Wrap modal-variant renders so the
+ * portal mounts.
+ */
+function ModalWrapper({ children }: { children: ReactNode }) {
+  return (
+    <Wrapper>
+      <Modal.Root open>{children}</Modal.Root>
+    </Wrapper>
+  );
+}
+
+function getInputByPlaceholder(placeholder: string): HTMLInputElement {
+  const input = Array.from(
+    document.querySelectorAll<HTMLInputElement>("input"),
+  ).find((el) => el.placeholder === placeholder);
+  if (!input) {
+    throw new Error(`expected an input with placeholder "${placeholder}"`);
+  }
+  return input;
+}
+
+function getButton(label: string): HTMLButtonElement {
+  const match = Array.from(
+    document.querySelectorAll<HTMLButtonElement>("button"),
+  ).find((b) => b.textContent?.trim() === label);
+  if (!match) {
+    throw new Error(
+      `expected a "${label}" button — saw: ${Array.from(
+        document.querySelectorAll("button"),
+      )
+        .map((b) => `"${b.textContent?.trim()}"`)
+        .join(", ")}`,
+    );
+  }
+  return match;
+}
+
+/**
+ * Drive the design-library Dropdown (a custom combobox, not a native
+ * <select>): click the trigger to open the listbox, then click the option
+ * whose visible label matches.
+ */
+function selectDropdownOption(ariaLabel: string, optionLabel: string): void {
+  const trigger = document.querySelector<HTMLButtonElement>(
+    `button[role="combobox"][aria-label="${ariaLabel}"]`,
+  );
+  if (!trigger) {
+    throw new Error(`expected a "${ariaLabel}" dropdown trigger`);
+  }
+  fireEvent.click(trigger);
+  const option = Array.from(
+    document.querySelectorAll<HTMLElement>('[role="option"]'),
+  ).find((o) => o.textContent?.trim() === optionLabel);
+  if (!option) {
+    throw new Error(
+      `expected an option "${optionLabel}" in the "${ariaLabel}" dropdown — saw: ${Array.from(
+        document.querySelectorAll('[role="option"]'),
+      )
+        .map((o) => `"${o.textContent?.trim()}"`)
+        .join(", ")}`,
+    );
+  }
+  fireEvent.click(option);
+}
+
+beforeEach(() => {
+  secretsPostCalls = [];
+  createConnectionCalls = [];
+  createdConnection = makeConnection("anthropic-personal");
+  createResponseOk = true;
+  createResponseStatus = 200;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ProviderCreateForm submit sequence", () => {
+  test("submitting an API key fires secretsPost then inferenceProviderconnectionsPost and calls onCreated", async () => {
+    let created: ProviderConnection | undefined;
+    render(
+      <ModalWrapper>
+        <ProviderCreateForm
+          assistantId={ASSISTANT_ID}
+          existingNames={[]}
+          onCreated={(c) => {
+            created = c;
+          }}
+          onCancel={() => {}}
+        />
+      </ModalWrapper>,
+    );
+
+    // Default provider is anthropic with platform auth — switch to API Key.
+    // Type a Key (name) and an API key value.
+    fireEvent.change(getInputByPlaceholder("e.g. anthropic-personal"), {
+      target: { value: "anthropic-personal" },
+    });
+
+    // Select API Key auth so the API Key field renders.
+    selectDropdownOption("Auth type", "API Key");
+
+    fireEvent.change(getInputByPlaceholder("Enter your API key"), {
+      target: { value: "sk-test-123" },
+    });
+
+    fireEvent.click(getButton("Create"));
+
+    await waitFor(() => {
+      expect(createConnectionCalls.length).toBe(1);
+    });
+
+    // secretsPost fired first with credential/<service>/<field> mapped to
+    // `<service>:<field>`.
+    expect(secretsPostCalls.length).toBe(1);
+    expect(secretsPostCalls[0].path.assistant_id).toBe(ASSISTANT_ID);
+    expect(secretsPostCalls[0].body).toEqual({
+      type: "credential",
+      name: "anthropic:api_key",
+      value: "sk-test-123",
+    });
+
+    // Then inferenceProviderconnectionsPost with the CreateConnectionInput.
+    expect(createConnectionCalls[0].path.assistant_id).toBe(ASSISTANT_ID);
+    expect(createConnectionCalls[0].body).toMatchObject({
+      name: "anthropic-personal",
+      provider: "anthropic",
+      auth: { type: "api_key", credential: "credential/anthropic/api_key" },
+    });
+
+    // onCreated received the returned connection.
+    await waitFor(() => {
+      expect(created).toBeDefined();
+    });
+    expect(created?.name).toBe("anthropic-personal");
+  });
+
+  test("blocks duplicate names with the existing validation message", () => {
+    render(
+      <ModalWrapper>
+        <ProviderCreateForm
+          assistantId={ASSISTANT_ID}
+          existingNames={["anthropic-personal"]}
+          onCreated={() => {}}
+          onCancel={() => {}}
+        />
+      </ModalWrapper>,
+    );
+
+    fireEvent.change(getInputByPlaceholder("e.g. anthropic-personal"), {
+      target: { value: "anthropic-personal" },
+    });
+
+    expect(document.body.textContent).toContain(
+      'A connection named "anthropic-personal" already exists.',
+    );
+    expect(getButton("Create").disabled).toBe(true);
+  });
+
+  test("variant=inline renders the form without Modal chrome and still creates", async () => {
+    let created: ProviderConnection | undefined;
+    render(
+      <Wrapper>
+        <ProviderCreateForm
+          variant="inline"
+          assistantId={ASSISTANT_ID}
+          existingNames={[]}
+          onCreated={(c) => {
+            created = c;
+          }}
+          onCancel={() => {}}
+        />
+      </Wrapper>,
+    );
+
+    // Inline variant drops the modal title.
+    expect(document.body.textContent).not.toContain("New Provider Connection");
+
+    fireEvent.change(getInputByPlaceholder("e.g. anthropic-personal"), {
+      target: { value: "anthropic-personal" },
+    });
+
+    selectDropdownOption("Auth type", "API Key");
+    fireEvent.change(getInputByPlaceholder("Enter your API key"), {
+      target: { value: "sk-test-123" },
+    });
+
+    fireEvent.click(getButton("Create"));
+
+    await waitFor(() => {
+      expect(createConnectionCalls.length).toBe(1);
+    });
+    await waitFor(() => {
+      expect(created?.name).toBe("anthropic-personal");
+    });
+  });
+
+  test("clicking Cancel invokes onCancel", () => {
+    let cancelled = false;
+    render(
+      <ModalWrapper>
+        <ProviderCreateForm
+          assistantId={ASSISTANT_ID}
+          existingNames={[]}
+          onCreated={() => {}}
+          onCancel={() => {
+            cancelled = true;
+          }}
+        />
+      </ModalWrapper>,
+    );
+    fireEvent.click(getButton("Cancel"));
+    expect(cancelled).toBe(true);
+  });
+});

--- a/apps/web/src/domains/settings/ai/provider-create-form.tsx
+++ b/apps/web/src/domains/settings/ai/provider-create-form.tsx
@@ -55,6 +55,13 @@ export interface ProviderCreateFormProps {
   chatgptSubscriptionEnabled?: boolean;
   /** Pre-selected provider type (e.g. when cloning a managed connection). */
   defaultProviderType?: ConnectionProvider;
+  /**
+   * Pre-selected auth type. When omitted, managed-capable providers default
+   * to `platform` (and ollama to `none`). The Save-as-New clone flow passes
+   * `api_key` here so cloning a managed connection seeds the "bring your own
+   * credential" path rather than another managed-proxy connection.
+   */
+  defaultAuthType?: AuthType;
   onCreated: (connection: ProviderConnection) => void;
   onCancel: () => void;
   /** "modal" wraps the form in Modal chrome; "inline" drops it for embedding. */
@@ -67,6 +74,7 @@ export function ProviderCreateForm({
   openAICompatibleEndpointsEnabled = false,
   chatgptSubscriptionEnabled = false,
   defaultProviderType,
+  defaultAuthType,
   onCreated,
   onCancel,
   variant = "modal",
@@ -76,8 +84,10 @@ export function ProviderCreateForm({
   const [label, setLabel] = useState("");
   const [name, setName] = useState("");
   const [provider, setProvider] = useState<ConnectionProvider>(initialProvider);
-  const [authType, setAuthType] = useState<AuthType>(() =>
-    initialProvider === "ollama" ? "none" : "platform",
+  const [authType, setAuthType] = useState<AuthType>(
+    () =>
+      defaultAuthType ??
+      (initialProvider === "ollama" ? "none" : "platform"),
   );
   const [credential, setCredential] = useState(() =>
     initialProvider === "ollama" ? "" : `credential/${initialProvider}/api_key`,

--- a/apps/web/src/domains/settings/ai/provider-create-form.tsx
+++ b/apps/web/src/domains/settings/ai/provider-create-form.tsx
@@ -1,0 +1,488 @@
+import { useMemo, useState, type ReactNode } from "react";
+
+import { useQueryClient } from "@tanstack/react-query";
+import { Button } from "@vellum/design-library/components/button";
+import { Dropdown } from "@vellum/design-library/components/dropdown";
+import { Input } from "@vellum/design-library/components/input";
+import { Modal } from "@vellum/design-library/components/modal";
+import { Typography } from "@vellum/design-library/components/typography";
+
+import {
+  inferenceProviderconnectionsPost,
+  secretsPost,
+} from "@/generated/daemon/sdk.gen";
+import { useStoredCredentialPresence } from "@/domains/settings/ai/use-stored-credential-presence";
+
+import { ChatgptOAuthSection } from "@/domains/settings/ai/chatgpt-oauth-section";
+import {
+  type Auth,
+  type ConnectionProvider,
+  type CreateConnectionInput,
+  PROVIDER_DISPLAY_NAMES,
+  type ProviderConnection,
+} from "@/domains/settings/ai/provider-connections-client";
+import {
+  type AuthType,
+  AUTH_TYPE_DISPLAY_NAMES,
+  CONNECTION_PROVIDERS,
+  connectionSaveErrorMessage,
+  parseCredentialRef,
+} from "@/domains/settings/ai/provider-editor-constants";
+import { ProviderEditorApiKeySection } from "@/domains/settings/ai/provider-editor-api-key-section";
+import { secretPlaceholder } from "@/domains/settings/ai/secret-placeholder";
+import { useLabelKeySync } from "@/domains/settings/ai/use-label-key-sync";
+import { useProviderCredentialsList } from "@/domains/settings/ai/use-provider-credentials-list";
+import { providerSupportsPlatformAuth } from "@/assistant/llm-model-catalog";
+
+// ---------------------------------------------------------------------------
+// ProviderCreateForm
+// ---------------------------------------------------------------------------
+//
+// Controlled presentational form for the CREATE path of a provider
+// connection. Lifted out of `ProviderEditorContent` so both the standalone
+// "Add Provider" modal (`variant="modal"`) and inline embeddings such as the
+// provider-first profile quick-add flow (`variant="inline"`) share the exact
+// same create UX, validation strings, and submit sequence
+// (`secretsPost` → `inferenceProviderconnectionsPost`).
+//
+// Edit / managed-edit live in `ProviderEditorContent` and are intentionally
+// NOT handled here — this component is create-only.
+
+export interface ProviderCreateFormProps {
+  assistantId: string;
+  existingNames: string[];
+  openAICompatibleEndpointsEnabled?: boolean;
+  chatgptSubscriptionEnabled?: boolean;
+  /** Pre-selected provider type (e.g. when cloning a managed connection). */
+  defaultProviderType?: ConnectionProvider;
+  onCreated: (connection: ProviderConnection) => void;
+  onCancel: () => void;
+  /** "modal" wraps the form in Modal chrome; "inline" drops it for embedding. */
+  variant?: "modal" | "inline";
+}
+
+export function ProviderCreateForm({
+  assistantId,
+  existingNames,
+  openAICompatibleEndpointsEnabled = false,
+  chatgptSubscriptionEnabled = false,
+  defaultProviderType,
+  onCreated,
+  onCancel,
+  variant = "modal",
+}: ProviderCreateFormProps) {
+  const initialProvider: ConnectionProvider = defaultProviderType ?? "anthropic";
+
+  const [label, setLabel] = useState("");
+  const [name, setName] = useState("");
+  const [provider, setProvider] = useState<ConnectionProvider>(initialProvider);
+  const [authType, setAuthType] = useState<AuthType>(() =>
+    initialProvider === "ollama" ? "none" : "platform",
+  );
+  const [credential, setCredential] = useState(() =>
+    initialProvider === "ollama" ? "" : `credential/${initialProvider}/api_key`,
+  );
+  const [baseUrl, setBaseUrl] = useState("");
+  const [connectionModels, setConnectionModels] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isOpenAICompatible = provider === "openai-compatible";
+  const connectionProviderOptions = useMemo(() => {
+    const options = openAICompatibleEndpointsEnabled
+      ? CONNECTION_PROVIDERS
+      : CONNECTION_PROVIDERS.filter((p) => p !== "openai-compatible");
+    if (provider && !options.includes(provider)) {
+      return [...options, provider];
+    }
+    return options;
+  }, [openAICompatibleEndpointsEnabled, provider]);
+
+  const { handleLabelChange, handleKeyChange: handleNameChange } =
+    useLabelKeySync("create", setLabel, setName);
+
+  const [apiKeyValue, setApiKeyValue] = useState("");
+  const [isSavingKey, setIsSavingKey] = useState(false);
+  const queryClient = useQueryClient();
+
+  // --- Credential presence (shared hook) ---
+  const parsedCredRef = useMemo(() => parseCredentialRef(credential), [credential]);
+  const needsCredentialCheck = authType === "api_key" && parsedCredRef !== null;
+
+  const {
+    hasStoredCredential,
+    isLoading: isLoadingCredential,
+    queryKey: credentialPresenceKey,
+  } = useStoredCredentialPresence({
+    assistantId,
+    credentialKind: "credential",
+    credentialName: parsedCredRef ? `${parsedCredRef.service}:${parsedCredRef.field}` : "",
+    enabled: needsCredentialCheck,
+    errorContext: "settings-provider-create-credential-presence",
+  });
+
+  // --- Available credentials list ---
+  const {
+    credentials: availableCredentials,
+    queryKey: credentialsListKey,
+  } = useProviderCredentialsList({
+    assistantId,
+    enabled: true,
+  });
+
+  const nameError = (() => {
+    if (!name.trim()) return null;
+    if (existingNames.includes(name.trim())) {
+      return `A connection named "${name.trim()}" already exists.`;
+    }
+    return null;
+  })();
+
+  const canSave = name.trim().length > 0 && !nameError;
+
+  async function handleSave() {
+    if (!canSave) return;
+    setSaving(true);
+    setError(null);
+    try {
+      let auth: Auth;
+
+      if (authType === "api_key") {
+        const effectiveCredential =
+          credential.trim() || `credential/${provider}/api_key`;
+        const trimmedKey = apiKeyValue.trim();
+
+        if (trimmedKey) {
+          setIsSavingKey(true);
+          try {
+            const parsed = parseCredentialRef(effectiveCredential);
+            await secretsPost({
+              path: { assistant_id: assistantId },
+              body: parsed
+                ? {
+                    type: "credential",
+                    name: `${parsed.service}:${parsed.field}`,
+                    value: trimmedKey,
+                  }
+                : {
+                    type: "api_key",
+                    name: provider,
+                    value: trimmedKey,
+                  },
+              throwOnError: true,
+            });
+            // Optimistically mark credential as present and invalidate
+            // the credentials list so TQ caches stay in sync.
+            queryClient.setQueryData(credentialPresenceKey, true);
+            void queryClient.invalidateQueries({ queryKey: credentialsListKey });
+          } catch {
+            setError("Failed to save API key. Please try again.");
+            return;
+          } finally {
+            setIsSavingKey(false);
+          }
+        } else if (!hasStoredCredential) {
+          setError("Enter an API key or select an existing credential.");
+          return;
+        }
+
+        auth = { type: "api_key", credential: effectiveCredential };
+      } else if (authType === "oauth_subscription") {
+        // OAuth subscription connections are created by the OAuth flow
+        // (ChatgptOAuthSection), not through Save.
+        setError("Use the \"Sign in with ChatGPT\" button to connect your subscription.");
+        return;
+      } else if (authType === "none") {
+        auth = { type: "none" };
+      } else {
+        auth = { type: "platform" };
+      }
+
+      const labelValue = label.trim() || null;
+
+      const input: CreateConnectionInput = {
+        name: name.trim(),
+        provider,
+        auth,
+        ...(labelValue !== null && { label: labelValue }),
+        ...(isOpenAICompatible && {
+          base_url: baseUrl.trim() || null,
+          models: connectionModels.trim()
+            ? connectionModels
+                .split(",")
+                .map((id) => ({ id: id.trim() }))
+                .filter((m) => m.id)
+            : null,
+        }),
+      };
+      const { data: created, response: createRes } = await inferenceProviderconnectionsPost({
+        path: { assistant_id: assistantId },
+        body: input,
+      });
+      if (!createRes?.ok) {
+        setError(connectionSaveErrorMessage(createRes?.status, name.trim()));
+        return;
+      }
+      if (!created) {
+        setError("Server returned an empty response. Please try again.");
+        return;
+      }
+      onCreated(created);
+    } catch {
+      setError("Failed to save connection. Please try again.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  // Credentials for the current provider (used in the Advanced dropdown)
+  const providerCredentials = availableCredentials.filter(
+    (c) => c.service === provider,
+  );
+
+  // Show the Advanced credential-reference disclosure only when there's at
+  // least one stored credential for the provider. In the create-mode empty
+  // state the API Key field above is the only path needed — saving a key
+  // auto-creates `credential/<provider>/api_key` under the hood, so the
+  // disclosure has nothing meaningful to offer.
+  const shouldShowAdvancedSection = providerCredentials.length > 0;
+  const apiKeyPlaceholder = secretPlaceholder(
+    "Enter your API key",
+    hasStoredCredential,
+  );
+
+  const body = (
+    <div className="space-y-4">
+      {/* Display Name */}
+      <div className="space-y-1">
+        <label className="block text-body-small-default text-[var(--content-tertiary)]">
+          Display Name{" "}
+          <span className="text-[var(--content-disabled)]">(optional)</span>
+        </label>
+        <Input
+          value={label}
+          onChange={(e) => handleLabelChange(e.target.value)}
+          placeholder="e.g. My Anthropic Key"
+          fullWidth
+        />
+      </div>
+
+      {/* Key — editable on create, auto-derived from label */}
+      <div className="space-y-1">
+        <label className="block text-body-small-default text-[var(--content-tertiary)]">
+          Key
+        </label>
+        <Input
+          value={name}
+          onChange={(e) => {
+            handleNameChange(e.target.value);
+            setError(null);
+          }}
+          placeholder="e.g. anthropic-personal"
+          fullWidth
+        />
+        {nameError && (
+          <Typography
+            variant="body-small-default"
+            as="p"
+            className="text-(--system-negative-strong)"
+          >
+            {nameError}
+          </Typography>
+        )}
+      </div>
+
+      {/* Provider */}
+      <div className="space-y-1">
+        <label className="block text-body-small-default text-[var(--content-tertiary)]">
+          Provider
+        </label>
+        <Dropdown
+          aria-label="Provider"
+          value={provider}
+          onChange={(v) => {
+            const newProvider = v as ConnectionProvider;
+            setProvider(newProvider);
+            if (newProvider === "ollama") {
+              setAuthType("none");
+              setCredential("");
+            } else {
+              setAuthType((prev) => {
+                if (prev === "none") {
+                  return "api_key";
+                }
+                if (
+                  prev === "oauth_subscription" &&
+                  newProvider !== "openai"
+                ) {
+                  return "api_key";
+                }
+                if (
+                  prev === "platform" &&
+                  !providerSupportsPlatformAuth(newProvider)
+                ) {
+                  return "api_key";
+                }
+                return prev;
+              });
+              setCredential(`credential/${newProvider}/api_key`);
+            }
+            // Credential ref changes above trigger a new TQ query key,
+            // so the presence check auto-refetches for the new provider.
+          }}
+          options={connectionProviderOptions.map((p) => ({
+            value: p,
+            label: PROVIDER_DISPLAY_NAMES[p],
+          }))}
+        />
+      </div>
+
+      {/* Base URL + Models — openai-compatible only */}
+      {isOpenAICompatible && (
+        <>
+          <div className="space-y-1">
+            <label className="block text-body-small-default text-[var(--content-tertiary)]">
+              Base URL
+            </label>
+            <Input
+              value={baseUrl}
+              onChange={(e) => setBaseUrl(e.target.value)}
+              placeholder="https://api.example.com/v1"
+              fullWidth
+            />
+          </div>
+          <div className="space-y-1">
+            <label className="block text-body-small-default text-[var(--content-tertiary)]">
+              Models
+            </label>
+            <Input
+              value={connectionModels}
+              onChange={(e) => setConnectionModels(e.target.value)}
+              placeholder="model-1, model-2"
+              fullWidth
+            />
+            <Typography
+              variant="body-small-default"
+              as="p"
+              className="text-[var(--content-tertiary)]"
+            >
+              Comma-separated model identifiers exposed by your endpoint.
+            </Typography>
+          </div>
+        </>
+      )}
+
+      {/* Auth type */}
+      <div className="space-y-1">
+        <label className="block text-body-small-default text-[var(--content-tertiary)]">
+          Auth Type
+        </label>
+        <Dropdown
+          aria-label="Auth type"
+          value={authType}
+          onChange={(v) => {
+            setAuthType(v as AuthType);
+            setError(null);
+          }}
+          disabled={provider === "ollama"}
+          options={(() => {
+            let types: AuthType[];
+            if (provider === "ollama") {
+              types = ["none"];
+            } else if (providerSupportsPlatformAuth(provider)) {
+              types = ["api_key", "platform"];
+            } else {
+              types = ["api_key"];
+            }
+            // Add oauth_subscription when ChatGPT flag is enabled for OpenAI.
+            if (chatgptSubscriptionEnabled && provider === "openai") {
+              types.push("oauth_subscription");
+            }
+            if (authType && !types.includes(authType)) {
+              types.push(authType);
+            }
+            return types.map((t) => ({
+              value: t,
+              label: AUTH_TYPE_DISPLAY_NAMES[t],
+            }));
+          })()}
+        />
+      </div>
+
+      {/* API Key + Advanced disclosure — only shown for api_key auth */}
+      {authType === "api_key" && (
+        <ProviderEditorApiKeySection
+          apiKeyValue={apiKeyValue}
+          onApiKeyChange={setApiKeyValue}
+          credential={credential}
+          onCredentialChange={setCredential}
+          isAuthLocked={false}
+          isLoadingCredential={isLoadingCredential}
+          apiKeyPlaceholder={apiKeyPlaceholder}
+          provider={provider}
+          providerCredentials={providerCredentials}
+          showAdvancedSection={shouldShowAdvancedSection}
+          onError={setError}
+        />
+      )}
+
+      {/* ChatGPT Subscription OAuth — shown when auth type is oauth_subscription */}
+      {authType === "oauth_subscription" && (
+        <ChatgptOAuthSection
+          assistantId={assistantId}
+          onConnected={onCreated}
+        />
+      )}
+
+      {error && (
+        <Typography
+          variant="body-small-default"
+          as="p"
+          className="text-(--system-negative-strong)"
+        >
+          {error}
+        </Typography>
+      )}
+    </div>
+  );
+
+  const footer: ReactNode = (
+    <>
+      <Button variant="ghost" size="compact" onClick={onCancel}>
+        Cancel
+      </Button>
+      <Button
+        variant="primary"
+        size="compact"
+        disabled={!canSave || saving || isSavingKey}
+        onClick={() => void handleSave()}
+      >
+        {saving ? "Saving…" : "Create"}
+      </Button>
+    </>
+  );
+
+  if (variant === "inline") {
+    return (
+      <div className="space-y-4">
+        {body}
+        <div className="flex justify-end gap-2">{footer}</div>
+      </div>
+    );
+  }
+
+  return (
+    <Modal.Content size="md">
+      <Modal.Header>
+        <Modal.Title>New Provider Connection</Modal.Title>
+        <Modal.Description>
+          Define a provider and auth configuration for inference routing.
+        </Modal.Description>
+      </Modal.Header>
+
+      <Modal.Body>{body}</Modal.Body>
+
+      <Modal.Footer>{footer}</Modal.Footer>
+    </Modal.Content>
+  );
+}

--- a/apps/web/src/domains/settings/ai/provider-editor-modal.tsx
+++ b/apps/web/src/domains/settings/ai/provider-editor-modal.tsx
@@ -84,6 +84,13 @@ export function ProviderEditorContent({
     "create" | "edit" | "managed-edit"
   >(mode);
 
+  // Auth type to seed the create form with when entering create mode via the
+  // Save as New clone flow. `undefined` for a genuine "create" open so the
+  // form keeps its own default (platform for managed-capable providers).
+  const [createAuthTypeSeed, setCreateAuthTypeSeed] = useState<
+    AuthType | undefined
+  >(undefined);
+
   // True when the editor is opened for a Vellum-managed connection. Locks
   // the auth-related inputs (Auth Type, API Key, Credential Reference) but
   // leaves Display Name + Status editable. Keyed off `effectiveMode` so
@@ -207,25 +214,7 @@ export function ProviderEditorContent({
   // common path for cloning off a managed connection).
   function handleSaveAsNew() {
     setEffectiveMode("create");
-    // Clear the Key so the user picks a new unique name. Reset the dirty
-    // flag so subsequent Label edits auto-derive the Key, matching the
-    // create-mode default UX.
-    setName("");
-    resetDirty();
-    if (provider === "ollama") {
-      setAuthType("none");
-      setCredential("");
-    } else {
-      setAuthType("api_key");
-      setCredential(`credential/${provider}/api_key`);
-    }
-    setApiKeyValue("");
-    setBaseUrl("");
-    setConnectionModels("");
-    setError(null);
-    // TQ credential queries auto-refetch: credential ref change above
-    // triggers a new presence query key, and the credentials list query
-    // stays enabled (effectiveMode is now "create").
+    setCreateAuthTypeSeed(provider === "ollama" ? "none" : "api_key");
   }
 
   const nameError = (() => {
@@ -377,6 +366,7 @@ export function ProviderEditorContent({
         openAICompatibleEndpointsEnabled={openAICompatibleEndpointsEnabled}
         chatgptSubscriptionEnabled={chatgptSubscriptionEnabled}
         defaultProviderType={provider}
+        defaultAuthType={createAuthTypeSeed}
         onCreated={onSave}
         onCancel={onCancel}
       />

--- a/apps/web/src/domains/settings/ai/provider-editor-modal.tsx
+++ b/apps/web/src/domains/settings/ai/provider-editor-modal.tsx
@@ -9,16 +9,15 @@ import { Typography } from "@vellum/design-library/components/typography";
 
 import {
   inferenceProviderconnectionsByNamePatch,
-  inferenceProviderconnectionsPost,
   secretsPost,
 } from "@/generated/daemon/sdk.gen";
 import { useStoredCredentialPresence } from "@/domains/settings/ai/use-stored-credential-presence";
 
 import { ChatgptOAuthSection } from "@/domains/settings/ai/chatgpt-oauth-section";
+import { ProviderCreateForm } from "@/domains/settings/ai/provider-create-form";
 import {
   type Auth,
   type ConnectionProvider,
-  type CreateConnectionInput,
   PROVIDER_DISPLAY_NAMES,
   type ProviderConnection,
   type UpdateConnectionInput,
@@ -280,23 +279,17 @@ export function ProviderEditorContent({
           } finally {
             setIsSavingKey(false);
           }
-        } else if (
-          !hasStoredCredential &&
-          effectiveMode === "create"
-        ) {
-          setError("Enter an API key or select an existing credential.");
-          return;
         }
 
         auth = { type: "api_key", credential: effectiveCredential };
       } else if (authType === "oauth_subscription") {
-        if (effectiveMode !== "create" && connection?.auth.type === "oauth_subscription") {
+        if (connection?.auth.type === "oauth_subscription") {
           // Editing an existing oauth_subscription connection — preserve
           // the stored auth so users can update display name / status.
           auth = connection.auth;
         } else {
-          // Create mode: OAuth subscription connections are created by
-          // the OAuth flow (handleChatgptUrlSubmit), not through Save.
+          // OAuth subscription connections are created by the OAuth flow
+          // (handleChatgptUrlSubmit), not through Save.
           setError("Use the \"Sign in with ChatGPT\" button to connect your subscription.");
           return;
         }
@@ -308,69 +301,35 @@ export function ProviderEditorContent({
 
       const labelValue = label.trim() || null;
 
-      let saved: ProviderConnection;
-      if (effectiveMode === "create") {
-        // Create path — used by genuine create-mode opens AND by the
-        // Save as New transition out of managed-edit. POSTs to
-        // `createConnection` either way, so the daemon assigns a fresh
-        // row that the user owns (not a managed clone).
-        const input: CreateConnectionInput = {
-          name: name.trim(),
-          provider,
-          auth,
-          ...(labelValue !== null && { label: labelValue }),
-          ...(isOpenAICompatible && {
-            base_url: baseUrl.trim() || null,
-            models: connectionModels.trim()
-              ? connectionModels
-                  .split(",")
-                  .map((id) => ({ id: id.trim() }))
-                  .filter((m) => m.id)
-              : null,
-          }),
-        };
-        const { data: created, response: createRes } = await inferenceProviderconnectionsPost({
-          path: { assistant_id: assistantId },
-          body: input,
-        });
-        if (!createRes?.ok) {
-          setError(connectionSaveErrorMessage(createRes?.status, name.trim()));
-          return;
-        }
-        if (!created) {
-          setError("Server returned an empty response. Please try again.");
-          return;
-        }
-        saved = created;
-      } else {
-        const input: UpdateConnectionInput = {
-          auth,
-          label: labelValue,
-          ...(isOpenAICompatible && {
-            base_url: baseUrl.trim() || null,
-            models: connectionModels.trim()
-              ? connectionModels
-                  .split(",")
-                  .map((id) => ({ id: id.trim() }))
-                  .filter((m) => m.id)
-              : null,
-          }),
-        };
-        const { data: updated, response: updateRes } = await inferenceProviderconnectionsByNamePatch({
-          path: { assistant_id: assistantId, name: connection?.name ?? name.trim() },
-          body: input,
-        });
-        if (!updateRes?.ok) {
-          setError(connectionSaveErrorMessage(updateRes?.status, name.trim()));
-          return;
-        }
-        if (!updated) {
-          setError("Server returned an empty response. Please try again.");
-          return;
-        }
-        saved = updated;
+      // Edit / managed-edit only — create mode is handled by
+      // ProviderCreateForm (see the early return above), which owns the
+      // POST path. This component never reaches handleSave in create mode.
+      const input: UpdateConnectionInput = {
+        auth,
+        label: labelValue,
+        ...(isOpenAICompatible && {
+          base_url: baseUrl.trim() || null,
+          models: connectionModels.trim()
+            ? connectionModels
+                .split(",")
+                .map((id) => ({ id: id.trim() }))
+                .filter((m) => m.id)
+            : null,
+        }),
+      };
+      const { data: updated, response: updateRes } = await inferenceProviderconnectionsByNamePatch({
+        path: { assistant_id: assistantId, name: connection?.name ?? name.trim() },
+        body: input,
+      });
+      if (!updateRes?.ok) {
+        setError(connectionSaveErrorMessage(updateRes?.status, name.trim()));
+        return;
       }
-      onSave(saved);
+      if (!updated) {
+        setError("Server returned an empty response. Please try again.");
+        return;
+      }
+      onSave(updated);
     } catch {
       setError("Failed to save connection. Please try again.");
     } finally {
@@ -401,20 +360,37 @@ export function ProviderEditorContent({
     hasStoredCredential,
   );
 
+  // Create mode (genuine opens AND the Save as New transition out of
+  // managed-edit) is fully owned by the shared ProviderCreateForm. It
+  // carries the create-path submit sequence (secretsPost →
+  // inferenceProviderconnectionsPost) and renders identical modal chrome.
+  // The `provider` carried over from a Save as New clone seeds the form via
+  // `defaultProviderType`. Keyed on it so a fresh provider remounts the form
+  // with the cloned starting point. Edit / managed-edit fall through below.
+  if (effectiveMode === "create") {
+    return (
+      <ProviderCreateForm
+        key={provider}
+        variant="modal"
+        assistantId={assistantId}
+        existingNames={existingNames}
+        openAICompatibleEndpointsEnabled={openAICompatibleEndpointsEnabled}
+        chatgptSubscriptionEnabled={chatgptSubscriptionEnabled}
+        defaultProviderType={provider}
+        onCreated={onSave}
+        onCancel={onCancel}
+      />
+    );
+  }
+
   return (
     <Modal.Content size="md">
       <Modal.Header>
-        <Modal.Title>
-          {effectiveMode === "create"
-            ? "New Provider Connection"
-            : "Edit Connection"}
-        </Modal.Title>
+        <Modal.Title>Edit Connection</Modal.Title>
         <Modal.Description>
-          {effectiveMode === "create"
-            ? "Define a provider and auth configuration for inference routing."
-            : isAuthLocked
-              ? `Managed by Vellum — auth is locked, but you can rename "${connection?.name}".`
-              : `Editing "${connection?.name}".`}
+          {isAuthLocked
+            ? `Managed by Vellum — auth is locked, but you can rename "${connection?.name}".`
+            : `Editing "${connection?.name}".`}
         </Modal.Description>
       </Modal.Header>
 
@@ -445,7 +421,7 @@ export function ProviderEditorContent({
               setError(null);
             }}
             placeholder="e.g. anthropic-personal"
-            disabled={effectiveMode !== "create"}
+            disabled
             fullWidth
           />
           {nameError && (
@@ -459,7 +435,8 @@ export function ProviderEditorContent({
           )}
         </div>
 
-        {/* Provider — only selectable on create */}
+        {/* Provider — read-only in edit / managed-edit (provider is fixed
+            once a connection exists; create mode lives in ProviderCreateForm). */}
         <div className="space-y-1">
           <label className="block text-body-small-default text-[var(--content-tertiary)]">
             Provider
@@ -467,39 +444,8 @@ export function ProviderEditorContent({
           <Dropdown
             aria-label="Provider"
             value={provider}
-            onChange={(v) => {
-              const newProvider = v as ConnectionProvider;
-              setProvider(newProvider);
-              if (effectiveMode === "create") {
-                if (newProvider === "ollama") {
-                  setAuthType("none");
-                  setCredential("");
-                } else {
-                  setAuthType((prev) => {
-                    if (prev === "none") {
-                      return "api_key";
-                    }
-                    if (
-                      prev === "oauth_subscription" &&
-                      newProvider !== "openai"
-                    ) {
-                      return "api_key";
-                    }
-                    if (
-                      prev === "platform" &&
-                      !providerSupportsPlatformAuth(newProvider)
-                    ) {
-                      return "api_key";
-                    }
-                    return prev;
-                  });
-                  setCredential(`credential/${newProvider}/api_key`);
-                }
-                // Credential ref changes above trigger a new TQ query key,
-                // so the presence check auto-refetches for the new provider.
-              }
-            }}
-            disabled={effectiveMode !== "create"}
+            onChange={(v) => setProvider(v as ConnectionProvider)}
+            disabled
             options={connectionProviderOptions.map((p) => ({
               value: p,
               label: PROVIDER_DISPLAY_NAMES[p],
@@ -565,15 +511,6 @@ export function ProviderEditorContent({
                 types = ["api_key", "platform"];
               } else {
                 types = ["api_key"];
-              }
-              // Add oauth_subscription when ChatGPT flag is enabled for
-              // OpenAI in create mode.
-              if (
-                chatgptSubscriptionEnabled &&
-                provider === "openai" &&
-                effectiveMode === "create"
-              ) {
-                types.push("oauth_subscription");
               }
               // Preserve the current auth type in edit mode so existing
               // connections display their saved value even if the type is
@@ -650,11 +587,7 @@ export function ProviderEditorContent({
           disabled={!canSave || saving || isSavingKey}
           onClick={() => void handleSave()}
         >
-          {saving
-            ? "Saving…"
-            : effectiveMode === "create"
-              ? "Create"
-              : "Save"}
+          {saving ? "Saving…" : "Save"}
         </Button>
       </Modal.Footer>
     </Modal.Content>


### PR DESCRIPTION
## Summary
- Extract reusable ProviderCreateForm from ProviderEditorContent create path
- Refactor standalone provider modal to consume it (variant=modal); edit/managed-edit unchanged
- Add tests asserting secretsPost + inferenceProviderconnectionsPost submit bodies and onCreated

Part of plan: provider-first-profile-quick-add.md (PR 2 of 5)