### PR TITLE
Add schedule filtering and grouping to usage endpoints

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -23110,7 +23110,13 @@ paths:
           required: false
           schema:
             type: string
-          description: "Group by: actor, provider, model, conversation, call_site, inference_profile (required)"
+          description: "Group by: actor, provider, model, conversation, call_site, inference_profile, schedule (required)"
+        - name: scheduleId
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Optional schedule id. When set, usage is attributed by cron run windows for that schedule.
   /v1/usage/daily:
     get:
       operationId: usage_daily_get
@@ -23187,6 +23193,12 @@ paths:
           description:
             IANA timezone identifier (e.g. "America/Los_Angeles"). Bucket boundaries and display labels are computed in
             this timezone. Defaults to "UTC" for backwards compatibility.
+        - name: scheduleId
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Optional schedule id. When set, usage is attributed by cron run windows for that schedule.
   /v1/usage/series:
     get:
       operationId: usage_series_get
@@ -23290,7 +23302,7 @@ paths:
           required: false
           schema:
             type: string
-          description: "Group by: actor, provider, model, call_site, inference_profile (required)"
+          description: "Group by: actor, provider, model, call_site, inference_profile, schedule (required)"
         - name: tz
           in: query
           required: false
@@ -23299,6 +23311,12 @@ paths:
           description:
             IANA timezone identifier (e.g. "America/Los_Angeles"). Bucket boundaries and display labels are computed in
             this timezone. Defaults to "UTC".
+        - name: scheduleId
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Optional schedule id. When set, usage is attributed by cron run windows for that schedule.
   /v1/usage/totals:
     get:
       operationId: usage_totals_get
@@ -23353,6 +23371,12 @@ paths:
           schema:
             type: integer
           description: End epoch millis (required)
+        - name: scheduleId
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Optional schedule id. When set, usage is attributed by cron run windows for that schedule.
   /v1/user-routes/inspect:
     post:
       operationId: userroutes_inspect_post

--- a/assistant/src/__tests__/llm-usage-store.test.ts
+++ b/assistant/src/__tests__/llm-usage-store.test.ts
@@ -6,7 +6,7 @@ mock.module("../util/logger.js", () => ({
   getLogger: () => makeMockLogger(),
 }));
 
-import { getDb } from "../memory/db-connection.js";
+import { getDb, getSqlite } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import {
   getUsageDayBuckets,
@@ -453,6 +453,228 @@ describe("getUsageTotals", () => {
     const totals = getUsageTotals({ from: 0, to: 5000 });
     expect(totals.totalCacheCreationTokens).toBe(50);
     expect(totals.totalCacheReadTokens).toBe(100);
+  });
+});
+
+describe("usage aggregation schedule filters", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run(`DELETE FROM llm_usage_events`);
+    db.run(`DELETE FROM cron_runs`);
+    db.run(`DELETE FROM cron_jobs`);
+  });
+
+  function insertScheduleJob(id: string, name: string): void {
+    const now = Date.UTC(2026, 0, 1);
+    getSqlite().run(
+      `INSERT INTO cron_jobs (
+        id,
+        name,
+        cron_expression,
+        message,
+        next_run_at,
+        created_by,
+        created_at,
+        updated_at
+      ) VALUES (?, ?, '* * * * *', 'Example scheduled task', ?, 'user', ?, ?)`,
+      [id, name, now, now, now],
+    );
+  }
+
+  function insertScheduleRun({
+    id,
+    scheduleId,
+    conversationId,
+    startedAt,
+    finishedAt,
+  }: {
+    id: string;
+    scheduleId: string;
+    conversationId: string;
+    startedAt: number;
+    finishedAt: number | null;
+  }): void {
+    getSqlite().run(
+      `INSERT INTO cron_runs (
+        id,
+        job_id,
+        status,
+        started_at,
+        finished_at,
+        conversation_id,
+        created_at
+      ) VALUES (?, ?, 'ok', ?, ?, ?, ?)`,
+      [id, scheduleId, startedAt, finishedAt, conversationId, startedAt],
+    );
+  }
+
+  function seedScheduleUsage(): void {
+    insertScheduleJob("schedule-a", "Morning summary");
+    insertScheduleJob("schedule-b", "Nightly sync");
+    insertScheduleRun({
+      id: "run-a-1",
+      scheduleId: "schedule-a",
+      conversationId: "conv-reused",
+      startedAt: 1_000,
+      finishedAt: 2_000,
+    });
+    insertScheduleRun({
+      id: "run-b-1",
+      scheduleId: "schedule-b",
+      conversationId: "conv-reused",
+      startedAt: 3_000,
+      finishedAt: 3_500,
+    });
+
+    insertEventAt(
+      900,
+      { conversationId: "conv-reused", inputTokens: 90 },
+      { estimatedCostUsd: 0.09, pricingStatus: "priced" },
+    );
+    insertEventAt(
+      1_000,
+      {
+        conversationId: "conv-reused",
+        callSite: "mainAgent",
+        inputTokens: 100,
+      },
+      { estimatedCostUsd: 0.1, pricingStatus: "priced" },
+    );
+    insertEventAt(
+      1_500,
+      {
+        conversationId: "conv-reused",
+        callSite: "mainAgent",
+        inputTokens: 200,
+      },
+      { estimatedCostUsd: 0.2, pricingStatus: "priced" },
+    );
+    insertEventAt(
+      2_000,
+      {
+        conversationId: "conv-reused",
+        callSite: "mainAgent",
+        inputTokens: 300,
+      },
+      { estimatedCostUsd: 0.3, pricingStatus: "priced" },
+    );
+    insertEventAt(
+      2_500,
+      { conversationId: "conv-reused", inputTokens: 400 },
+      { estimatedCostUsd: 0.4, pricingStatus: "priced" },
+    );
+    insertEventAt(
+      3_200,
+      {
+        conversationId: "conv-reused",
+        provider: "openai",
+        inputTokens: 500,
+      },
+      { estimatedCostUsd: 0.5, pricingStatus: "priced" },
+    );
+    insertEventAt(
+      1_500,
+      { conversationId: "conv-other", inputTokens: 800 },
+      { estimatedCostUsd: 0.8, pricingStatus: "priced" },
+    );
+  }
+
+  test("filters totals, buckets, breakdowns, and series by cron run windows", () => {
+    seedScheduleUsage();
+    const range = { from: 0, to: 4_000 };
+    const filter = { scheduleId: "schedule-a" };
+
+    const totals = getUsageTotals(range, filter);
+    expect(totals.eventCount).toBe(3);
+    expect(totals.totalInputTokens).toBe(600);
+    expect(totals.totalEstimatedCostUsd).toBeCloseTo(0.6);
+
+    const dailyBuckets = getUsageDayBuckets(range, "UTC", {}, filter);
+    expect(dailyBuckets).toHaveLength(1);
+    expect(dailyBuckets[0].totalInputTokens).toBe(600);
+    expect(dailyBuckets[0].eventCount).toBe(3);
+
+    const hourlyBuckets = getUsageHourBuckets(range, "UTC", {}, filter);
+    expect(hourlyBuckets).toHaveLength(1);
+    expect(hourlyBuckets[0].totalInputTokens).toBe(600);
+    expect(hourlyBuckets[0].eventCount).toBe(3);
+
+    const breakdown = getUsageGroupBreakdown(range, "provider", filter);
+    expect(breakdown).toHaveLength(1);
+    expect(breakdown[0].group).toBe("anthropic");
+    expect(breakdown[0].totalInputTokens).toBe(600);
+    expect(breakdown[0].eventCount).toBe(3);
+
+    const series = getUsageGroupedSeries(
+      range,
+      "call_site",
+      "daily",
+      "UTC",
+      {},
+      filter,
+    );
+    expect(series).toHaveLength(1);
+    expect(series[0].totalInputTokens).toBe(600);
+    expect(series[0].groups["null:call_site"]).toBeUndefined();
+    expect(series[0].groups["null:schedule"]).toBeUndefined();
+    expect(series[0].groups["value:mainAgent"]).toMatchObject({
+      group: "Main Agent",
+      totalInputTokens: 600,
+      eventCount: 3,
+    });
+  });
+
+  test("groups schedule-attributed usage by schedule id with schedule names", () => {
+    seedScheduleUsage();
+    const range = { from: 0, to: 4_000 };
+
+    const breakdown = getUsageGroupBreakdown(range, "schedule");
+    const scheduleA = breakdown.find((row) => row.groupKey === "schedule-a");
+    const scheduleB = breakdown.find((row) => row.groupKey === "schedule-b");
+    const other = breakdown.find((row) => row.groupKey === null);
+
+    expect(scheduleA).toMatchObject({
+      group: "Morning summary",
+      groupId: "schedule-a",
+      groupKey: "schedule-a",
+      totalInputTokens: 600,
+      eventCount: 3,
+    });
+    expect(scheduleB).toMatchObject({
+      group: "Nightly sync",
+      groupId: "schedule-b",
+      groupKey: "schedule-b",
+      totalInputTokens: 500,
+      eventCount: 1,
+    });
+    expect(other).toMatchObject({
+      group: "Other",
+      groupId: null,
+      groupKey: null,
+      totalInputTokens: 1_290,
+      eventCount: 3,
+    });
+
+    const series = getUsageGroupedSeries(range, "schedule", "daily", "UTC", {});
+    expect(series).toHaveLength(1);
+    expect(series[0].groups["value:schedule-a"]).toMatchObject({
+      group: "Morning summary",
+      groupKey: "schedule-a",
+      totalInputTokens: 600,
+      eventCount: 3,
+    });
+    expect(series[0].groups["value:schedule-b"]).toMatchObject({
+      group: "Nightly sync",
+      groupKey: "schedule-b",
+      totalInputTokens: 500,
+      eventCount: 1,
+    });
+    expect(series[0].groups["null:schedule"]).toMatchObject({
+      group: "Other",
+      groupKey: null,
+      totalInputTokens: 1_290,
+      eventCount: 3,
+    });
   });
 });
 

--- a/assistant/src/__tests__/usage-routes.test.ts
+++ b/assistant/src/__tests__/usage-routes.test.ts
@@ -19,6 +19,8 @@ import { ROUTES } from "../runtime/routes/usage-routes.js";
 initializeDb();
 
 function clearUsageEvents() {
+  getSqlite().run("DELETE FROM cron_runs");
+  getSqlite().run("DELETE FROM cron_jobs");
   getSqlite().run("DELETE FROM llm_usage_events");
 }
 
@@ -151,6 +153,77 @@ function recordCostAt(
   );
 }
 
+function insertScheduleJob(id: string, name: string): void {
+  const now = new Date("2026-01-01T00:00:00Z").getTime();
+  getSqlite().run(
+    `INSERT INTO cron_jobs (
+      id,
+      name,
+      cron_expression,
+      message,
+      next_run_at,
+      created_by,
+      created_at,
+      updated_at
+    ) VALUES (?, ?, '* * * * *', 'Example scheduled task', ?, 'user', ?, ?)`,
+    [id, name, now, now, now],
+  );
+}
+
+function insertScheduleRun({
+  id,
+  scheduleId,
+  conversationId,
+  startedAt,
+  finishedAt,
+}: {
+  id: string;
+  scheduleId: string;
+  conversationId: string;
+  startedAt: number;
+  finishedAt: number | null;
+}): void {
+  getSqlite().run(
+    `INSERT INTO cron_runs (
+      id,
+      job_id,
+      status,
+      started_at,
+      finished_at,
+      conversation_id,
+      created_at
+    ) VALUES (?, ?, 'ok', ?, ?, ?, ?)`,
+    [id, scheduleId, startedAt, finishedAt, conversationId, startedAt],
+  );
+}
+
+function seedScheduleRouteEvents() {
+  insertScheduleJob("schedule-a", "Morning summary");
+  insertScheduleJob("schedule-b", "Nightly sync");
+  insertScheduleRun({
+    id: "run-a-1",
+    scheduleId: "schedule-a",
+    conversationId: "conv-reused",
+    startedAt: 1_000,
+    finishedAt: 2_000,
+  });
+  insertScheduleRun({
+    id: "run-b-1",
+    scheduleId: "schedule-b",
+    conversationId: "conv-reused",
+    startedAt: 3_000,
+    finishedAt: 3_500,
+  });
+
+  recordCostAt("conv-reused", "route-before-a", 900, 0.09);
+  recordCostAt("conv-reused", "route-a-start", 1_000, 0.1);
+  recordCostAt("conv-reused", "route-a-inside", 1_500, 0.2);
+  recordCostAt("conv-reused", "route-a-finish", 2_000, 0.3);
+  recordCostAt("conv-reused", "route-after-a", 2_500, 0.4);
+  recordCostAt("conv-reused", "route-b-inside", 3_200, 0.5);
+  recordCostAt("conv-other", "route-other", 1_500, 0.8);
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -256,6 +329,19 @@ describe("usage routes", () => {
       expect(body.totalCacheCreationTokens).toBe(50);
       expect(body.totalCacheReadTokens).toBe(100);
     });
+
+    test("filters by trimmed scheduleId using schedule run windows", () => {
+      seedScheduleRouteEvents();
+
+      const body = dispatch(
+        "GET",
+        "usage/totals?from=0&to=4000&scheduleId=%20schedule-a%20",
+      ) as Record<string, number>;
+
+      expect(body.eventCount).toBe(3);
+      expect(body.totalInputTokens).toBe(300);
+      expect(body.totalEstimatedCostUsd).toBeCloseTo(0.6);
+    });
   });
 
   // -- daily buckets --
@@ -306,6 +392,21 @@ describe("usage routes", () => {
       expect(body.buckets[1].date).toBe("2025-01-16");
       expect(body.buckets[1].totalInputTokens).toBe(2000);
       expect(body.buckets[1].eventCount).toBe(1);
+    });
+
+    test("filters daily buckets by scheduleId", () => {
+      seedScheduleRouteEvents();
+
+      const body = dispatch(
+        "GET",
+        "usage/daily?from=0&to=4000&scheduleId=schedule-a",
+      ) as {
+        buckets: Array<{ totalEstimatedCostUsd: number; eventCount: number }>;
+      };
+
+      expect(body.buckets).toHaveLength(1);
+      expect(body.buckets[0].eventCount).toBe(3);
+      expect(body.buckets[0].totalEstimatedCostUsd).toBeCloseTo(0.6);
     });
   });
 
@@ -448,6 +549,70 @@ describe("usage routes", () => {
         null,
       ]);
     });
+
+    test("accepts groupBy=schedule and labels groups with schedule names", () => {
+      seedScheduleRouteEvents();
+
+      const body = dispatch(
+        "GET",
+        "usage/breakdown?from=0&to=4000&groupBy=schedule",
+      ) as {
+        breakdown: Array<{
+          group: string;
+          groupId: string | null;
+          groupKey: string | null;
+          totalEstimatedCostUsd: number;
+          eventCount: number;
+        }>;
+      };
+
+      expect(
+        body.breakdown.find((row) => row.groupKey === "schedule-a"),
+      ).toMatchObject({
+        group: "Morning summary",
+        groupId: "schedule-a",
+        totalEstimatedCostUsd: 0.6,
+        eventCount: 3,
+      });
+      expect(
+        body.breakdown.find((row) => row.groupKey === "schedule-b"),
+      ).toMatchObject({
+        group: "Nightly sync",
+        groupId: "schedule-b",
+        totalEstimatedCostUsd: 0.5,
+        eventCount: 1,
+      });
+      expect(body.breakdown.find((row) => row.groupKey === null)).toMatchObject(
+        {
+          group: "Other",
+          groupId: null,
+          totalEstimatedCostUsd: 1.29,
+          eventCount: 3,
+        },
+      );
+    });
+
+    test("filters breakdown by scheduleId", () => {
+      seedScheduleRouteEvents();
+
+      const body = dispatch(
+        "GET",
+        "usage/breakdown?from=0&to=4000&groupBy=provider&scheduleId=schedule-a",
+      ) as {
+        breakdown: Array<{
+          group: string;
+          totalEstimatedCostUsd: number;
+          eventCount: number;
+        }>;
+      };
+
+      expect(body.breakdown).toHaveLength(1);
+      expect(body.breakdown[0]).toMatchObject({
+        group: "anthropic",
+        totalEstimatedCostUsd: 0.6,
+        eventCount: 3,
+      });
+    });
   });
 
   describe("GET /v1/usage/series", () => {
@@ -535,6 +700,73 @@ describe("usage routes", () => {
         groupKey: null,
         totalInputTokens: 2000,
       });
+    });
+
+    test("accepts groupBy=schedule and labels schedule series groups", () => {
+      seedScheduleRouteEvents();
+
+      const body = dispatch(
+        "GET",
+        "usage/series?from=0&to=4000&groupBy=schedule&granularity=daily",
+      ) as {
+        buckets: Array<{
+          groups: Record<
+            string,
+            {
+              group: string;
+              groupKey: string | null;
+              totalEstimatedCostUsd: number;
+            }
+          >;
+        }>;
+      };
+
+      expect(body.buckets).toHaveLength(1);
+      expect(body.buckets[0].groups["value:schedule-a"]).toMatchObject({
+        group: "Morning summary",
+        groupKey: "schedule-a",
+      });
+      expect(
+        body.buckets[0].groups["value:schedule-a"].totalEstimatedCostUsd,
+      ).toBeCloseTo(0.6);
+      expect(body.buckets[0].groups["value:schedule-b"]).toMatchObject({
+        group: "Nightly sync",
+        groupKey: "schedule-b",
+      });
+      expect(
+        body.buckets[0].groups["value:schedule-b"].totalEstimatedCostUsd,
+      ).toBeCloseTo(0.5);
+      expect(body.buckets[0].groups["null:schedule"]).toMatchObject({
+        group: "Other",
+        groupKey: null,
+      });
+      expect(
+        body.buckets[0].groups["null:schedule"].totalEstimatedCostUsd,
+      ).toBeCloseTo(1.29);
+    });
+
+    test("filters grouped series by scheduleId", () => {
+      seedScheduleRouteEvents();
+
+      const body = dispatch(
+        "GET",
+        "usage/series?from=0&to=4000&groupBy=call_site&granularity=daily&scheduleId=schedule-a",
+      ) as {
+        buckets: Array<{
+          totalEstimatedCostUsd: number;
+          groups: Record<string, { totalEstimatedCostUsd: number }>;
+        }>;
+      };
+
+      expect(body.buckets).toHaveLength(1);
+      expect(body.buckets[0].totalEstimatedCostUsd).toBeCloseTo(0.6);
+      expect(body.buckets[0].groups["value:mainAgent"]).toMatchObject({
+        group: "Main Agent",
+        groupKey: "mainAgent",
+      });
+      expect(
+        body.buckets[0].groups["value:mainAgent"].totalEstimatedCostUsd,
+      ).toBeCloseTo(0.6);
     });
   });
 });

--- a/assistant/src/memory/llm-usage-store.ts
+++ b/assistant/src/memory/llm-usage-store.ts
@@ -282,6 +282,10 @@ export interface UsageTimeRange {
   to: number;
 }
 
+export interface UsageAggregationFilter {
+  scheduleId?: string;
+}
+
 /** Aggregate totals across a time range. */
 export interface UsageTotals {
   /** Direct input tokens only; cache traffic is reported separately below. */
@@ -332,14 +336,15 @@ export interface UsageGroupBreakdown {
   /**
    * Stable identifier for the group. Populated with the conversation id when
    * `groupBy === "conversation"` (and `null` for that mode's "Other" bucket,
-   * which aggregates events with no conversation id). For all other group-bys
-   * this is always `null`.
+   * which aggregates events with no conversation id) or with the schedule id
+   * when `groupBy === "schedule"` (and `null` for "Other"). For all other
+   * group-bys this is always `null`.
    */
   groupId: string | null;
   /**
    * Raw stored grouping value for dimensions whose display label may differ
-   * from storage (`call_site`, `inference_profile`). Omitted for legacy
-   * dimensions where `group` is already the raw value.
+   * from storage (`call_site`, `inference_profile`, `schedule`). Omitted for
+   * legacy dimensions where `group` is already the raw value.
    */
   groupKey?: string | null;
   /** Direct input tokens only; cache traffic is reported separately below. */
@@ -367,12 +372,90 @@ interface TotalsRow {
 interface GroupRow {
   group_key: string | null;
   group_id: string | null;
+  group_label: string | null;
   total_input_tokens: number;
   total_output_tokens: number;
   total_cache_creation_tokens: number;
   total_cache_read_tokens: number;
   total_estimated_cost_usd: number | null;
   event_count: number;
+}
+
+type UsageQueryParam = string | number;
+
+function normalizeUsageAggregationFilter(
+  filter?: UsageAggregationFilter,
+): UsageAggregationFilter {
+  const scheduleId = filter?.scheduleId?.trim();
+  return scheduleId ? { scheduleId } : {};
+}
+
+function usageColumn(column: string, eventAlias?: string): string {
+  return eventAlias ? `${eventAlias}.${column}` : column;
+}
+
+function scheduleRunWindowSql(
+  eventAlias: string,
+  runAlias: string,
+  filter: UsageAggregationFilter,
+): string {
+  const scheduleClause = filter.scheduleId ? `${runAlias}.job_id = ? AND ` : "";
+  return `${scheduleClause}${runAlias}.conversation_id = ${usageColumn(
+    "conversation_id",
+    eventAlias,
+  )}
+    AND ${usageColumn("created_at", eventAlias)} >= ${runAlias}.started_at
+    AND ${usageColumn("created_at", eventAlias)} <= COALESCE(${runAlias}.finished_at, ?)`;
+}
+
+function scheduleRunWindowParams(
+  filter: UsageAggregationFilter,
+  now: number,
+): UsageQueryParam[] {
+  return filter.scheduleId ? [filter.scheduleId, now] : [now];
+}
+
+function buildUsageAggregationWhere(
+  range: UsageTimeRange,
+  filter?: UsageAggregationFilter,
+  eventAlias?: string,
+  now: number = Date.now(),
+): { sql: string; params: UsageQueryParam[] } {
+  const normalized = normalizeUsageAggregationFilter(filter);
+  const createdAt = usageColumn("created_at", eventAlias);
+  const clauses = [`${createdAt} >= ? AND ${createdAt} <= ?`];
+  const params: UsageQueryParam[] = [range.from, range.to];
+
+  if (normalized.scheduleId) {
+    clauses.push(`EXISTS (
+      SELECT 1
+      FROM cron_runs schedule_filter_runs
+      WHERE ${scheduleRunWindowSql(
+        eventAlias ?? "llm_usage_events",
+        "schedule_filter_runs",
+        normalized,
+      )}
+    )`);
+    params.push(...scheduleRunWindowParams(normalized, now));
+  }
+
+  return { sql: clauses.join(" AND "), params };
+}
+
+function scheduleAttributionSubquery(
+  eventAlias: string,
+  filter: UsageAggregationFilter,
+  selectExpression: string,
+): string {
+  return `(
+    SELECT ${selectExpression}
+    FROM cron_runs schedule_attr_runs
+    LEFT JOIN cron_jobs schedule_attr_jobs
+      ON schedule_attr_jobs.id = schedule_attr_runs.job_id
+    WHERE ${scheduleRunWindowSql(eventAlias, "schedule_attr_runs", filter)}
+    ORDER BY schedule_attr_runs.started_at DESC, schedule_attr_runs.id DESC
+    LIMIT 1
+  )`;
 }
 
 /**
@@ -433,7 +516,11 @@ export function getUsageCostForConversationWindow({
 /**
  * Return aggregate totals for all usage events within the given time range.
  */
-export function getUsageTotals(range: UsageTimeRange): UsageTotals {
+export function getUsageTotals(
+  range: UsageTimeRange,
+  filter?: UsageAggregationFilter,
+): UsageTotals {
+  const where = buildUsageAggregationWhere(range, filter);
   const rows = rawAll<TotalsRow>(
     /*sql*/ `
     SELECT
@@ -446,10 +533,9 @@ export function getUsageTotals(range: UsageTimeRange): UsageTotals {
       COUNT(CASE WHEN pricing_status = 'priced' THEN 1 END)       AS priced_event_count,
       COUNT(CASE WHEN pricing_status = 'unpriced' THEN 1 END)     AS unpriced_event_count
     FROM llm_usage_events
-    WHERE created_at >= ?1 AND created_at <= ?2
+    WHERE ${where.sql}
     `,
-    range.from,
-    range.to,
+    ...where.params,
   );
   const row = rows[0];
   return {
@@ -465,7 +551,11 @@ export function getUsageTotals(range: UsageTimeRange): UsageTotals {
 }
 
 /** Fetch raw events in a time range for in-memory bucketing. */
-function fetchRawBucketRows(range: UsageTimeRange): UsageEventBucketRow[] {
+function fetchRawBucketRows(
+  range: UsageTimeRange,
+  filter?: UsageAggregationFilter,
+): UsageEventBucketRow[] {
+  const where = buildUsageAggregationWhere(range, filter);
   return rawAll<UsageEventBucketRow>(
     /*sql*/ `
     SELECT
@@ -475,11 +565,10 @@ function fetchRawBucketRows(range: UsageTimeRange): UsageEventBucketRow[] {
       estimated_cost_usd,
       llm_call_count
     FROM llm_usage_events
-    WHERE created_at >= ?1 AND created_at <= ?2
+    WHERE ${where.sql}
     ORDER BY created_at ASC
     `,
-    range.from,
-    range.to,
+    ...where.params,
   );
 }
 
@@ -506,8 +595,9 @@ export function getUsageDayBuckets(
   range: UsageTimeRange,
   tz: string = "UTC",
   options: UsageBucketOptions = {},
+  filter?: UsageAggregationFilter,
 ): UsageDayBucket[] {
-  const rows = fetchRawBucketRows(range);
+  const rows = fetchRawBucketRows(range, filter);
   return bucketEventsByDay(rows, range, tz, options);
 }
 
@@ -524,8 +614,9 @@ export function getUsageHourBuckets(
   range: UsageTimeRange,
   tz: string = "UTC",
   options: UsageBucketOptions = {},
+  filter?: UsageAggregationFilter,
 ): UsageDayBucket[] {
-  const rows = fetchRawBucketRows(range);
+  const rows = fetchRawBucketRows(range, filter);
   return bucketEventsByHour(rows, range, tz, options);
 }
 
@@ -536,6 +627,7 @@ export const USAGE_GROUP_BY_DIMENSIONS = [
   "conversation",
   "call_site",
   "inference_profile",
+  "schedule",
 ] as const;
 
 export type GroupByDimension = (typeof USAGE_GROUP_BY_DIMENSIONS)[number];
@@ -546,10 +638,11 @@ export const USAGE_SERIES_GROUP_BY_DIMENSIONS = [
   "model",
   "call_site",
   "inference_profile",
+  "schedule",
 ] as const satisfies readonly GroupByDimension[];
 
 const GROUP_BY_COLUMNS: Record<
-  Exclude<GroupByDimension, "conversation">,
+  Exclude<GroupByDimension, "conversation" | "schedule">,
   string
 > = {
   actor: "actor",
@@ -574,9 +667,11 @@ function mapGroupRow(
   groupBy: GroupByDimension,
 ): UsageGroupBreakdown {
   const includeGroupKey =
-    groupBy === "call_site" || groupBy === "inference_profile";
+    groupBy === "call_site" ||
+    groupBy === "inference_profile" ||
+    groupBy === "schedule";
   return {
-    group: displayUsageGroup(groupBy, row.group_key),
+    group: row.group_label ?? displayUsageGroup(groupBy, row.group_key),
     groupId: row.group_id,
     ...(includeGroupKey ? { groupKey: row.group_key } : {}),
     totalInputTokens: row.total_input_tokens,
@@ -595,12 +690,16 @@ function mapGroupRow(
 export function getUsageGroupBreakdown(
   range: UsageTimeRange,
   groupBy: GroupByDimension,
+  filter?: UsageAggregationFilter,
 ): UsageGroupBreakdown[] {
   // Runtime allowlist — defense-in-depth against SQL injection via type assertions.
   assertGroupByDimension(groupBy);
 
+  const normalizedFilter = normalizeUsageAggregationFilter(filter);
+
   // Conversation grouping requires a JOIN with conversations to resolve titles.
   if (groupBy === "conversation") {
+    const where = buildUsageAggregationWhere(range, normalizedFilter, "e");
     const rows = rawAll<GroupRow>(
       /*sql*/ `
       SELECT
@@ -608,6 +707,7 @@ export function getUsageGroupBreakdown(
              ELSE COALESCE(c.title, 'Untitled')
         END AS group_key,
         e.conversation_id                                AS group_id,
+        NULL                                             AS group_label,
         COALESCE(SUM(e.input_tokens), 0)                 AS total_input_tokens,
         COALESCE(SUM(e.output_tokens), 0)                AS total_output_tokens,
         COALESCE(SUM(e.cache_creation_input_tokens), 0)  AS total_cache_creation_tokens,
@@ -616,36 +716,81 @@ export function getUsageGroupBreakdown(
         COALESCE(SUM(COALESCE(e.llm_call_count, 1)), 0)  AS event_count
       FROM llm_usage_events e
       LEFT JOIN conversations c ON e.conversation_id = c.id
-      WHERE e.created_at >= ?1 AND e.created_at <= ?2
+      WHERE ${where.sql}
       GROUP BY e.conversation_id
       ORDER BY total_estimated_cost_usd DESC
       LIMIT 50
       `,
-      range.from,
-      range.to,
+      ...where.params,
+    );
+    return rows.map((row) => mapGroupRow(row, groupBy));
+  }
+
+  if (groupBy === "schedule") {
+    const now = Date.now();
+    const where = buildUsageAggregationWhere(range, normalizedFilter, "e", now);
+    const groupKeySubquery = scheduleAttributionSubquery(
+      "e",
+      normalizedFilter,
+      "schedule_attr_runs.job_id",
+    );
+    const scheduleParams = scheduleRunWindowParams(normalizedFilter, now);
+    const rows = rawAll<GroupRow>(
+      /*sql*/ `
+      WITH schedule_usage AS (
+        SELECT
+          e.input_tokens,
+          e.output_tokens,
+          e.cache_creation_input_tokens,
+          e.cache_read_input_tokens,
+          e.estimated_cost_usd,
+          e.llm_call_count,
+          ${groupKeySubquery} AS group_key
+        FROM llm_usage_events e
+        WHERE ${where.sql}
+      )
+      SELECT
+        schedule_usage.group_key                                      AS group_key,
+        schedule_usage.group_key                                      AS group_id,
+        MAX(schedule_group_jobs.name)                                 AS group_label,
+        COALESCE(SUM(schedule_usage.input_tokens), 0)                 AS total_input_tokens,
+        COALESCE(SUM(schedule_usage.output_tokens), 0)                AS total_output_tokens,
+        COALESCE(SUM(schedule_usage.cache_creation_input_tokens), 0)  AS total_cache_creation_tokens,
+        COALESCE(SUM(schedule_usage.cache_read_input_tokens), 0)      AS total_cache_read_tokens,
+        COALESCE(SUM(schedule_usage.estimated_cost_usd), 0)           AS total_estimated_cost_usd,
+        COALESCE(SUM(COALESCE(schedule_usage.llm_call_count, 1)), 0)  AS event_count
+      FROM schedule_usage
+      LEFT JOIN cron_jobs schedule_group_jobs
+        ON schedule_group_jobs.id = schedule_usage.group_key
+      GROUP BY schedule_usage.group_key
+      ORDER BY total_estimated_cost_usd DESC
+      `,
+      ...scheduleParams,
+      ...where.params,
     );
     return rows.map((row) => mapGroupRow(row, groupBy));
   }
 
   const column = GROUP_BY_COLUMNS[groupBy];
+  const where = buildUsageAggregationWhere(range, normalizedFilter, "e");
   const rows = rawAll<GroupRow>(
     /*sql*/ `
     SELECT
-      ${column}                                      AS group_key,
-      NULL                                           AS group_id,
-      COALESCE(SUM(input_tokens), 0)                 AS total_input_tokens,
-      COALESCE(SUM(output_tokens), 0)                AS total_output_tokens,
-      COALESCE(SUM(cache_creation_input_tokens), 0)  AS total_cache_creation_tokens,
-      COALESCE(SUM(cache_read_input_tokens), 0)      AS total_cache_read_tokens,
-      COALESCE(SUM(estimated_cost_usd), 0)           AS total_estimated_cost_usd,
-      COALESCE(SUM(COALESCE(llm_call_count, 1)), 0)  AS event_count
-    FROM llm_usage_events
-    WHERE created_at >= ?1 AND created_at <= ?2
-    GROUP BY ${column}
+      e.${column}                                      AS group_key,
+      NULL                                             AS group_id,
+      NULL                                             AS group_label,
+      COALESCE(SUM(e.input_tokens), 0)                 AS total_input_tokens,
+      COALESCE(SUM(e.output_tokens), 0)                AS total_output_tokens,
+      COALESCE(SUM(e.cache_creation_input_tokens), 0)  AS total_cache_creation_tokens,
+      COALESCE(SUM(e.cache_read_input_tokens), 0)      AS total_cache_read_tokens,
+      COALESCE(SUM(e.estimated_cost_usd), 0)           AS total_estimated_cost_usd,
+      COALESCE(SUM(COALESCE(e.llm_call_count, 1)), 0)  AS event_count
+    FROM llm_usage_events e
+    WHERE ${where.sql}
+    GROUP BY e.${column}
     ORDER BY total_estimated_cost_usd DESC
     `,
-    range.from,
-    range.to,
+    ...where.params,
   );
   return rows.map((row) => mapGroupRow(row, groupBy));
 }
@@ -656,29 +801,73 @@ export function getUsageGroupedSeries(
   granularity: UsageGranularity,
   tz: string = "UTC",
   options: UsageBucketOptions = {},
+  filter?: UsageAggregationFilter,
 ): UsageGroupedSeriesBucket[] {
   assertGroupByDimension(groupBy);
   if (groupBy === "conversation") {
     throw new Error("Grouped usage series does not support conversation");
   }
 
-  const column = GROUP_BY_COLUMNS[groupBy];
-  const rows = rawAll<UsageGroupedBucketRow>(
-    /*sql*/ `
-    SELECT
-      created_at,
-      input_tokens,
-      output_tokens,
-      estimated_cost_usd,
-      llm_call_count,
-      ${column} AS group_key
-    FROM llm_usage_events
-    WHERE created_at >= ?1 AND created_at <= ?2
-    ORDER BY created_at ASC
-    `,
-    range.from,
-    range.to,
-  );
+  const normalizedFilter = normalizeUsageAggregationFilter(filter);
+  let rows: UsageGroupedBucketRow[];
+
+  if (groupBy === "schedule") {
+    const now = Date.now();
+    const where = buildUsageAggregationWhere(range, normalizedFilter, "e", now);
+    const groupKeySubquery = scheduleAttributionSubquery(
+      "e",
+      normalizedFilter,
+      "schedule_attr_runs.job_id",
+    );
+    const scheduleParams = scheduleRunWindowParams(normalizedFilter, now);
+    rows = rawAll<UsageGroupedBucketRow>(
+      /*sql*/ `
+      WITH schedule_usage AS (
+        SELECT
+          e.created_at,
+          e.input_tokens,
+          e.output_tokens,
+          e.estimated_cost_usd,
+          e.llm_call_count,
+          ${groupKeySubquery} AS group_key
+        FROM llm_usage_events e
+        WHERE ${where.sql}
+      )
+      SELECT
+        schedule_usage.created_at,
+        schedule_usage.input_tokens,
+        schedule_usage.output_tokens,
+        schedule_usage.estimated_cost_usd,
+        schedule_usage.llm_call_count,
+        schedule_usage.group_key,
+        schedule_group_jobs.name AS group_label
+      FROM schedule_usage
+      LEFT JOIN cron_jobs schedule_group_jobs
+        ON schedule_group_jobs.id = schedule_usage.group_key
+      ORDER BY schedule_usage.created_at ASC
+      `,
+      ...scheduleParams,
+      ...where.params,
+    );
+  } else {
+    const column = GROUP_BY_COLUMNS[groupBy];
+    const where = buildUsageAggregationWhere(range, normalizedFilter, "e");
+    rows = rawAll<UsageGroupedBucketRow>(
+      /*sql*/ `
+      SELECT
+        e.created_at,
+        e.input_tokens,
+        e.output_tokens,
+        e.estimated_cost_usd,
+        e.llm_call_count,
+        e.${column} AS group_key
+      FROM llm_usage_events e
+      WHERE ${where.sql}
+      ORDER BY e.created_at ASC
+      `,
+      ...where.params,
+    );
+  }
 
   return bucketGroupedUsageEvents(rows, range, tz, {
     ...options,

--- a/assistant/src/memory/usage-grouped-buckets.ts
+++ b/assistant/src/memory/usage-grouped-buckets.ts
@@ -27,6 +27,7 @@ export interface UsageGroupedSeriesBucket extends UsageDayBucket {
 
 export interface UsageGroupedBucketRow extends UsageEventBucketRow {
   group_key: string | null;
+  group_label?: string | null;
 }
 
 const VALUE_GROUP_PREFIX = "value:";
@@ -41,6 +42,9 @@ export function displayUsageGroup(
   }
   if (groupBy === "inference_profile") {
     return groupKey === null ? "Default / Unset" : groupKey;
+  }
+  if (groupBy === "schedule") {
+    return groupKey ?? "Other";
   }
   return groupKey ?? "Other";
 }
@@ -102,7 +106,8 @@ export function bucketGroupedUsageEvents(
     let group = groupedBucket.groups[seriesKey];
     if (!group) {
       group = {
-        group: displayUsageGroup(options.groupBy, row.group_key),
+        group:
+          row.group_label ?? displayUsageGroup(options.groupBy, row.group_key),
         groupKey: row.group_key,
         totalInputTokens: 0,
         totalOutputTokens: 0,

--- a/assistant/src/runtime/routes/usage-routes.ts
+++ b/assistant/src/runtime/routes/usage-routes.ts
@@ -1,10 +1,10 @@
 /**
  * Route handlers for usage and cost summary endpoints.
  *
- * GET /v1/usage/totals?from=&to=              — aggregate totals for a time range
- * GET /v1/usage/daily?from=&to=               — per-day buckets for a time range
- * GET /v1/usage/breakdown?from=&to=&groupBy=  — grouped breakdown
- * GET /v1/usage/series?from=&to=&granularity=&groupBy= — grouped time-series buckets
+ * GET /v1/usage/totals?from=&to=&scheduleId=  — aggregate totals for a time range
+ * GET /v1/usage/daily?from=&to=&scheduleId=   — per-day buckets for a time range
+ * GET /v1/usage/breakdown?from=&to=&groupBy=&scheduleId=  — grouped breakdown
+ * GET /v1/usage/series?from=&to=&granularity=&groupBy=&scheduleId= — grouped time-series buckets
  */
 
 import { z } from "zod";
@@ -18,6 +18,7 @@ import {
   type GroupByDimension,
   USAGE_GROUP_BY_DIMENSIONS,
   USAGE_SERIES_GROUP_BY_DIMENSIONS,
+  type UsageAggregationFilter,
   type UsageGranularity,
 } from "../../memory/llm-usage-store.js";
 import { validateTimezone } from "../../memory/usage-buckets.js";
@@ -29,6 +30,8 @@ const VALID_GROUP_BY = new Set<string>(USAGE_GROUP_BY_DIMENSIONS);
 const VALID_SERIES_GROUP_BY = new Set<string>(USAGE_SERIES_GROUP_BY_DIMENSIONS);
 const GROUP_BY_DESCRIPTION = USAGE_GROUP_BY_DIMENSIONS.join(", ");
 const SERIES_GROUP_BY_DESCRIPTION = USAGE_SERIES_GROUP_BY_DIMENSIONS.join(", ");
+const SCHEDULE_ID_FILTER_DESCRIPTION =
+  "Optional schedule id. When set, usage is attributed by cron run windows for that schedule.";
 
 const usageTotalsSchema = z.object({
   totalInputTokens: z.number(),
@@ -115,9 +118,18 @@ function parseTimeRange(queryParams: Record<string, string>): {
   return { from, to };
 }
 
+function parseUsageAggregationFilter(
+  queryParams: Record<string, string>,
+): UsageAggregationFilter {
+  const scheduleId = queryParams.scheduleId?.trim();
+  return scheduleId ? { scheduleId } : {};
+}
+
 function handleUsageTotals({ queryParams }: RouteHandlerArgs) {
-  const range = parseTimeRange(queryParams ?? {});
-  return getUsageTotals(range);
+  const qp = queryParams ?? {};
+  const range = parseTimeRange(qp);
+  const filter = parseUsageAggregationFilter(qp);
+  return getUsageTotals(range, filter);
 }
 
 function handleUsageDaily({ queryParams }: RouteHandlerArgs) {
@@ -130,10 +142,11 @@ function handleUsageDaily({ queryParams }: RouteHandlerArgs) {
     );
   }
   const tz = resolveTimezone(qp);
+  const filter = parseUsageAggregationFilter(qp);
   const buckets =
     granularity === "hourly"
-      ? getUsageHourBuckets(range, tz, { fillEmpty: true })
-      : getUsageDayBuckets(range, tz, { fillEmpty: true });
+      ? getUsageHourBuckets(range, tz, { fillEmpty: true }, filter)
+      : getUsageDayBuckets(range, tz, { fillEmpty: true }, filter);
   return { buckets };
 }
 
@@ -153,7 +166,12 @@ function handleUsageBreakdown({ queryParams }: RouteHandlerArgs) {
     );
   }
 
-  const breakdown = getUsageGroupBreakdown(range, groupBy as GroupByDimension);
+  const filter = parseUsageAggregationFilter(qp);
+  const breakdown = getUsageGroupBreakdown(
+    range,
+    groupBy as GroupByDimension,
+    filter,
+  );
   return { breakdown };
 }
 
@@ -180,12 +198,14 @@ function handleUsageSeries({ queryParams }: RouteHandlerArgs) {
   }
 
   const tz = resolveTimezone(qp);
+  const filter = parseUsageAggregationFilter(qp);
   const buckets = getUsageGroupedSeries(
     range,
     groupBy as Exclude<GroupByDimension, "conversation">,
     granularity as UsageGranularity,
     tz,
     { fillEmpty: true },
+    filter,
   );
   return { buckets };
 }
@@ -212,6 +232,10 @@ export const ROUTES: RouteDefinition[] = [
         name: "to",
         type: "integer",
         description: "End epoch millis (required)",
+      },
+      {
+        name: "scheduleId",
+        description: SCHEDULE_ID_FILTER_DESCRIPTION,
       },
     ],
     responseBody: usageTotalsSchema,
@@ -249,6 +273,10 @@ export const ROUTES: RouteDefinition[] = [
         description:
           'IANA timezone identifier (e.g. "America/Los_Angeles"). Bucket boundaries and display labels are computed in this timezone. Defaults to "UTC" for backwards compatibility.',
       },
+      {
+        name: "scheduleId",
+        description: SCHEDULE_ID_FILTER_DESCRIPTION,
+      },
     ],
     responseBody: z.object({
       buckets: z.array(usageDayBucketSchema).describe("Usage bucket objects"),
@@ -281,6 +309,10 @@ export const ROUTES: RouteDefinition[] = [
       {
         name: "groupBy",
         description: `Group by: ${GROUP_BY_DESCRIPTION} (required)`,
+      },
+      {
+        name: "scheduleId",
+        description: SCHEDULE_ID_FILTER_DESCRIPTION,
       },
     ],
     responseBody: z.object({
@@ -326,6 +358,10 @@ export const ROUTES: RouteDefinition[] = [
         name: "tz",
         description:
           'IANA timezone identifier (e.g. "America/Los_Angeles"). Bucket boundaries and display labels are computed in this timezone. Defaults to "UTC".',
+      },
+      {
+        name: "scheduleId",
+        description: SCHEDULE_ID_FILTER_DESCRIPTION,
       },
     ],
     responseBody: z.object({


### PR DESCRIPTION
## Summary
- Adds schedule filtering across usage aggregations.
- Adds schedule grouping for usage breakdowns and series.

Part of plan: schedules-details-usage-consolidated.md (PR 5 of 8)