### PR TITLE
fix(gateway): canonicalize token before revocation hash (close signature-encoding bypass)

### DIFF
--- a/gateway/src/__tests__/actor-token-revocation.test.ts
+++ b/gateway/src/__tests__/actor-token-revocation.test.ts
@@ -102,6 +102,46 @@ describe("isActorTokenRevoked", () => {
   });
 });
 
+describe("signature-encoding canonicalization (revocation bypass)", () => {
+  function mintActorJwt(): string {
+    return mintToken({
+      aud: "vellum-gateway",
+      sub: ACTOR_SUB,
+      scope_profile: "actor_client_v1",
+      policy_epoch: CURRENT_POLICY_EPOCH,
+      ttlSeconds: 3600,
+    });
+  }
+
+  // Append base64 padding to the signature segment. Buffer.from(.., "base64url")
+  // decodes it to the SAME bytes, so the JWT still verifies — but the raw string
+  // differs, which (pre-fix) made the revocation hash miss the stored record.
+  function padSignature(jwt: string): string {
+    const [h, p, sig] = jwt.split(".");
+    return `${h}.${p}.${sig}=`;
+  }
+
+  test("detects a revoked token whose signature segment is re-encoded with padding", () => {
+    const jwt = mintActorJwt();
+    insertTokenRecord(jwt, "revoked"); // stored under the canonical token hash
+
+    // Baseline: the canonical token is detected as revoked.
+    expect(isActorTokenRevoked(jwt, actorClaims)).toBe(true);
+
+    // Bypass attempt: same token, signature re-encoded (different string, same
+    // bytes). Must still resolve to the revoked record.
+    const padded = padSignature(jwt);
+    expect(padded).not.toBe(jwt);
+    expect(isActorTokenRevoked(padded, actorClaims)).toBe(true);
+  });
+
+  test("does not falsely revoke an active token re-encoded with padding", () => {
+    const jwt = mintActorJwt();
+    insertTokenRecord(jwt, "active");
+    expect(isActorTokenRevoked(padSignature(jwt), actorClaims)).toBe(false);
+  });
+});
+
 describe("runtime proxy enforcement", () => {
   function makeConfig() {
     return {

--- a/gateway/src/auth/actor-token-revocation.ts
+++ b/gateway/src/auth/actor-token-revocation.ts
@@ -41,6 +41,39 @@ function hashToken(token: string): string {
 }
 
 /**
+ * Canonicalize a token's base64url encoding so the revocation hash reproduces
+ * the canonical minted string that was stored.
+ *
+ * Tokens are stored/revoked under the hash of their CANONICAL minted string
+ * (mintToken encodes every segment with Buffer#toString("base64url") — no
+ * padding, canonical alphabet). But validateEdgeToken verifies the signature by
+ * decoding the signature segment to BYTES and comparing bytes — it never checks
+ * the segment's textual encoding. So a revoked token can be re-encoded (append
+ * `=` padding, swap to the +/ alphabet, embed whitespace, perturb non-canonical
+ * trailing bits) and still verify with identical signature bytes, yet hash to a
+ * different string and MISS the revoked record — letting a revoked token keep
+ * authenticating. Re-encoding each segment via a base64url decode→encode
+ * round-trip reproduces the canonical minted string, so the lookup hash matches
+ * regardless of how the caller spelled the token. (Only the signature segment
+ * is actually malleable — header/payload are the HMAC input and are already
+ * verified by the time we run — but round-tripping all three is the simplest
+ * exact reproduction. Also subsumes the previous `.trim()`, which only handled
+ * surrounding whitespace e.g. a `?token=<jwt>%20` WebSocket query param.)
+ */
+function canonicalizeTokenForHash(rawToken: string): string {
+  const trimmed = rawToken.trim();
+  const parts = trimmed.split(".");
+  if (parts.length !== 3) return trimmed;
+  try {
+    return parts
+      .map((seg) => Buffer.from(seg, "base64url").toString("base64url"))
+      .join(".");
+  } catch {
+    return trimmed;
+  }
+}
+
+/**
  * True only when `rawToken` is an actor token with an explicitly revoked record.
  * Fail-open in every other case (non-actor, no record, DB error).
  */
@@ -53,12 +86,7 @@ export function isActorTokenRevoked(
     return false;
   }
 
-  // Canonicalize before hashing. validateEdgeToken tolerates surrounding
-  // whitespace (base64url signature decode ignores it), but tokens are stored
-  // hashed in their canonical form — so a token supplied with trailing
-  // whitespace (e.g. a `?token=<jwt>%20` WebSocket query param) would hash to a
-  // different value and miss the revoked record. Trim so the lookup matches.
-  const tokenHash = hashToken(rawToken.trim());
+  const tokenHash = hashToken(canonicalizeTokenForHash(rawToken));
 
   try {
     const record = getGatewayDb()


### PR DESCRIPTION
## Summary
- **Security fix (high):** closes a revocation bypass where a revoked-but-unexpired actor token could be re-encoded (append `=` to the signature segment, swap to the `+`/`/` alphabet, embed whitespace, perturb non-canonical trailing bits) and keep authenticating.
- `isActorTokenRevoked` now **canonicalizes** the token before hashing for the lookup — it re-encodes each base64url segment via a decode→encode round-trip to reproduce the canonical minted string — so the lookup hash matches the stored record regardless of how the signature was spelled. Fail-open semantics and all other behavior are unchanged.

## The bypass
Actor tokens are stored/revoked under the hash of their **canonical minted string**. But `verifyToken` validates the signature by decoding the signature segment to **bytes** (`Buffer.from(sig, "base64url")`) and comparing bytes — it never checks the segment's *textual* encoding, and that decoder is lenient. So many different strings (e.g. `H.P.SIG` vs `H.P.SIG=`) decode to the **same signature bytes** and all still verify. The revocation lookup, however, hashed the raw **string** (`hashToken(rawToken.trim())`). So:

1. Attacker holds a **revoked** but unexpired actor token; the revoked row stores `hash("H.P.SIG")`.
2. They send `H.P.SIG=` — `verifyToken` decodes the same sig bytes → ✅ valid.
3. `hashToken("H.P.SIG=") ≠ hashToken("H.P.SIG")` → no revoked row matches → `isActorTokenRevoked` returns false → **the revoked token keeps working.**

This is a canonicalization mismatch / parser-differential: the verifier normalizes to bytes, the revocation lookup compared literal text, and they disagreed on token identity. (Header/payload aren't malleable — they're the HMAC input, so any change breaks verification; only the signature segment is.)

## The fix & why it's in revocation (not the verifier)
We canonicalize in the revocation lookup rather than hardening `verifyToken`, deliberately:
- `verifyToken` is on the critical path of **every** authenticated request (web/extension/cli/mobile) — a regression there is catastrophic.
- The revocation check is newer, narrower, and **fail-open**, so the fix is contained — *low risk × catastrophic cost* favored the narrow fix.

`isActorTokenRevoked` is the **single chokepoint** for revocation decisions — the runtime proxy, IPC proxy, live-voice and STT WebSocket upgrades, the auth middleware, and the `/auth/token` re-mint guard all route through it — so fixing the one function covers every caller. (The only other `hashToken` sites are the opaque refresh-token lookup — not a JWT, no malleability — and mint-time recording, which is the canonical source.)

## Known residual (deliberate)
The verifier still accepts non-canonical signature encodings, so any **future** code that keys on the raw token string must canonicalize too. Hardening `verifyToken` to reject non-canonical encodings outright remains an option for a later defense-in-depth pass; this PR fixes the actual exploitable consumer.

This strengthens the device-revocation guarantee the pairing model (pair/unpair, refresh) relies on.

## Original prompt
A Codex high-severity finding showed that the hot-path actor-token revocation check could be bypassed: the JWT verifier accepts non-canonical signature encodings (it compares decoded bytes), while revocation hashed the raw token string, so a revoked token re-encoded with a `=` still verified but missed its revoked record. We chose the narrow fix — canonicalize the token in the revocation lookup, leaving the every-request verifier untouched — because the verifier's blast radius is catastrophic while the fail-open revocation check is contained.