### PR TITLE
Allowlist login page robots indexing

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -3,6 +3,22 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="robots" content="noindex, nofollow" />
+  <script data-robots-allowlist>
+    (function() {
+      try {
+        var path = window.location.pathname;
+        if (path.length > 1 && path.endsWith("/")) {
+          path = path.slice(0, -1);
+        }
+        if (path === "/account/login") {
+          var robots = document.querySelector('meta[name="robots"]');
+          if (robots) robots.remove();
+        }
+      } catch {
+        // Robots metadata must never block app startup.
+      }
+    })();
+  </script>
   <!-- viewport-fit=cover is required for iOS WKWebView to expose env(safe-area-inset-*);
        without it the Capacitor shell renders under the notch / home indicator. -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />

--- a/apps/web/src/index-html-robots.test.ts
+++ b/apps/web/src/index-html-robots.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, test } from "bun:test";
+
+const INDEX_HTML = readFileSync(new URL("../index.html", import.meta.url), "utf8");
+
+function readHeadHtml(): string {
+  const match = /<head>([\s\S]*?)<\/head>/.exec(INDEX_HTML);
+  expect(match).not.toBeNull();
+  return match![1]!;
+}
+
+function readRobotsAllowlistScript(): string {
+  const match =
+    /<script data-robots-allowlist>([\s\S]*?)<\/script>/.exec(INDEX_HTML);
+  expect(match).not.toBeNull();
+  return match![1]!;
+}
+
+function runRobotsAllowlist(pathname: string): HTMLMetaElement | null {
+  window.history.pushState(null, "", pathname);
+  document.head.innerHTML = readHeadHtml();
+
+  // Execute the exact inline script from index.html after the head is parsed.
+  new Function(readRobotsAllowlistScript())();
+
+  return document.querySelector('meta[name="robots"]');
+}
+
+describe("index.html robots metadata", () => {
+  test("keeps app routes noindexed by default", () => {
+    expect(
+      runRobotsAllowlist("/assistant/conversations/conversation-123")?.content,
+    ).toBe("noindex, nofollow");
+  });
+
+  test("keeps non-login account routes noindexed by default", () => {
+    expect(runRobotsAllowlist("/account/provider/callback")?.content).toBe(
+      "noindex, nofollow",
+    );
+  });
+
+  test("removes the robots tag for the login page", () => {
+    expect(runRobotsAllowlist("/account/login")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Restored noindex/nofollow as the default robots metadata for the shared web SPA shell.
- Added a narrow /account/login allowlist that removes the robots tag for the login page before the React app boots.
- Added a regression test proving app routes and non-login account routes stay noindexed while /account/login is allowed.

## Original prompt

User noticed /account/login was served with noindex,nofollow and asked to make reasonable public pages like login indexable without making the whole app indexable.

## Notes

Because apps/web is a static SPA shell, true server-emitted per-route robots metadata would require the static SPA host/platform layer to serve path-specific HTML or X-Robots-Tag headers. This PR keeps the repo-local change conservative: default noindex remains in source HTML, and only the login route is allowlisted for JS-executing crawlers.