### PR TITLE
Match iOS "About Assistant" layout to Figma mock

### DIFF
--- a/apps/web/src/domains/chat/chat-layout-header.tsx
+++ b/apps/web/src/domains/chat/chat-layout-header.tsx
@@ -60,7 +60,7 @@ export function ChatLayoutHeader({
       }}
     >
       <div
-        className="flex items-center gap-2 transition-[min-width] duration-150 ease-in-out"
+        className="flex items-center gap-2 transition-[min-width] duration-150 ease-in-out max-md:min-w-0 max-md:flex-1"
         style={!isMobile ? { minWidth: collapsed ? 48 : (sidebarWidth ?? 230) } : undefined}
       >
         {isMobile ? (
@@ -137,7 +137,7 @@ export function ChatLayoutHeader({
         {topBarCenter}
       </div>
 
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-2 max-md:flex-1 max-md:justify-end">
         {isMobile ? (
           <Button
             variant="ghost"

--- a/apps/web/src/domains/intelligence/intelligence-layout.test.tsx
+++ b/apps/web/src/domains/intelligence/intelligence-layout.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * Tests for `IntelligenceLayout`'s mobile/desktop title placement.
+ *
+ * On mobile the "About <name>" title moves into the shared top-bar center
+ * slot (via `setTopBarCenter`) and the in-body <h1> is hidden with
+ * `max-md:hidden`. On desktop the in-body <h1> renders the title and the
+ * top-bar center is cleared (`setTopBarCenter(null)`).
+ *
+ * `useIsMobile` and the slots-store setter are mocked; the assistant name is
+ * driven through the real identity store. `MemoryRouter` satisfies the
+ * component's `useLocation`/`NavLink` usage.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { isValidElement } from "react";
+import { cleanup, render } from "@testing-library/react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router";
+
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
+
+const isMobileRef = { value: false };
+const setTopBarCenterMock = mock((_node: unknown) => {});
+
+mock.module("@/hooks/use-is-mobile", () => ({
+  useIsMobile: () => isMobileRef.value,
+  MOBILE_MEDIA_QUERY: "(max-width: 767px)",
+}));
+
+mock.module("@/components/layout/chat-layout-slots-store", () => ({
+  useChatLayoutSlotsStore: {
+    use: {
+      setTopBarCenter: () => setTopBarCenterMock,
+    },
+  },
+}));
+
+// The real feature-flag store imports the generated API client, which isn't
+// available under the test runner. Stub the two selectors the layout reads;
+// `false` for `externalPlugins` keeps the baseline tab set.
+mock.module("@/stores/assistant-feature-flag-store", () => ({
+  useAssistantFeatureFlagStore: {
+    use: {
+      hasHydrated: () => true,
+      externalPlugins: () => false,
+    },
+  },
+}));
+
+const { IntelligenceLayout } = await import(
+  "@/domains/intelligence/intelligence-layout"
+);
+
+const renderLayout = () =>
+  render(
+    <MemoryRouter>
+      <IntelligenceLayout />
+    </MemoryRouter>,
+  );
+
+beforeEach(() => {
+  isMobileRef.value = false;
+  setTopBarCenterMock.mockClear();
+  useAssistantIdentityStore.getState().setIdentity("Ada", null);
+});
+
+afterEach(() => {
+  cleanup();
+  useAssistantIdentityStore.getState().clearIdentity();
+});
+
+describe("IntelligenceLayout", () => {
+  test("on mobile, registers the centered title and hides the in-body h1", () => {
+    isMobileRef.value = true;
+    const { container } = renderLayout();
+
+    // The in-body h1 still renders the title but is hidden on mobile.
+    const heading = container.querySelector("h1");
+    expect(heading?.textContent).toContain("About Ada");
+    expect(heading?.className).toContain("max-md:hidden");
+
+    // The top-bar center receives a node that renders the dynamic title.
+    const lastCall = setTopBarCenterMock.mock.calls.at(-1);
+    const node = lastCall?.[0];
+    expect(isValidElement(node)).toBe(true);
+    expect(renderToStaticMarkup(node as React.ReactElement)).toContain(
+      "About Ada",
+    );
+  });
+
+  test("on desktop, renders the in-body title and clears the top-bar center", () => {
+    isMobileRef.value = false;
+    const { container } = renderLayout();
+
+    const heading = container.querySelector("h1");
+    expect(heading?.textContent).toContain("About Ada");
+
+    expect(setTopBarCenterMock).toHaveBeenLastCalledWith(null);
+  });
+});

--- a/apps/web/src/domains/intelligence/intelligence-layout.tsx
+++ b/apps/web/src/domains/intelligence/intelligence-layout.tsx
@@ -55,7 +55,7 @@ export function IntelligenceLayout() {
       setTopBarCenter(
         <Typography
           variant="body-medium-default"
-          className="text-[var(--content-secondary)]"
+          className="truncate text-[var(--content-secondary)]"
         >
           About {assistantName || "Assistant"}
         </Typography>,

--- a/apps/web/src/domains/intelligence/intelligence-layout.tsx
+++ b/apps/web/src/domains/intelligence/intelligence-layout.tsx
@@ -100,11 +100,11 @@ export function IntelligenceLayout() {
               className={cn(
                 "relative -mb-px inline-flex cursor-pointer items-center gap-1.5 border-b-2 border-transparent bg-transparent px-2.5 py-[7px]",
                 "text-body-medium-default whitespace-nowrap",
-                "text-[var(--content-tertiary)] transition-colors",
+                "text-[var(--content-secondary)] transition-colors",
                 "outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] focus-visible:ring-offset-0",
                 "hover:bg-[var(--surface-hover)] hover:text-[var(--content-default)]",
                 isActive &&
-                  "border-[var(--primary-base)] text-[var(--content-default)]",
+                  "border-[var(--border-active)] text-[var(--primary-active)]",
                 isActive && "hover:bg-transparent",
               )}
             >

--- a/apps/web/src/domains/intelligence/intelligence-layout.tsx
+++ b/apps/web/src/domains/intelligence/intelligence-layout.tsx
@@ -1,8 +1,11 @@
+import { useEffect } from "react";
 import { NavLink, Outlet, useLocation } from "react-router";
 
-import { cn } from "@vellum/design-library";
+import { Typography, cn } from "@vellum/design-library";
 
 import { PageShell } from "@/components/page-shell";
+import { useChatLayoutSlotsStore } from "@/components/layout/chat-layout-slots-store";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { routes } from "@/utils/routes";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
@@ -40,6 +43,30 @@ export function IntelligenceLayout() {
   const hasHydrated = useAssistantFeatureFlagStore.use.hasHydrated();
   const externalPlugins = useAssistantFeatureFlagStore.use.externalPlugins();
   const { pathname } = useLocation();
+  const isMobile = useIsMobile();
+  const setTopBarCenter = useChatLayoutSlotsStore.use.setTopBarCenter();
+
+  // On mobile the title moves out of the page body and into the shared top
+  // bar — centered between the hamburger menu and the search icon — so the
+  // tab row can rise directly beneath the header. Desktop keeps the in-body
+  // <h1> and leaves the top-bar center empty.
+  useEffect(() => {
+    if (isMobile) {
+      setTopBarCenter(
+        <Typography
+          variant="body-medium-default"
+          className="text-[var(--content-secondary)]"
+        >
+          About {assistantName || "Assistant"}
+        </Typography>,
+      );
+    } else {
+      setTopBarCenter(null);
+    }
+    return () => {
+      setTopBarCenter(null);
+    };
+  }, [isMobile, assistantName, setTopBarCenter]);
 
   // Insert the Plugins tab between Identity and Skills when the
   // `external-plugins` flag is on. Gated on `hasHydrated` so we don't
@@ -54,7 +81,7 @@ export function IntelligenceLayout() {
 
   return (
     <PageShell>
-      <h1 className="mb-4 shrink-0 text-title-large text-[var(--content-default)]">
+      <h1 className="mb-4 shrink-0 text-title-large text-[var(--content-default)] max-md:hidden">
         About {assistantName || "Assistant"}
       </h1>
 


### PR DESCRIPTION
## Summary
Make the web-rendered "About Assistant" screen (shown on iOS via the Capacitor WebView) match the Figma mock:
- The screen title moves into the mobile top bar as a centered, dynamic **About {Assistant}** label between the hamburger menu and the search icon (`body-medium-default` / `content-secondary`). Desktop keeps its large in-body heading.
- Hiding the in-body `<h1>` on mobile raises the Identity / Plugins / Skills / Workspace / Contacts tabs directly beneath the header.
- Tab label colors updated to the mock: inactive `content-secondary`, active `primary-active` text with a `border-active` underline.

## Self-review result
Skipped (`--skip-reviews`).

## PRs merged into feature branch
- #33334: fix(web): center dynamic "About Assistant" title in mobile top bar
- #33335: fix(web): match About Assistant tab colors to Figma mock

Part of plan: about-assistant-ios-header.md