### PR TITLE
fix(acp): git credential for both agents + real HTTPS auth; continue rejects running; shared cred fields

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -137,9 +137,10 @@ paths:
       operationId: acp_continue_post
       summary: Continue ACP session
       description:
-        Send a follow-up turn to an existing live (running/idle) ACP session so the agent builds on the same
-        context and workspace. Resolve the target by explicit acpSessionId, or by the conversation's most-recent live
-        session via conversationId. Errors cleanly (404) for a closed or non-existent session.
+        Send a follow-up turn to an existing idle ACP session so the agent builds on the same context and
+        workspace. Resolve the target by explicit acpSessionId, or by the conversation's most-recent live session via
+        conversationId. Errors cleanly (404) for a closed or non-existent session, and (409) when the session is busy
+        with a prompt still in flight.
       tags:
         - acp
       responses:

--- a/assistant/src/acp/__tests__/prepare-agent-env.test.ts
+++ b/assistant/src/acp/__tests__/prepare-agent-env.test.ts
@@ -422,6 +422,64 @@ describe("prepareAgentEnv — claude-agent-acp gating", () => {
     expect(prepared.env?.GH_TOKEN).toBe("vault-git");
   });
 
+  test("a git token also wires the GIT_CONFIG_* URL-rewrite so plain git over HTTPS authenticates", async () => {
+    seedVaultToken("vault-oauth");
+    seedVaultField("git_token", "vault-git");
+
+    const prepared = await prepareAgentEnv({
+      command: "claude-agent-acp",
+      args: [],
+    });
+
+    // GH_TOKEN covers the gh CLI; the GIT_CONFIG_* trio makes a bare
+    // `git clone/push` over HTTPS rewrite github.com URLs to embed the token.
+    expect(prepared.env?.GH_TOKEN).toBe("vault-git");
+    expect(prepared.env?.GIT_CONFIG_COUNT).toBe("1");
+    expect(prepared.env?.GIT_CONFIG_KEY_0).toBe(
+      "url.https://x-access-token:vault-git@github.com/.insteadOf",
+    );
+    expect(prepared.env?.GIT_CONFIG_VALUE_0).toBe("https://github.com/");
+  });
+
+  test("does NOT set GIT_CONFIG_* when no git token is present", async () => {
+    seedVaultToken("vault-oauth");
+
+    const prepared = await prepareAgentEnv({
+      command: "claude-agent-acp",
+      args: [],
+    });
+
+    expect(prepared.env?.GH_TOKEN).toBeUndefined();
+    expect(prepared.env?.GIT_CONFIG_COUNT).toBeUndefined();
+    expect(prepared.env?.GIT_CONFIG_KEY_0).toBeUndefined();
+    expect(prepared.env?.GIT_CONFIG_VALUE_0).toBeUndefined();
+  });
+
+  test("appends to an existing GIT_CONFIG_COUNT rather than clobbering it", async () => {
+    seedVaultToken("vault-oauth");
+    seedVaultField("git_token", "vault-git");
+
+    const prepared = await prepareAgentEnv({
+      command: "claude-agent-acp",
+      args: [],
+      // Simulate a user-supplied ad-hoc git config entry already in agent.env.
+      env: {
+        GIT_CONFIG_COUNT: "1",
+        GIT_CONFIG_KEY_0: "user.name",
+        GIT_CONFIG_VALUE_0: "Existing User",
+      },
+    });
+
+    // Existing entry is preserved; ours is appended at the next index.
+    expect(prepared.env?.GIT_CONFIG_COUNT).toBe("2");
+    expect(prepared.env?.GIT_CONFIG_KEY_0).toBe("user.name");
+    expect(prepared.env?.GIT_CONFIG_VALUE_0).toBe("Existing User");
+    expect(prepared.env?.GIT_CONFIG_KEY_1).toBe(
+      "url.https://x-access-token:vault-git@github.com/.insteadOf",
+    );
+    expect(prepared.env?.GIT_CONFIG_VALUE_1).toBe("https://github.com/");
+  });
+
   test("git token works alongside the API-key-only LLM credential", async () => {
     seedVaultField("anthropic_api_key", "vault-anthropic-key");
     seedVaultField("git_token", "vault-git");

--- a/assistant/src/acp/credential-fields.ts
+++ b/assistant/src/acp/credential-fields.ts
@@ -1,0 +1,44 @@
+/**
+ * Single source of truth for the linkable ACP credential fields.
+ *
+ * Two sides must agree on this set or per-user agent spawns break:
+ *  - The WRITER (`runtime/routes/acp-routes.ts:linkCredential`) accepts only
+ *    these fields over the wire and seeds each one's metadata policy to
+ *    `allowedTools: ["acp_spawn"]` so the broker will later authorize the read.
+ *  - The READER (`acp/prepare-agent-env.ts`) reads these same fields through
+ *    the broker when injecting the agent's env.
+ *
+ * Before this module existed the field list and the per-field usage
+ * descriptions were declared TWICE — once on each side — with nothing enforcing
+ * that they stayed in lockstep. Hoisting them here makes the writer's
+ * allowlist/policy and the reader's resolution provably consistent. (The env-var
+ * mapping per field is reader-only, so it stays inline in prepare-agent-env.)
+ */
+
+/**
+ * The ONLY credential fields a client may link via `acp/credentials/link`,
+ * and the only `acp/<field>` secrets `prepare-agent-env.ts` reads through the
+ * broker. The link route is intentionally locked to this allowlist so the
+ * client-reachable surface can never write (or overwrite) an arbitrary
+ * `acp/*` secret outside the agent's needs.
+ */
+export const LINKABLE_ACP_FIELDS = [
+  "claude_oauth_token",
+  "anthropic_api_key",
+  "openai_api_key",
+  "git_token",
+] as const;
+
+export type LinkableAcpField = (typeof LINKABLE_ACP_FIELDS)[number];
+
+/**
+ * Human-readable usage description stored on each field's credential metadata
+ * (`usageDescription`). Surfaced in audit logs and in the credentials UI so a
+ * user can see why an `acp/<field>` secret is held.
+ */
+export const LINKABLE_FIELD_DESCRIPTIONS: Record<LinkableAcpField, string> = {
+  claude_oauth_token: "Claude OAuth token for ACP agent authentication",
+  anthropic_api_key: "Anthropic API key for ACP agent authentication",
+  openai_api_key: "OpenAI/Codex API key for ACP agent authentication",
+  git_token: "Git token for ACP agent clone/push",
+};

--- a/assistant/src/acp/prepare-agent-env.ts
+++ b/assistant/src/acp/prepare-agent-env.ts
@@ -30,6 +30,7 @@ import {
   upsertCredentialMetadata,
 } from "../tools/credentials/metadata-store.js";
 import { getLogger } from "../util/logger.js";
+import { LINKABLE_FIELD_DESCRIPTIONS } from "./credential-fields.js";
 import type { AcpAgentConfig } from "./types.js";
 
 /**
@@ -71,26 +72,31 @@ function ensureAcpTokenPolicy(field: string, usageDescription: string): void {
 }
 
 /**
- * Resolve a broker-stored `acp/<field>` credential into `env[envVar]` unless
- * the caller already supplied it via `agent.env`. Mirrors the OAuth-token
- * resolution: seed the read policy, then read through the broker (which only
- * runs `execute` on a successful, policy-allowed read). config.json overrides
- * always win, so we never clobber an explicit user-supplied value.
+ * Resolve a broker-stored `acp/<field>` credential into one or more env vars
+ * unless the caller already supplied any of them via `agent.env`. Mirrors the
+ * OAuth-token resolution: seed the read policy, then read through the broker
+ * (which only runs `execute` on a successful, policy-allowed read). config.json
+ * overrides always win, so we never clobber an explicit user-supplied value.
+ *
+ * `envVars` is a list so a single vault value can populate every var an adapter
+ * accepts — e.g. codex reads its API key from BOTH `OPENAI_API_KEY` and
+ * `CODEX_API_KEY`, so one `acp/openai_api_key` read fills both. The usage
+ * description seeded into the field's metadata is read from the shared
+ * single-source field map so the writer (link route) and this reader agree.
  */
 async function resolveAcpCredential(
   env: Record<string, string>,
-  envVar: string,
-  field: string,
-  usageDescription: string,
+  envVars: string[],
+  field: keyof typeof LINKABLE_FIELD_DESCRIPTIONS,
 ): Promise<void> {
-  if (env[envVar]) return;
-  ensureAcpTokenPolicy(field, usageDescription);
+  if (envVars.some((v) => env[v])) return;
+  ensureAcpTokenPolicy(field, LINKABLE_FIELD_DESCRIPTIONS[field]);
   await credentialBroker.serverUse<void>({
     service: "acp",
     field,
     toolName: ACP_SPAWN_TOOL,
     execute: async (value) => {
-      env[envVar] = value;
+      for (const envVar of envVars) env[envVar] = value;
     },
   });
 }
@@ -125,17 +131,11 @@ async function resolveLlmCredential(
   // (2) Vault: prefer the OAuth token, fall back to an Anthropic API key.
   await resolveAcpCredential(
     env,
-    "CLAUDE_CODE_OAUTH_TOKEN",
+    ["CLAUDE_CODE_OAUTH_TOKEN"],
     "claude_oauth_token",
-    "Claude OAuth token for ACP agent authentication",
   );
   if (!env.CLAUDE_CODE_OAUTH_TOKEN) {
-    await resolveAcpCredential(
-      env,
-      "ANTHROPIC_API_KEY",
-      "anthropic_api_key",
-      "Anthropic API key for ACP agent authentication",
-    );
+    await resolveAcpCredential(env, ["ANTHROPIC_API_KEY"], "anthropic_api_key");
   }
   if (env.CLAUDE_CODE_OAUTH_TOKEN || env.ANTHROPIC_API_KEY) return;
 
@@ -153,6 +153,50 @@ async function resolveLlmCredential(
 }
 
 /**
+ * Resolve the optional git/dev credential and wire it up so the agent can both
+ * run the `gh` CLI AND `git clone/push` over plain HTTPS. Applies to EVERY
+ * adapter (claude-agent-acp, codex-acp, …) — any agent with a linked git token
+ * should be able to clone and push. Never required: if no token resolves we
+ * inject nothing and the spawn proceeds (the agent simply has no git auth).
+ *
+ * Two pieces are needed because `GH_TOKEN` alone does NOT authenticate a plain
+ * `git` invocation — it only helps the `gh` CLI:
+ *  1. `GH_TOKEN` for the `gh` CLI.
+ *  2. A pure-env git config (no files written) that rewrites GitHub HTTPS URLs
+ *     to embed the token, so `git clone https://github.com/...` and `git push`
+ *     authenticate transparently. Git reads ad-hoc config from
+ *     `GIT_CONFIG_COUNT` + `GIT_CONFIG_KEY_<n>` / `GIT_CONFIG_VALUE_<n>`, so we
+ *     append an `url.<authed>.insteadOf = https://github.com/` entry.
+ *
+ * The injected vars (`GH_TOKEN`, `GIT_CONFIG_COUNT`, `GIT_CONFIG_KEY_*`,
+ * `GIT_CONFIG_VALUE_*`) are NOT in F1's spawn-env strip sets
+ * (`ACP_STRIPPED_SECRET_ENV_VARS` / `ACP_STRIPPED_CONTROL_PLANE_ENV_VARS` in
+ * `tools/terminal/safe-env.ts`), and `prepare-agent-env`'s returned `config.env`
+ * is applied LAST in `buildAgentSpawnEnv`, so they survive into the subprocess.
+ *
+ * If `GIT_CONFIG_COUNT` is already set (by an `acp.agents.<id>.env` override or
+ * an earlier injection), we APPEND at the next index rather than clobbering, so
+ * the user's own ad-hoc git config entries are preserved.
+ */
+async function resolveGitCredential(
+  env: Record<string, string>,
+): Promise<void> {
+  await resolveAcpCredential(env, ["GH_TOKEN"], "git_token");
+  const token = env.GH_TOKEN;
+  if (!token) return;
+
+  // Append a git URL-rewrite entry so plain HTTPS git operations authenticate.
+  // Parse any existing count defensively — a non-numeric value means we start
+  // fresh rather than produce a NaN index that git would ignore.
+  const existing = Number.parseInt(env.GIT_CONFIG_COUNT ?? "", 10);
+  const base = Number.isInteger(existing) && existing > 0 ? existing : 0;
+  env.GIT_CONFIG_COUNT = String(base + 1);
+  env[`GIT_CONFIG_KEY_${base}`] =
+    `url.https://x-access-token:${token}@github.com/.insteadOf`;
+  env[`GIT_CONFIG_VALUE_${base}`] = "https://github.com/";
+}
+
+/**
  * Returns a NEW config with any required credentials merged into `env`.
  * Does NOT mutate the input. Throws `FailedDependencyError` if a required
  * credential is missing from the user-supplied env override, the secure
@@ -162,8 +206,7 @@ async function resolveLlmCredential(
  * user-facing agent id, so a custom `acp.agents.my-claude = { command:
  * "claude-agent-acp", ... }` alias still gets the env it needs.
  *
- * For `claude-agent-acp` the agent needs ONE of two LLM credentials, plus
- * an optional git/dev credential so it can clone/push.
+ * For `claude-agent-acp` the agent needs ONE of two LLM credentials:
  *   1. LLM auth — `CLAUDE_CODE_OAUTH_TOKEN` (preferred) OR `ANTHROPIC_API_KEY`,
  *      resolved by precedence: explicit `acp.agents.<id>.env` in `config.json`
  *      wins, then the secure store (`acp/claude_oauth_token` /
@@ -172,8 +215,6 @@ async function resolveLlmCredential(
  *      inject a competing one over it (the adapter prefers OAuth when both are
  *      set, so an explicit API key must not be shadowed by a vault/ambient
  *      OAuth token — and vice versa).
- *   2. Git auth (optional) — `GH_TOKEN` from `acp.agents.<id>.env` or the
- *      secure store (`acp/git_token`). Injected when present; never required.
  * After resolution, this asserts at least one LLM credential is present
  * before spawning. The "fail-fast" throw is symmetric with the existing
  * `binary_not_found` preflight in `resolveAcpAgent` and strictly better
@@ -217,6 +258,13 @@ async function resolveLlmCredential(
  *     `codex login`), so the spawn must be allowed to proceed without us
  *     forcing any `OPENAI_API_KEY`/`CODEX_API_KEY`. We inject nothing extra
  *     and let the adapter read its own auth state.
+ *
+ * For BOTH adapters, an OPTIONAL git/dev credential is resolved last so the
+ * agent can clone/push: `GH_TOKEN` from `acp.agents.<id>.env` or the secure
+ * store (`acp/git_token`). When present we also set the `GIT_CONFIG_*`
+ * URL-rewrite env vars so plain `git clone/push` over HTTPS authenticates (a
+ * bare `GH_TOKEN` only covers the `gh` CLI). Never required — a missing git
+ * token leaves the env untouched. See {@link resolveGitCredential}.
  */
 export async function prepareAgentEnv(
   agentConfig: AcpAgentConfig,
@@ -237,36 +285,19 @@ export async function prepareAgentEnv(
           "(or --field anthropic_api_key <key>), or set it under acp.agents.<id>.env in config.json.",
       );
     }
-
-    // Git auth (optional): inject when present so the agent can clone/push.
-    await resolveAcpCredential(
-      env,
-      "GH_TOKEN",
-      "git_token",
-      "Git token for ACP agent clone/push",
-    );
   }
 
   if (commandBasename === "codex-acp") {
     // The codex-acp adapter shells out to the `codex` CLI, which accepts the
     // user's OpenAI/Codex API key via either CODEX_API_KEY or OPENAI_API_KEY.
     // A config.json env override (under either var) wins over the vault, so
-    // explicit per-workspace/rotated keys are never silently clobbered.
-    if (!env.OPENAI_API_KEY && !env.CODEX_API_KEY) {
-      ensureAcpTokenPolicy(
-        "openai_api_key",
-        "OpenAI/Codex API key for codex-acp agent authentication",
-      );
-      await credentialBroker.serverUse<void>({
-        service: "acp",
-        field: "openai_api_key",
-        toolName: ACP_SPAWN_TOOL,
-        execute: async (key) => {
-          env.OPENAI_API_KEY = key;
-          env.CODEX_API_KEY = key;
-        },
-      });
-    }
+    // explicit per-workspace/rotated keys are never silently clobbered. One
+    // vault `acp/openai_api_key` read fills BOTH vars (shared helper).
+    await resolveAcpCredential(
+      env,
+      ["OPENAI_API_KEY", "CODEX_API_KEY"],
+      "openai_api_key",
+    );
     if (!env.OPENAI_API_KEY && !env.CODEX_API_KEY && !getIsPlatform()) {
       // Lowest-precedence fallback: the daemon's ambient process.env. This is
       // LOCAL-ONLY (non-platform). On platform-hosted pods the daemon's
@@ -313,6 +344,11 @@ export async function prepareAgentEnv(
       );
     }
   }
+
+  // Git auth (optional): inject for ANY adapter so the agent can both run the
+  // `gh` CLI and `git clone/push` over HTTPS. Resolved after the LLM creds and
+  // never required — a missing git token leaves the env untouched.
+  await resolveGitCredential(env);
 
   return { ...agentConfig, env };
 }

--- a/assistant/src/runtime/routes/acp-routes.test.ts
+++ b/assistant/src/runtime/routes/acp-routes.test.ts
@@ -238,8 +238,29 @@ function getContinueHandler() {
   return route.handler;
 }
 
+/** Seed an in-memory session state so the continue route's getStatus + the
+ * delete-route status checks resolve it. */
+function seedInMemoryState(
+  id: string,
+  status: AcpSessionState["status"],
+): void {
+  inMemoryStates.set(id, {
+    id,
+    agentId: "claude",
+    acpSessionId: `proto-${id}`,
+    parentConversationId: "conv-1",
+    status,
+    startedAt: 1,
+  });
+}
+
 describe("POST /v1/acp/continue", () => {
+  beforeEach(() => {
+    inMemoryStates.clear();
+  });
+
   test("explicit acpSessionId: follow-up reaches that session via steer", async () => {
+    seedInMemoryState("acp-123", "idle");
     const handler = getContinueHandler();
     const result = (await handler({
       body: { acpSessionId: "acp-123", instruction: "now add tests" },
@@ -293,12 +314,50 @@ describe("POST /v1/acp/continue", () => {
     expect(steerCalls).toEqual([]);
   });
 
-  test("closed/non-existent session: steer rejection maps to 404", async () => {
+  test("explicit unknown session id: getStatus miss maps to 404 without steering", async () => {
+    // Not seeded → getStatus throws → 404, and steer is never reached.
+    const handler = getContinueHandler();
+    await expect(
+      handler({ body: { acpSessionId: "acp-gone", instruction: "go" } }),
+    ).rejects.toThrow("ACP session not found or not reusable");
+    expect(steerCalls).toEqual([]);
+  });
+
+  test("closed/non-reusable session: steer rejection maps to 404", async () => {
+    // Resolves as idle via getStatus, but steer rejects (adapter torn down
+    // between the status read and the steer).
+    seedInMemoryState("acp-gone", "idle");
     steerShouldThrow = true;
     const handler = getContinueHandler();
     await expect(
       handler({ body: { acpSessionId: "acp-gone", instruction: "go" } }),
     ).rejects.toThrow("ACP session not found or not reusable");
+  });
+
+  test("explicit running session: rejects with 409 and does NOT steer", async () => {
+    seedInMemoryState("acp-busy", "running");
+    const handler = getContinueHandler();
+    await expect(
+      handler({ body: { acpSessionId: "acp-busy", instruction: "also do X" } }),
+    ).rejects.toThrow("is busy");
+    // The in-flight prompt is preserved — steer was never called.
+    expect(steerCalls).toEqual([]);
+  });
+
+  test("conversation-resolved running session: rejects with 409 and does NOT steer", async () => {
+    liveByConversation.set("conv-busy", {
+      id: "acp-live-busy",
+      agentId: "claude",
+      acpSessionId: "proto-live-busy",
+      parentConversationId: "conv-busy",
+      status: "running",
+      startedAt: 1,
+    });
+    const handler = getContinueHandler();
+    await expect(
+      handler({ body: { conversationId: "conv-busy", instruction: "go" } }),
+    ).rejects.toThrow("is busy");
+    expect(steerCalls).toEqual([]);
   });
 });
 

--- a/assistant/src/runtime/routes/acp-routes.ts
+++ b/assistant/src/runtime/routes/acp-routes.ts
@@ -9,6 +9,11 @@ import { z } from "zod";
 
 import { getAcpSessionManager } from "../../acp/index.js";
 import {
+  LINKABLE_ACP_FIELDS,
+  LINKABLE_FIELD_DESCRIPTIONS,
+  type LinkableAcpField,
+} from "../../acp/credential-fields.js";
+import {
   ACP_SPAWN_TOOL,
   prepareAgentEnv,
 } from "../../acp/prepare-agent-env.js";
@@ -48,29 +53,6 @@ const MAX_SESSION_LIMIT = 500;
 
 /** Service namespace under which all linked ACP credentials are stored. */
 const ACP_CREDENTIAL_SERVICE = "acp";
-
-/**
- * The ONLY credential fields a client may link via `acp/credentials/link`.
- * These are the BYO secrets `prepare-agent-env.ts` reads through the broker
- * when spawning a per-user agent on a hosted pod. The route is intentionally
- * locked to this allowlist so the client-reachable surface can never write
- * (or overwrite) an arbitrary `acp/*` secret outside the agent's needs.
- */
-const LINKABLE_ACP_FIELDS = [
-  "claude_oauth_token",
-  "anthropic_api_key",
-  "openai_api_key",
-  "git_token",
-] as const;
-
-type LinkableAcpField = (typeof LINKABLE_ACP_FIELDS)[number];
-
-const LINKABLE_FIELD_DESCRIPTIONS: Record<LinkableAcpField, string> = {
-  claude_oauth_token: "Claude OAuth token for ACP agent authentication",
-  anthropic_api_key: "Anthropic API key for ACP agent authentication",
-  openai_api_key: "OpenAI API key for ACP agent authentication",
-  git_token: "Git access token for ACP agent repository operations",
-};
 
 const sessionEntrySchema = z.object({
   id: z.string(),
@@ -241,6 +223,12 @@ async function steerSession({ pathParams, body }: RouteHandlerArgs) {
  * `acpSessionId` when provided, otherwise from the conversation's most-recent
  * live session via `getLiveSessionForConversation`. A closed / non-existent
  * session errors cleanly with a 404 RouteError — never a crash.
+ *
+ * A session whose prompt is still in flight (`running`/`initializing`) is
+ * rejected with a 409 ConflictError rather than steered: `manager.steer`'s
+ * running-session path CANCELS the in-flight prompt, so continuing a busy
+ * session would abort the in-progress task. Only an idle (or otherwise
+ * non-running live) session is continued.
  */
 async function continueSession({ body }: RouteHandlerArgs) {
   const instruction = body?.instruction as string | undefined;
@@ -257,7 +245,18 @@ async function continueSession({ body }: RouteHandlerArgs) {
   const manager = getAcpSessionManager();
 
   let acpSessionId = explicitId;
-  if (!acpSessionId) {
+  // The resolved target's live status. For the conversation path
+  // `getLiveSessionForConversation` already carries it; for an explicit id we
+  // read it via `getStatus` (which throws for unknown ids — that maps to 404).
+  let status: AcpSessionState["status"] | undefined;
+  if (acpSessionId) {
+    try {
+      const state = manager.getStatus(acpSessionId);
+      if (!Array.isArray(state)) status = state.status;
+    } catch {
+      throw new NotFoundError("ACP session not found or not reusable");
+    }
+  } else {
     const live = manager.getLiveSessionForConversation(conversationId!);
     if (!live) {
       throw new NotFoundError(
@@ -265,6 +264,17 @@ async function continueSession({ body }: RouteHandlerArgs) {
       );
     }
     acpSessionId = live.id;
+    status = live.status;
+  }
+
+  // Never steer a session with a prompt in flight: `manager.steer`'s
+  // running-session path CANCELS the in-flight prompt, so a follow-up like
+  // "also do X" would abort in-progress work. Reject cleanly and let the
+  // caller wait for the current task to finish (or cancel it deliberately).
+  if (status === "running" || status === "initializing") {
+    throw new ConflictError(
+      `ACP session "${acpSessionId}" is busy (${status}); wait for the current task to finish before continuing.`,
+    );
   }
 
   try {
@@ -470,11 +480,12 @@ export const ROUTES: RouteDefinition[] = [
     handler: continueSession,
     summary: "Continue ACP session",
     description:
-      "Send a follow-up turn to an existing live (running/idle) ACP session " +
-      "so the agent builds on the same context and workspace. Resolve the " +
-      "target by explicit acpSessionId, or by the conversation's most-recent " +
-      "live session via conversationId. Errors cleanly (404) for a closed or " +
-      "non-existent session.",
+      "Send a follow-up turn to an existing idle ACP session so the agent " +
+      "builds on the same context and workspace. Resolve the target by " +
+      "explicit acpSessionId, or by the conversation's most-recent live " +
+      "session via conversationId. Errors cleanly (404) for a closed or " +
+      "non-existent session, and (409) when the session is busy with a " +
+      "prompt still in flight.",
     tags: ["acp"],
     requestBody: z.object({
       instruction: z.string().describe("The follow-up task for this turn"),

--- a/assistant/src/tools/acp/continue.test.ts
+++ b/assistant/src/tools/acp/continue.test.ts
@@ -20,6 +20,11 @@ let steerImpl: (acpSessionId: string, instruction: string) => Promise<void> =
 let liveSession: AcpSessionState | null = null;
 const liveLookups: string[] = [];
 
+// In-memory session state keyed by id, used by the explicit-id path's
+// getStatus lookup. Absent → getStatus throws (unknown session), mirroring the
+// real manager. Default status for a seeded entry is `idle`.
+const statesById = new Map<string, AcpSessionState>();
+
 // Spread the real module's exports so transitive importers that pull other
 // names from `../../acp/index.js` still resolve at parse time. Bun's
 // `mock.module` is process-global and returns *exactly* the factory's keys.
@@ -32,6 +37,12 @@ mock.module("../../acp/index.js", () => ({
     getLiveSessionForConversation: (conversationId: string) => {
       liveLookups.push(conversationId);
       return liveSession;
+    },
+    getStatus: (id?: string) => {
+      if (id === undefined) return Array.from(statesById.values());
+      const state = statesById.get(id);
+      if (!state) throw new Error(`ACP session "${id}" not found`);
+      return state;
     },
   }),
 }));
@@ -46,15 +57,23 @@ function makeContext(): ToolContext {
   };
 }
 
-function makeLive(id: string): AcpSessionState {
+function makeLive(
+  id: string,
+  status: AcpSessionState["status"] = "idle",
+): AcpSessionState {
   return {
     id,
     agentId: "claude",
     acpSessionId: `proto-${id}`,
     parentConversationId: "conv-test",
-    status: "idle",
+    status,
     startedAt: 1,
   };
+}
+
+/** Seed an in-memory state for the explicit-id getStatus path. */
+function seedState(id: string, status: AcpSessionState["status"] = "idle") {
+  statesById.set(id, makeLive(id, status));
 }
 
 beforeEach(() => {
@@ -62,10 +81,12 @@ beforeEach(() => {
   liveLookups.length = 0;
   steerImpl = defaultSteer;
   liveSession = null;
+  statesById.clear();
 });
 
 describe("executeAcpContinue", () => {
   test("explicit acp_session_id: reaches the same session via manager.steer", async () => {
+    seedState("acp-123", "idle");
     const result = await executeAcpContinue(
       { acp_session_id: "acp-123", instruction: "now also add tests" },
       makeContext(),
@@ -122,7 +143,24 @@ describe("executeAcpContinue", () => {
     expect(steerCalls).toEqual([]);
   });
 
-  test("closed/non-existent session: manager.steer rejection surfaces cleanly", async () => {
+  test("explicit unknown session id: getStatus miss surfaces cleanly without steering", async () => {
+    // Not seeded → getStatus throws → clean isError, and we never call steer
+    // (so a non-existent id can't fall through to the cancel path).
+    const result = await executeAcpContinue(
+      { acp_session_id: "acp-x", instruction: "continue" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Could not continue ACP session "acp-x"');
+    expect(result.content).toContain("not found or not reusable");
+    expect(steerCalls).toEqual([]);
+  });
+
+  test("closed/non-reusable session: manager.steer rejection surfaces cleanly", async () => {
+    // Session resolves as idle via getStatus but steer rejects (e.g. the
+    // adapter tore down between the status read and the steer).
+    seedState("acp-x", "idle");
     steerImpl = () =>
       Promise.reject(new Error('ACP session "acp-x" not found'));
 
@@ -134,5 +172,47 @@ describe("executeAcpContinue", () => {
     expect(result.isError).toBe(true);
     expect(result.content).toContain('Could not continue ACP session "acp-x"');
     expect(result.content).toContain("not found");
+  });
+
+  test("explicit running session: refuses to steer (would cancel the in-flight prompt)", async () => {
+    seedState("acp-busy", "running");
+
+    const result = await executeAcpContinue(
+      { acp_session_id: "acp-busy", instruction: "also do X" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("is busy");
+    expect(result.content).toContain("running");
+    // Critically, steer was NOT called — the in-flight prompt is preserved.
+    expect(steerCalls).toEqual([]);
+  });
+
+  test("conversation-resolved running session: refuses to steer", async () => {
+    liveSession = makeLive("acp-live-busy", "running");
+
+    const result = await executeAcpContinue(
+      { instruction: "also do X" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("is busy");
+    expect(steerCalls).toEqual([]);
+  });
+
+  test("idle session resolved from the conversation continues normally", async () => {
+    liveSession = makeLive("acp-live-idle", "idle");
+
+    const result = await executeAcpContinue(
+      { instruction: "keep going" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(steerCalls).toEqual([
+      { acpSessionId: "acp-live-idle", instruction: "keep going" },
+    ]);
   });
 });

--- a/assistant/src/tools/acp/continue.ts
+++ b/assistant/src/tools/acp/continue.ts
@@ -1,4 +1,5 @@
 import { getAcpSessionManager } from "../../acp/index.js";
+import type { AcpSessionState } from "../../acp/types.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
 
 /**
@@ -19,6 +20,12 @@ import type { ToolContext, ToolExecutionResult } from "../types.js";
  * Closed / non-existent sessions error cleanly (isError), never crash — either
  * because no live session exists for the conversation or because
  * `manager.steer` rejects for an unknown / non-reusable session id.
+ *
+ * A session whose prompt is still in flight (`running`/`initializing`) is
+ * refused with a clean `isError` result rather than steered: `manager.steer`'s
+ * running-session path CANCELS the in-flight prompt, so continuing a busy
+ * session would abort the in-progress task. Only an idle (or otherwise
+ * non-running live) session is continued.
  */
 export async function executeAcpContinue(
   input: Record<string, unknown>,
@@ -32,9 +39,26 @@ export async function executeAcpContinue(
   const manager = getAcpSessionManager();
 
   // Resolve the target session: an explicit id wins; otherwise fall back to
-  // the conversation's most-recent live (running/idle) session.
+  // the conversation's most-recent live (running/idle) session. Capture the
+  // resolved session's live status so we can refuse to continue one whose
+  // prompt is still in flight (see the busy guard below).
   let acpSessionId = input.acp_session_id as string | undefined;
-  if (!acpSessionId) {
+  let status: AcpSessionState["status"] | undefined;
+  if (acpSessionId) {
+    try {
+      const state = manager.getStatus(acpSessionId);
+      if (!Array.isArray(state)) status = state.status;
+    } catch {
+      // Unknown / closed session id — surface the same clean error the steer
+      // rejection path produces below.
+      return {
+        content:
+          `Could not continue ACP session "${acpSessionId}": ` +
+          "session not found or not reusable.",
+        isError: true,
+      };
+    }
+  } else {
     const live = manager.getLiveSessionForConversation(context.conversationId);
     if (!live) {
       return {
@@ -45,6 +69,19 @@ export async function executeAcpContinue(
       };
     }
     acpSessionId = live.id;
+    status = live.status;
+  }
+
+  // A prompt is still in flight: `manager.steer`'s running-session path would
+  // CANCEL it, so a follow-up like "also do X" would abort in-progress work.
+  // Refuse cleanly and let the caller wait for the current task to finish.
+  if (status === "running" || status === "initializing") {
+    return {
+      content:
+        `ACP session "${acpSessionId}" is busy (${status}); wait for the ` +
+        "current task to finish before continuing.",
+      isError: true,
+    };
   }
 
   try {


### PR DESCRIPTION
## Summary
Self-review remediation for acp-platform-hosted:
- Inject the git token for BOTH claude-agent-acp and codex-acp, and configure GIT_CONFIG_* URL-rewrite so plain git clone/push over HTTPS authenticates (not just the gh CLI).
- Single shared source for linkable ACP credential fields + descriptions + acp_spawn policy, imported by both prepare-agent-env and the link route; resolveAcpCredential generalized for the codex two-var case.
- acp_continue returns a clean error for a running session instead of cancelling its in-flight prompt.

Part of plan: acp-platform-hosted.md (self-review fix)