### PR TITLE
Add OAuth approval info Storybook affordance

### DIFF
--- a/apps/web/src/domains/chat/components/surfaces/choice-copy-surfaces.stories.tsx
+++ b/apps/web/src/domains/chat/components/surfaces/choice-copy-surfaces.stories.tsx
@@ -1,4 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Tooltip } from "@vellum/design-library";
+import { Info } from "lucide-react";
 import { useState } from "react";
 
 import type { Surface } from "@/domains/chat/types/types";
@@ -24,6 +26,9 @@ const meta: Meta = {
 
 export default meta;
 type Story = StoryObj;
+
+const OAUTH_APPROVAL_TOOLTIP =
+  "{assistant_name} never acts on your behalf without your approval";
 
 function makeChoiceSurface(overrides: Partial<Surface> = {}): Surface {
   return {
@@ -152,6 +157,20 @@ function InteractiveSurfacePreview({
   );
 }
 
+function StoryOnlyOAuthApprovalInfo() {
+  return (
+    <Tooltip content={OAUTH_APPROVAL_TOOLTIP} side="top" align="end">
+      <button
+        type="button"
+        aria-label="About assistant approval"
+        className="inline-flex h-5 w-5 items-center justify-center rounded-md text-[var(--content-tertiary)] transition-colors hover:bg-[var(--surface-hover)] hover:text-[var(--content-strong)] keyboard-focus:outline-none keyboard-focus:ring-2 keyboard-focus:ring-[var(--ring)]"
+      >
+        <Info className="h-3.5 w-3.5" />
+      </button>
+    </Tooltip>
+  );
+}
+
 function OAuthSurfacePreview() {
   const [surface, setSurface] = useState(makeOAuthConnectSurface());
   if (surface.completed) {
@@ -162,6 +181,7 @@ function OAuthSurfacePreview() {
       surface={surface}
       assistantId="assistant-story"
       oauthClient={storyOAuthClient}
+      descriptionAccessory={<StoryOnlyOAuthApprovalInfo />}
       onAction={(_surfaceId, _actionId, data) => {
         const providerLabel =
           typeof data?.providerLabel === "string"

--- a/apps/web/src/domains/chat/components/surfaces/oauth-connect-surface.tsx
+++ b/apps/web/src/domains/chat/components/surfaces/oauth-connect-surface.tsx
@@ -1,5 +1,5 @@
 import { CheckCircle2, ExternalLink, Loader2, X, XCircle } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 
 import { IntegrationIcon } from "@/components/integrations/integration-icon";
 import {
@@ -25,6 +25,7 @@ interface OAuthConnectSurfaceProps {
   ) => void;
   assistantId?: string | null;
   oauthClient?: ManagedOAuthConnectClient;
+  descriptionAccessory?: ReactNode;
 }
 
 type ConnectState = "idle" | "connecting" | "connected" | "error";
@@ -52,6 +53,7 @@ export function OAuthConnectSurface({
   onAction,
   assistantId,
   oauthClient = defaultManagedOAuthConnectClient,
+  descriptionAccessory,
 }: OAuthConnectSurfaceProps) {
   const data = surface.data as OAuthConnectSurfaceData;
   const providerKey = data.providerKey ?? "";
@@ -148,7 +150,12 @@ export function OAuthConnectSurface({
               {surface.title ?? `Connect ${providerLabel}`}
             </div>
             <p className="mt-1 text-body-medium-lighter text-[var(--content-quiet)]">
-              {description}
+              <span>{description}</span>
+              {descriptionAccessory && (
+                <span className="ml-1.5 inline-flex align-middle">
+                  {descriptionAccessory}
+                </span>
+              )}
             </p>
 
             {missingConfiguration && (


### PR DESCRIPTION
## Summary
- Adds a Storybook-only info affordance to the OAuth connect surface preview
- Places the info icon inline at the end of the OAuth subtitle line
- Adds an optional render hook on the OAuth surface component; the app does not pass it, Storybook does
- Tooltip text: `{assistant_name} never acts on your behalf without your approval`

## Verification
- `cd apps/web && bunx eslint src/domains/chat/components/surfaces/choice-copy-surfaces.stories.tsx src/domains/chat/components/surfaces/oauth-connect-surface.tsx`
- `cd apps/web && bun test src/domains/chat/components/surfaces/choice-copy-surfaces.test.tsx`
- `cd apps/web && bun run build-storybook -- --quiet`

Note: `cd apps/web && bunx tsc --noEmit` currently fails on `src/domains/chat/api/messages.ts` / `messages.test.ts` due to an unrelated generated message tool-call `id` type mismatch present on current `main`.