### PR TITLE
Fix Temperature toggle layout and rename Inherit button to Reset

### DIFF
--- a/apps/web/src/domains/settings/ai/profile-advanced-params.tsx
+++ b/apps/web/src/domains/settings/ai/profile-advanced-params.tsx
@@ -141,7 +141,7 @@ export function ProfileAdvancedParams({
               onClick={() => onMaxTokensChange(null)}
               disabled={isReadOnly || maxTokens === null}
             >
-              Inherit
+              Reset
             </Button>
           </div>
         </div>
@@ -184,7 +184,7 @@ export function ProfileAdvancedParams({
               onClick={() => onContextWindowChange(null)}
               disabled={isReadOnly || contextWindowMaxInputTokens === null}
             >
-              Inherit
+              Reset
             </Button>
           </div>
         </div>
@@ -241,17 +241,12 @@ export function ProfileAdvancedParams({
       {/* Temperature */}
       {visibility.temperature && (
         <div className="space-y-2">
-          <div className="flex items-center justify-between">
-            <label className="block text-body-small-default text-[var(--content-tertiary)]">
-              Temperature
-            </label>
-            <Toggle
-              checked={temperatureEnabled}
-              onChange={(v) => onTemperatureEnabledChange(v)}
-              disabled={isReadOnly}
-              aria-label="Enable temperature override"
-            />
-          </div>
+          <Toggle
+            checked={temperatureEnabled}
+            onChange={(v) => onTemperatureEnabledChange(v)}
+            label="Temperature"
+            disabled={isReadOnly}
+          />
           {temperatureEnabled && (
             <div className="flex items-center justify-between">
               <div className="flex-1">


### PR DESCRIPTION
## Summary
Two small UI fixes in the profile editor's Advanced params section:
- **Temperature toggle layout** — now uses the design-system `Toggle` `label` prop so the switch sits to the left of the "Temperature" label, matching the Extended Thinking toggle. It was previously hand-rolled with `justify-between`, pushing the switch to the far right.
- **"Inherit" button renamed to "Reset"** (Max Output Tokens and Context Window sliders). The slider's reset control now reads "Reset" (the action); the top-right value still reads "Inherit" when un-pinned (the state), removing the ambiguity of showing a number and "Inherit" in the same row.