### PR TITLE
fix(acp): current spawn-env comment + clear stale Claude replace flag in web card

### DIFF
--- a/apps/web/src/domains/settings/ai/acp-credentials-card.test.tsx
+++ b/apps/web/src/domains/settings/ai/acp-credentials-card.test.tsx
@@ -129,6 +129,81 @@ describe("AcpCredentialsCard", () => {
     expect(queryByLabelText("Git token")).toBeNull();
   });
 
+  test("switching the Claude dropdown during replace and linking clears the replace form", async () => {
+    const { getByLabelText, getByText, queryByText, queryByLabelText } = render(
+      <AcpCredentialsCard assistantId={ASSISTANT_ID} />,
+    );
+
+    // Link the Claude OAuth token (the default dropdown mode).
+    const claudeInput = getByLabelText(
+      "Claude OAuth token",
+    ) as HTMLInputElement;
+    fireEvent.change(claudeInput, { target: { value: "claude_oauth" } });
+
+    // The Claude row is the only credential row containing the mode dropdown
+    // (combobox), so scope button lookup to that row to disambiguate it.
+    const findClaudeButton = (text: string) =>
+      Array.from(document.querySelectorAll("button")).find((b) => {
+        if (b.textContent !== text) return false;
+        const row = b.closest("div.rounded-lg");
+        return row?.querySelector('[role="combobox"]') != null;
+      });
+
+    fireEvent.click(findClaudeButton("Link")!);
+    await waitFor(() => {
+      expect(linkMock).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(getByText(/Claude OAuth token linked/i)).toBeDefined();
+    });
+
+    // Start a replace, then switch the dropdown to the OTHER Claude credential.
+    fireEvent.click(getByText("Replace"));
+    await waitFor(() => {
+      expect(queryByLabelText("Claude OAuth token")).not.toBeNull();
+    });
+
+    const trigger = document.querySelector(
+      '[role="combobox"]',
+    ) as HTMLElement;
+    fireEvent.click(trigger);
+    const apiKeyOption = await waitFor(() => {
+      const el = Array.from(
+        document.querySelectorAll('[role="option"]'),
+      ).find((o) => o.textContent?.includes("Anthropic API key"));
+      expect(el).toBeDefined();
+      return el as HTMLElement;
+    });
+    fireEvent.click(apiKeyOption);
+
+    const apiKeyInput = (await waitFor(() => {
+      const el = queryByLabelText("Anthropic API key") as HTMLInputElement | null;
+      expect(el).not.toBeNull();
+      return el!;
+    })) as HTMLInputElement;
+
+    // Submit the new (Anthropic API key) credential.
+    fireEvent.change(apiKeyInput, { target: { value: "sk-ant" } });
+    fireEvent.click(findClaudeButton("Replace")!);
+
+    await waitFor(() => {
+      expect(linkMock).toHaveBeenCalledTimes(2);
+    });
+    expect(linkMock.mock.calls[1]![0]).toMatchObject({
+      body: { field: "anthropic_api_key", value: "sk-ant" },
+    });
+
+    // The replace form must be gone: linked state shows, no input lingers.
+    await waitFor(() => {
+      expect(getByText(/Anthropic API key linked/i)).toBeDefined();
+    });
+    expect(queryByLabelText("Anthropic API key")).toBeNull();
+    expect(queryByLabelText("Claude OAuth token")).toBeNull();
+    expect(
+      queryByText(/Enter a new value to overwrite the stored credential/i),
+    ).toBeNull();
+  });
+
   test("does not call the daemon when no assistant is present", () => {
     const { getByText, queryByLabelText } = render(
       <AcpCredentialsCard assistantId={undefined} />,

--- a/apps/web/src/domains/settings/ai/acp-credentials-card.tsx
+++ b/apps/web/src/domains/settings/ai/acp-credentials-card.tsx
@@ -97,16 +97,22 @@ export function AcpCredentialsCard({ assistantId }: AcpCredentialsCardProps) {
           throwOnError: true,
         });
         setLinked((l) => ({ ...l, [field]: true }));
-        // Close any in-progress "replace" input now that the overwrite landed.
-        setReplacing((r) => ({ ...r, [field]: false }));
-        // For Claude, only one of the two fields can be the active credential;
-        // clear the other so the UI shows a single linked Claude credential.
         if (field === "claude_oauth_token" || field === "anthropic_api_key") {
+          // For Claude, only one of the two fields can be the active
+          // credential; clear the other's linked flag so the UI shows a single
+          // linked Claude credential. The Claude row's `replacing` prop ORs
+          // both Claude flags, so reset BOTH replacing flags — otherwise a
+          // replace started against the now-cleared field would keep the row
+          // stuck on the replace form after a successful link.
           const other: AcpField =
             field === "claude_oauth_token"
               ? "anthropic_api_key"
               : "claude_oauth_token";
           setLinked((l) => ({ ...l, [other]: false }));
+          setReplacing((r) => ({ ...r, [field]: false, [other]: false }));
+        } else {
+          // Close any in-progress "replace" input now that the overwrite landed.
+          setReplacing((r) => ({ ...r, [field]: false }));
         }
       } catch (err) {
         captureError(err, { context: "acp_link_credential", bestEffort: true });

--- a/assistant/src/acp/resolve-agent.ts
+++ b/assistant/src/acp/resolve-agent.ts
@@ -67,9 +67,12 @@ function installHintFor(command: string): string {
 
 /**
  * Resolve the binary using the same PATH the spawn will see. `AcpAgentProcess`
- * spawns with `{ ...process.env, ...config.env }`, so a per-agent `env.PATH`
- * override wins over the daemon's PATH. Mirror that here so a config that
- * relies on a custom PATH to locate the binary doesn't fail preflight.
+ * spawns with `buildAgentSpawnEnv(config.env)`, which seeds the env from the
+ * shared safe-env allowlist (carrying the daemon's `PATH`) and then merges the
+ * agent's injected `config.env` on top — so a per-agent `env.PATH` override
+ * wins over the daemon's PATH. Mirror that precedence here (config PATH, else
+ * `process.env.PATH`) so a config that relies on a custom PATH to locate the
+ * binary doesn't fail preflight.
  */
 function findAgentBinary(agent: AcpAgentConfig): string | null {
   const PATH = agent.env?.PATH ?? process.env.PATH;


### PR DESCRIPTION
## Summary
Self-review remediation:
- Update findAgentBinary's doc comment to describe the current buildAgentSpawnEnv spawn-env (post-F1), per AGENTS.md no-removed-code-in-comments rule.
- Clear the other Claude field's 'replacing' flag on a successful Claude credential link so the card doesn't keep showing the replace form after a dropdown mode switch.

Part of plan: acp-platform-hosted.md (self-review fix)