### PR TITLE
Show consolidation system task runs

### DIFF
--- a/apps/web/src/domains/settings/api/schedules.test.ts
+++ b/apps/web/src/domains/settings/api/schedules.test.ts
@@ -2,11 +2,20 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 
 import * as sdkGen from "@/generated/daemon/sdk.gen";
 
-import type { SchedulesUsagesummaryGetResponse } from "@/generated/daemon/types.gen";
+import type {
+  ConsolidationRunsGetResponse,
+  SchedulesUsagesummaryGetResponse,
+} from "@/generated/daemon/types.gen";
 
 interface UsageSummaryCall {
   path: { assistant_id: string };
   query: { from: number; to: number };
+  throwOnError: false;
+}
+
+interface ConsolidationRunsCall {
+  path: { assistant_id: string };
+  query: { limit: number };
   throwOnError: false;
 }
 
@@ -19,12 +28,39 @@ const summaryRows: SchedulesUsagesummaryGetResponse["summaries"] = [
   },
 ];
 
+const consolidationRows: ConsolidationRunsGetResponse["runs"] = [
+  {
+    id: "conv-consolidation-1",
+    scheduledFor: 1_761_792_000_000,
+    startedAt: 1_761_792_001_000,
+    finishedAt: 1_761_792_004_000,
+    durationMs: 3000,
+    status: "ok",
+    skipReason: null,
+    error: null,
+    conversationId: "conv-consolidation-1",
+    conversationExists: true,
+    conversationArchivedAt: null,
+    estimatedCostUsd: 0.1234,
+    createdAt: 1_761_792_000_000,
+  },
+];
+
 let usageSummaryCalls: UsageSummaryCall[] = [];
+let consolidationRunsCalls: ConsolidationRunsCall[] = [];
 let responseOk = true;
 let responseStatus = 200;
 
 mock.module("@/generated/daemon/sdk.gen", () => ({
   ...sdkGen,
+  consolidationRunsGet: (opts: ConsolidationRunsCall) => {
+    consolidationRunsCalls.push(opts);
+    return Promise.resolve({
+      data: responseOk ? { runs: consolidationRows } : undefined,
+      error: undefined,
+      response: { ok: responseOk, status: responseStatus },
+    });
+  },
   schedulesUsagesummaryGet: (opts: UsageSummaryCall) => {
     usageSummaryCalls.push(opts);
     return Promise.resolve({
@@ -35,12 +71,46 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
   },
 }));
 
-const { fetchScheduleUsageSummary } = await import("./schedules");
+const { fetchConsolidationRuns, fetchScheduleUsageSummary } = await import(
+  "./schedules"
+);
 
 afterEach(() => {
   usageSummaryCalls = [];
+  consolidationRunsCalls = [];
   responseOk = true;
   responseStatus = 200;
+});
+
+describe("fetchConsolidationRuns", () => {
+  test("maps daemon consolidation runs into shared schedule run rows", async () => {
+    const result = await fetchConsolidationRuns("assistant-1");
+
+    expect(consolidationRunsCalls).toEqual([
+      {
+        path: { assistant_id: "assistant-1" },
+        query: { limit: 10 },
+        throwOnError: false,
+      },
+    ]);
+    expect(result).toEqual([
+      {
+        id: "conv-consolidation-1",
+        jobId: "consolidation",
+        status: "ok",
+        startedAt: 1_761_792_001_000,
+        finishedAt: 1_761_792_004_000,
+        durationMs: 3000,
+        output: null,
+        error: null,
+        conversationId: "conv-consolidation-1",
+        conversationExists: true,
+        conversationArchivedAt: null,
+        estimatedCostUsd: 0.1234,
+        createdAt: 1_761_792_000_000,
+      },
+    ]);
+  });
 });
 
 describe("fetchScheduleUsageSummary", () => {

--- a/apps/web/src/domains/settings/api/schedules.ts
+++ b/apps/web/src/domains/settings/api/schedules.ts
@@ -6,6 +6,7 @@
 import {
   consolidationConfigGet,
   consolidationRunnowPost,
+  consolidationRunsGet,
   heartbeatConfigGet,
   heartbeatRunnowPost,
   heartbeatRunsGet,
@@ -215,6 +216,39 @@ export async function fetchHeartbeatRuns(
     output: run.skipReason ? `Skipped: ${run.skipReason}` : null,
     error: run.error,
     conversationId: run.conversationId,
+    createdAt: run.createdAt,
+  }));
+}
+
+export async function fetchConsolidationRuns(
+  assistantId: string,
+  limit = 10,
+): Promise<ScheduleRun[]> {
+  const { data, error, response } = await consolidationRunsGet({
+    path: { assistant_id: assistantId },
+    query: { limit },
+    throwOnError: false,
+  });
+  assertHasResponse(response, error, "Failed to load consolidation runs.");
+  if (!response.ok) {
+    throw new ApiError(
+      response.status,
+      extractErrorMessage(error, response, "Failed to load consolidation runs."),
+    );
+  }
+  return (data?.runs ?? []).map((run) => ({
+    id: run.id,
+    jobId: "consolidation",
+    status: run.status,
+    startedAt: run.startedAt ?? run.scheduledFor,
+    finishedAt: run.finishedAt,
+    durationMs: run.durationMs,
+    output: null,
+    error: run.error,
+    conversationId: run.conversationId,
+    conversationExists: run.conversationExists,
+    conversationArchivedAt: run.conversationArchivedAt,
+    estimatedCostUsd: run.estimatedCostUsd,
     createdAt: run.createdAt,
   }));
 }

--- a/apps/web/src/domains/settings/pages/schedules-page.test.ts
+++ b/apps/web/src/domains/settings/pages/schedules-page.test.ts
@@ -1,6 +1,14 @@
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { createElement } from "react";
+import type { ReactElement } from "react";
 
 import * as schedulesApi from "@/domains/settings/api/schedules";
 import { routes } from "@/utils/routes";
@@ -28,10 +36,30 @@ const fetchScheduleUsageSummaryMock = mock(
     _range: ScheduleUsageSummaryRange,
   ): Promise<ScheduleUsageSummary[]> => [],
 );
+const fetchConsolidationRunsMock = mock(
+  async (_assistantId: string): Promise<ScheduleRun[]> => [
+    {
+      id: "consolidation-run-1",
+      jobId: "consolidation",
+      status: "ok",
+      startedAt: 1_761_792_000_000,
+      finishedAt: 1_761_792_003_000,
+      durationMs: 3000,
+      output: null,
+      error: null,
+      conversationId: "conv-consolidation-1",
+      conversationExists: true,
+      conversationArchivedAt: null,
+      estimatedCostUsd: 0.1234,
+      createdAt: 1_761_792_000_000,
+    },
+  ],
+);
 let nowSpy: ReturnType<typeof spyOn> | null = null;
 
 mock.module("@/domains/settings/api/schedules", () => ({
   ...schedulesApi,
+  fetchConsolidationRuns: fetchConsolidationRunsMock,
   fetchScheduleUsageSummary: fetchScheduleUsageSummaryMock,
 }));
 
@@ -42,15 +70,29 @@ const {
   formatScheduleCost,
   RecentRunsCard,
   ScheduleRow,
+  SystemTaskDetailView,
 } = await import("./schedules-page");
 
 afterEach(() => {
   cleanup();
   navigateCalls.length = 0;
+  fetchConsolidationRunsMock.mockClear();
   fetchScheduleUsageSummaryMock.mockClear();
   nowSpy?.mockRestore();
   nowSpy = null;
 });
+
+function renderWithQueryClient(element: ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+  return render(
+    createElement(QueryClientProvider, { client: queryClient }, element),
+  );
+}
 
 function schedule(
   overrides: Partial<Schedule> = {},
@@ -155,6 +197,42 @@ describe("scheduleUsageSummaryQueryOptions", () => {
           to: secondNow,
         },
       ],
+    ]);
+  });
+});
+
+describe("SystemTaskDetailView", () => {
+  test("loads consolidation runs and renders conversation-backed cost rows", async () => {
+    renderWithQueryClient(
+      createElement(SystemTaskDetailView, {
+        kind: "consolidation",
+        assistantId: "assistant-1",
+        name: "Memory consolidation",
+        subtitle: "Summarizes old context",
+        enabled: true,
+        nextRunAt: null,
+        lastRunAt: null,
+        isRunning: false,
+        onBack: () => {},
+        onRunNow: () => {},
+      }),
+    );
+
+    await waitFor(() =>
+      expect(fetchConsolidationRunsMock.mock.calls).toEqual([["assistant-1"]]),
+    );
+
+    await waitFor(() =>
+      expect(document.body.textContent).toContain("$0.1234"),
+    );
+    expect(document.body.textContent).not.toContain(
+      "Run history is not available",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Run at/i }));
+
+    expect(navigateCalls).toEqual([
+      routes.conversation("conv-consolidation-1"),
     ]);
   });
 });

--- a/apps/web/src/domains/settings/pages/schedules-page.tsx
+++ b/apps/web/src/domains/settings/pages/schedules-page.tsx
@@ -24,6 +24,7 @@ import { DetailCard } from "@/components/detail-card";
 import { assistantsListOptions } from "@/generated/api/@tanstack/react-query.gen";
 import {
   deleteSchedule,
+  fetchConsolidationRuns,
   fetchConsolidationConfig,
   fetchHeartbeatConfig,
   fetchHeartbeatRuns,
@@ -891,7 +892,7 @@ interface SystemTaskDetailViewProps {
   onRunNow: () => void;
 }
 
-function SystemTaskDetailView({
+export function SystemTaskDetailView({
   kind,
   assistantId,
   name,
@@ -906,8 +907,9 @@ function SystemTaskDetailView({
   const { data: runs, isLoading } = useQuery({
     queryKey: ["system-task-runs", assistantId, kind],
     queryFn: () =>
-      kind === "heartbeat" ? fetchHeartbeatRuns(assistantId) : [],
-    enabled: kind === "heartbeat",
+      kind === "heartbeat"
+        ? fetchHeartbeatRuns(assistantId)
+        : fetchConsolidationRuns(assistantId),
     staleTime: 10_000,
   });
 
@@ -962,15 +964,7 @@ function SystemTaskDetailView({
         </div>
       </DetailCard>
 
-      <RecentRunsCard
-        runs={kind === "heartbeat" ? runs : []}
-        isLoading={kind === "heartbeat" ? isLoading : false}
-        emptyMessage={
-          kind === "heartbeat"
-            ? "No runs yet."
-            : "Run history is not available for this system job yet."
-        }
-      />
+      <RecentRunsCard runs={runs} isLoading={isLoading} />
     </div>
   );
 }


### PR DESCRIPTION
Remediates self-review feedback for .private/plans/schedules-details-usage-consolidated.md: consolidation system-task details now fetch and display run history with conversation/cost metadata like heartbeat runs.