### PR TITLE
Show Advanced profile params only after a model is chosen

### DIFF
--- a/apps/web/src/domains/settings/ai/profile-editor-modal.test.tsx
+++ b/apps/web/src/domains/settings/ai/profile-editor-modal.test.tsx
@@ -261,10 +261,22 @@ describe("ProfileEditorModal create mode — provider-first", () => {
     expect(keyIdx).toBeGreaterThan(providerIdx);
   });
 
-  test("advanced params are collapsed by default in create mode", () => {
+  test("Advanced is hidden until a model is chosen, then collapsed by default", () => {
     renderCreate([makeConnection("anthropic-personal")]);
-    const advancedToggle = getButton("Advanced");
-    expect(advancedToggle.getAttribute("aria-expanded")).toBe("false");
+
+    // No model selected yet → the Advanced disclosure is not rendered.
+    const hasAdvancedButton = () =>
+      Array.from(document.querySelectorAll("button")).some(
+        (b) => b.textContent?.trim() === "Advanced",
+      );
+    expect(hasAdvancedButton()).toBe(false);
+
+    selectProvider("Anthropic");
+    selectModel("Claude Opus 4.8");
+
+    // Once a model is chosen the disclosure appears, collapsed.
+    expect(hasAdvancedButton()).toBe(true);
+    expect(getButton("Advanced").getAttribute("aria-expanded")).toBe("false");
   });
 
   test("selecting a model pre-fills Name and Key", () => {

--- a/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -776,8 +776,11 @@ function ProfileEditorModalInner({
     </div>
   );
 
+  // Only surface Advanced once a model is chosen — the advanced params are
+  // model-dependent (effort/thinking/token ranges resolve from the selected
+  // model), so showing the disclosure before then is meaningless.
   const createAdvancedDisclosure =
-    !isAutoProfile && advancedParamsNode ? (
+    !isAutoProfile && model !== "" && advancedParamsNode ? (
       <div>
         <button
           type="button"


### PR DESCRIPTION
## Summary
- In the provider-first profile create flow, the "Advanced" disclosure now only renders once a model has been selected. The advanced params (effort, extended thinking, token ranges) are model-dependent, so surfacing them before a model is chosen is meaningless.
- Updated the modal test to assert Advanced is hidden until a model is chosen, then collapsed.

Note: the modal is already viewport-centered by the design-system Modal (fixed-inset overlay portaled to body), so no centering change was needed.