### PR TITLE
feat(web): add SkillFileContent viewer with preview/raw mode

### DIFF
--- a/apps/web/src/domains/intelligence/components/skills/skill-file-content.test.tsx
+++ b/apps/web/src/domains/intelligence/components/skills/skill-file-content.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * Tests for `SkillFileContent` view-mode rendering.
+ *
+ * A markdown file renders as rendered HTML in "preview" mode (no `<pre>`) and
+ * as raw source inside a `<pre>` in "raw" mode. Binary files always show the
+ * binary-file message.
+ *
+ * Mounted via `@testing-library/react` (happy-dom — see
+ * `apps/web/test-setup.ts`).
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { cleanup, render, screen } from "@testing-library/react";
+
+import { SkillFileContent } from "@/domains/intelligence/components/skills/skill-file-content.js";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("SkillFileContent", () => {
+  test("markdown preview renders rendered markdown without a <pre>", () => {
+    render(
+      <SkillFileContent
+        fileName="readme.md"
+        content="# Heading"
+        isBinary={false}
+        viewMode="preview"
+      />,
+    );
+
+    expect(screen.getByText("Heading")).toBeTruthy();
+    expect(document.querySelector("pre")).toBeNull();
+  });
+
+  test("markdown raw renders the source inside a <pre>", () => {
+    render(
+      <SkillFileContent
+        fileName="readme.md"
+        content="# Heading"
+        isBinary={false}
+        viewMode="raw"
+      />,
+    );
+
+    const pre = document.querySelector("pre");
+    expect(pre).not.toBeNull();
+    expect(pre?.textContent).toContain("# Heading");
+  });
+
+  test("binary file shows the binary message", () => {
+    render(
+      <SkillFileContent
+        fileName="logo.png"
+        content={null}
+        isBinary={true}
+      />,
+    );
+
+    expect(screen.getByText("Binary file — no preview available.")).toBeTruthy();
+  });
+});

--- a/apps/web/src/domains/intelligence/components/skills/skill-file-content.tsx
+++ b/apps/web/src/domains/intelligence/components/skills/skill-file-content.tsx
@@ -1,0 +1,63 @@
+import { FileMarkdown, isMarkdown } from "@/components/file-markdown";
+
+/**
+ * Standalone file-content viewer used by the mobile skill-detail view.
+ *
+ * Mirrors the private `FileContent` in `skill-detail.tsx` (desktop) but adds a
+ * `viewMode` prop so callers can toggle between the rendered markdown
+ * ("preview") and its raw source ("raw"). Non-markdown files always render as
+ * source regardless of `viewMode`.
+ */
+export function SkillFileContent({
+  fileName,
+  content,
+  isBinary,
+  viewMode = "preview",
+}: {
+  fileName: string;
+  content: string | null;
+  isBinary: boolean;
+  viewMode?: "preview" | "raw";
+}) {
+  if (isBinary) {
+    return (
+      <p
+        className="flex h-full items-center justify-center text-body-medium-lighter"
+        style={{ color: "var(--content-tertiary)" }}
+      >
+        Binary file — no preview available.
+      </p>
+    );
+  }
+
+  if (content === null) {
+    return (
+      <p
+        className="flex h-full items-center justify-center text-body-medium-lighter"
+        style={{ color: "var(--content-tertiary)" }}
+      >
+        No preview available for {fileName}.
+      </p>
+    );
+  }
+
+  if (isMarkdown(fileName, undefined) && viewMode === "preview") {
+    return (
+      <div
+        className="h-full overflow-auto px-6 py-4"
+        style={{ color: "var(--content-default)" }}
+      >
+        <FileMarkdown content={content} />
+      </div>
+    );
+  }
+
+  return (
+    <pre
+      className="h-full overflow-auto p-4 font-mono text-body-small-default"
+      style={{ color: "var(--content-default)" }}
+    >
+      {content}
+    </pre>
+  );
+}


### PR DESCRIPTION
## Summary
- Add standalone SkillFileContent component with preview/raw viewMode for the upcoming mobile detail view
- Markdown renders rendered (preview) or source (raw); non-markdown always source

Part of plan: ios-skill-detail-mock.md (PR 2 of 4)