### PR TITLE
feat(acp): acp_continue — follow-up prompts to an existing live session

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -132,6 +132,51 @@ paths:
               required:
                 - instruction
               additionalProperties: false
+  /v1/acp/continue:
+    post:
+      operationId: acp_continue_post
+      summary: Continue ACP session
+      description:
+        Send a follow-up turn to an existing live (running/idle) ACP session so the agent builds on the same
+        context and workspace. Resolve the target by explicit acpSessionId, or by the conversation's most-recent live
+        session via conversationId. Errors cleanly (404) for a closed or non-existent session.
+      tags:
+        - acp
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  acpSessionId:
+                    type: string
+                  continued:
+                    type: boolean
+                required:
+                  - acpSessionId
+                  - continued
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                instruction:
+                  type: string
+                  description: The follow-up task for this turn
+                acpSessionId:
+                  type: string
+                  description: Explicit live session to continue
+                conversationId:
+                  type: string
+                  description: Resolve the most-recent live session for this conversation when acpSessionId is omitted
+              required:
+                - instruction
+              additionalProperties: false
   /v1/acp/credentials/link:
     post:
       operationId: acp_credentials_link_post

--- a/assistant/src/config/bundled-skills/acp/SKILL.md
+++ b/assistant/src/config/bundled-skills/acp/SKILL.md
@@ -81,10 +81,15 @@ npm i -g @zed-industries/codex-acp@latest
 
 Then retry the `acp_spawn` call.
 
-## When to use acp_steer vs acp_spawn
+## When to use acp_continue vs acp_spawn vs acp_steer
 
-- **`acp_steer` interrupts the in-flight prompt.** Use it to course-correct a running agent ("stop, do X instead"). It cancels whatever the agent is currently working on and replaces it with the new instruction.
-- **For follow-ups after the current task** ("also do Y when you're done"), do NOT use `acp_steer`. Wait for the `acp_session_completed` notification and call `acp_spawn` again with the new task. Queued follow-ups in the same session are not yet supported.
+Three distinct verbs — pick by intent:
+
+- **`acp_continue` builds on the SAME session.** This is the default for iterating on the same piece of work. After a session reports `acp_session_completed`, call `acp_continue` with the follow-up ("now also do Y", "fix the test you just broke", "address the review comments"). The agent reuses its existing process, ACP session, context, and workspace, so it remembers what it just did. By default it targets the conversation's most-recent live session; pass an explicit `acp_session_id` to continue a specific one.
+- **`acp_spawn` starts a FRESH session.** Use it only when you want a brand-new agent with no prior context — a different, unrelated task, or parallel work in a separate workspace/worktree.
+- **`acp_steer` interrupts the in-flight prompt.** Use it to course-correct a *running* agent mid-task ("stop, do X instead"). It cancels whatever the agent is currently working on and replaces it with the new instruction.
+
+Rule of thumb: same thread of work → `acp_continue`; new unrelated work → `acp_spawn`; redirect something already running → `acp_steer`. Do NOT wait-for-completion-then-respawn to continue work — that loses the agent's context; use `acp_continue` instead.
 
 ## Discoverability
 

--- a/assistant/src/config/bundled-skills/acp/TOOLS.json
+++ b/assistant/src/config/bundled-skills/acp/TOOLS.json
@@ -65,7 +65,7 @@
     },
     {
       "name": "acp_steer",
-      "description": "**Interrupts** the in-flight prompt of a running ACP session and replaces it with `instruction`. Use to redirect the agent (e.g., 'stop, do X instead'). For follow-up work that should happen *after* the current task, do NOT use this — wait for `acp_session_completed` and `acp_spawn` again.",
+      "description": "**Interrupts** the in-flight prompt of a running ACP session and replaces it with `instruction`. Use to redirect the agent (e.g., 'stop, do X instead'). For follow-up work that should happen *after* the current task, do NOT use this — wait for `acp_session_completed` and use `acp_continue` to add a new turn on the SAME session.",
       "category": "orchestration",
       "risk": "high",
       "input_schema": {
@@ -83,6 +83,28 @@
         "required": ["acp_session_id", "instruction"]
       },
       "executor": "tools/acp-steer.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "acp_continue",
+      "description": "Send a follow-up turn to an EXISTING live ACP session so the agent builds on the SAME context and workspace it already established. Use this after a session reports `acp_session_completed` to keep iterating ('now also do Y', 'fix the test you just broke') without losing state. Resolves the target session automatically from the current conversation's most-recent live session, or pass an explicit `acp_session_id`. Use `acp_spawn` ONLY when you want a FRESH session/process; use `acp_steer` ONLY to interrupt an in-flight prompt. Targeting a closed or non-existent session fails cleanly.",
+      "category": "orchestration",
+      "risk": "high",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "instruction": {
+            "type": "string",
+            "description": "The follow-up task for this new turn on the existing session."
+          },
+          "acp_session_id": {
+            "type": "string",
+            "description": "Optional ID of the live session to continue. When omitted, the most-recent live session for the current conversation is used."
+          }
+        },
+        "required": ["instruction"]
+      },
+      "executor": "tools/acp-continue.ts",
       "execution_target": "host"
     },
     {

--- a/assistant/src/config/bundled-skills/acp/tools/acp-continue.ts
+++ b/assistant/src/config/bundled-skills/acp/tools/acp-continue.ts
@@ -1,0 +1,12 @@
+import { executeAcpContinue } from "../../../../tools/acp/continue.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeAcpContinue(input, context);
+}

--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -15,6 +15,7 @@
 import type { SkillToolScript } from "../tools/skills/script-contract.js";
 // ── acp ────────────────────────────────────────────────────────────────────────
 import * as acpAbort from "./bundled-skills/acp/tools/acp-abort.js";
+import * as acpContinue from "./bundled-skills/acp/tools/acp-continue.js";
 import * as acpListAgents from "./bundled-skills/acp/tools/acp-list-agents.js";
 import * as acpSpawn from "./bundled-skills/acp/tools/acp-spawn.js";
 import * as acpStatus from "./bundled-skills/acp/tools/acp-status.js";
@@ -135,6 +136,7 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
   ["acp:tools/acp-status.ts", acpStatus],
   ["acp:tools/acp-abort.ts", acpAbort],
   ["acp:tools/acp-steer.ts", acpSteer],
+  ["acp:tools/acp-continue.ts", acpContinue],
   ["acp:tools/acp-list-agents.ts", acpListAgents],
 
   // app-builder

--- a/assistant/src/runtime/routes/acp-routes.test.ts
+++ b/assistant/src/runtime/routes/acp-routes.test.ts
@@ -66,8 +66,27 @@ const capturedSpawns: CapturedSpawn[] = [];
 // longer surfaces the session, matching the real map removal).
 const closedSessionIds: string[] = [];
 
+// Records (id, instruction) pairs passed to manager.steer so the
+// acp/continue route tests can assert the follow-up reached the right
+// session. Set `steerShouldThrow` to simulate a closed/non-reusable session.
+interface SteerCall {
+  id: string;
+  instruction: string;
+}
+const steerCalls: SteerCall[] = [];
+let steerShouldThrow = false;
+// Most-recent live session returned by getLiveSessionForConversation, keyed
+// by conversation id; absent → null (no live session).
+const liveByConversation = new Map<string, AcpSessionState>();
+
 mock.module("../../acp/index.js", () => ({
   getAcpSessionManager: () => ({
+    steer: async (id: string, instruction: string) => {
+      if (steerShouldThrow) throw new Error(`ACP session "${id}" not found`);
+      steerCalls.push({ id, instruction });
+    },
+    getLiveSessionForConversation: (conversationId: string) =>
+      liveByConversation.get(conversationId) ?? null,
     getStatus: (id?: string) => {
       if (id === undefined) {
         return Array.from(inMemoryStates.values());
@@ -134,8 +153,7 @@ mock.module("../../tools/credentials/metadata-store.js", () => ({
     const existing = metadataStore.get(key);
     metadataStore.set(key, {
       allowedTools: policy?.allowedTools ?? existing?.allowedTools ?? [],
-      usageDescription:
-        policy?.usageDescription ?? existing?.usageDescription,
+      usageDescription: policy?.usageDescription ?? existing?.usageDescription,
     });
     return {
       credentialId: `cred-${key}`,
@@ -200,8 +218,88 @@ beforeEach(() => {
   which.setWhich((cmd) => `/usr/local/bin/${cmd}`);
   capturedSpawns.length = 0;
   closedSessionIds.length = 0;
+  steerCalls.length = 0;
+  steerShouldThrow = false;
+  liveByConversation.clear();
   vaultStore.clear();
   metadataStore.clear();
+});
+
+// ---------------------------------------------------------------------------
+// POST /v1/acp/continue — follow-up turn on an existing live session
+// ---------------------------------------------------------------------------
+
+function getContinueHandler() {
+  const route = ROUTES.find(
+    (r: { endpoint: string; method: string }) =>
+      r.endpoint === "acp/continue" && r.method === "POST",
+  );
+  if (!route) throw new Error("acp/continue route not registered");
+  return route.handler;
+}
+
+describe("POST /v1/acp/continue", () => {
+  test("explicit acpSessionId: follow-up reaches that session via steer", async () => {
+    const handler = getContinueHandler();
+    const result = (await handler({
+      body: { acpSessionId: "acp-123", instruction: "now add tests" },
+    })) as { acpSessionId: string; continued: boolean };
+
+    expect(result).toEqual({ acpSessionId: "acp-123", continued: true });
+    expect(steerCalls).toEqual([
+      { id: "acp-123", instruction: "now add tests" },
+    ]);
+  });
+
+  test("resolves the conversation's live session when acpSessionId is omitted", async () => {
+    liveByConversation.set("conv-1", {
+      id: "acp-live",
+      agentId: "claude",
+      acpSessionId: "proto-live",
+      parentConversationId: "conv-1",
+      status: "idle",
+      startedAt: 1,
+    });
+
+    const handler = getContinueHandler();
+    const result = (await handler({
+      body: { conversationId: "conv-1", instruction: "keep going" },
+    })) as { acpSessionId: string; continued: boolean };
+
+    expect(result).toEqual({ acpSessionId: "acp-live", continued: true });
+    expect(steerCalls).toEqual([{ id: "acp-live", instruction: "keep going" }]);
+  });
+
+  test("missing instruction throws 400", async () => {
+    const handler = getContinueHandler();
+    await expect(
+      handler({ body: { acpSessionId: "acp-123" } }),
+    ).rejects.toThrow("instruction is required");
+    expect(steerCalls).toEqual([]);
+  });
+
+  test("no acpSessionId and no conversationId throws 400", async () => {
+    const handler = getContinueHandler();
+    await expect(handler({ body: { instruction: "go" } })).rejects.toThrow(
+      "acpSessionId or conversationId is required",
+    );
+  });
+
+  test("no live session for the conversation throws 404", async () => {
+    const handler = getContinueHandler();
+    await expect(
+      handler({ body: { conversationId: "conv-none", instruction: "go" } }),
+    ).rejects.toThrow("No live ACP session");
+    expect(steerCalls).toEqual([]);
+  });
+
+  test("closed/non-existent session: steer rejection maps to 404", async () => {
+    steerShouldThrow = true;
+    const handler = getContinueHandler();
+    await expect(
+      handler({ body: { acpSessionId: "acp-gone", instruction: "go" } }),
+    ).rejects.toThrow("ACP session not found or not reusable");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/routes/acp-routes.ts
+++ b/assistant/src/runtime/routes/acp-routes.ts
@@ -230,6 +230,51 @@ async function steerSession({ pathParams, body }: RouteHandlerArgs) {
   return { acpSessionId: id, steered: true };
 }
 
+/**
+ * Send a follow-up turn to an existing LIVE (running/idle) ACP session so the
+ * agent builds on the same context and workspace.
+ *
+ * Distinct from `spawnSession` (fresh process/session) and `steerSession`
+ * (the HTTP verb is the same `manager.steer`, but `acp_continue` targets a
+ * session left `idle` after its previous task completed — the multi-turn
+ * continuity path). The target session is resolved from an explicit
+ * `acpSessionId` when provided, otherwise from the conversation's most-recent
+ * live session via `getLiveSessionForConversation`. A closed / non-existent
+ * session errors cleanly with a 404 RouteError — never a crash.
+ */
+async function continueSession({ body }: RouteHandlerArgs) {
+  const instruction = body?.instruction as string | undefined;
+  const explicitId = body?.acpSessionId as string | undefined;
+  const conversationId = body?.conversationId as string | undefined;
+
+  if (!instruction) {
+    throw new BadRequestError("instruction is required");
+  }
+  if (!explicitId && !conversationId) {
+    throw new BadRequestError("acpSessionId or conversationId is required");
+  }
+
+  const manager = getAcpSessionManager();
+
+  let acpSessionId = explicitId;
+  if (!acpSessionId) {
+    const live = manager.getLiveSessionForConversation(conversationId!);
+    if (!live) {
+      throw new NotFoundError(
+        "No live ACP session to continue for this conversation",
+      );
+    }
+    acpSessionId = live.id;
+  }
+
+  try {
+    await manager.steer(acpSessionId, instruction);
+  } catch {
+    throw new NotFoundError("ACP session not found or not reusable");
+  }
+  return { acpSessionId, continued: true };
+}
+
 async function cancelSession({ pathParams }: RouteHandlerArgs) {
   const id = pathParams?.id as string;
   const manager = getAcpSessionManager();
@@ -412,6 +457,41 @@ export const ROUTES: RouteDefinition[] = [
     responseBody: z.object({
       acpSessionId: z.string(),
       steered: z.boolean(),
+    }),
+  },
+  {
+    operationId: "acp_continue",
+    endpoint: "acp/continue",
+    method: "POST",
+    policy: {
+      requiredScopes: ["chat.write"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    handler: continueSession,
+    summary: "Continue ACP session",
+    description:
+      "Send a follow-up turn to an existing live (running/idle) ACP session " +
+      "so the agent builds on the same context and workspace. Resolve the " +
+      "target by explicit acpSessionId, or by the conversation's most-recent " +
+      "live session via conversationId. Errors cleanly (404) for a closed or " +
+      "non-existent session.",
+    tags: ["acp"],
+    requestBody: z.object({
+      instruction: z.string().describe("The follow-up task for this turn"),
+      acpSessionId: z
+        .string()
+        .describe("Explicit live session to continue")
+        .optional(),
+      conversationId: z
+        .string()
+        .describe(
+          "Resolve the most-recent live session for this conversation when acpSessionId is omitted",
+        )
+        .optional(),
+    }),
+    responseBody: z.object({
+      acpSessionId: z.string(),
+      continued: z.boolean(),
     }),
   },
   {

--- a/assistant/src/tools/acp/continue.test.ts
+++ b/assistant/src/tools/acp/continue.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { AcpSessionState } from "../../acp/types.js";
+import type { ToolContext } from "../types.js";
+
+interface SteerCall {
+  acpSessionId: string;
+  instruction: string;
+}
+
+const steerCalls: SteerCall[] = [];
+const defaultSteer = (acpSessionId: string, instruction: string) => {
+  steerCalls.push({ acpSessionId, instruction });
+  return Promise.resolve();
+};
+let steerImpl: (acpSessionId: string, instruction: string) => Promise<void> =
+  defaultSteer;
+
+// Most-recent live session returned for a conversation, or null when none.
+let liveSession: AcpSessionState | null = null;
+const liveLookups: string[] = [];
+
+// Spread the real module's exports so transitive importers that pull other
+// names from `../../acp/index.js` still resolve at parse time. Bun's
+// `mock.module` is process-global and returns *exactly* the factory's keys.
+const realAcpModule = await import("../../acp/index.js");
+mock.module("../../acp/index.js", () => ({
+  ...realAcpModule,
+  getAcpSessionManager: () => ({
+    steer: (acpSessionId: string, instruction: string) =>
+      steerImpl(acpSessionId, instruction),
+    getLiveSessionForConversation: (conversationId: string) => {
+      liveLookups.push(conversationId);
+      return liveSession;
+    },
+  }),
+}));
+
+const { executeAcpContinue } = await import("./continue.js");
+
+function makeContext(): ToolContext {
+  return {
+    workingDir: "/tmp",
+    conversationId: "conv-test",
+    trustClass: "guardian",
+  };
+}
+
+function makeLive(id: string): AcpSessionState {
+  return {
+    id,
+    agentId: "claude",
+    acpSessionId: `proto-${id}`,
+    parentConversationId: "conv-test",
+    status: "idle",
+    startedAt: 1,
+  };
+}
+
+beforeEach(() => {
+  steerCalls.length = 0;
+  liveLookups.length = 0;
+  steerImpl = defaultSteer;
+  liveSession = null;
+});
+
+describe("executeAcpContinue", () => {
+  test("explicit acp_session_id: reaches the same session via manager.steer", async () => {
+    const result = await executeAcpContinue(
+      { acp_session_id: "acp-123", instruction: "now also add tests" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    // Did not resolve via conversation — explicit id wins.
+    expect(liveLookups).toEqual([]);
+    expect(steerCalls).toEqual([
+      { acpSessionId: "acp-123", instruction: "now also add tests" },
+    ]);
+
+    const parsed = JSON.parse(result.content as string);
+    expect(parsed.acpSessionId).toBe("acp-123");
+    expect(parsed.status).toBe("continued");
+  });
+
+  test("resolves the conversation's live session when acp_session_id is omitted", async () => {
+    liveSession = makeLive("acp-live");
+
+    const result = await executeAcpContinue(
+      { instruction: "keep going" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(liveLookups).toEqual(["conv-test"]);
+    expect(steerCalls).toEqual([
+      { acpSessionId: "acp-live", instruction: "keep going" },
+    ]);
+  });
+
+  test("missing instruction returns isError", async () => {
+    const result = await executeAcpContinue(
+      { acp_session_id: "acp-123" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('"instruction" is required');
+    expect(steerCalls).toEqual([]);
+  });
+
+  test("no live session for the conversation errors cleanly", async () => {
+    liveSession = null;
+
+    const result = await executeAcpContinue(
+      { instruction: "keep going" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("No live ACP session");
+    expect(steerCalls).toEqual([]);
+  });
+
+  test("closed/non-existent session: manager.steer rejection surfaces cleanly", async () => {
+    steerImpl = () =>
+      Promise.reject(new Error('ACP session "acp-x" not found'));
+
+    const result = await executeAcpContinue(
+      { acp_session_id: "acp-x", instruction: "continue" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Could not continue ACP session "acp-x"');
+    expect(result.content).toContain("not found");
+  });
+});

--- a/assistant/src/tools/acp/continue.ts
+++ b/assistant/src/tools/acp/continue.ts
@@ -1,0 +1,70 @@
+import { getAcpSessionManager } from "../../acp/index.js";
+import type { ToolContext, ToolExecutionResult } from "../types.js";
+
+/**
+ * Sends a follow-up turn to an EXISTING live (running/idle) ACP session so the
+ * agent builds on the same context and workspace it already established.
+ *
+ * Distinct from `acp_spawn` (which starts a FRESH session/process) and from
+ * `acp_steer` (which interrupts the in-flight prompt). `acp_continue` queues a
+ * new turn on a session that is alive — typically one that has gone `idle`
+ * after completing its previous task — via `manager.steer`.
+ *
+ * Targeting resolves in two ways:
+ *  - An explicit `acp_session_id`, when the assistant already knows which
+ *    session to continue.
+ *  - Otherwise, the current conversation's most-recent live session via
+ *    `getLiveSessionForConversation`.
+ *
+ * Closed / non-existent sessions error cleanly (isError), never crash — either
+ * because no live session exists for the conversation or because
+ * `manager.steer` rejects for an unknown / non-reusable session id.
+ */
+export async function executeAcpContinue(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const instruction = input.instruction as string;
+  if (!instruction) {
+    return { content: '"instruction" is required.', isError: true };
+  }
+
+  const manager = getAcpSessionManager();
+
+  // Resolve the target session: an explicit id wins; otherwise fall back to
+  // the conversation's most-recent live (running/idle) session.
+  let acpSessionId = input.acp_session_id as string | undefined;
+  if (!acpSessionId) {
+    const live = manager.getLiveSessionForConversation(context.conversationId);
+    if (!live) {
+      return {
+        content:
+          "No live ACP session to continue for this conversation. " +
+          "Spawn a fresh session with acp_spawn, or pass acp_session_id.",
+        isError: true,
+      };
+    }
+    acpSessionId = live.id;
+  }
+
+  try {
+    await manager.steer(acpSessionId, instruction);
+
+    return {
+      content: JSON.stringify({
+        acpSessionId,
+        status: "continued",
+        message:
+          "Follow-up turn started on the existing ACP session. " +
+          "Results stream back via SSE; you will be notified when it completes.",
+      }),
+      isError: false,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      content: `Could not continue ACP session "${acpSessionId}": ${msg}`,
+      isError: true,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- Add acp_continue (tool + route) that sends a follow-up turn to an existing live/idle ACP session via the session manager, preserving agent context and workspace; closed-session targeting errors cleanly.
- Update the ACP skill to use acp_continue for same-session iteration and acp_spawn only for fresh sessions.

Part of plan: acp-platform-hosted.md (PR E2, Wave 2)