### PR TITLE
fix(macos): fix Electron login, onboarding flow, and gateway auth

### DIFF
--- a/apps/macos/src/main/main-window.ts
+++ b/apps/macos/src/main/main-window.ts
@@ -113,6 +113,19 @@ const installSameOriginNavigationGuard = (win: BrowserWindow): void => {
       return;
     }
     if (isAllowedOrigin(target, allowedOrigin)) return;
+
+    // When the main window is already on an external origin (e.g.
+    // mid-OAuth on accounts.google.com after a server-side redirect
+    // chain), allow further navigations so the provider's own JS
+    // flows can complete. Only intercept navigations that originate
+    // from the app's SPA.
+    try {
+      const current = new URL(win.webContents.getURL());
+      if (!isAllowedOrigin(current, allowedOrigin)) return;
+    } catch {
+      // Unparseable current URL — fall through to the block.
+    }
+
     event.preventDefault();
     // External http(s) top-level navigations (e.g.
     // `window.location.href = "https://billing.stripe.com/..."`) route

--- a/apps/web/src/domains/onboarding/hatch-trigger.ts
+++ b/apps/web/src/domains/onboarding/hatch-trigger.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared hatch-operation state between the privacy screen (trigger) and the
+ * hatching screen (progress monitor).
+ *
+ * The privacy screen fires the hatch on "Start" click and navigates to the
+ * hatching screen, which picks up the in-flight promise and handles the
+ * post-hatch setup (gateway readiness, provider key, avatar sync). This
+ * avoids useEffect-driven hatch triggers that re-fire on dependency changes.
+ *
+ * Module-level state so it survives the unmount/remount across navigation
+ * and React strict-mode double mounts.
+ */
+
+import { hatchLocalAssistant, type LocalHatchResult } from "@/runtime/local-mode-host";
+import { hatchAssistant, type HatchResult } from "@/assistant/api";
+import { readSelectedVersion } from "@/domains/onboarding/prefs";
+
+let localHatchPromise: Promise<LocalHatchResult> | null = null;
+let platformHatchPromise: Promise<HatchResult> | null = null;
+
+export function triggerLocalHatch(species = "vellum"): Promise<LocalHatchResult> {
+  if (!localHatchPromise) {
+    localHatchPromise = hatchLocalAssistant(species);
+  }
+  return localHatchPromise;
+}
+
+export function triggerPlatformHatch(): Promise<HatchResult> {
+  if (!platformHatchPromise) {
+    const pinnedVersion = readSelectedVersion();
+    platformHatchPromise = hatchAssistant(
+      pinnedVersion ? { version: pinnedVersion } : undefined,
+    );
+  }
+  return platformHatchPromise;
+}
+
+export function getLocalHatchPromise(): Promise<LocalHatchResult> | null {
+  return localHatchPromise;
+}
+
+export function getPlatformHatchPromise(): Promise<HatchResult> | null {
+  return platformHatchPromise;
+}
+
+export function clearLocalHatch(): void {
+  localHatchPromise = null;
+}
+
+export function clearPlatformHatch(): void {
+  platformHatchPromise = null;
+}

--- a/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -5,7 +5,7 @@ import { useNavigate, useSearchParams } from "react-router";
 
 import { Button } from "@vellum/design-library/components/button";
 import { ProgressBar } from "@vellum/design-library/components/progress-bar";
-import { getAssistant, hatchAssistant } from "@/assistant/api";
+import { getAssistant } from "@/assistant/api";
 import {
   isPlatformHostedDisabled,
   PLATFORM_HOSTED_DISABLED_MESSAGE,
@@ -20,14 +20,18 @@ import type { CharacterTraits } from "@/types/avatar";
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
 import { extractErrorMessage } from "@/utils/api-errors";
 import { isLocalMode, loadLockfile, setSelectedAssistantId, saveLockfileAssistant, primeLocalGatewayConnection, getLocalGatewayUrl } from "@/lib/local-mode";
-import { hatchLocalAssistant } from "@/runtime/local-mode-host";
 import { getOnboardingEntrypoint } from "@/domains/onboarding/gate";
+import {
+  getLocalHatchPromise,
+  getPlatformHatchPromise,
+  clearLocalHatch,
+  clearPlatformHatch,
+} from "@/domains/onboarding/hatch-trigger";
 import { applyPendingProviderKey } from "@/domains/onboarding/provider-key";
 import { lifecycleService } from "@/assistant/lifecycle-service";
 import {
   readAiDataConsent,
   readOnboardingCompleted,
-  readSelectedVersion,
   readTosAccepted,
   useOnboardingCompleted,
   writeSelectedVersion,
@@ -49,11 +53,6 @@ import { routes } from "@/utils/routes";
 const POLL_INTERVAL_MS = 3000;
 const COMPLETION_NAVIGATE_DELAY_MS = 800;
 const MAX_HATCH_WAIT_MS = 300_000;
-
-// Module-level promises so HMR remounts and StrictMode double-mounts
-// can await the same in-flight hatch instead of spawning duplicates.
-let localHatchPromise: Promise<import("@/runtime/local-mode-host").LocalHatchResult> | null = null;
-let platformHatchPromise: Promise<import("@/assistant/api").HatchResult> | null = null;
 
 type HatchPhase = "initializing" | "provisioning" | "connecting" | "ready";
 
@@ -98,7 +97,7 @@ export function decideHatchGate(input: {
   cameFromPrivacyScreen: boolean;
 }): HatchGateDecision {
   if (!isSessionSettled(input.sessionStatus)) return { kind: "wait" };
-  if (!isAuthenticated(input.sessionStatus)) {
+  if (!isAuthenticated(input.sessionStatus) && !isLocalMode()) {
     return { kind: "redirect", to: routes.account.login };
   }
   if (input.onboardingCompleted && !input.isReplay) {
@@ -122,6 +121,16 @@ export function HatchingScreen() {
   const useLocalHatch = isLocalMode() && hostingParam !== null && hostingParam !== "vellum-cloud";
   const userId = useAuthStore.use.user()?.id ?? null;
   const sessionStatus = useAuthStore.use.sessionStatus();
+
+  // Refs for values the hatch effect reads but must NOT restart on.
+  // The platform-session probe can settle mid-hatch and change userId
+  // (from the local placeholder to the real platform user), which would
+  // re-trigger the effect, cancel the in-flight readiness poll, and
+  // start a duplicate hatch.
+  const userIdRef = useRef(userId);
+  userIdRef.current = userId;
+  const sessionStatusRef = useRef(sessionStatus);
+  sessionStatusRef.current = sessionStatus;
   const [, setOnboardingCompleted] = useOnboardingCompleted();
   const [hatchTraits] = useState<CharacterTraits>(() =>
     randomCharacterTraits(BUNDLED_COMPONENTS),
@@ -158,9 +167,11 @@ export function HatchingScreen() {
 
 
   useEffect(() => {
-    const cameFromPrivacyScreen = hasRecentPrivacyConsent(userId);
+    const snapshotUserId = userIdRef.current;
+    const snapshotSessionStatus = sessionStatusRef.current;
+    const cameFromPrivacyScreen = hasRecentPrivacyConsent(snapshotUserId);
     const decision = decideHatchGate({
-      sessionStatus,
+      sessionStatus: snapshotSessionStatus,
       isReplay,
       onboardingCompleted: readOnboardingCompleted(),
       tosAccepted: readTosAccepted(),
@@ -181,15 +192,13 @@ export function HatchingScreen() {
     let readyPollTimer: ReturnType<typeof setTimeout> | null = null;
     const pollStartMs = Date.now();
 
-    const pinnedVersion = readSelectedVersion();
-
     const handleHatchReady = () => {
       try {
         writeSelectedVersion("");
       } catch (err) {
         captureError(err, { context: "onboarding_mark_completed" });
       }
-      markPrivacyConsent(userId);
+      markPrivacyConsent(userIdRef.current);
       setDisplayProgress(1);
       displayProgressRef.current = 1;
       segmentStartRef.current = 1;
@@ -234,19 +243,18 @@ export function HatchingScreen() {
         return;
       }
 
-      // Local/Docker hatch lifecycle:
-      // 1. hatchLocalAssistant() runs the CLI (Vite middleware on web/dev,
-      //    main process over IPC in Electron) to spawn the daemon + gateway
-      // 2. Reload lockfile to discover the new assistant
-      // 3. Acquire gateway token + set self-hosted connection
-      // 4. Navigate to pre-chat flow
+      // The privacy screen fires the hatch before navigating here.
+      // If the promise is missing (page refresh, direct URL entry),
+      // bounce back to the privacy screen rather than re-triggering.
       if (useLocalHatch) {
+        const hatchPromise = getLocalHatchPromise();
+        if (!hatchPromise) {
+          void navigate(getOnboardingEntrypoint(), { replace: true });
+          return;
+        }
         try {
-          if (!localHatchPromise) {
-            localHatchPromise = hatchLocalAssistant();
-          }
-          const result = await localHatchPromise;
-          localHatchPromise = null;
+          const result = await hatchPromise;
+          clearLocalHatch();
           if (cancelled) return;
           if (!result.ok) {
             setError(result.error ?? "Failed to hatch local assistant.");
@@ -257,12 +265,6 @@ export function HatchingScreen() {
             setSelectedAssistantId(result.assistantId);
           }
 
-          // Wait for the gateway + daemon to be fully ready before proceeding.
-          // The CLI's hatch command spawns them as background processes and exits
-          // before they finish starting up. We poll /readyz (gateway + upstream
-          // daemon) and then attempt to acquire the gateway auth token. Both must
-          // succeed before we navigate away — the guardian token file may not
-          // exist on disk until after /readyz passes.
           transitionPhase("connecting");
           let gatewayReady = false;
           while (!cancelled && !gatewayReady) {
@@ -298,9 +300,6 @@ export function HatchingScreen() {
           }
           if (cancelled) return;
 
-          // Apply the model-provider key collected on the API-key step to the
-          // freshly hatched assistant. Non-blocking on failure — onboarding
-          // proceeds and the user can fix it in Settings.
           if (result.assistantId) {
             try {
               await applyPendingProviderKey(result.assistantId);
@@ -311,21 +310,21 @@ export function HatchingScreen() {
 
           handleHatchReady();
         } catch {
-          localHatchPromise = null;
+          clearLocalHatch();
           if (cancelled) return;
           setError("Failed to hatch local assistant. Check CLI logs for details.");
         }
         return;
       }
 
+      const platformPromise = getPlatformHatchPromise();
+      if (!platformPromise) {
+        void navigate(getOnboardingEntrypoint(), { replace: true });
+        return;
+      }
       try {
-        if (!platformHatchPromise) {
-          platformHatchPromise = hatchAssistant(
-            pinnedVersion ? { version: pinnedVersion } : undefined,
-          );
-        }
-        const result = await platformHatchPromise;
-        platformHatchPromise = null;
+        const result = await platformPromise;
+        clearPlatformHatch();
         if (cancelled) return;
         if (!result.ok) {
           Sentry.captureMessage("Onboarding hatch request failed", {
@@ -351,7 +350,7 @@ export function HatchingScreen() {
           }
         }
       } catch (err) {
-        platformHatchPromise = null;
+        clearPlatformHatch();
         captureError(err, { context: "onboarding_hatch_assistant" });
         if (cancelled) return;
       }
@@ -425,16 +424,18 @@ export function HatchingScreen() {
       if (navigateTimer) clearTimeout(navigateTimer);
       if (readyPollTimer) clearTimeout(readyPollTimer);
     };
+  // sessionStatus and userId are read via refs — they inform the
+  // initial gate decision but must not restart a running hatch when
+  // the platform-session probe settles and changes them mid-flow.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     attempt,
     hatchTraits,
-    sessionStatus,
     isReplay,
     navigate,
     setOnboardingCompleted,
     transitionPhase,
     useLocalHatch,
-    userId,
   ]);
 
   useEffect(() => {

--- a/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -270,8 +270,8 @@ export function HatchingScreen() {
         }
         try {
           const result = await hatchPromise;
-          clearLocalHatch();
           if (cancelled) return;
+          clearLocalHatch();
           if (!result.ok) {
             setError(result.error ?? "Failed to hatch local assistant.");
             return;
@@ -326,8 +326,8 @@ export function HatchingScreen() {
 
           handleHatchReady();
         } catch {
-          clearLocalHatch();
           if (cancelled) return;
+          clearLocalHatch();
           setError("Failed to hatch local assistant. Check CLI logs for details.");
         }
         return;
@@ -340,8 +340,8 @@ export function HatchingScreen() {
       }
       try {
         const result = await platformPromise;
-        clearPlatformHatch();
         if (cancelled) return;
+        clearPlatformHatch();
         if (!result.ok) {
           Sentry.captureMessage("Onboarding hatch request failed", {
             level: "warning",
@@ -366,9 +366,9 @@ export function HatchingScreen() {
           }
         }
       } catch (err) {
-        clearPlatformHatch();
         captureError(err, { context: "onboarding_hatch_assistant" });
         if (cancelled) return;
+        clearPlatformHatch();
       }
 
       scheduleNextPoll(0);

--- a/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -26,6 +26,8 @@ import {
   getPlatformHatchPromise,
   clearLocalHatch,
   clearPlatformHatch,
+  triggerLocalHatch,
+  triggerPlatformHatch,
 } from "@/domains/onboarding/hatch-trigger";
 import { applyPendingProviderKey } from "@/domains/onboarding/provider-key";
 import { lifecycleService } from "@/assistant/lifecycle-service";
@@ -165,6 +167,17 @@ export function HatchingScreen() {
     setAnimationEpoch((n) => n + 1);
   }, []);
 
+  // If the main effect returned early because the session wasn't settled
+  // yet ("wait"), re-trigger it once the session settles so the gate
+  // can re-evaluate. This is a separate effect so sessionStatus changes
+  // during an in-flight hatch don't restart the main effect.
+  const [gateWaiting, setGateWaiting] = useState(false);
+  useEffect(() => {
+    if (gateWaiting && isSessionSettled(sessionStatus)) {
+      setGateWaiting(false);
+      setAttempt((n) => n + 1);
+    }
+  }, [gateWaiting, sessionStatus]);
 
   useEffect(() => {
     const snapshotUserId = userIdRef.current;
@@ -182,7 +195,10 @@ export function HatchingScreen() {
       void navigate(decision.to, { replace: true });
       return;
     }
-    if (decision.kind === "wait") return;
+    if (decision.kind === "wait") {
+      setGateWaiting(true);
+      return;
+    }
 
     setPlatformHostedDisabled(false);
 
@@ -516,6 +532,11 @@ export function HatchingScreen() {
                 setAnimationEpoch((n) => n + 1);
                 setError(null);
                 setPlatformHostedDisabled(false);
+                if (useLocalHatch) {
+                  triggerLocalHatch();
+                } else {
+                  triggerPlatformHatch();
+                }
                 setAttempt((n) => n + 1);
               }}
             >

--- a/apps/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -23,7 +23,9 @@ import {
   useShareDiagnostics,
   useTosAccepted,
 } from "@/domains/onboarding/prefs";
+import { triggerLocalHatch, triggerPlatformHatch } from "@/domains/onboarding/hatch-trigger";
 import { markPrivacyConsent } from "@/domains/onboarding/signals";
+import { isLocalMode } from "@/lib/local-mode";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { useIsNativePlatform } from "@/runtime/native-auth";
 import { useAuthStore } from "@/stores/auth-store";
@@ -110,9 +112,19 @@ export function PrivacyScreen() {
         variant,
       });
     }
-    // Preserve the hosting param (Local/Docker need it so hatching runs the
-    // local hatch instead of a platform hatch).
     const hostingParam = searchParams.get("hosting");
+    const useLocalHatch = isLocalMode() && hostingParam !== null && hostingParam !== "vellum-cloud";
+
+    // Fire the hatch before navigating so the hatching screen picks up
+    // the in-flight promise instead of triggering its own.
+    if (!isReplay) {
+      if (useLocalHatch) {
+        triggerLocalHatch();
+      } else {
+        triggerPlatformHatch();
+      }
+    }
+
     const params = new URLSearchParams();
     if (hostingParam) params.set("hosting", hostingParam);
     if (isReplay) params.set("replay", "1");

--- a/apps/web/src/lib/auth/auth-middleware.test.ts
+++ b/apps/web/src/lib/auth/auth-middleware.test.ts
@@ -2,10 +2,14 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 const isLocalModeMock = mock(() => true);
 const hasAssistantsMock = mock(() => false);
+const readOnboardingCompletedMock = mock(() => false);
 mock.module("@/lib/local-mode", () => ({
   isLocalMode: isLocalModeMock,
   hasAssistants: hasAssistantsMock,
   getLocalGatewayUrl: () => undefined,
+}));
+mock.module("@/domains/onboarding/prefs", () => ({
+  readOnboardingCompleted: readOnboardingCompletedMock,
 }));
 
 import { authMiddleware } from "./auth-middleware";
@@ -39,11 +43,72 @@ const tick = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
 beforeEach(() => {
   isLocalModeMock.mockImplementation(() => true);
   hasAssistantsMock.mockImplementation(() => false);
+  readOnboardingCompletedMock.mockImplementation(() => false);
   useAuthStore.setState(initialAuthState, true);
 });
 
 afterEach(() => {
   useAuthStore.setState(initialAuthState, true);
+});
+
+describe("authMiddleware — unauthenticated local mode", () => {
+  test("redirects to onboarding welcome instead of login", async () => {
+    useAuthStore.setState({
+      sessionStatus: "unauthenticated",
+      user: null,
+      platformSession: "absent",
+    });
+
+    const res = await runMiddleware(routes.assistant);
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe(routes.onboarding.welcome);
+  });
+
+  test("allows onboarding routes through without authentication", async () => {
+    useAuthStore.setState({
+      sessionStatus: "unauthenticated",
+      user: null,
+      platformSession: "absent",
+    });
+
+    const args = {
+      request: new Request(`http://localhost${routes.onboarding.hosting}`),
+      context: { set: () => {}, get: () => null },
+    } as unknown as Parameters<typeof authMiddleware>[0];
+    let nextCalled = false;
+    const next = (async () => {
+      nextCalled = true;
+      return new Response();
+    }) as Parameters<typeof authMiddleware>[1];
+    await authMiddleware(args, next);
+    expect(nextCalled).toBe(true);
+  });
+
+  test("redirects to login when onboarding already completed", async () => {
+    readOnboardingCompletedMock.mockImplementation(() => true);
+    useAuthStore.setState({
+      sessionStatus: "unauthenticated",
+      user: null,
+      platformSession: "absent",
+    });
+
+    const res = await runMiddleware(routes.assistant);
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toContain("/account/login");
+  });
+
+  test("redirects to login in platform mode when unauthenticated", async () => {
+    isLocalModeMock.mockImplementation(() => false);
+    useAuthStore.setState({
+      sessionStatus: "unauthenticated",
+      user: null,
+      platformSession: "absent",
+    });
+
+    const res = await runMiddleware(routes.assistant);
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toContain("/account/login");
+  });
 });
 
 describe("authMiddleware — local-mode onboarding fork", () => {

--- a/apps/web/src/lib/auth/auth-middleware.ts
+++ b/apps/web/src/lib/auth/auth-middleware.ts
@@ -43,9 +43,10 @@ export const authMiddleware: MiddlewareFunction = async ({ request, context }, n
       if (url.pathname.startsWith("/assistant/onboarding/")) {
         return next();
       }
-      // Fresh user: route to the onboarding welcome. Returning user
-      // with an expired session: route to login so they re-auth.
-      if (!readOnboardingCompleted()) {
+      // Fresh user with no assistants: route to onboarding welcome.
+      // Returning user with existing assistants: fall through to
+      // login so the local login page can auto-connect them.
+      if (!hasAssistants() && !readOnboardingCompleted()) {
         throw redirect(routes.onboarding.welcome);
       }
     }

--- a/apps/web/src/lib/auth/auth-middleware.ts
+++ b/apps/web/src/lib/auth/auth-middleware.ts
@@ -18,8 +18,10 @@ import { useAuthStore, type AuthUser } from "@/stores/auth-store";
 import { isAuthenticated, isSessionSettled } from "@/stores/session-status";
 import { isGatewayAuthMode } from "@/lib/auth/gateway-session";
 import { isLocalMode, hasAssistants } from "@/lib/local-mode";
+import { readOnboardingCompleted } from "@/domains/onboarding/prefs";
 import { resolveLocalOnboardingRoute } from "@/utils/local-onboarding-route";
 import { whenStoreState } from "@/utils/when-store-state";
+import { routes } from "@/utils/routes";
 
 export const authUserContext = createRouterContext<AuthUser | null>(null);
 
@@ -35,6 +37,19 @@ export const authMiddleware: MiddlewareFunction = async ({ request, context }, n
     if (isGatewayAuthMode()) {
       return next();
     }
+
+    if (isLocalMode()) {
+      const url = new URL(request.url);
+      if (url.pathname.includes("/onboarding/")) {
+        return next();
+      }
+      // Fresh user: route to the onboarding welcome. Returning user
+      // with an expired session: route to login so they re-auth.
+      if (!readOnboardingCompleted()) {
+        throw redirect(routes.onboarding.welcome);
+      }
+    }
+
     const url = new URL(request.url);
     const returnTo = encodeURIComponent(url.pathname + url.search);
     throw redirect(`/account/login?returnTo=${returnTo}`);

--- a/apps/web/src/lib/auth/auth-middleware.ts
+++ b/apps/web/src/lib/auth/auth-middleware.ts
@@ -18,7 +18,7 @@ import { useAuthStore, type AuthUser } from "@/stores/auth-store";
 import { isAuthenticated, isSessionSettled } from "@/stores/session-status";
 import { isGatewayAuthMode } from "@/lib/auth/gateway-session";
 import { isLocalMode, hasAssistants } from "@/lib/local-mode";
-import { readOnboardingCompleted } from "@/domains/onboarding/prefs";
+import { clearOnboardingCompleted, readOnboardingCompleted } from "@/domains/onboarding/prefs";
 import { resolveLocalOnboardingRoute } from "@/utils/local-onboarding-route";
 import { whenStoreState } from "@/utils/when-store-state";
 import { routes } from "@/utils/routes";
@@ -56,6 +56,12 @@ export const authMiddleware: MiddlewareFunction = async ({ request, context }, n
   }
 
   if (isLocalMode() && !hasAssistants()) {
+    // The lockfile was emptied (assistants retired / disk reset) but
+    // localStorage still has the completion flag from a prior onboarding.
+    // Clear it so onboardingCompletedMiddleware doesn't bounce back here.
+    if (readOnboardingCompleted()) {
+      clearOnboardingCompleted();
+    }
     const url = new URL(request.url);
     if (!url.pathname.startsWith("/assistant/onboarding/") && !url.pathname.includes("/account")) {
       throw redirect(await resolveLocalOnboardingRoute());

--- a/apps/web/src/lib/auth/auth-middleware.ts
+++ b/apps/web/src/lib/auth/auth-middleware.ts
@@ -40,7 +40,7 @@ export const authMiddleware: MiddlewareFunction = async ({ request, context }, n
 
     if (isLocalMode()) {
       const url = new URL(request.url);
-      if (url.pathname.includes("/onboarding/")) {
+      if (url.pathname.startsWith("/assistant/onboarding/")) {
         return next();
       }
       // Fresh user: route to the onboarding welcome. Returning user
@@ -57,7 +57,7 @@ export const authMiddleware: MiddlewareFunction = async ({ request, context }, n
 
   if (isLocalMode() && !hasAssistants()) {
     const url = new URL(request.url);
-    if (!url.pathname.includes("/onboarding/") && !url.pathname.includes("/account")) {
+    if (!url.pathname.startsWith("/assistant/onboarding/") && !url.pathname.includes("/account")) {
       throw redirect(await resolveLocalOnboardingRoute());
     }
   }

--- a/apps/web/src/lib/auth/gateway-session.ts
+++ b/apps/web/src/lib/auth/gateway-session.ts
@@ -91,8 +91,14 @@ export async function ensureGatewayToken(tokenUrl?: string, guardianToken?: stri
   if (storedSource && storedSource !== source) {
     clearGatewayToken();
   }
-  const existing = getGatewayToken();
-  if (existing) return existing;
+  // When a guardian token is provided the caller has fresh credentials
+  // (e.g. primeLocalGatewayConnection after a hatch). Force-acquire so
+  // we don't return a stale JWT signed by a previous gateway instance
+  // that happened to run on the same port.
+  if (!guardianToken) {
+    const existing = getGatewayToken();
+    if (existing) return existing;
+  }
   return acquireGatewayToken(tokenUrl, guardianToken);
 }
 

--- a/cli/src/lib/hatch-local.ts
+++ b/cli/src/lib/hatch-local.ts
@@ -270,10 +270,9 @@ export async function hatchLocal(
         );
         await new Promise((r) => setTimeout(r, delayMs));
       } else {
-        reporter.error(
-          `⚠️  Guardian token lease failed after ${maxLeaseAttempts} attempts: ${err}\n` +
-            `   The assistant is running but guardian-token.json was not written.\n` +
-            `   If the desktop app loses its stored credentials, re-hatch to recover.`,
+        throw new Error(
+          `Guardian token lease failed after ${maxLeaseAttempts} attempts: ${err}\n` +
+            `The assistant started but cannot be authenticated. Re-run \`vellum hatch\` to retry.`,
         );
       }
     }

--- a/cli/src/lib/hatch-local.ts
+++ b/cli/src/lib/hatch-local.ts
@@ -270,9 +270,13 @@ export async function hatchLocal(
         );
         await new Promise((r) => setTimeout(r, delayMs));
       } else {
+        reporter.error(
+          `\n❌ Guardian token lease failed — stopping assistant to avoid orphaned processes.`,
+        );
+        await stopLocalProcesses(resources);
         throw new Error(
           `Guardian token lease failed after ${maxLeaseAttempts} attempts: ${err}\n` +
-            `The assistant started but cannot be authenticated. Re-run \`vellum hatch\` to retry.`,
+            `The assistant was stopped. Re-run \`vellum hatch\` to retry.`,
         );
       }
     }


### PR DESCRIPTION
## Summary

- **Fix Google OAuth login in Electron**: The navigation guard was blocking Google's JavaScript navigations mid-OAuth flow, ejecting the user to Chrome. Now the guard allows continued navigation when the main window is already on an external origin (mid-OAuth).
- **Use `/onboarding/welcome` as the entry point in local mode**: Unauthenticated users in local mode now see the onboarding welcome screen (with "Log In" / "Continue without account") instead of the standalone login page.
- **Move hatch trigger from useEffect to explicit button click**: The privacy screen's "Start" button now fires the hatch before navigating to the hatching screen. The hatching screen picks up the in-flight promise instead of triggering its own — eliminates double-hatch from effect re-runs.
- **Fix stale gateway token after port reuse**: When a new assistant hatches on the same port as a retired one, `ensureGatewayToken` now force-acquires a fresh JWT instead of returning a stale cached token signed by the old gateway.
- **Fail hatch when guardian token lease fails**: The CLI's hatch command now throws instead of silently continuing when the guardian token can't be leased, preventing unusable assistants.

## Test plan

- [ ] Run `bun run dev` (or `dev:standalone`) in `apps/macos`
- [ ] Verify the app starts at `/onboarding/welcome` on a fresh state (clear localStorage)
- [ ] Click "Continue with Google" — OAuth flow should complete within the Electron window
- [ ] Go through the full onboarding flow choosing "Local" hosting
- [ ] Verify only one assistant is hatched (check `vellum ps`)
- [ ] Verify gateway API calls succeed (no 401s) after hatching
- [ ] Retire the assistant, re-hatch — verify the new assistant works on the same port
- [ ] Force-reload mid-hatching — verify redirect back to onboarding, not a stuck spinner

🤖 Generated with [Claude Code](https://claude.com/claude-code)