### PR TITLE
Refresh system run details and share usage windows

### DIFF
--- a/apps/web/src/domains/logs/usage-tab-state.ts
+++ b/apps/web/src/domains/logs/usage-tab-state.ts
@@ -1,8 +1,5 @@
-import {
-  timezoneDayStartEpoch,
-  toTimezoneDateString,
-} from "@/components/charts/format-date-label";
 import { LLM_USAGE_DIMENSION_LABELS } from "@/utils/llm-dimension";
+import { resolveUsageRangeWindow } from "@/utils/usage-window";
 import { UsageRequestError } from "./usage-api";
 import type {
   UsageGranularity,
@@ -199,14 +196,6 @@ function isHourlyDate(date: string) {
   return /^\d{4}-\d{2}-\d{2} ([01]\d|2[0-3]):00$/.test(date);
 }
 
-const RANGE_START_DAY_OFFSETS: Record<Exclude<UsageTimeRange, "all">, number> =
-  {
-    today: 0,
-    [DEFAULT_USAGE_RANGE]: 6,
-    "30d": 29,
-    "90d": 89,
-  };
-
 /**
  * Resolve the `{ from, to }` epoch-ms window for a usage range, with calendar
  * day boundaries computed in the effective `tz` so they stay aligned with the
@@ -221,20 +210,7 @@ export function resolveRangeWindow(
   from: number;
   to: number;
 } {
-  const to = typeof now === "number" ? now : now.getTime();
-  if (range === "all") {
-    return { from: 0, to };
-  }
-  const dayOffset = RANGE_START_DAY_OFFSETS[range];
-  // Today's calendar date in `tz`, then step back whole days on a UTC-noon
-  // anchor to avoid DST slips before resolving zone-local midnight.
-  const todayInTz = toTimezoneDateString(new Date(to), tz);
-  const [y, m, d] = todayInTz.split("-").map(Number);
-  const anchor = new Date(Date.UTC(y, m - 1, d, 12));
-  anchor.setUTCDate(anchor.getUTCDate() - dayOffset);
-  const fromDate = toTimezoneDateString(anchor, "UTC");
-  const from = timezoneDayStartEpoch(fromDate, tz);
-  return { from, to };
+  return resolveUsageRangeWindow(range, tz, now);
 }
 
 export function resolveUsageGranularity(

--- a/apps/web/src/domains/settings/api/schedules.test.ts
+++ b/apps/web/src/domains/settings/api/schedules.test.ts
@@ -4,6 +4,7 @@ import * as sdkGen from "@/generated/daemon/sdk.gen";
 
 import type {
   ConsolidationRunsGetResponse,
+  HeartbeatRunsGetResponse,
   SchedulesUsagesummaryGetResponse,
 } from "@/generated/daemon/types.gen";
 
@@ -14,6 +15,12 @@ interface UsageSummaryCall {
 }
 
 interface ConsolidationRunsCall {
+  path: { assistant_id: string };
+  query: { limit: number };
+  throwOnError: false;
+}
+
+interface HeartbeatRunsCall {
   path: { assistant_id: string };
   query: { limit: number };
   throwOnError: false;
@@ -46,8 +53,27 @@ const consolidationRows: ConsolidationRunsGetResponse["runs"] = [
   },
 ];
 
+const heartbeatRows: HeartbeatRunsGetResponse["runs"] = [
+  {
+    id: "heartbeat-run-1",
+    scheduledFor: 1_761_792_000_000,
+    startedAt: 1_761_792_001_000,
+    finishedAt: 1_761_792_004_000,
+    durationMs: 3000,
+    status: "ok",
+    skipReason: null,
+    error: null,
+    conversationId: "conv-heartbeat-1",
+    conversationExists: true,
+    conversationArchivedAt: null,
+    estimatedCostUsd: 0.0567,
+    createdAt: 1_761_792_000_000,
+  },
+];
+
 let usageSummaryCalls: UsageSummaryCall[] = [];
 let consolidationRunsCalls: ConsolidationRunsCall[] = [];
+let heartbeatRunsCalls: HeartbeatRunsCall[] = [];
 let responseOk = true;
 let responseStatus = 200;
 
@@ -57,6 +83,14 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
     consolidationRunsCalls.push(opts);
     return Promise.resolve({
       data: responseOk ? { runs: consolidationRows } : undefined,
+      error: undefined,
+      response: { ok: responseOk, status: responseStatus },
+    });
+  },
+  heartbeatRunsGet: (opts: HeartbeatRunsCall) => {
+    heartbeatRunsCalls.push(opts);
+    return Promise.resolve({
+      data: responseOk ? { runs: heartbeatRows } : undefined,
       error: undefined,
       response: { ok: responseOk, status: responseStatus },
     });
@@ -71,15 +105,46 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
   },
 }));
 
-const { fetchConsolidationRuns, fetchScheduleUsageSummary } = await import(
-  "./schedules"
-);
+const { fetchConsolidationRuns, fetchHeartbeatRuns, fetchScheduleUsageSummary } =
+  await import("./schedules");
 
 afterEach(() => {
   usageSummaryCalls = [];
   consolidationRunsCalls = [];
+  heartbeatRunsCalls = [];
   responseOk = true;
   responseStatus = 200;
+});
+
+describe("fetchHeartbeatRuns", () => {
+  test("preserves conversation availability and cost metadata", async () => {
+    const result = await fetchHeartbeatRuns("assistant-1");
+
+    expect(heartbeatRunsCalls).toEqual([
+      {
+        path: { assistant_id: "assistant-1" },
+        query: { limit: 10 },
+        throwOnError: false,
+      },
+    ]);
+    expect(result).toEqual([
+      {
+        id: "heartbeat-run-1",
+        jobId: "heartbeat",
+        status: "ok",
+        startedAt: 1_761_792_001_000,
+        finishedAt: 1_761_792_004_000,
+        durationMs: 3000,
+        output: null,
+        error: null,
+        conversationId: "conv-heartbeat-1",
+        conversationExists: true,
+        conversationArchivedAt: null,
+        estimatedCostUsd: 0.0567,
+        createdAt: 1_761_792_000_000,
+      },
+    ]);
+  });
 });
 
 describe("fetchConsolidationRuns", () => {

--- a/apps/web/src/domains/settings/api/schedules.ts
+++ b/apps/web/src/domains/settings/api/schedules.ts
@@ -206,7 +206,6 @@ export async function fetchHeartbeatRuns(
     );
   }
   return (data?.runs ?? []).map((run) => ({
-    ...run,
     id: run.id,
     jobId: "heartbeat",
     status: run.status,
@@ -216,6 +215,9 @@ export async function fetchHeartbeatRuns(
     output: run.skipReason ? `Skipped: ${run.skipReason}` : null,
     error: run.error,
     conversationId: run.conversationId,
+    conversationExists: run.conversationExists,
+    conversationArchivedAt: run.conversationArchivedAt,
+    estimatedCostUsd: run.estimatedCostUsd,
     createdAt: run.createdAt,
   }));
 }

--- a/apps/web/src/domains/settings/pages/schedules-page.tsx
+++ b/apps/web/src/domains/settings/pages/schedules-page.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   ArrowLeft,
   BarChart3,
@@ -1158,6 +1158,7 @@ function SystemTasksSection({
 
 export function SchedulesPage() {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { scheduleId } = useParams<{ scheduleId?: string }>();
   const tz = useEffectiveTimezone();
   const {
@@ -1292,12 +1293,23 @@ export function SchedulesPage() {
     void refetchConsolidation();
   }, [refetchHeartbeat, refetchConsolidation]);
 
+  const refreshSystemTaskRuns = useCallback(
+    (kind: SystemTaskKind) => {
+      if (!assistantId) return;
+      void queryClient.invalidateQueries({
+        queryKey: ["system-task-runs", assistantId, kind],
+      });
+    },
+    [assistantId, queryClient],
+  );
+
   const handleRunHeartbeatNow = useCallback(async () => {
     if (!assistantId) return;
     setIsHeartbeatRunning(true);
     try {
       const result = await runHeartbeatNow(assistantId);
       void refetchHeartbeat();
+      refreshSystemTaskRuns("heartbeat");
       if (result.ran) {
         toast.success("Heartbeat started.");
       } else {
@@ -1309,7 +1321,7 @@ export function SchedulesPage() {
     } finally {
       setIsHeartbeatRunning(false);
     }
-  }, [assistantId, refetchHeartbeat]);
+  }, [assistantId, refetchHeartbeat, refreshSystemTaskRuns]);
 
   const handleRunConsolidationNow = useCallback(async () => {
     if (!assistantId) return;
@@ -1317,6 +1329,7 @@ export function SchedulesPage() {
     try {
       const result = await runConsolidationNow(assistantId);
       void refetchConsolidation();
+      refreshSystemTaskRuns("consolidation");
       if (result.ran) {
         toast.success("Consolidation queued.");
       } else {
@@ -1328,7 +1341,7 @@ export function SchedulesPage() {
     } finally {
       setIsConsolidationRunning(false);
     }
-  }, [assistantId, refetchConsolidation]);
+  }, [assistantId, refetchConsolidation, refreshSystemTaskRuns]);
 
   const isLoading = isAssistantLoading || isSchedulesLoading;
   const isSelectedSystemTaskLoading =

--- a/apps/web/src/domains/settings/utils/schedule-usage-window.ts
+++ b/apps/web/src/domains/settings/utils/schedule-usage-window.ts
@@ -1,8 +1,5 @@
-import {
-  timezoneDayStartEpoch,
-  toTimezoneDateString,
-} from "@/components/charts/format-date-label";
 import { getEffectiveTimezone } from "@/utils/effective-timezone";
+import { resolveUsageRangeWindow } from "@/utils/usage-window";
 
 export interface ScheduleUsageWindow {
   from: number;
@@ -13,15 +10,5 @@ export function resolveScheduleUsageWindow(
   tz: string = getEffectiveTimezone(),
   now: Date | number = Date.now(),
 ): ScheduleUsageWindow {
-  const to = typeof now === "number" ? now : now.getTime();
-  const todayInTz = toTimezoneDateString(new Date(to), tz);
-  const [year, month, day] = todayInTz.split("-").map(Number);
-  const anchor = new Date(Date.UTC(year, month - 1, day, 12));
-  anchor.setUTCDate(anchor.getUTCDate() - 6);
-  const fromDate = toTimezoneDateString(anchor, "UTC");
-
-  return {
-    from: timezoneDayStartEpoch(fromDate, tz),
-    to,
-  };
+  return resolveUsageRangeWindow("7d", tz, now);
 }

--- a/apps/web/src/utils/usage-window.ts
+++ b/apps/web/src/utils/usage-window.ts
@@ -1,0 +1,48 @@
+import {
+  timezoneDayStartEpoch,
+  toTimezoneDateString,
+} from "@/components/charts/format-date-label";
+
+export type UsageRangeWindowId = "today" | "7d" | "30d" | "90d" | "all";
+
+const RANGE_START_DAY_OFFSETS: Record<
+  Exclude<UsageRangeWindowId, "all">,
+  number
+> = {
+  today: 0,
+  "7d": 6,
+  "30d": 29,
+  "90d": 89,
+};
+
+/**
+ * Resolve the `{ from, to }` epoch-ms window for a usage range, with calendar
+ * day boundaries computed in the effective `tz` so they stay aligned with the
+ * backend's zone-aware usage buckets.
+ */
+export function resolveUsageRangeWindow(
+  range: UsageRangeWindowId,
+  tz: string,
+  now: Date | number = Date.now(),
+): {
+  from: number;
+  to: number;
+} {
+  const to = typeof now === "number" ? now : now.getTime();
+  if (range === "all") {
+    return { from: 0, to };
+  }
+
+  const dayOffset = RANGE_START_DAY_OFFSETS[range];
+  // Today's calendar date in `tz`, then step back whole days on a UTC-noon
+  // anchor to avoid DST slips before resolving zone-local midnight.
+  const todayInTz = toTimezoneDateString(new Date(to), tz);
+  const [year, month, day] = todayInTz.split("-").map(Number);
+  const anchor = new Date(Date.UTC(year, month - 1, day, 12));
+  anchor.setUTCDate(anchor.getUTCDate() - dayOffset);
+  const fromDate = toTimezoneDateString(anchor, "UTC");
+  return {
+    from: timezoneDayStartEpoch(fromDate, tz),
+    to,
+  };
+}


### PR DESCRIPTION
Remediates final self-review feedback for .private/plans/schedules-details-usage-consolidated.md: heartbeat run metadata is preserved, system run-now refreshes recent runs, and schedule row 7-day windows share the usage-page range resolver.

Verification:
- export PATH="/Users/aaronlevin/.bun/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/Users/aaronlevin/.codex/tmp/arg0/codex-arg0rZtahD:/Users/aaronlevin/.bun/bin:/Users/aaronlevin/google-cloud-sdk/bin:/Users/aaronlevin/.composio:/Users/aaronlevin/.antigravity/antigravity/bin:/Users/aaronlevin/.codeium/windsurf/bin:/Users/aaronlevin/.local/bin:/Users/aaronlevin/.local/share/uv/python/bin:/Users/aaronlevin/Library/pnpm:/Users/aaronlevin/.cargo/bin:/Applications/Visual Studio Code.app/Contents/Resources/app/bin:/Library/Frameworks/Python.framework/Versions/3.12/bin:/Applications/Codex.app/Contents/Resources:/Applications/Visual Studio Code.app/Contents/Resources/app/bin:/Library/Frameworks/Python.framework/Versions/3.12/bin" && cd apps/web && bun run openapi-ts && bun test src/domains/settings/api/schedules.test.ts src/domains/settings/pages/schedules-page.test.ts src/domains/settings/utils/schedule-usage-window.test.ts src/domains/logs/usage-tab-state.test.ts && bunx tsc --noEmit