### PR TITLE
feat(gateway): hot-path actor-token revocation check

### DIFF
--- a/gateway/src/__tests__/actor-token-revocation.test.ts
+++ b/gateway/src/__tests__/actor-token-revocation.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for the hot-path actor-token revocation check: a revoked actor token
+ * is rejected on live requests, with fail-open semantics for non-actor,
+ * unrecorded, and DB-error cases.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { initSigningKey, mintToken } from "../auth/token-service.js";
+import { CURRENT_POLICY_EPOCH } from "../auth/policy.js";
+import type { TokenClaims } from "../auth/types.js";
+
+initSigningKey(Buffer.from("test-signing-key-at-least-32-bytes-long-xx"));
+
+const { initGatewayDb, resetGatewayDb, getGatewayDb } =
+  await import("../db/connection.js");
+const { actorTokenRecords } = await import("../db/schema.js");
+const { hashToken } = await import("../auth/guardian-bootstrap.js");
+const { isActorTokenRevoked } =
+  await import("../auth/actor-token-revocation.js");
+const { createRuntimeProxyHandler } =
+  await import("../http/routes/runtime-proxy.js");
+
+const ACTOR_SUB = "actor:self:guardian-001";
+const actorClaims = { sub: ACTOR_SUB } as TokenClaims;
+
+let testRoot: string;
+
+function insertTokenRecord(rawToken: string, status: "active" | "revoked") {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(actorTokenRecords)
+    .values({
+      id: `id-${rawToken}`,
+      tokenHash: hashToken(rawToken),
+      guardianPrincipalId: "guardian-001",
+      hashedDeviceId: hashToken("device-A"),
+      platform: "web",
+      status,
+      issuedAt: now,
+      expiresAt: now + 86_400_000,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+beforeEach(async () => {
+  testRoot = mkdtempSync(join(tmpdir(), "revocation-test-"));
+  const securityDir = join(testRoot, "protected");
+  mkdirSync(securityDir, { recursive: true });
+  process.env.GATEWAY_SECURITY_DIR = securityDir;
+  await initGatewayDb();
+});
+
+afterEach(() => {
+  resetGatewayDb();
+  delete process.env.GATEWAY_SECURITY_DIR;
+  try {
+    rmSync(testRoot, { recursive: true, force: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+describe("isActorTokenRevoked", () => {
+  test("returns true for an actor token whose record is revoked", () => {
+    insertTokenRecord("token-revoked", "revoked");
+    expect(isActorTokenRevoked("token-revoked", actorClaims)).toBe(true);
+  });
+
+  test("returns false for an actor token whose record is active", () => {
+    insertTokenRecord("token-active", "active");
+    expect(isActorTokenRevoked("token-active", actorClaims)).toBe(false);
+  });
+
+  test("returns false (fail-open) for an actor token with no record", () => {
+    expect(isActorTokenRevoked("token-unknown", actorClaims)).toBe(false);
+  });
+
+  test("never checks non-actor tokens (svc)", () => {
+    // Even if a row with this hash were revoked, a svc sub must be ignored.
+    insertTokenRecord("svc-token", "revoked");
+    const svcClaims = { sub: "svc:gateway:self" } as TokenClaims;
+    expect(isActorTokenRevoked("svc-token", svcClaims)).toBe(false);
+  });
+
+  test("returns false (fail-open) when the gateway DB is unavailable", () => {
+    resetGatewayDb();
+    expect(isActorTokenRevoked("token-anything", actorClaims)).toBe(false);
+  });
+});
+
+describe("runtime proxy enforcement", () => {
+  function makeConfig() {
+    return {
+      assistantRuntimeBaseUrl: "http://localhost:7821",
+      routingEntries: [],
+      defaultAssistantId: undefined,
+      unmappedPolicy: "reject" as const,
+      port: 7830,
+      runtimeProxyRequireAuth: true,
+      shutdownDrainMs: 5000,
+      runtimeTimeoutMs: 30000,
+      runtimeMaxRetries: 2,
+      runtimeInitialBackoffMs: 500,
+      maxWebhookPayloadBytes: 1048576,
+      logFile: { dir: undefined, retentionDays: 30 },
+      maxAttachmentBytes: {
+        telegram: 50 * 1024 * 1024,
+        slack: 100 * 1024 * 1024,
+        whatsapp: 16 * 1024 * 1024,
+        default: 50 * 1024 * 1024,
+      },
+      maxAttachmentConcurrency: 3,
+      gatewayInternalBaseUrl: "http://127.0.0.1:7830",
+      trustProxy: false,
+    };
+  }
+
+  function mintActorJwt(): string {
+    return mintToken({
+      aud: "vellum-gateway",
+      sub: ACTOR_SUB,
+      scope_profile: "actor_client_v1",
+      policy_epoch: CURRENT_POLICY_EPOCH,
+      ttlSeconds: 3600,
+    });
+  }
+
+  test("rejects a revoked actor token with 401 on the chat path", async () => {
+    const jwt = mintActorJwt();
+    insertTokenRecord(jwt, "revoked");
+
+    const handler = createRuntimeProxyHandler(makeConfig());
+    const res = await handler(
+      new Request("http://127.0.0.1:7830/v1/assistants/self/messages", {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${jwt}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ content: "hi" }),
+      }),
+      "127.0.0.1",
+    );
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/gateway/src/__tests__/actor-token-revocation.test.ts
+++ b/gateway/src/__tests__/actor-token-revocation.test.ts
@@ -160,6 +160,39 @@ describe("runtime proxy enforcement", () => {
   });
 });
 
+describe("/auth/token revocation", () => {
+  function makeLoopbackServer() {
+    return {
+      requestIP: () => ({ address: "127.0.0.1", family: "IPv4", port: 5000 }),
+    } as unknown as import("bun").Server<unknown>;
+  }
+
+  test("rejects re-minting a token from a revoked source token", async () => {
+    const { handleCreateToken } = await import("../http/routes/auth-token.js");
+    const jwt = mintToken({
+      aud: "vellum-gateway",
+      sub: ACTOR_SUB,
+      scope_profile: "actor_client_v1",
+      policy_epoch: CURRENT_POLICY_EPOCH,
+      ttlSeconds: 3600,
+    });
+    insertTokenRecord(jwt, "revoked");
+
+    const res = await handleCreateToken(
+      new Request("http://127.0.0.1:7830/auth/token", {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${jwt}`,
+          origin: "http://localhost:3000",
+        },
+      }),
+      makeLoopbackServer(),
+    );
+
+    expect(res.status).toBe(401);
+  });
+});
+
 describe("m0004 token-hash index migration", () => {
   function rawDb() {
     return (

--- a/gateway/src/__tests__/actor-token-revocation.test.ts
+++ b/gateway/src/__tests__/actor-token-revocation.test.ts
@@ -91,6 +91,15 @@ describe("isActorTokenRevoked", () => {
     resetGatewayDb();
     expect(isActorTokenRevoked("token-anything", actorClaims)).toBe(false);
   });
+
+  test("still detects revocation when the token has surrounding whitespace", () => {
+    // The record is stored under the canonical (trimmed) token hash; a token
+    // supplied with trailing whitespace (e.g. a `?token=<jwt>%20` WS param)
+    // must still resolve to the revoked record.
+    insertTokenRecord("token-revoked", "revoked");
+    expect(isActorTokenRevoked("token-revoked ", actorClaims)).toBe(true);
+    expect(isActorTokenRevoked(" token-revoked\n", actorClaims)).toBe(true);
+  });
 });
 
 describe("runtime proxy enforcement", () => {

--- a/gateway/src/__tests__/actor-token-revocation.test.ts
+++ b/gateway/src/__tests__/actor-token-revocation.test.ts
@@ -150,3 +150,36 @@ describe("runtime proxy enforcement", () => {
     expect(res.status).toBe(401);
   });
 });
+
+describe("m0004 token-hash index migration", () => {
+  function rawDb() {
+    return (
+      getGatewayDb() as unknown as { $client: import("bun:sqlite").Database }
+    ).$client;
+  }
+  function indexSql(): string {
+    const row = rawDb()
+      .prepare(
+        "SELECT sql FROM sqlite_master WHERE type='index' AND name='idx_actor_tokens_hash'",
+      )
+      .get() as { sql: string } | null;
+    return row?.sql ?? "";
+  }
+
+  test("recreates a pre-existing partial index as unfiltered", async () => {
+    // Simulate an upgraded gateway: replace the index with the OLD partial form.
+    rawDb().exec("DROP INDEX IF EXISTS idx_actor_tokens_hash");
+    rawDb().exec(
+      "CREATE INDEX idx_actor_tokens_hash ON actor_token_records (token_hash) WHERE status = 'active'",
+    );
+    expect(indexSql().toLowerCase()).toContain("where");
+
+    const m0004 =
+      await import("../db/data-migrations/m0004-actor-token-hash-index-unfiltered.js");
+    expect(m0004.up()).toBe("done");
+
+    // The index now exists and no longer filters on status.
+    expect(indexSql()).not.toBe("");
+    expect(indexSql().toLowerCase()).not.toContain("where");
+  });
+});

--- a/gateway/src/__tests__/live-voice-websocket.test.ts
+++ b/gateway/src/__tests__/live-voice-websocket.test.ts
@@ -578,3 +578,70 @@ describe("live voice gateway boundary", () => {
     );
   });
 });
+
+describe("createLiveVoiceWebsocketHandler — revocation", () => {
+  // These tests exercise the gateway DB, so set it up per-test. (The other
+  // suites run without a DB; the revocation check is fail-open when the DB is
+  // absent, so they upgrade as before.)
+  let testRoot: string;
+
+  beforeEach(async () => {
+    const { mkdtempSync, mkdirSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    testRoot = mkdtempSync(join(tmpdir(), "live-voice-revocation-"));
+    mkdirSync(join(testRoot, "protected"), { recursive: true });
+    process.env.GATEWAY_SECURITY_DIR = join(testRoot, "protected");
+    const { initGatewayDb } = await import("../db/connection.js");
+    await initGatewayDb();
+  });
+
+  afterEach(async () => {
+    const { resetGatewayDb } = await import("../db/connection.js");
+    resetGatewayDb();
+    delete process.env.GATEWAY_SECURITY_DIR;
+    const { rmSync } = await import("node:fs");
+    try {
+      rmSync(testRoot, { recursive: true, force: true });
+    } catch {
+      /* best effort */
+    }
+  });
+
+  test("returns 401 when the actor token has been revoked", async () => {
+    const { getGatewayDb } = await import("../db/connection.js");
+    const { actorTokenRecords } = await import("../db/schema.js");
+    const { createHash } = await import("node:crypto");
+
+    const jwt = mintEdgeToken();
+    const now = Date.now();
+    getGatewayDb()
+      .insert(actorTokenRecords)
+      .values({
+        id: "id-revoked",
+        tokenHash: createHash("sha256").update(jwt).digest("hex"),
+        guardianPrincipalId: "guardian-001",
+        hashedDeviceId: createHash("sha256").update("device").digest("hex"),
+        platform: "web",
+        status: "revoked",
+        issuedAt: now,
+        expiresAt: now + 300_000,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+
+    const handler = createLiveVoiceWebsocketHandler(makeConfig());
+    const server = makeFakeServer();
+    const res = handler(
+      new Request(`http://127.0.0.1:7830/v1/live-voice?token=${jwt}`, {
+        headers: { upgrade: "websocket" },
+      }),
+      server,
+    );
+
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(401);
+    expect(server.upgrade).not.toHaveBeenCalled();
+  });
+});

--- a/gateway/src/auth/actor-token-revocation.ts
+++ b/gateway/src/auth/actor-token-revocation.ts
@@ -53,11 +53,18 @@ export function isActorTokenRevoked(
     return false;
   }
 
+  // Canonicalize before hashing. validateEdgeToken tolerates surrounding
+  // whitespace (base64url signature decode ignores it), but tokens are stored
+  // hashed in their canonical form — so a token supplied with trailing
+  // whitespace (e.g. a `?token=<jwt>%20` WebSocket query param) would hash to a
+  // different value and miss the revoked record. Trim so the lookup matches.
+  const tokenHash = hashToken(rawToken.trim());
+
   try {
     const record = getGatewayDb()
       .select({ status: actorTokenRecords.status })
       .from(actorTokenRecords)
-      .where(eq(actorTokenRecords.tokenHash, hashToken(rawToken)))
+      .where(eq(actorTokenRecords.tokenHash, tokenHash))
       .get();
     return record?.status === "revoked";
   } catch (err) {

--- a/gateway/src/auth/actor-token-revocation.ts
+++ b/gateway/src/auth/actor-token-revocation.ts
@@ -1,0 +1,70 @@
+/**
+ * Hot-path actor-token revocation check.
+ *
+ * Edge-token validation ({@link validateEdgeToken}) only verifies the JWT
+ * (signature, audience, expiry, policy epoch) — it never consults the DB. That
+ * means marking an actor token "revoked" in `actorTokenRecords` (on re-pair,
+ * device unpair, etc.) has no effect on live requests until the token expires.
+ *
+ * This check closes that gap: on the request hot path, after the JWT is
+ * validated, reject an actor token whose recorded row is `status = 'revoked'`.
+ *
+ * Policy is **fail-OPEN**:
+ *   - Non-actor tokens (svc/local) are never checked.
+ *   - An actor token with NO record is allowed — legacy/unrecorded tokens (and
+ *     any mint path not yet recording to the DB) must never be broken.
+ *   - Any DB error (incl. the gateway DB not being initialized) allows the
+ *     request and logs a warning — a revocation check must never take down auth
+ *     on a DB hiccup; we are no worse off than before this check existed.
+ *
+ * Only an explicit `status = 'revoked'` row results in rejection.
+ */
+import { createHash } from "node:crypto";
+
+import { eq } from "drizzle-orm";
+
+import { getGatewayDb } from "../db/connection.js";
+import { actorTokenRecords } from "../db/schema.js";
+import { getLogger } from "../logger.js";
+import type { TokenClaims } from "./types.js";
+import { parseSub } from "./subject.js";
+
+const log = getLogger("actor-token-revocation");
+
+/**
+ * SHA-256 hex digest, matching how tokens are hashed at mint time. Inlined
+ * (rather than imported from guardian-bootstrap, which several test suites
+ * mock.module) so this hot-path check has no dependency on that module.
+ */
+function hashToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+/**
+ * True only when `rawToken` is an actor token with an explicitly revoked record.
+ * Fail-open in every other case (non-actor, no record, DB error).
+ */
+export function isActorTokenRevoked(
+  rawToken: string,
+  claims: TokenClaims,
+): boolean {
+  const parsed = parseSub(claims.sub);
+  if (!parsed.ok || parsed.principalType !== "actor") {
+    return false;
+  }
+
+  try {
+    const record = getGatewayDb()
+      .select({ status: actorTokenRecords.status })
+      .from(actorTokenRecords)
+      .where(eq(actorTokenRecords.tokenHash, hashToken(rawToken)))
+      .get();
+    return record?.status === "revoked";
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "Actor-token revocation lookup failed — allowing request (fail-open)",
+    );
+    return false;
+  }
+}

--- a/gateway/src/db/data-migrations/index.ts
+++ b/gateway/src/db/data-migrations/index.ts
@@ -22,6 +22,7 @@ import { getLogger } from "../../logger.js";
 import * as m0001 from "./m0001-guardian-init-lock.js";
 import * as m0002 from "./m0002-actor-token-tables-to-gateway.js";
 import * as m0003 from "./m0003-recover-backup-key.js";
+import * as m0004 from "./m0004-actor-token-hash-index-unfiltered.js";
 
 const log = getLogger("data-migrations");
 
@@ -36,6 +37,7 @@ const MIGRATIONS: { key: string; mod: MigrationModule }[] = [
   { key: "m0001-guardian-init-lock", mod: m0001 },
   { key: "m0002-actor-token-tables-to-gateway", mod: m0002 },
   { key: "m0003-recover-backup-key", mod: m0003 },
+  { key: "m0004-actor-token-hash-index-unfiltered", mod: m0004 },
 ];
 
 /**

--- a/gateway/src/db/data-migrations/m0004-actor-token-hash-index-unfiltered.ts
+++ b/gateway/src/db/data-migrations/m0004-actor-token-hash-index-unfiltered.ts
@@ -1,0 +1,43 @@
+/**
+ * One-time migration: recreate `idx_actor_tokens_hash` without the
+ * `WHERE status = 'active'` predicate.
+ *
+ * The hot-path actor-token revocation lookup matches by `token_hash` and must
+ * find REVOKED rows, which the old partial index (filtered to active rows)
+ * cannot serve. The schema now declares this index unfiltered, but on already-
+ * provisioned gateways drizzle-kit `push` does NOT replace an index when only
+ * its predicate changes (the name is unchanged), so the old partial definition
+ * would persist and the lookup would full-scan. Drop and recreate it
+ * explicitly so existing installations get the unfiltered index too.
+ *
+ * Idempotent: on a fresh DB push already created the unfiltered index, and the
+ * DROP/CREATE here reproduces the same definition.
+ */
+
+import { Database } from "bun:sqlite";
+
+import { getLogger } from "../../logger.js";
+import { getGatewayDb } from "../connection.js";
+
+import type { MigrationResult } from "./index.js";
+
+const log = getLogger("m0004-actor-token-hash-index");
+
+function getRawGatewayDb(): Database {
+  return (getGatewayDb() as unknown as { $client: Database }).$client;
+}
+
+export function up(): MigrationResult {
+  const db = getRawGatewayDb();
+  db.exec("DROP INDEX IF EXISTS idx_actor_tokens_hash");
+  db.exec(
+    "CREATE INDEX IF NOT EXISTS idx_actor_tokens_hash ON actor_token_records (token_hash)",
+  );
+  log.info("Recreated idx_actor_tokens_hash without the status predicate");
+  return "done";
+}
+
+export function down(): MigrationResult {
+  // No-op: leaving the unfiltered index in place on rollback is harmless.
+  return "done";
+}

--- a/gateway/src/db/schema.ts
+++ b/gateway/src/db/schema.ts
@@ -197,9 +197,9 @@ export const actorTokenRecords = sqliteTable(
     uniqueIndex("idx_actor_tokens_active_device")
       .on(table.guardianPrincipalId, table.hashedDeviceId)
       .where(sql`status = 'active'`),
-    index("idx_actor_tokens_hash")
-      .on(table.tokenHash)
-      .where(sql`status = 'active'`),
+    // Unfiltered (not WHERE status='active') so the hot-path revocation lookup
+    // — which matches by token_hash and must find REVOKED rows — is indexed.
+    index("idx_actor_tokens_hash").on(table.tokenHash),
   ],
 );
 

--- a/gateway/src/http/middleware/auth.ts
+++ b/gateway/src/http/middleware/auth.ts
@@ -1,10 +1,11 @@
 import type { Server } from "bun";
 
+import { isActorTokenRevoked } from "../../auth/actor-token-revocation.js";
 import { findVellumGuardian } from "../../auth/guardian-bootstrap.js";
 import { resolveScopeProfile } from "../../auth/scopes.js";
 import { parseSub } from "../../auth/subject.js";
 import { validateEdgeToken } from "../../auth/token-exchange.js";
-import type { Scope } from "../../auth/types.js";
+import type { Scope, TokenClaims } from "../../auth/types.js";
 import { AuthFallbackLogThrottle } from "../../auth-fallback-log-throttle.js";
 import type { AuthRateLimiter } from "../../auth-rate-limiter.js";
 import { credentialKey } from "../../credential-key.js";
@@ -249,7 +250,7 @@ export function createAuthMiddleware(
       );
       return Response.json({ error: "Unauthorized" }, { status: 401 });
     }
-    return null;
+    return rejectIfActorTokenRevoked(req, token, result.claims);
   }
 
   function validateScopedEdgeBearer(
@@ -276,6 +277,8 @@ export function createAuthMiddleware(
       );
       return Response.json({ error: "Unauthorized" }, { status: 401 });
     }
+    const revoked = rejectIfActorTokenRevoked(req, token, result.claims);
+    if (revoked) return revoked;
     const scopes = resolveScopeProfile(result.claims.scope_profile);
     if (!scopes.has(scope)) {
       if (
@@ -333,6 +336,25 @@ export function createAuthMiddleware(
     log.warn(
       { path: new URL(req.url).pathname, ...extra },
       `${label} rejected: malformed Authorization header`,
+    );
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  /**
+   * Reject a validated edge token whose actor record has been revoked. Returns
+   * a 401 response when revoked, or null to continue. Fail-open for non-actor
+   * and unrecorded tokens (see isActorTokenRevoked).
+   */
+  function rejectIfActorTokenRevoked(
+    req: Request,
+    token: string,
+    claims: TokenClaims,
+  ): Response | null {
+    if (!isActorTokenRevoked(token, claims)) return null;
+    authRateLimiter.recordFailure(getClientIp());
+    log.warn(
+      { path: new URL(req.url).pathname },
+      "Edge auth rejected: actor token revoked",
     );
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
@@ -411,6 +433,8 @@ export function createAuthMiddleware(
       );
       return Response.json({ error: "Unauthorized" }, { status: 401 });
     }
+    const revoked = rejectIfActorTokenRevoked(req, token, result.claims);
+    if (revoked) return revoked;
     const parsed = parseSub(result.claims.sub);
     if (
       !parsed.ok ||

--- a/gateway/src/http/routes/auth-token.ts
+++ b/gateway/src/http/routes/auth-token.ts
@@ -1,5 +1,6 @@
 import type { Server } from "bun";
 
+import { isActorTokenRevoked } from "../../auth/actor-token-revocation.js";
 import { ensureVellumGuardianBinding } from "../../auth/guardian-bootstrap.js";
 import { CURRENT_POLICY_EPOCH } from "../../auth/policy.js";
 import { mintToken, verifyToken } from "../../auth/token-service.js";
@@ -29,17 +30,32 @@ export async function handleCreateToken(
 
   const authHeader = req.headers.get("authorization");
   if (!authHeader || !authHeader.toLowerCase().startsWith("bearer ")) {
-    log.warn("Token create rejected: missing or malformed Authorization header");
+    log.warn(
+      "Token create rejected: missing or malformed Authorization header",
+    );
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
   const bearerToken = authHeader.slice(7);
   const verifyResult = verifyToken(bearerToken, "vellum-gateway");
   if (!verifyResult.ok) {
-    log.warn({ reason: verifyResult.reason }, "Token create rejected: invalid guardian token");
+    log.warn(
+      { reason: verifyResult.reason },
+      "Token create rejected: invalid guardian token",
+    );
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
   if (verifyResult.claims.scope_profile !== "actor_client_v1") {
-    log.warn({ scope: verifyResult.claims.scope_profile }, "Token create rejected: insufficient scope");
+    log.warn(
+      { scope: verifyResult.claims.scope_profile },
+      "Token create rejected: insufficient scope",
+    );
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  // Don't let a revoked token re-mint a fresh one — that would be an escape
+  // hatch around device revocation, since the source token still verifies by
+  // signature until it expires.
+  if (isActorTokenRevoked(bearerToken, verifyResult.claims)) {
+    log.warn("Token create rejected: source token revoked");
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
 

--- a/gateway/src/http/routes/ipc-runtime-proxy.ts
+++ b/gateway/src/http/routes/ipc-runtime-proxy.ts
@@ -12,6 +12,7 @@
  * IPC, and converts the result back into an HTTP Response.
  */
 
+import { isActorTokenRevoked } from "../../auth/actor-token-revocation.js";
 import { resolveScopeProfile } from "../../auth/scopes.js";
 import { parseSub } from "../../auth/subject.js";
 import { validateEdgeToken } from "../../auth/token-exchange.js";
@@ -71,6 +72,13 @@ export async function tryIpcProxy(
           reason: result.reason,
         },
         "IPC proxy auth rejected",
+      );
+      return Response.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    if (isActorTokenRevoked(edgeJwt, result.claims)) {
+      log.warn(
+        { method: req.method, path: new URL(req.url).pathname },
+        "IPC proxy auth rejected: actor token revoked",
       );
       return Response.json({ error: "Unauthorized" }, { status: 401 });
     }

--- a/gateway/src/http/routes/live-voice-websocket.ts
+++ b/gateway/src/http/routes/live-voice-websocket.ts
@@ -4,6 +4,7 @@ import {
   validateEdgeToken,
   mintServiceToken,
 } from "../../auth/token-exchange.js";
+import { isActorTokenRevoked } from "../../auth/actor-token-revocation.js";
 import { parseSub } from "../../auth/subject.js";
 import type { GatewayConfig } from "../../config.js";
 import { getLogger } from "../../logger.js";
@@ -147,6 +148,11 @@ function checkLiveVoiceAuth(
   const result = validateEdgeToken(rawToken);
   if (!result.ok) {
     log.warn({ reason: result.reason }, "Live voice WS: authentication failed");
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  if (isActorTokenRevoked(rawToken, result.claims)) {
+    log.warn("Live voice WS: rejected — actor token revoked");
     return new Response("Unauthorized", { status: 401 });
   }
 

--- a/gateway/src/http/routes/runtime-proxy.ts
+++ b/gateway/src/http/routes/runtime-proxy.ts
@@ -11,6 +11,7 @@ import {
   mintExchangeToken,
   mintServiceToken,
 } from "../../auth/token-exchange.js";
+import { isActorTokenRevoked } from "../../auth/actor-token-revocation.js";
 import type { GatewayConfig } from "../../config.js";
 import { fetchImpl } from "../../fetch.js";
 import { getLogger } from "../../logger.js";
@@ -74,6 +75,13 @@ export function createRuntimeProxyHandler(config: GatewayConfig) {
         log.warn(
           { method: req.method, path: url.pathname, reason: result.reason },
           "Runtime proxy auth rejected: edge token validation failed",
+        );
+        return Response.json({ error: "Unauthorized" }, { status: 401 });
+      }
+      if (isActorTokenRevoked(edgeJwt, result.claims)) {
+        log.warn(
+          { method: req.method, path: url.pathname },
+          "Runtime proxy auth rejected: actor token revoked",
         );
         return Response.json({ error: "Unauthorized" }, { status: 401 });
       }

--- a/gateway/src/http/routes/stt-stream-websocket.ts
+++ b/gateway/src/http/routes/stt-stream-websocket.ts
@@ -4,6 +4,7 @@ import {
   validateEdgeToken,
   mintServiceToken,
 } from "../../auth/token-exchange.js";
+import { isActorTokenRevoked } from "../../auth/actor-token-revocation.js";
 import { parseSub } from "../../auth/subject.js";
 import type { GatewayConfig } from "../../config.js";
 import { getLogger } from "../../logger.js";
@@ -110,6 +111,11 @@ export function createSttStreamWebsocketHandler(config: GatewayConfig) {
         { reason: result.reason },
         "STT stream WS: authentication failed",
       );
+      return new Response("Unauthorized", { status: 401 });
+    }
+
+    if (isActorTokenRevoked(rawToken, result.claims)) {
+      log.warn("STT stream WS: rejected — actor token revoked");
       return new Response("Unauthorized", { status: 401 });
     }
 


### PR DESCRIPTION
## Summary
- Adds a hot-path **actor-token revocation check**: on live requests, after the edge JWT is validated, an actor token whose `actorTokenRecords` row is `status="revoked"` is rejected with 401. This makes the existing DB revocation (re-pair / device unpair) actually bite live requests — previously edge auth only checked the JWT signature, so revocation was toothless until token expiry.
- New `gateway/src/auth/actor-token-revocation.ts` (`isActorTokenRevoked`), enforced at the chat hot path (`runtime-proxy.ts`, `ipc-runtime-proxy.ts`) and the edge/* API middleware (`auth.ts`, all three edge-auth variants via a shared `rejectIfActorTokenRevoked` helper).
- **Fail-OPEN by design** (see below) — never breaks unrecorded/legacy tokens, so it's safe to land on main independent of PR 2 (#33359).

## The gap
`validateEdgeToken` only verifies the JWT (signature, audience, expiry, policy epoch) and never consults the DB. So marking a token `revoked` in `actorTokenRecords` had no effect on outstanding tokens — the only way to kill a live token was expiry or a global policy-epoch bump (which logs out every device). This is the check that closes that gap.

## Fail-open policy (and why)
`isActorTokenRevoked` returns true only for an actor token with an explicit `status="revoked"` record. Otherwise it allows:
- Non-actor tokens (svc/local) are never checked.
- An actor token with **no record** is allowed — legacy/unrecorded tokens (and any mint path not yet recording, e.g. pre-PR-2 pair tokens) must never break.
- Any **DB error / DB-not-initialized** allows + warns — a revocation check must never take down auth on a DB hiccup; we're no worse off than before it existed.

This also means the PR is safe on main regardless of PR 2: unrecorded pair tokens simply pass, while recorded bootstrap tokens become revocable immediately.

## Excluded / deferred
- The **guardian-refresh** path (`validateEdgeToken(token,{allowExpired:true})`) is deliberately NOT revocation-checked — refresh is the recovery path and uses its own DB-backed refresh-token validation.
- **In-memory cache** for the lookup — deferred to a follow-up perf PR; this is a plain indexed DB read per request.
- **Twilio** webhook auth paths — provider paths (not actor-device tokens); deferred. (The actor-device WS upgrades — `/v1/stt/stream`, `/v1/live-voice` — ARE covered as of the review fix.)

## Tests
- `isActorTokenRevoked`: revoked record → true; active → false; no record → false (fail-open); non-actor (svc) → false; DB unavailable → false (fail-open).
- Runtime-proxy integration: a revoked actor token is rejected with 401 on `/v1/assistants/self/messages` (401 before any upstream proxying).
- Existing auth/proxy/guardian suites pass in isolation (incl. edge-guardian-auth).

## Original prompt
Third and final foundation PR of the remote-pairing feature. Make recorded actor-token revocation actually enforced on live requests via a fail-open hot-path check at the runtime-proxy (chat) and edge-API chokepoints, excluding the refresh flow. This is what makes PR 2's recorded pair tokens genuinely revocable and unblocks re-introducing refreshable pairing (refresh is safe once revocation is enforced). Cache and websocket/voice paths are deferred.

## Note
A pre-existing, unrelated cross-file test-pollution failure occurs only when many gateway test suites run together in one `bun test` process (every suite, including all files touched here, passes in isolation, and the failure reproduces on the existing files without this PR's test). Not introduced here.