### PR TITLE
Slim credits section + standalone Earn Free Credits item

### DIFF
--- a/apps/web/src/domains/chat/components/credits-card.test.tsx
+++ b/apps/web/src/domains/chat/components/credits-card.test.tsx
@@ -17,14 +17,9 @@ afterEach(() => {
 describe("CreditsCard", () => {
   test("renders the balance, coins icon, and fires onAddCredits when Add is clicked", () => {
     const onAddCredits = mock(() => {});
-    const onEarnCredits = mock(() => {});
 
     const { getByText, getByRole, container } = render(
-      <CreditsCard
-        balance="60"
-        onAddCredits={onAddCredits}
-        onEarnCredits={onEarnCredits}
-      />,
+      <CreditsCard balance="60" onAddCredits={onAddCredits} />,
     );
 
     expect(getByText("60 credits")).toBeTruthy();
@@ -33,34 +28,13 @@ describe("CreditsCard", () => {
 
     fireEvent.click(getByRole("button", { name: /add/i }));
     expect(onAddCredits).toHaveBeenCalledTimes(1);
-    expect(onEarnCredits).not.toHaveBeenCalled();
   });
 
-  test("hides only the credits pill when balance is null but still renders Earn Credits", () => {
-    const { queryByText, getByText } = render(
-      <CreditsCard
-        balance={null}
-        onAddCredits={() => {}}
-        onEarnCredits={() => {}}
-      />,
+  test("renders nothing when balance is null", () => {
+    const { container } = render(
+      <CreditsCard balance={null} onAddCredits={() => {}} />,
     );
 
-    expect(queryByText(/credits$/)).toBeNull();
-    expect(getByText("Earn Credits")).toBeTruthy();
-  });
-
-  test("fires onEarnCredits when the Earn Credits row is clicked", () => {
-    const onEarnCredits = mock(() => {});
-
-    const { getByText } = render(
-      <CreditsCard
-        balance="60"
-        onAddCredits={() => {}}
-        onEarnCredits={onEarnCredits}
-      />,
-    );
-
-    fireEvent.click(getByText("Earn Credits"));
-    expect(onEarnCredits).toHaveBeenCalledTimes(1);
+    expect(container.firstChild).toBeNull();
   });
 });

--- a/apps/web/src/domains/chat/components/credits-card.test.tsx
+++ b/apps/web/src/domains/chat/components/credits-card.test.tsx
@@ -15,18 +15,18 @@ afterEach(() => {
 });
 
 describe("CreditsCard", () => {
-  test("renders the balance, coins icon, and fires onAddCredits when Add is clicked", () => {
+  test("renders the balance, coins icon, and fires onAddCredits when Credits is clicked", () => {
     const onAddCredits = mock(() => {});
 
     const { getByText, getByRole, container } = render(
       <CreditsCard balance="60" onAddCredits={onAddCredits} />,
     );
 
-    expect(getByText("60 credits")).toBeTruthy();
+    expect(getByText("60 c")).toBeTruthy();
     // The Coins icon renders a lucide SVG; assert at least one is present.
     expect(container.querySelector("svg.lucide-coins")).toBeTruthy();
 
-    fireEvent.click(getByRole("button", { name: /add/i }));
+    fireEvent.click(getByRole("button", { name: /credits/i }));
     expect(onAddCredits).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/web/src/domains/chat/components/credits-card.tsx
+++ b/apps/web/src/domains/chat/components/credits-card.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@vellum/design-library";
-import { Coins } from "lucide-react";
+import { Coins, Plus } from "lucide-react";
 
 interface CreditsCardProps {
   /** Formatted whole-credits string, or null when unavailable. */
@@ -10,7 +10,7 @@ interface CreditsCardProps {
 /**
  * Presentational credits card matching the preferences-drawer mock: a single
  * slim flat container with the coins icon + balance on the left and a ghost
- * "Add Credits" text button on the right. No nested background — the container
+ * "Add" button (plus icon) on the right. No nested background — the container
  * is the only surface. Purely presentational; callers supply the formatted
  * balance and handler.
  *
@@ -39,7 +39,8 @@ export function CreditsCard({ balance, onAddCredits }: CreditsCardProps) {
         onClick={onAddCredits}
         className="max-md:text-body-medium-default"
       >
-        Add Credits
+        <Plus className="h-3 w-3" aria-hidden />
+        Add
       </Button>
     </div>
   );

--- a/apps/web/src/domains/chat/components/credits-card.tsx
+++ b/apps/web/src/domains/chat/components/credits-card.tsx
@@ -33,13 +33,19 @@ export function CreditsCard({ balance, onAddCredits }: CreditsCardProps) {
           {balance} credits
         </span>
       </div>
+      {/*
+       * size="regular" gives the label `text-body-medium-default`, matching
+       * the balance's line-height so the two are optically centered (the
+       * compact token uses line-height:1, which floats the small label). We
+       * keep the slim height/padding via className.
+       */}
       <Button
         variant="ghost"
-        size="compact"
+        size="regular"
         onClick={onAddCredits}
-        className="max-md:text-body-medium-default"
+        className="h-6 px-1.5"
       >
-        <Plus className="h-3 w-3" aria-hidden />
+        <Plus className="h-3.5 w-3.5" aria-hidden />
         Add
       </Button>
     </div>

--- a/apps/web/src/domains/chat/components/credits-card.tsx
+++ b/apps/web/src/domains/chat/components/credits-card.tsx
@@ -10,7 +10,7 @@ interface CreditsCardProps {
 /**
  * Presentational credits card matching the preferences-drawer mock: a single
  * slim flat container with the coins icon + balance on the left and a ghost
- * "Add" button (plus icon) on the right. No nested background — the container
+ * "Credits" button (plus icon) on the right. No nested background — the container
  * is the only surface. Purely presentational; callers supply the formatted
  * balance and handler.
  *
@@ -29,8 +29,11 @@ export function CreditsCard({ balance, onAddCredits }: CreditsCardProps) {
           className="h-3.5 w-3.5 text-[color:var(--credits-accent)]"
           aria-hidden
         />
-        <span className="text-body-medium-default max-md:text-title-medium text-[color:var(--content-default)]">
-          {balance} credits
+        <span
+          className="text-body-medium-default max-md:text-title-medium text-[color:var(--content-default)]"
+          aria-label={`${balance} credits`}
+        >
+          {balance} c
         </span>
       </div>
       {/*
@@ -48,7 +51,7 @@ export function CreditsCard({ balance, onAddCredits }: CreditsCardProps) {
         className="h-6 gap-1 px-1.5"
       >
         <Plus className="h-3.5 w-3.5" aria-hidden />
-        Add
+        Credits
       </Button>
     </div>
   );

--- a/apps/web/src/domains/chat/components/credits-card.tsx
+++ b/apps/web/src/domains/chat/components/credits-card.tsx
@@ -23,7 +23,7 @@ export function CreditsCard({ balance, onAddCredits }: CreditsCardProps) {
   }
 
   return (
-    <div className="flex items-center justify-between gap-2 rounded-lg border border-[var(--surface-base)] bg-[var(--surface-overlay)] py-2 pl-2.5 pr-1.5 w-full">
+    <div className="flex items-center justify-between gap-2 rounded-lg bg-[var(--surface-base)] py-2 pl-2.5 pr-1.5 w-full">
       <div className="flex items-center gap-2">
         <Coins
           className="h-3.5 w-3.5 text-[color:var(--credits-accent)]"

--- a/apps/web/src/domains/chat/components/credits-card.tsx
+++ b/apps/web/src/domains/chat/components/credits-card.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@vellum/design-library";
-import { Coins, Plus } from "lucide-react";
+import { Coins } from "lucide-react";
 
 interface CreditsCardProps {
   /** Formatted whole-credits string, or null when unavailable. */
@@ -8,13 +8,14 @@ interface CreditsCardProps {
 }
 
 /**
- * Presentational credits card matching the iOS preferences-drawer mock:
- * a slim bordered card containing a single credits pill (coins icon + balance
- * + a primary "Add" button). Purely presentational — no data fetching; callers
- * supply the formatted balance and handler.
+ * Presentational credits card matching the preferences-drawer mock: a single
+ * slim flat container with the coins icon + balance on the left and a ghost
+ * "Add Credits" text button on the right. No nested background — the container
+ * is the only surface. Purely presentational; callers supply the formatted
+ * balance and handler.
  *
  * Renders nothing when `balance` is null (unavailable / still loading) so the
- * bordered card shell never shows up empty.
+ * container never shows up empty.
  */
 export function CreditsCard({ balance, onAddCredits }: CreditsCardProps) {
   if (balance === null) {
@@ -22,33 +23,24 @@ export function CreditsCard({ balance, onAddCredits }: CreditsCardProps) {
   }
 
   return (
-    <div className="flex flex-col rounded-lg border border-[var(--surface-base)] bg-[var(--surface-overlay)] p-2 w-full">
-      <div className="flex items-center justify-between gap-2 rounded-[10px] bg-[var(--surface-base)] py-2 pl-1.5 pr-2 w-full">
-        <div className="flex items-center gap-2">
-          <Coins
-            className="h-3.5 w-3.5 text-[color:var(--credits-accent)]"
-            aria-hidden
-          />
-          <span className="text-body-medium-default max-md:text-title-medium text-[color:var(--content-default)]">
-            {balance} credits
-          </span>
-        </div>
-        {/*
-         * Compact on desktop (size="compact"); the mobile mock keeps the
-         * larger regular button, so override the compact dimensions back to
-         * regular at max-md. (Button `size` is a prop, not a responsive
-         * class, so the breakpoint swap lives in className.)
-         */}
-        <Button
-          variant="primary"
-          size="compact"
-          onClick={onAddCredits}
-          className="max-md:h-8 max-md:rounded-md max-md:px-2.5 max-md:text-body-medium-default"
-        >
-          <Plus className="h-3 w-3" aria-hidden />
-          Add
-        </Button>
+    <div className="flex items-center justify-between gap-2 rounded-lg border border-[var(--surface-base)] bg-[var(--surface-overlay)] py-2 pl-2.5 pr-1.5 w-full">
+      <div className="flex items-center gap-2">
+        <Coins
+          className="h-3.5 w-3.5 text-[color:var(--credits-accent)]"
+          aria-hidden
+        />
+        <span className="text-body-medium-default max-md:text-title-medium text-[color:var(--content-default)]">
+          {balance} credits
+        </span>
       </div>
+      <Button
+        variant="ghost"
+        size="compact"
+        onClick={onAddCredits}
+        className="max-md:text-body-medium-default"
+      >
+        Add Credits
+      </Button>
     </div>
   );
 }

--- a/apps/web/src/domains/chat/components/credits-card.tsx
+++ b/apps/web/src/domains/chat/components/credits-card.tsx
@@ -37,13 +37,15 @@ export function CreditsCard({ balance, onAddCredits }: CreditsCardProps) {
        * size="regular" gives the label `text-body-medium-default`, matching
        * the balance's line-height so the two are optically centered (the
        * compact token uses line-height:1, which floats the small label). We
-       * keep the slim height/padding via className.
+       * keep the slim height/padding via className, and tighten the
+       * icon↔label gap from the base `gap-1.5` to `gap-1` for this button only
+       * (overriding the shared Button default without affecting other buttons).
        */}
       <Button
         variant="ghost"
         size="regular"
         onClick={onAddCredits}
-        className="h-6 px-1.5"
+        className="h-6 gap-1 px-1.5"
       >
         <Plus className="h-3.5 w-3.5" aria-hidden />
         Add

--- a/apps/web/src/domains/chat/components/credits-card.tsx
+++ b/apps/web/src/domains/chat/components/credits-card.tsx
@@ -1,65 +1,54 @@
 import { Button } from "@vellum/design-library";
-import { Coins, Gift, Plus } from "lucide-react";
+import { Coins, Plus } from "lucide-react";
 
 interface CreditsCardProps {
   /** Formatted whole-credits string, or null when unavailable. */
   balance: string | null;
   onAddCredits: () => void;
-  onEarnCredits: () => void;
 }
 
 /**
  * Presentational credits card matching the iOS preferences-drawer mock:
- * a bordered card containing a credits pill (coins icon + balance + a primary
- * "Add" button) and an "Earn Credits" row beneath. Purely presentational — no
- * data fetching; callers supply the formatted balance and handlers.
+ * a slim bordered card containing a single credits pill (coins icon + balance
+ * + a primary "Add" button). Purely presentational — no data fetching; callers
+ * supply the formatted balance and handler.
+ *
+ * Renders nothing when `balance` is null (unavailable / still loading) so the
+ * bordered card shell never shows up empty.
  */
-export function CreditsCard({
-  balance,
-  onAddCredits,
-  onEarnCredits,
-}: CreditsCardProps) {
-  return (
-    <div className="flex flex-col gap-2 max-md:gap-4 rounded-lg border border-[var(--surface-base)] bg-[var(--surface-overlay)] px-3 pt-3 pb-2 max-md:pb-4 w-full">
-      {balance !== null && (
-        <div className="flex items-center justify-between gap-2 rounded-[10px] bg-[var(--surface-base)] py-2 pl-1.5 pr-2 w-full">
-          <div className="flex items-center gap-2">
-            <Coins
-              className="h-3.5 w-3.5 text-[color:var(--credits-accent)]"
-              aria-hidden
-            />
-            <span className="text-body-medium-default max-md:text-title-medium text-[color:var(--content-default)]">
-              {balance} credits
-            </span>
-          </div>
-          {/*
-           * Compact on desktop (size="compact"); the mobile mock keeps the
-           * larger regular button, so override the compact dimensions back to
-           * regular at max-md. (Button `size` is a prop, not a responsive
-           * class, so the breakpoint swap lives in className.)
-           */}
-          <Button
-            variant="primary"
-            size="compact"
-            onClick={onAddCredits}
-            className="max-md:h-8 max-md:rounded-md max-md:px-2.5 max-md:text-body-medium-default"
-          >
-            <Plus className="h-3 w-3" aria-hidden />
-            Add
-          </Button>
-        </div>
-      )}
+export function CreditsCard({ balance, onAddCredits }: CreditsCardProps) {
+  if (balance === null) {
+    return null;
+  }
 
-      <Button
-        variant="ghost"
-        fullWidth
-        tintColor="var(--content-secondary)"
-        onClick={onEarnCredits}
-        className="text-body-medium-lighter max-md:text-body-large-default"
-      >
-        <Gift className="h-3.5 w-3.5" aria-hidden />
-        Earn Credits
-      </Button>
+  return (
+    <div className="flex flex-col rounded-lg border border-[var(--surface-base)] bg-[var(--surface-overlay)] p-2 w-full">
+      <div className="flex items-center justify-between gap-2 rounded-[10px] bg-[var(--surface-base)] py-2 pl-1.5 pr-2 w-full">
+        <div className="flex items-center gap-2">
+          <Coins
+            className="h-3.5 w-3.5 text-[color:var(--credits-accent)]"
+            aria-hidden
+          />
+          <span className="text-body-medium-default max-md:text-title-medium text-[color:var(--content-default)]">
+            {balance} credits
+          </span>
+        </div>
+        {/*
+         * Compact on desktop (size="compact"); the mobile mock keeps the
+         * larger regular button, so override the compact dimensions back to
+         * regular at max-md. (Button `size` is a prop, not a responsive
+         * class, so the breakpoint swap lives in className.)
+         */}
+        <Button
+          variant="primary"
+          size="compact"
+          onClick={onAddCredits}
+          className="max-md:h-8 max-md:rounded-md max-md:px-2.5 max-md:text-body-medium-default"
+        >
+          <Plus className="h-3 w-3" aria-hidden />
+          Add
+        </Button>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/domains/chat/components/preferences-menu.tsx
+++ b/apps/web/src/domains/chat/components/preferences-menu.tsx
@@ -167,7 +167,7 @@ function PreferencesMenuContent({
 
   return (
     <>
-      <ThemeToggle className="rounded-lg border-[1.5px] border-[var(--border-element)] px-2.5 py-1.5" />
+      <ThemeToggle className="rounded-lg border-[1.5px] border-[var(--border-subtle)] px-2.5 py-1.5" />
 
       {showBillingRows && effectiveBalance !== null ? (
         <div className="my-2">

--- a/apps/web/src/domains/chat/components/preferences-menu.tsx
+++ b/apps/web/src/domains/chat/components/preferences-menu.tsx
@@ -167,7 +167,7 @@ function PreferencesMenuContent({
 
   return (
     <>
-      <ThemeToggle className="rounded-lg border border-[var(--surface-base)] px-2.5 py-1.5" />
+      <ThemeToggle className="rounded-lg border-[1.5px] border-[var(--border-element)] px-2.5 py-1.5" />
 
       {showBillingRows && effectiveBalance !== null ? (
         <div className="my-2">

--- a/apps/web/src/domains/chat/components/preferences-menu.tsx
+++ b/apps/web/src/domains/chat/components/preferences-menu.tsx
@@ -167,7 +167,9 @@ function PreferencesMenuContent({
 
   return (
     <>
-      <ThemeToggle className="rounded-lg border-[1.5px] border-[var(--border-subtle)] px-2.5 py-1.5" />
+      <ThemeToggle className="px-2 py-0" />
+
+      <div className="my-2 border-t border-[var(--border-subtle)]" />
 
       {showBillingRows && effectiveBalance !== null ? (
         <div className="my-2">

--- a/apps/web/src/domains/chat/components/preferences-menu.tsx
+++ b/apps/web/src/domains/chat/components/preferences-menu.tsx
@@ -167,7 +167,7 @@ function PreferencesMenuContent({
 
   return (
     <>
-      <ThemeToggle className="px-2 py-0" />
+      <ThemeToggle className="rounded-lg border border-[var(--surface-base)] px-2.5 py-1.5" />
 
       {showBillingRows && effectiveBalance !== null ? (
         <div className="my-2">

--- a/apps/web/src/domains/chat/components/preferences-menu.tsx
+++ b/apps/web/src/domains/chat/components/preferences-menu.tsx
@@ -3,6 +3,7 @@ import {
   ChartColumn,
   ChevronDown,
   ChevronUp,
+  Gift,
   LogOut,
   MessageSquareText,
   Settings as SettingsIcon,
@@ -186,6 +187,17 @@ function PreferencesMenuContent({
             }}
           />
         </div>
+      ) : null}
+
+      {showBillingRows ? (
+        <PanelItem
+          icon={Gift}
+          label="Earn Free Credits"
+          onSelect={() => {
+            onClose();
+            onEarnCredits();
+          }}
+        />
       ) : null}
 
       <PanelItem

--- a/apps/web/src/domains/chat/components/preferences-menu.tsx
+++ b/apps/web/src/domains/chat/components/preferences-menu.tsx
@@ -181,10 +181,6 @@ function PreferencesMenuContent({
               onClose();
               navigate(routes.settings.billing);
             }}
-            onEarnCredits={() => {
-              onClose();
-              onEarnCredits();
-            }}
           />
         </div>
       ) : null}

--- a/apps/web/src/domains/chat/components/preferences-menu.tsx
+++ b/apps/web/src/domains/chat/components/preferences-menu.tsx
@@ -169,14 +169,10 @@ function PreferencesMenuContent({
     <>
       <ThemeToggle className="px-2 py-0" />
 
-      {showBillingRows ? (
+      {showBillingRows && effectiveBalance !== null ? (
         <div className="my-2">
           <CreditsCard
-            balance={
-              effectiveBalance !== null
-                ? formatWholeCredits(effectiveBalance)
-                : null
-            }
+            balance={formatWholeCredits(effectiveBalance)}
             onAddCredits={() => {
               onClose();
               navigate(routes.settings.billing);


### PR DESCRIPTION
## Summary
Restructures the credits section in the web preferences menu: the credits card is now a slim single-row pill (coins icon + balance + "Add"), and the "Earn Credits" action moved out of that card into its own standalone panel item ("Earn Free Credits", Gift icon) between the credits card and Settings. Because the menu is one responsive component (Popover on desktop, BottomSheet on mobile/Capacitor), this applies to the Capacitor/iOS shell automatically — no separate native web component to touch.

## Self-review result
PASS — 1 gap found and fixed across 1 fix PR (empty credits-card margin wrapper when balance is null/loading).

## PRs merged into feature branch
- #33428: feat(web): add standalone Earn Free Credits item to preferences menu
- #33431: refactor(web): slim credits card to pill, drop in-card earn button

### Fix PRs
- #33434: fix(web): only render credits card wrapper when balance is available

## Notes
- Out of scope: the macOS native SwiftUI drawer (`DrawerMenuView.swift`) still shows the old card-with-earn-button layout and label ("Earn credits"). A follow-up could mirror this slimming there for cross-platform consistency.
- Out of scope (per request): renaming "Add" → "Add Credits" and changing the balance format ("60.40 credits" → "60.4 cr") shown in the mock.

Part of plan: slim-credits-section.md