### PR TITLE
feat(flags): update experiment-activation-flow registry entry to assistant scope

### DIFF
--- a/apps/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/apps/web/src/lib/feature-flags/feature-flag-registry.json
@@ -35,10 +35,10 @@
     },
     {
       "id": "experiment-activation-flow-2026-06-03",
-      "scope": "client",
+      "scope": "assistant",
       "key": "experiment-activation-flow-2026-06-03",
       "label": "Activation Flow Experiment 2026-06-03",
-      "description": "Route allowlisted users to the activation-rail bootstrap template after pre-chat. Off by default and targeted through LaunchDarkly.",
+      "description": "String-variation experiment (control / treatment) that routes users into the model-driven activation rail. The daemon treats variation='treatment' as on; anything else (including default 'control') is off. Assignment is vid-keyed by the web app and flows to the daemon via the onboarding cohort channel — do not evaluate this flag independently in the daemon.",
       "defaultEnabled": false
     },
     {

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -35,10 +35,10 @@
     },
     {
       "id": "experiment-activation-flow-2026-06-03",
-      "scope": "client",
+      "scope": "assistant",
       "key": "experiment-activation-flow-2026-06-03",
       "label": "Activation Flow Experiment 2026-06-03",
-      "description": "Route allowlisted users to the activation-rail bootstrap template after pre-chat. Off by default and targeted through LaunchDarkly.",
+      "description": "String-variation experiment (control / treatment) that routes users into the model-driven activation rail. The daemon treats variation='treatment' as on; anything else (including default 'control') is off. Assignment is vid-keyed by the web app and flows to the daemon via the onboarding cohort channel — do not evaluate this flag independently in the daemon.",
       "defaultEnabled": false
     },
     {


### PR DESCRIPTION
## Summary

- Changes `experiment-activation-flow-2026-06-03` registry entry from `scope: "client"` to `scope: "assistant"` so `isAssistantFeatureFlagEnabled` resolves it in the daemon
- Updates the description to document the string-variation contract: daemon treats variation `"treatment"` as on, anything else (including default `"control"`) as off
- Regenerates synced copies via `bun meta/feature-flags/sync-bundled-copies.ts` (`assistant/src/config/` and `gateway/src/` are gitignored; `apps/web/src/lib/feature-flags/` is tracked)

## Note on the flag type

The flag is now a **string experiment** (not boolean) in the companion platform Terraform PR (vellum-ai/vellum-assistant-platform#8166). The daemon does **not** independently evaluate the LD flag at chat time — the web-assigned variation flows in through the onboarding cohort channel (PR 5 in the platform plan). This registry change ensures the daemon's resolver correctly handles the key for any direct override path.

## Human actions required

See companion platform PR vellum-ai/vellum-assistant-platform#8166 for required Terraform apply and LD targeting steps.

## Dependency

None (Wave 1). Pairs with vellum-ai/vellum-assistant-platform#8166.

Part of the activation-experiment retention rail (JARVIS-1102).