### PR TITLE
feat(web): add mobile skill detail layout matching Figma mock

### DIFF
--- a/apps/web/src/domains/intelligence/components/skills/skill-detail-mobile.test.tsx
+++ b/apps/web/src/domains/intelligence/components/skills/skill-detail-mobile.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * Tests for `SkillDetailMobile` — the single-column phone skill-detail layout.
+ *
+ * The data hook (`useSkillDetailFiles`) is mocked so the component renders a
+ * fixed set of file entries plus a markdown active file without touching React
+ * Query or the daemon client. We verify the action bar wiring (back / remove),
+ * the header content, and that the inline file dropdown lists the entries.
+ *
+ * Mounted via `@testing-library/react` (happy-dom — see `apps/web/test-setup.ts`).
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import type {
+  SkillFileEntry,
+  SkillInfo,
+} from "@/domains/intelligence/skills/types.js";
+
+const FILE_ENTRIES: SkillFileEntry[] = [
+  {
+    name: "SKILL.md",
+    path: "SKILL.md",
+    mimeType: "text/markdown",
+    size: 7,
+    isBinary: false,
+    content: "# Hello",
+  },
+  {
+    name: "helper.py",
+    path: "helper.py",
+    mimeType: "text/x-python",
+    size: 0,
+    isBinary: false,
+    content: null,
+  },
+];
+
+const ACTIVE_FILE = FILE_ENTRIES[0];
+
+mock.module("@/domains/intelligence/skills/use-skill-detail-files", () => ({
+  useSkillDetailFiles: () => ({
+    fileEntries: FILE_ENTRIES,
+    skillMd: FILE_ENTRIES[0],
+    selectedPath: null,
+    setSelectedPath: () => {},
+    activePath: ACTIVE_FILE.path,
+    activeFile: ACTIVE_FILE,
+    isFilesLoading: false,
+    fileContent: "# Hello",
+    isBinary: false,
+    isContentLoading: false,
+  }),
+}));
+
+const { SkillDetailMobile } = await import(
+  "@/domains/intelligence/components/skills/skill-detail-mobile.js"
+);
+
+afterEach(() => {
+  cleanup();
+});
+
+function makeSkill(overrides: Partial<SkillInfo> = {}): SkillInfo {
+  return {
+    id: "skill-1",
+    name: "Test Skill",
+    description: "A skill used in mobile detail tests",
+    emoji: "\u{1F9E9}",
+    kind: "installed",
+    status: "enabled",
+    origin: "custom",
+    category: "general",
+    ...overrides,
+  };
+}
+
+function getButton(label: string): HTMLButtonElement {
+  const match = document.querySelector<HTMLButtonElement>(
+    `button[aria-label="${label}"]`,
+  );
+  if (!match) {
+    throw new Error(`expected a button with aria-label="${label}"`);
+  }
+  return match;
+}
+
+describe("SkillDetailMobile", () => {
+  test("back button calls onBack", () => {
+    const onBack = mock(() => {});
+
+    render(<SkillDetailMobile assistantId="asst-1" skill={makeSkill()} onBack={onBack} />);
+
+    fireEvent.click(getButton("Back to skills"));
+
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
+  test("removable skill: remove button calls onRemove", () => {
+    const onRemove = mock(() => {});
+
+    render(
+      <SkillDetailMobile
+        assistantId="asst-1"
+        skill={makeSkill({ kind: "installed" })}
+        onBack={() => {}}
+        onRemove={onRemove}
+      />,
+    );
+
+    fireEvent.click(getButton("Remove skill"));
+
+    expect(onRemove).toHaveBeenCalledTimes(1);
+  });
+
+  test("renders the title and full description", () => {
+    render(
+      <SkillDetailMobile
+        assistantId="asst-1"
+        skill={makeSkill({
+          name: "My Skill",
+          description: "A long description that should not be clamped.",
+        })}
+        onBack={() => {}}
+      />,
+    );
+
+    // Title appears both in the action bar and the header block.
+    expect(screen.getAllByText("My Skill").length).toBeGreaterThan(0);
+    expect(
+      screen.getByText("A long description that should not be clamped."),
+    ).toBeTruthy();
+  });
+
+  test("file dropdown lists the provided file names", () => {
+    render(
+      <SkillDetailMobile assistantId="asst-1" skill={makeSkill()} onBack={() => {}} />,
+    );
+
+    // Open the inline file menu via its trigger (shows the active file name).
+    // Radix's dropdown trigger opens on pointer-down / keyboard, not a bare
+    // click, so drive it with a keyboard activation.
+    const trigger = screen.getByText("SKILL.md").closest("button");
+    if (!trigger) {
+      throw new Error("expected a file dropdown trigger button");
+    }
+    fireEvent.keyDown(trigger, { key: "Enter" });
+
+    expect(screen.getByText("helper.py")).toBeTruthy();
+  });
+});

--- a/apps/web/src/domains/intelligence/components/skills/skill-detail-mobile.tsx
+++ b/apps/web/src/domains/intelligence/components/skills/skill-detail-mobile.tsx
@@ -1,0 +1,307 @@
+import {
+  ArrowDownToLine,
+  ArrowLeft,
+  ChevronDown,
+  FileText,
+  Folder,
+  Loader2,
+  Trash2,
+} from "lucide-react";
+
+import { Button, Card, Menu } from "@vellum/design-library";
+import { SkillOriginBadge } from "./skill-origin-badge";
+import { SkillFileContent } from "./skill-file-content";
+import { useSkillDetailFiles } from "@/domains/intelligence/skills/use-skill-detail-files";
+import {
+  isAvailableSkill,
+  isRemovableSkill,
+  type SkillFileEntry,
+  type SkillInfo,
+} from "@/domains/intelligence/skills/types";
+
+interface SkillDetailMobileProps {
+  assistantId: string;
+  skill: SkillInfo;
+  onBack: () => void;
+  onInstall?: () => void;
+  onRemove?: () => void;
+  isInstalling?: boolean;
+  isRemoving?: boolean;
+}
+
+/**
+ * Single-column phone layout for viewing a skill's details.
+ *
+ * Mirrors the desktop `SkillDetail` data/behavior (via the shared
+ * `useSkillDetailFiles` hook) but lays out top-to-bottom: a circular action bar,
+ * a header block with the full (non-clamped) description, and a content card
+ * whose header hosts an inline file dropdown. The card-header right slot is an
+ * intentional placeholder for the Preview/Source segment control added later.
+ */
+export function SkillDetailMobile({
+  assistantId,
+  skill,
+  onBack,
+  onInstall,
+  onRemove,
+  isInstalling = false,
+  isRemoving = false,
+}: SkillDetailMobileProps) {
+  const available = isAvailableSkill(skill);
+  const removable = isRemovableSkill(skill);
+
+  const {
+    fileEntries,
+    setSelectedPath,
+    activePath,
+    activeFile,
+    isFilesLoading,
+    fileContent,
+    isBinary,
+    isContentLoading,
+  } = useSkillDetailFiles(assistantId, skill.id);
+
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-3 bg-[var(--surface-overlay)]">
+      {/* Action bar */}
+      <div className="flex items-center justify-between">
+        <Button
+          variant="ghost"
+          iconOnly={<ArrowLeft aria-hidden />}
+          expandOnMobile
+          aria-label="Back to skills"
+          onClick={onBack}
+          className="max-md:bg-[var(--surface-active)]"
+        />
+        <span
+          className="min-w-0 flex-1 truncate px-2 text-center text-body-medium-default"
+          style={{ color: "var(--content-secondary)" }}
+        >
+          {skill.name}
+        </span>
+        <RightAction
+          available={available}
+          removable={removable}
+          isInstalling={isInstalling}
+          isRemoving={isRemoving}
+          onInstall={onInstall}
+          onRemove={onRemove}
+        />
+      </div>
+
+      {/* Header block */}
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center justify-between gap-2">
+          <h2
+            className="min-w-0 truncate text-title-medium"
+            style={{ color: "var(--content-emphasised)" }}
+          >
+            {skill.name}
+          </h2>
+          <SkillOriginBadge origin={skill.origin} />
+        </div>
+        <p
+          className="text-body-medium-lighter"
+          style={{ color: "var(--content-tertiary)" }}
+        >
+          {skill.description}
+        </p>
+      </div>
+
+      {/* Content card */}
+      <Card.Root asChild noPadding>
+        <div
+          className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border bg-[var(--surface-lift)]"
+          style={{ borderColor: "var(--border-hover)" }}
+        >
+          <div
+            className="flex items-center justify-between gap-2 border-b px-3 py-2"
+            style={{ borderColor: "var(--border-hover)" }}
+          >
+            <FileDropdown
+              fileEntries={fileEntries}
+              activePath={activePath}
+              activeName={activeFile?.name ?? null}
+              onSelect={setSelectedPath}
+            />
+            {/* Placeholder for the Preview/Source segment control (later PR). */}
+            <div />
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-hidden">
+            {isFilesLoading || isContentLoading ? (
+              <div className="flex h-full items-center justify-center">
+                <Loader2
+                  className="h-6 w-6 animate-spin"
+                  style={{ color: "var(--content-tertiary)" }}
+                />
+              </div>
+            ) : activeFile ? (
+              <SkillFileContent
+                fileName={activeFile.name}
+                content={fileContent}
+                isBinary={isBinary}
+              />
+            ) : (
+              <p
+                className="flex h-full items-center justify-center text-body-medium-lighter"
+                style={{ color: "var(--content-tertiary)" }}
+              >
+                Select a file to view its contents.
+              </p>
+            )}
+          </div>
+        </div>
+      </Card.Root>
+    </div>
+  );
+}
+
+function RightAction({
+  available,
+  removable,
+  isInstalling,
+  isRemoving,
+  onInstall,
+  onRemove,
+}: {
+  available: boolean;
+  removable: boolean;
+  isInstalling: boolean;
+  isRemoving: boolean;
+  onInstall?: () => void;
+  onRemove?: () => void;
+}) {
+  if (isInstalling || isRemoving) {
+    return (
+      <Button
+        variant="ghost"
+        iconOnly={<Loader2 className="animate-spin" aria-hidden />}
+        expandOnMobile
+        disabled
+        aria-label="Pending"
+        className="max-md:bg-[var(--surface-active)]"
+      />
+    );
+  }
+
+  if (available) {
+    return (
+      <Button
+        variant="ghost"
+        iconOnly={<ArrowDownToLine aria-hidden />}
+        expandOnMobile
+        aria-label="Install skill"
+        onClick={onInstall}
+        disabled={!onInstall}
+        className="max-md:bg-[var(--surface-active)]"
+      />
+    );
+  }
+
+  if (removable) {
+    return (
+      <Button
+        variant="dangerGhost"
+        iconOnly={<Trash2 aria-hidden />}
+        expandOnMobile
+        aria-label="Remove skill"
+        onClick={onRemove}
+        disabled={!onRemove}
+        className="max-md:rounded-full max-md:bg-[var(--system-negative-weak)]"
+      />
+    );
+  }
+
+  // Bundled: not available and not removable.
+  return (
+    <Button
+      variant="dangerGhost"
+      iconOnly={<Trash2 aria-hidden />}
+      expandOnMobile
+      disabled
+      title="Bundled skills cannot be removed"
+      aria-label="Bundled skill cannot be removed"
+      className="max-md:rounded-full max-md:bg-[var(--system-negative-weak)]"
+    />
+  );
+}
+
+function isDirectoryEntry(mimeType: string | null | undefined): boolean {
+  return (mimeType ?? "").endsWith("/directory");
+}
+
+function FileDropdown({
+  fileEntries,
+  activePath,
+  activeName,
+  onSelect,
+}: {
+  fileEntries: SkillFileEntry[];
+  activePath: string | null;
+  activeName: string | null;
+  onSelect: (path: string) => void;
+}) {
+  const label = activeName ?? "Select a file";
+
+  if (fileEntries.length === 0) {
+    return (
+      <span
+        className="flex min-w-0 items-center gap-2 text-body-medium-default"
+        style={{ color: "var(--content-emphasised)" }}
+      >
+        <FileGlyph />
+        <span className="truncate">{label}</span>
+      </span>
+    );
+  }
+
+  return (
+    <Menu.Root>
+      <Menu.Trigger>
+        <button
+          type="button"
+          className="flex min-w-0 items-center gap-2 rounded-md text-body-medium-default"
+          style={{ color: "var(--content-emphasised)" }}
+        >
+          <FileGlyph />
+          <span className="truncate">{label}</span>
+          <ChevronDown
+            className="h-4 w-4 shrink-0"
+            style={{ color: "var(--content-tertiary)" }}
+            aria-hidden
+          />
+        </button>
+      </Menu.Trigger>
+      <Menu.Content align="start">
+        {fileEntries.map((entry) => {
+          const isDirectory = isDirectoryEntry(entry.mimeType);
+          return (
+            <Menu.Item
+              key={entry.path}
+              onSelect={() => onSelect(entry.path)}
+              leftIcon={isDirectory ? <Folder /> : <FileText />}
+              aria-current={entry.path === activePath ? "true" : undefined}
+            >
+              {entry.name}
+            </Menu.Item>
+          );
+        })}
+      </Menu.Content>
+    </Menu.Root>
+  );
+}
+
+function FileGlyph() {
+  return (
+    <span
+      className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-[var(--surface-base)]"
+      aria-hidden
+    >
+      <FileText
+        className="h-4 w-4"
+        style={{ color: "var(--content-secondary)" }}
+      />
+    </span>
+  );
+}

--- a/apps/web/src/domains/intelligence/components/skills/skills-tab.tsx
+++ b/apps/web/src/domains/intelligence/components/skills/skills-tab.tsx
@@ -18,10 +18,12 @@ import { useCallback, useMemo, useState } from "react";
 
 import { Button, Card, ConfirmDialog } from "@vellum/design-library";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import { getLocalBool, setLocalBool } from "@/utils/local-settings";
 import { CategorySidebar } from "@/domains/intelligence/components/skills/category-sidebar";
 import { FilterBar } from "@/domains/intelligence/components/skills/skill-filters";
 import { SkillDetail } from "@/domains/intelligence/components/skills/skill-detail";
+import { SkillDetailMobile } from "@/domains/intelligence/components/skills/skill-detail-mobile";
 import { SkillRow } from "@/domains/intelligence/components/skills/skill-row";
 import {
   skillsGetOptions,
@@ -53,6 +55,7 @@ const TIP_STORAGE_KEY = "vellum:skills:tipDismissed";
 
 export function SkillsTab({ assistantId, initialSkillId }: SkillsTabProps) {
   const queryClient = useQueryClient();
+  const isMobile = useIsMobile();
 
   const [searchValue, setSearchValue] = useState("");
   const debouncedSearch = useDebouncedValue(searchValue.trim(), SEARCH_DEBOUNCE_MS);
@@ -195,17 +198,23 @@ export function SkillsTab({ assistantId, initialSkillId }: SkillsTabProps) {
   );
 
   if (selectedSkill) {
+    const detailProps = {
+      assistantId,
+      skill: selectedSkill,
+      onBack: () => setSelectedSkillId(null),
+      onInstall: () => handleInstall(selectedSkill),
+      onRemove: () => handleRemove(selectedSkill),
+      isInstalling:
+        installingSkillId === (selectedSkill.slug ?? selectedSkill.id),
+      isRemoving: removingSkillId === selectedSkill.id,
+    };
     return (
       <>
-        <SkillDetail
-          assistantId={assistantId}
-          skill={selectedSkill}
-          onBack={() => setSelectedSkillId(null)}
-          onInstall={() => handleInstall(selectedSkill)}
-          onRemove={() => handleRemove(selectedSkill)}
-          isInstalling={installingSkillId === (selectedSkill.slug ?? selectedSkill.id)}
-          isRemoving={removingSkillId === selectedSkill.id}
-        />
+        {isMobile ? (
+          <SkillDetailMobile {...detailProps} />
+        ) : (
+          <SkillDetail {...detailProps} />
+        )}
         {removalDialog}
       </>
     );


### PR DESCRIPTION
## Summary
- Add SkillDetailMobile (action bar + header + content card with inline file dropdown) rendered on mobile viewports
- Wire skills-tab to render it via useIsMobile; desktop SkillDetail unchanged

Part of plan: ios-skill-detail-mock.md (PR 3 of 4)