### PR TITLE
feat(gateway): count + report legacy loopback auth fallbacks (PR 2/3)

### DIFF
--- a/gateway/src/__tests__/auth-fallback-count-tracker.test.ts
+++ b/gateway/src/__tests__/auth-fallback-count-tracker.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+
+import { AuthFallbackCountTracker } from "../auth-fallback-count-tracker.js";
+
+describe("AuthFallbackCountTracker", () => {
+  test("increments per (guard, path, failureKind) key", () => {
+    const t = new AuthFallbackCountTracker(0);
+    t.increment("edge", "/v1/chat", "missing_authorization");
+    t.increment("edge", "/v1/chat", "missing_authorization");
+    t.increment("edge", "/v1/chat", "token_validation_failed");
+    t.increment("edge-guardian", "/v1/chat", "missing_authorization");
+
+    const snap = t.snapshot();
+    expect(snap.length).toBe(3);
+    const find = (g: string, p: string, f: string) =>
+      snap.find((c) => c.guard === g && c.path === p && c.failureKind === f)
+        ?.count;
+    expect(find("edge", "/v1/chat", "missing_authorization")).toBe(2);
+    expect(find("edge", "/v1/chat", "token_validation_failed")).toBe(1);
+    expect(find("edge-guardian", "/v1/chat", "missing_authorization")).toBe(1);
+  });
+
+  test("drain returns the window + counts and resets", () => {
+    const t = new AuthFallbackCountTracker(1000);
+    t.increment("edge", "/v1/a", "missing_authorization");
+    t.increment("edge", "/v1/a", "missing_authorization");
+
+    const batch = t.drain(2000);
+    expect(batch.windowStart).toBe(1000);
+    expect(batch.windowEnd).toBe(2000);
+    expect(batch.counts).toEqual([
+      {
+        guard: "edge",
+        path: "/v1/a",
+        failureKind: "missing_authorization",
+        count: 2,
+      },
+    ]);
+
+    // Drained — tracker is empty and the window is re-anchored to the drain.
+    expect(t.snapshot()).toEqual([]);
+    const empty = t.drain(3000);
+    expect(empty.counts).toEqual([]);
+    expect(empty.windowStart).toBe(2000);
+    expect(empty.windowEnd).toBe(3000);
+  });
+
+  test("an empty drain leaves the window start anchored", () => {
+    const t = new AuthFallbackCountTracker(1000);
+    // Nothing recorded yet — draining must not shift windowStart forward.
+    expect(t.drain(2000)).toMatchObject({ windowStart: 1000, windowEnd: 2000 });
+    t.increment("edge", "/v1/a", "missing_authorization");
+    expect(t.drain(3000).windowStart).toBe(1000);
+  });
+
+  test("merge folds a drained batch back in", () => {
+    const t = new AuthFallbackCountTracker(0);
+    t.increment("edge", "/v1/a", "missing_authorization");
+    const batch = t.drain(100);
+
+    // Simulate a failed flush: counts come back, plus a newer count for the
+    // same key that accumulated after the drain.
+    t.increment("edge", "/v1/a", "missing_authorization");
+    t.merge(batch.counts);
+
+    const snap = t.snapshot();
+    expect(snap.length).toBe(1);
+    expect(snap[0].count).toBe(2);
+  });
+
+  test("caps distinct keys but keeps counting existing ones", () => {
+    const t = new AuthFallbackCountTracker(0);
+    // MAX_TRACKED_KEYS is 10_000; exceed it with distinct paths.
+    for (let i = 0; i < 10_050; i++) {
+      t.increment("edge", `/v1/p${i}`, "missing_authorization");
+    }
+    const snap = t.snapshot();
+    expect(snap.length).toBe(10_000);
+
+    // An already-tracked key still increments past the cap.
+    t.increment("edge", "/v1/p0", "missing_authorization");
+    expect(t.snapshot().find((c) => c.path === "/v1/p0")?.count).toBe(2);
+  });
+
+  test("reset clears counts", () => {
+    const t = new AuthFallbackCountTracker(0);
+    t.increment("edge", "/v1/a", "missing_authorization");
+    t.reset(500);
+    expect(t.snapshot()).toEqual([]);
+    expect(t.drain(600).windowStart).toBe(500);
+  });
+});

--- a/gateway/src/__tests__/auth-fallback-reporter.test.ts
+++ b/gateway/src/__tests__/auth-fallback-reporter.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import { AuthFallbackCountTracker } from "../auth-fallback-count-tracker.js";
+import { AuthFallbackReporter } from "../auth-fallback-reporter.js";
+
+const BASE_URL = "http://127.0.0.1:7821";
+
+function makeReporter(
+  tracker: AuthFallbackCountTracker,
+  fetchImpl: typeof import("../fetch.js").fetchImpl,
+) {
+  return new AuthFallbackReporter({
+    tracker,
+    baseUrl: BASE_URL,
+    intervalMs: 60_000,
+    fetchImpl,
+    mintToken: () => "test-service-token",
+  });
+}
+
+describe("AuthFallbackReporter", () => {
+  test("does nothing when there is nothing to flush", async () => {
+    const tracker = new AuthFallbackCountTracker(0);
+    const fetchMock = mock(async () => new Response("{}", { status: 200 }));
+    await makeReporter(tracker, fetchMock as never).flush();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("drains and POSTs the counts to the daemon route with a service token", async () => {
+    const tracker = new AuthFallbackCountTracker(0);
+    tracker.increment("edge", "/v1/chat", "missing_authorization");
+    tracker.increment("edge", "/v1/chat", "missing_authorization");
+    tracker.increment("edge-guardian", "/v1/sync", "guardian_mismatch");
+
+    const fetchMock = mock(async () => new Response("{}", { status: 200 }));
+    await makeReporter(tracker, fetchMock as never).flush();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [
+      string,
+      RequestInit,
+    ];
+    expect(url).toBe(`${BASE_URL}/v1/internal/telemetry/auth-fallback`);
+    expect(init.method).toBe("POST");
+    const headers = init.headers as Record<string, string>;
+    expect(headers["Content-Type"]).toBe("application/json");
+    expect(headers["Authorization"]).toBe("Bearer test-service-token");
+
+    const body = JSON.parse(init.body as string);
+    expect(typeof body.window_start).toBe("number");
+    expect(typeof body.window_end).toBe("number");
+    expect(body.counts).toEqual(
+      expect.arrayContaining([
+        {
+          guard: "edge",
+          path: "/v1/chat",
+          failure_kind: "missing_authorization",
+          count: 2,
+        },
+        {
+          guard: "edge-guardian",
+          path: "/v1/sync",
+          failure_kind: "guardian_mismatch",
+          count: 1,
+        },
+      ]),
+    );
+
+    // Successful flush drains the tracker.
+    expect(tracker.snapshot()).toEqual([]);
+  });
+
+  test("re-queues counts when the daemon returns a non-OK status", async () => {
+    const tracker = new AuthFallbackCountTracker(0);
+    tracker.increment("edge", "/v1/chat", "missing_authorization");
+
+    const fetchMock = mock(async () => new Response("nope", { status: 404 }));
+    await makeReporter(tracker, fetchMock as never).flush();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // Counts merged back so the next flush retries them.
+    const snap = tracker.snapshot();
+    expect(snap.length).toBe(1);
+    expect(snap[0].count).toBe(1);
+  });
+
+  test("re-queues counts when the POST throws", async () => {
+    const tracker = new AuthFallbackCountTracker(0);
+    tracker.increment("edge", "/v1/chat", "missing_authorization");
+    tracker.increment("edge", "/v1/chat", "missing_authorization");
+
+    const fetchMock = mock(async () => {
+      throw new Error("connection refused");
+    });
+    await makeReporter(tracker, fetchMock as never).flush();
+
+    const snap = tracker.snapshot();
+    expect(snap.length).toBe(1);
+    expect(snap[0].count).toBe(2);
+  });
+});

--- a/gateway/src/__tests__/edge-auth.test.ts
+++ b/gateway/src/__tests__/edge-auth.test.ts
@@ -43,7 +43,8 @@ mock.module("../auth/token-exchange.js", () => ({
 }));
 
 const { AuthRateLimiter } = await import("../auth-rate-limiter.js");
-const { createAuthMiddleware } = await import("../http/middleware/auth.js");
+const { createAuthMiddleware, loopbackFallbackCountTracker } =
+  await import("../http/middleware/auth.js");
 
 const PLATFORM_USER_ID = "user-abc-123";
 
@@ -68,6 +69,7 @@ function makeLoopbackServer(address = "127.0.0.1") {
 beforeEach(() => {
   mockReadCredential = mock(async () => undefined);
   mockValidateEdgeToken = mock(() => ({ ok: false, reason: "noop" }));
+  loopbackFallbackCountTracker.reset();
 });
 
 afterEach(() => {
@@ -190,6 +192,20 @@ describe("requireEdgeAuth — JWT mode", () => {
     const res = await requireEdgeAuth(makeReq(), makeLoopbackServer());
     expect(res).toBeNull();
     expect(mockValidateEdgeToken).not.toHaveBeenCalled();
+  });
+
+  test("a loopback fallback is counted by (guard, path, failureKind)", async () => {
+    const { requireEdgeAuth } = makeMiddleware();
+    await requireEdgeAuth(makeReq(), makeLoopbackServer());
+    await requireEdgeAuth(makeReq(), makeLoopbackServer());
+    expect(loopbackFallbackCountTracker.snapshot()).toEqual([
+      {
+        guard: "edge",
+        path: "/v1/something",
+        failureKind: "missing_authorization",
+        count: 2,
+      },
+    ]);
   });
 
   test("null on valid bearer token", async () => {

--- a/gateway/src/__tests__/edge-guardian-auth.test.ts
+++ b/gateway/src/__tests__/edge-guardian-auth.test.ts
@@ -43,7 +43,8 @@ mock.module("../auth/token-exchange.js", () => ({
 }));
 
 const { AuthRateLimiter } = await import("../auth-rate-limiter.js");
-const { createAuthMiddleware } = await import("../http/middleware/auth.js");
+const { createAuthMiddleware, loopbackFallbackCountTracker } =
+  await import("../http/middleware/auth.js");
 
 const PLATFORM_USER_ID = "user-abc-123";
 const GUARDIAN_PRINCIPAL = "actor-guardian-xyz";
@@ -70,6 +71,7 @@ beforeEach(() => {
   mockReadCredential = mock(async () => undefined);
   mockFindVellumGuardian = mock(async () => null);
   mockValidateEdgeToken = mock(() => ({ ok: false, reason: "noop" }));
+  loopbackFallbackCountTracker.reset();
 });
 
 afterEach(() => {
@@ -188,6 +190,19 @@ describe("requireEdgeGuardianAuth — actor principal mode", () => {
     );
     expect(res).toBeNull();
     expect(mockFindVellumGuardian).not.toHaveBeenCalled();
+  });
+
+  test("a guardian loopback fallback is counted under the edge-guardian guard", async () => {
+    const { requireEdgeGuardianAuth } = makeMiddleware();
+    await requireEdgeGuardianAuth(makeReq(), makeLoopbackServer());
+    expect(loopbackFallbackCountTracker.snapshot()).toEqual([
+      {
+        guard: "edge-guardian",
+        path: "/v1/contact-channels/abc/verify",
+        failureKind: "missing_authorization",
+        count: 1,
+      },
+    ]);
   });
 
   test("returns 503 when findVellumGuardian throws (transient assistant DB outage)", async () => {

--- a/gateway/src/auth-fallback-count-tracker.ts
+++ b/gateway/src/auth-fallback-count-tracker.ts
@@ -1,0 +1,113 @@
+// Accumulates counts of requests served via the legacy loopback auth fallback,
+// keyed by (guard, path, failureKind). The auth hot path calls `increment`
+// (an O(1) Map bump, no I/O); a background reporter periodically `drain`s the
+// accumulated counts and ships them to the daemon telemetry route. This is the
+// data complement to AuthFallbackLogThrottle's throttled log line: the log is a
+// sampled human signal, these counts are the exact volume.
+
+import { getLogger } from "./logger.js";
+
+const log = getLogger("auth-fallback-tracker");
+
+// Bounds memory if a caller floods distinct paths. Cardinality is normally
+// tiny (edge routes × failure kinds), so this only trips under abuse.
+const MAX_TRACKED_KEYS = 10_000;
+
+// Composite-key separator, mirroring AuthFallbackLogThrottle's `${guard} ${path}`
+// key. Safe because guard values are fixed slugs, URL pathnames percent-encode
+// spaces, and failureKind values are underscore tokens — none contain a space.
+const SEP = " ";
+
+/** One aggregated count for a single (guard, path, failureKind). */
+export interface AuthFallbackCount {
+  guard: string;
+  path: string;
+  failureKind: string;
+  count: number;
+}
+
+/** A drained window of counts, ready to ship. */
+export interface AuthFallbackBatch {
+  windowStart: number;
+  windowEnd: number;
+  counts: AuthFallbackCount[];
+}
+
+export class AuthFallbackCountTracker {
+  private counts = new Map<string, AuthFallbackCount>();
+  private windowStartedAt: number;
+  private warnedAtCap = false;
+
+  constructor(now: number = Date.now()) {
+    this.windowStartedAt = now;
+  }
+
+  /** Record one fallback. O(1), no I/O — safe on the auth hot path. */
+  increment(guard: string, path: string, failureKind: string): void {
+    this.add(guard, path, failureKind, 1);
+  }
+
+  /**
+   * Drain and reset the accumulated counts. Returns the window covered and the
+   * per-key counts. When nothing was tracked the window start is left anchored
+   * (an empty drain doesn't shift the accumulation window).
+   */
+  drain(now: number = Date.now()): AuthFallbackBatch {
+    const counts = [...this.counts.values()];
+    const windowStart = this.windowStartedAt;
+    if (counts.length === 0) {
+      return { windowStart, windowEnd: now, counts };
+    }
+    this.counts = new Map();
+    this.windowStartedAt = now;
+    this.warnedAtCap = false;
+    return { windowStart, windowEnd: now, counts };
+  }
+
+  /**
+   * Fold a previously-drained batch back in — used by the reporter to avoid
+   * losing a window when the daemon POST fails. Subject to the same key cap.
+   */
+  merge(counts: AuthFallbackCount[]): void {
+    for (const c of counts) {
+      this.add(c.guard, c.path, c.failureKind, c.count);
+    }
+  }
+
+  /** Read-only view of the current counts (for tests/inspection). */
+  snapshot(): AuthFallbackCount[] {
+    return [...this.counts.values()].map((c) => ({ ...c }));
+  }
+
+  /** Clear all state (for test isolation). */
+  reset(now: number = Date.now()): void {
+    this.counts = new Map();
+    this.windowStartedAt = now;
+    this.warnedAtCap = false;
+  }
+
+  private add(
+    guard: string,
+    path: string,
+    failureKind: string,
+    delta: number,
+  ): void {
+    const key = `${guard}${SEP}${path}${SEP}${failureKind}`;
+    const existing = this.counts.get(key);
+    if (existing) {
+      existing.count += delta;
+      return;
+    }
+    if (this.counts.size >= MAX_TRACKED_KEYS) {
+      if (!this.warnedAtCap) {
+        this.warnedAtCap = true;
+        log.warn(
+          { maxKeys: MAX_TRACKED_KEYS },
+          "Auth-fallback tracker at key cap — new (guard, path, failureKind) keys dropped until next flush",
+        );
+      }
+      return;
+    }
+    this.counts.set(key, { guard, path, failureKind, count: delta });
+  }
+}

--- a/gateway/src/auth-fallback-reporter.ts
+++ b/gateway/src/auth-fallback-reporter.ts
@@ -1,0 +1,135 @@
+// Periodically drains AuthFallbackCountTracker and ships the accumulated counts
+// to the daemon's internal telemetry route, which persists them and forwards
+// them to the platform. Best-effort background work: failures are logged and the
+// drained counts are merged back so a transient daemon blip doesn't lose a
+// window. Deliberately does NOT touch the runtime circuit breaker — this is
+// non-critical traffic and must never affect chat routing.
+
+import { buildUpstreamUrl } from "@vellumai/assistant-client";
+
+import { mintServiceToken } from "./auth/token-exchange.js";
+import type {
+  AuthFallbackCount,
+  AuthFallbackCountTracker,
+} from "./auth-fallback-count-tracker.js";
+import { fetchImpl } from "./fetch.js";
+import { getLogger } from "./logger.js";
+
+const log = getLogger("auth-fallback-reporter");
+
+const ROUTE_PATH = "/v1/internal/telemetry/auth-fallback";
+const DEFAULT_FLUSH_INTERVAL_MS = 60_000;
+const POST_TIMEOUT_MS = 10_000;
+
+function getFlushIntervalMs(): number {
+  const raw = process.env.AUTH_FALLBACK_FLUSH_INTERVAL_MS;
+  if (raw) {
+    const parsed = parseInt(raw, 10);
+    if (!isNaN(parsed) && parsed > 0) return parsed;
+  }
+  return DEFAULT_FLUSH_INTERVAL_MS;
+}
+
+export type AuthFallbackReporterConfig = {
+  tracker: AuthFallbackCountTracker;
+  /** Daemon runtime base URL (`config.assistantRuntimeBaseUrl`). */
+  baseUrl: string;
+  /** Flush cadence; defaults to AUTH_FALLBACK_FLUSH_INTERVAL_MS or 60s. */
+  intervalMs?: number;
+  /** Injectable for tests. Defaults to the shared fetch wrapper. */
+  fetchImpl?: typeof fetchImpl;
+  /** Injectable for tests. Defaults to minting a real service token. */
+  mintToken?: () => string;
+};
+
+/** Shape the daemon route expects (`failure_kind` is snake_case on the wire). */
+type WireCount = {
+  guard: string;
+  path: string;
+  failure_kind: string;
+  count: number;
+};
+
+export class AuthFallbackReporter {
+  private readonly tracker: AuthFallbackCountTracker;
+  private readonly baseUrl: string;
+  private readonly intervalMs: number;
+  private readonly doFetch: typeof fetchImpl;
+  private readonly mintToken: () => string;
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(config: AuthFallbackReporterConfig) {
+    this.tracker = config.tracker;
+    this.baseUrl = config.baseUrl;
+    this.intervalMs = config.intervalMs ?? getFlushIntervalMs();
+    this.doFetch = config.fetchImpl ?? fetchImpl;
+    this.mintToken = config.mintToken ?? mintServiceToken;
+  }
+
+  start(): void {
+    if (this.timer) return;
+    this.timer = setInterval(() => {
+      void this.flush();
+    }, this.intervalMs);
+    log.info({ intervalMs: this.intervalMs }, "Auth-fallback reporter started");
+  }
+
+  /** Stop the timer and flush whatever is buffered one last time. */
+  async stop(): Promise<void> {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    await this.flush();
+  }
+
+  /**
+   * Drain the tracker and POST the counts to the daemon. On any failure the
+   * drained counts are merged back so they retry on the next flush.
+   */
+  async flush(): Promise<void> {
+    const batch = this.tracker.drain();
+    if (batch.counts.length === 0) return;
+
+    const body = {
+      window_start: batch.windowStart,
+      window_end: batch.windowEnd,
+      counts: batch.counts.map(
+        (c: AuthFallbackCount): WireCount => ({
+          guard: c.guard,
+          path: c.path,
+          failure_kind: c.failureKind,
+          count: c.count,
+        }),
+      ),
+    };
+
+    try {
+      const url = buildUpstreamUrl(this.baseUrl, ROUTE_PATH);
+      const resp = await this.doFetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${this.mintToken()}`,
+        },
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(POST_TIMEOUT_MS),
+      });
+      if (!resp.ok) {
+        log.warn(
+          { status: resp.status, keys: batch.counts.length },
+          "Auth-fallback flush rejected — re-queueing counts for next flush",
+        );
+        this.tracker.merge(batch.counts);
+        return;
+      }
+      await resp.text(); // release the connection
+    } catch (err) {
+      log.warn(
+        { err, keys: batch.counts.length },
+        "Auth-fallback flush failed — re-queueing counts for next flush",
+      );
+      this.tracker.merge(batch.counts);
+    }
+  }
+}

--- a/gateway/src/http/middleware/auth.ts
+++ b/gateway/src/http/middleware/auth.ts
@@ -6,6 +6,7 @@ import { resolveScopeProfile } from "../../auth/scopes.js";
 import { parseSub } from "../../auth/subject.js";
 import { validateEdgeToken } from "../../auth/token-exchange.js";
 import type { Scope, TokenClaims } from "../../auth/types.js";
+import { AuthFallbackCountTracker } from "../../auth-fallback-count-tracker.js";
 import { AuthFallbackLogThrottle } from "../../auth-fallback-log-throttle.js";
 import type { AuthRateLimiter } from "../../auth-rate-limiter.js";
 import { credentialKey } from "../../credential-key.js";
@@ -20,6 +21,12 @@ const log = getLogger("auth");
 // without per-request noise. Process-lifetime — createAuthMiddleware is invoked
 // per request, so this state can't live in its closure.
 const loopbackFallbackLogThrottle = new AuthFallbackLogThrottle();
+
+// Exact, unthrottled count of every loopback fallback, keyed by
+// (guard, path, failureKind). Drained and shipped to the daemon telemetry route
+// by AuthFallbackReporter. Process-lifetime singleton for the same reason as the
+// throttle above; exported so the reporter and tests share the one instance.
+export const loopbackFallbackCountTracker = new AuthFallbackCountTracker();
 
 type GetClientIp = () => string;
 
@@ -372,6 +379,11 @@ export function createAuthMiddleware(
       typeof extra?.authFailure === "string"
         ? extra.authFailure
         : "unspecified";
+
+    // Count every fallback (unthrottled) for telemetry. The throttle below only
+    // governs log volume — it must not gate the count, or the data undercounts.
+    loopbackFallbackCountTracker.increment(guard, path, failureKind);
+
     if (
       loopbackFallbackLogThrottle.shouldLog(`${guard} ${path} ${failureKind}`)
     ) {

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -17,6 +17,8 @@ import {
 } from "./auth/token-service.js";
 import { validateEdgeToken, mintServiceToken } from "./auth/token-exchange.js";
 import { findGuardianForChannelActor } from "./auth/guardian-bootstrap.js";
+import { AuthFallbackReporter } from "./auth-fallback-reporter.js";
+import { loopbackFallbackCountTracker } from "./http/middleware/auth.js";
 import { ConfigFileCache } from "./config-file-cache.js";
 import { ConfigFileWatcher } from "./config-file-watcher.js";
 import { FeatureFlagWatcher } from "./feature-flag-watcher.js";
@@ -2369,6 +2371,14 @@ async function main() {
   // the gateway continues with registry defaults if it fails.
   void remoteFeatureFlagSync.start();
 
+  // Periodically ship legacy-loopback auth-fallback counts to the daemon
+  // telemetry route. Best-effort background work; never blocks auth.
+  const authFallbackReporter = new AuthFallbackReporter({
+    tracker: loopbackFallbackCountTracker,
+    baseUrl: config.assistantRuntimeBaseUrl,
+  });
+  authFallbackReporter.start();
+
   // ── Sleep/wake detection ──
   // Detect system sleep/wake transitions and force-reconnect channels
   // that may have stale connections after the OS suspended the process.
@@ -2412,6 +2422,8 @@ async function main() {
     avatarSyncWatcher.stop();
     featureFlagWatcher.stop();
     remoteFeatureFlagSync.stop();
+    // Stop the timer and flush any buffered auth-fallback counts before exit.
+    shutdownTasks.push(authFallbackReporter.stop());
     const velayStop = velayTunnelClient?.stop();
     if (velayStop) shutdownTasks.push(velayStop);
     ipcServer.stop();


### PR DESCRIPTION
## Summary
- Adds the **gateway sender** for auth-fallback telemetry: an in-memory tracker counts every legacy-loopback fallback by `(guard, path, failureKind)`, and a background reporter flushes the counts (per ~60s window) to the daemon's `POST /v1/internal/telemetry/auth-fallback` route added in PR #33370.
- Hot-path-safe: the auth path only does an O(1) Map increment (no I/O) — the existing throttled `log.warn` is unchanged and the throttle governs log volume only, never the count. The reporter is best-effort (re-queues counts on failure, never touches the runtime circuit breaker) and flushes once more on SIGTERM. Interval overridable via `AUTH_FALLBACK_FLUSH_INTERVAL_MS`.
- Tests: tracker unit tests (increment/drain/merge/key-cap), reporter tests (drains + POSTs correct URL/body/service-token; re-queues on non-OK and on throw), and edge-auth/edge-guardian assertions that a loopback fallback is counted under the right guard/path/failureKind.

## Original prompt
PR #33011 made the gateway prefer bearer auth and keep a throttled, local-only log when requests fall back to the loopback exemption — no way to know how often or from which path. We're turning that into real telemetry. PR #33370 added the assistant-side receiver + platform forwarding; this is **PR 2 of 3**, the gateway sender that actually counts the fallbacks and ships them. It depends on #33370's route at runtime (until merged the POST 404s and counts are harmlessly re-queued). PR 3 (separate platform repo) adds `/v1/telemetry/ingest/` ingestion + a dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)