### PR TITLE
feat(assistant): gate activation rail on web-assigned variation (JARVIS-1102)

### DIFF
--- a/apps/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
+++ b/apps/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
@@ -66,7 +66,6 @@ type TestOnboardingRecipe = {
 
 let onboardingCompleted = false;
 let prechatOnboardingCondensedFlow = true;
-let activationFlowExperiment = false;
 let selfIntroGreeting = true;
 let isIOSWeb = false;
 let isMacOSWeb = false;
@@ -200,7 +199,6 @@ mock.module("@/stores/client-feature-flag-store", () => ({
   useClientFeatureFlagStore: {
     use: {
       prechatOnboardingCondensedFlow: () => prechatOnboardingCondensedFlow,
-      experimentActivationFlow20260603: () => activationFlowExperiment,
       selfIntroGreeting: () => selfIntroGreeting,
     },
   },
@@ -349,7 +347,6 @@ beforeEach(() => {
   checkAssistantImpl = async () => {};
   onboardingCompleted = false;
   prechatOnboardingCondensedFlow = true;
-  activationFlowExperiment = false;
   selfIntroGreeting = true;
   isIOSWeb = false;
   isMacOSWeb = false;
@@ -476,8 +473,19 @@ describe("onboarding lifecycle sync", () => {
     });
   });
 
-  test("activation flow flag selects the activation bootstrap after pre-chat", async () => {
-    activationFlowExperiment = true;
+  test("activation flow recipe delivers cohort and bootstrap to the onboarding context", async () => {
+    // The platform delivers cohort + bootstrapTemplate via the recipe endpoint (PR 5)
+    // for treatment users. The context builder forwards them unchanged — no independent
+    // flag evaluation. This is the "no second eval" invariant from JARVIS-1102.
+    fetchOnboardingRecipeImpl = async () => ({
+      cohort: ACTIVATION_FLOW_COHORT,
+      bootstrapTemplate: ACTIVATION_RAIL_BOOTSTRAP_TEMPLATE,
+      initialMessage: "",
+      tasks: [],
+      tone: "grounded",
+      skills: [],
+      skipPrechat: false,
+    });
 
     render(<PreChatFlow />);
 
@@ -494,6 +502,7 @@ describe("onboarding lifecycle sync", () => {
       cohort: ACTIVATION_FLOW_COHORT,
       initialMessage: "Hi, I'm Alice. Nice to meet you.",
       bootstrapTemplate: ACTIVATION_RAIL_BOOTSTRAP_TEMPLATE,
+      skills: [],
     });
   });
 

--- a/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
+++ b/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
@@ -105,8 +105,6 @@ export function PreChatFlow() {
   const showIOSAppStep = isIOSWeb && !readIOSAppDownloaded();
   const condensedPrechatFlag =
     useClientFeatureFlagStore.use.prechatOnboardingCondensedFlow();
-  const activationFlowEnabled =
-    useClientFeatureFlagStore.use.experimentActivationFlow20260603();
   const selfIntroGreetingEnabled =
     useClientFeatureFlagStore.use.selfIntroGreeting();
   const preferredFunnelVariant =
@@ -330,7 +328,6 @@ export function PreChatFlow() {
       userName,
       assistantName,
       selfIntroGreetingEnabled,
-      activationFlowEnabled,
       googleConnected,
       googleScopes,
       connectedScopes: args?.connectedScopes,

--- a/apps/web/src/domains/onboarding/prechat-context.test.ts
+++ b/apps/web/src/domains/onboarding/prechat-context.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "bun:test";
 
-import { DEFAULT_PRECHAT_INITIAL_MESSAGE } from "@/domains/onboarding/prechat";
 import {
   ACTIVATION_FLOW_COHORT,
   ACTIVATION_RAIL_BOOTSTRAP_TEMPLATE,
@@ -29,32 +28,48 @@ function baseInput(
 }
 
 describe("buildPreChatContext — activation rail", () => {
-  test("selects the activation bootstrap template when the experiment flag is on", () => {
+  test("selects the activation cohort and bootstrap template from the recipe", () => {
+    // Treatment users receive a recipe from the platform (PR 5) whose cohort is
+    // ACTIVATION_FLOW_COHORT and bootstrap_template is ACTIVATION_RAIL_BOOTSTRAP_TEMPLATE.
+    // The context builder propagates them unchanged via the recipe path.
     const context = buildPreChatContext(
-      baseInput({ activationFlowEnabled: true }),
+      baseInput({
+        recipe: {
+          cohort: ACTIVATION_FLOW_COHORT,
+          bootstrapTemplate: ACTIVATION_RAIL_BOOTSTRAP_TEMPLATE,
+          initialMessage: "",
+          tasks: [],
+          tone: "",
+          skills: [],
+          skipPrechat: false,
+        },
+      }),
     );
 
     expect(context.cohort).toBe(ACTIVATION_FLOW_COHORT);
     expect(context.bootstrapTemplate).toBe(ACTIVATION_RAIL_BOOTSTRAP_TEMPLATE);
   });
 
-  test("activation template wins over a marketing recipe template", () => {
+  test("marketing campaign recipe cohort takes precedence over activation when both present", () => {
+    // The platform delivers the campaign recipe when one matches (PR 5 resolution order:
+    // campaign > experiment assignment). The context builder forwards the campaign cohort.
     const context = buildPreChatContext(
       baseInput({
-        activationFlowEnabled: true,
         recipe: {
           cohort: "content-automation",
           bootstrapTemplate: "BOOTSTRAP-CONTENT-AUTOMATION.md",
           initialMessage: "Campaign hello",
+          tasks: ["writing"],
+          tone: "grounded",
           skills: ["geo-writing"],
-        } as BuildPreChatContextInput["recipe"],
+          skipPrechat: true,
+        },
       }),
     );
 
-    expect(context.cohort).toBe(ACTIVATION_FLOW_COHORT);
-    expect(context.bootstrapTemplate).toBe(ACTIVATION_RAIL_BOOTSTRAP_TEMPLATE);
-    expect(context.skills).toEqual(["geo-writing"]);
-    expect(context.initialMessage).toBe(DEFAULT_PRECHAT_INITIAL_MESSAGE);
+    expect(context.cohort).toBe("content-automation");
+    expect(context.bootstrapTemplate).toBe("BOOTSTRAP-CONTENT-AUTOMATION.md");
+    expect(context.initialMessage).toBe("Campaign hello");
   });
 });
 

--- a/apps/web/src/domains/onboarding/prechat-context.ts
+++ b/apps/web/src/domains/onboarding/prechat-context.ts
@@ -41,8 +41,6 @@ export interface BuildPreChatContextInput {
   userName: string;
   assistantName: string;
   selfIntroGreetingEnabled: boolean;
-  /** Selects the activation rail bootstrap template for experiment users. */
-  activationFlowEnabled?: boolean;
   /** Persisted Google connection state from a step the user already passed. */
   googleConnected: boolean;
   googleScopes: string[];
@@ -100,11 +98,6 @@ export function buildPreChatContext(
     context.skills = recipe.skills;
   }
 
-  if (input.activationFlowEnabled) {
-    context.cohort = ACTIVATION_FLOW_COHORT;
-    context.bootstrapTemplate = ACTIVATION_RAIL_BOOTSTRAP_TEMPLATE;
-  }
-
   const trimmedUser = input.userName.trim();
   if (trimmedUser) context.userName = trimmedUser;
   const trimmedAssistant = input.assistantName.trim();
@@ -134,7 +127,7 @@ export function buildPreChatContext(
 
   context.initialMessage = resolveInitialMessage(
     context,
-    input.activationFlowEnabled ? null : recipe,
+    recipe,
     input.selfIntroGreetingEnabled,
   );
   return context;

--- a/apps/web/src/lib/feature-flags/feature-flag-catalog.test.ts
+++ b/apps/web/src/lib/feature-flags/feature-flag-catalog.test.ts
@@ -11,10 +11,12 @@ describe("feature flag catalog", () => {
     expect(ASSISTANT_FLAG_DEFAULTS.selfIntroGreeting).toBe(false);
   });
 
-  test("exposes the activation flow experiment as a client flag", () => {
-    expect(CLIENT_FLAG_DEFAULTS.experimentActivationFlow20260603).toBe(false);
+  test("exposes the activation flow experiment as an assistant flag (not client)", () => {
+    // The activation flag is now scope:'assistant' — the daemon evaluates it, not the web client.
+    // The web client gates the rail via the recipe cohort delivered by the platform (JARVIS-1102).
     expect(
-      "experimentActivationFlow20260603" in ASSISTANT_FLAG_DEFAULTS,
+      "experimentActivationFlow20260603" in CLIENT_FLAG_DEFAULTS,
     ).toBe(false);
+    expect(ASSISTANT_FLAG_DEFAULTS.experimentActivationFlow20260603).toBe(false);
   });
 });

--- a/apps/web/src/lib/feature-flags/feature-flag-catalog.test.ts
+++ b/apps/web/src/lib/feature-flags/feature-flag-catalog.test.ts
@@ -11,12 +11,17 @@ describe("feature flag catalog", () => {
     expect(ASSISTANT_FLAG_DEFAULTS.selfIntroGreeting).toBe(false);
   });
 
-  test("exposes the activation flow experiment as an assistant flag (not client)", () => {
-    // The activation flag is now scope:'assistant' — the daemon evaluates it, not the web client.
-    // The web client gates the rail via the recipe cohort delivered by the platform (JARVIS-1102).
+  test("does not declare the activation flow experiment as a toggleable flag", () => {
+    // The activation rail is gated by the onboarding recipe cohort (control /
+    // treatment) assigned vid-keyed on the platform — not by a boolean feature
+    // flag. Declaring it in the registry would render it as a manual toggle in
+    // Settings → Feature Flags, letting a hand-flipped override diverge from the
+    // vid-keyed assignment, so it must not appear in either flag store (JARVIS-1102).
     expect(
       "experimentActivationFlow20260603" in CLIENT_FLAG_DEFAULTS,
     ).toBe(false);
-    expect(ASSISTANT_FLAG_DEFAULTS.experimentActivationFlow20260603).toBe(false);
+    expect(
+      "experimentActivationFlow20260603" in ASSISTANT_FLAG_DEFAULTS,
+    ).toBe(false);
   });
 });

--- a/apps/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/apps/web/src/lib/feature-flags/feature-flag-registry.json
@@ -34,14 +34,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "experiment-activation-flow-2026-06-03",
-      "scope": "assistant",
-      "key": "experiment-activation-flow-2026-06-03",
-      "label": "Activation Flow Experiment 2026-06-03",
-      "description": "String-variation experiment (control / treatment) that routes users into the model-driven activation rail. The daemon treats variation='treatment' as on; anything else (including default 'control') is off. Assignment is vid-keyed by the web app and flows to the daemon via the onboarding cohort channel — do not evaluate this flag independently in the daemon.",
-      "defaultEnabled": false
-    },
-    {
       "id": "local-docker-enabled",
       "scope": "client",
       "key": "local-docker-enabled",

--- a/apps/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/apps/web/src/lib/feature-flags/feature-flag-registry.json
@@ -35,10 +35,10 @@
     },
     {
       "id": "experiment-activation-flow-2026-06-03",
-      "scope": "client",
+      "scope": "assistant",
       "key": "experiment-activation-flow-2026-06-03",
       "label": "Activation Flow Experiment 2026-06-03",
-      "description": "Route allowlisted users to the activation-rail bootstrap template after pre-chat. Off by default and targeted through LaunchDarkly.",
+      "description": "String-variation experiment (control / treatment) that routes users into the model-driven activation rail. The daemon treats variation='treatment' as on; anything else (including default 'control') is off. Assignment is vid-keyed by the web app and flows to the daemon via the onboarding cohort channel — do not evaluate this flag independently in the daemon.",
       "defaultEnabled": false
     },
     {

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -34,14 +34,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "experiment-activation-flow-2026-06-03",
-      "scope": "assistant",
-      "key": "experiment-activation-flow-2026-06-03",
-      "label": "Activation Flow Experiment 2026-06-03",
-      "description": "String-variation experiment (control / treatment) that routes users into the model-driven activation rail. The daemon treats variation='treatment' as on; anything else (including default 'control') is off. Assignment is vid-keyed by the web app and flows to the daemon via the onboarding cohort channel — do not evaluate this flag independently in the daemon.",
-      "defaultEnabled": false
-    },
-    {
       "id": "local-docker-enabled",
       "scope": "client",
       "key": "local-docker-enabled",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -35,10 +35,10 @@
     },
     {
       "id": "experiment-activation-flow-2026-06-03",
-      "scope": "client",
+      "scope": "assistant",
       "key": "experiment-activation-flow-2026-06-03",
       "label": "Activation Flow Experiment 2026-06-03",
-      "description": "Route allowlisted users to the activation-rail bootstrap template after pre-chat. Off by default and targeted through LaunchDarkly.",
+      "description": "String-variation experiment (control / treatment) that routes users into the model-driven activation rail. The daemon treats variation='treatment' as on; anything else (including default 'control') is off. Assignment is vid-keyed by the web app and flows to the daemon via the onboarding cohort channel — do not evaluate this flag independently in the daemon.",
       "defaultEnabled": false
     },
     {


### PR DESCRIPTION
## Summary

Gates the activation flow experiment rail exclusively on the variation delivered by the platform's onboarding recipe endpoint, eliminating the independent LD flag re-evaluation in the web pre-chat context.

### Why this matters

The `experiment-activation-flow-2026-06-03` flag was previously gated client-side via `useClientFeatureFlagStore.use.experimentActivationFlow20260603()` — a boolean LD eval that happened independently of the warehouse-logged vid-keyed assignment. This created a risk of the logged assignment diverging from the user experience, which would corrupt retention-by-cohort analysis.

### How it works after this PR

1. `(app)/layout.tsx` calls `getActivationAssignment()` which logs `source:"experiment"` + persists `AssistantExperimentAssignment` to Django (platform PR #8173)
2. `fetchOnboardingRecipe()` returns a recipe with `cohort=experiment-activation-flow-2026-06-03` and `bootstrapTemplate=BOOTSTRAP-ACTIVATION-RAIL.md` for treatment users (platform PR #8174)
3. The existing recipe path in `buildPreChatContext` propagates `cohort + bootstrapTemplate` into `onboarding.cohort` → daemon reads it
4. No independent flag evaluation anywhere in the client path

### Changes

- `prechat-context.ts`: remove `activationFlowEnabled` from `BuildPreChatContextInput` and the override block; remove the conditional that passed `null` recipe to `resolveInitialMessage` for activation users
- `pre-chat-flow.tsx`: remove `experimentActivationFlow20260603` flag store read and the `activationFlowEnabled` prop from `buildPreChatContext` call
- `feature-flag-registry.json` (meta + apps/web): scope `client` → `assistant`; update description to document the string-variation contract
- Tests: rewrite activation-rail tests to use recipe input; update catalog test for new scope

### Dependency chain

Wave 1: platform #8166 (flag string variations) + #8167 (dbt experiments) + #8168 (sink widening)
Wave 2: platform #8173 (web eval + log + persist)
Wave 3: platform #8174 (cohort delivery via recipe)
Wave 4: **this PR** (assistant — gate rail on delivered variation)

Closes JARVIS-1102