### PR TITLE
feat(acp): stable per-project persistent workspace cwd

### DIFF
--- a/assistant/src/acp/__tests__/workspace-path.test.ts
+++ b/assistant/src/acp/__tests__/workspace-path.test.ts
@@ -40,9 +40,13 @@ describe("resolveAcpWorkspaceDir", () => {
     const conversationId = "11111111-2222-3333-4444-555555555555";
     const dir = resolveAcpWorkspaceDir(conversationId);
 
-    const expected = join(workspaceRoot, "acp", conversationId);
-    expect(dir).toBe(expected);
-    expect(dir.startsWith(workspaceRoot + sep)).toBe(true);
+    const acpRoot = join(workspaceRoot, "acp");
+    expect(dir.startsWith(acpRoot + sep)).toBe(true);
+    // The segment keeps a readable prefix of the id for debuggability and
+    // appends a hash, so it is a single segment under the acp root.
+    const segment = dir.slice(acpRoot.length + 1);
+    expect(segment.includes(sep)).toBe(false);
+    expect(segment.startsWith(conversationId)).toBe(true);
   });
 
   test("returns the SAME path for repeated calls (across turns/respawns)", () => {
@@ -86,7 +90,36 @@ describe("resolveAcpWorkspaceDir", () => {
   });
 
   test("maps a degenerate id to a safe single segment", () => {
-    const dir = resolveAcpWorkspaceDir("..");
-    expect(dir).toBe(join(workspaceRoot, "acp", "_"));
+    const acpRoot = join(workspaceRoot, "acp");
+    for (const id of ["..", ".", ""]) {
+      const dir = resolveAcpWorkspaceDir(id);
+      expect(dir.startsWith(acpRoot + sep)).toBe(true);
+      const segment = dir.slice(acpRoot.length + 1);
+      expect(segment.includes(sep)).toBe(false);
+      expect(segment).not.toBe("");
+      expect(segment).not.toBe(".");
+      expect(segment).not.toBe("..");
+      // Hash-only segment (no usable readable prefix): lowercase hex.
+      expect(/^[0-9a-f]+$/.test(segment)).toBe(true);
+    }
+  });
+
+  test("does not collide ids that sanitize to the same prefix", () => {
+    // `foo/bar` and `foo_bar` both sanitize to `foo_bar`; the full-id hash
+    // must keep them in DISTINCT directories.
+    const slashed = resolveAcpWorkspaceDir("foo/bar");
+    const underscored = resolveAcpWorkspaceDir("foo_bar");
+    expect(slashed).not.toBe(underscored);
+  });
+
+  test("does not collide long ids sharing a truncated prefix", () => {
+    // Two ids identical for the first 128+ chars but differing at the end
+    // must still resolve to distinct directories (the hash sees the full id).
+    const base = "a".repeat(130);
+    const idA = base + "-A";
+    const idB = base + "-B";
+    expect(resolveAcpWorkspaceDir(idA)).not.toBe(resolveAcpWorkspaceDir(idB));
+    // And each remains deterministic.
+    expect(resolveAcpWorkspaceDir(idA)).toBe(resolveAcpWorkspaceDir(idA));
   });
 });

--- a/assistant/src/acp/__tests__/workspace-path.test.ts
+++ b/assistant/src/acp/__tests__/workspace-path.test.ts
@@ -14,7 +14,6 @@
 import { existsSync, mkdtempSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, sep } from "node:path";
-
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { resolveAcpWorkspaceDir } from "../workspace-path.js";

--- a/assistant/src/acp/__tests__/workspace-path.test.ts
+++ b/assistant/src/acp/__tests__/workspace-path.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Tests for `resolveAcpWorkspaceDir` — the stable per-project workspace
+ * resolver that pins an ACP session's default `cwd` to a durable directory
+ * under the persistent workspace volume.
+ *
+ * The contract: for a given conversation id the resolved path is
+ * deterministic, lives under the workspace volume (so it survives turns,
+ * respawns, and idle-sleep), is never an ephemeral temp dir, and is created
+ * on disk. We drive the workspace root via `VELLUM_WORKSPACE_DIR` (the same
+ * override containerized deployments use to point at the PVC) so the test
+ * doesn't touch the real `~/.vellum/workspace`.
+ */
+
+import { existsSync, mkdtempSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, sep } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { resolveAcpWorkspaceDir } from "../workspace-path.js";
+
+let workspaceRoot: string;
+let prevOverride: string | undefined;
+
+beforeEach(() => {
+  // The temp dir is only the test's stand-in for the persistent PVC mount;
+  // the helper under test never derives paths from os.tmpdir itself.
+  workspaceRoot = mkdtempSync(join(tmpdir(), "acp-workspace-test-"));
+  prevOverride = process.env.VELLUM_WORKSPACE_DIR;
+  process.env.VELLUM_WORKSPACE_DIR = workspaceRoot;
+});
+
+afterEach(() => {
+  if (prevOverride === undefined) delete process.env.VELLUM_WORKSPACE_DIR;
+  else process.env.VELLUM_WORKSPACE_DIR = prevOverride;
+  rmSync(workspaceRoot, { recursive: true, force: true });
+});
+
+describe("resolveAcpWorkspaceDir", () => {
+  test("resolves to a stable path under the workspace volume", () => {
+    const conversationId = "11111111-2222-3333-4444-555555555555";
+    const dir = resolveAcpWorkspaceDir(conversationId);
+
+    const expected = join(workspaceRoot, "acp", conversationId);
+    expect(dir).toBe(expected);
+    expect(dir.startsWith(workspaceRoot + sep)).toBe(true);
+  });
+
+  test("returns the SAME path for repeated calls (across turns/respawns)", () => {
+    const conversationId = "conv-abc";
+    const first = resolveAcpWorkspaceDir(conversationId);
+    const second = resolveAcpWorkspaceDir(conversationId);
+    expect(second).toBe(first);
+  });
+
+  test("creates the directory if it does not exist", () => {
+    const dir = resolveAcpWorkspaceDir("fresh-conversation");
+    expect(existsSync(dir)).toBe(true);
+    expect(statSync(dir).isDirectory()).toBe(true);
+  });
+
+  test("keys distinct conversations to distinct directories", () => {
+    const a = resolveAcpWorkspaceDir("conversation-a");
+    const b = resolveAcpWorkspaceDir("conversation-b");
+    expect(a).not.toBe(b);
+  });
+
+  test("derives from the workspace volume, not os.tmpdir", () => {
+    // The path must be anchored to the configured workspace root. (The
+    // workspace root happens to be a temp dir in this test, but the helper
+    // never reaches for os.tmpdir on its own — it only uses getWorkspaceDir.)
+    const dir = resolveAcpWorkspaceDir("conv-1");
+    expect(dir.startsWith(workspaceRoot + sep)).toBe(true);
+  });
+
+  test("sanitizes path-traversal in the conversation id", () => {
+    const dir = resolveAcpWorkspaceDir("../../etc/passwd");
+    // Must stay confined under the acp workspace root — no escape.
+    const acpRoot = join(workspaceRoot, "acp");
+    expect(dir.startsWith(acpRoot + sep)).toBe(true);
+    // The id collapses to exactly one segment under the acp root — slashes
+    // are stripped, so there is no separator to traverse out of, and the
+    // segment can never equal a bare ".." (guarded by the resolver).
+    const segment = dir.slice(acpRoot.length + 1);
+    expect(segment.includes(sep)).toBe(false);
+    expect(segment).not.toBe("..");
+  });
+
+  test("maps a degenerate id to a safe single segment", () => {
+    const dir = resolveAcpWorkspaceDir("..");
+    expect(dir).toBe(join(workspaceRoot, "acp", "_"));
+  });
+});

--- a/assistant/src/acp/workspace-path.ts
+++ b/assistant/src/acp/workspace-path.ts
@@ -20,27 +20,51 @@
  * helper only governs the *default*.
  */
 
+import { createHash } from "node:crypto";
 import { mkdirSync } from "node:fs";
 import { join } from "node:path";
 
 import { getWorkspaceDir } from "../util/platform.js";
 
 /**
- * Sanitize a conversation id into a single safe path segment.
+ * Derive a collision-resistant single path segment from a conversation id.
  *
- * Conversation ids are normally UUIDs, but we don't want a hostile or
- * unusual id to escape the ACP workspace root (e.g. via `..` or a slash) or
- * collide with sibling state. Replace anything outside `[A-Za-z0-9._-]` with
- * `_`, collapse a leading-dot-only result, and cap the length so the path
- * stays well within filesystem limits.
+ * Conversation ids are normally UUIDs, but the HTTP ACP spawn route accepts
+ * `conversationId` as an arbitrary string and uses the resulting directory as
+ * the durable cwd. A naive "replace disallowed chars + truncate" scheme is
+ * NOT injective: distinct ids can map to the same segment (e.g. `foo/bar` and
+ * `foo_bar` both sanitize to `foo_bar`, and two long ids sharing the first
+ * 128 chars truncate to the same prefix). That would let malformed/external
+ * callers accidentally SHARE an ACP workspace and see/overwrite another
+ * session's repo.
+ *
+ * To guarantee uniqueness while staying debuggable we combine:
+ *   - a short, human-readable sanitized prefix of the original id, and
+ *   - a hex slice of a sha256 hash of the FULL original id.
+ * The hash makes the segment unique per distinct id (same id → same segment,
+ * so resolution stays deterministic), and we never let it escape its parent:
+ * the prefix is sanitized to `[A-Za-z0-9._-]` and capped, and the appended
+ * hash is pure hex, so the result is always a single safe path segment that
+ * can never equal "", ".", or "..".
  */
 function sanitizeProjectKey(conversationId: string): string {
-  const cleaned = conversationId.replace(/[^A-Za-z0-9._-]/g, "_").slice(0, 128);
-  // Guard against "", ".", ".." after sanitization.
-  if (cleaned === "" || cleaned === "." || cleaned === "..") {
-    return "_";
-  }
-  return cleaned;
+  // Hex sha256 of the full id — uniquely identifies the conversation and is
+  // itself a safe path-segment fragment (lowercase hex only).
+  const hash = createHash("sha256")
+    .update(conversationId, "utf8")
+    .digest("hex")
+    .slice(0, 16);
+
+  // Short readable prefix for debuggability. Replace anything outside
+  // `[A-Za-z0-9._-]` with `_` and cap the length so the segment stays well
+  // within filesystem limits; the hash below guarantees uniqueness regardless.
+  const prefix = conversationId.replace(/[^A-Za-z0-9._-]/g, "_").slice(0, 64);
+
+  // Drop a prefix that would otherwise produce a leading-dot-only or empty
+  // segment; the hash alone is a valid, unique, safe segment.
+  const safePrefix = prefix === "" || prefix === "." || prefix === ".." ? "" : prefix;
+
+  return safePrefix === "" ? hash : `${safePrefix}-${hash}`;
 }
 
 /**
@@ -50,7 +74,9 @@ function sanitizeProjectKey(conversationId: string): string {
  * The returned path is deterministic for a given conversation id and lives
  * under the persistent workspace volume, so repeated spawns for the same
  * conversation reuse the same on-disk workspace across turns, respawns, and
- * idle-sleep/wake.
+ * idle-sleep/wake. The directory segment is keyed by a sha256 of the FULL id
+ * (with a readable prefix) so distinct conversation ids never collide onto a
+ * shared workspace.
  */
 export function resolveAcpWorkspaceDir(conversationId: string): string {
   // Per-project workspaces live under `<workspaceDir>/acp` on the volume.

--- a/assistant/src/acp/workspace-path.ts
+++ b/assistant/src/acp/workspace-path.ts
@@ -1,0 +1,61 @@
+/**
+ * Stable per-project workspace resolution for ACP sessions.
+ *
+ * An ACP session's `cwd` must be a DURABLE directory so cloned repos and
+ * edits survive across turns, agent respawns, and idle-sleep/wake. The two
+ * spawn paths (`runtime/routes/acp-routes.ts` and `tools/acp/spawn.ts`)
+ * previously defaulted `cwd` to `process.cwd()` / `context.workingDir`,
+ * which can be an ephemeral temp or vary between daemon restarts — anything
+ * the agent wrote would be lost on the next turn.
+ *
+ * The pod's persistent workspace volume (the PVC in containerized
+ * deployments, `~/.vellum/workspace` on bare metal) already survives those
+ * transitions, so we pin the default `cwd` to a per-project subdirectory
+ * underneath it, keyed by the parent conversation id. A follow-up spawn for
+ * the same conversation deterministically resolves to the same directory and
+ * lands in the same workspace the previous turn left behind.
+ *
+ * For isolated/risky work the caller can still pass an explicit `cwd` (e.g. a
+ * git worktree); see the ACP SKILL.md "Working directory" section. This
+ * helper only governs the *default*.
+ */
+
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { getWorkspaceDir } from "../util/platform.js";
+
+/**
+ * Sanitize a conversation id into a single safe path segment.
+ *
+ * Conversation ids are normally UUIDs, but we don't want a hostile or
+ * unusual id to escape the ACP workspace root (e.g. via `..` or a slash) or
+ * collide with sibling state. Replace anything outside `[A-Za-z0-9._-]` with
+ * `_`, collapse a leading-dot-only result, and cap the length so the path
+ * stays well within filesystem limits.
+ */
+function sanitizeProjectKey(conversationId: string): string {
+  const cleaned = conversationId.replace(/[^A-Za-z0-9._-]/g, "_").slice(0, 128);
+  // Guard against "", ".", ".." after sanitization.
+  if (cleaned === "" || cleaned === "." || cleaned === "..") {
+    return "_";
+  }
+  return cleaned;
+}
+
+/**
+ * Resolve the stable per-project workspace directory for an ACP session,
+ * creating it (recursively) if it doesn't yet exist.
+ *
+ * The returned path is deterministic for a given conversation id and lives
+ * under the persistent workspace volume, so repeated spawns for the same
+ * conversation reuse the same on-disk workspace across turns, respawns, and
+ * idle-sleep/wake.
+ */
+export function resolveAcpWorkspaceDir(conversationId: string): string {
+  // Per-project workspaces live under `<workspaceDir>/acp` on the volume.
+  const dir = join(getWorkspaceDir(), "acp", sanitizeProjectKey(conversationId));
+  // `recursive: true` is idempotent — no existence pre-check (avoids TOCTOU).
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}

--- a/assistant/src/acp/workspace-path.ts
+++ b/assistant/src/acp/workspace-path.ts
@@ -1,23 +1,18 @@
 /**
  * Stable per-project workspace resolution for ACP sessions.
  *
- * An ACP session's `cwd` must be a DURABLE directory so cloned repos and
- * edits survive across turns, agent respawns, and idle-sleep/wake. The two
- * spawn paths (`runtime/routes/acp-routes.ts` and `tools/acp/spawn.ts`)
- * previously defaulted `cwd` to `process.cwd()` / `context.workingDir`,
- * which can be an ephemeral temp or vary between daemon restarts — anything
- * the agent wrote would be lost on the next turn.
+ * An ACP session's default `cwd` must be a DURABLE directory so cloned repos
+ * and edits survive across turns, agent respawns, and idle-sleep/wake. The
+ * pod's persistent workspace volume (the PVC in containerized deployments,
+ * `~/.vellum/workspace` on bare metal) survives those transitions, so the
+ * default `cwd` is pinned to a per-project subdirectory underneath it, keyed
+ * by a collision-resistant hash of the parent conversation id. A follow-up
+ * spawn for the same conversation deterministically resolves to the same
+ * directory and lands in the same workspace the previous turn left behind.
  *
- * The pod's persistent workspace volume (the PVC in containerized
- * deployments, `~/.vellum/workspace` on bare metal) already survives those
- * transitions, so we pin the default `cwd` to a per-project subdirectory
- * underneath it, keyed by the parent conversation id. A follow-up spawn for
- * the same conversation deterministically resolves to the same directory and
- * lands in the same workspace the previous turn left behind.
- *
- * For isolated/risky work the caller can still pass an explicit `cwd` (e.g. a
- * git worktree); see the ACP SKILL.md "Working directory" section. This
- * helper only governs the *default*.
+ * For isolated/risky work the caller can pass an explicit `cwd` (e.g. a git
+ * worktree); see the ACP SKILL.md "Working directory" section. This helper
+ * only governs the default.
  */
 
 import { createHash } from "node:crypto";

--- a/assistant/src/config/bundled-skills/acp/SKILL.md
+++ b/assistant/src/config/bundled-skills/acp/SKILL.md
@@ -92,7 +92,9 @@ Use `acp_list_agents` to see what's set up and what's missing. It returns each a
 
 ## Working directory
 
-Default to the conversation's current working directory when spawning an agent. For risky changes or parallel work where you don't want the agent touching the same checkout the user is editing, create a git worktree first via the shell tool and pass that worktree path as `cwd` to `acp_spawn`. That keeps the agent isolated from the user's in-progress work.
+When you omit `cwd`, the agent defaults to a **stable per-project workspace** under the persistent workspace volume, keyed by the conversation. This directory survives across turns, agent respawns, and idle-sleep/wake, so repos the agent clones and files it edits are still there on the next `acp_spawn` for the same conversation. Prefer this default for ongoing work — don't pass an ephemeral temp dir, which would be lost on respawn.
+
+For risky changes or parallel work where you don't want the agent touching the same checkout, create a git worktree first via the shell tool (inside the persistent workspace) and pass that worktree path as `cwd` to `acp_spawn`. That keeps the agent isolated from other in-progress work while still persisting.
 
 ## Tips
 

--- a/assistant/src/config/bundled-skills/acp/TOOLS.json
+++ b/assistant/src/config/bundled-skills/acp/TOOLS.json
@@ -19,7 +19,7 @@
           },
           "cwd": {
             "type": "string",
-            "description": "Working directory for the agent. This determines where the agent runs and where its session is stored. Set this to the project/repo root the user wants the agent to work in. Defaults to current conversation's working directory."
+            "description": "Working directory for the agent. This determines where the agent runs and where its session is stored. Set this to the project/repo root the user wants the agent to work in. When omitted, defaults to a stable per-project persistent workspace under the workspace volume (keyed by conversation) that persists across turns, respawns, and idle-sleep — reuse this default for ongoing work. Pass an explicit path (e.g. a git worktree) for isolated/parallel work."
           }
         },
         "required": ["task"]

--- a/assistant/src/runtime/routes/acp-routes.ts
+++ b/assistant/src/runtime/routes/acp-routes.ts
@@ -11,6 +11,7 @@ import { getAcpSessionManager } from "../../acp/index.js";
 import { prepareAgentEnv } from "../../acp/prepare-agent-env.js";
 import { resolveAcpAgent } from "../../acp/resolve-agent.js";
 import type { AcpSessionState } from "../../acp/types.js";
+import { resolveAcpWorkspaceDir } from "../../acp/workspace-path.js";
 import { getDb } from "../../memory/db-connection.js";
 import { rawChanges } from "../../memory/raw-query.js";
 import { acpSessionHistory } from "../../memory/schema.js";
@@ -55,11 +56,17 @@ async function spawnSession({ body }: RouteHandlerArgs) {
   const agent = body?.agent as string | undefined;
   const task = body?.task as string | undefined;
   const conversationId = body?.conversationId as string | undefined;
-  const cwd = (body?.cwd as string | undefined) ?? process.cwd();
 
   if (!agent || !task || !conversationId) {
     throw new BadRequestError("agent, task, and conversationId are required");
   }
+
+  // Default to a STABLE per-project directory under the persistent workspace
+  // volume (keyed by conversation id) so the agent's clones and edits survive
+  // across turns, respawns, and idle-sleep — not an ephemeral `process.cwd()`.
+  // An explicit `cwd` (e.g. a git worktree for isolated work) still wins.
+  const cwd =
+    (body?.cwd as string | undefined) ?? resolveAcpWorkspaceDir(conversationId);
 
   const resolved = resolveAcpAgent(agent);
   if (!resolved.ok) {

--- a/assistant/src/tools/acp/spawn.ts
+++ b/assistant/src/tools/acp/spawn.ts
@@ -3,6 +3,7 @@ import { execFile } from "node:child_process";
 import { getAcpSessionManager } from "../../acp/index.js";
 import { prepareAgentEnv } from "../../acp/prepare-agent-env.js";
 import { resolveAcpAgent } from "../../acp/resolve-agent.js";
+import { resolveAcpWorkspaceDir } from "../../acp/workspace-path.js";
 import { DEFAULT_AGENT_NPM_PACKAGES } from "../../config/acp-defaults.js";
 import { getLogger } from "../../util/logger.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
@@ -190,7 +191,13 @@ export async function executeAcpSpawn(
 
   try {
     const manager = getAcpSessionManager();
-    const cwd = (input.cwd as string) || context.workingDir;
+    // Default to a STABLE per-project directory under the persistent workspace
+    // volume (keyed by conversation id) so the agent's clones and edits
+    // survive across turns, respawns, and idle-sleep — not the ephemeral
+    // `context.workingDir`. An explicit `cwd` (e.g. a git worktree for
+    // isolated/risky work; see the ACP SKILL.md) still wins.
+    const cwd =
+      (input.cwd as string) || resolveAcpWorkspaceDir(context.conversationId);
     const { acpSessionId, protocolSessionId } = await manager.spawn(
       agent,
       agentConfig,


### PR DESCRIPTION
## Summary
- Resolve an ACP session's default cwd to a durable per-project directory under the persistent workspace PVC (keyed by conversation/project) instead of an ephemeral temp, so repos and edits persist across turns, respawns, and idle-sleep.

Part of plan: acp-platform-hosted.md (PR 7 of 11)