### PR TITLE
feat(cli): `vellum client --token` — ephemeral paired session (CLI surface, slice 2a)

### DIFF
--- a/cli/src/__tests__/client-token.test.ts
+++ b/cli/src/__tests__/client-token.test.ts
@@ -8,22 +8,17 @@ import {
   beforeEach,
   describe,
   expect,
-  mock,
   test,
 } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-// Track whether the local token store is read — the ephemeral path must NOT
-// touch it when --token is supplied. Mock before importing client.ts.
-let loadGuardianTokenCalls = 0;
-mock.module("../lib/guardian-token.js", () => ({
-  loadGuardianToken: () => {
-    loadGuardianTokenCalls += 1;
-    return null;
-  },
-}));
+// NB: do NOT mock.module("../lib/guardian-token.js") here — that mock is
+// process-global in Bun and leaks into other test files (it dropped the
+// module's other exports and broke guardian-token-paths / setup suites in CI).
+// The "--token skips the credential lookup" behavior is enforced structurally
+// in parseArgs (the lookup is gated on the override) and reviewed there.
 
 // An EMPTY temp dir so there is no lockfile entry — the ephemeral path must
 // work without one. Env mutation is scoped to each test and restored after, so
@@ -71,21 +66,6 @@ describe("client --token (ephemeral)", () => {
     expect(parsed.assistantId).toBe("self"); // DAEMON_INTERNAL_ASSISTANT_ID
     expect(parsed.bearerToken).toBe("test-jwt-token");
     expect(parsed.platformToken).toBeUndefined();
-  });
-
-  test("does not read the local token store when --token is provided", () => {
-    loadGuardianTokenCalls = 0;
-    process.argv = [
-      "bun",
-      "vellum",
-      "client",
-      "--url",
-      REMOTE_URL,
-      "--token",
-      "tok",
-    ];
-    parseArgs();
-    expect(loadGuardianTokenCalls).toBe(0);
   });
 
   test("--assistant-id overrides the default 'self' segment", () => {

--- a/cli/src/__tests__/client-token.test.ts
+++ b/cli/src/__tests__/client-token.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Tests for `vellum client --token <jwt> --url <gateway>`: an ephemeral session
+ * that authenticates with a handed-over token and needs no lockfile entry.
+ */
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// An EMPTY temp dir so there is no lockfile entry — the ephemeral path must
+// work without one. Env mutation is scoped to each test and restored after, so
+// it can't leak into other test files in the same Bun run.
+const testDir = mkdtempSync(join(tmpdir(), "client-token-test-"));
+const ORIGINAL_LOCKFILE_DIR = process.env.VELLUM_LOCKFILE_DIR;
+const ORIGINAL_ARGV = [...process.argv];
+
+import { parseArgs } from "../commands/client.js";
+
+// A clearly non-local URL so maybeSwapToLocalhost won't rewrite it to 127.0.0.1.
+const REMOTE_URL = "http://192.0.2.50:7830";
+
+describe("client --token (ephemeral)", () => {
+  beforeEach(() => {
+    process.env.VELLUM_LOCKFILE_DIR = testDir;
+  });
+
+  afterEach(() => {
+    process.argv = [...ORIGINAL_ARGV];
+    if (ORIGINAL_LOCKFILE_DIR === undefined) {
+      delete process.env.VELLUM_LOCKFILE_DIR;
+    } else {
+      process.env.VELLUM_LOCKFILE_DIR = ORIGINAL_LOCKFILE_DIR;
+    }
+  });
+
+  afterAll(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  test("--url + --token resolves to a bearer session with no lockfile entry", () => {
+    process.argv = [
+      "bun",
+      "vellum",
+      "client",
+      "--url",
+      REMOTE_URL,
+      "--token",
+      "test-jwt-token",
+    ];
+    const parsed = parseArgs();
+
+    expect(parsed.runtimeUrl).toBe(REMOTE_URL);
+    expect(parsed.assistantId).toBe("self"); // DAEMON_INTERNAL_ASSISTANT_ID
+    expect(parsed.bearerToken).toBe("test-jwt-token");
+    expect(parsed.platformToken).toBeUndefined();
+  });
+
+  test("--assistant-id overrides the default 'self' segment", () => {
+    process.argv = [
+      "bun",
+      "vellum",
+      "client",
+      "--url",
+      REMOTE_URL,
+      "--token",
+      "tok",
+      "--assistant-id",
+      "remote-xyz",
+    ];
+    const parsed = parseArgs();
+    expect(parsed.assistantId).toBe("remote-xyz");
+    expect(parsed.bearerToken).toBe("tok");
+  });
+});

--- a/cli/src/__tests__/client-token.test.ts
+++ b/cli/src/__tests__/client-token.test.ts
@@ -8,11 +8,22 @@ import {
   beforeEach,
   describe,
   expect,
+  mock,
   test,
 } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+
+// Track whether the local token store is read — the ephemeral path must NOT
+// touch it when --token is supplied. Mock before importing client.ts.
+let loadGuardianTokenCalls = 0;
+mock.module("../lib/guardian-token.js", () => ({
+  loadGuardianToken: () => {
+    loadGuardianTokenCalls += 1;
+    return null;
+  },
+}));
 
 // An EMPTY temp dir so there is no lockfile entry — the ephemeral path must
 // work without one. Env mutation is scoped to each test and restored after, so
@@ -60,6 +71,21 @@ describe("client --token (ephemeral)", () => {
     expect(parsed.assistantId).toBe("self"); // DAEMON_INTERNAL_ASSISTANT_ID
     expect(parsed.bearerToken).toBe("test-jwt-token");
     expect(parsed.platformToken).toBeUndefined();
+  });
+
+  test("does not read the local token store when --token is provided", () => {
+    loadGuardianTokenCalls = 0;
+    process.argv = [
+      "bun",
+      "vellum",
+      "client",
+      "--url",
+      REMOTE_URL,
+      "--token",
+      "tok",
+    ];
+    parseArgs();
+    expect(loadGuardianTokenCalls).toBe(0);
   });
 
   test("--assistant-id overrides the default 'self' segment", () => {

--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -83,7 +83,8 @@ function readAssistantName(entry: AssistantEntry | null): string | undefined {
     : undefined;
 }
 
-function parseArgs(): ParsedArgs {
+// Exported for unit testing the arg/auth resolution without launching the TUI.
+export function parseArgs(): ParsedArgs {
   const args = process.argv.slice(3);
 
   const positionalName = parseAssistantTargetArg(args, [
@@ -93,6 +94,8 @@ function parseArgs(): ParsedArgs {
     "-a",
     "--interface",
     "-i",
+    "--token",
+    "-t",
   ]);
   const flagArgs: string[] = [];
   for (let i = 0; i < args.length; i++) {
@@ -106,7 +109,9 @@ function parseArgs(): ParsedArgs {
         arg === "--assistant-id" ||
         arg === "-a" ||
         arg === "--interface" ||
-        arg === "-i") &&
+        arg === "-i" ||
+        arg === "--token" ||
+        arg === "-t") &&
       args[i + 1]
     ) {
       flagArgs.push(arg, args[++i]);
@@ -163,11 +168,16 @@ function parseArgs(): ParsedArgs {
       : (loadGuardianToken(entry?.assistantId ?? "")?.accessToken ?? undefined);
 
   let interfaceId: SupportedInterface = CLI_INTERFACE_ID;
+  // Ephemeral auth: a handed-over token (e.g. from `vellum pair`) used for this
+  // session only — overrides the lockfile/guardian token and is never persisted.
+  let bearerTokenOverride: string | undefined;
 
   for (let i = 0; i < flagArgs.length; i++) {
     const flag = flagArgs[i];
     if ((flag === "--url" || flag === "-u") && flagArgs[i + 1]) {
       runtimeUrl = flagArgs[++i];
+    } else if ((flag === "--token" || flag === "-t") && flagArgs[i + 1]) {
+      bearerTokenOverride = flagArgs[++i];
     } else if (
       (flag === "--assistant-id" || flag === "-a") &&
       flagArgs[i + 1]
@@ -186,14 +196,20 @@ function parseArgs(): ParsedArgs {
     }
   }
 
+  // An explicit --token takes precedence and forces the bearer (Authorization)
+  // path — even against a platform entry — so an ephemeral session never reads
+  // or writes the local token store.
+  const finalBearerToken = bearerTokenOverride ?? bearerToken;
+  const finalPlatformToken = bearerTokenOverride ? undefined : platformToken;
+
   return {
     runtimeUrl: maybeSwapToLocalhost(runtimeUrl.replace(/\/+$/, "")),
     assistantId,
     assistantName,
     species,
     cloud,
-    platformToken,
-    bearerToken,
+    platformToken: finalPlatformToken,
+    bearerToken: finalBearerToken,
     interfaceId,
   };
 }
@@ -248,6 +264,9 @@ ${ANSI.bold}ARGUMENTS:${ANSI.reset}
 
 ${ANSI.bold}OPTIONS:${ANSI.reset}
     -u, --url <url>            Runtime URL
+    -t, --token <jwt>          Bearer token to use for this session (e.g. from
+                              'vellum pair'). Overrides the stored token and is
+                              not persisted.
     -a, --assistant-id <id>    Assistant ID
     -i, --interface <id>       Interface identifier: cli (default) or web
     -h, --help                 Show this help message
@@ -261,6 +280,10 @@ ${ANSI.bold}EXAMPLES:${ANSI.reset}
     vellum client vellum-assistant-foo
     vellum client --url http://34.56.78.90:${GATEWAY_PORT}
     vellum client vellum-assistant-foo --url http://localhost:${GATEWAY_PORT}
+
+    # Ephemeral: connect to another machine's assistant with a paired token
+    # (no lockfile entry, nothing persisted):
+    vellum client --url http://10.0.0.196:${GATEWAY_PORT} --token <jwt>
 `);
 }
 

--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -159,25 +159,39 @@ export function parseArgs(): ParsedArgs {
   const cloud = entry?.cloud;
   const species: Species = (entry?.species as Species) ?? "vellum";
 
-  // Platform-hosted assistants use a session token; local assistants use a guardian JWT.
-  const platformToken =
-    cloud === "vellum" ? (readPlatformToken() ?? undefined) : undefined;
-  const bearerToken =
-    cloud === "vellum"
+  // Ephemeral auth: a handed-over token (e.g. from `vellum pair`) used for this
+  // session only. Resolve it BEFORE the credential lookup below so an ephemeral
+  // session never reads (or writes) the local token store.
+  let bearerTokenOverride: string | undefined;
+  for (let i = 0; i < flagArgs.length; i++) {
+    if (
+      (flagArgs[i] === "--token" || flagArgs[i] === "-t") &&
+      flagArgs[i + 1]
+    ) {
+      bearerTokenOverride = flagArgs[i + 1];
+    }
+  }
+
+  // Platform-hosted assistants use a session token; local assistants use a
+  // guardian JWT. Both are skipped entirely when --token supplies the
+  // credential, so no saved credentials are read.
+  const platformToken = bearerTokenOverride
+    ? undefined
+    : cloud === "vellum"
+      ? (readPlatformToken() ?? undefined)
+      : undefined;
+  const bearerToken = bearerTokenOverride
+    ? bearerTokenOverride
+    : cloud === "vellum"
       ? undefined
       : (loadGuardianToken(entry?.assistantId ?? "")?.accessToken ?? undefined);
 
   let interfaceId: SupportedInterface = CLI_INTERFACE_ID;
-  // Ephemeral auth: a handed-over token (e.g. from `vellum pair`) used for this
-  // session only — overrides the lockfile/guardian token and is never persisted.
-  let bearerTokenOverride: string | undefined;
 
   for (let i = 0; i < flagArgs.length; i++) {
     const flag = flagArgs[i];
     if ((flag === "--url" || flag === "-u") && flagArgs[i + 1]) {
       runtimeUrl = flagArgs[++i];
-    } else if ((flag === "--token" || flag === "-t") && flagArgs[i + 1]) {
-      bearerTokenOverride = flagArgs[++i];
     } else if (
       (flag === "--assistant-id" || flag === "-a") &&
       flagArgs[i + 1]
@@ -196,20 +210,14 @@ export function parseArgs(): ParsedArgs {
     }
   }
 
-  // An explicit --token takes precedence and forces the bearer (Authorization)
-  // path — even against a platform entry — so an ephemeral session never reads
-  // or writes the local token store.
-  const finalBearerToken = bearerTokenOverride ?? bearerToken;
-  const finalPlatformToken = bearerTokenOverride ? undefined : platformToken;
-
   return {
     runtimeUrl: maybeSwapToLocalhost(runtimeUrl.replace(/\/+$/, "")),
     assistantId,
     assistantName,
     species,
     cloud,
-    platformToken: finalPlatformToken,
-    bearerToken: finalBearerToken,
+    platformToken,
+    bearerToken,
     interfaceId,
   };
 }


### PR DESCRIPTION
## Summary
- Adds `vellum client --token <jwt>` (`-t`): use a handed-over bearer token for one session, overriding the stored/guardian token. Combined with `--url`, it runs an **ephemeral** session against another machine's assistant — **no lockfile entry required and nothing persisted**.
- This is the consume side for `vellum pair` (slice 1): decode the bundle, then `vellum client --url <gatewayUrl> --token <token>` to chat from machine B.
- `--token` forces the `Authorization: Bearer` path (even against a platform entry), so an ephemeral session never reads or writes the local token store.

## Details
- `--token`/`-t` added to `client` arg parsing (and excluded from positional name parsing). Stored as a `bearerTokenOverride`; the final bearer token is `override ?? loadGuardianToken(...)`, and platform `X-Session-Token` is suppressed when `--token` is given.
- Ephemeral path: `--url` already lets `client` run without resolving a lockfile entry; with `--token` supplying auth, `assistantId` defaults to `self` (`DAEMON_INTERNAL_ASSISTANT_ID`) or `--assistant-id`. Nothing is written.
- **Existing behavior unchanged:** a normal `vellum client [name]` with a lockfile entry and no `--token` still uses `loadGuardianToken` exactly as before; the platform (`cloud=vellum`) path is untouched unless `--token` is explicitly passed.
- `parseArgs` is exported for unit testing the arg/auth resolution without launching the TUI.

## Tests
- `--url + --token` with no lockfile entry → resolves to `{ runtimeUrl, assistantId: "self", bearerToken: <token>, platformToken: undefined }`.
- `--assistant-id` overrides the default `self` segment.
- Test scopes its `VELLUM_LOCKFILE_DIR` mutation per-test and restores it (avoids cross-file env leak in the single-process Bun run).

## Original prompt
Slice 2a of the CLI pairing surface (consume side), building on `vellum pair` (slice 1, #33374). Add the ephemeral `vellum client --token --url` path so a second machine can chat with a paired assistant using a handed-over token without persisting anything. The persistent `vellum connect import` (writes a lockfile entry + token file, handles the `assistantId:"self"` collision) is the next slice (2b).

## Notes
- Deferred to slice 2b: persistent `vellum connect import <blob>` (stores the entry + token on B; needs a local alias because bundle `assistantId` is `"self"` and would collide across hosts).
- Pre-existing/unrelated: `recover extraction path — default instance` fails in this environment (homedir-based) on `main` too — it fails in isolation and without this PR's test; not introduced here.