### PR TITLE
feat(web): add preview/source toggle to mobile skill detail

### DIFF
--- a/apps/web/src/domains/intelligence/components/skills/skill-detail-mobile.test.tsx
+++ b/apps/web/src/domains/intelligence/components/skills/skill-detail-mobile.test.tsx
@@ -2,9 +2,11 @@
  * Tests for `SkillDetailMobile` — the single-column phone skill-detail layout.
  *
  * The data hook (`useSkillDetailFiles`) is mocked so the component renders a
- * fixed set of file entries plus a markdown active file without touching React
- * Query or the daemon client. We verify the action bar wiring (back / remove),
- * the header content, and that the inline file dropdown lists the entries.
+ * fixed set of file entries plus an active file without touching React Query or
+ * the daemon client. A mutable `hookState` lets individual tests swap the active
+ * file (markdown vs non-markdown). We verify the action bar wiring (back /
+ * remove), the header content, the inline file dropdown, and the Preview/Source
+ * segment control.
  *
  * Mounted via `@testing-library/react` (happy-dom — see `apps/web/test-setup.ts`).
  */
@@ -37,7 +39,33 @@ const FILE_ENTRIES: SkillFileEntry[] = [
   },
 ];
 
-const ACTIVE_FILE = FILE_ENTRIES[0];
+const MARKDOWN_FILE = FILE_ENTRIES[0];
+
+const JSON_FILE: SkillFileEntry = {
+  name: "data.json",
+  path: "data.json",
+  mimeType: "application/json",
+  size: 13,
+  isBinary: false,
+  content: '{"hi":true}',
+};
+
+// Mutable so individual tests can swap the active file (markdown vs not).
+const hookState: {
+  activeFile: SkillFileEntry;
+  activePath: string;
+  fileContent: string;
+} = {
+  activeFile: MARKDOWN_FILE,
+  activePath: MARKDOWN_FILE.path,
+  fileContent: "# Hello",
+};
+
+function setActiveFile(file: SkillFileEntry): void {
+  hookState.activeFile = file;
+  hookState.activePath = file.path;
+  hookState.fileContent = file.content ?? "";
+}
 
 mock.module("@/domains/intelligence/skills/use-skill-detail-files", () => ({
   useSkillDetailFiles: () => ({
@@ -45,10 +73,10 @@ mock.module("@/domains/intelligence/skills/use-skill-detail-files", () => ({
     skillMd: FILE_ENTRIES[0],
     selectedPath: null,
     setSelectedPath: () => {},
-    activePath: ACTIVE_FILE.path,
-    activeFile: ACTIVE_FILE,
+    activePath: hookState.activePath,
+    activeFile: hookState.activeFile,
     isFilesLoading: false,
-    fileContent: "# Hello",
+    fileContent: hookState.fileContent,
     isBinary: false,
     isContentLoading: false,
   }),
@@ -60,6 +88,7 @@ const { SkillDetailMobile } = await import(
 
 afterEach(() => {
   cleanup();
+  setActiveFile(MARKDOWN_FILE);
 });
 
 function makeSkill(overrides: Partial<SkillInfo> = {}): SkillInfo {
@@ -148,5 +177,40 @@ describe("SkillDetailMobile", () => {
     fireEvent.keyDown(trigger, { key: "Enter" });
 
     expect(screen.getByText("helper.py")).toBeTruthy();
+  });
+
+  test("markdown file: toggles between rendered preview and raw source", () => {
+    render(
+      <SkillDetailMobile assistantId="asst-1" skill={makeSkill()} onBack={() => {}} />,
+    );
+
+    // Default is preview: rendered markdown (no raw <pre>, heading text shown).
+    expect(document.querySelector("pre")).toBeNull();
+    expect(screen.getByText("Hello")).toBeTruthy();
+
+    // Switch to Source: raw <pre> with the markdown source text.
+    fireEvent.click(getButton("Source"));
+    const pre = document.querySelector("pre");
+    expect(pre).not.toBeNull();
+    expect(pre?.textContent).toBe("# Hello");
+
+    // Switch back to Preview: rendered markdown again.
+    fireEvent.click(getButton("Preview"));
+    expect(document.querySelector("pre")).toBeNull();
+    expect(screen.getByText("Hello")).toBeTruthy();
+  });
+
+  test("non-markdown file: Preview disabled and content shows as source", () => {
+    setActiveFile(JSON_FILE);
+
+    render(
+      <SkillDetailMobile assistantId="asst-1" skill={makeSkill()} onBack={() => {}} />,
+    );
+
+    expect(getButton("Preview").disabled).toBe(true);
+
+    const pre = document.querySelector("pre");
+    expect(pre).not.toBeNull();
+    expect(pre?.textContent).toBe('{"hi":true}');
   });
 });

--- a/apps/web/src/domains/intelligence/components/skills/skill-detail-mobile.tsx
+++ b/apps/web/src/domains/intelligence/components/skills/skill-detail-mobile.tsx
@@ -2,15 +2,19 @@ import {
   ArrowDownToLine,
   ArrowLeft,
   ChevronDown,
+  Code,
+  Eye,
   FileText,
   Folder,
   Loader2,
   Trash2,
 } from "lucide-react";
+import { useEffect, useState } from "react";
 
-import { Button, Card, Menu } from "@vellum/design-library";
+import { Button, Card, Menu, SegmentControl } from "@vellum/design-library";
 import { SkillOriginBadge } from "./skill-origin-badge";
 import { SkillFileContent } from "./skill-file-content";
+import { isMarkdown } from "@/components/file-markdown";
 import { useSkillDetailFiles } from "@/domains/intelligence/skills/use-skill-detail-files";
 import {
   isAvailableSkill,
@@ -35,8 +39,10 @@ interface SkillDetailMobileProps {
  * Mirrors the desktop `SkillDetail` data/behavior (via the shared
  * `useSkillDetailFiles` hook) but lays out top-to-bottom: a circular action bar,
  * a header block with the full (non-clamped) description, and a content card
- * whose header hosts an inline file dropdown. The card-header right slot is an
- * intentional placeholder for the Preview/Source segment control added later.
+ * whose header hosts an inline file dropdown (left) and an icon-only
+ * Preview/Source segment control (right). Preview is disabled for non-markdown
+ * files, which always render as source, and the view resets to Preview when the
+ * active file changes.
  */
 export function SkillDetailMobile({
   assistantId,
@@ -60,6 +66,18 @@ export function SkillDetailMobile({
     isBinary,
     isContentLoading,
   } = useSkillDetailFiles(assistantId, skill.id);
+
+  const [viewMode, setViewMode] = useState<"preview" | "raw">("preview");
+
+  // Each newly opened file starts in preview.
+  useEffect(() => {
+    setViewMode("preview");
+  }, [activePath]);
+
+  const activeIsMarkdown = activeFile
+    ? isMarkdown(activeFile.name, undefined)
+    : false;
+  const effectiveViewMode = activeIsMarkdown ? viewMode : "raw";
 
   return (
     <div className="flex h-full min-h-0 flex-col gap-3 bg-[var(--surface-overlay)]">
@@ -124,8 +142,25 @@ export function SkillDetailMobile({
               activeName={activeFile?.name ?? null}
               onSelect={setSelectedPath}
             />
-            {/* Placeholder for the Preview/Source segment control (later PR). */}
-            <div />
+            <SegmentControl<"preview" | "raw">
+              iconOnly
+              ariaLabel="File view mode"
+              value={effectiveViewMode}
+              onChange={setViewMode}
+              items={[
+                {
+                  value: "preview",
+                  label: "Preview",
+                  icon: <Eye aria-hidden />,
+                  disabled: !activeIsMarkdown,
+                },
+                {
+                  value: "raw",
+                  label: "Source",
+                  icon: <Code aria-hidden />,
+                },
+              ]}
+            />
           </div>
 
           <div className="min-h-0 flex-1 overflow-hidden">
@@ -141,6 +176,7 @@ export function SkillDetailMobile({
                 fileName={activeFile.name}
                 content={fileContent}
                 isBinary={isBinary}
+                viewMode={effectiveViewMode}
               />
             ) : (
               <p


### PR DESCRIPTION
## Summary
- Add icon-only Preview/Source SegmentControl to the mobile skill detail card header
- Toggles rendered markdown vs raw source; Preview disabled for non-markdown; resets to Preview on file switch

Part of plan: ios-skill-detail-mock.md (PR 4 of 4)