### PR TITLE
fix(web): wrap source view in mobile skill detail

### DIFF
--- a/apps/web/src/domains/intelligence/components/skills/skill-file-content.tsx
+++ b/apps/web/src/domains/intelligence/components/skills/skill-file-content.tsx
@@ -54,7 +54,7 @@ export function SkillFileContent({
 
   return (
     <pre
-      className="h-full overflow-auto p-4 font-mono text-body-small-default"
+      className="h-full overflow-y-auto whitespace-pre-wrap break-words p-4 font-mono text-body-small-default"
       style={{ color: "var(--content-default)" }}
     >
       {content}


### PR DESCRIPTION
## Summary
- Source view (`SkillFileContent` raw mode) now soft-wraps long lines (`whitespace-pre-wrap` + `break-words`, vertical scroll only) instead of scrolling horizontally.
- Pure CSS; content/DOM structure unchanged. Markdown preview code blocks (shared `file-markdown`) intentionally left as-is.

Part of plan: ios-skill-detail-mock.md (follow-up fix)