### PR TITLE
Add inline OAuth approval info affordance

### DIFF
--- a/apps/web/src/domains/chat/components/surfaces/choice-copy-surfaces.stories.tsx
+++ b/apps/web/src/domains/chat/components/surfaces/choice-copy-surfaces.stories.tsx
@@ -161,6 +161,7 @@ function OAuthSurfacePreview() {
     <OAuthConnectSurface
       surface={surface}
       assistantId="assistant-story"
+      assistantDisplayName="Assistant"
       oauthClient={storyOAuthClient}
       onAction={(_surfaceId, _actionId, data) => {
         const providerLabel =

--- a/apps/web/src/domains/chat/components/surfaces/choice-copy-surfaces.test.tsx
+++ b/apps/web/src/domains/chat/components/surfaces/choice-copy-surfaces.test.tsx
@@ -209,6 +209,7 @@ describe("OAuthConnectSurface", () => {
           },
         })}
         assistantId="assistant-1"
+        assistantDisplayName="Assistant"
         oauthClient={oauthClient}
         onAction={onAction}
       />,
@@ -216,6 +217,9 @@ describe("OAuthConnectSurface", () => {
 
     expect(queryByText("gmail.readonly")).toBeNull();
     expect(queryByText("Connect Google Account")).toBeNull();
+    expect(
+      getByRole("button", { name: "About assistant approval" }),
+    ).toBeTruthy();
 
     fireEvent.click(getByRole("button", { name: "Connect" }));
 

--- a/apps/web/src/domains/chat/components/surfaces/oauth-connect-surface.tsx
+++ b/apps/web/src/domains/chat/components/surfaces/oauth-connect-surface.tsx
@@ -1,4 +1,12 @@
-import { CheckCircle2, ExternalLink, Loader2, X, XCircle } from "lucide-react";
+import { Tooltip } from "@vellum/design-library";
+import {
+  CheckCircle2,
+  ExternalLink,
+  Info,
+  Loader2,
+  X,
+  XCircle,
+} from "lucide-react";
 import { useEffect, useState } from "react";
 
 import { IntegrationIcon } from "@/components/integrations/integration-icon";
@@ -24,6 +32,7 @@ interface OAuthConnectSurfaceProps {
     data?: Record<string, unknown>,
   ) => void;
   assistantId?: string | null;
+  assistantDisplayName?: string | null;
   oauthClient?: ManagedOAuthConnectClient;
 }
 
@@ -47,10 +56,34 @@ function getProviderLabel(
   return "this account";
 }
 
+function OAuthApprovalInfo({
+  assistantDisplayName,
+}: {
+  assistantDisplayName?: string | null;
+}) {
+  const assistantLabel = assistantDisplayName?.trim() || "Your assistant";
+  return (
+    <Tooltip
+      content={`${assistantLabel} never acts on your behalf without your approval`}
+      side="top"
+      align="end"
+    >
+      <button
+        type="button"
+        aria-label="About assistant approval"
+        className="inline-flex h-5 w-5 items-center justify-center rounded-md text-[var(--content-tertiary)] transition-colors hover:bg-[var(--surface-hover)] hover:text-[var(--content-strong)] keyboard-focus:outline-none keyboard-focus:ring-2 keyboard-focus:ring-[var(--ring)]"
+      >
+        <Info className="h-3.5 w-3.5" />
+      </button>
+    </Tooltip>
+  );
+}
+
 export function OAuthConnectSurface({
   surface,
   onAction,
   assistantId,
+  assistantDisplayName,
   oauthClient = defaultManagedOAuthConnectClient,
 }: OAuthConnectSurfaceProps) {
   const data = surface.data as OAuthConnectSurfaceData;
@@ -148,7 +181,12 @@ export function OAuthConnectSurface({
               {surface.title ?? `Connect ${providerLabel}`}
             </div>
             <p className="mt-1 text-body-medium-lighter text-[var(--content-quiet)]">
-              {description}
+              <span>{description}</span>
+              <span className="ml-1.5 inline-flex align-middle">
+                <OAuthApprovalInfo
+                  assistantDisplayName={assistantDisplayName}
+                />
+              </span>
             </p>
 
             {missingConfiguration && (

--- a/apps/web/src/domains/chat/components/surfaces/surface-router.tsx
+++ b/apps/web/src/domains/chat/components/surfaces/surface-router.tsx
@@ -27,6 +27,7 @@ export interface SurfaceRouterProps {
     data?: Record<string, unknown>,
   ) => void;
   assistantId?: string | null;
+  assistantDisplayName?: string | null;
   onOpenApp?: (appId: string) => void;
   onOpenDocument?: (documentSurfaceId: string) => void;
   /** Tool calls of the message this surface belongs to. Threaded to
@@ -39,6 +40,7 @@ export function SurfaceRouter({
   surface,
   onAction,
   assistantId,
+  assistantDisplayName,
   onOpenApp,
   onOpenDocument,
   toolCalls,
@@ -94,6 +96,7 @@ export function SurfaceRouter({
           surface={surface}
           onAction={onAction}
           assistantId={assistantId}
+          assistantDisplayName={assistantDisplayName}
         />
       );
 

--- a/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -481,6 +481,7 @@ export function TranscriptMessageBody({
                     onOpenApp={onOpenApp}
                     onOpenDocument={onOpenDocument}
                     assistantId={assistantId}
+                    assistantDisplayName={assistantDisplayName}
                     toolCalls={message.toolCalls}
                   />
                 </div>
@@ -766,6 +767,7 @@ export function TranscriptMessageBody({
                     onOpenApp={onOpenApp}
                     onOpenDocument={onOpenDocument}
                     assistantId={assistantId}
+                    assistantDisplayName={assistantDisplayName}
                     toolCalls={message.toolCalls}
                   />
                 </div>
@@ -912,6 +914,7 @@ export function TranscriptMessageBody({
                   onOpenApp={onOpenApp}
                   onOpenDocument={onOpenDocument}
                   assistantId={assistantId}
+                  assistantDisplayName={assistantDisplayName}
                   toolCalls={message.toolCalls}
                 />
               </div>
@@ -1033,6 +1036,7 @@ export function TranscriptMessageBody({
                 onOpenApp={onOpenApp}
                 onOpenDocument={onOpenDocument}
                 assistantId={assistantId}
+                assistantDisplayName={assistantDisplayName}
                 toolCalls={message.toolCalls}
               />
             </div>

--- a/apps/web/src/domains/chat/transcript/transcript-row.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-row.tsx
@@ -145,6 +145,7 @@ export const TranscriptRow = memo(function TranscriptRow({
           onOpenApp={onOpenApp}
           onOpenDocument={onOpenDocument}
           assistantId={assistantId}
+          assistantDisplayName={assistantDisplayName}
         />
       );
 


### PR DESCRIPTION
## Summary
- Adds the approval info icon to the actual OAuth connect surface, inline at the end of the subtitle under the Connect Google title
- Threads assistant display name through SurfaceRouter so the tooltip can say `<assistant name> never acts on your behalf without your approval`
- Keeps Storybook using the same component path, so the preview matches production

## Verification
- `cd apps/web && bunx eslint src/domains/chat/components/surfaces/choice-copy-surfaces.stories.tsx src/domains/chat/components/surfaces/choice-copy-surfaces.test.tsx src/domains/chat/components/surfaces/oauth-connect-surface.tsx src/domains/chat/components/surfaces/surface-router.tsx src/domains/chat/transcript/transcript-message-body.tsx src/domains/chat/transcript/transcript-row.tsx`
- `cd apps/web && bun test src/domains/chat/components/surfaces/choice-copy-surfaces.test.tsx`
- `cd apps/web && bun run build-storybook -- --quiet`

Note: `cd apps/web && bun run openapi-ts && bunx tsc --noEmit` still fails on `src/domains/chat/api/messages.ts` / `messages.test.ts` due to the unrelated generated message tool-call `id` type mismatch present on current `main`.