### PR TITLE
Add confirmation toasts and empty/error/saving states to profile + provider create

### DIFF
--- a/apps/web/src/domains/settings/ai/manage-profiles-modal.test.tsx
+++ b/apps/web/src/domains/settings/ai/manage-profiles-modal.test.tsx
@@ -1,0 +1,229 @@
+/**
+ * Tests for `ManageProfilesModal` — the SETTINGS surface that owns the
+ * profile-create success toast.
+ *
+ * Per the provider-first-profile-quick-add plan (PR 5), the success toast for
+ * a profile create fires from THIS surface's save resolve (create mode only),
+ * NOT from the shared `ProfileEditorModal` — so the composer quick-add surface
+ * can own its own toast without double-firing.
+ *
+ * We mock `use-daemon-config` (query + capturing mutation), the feature-flag
+ * store, the connections query, and the design-library toast so we can drive a
+ * provider-first create end to end and assert exactly one success toast fires.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createElement, type ReactNode } from "react";
+
+import type { DaemonConfigPatch, ProfileEntry } from "@/domains/settings/ai/ai-types";
+import type { ProviderConnection } from "@/domains/settings/ai/provider-connections-client";
+import * as daemonQueryGen from "@/generated/daemon/@tanstack/react-query.gen";
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+let toastSuccessCalls: string[] = [];
+let mutatePatches: DaemonConfigPatch[] = [];
+let profilesState: Record<string, ProfileEntry> = {};
+
+mock.module("@vellum/design-library/components/toast", () => ({
+  toast: {
+    success: (message: string) => {
+      toastSuccessCalls.push(message);
+    },
+    error: () => {},
+  },
+  Toaster: () => null,
+  ToastContent: () => null,
+}));
+
+mock.module("@/domains/settings/ai/use-daemon-config", () => ({
+  useDaemonConfigQuery: () => ({
+    assistantId: "asst-1",
+    config: undefined,
+    profiles: profilesState,
+    profileOrder: Object.keys(profilesState),
+    orderedProfiles: [],
+    activeProfile: null,
+    callSites: {},
+  }),
+  useDaemonConfigMutation: () => ({
+    mutateAsync: (patch: DaemonConfigPatch) => {
+      mutatePatches.push(patch);
+      return Promise.resolve({ data: undefined, resolvedId: "asst-1" });
+    },
+  }),
+}));
+
+// Feature-flag store: `.use.<flag>()` accessors return booleans.
+mock.module("@/stores/assistant-feature-flag-store", () => {
+  const store = () => null;
+  store.use = {
+    openAICompatibleEndpoints: () => false,
+    chatgptSubscriptionAuth: () => false,
+    queryComplexityRouting: () => false,
+  };
+  return { useAssistantFeatureFlagStore: store };
+});
+
+// Connections query — supply a single Anthropic connection so the provider-
+// first picker offers "Anthropic" without needing the inline create path.
+const connection: ProviderConnection = {
+  name: "anthropic-personal",
+  label: null,
+  provider: "anthropic",
+  auth: { type: "api_key", credential: "credential/anthropic/api_key" },
+  models: null,
+} as unknown as ProviderConnection;
+
+mock.module("@/generated/daemon/@tanstack/react-query.gen", () => ({
+  ...daemonQueryGen,
+  inferenceProviderconnectionsGetOptions: () => ({
+    queryKey: [{ _id: "inferenceProviderconnectionsGet" }],
+    queryFn: () => Promise.resolve({ connections: [connection] }),
+  }),
+  inferenceProviderconnectionsGetQueryKey: () => [
+    { _id: "inferenceProviderconnectionsGet" },
+  ],
+}));
+
+const { ManageProfilesModal } = await import(
+  "@/domains/settings/ai/manage-profiles-modal"
+);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  // Seed the connections cache so the provider-first picker has options on
+  // first render (the modal reads from this query).
+  client.setQueryData(
+    [{ _id: "inferenceProviderconnectionsGet" }],
+    { connections: [connection] },
+  );
+  return createElement(QueryClientProvider, { client }, children);
+}
+
+function getInputByPlaceholder(placeholder: string): HTMLInputElement {
+  const input = Array.from(
+    document.querySelectorAll<HTMLInputElement>("input"),
+  ).find((el) => el.placeholder === placeholder);
+  if (!input) {
+    throw new Error(`expected an input with placeholder "${placeholder}"`);
+  }
+  return input;
+}
+
+function getButton(label: string): HTMLButtonElement {
+  const match = Array.from(
+    document.querySelectorAll<HTMLButtonElement>("button"),
+  ).find((b) => b.textContent?.trim() === label);
+  if (!match) throw new Error(`expected a "${label}" button`);
+  return match;
+}
+
+function getSaveBtn(): HTMLButtonElement {
+  const btn = document.querySelector<HTMLButtonElement>(
+    '[data-testid="modal-save-btn"]',
+  );
+  if (!btn) throw new Error("expected a modal-save-btn");
+  return btn;
+}
+
+function providerTrigger(): HTMLButtonElement {
+  const trigger = document.querySelector<HTMLButtonElement>(
+    'button[role="combobox"][aria-labelledby="profile-editor-provider-label"]',
+  );
+  if (!trigger) throw new Error("expected the Provider dropdown trigger");
+  return trigger;
+}
+
+function pickOption(trigger: HTMLButtonElement, optionLabel: string): void {
+  fireEvent.click(trigger);
+  const option = Array.from(
+    document.querySelectorAll<HTMLElement>('[role="option"]'),
+  ).find((o) => o.textContent?.trim() === optionLabel);
+  if (!option) {
+    throw new Error(`expected option "${optionLabel}"`);
+  }
+  fireEvent.click(option);
+}
+
+function selectModel(label: string): void {
+  const provTrigger = providerTrigger();
+  for (const trigger of Array.from(
+    document.querySelectorAll<HTMLButtonElement>('button[role="combobox"]'),
+  )) {
+    if (trigger === provTrigger) continue;
+    fireEvent.click(trigger);
+    const option = Array.from(
+      document.querySelectorAll<HTMLElement>('[role="option"]'),
+    ).find((o) => o.textContent?.trim() === label);
+    if (option) {
+      fireEvent.click(option);
+      return;
+    }
+    fireEvent.click(trigger);
+  }
+  throw new Error(`expected a Model dropdown offering "${label}"`);
+}
+
+beforeEach(() => {
+  toastSuccessCalls = [];
+  mutatePatches = [];
+  profilesState = {};
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ManageProfilesModal — profile-create success toast (Settings surface)", () => {
+  test("fires exactly one success toast on a successful create", async () => {
+    render(
+      <Wrapper>
+        <ManageProfilesModal isOpen assistantId="asst-1" onClose={() => {}} />
+      </Wrapper>,
+    );
+
+    // Open the create editor.
+    fireEvent.click(getButton("+ New Profile"));
+
+    // Provider-first create: pick Anthropic, a model, then a name.
+    pickOption(providerTrigger(), "Anthropic");
+    selectModel("Claude Opus 4.8");
+
+    fireEvent.change(getInputByPlaceholder("e.g. fast-cheap"), {
+      target: { value: "my-profile" },
+    });
+    fireEvent.change(getInputByPlaceholder("e.g. Fast & Cheap"), {
+      target: { value: "My Profile" },
+    });
+
+    await waitFor(() => {
+      expect(getSaveBtn().disabled).toBe(false);
+    });
+    fireEvent.click(getSaveBtn());
+
+    // The config mutation ran and the Settings surface fired one toast using
+    // the entered label.
+    await waitFor(() => {
+      expect(mutatePatches.length).toBeGreaterThan(0);
+    });
+    await waitFor(() => {
+      expect(toastSuccessCalls).toEqual(['Profile "My Profile" created']);
+    });
+  });
+});

--- a/apps/web/src/domains/settings/ai/manage-profiles-modal.tsx
+++ b/apps/web/src/domains/settings/ai/manage-profiles-modal.tsx
@@ -7,6 +7,7 @@ import { Dropdown } from "@vellum/design-library/components/dropdown";
 import { Toggle } from "@vellum/design-library/components/toggle";
 import { Modal } from "@vellum/design-library/components/modal";
 import { Tag } from "@vellum/design-library/components/tag";
+import { toast } from "@vellum/design-library/components/toast";
 import { Typography } from "@vellum/design-library/components/typography";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { captureError } from "@/lib/sentry/capture-error";
@@ -130,6 +131,14 @@ export function ManageProfilesModal({
       }
     } else {
       await configMutation.mutateAsync({ llm: llmPatch });
+    }
+
+    // Fire the profile-create success toast from the SETTINGS surface only.
+    // The composer quick-add surface owns its own create toast, so firing
+    // here (rather than inside ProfileEditorModal, which both surfaces share)
+    // keeps exactly one success toast per create with no double-fire.
+    if (isNew) {
+      toast.success(`Profile "${entry.label ?? name}" created`);
     }
 
     setEditorOpen(false);

--- a/apps/web/src/domains/settings/ai/profile-editor-modal.test.tsx
+++ b/apps/web/src/domains/settings/ai/profile-editor-modal.test.tsx
@@ -31,6 +31,22 @@ import type { ProviderConnection } from "@/domains/settings/ai/provider-connecti
 // ---------------------------------------------------------------------------
 
 let createdConnection: ProviderConnection;
+let toastSuccessCalls: string[] = [];
+
+// Spy on the design-library toast so we can assert the shared ProfileEditorModal
+// does NOT fire a profile-create success toast itself — that toast belongs to
+// the surrounding surface (Settings via ManageProfilesModal, composer via its
+// own quick-add), preventing a double-fire.
+mock.module("@vellum/design-library/components/toast", () => ({
+  toast: {
+    success: (message: string) => {
+      toastSuccessCalls.push(message);
+    },
+    error: () => {},
+  },
+  Toaster: () => null,
+  ToastContent: () => null,
+}));
 
 mock.module("@/generated/daemon/sdk.gen", () => ({
   ...sdkGen,
@@ -177,7 +193,11 @@ function selectModel(label: string): void {
   throw new Error(`expected a Model dropdown offering "${label}"`);
 }
 
-function renderCreate(connections: ProviderConnection[]) {
+function renderCreate(
+  connections: ProviderConnection[],
+  onSave: (name: string, entry: unknown) => Promise<void> = () =>
+    Promise.resolve(),
+) {
   return render(
     <Wrapper>
       <ProfileEditorModal
@@ -186,15 +206,25 @@ function renderCreate(connections: ProviderConnection[]) {
         existingNames={[]}
         connections={connections}
         assistantId={ASSISTANT_ID}
-        onSave={() => Promise.resolve()}
+        onSave={onSave}
         onCancel={() => {}}
       />
     </Wrapper>,
   );
 }
 
+/** Drive a provider-first create up to a Save-enabled state. */
+function fillCreateForm(): void {
+  selectProvider("Anthropic");
+  selectModel("Claude Opus 4.8");
+  fireEvent.change(getInputByPlaceholder("e.g. fast-cheap"), {
+    target: { value: "my-profile" },
+  });
+}
+
 beforeEach(() => {
   createdConnection = makeConnection("anthropic-personal");
+  toastSuccessCalls = [];
 });
 
 afterEach(() => {
@@ -300,5 +330,77 @@ describe("ProfileEditorModal create mode — provider-first", () => {
     await waitFor(() => {
       expect(getSaveBtn().disabled).toBe(false);
     });
+  });
+
+  test("Save shows 'Saving…' and disables while the create is in flight", async () => {
+    // Hold the save promise open so we can observe the in-flight state.
+    let resolveSave: () => void = () => {};
+    const onSave = () =>
+      new Promise<void>((resolve) => {
+        resolveSave = resolve;
+      });
+
+    renderCreate([makeConnection("anthropic-personal")], onSave);
+    fillCreateForm();
+
+    await waitFor(() => {
+      expect(getSaveBtn().disabled).toBe(false);
+    });
+    fireEvent.click(getSaveBtn());
+
+    // While pending: button is disabled and shows progress text.
+    await waitFor(() => {
+      expect(getSaveBtn().textContent?.trim()).toBe("Saving…");
+    });
+    expect(getSaveBtn().disabled).toBe(true);
+
+    resolveSave();
+    await waitFor(() => {
+      expect(getSaveBtn().textContent?.trim()).toBe("Save");
+    });
+  });
+
+  test("a save failure renders inline and keeps the modal open", async () => {
+    const onSave = () => Promise.reject(new Error("invalid API key"));
+
+    renderCreate([makeConnection("anthropic-personal")], onSave);
+    fillCreateForm();
+
+    await waitFor(() => {
+      expect(getSaveBtn().disabled).toBe(false);
+    });
+    fireEvent.click(getSaveBtn());
+
+    // The inline error surfaces...
+    await waitFor(() => {
+      expect(document.body.textContent).toContain(
+        "Failed to save profile. Please try again.",
+      );
+    });
+    // ...and the modal stays open (the Save button is still rendered).
+    expect(getSaveBtn()).toBeDefined();
+  });
+
+  test("the modal itself does NOT fire a profile-create success toast", async () => {
+    // The success toast belongs to the surrounding surface (Settings/composer),
+    // not the shared modal — this guards against a double-fire regression.
+    let resolved = false;
+    const onSave = () => {
+      resolved = true;
+      return Promise.resolve();
+    };
+
+    renderCreate([makeConnection("anthropic-personal")], onSave);
+    fillCreateForm();
+
+    await waitFor(() => {
+      expect(getSaveBtn().disabled).toBe(false);
+    });
+    fireEvent.click(getSaveBtn());
+
+    await waitFor(() => {
+      expect(resolved).toBe(true);
+    });
+    expect(toastSuccessCalls).toEqual([]);
   });
 });

--- a/apps/web/src/domains/settings/ai/provider-create-form.test.tsx
+++ b/apps/web/src/domains/settings/ai/provider-create-form.test.tsx
@@ -45,6 +45,18 @@ let createConnectionCalls: CreateConnectionCall[] = [];
 let createdConnection: ProviderConnection;
 let createResponseOk = true;
 let createResponseStatus = 200;
+let toastSuccessCalls: string[] = [];
+
+mock.module("@vellum/design-library/components/toast", () => ({
+  toast: {
+    success: (message: string) => {
+      toastSuccessCalls.push(message);
+    },
+    error: () => {},
+  },
+  Toaster: () => null,
+  ToastContent: () => null,
+}));
 
 mock.module("@/generated/daemon/sdk.gen", () => ({
   ...sdkGen,
@@ -180,6 +192,7 @@ beforeEach(() => {
   createdConnection = makeConnection("anthropic-personal");
   createResponseOk = true;
   createResponseStatus = 200;
+  toastSuccessCalls = [];
 });
 
 afterEach(() => {
@@ -328,6 +341,67 @@ describe("ProviderCreateForm submit sequence", () => {
     // confirms the form initialized on the "bring your own credential" path
     // (instead of the managed-capable provider's default `platform`).
     expect(getInputByPlaceholder("Enter your API key")).toBeDefined();
+  });
+
+  test("fires a 'Provider connected' success toast on a successful create", async () => {
+    render(
+      <ModalWrapper>
+        <ProviderCreateForm
+          assistantId={ASSISTANT_ID}
+          existingNames={[]}
+          onCreated={() => {}}
+          onCancel={() => {}}
+        />
+      </ModalWrapper>,
+    );
+
+    fireEvent.change(getInputByPlaceholder("e.g. anthropic-personal"), {
+      target: { value: "anthropic-personal" },
+    });
+    selectDropdownOption("Auth type", "API Key");
+    fireEvent.change(getInputByPlaceholder("Enter your API key"), {
+      target: { value: "sk-test-123" },
+    });
+
+    fireEvent.click(getButton("Create"));
+
+    await waitFor(() => {
+      expect(toastSuccessCalls).toEqual(["Provider connected"]);
+    });
+  });
+
+  test("a connection failure renders inline, keeps the form open, and does NOT toast", async () => {
+    createResponseOk = false;
+    createResponseStatus = 401;
+
+    render(
+      <ModalWrapper>
+        <ProviderCreateForm
+          assistantId={ASSISTANT_ID}
+          existingNames={[]}
+          onCreated={() => {}}
+          onCancel={() => {}}
+        />
+      </ModalWrapper>,
+    );
+
+    fireEvent.change(getInputByPlaceholder("e.g. anthropic-personal"), {
+      target: { value: "anthropic-personal" },
+    });
+    selectDropdownOption("Auth type", "API Key");
+    fireEvent.change(getInputByPlaceholder("Enter your API key"), {
+      target: { value: "sk-test-123" },
+    });
+
+    fireEvent.click(getButton("Create"));
+
+    // The connection-failure message surfaces inline...
+    await waitFor(() => {
+      expect(createConnectionCalls.length).toBe(1);
+    });
+    expect(toastSuccessCalls).toEqual([]);
+    // ...and the form stays mounted (the Create button is still present).
+    expect(getButton("Create")).toBeDefined();
   });
 
   test("clicking Cancel invokes onCancel", () => {

--- a/apps/web/src/domains/settings/ai/provider-create-form.tsx
+++ b/apps/web/src/domains/settings/ai/provider-create-form.tsx
@@ -5,6 +5,7 @@ import { Button } from "@vellum/design-library/components/button";
 import { Dropdown } from "@vellum/design-library/components/dropdown";
 import { Input } from "@vellum/design-library/components/input";
 import { Modal } from "@vellum/design-library/components/modal";
+import { toast } from "@vellum/design-library/components/toast";
 import { Typography } from "@vellum/design-library/components/typography";
 
 import {
@@ -237,6 +238,9 @@ export function ProviderCreateForm({
         setError("Server returned an empty response. Please try again.");
         return;
       }
+      // Single success confirmation for both the standalone and inline
+      // surfaces; failures above already surface inline via `error` (no toast).
+      toast.success("Provider connected");
       onCreated(created);
     } catch {
       setError("Failed to save connection. Please try again.");


### PR DESCRIPTION
## Summary
- Fire success toasts on Settings profile create and on provider connect (composer create toast owned by its own surface)
- Keep API-key/connection failures inline without dismissing the modal
- Ensure Create/Save shows Saving… and disables during in-flight create

Part of plan: provider-first-profile-quick-add.md (PR 5 of 5)