### PR TITLE
feat(electron): add Log Out to app menu gated on platform session

### DIFF
--- a/apps/macos/src/main/commands.ts
+++ b/apps/macos/src/main/commands.ts
@@ -12,7 +12,8 @@ import { readSetting } from "./settings";
 export type VellumCommand =
   | { kind: "newConversation" }
   | { kind: "currentConversation" }
-  | { kind: "markCurrentUnread" };
+  | { kind: "markCurrentUnread" }
+  | { kind: "logout" };
 
 export type VellumCommandKind = VellumCommand["kind"];
 
@@ -29,6 +30,7 @@ export const DEFAULT_ACCELERATORS: Record<VellumCommandKind, string> = {
   newConversation: "CmdOrCtrl+N",
   currentConversation: "CmdOrCtrl+Shift+N",
   markCurrentUnread: "CmdOrCtrl+Shift+U",
+  logout: "",
 };
 
 /**

--- a/apps/macos/src/main/menu.ts
+++ b/apps/macos/src/main/menu.ts
@@ -1,4 +1,5 @@
 import { Menu, type MenuItemConstructorOptions, app, shell } from "electron";
+import { z } from "zod";
 
 import { openAboutWindow } from "./about";
 import {
@@ -6,17 +7,17 @@ import {
   resolveAccelerator,
   type VellumCommand,
 } from "./commands";
+import { handle } from "./ipc";
 
-/**
- * Builds and installs the macOS application menu. Without this, Electron
- * ships a default menu that includes developer-flavored items (Reload,
- * Toggle Developer Tools at the top level) and lacks the standard macOS
- * shape end users expect.
- *
- * The `View > Toggle Developer Tools` item is gated to dev only so the
- * packaged build doesn't expose devtools to end users.
- */
-export const installApplicationMenu = (): void => {
+interface MenuState {
+  hasPlatformSession: boolean;
+}
+
+const state: MenuState = {
+  hasPlatformSession: false,
+};
+
+const buildTemplate = (): MenuItemConstructorOptions[] => {
   const isDev = !app.isPackaged;
 
   const fileItem = (
@@ -28,16 +29,10 @@ export const installApplicationMenu = (): void => {
     click: () => dispatchToFocused(command),
   });
 
-  const template: MenuItemConstructorOptions[] = [
+  return [
     {
-      // macOS convention: the first submenu is always the app menu.
       label: app.name,
       submenu: [
-        // Branded About window — replaces `role: "about"` so we render
-        // version + commit SHA + copyright in our own UI instead of
-        // Electron's default panel. Native panel metadata is still
-        // populated by `installAbout()` so AppleScript / accessibility
-        // queries see the right values.
         {
           label: `About ${app.name}`,
           click: () => {
@@ -46,6 +41,12 @@ export const installApplicationMenu = (): void => {
         },
         { type: "separator" },
         { role: "services" },
+        { type: "separator" },
+        {
+          label: "Log Out",
+          enabled: state.hasPlatformSession,
+          click: () => dispatchToFocused({ kind: "logout" }),
+        },
         { type: "separator" },
         { role: "hide" },
         { role: "hideOthers" },
@@ -95,6 +96,38 @@ export const installApplicationMenu = (): void => {
       ],
     },
   ];
+};
 
-  Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+const applyMenu = (): void => {
+  Menu.setApplicationMenu(Menu.buildFromTemplate(buildTemplate()));
+};
+
+/**
+ * Builds and installs the macOS application menu. Without this, Electron
+ * ships a default menu that includes developer-flavored items (Reload,
+ * Toggle Developer Tools at the top level) and lacks the standard macOS
+ * shape end users expect.
+ *
+ * The `View > Toggle Developer Tools` item is gated to dev only so the
+ * packaged build doesn't expose devtools to end users.
+ *
+ * Registers an IPC handler so the renderer can publish platform session
+ * state, which gates the "Log Out" item in the app menu.
+ */
+let installed = false;
+export const installApplicationMenu = (): void => {
+  if (installed) return;
+  installed = true;
+
+  handle(
+    "vellum:menu:setPlatformSession",
+    z.tuple([z.boolean()]),
+    ([has]) => {
+      if (state.hasPlatformSession === has) return;
+      state.hasPlatformSession = has;
+      applyMenu();
+    },
+  );
+
+  applyMenu();
 };

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -11,7 +11,8 @@ import type { Lockfile, LockfileWriteResult } from "@vellumai/local-mode";
 export type VellumCommand =
   | { kind: "newConversation" }
   | { kind: "currentConversation" }
-  | { kind: "markCurrentUnread" };
+  | { kind: "markCurrentUnread" }
+  | { kind: "logout" };
 
 // Surface exposed to the renderer as `window.vellum`. `platform`, `settings`,
 // and `commands` are wired through IPC; `auth` and `helper` are typed stubs
@@ -182,6 +183,9 @@ export interface VellumBridge {
       | { ok: false; status: number; error: string }
     >;
   };
+  menu: {
+    setPlatformSession(has: boolean): Promise<void>;
+  };
   mainWindow: {
     /**
      * Bring the main window to the foreground: recreate if destroyed,
@@ -315,6 +319,10 @@ const bridge: VellumBridge = {
         | { ok: true; accessToken: string }
         | { ok: false; status: number; error: string }
       >,
+  },
+  menu: {
+    setPlatformSession: (has: boolean): Promise<void> =>
+      ipcRenderer.invoke("vellum:menu:setPlatformSession", has) as Promise<void>,
   },
   mainWindow: {
     ensureVisible: (): Promise<void> =>

--- a/apps/web/src/domains/chat/components/preferences-menu.tsx
+++ b/apps/web/src/domains/chat/components/preferences-menu.tsx
@@ -24,7 +24,12 @@ import { LazyBoundary } from "@/components/lazy-boundary";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import { hardNavigate } from "@/lib/auth/hard-navigate";
-import { useAuthStore, useIsAuthenticated } from "@/stores/auth-store";
+import { isLocalMode } from "@/lib/local-mode";
+import {
+  useAuthStore,
+  useHasPlatformSession,
+  useIsAuthenticated,
+} from "@/stores/auth-store";
 import {
   useActiveAssistantIsPlatformHosted,
   usePlatformGate,
@@ -157,6 +162,8 @@ function PreferencesMenuContent({
   const billingPlatformGate = usePlatformGate({ platformHostedOnly: true });
   const isPlatformHosted = useActiveAssistantIsPlatformHosted();
   const isOrgReady = useIsOrgReady();
+  const hasPlatformSession = useHasPlatformSession();
+  const showLogout = !isLocalMode() || hasPlatformSession;
   const showBillingRows =
     billingPlatformGate === "full" && isPlatformHosted && isOrgReady;
   const { data: billingSummary } = useQuery({
@@ -234,15 +241,17 @@ function PreferencesMenuContent({
         />
       ) : null}
 
-      <PanelItem
-        icon={LogOut}
-        label="Log Out"
-        onSelect={async () => {
-          await logout();
-          onClose();
-          hardNavigate(routes.account.login);
-        }}
-      />
+      {showLogout ? (
+        <PanelItem
+          icon={LogOut}
+          label="Log Out"
+          onSelect={async () => {
+            await logout();
+            onClose();
+            hardNavigate(routes.account.login);
+          }}
+        />
+      ) : null}
     </>
   );
 }

--- a/apps/web/src/domains/chat/hooks/use-electron-dock-sync.ts
+++ b/apps/web/src/domains/chat/hooks/use-electron-dock-sync.ts
@@ -1,7 +1,8 @@
 import { useEffect, useMemo } from "react";
 
 import { setDockBadge, setDockSignedIn } from "@/runtime/dock";
-import { useIsAuthenticated } from "@/stores/auth-store";
+import { setMenuPlatformSession } from "@/runtime/menu";
+import { useHasPlatformSession, useIsAuthenticated } from "@/stores/auth-store";
 import type { Conversation } from "@/types/conversation-types";
 import { contributesToUnreadCount } from "@/utils/conversation-predicates";
 
@@ -28,6 +29,7 @@ import { contributesToUnreadCount } from "@/utils/conversation-predicates";
  */
 export function useElectronDockSync(conversations: Conversation[]): void {
   const isAuthenticated = useIsAuthenticated();
+  const hasPlatformSession = useHasPlatformSession();
 
   const unreadCount = useMemo(
     () =>
@@ -45,4 +47,8 @@ export function useElectronDockSync(conversations: Conversation[]): void {
   useEffect(() => {
     void setDockSignedIn(isAuthenticated);
   }, [isAuthenticated]);
+
+  useEffect(() => {
+    void setMenuPlatformSession(hasPlatformSession);
+  }, [hasPlatformSession]);
 }

--- a/apps/web/src/root-layout.tsx
+++ b/apps/web/src/root-layout.tsx
@@ -12,6 +12,9 @@ import {
   useIsSessionInitializing,
   useHasPlatformSession,
 } from "@/stores/auth-store";
+import { getOnboardingEntrypoint } from "@/domains/onboarding/gate";
+import { setMenuPlatformSession } from "@/runtime/menu";
+import { useVellumCommands } from "@/runtime/vellum-commands";
 import { useEnvironmentStore } from "@/stores/environment-store";
 import { useAssistantResourceSync } from "@/hooks/use-assistant-resource-sync";
 import { useDocumentEditorSync } from "@/hooks/use-document-editor-sync";
@@ -101,6 +104,16 @@ export function RootLayout() {
   // `useDeepLinkConsumer` because it owns `setInput`; the two
   // hand off via `pending-deep-link-store`.
   useGlobalDeepLinkConsumer();
+
+  useVellumCommands({
+    logout: () => {
+      void setMenuPlatformSession(false).then(() =>
+        useAuthStore.getState().logout(),
+      ).then(() => {
+        navigate(getOnboardingEntrypoint());
+      });
+    },
+  });
 
   const keyboardOpen =
     isMobile &&

--- a/apps/web/src/runtime/is-electron.ts
+++ b/apps/web/src/runtime/is-electron.ts
@@ -31,7 +31,8 @@ import type { Lockfile, LockfileWriteResult } from "@vellumai/local-mode/contrac
 export type VellumCommand =
   | { kind: "newConversation" }
   | { kind: "currentConversation" }
-  | { kind: "markCurrentUnread" };
+  | { kind: "markCurrentUnread" }
+  | { kind: "logout" };
 
 declare global {
   interface Window {
@@ -57,6 +58,9 @@ declare global {
       dock: {
         setBadge(count: number): Promise<void>;
         setSignedIn(signedIn: boolean): Promise<void>;
+      };
+      menu: {
+        setPlatformSession(has: boolean): Promise<void>;
       };
       localMode: {
         hatch(species: string, remote?: string): Promise<{

--- a/apps/web/src/runtime/menu.ts
+++ b/apps/web/src/runtime/menu.ts
@@ -1,0 +1,6 @@
+import { isElectron } from "@/runtime/is-electron";
+
+export async function setMenuPlatformSession(has: boolean): Promise<void> {
+  if (!isElectron()) return;
+  await window.vellum?.menu.setPlatformSession(has);
+}

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -276,18 +276,17 @@ export async function whenPlatformSessionSettled(): Promise<void> {
 }
 
 /**
- * Probe the platform session only when one could exist — non-local mode, or
- * local mode with at least one platform assistant in the lockfile. When there
- * is nothing to probe, settle directly to `"absent"` rather than leaving the
- * status `"unknown"`. Centralizes the reachability gate shared by the local
- * gateway auth entry points (`initSession`, `refreshSession`,
- * `connectLocalAssistant`).
+ * Probe the platform session when one could exist: non-local mode, gateway
+ * auth enabled, or local mode with platform assistants in the lockfile.
+ * Gateway auth always probes because the user may have logged into the
+ * platform (e.g. via the login flow) without having added platform
+ * assistants yet. When nothing qualifies, settle to `"absent"`.
  */
 function probePlatformSessionIfReachable(
   set: AuthSet,
   options?: { setUserOnSuccess?: boolean; clearOnFailure?: boolean },
 ): void {
-  if (!isLocalMode() || getPlatformAssistants().length > 0) {
+  if (!isLocalMode() || isGatewayAuthEnabled() || getPlatformAssistants().length > 0) {
     probePlatformSession(set, options);
   } else {
     set({ platformSession: "absent" });


### PR DESCRIPTION
## Summary
- Add a "Log Out" menu item to the Electron app menu, enabled only when the renderer detects a live platform session via the existing allauth probe
- Wire a new `vellum:menu:setPlatformSession` IPC channel so the renderer publishes platform session state to main, which rebuilds the menu on change
- Fix `probePlatformSessionIfReachable` to always probe when gateway auth is enabled, so the platform session is detected even without platform assistants in the lockfile
- Gate the in-app Preferences "Log Out" button on the same `isLocalMode() + hasPlatformSession` condition
- Handle the `logout` command in `RootLayout` (not `ChatLayout`) so it works from onboarding routes too, navigating to the onboarding entrypoint after logout
- Eagerly clear the menu state during logout so the menu item disables immediately

## Original prompt
The user asked to gate the Logout button in the Preferences popper when in local mode with no platform session, then add a corresponding Log Out item to the native Electron app menu. During testing, several issues were found and fixed: the platform session probe wasn't running in gateway auth mode without platform assistants, the logout command wasn't reachable from onboarding routes because it was mounted in ChatLayout, and the menu item stayed enabled after logout because the renderer unmounted before publishing the state change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)