### PR TITLE
feat(web): credit bundle selection in upgrade and change flows

### DIFF
--- a/apps/web/src/domains/settings/components/adjust-plan-modal.test.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.test.tsx
@@ -168,7 +168,7 @@ function renderModal(
   sub: SubscriptionResponse,
   plans: PlanListResponse,
   onTierUpgraded?: () => void,
-): ReturnType<typeof render> {
+): ReturnType<typeof render> & { client: QueryClient } {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
@@ -183,11 +183,12 @@ function renderModal(
       selected_storage_gib: 10,
     },
   );
-  return render(
+  const result = render(
     <QueryClientProvider client={client}>
       <AdjustPlanModal open onClose={() => {}} onTierUpgraded={onTierUpgraded} />
     </QueryClientProvider>,
   );
+  return { ...result, client };
 }
 
 function openCreditDropdown(): void {
@@ -299,6 +300,89 @@ describe("AdjustPlanModal credit bundle — change mode", () => {
     openCreditDropdown();
     clickOption("No credit bundle — $0/mo");
 
+    fireEvent.click(getByTestId("modal-change-tier-button"));
+
+    await waitFor(() => {
+      if (!changeCreditTierCall) throw new Error("change not called");
+    });
+    expect(
+      (changeCreditTierCall!.body as Record<string, unknown>).credit_tier,
+    ).toBeNull();
+  });
+});
+
+describe("AdjustPlanModal credit bundle — unseeded sentinel", () => {
+  test("does not enable Update Plan from a spurious pre-seed creditChanged", async () => {
+    // A Pro user with an existing bundle and no other pending change. Once the
+    // seed effect lands, selectedCreditTier equals currentCreditTier, so no
+    // dimension changed and the CTA stays disabled. The unseeded `undefined`
+    // sentinel must never read as a credit diff vs. the existing bundle.
+    const { getByTestId } = renderModal(
+      subscription("pro", "credits_50"),
+      proPlansResponse(CREDIT_TIERS),
+    );
+
+    await waitFor(() => {
+      const trigger = document.querySelector(
+        'button[role="combobox"][aria-label="Credit bundle"]',
+      );
+      if (!trigger) throw new Error("picker not rendered yet");
+    });
+
+    const button = getByTestId("modal-change-tier-button") as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+  });
+
+  test("does not send credit_tier: null before the user changes anything", async () => {
+    // Even if the CTA were clicked, no credit mutation should fire because the
+    // seeded selection matches the current bundle. Guards against the pre-seed
+    // `null` removing a paid bundle without intent.
+    const { getByTestId } = renderModal(
+      subscription("pro", "credits_50"),
+      proPlansResponse(CREDIT_TIERS),
+    );
+
+    await waitFor(() => {
+      const trigger = document.querySelector(
+        'button[role="combobox"][aria-label="Credit bundle"]',
+      );
+      if (!trigger) throw new Error("picker not rendered yet");
+    });
+
+    fireEvent.click(getByTestId("modal-change-tier-button"));
+
+    // Give any (erroneous) mutation a tick to fire.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(changeCreditTierCall).toBeNull();
+  });
+
+  test("preserves an explicit 'No bundle' choice across a plans refetch", async () => {
+    // Pro user with credits_50 picks "No credit bundle" (selection becomes
+    // null). A subsequent plans refetch re-runs the seeding effect; the explicit
+    // null must NOT be coalesced back to the existing bundle.
+    const { getByTestId, client } = renderModal(
+      subscription("pro", "credits_50"),
+      proPlansResponse(CREDIT_TIERS),
+    );
+
+    await waitFor(() => {
+      const trigger = document.querySelector(
+        'button[role="combobox"][aria-label="Credit bundle"]',
+      );
+      if (!trigger) throw new Error("picker not rendered yet");
+    });
+
+    openCreditDropdown();
+    clickOption("No credit bundle — $0/mo");
+
+    // Simulate a mid-modal refetch: re-seed by replacing the plans object so the
+    // seeding effect re-runs with a fresh `proPlan` identity.
+    client.setQueryData(
+      organizationsBillingPlansRetrieveQueryKey(),
+      proPlansResponse(CREDIT_TIERS),
+    );
+
+    // The pending removal must survive the re-seed.
     fireEvent.click(getByTestId("modal-change-tier-button"));
 
     await waitFor(() => {

--- a/apps/web/src/domains/settings/components/adjust-plan-modal.test.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.test.tsx
@@ -1,0 +1,289 @@
+/**
+ * Tests for the credit-bundle wiring in `AdjustPlanModal` (PR 4 of the
+ * pro-credit-bundles-frontend plan).
+ *
+ * Strategy: mock the generated API SDK so the upgrade / change-credit-tier
+ * mutations resolve without network calls and we can capture the request
+ * bodies. The modal's React Query reads are pre-seeded into the cache so they
+ * resolve synchronously. The credit-bundle Dropdown is the design-library
+ * combobox (not a native <select>): open it via its trigger, then click the
+ * option whose visible label matches.
+ *
+ * Coverage:
+ *  - upgrade (Base→Pro) forwards `credit_tier` (a selected bundle, and null for
+ *    "No bundle"),
+ *  - change mode (existing Pro) calls change-credit-tier with the selected
+ *    value and with null on removal,
+ *  - the credit UI is hidden when the catalog has no `credit_tiers`.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import * as sdkGen from "@/generated/api/sdk.gen";
+import {
+  organizationsBillingPlansRetrieveQueryKey,
+  organizationsBillingSubscriptionOnboardingRetrieveQueryKey,
+  organizationsBillingSubscriptionRetrieveQueryKey,
+} from "@/generated/api/@tanstack/react-query.gen";
+import type {
+  CreditTier,
+  PlanListResponse,
+  SubscriptionResponse,
+} from "@/generated/api/types.gen";
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+type Captured = { body?: unknown };
+let upgradeCall: Captured | null = null;
+let changeCreditTierCall: Captured | null = null;
+
+mock.module("@/generated/api/sdk.gen", () => ({
+  ...sdkGen,
+  organizationsBillingSubscriptionUpgradeCreate: (opts: Captured) => {
+    upgradeCall = opts;
+    return Promise.resolve({ data: { status: "ok" }, response: { ok: true } });
+  },
+  organizationsBillingSubscriptionChangeCreditTierCreate: (opts: Captured) => {
+    changeCreditTierCall = opts;
+    return Promise.resolve({
+      data: { status: "ok", credit_tier: null },
+      response: { ok: true },
+    });
+  },
+}));
+
+// Avoid pulling the real billing-portal hook's network fan-out; the downgrade /
+// portal paths are unrelated to credit-bundle wiring.
+mock.module("@/domains/settings/hooks/use-billing-portal-session", () => ({
+  buildPortalReturnSnapshot: () => ({}),
+  formatGraceDate: () => "",
+  getEffectiveCancelDate: () => null,
+  useBillingPortalSession: () => ({ isPending: false, mutate: () => {} }),
+}));
+
+import { AdjustPlanModal } from "./adjust-plan-modal";
+
+const CREDIT_TIERS: CreditTier[] = [
+  {
+    tier: "credits_25",
+    label: "25 credits",
+    credits_usd: 25,
+    price_cents: 2500,
+    lookup_key: "credits_25_lk",
+  },
+  {
+    tier: "credits_50",
+    label: "50 credits",
+    credits_usd: 50,
+    price_cents: 5000,
+    lookup_key: "credits_50_lk",
+  },
+];
+
+function proPlansResponse(creditTiers?: CreditTier[]): PlanListResponse {
+  return {
+    plans: [
+      {
+        id: "base",
+        name: "Base",
+        base_price_cents: 0,
+        base_lookup_key: "base",
+        billing_interval: "month",
+        included_features: [],
+      },
+      {
+        id: "pro",
+        name: "Pro",
+        base_price_cents: 2000,
+        base_lookup_key: "pro_base",
+        billing_interval: "month",
+        machine_tiers: [
+          {
+            tier: "machine_small",
+            label: "Small",
+            price_cents: 1000,
+            cpu: "1",
+            memory: "2Gi",
+          },
+        ],
+        storage_tiers: [
+          {
+            tier: "storage_10",
+            label: "10 GiB",
+            price_cents: 500,
+            storage_gib: 10,
+          },
+        ],
+        included_features: [],
+        ...(creditTiers ? { credit_tiers: creditTiers } : {}),
+      },
+    ],
+  } as unknown as PlanListResponse;
+}
+
+function subscription(
+  planId: "base" | "pro",
+  selectedCreditTier: string | null,
+): SubscriptionResponse {
+  return {
+    plan_id: planId,
+    status: "active",
+    renewal_date: null,
+    current_period_end: null,
+    cancel_at_period_end: false,
+    cancel_at: null,
+    selected_credit_tier: selectedCreditTier,
+    entitlements: { managed_email: false, phone_number: false },
+  } as unknown as SubscriptionResponse;
+}
+
+function renderModal(
+  sub: SubscriptionResponse,
+  plans: PlanListResponse,
+): ReturnType<typeof render> {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  client.setQueryData(organizationsBillingSubscriptionRetrieveQueryKey(), sub);
+  client.setQueryData(organizationsBillingPlansRetrieveQueryKey(), plans);
+  // Onboarding carries the current machine/storage tiers for the change flow.
+  client.setQueryData(
+    organizationsBillingSubscriptionOnboardingRetrieveQueryKey(),
+    {
+      max_machine_tier: "machine_small",
+      selected_storage_tier: "storage_10",
+      selected_storage_gib: 10,
+    },
+  );
+  return render(
+    <QueryClientProvider client={client}>
+      <AdjustPlanModal open onClose={() => {}} />
+    </QueryClientProvider>,
+  );
+}
+
+function openCreditDropdown(): void {
+  const trigger = document.querySelector<HTMLButtonElement>(
+    'button[role="combobox"][aria-label="Credit bundle"]',
+  );
+  if (!trigger) throw new Error("expected a Credit bundle dropdown trigger");
+  fireEvent.click(trigger);
+}
+
+function clickOption(label: string): void {
+  const option = Array.from(
+    document.querySelectorAll<HTMLElement>('[role="option"]'),
+  ).find((o) => o.textContent?.trim() === label);
+  if (!option) throw new Error(`expected option "${label}"`);
+  fireEvent.click(option);
+}
+
+beforeEach(() => {
+  upgradeCall = null;
+  changeCreditTierCall = null;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("AdjustPlanModal credit bundle — upgrade", () => {
+  test("forwards the selected credit_tier in the upgrade body", async () => {
+    const { getByTestId } = renderModal(
+      subscription("base", null),
+      proPlansResponse(CREDIT_TIERS),
+    );
+
+    openCreditDropdown();
+    clickOption("50 credits — $50/mo");
+
+    fireEvent.click(getByTestId("modal-upgrade-to-pro-button"));
+
+    await waitFor(() => {
+      if (!upgradeCall) throw new Error("upgrade not called");
+    });
+    expect((upgradeCall!.body as Record<string, unknown>).credit_tier).toBe(
+      "credits_50",
+    );
+  });
+
+  test("forwards credit_tier: null when 'No bundle' is selected (default)", async () => {
+    const { getByTestId } = renderModal(
+      subscription("base", null),
+      proPlansResponse(CREDIT_TIERS),
+    );
+
+    fireEvent.click(getByTestId("modal-upgrade-to-pro-button"));
+
+    await waitFor(() => {
+      if (!upgradeCall) throw new Error("upgrade not called");
+    });
+    expect(
+      (upgradeCall!.body as Record<string, unknown>).credit_tier,
+    ).toBeNull();
+  });
+});
+
+describe("AdjustPlanModal credit bundle — change mode", () => {
+  test("calls change-credit-tier with the newly selected value", async () => {
+    const { getByTestId } = renderModal(
+      subscription("pro", null),
+      proPlansResponse(CREDIT_TIERS),
+    );
+
+    openCreditDropdown();
+    clickOption("25 credits — $25/mo");
+
+    fireEvent.click(getByTestId("modal-change-tier-button"));
+
+    await waitFor(() => {
+      if (!changeCreditTierCall) throw new Error("change not called");
+    });
+    expect(
+      (changeCreditTierCall!.body as Record<string, unknown>).credit_tier,
+    ).toBe("credits_25");
+  });
+
+  test("calls change-credit-tier with null when removing the bundle", async () => {
+    const { getByTestId } = renderModal(
+      subscription("pro", "credits_50"),
+      proPlansResponse(CREDIT_TIERS),
+    );
+
+    openCreditDropdown();
+    clickOption("No credit bundle — $0/mo");
+
+    fireEvent.click(getByTestId("modal-change-tier-button"));
+
+    await waitFor(() => {
+      if (!changeCreditTierCall) throw new Error("change not called");
+    });
+    expect(
+      (changeCreditTierCall!.body as Record<string, unknown>).credit_tier,
+    ).toBeNull();
+  });
+});
+
+describe("AdjustPlanModal credit bundle — catalog gate", () => {
+  test("hides the credit UI when the plan has no credit_tiers (upgrade)", () => {
+    renderModal(subscription("base", null), proPlansResponse(undefined));
+    expect(
+      document.querySelector(
+        'button[role="combobox"][aria-label="Credit bundle"]',
+      ),
+    ).toBeNull();
+  });
+
+  test("hides the credit UI when the plan has no credit_tiers (change)", () => {
+    renderModal(subscription("pro", null), proPlansResponse(undefined));
+    expect(
+      document.querySelector(
+        'button[role="combobox"][aria-label="Credit bundle"]',
+      ),
+    ).toBeNull();
+  });
+});

--- a/apps/web/src/domains/settings/components/adjust-plan-modal.test.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.test.tsx
@@ -40,6 +40,8 @@ import type {
 type Captured = { body?: unknown };
 let upgradeCall: Captured | null = null;
 let changeCreditTierCall: Captured | null = null;
+let changeMachineTierCall: Captured | null = null;
+let changeStorageTierCall: Captured | null = null;
 
 mock.module("@/generated/api/sdk.gen", () => ({
   ...sdkGen,
@@ -53,6 +55,14 @@ mock.module("@/generated/api/sdk.gen", () => ({
       data: { status: "ok", credit_tier: null },
       response: { ok: true },
     });
+  },
+  organizationsBillingSubscriptionChangeMachineTierCreate: (opts: Captured) => {
+    changeMachineTierCall = opts;
+    return Promise.resolve({ data: { status: "ok" }, response: { ok: true } });
+  },
+  organizationsBillingSubscriptionChangeStorageTierCreate: (opts: Captured) => {
+    changeStorageTierCall = opts;
+    return Promise.resolve({ data: { status: "ok" }, response: { ok: true } });
   },
 }));
 
@@ -109,6 +119,13 @@ function proPlansResponse(creditTiers?: CreditTier[]): PlanListResponse {
             cpu: "1",
             memory: "2Gi",
           },
+          {
+            tier: "machine_large",
+            label: "Large",
+            price_cents: 3000,
+            cpu: "4",
+            memory: "8Gi",
+          },
         ],
         storage_tiers: [
           {
@@ -116,6 +133,12 @@ function proPlansResponse(creditTiers?: CreditTier[]): PlanListResponse {
             label: "10 GiB",
             price_cents: 500,
             storage_gib: 10,
+          },
+          {
+            tier: "storage_20",
+            label: "20 GiB",
+            price_cents: 900,
+            storage_gib: 20,
           },
         ],
         included_features: [],
@@ -144,6 +167,7 @@ function subscription(
 function renderModal(
   sub: SubscriptionResponse,
   plans: PlanListResponse,
+  onTierUpgraded?: () => void,
 ): ReturnType<typeof render> {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -161,7 +185,7 @@ function renderModal(
   );
   return render(
     <QueryClientProvider client={client}>
-      <AdjustPlanModal open onClose={() => {}} />
+      <AdjustPlanModal open onClose={() => {}} onTierUpgraded={onTierUpgraded} />
     </QueryClientProvider>,
   );
 }
@@ -172,6 +196,22 @@ function openCreditDropdown(): void {
   );
   if (!trigger) throw new Error("expected a Credit bundle dropdown trigger");
   fireEvent.click(trigger);
+}
+
+function openMachineDropdown(): void {
+  const trigger = document.querySelector<HTMLButtonElement>(
+    'button[role="combobox"][aria-label="Machine tier"]',
+  );
+  if (!trigger) throw new Error("expected a Machine tier dropdown trigger");
+  fireEvent.click(trigger);
+}
+
+function clickOptionStartingWith(prefix: string): void {
+  const option = Array.from(
+    document.querySelectorAll<HTMLElement>('[role="option"]'),
+  ).find((o) => o.textContent?.trim().startsWith(prefix));
+  if (!option) throw new Error(`expected option starting with "${prefix}"`);
+  fireEvent.click(option);
 }
 
 function clickOption(label: string): void {
@@ -185,6 +225,8 @@ function clickOption(label: string): void {
 beforeEach(() => {
   upgradeCall = null;
   changeCreditTierCall = null;
+  changeMachineTierCall = null;
+  changeStorageTierCall = null;
 });
 
 afterEach(() => {
@@ -265,6 +307,58 @@ describe("AdjustPlanModal credit bundle — change mode", () => {
     expect(
       (changeCreditTierCall!.body as Record<string, unknown>).credit_tier,
     ).toBeNull();
+  });
+});
+
+describe("AdjustPlanModal credit bundle — resize flow", () => {
+  test("a credit-only change refreshes without invoking onTierUpgraded", async () => {
+    let upgraded = false;
+    const { getByTestId } = renderModal(
+      subscription("pro", null),
+      proPlansResponse(CREDIT_TIERS),
+      () => {
+        upgraded = true;
+      },
+    );
+
+    openCreditDropdown();
+    clickOption("25 credits — $25/mo");
+
+    fireEvent.click(getByTestId("modal-change-tier-button"));
+
+    await waitFor(() => {
+      if (!changeCreditTierCall) throw new Error("change not called");
+    });
+    // The credit mutation fired (refresh path), but the resize flow must not.
+    expect(upgraded).toBe(false);
+    expect(changeMachineTierCall).toBeNull();
+    expect(changeStorageTierCall).toBeNull();
+  });
+
+  test("a machine tier change still invokes onTierUpgraded", async () => {
+    let upgraded = false;
+    const { getByTestId } = renderModal(
+      subscription("pro", null),
+      proPlansResponse(CREDIT_TIERS),
+      () => {
+        upgraded = true;
+      },
+    );
+
+    openMachineDropdown();
+    // Switching from the current "Small" tier to "Large" is an upgrade, which
+    // fires immediately (no downgrade reconfirm) and opens the resize flow.
+    clickOptionStartingWith("Large");
+
+    fireEvent.click(getByTestId("modal-change-tier-button"));
+
+    await waitFor(() => {
+      if (!changeMachineTierCall) throw new Error("machine change not called");
+    });
+    await waitFor(() => {
+      if (!upgraded) throw new Error("onTierUpgraded not called");
+    });
+    expect(changeCreditTierCall).toBeNull();
   });
 });
 

--- a/apps/web/src/domains/settings/components/adjust-plan-modal.test.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.test.tsx
@@ -170,7 +170,12 @@ function renderModal(
   onTierUpgraded?: () => void,
 ): ReturnType<typeof render> & { client: QueryClient } {
   const client = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
+    // `staleTime: Infinity` stops the pre-seeded reads from being marked stale
+    // and refetched on mount. Without it, the seeded queries fire background
+    // fetches: locally those hit a listening dev server (a soft 502 React Query
+    // swallows while keeping the cached data), but CI is hermetic so the same
+    // fetch rejects with ECONNREFUSED and the change-tier button never renders.
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
   });
   client.setQueryData(organizationsBillingSubscriptionRetrieveQueryKey(), sub);
   client.setQueryData(organizationsBillingPlansRetrieveQueryKey(), plans);

--- a/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
@@ -10,10 +10,13 @@ import { Notice } from "@vellum/design-library/components/notice";
 import { Tag } from "@vellum/design-library/components/tag";
 import { toast } from "@vellum/design-library/components/toast";
 import { Typography } from "@vellum/design-library/components/typography";
+import { CreditBundlePicker } from "./credit-bundle-picker";
 import { DowngradeReconfirmModal } from "./downgrade-reconfirm-modal";
 import { PlanFeatureList } from "./plan-feature-list";
 import { TierPicker, isTierDisabled } from "./tier-picker";
 import type {
+  CreditTier,
+  CreditTierEnum,
   MachineTier,
   MachineTierEnum,
   ProPlan,
@@ -24,6 +27,7 @@ import type {
 import {
   organizationsBillingPlansRetrieveOptions,
   organizationsBillingPlansRetrieveQueryKey,
+  organizationsBillingSubscriptionChangeCreditTierCreateMutation,
   organizationsBillingSubscriptionChangeMachineTierCreateMutation,
   organizationsBillingSubscriptionChangeStorageTierCreateMutation,
   organizationsBillingSubscriptionOnboardingRetrieveOptions,
@@ -63,6 +67,7 @@ const DRF_FIELD_KEYS = [
   "confirm",
   "machine_tier",
   "storage_tier",
+  "credit_tier",
   "non_field_errors",
 ] as const;
 
@@ -105,6 +110,26 @@ export function resolveTierSelection<T extends string>(
 }
 
 /**
+ * Resolve which credit tier should be selected given the user's previous choice
+ * and the current catalog. Mirrors `resolveTierSelection` but for credit
+ * bundles, which have no disabled state and where `null` ("No bundle") is always
+ * a valid selection: keep `prev` only if it is still present in the catalog,
+ * otherwise fall back to `null`.
+ *
+ * Revalidating guards the case where a plans refetch removes the
+ * previously-selected bundle while the modal is open.
+ */
+export function resolveCreditTierSelection(
+  tiers: CreditTier[],
+  prev: CreditTierEnum | null,
+): CreditTierEnum | null {
+  if (prev !== null && tiers.some((t) => t.tier === prev)) {
+    return prev;
+  }
+  return null;
+}
+
+/**
  * Cheapest tier price in cents, or 0 when the list is empty. Guards the
  * "From $" summary against `Math.min(...[])` → `Infinity` (which would render
  * "From $Infinity"). Production plans always carry populated tier arrays, so
@@ -135,6 +160,9 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
   const changeStorageTierMutation = useMutation(
     organizationsBillingSubscriptionChangeStorageTierCreateMutation(),
   );
+  const changeCreditTierMutation = useMutation(
+    organizationsBillingSubscriptionChangeCreditTierCreateMutation(),
+  );
   const portalSnapshot = buildPortalReturnSnapshot(subscriptionQuery.data);
   const portalMutation = useBillingPortalSession(portalSnapshot);
   const [view, setView] = useState<"plans" | "downgrade-confirm">("plans");
@@ -143,6 +171,8 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
     useState<MachineTierEnum | null>(null);
   const [selectedStorageTier, setSelectedStorageTier] =
     useState<StorageTierEnum | null>(null);
+  const [selectedCreditTier, setSelectedCreditTier] =
+    useState<CreditTierEnum | null>(null);
 
   // On native (Capacitor iOS), Stripe Checkout / the billing portal opens in
   // SFSafariViewController as a popover on top of the app. When the user
@@ -209,6 +239,22 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
     (p): p is ProPlan => p.id === "pro",
   );
 
+  // Credit bundles are server-flag-gated via the catalog: render the picker and
+  // run the credit logic only when the Pro plan ships a non-empty `credit_tiers`
+  // list. When absent, the modal behaves exactly as before.
+  const creditTiers = proPlan?.credit_tiers ?? [];
+  const creditTiersEnabled = creditTiers.length > 0;
+
+  // Unlike machine/storage (read from the onboarding endpoint), the current
+  // credit bundle lives on the subscription response. Coerce to the enum so the
+  // picker seed and price lookup share one source of truth.
+  const currentCreditTier =
+    (subscriptionQuery.data?.selected_credit_tier as CreditTierEnum | null) ??
+    null;
+  const priceForCredit = (tier: CreditTierEnum | null): number =>
+    creditTiers.find((t) => t.tier === tier)?.price_cents ?? 0;
+  const currentCreditPriceCents = priceForCredit(currentCreditTier);
+
   // For an active Pro subscriber, disable any storage tier strictly below the
   // current selection — downgrading storage is not allowed. TierPicker honors
   // the `disabled` flag via `isTierDisabled`; machine tiers stay fully enabled
@@ -234,6 +280,7 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
     if (!open) {
       setSelectedMachineTier(null);
       setSelectedStorageTier(null);
+      setSelectedCreditTier(null);
       return;
     }
     if (!proPlan) return;
@@ -253,6 +300,13 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
           prev ?? currentStorageTier,
         ),
       );
+      // Seed the credit bundle from the subscription's current selection,
+      // revalidating against the live catalog: keep the prior/current choice
+      // only if it still exists in `credit_tiers`, else fall back to null
+      // (no bundle). null is always a valid selection.
+      setSelectedCreditTier((prev) =>
+        resolveCreditTierSelection(creditTiers, prev ?? currentCreditTier),
+      );
       return;
     }
     setSelectedMachineTier((prev) =>
@@ -261,15 +315,21 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
     setSelectedStorageTier((prev) =>
       resolveTierSelection<StorageTierEnum>(proPlan.storage_tiers, prev),
     );
-    // machineTiersForPicker/storageTiersForPicker are derived from proPlan +
-    // onboarding values already in the dep list; omitting them keeps the effect
-    // from re-running on each render's fresh array identity.
+    // Base upgrade defaults to no bundle ($0); revalidate any prior choice
+    // against the live catalog.
+    setSelectedCreditTier((prev) =>
+      resolveCreditTierSelection(creditTiers, prev),
+    );
+    // machineTiersForPicker/storageTiersForPicker/creditTiers are derived from
+    // proPlan + onboarding values already in the dep list; omitting them keeps
+    // the effect from re-running on each render's fresh array identity.
   }, [
     open,
     proPlan,
     proTierChangeMode,
     currentMachineTier,
     currentStorageTier,
+    currentCreditTier,
   ]);
 
   const basePlan = plansQuery.data?.plans.find((p) => p.id === "base");
@@ -293,6 +353,9 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
           confirm: true,
           machine_tier: selectedMachineTier,
           storage_tier: selectedStorageTier,
+          // null = "No bundle". The backend ignores this when the credit-bundles
+          // flag is off, so always sending it is safe.
+          credit_tier: selectedCreditTier,
         },
       },
       {
@@ -345,14 +408,20 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
   };
 
   const tierChangePending =
-    changeMachineTierMutation.isPending || changeStorageTierMutation.isPending;
+    changeMachineTierMutation.isPending ||
+    changeStorageTierMutation.isPending ||
+    changeCreditTierMutation.isPending;
 
   // What changed vs. the current selection. Storage downgrades are impossible
-  // (those tiers are disabled), so a storage diff is always an upgrade.
+  // (those tiers are disabled), so a storage diff is always an upgrade. The
+  // credit bundle is its own dimension; `null` ("No bundle") is a valid value,
+  // so we compare directly rather than gating on non-null.
   const machineChanged =
     selectedMachineTier != null && selectedMachineTier !== currentMachineTier;
   const storageChanged =
     selectedStorageTier != null && selectedStorageTier !== currentStorageTier;
+  const creditChanged =
+    creditTiersEnabled && selectedCreditTier !== currentCreditTier;
 
   const priceForMachine = (tier: MachineTierEnum | null): number | null =>
     machineTiersForPicker.find((t) => t.tier === tier)?.price_cents ?? null;
@@ -423,10 +492,42 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
     );
   };
 
+  const submitCreditTierChange = () => {
+    if (tierChangePending) return;
+    changeCreditTierMutation.mutate(
+      // null removes the bundle ("No bundle"). Bundle changes apply at the next
+      // cycle — no proration/immediate-charge subtleties — so no reconfirm.
+      { body: { credit_tier: selectedCreditTier } },
+      {
+        onSuccess: () => {
+          // Refresh the subscription (and the rest of billing) so the plan card
+          // and this modal reflect the new bundle.
+          invalidateBillingQueries();
+          if (onTierUpgraded) {
+            onClose();
+            onTierUpgraded();
+          } else {
+            toast.success("Credit bundle updated.", { id: "pro-tier-change" });
+          }
+        },
+        onError: (error) => {
+          toast.error(
+            extractMutationError(
+              error,
+              "Failed to change credit bundle. Please try again.",
+            ),
+            { id: "pro-tier-change-error" },
+          );
+        },
+      },
+    );
+  };
+
   // Fire only the dimension(s) that actually changed.
   const submitTierChanges = () => {
     if (machineChanged) submitMachineTierChange();
     if (storageChanged) submitStorageTierChange();
+    if (creditChanged) submitCreditTierChange();
   };
 
   // When the machine tier is being lowered, defer the whole apply behind the
@@ -616,7 +717,8 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                                   {Math.round(
                                     (plan.base_price_cents +
                                       currentMachinePrice +
-                                      currentStoragePrice) /
+                                      currentStoragePrice +
+                                      currentCreditPriceCents) /
                                       100,
                                   )}
                                 </Typography>
@@ -676,6 +778,14 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                                 onMachineTierChange={setSelectedMachineTier}
                                 onStorageTierChange={setSelectedStorageTier}
                               />
+                              {creditTiersEnabled && (
+                                <CreditBundlePicker
+                                  creditTiers={creditTiers}
+                                  selectedCreditTier={selectedCreditTier}
+                                  onCreditTierChange={setSelectedCreditTier}
+                                  disabled={upgradeMutation.isPending}
+                                />
+                              )}
                               <Button
                                 variant="primary"
                                 className="w-full"
@@ -716,10 +826,25 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                                   currentMachinePriceCents={currentMachinePrice}
                                   currentStoragePriceCents={currentStoragePrice}
                                 />
-                                {(changeMachineTierMutation.isError || changeStorageTierMutation.isError) && (
+                                {creditTiersEnabled && (
+                                  <CreditBundlePicker
+                                    creditTiers={creditTiers}
+                                    selectedCreditTier={selectedCreditTier}
+                                    onCreditTierChange={setSelectedCreditTier}
+                                    currentCreditPriceCents={
+                                      currentCreditPriceCents
+                                    }
+                                    disabled={tierChangePending}
+                                  />
+                                )}
+                                {(changeMachineTierMutation.isError ||
+                                  changeStorageTierMutation.isError ||
+                                  changeCreditTierMutation.isError) && (
                                   <Notice tone="error">
                                     {extractMutationError(
-                                      changeMachineTierMutation.error ?? changeStorageTierMutation.error,
+                                      changeMachineTierMutation.error ??
+                                        changeStorageTierMutation.error ??
+                                        changeCreditTierMutation.error,
                                       "Failed to update plan. Please try again.",
                                     )}
                                   </Notice>
@@ -730,7 +855,9 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                                   onClick={handleApplyTierChange}
                                   disabled={
                                     tierChangePending ||
-                                    (!machineChanged && !storageChanged)
+                                    (!machineChanged &&
+                                      !storageChanged &&
+                                      !creditChanged)
                                   }
                                   data-testid="modal-change-tier-button"
                                 >

--- a/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
@@ -110,21 +110,26 @@ export function resolveTierSelection<T extends string>(
 }
 
 /**
- * Resolve which credit tier should be selected given the user's previous choice
- * and the current catalog. Mirrors `resolveTierSelection` but for credit
- * bundles, which have no disabled state and where `null` ("No bundle") is always
- * a valid selection: keep `prev` only if it is still present in the catalog,
- * otherwise fall back to `null`.
+ * Resolve which credit tier should be selected given the previous selection,
+ * the resolved current bundle, and the live catalog. Mirrors
+ * `resolveTierSelection` but for credit bundles, which have no disabled state
+ * and where both `null` ("No bundle") and a catalog tier are valid selections.
  *
- * Revalidating guards the case where a plans refetch removes the
- * previously-selected bundle while the modal is open.
+ * `prev` carries the sentinel meaning: `undefined` is un-seeded (the effect has
+ * not yet seeded a value), so we seed to `current`. A non-undefined `prev`
+ * (including an explicit `null` for "No bundle") is the user's standing choice
+ * and must be preserved — we keep it, only revalidating a concrete tier against
+ * the catalog so a refetch that removes the selected bundle falls back to
+ * "No bundle" rather than leaving a stale tier the CTA would submit.
  */
 export function resolveCreditTierSelection(
   tiers: CreditTier[],
-  prev: CreditTierEnum | null,
+  prev: CreditTierEnum | null | undefined,
+  current: CreditTierEnum | null,
 ): CreditTierEnum | null {
-  if (prev !== null && tiers.some((t) => t.tier === prev)) {
-    return prev;
+  const seeded = prev === undefined ? current : prev;
+  if (seeded !== null && tiers.some((t) => t.tier === seeded)) {
+    return seeded;
   }
   return null;
 }
@@ -171,8 +176,13 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
     useState<MachineTierEnum | null>(null);
   const [selectedStorageTier, setSelectedStorageTier] =
     useState<StorageTierEnum | null>(null);
+  // `undefined` is the un-seeded sentinel (before the seeding effect runs);
+  // `null` is the user's explicit "No bundle" choice. Machine/storage don't need
+  // this distinction because `null` is never a valid selection for them, but for
+  // credits both values are meaningful — see `creditChanged` and the seeding
+  // effect for why conflating them caused spurious bundle removals.
   const [selectedCreditTier, setSelectedCreditTier] =
-    useState<CreditTierEnum | null>(null);
+    useState<CreditTierEnum | null | undefined>(undefined);
 
   // On native (Capacitor iOS), Stripe Checkout / the billing portal opens in
   // SFSafariViewController as a popover on top of the app. When the user
@@ -255,6 +265,13 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
     creditTiers.find((t) => t.tier === tier)?.price_cents ?? 0;
   const currentCreditPriceCents = priceForCredit(currentCreditTier);
 
+  // The picker and the mutation bodies require `CreditTierEnum | null` — never
+  // the un-seeded `undefined` sentinel. While un-seeded, fall back to the
+  // current bundle (which is `null` for a Base user upgrading), matching what
+  // the seeding effect will resolve to so display and the pre-seed value agree.
+  const displayCreditTier: CreditTierEnum | null =
+    selectedCreditTier === undefined ? currentCreditTier : selectedCreditTier;
+
   // For an active Pro subscriber, disable any storage tier strictly below the
   // current selection — downgrading storage is not allowed. TierPicker honors
   // the `disabled` flag via `isTierDisabled`; machine tiers stay fully enabled
@@ -280,7 +297,9 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
     if (!open) {
       setSelectedMachineTier(null);
       setSelectedStorageTier(null);
-      setSelectedCreditTier(null);
+      // Reset to the un-seeded sentinel (not null, which is a valid "No bundle"
+      // choice) so the next open re-seeds from the current bundle.
+      setSelectedCreditTier(undefined);
       return;
     }
     if (!proPlan) return;
@@ -300,12 +319,14 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
           prev ?? currentStorageTier,
         ),
       );
-      // Seed the credit bundle from the subscription's current selection,
-      // revalidating against the live catalog: keep the prior/current choice
-      // only if it still exists in `credit_tiers`, else fall back to null
-      // (no bundle). null is always a valid selection.
+      // Seed the credit bundle from the subscription's current selection only
+      // while un-seeded (`prev === undefined`); once the user has chosen,
+      // `resolveCreditTierSelection` preserves their choice — including an
+      // explicit `null` ("No bundle") — and only revalidates a concrete tier
+      // against the live catalog. This stops a mid-modal refetch from snapping a
+      // pending removal back to the existing bundle.
       setSelectedCreditTier((prev) =>
-        resolveCreditTierSelection(creditTiers, prev ?? currentCreditTier),
+        resolveCreditTierSelection(creditTiers, prev, currentCreditTier),
       );
       return;
     }
@@ -315,10 +336,11 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
     setSelectedStorageTier((prev) =>
       resolveTierSelection<StorageTierEnum>(proPlan.storage_tiers, prev),
     );
-    // Base upgrade defaults to no bundle ($0); revalidate any prior choice
-    // against the live catalog.
+    // Base upgrade has no current bundle, so it seeds to null ("No bundle",
+    // $0); `resolveCreditTierSelection` then preserves any prior choice and
+    // revalidates a concrete tier against the live catalog.
     setSelectedCreditTier((prev) =>
-      resolveCreditTierSelection(creditTiers, prev),
+      resolveCreditTierSelection(creditTiers, prev, null),
     );
     // machineTiersForPicker/storageTiersForPicker/creditTiers are derived from
     // proPlan + onboarding values already in the dep list; omitting them keeps
@@ -355,7 +377,7 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
           storage_tier: selectedStorageTier,
           // null = "No bundle". The backend ignores this when the credit-bundles
           // flag is off, so always sending it is safe.
-          credit_tier: selectedCreditTier,
+          credit_tier: displayCreditTier,
         },
       },
       {
@@ -420,8 +442,15 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
     selectedMachineTier != null && selectedMachineTier !== currentMachineTier;
   const storageChanged =
     selectedStorageTier != null && selectedStorageTier !== currentStorageTier;
+  // Gate on `!== undefined` (un-seeded) the way machine/storage gate on
+  // `!= null` — until the effect seeds, there is no user-intended change, so a
+  // pre-seed `undefined` vs. existing `currentCreditTier` must not enable the
+  // CTA or submit `credit_tier: null`. Once seeded, `null` ("No bundle") is a
+  // valid value, so we compare directly rather than gating on non-null.
   const creditChanged =
-    creditTiersEnabled && selectedCreditTier !== currentCreditTier;
+    creditTiersEnabled &&
+    selectedCreditTier !== undefined &&
+    selectedCreditTier !== currentCreditTier;
 
   const priceForMachine = (tier: MachineTierEnum | null): number | null =>
     machineTiersForPicker.find((t) => t.tier === tier)?.price_cents ?? null;
@@ -497,7 +526,9 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
     changeCreditTierMutation.mutate(
       // null removes the bundle ("No bundle"). Bundle changes apply at the next
       // cycle — no proration/immediate-charge subtleties — so no reconfirm.
-      { body: { credit_tier: selectedCreditTier } },
+      // `creditChanged` already gates out the un-seeded state, so this only runs
+      // with a seeded value, but coalesce defensively to never send `undefined`.
+      { body: { credit_tier: displayCreditTier } },
       {
         onSuccess: () => {
           // Refresh billing so the plan card and this modal reflect the new
@@ -780,7 +811,7 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                               {creditTiersEnabled && (
                                 <CreditBundlePicker
                                   creditTiers={creditTiers}
-                                  selectedCreditTier={selectedCreditTier}
+                                  selectedCreditTier={displayCreditTier}
                                   onCreditTierChange={setSelectedCreditTier}
                                   disabled={upgradeMutation.isPending}
                                 />
@@ -828,7 +859,7 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                                 {creditTiersEnabled && (
                                   <CreditBundlePicker
                                     creditTiers={creditTiers}
-                                    selectedCreditTier={selectedCreditTier}
+                                    selectedCreditTier={displayCreditTier}
                                     onCreditTierChange={setSelectedCreditTier}
                                     currentCreditPriceCents={
                                       currentCreditPriceCents

--- a/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
@@ -500,15 +500,14 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
       { body: { credit_tier: selectedCreditTier } },
       {
         onSuccess: () => {
-          // Refresh the subscription (and the rest of billing) so the plan card
-          // and this modal reflect the new bundle.
+          // Refresh billing so the plan card and this modal reflect the new
+          // bundle. A credit change never alters machine/storage resources, so
+          // it must not invoke `onTierUpgraded` (the assistant resize flow) —
+          // that would show an unrelated resize prompt and fire needless
+          // resource queries. `submitTierChanges` still opens the resize flow
+          // when a machine or storage dimension also changed.
           invalidateBillingQueries();
-          if (onTierUpgraded) {
-            onClose();
-            onTierUpgraded();
-          } else {
-            toast.success("Credit bundle updated.", { id: "pro-tier-change" });
-          }
+          toast.success("Credit bundle updated.", { id: "pro-tier-change" });
         },
         onError: (error) => {
           toast.error(


### PR DESCRIPTION
## Summary
- Wire CreditBundlePicker into AdjustPlanModal for both Base→Pro upgrade and existing-Pro change flows
- Upgrade forwards credit_tier; change calls the change-credit-tier mutation, factors the bundle into the total, and refreshes on success
- Catalog-gated: all credit UI/logic hidden when the catalog has no credit_tiers

Part of plan: pro-credit-bundles-frontend.md (PR 4 of 4)