### PR TITLE
feat(acp): inject user OpenAI/Codex credential for codex-acp

### DIFF
--- a/assistant/src/acp/__tests__/prepare-agent-env.test.ts
+++ b/assistant/src/acp/__tests__/prepare-agent-env.test.ts
@@ -116,6 +116,10 @@ function seedVaultToken(token: string): void {
   vaultStore.set("acp/claude_oauth_token", token);
 }
 
+function seedVaultOpenAiKey(key: string): void {
+  vaultStore.set("acp/openai_api_key", key);
+}
+
 describe("prepareAgentEnv — claude-agent-acp gating", () => {
   test("injects CLAUDE_CODE_OAUTH_TOKEN from the vault via the broker when agent.env has no override", async () => {
     seedVaultToken("vault-AAA");
@@ -234,16 +238,110 @@ describe("prepareAgentEnv — claude-agent-acp gating", () => {
   });
 });
 
-describe("prepareAgentEnv — non-claude commands", () => {
-  test("returns the config unchanged for codex-acp (no required env vars today)", async () => {
+describe("prepareAgentEnv — codex-acp gating", () => {
+  test("injects OPENAI_API_KEY + CODEX_API_KEY from the vault via the broker when agent.env has no override", async () => {
+    seedVaultOpenAiKey("vault-openai-AAA");
+
     const prepared = await prepareAgentEnv({
       command: "codex-acp",
       args: [],
     });
 
-    expect(prepared.env).toEqual({});
+    expect(prepared.env?.OPENAI_API_KEY).toBe("vault-openai-AAA");
+    expect(prepared.env?.CODEX_API_KEY).toBe("vault-openai-AAA");
   });
 
+  test("auto-registers acp/openai_api_key metadata with acp_spawn when none exists", async () => {
+    seedVaultOpenAiKey("vault-openai-auto-meta");
+
+    await prepareAgentEnv({ command: "codex-acp", args: [] });
+
+    const meta = metadataStore.get("acp/openai_api_key");
+    expect(meta).toBeDefined();
+    expect(meta!.allowedTools).toContain("acp_spawn");
+  });
+
+  test("respects explicit tool policy that excludes acp_spawn", async () => {
+    metadataStore.set("acp/openai_api_key", { allowedTools: ["other_tool"] });
+    seedVaultOpenAiKey("vault-openai-restricted");
+
+    await expect(
+      prepareAgentEnv({ command: "codex-acp", args: [] }),
+    ).rejects.toThrow("OPENAI_API_KEY");
+
+    const meta = metadataStore.get("acp/openai_api_key");
+    expect(meta!.allowedTools).toEqual(["other_tool"]);
+  });
+
+  test("accepts OPENAI_API_KEY from agent.env (config.json override) with no vault entry", async () => {
+    const prepared = await prepareAgentEnv({
+      command: "codex-acp",
+      args: [],
+      env: { OPENAI_API_KEY: "config-openai-BBB" },
+    });
+
+    expect(prepared.env?.OPENAI_API_KEY).toBe("config-openai-BBB");
+  });
+
+  test("accepts CODEX_API_KEY from agent.env (config.json override) with no vault entry", async () => {
+    const prepared = await prepareAgentEnv({
+      command: "codex-acp",
+      args: [],
+      env: { CODEX_API_KEY: "config-codex-BBB" },
+    });
+
+    expect(prepared.env?.CODEX_API_KEY).toBe("config-codex-BBB");
+  });
+
+  test("agent.env override wins over the vault entry (precedence pin)", async () => {
+    seedVaultOpenAiKey("vault-openai-CCC");
+
+    const prepared = await prepareAgentEnv({
+      command: "codex-acp",
+      args: [],
+      env: { OPENAI_API_KEY: "config-openai-DDD" },
+    });
+
+    // Override satisfies the requirement; the vault is not consulted, so
+    // CODEX_API_KEY is left untouched.
+    expect(prepared.env?.OPENAI_API_KEY).toBe("config-openai-DDD");
+    expect(prepared.env?.CODEX_API_KEY).toBeUndefined();
+  });
+
+  test("throws FailedDependencyError when no key is provided from either route", async () => {
+    await expect(
+      prepareAgentEnv({ command: "codex-acp", args: [] }),
+    ).rejects.toThrow("codex-acp requires an OpenAI/Codex API key");
+  });
+
+  test("gates on the resolved command BASENAME (alias to /custom/path/codex-acp still gets the key)", async () => {
+    seedVaultOpenAiKey("vault-openai-FFF");
+
+    const prepared = await prepareAgentEnv({
+      command: "/opt/bin/codex-acp",
+      args: [],
+    });
+
+    expect(prepared.env?.OPENAI_API_KEY).toBe("vault-openai-FFF");
+    expect(prepared.env?.CODEX_API_KEY).toBe("vault-openai-FFF");
+  });
+
+  test("does not affect claude-agent-acp spawns (claude unaffected)", async () => {
+    seedVaultToken("vault-claude-only");
+    seedVaultOpenAiKey("vault-openai-unused");
+
+    const prepared = await prepareAgentEnv({
+      command: "claude-agent-acp",
+      args: [],
+    });
+
+    expect(prepared.env?.CLAUDE_CODE_OAUTH_TOKEN).toBe("vault-claude-only");
+    expect(prepared.env?.OPENAI_API_KEY).toBeUndefined();
+    expect(prepared.env?.CODEX_API_KEY).toBeUndefined();
+  });
+});
+
+describe("prepareAgentEnv — non-claude commands", () => {
   test("returns the config unchanged for an unrecognized command basename", async () => {
     seedVaultToken("vault-HHH");
 

--- a/assistant/src/acp/__tests__/prepare-agent-env.test.ts
+++ b/assistant/src/acp/__tests__/prepare-agent-env.test.ts
@@ -119,21 +119,31 @@ function restoreEnv(name: string, prev: string | undefined): void {
 // Snapshot + clear any ambient codex/openai creds the test daemon may have
 // exported, so the vault/agent.env/throw paths exercise the intended source
 // rather than silently picking up an ambient key. Restored in afterEach.
+//
+// IS_PLATFORM gates the codex-acp missing-key handling (throw on hosted pods,
+// proceed locally). `getIsPlatform()` reads `process.env.IS_PLATFORM` via the
+// dependency-free env-registry flag helper, so we toggle it through the env
+// var directly. Default each test to the LOCAL (non-platform) posture and
+// snapshot/restore so a leaked value can't cross-contaminate.
 let savedOpenAiKey: string | undefined;
 let savedCodexKey: string | undefined;
+let savedIsPlatform: string | undefined;
 
 beforeEach(() => {
   metadataStore.clear();
   vaultStore.clear();
   savedOpenAiKey = process.env.OPENAI_API_KEY;
   savedCodexKey = process.env.CODEX_API_KEY;
+  savedIsPlatform = process.env.IS_PLATFORM;
   delete process.env.OPENAI_API_KEY;
   delete process.env.CODEX_API_KEY;
+  delete process.env.IS_PLATFORM;
 });
 
 afterEach(() => {
   restoreEnv("OPENAI_API_KEY", savedOpenAiKey);
   restoreEnv("CODEX_API_KEY", savedCodexKey);
+  restoreEnv("IS_PLATFORM", savedIsPlatform);
 });
 
 // ---------------------------------------------------------------------------
@@ -290,6 +300,10 @@ describe("prepareAgentEnv — codex-acp gating", () => {
   });
 
   test("respects explicit tool policy that excludes acp_spawn", async () => {
+    // The broker denies the vault read (policy excludes acp_spawn), so no
+    // credential resolves. On platform that is fatal; pin the throw under the
+    // hosted posture so this asserts the denial, not the platform default.
+    process.env.IS_PLATFORM = "true";
     metadataStore.set("acp/openai_api_key", { allowedTools: ["other_tool"] });
     seedVaultOpenAiKey("vault-openai-restricted");
 
@@ -387,11 +401,64 @@ describe("prepareAgentEnv — codex-acp gating", () => {
     expect(prepared.env?.CODEX_API_KEY).toBeUndefined();
   });
 
-  test("throws FailedDependencyError when no key is provided from any route", async () => {
+  test("PLATFORM + no key from any route → throws FailedDependencyError", async () => {
     // beforeEach already cleared ambient OPENAI_API_KEY/CODEX_API_KEY.
+    // On platform-hosted pods there is no interactive `codex login`, so a
+    // missing key is fatal.
+    process.env.IS_PLATFORM = "true";
+
     await expect(
       prepareAgentEnv({ command: "codex-acp", args: [] }),
     ).rejects.toThrow("codex-acp requires an OpenAI/Codex API key");
+  });
+
+  test("LOCAL (non-platform) + no key from any route → does NOT throw, no OPENAI/CODEX vars forced", async () => {
+    // beforeEach leaves IS_PLATFORM unset (local). A locally logged-in codex
+    // CLI authenticates from its own stored OAuth state, so the spawn must be
+    // allowed to proceed and we must NOT force any OPENAI_API_KEY/CODEX_API_KEY.
+    const prepared = await prepareAgentEnv({ command: "codex-acp", args: [] });
+
+    expect(prepared.env?.OPENAI_API_KEY).toBeUndefined();
+    expect(prepared.env?.CODEX_API_KEY).toBeUndefined();
+  });
+
+  test("LOCAL (non-platform) preserves unrelated agent.env without forcing codex keys", async () => {
+    const prepared = await prepareAgentEnv({
+      command: "codex-acp",
+      args: [],
+      env: { OTHER_VAR: "keep-me" },
+    });
+
+    expect(prepared.env?.OTHER_VAR).toBe("keep-me");
+    expect(prepared.env?.OPENAI_API_KEY).toBeUndefined();
+    expect(prepared.env?.CODEX_API_KEY).toBeUndefined();
+  });
+
+  test("a resolved credential injects BOTH vars regardless of platform (platform=true)", async () => {
+    // A present credential short-circuits the platform-scoped missing-key
+    // branch entirely: injection is identical on platform and local.
+    process.env.IS_PLATFORM = "true";
+    seedVaultOpenAiKey("vault-platform-key");
+
+    const prepared = await prepareAgentEnv({
+      command: "codex-acp",
+      args: [],
+    });
+
+    expect(prepared.env?.OPENAI_API_KEY).toBe("vault-platform-key");
+    expect(prepared.env?.CODEX_API_KEY).toBe("vault-platform-key");
+  });
+
+  test("a resolved credential injects BOTH vars regardless of platform (local)", async () => {
+    seedVaultOpenAiKey("vault-local-key");
+
+    const prepared = await prepareAgentEnv({
+      command: "codex-acp",
+      args: [],
+    });
+
+    expect(prepared.env?.OPENAI_API_KEY).toBe("vault-local-key");
+    expect(prepared.env?.CODEX_API_KEY).toBe("vault-local-key");
   });
 
   test("gates on the resolved command BASENAME (alias to /custom/path/codex-acp still gets the key)", async () => {

--- a/assistant/src/acp/__tests__/prepare-agent-env.test.ts
+++ b/assistant/src/acp/__tests__/prepare-agent-env.test.ts
@@ -10,7 +10,7 @@
  * mock the broker and metadata store rather than the raw secure-keys backend.
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 // ---------------------------------------------------------------------------
 // Stubs — wired BEFORE importing the helper via dynamic import.
@@ -103,9 +103,37 @@ mock.module("../../tools/credentials/broker.js", () => ({
 
 const { prepareAgentEnv } = await import("../prepare-agent-env.js");
 
+/**
+ * Restore (or delete) a process.env var to a previously captured value.
+ * Used by the codex ambient-fallback tests so they don't leak into one
+ * another or into the real daemon environment the suite runs under.
+ */
+function restoreEnv(name: string, prev: string | undefined): void {
+  if (prev === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = prev;
+  }
+}
+
+// Snapshot + clear any ambient codex/openai creds the test daemon may have
+// exported, so the vault/agent.env/throw paths exercise the intended source
+// rather than silently picking up an ambient key. Restored in afterEach.
+let savedOpenAiKey: string | undefined;
+let savedCodexKey: string | undefined;
+
 beforeEach(() => {
   metadataStore.clear();
   vaultStore.clear();
+  savedOpenAiKey = process.env.OPENAI_API_KEY;
+  savedCodexKey = process.env.CODEX_API_KEY;
+  delete process.env.OPENAI_API_KEY;
+  delete process.env.CODEX_API_KEY;
+});
+
+afterEach(() => {
+  restoreEnv("OPENAI_API_KEY", savedOpenAiKey);
+  restoreEnv("CODEX_API_KEY", savedCodexKey);
 });
 
 // ---------------------------------------------------------------------------
@@ -308,7 +336,59 @@ describe("prepareAgentEnv — codex-acp gating", () => {
     expect(prepared.env?.CODEX_API_KEY).toBeUndefined();
   });
 
-  test("throws FailedDependencyError when no key is provided from either route", async () => {
+  test("falls back to ambient process.env.OPENAI_API_KEY (no agent.env, no vault) — injects both vars", async () => {
+    // beforeEach cleared ambient creds; afterEach restores them.
+    process.env.OPENAI_API_KEY = "ambient-openai-XYZ";
+
+    const prepared = await prepareAgentEnv({
+      command: "codex-acp",
+      args: [],
+    });
+
+    expect(prepared.env?.OPENAI_API_KEY).toBe("ambient-openai-XYZ");
+    expect(prepared.env?.CODEX_API_KEY).toBe("ambient-openai-XYZ");
+  });
+
+  test("falls back to ambient process.env.CODEX_API_KEY when only CODEX_API_KEY is set", async () => {
+    process.env.CODEX_API_KEY = "ambient-codex-XYZ";
+
+    const prepared = await prepareAgentEnv({
+      command: "codex-acp",
+      args: [],
+    });
+
+    expect(prepared.env?.OPENAI_API_KEY).toBe("ambient-codex-XYZ");
+    expect(prepared.env?.CODEX_API_KEY).toBe("ambient-codex-XYZ");
+  });
+
+  test("vault wins over ambient process.env (precedence pin)", async () => {
+    process.env.OPENAI_API_KEY = "ambient-loser";
+    seedVaultOpenAiKey("vault-winner");
+
+    const prepared = await prepareAgentEnv({
+      command: "codex-acp",
+      args: [],
+    });
+
+    expect(prepared.env?.OPENAI_API_KEY).toBe("vault-winner");
+    expect(prepared.env?.CODEX_API_KEY).toBe("vault-winner");
+  });
+
+  test("agent.env override wins over ambient process.env (precedence pin)", async () => {
+    process.env.OPENAI_API_KEY = "ambient-loser";
+
+    const prepared = await prepareAgentEnv({
+      command: "codex-acp",
+      args: [],
+      env: { OPENAI_API_KEY: "config-winner" },
+    });
+
+    expect(prepared.env?.OPENAI_API_KEY).toBe("config-winner");
+    expect(prepared.env?.CODEX_API_KEY).toBeUndefined();
+  });
+
+  test("throws FailedDependencyError when no key is provided from any route", async () => {
+    // beforeEach already cleared ambient OPENAI_API_KEY/CODEX_API_KEY.
     await expect(
       prepareAgentEnv({ command: "codex-acp", args: [] }),
     ).rejects.toThrow("codex-acp requires an OpenAI/Codex API key");

--- a/assistant/src/acp/__tests__/prepare-agent-env.test.ts
+++ b/assistant/src/acp/__tests__/prepare-agent-env.test.ts
@@ -375,6 +375,45 @@ describe("prepareAgentEnv — codex-acp gating", () => {
     expect(prepared.env?.CODEX_API_KEY).toBe("ambient-codex-XYZ");
   });
 
+  test("PLATFORM + ambient process.env.OPENAI_API_KEY only (no agent.env, no vault) → THROWS; operator key is NOT passed through", async () => {
+    // On platform-hosted pods the daemon's ambient OPENAI_API_KEY is an
+    // OPERATOR/PROVIDER key, NOT the agent user's credential. The ambient
+    // fallback is local-only, so on platform this key must be ignored: with no
+    // agent.env override and no user vault cred, the missing-key branch fires
+    // and we fail fast rather than leaking the operator key into the spawn.
+    process.env.IS_PLATFORM = "true";
+    process.env.OPENAI_API_KEY = "operator-ambient-key";
+
+    await expect(
+      prepareAgentEnv({ command: "codex-acp", args: [] }),
+    ).rejects.toThrow("codex-acp requires an OpenAI/Codex API key");
+  });
+
+  test("PLATFORM + ambient process.env.CODEX_API_KEY only → THROWS; operator key is NOT passed through", async () => {
+    process.env.IS_PLATFORM = "true";
+    process.env.CODEX_API_KEY = "operator-ambient-codex-key";
+
+    await expect(
+      prepareAgentEnv({ command: "codex-acp", args: [] }),
+    ).rejects.toThrow("codex-acp requires an OpenAI/Codex API key");
+  });
+
+  test("PLATFORM + ambient key but vault cred present → vault wins; ambient operator key ignored", async () => {
+    // The user's vault BYO cred is always allowed on platform; the ambient
+    // operator key must never be the resolved source.
+    process.env.IS_PLATFORM = "true";
+    process.env.OPENAI_API_KEY = "operator-ambient-key";
+    seedVaultOpenAiKey("vault-user-key");
+
+    const prepared = await prepareAgentEnv({
+      command: "codex-acp",
+      args: [],
+    });
+
+    expect(prepared.env?.OPENAI_API_KEY).toBe("vault-user-key");
+    expect(prepared.env?.CODEX_API_KEY).toBe("vault-user-key");
+  });
+
   test("vault wins over ambient process.env (precedence pin)", async () => {
     process.env.OPENAI_API_KEY = "ambient-loser";
     seedVaultOpenAiKey("vault-winner");

--- a/assistant/src/acp/prepare-agent-env.ts
+++ b/assistant/src/acp/prepare-agent-env.ts
@@ -94,19 +94,30 @@ function ensureAcpTokenPolicy(field: string, usageDescription: string): void {
  * may set either var; an override under one satisfies the requirement and
  * the vault is not consulted. The vault field is `acp/openai_api_key`.
  *
- * codex-acp adds a THIRD, lowest-precedence route: the daemon's ambient
- * `process.env.OPENAI_API_KEY` / `process.env.CODEX_API_KEY`. The full
- * precedence is: agent.env override → vault `acp/openai_api_key` → ambient
- * `process.env`. The ambient fallback exists for backward compatibility
- * with existing local users who `export OPENAI_API_KEY`/`CODEX_API_KEY` at
- * the daemon level: the sibling PR (F1) strips the daemon's ambient env
- * from the spawned agent subprocess, so an ambient key only reaches the
- * codex adapter if this helper reads it and re-injects it into the returned
- * `env` (which survives F1's strip). Whichever source wins, BOTH
- * `OPENAI_API_KEY` and `CODEX_API_KEY` are injected.
+ * codex-acp adds a THIRD, lowest-precedence, LOCAL-ONLY route: the daemon's
+ * ambient `process.env.OPENAI_API_KEY` / `process.env.CODEX_API_KEY`. The
+ * full precedence is:
+ *   1. agent.env override (OPENAI_API_KEY/CODEX_API_KEY) — always allowed
+ *      (user config).
+ *   2. vault `acp/openai_api_key` — always allowed (user BYO cred).
+ *   3. ambient `process.env` OPENAI_API_KEY/CODEX_API_KEY — ONLY when
+ *      `getIsPlatform()` is false (local). On platform-hosted pods the
+ *      daemon's ambient key is an OPERATOR/PROVIDER key (provider env
+ *      fallback / operator broker key), NOT the agent user's credential.
+ *      Passing it to the agent-driven session would leak the operator key
+ *      AND mask a missing/broker-denied user credential, so on platform the
+ *      ambient route is skipped entirely.
+ * The ambient fallback exists for backward compatibility with existing local
+ * users who `export OPENAI_API_KEY`/`CODEX_API_KEY` at the daemon level: the
+ * sibling PR (F1) strips the daemon's ambient env from the spawned agent
+ * subprocess, so an ambient key only reaches the codex adapter if this helper
+ * reads it and re-injects it into the returned `env` (which survives F1's
+ * strip). Whichever source wins, BOTH `OPENAI_API_KEY` and `CODEX_API_KEY`
+ * are injected.
  *
- * If NO codex credential resolves from any of those three routes, the
- * missing-key handling is PLATFORM-SCOPED:
+ * If NO codex credential resolves from the allowed routes (on platform: only
+ * agent.env + vault; on local: agent.env + vault + ambient), the missing-key
+ * handling is PLATFORM-SCOPED:
  *   - Platform-hosted (`getIsPlatform()` true): THROW `FailedDependencyError`.
  *     Hosted pods have no interactive terminal, so the `codex login`
  *     (ChatGPT OAuth) flow is unavailable and an API key is mandatory.
@@ -169,9 +180,17 @@ export async function prepareAgentEnv(
         },
       });
     }
-    if (!env.OPENAI_API_KEY && !env.CODEX_API_KEY) {
-      // Lowest-precedence fallback: the daemon's ambient process.env. Sibling
-      // PR F1 strips the daemon's ambient env from the spawned subprocess, so
+    if (!env.OPENAI_API_KEY && !env.CODEX_API_KEY && !getIsPlatform()) {
+      // Lowest-precedence fallback: the daemon's ambient process.env. This is
+      // LOCAL-ONLY (non-platform). On platform-hosted pods the daemon's
+      // ambient OPENAI_API_KEY/CODEX_API_KEY is an OPERATOR/PROVIDER key (the
+      // provider env fallback / operator broker key), NOT the agent user's
+      // credential. Passing it through would (a) leak an operator key to the
+      // agent-driven codex-acp session and (b) mask a missing/broker-denied
+      // user credential. So on platform we resolve ONLY from agent.env +
+      // vault `acp/openai_api_key` (the user's BYO cred) and never consult
+      // ambient env. Local dev keeps the ambient fallback: sibling PR F1
+      // strips the daemon's ambient env from the spawned subprocess, so we
       // re-inject it here to preserve existing local users who exported the
       // key at the daemon level. Inject BOTH var names from whichever ambient
       // var is set so the codex CLI sees a consistent credential.

--- a/assistant/src/acp/prepare-agent-env.ts
+++ b/assistant/src/acp/prepare-agent-env.ts
@@ -22,15 +22,19 @@
 
 import { basename } from "node:path";
 
+import { getIsPlatform } from "../config/env-registry.js";
 import { FailedDependencyError } from "../runtime/routes/errors.js";
 import { credentialBroker } from "../tools/credentials/broker.js";
 import {
   getCredentialMetadata,
   upsertCredentialMetadata,
 } from "../tools/credentials/metadata-store.js";
+import { getLogger } from "../util/logger.js";
 import type { AcpAgentConfig } from "./types.js";
 
 const ACP_SPAWN_TOOL = "acp_spawn";
+
+const log = getLogger("acp:prepare-agent-env");
 
 /**
  * Ensure the `acp/<field>` credential has metadata that allows the
@@ -100,6 +104,17 @@ function ensureAcpTokenPolicy(field: string, usageDescription: string): void {
  * codex adapter if this helper reads it and re-injects it into the returned
  * `env` (which survives F1's strip). Whichever source wins, BOTH
  * `OPENAI_API_KEY` and `CODEX_API_KEY` are injected.
+ *
+ * If NO codex credential resolves from any of those three routes, the
+ * missing-key handling is PLATFORM-SCOPED:
+ *   - Platform-hosted (`getIsPlatform()` true): THROW `FailedDependencyError`.
+ *     Hosted pods have no interactive terminal, so the `codex login`
+ *     (ChatGPT OAuth) flow is unavailable and an API key is mandatory.
+ *   - Local (non-platform): DO NOT throw. A locally logged-in `codex` CLI
+ *     authenticates from its own stored auth state (`~/.codex`, via
+ *     `codex login`), so the spawn must be allowed to proceed without us
+ *     forcing any `OPENAI_API_KEY`/`CODEX_API_KEY`. We inject nothing extra
+ *     and let the adapter read its own auth state.
  */
 export async function prepareAgentEnv(
   agentConfig: AcpAgentConfig,
@@ -168,14 +183,27 @@ export async function prepareAgentEnv(
       }
     }
     if (!env.OPENAI_API_KEY && !env.CODEX_API_KEY) {
-      throw new FailedDependencyError(
-        "codex-acp requires an OpenAI/Codex API key (OPENAI_API_KEY or CODEX_API_KEY) " +
-          "for hosted/agent-driven spawns. Resolution order: acp.agents.<id>.env in " +
-          "config.json → vault (assistant credentials set --service acp --field " +
-          "openai_api_key <key>) → ambient OPENAI_API_KEY/CODEX_API_KEY in the daemon " +
-          "environment. None were set. The interactive `codex login` (ChatGPT OAuth) " +
-          "flow is a local-only path and is not available on platform-hosted pods, so " +
-          "an API key is required here.",
+      // No credential from any route. The requirement is platform-scoped:
+      // hosted pods have no interactive `codex login`, so an API key is
+      // mandatory and we fail fast. Local assistants CAN authenticate via the
+      // codex CLI's own stored OAuth state (`codex login`, ~/.codex), so we
+      // let the spawn proceed without forcing any key and let the adapter
+      // read its own auth state.
+      if (getIsPlatform()) {
+        throw new FailedDependencyError(
+          "codex-acp requires an OpenAI/Codex API key (OPENAI_API_KEY or CODEX_API_KEY) " +
+            "for hosted/agent-driven spawns. Resolution order: acp.agents.<id>.env in " +
+            "config.json → vault (assistant credentials set --service acp --field " +
+            "openai_api_key <key>) → ambient OPENAI_API_KEY/CODEX_API_KEY in the daemon " +
+            "environment. None were set. The interactive `codex login` (ChatGPT OAuth) " +
+            "flow is a local-only path and is not available on platform-hosted pods, so " +
+            "an API key is required here.",
+        );
+      }
+      log.debug(
+        "codex-acp: no API key resolved (agent.env/vault/ambient); proceeding " +
+          "on local (non-platform) assistant so the codex CLI can use its own " +
+          "stored OAuth/auth state (codex login, ~/.codex).",
       );
     }
   }

--- a/assistant/src/acp/prepare-agent-env.ts
+++ b/assistant/src/acp/prepare-agent-env.ts
@@ -89,6 +89,17 @@ function ensureAcpTokenPolicy(field: string, usageDescription: string): void {
  * `CODEX_API_KEY` (the codex CLI accepts either). The config.json override
  * may set either var; an override under one satisfies the requirement and
  * the vault is not consulted. The vault field is `acp/openai_api_key`.
+ *
+ * codex-acp adds a THIRD, lowest-precedence route: the daemon's ambient
+ * `process.env.OPENAI_API_KEY` / `process.env.CODEX_API_KEY`. The full
+ * precedence is: agent.env override → vault `acp/openai_api_key` → ambient
+ * `process.env`. The ambient fallback exists for backward compatibility
+ * with existing local users who `export OPENAI_API_KEY`/`CODEX_API_KEY` at
+ * the daemon level: the sibling PR (F1) strips the daemon's ambient env
+ * from the spawned agent subprocess, so an ambient key only reaches the
+ * codex adapter if this helper reads it and re-injects it into the returned
+ * `env` (which survives F1's strip). Whichever source wins, BOTH
+ * `OPENAI_API_KEY` and `CODEX_API_KEY` are injected.
  */
 export async function prepareAgentEnv(
   agentConfig: AcpAgentConfig,
@@ -144,10 +155,27 @@ export async function prepareAgentEnv(
       });
     }
     if (!env.OPENAI_API_KEY && !env.CODEX_API_KEY) {
+      // Lowest-precedence fallback: the daemon's ambient process.env. Sibling
+      // PR F1 strips the daemon's ambient env from the spawned subprocess, so
+      // re-inject it here to preserve existing local users who exported the
+      // key at the daemon level. Inject BOTH var names from whichever ambient
+      // var is set so the codex CLI sees a consistent credential.
+      const ambientKey =
+        process.env.OPENAI_API_KEY ?? process.env.CODEX_API_KEY;
+      if (ambientKey) {
+        env.OPENAI_API_KEY = ambientKey;
+        env.CODEX_API_KEY = ambientKey;
+      }
+    }
+    if (!env.OPENAI_API_KEY && !env.CODEX_API_KEY) {
       throw new FailedDependencyError(
-        "codex-acp requires an OpenAI/Codex API key (OPENAI_API_KEY or CODEX_API_KEY). " +
-          "Run: assistant credentials set --service acp --field openai_api_key <key> " +
-          "(or set it under acp.agents.<id>.env in config.json).",
+        "codex-acp requires an OpenAI/Codex API key (OPENAI_API_KEY or CODEX_API_KEY) " +
+          "for hosted/agent-driven spawns. Resolution order: acp.agents.<id>.env in " +
+          "config.json → vault (assistant credentials set --service acp --field " +
+          "openai_api_key <key>) → ambient OPENAI_API_KEY/CODEX_API_KEY in the daemon " +
+          "environment. None were set. The interactive `codex login` (ChatGPT OAuth) " +
+          "flow is a local-only path and is not available on platform-hosted pods, so " +
+          "an API key is required here.",
       );
     }
   }

--- a/assistant/src/acp/prepare-agent-env.ts
+++ b/assistant/src/acp/prepare-agent-env.ts
@@ -33,8 +33,8 @@ import type { AcpAgentConfig } from "./types.js";
 const ACP_SPAWN_TOOL = "acp_spawn";
 
 /**
- * Ensure the `acp/claude_oauth_token` credential has metadata that allows
- * the `acp_spawn` tool to read it, but only for legacy/unmanaged cases:
+ * Ensure the `acp/<field>` credential has metadata that allows the
+ * `acp_spawn` tool to read it, but only for legacy/unmanaged cases:
  *
  * - No metadata at all → create with `allowedTools: ["acp_spawn"]`.
  * - Metadata exists with an empty `allowedTools` → default provisioning
@@ -43,19 +43,18 @@ const ACP_SPAWN_TOOL = "acp_spawn";
  *   by the user/admin. Respect it even if `acp_spawn` is absent — the
  *   broker will deny the read and the preflight will throw.
  */
-function ensureAcpTokenPolicy(): void {
-  const meta = getCredentialMetadata("acp", "claude_oauth_token");
+function ensureAcpTokenPolicy(field: string, usageDescription: string): void {
+  const meta = getCredentialMetadata("acp", field);
   if (!meta) {
-    upsertCredentialMetadata("acp", "claude_oauth_token", {
+    upsertCredentialMetadata("acp", field, {
       allowedTools: [ACP_SPAWN_TOOL],
-      usageDescription:
-        "Claude OAuth token for ACP agent authentication",
+      usageDescription,
     });
     return;
   }
   const tools = meta.allowedTools ?? [];
   if (tools.length === 0) {
-    upsertCredentialMetadata("acp", "claude_oauth_token", {
+    upsertCredentialMetadata("acp", field, {
       allowedTools: [ACP_SPAWN_TOOL],
     });
   }
@@ -84,6 +83,12 @@ function ensureAcpTokenPolicy(): void {
  * before spawning. The "fail-fast" throw is symmetric with the existing
  * `binary_not_found` preflight in `resolveAcpAgent` and strictly better
  * than a `warn` + zombie subprocess 10 seconds later.
+ *
+ * For `codex-acp` the same two-route resolution applies to the user's
+ * OpenAI/Codex API key, injected as both `OPENAI_API_KEY` and
+ * `CODEX_API_KEY` (the codex CLI accepts either). The config.json override
+ * may set either var; an override under one satisfies the requirement and
+ * the vault is not consulted. The vault field is `acp/openai_api_key`.
  */
 export async function prepareAgentEnv(
   agentConfig: AcpAgentConfig,
@@ -96,7 +101,10 @@ export async function prepareAgentEnv(
 
   if (commandBasename === "claude-agent-acp") {
     if (!env.CLAUDE_CODE_OAUTH_TOKEN) {
-      ensureAcpTokenPolicy();
+      ensureAcpTokenPolicy(
+        "claude_oauth_token",
+        "Claude OAuth token for ACP agent authentication",
+      );
       await credentialBroker.serverUse<void>({
         service: "acp",
         field: "claude_oauth_token",
@@ -110,6 +118,35 @@ export async function prepareAgentEnv(
       throw new FailedDependencyError(
         "claude-agent-acp requires CLAUDE_CODE_OAUTH_TOKEN. " +
           "Run: assistant credentials set --service acp --field claude_oauth_token <token> " +
+          "(or set it under acp.agents.<id>.env in config.json).",
+      );
+    }
+  }
+
+  if (commandBasename === "codex-acp") {
+    // The codex-acp adapter shells out to the `codex` CLI, which accepts the
+    // user's OpenAI/Codex API key via either CODEX_API_KEY or OPENAI_API_KEY.
+    // A config.json env override (under either var) wins over the vault, so
+    // explicit per-workspace/rotated keys are never silently clobbered.
+    if (!env.OPENAI_API_KEY && !env.CODEX_API_KEY) {
+      ensureAcpTokenPolicy(
+        "openai_api_key",
+        "OpenAI/Codex API key for codex-acp agent authentication",
+      );
+      await credentialBroker.serverUse<void>({
+        service: "acp",
+        field: "openai_api_key",
+        toolName: ACP_SPAWN_TOOL,
+        execute: async (key) => {
+          env.OPENAI_API_KEY = key;
+          env.CODEX_API_KEY = key;
+        },
+      });
+    }
+    if (!env.OPENAI_API_KEY && !env.CODEX_API_KEY) {
+      throw new FailedDependencyError(
+        "codex-acp requires an OpenAI/Codex API key (OPENAI_API_KEY or CODEX_API_KEY). " +
+          "Run: assistant credentials set --service acp --field openai_api_key <key> " +
           "(or set it under acp.agents.<id>.env in config.json).",
       );
     }

--- a/assistant/src/runtime/routes/acp-routes.test.ts
+++ b/assistant/src/runtime/routes/acp-routes.test.ts
@@ -391,6 +391,9 @@ describe("POST /v1/acp/spawn — CLAUDE_CODE_OAUTH_TOKEN injection", () => {
 
   test("does NOT inject CLAUDE_CODE_OAUTH_TOKEN for agents whose command is not claude-agent-acp", async () => {
     seedVaultToken("test-token-abc123");
+    // The codex-acp path requires an OpenAI/Codex key; seed one so the spawn
+    // succeeds and we can assert the CLAUDE token is NOT injected for it.
+    vaultStore.set("acp/openai_api_key", "test-openai-key-abc123");
 
     const handler = getSpawnHandler();
     await handler({

--- a/assistant/src/tools/acp/spawn.test.ts
+++ b/assistant/src/tools/acp/spawn.test.ts
@@ -210,12 +210,14 @@ beforeEach(() => {
   _resetAdapterVersionCacheForTests();
   config.setConfig({ agents: DEFAULT_TEST_AGENTS });
   which.setWhich((cmd) => `/usr/local/bin/${cmd}`);
-  // Default: vault has a claude token so the preflight in `prepareAgentEnv`
-  // succeeds for tests that don't care about env injection. Env-injection
-  // tests below clear/override this explicitly.
+  // Default: vault has both a claude token and an OpenAI/Codex key so the
+  // preflight in `prepareAgentEnv` succeeds for tests that don't care about
+  // env injection (including codex-acp spawns). Env-injection tests below
+  // clear/override this explicitly.
   vaultStore.clear();
   metadataStore.clear();
   vaultStore.set("acp/claude_oauth_token", "default-test-token");
+  vaultStore.set("acp/openai_api_key", "default-test-openai-key");
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add a codex-acp auth branch resolving acp/openai_api_key (env override wins) and injecting the codex CLI credential; seed read policy; fail fast when absent.

Part of plan: acp-platform-hosted.md (PR 4 of 11)