### PR TITLE
Share schedule usage attribution helpers

### DIFF
--- a/assistant/src/memory/llm-usage-store.ts
+++ b/assistant/src/memory/llm-usage-store.ts
@@ -9,6 +9,13 @@ import type {
 import { APP_VERSION } from "../version.js";
 import { getDb } from "./db-connection.js";
 import { rawAll } from "./raw-query.js";
+import {
+  buildScheduleAttributionSubquery,
+  buildScheduleRunWindowExists,
+  normalizeScheduleAttributionFilter,
+  type ScheduleAttributionFilter,
+  type ScheduleAttributionSqlParam,
+} from "./schedule-attribution-sql.js";
 import { conversations, llmUsageEvents } from "./schema.js";
 import {
   bucketEventsByDay,
@@ -282,9 +289,7 @@ export interface UsageTimeRange {
   to: number;
 }
 
-export interface UsageAggregationFilter {
-  scheduleId?: string;
-}
+export type UsageAggregationFilter = ScheduleAttributionFilter;
 
 /** Aggregate totals across a time range. */
 export interface UsageTotals {
@@ -381,38 +386,12 @@ interface GroupRow {
   event_count: number;
 }
 
-type UsageQueryParam = string | number;
+type UsageQueryParam = ScheduleAttributionSqlParam;
 
 function normalizeUsageAggregationFilter(
   filter?: UsageAggregationFilter,
 ): UsageAggregationFilter {
-  const scheduleId = filter?.scheduleId?.trim();
-  return scheduleId ? { scheduleId } : {};
-}
-
-function usageColumn(column: string, eventAlias?: string): string {
-  return eventAlias ? `${eventAlias}.${column}` : column;
-}
-
-function scheduleRunWindowSql(
-  eventAlias: string,
-  runAlias: string,
-  filter: UsageAggregationFilter,
-): string {
-  const scheduleClause = filter.scheduleId ? `${runAlias}.job_id = ? AND ` : "";
-  return `${scheduleClause}${runAlias}.conversation_id = ${usageColumn(
-    "conversation_id",
-    eventAlias,
-  )}
-    AND ${usageColumn("created_at", eventAlias)} >= ${runAlias}.started_at
-    AND ${usageColumn("created_at", eventAlias)} <= COALESCE(${runAlias}.finished_at, ?)`;
-}
-
-function scheduleRunWindowParams(
-  filter: UsageAggregationFilter,
-  now: number,
-): UsageQueryParam[] {
-  return filter.scheduleId ? [filter.scheduleId, now] : [now];
+  return normalizeScheduleAttributionFilter(filter);
 }
 
 function buildUsageAggregationWhere(
@@ -422,40 +401,22 @@ function buildUsageAggregationWhere(
   now: number = Date.now(),
 ): { sql: string; params: UsageQueryParam[] } {
   const normalized = normalizeUsageAggregationFilter(filter);
-  const createdAt = usageColumn("created_at", eventAlias);
+  const eventTable = eventAlias ?? "llm_usage_events";
+  const createdAt = `${eventTable}.created_at`;
   const clauses = [`${createdAt} >= ? AND ${createdAt} <= ?`];
   const params: UsageQueryParam[] = [range.from, range.to];
 
   if (normalized.scheduleId) {
-    clauses.push(`EXISTS (
-      SELECT 1
-      FROM cron_runs schedule_filter_runs
-      WHERE ${scheduleRunWindowSql(
-        eventAlias ?? "llm_usage_events",
-        "schedule_filter_runs",
-        normalized,
-      )}
-    )`);
-    params.push(...scheduleRunWindowParams(normalized, now));
+    const exists = buildScheduleRunWindowExists({
+      eventAlias: eventTable,
+      filter: normalized,
+      now,
+    });
+    clauses.push(exists.sql);
+    params.push(...exists.params);
   }
 
   return { sql: clauses.join(" AND "), params };
-}
-
-function scheduleAttributionSubquery(
-  eventAlias: string,
-  filter: UsageAggregationFilter,
-  selectExpression: string,
-): string {
-  return `(
-    SELECT ${selectExpression}
-    FROM cron_runs schedule_attr_runs
-    LEFT JOIN cron_jobs schedule_attr_jobs
-      ON schedule_attr_jobs.id = schedule_attr_runs.job_id
-    WHERE ${scheduleRunWindowSql(eventAlias, "schedule_attr_runs", filter)}
-    ORDER BY schedule_attr_runs.started_at DESC, schedule_attr_runs.id DESC
-    LIMIT 1
-  )`;
 }
 
 /**
@@ -729,12 +690,12 @@ export function getUsageGroupBreakdown(
   if (groupBy === "schedule") {
     const now = Date.now();
     const where = buildUsageAggregationWhere(range, normalizedFilter, "e", now);
-    const groupKeySubquery = scheduleAttributionSubquery(
-      "e",
-      normalizedFilter,
-      "schedule_attr_runs.job_id",
-    );
-    const scheduleParams = scheduleRunWindowParams(normalizedFilter, now);
+    const groupKeySubquery = buildScheduleAttributionSubquery({
+      eventAlias: "e",
+      filter: normalizedFilter,
+      now,
+      selectExpression: "schedule_attr_runs.job_id",
+    });
     const rows = rawAll<GroupRow>(
       /*sql*/ `
       WITH schedule_usage AS (
@@ -745,7 +706,7 @@ export function getUsageGroupBreakdown(
           e.cache_read_input_tokens,
           e.estimated_cost_usd,
           e.llm_call_count,
-          ${groupKeySubquery} AS group_key
+          ${groupKeySubquery.sql} AS group_key
         FROM llm_usage_events e
         WHERE ${where.sql}
       )
@@ -765,7 +726,7 @@ export function getUsageGroupBreakdown(
       GROUP BY schedule_usage.group_key
       ORDER BY total_estimated_cost_usd DESC
       `,
-      ...scheduleParams,
+      ...groupKeySubquery.params,
       ...where.params,
     );
     return rows.map((row) => mapGroupRow(row, groupBy));
@@ -814,12 +775,12 @@ export function getUsageGroupedSeries(
   if (groupBy === "schedule") {
     const now = Date.now();
     const where = buildUsageAggregationWhere(range, normalizedFilter, "e", now);
-    const groupKeySubquery = scheduleAttributionSubquery(
-      "e",
-      normalizedFilter,
-      "schedule_attr_runs.job_id",
-    );
-    const scheduleParams = scheduleRunWindowParams(normalizedFilter, now);
+    const groupKeySubquery = buildScheduleAttributionSubquery({
+      eventAlias: "e",
+      filter: normalizedFilter,
+      now,
+      selectExpression: "schedule_attr_runs.job_id",
+    });
     rows = rawAll<UsageGroupedBucketRow>(
       /*sql*/ `
       WITH schedule_usage AS (
@@ -829,7 +790,7 @@ export function getUsageGroupedSeries(
           e.output_tokens,
           e.estimated_cost_usd,
           e.llm_call_count,
-          ${groupKeySubquery} AS group_key
+          ${groupKeySubquery.sql} AS group_key
         FROM llm_usage_events e
         WHERE ${where.sql}
       )
@@ -846,7 +807,7 @@ export function getUsageGroupedSeries(
         ON schedule_group_jobs.id = schedule_usage.group_key
       ORDER BY schedule_usage.created_at ASC
       `,
-      ...scheduleParams,
+      ...groupKeySubquery.params,
       ...where.params,
     );
   } else {

--- a/assistant/src/memory/schedule-attribution-sql.ts
+++ b/assistant/src/memory/schedule-attribution-sql.ts
@@ -1,0 +1,104 @@
+export interface ScheduleAttributionFilter {
+  scheduleId?: string;
+}
+
+export type ScheduleAttributionSqlParam = string | number;
+
+export interface ScheduleAttributionSqlFragment {
+  sql: string;
+  params: ScheduleAttributionSqlParam[];
+}
+
+export function normalizeScheduleAttributionFilter(
+  filter?: ScheduleAttributionFilter,
+): ScheduleAttributionFilter {
+  const scheduleId = filter?.scheduleId?.trim();
+  return scheduleId ? { scheduleId } : {};
+}
+
+function usageColumn(column: string, eventAlias: string): string {
+  return `${eventAlias}.${column}`;
+}
+
+function buildScheduleRunWindowPredicate({
+  eventAlias,
+  runAlias,
+  filter,
+}: {
+  eventAlias: string;
+  runAlias: string;
+  filter?: ScheduleAttributionFilter;
+}): string {
+  const normalized = normalizeScheduleAttributionFilter(filter);
+  const scheduleClause = normalized.scheduleId
+    ? `${runAlias}.job_id = ? AND `
+    : "";
+  return `${scheduleClause}${runAlias}.conversation_id = ${usageColumn(
+    "conversation_id",
+    eventAlias,
+  )}
+    AND ${usageColumn("created_at", eventAlias)} >= ${runAlias}.started_at
+    AND ${usageColumn("created_at", eventAlias)} <= COALESCE(${runAlias}.finished_at, ?)`;
+}
+
+function buildScheduleRunWindowParams(
+  filter: ScheduleAttributionFilter | undefined,
+  now: number,
+): ScheduleAttributionSqlParam[] {
+  const normalized = normalizeScheduleAttributionFilter(filter);
+  return normalized.scheduleId ? [normalized.scheduleId, now] : [now];
+}
+
+export function buildScheduleRunWindowExists({
+  eventAlias,
+  filter,
+  now,
+  runAlias = "schedule_filter_runs",
+}: {
+  eventAlias: string;
+  filter?: ScheduleAttributionFilter;
+  now: number;
+  runAlias?: string;
+}): ScheduleAttributionSqlFragment {
+  return {
+    sql: `EXISTS (
+      SELECT 1
+      FROM cron_runs ${runAlias}
+      WHERE ${buildScheduleRunWindowPredicate({
+        eventAlias,
+        runAlias,
+        filter,
+      })}
+    )`,
+    params: buildScheduleRunWindowParams(filter, now),
+  };
+}
+
+export function buildScheduleAttributionSubquery({
+  eventAlias,
+  filter,
+  now,
+  selectExpression,
+  runAlias = "schedule_attr_runs",
+}: {
+  eventAlias: string;
+  filter?: ScheduleAttributionFilter;
+  now: number;
+  selectExpression: string;
+  runAlias?: string;
+}): ScheduleAttributionSqlFragment {
+  return {
+    sql: `(
+    SELECT ${selectExpression}
+    FROM cron_runs ${runAlias}
+    WHERE ${buildScheduleRunWindowPredicate({
+      eventAlias,
+      runAlias,
+      filter,
+    })}
+    ORDER BY ${runAlias}.started_at DESC, ${runAlias}.id DESC
+    LIMIT 1
+  )`,
+    params: buildScheduleRunWindowParams(filter, now),
+  };
+}

--- a/assistant/src/runtime/routes/epoch-millis-range.ts
+++ b/assistant/src/runtime/routes/epoch-millis-range.ts
@@ -1,0 +1,34 @@
+import { BadRequestError } from "./errors.js";
+
+export interface EpochMillisRange {
+  from: number;
+  to: number;
+}
+
+export function parseEpochMillisRange(
+  queryParams: Record<string, string>,
+): EpochMillisRange {
+  const fromRaw = queryParams.from;
+  const toRaw = queryParams.to;
+
+  if (!fromRaw || !toRaw) {
+    throw new BadRequestError(
+      'Missing required query parameters: "from" and "to" (epoch milliseconds)',
+    );
+  }
+
+  const from = Number(fromRaw);
+  const to = Number(toRaw);
+
+  if (!Number.isFinite(from) || !Number.isFinite(to)) {
+    throw new BadRequestError(
+      '"from" and "to" must be valid numbers (epoch milliseconds)',
+    );
+  }
+
+  if (from > to) {
+    throw new BadRequestError('"from" must be less than or equal to "to"');
+  }
+
+  return { from, to };
+}

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -34,6 +34,7 @@ import {
 import { getScheduleUsageSummaries } from "../../schedule/schedule-usage-store.js";
 import { getLogger } from "../../util/logger.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import { parseEpochMillisRange } from "./epoch-millis-range.js";
 import { BadRequestError, InternalError, NotFoundError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
@@ -376,37 +377,8 @@ function handleListScheduleRuns(
   };
 }
 
-function parseUsageSummaryRange(queryParams: Record<string, string>): {
-  from: number;
-  to: number;
-} {
-  const fromRaw = queryParams.from;
-  const toRaw = queryParams.to;
-
-  if (!fromRaw || !toRaw) {
-    throw new BadRequestError(
-      'Missing required query parameters: "from" and "to" (epoch milliseconds)',
-    );
-  }
-
-  const from = Number(fromRaw);
-  const to = Number(toRaw);
-
-  if (!Number.isFinite(from) || !Number.isFinite(to)) {
-    throw new BadRequestError(
-      '"from" and "to" must be valid numbers (epoch milliseconds)',
-    );
-  }
-
-  if (from > to) {
-    throw new BadRequestError('"from" must be less than or equal to "to"');
-  }
-
-  return { from, to };
-}
-
 function handleScheduleUsageSummary(queryParams: Record<string, string>) {
-  const range = parseUsageSummaryRange(queryParams);
+  const range = parseEpochMillisRange(queryParams);
   return { summaries: getScheduleUsageSummaries(range) };
 }
 

--- a/assistant/src/runtime/routes/usage-routes.ts
+++ b/assistant/src/runtime/routes/usage-routes.ts
@@ -23,6 +23,7 @@ import {
 } from "../../memory/llm-usage-store.js";
 import { validateTimezone } from "../../memory/usage-buckets.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import { parseEpochMillisRange } from "./epoch-millis-range.js";
 import { BadRequestError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
@@ -89,35 +90,6 @@ function resolveTimezone(queryParams: Record<string, string>): string {
   return tz;
 }
 
-function parseTimeRange(queryParams: Record<string, string>): {
-  from: number;
-  to: number;
-} {
-  const fromRaw = queryParams.from;
-  const toRaw = queryParams.to;
-
-  if (!fromRaw || !toRaw) {
-    throw new BadRequestError(
-      'Missing required query parameters: "from" and "to" (epoch milliseconds)',
-    );
-  }
-
-  const from = Number(fromRaw);
-  const to = Number(toRaw);
-
-  if (!Number.isFinite(from) || !Number.isFinite(to)) {
-    throw new BadRequestError(
-      '"from" and "to" must be valid numbers (epoch milliseconds)',
-    );
-  }
-
-  if (from > to) {
-    throw new BadRequestError('"from" must be less than or equal to "to"');
-  }
-
-  return { from, to };
-}
-
 function parseUsageAggregationFilter(
   queryParams: Record<string, string>,
 ): UsageAggregationFilter {
@@ -127,14 +99,14 @@ function parseUsageAggregationFilter(
 
 function handleUsageTotals({ queryParams }: RouteHandlerArgs) {
   const qp = queryParams ?? {};
-  const range = parseTimeRange(qp);
+  const range = parseEpochMillisRange(qp);
   const filter = parseUsageAggregationFilter(qp);
   return getUsageTotals(range, filter);
 }
 
 function handleUsageDaily({ queryParams }: RouteHandlerArgs) {
   const qp = queryParams ?? {};
-  const range = parseTimeRange(qp);
+  const range = parseEpochMillisRange(qp);
   const granularity = qp.granularity ?? "daily";
   if (granularity !== "daily" && granularity !== "hourly") {
     throw new BadRequestError(
@@ -152,7 +124,7 @@ function handleUsageDaily({ queryParams }: RouteHandlerArgs) {
 
 function handleUsageBreakdown({ queryParams }: RouteHandlerArgs) {
   const qp = queryParams ?? {};
-  const range = parseTimeRange(qp);
+  const range = parseEpochMillisRange(qp);
 
   const groupBy = qp.groupBy;
   if (!groupBy) {
@@ -177,7 +149,7 @@ function handleUsageBreakdown({ queryParams }: RouteHandlerArgs) {
 
 function handleUsageSeries({ queryParams }: RouteHandlerArgs) {
   const qp = queryParams ?? {};
-  const range = parseTimeRange(qp);
+  const range = parseEpochMillisRange(qp);
   const granularity = qp.granularity ?? "daily";
   if (granularity !== "daily" && granularity !== "hourly") {
     throw new BadRequestError(

--- a/assistant/src/schedule/schedule-usage-store.ts
+++ b/assistant/src/schedule/schedule-usage-store.ts
@@ -1,4 +1,5 @@
 import { rawAll } from "../memory/raw-query.js";
+import { buildScheduleAttributionSubquery } from "../memory/schedule-attribution-sql.js";
 
 export interface ScheduleUsageSummary {
   scheduleId: string;
@@ -22,6 +23,11 @@ export function getScheduleUsageSummaries({
   to: number;
 }): ScheduleUsageSummary[] {
   const now = Date.now();
+  const scheduleAttribution = buildScheduleAttributionSubquery({
+    eventAlias: "e",
+    now,
+    selectExpression: "schedule_attr_runs.job_id",
+  });
   const rows = rawAll<ScheduleUsageSummaryRow>(
     /*sql*/ `
     WITH run_counts AS (
@@ -29,26 +35,18 @@ export function getScheduleUsageSummaries({
         job_id AS schedule_id,
         COUNT(*) AS run_count
       FROM cron_runs
-      WHERE started_at >= ?1
-        AND started_at <= ?2
+      WHERE started_at >= ?
+        AND started_at <= ?
       GROUP BY job_id
     ),
     attributed_usage AS (
       SELECT
         e.estimated_cost_usd,
         COALESCE(e.llm_call_count, 1) AS event_count,
-        (
-          SELECT schedule_attr_runs.job_id
-          FROM cron_runs schedule_attr_runs
-          WHERE schedule_attr_runs.conversation_id = e.conversation_id
-            AND e.created_at >= schedule_attr_runs.started_at
-            AND e.created_at <= COALESCE(schedule_attr_runs.finished_at, ?3)
-          ORDER BY schedule_attr_runs.started_at DESC, schedule_attr_runs.id DESC
-          LIMIT 1
-        ) AS schedule_id
+        ${scheduleAttribution.sql} AS schedule_id
       FROM llm_usage_events e
-      WHERE e.created_at >= ?1
-        AND e.created_at <= ?2
+      WHERE e.created_at >= ?
+        AND e.created_at <= ?
     ),
     usage_totals AS (
       SELECT
@@ -71,7 +69,9 @@ export function getScheduleUsageSummaries({
     `,
     from,
     to,
-    now,
+    ...scheduleAttribution.params,
+    from,
+    to,
   );
 
   return rows.map((row) => ({


### PR DESCRIPTION
Remediates final self-review feedback for .private/plans/schedules-details-usage-consolidated.md: schedule summaries and usage aggregation now share schedule run-window attribution helpers, reducing semantic drift.