### PR TITLE
fix(web): use 400 weight for credits row text and button label

### DIFF
--- a/apps/web/src/domains/chat/components/credits-card.tsx
+++ b/apps/web/src/domains/chat/components/credits-card.tsx
@@ -30,7 +30,7 @@ export function CreditsCard({ balance, onAddCredits }: CreditsCardProps) {
           aria-hidden
         />
         <span
-          className="text-body-medium-default max-md:text-title-medium text-[color:var(--content-default)]"
+          className="text-body-medium-default font-normal! max-md:text-title-medium text-[color:var(--content-default)]"
           aria-label={`${balance} credits`}
         >
           {balance} c
@@ -48,7 +48,7 @@ export function CreditsCard({ balance, onAddCredits }: CreditsCardProps) {
         variant="ghost"
         size="regular"
         onClick={onAddCredits}
-        className="h-6 gap-1 px-1.5"
+        className="h-6 gap-1 px-1.5 font-normal!"
       >
         <Plus className="h-3.5 w-3.5" aria-hidden />
         Credits


### PR DESCRIPTION
## Summary
Both the credits balance text and the "Credits" button label in the web preferences menu rendered at font-weight **500** (inherited from the shared `text-body-medium-default` token). This changes both to weight **400**.

## Changes
- `apps/web/src/domains/chat/components/credits-card.tsx`
  - Balance span: add `font-normal!`
  - "Credits" Button: add `font-normal!`

`font-normal!` uses the Tailwind v4 important modifier so the 400 weight reliably wins over the custom `text-body-medium-default` `@utility` (which sets `font-weight: 500`). Scoped to these two elements only — the shared token and the `Button` component are untouched.

## Verification
- Open Preferences in the web app; the credits balance and "Credits" button label should render at the lighter 400 weight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)