### PR TITLE
feat(web): add CreditBundlePicker component for credit bundle selection

### DIFF
--- a/apps/web/src/domains/settings/components/credit-bundle-picker.test.tsx
+++ b/apps/web/src/domains/settings/components/credit-bundle-picker.test.tsx
@@ -1,0 +1,196 @@
+/**
+ * Tests for the presentational `CreditBundlePicker`.
+ *
+ * Renders via `@testing-library/react` (happy-dom registered in test-setup.ts)
+ * and drives the design-library Dropdown — a custom combobox, not a native
+ * <select> — by clicking the trigger to open the listbox, then clicking the
+ * option whose visible label matches. No jest-dom matchers; we assert with
+ * plain bun `expect` against query results.
+ */
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import type { CreditTier, CreditTierEnum } from "@/generated/api/types.gen";
+
+import {
+  CreditBundlePicker,
+  formatBundleOptionLabel,
+} from "./credit-bundle-picker";
+
+afterEach(() => {
+  cleanup();
+});
+
+const TIERS: CreditTier[] = [
+  {
+    tier: "credits_10",
+    label: "10 credits",
+    credits_usd: 10,
+    price_cents: 1000,
+    lookup_key: "credits_10",
+  },
+  {
+    tier: "credits_25",
+    label: "25 credits",
+    credits_usd: 25,
+    price_cents: 2500,
+    lookup_key: "credits_25",
+  },
+  {
+    tier: "credits_50",
+    label: "50 credits",
+    credits_usd: 50,
+    price_cents: 5000,
+    lookup_key: "credits_50",
+  },
+  {
+    tier: "credits_100",
+    label: "100 credits",
+    credits_usd: 100,
+    price_cents: 10000,
+    lookup_key: "credits_100",
+  },
+  {
+    tier: "credits_200",
+    label: "200 credits",
+    credits_usd: 200,
+    price_cents: 20000,
+    lookup_key: "credits_200",
+  },
+];
+
+function openDropdown(): void {
+  const trigger = document.querySelector<HTMLButtonElement>(
+    'button[role="combobox"][aria-label="Credit bundle"]',
+  );
+  if (!trigger) {
+    throw new Error("expected a Credit bundle dropdown trigger");
+  }
+  fireEvent.click(trigger);
+}
+
+function optionLabels(): string[] {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>('[role="option"]'),
+  ).map((o) => o.textContent?.trim() ?? "");
+}
+
+function clickOption(label: string): void {
+  const option = Array.from(
+    document.querySelectorAll<HTMLElement>('[role="option"]'),
+  ).find((o) => o.textContent?.trim() === label);
+  if (!option) {
+    throw new Error(
+      `expected option "${label}" — saw: ${optionLabels()
+        .map((l) => `"${l}"`)
+        .join(", ")}`,
+    );
+  }
+  fireEvent.click(option);
+}
+
+describe("formatBundleOptionLabel", () => {
+  test("formats whole-dollar tiers", () => {
+    expect(formatBundleOptionLabel(TIERS[2]!)).toBe("50 credits — $50/mo");
+  });
+
+  test("formats sub-dollar cents with two decimals", () => {
+    expect(
+      formatBundleOptionLabel({ ...TIERS[0]!, price_cents: 1050 }),
+    ).toBe("10 credits — $10.50/mo");
+  });
+});
+
+describe("CreditBundlePicker", () => {
+  test("renders the no-bundle option first, then all five tiers with prices", () => {
+    render(
+      <CreditBundlePicker
+        creditTiers={TIERS}
+        selectedCreditTier={null}
+        onCreditTierChange={() => {}}
+      />,
+    );
+    openDropdown();
+
+    expect(optionLabels()).toEqual([
+      "No credit bundle — $0/mo",
+      "10 credits — $10/mo",
+      "25 credits — $25/mo",
+      "50 credits — $50/mo",
+      "100 credits — $100/mo",
+      "200 credits — $200/mo",
+    ]);
+  });
+
+  test("selecting a tier emits its CreditTierEnum value", () => {
+    const onCreditTierChange = mock((_t: CreditTierEnum | null) => {});
+    render(
+      <CreditBundlePicker
+        creditTiers={TIERS}
+        selectedCreditTier={null}
+        onCreditTierChange={onCreditTierChange}
+      />,
+    );
+    openDropdown();
+    clickOption("50 credits — $50/mo");
+
+    expect(onCreditTierChange).toHaveBeenCalledTimes(1);
+    expect(onCreditTierChange.mock.calls[0]?.[0]).toBe("credits_50");
+  });
+
+  test("selecting the no-bundle option emits null", () => {
+    const onCreditTierChange = mock((_t: CreditTierEnum | null) => {});
+    render(
+      <CreditBundlePicker
+        creditTiers={TIERS}
+        selectedCreditTier="credits_50"
+        onCreditTierChange={onCreditTierChange}
+      />,
+    );
+    openDropdown();
+    clickOption("No credit bundle — $0/mo");
+
+    expect(onCreditTierChange).toHaveBeenCalledTimes(1);
+    expect(onCreditTierChange.mock.calls[0]?.[0]).toBeNull();
+  });
+
+  test("shows a positive delta in change mode when upgrading", () => {
+    const { getByTestId } = render(
+      <CreditBundlePicker
+        creditTiers={TIERS}
+        selectedCreditTier="credits_50"
+        onCreditTierChange={() => {}}
+        currentCreditPriceCents={2500}
+      />,
+    );
+    expect(getByTestId("credit-bundle-picker-delta").textContent).toBe(
+      "+$25/mo",
+    );
+  });
+
+  test("shows a negative delta in change mode when dropping to no bundle", () => {
+    const { getByTestId } = render(
+      <CreditBundlePicker
+        creditTiers={TIERS}
+        selectedCreditTier={null}
+        onCreditTierChange={() => {}}
+        currentCreditPriceCents={5000}
+      />,
+    );
+    expect(getByTestId("credit-bundle-picker-delta").textContent).toBe(
+      "−$50/mo",
+    );
+  });
+
+  test("renders no delta when the selection matches the current price", () => {
+    const { queryByTestId } = render(
+      <CreditBundlePicker
+        creditTiers={TIERS}
+        selectedCreditTier="credits_50"
+        onCreditTierChange={() => {}}
+        currentCreditPriceCents={5000}
+      />,
+    );
+    expect(queryByTestId("credit-bundle-picker-delta")).toBeNull();
+  });
+});

--- a/apps/web/src/domains/settings/components/credit-bundle-picker.tsx
+++ b/apps/web/src/domains/settings/components/credit-bundle-picker.tsx
@@ -1,0 +1,114 @@
+import { Info } from "lucide-react";
+import { useMemo } from "react";
+
+import { Dropdown } from "@vellum/design-library/components/dropdown";
+import { Typography } from "@vellum/design-library/components/typography";
+import type { CreditTier, CreditTierEnum } from "@/generated/api/types.gen";
+
+/**
+ * Sentinel option value for the synthesized "No credit bundle" entry. The
+ * design-library Dropdown is generic over `T extends string`, so it cannot
+ * carry a real `null` value — we map this sentinel to/from `null` at the
+ * component boundary so callers see a clean `CreditTierEnum | null`.
+ */
+const NO_BUNDLE_VALUE = "__none__";
+
+type CreditOptionValue = CreditTierEnum | typeof NO_BUNDLE_VALUE;
+
+/** "$50/mo" for whole-dollar tiers; "$50.50/mo" only when cents are present. */
+function formatMonthly(totalCents: number): string {
+  const dollars = totalCents / 100;
+  return Number.isInteger(dollars)
+    ? `$${dollars}/mo`
+    : `$${dollars.toFixed(2)}/mo`;
+}
+
+function formatDelta(deltaCents: number): string {
+  const prefix = deltaCents > 0 ? "+" : "−";
+  const absDollars = Math.abs(deltaCents) / 100;
+  const formatted = Number.isInteger(absDollars)
+    ? `$${absDollars}`
+    : `$${absDollars.toFixed(2)}`;
+  return `${prefix}${formatted}/mo`;
+}
+
+/** "50 credits — $50/mo" for a catalog tier. */
+export function formatBundleOptionLabel(tier: CreditTier): string {
+  return `${tier.label} — ${formatMonthly(tier.price_cents)}`;
+}
+
+export interface CreditBundlePickerProps {
+  creditTiers: CreditTier[];
+  selectedCreditTier: CreditTierEnum | null;
+  onCreditTierChange: (tier: CreditTierEnum | null) => void;
+  currentCreditPriceCents?: number | null;
+  disabled?: boolean;
+}
+
+export function CreditBundlePicker({
+  creditTiers,
+  selectedCreditTier,
+  onCreditTierChange,
+  currentCreditPriceCents,
+  disabled = false,
+}: CreditBundlePickerProps) {
+  const selectedTier = creditTiers.find((t) => t.tier === selectedCreditTier);
+  const selectedPriceCents = selectedTier?.price_cents ?? 0;
+  const delta =
+    currentCreditPriceCents != null
+      ? selectedPriceCents - currentCreditPriceCents
+      : null;
+
+  const options = useMemo(() => {
+    const noBundle = {
+      value: NO_BUNDLE_VALUE as CreditOptionValue,
+      label: `No credit bundle — ${formatMonthly(0)}`,
+    };
+    const tierOptions = creditTiers.map((t) => ({
+      value: t.tier as CreditOptionValue,
+      label: formatBundleOptionLabel(t),
+    }));
+    return [noBundle, ...tierOptions];
+  }, [creditTiers]);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-1.5">
+        <div className="flex items-center gap-1">
+          <Typography
+            as="p"
+            variant="label-small-default"
+            className="text-[var(--content-secondary)]"
+          >
+            Credit bundle
+          </Typography>
+          <span title="A monthly allotment of credits added to your Pro Plan subscription">
+            <Info className="h-3 w-3 text-[var(--content-tertiary)]" />
+          </span>
+        </div>
+        <Dropdown<CreditOptionValue>
+          aria-label="Credit bundle"
+          placeholder="Select a credit bundle"
+          disabled={disabled}
+          value={selectedCreditTier ?? NO_BUNDLE_VALUE}
+          onChange={(value) =>
+            onCreditTierChange(
+              value === NO_BUNDLE_VALUE ? null : (value as CreditTierEnum),
+            )
+          }
+          options={options}
+        />
+      </div>
+      {delta != null && delta !== 0 && (
+        <Typography
+          as="p"
+          variant="body-small-emphasised"
+          data-testid="credit-bundle-picker-delta"
+          className="text-[var(--content-tertiary)]"
+        >
+          {formatDelta(delta)}
+        </Typography>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add presentational CreditBundlePicker (single-dropdown analogue of TierPicker)
- Synthesizes a 'No credit bundle — $0/mo' option mapping to null; renders catalog tiers with prices and change-mode deltas

Part of plan: pro-credit-bundles-frontend.md (PR 2 of 4)