### PR TITLE
Mention OAuth connect chat surface in skill

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -238,7 +238,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T22:51:59.000Z"
+      "updatedAt": "2026-06-04T15:23:46.000Z"
     },
     {
       "id": "google-calendar",
@@ -557,7 +557,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T22:51:59.000Z"
+      "updatedAt": "2026-06-04T15:23:46.000Z"
     },
     {
       "id": "outlook-calendar",
@@ -685,7 +685,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T22:51:59.000Z"
+      "updatedAt": "2026-06-04T15:23:46.000Z"
     },
     {
       "id": "slack-app-setup",
@@ -957,7 +957,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "updatedAt": "2026-06-04T16:31:25.000Z"
     },
     {
       "id": "vellum-self-knowledge",

--- a/skills/vellum-oauth-integrations/SKILL.md
+++ b/skills/vellum-oauth-integrations/SKILL.md
@@ -43,6 +43,8 @@ All providers support "your-own" mode and some support "managed" mode.
 
 "managed" mode relies on a first-class integration with the Vellum Platform. Managed mode is typically easier to set up and get going, often only requiring the user to log in with no additional configuration needed before they can begin using the integration. Managed mode is the recommended method for most users, especially those that are less technical or newer to their Vellum assistant.
 
+When a task needs a managed OAuth connection, present it in chat with `ui_show` using `surface_type: "oauth_connect"` instead of sending the user to Settings or trying to open the OAuth flow from shell. See [Connecting Accounts](references/CONNECTING_ACCOUNTS.md) for the exact surface shape.
+
 Note that using managed mode:
 
 - Requires an account with the Vellum Platform

--- a/skills/vellum-oauth-integrations/references/CONNECTING_ACCOUNTS.md
+++ b/skills/vellum-oauth-integrations/references/CONNECTING_ACCOUNTS.md
@@ -41,7 +41,9 @@ If there are none, see [Configuring a New OAuth Application](CONFIGURING_APPLICA
 
 ## Choosing Scopes
 
-Before connecting, consider what the user is trying to accomplish and request only the scopes needed for that task. You can see what scopes are available for a provider with:
+For managed mode, do not choose or display scopes yourself. Managed providers use the platform's configured scopes, and the chat surface handles the connection affordance.
+
+For your-own mode, consider what the user is trying to accomplish and request only the scopes needed for that task. You can see what scopes are available for a provider with:
 
 ```bash
 assistant oauth providers get <provider-key>
@@ -49,11 +51,33 @@ assistant oauth providers get <provider-key>
 
 **Always request the bare minimum scopes needed for the task at hand.** For example, if the user only wants to read their calendar, don't also request write access. If they only need to view emails, don't request send permissions. This follows the principle of least privilege and builds trust with the user — they'll see exactly what they're granting on the provider's consent screen.
 
-If the user later needs additional scopes for a different task, you can disconnect and reconnect with updated scopes. See [Updating Scopes](UPDATING_SCOPES.md) for details.
+If the user later needs additional scopes for a different task in your-own mode, you can disconnect and reconnect with updated scopes. See [Updating Scopes](UPDATING_SCOPES.md) for details.
 
 ## Initiating the Connection
 
-To actually initiate a connection with the OAuth provider, run:
+### Managed mode: show the in-chat connect surface
+
+If the provider is in managed mode, use `ui_show` with `surface_type: "oauth_connect"`. This is the same managed connection path available through Settings, but presented in chat at the moment the task needs it.
+
+Use a short task-specific description, and let the client own the action label. Do not include scopes, raw OAuth URLs, or a custom connect button label in the surface.
+
+```json
+{
+  "surface_type": "oauth_connect",
+  "title": "Connect Google",
+  "data": {
+    "providerKey": "google",
+    "displayName": "Google",
+    "description": "Connect Gmail, Calendar, and Drive for this task."
+  }
+}
+```
+
+Wait for the user to complete or dismiss the surface before proceeding. If they connect, verify the connection before making requests. If they dismiss it, continue only if the task can proceed without that account.
+
+### Your-own mode: run the CLI connect command
+
+If the provider is in your-own mode, initiate the connection with the OAuth provider by running:
 
 ```bash
 assistant oauth connect <provider-key> --scopes <scope1> <scope2> ...


### PR DESCRIPTION
## Summary
- Tell `vellum-oauth-integrations` to use the `oauth_connect` `ui_show` surface for managed OAuth setup in chat.
- Split managed-mode connection guidance from the existing your-own CLI flow.
- Clarify that managed providers should not expose scopes or custom CTA labels in the surface.

## Testing
- `git diff --check origin/main...HEAD`
- Not run: runtime tests are not applicable for this markdown-only skill instruction update.

Follow-up to #33445.