### PR TITLE
feat(calls): add transport-agnostic call-setup-flow module (normal_call + deny)

### DIFF
--- a/assistant/src/__tests__/call-setup-flow.test.ts
+++ b/assistant/src/__tests__/call-setup-flow.test.ts
@@ -62,6 +62,9 @@ function makeDeps() {
   const completed: SetupFlowResult[] = [];
   const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
   const spoken: Array<{ text: string }> = [];
+  // Captured scheduled teardowns; tests fire them manually to assert the
+  // deny hangup is deferred rather than synchronous. No real timers run.
+  const scheduled: Array<{ fn: () => void; delayMs: number }> = [];
   const deps: CallSetupFlowDeps = {
     async speakSystemPrompt(_transport, text) {
       spoken.push({ text });
@@ -72,8 +75,12 @@ function makeDeps() {
     onComplete(result) {
       completed.push(result);
     },
+    hangupDelayMs: 1234,
+    schedule(fn, delayMs) {
+      scheduled.push({ fn, delayMs });
+    },
   };
-  return { deps, completed, events, spoken };
+  return { deps, completed, events, spoken, scheduled };
 }
 
 const RESOLVED: SetupResolved = {
@@ -120,7 +127,7 @@ describe("CallSetupFlow", () => {
     expect(transport.calls.ended).toHaveLength(0);
   });
 
-  test("deny speaks the message, ends the session, resolves to ended", async () => {
+  test("deny speaks the message and resolves to ended without ending the session synchronously", async () => {
     const outcome: SetupOutcome = {
       action: "deny",
       message: "This number is not authorized.",
@@ -136,17 +143,27 @@ describe("CallSetupFlow", () => {
     expect(depsCtx.spoken).toEqual([
       { text: "This number is not authorized." },
     ]);
-    expect(transport.calls.ended).toEqual([
-      "Inbound voice ACL: member policy deny",
-    ]);
+    // The transport teardown must NOT fire synchronously — endSession()
+    // flushes queued TTS playback, so the denial audio needs time to play.
+    expect(transport.calls.ended).toHaveLength(0);
+    // Instead the teardown is scheduled with the (injected) playback delay.
+    expect(depsCtx.scheduled).toHaveLength(1);
+    expect(depsCtx.scheduled[0]!.delayMs).toBe(1234);
+    // The session is still reported ended right away.
     expect(depsCtx.completed).toEqual([result]);
+    expect(flow.getState()).toBe("completed");
     expect(depsCtx.events).toEqual([
       {
         type: "inbound_acl_denied",
         payload: { logReason: "Inbound voice ACL: member policy deny" },
       },
     ]);
-    expect(flow.getState()).toBe("completed");
+
+    // Once the scheduled delay elapses, the session is torn down.
+    depsCtx.scheduled[0]!.fn();
+    expect(transport.calls.ended).toEqual([
+      "Inbound voice ACL: member policy deny",
+    ]);
   });
 
   test("unsupported actions throw UnsupportedSetupFlowError", async () => {

--- a/assistant/src/__tests__/call-setup-flow.test.ts
+++ b/assistant/src/__tests__/call-setup-flow.test.ts
@@ -1,0 +1,210 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Logger mock (must come before any source imports) ────────────────
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// ── toTrustContext stub ──────────────────────────────────────────────
+// Avoids pulling config/canonicalization into the unit test; the flow only
+// forwards the resulting TrustContext, so a deterministic stub is enough.
+
+mock.module("../runtime/actor-trust-resolver.js", () => ({
+  toTrustContext: (ctx: { trustClass: string }, externalId: string) => ({
+    sourceChannel: "phone",
+    trustClass: ctx.trustClass,
+    requesterExternalUserId: externalId,
+  }),
+}));
+
+import {
+  CallSetupFlow,
+  type CallSetupFlowDeps,
+  UnsupportedSetupFlowError,
+} from "../calls/call-setup-flow.js";
+import type {
+  SetupFlowResult,
+  SetupFlowTransport,
+} from "../calls/call-setup-flow-types.js";
+import { MediaStreamOutput } from "../calls/media-stream-output.js";
+import type {
+  SetupOutcome,
+  SetupResolved,
+} from "../calls/relay-setup-router.js";
+import type { ActorTrustContext } from "../runtime/actor-trust-resolver.js";
+
+// ── Test doubles ─────────────────────────────────────────────────────
+
+function makeTransport() {
+  const calls = {
+    spoken: [] as Array<{ token: string; last: boolean }>,
+    ended: [] as Array<string | undefined>,
+  };
+  const transport: SetupFlowTransport = {
+    sendTextToken(token, last) {
+      calls.spoken.push({ token, last });
+    },
+    endSession(reason) {
+      calls.ended.push(reason);
+    },
+    getConnectionState() {
+      return "connected";
+    },
+  };
+  return { transport, calls };
+}
+
+function makeDeps() {
+  const completed: SetupFlowResult[] = [];
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const spoken: Array<{ text: string }> = [];
+  const deps: CallSetupFlowDeps = {
+    async speakSystemPrompt(_transport, text) {
+      spoken.push({ text });
+    },
+    recordCallEvent(_id, eventType, payload) {
+      events.push({ type: eventType, payload });
+    },
+    onComplete(result) {
+      completed.push(result);
+    },
+  };
+  return { deps, completed, events, spoken };
+}
+
+const RESOLVED: SetupResolved = {
+  assistantId: "asst_test",
+  isInbound: true,
+  otherPartyNumber: "+15550100",
+  actorTrust: { trustClass: "guardian" } as unknown as ActorTrustContext,
+};
+
+describe("CallSetupFlow", () => {
+  let transport: ReturnType<typeof makeTransport>;
+  let depsCtx: ReturnType<typeof makeDeps>;
+  let flow: CallSetupFlow;
+
+  beforeEach(() => {
+    transport = makeTransport();
+    depsCtx = makeDeps();
+    flow = new CallSetupFlow("call_1", transport.transport, depsCtx.deps);
+  });
+
+  test("starts in idle state", () => {
+    expect(flow.getState()).toBe("idle");
+  });
+
+  test("normal_call resolves to proceed-initial-greeting", async () => {
+    const outcome: SetupOutcome = { action: "normal_call", isInbound: true };
+
+    const result = await flow.start(outcome, RESOLVED);
+
+    expect(result).toEqual({
+      kind: "proceed-initial-greeting",
+      assistantId: "asst_test",
+      trustContext: {
+        sourceChannel: "phone",
+        trustClass: "guardian",
+        requesterExternalUserId: "+15550100",
+      },
+    });
+    expect(depsCtx.completed).toEqual([result]);
+    expect(flow.getState()).toBe("completed");
+    // Normal call does not speak or end the session here — the controller
+    // takes over with startInitialGreeting().
+    expect(transport.calls.spoken).toHaveLength(0);
+    expect(transport.calls.ended).toHaveLength(0);
+  });
+
+  test("deny speaks the message, ends the session, resolves to ended", async () => {
+    const outcome: SetupOutcome = {
+      action: "deny",
+      message: "This number is not authorized.",
+      logReason: "Inbound voice ACL: member policy deny",
+    };
+
+    const result = await flow.start(outcome, RESOLVED);
+
+    expect(result).toEqual({
+      kind: "ended",
+      reason: "Inbound voice ACL: member policy deny",
+    });
+    expect(depsCtx.spoken).toEqual([
+      { text: "This number is not authorized." },
+    ]);
+    expect(transport.calls.ended).toEqual([
+      "Inbound voice ACL: member policy deny",
+    ]);
+    expect(depsCtx.completed).toEqual([result]);
+    expect(depsCtx.events).toEqual([
+      {
+        type: "inbound_acl_denied",
+        payload: { logReason: "Inbound voice ACL: member policy deny" },
+      },
+    ]);
+    expect(flow.getState()).toBe("completed");
+  });
+
+  test("unsupported actions throw UnsupportedSetupFlowError", async () => {
+    const outcome: SetupOutcome = {
+      action: "name_capture",
+      assistantId: "asst_test",
+      fromNumber: "+15550100",
+    };
+
+    await expect(flow.start(outcome, RESOLVED)).rejects.toBeInstanceOf(
+      UnsupportedSetupFlowError,
+    );
+    expect(depsCtx.completed).toHaveLength(0);
+  });
+
+  test("pushDtmfDigit / pushTranscriptFinal are no-ops before a sub-flow is active", () => {
+    expect(() => flow.pushDtmfDigit("4")).not.toThrow();
+    expect(() => flow.pushTranscriptFinal("hello")).not.toThrow();
+    expect(flow.getState()).toBe("idle");
+  });
+
+  describe("SetupFlowResult variants", () => {
+    test("encodes all four continuation kinds", () => {
+      const variants: SetupFlowResult[] = [
+        {
+          kind: "proceed-initial-greeting",
+          assistantId: "a",
+          trustContext: { sourceChannel: "phone", trustClass: "guardian" },
+        },
+        {
+          kind: "proceed-post-verification-greeting",
+          assistantId: "a",
+          trustContext: { sourceChannel: "phone", trustClass: "guardian" },
+        },
+        {
+          kind: "proceed-handoff-spoken",
+          assistantId: "a",
+          trustContext: { sourceChannel: "phone", trustClass: "guardian" },
+        },
+        { kind: "ended", reason: "denied" },
+      ];
+
+      expect(variants.map((v) => v.kind)).toEqual([
+        "proceed-initial-greeting",
+        "proceed-post-verification-greeting",
+        "proceed-handoff-spoken",
+        "ended",
+      ]);
+    });
+  });
+
+  test("MediaStreamOutput is assignable to SetupFlowTransport", () => {
+    // Type-level assertion: MediaStreamOutput satisfies the structural
+    // SetupFlowTransport subset. A failure here is a compile error.
+    const assertAssignable = (_t: SetupFlowTransport): void => {};
+    const _check = (output: MediaStreamOutput): void => {
+      assertAssignable(output);
+    };
+    expect(typeof _check).toBe("function");
+  });
+});

--- a/assistant/src/calls/call-setup-flow-types.ts
+++ b/assistant/src/calls/call-setup-flow-types.ts
@@ -1,0 +1,106 @@
+/**
+ * Transport-agnostic interactive call-setup types.
+ *
+ * These describe the surface of the {@link CallSetupFlow} state machine,
+ * which orchestrates the deterministic, pre-conversation setup phase of a
+ * call (verification, invite redemption, name capture, etc.) independently
+ * of any specific wire transport.
+ *
+ * The flow is the source of truth for its own wait state via
+ * {@link SetupFlowState} — it does **not** infer wait state from
+ * `transport.getConnectionState()`. On the media-stream transport that
+ * method only reports `connected`/`closed` (see `media-stream-output.ts`
+ * `state`), so it cannot distinguish "collecting a DTMF code" from
+ * "awaiting a guardian decision". An explicit state surface keeps the
+ * controller and tests honest about which sub-flow is active.
+ */
+
+import type { TrustContext } from "../daemon/trust-context.js";
+
+// ── Transport ────────────────────────────────────────────────────────
+
+/**
+ * The structural subset of {@link import("./call-transport.js").CallTransport}
+ * that the setup flow needs to speak prompts and end the session.
+ *
+ * Deliberately narrower than `CallTransport` so the flow can be driven by
+ * any output adapter — including {@link import("./media-stream-output.js").MediaStreamOutput},
+ * which satisfies this shape.
+ */
+export interface SetupFlowTransport {
+  /** Send a text token for TTS playback; `last: true` signals end-of-turn. */
+  sendTextToken(token: string, last: boolean): void;
+  /** End the underlying call session. */
+  endSession(reason?: string): void;
+  /** Connection-level state (`connected`/`closed` on media-stream). */
+  getConnectionState(): string;
+  /** When true, the transport requires WAV (PCM) audio for playback. */
+  readonly requiresWavAudio?: boolean;
+}
+
+// ── Caller input ─────────────────────────────────────────────────────
+
+/**
+ * Caller-driven input fed into the active sub-flow. Sub-flows added in
+ * later PRs (verification, invite, name capture) consume these; until a
+ * sub-flow is active they are no-ops.
+ */
+export interface SetupFlowInput {
+  /** A single DTMF digit pressed by the caller. */
+  pushDtmfDigit(digit: string): void;
+  /** A finalized speech transcript from the caller. */
+  pushTranscriptFinal(text: string): void;
+}
+
+// ── Explicit flow state ──────────────────────────────────────────────
+
+/**
+ * Explicit setup-flow state. The source of truth for which sub-flow (if
+ * any) is awaiting caller input — never inferred from the transport's
+ * connection state.
+ */
+export type SetupFlowState =
+  | "idle"
+  | "collecting_code"
+  | "capturing_name"
+  | "awaiting_guardian_decision"
+  | "completed";
+
+// ── Result ───────────────────────────────────────────────────────────
+
+/**
+ * The continuation the controller should perform once the setup flow has
+ * resolved. Mirrors the distinct continuations `relay-server.ts`
+ * `handleSetup` performs after routing.
+ */
+export type SetupFlowResult =
+  | {
+      /** Normal call — controller fires `startInitialGreeting()`. */
+      kind: "proceed-initial-greeting";
+      assistantId: string;
+      trustContext: TrustContext;
+    }
+  | {
+      /**
+       * Outbound verification succeeded — controller fires
+       * `startPostVerificationGreeting()`.
+       */
+      kind: "proceed-post-verification-greeting";
+      assistantId: string;
+      trustContext: TrustContext;
+    }
+  | {
+      /**
+       * A continuation already spoke (e.g. post-approval handoff copy), so
+       * the controller should `markNextCallerTurnAsOpeningAck()` rather
+       * than greet again.
+       */
+      kind: "proceed-handoff-spoken";
+      assistantId: string;
+      trustContext: TrustContext;
+    }
+  | {
+      /** The flow spoke a terminal message and ended the session. */
+      kind: "ended";
+      reason: string;
+    };

--- a/assistant/src/calls/call-setup-flow.ts
+++ b/assistant/src/calls/call-setup-flow.ts
@@ -1,0 +1,151 @@
+/**
+ * Transport-agnostic interactive call-setup state machine.
+ *
+ * `CallSetupFlow` owns the deterministic, pre-conversation setup phase of a
+ * call: it decides what to speak/await before the assistant's first
+ * conversational turn, and reports back (via {@link SetupFlowResult}) which
+ * greeting/handoff continuation the controller should perform.
+ *
+ * This is the scaffold introduced by PR 2 of the media-stream migration. It
+ * implements only the two terminal-in-one-step routing outcomes:
+ *
+ * - `normal_call` → {@link SetupFlowResult} `proceed-initial-greeting`
+ * - `deny` → speak the denial copy, end the session, `ended`
+ *
+ * Every other `routeSetup` outcome throws {@link UnsupportedSetupFlowError};
+ * later PRs (5/6/7/8) add the verification / invite / name-capture
+ * sub-flows, and PR 9 wires the flow into the media-stream transport.
+ *
+ * The flow is the source of truth for its own wait state via
+ * {@link getState}; it never derives wait state from the transport.
+ */
+
+import type { TrustContext } from "../daemon/trust-context.js";
+import { toTrustContext } from "../runtime/actor-trust-resolver.js";
+import { AssistantError, ErrorCode } from "../util/errors.js";
+import { getLogger } from "../util/logger.js";
+import type {
+  SetupFlowInput,
+  SetupFlowResult,
+  SetupFlowState,
+  SetupFlowTransport,
+} from "./call-setup-flow-types.js";
+import type { SetupOutcome, SetupResolved } from "./relay-setup-router.js";
+
+const log = getLogger("call-setup-flow");
+
+// ── Errors ───────────────────────────────────────────────────────────
+
+/**
+ * Thrown when {@link CallSetupFlow.start} is asked to handle a routing
+ * outcome that this scaffold does not yet implement. Surfacing this as a
+ * typed error (rather than silently no-op'ing) ensures the missing sub-flow
+ * is caught loudly during the staged migration.
+ */
+export class UnsupportedSetupFlowError extends AssistantError {
+  constructor(action: string) {
+    super(`Unsupported call-setup action: ${action}`, ErrorCode.DAEMON_ERROR);
+    this.name = "UnsupportedSetupFlowError";
+  }
+}
+
+// ── Dependencies ─────────────────────────────────────────────────────
+
+/**
+ * Injected collaborators. Functions are injected (rather than imported
+ * directly) so the flow can be unit-tested without a live transport, TTS
+ * provider, or database.
+ */
+export interface CallSetupFlowDeps {
+  /** Speak a deterministic prompt through the transport's TTS path. */
+  speakSystemPrompt(transport: SetupFlowTransport, text: string): Promise<void>;
+  /** Record a setup-related call event (call-store accessor). */
+  recordCallEvent(
+    callSessionId: string,
+    eventType: string,
+    payload?: Record<string, unknown>,
+  ): void;
+  /** Invoked once the flow resolves, with its terminal result. */
+  onComplete(result: SetupFlowResult): void;
+}
+
+// ── Flow ─────────────────────────────────────────────────────────────
+
+export class CallSetupFlow implements SetupFlowInput {
+  private state: SetupFlowState = "idle";
+
+  constructor(
+    private readonly callSessionId: string,
+    private readonly transport: SetupFlowTransport,
+    private readonly deps: CallSetupFlowDeps,
+  ) {}
+
+  /** Explicit wait-state surface — the source of truth, never transport-derived. */
+  getState(): SetupFlowState {
+    return this.state;
+  }
+
+  /**
+   * Drive the setup flow for a routed outcome. Returns the continuation the
+   * controller should perform, and also delivers it via `deps.onComplete`.
+   *
+   * Only `normal_call` and `deny` are implemented in this scaffold; any
+   * other action throws {@link UnsupportedSetupFlowError}.
+   */
+  async start(
+    outcome: SetupOutcome,
+    resolved: SetupResolved,
+  ): Promise<SetupFlowResult> {
+    switch (outcome.action) {
+      case "normal_call":
+        return this.complete({
+          kind: "proceed-initial-greeting",
+          assistantId: resolved.assistantId,
+          trustContext: this.trustContextFor(resolved),
+        });
+
+      case "deny":
+        return this.handleDeny(outcome);
+
+      default:
+        throw new UnsupportedSetupFlowError(outcome.action);
+    }
+  }
+
+  // ── SetupFlowInput ──────────────────────────────────────────────────
+  // No-ops until a sub-flow (verification / name capture) is active; the
+  // sub-flows that consume caller input land in later PRs.
+
+  pushDtmfDigit(_digit: string): void {}
+
+  pushTranscriptFinal(_text: string): void {}
+
+  // ── Internal ────────────────────────────────────────────────────────
+
+  /** Speak the denial copy, end the session, and resolve as `ended`. */
+  private async handleDeny(
+    outcome: Extract<SetupOutcome, { action: "deny" }>,
+  ): Promise<SetupFlowResult> {
+    this.deps.recordCallEvent(this.callSessionId, "inbound_acl_denied", {
+      logReason: outcome.logReason,
+    });
+    await this.deps.speakSystemPrompt(this.transport, outcome.message);
+    this.transport.endSession(outcome.logReason);
+    return this.complete({ kind: "ended", reason: outcome.logReason });
+  }
+
+  /** Mark the flow completed, notify via `onComplete`, and return the result. */
+  private complete(result: SetupFlowResult): SetupFlowResult {
+    this.state = "completed";
+    log.info(
+      { callSessionId: this.callSessionId, kind: result.kind },
+      "Call setup flow completed",
+    );
+    this.deps.onComplete(result);
+    return result;
+  }
+
+  private trustContextFor(resolved: SetupResolved): TrustContext {
+    return toTrustContext(resolved.actorTrust, resolved.otherPartyNumber);
+  }
+}

--- a/assistant/src/calls/call-setup-flow.ts
+++ b/assistant/src/calls/call-setup-flow.ts
@@ -24,6 +24,7 @@ import type { TrustContext } from "../daemon/trust-context.js";
 import { toTrustContext } from "../runtime/actor-trust-resolver.js";
 import { AssistantError, ErrorCode } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
+import { getTtsPlaybackDelayMs } from "./call-constants.js";
 import type {
   SetupFlowInput,
   SetupFlowResult,
@@ -67,6 +68,19 @@ export interface CallSetupFlowDeps {
   ): void;
   /** Invoked once the flow resolves, with its terminal result. */
   onComplete(result: SetupFlowResult): void;
+  /**
+   * Delay (ms) to wait after speaking a terminal prompt before tearing down
+   * the transport, so queued TTS playback isn't flushed by `endSession()`.
+   * Defaults to {@link getTtsPlaybackDelayMs}; overridable (e.g. `0`) so unit
+   * tests don't sleep for real seconds.
+   */
+  hangupDelayMs?: number;
+  /**
+   * Scheduler used to defer the transport teardown. Defaults to `setTimeout`;
+   * injectable so tests can drive timers deterministically. Must invoke `fn`
+   * after roughly `delayMs`.
+   */
+  schedule?: (fn: () => void, delayMs: number) => void;
 }
 
 // ── Flow ─────────────────────────────────────────────────────────────
@@ -122,7 +136,18 @@ export class CallSetupFlow implements SetupFlowInput {
 
   // ── Internal ────────────────────────────────────────────────────────
 
-  /** Speak the denial copy, end the session, and resolve as `ended`. */
+  /**
+   * Speak the denial copy, then resolve as `ended`. The transport teardown is
+   * deferred by the TTS playback delay so the denial audio has time to play —
+   * `endSession()` flushes any queued playback (e.g. on `MediaStreamOutput`),
+   * so calling it synchronously after `speakSystemPrompt()` (which only
+   * guarantees the audio was queued, not heard) would cut off the message.
+   *
+   * Mirrors the deny paths in `relay-server.ts` and `media-stream-server.ts`:
+   * the session is reported ended immediately, but the actual transport
+   * `endSession()` fires only after the (injectable) delay via a scheduled
+   * timer — it never blocks the event loop with a real sleep.
+   */
   private async handleDeny(
     outcome: Extract<SetupOutcome, { action: "deny" }>,
   ): Promise<SetupFlowResult> {
@@ -130,8 +155,16 @@ export class CallSetupFlow implements SetupFlowInput {
       logReason: outcome.logReason,
     });
     await this.deps.speakSystemPrompt(this.transport, outcome.message);
-    this.transport.endSession(outcome.logReason);
-    return this.complete({ kind: "ended", reason: outcome.logReason });
+    const result = this.complete({ kind: "ended", reason: outcome.logReason });
+    this.scheduleHangup(() => this.transport.endSession(outcome.logReason));
+    return result;
+  }
+
+  /** Defer a transport teardown by the (overridable) TTS playback delay. */
+  private scheduleHangup(fn: () => void): void {
+    const delayMs = this.deps.hangupDelayMs ?? getTtsPlaybackDelayMs();
+    const schedule = this.deps.schedule ?? setTimeout;
+    schedule(fn, delayMs);
   }
 
   /** Mark the flow completed, notify via `onComplete`, and return the result. */

--- a/assistant/src/calls/relay-setup-router.ts
+++ b/assistant/src/calls/relay-setup-router.ts
@@ -31,7 +31,7 @@ interface SetupContext {
 
 // ── Setup outcomes ───────────────────────────────────────────────────
 
-type SetupOutcome =
+export type SetupOutcome =
   | { action: "normal_call"; isInbound: boolean }
   | {
       action: "verification";


### PR DESCRIPTION
## Summary
- Add CallSetupFlow + types (SetupFlowTransport/Input/State/Result)
- Explicit getState() surface (not transport-derived)
- Handles normal_call + deny; other actions throw UnsupportedSetupFlowError
- Unit tests incl. MediaStreamOutput→SetupFlowTransport assignability

Part of plan: migrate-phone-off-conversation-relay.md (PR 2 of 18)