### PR TITLE
feat(assistant): record auth_fallback telemetry events (PR 1/3)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -14220,6 +14220,86 @@ paths:
           required: true
           schema:
             type: string
+  /v1/internal/telemetry/auth-fallback:
+    post:
+      operationId: internal_telemetry_authfallback_post
+      summary: Record auth-fallback counts
+      description:
+        Receives aggregated legacy-loopback auth-fallback counts forwarded by the gateway and persists them for
+        telemetry reporting.
+      tags:
+        - internal
+        - telemetry
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - type: object
+                    properties:
+                      recorded:
+                        type: integer
+                        minimum: 0
+                        maximum: 9007199254740991
+                    required:
+                      - recorded
+                    additionalProperties: false
+                  - type: object
+                    properties:
+                      skipped:
+                        type: boolean
+                        const: true
+                        description: Counts dropped because usage data collection is disabled
+                    required:
+                      - skipped
+                    additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                window_start:
+                  type: integer
+                  minimum: 0
+                  maximum: 9007199254740991
+                window_end:
+                  type: integer
+                  minimum: 0
+                  maximum: 9007199254740991
+                counts:
+                  minItems: 1
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      guard:
+                        type: string
+                        minLength: 1
+                      path:
+                        type: string
+                        minLength: 1
+                      failure_kind:
+                        type: string
+                        minLength: 1
+                      count:
+                        type: integer
+                        exclusiveMinimum: 0
+                        maximum: 9007199254740991
+                    required:
+                      - guard
+                      - path
+                      - failure_kind
+                      - count
+                    additionalProperties: false
+              required:
+                - window_start
+                - window_end
+                - counts
+              additionalProperties: false
   /v1/internal/twilio/connect-action:
     post:
       operationId: internal_twilio_connectaction_post

--- a/assistant/src/__tests__/auth-fallback-events-store.test.ts
+++ b/assistant/src/__tests__/auth-fallback-events-store.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+let collectUsageData = true;
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    model: "test",
+    provider: "test",
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0 },
+    secretDetection: { enabled: false },
+    collectUsageData,
+  }),
+}));
+
+import {
+  type AuthFallbackCount,
+  queryUnreportedAuthFallbackEvents,
+  recordAuthFallbackCounts,
+} from "../memory/auth-fallback-events-store.js";
+import { getDb } from "../memory/db-connection.js";
+import { initializeDb } from "../memory/db-init.js";
+import { authFallbackEvents } from "../memory/schema.js";
+
+initializeDb();
+
+function resetTable(): void {
+  getDb().delete(authFallbackEvents).run();
+}
+
+const SAMPLE: AuthFallbackCount[] = [
+  {
+    guard: "edge",
+    path: "/v1/messages",
+    failureKind: "missing_authorization",
+    count: 7,
+  },
+  {
+    guard: "edge-scoped",
+    path: "/v1/files",
+    failureKind: "insufficient_scope",
+    count: 2,
+  },
+];
+
+describe("auth-fallback-events-store", () => {
+  beforeEach(() => {
+    collectUsageData = true;
+    resetTable();
+  });
+
+  test("records one row per count entry and they are queryable", () => {
+    const recorded = recordAuthFallbackCounts(1000, 2000, SAMPLE);
+    expect(recorded).toBe(2);
+
+    const rows = queryUnreportedAuthFallbackEvents(0, undefined, 100);
+    expect(rows.length).toBe(2);
+    const byGuard = Object.fromEntries(rows.map((r) => [r.guard, r]));
+    expect(byGuard["edge"]).toMatchObject({
+      path: "/v1/messages",
+      failureKind: "missing_authorization",
+      count: 7,
+      windowStart: 1000,
+      windowEnd: 2000,
+    });
+    expect(byGuard["edge-scoped"]).toMatchObject({
+      path: "/v1/files",
+      failureKind: "insufficient_scope",
+      count: 2,
+    });
+  });
+
+  test("honors the collectUsageData opt-out (records nothing)", () => {
+    collectUsageData = false;
+    const recorded = recordAuthFallbackCounts(1000, 2000, SAMPLE);
+    expect(recorded).toBe(0);
+    expect(queryUnreportedAuthFallbackEvents(0, undefined, 100).length).toBe(0);
+  });
+
+  test("empty counts batch is a no-op", () => {
+    expect(recordAuthFallbackCounts(1000, 2000, [])).toBe(0);
+    expect(queryUnreportedAuthFallbackEvents(0, undefined, 100).length).toBe(0);
+  });
+
+  test("query advances past the compound (createdAt, id) cursor", () => {
+    recordAuthFallbackCounts(1000, 2000, SAMPLE);
+    const all = queryUnreportedAuthFallbackEvents(0, undefined, 100);
+    expect(all.length).toBe(2);
+
+    // All rows share the same createdAt (one insert batch). Paginating with a
+    // limit of 1 must use the id tiebreaker to make forward progress, not loop.
+    const first = queryUnreportedAuthFallbackEvents(0, undefined, 1);
+    expect(first.length).toBe(1);
+    const second = queryUnreportedAuthFallbackEvents(
+      first[0].createdAt,
+      first[0].id,
+      1,
+    );
+    expect(second.length).toBe(1);
+    expect(second[0].id).not.toBe(first[0].id);
+
+    // Cursor past the last row returns nothing.
+    const last = all[all.length - 1];
+    expect(
+      queryUnreportedAuthFallbackEvents(last.createdAt, last.id, 100).length,
+    ).toBe(0);
+  });
+});

--- a/assistant/src/__tests__/internal-telemetry-routes.test.ts
+++ b/assistant/src/__tests__/internal-telemetry-routes.test.ts
@@ -7,18 +7,35 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-const mockRecordAuthFallbackCounts = mock<
-  (windowStart: number, windowEnd: number, counts: unknown[]) => number
->(() => 0);
+// Toggle for the collectUsageData opt-out the real store consults. The store
+// module is intentionally NOT mocked here — it has its own DB-backed tests, and
+// Bun's `mock.module` is process-global, so mocking it would leak into those
+// tests when files share an invocation. Exercising the real store keeps every
+// auth-fallback test order-independent.
+let collectUsageData = true;
 
-mock.module("../memory/auth-fallback-events-store.js", () => ({
-  recordAuthFallbackCounts: mockRecordAuthFallbackCounts,
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    model: "test",
+    provider: "test",
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0 },
+    secretDetection: { enabled: false },
+    collectUsageData,
+  }),
 }));
 
+import { queryUnreportedAuthFallbackEvents } from "../memory/auth-fallback-events-store.js";
+import { getDb } from "../memory/db-connection.js";
+import { initializeDb } from "../memory/db-init.js";
+import { authFallbackEvents } from "../memory/schema.js";
 import { GATEWAY_PRINCIPALS } from "../runtime/auth/route-policy.js";
 import { RouteError } from "../runtime/routes/errors.js";
 import { ROUTES } from "../runtime/routes/internal-telemetry-routes.js";
 import type { RouteHandlerArgs } from "../runtime/routes/types.js";
+
+initializeDb();
 
 const route = ROUTES.find(
   (r) => r.operationId === "internal_telemetry_auth_fallback",
@@ -44,8 +61,8 @@ const VALID_BODY = {
 
 describe("internal-telemetry-routes: auth-fallback", () => {
   beforeEach(() => {
-    mockRecordAuthFallbackCounts.mockReset();
-    mockRecordAuthFallbackCounts.mockReturnValue(1);
+    collectUsageData = true;
+    getDb().delete(authFallbackEvents).run();
   });
 
   test("route is locked to service-token callers (GATEWAY_PRINCIPALS + internal.write)", () => {
@@ -56,31 +73,29 @@ describe("internal-telemetry-routes: auth-fallback", () => {
     expect(route?.policy?.requiredScopes).toEqual(["internal.write"]);
   });
 
-  test("valid batch is recorded with snake_case → camelCase mapping", () => {
-    mockRecordAuthFallbackCounts.mockReturnValue(1);
+  test("valid batch is persisted with snake_case → camelCase mapping", () => {
     const result = call(VALID_BODY);
     expect(result).toEqual({ recorded: 1 });
-    expect(mockRecordAuthFallbackCounts).toHaveBeenCalledTimes(1);
-    const [windowStart, windowEnd, counts] =
-      mockRecordAuthFallbackCounts.mock.calls[0];
-    expect(windowStart).toBe(1000);
-    expect(windowEnd).toBe(2000);
-    expect(counts).toEqual([
-      {
-        guard: "edge",
-        path: "/v1/messages",
-        failureKind: "missing_authorization",
-        count: 5,
-      },
-    ]);
+
+    const rows = queryUnreportedAuthFallbackEvents(0, undefined, 100);
+    expect(rows.length).toBe(1);
+    expect(rows[0]).toMatchObject({
+      guard: "edge",
+      path: "/v1/messages",
+      failureKind: "missing_authorization",
+      count: 5,
+      windowStart: 1000,
+      windowEnd: 2000,
+    });
   });
 
-  test("returns skipped when the store drops counts (opt-out)", () => {
-    mockRecordAuthFallbackCounts.mockReturnValue(0);
+  test("returns skipped and persists nothing under the opt-out", () => {
+    collectUsageData = false;
     expect(call(VALID_BODY)).toEqual({ skipped: true });
+    expect(queryUnreportedAuthFallbackEvents(0, undefined, 100).length).toBe(0);
   });
 
-  test("rejects a malformed body", () => {
+  test("rejects a malformed body without persisting", () => {
     expect(() => call({ window_start: 1000 })).toThrow(RouteError);
     expect(() => call({ ...VALID_BODY, counts: [] })).toThrow(RouteError);
     expect(() =>
@@ -89,6 +104,6 @@ describe("internal-telemetry-routes: auth-fallback", () => {
         counts: [{ guard: "edge", path: "/x", failure_kind: "y", count: 0 }],
       }),
     ).toThrow(RouteError);
-    expect(mockRecordAuthFallbackCounts).not.toHaveBeenCalled();
+    expect(queryUnreportedAuthFallbackEvents(0, undefined, 100).length).toBe(0);
   });
 });

--- a/assistant/src/__tests__/internal-telemetry-routes.test.ts
+++ b/assistant/src/__tests__/internal-telemetry-routes.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+const mockRecordAuthFallbackCounts = mock<
+  (windowStart: number, windowEnd: number, counts: unknown[]) => number
+>(() => 0);
+
+mock.module("../memory/auth-fallback-events-store.js", () => ({
+  recordAuthFallbackCounts: mockRecordAuthFallbackCounts,
+}));
+
+import { GATEWAY_PRINCIPALS } from "../runtime/auth/route-policy.js";
+import { RouteError } from "../runtime/routes/errors.js";
+import { ROUTES } from "../runtime/routes/internal-telemetry-routes.js";
+import type { RouteHandlerArgs } from "../runtime/routes/types.js";
+
+const route = ROUTES.find(
+  (r) => r.operationId === "internal_telemetry_auth_fallback",
+);
+
+function call(body: unknown) {
+  if (!route) throw new Error("route not found");
+  return route.handler({ body } as RouteHandlerArgs);
+}
+
+const VALID_BODY = {
+  window_start: 1000,
+  window_end: 2000,
+  counts: [
+    {
+      guard: "edge",
+      path: "/v1/messages",
+      failure_kind: "missing_authorization",
+      count: 5,
+    },
+  ],
+};
+
+describe("internal-telemetry-routes: auth-fallback", () => {
+  beforeEach(() => {
+    mockRecordAuthFallbackCounts.mockReset();
+    mockRecordAuthFallbackCounts.mockReturnValue(1);
+  });
+
+  test("route is locked to service-token callers (GATEWAY_PRINCIPALS + internal.write)", () => {
+    expect(route).toBeDefined();
+    expect(route?.endpoint).toBe("internal/telemetry/auth-fallback");
+    expect(route?.method).toBe("POST");
+    expect(route?.policy?.allowedPrincipalTypes).toEqual(GATEWAY_PRINCIPALS);
+    expect(route?.policy?.requiredScopes).toEqual(["internal.write"]);
+  });
+
+  test("valid batch is recorded with snake_case → camelCase mapping", () => {
+    mockRecordAuthFallbackCounts.mockReturnValue(1);
+    const result = call(VALID_BODY);
+    expect(result).toEqual({ recorded: 1 });
+    expect(mockRecordAuthFallbackCounts).toHaveBeenCalledTimes(1);
+    const [windowStart, windowEnd, counts] =
+      mockRecordAuthFallbackCounts.mock.calls[0];
+    expect(windowStart).toBe(1000);
+    expect(windowEnd).toBe(2000);
+    expect(counts).toEqual([
+      {
+        guard: "edge",
+        path: "/v1/messages",
+        failureKind: "missing_authorization",
+        count: 5,
+      },
+    ]);
+  });
+
+  test("returns skipped when the store drops counts (opt-out)", () => {
+    mockRecordAuthFallbackCounts.mockReturnValue(0);
+    expect(call(VALID_BODY)).toEqual({ skipped: true });
+  });
+
+  test("rejects a malformed body", () => {
+    expect(() => call({ window_start: 1000 })).toThrow(RouteError);
+    expect(() => call({ ...VALID_BODY, counts: [] })).toThrow(RouteError);
+    expect(() =>
+      call({
+        ...VALID_BODY,
+        counts: [{ guard: "edge", path: "/x", failure_kind: "y", count: 0 }],
+      }),
+    ).toThrow(RouteError);
+    expect(mockRecordAuthFallbackCounts).not.toHaveBeenCalled();
+  });
+});

--- a/assistant/src/memory/auth-fallback-events-store.ts
+++ b/assistant/src/memory/auth-fallback-events-store.ts
@@ -1,0 +1,94 @@
+import { and, asc, eq, gt, or } from "drizzle-orm";
+import { v4 as uuid } from "uuid";
+
+import { getConfig } from "../config/loader.js";
+import { getDb } from "./db-connection.js";
+import { authFallbackEvents } from "./schema.js";
+
+/** A single aggregated auth-fallback count for one (guard, path, failure_kind). */
+export interface AuthFallbackCount {
+  guard: string;
+  path: string;
+  failureKind: string;
+  count: number;
+}
+
+/** A persisted auth-fallback event row. */
+export interface AuthFallbackEvent {
+  id: string;
+  createdAt: number;
+  guard: string;
+  path: string;
+  failureKind: string;
+  count: number;
+  windowStart: number;
+  windowEnd: number;
+}
+
+/**
+ * Record a batch of aggregated auth-fallback counts forwarded by the gateway —
+ * one row per count entry, all sharing the same flush window. Returns the
+ * number of rows recorded, or 0 when usage data collection is disabled (the
+ * counts are dropped to honor the opt-out, matching the rest of telemetry).
+ */
+export function recordAuthFallbackCounts(
+  windowStart: number,
+  windowEnd: number,
+  counts: AuthFallbackCount[],
+): number {
+  if (!getConfig().collectUsageData) return 0;
+  if (counts.length === 0) return 0;
+  const db = getDb();
+  const createdAt = Date.now();
+  const rows = counts.map((c) => ({
+    id: uuid(),
+    createdAt,
+    guard: c.guard,
+    path: c.path,
+    failureKind: c.failureKind,
+    count: c.count,
+    windowStart,
+    windowEnd,
+  }));
+  db.insert(authFallbackEvents).values(rows).run();
+  return rows.length;
+}
+
+/**
+ * Query auth-fallback events that haven't been reported to telemetry yet.
+ * Uses a compound cursor (createdAt + id) for reliable watermarking.
+ */
+export function queryUnreportedAuthFallbackEvents(
+  afterCreatedAt: number,
+  afterId: string | undefined,
+  limit: number,
+): AuthFallbackEvent[] {
+  const db = getDb();
+  const rows = db
+    .select({
+      id: authFallbackEvents.id,
+      createdAt: authFallbackEvents.createdAt,
+      guard: authFallbackEvents.guard,
+      path: authFallbackEvents.path,
+      failureKind: authFallbackEvents.failureKind,
+      count: authFallbackEvents.count,
+      windowStart: authFallbackEvents.windowStart,
+      windowEnd: authFallbackEvents.windowEnd,
+    })
+    .from(authFallbackEvents)
+    .where(
+      afterId
+        ? or(
+            gt(authFallbackEvents.createdAt, afterCreatedAt),
+            and(
+              eq(authFallbackEvents.createdAt, afterCreatedAt),
+              gt(authFallbackEvents.id, afterId),
+            ),
+          )
+        : gt(authFallbackEvents.createdAt, afterCreatedAt),
+    )
+    .orderBy(asc(authFallbackEvents.createdAt), asc(authFallbackEvents.id))
+    .limit(limit)
+    .all();
+  return rows;
+}

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -18,6 +18,7 @@ import {
   addCoreColumns,
   createApprovalPromptTsTrackerTable,
   createAssistantInboxTables,
+  createAuthFallbackEventsTable,
   createCallSessionsTables,
   createCanonicalGuardianTables,
   createChannelGuardianTables,
@@ -474,6 +475,7 @@ export function initializeDb(): void {
     migrateAddMemoryV3Selections,
     migrateScheduleScriptTimeout,
     migrateMessagesRoleCreatedAtIndex,
+    createAuthFallbackEventsTable,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/271-create-auth-fallback-events.ts
+++ b/assistant/src/memory/migrations/271-create-auth-fallback-events.ts
@@ -1,0 +1,21 @@
+import type { DrizzleDb } from "../db-connection.js";
+
+/**
+ * Create the auth_fallback_events table for tracking legacy-loopback
+ * auth-fallback counts forwarded by the gateway. One row per
+ * (guard, path, failure_kind) per flush window.
+ */
+export function createAuthFallbackEventsTable(database: DrizzleDb): void {
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS auth_fallback_events (
+      id TEXT PRIMARY KEY,
+      created_at INTEGER NOT NULL,
+      guard TEXT NOT NULL,
+      path TEXT NOT NULL,
+      failure_kind TEXT NOT NULL,
+      count INTEGER NOT NULL,
+      window_start INTEGER NOT NULL,
+      window_end INTEGER NOT NULL
+    )
+  `);
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -257,6 +257,7 @@ export { migrateLlmUsageEventsAddAssistantVersion } from "./267-llm-usage-events
 export { migrateAddMemoryV3Selections } from "./268-add-memory-v3-selections.js";
 export { migrateScheduleScriptTimeout } from "./269-schedule-script-timeout.js";
 export { migrateMessagesRoleCreatedAtIndex } from "./270-messages-role-created-at-index.js";
+export { createAuthFallbackEventsTable } from "./271-create-auth-fallback-events.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/infrastructure.ts
+++ b/assistant/src/memory/schema/infrastructure.ts
@@ -278,6 +278,21 @@ export const onboardingEvents = sqliteTable("onboarding_events", {
   abVariant: text("ab_variant"),
 });
 
+// Aggregated legacy-loopback auth-fallback counts forwarded by the gateway.
+// One row per (guard, path, failure_kind) per flush window; `count` is how many
+// requests fell back to the loopback exemption in that window. Flushed to the
+// platform telemetry endpoint by the usage telemetry reporter.
+export const authFallbackEvents = sqliteTable("auth_fallback_events", {
+  id: text("id").primaryKey(),
+  createdAt: integer("created_at").notNull(),
+  guard: text("guard").notNull(), // 'edge' | 'edge-scoped' | 'edge-guardian'
+  path: text("path").notNull(),
+  failureKind: text("failure_kind").notNull(),
+  count: integer("count").notNull(),
+  windowStart: integer("window_start").notNull(),
+  windowEnd: integer("window_end").notNull(),
+});
+
 export const traceEvents = sqliteTable(
   "trace_events",
   {

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -85,6 +85,7 @@ import { ROUTES as TELEGRAM_ROUTES } from "./integrations/telegram.js";
 import { ROUTES as TWILIO_ROUTES } from "./integrations/twilio.js";
 import { ROUTES as VERCEL_ROUTES } from "./integrations/vercel.js";
 import { ROUTES as INTERNAL_OAUTH_ROUTES } from "./internal-oauth-routes.js";
+import { ROUTES as INTERNAL_TELEMETRY_ROUTES } from "./internal-telemetry-routes.js";
 import { ROUTES as INTERNAL_TWILIO_ROUTES } from "./internal-twilio-routes.js";
 import { ROUTES as LLM_CALL_SITES_ROUTES } from "./llm-call-sites-routes.js";
 import { ROUTES as LOG_EXPORT_ROUTES } from "./log-export-routes.js";
@@ -212,6 +213,7 @@ export const ROUTES: RouteDefinition[] = [
   ...INFERENCE_PROVIDER_CONNECTION_ROUTES,
   ...INFERENCE_SEND_ROUTES,
   ...INTERNAL_OAUTH_ROUTES,
+  ...INTERNAL_TELEMETRY_ROUTES,
   ...MCP_AUTH_ROUTES,
   ...OAUTH_CONNECT_ROUTES,
   ...INTERNAL_TWILIO_ROUTES,

--- a/assistant/src/runtime/routes/internal-telemetry-routes.ts
+++ b/assistant/src/runtime/routes/internal-telemetry-routes.ts
@@ -1,0 +1,88 @@
+/**
+ * Internal telemetry routes — receive operational signals forwarded from the
+ * gateway over the internal (service-token) transport.
+ *
+ * POST /v1/internal/telemetry/auth-fallback — record aggregated counts of
+ * requests served via the legacy loopback auth fallback. The gateway counts
+ * fallbacks in memory and flushes them here per window; the usage telemetry
+ * reporter ships the persisted rows to the platform.
+ */
+
+import { z } from "zod";
+
+import {
+  type AuthFallbackCount,
+  recordAuthFallbackCounts,
+} from "../../memory/auth-fallback-events-store.js";
+import { getLogger } from "../../util/logger.js";
+import { GATEWAY_PRINCIPALS } from "../auth/route-policy.js";
+import { BadRequestError } from "./errors.js";
+import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+
+const log = getLogger("internal-telemetry-routes");
+
+const authFallbackBody = z.object({
+  window_start: z.number().int().nonnegative(),
+  window_end: z.number().int().nonnegative(),
+  counts: z
+    .array(
+      z.object({
+        guard: z.string().min(1),
+        path: z.string().min(1),
+        failure_kind: z.string().min(1),
+        count: z.number().int().positive(),
+      }),
+    )
+    .min(1),
+});
+
+function handleRecordAuthFallback({ body }: RouteHandlerArgs) {
+  const parsed = authFallbackBody.safeParse(body);
+  if (!parsed.success) {
+    throw new BadRequestError(
+      `Invalid auth-fallback payload: ${parsed.error.message}`,
+    );
+  }
+  const { window_start, window_end, counts } = parsed.data;
+  const mapped: AuthFallbackCount[] = counts.map((c) => ({
+    guard: c.guard,
+    path: c.path,
+    failureKind: c.failure_kind,
+    count: c.count,
+  }));
+
+  const recorded = recordAuthFallbackCounts(window_start, window_end, mapped);
+  if (recorded === 0) {
+    // collectUsageData disabled — counts dropped to honor the opt-out.
+    return { skipped: true };
+  }
+  log.debug({ recorded }, "Recorded auth-fallback counts");
+  return { recorded };
+}
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "internal_telemetry_auth_fallback",
+    endpoint: "internal/telemetry/auth-fallback",
+    method: "POST",
+    policy: {
+      requiredScopes: ["internal.write"],
+      allowedPrincipalTypes: GATEWAY_PRINCIPALS,
+    },
+    summary: "Record auth-fallback counts",
+    description:
+      "Receives aggregated legacy-loopback auth-fallback counts forwarded by " +
+      "the gateway and persists them for telemetry reporting.",
+    tags: ["internal", "telemetry"],
+    requestBody: authFallbackBody,
+    responseBody: z.union([
+      z.object({ recorded: z.number().int().nonnegative() }),
+      z.object({
+        skipped: z
+          .literal(true)
+          .describe("Counts dropped because usage data collection is disabled"),
+      }),
+    ]),
+    handler: handleRecordAuthFallback,
+  },
+];

--- a/assistant/src/telemetry/types.ts
+++ b/assistant/src/telemetry/types.ts
@@ -185,9 +185,37 @@ export interface OnboardingTelemetryEvent extends TelemetryEventBase {
   ab_variant?: string;
 }
 
+/**
+ * Auth-fallback event — aggregated count of requests served via the legacy
+ * loopback auth fallback. One event per (guard, path, failure_kind) per flush
+ * window. Lets the platform see which deployments still rely on the loopback
+ * exemption instead of sending a bearer token.
+ */
+export interface AuthFallbackTelemetryEvent extends TelemetryEventBase {
+  type: "auth_fallback";
+  /** Which auth guard fell back: `"edge"` | `"edge-scoped"` | `"edge-guardian"`. */
+  guard: string;
+  /** Request pathname that fell back. */
+  path: string;
+  /**
+   * Why the bearer-token check did not succeed before the fallback:
+   * `"missing_authorization"` | `"malformed_authorization"` |
+   * `"token_validation_failed"` | `"insufficient_scope"` |
+   * `"non_actor_principal"` | `"guardian_mismatch"`.
+   */
+  failure_kind: string;
+  /** Number of requests that fell back for this key during the window. */
+  count: number;
+  /** Window start (epoch ms) the count was accumulated over. */
+  window_start: number;
+  /** Window end (epoch ms) the count was accumulated over. */
+  window_end: number;
+}
+
 /** Discriminated union of all telemetry event types. */
 export type TelemetryEvent =
   | LlmUsageTelemetryEvent
   | TurnTelemetryEvent
   | LifecycleTelemetryEvent
-  | OnboardingTelemetryEvent;
+  | OnboardingTelemetryEvent
+  | AuthFallbackTelemetryEvent;

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -94,7 +94,15 @@ mock.module("../version.js", () => ({
 let mockCollectUsageData = true;
 
 mock.module("../config/loader.js", () => ({
-  getConfig: () => ({ collectUsageData: mockCollectUsageData }),
+  getConfig: () => ({
+    ui: {},
+    model: "test",
+    provider: "test",
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0 },
+    secretDetection: { enabled: false },
+    collectUsageData: mockCollectUsageData,
+  }),
 }));
 
 const mockQueryUnreportedLifecycleEvents = mock(
@@ -130,30 +138,23 @@ mock.module("../memory/onboarding-events-store.js", () => ({
   queryUnreportedOnboardingEvents: mockQueryUnreportedOnboardingEvents,
 }));
 
-const mockQueryUnreportedAuthFallbackEvents = mock(
-  () =>
-    [] as {
-      id: string;
-      createdAt: number;
-      guard: string;
-      path: string;
-      failureKind: string;
-      count: number;
-      windowStart: number;
-      windowEnd: number;
-    }[],
-);
-
-mock.module("../memory/auth-fallback-events-store.js", () => ({
-  queryUnreportedAuthFallbackEvents: mockQueryUnreportedAuthFallbackEvents,
-}));
+// The auth-fallback store is intentionally NOT mocked — it has its own
+// DB-backed tests, and Bun's `mock.module` is process-global, so mocking it
+// here would leak into those tests when files share an invocation. We seed the
+// real DB instead so every auth-fallback test stays order-independent.
 
 // ---------------------------------------------------------------------------
 // Production import (after mocks)
 // ---------------------------------------------------------------------------
 
+import { recordAuthFallbackCounts } from "../memory/auth-fallback-events-store.js";
+import { getDb } from "../memory/db-connection.js";
+import { initializeDb } from "../memory/db-init.js";
+import { authFallbackEvents } from "../memory/schema.js";
 import type { UsageEvent } from "../usage/types.js";
 import { UsageTelemetryReporter } from "./usage-telemetry-reporter.js";
+
+initializeDb();
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -219,8 +220,7 @@ beforeEach(() => {
   mockQueryUnreportedLifecycleEvents.mockReturnValue([]);
   mockQueryUnreportedOnboardingEvents.mockReset();
   mockQueryUnreportedOnboardingEvents.mockReturnValue([]);
-  mockQueryUnreportedAuthFallbackEvents.mockReset();
-  mockQueryUnreportedAuthFallbackEvents.mockReturnValue([]);
+  getDb().delete(authFallbackEvents).run();
   mockPlatformClient = null;
   mockGetPlatformBaseUrl.mockReset();
   mockGetDeviceId.mockReset();
@@ -1103,16 +1103,12 @@ describe("UsageTelemetryReporter", () => {
 
   test("auth_fallback events are included in the events array with type discriminator", async () => {
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
-    mockQueryUnreportedAuthFallbackEvents.mockReturnValue([
+    recordAuthFallbackCounts(1700000740000, 1700000800000, [
       {
-        id: "evt-af-1",
-        createdAt: 1700000800000,
         guard: "edge",
         path: "/v1/messages",
         failureKind: "missing_authorization",
         count: 42,
-        windowStart: 1700000740000,
-        windowEnd: 1700000800000,
       },
     ]);
     mockFetch.mockImplementation(() =>
@@ -1129,8 +1125,6 @@ describe("UsageTelemetryReporter", () => {
     expect(body.events.length).toBe(1);
     expect(body.events[0]).toMatchObject({
       type: "auth_fallback",
-      daemon_event_id: "evt-af-1",
-      recorded_at: 1700000800000,
       guard: "edge",
       path: "/v1/messages",
       failure_kind: "missing_authorization",
@@ -1139,35 +1133,39 @@ describe("UsageTelemetryReporter", () => {
       window_end: 1700000800000,
       assistant_version: "1.2.3-test",
     });
+    // recorded_at is the row's createdAt (stamped at record time).
+    expect(typeof body.events[0].recorded_at).toBe("number");
+    expect(typeof body.events[0].daemon_event_id).toBe("string");
   });
 
-  test("auth_fallback watermark advances on successful upload", async () => {
+  test("auth_fallback watermark advances to the last reported row on success", async () => {
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
-    mockQueryUnreportedAuthFallbackEvents.mockReturnValue([
+    recordAuthFallbackCounts(1700000000000, 1700000001000, [
       {
-        id: "evt-af-w1",
-        createdAt: 1700000001000,
         guard: "edge-scoped",
         path: "/v1/a",
         failureKind: "insufficient_scope",
         count: 1,
-        windowStart: 1700000000000,
-        windowEnd: 1700000001000,
       },
       {
-        id: "evt-af-w2",
-        createdAt: 1700000002000,
         guard: "edge-guardian",
         path: "/v1/b",
         failureKind: "guardian_mismatch",
         count: 3,
-        windowStart: 1700000001000,
-        windowEnd: 1700000002000,
       },
     ]);
     mockFetch.mockImplementation(() =>
       Promise.resolve(new Response('{"accepted":2}', { status: 200 })),
     );
+
+    // The last row by the reporter's (createdAt, id) cursor order is the one
+    // whose watermark should be persisted after a successful upload.
+    const rows = getDb()
+      .select()
+      .from(authFallbackEvents)
+      .orderBy(authFallbackEvents.createdAt, authFallbackEvents.id)
+      .all();
+    const lastRow = rows[rows.length - 1];
 
     const reporter = new UsageTelemetryReporter();
     await reporter.flush();
@@ -1177,13 +1175,13 @@ describe("UsageTelemetryReporter", () => {
     );
     expect(watermarkCalls.length).toBeGreaterThanOrEqual(1);
     expect(watermarkCalls[watermarkCalls.length - 1][1]).toBe(
-      String(1700000002000),
+      String(lastRow.createdAt),
     );
 
     const idCalls = mockSetMemoryCheckpoint.mock.calls.filter(
       (c) => c[0] === "telemetry:auth_fallback:last_reported_id",
     );
     expect(idCalls.length).toBeGreaterThanOrEqual(1);
-    expect(idCalls[idCalls.length - 1][1]).toBe("evt-af-w2");
+    expect(idCalls[idCalls.length - 1][1]).toBe(lastRow.id);
   });
 });

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -130,6 +130,24 @@ mock.module("../memory/onboarding-events-store.js", () => ({
   queryUnreportedOnboardingEvents: mockQueryUnreportedOnboardingEvents,
 }));
 
+const mockQueryUnreportedAuthFallbackEvents = mock(
+  () =>
+    [] as {
+      id: string;
+      createdAt: number;
+      guard: string;
+      path: string;
+      failureKind: string;
+      count: number;
+      windowStart: number;
+      windowEnd: number;
+    }[],
+);
+
+mock.module("../memory/auth-fallback-events-store.js", () => ({
+  queryUnreportedAuthFallbackEvents: mockQueryUnreportedAuthFallbackEvents,
+}));
+
 // ---------------------------------------------------------------------------
 // Production import (after mocks)
 // ---------------------------------------------------------------------------
@@ -201,6 +219,8 @@ beforeEach(() => {
   mockQueryUnreportedLifecycleEvents.mockReturnValue([]);
   mockQueryUnreportedOnboardingEvents.mockReset();
   mockQueryUnreportedOnboardingEvents.mockReturnValue([]);
+  mockQueryUnreportedAuthFallbackEvents.mockReset();
+  mockQueryUnreportedAuthFallbackEvents.mockReturnValue([]);
   mockPlatformClient = null;
   mockGetPlatformBaseUrl.mockReset();
   mockGetDeviceId.mockReset();
@@ -909,9 +929,9 @@ describe("UsageTelemetryReporter", () => {
     // No HTTP call should have been made
     expect(mockFetch).not.toHaveBeenCalled();
 
-    // All 4 timestamp watermarks should have been advanced (IDs left untouched
+    // All 5 timestamp watermarks should have been advanced (IDs left untouched
     // so the compound-cursor branch stays active)
-    expect(mockSetMemoryCheckpoint).toHaveBeenCalledTimes(4);
+    expect(mockSetMemoryCheckpoint).toHaveBeenCalledTimes(5);
 
     const calls = mockSetMemoryCheckpoint.mock.calls;
     const keys = calls.map((c) => c[0]);
@@ -919,6 +939,7 @@ describe("UsageTelemetryReporter", () => {
     expect(keys).toContain("telemetry:turns:last_reported_at");
     expect(keys).toContain("telemetry:lifecycle:last_reported_at");
     expect(keys).toContain("telemetry:onboarding:last_reported_at");
+    expect(keys).toContain("telemetry:auth_fallback:last_reported_at");
   });
 
   test("events sent normally after re-enabling collectUsageData", async () => {
@@ -1074,5 +1095,95 @@ describe("UsageTelemetryReporter", () => {
     expect(versions.sort()).toEqual(["0.8.3", "0.8.5"]);
     // Envelope still reflects the running binary, not either event.
     expect(body.assistant_version).toBe("1.2.3-test");
+  });
+
+  // -------------------------------------------------------------------------
+  // Auth-fallback events
+  // -------------------------------------------------------------------------
+
+  test("auth_fallback events are included in the events array with type discriminator", async () => {
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    mockQueryUnreportedAuthFallbackEvents.mockReturnValue([
+      {
+        id: "evt-af-1",
+        createdAt: 1700000800000,
+        guard: "edge",
+        path: "/v1/messages",
+        failureKind: "missing_authorization",
+        count: 42,
+        windowStart: 1700000740000,
+        windowEnd: 1700000800000,
+      },
+    ]);
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
+    );
+
+    const reporter = new UsageTelemetryReporter();
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect(body.events.length).toBe(1);
+    expect(body.events[0]).toMatchObject({
+      type: "auth_fallback",
+      daemon_event_id: "evt-af-1",
+      recorded_at: 1700000800000,
+      guard: "edge",
+      path: "/v1/messages",
+      failure_kind: "missing_authorization",
+      count: 42,
+      window_start: 1700000740000,
+      window_end: 1700000800000,
+      assistant_version: "1.2.3-test",
+    });
+  });
+
+  test("auth_fallback watermark advances on successful upload", async () => {
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    mockQueryUnreportedAuthFallbackEvents.mockReturnValue([
+      {
+        id: "evt-af-w1",
+        createdAt: 1700000001000,
+        guard: "edge-scoped",
+        path: "/v1/a",
+        failureKind: "insufficient_scope",
+        count: 1,
+        windowStart: 1700000000000,
+        windowEnd: 1700000001000,
+      },
+      {
+        id: "evt-af-w2",
+        createdAt: 1700000002000,
+        guard: "edge-guardian",
+        path: "/v1/b",
+        failureKind: "guardian_mismatch",
+        count: 3,
+        windowStart: 1700000001000,
+        windowEnd: 1700000002000,
+      },
+    ]);
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response('{"accepted":2}', { status: 200 })),
+    );
+
+    const reporter = new UsageTelemetryReporter();
+    await reporter.flush();
+
+    const watermarkCalls = mockSetMemoryCheckpoint.mock.calls.filter(
+      (c) => c[0] === "telemetry:auth_fallback:last_reported_at",
+    );
+    expect(watermarkCalls.length).toBeGreaterThanOrEqual(1);
+    expect(watermarkCalls[watermarkCalls.length - 1][1]).toBe(
+      String(1700000002000),
+    );
+
+    const idCalls = mockSetMemoryCheckpoint.mock.calls.filter(
+      (c) => c[0] === "telemetry:auth_fallback:last_reported_id",
+    );
+    expect(idCalls.length).toBeGreaterThanOrEqual(1);
+    expect(idCalls[idCalls.length - 1][1]).toBe("evt-af-w2");
   });
 });

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -15,6 +15,7 @@ import {
   getPlatformUserId,
 } from "../config/env.js";
 import { getConfig } from "../config/loader.js";
+import { queryUnreportedAuthFallbackEvents } from "../memory/auth-fallback-events-store.js";
 import {
   getMemoryCheckpoint,
   setMemoryCheckpoint,
@@ -47,6 +48,10 @@ const CHECKPOINT_KEY_ONBOARDING_WATERMARK =
   "telemetry:onboarding:last_reported_at";
 const CHECKPOINT_KEY_ONBOARDING_WATERMARK_ID =
   "telemetry:onboarding:last_reported_id";
+const CHECKPOINT_KEY_AUTH_FALLBACK_WATERMARK =
+  "telemetry:auth_fallback:last_reported_at";
+const CHECKPOINT_KEY_AUTH_FALLBACK_WATERMARK_ID =
+  "telemetry:auth_fallback:last_reported_id";
 const REPORT_INTERVAL_MS = 5 * 60 * 1000;
 const INITIAL_FLUSH_DELAY_MS = 30_000; // Delay first flush to let CES handshake complete
 const BATCH_SIZE = 500;
@@ -139,6 +144,7 @@ export class UsageTelemetryReporter {
         setMemoryCheckpoint(CHECKPOINT_KEY_TURN_WATERMARK, now);
         setMemoryCheckpoint(CHECKPOINT_KEY_LIFECYCLE_WATERMARK, now);
         setMemoryCheckpoint(CHECKPOINT_KEY_ONBOARDING_WATERMARK, now);
+        setMemoryCheckpoint(CHECKPOINT_KEY_AUTH_FALLBACK_WATERMARK, now);
         return;
       }
 
@@ -171,6 +177,14 @@ export class UsageTelemetryReporter {
         getMemoryCheckpoint(CHECKPOINT_KEY_ONBOARDING_WATERMARK_ID) ??
         undefined;
 
+      // Read auth-fallback watermark (compound cursor: createdAt + id)
+      const authFallbackWatermark = Number(
+        getMemoryCheckpoint(CHECKPOINT_KEY_AUTH_FALLBACK_WATERMARK) ?? "0",
+      );
+      const authFallbackWatermarkId =
+        getMemoryCheckpoint(CHECKPOINT_KEY_AUTH_FALLBACK_WATERMARK_ID) ??
+        undefined;
+
       // Query unreported events
       const events = queryUnreportedUsageEvents(
         watermark,
@@ -192,12 +206,18 @@ export class UsageTelemetryReporter {
         onboardingWatermarkId,
         BATCH_SIZE,
       );
+      const authFallbackEvents = queryUnreportedAuthFallbackEvents(
+        authFallbackWatermark,
+        authFallbackWatermarkId,
+        BATCH_SIZE,
+      );
 
       if (
         events.length === 0 &&
         turnEvents.length === 0 &&
         lifecycleEvents.length === 0 &&
-        onboardingEvents.length === 0
+        onboardingEvents.length === 0 &&
+        authFallbackEvents.length === 0
       )
         return;
 
@@ -211,6 +231,7 @@ export class UsageTelemetryReporter {
           turnCount: turnEvents.length,
           lifecycleCount: lifecycleEvents.length,
           onboardingCount: onboardingEvents.length,
+          authFallbackCount: authFallbackEvents.length,
         },
         "Telemetry flush: resolved auth context",
       );
@@ -337,6 +358,25 @@ export class UsageTelemetryReporter {
             assistant_version: APP_VERSION,
           }),
         ),
+        ...authFallbackEvents.map(
+          (e): TelemetryEvent => ({
+            type: "auth_fallback",
+            daemon_event_id: e.id,
+            recorded_at: e.createdAt,
+            guard: e.guard,
+            path: e.path,
+            failure_kind: e.failureKind,
+            count: e.count,
+            window_start: e.windowStart,
+            window_end: e.windowEnd,
+            // Aggregated counts forwarded by the gateway carry no record-time
+            // binary version; stamp the running binary's `APP_VERSION` so the
+            // wire value is concrete rather than an explicit null that would
+            // override the envelope under the platform's per-event-wins
+            // contract.
+            assistant_version: APP_VERSION,
+          }),
+        ),
       ];
 
       const organizationId = getPlatformOrganizationId() || undefined;
@@ -422,12 +462,27 @@ export class UsageTelemetryReporter {
         );
       }
 
+      // Advance auth-fallback watermark (compound cursor)
+      if (authFallbackEvents.length > 0) {
+        const lastAuthFallback =
+          authFallbackEvents[authFallbackEvents.length - 1];
+        setMemoryCheckpoint(
+          CHECKPOINT_KEY_AUTH_FALLBACK_WATERMARK,
+          String(lastAuthFallback.createdAt),
+        );
+        setMemoryCheckpoint(
+          CHECKPOINT_KEY_AUTH_FALLBACK_WATERMARK_ID,
+          lastAuthFallback.id,
+        );
+      }
+
       // If we got a full batch of any type, there may be more — recurse
       if (
         events.length === BATCH_SIZE ||
         turnEvents.length === BATCH_SIZE ||
         lifecycleEvents.length === BATCH_SIZE ||
-        onboardingEvents.length === BATCH_SIZE
+        onboardingEvents.length === BATCH_SIZE ||
+        authFallbackEvents.length === BATCH_SIZE
       ) {
         await this._doFlush(batchCount + 1);
       }


### PR DESCRIPTION
## Summary
- Add an `auth_fallback` telemetry event so loopback auth-fallbacks (PR #33011) become trackable **data** — aggregated counts broken down by guard, path, and failure kind — instead of a throttled, local-only log line.
- Assistant-side receiver only: new `auth_fallback_events` table + migration 271, an event store mirroring `lifecycle-events-store.ts` (compound `(created_at, id)` watermark cursor, honors the `collectUsageData` opt-out), a service-token internal route `POST /v1/internal/telemetry/auth-fallback` (`GATEWAY_PRINCIPALS` + `internal.write`), and wiring through `UsageTelemetryReporter` so the rows flush to `/v1/telemetry/ingest/`.
- Tests: store (opt-out + compound-cursor pagination), route (mapping, opt-out skip, malformed-body rejection, service-token policy lock), and reporter (event shape + watermark advance).

## Original prompt
PR #33011 made the gateway prefer bearer auth and keep loopback as a fallback, but it only emits a throttled, local-only log line — so there's no way to know how often requests fall back or which path they come from. We agreed to turn this into real telemetry: the gateway will aggregate fallback counts in memory and flush them to the daemon, which ships them to the Vellum cloud via the existing telemetry pipeline, broken down by path + guard + failure kind (honoring the `collectUsageData` opt-out). This is **PR 1 of 3** — the assistant-side receiver. PR 2 adds the gateway sender; PR 3 (separate platform repo) adds `/v1/telemetry/ingest/` ingestion and a dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)