### PR TITLE
feat(acp): keep ACP session + adapter process alive across prompts

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -238,8 +238,9 @@ paths:
       operationId: acp_sessions_by_id_delete
       summary: Delete ACP session from history
       description:
-        Remove a persisted ACP session row. Rejects with 409 when the session is still active in memory; idempotent
-        for unknown ids.
+        Remove a persisted ACP session row. Closes (tears down) a live `idle` session first so the delete is
+        consistent. Rejects with 409 only when the session is still running/initializing in memory; idempotent for
+        unknown ids.
       tags:
         - acp
       responses:

--- a/assistant/src/__tests__/acp-session.test.ts
+++ b/assistant/src/__tests__/acp-session.test.ts
@@ -3,7 +3,20 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { VellumAcpClientHandler } from "../acp/client-handler.js";
 import { AcpSessionManager } from "../acp/session-manager.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
+import { getSqlite } from "../memory/db-connection.js";
+import { initializeDb } from "../memory/db-init.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
+
+// Ensure the acp_session_history table exists so terminal-row persistence in
+// the session-cleanup tests has somewhere to write.
+initializeDb();
+
+function readHistoryStatus(id: string): string | null {
+  const row = getSqlite()
+    .query("SELECT status FROM acp_session_history WHERE id = ?")
+    .get(id) as { status: string } | null;
+  return row?.status ?? null;
+}
 
 // ---------------------------------------------------------------------------
 // VellumAcpClientHandler tests
@@ -246,13 +259,20 @@ describe("AcpSessionManager", () => {
   });
 
   describe("session cleanup after prompt", () => {
-    test("completed session is removed from the session map", async () => {
+    test("completed session is retained as idle and its process kept alive", async () => {
+      getSqlite().run("DELETE FROM acp_session_history WHERE id = ?", [
+        "test-session",
+      ]);
+
       let resolvePrompt: (v: { stopReason: string }) => void;
       const promptPromise = new Promise<{ stopReason: string }>((r) => {
         resolvePrompt = r;
       });
 
-      const manager = new AcpSessionManager(1);
+      // Large idle timeout so the reaper doesn't fire during the test — we're
+      // asserting the post-completion idle state, not the timeout teardown
+      // (that path is covered in session-manager-idle.test.ts).
+      const manager = new AcpSessionManager(1, 60_000);
       const sendToVellum = mock(() => {});
 
       // Inject a fake session directly into the manager to avoid needing
@@ -273,6 +293,8 @@ describe("AcpSessionManager", () => {
 
       // Access private sessions map via any cast
       const sessions = (manager as any).sessions as Map<string, any>;
+      const eventBuffers = (manager as any).eventBuffers as Map<string, any[]>;
+      eventBuffers.set("test-session", []);
       const entry = {
         process: fakeProcess,
         state: {
@@ -288,6 +310,9 @@ describe("AcpSessionManager", () => {
         currentPrompt: null as any,
         parentConversationId: "conv-1",
         cwd: "/tmp",
+        command: "codex-acp",
+        idleTimer: null,
+        historyPersisted: false,
       };
       sessions.set("test-session", entry);
 
@@ -307,9 +332,20 @@ describe("AcpSessionManager", () => {
       resolvePrompt!({ stopReason: "end_turn" });
       await bgPromise;
 
-      // Session should be cleaned up
-      expect((manager.getStatus() as any[]).length).toBe(0);
-      expect(fakeProcess.kill).toHaveBeenCalled();
+      // Under the keep-alive lifecycle the completed session is RETAINED in
+      // the map as `idle`, with its adapter process still alive so a
+      // follow-up steer() can reuse the same context. It is reclaimed later
+      // by an explicit close() or the idle-timeout reaper, not here.
+      expect((manager.getStatus() as any[]).length).toBe(1);
+      const state = manager.getStatus("test-session") as any;
+      expect(state.status).toBe("idle");
+      expect(fakeProcess.kill).not.toHaveBeenCalled();
+
+      // The terminal `completed` task is still persisted to history.
+      expect(readHistoryStatus("test-session")).toBe("completed");
+
+      // Clean up the live session + its idle timer.
+      manager.close("test-session");
     });
 
     test("failed session is removed from the session map", async () => {

--- a/assistant/src/__tests__/acp-session.test.ts
+++ b/assistant/src/__tests__/acp-session.test.ts
@@ -313,6 +313,7 @@ describe("AcpSessionManager", () => {
         command: "codex-acp",
         idleTimer: null,
         historyPersisted: false,
+        turnIndex: 0,
       };
       sessions.set("test-session", entry);
 
@@ -383,6 +384,7 @@ describe("AcpSessionManager", () => {
         currentPrompt: null as any,
         parentConversationId: "conv-2",
         cwd: "/tmp",
+        turnIndex: 0,
       };
       sessions.set("test-session-2", entry);
 

--- a/assistant/src/acp/__tests__/session-manager-idle.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-idle.test.ts
@@ -43,6 +43,22 @@ function readStatus(id: string): string | null {
   return row?.status ?? null;
 }
 
+/** All history rows whose id is `<base>` or `<base>:<turn>`, ordered by id. */
+function readTurnRows(
+  base: string,
+): { id: string; status: string; stopReason: string | null }[] {
+  return getSqlite()
+    .query(
+      "SELECT id, status, stop_reason AS stopReason FROM acp_session_history " +
+        "WHERE id = ? OR id LIKE ? ORDER BY id",
+    )
+    .all(base, `${base}:%`) as {
+    id: string;
+    status: string;
+    stopReason: string | null;
+  }[];
+}
+
 interface FakeProcess {
   prompt: (sessionId: string, text: string) => Promise<{ stopReason: string }>;
   kill: () => void;
@@ -120,6 +136,7 @@ function buildIdleSession(opts: {
     command: "codex-acp",
     idleTimer: null,
     historyPersisted: false,
+    turnIndex: 0,
   };
   sessions.set(opts.id, entry);
 
@@ -250,6 +267,64 @@ describe("AcpSessionManager — idle keep-alive lifecycle", () => {
     expect(fakeProcess.killed).toBe(true);
     expect(() => manager.getStatus(id)).toThrow();
     // Row still 'completed' (not overwritten to 'cancelled').
+    expect(readStatus(id)).toBe("completed");
+  });
+
+  test("a reused (steered) idle session's second turn is persisted to its own history row", async () => {
+    const id = "idle-6";
+    const { manager, resolvePrompt } = buildIdleSession({
+      id,
+      parentConversationId: "conv-idle-6",
+    });
+
+    // Turn 0 completes → persisted under the bare id.
+    resolvePrompt({ stopReason: "end_turn" });
+    await flush();
+    expect((manager.getStatus(id) as { status: string }).status).toBe("idle");
+
+    // Reuse the idle session for a second turn, then complete it.
+    await manager.steer(id, "now do more");
+    resolvePrompt({ stopReason: "max_tokens" });
+    await flush();
+
+    // Both turns are durably recorded as distinct rows — the second turn was
+    // NOT silently dropped by onConflictDoNothing against the first turn's id.
+    const rows = readTurnRows(id);
+    expect(rows.map((r) => r.id)).toEqual([id, `${id}:1`]);
+    expect(rows.map((r) => r.status)).toEqual(["completed", "completed"]);
+    // Each row carries its own turn's stop reason.
+    expect(rows[0]!.stopReason).toBe("end_turn");
+    expect(rows[1]!.stopReason).toBe("max_tokens");
+  });
+
+  test("cancel() of an idle session tears it down (process killed, slot + timer freed)", async () => {
+    const id = "idle-7";
+    const { manager, fakeProcess, resolvePrompt } = buildIdleSession({
+      id,
+      // Small timeout so a leaked timer would be observable; teardown must
+      // clear it.
+      idleTimeoutMs: 10,
+      parentConversationId: "conv-idle-7",
+    });
+
+    resolvePrompt({ stopReason: "end_turn" });
+    await flush();
+    expect((manager.getStatus(id) as { status: string }).status).toBe("idle");
+
+    // The idle session has no in-flight prompt — cancel must drive teardown
+    // directly rather than wait on a catch handler that will never fire.
+    await manager.cancel(id);
+
+    // Process killed, session removed from the map.
+    expect(fakeProcess.killed).toBe(true);
+    expect(() => manager.getStatus(id)).toThrow();
+
+    // The idle timer was cleared: even after the timeout elapses, the reaper
+    // does not run against a dangling entry (no throw, state unchanged).
+    await new Promise((r) => setTimeout(r, 40));
+    expect(() => manager.getStatus(id)).toThrow();
+
+    // Completed history row was not clobbered to 'cancelled'.
     expect(readStatus(id)).toBe("completed");
   });
 });

--- a/assistant/src/acp/__tests__/session-manager-idle.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-idle.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Tests for AcpSessionManager's keep-alive idle lifecycle (PR E1):
+ *
+ * - After a prompt completes the session stays alive in `idle` status with
+ *   its process intact (it is NOT torn down), while a terminal `completed`
+ *   row is still persisted to `acp_session_history`.
+ * - An idle session is reusable: `steer()` runs a follow-up prompt on the
+ *   same process and resets per-turn streaming state.
+ * - The idle-timeout reaper reclaims an idle session (process killed, slot
+ *   freed) once the timeout elapses, without re-persisting history.
+ * - `getLiveSessionForConversation` finds the live (running/idle) session for
+ *   a conversation so follow-ups (PR E2) can reattach.
+ *
+ * Like session-manager-persistence.test.ts, these inject a fake
+ * AcpAgentProcess directly into the session map to drive prompt
+ * completion/timing deterministically without spawning a child process.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import { VellumAcpClientHandler } from "../../acp/client-handler.js";
+import { AcpSessionManager } from "../../acp/session-manager.js";
+import type { ServerMessage } from "../../daemon/message-protocol.js";
+import { getSqlite } from "../../memory/db-connection.js";
+import { initializeDb } from "../../memory/db-init.js";
+initializeDb();
+
+function clearHistory() {
+  getSqlite().run("DELETE FROM acp_session_history");
+}
+
+function readStatus(id: string): string | null {
+  const row = getSqlite()
+    .query("SELECT status FROM acp_session_history WHERE id = ?")
+    .get(id) as { status: string } | null;
+  return row?.status ?? null;
+}
+
+interface FakeProcess {
+  prompt: (sessionId: string, text: string) => Promise<{ stopReason: string }>;
+  kill: () => void;
+  cancel: () => Promise<void>;
+  killed: boolean;
+  promptCalls: string[];
+}
+
+/**
+ * Injects a fake session into the manager map (matching spawn()'s wiring) and
+ * fires its first prompt. The returned `resolvePrompt` drives the prompt to
+ * completion. `idleTimeoutMs` lets callers exercise the reaper.
+ */
+function buildIdleSession(opts: {
+  id: string;
+  parentConversationId: string;
+  idleTimeoutMs?: number;
+}): {
+  manager: AcpSessionManager;
+  fakeProcess: FakeProcess;
+  resolvePrompt: (v: { stopReason: string }) => void;
+  sent: ServerMessage[];
+} {
+  const manager = new AcpSessionManager(4, opts.idleTimeoutMs ?? 60_000);
+  const sent: ServerMessage[] = [];
+  const sendToVellum = (msg: ServerMessage) => sent.push(msg);
+
+  // Each prompt() call gets a fresh, independently-resolvable promise so a
+  // follow-up steer() doesn't inherit the first turn's already-resolved one.
+  let resolvePrompt!: (v: { stopReason: string }) => void;
+
+  const fakeProcess: FakeProcess = {
+    promptCalls: [],
+    killed: false,
+    prompt(_sessionId: string, text: string) {
+      this.promptCalls.push(text);
+      return new Promise<{ stopReason: string }>((res) => {
+        resolvePrompt = res;
+      });
+    },
+    kill() {
+      this.killed = true;
+    },
+    cancel: () => Promise.resolve(),
+  };
+
+  const sessions = (manager as unknown as { sessions: Map<string, unknown> })
+    .sessions;
+  const eventBuffers = (
+    manager as unknown as { eventBuffers: Map<string, unknown[]> }
+  ).eventBuffers;
+  eventBuffers.set(opts.id, []);
+
+  const clientHandler = new VellumAcpClientHandler(
+    opts.id,
+    sendToVellum,
+    opts.parentConversationId,
+  );
+
+  const entry = {
+    process: fakeProcess,
+    state: {
+      id: opts.id,
+      agentId: "agent-X",
+      acpSessionId: "proto-X",
+      parentConversationId: opts.parentConversationId,
+      status: "running",
+      startedAt: Date.now(),
+    },
+    clientHandler,
+    sendToVellum,
+    currentPrompt: null as Promise<unknown> | null,
+    parentConversationId: opts.parentConversationId,
+    cwd: "/tmp",
+    command: "codex-acp",
+    idleTimer: null,
+    historyPersisted: false,
+  };
+  sessions.set(opts.id, entry);
+
+  entry.currentPrompt = (
+    manager as unknown as {
+      firePromptInBackground: (
+        id: string,
+        e: typeof entry,
+        protoId: string,
+        msg: string,
+      ) => Promise<unknown>;
+    }
+  ).firePromptInBackground(opts.id, entry, "proto-X", "do work");
+
+  // `resolvePrompt` always resolves the most recent prompt() promise — the
+  // fake reassigns it on every call, so steer() reuse can be driven too.
+  return {
+    manager,
+    fakeProcess,
+    resolvePrompt: (v: { stopReason: string }) => resolvePrompt(v),
+    sent,
+  };
+}
+
+async function flush() {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("AcpSessionManager — idle keep-alive lifecycle", () => {
+  beforeEach(() => {
+    clearHistory();
+  });
+
+  test("a completed prompt leaves the session idle and alive, with a persisted 'completed' row", async () => {
+    const id = "idle-1";
+    const { manager, fakeProcess, resolvePrompt } = buildIdleSession({
+      id,
+      parentConversationId: "conv-idle-1",
+    });
+
+    resolvePrompt({ stopReason: "end_turn" });
+    await flush();
+
+    // In-memory: status idle, process NOT killed, still in the map.
+    const state = manager.getStatus(id) as { status: string };
+    expect(state.status).toBe("idle");
+    expect(fakeProcess.killed).toBe(false);
+
+    // History: a terminal 'completed' row was written.
+    expect(readStatus(id)).toBe("completed");
+  });
+
+  test("getLiveSessionForConversation finds the idle session for its conversation", async () => {
+    const id = "idle-2";
+    const { manager, resolvePrompt } = buildIdleSession({
+      id,
+      parentConversationId: "conv-idle-2",
+    });
+
+    resolvePrompt({ stopReason: "end_turn" });
+    await flush();
+
+    const live = manager.getLiveSessionForConversation("conv-idle-2");
+    expect(live).not.toBeNull();
+    expect(live!.id).toBe(id);
+    expect(live!.status).toBe("idle");
+
+    expect(manager.getLiveSessionForConversation("nope")).toBeNull();
+  });
+
+  test("steer() reuses an idle session — same process, status back to running", async () => {
+    const id = "idle-3";
+    const { manager, fakeProcess, resolvePrompt } = buildIdleSession({
+      id,
+      parentConversationId: "conv-idle-3",
+    });
+
+    resolvePrompt({ stopReason: "end_turn" });
+    await flush();
+    expect((manager.getStatus(id) as { status: string }).status).toBe("idle");
+
+    await manager.steer(id, "now change Y");
+
+    // Same process reused (not killed); a second prompt was sent.
+    expect(fakeProcess.killed).toBe(false);
+    expect(fakeProcess.promptCalls).toEqual(["do work", "now change Y"]);
+    expect((manager.getStatus(id) as { status: string }).status).toBe(
+      "running",
+    );
+  });
+
+  test("idle-timeout reaper closes the session (process killed, slot freed)", async () => {
+    const id = "idle-4";
+    const { manager, fakeProcess, resolvePrompt } = buildIdleSession({
+      id,
+      parentConversationId: "conv-idle-4",
+      idleTimeoutMs: 10,
+    });
+
+    resolvePrompt({ stopReason: "end_turn" });
+    await flush();
+    expect((manager.getStatus(id) as { status: string }).status).toBe("idle");
+
+    // Wait for the 10ms idle reaper to fire.
+    await new Promise((r) => setTimeout(r, 40));
+
+    expect(fakeProcess.killed).toBe(true);
+    // Session removed from the map.
+    expect(() => manager.getStatus(id)).toThrow();
+    // History row remains 'completed' — the reaper did not clobber it.
+    expect(readStatus(id)).toBe("completed");
+  });
+
+  test("explicit close() of an idle session tears it down without re-persisting", async () => {
+    const id = "idle-5";
+    const { manager, fakeProcess, resolvePrompt } = buildIdleSession({
+      id,
+      parentConversationId: "conv-idle-5",
+    });
+
+    resolvePrompt({ stopReason: "end_turn" });
+    await flush();
+
+    manager.close(id);
+
+    expect(fakeProcess.killed).toBe(true);
+    expect(() => manager.getStatus(id)).toThrow();
+    // Row still 'completed' (not overwritten to 'cancelled').
+    expect(readStatus(id)).toBe("completed");
+  });
+});

--- a/assistant/src/acp/client-handler.ts
+++ b/assistant/src/acp/client-handler.ts
@@ -59,6 +59,15 @@ export class VellumAcpClientHandler implements Client {
     return this.accumulatedText;
   }
 
+  /**
+   * Clears accumulated per-turn state so a reused (idle → running) session's
+   * follow-up prompt starts with a fresh response buffer instead of
+   * inheriting the previous turn's text.
+   */
+  resetTurn(): void {
+    this.accumulatedText = "";
+  }
+
   constructor(
     private readonly acpSessionId: string,
     private readonly sendToVellum: (msg: ServerMessage) => void,

--- a/assistant/src/acp/index.ts
+++ b/assistant/src/acp/index.ts
@@ -13,7 +13,10 @@ let manager: AcpSessionManager | null = null;
 export function getAcpSessionManager(): AcpSessionManager {
   if (!manager) {
     const config = getConfig();
-    manager = new AcpSessionManager(config.acp.maxConcurrentSessions);
+    manager = new AcpSessionManager(
+      config.acp.maxConcurrentSessions,
+      config.acp.idleTimeoutMs,
+    );
   }
   return manager;
 }

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -64,6 +64,16 @@ interface SessionEntry {
    * outcome with a `cancelled` status.
    */
   historyPersisted: boolean;
+  /**
+   * Zero-based index of the current prompt turn. The session and its ACP
+   * protocol id are reused across turns when an idle session is steered, but
+   * each turn must get its own `acp_session_history` row — otherwise the
+   * `id`-keyed insert silently no-ops (`onConflictDoNothing`) on the second
+   * turn and drops its event log / stop reason. `historyRowId()` derives a
+   * per-turn primary key from this; turn 0 keeps the bare `acpSessionId` so
+   * the first turn's row id (and all existing behavior) is unchanged.
+   */
+  turnIndex: number;
 }
 
 export class AcpSessionManager {
@@ -197,6 +207,7 @@ export class AcpSessionManager {
       command: agentConfig.command,
       idleTimer: null,
       historyPersisted: false,
+      turnIndex: 0,
     };
 
     this.sessions.set(acpSessionId, entry);
@@ -291,6 +302,9 @@ export class AcpSessionManager {
     entry.clientHandler.resetTurn();
     this.eventBuffers.set(acpSessionId, []);
     entry.historyPersisted = false;
+    // Advance the turn so this reused turn persists to its own history row
+    // instead of no-op-conflicting against the prior turn's row.
+    entry.turnIndex += 1;
     entry.state.status = "running";
     entry.state.completedAt = undefined;
     entry.state.stopReason = undefined;
@@ -340,6 +354,24 @@ export class AcpSessionManager {
     if (!entry) {
       throw new Error(`ACP session "${acpSessionId}" not found`);
     }
+
+    // An `idle` session has no in-flight prompt, so there is no catch handler
+    // to persist + tear it down. Cancelling it must therefore drive the
+    // close/teardown path directly — otherwise the adapter process, idle
+    // timer, and session-map entry leak until the daemon restarts. Its
+    // completed task already wrote a terminal history row, so `close()` skips
+    // re-persisting (and won't clobber the durable `completed` row).
+    if (entry.state.status === "idle") {
+      await entry.process.cancel(entry.state.acpSessionId).catch((err) => {
+        log.warn(
+          { acpSessionId, err },
+          "Failed to send ACP cancel before tearing down idle session",
+        );
+      });
+      this.close(acpSessionId);
+      return;
+    }
+
     await entry.process.cancel(entry.state.acpSessionId);
     entry.state.status = "cancelled";
     entry.state.completedAt = Date.now();
@@ -479,6 +511,18 @@ export class AcpSessionManager {
   }
 
   /**
+   * Derives the `acp_session_history` primary key for a given turn. Turn 0
+   * (the spawn prompt) keeps the bare `acpSessionId` so first-turn rows — and
+   * the in-memory→DB id merge in the sessions list — are unchanged. Reused
+   * turns (via `steer()` on an idle session) get a `<acpSessionId>:<turn>`
+   * suffix so each turn persists to its own row instead of silently
+   * conflicting against the first turn's already-written row.
+   */
+  private historyRowId(acpSessionId: string, turnIndex: number): string {
+    return turnIndex === 0 ? acpSessionId : `${acpSessionId}:${turnIndex}`;
+  }
+
+  /**
    * Persists the session's final state + buffered event log to
    * `acp_session_history`, then frees the buffer entry. Best-effort: a DB
    * failure is logged but does not propagate, since the session has already
@@ -493,7 +537,7 @@ export class AcpSessionManager {
       getDb()
         .insert(acpSessionHistory)
         .values({
-          id: acpSessionId,
+          id: this.historyRowId(acpSessionId, entry.turnIndex),
           agentId: entry.state.agentId,
           acpSessionId: entry.state.acpSessionId,
           parentConversationId: entry.parentConversationId,

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -519,7 +519,9 @@ export class AcpSessionManager {
    * conflicting against the first turn's already-written row.
    */
   private historyRowId(acpSessionId: string, turnIndex: number): string {
-    return turnIndex === 0 ? acpSessionId : `${acpSessionId}:${turnIndex}`;
+    // First turn (turnIndex 0, or unset on manually-built entries) keeps the
+    // bare session id; only reused turns get a `:<n>` suffix.
+    return turnIndex ? `${acpSessionId}:${turnIndex}` : acpSessionId;
   }
 
   /**

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -24,6 +24,11 @@ const log = getLogger("acp:session-manager");
 const MAX_BUFFER_EVENTS = 200;
 /** Maximum aggregate JSON size of a session's ring buffer, in bytes. */
 const MAX_BUFFER_BYTES = 256 * 1024;
+/**
+ * Default idle timeout, used when the manager is constructed without one
+ * (e.g. tests). The production value comes from `acp.idleTimeoutMs`.
+ */
+const DEFAULT_IDLE_TIMEOUT_MS = 15 * 60 * 1000;
 
 interface BufferedAcpUpdate {
   /** The wire-shaped update — exactly what was forwarded to clients. */
@@ -44,6 +49,21 @@ interface SessionEntry {
   /** The adapter binary that was spawned. Used to gate resume hints to
    *  the only adapter (claude-agent-acp) whose CLI accepts `--resume`. */
   command: string;
+  /**
+   * Timer that reclaims this session once it has sat `idle` (process alive,
+   * no in-flight prompt) past the configured idle timeout. Armed when a
+   * prompt completes and the session transitions to `idle`; cleared when a
+   * follow-up prompt starts or the session is torn down.
+   */
+  idleTimer: ReturnType<typeof setTimeout> | null;
+  /**
+   * Whether a terminal `acp_session_history` row has already been written
+   * for this session's last completed task. Set when a prompt completes and
+   * the session goes idle (the row reflects that completed task). Prevents a
+   * later close/idle-reap from re-persisting and clobbering the durable
+   * outcome with a `cancelled` status.
+   */
+  historyPersisted: boolean;
 }
 
 export class AcpSessionManager {
@@ -56,7 +76,13 @@ export class AcpSessionManager {
    */
   private eventBuffers = new Map<string, BufferedAcpUpdate[]>();
 
-  constructor(private readonly maxConcurrent: number) {
+  private readonly idleTimeoutMs: number;
+
+  constructor(
+    private readonly maxConcurrent: number,
+    idleTimeoutMs: number = DEFAULT_IDLE_TIMEOUT_MS,
+  ) {
+    this.idleTimeoutMs = idleTimeoutMs;
     this.cleanupStaleRunningRows();
   }
 
@@ -169,6 +195,8 @@ export class AcpSessionManager {
       parentConversationId,
       cwd,
       command: agentConfig.command,
+      idleTimer: null,
+      historyPersisted: false,
     };
 
     this.sessions.set(acpSessionId, entry);
@@ -219,6 +247,11 @@ export class AcpSessionManager {
   /**
    * Sends a follow-up instruction to an existing session.
    *
+   * Works against a `running` session (cancels its in-flight prompt first)
+   * or an `idle` session left alive after a previous prompt completed — the
+   * latter is the multi-turn continuity path: the adapter process and ACP
+   * session are reused so the follow-up builds on the same context.
+   *
    * Cancels any in-flight prompt first, then fires the new prompt in the
    * background with completion/error event handlers (matching spawn's pattern).
    */
@@ -228,11 +261,14 @@ export class AcpSessionManager {
       throw new Error(`ACP session "${acpSessionId}" not found`);
     }
 
-    if (entry.state.status !== "running") {
+    if (entry.state.status !== "running" && entry.state.status !== "idle") {
       throw new Error(
-        `ACP session "${acpSessionId}" is not running (status: ${entry.state.status})`,
+        `ACP session "${acpSessionId}" is not reusable (status: ${entry.state.status})`,
       );
     }
+
+    // Disarm the idle reaper — the session is being reused.
+    this.clearIdleTimer(entry);
 
     // Cancel any in-flight prompt before starting a new one.
     // Clear currentPrompt BEFORE awaiting cancel so the old prompt's
@@ -249,6 +285,17 @@ export class AcpSessionManager {
       }
     }
 
+    // Reset per-turn streaming state so this follow-up's events are buffered
+    // and (on completion) persisted fresh, not appended to the prior task's
+    // already-persisted log.
+    entry.clientHandler.resetTurn();
+    this.eventBuffers.set(acpSessionId, []);
+    entry.historyPersisted = false;
+    entry.state.status = "running";
+    entry.state.completedAt = undefined;
+    entry.state.stopReason = undefined;
+    entry.state.error = undefined;
+
     // Fire new prompt in the background with event handlers
     entry.currentPrompt = this.firePromptInBackground(
       acpSessionId,
@@ -256,6 +303,28 @@ export class AcpSessionManager {
       entry.state.acpSessionId,
       instruction,
     );
+  }
+
+  /**
+   * Returns the live (non-terminal: running or idle) session attached to a
+   * conversation, if any. Used to reattach a follow-up prompt to an existing
+   * session for multi-turn continuity (PR E2). Returns the most recently
+   * started match when several are live for the same conversation.
+   */
+  getLiveSessionForConversation(
+    parentConversationId: string,
+  ): AcpSessionState | null {
+    let best: AcpSessionState | null = null;
+    for (const entry of this.sessions.values()) {
+      if (entry.parentConversationId !== parentConversationId) continue;
+      if (entry.state.status !== "running" && entry.state.status !== "idle") {
+        continue;
+      }
+      if (!best || entry.state.startedAt > best.startedAt) {
+        best = entry.state;
+      }
+    }
+    return best;
   }
 
   /**
@@ -284,6 +353,10 @@ export class AcpSessionManager {
    * session is still in a non-terminal state, mark it cancelled so the
    * persisted row reflects reality. The in-flight prompt's then/catch
    * handler will short-circuit after teardown removes the entry.
+   *
+   * An `idle` session is a special case: its last task already wrote a
+   * terminal `completed` row, so we skip re-persisting (which would only
+   * be a no-op `onConflictDoNothing`) and just tear down the live process.
    */
   close(acpSessionId: string): void {
     const entry = this.sessions.get(acpSessionId);
@@ -297,7 +370,11 @@ export class AcpSessionManager {
       entry.state.status = "cancelled";
       entry.state.completedAt = Date.now();
     }
-    this.persistTerminal(acpSessionId, entry);
+    // Skip re-persisting when the idle session's completed task was already
+    // written to history; otherwise persist the buffered log + terminal row.
+    if (!entry.historyPersisted) {
+      this.persistTerminal(acpSessionId, entry);
+    }
     this.teardownSession(acpSessionId, entry);
   }
 
@@ -305,6 +382,7 @@ export class AcpSessionManager {
    * Denies pending ACP permissions, kills the process, and removes the session.
    */
   private teardownSession(acpSessionId: string, entry: SessionEntry): void {
+    this.clearIdleTimer(entry);
     for (const requestId of entry.clientHandler.pendingRequestIds) {
       const interaction = pendingInteractions.resolve(requestId, "cancelled");
       if (interaction?.directResolve) {
@@ -316,6 +394,40 @@ export class AcpSessionManager {
     // Free the buffer in case persistTerminal hasn't already (e.g. close()
     // before terminal transition).
     this.eventBuffers.delete(acpSessionId);
+  }
+
+  /**
+   * Arms the idle-timeout reaper for a session that just went `idle`. When it
+   * fires the session is closed (process killed, slot freed) unless a
+   * follow-up prompt reused it first. `unref()` so the timer never keeps the
+   * process alive on shutdown.
+   */
+  private armIdleTimer(acpSessionId: string, entry: SessionEntry): void {
+    this.clearIdleTimer(entry);
+    const timer = setTimeout(() => {
+      const current = this.sessions.get(acpSessionId);
+      // Only reap if it's still the same idle session (not reused/closed).
+      if (!current || current !== entry || current.state.status !== "idle") {
+        return;
+      }
+      log.info(
+        { acpSessionId, idleTimeoutMs: this.idleTimeoutMs },
+        "Reclaiming idle ACP session after timeout",
+      );
+      // History was already persisted on completion; close() tears down
+      // without re-persisting.
+      this.close(acpSessionId);
+    }, this.idleTimeoutMs);
+    timer.unref?.();
+    entry.idleTimer = timer;
+  }
+
+  /** Clears a session's idle-timeout reaper if one is armed. */
+  private clearIdleTimer(entry: SessionEntry): void {
+    if (entry.idleTimer) {
+      clearTimeout(entry.idleTimer);
+      entry.idleTimer = null;
+    }
   }
 
   /**
@@ -423,8 +535,14 @@ export class AcpSessionManager {
         // current prompt (not stale from a previous steer), and the status
         // hasn't been set to "cancelled" already.
         if (current && current.currentPrompt === promptPromise) {
-          if (current.state.status !== "cancelled") {
-            current.state.status = "completed";
+          // A concurrent cancel()/close() may have flipped the status to a
+          // terminal state. Only `cancelled` here means the prompt was
+          // explicitly aborted — preserve it and tear down (the abort path
+          // owns persistence). Otherwise the task finished cleanly: persist
+          // a terminal history row but keep the session alive as `idle` so a
+          // follow-up prompt can reuse the same process and context.
+          const wasCancelled = current.state.status === "cancelled";
+          if (!wasCancelled) {
             current.state.completedAt = Date.now();
             current.state.stopReason = response.stopReason;
           }
@@ -439,13 +557,21 @@ export class AcpSessionManager {
             stopReason: response.stopReason,
           });
 
-          // Persist the terminal row + buffered event log before tearing
-          // down (teardown deletes the buffer entry).
-          this.persistTerminal(acpSessionId, current);
-
-          // Free the session slot, deny any pending permissions, and
-          // kill the agent process.
-          this.teardownSession(acpSessionId, current);
+          if (wasCancelled) {
+            // Persist the cancelled terminal row + buffered event log, then
+            // tear the session down (cancel is not a reuse path).
+            this.persistTerminal(acpSessionId, current);
+            this.teardownSession(acpSessionId, current);
+          } else {
+            // Persist the completed task to history (the durable record),
+            // then transition to `idle` and arm the reaper. The process and
+            // ACP session stay alive for a follow-up `steer()`.
+            current.state.status = "completed";
+            this.persistTerminal(acpSessionId, current);
+            current.historyPersisted = true;
+            current.state.status = "idle";
+            this.armIdleTimer(acpSessionId, current);
+          }
 
           // Notify parent session so the LLM sees the agent's output
           const agentLabel = current.state.agentId;

--- a/assistant/src/acp/types.ts
+++ b/assistant/src/acp/types.ts
@@ -23,7 +23,23 @@ export interface AcpSessionState {
   acpSessionId: string;
   /** Conversation that spawned this session. */
   parentConversationId: string;
-  status: "initializing" | "running" | "completed" | "failed" | "cancelled";
+  /**
+   * Session lifecycle status.
+   *
+   * - `initializing` / `running`: a prompt is in flight.
+   * - `idle`: the previous prompt finished and the process is still alive,
+   *   ready to accept a follow-up prompt (multi-turn continuity). A terminal
+   *   `acp_session_history` row already reflects the completed task; the live
+   *   session lingers until reused, idle-timed-out, or explicitly closed.
+   * - `completed` / `failed` / `cancelled`: terminal — the process is gone.
+   */
+  status:
+    | "initializing"
+    | "running"
+    | "idle"
+    | "completed"
+    | "failed"
+    | "cancelled";
   startedAt: number;
   completedAt?: number;
   error?: string;

--- a/assistant/src/config/acp-schema.ts
+++ b/assistant/src/config/acp-schema.ts
@@ -34,6 +34,15 @@ export const AcpConfigSchema = z
       .describe(
         "Maximum number of ACP agent sessions that can run simultaneously",
       ),
+    idleTimeoutMs: z
+      .number()
+      .int()
+      .positive()
+      .default(15 * 60 * 1000)
+      .describe(
+        "How long an idle ACP session (process alive, awaiting a follow-up " +
+          "prompt) is kept before it is reclaimed and its process killed",
+      ),
     agents: z
       .record(z.string(), AcpAgentConfigSchema)
       .default({})

--- a/assistant/src/runtime/routes/acp-routes.test.ts
+++ b/assistant/src/runtime/routes/acp-routes.test.ts
@@ -60,6 +60,12 @@ interface CapturedSpawn {
 
 const capturedSpawns: CapturedSpawn[] = [];
 
+// Records ids passed to manager.close() so the idle delete/bulk-clear tests
+// can assert the session was actually torn down. close() also evicts the
+// in-memory state, mirroring the real teardown (so a subsequent getStatus no
+// longer surfaces the session, matching the real map removal).
+const closedSessionIds: string[] = [];
+
 mock.module("../../acp/index.js", () => ({
   getAcpSessionManager: () => ({
     getStatus: (id?: string) => {
@@ -69,6 +75,12 @@ mock.module("../../acp/index.js", () => ({
       const state = inMemoryStates.get(id);
       if (!state) throw new Error(`ACP session "${id}" not found`);
       return state;
+    },
+    close: (id: string) => {
+      const state = inMemoryStates.get(id);
+      if (!state) throw new Error(`ACP session "${id}" not found`);
+      closedSessionIds.push(id);
+      inMemoryStates.delete(id);
     },
     spawn: async (
       agent: string,
@@ -183,6 +195,7 @@ beforeEach(() => {
   config.setConfig({});
   which.setWhich((cmd) => `/usr/local/bin/${cmd}`);
   capturedSpawns.length = 0;
+  closedSessionIds.length = 0;
   vaultStore.clear();
   metadataStore.clear();
 });
@@ -516,6 +529,45 @@ describe("DELETE /v1/acp/sessions?status=completed", () => {
     );
     expect(listRows()).toHaveLength(1);
   });
+
+  test("closes in-memory idle sessions whose rows are cleared; leaves running untouched", async () => {
+    // An idle session has already written a terminal `completed` row.
+    seedHistoryRow("sess-idle", "completed", 1000);
+    inMemoryStates.set("sess-idle", {
+      id: "sess-idle",
+      agentId: "claude",
+      acpSessionId: "proto-idle",
+      parentConversationId: "conv-1",
+      status: "idle",
+      startedAt: 1000,
+    });
+    // A running session — its (running) row is not terminal, must survive.
+    seedHistoryRow("sess-running", "running", 2000);
+    inMemoryStates.set("sess-running", {
+      id: "sess-running",
+      agentId: "claude",
+      acpSessionId: "proto-running",
+      parentConversationId: "conv-1",
+      status: "running",
+      startedAt: 2000,
+    });
+
+    const handler = getBulkDeleteHandler();
+    const result = (await handler({
+      queryParams: { status: "completed" },
+    })) as { deleted: number };
+
+    // The idle session was closed (torn down) before its row was cleared, so
+    // it won't reappear on the next /acp/sessions refresh.
+    expect(closedSessionIds).toEqual(["sess-idle"]);
+    expect(inMemoryStates.has("sess-idle")).toBe(false);
+    // The running session was NOT closed.
+    expect(inMemoryStates.has("sess-running")).toBe(true);
+
+    // Only the idle session's terminal row was deleted; the running row stays.
+    expect(result.deleted).toBe(1);
+    expect(listRows().map((r) => r.id)).toEqual(["sess-running"]);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -616,6 +668,36 @@ describe("DELETE /v1/acp/sessions/:id", () => {
       pathParams: { id: "does-not-exist" },
     })) as { deleted: boolean };
     expect(result.deleted).toBe(false);
+  });
+
+  test("closes a live idle session, then deletes its row (no 409)", async () => {
+    inMemoryStates.set("sess-idle", {
+      id: "sess-idle",
+      agentId: "claude",
+      acpSessionId: "proto-idle",
+      parentConversationId: "conv-1",
+      status: "idle",
+      startedAt: 1_700_000_000_000,
+      completedAt: 1_700_000_001_000,
+    });
+    insertHistoryRow({ id: "sess-idle", status: "completed" });
+
+    const handler = getDeleteSessionHandler();
+    const result = (await handler({
+      pathParams: { id: "sess-idle" },
+    })) as { deleted: boolean };
+
+    // The idle session was closed (teardown) before the row delete.
+    expect(closedSessionIds).toEqual(["sess-idle"]);
+    expect(inMemoryStates.has("sess-idle")).toBe(false);
+    // The row was removed and success returned — no 409.
+    expect(result.deleted).toBe(true);
+    const remaining = getDb()
+      .select()
+      .from(acpSessionHistory)
+      .where(eq(acpSessionHistory.id, "sess-idle"))
+      .all();
+    expect(remaining).toHaveLength(0);
   });
 
   test("deletes a cancelled in-memory session whose row is in history", async () => {

--- a/assistant/src/runtime/routes/acp-routes.ts
+++ b/assistant/src/runtime/routes/acp-routes.ts
@@ -161,6 +161,32 @@ function bulkDeleteSessions({ queryParams }: RouteHandlerArgs) {
       "status query param is required and must be 'completed'",
     );
   }
+
+  // Close any in-memory `idle` session before clearing its persisted row.
+  // An idle session is terminal-for-affordances on the client (its last task
+  // already wrote a `completed` row), but its adapter process, idle timer, and
+  // map entry are still live. Without closing it here the bulk-clear would wipe
+  // the DB row only for the session to reappear on the next `/acp/sessions`
+  // refresh (the merge re-surfaces the live idle entry) until the idle timeout.
+  // `close()` reuses the cycle-1 idle teardown: it skips re-persisting the
+  // already-written `completed` row, so the subsequent DB delete still removes
+  // it. Active (running/initializing) sessions are left untouched — their rows
+  // aren't terminal, so the bulk delete skips them too.
+  const manager = getAcpSessionManager();
+  const states = manager.getStatus() as AcpSessionState[];
+  for (const state of states) {
+    if (state.status === "idle") {
+      try {
+        manager.close(state.id);
+      } catch (err) {
+        log.warn(
+          { acpSessionId: state.id, err },
+          "Failed to close idle ACP session during bulk-clear",
+        );
+      }
+    }
+  }
+
   getDb()
     .delete(acpSessionHistory)
     .where(inArray(acpSessionHistory.status, TERMINAL_SESSION_STATUSES))
@@ -173,17 +199,27 @@ function bulkDeleteSessions({ queryParams }: RouteHandlerArgs) {
 function deleteSession({ pathParams }: RouteHandlerArgs) {
   const id = pathParams?.id as string;
 
+  const manager = getAcpSessionManager();
   try {
-    const state = getAcpSessionManager().getStatus(id);
-    if (
-      !Array.isArray(state) &&
-      (state.status === "running" ||
-        state.status === "initializing" ||
-        state.status === "idle")
-    ) {
-      throw new ConflictError(
-        `ACP session "${id}" is still ${state.status}. Cancel or close it before deleting.`,
-      );
+    const state = manager.getStatus(id);
+    if (!Array.isArray(state)) {
+      if (state.status === "running" || state.status === "initializing") {
+        // A genuinely active session (prompt in flight) must not be deleted —
+        // tearing it down would orphan the running prompt. The caller must
+        // cancel/close it first.
+        throw new ConflictError(
+          `ACP session "${id}" is still ${state.status}. Cancel or close it before deleting.`,
+        );
+      }
+      if (state.status === "idle") {
+        // An idle session is terminal-for-affordances on the client, but its
+        // adapter process, idle timer, and map entry are still live. Close it
+        // (cycle-1 idle teardown: kill process, clear timer, drop the map
+        // entry, skip re-persisting the already-written `completed` row) before
+        // removing its history row, so the delete is consistent — no 409, and
+        // it does not reappear on the next `/acp/sessions` refresh.
+        manager.close(id);
+      }
     }
   } catch (err) {
     if (err instanceof ConflictError) throw err;
@@ -351,8 +387,10 @@ export const ROUTES: RouteDefinition[] = [
     handler: deleteSession,
     summary: "Delete ACP session from history",
     description:
-      "Remove a persisted ACP session row. Rejects with 409 when the " +
-      "session is still active in memory; idempotent for unknown ids.",
+      "Remove a persisted ACP session row. Closes (tears down) a live " +
+      "`idle` session first so the delete is consistent. Rejects with 409 " +
+      "only when the session is still running/initializing in memory; " +
+      "idempotent for unknown ids.",
     tags: ["acp"],
     responseBody: z.object({
       deleted: z.boolean(),

--- a/assistant/src/runtime/routes/acp-routes.ts
+++ b/assistant/src/runtime/routes/acp-routes.ts
@@ -177,7 +177,9 @@ function deleteSession({ pathParams }: RouteHandlerArgs) {
     const state = getAcpSessionManager().getStatus(id);
     if (
       !Array.isArray(state) &&
-      (state.status === "running" || state.status === "initializing")
+      (state.status === "running" ||
+        state.status === "initializing" ||
+        state.status === "idle")
     ) {
       throw new ConflictError(
         `ACP session "${id}" is still ${state.status}. Cancel or close it before deleting.`,

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionDetailView.swift
@@ -163,7 +163,8 @@ struct ACPSessionDetailView: View {
     var isCancelable: Bool {
         switch session.state.status {
         case .running, .initializing: return true
-        case .completed, .failed, .cancelled, .unknown: return false
+        // `idle` has no prompt in flight, so there is nothing to cancel.
+        case .idle, .completed, .failed, .cancelled, .unknown: return false
         }
     }
 
@@ -218,10 +219,10 @@ struct ACPSessionDetailView: View {
 
     private func statusTone(_ status: ACPSessionState.Status) -> VBadge.Tone {
         switch status {
-        case .running, .initializing: return .accent
-        case .completed:              return .positive
-        case .failed:                 return .danger
-        case .cancelled, .unknown:    return .neutral
+        case .running, .initializing:   return .accent
+        case .completed:                return .positive
+        case .failed:                   return .danger
+        case .idle, .cancelled, .unknown: return .neutral
         }
     }
 

--- a/clients/shared/Features/Chat/ACPSpawnStatusIndicator.swift
+++ b/clients/shared/Features/Chat/ACPSpawnStatusIndicator.swift
@@ -69,7 +69,9 @@ public enum ACPSpawnStatusIndicator: Equatable {
         switch status {
         case .running, .initializing:
             return .pulsing
-        case .completed:
+        // `idle` means the prompt finished (a terminal history row exists) and
+        // the process is merely kept warm — present it as a completed run.
+        case .completed, .idle:
             return .icon(glyph: .check, role: .positive)
         case .failed:
             return .icon(glyph: .xmark, role: .negative)

--- a/clients/shared/Network/ACPMessages.swift
+++ b/clients/shared/Network/ACPMessages.swift
@@ -46,6 +46,12 @@ public struct ACPSessionState: Codable, Equatable, Identifiable, Sendable {
     public enum Status: String, Codable, Equatable, Sendable {
         case initializing
         case running
+        /// A prompt finished but the agent process is still alive, ready to
+        /// accept a follow-up prompt. The completed task already has a terminal
+        /// history row; the live session lingers until reused, idle-timed-out,
+        /// or explicitly closed. For client clear/delete affordances this is
+        /// treated as terminal-equivalent (see ``ACPSessionStore.isTerminal``).
+        case idle
         case completed
         case failed
         case cancelled

--- a/clients/shared/Network/ACPSessionStateFormatter.swift
+++ b/clients/shared/Network/ACPSessionStateFormatter.swift
@@ -26,6 +26,7 @@ public enum ACPSessionStateFormatter {
         switch status {
         case .initializing: return "Starting"
         case .running: return "Running"
+        case .idle: return "Idle"
         case .completed: return "Completed"
         case .failed: return "Failed"
         case .cancelled: return "Cancelled"
@@ -40,7 +41,9 @@ public enum ACPSessionStateFormatter {
         case .running, .initializing: return VColor.primaryActive
         case .completed: return VColor.systemPositiveStrong
         case .failed, .cancelled: return VColor.systemNegativeStrong
-        case .unknown: return VColor.contentTertiary
+        // Idle is finished-but-warm: no work in flight, so it reads as a quiet
+        // neutral row rather than the live accent.
+        case .idle, .unknown: return VColor.contentTertiary
         }
     }
 

--- a/clients/shared/Network/ACPSessionStore.swift
+++ b/clients/shared/Network/ACPSessionStore.swift
@@ -382,7 +382,10 @@ open class ACPSessionStore {
     /// the session is still live, so it stays in the list.
     public static func isTerminal(_ status: ACPSessionState.Status) -> Bool {
         switch status {
-        case .completed, .failed, .cancelled:
+        // `idle` is terminal-for-affordances: the prompt finished and no work
+        // is in flight, so the user may clear/delete the row even though the
+        // daemon keeps the process warm for a possible follow-up prompt.
+        case .completed, .failed, .cancelled, .idle:
             return true
         case .initializing, .running, .unknown:
             return false


### PR DESCRIPTION
## Summary
- After a prompt completes, keep the ACP session and adapter process alive in an idle state for follow-ups, distinct from a closed session; preserve acp_session_history terminal-state persistence.
- Add an idle timeout/explicit-close reaper and tie a live session to its conversation for reattach.

Part of plan: acp-platform-hosted.md (PR 6 of 11)