### PR TITLE
feat(web): add standalone Earn Free Credits item to preferences menu

### DIFF
--- a/apps/web/src/domains/chat/components/preferences-menu.tsx
+++ b/apps/web/src/domains/chat/components/preferences-menu.tsx
@@ -3,6 +3,7 @@ import {
   ChartColumn,
   ChevronDown,
   ChevronUp,
+  Gift,
   LogOut,
   MessageSquareText,
   Settings as SettingsIcon,
@@ -186,6 +187,17 @@ function PreferencesMenuContent({
             }}
           />
         </div>
+      ) : null}
+
+      {showBillingRows ? (
+        <PanelItem
+          icon={Gift}
+          label="Earn Free Credits"
+          onSelect={() => {
+            onClose();
+            onEarnCredits();
+          }}
+        />
       ) : null}
 
       <PanelItem


### PR DESCRIPTION
## Summary
- Add a standalone "Earn Free Credits" PanelItem (Gift icon) to the preferences menu, gated by showBillingRows, positioned between the credits card and Settings.
- Wired to the existing onEarnCredits handler (opens EarnCreditsModal). In-card Earn button left in place for now (removed in PR 2).

Part of plan: slim-credits-section.md (PR 1 of 2)