### PR TITLE
fix(gateway): reject browser-origin requests on the /v1/pair cli interface

### DIFF
--- a/gateway/src/__tests__/pair-device-bound.test.ts
+++ b/gateway/src/__tests__/pair-device-bound.test.ts
@@ -201,4 +201,25 @@ describe("/v1/pair cli interface", () => {
     expect(res.status).toBe(403);
     expect(activeTokens()).toHaveLength(0);
   });
+
+  test("rejects a cli request carrying an Origin header (WebView exfiltration vector)", async () => {
+    // A browser/WebView page (e.g. a dynamic surface at *.vellum.local) always
+    // sends an Origin; a real `vellum pair` never does. Such a request would
+    // otherwise pass the loopback guards (it runs on the same machine) and mint
+    // a broadly-scoped token the page could read back via the WebView CORS
+    // allowance — so it must be refused, minting nothing.
+    const req = new Request("http://localhost:7830/v1/pair", {
+      method: "POST",
+      headers: {
+        host: "localhost:7830",
+        "content-type": "application/json",
+        "x-vellum-interface-id": "cli",
+        origin: "https://app.vellum.local",
+      },
+      body: JSON.stringify({ deviceId: "device-cli", platform: "webview" }),
+    });
+    const res = await handlePair(req, LOOPBACK_IP);
+    expect(res.status).toBe(403);
+    expect(activeTokens()).toHaveLength(0);
+  });
 });

--- a/gateway/src/http/routes/pair.ts
+++ b/gateway/src/http/routes/pair.ts
@@ -367,11 +367,22 @@ export async function handlePair(
   }
 
   // CLI pairing (e.g. `vellum pair`): a loopback-local caller mints a
-  // device-bound token for another machine. No extension-origin check applies
-  // (the CLI is not a browser); the loopback / X-Forwarded-For / edge-marker
-  // guards above are the boundary. A deviceId is required — CLI pairing is
-  // always device-scoped (and thus revocable).
+  // device-bound token for another machine. The loopback / X-Forwarded-For /
+  // edge-marker guards above are the boundary. A deviceId is required — CLI
+  // pairing is always device-scoped (and thus revocable).
   if (interfaceId === "cli") {
+    // A real `vellum pair` is a terminal process and never sends an Origin
+    // header; any Origin means a browser/WebView is calling (e.g. dynamic
+    // surface JS at https://<appId>.vellum.local). Reject it: combined with the
+    // gateway's WebView CORS allowance, such JS could otherwise mint and read
+    // back a broadly-scoped actor_client_v1 token. (A local non-browser process
+    // omitting Origin can still mint — that's the intentional loopback trust
+    // model; this guard closes the browser/WebView sandbox-escape vector.)
+    const origin = req.headers.get("origin");
+    if (origin) {
+      auditDeny(req, clientIp, "cli_browser_origin", { origin });
+      return errorResponse("FORBIDDEN", "endpoint is local-only", 403);
+    }
     if (!deviceId) {
       return errorResponse(
         "BAD_REQUEST",


### PR DESCRIPTION
## Summary
- **Security fix:** the `/v1/pair` **cli** interface now rejects (403) any request carrying an `Origin` header. A real `vellum pair` is a terminal process and never sends `Origin`; every browser/WebView fetch always does — so an `Origin` means a browser is calling, which has no legitimate use of the cli pair interface.
- Mirrors the existing `chrome-extension` branch's Origin validation; reuses the same `auditDeny`/`errorResponse` helpers (audit reason `cli_browser_origin`). No other behavior changes — a loopback `vellum pair` (no Origin) still mints a device-bound token exactly as before.

## The vulnerability
The `chrome-extension` pair branch validates `Origin` against `KNOWN_EXTENSION_ORIGINS`, but the **cli** branch did **no** Origin check — only loopback peer IP + loopback `Host` + a `deviceId`. `X-Vellum-Interface-Id` is an attacker-controlled header. Meanwhile the gateway's global CORS reflects any `https://<appId>.vellum.local` WebView origin into `Access-Control-Allow-Origin` on **every** route response (incl. `/v1/pair`), and `ALLOWED_HEADERS` includes `Content-Type` + `X-Vellum-Interface-Id`.

So JavaScript in a dynamic surface (model/app-provided HTML at `https://<appId>.vellum.local` in the WKWebView) could:
```js
fetch('http://127.0.0.1:7830/v1/pair', {
  method: 'POST',
  headers: { 'Content-Type': 'application/json', 'X-Vellum-Interface-Id': 'cli' },
  body: JSON.stringify({ deviceId: crypto.randomUUID(), platform: 'webview' }),
})
```
pass every loopback guard (it runs on the same machine), and **read back** the response via the WebView CORS allowance. The returned token is a broadly-scoped `actor_client_v1` gateway JWT (chat read/write, settings, attachments, approval decisions) — i.e. full local account compromise from sandboxed surface JS.

## The fix
Reject any `Origin`-bearing request on the cli interface, closing the mint at the request layer. The residual case — a local **non-browser** process that omits `Origin` — is the intentional loopback trust model (a local process running as the user already has full machine access, including the token files); this guard specifically defeats the **browser/WebView sandbox-escape** vector.

## Scope / follow-ups
- Surgical: only the cli branch + one regression test. The chrome-extension branch, stateless path, loopback/XFF/edge-marker guards, and CORS middleware are untouched.
- **Defense-in-depth follow-up (separate PR):** exclude `/v1/pair` from the WebView CORS allowance so the response isn't cross-origin-readable even if something mints — a second layer behind this request-layer fix.
- **Prerequisite for #33458:** that PR adds a refresh token to the device-bound pair response; without this guard it would widen this hole's blast radius from a 24h token to a long-lived refreshable credential. #33458 should merge only after this lands.

## Original prompt
A security review of the pairing work found that the `/v1/pair` cli interface (added for `vellum pair`) performs only loopback checks and no Origin validation, while the gateway CORS-allows `*.vellum.local` WebView origins to read responses — letting dynamic-surface JS silently mint and exfiltrate a broadly-scoped actor token. The agreed fix is to reject any browser-origin (Origin-bearing) request on the cli interface, shipped as a standalone change ahead of the refresh-token PR (#33458) that would otherwise amplify the impact.