### PR TITLE
feat(calls): add mu-law→PCM16 decode + resample helper for media-stream STT

### DIFF
--- a/assistant/src/__tests__/media-stream-audio-transcode.test.ts
+++ b/assistant/src/__tests__/media-stream-audio-transcode.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  mulawToPcm16,
+  pcm16ToMulaw,
+  resamplePcm16,
+} from "../calls/media-stream-audio-transcode.js";
+
+/** Build a PCM16 LE buffer from signed sample values. */
+function pcm16Buffer(samples: number[]): Buffer {
+  const buf = Buffer.alloc(samples.length * 2);
+  samples.forEach((s, i) => buf.writeInt16LE(s, i * 2));
+  return buf;
+}
+
+/** Read a PCM16 LE buffer back into an array of signed sample values. */
+function readPcm16(buf: Buffer): number[] {
+  const out: number[] = [];
+  for (let i = 0; i < buf.length; i += 2) out.push(buf.readInt16LE(i));
+  return out;
+}
+
+describe("mulawToPcm16", () => {
+  test("output length is 2x the input length", () => {
+    const mulaw = Uint8Array.from([0x00, 0x7f, 0x80, 0xff, 0x12]);
+    const pcm = mulawToPcm16(mulaw);
+    expect(pcm.length).toBe(mulaw.length * 2);
+  });
+
+  test("empty input yields empty output", () => {
+    expect(mulawToPcm16(new Uint8Array(0)).length).toBe(0);
+  });
+
+  test("round-trips PCM16 through pcm16ToMulaw with bounded error", () => {
+    // A spread of magnitudes and both signs across the dynamic range.
+    const samples = [
+      0, 1, -1, 100, -100, 1000, -1000, 8000, -8000, 20000, -20000, 30000,
+      -30000, 32000, -32000,
+    ];
+    const original = pcm16Buffer(samples);
+
+    const mulaw = pcm16ToMulaw(original);
+    const decoded = readPcm16(mulawToPcm16(mulaw));
+
+    expect(decoded.length).toBe(samples.length);
+
+    // mu-law is lossy; quantization error grows with magnitude. Bound the
+    // relative error rather than asserting exact equality.
+    decoded.forEach((value, i) => {
+      const expected = samples[i]!;
+      const error = Math.abs(value - expected);
+      // mu-law is logarithmic; quantization step grows with magnitude.
+      const tolerance = Math.max(8, Math.abs(expected) * 0.05);
+      expect(error).toBeLessThanOrEqual(tolerance);
+      // Sign must be preserved (except near zero).
+      if (Math.abs(expected) > 256) {
+        expect(Math.sign(value)).toBe(Math.sign(expected));
+      }
+    });
+  });
+});
+
+describe("resamplePcm16", () => {
+  test("8000 -> 8000 is identity", () => {
+    const pcm = pcm16Buffer([0, 1000, -1000, 32000, -32000, 5]);
+    const out = resamplePcm16(pcm, 8000, 8000);
+    expect(out.equals(pcm)).toBe(true);
+    // Returns a copy, not the same backing buffer.
+    expect(out).not.toBe(pcm);
+  });
+
+  test("8000 -> 16000 doubles the sample count", () => {
+    const samples = [0, 1000, 2000, 3000, 4000, 5000, 6000, 7000];
+    const pcm = pcm16Buffer(samples);
+    const out = resamplePcm16(pcm, 8000, 16000);
+    expect(out.length / 2).toBe(samples.length * 2);
+  });
+
+  test("8000 -> 16000 interpolates between source samples", () => {
+    const pcm = pcm16Buffer([0, 100]);
+    const out = readPcm16(resamplePcm16(pcm, 8000, 16000));
+    // First output aligns with the first source sample.
+    expect(out[0]).toBe(0);
+    // An interpolated sample falls between the two source values.
+    const interpolated = out.find((v) => v > 0 && v < 100);
+    expect(interpolated).toBeDefined();
+  });
+
+  test("rejects non-positive sample rates", () => {
+    const pcm = pcm16Buffer([1, 2, 3]);
+    expect(() => resamplePcm16(pcm, 0, 16000)).toThrow();
+    expect(() => resamplePcm16(pcm, 8000, -1)).toThrow();
+  });
+
+  test("empty input yields empty output", () => {
+    expect(resamplePcm16(Buffer.alloc(0), 8000, 16000).length).toBe(0);
+  });
+});

--- a/assistant/src/calls/media-stream-audio-transcode.ts
+++ b/assistant/src/calls/media-stream-audio-transcode.ts
@@ -101,6 +101,92 @@ export function pcm16ToMulaw(pcm: Uint8Array): Buffer {
 }
 
 // ---------------------------------------------------------------------------
+// mu-law to linear PCM conversion (inbound)
+// ---------------------------------------------------------------------------
+
+/**
+ * Decode a single 8-bit mu-law byte to a signed 16-bit linear PCM sample.
+ *
+ * Mirrors {@link linearToMulaw}: Twilio's mu-law bytes are bitwise-inverted,
+ * so we re-invert before extracting the sign (bit 7), exponent (bits 4-6),
+ * and mantissa (bits 0-3), then undo the {@link MULAW_BIAS} offset applied
+ * during encoding to recover the signed linear sample.
+ */
+function mulawToLinear(mulawByte: number): number {
+  // mu-law bytes are bitwise-inverted in Twilio's encoding.
+  const b = ~mulawByte & 0xff;
+  const exponent = (b >> 4) & 0x07;
+  const mantissa = b & 0x0f;
+  const magnitude = (((mantissa << 3) + MULAW_BIAS) << exponent) - MULAW_BIAS;
+  // After re-inversion, bit 7 set means the original sample was negative.
+  return b & 0x80 ? -magnitude : magnitude;
+}
+
+/**
+ * Decode a buffer of 8-bit mu-law bytes to 16-bit signed little-endian PCM.
+ *
+ * This is the inbound counterpart to {@link pcm16ToMulaw}: it turns Twilio
+ * media-stream telephony audio into raw PCM16 suitable for streaming STT.
+ *
+ * @param mulaw - Raw mu-law bytes (one byte per sample).
+ * @returns A Buffer of PCM16 LE samples (twice the length of the input).
+ */
+export function mulawToPcm16(mulaw: Uint8Array): Buffer {
+  const pcm = Buffer.alloc(mulaw.length * 2);
+  for (let i = 0; i < mulaw.length; i++) {
+    pcm.writeInt16LE(mulawToLinear(mulaw[i]!), i * 2);
+  }
+  return pcm;
+}
+
+// ---------------------------------------------------------------------------
+// Resampling
+// ---------------------------------------------------------------------------
+
+/**
+ * Resample a buffer of 16-bit signed little-endian PCM from one sample rate
+ * to another using linear interpolation.
+ *
+ * Supports identity conversions (e.g. 8000→8000) and upsampling needed to
+ * feed 8 kHz telephony audio to streaming transcribers that expect 16 kHz.
+ *
+ * @param pcm - Source PCM16 LE buffer.
+ * @param fromRate - Source sample rate in Hz (must be > 0).
+ * @param toRate - Target sample rate in Hz (must be > 0).
+ * @returns A new PCM16 LE buffer at the target sample rate.
+ */
+export function resamplePcm16(
+  pcm: Buffer,
+  fromRate: number,
+  toRate: number,
+): Buffer {
+  if (fromRate <= 0 || toRate <= 0) {
+    throw new Error(`Invalid sample rate: from=${fromRate} to=${toRate}`);
+  }
+  if (fromRate === toRate) return Buffer.from(pcm);
+
+  const inCount = Math.floor(pcm.length / 2);
+  if (inCount === 0) return Buffer.alloc(0);
+
+  const ratio = toRate / fromRate;
+  const outCount = Math.max(1, Math.round(inCount * ratio));
+  const out = Buffer.alloc(outCount * 2);
+
+  for (let i = 0; i < outCount; i++) {
+    // Position in the source signal that this output sample maps to.
+    const srcPos = i / ratio;
+    const idx = Math.floor(srcPos);
+    const frac = srcPos - idx;
+    const s0 = pcm.readInt16LE(Math.min(idx, inCount - 1) * 2);
+    const s1 = pcm.readInt16LE(Math.min(idx + 1, inCount - 1) * 2);
+    const value = Math.round(s0 + (s1 - s0) * frac);
+    out.writeInt16LE(value, i * 2);
+  }
+
+  return out;
+}
+
+// ---------------------------------------------------------------------------
 // Chunking
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Add mulawToPcm16() decoding Twilio 8-bit µ-law to PCM16 LE
- Add resamplePcm16() (8k→16k linear interp, identity 8k→8k)
- Unit tests for round-trip, length, and resample invariants

Part of plan: migrate-phone-off-conversation-relay.md (PR 1 of 18)