### PR TITLE
Add chat choice and copy surfaces

### DIFF
--- a/apps/web/src/domains/chat/components/surfaces/choice-copy-surfaces.stories.tsx
+++ b/apps/web/src/domains/chat/components/surfaces/choice-copy-surfaces.stories.tsx
@@ -1,0 +1,174 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+
+import type { Surface } from "@/domains/chat/types/types";
+
+import { SurfaceRouter } from "./surface-router";
+
+const meta: Meta = {
+  title: "Chat/Surfaces/ChoiceAndCopy",
+  parameters: {
+    layout: "padded",
+  },
+  decorators: [
+    (Story) => (
+      <div className="max-w-[620px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj;
+
+function makeChoiceSurface(overrides: Partial<Surface> = {}): Surface {
+  return {
+    surfaceId: "choice-surface",
+    surfaceType: "choice",
+    title: "Pick a next move",
+    data: {
+      description: "Choose where the assistant should start.",
+      options: [
+        {
+          id: "inbox",
+          title: "Clean up my inbox",
+          description:
+            "Archive low-value mail and surface the important threads.",
+          recommended: true,
+          data: { outcome: "inbox_cleanup" },
+        },
+        {
+          id: "calendar",
+          title: "Plan my week",
+          description: "Find scheduling conflicts and protect focus blocks.",
+          data: { outcome: "weekly_planning" },
+        },
+        {
+          id: "research",
+          title: "Summarize open research",
+          description: "Turn scattered notes into the next concrete decision.",
+          data: { outcome: "research_summary" },
+        },
+      ],
+    },
+    ...overrides,
+  };
+}
+
+function makeCopyBlockSurface(overrides: Partial<Surface> = {}): Surface {
+  return {
+    surfaceId: "copy-block-surface",
+    surfaceType: "copy_block",
+    data: {
+      label: "Assistant migration prompt",
+      language: "text",
+      text: "Summarize what you know about me, the way I like to work, recurring tasks you help with, and any instructions or workflows I should carry into a new assistant. Keep it concise but specific.",
+    },
+    ...overrides,
+  };
+}
+
+function InteractiveSurfacePreview({
+  initialSurface,
+}: {
+  initialSurface: Surface;
+}) {
+  const [surface, setSurface] = useState(initialSurface);
+
+  return (
+    <SurfaceRouter
+      surface={surface}
+      onAction={(_surfaceId, actionId, data) => {
+        const choiceTitle =
+          typeof data?.choiceTitle === "string" ? data.choiceTitle : undefined;
+        const selectedTitles = Array.isArray(data?.selectedTitles)
+          ? data.selectedTitles.filter(
+              (title): title is string => typeof title === "string",
+            )
+          : [];
+        const label =
+          choiceTitle ??
+          (selectedTitles.length === 1
+            ? selectedTitles[0]
+            : selectedTitles.length > 1
+              ? `${selectedTitles.length} outcomes selected`
+              : actionId);
+
+        setSurface((current) => ({
+          ...current,
+          completed: true,
+          completionSummary: `User chose: "${label}"`,
+        }));
+      }}
+    />
+  );
+}
+
+export const RecommendedChoice: Story = {
+  render: () => (
+    <InteractiveSurfacePreview initialSurface={makeChoiceSurface()} />
+  ),
+};
+
+export const MultiSelectChoice: Story = {
+  render: () => (
+    <InteractiveSurfacePreview
+      initialSurface={makeChoiceSurface({
+        data: {
+          description: "Pick every outcome worth doing now.",
+          selectionMode: "multiple",
+          submitLabel: "Run selected",
+          options: [
+            {
+              id: "inbox",
+              title: "Clean up my inbox",
+              description:
+                "Archive low-value mail and surface the important threads.",
+              recommended: true,
+            },
+            {
+              id: "calendar",
+              title: "Plan my week",
+              description:
+                "Find scheduling conflicts and protect focus blocks.",
+            },
+            {
+              id: "research",
+              title: "Summarize open research",
+              description:
+                "Turn scattered notes into the next concrete decision.",
+            },
+          ],
+        },
+      })}
+    />
+  ),
+};
+
+export const CopyBlock: Story = {
+  render: () => (
+    <SurfaceRouter surface={makeCopyBlockSurface()} onAction={() => {}} />
+  ),
+};
+
+export const ActivationRailStack: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <SurfaceRouter surface={makeCopyBlockSurface()} onAction={() => {}} />
+      <InteractiveSurfacePreview initialSurface={makeChoiceSurface()} />
+    </div>
+  ),
+};
+
+export const CompletedChoice: Story = {
+  render: () => (
+    <SurfaceRouter
+      surface={makeChoiceSurface({
+        completed: true,
+        completionSummary: 'User chose: "Clean up my inbox"',
+      })}
+      onAction={() => {}}
+    />
+  ),
+};

--- a/apps/web/src/domains/chat/components/surfaces/choice-copy-surfaces.test.tsx
+++ b/apps/web/src/domains/chat/components/surfaces/choice-copy-surfaces.test.tsx
@@ -1,0 +1,194 @@
+import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+
+mock.module("@/domains/chat/components/chat-markdown-message", () => ({
+  ChatMarkdownMessage: ({ content }: { content: string }) => (
+    <div>{content}</div>
+  ),
+}));
+
+import { ChoiceSurface } from "@/domains/chat/components/surfaces/choice-surface";
+import { CopyBlockSurface } from "@/domains/chat/components/surfaces/copy-block-surface";
+import { SurfaceRouter } from "@/domains/chat/components/surfaces/surface-router";
+import type { Surface } from "@/domains/chat/types/types";
+
+afterAll(() => {
+  mock.restore();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+function makeSurface(overrides: Partial<Surface>): Surface {
+  return {
+    surfaceId: "surface-1",
+    surfaceType: "choice",
+    data: {},
+    ...overrides,
+  };
+}
+
+describe("ChoiceSurface", () => {
+  test("highlights recommended options and commits single-select choices on click", () => {
+    const onAction = mock(() => {});
+    const { getByRole, getByText } = render(
+      <ChoiceSurface
+        surface={makeSurface({
+          title: "Pick an outcome",
+          data: {
+            description: "Choose the best next move.",
+            options: [
+              {
+                id: "inbox",
+                title: "Clean up my inbox",
+                description: "Archive noise and surface the important threads.",
+                recommended: true,
+                data: { outcome: "inbox_cleanup" },
+              },
+              { id: "calendar", title: "Plan my week" },
+            ],
+          },
+        })}
+        onAction={onAction}
+      />,
+    );
+
+    expect(getByText("Recommended")).toBeTruthy();
+
+    fireEvent.click(getByRole("button", { name: /clean up my inbox/i }));
+
+    expect(onAction).toHaveBeenCalledWith("surface-1", "inbox", {
+      choiceId: "inbox",
+      choiceTitle: "Clean up my inbox",
+      selectedIds: ["inbox"],
+      selectedTitles: ["Clean up my inbox"],
+      choiceDescription: "Archive noise and surface the important threads.",
+      recommended: true,
+      outcome: "inbox_cleanup",
+    });
+  });
+
+  test("multi-select choices require an explicit submit action", () => {
+    const onAction = mock(() => {});
+    const { getByRole } = render(
+      <ChoiceSurface
+        surface={makeSurface({
+          data: {
+            selectionMode: "multiple",
+            submitLabel: "Run these",
+            options: [
+              { id: "inbox", title: "Clean up my inbox" },
+              { id: "calendar", title: "Plan my week" },
+            ],
+          },
+        })}
+        onAction={onAction}
+      />,
+    );
+
+    const submit = getByRole("button", { name: /run these/i });
+    expect((submit as HTMLButtonElement).disabled).toBe(true);
+
+    fireEvent.click(getByRole("button", { name: /clean up my inbox/i }));
+    fireEvent.click(getByRole("button", { name: /plan my week/i }));
+    expect((submit as HTMLButtonElement).disabled).toBe(false);
+
+    fireEvent.click(submit);
+
+    expect(onAction).toHaveBeenCalledWith("surface-1", "submit", {
+      selectedIds: ["inbox", "calendar"],
+      selectedTitles: ["Clean up my inbox", "Plan my week"],
+      choices: [
+        { id: "inbox", title: "Clean up my inbox" },
+        { id: "calendar", title: "Plan my week" },
+      ],
+    });
+  });
+
+  test("recommended multi-select options are auto-selected but can be deselected", () => {
+    const onAction = mock(() => {});
+    const { getByRole } = render(
+      <ChoiceSurface
+        surface={makeSurface({
+          data: {
+            selectionMode: "multiple",
+            submitLabel: "Run these",
+            options: [
+              { id: "inbox", title: "Clean up my inbox", recommended: true },
+              { id: "calendar", title: "Plan my week" },
+            ],
+          },
+        })}
+        onAction={onAction}
+      />,
+    );
+
+    const recommended = getByRole("button", { name: /clean up my inbox/i });
+    const submit = getByRole("button", { name: /run these/i });
+
+    expect(recommended.getAttribute("aria-pressed")).toBe("true");
+    expect(recommended.querySelector("svg")).not.toBeNull();
+    expect((submit as HTMLButtonElement).disabled).toBe(false);
+
+    fireEvent.click(recommended);
+    expect(recommended.getAttribute("aria-pressed")).toBe("false");
+    expect(recommended.querySelector("svg")).toBeNull();
+    expect((submit as HTMLButtonElement).disabled).toBe(true);
+    expect(onAction).not.toHaveBeenCalled();
+  });
+});
+
+describe("CopyBlockSurface", () => {
+  test("renders a visible copy affordance for the block text", async () => {
+    const writeText = mock(() => Promise.resolve());
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+
+    const { getByRole, getByText } = render(
+      <CopyBlockSurface
+        surface={makeSurface({
+          surfaceType: "copy_block",
+          data: {
+            label: "Port prompt",
+            text: "Paste this into another assistant.",
+          },
+        })}
+        onAction={() => {}}
+      />,
+    );
+
+    expect(getByText("Paste this into another assistant.")).toBeTruthy();
+
+    fireEvent.click(getByRole("button", { name: "Copy" }));
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(
+        "Paste this into another assistant.",
+      );
+    });
+    expect(getByRole("button", { name: "Copied" })).toBeTruthy();
+  });
+});
+
+describe("SurfaceRouter", () => {
+  test("collapses completed choice surfaces into a completion chip", () => {
+    const { queryByText, getByText } = render(
+      <SurfaceRouter
+        surface={makeSurface({
+          completed: true,
+          completionSummary: 'User chose: "Clean up my inbox"',
+          data: {
+            options: [{ id: "inbox", title: "Clean up my inbox" }],
+          },
+        })}
+        onAction={() => {}}
+      />,
+    );
+
+    expect(queryByText("Clean up my inbox")).toBeNull();
+    expect(getByText('User chose: "Clean up my inbox"')).toBeTruthy();
+  });
+});

--- a/apps/web/src/domains/chat/components/surfaces/choice-surface.tsx
+++ b/apps/web/src/domains/chat/components/surfaces/choice-surface.tsx
@@ -1,0 +1,218 @@
+import { Check, Loader2 } from "lucide-react";
+import { useMemo, useState } from "react";
+
+import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-message";
+import type { Surface } from "@/domains/chat/types/types";
+
+interface ChoiceOption {
+  id: string;
+  title: string;
+  description?: string;
+  recommended?: boolean;
+  data?: Record<string, unknown>;
+}
+
+interface ChoiceSurfaceData {
+  description?: string;
+  options?: ChoiceOption[];
+  selectionMode?: "single" | "multiple";
+  commitOnSelect?: boolean;
+  submitLabel?: string;
+}
+
+interface ChoiceSurfaceProps {
+  surface: Surface;
+  onAction: (
+    surfaceId: string,
+    actionId: string,
+    data?: Record<string, unknown>,
+  ) => void;
+}
+
+const EMPTY_OPTIONS: ChoiceOption[] = [];
+
+function buildInitialSelectedIds(
+  selectionMode: ChoiceSurfaceData["selectionMode"],
+  options: ChoiceOption[],
+): Set<string> {
+  if (selectionMode !== "multiple") return new Set();
+  return new Set(
+    options
+      .filter((option) => option.recommended === true)
+      .map((option) => option.id),
+  );
+}
+
+function buildChoicePayload(option: ChoiceOption): Record<string, unknown> {
+  return {
+    choiceId: option.id,
+    choiceTitle: option.title,
+    selectedIds: [option.id],
+    selectedTitles: [option.title],
+    ...(option.description ? { choiceDescription: option.description } : {}),
+    ...(option.recommended ? { recommended: true } : {}),
+    ...(option.data ?? {}),
+  };
+}
+
+export function ChoiceSurface({ surface, onAction }: ChoiceSurfaceProps) {
+  const data = surface.data as ChoiceSurfaceData;
+  const options = data.options ?? EMPTY_OPTIONS;
+  const selectionMode = data.selectionMode ?? "single";
+  const commitOnSelect =
+    selectionMode === "single" ? data.commitOnSelect !== false : false;
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(() =>
+    buildInitialSelectedIds(selectionMode, options),
+  );
+  const [submitting, setSubmitting] = useState<string | null>(null);
+
+  const selectedOptions = useMemo(
+    () => options.filter((option) => selectedIds.has(option.id)),
+    [options, selectedIds],
+  );
+
+  const submitOption = async (option: ChoiceOption) => {
+    if (submitting) return;
+    setSubmitting(option.id);
+    try {
+      await onAction(surface.surfaceId, option.id, buildChoicePayload(option));
+    } catch {
+      setSubmitting(null);
+    }
+  };
+
+  const toggleOption = (option: ChoiceOption) => {
+    if (commitOnSelect) {
+      void submitOption(option);
+      return;
+    }
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (selectionMode === "single") {
+        if (next.has(option.id)) {
+          next.clear();
+        } else {
+          next.clear();
+          next.add(option.id);
+        }
+        return next;
+      }
+      if (next.has(option.id)) {
+        next.delete(option.id);
+      } else {
+        next.add(option.id);
+      }
+      return next;
+    });
+  };
+
+  const handleSubmit = async () => {
+    if (selectedOptions.length === 0 || submitting) return;
+    setSubmitting("submit");
+    try {
+      await onAction(surface.surfaceId, "submit", {
+        selectedIds: selectedOptions.map((option) => option.id),
+        selectedTitles: selectedOptions.map((option) => option.title),
+        choices: selectedOptions.map((option) => ({
+          id: option.id,
+          title: option.title,
+          ...(option.description ? { description: option.description } : {}),
+          ...(option.recommended ? { recommended: true } : {}),
+          ...(option.data ? { data: option.data } : {}),
+        })),
+      });
+    } catch {
+      setSubmitting(null);
+    }
+  };
+
+  return (
+    <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-lift)] p-4">
+      {surface.title && (
+        <div className="text-title-small text-[var(--content-strong)]">
+          {surface.title}
+        </div>
+      )}
+      {data.description && (
+        <ChatMarkdownMessage
+          content={data.description}
+          className="mt-1 text-body-medium-lighter text-[var(--content-quiet)]"
+        />
+      )}
+
+      <div className="mt-3 grid gap-2">
+        {options.map((option) => {
+          const selected = selectedIds.has(option.id);
+          const optionSubmitting = submitting === option.id;
+          return (
+            <button
+              key={option.id}
+              type="button"
+              aria-pressed={selected}
+              disabled={submitting !== null}
+              onClick={() => toggleOption(option)}
+              className={[
+                "group flex w-full items-start gap-3 rounded-lg border p-3 text-left transition-colors",
+                option.recommended
+                  ? "border-[var(--primary-base)] bg-[var(--primary-base)]/10"
+                  : "border-[var(--border-element)] bg-[var(--surface-base)] hover:bg-[var(--surface-hover)]",
+                selected ? "ring-1 ring-[var(--primary-base)]" : "",
+                submitting !== null ? "opacity-70" : "",
+              ].join(" ")}
+            >
+              <span
+                className={[
+                  "mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full border",
+                  selected
+                    ? "border-[var(--primary-base)] bg-[var(--primary-base)] text-[var(--content-inset)]"
+                    : option.recommended
+                      ? "border-[var(--primary-base)] bg-[var(--surface-base)]"
+                      : "border-[var(--border-element)]",
+                ].join(" ")}
+              >
+                {optionSubmitting ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : selected ? (
+                  <Check className="h-3.5 w-3.5" />
+                ) : null}
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="flex flex-wrap items-center gap-2">
+                  <span className="text-body-medium-default text-[var(--content-strong)]">
+                    {option.title}
+                  </span>
+                  {option.recommended && (
+                    <span className="rounded-full bg-[var(--primary-base)] px-2 py-0.5 text-label-small-default text-[var(--content-inset)]">
+                      Recommended
+                    </span>
+                  )}
+                </span>
+                {option.description && (
+                  <span className="mt-1 block text-body-small-default text-[var(--content-quiet)]">
+                    {option.description}
+                  </span>
+                )}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      {!commitOnSelect && (
+        <div className="mt-3 flex justify-end">
+          <button
+            type="button"
+            disabled={selectedOptions.length === 0 || submitting !== null}
+            onClick={handleSubmit}
+            className="inline-flex items-center gap-2 rounded-lg bg-[var(--primary-base)] px-4 py-2 text-body-medium-default text-[var(--content-inset)] transition-opacity hover:opacity-90 disabled:opacity-50"
+          >
+            {submitting === "submit" && (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            )}
+            {data.submitLabel ?? "Continue"}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/domains/chat/components/surfaces/copy-block-surface.tsx
+++ b/apps/web/src/domains/chat/components/surfaces/copy-block-surface.tsx
@@ -1,0 +1,61 @@
+import { Check, Copy } from "lucide-react";
+import { useState } from "react";
+
+import type { Surface } from "@/domains/chat/types/types";
+
+interface CopyBlockSurfaceData {
+  text?: string;
+  label?: string;
+  language?: string;
+}
+
+interface CopyBlockSurfaceProps {
+  surface: Surface;
+  onAction: (
+    surfaceId: string,
+    actionId: string,
+    data?: Record<string, unknown>,
+  ) => void;
+}
+
+export function CopyBlockSurface({ surface }: CopyBlockSurfaceProps) {
+  const data = surface.data as CopyBlockSurfaceData;
+  const [copied, setCopied] = useState(false);
+  const text = data.text ?? "";
+  const label = data.label ?? data.language;
+
+  const handleCopy = async () => {
+    if (!text) return;
+    await navigator.clipboard?.writeText(text);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1600);
+  };
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-[var(--border-element)] bg-[var(--surface-lift)] p-3">
+      {label && (
+        <div className="mb-2 truncate text-label-small-default text-[var(--content-tertiary)]">
+          {label}
+        </div>
+      )}
+      <pre className="max-h-96 overflow-auto whitespace-pre-wrap break-words text-body-medium-default font-medium leading-snug text-[var(--content-strong)]">
+        {text}
+      </pre>
+      <div className="mt-3 flex justify-end">
+        <button
+          type="button"
+          onClick={handleCopy}
+          disabled={!text}
+          className="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-md border border-[var(--border-element)] bg-[var(--surface-base)] px-2.5 text-label-medium-default text-[var(--content-secondary)] transition-colors hover:bg-[var(--surface-hover)] hover:text-[var(--content-strong)] disabled:opacity-50"
+        >
+          {copied ? (
+            <Check className="h-3.5 w-3.5" />
+          ) : (
+            <Copy className="h-3.5 w-3.5" />
+          )}
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/domains/chat/components/surfaces/surface-router.tsx
+++ b/apps/web/src/domains/chat/components/surfaces/surface-router.tsx
@@ -1,4 +1,3 @@
-
 import { CheckCircle, XCircle } from "lucide-react";
 
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
@@ -7,7 +6,9 @@ import type { Surface } from "@/domains/chat/types/types";
 import { BrowserViewSurface } from "@/domains/chat/components/surfaces/browser-view-surface";
 import { CallSummarySurface } from "@/domains/chat/components/surfaces/call-summary-surface";
 import { CardSurface } from "@/domains/chat/components/surfaces/card-surface";
+import { ChoiceSurface } from "@/domains/chat/components/surfaces/choice-surface";
 import { ConfirmationSurface } from "@/domains/chat/components/surfaces/confirmation-surface";
+import { CopyBlockSurface } from "@/domains/chat/components/surfaces/copy-block-surface";
 import { DocumentPreviewSurface } from "@/domains/chat/components/surfaces/document-preview-surface";
 import { DynamicPageSurface } from "@/domains/chat/components/surfaces/dynamic-page-surface";
 import { FileUploadSurface } from "@/domains/chat/components/surfaces/file-upload-surface";
@@ -19,7 +20,11 @@ import { TaskPreferencesSurface } from "@/domains/chat/components/surfaces/task-
 
 export interface SurfaceRouterProps {
   surface: Surface;
-  onAction: (surfaceId: string, actionId: string, data?: Record<string, unknown>) => void;
+  onAction: (
+    surfaceId: string,
+    actionId: string,
+    data?: Record<string, unknown>,
+  ) => void;
   assistantId?: string | null;
   onOpenApp?: (appId: string) => void;
   onOpenDocument?: (documentSurfaceId: string) => void;
@@ -37,7 +42,13 @@ export function SurfaceRouter({
   onOpenDocument,
   toolCalls,
 }: SurfaceRouterProps) {
-  const CHIP_COLLAPSE_TYPES = ["form", "confirmation", "file_upload", "task_preferences"];
+  const CHIP_COLLAPSE_TYPES = [
+    "choice",
+    "form",
+    "confirmation",
+    "file_upload",
+    "task_preferences",
+  ];
   if (surface.completed && CHIP_COLLAPSE_TYPES.includes(surface.surfaceType)) {
     const isCancelled = surface.completionSummary === "Cancelled";
     if (isCancelled) {
@@ -68,6 +79,12 @@ export function SurfaceRouter({
 
     case "card":
       return <CardSurface surface={surface} onAction={onAction} />;
+
+    case "choice":
+      return <ChoiceSurface surface={surface} onAction={onAction} />;
+
+    case "copy_block":
+      return <CopyBlockSurface surface={surface} onAction={onAction} />;
 
     case "list":
       return <ListSurface surface={surface} onAction={onAction} />;

--- a/apps/web/src/domains/chat/types/types.test.ts
+++ b/apps/web/src/domains/chat/types/types.test.ts
@@ -7,9 +7,7 @@ import {
   type Surface,
 } from "@/domains/chat/types/types";
 
-function makeSurface(
-  overrides: Partial<Surface> = {},
-): Surface {
+function makeSurface(overrides: Partial<Surface> = {}): Surface {
   return {
     surfaceId: "test-surface",
     surfaceType: "card",
@@ -32,7 +30,9 @@ function makeToolCall(
 
 describe("isSurfaceInteractive", () => {
   test("card without actions is not interactive", () => {
-    expect(isSurfaceInteractive(makeSurface({ surfaceType: "card" }))).toBe(false);
+    expect(isSurfaceInteractive(makeSurface({ surfaceType: "card" }))).toBe(
+      false,
+    );
   });
 
   test("card with actions is interactive", () => {
@@ -47,7 +47,9 @@ describe("isSurfaceInteractive", () => {
   });
 
   test("table without actions is not interactive", () => {
-    expect(isSurfaceInteractive(makeSurface({ surfaceType: "table" }))).toBe(false);
+    expect(isSurfaceInteractive(makeSurface({ surfaceType: "table" }))).toBe(
+      false,
+    );
   });
 
   test("table with actions is interactive", () => {
@@ -62,7 +64,9 @@ describe("isSurfaceInteractive", () => {
   });
 
   test("list without actions is not interactive", () => {
-    expect(isSurfaceInteractive(makeSurface({ surfaceType: "list" }))).toBe(false);
+    expect(isSurfaceInteractive(makeSurface({ surfaceType: "list" }))).toBe(
+      false,
+    );
   });
 
   test("list with actions is interactive", () => {
@@ -77,19 +81,39 @@ describe("isSurfaceInteractive", () => {
   });
 
   test("form is always interactive", () => {
-    expect(isSurfaceInteractive(makeSurface({ surfaceType: "form" }))).toBe(true);
+    expect(isSurfaceInteractive(makeSurface({ surfaceType: "form" }))).toBe(
+      true,
+    );
   });
 
   test("confirmation is always interactive", () => {
-    expect(isSurfaceInteractive(makeSurface({ surfaceType: "confirmation" }))).toBe(true);
+    expect(
+      isSurfaceInteractive(makeSurface({ surfaceType: "confirmation" })),
+    ).toBe(true);
   });
 
   test("file_upload is always interactive", () => {
-    expect(isSurfaceInteractive(makeSurface({ surfaceType: "file_upload" }))).toBe(true);
+    expect(
+      isSurfaceInteractive(makeSurface({ surfaceType: "file_upload" })),
+    ).toBe(true);
+  });
+
+  test("choice is always interactive", () => {
+    expect(isSurfaceInteractive(makeSurface({ surfaceType: "choice" }))).toBe(
+      true,
+    );
+  });
+
+  test("copy_block is display-only without actions", () => {
+    expect(
+      isSurfaceInteractive(makeSurface({ surfaceType: "copy_block" })),
+    ).toBe(false);
   });
 
   test("dynamic_page without actions is not interactive", () => {
-    expect(isSurfaceInteractive(makeSurface({ surfaceType: "dynamic_page" }))).toBe(false);
+    expect(
+      isSurfaceInteractive(makeSurface({ surfaceType: "dynamic_page" })),
+    ).toBe(false);
   });
 
   test("dynamic_page with actions is interactive", () => {
@@ -112,44 +136,40 @@ describe("isSurfaceInteractive", () => {
 
 describe("isSurfaceToolCallComplete", () => {
   test("surface without a linked tool call is complete", () => {
-    expect(
-      isSurfaceToolCallComplete(makeSurface(), [makeToolCall()]),
-    ).toBe(true);
+    expect(isSurfaceToolCallComplete(makeSurface(), [makeToolCall()])).toBe(
+      true,
+    );
   });
 
   test("complete when the linked tool call has completed", () => {
     expect(
-      isSurfaceToolCallComplete(
-        makeSurface({ toolCallId: "tc-1" }),
-        [makeToolCall({ id: "tc-1", status: "completed" })],
-      ),
+      isSurfaceToolCallComplete(makeSurface({ toolCallId: "tc-1" }), [
+        makeToolCall({ id: "tc-1", status: "completed" }),
+      ]),
     ).toBe(true);
   });
 
   test("incomplete while the linked tool call is still running", () => {
     expect(
-      isSurfaceToolCallComplete(
-        makeSurface({ toolCallId: "tc-1" }),
-        [makeToolCall({ id: "tc-1", status: "running" })],
-      ),
+      isSurfaceToolCallComplete(makeSurface({ toolCallId: "tc-1" }), [
+        makeToolCall({ id: "tc-1", status: "running" }),
+      ]),
     ).toBe(false);
   });
 
   test("incomplete when the linked tool call errored", () => {
     expect(
-      isSurfaceToolCallComplete(
-        makeSurface({ toolCallId: "tc-1" }),
-        [makeToolCall({ id: "tc-1", status: "error" })],
-      ),
+      isSurfaceToolCallComplete(makeSurface({ toolCallId: "tc-1" }), [
+        makeToolCall({ id: "tc-1", status: "error" }),
+      ]),
     ).toBe(false);
   });
 
   test("complete when the linked tool call is not present in the message", () => {
     expect(
-      isSurfaceToolCallComplete(
-        makeSurface({ toolCallId: "tc-missing" }),
-        [makeToolCall({ id: "tc-1", status: "running" })],
-      ),
+      isSurfaceToolCallComplete(makeSurface({ toolCallId: "tc-missing" }), [
+        makeToolCall({ id: "tc-1", status: "running" }),
+      ]),
     ).toBe(true);
   });
 

--- a/apps/web/src/domains/chat/types/types.ts
+++ b/apps/web/src/domains/chat/types/types.ts
@@ -13,7 +13,10 @@ import type { SlackMessageLink } from "@/utils/slack-message-link";
 export type { DisplayAttachment } from "@/types/attachment-types";
 
 export type { SlackMessageLink } from "@/utils/slack-message-link";
-export { parseSlackMessageLink, getSlackLinkUrl } from "@/utils/slack-message-link";
+export {
+  parseSlackMessageLink,
+  getSlackLinkUrl,
+} from "@/utils/slack-message-link";
 
 export interface SlackMessageSender {
   id?: string;
@@ -127,6 +130,7 @@ export interface Surface extends ConversationMessageSurface {
  * which is handled by the `hasActions` check below.
  */
 const INHERENTLY_INTERACTIVE_SURFACE_TYPES = [
+  "choice",
   "form",
   "confirmation",
   "file_upload",
@@ -137,15 +141,18 @@ const INHERENTLY_INTERACTIVE_SURFACE_TYPES = [
  * Whether a surface requires user interaction to "complete".
  *
  * A surface is interactive when it either carries explicit action buttons
- * or is an inherently interactive type (form, confirmation, file_upload).
- * Display-only surfaces — tables, cards, lists, and dynamic pages without
+ * or is an inherently interactive type (choice, form, confirmation, file_upload).
+ * Display-only surfaces — copy blocks, tables, cards, lists, and dynamic pages without
  * actions — are non-interactive and should never block the composer.
  */
 export function isSurfaceInteractive(surface: Surface): boolean {
   if (surface.completed) return false;
   const hasActions =
     Array.isArray(surface.actions) && surface.actions.length > 0;
-  return hasActions || INHERENTLY_INTERACTIVE_SURFACE_TYPES.includes(surface.surfaceType);
+  return (
+    hasActions ||
+    INHERENTLY_INTERACTIVE_SURFACE_TYPES.includes(surface.surfaceType)
+  );
 }
 
 /**

--- a/assistant/src/__tests__/ui-choice-copy-surfaces.test.ts
+++ b/assistant/src/__tests__/ui-choice-copy-surfaces.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildCompletionSummary,
+  createSurfaceMutex,
+  type SurfaceConversationContext,
+  surfaceProxyResolver,
+} from "../daemon/conversation-surfaces.js";
+import type {
+  ChoiceSurfaceData,
+  CopyBlockSurfaceData,
+  ServerMessage,
+  SurfaceData,
+  SurfaceType,
+  UiSurfaceShow,
+} from "../daemon/message-protocol.js";
+import { INTERACTIVE_SURFACE_TYPES } from "../daemon/message-protocol.js";
+import { uiShowTool } from "../tools/ui-surface/definitions.js";
+
+function makeContext(sent: ServerMessage[] = []): SurfaceConversationContext {
+  return {
+    conversationId: "session-1",
+    traceEmitter: { emit: () => {} },
+    sendToClient: (msg) => sent.push(msg),
+    pendingSurfaceActions: new Map<string, { surfaceType: SurfaceType }>(),
+    lastSurfaceAction: new Map<
+      string,
+      { actionId: string; data?: Record<string, unknown> }
+    >(),
+    surfaceState: new Map<
+      string,
+      {
+        surfaceType: SurfaceType;
+        data: SurfaceData;
+        title?: string;
+        actions?: Array<{
+          id: string;
+          label: string;
+          style?: string;
+          data?: Record<string, unknown>;
+        }>;
+      }
+    >(),
+    surfaceUndoStacks: new Map<string, string[]>(),
+    accumulatedSurfaceState: new Map<string, Record<string, unknown>>(),
+    surfaceActionRequestIds: new Set<string>(),
+    currentTurnSurfaces: [],
+    isProcessing: () => false,
+    enqueueMessage: () => ({ queued: false, requestId: "req-1" }),
+    getQueueDepth: () => 0,
+    processMessage: async () => "ok",
+    withSurface: createSurfaceMutex(),
+  };
+}
+
+function getSurfaceTypeEnum(): string[] {
+  return (
+    uiShowTool.input_schema as {
+      properties: { surface_type: { enum: string[] } };
+    }
+  ).properties.surface_type.enum;
+}
+
+describe("choice and copy_block surface definitions", () => {
+  test("ui_show advertises the new surface types", () => {
+    expect(getSurfaceTypeEnum()).toContain("choice");
+    expect(getSurfaceTypeEnum()).toContain("copy_block");
+    expect(uiShowTool.description).toContain("recommended");
+    expect(uiShowTool.description).toContain("visible copy button");
+  });
+
+  test("choice is interactive but copy_block is display-only", () => {
+    expect(INTERACTIVE_SURFACE_TYPES).toContain("choice");
+    expect(INTERACTIVE_SURFACE_TYPES).not.toContain("copy_block");
+  });
+});
+
+describe("choice and copy_block surface proxying", () => {
+  test("ui_show normalizes choice options and creates recommended action payloads", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+
+    const result = await surfaceProxyResolver(ctx, "ui_show", {
+      surface_type: "choice",
+      title: "Pick a next move",
+      data: {
+        description: "Choose where to start.",
+        options: [
+          {
+            id: "clean-inbox",
+            title: "Clean up my inbox",
+            description: "Triage unread mail and archive noise.",
+            recommended: true,
+            data: { outcome: "inbox_cleanup" },
+          },
+          { id: "plan-week", title: "Plan my week" },
+          { id: "", title: "Ignored" },
+        ],
+      },
+    });
+
+    expect(result.isError).toBe(false);
+    expect(result.yieldToUser).toBe(true);
+
+    const showMessage = sent.find(
+      (msg): msg is UiSurfaceShow => msg.type === "ui_surface_show",
+    );
+    expect(showMessage).toBeDefined();
+    if (!showMessage || showMessage.surfaceType !== "choice") return;
+
+    const data = showMessage.data as ChoiceSurfaceData;
+    expect(data.options.map((option) => option.id)).toEqual([
+      "clean-inbox",
+      "plan-week",
+    ]);
+    expect(data.options[0].recommended).toBe(true);
+    expect(showMessage.actions?.[0]).toEqual({
+      id: "clean-inbox",
+      label: "Clean up my inbox",
+      style: "primary",
+      data: {
+        choiceId: "clean-inbox",
+        choiceTitle: "Clean up my inbox",
+        selectedIds: ["clean-inbox"],
+        selectedTitles: ["Clean up my inbox"],
+        choiceDescription: "Triage unread mail and archive noise.",
+        recommended: true,
+        outcome: "inbox_cleanup",
+      },
+    });
+    expect(ctx.pendingSurfaceActions.get(showMessage.surfaceId)).toEqual({
+      surfaceType: "choice",
+    });
+  });
+
+  test("ui_show rejects choice surfaces without valid options", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+
+    const result = await surfaceProxyResolver(ctx, "ui_show", {
+      surface_type: "choice",
+      data: { options: [{ id: "", title: "Missing id" }] },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      "choice surfaces require at least one option",
+    );
+    expect(sent).toHaveLength(0);
+  });
+
+  test("ui_show passes copy_block data through without awaiting action", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+
+    const result = await surfaceProxyResolver(ctx, "ui_show", {
+      surface_type: "copy_block",
+      data: {
+        text: "Paste this prompt into another assistant.",
+        label: "Port prompt",
+        language: "text",
+      },
+    });
+
+    expect(result.isError).toBe(false);
+    expect(result.yieldToUser).toBeUndefined();
+
+    const showMessage = sent.find(
+      (msg): msg is UiSurfaceShow => msg.type === "ui_surface_show",
+    );
+    expect(showMessage).toBeDefined();
+    if (!showMessage || showMessage.surfaceType !== "copy_block") return;
+
+    expect(showMessage.data as CopyBlockSurfaceData).toEqual({
+      text: "Paste this prompt into another assistant.",
+      label: "Port prompt",
+      language: "text",
+    });
+    expect(ctx.pendingSurfaceActions.has(showMessage.surfaceId)).toBe(false);
+  });
+
+  test("choice completion summary names multi-select choices", () => {
+    expect(
+      buildCompletionSummary("choice", "submit", {
+        selectedIds: ["a", "b"],
+        selectedTitles: ["Clean up my inbox", "Plan my week"],
+      }),
+    ).toBe('User chose 2 options: "Clean up my inbox", "Plan my week"');
+  });
+});

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -38,7 +38,9 @@ import type { HostAppControlProxy } from "./host-app-control-proxy.js";
 import type { HostCuProxy } from "./host-cu-proxy.js";
 import type {
   CardSurfaceData,
+  ChoiceSurfaceData,
   ConfirmationSurfaceData,
+  CopyBlockSurfaceData,
   DynamicPageSurfaceData,
   FormSurfaceData,
   ListSurfaceData,
@@ -393,6 +395,89 @@ function normalizeTaskProgressCardPatch(
   }
 
   return normalizedPatch;
+}
+
+function normalizeChoiceShowData(
+  rawData: Record<string, unknown>,
+): ChoiceSurfaceData {
+  const options = Array.isArray(rawData.options)
+    ? rawData.options
+        .filter((option): option is Record<string, unknown> =>
+          isPlainObject(option),
+        )
+        .map((option) => {
+          const id = typeof option.id === "string" ? option.id.trim() : "";
+          const title =
+            typeof option.title === "string"
+              ? option.title.trim()
+              : typeof option.label === "string"
+                ? option.label.trim()
+                : "";
+          if (!id || !title) return null;
+          return {
+            id,
+            title,
+            ...(typeof option.description === "string"
+              ? { description: option.description }
+              : {}),
+            ...(option.recommended === true ? { recommended: true } : {}),
+            ...(isPlainObject(option.data)
+              ? { data: option.data as Record<string, unknown> }
+              : {}),
+          };
+        })
+        .filter(
+          (option): option is NonNullable<typeof option> => option !== null,
+        )
+    : [];
+
+  return {
+    ...(typeof rawData.description === "string"
+      ? { description: rawData.description }
+      : {}),
+    options,
+    selectionMode: rawData.selectionMode === "multiple" ? "multiple" : "single",
+    ...(typeof rawData.submitLabel === "string"
+      ? { submitLabel: rawData.submitLabel }
+      : {}),
+    ...(typeof rawData.commitOnSelect === "boolean"
+      ? { commitOnSelect: rawData.commitOnSelect }
+      : {}),
+  };
+}
+
+function normalizeCopyBlockShowData(
+  rawData: Record<string, unknown>,
+): CopyBlockSurfaceData {
+  return {
+    text: typeof rawData.text === "string" ? rawData.text : "",
+    ...(typeof rawData.label === "string" ? { label: rawData.label } : {}),
+    ...(typeof rawData.language === "string"
+      ? { language: rawData.language }
+      : {}),
+  };
+}
+
+function buildChoiceActions(data: ChoiceSurfaceData): Array<{
+  id: string;
+  label: string;
+  style?: string;
+  data?: Record<string, unknown>;
+}> {
+  return data.options.map((option) => ({
+    id: option.id,
+    label: option.title,
+    style: option.recommended ? "primary" : "secondary",
+    data: {
+      choiceId: option.id,
+      choiceTitle: option.title,
+      selectedIds: [option.id],
+      selectedTitles: [option.title],
+      ...(option.description ? { choiceDescription: option.description } : {}),
+      ...(option.recommended ? { recommended: true } : {}),
+      ...(option.data ?? {}),
+    },
+  }));
 }
 
 function isTaskProgressCardData(data: SurfaceData | Record<string, unknown>) {
@@ -1860,6 +1945,12 @@ export function buildCompletionSummary(
   data?: Record<string, unknown>,
   surfaceData?: Record<string, unknown>,
 ): string {
+  const selectedTitles = Array.isArray(data?.selectedTitles)
+    ? data.selectedTitles.filter(
+        (title): title is string => typeof title === "string",
+      )
+    : [];
+
   if (surfaceType === "confirmation") {
     if (actionId === "cancel") {
       const cancelLabel =
@@ -1892,6 +1983,19 @@ export function buildCompletionSummary(
   if (surfaceType === "form") {
     return "Submitted";
   }
+  if (surfaceType === "choice" && data) {
+    const choiceTitle =
+      typeof data.choiceTitle === "string" ? data.choiceTitle : undefined;
+    if (choiceTitle) return `User chose: "${choiceTitle}"`;
+    if (selectedTitles.length === 1)
+      return `User chose: "${selectedTitles[0]}"`;
+    if (selectedTitles.length > 1) {
+      return `User chose ${selectedTitles.length} options: ${selectedTitles
+        .map((title) => `"${title}"`)
+        .join(", ")}`;
+    }
+    return `User chose: ${actionId}`;
+  }
   if (surfaceType === "list" && data) {
     const selectedIds = data.selectedIds as string[] | undefined;
     const actionSuffix = actionId ? ` (action: ${actionId})` : "";
@@ -1922,6 +2026,11 @@ function buildUserFacingLabel(
   surfaceData?: Record<string, unknown>,
 ): string {
   const count = (data?.selectedIds as string[] | undefined)?.length;
+  const selectedTitles = Array.isArray(data?.selectedTitles)
+    ? data.selectedTitles.filter(
+        (title): title is string => typeof title === "string",
+      )
+    : [];
 
   if (surfaceType === "confirmation") {
     if (actionId === "cancel") {
@@ -1948,6 +2057,15 @@ function buildUserFacingLabel(
     return `Selected: ${actionId}`;
   }
   if (surfaceType === "form") return "Submitted";
+  if (surfaceType === "choice") {
+    const choiceTitle =
+      typeof data?.choiceTitle === "string" ? data.choiceTitle : undefined;
+    if (choiceTitle) return choiceTitle;
+    if (selectedTitles.length === 1) return selectedTitles[0];
+    if (selectedTitles.length > 1)
+      return `Selected ${selectedTitles.length} options`;
+    return "Selected";
+  }
 
   // Table / list selection actions
   if (count) {
@@ -2213,11 +2331,15 @@ export async function surfaceProxyResolver(
     const data = (
       surfaceType === "card"
         ? normalizeCardShowData(input, rawData)
-        : surfaceType === "dynamic_page"
-          ? normalizeDynamicPageShowData(input, rawData)
-          : rawData
+        : surfaceType === "choice"
+          ? normalizeChoiceShowData(rawData)
+          : surfaceType === "copy_block"
+            ? normalizeCopyBlockShowData(rawData)
+            : surfaceType === "dynamic_page"
+              ? normalizeDynamicPageShowData(input, rawData)
+              : rawData
     ) as SurfaceData;
-    const actions = input.actions as
+    const inputActions = input.actions as
       | Array<{
           id: string;
           label: string;
@@ -2225,8 +2347,19 @@ export async function surfaceProxyResolver(
           data?: Record<string, unknown>;
         }>
       | undefined;
+    const actions =
+      surfaceType === "choice"
+        ? buildChoiceActions(data as ChoiceSurfaceData)
+        : inputActions;
     // Interactive surfaces default to awaiting user action.
     const hasActions = Array.isArray(actions) && actions.length > 0;
+    if (surfaceType === "choice" && !hasActions) {
+      return {
+        content:
+          "choice surfaces require at least one option with both id and title.",
+        isError: true,
+      };
+    }
     const isInteractive =
       surfaceType === "card"
         ? hasActions

--- a/assistant/src/daemon/message-types/surfaces.ts
+++ b/assistant/src/daemon/message-types/surfaces.ts
@@ -4,6 +4,8 @@
 
 export type SurfaceType =
   | "card"
+  | "choice"
+  | "copy_block"
   | "form"
   | "list"
   | "table"
@@ -14,6 +16,7 @@ export type SurfaceType =
   | "task_preferences";
 
 export const INTERACTIVE_SURFACE_TYPES: SurfaceType[] = [
+  "choice",
   "form",
   "confirmation",
   "dynamic_page",
@@ -38,6 +41,34 @@ export interface CardSurfaceData {
   template?: string;
   /** Arbitrary data consumed by the template renderer. Shape depends on template. */
   templateData?: Record<string, unknown>;
+}
+
+export interface ChoiceOption {
+  id: string;
+  title: string;
+  description?: string;
+  /** Visually highlight this option as the assistant's recommendation. */
+  recommended?: boolean;
+  /** Optional structured payload returned with this choice. */
+  data?: Record<string, unknown>;
+}
+
+export interface ChoiceSurfaceData {
+  description?: string;
+  options: ChoiceOption[];
+  selectionMode?: "single" | "multiple";
+  /**
+   * When true, clicking an option submits it immediately. Defaults to true for
+   * single-select choice surfaces.
+   */
+  commitOnSelect?: boolean;
+  submitLabel?: string;
+}
+
+export interface CopyBlockSurfaceData {
+  text: string;
+  label?: string;
+  language?: string;
 }
 
 export interface FormField {
@@ -150,6 +181,8 @@ export interface DocumentPreviewSurfaceData {
 
 export type SurfaceData =
   | CardSurfaceData
+  | ChoiceSurfaceData
+  | CopyBlockSurfaceData
   | FormSurfaceData
   | ListSurfaceData
   | TableSurfaceData
@@ -197,6 +230,16 @@ export interface UiSurfaceShowCard extends UiSurfaceShowBase {
   data: CardSurfaceData;
 }
 
+export interface UiSurfaceShowChoice extends UiSurfaceShowBase {
+  surfaceType: "choice";
+  data: ChoiceSurfaceData;
+}
+
+export interface UiSurfaceShowCopyBlock extends UiSurfaceShowBase {
+  surfaceType: "copy_block";
+  data: CopyBlockSurfaceData;
+}
+
 export interface UiSurfaceShowForm extends UiSurfaceShowBase {
   surfaceType: "form";
   data: FormSurfaceData;
@@ -234,6 +277,8 @@ export interface UiSurfaceShowDocumentPreview extends UiSurfaceShowBase {
 
 export type UiSurfaceShow =
   | UiSurfaceShowCard
+  | UiSurfaceShowChoice
+  | UiSurfaceShowCopyBlock
   | UiSurfaceShowForm
   | UiSurfaceShowList
   | UiSurfaceShowTable

--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -105,6 +105,8 @@ export const uiShowTool = {
     'Surface structured data or UI in the conversation. For long-form writing use the document skill. For interactive apps, dashboards, games, calculators, or durable tools, call `skill_load` with `skill: "app-builder"` and use the app-builder workflow; do not use `dynamic_page` as a substitute for a persistent app. App-like `dynamic_page` calls are rejected.\n\n' +
     "Surface types (data shapes):\n" +
     '- card: { title, subtitle?, body, metadata?: [{ label, value }], template?, templateData? }. Templates: "weather_forecast" (native weather widget), "task_progress" (live step tracker - update via ui_update on data.templateData; shape: { title, status: "in_progress"|"completed"|"failed", steps: [{ label, status: "pending"|"in_progress"|"completed"|"failed", detail? }] })\n' +
+    "- copy_block: { text, label?, language? }. Shows copyable text with a visible copy button; use for prompts, commands, paths, or snippets the user should copy.\n" +
+    '- choice: { description?, options: [{ id, title, description?, recommended?, data? }], selectionMode?: "single"|"multiple", commitOnSelect?, submitLabel? }. Single-select choices commit on option click by default. Use for outcome offers and follow-up choices; mark the strongest option with recommended: true.\n' +
     '- table: { columns: [{ id, label }], rows: [{ id, cells: Record<id, string | { text, icon?, iconColor?: "success"|"warning"|"error"|"muted" }>, selectable?, selected? }], selectionMode?: "none"|"single"|"multiple", caption? }\n' +
     '- form: { description?, fields: [{ id, type: "text"|"textarea"|"select"|"toggle"|"number"|"password", label, placeholder?, required?, defaultValue?, options?: [{ label, value }] }], submitLabel? }. Multi-page: { pages: [{ id, title, description?, fields }], pageLabels?: { next?, back?, submit? }, submitLabel? }\n' +
     '- list: { items: [{ id, title, subtitle?, icon?, selected? }], selectionMode: "single"|"multiple"|"none" }\n' +
@@ -124,6 +126,8 @@ export const uiShowTool = {
         type: "string",
         enum: [
           "card",
+          "choice",
+          "copy_block",
           "form",
           "list",
           "table",


### PR DESCRIPTION
## Summary
- Add `choice` and `copy_block` chat surface contracts to `ui_show` and daemon surface handling.
- Render recommended single-select and submittable multi-select choice surfaces in chat, plus copyable prompt/code blocks.
- Add Storybook stories for recommended choice, multi-select choice, copy block, activation rail stack, and completed choice states.

## Tests
- `cd assistant && bun test src/__tests__/ui-choice-copy-surfaces.test.ts`
- `cd assistant && bunx tsc --noEmit`
- `cd apps/web && bun test src/domains/chat/components/surfaces/choice-copy-surfaces.test.tsx src/domains/chat/types/types.test.ts`
- `cd apps/web && bun test src/domains/chat/components/surfaces/choice-copy-surfaces.test.tsx`
- `cd apps/web && bunx tsc --noEmit`
- Storybook smoke-tested the activation rail story with Playwright

Related to JARVIS-1090.