### PR TITLE
feat(web): connect Claude Code / Codex + Git credential settings

### DIFF
--- a/apps/web/scripts/transform-daemon-spec.ts
+++ b/apps/web/scripts/transform-daemon-spec.ts
@@ -46,7 +46,16 @@ const EXCLUDED_PREFIXES = [
 
 const EXCLUDED_SEGMENTS = ["/playground/"];
 
+/**
+ * Web-facing exceptions that fall under an excluded prefix but ARE proxied
+ * through the platform gateway and consumed by the web app. Most `/v1/acp/`
+ * routes are CLI-only session endpoints, but credential-linking is a settings
+ * UI flow and must be present in the generated SDK.
+ */
+const INCLUDED_PATHS = ["/v1/acp/credentials/link"];
+
 function shouldExclude(path: string): boolean {
+  if (INCLUDED_PATHS.includes(path)) return false;
   if (EXCLUDED_PREFIXES.some((prefix) => path.startsWith(prefix))) return true;
   if (EXCLUDED_SEGMENTS.some((seg) => path.includes(seg))) return true;
   return false;

--- a/apps/web/src/domains/settings/ai/acp-credentials-card.test.tsx
+++ b/apps/web/src/domains/settings/ai/acp-credentials-card.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * Tests for `AcpCredentialsCard` — the "Connect Claude Code / Codex + Git"
+ * settings flow.
+ *
+ * Strategy mirrors `general-page.test.tsx`: render the card directly, mock the
+ * generated daemon SDK's `acpCredentialsLinkPost`, and drive the link/unlink
+ * UI with testing-library. Asserts that:
+ *   - the in-pod privacy copy renders,
+ *   - linking the Git token POSTs `{ field: "git_token", value }` and flips the
+ *     row to the linked state (optimistic, since the route is write-only),
+ *   - "Unlink" returns the row to the input state.
+ */
+import {
+  afterEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  waitFor,
+} from "@testing-library/react";
+
+interface LinkArgs {
+  path: { assistant_id: string };
+  body: { field: string; value: string };
+}
+
+const linkMock = mock(async (_args: LinkArgs) => ({
+  data: { field: _args.body.field, linked: true },
+}));
+
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  acpCredentialsLinkPost: linkMock,
+}));
+
+mock.module("@/lib/sentry/capture-error", () => ({
+  captureError: () => {},
+}));
+
+const { AcpCredentialsCard } = await import(
+  "@/domains/settings/ai/acp-credentials-card"
+);
+
+const ASSISTANT_ID = "asst-1";
+
+afterEach(() => {
+  cleanup();
+  linkMock.mockClear();
+});
+
+describe("AcpCredentialsCard", () => {
+  test("states the in-pod privacy model", () => {
+    const { getByText } = render(
+      <AcpCredentialsCard assistantId={ASSISTANT_ID} />,
+    );
+    expect(
+      getByText(/stored only in your private environment/i),
+    ).toBeDefined();
+    expect(getByText(/never sent to our servers/i)).toBeDefined();
+  });
+
+  test("links the git token and shows linked + unlink, then unlinks", async () => {
+    const { getByLabelText, getByText, queryByLabelText } = render(
+      <AcpCredentialsCard assistantId={ASSISTANT_ID} />,
+    );
+
+    const gitInput = getByLabelText("Git token") as HTMLInputElement;
+    fireEvent.change(gitInput, { target: { value: "ghp_secret" } });
+
+    // The Git row's Link button is the third "Link" button (Claude, OpenAI, Git).
+    const linkButtons = document.querySelectorAll("button");
+    const gitLinkButton = Array.from(linkButtons).find(
+      (b) =>
+        b.textContent === "Link" &&
+        b.closest("div")?.querySelector('[aria-label="Git token"]') != null,
+    );
+    expect(gitLinkButton).toBeDefined();
+    fireEvent.click(gitLinkButton!);
+
+    await waitFor(() => {
+      expect(linkMock).toHaveBeenCalledTimes(1);
+    });
+    expect(linkMock.mock.calls[0]![0]).toMatchObject({
+      path: { assistant_id: ASSISTANT_ID },
+      body: { field: "git_token", value: "ghp_secret" },
+    });
+
+    // Optimistic linked state: status + unlink affordance render.
+    await waitFor(() => {
+      expect(getByText(/Git token linked/i)).toBeDefined();
+    });
+    expect(queryByLabelText("Git token")).toBeNull();
+
+    // Unlink returns the row to the input state.
+    fireEvent.click(getByText("Unlink"));
+    await waitFor(() => {
+      expect(queryByLabelText("Git token")).not.toBeNull();
+    });
+  });
+
+  test("does not call the daemon when no assistant is present", () => {
+    const { getByText, queryByLabelText } = render(
+      <AcpCredentialsCard assistantId={undefined} />,
+    );
+    expect(getByText(/No assistant found yet/i)).toBeDefined();
+    expect(queryByLabelText("Git token")).toBeNull();
+    expect(linkMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/domains/settings/ai/acp-credentials-card.test.tsx
+++ b/apps/web/src/domains/settings/ai/acp-credentials-card.test.tsx
@@ -3,12 +3,14 @@
  * settings flow.
  *
  * Strategy mirrors `general-page.test.tsx`: render the card directly, mock the
- * generated daemon SDK's `acpCredentialsLinkPost`, and drive the link/unlink
+ * generated daemon SDK's `acpCredentialsLinkPost`, and drive the link/replace
  * UI with testing-library. Asserts that:
  *   - the in-pod privacy copy renders,
  *   - linking the Git token POSTs `{ field: "git_token", value }` and flips the
- *     row to the linked state (optimistic, since the route is write-only),
- *   - "Unlink" returns the row to the input state.
+ *     row to a truthful linked state (optimistic, since the route is write-only),
+ *   - "Replace" re-opens the input and posting a new value overwrites the stored
+ *     secret (rotation) — there is no local-only "unlink" that falsely implies
+ *     server-side removal.
  */
 import {
   afterEach,
@@ -63,21 +65,22 @@ describe("AcpCredentialsCard", () => {
     expect(getByText(/never sent to our servers/i)).toBeDefined();
   });
 
-  test("links the git token and shows linked + unlink, then unlinks", async () => {
-    const { getByLabelText, getByText, queryByLabelText } = render(
+  test("links the git token, then Replace overwrites the stored secret", async () => {
+    const { getByLabelText, getByText, queryByText, queryByLabelText } = render(
       <AcpCredentialsCard assistantId={ASSISTANT_ID} />,
     );
 
     const gitInput = getByLabelText("Git token") as HTMLInputElement;
     fireEvent.change(gitInput, { target: { value: "ghp_secret" } });
 
-    // The Git row's Link button is the third "Link" button (Claude, OpenAI, Git).
-    const linkButtons = document.querySelectorAll("button");
-    const gitLinkButton = Array.from(linkButtons).find(
-      (b) =>
-        b.textContent === "Link" &&
-        b.closest("div")?.querySelector('[aria-label="Git token"]') != null,
-    );
+    const findGitLinkButton = (text: string) =>
+      Array.from(document.querySelectorAll("button")).find(
+        (b) =>
+          b.textContent === text &&
+          b.closest("div")?.querySelector('[aria-label="Git token"]') != null,
+      );
+
+    const gitLinkButton = findGitLinkButton("Link");
     expect(gitLinkButton).toBeDefined();
     fireEvent.click(gitLinkButton!);
 
@@ -89,17 +92,41 @@ describe("AcpCredentialsCard", () => {
       body: { field: "git_token", value: "ghp_secret" },
     });
 
-    // Optimistic linked state: status + unlink affordance render.
+    // Optimistic, truthful linked state: status + Replace affordance render;
+    // there is NO "Unlink" affordance implying server-side removal.
     await waitFor(() => {
       expect(getByText(/Git token linked/i)).toBeDefined();
     });
     expect(queryByLabelText("Git token")).toBeNull();
+    expect(queryByText("Unlink")).toBeNull();
 
-    // Unlink returns the row to the input state.
-    fireEvent.click(getByText("Unlink"));
+    // Replace re-opens the input so the user can rotate the stored secret.
+    fireEvent.click(getByText("Replace"));
+    let replacedInput: HTMLInputElement | null = null;
     await waitFor(() => {
-      expect(queryByLabelText("Git token")).not.toBeNull();
+      replacedInput = queryByLabelText("Git token") as HTMLInputElement | null;
+      expect(replacedInput).not.toBeNull();
     });
+
+    // Entering a new value and submitting POSTs the overwrite (rotation).
+    fireEvent.change(replacedInput!, { target: { value: "ghp_rotated" } });
+    const replaceButton = findGitLinkButton("Replace");
+    expect(replaceButton).toBeDefined();
+    fireEvent.click(replaceButton!);
+
+    await waitFor(() => {
+      expect(linkMock).toHaveBeenCalledTimes(2);
+    });
+    expect(linkMock.mock.calls[1]![0]).toMatchObject({
+      path: { assistant_id: ASSISTANT_ID },
+      body: { field: "git_token", value: "ghp_rotated" },
+    });
+
+    // Back to the truthful linked state after the overwrite lands.
+    await waitFor(() => {
+      expect(getByText(/Git token linked/i)).toBeDefined();
+    });
+    expect(queryByLabelText("Git token")).toBeNull();
   });
 
   test("does not call the daemon when no assistant is present", () => {

--- a/apps/web/src/domains/settings/ai/acp-credentials-card.tsx
+++ b/apps/web/src/domains/settings/ai/acp-credentials-card.tsx
@@ -1,0 +1,324 @@
+import type { ReactNode } from "react";
+import { CircleCheck, Loader2, ShieldCheck } from "lucide-react";
+import { useCallback, useState } from "react";
+
+import { Button } from "@vellum/design-library/components/button";
+import { Dropdown } from "@vellum/design-library/components/dropdown";
+import { Input } from "@vellum/design-library/components/input";
+import { Notice } from "@vellum/design-library/components/notice";
+import { Typography } from "@vellum/design-library/components/typography";
+
+import { acpCredentialsLinkPost } from "@/generated/daemon/sdk.gen";
+import type { AcpCredentialsLinkPostData } from "@/generated/daemon/types.gen";
+import { DetailCard } from "@/components/detail-card";
+import { extractErrorMessage } from "@/utils/api-errors";
+import { captureError } from "@/lib/sentry/capture-error";
+
+// ---------------------------------------------------------------------------
+// AcpCredentialsCard — "Connect Claude Code / Codex + Git"
+// ---------------------------------------------------------------------------
+//
+// Links the four per-user ACP/dev credentials into the user's private in-pod
+// environment via the write-only `acp/credentials/link` daemon route
+// (operationId acp_link_credential). Each secret is stored ONLY in the pod's
+// secure store under acp/<field>; it is never returned in the response and
+// never sent to Vellum's central servers.
+//
+// Linked-state caveat: the link route is write-only — there is no read/list
+// endpoint to recover which credentials are present after a reload. We derive
+// linked state optimistically: a successful link call marks that field linked
+// in component-local state for the session; "Unlink" clears it locally so the
+// user can re-enter a value. (Unlinking here is a UI affordance to re-link; a
+// dedicated server-side delete route is out of scope for D2.)
+
+type AcpField = AcpCredentialsLinkPostData["body"]["field"];
+
+type ClaudeMode = "claude_oauth_token" | "anthropic_api_key";
+
+interface AcpCredentialsCardProps {
+  assistantId: string | undefined;
+}
+
+const CLAUDE_MODE_OPTIONS: { value: ClaudeMode; label: string }[] = [
+  { value: "claude_oauth_token", label: "Claude OAuth token" },
+  { value: "anthropic_api_key", label: "Anthropic API key" },
+];
+
+const FIELD_LABEL: Record<AcpField, string> = {
+  claude_oauth_token: "Claude OAuth token",
+  anthropic_api_key: "Anthropic API key",
+  openai_api_key: "OpenAI API key",
+  git_token: "Git token",
+};
+
+export function AcpCredentialsCard({ assistantId }: AcpCredentialsCardProps) {
+  // Which Claude credential the user wants to link.
+  const [claudeMode, setClaudeMode] = useState<ClaudeMode>("claude_oauth_token");
+
+  // Draft values, never persisted anywhere other than the in-pod store.
+  const [claudeValue, setClaudeValue] = useState("");
+  const [openaiValue, setOpenaiValue] = useState("");
+  const [gitValue, setGitValue] = useState("");
+
+  // Optimistic linked state (see caveat above). Tracks the specific field that
+  // was linked so the Claude row reflects OAuth-vs-API-key choice.
+  const [linked, setLinked] = useState<Partial<Record<AcpField, boolean>>>({});
+
+  // Per-field in-flight + error state.
+  const [pending, setPending] = useState<Partial<Record<AcpField, boolean>>>({});
+  const [errors, setErrors] = useState<Partial<Record<AcpField, string>>>({});
+
+  const linkField = useCallback(
+    async (field: AcpField, value: string) => {
+      if (!assistantId) return;
+      const trimmed = value.trim();
+      if (!trimmed) {
+        setErrors((e) => ({ ...e, [field]: "Enter a value to link." }));
+        return;
+      }
+      setErrors((e) => ({ ...e, [field]: undefined }));
+      setPending((p) => ({ ...p, [field]: true }));
+      try {
+        await acpCredentialsLinkPost({
+          path: { assistant_id: assistantId },
+          body: { field, value: trimmed },
+          throwOnError: true,
+        });
+        setLinked((l) => ({ ...l, [field]: true }));
+        // For Claude, only one of the two fields can be the active credential;
+        // clear the other so the UI shows a single linked Claude credential.
+        if (field === "claude_oauth_token" || field === "anthropic_api_key") {
+          const other: AcpField =
+            field === "claude_oauth_token"
+              ? "anthropic_api_key"
+              : "claude_oauth_token";
+          setLinked((l) => ({ ...l, [other]: false }));
+        }
+      } catch (err) {
+        captureError(err, { context: "acp_link_credential", bestEffort: true });
+        setErrors((e) => ({
+          ...e,
+          [field]: extractErrorMessage(
+            err,
+            undefined,
+            "Failed to link credential. Please try again.",
+          ),
+        }));
+      } finally {
+        setPending((p) => ({ ...p, [field]: false }));
+      }
+    },
+    [assistantId],
+  );
+
+  const unlinkField = useCallback((field: AcpField, clear: () => void) => {
+    // Write-only route: no server delete in D2, so unlink is a local reset that
+    // lets the user enter and re-link a fresh value.
+    setLinked((l) => ({ ...l, [field]: false }));
+    setErrors((e) => ({ ...e, [field]: undefined }));
+    clear();
+  }, []);
+
+  return (
+    <DetailCard
+      id="coding-credentials"
+      title="Connect Claude Code / Codex + Git"
+      subtitle="Bring your own credentials so the coding agent can run in your private environment."
+    >
+      <div className="h-px bg-[var(--surface-active)]" />
+
+      <div className="mt-4 space-y-5">
+        <Notice tone="info" icon={<ShieldCheck className="h-4 w-4" aria-hidden />}>
+          These secrets are stored only in your private environment and are
+          never sent to our servers. They&apos;re write-only: once linked, the
+          value can&apos;t be read back.
+        </Notice>
+
+        {!assistantId ? (
+          <Typography
+            variant="body-small-default"
+            as="p"
+            className="text-[var(--content-tertiary)]"
+          >
+            No assistant found yet.
+          </Typography>
+        ) : (
+          <>
+            {/* Claude credential (OAuth token OR Anthropic API key) */}
+            <CredentialRow
+              title="Claude Code"
+              description="Link a Claude OAuth token or an Anthropic API key for the Claude coding agent."
+              field={claudeMode}
+              linked={
+                linked.claude_oauth_token === true ||
+                linked.anthropic_api_key === true
+              }
+              linkedLabel={
+                linked.claude_oauth_token
+                  ? FIELD_LABEL.claude_oauth_token
+                  : linked.anthropic_api_key
+                    ? FIELD_LABEL.anthropic_api_key
+                    : undefined
+              }
+              value={claudeValue}
+              onValueChange={setClaudeValue}
+              pending={
+                pending.claude_oauth_token === true ||
+                pending.anthropic_api_key === true
+              }
+              error={errors[claudeMode]}
+              onLink={() => void linkField(claudeMode, claudeValue)}
+              onUnlink={() => {
+                const linkedField: AcpField = linked.anthropic_api_key
+                  ? "anthropic_api_key"
+                  : "claude_oauth_token";
+                unlinkField(linkedField, () => setClaudeValue(""));
+              }}
+              extraControl={
+                <Dropdown<ClaudeMode>
+                  value={claudeMode}
+                  onChange={(val) => {
+                    setClaudeMode(val);
+                    setClaudeValue("");
+                    setErrors((e) => ({
+                      ...e,
+                      claude_oauth_token: undefined,
+                      anthropic_api_key: undefined,
+                    }));
+                  }}
+                  options={CLAUDE_MODE_OPTIONS}
+                />
+              }
+            />
+
+            {/* OpenAI API key (Codex) */}
+            <CredentialRow
+              title="Codex (OpenAI)"
+              description="Link an OpenAI API key for the Codex coding agent."
+              field="openai_api_key"
+              linked={linked.openai_api_key === true}
+              value={openaiValue}
+              onValueChange={setOpenaiValue}
+              pending={pending.openai_api_key === true}
+              error={errors.openai_api_key}
+              onLink={() => void linkField("openai_api_key", openaiValue)}
+              onUnlink={() =>
+                unlinkField("openai_api_key", () => setOpenaiValue(""))
+              }
+            />
+
+            {/* Git token */}
+            <CredentialRow
+              title="Git"
+              description="Link a Git token (e.g. a GitHub personal access token) so the agent can clone and push."
+              field="git_token"
+              linked={linked.git_token === true}
+              value={gitValue}
+              onValueChange={setGitValue}
+              pending={pending.git_token === true}
+              error={errors.git_token}
+              onLink={() => void linkField("git_token", gitValue)}
+              onUnlink={() => unlinkField("git_token", () => setGitValue(""))}
+            />
+          </>
+        )}
+      </div>
+    </DetailCard>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// CredentialRow — single labelled secret input with link/unlink + status
+// ---------------------------------------------------------------------------
+
+interface CredentialRowProps {
+  title: string;
+  description: string;
+  field: AcpField;
+  linked: boolean;
+  /** Optional label of the specific linked credential (Claude OAuth vs key). */
+  linkedLabel?: string;
+  value: string;
+  onValueChange: (value: string) => void;
+  pending: boolean;
+  error?: string;
+  onLink: () => void;
+  onUnlink: () => void;
+  extraControl?: ReactNode;
+}
+
+function CredentialRow({
+  title,
+  description,
+  field,
+  linked,
+  linkedLabel,
+  value,
+  onValueChange,
+  pending,
+  error,
+  onLink,
+  onUnlink,
+  extraControl,
+}: CredentialRowProps) {
+  return (
+    <div className="space-y-2 rounded-lg border border-[var(--border-base)] p-4">
+      <div className="space-y-1">
+        <Typography
+          variant="body-medium-default"
+          as="p"
+          className="text-[var(--content-emphasised)]"
+        >
+          {title}
+        </Typography>
+        <Typography
+          variant="body-small-default"
+          as="p"
+          className="text-[var(--content-tertiary)]"
+        >
+          {description}
+        </Typography>
+      </div>
+
+      {linked ? (
+        <div className="flex items-center justify-between gap-2">
+          <span className="flex items-center gap-2 text-body-small-default text-[var(--system-positive-strong)]">
+            <CircleCheck className="h-4 w-4 shrink-0" />
+            {linkedLabel ?? FIELD_LABEL[field]} linked
+          </span>
+          <Button variant="dangerGhost" size="compact" onClick={onUnlink}>
+            Unlink
+          </Button>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {extraControl ? <div className="max-w-[280px]">{extraControl}</div> : null}
+          <div className="flex items-start gap-2">
+            <Input
+              type="password"
+              autoComplete="off"
+              value={value}
+              onChange={(e) => onValueChange(e.target.value)}
+              placeholder={`Paste ${FIELD_LABEL[field]}…`}
+              aria-label={FIELD_LABEL[field]}
+              errorText={error}
+              fullWidth
+              wrapperClassName="flex-1"
+            />
+            <Button
+              size="compact"
+              disabled={pending || !value.trim()}
+              onClick={onLink}
+            >
+              {pending ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                "Link"
+              )}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/domains/settings/ai/acp-credentials-card.tsx
+++ b/apps/web/src/domains/settings/ai/acp-credentials-card.tsx
@@ -27,9 +27,15 @@ import { captureError } from "@/lib/sentry/capture-error";
 // Linked-state caveat: the link route is write-only — there is no read/list
 // endpoint to recover which credentials are present after a reload. We derive
 // linked state optimistically: a successful link call marks that field linked
-// in component-local state for the session; "Unlink" clears it locally so the
-// user can re-enter a value. (Unlinking here is a UI affordance to re-link; a
-// dedicated server-side delete route is out of scope for D2.)
+// in component-local state for the session.
+//
+// There is intentionally NO "unlink"/delete affordance: the daemon route is
+// write-only by design and exposes no delete/revoke endpoint, so the secret
+// cannot actually be removed from the pod here. The only real mutation is to
+// overwrite the stored value. We therefore offer a "Replace" affordance that
+// lets the user link a NEW value (overwriting the stored secret), which is a
+// genuine way to rotate a leaked or obsolete token. True server-side removal
+// is a documented follow-up (a dedicated revoke route).
 
 type AcpField = AcpCredentialsLinkPostData["body"]["field"];
 
@@ -68,6 +74,12 @@ export function AcpCredentialsCard({ assistantId }: AcpCredentialsCardProps) {
   const [pending, setPending] = useState<Partial<Record<AcpField, boolean>>>({});
   const [errors, setErrors] = useState<Partial<Record<AcpField, string>>>({});
 
+  // Per-field "replacing" state: the credential is linked but the user has
+  // chosen to enter a new value to overwrite (rotate) the stored secret.
+  const [replacing, setReplacing] = useState<
+    Partial<Record<AcpField, boolean>>
+  >({});
+
   const linkField = useCallback(
     async (field: AcpField, value: string) => {
       if (!assistantId) return;
@@ -85,6 +97,8 @@ export function AcpCredentialsCard({ assistantId }: AcpCredentialsCardProps) {
           throwOnError: true,
         });
         setLinked((l) => ({ ...l, [field]: true }));
+        // Close any in-progress "replace" input now that the overwrite landed.
+        setReplacing((r) => ({ ...r, [field]: false }));
         // For Claude, only one of the two fields can be the active credential;
         // clear the other so the UI shows a single linked Claude credential.
         if (field === "claude_oauth_token" || field === "anthropic_api_key") {
@@ -111,10 +125,18 @@ export function AcpCredentialsCard({ assistantId }: AcpCredentialsCardProps) {
     [assistantId],
   );
 
-  const unlinkField = useCallback((field: AcpField, clear: () => void) => {
-    // Write-only route: no server delete in D2, so unlink is a local reset that
-    // lets the user enter and re-link a fresh value.
-    setLinked((l) => ({ ...l, [field]: false }));
+  // Open the "Replace" input for a linked field so the user can enter a new
+  // value to overwrite the stored secret. This does NOT remove the existing
+  // credential — the field stays linked until a new value is successfully
+  // posted (or the user cancels). The route is write-only with no delete.
+  const startReplace = useCallback((field: AcpField, clear: () => void) => {
+    setReplacing((r) => ({ ...r, [field]: true }));
+    setErrors((e) => ({ ...e, [field]: undefined }));
+    clear();
+  }, []);
+
+  const cancelReplace = useCallback((field: AcpField, clear: () => void) => {
+    setReplacing((r) => ({ ...r, [field]: false }));
     setErrors((e) => ({ ...e, [field]: undefined }));
     clear();
   }, []);
@@ -131,7 +153,9 @@ export function AcpCredentialsCard({ assistantId }: AcpCredentialsCardProps) {
         <Notice tone="info" icon={<ShieldCheck className="h-4 w-4" aria-hidden />}>
           These secrets are stored only in your private environment and are
           never sent to our servers. They&apos;re write-only: once linked, the
-          value can&apos;t be read back.
+          value can&apos;t be read back. To rotate a token, use Replace to
+          overwrite the stored value — removing a credential entirely
+          isn&apos;t available here yet.
         </Notice>
 
         {!assistantId ? (
@@ -167,12 +191,22 @@ export function AcpCredentialsCard({ assistantId }: AcpCredentialsCardProps) {
                 pending.anthropic_api_key === true
               }
               error={errors[claudeMode]}
+              replacing={
+                replacing.claude_oauth_token === true ||
+                replacing.anthropic_api_key === true
+              }
               onLink={() => void linkField(claudeMode, claudeValue)}
-              onUnlink={() => {
+              onReplace={() => {
                 const linkedField: AcpField = linked.anthropic_api_key
                   ? "anthropic_api_key"
                   : "claude_oauth_token";
-                unlinkField(linkedField, () => setClaudeValue(""));
+                startReplace(linkedField, () => setClaudeValue(""));
+              }}
+              onCancelReplace={() => {
+                const linkedField: AcpField = linked.anthropic_api_key
+                  ? "anthropic_api_key"
+                  : "claude_oauth_token";
+                cancelReplace(linkedField, () => setClaudeValue(""));
               }}
               extraControl={
                 <Dropdown<ClaudeMode>
@@ -201,9 +235,13 @@ export function AcpCredentialsCard({ assistantId }: AcpCredentialsCardProps) {
               onValueChange={setOpenaiValue}
               pending={pending.openai_api_key === true}
               error={errors.openai_api_key}
+              replacing={replacing.openai_api_key === true}
               onLink={() => void linkField("openai_api_key", openaiValue)}
-              onUnlink={() =>
-                unlinkField("openai_api_key", () => setOpenaiValue(""))
+              onReplace={() =>
+                startReplace("openai_api_key", () => setOpenaiValue(""))
+              }
+              onCancelReplace={() =>
+                cancelReplace("openai_api_key", () => setOpenaiValue(""))
               }
             />
 
@@ -217,8 +255,12 @@ export function AcpCredentialsCard({ assistantId }: AcpCredentialsCardProps) {
               onValueChange={setGitValue}
               pending={pending.git_token === true}
               error={errors.git_token}
+              replacing={replacing.git_token === true}
               onLink={() => void linkField("git_token", gitValue)}
-              onUnlink={() => unlinkField("git_token", () => setGitValue(""))}
+              onReplace={() => startReplace("git_token", () => setGitValue(""))}
+              onCancelReplace={() =>
+                cancelReplace("git_token", () => setGitValue(""))
+              }
             />
           </>
         )}
@@ -228,7 +270,7 @@ export function AcpCredentialsCard({ assistantId }: AcpCredentialsCardProps) {
 }
 
 // ---------------------------------------------------------------------------
-// CredentialRow — single labelled secret input with link/unlink + status
+// CredentialRow — single labelled secret input with link/replace + status
 // ---------------------------------------------------------------------------
 
 interface CredentialRowProps {
@@ -242,8 +284,13 @@ interface CredentialRowProps {
   onValueChange: (value: string) => void;
   pending: boolean;
   error?: string;
+  /** Linked field whose value the user is currently overwriting. */
+  replacing: boolean;
   onLink: () => void;
-  onUnlink: () => void;
+  /** Open the input to overwrite (rotate) the stored secret. */
+  onReplace: () => void;
+  /** Abandon an in-progress replace and return to the linked state. */
+  onCancelReplace: () => void;
   extraControl?: ReactNode;
 }
 
@@ -257,8 +304,10 @@ function CredentialRow({
   onValueChange,
   pending,
   error,
+  replacing,
   onLink,
-  onUnlink,
+  onReplace,
+  onCancelReplace,
   extraControl,
 }: CredentialRowProps) {
   return (
@@ -280,19 +329,30 @@ function CredentialRow({
         </Typography>
       </div>
 
-      {linked ? (
+      {linked && !replacing ? (
         <div className="flex items-center justify-between gap-2">
           <span className="flex items-center gap-2 text-body-small-default text-[var(--system-positive-strong)]">
             <CircleCheck className="h-4 w-4 shrink-0" />
-            {linkedLabel ?? FIELD_LABEL[field]} linked
+            {linkedLabel ?? FIELD_LABEL[field]} linked — stored in your private
+            environment
           </span>
-          <Button variant="dangerGhost" size="compact" onClick={onUnlink}>
-            Unlink
+          <Button variant="outlined" size="compact" onClick={onReplace}>
+            Replace
           </Button>
         </div>
       ) : (
         <div className="space-y-2">
           {extraControl ? <div className="max-w-[280px]">{extraControl}</div> : null}
+          {replacing ? (
+            <Typography
+              variant="body-small-default"
+              as="p"
+              className="text-[var(--content-tertiary)]"
+            >
+              Enter a new value to overwrite the stored credential. This
+              rotates the secret; the previous value is replaced.
+            </Typography>
+          ) : null}
           <div className="flex items-start gap-2">
             <Input
               type="password"
@@ -312,10 +372,22 @@ function CredentialRow({
             >
               {pending ? (
                 <Loader2 className="h-4 w-4 animate-spin" />
+              ) : replacing ? (
+                "Replace"
               ) : (
                 "Link"
               )}
             </Button>
+            {replacing ? (
+              <Button
+                variant="outlined"
+                size="compact"
+                disabled={pending}
+                onClick={onCancelReplace}
+              >
+                Cancel
+              </Button>
+            ) : null}
           </div>
         </div>
       )}

--- a/apps/web/src/domains/settings/ai/ai-page.tsx
+++ b/apps/web/src/domains/settings/ai/ai-page.tsx
@@ -13,6 +13,7 @@ import { EmailServiceCard } from "@/domains/settings/ai/email-service-card";
 import { ImageGenerationCard } from "@/domains/settings/ai/image-generation-card";
 import { TextToSpeechCard } from "@/domains/settings/ai/text-to-speech-card";
 import { SpeechToTextCard } from "@/domains/settings/ai/speech-to-text-card";
+import { AcpCredentialsCard } from "@/domains/settings/ai/acp-credentials-card";
 
 // ---------------------------------------------------------------------------
 // AiPage — layout shell
@@ -57,6 +58,7 @@ export function AiPage() {
       <ImageGenerationCard />
       <TextToSpeechCard />
       <SpeechToTextCard />
+      <AcpCredentialsCard assistantId={assistantId} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add a settings flow to link Claude OAuth/Anthropic key, OpenAI key, and Git token via the in-pod acp/credentials/link route; copy states the in-pod privacy model; shows linked/unlinked + unlink.

Part of plan: acp-platform-hosted.md (PR D2, Wave 2)