### PR TITLE
feat(web): show current credit bundle on the billing plan card

### DIFF
--- a/apps/web/src/domains/settings/components/plan-card.test.tsx
+++ b/apps/web/src/domains/settings/components/plan-card.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * Tests for the PlanCard credit-bundle row: a Pro org with a selected credit
+ * tier shows the catalog label + monthly price; null shows no row; the row is
+ * catalog-gated (suppressed when the Pro plan has no `credit_tiers`).
+ *
+ * Strategy: pre-populate the React Query cache so the card's `useQuery` calls
+ * resolve synchronously — `renderToStaticMarkup` is single-pass, so a pending
+ * query would otherwise report `isLoading` and render the spinner.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import {
+  organizationsBillingPlansRetrieveQueryKey,
+  organizationsBillingSubscriptionRetrieveQueryKey,
+} from "@/generated/api/@tanstack/react-query.gen";
+import type {
+  CreditTier,
+  PlanListResponse,
+  SubscriptionResponse,
+} from "@/generated/api/types.gen";
+
+import { PlanCard } from "./plan-card";
+
+const CREDIT_TIERS: CreditTier[] = [
+  {
+    tier: "credits_25",
+    label: "25 credits",
+    credits_usd: 25,
+    price_cents: 2500,
+    lookup_key: "credits_25_lk",
+  },
+  {
+    tier: "credits_50",
+    label: "50 credits",
+    credits_usd: 50,
+    price_cents: 5000,
+    lookup_key: "credits_50_lk",
+  },
+];
+
+function proPlansResponse(creditTiers?: CreditTier[]): PlanListResponse {
+  return {
+    plans: [
+      {
+        id: "pro",
+        name: "Pro",
+        base_price_cents: 2000,
+        base_lookup_key: "pro_base",
+        billing_interval: "month",
+        machine_tiers: [],
+        storage_tiers: [],
+        included_features: [],
+        ...(creditTiers ? { credit_tiers: creditTiers } : {}),
+      },
+    ],
+  };
+}
+
+function proSubscription(
+  selectedCreditTier: string | null,
+): SubscriptionResponse {
+  return {
+    plan_id: "pro",
+    status: "active",
+    renewal_date: null,
+    current_period_end: null,
+    cancel_at_period_end: false,
+    cancel_at: null,
+    selected_credit_tier: selectedCreditTier,
+    entitlements: { managed_email: false, phone_number: false },
+  };
+}
+
+function renderCard(
+  subscription: SubscriptionResponse,
+  plans: PlanListResponse,
+): string {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  client.setQueryData(
+    organizationsBillingSubscriptionRetrieveQueryKey(),
+    subscription,
+  );
+  client.setQueryData(organizationsBillingPlansRetrieveQueryKey(), plans);
+  return renderToStaticMarkup(
+    <QueryClientProvider client={client}>
+      <PlanCard onManage={() => {}} />
+    </QueryClientProvider>,
+  );
+}
+
+describe("PlanCard credit bundle", () => {
+  test("shows the bundle row with the catalog label and monthly price", () => {
+    const html = renderCard(
+      proSubscription("credits_50"),
+      proPlansResponse(CREDIT_TIERS),
+    );
+    expect(html).toContain("plan-card-credit-bundle");
+    expect(html).toContain("Monthly credits: 50 credits ($50/mo)");
+  });
+
+  test("renders no bundle row when the selected tier is null", () => {
+    const html = renderCard(
+      proSubscription(null),
+      proPlansResponse(CREDIT_TIERS),
+    );
+    expect(html).not.toContain("plan-card-credit-bundle");
+  });
+
+  test("is catalog-gated: no bundle row when the plan has no credit_tiers", () => {
+    const html = renderCard(
+      proSubscription("credits_50"),
+      proPlansResponse(undefined),
+    );
+    expect(html).not.toContain("plan-card-credit-bundle");
+  });
+
+  test("falls back to the raw tier key when no catalog match exists", () => {
+    const html = renderCard(
+      proSubscription("credits_200"),
+      proPlansResponse(CREDIT_TIERS),
+    );
+    expect(html).toContain("plan-card-credit-bundle");
+    expect(html).toContain("Monthly credits: credits_200");
+  });
+});

--- a/apps/web/src/domains/settings/components/plan-card.tsx
+++ b/apps/web/src/domains/settings/components/plan-card.tsx
@@ -9,6 +9,7 @@ import { Button } from "@vellum/design-library/components/button";
 import { Card } from "@vellum/design-library/components/card";
 import { Notice } from "@vellum/design-library/components/notice";
 import { Typography } from "@vellum/design-library/components/typography";
+import type { ProPlan } from "@/generated/api/types.gen";
 import { InvoicesModal } from "./invoices-modal";
 import { PlanFeatureList } from "./plan-feature-list";
 import {
@@ -120,6 +121,21 @@ export function PlanCard({ onManage }: PlanCardProps) {
   const showRenewal = display.showsRenewal && !isCancelling && !isCanceled && subscription.current_period_end;
   const showCancellation = display.showsRenewal && isCancelling && !isCanceled && cancelDate;
 
+  // Catalog-gated current credit bundle, shown only for a Pro org with a
+  // non-null selected tier when the catalog advertises `credit_tiers`. Resolve
+  // the label/price from the catalog, falling back to the raw tier key. A null
+  // selection (no bundle / $0) renders nothing.
+  const proPlan = currentPlan.id === "pro" ? (currentPlan as ProPlan) : undefined;
+  const selectedCreditTier = subscription.selected_credit_tier ?? null;
+  const creditTiers =
+    selectedCreditTier != null ? proPlan?.credit_tiers : undefined;
+  const creditTier = creditTiers?.find((t) => t.tier === selectedCreditTier);
+  const creditBundleLabel = creditTier
+    ? `${creditTier.label} ($${Math.round(creditTier.price_cents / 100)}/mo)`
+    : creditTiers?.length
+      ? selectedCreditTier
+      : null;
+
   return (
     <Card padding="lg">
       <div className="flex flex-col gap-4">
@@ -157,6 +173,16 @@ export function PlanCard({ onManage }: PlanCardProps) {
             {display.actionLabel}
           </Button>
         </div>
+        {creditBundleLabel && (
+          <Typography
+            as="p"
+            variant="body-small-default"
+            className="text-[var(--content-tertiary)]"
+            data-testid="plan-card-credit-bundle"
+          >
+            Monthly credits: {creditBundleLabel}
+          </Typography>
+        )}
         {showRenewal && (
           <Typography
             as="p"


### PR DESCRIPTION
## Summary
- Show the current monthly credit bundle (label + price) on the Pro plan card, resolved from the catalog
- Catalog-gated; renders nothing when there's no bundle or the catalog has no credit_tiers

Part of plan: pro-credit-bundles-frontend.md (PR 3 of 4)