### PR TITLE
feat(web): add useSkillDetailFiles hook for skill file browsing

### DIFF
--- a/apps/web/src/domains/intelligence/skills/use-skill-detail-files.test.ts
+++ b/apps/web/src/domains/intelligence/skills/use-skill-detail-files.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Tests for `pickDefaultFilePath`, the pure helper backing
+ * `useSkillDetailFiles`. It resolves which file path should be active given the
+ * current selection, defaulting to a `SKILL.md` entry when nothing is selected.
+ */
+
+import { describe, expect, it } from "bun:test";
+
+import type { SkillFileEntry } from "@/domains/intelligence/skills/types.js";
+import { pickDefaultFilePath } from "@/domains/intelligence/skills/use-skill-detail-files.js";
+
+function makeEntry(overrides: Partial<SkillFileEntry> = {}): SkillFileEntry {
+  return {
+    name: "file.txt",
+    path: "file.txt",
+    size: 0,
+    mimeType: "text/plain",
+    isBinary: false,
+    content: "",
+    ...overrides,
+  };
+}
+
+describe("pickDefaultFilePath", () => {
+  it("returns the selected path when one is set", () => {
+    const entries = [
+      makeEntry({ name: "SKILL.md", path: "SKILL.md" }),
+      makeEntry({ name: "other.md", path: "docs/other.md" }),
+    ];
+
+    expect(pickDefaultFilePath(entries, "docs/other.md")).toBe("docs/other.md");
+  });
+
+  it("returns the SKILL.md path when nothing is selected and it exists", () => {
+    const entries = [
+      makeEntry({ name: "other.md", path: "docs/other.md" }),
+      makeEntry({ name: "SKILL.md", path: "SKILL.md" }),
+    ];
+
+    expect(pickDefaultFilePath(entries, null)).toBe("SKILL.md");
+  });
+
+  it("returns null when nothing is selected and there is no SKILL.md", () => {
+    const entries = [makeEntry({ name: "other.md", path: "docs/other.md" })];
+
+    expect(pickDefaultFilePath(entries, null)).toBeNull();
+  });
+});

--- a/apps/web/src/domains/intelligence/skills/use-skill-detail-files.ts
+++ b/apps/web/src/domains/intelligence/skills/use-skill-detail-files.ts
@@ -1,0 +1,77 @@
+import { useQuery } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
+
+import {
+  skillsByIdFilesContentGetOptions,
+  skillsByIdFilesGetOptions,
+} from "@/generated/daemon/@tanstack/react-query.gen";
+import type { SkillsByIdFilesContentGetResponse } from "@/generated/daemon/types.gen";
+import type { SkillFileEntry } from "@/domains/intelligence/skills/types";
+
+/**
+ * Resolve the file path that should be active given the current selection.
+ *
+ * Falls back to the skill's `SKILL.md` entry when nothing is explicitly
+ * selected, mirroring the default-file behavior of the desktop skill detail.
+ */
+export function pickDefaultFilePath(
+  fileEntries: SkillFileEntry[],
+  selectedPath: string | null,
+): string | null {
+  return (
+    selectedPath ?? fileEntries.find((f) => f.name === "SKILL.md")?.path ?? null
+  );
+}
+
+/**
+ * Shared data hook for browsing a skill's files: lists the entries, tracks the
+ * selected file (defaulting to `SKILL.md`), and fetches the active file's
+ * content. Extracted so multiple layouts (desktop + mobile) can reuse the same
+ * query setup without duplication.
+ */
+export function useSkillDetailFiles(assistantId: string, skillId: string) {
+  const [selectedPath, setSelectedPath] = useState<string | null>(null);
+
+  const filesQuery = useQuery({
+    ...skillsByIdFilesGetOptions({
+      path: { assistant_id: assistantId, id: skillId },
+    }),
+    select: (data) => data ?? null,
+  });
+
+  const fileEntries = useMemo<SkillFileEntry[]>(
+    () => filesQuery.data?.files ?? [],
+    [filesQuery.data],
+  );
+
+  const skillMd = useMemo(
+    () => fileEntries.find((f) => f.name === "SKILL.md"),
+    [fileEntries],
+  );
+
+  const activePath = pickDefaultFilePath(fileEntries, selectedPath);
+
+  const fileContentQuery = useQuery({
+    ...skillsByIdFilesContentGetOptions({
+      path: { assistant_id: assistantId, id: skillId },
+      query: { path: activePath ?? "" },
+    }),
+    select: (data): SkillsByIdFilesContentGetResponse | null => data ?? null,
+    enabled: Boolean(activePath),
+  });
+
+  const activeFile = fileEntries.find((f) => f.path === activePath);
+
+  return {
+    fileEntries,
+    skillMd,
+    selectedPath,
+    setSelectedPath,
+    activePath,
+    activeFile,
+    isFilesLoading: filesQuery.isLoading,
+    fileContent: fileContentQuery.data?.content ?? null,
+    isBinary: Boolean(fileContentQuery.data?.isBinary),
+    isContentLoading: fileContentQuery.isLoading,
+  };
+}


### PR DESCRIPTION
## Summary
- Extract reusable skill file-browsing data hook for the upcoming mobile detail view
- Add pickDefaultFilePath pure helper + unit tests

Part of plan: ios-skill-detail-mock.md (PR 1 of 4)