### PR TITLE
fix: provider name/key pre-fill, inline-create binding race, dead-code cleanup

### DIFF
--- a/apps/web/src/domains/settings/ai/profile-editor-modal.test.tsx
+++ b/apps/web/src/domains/settings/ai/profile-editor-modal.test.tsx
@@ -332,6 +332,53 @@ describe("ProfileEditorModal create mode — provider-first", () => {
     });
   });
 
+  test("inline-create then immediate save persists the new provider_connection (no race)", async () => {
+    // Regression: before the optimistic local-connection merge, saving in the
+    // window between inline create and the parent connections refetch left
+    // `connectionNotFound` true, so the save handler dropped the binding to "".
+    createdConnection = makeConnection("anthropic-personal");
+
+    const saveCalls: { name: string; entry: Record<string, unknown> }[] = [];
+    const onSave = (name: string, entry: unknown) => {
+      saveCalls.push({ name, entry: entry as Record<string, unknown> });
+      return Promise.resolve();
+    };
+
+    // Start with zero connections so the only Provider option is "+ Create
+    // new provider" and the parent prop never refetches in this test (the
+    // binding must be valid purely from the optimistic local merge).
+    renderCreate([], onSave);
+
+    selectProvider("+ Create new provider");
+    fireEvent.change(getInputByPlaceholder("e.g. anthropic-personal"), {
+      target: { value: "anthropic-personal" },
+    });
+    fireEvent.click(getButton("Create"));
+
+    await waitFor(() => {
+      expect(document.body.textContent).toContain(
+        "New provider connection will show up in the Providers section.",
+      );
+    });
+
+    // Pick a model + key, then save immediately (no connections refetch).
+    selectModel("Claude Opus 4.8");
+    fireEvent.change(getInputByPlaceholder("e.g. fast-cheap"), {
+      target: { value: "my-profile" },
+    });
+
+    await waitFor(() => {
+      expect(getSaveBtn().disabled).toBe(false);
+    });
+    fireEvent.click(getSaveBtn());
+
+    await waitFor(() => {
+      expect(saveCalls.length).toBe(1);
+    });
+    expect(saveCalls[0].entry.provider).toBe("anthropic");
+    expect(saveCalls[0].entry.provider_connection).toBe("anthropic-personal");
+  });
+
   test("Save shows 'Saving…' and disables while the create is in flight", async () => {
     // Hold the save promise open so we can observe the in-flight state.
     let resolveSave: () => void = () => {};

--- a/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -188,6 +188,15 @@ function ProfileEditorModalInner({
     initialValues?.provider_connection ?? "",
   );
   const [status, setStatus] = useState<ProfileStatus>(initialValues?.status ?? "active");
+  // Connections created inline this session, before the parent's `connections`
+  // prop has refetched. Unioned into the available-connections set so a
+  // just-created binding is treated as valid immediately — otherwise
+  // `connectionNotFound` would stay true during the parent refetch window and
+  // `handleSave` would persist an empty `provider_connection` (the binding the
+  // user just created + selected would be silently dropped).
+  const [locallyCreatedConnections, setLocallyCreatedConnections] = useState<
+    ProviderConnection[]
+  >([]);
   // True when in view mode and the user has touched either of the two
   // fields that view mode permits editing (label, status). Drives the
   // view-mode Save button's enabled state and the partial-update save path.
@@ -244,19 +253,33 @@ function ProfileEditorModalInner({
     [provider, model],
   );
 
+  // Parent-supplied connections unioned with any created inline this session
+  // (deduped by name, prop wins). Drives the Connection sub-dropdown and the
+  // save handler's binding resolution so an inline-created connection counts
+  // as valid before the parent refetch lands.
+  const effectiveConnections = useMemo(() => {
+    const base = connections ?? [];
+    if (locallyCreatedConnections.length === 0) return base;
+    const known = new Set(base.map((c) => c.name));
+    return [
+      ...base,
+      ...locallyCreatedConnections.filter((c) => !known.has(c.name)),
+    ];
+  }, [connections, locallyCreatedConnections]);
+
   // Connections matching the currently selected provider. Also used by
   // the save handler for binding resolution.
   const availableConnectionsForProvider = useMemo(
     () =>
       provider
-        ? (connections ?? []).filter(
+        ? effectiveConnections.filter(
             (c) =>
               c.provider === provider &&
               (openAICompatibleEndpointsEnabled ||
                 c.provider !== OPENAI_COMPATIBLE_PROVIDER),
           )
         : [],
-    [provider, connections, openAICompatibleEndpointsEnabled],
+    [provider, effectiveConnections, openAICompatibleEndpointsEnabled],
   );
 
   // Saved binding no longer points at any known connection. The save handler
@@ -283,6 +306,7 @@ function ProfileEditorModalInner({
     setCreatingProvider(false);
     setAdvancedExpanded(false);
     setNewProviderNote(false);
+    setLocallyCreatedConnections([]);
   }, [profileName, mode, resetDirty]);
 
   function handleProviderChange(newProvider: string) {
@@ -292,7 +316,7 @@ function ProfileEditorModalInner({
     // Auto-select connection: if exactly one connection exists for the new
     // provider, select it automatically. If multiple exist, clear so the user
     // must pick. If zero, clear.
-    const connectionsForProvider = (connections ?? []).filter(
+    const connectionsForProvider = effectiveConnections.filter(
       (c) => c.provider === newProvider,
     );
     setProviderConnection(
@@ -370,6 +394,13 @@ function ProfileEditorModalInner({
   // provider + connection, collapse the sub-form, surface the helper note,
   // and invalidate the connections query so the dropdown picks up the row.
   function handleProviderCreated(connection: ProviderConnection) {
+    // Optimistically register the new connection locally so the binding is
+    // valid immediately (the parent `connections` refetch below is async).
+    setLocallyCreatedConnections((prev) =>
+      prev.some((c) => c.name === connection.name)
+        ? prev
+        : [...prev, connection],
+    );
     setProvider(connection.provider);
     setProviderConnection(connection.name);
     setModel("");
@@ -643,7 +674,7 @@ function ProfileEditorModalInner({
   const createModeProviderOptions = useMemo(() => {
     const seen = new Set<string>();
     const opts: { value: string; label: string }[] = [];
-    for (const c of connections ?? []) {
+    for (const c of effectiveConnections) {
       if (
         !openAICompatibleEndpointsEnabled &&
         c.provider === OPENAI_COMPATIBLE_PROVIDER
@@ -663,7 +694,7 @@ function ProfileEditorModalInner({
       label: "+ Create new provider",
     });
     return opts;
-  }, [connections, openAICompatibleEndpointsEnabled]);
+  }, [effectiveConnections, openAICompatibleEndpointsEnabled]);
 
   const createProviderSection = (
     <div className="space-y-4">
@@ -711,7 +742,7 @@ function ProfileEditorModalInner({
         <ProviderCreateForm
           variant="inline"
           assistantId={assistantId}
-          existingNames={(connections ?? []).map((c) => c.name)}
+          existingNames={effectiveConnections.map((c) => c.name)}
           openAICompatibleEndpointsEnabled={openAICompatibleEndpointsEnabled}
           chatgptSubscriptionEnabled={chatgptSubscriptionEnabled}
           defaultProviderType={
@@ -728,7 +759,7 @@ function ProfileEditorModalInner({
           onProviderChange={handleProviderChange}
           onModelChange={handleModelChange}
           onConnectionChange={handleConnectionChange}
-          connections={connections}
+          connections={effectiveConnections}
           openAICompatibleEndpointsEnabled={openAICompatibleEndpointsEnabled}
           isReadOnly={isReadOnly}
           availableConnectionsForProvider={availableConnectionsForProvider}

--- a/apps/web/src/domains/settings/ai/profile-prefill.test.ts
+++ b/apps/web/src/domains/settings/ai/profile-prefill.test.ts
@@ -1,58 +1,63 @@
 import { describe, expect, test } from "bun:test";
 
 import {
-  dedupeKey,
   deriveProfileDefaults,
   deriveProviderDefaults,
-  slugify,
 } from "@/domains/settings/ai/profile-prefill";
 
-describe("slugify", () => {
-  test("collapses dots into hyphens", () => {
-    expect(slugify("Claude Opus 4.7")).toBe("claude-opus-4-7");
-  });
+// `slugify` and `dedupeKey` are module-private — they have no non-test
+// consumers, so they're exercised here through the public `derive*` helpers
+// that compose them (the `key` field is the slugified + deduped result).
 
-  test("collapses multiple spaces into a single hyphen", () => {
-    expect(slugify("GPT   5   Mini")).toBe("gpt-5-mini");
+describe("deriveProfileDefaults — slug derivation (slugify)", () => {
+  test("collapses dots and spaces into single hyphens", () => {
+    expect(deriveProfileDefaults("Claude Opus 4.7", []).key).toBe(
+      "claude-opus-4-7",
+    );
+    expect(deriveProfileDefaults("GPT   5   Mini", []).key).toBe("gpt-5-mini");
   });
 
   test("collapses symbols and consecutive separators", () => {
-    expect(slugify("Hello, World!!")).toBe("hello-world");
-    expect(slugify("a---b___c")).toBe("a-b-c");
+    expect(deriveProfileDefaults("Hello, World!!", []).key).toBe("hello-world");
+    expect(deriveProfileDefaults("a---b___c", []).key).toBe("a-b-c");
   });
 
   test("strips leading and trailing separators", () => {
-    expect(slugify("  Spaces  ")).toBe("spaces");
-    expect(slugify("--anthropic--")).toBe("anthropic");
+    expect(deriveProfileDefaults("  Spaces  ", []).key).toBe("spaces");
+    expect(deriveProfileDefaults("--anthropic--", []).key).toBe("anthropic");
   });
 
-  test("handles empty string", () => {
-    expect(slugify("")).toBe("");
-  });
-
-  test("handles a string with no alphanumerics", () => {
-    expect(slugify("!!!")).toBe("");
+  test("yields an empty key when there are no alphanumerics", () => {
+    expect(deriveProfileDefaults("!!!", []).key).toBe("");
   });
 });
 
-describe("dedupeKey", () => {
-  test("returns the base when there is no collision", () => {
-    expect(dedupeKey("anthropic", [])).toBe("anthropic");
-    expect(dedupeKey("anthropic", ["openai"])).toBe("anthropic");
-  });
-
-  test("appends -2 on the first collision", () => {
-    expect(dedupeKey("anthropic", ["anthropic"])).toBe("anthropic-2");
-  });
-
-  test("walks the suffix until unique", () => {
-    expect(dedupeKey("anthropic", ["anthropic", "anthropic-2"])).toBe(
-      "anthropic-3",
+describe("deriveProfileDefaults — collision handling (dedupeKey)", () => {
+  test("returns the base slug when there is no collision", () => {
+    expect(deriveProfileDefaults("Anthropic", []).key).toBe("anthropic");
+    expect(deriveProfileDefaults("Anthropic", ["openai"]).key).toBe(
+      "anthropic",
     );
   });
 
-  test("compares case-insensitively", () => {
-    expect(dedupeKey("Anthropic", ["anthropic"])).toBe("Anthropic-2");
+  test("appends -2 on the first collision", () => {
+    expect(deriveProfileDefaults("Anthropic", ["anthropic"]).key).toBe(
+      "anthropic-2",
+    );
+  });
+
+  test("walks the suffix until unique", () => {
+    expect(
+      deriveProfileDefaults("Anthropic", ["anthropic", "anthropic-2"]).key,
+    ).toBe("anthropic-3");
+  });
+
+  test("compares collisions case-insensitively", () => {
+    // Slug is already lowercase, so seed an upper-case existing name to prove
+    // the comparison ignores case.
+    expect(deriveProfileDefaults("Anthropic", ["ANTHROPIC"]).key).toBe(
+      "anthropic-2",
+    );
   });
 });
 

--- a/apps/web/src/domains/settings/ai/profile-prefill.ts
+++ b/apps/web/src/domains/settings/ai/profile-prefill.ts
@@ -6,7 +6,7 @@ import { toKebabCase } from "@/domains/settings/ai/slugify";
  * run of non-alphanumeric characters into a single `-`, and strip leading and
  * trailing separators. e.g. "Claude Opus 4.7" -> "claude-opus-4-7".
  */
-export function slugify(input: string): string {
+function slugify(input: string): string {
   return toKebabCase(input);
 }
 
@@ -15,7 +15,7 @@ export function slugify(input: string): string {
  * numeric suffix (`-2`, `-3`, ...) until the result is unique. Comparison is
  * case-insensitive.
  */
-export function dedupeKey(base: string, existing: string[]): string {
+function dedupeKey(base: string, existing: string[]): string {
   const taken = new Set(existing.map((name) => name.toLowerCase()));
   if (!taken.has(base.toLowerCase())) {
     return base;

--- a/apps/web/src/domains/settings/ai/provider-create-form.test.tsx
+++ b/apps/web/src/domains/settings/ai/provider-create-form.test.tsx
@@ -404,6 +404,121 @@ describe("ProviderCreateForm submit sequence", () => {
     expect(getButton("Create")).toBeDefined();
   });
 
+  test("seeds Name + Key from the initial provider type", () => {
+    render(
+      <ModalWrapper>
+        <ProviderCreateForm
+          assistantId={ASSISTANT_ID}
+          existingNames={[]}
+          defaultProviderType="anthropic"
+          onCreated={() => {}}
+          onCancel={() => {}}
+        />
+      </ModalWrapper>,
+    );
+
+    expect(getInputByPlaceholder("e.g. My Anthropic Key").value).toBe(
+      "Anthropic",
+    );
+    expect(getInputByPlaceholder("e.g. anthropic-personal").value).toBe(
+      "anthropic",
+    );
+  });
+
+  test("dedupes the seeded Key against existingNames", () => {
+    render(
+      <ModalWrapper>
+        <ProviderCreateForm
+          assistantId={ASSISTANT_ID}
+          existingNames={["anthropic"]}
+          defaultProviderType="anthropic"
+          onCreated={() => {}}
+          onCancel={() => {}}
+        />
+      </ModalWrapper>,
+    );
+
+    expect(getInputByPlaceholder("e.g. My Anthropic Key").value).toBe(
+      "Anthropic",
+    );
+    expect(getInputByPlaceholder("e.g. anthropic-personal").value).toBe(
+      "anthropic-2",
+    );
+  });
+
+  test("changing the provider type re-seeds Name + Key", () => {
+    render(
+      <ModalWrapper>
+        <ProviderCreateForm
+          assistantId={ASSISTANT_ID}
+          existingNames={[]}
+          defaultProviderType="anthropic"
+          onCreated={() => {}}
+          onCancel={() => {}}
+        />
+      </ModalWrapper>,
+    );
+
+    selectDropdownOption("Provider", "OpenAI");
+
+    expect(getInputByPlaceholder("e.g. My Anthropic Key").value).toBe("OpenAI");
+    expect(getInputByPlaceholder("e.g. anthropic-personal").value).toBe(
+      "openai",
+    );
+  });
+
+  test("a manual Name edit is NOT overwritten by a later provider-type change", () => {
+    render(
+      <ModalWrapper>
+        <ProviderCreateForm
+          assistantId={ASSISTANT_ID}
+          existingNames={[]}
+          defaultProviderType="anthropic"
+          onCreated={() => {}}
+          onCancel={() => {}}
+        />
+      </ModalWrapper>,
+    );
+
+    // User overrides the Name; the Key auto-follows the label edit.
+    fireEvent.change(getInputByPlaceholder("e.g. My Anthropic Key"), {
+      target: { value: "My Custom Name" },
+    });
+
+    selectDropdownOption("Provider", "OpenAI");
+
+    expect(getInputByPlaceholder("e.g. My Anthropic Key").value).toBe(
+      "My Custom Name",
+    );
+    expect(getInputByPlaceholder("e.g. anthropic-personal").value).toBe(
+      "my-custom-name",
+    );
+  });
+
+  test("a manual Key edit is NOT overwritten by a later provider-type change", () => {
+    render(
+      <ModalWrapper>
+        <ProviderCreateForm
+          assistantId={ASSISTANT_ID}
+          existingNames={[]}
+          defaultProviderType="anthropic"
+          onCreated={() => {}}
+          onCancel={() => {}}
+        />
+      </ModalWrapper>,
+    );
+
+    fireEvent.change(getInputByPlaceholder("e.g. anthropic-personal"), {
+      target: { value: "my-custom-key" },
+    });
+
+    selectDropdownOption("Provider", "OpenAI");
+
+    expect(getInputByPlaceholder("e.g. anthropic-personal").value).toBe(
+      "my-custom-key",
+    );
+  });
+
   test("clicking Cancel invokes onCancel", () => {
     let cancelled = false;
     render(

--- a/apps/web/src/domains/settings/ai/provider-create-form.tsx
+++ b/apps/web/src/domains/settings/ai/provider-create-form.tsx
@@ -29,6 +29,7 @@ import {
   connectionSaveErrorMessage,
   parseCredentialRef,
 } from "@/domains/settings/ai/provider-editor-constants";
+import { deriveProviderDefaults } from "@/domains/settings/ai/profile-prefill";
 import { ProviderEditorApiKeySection } from "@/domains/settings/ai/provider-editor-api-key-section";
 import { secretPlaceholder } from "@/domains/settings/ai/secret-placeholder";
 import { useLabelKeySync } from "@/domains/settings/ai/use-label-key-sync";
@@ -82,8 +83,15 @@ export function ProviderCreateForm({
 }: ProviderCreateFormProps) {
   const initialProvider: ConnectionProvider = defaultProviderType ?? "anthropic";
 
-  const [label, setLabel] = useState("");
-  const [name, setName] = useState("");
+  // Seed Display Name (label) + Key (name) from the initial provider type so
+  // the form opens pre-filled (e.g. Anthropic → "Anthropic" / "anthropic"),
+  // deduped against existing connection names. The user can override both, and
+  // a provider-type change re-seeds only while they haven't edited the fields
+  // (see the dirty guard in the Provider dropdown's onChange below).
+  const initialDefaults = deriveProviderDefaults(initialProvider, existingNames);
+
+  const [label, setLabel] = useState(initialDefaults.name);
+  const [name, setName] = useState(initialDefaults.key);
   const [provider, setProvider] = useState<ConnectionProvider>(initialProvider);
   const [authType, setAuthType] = useState<AuthType>(
     () =>
@@ -109,7 +117,7 @@ export function ProviderCreateForm({
     return options;
   }, [openAICompatibleEndpointsEnabled, provider]);
 
-  const { handleLabelChange, handleKeyChange: handleNameChange } =
+  const { handleLabelChange, handleKeyChange: handleNameChange, getDirty } =
     useLabelKeySync("create", setLabel, setName);
 
   const [apiKeyValue, setApiKeyValue] = useState("");
@@ -317,6 +325,18 @@ export function ProviderCreateForm({
           onChange={(v) => {
             const newProvider = v as ConnectionProvider;
             setProvider(newProvider);
+            // Re-seed Name + Key from the newly selected provider type, but
+            // only while the user hasn't manually edited either field (dirty
+            // tracking lives in useLabelKeySync). Seeding writes state
+            // directly so it doesn't itself flip the dirty flag.
+            if (!getDirty()) {
+              const { name: seedName, key: seedKey } = deriveProviderDefaults(
+                newProvider,
+                existingNames,
+              );
+              setLabel(seedName);
+              setName(seedKey);
+            }
             if (newProvider === "ollama") {
               setAuthType("none");
               setCredential("");

--- a/apps/web/src/domains/settings/ai/provider-editor-modal.tsx
+++ b/apps/web/src/domains/settings/ai/provider-editor-modal.tsx
@@ -132,7 +132,7 @@ export function ProviderEditorContent({
     return options;
   }, [openAICompatibleEndpointsEnabled, provider]);
 
-  const { handleLabelChange, handleKeyChange: handleNameChange, resetDirty } =
+  const { handleLabelChange, resetDirty } =
     useLabelKeySync(effectiveMode, setLabel, setName);
 
   const [apiKeyValue, setApiKeyValue] = useState("");
@@ -156,8 +156,9 @@ export function ProviderEditorContent({
   });
 
   // --- Available credentials list ---
-  const needsCredentialsList =
-    authType === "api_key" || effectiveMode === "create";
+  // Create mode is fully owned by ProviderCreateForm (early return below), so
+  // the only reachable path here is edit / managed-edit — gate purely on auth.
+  const needsCredentialsList = authType === "api_key";
 
   const {
     credentials: availableCredentials,
@@ -217,15 +218,11 @@ export function ProviderEditorContent({
     setCreateAuthTypeSeed(provider === "ollama" ? "none" : "api_key");
   }
 
-  const nameError = (() => {
-    if (!name.trim()) return null;
-    if (effectiveMode === "create" && existingNames.includes(name.trim())) {
-      return `A connection named "${name.trim()}" already exists.`;
-    }
-    return null;
-  })();
-
-  const canSave = name.trim().length > 0 && !nameError;
+  // Only edit / managed-edit reach this component's own Save (create is owned
+  // by ProviderCreateForm via the early return below), and the Key field is
+  // fixed/disabled there, so a non-empty name is the only save gate. Duplicate
+  // -name validation lives in ProviderCreateForm.
+  const canSave = name.trim().length > 0;
 
   async function handleSave() {
     if (!canSave) return;
@@ -399,30 +396,17 @@ export function ProviderEditorContent({
           />
         </div>
 
-        {/* Key — only editable on create, auto-derived from label */}
+        {/* Key — fixed once a connection exists; edit / managed-edit only. */}
         <div className="space-y-1">
           <label className="block text-body-small-default text-[var(--content-tertiary)]">
             Key
           </label>
           <Input
             value={name}
-            onChange={(e) => {
-              handleNameChange(e.target.value);
-              setError(null);
-            }}
             placeholder="e.g. anthropic-personal"
             disabled
             fullWidth
           />
-          {nameError && (
-            <Typography
-              variant="body-small-default"
-              as="p"
-              className="text-(--system-negative-strong)"
-            >
-              {nameError}
-            </Typography>
-          )}
         </div>
 
         {/* Provider — read-only in edit / managed-edit (provider is fixed


### PR DESCRIPTION
## Summary
Fixes gaps from plan review for provider-first-profile-quick-add.md.
- Wire deriveProviderDefaults so inline/standalone provider create pre-fills Name/Key from the provider type (deduped, overridable, stops on user edit)
- Fix race where saving immediately after inline provider creation persisted an empty provider_connection
- Remove orphaned create-mode dead code from provider-editor-modal.tsx after the ProviderCreateForm extraction
- Tighten profile-prefill exports