### PR TITLE
Persist source conversations for created schedules

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -18205,6 +18205,16 @@ paths:
                           anyOf:
                             - type: number
                             - type: "null"
+                        createdFromConversationId:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        createdFromConversationExists:
+                          type: boolean
+                        createdFromConversationArchivedAt:
+                          anyOf:
+                            - type: number
+                            - type: "null"
                         description:
                           anyOf:
                             - type: string
@@ -18254,6 +18264,9 @@ paths:
                         - maxRetries
                         - retryBackoffMs
                         - timeoutMs
+                        - createdFromConversationId
+                        - createdFromConversationExists
+                        - createdFromConversationArchivedAt
                         - description
                         - mode
                         - status
@@ -18341,6 +18354,16 @@ paths:
                           anyOf:
                             - type: number
                             - type: "null"
+                        createdFromConversationId:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        createdFromConversationExists:
+                          type: boolean
+                        createdFromConversationArchivedAt:
+                          anyOf:
+                            - type: number
+                            - type: "null"
                         description:
                           anyOf:
                             - type: string
@@ -18390,6 +18413,9 @@ paths:
                         - maxRetries
                         - retryBackoffMs
                         - timeoutMs
+                        - createdFromConversationId
+                        - createdFromConversationExists
+                        - createdFromConversationArchivedAt
                         - description
                         - mode
                         - status
@@ -18503,6 +18529,16 @@ paths:
                           anyOf:
                             - type: number
                             - type: "null"
+                        createdFromConversationId:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        createdFromConversationExists:
+                          type: boolean
+                        createdFromConversationArchivedAt:
+                          anyOf:
+                            - type: number
+                            - type: "null"
                         description:
                           anyOf:
                             - type: string
@@ -18552,6 +18588,9 @@ paths:
                         - maxRetries
                         - retryBackoffMs
                         - timeoutMs
+                        - createdFromConversationId
+                        - createdFromConversationExists
+                        - createdFromConversationArchivedAt
                         - description
                         - mode
                         - status
@@ -18638,6 +18677,16 @@ paths:
                           anyOf:
                             - type: number
                             - type: "null"
+                        createdFromConversationId:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        createdFromConversationExists:
+                          type: boolean
+                        createdFromConversationArchivedAt:
+                          anyOf:
+                            - type: number
+                            - type: "null"
                         description:
                           anyOf:
                             - type: string
@@ -18687,6 +18736,9 @@ paths:
                         - maxRetries
                         - retryBackoffMs
                         - timeoutMs
+                        - createdFromConversationId
+                        - createdFromConversationExists
+                        - createdFromConversationArchivedAt
                         - description
                         - mode
                         - status
@@ -18816,6 +18868,16 @@ paths:
                           anyOf:
                             - type: number
                             - type: "null"
+                        createdFromConversationId:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        createdFromConversationExists:
+                          type: boolean
+                        createdFromConversationArchivedAt:
+                          anyOf:
+                            - type: number
+                            - type: "null"
                         description:
                           anyOf:
                             - type: string
@@ -18865,6 +18927,9 @@ paths:
                         - maxRetries
                         - retryBackoffMs
                         - timeoutMs
+                        - createdFromConversationId
+                        - createdFromConversationExists
+                        - createdFromConversationArchivedAt
                         - description
                         - mode
                         - status
@@ -18952,6 +19017,16 @@ paths:
                           anyOf:
                             - type: number
                             - type: "null"
+                        createdFromConversationId:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        createdFromConversationExists:
+                          type: boolean
+                        createdFromConversationArchivedAt:
+                          anyOf:
+                            - type: number
+                            - type: "null"
                         description:
                           anyOf:
                             - type: string
@@ -19001,6 +19076,9 @@ paths:
                         - maxRetries
                         - retryBackoffMs
                         - timeoutMs
+                        - createdFromConversationId
+                        - createdFromConversationExists
+                        - createdFromConversationArchivedAt
                         - description
                         - mode
                         - status
@@ -19166,6 +19244,16 @@ paths:
                           anyOf:
                             - type: number
                             - type: "null"
+                        createdFromConversationId:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        createdFromConversationExists:
+                          type: boolean
+                        createdFromConversationArchivedAt:
+                          anyOf:
+                            - type: number
+                            - type: "null"
                         description:
                           anyOf:
                             - type: string
@@ -19215,6 +19303,9 @@ paths:
                         - maxRetries
                         - retryBackoffMs
                         - timeoutMs
+                        - createdFromConversationId
+                        - createdFromConversationExists
+                        - createdFromConversationArchivedAt
                         - description
                         - mode
                         - status

--- a/assistant/src/__tests__/db-schedule-syntax-migration.test.ts
+++ b/assistant/src/__tests__/db-schedule-syntax-migration.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, test } from "bun:test";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
+import { migrateScheduleSourceConversation } from "../memory/migrations/270-schedule-source-conversation.js";
 import * as schema from "../memory/schema.js";
 import { scheduleJobs } from "../memory/schema.js";
 
@@ -38,6 +39,7 @@ describe("schedule_syntax column migration", () => {
         retry_count INTEGER NOT NULL DEFAULT 0,
         max_retries INTEGER NOT NULL DEFAULT 3,
         retry_backoff_ms INTEGER NOT NULL DEFAULT 60000,
+        created_from_conversation_id TEXT,
         created_by TEXT NOT NULL,
         mode TEXT NOT NULL DEFAULT 'execute',
         routing_intent TEXT NOT NULL DEFAULT 'all_channels',
@@ -134,6 +136,7 @@ describe("schedule_syntax column migration", () => {
     } catch {
       /* already exists */
     }
+    migrateScheduleSourceConversation(db);
 
     const row = db
       .select()
@@ -197,6 +200,8 @@ describe("schedule_syntax column migration", () => {
     } catch {
       /* ok */
     }
+    migrateScheduleSourceConversation(db);
+    migrateScheduleSourceConversation(db);
 
     const now = Date.now();
     raw.exec(

--- a/assistant/src/__tests__/schedule-routes.test.ts
+++ b/assistant/src/__tests__/schedule-routes.test.ts
@@ -40,6 +40,10 @@ mock.module("../daemon/conversation-store.js", () => ({
 }));
 
 import { SYNC_TAGS } from "../daemon/message-types/sync.js";
+import {
+  archiveConversation,
+  createConversation,
+} from "../memory/conversation-crud.js";
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import type { AssistantEvent } from "../runtime/assistant-event.js";
@@ -204,6 +208,70 @@ describe("GET /schedules — default defer exclusion", () => {
       queryParams: { include_all: "true" },
     }) as { schedules: Array<{ id: string }> };
     expect(result.schedules).toHaveLength(2);
+  });
+
+  test("includes source conversation availability metadata", () => {
+    const activeSource = createConversation("Active schedule source");
+    const archivedSource = createConversation("Archived schedule source");
+    expect(archiveConversation(archivedSource.id)).toBe(true);
+
+    createSchedule({
+      name: "Active source schedule",
+      cronExpression: "* * * * *",
+      message: "active source",
+      syntax: "cron",
+      createdFromConversationId: activeSource.id,
+    });
+    createSchedule({
+      name: "Archived source schedule",
+      cronExpression: "0 9 * * *",
+      message: "archived source",
+      syntax: "cron",
+      createdFromConversationId: archivedSource.id,
+    });
+    createSchedule({
+      name: "Missing source schedule",
+      cronExpression: "0 10 * * *",
+      message: "missing source",
+      syntax: "cron",
+      createdFromConversationId: "conv-missing",
+    });
+    createSchedule({
+      name: "No source schedule",
+      cronExpression: "0 11 * * *",
+      message: "no source",
+      syntax: "cron",
+    });
+
+    const route = findRoute("schedules", "GET");
+    const result = route.handler({}) as {
+      schedules: Array<{
+        name: string;
+        createdFromConversationId: string | null;
+        createdFromConversationExists: boolean;
+        createdFromConversationArchivedAt: number | null;
+      }>;
+    };
+
+    const byName = new Map(result.schedules.map((s) => [s.name, s]));
+    const active = byName.get("Active source schedule")!;
+    expect(active.createdFromConversationId).toBe(activeSource.id);
+    expect(active.createdFromConversationExists).toBe(true);
+    expect(active.createdFromConversationArchivedAt).toBeNull();
+
+    const archived = byName.get("Archived source schedule")!;
+    expect(archived.createdFromConversationExists).toBe(true);
+    expect(archived.createdFromConversationArchivedAt).toBeGreaterThan(0);
+
+    const missing = byName.get("Missing source schedule")!;
+    expect(missing.createdFromConversationId).toBe("conv-missing");
+    expect(missing.createdFromConversationExists).toBe(false);
+    expect(missing.createdFromConversationArchivedAt).toBeNull();
+
+    const noSource = byName.get("No source schedule")!;
+    expect(noSource.createdFromConversationId).toBeNull();
+    expect(noSource.createdFromConversationExists).toBe(false);
+    expect(noSource.createdFromConversationArchivedAt).toBeNull();
   });
 
   test("mutation responses also exclude deferred wakes", () => {

--- a/assistant/src/__tests__/schedule-store.test.ts
+++ b/assistant/src/__tests__/schedule-store.test.ts
@@ -179,6 +179,47 @@ describe("createSchedule (cron)", () => {
     expect(retrieved!.cronExpression).toBe("0 * * * *");
   });
 
+  test("defaults source conversation metadata to null", () => {
+    const job = createSchedule({
+      name: "No source conversation",
+      cronExpression: "0 9 * * *",
+      message: "daily check",
+      syntax: "cron",
+    });
+
+    expect(job.createdFromConversationId).toBeNull();
+    expect(getSchedule(job.id)!.createdFromConversationId).toBeNull();
+
+    const raw = getRawDb()
+      .query("SELECT created_from_conversation_id FROM cron_jobs WHERE id = ?")
+      .get(job.id) as { created_from_conversation_id: string | null };
+    expect(raw.created_from_conversation_id).toBeNull();
+  });
+
+  test("persists source conversation metadata through create, list, and update", () => {
+    const job = createSchedule({
+      name: "With source conversation",
+      cronExpression: "0 9 * * *",
+      message: "daily check",
+      syntax: "cron",
+      createdFromConversationId: "conv-source",
+    });
+
+    expect(job.createdFromConversationId).toBe("conv-source");
+    expect(getSchedule(job.id)!.createdFromConversationId).toBe("conv-source");
+    expect(listSchedules()[0].createdFromConversationId).toBe("conv-source");
+
+    const updated = updateSchedule(job.id, {
+      createdFromConversationId: "conv-updated",
+    });
+    expect(updated!.createdFromConversationId).toBe("conv-updated");
+
+    const cleared = updateSchedule(job.id, {
+      createdFromConversationId: null,
+    });
+    expect(cleared!.createdFromConversationId).toBeNull();
+  });
+
   test("stores schedule_syntax in the DB row", () => {
     const job = createSchedule({
       name: "Syntax check",

--- a/assistant/src/__tests__/schedule-tools.test.ts
+++ b/assistant/src/__tests__/schedule-tools.test.ts
@@ -66,6 +66,23 @@ describe("schedule_create tool", () => {
     expect(result.content).toContain("Enabled: true");
   });
 
+  test("persists the creating conversation for recurring schedules", async () => {
+    const result = await executeScheduleCreate(
+      {
+        name: "Recurring source",
+        expression: "0 9 * * *",
+        message: "remember the source",
+      },
+      ctx,
+    );
+
+    expect(result.isError).toBe(false);
+    const row = getRawDb()
+      .query("SELECT created_from_conversation_id FROM cron_jobs LIMIT 1")
+      .get() as { created_from_conversation_id: string | null };
+    expect(row.created_from_conversation_id).toBe(ctx.conversationId);
+  });
+
   test("creates a disabled schedule", async () => {
     const result = await executeScheduleCreate(
       {
@@ -190,6 +207,24 @@ describe("schedule_create with fire_at (one-shot)", () => {
     expect(result.content).toContain("Mode: execute");
     expect(result.content).toContain("One-time reminder");
     expect(result.content).toContain("Status: active");
+  });
+
+  test("persists the creating conversation for one-shot schedules", async () => {
+    const futureDate = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+    const result = await executeScheduleCreate(
+      {
+        name: "One-shot source",
+        fire_at: futureDate,
+        message: "remember this source too",
+      },
+      ctx,
+    );
+
+    expect(result.isError).toBe(false);
+    const row = getRawDb()
+      .query("SELECT created_from_conversation_id FROM cron_jobs LIMIT 1")
+      .get() as { created_from_conversation_id: string | null };
+    expect(row.created_from_conversation_id).toBe(ctx.conversationId);
   });
 
   test("rejects fire_at that is not valid ISO 8601", async () => {

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -189,6 +189,7 @@ import {
   migrateScheduleReuseConversation,
   migrateScheduleScriptColumn,
   migrateScheduleScriptTimeout,
+  migrateScheduleSourceConversation,
   migrateScheduleWakeConversationId,
   migrateSchemaIndexesAndColumns,
   migrateScrubCorruptedImageAttachments,
@@ -474,6 +475,7 @@ export function initializeDb(): void {
     migrateLlmUsageEventsAddAssistantVersion,
     migrateAddMemoryV3Selections,
     migrateScheduleScriptTimeout,
+    migrateScheduleSourceConversation,
     migrateMessagesRoleCreatedAtIndex,
     createAuthFallbackEventsTable,
   ];

--- a/assistant/src/memory/migrations/270-schedule-source-conversation.ts
+++ b/assistant/src/memory/migrations/270-schedule-source-conversation.ts
@@ -1,0 +1,13 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+export function migrateScheduleSourceConversation(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  try {
+    raw.exec(
+      `ALTER TABLE cron_jobs ADD COLUMN created_from_conversation_id TEXT`,
+    );
+  } catch {
+    // Column already exists — nothing to do.
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -257,6 +257,7 @@ export { migrateLlmUsageEventsAddAssistantVersion } from "./267-llm-usage-events
 export { migrateAddMemoryV3Selections } from "./268-add-memory-v3-selections.js";
 export { migrateScheduleScriptTimeout } from "./269-schedule-script-timeout.js";
 export { migrateMessagesRoleCreatedAtIndex } from "./270-messages-role-created-at-index.js";
+export { migrateScheduleSourceConversation } from "./270-schedule-source-conversation.js";
 export { createAuthFallbackEventsTable } from "./271-create-auth-fallback-events.js";
 export {
   MIGRATION_REGISTRY,

--- a/assistant/src/memory/schema/infrastructure.ts
+++ b/assistant/src/memory/schema/infrastructure.ts
@@ -22,6 +22,7 @@ export const cronJobs = sqliteTable("cron_jobs", {
   maxRetries: integer("max_retries").notNull().default(3),
   retryBackoffMs: integer("retry_backoff_ms").notNull().default(60000),
   timeoutMs: integer("timeout_ms"), // script-mode execution timeout override (ms); null = use default
+  createdFromConversationId: text("created_from_conversation_id"),
   createdBy: text("created_by").notNull(), // 'agent' | 'user'
   mode: text("mode").notNull().default("execute"), // 'notify' | 'execute'
   routingIntent: text("routing_intent").notNull().default("all_channels"), // 'single_channel' | 'multi_channel' | 'all_channels'

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -57,6 +57,9 @@ const scheduleSchema = z.object({
   maxRetries: z.number(),
   retryBackoffMs: z.number(),
   timeoutMs: z.number().nullable(),
+  createdFromConversationId: z.string().nullable(),
+  createdFromConversationExists: z.boolean(),
+  createdFromConversationArchivedAt: z.number().nullable(),
   description: z.string().nullable(),
   mode: z.enum(["notify", "execute", "script", "wake"]),
   status: z.enum(["active", "firing", "fired", "cancelled"]),
@@ -83,41 +86,79 @@ const scheduleRunSchema = z.object({
 // Handlers (transport-agnostic)
 // ---------------------------------------------------------------------------
 
+interface CreatedFromConversationState {
+  exists: boolean;
+  archivedAt: number | null;
+}
+
+function getCreatedFromConversationState(
+  conversationId: string | null,
+  cache: Map<string, CreatedFromConversationState>,
+): CreatedFromConversationState {
+  if (!conversationId) {
+    return { exists: false, archivedAt: null };
+  }
+
+  const cached = cache.get(conversationId);
+  if (cached) return cached;
+
+  const conversation = getConversation(conversationId);
+  const state = {
+    exists: conversation !== null,
+    archivedAt: conversation?.archivedAt ?? null,
+  };
+  cache.set(conversationId, state);
+  return state;
+}
+
 function handleListSchedules(queryParams: Record<string, string>) {
   const includeAll = queryParams.include_all === "true";
   const jobs = listSchedules();
   const filtered = includeAll
     ? jobs
     : jobs.filter((j) => j.createdBy !== "defer");
+  const sourceConversationCache = new Map<
+    string,
+    CreatedFromConversationState
+  >();
   return {
-    schedules: filtered.map((j) => ({
-      id: j.id,
-      name: j.name,
-      enabled: j.enabled,
-      syntax: j.syntax,
-      expression: j.expression,
-      cronExpression: j.cronExpression,
-      timezone: j.timezone,
-      message: j.message,
-      script: j.script,
-      nextRunAt: j.nextRunAt,
-      lastRunAt: j.lastRunAt,
-      lastStatus: j.lastStatus,
-      retryCount: j.retryCount,
-      maxRetries: j.maxRetries,
-      retryBackoffMs: j.retryBackoffMs,
-      timeoutMs: j.timeoutMs,
-      description:
-        j.syntax === "cron"
-          ? describeCronExpression(j.cronExpression)
-          : j.expression,
-      mode: j.mode,
-      status: j.status,
-      routingIntent: j.routingIntent,
-      reuseConversation: j.reuseConversation,
-      wakeConversationId: j.wakeConversationId,
-      isOneShot: j.cronExpression == null,
-    })),
+    schedules: filtered.map((j) => {
+      const sourceConversation = getCreatedFromConversationState(
+        j.createdFromConversationId,
+        sourceConversationCache,
+      );
+      return {
+        id: j.id,
+        name: j.name,
+        enabled: j.enabled,
+        syntax: j.syntax,
+        expression: j.expression,
+        cronExpression: j.cronExpression,
+        timezone: j.timezone,
+        message: j.message,
+        script: j.script,
+        nextRunAt: j.nextRunAt,
+        lastRunAt: j.lastRunAt,
+        lastStatus: j.lastStatus,
+        retryCount: j.retryCount,
+        maxRetries: j.maxRetries,
+        retryBackoffMs: j.retryBackoffMs,
+        timeoutMs: j.timeoutMs,
+        createdFromConversationId: j.createdFromConversationId,
+        createdFromConversationExists: sourceConversation.exists,
+        createdFromConversationArchivedAt: sourceConversation.archivedAt,
+        description:
+          j.syntax === "cron"
+            ? describeCronExpression(j.cronExpression)
+            : j.expression,
+        mode: j.mode,
+        status: j.status,
+        routingIntent: j.routingIntent,
+        reuseConversation: j.reuseConversation,
+        wakeConversationId: j.wakeConversationId,
+        isOneShot: j.cronExpression == null,
+      };
+    }),
   };
 }
 

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -49,6 +49,7 @@ export interface ScheduleJob {
   retryBackoffMs: number;
   /** Script-mode execution timeout override (ms); null = use the default. */
   timeoutMs: number | null;
+  createdFromConversationId: string | null;
   createdBy: string;
   mode: ScheduleMode;
   routingIntent: RoutingIntent;
@@ -102,6 +103,7 @@ export function createSchedule(params: {
   maxRetries?: number;
   retryBackoffMs?: number;
   timeoutMs?: number | null;
+  createdFromConversationId?: string | null;
 }): ScheduleJob {
   const expression = params.expression ?? params.cronExpression ?? null;
   const isOneShot = expression == null;
@@ -138,6 +140,7 @@ export function createSchedule(params: {
   const maxRetries = params.maxRetries ?? 3;
   const retryBackoffMs = params.retryBackoffMs ?? 60000;
   const timeoutMs = params.timeoutMs ?? null;
+  const createdFromConversationId = params.createdFromConversationId ?? null;
 
   let nextRunAt: number;
   if (isOneShot) {
@@ -165,6 +168,7 @@ export function createSchedule(params: {
     maxRetries,
     retryBackoffMs,
     timeoutMs,
+    createdFromConversationId,
     createdBy: params.createdBy ?? "agent",
     mode,
     routingIntent,
@@ -264,6 +268,7 @@ export function updateSchedule(
     maxRetries?: number;
     retryBackoffMs?: number;
     timeoutMs?: number | null;
+    createdFromConversationId?: string | null;
   },
 ): ScheduleJob | null {
   const db = getDb();
@@ -329,6 +334,8 @@ export function updateSchedule(
   if (updates.retryBackoffMs !== undefined)
     set.retryBackoffMs = updates.retryBackoffMs;
   if (updates.timeoutMs !== undefined) set.timeoutMs = updates.timeoutMs;
+  if (updates.createdFromConversationId !== undefined)
+    set.createdFromConversationId = updates.createdFromConversationId;
 
   // Recompute nextRunAt if schedule timing may have changed (only for recurring)
   if (
@@ -977,6 +984,7 @@ function parseJobRow(row: typeof scheduleJobs.$inferSelect): ScheduleJob {
     maxRetries: row.maxRetries ?? 3,
     retryBackoffMs: row.retryBackoffMs ?? 60000,
     timeoutMs: row.timeoutMs ?? null,
+    createdFromConversationId: row.createdFromConversationId ?? null,
     createdBy: row.createdBy,
     mode: (row.mode ?? "execute") as ScheduleMode,
     routingIntent: (row.routingIntent ?? "all_channels") as RoutingIntent,

--- a/assistant/src/tools/schedule/create.ts
+++ b/assistant/src/tools/schedule/create.ts
@@ -144,6 +144,7 @@ export async function executeScheduleCreate(
         maxRetries,
         retryBackoffMs,
         timeoutMs,
+        createdFromConversationId: context.conversationId,
       });
 
       const fireDate = formatLocalDate(job.nextRunAt);
@@ -225,6 +226,7 @@ export async function executeScheduleCreate(
       maxRetries,
       retryBackoffMs,
       timeoutMs,
+      createdFromConversationId: context.conversationId,
     });
 
     const scheduleDescription =


### PR DESCRIPTION
## Summary
- Persists the conversation that created a schedule.
- Exposes source conversation availability in schedule list responses.

Part of plan: schedules-details-usage-consolidated.md (PR 2 of 8)