### PR TITLE
refactor(web): slim credits card to pill, drop in-card earn button

### DIFF
--- a/apps/web/src/domains/chat/components/credits-card.test.tsx
+++ b/apps/web/src/domains/chat/components/credits-card.test.tsx
@@ -30,11 +30,11 @@ describe("CreditsCard", () => {
     expect(onAddCredits).toHaveBeenCalledTimes(1);
   });
 
-  test("hides the credits pill when balance is null and renders without errors", () => {
-    const { queryByText } = render(
+  test("renders nothing when balance is null", () => {
+    const { container } = render(
       <CreditsCard balance={null} onAddCredits={() => {}} />,
     );
 
-    expect(queryByText(/credits$/)).toBeNull();
+    expect(container.firstChild).toBeNull();
   });
 });

--- a/apps/web/src/domains/chat/components/credits-card.test.tsx
+++ b/apps/web/src/domains/chat/components/credits-card.test.tsx
@@ -17,14 +17,9 @@ afterEach(() => {
 describe("CreditsCard", () => {
   test("renders the balance, coins icon, and fires onAddCredits when Add is clicked", () => {
     const onAddCredits = mock(() => {});
-    const onEarnCredits = mock(() => {});
 
     const { getByText, getByRole, container } = render(
-      <CreditsCard
-        balance="60"
-        onAddCredits={onAddCredits}
-        onEarnCredits={onEarnCredits}
-      />,
+      <CreditsCard balance="60" onAddCredits={onAddCredits} />,
     );
 
     expect(getByText("60 credits")).toBeTruthy();
@@ -33,34 +28,13 @@ describe("CreditsCard", () => {
 
     fireEvent.click(getByRole("button", { name: /add/i }));
     expect(onAddCredits).toHaveBeenCalledTimes(1);
-    expect(onEarnCredits).not.toHaveBeenCalled();
   });
 
-  test("hides only the credits pill when balance is null but still renders Earn Credits", () => {
-    const { queryByText, getByText } = render(
-      <CreditsCard
-        balance={null}
-        onAddCredits={() => {}}
-        onEarnCredits={() => {}}
-      />,
+  test("hides the credits pill when balance is null and renders without errors", () => {
+    const { queryByText } = render(
+      <CreditsCard balance={null} onAddCredits={() => {}} />,
     );
 
     expect(queryByText(/credits$/)).toBeNull();
-    expect(getByText("Earn Credits")).toBeTruthy();
-  });
-
-  test("fires onEarnCredits when the Earn Credits row is clicked", () => {
-    const onEarnCredits = mock(() => {});
-
-    const { getByText } = render(
-      <CreditsCard
-        balance="60"
-        onAddCredits={() => {}}
-        onEarnCredits={onEarnCredits}
-      />,
-    );
-
-    fireEvent.click(getByText("Earn Credits"));
-    expect(onEarnCredits).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/domains/chat/components/credits-card.tsx
+++ b/apps/web/src/domains/chat/components/credits-card.tsx
@@ -1,26 +1,21 @@
 import { Button } from "@vellum/design-library";
-import { Coins, Gift, Plus } from "lucide-react";
+import { Coins, Plus } from "lucide-react";
 
 interface CreditsCardProps {
   /** Formatted whole-credits string, or null when unavailable. */
   balance: string | null;
   onAddCredits: () => void;
-  onEarnCredits: () => void;
 }
 
 /**
  * Presentational credits card matching the iOS preferences-drawer mock:
- * a bordered card containing a credits pill (coins icon + balance + a primary
- * "Add" button) and an "Earn Credits" row beneath. Purely presentational — no
- * data fetching; callers supply the formatted balance and handlers.
+ * a slim bordered card containing a single credits pill (coins icon + balance
+ * + a primary "Add" button). Purely presentational — no data fetching; callers
+ * supply the formatted balance and handler.
  */
-export function CreditsCard({
-  balance,
-  onAddCredits,
-  onEarnCredits,
-}: CreditsCardProps) {
+export function CreditsCard({ balance, onAddCredits }: CreditsCardProps) {
   return (
-    <div className="flex flex-col gap-2 max-md:gap-4 rounded-lg border border-[var(--surface-base)] bg-[var(--surface-overlay)] px-3 pt-3 pb-2 max-md:pb-4 w-full">
+    <div className="flex flex-col rounded-lg border border-[var(--surface-base)] bg-[var(--surface-overlay)] p-2 w-full">
       {balance !== null && (
         <div className="flex items-center justify-between gap-2 rounded-[10px] bg-[var(--surface-base)] py-2 pl-1.5 pr-2 w-full">
           <div className="flex items-center gap-2">
@@ -49,17 +44,6 @@ export function CreditsCard({
           </Button>
         </div>
       )}
-
-      <Button
-        variant="ghost"
-        fullWidth
-        tintColor="var(--content-secondary)"
-        onClick={onEarnCredits}
-        className="text-body-medium-lighter max-md:text-body-large-default"
-      >
-        <Gift className="h-3.5 w-3.5" aria-hidden />
-        Earn Credits
-      </Button>
     </div>
   );
 }

--- a/apps/web/src/domains/chat/components/credits-card.tsx
+++ b/apps/web/src/domains/chat/components/credits-card.tsx
@@ -12,38 +12,43 @@ interface CreditsCardProps {
  * a slim bordered card containing a single credits pill (coins icon + balance
  * + a primary "Add" button). Purely presentational — no data fetching; callers
  * supply the formatted balance and handler.
+ *
+ * Renders nothing when `balance` is null (unavailable / still loading) so the
+ * bordered card shell never shows up empty.
  */
 export function CreditsCard({ balance, onAddCredits }: CreditsCardProps) {
+  if (balance === null) {
+    return null;
+  }
+
   return (
     <div className="flex flex-col rounded-lg border border-[var(--surface-base)] bg-[var(--surface-overlay)] p-2 w-full">
-      {balance !== null && (
-        <div className="flex items-center justify-between gap-2 rounded-[10px] bg-[var(--surface-base)] py-2 pl-1.5 pr-2 w-full">
-          <div className="flex items-center gap-2">
-            <Coins
-              className="h-3.5 w-3.5 text-[color:var(--credits-accent)]"
-              aria-hidden
-            />
-            <span className="text-body-medium-default max-md:text-title-medium text-[color:var(--content-default)]">
-              {balance} credits
-            </span>
-          </div>
-          {/*
-           * Compact on desktop (size="compact"); the mobile mock keeps the
-           * larger regular button, so override the compact dimensions back to
-           * regular at max-md. (Button `size` is a prop, not a responsive
-           * class, so the breakpoint swap lives in className.)
-           */}
-          <Button
-            variant="primary"
-            size="compact"
-            onClick={onAddCredits}
-            className="max-md:h-8 max-md:rounded-md max-md:px-2.5 max-md:text-body-medium-default"
-          >
-            <Plus className="h-3 w-3" aria-hidden />
-            Add
-          </Button>
+      <div className="flex items-center justify-between gap-2 rounded-[10px] bg-[var(--surface-base)] py-2 pl-1.5 pr-2 w-full">
+        <div className="flex items-center gap-2">
+          <Coins
+            className="h-3.5 w-3.5 text-[color:var(--credits-accent)]"
+            aria-hidden
+          />
+          <span className="text-body-medium-default max-md:text-title-medium text-[color:var(--content-default)]">
+            {balance} credits
+          </span>
         </div>
-      )}
+        {/*
+         * Compact on desktop (size="compact"); the mobile mock keeps the
+         * larger regular button, so override the compact dimensions back to
+         * regular at max-md. (Button `size` is a prop, not a responsive
+         * class, so the breakpoint swap lives in className.)
+         */}
+        <Button
+          variant="primary"
+          size="compact"
+          onClick={onAddCredits}
+          className="max-md:h-8 max-md:rounded-md max-md:px-2.5 max-md:text-body-medium-default"
+        >
+          <Plus className="h-3 w-3" aria-hidden />
+          Add
+        </Button>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/domains/chat/components/preferences-menu.tsx
+++ b/apps/web/src/domains/chat/components/preferences-menu.tsx
@@ -181,10 +181,6 @@ function PreferencesMenuContent({
               onClose();
               navigate(routes.settings.billing);
             }}
-            onEarnCredits={() => {
-              onClose();
-              onEarnCredits();
-            }}
           />
         </div>
       ) : null}


### PR DESCRIPTION
## Summary
- Slim CreditsCard to a single credits pill inside a tight bordered container.
- Remove the in-card Earn Credits button and the onEarnCredits prop (now a standalone preferences menu item from PR 1).
- Update credits-card.test.tsx accordingly.

Part of plan: slim-credits-section.md (PR 2 of 2)