### PR TITLE
Show cost and run counts on schedule rows

### DIFF
--- a/apps/web/src/domains/settings/api/schedules.test.ts
+++ b/apps/web/src/domains/settings/api/schedules.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import * as sdkGen from "@/generated/daemon/sdk.gen";
+
+import type { SchedulesUsagesummaryGetResponse } from "@/generated/daemon/types.gen";
+
+interface UsageSummaryCall {
+  path: { assistant_id: string };
+  query: { from: number; to: number };
+  throwOnError: false;
+}
+
+const summaryRows: SchedulesUsagesummaryGetResponse["summaries"] = [
+  {
+    scheduleId: "schedule-123",
+    runCount: 2,
+    totalEstimatedCostUsd: 0.42,
+    eventCount: 7,
+  },
+];
+
+let usageSummaryCalls: UsageSummaryCall[] = [];
+let responseOk = true;
+let responseStatus = 200;
+
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  ...sdkGen,
+  schedulesUsagesummaryGet: (opts: UsageSummaryCall) => {
+    usageSummaryCalls.push(opts);
+    return Promise.resolve({
+      data: responseOk ? { summaries: summaryRows } : undefined,
+      error: undefined,
+      response: { ok: responseOk, status: responseStatus },
+    });
+  },
+}));
+
+const { fetchScheduleUsageSummary } = await import("./schedules");
+
+afterEach(() => {
+  usageSummaryCalls = [];
+  responseOk = true;
+  responseStatus = 200;
+});
+
+describe("fetchScheduleUsageSummary", () => {
+  test("passes summary range query params to the daemon SDK", async () => {
+    const result = await fetchScheduleUsageSummary("assistant-1", {
+      from: 100,
+      to: 200,
+    });
+
+    expect(result).toEqual(summaryRows);
+    expect(usageSummaryCalls).toEqual([
+      {
+        path: { assistant_id: "assistant-1" },
+        query: { from: 100, to: 200 },
+        throwOnError: false,
+      },
+    ]);
+  });
+
+  test("preserves from=0 in summary query params", async () => {
+    await fetchScheduleUsageSummary("assistant-1", {
+      from: 0,
+      to: 200,
+    });
+
+    expect(usageSummaryCalls[0]?.query).toEqual({ from: 0, to: 200 });
+  });
+});

--- a/apps/web/src/domains/settings/api/schedules.ts
+++ b/apps/web/src/domains/settings/api/schedules.ts
@@ -14,6 +14,7 @@ import {
   schedulesByIdRunPost,
   schedulesByIdRunsGet,
   schedulesByIdTogglePost,
+  schedulesUsagesummaryGet,
   schedulesPost,
 } from "@/generated/daemon/sdk.gen";
 import type {
@@ -29,7 +30,11 @@ import {
 } from "@/utils/api-errors";
 import { fetchSchedules as fetchSharedSchedules } from "@/utils/schedules";
 
-import type { Schedule, ScheduleRun } from "@/domains/settings/types/schedules";
+import type {
+  Schedule,
+  ScheduleRun,
+  ScheduleUsageSummary,
+} from "@/domains/settings/types/schedules";
 
 export { ApiError };
 
@@ -104,6 +109,30 @@ export async function fetchScheduleRuns(
     );
   }
   return data?.runs ?? [];
+}
+
+export interface ScheduleUsageSummaryRange {
+  from: number;
+  to: number;
+}
+
+export async function fetchScheduleUsageSummary(
+  assistantId: string,
+  range: ScheduleUsageSummaryRange,
+): Promise<ScheduleUsageSummary[]> {
+  const { data, error, response } = await schedulesUsagesummaryGet({
+    path: { assistant_id: assistantId },
+    query: { from: range.from, to: range.to },
+    throwOnError: false,
+  });
+  assertHasResponse(response, error, "Failed to load schedule usage.");
+  if (!response.ok) {
+    throw new ApiError(
+      response.status,
+      extractErrorMessage(error, response, "Failed to load schedule usage."),
+    );
+  }
+  return data?.summaries ?? [];
 }
 
 export async function toggleSchedule(

--- a/apps/web/src/domains/settings/pages/schedules-page.test.ts
+++ b/apps/web/src/domains/settings/pages/schedules-page.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { createElement } from "react";
 
 import { routes } from "@/utils/routes";
@@ -24,6 +24,7 @@ const {
   canOpenScheduleSourceConversation,
   formatScheduleCost,
   RecentRunsCard,
+  ScheduleRow,
 } = await import("./schedules-page");
 
 afterEach(() => {
@@ -183,5 +184,111 @@ describe("RecentRunsCard", () => {
     expect(document.body.textContent).not.toContain("Run details");
     expect(document.body.textContent).not.toContain("Back to runs");
     expect(routes.settings.schedule("schedule-1")).not.toContain("/runs/");
+  });
+});
+
+describe("ScheduleRow", () => {
+  function rowSchedule(overrides: Partial<Schedule> = {}): Schedule {
+    return schedule({
+      id: "schedule-123",
+      name: "Daily summary",
+      description: "Summarize the day",
+      mode: "execute",
+      enabled: true,
+      lastRunAt: null,
+      lastStatus: null,
+      ...overrides,
+    });
+  }
+
+  test("cost metric opens usage without opening row details", () => {
+    let detailClicks = 0;
+    let usageClicks = 0;
+
+    render(
+      createElement(ScheduleRow, {
+        schedule: rowSchedule(),
+        usage: {
+          status: "ready",
+          summary: {
+            scheduleId: "schedule-123",
+            runCount: 2,
+            totalEstimatedCostUsd: 0.42,
+            eventCount: 7,
+          },
+        },
+        onClick: () => {
+          detailClicks += 1;
+        },
+        onToggle: () => {},
+        onOpenUsage: () => {
+          usageClicks += 1;
+        },
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /view usage/i }));
+
+    expect(usageClicks).toBe(1);
+    expect(detailClicks).toBe(0);
+    expect(navigateCalls).toEqual([]);
+  });
+
+  test("run count metric is not clickable", () => {
+    let detailClicks = 0;
+    let usageClicks = 0;
+
+    render(
+      createElement(ScheduleRow, {
+        schedule: rowSchedule(),
+        usage: {
+          status: "ready",
+          summary: {
+            scheduleId: "schedule-123",
+            runCount: 2,
+            totalEstimatedCostUsd: 0.42,
+            eventCount: 7,
+          },
+        },
+        onClick: () => {
+          detailClicks += 1;
+        },
+        onToggle: () => {},
+        onOpenUsage: () => {
+          usageClicks += 1;
+        },
+      }),
+    );
+
+    fireEvent.click(screen.getByText("2 runs"));
+
+    expect(usageClicks).toBe(0);
+    expect(detailClicks).toBe(0);
+  });
+
+  test("renders loading placeholders and unavailable error stats", () => {
+    const { rerender } = render(
+      createElement(ScheduleRow, {
+        schedule: rowSchedule(),
+        usage: { status: "loading" },
+        onClick: () => {},
+        onToggle: () => {},
+        onOpenUsage: () => {},
+      }),
+    );
+
+    expect(screen.getByLabelText("Loading schedule usage")).toBeTruthy();
+
+    rerender(
+      createElement(ScheduleRow, {
+        schedule: rowSchedule(),
+        usage: { status: "error" },
+        onClick: () => {},
+        onToggle: () => {},
+        onOpenUsage: () => {},
+      }),
+    );
+
+    expect(screen.getAllByText("--")).toHaveLength(2);
   });
 });

--- a/apps/web/src/domains/settings/pages/schedules-page.test.ts
+++ b/apps/web/src/domains/settings/pages/schedules-page.test.ts
@@ -1,13 +1,16 @@
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { createElement } from "react";
 
+import * as schedulesApi from "@/domains/settings/api/schedules";
 import { routes } from "@/utils/routes";
 
 import type {
   Schedule,
   ScheduleRun,
+  ScheduleUsageSummary,
 } from "@/domains/settings/types/schedules";
+import type { ScheduleUsageSummaryRange } from "@/domains/settings/api/schedules";
 
 const navigateCalls: string[] = [];
 const navigateMock = (to: string) => {
@@ -19,7 +22,21 @@ mock.module("react-router", () => ({
   useParams: () => ({}),
 }));
 
+const fetchScheduleUsageSummaryMock = mock(
+  async (
+    _assistantId: string,
+    _range: ScheduleUsageSummaryRange,
+  ): Promise<ScheduleUsageSummary[]> => [],
+);
+let nowSpy: ReturnType<typeof spyOn> | null = null;
+
+mock.module("@/domains/settings/api/schedules", () => ({
+  ...schedulesApi,
+  fetchScheduleUsageSummary: fetchScheduleUsageSummaryMock,
+}));
+
 const {
+  scheduleUsageSummaryQueryOptions,
   canOpenScheduleRunConversation,
   canOpenScheduleSourceConversation,
   formatScheduleCost,
@@ -30,6 +47,9 @@ const {
 afterEach(() => {
   cleanup();
   navigateCalls.length = 0;
+  fetchScheduleUsageSummaryMock.mockClear();
+  nowSpy?.mockRestore();
+  nowSpy = null;
 });
 
 function schedule(
@@ -100,6 +120,42 @@ describe("formatScheduleCost", () => {
   test("falls back when cost is missing or invalid", () => {
     expect(formatScheduleCost(null)).toBe("—");
     expect(formatScheduleCost(Number.NaN)).toBe("—");
+  });
+});
+
+describe("scheduleUsageSummaryQueryOptions", () => {
+  test("resolves the usage window when the query fetches", async () => {
+    const firstNow = Date.UTC(2026, 5, 2, 18, 30, 0);
+    const secondNow = firstNow + 60_000;
+    nowSpy = spyOn(Date, "now").mockReturnValue(firstNow);
+    const options = scheduleUsageSummaryQueryOptions("assistant-1", "UTC");
+
+    expect(options.queryKey).toEqual([
+      "schedule-usage-summary",
+      "assistant-1",
+      "UTC",
+    ]);
+
+    await options.queryFn();
+    nowSpy.mockReturnValue(secondNow);
+    await options.queryFn();
+
+    expect(fetchScheduleUsageSummaryMock.mock.calls).toEqual([
+      [
+        "assistant-1",
+        {
+          from: Date.UTC(2026, 4, 27, 0, 0, 0),
+          to: firstNow,
+        },
+      ],
+      [
+        "assistant-1",
+        {
+          from: Date.UTC(2026, 4, 27, 0, 0, 0),
+          to: secondNow,
+        },
+      ],
+    ]);
   });
 });
 

--- a/apps/web/src/domains/settings/pages/schedules-page.tsx
+++ b/apps/web/src/domains/settings/pages/schedules-page.tsx
@@ -27,6 +27,7 @@ import {
   fetchConsolidationConfig,
   fetchHeartbeatConfig,
   fetchHeartbeatRuns,
+  fetchScheduleUsageSummary,
   fetchScheduleRuns,
   fetchSchedules,
   runConsolidationNow,
@@ -41,8 +42,10 @@ import {
   assistantSchedulesQueryKey,
 } from "@/lib/sync/query-tags";
 import { routes } from "@/utils/routes";
+import { useEffectiveTimezone } from "@/utils/use-effective-timezone";
 
 import { CreateScheduleModal } from "@/domains/settings/components/create-schedule-modal";
+import { resolveScheduleUsageWindow } from "@/domains/settings/utils/schedule-usage-window";
 
 import type {
   ConsolidationConfigGetResponse,
@@ -51,6 +54,7 @@ import type {
 import type {
   Schedule,
   ScheduleRun,
+  ScheduleUsageSummary,
   SystemTaskKind,
 } from "@/domains/settings/types/schedules";
 import type { TagTone } from "@vellum/design-library/components/tag";
@@ -86,6 +90,11 @@ const costFormatter = new Intl.NumberFormat(undefined, {
 export function formatScheduleCost(cost: number | null | undefined): string {
   if (cost == null || !Number.isFinite(cost)) return "—";
   return costFormatter.format(cost);
+}
+
+function formatScheduleRunCount(count: number): string {
+  const formatted = count.toLocaleString();
+  return `${formatted} ${count === 1 ? "run" : "runs"}`;
 }
 
 export function canOpenScheduleSourceConversation(schedule: Schedule): boolean {
@@ -675,17 +684,94 @@ export function ScheduleDetailView({
 // Schedule list row
 // ---------------------------------------------------------------------------
 
-function ScheduleRow({
+export type ScheduleRowUsage =
+  | { status: "loading" }
+  | { status: "error" }
+  | { status: "ready"; summary: ScheduleUsageSummary };
+
+function zeroScheduleUsageSummary(scheduleId: string): ScheduleUsageSummary {
+  return {
+    scheduleId,
+    runCount: 0,
+    totalEstimatedCostUsd: 0,
+    eventCount: 0,
+  };
+}
+
+function ScheduleUsageStats({
+  scheduleName,
+  usage,
+  onOpenUsage,
+}: {
+  scheduleName: string;
+  usage: ScheduleRowUsage;
+  onOpenUsage: () => void;
+}) {
+  if (usage.status === "loading") {
+    return (
+      <div
+        aria-label="Loading schedule usage"
+        className="flex w-[136px] shrink-0 items-center justify-end gap-3"
+      >
+        <span className="h-8 w-14 animate-pulse rounded bg-[var(--surface-muted)]" />
+        <span className="h-8 w-14 animate-pulse rounded bg-[var(--surface-muted)]" />
+      </div>
+    );
+  }
+
+  const isUnavailable = usage.status === "error";
+  const cost = isUnavailable
+    ? "--"
+    : formatScheduleCost(usage.summary.totalEstimatedCostUsd);
+  const runs = isUnavailable
+    ? "--"
+    : formatScheduleRunCount(usage.summary.runCount);
+
+  return (
+    <div className="flex w-[136px] shrink-0 items-center justify-end gap-3 text-right">
+      <button
+        type="button"
+        onClick={onOpenUsage}
+        aria-label={`View usage for ${scheduleName}`}
+        className="min-w-[54px] cursor-pointer rounded px-1 py-0.5 text-right transition-colors hover:bg-[var(--surface-hover)]"
+      >
+        <span className="block text-label-small-default text-[var(--content-tertiary)]">
+          Cost
+        </span>
+        <span className="block text-body-small-default text-[var(--content-default)]">
+          {cost}
+        </span>
+      </button>
+      <span
+        aria-label={`Runs for ${scheduleName} in the last 7 days: ${runs}`}
+        className="block min-w-[54px] px-1 py-0.5"
+      >
+        <span className="block text-label-small-default text-[var(--content-tertiary)]">
+          Runs
+        </span>
+        <span className="block text-body-small-default text-[var(--content-default)]">
+          {runs}
+        </span>
+      </span>
+    </div>
+  );
+}
+
+export function ScheduleRow({
   schedule,
+  usage,
   onClick,
   onToggle,
+  onOpenUsage,
 }: {
   schedule: Schedule;
+  usage: ScheduleRowUsage;
   onClick: () => void;
   onToggle: (enabled: boolean) => void;
+  onOpenUsage: () => void;
 }) {
   return (
-    <div className="flex items-center gap-3 py-3 first:pt-0 last:pb-0 [&+&]:border-t [&+&]:border-[var(--border-base)]">
+    <div className="flex flex-wrap items-center gap-3 py-3 first:pt-0 last:pb-0 [&+&]:border-t [&+&]:border-[var(--border-base)]">
       <button
         type="button"
         onClick={onClick}
@@ -710,15 +796,24 @@ function ScheduleRow({
         </div>
       </button>
       <div className="flex shrink-0 items-center gap-3">
+        <ScheduleUsageStats
+          scheduleName={schedule.name}
+          usage={usage}
+          onOpenUsage={onOpenUsage}
+        />
         <Toggle
           checked={schedule.enabled}
           onChange={onToggle}
           aria-label={`Toggle ${schedule.name}`}
         />
-        <ChevronRight
-          className="h-4 w-4 text-[var(--content-tertiary)] cursor-pointer"
+        <button
+          type="button"
           onClick={onClick}
-        />
+          aria-label={`Open ${schedule.name}`}
+          className="flex h-7 w-7 cursor-pointer items-center justify-center rounded text-[var(--content-tertiary)] transition-colors hover:bg-[var(--surface-hover)]"
+        >
+          <ChevronRight className="h-4 w-4" />
+        </button>
       </div>
     </div>
   );
@@ -1050,6 +1145,7 @@ function SystemTasksSection({
 export function SchedulesPage() {
   const navigate = useNavigate();
   const { scheduleId } = useParams<{ scheduleId?: string }>();
+  const tz = useEffectiveTimezone();
   const {
     data: assistantList,
     isLoading: isAssistantLoading,
@@ -1066,6 +1162,23 @@ export function SchedulesPage() {
   } = useQuery({
     queryKey: assistantSchedulesQueryKey(assistantId),
     queryFn: () => fetchSchedules(assistantId!),
+    enabled: !!assistantId,
+    staleTime: 10_000,
+  });
+
+  const usageWindow = useMemo(() => resolveScheduleUsageWindow(tz), [tz]);
+  const {
+    data: usageSummaries,
+    isLoading: isUsageSummaryLoading,
+    isError: isUsageSummaryError,
+  } = useQuery({
+    queryKey: [
+      "schedule-usage-summary",
+      assistantId,
+      usageWindow.from,
+      usageWindow.to,
+    ],
+    queryFn: () => fetchScheduleUsageSummary(assistantId!, usageWindow),
     enabled: !!assistantId,
     staleTime: 10_000,
   });
@@ -1105,6 +1218,34 @@ export function SchedulesPage() {
           null)
         : null,
     [schedules, scheduleId, selectedSystemTask],
+  );
+  const usageSummaryByScheduleId = useMemo(
+    () =>
+      new Map(
+        (usageSummaries ?? []).map((summary) => [
+          summary.scheduleId,
+          summary,
+        ]),
+      ),
+    [usageSummaries],
+  );
+
+  const usageForSchedule = useCallback(
+    (scheduleId: string): ScheduleRowUsage => {
+      if (isUsageSummaryLoading) {
+        return { status: "loading" };
+      }
+      if (isUsageSummaryError) {
+        return { status: "error" };
+      }
+      return {
+        status: "ready",
+        summary:
+          usageSummaryByScheduleId.get(scheduleId) ??
+          zeroScheduleUsageSummary(scheduleId),
+      };
+    },
+    [isUsageSummaryError, isUsageSummaryLoading, usageSummaryByScheduleId],
   );
 
   const navigateToSchedules = useCallback(() => {
@@ -1349,6 +1490,12 @@ export function SchedulesPage() {
         </Button>
       </div>
 
+      {isUsageSummaryError ? (
+        <Notice tone="warning" className="py-2 text-body-small-default">
+          Schedule usage stats are unavailable right now.
+        </Notice>
+      ) : null}
+
       {recurring.length > 0 && (
         <DetailCard
           title="Schedules"
@@ -1359,8 +1506,12 @@ export function SchedulesPage() {
               <ScheduleRow
                 key={schedule.id}
                 schedule={schedule}
+                usage={usageForSchedule(schedule.id)}
                 onClick={() => navigateToSchedule(schedule.id)}
                 onToggle={(enabled) => void handleToggle(schedule.id, enabled)}
+                onOpenUsage={() =>
+                  navigate(routes.logs.usageForSchedule(schedule.id))
+                }
               />
             ))}
           </div>
@@ -1395,8 +1546,12 @@ export function SchedulesPage() {
               <ScheduleRow
                 key={schedule.id}
                 schedule={schedule}
+                usage={usageForSchedule(schedule.id)}
                 onClick={() => navigateToSchedule(schedule.id)}
                 onToggle={(enabled) => void handleToggle(schedule.id, enabled)}
+                onOpenUsage={() =>
+                  navigate(routes.logs.usageForSchedule(schedule.id))
+                }
               />
             ))}
           </div>

--- a/apps/web/src/domains/settings/pages/schedules-page.tsx
+++ b/apps/web/src/domains/settings/pages/schedules-page.tsx
@@ -689,6 +689,26 @@ export type ScheduleRowUsage =
   | { status: "error" }
   | { status: "ready"; summary: ScheduleUsageSummary };
 
+export function scheduleUsageSummaryQueryOptions(
+  assistantId: string | undefined,
+  tz: string,
+) {
+  return {
+    queryKey: ["schedule-usage-summary", assistantId, tz],
+    queryFn: () => {
+      if (!assistantId) {
+        return Promise.resolve<ScheduleUsageSummary[]>([]);
+      }
+      return fetchScheduleUsageSummary(
+        assistantId,
+        resolveScheduleUsageWindow(tz),
+      );
+    },
+    enabled: !!assistantId,
+    staleTime: 10_000,
+  };
+}
+
 function zeroScheduleUsageSummary(scheduleId: string): ScheduleUsageSummary {
   return {
     scheduleId,
@@ -1166,22 +1186,11 @@ export function SchedulesPage() {
     staleTime: 10_000,
   });
 
-  const usageWindow = useMemo(() => resolveScheduleUsageWindow(tz), [tz]);
   const {
     data: usageSummaries,
     isLoading: isUsageSummaryLoading,
     isError: isUsageSummaryError,
-  } = useQuery({
-    queryKey: [
-      "schedule-usage-summary",
-      assistantId,
-      usageWindow.from,
-      usageWindow.to,
-    ],
-    queryFn: () => fetchScheduleUsageSummary(assistantId!, usageWindow),
-    enabled: !!assistantId,
-    staleTime: 10_000,
-  });
+  } = useQuery(scheduleUsageSummaryQueryOptions(assistantId, tz));
 
   const {
     data: heartbeatConfig,

--- a/apps/web/src/domains/settings/types/schedules.ts
+++ b/apps/web/src/domains/settings/types/schedules.ts
@@ -1,6 +1,7 @@
 import type {
   SchedulesByIdRunsGetResponse,
   SchedulesGetResponse,
+  SchedulesUsagesummaryGetResponse,
 } from "@/generated/daemon/types.gen";
 
 export type Schedule = SchedulesGetResponse["schedules"][number] & {
@@ -14,5 +15,9 @@ export type ScheduleRun = SchedulesByIdRunsGetResponse["runs"][number] & {
   conversationArchivedAt?: number | null;
   estimatedCostUsd?: number;
 };
+
+export type ScheduleUsageSummaryResponse = SchedulesUsagesummaryGetResponse;
+export type ScheduleUsageSummary =
+  ScheduleUsageSummaryResponse["summaries"][number];
 
 export type SystemTaskKind = "heartbeat" | "consolidation";

--- a/apps/web/src/domains/settings/utils/schedule-usage-window.test.ts
+++ b/apps/web/src/domains/settings/utils/schedule-usage-window.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+
+import { timezoneDayStartEpoch } from "@/components/charts/format-date-label";
+
+import { resolveScheduleUsageWindow } from "./schedule-usage-window";
+
+describe("resolveScheduleUsageWindow", () => {
+  test("matches the usage page's 7d window semantics in UTC", () => {
+    const now = Date.UTC(2026, 5, 2, 18, 30, 0);
+
+    expect(resolveScheduleUsageWindow("UTC", now)).toEqual({
+      from: Date.UTC(2026, 4, 27, 0, 0, 0),
+      to: now,
+    });
+  });
+
+  test("uses zone-local midnight for the first day of the 7d window", () => {
+    const now = Date.UTC(2026, 5, 2, 18, 0, 0);
+    const window = resolveScheduleUsageWindow("America/New_York", now);
+
+    expect(window.to).toBe(now);
+    expect(window.from).toBe(
+      timezoneDayStartEpoch("2026-05-27", "America/New_York"),
+    );
+    expect(
+      new Intl.DateTimeFormat("en-US", {
+        timeZone: "America/New_York",
+        hour: "2-digit",
+        minute: "2-digit",
+        hourCycle: "h23",
+      }).format(new Date(window.from)),
+    ).toBe("00:00");
+  });
+});

--- a/apps/web/src/domains/settings/utils/schedule-usage-window.ts
+++ b/apps/web/src/domains/settings/utils/schedule-usage-window.ts
@@ -1,0 +1,27 @@
+import {
+  timezoneDayStartEpoch,
+  toTimezoneDateString,
+} from "@/components/charts/format-date-label";
+import { getEffectiveTimezone } from "@/utils/effective-timezone";
+
+export interface ScheduleUsageWindow {
+  from: number;
+  to: number;
+}
+
+export function resolveScheduleUsageWindow(
+  tz: string = getEffectiveTimezone(),
+  now: Date | number = Date.now(),
+): ScheduleUsageWindow {
+  const to = typeof now === "number" ? now : now.getTime();
+  const todayInTz = toTimezoneDateString(new Date(to), tz);
+  const [year, month, day] = todayInTz.split("-").map(Number);
+  const anchor = new Date(Date.UTC(year, month - 1, day, 12));
+  anchor.setUTCDate(anchor.getUTCDate() - 6);
+  const fromDate = toTimezoneDateString(anchor, "UTC");
+
+  return {
+    from: timezoneDayStartEpoch(fromDate, tz),
+    to,
+  };
+}

--- a/apps/web/src/utils/routes.test.ts
+++ b/apps/web/src/utils/routes.test.ts
@@ -24,13 +24,13 @@ describe("routes", () => {
 
   test("builds schedule-filtered usage URLs", () => {
     expect(routes.logs.usageForSchedule("schedule-123")).toBe(
-      "/assistant/logs/usage?groupBy=schedule&scheduleId=schedule-123",
+      "/assistant/logs/usage?range=7d&groupBy=schedule&scheduleId=schedule-123",
     );
   });
 
   test("encodes schedule ids in usage URLs", () => {
     expect(routes.logs.usageForSchedule("schedule with spaces")).toBe(
-      "/assistant/logs/usage?groupBy=schedule&scheduleId=schedule+with+spaces",
+      "/assistant/logs/usage?range=7d&groupBy=schedule&scheduleId=schedule+with+spaces",
     );
   });
 });

--- a/apps/web/src/utils/routes.ts
+++ b/apps/web/src/utils/routes.ts
@@ -44,6 +44,7 @@ export const routes = {
     usage: LOGS_USAGE_PATH,
     usageForSchedule: (scheduleId: string) => {
       const params = new URLSearchParams({
+        range: "7d",
         groupBy: "schedule",
         scheduleId,
       });


### PR DESCRIPTION
Implements PR 8 from .private/plans/schedules-details-usage-consolidated.md: recurring and one-time schedule rows now show past-7-days cost/run stats by default, cost links to schedule-filtered usage, and summary loading/error states stay non-blocking. Base feature branch: awlevin/schedules-details-usage-consolidated.