### PR TITLE
refactor(web): consolidate duplicated transcript content helpers

### DIFF
--- a/apps/web/src/domains/chat/components/surfaces/card-surface.tsx
+++ b/apps/web/src/domains/chat/components/surfaces/card-surface.tsx
@@ -3,6 +3,7 @@ import { Circle, CircleCheck, CircleX, Clock, Loader2 } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 
 import type { Surface } from "@/domains/chat/types/types";
+import { isTaskProgressSurface } from "@/domains/chat/transcript/message-content";
 
 import { LazyBoundary } from "@/components/lazy-boundary";
 import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-message";
@@ -204,8 +205,9 @@ export function CardSurface({ surface, onAction }: CardSurfaceProps) {
   const data = surface.data as unknown as CardSurfaceData;
   const isWeather = data.template === "weather_forecast" && data.templateData;
   const isTaskProgress = data.template === "task_progress" && data.templateData;
-  const hasSteps = isTaskProgress && Array.isArray(data.templateData?.steps) &&
-    (data.templateData!.steps as unknown[]).length > 0;
+  // Shared predicate so this render-detection and the activity-summary
+  // hoist-detection in transcript-message-body cannot drift.
+  const hasSteps = isTaskProgressSurface(surface);
 
   if (hasSteps) {
     return (

--- a/apps/web/src/domains/chat/hooks/tool-call-card-utils.ts
+++ b/apps/web/src/domains/chat/hooks/tool-call-card-utils.ts
@@ -462,7 +462,23 @@ function deriveCarouselItems(
 // ---------------------------------------------------------------------------
 
 /**
- * Card-level state derivation. Precedence (highest first):
+ * Combine per-call/per-step states into a single card-level state using the
+ * canonical precedence (highest first): `denied` > `loading` > `error` >
+ * `complete`. Shared so the per-turn activity aggregate (`turn-activity.ts`)
+ * and `deriveCardState` below cannot drift.
+ */
+export function combineCardStates(
+  states: Array<"loading" | "complete" | "error" | "denied">,
+): "loading" | "complete" | "error" | "denied" {
+  if (states.includes("denied")) return "denied";
+  if (states.includes("loading")) return "loading";
+  if (states.includes("error")) return "error";
+  return "complete";
+}
+
+/**
+ * Card-level state derivation. Maps each tool call to its narrowed state and
+ * combines them via `combineCardStates`. Precedence (highest first):
  *   1. `denied` — any tool call whose confirmation was denied or timed-out.
  *   2. `loading` — any tool call still running.
  *   3. `error` — any tool ended in `status === "error"` (no still-running).
@@ -471,23 +487,19 @@ function deriveCarouselItems(
 function deriveCardState(
   toolCalls: ChatMessageToolCall[],
 ): "loading" | "complete" | "error" | "denied" {
-  let anyRunning = false;
-  let anyError = false;
-  let anyDenied = false;
-  for (const tc of toolCalls) {
-    if (
-      tc.confirmationDecision === "denied" ||
-      tc.confirmationDecision === "timed_out"
-    ) {
-      anyDenied = true;
-    }
-    if (tc.status === "running") anyRunning = true;
-    if (tc.status === "error") anyError = true;
-  }
-  if (anyDenied) return "denied";
-  if (anyRunning) return "loading";
-  if (anyError) return "error";
-  return "complete";
+  return combineCardStates(
+    toolCalls.map((tc) => {
+      if (
+        tc.confirmationDecision === "denied" ||
+        tc.confirmationDecision === "timed_out"
+      ) {
+        return "denied";
+      }
+      if (tc.status === "running") return "loading";
+      if (tc.status === "error") return "error";
+      return "complete";
+    }),
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/domains/chat/transcript/message-content.test.ts
+++ b/apps/web/src/domains/chat/transcript/message-content.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
+import type { Surface } from "@/domains/chat/types/types";
+import type { DisplayMessage } from "@/domains/chat/utils/reconcile";
+import {
+  groupMessageContent,
+  isSubagentSpawnCall,
+  isSuppressedUiTool,
+  isTaskProgressSurface,
+  resolveThinkingContent,
+  resolveToolCall,
+} from "@/domains/chat/transcript/message-content";
+
+function toolCall(
+  overrides: Partial<ChatMessageToolCall> & Pick<ChatMessageToolCall, "id">,
+): ChatMessageToolCall {
+  return {
+    toolName: "bash",
+    input: {},
+    status: "completed",
+    ...overrides,
+  };
+}
+
+function assistant(overrides: Partial<DisplayMessage>): DisplayMessage {
+  return {
+    id: "m1",
+    role: "assistant",
+    ...overrides,
+  };
+}
+
+function surface(data: Record<string, unknown>): Surface {
+  return { surfaceId: "s1", surfaceType: "card", data };
+}
+
+describe("groupMessageContent", () => {
+  test("merges consecutive toolCall/tool and thinking, passes text/surface", () => {
+    const message = assistant({
+      contentOrder: [
+        { type: "thinking", id: "0" },
+        { type: "thinking", id: "1" },
+        { type: "toolCall", id: "a" },
+        { type: "tool", id: "b" },
+        { type: "text", id: "0" },
+        { type: "surface", id: "0" },
+        { type: "toolCall", id: "c" },
+      ],
+    });
+
+    expect(groupMessageContent(message)).toEqual([
+      { type: "thinking", ids: ["0", "1"] },
+      { type: "toolCalls", ids: ["a", "b"] },
+      { type: "text", id: "0" },
+      { type: "surface", id: "0" },
+      { type: "toolCalls", ids: ["c"] },
+    ]);
+  });
+
+  test("empty / missing contentOrder yields no groups", () => {
+    expect(groupMessageContent(assistant({}))).toEqual([]);
+  });
+});
+
+describe("resolveToolCall", () => {
+  const message = assistant({
+    toolCalls: [toolCall({ id: "call-a" }), toolCall({ id: "call-b" })],
+  });
+
+  test("finds by id", () => {
+    expect(resolveToolCall(message, "call-b")?.id).toBe("call-b");
+  });
+
+  test("falls back to positional index", () => {
+    expect(resolveToolCall(message, "0")?.id).toBe("call-a");
+    expect(resolveToolCall(message, "1")?.id).toBe("call-b");
+  });
+
+  test("returns undefined when out of range / unmatched", () => {
+    expect(resolveToolCall(message, "9")).toBeUndefined();
+    expect(resolveToolCall(message, "nope")).toBeUndefined();
+  });
+});
+
+describe("resolveThinkingContent", () => {
+  test("joins referenced segments with newlines, skipping missing", () => {
+    const message = assistant({ thinkingSegments: ["first", "second"] });
+    expect(resolveThinkingContent(message, ["0", "1"])).toBe("first\nsecond");
+    expect(resolveThinkingContent(message, ["0", "9"])).toBe("first");
+    expect(resolveThinkingContent(message, ["nan"])).toBe("");
+  });
+});
+
+describe("isSubagentSpawnCall", () => {
+  test("matches bare subagent_spawn", () => {
+    expect(isSubagentSpawnCall(toolCall({ id: "x", toolName: "subagent_spawn" }))).toBe(
+      true,
+    );
+  });
+
+  test("matches skill_execute with input.tool === subagent_spawn", () => {
+    expect(
+      isSubagentSpawnCall(
+        toolCall({
+          id: "x",
+          toolName: "skill_execute",
+          input: { tool: "subagent_spawn" },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  test("does not match other tools or other skill_execute inputs", () => {
+    expect(isSubagentSpawnCall(toolCall({ id: "x", toolName: "bash" }))).toBe(false);
+    expect(
+      isSubagentSpawnCall(
+        toolCall({ id: "x", toolName: "skill_execute", input: { tool: "other" } }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("isSuppressedUiTool", () => {
+  test("suppresses ui_* tools without pending confirmation", () => {
+    expect(isSuppressedUiTool(toolCall({ id: "x", toolName: "ui_show" }))).toBe(true);
+    expect(isSuppressedUiTool(toolCall({ id: "x", toolName: "ui_update" }))).toBe(true);
+    expect(isSuppressedUiTool(toolCall({ id: "x", toolName: "ui_dismiss" }))).toBe(true);
+  });
+
+  test("does not suppress ui_* with a pending confirmation, or non-ui tools", () => {
+    expect(
+      isSuppressedUiTool(
+        toolCall({
+          id: "x",
+          toolName: "ui_show",
+          pendingConfirmation: { requestId: "req-1" },
+        }),
+      ),
+    ).toBe(false);
+    expect(isSuppressedUiTool(toolCall({ id: "x", toolName: "bash" }))).toBe(false);
+  });
+});
+
+describe("isTaskProgressSurface", () => {
+  test("true for task_progress with a non-empty steps array", () => {
+    expect(
+      isTaskProgressSurface(
+        surface({ template: "task_progress", templateData: { steps: [{ id: "1" }] } }),
+      ),
+    ).toBe(true);
+  });
+
+  test("false for empty steps, missing steps, or other templates", () => {
+    expect(
+      isTaskProgressSurface(
+        surface({ template: "task_progress", templateData: { steps: [] } }),
+      ),
+    ).toBe(false);
+    expect(
+      isTaskProgressSurface(surface({ template: "task_progress", templateData: {} })),
+    ).toBe(false);
+    expect(isTaskProgressSurface(surface({ template: "weather_forecast" }))).toBe(false);
+  });
+});

--- a/apps/web/src/domains/chat/transcript/message-content.ts
+++ b/apps/web/src/domains/chat/transcript/message-content.ts
@@ -1,0 +1,140 @@
+// Pure, leaf helpers for projecting and rendering a `DisplayMessage`'s ordered
+// content. NO React/DOM imports so this can be exercised with `bun test` and
+// imported by both the pure activity projection (`turn-activity.ts`) and the
+// React render path (`transcript-message-body.tsx`) WITHOUT a circular
+// dependency. This module is the single source of truth for the grouping /
+// anchor / suppression logic so the projection and the rendered DOM anchors
+// cannot drift.
+
+import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
+import type { Surface } from "@/domains/chat/types/types";
+import type { DisplayMessage } from "@/domains/chat/utils/reconcile";
+
+/**
+ * Grouped content shape for the interleaved render branch — merge adjacent
+ * `toolCall`/`tool` entries into one group, merge adjacent `thinking` entries
+ * into one group, and pass `text`/`surface` through individually.
+ */
+export type ContentGroup =
+  | { type: "text"; id: string }
+  | { type: "toolCalls"; ids: string[] }
+  | { type: "thinking"; ids: string[] }
+  | { type: "surface"; id: string };
+
+/**
+ * Group consecutive `message.contentOrder` entries — merge adjacent
+ * `toolCall`/`tool` entries into one group, merge adjacent `thinking` entries
+ * into one group, and pass `text`/`surface` through individually. Mirrors macOS
+ * `groupContentBlocks`.
+ */
+export function groupMessageContent(message: DisplayMessage): ContentGroup[] {
+  const groups: ContentGroup[] = [];
+  for (const entry of message.contentOrder ?? []) {
+    if (entry.type === "toolCall" || entry.type === "tool") {
+      const lastGroup = groups[groups.length - 1];
+      if (lastGroup?.type === "toolCalls") {
+        lastGroup.ids.push(entry.id);
+      } else {
+        groups.push({ type: "toolCalls", ids: [entry.id] });
+      }
+    } else if (entry.type === "thinking") {
+      const lastGroup = groups[groups.length - 1];
+      if (lastGroup?.type === "thinking") {
+        lastGroup.ids.push(entry.id);
+      } else {
+        groups.push({ type: "thinking", ids: [entry.id] });
+      }
+    } else if (entry.type === "text") {
+      groups.push({ type: "text", id: entry.id });
+    } else if (entry.type === "surface") {
+      groups.push({ type: "surface", id: entry.id });
+    }
+  }
+  return groups;
+}
+
+/**
+ * Resolve a tool call from a contentOrder id — find by `id`, else parse-int the
+ * id into a positional index of `message.toolCalls`.
+ */
+export function resolveToolCall(
+  message: DisplayMessage,
+  id: string,
+): ChatMessageToolCall | undefined {
+  const tc = message.toolCalls?.find((t) => t.id === id);
+  if (tc) {
+    return tc;
+  }
+  const idx = parseInt(id, 10);
+  if (!isNaN(idx) && message.toolCalls && idx < message.toolCalls.length) {
+    return message.toolCalls[idx];
+  }
+  return undefined;
+}
+
+/**
+ * Join the reasoning segments referenced by a run of `thinking` contentOrder
+ * ids into a single markdown string (mirrors macOS, which joins adjacent
+ * reasoning indices with newlines).
+ */
+export function resolveThinkingContent(
+  message: DisplayMessage,
+  ids: string[],
+): string {
+  return ids
+    .map((id) => {
+      const idx = parseInt(id, 10);
+      return !isNaN(idx) ? message.thinkingSegments?.[idx] : undefined;
+    })
+    .filter((s): s is string => Boolean(s))
+    .join("\n");
+}
+
+/**
+ * UI surface tools are rendered by the inline surface widget, not as tool-call
+ * chips — unless they carry a pending confirmation, in which case the chip must
+ * render so the inline confirmation card is visible.
+ */
+export function isSuppressedUiTool(tc: ChatMessageToolCall): boolean {
+  return (
+    !tc.pendingConfirmation &&
+    (tc.toolName === "ui_show" ||
+      tc.toolName === "ui_update" ||
+      tc.toolName === "ui_dismiss")
+  );
+}
+
+/**
+ * Detect whether a tool call is a `subagent_spawn` invocation. The daemon
+ * exposes `subagent_spawn` as a bundled-skill tool, which means the LLM
+ * actually emits a `skill_execute` call with `input.tool === "subagent_spawn"`
+ * — the daemon's `skill_execute` interceptor (see
+ * `assistant/src/daemon/conversation-tool-setup.ts`) re-dispatches to the
+ * real executor, but the `tool_use_start` event the frontend receives still
+ * carries `toolName: "skill_execute"`. Matching on the raw `toolName` would
+ * miss every spawn and leave inline subagent cards unrendered.
+ */
+export function isSubagentSpawnCall(toolCall: ChatMessageToolCall): boolean {
+  if (toolCall.toolName === "subagent_spawn") return true;
+  if (toolCall.toolName !== "skill_execute") return false;
+  const input = toolCall.input;
+  if (input == null || typeof input !== "object") return false;
+  return (input as Record<string, unknown>).tool === "subagent_spawn";
+}
+
+/**
+ * Detect a task-progress card surface — `template === "task_progress"` with a
+ * non-empty `steps` array. Single source of truth shared by `CardSurface`'s
+ * render-detection and the activity-summary path's hoist-detection so the two
+ * decisions cannot drift.
+ */
+export function isTaskProgressSurface(surface: Surface): boolean {
+  const data = surface.data as
+    | { template?: string; templateData?: { steps?: unknown } }
+    | undefined;
+  return (
+    data?.template === "task_progress" &&
+    Array.isArray(data.templateData?.steps) &&
+    (data.templateData!.steps as unknown[]).length > 0
+  );
+}

--- a/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -27,6 +27,15 @@ import {
   activityAnchorId,
   buildTurnActivity,
 } from "@/domains/chat/transcript/turn-activity";
+import {
+  groupMessageContent,
+  isSubagentSpawnCall,
+  isSuppressedUiTool,
+  isTaskProgressSurface,
+  resolveThinkingContent,
+  resolveToolCall,
+  type ContentGroup,
+} from "@/domains/chat/transcript/message-content";
 import { parseInlineSurfaces } from "@/domains/chat/utils/parse-inline-surfaces";
 import { segmentsToPlainText } from "@/domains/chat/utils/segments-to-plain-text";
 import {
@@ -42,23 +51,6 @@ import {
 import type { ConfirmationDecision } from "@/types/event-types";
 import type { AllowlistOption, DirectoryScopeOption, RiskScopeOption, ScopeOption } from "@/types/interaction-ui-types";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
-
-/**
- * Detect a task-progress card surface — mirrors `CardSurface`'s `hasSteps`
- * discrimination (`template === "task_progress"` with a non-empty `steps`
- * array). Used by the activity-summary path to hoist this surface beneath the
- * combined progress card and suppress it from its inline position.
- */
-function isTaskProgressSurface(surface: Surface): boolean {
-  const data = surface.data as
-    | { template?: string; templateData?: { steps?: unknown } }
-    | undefined;
-  return (
-    data?.template === "task_progress" &&
-    Array.isArray(data.templateData?.steps) &&
-    (data.templateData!.steps as unknown[]).length > 0
-  );
-}
 
 export interface OpenRuleEditorContext {
   toolName: string;
@@ -145,24 +137,6 @@ export interface TranscriptMessageBodyProps {
    * of the turn. Collapses back to the compact default once the turn ends.
    */
   isStreaming?: boolean;
-}
-
-/**
- * Detect whether a tool call is a `subagent_spawn` invocation. The daemon
- * exposes `subagent_spawn` as a bundled-skill tool, which means the LLM
- * actually emits a `skill_execute` call with `input.tool === "subagent_spawn"`
- * — the daemon's `skill_execute` interceptor (see
- * `assistant/src/daemon/conversation-tool-setup.ts`) re-dispatches to the
- * real executor, but the `tool_use_start` event the frontend receives still
- * carries `toolName: "skill_execute"`. Matching on the raw `toolName` would
- * miss every spawn and leave inline subagent cards unrendered.
- */
-export function isSubagentSpawnCall(toolCall: ChatMessageToolCall): boolean {
-  if (toolCall.toolName === "subagent_spawn") return true;
-  if (toolCall.toolName !== "skill_execute") return false;
-  const input = toolCall.input;
-  if (input == null || typeof input !== "object") return false;
-  return (input as Record<string, unknown>).tool === "subagent_spawn";
 }
 
 /**
@@ -388,18 +362,6 @@ export function TranscriptMessageBody({
   // groups (e.g. a tool_use lands before the first assistant_text_delta).
   const messageText = segmentsToPlainText(message.textSegments);
 
-  // Join the reasoning segments referenced by a run of `thinking`
-  // content-order ids into a single markdown string (mirrors macOS, which
-  // joins adjacent reasoning indices with newlines).
-  const resolveThinkingContent = (ids: string[]): string =>
-    ids
-      .map((id) => {
-        const idx = parseInt(id, 10);
-        return !isNaN(idx) ? message.thinkingSegments?.[idx] : undefined;
-      })
-      .filter((s): s is string => Boolean(s))
-      .join("\n");
-
   // `textBubbleClass` applies only to the assistant text path: it carries the
   // text bubble per segment inside `segmentClass`'s assistant branch. User
   // messages get their bubble once at the wrapper via `userBubbleClass`, so the
@@ -488,14 +450,6 @@ export function TranscriptMessageBody({
     }
     return undefined;
   };
-
-  // UI surface tools are rendered by the inline surface widget, not as
-  // tool call chips — unless they have a pending confirmation attached,
-  // in which case the chip must render so the inline confirmation card
-  // is visible.
-  const isSuppressedUiTool = (tc: ChatMessageToolCall) =>
-    !tc.pendingConfirmation &&
-    (tc.toolName === "ui_show" || tc.toolName === "ui_update" || tc.toolName === "ui_dismiss");
 
   // Hard line breaks are enabled for every transcript message regardless of
   // role: single `\n`s in assistant output (not just user Shift+Enter input)
@@ -721,49 +675,10 @@ export function TranscriptMessageBody({
 
   if (hasInterleavedToolCalls && message.contentOrder) {
     // Group consecutive entries: merge adjacent toolCall/tool entries into a
-    // single group (mirrors macOS `groupContentBlocks`).
-    type ContentGroup =
-      | { type: "text"; id: string }
-      | { type: "toolCalls"; ids: string[] }
-      | { type: "thinking"; ids: string[] }
-      | { type: "surface"; id: string };
-
-    const groups: ContentGroup[] = [];
-    for (const entry of message.contentOrder) {
-      if (entry.type === "toolCall" || entry.type === "tool") {
-        const lastGroup = groups[groups.length - 1];
-        if (lastGroup?.type === "toolCalls") {
-          lastGroup.ids.push(entry.id);
-        } else {
-          groups.push({ type: "toolCalls", ids: [entry.id] });
-        }
-      } else if (entry.type === "thinking") {
-        // Merge consecutive thinking entries into one block (mirrors macOS
-        // `groupContentBlocks`, which joins adjacent reasoning indices).
-        const lastGroup = groups[groups.length - 1];
-        if (lastGroup?.type === "thinking") {
-          lastGroup.ids.push(entry.id);
-        } else {
-          groups.push({ type: "thinking", ids: [entry.id] });
-        }
-      } else if (entry.type === "text") {
-        groups.push({ type: "text", id: entry.id });
-      } else if (entry.type === "surface") {
-        groups.push({ type: "surface", id: entry.id });
-      }
-    }
-
-    const resolveToolCall = (id: string): ChatMessageToolCall | undefined => {
-      const tc = message.toolCalls?.find((t) => t.id === id);
-      if (tc) {
-        return tc;
-      }
-      const idx = parseInt(id, 10);
-      if (!isNaN(idx) && message.toolCalls && idx < message.toolCalls.length) {
-        return message.toolCalls[idx];
-      }
-      return undefined;
-    };
+    // single group (mirrors macOS `groupContentBlocks`). Shared with the pure
+    // activity projection via `./message-content` so the rendered anchors and
+    // the projected step anchors stay byte-identical.
+    const groups = groupMessageContent(message);
 
     // Each entry carries its group `type` alongside the rendered node so the
     // user branch can place text inside the bubble and tool-call/surface
@@ -776,7 +691,7 @@ export function TranscriptMessageBody({
       const node = ((): ReactNode => {
             if (group.type === "toolCalls") {
               const toolCalls = group.ids
-                .map(resolveToolCall)
+                .map((id) => resolveToolCall(message, id))
                 .filter((tc): tc is ChatMessageToolCall => tc != null && !isSuppressedUiTool(tc));
               if (toolCalls.length === 0) {
                 return null;
@@ -828,7 +743,7 @@ export function TranscriptMessageBody({
               );
             }
             if (group.type === "thinking") {
-              const thinkingContent = resolveThinkingContent(group.ids);
+              const thinkingContent = resolveThinkingContent(message, group.ids);
               if (!thinkingContent) {
                 return null;
               }
@@ -983,7 +898,7 @@ export function TranscriptMessageBody({
       }
       const ids = pendingThinkingIds;
       pendingThinkingIds = [];
-      const thinkingContent = resolveThinkingContent(ids);
+      const thinkingContent = resolveThinkingContent(message, ids);
       if (!thinkingContent) {
         return;
       }

--- a/apps/web/src/domains/chat/transcript/turn-activity.ts
+++ b/apps/web/src/domains/chat/transcript/turn-activity.ts
@@ -1,12 +1,25 @@
 // Pure per-assistant-turn activity projection. No React/DOM imports so it can
 // be exercised with `bun test` like `build-items.ts`.
 //
-// Grouping rules MIRROR transcript-message-body.tsx; keep in lockstep —
-// cross-checked by transcript-message-body.test.tsx in PR 3.
+// Grouping / resolution / suppression logic lives in the shared leaf module
+// `./message-content`, which both this projection and the rendered DOM
+// (`transcript-message-body.tsx`) import — so the projected anchors and the
+// rendered anchors stay byte-identical. Cross-checked by
+// transcript-message-body.test.tsx.
 
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
-import { computeToolCallCardData } from "@/domains/chat/hooks/tool-call-card-utils";
+import {
+  combineCardStates,
+  computeToolCallCardData,
+} from "@/domains/chat/hooks/tool-call-card-utils";
 import type { DisplayMessage } from "@/domains/chat/utils/reconcile";
+import {
+  groupMessageContent,
+  isSubagentSpawnCall,
+  isSuppressedUiTool,
+  resolveThinkingContent,
+  resolveToolCall,
+} from "@/domains/chat/transcript/message-content";
 
 export type ActivityKind = "thinking" | "tool";
 
@@ -39,123 +52,6 @@ export interface TurnActivity {
   currentStepInfo: string;
   state: "loading" | "complete" | "error" | "denied";
   stepCount: number;
-}
-
-/**
- * Grouped content shape — a pure replica of the `ContentGroup` union in the
- * interleaved branch of `transcript-message-body.tsx`.
- */
-export type ContentGroup =
-  | { type: "text"; id: string }
-  | { type: "toolCalls"; ids: string[] }
-  | { type: "thinking"; ids: string[] }
-  | { type: "surface"; id: string };
-
-/**
- * Group consecutive `message.contentOrder` entries — merge adjacent
- * `toolCall`/`tool` entries into one group, merge adjacent `thinking` entries
- * into one group, and pass `text`/`surface` through individually. Mirrors the
- * interleaved-branch loop in `transcript-message-body.tsx`.
- */
-export function groupMessageContent(message: DisplayMessage): ContentGroup[] {
-  const groups: ContentGroup[] = [];
-  for (const entry of message.contentOrder ?? []) {
-    if (entry.type === "toolCall" || entry.type === "tool") {
-      const lastGroup = groups[groups.length - 1];
-      if (lastGroup?.type === "toolCalls") {
-        lastGroup.ids.push(entry.id);
-      } else {
-        groups.push({ type: "toolCalls", ids: [entry.id] });
-      }
-    } else if (entry.type === "thinking") {
-      const lastGroup = groups[groups.length - 1];
-      if (lastGroup?.type === "thinking") {
-        lastGroup.ids.push(entry.id);
-      } else {
-        groups.push({ type: "thinking", ids: [entry.id] });
-      }
-    } else if (entry.type === "text") {
-      groups.push({ type: "text", id: entry.id });
-    } else if (entry.type === "surface") {
-      groups.push({ type: "surface", id: entry.id });
-    }
-  }
-  return groups;
-}
-
-/**
- * Resolve a tool call from a contentOrder id — find by `id`, else parse-int the
- * id into a positional index of `message.toolCalls`. Mirrors `resolveToolCall`
- * in `transcript-message-body.tsx`.
- */
-function resolveToolCall(
-  message: DisplayMessage,
-  id: string,
-): ChatMessageToolCall | undefined {
-  const tc = message.toolCalls?.find((t) => t.id === id);
-  if (tc) {
-    return tc;
-  }
-  const idx = parseInt(id, 10);
-  if (!isNaN(idx) && message.toolCalls && idx < message.toolCalls.length) {
-    return message.toolCalls[idx];
-  }
-  return undefined;
-}
-
-/**
- * Join the reasoning segments referenced by a run of `thinking` contentOrder
- * ids into one string. Mirrors `resolveThinkingContent` in
- * `transcript-message-body.tsx`.
- */
-function resolveThinkingContent(message: DisplayMessage, ids: string[]): string {
-  return ids
-    .map((id) => {
-      const idx = parseInt(id, 10);
-      return !isNaN(idx) ? message.thinkingSegments?.[idx] : undefined;
-    })
-    .filter((s): s is string => Boolean(s))
-    .join("\n");
-}
-
-/**
- * Detect a `subagent_spawn` invocation in either canonical form. Mirrors
- * `isSubagentSpawnCall` in `transcript-message-body.tsx`.
- */
-function isSubagentSpawnCall(toolCall: ChatMessageToolCall): boolean {
-  if (toolCall.toolName === "subagent_spawn") return true;
-  if (toolCall.toolName !== "skill_execute") return false;
-  const input = toolCall.input;
-  if (input == null || typeof input !== "object") return false;
-  return (input as Record<string, unknown>).tool === "subagent_spawn";
-}
-
-/**
- * UI surface tools are rendered by the inline surface widget, not as tool-call
- * chips — unless they carry a pending confirmation. Mirrors `isSuppressedUiTool`
- * in `transcript-message-body.tsx`.
- */
-function isSuppressedUiTool(tc: ChatMessageToolCall): boolean {
-  return (
-    !tc.pendingConfirmation &&
-    (tc.toolName === "ui_show" ||
-      tc.toolName === "ui_update" ||
-      tc.toolName === "ui_dismiss")
-  );
-}
-
-/**
- * Aggregate card-level state across steps using the same precedence as
- * `deriveCardState` in tool-call-card-utils.ts: denied > loading > error >
- * complete.
- */
-function aggregateState(
-  states: Array<"loading" | "complete" | "error" | "denied">,
-): "loading" | "complete" | "error" | "denied" {
-  if (states.includes("denied")) return "denied";
-  if (states.includes("loading")) return "loading";
-  if (states.includes("error")) return "error";
-  return "complete";
 }
 
 /** Icon name of the last `tool`-kind step in a `ToolCallCardData.steps`. */
@@ -277,7 +173,7 @@ export function buildTurnActivity(message: DisplayMessage): TurnActivity {
     steps,
     currentStepTitle: last?.title ?? "",
     currentStepInfo: last?.info ?? "",
-    state: aggregateState(steps.map((s) => s.state)),
+    state: combineCardStates(steps.map((s) => s.state)),
     stepCount: steps.length,
   };
 }


### PR DESCRIPTION
## Summary
Behavior-preserving refactor addressing slop found in plan self-review. Extracts the duplicated pure helpers (groupMessageContent, ContentGroup, resolveToolCall, resolveThinkingContent, isSuppressedUiTool, isSubagentSpawnCall, isTaskProgressSurface) into a single leaf module `transcript/message-content.ts`, consumed by turn-activity.ts, transcript-message-body.tsx, and card-surface.tsx. Removes dead exports and the circular-dependency that forced the copies; strengthens the projection/DOM anchor single-source-of-truth.

Fixes gaps from plan review for web-activity-summary.md.