### PR TITLE
fix(web): keep mock trash palette on bundled skills (mobile detail)

### DIFF
--- a/apps/web/src/domains/intelligence/components/skills/skill-detail-mobile.tsx
+++ b/apps/web/src/domains/intelligence/components/skills/skill-detail-mobile.tsx
@@ -287,7 +287,11 @@ function RightAction({
     );
   }
 
-  // Bundled: not available and not removable.
+  // Bundled: not available and not removable. Keep the mock's destructive
+  // palette (negative-weak circle, negative-strong glyph) even though the
+  // action is unavailable — the disabled state otherwise mutes the icon to
+  // `--content-disabled`. The inline custom property wins over the variant's
+  // `disabled:` override, which a className alone wouldn't reliably do.
   return (
     <Button
       variant="dangerGhost"
@@ -297,6 +301,7 @@ function RightAction({
       title="Bundled skills cannot be removed"
       aria-label="Bundled skill cannot be removed"
       className="max-md:rounded-full max-md:bg-[var(--system-negative-weak)]"
+      style={{ ["--vbtn-fg" as string]: "var(--system-negative-strong)" }}
     />
   );
 }


### PR DESCRIPTION
## Summary
- The bundled (non-removable) trash button in the mobile skill detail rendered `disabled`, which muted the icon to `--content-disabled` (grey).
- Force the icon to `--system-negative-strong` via an inline custom property (wins over the variant's `disabled:` override) so it keeps the mock's destructive palette: `--system-negative-weak` circle + `--system-negative-strong` glyph. Behavior unchanged (still non-interactive for bundled skills).

Follow-up to the iOS skill detail view (#33358).