### PR TITLE
feat(cli): `vellum pair` — device-scoped pairing (CLI surface, slice 1/3)

### DIFF
--- a/cli/src/__tests__/pair.test.ts
+++ b/cli/src/__tests__/pair.test.ts
@@ -1,4 +1,12 @@
-import { afterAll, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  spyOn,
+  test,
+} from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -30,16 +38,21 @@ function writeLockfile(): void {
   );
 }
 
-describe("pair command", () => {
-  let originalArgv: string[];
+// Capture the real argv ONCE, before any test mutates it, and restore after
+// every test — so a `['bun','vellum','pair',...]` argv can't leak into other
+// test files in the same Bun run.
+const ORIGINAL_ARGV = [...process.argv];
 
+describe("pair command", () => {
   beforeEach(() => {
-    originalArgv = [...process.argv];
     writeLockfile();
   });
 
+  afterEach(() => {
+    process.argv = [...ORIGINAL_ARGV];
+  });
+
   afterAll(() => {
-    process.argv = originalArgv;
     rmSync(testDir, { recursive: true, force: true });
     delete process.env.VELLUM_LOCKFILE_DIR;
   });

--- a/cli/src/__tests__/pair.test.ts
+++ b/cli/src/__tests__/pair.test.ts
@@ -1,0 +1,100 @@
+import { afterAll, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Real assistant-config reads the lockfile from VELLUM_LOCKFILE_DIR.
+const testDir = mkdtempSync(join(tmpdir(), "pair-command-test-"));
+process.env.VELLUM_LOCKFILE_DIR = testDir;
+
+import { pair } from "../commands/pair.js";
+
+const GATEWAY_URL = "http://127.0.0.1:7830";
+
+function writeLockfile(): void {
+  writeFileSync(
+    join(testDir, ".vellum.lock.json"),
+    JSON.stringify({
+      assistants: [
+        {
+          assistantId: "pair-test",
+          runtimeUrl: GATEWAY_URL,
+          localUrl: GATEWAY_URL,
+          cloud: "local",
+        },
+      ],
+      activeAssistant: "pair-test",
+    }),
+  );
+}
+
+describe("pair command", () => {
+  let originalArgv: string[];
+
+  beforeEach(() => {
+    originalArgv = [...process.argv];
+    writeLockfile();
+  });
+
+  afterAll(() => {
+    process.argv = originalArgv;
+    rmSync(testDir, { recursive: true, force: true });
+    delete process.env.VELLUM_LOCKFILE_DIR;
+  });
+
+  test("POSTs a cli device-bound pair request and prints a decodable bundle", async () => {
+    const calls: Array<[string, RequestInit]> = [];
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: string, init: RequestInit) => {
+      calls.push([url, init]);
+      return new Response(
+        JSON.stringify({
+          token: "test-access-token",
+          expiresAt: "2026-06-04T00:00:00.000Z",
+          guardianId: "guardian-001",
+          assistantId: "self",
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+
+    const logs: string[] = [];
+    const logSpy = spyOn(console, "log").mockImplementation(
+      (...a: unknown[]) => {
+        logs.push(a.join(" "));
+      },
+    );
+
+    process.argv = ["bun", "vellum", "pair", "--json"];
+    try {
+      await pair();
+    } finally {
+      logSpy.mockRestore();
+      globalThis.fetch = origFetch;
+    }
+
+    // Hit /v1/pair with the cli interface + a device-bound body.
+    expect(calls).toHaveLength(1);
+    const [url, init] = calls[0];
+    expect(url).toBe(`${GATEWAY_URL}/v1/pair`);
+    expect(init.method).toBe("POST");
+    const headers = Object.fromEntries(
+      Object.entries(init.headers as Record<string, string>).map(([k, v]) => [
+        k.toLowerCase(),
+        v,
+      ]),
+    );
+    expect(headers["x-vellum-interface-id"]).toBe("cli");
+    const body = JSON.parse(init.body as string);
+    expect(typeof body.deviceId).toBe("string");
+    expect(body.deviceId.length).toBeGreaterThan(0);
+    expect(body.platform).toBe("cli");
+
+    // --json output carries the bundle the consume side will import.
+    const out = JSON.parse(logs.join("\n"));
+    expect(out.gatewayUrl).toBe(GATEWAY_URL);
+    expect(out.assistantId).toBe("self");
+    expect(out.token).toBe("test-access-token");
+    expect(out.deviceId).toBe(body.deviceId);
+  });
+});

--- a/cli/src/__tests__/pair.test.ts
+++ b/cli/src/__tests__/pair.test.ts
@@ -9,7 +9,9 @@ process.env.VELLUM_LOCKFILE_DIR = testDir;
 
 import { pair } from "../commands/pair.js";
 
-const GATEWAY_URL = "http://127.0.0.1:7830";
+// Distinct loopback (mint) vs reachable (advertised) URLs to verify the split.
+const LOCAL_URL = "http://127.0.0.1:7830";
+const RUNTIME_URL = "http://192.168.1.50:7830";
 
 function writeLockfile(): void {
   writeFileSync(
@@ -18,8 +20,8 @@ function writeLockfile(): void {
       assistants: [
         {
           assistantId: "pair-test",
-          runtimeUrl: GATEWAY_URL,
-          localUrl: GATEWAY_URL,
+          runtimeUrl: RUNTIME_URL,
+          localUrl: LOCAL_URL,
           cloud: "local",
         },
       ],
@@ -73,10 +75,10 @@ describe("pair command", () => {
       globalThis.fetch = origFetch;
     }
 
-    // Hit /v1/pair with the cli interface + a device-bound body.
+    // Mint over the loopback (localUrl), not the reachable runtime URL.
     expect(calls).toHaveLength(1);
     const [url, init] = calls[0];
-    expect(url).toBe(`${GATEWAY_URL}/v1/pair`);
+    expect(url).toBe(`${LOCAL_URL}/v1/pair`);
     expect(init.method).toBe("POST");
     const headers = Object.fromEntries(
       Object.entries(init.headers as Record<string, string>).map(([k, v]) => [
@@ -90,9 +92,9 @@ describe("pair command", () => {
     expect(body.deviceId.length).toBeGreaterThan(0);
     expect(body.platform).toBe("cli");
 
-    // --json output carries the bundle the consume side will import.
+    // The bundle advertises the REACHABLE runtime URL, not loopback.
     const out = JSON.parse(logs.join("\n"));
-    expect(out.gatewayUrl).toBe(GATEWAY_URL);
+    expect(out.gatewayUrl).toBe(RUNTIME_URL);
     expect(out.assistantId).toBe("self");
     expect(out.token).toBe("test-access-token");
     expect(out.deviceId).toBe(body.deviceId);

--- a/cli/src/__tests__/pair.test.ts
+++ b/cli/src/__tests__/pair.test.ts
@@ -99,4 +99,50 @@ describe("pair command", () => {
     expect(out.token).toBe("test-access-token");
     expect(out.deviceId).toBe(body.deviceId);
   });
+
+  test("resolves an unquoted multi-word display name", async () => {
+    // Assistant whose display name has a space; passed as separate argv tokens.
+    writeFileSync(
+      join(testDir, ".vellum.lock.json"),
+      JSON.stringify({
+        assistants: [
+          {
+            assistantId: "pair-test",
+            name: "My Assistant",
+            runtimeUrl: RUNTIME_URL,
+            localUrl: LOCAL_URL,
+            cloud: "local",
+          },
+        ],
+        activeAssistant: "pair-test",
+      }),
+    );
+
+    let fetchCalled = false;
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      fetchCalled = true;
+      return new Response(
+        JSON.stringify({
+          token: "t",
+          expiresAt: "2026-06-04T00:00:00.000Z",
+          guardianId: "g",
+          assistantId: "self",
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+    const logSpy = spyOn(console, "log").mockImplementation(() => {});
+
+    process.argv = ["bun", "vellum", "pair", "My", "Assistant", "--json"];
+    try {
+      await pair();
+    } finally {
+      logSpy.mockRestore();
+      globalThis.fetch = origFetch;
+    }
+
+    // Resolution succeeded (no exit), so the mint request was made.
+    expect(fetchCalled).toBe(true);
+  });
 });

--- a/cli/src/__tests__/pair.test.ts
+++ b/cli/src/__tests__/pair.test.ts
@@ -145,4 +145,104 @@ describe("pair command", () => {
     // Resolution succeeded (no exit), so the mint request was made.
     expect(fetchCalled).toBe(true);
   });
+
+  test("refuses to advertise a loopback URL without --url", async () => {
+    // Local hatch: runtimeUrl is itself loopback.
+    writeFileSync(
+      join(testDir, ".vellum.lock.json"),
+      JSON.stringify({
+        assistants: [
+          {
+            assistantId: "pair-test",
+            runtimeUrl: LOCAL_URL,
+            localUrl: LOCAL_URL,
+            cloud: "local",
+          },
+        ],
+        activeAssistant: "pair-test",
+      }),
+    );
+
+    let fetchCalled = false;
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      fetchCalled = true;
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
+    const errSpy = spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(((
+      code?: number,
+    ) => {
+      throw new Error(`exit:${code}`);
+    }) as never);
+
+    process.argv = ["bun", "vellum", "pair"];
+    let exited = false;
+    try {
+      await pair();
+    } catch (e) {
+      exited = (e as Error).message === "exit:1";
+    } finally {
+      errSpy.mockRestore();
+      exitSpy.mockRestore();
+      globalThis.fetch = origFetch;
+    }
+
+    // Exited with an error before minting — no token created for a dead URL.
+    expect(exited).toBe(true);
+    expect(fetchCalled).toBe(false);
+  });
+
+  test("--url override allows pairing even when the runtime URL is loopback", async () => {
+    writeFileSync(
+      join(testDir, ".vellum.lock.json"),
+      JSON.stringify({
+        assistants: [
+          {
+            assistantId: "pair-test",
+            runtimeUrl: LOCAL_URL,
+            localUrl: LOCAL_URL,
+            cloud: "local",
+          },
+        ],
+        activeAssistant: "pair-test",
+      }),
+    );
+
+    const calls: Array<[string, RequestInit]> = [];
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: string, init: RequestInit) => {
+      calls.push([url, init]);
+      return new Response(
+        JSON.stringify({
+          token: "t",
+          expiresAt: "2026-06-04T00:00:00.000Z",
+          guardianId: "g",
+          assistantId: "self",
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+    const logs: string[] = [];
+    const logSpy = spyOn(console, "log").mockImplementation(
+      (...a: unknown[]) => {
+        logs.push(a.join(" "));
+      },
+    );
+
+    const OVERRIDE = "https://abc123.ngrok.app";
+    process.argv = ["bun", "vellum", "pair", "--url", OVERRIDE, "--json"];
+    try {
+      await pair();
+    } finally {
+      logSpy.mockRestore();
+      globalThis.fetch = origFetch;
+    }
+
+    // Mint still over loopback; bundle advertises the override.
+    expect(calls).toHaveLength(1);
+    expect(calls[0][0]).toBe(`${LOCAL_URL}/v1/pair`);
+    const out = JSON.parse(logs.join("\n"));
+    expect(out.gatewayUrl).toBe(OVERRIDE);
+  });
 });

--- a/cli/src/__tests__/pair.test.ts
+++ b/cli/src/__tests__/pair.test.ts
@@ -146,16 +146,17 @@ describe("pair command", () => {
     expect(fetchCalled).toBe(true);
   });
 
-  test("refuses to advertise a loopback URL without --url", async () => {
-    // Local hatch: runtimeUrl is itself loopback.
+  test("refuses to advertise a loopback URL without --url (suggests the assistant's own port)", async () => {
+    // Local hatch on a NON-default gateway port (e.g. a 2nd instance).
+    const LOOPBACK_CUSTOM = "http://127.0.0.1:7842";
     writeFileSync(
       join(testDir, ".vellum.lock.json"),
       JSON.stringify({
         assistants: [
           {
             assistantId: "pair-test",
-            runtimeUrl: LOCAL_URL,
-            localUrl: LOCAL_URL,
+            runtimeUrl: LOOPBACK_CUSTOM,
+            localUrl: LOOPBACK_CUSTOM,
             cloud: "local",
           },
         ],
@@ -169,7 +170,12 @@ describe("pair command", () => {
       fetchCalled = true;
       return new Response("{}", { status: 200 });
     }) as unknown as typeof fetch;
-    const errSpy = spyOn(console, "error").mockImplementation(() => {});
+    const errors: string[] = [];
+    const errSpy = spyOn(console, "error").mockImplementation(
+      (...a: unknown[]) => {
+        errors.push(a.join(" "));
+      },
+    );
     const exitSpy = spyOn(process, "exit").mockImplementation(((
       code?: number,
     ) => {
@@ -187,6 +193,10 @@ describe("pair command", () => {
       exitSpy.mockRestore();
       globalThis.fetch = origFetch;
     }
+
+    // The suggested --url uses the assistant's actual port, not the default.
+    expect(errors.join("\n")).toContain(":7842");
+    expect(errors.join("\n")).not.toContain(":7830");
 
     // Exited with an error before minting — no token created for a dead URL.
     expect(exited).toBe(true);

--- a/cli/src/commands/pair.ts
+++ b/cli/src/commands/pair.ts
@@ -13,7 +13,12 @@
 import { nanoid } from "nanoid";
 
 import { extractFlag } from "../lib/arg-utils.js";
-import { resolveAssistant } from "../lib/assistant-config.js";
+import {
+  formatAssistantLookupError,
+  lookupAssistantByIdentifier,
+  resolveAssistant,
+  type AssistantEntry,
+} from "../lib/assistant-config.js";
 import {
   CLI_INTERFACE_ID,
   getClientRegistrationHeaders,
@@ -30,12 +35,15 @@ ARGUMENTS:
     [assistant]    Instance name (default: active assistant)
 
 OPTIONS:
+    --url <url>      Reachable gateway URL to advertise in the bundle
+                    (default: the assistant's runtime URL, not loopback)
     --label <name>   Human label for this pairing (echoed in the output)
     --json           Output the raw bundle as JSON
 
 EXAMPLES:
     vellum pair
-    vellum pair my-assistant --label "phone"
+    vellum pair "My Assistant" --label "phone"
+    vellum pair --url https://abc123.ngrok.app
     vellum pair --json
 `);
 }
@@ -58,25 +66,43 @@ export async function pair(): Promise<void> {
   const jsonOutput = rawArgs.includes("--json");
   let args = rawArgs.filter((a) => a !== "--json");
 
-  const [label, filteredArgs] = extractFlag(args, "--label");
-  args = filteredArgs;
+  const [label, afterLabel] = extractFlag(args, "--label");
+  const [urlOverride, afterUrl] = extractFlag(afterLabel, "--url");
+  args = afterUrl;
 
+  // Resolve the target. An explicit argument is matched by display name OR id
+  // (with the standard ambiguity error); no argument falls back to the active
+  // assistant.
   const assistantName = args[0];
-  const entry = resolveAssistant(assistantName);
-  if (!entry) {
-    console.error(
-      assistantName
-        ? `No assistant instance found with name '${assistantName}'.`
-        : "No assistant instance found. Run `vellum hatch` first.",
-    );
-    process.exit(1);
+  let entry: AssistantEntry | null;
+  if (assistantName) {
+    const result = lookupAssistantByIdentifier(assistantName);
+    if (result.status !== "found") {
+      console.error(formatAssistantLookupError(assistantName, result));
+      process.exit(1);
+    }
+    entry = result.entry;
+  } else {
+    entry = resolveAssistant();
+    if (!entry) {
+      console.error("No assistant instance found. Run `vellum hatch` first.");
+      process.exit(1);
+    }
   }
 
-  const gatewayUrl = (
+  // Mint over loopback (localUrl avoids mDNS for same-machine calls), but
+  // advertise a REACHABLE url in the bundle — the loopback url would point the
+  // other machine at its own localhost. Prefer an explicit --url, then the
+  // runtime (LAN/tunnel) url.
+  const mintUrl = (
     entry.localUrl ||
     entry.runtimeUrl ||
     `http://127.0.0.1:${GATEWAY_PORT}`
   ).replace(/\/+$/, "");
+  const advertisedUrl = (urlOverride || entry.runtimeUrl || mintUrl).replace(
+    /\/+$/,
+    "",
+  );
 
   // Fresh per-pairing device identity — each `vellum pair` is independently
   // revocable.
@@ -84,7 +110,7 @@ export async function pair(): Promise<void> {
 
   let response: Response;
   try {
-    response = await fetch(`${gatewayUrl}/v1/pair`, {
+    response = await fetch(`${mintUrl}/v1/pair`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -94,7 +120,7 @@ export async function pair(): Promise<void> {
     });
   } catch (err) {
     console.error(
-      `Error: could not reach the gateway at ${gatewayUrl} ` +
+      `Error: could not reach the gateway at ${mintUrl} ` +
         `(${err instanceof Error ? err.message : String(err)}).`,
     );
     console.error("Is the assistant running? Try `vellum wake`.");
@@ -114,7 +140,7 @@ export async function pair(): Promise<void> {
   // Single-line, copy-pasteable blob for the consume side (`vellum connect
   // import <blob>`, forthcoming).
   const bundle = {
-    gatewayUrl,
+    gatewayUrl: advertisedUrl,
     assistantId: result.assistantId,
     token: result.token,
     deviceId,
@@ -131,7 +157,7 @@ export async function pair(): Promise<void> {
   const displayName = entry.name || entry.assistantName || entry.assistantId;
   console.log(`Paired ${label ? `"${label}" ` : ""}with ${displayName}.`);
   console.log("");
-  console.log(`  Gateway:   ${gatewayUrl}`);
+  console.log(`  Gateway:   ${advertisedUrl}`);
   console.log(`  Assistant: ${result.assistantId}`);
   console.log(`  Expires:   ${result.expiresAt}`);
   console.log("");

--- a/cli/src/commands/pair.ts
+++ b/cli/src/commands/pair.ts
@@ -122,9 +122,17 @@ export async function pair(): Promise<void> {
   // explicitly passed one. (An explicit --url is trusted as-is.)
   if (!urlOverride && isLoopbackHost(advertisedUrl)) {
     const lan = getLocalLanIPv4();
+    // Use THIS assistant's gateway port (not the global default) — second
+    // local instances listen on a different port.
+    let port = String(GATEWAY_PORT);
+    try {
+      port = new URL(mintUrl).port || port;
+    } catch {
+      /* keep default */
+    }
     const suggestion = lan
-      ? `http://${lan}:${GATEWAY_PORT}`
-      : "http://<this-machine-ip>:" + GATEWAY_PORT;
+      ? `http://${lan}:${port}`
+      : `http://<this-machine-ip>:${port}`;
     console.error(
       "Error: this assistant has no reachable gateway URL — its address is " +
         `loopback (${advertisedUrl}), which the other machine can't connect to.`,

--- a/cli/src/commands/pair.ts
+++ b/cli/src/commands/pair.ts
@@ -25,6 +25,16 @@ import {
   getClientRegistrationHeaders,
 } from "../lib/client-identity.js";
 import { GATEWAY_PORT } from "../lib/constants.js";
+import { getLocalLanIPv4 } from "../lib/local.js";
+
+function isLoopbackHost(url: string): boolean {
+  try {
+    const host = new URL(url).hostname.toLowerCase();
+    return host === "localhost" || host === "::1" || host.startsWith("127.");
+  } catch {
+    return false;
+  }
+}
 
 function printUsage(): void {
   console.log(`vellum pair - Mint a device-scoped token for another machine
@@ -105,6 +115,25 @@ export async function pair(): Promise<void> {
     /\/+$/,
     "",
   );
+
+  // A local hatch's runtimeUrl is itself loopback (http://localhost:<port>),
+  // so without an explicit --url the bundle would point the other machine at
+  // its own localhost. Refuse to advertise a loopback URL unless the user
+  // explicitly passed one. (An explicit --url is trusted as-is.)
+  if (!urlOverride && isLoopbackHost(advertisedUrl)) {
+    const lan = getLocalLanIPv4();
+    const suggestion = lan
+      ? `http://${lan}:${GATEWAY_PORT}`
+      : "http://<this-machine-ip>:" + GATEWAY_PORT;
+    console.error(
+      "Error: this assistant has no reachable gateway URL — its address is " +
+        `loopback (${advertisedUrl}), which the other machine can't connect to.`,
+    );
+    console.error(
+      `Re-run with a reachable URL, e.g.:\n  vellum pair --url ${suggestion}`,
+    );
+    process.exit(1);
+  }
 
   // Fresh per-pairing device identity — each `vellum pair` is independently
   // revocable.

--- a/cli/src/commands/pair.ts
+++ b/cli/src/commands/pair.ts
@@ -13,6 +13,7 @@
 import { nanoid } from "nanoid";
 
 import { extractFlag } from "../lib/arg-utils.js";
+import { parseAssistantTargetArg } from "../lib/assistant-target-args.js";
 import {
   formatAssistantLookupError,
   lookupAssistantByIdentifier,
@@ -72,8 +73,9 @@ export async function pair(): Promise<void> {
 
   // Resolve the target. An explicit argument is matched by display name OR id
   // (with the standard ambiguity error); no argument falls back to the active
-  // assistant.
-  const assistantName = args[0];
+  // assistant. Join positional tokens so multi-word display names work even
+  // unquoted (e.g. `vellum pair My Assistant`).
+  const assistantName = parseAssistantTargetArg(args);
   let entry: AssistantEntry | null;
   if (assistantName) {
     const result = lookupAssistantByIdentifier(assistantName);

--- a/cli/src/commands/pair.ts
+++ b/cli/src/commands/pair.ts
@@ -1,0 +1,142 @@
+/**
+ * `vellum pair [assistant] [--label <name>]`
+ *
+ * Mint a device-scoped token for another machine and print a pairing bundle.
+ * Runs on the machine hosting the assistant: it calls the local gateway's
+ * loopback-only `POST /v1/pair` (cli interface) with a freshly generated
+ * deviceId, then prints the credentials to hand to a second device.
+ *
+ * Each invocation generates a NEW random deviceId, so each pairing is an
+ * independent, separately-revocable device (see `vellum unpair`, forthcoming).
+ */
+
+import { nanoid } from "nanoid";
+
+import { extractFlag } from "../lib/arg-utils.js";
+import { resolveAssistant } from "../lib/assistant-config.js";
+import {
+  CLI_INTERFACE_ID,
+  getClientRegistrationHeaders,
+} from "../lib/client-identity.js";
+import { GATEWAY_PORT } from "../lib/constants.js";
+
+function printUsage(): void {
+  console.log(`vellum pair - Mint a device-scoped token for another machine
+
+USAGE:
+    vellum pair [assistant] [options]
+
+ARGUMENTS:
+    [assistant]    Instance name (default: active assistant)
+
+OPTIONS:
+    --label <name>   Human label for this pairing (echoed in the output)
+    --json           Output the raw bundle as JSON
+
+EXAMPLES:
+    vellum pair
+    vellum pair my-assistant --label "phone"
+    vellum pair --json
+`);
+}
+
+interface PairResponse {
+  token: string;
+  expiresAt: string;
+  guardianId: string;
+  assistantId: string;
+}
+
+export async function pair(): Promise<void> {
+  const rawArgs = process.argv.slice(3);
+
+  if (rawArgs.includes("--help") || rawArgs.includes("-h")) {
+    printUsage();
+    return;
+  }
+
+  const jsonOutput = rawArgs.includes("--json");
+  let args = rawArgs.filter((a) => a !== "--json");
+
+  const [label, filteredArgs] = extractFlag(args, "--label");
+  args = filteredArgs;
+
+  const assistantName = args[0];
+  const entry = resolveAssistant(assistantName);
+  if (!entry) {
+    console.error(
+      assistantName
+        ? `No assistant instance found with name '${assistantName}'.`
+        : "No assistant instance found. Run `vellum hatch` first.",
+    );
+    process.exit(1);
+  }
+
+  const gatewayUrl = (
+    entry.localUrl ||
+    entry.runtimeUrl ||
+    `http://127.0.0.1:${GATEWAY_PORT}`
+  ).replace(/\/+$/, "");
+
+  // Fresh per-pairing device identity — each `vellum pair` is independently
+  // revocable.
+  const deviceId = nanoid();
+
+  let response: Response;
+  try {
+    response = await fetch(`${gatewayUrl}/v1/pair`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...getClientRegistrationHeaders(CLI_INTERFACE_ID),
+      },
+      body: JSON.stringify({ deviceId, platform: "cli" }),
+    });
+  } catch (err) {
+    console.error(
+      `Error: could not reach the gateway at ${gatewayUrl} ` +
+        `(${err instanceof Error ? err.message : String(err)}).`,
+    );
+    console.error("Is the assistant running? Try `vellum wake`.");
+    process.exit(1);
+  }
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    console.error(
+      `Error: HTTP ${response.status}: ${body || response.statusText}`,
+    );
+    process.exit(1);
+  }
+
+  const result = (await response.json()) as PairResponse;
+
+  // Single-line, copy-pasteable blob for the consume side (`vellum connect
+  // import <blob>`, forthcoming).
+  const bundle = {
+    gatewayUrl,
+    assistantId: result.assistantId,
+    token: result.token,
+    deviceId,
+  };
+  const blob = Buffer.from(JSON.stringify(bundle)).toString("base64");
+
+  if (jsonOutput) {
+    console.log(
+      JSON.stringify({ ...bundle, expiresAt: result.expiresAt }, null, 2),
+    );
+    return;
+  }
+
+  const displayName = entry.name || entry.assistantName || entry.assistantId;
+  console.log(`Paired ${label ? `"${label}" ` : ""}with ${displayName}.`);
+  console.log("");
+  console.log(`  Gateway:   ${gatewayUrl}`);
+  console.log(`  Assistant: ${result.assistantId}`);
+  console.log(`  Expires:   ${result.expiresAt}`);
+  console.log("");
+  console.log("Hand this to the other machine (keep it secret):");
+  console.log("");
+  console.log(`  ${blob}`);
+  console.log("");
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -13,6 +13,7 @@ import { hatch } from "./commands/hatch";
 import { login, logout, whoami } from "./commands/login";
 import { logs } from "./commands/logs";
 import { message } from "./commands/message";
+import { pair } from "./commands/pair";
 import { ps } from "./commands/ps";
 import { recover } from "./commands/recover";
 import { restore } from "./commands/restore";
@@ -46,6 +47,7 @@ const commands = {
   logout,
   logs,
   message,
+  pair,
   ps,
   recover,
   restore,
@@ -83,6 +85,9 @@ function printHelp(): void {
   console.log("  login    Log in to the Vellum platform");
   console.log("  logout   Log out of the Vellum platform");
   console.log("  message  Send a message to a running assistant");
+  console.log(
+    "  pair     Mint a device-scoped token to connect another machine",
+  );
   console.log(
     "  ps       List assistants (or processes for a specific assistant)",
   );

--- a/gateway/src/__tests__/pair-device-bound.test.ts
+++ b/gateway/src/__tests__/pair-device-bound.test.ts
@@ -152,3 +152,53 @@ describe("/v1/pair device-bound minting", () => {
     expect(activeTokens()).toHaveLength(0);
   });
 });
+
+describe("/v1/pair cli interface", () => {
+  // The cli interface (e.g. `vellum pair`) is loopback-gated like the rest of
+  // /v1/pair, but is NOT a browser, so it carries no Origin header.
+  function makeCliRequest(body?: Record<string, unknown>): Request {
+    return new Request("http://localhost:7830/v1/pair", {
+      method: "POST",
+      headers: {
+        host: "localhost:7830",
+        "content-type": "application/json",
+        "x-vellum-interface-id": "cli",
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+  }
+
+  test("mints a device-bound access token (no Origin header required, no refresh)", async () => {
+    const res = await handlePair(
+      makeCliRequest({ deviceId: "device-cli" }),
+      LOOPBACK_IP,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+
+    expect(typeof body.token).toBe("string");
+    expect(typeof body.expiresAt).toBe("string");
+    expect(body.guardianId).toBe(GUARDIAN_ID);
+    expect(body.refreshToken).toBeUndefined();
+
+    const tokens = activeTokens();
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0].hashedDeviceId).toBe(hashToken("device-cli"));
+    expect(tokens[0].platform).toBe("cli");
+  });
+
+  test("rejects a cli pair request without a deviceId (400)", async () => {
+    const res = await handlePair(makeCliRequest(), LOOPBACK_IP);
+    expect(res.status).toBe(400);
+    expect(activeTokens()).toHaveLength(0);
+  });
+
+  test("still rejects non-loopback cli callers", async () => {
+    const res = await handlePair(
+      makeCliRequest({ deviceId: "device-cli" }),
+      "8.8.8.8",
+    );
+    expect(res.status).toBe(403);
+    expect(activeTokens()).toHaveLength(0);
+  });
+});

--- a/gateway/src/http/routes/pair.ts
+++ b/gateway/src/http/routes/pair.ts
@@ -331,31 +331,15 @@ export async function handlePair(
       );
     }
 
-    // Device-bound path: mint a recorded, per-device-revocable access token on
-    // the same short pair TTL as the stateless path. No refresh token is
-    // issued — until hot-path revocation is enforced, a long-lived refresh
-    // could silently re-mint long access tokens, so refreshable pairing is
-    // deferred. The recorded token becomes immediately revocable once the
-    // revocation check lands; in the interim the short TTL bounds its reach.
+    // Device-bound path: mint a recorded, per-device-revocable access token.
     if (deviceId) {
-      const platform = bodyPlatform ?? interfaceId;
-      const access = mintAndRecordDeviceBoundAccessToken({
+      return mintDeviceBoundPairResponse({
         guardianPrincipalId,
-        deviceId,
-        platform,
-        ttlSeconds: PAIR_TOKEN_TTL_SECONDS,
-      });
-
-      log.info(
-        { interfaceId, clientId, guardianPrincipalId, platform },
-        "Client paired successfully via loopback (device-bound)",
-      );
-
-      return Response.json({
-        token: access.accessToken,
-        expiresAt: new Date(access.accessTokenExpiresAt).toISOString(),
-        guardianId: guardianPrincipalId,
         assistantId,
+        deviceId,
+        platform: bodyPlatform ?? interfaceId,
+        interfaceId,
+        clientId,
       });
     }
 
@@ -382,10 +366,76 @@ export async function handlePair(
     });
   }
 
+  // CLI pairing (e.g. `vellum pair`): a loopback-local caller mints a
+  // device-bound token for another machine. No extension-origin check applies
+  // (the CLI is not a browser); the loopback / X-Forwarded-For / edge-marker
+  // guards above are the boundary. A deviceId is required — CLI pairing is
+  // always device-scoped (and thus revocable).
+  if (interfaceId === "cli") {
+    if (!deviceId) {
+      return errorResponse(
+        "BAD_REQUEST",
+        "cli interface requires a deviceId",
+        400,
+      );
+    }
+    return mintDeviceBoundPairResponse({
+      guardianPrincipalId,
+      assistantId,
+      deviceId,
+      platform: bodyPlatform ?? "cli",
+      interfaceId,
+      clientId,
+    });
+  }
+
   auditDeny(req, clientIp, "unknown_interface", { interfaceId });
   return errorResponse(
     "BAD_REQUEST",
     `unsupported interface: '${interfaceId}'`,
     400,
   );
+}
+
+/**
+ * Mint a device-bound, recorded, per-device-revocable access token (short pair
+ * TTL, no refresh token) and build the pair response. Shared by the
+ * chrome-extension (deviceId) and cli pairing paths.
+ *
+ * No refresh token is issued: a long-lived refresh could silently re-mint long
+ * access tokens, so refreshable pairing is deferred until that's handled
+ * explicitly. The recorded token is immediately revocable; the short TTL bounds
+ * its reach in the interim.
+ */
+function mintDeviceBoundPairResponse(opts: {
+  guardianPrincipalId: string;
+  assistantId: string;
+  deviceId: string;
+  platform: string;
+  interfaceId: string;
+  clientId: string | null;
+}): Response {
+  const access = mintAndRecordDeviceBoundAccessToken({
+    guardianPrincipalId: opts.guardianPrincipalId,
+    deviceId: opts.deviceId,
+    platform: opts.platform,
+    ttlSeconds: PAIR_TOKEN_TTL_SECONDS,
+  });
+
+  log.info(
+    {
+      interfaceId: opts.interfaceId,
+      clientId: opts.clientId,
+      guardianPrincipalId: opts.guardianPrincipalId,
+      platform: opts.platform,
+    },
+    "Client paired successfully via loopback (device-bound)",
+  );
+
+  return Response.json({
+    token: access.accessToken,
+    expiresAt: new Date(access.accessTokenExpiresAt).toISOString(),
+    guardianId: opts.guardianPrincipalId,
+    assistantId: opts.assistantId,
+  });
 }


### PR DESCRIPTION
## Summary
- Adds `vellum pair [assistant] [--label <name>] [--json]` — run on the machine hosting the assistant, it mints a **device-scoped** token via the local gateway and prints a copy-pasteable pairing bundle for another machine.
- Opens the gateway's loopback-only `POST /v1/pair` to a new `cli` interface id, reusing PR #33359's **access-only, device-bound, revocable** mint (`mintAndRecordDeviceBoundAccessToken`). Factors the device-bound mint+response into a shared helper so the chrome-extension and cli paths don't duplicate it.
- Each `vellum pair` invocation generates a **fresh random deviceId**, so each pairing is an independent, separately-revocable device (revocation lands in Slice 3).

## Details
- `/v1/pair` cli branch: loopback-gated exactly like the rest of the endpoint (peer IP + X-Forwarded-For + edge-marker guards still run first), but no extension-origin check (the CLI isn't a browser). `deviceId` is **required** for cli (CLI pairing is always device-scoped). No new remote exposure — the endpoint remains loopback-only.
- Bundle: human-readable summary plus a single-line base64 blob = `base64(JSON.stringify({ gatewayUrl, assistantId, token, deviceId }))` that Slice 2's `vellum connect import <blob>` will consume. `--json` prints the raw bundle.
- No refresh token is issued (consistent with PR #33359's deliberate access-only pairing).

## Tests
- Gateway: cli interface with a deviceId mints a device-bound access token (no Origin header needed, no refresh); cli without deviceId → 400; non-loopback cli caller → 403; chrome-extension path unchanged.
- CLI: `vellum pair --json` POSTs `/v1/pair` with the `cli` interface header + `{deviceId, platform:"cli"}` and prints a bundle whose deviceId matches the request.

## Original prompt
First of three slices building the CLI pairing surface on top of the merged remote-pairing foundation (#33349/#33359/#33368). This slice is the A-side: `vellum pair` to mint+emit a bundle, and opening `/v1/pair` to the loopback `cli` interface. The consume side (`vellum connect import` / `vellum client --token`) and management (`vellum devices`/`vellum unpair` + a loopback revoke endpoint) are the next two slices.

## Deferred (next slices)
- Slice 2: consume side — `vellum connect import <blob>` / `vellum client --token` so another machine can chat with the handed-over token.
- Slice 3: `vellum devices` + `vellum unpair` + a loopback revoke endpoint.
- Also deferred: re-introducing refresh tokens; tunnel/edge exposure; storing a human label server-side (the `--label` here is only echoed in output for now).