### PR TITLE
fix(web): only render credits card wrapper when balance is available

### DIFF
--- a/apps/web/src/domains/chat/components/preferences-menu.tsx
+++ b/apps/web/src/domains/chat/components/preferences-menu.tsx
@@ -169,14 +169,10 @@ function PreferencesMenuContent({
     <>
       <ThemeToggle className="px-2 py-0" />
 
-      {showBillingRows ? (
+      {showBillingRows && effectiveBalance !== null ? (
         <div className="my-2">
           <CreditsCard
-            balance={
-              effectiveBalance !== null
-                ? formatWholeCredits(effectiveBalance)
-                : null
-            }
+            balance={formatWholeCredits(effectiveBalance)}
             onAddCredits={() => {
               onClose();
               navigate(routes.settings.billing);


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for slim-credits-section.md.

**Gap:** Empty credits-card margin wrapper renders stray vertical margin when balance is null
**What was expected:** No empty/blank space in the preferences menu when billing is enabled but the balance is still loading/unavailable
**What was found:** The `<div className="my-2">` wrapper around CreditsCard was gated only on showBillingRows, so it mounted an empty margin div when CreditsCard returned null for a null balance

Now the wrapper is gated on `showBillingRows && effectiveBalance !== null`. The standalone Earn Free Credits item remains gated on showBillingRows alone so it stays available while the balance loads.