### PR TITLE
Add quick-add profile "+" to the composer Model Profile popover

### DIFF
--- a/apps/web/src/components/profile-quick-add-provider.test.tsx
+++ b/apps/web/src/components/profile-quick-add-provider.test.tsx
@@ -70,8 +70,16 @@ mock.module("@/generated/daemon/@tanstack/react-query.gen", () => ({
 const clientPatch = mock(
   async (_opts: unknown): Promise<{ data: unknown }> => ({ data: {} }),
 );
+// The save path re-reads the latest server config so the appended profileOrder
+// is authoritative regardless of what the modal was opened with. Default to one
+// pre-existing profile; individual tests override per-call as needed.
+const clientGet = mock(
+  async (_opts: unknown): Promise<{ data: unknown }> => ({
+    data: { llm: { profileOrder: ["smart"], profiles: { smart: { label: "Smart" } } } },
+  }),
+);
 mock.module("@/generated/api/client.gen", () => ({
-  client: { patch: clientPatch },
+  client: { get: clientGet, patch: clientPatch },
 }));
 
 import {
@@ -81,15 +89,15 @@ import {
 
 // Test consumer: opens the quick-add on mount and records the onCreated name.
 const onCreated = mock((_name: string) => {});
-function Opener({ profileOrder }: { profileOrder: string[] }) {
+function Opener({ existingNames }: { existingNames: string[] }) {
   const { openProfileQuickAdd } = useProfileQuickAdd();
   useEffect(() => {
-    openProfileQuickAdd({ existingNames: profileOrder, profileOrder, onCreated });
-  }, [openProfileQuickAdd, profileOrder]);
+    openProfileQuickAdd({ existingNames, onCreated });
+  }, [openProfileQuickAdd, existingNames]);
   return null;
 }
 
-function renderProvider(profileOrder: string[]) {
+function renderProvider(existingNames: string[]) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
@@ -97,7 +105,7 @@ function renderProvider(profileOrder: string[]) {
     createElement(
       QueryClientProvider,
       { client: queryClient },
-      createElement(ProfileQuickAddProvider, null, createElement(Opener, { profileOrder })),
+      createElement(ProfileQuickAddProvider, null, createElement(Opener, { existingNames })),
     ),
   );
 }
@@ -106,6 +114,7 @@ beforeEach(() => {
   toastSuccess.mockClear();
   onCreated.mockClear();
   clientPatch.mockClear();
+  clientGet.mockClear();
 });
 
 afterEach(() => {
@@ -143,5 +152,57 @@ describe("ProfileQuickAddProvider", () => {
       expect(toastSuccess).toHaveBeenCalledWith(`Profile "${NEW_PROFILE_NAME}" created`);
     });
     expect(screen.queryByTestId("modal-save-btn")).toBeNull();
+  });
+
+  test("the save path reads the LATEST server config — appends to the server order, not the (stale/empty) opener input", async () => {
+    // Server already has two profiles in a specific order. The opener was given
+    // an EMPTY existingNames (simulating a click before config loaded); the
+    // PATCH must still append to the server's order, preserving both existing
+    // profiles rather than resetting the order to just the new name.
+    clientGet.mockImplementationOnce(async () => ({
+      data: {
+        llm: {
+          profileOrder: ["smart", "creative"],
+          profiles: { smart: { label: "Smart" }, creative: { label: "Creative" } },
+        },
+      },
+    }));
+
+    renderProvider([]); // opener passes no existing names
+    await waitFor(() => screen.getByTestId("modal-save-btn"));
+    fireEvent.click(screen.getByTestId("modal-save-btn"));
+
+    await waitFor(() => {
+      expect(clientPatch).toHaveBeenCalledTimes(1);
+    });
+    // Re-read the freshest config before persisting.
+    expect(clientGet).toHaveBeenCalledTimes(1);
+    const patchBody = (clientPatch.mock.calls[0]![0] as { body: { llm: Record<string, unknown> } }).body.llm;
+    expect(patchBody.profileOrder).toEqual(["smart", "creative", NEW_PROFILE_NAME]);
+  });
+
+  test("the save path dedupes against fresh server state — no profileOrder reset when the name already exists on the server", async () => {
+    // The new name already exists on the server (in the map). The PATCH must
+    // omit profileOrder entirely rather than re-appending or resetting it.
+    clientGet.mockImplementationOnce(async () => ({
+      data: {
+        llm: {
+          profileOrder: ["smart"],
+          profiles: { smart: { label: "Smart" }, [NEW_PROFILE_NAME]: { label: "Existing" } },
+        },
+      },
+    }));
+
+    renderProvider([]);
+    await waitFor(() => screen.getByTestId("modal-save-btn"));
+    fireEvent.click(screen.getByTestId("modal-save-btn"));
+
+    await waitFor(() => {
+      expect(clientPatch).toHaveBeenCalledTimes(1);
+    });
+    const patchBody = (clientPatch.mock.calls[0]![0] as { body: { llm: Record<string, unknown> } }).body.llm;
+    expect("profileOrder" in patchBody).toBe(false);
+    // The profile entry is still written (the create/overwrite of llm.profiles).
+    expect((patchBody.profiles as Record<string, unknown>)[NEW_PROFILE_NAME]).toBeTruthy();
   });
 });

--- a/apps/web/src/components/profile-quick-add-provider.test.tsx
+++ b/apps/web/src/components/profile-quick-add-provider.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * Tests for the top-level ProfileQuickAddProvider / useProfileQuickAdd().
+ *
+ * The provider owns the settings ProfileEditorModal create flow so chat (and
+ * other domains) can trigger a profile quick-add without importing settings.
+ * We mock the settings modal as a lightweight stub that calls `onSave` with a
+ * deterministic entry, then assert the controller persists the new profile via
+ * the daemon config PATCH, fires `onCreated` with the new name, and toasts.
+ *
+ * Mounted with `@testing-library/react` (happy-dom — see `apps/web/test-setup.ts`).
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { createElement, useEffect } from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const NEW_PROFILE_NAME = "fast-cheap";
+
+// --- selection store (active assistant id) -----------------------------------
+mock.module("@/assistant/selection-store", () => {
+  const store = () => null;
+  store.use = { activeAssistantId: () => "assistant-1" };
+  return { useAssistantSelectionStore: store };
+});
+
+// --- feature flag store ------------------------------------------------------
+mock.module("@/stores/assistant-feature-flag-store", () => {
+  const store = () => null;
+  store.use = {
+    openAICompatibleEndpoints: () => false,
+    chatgptSubscriptionAuth: () => false,
+  };
+  return { useAssistantFeatureFlagStore: store };
+});
+
+// --- toast -------------------------------------------------------------------
+const toastSuccess = mock((_msg: string) => {});
+mock.module("@vellum/design-library/components/toast", () => ({
+  toast: { success: toastSuccess, error: () => {} },
+}));
+
+// --- ProfileEditorModal stub -------------------------------------------------
+// Renders a Save button (only when open) that invokes onSave with a fixed entry.
+mock.module("@/domains/settings/ai/profile-editor-modal", () => ({
+  ProfileEditorModal: ({ isOpen, onSave }: { isOpen: boolean; onSave: (n: string, e: unknown) => Promise<void> }) =>
+    isOpen
+      ? createElement(
+          "button",
+          {
+            "data-testid": "modal-save-btn",
+            onClick: () => void onSave(NEW_PROFILE_NAME, { label: "Fast & Cheap" }),
+          },
+          "Save",
+        )
+      : null,
+}));
+
+mock.module("@/domains/settings/ai/provider-connections-client", () => ({
+  filterFlaggedConnections: (c: unknown) => c,
+}));
+
+mock.module("@/generated/daemon/@tanstack/react-query.gen", () => ({
+  inferenceProviderconnectionsGetOptions: () => ({
+    queryKey: [{ _id: "inferenceProviderconnectionsGet" }],
+    queryFn: async () => ({ connections: [] }),
+  }),
+}));
+
+const clientPatch = mock(
+  async (_opts: unknown): Promise<{ data: unknown }> => ({ data: {} }),
+);
+mock.module("@/generated/api/client.gen", () => ({
+  client: { patch: clientPatch },
+}));
+
+import {
+  ProfileQuickAddProvider,
+  useProfileQuickAdd,
+} from "@/components/profile-quick-add-provider";
+
+// Test consumer: opens the quick-add on mount and records the onCreated name.
+const onCreated = mock((_name: string) => {});
+function Opener({ profileOrder }: { profileOrder: string[] }) {
+  const { openProfileQuickAdd } = useProfileQuickAdd();
+  useEffect(() => {
+    openProfileQuickAdd({ existingNames: profileOrder, profileOrder, onCreated });
+  }, [openProfileQuickAdd, profileOrder]);
+  return null;
+}
+
+function renderProvider(profileOrder: string[]) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      createElement(ProfileQuickAddProvider, null, createElement(Opener, { profileOrder })),
+    ),
+  );
+}
+
+beforeEach(() => {
+  toastSuccess.mockClear();
+  onCreated.mockClear();
+  clientPatch.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ProfileQuickAddProvider", () => {
+  test("opens the create modal when openProfileQuickAdd is called", async () => {
+    renderProvider(["smart"]);
+    await waitFor(() => {
+      expect(screen.getByTestId("modal-save-btn")).toBeTruthy();
+    });
+  });
+
+  test("persisting a create writes the config PATCH, fires onCreated, and toasts", async () => {
+    renderProvider(["smart"]);
+    await waitFor(() => screen.getByTestId("modal-save-btn"));
+    fireEvent.click(screen.getByTestId("modal-save-btn"));
+
+    // Persists via the daemon config PATCH with the appended profileOrder.
+    await waitFor(() => {
+      expect(clientPatch).toHaveBeenCalledTimes(1);
+    });
+    const patchBody = (clientPatch.mock.calls[0]![0] as { body: { llm: Record<string, unknown> } }).body.llm;
+    expect((patchBody.profiles as Record<string, unknown>)[NEW_PROFILE_NAME]).toBeTruthy();
+    expect(patchBody.profileOrder).toEqual(["smart", NEW_PROFILE_NAME]);
+
+    // Hands the new name back to the caller.
+    await waitFor(() => {
+      expect(onCreated).toHaveBeenCalledWith(NEW_PROFILE_NAME);
+    });
+
+    // Surfaces the success toast and closes the modal.
+    await waitFor(() => {
+      expect(toastSuccess).toHaveBeenCalledWith(`Profile "${NEW_PROFILE_NAME}" created`);
+    });
+    expect(screen.queryByTestId("modal-save-btn")).toBeNull();
+  });
+});

--- a/apps/web/src/components/profile-quick-add-provider.test.tsx
+++ b/apps/web/src/components/profile-quick-add-provider.test.tsx
@@ -185,9 +185,10 @@ describe("ProfileQuickAddProvider", () => {
     expect(patchBody.profileOrder).toEqual(["smart", "creative", NEW_PROFILE_NAME]);
   });
 
-  test("the save path dedupes against fresh server state — no profileOrder reset when the name already exists on the server", async () => {
-    // The new name already exists on the server (in the map). The PATCH must
-    // omit profileOrder entirely rather than re-appending or resetting it.
+  test("the save path ABORTS when the name already exists on fresh server state — never overwrites an existing profile", async () => {
+    // The new name already exists on the server (in the map), e.g. created by
+    // another client while the modal was open. A create must NOT deep-merge over
+    // it (config PATCHes merge profile entries) — it must abort with no PATCH.
     clientGet.mockImplementationOnce(async () => ({
       data: {
         llm: {
@@ -201,13 +202,15 @@ describe("ProfileQuickAddProvider", () => {
     await waitFor(() => screen.getByTestId("modal-save-btn"));
     fireEvent.click(screen.getByTestId("modal-save-btn"));
 
+    // The reload ran, but the duplicate is rejected: no PATCH, no success, and
+    // the modal stays open so the inline error is visible.
     await waitFor(() => {
-      expect(clientPatch).toHaveBeenCalledTimes(1);
+      expect(clientGet).toHaveBeenCalledTimes(1);
     });
-    const patchBody = (clientPatch.mock.calls[0]![0] as { body: { llm: Record<string, unknown> } }).body.llm;
-    expect("profileOrder" in patchBody).toBe(false);
-    // The profile entry is still written (the create/overwrite of llm.profiles).
-    expect((patchBody.profiles as Record<string, unknown>)[NEW_PROFILE_NAME]).toBeTruthy();
+    expect(clientPatch).not.toHaveBeenCalled();
+    expect(toastSuccess).not.toHaveBeenCalled();
+    expect(onCreated).not.toHaveBeenCalled();
+    expect(screen.getByTestId("modal-save-btn")).toBeTruthy();
   });
 
   test("a failed config reload ABORTS the save — no PATCH, no success toast, modal stays open", async () => {

--- a/apps/web/src/components/profile-quick-add-provider.test.tsx
+++ b/apps/web/src/components/profile-quick-add-provider.test.tsx
@@ -49,7 +49,11 @@ mock.module("@/domains/settings/ai/profile-editor-modal", () => ({
           "button",
           {
             "data-testid": "modal-save-btn",
-            onClick: () => void onSave(NEW_PROFILE_NAME, { label: "Fast & Cheap" }),
+            // Mirror the real modal: it awaits onSave inside try/catch and stays
+            // open (showing saveError) on rejection. Swallow here so a failing
+            // save surfaces via assertions, not an unhandled rejection.
+            onClick: () =>
+              void onSave(NEW_PROFILE_NAME, { label: "Fast & Cheap" }).catch(() => {}),
           },
           "Save",
         )
@@ -204,5 +208,27 @@ describe("ProfileQuickAddProvider", () => {
     expect("profileOrder" in patchBody).toBe(false);
     // The profile entry is still written (the create/overwrite of llm.profiles).
     expect((patchBody.profiles as Record<string, unknown>)[NEW_PROFILE_NAME]).toBeTruthy();
+  });
+
+  test("a failed config reload ABORTS the save — no PATCH, no success toast, modal stays open", async () => {
+    // The fresh config read fails (throwOnError: true rejects). The save must
+    // abort rather than fall back to empty server state and reset profileOrder.
+    clientGet.mockImplementationOnce(async () => {
+      throw new Error("config read failed");
+    });
+
+    renderProvider(["smart"]);
+    await waitFor(() => screen.getByTestId("modal-save-btn"));
+    fireEvent.click(screen.getByTestId("modal-save-btn"));
+
+    // The reload was attempted, but the PATCH never runs and nothing is reported
+    // as a success; the modal remains open so the inline error is visible.
+    await waitFor(() => {
+      expect(clientGet).toHaveBeenCalledTimes(1);
+    });
+    expect(clientPatch).not.toHaveBeenCalled();
+    expect(toastSuccess).not.toHaveBeenCalled();
+    expect(onCreated).not.toHaveBeenCalled();
+    expect(screen.getByTestId("modal-save-btn")).toBeTruthy();
   });
 });

--- a/apps/web/src/components/profile-quick-add-provider.tsx
+++ b/apps/web/src/components/profile-quick-add-provider.tsx
@@ -1,0 +1,177 @@
+/**
+ * App-level controller for the profile quick-add ("+ New Profile") flow.
+ *
+ * Chat's `ComposerSettingsMenu` must not import from `@/domains/settings/...`
+ * (enforced by `local/no-cross-domain-imports`). This provider lifts the
+ * settings-owned `ProfileEditorModal` create flow up to the top level, where
+ * importing settings is allowed, and exposes an imperative opener via the
+ * `useProfileQuickAdd()` hook. The composer calls `openProfileQuickAdd({...})`
+ * and receives the newly-created profile name back through an `onCreated`
+ * callback so it can run its existing autoselect logic in chat context.
+ *
+ * The controller owns everything settings-specific the composer previously
+ * inlined: the `ProfileEditorModal` render (create mode), the provider-
+ * connections query that feeds its Provider picker, the existing-name list,
+ * the feature-flag props, the create-persistence config PATCH (byte-identical
+ * to `ManageProfilesModal`'s create path), and the success toast.
+ *
+ * `assistantId` and feature flags are read from top-level stores rather than
+ * threaded through props, so the provider stays decoupled from any one domain.
+ */
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { toast } from "@vellum/design-library/components/toast";
+import { client } from "@/generated/api/client.gen";
+import { inferenceProviderconnectionsGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
+import { ProfileEditorModal } from "@/domains/settings/ai/profile-editor-modal";
+import { filterFlaggedConnections } from "@/domains/settings/ai/provider-connections-client";
+import type { ProfileEntry } from "@/domains/settings/ai/ai-types";
+import { useAssistantSelectionStore } from "@/assistant/selection-store";
+import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
+
+interface OpenProfileQuickAddArgs {
+  /** Names already present so the modal can reject duplicates. */
+  existingNames?: string[];
+  /**
+   * Current picker order. The new profile is appended to this in the create
+   * PATCH so the daemon records its position — kept distinct from
+   * `existingNames` (which also includes map-only entries) to preserve the
+   * exact `profileOrder` the picker renders.
+   */
+  profileOrder?: string[];
+  /**
+   * Invoked with the new profile name after the create persists. The caller
+   * runs its own follow-up (e.g. autoselecting the profile for the thread).
+   */
+  onCreated?: (newProfileName: string) => void;
+}
+
+interface ProfileQuickAddContextValue {
+  openProfileQuickAdd: (args?: OpenProfileQuickAddArgs) => void;
+}
+
+const ProfileQuickAddContext = createContext<ProfileQuickAddContextValue | null>(
+  null,
+);
+
+export function ProfileQuickAddProvider({ children }: { children: ReactNode }) {
+  const assistantId = useAssistantSelectionStore.use.activeAssistantId();
+  const openAICompatibleEndpoints =
+    useAssistantFeatureFlagStore.use.openAICompatibleEndpoints();
+  const chatgptSubscriptionAuth =
+    useAssistantFeatureFlagStore.use.chatgptSubscriptionAuth();
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [existingNames, setExistingNames] = useState<string[]>([]);
+  const [profileOrder, setProfileOrder] = useState<string[]>([]);
+  // Held in a ref so the modal's onSave closure always sees the latest caller
+  // callback without re-creating handlers on every open.
+  const onCreatedRef = useRef<((newProfileName: string) => void) | undefined>(
+    undefined,
+  );
+
+  const openProfileQuickAdd = useCallback((args?: OpenProfileQuickAddArgs) => {
+    setExistingNames(args?.existingNames ?? []);
+    setProfileOrder(args?.profileOrder ?? []);
+    onCreatedRef.current = args?.onCreated;
+    setIsOpen(true);
+  }, []);
+
+  // Provider connections feed the modal's Provider picker. Gated on `isOpen`
+  // (and a known assistant) so the query doesn't fire until the user actually
+  // starts creating a profile.
+  const { data: connectionsData } = useQuery({
+    ...inferenceProviderconnectionsGetOptions({
+      path: { assistant_id: assistantId ?? "" },
+    }),
+    enabled: isOpen && !!assistantId,
+  });
+  const connections = useMemo(
+    () =>
+      connectionsData
+        ? filterFlaggedConnections(
+            connectionsData.connections,
+            openAICompatibleEndpoints,
+          )
+        : undefined,
+    [connectionsData, openAICompatibleEndpoints],
+  );
+
+  // Persist a freshly-created profile, then hand the name back to the caller.
+  // Mirrors ManageProfilesModal's create path: write `llm.profiles[name]` plus
+  // an appended `profileOrder` in a single config PATCH so the daemon records
+  // both the entry and its picker position.
+  const handleSave = useCallback(
+    async (name: string, entry: ProfileEntry) => {
+      if (!assistantId) return;
+      const profileOrderPatch = profileOrder.includes(name)
+        ? undefined
+        : [...profileOrder, name];
+      await client.patch({
+        url: `/v1/assistants/{assistant_id}/config`,
+        path: { assistant_id: assistantId },
+        body: {
+          llm: {
+            profiles: { [name]: entry },
+            ...(profileOrderPatch ? { profileOrder: profileOrderPatch } : {}),
+          },
+        },
+        headers: { "Content-Type": "application/json" },
+        throwOnError: true,
+      });
+      onCreatedRef.current?.(name);
+      setIsOpen(false);
+      toast.success(`Profile "${name}" created`);
+    },
+    [assistantId, profileOrder],
+  );
+
+  const value = useMemo<ProfileQuickAddContextValue>(
+    () => ({ openProfileQuickAdd }),
+    [openProfileQuickAdd],
+  );
+
+  return (
+    <ProfileQuickAddContext.Provider value={value}>
+      {children}
+      {assistantId ? (
+        <ProfileEditorModal
+          isOpen={isOpen}
+          mode="create"
+          existingNames={existingNames}
+          connections={connections}
+          openAICompatibleEndpointsEnabled={openAICompatibleEndpoints}
+          assistantId={assistantId}
+          chatgptSubscriptionEnabled={chatgptSubscriptionAuth}
+          onSave={handleSave}
+          onCancel={() => setIsOpen(false)}
+        />
+      ) : null}
+    </ProfileQuickAddContext.Provider>
+  );
+}
+
+/**
+ * Imperative opener for the profile quick-add modal. Throws if used outside
+ * `ProfileQuickAddProvider` so a missing provider fails loudly rather than
+ * silently no-op'ing.
+ */
+export function useProfileQuickAdd(): ProfileQuickAddContextValue {
+  const ctx = useContext(ProfileQuickAddContext);
+  if (!ctx) {
+    throw new Error(
+      "useProfileQuickAdd() called outside <ProfileQuickAddProvider>. " +
+        "Mount the consumer under the provider (composed in AppProviders).",
+    );
+  }
+  return ctx;
+}

--- a/apps/web/src/components/profile-quick-add-provider.tsx
+++ b/apps/web/src/components/profile-quick-add-provider.tsx
@@ -39,15 +39,13 @@ import { useAssistantSelectionStore } from "@/assistant/selection-store";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 
 interface OpenProfileQuickAddArgs {
-  /** Names already present so the modal can reject duplicates. */
-  existingNames?: string[];
   /**
-   * Current picker order. The new profile is appended to this in the create
-   * PATCH so the daemon records its position — kept distinct from
-   * `existingNames` (which also includes map-only entries) to preserve the
-   * exact `profileOrder` the picker renders.
+   * Names already present, used only for the modal's immediate client-side
+   * duplicate-name feedback. The authoritative dedupe + `profileOrder` append
+   * happens at save time from a fresh server config fetch (see `handleSave`),
+   * so this list is a UX nicety, not a correctness dependency.
    */
-  profileOrder?: string[];
+  existingNames?: string[];
   /**
    * Invoked with the new profile name after the create persists. The caller
    * runs its own follow-up (e.g. autoselecting the profile for the thread).
@@ -72,7 +70,6 @@ export function ProfileQuickAddProvider({ children }: { children: ReactNode }) {
 
   const [isOpen, setIsOpen] = useState(false);
   const [existingNames, setExistingNames] = useState<string[]>([]);
-  const [profileOrder, setProfileOrder] = useState<string[]>([]);
   // Held in a ref so the modal's onSave closure always sees the latest caller
   // callback without re-creating handlers on every open.
   const onCreatedRef = useRef<((newProfileName: string) => void) | undefined>(
@@ -81,7 +78,6 @@ export function ProfileQuickAddProvider({ children }: { children: ReactNode }) {
 
   const openProfileQuickAdd = useCallback((args?: OpenProfileQuickAddArgs) => {
     setExistingNames(args?.existingNames ?? []);
-    setProfileOrder(args?.profileOrder ?? []);
     onCreatedRef.current = args?.onCreated;
     setIsOpen(true);
   }, []);
@@ -110,12 +106,36 @@ export function ProfileQuickAddProvider({ children }: { children: ReactNode }) {
   // Mirrors ManageProfilesModal's create path: write `llm.profiles[name]` plus
   // an appended `profileOrder` in a single config PATCH so the daemon records
   // both the entry and its picker position.
+  //
+  // The order is computed from a FRESH server fetch rather than the
+  // `profileOrder` captured when the modal opened. The caller may have opened
+  // the quick-add before its own config fetch settled (passing an empty
+  // order); trusting that would reset the persisted `profileOrder` to just the
+  // new name, dropping every existing profile's position. Reading the latest
+  // config here keeps the append authoritative regardless of stale inputs.
   const handleSave = useCallback(
     async (name: string, entry: ProfileEntry) => {
       if (!assistantId) return;
-      const profileOrderPatch = profileOrder.includes(name)
+
+      const configResult = await client.get<Record<string, unknown>, unknown>({
+        url: `/v1/assistants/{assistant_id}/config`,
+        path: { assistant_id: assistantId },
+        throwOnError: false,
+      });
+      const llm =
+        (configResult.data as { llm?: Record<string, unknown> } | undefined)
+          ?.llm ?? {};
+      const serverOrder = (llm.profileOrder as string[] | undefined) ?? [];
+      const serverProfiles =
+        (llm.profiles as Record<string, unknown> | undefined) ?? {};
+      // Dedupe against the union of order + map entries (an entry can exist in
+      // the map without being in the order), then append only if absent.
+      const existsOnServer =
+        serverOrder.includes(name) || name in serverProfiles;
+      const profileOrderPatch = existsOnServer
         ? undefined
-        : [...profileOrder, name];
+        : [...serverOrder, name];
+
       await client.patch({
         url: `/v1/assistants/{assistant_id}/config`,
         path: { assistant_id: assistantId },
@@ -132,7 +152,7 @@ export function ProfileQuickAddProvider({ children }: { children: ReactNode }) {
       setIsOpen(false);
       toast.success(`Profile "${name}" created`);
     },
-    [assistantId, profileOrder],
+    [assistantId],
   );
 
   const value = useMemo<ProfileQuickAddContextValue>(

--- a/apps/web/src/components/profile-quick-add-provider.tsx
+++ b/apps/web/src/components/profile-quick-add-provider.tsx
@@ -134,13 +134,18 @@ export function ProfileQuickAddProvider({ children }: { children: ReactNode }) {
       const serverOrder = (llm.profileOrder as string[] | undefined) ?? [];
       const serverProfiles =
         (llm.profiles as Record<string, unknown> | undefined) ?? {};
-      // Dedupe against the union of order + map entries (an entry can exist in
-      // the map without being in the order), then append only if absent.
+      // Abort if the name already exists on the server (union of order + map —
+      // an entry can exist in the map without being in the order). This is a
+      // create flow, and config PATCHes deep-merge profile entries, so writing
+      // `profiles[name]` for an existing key would silently overwrite that
+      // profile's provider/model rather than reporting the duplicate. Throwing
+      // surfaces the error in the modal and leaves the existing profile intact.
+      // (The modal also dedupes client-side; this guards races and stale state.)
       const existsOnServer =
         serverOrder.includes(name) || name in serverProfiles;
-      const profileOrderPatch = existsOnServer
-        ? undefined
-        : [...serverOrder, name];
+      if (existsOnServer) {
+        throw new Error(`A profile with the key "${name}" already exists.`);
+      }
 
       await client.patch({
         url: `/v1/assistants/{assistant_id}/config`,
@@ -148,7 +153,7 @@ export function ProfileQuickAddProvider({ children }: { children: ReactNode }) {
         body: {
           llm: {
             profiles: { [name]: entry },
-            ...(profileOrderPatch ? { profileOrder: profileOrderPatch } : {}),
+            profileOrder: [...serverOrder, name],
           },
         },
         headers: { "Content-Type": "application/json" },

--- a/apps/web/src/components/profile-quick-add-provider.tsx
+++ b/apps/web/src/components/profile-quick-add-provider.tsx
@@ -117,10 +117,16 @@ export function ProfileQuickAddProvider({ children }: { children: ReactNode }) {
     async (name: string, entry: ProfileEntry) => {
       if (!assistantId) return;
 
-      const configResult = await client.get<Record<string, unknown>, unknown>({
+      // throwOnError: true so a failed reload ABORTS the save. With a swallowed
+      // error the empty fallbacks below would treat the server config as empty
+      // and the PATCH would reset `profileOrder` (and could overwrite an
+      // existing key) on a merely transient read failure. Letting it throw
+      // propagates to the modal's save handler, which surfaces the error inline
+      // and keeps the modal open — no PATCH, no success toast.
+      const configResult = await client.get<Record<string, unknown>, unknown, true>({
         url: `/v1/assistants/{assistant_id}/config`,
         path: { assistant_id: assistantId },
-        throwOnError: false,
+        throwOnError: true,
       });
       const llm =
         (configResult.data as { llm?: Record<string, unknown> } | undefined)

--- a/apps/web/src/components/providers.tsx
+++ b/apps/web/src/components/providers.tsx
@@ -16,6 +16,7 @@ import { useState, type ReactNode } from "react";
 
 import { useAuthStore } from "@/stores/auth-store";
 import { useOrganizationStore } from "@/stores/organization-store";
+import { ProfileQuickAddProvider } from "@/components/profile-quick-add-provider";
 
 function createQueryClient(): QueryClient {
   return new QueryClient({
@@ -64,7 +65,7 @@ function ScopeKeyedQueryClientProvider({
 
   return (
     <RequestScopedQueryClientProvider key={scopeKey}>
-      {children}
+      <ProfileQuickAddProvider>{children}</ProfileQuickAddProvider>
     </RequestScopedQueryClientProvider>
   );
 }

--- a/apps/web/src/domains/chat/components/composer-settings-menu.test.tsx
+++ b/apps/web/src/domains/chat/components/composer-settings-menu.test.tsx
@@ -3,16 +3,17 @@
  *
  * Mounted with `@testing-library/react` (happy-dom — see
  * `apps/web/test-setup.ts`). The real Radix `Menu`/`BottomSheet` only mount
- * their content when open, and the real `ProfileEditorModal` pulls in the
- * provider/model catalog plus its own queries — so we mock both:
- *   - `@vellum/design-library` surfaces render inline so popover/sheet content
- *     is always in the DOM and clickable.
- *   - `ProfileEditorModal` is a lightweight stub that renders a
- *     `data-testid="modal-save-btn"` calling `onSave` with a fixed entry,
- *     letting us assert the create → autoselect → toast flow.
+ * their content when open, so we mock `@vellum/design-library` surfaces to
+ * render inline (popover/sheet content is always in the DOM and clickable).
  *
- * We also stub the generated daemon/api SDK so the menu's mount-time config
- * fetch and the quick-add config PATCH / per-thread profile PUT are observable.
+ * The quick-add modal now lives in the top-level `ProfileQuickAddProvider`
+ * (chat must not import settings — see `local/no-cross-domain-imports`). The
+ * composer only consumes `useProfileQuickAdd()`, so we mock that hook: clicking
+ * "+" must close the popover and call `openProfileQuickAdd`, and simulating the
+ * provider's `onCreated(name)` callback must run the composer's autoselect.
+ *
+ * We stub the generated daemon/api SDK so the menu's mount-time config fetch
+ * and the autoselect per-thread profile PUT are observable.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -47,10 +48,17 @@ mock.module("@/lib/threshold-api", () => ({
   setGlobalThresholds: async () => {},
 }));
 
-// --- toast -------------------------------------------------------------------
-const toastSuccess = mock((_msg: string) => {});
-mock.module("@vellum/design-library/components/toast", () => ({
-  toast: { success: toastSuccess, error: () => {} },
+// --- profile quick-add controller (top-level) --------------------------------
+// Capture the args passed to openProfileQuickAdd so tests can assert the "+"
+// wiring and simulate the provider's onCreated callback firing.
+type QuickAddArgs = {
+  existingNames?: string[];
+  profileOrder?: string[];
+  onCreated?: (name: string) => void;
+};
+const openProfileQuickAdd = mock((_args?: QuickAddArgs) => {});
+mock.module("@/components/profile-quick-add-provider", () => ({
+  useProfileQuickAdd: () => ({ openProfileQuickAdd }),
 }));
 
 // --- design-library surfaces (render content inline) -------------------------
@@ -98,34 +106,7 @@ mock.module("@vellum/design-library", () => {
   };
 });
 
-// --- ProfileEditorModal stub -------------------------------------------------
-// Renders a Save button that invokes onSave with a deterministic entry so the
-// test drives the create flow without the real provider-first form.
 const NEW_PROFILE_NAME = "fast-cheap";
-mock.module("@/domains/settings/ai/profile-editor-modal", () => ({
-  ProfileEditorModal: ({ isOpen, onSave }: { isOpen: boolean; onSave: (n: string, e: unknown) => Promise<void> }) =>
-    isOpen
-      ? createElement(
-          "button",
-          {
-            "data-testid": "modal-save-btn",
-            onClick: () => void onSave(NEW_PROFILE_NAME, { label: "Fast & Cheap" }),
-          },
-          "Save",
-        )
-      : null,
-}));
-
-mock.module("@/domains/settings/ai/provider-connections-client", () => ({
-  filterFlaggedConnections: (c: unknown) => c,
-}));
-
-mock.module("@/generated/daemon/@tanstack/react-query.gen", () => ({
-  inferenceProviderconnectionsGetOptions: () => ({
-    queryKey: [{ _id: "inferenceProviderconnectionsGet" }],
-    queryFn: async () => ({ connections: [] }),
-  }),
-}));
 
 // --- generated SDK -----------------------------------------------------------
 // Mocks are loosely typed (`unknown` args, structural returns) so per-test
@@ -174,7 +155,7 @@ function renderMenu() {
 
 beforeEach(() => {
   isMobileRef.value = false;
-  toastSuccess.mockClear();
+  openProfileQuickAdd.mockClear();
   inferenceprofilePut.mockClear();
   clientPatch.mockClear();
 });
@@ -212,30 +193,36 @@ describe("Model Profile quick-add", () => {
     expect(document.body.textContent).toContain("Model Profile");
   });
 
-  test("clicking + closes the popover and opens the create modal", async () => {
+  test("clicking + closes the popover and opens the quick-add controller", async () => {
     renderMenu();
     await waitFor(() => screen.getByLabelText("New Profile"));
 
-    expect(screen.queryByTestId("modal-save-btn")).toBeNull();
     fireEvent.click(screen.getByLabelText("New Profile"));
-    expect(screen.getByTestId("modal-save-btn")).toBeTruthy();
+
+    // Delegates to the top-level controller with the current profile names.
+    await waitFor(() => {
+      expect(openProfileQuickAdd).toHaveBeenCalledTimes(1);
+    });
+    const args = openProfileQuickAdd.mock.calls[0]![0]!;
+    expect(args.existingNames).toEqual(["smart"]);
+    expect(args.profileOrder).toEqual(["smart"]);
+    expect(typeof args.onCreated).toBe("function");
   });
 
-  test("completing a create autoselects the new profile and toasts", async () => {
+  test("the onCreated callback autoselects the new profile for the thread", async () => {
     renderMenu();
     await waitFor(() => screen.getByLabelText("New Profile"));
     fireEvent.click(screen.getByLabelText("New Profile"));
-    fireEvent.click(screen.getByTestId("modal-save-btn"));
 
-    // Persists the profile via the daemon config PATCH.
     await waitFor(() => {
-      expect(clientPatch).toHaveBeenCalledTimes(1);
+      expect(openProfileQuickAdd).toHaveBeenCalledTimes(1);
     });
-    const patchBody = (clientPatch.mock.calls[0]![0] as { body: { llm: Record<string, unknown> } }).body.llm;
-    expect((patchBody.profiles as Record<string, unknown>)[NEW_PROFILE_NAME]).toBeTruthy();
-    expect(patchBody.profileOrder).toEqual(["smart", NEW_PROFILE_NAME]);
 
-    // Autoselects the new profile as the per-thread override.
+    // Simulate the provider persisting a profile and invoking onCreated — the
+    // composer must run handleProfileSelect (per-thread override PUT).
+    const onCreated = openProfileQuickAdd.mock.calls[0]![0]!.onCreated!;
+    onCreated(NEW_PROFILE_NAME);
+
     await waitFor(() => {
       expect(inferenceprofilePut).toHaveBeenCalledTimes(1);
     });
@@ -243,13 +230,9 @@ describe("Model Profile quick-add", () => {
       (inferenceprofilePut.mock.calls[0]![0] as { body: { profile: string } }).body.profile,
     ).toBe(NEW_PROFILE_NAME);
 
-    // Surfaces the success toast and closes the modal.
+    // The new profile is now reflected locally and renders in the picker.
     await waitFor(() => {
-      expect(toastSuccess).toHaveBeenCalledWith(`Profile "${NEW_PROFILE_NAME}" created`);
+      expect(document.body.textContent).toContain(NEW_PROFILE_NAME);
     });
-    expect(screen.queryByTestId("modal-save-btn")).toBeNull();
-
-    // The new profile now renders as active/checked in the picker.
-    expect(document.body.textContent).toContain("Fast & Cheap");
   });
 });

--- a/apps/web/src/domains/chat/components/composer-settings-menu.test.tsx
+++ b/apps/web/src/domains/chat/components/composer-settings-menu.test.tsx
@@ -28,6 +28,13 @@ mock.module("@/hooks/use-is-mobile", () => ({
   MOBILE_MEDIA_QUERY: "(max-width: 767px)",
 }));
 
+// --- toast -------------------------------------------------------------------
+const toastSuccess = mock((_msg: string) => {});
+const toastError = mock((_msg: string) => {});
+mock.module("@vellum/design-library/components/toast", () => ({
+  toast: { success: toastSuccess, error: toastError },
+}));
+
 // --- feature flag store ------------------------------------------------------
 mock.module("@/stores/assistant-feature-flag-store", () => {
   const store = () => null;
@@ -53,7 +60,6 @@ mock.module("@/lib/threshold-api", () => ({
 // wiring and simulate the provider's onCreated callback firing.
 type QuickAddArgs = {
   existingNames?: string[];
-  profileOrder?: string[];
   onCreated?: (name: string) => void;
 };
 const openProfileQuickAdd = mock((_args?: QuickAddArgs) => {});
@@ -158,6 +164,9 @@ beforeEach(() => {
   openProfileQuickAdd.mockClear();
   inferenceprofilePut.mockClear();
   clientPatch.mockClear();
+  clientGet.mockClear();
+  toastSuccess.mockClear();
+  toastError.mockClear();
 });
 
 afterEach(() => {
@@ -205,7 +214,6 @@ describe("Model Profile quick-add", () => {
     });
     const args = openProfileQuickAdd.mock.calls[0]![0]!;
     expect(args.existingNames).toEqual(["smart"]);
-    expect(args.profileOrder).toEqual(["smart"]);
     expect(typeof args.onCreated).toBe("function");
   });
 
@@ -233,6 +241,56 @@ describe("Model Profile quick-add", () => {
     // The new profile is now reflected locally and renders in the picker.
     await waitFor(() => {
       expect(document.body.textContent).toContain(NEW_PROFILE_NAME);
+    });
+  });
+
+  test('"+" is disabled until the profile config fetch settles', async () => {
+    // Config never resolves — the "+" must stay disabled (opening the modal
+    // with the empty initial profileOrder/profileMap would let a duplicate
+    // overwrite a profile and reset the persisted order).
+    clientGet.mockImplementationOnce(() => new Promise(() => {}));
+    renderMenu();
+
+    await waitFor(() => screen.getByLabelText("New Profile"));
+    const plus = screen.getByLabelText("New Profile") as HTMLButtonElement;
+    expect(plus.disabled).toBe(true);
+    expect(plus.getAttribute("aria-disabled")).toBe("true");
+
+    // A click while disabled must NOT open the quick-add controller.
+    fireEvent.click(plus);
+    expect(openProfileQuickAdd).not.toHaveBeenCalled();
+  });
+
+  test('"+" enables once the config fetch settles', async () => {
+    renderMenu();
+    await waitFor(() => {
+      const plus = screen.getByLabelText("New Profile") as HTMLButtonElement;
+      expect(plus.disabled).toBe(false);
+    });
+  });
+
+  test("a failed autoselect surfaces an error toast (without claiming creation failed)", async () => {
+    // The per-thread profile PUT fails — the new profile was created but could
+    // not be switched to. The flow must surface that instead of silently
+    // reporting success.
+    inferenceprofilePut.mockImplementationOnce(async () => {
+      throw new Error("network");
+    });
+
+    renderMenu();
+    await waitFor(() => screen.getByLabelText("New Profile"));
+    fireEvent.click(screen.getByLabelText("New Profile"));
+
+    await waitFor(() => {
+      expect(openProfileQuickAdd).toHaveBeenCalledTimes(1);
+    });
+    const onCreated = openProfileQuickAdd.mock.calls[0]![0]!.onCreated!;
+    onCreated(NEW_PROFILE_NAME);
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith(
+        "Profile created, but couldn't switch to it",
+      );
     });
   });
 });

--- a/apps/web/src/domains/chat/components/composer-settings-menu.test.tsx
+++ b/apps/web/src/domains/chat/components/composer-settings-menu.test.tsx
@@ -1,0 +1,255 @@
+/**
+ * Tests for the composer Model Profile quick-add "+".
+ *
+ * Mounted with `@testing-library/react` (happy-dom — see
+ * `apps/web/test-setup.ts`). The real Radix `Menu`/`BottomSheet` only mount
+ * their content when open, and the real `ProfileEditorModal` pulls in the
+ * provider/model catalog plus its own queries — so we mock both:
+ *   - `@vellum/design-library` surfaces render inline so popover/sheet content
+ *     is always in the DOM and clickable.
+ *   - `ProfileEditorModal` is a lightweight stub that renders a
+ *     `data-testid="modal-save-btn"` calling `onSave` with a fixed entry,
+ *     letting us assert the create → autoselect → toast flow.
+ *
+ * We also stub the generated daemon/api SDK so the menu's mount-time config
+ * fetch and the quick-add config PATCH / per-thread profile PUT are observable.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { createElement, type ReactNode } from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+// --- use-is-mobile -----------------------------------------------------------
+const isMobileRef = { value: false };
+mock.module("@/hooks/use-is-mobile", () => ({
+  useIsMobile: () => isMobileRef.value,
+  MOBILE_MEDIA_QUERY: "(max-width: 767px)",
+}));
+
+// --- feature flag store ------------------------------------------------------
+mock.module("@/stores/assistant-feature-flag-store", () => {
+  const store = () => null;
+  store.use = {
+    queryComplexityRouting: () => false,
+    openAICompatibleEndpoints: () => false,
+    chatgptSubscriptionAuth: () => false,
+  };
+  return { useAssistantFeatureFlagStore: store };
+});
+
+// --- threshold-api (mount-time access-level fetches) -------------------------
+mock.module("@/lib/threshold-api", () => ({
+  getGlobalThresholds: async () => ({ interactive: 50 }),
+  getConversationOverride: async () => null,
+  setConversationOverride: async () => {},
+  deleteConversationOverride: async () => {},
+  setGlobalThresholds: async () => {},
+}));
+
+// --- toast -------------------------------------------------------------------
+const toastSuccess = mock((_msg: string) => {});
+mock.module("@vellum/design-library/components/toast", () => ({
+  toast: { success: toastSuccess, error: () => {} },
+}));
+
+// --- design-library surfaces (render content inline) -------------------------
+const passthrough = ({ children, ...props }: Record<string, unknown>) =>
+  createElement("div", props, children as ReactNode);
+mock.module("@vellum/design-library", () => {
+  const MenuMock = {
+    Root: passthrough,
+    Trigger: passthrough,
+    Content: passthrough,
+    Item: ({ children, onSelect, leftIcon, ...rest }: Record<string, unknown>) =>
+      createElement(
+        "button",
+        {
+          "data-testid": "menu-item",
+          onClick: onSelect as (() => void) | undefined,
+          ...rest,
+        },
+        leftIcon as ReactNode,
+        children as ReactNode,
+      ),
+    Label: passthrough,
+    Separator: () => createElement("hr"),
+  };
+  const BottomSheetMock = {
+    Root: passthrough,
+    Trigger: passthrough,
+    Content: passthrough,
+    Header: passthrough,
+    Title: passthrough,
+    Body: passthrough,
+  };
+  return {
+    Menu: MenuMock,
+    BottomSheet: BottomSheetMock,
+    Button: ({ onClick, "aria-label": ariaLabel, iconOnly: _i, ...rest }: Record<string, unknown>) =>
+      createElement("button", { onClick, "aria-label": ariaLabel, ...rest }),
+    PanelItem: ({ label, onSelect, ...rest }: Record<string, unknown>) =>
+      createElement(
+        "button",
+        { "data-testid": "panel-item", onClick: onSelect as (() => void) | undefined, ...rest },
+        label as ReactNode,
+      ),
+    Tooltip: ({ children }: Record<string, unknown>) => children as ReactNode,
+  };
+});
+
+// --- ProfileEditorModal stub -------------------------------------------------
+// Renders a Save button that invokes onSave with a deterministic entry so the
+// test drives the create flow without the real provider-first form.
+const NEW_PROFILE_NAME = "fast-cheap";
+mock.module("@/domains/settings/ai/profile-editor-modal", () => ({
+  ProfileEditorModal: ({ isOpen, onSave }: { isOpen: boolean; onSave: (n: string, e: unknown) => Promise<void> }) =>
+    isOpen
+      ? createElement(
+          "button",
+          {
+            "data-testid": "modal-save-btn",
+            onClick: () => void onSave(NEW_PROFILE_NAME, { label: "Fast & Cheap" }),
+          },
+          "Save",
+        )
+      : null,
+}));
+
+mock.module("@/domains/settings/ai/provider-connections-client", () => ({
+  filterFlaggedConnections: (c: unknown) => c,
+}));
+
+mock.module("@/generated/daemon/@tanstack/react-query.gen", () => ({
+  inferenceProviderconnectionsGetOptions: () => ({
+    queryKey: [{ _id: "inferenceProviderconnectionsGet" }],
+    queryFn: async () => ({ connections: [] }),
+  }),
+}));
+
+// --- generated SDK -----------------------------------------------------------
+// Mocks are loosely typed (`unknown` args, structural returns) so per-test
+// overrides and `.mock.calls` indexing don't fight the generated SDK types.
+const inferenceprofilePut = mock(
+  async (_opts: unknown): Promise<{ data: unknown }> => ({ data: {} }),
+);
+const clientGet = mock(
+  // One pre-existing profile so the picker renders a list and order.
+  async (_opts: unknown): Promise<{ data: unknown }> => ({
+    data: { llm: { profileOrder: ["smart"], profiles: { smart: { label: "Smart" } }, activeProfile: "smart" } },
+  }),
+);
+const clientPatch = mock(
+  async (_opts: unknown): Promise<{ data: unknown }> => ({ data: {} }),
+);
+
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  conversationsByIdGet: async () => ({
+    data: { conversation: { inferenceProfile: null } },
+  }),
+  conversationsByIdInferenceprofilePut: inferenceprofilePut,
+}));
+
+mock.module("@/generated/api/client.gen", () => ({
+  client: { get: clientGet, patch: clientPatch },
+}));
+
+import { ComposerSettingsMenu } from "@/domains/chat/components/composer-settings-menu";
+
+function renderMenu() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      createElement(ComposerSettingsMenu, {
+        assistantId: "assistant-1",
+        conversationId: "conv-1",
+      }),
+    ),
+  );
+}
+
+beforeEach(() => {
+  isMobileRef.value = false;
+  toastSuccess.mockClear();
+  inferenceprofilePut.mockClear();
+  clientPatch.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Model Profile quick-add", () => {
+  test('"+" New Profile renders on desktop, including with profiles present', async () => {
+    renderMenu();
+    await waitFor(() => {
+      expect(screen.getByLabelText("New Profile")).toBeTruthy();
+    });
+    // Header is present alongside the existing profile.
+    expect(document.body.textContent).toContain("Model Profile");
+  });
+
+  test('"+" New Profile renders on mobile', async () => {
+    isMobileRef.value = true;
+    renderMenu();
+    await waitFor(() => {
+      expect(screen.getByLabelText("New Profile")).toBeTruthy();
+    });
+  });
+
+  test('"+" New Profile renders even with zero profiles', async () => {
+    clientGet.mockImplementationOnce(async () => ({
+      data: { llm: { profileOrder: [], profiles: {}, activeProfile: null } },
+    }));
+    renderMenu();
+    await waitFor(() => {
+      expect(screen.getByLabelText("New Profile")).toBeTruthy();
+    });
+    expect(document.body.textContent).toContain("Model Profile");
+  });
+
+  test("clicking + closes the popover and opens the create modal", async () => {
+    renderMenu();
+    await waitFor(() => screen.getByLabelText("New Profile"));
+
+    expect(screen.queryByTestId("modal-save-btn")).toBeNull();
+    fireEvent.click(screen.getByLabelText("New Profile"));
+    expect(screen.getByTestId("modal-save-btn")).toBeTruthy();
+  });
+
+  test("completing a create autoselects the new profile and toasts", async () => {
+    renderMenu();
+    await waitFor(() => screen.getByLabelText("New Profile"));
+    fireEvent.click(screen.getByLabelText("New Profile"));
+    fireEvent.click(screen.getByTestId("modal-save-btn"));
+
+    // Persists the profile via the daemon config PATCH.
+    await waitFor(() => {
+      expect(clientPatch).toHaveBeenCalledTimes(1);
+    });
+    const patchBody = (clientPatch.mock.calls[0]![0] as { body: { llm: Record<string, unknown> } }).body.llm;
+    expect((patchBody.profiles as Record<string, unknown>)[NEW_PROFILE_NAME]).toBeTruthy();
+    expect(patchBody.profileOrder).toEqual(["smart", NEW_PROFILE_NAME]);
+
+    // Autoselects the new profile as the per-thread override.
+    await waitFor(() => {
+      expect(inferenceprofilePut).toHaveBeenCalledTimes(1);
+    });
+    expect(
+      (inferenceprofilePut.mock.calls[0]![0] as { body: { profile: string } }).body.profile,
+    ).toBe(NEW_PROFILE_NAME);
+
+    // Surfaces the success toast and closes the modal.
+    await waitFor(() => {
+      expect(toastSuccess).toHaveBeenCalledWith(`Profile "${NEW_PROFILE_NAME}" created`);
+    });
+    expect(screen.queryByTestId("modal-save-btn")).toBeNull();
+
+    // The new profile now renders as active/checked in the picker.
+    expect(document.body.textContent).toContain("Fast & Cheap");
+  });
+});

--- a/apps/web/src/domains/chat/components/composer-settings-menu.tsx
+++ b/apps/web/src/domains/chat/components/composer-settings-menu.tsx
@@ -1,17 +1,20 @@
 
-import { Check, Sparkles, SlidersHorizontal } from "lucide-react";
+import { Check, Plus, Sparkles, SlidersHorizontal } from "lucide-react";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from "react";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { BottomSheet } from "@vellum/design-library";
 import { Button } from "@vellum/design-library";
 import { Menu } from "@vellum/design-library";
 import { PanelItem } from "@vellum/design-library";
+import { Tooltip } from "@vellum/design-library";
+import { toast } from "@vellum/design-library/components/toast";
 import { client } from "@/generated/api/client.gen";
 import {
   conversationsByIdGet,
   conversationsByIdInferenceprofilePut,
 } from "@/generated/daemon/sdk.gen";
+import { inferenceProviderconnectionsGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import {
   profilePickerLabel,
@@ -19,6 +22,9 @@ import {
   gateAutoProfile,
   type ProfilePickerEntry,
 } from "@/assistant/profile-pickers";
+import { ProfileEditorModal } from "@/domains/settings/ai/profile-editor-modal";
+import { filterFlaggedConnections } from "@/domains/settings/ai/provider-connections-client";
+import type { ProfileEntry } from "@/domains/settings/ai/ai-types";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import {
   deleteConversationOverride,
@@ -289,6 +295,10 @@ export function ComposerSettingsMenu({ assistantId, conversationId }: Props) {
 
   const queryComplexityRoutingEnabled =
     useAssistantFeatureFlagStore.use.queryComplexityRouting();
+  const openAICompatibleEndpoints =
+    useAssistantFeatureFlagStore.use.openAICompatibleEndpoints();
+  const chatgptSubscriptionAuth =
+    useAssistantFeatureFlagStore.use.chatgptSubscriptionAuth();
 
   const visibleProfileEntries = useMemo(
     () =>
@@ -297,6 +307,98 @@ export function ComposerSettingsMenu({ assistantId, conversationId }: Props) {
         queryComplexityRoutingEnabled,
       ),
     [orderedProfileEntries, profileActiveKey, queryComplexityRoutingEnabled],
+  );
+
+  // Quick-add: open the shared provider-first ProfileEditorModal in create
+  // mode over the chat. Provider connections feed the modal's Provider picker;
+  // the query is gated on `quickAddOpen` so the menu doesn't fetch them until
+  // the user actually starts creating a profile.
+  const [quickAddOpen, setQuickAddOpen] = useState(false);
+  const { data: connectionsData } = useQuery({
+    ...inferenceProviderconnectionsGetOptions({
+      path: { assistant_id: assistantId },
+    }),
+    enabled: quickAddOpen && !!assistantId,
+  });
+  const quickAddConnections = useMemo(
+    () =>
+      connectionsData
+        ? filterFlaggedConnections(connectionsData.connections, openAICompatibleEndpoints)
+        : undefined,
+    [connectionsData, openAICompatibleEndpoints],
+  );
+
+  const existingProfileNames = useMemo(
+    () => Array.from(new Set([...profileOrder, ...Object.keys(profileMap)])),
+    [profileOrder, profileMap],
+  );
+
+  // Persist a freshly-created profile, then autoselect it for this thread.
+  // Mirrors ManageProfilesModal's create path: write `llm.profiles[name]`
+  // plus an appended `profileOrder` in a single config PATCH so the daemon
+  // records both the entry and its picker position. On success we reuse the
+  // existing per-thread selection handler (writes the override + invalidates
+  // the active-model cache) and surface a success toast.
+  const handleQuickAddSave = useCallback(
+    async (name: string, entry: ProfileEntry) => {
+      const profileOrderPatch = profileOrder.includes(name)
+        ? undefined
+        : [...profileOrder, name];
+      await client.patch({
+        url: `/v1/assistants/{assistant_id}/config`,
+        path: { assistant_id: assistantId },
+        body: {
+          llm: {
+            profiles: { [name]: entry },
+            ...(profileOrderPatch ? { profileOrder: profileOrderPatch } : {}),
+          },
+        },
+        headers: { "Content-Type": "application/json" },
+        throwOnError: true,
+      });
+      // Reflect the new profile locally so the picker renders it immediately
+      // (the daemon-config fetch only re-runs on assistant/conversation change).
+      setProfileMap((prev) => ({ ...prev, [name]: { label: entry.label ?? null } }));
+      if (profileOrderPatch) setProfileOrder(profileOrderPatch);
+      // Profiles are guaranteed loaded by now (the menu opened); allow the
+      // autoselect below to write the per-thread override.
+      profilesReadyRef.current = true;
+      await handleProfileSelect(name);
+      setQuickAddOpen(false);
+      toast.success(`Profile "${name}" created`);
+    },
+    [assistantId, profileOrder, handleProfileSelect],
+  );
+
+  // The "+" quick-add affordance rendered in both the desktop Menu.Label and
+  // the mobile SectionLabel. Closes the popover/sheet, then opens the modal.
+  const quickAddButton = (
+    <Tooltip content="New Profile" side="top">
+      <Button
+        variant="ghost"
+        size="compact"
+        iconOnly={<Plus className="h-3.5 w-3.5" />}
+        aria-label="New Profile"
+        onClick={() => {
+          setOpen(false);
+          setQuickAddOpen(true);
+        }}
+      />
+    </Tooltip>
+  );
+
+  const quickAddModal = (
+    <ProfileEditorModal
+      isOpen={quickAddOpen}
+      mode="create"
+      existingNames={existingProfileNames}
+      connections={quickAddConnections}
+      openAICompatibleEndpointsEnabled={openAICompatibleEndpoints}
+      assistantId={assistantId}
+      chatgptSubscriptionEnabled={chatgptSubscriptionAuth}
+      onSave={handleQuickAddSave}
+      onCancel={() => setQuickAddOpen(false)}
+    />
   );
 
   const trigger = (
@@ -310,6 +412,7 @@ export function ComposerSettingsMenu({ assistantId, conversationId }: Props) {
 
   if (isMobile) {
     return (
+      <>
       <BottomSheet.Root open={open} onOpenChange={setOpen}>
         <BottomSheet.Trigger asChild>{trigger}</BottomSheet.Trigger>
         {/* Radix Dialog requires a Title for screen-reader accessibility;
@@ -345,39 +448,40 @@ export function ComposerSettingsMenu({ assistantId, conversationId }: Props) {
                 />
               );
             })}
-            {visibleProfileEntries.length > 0 && (
-              <>
-                <MenuDivider />
-                <SectionLabel>Model Profile</SectionLabel>
-                {visibleProfileEntries.map((entry) => {
-                  const isActive = entry.name === profileActiveKey;
-                  return (
-                    <PanelItem
-                      key={entry.name}
-                      icon={Sparkles}
-                      label={profilePickerLabel(entry)}
-                      active={isActive}
-                      trailingAction={
-                        isActive ? (
-                          <Check className="h-3.5 w-3.5 text-[var(--system-positive-strong)]" />
-                        ) : undefined
-                      }
-                      onSelect={() => {
-                        handleProfileSelect(entry.name);
-                        setOpen(false);
-                      }}
-                    />
-                  );
-                })}
-              </>
-            )}
+            <MenuDivider />
+            <SectionLabel trailingAction={quickAddButton}>
+              Model Profile
+            </SectionLabel>
+            {visibleProfileEntries.map((entry) => {
+              const isActive = entry.name === profileActiveKey;
+              return (
+                <PanelItem
+                  key={entry.name}
+                  icon={Sparkles}
+                  label={profilePickerLabel(entry)}
+                  active={isActive}
+                  trailingAction={
+                    isActive ? (
+                      <Check className="h-3.5 w-3.5 text-[var(--system-positive-strong)]" />
+                    ) : undefined
+                  }
+                  onSelect={() => {
+                    handleProfileSelect(entry.name);
+                    setOpen(false);
+                  }}
+                />
+              );
+            })}
           </BottomSheet.Body>
         </BottomSheet.Content>
       </BottomSheet.Root>
+      {quickAddModal}
+      </>
     );
   }
 
   return (
+    <>
     <Menu.Root open={open} onOpenChange={setOpen}>
       <Menu.Trigger asChild>{trigger}</Menu.Trigger>
       <Menu.Content side="top" align="start">
@@ -405,39 +509,45 @@ export function ComposerSettingsMenu({ assistantId, conversationId }: Props) {
             </Menu.Item>
           );
         })}
-        {visibleProfileEntries.length > 0 && (
-          <>
-            <Menu.Separator />
-            <Menu.Label className="text-label-small-default normal-case tracking-normal">
-              Model Profile
-            </Menu.Label>
-            {visibleProfileEntries.map((entry) => {
-              const isActive = entry.name === profileActiveKey;
-              return (
-                <Menu.Item
-                  key={entry.name}
-                  onSelect={() => handleProfileSelect(entry.name)}
-                  leftIcon={<Sparkles className="h-3.5 w-3.5" />}
-                  className={isActive ? "bg-[var(--surface-active)] text-[var(--content-emphasised)]" : ""}
-                  shortcut={isActive ? <Check className="h-3.5 w-3.5 text-[var(--system-positive-strong)]" /> : undefined}
-                  title={entry.name === "auto" ? "Automatically switches profiles based on the query" : undefined}
-                >
-                  {profilePickerLabel(entry)}
-                </Menu.Item>
-              );
-            })}
-          </>
-        )}
+        <Menu.Separator />
+        <Menu.Label className="flex items-center justify-between gap-2 text-label-small-default normal-case tracking-normal">
+          <span>Model Profile</span>
+          {quickAddButton}
+        </Menu.Label>
+        {visibleProfileEntries.map((entry) => {
+          const isActive = entry.name === profileActiveKey;
+          return (
+            <Menu.Item
+              key={entry.name}
+              onSelect={() => handleProfileSelect(entry.name)}
+              leftIcon={<Sparkles className="h-3.5 w-3.5" />}
+              className={isActive ? "bg-[var(--surface-active)] text-[var(--content-emphasised)]" : ""}
+              shortcut={isActive ? <Check className="h-3.5 w-3.5 text-[var(--system-positive-strong)]" /> : undefined}
+              title={entry.name === "auto" ? "Automatically switches profiles based on the query" : undefined}
+            >
+              {profilePickerLabel(entry)}
+            </Menu.Item>
+          );
+        })}
       </Menu.Content>
     </Menu.Root>
+    {quickAddModal}
+    </>
   );
 }
 
 /** Bottom-sheet section label — small-caps style matching Menu.Label. */
-function SectionLabel({ children }: { children: ReactNode }) {
+function SectionLabel({
+  children,
+  trailingAction,
+}: {
+  children: ReactNode;
+  trailingAction?: ReactNode;
+}) {
   return (
-    <div className="px-[8px] pt-2.5 pb-2 text-body-small-default text-[var(--content-tertiary)]">
-      {children}
+    <div className="flex items-center justify-between gap-2 px-[8px] pt-2.5 pb-2 text-body-small-default text-[var(--content-tertiary)]">
+      <span>{children}</span>
+      {trailingAction}
     </div>
   );
 }

--- a/apps/web/src/domains/chat/components/composer-settings-menu.tsx
+++ b/apps/web/src/domains/chat/components/composer-settings-menu.tsx
@@ -1,20 +1,18 @@
 
 import { Check, Plus, Sparkles, SlidersHorizontal } from "lucide-react";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from "react";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 
 import { BottomSheet } from "@vellum/design-library";
 import { Button } from "@vellum/design-library";
 import { Menu } from "@vellum/design-library";
 import { PanelItem } from "@vellum/design-library";
 import { Tooltip } from "@vellum/design-library";
-import { toast } from "@vellum/design-library/components/toast";
 import { client } from "@/generated/api/client.gen";
 import {
   conversationsByIdGet,
   conversationsByIdInferenceprofilePut,
 } from "@/generated/daemon/sdk.gen";
-import { inferenceProviderconnectionsGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import {
   profilePickerLabel,
@@ -22,9 +20,7 @@ import {
   gateAutoProfile,
   type ProfilePickerEntry,
 } from "@/assistant/profile-pickers";
-import { ProfileEditorModal } from "@/domains/settings/ai/profile-editor-modal";
-import { filterFlaggedConnections } from "@/domains/settings/ai/provider-connections-client";
-import type { ProfileEntry } from "@/domains/settings/ai/ai-types";
+import { useProfileQuickAdd } from "@/components/profile-quick-add-provider";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import {
   deleteConversationOverride,
@@ -295,10 +291,6 @@ export function ComposerSettingsMenu({ assistantId, conversationId }: Props) {
 
   const queryComplexityRoutingEnabled =
     useAssistantFeatureFlagStore.use.queryComplexityRouting();
-  const openAICompatibleEndpoints =
-    useAssistantFeatureFlagStore.use.openAICompatibleEndpoints();
-  const chatgptSubscriptionAuth =
-    useAssistantFeatureFlagStore.use.chatgptSubscriptionAuth();
 
   const visibleProfileEntries = useMemo(
     () =>
@@ -309,65 +301,16 @@ export function ComposerSettingsMenu({ assistantId, conversationId }: Props) {
     [orderedProfileEntries, profileActiveKey, queryComplexityRoutingEnabled],
   );
 
-  // Quick-add: open the shared provider-first ProfileEditorModal in create
-  // mode over the chat. Provider connections feed the modal's Provider picker;
-  // the query is gated on `quickAddOpen` so the menu doesn't fetch them until
-  // the user actually starts creating a profile.
-  const [quickAddOpen, setQuickAddOpen] = useState(false);
-  const { data: connectionsData } = useQuery({
-    ...inferenceProviderconnectionsGetOptions({
-      path: { assistant_id: assistantId },
-    }),
-    enabled: quickAddOpen && !!assistantId,
-  });
-  const quickAddConnections = useMemo(
-    () =>
-      connectionsData
-        ? filterFlaggedConnections(connectionsData.connections, openAICompatibleEndpoints)
-        : undefined,
-    [connectionsData, openAICompatibleEndpoints],
-  );
+  // Quick-add is owned by the top-level ProfileQuickAddProvider (chat must not
+  // import settings directly — see local/no-cross-domain-imports). The provider
+  // renders the ProfileEditorModal in create mode, persists the new profile,
+  // and toasts; we hand it the current profile names and an onCreated callback
+  // so the new profile is autoselected for this thread once it persists.
+  const { openProfileQuickAdd } = useProfileQuickAdd();
 
   const existingProfileNames = useMemo(
     () => Array.from(new Set([...profileOrder, ...Object.keys(profileMap)])),
     [profileOrder, profileMap],
-  );
-
-  // Persist a freshly-created profile, then autoselect it for this thread.
-  // Mirrors ManageProfilesModal's create path: write `llm.profiles[name]`
-  // plus an appended `profileOrder` in a single config PATCH so the daemon
-  // records both the entry and its picker position. On success we reuse the
-  // existing per-thread selection handler (writes the override + invalidates
-  // the active-model cache) and surface a success toast.
-  const handleQuickAddSave = useCallback(
-    async (name: string, entry: ProfileEntry) => {
-      const profileOrderPatch = profileOrder.includes(name)
-        ? undefined
-        : [...profileOrder, name];
-      await client.patch({
-        url: `/v1/assistants/{assistant_id}/config`,
-        path: { assistant_id: assistantId },
-        body: {
-          llm: {
-            profiles: { [name]: entry },
-            ...(profileOrderPatch ? { profileOrder: profileOrderPatch } : {}),
-          },
-        },
-        headers: { "Content-Type": "application/json" },
-        throwOnError: true,
-      });
-      // Reflect the new profile locally so the picker renders it immediately
-      // (the daemon-config fetch only re-runs on assistant/conversation change).
-      setProfileMap((prev) => ({ ...prev, [name]: { label: entry.label ?? null } }));
-      if (profileOrderPatch) setProfileOrder(profileOrderPatch);
-      // Profiles are guaranteed loaded by now (the menu opened); allow the
-      // autoselect below to write the per-thread override.
-      profilesReadyRef.current = true;
-      await handleProfileSelect(name);
-      setQuickAddOpen(false);
-      toast.success(`Profile "${name}" created`);
-    },
-    [assistantId, profileOrder, handleProfileSelect],
   );
 
   // The "+" quick-add affordance rendered in both the desktop Menu.Label and
@@ -381,24 +324,26 @@ export function ComposerSettingsMenu({ assistantId, conversationId }: Props) {
         aria-label="New Profile"
         onClick={() => {
           setOpen(false);
-          setQuickAddOpen(true);
+          openProfileQuickAdd({
+            existingNames: existingProfileNames,
+            profileOrder,
+            onCreated: (name) => {
+              // Reflect the new profile locally so the picker renders it
+              // immediately (the daemon-config fetch only re-runs on
+              // assistant/conversation change).
+              setProfileMap((prev) => ({ ...prev, [name]: { label: null } }));
+              setProfileOrder((prev) =>
+                prev.includes(name) ? prev : [...prev, name],
+              );
+              // Profiles are guaranteed loaded by now (the menu opened); allow
+              // the autoselect to write the per-thread override.
+              profilesReadyRef.current = true;
+              void handleProfileSelect(name);
+            },
+          });
         }}
       />
     </Tooltip>
-  );
-
-  const quickAddModal = (
-    <ProfileEditorModal
-      isOpen={quickAddOpen}
-      mode="create"
-      existingNames={existingProfileNames}
-      connections={quickAddConnections}
-      openAICompatibleEndpointsEnabled={openAICompatibleEndpoints}
-      assistantId={assistantId}
-      chatgptSubscriptionEnabled={chatgptSubscriptionAuth}
-      onSave={handleQuickAddSave}
-      onCancel={() => setQuickAddOpen(false)}
-    />
   );
 
   const trigger = (
@@ -412,7 +357,6 @@ export function ComposerSettingsMenu({ assistantId, conversationId }: Props) {
 
   if (isMobile) {
     return (
-      <>
       <BottomSheet.Root open={open} onOpenChange={setOpen}>
         <BottomSheet.Trigger asChild>{trigger}</BottomSheet.Trigger>
         {/* Radix Dialog requires a Title for screen-reader accessibility;
@@ -475,13 +419,10 @@ export function ComposerSettingsMenu({ assistantId, conversationId }: Props) {
           </BottomSheet.Body>
         </BottomSheet.Content>
       </BottomSheet.Root>
-      {quickAddModal}
-      </>
     );
   }
 
   return (
-    <>
     <Menu.Root open={open} onOpenChange={setOpen}>
       <Menu.Trigger asChild>{trigger}</Menu.Trigger>
       <Menu.Content side="top" align="start">
@@ -531,8 +472,6 @@ export function ComposerSettingsMenu({ assistantId, conversationId }: Props) {
         })}
       </Menu.Content>
     </Menu.Root>
-    {quickAddModal}
-    </>
   );
 }
 

--- a/apps/web/src/domains/chat/components/composer-settings-menu.tsx
+++ b/apps/web/src/domains/chat/components/composer-settings-menu.tsx
@@ -3,6 +3,7 @@ import { Check, Plus, Sparkles, SlidersHorizontal } from "lucide-react";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 
+import { toast } from "@vellum/design-library/components/toast";
 import { BottomSheet } from "@vellum/design-library";
 import { Button } from "@vellum/design-library";
 import { Menu } from "@vellum/design-library";
@@ -66,6 +67,12 @@ export function ComposerSettingsMenu({ assistantId, conversationId }: Props) {
   // Ref (not state) — flipped to true once the first combined fetch resolves.
   // Used to guard handleProfileSelect without triggering extra renders.
   const profilesReadyRef = useRef(false);
+  // State mirror of profilesReadyRef — drives a re-render so the quick-add "+"
+  // can disable itself until the config fetch settles. Gating "+" on the empty
+  // initial profileOrder/profileMap matters: opening the modal with those empty
+  // values would let a duplicate name overwrite an existing profile and reset
+  // the persisted profileOrder to just the new entry.
+  const [profilesLoaded, setProfilesLoaded] = useState(false);
 
   const conversationIdRef = useRef(conversationId);
   useLayoutEffect(() => {
@@ -113,6 +120,7 @@ export function ComposerSettingsMenu({ assistantId, conversationId }: Props) {
   useEffect(() => {
     if (!assistantId) return;
     profilesReadyRef.current = false;
+    setProfilesLoaded(false);
     let cancelled = false;
 
     (async () => {
@@ -159,6 +167,7 @@ export function ComposerSettingsMenu({ assistantId, conversationId }: Props) {
         setProfileActiveKey(effective);
         lastConfirmedProfileRef.current = effective;
         profilesReadyRef.current = true;
+        setProfilesLoaded(true);
       } catch {
         if (cancelled) return;
       }
@@ -215,11 +224,16 @@ export function ComposerSettingsMenu({ assistantId, conversationId }: Props) {
     [assistantId, conversationId, globalInteractive],
   );
 
+  // Resolves to `true` when the selection write was confirmed by the server,
+  // `false` when it was guarded out or rolled back. Normal picker callers
+  // ignore the result (their rollback UX is unchanged); the quick-add
+  // onCreated path awaits it so a failed autoselect can surface an error toast
+  // instead of silently reporting success.
   const handleProfileSelect = useCallback(
-    async (name: string) => {
+    async (name: string): Promise<boolean> => {
       // Guard against interaction before profiles are loaded — mirrors the
       // globalInteractive === null guard on handleSelect.
-      if (!profilesReadyRef.current) return;
+      if (!profilesReadyRef.current) return false;
       // Capture conversationId at call time so post-async guards can verify the
       // user hasn't switched conversations while the request was in flight.
       const capturedConversationId = conversationIdRef.current;
@@ -263,6 +277,7 @@ export function ComposerSettingsMenu({ assistantId, conversationId }: Props) {
               (seg, i) => seg === null || query.queryKey[i] === seg,
             ),
         });
+        return true;
       } catch {
         if (conversationIdRef.current === capturedConversationId) {
           // Roll back to the last server-confirmed value, not a stale closure
@@ -270,6 +285,7 @@ export function ComposerSettingsMenu({ assistantId, conversationId }: Props) {
           // requests race (select A → select B → A fails → should stay at B).
           setProfileActiveKey(lastConfirmedProfileRef.current);
         }
+        return false;
       }
     },
     [assistantId, queryClient],
@@ -315,18 +331,24 @@ export function ComposerSettingsMenu({ assistantId, conversationId }: Props) {
 
   // The "+" quick-add affordance rendered in both the desktop Menu.Label and
   // the mobile SectionLabel. Closes the popover/sheet, then opens the modal.
+  // Disabled until `profilesLoaded` (see its declaration for why).
   const quickAddButton = (
-    <Tooltip content="New Profile" side="top">
+    <Tooltip
+      content={profilesLoaded ? "New Profile" : "Loading profiles…"}
+      side="top"
+    >
       <Button
         variant="ghost"
         size="compact"
         iconOnly={<Plus className="h-3.5 w-3.5" />}
         aria-label="New Profile"
+        disabled={!profilesLoaded}
+        aria-disabled={!profilesLoaded}
         onClick={() => {
+          if (!profilesLoaded) return;
           setOpen(false);
           openProfileQuickAdd({
             existingNames: existingProfileNames,
-            profileOrder,
             onCreated: (name) => {
               // Reflect the new profile locally so the picker renders it
               // immediately (the daemon-config fetch only re-runs on
@@ -335,10 +357,18 @@ export function ComposerSettingsMenu({ assistantId, conversationId }: Props) {
               setProfileOrder((prev) =>
                 prev.includes(name) ? prev : [...prev, name],
               );
-              // Profiles are guaranteed loaded by now (the menu opened); allow
-              // the autoselect to write the per-thread override.
+              // Profiles are guaranteed loaded by now (the "+" is disabled
+              // until then); allow the autoselect to write the per-thread
+              // override. If that write fails, handleProfileSelect rolls the
+              // selection back and resolves false — surface that so the flow
+              // doesn't silently report the profile as selected. Creation
+              // itself succeeded, so the provider's create-success toast stays.
               profilesReadyRef.current = true;
-              void handleProfileSelect(name);
+              void handleProfileSelect(name).then((selected) => {
+                if (!selected) {
+                  toast.error("Profile created, but couldn't switch to it");
+                }
+              });
             },
           });
         }}


### PR DESCRIPTION
## Summary
- Add a New Profile "+" to the composer Model Profile section header (desktop + mobile), including the zero-profiles state
- Opens the shared provider-first ProfileEditorModal in create mode over the chat
- On create, autoselects the new profile for the current thread and shows a success toast

Part of plan: provider-first-profile-quick-add.md (PR 4 of 5)