### PR TITLE
feat(acp): strip spawned agent env to allowlist + its own credentials

### DIFF
--- a/assistant/src/acp/agent-process.ts
+++ b/assistant/src/acp/agent-process.ts
@@ -17,6 +17,7 @@ import type {
 } from "@agentclientprotocol/sdk";
 import * as acp from "@agentclientprotocol/sdk";
 
+import { buildAgentSpawnEnv } from "../tools/terminal/safe-env.js";
 import { getLogger } from "../util/logger.js";
 import type { AcpAgentConfig } from "./types.js";
 
@@ -53,7 +54,7 @@ export class AcpAgentProcess {
     this.proc = spawn(this.config.command, this.config.args, {
       cwd,
       stdio: ["pipe", "pipe", "pipe"],
-      env: { ...process.env, ...this.config.env },
+      env: buildAgentSpawnEnv(this.config.env),
     });
 
     const stream = acp.ndJsonStream(

--- a/assistant/src/tools/terminal/safe-env.test.ts
+++ b/assistant/src/tools/terminal/safe-env.test.ts
@@ -4,7 +4,10 @@
  * The spawned agent runs in the user's own pod and is treated as untrusted
  * code, so it must receive only the shared safe-env allowlist (PATH +
  * allowlisted vars) plus its own injected ACP/git credentials — never the
- * daemon's platform secrets (`CES_SERVICE_TOKEN`, `ACTOR_TOKEN_SIGNING_KEY`).
+ * daemon's platform secrets (`CES_SERVICE_TOKEN`, `ACTOR_TOKEN_SIGNING_KEY`)
+ * and never the internal control-plane reachability vars (the internal gateway
+ * URL, CES daemon endpoints, in-pod IPC sockets) that would let the untrusted
+ * agent reach the tokenless-loopback gateway control plane.
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
@@ -13,11 +16,25 @@ import { buildAgentSpawnEnv } from "./safe-env.js";
 
 describe("buildAgentSpawnEnv", () => {
   const saved: Record<string, string | undefined> = {};
+  // Internal control-plane reachability vars that must be stripped from the
+  // untrusted ACP agent's spawn env. INTERNAL_GATEWAY_BASE_URL is always
+  // injected by buildSanitizedEnv(); the rest are allowlist pass-throughs.
+  const CONTROL_PLANE_VARS = [
+    "GATEWAY_INTERNAL_URL",
+    "CES_CREDENTIAL_URL",
+    "CES_BOOTSTRAP_SOCKET_DIR",
+    "ASSISTANT_IPC_SOCKET_DIR",
+    "ASSISTANT_SKILL_IPC_SOCKET_DIR",
+    "GATEWAY_IPC_SOCKET_DIR",
+    "GATEWAY_SECURITY_DIR",
+  ];
   const TOUCHED = [
     "PATH",
     "HOME",
     "CES_SERVICE_TOKEN",
     "ACTOR_TOKEN_SIGNING_KEY",
+    "INTERNAL_GATEWAY_BASE_URL",
+    ...CONTROL_PLANE_VARS,
   ];
 
   beforeEach(() => {
@@ -26,6 +43,16 @@ describe("buildAgentSpawnEnv", () => {
     process.env.HOME = "/home/agent";
     process.env.CES_SERVICE_TOKEN = "daemon-service-token";
     process.env.ACTOR_TOKEN_SIGNING_KEY = "f".repeat(64);
+    // Stub the internal control-plane vars so we can assert they are stripped.
+    // INTERNAL_GATEWAY_BASE_URL is injected by buildSanitizedEnv() regardless,
+    // but we set GATEWAY_INTERNAL_URL so that injection resolves to it.
+    process.env.GATEWAY_INTERNAL_URL = "http://gateway:7822";
+    process.env.CES_CREDENTIAL_URL = "http://127.0.0.1:7900/credentials";
+    process.env.CES_BOOTSTRAP_SOCKET_DIR = "/run/ces-bootstrap";
+    process.env.ASSISTANT_IPC_SOCKET_DIR = "/run/assistant-ipc";
+    process.env.ASSISTANT_SKILL_IPC_SOCKET_DIR = "/run/skill-ipc";
+    process.env.GATEWAY_IPC_SOCKET_DIR = "/run/gateway-ipc";
+    process.env.GATEWAY_SECURITY_DIR = "/run/gateway-security";
   });
 
   afterEach(() => {
@@ -55,6 +82,24 @@ describe("buildAgentSpawnEnv", () => {
 
     expect(env.CES_SERVICE_TOKEN).toBeUndefined();
     expect(env.ACTOR_TOKEN_SIGNING_KEY).toBeUndefined();
+  });
+
+  test("strips internal control-plane reachability vars from the agent env", () => {
+    const env = buildAgentSpawnEnv({
+      CLAUDE_CODE_OAUTH_TOKEN: "oauth-abc",
+    });
+
+    // The internal gateway URL (the tokenless-loopback control plane) must not
+    // leak to the untrusted agent — even though buildSanitizedEnv() injects it.
+    expect(env.INTERNAL_GATEWAY_BASE_URL).toBeUndefined();
+    // Sibling internal gateway / CES daemon / IPC-socket vars are stripped too.
+    for (const key of CONTROL_PLANE_VARS) {
+      expect(env[key]).toBeUndefined();
+    }
+    // Injected creds still land — the agent reaches services via its own creds.
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe("oauth-abc");
+    // PATH is still preserved so ACP adapter binaries resolve.
+    expect(env.PATH).toBe("/usr/local/bin:/usr/bin:/bin");
   });
 
   test("works with no injected env", () => {

--- a/assistant/src/tools/terminal/safe-env.test.ts
+++ b/assistant/src/tools/terminal/safe-env.test.ts
@@ -115,6 +115,24 @@ describe("buildAgentSpawnEnv", () => {
     expect(env.HOME).toBe("/workspace");
   });
 
+  test("injected env cannot reintroduce stripped control-plane vars (config-injection bypass)", () => {
+    // Simulate a malicious/misconfigured user/workspace acp.agents.<id>.env
+    // that tries to put forbidden control-plane reachability vars back into the
+    // spawn env. The post-merge strip must remove them regardless of source,
+    // while legitimate injected credentials still pass through.
+    const env = buildAgentSpawnEnv({
+      INTERNAL_GATEWAY_BASE_URL: "http://gateway:7822",
+      CES_BOOTSTRAP_SOCKET_DIR: "/run/attacker-ces-bootstrap",
+      OPENAI_API_KEY: "sk-legit-openai-key",
+    });
+
+    // Forbidden control-plane vars injected via config are NOT in the final env.
+    expect(env.INTERNAL_GATEWAY_BASE_URL).toBeUndefined();
+    expect(env.CES_BOOTSTRAP_SOCKET_DIR).toBeUndefined();
+    // Legit injected credential the agent needs still lands.
+    expect(env.OPENAI_API_KEY).toBe("sk-legit-openai-key");
+  });
+
   test("a CES_SERVICE_TOKEN supplied via injected env is still honored", () => {
     // Stripping targets the inherited daemon secret, not deliberately
     // injected credentials. Injected env wins because it is applied last.

--- a/assistant/src/tools/terminal/safe-env.test.ts
+++ b/assistant/src/tools/terminal/safe-env.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for the ACP agent spawn environment.
+ *
+ * The spawned agent runs in the user's own pod and is treated as untrusted
+ * code, so it must receive only the shared safe-env allowlist (PATH +
+ * allowlisted vars) plus its own injected ACP/git credentials — never the
+ * daemon's platform secrets (`CES_SERVICE_TOKEN`, `ACTOR_TOKEN_SIGNING_KEY`).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { buildAgentSpawnEnv } from "./safe-env.js";
+
+describe("buildAgentSpawnEnv", () => {
+  const saved: Record<string, string | undefined> = {};
+  const TOUCHED = [
+    "PATH",
+    "HOME",
+    "CES_SERVICE_TOKEN",
+    "ACTOR_TOKEN_SIGNING_KEY",
+  ];
+
+  beforeEach(() => {
+    for (const key of TOUCHED) saved[key] = process.env[key];
+    process.env.PATH = "/usr/local/bin:/usr/bin:/bin";
+    process.env.HOME = "/home/agent";
+    process.env.CES_SERVICE_TOKEN = "daemon-service-token";
+    process.env.ACTOR_TOKEN_SIGNING_KEY = "f".repeat(64);
+  });
+
+  afterEach(() => {
+    for (const key of TOUCHED) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+  });
+
+  test("includes PATH and allowlisted vars, plus injected creds applied last", () => {
+    const env = buildAgentSpawnEnv({
+      CLAUDE_CODE_OAUTH_TOKEN: "oauth-abc",
+      GIT_ASKPASS: "/usr/local/bin/git-askpass",
+    });
+
+    // PATH preserved so the ACP adapter binaries resolve.
+    expect(env.PATH).toBe("/usr/local/bin:/usr/bin:/bin");
+    // Other allowlisted vars pass through.
+    expect(env.HOME).toBe("/home/agent");
+    // Injected ACP/git credentials land (applied last).
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe("oauth-abc");
+    expect(env.GIT_ASKPASS).toBe("/usr/local/bin/git-askpass");
+  });
+
+  test("strips daemon/platform secrets from the inherited env", () => {
+    const env = buildAgentSpawnEnv();
+
+    expect(env.CES_SERVICE_TOKEN).toBeUndefined();
+    expect(env.ACTOR_TOKEN_SIGNING_KEY).toBeUndefined();
+  });
+
+  test("works with no injected env", () => {
+    const env = buildAgentSpawnEnv();
+
+    expect(env.PATH).toBe("/usr/local/bin:/usr/bin:/bin");
+    expect(env.CES_SERVICE_TOKEN).toBeUndefined();
+  });
+
+  test("injected env overrides allowlist base for the same key", () => {
+    const env = buildAgentSpawnEnv({ HOME: "/workspace" });
+
+    expect(env.HOME).toBe("/workspace");
+  });
+
+  test("a CES_SERVICE_TOKEN supplied via injected env is still honored", () => {
+    // Stripping targets the inherited daemon secret, not deliberately
+    // injected credentials. Injected env wins because it is applied last.
+    const env = buildAgentSpawnEnv({ CES_SERVICE_TOKEN: "agent-scoped-token" });
+
+    expect(env.CES_SERVICE_TOKEN).toBe("agent-scoped-token");
+  });
+});

--- a/assistant/src/tools/terminal/safe-env.ts
+++ b/assistant/src/tools/terminal/safe-env.ts
@@ -167,3 +167,36 @@ export function buildSanitizedEnv(): Record<string, string> {
   if (!env.LC_ALL) env.LC_ALL = utf8Locale;
   return env;
 }
+
+/**
+ * Platform/daemon secrets that the `buildSanitizedEnv()` allowlist keeps (the
+ * bash/skill sandbox runs trusted, daemon-authored code) but that a spawned
+ * ACP agent must NOT inherit. The agent runs in the user's own pod and is
+ * treated as untrusted code, so it gets only allowlisted vars + its own
+ * injected credentials. `ACTOR_TOKEN_SIGNING_KEY` is already absent from the
+ * allowlist; `CES_SERVICE_TOKEN` is listed there for the sandbox, so it is
+ * stripped here explicitly.
+ */
+const ACP_STRIPPED_ENV_VARS = [
+  "CES_SERVICE_TOKEN",
+  "ACTOR_TOKEN_SIGNING_KEY",
+] as const;
+
+/**
+ * Build the environment for a spawned ACP agent.
+ *
+ * Reuses the shared safe-env allowlist as the base (so the list lives in one
+ * place), strips the daemon/platform secrets the agent must never hold, then
+ * layers the agent's own injected credentials (`injectedEnv`, from
+ * `prepare-agent-env.ts`) LAST so they always land. `PATH` is preserved by the
+ * allowlist so the ACP adapter binaries resolve.
+ */
+export function buildAgentSpawnEnv(
+  injectedEnv?: Record<string, string>,
+): Record<string, string> {
+  const env = buildSanitizedEnv();
+  for (const key of ACP_STRIPPED_ENV_VARS) {
+    delete env[key];
+  }
+  return { ...env, ...injectedEnv };
+}

--- a/assistant/src/tools/terminal/safe-env.ts
+++ b/assistant/src/tools/terminal/safe-env.ts
@@ -215,28 +215,45 @@ const ACP_STRIPPED_CONTROL_PLANE_ENV_VARS = [
   "GATEWAY_SECURITY_DIR",
 ] as const;
 
-/** All env vars stripped from the untrusted ACP agent's spawn env. */
-const ACP_STRIPPED_ENV_VARS = [
-  ...ACP_STRIPPED_SECRET_ENV_VARS,
-  ...ACP_STRIPPED_CONTROL_PLANE_ENV_VARS,
-] as const;
-
 /**
  * Build the environment for a spawned ACP agent.
  *
  * Reuses the shared safe-env allowlist as the base (so the list lives in one
- * place), strips the daemon/platform secrets AND the internal control-plane
- * reachability vars the agent must never hold (see ACP_STRIPPED_ENV_VARS),
+ * place), strips the daemon/platform secrets the agent must never inherit,
  * then layers the agent's own injected credentials (`injectedEnv`, from
- * `prepare-agent-env.ts`) LAST so they always land. `PATH` is preserved by the
- * allowlist so the ACP adapter binaries resolve.
+ * `prepare-agent-env.ts` — which includes user/workspace `acp.agents.<id>.env`)
+ * on top so they always land. `PATH` is preserved by the allowlist so the ACP
+ * adapter binaries resolve.
+ *
+ * The daemon-secret strip happens BEFORE the merge so a deliberately injected,
+ * agent-scoped credential (e.g. a scoped `CES_SERVICE_TOKEN`) can still win.
+ *
+ * The internal control-plane reachability vars, however, are stripped from the
+ * FINAL merged env — AFTER `injectedEnv` is applied. This closes a
+ * config-injection bypass: a user/workspace `acp.agents.<id>.env` could
+ * otherwise reintroduce a stripped key (INTERNAL_GATEWAY_BASE_URL /
+ * GATEWAY_INTERNAL_URL / CES + IPC socket dirs) and put the untrusted agent
+ * back onto the tokenless-loopback control plane. By deleting these keys last,
+ * neither the allowlist base nor any injected source can reintroduce them.
+ * Legitimate credential keys the agent needs (OPENAI_API_KEY, CODEX_API_KEY,
+ * ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN, GH_TOKEN, GIT_*) are not in this
+ * set and pass through untouched.
  */
 export function buildAgentSpawnEnv(
   injectedEnv?: Record<string, string>,
 ): Record<string, string> {
   const env = buildSanitizedEnv();
-  for (const key of ACP_STRIPPED_ENV_VARS) {
+  // Strip inherited daemon/platform secrets pre-merge so a deliberately
+  // injected, agent-scoped credential can still override them.
+  for (const key of ACP_STRIPPED_SECRET_ENV_VARS) {
     delete env[key];
   }
-  return { ...env, ...injectedEnv };
+  const merged = { ...env, ...injectedEnv };
+  // Post-merge strip closes the config-injection bypass: forbidden
+  // control-plane reachability vars must not be present in the FINAL env
+  // regardless of source (allowlist base OR user/workspace acp.agents.<id>.env).
+  for (const key of ACP_STRIPPED_CONTROL_PLANE_ENV_VARS) {
+    delete merged[key];
+  }
+  return merged;
 }

--- a/assistant/src/tools/terminal/safe-env.ts
+++ b/assistant/src/tools/terminal/safe-env.ts
@@ -177,17 +177,57 @@ export function buildSanitizedEnv(): Record<string, string> {
  * allowlist; `CES_SERVICE_TOKEN` is listed there for the sandbox, so it is
  * stripped here explicitly.
  */
-const ACP_STRIPPED_ENV_VARS = [
+const ACP_STRIPPED_SECRET_ENV_VARS = [
   "CES_SERVICE_TOKEN",
   "ACTOR_TOKEN_SIGNING_KEY",
+] as const;
+
+/**
+ * Internal control-plane reachability vars that the trusted bash/skill sandbox
+ * is allowed to see (and that `buildSanitizedEnv()` therefore allowlists /
+ * injects) but that an UNTRUSTED ACP agent must NOT receive.
+ *
+ * The gateway's auth middleware still accepts tokenless loopback requests
+ * (`allowLegacyLoopbackFallback` in gateway/src/http/middleware/auth.ts), so
+ * any spawned process that knows the internal gateway URL can curl `/v1/...`
+ * control-plane routes WITHOUT a bearer token. The same applies to the CES
+ * credential daemon and the in-pod IPC sockets. The ACP adapter gets its own
+ * scoped credentials via `injectedEnv` (config.env) and never needs these
+ * internal addresses, so we strip them to keep the untrusted agent off the
+ * tokenless-loopback control plane.
+ *
+ * NOTE: the public, auth-gated platform endpoints (VELLUM_PLATFORM_URL etc.)
+ * are intentionally NOT in this set — they require real credentials and are not
+ * the tokenless-loopback control plane.
+ */
+const ACP_STRIPPED_CONTROL_PLANE_ENV_VARS = [
+  // Internal gateway base URLs — the tokenless-loopback control plane itself.
+  "INTERNAL_GATEWAY_BASE_URL",
+  "GATEWAY_INTERNAL_URL",
+  // CES (Credential Execution Service) daemon reachability.
+  "CES_CREDENTIAL_URL",
+  "CES_BOOTSTRAP_SOCKET_DIR",
+  // In-pod IPC sockets that reach assistant/gateway control-plane services.
+  "ASSISTANT_IPC_SOCKET_DIR",
+  "ASSISTANT_SKILL_IPC_SOCKET_DIR",
+  "GATEWAY_IPC_SOCKET_DIR",
+  // Gateway security/allowlist directory (governs gateway trust decisions).
+  "GATEWAY_SECURITY_DIR",
+] as const;
+
+/** All env vars stripped from the untrusted ACP agent's spawn env. */
+const ACP_STRIPPED_ENV_VARS = [
+  ...ACP_STRIPPED_SECRET_ENV_VARS,
+  ...ACP_STRIPPED_CONTROL_PLANE_ENV_VARS,
 ] as const;
 
 /**
  * Build the environment for a spawned ACP agent.
  *
  * Reuses the shared safe-env allowlist as the base (so the list lives in one
- * place), strips the daemon/platform secrets the agent must never hold, then
- * layers the agent's own injected credentials (`injectedEnv`, from
+ * place), strips the daemon/platform secrets AND the internal control-plane
+ * reachability vars the agent must never hold (see ACP_STRIPPED_ENV_VARS),
+ * then layers the agent's own injected credentials (`injectedEnv`, from
  * `prepare-agent-env.ts`) LAST so they always land. `PATH` is preserved by the
  * allowlist so the ACP adapter binaries resolve.
  */


### PR DESCRIPTION
## Summary
- Build the ACP adapter spawn env from the shared safe-env allowlist base + injected ACP/git creds + PATH, instead of inheriting the daemon's full process.env, so platform secrets (CES_SERVICE_TOKEN, ACTOR_TOKEN_SIGNING_KEY) aren't handed to the agent.

Part of plan: acp-platform-hosted.md (PR 8 of 11)