### PR TITLE
feat(acp): in-pod route to link per-user ACP/dev credentials

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -132,6 +132,55 @@ paths:
               required:
                 - instruction
               additionalProperties: false
+  /v1/acp/credentials/link:
+    post:
+      operationId: acp_credentials_link_post
+      summary: Link a per-user ACP/dev credential
+      description:
+        "Write a BYO ACP credential (Claude OAuth token, Anthropic/OpenAI API key, or git token) into the pod's
+        secure store for the agent spawn path to read. Write-only: the value is never returned in the response and never
+        sent centrally. Stored under acp/<field> with an acp_spawn-only policy."
+      tags:
+        - acp
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  field:
+                    type: string
+                  linked:
+                    type: boolean
+                required:
+                  - field
+                  - linked
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                field:
+                  type: string
+                  enum:
+                    - claude_oauth_token
+                    - anthropic_api_key
+                    - openai_api_key
+                    - git_token
+                  description: Which ACP credential to link
+                value:
+                  type: string
+                  minLength: 1
+                  description: Secret value to store (write-only)
+              required:
+                - field
+                - value
+              additionalProperties: false
   /v1/acp/sessions:
     delete:
       operationId: acp_sessions_delete

--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -198,6 +198,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "oauth/credential-token-resolver.ts", // centralized access-token key resolution for OAuth and manual-token providers
       "oauth/connection-resolver.ts", // resolve OAuthConnection from oauth-store (access_token lookup)
       "runtime/routes/secret-routes.ts", // HTTP secret management routes (set/delete secrets)
+      "runtime/routes/acp-routes.ts", // write-only ACP credential-link control-plane route (stores BYO acp/* creds; never reads secret plaintext back)
       "runtime/routes/migration-routes.ts", // migration import credential restore
       "daemon/conversation-messaging.ts", // credential storage during session messaging
       "runtime/routes/settings-routes.ts", // settings routes OAuth credential lookup (client_secret)

--- a/assistant/src/acp/prepare-agent-env.ts
+++ b/assistant/src/acp/prepare-agent-env.ts
@@ -30,7 +30,13 @@ import {
 } from "../tools/credentials/metadata-store.js";
 import type { AcpAgentConfig } from "./types.js";
 
-const ACP_SPAWN_TOOL = "acp_spawn";
+/**
+ * Tool name the agent-spawn path presents to the credential broker. The
+ * in-pod credential-link route (`runtime/routes/acp-routes.ts`) writes this
+ * into each linked credential's `allowedTools` so the broker authorizes the
+ * read here. Exported so the two sides can never drift.
+ */
+export const ACP_SPAWN_TOOL = "acp_spawn";
 
 /**
  * Ensure the `acp/claude_oauth_token` credential has metadata that allows

--- a/assistant/src/runtime/routes/acp-credential-link-routes.test.ts
+++ b/assistant/src/runtime/routes/acp-credential-link-routes.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Tests for POST /v1/acp/credentials/link — the in-pod route hosted users
+ * (who have no shell) use to link their BYO ACP/dev credentials via
+ * client → gateway → daemon.
+ *
+ * The key invariant under test: credential values are WRITE-ONLY over the
+ * wire. The handler stores the secret in the SAME broker location
+ * `prepare-agent-env.ts` reads (`credential/acp/<field>` in secure-keys,
+ * with `allowedTools: ["acp_spawn"]` metadata) and NEVER echoes the value
+ * back in the response.
+ *
+ * These tests use the REAL secure-keys backend and metadata store (the test
+ * preload routes both into a per-process temp workspace with CES disabled),
+ * so we assert the value is actually readable by the credential broker the
+ * way `acp_spawn` would read it — and that it never leaks back in responses.
+ */
+
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+
+import { credentialKey } from "../../security/credential-key.js";
+import {
+  deleteSecureKeyAsync,
+  getSecureKeyAsync,
+} from "../../security/secure-keys.js";
+import {
+  deleteCredentialMetadata,
+  getCredentialMetadata,
+} from "../../tools/credentials/metadata-store.js";
+import { ROUTES } from "./acp-routes.js";
+
+const LINKABLE_FIELDS = [
+  "claude_oauth_token",
+  "anthropic_api_key",
+  "openai_api_key",
+  "git_token",
+] as const;
+
+function getLinkHandler() {
+  const route = ROUTES.find(
+    (r) => r.endpoint === "acp/credentials/link" && r.method === "POST",
+  );
+  if (!route) throw new Error("acp/credentials/link route not registered");
+  return route.handler;
+}
+
+async function clearLinkedCredentials() {
+  for (const field of LINKABLE_FIELDS) {
+    await deleteSecureKeyAsync(credentialKey("acp", field));
+    deleteCredentialMetadata("acp", field);
+  }
+}
+
+beforeEach(async () => {
+  await clearLinkedCredentials();
+});
+
+afterAll(async () => {
+  await clearLinkedCredentials();
+});
+
+describe("POST /v1/acp/credentials/link", () => {
+  test("is registered with a settings.write policy", () => {
+    const route = ROUTES.find(
+      (r) => r.endpoint === "acp/credentials/link" && r.method === "POST",
+    );
+    expect(route).toBeDefined();
+    expect(route?.policy?.requiredScopes).toEqual(["settings.write"]);
+  });
+
+  test("stores the value under credential/acp/<field> with an acp_spawn-only policy", async () => {
+    const handler = getLinkHandler();
+    const result = await handler({
+      body: { field: "claude_oauth_token", value: "token-abc123" },
+    });
+
+    // Readable where prepare-agent-env.ts / the broker reads it.
+    expect(await getSecureKeyAsync(credentialKey("acp", "claude_oauth_token")))
+      .toBe("token-abc123");
+    // Scoped to the agent spawn path only.
+    expect(
+      getCredentialMetadata("acp", "claude_oauth_token")?.allowedTools,
+    ).toEqual(["acp_spawn"]);
+    expect(result).toEqual({ field: "claude_oauth_token", linked: true });
+  });
+
+  test("WRITE-ONLY: the response never echoes the credential value", async () => {
+    const handler = getLinkHandler();
+    const secret = "super-secret-value-xyz";
+    const result = (await handler({
+      body: { field: "anthropic_api_key", value: secret },
+    })) as Record<string, unknown>;
+
+    expect(JSON.stringify(result)).not.toContain(secret);
+    // No scrubbed/preview field either — just field + linked.
+    expect(Object.keys(result).sort()).toEqual(["field", "linked"]);
+  });
+
+  test("accepts all four linkable fields, each scoped to acp_spawn", async () => {
+    const handler = getLinkHandler();
+    for (const field of LINKABLE_FIELDS) {
+      const result = await handler({ body: { field, value: `v-${field}` } });
+      expect(result).toEqual({ field, linked: true });
+      expect(await getSecureKeyAsync(credentialKey("acp", field))).toBe(
+        `v-${field}`,
+      );
+      expect(getCredentialMetadata("acp", field)?.allowedTools).toEqual([
+        "acp_spawn",
+      ]);
+    }
+  });
+
+  test("re-linking a field overwrites the value and re-asserts the acp_spawn policy", async () => {
+    const handler = getLinkHandler();
+    await handler({ body: { field: "git_token", value: "old" } });
+    await handler({ body: { field: "git_token", value: "new" } });
+
+    expect(await getSecureKeyAsync(credentialKey("acp", "git_token"))).toBe(
+      "new",
+    );
+    expect(getCredentialMetadata("acp", "git_token")?.allowedTools).toEqual([
+      "acp_spawn",
+    ]);
+  });
+
+  test("rejects a field outside the allowlist without writing anything", async () => {
+    const handler = getLinkHandler();
+    await expect(
+      handler({ body: { field: "session_token", value: "v" } }),
+    ).rejects.toThrow("field must be one of");
+    expect(getCredentialMetadata("acp", "session_token")).toBeUndefined();
+  });
+
+  test("rejects a missing field", async () => {
+    const handler = getLinkHandler();
+    await expect(handler({ body: { value: "v" } })).rejects.toThrow(
+      "field is required",
+    );
+  });
+
+  test("rejects a missing value", async () => {
+    const handler = getLinkHandler();
+    await expect(
+      handler({ body: { field: "git_token" } }),
+    ).rejects.toThrow("value is required");
+    expect(
+      await getSecureKeyAsync(credentialKey("acp", "git_token")),
+    ).toBeFalsy();
+  });
+});

--- a/assistant/src/runtime/routes/acp-routes.test.ts
+++ b/assistant/src/runtime/routes/acp-routes.test.ts
@@ -94,6 +94,10 @@ const metadataStore = new Map<
 >();
 
 mock.module("../../tools/credentials/metadata-store.js", () => ({
+  // acp-routes.js (the module under test) also exports the credential-link
+  // route, which imports assertMetadataWritable from this module. Since the
+  // mock replaces the whole module, it must provide that export too.
+  assertMetadataWritable: () => {},
   getCredentialMetadata: (service: string, field: string) => {
     const key = `${service}/${field}`;
     const entry = metadataStore.get(key);

--- a/assistant/src/runtime/routes/acp-routes.ts
+++ b/assistant/src/runtime/routes/acp-routes.ts
@@ -8,19 +8,32 @@ import { desc, eq, inArray } from "drizzle-orm";
 import { z } from "zod";
 
 import { getAcpSessionManager } from "../../acp/index.js";
-import { prepareAgentEnv } from "../../acp/prepare-agent-env.js";
+import {
+  ACP_SPAWN_TOOL,
+  prepareAgentEnv,
+} from "../../acp/prepare-agent-env.js";
 import { resolveAcpAgent } from "../../acp/resolve-agent.js";
 import type { AcpSessionState } from "../../acp/types.js";
 import { getDb } from "../../memory/db-connection.js";
 import { rawChanges } from "../../memory/raw-query.js";
 import { acpSessionHistory } from "../../memory/schema.js";
 import { broadcastMessage } from "../../runtime/assistant-event-hub.js";
+import { credentialKey } from "../../security/credential-key.js";
+import {
+  getActiveBackendName,
+  setSecureKeyAsync,
+} from "../../security/secure-keys.js";
+import {
+  assertMetadataWritable,
+  upsertCredentialMetadata,
+} from "../../tools/credentials/metadata-store.js";
 import { getLogger } from "../../util/logger.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import {
   BadRequestError,
   ConflictError,
   FailedDependencyError,
+  InternalError,
   NotFoundError,
 } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
@@ -31,6 +44,32 @@ const log = getLogger("acp-routes");
 
 const DEFAULT_SESSION_LIMIT = 50;
 const MAX_SESSION_LIMIT = 500;
+
+/** Service namespace under which all linked ACP credentials are stored. */
+const ACP_CREDENTIAL_SERVICE = "acp";
+
+/**
+ * The ONLY credential fields a client may link via `acp/credentials/link`.
+ * These are the BYO secrets `prepare-agent-env.ts` reads through the broker
+ * when spawning a per-user agent on a hosted pod. The route is intentionally
+ * locked to this allowlist so the client-reachable surface can never write
+ * (or overwrite) an arbitrary `acp/*` secret outside the agent's needs.
+ */
+const LINKABLE_ACP_FIELDS = [
+  "claude_oauth_token",
+  "anthropic_api_key",
+  "openai_api_key",
+  "git_token",
+] as const;
+
+type LinkableAcpField = (typeof LINKABLE_ACP_FIELDS)[number];
+
+const LINKABLE_FIELD_DESCRIPTIONS: Record<LinkableAcpField, string> = {
+  claude_oauth_token: "Claude OAuth token for ACP agent authentication",
+  anthropic_api_key: "Anthropic API key for ACP agent authentication",
+  openai_api_key: "OpenAI API key for ACP agent authentication",
+  git_token: "Git access token for ACP agent repository operations",
+};
 
 const sessionEntrySchema = z.object({
   id: z.string(),
@@ -106,6 +145,65 @@ async function spawnSession({ body }: RouteHandlerArgs) {
 
   log.info({ acpSessionId, protocolSessionId, agent }, "ACP spawn succeeded");
   return { acpSessionId, protocolSessionId, agent };
+}
+
+/**
+ * Link a per-user ACP/dev credential into the pod's secure store.
+ *
+ * Hosted users have no shell, so they cannot run `assistant credentials set`.
+ * This route is the client → gateway → daemon path that writes the BYO
+ * secret into the SAME broker location `prepare-agent-env.ts` reads:
+ * `credential/acp/<field>` in secure-keys, with metadata whose
+ * `allowedTools` is `["acp_spawn"]` so only the agent spawn path can read it.
+ *
+ * Invariants (enforced here, asserted by tests):
+ *  - WRITE-ONLY over the wire: the response NEVER echoes the value back.
+ *  - IN-POD ONLY: the value goes to the local secure store; it is never sent
+ *    centrally (no managed-catalog / platform sync call on this path).
+ *  - Locked to the {@link LINKABLE_ACP_FIELDS} allowlist.
+ */
+async function linkCredential({ body }: RouteHandlerArgs) {
+  const rawField = body?.field;
+  const value = body?.value as string | undefined;
+
+  if (!rawField || typeof rawField !== "string") {
+    throw new BadRequestError("field is required");
+  }
+  if (!LINKABLE_ACP_FIELDS.includes(rawField as LinkableAcpField)) {
+    throw new BadRequestError(
+      `field must be one of: ${LINKABLE_ACP_FIELDS.join(", ")}`,
+    );
+  }
+  const field = rawField as LinkableAcpField;
+  if (!value || typeof value !== "string") {
+    throw new BadRequestError("value is required");
+  }
+
+  // Fail before any side effects if the metadata store is on an
+  // unrecognized version, mirroring `credentials/set`.
+  assertMetadataWritable();
+
+  const storageKey = credentialKey(ACP_CREDENTIAL_SERVICE, field);
+  const stored = await setSecureKeyAsync(storageKey, value);
+  if (!stored) {
+    throw new InternalError(
+      `Failed to store ACP credential in secure storage (backend: ${getActiveBackendName()})`,
+    );
+  }
+
+  // Scope the credential to acp_spawn ONLY so nothing but the agent spawn
+  // path can read it back through the broker. We always (re)assert this
+  // policy on link so the client can never widen it.
+  upsertCredentialMetadata(ACP_CREDENTIAL_SERVICE, field, {
+    allowedTools: [ACP_SPAWN_TOOL],
+    usageDescription: LINKABLE_FIELD_DESCRIPTIONS[field],
+  });
+
+  log.info({ field }, "ACP credential linked");
+
+  // Write-only: respond with the field name and a boolean ONLY. Never the
+  // value, never a scrubbed preview that could leak length/suffix.
+  return { field, linked: true };
 }
 
 async function steerSession({ pathParams, body }: RouteHandlerArgs) {
@@ -221,6 +319,34 @@ export const ROUTES: RouteDefinition[] = [
       acpSessionId: z.string(),
       protocolSessionId: z.string(),
       agent: z.string(),
+    }),
+  },
+  {
+    operationId: "acp_link_credential",
+    endpoint: "acp/credentials/link",
+    method: "POST",
+    policy: {
+      requiredScopes: ["settings.write"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    handler: linkCredential,
+    summary: "Link a per-user ACP/dev credential",
+    description:
+      "Write a BYO ACP credential (Claude OAuth token, Anthropic/OpenAI API " +
+      "key, or git token) into the pod's secure store for the agent spawn " +
+      "path to read. Write-only: the value is never returned in the response " +
+      "and never sent centrally. Stored under acp/<field> with an " +
+      "acp_spawn-only policy.",
+    tags: ["acp"],
+    requestBody: z.object({
+      field: z
+        .enum(LINKABLE_ACP_FIELDS)
+        .describe("Which ACP credential to link"),
+      value: z.string().min(1).describe("Secret value to store (write-only)"),
+    }),
+    responseBody: z.object({
+      field: z.string(),
+      linked: z.boolean(),
     }),
   },
   {


### PR DESCRIPTION
## Summary
- Add/extend an authenticated in-pod route to link acp/claude_oauth_token, acp/anthropic_api_key, acp/openai_api_key, acp/git_token via the broker path prepare-agent-env reads; write-only over the wire, never central; policy allows acp_spawn.

Part of plan: acp-platform-hosted.md (PR 5 of 11)