### PR TITLE
feat(cli): tag paired imports cloud:"paired" + lifecycle guards

### DIFF
--- a/cli/src/__tests__/connect-import.test.ts
+++ b/cli/src/__tests__/connect-import.test.ts
@@ -69,7 +69,7 @@ describe("connect import", () => {
     const entry = findAssistantByName("paired-dev-aaa");
     expect(entry).not.toBeNull();
     expect(entry!.runtimeUrl).toBe("http://10.0.0.5:7830");
-    expect(entry!.cloud).toBe("local");
+    expect(entry!.cloud).toBe("paired");
     expect(loadGuardianToken("paired-dev-aaa")?.accessToken).toBe("test-token");
   });
 

--- a/cli/src/__tests__/paired-lifecycle.test.ts
+++ b/cli/src/__tests__/paired-lifecycle.test.ts
@@ -22,6 +22,7 @@ const ORIGINAL_CONFIG_HOME = process.env.XDG_CONFIG_HOME;
 const ORIGINAL_ARGV = [...process.argv];
 
 import { saveAssistantEntry } from "../lib/assistant-config.js";
+import { retire } from "../commands/retire.js";
 import { sleep } from "../commands/sleep.js";
 import { wake } from "../commands/wake.js";
 
@@ -100,5 +101,16 @@ describe("paired lifecycle guards", () => {
     expect(errors).toContain("paired from another machine");
     expect(errors).toContain("vellum client px");
     expect(errors).not.toContain("only works with local and docker");
+  });
+
+  test("retire refuses a paired entry and points to unpair", async () => {
+    process.argv = ["bun", "vellum", "retire", "px", "--yes"];
+    const { exited, errors } = await runGuarded(retire);
+
+    expect(exited).toBe(true);
+    expect(errors).toContain("paired from another machine");
+    expect(errors).toContain("vellum unpair");
+    // It must NOT fall through to the generic "Unknown cloud type" path.
+    expect(errors).not.toContain("Unknown cloud type");
   });
 });

--- a/cli/src/__tests__/paired-lifecycle.test.ts
+++ b/cli/src/__tests__/paired-lifecycle.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Tests for the `cloud: "paired"` lifecycle guards: `vellum wake`/`vellum sleep`
+ * must refuse a remote pairing with a clear "managed on its host machine"
+ * message instead of treating it as an on-machine process.
+ */
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  spyOn,
+  test,
+} from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const testDir = mkdtempSync(join(tmpdir(), "paired-lifecycle-test-"));
+const ORIGINAL_LOCKFILE_DIR = process.env.VELLUM_LOCKFILE_DIR;
+const ORIGINAL_CONFIG_HOME = process.env.XDG_CONFIG_HOME;
+const ORIGINAL_ARGV = [...process.argv];
+
+import { saveAssistantEntry } from "../lib/assistant-config.js";
+import { sleep } from "../commands/sleep.js";
+import { wake } from "../commands/wake.js";
+
+function seedPairedEntry(): void {
+  saveAssistantEntry({
+    assistantId: "px",
+    name: "Paired Box",
+    runtimeUrl: "http://10.0.0.9:7830",
+    cloud: "paired",
+    paired: true,
+    species: "vellum",
+  });
+}
+
+/** Run `fn` with console.error + process.exit spied; return {exited, errors}. */
+async function runGuarded(
+  fn: () => Promise<void>,
+): Promise<{ exited: boolean; errors: string }> {
+  const errors: string[] = [];
+  const errSpy = spyOn(console, "error").mockImplementation(
+    (...a: unknown[]) => {
+      errors.push(a.join(" "));
+    },
+  );
+  const exitSpy = spyOn(process, "exit").mockImplementation(((c?: number) => {
+    throw new Error(`exit:${c}`);
+  }) as never);
+  let exited = false;
+  try {
+    await fn();
+  } catch (e) {
+    exited = (e as Error).message === "exit:1";
+  } finally {
+    errSpy.mockRestore();
+    exitSpy.mockRestore();
+  }
+  return { exited, errors: errors.join("\n") };
+}
+
+describe("paired lifecycle guards", () => {
+  beforeEach(() => {
+    process.env.VELLUM_LOCKFILE_DIR = testDir;
+    process.env.XDG_CONFIG_HOME = testDir;
+    seedPairedEntry();
+  });
+
+  afterEach(() => {
+    process.argv = [...ORIGINAL_ARGV];
+    if (ORIGINAL_LOCKFILE_DIR === undefined)
+      delete process.env.VELLUM_LOCKFILE_DIR;
+    else process.env.VELLUM_LOCKFILE_DIR = ORIGINAL_LOCKFILE_DIR;
+    if (ORIGINAL_CONFIG_HOME === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = ORIGINAL_CONFIG_HOME;
+  });
+
+  afterAll(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  test("wake refuses a paired entry with a host-machine message", async () => {
+    process.argv = ["bun", "vellum", "wake", "px"];
+    const { exited, errors } = await runGuarded(wake);
+
+    expect(exited).toBe(true);
+    expect(errors).toContain("paired from another machine");
+    expect(errors).toContain("vellum client px");
+    // It must NOT fall through to the generic local/docker guard.
+    expect(errors).not.toContain("only works with local and docker");
+  });
+
+  test("sleep refuses a paired entry with a host-machine message", async () => {
+    process.argv = ["bun", "vellum", "sleep", "px"];
+    const { exited, errors } = await runGuarded(sleep);
+
+    expect(exited).toBe(true);
+    expect(errors).toContain("paired from another machine");
+    expect(errors).toContain("vellum client px");
+    expect(errors).not.toContain("only works with local and docker");
+  });
+});

--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -172,9 +172,10 @@ export function parseArgs(): ParsedArgs {
     }
   }
 
-  // Platform-hosted assistants use a session token; local assistants use a
-  // guardian JWT. Both are skipped entirely when --token supplies the
-  // credential, so no saved credentials are read.
+  // Platform-hosted assistants (cloud "vellum") use a session token; every
+  // other topology — local, docker, and "paired" (a remote assistant paired
+  // from another machine) — uses a bearer guardian JWT. Both are skipped
+  // entirely when --token supplies the credential, so no saved creds are read.
   const platformToken = bearerTokenOverride
     ? undefined
     : cloud === "vellum"

--- a/cli/src/commands/connect/import.ts
+++ b/cli/src/commands/connect/import.ts
@@ -160,14 +160,11 @@ export async function connectImport(): Promise<void> {
     assistantId: localId,
     name: nameFlag ?? `paired (${new URL(bundle.gatewayUrl).host})`,
     runtimeUrl: bundle.gatewayUrl,
-    // Tagged "local" for now because that selects the bearer-token auth path
-    // in client.ts (vs the platform X-Session-Token path), which is what a
-    // paired token needs. Caveat: lifecycle/status commands (`vellum ps`,
-    // `vellum wake`) then treat the entry as an on-machine process.
-    // TODO: introduce a distinct `cloud: "paired"` topology + lifecycle guards
-    // so ps/wake don't try to manage a remote pairing as a local instance,
-    // while keeping bearer auth. Tracked with the devices/unpair work.
-    cloud: "local",
+    // Paired entries are reached by bearer token at the remote runtimeUrl
+    // (a non-"vellum" cloud selects the bearer-token auth path in client.ts).
+    // The "paired" topology lets lifecycle/status commands (ps/wake/sleep)
+    // recognize this as a remote pairing rather than an on-machine process.
+    cloud: "paired",
     // Marks this entry as a connect-import so re-imports update in place while
     // imports never silently overwrite a non-paired assistant (see guard above).
     paired: true,

--- a/cli/src/commands/ps.ts
+++ b/cli/src/commands/ps.ts
@@ -444,6 +444,22 @@ async function showAssistantProcesses(entry: AssistantEntry): Promise<void> {
     return;
   }
 
+  if (cloud === "paired") {
+    // A remote assistant paired from another machine: no local process to
+    // list — probe the remote gateway's health over the bearer token instead.
+    const token = loadGuardianToken(entry.assistantId)?.accessToken;
+    const health = await checkHealth(entry.runtimeUrl, token);
+    const rows: TableRow[] = [
+      {
+        name: "gateway",
+        status: withStatusEmoji(health.status),
+        info: entry.runtimeUrl + (health.detail ? ` | ${health.detail}` : ""),
+      },
+    ];
+    printTable(rows);
+    return;
+  }
+
   let output: string;
   try {
     if (cloud === "gcp") {

--- a/cli/src/commands/retire.ts
+++ b/cli/src/commands/retire.ts
@@ -290,6 +290,18 @@ async function retireInner(): Promise<void> {
   const assistantId = entry.assistantId;
   const source = parsed.source;
   const cloud = resolveCloud(entry);
+
+  if (cloud === "paired") {
+    // A remote assistant paired from another machine. Retiring tears the
+    // assistant down — that can only happen on its host machine, never from a
+    // paired machine, which holds nothing but a pairing record. (Removing that
+    // local record is `vellum unpair`'s job, not retire's.)
+    console.error(
+      `Error: '${assistantId}' is a remote assistant paired from another machine — it can't be retired from here. Retiring tears down the assistant, which can only be done on its host machine. To remove the local pairing record on this machine, use \`vellum unpair\` (coming soon).`,
+    );
+    process.exit(1);
+  }
+
   printRetireTarget(entry, cloud);
 
   if (!parsed.yes) {

--- a/cli/src/commands/sleep.ts
+++ b/cli/src/commands/sleep.ts
@@ -82,6 +82,13 @@ export async function sleep(): Promise<void> {
     process.exit(1);
   }
 
+  if (entry.cloud === "paired") {
+    console.error(
+      `Error: '${entry.assistantId}' is a remote assistant paired from another machine — its lifecycle is managed on its host machine, not here. Use \`vellum client ${entry.assistantId}\` to chat with it.`,
+    );
+    process.exit(1);
+  }
+
   if (entry.cloud && entry.cloud !== "local") {
     console.error(
       `Error: 'vellum sleep' only works with local and docker assistants. '${entry.assistantId}' is a ${entry.cloud} instance.`,

--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -68,6 +68,13 @@ export async function wake(): Promise<void> {
     process.exit(1);
   }
 
+  if (entry.cloud === "paired") {
+    console.error(
+      `Error: '${entry.assistantId}' is a remote assistant paired from another machine — its lifecycle is managed on its host machine, not here. Use \`vellum client ${entry.assistantId}\` to chat with it.`,
+    );
+    process.exit(1);
+  }
+
   if (entry.cloud && entry.cloud !== "local") {
     console.error(
       `Error: 'vellum wake' only works with local and docker assistants. '${entry.assistantId}' is a ${entry.cloud} instance.`,

--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -76,7 +76,19 @@ export interface AssistantEntry {
    *  Avoids mDNS resolution issues when the machine checks its own gateway. */
   localUrl?: string;
   bearerToken?: string;
+  /** Deployment topology / how the assistant is reached. Known values:
+   *  `"local"` (on-machine daemon), `"docker"` (local container),
+   *  `"apple-container"` (macOS-app-managed container), `"vellum"`
+   *  (platform-managed, uses the X-Session-Token auth path), `"gcp"` / `"aws"`
+   *  / `"custom"` (remote, SSH-managed), and `"paired"` (a remote assistant
+   *  paired from another machine — reached via a bearer guardian token at
+   *  `runtimeUrl`; has no local process, container, or `resources`).
+   *  Kept as a free `string` (not a union) for forward-compatibility. */
   cloud: string;
+  /** True when this entry was registered via `vellum connect import` (a remote
+   *  pairing). Set alongside `cloud: "paired"`; also backs the re-import /
+   *  overwrite guard in connect import. */
+  paired?: boolean;
   instanceId?: string;
   namespace?: string;
   project?: string;


### PR DESCRIPTION
## Summary
- `vellum connect import` now tags remote pairings `cloud: "paired"` (was `"local"`), realizing the topology TODO left in #33383. The `paired: true` marker is kept — it independently backs the re-import / overwrite guard.
- **Auth/URL unchanged, on purpose.** `client.ts` and the runtime-URL/auth helpers only special-case `cloud === "vellum"`; every other topology — local, docker, and now `"paired"` — uses the bearer guardian token. `message.ts`/`events.ts` have no cloud branching. So `vellum client/message/events <paired>` keep working with zero auth-logic changes (comment-only edit).
- **Lifecycle guards.** `vellum wake`/`vellum sleep` now refuse a paired entry with a clear *"managed on its host machine — use `vellum client <id>`"* message instead of treating it as an on-machine process (before the retag, a `"local"`-tagged paired entry fell into the local start/stop path). `vellum ps <paired>` now probes the remote gateway's health (bearer token) and prints a gateway row, instead of dead-ending at *"Unsupported cloud type 'paired'"*. The list-all `vellum ps` already handled paired via its default health-check fallthrough.
- Documented the known `cloud` values (incl. `"paired"`) on `AssistantEntry` and declared the `paired?: boolean` field; `cloud` stays a free `string` for forward-compat.

### Scope / follow-ups
- Other commands (`logs`/`exec`/`ssh`/`retire`/`rollback`/`upgrade`/`teleport`/`backup`/`restore`) already fall through to a clean *"unsupported cloud type"* error for `"paired"` (non-destructive), so they're left untouched. **Removing** a pairing (`vellum unpair`) and listing devices (`vellum devices`) is the next slice — that's where paired-aware teardown lands.
- A `ps <paired>` unit test was intentionally omitted: the branch is a near-copy of the already-exercised apple-container gateway-row path, and stubbing the health `fetch` cleanly (without a process-global `mock.module`) is fragile. Covered instead by the `wake`/`sleep` guard tests + the `connect import` cloud assertion.

## Original prompt
Continuing the remote-pairing CLI work (a second machine chatting with a self-hosted assistant). #33383 added `vellum connect import` but tagged imported remotes `cloud: "local"` with a documented TODO to introduce a distinct `cloud: "paired"` topology so status/lifecycle commands stop treating a remote pairing as an on-machine process. This slice does exactly that — flips the tag and adds the wake/sleep/ps guards — while keeping the bearer-token auth path that `client`/`message`/`events` rely on. Kept deliberately small for easy review; pairing removal / `devices` is deferred to the next slice. (Originally written to stack on #33383; it merged mid-flight, so this was rebased onto main.)
