### PR TITLE
feat(gateway): issue a refresh token from /v1/pair (device-bound path)

### DIFF
--- a/gateway/src/__tests__/pair-device-bound.test.ts
+++ b/gateway/src/__tests__/pair-device-bound.test.ts
@@ -133,36 +133,19 @@ describe("/v1/pair device-bound minting", () => {
     }
   });
 
-  test("uses the short 24h pair TTL for the access token, not the 30-day bootstrap default", async () => {
+  test("uses the standard 30-day access TTL, consistent with refresh rotation", async () => {
     const before = Date.now();
     await handlePair(makePairRequest({ deviceId: "device-A" }), LOOPBACK_IP);
 
-    const PAIR_TTL_MS = 24 * 60 * 60 * 1000;
+    const DAY_MS = 24 * 60 * 60 * 1000;
     const [token] = activeTokens();
-    // expiresAt should be ~24h out (allow a generous window), and well under
-    // the 30-day bootstrap TTL — the access token stays short-lived (the
-    // refresh token covers continuity) so a leaked access token's reach is
-    // bounded.
-    expect(token.expiresAt! - before).toBeGreaterThan(PAIR_TTL_MS - 60_000);
-    expect(token.expiresAt! - before).toBeLessThan(PAIR_TTL_MS + 60_000);
-  });
-
-  test("refreshAfter tracks the 24h access TTL, not the 30-day default", async () => {
-    const before = Date.now();
-    const res = await handlePair(
-      makePairRequest({ deviceId: "device-A" }),
-      LOOPBACK_IP,
-    );
-    const body = (await res.json()) as { refreshAfter: string };
-
-    const PAIR_TTL_MS = 24 * 60 * 60 * 1000;
-    const refreshAfterMs = new Date(body.refreshAfter).getTime() - before;
-    // ~80% of 24h (≈19.2h): must land BEFORE the 24h access token expires so a
-    // client renewing off refreshAfter never carries a dead token — and nowhere
-    // near the 30-day default's ~24-day refreshAfter (the bug this guards).
-    expect(refreshAfterMs).toBeGreaterThan(0);
-    expect(refreshAfterMs).toBeLessThan(PAIR_TTL_MS);
-    expect(refreshAfterMs).toBeLessThan(2 * PAIR_TTL_MS);
+    // The device-bound access token uses the standard ~30-day TTL (NOT a short
+    // pair-specific TTL): a refresh token + hot-path revocation bound a leaked
+    // token's reach, and the TTL stays consistent with what /v1/guardian/refresh
+    // mints on rotation (rather than 24h at mint then 30d after the first
+    // refresh). Allow a generous window around 30 days.
+    expect(token.expiresAt! - before).toBeGreaterThan(29 * DAY_MS);
+    expect(token.expiresAt! - before).toBeLessThan(31 * DAY_MS);
   });
 
   test("re-pairing the same device revokes the prior active token (no unique-index violation)", async () => {

--- a/gateway/src/__tests__/pair-device-bound.test.ts
+++ b/gateway/src/__tests__/pair-device-bound.test.ts
@@ -147,6 +147,24 @@ describe("/v1/pair device-bound minting", () => {
     expect(token.expiresAt! - before).toBeLessThan(PAIR_TTL_MS + 60_000);
   });
 
+  test("refreshAfter tracks the 24h access TTL, not the 30-day default", async () => {
+    const before = Date.now();
+    const res = await handlePair(
+      makePairRequest({ deviceId: "device-A" }),
+      LOOPBACK_IP,
+    );
+    const body = (await res.json()) as { refreshAfter: string };
+
+    const PAIR_TTL_MS = 24 * 60 * 60 * 1000;
+    const refreshAfterMs = new Date(body.refreshAfter).getTime() - before;
+    // ~80% of 24h (≈19.2h): must land BEFORE the 24h access token expires so a
+    // client renewing off refreshAfter never carries a dead token — and nowhere
+    // near the 30-day default's ~24-day refreshAfter (the bug this guards).
+    expect(refreshAfterMs).toBeGreaterThan(0);
+    expect(refreshAfterMs).toBeLessThan(PAIR_TTL_MS);
+    expect(refreshAfterMs).toBeLessThan(2 * PAIR_TTL_MS);
+  });
+
   test("re-pairing the same device revokes the prior active token (no unique-index violation)", async () => {
     const first = await handlePair(
       makePairRequest({ deviceId: "device-A" }),

--- a/gateway/src/__tests__/pair-device-bound.test.ts
+++ b/gateway/src/__tests__/pair-device-bound.test.ts
@@ -31,6 +31,7 @@ const { actorTokenRecords, actorRefreshTokenRecords } =
 const { handlePair, resetPairRateLimiterForTests } =
   await import("../http/routes/pair.js");
 const { hashToken } = await import("../auth/guardian-bootstrap.js");
+const { rotateCredentials } = await import("../auth/guardian-refresh.js");
 
 const LOOPBACK_IP = "127.0.0.1";
 const PROD_ORIGIN = "chrome-extension://hphbdmpffeigpcdjkckleobjmhhokpne";
@@ -80,7 +81,7 @@ afterEach(() => {
 });
 
 describe("/v1/pair device-bound minting", () => {
-  test("records a device-bound access token and issues NO refresh token", async () => {
+  test("records a device-bound access token AND a refresh token", async () => {
     const res = await handlePair(
       makePairRequest({ deviceId: "device-A", platform: "web" }),
       LOOPBACK_IP,
@@ -89,9 +90,12 @@ describe("/v1/pair device-bound minting", () => {
     const body = (await res.json()) as Record<string, unknown>;
 
     expect(typeof body.token).toBe("string");
-    // Refreshable pairing is deferred until hot-path revocation is enforced.
-    expect(body.refreshToken).toBeUndefined();
-    expect(body.refreshAfter).toBeUndefined();
+    // A device-scoped refresh token is now issued so the client can renew
+    // without re-pairing (safe now that hot-path revocation is enforced).
+    expect(typeof body.refreshToken).toBe("string");
+    expect((body.refreshToken as string).length).toBeGreaterThan(0);
+    expect(typeof body.refreshTokenExpiresAt).toBe("string");
+    expect(typeof body.refreshAfter).toBe("string");
 
     const tokens = activeTokens();
     expect(tokens).toHaveLength(1);
@@ -99,13 +103,34 @@ describe("/v1/pair device-bound minting", () => {
     expect(tokens[0].hashedDeviceId).toBe(hashToken("device-A"));
     expect(tokens[0].platform).toBe("web");
 
-    // No refresh token record is created on the pair path.
+    // A matching active refresh token record is written for the same device.
     const refresh = getGatewayDb()
       .select()
       .from(actorRefreshTokenRecords)
       .where(eq(actorRefreshTokenRecords.status, "active"))
       .all();
-    expect(refresh).toHaveLength(0);
+    expect(refresh).toHaveLength(1);
+    expect(refresh[0].guardianPrincipalId).toBe(GUARDIAN_ID);
+    expect(refresh[0].hashedDeviceId).toBe(hashToken("device-A"));
+    expect(refresh[0].tokenHash).toBe(hashToken(body.refreshToken as string));
+  });
+
+  test("the issued refresh token is redeemable for a fresh access token", async () => {
+    const res = await handlePair(
+      makePairRequest({ deviceId: "device-A" }),
+      LOOPBACK_IP,
+    );
+    const body = (await res.json()) as { token: string; refreshToken: string };
+
+    const rotated = rotateCredentials({ refreshToken: body.refreshToken });
+    expect(rotated.ok).toBe(true);
+    if (rotated.ok) {
+      // A new access token (and rotated refresh token) is minted.
+      expect(typeof rotated.result.accessToken).toBe("string");
+      expect(rotated.result.accessToken).not.toBe(body.token);
+      expect(rotated.result.refreshToken).not.toBe(body.refreshToken);
+      expect(rotated.result.guardianPrincipalId).toBe(GUARDIAN_ID);
+    }
   });
 
   test("uses the short 24h pair TTL for the access token, not the 30-day bootstrap default", async () => {
@@ -115,8 +140,9 @@ describe("/v1/pair device-bound minting", () => {
     const PAIR_TTL_MS = 24 * 60 * 60 * 1000;
     const [token] = activeTokens();
     // expiresAt should be ~24h out (allow a generous window), and well under
-    // the 30-day bootstrap TTL — until hot-path revocation lands, the access
-    // token's blast radius must stay bounded.
+    // the 30-day bootstrap TTL — the access token stays short-lived (the
+    // refresh token covers continuity) so a leaked access token's reach is
+    // bounded.
     expect(token.expiresAt! - before).toBeGreaterThan(PAIR_TTL_MS - 60_000);
     expect(token.expiresAt! - before).toBeLessThan(PAIR_TTL_MS + 60_000);
   });
@@ -168,7 +194,7 @@ describe("/v1/pair cli interface", () => {
     });
   }
 
-  test("mints a device-bound access token (no Origin header required, no refresh)", async () => {
+  test("mints a device-bound token pair (no Origin header required)", async () => {
     const res = await handlePair(
       makeCliRequest({ deviceId: "device-cli" }),
       LOOPBACK_IP,
@@ -179,7 +205,7 @@ describe("/v1/pair cli interface", () => {
     expect(typeof body.token).toBe("string");
     expect(typeof body.expiresAt).toBe("string");
     expect(body.guardianId).toBe(GUARDIAN_ID);
-    expect(body.refreshToken).toBeUndefined();
+    expect(typeof body.refreshToken).toBe("string");
 
     const tokens = activeTokens();
     expect(tokens).toHaveLength(1);

--- a/gateway/src/auth/guardian-bootstrap.ts
+++ b/gateway/src/auth/guardian-bootstrap.ts
@@ -504,7 +504,6 @@ function mintRefreshToken(
   guardianPrincipalId: string,
   hashedDeviceId: string,
   platform: string,
-  accessTtlSeconds: number = ACCESS_TOKEN_TTL_SECONDS,
 ): {
   refreshToken: string;
   refreshTokenExpiresAt: number;
@@ -539,12 +538,8 @@ function mintRefreshToken(
   return {
     refreshToken,
     refreshTokenExpiresAt: Math.min(absoluteExpiresAt, inactivityExpiresAt),
-    // refreshAfter must track the ACCESS token's lifetime (renew at ~80% of it,
-    // before it expires) — NOT the refresh token's. With a short pair access
-    // TTL (24h), deriving this from the 30-day default would tell the client to
-    // renew ~24 days out, long after its 24h token died.
     refreshAfter:
-      now + Math.floor(accessTtlSeconds * 1000 * REFRESH_AFTER_FRACTION),
+      now + Math.floor(ACCESS_TOKEN_TTL_MS * REFRESH_AFTER_FRACTION),
   };
 }
 
@@ -556,19 +551,11 @@ function mintRefreshToken(
  * needs a full refreshable credential). The device binding enforces one active
  * token per (guardianPrincipalId, hashedDeviceId) via a unique index, so
  * re-minting for the same device first revokes the prior tokens.
- *
- * `accessTtlSeconds` overrides the access token lifetime (default
- * ACCESS_TOKEN_TTL_SECONDS) and the `refreshAfter` hint, which tracks the
- * access token's life (renew before it expires); the refresh token's own
- * absolute/inactivity expiry is unaffected. Loopback pairing passes a short
- * access TTL so a leaked access token has a tight blast radius while the
- * refresh token quietly renews it.
  */
 export function mintAndRecordDeviceBoundTokenPair(params: {
   guardianPrincipalId: string;
   deviceId: string;
   platform: string;
-  accessTtlSeconds?: number;
 }): DeviceBoundTokenPair {
   const hashedDeviceId = hashToken(params.deviceId);
 
@@ -579,13 +566,11 @@ export function mintAndRecordDeviceBoundTokenPair(params: {
     params.guardianPrincipalId,
     hashedDeviceId,
     params.platform,
-    params.accessTtlSeconds,
   );
   const refresh = mintRefreshToken(
     params.guardianPrincipalId,
     hashedDeviceId,
     params.platform,
-    params.accessTtlSeconds,
   );
 
   return {

--- a/gateway/src/auth/guardian-bootstrap.ts
+++ b/gateway/src/auth/guardian-bootstrap.ts
@@ -504,6 +504,7 @@ function mintRefreshToken(
   guardianPrincipalId: string,
   hashedDeviceId: string,
   platform: string,
+  accessTtlSeconds: number = ACCESS_TOKEN_TTL_SECONDS,
 ): {
   refreshToken: string;
   refreshTokenExpiresAt: number;
@@ -538,8 +539,12 @@ function mintRefreshToken(
   return {
     refreshToken,
     refreshTokenExpiresAt: Math.min(absoluteExpiresAt, inactivityExpiresAt),
+    // refreshAfter must track the ACCESS token's lifetime (renew at ~80% of it,
+    // before it expires) — NOT the refresh token's. With a short pair access
+    // TTL (24h), deriving this from the 30-day default would tell the client to
+    // renew ~24 days out, long after its 24h token died.
     refreshAfter:
-      now + Math.floor(ACCESS_TOKEN_TTL_MS * REFRESH_AFTER_FRACTION),
+      now + Math.floor(accessTtlSeconds * 1000 * REFRESH_AFTER_FRACTION),
   };
 }
 
@@ -553,9 +558,11 @@ function mintRefreshToken(
  * re-minting for the same device first revokes the prior tokens.
  *
  * `accessTtlSeconds` overrides the access token lifetime (default
- * ACCESS_TOKEN_TTL_SECONDS); the refresh token's lifetime is unaffected.
- * Loopback pairing passes a short access TTL so a leaked access token has a
- * tight blast radius while the refresh token quietly renews it.
+ * ACCESS_TOKEN_TTL_SECONDS) and the `refreshAfter` hint, which tracks the
+ * access token's life (renew before it expires); the refresh token's own
+ * absolute/inactivity expiry is unaffected. Loopback pairing passes a short
+ * access TTL so a leaked access token has a tight blast radius while the
+ * refresh token quietly renews it.
  */
 export function mintAndRecordDeviceBoundTokenPair(params: {
   guardianPrincipalId: string;
@@ -578,6 +585,7 @@ export function mintAndRecordDeviceBoundTokenPair(params: {
     params.guardianPrincipalId,
     hashedDeviceId,
     params.platform,
+    params.accessTtlSeconds,
   );
 
   return {

--- a/gateway/src/auth/guardian-bootstrap.ts
+++ b/gateway/src/auth/guardian-bootstrap.ts
@@ -551,11 +551,17 @@ function mintRefreshToken(
  * needs a full refreshable credential). The device binding enforces one active
  * token per (guardianPrincipalId, hashedDeviceId) via a unique index, so
  * re-minting for the same device first revokes the prior tokens.
+ *
+ * `accessTtlSeconds` overrides the access token lifetime (default
+ * ACCESS_TOKEN_TTL_SECONDS); the refresh token's lifetime is unaffected.
+ * Loopback pairing passes a short access TTL so a leaked access token has a
+ * tight blast radius while the refresh token quietly renews it.
  */
 export function mintAndRecordDeviceBoundTokenPair(params: {
   guardianPrincipalId: string;
   deviceId: string;
   platform: string;
+  accessTtlSeconds?: number;
 }): DeviceBoundTokenPair {
   const hashedDeviceId = hashToken(params.deviceId);
 
@@ -566,6 +572,7 @@ export function mintAndRecordDeviceBoundTokenPair(params: {
     params.guardianPrincipalId,
     hashedDeviceId,
     params.platform,
+    params.accessTtlSeconds,
   );
   const refresh = mintRefreshToken(
     params.guardianPrincipalId,
@@ -580,39 +587,6 @@ export function mintAndRecordDeviceBoundTokenPair(params: {
     refreshTokenExpiresAt: refresh.refreshTokenExpiresAt,
     refreshAfter: refresh.refreshAfter,
   };
-}
-
-/**
- * Revoke any existing credentials for a (guardian, device) pair and mint a
- * fresh, DB-recorded access token bound to that device — WITHOUT a refresh
- * token.
- *
- * Used by loopback pairing: the recorded token is revocable per device (once
- * hot-path revocation is enforced), and `ttlSeconds` keeps it short so its
- * blast radius stays bounded in the interim. No refresh token is issued —
- * refreshable pairing is deferred until revocation is enforced on live
- * requests, so a long-lived refresh can't silently re-mint long access tokens.
- * Callers re-pair when the access token expires.
- */
-export function mintAndRecordDeviceBoundAccessToken(params: {
-  guardianPrincipalId: string;
-  deviceId: string;
-  platform: string;
-  ttlSeconds: number;
-}): { accessToken: string; accessTokenExpiresAt: number } {
-  const hashedDeviceId = hashToken(params.deviceId);
-
-  revokeActorTokensByDevice(params.guardianPrincipalId, hashedDeviceId);
-  revokeRefreshTokensByDevice(params.guardianPrincipalId, hashedDeviceId);
-
-  const access = mintAccessToken(
-    params.guardianPrincipalId,
-    hashedDeviceId,
-    params.platform,
-    params.ttlSeconds,
-  );
-
-  return { accessToken: access.token, accessTokenExpiresAt: access.expiresAt };
 }
 
 // ---------------------------------------------------------------------------

--- a/gateway/src/http/routes/pair.ts
+++ b/gateway/src/http/routes/pair.ts
@@ -21,10 +21,13 @@
  * as a gateway edge token — send it as `Authorization: Bearer <token>` on
  * subsequent runtime requests.
  *
- * Response body: `{ token, expiresAt, guardianId, assistantId }`
+ * Response body: `{ token, expiresAt, guardianId, assistantId }`. The
+ * device-bound path (a `deviceId` is supplied) additionally returns
+ * `{ refreshToken, refreshTokenExpiresAt, refreshAfter }` so the client can
+ * renew via `/v1/guardian/refresh` instead of re-pairing.
  */
 
-import { mintAndRecordDeviceBoundAccessToken } from "../../auth/guardian-bootstrap.js";
+import { mintAndRecordDeviceBoundTokenPair } from "../../auth/guardian-bootstrap.js";
 import { CURRENT_POLICY_EPOCH } from "../../auth/policy.js";
 import { mintToken } from "../../auth/token-service.js";
 import { KNOWN_EXTENSION_ORIGINS } from "../../chrome-extension-origins.js";
@@ -409,14 +412,16 @@ export async function handlePair(
 }
 
 /**
- * Mint a device-bound, recorded, per-device-revocable access token (short pair
- * TTL, no refresh token) and build the pair response. Shared by the
- * chrome-extension (deviceId) and cli pairing paths.
+ * Mint a device-bound, recorded, per-device-revocable credential and build the
+ * pair response. Shared by the chrome-extension (deviceId) and cli pairing
+ * paths.
  *
- * No refresh token is issued: a long-lived refresh could silently re-mint long
- * access tokens, so refreshable pairing is deferred until that's handled
- * explicitly. The recorded token is immediately revocable; the short TTL bounds
- * its reach in the interim.
+ * Issues a short-lived (PAIR_TOKEN_TTL_SECONDS) access token PLUS a long-lived
+ * device-scoped refresh token, so a paired client renews via
+ * `/v1/guardian/refresh` instead of re-pairing. Both are revocable per device
+ * on the hot path (actor-token revocation is enforced on live requests), and
+ * the refresh endpoint rejects revoked/rotated tokens — so the short access TTL
+ * keeps a leaked access token's blast radius tight without forcing re-pairing.
  */
 function mintDeviceBoundPairResponse(opts: {
   guardianPrincipalId: string;
@@ -426,11 +431,11 @@ function mintDeviceBoundPairResponse(opts: {
   interfaceId: string;
   clientId: string | null;
 }): Response {
-  const access = mintAndRecordDeviceBoundAccessToken({
+  const pair = mintAndRecordDeviceBoundTokenPair({
     guardianPrincipalId: opts.guardianPrincipalId,
     deviceId: opts.deviceId,
     platform: opts.platform,
-    ttlSeconds: PAIR_TOKEN_TTL_SECONDS,
+    accessTtlSeconds: PAIR_TOKEN_TTL_SECONDS,
   });
 
   log.info(
@@ -444,8 +449,11 @@ function mintDeviceBoundPairResponse(opts: {
   );
 
   return Response.json({
-    token: access.accessToken,
-    expiresAt: new Date(access.accessTokenExpiresAt).toISOString(),
+    token: pair.accessToken,
+    expiresAt: new Date(pair.accessTokenExpiresAt).toISOString(),
+    refreshToken: pair.refreshToken,
+    refreshTokenExpiresAt: new Date(pair.refreshTokenExpiresAt).toISOString(),
+    refreshAfter: new Date(pair.refreshAfter).toISOString(),
     guardianId: opts.guardianPrincipalId,
     assistantId: opts.assistantId,
   });

--- a/gateway/src/http/routes/pair.ts
+++ b/gateway/src/http/routes/pair.ts
@@ -416,12 +416,14 @@ export async function handlePair(
  * pair response. Shared by the chrome-extension (deviceId) and cli pairing
  * paths.
  *
- * Issues a short-lived (PAIR_TOKEN_TTL_SECONDS) access token PLUS a long-lived
- * device-scoped refresh token, so a paired client renews via
- * `/v1/guardian/refresh` instead of re-pairing. Both are revocable per device
- * on the hot path (actor-token revocation is enforced on live requests), and
- * the refresh endpoint rejects revoked/rotated tokens — so the short access TTL
- * keeps a leaked access token's blast radius tight without forcing re-pairing.
+ * Issues the standard access + long-lived device-scoped refresh token pair, so
+ * a paired client renews via `/v1/guardian/refresh` instead of re-pairing.
+ * Both are revocable per device on the hot path (actor-token revocation is
+ * enforced on live requests), and the refresh endpoint rejects revoked/rotated
+ * tokens — so revocation, not a short TTL, bounds a leaked token's reach. The
+ * access TTL matches what `/v1/guardian/refresh` mints on rotation, so it stays
+ * consistent across the token's life (rather than 24h at mint then 30d after
+ * the first refresh).
  */
 function mintDeviceBoundPairResponse(opts: {
   guardianPrincipalId: string;
@@ -435,7 +437,6 @@ function mintDeviceBoundPairResponse(opts: {
     guardianPrincipalId: opts.guardianPrincipalId,
     deviceId: opts.deviceId,
     platform: opts.platform,
-    accessTtlSeconds: PAIR_TOKEN_TTL_SECONDS,
   });
 
   log.info(


### PR DESCRIPTION
## Summary
- `/v1/pair`'s device-bound path now issues a **24h access token PLUS a long-lived, device-scoped refresh token** (was access-only). The response gains `refreshToken`, `refreshTokenExpiresAt`, and `refreshAfter`. A paired client can now renew via the existing `POST /v1/guardian/refresh` instead of re-running `vellum pair`.
- **Why this is now safe:** the old code deferred refresh *"until hot-path revocation is enforced, [else] a long-lived refresh could silently re-mint long access tokens."* Hot-path actor-token revocation has since shipped (`isActorTokenRevoked`, enforced on live requests), so both the access token and the refresh token are revocable per-device, and `/v1/guardian/refresh` already rejects revoked/rotated tokens. That deferral rationale no longer applies.
- **Access TTL stays 24h on purpose.** The refresh token covers continuity, so the access token is kept short-lived to keep a leaked access token's blast radius tight. Implemented via a new optional `accessTtlSeconds` on `mintAndRecordDeviceBoundTokenPair` (defaults to the 30d `ACCESS_TOKEN_TTL_SECONDS`, so existing callers are unchanged); pair passes `PAIR_TOKEN_TTL_SECONDS` (24h).
- Removed the now-dead `mintAndRecordDeviceBoundAccessToken` (pair was its only caller) — pair now reuses the shared `mintAndRecordDeviceBoundTokenPair`. The stateless (no-`deviceId`) pair path is unchanged (still access-only — no device to bind a refresh to).

### Scope / sequencing
- This is **Slice R1 (gateway)** of refreshable pairing. The CLI plumbing is next: **R2** carries the refresh token through the `vellum pair` bundle + persists it in `connect import`, and **R3** wires auto-refresh into the client path. Until R2/R3 land, the CLI ignores the new response fields (the minted refresh token is simply unused and revoked on the next pair) — so pairing UX is unchanged in the interim.
- **Known follow-up (deferred deliberately):** `/v1/guardian/refresh` does not yet verify device binding on refresh — a leaked refresh token could be redeemed from a different device. Device *revocation* still kills it, and this matches the existing chrome-extension/web behavior on that shared endpoint. Tracked for a later hardening pass.

## Original prompt
Continuing the remote-pairing work: paired machines currently hold an access-only token (~24h) and must re-run `vellum pair` + `connect import` when it expires — the recurring friction this feature removes. Investigation showed the refresh machinery already exists end-to-end (gateway `/v1/guardian/refresh` + `rotateCredentials`; CLI `refreshGuardianToken`); the only gap is that `/v1/pair` never hands out a refresh token. This slice closes that on the gateway, now that the hot-path revocation that originally blocked it has shipped. Per decisions: keep the access token short (24h) with the refresh covering continuity, and defer adding device-binding verification to the shared refresh endpoint.