### PR TITLE
feat(web): iOS skill detail view matching Figma mock

### DIFF
--- a/apps/web/src/domains/intelligence/components/skills/skill-detail-mobile.test.tsx
+++ b/apps/web/src/domains/intelligence/components/skills/skill-detail-mobile.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * Tests for `SkillDetailMobile` — the single-column phone skill-detail layout.
+ *
+ * The data hook (`useSkillDetailFiles`) is mocked so the component renders a
+ * fixed set of file entries plus a markdown active file without touching React
+ * Query or the daemon client. We verify the action bar wiring (back / remove),
+ * the header content, and that the inline file dropdown lists the entries.
+ *
+ * Mounted via `@testing-library/react` (happy-dom — see `apps/web/test-setup.ts`).
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import type {
+  SkillFileEntry,
+  SkillInfo,
+} from "@/domains/intelligence/skills/types.js";
+
+const FILE_ENTRIES: SkillFileEntry[] = [
+  {
+    name: "SKILL.md",
+    path: "SKILL.md",
+    mimeType: "text/markdown",
+    size: 7,
+    isBinary: false,
+    content: "# Hello",
+  },
+  {
+    name: "helper.py",
+    path: "helper.py",
+    mimeType: "text/x-python",
+    size: 0,
+    isBinary: false,
+    content: null,
+  },
+];
+
+const ACTIVE_FILE = FILE_ENTRIES[0];
+
+mock.module("@/domains/intelligence/skills/use-skill-detail-files", () => ({
+  useSkillDetailFiles: () => ({
+    fileEntries: FILE_ENTRIES,
+    skillMd: FILE_ENTRIES[0],
+    selectedPath: null,
+    setSelectedPath: () => {},
+    activePath: ACTIVE_FILE.path,
+    activeFile: ACTIVE_FILE,
+    isFilesLoading: false,
+    fileContent: "# Hello",
+    isBinary: false,
+    isContentLoading: false,
+  }),
+}));
+
+const { SkillDetailMobile } = await import(
+  "@/domains/intelligence/components/skills/skill-detail-mobile.js"
+);
+
+afterEach(() => {
+  cleanup();
+});
+
+function makeSkill(overrides: Partial<SkillInfo> = {}): SkillInfo {
+  return {
+    id: "skill-1",
+    name: "Test Skill",
+    description: "A skill used in mobile detail tests",
+    emoji: "\u{1F9E9}",
+    kind: "installed",
+    status: "enabled",
+    origin: "custom",
+    category: "general",
+    ...overrides,
+  };
+}
+
+function getButton(label: string): HTMLButtonElement {
+  const match = document.querySelector<HTMLButtonElement>(
+    `button[aria-label="${label}"]`,
+  );
+  if (!match) {
+    throw new Error(`expected a button with aria-label="${label}"`);
+  }
+  return match;
+}
+
+describe("SkillDetailMobile", () => {
+  test("back button calls onBack", () => {
+    const onBack = mock(() => {});
+
+    render(<SkillDetailMobile assistantId="asst-1" skill={makeSkill()} onBack={onBack} />);
+
+    fireEvent.click(getButton("Back to skills"));
+
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
+  test("removable skill: remove button calls onRemove", () => {
+    const onRemove = mock(() => {});
+
+    render(
+      <SkillDetailMobile
+        assistantId="asst-1"
+        skill={makeSkill({ kind: "installed" })}
+        onBack={() => {}}
+        onRemove={onRemove}
+      />,
+    );
+
+    fireEvent.click(getButton("Remove skill"));
+
+    expect(onRemove).toHaveBeenCalledTimes(1);
+  });
+
+  test("renders the title and full description", () => {
+    render(
+      <SkillDetailMobile
+        assistantId="asst-1"
+        skill={makeSkill({
+          name: "My Skill",
+          description: "A long description that should not be clamped.",
+        })}
+        onBack={() => {}}
+      />,
+    );
+
+    // Title appears both in the action bar and the header block.
+    expect(screen.getAllByText("My Skill").length).toBeGreaterThan(0);
+    expect(
+      screen.getByText("A long description that should not be clamped."),
+    ).toBeTruthy();
+  });
+
+  test("file dropdown lists the provided file names", () => {
+    render(
+      <SkillDetailMobile assistantId="asst-1" skill={makeSkill()} onBack={() => {}} />,
+    );
+
+    // Open the inline file menu via its trigger (shows the active file name).
+    // Radix's dropdown trigger opens on pointer-down / keyboard, not a bare
+    // click, so drive it with a keyboard activation.
+    const trigger = screen.getByText("SKILL.md").closest("button");
+    if (!trigger) {
+      throw new Error("expected a file dropdown trigger button");
+    }
+    fireEvent.keyDown(trigger, { key: "Enter" });
+
+    expect(screen.getByText("helper.py")).toBeTruthy();
+  });
+});

--- a/apps/web/src/domains/intelligence/components/skills/skill-detail-mobile.test.tsx
+++ b/apps/web/src/domains/intelligence/components/skills/skill-detail-mobile.test.tsx
@@ -2,9 +2,11 @@
  * Tests for `SkillDetailMobile` — the single-column phone skill-detail layout.
  *
  * The data hook (`useSkillDetailFiles`) is mocked so the component renders a
- * fixed set of file entries plus a markdown active file without touching React
- * Query or the daemon client. We verify the action bar wiring (back / remove),
- * the header content, and that the inline file dropdown lists the entries.
+ * fixed set of file entries plus an active file without touching React Query or
+ * the daemon client. A mutable `hookState` lets individual tests swap the active
+ * file (markdown vs non-markdown). We verify the action bar wiring (back /
+ * remove), the header content, the inline file dropdown, and the Preview/Source
+ * segment control.
  *
  * Mounted via `@testing-library/react` (happy-dom — see `apps/web/test-setup.ts`).
  */
@@ -37,7 +39,33 @@ const FILE_ENTRIES: SkillFileEntry[] = [
   },
 ];
 
-const ACTIVE_FILE = FILE_ENTRIES[0];
+const MARKDOWN_FILE = FILE_ENTRIES[0];
+
+const JSON_FILE: SkillFileEntry = {
+  name: "data.json",
+  path: "data.json",
+  mimeType: "application/json",
+  size: 13,
+  isBinary: false,
+  content: '{"hi":true}',
+};
+
+// Mutable so individual tests can swap the active file (markdown vs not).
+const hookState: {
+  activeFile: SkillFileEntry;
+  activePath: string;
+  fileContent: string;
+} = {
+  activeFile: MARKDOWN_FILE,
+  activePath: MARKDOWN_FILE.path,
+  fileContent: "# Hello",
+};
+
+function setActiveFile(file: SkillFileEntry): void {
+  hookState.activeFile = file;
+  hookState.activePath = file.path;
+  hookState.fileContent = file.content ?? "";
+}
 
 mock.module("@/domains/intelligence/skills/use-skill-detail-files", () => ({
   useSkillDetailFiles: () => ({
@@ -45,10 +73,10 @@ mock.module("@/domains/intelligence/skills/use-skill-detail-files", () => ({
     skillMd: FILE_ENTRIES[0],
     selectedPath: null,
     setSelectedPath: () => {},
-    activePath: ACTIVE_FILE.path,
-    activeFile: ACTIVE_FILE,
+    activePath: hookState.activePath,
+    activeFile: hookState.activeFile,
     isFilesLoading: false,
-    fileContent: "# Hello",
+    fileContent: hookState.fileContent,
     isBinary: false,
     isContentLoading: false,
   }),
@@ -60,6 +88,7 @@ const { SkillDetailMobile } = await import(
 
 afterEach(() => {
   cleanup();
+  setActiveFile(MARKDOWN_FILE);
 });
 
 function makeSkill(overrides: Partial<SkillInfo> = {}): SkillInfo {
@@ -148,5 +177,40 @@ describe("SkillDetailMobile", () => {
     fireEvent.keyDown(trigger, { key: "Enter" });
 
     expect(screen.getByText("helper.py")).toBeTruthy();
+  });
+
+  test("markdown file: toggles between rendered preview and raw source", () => {
+    render(
+      <SkillDetailMobile assistantId="asst-1" skill={makeSkill()} onBack={() => {}} />,
+    );
+
+    // Default is preview: rendered markdown (no raw <pre>, heading text shown).
+    expect(document.querySelector("pre")).toBeNull();
+    expect(screen.getByText("Hello")).toBeTruthy();
+
+    // Switch to Source: raw <pre> with the markdown source text.
+    fireEvent.click(getButton("Source"));
+    const pre = document.querySelector("pre");
+    expect(pre).not.toBeNull();
+    expect(pre?.textContent).toBe("# Hello");
+
+    // Switch back to Preview: rendered markdown again.
+    fireEvent.click(getButton("Preview"));
+    expect(document.querySelector("pre")).toBeNull();
+    expect(screen.getByText("Hello")).toBeTruthy();
+  });
+
+  test("non-markdown file: Preview disabled and content shows as source", () => {
+    setActiveFile(JSON_FILE);
+
+    render(
+      <SkillDetailMobile assistantId="asst-1" skill={makeSkill()} onBack={() => {}} />,
+    );
+
+    expect(getButton("Preview").disabled).toBe(true);
+
+    const pre = document.querySelector("pre");
+    expect(pre).not.toBeNull();
+    expect(pre?.textContent).toBe('{"hi":true}');
   });
 });

--- a/apps/web/src/domains/intelligence/components/skills/skill-detail-mobile.tsx
+++ b/apps/web/src/domains/intelligence/components/skills/skill-detail-mobile.tsx
@@ -10,6 +10,7 @@ import {
   Trash2,
 } from "lucide-react";
 import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 
 import { Button, Card, Menu, SegmentControl } from "@vellum/design-library";
 import { SkillOriginBadge } from "./skill-origin-badge";
@@ -35,6 +36,14 @@ interface SkillDetailMobileProps {
 
 /**
  * Single-column phone layout for viewing a skill's details.
+ *
+ * Renders as a full-screen overlay that takes over the whole viewport — its own
+ * back · title · trash action bar replaces the app's mobile chrome (hamburger /
+ * home / search) and the Intelligence tab row, matching the iOS mock. The
+ * overlay is portaled into `RootLayout`'s `#viewport-overlays` container so a
+ * transformed layout ancestor can't scope its `position: fixed` (the same
+ * pattern the chat-side mobile detail overlays use). When the portal target
+ * isn't resolved yet (first paint / tests) it falls back to rendering inline.
  *
  * Mirrors the desktop `SkillDetail` data/behavior (via the shared
  * `useSkillDetailFiles` hook) but lays out top-to-bottom: a circular action bar,
@@ -74,13 +83,33 @@ export function SkillDetailMobile({
     setViewMode("preview");
   }, [activePath]);
 
+  // Resolve the full-screen portal target after commit (SSR-safe; the
+  // element is mounted by RootLayout). Falls back to inline rendering when
+  // absent (e.g. tests, first paint).
+  const [overlayTarget, setOverlayTarget] = useState<HTMLElement | null>(null);
+  useEffect(() => {
+    setOverlayTarget(document.getElementById("viewport-overlays"));
+  }, []);
+
   const activeIsMarkdown = activeFile
     ? isMarkdown(activeFile.name, undefined)
     : false;
   const effectiveViewMode = activeIsMarkdown ? viewMode : "raw";
 
-  return (
-    <div className="flex h-full min-h-0 flex-col gap-3 bg-[var(--surface-overlay)]">
+  const overlay = (
+    <div
+      className="fixed inset-0 z-40 flex flex-col gap-3 overflow-hidden bg-[var(--surface-overlay)]"
+      style={{
+        paddingTop:
+          "calc(8px + var(--safe-area-inset-top, env(safe-area-inset-top, 0px)))",
+        paddingBottom:
+          "calc(8px + var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)))",
+        paddingLeft:
+          "calc(12px + var(--safe-area-inset-left, env(safe-area-inset-left, 0px)))",
+        paddingRight:
+          "calc(12px + var(--safe-area-inset-right, env(safe-area-inset-right, 0px)))",
+      }}
+    >
       {/* Action bar */}
       <div className="flex items-center justify-between">
         <Button
@@ -191,6 +220,8 @@ export function SkillDetailMobile({
       </Card.Root>
     </div>
   );
+
+  return overlayTarget ? createPortal(overlay, overlayTarget) : overlay;
 }
 
 function RightAction({

--- a/apps/web/src/domains/intelligence/components/skills/skill-detail-mobile.tsx
+++ b/apps/web/src/domains/intelligence/components/skills/skill-detail-mobile.tsx
@@ -99,7 +99,7 @@ export function SkillDetailMobile({
 
   const overlay = (
     <div
-      className="fixed inset-0 z-40 flex flex-col gap-4 overflow-hidden bg-[var(--surface-overlay)]"
+      className="fixed inset-0 z-40 flex flex-col overflow-hidden bg-[var(--surface-overlay)]"
       style={{
         paddingTop:
           "calc(8px + var(--safe-area-inset-top, env(safe-area-inset-top, 0px)))",
@@ -137,8 +137,8 @@ export function SkillDetailMobile({
         />
       </div>
 
-      {/* Header block */}
-      <div className="flex flex-col gap-2">
+      {/* Header block — 16px below the action bar */}
+      <div className="mt-4 flex flex-col gap-2">
         <div className="flex items-center justify-between gap-2">
           <div className="flex min-w-0 items-center gap-2">
             <SkillIcon
@@ -162,10 +162,10 @@ export function SkillDetailMobile({
         </p>
       </div>
 
-      {/* Content card */}
+      {/* Content card — 24px below the description */}
       <Card.Root asChild noPadding>
         <div
-          className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border bg-[var(--surface-lift)]"
+          className="mt-6 flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border bg-[var(--surface-lift)]"
           style={{ borderColor: "var(--border-hover)" }}
         >
           <div

--- a/apps/web/src/domains/intelligence/components/skills/skill-detail-mobile.tsx
+++ b/apps/web/src/domains/intelligence/components/skills/skill-detail-mobile.tsx
@@ -13,6 +13,7 @@ import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 
 import { Button, Card, Menu, SegmentControl } from "@vellum/design-library";
+import { SkillIcon } from "./skill-icon";
 import { SkillOriginBadge } from "./skill-origin-badge";
 import { SkillFileContent } from "./skill-file-content";
 import { isMarkdown } from "@/components/file-markdown";
@@ -98,7 +99,7 @@ export function SkillDetailMobile({
 
   const overlay = (
     <div
-      className="fixed inset-0 z-40 flex flex-col gap-3 overflow-hidden bg-[var(--surface-overlay)]"
+      className="fixed inset-0 z-40 flex flex-col gap-4 overflow-hidden bg-[var(--surface-overlay)]"
       style={{
         paddingTop:
           "calc(8px + var(--safe-area-inset-top, env(safe-area-inset-top, 0px)))",
@@ -139,12 +140,18 @@ export function SkillDetailMobile({
       {/* Header block */}
       <div className="flex flex-col gap-2">
         <div className="flex items-center justify-between gap-2">
-          <h2
-            className="min-w-0 truncate text-title-medium"
-            style={{ color: "var(--content-emphasised)" }}
-          >
-            {skill.name}
-          </h2>
+          <div className="flex min-w-0 items-center gap-2">
+            <SkillIcon
+              skill={skill}
+              className="h-6 w-6 shrink-0 text-[22px] leading-none"
+            />
+            <h2
+              className="min-w-0 truncate text-title-medium"
+              style={{ color: "var(--content-emphasised)" }}
+            >
+              {skill.name}
+            </h2>
+          </div>
           <SkillOriginBadge origin={skill.origin} />
         </div>
         <p

--- a/apps/web/src/domains/intelligence/components/skills/skill-detail-mobile.tsx
+++ b/apps/web/src/domains/intelligence/components/skills/skill-detail-mobile.tsx
@@ -2,15 +2,19 @@ import {
   ArrowDownToLine,
   ArrowLeft,
   ChevronDown,
+  Code,
+  Eye,
   FileText,
   Folder,
   Loader2,
   Trash2,
 } from "lucide-react";
+import { useEffect, useState } from "react";
 
-import { Button, Card, Menu } from "@vellum/design-library";
+import { Button, Card, Menu, SegmentControl } from "@vellum/design-library";
 import { SkillOriginBadge } from "./skill-origin-badge";
 import { SkillFileContent } from "./skill-file-content";
+import { isMarkdown } from "@/components/file-markdown";
 import { useSkillDetailFiles } from "@/domains/intelligence/skills/use-skill-detail-files";
 import {
   isAvailableSkill,
@@ -35,8 +39,10 @@ interface SkillDetailMobileProps {
  * Mirrors the desktop `SkillDetail` data/behavior (via the shared
  * `useSkillDetailFiles` hook) but lays out top-to-bottom: a circular action bar,
  * a header block with the full (non-clamped) description, and a content card
- * whose header hosts an inline file dropdown. The card-header right slot is an
- * intentional placeholder for the Preview/Source segment control added later.
+ * whose header hosts an inline file dropdown (left) and an icon-only
+ * Preview/Source segment control (right). Preview is disabled for non-markdown
+ * files, which always render as source, and the view resets to Preview when the
+ * active file changes.
  */
 export function SkillDetailMobile({
   assistantId,
@@ -60,6 +66,18 @@ export function SkillDetailMobile({
     isBinary,
     isContentLoading,
   } = useSkillDetailFiles(assistantId, skill.id);
+
+  const [viewMode, setViewMode] = useState<"preview" | "raw">("preview");
+
+  // Each newly opened file starts in preview.
+  useEffect(() => {
+    setViewMode("preview");
+  }, [activePath]);
+
+  const activeIsMarkdown = activeFile
+    ? isMarkdown(activeFile.name, undefined)
+    : false;
+  const effectiveViewMode = activeIsMarkdown ? viewMode : "raw";
 
   return (
     <div className="flex h-full min-h-0 flex-col gap-3 bg-[var(--surface-overlay)]">
@@ -124,8 +142,25 @@ export function SkillDetailMobile({
               activeName={activeFile?.name ?? null}
               onSelect={setSelectedPath}
             />
-            {/* Placeholder for the Preview/Source segment control (later PR). */}
-            <div />
+            <SegmentControl<"preview" | "raw">
+              iconOnly
+              ariaLabel="File view mode"
+              value={effectiveViewMode}
+              onChange={setViewMode}
+              items={[
+                {
+                  value: "preview",
+                  label: "Preview",
+                  icon: <Eye aria-hidden />,
+                  disabled: !activeIsMarkdown,
+                },
+                {
+                  value: "raw",
+                  label: "Source",
+                  icon: <Code aria-hidden />,
+                },
+              ]}
+            />
           </div>
 
           <div className="min-h-0 flex-1 overflow-hidden">
@@ -141,6 +176,7 @@ export function SkillDetailMobile({
                 fileName={activeFile.name}
                 content={fileContent}
                 isBinary={isBinary}
+                viewMode={effectiveViewMode}
               />
             ) : (
               <p

--- a/apps/web/src/domains/intelligence/components/skills/skill-detail-mobile.tsx
+++ b/apps/web/src/domains/intelligence/components/skills/skill-detail-mobile.tsx
@@ -1,0 +1,307 @@
+import {
+  ArrowDownToLine,
+  ArrowLeft,
+  ChevronDown,
+  FileText,
+  Folder,
+  Loader2,
+  Trash2,
+} from "lucide-react";
+
+import { Button, Card, Menu } from "@vellum/design-library";
+import { SkillOriginBadge } from "./skill-origin-badge";
+import { SkillFileContent } from "./skill-file-content";
+import { useSkillDetailFiles } from "@/domains/intelligence/skills/use-skill-detail-files";
+import {
+  isAvailableSkill,
+  isRemovableSkill,
+  type SkillFileEntry,
+  type SkillInfo,
+} from "@/domains/intelligence/skills/types";
+
+interface SkillDetailMobileProps {
+  assistantId: string;
+  skill: SkillInfo;
+  onBack: () => void;
+  onInstall?: () => void;
+  onRemove?: () => void;
+  isInstalling?: boolean;
+  isRemoving?: boolean;
+}
+
+/**
+ * Single-column phone layout for viewing a skill's details.
+ *
+ * Mirrors the desktop `SkillDetail` data/behavior (via the shared
+ * `useSkillDetailFiles` hook) but lays out top-to-bottom: a circular action bar,
+ * a header block with the full (non-clamped) description, and a content card
+ * whose header hosts an inline file dropdown. The card-header right slot is an
+ * intentional placeholder for the Preview/Source segment control added later.
+ */
+export function SkillDetailMobile({
+  assistantId,
+  skill,
+  onBack,
+  onInstall,
+  onRemove,
+  isInstalling = false,
+  isRemoving = false,
+}: SkillDetailMobileProps) {
+  const available = isAvailableSkill(skill);
+  const removable = isRemovableSkill(skill);
+
+  const {
+    fileEntries,
+    setSelectedPath,
+    activePath,
+    activeFile,
+    isFilesLoading,
+    fileContent,
+    isBinary,
+    isContentLoading,
+  } = useSkillDetailFiles(assistantId, skill.id);
+
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-3 bg-[var(--surface-overlay)]">
+      {/* Action bar */}
+      <div className="flex items-center justify-between">
+        <Button
+          variant="ghost"
+          iconOnly={<ArrowLeft aria-hidden />}
+          expandOnMobile
+          aria-label="Back to skills"
+          onClick={onBack}
+          className="max-md:bg-[var(--surface-active)]"
+        />
+        <span
+          className="min-w-0 flex-1 truncate px-2 text-center text-body-medium-default"
+          style={{ color: "var(--content-secondary)" }}
+        >
+          {skill.name}
+        </span>
+        <RightAction
+          available={available}
+          removable={removable}
+          isInstalling={isInstalling}
+          isRemoving={isRemoving}
+          onInstall={onInstall}
+          onRemove={onRemove}
+        />
+      </div>
+
+      {/* Header block */}
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center justify-between gap-2">
+          <h2
+            className="min-w-0 truncate text-title-medium"
+            style={{ color: "var(--content-emphasised)" }}
+          >
+            {skill.name}
+          </h2>
+          <SkillOriginBadge origin={skill.origin} />
+        </div>
+        <p
+          className="text-body-medium-lighter"
+          style={{ color: "var(--content-tertiary)" }}
+        >
+          {skill.description}
+        </p>
+      </div>
+
+      {/* Content card */}
+      <Card.Root asChild noPadding>
+        <div
+          className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border bg-[var(--surface-lift)]"
+          style={{ borderColor: "var(--border-hover)" }}
+        >
+          <div
+            className="flex items-center justify-between gap-2 border-b px-3 py-2"
+            style={{ borderColor: "var(--border-hover)" }}
+          >
+            <FileDropdown
+              fileEntries={fileEntries}
+              activePath={activePath}
+              activeName={activeFile?.name ?? null}
+              onSelect={setSelectedPath}
+            />
+            {/* Placeholder for the Preview/Source segment control (later PR). */}
+            <div />
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-hidden">
+            {isFilesLoading || isContentLoading ? (
+              <div className="flex h-full items-center justify-center">
+                <Loader2
+                  className="h-6 w-6 animate-spin"
+                  style={{ color: "var(--content-tertiary)" }}
+                />
+              </div>
+            ) : activeFile ? (
+              <SkillFileContent
+                fileName={activeFile.name}
+                content={fileContent}
+                isBinary={isBinary}
+              />
+            ) : (
+              <p
+                className="flex h-full items-center justify-center text-body-medium-lighter"
+                style={{ color: "var(--content-tertiary)" }}
+              >
+                Select a file to view its contents.
+              </p>
+            )}
+          </div>
+        </div>
+      </Card.Root>
+    </div>
+  );
+}
+
+function RightAction({
+  available,
+  removable,
+  isInstalling,
+  isRemoving,
+  onInstall,
+  onRemove,
+}: {
+  available: boolean;
+  removable: boolean;
+  isInstalling: boolean;
+  isRemoving: boolean;
+  onInstall?: () => void;
+  onRemove?: () => void;
+}) {
+  if (isInstalling || isRemoving) {
+    return (
+      <Button
+        variant="ghost"
+        iconOnly={<Loader2 className="animate-spin" aria-hidden />}
+        expandOnMobile
+        disabled
+        aria-label="Pending"
+        className="max-md:bg-[var(--surface-active)]"
+      />
+    );
+  }
+
+  if (available) {
+    return (
+      <Button
+        variant="ghost"
+        iconOnly={<ArrowDownToLine aria-hidden />}
+        expandOnMobile
+        aria-label="Install skill"
+        onClick={onInstall}
+        disabled={!onInstall}
+        className="max-md:bg-[var(--surface-active)]"
+      />
+    );
+  }
+
+  if (removable) {
+    return (
+      <Button
+        variant="dangerGhost"
+        iconOnly={<Trash2 aria-hidden />}
+        expandOnMobile
+        aria-label="Remove skill"
+        onClick={onRemove}
+        disabled={!onRemove}
+        className="max-md:rounded-full max-md:bg-[var(--system-negative-weak)]"
+      />
+    );
+  }
+
+  // Bundled: not available and not removable.
+  return (
+    <Button
+      variant="dangerGhost"
+      iconOnly={<Trash2 aria-hidden />}
+      expandOnMobile
+      disabled
+      title="Bundled skills cannot be removed"
+      aria-label="Bundled skill cannot be removed"
+      className="max-md:rounded-full max-md:bg-[var(--system-negative-weak)]"
+    />
+  );
+}
+
+function isDirectoryEntry(mimeType: string | null | undefined): boolean {
+  return (mimeType ?? "").endsWith("/directory");
+}
+
+function FileDropdown({
+  fileEntries,
+  activePath,
+  activeName,
+  onSelect,
+}: {
+  fileEntries: SkillFileEntry[];
+  activePath: string | null;
+  activeName: string | null;
+  onSelect: (path: string) => void;
+}) {
+  const label = activeName ?? "Select a file";
+
+  if (fileEntries.length === 0) {
+    return (
+      <span
+        className="flex min-w-0 items-center gap-2 text-body-medium-default"
+        style={{ color: "var(--content-emphasised)" }}
+      >
+        <FileGlyph />
+        <span className="truncate">{label}</span>
+      </span>
+    );
+  }
+
+  return (
+    <Menu.Root>
+      <Menu.Trigger>
+        <button
+          type="button"
+          className="flex min-w-0 items-center gap-2 rounded-md text-body-medium-default"
+          style={{ color: "var(--content-emphasised)" }}
+        >
+          <FileGlyph />
+          <span className="truncate">{label}</span>
+          <ChevronDown
+            className="h-4 w-4 shrink-0"
+            style={{ color: "var(--content-tertiary)" }}
+            aria-hidden
+          />
+        </button>
+      </Menu.Trigger>
+      <Menu.Content align="start">
+        {fileEntries.map((entry) => {
+          const isDirectory = isDirectoryEntry(entry.mimeType);
+          return (
+            <Menu.Item
+              key={entry.path}
+              onSelect={() => onSelect(entry.path)}
+              leftIcon={isDirectory ? <Folder /> : <FileText />}
+              aria-current={entry.path === activePath ? "true" : undefined}
+            >
+              {entry.name}
+            </Menu.Item>
+          );
+        })}
+      </Menu.Content>
+    </Menu.Root>
+  );
+}
+
+function FileGlyph() {
+  return (
+    <span
+      className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-[var(--surface-base)]"
+      aria-hidden
+    >
+      <FileText
+        className="h-4 w-4"
+        style={{ color: "var(--content-secondary)" }}
+      />
+    </span>
+  );
+}

--- a/apps/web/src/domains/intelligence/components/skills/skill-file-content.test.tsx
+++ b/apps/web/src/domains/intelligence/components/skills/skill-file-content.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * Tests for `SkillFileContent` view-mode rendering.
+ *
+ * A markdown file renders as rendered HTML in "preview" mode (no `<pre>`) and
+ * as raw source inside a `<pre>` in "raw" mode. Binary files always show the
+ * binary-file message.
+ *
+ * Mounted via `@testing-library/react` (happy-dom — see
+ * `apps/web/test-setup.ts`).
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { cleanup, render, screen } from "@testing-library/react";
+
+import { SkillFileContent } from "@/domains/intelligence/components/skills/skill-file-content.js";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("SkillFileContent", () => {
+  test("markdown preview renders rendered markdown without a <pre>", () => {
+    render(
+      <SkillFileContent
+        fileName="readme.md"
+        content="# Heading"
+        isBinary={false}
+        viewMode="preview"
+      />,
+    );
+
+    expect(screen.getByText("Heading")).toBeTruthy();
+    expect(document.querySelector("pre")).toBeNull();
+  });
+
+  test("markdown raw renders the source inside a <pre>", () => {
+    render(
+      <SkillFileContent
+        fileName="readme.md"
+        content="# Heading"
+        isBinary={false}
+        viewMode="raw"
+      />,
+    );
+
+    const pre = document.querySelector("pre");
+    expect(pre).not.toBeNull();
+    expect(pre?.textContent).toContain("# Heading");
+  });
+
+  test("binary file shows the binary message", () => {
+    render(
+      <SkillFileContent
+        fileName="logo.png"
+        content={null}
+        isBinary={true}
+      />,
+    );
+
+    expect(screen.getByText("Binary file — no preview available.")).toBeTruthy();
+  });
+});

--- a/apps/web/src/domains/intelligence/components/skills/skill-file-content.tsx
+++ b/apps/web/src/domains/intelligence/components/skills/skill-file-content.tsx
@@ -54,7 +54,7 @@ export function SkillFileContent({
 
   return (
     <pre
-      className="h-full overflow-auto p-4 font-mono text-body-small-default"
+      className="h-full overflow-y-auto whitespace-pre-wrap break-words p-4 font-mono text-body-small-default"
       style={{ color: "var(--content-default)" }}
     >
       {content}

--- a/apps/web/src/domains/intelligence/components/skills/skill-file-content.tsx
+++ b/apps/web/src/domains/intelligence/components/skills/skill-file-content.tsx
@@ -1,0 +1,63 @@
+import { FileMarkdown, isMarkdown } from "@/components/file-markdown";
+
+/**
+ * Standalone file-content viewer used by the mobile skill-detail view.
+ *
+ * Mirrors the private `FileContent` in `skill-detail.tsx` (desktop) but adds a
+ * `viewMode` prop so callers can toggle between the rendered markdown
+ * ("preview") and its raw source ("raw"). Non-markdown files always render as
+ * source regardless of `viewMode`.
+ */
+export function SkillFileContent({
+  fileName,
+  content,
+  isBinary,
+  viewMode = "preview",
+}: {
+  fileName: string;
+  content: string | null;
+  isBinary: boolean;
+  viewMode?: "preview" | "raw";
+}) {
+  if (isBinary) {
+    return (
+      <p
+        className="flex h-full items-center justify-center text-body-medium-lighter"
+        style={{ color: "var(--content-tertiary)" }}
+      >
+        Binary file — no preview available.
+      </p>
+    );
+  }
+
+  if (content === null) {
+    return (
+      <p
+        className="flex h-full items-center justify-center text-body-medium-lighter"
+        style={{ color: "var(--content-tertiary)" }}
+      >
+        No preview available for {fileName}.
+      </p>
+    );
+  }
+
+  if (isMarkdown(fileName, undefined) && viewMode === "preview") {
+    return (
+      <div
+        className="h-full overflow-auto px-6 py-4"
+        style={{ color: "var(--content-default)" }}
+      >
+        <FileMarkdown content={content} />
+      </div>
+    );
+  }
+
+  return (
+    <pre
+      className="h-full overflow-auto p-4 font-mono text-body-small-default"
+      style={{ color: "var(--content-default)" }}
+    >
+      {content}
+    </pre>
+  );
+}

--- a/apps/web/src/domains/intelligence/components/skills/skills-tab.tsx
+++ b/apps/web/src/domains/intelligence/components/skills/skills-tab.tsx
@@ -18,10 +18,12 @@ import { useCallback, useMemo, useState } from "react";
 
 import { Button, Card, ConfirmDialog } from "@vellum/design-library";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import { getLocalBool, setLocalBool } from "@/utils/local-settings";
 import { CategorySidebar } from "@/domains/intelligence/components/skills/category-sidebar";
 import { FilterBar } from "@/domains/intelligence/components/skills/skill-filters";
 import { SkillDetail } from "@/domains/intelligence/components/skills/skill-detail";
+import { SkillDetailMobile } from "@/domains/intelligence/components/skills/skill-detail-mobile";
 import { SkillRow } from "@/domains/intelligence/components/skills/skill-row";
 import {
   skillsGetOptions,
@@ -53,6 +55,7 @@ const TIP_STORAGE_KEY = "vellum:skills:tipDismissed";
 
 export function SkillsTab({ assistantId, initialSkillId }: SkillsTabProps) {
   const queryClient = useQueryClient();
+  const isMobile = useIsMobile();
 
   const [searchValue, setSearchValue] = useState("");
   const debouncedSearch = useDebouncedValue(searchValue.trim(), SEARCH_DEBOUNCE_MS);
@@ -195,17 +198,23 @@ export function SkillsTab({ assistantId, initialSkillId }: SkillsTabProps) {
   );
 
   if (selectedSkill) {
+    const detailProps = {
+      assistantId,
+      skill: selectedSkill,
+      onBack: () => setSelectedSkillId(null),
+      onInstall: () => handleInstall(selectedSkill),
+      onRemove: () => handleRemove(selectedSkill),
+      isInstalling:
+        installingSkillId === (selectedSkill.slug ?? selectedSkill.id),
+      isRemoving: removingSkillId === selectedSkill.id,
+    };
     return (
       <>
-        <SkillDetail
-          assistantId={assistantId}
-          skill={selectedSkill}
-          onBack={() => setSelectedSkillId(null)}
-          onInstall={() => handleInstall(selectedSkill)}
-          onRemove={() => handleRemove(selectedSkill)}
-          isInstalling={installingSkillId === (selectedSkill.slug ?? selectedSkill.id)}
-          isRemoving={removingSkillId === selectedSkill.id}
-        />
+        {isMobile ? (
+          <SkillDetailMobile {...detailProps} />
+        ) : (
+          <SkillDetail {...detailProps} />
+        )}
         {removalDialog}
       </>
     );

--- a/apps/web/src/domains/intelligence/skills/use-skill-detail-files.test.ts
+++ b/apps/web/src/domains/intelligence/skills/use-skill-detail-files.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Tests for `pickDefaultFilePath`, the pure helper backing
+ * `useSkillDetailFiles`. It resolves which file path should be active given the
+ * current selection, defaulting to a `SKILL.md` entry when nothing is selected.
+ */
+
+import { describe, expect, it } from "bun:test";
+
+import type { SkillFileEntry } from "@/domains/intelligence/skills/types.js";
+import { pickDefaultFilePath } from "@/domains/intelligence/skills/use-skill-detail-files.js";
+
+function makeEntry(overrides: Partial<SkillFileEntry> = {}): SkillFileEntry {
+  return {
+    name: "file.txt",
+    path: "file.txt",
+    size: 0,
+    mimeType: "text/plain",
+    isBinary: false,
+    content: "",
+    ...overrides,
+  };
+}
+
+describe("pickDefaultFilePath", () => {
+  it("returns the selected path when one is set", () => {
+    const entries = [
+      makeEntry({ name: "SKILL.md", path: "SKILL.md" }),
+      makeEntry({ name: "other.md", path: "docs/other.md" }),
+    ];
+
+    expect(pickDefaultFilePath(entries, "docs/other.md")).toBe("docs/other.md");
+  });
+
+  it("returns the SKILL.md path when nothing is selected and it exists", () => {
+    const entries = [
+      makeEntry({ name: "other.md", path: "docs/other.md" }),
+      makeEntry({ name: "SKILL.md", path: "SKILL.md" }),
+    ];
+
+    expect(pickDefaultFilePath(entries, null)).toBe("SKILL.md");
+  });
+
+  it("returns null when nothing is selected and there is no SKILL.md", () => {
+    const entries = [makeEntry({ name: "other.md", path: "docs/other.md" })];
+
+    expect(pickDefaultFilePath(entries, null)).toBeNull();
+  });
+});

--- a/apps/web/src/domains/intelligence/skills/use-skill-detail-files.ts
+++ b/apps/web/src/domains/intelligence/skills/use-skill-detail-files.ts
@@ -1,0 +1,77 @@
+import { useQuery } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
+
+import {
+  skillsByIdFilesContentGetOptions,
+  skillsByIdFilesGetOptions,
+} from "@/generated/daemon/@tanstack/react-query.gen";
+import type { SkillsByIdFilesContentGetResponse } from "@/generated/daemon/types.gen";
+import type { SkillFileEntry } from "@/domains/intelligence/skills/types";
+
+/**
+ * Resolve the file path that should be active given the current selection.
+ *
+ * Falls back to the skill's `SKILL.md` entry when nothing is explicitly
+ * selected, mirroring the default-file behavior of the desktop skill detail.
+ */
+export function pickDefaultFilePath(
+  fileEntries: SkillFileEntry[],
+  selectedPath: string | null,
+): string | null {
+  return (
+    selectedPath ?? fileEntries.find((f) => f.name === "SKILL.md")?.path ?? null
+  );
+}
+
+/**
+ * Shared data hook for browsing a skill's files: lists the entries, tracks the
+ * selected file (defaulting to `SKILL.md`), and fetches the active file's
+ * content. Extracted so multiple layouts (desktop + mobile) can reuse the same
+ * query setup without duplication.
+ */
+export function useSkillDetailFiles(assistantId: string, skillId: string) {
+  const [selectedPath, setSelectedPath] = useState<string | null>(null);
+
+  const filesQuery = useQuery({
+    ...skillsByIdFilesGetOptions({
+      path: { assistant_id: assistantId, id: skillId },
+    }),
+    select: (data) => data ?? null,
+  });
+
+  const fileEntries = useMemo<SkillFileEntry[]>(
+    () => filesQuery.data?.files ?? [],
+    [filesQuery.data],
+  );
+
+  const skillMd = useMemo(
+    () => fileEntries.find((f) => f.name === "SKILL.md"),
+    [fileEntries],
+  );
+
+  const activePath = pickDefaultFilePath(fileEntries, selectedPath);
+
+  const fileContentQuery = useQuery({
+    ...skillsByIdFilesContentGetOptions({
+      path: { assistant_id: assistantId, id: skillId },
+      query: { path: activePath ?? "" },
+    }),
+    select: (data): SkillsByIdFilesContentGetResponse | null => data ?? null,
+    enabled: Boolean(activePath),
+  });
+
+  const activeFile = fileEntries.find((f) => f.path === activePath);
+
+  return {
+    fileEntries,
+    skillMd,
+    selectedPath,
+    setSelectedPath,
+    activePath,
+    activeFile,
+    isFilesLoading: filesQuery.isLoading,
+    fileContent: fileContentQuery.data?.content ?? null,
+    isBinary: Boolean(fileContentQuery.data?.isBinary),
+    isContentLoading: fileContentQuery.isLoading,
+  };
+}


### PR DESCRIPTION
## Summary
Restyles the opened-skill **detail view** (tapping a skill row) to match the iOS Figma mock (`cCGBcpVDbn22kj3OPU58W8`, node `4505-122412`). Adds a new single-column mobile layout — action bar (circular back · centered skill name · circular trash/install) + header block (title + origin badge + full description) + content card (inline file dropdown + Preview/Source segment control over the file body) — rendered only on mobile viewports via `useIsMobile()`. The desktop two-pane `SkillDetail` is left completely untouched.

To make this iOS-only instead of all narrow viewports, change the single gate in `skills-tab.tsx` from `useIsMobile()` to `useIsNativePlatform()`.

## Self-review result
Skipped (`--skip-reviews`).

## PRs merged into feature branch
- #33354: feat(web): add useSkillDetailFiles hook for skill file browsing (PR 1)
- #33353: feat(web): add SkillFileContent viewer with preview/raw mode (PR 2)
- #33355: feat(web): add mobile skill detail layout matching Figma mock (PR 3)
- #33357: feat(web): add preview/source toggle to mobile skill detail (PR 4)

Part of plan: ios-skill-detail-mock.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)