### PR TITLE
feat(prompts): centralize communication style — keep deliberation in thinking, not user-facing text

### DIFF
--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -682,8 +682,10 @@ describe("buildSystemPrompt", () => {
       expect(result).toContain(
         "in your private thinking — never in user-facing text",
       );
-      // The section is self-editable, mirroring IDENTITY.md.
-      expect(result).toContain("prompts/system/01-communication.md");
+      // Closes by deferring to the user's established communication preferences.
+      expect(result).toContain(
+        "Always prioritize communication preferences that you've established",
+      );
       const communicationIdx = result.indexOf("## Communication");
       const parallelIdx = result.indexOf("<use_parallel_tool_calls>");
       expect(communicationIdx).toBeGreaterThan(-1);

--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -678,7 +678,12 @@ describe("buildSystemPrompt", () => {
       // communication guidance leads the operational sections.
       const result = buildSystemPrompt();
       expect(result).toContain("## Communication");
-      expect(result).toContain("keep your reasoning and tool calls adjacent");
+      // The core rule: deliberation belongs in private thinking, not text.
+      expect(result).toContain(
+        "in your private thinking — never in user-facing text",
+      );
+      // The section is self-editable, mirroring IDENTITY.md.
+      expect(result).toContain("prompts/system/01-communication.md");
       const communicationIdx = result.indexOf("## Communication");
       const parallelIdx = result.indexOf("<use_parallel_tool_calls>");
       expect(communicationIdx).toBeGreaterThan(-1);

--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -673,6 +673,19 @@ describe("buildSystemPrompt", () => {
       expect(result).toContain("Batch independent tool calls");
     });
 
+    test("bundled communication section renders and sorts before the parallel-tool-calls block", () => {
+      // `01-communication` sorts ahead of `01-parallel-tool-calls`, so the
+      // communication guidance leads the operational sections.
+      const result = buildSystemPrompt();
+      expect(result).toContain("## Communication");
+      expect(result).toContain("keep your reasoning and tool calls adjacent");
+      const communicationIdx = result.indexOf("## Communication");
+      const parallelIdx = result.indexOf("<use_parallel_tool_calls>");
+      expect(communicationIdx).toBeGreaterThan(-1);
+      expect(parallelIdx).toBeGreaterThan(-1);
+      expect(communicationIdx).toBeLessThan(parallelIdx);
+    });
+
     test("workspace prefix with frontmatter renders body at the very top", () => {
       mkdirSync(SYSTEM_PROMPTS_DIR, { recursive: true });
       writeFileSync(

--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -27,13 +27,6 @@ When the user mentions "email" - sending, reading, checking, decluttering, draft
 
 Do not offer the assistant's own email as an option unless the user specifically asks. If Gmail and Outlook are not connected, guide them through setup.
 
-## Communication Style
-
-- **Be action-oriented.** When the user asks to do something ("declutter", "check my email"), start doing it immediately. Don't ask for permission to read their inbox - that's obviously what they want.
-- **Keep it human.** Never mention OAuth, tokens, APIs, sandboxes, credential proxies, or other technical internals. If something isn't working, say "Gmail needs to be reconnected" - not "the OAuth2 access token for google has expired."
-- **Show progress.** When running a tool that scans many emails, tell the user what you're doing: "Scanning your inbox for clutter..." Don't go silent.
-- **Be brief and warm.** One or two sentences per update is plenty. Don't over-explain what you're about to do - just do it and narrate lightly.
-
 When a platform is connected (auth test succeeds), always use the messaging API tools for that platform. Never fall back to browser automation, shell commands (bash, curl), or any other approach for operations that messaging tools can handle. The messaging tools handle authentication internally - never try to access tokens or call APIs directly. Browser automation is only appropriate for initial credential setup (OAuth consent screens), not for day-to-day messaging operations.
 
 **Exception: Slack.** Slack messaging should use the Slack Web API directly via CLI, not messaging tools. See the **slack** skill for details.

--- a/assistant/src/prompts/templates/system-sections.ts
+++ b/assistant/src/prompts/templates/system-sections.ts
@@ -231,6 +231,13 @@ export const BUNDLED_SYSTEM_SECTIONS: readonly BundledSection[] = [
     enabled: "!excludeCustomPrefix",
   },
   {
+    id: "01-communication",
+    body: `## Communication
+
+After an optional one-line acknowledgement, keep your reasoning and tool calls adjacent — think, call a tool, think, call a tool — with no user-facing prose between them. Don't narrate progress mid-task ("I'm checking X now", "Let me look at Y next"); that filler fragments one continuous stream of work. Let reasoning and tool calls run uninterrupted until the task is done, then close with a single concise summary of what you did. Err toward brevity — expand only when the user follows up or their style calls for more.
+`,
+  },
+  {
     id: "01-parallel-tool-calls",
     body: `<use_parallel_tool_calls>
 Batch independent tool calls into the same response. An extra LLM round trip costs orders of magnitude more than a few wasted tool calls — err on the side of parallelizing when calls are independent. Reading multiple files, \`glob\`/\`grep\`, \`ls\`, \`git status\`/\`diff\`/\`log\`, type-checks, and tests should be batched.

--- a/assistant/src/prompts/templates/system-sections.ts
+++ b/assistant/src/prompts/templates/system-sections.ts
@@ -234,7 +234,13 @@ export const BUNDLED_SYSTEM_SECTIONS: readonly BundledSection[] = [
     id: "01-communication",
     body: `## Communication
 
-After an optional one-line acknowledgement, keep your reasoning and tool calls adjacent — think, call a tool, think, call a tool — with no user-facing prose between them. Don't narrate progress mid-task ("I'm checking X now", "Let me look at Y next"); that filler fragments one continuous stream of work. Let reasoning and tool calls run uninterrupted until the task is done, then close with a single concise summary of what you did. Err toward brevity — expand only when the user follows up or their style calls for more.
+Keep your reasoning, planning, and deliberation in your private thinking — never in user-facing text. A user-facing message is only ever: an optional one-line acknowledgement when starting longer work, the actual answer or question the user needs, and a single concise summary when you're done. Lines like "Let me check X," "I'm looking at Y now," or "Profile is balanced, so I'll ask first" are thinking that leaked into text — keep them private or cut them.
+
+Don't narrate your intentions — take the action. If you need something from the user, ask the question itself rather than announcing that you're about to ask; when the next step is an obvious, low-risk part of what they clearly want, just do it instead of asking permission. Keep reasoning and tool calls adjacent (think, call a tool, think, call a tool) with no user-facing prose between them, so one stream of work renders as one block.
+
+Don't expose technical internals in user-facing text — translate them into plain language ("Gmail needs reconnecting," not "the OAuth token expired"). Err toward brevity; expand only when the user follows up or their style calls for more.
+
+You may revise this section for yourself by writing the full replacement to \`prompts/system/01-communication.md\` in your workspace, the same way you maintain IDENTITY.md.
 `,
   },
   {

--- a/assistant/src/prompts/templates/system-sections.ts
+++ b/assistant/src/prompts/templates/system-sections.ts
@@ -234,13 +234,15 @@ export const BUNDLED_SYSTEM_SECTIONS: readonly BundledSection[] = [
     id: "01-communication",
     body: `## Communication
 
-Keep your reasoning, planning, and deliberation in your private thinking — never in user-facing text. A user-facing message is only ever: an optional one-line acknowledgement when starting longer work, the actual answer or question the user needs, and a single concise summary when you're done. Lines like "Let me check X," "I'm looking at Y now," or "Profile is balanced, so I'll ask first" are thinking that leaked into text — keep them private or cut them.
+Keep your reasoning, planning, and deliberation in your private thinking — never in user-facing text. A user-facing message is only ever: an optional one-line acknowledgement when starting longer work, the actual answer or question the user needs, and a single concise summary when you're done. 
 
-Don't narrate your intentions — take the action. If you need something from the user, ask the question itself rather than announcing that you're about to ask; when the next step is an obvious, low-risk part of what they clearly want, just do it instead of asking permission. Keep reasoning and tool calls adjacent (think, call a tool, think, call a tool) with no user-facing prose between them, so one stream of work renders as one block.
+Keep reasoning and tool calls adjacent (think, call a tool, think, call a tool) with no user-facing prose between them, so one stream of work renders as one block. 
 
-Don't expose technical internals in user-facing text — translate them into plain language ("Gmail needs reconnecting," not "the OAuth token expired"). Err toward brevity; expand only when the user follows up or their style calls for more.
+Meet your user where they are. If they are nontechnical, prefer "Gmail needs reconnecting," not "the OAuth token expired". You can use more acronyms and industry-specific jargon if your user is a subject matter expert in the domain you are working together on. This applies for marketers, engineers, consultants, entrepreneurs, etc. 
 
-You may revise this section for yourself by writing the full replacement to \`prompts/system/01-communication.md\` in your workspace, the same way you maintain IDENTITY.md.
+Err toward brevity; expand only when the user follows up or their style calls for more.
+
+These are default guidelines. Always prioritize communication preferences that you've established through your relationship with your human.
 `,
   },
   {

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -238,7 +238,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T17:40:47.000Z"
+      "updatedAt": "2026-06-03T22:51:59.000Z"
     },
     {
       "id": "google-calendar",
@@ -557,7 +557,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "updatedAt": "2026-06-03T22:51:59.000Z"
     },
     {
       "id": "outlook-calendar",
@@ -685,7 +685,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "updatedAt": "2026-06-03T22:51:59.000Z"
     },
     {
       "id": "slack-app-setup",

--- a/skills/gmail/SKILL.md
+++ b/skills/gmail/SKILL.md
@@ -235,13 +235,6 @@ Do not offer the assistant's own email as an option unless the user specifically
 1. **Check connection health first.** Run `assistant oauth status google`. This checks whether the user's Google account is connected and the token is valid.
 2. **If no connection is found or the status check fails:** Load the `vellum-oauth-integrations` skill. The skill will evaluate whether managed or your-own mode is appropriate and guide the user accordingly.
 
-## Communication Style
-
-- **Be action-oriented.** When the user asks to do something ("declutter", "check my email"), start doing it immediately. Don't ask for permission to read their inbox - that's obviously what they want.
-- **Keep it human.** Never mention OAuth, tokens, APIs, sandboxes, credential proxies, or other technical internals. If something isn't working, say "Gmail needs to be reconnected" - not "the OAuth2 access token for google has expired."
-- **Show progress.** When running a script that scans many emails, tell the user what you're doing: "Scanning your inbox for clutter..." Don't go silent.
-- **Be brief and warm.** One or two sentences per update is plenty. Don't over-explain what you're about to do - just do it and narrate lightly.
-
 ## Error Recovery
 
 When a Gmail script fails with a token or authorization error:

--- a/skills/outlook/SKILL.md
+++ b/skills/outlook/SKILL.md
@@ -103,13 +103,6 @@ Do not offer the assistant's own email as an option unless the user specifically
 1. **Check connection health first.** Run `assistant oauth ping outlook`. This checks whether the user's Outlook/Microsoft account is connected and the token is valid.
 2. **If no connection is found or the ping fails:** Load the `vellum-oauth-integrations` skill. The skill will evaluate whether managed or your-own mode is appropriate and guide the user accordingly.
 
-## Communication Style
-
-- **Be action-oriented.** When the user asks to do something ("declutter", "check my email"), start doing it immediately. Don't ask for permission to read their inbox - that's obviously what they want.
-- **Keep it human.** Never mention OAuth, tokens, APIs, sandboxes, credential proxies, or other technical internals. If something isn't working, say "Outlook needs to be reconnected" - not "the OAuth2 access token for outlook has expired."
-- **Show progress.** When running a script that scans many emails, tell the user what you're doing: "Scanning your inbox for clutter..." Don't go silent.
-- **Be brief and warm.** One or two sentences per update is plenty. Don't over-explain what you're about to do - just do it and narrate lightly.
-
 ## Error Recovery
 
 When an Outlook script fails with a token or authorization error:

--- a/skills/slack/SKILL.md
+++ b/skills/slack/SKILL.md
@@ -176,12 +176,6 @@ Before making any Slack API calls, verify that Slack is connected. If not connec
 
 If a Slack API call fails due to missing or invalid credentials -- for example, an error indicating that the token is missing or invalid -- do NOT attempt to fix the credentials manually. Instead, load the **slack-app-setup** skill (`skill_load` with `skill: "slack-app-setup"`) and follow its guided flow to set up or reconnect Slack. Tell the user something like "Slack needs to be reconnected" and start the setup skill.
 
-## Communication Style
-
-- **Be action-oriented.** When the user asks to check Slack, start scanning immediately.
-- **Keep it human.** Never mention OAuth, tokens, APIs, proxies, or credential IDs. If something isn't working, say "Slack needs to be reconnected."
-- **Show progress.** When scanning multiple channels, tell the user what you're doing.
-
 ## Delivery Notes
 
 - For rich content (digests, reports, formatted summaries): use `chat.postMessage` with blocks via `assistant oauth request --provider slack_channel`


### PR DESCRIPTION
## Summary

- **Sharpen the `01-communication` system-prompt section** so the main agent's reasoning/planning/deliberation stays in its **private thinking channel** and user-facing text is reserved for: an optional one-line ack, the actual answer/question, and a final concise summary. Directly targets the observed leak where chain-of-thought ("Profile is balanced, so I'll ask first") surfaced as a `type: text` block instead of `type: thinking`.
- **Centralize communication style into this one section** and make it **self-editable** by the assistant — it can rewrite `prompts/system/01-communication.md` in its workspace, the same override path used for IDENTITY.md (mechanism already supported by `resolveSection` in `sections.ts`; no new plumbing or migration).
- **Absorb the universal principles** previously duplicated across skills — plain-language errors (no OAuth/token jargon) and acting on obvious low-risk intent — then **remove the duplicated `## Communication Style` sections** from the `messaging`, `gmail`, `outlook`, and `slack` skills. Progress for long operations is handled by the existing `task_progress` UI card, not chat narration.
- Updated the section's test to assert the thinking-vs-text rule and the self-edit pointer.

## Why

A user saw the assistant emit deliberation ("Profile is currently balanced. Let me ask Aaron if he wants to bump to the quality model…") in a user-facing **text** block rather than a **thinking** block. Investigation found no global rule that deliberation belongs in thinking, while several skills actively encouraged narration ("Show progress… tell the user what you're doing… narrate lightly"). This consolidates the guidance into one always-on, self-editable section and removes the conflicting skill-level instructions.

## Original prompt

Add a concise global `## Communication` section to the assistant system prompt that keeps tool calls and reasoning adjacent (so the UI can group a continuous stream of work into one block instead of fragments), then — after seeing reasoning leak into a `type: text` block — sharpen it so deliberation goes in the thinking channel and user-facing text is only an optional ack + the answer + a final summary. Centralize all "how to talk to the user" guidance here, remove the broad narration instructions from the individual skills, and let the assistant update this section itself the way it maintains IDENTITY.md.

## Scope note for reviewers

I scoped the skill cleanup to the four skills carrying the duplicated `## Communication Style` boilerplate (messaging/gmail/outlook/slack). A few other skills have minor tone/narration lines (`start-the-day` `## Tone`, `guardian-verify-setup`, `restaurant-reservation`) that were left as-is to avoid scope creep — happy to fold those in if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)