### PR TITLE
Restore LLM-backed empty-state greetings

### DIFF
--- a/apps/web/src/domains/chat/hooks/use-empty-state-greeting.test.tsx
+++ b/apps/web/src/domains/chat/hooks/use-empty-state-greeting.test.tsx
@@ -7,15 +7,23 @@ import { assistantIdentityIntroQueryKey } from "@/lib/sync/query-tags";
 
 interface CapturedQueryOptions {
   queryKey: readonly unknown[];
-  queryFn: () => Promise<readonly string[] | null>;
+  queryFn: () => Promise<EmptyStateGreetingQueryResult | null>;
   enabled: boolean;
   staleTime: number;
+  refetchInterval?: (query: {
+    state: { data?: EmptyStateGreetingQueryResult | null };
+  }) => number | false;
 }
 
 let lastCapturedOptions: CapturedQueryOptions | null = null;
 
+interface EmptyStateGreetingQueryResult {
+  candidates: readonly string[];
+  refreshing: boolean;
+}
+
 interface UseQueryStub {
-  data: readonly string[] | null | undefined;
+  data: EmptyStateGreetingQueryResult | null | undefined;
 }
 
 let useQueryStub: UseQueryStub = { data: undefined };
@@ -106,10 +114,40 @@ describe("useEmptyStateGreeting", () => {
   });
 
   test("selects one greeting candidate from the daemon response", () => {
-    useQueryStub = { data: ["First greeting", "Second greeting"] };
+    useQueryStub = {
+      data: {
+        candidates: ["First greeting", "Second greeting"],
+        refreshing: false,
+      },
+    };
     Math.random = () => 0.99;
 
     expect(runHook("asst-1")).toBe("Second greeting");
+  });
+
+  test("polls while fallback greetings are refreshing", () => {
+    runHook("asst-1");
+
+    expect(
+      lastCapturedOptions?.refetchInterval?.({
+        state: {
+          data: {
+            candidates: ["What are we working on?"],
+            refreshing: true,
+          },
+        },
+      })
+    ).toBe(1500);
+    expect(
+      lastCapturedOptions?.refetchInterval?.({
+        state: {
+          data: {
+            candidates: ["Generated greeting"],
+            refreshing: false,
+          },
+        },
+      })
+    ).toBe(false);
   });
 
   test("queryFn returns trimmed greetings from the daemon array", async () => {
@@ -125,7 +163,10 @@ describe("useEmptyStateGreeting", () => {
     runHook("asst-1");
     const result = await lastCapturedOptions!.queryFn();
 
-    expect(result).toEqual(["First greeting", "Second greeting"]);
+    expect(result).toEqual({
+      candidates: ["First greeting", "Second greeting"],
+      refreshing: false,
+    });
     expect(identityIntroCalls).toHaveLength(1);
     expect(
       (identityIntroCalls[0] as { path: { assistant_id: string } }).path
@@ -142,6 +183,9 @@ describe("useEmptyStateGreeting", () => {
     runHook("asst-1");
     const result = await lastCapturedOptions!.queryFn();
 
-    expect(result).toEqual(["Legacy greeting"]);
+    expect(result).toEqual({
+      candidates: ["Legacy greeting"],
+      refreshing: false,
+    });
   });
 });

--- a/apps/web/src/domains/chat/hooks/use-empty-state-greeting.ts
+++ b/apps/web/src/domains/chat/hooks/use-empty-state-greeting.ts
@@ -2,8 +2,8 @@
  * React hook that fetches a personalized empty-state greeting from the daemon.
  *
  * Calls `GET /v1/assistants/{assistant_id}/identity/intro` which returns a
- * list of greetings derived from SOUL.md, cached model output, or the
- * assistant's IDENTITY.md name. Falls back to
+ * list of greetings derived from SOUL.md, cached model output, fresh
+ * generation, or generic fallback options. Falls back to
  * {@link DEFAULT_EMPTY_STATE_GREETING} when the assistant ID is missing, the
  * daemon is unreachable, or the response is empty.
  *

--- a/apps/web/src/domains/chat/hooks/use-empty-state-greeting.ts
+++ b/apps/web/src/domains/chat/hooks/use-empty-state-greeting.ts
@@ -21,15 +21,23 @@ import type { IdentityIntroGetResponse } from "@/generated/daemon/types.gen";
 import { assistantIdentityIntroQueryKey } from "@/lib/sync/query-tags";
 
 const STALE_TIME_MS = 5 * 60 * 1000;
+const FALLBACK_REFRESH_INTERVAL_MS = 1500;
 
 type IdentityIntroResponse = Partial<IdentityIntroGetResponse> & {
   greetings?: unknown;
   text?: unknown;
+  source?: unknown;
+  refreshing?: unknown;
 };
+
+interface EmptyStateGreetingQueryResult {
+  candidates: readonly string[];
+  refreshing: boolean;
+}
 
 async function fetchIdentityIntro(
   assistantId: string
-): Promise<readonly string[] | null> {
+): Promise<EmptyStateGreetingQueryResult | null> {
   try {
     const { data, error, response } = await identityIntroGet({
       path: { assistant_id: assistantId },
@@ -41,7 +49,15 @@ async function fetchIdentityIntro(
       return null;
     }
 
-    return normalizeIdentityIntroCandidates(data);
+    const candidates = normalizeIdentityIntroCandidates(data);
+    if (!candidates) {
+      return null;
+    }
+
+    return {
+      candidates,
+      refreshing: data.source === "fallback" && data.refreshing === true,
+    };
   } catch {
     return null;
   }
@@ -80,16 +96,19 @@ export function useEmptyStateGreeting(
 ): string {
   const enabled = Boolean(assistantId);
 
-  const query = useQuery<readonly string[] | null>({
+  const query = useQuery<EmptyStateGreetingQueryResult | null>({
     queryKey: assistantIdentityIntroQueryKey(assistantId),
     queryFn: () => fetchIdentityIntro(assistantId!),
     enabled,
     staleTime: STALE_TIME_MS,
+    refetchInterval: (query) =>
+      query.state.data?.refreshing ? FALLBACK_REFRESH_INTERVAL_MS : false,
   });
 
-  const greeting = useMemo(() => pickGreetingCandidate(query.data), [
-    query.data,
-  ]);
+  const greeting = useMemo(
+    () => pickGreetingCandidate(query.data?.candidates),
+    [query.data]
+  );
 
   return greeting ?? DEFAULT_EMPTY_STATE_GREETING;
 }

--- a/apps/web/src/lib/feature-flags/feature-flag-catalog.test.ts
+++ b/apps/web/src/lib/feature-flags/feature-flag-catalog.test.ts
@@ -13,8 +13,13 @@ describe("feature flag catalog", () => {
 
   test("exposes the activation flow experiment as a client flag", () => {
     expect(CLIENT_FLAG_DEFAULTS.experimentActivationFlow20260603).toBe(false);
-    expect(
-      "experimentActivationFlow20260603" in ASSISTANT_FLAG_DEFAULTS,
-    ).toBe(false);
+    expect("experimentActivationFlow20260603" in ASSISTANT_FLAG_DEFAULTS).toBe(
+      false
+    );
+  });
+
+  test("exposes dynamic empty-state greetings as an assistant flag", () => {
+    expect(ASSISTANT_FLAG_DEFAULTS.emptyStateDynamicGreetings).toBe(false);
+    expect("emptyStateDynamicGreetings" in CLIENT_FLAG_DEFAULTS).toBe(false);
   });
 });

--- a/apps/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/apps/web/src/lib/feature-flags/feature-flag-registry.json
@@ -458,6 +458,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "empty-state-dynamic-greetings",
+      "scope": "assistant",
+      "key": "empty-state-dynamic-greetings",
+      "label": "Dynamic Empty-State Greetings",
+      "description": "Enable the empty new-chat screen to refresh cached greeting options via the empty-state greeting LLM call site. When off, the assistant serves workspace-authored greetings or static fallbacks only.",
+      "defaultEnabled": false
+    },
+    {
       "id": "self-intro-greeting",
       "scope": "both",
       "key": "self-intro-greeting",

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -12742,7 +12742,7 @@ paths:
     get:
       operationId: identity_intro_get
       summary: Get identity greetings
-      description: Returns an array of greetings sourced from SOUL.md, LLM cache, or static fallbacks.
+      description: Returns greetings sourced from SOUL.md, the generated cache, fresh LLM generation, or generic fallbacks.
       tags:
         - identity
       responses:

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -12742,7 +12742,9 @@ paths:
     get:
       operationId: identity_intro_get
       summary: Get identity greetings
-      description: Returns greetings sourced from SOUL.md, the generated cache, fresh LLM generation, or generic fallbacks.
+      description:
+        Returns greetings sourced from SOUL.md, the generated cache, or generic fallbacks while background
+        generation refreshes the cache.
       tags:
         - identity
       responses:
@@ -12759,9 +12761,19 @@ paths:
                       type: string
                   text:
                     type: string
+                  source:
+                    type: string
+                    enum:
+                      - workspace
+                      - cache
+                      - fallback
+                  refreshing:
+                    type: boolean
                 required:
                   - greetings
                   - text
+                  - source
+                  - refreshing
                 additionalProperties: false
   /v1/image-generation/generate:
     post:

--- a/assistant/src/__tests__/btw-routes.test.ts
+++ b/assistant/src/__tests__/btw-routes.test.ts
@@ -6,6 +6,8 @@
  * and no session.processing mutation.
  */
 
+import { rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, mock, test } from "bun:test";
 
 // ---------------------------------------------------------------------------
@@ -123,6 +125,7 @@ import {
   ServiceUnavailableError,
 } from "../runtime/routes/errors.js";
 import type { RouteHandlerArgs } from "../runtime/routes/types.js";
+import { getWorkspaceDir } from "../util/platform.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -354,6 +357,32 @@ describe("POST /v1/btw", () => {
     expect(provider.sendMessage).toHaveBeenCalledTimes(1);
     const [, options] = provider.sendMessage.mock.calls[0];
     expect(options!.config!.callSite).toBe("identityIntro");
+  });
+
+  test("identity intro requests do not synthesize a static name greeting", async () => {
+    const identityPath = join(getWorkspaceDir(), "IDENTITY.md");
+    writeFileSync(
+      identityPath,
+      "# Identity\n\n- **Name:** Example Assistant\n",
+      "utf-8",
+    );
+
+    try {
+      const provider = makeMockProvider();
+      const session = makeMockSession(provider);
+      mockGetOrCreateConversation.mockImplementationOnce(async () => session);
+
+      const { result } = await callHandler({
+        conversationKey: "identity-intro",
+        content: "Generate an intro",
+      });
+      const text = await readStream(result as ReadableStream<Uint8Array>);
+
+      expect(provider.sendMessage).toHaveBeenCalledTimes(1);
+      expect(text).not.toContain("Hi, I'm Example Assistant!");
+    } finally {
+      rmSync(identityPath, { force: true });
+    }
   });
 
   // -- No persistence --

--- a/assistant/src/__tests__/btw-routes.test.ts
+++ b/assistant/src/__tests__/btw-routes.test.ts
@@ -8,7 +8,7 @@
 
 import { rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 // ---------------------------------------------------------------------------
 // Mocks — must be defined before importing the module under test
@@ -78,7 +78,13 @@ mock.module("../runtime/routes/identity-intro-cache.js", () => ({
   getCachedIntro: () => null,
   readWorkspaceIdentityIntro: () => null,
   setCachedIntro: () => {},
-  computeIdentityContentHash: () => "test-hash",
+}));
+
+const assistantFeatureFlags: Record<string, boolean> = {};
+
+mock.module("../config/assistant-feature-flags.js", () => ({
+  isAssistantFeatureFlagEnabled: (key: string) =>
+    assistantFeatureFlags[key] ?? false,
 }));
 
 // Mock getOrCreateConversation from conversation-store so the handler
@@ -179,6 +185,12 @@ function makeMockSession(
 
 const route = ROUTES.find((r) => r.endpoint === "btw" && r.method === "POST");
 if (!route) throw new Error("btw route not found in ROUTES");
+
+beforeEach(() => {
+  for (const key of Object.keys(assistantFeatureFlags)) {
+    delete assistantFeatureFlags[key];
+  }
+});
 
 async function callHandler(
   body: Record<string, unknown>,
@@ -327,7 +339,25 @@ describe("POST /v1/btw", () => {
     expect(options!.config!.modelIntent).toBeUndefined();
   });
 
-  test("greeting requests pass callSite: 'emptyStateGreeting'", async () => {
+  test("greeting requests return static fallback when the dynamic greetings flag is off", async () => {
+    mockGetOrCreateConversation.mockClear();
+
+    const { result } = await callHandler({
+      conversationKey: "greeting",
+      content: "Generate a greeting",
+    });
+    const text = await readStream(result as ReadableStream<Uint8Array>);
+
+    expect(text).toContain(
+      `event: btw_text_delta\ndata: {"text":"What are we working on?"}`,
+    );
+    expect(text).toContain("event: btw_complete\ndata: {}");
+    expect(mockGetOrCreateConversation).not.toHaveBeenCalled();
+  });
+
+  test("greeting requests pass callSite: 'emptyStateGreeting' when the dynamic greetings flag is on", async () => {
+    assistantFeatureFlags["empty-state-dynamic-greetings"] = true;
+
     const provider = makeMockProvider();
     const session = makeMockSession(provider);
     mockGetOrCreateConversation.mockImplementationOnce(async () => session);

--- a/assistant/src/__tests__/config-watcher.test.ts
+++ b/assistant/src/__tests__/config-watcher.test.ts
@@ -231,7 +231,7 @@ describe("ConfigWatcher workspace file handlers", () => {
     expect(evictCallCount).toBe(1);
   });
 
-  test("SOUL.md change triggers identity intro invalidation", async () => {
+  test("SOUL.md change triggers identity intro refetch notification", async () => {
     let introCallCount = 0;
     watcher.start(
       onConversationEvict,

--- a/assistant/src/__tests__/identity-intro-cache.test.ts
+++ b/assistant/src/__tests__/identity-intro-cache.test.ts
@@ -1,9 +1,8 @@
 /**
  * Unit tests for the identity intro cache (identity-intro-cache.ts).
  *
- * Validates TTL-based expiration, content-hash-based invalidation when
- * workspace identity files or the guardian persona content change, and
- * round-trip get/set behavior.
+ * Validates TTL-based expiration, round-trip get/set behavior, and parsing
+ * workspace-authored greeting sections.
  */
 
 import { afterEach, describe, expect, mock, test } from "bun:test";
@@ -45,20 +44,11 @@ mock.module("node:fs", () => ({
   },
 }));
 
-// Mocked guardian persona — mutable so tests can change it and verify cache
-// invalidation based on the per-user persona file content.
-let guardianPersonaContent: string | null = null;
-
-mock.module("../prompts/persona-resolver.js", () => ({
-  resolveGuardianPersona: () => guardianPersonaContent,
-}));
-
 // ---------------------------------------------------------------------------
 // Imports (after mocks)
 // ---------------------------------------------------------------------------
 
 import {
-  computeIdentityContentHash,
   getCachedIntro,
   parseGreetingsSection,
   readWorkspaceGreetings,
@@ -75,7 +65,6 @@ afterEach(() => {
   for (const key of Object.keys(workspaceFiles)) {
     delete workspaceFiles[key];
   }
-  guardianPersonaContent = null;
 });
 
 // ---------------------------------------------------------------------------
@@ -118,7 +107,6 @@ describe("identity intro cache", () => {
   test("round-trip: set then get returns cached greetings array", () => {
     workspaceFiles["IDENTITY.md"] = "- **Name:** Atlas";
     workspaceFiles["SOUL.md"] = "Be playful.";
-    guardianPersonaContent = "The user likes coffee.";
 
     setCachedIntro(["Hey, I'm Atlas.", "What's up?"]);
     const cached = getCachedIntro();
@@ -131,111 +119,45 @@ describe("identity intro cache", () => {
 
     setCachedIntro(["Hello!"]);
 
-    // Manually set the timestamp to 5 hours ago
-    const fiveHoursAgo = String(Date.now() - 5 * 60 * 60 * 1000);
-    checkpointStore.set("identity:intro:cached_at", fiveHoursAgo);
+    const fortyNineHoursAgo = String(Date.now() - 49 * 60 * 60 * 1000);
+    checkpointStore.set("identity:intro:cached_at", fortyNineHoursAgo);
 
     expect(getCachedIntro()).toBeNull();
   });
 
-  test("returns cached greetings when within TTL (3 hours ago)", () => {
+  test("returns cached greetings when within TTL (47 hours ago)", () => {
     workspaceFiles["IDENTITY.md"] = "- **Name:** Atlas";
 
     setCachedIntro(["Hello!"]);
 
-    // Set timestamp to 3 hours ago (within 4-hour TTL)
-    const threeHoursAgo = String(Date.now() - 3 * 60 * 60 * 1000);
-    checkpointStore.set("identity:intro:cached_at", threeHoursAgo);
+    const fortySevenHoursAgo = String(Date.now() - 47 * 60 * 60 * 1000);
+    checkpointStore.set("identity:intro:cached_at", fortySevenHoursAgo);
 
     const cached = getCachedIntro();
     expect(cached).not.toBeNull();
     expect(cached!.greetings).toEqual(["Hello!"]);
   });
 
-  test("busts cache when IDENTITY.md changes", () => {
+  test("keeps cached greetings when IDENTITY.md changes", () => {
     workspaceFiles["IDENTITY.md"] = "- **Name:** Atlas";
     setCachedIntro(["I'm Atlas!"]);
 
-    // Change IDENTITY.md
     workspaceFiles["IDENTITY.md"] = "- **Name:** Nova";
 
-    expect(getCachedIntro()).toBeNull();
+    expect(getCachedIntro()?.greetings).toEqual(["I'm Atlas!"]);
   });
 
-  test("busts cache when SOUL.md changes", () => {
+  test("keeps cached greetings when SOUL.md changes", () => {
     workspaceFiles["SOUL.md"] = "Be playful.";
     setCachedIntro(["Hey there!"]);
 
-    // Change SOUL.md
     workspaceFiles["SOUL.md"] = "Be serious and formal.";
 
-    expect(getCachedIntro()).toBeNull();
-  });
-
-  test("busts cache when guardian persona content changes", () => {
-    guardianPersonaContent = "Likes coffee.";
-    setCachedIntro(["Good morning!"]);
-
-    // Change guardian persona (e.g. user edited users/<slug>.md)
-    guardianPersonaContent = "Likes tea.";
-
-    expect(getCachedIntro()).toBeNull();
-  });
-
-  test("cache remains valid when guardian persona is unchanged", () => {
-    workspaceFiles["IDENTITY.md"] = "- **Name:** Atlas";
-    workspaceFiles["SOUL.md"] = "Be chill.";
-    guardianPersonaContent = "Likes sunsets.";
-
-    setCachedIntro(["Atlas here.", "Hey friend."]);
-
-    expect(getCachedIntro()?.greetings).toEqual(["Atlas here.", "Hey friend."]);
-    expect(getCachedIntro()?.greetings).toEqual(["Atlas here.", "Hey friend."]);
-  });
-
-  test("computeIdentityContentHash is deterministic", () => {
-    workspaceFiles["IDENTITY.md"] = "test";
-    workspaceFiles["SOUL.md"] = "test2";
-    guardianPersonaContent = "test3";
-
-    const hash1 = computeIdentityContentHash();
-    const hash2 = computeIdentityContentHash();
-    expect(hash1).toBe(hash2);
-    expect(hash1).toMatch(/^[a-f0-9]{64}$/); // SHA-256 hex
-  });
-
-  test("computeIdentityContentHash changes when guardian persona changes", () => {
-    workspaceFiles["IDENTITY.md"] = "- **Name:** Atlas";
-    workspaceFiles["SOUL.md"] = "Be playful.";
-    guardianPersonaContent = "Likes coffee.";
-    const hash1 = computeIdentityContentHash();
-
-    guardianPersonaContent = "Likes tea.";
-    const hash2 = computeIdentityContentHash();
-
-    expect(hash1).not.toBe(hash2);
-  });
-
-  test("computeIdentityContentHash handles null guardian persona", () => {
-    workspaceFiles["IDENTITY.md"] = "- **Name:** Atlas";
-    guardianPersonaContent = null;
-
-    const hash = computeIdentityContentHash();
-    expect(hash).toMatch(/^[a-f0-9]{64}$/);
-  });
-
-  test("computeIdentityContentHash changes when file content changes", () => {
-    workspaceFiles["IDENTITY.md"] = "v1";
-    const hash1 = computeIdentityContentHash();
-
-    workspaceFiles["IDENTITY.md"] = "v2";
-    const hash2 = computeIdentityContentHash();
-
-    expect(hash1).not.toBe(hash2);
+    expect(getCachedIntro()?.greetings).toEqual(["Hey there!"]);
   });
 
   test("handles missing workspace files gracefully", () => {
-    // No files exist — should still work (empty content hashed)
+    // No files exist — should still work.
     setCachedIntro(["Hello!"]);
     const cached = getCachedIntro();
     expect(cached).not.toBeNull();
@@ -244,9 +166,7 @@ describe("identity intro cache", () => {
 
   test("handles legacy single-string cache value", () => {
     // Simulate a cache entry written by an older daemon version
-    const hash = computeIdentityContentHash();
     checkpointStore.set("identity:intro:greetings", "Legacy greeting");
-    checkpointStore.set("identity:intro:content_hash", hash);
     checkpointStore.set("identity:intro:cached_at", String(Date.now()));
 
     const cached = getCachedIntro();
@@ -255,20 +175,12 @@ describe("identity intro cache", () => {
   });
 
   test("returns null when greetings checkpoint is missing", () => {
-    checkpointStore.set("identity:intro:content_hash", "abc");
-    checkpointStore.set("identity:intro:cached_at", String(Date.now()));
-    expect(getCachedIntro()).toBeNull();
-  });
-
-  test("returns null when hash checkpoint is missing", () => {
-    checkpointStore.set("identity:intro:greetings", '["Hello"]');
     checkpointStore.set("identity:intro:cached_at", String(Date.now()));
     expect(getCachedIntro()).toBeNull();
   });
 
   test("returns null when timestamp checkpoint is missing", () => {
     checkpointStore.set("identity:intro:greetings", '["Hello"]');
-    checkpointStore.set("identity:intro:content_hash", "abc");
     expect(getCachedIntro()).toBeNull();
   });
 });

--- a/assistant/src/__tests__/identity-routes.test.ts
+++ b/assistant/src/__tests__/identity-routes.test.ts
@@ -22,14 +22,53 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
+const checkpointStore = new Map<string, string>();
+
+mock.module("../memory/checkpoints.js", () => ({
+  getMemoryCheckpoint: (key: string) => checkpointStore.get(key) ?? null,
+  setMemoryCheckpoint: (key: string, value: string) => {
+    checkpointStore.set(key, value);
+  },
+}));
+
+const getConfiguredProviderCalls: string[] = [];
+const mockProvider = { name: "mock-provider" };
+
+mock.module("../providers/provider-send-message.js", () => ({
+  getConfiguredProvider: mock(async (callSite: string) => {
+    getConfiguredProviderCalls.push(callSite);
+    return mockProvider;
+  }),
+}));
+
+type SidechainCall = {
+  callSite?: string;
+  content: string;
+  maxTokens?: number;
+  systemPrompt?: string;
+  tools: unknown[];
+};
+
+const sidechainCalls: SidechainCall[] = [];
+let sidechainText = "";
+
+mock.module("../runtime/btw-sidechain.js", () => ({
+  runBtwSidechain: mock(async (params: SidechainCall) => {
+    sidechainCalls.push(params);
+    return {
+      text: sidechainText,
+      hadTextDeltas: false,
+      response: { content: [] },
+    };
+  }),
+}));
+
 import {
   handleDetailedHealth,
   handleReadyz,
   ROUTES,
 } from "../runtime/routes/identity-routes.js";
-import {
-  setCesClient,
-} from "../security/secure-keys.js";
+import { setCesClient } from "../security/secure-keys.js";
 import { getWorkspaceDir } from "../util/platform.js";
 import {
   getHatchedSidecarPath,
@@ -133,6 +172,11 @@ beforeEach(() => {
 
   rmSync(getHatchedSidecarPath(), { force: true });
   rmSync(join(getWorkspaceDir(), "IDENTITY.md"), { force: true });
+  rmSync(join(getWorkspaceDir(), "SOUL.md"), { force: true });
+  checkpointStore.clear();
+  getConfiguredProviderCalls.length = 0;
+  sidechainCalls.length = 0;
+  sidechainText = "";
 });
 
 afterEach(() => {
@@ -202,21 +246,30 @@ describe("identity routes — health endpoint", () => {
     });
 
     test("readyz returns 200 when CES is connected and ready", () => {
-      const mockClient = { isReady: () => true, close: () => {} } as unknown as import("../credential-execution/client.js").CesClient;
+      const mockClient = {
+        isReady: () => true,
+        close: () => {},
+      } as unknown as import("../credential-execution/client.js").CesClient;
       setCesClient(mockClient);
       const res = handleReadyz();
       expect(res.status).toBe(200);
     });
 
     test("readyz returns 200 when CES client exists but is not ready", () => {
-      const mockClient = { isReady: () => false, close: () => {} } as unknown as import("../credential-execution/client.js").CesClient;
+      const mockClient = {
+        isReady: () => false,
+        close: () => {},
+      } as unknown as import("../credential-execution/client.js").CesClient;
       setCesClient(mockClient);
       const res = handleReadyz();
       expect(res.status).toBe(200);
     });
 
     test("/v1/health reports ces.connected=true when CES is ready", async () => {
-      const mockClient = { isReady: () => true, close: () => {} } as unknown as import("../credential-execution/client.js").CesClient;
+      const mockClient = {
+        isReady: () => true,
+        close: () => {},
+      } as unknown as import("../credential-execution/client.js").CesClient;
       setCesClient(mockClient);
       const res = handleDetailedHealth();
       const body = (await res.json()) as Record<string, unknown>;
@@ -226,7 +279,10 @@ describe("identity routes — health endpoint", () => {
     });
 
     test("/v1/health reports ces.connected=false when CES is not ready", async () => {
-      const mockClient = { isReady: () => false, close: () => {} } as unknown as import("../credential-execution/client.js").CesClient;
+      const mockClient = {
+        isReady: () => false,
+        close: () => {},
+      } as unknown as import("../credential-execution/client.js").CesClient;
       setCesClient(mockClient);
       const res = handleDetailedHealth();
       const body = (await res.json()) as Record<string, unknown>;
@@ -483,5 +539,81 @@ describe("identity routes — createdAt selection", () => {
     const body = route!.handler({}) as { createdAt?: string };
     expect(Date.parse(body.createdAt ?? "")).toBeGreaterThan(0);
     expect(existsSync(getHatchedSidecarPath())).toBe(false);
+  });
+});
+
+describe("identity routes — intro greetings", () => {
+  test("generates personalized empty-state greetings with the callsite, then reuses the cache", async () => {
+    const workspaceDir = getWorkspaceDir();
+    writeFileSync(
+      join(workspaceDir, "IDENTITY.md"),
+      [
+        "# Identity",
+        "",
+        "- **Name:** Example Assistant",
+        "- **Personality:** enjoys crisp, useful hellos",
+        "",
+        "Identity sentinel: chartreuse compass.",
+      ].join("\n"),
+      "utf-8",
+    );
+    writeFileSync(
+      join(workspaceDir, "SOUL.md"),
+      [
+        "# Soul",
+        "",
+        "Soul sentinel: copper lighthouse.",
+        "",
+        "Keep greetings warm and specific.",
+      ].join("\n"),
+      "utf-8",
+    );
+    sidechainText = JSON.stringify([
+      "Charting the next useful thing?",
+      "I brought the compass. Where to?",
+      "Ready to make this lighter.",
+    ]);
+
+    const route = ROUTES.find(
+      (candidate) => candidate.operationId === "identity_intro",
+    );
+    expect(route).toBeDefined();
+
+    const body = (await route!.handler({})) as {
+      greetings: string[];
+      text: string;
+    };
+
+    expect(getConfiguredProviderCalls).toEqual(["emptyStateGreeting"]);
+    expect(sidechainCalls).toHaveLength(1);
+    expect(sidechainCalls[0]?.callSite).toBe("emptyStateGreeting");
+    expect(sidechainCalls[0]?.tools).toEqual([]);
+    expect(sidechainCalls[0]?.content).toContain("JSON array");
+    expect(sidechainCalls[0]?.systemPrompt).toContain(
+      "Identity sentinel: chartreuse compass.",
+    );
+    expect(sidechainCalls[0]?.systemPrompt).toContain(
+      "Soul sentinel: copper lighthouse.",
+    );
+    expect(body).toEqual({
+      greetings: [
+        "Charting the next useful thing?",
+        "I brought the compass. Where to?",
+        "Ready to make this lighter.",
+      ],
+      text: "Charting the next useful thing?",
+    });
+
+    sidechainCalls.length = 0;
+    getConfiguredProviderCalls.length = 0;
+
+    const cachedBody = (await route!.handler({})) as {
+      greetings: string[];
+      text: string;
+    };
+
+    expect(cachedBody).toEqual(body);
+    expect(getConfiguredProviderCalls).toEqual([]);
+    expect(sidechainCalls).toEqual([]);
   });
 });

--- a/assistant/src/__tests__/identity-routes.test.ts
+++ b/assistant/src/__tests__/identity-routes.test.ts
@@ -49,12 +49,22 @@ type SidechainCall = {
   tools: unknown[];
 };
 
+type SidechainResult = {
+  text: string;
+  hadTextDeltas: false;
+  response: { content: [] };
+};
+
 const sidechainCalls: SidechainCall[] = [];
 let sidechainText = "";
+let sidechainResultPromise: Promise<SidechainResult> | null = null;
 
 mock.module("../runtime/btw-sidechain.js", () => ({
   runBtwSidechain: mock(async (params: SidechainCall) => {
     sidechainCalls.push(params);
+    if (sidechainResultPromise) {
+      return sidechainResultPromise;
+    }
     return {
       text: sidechainText,
       hadTextDeltas: false,
@@ -75,6 +85,17 @@ import {
   resolveHatchedAtReadOnly,
   selectHatchedAtFromStats,
 } from "../workspace/hatched-date.js";
+
+function createDeferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
 
 // ── Env helpers ─────────────────────────────────────────────────────────
 
@@ -177,6 +198,7 @@ beforeEach(() => {
   getConfiguredProviderCalls.length = 0;
   sidechainCalls.length = 0;
   sidechainText = "";
+  sidechainResultPromise = null;
 });
 
 afterEach(() => {
@@ -543,7 +565,7 @@ describe("identity routes — createdAt selection", () => {
 });
 
 describe("identity routes — intro greetings", () => {
-  test("generates personalized empty-state greetings with the callsite, then reuses the cache", async () => {
+  test("returns fallback immediately, generates personalized greetings in the background, then reuses the cache", async () => {
     const workspaceDir = getWorkspaceDir();
     writeFileSync(
       join(workspaceDir, "IDENTITY.md"),
@@ -568,21 +590,37 @@ describe("identity routes — intro greetings", () => {
       ].join("\n"),
       "utf-8",
     );
-    sidechainText = JSON.stringify([
-      "Charting the next useful thing?",
-      "I brought the compass. Where to?",
-      "Ready to make this lighter.",
-    ]);
+    const deferredSidechain = createDeferred<SidechainResult>();
+    sidechainResultPromise = deferredSidechain.promise;
 
     const route = ROUTES.find(
       (candidate) => candidate.operationId === "identity_intro",
     );
     expect(route).toBeDefined();
 
-    const body = (await route!.handler({})) as {
+    const body = route!.handler({}) as {
       greetings: string[];
       text: string;
+      source: string;
+      refreshing: boolean;
     };
+
+    expect(body).toEqual({
+      greetings: [
+        "What are we working on?",
+        "I'm here whenever you need me.",
+        "What's on your mind?",
+        "Ready when you are.",
+      ],
+      text: "What are we working on?",
+      source: "fallback",
+      refreshing: true,
+    });
+    expect(getConfiguredProviderCalls).toEqual([]);
+    expect(sidechainCalls).toEqual([]);
+
+    await Promise.resolve();
+    await Promise.resolve();
 
     expect(getConfiguredProviderCalls).toEqual(["emptyStateGreeting"]);
     expect(sidechainCalls).toHaveLength(1);
@@ -595,14 +633,18 @@ describe("identity routes — intro greetings", () => {
     expect(sidechainCalls[0]?.systemPrompt).toContain(
       "Soul sentinel: copper lighthouse.",
     );
-    expect(body).toEqual({
-      greetings: [
+    deferredSidechain.resolve({
+      text: JSON.stringify([
         "Charting the next useful thing?",
         "I brought the compass. Where to?",
         "Ready to make this lighter.",
-      ],
-      text: "Charting the next useful thing?",
+      ]),
+      hadTextDeltas: false,
+      response: { content: [] },
     });
+
+    await sidechainResultPromise;
+    await new Promise((resolve) => setTimeout(resolve, 0));
 
     sidechainCalls.length = 0;
     getConfiguredProviderCalls.length = 0;
@@ -610,9 +652,20 @@ describe("identity routes — intro greetings", () => {
     const cachedBody = (await route!.handler({})) as {
       greetings: string[];
       text: string;
+      source: string;
+      refreshing: boolean;
     };
 
-    expect(cachedBody).toEqual(body);
+    expect(cachedBody).toEqual({
+      greetings: [
+        "Charting the next useful thing?",
+        "I brought the compass. Where to?",
+        "Ready to make this lighter.",
+      ],
+      text: "Charting the next useful thing?",
+      source: "cache",
+      refreshing: false,
+    });
     expect(getConfiguredProviderCalls).toEqual([]);
     expect(sidechainCalls).toEqual([]);
   });

--- a/assistant/src/__tests__/identity-routes.test.ts
+++ b/assistant/src/__tests__/identity-routes.test.ts
@@ -73,6 +73,13 @@ mock.module("../runtime/btw-sidechain.js", () => ({
   }),
 }));
 
+const assistantFeatureFlags: Record<string, boolean> = {};
+
+mock.module("../config/assistant-feature-flags.js", () => ({
+  isAssistantFeatureFlagEnabled: (key: string) =>
+    assistantFeatureFlags[key] ?? false,
+}));
+
 import {
   handleDetailedHealth,
   handleReadyz,
@@ -199,6 +206,9 @@ beforeEach(() => {
   sidechainCalls.length = 0;
   sidechainText = "";
   sidechainResultPromise = null;
+  for (const key of Object.keys(assistantFeatureFlags)) {
+    delete assistantFeatureFlags[key];
+  }
 });
 
 afterEach(() => {
@@ -565,7 +575,53 @@ describe("identity routes — createdAt selection", () => {
 });
 
 describe("identity routes — intro greetings", () => {
+  test("returns static fallback and does not generate when the dynamic greetings flag is off", async () => {
+    const workspaceDir = getWorkspaceDir();
+    writeFileSync(
+      join(workspaceDir, "IDENTITY.md"),
+      "# Identity\n\n- **Name:** Example Assistant\n",
+      "utf-8",
+    );
+    writeFileSync(
+      join(workspaceDir, "SOUL.md"),
+      "# Soul\n\nNo explicit greetings section here.\n",
+      "utf-8",
+    );
+
+    const route = ROUTES.find(
+      (candidate) => candidate.operationId === "identity_intro",
+    );
+    expect(route).toBeDefined();
+
+    const body = route!.handler({}) as {
+      greetings: string[];
+      text: string;
+      source: string;
+      refreshing: boolean;
+    };
+
+    expect(body).toEqual({
+      greetings: [
+        "What are we working on?",
+        "I'm here whenever you need me.",
+        "What's on your mind?",
+        "Ready when you are.",
+      ],
+      text: "What are we working on?",
+      source: "fallback",
+      refreshing: false,
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(getConfiguredProviderCalls).toEqual([]);
+    expect(sidechainCalls).toEqual([]);
+  });
+
   test("returns fallback immediately, generates personalized greetings in the background, then reuses the cache", async () => {
+    assistantFeatureFlags["empty-state-dynamic-greetings"] = true;
+
     const workspaceDir = getWorkspaceDir();
     writeFileSync(
       join(workspaceDir, "IDENTITY.md"),

--- a/assistant/src/daemon/config-watcher.ts
+++ b/assistant/src/daemon/config-watcher.ts
@@ -178,8 +178,8 @@ export class ConfigWatcher {
    * Start all file watchers. `onConversationEvict` is called when watched
    * files change and conversations need to be evicted for reload.
    * `onIdentityChanged` is called when IDENTITY.md changes on disk.
-   * `onIdentityIntroChanged` is called when SOUL.md changes and cached
-   * identity intro greetings should be invalidated.
+   * `onIdentityIntroChanged` is called when SOUL.md changes and identity
+   * intro subscribers should refetch.
    * `onSkillsChanged` is called after skill directory changes evict
    * conversations.
    */

--- a/assistant/src/home/home-greeting-cache.ts
+++ b/assistant/src/home/home-greeting-cache.ts
@@ -10,11 +10,15 @@
  * Storage uses the existing `memory_checkpoints` table (simple key-value store).
  */
 
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+
 import {
   getMemoryCheckpoint,
   setMemoryCheckpoint,
 } from "../memory/checkpoints.js";
-import { computeIdentityContentHash } from "../runtime/routes/identity-intro-cache.js";
+import { resolveGuardianPersona } from "../prompts/persona-resolver.js";
+import { getWorkspacePromptPath } from "../util/platform.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -25,6 +29,25 @@ const CACHE_TTL_MS = 4 * 60 * 60 * 1000; // 4 hours
 const CHECKPOINT_KEY_TEXT = "home:greeting:text";
 const CHECKPOINT_KEY_HASH = "home:greeting:content_hash";
 const CHECKPOINT_KEY_TIMESTAMP = "home:greeting:cached_at";
+
+const IDENTITY_FILES = ["IDENTITY.md", "SOUL.md"] as const;
+
+function readWorkspaceFile(name: string): string {
+  try {
+    const path = getWorkspacePromptPath(name);
+    if (!existsSync(path)) return "";
+    return readFileSync(path, "utf-8");
+  } catch {
+    return "";
+  }
+}
+
+function computeIdentityContentHash(): string {
+  const staticFiles = IDENTITY_FILES.map(readWorkspaceFile).join("\n---\n");
+  const guardianPersona = resolveGuardianPersona() ?? "";
+  const combined = staticFiles + "\n---\n" + guardianPersona;
+  return createHash("sha256").update(combined).digest("hex");
+}
 
 // ---------------------------------------------------------------------------
 // Public API

--- a/assistant/src/runtime/routes/btw-routes.ts
+++ b/assistant/src/runtime/routes/btw-routes.ts
@@ -14,6 +14,7 @@
 
 import { z } from "zod";
 
+import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import { getConfig } from "../../config/loader.js";
 import { readNowScratchpad } from "../../daemon/conversation-runtime-assembly.js";
 import { getOrCreateConversation } from "../../daemon/conversation-store.js";
@@ -33,6 +34,9 @@ const IDENTITY_INTRO_KEY = "identity-intro";
 
 /** Conversation key used by the client for empty-state greeting generation. */
 const GREETING_KEY = "greeting";
+const EMPTY_STATE_DYNAMIC_GREETINGS_FLAG =
+  "empty-state-dynamic-greetings" as const;
+const STATIC_EMPTY_STATE_GREETING = "What are we working on?";
 
 // ---------------------------------------------------------------------------
 // SSE helpers
@@ -64,18 +68,22 @@ async function handleBtw({
 
   const trimmedContent = content.trim();
 
+  if (
+    conversationKey === GREETING_KEY &&
+    !isAssistantFeatureFlagEnabled(
+      EMPTY_STATE_DYNAMIC_GREETINGS_FLAG,
+      getConfig(),
+    )
+  ) {
+    return streamText(STATIC_EMPTY_STATE_GREETING);
+  }
+
   // ----- Cached identity intro fast-path -----
   if (conversationKey === IDENTITY_INTRO_KEY) {
     const fastText = getCachedIntro()?.greetings[0];
     if (fastText) {
       log.debug("Returning identity intro fast-path");
-      return new ReadableStream({
-        start(controller) {
-          controller.enqueue(sseEvent("btw_text_delta", { text: fastText }));
-          controller.enqueue(sseEvent("btw_complete", {}));
-          controller.close();
-        },
-      });
+      return streamText(fastText);
     }
   }
 
@@ -155,6 +163,16 @@ async function handleBtw({
           }
         }
       })();
+    },
+  });
+}
+
+function streamText(text: string): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(sseEvent("btw_text_delta", { text }));
+      controller.enqueue(sseEvent("btw_complete", {}));
+      controller.close();
     },
   });
 }

--- a/assistant/src/runtime/routes/btw-routes.ts
+++ b/assistant/src/runtime/routes/btw-routes.ts
@@ -12,18 +12,14 @@
  * No messages are persisted. The conversation's processing flag is never set or checked.
  */
 
-import { existsSync, readFileSync } from "node:fs";
-
 import { z } from "zod";
 
 import { getConfig } from "../../config/loader.js";
 import { readNowScratchpad } from "../../daemon/conversation-runtime-assembly.js";
 import { getOrCreateConversation } from "../../daemon/conversation-store.js";
-import { parseIdentityFields } from "../../daemon/handlers/identity.js";
 import { getConversationByKey } from "../../memory/conversation-key-store.js";
 import { getAllToolDefinitions } from "../../tools/registry.js";
 import { getLogger } from "../../util/logger.js";
-import { getWorkspacePromptPath } from "../../util/platform.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import { runBtwSidechain } from "../btw-sidechain.js";
 import { BadRequestError, ServiceUnavailableError } from "./errors.js";
@@ -68,17 +64,9 @@ async function handleBtw({
 
   const trimmedContent = content.trim();
 
-  // ----- Identity intro fast-path -----
+  // ----- Cached identity intro fast-path -----
   if (conversationKey === IDENTITY_INTRO_KEY) {
-    let fastText: string | undefined;
-    const identityPath = getWorkspacePromptPath("IDENTITY.md");
-    if (existsSync(identityPath)) {
-      const fields = parseIdentityFields(readFileSync(identityPath, "utf-8"));
-      if (fields.name) {
-        fastText = `Hi, I'm ${fields.name}!`;
-      }
-    }
-    fastText ??= getCachedIntro()?.greetings[0];
+    const fastText = getCachedIntro()?.greetings[0];
     if (fastText) {
       log.debug("Returning identity intro fast-path");
       return new ReadableStream({

--- a/assistant/src/runtime/routes/identity-intro-cache.ts
+++ b/assistant/src/runtime/routes/identity-intro-cache.ts
@@ -3,8 +3,8 @@
  *
  * Greetings are sourced from (in priority order):
  * 1. A `## Greetings` section in SOUL.md (user-defined bullet list)
- * 2. A cached greetings array (populated by the BTW side-chain LLM call)
- * 3. Fallback: the assistant name from IDENTITY.md
+ * 2. A cached greetings array (populated by the empty-state greeting callsite)
+ * 3. A generic fallback when generation is unavailable
  *
  * Cache uses TTL + content-hash invalidation: when IDENTITY.md, SOUL.md, or
  * the guardian persona change, the cache is busted.

--- a/assistant/src/runtime/routes/identity-intro-cache.ts
+++ b/assistant/src/runtime/routes/identity-intro-cache.ts
@@ -6,34 +6,29 @@
  * 2. A cached greetings array (populated by the empty-state greeting callsite)
  * 3. A generic fallback when generation is unavailable
  *
- * Cache uses TTL + content-hash invalidation: when IDENTITY.md, SOUL.md, or
- * the guardian persona change, the cache is busted.
+ * Cache invalidation is intentionally TTL-only. User-authored SOUL.md
+ * greetings are read before cache, so manual overrides still take priority
+ * without coupling cache validity to prompt-file edits.
  *
  * Storage uses the existing `memory_checkpoints` table (simple key-value store).
  */
 
-import { createHash } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 
 import {
   getMemoryCheckpoint,
   setMemoryCheckpoint,
 } from "../../memory/checkpoints.js";
-import { resolveGuardianPersona } from "../../prompts/persona-resolver.js";
 import { getWorkspacePromptPath } from "../../util/platform.js";
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
-const CACHE_TTL_MS = 4 * 60 * 60 * 1000; // 4 hours
+const CACHE_TTL_MS = 2 * 24 * 60 * 60 * 1000; // 2 days
 
 const CHECKPOINT_KEY_GREETINGS = "identity:intro:greetings";
-const CHECKPOINT_KEY_HASH = "identity:intro:content_hash";
 const CHECKPOINT_KEY_TIMESTAMP = "identity:intro:cached_at";
-
-/** Workspace files whose content influences the identity intro. */
-const IDENTITY_FILES = ["IDENTITY.md", "SOUL.md"] as const;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -125,14 +120,6 @@ export function readWorkspaceGreetings(): string[] | null {
   return parseGreetingsSection(soulContent);
 }
 
-/** Compute a SHA-256 hex hash of the concatenated identity file contents. */
-export function computeIdentityContentHash(): string {
-  const staticFiles = IDENTITY_FILES.map(readWorkspaceFile).join("\n---\n");
-  const guardianPersona = resolveGuardianPersona() ?? "";
-  const combined = staticFiles + "\n---\n" + guardianPersona;
-  return createHash("sha256").update(combined).digest("hex");
-}
-
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -142,26 +129,21 @@ export interface CachedIntro {
 }
 
 /**
- * Retrieve the cached greetings array if it exists, is within the TTL window,
- * and the identity files have not changed since it was generated.
+ * Retrieve the cached greetings array if it exists and is within the TTL
+ * window.
  *
- * Returns `null` when the cache is missing, expired, or invalidated.
+ * Returns `null` when the cache is missing or expired.
  */
 export function getCachedIntro(): CachedIntro | null {
   try {
     const raw = getMemoryCheckpoint(CHECKPOINT_KEY_GREETINGS);
-    const hash = getMemoryCheckpoint(CHECKPOINT_KEY_HASH);
     const timestampStr = getMemoryCheckpoint(CHECKPOINT_KEY_TIMESTAMP);
 
-    if (!raw || !hash || !timestampStr) return null;
+    if (!raw || !timestampStr) return null;
 
     // TTL check
     const cachedAt = Number(timestampStr);
     if (isNaN(cachedAt) || Date.now() - cachedAt > CACHE_TTL_MS) return null;
-
-    // Content-hash check — bust cache when identity files change
-    const currentHash = computeIdentityContentHash();
-    if (currentHash !== hash) return null;
 
     // Parse stored value — handles both JSON array and legacy single string
     let greetings: string[];
@@ -178,16 +160,11 @@ export function getCachedIntro(): CachedIntro | null {
   }
 }
 
-/**
- * Store a greetings array in the cache along with the current content hash
- * and timestamp.
- */
+/** Store a greetings array in the cache along with the current timestamp. */
 export function setCachedIntro(greetings: string[]): void {
   try {
-    const hash = computeIdentityContentHash();
     const now = String(Date.now());
     setMemoryCheckpoint(CHECKPOINT_KEY_GREETINGS, JSON.stringify(greetings));
-    setMemoryCheckpoint(CHECKPOINT_KEY_HASH, hash);
     setMemoryCheckpoint(CHECKPOINT_KEY_TIMESTAMP, now);
   } catch {
     // Cache write failure is non-fatal — next request will regenerate.

--- a/assistant/src/runtime/routes/identity-routes.ts
+++ b/assistant/src/runtime/routes/identity-routes.ts
@@ -8,9 +8,13 @@ import { availableParallelism, cpus, totalmem } from "node:os";
 import { z } from "zod";
 
 import { getCpuLimit, getIsPlatform } from "../../config/env-registry.js";
+import { resolveCallSiteConfig } from "../../config/llm-resolver.js";
+import { getConfig } from "../../config/loader.js";
 import { parseIdentityFields } from "../../daemon/handlers/identity.js";
 import { getProfilerRuntimeStatus } from "../../daemon/profiler-run-store.js";
 import { getMaxMigrationVersion } from "../../memory/migrations/registry.js";
+import { buildSystemPrompt } from "../../prompts/system-prompt.js";
+import { getConfiguredProvider } from "../../providers/provider-send-message.js";
 import { getCesClient } from "../../security/secure-keys.js";
 import {
   getDiskUsageInfo,
@@ -23,10 +27,12 @@ import { resolveHatchedAtReadOnly } from "../../workspace/hatched-date.js";
 import { WORKSPACE_MIGRATIONS } from "../../workspace/migrations/registry.js";
 import { getLastWorkspaceMigrationId } from "../../workspace/migrations/runner.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import { runBtwSidechain } from "../btw-sidechain.js";
 import { NotFoundError } from "./errors.js";
 import {
   getCachedIntro,
   readWorkspaceGreetings,
+  setCachedIntro,
 } from "./identity-intro-cache.js";
 import type { RouteDefinition } from "./types.js";
 
@@ -402,7 +408,11 @@ const FALLBACK_GREETINGS = [
   "Ready when you are.",
 ];
 
-function getIdentityIntro() {
+const GENERATED_GREETING_LIMIT = 4;
+const GREETING_GENERATION_TIMEOUT_MS = 10_000;
+const EMPTY_STATE_GREETING_CALLSITE = "emptyStateGreeting" as const;
+
+async function getIdentityIntro() {
   // 1. User-defined greetings from SOUL.md `## Greetings`
   const workspaceGreetings = readWorkspaceGreetings();
   if (workspaceGreetings) {
@@ -415,18 +425,112 @@ function getIdentityIntro() {
     return { greetings: cached.greetings, text: cached.greetings[0] };
   }
 
-  // 3. Fallback: name-based greeting + static defaults
-  const identityPath = getWorkspacePromptPath("IDENTITY.md");
-  if (existsSync(identityPath)) {
-    const content = readFileSync(identityPath, "utf-8");
-    const fields = parseIdentityFields(content);
-    if (fields.name) {
-      const greetings = [`Hi, I'm ${fields.name}!`, ...FALLBACK_GREETINGS];
-      return { greetings, text: greetings[0] };
-    }
+  // 3. Fresh LLM-generated greetings, cached for subsequent empty states.
+  const generated = await generateEmptyStateGreetings();
+  if (generated) {
+    return { greetings: generated, text: generated[0] };
   }
 
+  // 4. Generic fallback only when generation is unavailable.
   return { greetings: FALLBACK_GREETINGS, text: FALLBACK_GREETINGS[0] };
+}
+
+async function generateEmptyStateGreetings(): Promise<string[] | null> {
+  try {
+    const provider = await getConfiguredProvider(EMPTY_STATE_GREETING_CALLSITE);
+    if (!provider) {
+      return null;
+    }
+
+    const resolved = resolveCallSiteConfig(
+      EMPTY_STATE_GREETING_CALLSITE,
+      getConfig().llm,
+    );
+    const systemPrompt = buildSystemPrompt({
+      excludeBootstrap: true,
+      excludeCustomPrefix: true,
+    });
+    const result = await runBtwSidechain({
+      content:
+        `Generate ${GENERATED_GREETING_LIMIT} short first-person greeting options for the empty new-chat screen. ` +
+        "Use the assistant identity, voice, and relationship guidance from IDENTITY.md and SOUL.md. " +
+        "Each greeting should feel personal and inviting, not like a generic assistant introduction. " +
+        "Return only a JSON array of strings. No markdown, keys, or explanation.",
+      provider,
+      systemPrompt,
+      messages: [],
+      tools: [],
+      callSite: EMPTY_STATE_GREETING_CALLSITE,
+      maxTokens: resolved.maxTokens,
+      timeoutMs: GREETING_GENERATION_TIMEOUT_MS,
+    });
+
+    const greetings = parseGeneratedGreetings(result.text);
+    if (greetings.length === 0) {
+      return null;
+    }
+
+    setCachedIntro(greetings);
+    return greetings;
+  } catch (err) {
+    getLogger("identity").warn(
+      { err },
+      "Failed to generate empty-state greetings",
+    );
+    return null;
+  }
+}
+
+function parseGeneratedGreetings(text: string): string[] {
+  const cleaned = text
+    .trim()
+    .replace(/^```(?:json)?\s*/i, "")
+    .replace(/\s*```$/i, "")
+    .trim();
+
+  try {
+    const parsed = JSON.parse(cleaned) as unknown;
+    if (Array.isArray(parsed)) {
+      return normalizeGeneratedGreetings(parsed);
+    }
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      Array.isArray((parsed as { greetings?: unknown }).greetings)
+    ) {
+      return normalizeGeneratedGreetings(
+        (parsed as { greetings: unknown[] }).greetings,
+      );
+    }
+  } catch {
+    // Fall through to line parsing for non-JSON model output.
+  }
+
+  return normalizeGeneratedGreetings(cleaned.split("\n"));
+}
+
+function normalizeGeneratedGreetings(values: unknown[]): string[] {
+  const greetings: string[] = [];
+  const seen = new Set<string>();
+
+  for (const value of values) {
+    if (typeof value !== "string") continue;
+    const greeting = value
+      .trim()
+      .replace(/^(?:[-*+]\s+|\d+[.)]\s+)/, "")
+      .replace(/^["'`]+|["'`]+$/g, "")
+      .trim();
+    if (!greeting) continue;
+
+    const key = greeting.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    greetings.push(greeting);
+
+    if (greetings.length >= GENERATED_GREETING_LIMIT) break;
+  }
+
+  return greetings;
 }
 
 // ---------------------------------------------------------------------------
@@ -567,7 +671,7 @@ export const ROUTES: RouteDefinition[] = [
     handler: getIdentityIntro,
     summary: "Get identity greetings",
     description:
-      "Returns an array of greetings sourced from SOUL.md, LLM cache, or static fallbacks.",
+      "Returns greetings sourced from SOUL.md, the generated cache, fresh LLM generation, or generic fallbacks.",
     tags: ["identity"],
     responseBody: z.object({
       greetings: z.array(z.string()),

--- a/assistant/src/runtime/routes/identity-routes.ts
+++ b/assistant/src/runtime/routes/identity-routes.ts
@@ -410,29 +410,81 @@ const FALLBACK_GREETINGS = [
 
 const GENERATED_GREETING_LIMIT = 4;
 const GREETING_GENERATION_TIMEOUT_MS = 10_000;
+const GREETING_GENERATION_FAILURE_COOLDOWN_MS = 60_000;
 const EMPTY_STATE_GREETING_CALLSITE = "emptyStateGreeting" as const;
 
-async function getIdentityIntro() {
+type IdentityIntroSource = "workspace" | "cache" | "fallback";
+
+interface IdentityIntroResponse {
+  greetings: string[];
+  text: string;
+  source: IdentityIntroSource;
+  refreshing: boolean;
+}
+
+let greetingGenerationInFlight: Promise<void> | null = null;
+let lastGreetingGenerationFailureAt = 0;
+
+function identityIntroResponse(
+  greetings: string[],
+  source: IdentityIntroSource,
+  refreshing = false,
+): IdentityIntroResponse {
+  return {
+    greetings,
+    text: greetings[0] ?? "",
+    source,
+    refreshing,
+  };
+}
+
+function getIdentityIntro(): IdentityIntroResponse {
   // 1. User-defined greetings from SOUL.md `## Greetings`
   const workspaceGreetings = readWorkspaceGreetings();
   if (workspaceGreetings) {
-    return { greetings: workspaceGreetings, text: workspaceGreetings[0] };
+    return identityIntroResponse(workspaceGreetings, "workspace");
   }
 
   // 2. Cached LLM-generated greetings
   const cached = getCachedIntro();
   if (cached) {
-    return { greetings: cached.greetings, text: cached.greetings[0] };
+    return identityIntroResponse(cached.greetings, "cache");
   }
 
-  // 3. Fresh LLM-generated greetings, cached for subsequent empty states.
-  const generated = await generateEmptyStateGreetings();
-  if (generated) {
-    return { greetings: generated, text: generated[0] };
-  }
+  // 3. Trigger fresh generation without blocking the empty-state UI.
+  const refreshing = triggerEmptyStateGreetingGeneration();
 
   // 4. Generic fallback only when generation is unavailable.
-  return { greetings: FALLBACK_GREETINGS, text: FALLBACK_GREETINGS[0] };
+  return identityIntroResponse(FALLBACK_GREETINGS, "fallback", refreshing);
+}
+
+function triggerEmptyStateGreetingGeneration(): boolean {
+  if (greetingGenerationInFlight) {
+    return true;
+  }
+
+  if (
+    lastGreetingGenerationFailureAt > 0 &&
+    Date.now() - lastGreetingGenerationFailureAt <
+      GREETING_GENERATION_FAILURE_COOLDOWN_MS
+  ) {
+    return false;
+  }
+
+  greetingGenerationInFlight = new Promise<void>((resolve) => {
+    queueMicrotask(() => {
+      void generateEmptyStateGreetings()
+        .then((greetings) => {
+          lastGreetingGenerationFailureAt = greetings === null ? Date.now() : 0;
+        })
+        .finally(() => {
+          greetingGenerationInFlight = null;
+          resolve();
+        });
+    });
+  });
+
+  return true;
 }
 
 async function generateEmptyStateGreetings(): Promise<string[] | null> {
@@ -671,11 +723,13 @@ export const ROUTES: RouteDefinition[] = [
     handler: getIdentityIntro,
     summary: "Get identity greetings",
     description:
-      "Returns greetings sourced from SOUL.md, the generated cache, fresh LLM generation, or generic fallbacks.",
+      "Returns greetings sourced from SOUL.md, the generated cache, or generic fallbacks while background generation refreshes the cache.",
     tags: ["identity"],
     responseBody: z.object({
       greetings: z.array(z.string()),
       text: z.string(),
+      source: z.enum(["workspace", "cache", "fallback"]),
+      refreshing: z.boolean(),
     }),
   },
 ];

--- a/assistant/src/runtime/routes/identity-routes.ts
+++ b/assistant/src/runtime/routes/identity-routes.ts
@@ -7,6 +7,7 @@ import { availableParallelism, cpus, totalmem } from "node:os";
 
 import { z } from "zod";
 
+import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import { getCpuLimit, getIsPlatform } from "../../config/env-registry.js";
 import { resolveCallSiteConfig } from "../../config/llm-resolver.js";
 import { getConfig } from "../../config/loader.js";
@@ -412,6 +413,8 @@ const GENERATED_GREETING_LIMIT = 4;
 const GREETING_GENERATION_TIMEOUT_MS = 10_000;
 const GREETING_GENERATION_FAILURE_COOLDOWN_MS = 60_000;
 const EMPTY_STATE_GREETING_CALLSITE = "emptyStateGreeting" as const;
+const EMPTY_STATE_DYNAMIC_GREETINGS_FLAG =
+  "empty-state-dynamic-greetings" as const;
 
 type IdentityIntroSource = "workspace" | "cache" | "fallback";
 
@@ -443,6 +446,13 @@ function getIdentityIntro(): IdentityIntroResponse {
   const workspaceGreetings = readWorkspaceGreetings();
   if (workspaceGreetings) {
     return identityIntroResponse(workspaceGreetings, "workspace");
+  }
+
+  const config = getConfig();
+  if (
+    !isAssistantFeatureFlagEnabled(EMPTY_STATE_DYNAMIC_GREETINGS_FLAG, config)
+  ) {
+    return identityIntroResponse(FALLBACK_GREETINGS, "fallback");
   }
 
   // 2. Cached LLM-generated greetings

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -458,6 +458,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "empty-state-dynamic-greetings",
+      "scope": "assistant",
+      "key": "empty-state-dynamic-greetings",
+      "label": "Dynamic Empty-State Greetings",
+      "description": "Enable the empty new-chat screen to refresh cached greeting options via the empty-state greeting LLM call site. When off, the assistant serves workspace-authored greetings or static fallbacks only.",
+      "defaultEnabled": false
+    },
+    {
       "id": "self-intro-greeting",
       "scope": "both",
       "key": "self-intro-greeting",


### PR DESCRIPTION
## Summary
- Restore the new-chat identity intro endpoint so cache misses generate multiple personalized greetings through the `emptyStateGreeting` callsite.
- Build that sidechain with the normal sidechain system prompt, so IDENTITY.md and SOUL.md are included before the final generation instruction for prompt-cache friendliness.
- Remove the legacy static `Hi, I'm ...` identity-intro fast path and add regressions for generated/cached greetings.

## Original prompt
The user clarified that the new chat page should not fall back to a static `Hi, I'm {assistantName}!` greeting. It should use the empty-state greeting callsite, include IDENTITY.md and SOUL.md in the injected prompt, cache a few generated options to reduce LLM calls, and avoid putting dynamic prompt content before static prompt context.