### PR TITLE
feat(cli): carry the pair refresh token through the bundle + persist on import

### DIFF
--- a/cli/src/__tests__/connect-import.test.ts
+++ b/cli/src/__tests__/connect-import.test.ts
@@ -71,6 +71,36 @@ describe("connect import", () => {
     expect(entry!.runtimeUrl).toBe("http://10.0.0.5:7830");
     expect(entry!.cloud).toBe("paired");
     expect(loadGuardianToken("paired-dev-aaa")?.accessToken).toBe("test-token");
+    // Back-compat: a bundle without refresh fields imports access-only.
+    expect(loadGuardianToken("paired-dev-aaa")?.refreshToken).toBe("");
+  });
+
+  test("persists the refresh credential when the bundle carries one", async () => {
+    process.argv = [
+      "bun",
+      "vellum",
+      "connect",
+      "import",
+      bundleFor({
+        deviceId: "dev-refresh",
+        token: "acc-tok",
+        refreshToken: "refresh-tok",
+        refreshTokenExpiresAt: "2027-01-01T00:00:00.000Z",
+        refreshAfter: "2026-07-01T00:00:00.000Z",
+      }),
+    ];
+    const logSpy = spyOn(console, "log").mockImplementation(() => {});
+    try {
+      await connectImport();
+    } finally {
+      logSpy.mockRestore();
+    }
+
+    const tok = loadGuardianToken("paired-dev-refresh");
+    expect(tok?.accessToken).toBe("acc-tok");
+    expect(tok?.refreshToken).toBe("refresh-tok");
+    expect(tok?.refreshTokenExpiresAt).toBe("2027-01-01T00:00:00.000Z");
+    expect(tok?.refreshAfter).toBe("2026-07-01T00:00:00.000Z");
   });
 
   test("two different bundles (both assistantId 'self') do not collide", async () => {

--- a/cli/src/__tests__/connect-import.test.ts
+++ b/cli/src/__tests__/connect-import.test.ts
@@ -103,6 +103,33 @@ describe("connect import", () => {
     expect(tok?.refreshAfter).toBe("2026-07-01T00:00:00.000Z");
   });
 
+  test("preserves a numeric (epoch-ms) refreshTokenExpiresAt", async () => {
+    // GuardianTokenData allows refreshTokenExpiresAt to be an epoch-ms number;
+    // a numeric value in the bundle must round-trip, not be dropped to 0.
+    const expiresMs = 1893456000000; // 2030-01-01
+    process.argv = [
+      "bun",
+      "vellum",
+      "connect",
+      "import",
+      bundleFor({
+        deviceId: "dev-num",
+        refreshToken: "refresh-tok",
+        refreshTokenExpiresAt: expiresMs,
+      }),
+    ];
+    const logSpy = spyOn(console, "log").mockImplementation(() => {});
+    try {
+      await connectImport();
+    } finally {
+      logSpy.mockRestore();
+    }
+
+    expect(loadGuardianToken("paired-dev-num")?.refreshTokenExpiresAt).toBe(
+      expiresMs,
+    );
+  });
+
   test("two different bundles (both assistantId 'self') do not collide", async () => {
     process.argv = [
       "bun",

--- a/cli/src/commands/connect/import.ts
+++ b/cli/src/commands/connect/import.ts
@@ -46,11 +46,13 @@ interface PairBundle {
   token: string;
   assistantId?: string;
   deviceId?: string;
-  // Optional refresh credential (ISO-8601 strings). Present when the host's
-  // gateway issued a device-bound token pair; absent for older access-only
-  // bundles (which remain importable, just without auto-renewal).
+  // Optional refresh credential. Present when the host's gateway issued a
+  // device-bound token pair; absent for older access-only bundles (which remain
+  // importable, just without auto-renewal). `refreshTokenExpiresAt` mirrors
+  // GuardianTokenData (ISO string OR epoch-ms number) so a numeric expiry isn't
+  // silently dropped on import.
   refreshToken?: string;
-  refreshTokenExpiresAt?: string;
+  refreshTokenExpiresAt?: string | number;
   refreshAfter?: string;
 }
 
@@ -86,7 +88,8 @@ function decodeBundle(blob: string): PairBundle | null {
     refreshToken:
       typeof b.refreshToken === "string" ? b.refreshToken : undefined,
     refreshTokenExpiresAt:
-      typeof b.refreshTokenExpiresAt === "string"
+      typeof b.refreshTokenExpiresAt === "string" ||
+      typeof b.refreshTokenExpiresAt === "number"
         ? b.refreshTokenExpiresAt
         : undefined,
     refreshAfter:

--- a/cli/src/commands/connect/import.ts
+++ b/cli/src/commands/connect/import.ts
@@ -46,6 +46,12 @@ interface PairBundle {
   token: string;
   assistantId?: string;
   deviceId?: string;
+  // Optional refresh credential (ISO-8601 strings). Present when the host's
+  // gateway issued a device-bound token pair; absent for older access-only
+  // bundles (which remain importable, just without auto-renewal).
+  refreshToken?: string;
+  refreshTokenExpiresAt?: string;
+  refreshAfter?: string;
 }
 
 /** Decode the base64 bundle, returning null if malformed or missing fields. */
@@ -77,6 +83,14 @@ function decodeBundle(blob: string): PairBundle | null {
     token: b.token,
     assistantId: typeof b.assistantId === "string" ? b.assistantId : undefined,
     deviceId: typeof b.deviceId === "string" ? b.deviceId : undefined,
+    refreshToken:
+      typeof b.refreshToken === "string" ? b.refreshToken : undefined,
+    refreshTokenExpiresAt:
+      typeof b.refreshTokenExpiresAt === "string"
+        ? b.refreshTokenExpiresAt
+        : undefined,
+    refreshAfter:
+      typeof b.refreshAfter === "string" ? b.refreshAfter : undefined,
   };
 }
 
@@ -172,14 +186,15 @@ export async function connectImport(): Promise<void> {
   });
 
   const now = Date.now();
+  const hasRefresh = Boolean(bundle.refreshToken);
   saveGuardianToken(localId, {
     guardianPrincipalId: "imported",
     accessToken: bundle.token,
     accessTokenExpiresAt:
       jwtExpiryMs(bundle.token) ?? now + 24 * 60 * 60 * 1000,
-    refreshToken: "",
-    refreshTokenExpiresAt: 0,
-    refreshAfter: "",
+    refreshToken: bundle.refreshToken ?? "",
+    refreshTokenExpiresAt: bundle.refreshTokenExpiresAt ?? 0,
+    refreshAfter: bundle.refreshAfter ?? "",
     isNew: false,
     deviceId: bundle.deviceId ?? "",
     leasedAt: new Date(now).toISOString(),
@@ -192,6 +207,8 @@ export async function connectImport(): Promise<void> {
   console.log(`  Connect with:  vellum client ${localId}`);
   console.log("");
   console.log(
-    "Note: the token is access-only and will expire — re-run `vellum pair` and import again when it does.",
+    hasRefresh
+      ? "Note: this connection includes a refresh credential, so it can renew itself — re-pair only if it's revoked or the refresh credential expires."
+      : "Note: the token is access-only and will expire — re-run `vellum pair` and import again when it does.",
   );
 }

--- a/cli/src/commands/pair.ts
+++ b/cli/src/commands/pair.ts
@@ -64,6 +64,11 @@ interface PairResponse {
   expiresAt: string;
   guardianId: string;
   assistantId: string;
+  // Present on the device-bound path: a long-lived refresh credential the
+  // imported client uses to renew its access token (ISO-8601 strings).
+  refreshToken?: string;
+  refreshTokenExpiresAt?: string;
+  refreshAfter?: string;
 }
 
 export async function pair(): Promise<void> {
@@ -183,6 +188,16 @@ export async function pair(): Promise<void> {
     assistantId: result.assistantId,
     token: result.token,
     deviceId,
+    // Carry the refresh credential through when the gateway issued one, so the
+    // imported client can renew without re-pairing. Omitted entirely for an
+    // access-only (older gateway) response so the bundle stays clean.
+    ...(result.refreshToken
+      ? {
+          refreshToken: result.refreshToken,
+          refreshTokenExpiresAt: result.refreshTokenExpiresAt,
+          refreshAfter: result.refreshAfter,
+        }
+      : {}),
   };
   const blob = Buffer.from(JSON.stringify(bundle)).toString("base64");
 


### PR DESCRIPTION
## Summary
- `vellum pair` now carries the refresh credential through the handoff bundle: `PairResponse` and the base64 bundle gain optional `refreshToken` / `refreshTokenExpiresAt` / `refreshAfter`, included **only when** the gateway returned them (R1, #33458). Older access-only responses produce an unchanged bundle.
- `vellum connect import` now **persists** those fields instead of hard-zeroing them — so a paired machine's guardian-token holds a real refresh token (with a future expiry), which makes the existing `refreshGuardianToken` machinery usable. The closing note reflects whether the connection can self-renew.
- **Back-compatible:** a bundle without the refresh fields imports exactly as before (empty `refreshToken`, access-only) — covered by a regression assertion.

## Scope / sequencing
- This is **Slice R2** of refreshable pairing. **R1** (#33458, gateway issues the refresh token) and **R3** (client-side auto-refresh — actually *consuming* the stored refresh token via `refreshGuardianToken`, with proactive renewal + 401-retry) are the other two slices. R2 only plumbs and stores the credential; it does **not** wire client auto-refresh (that's R3).
- End-to-end this only takes effect once R1 is also deployed (gateway must return the refresh fields). Until R3 lands, the stored refresh token sits unused — no behavior change for users yet.

## Tests
- connect import of a bundle **with** refresh fields → `loadGuardianToken` returns the persisted `refreshToken`/`refreshTokenExpiresAt`/`refreshAfter`.
- connect import of a bundle **without** them → still imports, `refreshToken === ""` (back-compat).
- `vellum pair` has no clean unit-test seam (resolves a reachable URL + hits the gateway), so its bundle-carrying is verified structurally via the conditional spread rather than a unit test.

## Original prompt
Continuing refreshable pairing: R1 makes the gateway issue a device-bound refresh token from `/v1/pair`, but the CLI still drops it — `vellum pair` serializes only the access token and `connect import` stores an empty refresh token, so paired machines must re-pair on expiry. This slice carries the refresh credential through the bundle and persists it on import (kept back-compatible), setting up R3 to consume it for transparent renewal.