### PR TITLE
Reorder profile editor to provider-first with inline provider create and pre-fill

### DIFF
--- a/apps/web/src/domains/settings/ai/manage-profiles-modal.tsx
+++ b/apps/web/src/domains/settings/ai/manage-profiles-modal.tsx
@@ -58,6 +58,7 @@ export function ManageProfilesModal({
   const configMutation = useDaemonConfigMutation();
 
   const openAICompatibleEndpoints = useAssistantFeatureFlagStore.use.openAICompatibleEndpoints();
+  const chatgptSubscriptionAuth = useAssistantFeatureFlagStore.use.chatgptSubscriptionAuth();
   const [editorOpen, setEditorOpen] = useState(false);
   const [editingProfile, setEditingProfile] = useState<ProfileWithName | null>(null);
 
@@ -177,6 +178,8 @@ export function ManageProfilesModal({
         existingNames={existingNames}
         connections={connections}
         openAICompatibleEndpointsEnabled={openAICompatibleEndpoints}
+        assistantId={assistantId}
+        chatgptSubscriptionEnabled={chatgptSubscriptionAuth}
         onSave={handleEditorSave}
         onCancel={() => {
           setEditorOpen(false);

--- a/apps/web/src/domains/settings/ai/profile-editor-modal.test.tsx
+++ b/apps/web/src/domains/settings/ai/profile-editor-modal.test.tsx
@@ -1,0 +1,304 @@
+/**
+ * Tests for the create-mode `ProfileEditorModal` — the provider-first reorder
+ * + pre-fill + inline provider create flow (PR 3 of the
+ * provider-first-profile-quick-add plan).
+ *
+ * We mock the generated daemon SDK (sdk.gen) the same way
+ * `provider-create-form.test.tsx` does so the inline `ProviderCreateForm`
+ * sub-form can run its create sequence without real network calls, and stub
+ * its credential hooks so render doesn't fan out daemon queries.
+ *
+ * Coverage:
+ *  - field order is provider-first (Provider before Name/Key/Description),
+ *  - selecting a model pre-fills Name + Key from the model display name,
+ *  - editing Name then selecting another model does NOT clobber Name/Key,
+ *  - "+ Create new provider" mounts the inline ProviderCreateForm, and a
+ *    successful create selects that provider + enables Save once a model is
+ *    chosen.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createElement, type ReactNode } from "react";
+
+import * as sdkGen from "@/generated/daemon/sdk.gen";
+import type { ProviderConnection } from "@/domains/settings/ai/provider-connections-client";
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+let createdConnection: ProviderConnection;
+
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  ...sdkGen,
+  secretsPost: () =>
+    Promise.resolve({ data: undefined, response: { ok: true } }),
+  inferenceProviderconnectionsPost: () =>
+    Promise.resolve({
+      data: createdConnection,
+      response: { ok: true, status: 200 },
+    }),
+}));
+
+// Stub the credential hooks so the inline ProviderCreateForm renders without
+// issuing real daemon queries.
+mock.module("@/domains/settings/ai/use-stored-credential-presence", () => ({
+  useStoredCredentialPresence: () => ({
+    hasStoredCredential: false,
+    isLoading: false,
+    queryKey: ["stored-credential-presence"],
+  }),
+}));
+
+mock.module("@/domains/settings/ai/use-provider-credentials-list", () => ({
+  useProviderCredentialsList: () => ({
+    credentials: [],
+    isLoading: false,
+    queryKey: ["provider-credentials-list"],
+  }),
+}));
+
+const { ProfileEditorModal } = await import(
+  "@/domains/settings/ai/profile-editor-modal"
+);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ASSISTANT_ID = "asst-1";
+
+function makeConnection(name: string, provider = "anthropic"): ProviderConnection {
+  return {
+    name,
+    label: null,
+    provider,
+    auth: { type: "api_key", credential: `credential/${provider}/api_key` },
+    models: null,
+  } as unknown as ProviderConnection;
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return createElement(QueryClientProvider, { client }, children);
+}
+
+function getInputByPlaceholder(placeholder: string): HTMLInputElement {
+  const input = Array.from(
+    document.querySelectorAll<HTMLInputElement>("input"),
+  ).find((el) => el.placeholder === placeholder);
+  if (!input) {
+    throw new Error(`expected an input with placeholder "${placeholder}"`);
+  }
+  return input;
+}
+
+function getButton(label: string): HTMLButtonElement {
+  const match = Array.from(
+    document.querySelectorAll<HTMLButtonElement>("button"),
+  ).find((b) => b.textContent?.trim() === label);
+  if (!match) {
+    throw new Error(`expected a "${label}" button`);
+  }
+  return match;
+}
+
+function getSaveBtn(): HTMLButtonElement {
+  const btn = document.querySelector<HTMLButtonElement>(
+    '[data-testid="modal-save-btn"]',
+  );
+  if (!btn) throw new Error("expected a modal-save-btn");
+  return btn;
+}
+
+/** All Dropdown triggers (custom comboboxes) in document order. */
+function dropdownTriggers(): HTMLButtonElement[] {
+  return Array.from(
+    document.querySelectorAll<HTMLButtonElement>('button[role="combobox"]'),
+  );
+}
+
+/** Open the dropdown trigger and click the option whose label matches. */
+function pickOption(trigger: HTMLButtonElement, optionLabel: string): void {
+  fireEvent.click(trigger);
+  const option = Array.from(
+    document.querySelectorAll<HTMLElement>('[role="option"]'),
+  ).find((o) => o.textContent?.trim() === optionLabel);
+  if (!option) {
+    throw new Error(
+      `expected option "${optionLabel}" — saw: ${Array.from(
+        document.querySelectorAll('[role="option"]'),
+      )
+        .map((o) => `"${o.textContent?.trim()}"`)
+        .join(", ")}`,
+    );
+  }
+  fireEvent.click(option);
+}
+
+/** The create-mode Provider dropdown is labelled via `aria-labelledby`. */
+function providerTrigger(): HTMLButtonElement {
+  const trigger = document.querySelector<HTMLButtonElement>(
+    'button[role="combobox"][aria-labelledby="profile-editor-provider-label"]',
+  );
+  if (!trigger) throw new Error("expected the Provider dropdown trigger");
+  return trigger;
+}
+
+/** Selects a provider in the create-mode Provider dropdown, then a model in
+ *  the Model dropdown (the only other combobox once a provider is set). */
+function selectProvider(label: string): void {
+  pickOption(providerTrigger(), label);
+}
+
+function selectModel(label: string): void {
+  // The Model dropdown is the combobox (other than Provider) whose open
+  // listbox contains the target model label. Probing each candidate keeps the
+  // helper robust to the optional Connection dropdown appearing alongside it.
+  const provTrigger = providerTrigger();
+  for (const trigger of dropdownTriggers()) {
+    if (trigger === provTrigger) continue;
+    fireEvent.click(trigger);
+    const option = Array.from(
+      document.querySelectorAll<HTMLElement>('[role="option"]'),
+    ).find((o) => o.textContent?.trim() === label);
+    if (option) {
+      fireEvent.click(option);
+      return;
+    }
+    // Close this listbox before probing the next trigger.
+    fireEvent.click(trigger);
+  }
+  throw new Error(`expected a Model dropdown offering "${label}"`);
+}
+
+function renderCreate(connections: ProviderConnection[]) {
+  return render(
+    <Wrapper>
+      <ProfileEditorModal
+        isOpen
+        mode="create"
+        existingNames={[]}
+        connections={connections}
+        assistantId={ASSISTANT_ID}
+        onSave={() => Promise.resolve()}
+        onCancel={() => {}}
+      />
+    </Wrapper>,
+  );
+}
+
+beforeEach(() => {
+  createdConnection = makeConnection("anthropic-personal");
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ProfileEditorModal create mode — provider-first", () => {
+  test("renders Provider before Name/Key in create mode", () => {
+    renderCreate([makeConnection("anthropic-personal")]);
+
+    const text = document.body.textContent ?? "";
+    const providerIdx = text.indexOf("Provider");
+    const nameIdx = text.indexOf("Name");
+    const keyIdx = text.indexOf("Key");
+    expect(providerIdx).toBeGreaterThanOrEqual(0);
+    expect(nameIdx).toBeGreaterThan(providerIdx);
+    expect(keyIdx).toBeGreaterThan(providerIdx);
+  });
+
+  test("advanced params are collapsed by default in create mode", () => {
+    renderCreate([makeConnection("anthropic-personal")]);
+    const advancedToggle = getButton("Advanced");
+    expect(advancedToggle.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  test("selecting a model pre-fills Name and Key", () => {
+    renderCreate([makeConnection("anthropic-personal")]);
+
+    selectProvider("Anthropic");
+    selectModel("Claude Opus 4.8");
+
+    expect(getInputByPlaceholder("e.g. Fast & Cheap").value).toBe(
+      "Claude Opus 4.8",
+    );
+    expect(getInputByPlaceholder("e.g. fast-cheap").value).toBe(
+      "claude-opus-4-8",
+    );
+  });
+
+  test("editing Name stops model-driven pre-fill from overwriting", () => {
+    renderCreate([makeConnection("anthropic-personal")]);
+
+    selectProvider("Anthropic");
+    selectModel("Claude Opus 4.8");
+
+    // User overrides the Name.
+    fireEvent.change(getInputByPlaceholder("e.g. Fast & Cheap"), {
+      target: { value: "My Custom Profile" },
+    });
+
+    // Selecting a different model must NOT clobber the manual Name/Key.
+    selectModel("Claude Opus 4.7");
+
+    expect(getInputByPlaceholder("e.g. Fast & Cheap").value).toBe(
+      "My Custom Profile",
+    );
+    expect(getInputByPlaceholder("e.g. fast-cheap").value).toBe(
+      "my-custom-profile",
+    );
+  });
+
+  test("first-run empty state shows only the create-new-provider option", () => {
+    renderCreate([]);
+    fireEvent.click(providerTrigger());
+    const optionLabels = Array.from(
+      document.querySelectorAll<HTMLElement>('[role="option"]'),
+    ).map((o) => o.textContent?.trim());
+    expect(optionLabels).toEqual(["+ Create new provider"]);
+  });
+
+  test("+ Create new provider mounts ProviderCreateForm; successful create selects it and Save enables after a model", async () => {
+    renderCreate([]);
+
+    selectProvider("+ Create new provider");
+
+    // Inline ProviderCreateForm is mounted (its Key field placeholder).
+    const inlineKey = getInputByPlaceholder("e.g. anthropic-personal");
+    expect(inlineKey).toBeDefined();
+
+    // Fill the inline form and create (anthropic defaults to platform auth,
+    // so no API key entry is required).
+    fireEvent.change(inlineKey, { target: { value: "anthropic-personal" } });
+    fireEvent.click(getButton("Create"));
+
+    // After create, the sub-form collapses and the provider is selected.
+    await waitFor(() => {
+      expect(
+        document.body.textContent,
+      ).toContain(
+        "New provider connection will show up in the Providers section.",
+      );
+    });
+
+    // Save is still blocked until a model is chosen.
+    expect(getSaveBtn().disabled).toBe(true);
+
+    selectModel("Claude Opus 4.8");
+
+    await waitFor(() => {
+      expect(getSaveBtn().disabled).toBe(false);
+    });
+  });
+});

--- a/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -1,25 +1,36 @@
 import { useEffect, useMemo, useState } from "react";
 
+import { useQueryClient } from "@tanstack/react-query";
 import { Button } from "@vellum/design-library/components/button";
+import { Dropdown } from "@vellum/design-library/components/dropdown";
 import { Input, Textarea } from "@vellum/design-library/components/input";
 import { Modal } from "@vellum/design-library/components/modal";
 import { Tag } from "@vellum/design-library/components/tag";
 import { Toggle } from "@vellum/design-library/components/toggle";
 import { Typography } from "@vellum/design-library/components/typography";
+import { ChevronRight } from "lucide-react";
 
 import { getModelsForProvider } from "@/assistant/llm-model-catalog";
+import { inferenceProviderconnectionsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
 
 import type { ProfileEntry, ProfileStatus, ProfileWithName } from "@/domains/settings/ai/ai-types";
-import { OPENAI_COMPATIBLE_PROVIDER } from "@/domains/settings/ai/ai-types";
+import { INFERENCE_PROVIDER_DISPLAY_NAMES, OPENAI_COMPATIBLE_PROVIDER } from "@/domains/settings/ai/ai-types";
 import {
   ProfileAdvancedParams,
   THINKING_LEVEL_INHERIT,
 } from "@/domains/settings/ai/profile-advanced-params";
 import { ProfileEditorProviderSection } from "@/domains/settings/ai/profile-editor-provider-section";
 import { resolveProfileParamVisibility } from "@/domains/settings/ai/profile-param-visibility";
+import { deriveProfileDefaults } from "@/domains/settings/ai/profile-prefill";
 import { AUTO_PROFILE_NAME } from "@/domains/settings/ai/profile-pickers";
-import type { ProviderConnection } from "@/domains/settings/ai/provider-connections-client";
+import type { ConnectionProvider, ProviderConnection } from "@/domains/settings/ai/provider-connections-client";
+import { ProviderCreateForm } from "@/domains/settings/ai/provider-create-form";
 import { useLabelKeySync } from "@/domains/settings/ai/use-label-key-sync";
+
+// Sentinel value for the "+ Create new provider" option in the create-mode
+// Provider dropdown. Picking it mounts the inline ProviderCreateForm instead
+// of selecting a provider.
+const CREATE_NEW_PROVIDER_SENTINEL = "__create_new_provider__";
 
 export interface ProfileEditorModalProps {
   isOpen: boolean;
@@ -44,6 +55,14 @@ export interface ProfileEditorModalProps {
    */
   connections?: ProviderConnection[];
   openAICompatibleEndpointsEnabled?: boolean;
+  /**
+   * Assistant whose provider connections the inline "+ Create new provider"
+   * sub-form writes to. Required for the create-mode quick-add flow.
+   */
+  assistantId: string;
+  /** Surfaces the "Sign in with ChatGPT" subscription path in the inline
+   *  provider create sub-form when enabled. */
+  chatgptSubscriptionEnabled?: boolean;
   /**
    * Persist a profile entry. The optional `options.mode` argument tells the
    * parent how to combine `entry` with the existing on-disk record:
@@ -75,6 +94,8 @@ export function ProfileEditorModal({
   existingNames,
   connections,
   openAICompatibleEndpointsEnabled = false,
+  assistantId,
+  chatgptSubscriptionEnabled = false,
   onSave,
   onCancel,
 }: ProfileEditorModalProps) {
@@ -93,6 +114,8 @@ export function ProfileEditorModal({
           existingNames={existingNames}
           connections={connections}
           openAICompatibleEndpointsEnabled={openAICompatibleEndpointsEnabled}
+          assistantId={assistantId}
+          chatgptSubscriptionEnabled={chatgptSubscriptionEnabled}
           onSave={onSave}
           onCancel={onCancel}
         />
@@ -113,6 +136,8 @@ interface ProfileEditorModalInnerProps {
   // See `ProfileEditorModalProps.connections` for nil-vs-empty semantics.
   connections: ProviderConnection[] | undefined;
   openAICompatibleEndpointsEnabled: boolean;
+  assistantId: string;
+  chatgptSubscriptionEnabled: boolean;
   onSave: (
     name: string,
     entry: ProfileEntry,
@@ -128,6 +153,8 @@ function ProfileEditorModalInner({
   existingNames,
   connections,
   openAICompatibleEndpointsEnabled,
+  assistantId,
+  chatgptSubscriptionEnabled,
   onSave,
   onCancel,
 }: ProfileEditorModalInnerProps) {
@@ -238,12 +265,24 @@ function ProfileEditorModalInner({
     providerConnection !== "" &&
     !availableConnectionsForProvider.some((c) => c.name === providerConnection);
 
-  const { handleLabelChange, handleKeyChange, resetDirty } =
+  const { handleLabelChange, handleKeyChange, resetDirty, getDirty } =
     useLabelKeySync(effectiveMode, setLabel, setKey);
+
+  const queryClient = useQueryClient();
+
+  // Create-mode-only UI: whether the inline "+ Create new provider" sub-form
+  // is mounted, and whether the advanced-params disclosure is expanded.
+  const [creatingProvider, setCreatingProvider] = useState(false);
+  const [advancedExpanded, setAdvancedExpanded] = useState(false);
+  // One-time helper note shown after an inline provider create succeeds.
+  const [newProviderNote, setNewProviderNote] = useState(false);
 
   // Reset dirty tracking when modal re-opens with new values.
   useEffect(() => {
     resetDirty();
+    setCreatingProvider(false);
+    setAdvancedExpanded(false);
+    setNewProviderNote(false);
   }, [profileName, mode, resetDirty]);
 
   function handleProviderChange(newProvider: string) {
@@ -294,12 +333,53 @@ function ProfileEditorModalInner({
     }
   }
 
+  // Resolve a model id to its human-facing display name. The static catalog
+  // covers first-party providers; openai-compatible models live on the
+  // connection, so fall back to those and finally to the id itself.
+  function resolveModelDisplayName(modelId: string): string {
+    const catalogMatch = getModelsForProvider(provider).find((m) => m.id === modelId);
+    if (catalogMatch) return catalogMatch.displayName;
+    for (const conn of availableConnectionsForProvider) {
+      const match = (conn.models ?? []).find((m) => m.id === modelId);
+      if (match) return match.displayName ?? match.id;
+    }
+    return modelId;
+  }
+
   function handleModelChange(newModel: string) {
     if (newModel === model) return;
     setModel(newModel);
     // Reset token sliders when model changes
     setMaxTokens(null);
     setContextWindowMaxInputTokens(null);
+    // Create-mode pre-fill: seed Name + Key from the model's display name,
+    // but only while the user hasn't manually edited either field (dirty
+    // tracking lives in useLabelKeySync). Clearing the model leaves the
+    // current values untouched.
+    if (effectiveMode === "create" && newModel && !getDirty()) {
+      const { name, key: derivedKey } = deriveProfileDefaults(
+        resolveModelDisplayName(newModel),
+        existingNames,
+      );
+      setLabel(name);
+      setKey(derivedKey);
+    }
+  }
+
+  // Inline provider create: bind the new connection as this profile's
+  // provider + connection, collapse the sub-form, surface the helper note,
+  // and invalidate the connections query so the dropdown picks up the row.
+  function handleProviderCreated(connection: ProviderConnection) {
+    setProvider(connection.provider);
+    setProviderConnection(connection.name);
+    setModel("");
+    setCreatingProvider(false);
+    setNewProviderNote(true);
+    void queryClient.invalidateQueries({
+      queryKey: inferenceProviderconnectionsGetQueryKey({
+        path: { assistant_id: assistantId },
+      }),
+    });
   }
 
   // Validation
@@ -447,6 +527,238 @@ function ProfileEditorModalInner({
         ? "Edit Profile"
         : (initialValues?.label ?? profileName ?? "Profile");
 
+  const isCreate = effectiveMode === "create";
+
+  // ---- Reusable field nodes (shared by create + edit/view bodies) ----
+
+  const displayNameField = (
+    <div className="space-y-1">
+      <label className="block text-body-small-default text-[var(--content-tertiary)]">
+        {isCreate ? "Name" : "Display Name"}
+      </label>
+      <Input
+        type="text"
+        value={label}
+        onChange={(e) => handleLabelChange(e.target.value)}
+        placeholder="e.g. Fast & Cheap"
+        fullWidth
+      />
+    </div>
+  );
+
+  const descriptionField = (
+    <Textarea
+      label={
+        <>
+          Description{" "}
+          <span className="text-[var(--content-disabled)]">(optional)</span>
+        </>
+      }
+      value={description}
+      onChange={(e) => setDescription(e.target.value)}
+      placeholder="Describe when to use this profile"
+      disabled={isReadOnly}
+      rows={2}
+      fullWidth
+      className="resize-none"
+    />
+  );
+
+  const keyField = (
+    <div className="space-y-1">
+      <label className="block text-body-small-default text-[var(--content-tertiary)]">
+        Key
+      </label>
+      <Input
+        type="text"
+        value={key}
+        onChange={(e) => handleKeyChange(e.target.value)}
+        placeholder="e.g. fast-cheap"
+        disabled={isReadOnly || effectiveMode === "edit"}
+        fullWidth
+      />
+      {keyError && !isReadOnly ? (
+        <Typography
+          variant="body-small-default"
+          as="p"
+          className="text-(--system-negative-strong)"
+        >
+          {keyError}
+        </Typography>
+      ) : null}
+    </div>
+  );
+
+  const activeToggle = (
+    <Toggle
+      checked={status === "active"}
+      onChange={(v) => setStatus(v ? "active" : "disabled")}
+      label="Active"
+    />
+  );
+
+  const advancedParamsNode = !isAutoProfile ? (
+    <ProfileAdvancedParams
+      visibility={visibility}
+      isReadOnly={isReadOnly}
+      model={model}
+      selectedModel={selectedModel}
+      maxTokens={maxTokens}
+      onMaxTokensChange={setMaxTokens}
+      contextWindowMaxInputTokens={contextWindowMaxInputTokens}
+      onContextWindowChange={setContextWindowMaxInputTokens}
+      effort={effort}
+      onEffortChange={setEffort}
+      speed={speed}
+      onSpeedChange={setSpeed}
+      verbosity={verbosity}
+      onVerbosityChange={setVerbosity}
+      temperatureEnabled={temperatureEnabled}
+      onTemperatureEnabledChange={setTemperatureEnabled}
+      temperature={temperature}
+      onTemperatureChange={setTemperature}
+      thinkingEnabled={thinkingEnabled}
+      onThinkingEnabledChange={setThinkingEnabled}
+      thinkingStreamThinking={thinkingStreamThinking}
+      onThinkingStreamThinkingChange={setThinkingStreamThinking}
+      thinkingLevel={thinkingLevel}
+      onThinkingLevelChange={setThinkingLevel}
+    />
+  ) : null;
+
+  const saveErrorNode = saveError ? (
+    <Typography
+      variant="body-small-default"
+      as="p"
+      className="text-(--system-negative-strong)"
+    >
+      {saveError}
+    </Typography>
+  ) : null;
+
+  // ---- Create-mode-only: provider-first picker with inline create ----
+
+  // Providers with at least one connection, plus the always-present "+ Create
+  // new provider" sentinel. First-run empty state shows ONLY the sentinel.
+  const createModeProviderOptions = useMemo(() => {
+    const seen = new Set<string>();
+    const opts: { value: string; label: string }[] = [];
+    for (const c of connections ?? []) {
+      if (
+        !openAICompatibleEndpointsEnabled &&
+        c.provider === OPENAI_COMPATIBLE_PROVIDER
+      ) {
+        continue;
+      }
+      if (!seen.has(c.provider)) {
+        seen.add(c.provider);
+        opts.push({
+          value: c.provider,
+          label: INFERENCE_PROVIDER_DISPLAY_NAMES[c.provider] ?? c.provider,
+        });
+      }
+    }
+    opts.push({
+      value: CREATE_NEW_PROVIDER_SENTINEL,
+      label: "+ Create new provider",
+    });
+    return opts;
+  }, [connections, openAICompatibleEndpointsEnabled]);
+
+  const createProviderSection = (
+    <div className="space-y-4">
+      <div className="space-y-1">
+        <div className="flex items-center justify-between gap-2">
+          <label
+            id="profile-editor-provider-label"
+            className="block text-body-small-default text-[var(--content-tertiary)]"
+          >
+            Provider
+          </label>
+          {providerMissing && !creatingProvider ? (
+            <span className="rounded-full bg-[var(--surface-warning-subtle)] px-2 py-0.5 text-body-small-default text-[var(--content-warning)]">
+              Pick a provider
+            </span>
+          ) : null}
+        </div>
+        <Dropdown
+          value={creatingProvider ? CREATE_NEW_PROVIDER_SENTINEL : provider}
+          onChange={(next) => {
+            if (next === CREATE_NEW_PROVIDER_SENTINEL) {
+              setCreatingProvider(true);
+              setNewProviderNote(false);
+              return;
+            }
+            setCreatingProvider(false);
+            handleProviderChange(next);
+          }}
+          placeholder="Select a provider…"
+          aria-labelledby="profile-editor-provider-label"
+          options={createModeProviderOptions}
+        />
+        {newProviderNote ? (
+          <Typography
+            variant="body-small-default"
+            as="p"
+            className="text-[var(--content-tertiary)]"
+          >
+            New provider connection will show up in the Providers section.
+          </Typography>
+        ) : null}
+      </div>
+
+      {creatingProvider ? (
+        <ProviderCreateForm
+          variant="inline"
+          assistantId={assistantId}
+          existingNames={(connections ?? []).map((c) => c.name)}
+          openAICompatibleEndpointsEnabled={openAICompatibleEndpointsEnabled}
+          chatgptSubscriptionEnabled={chatgptSubscriptionEnabled}
+          defaultProviderType={
+            (provider || undefined) as ConnectionProvider | undefined
+          }
+          onCreated={handleProviderCreated}
+          onCancel={() => setCreatingProvider(false)}
+        />
+      ) : (
+        <ProfileEditorProviderSection
+          provider={provider}
+          model={model}
+          providerConnection={providerConnection}
+          onProviderChange={handleProviderChange}
+          onModelChange={handleModelChange}
+          onConnectionChange={handleConnectionChange}
+          connections={connections}
+          openAICompatibleEndpointsEnabled={openAICompatibleEndpointsEnabled}
+          isReadOnly={isReadOnly}
+          availableConnectionsForProvider={availableConnectionsForProvider}
+          connectionNotFound={connectionNotFound}
+          hideProviderField
+        />
+      )}
+    </div>
+  );
+
+  const createAdvancedDisclosure =
+    !isAutoProfile && advancedParamsNode ? (
+      <div>
+        <button
+          type="button"
+          aria-expanded={advancedExpanded}
+          onClick={() => setAdvancedExpanded((v) => !v)}
+          className="flex items-center gap-1 text-body-small-default text-[var(--content-secondary)] w-full text-left"
+        >
+          <ChevronRight
+            className={`h-4 w-4 transition-transform ${advancedExpanded ? "rotate-90" : ""}`}
+          />
+          <span>Advanced</span>
+        </button>
+        {advancedExpanded ? (
+          <div className="mt-2">{advancedParamsNode}</div>
+        ) : null}
+      </div>
+    ) : null;
+
   return (
     <Modal.Content size="md">
       <Modal.Header>
@@ -461,142 +773,77 @@ function ProfileEditorModalInner({
       </Modal.Header>
 
       <Modal.Body>
-        <div className="space-y-4">
-          {/* Display Name — editable in all modes, including view (managed
-              profiles can be renamed without leaving view mode; everything
-              else stays locked). */}
-          <div className="space-y-1">
-            <label className="block text-body-small-default text-[var(--content-tertiary)]">
-              Display Name
-            </label>
-            <Input
-              type="text"
-              value={label}
-              onChange={(e) => handleLabelChange(e.target.value)}
-              placeholder="e.g. Fast & Cheap"
-              fullWidth
-            />
+        {isCreate ? (
+          // Create mode is provider-first: Provider (with inline create) ->
+          // Model -> Name -> Key -> Description -> collapsed Advanced.
+          <div className="space-y-4">
+            {isAutoProfile && (
+              <div className="rounded-lg bg-[var(--surface-info-subtle)] p-3">
+                <p className="text-body-small-default text-[var(--content-secondary)]">
+                  Auto mode routes each query to the best profile automatically
+                  — fast for simple questions, capable for complex ones. No
+                  provider or model configuration needed.
+                </p>
+              </div>
+            )}
+
+            {/* Provider + Connection + Model — hidden for the auto profile. */}
+            {!isAutoProfile && createProviderSection}
+
+            {displayNameField}
+            {keyField}
+            {descriptionField}
+            {activeToggle}
+
+            {/* Advanced params — collapsed by default in create mode. */}
+            {createAdvancedDisclosure}
+
+            {saveErrorNode}
           </div>
+        ) : (
+          // Edit / view modes keep the original field order and locking:
+          // Display Name -> Description -> Key -> Active -> Provider -> Model
+          // -> always-visible Advanced.
+          <div className="space-y-4">
+            {displayNameField}
+            {descriptionField}
+            {keyField}
+            {activeToggle}
 
-          {/* Description */}
-          <Textarea
-            label={
-              <>
-                Description{" "}
-                <span className="text-[var(--content-disabled)]">(optional)</span>
-              </>
-            }
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
-            placeholder="Describe when to use this profile"
-            disabled={isReadOnly}
-            rows={2}
-            fullWidth
-            className="resize-none"
-          />
+            {isAutoProfile && (
+              <div className="rounded-lg bg-[var(--surface-info-subtle)] p-3">
+                <p className="text-body-small-default text-[var(--content-secondary)]">
+                  Auto mode routes each query to the best profile automatically
+                  — fast for simple questions, capable for complex ones. No
+                  provider or model configuration needed.
+                </p>
+              </div>
+            )}
 
-          {/* Key */}
-          <div className="space-y-1">
-            <label className="block text-body-small-default text-[var(--content-tertiary)]">
-              Key
-            </label>
-            <Input
-              type="text"
-              value={key}
-              onChange={(e) => handleKeyChange(e.target.value)}
-              placeholder="e.g. fast-cheap"
-              disabled={isReadOnly || effectiveMode === "edit"}
-              fullWidth
-            />
-            {keyError && !isReadOnly ? (
-              <Typography
-                variant="body-small-default"
-                as="p"
-                className="text-(--system-negative-strong)"
-              >
-                {keyError}
-              </Typography>
-            ) : null}
+            {/* Provider, Connection, Model — hidden for the "auto" meta-profile
+                which has no provider/model of its own. */}
+            {!isAutoProfile && (
+              <ProfileEditorProviderSection
+                provider={provider}
+                model={model}
+                providerConnection={providerConnection}
+                onProviderChange={handleProviderChange}
+                onModelChange={handleModelChange}
+                onConnectionChange={handleConnectionChange}
+                connections={connections}
+                openAICompatibleEndpointsEnabled={openAICompatibleEndpointsEnabled}
+                isReadOnly={isReadOnly}
+                availableConnectionsForProvider={availableConnectionsForProvider}
+                connectionNotFound={connectionNotFound}
+              />
+            )}
+
+            {/* Advanced params — hidden for the auto meta-profile */}
+            {advancedParamsNode}
+
+            {saveErrorNode}
           </div>
-
-          {/* Status — editable in all modes, including view. Same rationale
-              as Display Name: status is user policy, not daemon contract,
-              so view-mode-on-managed still allows disabling. */}
-          <Toggle
-            checked={status === "active"}
-            onChange={(v) => setStatus(v ? "active" : "disabled")}
-            label="Active"
-          />
-
-          {isAutoProfile && (
-            <div className="rounded-lg bg-[var(--surface-info-subtle)] p-3">
-              <p className="text-body-small-default text-[var(--content-secondary)]">
-                Auto mode routes each query to the best profile automatically
-                — fast for simple questions, capable for complex ones. No
-                provider or model configuration needed.
-              </p>
-            </div>
-          )}
-
-          {/* Provider, Connection, Model — hidden for the "auto" meta-profile
-              which has no provider/model of its own. */}
-          {!isAutoProfile && (
-            <ProfileEditorProviderSection
-              provider={provider}
-              model={model}
-              providerConnection={providerConnection}
-              onProviderChange={handleProviderChange}
-              onModelChange={handleModelChange}
-              onConnectionChange={handleConnectionChange}
-              connections={connections}
-              openAICompatibleEndpointsEnabled={openAICompatibleEndpointsEnabled}
-              isReadOnly={isReadOnly}
-              availableConnectionsForProvider={availableConnectionsForProvider}
-              connectionNotFound={connectionNotFound}
-            />
-          )}
-
-          {/* Advanced params — hidden for the auto meta-profile */}
-          {!isAutoProfile && (
-            <ProfileAdvancedParams
-              visibility={visibility}
-              isReadOnly={isReadOnly}
-              model={model}
-              selectedModel={selectedModel}
-              maxTokens={maxTokens}
-              onMaxTokensChange={setMaxTokens}
-              contextWindowMaxInputTokens={contextWindowMaxInputTokens}
-              onContextWindowChange={setContextWindowMaxInputTokens}
-              effort={effort}
-              onEffortChange={setEffort}
-              speed={speed}
-              onSpeedChange={setSpeed}
-              verbosity={verbosity}
-              onVerbosityChange={setVerbosity}
-              temperatureEnabled={temperatureEnabled}
-              onTemperatureEnabledChange={setTemperatureEnabled}
-              temperature={temperature}
-              onTemperatureChange={setTemperature}
-              thinkingEnabled={thinkingEnabled}
-              onThinkingEnabledChange={setThinkingEnabled}
-              thinkingStreamThinking={thinkingStreamThinking}
-              onThinkingStreamThinkingChange={setThinkingStreamThinking}
-              thinkingLevel={thinkingLevel}
-              onThinkingLevelChange={setThinkingLevel}
-            />
-          )}
-
-          {/* Save error */}
-          {saveError ? (
-            <Typography
-              variant="body-small-default"
-              as="p"
-              className="text-(--system-negative-strong)"
-            >
-              {saveError}
-            </Typography>
-          ) : null}
-        </div>
+        )}
       </Modal.Body>
 
       <Modal.Footer>

--- a/apps/web/src/domains/settings/ai/profile-editor-provider-section.tsx
+++ b/apps/web/src/domains/settings/ai/profile-editor-provider-section.tsx
@@ -47,6 +47,13 @@ interface ProfileEditorProviderSectionProps {
   availableConnectionsForProvider: ProviderConnection[];
   /** True when the saved binding no longer points at any known connection. */
   connectionNotFound: boolean;
+  /**
+   * Hide the Provider dropdown (and its empty-state hint). The create-mode
+   * profile editor renders its own provider picker — with a "+ Create new
+   * provider" sentinel and inline create form — and reuses this component
+   * only for the Connection + Model fields below.
+   */
+  hideProviderField?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -73,6 +80,7 @@ export function ProfileEditorProviderSection({
   isReadOnly,
   availableConnectionsForProvider,
   connectionNotFound,
+  hideProviderField = false,
 }: ProfileEditorProviderSectionProps) {
   const providerMissing = provider.length === 0;
   const providerWithoutModel = provider.length > 0 && model.length === 0;
@@ -200,42 +208,44 @@ export function ProfileEditorProviderSection({
     <>
       {/* Provider — required. Filtered to providers with at least one
           connection so users can't bind a profile to a non-dispatchable
-          route. */}
-      <div className="space-y-1">
-        <div className="flex items-center justify-between gap-2">
-          <label
-            id="profile-editor-provider-label"
-            className="block text-body-small-default text-[var(--content-tertiary)]"
-          >
-            Provider
-          </label>
-          {providerMissing ? (
-            <span className="rounded-full bg-[var(--surface-warning-subtle)] px-2 py-0.5 text-body-small-default text-[var(--content-warning)]">
-              Pick a provider
-            </span>
+          route. Hidden when the parent renders its own provider picker. */}
+      {!hideProviderField && (
+        <div className="space-y-1">
+          <div className="flex items-center justify-between gap-2">
+            <label
+              id="profile-editor-provider-label"
+              className="block text-body-small-default text-[var(--content-tertiary)]"
+            >
+              Provider
+            </label>
+            {providerMissing ? (
+              <span className="rounded-full bg-[var(--surface-warning-subtle)] px-2 py-0.5 text-body-small-default text-[var(--content-warning)]">
+                Pick a provider
+              </span>
+            ) : null}
+          </div>
+          <Dropdown
+            value={provider}
+            onChange={onProviderChange}
+            disabled={isReadOnly}
+            placeholder="Select a provider…"
+            aria-labelledby="profile-editor-provider-label"
+            options={providerOptionsSource.map((p) => ({
+              value: p,
+              label: INFERENCE_PROVIDER_DISPLAY_NAMES[p] ?? p,
+            }))}
+          />
+          {providerOptionsSource.length === 0 && !isReadOnly ? (
+            <Typography
+              variant="body-small-default"
+              as="p"
+              className="text-[var(--content-tertiary)]"
+            >
+              No provider connections. Open Providers to add one.
+            </Typography>
           ) : null}
         </div>
-        <Dropdown
-          value={provider}
-          onChange={onProviderChange}
-          disabled={isReadOnly}
-          placeholder="Select a provider…"
-          aria-labelledby="profile-editor-provider-label"
-          options={providerOptionsSource.map((p) => ({
-            value: p,
-            label: INFERENCE_PROVIDER_DISPLAY_NAMES[p] ?? p,
-          }))}
-        />
-        {providerOptionsSource.length === 0 && !isReadOnly ? (
-          <Typography
-            variant="body-small-default"
-            as="p"
-            className="text-[var(--content-tertiary)]"
-          >
-            No provider connections. Open Providers to add one.
-          </Typography>
-        ) : null}
-      </div>
+      )}
 
       {/* Connection — visible when matching connections exist or a saved
           binding exists (even if stale). */}

--- a/apps/web/src/domains/settings/ai/use-label-key-sync.ts
+++ b/apps/web/src/domains/settings/ai/use-label-key-sync.ts
@@ -9,9 +9,16 @@ import { toKebabCase } from "@/domains/settings/ai/slugify";
  * the key with a kebab-cased slug. Once the user touches the key field
  * directly, auto-derivation stops.
  *
- * `resetDirty` is stable (empty deps) and safe in effect dependency arrays.
- * `handleLabelChange` and `handleKeyChange` update when `mode`, `setLabel`,
- * or `setKey` change — both are event handlers, not effect dependencies.
+ * `getDirty()` reports whether the user has manually edited EITHER the label
+ * or the key. Callers that pre-fill both fields from another source (e.g. the
+ * profile editor seeding Name/Key from the selected model) use it to avoid
+ * clobbering user edits. It's separate from the internal key-follows-label
+ * tracking so a label edit still drives the auto-derived key.
+ *
+ * `resetDirty` and `getDirty` are stable (empty deps) and safe in effect
+ * dependency arrays. `handleLabelChange` and `handleKeyChange` update when
+ * `mode`, `setLabel`, or `setKey` change — both are event handlers, not
+ * effect dependencies.
  */
 export function useLabelKeySync(
   mode: string,
@@ -19,9 +26,14 @@ export function useLabelKeySync(
   setKey: (value: string) => void,
 ) {
   const keyDirtyRef = useRef(false);
+  // True once the user manually edits Name (label) or Key. Distinct from
+  // `keyDirtyRef`, which only tracks the key field so a label edit can keep
+  // driving the auto-derived key.
+  const touchedRef = useRef(false);
 
   const handleLabelChange = useCallback(
     (newLabel: string) => {
+      touchedRef.current = true;
       setLabel(newLabel);
       if (mode === "create" && !keyDirtyRef.current) {
         setKey(toKebabCase(newLabel));
@@ -33,6 +45,7 @@ export function useLabelKeySync(
   const handleKeyChange = useCallback(
     (newKey: string) => {
       keyDirtyRef.current = true;
+      touchedRef.current = true;
       setKey(newKey);
     },
     [setKey],
@@ -40,7 +53,10 @@ export function useLabelKeySync(
 
   const resetDirty = useCallback(() => {
     keyDirtyRef.current = false;
+    touchedRef.current = false;
   }, []);
 
-  return { handleLabelChange, handleKeyChange, resetDirty };
+  const getDirty = useCallback(() => touchedRef.current, []);
+
+  return { handleLabelChange, handleKeyChange, resetDirty, getDirty };
 }


### PR DESCRIPTION
## Summary
- Reorder create-mode profile modal: Provider (with inline + Create new provider) -> Model -> Name/Key (pre-filled) -> Description -> collapsed Advanced
- Pre-fill provider name/key from provider type and profile name/key from model via shared helpers, respecting manual edits
- Collapse advanced params behind a disclosure in create mode; edit/view unchanged

Part of plan: provider-first-profile-quick-add.md (PR 3 of 5)