### PR TITLE
Keep schedule usage stats fresh

### DIFF
--- a/apps/web/src/components/charts/date-range-select.tsx
+++ b/apps/web/src/components/charts/date-range-select.tsx
@@ -5,8 +5,8 @@ import {
   type DropdownOption,
 } from "@vellum/design-library/components/dropdown";
 
-import { toTimezoneDateString } from "@/components/charts/format-date-label";
 import { getEffectiveTimezone } from "@/utils/effective-timezone";
+import { resolveLastTimezoneCalendarDays } from "@/utils/usage-window";
 import { useEffectiveTimezone } from "@/utils/use-effective-timezone";
 
 export interface DateRange {
@@ -52,12 +52,8 @@ export function computeRangeInTimezone(
   days: number,
   tz: string = getEffectiveTimezone(),
 ): DateRange {
-  const to = toTimezoneDateString(new Date(), tz);
-  const [y, m, d] = to.split("-").map(Number);
-  const anchor = new Date(Date.UTC(y, m - 1, d, 12));
-  anchor.setUTCDate(anchor.getUTCDate() - (days - 1));
-  const from = toTimezoneDateString(anchor, "UTC");
-  return { from, to };
+  const { fromDate, toDate } = resolveLastTimezoneCalendarDays(days, tz);
+  return { from: fromDate, to: toDate };
 }
 
 function daysBetween(from: string, to: string): number {

--- a/apps/web/src/domains/settings/pages/schedules-page.test.ts
+++ b/apps/web/src/domains/settings/pages/schedules-page.test.ts
@@ -199,6 +199,16 @@ describe("scheduleUsageSummaryQueryOptions", () => {
       ],
     ]);
   });
+
+  test("can be disabled when schedule row stats are not visible", () => {
+    const options = scheduleUsageSummaryQueryOptions(
+      "assistant-1",
+      "UTC",
+      false,
+    );
+
+    expect(options.enabled).toBe(false);
+  });
 });
 
 describe("SystemTaskDetailView", () => {

--- a/apps/web/src/domains/settings/pages/schedules-page.tsx
+++ b/apps/web/src/domains/settings/pages/schedules-page.tsx
@@ -40,6 +40,7 @@ import {
 import { captureError } from "@/lib/sentry/capture-error";
 import {
   assistantScheduleRunsQueryKey,
+  assistantScheduleUsageSummaryQueryKey,
   assistantSchedulesQueryKey,
 } from "@/lib/sync/query-tags";
 import { routes } from "@/utils/routes";
@@ -693,9 +694,10 @@ export type ScheduleRowUsage =
 export function scheduleUsageSummaryQueryOptions(
   assistantId: string | undefined,
   tz: string,
+  enabled = true,
 ) {
   return {
-    queryKey: ["schedule-usage-summary", assistantId, tz],
+    queryKey: assistantScheduleUsageSummaryQueryKey(assistantId, tz),
     queryFn: () => {
       if (!assistantId) {
         return Promise.resolve<ScheduleUsageSummary[]>([]);
@@ -705,7 +707,7 @@ export function scheduleUsageSummaryQueryOptions(
         resolveScheduleUsageWindow(tz),
       );
     },
-    enabled: !!assistantId,
+    enabled: !!assistantId && enabled,
     staleTime: 10_000,
   };
 }
@@ -1185,7 +1187,9 @@ export function SchedulesPage() {
     data: usageSummaries,
     isLoading: isUsageSummaryLoading,
     isError: isUsageSummaryError,
-  } = useQuery(scheduleUsageSummaryQueryOptions(assistantId, tz));
+  } = useQuery(
+    scheduleUsageSummaryQueryOptions(assistantId, tz, scheduleId == null),
+  );
 
   const {
     data: heartbeatConfig,
@@ -1294,11 +1298,18 @@ export function SchedulesPage() {
   }, [refetchHeartbeat, refetchConsolidation]);
 
   const refreshSystemTaskRuns = useCallback(
-    (kind: SystemTaskKind) => {
+    (kind: SystemTaskKind, delayed = false) => {
       if (!assistantId) return;
-      void queryClient.invalidateQueries({
-        queryKey: ["system-task-runs", assistantId, kind],
-      });
+      const invalidate = () => {
+        void queryClient.invalidateQueries({
+          queryKey: ["system-task-runs", assistantId, kind],
+        });
+      };
+      invalidate();
+      if (delayed) {
+        setTimeout(invalidate, 1_000);
+        setTimeout(invalidate, 5_000);
+      }
     },
     [assistantId, queryClient],
   );
@@ -1329,7 +1340,7 @@ export function SchedulesPage() {
     try {
       const result = await runConsolidationNow(assistantId);
       void refetchConsolidation();
-      refreshSystemTaskRuns("consolidation");
+      refreshSystemTaskRuns("consolidation", result.ran);
       if (result.ran) {
         toast.success("Consolidation queued.");
       } else {

--- a/apps/web/src/hooks/use-assistant-resource-sync.test.tsx
+++ b/apps/web/src/hooks/use-assistant-resource-sync.test.tsx
@@ -15,6 +15,7 @@ import {
   assistantDaemonConfigQueryKey,
   assistantIdentityQueryKey,
   assistantIdentityIntroQueryKey,
+  assistantScheduleUsageSummaryQueryKey,
   assistantSchedulesQueryKey,
   assistantSoundsConfigQueryKey,
   avatarQueryKey,
@@ -167,6 +168,7 @@ describe("useAssistantResourceSync", () => {
           assistantDaemonConfigQueryKey("asst-1"),
           assistantSoundsConfigQueryKey("asst-1"),
           assistantSchedulesQueryKey("asst-1"),
+          assistantScheduleUsageSummaryQueryKey("asst-1"),
         ]) as never
       );
     });

--- a/apps/web/src/hooks/use-assistant-resource-sync.ts
+++ b/apps/web/src/hooks/use-assistant-resource-sync.ts
@@ -27,6 +27,7 @@ import {
   assistantIdentityQueryKey,
   assistantIdentityIntroQueryKey,
   assistantScheduleRunsQueryKey,
+  assistantScheduleUsageSummaryQueryKey,
   assistantSchedulesQueryKey,
   assistantSoundsAvailableQueryKey,
   assistantSoundsConfigQueryKey,
@@ -94,6 +95,9 @@ export function useAssistantResourceSync(
               });
               void queryClient.invalidateQueries({
                 queryKey: assistantScheduleRunsQueryKey(assistantId),
+              });
+              void queryClient.invalidateQueries({
+                queryKey: assistantScheduleUsageSummaryQueryKey(assistantId),
               });
               break;
             case SYNC_TAGS.appsList:

--- a/apps/web/src/lib/sync/query-tags.ts
+++ b/apps/web/src/lib/sync/query-tags.ts
@@ -93,6 +93,15 @@ export function assistantScheduleRunsQueryKey(
     : (["schedule-runs", assistantId] as const);
 }
 
+export function assistantScheduleUsageSummaryQueryKey(
+  assistantId: string | null | undefined,
+  tz?: string | null,
+) {
+  return tz
+    ? (["schedule-usage-summary", assistantId, tz] as const)
+    : (["schedule-usage-summary", assistantId] as const);
+}
+
 export const CLIENT_FLAG_QUERY_KEY = ["client-feature-flag-values"] as const;
 
 export const ASSISTANT_FLAG_VALUES_QUERY_KEY =
@@ -150,5 +159,8 @@ export function invalidateAssistantSchedulesQueries(
   });
   void queryClient.invalidateQueries({
     queryKey: assistantScheduleRunsQueryKey(assistantId),
+  });
+  void queryClient.invalidateQueries({
+    queryKey: assistantScheduleUsageSummaryQueryKey(assistantId),
   });
 }

--- a/apps/web/src/utils/usage-window.ts
+++ b/apps/web/src/utils/usage-window.ts
@@ -34,15 +34,32 @@ export function resolveUsageRangeWindow(
   }
 
   const dayOffset = RANGE_START_DAY_OFFSETS[range];
-  // Today's calendar date in `tz`, then step back whole days on a UTC-noon
-  // anchor to avoid DST slips before resolving zone-local midnight.
-  const todayInTz = toTimezoneDateString(new Date(to), tz);
-  const [year, month, day] = todayInTz.split("-").map(Number);
-  const anchor = new Date(Date.UTC(year, month - 1, day, 12));
-  anchor.setUTCDate(anchor.getUTCDate() - dayOffset);
-  const fromDate = toTimezoneDateString(anchor, "UTC");
+  const { fromDate } = resolveLastTimezoneCalendarDays(
+    dayOffset + 1,
+    tz,
+    to,
+  );
   return {
     from: timezoneDayStartEpoch(fromDate, tz),
     to,
   };
+}
+
+export function resolveLastTimezoneCalendarDays(
+  days: number,
+  tz: string,
+  now: Date | number = Date.now(),
+): {
+  fromDate: string;
+  toDate: string;
+} {
+  const to = typeof now === "number" ? now : now.getTime();
+  // Today's calendar date in `tz`, then step back whole days on a UTC-noon
+  // anchor to avoid DST slips before resolving zone-local midnight.
+  const toDate = toTimezoneDateString(new Date(to), tz);
+  const [year, month, day] = toDate.split("-").map(Number);
+  const anchor = new Date(Date.UTC(year, month - 1, day, 12));
+  anchor.setUTCDate(anchor.getUTCDate() - (days - 1));
+  const fromDate = toTimezoneDateString(anchor, "UTC");
+  return { fromDate, toDate };
 }


### PR DESCRIPTION
Remediates final self-review feedback for .private/plans/schedules-details-usage-consolidated.md: schedule sync now invalidates row usage summaries, detail pages avoid unused summary fetches, queued consolidation run-now refreshes run history after the run can appear, and chart/date usage windows share one timezone calendar-day helper.

Verification:
- export PATH="/Users/aaronlevin/.bun/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/Users/aaronlevin/.codex/tmp/arg0/codex-arg0rZtahD:/Users/aaronlevin/.bun/bin:/Users/aaronlevin/google-cloud-sdk/bin:/Users/aaronlevin/.composio:/Users/aaronlevin/.antigravity/antigravity/bin:/Users/aaronlevin/.codeium/windsurf/bin:/Users/aaronlevin/.local/bin:/Users/aaronlevin/.local/share/uv/python/bin:/Users/aaronlevin/Library/pnpm:/Users/aaronlevin/.cargo/bin:/Applications/Visual Studio Code.app/Contents/Resources/app/bin:/Library/Frameworks/Python.framework/Versions/3.12/bin:/Applications/Codex.app/Contents/Resources:/Applications/Visual Studio Code.app/Contents/Resources/app/bin:/Library/Frameworks/Python.framework/Versions/3.12/bin" && cd apps/web && bun run openapi-ts && bun test src/domains/settings/api/schedules.test.ts src/domains/settings/pages/schedules-page.test.ts src/domains/settings/utils/schedule-usage-window.test.ts src/domains/logs/usage-tab-state.test.ts src/hooks/use-assistant-resource-sync.test.tsx src/domains/settings/components/billing-usage/use-billing-usage-data.test.ts && bunx tsc --noEmit
- export PATH="/Users/aaronlevin/.bun/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/Users/aaronlevin/.codex/tmp/arg0/codex-arg0rZtahD:/Users/aaronlevin/.bun/bin:/Users/aaronlevin/google-cloud-sdk/bin:/Users/aaronlevin/.composio:/Users/aaronlevin/.antigravity/antigravity/bin:/Users/aaronlevin/.codeium/windsurf/bin:/Users/aaronlevin/.local/bin:/Users/aaronlevin/.local/share/uv/python/bin:/Users/aaronlevin/Library/pnpm:/Users/aaronlevin/.cargo/bin:/Applications/Visual Studio Code.app/Contents/Resources/app/bin:/Library/Frameworks/Python.framework/Versions/3.12/bin:/Applications/Codex.app/Contents/Resources:/Applications/Visual Studio Code.app/Contents/Resources/app/bin:/Library/Frameworks/Python.framework/Versions/3.12/bin" && cd apps/web && bunx eslint src/components/charts/date-range-select.tsx src/domains/logs/usage-tab-state.ts src/domains/settings/api/schedules.test.ts src/domains/settings/api/schedules.ts src/domains/settings/pages/schedules-page.tsx src/domains/settings/pages/schedules-page.test.ts src/domains/settings/utils/schedule-usage-window.ts src/hooks/use-assistant-resource-sync.ts src/hooks/use-assistant-resource-sync.test.tsx src/lib/sync/query-tags.ts src/utils/usage-window.ts