### PR TITLE
[codex] Fix duplicate card surface titles

### DIFF
--- a/apps/web/src/domains/chat/components/surfaces/card-surface.test.tsx
+++ b/apps/web/src/domains/chat/components/surfaces/card-surface.test.tsx
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { CardSurface } from "@/domains/chat/components/surfaces/card-surface";
+import type { Surface } from "@/domains/chat/types/types";
+
+function surface(overrides: Partial<Surface> = {}): Surface {
+  return {
+    surfaceId: "surface-123",
+    surfaceType: "card",
+    title: "Response limit reached",
+    data: {
+      title: "Response limit reached",
+      subtitle: "The partial response above was saved.",
+      body: "I hit the response limit before I could finish.",
+    },
+    actions: [
+      {
+        id: "relay_prompt",
+        label: "Continue",
+        style: "primary",
+        data: { prompt: "Continue from where you stopped." },
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function countOccurrences(value: string, needle: string): number {
+  return value.split(needle).length - 1;
+}
+
+describe("CardSurface", () => {
+  test("does not duplicate the card title when the surface envelope has the same title", () => {
+    const rendered = renderToStaticMarkup(
+      <CardSurface surface={surface()} onAction={() => undefined} />,
+    );
+
+    expect(countOccurrences(rendered, "Response limit reached")).toBe(1);
+    expect(rendered).toContain("The partial response above was saved.");
+    expect(rendered).toContain("I hit the response limit before I could finish.");
+  });
+
+  test("renders the card data title instead of the envelope title", () => {
+    const rendered = renderToStaticMarkup(
+      <CardSurface
+        surface={surface({
+          title: "Envelope title",
+          data: {
+            title: "Card title",
+            subtitle: "Card subtitle",
+            body: "Card body",
+          },
+        })}
+        onAction={() => undefined}
+      />,
+    );
+
+    expect(rendered).toContain("Card title");
+    expect(rendered).not.toContain("Envelope title");
+  });
+
+  test("falls back to the envelope title when card data has no title", () => {
+    const rendered = renderToStaticMarkup(
+      <CardSurface
+        surface={surface({
+          title: "Envelope fallback",
+          data: {
+            subtitle: "Card subtitle",
+            body: "Card body",
+          },
+        })}
+        onAction={() => undefined}
+      />,
+    );
+
+    expect(rendered).toContain("Envelope fallback");
+    expect(countOccurrences(rendered, "Envelope fallback")).toBe(1);
+  });
+});

--- a/apps/web/src/domains/chat/components/surfaces/card-surface.tsx
+++ b/apps/web/src/domains/chat/components/surfaces/card-surface.tsx
@@ -64,6 +64,10 @@ function getStatusConfig(status: string | undefined) {
   return STATUS_CONFIG[status ?? ""] ?? DEFAULT_STATUS;
 }
 
+function normalizedTitle(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
 function StatusBadge({ status }: { status: string | undefined }) {
   const { label, colorClass } = getStatusConfig(status);
   return (
@@ -173,13 +177,19 @@ function TaskStepList({ steps }: { steps: TaskStepItem[] }) {
   );
 }
 
-function TaskProgressDisplay({ templateData }: { templateData: Record<string, unknown> }) {
+function TaskProgressDisplay({
+  templateData,
+  titleFallback,
+}: {
+  templateData: Record<string, unknown>;
+  titleFallback?: string;
+}) {
   const steps = Array.isArray(templateData.steps)
     ? (templateData.steps as TaskStepItem[])
     : null;
 
   if (steps && steps.length > 0) {
-    const title = typeof templateData.title === "string" ? templateData.title : "Task";
+    const title = normalizedTitle(templateData.title) || titleFallback || "Task";
     const status = typeof templateData.status === "string" ? templateData.status : undefined;
 
     return (
@@ -206,19 +216,26 @@ export function CardSurface({ surface, onAction }: CardSurfaceProps) {
   const isTaskProgress = data.template === "task_progress" && data.templateData;
   const hasSteps = isTaskProgress && Array.isArray(data.templateData?.steps) &&
     (data.templateData!.steps as unknown[]).length > 0;
+  const cardTitle = normalizedTitle(data.title) || normalizedTitle(surface.title);
+  const surfaceWithoutContainerTitle = { ...surface, title: undefined };
 
   if (hasSteps) {
     return (
-      <SurfaceContainer surface={surface} onAction={onAction}>
-        <TaskProgressDisplay templateData={data.templateData!} />
+      <SurfaceContainer surface={surfaceWithoutContainerTitle} onAction={onAction}>
+        <TaskProgressDisplay
+          templateData={data.templateData!}
+          titleFallback={cardTitle}
+        />
       </SurfaceContainer>
     );
   }
 
   return (
-    <SurfaceContainer surface={surface} onAction={onAction}>
+    <SurfaceContainer surface={surfaceWithoutContainerTitle} onAction={onAction}>
       <div>
-        <h3 className="text-title-small text-[var(--content-strong)]">{data.title}</h3>
+        {cardTitle && (
+          <h3 className="text-title-small text-[var(--content-strong)]">{cardTitle}</h3>
+        )}
 
         {data.subtitle && (
           <p className="mt-0.5 text-body-small-default text-[var(--content-quiet)]">{data.subtitle}</p>
@@ -267,7 +284,10 @@ export function CardSurface({ surface, onAction }: CardSurfaceProps) {
             )}
 
             {isTaskProgress && (
-              <TaskProgressDisplay templateData={data.templateData!} />
+              <TaskProgressDisplay
+                templateData={data.templateData!}
+                titleFallback={cardTitle}
+              />
             )}
           </>
         )}


### PR DESCRIPTION
## Summary

- Make `CardSurface` own card title rendering instead of letting the generic `SurfaceContainer` render an envelope title too.
- Prefer `data.title` for card content and fall back to `surface.title` only when the card payload has no title.
- Add regression coverage for duplicate titles, data-title priority, and envelope-title fallback.

## Root Cause

`CardSurface` rendered `data.title` inside the card while `SurfaceContainer` also rendered the envelope-level `surface.title`. The response-limit card sets both fields to `Response limit reached`, so the title appeared twice.

## Validation

- `bun test ./src/domains/chat/components/surfaces/card-surface.test.tsx`
- `bunx tsc --noEmit`
- Commit hook: lint and typecheck for touched `apps/web` files
