### PR TITLE
feat(gateway): device-scoped, revocable /v1/pair token minting

### DIFF
--- a/gateway/src/__tests__/pair-device-bound.test.ts
+++ b/gateway/src/__tests__/pair-device-bound.test.ts
@@ -108,6 +108,19 @@ describe("/v1/pair device-bound minting", () => {
     expect(refresh[0].hashedDeviceId).toBe(hashToken("device-A"));
   });
 
+  test("uses the short 24h pair TTL for the access token, not the 30-day bootstrap default", async () => {
+    const before = Date.now();
+    await handlePair(makePairRequest({ deviceId: "device-A" }), LOOPBACK_IP);
+
+    const PAIR_TTL_MS = 24 * 60 * 60 * 1000;
+    const [token] = activeTokens();
+    // expiresAt should be ~24h out (allow a generous window), and well under
+    // the 30-day bootstrap TTL — until hot-path revocation lands, the access
+    // token's blast radius must stay bounded.
+    expect(token.expiresAt! - before).toBeGreaterThan(PAIR_TTL_MS - 60_000);
+    expect(token.expiresAt! - before).toBeLessThan(PAIR_TTL_MS + 60_000);
+  });
+
   test("the returned refresh token can be rotated via the refresh handler", async () => {
     const res = await handlePair(
       makePairRequest({ deviceId: "device-A" }),

--- a/gateway/src/__tests__/pair-device-bound.test.ts
+++ b/gateway/src/__tests__/pair-device-bound.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Tests for device-scoped /v1/pair minting: when a request supplies a deviceId,
+ * pair mints a DB-recorded, revocable, refreshable token pair (instead of the
+ * legacy stateless token).
+ */
+import { describe, test, expect, mock, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { eq } from "drizzle-orm";
+
+import { initSigningKey } from "../auth/token-service.js";
+
+// Must init signing key before importing modules that mint tokens.
+initSigningKey(Buffer.from("test-signing-key-at-least-32-bytes-long-xx"));
+
+// pair.ts → resolveLocalGuardianPrincipalId() queries the assistant DB; mock it
+// to return a stable principal. The device-bound token records live in the
+// (real) gateway DB initialized below.
+const mockQuery = mock();
+mock.module("../db/assistant-db-proxy.js", () => ({
+  assistantDbQuery: mockQuery,
+  assistantDbRun: mock(),
+  assistantDbExec: mock(),
+}));
+
+const { initGatewayDb, resetGatewayDb, getGatewayDb } =
+  await import("../db/connection.js");
+const { actorTokenRecords, actorRefreshTokenRecords } =
+  await import("../db/schema.js");
+const { handlePair, resetPairRateLimiterForTests } =
+  await import("../http/routes/pair.js");
+const { rotateCredentials } = await import("../auth/guardian-refresh.js");
+const { hashToken } = await import("../auth/guardian-bootstrap.js");
+
+const LOOPBACK_IP = "127.0.0.1";
+const PROD_ORIGIN = "chrome-extension://hphbdmpffeigpcdjkckleobjmhhokpne";
+const GUARDIAN_ID = "guardian-001";
+
+let testRoot: string;
+
+function makePairRequest(body?: Record<string, unknown>): Request {
+  return new Request("http://localhost:7830/v1/pair", {
+    method: "POST",
+    headers: {
+      host: "localhost:7830",
+      "content-type": "application/json",
+      origin: PROD_ORIGIN,
+      "x-vellum-interface-id": "chrome-extension",
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+function activeTokens() {
+  return getGatewayDb()
+    .select()
+    .from(actorTokenRecords)
+    .where(eq(actorTokenRecords.status, "active"))
+    .all();
+}
+
+beforeEach(async () => {
+  resetPairRateLimiterForTests();
+  mockQuery.mockResolvedValue([{ principalId: GUARDIAN_ID }]);
+  testRoot = mkdtempSync(join(tmpdir(), "pair-device-test-"));
+  const securityDir = join(testRoot, "protected");
+  mkdirSync(securityDir, { recursive: true });
+  process.env.GATEWAY_SECURITY_DIR = securityDir;
+  await initGatewayDb();
+});
+
+afterEach(() => {
+  resetGatewayDb();
+  delete process.env.GATEWAY_SECURITY_DIR;
+  try {
+    rmSync(testRoot, { recursive: true, force: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+describe("/v1/pair device-bound minting", () => {
+  test("records an access + refresh token bound to the device and returns a refresh token", async () => {
+    const res = await handlePair(
+      makePairRequest({ deviceId: "device-A", platform: "web" }),
+      LOOPBACK_IP,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+
+    expect(typeof body.token).toBe("string");
+    expect(typeof body.refreshToken).toBe("string");
+    expect(typeof body.refreshAfter).toBe("string");
+
+    const tokens = activeTokens();
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0].guardianPrincipalId).toBe(GUARDIAN_ID);
+    expect(tokens[0].hashedDeviceId).toBe(hashToken("device-A"));
+    expect(tokens[0].platform).toBe("web");
+
+    const refresh = getGatewayDb()
+      .select()
+      .from(actorRefreshTokenRecords)
+      .where(eq(actorRefreshTokenRecords.status, "active"))
+      .all();
+    expect(refresh).toHaveLength(1);
+    expect(refresh[0].hashedDeviceId).toBe(hashToken("device-A"));
+  });
+
+  test("the returned refresh token can be rotated via the refresh handler", async () => {
+    const res = await handlePair(
+      makePairRequest({ deviceId: "device-A" }),
+      LOOPBACK_IP,
+    );
+    const { refreshToken } = (await res.json()) as { refreshToken: string };
+
+    const rotated = rotateCredentials({ refreshToken });
+    expect(rotated.ok).toBe(true);
+    if (!rotated.ok) throw new Error("expected rotation to succeed");
+    expect(rotated.result.accessToken).toBeTruthy();
+    expect(rotated.result.refreshToken).toBeTruthy();
+    expect(rotated.result.refreshToken).not.toBe(refreshToken);
+  });
+
+  test("re-pairing the same device revokes the prior active token (no unique-index violation)", async () => {
+    const first = await handlePair(
+      makePairRequest({ deviceId: "device-A" }),
+      LOOPBACK_IP,
+    );
+    const firstToken = (await first.json()) as { token: string };
+
+    const second = await handlePair(
+      makePairRequest({ deviceId: "device-A" }),
+      LOOPBACK_IP,
+    );
+    expect(second.status).toBe(200);
+
+    // Exactly one active token remains for the device; the first is revoked.
+    const tokens = activeTokens();
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0].tokenHash).not.toBe(hashToken(firstToken.token));
+  });
+
+  test("without a deviceId, returns the legacy stateless token and records nothing", async () => {
+    const res = await handlePair(makePairRequest(), LOOPBACK_IP);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+
+    expect(typeof body.token).toBe("string");
+    expect(body.refreshToken).toBeUndefined();
+    expect(body.refreshAfter).toBeUndefined();
+
+    expect(activeTokens()).toHaveLength(0);
+  });
+});

--- a/gateway/src/__tests__/pair-device-bound.test.ts
+++ b/gateway/src/__tests__/pair-device-bound.test.ts
@@ -30,7 +30,6 @@ const { actorTokenRecords, actorRefreshTokenRecords } =
   await import("../db/schema.js");
 const { handlePair, resetPairRateLimiterForTests } =
   await import("../http/routes/pair.js");
-const { rotateCredentials } = await import("../auth/guardian-refresh.js");
 const { hashToken } = await import("../auth/guardian-bootstrap.js");
 
 const LOOPBACK_IP = "127.0.0.1";
@@ -81,7 +80,7 @@ afterEach(() => {
 });
 
 describe("/v1/pair device-bound minting", () => {
-  test("records an access + refresh token bound to the device and returns a refresh token", async () => {
+  test("records a device-bound access token and issues NO refresh token", async () => {
     const res = await handlePair(
       makePairRequest({ deviceId: "device-A", platform: "web" }),
       LOOPBACK_IP,
@@ -90,8 +89,9 @@ describe("/v1/pair device-bound minting", () => {
     const body = (await res.json()) as Record<string, unknown>;
 
     expect(typeof body.token).toBe("string");
-    expect(typeof body.refreshToken).toBe("string");
-    expect(typeof body.refreshAfter).toBe("string");
+    // Refreshable pairing is deferred until hot-path revocation is enforced.
+    expect(body.refreshToken).toBeUndefined();
+    expect(body.refreshAfter).toBeUndefined();
 
     const tokens = activeTokens();
     expect(tokens).toHaveLength(1);
@@ -99,13 +99,13 @@ describe("/v1/pair device-bound minting", () => {
     expect(tokens[0].hashedDeviceId).toBe(hashToken("device-A"));
     expect(tokens[0].platform).toBe("web");
 
+    // No refresh token record is created on the pair path.
     const refresh = getGatewayDb()
       .select()
       .from(actorRefreshTokenRecords)
       .where(eq(actorRefreshTokenRecords.status, "active"))
       .all();
-    expect(refresh).toHaveLength(1);
-    expect(refresh[0].hashedDeviceId).toBe(hashToken("device-A"));
+    expect(refresh).toHaveLength(0);
   });
 
   test("uses the short 24h pair TTL for the access token, not the 30-day bootstrap default", async () => {
@@ -119,21 +119,6 @@ describe("/v1/pair device-bound minting", () => {
     // token's blast radius must stay bounded.
     expect(token.expiresAt! - before).toBeGreaterThan(PAIR_TTL_MS - 60_000);
     expect(token.expiresAt! - before).toBeLessThan(PAIR_TTL_MS + 60_000);
-  });
-
-  test("the returned refresh token can be rotated via the refresh handler", async () => {
-    const res = await handlePair(
-      makePairRequest({ deviceId: "device-A" }),
-      LOOPBACK_IP,
-    );
-    const { refreshToken } = (await res.json()) as { refreshToken: string };
-
-    const rotated = rotateCredentials({ refreshToken });
-    expect(rotated.ok).toBe(true);
-    if (!rotated.ok) throw new Error("expected rotation to succeed");
-    expect(rotated.result.accessToken).toBeTruthy();
-    expect(rotated.result.refreshToken).toBeTruthy();
-    expect(rotated.result.refreshToken).not.toBe(refreshToken);
   });
 
   test("re-pairing the same device revokes the prior active token (no unique-index violation)", async () => {

--- a/gateway/src/auth/guardian-bootstrap.ts
+++ b/gateway/src/auth/guardian-bootstrap.ts
@@ -461,6 +461,7 @@ function mintAccessToken(
   guardianPrincipalId: string,
   hashedDeviceId: string,
   platform: string,
+  ttlSeconds: number = ACCESS_TOKEN_TTL_SECONDS,
 ): { token: string; expiresAt: number } {
   const externalAssistantId = getExternalAssistantId();
   const sub = `actor:${externalAssistantId}:${guardianPrincipalId}`;
@@ -470,11 +471,11 @@ function mintAccessToken(
     sub,
     scope_profile: "actor_client_v1",
     policy_epoch: CURRENT_POLICY_EPOCH,
-    ttlSeconds: ACCESS_TOKEN_TTL_SECONDS,
+    ttlSeconds,
   });
 
   const now = Date.now();
-  const expiresAt = now + ACCESS_TOKEN_TTL_MS;
+  const expiresAt = now + ttlSeconds * 1000;
   const tokenHash = hashToken(token);
 
   getGatewayDb()
@@ -503,6 +504,7 @@ function mintRefreshToken(
   guardianPrincipalId: string,
   hashedDeviceId: string,
   platform: string,
+  accessTtlMs: number = ACCESS_TOKEN_TTL_MS,
 ): {
   refreshToken: string;
   refreshTokenExpiresAt: number;
@@ -537,8 +539,7 @@ function mintRefreshToken(
   return {
     refreshToken,
     refreshTokenExpiresAt: Math.min(absoluteExpiresAt, inactivityExpiresAt),
-    refreshAfter:
-      now + Math.floor(ACCESS_TOKEN_TTL_MS * REFRESH_AFTER_FRACTION),
+    refreshAfter: now + Math.floor(accessTtlMs * REFRESH_AFTER_FRACTION),
   };
 }
 
@@ -550,13 +551,20 @@ function mintRefreshToken(
  * pairing. The device binding enforces one active token per
  * (guardianPrincipalId, hashedDeviceId) via a unique index, so re-minting for
  * the same device first revokes the prior tokens.
+ *
+ * `accessTtlSeconds` controls the access-token lifetime (default: the
+ * bootstrap TTL). Callers can pass a shorter value — e.g. loopback pairing
+ * keeps a short access TTL so a token stays low-blast-radius until hot-path
+ * revocation is enforced; the refresh token remains long-lived and DB-backed.
  */
 export function mintAndRecordDeviceBoundTokenPair(params: {
   guardianPrincipalId: string;
   deviceId: string;
   platform: string;
+  accessTtlSeconds?: number;
 }): DeviceBoundTokenPair {
   const hashedDeviceId = hashToken(params.deviceId);
+  const accessTtlSeconds = params.accessTtlSeconds ?? ACCESS_TOKEN_TTL_SECONDS;
 
   revokeActorTokensByDevice(params.guardianPrincipalId, hashedDeviceId);
   revokeRefreshTokensByDevice(params.guardianPrincipalId, hashedDeviceId);
@@ -565,11 +573,13 @@ export function mintAndRecordDeviceBoundTokenPair(params: {
     params.guardianPrincipalId,
     hashedDeviceId,
     params.platform,
+    accessTtlSeconds,
   );
   const refresh = mintRefreshToken(
     params.guardianPrincipalId,
     hashedDeviceId,
     params.platform,
+    accessTtlSeconds * 1000,
   );
 
   return {

--- a/gateway/src/auth/guardian-bootstrap.ts
+++ b/gateway/src/auth/guardian-bootstrap.ts
@@ -402,6 +402,17 @@ export async function createGuardianBinding(
 // ---------------------------------------------------------------------------
 
 /**
+ * A freshly minted, DB-recorded access + refresh token pair bound to a device.
+ */
+export interface DeviceBoundTokenPair {
+  accessToken: string;
+  accessTokenExpiresAt: number;
+  refreshToken: string;
+  refreshTokenExpiresAt: number;
+  refreshAfter: number;
+}
+
+/**
  * Revoke active actor tokens for a device binding.
  */
 function revokeActorTokensByDevice(
@@ -531,6 +542,45 @@ function mintRefreshToken(
   };
 }
 
+/**
+ * Revoke any existing credentials for a (guardian, device) pair and mint a
+ * fresh, DB-recorded access + refresh token pair bound to that device.
+ *
+ * This is the shared core used by both guardian bootstrap and device-scoped
+ * pairing. The device binding enforces one active token per
+ * (guardianPrincipalId, hashedDeviceId) via a unique index, so re-minting for
+ * the same device first revokes the prior tokens.
+ */
+export function mintAndRecordDeviceBoundTokenPair(params: {
+  guardianPrincipalId: string;
+  deviceId: string;
+  platform: string;
+}): DeviceBoundTokenPair {
+  const hashedDeviceId = hashToken(params.deviceId);
+
+  revokeActorTokensByDevice(params.guardianPrincipalId, hashedDeviceId);
+  revokeRefreshTokensByDevice(params.guardianPrincipalId, hashedDeviceId);
+
+  const access = mintAccessToken(
+    params.guardianPrincipalId,
+    hashedDeviceId,
+    params.platform,
+  );
+  const refresh = mintRefreshToken(
+    params.guardianPrincipalId,
+    hashedDeviceId,
+    params.platform,
+  );
+
+  return {
+    accessToken: access.token,
+    accessTokenExpiresAt: access.expiresAt,
+    refreshToken: refresh.refreshToken,
+    refreshTokenExpiresAt: refresh.refreshTokenExpiresAt,
+    refreshAfter: refresh.refreshAfter,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Public: guardian bootstrap
 // ---------------------------------------------------------------------------
@@ -628,10 +678,6 @@ export async function bootstrapGuardian(params: {
   platform: string;
   deviceId: string;
 }): Promise<GuardianBootstrapResult> {
-  const hashedDeviceId = createHash("sha256")
-    .update(params.deviceId)
-    .digest("hex");
-
   // 1. Ensure guardian principal
   let isNew = false;
   let guardianPrincipalId: string;
@@ -651,21 +697,12 @@ export async function bootstrapGuardian(params: {
     isNew = true;
   }
 
-  // 2. Revoke existing credentials for this device
-  revokeActorTokensByDevice(guardianPrincipalId, hashedDeviceId);
-  revokeRefreshTokensByDevice(guardianPrincipalId, hashedDeviceId);
-
-  // 3. Mint new credentials
-  const access = mintAccessToken(
+  // 2. Revoke existing credentials for this device and mint a fresh pair.
+  const pair = mintAndRecordDeviceBoundTokenPair({
     guardianPrincipalId,
-    hashedDeviceId,
-    params.platform,
-  );
-  const refresh = mintRefreshToken(
-    guardianPrincipalId,
-    hashedDeviceId,
-    params.platform,
-  );
+    deviceId: params.deviceId,
+    platform: params.platform,
+  });
 
   log.info(
     { platform: params.platform, guardianPrincipalId, isNew },
@@ -674,11 +711,11 @@ export async function bootstrapGuardian(params: {
 
   return {
     guardianPrincipalId,
-    accessToken: access.token,
-    accessTokenExpiresAt: access.expiresAt,
-    refreshToken: refresh.refreshToken,
-    refreshTokenExpiresAt: refresh.refreshTokenExpiresAt,
-    refreshAfter: refresh.refreshAfter,
+    accessToken: pair.accessToken,
+    accessTokenExpiresAt: pair.accessTokenExpiresAt,
+    refreshToken: pair.refreshToken,
+    refreshTokenExpiresAt: pair.refreshTokenExpiresAt,
+    refreshAfter: pair.refreshAfter,
     isNew,
   };
 }

--- a/gateway/src/auth/guardian-bootstrap.ts
+++ b/gateway/src/auth/guardian-bootstrap.ts
@@ -504,7 +504,6 @@ function mintRefreshToken(
   guardianPrincipalId: string,
   hashedDeviceId: string,
   platform: string,
-  accessTtlMs: number = ACCESS_TOKEN_TTL_MS,
 ): {
   refreshToken: string;
   refreshTokenExpiresAt: number;
@@ -539,7 +538,8 @@ function mintRefreshToken(
   return {
     refreshToken,
     refreshTokenExpiresAt: Math.min(absoluteExpiresAt, inactivityExpiresAt),
-    refreshAfter: now + Math.floor(accessTtlMs * REFRESH_AFTER_FRACTION),
+    refreshAfter:
+      now + Math.floor(ACCESS_TOKEN_TTL_MS * REFRESH_AFTER_FRACTION),
   };
 }
 
@@ -547,24 +547,17 @@ function mintRefreshToken(
  * Revoke any existing credentials for a (guardian, device) pair and mint a
  * fresh, DB-recorded access + refresh token pair bound to that device.
  *
- * This is the shared core used by both guardian bootstrap and device-scoped
- * pairing. The device binding enforces one active token per
- * (guardianPrincipalId, hashedDeviceId) via a unique index, so re-minting for
- * the same device first revokes the prior tokens.
- *
- * `accessTtlSeconds` controls the access-token lifetime (default: the
- * bootstrap TTL). Callers can pass a shorter value — e.g. loopback pairing
- * keeps a short access TTL so a token stays low-blast-radius until hot-path
- * revocation is enforced; the refresh token remains long-lived and DB-backed.
+ * This is the shared core used by guardian bootstrap (and any other flow that
+ * needs a full refreshable credential). The device binding enforces one active
+ * token per (guardianPrincipalId, hashedDeviceId) via a unique index, so
+ * re-minting for the same device first revokes the prior tokens.
  */
 export function mintAndRecordDeviceBoundTokenPair(params: {
   guardianPrincipalId: string;
   deviceId: string;
   platform: string;
-  accessTtlSeconds?: number;
 }): DeviceBoundTokenPair {
   const hashedDeviceId = hashToken(params.deviceId);
-  const accessTtlSeconds = params.accessTtlSeconds ?? ACCESS_TOKEN_TTL_SECONDS;
 
   revokeActorTokensByDevice(params.guardianPrincipalId, hashedDeviceId);
   revokeRefreshTokensByDevice(params.guardianPrincipalId, hashedDeviceId);
@@ -573,13 +566,11 @@ export function mintAndRecordDeviceBoundTokenPair(params: {
     params.guardianPrincipalId,
     hashedDeviceId,
     params.platform,
-    accessTtlSeconds,
   );
   const refresh = mintRefreshToken(
     params.guardianPrincipalId,
     hashedDeviceId,
     params.platform,
-    accessTtlSeconds * 1000,
   );
 
   return {
@@ -589,6 +580,39 @@ export function mintAndRecordDeviceBoundTokenPair(params: {
     refreshTokenExpiresAt: refresh.refreshTokenExpiresAt,
     refreshAfter: refresh.refreshAfter,
   };
+}
+
+/**
+ * Revoke any existing credentials for a (guardian, device) pair and mint a
+ * fresh, DB-recorded access token bound to that device — WITHOUT a refresh
+ * token.
+ *
+ * Used by loopback pairing: the recorded token is revocable per device (once
+ * hot-path revocation is enforced), and `ttlSeconds` keeps it short so its
+ * blast radius stays bounded in the interim. No refresh token is issued —
+ * refreshable pairing is deferred until revocation is enforced on live
+ * requests, so a long-lived refresh can't silently re-mint long access tokens.
+ * Callers re-pair when the access token expires.
+ */
+export function mintAndRecordDeviceBoundAccessToken(params: {
+  guardianPrincipalId: string;
+  deviceId: string;
+  platform: string;
+  ttlSeconds: number;
+}): { accessToken: string; accessTokenExpiresAt: number } {
+  const hashedDeviceId = hashToken(params.deviceId);
+
+  revokeActorTokensByDevice(params.guardianPrincipalId, hashedDeviceId);
+  revokeRefreshTokensByDevice(params.guardianPrincipalId, hashedDeviceId);
+
+  const access = mintAccessToken(
+    params.guardianPrincipalId,
+    hashedDeviceId,
+    params.platform,
+    params.ttlSeconds,
+  );
+
+  return { accessToken: access.token, accessTokenExpiresAt: access.expiresAt };
 }
 
 // ---------------------------------------------------------------------------

--- a/gateway/src/http/routes/pair.ts
+++ b/gateway/src/http/routes/pair.ts
@@ -24,6 +24,7 @@
  * Response body: `{ token, expiresAt, guardianId, assistantId }`
  */
 
+import { mintAndRecordDeviceBoundTokenPair } from "../../auth/guardian-bootstrap.js";
 import { CURRENT_POLICY_EPOCH } from "../../auth/policy.js";
 import { mintToken } from "../../auth/token-service.js";
 import { KNOWN_EXTENSION_ORIGINS } from "../../chrome-extension-origins.js";
@@ -282,6 +283,29 @@ export async function handlePair(
   const guardianPrincipalId = await resolveLocalGuardianPrincipalId();
   const assistantId = getExternalAssistantId();
 
+  // Optionally, a client may supply a deviceId to receive a device-bound,
+  // DB-recorded, refreshable token pair (revocable per device) instead of the
+  // legacy stateless token. The body is optional — a malformed or absent body
+  // simply leaves deviceId undefined and preserves the stateless path.
+  let deviceId: string | undefined;
+  let bodyPlatform: string | undefined;
+  if ((req.headers.get("content-type") ?? "").includes("json")) {
+    try {
+      const body = (await req.json()) as {
+        deviceId?: unknown;
+        platform?: unknown;
+      };
+      if (typeof body.deviceId === "string" && body.deviceId.trim()) {
+        deviceId = body.deviceId.trim();
+      }
+      if (typeof body.platform === "string" && body.platform.trim()) {
+        bodyPlatform = body.platform.trim();
+      }
+    } catch {
+      // Ignore malformed/empty body — fall back to the stateless path.
+    }
+  }
+
   if (interfaceId === "chrome-extension") {
     // Require the request to originate from a known Vellum extension origin.
     //
@@ -305,6 +329,30 @@ export async function handlePair(
         "origin does not match a known Vellum extension",
         403,
       );
+    }
+
+    // Device-bound path: mint a recorded, revocable, refreshable token pair.
+    if (deviceId) {
+      const platform = bodyPlatform ?? interfaceId;
+      const pair = mintAndRecordDeviceBoundTokenPair({
+        guardianPrincipalId,
+        deviceId,
+        platform,
+      });
+
+      log.info(
+        { interfaceId, clientId, guardianPrincipalId, platform },
+        "Client paired successfully via loopback (device-bound)",
+      );
+
+      return Response.json({
+        token: pair.accessToken,
+        expiresAt: new Date(pair.accessTokenExpiresAt).toISOString(),
+        guardianId: guardianPrincipalId,
+        assistantId,
+        refreshToken: pair.refreshToken,
+        refreshAfter: new Date(pair.refreshAfter).toISOString(),
+      });
     }
 
     const expiresAt = Date.now() + PAIR_TOKEN_TTL_SECONDS * 1000;

--- a/gateway/src/http/routes/pair.ts
+++ b/gateway/src/http/routes/pair.ts
@@ -24,7 +24,7 @@
  * Response body: `{ token, expiresAt, guardianId, assistantId }`
  */
 
-import { mintAndRecordDeviceBoundTokenPair } from "../../auth/guardian-bootstrap.js";
+import { mintAndRecordDeviceBoundAccessToken } from "../../auth/guardian-bootstrap.js";
 import { CURRENT_POLICY_EPOCH } from "../../auth/policy.js";
 import { mintToken } from "../../auth/token-service.js";
 import { KNOWN_EXTENSION_ORIGINS } from "../../chrome-extension-origins.js";
@@ -331,19 +331,19 @@ export async function handlePair(
       );
     }
 
-    // Device-bound path: mint a recorded, revocable, refreshable token pair.
-    // Keep the access token on the short pair TTL (not the 30-day bootstrap
-    // default): until hot-path revocation is enforced, the access JWT is only
-    // checked by signature, so a short lifetime bounds its blast radius. The
-    // refresh token is long-lived and DB-backed, so the client stays paired by
-    // rotating through the refresh endpoint (which honors revocation).
+    // Device-bound path: mint a recorded, per-device-revocable access token on
+    // the same short pair TTL as the stateless path. No refresh token is
+    // issued — until hot-path revocation is enforced, a long-lived refresh
+    // could silently re-mint long access tokens, so refreshable pairing is
+    // deferred. The recorded token becomes immediately revocable once the
+    // revocation check lands; in the interim the short TTL bounds its reach.
     if (deviceId) {
       const platform = bodyPlatform ?? interfaceId;
-      const pair = mintAndRecordDeviceBoundTokenPair({
+      const access = mintAndRecordDeviceBoundAccessToken({
         guardianPrincipalId,
         deviceId,
         platform,
-        accessTtlSeconds: PAIR_TOKEN_TTL_SECONDS,
+        ttlSeconds: PAIR_TOKEN_TTL_SECONDS,
       });
 
       log.info(
@@ -352,12 +352,10 @@ export async function handlePair(
       );
 
       return Response.json({
-        token: pair.accessToken,
-        expiresAt: new Date(pair.accessTokenExpiresAt).toISOString(),
+        token: access.accessToken,
+        expiresAt: new Date(access.accessTokenExpiresAt).toISOString(),
         guardianId: guardianPrincipalId,
         assistantId,
-        refreshToken: pair.refreshToken,
-        refreshAfter: new Date(pair.refreshAfter).toISOString(),
       });
     }
 

--- a/gateway/src/http/routes/pair.ts
+++ b/gateway/src/http/routes/pair.ts
@@ -332,12 +332,18 @@ export async function handlePair(
     }
 
     // Device-bound path: mint a recorded, revocable, refreshable token pair.
+    // Keep the access token on the short pair TTL (not the 30-day bootstrap
+    // default): until hot-path revocation is enforced, the access JWT is only
+    // checked by signature, so a short lifetime bounds its blast radius. The
+    // refresh token is long-lived and DB-backed, so the client stays paired by
+    // rotating through the refresh endpoint (which honors revocation).
     if (deviceId) {
       const platform = bodyPlatform ?? interfaceId;
       const pair = mintAndRecordDeviceBoundTokenPair({
         guardianPrincipalId,
         deviceId,
         platform,
+        accessTtlSeconds: PAIR_TOKEN_TTL_SECONDS,
       });
 
       log.info(


### PR DESCRIPTION
## Summary
- Extracts a shared, exported `mintAndRecordDeviceBoundTokenPair(...)` from the previously-private mint/record/revoke logic in `guardian-bootstrap.ts`, and routes `bootstrapGuardian` through it — a **pure refactor with no behavior change** (existing bootstrap/guardian-init tests pass unchanged).
- Adds a sibling `mintAndRecordDeviceBoundAccessToken(...)` (access token only, no refresh) and wires `/v1/pair` to use it **when a `deviceId` is supplied**: a recorded, per-device-revocable access token on the same short **24h** pair TTL.
- **Backward-compatible:** no `deviceId` → identical stateless token + response, no DB record. The existing chrome-extension flow is untouched, and the device-bound response shape matches the stateless one (the difference is internal: the token is now recorded/device-bound).

## Why
Foundation for revocable, device-scoped pairing and PR 3 (a hot-path revocation check). Recording the pair token (keyed by `hashedDeviceId`, one active per device) makes it revocable the moment PR 3 lands.

## Why no refresh token on the pair path (review-driven)
Reviewers correctly noted that issuing a long-lived refresh token here is unsafe **until revocation is enforced on live requests**: `validateEdgeToken` only checks the JWT signature today, and a refresh would re-mint long-lived access tokens that can't yet be revoked. So the pair path issues a short (24h) recorded access token and **no refresh** — clients re-pair on expiry (same UX as the prior stateless token). Refreshable pairing is deferred to the PR that lands alongside hot-path revocation, where it's safe. `bootstrapGuardian` continues to issue its full access+refresh pair (unchanged), since those flows already exist.

## Deferred to later PRs
- Refreshable pairing (lands with hot-path revocation enforcement, PR 3).
- Opening `/v1/pair` to non-`chrome-extension` interface IDs.
- The `/v1/pair/redeem` browser endpoint and the `vellum pair` CLI.

## Tests
- pair WITH deviceId records an active, device-bound access token (correct `hashedDeviceId`, `platform`) and issues NO refresh token (no refresh record).
- the access token uses the short 24h pair TTL, not the 30-day bootstrap default.
- re-pairing the SAME device revokes/replaces the prior active token (respects the unique-active-per-device index).
- pair WITHOUT deviceId returns the unchanged stateless response and writes no DB record.
- the existing guardian-init/bootstrap suite passes unchanged (refactor regression).

## Original prompt
Second PR of the remote-pairing feature: make `/v1/pair` mint device-scoped, DB-recorded, revocable tokens by reusing guardian-bootstrap's machinery (extracted into shared helpers), as an additive/backward-compatible change that unblocks PR 3 (hot-path revocation). Per review, the pair path issues an access-only short-lived token; refreshable pairing is deferred to the revocation-enforcement PR.

## Note
PR 1 (#33349) merged to main, so this builds on it cleanly.