### PR TITLE
feat(acp): claude-agent-acp auth via OAuth or Anthropic API key + git token

### DIFF
--- a/assistant/src/acp/__tests__/prepare-agent-env.test.ts
+++ b/assistant/src/acp/__tests__/prepare-agent-env.test.ts
@@ -116,6 +116,10 @@ function seedVaultToken(token: string): void {
   vaultStore.set("acp/claude_oauth_token", token);
 }
 
+function seedVaultField(field: string, value: string): void {
+  vaultStore.set(`acp/${field}`, value);
+}
+
 describe("prepareAgentEnv — claude-agent-acp gating", () => {
   test("injects CLAUDE_CODE_OAUTH_TOKEN from the vault via the broker when agent.env has no override", async () => {
     seedVaultToken("vault-AAA");
@@ -214,6 +218,112 @@ describe("prepareAgentEnv — claude-agent-acp gating", () => {
     });
 
     expect(prepared.env?.CLAUDE_CODE_OAUTH_TOKEN).toBe("vault-FFF");
+  });
+
+  test("falls back to ANTHROPIC_API_KEY from the vault when no OAuth token exists", async () => {
+    seedVaultField("anthropic_api_key", "vault-anthropic-key");
+
+    const prepared = await prepareAgentEnv({
+      command: "claude-agent-acp",
+      args: [],
+    });
+
+    expect(prepared.env?.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+    expect(prepared.env?.ANTHROPIC_API_KEY).toBe("vault-anthropic-key");
+  });
+
+  test("accepts ANTHROPIC_API_KEY from agent.env (config.json override) with no vault entry", async () => {
+    const prepared = await prepareAgentEnv({
+      command: "claude-agent-acp",
+      args: [],
+      env: { ANTHROPIC_API_KEY: "config-anthropic" },
+    });
+
+    expect(prepared.env?.ANTHROPIC_API_KEY).toBe("config-anthropic");
+  });
+
+  test("prefers the OAuth token over the Anthropic API key when both are present", async () => {
+    seedVaultToken("vault-oauth");
+    seedVaultField("anthropic_api_key", "vault-anthropic-key");
+
+    const prepared = await prepareAgentEnv({
+      command: "claude-agent-acp",
+      args: [],
+    });
+
+    expect(prepared.env?.CLAUDE_CODE_OAUTH_TOKEN).toBe("vault-oauth");
+    // API-key fallback is only consulted when no OAuth token resolves.
+    expect(prepared.env?.ANTHROPIC_API_KEY).toBeUndefined();
+  });
+
+  test("agent.env ANTHROPIC_API_KEY override wins over the vault entry", async () => {
+    seedVaultField("anthropic_api_key", "vault-anthropic-key");
+
+    const prepared = await prepareAgentEnv({
+      command: "claude-agent-acp",
+      args: [],
+      env: { ANTHROPIC_API_KEY: "config-anthropic" },
+    });
+
+    expect(prepared.env?.ANTHROPIC_API_KEY).toBe("config-anthropic");
+  });
+
+  test("injects GH_TOKEN from the vault when a git token is present", async () => {
+    seedVaultToken("vault-oauth");
+    seedVaultField("git_token", "vault-git");
+
+    const prepared = await prepareAgentEnv({
+      command: "claude-agent-acp",
+      args: [],
+    });
+
+    expect(prepared.env?.GH_TOKEN).toBe("vault-git");
+  });
+
+  test("git token works alongside the API-key-only LLM credential", async () => {
+    seedVaultField("anthropic_api_key", "vault-anthropic-key");
+    seedVaultField("git_token", "vault-git");
+
+    const prepared = await prepareAgentEnv({
+      command: "claude-agent-acp",
+      args: [],
+    });
+
+    expect(prepared.env?.ANTHROPIC_API_KEY).toBe("vault-anthropic-key");
+    expect(prepared.env?.GH_TOKEN).toBe("vault-git");
+  });
+
+  test("agent.env GH_TOKEN override wins over the vault entry", async () => {
+    seedVaultToken("vault-oauth");
+    seedVaultField("git_token", "vault-git");
+
+    const prepared = await prepareAgentEnv({
+      command: "claude-agent-acp",
+      args: [],
+      env: { GH_TOKEN: "config-git" },
+    });
+
+    expect(prepared.env?.GH_TOKEN).toBe("config-git");
+  });
+
+  test("does NOT inject GH_TOKEN when no git token is present", async () => {
+    seedVaultToken("vault-oauth");
+
+    const prepared = await prepareAgentEnv({
+      command: "claude-agent-acp",
+      args: [],
+    });
+
+    expect(prepared.env?.GH_TOKEN).toBeUndefined();
+  });
+
+  test("throws FailedDependencyError when NEITHER LLM credential is present", async () => {
+    // A git token alone is not sufficient — an LLM credential is required.
+    seedVaultField("git_token", "vault-git");
+
+    await expect(
+      prepareAgentEnv({ command: "claude-agent-acp", args: [] }),
+    ).rejects.toThrow("ANTHROPIC_API_KEY");
   });
 
   test("does NOT mutate the caller's agentConfig", async () => {

--- a/assistant/src/acp/__tests__/prepare-agent-env.test.ts
+++ b/assistant/src/acp/__tests__/prepare-agent-env.test.ts
@@ -106,6 +106,10 @@ const { prepareAgentEnv } = await import("../prepare-agent-env.js");
 beforeEach(() => {
   metadataStore.clear();
   vaultStore.clear();
+  // Ambient daemon-level creds are an explicit fallback source; clear them so
+  // a value leaking in from the test runner's own env can't mask precedence.
+  delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+  delete process.env.ANTHROPIC_API_KEY;
 });
 
 // ---------------------------------------------------------------------------
@@ -266,6 +270,95 @@ describe("prepareAgentEnv — claude-agent-acp gating", () => {
     });
 
     expect(prepared.env?.ANTHROPIC_API_KEY).toBe("config-anthropic");
+  });
+
+  test("explicit agent.env ANTHROPIC_API_KEY wins over a vault OAuth token (no OAuth-over-API-key)", async () => {
+    // The precedence bug: a stored OAuth token must NOT be injected over an
+    // API key the user intentionally set via config.json, because the adapter
+    // prefers OAuth when both are present.
+    seedVaultToken("vault-oauth");
+
+    const prepared = await prepareAgentEnv({
+      command: "claude-agent-acp",
+      args: [],
+      env: { ANTHROPIC_API_KEY: "config-anthropic" },
+    });
+
+    expect(prepared.env?.ANTHROPIC_API_KEY).toBe("config-anthropic");
+    expect(prepared.env?.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+  });
+
+  test("explicit agent.env CLAUDE_CODE_OAUTH_TOKEN wins over a vault Anthropic API key", async () => {
+    seedVaultField("anthropic_api_key", "vault-anthropic-key");
+
+    const prepared = await prepareAgentEnv({
+      command: "claude-agent-acp",
+      args: [],
+      env: { CLAUDE_CODE_OAUTH_TOKEN: "config-oauth" },
+    });
+
+    expect(prepared.env?.CLAUDE_CODE_OAUTH_TOKEN).toBe("config-oauth");
+    expect(prepared.env?.ANTHROPIC_API_KEY).toBeUndefined();
+  });
+
+  test("falls back to ambient process.env.ANTHROPIC_API_KEY when neither agent.env nor the vault has a credential", async () => {
+    process.env.ANTHROPIC_API_KEY = "ambient-anthropic";
+
+    const prepared = await prepareAgentEnv({
+      command: "claude-agent-acp",
+      args: [],
+    });
+
+    expect(prepared.env?.ANTHROPIC_API_KEY).toBe("ambient-anthropic");
+    expect(prepared.env?.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+  });
+
+  test("falls back to ambient process.env.CLAUDE_CODE_OAUTH_TOKEN, preferred over an ambient API key", async () => {
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = "ambient-oauth";
+    process.env.ANTHROPIC_API_KEY = "ambient-anthropic";
+
+    const prepared = await prepareAgentEnv({
+      command: "claude-agent-acp",
+      args: [],
+    });
+
+    expect(prepared.env?.CLAUDE_CODE_OAUTH_TOKEN).toBe("ambient-oauth");
+    expect(prepared.env?.ANTHROPIC_API_KEY).toBeUndefined();
+  });
+
+  test("vault credential wins over the ambient process.env fallback", async () => {
+    seedVaultToken("vault-oauth");
+    process.env.ANTHROPIC_API_KEY = "ambient-anthropic";
+
+    const prepared = await prepareAgentEnv({
+      command: "claude-agent-acp",
+      args: [],
+    });
+
+    expect(prepared.env?.CLAUDE_CODE_OAUTH_TOKEN).toBe("vault-oauth");
+    // Ambient is only consulted when neither agent.env nor the vault supplies one.
+    expect(prepared.env?.ANTHROPIC_API_KEY).toBeUndefined();
+  });
+
+  test("full precedence: agent.env API key beats both a vault OAuth token and an ambient OAuth token", async () => {
+    seedVaultToken("vault-oauth");
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = "ambient-oauth";
+
+    const prepared = await prepareAgentEnv({
+      command: "claude-agent-acp",
+      args: [],
+      env: { ANTHROPIC_API_KEY: "config-anthropic" },
+    });
+
+    expect(prepared.env?.ANTHROPIC_API_KEY).toBe("config-anthropic");
+    expect(prepared.env?.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+  });
+
+  test("throws when no LLM credential exists in agent.env, the vault, or the ambient env", async () => {
+    // No vault entry, no agent.env, no ambient cred (cleared in beforeEach).
+    await expect(
+      prepareAgentEnv({ command: "claude-agent-acp", args: [] }),
+    ).rejects.toThrow("ANTHROPIC_API_KEY");
   });
 
   test("injects GH_TOKEN from the vault when a git token is present", async () => {

--- a/assistant/src/acp/prepare-agent-env.ts
+++ b/assistant/src/acp/prepare-agent-env.ts
@@ -33,8 +33,8 @@ import type { AcpAgentConfig } from "./types.js";
 const ACP_SPAWN_TOOL = "acp_spawn";
 
 /**
- * Ensure the `acp/claude_oauth_token` credential has metadata that allows
- * the `acp_spawn` tool to read it, but only for legacy/unmanaged cases:
+ * Ensure an `acp/<field>` credential has metadata that allows the
+ * `acp_spawn` tool to read it, but only for legacy/unmanaged cases:
  *
  * - No metadata at all → create with `allowedTools: ["acp_spawn"]`.
  * - Metadata exists with an empty `allowedTools` → default provisioning
@@ -43,22 +43,46 @@ const ACP_SPAWN_TOOL = "acp_spawn";
  *   by the user/admin. Respect it even if `acp_spawn` is absent — the
  *   broker will deny the read and the preflight will throw.
  */
-function ensureAcpTokenPolicy(): void {
-  const meta = getCredentialMetadata("acp", "claude_oauth_token");
+function ensureAcpTokenPolicy(field: string, usageDescription: string): void {
+  const meta = getCredentialMetadata("acp", field);
   if (!meta) {
-    upsertCredentialMetadata("acp", "claude_oauth_token", {
+    upsertCredentialMetadata("acp", field, {
       allowedTools: [ACP_SPAWN_TOOL],
-      usageDescription:
-        "Claude OAuth token for ACP agent authentication",
+      usageDescription,
     });
     return;
   }
   const tools = meta.allowedTools ?? [];
   if (tools.length === 0) {
-    upsertCredentialMetadata("acp", "claude_oauth_token", {
+    upsertCredentialMetadata("acp", field, {
       allowedTools: [ACP_SPAWN_TOOL],
     });
   }
+}
+
+/**
+ * Resolve a broker-stored `acp/<field>` credential into `env[envVar]` unless
+ * the caller already supplied it via `agent.env`. Mirrors the OAuth-token
+ * resolution: seed the read policy, then read through the broker (which only
+ * runs `execute` on a successful, policy-allowed read). config.json overrides
+ * always win, so we never clobber an explicit user-supplied value.
+ */
+async function resolveAcpCredential(
+  env: Record<string, string>,
+  envVar: string,
+  field: string,
+  usageDescription: string,
+): Promise<void> {
+  if (env[envVar]) return;
+  ensureAcpTokenPolicy(field, usageDescription);
+  await credentialBroker.serverUse<void>({
+    service: "acp",
+    field,
+    toolName: ACP_SPAWN_TOOL,
+    execute: async (value) => {
+      env[envVar] = value;
+    },
+  });
 }
 
 /**
@@ -71,16 +95,18 @@ function ensureAcpTokenPolicy(): void {
  * user-facing agent id, so a custom `acp.agents.my-claude = { command:
  * "claude-agent-acp", ... }` alias still gets the env it needs.
  *
- * For `claude-agent-acp` the only required env var is
- * `CLAUDE_CODE_OAUTH_TOKEN`. Two provisioning routes converge on it, with
- * config.json winning over the vault so explicit user overrides
- * (per-workspace, rotated, etc.) are never silently clobbered:
- *   1. `acp.agents.<id>.env.CLAUDE_CODE_OAUTH_TOKEN` in `config.json` —
- *      the user-supplied env override on the resolved agent config.
- *   2. Secure store via CLI: `assistant credentials set --service acp \
- *        --field claude_oauth_token <token>` — read through the
+ * For `claude-agent-acp` the agent needs ONE of two LLM credentials, plus
+ * an optional git/dev credential so it can clone/push. For each, config.json
+ * wins over the vault so explicit user overrides (per-workspace, rotated,
+ * etc.) are never silently clobbered:
+ *   1. LLM auth — `CLAUDE_CODE_OAUTH_TOKEN` (preferred) OR, as a fallback
+ *      when no OAuth token is present, `ANTHROPIC_API_KEY`. Each resolves
+ *      from `acp.agents.<id>.env` in `config.json` or the secure store
+ *      (`acp/claude_oauth_token` / `acp/anthropic_api_key`) read through the
  *      credential broker for policy enforcement and audit logging.
- * After resolution, this asserts the token is present (from either route)
+ *   2. Git auth (optional) — `GH_TOKEN` from `acp.agents.<id>.env` or the
+ *      secure store (`acp/git_token`). Injected when present; never required.
+ * After resolution, this asserts at least one LLM credential is present
  * before spawning. The "fail-fast" throw is symmetric with the existing
  * `binary_not_found` preflight in `resolveAcpAgent` and strictly better
  * than a `warn` + zombie subprocess 10 seconds later.
@@ -95,24 +121,36 @@ export async function prepareAgentEnv(
   const commandBasename = basename(agentConfig.command);
 
   if (commandBasename === "claude-agent-acp") {
+    // LLM auth: prefer the OAuth token, fall back to an Anthropic API key.
+    await resolveAcpCredential(
+      env,
+      "CLAUDE_CODE_OAUTH_TOKEN",
+      "claude_oauth_token",
+      "Claude OAuth token for ACP agent authentication",
+    );
     if (!env.CLAUDE_CODE_OAUTH_TOKEN) {
-      ensureAcpTokenPolicy();
-      await credentialBroker.serverUse<void>({
-        service: "acp",
-        field: "claude_oauth_token",
-        toolName: ACP_SPAWN_TOOL,
-        execute: async (token) => {
-          env.CLAUDE_CODE_OAUTH_TOKEN = token;
-        },
-      });
-    }
-    if (!env.CLAUDE_CODE_OAUTH_TOKEN) {
-      throw new FailedDependencyError(
-        "claude-agent-acp requires CLAUDE_CODE_OAUTH_TOKEN. " +
-          "Run: assistant credentials set --service acp --field claude_oauth_token <token> " +
-          "(or set it under acp.agents.<id>.env in config.json).",
+      await resolveAcpCredential(
+        env,
+        "ANTHROPIC_API_KEY",
+        "anthropic_api_key",
+        "Anthropic API key for ACP agent authentication",
       );
     }
+    if (!env.CLAUDE_CODE_OAUTH_TOKEN && !env.ANTHROPIC_API_KEY) {
+      throw new FailedDependencyError(
+        "claude-agent-acp requires an LLM credential: either CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY. " +
+          "Run: assistant credentials set --service acp --field claude_oauth_token <token> " +
+          "(or --field anthropic_api_key <key>), or set it under acp.agents.<id>.env in config.json.",
+      );
+    }
+
+    // Git auth (optional): inject when present so the agent can clone/push.
+    await resolveAcpCredential(
+      env,
+      "GH_TOKEN",
+      "git_token",
+      "Git token for ACP agent clone/push",
+    );
   }
 
   return { ...agentConfig, env };

--- a/assistant/src/acp/prepare-agent-env.ts
+++ b/assistant/src/acp/prepare-agent-env.ts
@@ -86,24 +86,82 @@ async function resolveAcpCredential(
 }
 
 /**
+ * Resolve an LLM credential into `env` honoring the documented precedence:
+ *
+ *   agent.env explicit  →  vault (broker)  →  ambient process.env
+ *
+ * The two LLM credentials are mutually exclusive at the adapter level — when
+ * both `CLAUDE_CODE_OAUTH_TOKEN` and `ANTHROPIC_API_KEY` are set the adapter
+ * prefers OAuth — so we must NOT inject a competing credential over one the
+ * caller intentionally supplied. Precedence is therefore evaluated as a whole:
+ *
+ *   1. If `agent.env` already carries EITHER LLM credential, it is the
+ *      highest-precedence source. Leave it untouched and inject nothing else
+ *      (no vault/ambient OAuth over an explicit API key, and vice versa).
+ *   2. Otherwise prefer the vault OAuth token, then the vault API key.
+ *   3. Otherwise fall back to the ambient `process.env` OAuth token, then the
+ *      ambient API key. This preserves local users who export a daemon-level
+ *      `ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN`: sibling PR F1 strips
+ *      the daemon's ambient env from the spawned agent, so the only way an
+ *      ambient cred reaches the adapter is for us to read it here and inject
+ *      it via the returned `config.env` (which survives the F1 strip).
+ */
+async function resolveLlmCredential(
+  env: Record<string, string>,
+): Promise<void> {
+  // (1) Explicit agent.env credential wins outright — never compete with it.
+  if (env.CLAUDE_CODE_OAUTH_TOKEN || env.ANTHROPIC_API_KEY) return;
+
+  // (2) Vault: prefer the OAuth token, fall back to an Anthropic API key.
+  await resolveAcpCredential(
+    env,
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "claude_oauth_token",
+    "Claude OAuth token for ACP agent authentication",
+  );
+  if (!env.CLAUDE_CODE_OAUTH_TOKEN) {
+    await resolveAcpCredential(
+      env,
+      "ANTHROPIC_API_KEY",
+      "anthropic_api_key",
+      "Anthropic API key for ACP agent authentication",
+    );
+  }
+  if (env.CLAUDE_CODE_OAUTH_TOKEN || env.ANTHROPIC_API_KEY) return;
+
+  // (3) Ambient process.env: same OAuth-preferred ordering. Injected into the
+  // returned env so it survives F1's spawn-env strip.
+  const ambientOAuth = process.env.CLAUDE_CODE_OAUTH_TOKEN;
+  if (ambientOAuth) {
+    env.CLAUDE_CODE_OAUTH_TOKEN = ambientOAuth;
+    return;
+  }
+  const ambientApiKey = process.env.ANTHROPIC_API_KEY;
+  if (ambientApiKey) {
+    env.ANTHROPIC_API_KEY = ambientApiKey;
+  }
+}
+
+/**
  * Returns a NEW config with any required credentials merged into `env`.
  * Does NOT mutate the input. Throws `FailedDependencyError` if a required
- * credential is missing from both the user-supplied env override and the
- * secure store.
+ * credential is missing from the user-supplied env override, the secure
+ * store, AND the ambient process env.
  *
  * Gating is keyed off the resolved agent COMMAND (basename), not the
  * user-facing agent id, so a custom `acp.agents.my-claude = { command:
  * "claude-agent-acp", ... }` alias still gets the env it needs.
  *
  * For `claude-agent-acp` the agent needs ONE of two LLM credentials, plus
- * an optional git/dev credential so it can clone/push. For each, config.json
- * wins over the vault so explicit user overrides (per-workspace, rotated,
- * etc.) are never silently clobbered:
- *   1. LLM auth — `CLAUDE_CODE_OAUTH_TOKEN` (preferred) OR, as a fallback
- *      when no OAuth token is present, `ANTHROPIC_API_KEY`. Each resolves
- *      from `acp.agents.<id>.env` in `config.json` or the secure store
- *      (`acp/claude_oauth_token` / `acp/anthropic_api_key`) read through the
- *      credential broker for policy enforcement and audit logging.
+ * an optional git/dev credential so it can clone/push.
+ *   1. LLM auth — `CLAUDE_CODE_OAUTH_TOKEN` (preferred) OR `ANTHROPIC_API_KEY`,
+ *      resolved by precedence: explicit `acp.agents.<id>.env` in `config.json`
+ *      wins, then the secure store (`acp/claude_oauth_token` /
+ *      `acp/anthropic_api_key`) read through the credential broker, then the
+ *      ambient `process.env`. Once a source supplies a credential we never
+ *      inject a competing one over it (the adapter prefers OAuth when both are
+ *      set, so an explicit API key must not be shadowed by a vault/ambient
+ *      OAuth token — and vice versa).
  *   2. Git auth (optional) — `GH_TOKEN` from `acp.agents.<id>.env` or the
  *      secure store (`acp/git_token`). Injected when present; never required.
  * After resolution, this asserts at least one LLM credential is present
@@ -121,21 +179,8 @@ export async function prepareAgentEnv(
   const commandBasename = basename(agentConfig.command);
 
   if (commandBasename === "claude-agent-acp") {
-    // LLM auth: prefer the OAuth token, fall back to an Anthropic API key.
-    await resolveAcpCredential(
-      env,
-      "CLAUDE_CODE_OAUTH_TOKEN",
-      "claude_oauth_token",
-      "Claude OAuth token for ACP agent authentication",
-    );
-    if (!env.CLAUDE_CODE_OAUTH_TOKEN) {
-      await resolveAcpCredential(
-        env,
-        "ANTHROPIC_API_KEY",
-        "anthropic_api_key",
-        "Anthropic API key for ACP agent authentication",
-      );
-    }
+    // LLM auth: agent.env explicit → vault → ambient process.env.
+    await resolveLlmCredential(env);
     if (!env.CLAUDE_CODE_OAUTH_TOKEN && !env.ANTHROPIC_API_KEY) {
       throw new FailedDependencyError(
         "claude-agent-acp requires an LLM credential: either CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY. " +


### PR DESCRIPTION
## Summary
- Fall back to broker acp/anthropic_api_key (ANTHROPIC_API_KEY) when no OAuth token; throw only if neither LLM cred is present.
- Inject an optional git/dev credential (acp/git_token) so the agent can clone/push; seed read policies for acp_spawn.

Part of plan: acp-platform-hosted.md (PR 3 of 11)