### PR TITLE
feat(calls): ensure media-stream TTS provider can synthesize playable audio

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -235,6 +235,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "tts/providers/elevenlabs-provider.ts", // ElevenLabs TTS API key lookup
       "tts/providers/deepgram-provider.ts", // Deepgram TTS API key lookup
       "tts/providers/xai-provider.ts", // xAI TTS API key lookup
+      "calls/telephony-tts-capability.ts", // telephony TTS playability check reads provider key presence (same risk class as the TTS provider modules above)
       "credential-health/credential-health-service.ts", // credential health check reads access tokens for liveness pings
       "ipc/skill-routes/providers.ts", // skill IPC route exposes provider key lookup to hosted skills
       "runtime/routes/avatar-routes.ts", // avatar generate route reads platform_base_url from credential store

--- a/assistant/src/__tests__/media-stream-output.test.ts
+++ b/assistant/src/__tests__/media-stream-output.test.ts
@@ -27,14 +27,23 @@ mock.module("../calls/resolve-call-tts-provider.js", () => ({
     useSynthesizedPath: false,
     audioFormat: "wav" as const,
   })),
+  resolvePlayableCallTtsProvider: jest.fn(async () => ({
+    provider: mockProvider,
+    audioFormat: "wav" as const,
+  })),
 }));
 
 import { MediaStreamOutput } from "../calls/media-stream-output.js";
-import { resolveCallTtsProvider } from "../calls/resolve-call-tts-provider.js";
+import {
+  resolveCallTtsProvider,
+  resolvePlayableCallTtsProvider,
+} from "../calls/resolve-call-tts-provider.js";
 
 const mockResolveCallTtsProvider = resolveCallTtsProvider as ReturnType<
   typeof jest.fn
 >;
+const mockResolvePlayableCallTtsProvider =
+  resolvePlayableCallTtsProvider as ReturnType<typeof jest.fn>;
 
 // ---------------------------------------------------------------------------
 // Mock WebSocket
@@ -117,6 +126,11 @@ afterEach(() => {
   mockResolveCallTtsProvider.mockImplementation(() => ({
     provider: mockProvider,
     useSynthesizedPath: false,
+    audioFormat: "wav" as const,
+  }));
+  // Restore the default media-stream playability-guarded mock
+  mockResolvePlayableCallTtsProvider.mockImplementation(async () => ({
+    provider: mockProvider,
     audioFormat: "wav" as const,
   }));
 });

--- a/assistant/src/__tests__/media-stream-server-integration.test.ts
+++ b/assistant/src/__tests__/media-stream-server-integration.test.ts
@@ -190,6 +190,10 @@ mock.module("../calls/resolve-call-tts-provider.js", () => ({
     useSynthesizedPath: false,
     audioFormat: "mp3" as const,
   })),
+  resolvePlayableCallTtsProvider: jest.fn(async () => ({
+    provider: null,
+    audioFormat: "wav" as const,
+  })),
 }));
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/telephony-tts-guard.test.ts
+++ b/assistant/src/__tests__/telephony-tts-guard.test.ts
@@ -57,6 +57,14 @@ const fakeCatalog: Record<
     mediaStreamPlayback: { outputFormat: "none" },
     key: "k/compressed",
   },
+  // Provider whose catalog requirement uses the standard namespaced api_key
+  // store key (credential/{id}/api_key), exercising the getProviderKeyAsync
+  // path: a key configured only under the legacy bare or env form must still
+  // be recognized as available.
+  "legacy-keyed": {
+    mediaStreamPlayback: { outputFormat: "pcm" },
+    key: "credential/legacy-keyed/api_key",
+  },
 };
 
 mock.module("../tts/provider-catalog.js", () => ({
@@ -79,9 +87,18 @@ mock.module("../tts/provider-catalog.js", () => ({
 
 // Stored credentials keyed by credential store key (mutated per test).
 let storedKeys: Record<string, string> = {};
+// Env-var fallback values keyed by provider id (mutated per test).
+let envProviderKeys: Record<string, string> = {};
 
 mock.module("../security/secure-keys.js", () => ({
   getSecureKeyAsync: async (account: string) => storedKeys[account],
+  // Mirror the real getProviderKeyAsync lookup order: namespaced
+  // credential/{provider}/api_key, then the legacy bare {provider} key, then
+  // an env-var fallback. This is the same lookup the TTS adapters use.
+  getProviderKeyAsync: async (provider: string) =>
+    storedKeys[`credential/${provider}/api_key`] ??
+    storedKeys[provider] ??
+    envProviderKeys[provider],
 }));
 
 // Provider registry — returns a trivial provider for any registered id.
@@ -124,6 +141,7 @@ function makeProvider(id: string): TtsProvider {
 beforeEach(() => {
   configuredProvider = "elevenlabs";
   storedKeys = {};
+  envProviderKeys = {};
   for (const key of Object.keys(registeredProviders)) {
     delete registeredProviders[key];
   }
@@ -186,6 +204,39 @@ describe("resolveTelephonyTtsCapability", () => {
       expect(result.reason).toBe("missing-credentials");
     }
   });
+
+  test("playable when key exists only under the legacy bare store key", async () => {
+    configuredProvider = "legacy-keyed";
+    // Namespaced credential/legacy-keyed/api_key is absent; only the legacy
+    // bare key is present — the adapter (getProviderKeyAsync) would find it.
+    storedKeys["legacy-keyed"] = "sk_legacy";
+
+    const result = await resolveTelephonyTtsCapability();
+    expect(result.status).toBe("playable");
+    expect(result.providerId).toBe("legacy-keyed");
+  });
+
+  test("playable when key exists only via the env-var fallback", async () => {
+    configuredProvider = "legacy-keyed";
+    // Neither store key is set; only the provider env-var fallback resolves.
+    envProviderKeys["legacy-keyed"] = "sk_from_env";
+
+    const result = await resolveTelephonyTtsCapability();
+    expect(result.status).toBe("playable");
+    expect(result.providerId).toBe("legacy-keyed");
+  });
+
+  test("missing-credentials when no key resolves under any lookup", async () => {
+    configuredProvider = "legacy-keyed";
+    // No namespaced, bare, or env key present.
+
+    const result = await resolveTelephonyTtsCapability();
+    expect(result.status).toBe("not-playable");
+    if (result.status === "not-playable") {
+      expect(result.reason).toBe("missing-credentials");
+      expect(result.providerId).toBe("legacy-keyed");
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -200,6 +251,16 @@ describe("isTtsProviderCredentialAvailable", () => {
 
   test("false when no credential is stored", async () => {
     expect(await isTtsProviderCredentialAvailable("elevenlabs")).toBe(false);
+  });
+
+  test("true when only the legacy bare key is set", async () => {
+    storedKeys["legacy-keyed"] = "sk_legacy";
+    expect(await isTtsProviderCredentialAvailable("legacy-keyed")).toBe(true);
+  });
+
+  test("true when only the env-var fallback resolves", async () => {
+    envProviderKeys["legacy-keyed"] = "sk_from_env";
+    expect(await isTtsProviderCredentialAvailable("legacy-keyed")).toBe(true);
   });
 });
 

--- a/assistant/src/__tests__/telephony-tts-guard.test.ts
+++ b/assistant/src/__tests__/telephony-tts-guard.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Telephony TTS playability guard.
+ *
+ * Verifies that media-stream TTS selection keys off declared
+ * `mediaStreamPlayback.outputFormat` metadata PLUS credential availability,
+ * and that an unplayable configured provider falls back to a PCM-capable
+ * default instead of producing a silent call.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { MediaStreamPlaybackFormat } from "../tts/provider-catalog.js";
+import type { TtsProvider, TtsProviderId } from "../tts/types.js";
+
+// ---------------------------------------------------------------------------
+// Mocks — declared before subject imports
+// ---------------------------------------------------------------------------
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+// Configured provider id (mutated per test).
+let configuredProvider: TtsProviderId = "elevenlabs";
+
+mock.module("../config/loader.js", () => ({
+  loadConfig: () => ({ services: { tts: { provider: configuredProvider } } }),
+}));
+
+mock.module("../tts/tts-config-resolver.js", () => ({
+  resolveTtsConfig: () => ({
+    provider: configuredProvider,
+    providerConfig: {},
+  }),
+}));
+
+// Synthetic catalog: each entry declares a media-stream output format and a
+// credential store key. Real adapter behavior is irrelevant to the guard.
+const fakeCatalog: Record<
+  string,
+  {
+    mediaStreamPlayback: { outputFormat: MediaStreamPlaybackFormat };
+    key: string;
+  }
+> = {
+  elevenlabs: { mediaStreamPlayback: { outputFormat: "pcm" }, key: "k/eleven" },
+  "wav-provider": {
+    mediaStreamPlayback: { outputFormat: "wav" },
+    key: "k/wav",
+  },
+  "compressed-only": {
+    mediaStreamPlayback: { outputFormat: "none" },
+    key: "k/compressed",
+  },
+};
+
+mock.module("../tts/provider-catalog.js", () => ({
+  getCatalogProvider: (id: string) => {
+    const entry = fakeCatalog[id];
+    if (!entry) throw new Error(`Unknown TTS provider "${id}"`);
+    return {
+      id,
+      mediaStreamPlayback: entry.mediaStreamPlayback,
+      secretRequirements: [
+        {
+          credentialStoreKey: entry.key,
+          displayName: `${id} key`,
+          setCommand: "set",
+        },
+      ],
+    };
+  },
+}));
+
+// Stored credentials keyed by credential store key (mutated per test).
+let storedKeys: Record<string, string> = {};
+
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKeyAsync: async (account: string) => storedKeys[account],
+}));
+
+// Provider registry — returns a trivial provider for any registered id.
+const registeredProviders: Record<string, TtsProvider> = {};
+mock.module("../tts/provider-registry.js", () => ({
+  getTtsProvider: (id: string) => {
+    const p = registeredProviders[id];
+    if (!p) throw new Error(`Unknown TTS provider "${id}"`);
+    return p;
+  },
+}));
+
+mock.module("../calls/tts-call-strategy.js", () => ({
+  resolveCallStrategy: () => ({
+    providerId: configuredProvider,
+    callMode: "synthesized-play",
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Subject imports (after mocks)
+// ---------------------------------------------------------------------------
+
+import { resolvePlayableCallTtsProvider } from "../calls/resolve-call-tts-provider.js";
+import {
+  isTtsProviderCredentialAvailable,
+  resolveTelephonyTtsCapability,
+} from "../calls/telephony-tts-capability.js";
+
+function makeProvider(id: string): TtsProvider {
+  return {
+    id,
+    capabilities: { supportsStreaming: false, supportedFormats: ["pcm"] },
+    async synthesize() {
+      return { audio: Buffer.from(""), contentType: "audio/pcm" };
+    },
+  };
+}
+
+beforeEach(() => {
+  configuredProvider = "elevenlabs";
+  storedKeys = {};
+  for (const key of Object.keys(registeredProviders)) {
+    delete registeredProviders[key];
+  }
+  registeredProviders.elevenlabs = makeProvider("elevenlabs");
+});
+
+// ---------------------------------------------------------------------------
+// resolveTelephonyTtsCapability
+// ---------------------------------------------------------------------------
+
+describe("resolveTelephonyTtsCapability", () => {
+  test("pcm provider with credentials is playable", async () => {
+    configuredProvider = "elevenlabs";
+    storedKeys["k/eleven"] = "sk_test";
+
+    const result = await resolveTelephonyTtsCapability();
+    expect(result.status).toBe("playable");
+    expect(result.providerId).toBe("elevenlabs");
+  });
+
+  test("wav provider with credentials is playable", async () => {
+    configuredProvider = "wav-provider";
+    storedKeys["k/wav"] = "sk_test";
+
+    const result = await resolveTelephonyTtsCapability();
+    expect(result.status).toBe("playable");
+  });
+
+  test("none-format provider is not-playable (unsupported-format)", async () => {
+    configuredProvider = "compressed-only";
+    storedKeys["k/compressed"] = "sk_test"; // credential present, format still no good
+
+    const result = await resolveTelephonyTtsCapability();
+    expect(result.status).toBe("not-playable");
+    if (result.status === "not-playable") {
+      expect(result.reason).toBe("unsupported-format");
+      expect(result.providerId).toBe("compressed-only");
+    }
+  });
+
+  test("pcm provider with no key is not-playable (missing-credentials)", async () => {
+    configuredProvider = "elevenlabs";
+    // No stored key.
+
+    const result = await resolveTelephonyTtsCapability();
+    expect(result.status).toBe("not-playable");
+    if (result.status === "not-playable") {
+      expect(result.reason).toBe("missing-credentials");
+      expect(result.providerId).toBe("elevenlabs");
+    }
+  });
+
+  test("blank credential is treated as missing", async () => {
+    configuredProvider = "elevenlabs";
+    storedKeys["k/eleven"] = "   ";
+
+    const result = await resolveTelephonyTtsCapability();
+    expect(result.status).toBe("not-playable");
+    if (result.status === "not-playable") {
+      expect(result.reason).toBe("missing-credentials");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isTtsProviderCredentialAvailable (reusable helper)
+// ---------------------------------------------------------------------------
+
+describe("isTtsProviderCredentialAvailable", () => {
+  test("true when the catalog credential key has a value", async () => {
+    storedKeys["k/eleven"] = "sk_test";
+    expect(await isTtsProviderCredentialAvailable("elevenlabs")).toBe(true);
+  });
+
+  test("false when no credential is stored", async () => {
+    expect(await isTtsProviderCredentialAvailable("elevenlabs")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolvePlayableCallTtsProvider fallback
+// ---------------------------------------------------------------------------
+
+describe("resolvePlayableCallTtsProvider", () => {
+  test("returns the configured provider when it is playable", async () => {
+    configuredProvider = "wav-provider";
+    storedKeys["k/wav"] = "sk_test";
+    registeredProviders["wav-provider"] = makeProvider("wav-provider");
+
+    const result = await resolvePlayableCallTtsProvider();
+    expect(result.provider).not.toBeNull();
+    expect(result.provider!.id).toBe("wav-provider");
+    expect(result.audioFormat).toBe("wav");
+  });
+
+  test("falls back to the PCM-capable default when format is unsupported", async () => {
+    configuredProvider = "compressed-only";
+    storedKeys["k/compressed"] = "sk_test";
+    storedKeys["k/eleven"] = "sk_default"; // default provider is credentialed
+
+    const result = await resolvePlayableCallTtsProvider();
+    // No silent path: a usable provider is returned (the default), not null.
+    expect(result.provider).not.toBeNull();
+    expect(result.provider!.id).toBe("elevenlabs");
+    expect(result.audioFormat).toBe("wav");
+  });
+
+  test("falls back to the PCM-capable default when credentials are missing", async () => {
+    configuredProvider = "wav-provider"; // playable format but no key
+    storedKeys["k/eleven"] = "sk_default";
+    registeredProviders["wav-provider"] = makeProvider("wav-provider");
+
+    const result = await resolvePlayableCallTtsProvider();
+    expect(result.provider).not.toBeNull();
+    expect(result.provider!.id).toBe("elevenlabs");
+  });
+});

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -50,7 +50,10 @@ import type { CallTransport } from "./call-transport.js";
 import { finalizeCall } from "./finalize-call.js";
 import { sendGuardianExpiryNotices } from "./guardian-action-sweep.js";
 import { dispatchGuardianQuestion } from "./guardian-dispatch.js";
-import { resolveCallTtsProvider } from "./resolve-call-tts-provider.js";
+import {
+  resolveCallTtsProvider,
+  resolvePlayableCallTtsProvider,
+} from "./resolve-call-tts-provider.js";
 import type { PromptSpeakerContext } from "./speaker-identification.js";
 import { sanitizeForTts } from "./tts-text-sanitizer.js";
 import {
@@ -588,13 +591,24 @@ export class CallController {
     // audio chunks to Twilio via play-URL. Native-twilio providers
     // stream text tokens to the relay for Twilio's built-in TTS.
     //
-    // When the transport requires WAV (media-stream), request WAV so
-    // the audio store entry and any downstream fetch/transcode receives
-    // PCM that audioBufferToFrames can convert to mu-law.
-    const { provider, useSynthesizedPath, audioFormat } =
-      resolveCallTtsProvider({
-        preferWav: this.transport.requiresWavAudio,
-      });
+    // When the transport requires WAV (media-stream), ALL telephony audio is
+    // daemon-synthesized then transcoded PCM -> mu-law, so we MUST use the
+    // synthesized path with a provider that can actually emit playable audio.
+    // The playability guard falls back to a PCM-capable, credentialed default
+    // when the configured provider can't, avoiding a silent call. Otherwise
+    // (native Twilio relay), use the catalog-driven call-mode resolution.
+    let provider: TtsProvider | null;
+    let useSynthesizedPath: boolean;
+    let audioFormat: "mp3" | "wav" | "opus";
+    if (this.transport.requiresWavAudio) {
+      const playable = await resolvePlayableCallTtsProvider();
+      provider = playable.provider;
+      useSynthesizedPath = provider != null;
+      audioFormat = playable.audioFormat;
+    } else {
+      ({ provider, useSynthesizedPath, audioFormat } =
+        resolveCallTtsProvider());
+    }
 
     // Buffer incoming tokens so we can strip control markers ([ASK_GUARDIAN:...], [END_CALL])
     // before they reach TTS. We hold text whenever an unmatched '[' appears, since it

--- a/assistant/src/calls/call-speech-output.ts
+++ b/assistant/src/calls/call-speech-output.ts
@@ -21,7 +21,10 @@ import type { TtsProvider, TtsProviderId } from "../tts/types.js";
 import { getLogger } from "../util/logger.js";
 import { createStreamingEntry } from "./audio-store.js";
 import type { CallTransport } from "./call-transport.js";
-import { resolveCallTtsProvider } from "./resolve-call-tts-provider.js";
+import {
+  resolveCallTtsProvider,
+  resolvePlayableCallTtsProvider,
+} from "./resolve-call-tts-provider.js";
 
 const log = getLogger("call-speech-output");
 
@@ -46,13 +49,16 @@ export function speakSystemPrompt(
   relay: CallTransport,
   text: string,
 ): Promise<void> {
-  // When the transport requires WAV (media-stream), request WAV so
-  // the audio store entry contains PCM that audioBufferToFrames can
-  // transcode to mu-law. Without this, compressed formats (mp3, opus)
-  // are fetched by processFetchUrlItem and produce garbled audio.
-  const { provider, useSynthesizedPath, audioFormat } = resolveCallTtsProvider({
-    preferWav: relay.requiresWavAudio,
-  });
+  // Media-stream transport: ALL audio is daemon-synthesized then transcoded
+  // PCM -> mu-law, so the provider MUST be able to emit playable audio. Use
+  // the playability guard, which falls back to a PCM-capable, credentialed
+  // default when the configured provider can't (avoiding a silent call).
+  if (relay.requiresWavAudio) {
+    return speakSystemPromptOverMediaStream(relay, text);
+  }
+
+  const { provider, useSynthesizedPath, audioFormat } =
+    resolveCallTtsProvider();
 
   if (!useSynthesizedPath || !provider) {
     // Native path — send text for Twilio's built-in TTS.
@@ -61,6 +67,31 @@ export function speakSystemPrompt(
   }
 
   // Synthesized path — synthesize audio and send play URL.
+  return synthesizeAndPlay(relay, provider, text, audioFormat);
+}
+
+/**
+ * Speak a deterministic prompt over the media-stream transport.
+ *
+ * Always synthesizes through a playability-guarded provider so the prompt is
+ * audible. There is no "send only an end-of-turn signal" silent path here —
+ * if the configured provider can't emit playable audio, the guard has already
+ * substituted a PCM-capable default.
+ */
+async function speakSystemPromptOverMediaStream(
+  relay: CallTransport,
+  text: string,
+): Promise<void> {
+  const { provider, audioFormat } = await resolvePlayableCallTtsProvider();
+  if (!provider) {
+    // No provider resolvable at all (e.g. registry empty in early startup).
+    // Send the end-of-turn signal so the relay transitions back to listening.
+    log.error(
+      "No playable media-stream TTS provider available for system prompt",
+    );
+    relay.sendTextToken("", true);
+    return;
+  }
   return synthesizeAndPlay(relay, provider, text, audioFormat);
 }
 

--- a/assistant/src/calls/media-stream-output.ts
+++ b/assistant/src/calls/media-stream-output.ts
@@ -394,14 +394,13 @@ export class MediaStreamOutput implements CallTransport {
     this.activePlaybackAbort = abortController;
 
     try {
-      const { resolveCallTtsProvider } =
+      const { resolvePlayableCallTtsProvider } =
         await import("./resolve-call-tts-provider.js");
-      // Request WAV so audioBufferToFrames gets PCM it can transcode
-      // to mu-law. Compressed formats (mp3, opus) would be sent as raw
-      // bytes and produce garbled audio.
-      const { provider, audioFormat } = resolveCallTtsProvider({
-        preferWav: true,
-      });
+      // Resolve a provider guaranteed to emit transcodable (PCM/WAV) audio.
+      // When the configured provider can't feed the PCM -> mu-law transcoder
+      // (or its credential is missing), the guard falls back to a PCM-capable
+      // default instead of leaving the call silent.
+      const { provider, audioFormat } = await resolvePlayableCallTtsProvider();
       if (!provider) {
         log.warn(
           { streamSid: this.streamSid },

--- a/assistant/src/calls/resolve-call-tts-provider.ts
+++ b/assistant/src/calls/resolve-call-tts-provider.ts
@@ -12,6 +12,10 @@ import { getTtsProvider } from "../tts/provider-registry.js";
 import { resolveTtsConfig } from "../tts/tts-config-resolver.js";
 import type { TtsProvider } from "../tts/types.js";
 import { getLogger } from "../util/logger.js";
+import {
+  DEFAULT_PLAYABLE_TTS_PROVIDER,
+  resolveTelephonyTtsCapability,
+} from "./telephony-tts-capability.js";
 import { resolveCallStrategy } from "./tts-call-strategy.js";
 
 const log = getLogger("resolve-call-tts-provider");
@@ -37,21 +41,6 @@ export interface ResolvedCallTts {
 }
 
 // ---------------------------------------------------------------------------
-// Options
-// ---------------------------------------------------------------------------
-
-export interface ResolveCallTtsOptions {
-  /**
-   * When true, force `audioFormat` to `"wav"` regardless of the
-   * provider's configured format. The media-stream transport sets this
-   * because its {@link audioBufferToFrames} can only correctly
-   * transcode WAV (PCM) to mu-law -- compressed formats (mp3, opus)
-   * are sent as raw bytes and produce garbled audio.
-   */
-  preferWav?: boolean;
-}
-
-// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
@@ -69,10 +58,12 @@ export interface ResolveCallTtsOptions {
  * Falls back to the native path with `mp3` format when the config is
  * missing a `services.tts` block or the provider is not registered
  * (e.g. unit tests or early startup).
+ *
+ * For the media-stream call path (where every byte is transcoded
+ * PCM -> mu-law), use {@link resolvePlayableCallTtsProvider} instead --
+ * it guarantees a provider that can emit playable audio.
  */
-export function resolveCallTtsProvider(
-  options?: ResolveCallTtsOptions,
-): ResolvedCallTts {
+export function resolveCallTtsProvider(): ResolvedCallTts {
   try {
     const config = loadConfig();
     const resolved = resolveTtsConfig(config);
@@ -109,22 +100,15 @@ export function resolveCallTtsProvider(
     // Read the user-configured audio format from the resolved provider
     // config so the streaming store entry's content-type matches the
     // actual audio bytes the provider produces.
-    //
-    // When preferWav is set (media-stream transport), force WAV so
-    // audioBufferToFrames receives PCM it can transcode to mu-law.
-    const audioFormat: "mp3" | "wav" | "opus" = options?.preferWav
-      ? "wav"
-      : (() => {
-          const configuredFormat = (
-            resolved.providerConfig as { format?: string }
-          ).format;
-          return (
-            configuredFormat &&
-            ["mp3", "wav", "opus"].includes(configuredFormat)
-              ? configuredFormat
-              : "mp3"
-          ) as "mp3" | "wav" | "opus";
-        })();
+    const audioFormat: "mp3" | "wav" | "opus" = (() => {
+      const configuredFormat = (resolved.providerConfig as { format?: string })
+        .format;
+      return (
+        configuredFormat && ["mp3", "wav", "opus"].includes(configuredFormat)
+          ? configuredFormat
+          : "mp3"
+      ) as "mp3" | "wav" | "opus";
+    })();
 
     return { provider, useSynthesizedPath, audioFormat };
   } catch {
@@ -132,5 +116,67 @@ export function resolveCallTtsProvider(
     // (e.g. unit tests or early startup) -- fall back to the native
     // path where the provider object is not used.
     return { provider: null, useSynthesizedPath: false, audioFormat: "mp3" };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Media-stream playability guard
+// ---------------------------------------------------------------------------
+
+/** A media-stream TTS provider guaranteed to emit transcodable audio. */
+export interface PlayableCallTts {
+  /** The resolved, PCM/WAV-capable, credentialed provider (or null). */
+  provider: TtsProvider | null;
+
+  /** Audio format to request for synthesized audio (always `"wav"`). */
+  audioFormat: "wav";
+}
+
+/**
+ * Resolve a TTS provider for the **media-stream** call path, guaranteeing
+ * that the returned provider can actually feed the PCM -> mu-law transcoder.
+ *
+ * On media-stream every byte of telephony audio is daemon-synthesized and
+ * transcoded, so a provider that cannot emit PCM/WAV (or whose credential is
+ * missing) would produce a silent call. When the configured provider is
+ * {@link resolveTelephonyTtsCapability not playable}, this falls back to a
+ * known PCM-capable, credentialed default ({@link DEFAULT_PLAYABLE_TTS_PROVIDER})
+ * instead of leaving the call silent, logging a clear warning with the
+ * configured provider id and the reason.
+ *
+ * Returns `{ provider: null }` only when neither the configured provider nor
+ * the fallback can be resolved (e.g. registry empty in tests / early startup),
+ * so callers can degrade without throwing.
+ */
+export async function resolvePlayableCallTtsProvider(): Promise<PlayableCallTts> {
+  try {
+    const capability = await resolveTelephonyTtsCapability();
+
+    if (capability.status === "playable") {
+      return {
+        provider: getTtsProvider(capability.providerId),
+        audioFormat: "wav",
+      };
+    }
+
+    // Configured provider cannot feed the media-stream transcoder. Fall back
+    // to a known PCM-capable, credentialed default rather than emitting a
+    // silent call.
+    log.warn(
+      {
+        configuredProvider: capability.providerId,
+        reason: capability.reason,
+        fallbackProvider: DEFAULT_PLAYABLE_TTS_PROVIDER,
+      },
+      "Configured media-stream TTS provider cannot synthesize playable audio — " +
+        "falling back to a PCM-capable default",
+    );
+    return {
+      provider: getTtsProvider(DEFAULT_PLAYABLE_TTS_PROVIDER),
+      audioFormat: "wav",
+    };
+  } catch {
+    // Config missing / provider not registered (e.g. tests, early startup).
+    return { provider: null, audioFormat: "wav" };
   }
 }

--- a/assistant/src/calls/telephony-tts-capability.ts
+++ b/assistant/src/calls/telephony-tts-capability.ts
@@ -21,7 +21,11 @@
  */
 
 import { loadConfig } from "../config/loader.js";
-import { getSecureKeyAsync } from "../security/secure-keys.js";
+import { credentialKey } from "../security/credential-key.js";
+import {
+  getProviderKeyAsync,
+  getSecureKeyAsync,
+} from "../security/secure-keys.js";
 import {
   getCatalogProvider,
   type MediaStreamPlaybackFormat,
@@ -70,13 +74,24 @@ export type TelephonyTtsCapability =
 // ---------------------------------------------------------------------------
 
 /**
- * Returns true when the given provider's credential is available in the
- * secure store.
+ * Returns true when the given provider's credential is available under the
+ * SAME lookup semantics the TTS adapters use to read their key.
  *
- * Keys off the provider's `secretRequirements` in the canonical catalog
- * (the `credentialStoreKey`), so the check stays in lockstep with the
- * declared requirements. A provider with no declared secret requirements is
- * treated as always-available (e.g. keyless local providers).
+ * The real adapters (e.g. the Deepgram adapter) resolve their key via
+ * {@link getProviderKeyAsync}, which consults — in order — the namespaced
+ * `credential/{provider}/api_key` store key, the legacy bare `{provider}`
+ * store key, and the provider's env-var fallback. Probing only the catalog's
+ * namespaced `credentialStoreKey` here would report a legacy- or
+ * env-configured key as missing, wrongly triggering the fallback (or silence)
+ * even though synthesis would actually succeed.
+ *
+ * Behavior is preserved for providers that declare a non-standard catalog
+ * `credentialStoreKey` (one that is not `credential/{providerId}/api_key`):
+ * those keys are still probed directly via {@link getSecureKeyAsync}, since
+ * {@link getProviderKeyAsync} would not know to look for them.
+ *
+ * A provider with no declared secret requirements is treated as
+ * always-available (e.g. keyless local providers).
  *
  * Exported for reuse by the call preflight path so the daemon can warn about
  * an unplayable telephony TTS config before a call connects.
@@ -86,7 +101,18 @@ export async function isTtsProviderCredentialAvailable(
 ): Promise<boolean> {
   const entry = getCatalogProvider(providerId);
   if (entry.secretRequirements.length === 0) return true;
+
+  // Primary probe: match the adapter's `getProviderKeyAsync` semantics so
+  // legacy bare keys and env-var fallbacks are recognized.
+  const providerKey = await getProviderKeyAsync(providerId);
+  if (providerKey && providerKey.trim().length > 0) return true;
+
+  // Preserve behavior for any requirement that uses a non-standard catalog
+  // key (i.e. not the provider-namespaced api_key that getProviderKeyAsync
+  // already covered above).
+  const standardKey = credentialKey(providerId, "api_key");
   for (const requirement of entry.secretRequirements) {
+    if (requirement.credentialStoreKey === standardKey) continue;
     const value = await getSecureKeyAsync(requirement.credentialStoreKey);
     if (value && value.trim().length > 0) return true;
   }

--- a/assistant/src/calls/telephony-tts-capability.ts
+++ b/assistant/src/calls/telephony-tts-capability.ts
@@ -1,0 +1,133 @@
+/**
+ * Telephony TTS playability guard for the media-stream call path.
+ *
+ * On the media-stream pipeline ALL telephony audio is synthesized by the
+ * daemon and transcoded PCM/WAV -> mu-law before being sent to the carrier.
+ * A TTS provider that cannot emit a transcodable linear format (PCM/WAV)
+ * -- or whose credential is not available -- would produce a silent call.
+ *
+ * This module turns "can the configured provider feed the media-stream
+ * transcoder?" into an explicit, testable decision driven by:
+ *   1. the provider's declared {@link MediaStreamPlaybackFormat} in the
+ *      canonical catalog, and
+ *   2. whether the provider's credential is actually available.
+ *
+ * It deliberately does NOT key off {@link TtsCallMode} -- call mode describes
+ * the Twilio integration strategy, not whether synthesized bytes are playable
+ * over the media-stream transcoder.
+ *
+ * The credential-availability check ({@link isTtsProviderCredentialAvailable})
+ * is exported for reuse by the call preflight path.
+ */
+
+import { loadConfig } from "../config/loader.js";
+import { getSecureKeyAsync } from "../security/secure-keys.js";
+import {
+  getCatalogProvider,
+  type MediaStreamPlaybackFormat,
+} from "../tts/provider-catalog.js";
+import { resolveTtsConfig } from "../tts/tts-config-resolver.js";
+import type { TtsProviderId } from "../tts/types.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Default provider used when the configured provider cannot feed the
+ * media-stream transcoder. ElevenLabs emits `pcm_16000` and is the catalog
+ * default, so it is the safe PCM-capable fallback.
+ */
+export const DEFAULT_PLAYABLE_TTS_PROVIDER: TtsProviderId = "elevenlabs";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * Why a configured provider cannot feed the media-stream transcoder.
+ *
+ * - `unsupported-format`  — the provider's declared media-stream output
+ *                            format is `"none"` (it cannot emit PCM/WAV).
+ * - `missing-credentials` — the provider could emit PCM/WAV but its
+ *                            credential is not available.
+ */
+export type TelephonyTtsNotPlayableReason =
+  | "unsupported-format"
+  | "missing-credentials";
+
+/** Result of {@link resolveTelephonyTtsCapability}. */
+export type TelephonyTtsCapability =
+  | { status: "playable"; providerId: TtsProviderId }
+  | {
+      status: "not-playable";
+      providerId: TtsProviderId;
+      reason: TelephonyTtsNotPlayableReason;
+    };
+
+// ---------------------------------------------------------------------------
+// Credential availability (reusable)
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true when the given provider's credential is available in the
+ * secure store.
+ *
+ * Keys off the provider's `secretRequirements` in the canonical catalog
+ * (the `credentialStoreKey`), so the check stays in lockstep with the
+ * declared requirements. A provider with no declared secret requirements is
+ * treated as always-available (e.g. keyless local providers).
+ *
+ * Exported for reuse by the call preflight path so the daemon can warn about
+ * an unplayable telephony TTS config before a call connects.
+ */
+export async function isTtsProviderCredentialAvailable(
+  providerId: TtsProviderId,
+): Promise<boolean> {
+  const entry = getCatalogProvider(providerId);
+  if (entry.secretRequirements.length === 0) return true;
+  for (const requirement of entry.secretRequirements) {
+    const value = await getSecureKeyAsync(requirement.credentialStoreKey);
+    if (value && value.trim().length > 0) return true;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Capability resolution
+// ---------------------------------------------------------------------------
+
+/** A media-stream output format that the transcoder can actually play. */
+function isPlayableFormat(format: MediaStreamPlaybackFormat): boolean {
+  return format === "pcm" || format === "wav";
+}
+
+/**
+ * Resolve whether the currently configured `services.tts.provider` can feed
+ * the media-stream transcoder with playable audio.
+ *
+ * Returns `{ status: "playable" }` only when the provider's declared
+ * media-stream output format is PCM/WAV **and** its credential is available.
+ * Otherwise returns `{ status: "not-playable"; providerId; reason }`.
+ */
+export async function resolveTelephonyTtsCapability(): Promise<TelephonyTtsCapability> {
+  const config = loadConfig();
+  const resolved = resolveTtsConfig(config);
+  const providerId = resolved.provider;
+  const entry = getCatalogProvider(providerId);
+
+  if (!isPlayableFormat(entry.mediaStreamPlayback.outputFormat)) {
+    return { status: "not-playable", providerId, reason: "unsupported-format" };
+  }
+
+  const hasCredential = await isTtsProviderCredentialAvailable(providerId);
+  if (!hasCredential) {
+    return {
+      status: "not-playable",
+      providerId,
+      reason: "missing-credentials",
+    };
+  }
+
+  return { status: "playable", providerId };
+}

--- a/assistant/src/tts/provider-catalog.ts
+++ b/assistant/src/tts/provider-catalog.ts
@@ -56,6 +56,34 @@ interface TtsProviderCatalogCapabilities {
 }
 
 /**
+ * Output format a provider can emit for the **media-stream** telephony path.
+ *
+ * On the media-stream pipeline every byte of telephony audio is synthesized
+ * by the daemon and transcoded PCM/WAV -> mu-law before being sent to the
+ * carrier. A provider that can only emit compressed (mp3/opus) or otherwise
+ * non-linear audio cannot feed that transcoder, so it would produce silence.
+ *
+ * - `"pcm"`  — provider can return raw PCM (e.g. ElevenLabs `pcm_16000`).
+ * - `"wav"`  — provider can return a WAV (linear PCM) container.
+ * - `"none"` — provider cannot emit a transcodable linear format; selecting
+ *               it on media-stream would yield silence and must fall back.
+ */
+export type MediaStreamPlaybackFormat = "pcm" | "wav" | "none";
+
+/**
+ * Declares whether (and how) a provider can feed the media-stream
+ * PCM -> mu-law transcoder. This makes media-stream playability **declared
+ * data** rather than something inferred from adapter internals.
+ */
+interface TtsMediaStreamPlayback {
+  /**
+   * The linear audio format the provider can emit for media-stream synthesis,
+   * or `"none"` when it cannot emit a transcodable format at all.
+   */
+  readonly outputFormat: MediaStreamPlaybackFormat;
+}
+
+/**
  * Link to a provider's API-key management page, shown in settings UI.
  */
 interface TtsCredentialsGuide {
@@ -110,6 +138,13 @@ interface TtsProviderCatalogEntry {
   /** Static provider-level capabilities. */
   readonly capabilities: Readonly<TtsProviderCatalogCapabilities>;
 
+  /**
+   * Whether (and how) this provider can synthesize audio that the
+   * media-stream telephony transcoder can play. See
+   * {@link TtsMediaStreamPlayback}.
+   */
+  readonly mediaStreamPlayback: Readonly<TtsMediaStreamPlayback>;
+
   /** Secrets the provider requires to function. */
   readonly secretRequirements: readonly Readonly<TtsProviderSecretRequirement>[];
 }
@@ -143,6 +178,9 @@ const CATALOG: readonly TtsProviderCatalogEntry[] = [
       supportsStreaming: false,
       supportedFormats: ["mp3"],
     },
+    // ElevenLabs honours `outputFormat: "pcm"` by returning `pcm_16000`
+    // (see resolveOutputFormat in elevenlabs-provider.ts).
+    mediaStreamPlayback: { outputFormat: "pcm" },
     secretRequirements: [
       {
         credentialStoreKey: "credential/elevenlabs/api_key",
@@ -171,6 +209,8 @@ const CATALOG: readonly TtsProviderCatalogEntry[] = [
       supportsStreaming: true,
       supportedFormats: ["mp3", "wav", "opus"],
     },
+    // Fish Audio honours `outputFormat: "pcm"` for raw PCM output.
+    mediaStreamPlayback: { outputFormat: "pcm" },
     secretRequirements: [
       {
         credentialStoreKey: "credential/fish-audio/api_key",
@@ -199,6 +239,8 @@ const CATALOG: readonly TtsProviderCatalogEntry[] = [
       supportsStreaming: false,
       supportedFormats: ["mp3", "wav", "opus"],
     },
+    // Deepgram honours `outputFormat: "pcm"` via linear16/container=none.
+    mediaStreamPlayback: { outputFormat: "pcm" },
     secretRequirements: [
       {
         credentialStoreKey: "credential/deepgram/api_key",
@@ -226,6 +268,8 @@ const CATALOG: readonly TtsProviderCatalogEntry[] = [
       supportsStreaming: false,
       supportedFormats: ["mp3", "wav"],
     },
+    // xAI honours `outputFormat: "pcm"` via codec=pcm.
+    mediaStreamPlayback: { outputFormat: "pcm" },
     secretRequirements: [
       {
         credentialStoreKey: "credential/xai/api_key",


### PR DESCRIPTION
## Summary
- Add explicit mediaStreamPlayback.outputFormat metadata to TTS catalog
- resolveTelephonyTtsCapability() = playback-format + credential availability
- Fix media-stream fallback to a PCM-capable default instead of silence

Part of plan: migrate-phone-off-conversation-relay.md (PR 3 of 18)