### PR TITLE
Open schedule runs before normal execution

### DIFF
--- a/assistant/src/__tests__/task-scheduler.test.ts
+++ b/assistant/src/__tests__/task-scheduler.test.ts
@@ -24,6 +24,7 @@ mock.module("../runtime/background-job-runner.js", () => ({
     prompt: string;
     groupId?: string;
     trustContext: { sourceChannel: string; trustClass: string };
+    onConversationCreated?: (conversationId: string) => void;
   }) => {
     const { createConversation } =
       await import("../memory/conversation-crud.js");
@@ -33,6 +34,7 @@ mock.module("../runtime/background-job-runner.js", () => ({
       source: "schedule",
       ...(opts.groupId ? { groupId: opts.groupId } : {}),
     });
+    opts.onConversationCreated?.(conv.id);
     onRunBackgroundJobCall?.({
       conversationId: conv.id,
       prompt: opts.prompt,
@@ -377,6 +379,83 @@ describe("scheduler run_task detection", () => {
       scheduleId: schedule.id,
       runCount: 1,
       totalEstimatedCostUsd: 0.25,
+      eventCount: 1,
+    });
+  });
+
+  test("opens a normal execute schedule run before fresh background processing and records the conversation id", async () => {
+    const schedule = createSchedule({
+      name: "Usage Attribution Message Schedule",
+      cronExpression: "* * * * *",
+      message: "Spend scheduled message tokens",
+      syntax: "cron",
+    });
+    forceScheduleDue(schedule.id);
+
+    const from = Date.now() - 1000;
+    let processingConversationId: string | null = null;
+    let usageEventCreatedAt: number | null = null;
+    let runsDuringProcessing: ReturnType<typeof getScheduleRuns> = [];
+
+    onRunBackgroundJobCall = (info) => {
+      processingConversationId = info.conversationId;
+      runsDuringProcessing = getScheduleRuns(schedule.id);
+      const event = recordUsageEvent(
+        {
+          conversationId: info.conversationId,
+          runId: null,
+          requestId: "req-scheduled-message-usage",
+          actor: "main_agent",
+          callSite: "mainAgent",
+          inferenceProfile: "balanced",
+          provider: "anthropic",
+          model: "claude-sonnet-4-20250514",
+          inputTokens: 80,
+          outputTokens: 20,
+          cacheCreationInputTokens: 0,
+          cacheReadInputTokens: 0,
+          rawUsage: null,
+        },
+        { estimatedCostUsd: 0.1, pricingStatus: "priced" },
+      );
+      usageEventCreatedAt = event.createdAt;
+    };
+
+    const result = await runScheduleDueWorkOnce(
+      async () => {},
+      () => {},
+    );
+    const to = Date.now() + 1000;
+
+    expect(result.completed).toBe(1);
+    expect(result.failed).toBe(0);
+    expect(processingConversationId).not.toBeNull();
+    expect(usageEventCreatedAt).not.toBeNull();
+    expect(runsDuringProcessing).toHaveLength(1);
+    expect(runsDuringProcessing[0].status).toBe("running");
+    expect(runsDuringProcessing[0].conversationId).toBe(
+      processingConversationId,
+    );
+    expect(runsDuringProcessing[0].startedAt).toBeLessThanOrEqual(
+      usageEventCreatedAt!,
+    );
+
+    const runs = getScheduleRuns(schedule.id);
+    expect(runs).toHaveLength(1);
+    expect(runs[0].id).toBe(runsDuringProcessing[0].id);
+    expect(runs[0].status).toBe("ok");
+    expect(runs[0].conversationId).toBe(processingConversationId);
+    expect(runs[0].startedAt).toBeLessThanOrEqual(usageEventCreatedAt!);
+    expect(runs[0].finishedAt).not.toBeNull();
+    expect(runs[0].finishedAt!).toBeGreaterThanOrEqual(usageEventCreatedAt!);
+
+    const summary = getScheduleUsageSummaries({ from, to }).find(
+      (row) => row.scheduleId === schedule.id,
+    );
+    expect(summary).toEqual({
+      scheduleId: schedule.id,
+      runCount: 1,
+      totalEstimatedCostUsd: 0.1,
       eventCount: 1,
     });
   });

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -585,6 +585,8 @@ export async function runScheduleDueWorkOnce(
     let ok: boolean;
     let errorMsg: string | undefined;
     const conversationReused = reusedConversationId != null;
+    let runConversationId = reusedConversationId;
+    const runId = createScheduleRun(job.id, reusedConversationId);
 
     if (reusedConversationId) {
       // Reuse path: keep using the injected `processMessage` callback so the
@@ -626,6 +628,8 @@ export async function runScheduleDueWorkOnce(
         scheduleJobId: job.id,
         suppressFailureNotifications: job.quiet === true,
         onConversationCreated: (newConversationId) => {
+          runConversationId = newConversationId;
+          setScheduleRunConversationId(runId, newConversationId);
           onScheduleConversationCreated?.({
             conversationId: newConversationId,
             scheduleJobId: job.id,
@@ -642,11 +646,13 @@ export async function runScheduleDueWorkOnce(
         !result.ok && result.conversationId === ""
           ? `bootstrap-error:${job.id}`
           : result.conversationId;
+      if (runConversationId !== conversationId) {
+        runConversationId = conversationId;
+        setScheduleRunConversationId(runId, conversationId);
+      }
       ok = result.ok;
       errorMsg = result.error?.message;
     }
-
-    const runId = createScheduleRun(job.id, conversationId);
 
     if (ok) {
       completeScheduleRun(runId, { status: "ok" });


### PR DESCRIPTION
Remediates self-review feedback for .private/plans/schedules-details-usage-consolidated.md: normal execute-mode schedules now open cron_runs before assistant work so run-window usage attribution includes the run's own LLM events.