### PR TITLE
feat(cli): `vellum connect import` — persistent paired assistant (CLI surface, slice 2b)

### DIFF
--- a/cli/src/__tests__/connect-import.test.ts
+++ b/cli/src/__tests__/connect-import.test.ts
@@ -21,7 +21,10 @@ const ORIGINAL_CONFIG_HOME = process.env.XDG_CONFIG_HOME;
 const ORIGINAL_ARGV = [...process.argv];
 
 import { connectImport } from "../commands/connect/import.js";
-import { findAssistantByName } from "../lib/assistant-config.js";
+import {
+  findAssistantByName,
+  saveAssistantEntry,
+} from "../lib/assistant-config.js";
 import { loadGuardianToken } from "../lib/guardian-token.js";
 
 function bundleFor(overrides: Record<string, unknown> = {}): string {
@@ -146,6 +149,93 @@ describe("connect import", () => {
     expect(id).not.toContain("/");
     expect(id).not.toContain("..");
     expect(loadGuardianToken(id)?.accessToken).toBe("tokX");
+  });
+
+  test("does not overwrite an existing non-paired assistant", async () => {
+    saveAssistantEntry({
+      assistantId: "desk",
+      name: "Desk",
+      runtimeUrl: "http://127.0.0.1:7830",
+      cloud: "local",
+      species: "vellum",
+    });
+    process.argv = [
+      "bun",
+      "vellum",
+      "connect",
+      "import",
+      bundleFor({ deviceId: "dx" }),
+      "--name",
+      "desk",
+    ];
+    const errSpy = spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(((c?: number) => {
+      throw new Error(`exit:${c}`);
+    }) as never);
+    let exited = false;
+    try {
+      await connectImport();
+    } catch (e) {
+      exited = (e as Error).message === "exit:1";
+    } finally {
+      errSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+    expect(exited).toBe(true);
+    // The original local assistant is untouched (not overwritten).
+    const e = findAssistantByName("desk");
+    expect(e!.runtimeUrl).toBe("http://127.0.0.1:7830");
+    expect(e!.paired).toBeUndefined();
+  });
+
+  test("re-importing the same pairing updates in place", async () => {
+    const logSpy = spyOn(console, "log").mockImplementation(() => {});
+    try {
+      process.argv = [
+        "bun",
+        "vellum",
+        "connect",
+        "import",
+        bundleFor({ deviceId: "dev-re", token: "t1" }),
+      ];
+      await connectImport();
+      process.argv = [
+        "bun",
+        "vellum",
+        "connect",
+        "import",
+        bundleFor({ deviceId: "dev-re", token: "t2" }),
+      ];
+      await connectImport();
+    } finally {
+      logSpy.mockRestore();
+    }
+    expect(loadGuardianToken("paired-dev-re")?.accessToken).toBe("t2");
+  });
+
+  test("rejects a bundle whose gatewayUrl is not http(s)", async () => {
+    process.argv = [
+      "bun",
+      "vellum",
+      "connect",
+      "import",
+      bundleFor({ gatewayUrl: "ftp://nope", deviceId: "dz" }),
+    ];
+    const errSpy = spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(((c?: number) => {
+      throw new Error(`exit:${c}`);
+    }) as never);
+    let exited = false;
+    try {
+      await connectImport();
+    } catch (e) {
+      exited = (e as Error).message === "exit:1";
+    } finally {
+      errSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+    expect(exited).toBe(true);
+    expect(findAssistantByName("paired-dz")).toBeNull();
   });
 
   test("a malformed bundle exits 1 and registers nothing", async () => {

--- a/cli/src/__tests__/connect-import.test.ts
+++ b/cli/src/__tests__/connect-import.test.ts
@@ -119,6 +119,35 @@ describe("connect import", () => {
     expect(findAssistantByName("desk-box")).not.toBeNull();
   });
 
+  test("sanitizes a malicious bundle deviceId (no path traversal in the local id)", async () => {
+    process.argv = [
+      "bun",
+      "vellum",
+      "connect",
+      "import",
+      bundleFor({ deviceId: "-/../../tmp/x", token: "tokX" }),
+    ];
+    const logs: string[] = [];
+    const logSpy = spyOn(console, "log").mockImplementation(
+      (...a: unknown[]) => {
+        logs.push(a.join(" "));
+      },
+    );
+    try {
+      await connectImport();
+    } finally {
+      logSpy.mockRestore();
+    }
+
+    // The registered id must contain no path separators or `..`.
+    const m = logs.join("\n").match(/paired assistant '([^']+)'/);
+    expect(m).not.toBeNull();
+    const id = m![1];
+    expect(id).not.toContain("/");
+    expect(id).not.toContain("..");
+    expect(loadGuardianToken(id)?.accessToken).toBe("tokX");
+  });
+
   test("a malformed bundle exits 1 and registers nothing", async () => {
     process.argv = ["bun", "vellum", "connect", "import", "not-valid-base64!!"];
     const errSpy = spyOn(console, "error").mockImplementation(() => {});

--- a/cli/src/__tests__/connect-import.test.ts
+++ b/cli/src/__tests__/connect-import.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests for `vellum connect import <blob>`: decode a `vellum pair` bundle and
+ * persist a lockfile entry + guardian token under a unique local id.
+ */
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  spyOn,
+  test,
+} from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const testDir = mkdtempSync(join(tmpdir(), "connect-import-test-"));
+const ORIGINAL_LOCKFILE_DIR = process.env.VELLUM_LOCKFILE_DIR;
+const ORIGINAL_CONFIG_HOME = process.env.XDG_CONFIG_HOME;
+const ORIGINAL_ARGV = [...process.argv];
+
+import { connectImport } from "../commands/connect/import.js";
+import { findAssistantByName } from "../lib/assistant-config.js";
+import { loadGuardianToken } from "../lib/guardian-token.js";
+
+function bundleFor(overrides: Record<string, unknown> = {}): string {
+  const obj = {
+    gatewayUrl: "http://10.0.0.5:7830",
+    assistantId: "self",
+    token: "test-token",
+    deviceId: "dev-aaa",
+    ...overrides,
+  };
+  return Buffer.from(JSON.stringify(obj)).toString("base64");
+}
+
+describe("connect import", () => {
+  beforeEach(() => {
+    process.env.VELLUM_LOCKFILE_DIR = testDir;
+    process.env.XDG_CONFIG_HOME = testDir;
+  });
+
+  afterEach(() => {
+    process.argv = [...ORIGINAL_ARGV];
+    if (ORIGINAL_LOCKFILE_DIR === undefined)
+      delete process.env.VELLUM_LOCKFILE_DIR;
+    else process.env.VELLUM_LOCKFILE_DIR = ORIGINAL_LOCKFILE_DIR;
+    if (ORIGINAL_CONFIG_HOME === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = ORIGINAL_CONFIG_HOME;
+  });
+
+  afterAll(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  test("writes a lockfile entry + guardian token from a valid bundle", async () => {
+    process.argv = ["bun", "vellum", "connect", "import", bundleFor()];
+    const logSpy = spyOn(console, "log").mockImplementation(() => {});
+    try {
+      await connectImport();
+    } finally {
+      logSpy.mockRestore();
+    }
+
+    const entry = findAssistantByName("paired-dev-aaa");
+    expect(entry).not.toBeNull();
+    expect(entry!.runtimeUrl).toBe("http://10.0.0.5:7830");
+    expect(entry!.cloud).toBe("local");
+    expect(loadGuardianToken("paired-dev-aaa")?.accessToken).toBe("test-token");
+  });
+
+  test("two different bundles (both assistantId 'self') do not collide", async () => {
+    process.argv = [
+      "bun",
+      "vellum",
+      "connect",
+      "import",
+      bundleFor({ deviceId: "dev-one", token: "tok1" }),
+    ];
+    const logSpy = spyOn(console, "log").mockImplementation(() => {});
+    try {
+      await connectImport();
+      process.argv = [
+        "bun",
+        "vellum",
+        "connect",
+        "import",
+        bundleFor({ deviceId: "dev-two", token: "tok2" }),
+      ];
+      await connectImport();
+    } finally {
+      logSpy.mockRestore();
+    }
+
+    expect(findAssistantByName("paired-dev-one")).not.toBeNull();
+    expect(findAssistantByName("paired-dev-two")).not.toBeNull();
+    expect(loadGuardianToken("paired-dev-one")?.accessToken).toBe("tok1");
+    expect(loadGuardianToken("paired-dev-two")?.accessToken).toBe("tok2");
+  });
+
+  test("--name registers the entry under that name", async () => {
+    process.argv = [
+      "bun",
+      "vellum",
+      "connect",
+      "import",
+      bundleFor({ deviceId: "dev-named" }),
+      "--name",
+      "Desk Box",
+    ];
+    const logSpy = spyOn(console, "log").mockImplementation(() => {});
+    try {
+      await connectImport();
+    } finally {
+      logSpy.mockRestore();
+    }
+    // Slugified to a stable id.
+    expect(findAssistantByName("desk-box")).not.toBeNull();
+  });
+
+  test("a malformed bundle exits 1 and registers nothing", async () => {
+    process.argv = ["bun", "vellum", "connect", "import", "not-valid-base64!!"];
+    const errSpy = spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(((c?: number) => {
+      throw new Error(`exit:${c}`);
+    }) as never);
+    let exited = false;
+    try {
+      await connectImport();
+    } catch (e) {
+      exited = (e as Error).message === "exit:1";
+    } finally {
+      errSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+    expect(exited).toBe(true);
+    // A malformed bundle has no deviceId, so no `paired-*` entry is created.
+    expect(findAssistantByName("paired-")).toBeNull();
+  });
+});

--- a/cli/src/commands/connect.ts
+++ b/cli/src/commands/connect.ts
@@ -1,0 +1,31 @@
+import { connectImport } from "./connect/import.js";
+
+function printUsage(): void {
+  console.log("Usage: vellum connect <subcommand>");
+  console.log("");
+  console.log("Connect to an assistant paired from another machine.");
+  console.log("");
+  console.log("Subcommands:");
+  console.log(
+    "  import    Import a pairing bundle from `vellum pair` and register it",
+  );
+}
+
+export async function connect(): Promise<void> {
+  const args = process.argv.slice(3);
+  const subcommand = args[0];
+
+  if (subcommand === "--help" || subcommand === "-h" || !subcommand) {
+    printUsage();
+    process.exit(0);
+  }
+
+  if (subcommand === "import") {
+    await connectImport();
+    return;
+  }
+
+  console.error(`Unknown subcommand: ${subcommand}`);
+  printUsage();
+  process.exit(1);
+}

--- a/cli/src/commands/connect/import.ts
+++ b/cli/src/commands/connect/import.ts
@@ -118,9 +118,12 @@ export async function connectImport(): Promise<void> {
 
   // Unique local id: a --name slug, or paired-<deviceId> (deviceId is unique
   // per pairing). Never the bundle's "self" assistantId — that would collide.
+  // The deviceId comes from an untrusted bundle and is used as a path component
+  // by saveGuardianToken, so it MUST be slugified (no `../` traversal); fall
+  // back to a random id if it sanitizes to empty.
   const localId = nameFlag
     ? slugify(nameFlag)
-    : `paired-${bundle.deviceId || nanoid()}`;
+    : `paired-${slugify(bundle.deviceId ?? "") || nanoid()}`;
   if (!localId) {
     console.error(
       "Error: --name must contain at least one alphanumeric character.",

--- a/cli/src/commands/connect/import.ts
+++ b/cli/src/commands/connect/import.ts
@@ -1,0 +1,164 @@
+/**
+ * `vellum connect import <blob> [--name <localname>]`
+ *
+ * Import a pairing bundle printed by `vellum pair` on another machine and
+ * register it locally so `vellum client`/`message`/`events <name>` work against
+ * the remote assistant.
+ *
+ * The bundle is base64(JSON.stringify({ gatewayUrl, assistantId, token,
+ * deviceId })). We store the entry under a UNIQUE LOCAL id (not the bundle's
+ * assistantId, which is typically "self" and would collide across hosts). This
+ * is safe because the gateway's runtime proxy strips the `/v1/assistants/<id>/`
+ * segment before forwarding, so the local id never has to match the remote one
+ * — the token (validated by signature/audience) is what authorizes requests.
+ */
+
+import { nanoid } from "nanoid";
+
+import { extractFlag } from "../../lib/arg-utils.js";
+import {
+  findAssistantByName,
+  saveAssistantEntry,
+} from "../../lib/assistant-config.js";
+import { saveGuardianToken } from "../../lib/guardian-token.js";
+
+function printUsage(): void {
+  console.log(`vellum connect import - Register an assistant paired from another machine
+
+USAGE:
+    vellum connect import <bundle> [options]
+
+ARGUMENTS:
+    <bundle>    The base64 bundle printed by 'vellum pair' on the host machine
+
+OPTIONS:
+    --name <name>   Local name to register the assistant under
+                    (default: paired-<deviceId>)
+
+EXAMPLES:
+    vellum connect import eyJnYXRld2F5...
+    vellum connect import eyJnYXRld2F5... --name desk
+`);
+}
+
+interface PairBundle {
+  gatewayUrl: string;
+  token: string;
+  assistantId?: string;
+  deviceId?: string;
+}
+
+/** Decode the base64 bundle, returning null if malformed or missing fields. */
+function decodeBundle(blob: string): PairBundle | null {
+  let json: unknown;
+  try {
+    json = JSON.parse(Buffer.from(blob, "base64").toString("utf8"));
+  } catch {
+    return null;
+  }
+  if (typeof json !== "object" || json === null) return null;
+  const b = json as Record<string, unknown>;
+  if (typeof b.gatewayUrl !== "string" || typeof b.token !== "string") {
+    return null;
+  }
+  return {
+    gatewayUrl: b.gatewayUrl,
+    token: b.token,
+    assistantId: typeof b.assistantId === "string" ? b.assistantId : undefined,
+    deviceId: typeof b.deviceId === "string" ? b.deviceId : undefined,
+  };
+}
+
+/** Lowercase, collapse non-alphanumerics to single dashes, trim dashes. */
+function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/** Best-effort JWT `exp` (epoch seconds) → epoch ms; null if undecodable. */
+function jwtExpiryMs(token: string): number | null {
+  const parts = token.split(".");
+  if (parts.length !== 3) return null;
+  try {
+    const payload = JSON.parse(
+      Buffer.from(parts[1], "base64").toString("utf8"),
+    );
+    if (typeof payload.exp === "number") return payload.exp * 1000;
+  } catch {
+    /* fall through */
+  }
+  return null;
+}
+
+export async function connectImport(): Promise<void> {
+  const rawArgs = process.argv.slice(4);
+
+  if (rawArgs.includes("--help") || rawArgs.includes("-h")) {
+    printUsage();
+    return;
+  }
+
+  const [nameFlag, args] = extractFlag(rawArgs, "--name");
+  const blob = args[0];
+  if (!blob) {
+    console.error("Error: missing pairing bundle.");
+    printUsage();
+    process.exit(1);
+  }
+
+  const bundle = decodeBundle(blob);
+  if (!bundle) {
+    console.error(
+      "Error: invalid pairing bundle. Paste the full base64 string printed by `vellum pair`.",
+    );
+    process.exit(1);
+  }
+
+  // Unique local id: a --name slug, or paired-<deviceId> (deviceId is unique
+  // per pairing). Never the bundle's "self" assistantId — that would collide.
+  const localId = nameFlag
+    ? slugify(nameFlag)
+    : `paired-${bundle.deviceId || nanoid()}`;
+  if (!localId) {
+    console.error(
+      "Error: --name must contain at least one alphanumeric character.",
+    );
+    process.exit(1);
+  }
+
+  const existed = findAssistantByName(localId) !== null;
+
+  saveAssistantEntry({
+    assistantId: localId,
+    name: nameFlag ?? `paired (${new URL(bundle.gatewayUrl).host})`,
+    runtimeUrl: bundle.gatewayUrl,
+    cloud: "local",
+    species: "vellum",
+  });
+
+  const now = Date.now();
+  saveGuardianToken(localId, {
+    guardianPrincipalId: "imported",
+    accessToken: bundle.token,
+    accessTokenExpiresAt:
+      jwtExpiryMs(bundle.token) ?? now + 24 * 60 * 60 * 1000,
+    refreshToken: "",
+    refreshTokenExpiresAt: 0,
+    refreshAfter: "",
+    isNew: false,
+    deviceId: bundle.deviceId ?? "",
+    leasedAt: new Date(now).toISOString(),
+  });
+
+  console.log(
+    `${existed ? "Updated" : "Imported"} paired assistant '${localId}'.`,
+  );
+  console.log("");
+  console.log(`  Connect with:  vellum client ${localId}`);
+  console.log("");
+  console.log(
+    "Note: the token is access-only and will expire — re-run `vellum pair` and import again when it does.",
+  );
+}

--- a/cli/src/commands/connect/import.ts
+++ b/cli/src/commands/connect/import.ts
@@ -137,6 +137,13 @@ export async function connectImport(): Promise<void> {
     assistantId: localId,
     name: nameFlag ?? `paired (${new URL(bundle.gatewayUrl).host})`,
     runtimeUrl: bundle.gatewayUrl,
+    // Tagged "local" for now because that selects the bearer-token auth path
+    // in client.ts (vs the platform X-Session-Token path), which is what a
+    // paired token needs. Caveat: lifecycle/status commands (`vellum ps`,
+    // `vellum wake`) then treat the entry as an on-machine process.
+    // TODO: introduce a distinct `cloud: "paired"` topology + lifecycle guards
+    // so ps/wake don't try to manage a remote pairing as a local instance,
+    // while keeping bearer auth. Tracked with the devices/unpair work.
     cloud: "local",
     species: "vellum",
   });

--- a/cli/src/commands/connect/import.ts
+++ b/cli/src/commands/connect/import.ts
@@ -61,6 +61,17 @@ function decodeBundle(blob: string): PairBundle | null {
   if (typeof b.gatewayUrl !== "string" || typeof b.token !== "string") {
     return null;
   }
+  // The gatewayUrl is persisted as runtimeUrl and used to build fetch URLs, so
+  // require an absolute http(s) URL here rather than letting an invalid string
+  // through (which would crash `new URL(...)` or break later client calls).
+  try {
+    const parsed = new URL(b.gatewayUrl);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return null;
+    }
+  } catch {
+    return null;
+  }
   return {
     gatewayUrl: b.gatewayUrl,
     token: b.token,
@@ -131,7 +142,19 @@ export async function connectImport(): Promise<void> {
     process.exit(1);
   }
 
-  const existed = findAssistantByName(localId) !== null;
+  // Don't clobber an existing assistant. Only update in place when the prior
+  // entry is itself a paired import (marked `paired: true`); otherwise the id
+  // collides with a real local/remote assistant and overwriting would drop its
+  // resources/runtime metadata. Reject and let the user pick a fresh --name.
+  const existing = findAssistantByName(localId);
+  if (existing && existing.paired !== true) {
+    console.error(
+      `Error: an assistant named '${localId}' already exists locally. ` +
+        "Choose a different --name to avoid overwriting it.",
+    );
+    process.exit(1);
+  }
+  const existed = existing !== null;
 
   saveAssistantEntry({
     assistantId: localId,
@@ -145,6 +168,9 @@ export async function connectImport(): Promise<void> {
     // so ps/wake don't try to manage a remote pairing as a local instance,
     // while keeping bearer auth. Tracked with the devices/unpair work.
     cloud: "local",
+    // Marks this entry as a connect-import so re-imports update in place while
+    // imports never silently overwrite a non-paired assistant (see guard above).
+    paired: true,
     species: "vellum",
   });
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -4,6 +4,7 @@ import cliPkg from "../package.json";
 import { backup } from "./commands/backup";
 import { clean } from "./commands/clean";
 import { client } from "./commands/client";
+import { connect } from "./commands/connect";
 import { env } from "./commands/env";
 import { events } from "./commands/events";
 import { exec } from "./commands/exec";
@@ -37,6 +38,7 @@ const commands = {
   backup,
   clean,
   client,
+  connect,
   env,
   events,
   exec,
@@ -75,6 +77,7 @@ function printHelp(): void {
   console.log("  backup   Export a backup of a running assistant");
   console.log("  clean    Kill orphaned vellum processes");
   console.log("  client   Connect to a hatched assistant");
+  console.log("  connect  Import an assistant paired from another machine");
   console.log("  env      Manage the default CLI environment");
   console.log("  events   Stream events from a running assistant");
   console.log("  exec     Execute a command inside an assistant's container");


### PR DESCRIPTION
## Summary
- Adds `vellum connect import <bundle> [--name <localname>]` — the persistent consume side of pairing. Decode a `vellum pair` bundle on machine B and register the remote assistant locally (lockfile entry + guardian token), so `vellum client`/`message`/`events <name>` then work normally with no re-pasting.
- Stores the entry under a **unique local id** (a `--name` slug, or `paired-<deviceId>`), so importing multiple remotes — all of whose bundle `assistantId` is `"self"` — never collide in the lockfile.

## Why the local id can differ from the remote `"self"`
The gateway's runtime proxy strips the `/v1/assistants/<id>/` segment (`runtime-proxy.ts`, the `assistantScopedMatch` rewrite) before forwarding to the daemon, so the assistant id in the request URL is irrelevant for a self-hosted gateway — the bearer token (validated by signature/audience, `sub=actor:self:…`) is what authorizes requests. So a local alias is sufficient; **no remote-assistant-id threading through client.ts/AssistantClient is needed.**

## Details
- New `connect` dispatcher (mirrors `gateway`) → `connect import`.
- `connect import`: base64-decode + validate the bundle (`gatewayUrl` + `token` required); save an `AssistantEntry` (`cloud: "local"` → bearer auth path, `runtimeUrl` = the remote gateway URL) and the token via `saveGuardianToken` (mode 0600), with `accessTokenExpiresAt` parsed from the JWT `exp`.
- Re-importing the same device/name updates in place ("Updated" vs "Imported").
- Tokens are **access-only** (pairing doesn't issue refresh) — re-pair + import again when it expires.

## Tests
- Valid bundle → lockfile entry (unique id, `runtimeUrl`, `cloud:"local"`) + guardian token readable back (accessToken matches).
- Two different bundles (both `assistantId:"self"`) → two coexisting entries, no collision.
- `--name "Desk Box"` → resolvable as `desk-box`.
- Malformed bundle → exits 1, registers nothing.

## Original prompt
Persistent consume side of the CLI pairing surface (after `vellum pair` #33374 and the ephemeral `vellum client --token` #33382). `vellum connect import` registers a paired assistant on machine B from the bundle, avoiding the `assistantId:"self"` lockfile collision via a unique local id (safe because the gateway strips the URL assistant segment). `vellum devices`/`vellum unpair` (revocation management on the host) is the next slice.

## Note
Pre-existing/unrelated: `recover extraction path — default instance` fails in this environment (homedir-based) on `main` too; it fails in isolation and is not touched here.