### PR TITLE
Add work result chat surface

### DIFF
--- a/apps/web/src/domains/chat/components/surfaces/surface-router.tsx
+++ b/apps/web/src/domains/chat/components/surfaces/surface-router.tsx
@@ -18,6 +18,7 @@ import { OAuthConnectSurface } from "@/domains/chat/components/surfaces/oauth-co
 import { SurfaceContainer } from "@/domains/chat/components/surfaces/surface-container";
 import { TableSurface } from "@/domains/chat/components/surfaces/table-surface";
 import { TaskPreferencesSurface } from "@/domains/chat/components/surfaces/task-preferences-surface";
+import { WorkResultSurface } from "@/domains/chat/components/surfaces/work-result-surface";
 
 export interface SurfaceRouterProps {
   surface: Surface;
@@ -125,6 +126,9 @@ export function SurfaceRouter({
 
     case "task_preferences":
       return <TaskPreferencesSurface surface={surface} onAction={onAction} />;
+
+    case "work_result":
+      return <WorkResultSurface surface={surface} onAction={onAction} />;
 
     case "document_preview":
       return (

--- a/apps/web/src/domains/chat/components/surfaces/work-result-surface.stories.tsx
+++ b/apps/web/src/domains/chat/components/surfaces/work-result-surface.stories.tsx
@@ -1,0 +1,619 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+
+import type { Surface } from "@/domains/chat/types/types";
+
+import { SurfaceRouter } from "./surface-router";
+
+const meta: Meta = {
+  title: "Chat/Surfaces/WorkResult",
+  parameters: {
+    layout: "padded",
+  },
+  decorators: [
+    (Story) => (
+      <div className="max-w-[920px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj;
+
+function makeWorkResultSurface(overrides: Partial<Surface> = {}): Surface {
+  return {
+    surfaceId: "work-result-surface",
+    surfaceType: "work_result",
+    title: "Inbox cleaned up",
+    data: {},
+    ...overrides,
+  };
+}
+
+function WorkResultPreview({ surface }: { surface: Surface }) {
+  const [currentSurface, setCurrentSurface] = useState(surface);
+  return (
+    <SurfaceRouter
+      surface={currentSurface}
+      onAction={(_surfaceId, actionId) => {
+        const action = currentSurface.actions?.find(
+          (item) => item.id === actionId,
+        );
+        setCurrentSurface((current) => ({
+          ...current,
+          completed: true,
+          completionSummary: action?.label
+            ? `${action.label} selected`
+            : "Action selected",
+        }));
+      }}
+    />
+  );
+}
+
+const inboxCleanupSurface = makeWorkResultSurface({
+  title: "Inbox cleaned up",
+  data: {
+    eyebrow: "Moment 1 output",
+    status: "completed",
+    summary:
+      "Archived low-signal newsletters, labeled receipts, and surfaced the two threads that actually need a reply.",
+    metrics: [
+      { label: "Archived", value: 31, tone: "positive" },
+      {
+        label: "Labeled",
+        value: 7,
+        detail: "Receipts + travel",
+        tone: "neutral",
+      },
+      { label: "Needs reply", value: 2, tone: "warning" },
+    ],
+    sections: [
+      {
+        id: "attention",
+        title: "Needs attention",
+        type: "items",
+        items: [
+          {
+            id: "contract",
+            title: "Contract follow-up",
+            description:
+              "Alice asked for edits before tomorrow's vendor review.",
+            status: "Reply today",
+            tone: "warning",
+            metadata: [
+              { label: "Mailbox", value: "Work" },
+              { label: "Age", value: "1 day" },
+            ],
+          },
+          {
+            id: "flight",
+            title: "Flight change confirmation",
+            description:
+              "The airline moved the return flight earlier by 45 minutes.",
+            status: "Review",
+            tone: "warning",
+            metadata: [{ label: "Trip", value: "June offsite" }],
+          },
+        ],
+      },
+      {
+        id: "changes",
+        title: "What changed",
+        type: "timeline",
+        items: [
+          {
+            id: "newsletters",
+            title: "Archived recurring newsletters",
+            description: "27 threads from senders you never opened this month.",
+            tone: "positive",
+          },
+          {
+            id: "receipts",
+            title: "Labeled receipts",
+            description: "4 purchase confirmations moved under Receipts.",
+            tone: "positive",
+          },
+        ],
+      },
+    ],
+  },
+  actions: [
+    {
+      id: "review",
+      label: "Review",
+      style: "primary",
+      data: { next: "review_inbox" },
+    },
+    { id: "undo", label: "Undo", data: { next: "undo_inbox_cleanup" } },
+  ],
+});
+
+const calendarPlanSurface = makeWorkResultSurface({
+  surfaceId: "calendar-plan-result",
+  title: "Week reshaped",
+  data: {
+    status: "completed",
+    summary:
+      "Moved meetings away from deep work blocks and left one decision for you because it affects another person.",
+    metrics: [
+      { label: "Focus blocks", value: 5, tone: "positive" },
+      { label: "Conflicts fixed", value: 3, tone: "positive" },
+      { label: "Needs approval", value: 1, tone: "warning" },
+    ],
+    sections: [
+      {
+        id: "timeline",
+        title: "Schedule changes",
+        type: "timeline",
+        items: [
+          {
+            id: "monday",
+            title: "Protected Monday morning",
+            description: "Moved two internal check-ins after lunch.",
+            tone: "positive",
+          },
+          {
+            id: "wednesday",
+            title: "Cleared Wednesday writing block",
+            description: "Converted a sync into async notes.",
+            tone: "positive",
+          },
+          {
+            id: "friday",
+            title: "Left Friday partner review unchanged",
+            description: "Moving it would collide with Bob's calendar.",
+            tone: "warning",
+            status: "Ask first",
+          },
+        ],
+      },
+      {
+        id: "warnings",
+        title: "Open decision",
+        type: "warnings",
+        items: [
+          {
+            id: "partner-review",
+            title: "Friday review could move to 2:30 PM",
+            description:
+              "It creates a cleaner afternoon, but the invite includes an external attendee.",
+            tone: "warning",
+          },
+        ],
+      },
+    ],
+  },
+  actions: [
+    { id: "ask", label: "Ask Bob", style: "primary" },
+    { id: "leave", label: "Leave it" },
+  ],
+});
+
+const documentDraftSurface = makeWorkResultSurface({
+  surfaceId: "document-draft-result",
+  title: "Launch memo tightened",
+  data: {
+    status: "completed",
+    summary:
+      "Turned the rough launch notes into a decision memo with a sharper ask and a shorter executive summary.",
+    metrics: [
+      { label: "Words removed", value: 420, tone: "positive" },
+      { label: "Open comments", value: 3, tone: "warning" },
+      { label: "Sections", value: 5, tone: "neutral" },
+    ],
+    sections: [
+      {
+        id: "diff",
+        title: "Important rewrite",
+        type: "diff",
+        diffs: [
+          {
+            label: "Executive ask",
+            before:
+              "We should probably consider launching the beta if the team feels ready.",
+            after:
+              "Approve a 20-user beta next week with support coverage limited to weekdays.",
+          },
+          {
+            label: "Risk framing",
+            before: "There are some support risks.",
+            after:
+              "The main risk is support volume, mitigated by a hard beta cap and a published response window.",
+          },
+        ],
+      },
+      {
+        id: "artifact",
+        title: "Created artifact",
+        type: "artifacts",
+        items: [
+          {
+            id: "memo",
+            title: "Beta launch decision memo",
+            description: "Saved in the project workspace.",
+            tone: "positive",
+            href: "#",
+            metadata: [
+              { label: "Format", value: "Document" },
+              { label: "Status", value: "Draft" },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  actions: [
+    { id: "open", label: "Open memo", style: "primary" },
+    { id: "comments", label: "Review comments" },
+  ],
+});
+
+const automationSetupSurface = makeWorkResultSurface({
+  surfaceId: "automation-setup-result",
+  title: "Morning briefing scheduled",
+  data: {
+    status: "completed",
+    summary:
+      "Set up a weekday briefing that checks calendar risk, urgent messages, and the project board before work starts.",
+    metrics: [
+      { label: "Sources", value: 4, tone: "neutral" },
+      { label: "Runs", value: "Weekdays", tone: "positive" },
+      { label: "First run", value: "Tomorrow", tone: "positive" },
+    ],
+    sections: [
+      {
+        id: "steps",
+        title: "Automation pieces",
+        type: "timeline",
+        items: [
+          {
+            id: "calendar",
+            title: "Calendar risk check",
+            description: "Looks for conflicts and meetings without prep.",
+            tone: "positive",
+          },
+          {
+            id: "mail",
+            title: "Urgent message scan",
+            description: "Flags threads that need a same-day reply.",
+            tone: "positive",
+          },
+          {
+            id: "tasks",
+            title: "Project board pulse",
+            description: "Summarizes blockers and items due today.",
+            tone: "positive",
+          },
+        ],
+      },
+      {
+        id: "boundaries",
+        title: "Boundaries",
+        type: "warnings",
+        items: [
+          {
+            id: "approval",
+            title: "Draft-only for outbound messages",
+            description:
+              "The assistant will prepare replies but will not send them without approval.",
+            tone: "warning",
+          },
+        ],
+      },
+    ],
+  },
+  actions: [
+    { id: "preview", label: "Preview tomorrow", style: "primary" },
+    { id: "edit", label: "Edit sources" },
+  ],
+});
+
+const oauthConsentSurface = makeWorkResultSurface({
+  surfaceId: "oauth-sequence-result",
+  title: "Google connected for inbox cleanup",
+  data: {
+    status: "completed",
+    summary:
+      "Connected Google at the point of need, then used the granted account to run the inbox cleanup.",
+    metrics: [
+      { label: "Connection", value: "Google", tone: "positive" },
+      { label: "OAuth mode", value: "Managed", tone: "neutral" },
+      { label: "User approvals", value: 2, tone: "positive" },
+    ],
+    sections: [
+      {
+        id: "sequence",
+        title: "Consent and execution path",
+        type: "timeline",
+        items: [
+          {
+            id: "choice",
+            title: "Inbox cleanup selected",
+            description:
+              "The assistant requested Google only after the user chose account-backed work.",
+            tone: "positive",
+          },
+          {
+            id: "connect",
+            title: "Google connected",
+            description:
+              "The managed OAuth surface handled consent without sending the user to settings.",
+            tone: "positive",
+          },
+          {
+            id: "run",
+            title: "Inbox cleanup ran",
+            description:
+              "The assistant used the connected account to archive noise and surface reply threads.",
+            tone: "positive",
+          },
+        ],
+      },
+      {
+        id: "guardrails",
+        title: "Guardrails",
+        type: "warnings",
+        items: [
+          {
+            id: "approval",
+            title: "No silent account work",
+            description:
+              "The assistant waits for the connect surface to complete before running account-backed tools.",
+            tone: "warning",
+          },
+        ],
+      },
+    ],
+  },
+});
+
+const researchSynthesisSurface = makeWorkResultSurface({
+  surfaceId: "research-result",
+  title: "Research condensed",
+  data: {
+    status: "completed",
+    summary:
+      "Collapsed the open notes into three claims, two unresolved questions, and one recommended next decision.",
+    metrics: [
+      { label: "Notes read", value: 18, tone: "neutral" },
+      { label: "Claims", value: 3, tone: "positive" },
+      { label: "Open questions", value: 2, tone: "warning" },
+    ],
+    sections: [
+      {
+        id: "claims",
+        title: "Strongest claims",
+        type: "items",
+        items: [
+          {
+            id: "claim-1",
+            title: "Users understand the value after seeing real work",
+            description:
+              "The strongest signal appears after the assistant changes something visible.",
+            tone: "positive",
+            metadata: [{ label: "Confidence", value: "High" }],
+          },
+          {
+            id: "claim-2",
+            title: "Menus underperform single recommended outcomes",
+            description:
+              "Open-ended offers make users defer; concrete recommendations get acted on.",
+            tone: "positive",
+            metadata: [{ label: "Confidence", value: "Medium" }],
+          },
+        ],
+      },
+      {
+        id: "questions",
+        title: "Still unresolved",
+        type: "warnings",
+        items: [
+          {
+            id: "question-1",
+            title: "How much context is enough before the first outcome?",
+            description:
+              "The notes disagree on whether the port step should always come first.",
+            tone: "warning",
+          },
+          {
+            id: "question-2",
+            title: "Which work receipt gets users to trust the run?",
+            description:
+              "Inbox cleanup and calendar reshaping show different kinds of proof.",
+            tone: "warning",
+          },
+        ],
+      },
+    ],
+  },
+  actions: [
+    { id: "decision", label: "Pick a direction", style: "primary" },
+    { id: "sources", label: "Show sources" },
+  ],
+});
+
+const partialFailureSurface = makeWorkResultSurface({
+  surfaceId: "partial-result",
+  title: "Drive organized, with two skips",
+  data: {
+    status: "partial",
+    summary:
+      "Renamed the files it could identify confidently and left ambiguous items untouched.",
+    metrics: [
+      { label: "Renamed", value: 14, tone: "positive" },
+      { label: "Moved", value: 9, tone: "positive" },
+      { label: "Skipped", value: 2, tone: "warning" },
+    ],
+    sections: [
+      {
+        id: "done",
+        title: "Completed",
+        type: "artifacts",
+        items: [
+          {
+            id: "contracts",
+            title: "Vendor contracts folder",
+            description: "Grouped signed PDFs and renewal drafts.",
+            tone: "positive",
+            metadata: [{ label: "Files", value: 8 }],
+          },
+          {
+            id: "receipts",
+            title: "Receipts folder",
+            description: "Moved purchase confirmations into month folders.",
+            tone: "positive",
+            metadata: [{ label: "Files", value: 6 }],
+          },
+        ],
+      },
+      {
+        id: "skipped",
+        title: "Skipped",
+        type: "warnings",
+        items: [
+          {
+            id: "scan",
+            title: "scan-final-final.pdf",
+            description:
+              "Could be a contract or an invoice; leaving it untouched avoids a bad move.",
+            tone: "warning",
+          },
+          {
+            id: "image",
+            title: "IMG_2048.png",
+            description: "No readable text or surrounding context.",
+            tone: "warning",
+          },
+        ],
+      },
+    ],
+  },
+  actions: [
+    { id: "resolve", label: "Resolve skips", style: "primary" },
+    { id: "done", label: "Looks good" },
+  ],
+});
+
+const compactMetricsSurface = makeWorkResultSurface({
+  surfaceId: "metrics-only-result",
+  title: "Newsletter triage complete",
+  data: {
+    status: "completed",
+    summary: "Applied the rule to the backlog and left the inbox clear.",
+    metrics: [
+      { label: "Archived", value: 86, tone: "positive" },
+      { label: "Senders muted", value: 12, tone: "positive" },
+      { label: "Kept", value: 4, tone: "neutral" },
+    ],
+  },
+});
+
+const activationPortPromptSurface: Surface = {
+  surfaceId: "copy-block-port",
+  surfaceType: "copy_block",
+  data: {
+    label: "Assistant migration prompt",
+    language: "text",
+    text: "Summarize what you know about my work style, recurring tasks, preferences, and workflows that a new assistant should carry forward. Keep it concise but specific.",
+  },
+};
+
+const activationOutcomeChoiceSurface: Surface = {
+  surfaceId: "activation-choice",
+  surfaceType: "choice",
+  title: "Pick the first useful run",
+  data: {
+    description:
+      "Choose where the assistant should spend the next few minutes.",
+    options: [
+      {
+        id: "inbox",
+        title: "Clean up my inbox",
+        description: "Archive noise and surface the threads that need action.",
+        recommended: true,
+      },
+      {
+        id: "calendar",
+        title: "Protect my week",
+        description: "Move low-value meetings away from focus time.",
+      },
+    ],
+  },
+};
+
+const activationFollowThroughSurface: Surface = {
+  surfaceId: "activation-follow-through",
+  surfaceType: "choice",
+  title: "Next best move",
+  data: {
+    description: "The inbox cleanup exposed one obvious follow-through.",
+    options: [
+      {
+        id: "draft-replies",
+        title: "Draft the two replies",
+        description: "Prepare responses for review without sending.",
+        recommended: true,
+      },
+      {
+        id: "setup-briefing",
+        title: "Make this a morning briefing",
+        description: "Run a lighter version every weekday.",
+      },
+    ],
+  },
+};
+
+export const InboxCleanup: Story = {
+  render: () => <WorkResultPreview surface={inboxCleanupSurface} />,
+};
+
+export const CalendarPlanning: Story = {
+  render: () => <WorkResultPreview surface={calendarPlanSurface} />,
+};
+
+export const DocumentDiff: Story = {
+  render: () => <WorkResultPreview surface={documentDraftSurface} />,
+};
+
+export const AutomationSetup: Story = {
+  render: () => <WorkResultPreview surface={automationSetupSurface} />,
+};
+
+export const OAuthConsentResult: Story = {
+  render: () => <WorkResultPreview surface={oauthConsentSurface} />,
+};
+
+export const ResearchSynthesis: Story = {
+  render: () => <WorkResultPreview surface={researchSynthesisSurface} />,
+};
+
+export const PartialFailure: Story = {
+  render: () => <WorkResultPreview surface={partialFailureSurface} />,
+};
+
+export const CompactMetricsOnly: Story = {
+  render: () => <WorkResultPreview surface={compactMetricsSurface} />,
+};
+
+export const ActivationRunStack: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <SurfaceRouter
+        surface={activationPortPromptSurface}
+        onAction={() => {}}
+      />
+      <SurfaceRouter
+        surface={activationOutcomeChoiceSurface}
+        onAction={() => {}}
+      />
+      <WorkResultPreview surface={inboxCleanupSurface} />
+      <SurfaceRouter
+        surface={activationFollowThroughSurface}
+        onAction={() => {}}
+      />
+    </div>
+  ),
+};

--- a/apps/web/src/domains/chat/components/surfaces/work-result-surface.test.tsx
+++ b/apps/web/src/domains/chat/components/surfaces/work-result-surface.test.tsx
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+
+import { SurfaceRouter } from "@/domains/chat/components/surfaces/surface-router";
+import { WorkResultSurface } from "@/domains/chat/components/surfaces/work-result-surface";
+import type { Surface } from "@/domains/chat/types/types";
+
+afterEach(() => {
+  cleanup();
+});
+
+function makeSurface(overrides: Partial<Surface> = {}): Surface {
+  return {
+    surfaceId: "surface-1",
+    surfaceType: "work_result",
+    title: "Inbox cleaned up",
+    data: {
+      status: "completed",
+      summary: "Archived low-signal mail and surfaced the important threads.",
+      metrics: [
+        { label: "Archived", value: 31, tone: "positive" },
+        { label: "Needs reply", value: 2, tone: "warning" },
+      ],
+      sections: [
+        {
+          id: "attention",
+          title: "Needs attention",
+          type: "items",
+          items: [
+            {
+              id: "contract",
+              title: "Contract follow-up",
+              description: "Alice asked for edits before tomorrow.",
+              tone: "warning",
+              status: "Reply today",
+              metadata: [{ label: "Mailbox", value: "Work" }],
+            },
+          ],
+        },
+      ],
+    },
+    ...overrides,
+  };
+}
+
+describe("WorkResultSurface", () => {
+  test("renders metrics, sections, metadata, and action buttons", async () => {
+    const onAction = mock(() => {});
+    const { getByRole, getByText } = render(
+      <WorkResultSurface
+        surface={makeSurface({
+          actions: [
+            { id: "review", label: "Review", style: "primary" },
+            { id: "undo", label: "Undo" },
+          ],
+        })}
+        onAction={onAction}
+      />,
+    );
+
+    expect(getByText("Inbox cleaned up")).toBeTruthy();
+    expect(
+      getByText("Archived low-signal mail and surfaced the important threads."),
+    ).toBeTruthy();
+    expect(getByText("31")).toBeTruthy();
+    expect(getByText("Archived")).toBeTruthy();
+    expect(getByText("Needs attention")).toBeTruthy();
+    expect(getByText("Contract follow-up")).toBeTruthy();
+    expect(getByText("Mailbox:")).toBeTruthy();
+
+    fireEvent.click(getByRole("button", { name: "Review" }));
+
+    await waitFor(() => {
+      expect(onAction).toHaveBeenCalledWith("surface-1", "review", undefined);
+    });
+  });
+
+  test("handles sparse data without crashing", () => {
+    const { getByText } = render(
+      <WorkResultSurface
+        surface={makeSurface({ title: "Done", data: {} })}
+        onAction={() => {}}
+      />,
+    );
+
+    expect(getByText("Done")).toBeTruthy();
+  });
+});
+
+describe("SurfaceRouter", () => {
+  test("routes work_result surfaces", () => {
+    const { queryByText, getByText } = render(
+      <SurfaceRouter surface={makeSurface()} onAction={() => {}} />,
+    );
+
+    expect(queryByText("Unsupported surface type: work_result")).toBeNull();
+    expect(getByText("Inbox cleaned up")).toBeTruthy();
+  });
+});

--- a/apps/web/src/domains/chat/components/surfaces/work-result-surface.tsx
+++ b/apps/web/src/domains/chat/components/surfaces/work-result-surface.tsx
@@ -1,0 +1,544 @@
+import {
+  AlertTriangle,
+  ArrowRight,
+  CheckCircle2,
+  CircleDot,
+  Clock3,
+  ExternalLink,
+  FileText,
+  ListChecks,
+  Sparkles,
+  XCircle,
+} from "lucide-react";
+
+import type { Surface } from "@/domains/chat/types/types";
+
+import { SurfaceContainer } from "@/domains/chat/components/surfaces/surface-container";
+
+type WorkResultStatus = "completed" | "partial" | "failed" | "in_progress";
+type WorkResultTone = "neutral" | "positive" | "warning" | "negative";
+type WorkResultSectionType =
+  | "items"
+  | "timeline"
+  | "diff"
+  | "artifacts"
+  | "warnings";
+
+interface WorkResultMetric {
+  label: string;
+  value: string | number;
+  detail?: string;
+  tone?: WorkResultTone;
+}
+
+interface WorkResultMetadata {
+  label: string;
+  value: string | number;
+}
+
+interface WorkResultItem {
+  id?: string;
+  title: string;
+  description?: string;
+  status?: string;
+  tone?: WorkResultTone;
+  metadata?: WorkResultMetadata[];
+  href?: string;
+}
+
+interface WorkResultDiff {
+  label?: string;
+  before?: string;
+  after?: string;
+}
+
+interface WorkResultSection {
+  id?: string;
+  title: string;
+  description?: string;
+  type?: WorkResultSectionType;
+  items?: WorkResultItem[];
+  diffs?: WorkResultDiff[];
+}
+
+interface WorkResultSurfaceData {
+  eyebrow?: string;
+  status?: WorkResultStatus;
+  summary?: string;
+  metrics?: WorkResultMetric[];
+  sections?: WorkResultSection[];
+}
+
+interface WorkResultSurfaceProps {
+  surface: Surface;
+  onAction: (
+    surfaceId: string,
+    actionId: string,
+    data?: Record<string, unknown>,
+  ) => void;
+}
+
+const STATUS_COPY: Record<
+  WorkResultStatus,
+  { label: string; tone: WorkResultTone }
+> = {
+  completed: { label: "Completed", tone: "positive" },
+  partial: { label: "Partial", tone: "warning" },
+  failed: { label: "Needs attention", tone: "negative" },
+  in_progress: { label: "In progress", tone: "neutral" },
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function asStringOrNumber(value: unknown): string | number | undefined {
+  return typeof value === "string" || typeof value === "number"
+    ? value
+    : undefined;
+}
+
+function asTone(value: unknown): WorkResultTone | undefined {
+  return value === "positive" ||
+    value === "warning" ||
+    value === "negative" ||
+    value === "neutral"
+    ? value
+    : undefined;
+}
+
+function asStatus(value: unknown): WorkResultStatus | undefined {
+  return value === "completed" ||
+    value === "partial" ||
+    value === "failed" ||
+    value === "in_progress"
+    ? value
+    : undefined;
+}
+
+function asSectionType(value: unknown): WorkResultSectionType | undefined {
+  return value === "items" ||
+    value === "timeline" ||
+    value === "diff" ||
+    value === "artifacts" ||
+    value === "warnings"
+    ? value
+    : undefined;
+}
+
+function parseMetadata(value: unknown): WorkResultMetadata[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item) => {
+    if (!isRecord(item)) return [];
+    const label = asString(item.label);
+    const metricValue = asStringOrNumber(item.value);
+    return label && metricValue !== undefined
+      ? [{ label, value: metricValue }]
+      : [];
+  });
+}
+
+function parseItems(value: unknown): WorkResultItem[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item, index) => {
+    if (!isRecord(item)) return [];
+    const title = asString(item.title);
+    if (!title) return [];
+    return [
+      {
+        id: asString(item.id) ?? `${index}`,
+        title,
+        description: asString(item.description),
+        status: asString(item.status),
+        tone: asTone(item.tone),
+        metadata: parseMetadata(item.metadata),
+        href: asString(item.href),
+      },
+    ];
+  });
+}
+
+function parseDiffs(value: unknown): WorkResultDiff[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item) => {
+    if (!isRecord(item)) return [];
+    const before = asString(item.before);
+    const after = asString(item.after);
+    if (!before && !after) return [];
+    return [
+      {
+        label: asString(item.label),
+        before,
+        after,
+      },
+    ];
+  });
+}
+
+function parseMetrics(value: unknown): WorkResultMetric[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item) => {
+    if (!isRecord(item)) return [];
+    const label = asString(item.label);
+    const metricValue = asStringOrNumber(item.value);
+    if (!label || metricValue === undefined) return [];
+    return [
+      {
+        label,
+        value: metricValue,
+        detail: asString(item.detail),
+        tone: asTone(item.tone),
+      },
+    ];
+  });
+}
+
+function parseSections(value: unknown): WorkResultSection[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((section, index) => {
+    if (!isRecord(section)) return [];
+    const title = asString(section.title);
+    if (!title) return [];
+    return [
+      {
+        id: asString(section.id) ?? `${index}`,
+        title,
+        description: asString(section.description),
+        type: asSectionType(section.type),
+        items: parseItems(section.items),
+        diffs: parseDiffs(section.diffs),
+      },
+    ];
+  });
+}
+
+function parseData(value: unknown): WorkResultSurfaceData {
+  if (!isRecord(value)) return {};
+  return {
+    eyebrow: asString(value.eyebrow),
+    status: asStatus(value.status),
+    summary: asString(value.summary),
+    metrics: parseMetrics(value.metrics),
+    sections: parseSections(value.sections),
+  };
+}
+
+function toneClasses(tone: WorkResultTone | undefined): {
+  text: string;
+  bg: string;
+  border: string;
+} {
+  switch (tone) {
+    case "positive":
+      return {
+        text: "text-[var(--system-positive-strong)]",
+        bg: "bg-[var(--system-positive-weak)]",
+        border: "border-[var(--system-positive-weak)]",
+      };
+    case "warning":
+      return {
+        text: "text-[var(--system-mid-strong)]",
+        bg: "bg-[var(--system-mid-weak)]",
+        border: "border-[var(--system-mid-weak)]",
+      };
+    case "negative":
+      return {
+        text: "text-[var(--system-negative-strong)]",
+        bg: "bg-[var(--system-negative-weak)]",
+        border: "border-[var(--system-negative-weak)]",
+      };
+    default:
+      return {
+        text: "text-[var(--content-secondary)]",
+        bg: "bg-[var(--surface-base)]",
+        border: "border-[var(--border-base)]",
+      };
+  }
+}
+
+function ResultStatusBadge({ status }: { status?: WorkResultStatus }) {
+  if (!status) return null;
+  const config = STATUS_COPY[status];
+  const tone = toneClasses(config.tone);
+  const Icon =
+    status === "completed"
+      ? CheckCircle2
+      : status === "partial"
+        ? AlertTriangle
+        : status === "failed"
+          ? XCircle
+          : Clock3;
+
+  return (
+    <span
+      className={`inline-flex shrink-0 items-center gap-1.5 rounded-full px-2 py-0.5 text-label-small-default ${tone.bg} ${tone.text}`}
+    >
+      <Icon className="h-3.5 w-3.5" />
+      {config.label}
+    </span>
+  );
+}
+
+function MetricGrid({ metrics }: { metrics: WorkResultMetric[] }) {
+  if (metrics.length === 0) return null;
+  return (
+    <div className="mt-4 grid gap-px overflow-hidden rounded-md border border-[var(--border-base)] bg-[var(--border-base)] sm:grid-cols-3">
+      {metrics.map((metric) => {
+        const tone = toneClasses(metric.tone);
+        return (
+          <div
+            key={`${metric.label}-${metric.value}`}
+            className="min-w-0 bg-[var(--surface-base)] px-3 py-2.5"
+          >
+            <div className={`text-title-small tabular-nums ${tone.text}`}>
+              {metric.value}
+            </div>
+            <div className="mt-0.5 truncate text-body-small-default text-[var(--content-secondary)]">
+              {metric.label}
+            </div>
+            {metric.detail && (
+              <div className="mt-1 truncate text-body-small-default text-[var(--content-tertiary)]">
+                {metric.detail}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function ItemIcon({
+  item,
+  sectionType,
+}: {
+  item: WorkResultItem;
+  sectionType: WorkResultSectionType;
+}) {
+  const tone = toneClasses(item.tone);
+  const Icon =
+    item.tone === "positive"
+      ? CheckCircle2
+      : item.tone === "warning"
+        ? AlertTriangle
+        : item.tone === "negative"
+          ? XCircle
+          : sectionType === "artifacts"
+            ? FileText
+            : sectionType === "timeline"
+              ? CircleDot
+              : ListChecks;
+
+  return (
+    <span
+      className={`mt-0.5 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md ${tone.bg} ${tone.text}`}
+    >
+      <Icon className="h-3.5 w-3.5" />
+    </span>
+  );
+}
+
+function MetadataRow({ metadata }: { metadata: WorkResultMetadata[] }) {
+  if (metadata.length === 0) return null;
+  return (
+    <div className="mt-1.5 flex flex-wrap gap-1.5">
+      {metadata.map((meta) => (
+        <span
+          key={`${meta.label}-${meta.value}`}
+          className="rounded-full bg-[var(--surface-active)] px-2 py-0.5 text-body-small-default text-[var(--content-tertiary)]"
+        >
+          {meta.label}:{" "}
+          <span className="text-[var(--content-secondary)]">{meta.value}</span>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function ItemList({
+  items,
+  sectionType,
+}: {
+  items: WorkResultItem[];
+  sectionType: WorkResultSectionType;
+}) {
+  if (items.length === 0) return null;
+  return (
+    <div className="mt-3 divide-y divide-[var(--border-base)]">
+      {items.map((item) => (
+        <div
+          key={item.id ?? item.title}
+          className="flex gap-3 py-2.5 first:pt-0 last:pb-0"
+        >
+          <ItemIcon item={item} sectionType={sectionType} />
+          <div className="min-w-0 flex-1">
+            <div className="flex min-w-0 items-start gap-2">
+              <span className="min-w-0 flex-1 text-body-medium-default text-[var(--content-strong)]">
+                {item.title}
+              </span>
+              {item.status && (
+                <span className="shrink-0 rounded-full bg-[var(--surface-active)] px-2 py-0.5 text-label-small-default text-[var(--content-secondary)]">
+                  {item.status}
+                </span>
+              )}
+              {item.href && (
+                <ExternalLink className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[var(--content-tertiary)]" />
+              )}
+            </div>
+            {item.description && (
+              <p className="mt-0.5 text-body-small-default text-[var(--content-quiet)]">
+                {item.description}
+              </p>
+            )}
+            <MetadataRow metadata={item.metadata ?? []} />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function DiffBlock({ diffs }: { diffs: WorkResultDiff[] }) {
+  if (diffs.length === 0) return null;
+  return (
+    <div className="mt-3 space-y-3">
+      {diffs.map((diff, index) => (
+        <div key={`${diff.label ?? "diff"}-${index}`}>
+          {diff.label && (
+            <div className="mb-1 text-label-medium-default text-[var(--content-secondary)]">
+              {diff.label}
+            </div>
+          )}
+          <div className="grid gap-px overflow-hidden rounded-md border border-[var(--border-base)] bg-[var(--border-base)] sm:grid-cols-[1fr_auto_1fr]">
+            <div className="min-w-0 bg-[var(--surface-base)] p-3">
+              <div className="mb-1 text-label-small-default text-[var(--content-tertiary)]">
+                Before
+              </div>
+              <p className="whitespace-pre-wrap text-body-small-default text-[var(--content-secondary)]">
+                {diff.before ?? "Not set"}
+              </p>
+            </div>
+            <div className="hidden items-center bg-[var(--surface-base)] px-2 text-[var(--content-tertiary)] sm:flex">
+              <ArrowRight className="h-4 w-4" />
+            </div>
+            <div className="min-w-0 bg-[var(--surface-base)] p-3">
+              <div className="mb-1 text-label-small-default text-[var(--content-tertiary)]">
+                After
+              </div>
+              <p className="whitespace-pre-wrap text-body-small-default text-[var(--content-strong)]">
+                {diff.after ?? "Removed"}
+              </p>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function SectionIcon({ type }: { type: WorkResultSectionType }) {
+  const Icon =
+    type === "warnings"
+      ? AlertTriangle
+      : type === "artifacts"
+        ? FileText
+        : type === "diff"
+          ? ArrowRight
+          : type === "timeline"
+            ? Clock3
+            : Sparkles;
+  const tone =
+    type === "warnings"
+      ? toneClasses("warning")
+      : type === "artifacts"
+        ? toneClasses("positive")
+        : toneClasses("neutral");
+  return (
+    <span
+      className={`inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md ${tone.bg} ${tone.text}`}
+    >
+      <Icon className="h-4 w-4" />
+    </span>
+  );
+}
+
+function ResultSection({ section }: { section: WorkResultSection }) {
+  const type = section.type ?? "items";
+  return (
+    <section className="border-t border-[var(--border-base)] pt-4 first:border-t-0 first:pt-0">
+      <div className="flex gap-3">
+        <SectionIcon type={type} />
+        <div className="min-w-0 flex-1">
+          <h4 className="text-title-small text-[var(--content-strong)]">
+            {section.title}
+          </h4>
+          {section.description && (
+            <p className="mt-0.5 text-body-small-default text-[var(--content-quiet)]">
+              {section.description}
+            </p>
+          )}
+          {type === "diff" ? (
+            <DiffBlock diffs={section.diffs ?? []} />
+          ) : (
+            <ItemList items={section.items ?? []} sectionType={type} />
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function WorkResultSurface({
+  surface,
+  onAction,
+}: WorkResultSurfaceProps) {
+  const data = parseData(surface.data);
+  const title = surface.title || "Work completed";
+  const sections = data.sections ?? [];
+  const surfaceWithoutContainerTitle = { ...surface, title: undefined };
+
+  return (
+    <SurfaceContainer
+      surface={surfaceWithoutContainerTitle}
+      onAction={onAction}
+    >
+      <div>
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            {data.eyebrow && (
+              <div className="mb-1 text-label-small-default uppercase text-[var(--content-tertiary)]">
+                {data.eyebrow}
+              </div>
+            )}
+            <h3 className="text-title-medium text-[var(--content-strong)]">
+              {title}
+            </h3>
+            {data.summary && (
+              <p className="mt-1 text-body-medium-lighter text-[var(--content-quiet)]">
+                {data.summary}
+              </p>
+            )}
+          </div>
+          <ResultStatusBadge status={data.status} />
+        </div>
+
+        <MetricGrid metrics={data.metrics ?? []} />
+
+        {sections.length > 0 && (
+          <div className="mt-5 space-y-4">
+            {sections.map((section) => (
+              <ResultSection
+                key={section.id ?? section.title}
+                section={section}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </SurfaceContainer>
+  );
+}

--- a/apps/web/src/domains/chat/types/types.test.ts
+++ b/apps/web/src/domains/chat/types/types.test.ts
@@ -110,6 +110,23 @@ describe("isSurfaceInteractive", () => {
     ).toBe(false);
   });
 
+  test("work_result without actions is not interactive", () => {
+    expect(
+      isSurfaceInteractive(makeSurface({ surfaceType: "work_result" })),
+    ).toBe(false);
+  });
+
+  test("work_result with actions is interactive", () => {
+    expect(
+      isSurfaceInteractive(
+        makeSurface({
+          surfaceType: "work_result",
+          actions: [{ id: "review", label: "Review" }],
+        }),
+      ),
+    ).toBe(true);
+  });
+
   test("dynamic_page without actions is not interactive", () => {
     expect(
       isSurfaceInteractive(makeSurface({ surfaceType: "dynamic_page" })),

--- a/apps/web/src/domains/chat/types/types.ts
+++ b/apps/web/src/domains/chat/types/types.ts
@@ -142,9 +142,10 @@ const INHERENTLY_INTERACTIVE_SURFACE_TYPES = [
  * Whether a surface requires user interaction to "complete".
  *
  * A surface is interactive when it either carries explicit action buttons
- * or is an inherently interactive type (choice, oauth_connect, form, confirmation, file_upload).
- * Display-only surfaces — copy blocks, tables, cards, lists, and dynamic pages without
- * actions — are non-interactive and should never block the composer.
+ * or is an inherently interactive type (choice, oauth_connect, form,
+ * confirmation, file_upload, task_preferences). Display-only surfaces — copy
+ * blocks, tables, cards, lists, work results, and dynamic pages without actions
+ * — are non-interactive and should never block the composer.
  */
 export function isSurfaceInteractive(surface: Surface): boolean {
   if (surface.completed) return false;

--- a/assistant/src/__tests__/ui-work-result-surface.test.ts
+++ b/assistant/src/__tests__/ui-work-result-surface.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  createSurfaceMutex,
+  type SurfaceConversationContext,
+  surfaceProxyResolver,
+} from "../daemon/conversation-surfaces.js";
+import type {
+  ServerMessage,
+  SurfaceData,
+  SurfaceType,
+  UiSurfaceShow,
+  UiSurfaceShowWorkResult,
+  WorkResultSurfaceData,
+} from "../daemon/message-protocol.js";
+import { INTERACTIVE_SURFACE_TYPES } from "../daemon/message-protocol.js";
+import { uiShowTool } from "../tools/ui-surface/definitions.js";
+
+function makeContext(sent: ServerMessage[] = []): SurfaceConversationContext {
+  return {
+    conversationId: "session-1",
+    traceEmitter: { emit: () => {} },
+    sendToClient: (msg) => sent.push(msg),
+    pendingSurfaceActions: new Map<string, { surfaceType: SurfaceType }>(),
+    lastSurfaceAction: new Map<
+      string,
+      { actionId: string; data?: Record<string, unknown> }
+    >(),
+    surfaceState: new Map<
+      string,
+      {
+        surfaceType: SurfaceType;
+        data: SurfaceData;
+        title?: string;
+        actions?: Array<{
+          id: string;
+          label: string;
+          style?: string;
+          data?: Record<string, unknown>;
+        }>;
+      }
+    >(),
+    surfaceUndoStacks: new Map<string, string[]>(),
+    accumulatedSurfaceState: new Map<string, Record<string, unknown>>(),
+    surfaceActionRequestIds: new Set<string>(),
+    currentTurnSurfaces: [],
+    isProcessing: () => false,
+    enqueueMessage: () => ({ queued: false, requestId: "req-1" }),
+    getQueueDepth: () => 0,
+    processMessage: async () => "ok",
+    withSurface: createSurfaceMutex(),
+  };
+}
+
+function getSurfaceTypeEnum(): string[] {
+  return (
+    uiShowTool.input_schema as {
+      properties: { surface_type: { enum: string[] } };
+    }
+  ).properties.surface_type.enum;
+}
+
+describe("work_result surface protocol", () => {
+  test("accepts the structured work result data shape", () => {
+    const data: WorkResultSurfaceData = {
+      eyebrow: "Moment 1 output",
+      status: "partial",
+      summary: "Archived low-signal mail and left two threads for review.",
+      metrics: [
+        { label: "Archived", value: 31, tone: "positive" },
+        { label: "Skipped", value: 2, detail: "Needs review", tone: "warning" },
+      ],
+      sections: [
+        {
+          id: "attention",
+          title: "Needs attention",
+          type: "items",
+          items: [
+            {
+              id: "contract",
+              title: "Contract follow-up",
+              description: "Needs a reply today.",
+              status: "Reply today",
+              tone: "warning",
+              metadata: [{ label: "Mailbox", value: "Work" }],
+            },
+          ],
+        },
+        {
+          id: "rewrite",
+          title: "Important rewrite",
+          type: "diff",
+          diffs: [
+            {
+              label: "Executive ask",
+              before: "Consider launching when ready.",
+              after: "Approve a limited beta next week.",
+            },
+          ],
+        },
+      ],
+    };
+
+    const msg: UiSurfaceShowWorkResult = {
+      type: "ui_surface_show",
+      conversationId: "session-1",
+      surfaceId: "surface-1",
+      surfaceType: "work_result",
+      title: "Inbox cleaned up",
+      data,
+    };
+
+    expect(msg.surfaceType).toBe("work_result");
+    expect(msg.data.metrics?.[0].value).toBe(31);
+    expect(msg.data.sections?.[1].type).toBe("diff");
+  });
+
+  test("ui_show advertises work_result as display-only by default", () => {
+    expect(getSurfaceTypeEnum()).toContain("work_result");
+    expect(uiShowTool.description).toContain("work_result");
+    expect(uiShowTool.description).toContain("structured receipt");
+    expect(INTERACTIVE_SURFACE_TYPES).not.toContain("work_result");
+  });
+
+  test("ui_show can emit a work_result surface", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+
+    const result = await surfaceProxyResolver(ctx, "ui_show", {
+      surface_type: "work_result",
+      title: "Inbox cleaned up",
+      data: {
+        status: "completed",
+        summary: "Archived newsletters and surfaced reply threads.",
+        metrics: [{ label: "Archived", value: 31, tone: "positive" }],
+      },
+    });
+
+    expect(result.isError).toBe(false);
+    expect(result.yieldToUser).toBeUndefined();
+
+    const showMessage = sent.find(
+      (msg): msg is UiSurfaceShow => msg.type === "ui_surface_show",
+    );
+    expect(showMessage).toBeDefined();
+    if (!showMessage || showMessage.surfaceType !== "work_result") return;
+
+    expect(showMessage.title).toBe("Inbox cleaned up");
+    expect(showMessage.data.summary).toBe(
+      "Archived newsletters and surfaced reply threads.",
+    );
+    expect(showMessage.data.metrics?.[0]).toEqual({
+      label: "Archived",
+      value: 31,
+      tone: "positive",
+    });
+    expect(ctx.pendingSurfaceActions.has(showMessage.surfaceId)).toBe(false);
+  });
+});

--- a/assistant/src/daemon/message-types/surfaces.ts
+++ b/assistant/src/daemon/message-types/surfaces.ts
@@ -14,7 +14,8 @@ export type SurfaceType =
   | "dynamic_page"
   | "file_upload"
   | "document_preview"
-  | "task_preferences";
+  | "task_preferences"
+  | "work_result";
 
 export const INTERACTIVE_SURFACE_TYPES: SurfaceType[] = [
   "choice",
@@ -192,6 +193,66 @@ export interface DocumentPreviewSurfaceData {
   subtitle?: string;
 }
 
+export type WorkResultStatus =
+  | "completed"
+  | "partial"
+  | "failed"
+  | "in_progress";
+
+export type WorkResultTone = "neutral" | "positive" | "warning" | "negative";
+
+export type WorkResultSectionType =
+  | "items"
+  | "timeline"
+  | "diff"
+  | "artifacts"
+  | "warnings";
+
+export interface WorkResultMetric {
+  label: string;
+  value: string | number;
+  detail?: string;
+  tone?: WorkResultTone;
+}
+
+export interface WorkResultMetadata {
+  label: string;
+  value: string | number;
+}
+
+export interface WorkResultItem {
+  id?: string;
+  title: string;
+  description?: string;
+  status?: string;
+  tone?: WorkResultTone;
+  metadata?: WorkResultMetadata[];
+  href?: string;
+}
+
+export interface WorkResultDiff {
+  label?: string;
+  before?: string;
+  after?: string;
+}
+
+export interface WorkResultSection {
+  id?: string;
+  title: string;
+  description?: string;
+  type?: WorkResultSectionType;
+  items?: WorkResultItem[];
+  diffs?: WorkResultDiff[];
+}
+
+export interface WorkResultSurfaceData {
+  eyebrow?: string;
+  status?: WorkResultStatus;
+  summary?: string;
+  metrics?: WorkResultMetric[];
+  sections?: WorkResultSection[];
+}
+
 export type SurfaceData =
   | CardSurfaceData
   | ChoiceSurfaceData
@@ -203,7 +264,8 @@ export type SurfaceData =
   | ConfirmationSurfaceData
   | DynamicPageSurfaceData
   | FileUploadSurfaceData
-  | DocumentPreviewSurfaceData;
+  | DocumentPreviewSurfaceData
+  | WorkResultSurfaceData;
 
 // === Client → Server ===
 
@@ -294,6 +356,11 @@ export interface UiSurfaceShowDocumentPreview extends UiSurfaceShowBase {
   data: DocumentPreviewSurfaceData;
 }
 
+export interface UiSurfaceShowWorkResult extends UiSurfaceShowBase {
+  surfaceType: "work_result";
+  data: WorkResultSurfaceData;
+}
+
 export type UiSurfaceShow =
   | UiSurfaceShowCard
   | UiSurfaceShowChoice
@@ -305,7 +372,8 @@ export type UiSurfaceShow =
   | UiSurfaceShowConfirmation
   | UiSurfaceShowDynamicPage
   | UiSurfaceShowFileUpload
-  | UiSurfaceShowDocumentPreview;
+  | UiSurfaceShowDocumentPreview
+  | UiSurfaceShowWorkResult;
 
 export interface UiSurfaceUpdate {
   type: "ui_surface_update";

--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -114,7 +114,8 @@ export const uiShowTool = {
     "- confirmation: { message, detail?, confirmLabel?, confirmedLabel?, cancelLabel?, destructive? }\n" +
     "- dynamic_page: { html, width?, height?, preview?: { title, subtitle?, description?, icon?, metrics?: [{ label, value }] } }\n" +
     "- file_upload: { prompt, acceptedTypes?, maxFiles? }\n" +
-    "- task_preferences: {} (no data needed — categories are rendered client-side)\n\n" +
+    "- task_preferences: {} (no data needed — categories are rendered client-side)\n" +
+    '- work_result: { eyebrow?, status?: "completed"|"partial"|"failed"|"in_progress", summary?, metrics?: [{ label, value, detail?, tone?: "neutral"|"positive"|"warning"|"negative" }], sections?: [{ id?, title, description?, type?: "items"|"timeline"|"diff"|"artifacts"|"warnings", items?: [{ id?, title, description?, status?, tone?, metadata?: [{ label, value }], href? }], diffs?: [{ label?, before?, after? }] }] }. Shows a structured receipt after real work: what changed, what was skipped, proof points, and next actions. Keep display-only unless explicit follow-up buttons are needed.\n\n' +
     "Proactively show a task_progress card before multi-step or long-running work (web searches, file operations, research). Show it before your first tool call, then update steps as work progresses.",
   category: "ui-surface",
   defaultRiskLevel: RiskLevel.Low,
@@ -137,6 +138,7 @@ export const uiShowTool = {
           "dynamic_page",
           "file_upload",
           "task_preferences",
+          "work_result",
         ],
         description: "The type of surface to display",
       },


### PR DESCRIPTION
## Summary
- Add a `work_result` chat surface for structured assistant work receipts.
- Route `work_result` through the chat surface router and keep it display-only unless actions are present.
- Add Storybook examples for inbox cleanup, calendar planning, document diffs, automation setup, OAuth consent results, partial failures, compact metrics, and activation-run stacking.

## Verification
- `cd apps/web && bun test src/domains/chat/components/surfaces/work-result-surface.test.tsx`
- `cd apps/web && bun run lint -- src/domains/chat/components/surfaces/work-result-surface.tsx src/domains/chat/components/surfaces/work-result-surface.stories.tsx src/domains/chat/components/surfaces/work-result-surface.test.tsx src/domains/chat/components/surfaces/surface-router.tsx src/domains/chat/types/types.ts`
- `cd apps/web && bun run build-storybook -- --output-dir /tmp/vellum-work-result-storybook`
- pre-commit hook ran apps/web lint and `bunx tsc --noEmit` successfully

Note: the Storybook build still reports existing extensionless-import and chunk-size warnings outside this change.