### PR TITLE
fix(acp): idle eviction by idle-time + single-source acp_continue guard

### DIFF
--- a/assistant/src/acp/__tests__/session-manager-idle.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-idle.test.ts
@@ -446,6 +446,60 @@ describe("AcpSessionManager — idle sessions don't wedge the spawn limit", () =
     expect(readStatus(sessions[0]!.id)).toBe("completed");
   });
 
+  test("eviction reaps the LONGEST-idle session, not the oldest-started — a just-reused session is spared", async () => {
+    const max = 3;
+    const manager = new AcpSessionManager(max, 60_000);
+
+    // Fill the budget; drive each to idle. `sessions[0]` started first (oldest
+    // startedAt), `sessions[2]` started last.
+    const sessions: { id: string; fake: FakeSpawnedProcess }[] = [];
+    for (let i = 0; i < max; i++) {
+      const s = await spawnSession(manager, `/cwd-${i}`);
+      s.fake.resolvePrompt({ stopReason: "end_turn" });
+      await flush();
+      sessions.push(s);
+    }
+
+    // Reuse the OLDEST-started session (sessions[0]) via steer, then drive it
+    // back to idle. steer() refreshes its `lastActiveAt`, so although it has
+    // the oldest startedAt it is now the MOST-recently-active idle session.
+    await manager.steer(sessions[0]!.id, "follow-up turn");
+    expect((manager.getStatus(sessions[0]!.id) as { status: string }).status)
+      .toBe("running");
+    sessions[0]!.fake.resolvePrompt({ stopReason: "end_turn" });
+    await flush();
+    expect((manager.getStatus(sessions[0]!.id) as { status: string }).status)
+      .toBe("idle");
+
+    // Make the relative idle ordering deterministic regardless of wall-clock
+    // resolution: sessions[1] has been idle the LONGEST, sessions[0] (just
+    // reused) the shortest. Stamp `lastActiveAt` directly on the entries.
+    const sessionMap = (
+      manager as unknown as {
+        sessions: Map<string, { lastActiveAt: number }>;
+      }
+    ).sessions;
+    sessionMap.get(sessions[1]!.id)!.lastActiveAt = 1_000;
+    sessionMap.get(sessions[2]!.id)!.lastActiveAt = 2_000;
+    sessionMap.get(sessions[0]!.id)!.lastActiveAt = 3_000;
+
+    // The (N+1)th spawn must reap the LONGEST-idle session (sessions[1]),
+    // NOT the oldest-started one (sessions[0], which was just reused).
+    const extra = await spawnSession(manager, "/cwd-new");
+    expect(extra.id).toBeTruthy();
+
+    expect(sessions[1]!.fake.killed).toBe(true);
+    expect(() => manager.getStatus(sessions[1]!.id)).toThrow();
+
+    // The just-reused oldest-started session and the other idle one survive.
+    expect(sessions[0]!.fake.killed).toBe(false);
+    expect(sessions[2]!.fake.killed).toBe(false);
+    expect((manager.getStatus(sessions[0]!.id) as { status: string }).status)
+      .toBe("idle");
+
+    expect((manager.getStatus() as unknown[]).length).toBe(max);
+  });
+
   test("a genuinely RUNNING session still counts toward the limit (no idle to reap → reject)", async () => {
     const max = 2;
     const manager = new AcpSessionManager(max, 60_000);

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -20,6 +20,42 @@ import type { AcpAgentConfig, AcpSessionState } from "./types.js";
 
 const log = getLogger("acp:session-manager");
 
+/**
+ * Thrown by {@link AcpSessionManager.continueSession} when the resolved target
+ * session has a prompt still in flight (`running`/`initializing`). Continuing
+ * such a session would route through `steer()`'s cancel-on-running path and
+ * abort the in-progress task, so the manager rejects it and lets callers
+ * translate to their wire format (tool → isError, route → 409). Distinct from
+ * the generic not-found `Error` so callers can map it to the right status.
+ */
+export class SessionBusyError extends Error {
+  readonly acpSessionId: string;
+  readonly sessionStatus: "running" | "initializing";
+
+  constructor(acpSessionId: string, status: "running" | "initializing") {
+    super(
+      `ACP session "${acpSessionId}" is busy (${status}); wait for the ` +
+        "current task to finish before continuing.",
+    );
+    this.name = "SessionBusyError";
+    this.acpSessionId = acpSessionId;
+    this.sessionStatus = status;
+  }
+}
+
+/**
+ * Thrown by {@link AcpSessionManager.continueSession} when the continue target
+ * cannot be resolved — an unknown/closed explicit id, or no live session for
+ * the conversation. Distinct from {@link SessionBusyError} so callers map it to
+ * not-found (tool → isError, route → 404) rather than busy.
+ */
+export class SessionNotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SessionNotFoundError";
+  }
+}
+
 /** Maximum number of update events kept in a session's ring buffer. */
 const MAX_BUFFER_EVENTS = 200;
 /** Maximum aggregate JSON size of a session's ring buffer, in bytes. */
@@ -56,6 +92,15 @@ interface SessionEntry {
    * follow-up prompt starts or the session is torn down.
    */
   idleTimer: ReturnType<typeof setTimeout> | null;
+  /**
+   * Timestamp (epoch ms) of the session's most recent activity boundary —
+   * stamped whenever the session transitions to `idle` (a prompt completed)
+   * and refreshed on every `steer()` reuse. Unlike `state.startedAt` (set once
+   * at creation, never updated), this reflects *recency of use*, so the idle
+   * eviction picker can reap the session that has actually sat idle the
+   * longest instead of the one with the oldest start time.
+   */
+  lastActiveAt: number;
   /**
    * Whether a terminal `acp_session_history` row has already been written
    * for this session's last completed task. Set when a prompt completes and
@@ -223,6 +268,7 @@ export class AcpSessionManager {
       cwd,
       command: agentConfig.command,
       idleTimer: null,
+      lastActiveAt: Date.now(),
       historyPersisted: false,
       turnIndex: 0,
     };
@@ -297,6 +343,9 @@ export class AcpSessionManager {
 
     // Disarm the idle reaper — the session is being reused.
     this.clearIdleTimer(entry);
+    // Mark the session freshly active so a just-reused session is treated as
+    // recently active (not stale) by the idle eviction picker.
+    entry.lastActiveAt = Date.now();
 
     // Cancel any in-flight prompt before starting a new one.
     // Clear currentPrompt BEFORE awaiting cancel so the old prompt's
@@ -337,6 +386,78 @@ export class AcpSessionManager {
   }
 
   /**
+   * Single source of truth for the `acp_continue` flow (used by both the
+   * `acp_continue` tool and the `POST /v1/acp/continue` route): resolve the
+   * target session, refuse one whose prompt is still in flight, and otherwise
+   * steer a follow-up turn onto it.
+   *
+   * Targeting resolves an explicit `acpSessionId` (via `getStatus`) when given,
+   * otherwise the conversation's most-recent live session (via
+   * `getLiveSessionForConversation`).
+   *
+   * Rejection semantics — distinct from `steer()`, whose cancel-on-running
+   * behavior `acp_steer` deliberately keeps:
+   *  - {@link SessionNotFoundError}: unknown/closed explicit id, or no live
+   *    session for the conversation, or a steer that rejects (adapter torn down
+   *    between the status read and the steer).
+   *  - {@link SessionBusyError}: the resolved session is `running`/
+   *    `initializing` — continuing it would abort the in-flight task.
+   *
+   * Returns the resolved `acpSessionId` on success so callers can echo it.
+   */
+  async continueSession(opts: {
+    acpSessionId?: string;
+    parentConversationId?: string;
+    instruction: string;
+  }): Promise<{ acpSessionId: string }> {
+    let acpSessionId = opts.acpSessionId;
+    let status: AcpSessionState["status"] | undefined;
+
+    if (acpSessionId) {
+      let state: AcpSessionState | AcpSessionState[];
+      try {
+        state = this.getStatus(acpSessionId);
+      } catch {
+        throw new SessionNotFoundError(
+          `ACP session "${acpSessionId}" not found or not reusable.`,
+        );
+      }
+      if (!Array.isArray(state)) status = state.status;
+    } else if (opts.parentConversationId) {
+      const live = this.getLiveSessionForConversation(
+        opts.parentConversationId,
+      );
+      if (!live) {
+        throw new SessionNotFoundError(
+          "No live ACP session to continue for this conversation.",
+        );
+      }
+      acpSessionId = live.id;
+      status = live.status;
+    } else {
+      throw new SessionNotFoundError(
+        "No live ACP session to continue for this conversation.",
+      );
+    }
+
+    // A prompt is still in flight: steering would CANCEL it, aborting the
+    // in-progress task. Refuse cleanly and let the caller wait.
+    if (status === "running" || status === "initializing") {
+      throw new SessionBusyError(acpSessionId!, status);
+    }
+
+    try {
+      await this.steer(acpSessionId!, opts.instruction);
+    } catch (err) {
+      throw new SessionNotFoundError(
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+
+    return { acpSessionId: acpSessionId! };
+  }
+
+  /**
    * Returns the live (non-terminal: running or idle) session attached to a
    * conversation, if any. Used to reattach a follow-up prompt to an existing
    * session for multi-turn continuity (PR E2). Returns the most recently
@@ -359,18 +480,22 @@ export class AcpSessionManager {
   }
 
   /**
-   * Returns the acpSessionId of the least-recently-started `idle` session, or
-   * null if none are idle. Used to free a concurrency slot when a new spawn
-   * hits the limit: idle sessions have no in-flight prompt, so reaping the
-   * oldest one is the least-disruptive way to make room.
+   * Returns the acpSessionId of the `idle` session that has sat idle the
+   * LONGEST (smallest `lastActiveAt`), or null if none are idle. Used to free a
+   * concurrency slot when a new spawn hits the limit: idle sessions have no
+   * in-flight prompt, so reaping the least-recently-active one is the
+   * least-disruptive way to make room. Keyed on `lastActiveAt` (refreshed on
+   * every steer reuse) rather than `state.startedAt` (set once at creation), so
+   * a just-reused session is not reaped before one that has actually been idle
+   * far longer.
    */
   private oldestIdleSession(): string | null {
     let bestId: string | null = null;
-    let bestStartedAt = Infinity;
+    let bestActiveAt = Infinity;
     for (const [id, entry] of this.sessions) {
       if (entry.state.status !== "idle") continue;
-      if (entry.state.startedAt < bestStartedAt) {
-        bestStartedAt = entry.state.startedAt;
+      if (entry.lastActiveAt < bestActiveAt) {
+        bestActiveAt = entry.lastActiveAt;
         bestId = id;
       }
     }
@@ -652,6 +777,9 @@ export class AcpSessionManager {
             this.persistTerminal(acpSessionId, current);
             current.historyPersisted = true;
             current.state.status = "idle";
+            // Stamp the idle boundary so eviction reaps the longest-idle
+            // session, not the one with the oldest start time.
+            current.lastActiveAt = Date.now();
             this.armIdleTimer(acpSessionId, current);
           }
 

--- a/assistant/src/runtime/routes/acp-routes.test.ts
+++ b/assistant/src/runtime/routes/acp-routes.test.ts
@@ -36,6 +36,10 @@ import {
 import { installAcpConfigStub } from "../../acp/__tests__/helpers/acp-config-stub.js";
 import { installWhichStub } from "../../acp/__tests__/helpers/which-stub.js";
 import type { AcpSessionState } from "../../acp/index.js";
+import {
+  SessionBusyError,
+  SessionNotFoundError,
+} from "../../acp/session-manager.js";
 
 const config = await installAcpConfigStub();
 const which = installWhichStub();
@@ -79,8 +83,54 @@ let steerShouldThrow = false;
 // by conversation id; absent → null (no live session).
 const liveByConversation = new Map<string, AcpSessionState>();
 
+/**
+ * Faithful re-implementation of `AcpSessionManager.continueSession` over the
+ * route test's doubles. The `acp/continue` route now delegates the resolve +
+ * running-session guard to this shared helper, so the mock exercises the same
+ * control flow and throws the same typed errors the route maps to 409/404.
+ */
+async function fakeContinueSession(opts: {
+  acpSessionId?: string;
+  parentConversationId?: string;
+  instruction: string;
+}): Promise<{ acpSessionId: string }> {
+  let acpSessionId = opts.acpSessionId;
+  let status: AcpSessionState["status"] | undefined;
+  if (acpSessionId) {
+    const state = inMemoryStates.get(acpSessionId);
+    if (!state) {
+      throw new SessionNotFoundError(
+        `ACP session "${acpSessionId}" not found or not reusable.`,
+      );
+    }
+    status = state.status;
+  } else if (opts.parentConversationId) {
+    const live = liveByConversation.get(opts.parentConversationId) ?? null;
+    if (!live) {
+      throw new SessionNotFoundError(
+        "No live ACP session to continue for this conversation.",
+      );
+    }
+    acpSessionId = live.id;
+    status = live.status;
+  } else {
+    throw new SessionNotFoundError(
+      "No live ACP session to continue for this conversation.",
+    );
+  }
+  if (status === "running" || status === "initializing") {
+    throw new SessionBusyError(acpSessionId!, status);
+  }
+  if (steerShouldThrow) {
+    throw new SessionNotFoundError(`ACP session "${acpSessionId}" not found`);
+  }
+  steerCalls.push({ id: acpSessionId!, instruction: opts.instruction });
+  return { acpSessionId: acpSessionId! };
+}
+
 mock.module("../../acp/index.js", () => ({
   getAcpSessionManager: () => ({
+    continueSession: fakeContinueSession,
     steer: async (id: string, instruction: string) => {
       if (steerShouldThrow) throw new Error(`ACP session "${id}" not found`);
       steerCalls.push({ id, instruction });

--- a/assistant/src/runtime/routes/acp-routes.ts
+++ b/assistant/src/runtime/routes/acp-routes.ts
@@ -18,6 +18,10 @@ import {
   prepareAgentEnv,
 } from "../../acp/prepare-agent-env.js";
 import { resolveAcpAgent } from "../../acp/resolve-agent.js";
+import {
+  SessionBusyError,
+  SessionNotFoundError,
+} from "../../acp/session-manager.js";
 import type { AcpSessionState } from "../../acp/types.js";
 import { resolveAcpWorkspaceDir } from "../../acp/workspace-path.js";
 import { getDb } from "../../memory/db-connection.js";
@@ -244,45 +248,34 @@ async function continueSession({ body }: RouteHandlerArgs) {
 
   const manager = getAcpSessionManager();
 
-  let acpSessionId = explicitId;
-  // The resolved target's live status. For the conversation path
-  // `getLiveSessionForConversation` already carries it; for an explicit id we
-  // read it via `getStatus` (which throws for unknown ids — that maps to 404).
-  let status: AcpSessionState["status"] | undefined;
-  if (acpSessionId) {
-    try {
-      const state = manager.getStatus(acpSessionId);
-      if (!Array.isArray(state)) status = state.status;
-    } catch {
-      throw new NotFoundError("ACP session not found or not reusable");
+  // Resolution + the running-session rejection live in the shared
+  // `manager.continueSession` helper (single source of truth, also used by the
+  // `acp_continue` tool). The route only translates the typed outcome into the
+  // wire format: SessionBusyError → 409, SessionNotFoundError → 404.
+  try {
+    const { acpSessionId } = await manager.continueSession({
+      acpSessionId: explicitId,
+      parentConversationId: explicitId ? undefined : conversationId,
+      instruction,
+    });
+    return { acpSessionId, continued: true };
+  } catch (err) {
+    if (err instanceof SessionBusyError) {
+      throw new ConflictError(err.message);
     }
-  } else {
-    const live = manager.getLiveSessionForConversation(conversationId!);
-    if (!live) {
+    if (err instanceof SessionNotFoundError) {
+      // The conversation-resolution miss has its own message ("No live ACP
+      // session …"); the id-resolution / steer-rejection misses collapse to a
+      // single not-found string. Preserve the conversation message; flatten
+      // the rest.
       throw new NotFoundError(
-        "No live ACP session to continue for this conversation",
+        explicitId
+          ? "ACP session not found or not reusable"
+          : err.message,
       );
     }
-    acpSessionId = live.id;
-    status = live.status;
+    throw err;
   }
-
-  // Never steer a session with a prompt in flight: `manager.steer`'s
-  // running-session path CANCELS the in-flight prompt, so a follow-up like
-  // "also do X" would abort in-progress work. Reject cleanly and let the
-  // caller wait for the current task to finish (or cancel it deliberately).
-  if (status === "running" || status === "initializing") {
-    throw new ConflictError(
-      `ACP session "${acpSessionId}" is busy (${status}); wait for the current task to finish before continuing.`,
-    );
-  }
-
-  try {
-    await manager.steer(acpSessionId, instruction);
-  } catch {
-    throw new NotFoundError("ACP session not found or not reusable");
-  }
-  return { acpSessionId, continued: true };
 }
 
 async function cancelSession({ pathParams }: RouteHandlerArgs) {

--- a/assistant/src/tools/acp/continue.test.ts
+++ b/assistant/src/tools/acp/continue.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import {
+  SessionBusyError,
+  SessionNotFoundError,
+} from "../../acp/session-manager.js";
 import type { AcpSessionState } from "../../acp/types.js";
 import type { ToolContext } from "../types.js";
 
@@ -25,6 +29,54 @@ const liveLookups: string[] = [];
 // real manager. Default status for a seeded entry is `idle`.
 const statesById = new Map<string, AcpSessionState>();
 
+/**
+ * Faithful re-implementation of `AcpSessionManager.continueSession` over the
+ * test doubles (steer/getStatus/getLiveSessionForConversation). The tool now
+ * delegates the resolve + running-session guard to this shared helper, so the
+ * mock exercises the same control flow and throws the same typed errors.
+ */
+async function fakeContinueSession(opts: {
+  acpSessionId?: string;
+  parentConversationId?: string;
+  instruction: string;
+}): Promise<{ acpSessionId: string }> {
+  let acpSessionId = opts.acpSessionId;
+  let status: AcpSessionState["status"] | undefined;
+  if (acpSessionId) {
+    const state = statesById.get(acpSessionId);
+    if (!state) {
+      throw new SessionNotFoundError(
+        `ACP session "${acpSessionId}" not found or not reusable.`,
+      );
+    }
+    status = state.status;
+  } else if (opts.parentConversationId) {
+    liveLookups.push(opts.parentConversationId);
+    if (!liveSession) {
+      throw new SessionNotFoundError(
+        "No live ACP session to continue for this conversation.",
+      );
+    }
+    acpSessionId = liveSession.id;
+    status = liveSession.status;
+  } else {
+    throw new SessionNotFoundError(
+      "No live ACP session to continue for this conversation.",
+    );
+  }
+  if (status === "running" || status === "initializing") {
+    throw new SessionBusyError(acpSessionId!, status);
+  }
+  try {
+    await steerImpl(acpSessionId!, opts.instruction);
+  } catch (err) {
+    throw new SessionNotFoundError(
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+  return { acpSessionId: acpSessionId! };
+}
+
 // Spread the real module's exports so transitive importers that pull other
 // names from `../../acp/index.js` still resolve at parse time. Bun's
 // `mock.module` is process-global and returns *exactly* the factory's keys.
@@ -32,6 +84,7 @@ const realAcpModule = await import("../../acp/index.js");
 mock.module("../../acp/index.js", () => ({
   ...realAcpModule,
   getAcpSessionManager: () => ({
+    continueSession: fakeContinueSession,
     steer: (acpSessionId: string, instruction: string) =>
       steerImpl(acpSessionId, instruction),
     getLiveSessionForConversation: (conversationId: string) => {

--- a/assistant/src/tools/acp/continue.ts
+++ b/assistant/src/tools/acp/continue.ts
@@ -1,5 +1,5 @@
 import { getAcpSessionManager } from "../../acp/index.js";
-import type { AcpSessionState } from "../../acp/types.js";
+import { SessionBusyError } from "../../acp/session-manager.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
 
 /**
@@ -38,54 +38,16 @@ export async function executeAcpContinue(
 
   const manager = getAcpSessionManager();
 
-  // Resolve the target session: an explicit id wins; otherwise fall back to
-  // the conversation's most-recent live (running/idle) session. Capture the
-  // resolved session's live status so we can refuse to continue one whose
-  // prompt is still in flight (see the busy guard below).
-  let acpSessionId = input.acp_session_id as string | undefined;
-  let status: AcpSessionState["status"] | undefined;
-  if (acpSessionId) {
-    try {
-      const state = manager.getStatus(acpSessionId);
-      if (!Array.isArray(state)) status = state.status;
-    } catch {
-      // Unknown / closed session id — surface the same clean error the steer
-      // rejection path produces below.
-      return {
-        content:
-          `Could not continue ACP session "${acpSessionId}": ` +
-          "session not found or not reusable.",
-        isError: true,
-      };
-    }
-  } else {
-    const live = manager.getLiveSessionForConversation(context.conversationId);
-    if (!live) {
-      return {
-        content:
-          "No live ACP session to continue for this conversation. " +
-          "Spawn a fresh session with acp_spawn, or pass acp_session_id.",
-        isError: true,
-      };
-    }
-    acpSessionId = live.id;
-    status = live.status;
-  }
-
-  // A prompt is still in flight: `manager.steer`'s running-session path would
-  // CANCEL it, so a follow-up like "also do X" would abort in-progress work.
-  // Refuse cleanly and let the caller wait for the current task to finish.
-  if (status === "running" || status === "initializing") {
-    return {
-      content:
-        `ACP session "${acpSessionId}" is busy (${status}); wait for the ` +
-        "current task to finish before continuing.",
-      isError: true,
-    };
-  }
-
+  // Resolution + the running-session rejection live in the shared
+  // `manager.continueSession` helper (single source of truth, also used by the
+  // HTTP route). The tool only translates the outcome into `{ isError }`.
+  const explicitId = input.acp_session_id as string | undefined;
   try {
-    await manager.steer(acpSessionId, instruction);
+    const { acpSessionId } = await manager.continueSession({
+      acpSessionId: explicitId,
+      parentConversationId: explicitId ? undefined : context.conversationId,
+      instruction,
+    });
 
     return {
       content: JSON.stringify({
@@ -98,9 +60,17 @@ export async function executeAcpContinue(
       isError: false,
     };
   } catch (err) {
+    if (err instanceof SessionBusyError) {
+      return { content: err.message, isError: true };
+    }
     const msg = err instanceof Error ? err.message : String(err);
+    // The explicit-id path wraps the failure with its session label; the
+    // conversation path surfaces the manager's message plus the long-standing
+    // spawn/pass-id remediation hint.
     return {
-      content: `Could not continue ACP session "${acpSessionId}": ${msg}`,
+      content: explicitId
+        ? `Could not continue ACP session "${explicitId}": ${msg}`
+        : `${msg} Spawn a fresh session with acp_spawn, or pass acp_session_id.`,
       isError: true,
     };
   }


### PR DESCRIPTION
## Summary
Self-review round-2 remediation:
- Evict the session that has been idle longest (track last-active/idle-since) instead of the one with the oldest start time, so a just-reused session isn't reaped before a stale one.
- Move the acp_continue running-session rejection into a single manager helper that both the tool and HTTP route delegate to (steer stays unchanged for acp_steer's intentional cancel-on-running).

Part of plan: acp-platform-hosted.md (self-review fix)