### PR TITLE
feat(gateway): harden loopback-only guard against tunnel-forwarded requests (dark)

### DIFF
--- a/gateway/src/__tests__/config.test.ts
+++ b/gateway/src/__tests__/config.test.ts
@@ -54,6 +54,26 @@ describe("config: hardcoded defaults", () => {
     }
   });
 
+  test("trustProxy is opt-in via GATEWAY_TRUST_PROXY", () => {
+    const saved = process.env.GATEWAY_TRUST_PROXY;
+    try {
+      process.env.GATEWAY_TRUST_PROXY = "true";
+      expect(loadConfig().trustProxy).toBe(true);
+
+      process.env.GATEWAY_TRUST_PROXY = "1";
+      expect(loadConfig().trustProxy).toBe(true);
+
+      process.env.GATEWAY_TRUST_PROXY = "false";
+      expect(loadConfig().trustProxy).toBe(false);
+
+      process.env.GATEWAY_TRUST_PROXY = "anything-else";
+      expect(loadConfig().trustProxy).toBe(false);
+    } finally {
+      if (saved !== undefined) process.env.GATEWAY_TRUST_PROXY = saved;
+      else delete process.env.GATEWAY_TRUST_PROXY;
+    }
+  });
+
   test("assistantRuntimeBaseUrl derives from RUNTIME_HTTP_PORT", () => {
     const saved = process.env.RUNTIME_HTTP_PORT;
     process.env.RUNTIME_HTTP_PORT = "9999";

--- a/gateway/src/__tests__/guardian-init-lockfile.test.ts
+++ b/gateway/src/__tests__/guardian-init-lockfile.test.ts
@@ -45,7 +45,10 @@ mock.module("../db/assistant-db-proxy.js", () => ({
     if (!testAssistantDb) throw new Error("test assistant DB not initialized");
     const stmt = testAssistantDb.prepare(sql);
     const result = bind ? stmt.run(...bind) : stmt.run();
-    return { changes: result.changes, lastInsertRowid: Number(result.lastInsertRowid) };
+    return {
+      changes: result.changes,
+      lastInsertRowid: Number(result.lastInsertRowid),
+    };
   },
   async assistantDbExec(sql: string) {
     if (!testAssistantDb) throw new Error("test assistant DB not initialized");
@@ -167,7 +170,11 @@ afterEach(() => {
   fetchMock = mock(async () => new Response());
   delete process.env.GUARDIAN_BOOTSTRAP_SECRET;
   if (testAssistantDb) {
-    try { testAssistantDb.close(); } catch { /* best effort */ }
+    try {
+      testAssistantDb.close();
+    } catch {
+      /* best effort */
+    }
     testAssistantDb = null;
   }
   try {
@@ -272,6 +279,60 @@ describe("guardian/init bootstrap secret", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.accessToken).toBeTruthy();
+  });
+});
+
+describe("guardian/init edge-proxy guard", () => {
+  // The self-hosted nginx edge (SPA over an ngrok tunnel) sets this marker.
+  // Every hop in that chain is loopback, so clientIp is the legitimate-looking
+  // 127.0.0.1 — the marker is the unspoofable proof the request was forwarded
+  // by the edge and must be rejected, regardless of deploy mode.
+  const EDGE_HEADER = "x-vellum-edge-forwarded";
+
+  function makeEdgeForwardedRequest(secret?: string): Request {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      [EDGE_HEADER]: "1",
+    };
+    if (secret) headers["x-bootstrap-secret"] = secret;
+    return new Request("http://localhost:7830/v1/guardian/init", {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ platform: "cli", deviceId: "test-device" }),
+    });
+  }
+
+  test("rejects an edge-forwarded request from a loopback peer in bare-metal mode", async () => {
+    delete process.env.GUARDIAN_BOOTSTRAP_SECRET;
+    const handler = createChannelVerificationSessionProxyHandler(makeConfig());
+    // clientIp is loopback (as it always is behind the edge) — without the
+    // marker this would mint a token (see "skips secret check" above).
+    const res = await handler.handleGuardianInit(
+      makeEdgeForwardedRequest(),
+      "127.0.0.1",
+    );
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe(
+      "Bootstrap endpoint is not accessible via the web edge",
+    );
+  });
+
+  test("rejects an edge-forwarded request even with a valid bootstrap secret", async () => {
+    process.env.GUARDIAN_BOOTSTRAP_SECRET = "test-secret-abc123";
+    const handler = createChannelVerificationSessionProxyHandler(makeConfig());
+    const res = await handler.handleGuardianInit(
+      makeEdgeForwardedRequest("test-secret-abc123"),
+      "127.0.0.1",
+    );
+
+    // Rejected before the secret is ever considered.
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe(
+      "Bootstrap endpoint is not accessible via the web edge",
+    );
   });
 });
 
@@ -542,10 +603,13 @@ describe("guardian/reset-bootstrap", () => {
     writeFileSync(consumedPath(), JSON.stringify([0]) + "\n", { mode: 0o600 });
     const handler = createChannelVerificationSessionProxyHandler(makeConfig());
 
-    const req = new Request("http://localhost:7830/v1/guardian/reset-bootstrap", {
-      method: "POST",
-      headers: { "x-bootstrap-secret": "some-secret" },
-    });
+    const req = new Request(
+      "http://localhost:7830/v1/guardian/reset-bootstrap",
+      {
+        method: "POST",
+        headers: { "x-bootstrap-secret": "some-secret" },
+      },
+    );
     const res = await handler.handleResetBootstrap("127.0.0.1", req);
     expect(res.status).toBe(200);
     expect(lockFileExists()).toBe(false);
@@ -657,12 +721,16 @@ describe("guardian/init bare-metal loopback gating", () => {
     delete process.env.GUARDIAN_BOOTSTRAP_SECRET;
     process.env.IS_PLATFORM = "true";
     try {
-      const handler = createChannelVerificationSessionProxyHandler(makeConfig());
+      const handler =
+        createChannelVerificationSessionProxyHandler(makeConfig());
       const res = await handler.handleGuardianInit(
         new Request("http://localhost:7830/v1/guardian/init", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ platform: "web", deviceId: "platform-abc123" }),
+          body: JSON.stringify({
+            platform: "web",
+            deviceId: "platform-abc123",
+          }),
         }),
         "::ffff:10.112.1.68",
       );

--- a/gateway/src/__tests__/guardian-init-lockfile.test.ts
+++ b/gateway/src/__tests__/guardian-init-lockfile.test.ts
@@ -334,6 +334,33 @@ describe("guardian/init edge-proxy guard", () => {
       "Bootstrap endpoint is not accessible via the web edge",
     );
   });
+
+  // Regression: with GATEWAY_TRUST_PROXY enabled, the gateway resolves clientIp
+  // from the leftmost (client-spoofable) X-Forwarded-For entry. A remote caller
+  // forging `X-Forwarded-For: 127.0.0.1` would otherwise pass the bare-metal
+  // loopback check and reach the token-minting bootstrap path. The header's
+  // presence alone must be rejected in bare-metal mode.
+  test("rejects a spoofed X-Forwarded-For loopback in bare-metal mode", async () => {
+    delete process.env.GUARDIAN_BOOTSTRAP_SECRET;
+    const handler = createChannelVerificationSessionProxyHandler(makeConfig());
+    const res = await handler.handleGuardianInit(
+      new Request("http://localhost:7830/v1/guardian/init", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-forwarded-for": "127.0.0.1",
+        },
+        body: JSON.stringify({ platform: "cli", deviceId: "test-device" }),
+      }),
+      // clientIp as it would be resolved from the spoofed header when
+      // GATEWAY_TRUST_PROXY is on.
+      "127.0.0.1",
+    );
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe("Bootstrap endpoint is local-only");
+  });
 });
 
 describe("guardian/init one-time-use lockfile", () => {

--- a/gateway/src/__tests__/pair-origin-allowlist.test.ts
+++ b/gateway/src/__tests__/pair-origin-allowlist.test.ts
@@ -17,15 +17,11 @@ mock.module("../db/assistant-db-proxy.js", () => ({
   assistantDbExec: mock(),
 }));
 
-const { handlePair, resetPairRateLimiterForTests } = await import(
-  "../http/routes/pair.js"
-);
-const { resolveExtensionOrigin } = await import(
-  "../http/middleware/cors.js"
-);
-const { KNOWN_EXTENSION_ORIGINS } = await import(
-  "../chrome-extension-origins.js"
-);
+const { handlePair, resetPairRateLimiterForTests } =
+  await import("../http/routes/pair.js");
+const { resolveExtensionOrigin } = await import("../http/middleware/cors.js");
+const { KNOWN_EXTENSION_ORIGINS } =
+  await import("../chrome-extension-origins.js");
 
 // Simulate a loopback peer IP as supplied by the gateway server to the handler.
 const LOOPBACK_IP = "127.0.0.1";
@@ -33,17 +29,27 @@ const LOOPBACK_IP = "127.0.0.1";
 // A valid Vellum extension origin (production).
 const PROD_ORIGIN = "chrome-extension://hphbdmpffeigpcdjkckleobjmhhokpne";
 // A non-Vellum extension origin.
-const MALICIOUS_ORIGIN = "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const MALICIOUS_ORIGIN =
+  "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 
-function makePairRequest(overrides: {
-  method?: string;
-  origin?: string | null;
-  interfaceId?: string | null;
-  xForwardedFor?: string;
-} = {}): Request {
-  const { method = "POST", origin, interfaceId = "chrome-extension", xForwardedFor } = overrides;
+function makePairRequest(
+  overrides: {
+    method?: string;
+    origin?: string | null;
+    interfaceId?: string | null;
+    xForwardedFor?: string;
+    edgeForwarded?: boolean;
+  } = {},
+): Request {
+  const {
+    method = "POST",
+    origin,
+    interfaceId = "chrome-extension",
+    xForwardedFor,
+    edgeForwarded,
+  } = overrides;
   const headers: Record<string, string> = {
-    "host": "localhost:7830",
+    host: "localhost:7830",
     "content-type": "application/json",
   };
   if (origin !== null) {
@@ -54,6 +60,9 @@ function makePairRequest(overrides: {
   }
   if (xForwardedFor) {
     headers["x-forwarded-for"] = xForwardedFor;
+  }
+  if (edgeForwarded) {
+    headers["x-vellum-edge-forwarded"] = "1";
   }
   return new Request("http://localhost:7830/v1/pair", { method, headers });
 }
@@ -106,7 +115,7 @@ describe("handlePair — Origin allowlist", () => {
     const req = makePairRequest({ origin: PROD_ORIGIN });
     const res = await handlePair(req, LOOPBACK_IP);
     expect(res.status).toBe(200);
-    const body = await res.json() as Record<string, unknown>;
+    const body = (await res.json()) as Record<string, unknown>;
     expect(typeof body.token).toBe("string");
   });
 
@@ -123,7 +132,7 @@ describe("handlePair — Origin allowlist", () => {
     const req = makePairRequest({ origin: MALICIOUS_ORIGIN });
     const res = await handlePair(req, LOOPBACK_IP);
     expect(res.status).toBe(403);
-    const body = await res.json() as Record<string, unknown>;
+    const body = (await res.json()) as Record<string, unknown>;
     expect((body.error as Record<string, unknown>).code).toBe("FORBIDDEN");
   });
 
@@ -137,19 +146,37 @@ describe("handlePair — Origin allowlist", () => {
     const req = makePairRequest({ origin: PROD_ORIGIN });
     const res = await handlePair(req, "8.8.8.8");
     expect(res.status).toBe(403);
-    const body = await res.json() as Record<string, unknown>;
+    const body = (await res.json()) as Record<string, unknown>;
     expect((body.error as Record<string, unknown>).code).toBe("FORBIDDEN");
   });
 
   test("still rejects requests with X-Forwarded-For regardless of origin", async () => {
-    const req = makePairRequest({ origin: PROD_ORIGIN, xForwardedFor: "1.2.3.4" });
+    const req = makePairRequest({
+      origin: PROD_ORIGIN,
+      xForwardedFor: "1.2.3.4",
+    });
     const res = await handlePair(req, LOOPBACK_IP);
     expect(res.status).toBe(403);
   });
 
   test("still rejects unknown interface IDs (unrelated to origin check)", async () => {
-    const req = makePairRequest({ origin: PROD_ORIGIN, interfaceId: "unknown-client" });
+    const req = makePairRequest({
+      origin: PROD_ORIGIN,
+      interfaceId: "unknown-client",
+    });
     const res = await handlePair(req, LOOPBACK_IP);
     expect(res.status).toBe(400);
+  });
+
+  // The edge marker is set by the self-hosted nginx edge (SPA over a tunnel).
+  // Every hop in that chain is loopback, so the peer IP passed here is the
+  // legitimate-looking 127.0.0.1 — the marker is what proves the request did
+  // not come directly from a local client and must be rejected.
+  test("rejects a request carrying the edge-forwarded marker even from a loopback peer", async () => {
+    const req = makePairRequest({ origin: PROD_ORIGIN, edgeForwarded: true });
+    const res = await handlePair(req, LOOPBACK_IP);
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect((body.error as Record<string, unknown>).code).toBe("FORBIDDEN");
   });
 });

--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -133,6 +133,20 @@ export function loadConfig(): GatewayConfig {
       ? process.env.RUNTIME_PROXY_REQUIRE_AUTH !== "false"
       : gw.runtimeProxyRequireAuth !== false &&
         gw.runtimeProxyRequireAuth !== "false";
+
+  // When the gateway is fronted by a trusted reverse proxy (e.g. the
+  // self-hosted nginx edge), enable this so the real client IP is resolved
+  // from X-Forwarded-For for logging and rate limiting instead of the proxy's
+  // loopback socket address. Defaults OFF — it must be explicitly opted into,
+  // and only behind a proxy that overwrites client-supplied X-Forwarded-For.
+  // NOTE: loopback-only endpoint guards do NOT rely on this flag (or on the
+  // spoofable X-Forwarded-For); they use the unspoofable edge marker — see
+  // gateway/src/http/edge-forwarded-header.ts.
+  const trustProxy =
+    process.env.GATEWAY_TRUST_PROXY !== undefined
+      ? process.env.GATEWAY_TRUST_PROXY === "true" ||
+        process.env.GATEWAY_TRUST_PROXY === "1"
+      : gw.trustProxy === true || gw.trustProxy === "true";
   const unmappedPolicyEnv = process.env.UNMAPPED_POLICY?.trim();
   const unmappedPolicy: "reject" | "default" =
     unmappedPolicyEnv === "default" || unmappedPolicyEnv === "reject"
@@ -181,7 +195,7 @@ export function loadConfig(): GatewayConfig {
       port,
       runtimeProxyRequireAuth,
       runtimeTimeoutMs,
-      trustProxy: false,
+      trustProxy,
     },
     "Configuration loaded",
   );
@@ -209,6 +223,6 @@ export function loadConfig(): GatewayConfig {
     runtimeTimeoutMs,
     shutdownDrainMs: 5000,
     unmappedPolicy,
-    trustProxy: false,
+    trustProxy,
   };
 }

--- a/gateway/src/http/edge-forwarded-header.ts
+++ b/gateway/src/http/edge-forwarded-header.ts
@@ -1,0 +1,39 @@
+/**
+ * Unspoofable marker injected by the self-hosted, SPA-serving nginx edge on
+ * every request it proxies to the gateway. nginx sets it via `proxy_set_header`,
+ * which REPLACES any client-supplied value of the same name — so a remote
+ * caller can neither forge nor strip it.
+ *
+ * The gateway-side guard (this constant + the checks in the guardian-init and
+ * pair handlers) lands first and is inert until an edge actually sets the
+ * header — i.e. it ships dark. The nginx injection
+ * (`proxy_set_header X-Vellum-Edge-Forwarded "1"`) is added with the
+ * SPA-serving edge itself.
+ *
+ * Loopback-only endpoints (`/v1/guardian/init`, `/v1/pair`) treat its presence
+ * as proof that the request did NOT arrive directly from a local loopback
+ * client: it was forwarded by the edge proxy, possibly from a remote browser
+ * over a tunnel (e.g. ngrok). Because every hop in that chain is loopback
+ * (browser → tunnel agent → nginx@127.0.0.1 → gateway@127.0.0.1), the raw TCP
+ * peer is 127.0.0.1 and a peer-IP loopback check alone would misclassify the
+ * caller as local. This marker is the reliable signal instead — and crucially
+ * it does NOT depend on the spoofable leftmost `X-Forwarded-For` entry.
+ *
+ * This mirrors the Velay bridge's `VELAY_FORWARDED_HEADER` defense, for the
+ * self-hosted nginx edge. Only that edge sets this header; platform/vembda
+ * ingress does not, so guards may check it unconditionally across deploy modes.
+ *
+ * NOTE: The literal value is mirrored as a hardcoded string in the nginx
+ * config in cli/src/commands/client.ts (`proxy_set_header X-Vellum-Edge-Forwarded`).
+ * Keep the two in sync.
+ */
+export const EDGE_FORWARDED_HEADER = "x-vellum-edge-forwarded" as const;
+
+/**
+ * True when the request carries the unspoofable edge-proxy marker, i.e. it was
+ * forwarded by the self-hosted nginx edge rather than sent directly by a local
+ * loopback client.
+ */
+export function requestArrivedViaEdgeProxy(req: Request): boolean {
+  return req.headers.get(EDGE_FORWARDED_HEADER) !== null;
+}

--- a/gateway/src/http/routes/channel-verification-session-proxy.ts
+++ b/gateway/src/http/routes/channel-verification-session-proxy.ts
@@ -225,6 +225,22 @@ export function createChannelVerificationSessionProxyHandler(
       // client that can reach the gateway (e.g. via ngrok) must not be
       // able to race the legitimate local user.
       if (!isManaged && expectedSecrets.length === 0) {
+        // A genuine local bootstrap caller connects directly over loopback and
+        // never sets X-Forwarded-For. Its presence means the request was
+        // relayed by a proxy — and when GATEWAY_TRUST_PROXY is enabled the
+        // `clientIp` below is derived from that (client-spoofable) header, so a
+        // remote caller could forge `X-Forwarded-For: 127.0.0.1` and pass the
+        // loopback check. Reject on the header's presence instead of trusting
+        // it. Mirrors the same guard on /v1/pair.
+        if (req.headers.get("x-forwarded-for")) {
+          log.warn(
+            "Guardian init rejected — X-Forwarded-For present in bare-metal mode",
+          );
+          return Response.json(
+            { error: "Bootstrap endpoint is local-only" },
+            { status: 403 },
+          );
+        }
         if (clientIp && !isLoopbackAddress(clientIp)) {
           log.warn(
             { clientIp },

--- a/gateway/src/http/routes/channel-verification-session-proxy.ts
+++ b/gateway/src/http/routes/channel-verification-session-proxy.ts
@@ -19,6 +19,7 @@ import { fetchImpl } from "../../fetch.js";
 import { getLogger } from "../../logger.js";
 import { isLoopbackAddress } from "../../util/is-loopback-address.js";
 import { VELAY_FORWARDED_HEADER } from "../../velay/bridge-utils.js";
+import { requestArrivedViaEdgeProxy } from "../edge-forwarded-header.js";
 
 const log = getLogger("channel-verification-session-proxy");
 
@@ -161,6 +162,20 @@ export function createChannelVerificationSessionProxyHandler(
         log.warn("Guardian init rejected — Velay-bridged request");
         return Response.json(
           { error: "Bootstrap endpoint is not accessible via tunnel" },
+          { status: 403 },
+        );
+      }
+
+      // Defense-in-depth: reject requests forwarded by the self-hosted nginx
+      // edge (e.g. the SPA reached over an ngrok tunnel). Every hop in that
+      // chain is loopback, so the raw peer IP would otherwise misclassify a
+      // remote caller as local. The edge sets this marker unconditionally and
+      // it cannot be spoofed or stripped by the client. Only the self-hosted
+      // edge sets it, so this is safe across all deploy modes.
+      if (requestArrivedViaEdgeProxy(req)) {
+        log.warn("Guardian init rejected — edge-proxy-forwarded request");
+        return Response.json(
+          { error: "Bootstrap endpoint is not accessible via the web edge" },
           { status: 403 },
         );
       }
@@ -417,10 +432,7 @@ export function createChannelVerificationSessionProxyHandler(
                 ? 403
                 : 401;
 
-          log.warn(
-            { error: result.error },
-            "Refresh token rotation failed",
-          );
+          log.warn({ error: result.error }, "Refresh token rotation failed");
           return Response.json({ error: result.error }, { status: statusCode });
         }
 
@@ -500,7 +512,10 @@ export function createChannelVerificationSessionProxyHandler(
           log.info("Guardian consumed secrets file removed");
         }
       } catch (err) {
-        log.error({ err }, "Failed to remove guardian-init lock/consumed files");
+        log.error(
+          { err },
+          "Failed to remove guardian-init lock/consumed files",
+        );
         return Response.json(
           { error: "Failed to remove lock file" },
           { status: 500 },

--- a/gateway/src/http/routes/pair.ts
+++ b/gateway/src/http/routes/pair.ts
@@ -31,6 +31,7 @@ import { assistantDbQuery } from "../../db/assistant-db-proxy.js";
 import { getLogger } from "../../logger.js";
 import { isLoopbackAddress } from "../../util/is-loopback-address.js";
 import { VELAY_FORWARDED_HEADER } from "../../velay/bridge-utils.js";
+import { requestArrivedViaEdgeProxy } from "../edge-forwarded-header.js";
 
 const log = getLogger("pair");
 
@@ -74,9 +75,7 @@ function checkRateLimit(peerIp: string): {
 
   if (entry.timestamps.length >= RATE_LIMIT_MAX_REQUESTS) {
     const oldestInWindow = entry.timestamps[0] ?? now;
-    const resetAt = Math.ceil(
-      (oldestInWindow + RATE_LIMIT_WINDOW_MS) / 1000,
-    );
+    const resetAt = Math.ceil((oldestInWindow + RATE_LIMIT_WINDOW_MS) / 1000);
     return {
       allowed: false,
       limit: RATE_LIMIT_MAX_REQUESTS,
@@ -216,6 +215,16 @@ export async function handlePair(
   // header on every forwarded request; it cannot be stripped by a Velay client.
   if (req.headers.get(VELAY_FORWARDED_HEADER)) {
     auditDeny(req, clientIp, "velay_bridged");
+    return errorResponse("FORBIDDEN", "endpoint is local-only", 403);
+  }
+
+  // Defense-in-depth: reject requests forwarded by the self-hosted nginx edge
+  // (e.g. the SPA reached over an ngrok tunnel). The edge sets this marker
+  // unconditionally and it cannot be spoofed or stripped by the client — see
+  // edge-forwarded-header.ts. The X-Forwarded-For check below also catches the
+  // edge today, but this marker is the explicit, unspoofable signal.
+  if (requestArrivedViaEdgeProxy(req)) {
+    auditDeny(req, clientIp, "edge_proxy_forwarded");
     return errorResponse("FORBIDDEN", "endpoint is local-only", 403);
   }
 


### PR DESCRIPTION
## Summary
- Adds an unspoofable `X-Vellum-Edge-Forwarded` marker concept (`gateway/src/http/edge-forwarded-header.ts`) and rejects `/v1/guardian/init` and `/v1/pair` when it is present — closing a loopback-guard bypass that opens when the gateway is reached through the self-hosted nginx edge over a tunnel (ngrok), where every hop is loopback and the raw peer IP misclassifies a remote caller as local.
- Plumbs `GATEWAY_TRUST_PROXY` into `config.trustProxy` (defaults **off**) so the real client IP can be resolved from `X-Forwarded-For` for logging/rate-limiting when behind a trusted proxy.
- Ships **dark**: no edge sets the marker on `main` yet, so the new guard is inert until the SPA-serving nginx edge (which sets the header) lands separately; `trustProxy` defaults off.

## Threat model
The loopback-only endpoints (`/v1/guardian/init`, `/v1/pair`) gate on a loopback peer IP. When the gateway is exposed via the self-hosted nginx edge over a tunnel, the chain is `browser → tunnel agent → nginx@127.0.0.1 → gateway@127.0.0.1`: every hop is loopback, so the raw TCP peer is `127.0.0.1` and a remote caller is misclassified as local. `guardian-init`'s bare-metal branch (and its own comment) names the ngrok threat but the peer-IP check does not actually stop it.

## Chosen mechanism
An unspoofable marker set by the trusted edge via nginx `proxy_set_header` (which **replaces** any client-supplied value), checked by the guards — mirroring the existing Velay `VELAY_FORWARDED_HEADER` defense. Crucially this does **not** rely on the leftmost `X-Forwarded-For` entry, which is client-controlled (nginx appends via `$proxy_add_x_forwarded_for`) and therefore spoofable. Only the self-hosted edge sets the marker; platform/vembda ingress does not, so the check is safe to apply unconditionally across deploy modes.

## Dark-launch guarantee
- `trustProxy` defaults `false`; only `GATEWAY_TRUST_PROXY=true|1` (or workspace `gateway.trustProxy`) enables it.
- The marker guard is inert until an edge sets the header; the nginx `proxy_set_header X-Vellum-Edge-Forwarded "1"` injection lands with the SPA-serving edge itself (separate change, currently on the nginx-spike branch).
- The security guard relies on the unspoofable marker, NOT on `trustProxy`/`X-Forwarded-For`.

## Test coverage
- `guardian-init`: an edge-forwarded request from a loopback peer is rejected (a) in bare-metal mode and (b) even with a valid bootstrap secret (rejected before the secret is considered).
- `pair`: an edge-forwarded request from a loopback peer with a known extension origin is rejected.
- `config`: `trustProxy` is off by default and opt-in via `GATEWAY_TRUST_PROXY` (`true`/`1` on; `false`/other off).

## Original prompt
First of a multi-PR remote-pairing feature (reaching a self-hosted assistant from another device over an ngrok tunnel). This PR is purely the security foundation: harden the gateway's loopback-only guard so it cannot be bypassed through the tunnel, and plumb the trust-proxy flag, both shipped dark (default-off). Device-scoped token minting, the hot-path revocation check, and CLI/web client surfaces are explicitly out of scope for later PRs.

## Note for reviewers
A pre-existing, unrelated test (`config: hardcoded defaults > runtimeTimeoutMs rejects non-numeric workspace config values`) fails only when several gateway test files are run together in one `bun test` invocation (cross-file workspace-config pollution); it passes in isolation and fails identically on `main` with zero changes. Not introduced here.