### PR TITLE
fix(web): pin onboarding creature footer to physical bottom (iOS safe-area gap)

### DIFF
--- a/apps/web/src/domains/onboarding/components/creature-footer.test.tsx
+++ b/apps/web/src/domains/onboarding/components/creature-footer.test.tsx
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, render } from "@testing-library/react";
+
+import { CreatureFooter } from "./creature-footer";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("CreatureFooter", () => {
+  test("renders the decorative image", () => {
+    const { container } = render(<CreatureFooter />);
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute("alt")).toBe("");
+    expect(img?.getAttribute("src")).toMatch(/login-background-characters\.svg$/);
+  });
+
+  test("pins the container to the physical bottom with `fixed` (not `absolute`)", () => {
+    const { container } = render(<CreatureFooter />);
+    const footer = container.querySelector("div");
+    expect(footer?.className).toContain("fixed");
+    expect(footer?.className).toContain("bottom-0");
+    expect(footer?.className).not.toContain("absolute");
+  });
+
+  test("forwards a passed className", () => {
+    const { container } = render(<CreatureFooter className="test-extra" />);
+    const footer = container.querySelector("div");
+    expect(footer?.className).toContain("test-extra");
+  });
+
+  test("is decorative and non-interactive", () => {
+    const { container } = render(<CreatureFooter />);
+    const footer = container.querySelector("div");
+    expect(footer?.getAttribute("aria-hidden")).toBe("true");
+    expect(footer?.className).toContain("pointer-events-none");
+  });
+});

--- a/apps/web/src/domains/onboarding/components/creature-footer.tsx
+++ b/apps/web/src/domains/onboarding/components/creature-footer.tsx
@@ -1,15 +1,25 @@
 import { publicAsset } from "@/utils/public-asset";
 
 /**
- * Decorative SVG footer pinned to the bottom of every onboarding screen.
- * Uses a plain `<img>` (Vite serves static assets from the public directory
- * or the backend CDN at runtime — no Next.js Image component needed).
+ * Decorative SVG footer for onboarding screens.
+ *
+ * Positioned `fixed` (not `absolute`) so it anchors to the layout viewport
+ * bottom and bleeds past `RootLayout`'s `app-shell` bottom safe-area padding
+ * + `overflow-hidden` inner wrapper (src/root-layout.tsx). With `absolute`
+ * the art floated `env(safe-area-inset-bottom)` (~34px) above the physical
+ * edge on iOS, exposing the surface background beneath the creatures. `fixed`
+ * escapes the clip and reaches the physical screen bottom; on desktop the
+ * inset is 0 so rendering is unchanged. No transformed ancestor exists, so
+ * `fixed` resolves against the viewport. `viewport-fit=cover` (index.html)
+ * makes the layout viewport span the full physical screen.
+ *
+ * Uses a plain `<img>` (Vite serves static assets — no Next.js Image needed).
  */
 export function CreatureFooter({ className = "" }: { className?: string }) {
   return (
     <div
       aria-hidden="true"
-      className={`pointer-events-none absolute bottom-0 left-0 right-0 flex justify-center overflow-hidden ${className}`}
+      className={`pointer-events-none fixed bottom-0 left-0 right-0 flex justify-center overflow-hidden ${className}`}
     >
       <img
         src={publicAsset("/login-background-characters.svg")}


### PR DESCRIPTION
## Summary
- Switch CreatureFooter from `absolute` to `fixed` so the onboarding welcome creatures reach the physical screen bottom on iOS instead of floating ~34px above it (above RootLayout's safe-area padding + overflow-hidden clip).
- Add creature-footer.test.tsx regression guard pinning the `fixed`/`bottom-0`/no-`absolute` invariant.

Part of plan: onboarding-footer-align.md (PR 1 of 1)