### PR TITLE
Expose per-schedule cost and run summaries

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -19370,6 +19370,57 @@ paths:
               required:
                 - enabled
               additionalProperties: false
+  /v1/schedules/usage-summary:
+    get:
+      operationId: schedules_usagesummary_get
+      summary: Get schedule usage summaries
+      description: Return per-schedule run counts and usage totals for a time range.
+      tags:
+        - schedules
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  summaries:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        scheduleId:
+                          type: string
+                        runCount:
+                          type: number
+                        totalEstimatedCostUsd:
+                          type: number
+                        eventCount:
+                          type: number
+                      required:
+                        - scheduleId
+                        - runCount
+                        - totalEstimatedCostUsd
+                        - eventCount
+                      additionalProperties: false
+                    description: Schedule usage summary rows
+                required:
+                  - summaries
+                additionalProperties: false
+      parameters:
+        - name: from
+          in: query
+          required: true
+          schema:
+            type: integer
+          description: Start epoch millis (required)
+        - name: to
+          in: query
+          required: true
+          schema:
+            type: integer
+          description: End epoch millis (required)
   /v1/search:
     get:
       operationId: search_get

--- a/assistant/src/__tests__/schedule-routes.test.ts
+++ b/assistant/src/__tests__/schedule-routes.test.ts
@@ -76,6 +76,7 @@ import { recordUsageEvent } from "../memory/llm-usage-store.js";
 import { rawRun } from "../memory/raw-query.js";
 import type { AssistantEvent } from "../runtime/assistant-event.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
+import { BadRequestError } from "../runtime/routes/errors.js";
 import { ROUTES as HEARTBEAT_ROUTES } from "../runtime/routes/heartbeat-routes.js";
 import { ROUTES as SCHEDULE_ROUTES } from "../runtime/routes/schedule-routes.js";
 import type { RouteDefinition } from "../runtime/routes/types.js";
@@ -146,6 +147,28 @@ function recordUsageCostAt(
     "UPDATE llm_usage_events SET created_at = ? WHERE id = ?",
     createdAt,
     event.id,
+  );
+}
+
+function setScheduleRunWindow({
+  runId,
+  startedAt,
+  finishedAt,
+  status = "ok",
+}: {
+  runId: string;
+  startedAt: number;
+  finishedAt: number | null;
+  status?: "ok" | "error" | "running";
+}) {
+  rawRun(
+    "UPDATE cron_runs SET status = ?, started_at = ?, finished_at = ?, duration_ms = ?, created_at = ? WHERE id = ?",
+    status,
+    startedAt,
+    finishedAt,
+    finishedAt == null ? null : finishedAt - startedAt,
+    startedAt,
+    runId,
   );
 }
 
@@ -720,6 +743,169 @@ describe("schedule and heartbeat run metadata", () => {
     };
 
     expect(result.runs[0].estimatedCostUsd).toBeCloseTo(0.02);
+  });
+});
+
+// ── schedules/usage-summary ───────────────────────────────────────────────
+
+describe("GET /schedules/usage-summary", () => {
+  beforeEach(() => {
+    clearTables();
+  });
+
+  function getUsageSummary(queryParams: Record<string, string>) {
+    const route = findRoute("schedules/usage-summary", "GET");
+    return route.handler({ queryParams }) as {
+      summaries: Array<{
+        scheduleId: string;
+        runCount: number;
+        totalEstimatedCostUsd: number;
+        eventCount: number;
+      }>;
+    };
+  }
+
+  test("returns zero rows when no schedules exist", () => {
+    const result = getUsageSummary({ from: "0", to: "5000" });
+
+    expect(result.summaries).toEqual([]);
+  });
+
+  test("includes active and inactive schedules with zero activity", () => {
+    const active = createSchedule({
+      name: "Active summary schedule",
+      cronExpression: "* * * * *",
+      message: "hi",
+      syntax: "cron",
+    });
+    const inactive = createSchedule({
+      name: "Inactive summary schedule",
+      cronExpression: "0 9 * * *",
+      message: "hi",
+      syntax: "cron",
+      enabled: false,
+    });
+
+    const result = getUsageSummary({ from: "0", to: "5000" });
+    const byScheduleId = new Map(
+      result.summaries.map((summary) => [summary.scheduleId, summary]),
+    );
+
+    expect(byScheduleId.get(active.id)).toEqual({
+      scheduleId: active.id,
+      runCount: 0,
+      totalEstimatedCostUsd: 0,
+      eventCount: 0,
+    });
+    expect(byScheduleId.get(inactive.id)).toEqual({
+      scheduleId: inactive.id,
+      runCount: 0,
+      totalEstimatedCostUsd: 0,
+      eventCount: 0,
+    });
+  });
+
+  test("counts runs by started_at in the inclusive range regardless of status", () => {
+    const schedule = createSchedule({
+      name: "Run count schedule",
+      cronExpression: "* * * * *",
+      message: "hi",
+      syntax: "cron",
+    });
+    const beforeRun = createScheduleRun(schedule.id, "conv-runs");
+    const startRun = createScheduleRun(schedule.id, "conv-runs");
+    const errorRun = createScheduleRun(schedule.id, "conv-runs");
+    const runningRun = createScheduleRun(schedule.id, "conv-runs");
+    const afterRun = createScheduleRun(schedule.id, "conv-runs");
+
+    setScheduleRunWindow({
+      runId: beforeRun,
+      startedAt: 999,
+      finishedAt: 1100,
+    });
+    setScheduleRunWindow({
+      runId: startRun,
+      startedAt: 1000,
+      finishedAt: 1200,
+    });
+    setScheduleRunWindow({
+      runId: errorRun,
+      startedAt: 1500,
+      finishedAt: 1700,
+      status: "error",
+    });
+    setScheduleRunWindow({
+      runId: runningRun,
+      startedAt: 2000,
+      finishedAt: null,
+      status: "running",
+    });
+    setScheduleRunWindow({
+      runId: afterRun,
+      startedAt: 2001,
+      finishedAt: 2100,
+    });
+
+    const result = getUsageSummary({ from: "1000", to: "2000" });
+
+    expect(result.summaries).toHaveLength(1);
+    expect(result.summaries[0].runCount).toBe(3);
+  });
+
+  test("sums usage by schedule run windows and excludes reused-conversation usage outside those windows", () => {
+    const schedule = createSchedule({
+      name: "Usage attribution schedule",
+      cronExpression: "* * * * *",
+      message: "hi",
+      syntax: "cron",
+      reuseConversation: true,
+    });
+    const conversation = createConversation({
+      title: "Reused schedule conversation",
+      source: "schedule",
+      scheduleJobId: schedule.id,
+    });
+    const includedRun = createScheduleRun(schedule.id, conversation.id);
+    const outsideRangeRun = createScheduleRun(schedule.id, conversation.id);
+
+    setScheduleRunWindow({
+      runId: includedRun,
+      startedAt: 1000,
+      finishedAt: 2000,
+    });
+    setScheduleRunWindow({
+      runId: outsideRangeRun,
+      startedAt: 3000,
+      finishedAt: 3500,
+    });
+
+    recordUsageCostAt(conversation.id, "summary-before-run", 900, 0.4);
+    recordUsageCostAt(conversation.id, "summary-at-start", 1000, 0.01);
+    recordUsageCostAt(conversation.id, "summary-inside-run", 1500, 0.02);
+    recordUsageCostAt(conversation.id, "summary-at-finish", 2000, 0.03);
+    recordUsageCostAt(conversation.id, "summary-between-runs", 2500, 0.5);
+    recordUsageCostAt(conversation.id, "summary-outside-range-run", 3200, 0.8);
+
+    const result = getUsageSummary({ from: "1000", to: "2000" });
+
+    expect(result.summaries).toHaveLength(1);
+    expect(result.summaries[0]).toMatchObject({
+      scheduleId: schedule.id,
+      runCount: 1,
+      eventCount: 3,
+    });
+    expect(result.summaries[0].totalEstimatedCostUsd).toBeCloseTo(0.06);
+  });
+
+  test("validates required numeric range parameters", () => {
+    expect(() => getUsageSummary({ to: "2000" })).toThrow(BadRequestError);
+    expect(() => getUsageSummary({ from: "1000" })).toThrow(BadRequestError);
+    expect(() => getUsageSummary({ from: "abc", to: "2000" })).toThrow(
+      BadRequestError,
+    );
+    expect(() => getUsageSummary({ from: "3000", to: "2000" })).toThrow(
+      BadRequestError,
+    );
   });
 });
 

--- a/assistant/src/__tests__/schedule-routes.test.ts
+++ b/assistant/src/__tests__/schedule-routes.test.ts
@@ -84,6 +84,7 @@ import {
   completeScheduleRun,
   createSchedule,
   createScheduleRun,
+  getScheduleRuns,
   listSchedules,
 } from "../schedule/schedule-store.js";
 import { scheduleTask } from "../tasks/task-scheduler.js";
@@ -249,6 +250,78 @@ describe("schedule run-now trust propagation", () => {
     expect(processCalls[0].isInteractive).toBe(false);
     expect(typeof observedTaskRunIds[0]).toBe("string");
     expect(fakeConversation.taskRunId).toBeUndefined();
+  });
+
+  test("manual run-now opens task-backed schedule runs before task processing", async () => {
+    const task = createTask({
+      title: "Manual Usage Task",
+      template: "spend tokens manually",
+    });
+    const schedule = scheduleTask({
+      taskId: task.id,
+      name: "Manual scheduled task",
+      cronExpression: "* * * * *",
+    });
+
+    const from = Date.now() - 1000;
+    let usageEventCreatedAt: number | null = null;
+    let runsDuringProcessing: ReturnType<typeof getScheduleRuns> = [];
+    fakeConversation = {
+      taskRunId: undefined,
+      async processMessage(options: Record<string, unknown>) {
+        processCalls.push(options);
+        const conversationId = getOrCreateCalls[0]?.conversationId;
+        runsDuringProcessing = getScheduleRuns(schedule.id);
+        usageEventCreatedAt = Date.now();
+        recordUsageCostAt(
+          conversationId ?? "missing-conversation",
+          "manual-scheduled-task-usage",
+          usageEventCreatedAt,
+          0.25,
+        );
+        return "message-id";
+      },
+    };
+
+    const route = findRoute("schedules/:id/run", "POST");
+    await route.handler({ pathParams: { id: schedule.id } });
+    const to = Date.now() + 1000;
+
+    expect(usageEventCreatedAt).not.toBeNull();
+    expect(runsDuringProcessing).toHaveLength(1);
+    expect(runsDuringProcessing[0].status).toBe("running");
+    expect(runsDuringProcessing[0].conversationId).toBeNull();
+    expect(runsDuringProcessing[0].startedAt).toBeLessThanOrEqual(
+      usageEventCreatedAt!,
+    );
+
+    const runs = getScheduleRuns(schedule.id);
+    expect(runs).toHaveLength(1);
+    expect(runs[0].id).toBe(runsDuringProcessing[0].id);
+    expect(runs[0].status).toBe("ok");
+    expect(runs[0].conversationId).toBe(getOrCreateCalls[0].conversationId);
+    expect(runs[0].finishedAt).not.toBeNull();
+    expect(runs[0].finishedAt!).toBeGreaterThanOrEqual(usageEventCreatedAt!);
+
+    const summaryRoute = findRoute("schedules/usage-summary", "GET");
+    const summaryResult = summaryRoute.handler({
+      queryParams: { from: String(from), to: String(to) },
+    }) as {
+      summaries: Array<{
+        scheduleId: string;
+        runCount: number;
+        totalEstimatedCostUsd: number;
+        eventCount: number;
+      }>;
+    };
+    expect(
+      summaryResult.summaries.find((row) => row.scheduleId === schedule.id),
+    ).toEqual({
+      scheduleId: schedule.id,
+      runCount: 1,
+      totalEstimatedCostUsd: 0.25,
+      eventCount: 1,
+    });
   });
 });
 

--- a/assistant/src/__tests__/task-scheduler.test.ts
+++ b/assistant/src/__tests__/task-scheduler.test.ts
@@ -60,12 +60,17 @@ mock.module("../notifications/emit-signal.js", () => ({
 
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
+import { recordUsageEvent } from "../memory/llm-usage-store.js";
 import {
   createSchedule,
   getSchedule,
   getScheduleRuns,
 } from "../schedule/schedule-store.js";
-import { startScheduler } from "../schedule/scheduler.js";
+import { getScheduleUsageSummaries } from "../schedule/schedule-usage-store.js";
+import {
+  runScheduleDueWorkOnce,
+  startScheduler,
+} from "../schedule/scheduler.js";
 import { scheduleTask } from "../tasks/task-scheduler.js";
 import { createTask } from "../tasks/task-store.js";
 
@@ -160,6 +165,7 @@ describe("scheduler run_task detection", () => {
     db.run("DELETE FROM cron_jobs");
     db.run("DELETE FROM task_runs");
     db.run("DELETE FROM tasks");
+    db.run("DELETE FROM llm_usage_events");
     db.run("DELETE FROM messages");
     db.run("DELETE FROM conversations");
     onRunBackgroundJobCall = null;
@@ -297,5 +303,81 @@ describe("scheduler run_task detection", () => {
     expect(failureSignal?.dedupeKey).toMatch(
       /^activity-failed:task:nonexistent-task-id:\d{4}-\d{2}-\d{2}$/,
     );
+  });
+
+  test("opens a task-backed schedule run before task processing and backfills the real conversation id", async () => {
+    const task = createTask({
+      title: "Usage Attribution Task",
+      template: "Spend scheduled tokens",
+    });
+    const schedule = scheduleTask({
+      taskId: task.id,
+      name: "Usage Attribution Schedule",
+      cronExpression: "* * * * *",
+    });
+    forceScheduleDue(schedule.id);
+
+    const from = Date.now() - 1000;
+    let processingConversationId: string | null = null;
+    let usageEventCreatedAt: number | null = null;
+    let runsDuringProcessing: ReturnType<typeof getScheduleRuns> = [];
+
+    const result = await runScheduleDueWorkOnce(
+      async (conversationId) => {
+        processingConversationId = conversationId;
+        runsDuringProcessing = getScheduleRuns(schedule.id);
+        const event = recordUsageEvent(
+          {
+            conversationId,
+            runId: null,
+            requestId: "req-scheduled-task-usage",
+            actor: "main_agent",
+            callSite: "mainAgent",
+            inferenceProfile: "balanced",
+            provider: "anthropic",
+            model: "claude-sonnet-4-20250514",
+            inputTokens: 100,
+            outputTokens: 50,
+            cacheCreationInputTokens: 0,
+            cacheReadInputTokens: 0,
+            rawUsage: null,
+          },
+          { estimatedCostUsd: 0.25, pricingStatus: "priced" },
+        );
+        usageEventCreatedAt = event.createdAt;
+      },
+      () => {},
+    );
+    const to = Date.now() + 1000;
+
+    expect(result.completed).toBe(1);
+    expect(result.failed).toBe(0);
+    expect(processingConversationId).not.toBeNull();
+    expect(usageEventCreatedAt).not.toBeNull();
+    expect(runsDuringProcessing).toHaveLength(1);
+    expect(runsDuringProcessing[0].status).toBe("running");
+    expect(runsDuringProcessing[0].conversationId).toBeNull();
+    expect(runsDuringProcessing[0].startedAt).toBeLessThanOrEqual(
+      usageEventCreatedAt!,
+    );
+
+    const runs = getScheduleRuns(schedule.id);
+    expect(runs).toHaveLength(1);
+    expect(runs[0].id).toBe(runsDuringProcessing[0].id);
+    expect(runs[0].status).toBe("ok");
+    expect(runs[0].conversationId).toBe(processingConversationId);
+    expect(runs[0].startedAt).toBeLessThanOrEqual(usageEventCreatedAt!);
+    expect(runs[0].finishedAt).not.toBeNull();
+    expect(runs[0].finishedAt!).toBeGreaterThanOrEqual(usageEventCreatedAt!);
+
+    const summary = getScheduleUsageSummaries({ from, to }).find(
+      (row) => row.scheduleId === schedule.id,
+    );
+    expect(summary).toEqual({
+      scheduleId: schedule.id,
+      runCount: 1,
+      totalEstimatedCostUsd: 0.25,
+      eventCount: 1,
+    });
   });
 });

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -30,6 +30,7 @@ import {
   listSchedules,
   updateSchedule,
 } from "../../schedule/schedule-store.js";
+import { getScheduleUsageSummaries } from "../../schedule/schedule-usage-store.js";
 import { getLogger } from "../../util/logger.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import { BadRequestError, InternalError, NotFoundError } from "./errors.js";
@@ -84,6 +85,13 @@ const scheduleRunSchema = z.object({
   conversationArchivedAt: z.number().nullable(),
   estimatedCostUsd: z.number(),
   createdAt: z.number(),
+});
+
+const scheduleUsageSummarySchema = z.object({
+  scheduleId: z.string(),
+  runCount: z.number(),
+  totalEstimatedCostUsd: z.number(),
+  eventCount: z.number(),
 });
 
 // ---------------------------------------------------------------------------
@@ -367,6 +375,40 @@ function handleListScheduleRuns(
   };
 }
 
+function parseUsageSummaryRange(queryParams: Record<string, string>): {
+  from: number;
+  to: number;
+} {
+  const fromRaw = queryParams.from;
+  const toRaw = queryParams.to;
+
+  if (!fromRaw || !toRaw) {
+    throw new BadRequestError(
+      'Missing required query parameters: "from" and "to" (epoch milliseconds)',
+    );
+  }
+
+  const from = Number(fromRaw);
+  const to = Number(toRaw);
+
+  if (!Number.isFinite(from) || !Number.isFinite(to)) {
+    throw new BadRequestError(
+      '"from" and "to" must be valid numbers (epoch milliseconds)',
+    );
+  }
+
+  if (from > to) {
+    throw new BadRequestError('"from" must be less than or equal to "to"');
+  }
+
+  return { from, to };
+}
+
+function handleScheduleUsageSummary(queryParams: Record<string, string>) {
+  const range = parseUsageSummaryRange(queryParams);
+  return { summaries: getScheduleUsageSummaries(range) };
+}
+
 // ---------------------------------------------------------------------------
 // Shared route definitions (HTTP + IPC)
 // ---------------------------------------------------------------------------
@@ -396,6 +438,40 @@ export const ROUTES: RouteDefinition[] = [
     }),
     handler: ({ queryParams }: RouteHandlerArgs) =>
       handleListSchedules(queryParams ?? {}),
+  },
+  {
+    operationId: "getScheduleUsageSummary",
+    endpoint: "schedules/usage-summary",
+    method: "GET",
+    policy: {
+      requiredScopes: ["settings.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Get schedule usage summaries",
+    description:
+      "Return per-schedule run counts and usage totals for a time range.",
+    tags: ["schedules"],
+    queryParams: [
+      {
+        name: "from",
+        type: "integer",
+        required: true,
+        description: "Start epoch millis (required)",
+      },
+      {
+        name: "to",
+        type: "integer",
+        required: true,
+        description: "End epoch millis (required)",
+      },
+    ],
+    responseBody: z.object({
+      summaries: z
+        .array(scheduleUsageSummarySchema)
+        .describe("Schedule usage summary rows"),
+    }),
+    handler: ({ queryParams }: RouteHandlerArgs) =>
+      handleScheduleUsageSummary(queryParams ?? {}),
   },
   {
     operationId: "createSchedule",

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -28,6 +28,7 @@ import {
   getSchedule,
   getScheduleRuns,
   listSchedules,
+  setScheduleRunConversationId,
   updateSchedule,
 } from "../../schedule/schedule-store.js";
 import { getScheduleUsageSummaries } from "../../schedule/schedule-usage-store.js";
@@ -687,6 +688,7 @@ async function handleRunScheduleNow(id: string) {
   const taskMatch = schedule.message.match(/^run_task:(\S+)$/);
   if (taskMatch) {
     const taskId = taskMatch[1];
+    const runId = createScheduleRun(schedule.id, null);
     try {
       log.info(
         { jobId: schedule.id, name: schedule.name, taskId },
@@ -713,7 +715,7 @@ async function handleRunScheduleNow(id: string) {
         },
       );
 
-      const runId = createScheduleRun(schedule.id, result.conversationId);
+      setScheduleRunConversationId(runId, result.conversationId);
       if (result.status === "failed") {
         completeScheduleRun(runId, {
           status: "error",
@@ -734,7 +736,7 @@ async function handleRunScheduleNow(id: string) {
         origin: "schedule",
         systemHint: `Schedule (manual): ${schedule.name}`,
       });
-      const runId = createScheduleRun(schedule.id, fallbackConversation.id);
+      setScheduleRunConversationId(runId, fallbackConversation.id);
       completeScheduleRun(runId, { status: "error", error: message });
     }
     return handleListSchedules({});

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -598,7 +598,7 @@ export function cancelSchedule(id: string): boolean {
 
 export function createScheduleRun(
   jobId: string,
-  conversationId: string,
+  conversationId: string | null,
 ): string {
   const db = getDb();
   const id = uuid();
@@ -618,6 +618,17 @@ export function createScheduleRun(
     })
     .run();
   return id;
+}
+
+export function setScheduleRunConversationId(
+  runId: string,
+  conversationId: string,
+): void {
+  const db = getDb();
+  db.update(scheduleRuns)
+    .set({ conversationId })
+    .where(eq(scheduleRuns.id, runId))
+    .run();
 }
 
 export function completeScheduleRun(

--- a/assistant/src/schedule/schedule-usage-store.ts
+++ b/assistant/src/schedule/schedule-usage-store.ts
@@ -1,0 +1,83 @@
+import { rawAll } from "../memory/raw-query.js";
+
+export interface ScheduleUsageSummary {
+  scheduleId: string;
+  runCount: number;
+  totalEstimatedCostUsd: number;
+  eventCount: number;
+}
+
+interface ScheduleUsageSummaryRow {
+  schedule_id: string;
+  run_count: number;
+  total_estimated_cost_usd: number | null;
+  event_count: number | null;
+}
+
+export function getScheduleUsageSummaries({
+  from,
+  to,
+}: {
+  from: number;
+  to: number;
+}): ScheduleUsageSummary[] {
+  const now = Date.now();
+  const rows = rawAll<ScheduleUsageSummaryRow>(
+    /*sql*/ `
+    WITH run_counts AS (
+      SELECT
+        job_id AS schedule_id,
+        COUNT(*) AS run_count
+      FROM cron_runs
+      WHERE started_at >= ?1
+        AND started_at <= ?2
+      GROUP BY job_id
+    ),
+    attributed_usage AS (
+      SELECT
+        e.estimated_cost_usd,
+        COALESCE(e.llm_call_count, 1) AS event_count,
+        (
+          SELECT schedule_attr_runs.job_id
+          FROM cron_runs schedule_attr_runs
+          WHERE schedule_attr_runs.conversation_id = e.conversation_id
+            AND e.created_at >= schedule_attr_runs.started_at
+            AND e.created_at <= COALESCE(schedule_attr_runs.finished_at, ?3)
+          ORDER BY schedule_attr_runs.started_at DESC, schedule_attr_runs.id DESC
+          LIMIT 1
+        ) AS schedule_id
+      FROM llm_usage_events e
+      WHERE e.created_at >= ?1
+        AND e.created_at <= ?2
+    ),
+    usage_totals AS (
+      SELECT
+        schedule_id,
+        COALESCE(SUM(estimated_cost_usd), 0) AS total_estimated_cost_usd,
+        COALESCE(SUM(event_count), 0) AS event_count
+      FROM attributed_usage
+      WHERE schedule_id IS NOT NULL
+      GROUP BY schedule_id
+    )
+    SELECT
+      cron_jobs.id AS schedule_id,
+      COALESCE(run_counts.run_count, 0) AS run_count,
+      COALESCE(usage_totals.total_estimated_cost_usd, 0) AS total_estimated_cost_usd,
+      COALESCE(usage_totals.event_count, 0) AS event_count
+    FROM cron_jobs
+    LEFT JOIN run_counts ON run_counts.schedule_id = cron_jobs.id
+    LEFT JOIN usage_totals ON usage_totals.schedule_id = cron_jobs.id
+    ORDER BY cron_jobs.created_at ASC, cron_jobs.id ASC
+    `,
+    from,
+    to,
+    now,
+  );
+
+  return rows.map((row) => ({
+    scheduleId: row.schedule_id,
+    runCount: row.run_count,
+    totalEstimatedCostUsd: row.total_estimated_cost_usd ?? 0,
+    eventCount: row.event_count ?? 0,
+  }));
+}

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -28,6 +28,7 @@ import {
   type RoutingIntent,
   type ScheduleJob,
   scheduleRetry,
+  setScheduleRunConversationId,
 } from "./schedule-store.js";
 
 const log = getLogger("scheduler");
@@ -442,6 +443,7 @@ export async function runScheduleDueWorkOnce(
         job.syntax === "rrule" &&
         job.expression != null &&
         hasSetConstructs(job.expression);
+      const runId = createScheduleRun(job.id, null);
       let failed = false;
       try {
         log.info(
@@ -472,14 +474,13 @@ export async function runScheduleDueWorkOnce(
           },
         );
 
+        setScheduleRunConversationId(runId, result.conversationId);
         onScheduleConversationCreated?.({
           conversationId: result.conversationId,
           scheduleJobId: job.id,
           title: result.status === "failed" ? `${job.name}: Error` : job.name,
         });
 
-        // Track the schedule run using the task's conversation
-        const runId = createScheduleRun(job.id, result.conversationId);
         if (result.status === "failed") {
           const errorMessage = result.error ?? "Task run failed";
           completeScheduleRun(runId, {
@@ -530,7 +531,7 @@ export async function runScheduleDueWorkOnce(
           scheduleJobId: job.id,
           title: `${job.name}: Error`,
         });
-        const runId = createScheduleRun(job.id, fallbackConversation.id);
+        setScheduleRunConversationId(runId, fallbackConversation.id);
         completeScheduleRun(runId, { status: "error", error: message });
         emitTaskActivityFailed({
           taskId,


### PR DESCRIPTION
## Summary
- Adds a schedule usage summary endpoint.
- Counts runs and usage with schedule run-window attribution.

Part of plan: schedules-details-usage-consolidated.md (PR 6 of 8)