### PR TITLE
feat(cli): auto-refresh paired access tokens on 401 (message/events)

### DIFF
--- a/cli/src/__tests__/assistant-client-refresh.test.ts
+++ b/cli/src/__tests__/assistant-client-refresh.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests for AssistantClient's reactive 401 -> refresh -> retry: a paired/local
+ * guardian access token that 401s is refreshed once via the stored refresh
+ * credential and the request retried. Self-gating (no refresh token => no
+ * retry) and never applied to the platform session-auth path.
+ */
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const testDir = mkdtempSync(join(tmpdir(), "client-refresh-test-"));
+const ORIGINAL_LOCKFILE_DIR = process.env.VELLUM_LOCKFILE_DIR;
+const ORIGINAL_CONFIG_HOME = process.env.XDG_CONFIG_HOME;
+const ORIGINAL_FETCH = globalThis.fetch;
+
+import { AssistantClient } from "../lib/assistant-client.js";
+import { saveAssistantEntry } from "../lib/assistant-config.js";
+import { loadGuardianToken, saveGuardianToken } from "../lib/guardian-token.js";
+
+const RUNTIME = "http://10.0.0.9:7830";
+const FUTURE = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString();
+
+function seedPaired(refreshToken: string): void {
+  saveAssistantEntry({
+    assistantId: "px",
+    name: "Paired",
+    runtimeUrl: RUNTIME,
+    cloud: "paired",
+    paired: true,
+    species: "vellum",
+  });
+  saveGuardianToken("px", {
+    guardianPrincipalId: "imported",
+    accessToken: "old-acc",
+    accessTokenExpiresAt: FUTURE,
+    refreshToken,
+    refreshTokenExpiresAt: refreshToken ? FUTURE : 0,
+    refreshAfter: "",
+    isNew: false,
+    deviceId: "dev",
+    leasedAt: new Date().toISOString(),
+  });
+}
+
+interface Call {
+  url: string;
+  headers: Record<string, string>;
+}
+
+/** Replace global fetch with a URL-routed stub; returns the call log. */
+function stubFetch(handler: (url: string, calls: Call[]) => Response): Call[] {
+  const calls: Call[] = [];
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : String(input);
+    calls.push({
+      url,
+      headers: (init?.headers ?? {}) as Record<string, string>,
+    });
+    return handler(url, calls);
+  }) as typeof fetch;
+  return calls;
+}
+
+const isRefresh = (url: string) => url.includes("/v1/guardian/refresh");
+
+function refreshResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      accessToken: "new-acc",
+      refreshToken: "new-ref",
+      accessTokenExpiresAt: FUTURE,
+      refreshTokenExpiresAt: FUTURE,
+      refreshAfter: "",
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+describe("AssistantClient 401 -> refresh -> retry", () => {
+  beforeEach(() => {
+    process.env.VELLUM_LOCKFILE_DIR = testDir;
+    process.env.XDG_CONFIG_HOME = testDir;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = ORIGINAL_FETCH;
+    if (ORIGINAL_LOCKFILE_DIR === undefined)
+      delete process.env.VELLUM_LOCKFILE_DIR;
+    else process.env.VELLUM_LOCKFILE_DIR = ORIGINAL_LOCKFILE_DIR;
+    if (ORIGINAL_CONFIG_HOME === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = ORIGINAL_CONFIG_HOME;
+  });
+
+  afterAll(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  test("refreshes and retries once on 401, persisting the new token", async () => {
+    seedPaired("refresh-tok");
+    let assistantAttempts = 0;
+    const calls = stubFetch((url) => {
+      if (isRefresh(url)) return refreshResponse();
+      assistantAttempts++;
+      return new Response("", { status: assistantAttempts === 1 ? 401 : 200 });
+    });
+
+    const client = new AssistantClient({ assistantId: "px" });
+    const res = await client.get("/messages/");
+
+    expect(res.status).toBe(200);
+    expect(assistantAttempts).toBe(2); // original + one retry
+    expect(calls.filter((c) => isRefresh(c.url))).toHaveLength(1);
+    // The retry carried the refreshed bearer token.
+    const assistantCalls = calls.filter((c) => !isRefresh(c.url));
+    expect(assistantCalls[1].headers["Authorization"]).toBe("Bearer new-acc");
+    // refreshGuardianToken persisted the rotated token.
+    expect(loadGuardianToken("px")?.accessToken).toBe("new-acc");
+  });
+
+  test("does not retry when there is no stored refresh token", async () => {
+    seedPaired(""); // access-only
+    let assistantAttempts = 0;
+    const calls = stubFetch((url) => {
+      if (isRefresh(url)) return refreshResponse();
+      assistantAttempts++;
+      return new Response("", { status: 401 });
+    });
+
+    const client = new AssistantClient({ assistantId: "px" });
+    const res = await client.get("/messages/");
+
+    expect(res.status).toBe(401);
+    expect(assistantAttempts).toBe(1); // no retry
+    expect(calls.filter((c) => isRefresh(c.url))).toHaveLength(0);
+  });
+
+  test("never refreshes on the platform session-auth path", async () => {
+    seedPaired("refresh-tok"); // entry must exist; session auth ignores it
+    let assistantAttempts = 0;
+    const calls = stubFetch((url) => {
+      if (isRefresh(url)) return refreshResponse();
+      assistantAttempts++;
+      return new Response("", { status: 401 });
+    });
+
+    const client = new AssistantClient({
+      assistantId: "px",
+      sessionToken: "sess-tok",
+      orgId: "org-1",
+    });
+    const res = await client.get("/messages/");
+
+    expect(res.status).toBe(401);
+    expect(assistantAttempts).toBe(1);
+    expect(calls.filter((c) => isRefresh(c.url))).toHaveLength(0);
+  });
+
+  test("retries at most once (second 401 is not refreshed again)", async () => {
+    seedPaired("refresh-tok");
+    let assistantAttempts = 0;
+    const calls = stubFetch((url) => {
+      if (isRefresh(url)) return refreshResponse();
+      assistantAttempts++;
+      return new Response("", { status: 401 }); // always 401
+    });
+
+    const client = new AssistantClient({ assistantId: "px" });
+    const res = await client.get("/messages/");
+
+    expect(res.status).toBe(401);
+    expect(assistantAttempts).toBe(2); // original + one retry, no more
+    expect(calls.filter((c) => isRefresh(c.url))).toHaveLength(1);
+  });
+});

--- a/cli/src/__tests__/guardian-token.test.ts
+++ b/cli/src/__tests__/guardian-token.test.ts
@@ -1,11 +1,20 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 import {
   getOrCreatePersistedDeviceId,
   loadGuardianToken,
+  refreshGuardianToken,
   saveGuardianToken,
   seedGuardianTokenFromSiblingEnv,
   type GuardianTokenData,
@@ -221,5 +230,120 @@ describe("guardian-token paths are env-scoped", () => {
     expect(loadGuardianToken("alpha")!.guardianPrincipalId).toBe(
       "principal-local",
     );
+  });
+});
+
+describe("refreshGuardianToken", () => {
+  let tempHome: string;
+  let savedXdg: string | undefined;
+  let savedEnv: string | undefined;
+  const ORIGINAL_FETCH = globalThis.fetch;
+
+  const future = () => new Date(Date.now() + 60 * 60 * 1000).toISOString();
+
+  function lockPath(id: string): string {
+    return join(tempHome, "vellum", "assistants", id, "refresh.lock");
+  }
+
+  function seed(refreshExpiresAt: string | number): void {
+    saveGuardianToken("px", {
+      guardianPrincipalId: "imported",
+      accessToken: "old-acc",
+      accessTokenExpiresAt: future(),
+      refreshToken: "old-ref",
+      refreshTokenExpiresAt: refreshExpiresAt,
+      refreshAfter: "",
+      isNew: false,
+      deviceId: "dev",
+      leasedAt: new Date().toISOString(),
+    });
+  }
+
+  beforeEach(() => {
+    savedXdg = process.env.XDG_CONFIG_HOME;
+    savedEnv = process.env.VELLUM_ENVIRONMENT;
+    tempHome = mkdtempSync(join(tmpdir(), "cli-refresh-test-"));
+    process.env.XDG_CONFIG_HOME = tempHome;
+    delete process.env.VELLUM_ENVIRONMENT;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = ORIGINAL_FETCH;
+    if (savedXdg === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = savedXdg;
+    if (savedEnv === undefined) delete process.env.VELLUM_ENVIRONMENT;
+    else process.env.VELLUM_ENVIRONMENT = savedEnv;
+    rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  test("refreshes, persists the rotated token, sends an abort signal, releases the lock", async () => {
+    seed(future());
+    let sawSignal = false;
+    globalThis.fetch = (async (_url: unknown, init?: RequestInit) => {
+      sawSignal = init?.signal instanceof AbortSignal;
+      return new Response(
+        JSON.stringify({
+          accessToken: "new-acc",
+          refreshToken: "new-ref",
+          accessTokenExpiresAt: future(),
+          refreshTokenExpiresAt: future(),
+          refreshAfter: "",
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    const result = await refreshGuardianToken("http://10.0.0.9:7830", "px");
+
+    expect(result?.accessToken).toBe("new-acc");
+    expect(loadGuardianToken("px")?.accessToken).toBe("new-acc");
+    expect(sawSignal).toBe(true); // fetch carries a timeout AbortSignal
+    expect(existsSync(lockPath("px"))).toBe(false); // lock released
+  });
+
+  test("returns null without calling the gateway when the refresh token is expired", async () => {
+    seed(new Date(Date.now() - 1000).toISOString());
+    let called = false;
+    globalThis.fetch = (async () => {
+      called = true;
+      return new Response("", { status: 200 });
+    }) as typeof fetch;
+
+    expect(await refreshGuardianToken("http://10.0.0.9:7830", "px")).toBeNull();
+    expect(called).toBe(false);
+  });
+
+  test("returns null when there is no stored token", async () => {
+    let called = false;
+    globalThis.fetch = (async () => {
+      called = true;
+      return new Response("", { status: 200 });
+    }) as typeof fetch;
+
+    expect(
+      await refreshGuardianToken("http://10.0.0.9:7830", "missing"),
+    ).toBeNull();
+    expect(called).toBe(false);
+  });
+
+  test("steals a stale lock and still refreshes", async () => {
+    seed(future());
+    // Pre-create a stale lock (mtime well in the past) as if a crashed holder
+    // left it behind; the refresh must steal it rather than block.
+    const lp = lockPath("px");
+    mkdirSync(dirname(lp), { recursive: true });
+    writeFileSync(lp, "99999");
+    const old = new Date(Date.now() - 60_000);
+    utimesSync(lp, old, old);
+
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ accessToken: "new-acc" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })) as typeof fetch;
+
+    const result = await refreshGuardianToken("http://10.0.0.9:7830", "px");
+    expect(result?.accessToken).toBe("new-acc");
+    expect(existsSync(lp)).toBe(false); // stolen lock cleaned up after release
   });
 });

--- a/cli/src/__tests__/guardian-token.test.ts
+++ b/cli/src/__tests__/guardian-token.test.ts
@@ -304,7 +304,7 @@ describe("refreshGuardianToken", () => {
   test("returns null without calling the gateway when the refresh token is expired", async () => {
     seed(new Date(Date.now() - 1000).toISOString());
     let called = false;
-    globalThis.fetch = (async () => {
+    globalThis.fetch = (async (_url: unknown, _init?: RequestInit) => {
       called = true;
       return new Response("", { status: 200 });
     }) as typeof fetch;
@@ -315,7 +315,7 @@ describe("refreshGuardianToken", () => {
 
   test("returns null when there is no stored token", async () => {
     let called = false;
-    globalThis.fetch = (async () => {
+    globalThis.fetch = (async (_url: unknown, _init?: RequestInit) => {
       called = true;
       return new Response("", { status: 200 });
     }) as typeof fetch;
@@ -336,7 +336,7 @@ describe("refreshGuardianToken", () => {
     const old = new Date(Date.now() - 60_000);
     utimesSync(lp, old, old);
 
-    globalThis.fetch = (async () =>
+    globalThis.fetch = (async (_url: unknown, _init?: RequestInit) =>
       new Response(JSON.stringify({ accessToken: "new-acc" }), {
         status: 200,
         headers: { "content-type": "application/json" },

--- a/cli/src/lib/assistant-client.ts
+++ b/cli/src/lib/assistant-client.ts
@@ -12,11 +12,9 @@
  * ```
  */
 
-import {
-  resolveAssistant,
-} from "./assistant-config.js";
+import { resolveAssistant } from "./assistant-config.js";
 import { GATEWAY_PORT } from "./constants.js";
-import { loadGuardianToken } from "./guardian-token.js";
+import { loadGuardianToken, refreshGuardianToken } from "./guardian-token.js";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 const FALLBACK_RUNTIME_URL = `http://127.0.0.1:${GATEWAY_PORT}`;
@@ -45,7 +43,8 @@ export class AssistantClient {
   readonly runtimeUrl: string;
 
   private readonly _assistantId: string;
-  private readonly token: string | undefined;
+  /** Mutable: a 401 on the guardian path refreshes this in place (see request). */
+  private token: string | undefined;
   /** True when token is a platform session token (X-Session-Token), false for guardian JWT (Authorization: Bearer). */
   private readonly isSessionAuth: boolean;
   private readonly orgId: string | undefined;
@@ -176,45 +175,67 @@ export class AssistantClient {
       ? `?${new URLSearchParams(opts.query).toString()}`
       : "";
     const url = `${this.runtimeUrl}/v1/assistants/${this._assistantId}${urlPath}${qs}`;
-
-    const headers: Record<string, string> = { ...opts?.headers };
-    if (this.token) {
-      if (this.isSessionAuth) {
-        headers["X-Session-Token"] ??= this.token;
-      } else {
-        headers["Authorization"] ??= `Bearer ${this.token}`;
-      }
-    }
-    if (this.orgId) {
-      headers["Vellum-Organization-Id"] ??= this.orgId;
-    }
-    if (body !== undefined) {
-      headers["Content-Type"] = "application/json";
-    }
-
     const jsonBody = body !== undefined ? JSON.stringify(body) : undefined;
 
-    if (opts?.signal) {
+    // Headers are built per-attempt so a refreshed token is picked up on retry.
+    const buildHeaders = (): Record<string, string> => {
+      const headers: Record<string, string> = { ...opts?.headers };
+      if (this.token) {
+        if (this.isSessionAuth) {
+          headers["X-Session-Token"] ??= this.token;
+        } else {
+          headers["Authorization"] ??= `Bearer ${this.token}`;
+        }
+      }
+      if (this.orgId) {
+        headers["Vellum-Organization-Id"] ??= this.orgId;
+      }
+      if (body !== undefined) {
+        headers["Content-Type"] = "application/json";
+      }
+      return headers;
+    };
+
+    const doFetch = (): Promise<Response> => {
+      const headers = buildHeaders();
+      if (opts?.signal) {
+        return fetch(url, {
+          method,
+          headers,
+          body: jsonBody,
+          signal: opts.signal,
+        });
+      }
+      const timeout = opts?.timeout ?? DEFAULT_TIMEOUT_MS;
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), timeout);
       return fetch(url, {
         method,
         headers,
         body: jsonBody,
-        signal: opts.signal,
-      });
+        signal: controller.signal,
+      }).finally(() => clearTimeout(timeoutId));
+    };
+
+    const response = await doFetch();
+
+    // Reactive auto-refresh: a paired/local guardian access token that has
+    // expired comes back 401. Refresh it once via the stored refresh credential
+    // and retry. Self-gating — refreshGuardianToken returns null unless a usable
+    // refresh token is stored, so ephemeral (`--token`) and access-only sessions
+    // just see the original 401. The platform session-auth path is never
+    // refreshed here (its token is managed by the Vellum platform).
+    if (response.status === 401 && !this.isSessionAuth) {
+      const refreshed = await refreshGuardianToken(
+        this.runtimeUrl,
+        this._assistantId,
+      );
+      if (refreshed?.accessToken) {
+        this.token = refreshed.accessToken;
+        return doFetch();
+      }
     }
 
-    const timeout = opts?.timeout ?? DEFAULT_TIMEOUT_MS;
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), timeout);
-    try {
-      return await fetch(url, {
-        method,
-        headers,
-        body: jsonBody,
-        signal: controller.signal,
-      });
-    } finally {
-      clearTimeout(timeoutId);
-    }
+    return response;
   }
 }

--- a/cli/src/lib/guardian-token.ts
+++ b/cli/src/lib/guardian-token.ts
@@ -255,6 +255,15 @@ export async function refreshGuardianToken(
     if (current && current.refreshToken !== before.refreshToken) {
       return current;
     }
+
+    // We did NOT acquire the lock (another process is likely mid-refresh) and
+    // the stored token hasn't been rotated yet. Do NOT call the gateway: our
+    // refresh token may be the one the winner is rotating right now, and
+    // replaying a rotated token revokes the whole family (forcing re-pair).
+    // Give up — the caller surfaces the original 401, and the next attempt
+    // picks up the winner's persisted token.
+    if (!locked) return null;
+
     const tokenData = current ?? before;
 
     const response = await fetch(`${gatewayUrl}/v1/guardian/refresh`, {

--- a/cli/src/lib/guardian-token.ts
+++ b/cli/src/lib/guardian-token.ts
@@ -2,11 +2,15 @@ import { createHash, randomUUID } from "node:crypto";
 import { execSync } from "node:child_process";
 import {
   chmodSync,
+  closeSync,
   existsSync,
   mkdirSync,
+  openSync,
   readFileSync,
   statSync,
+  unlinkSync,
   writeFileSync,
+  writeSync,
 } from "fs";
 import { platform } from "os";
 import { dirname, join } from "path";
@@ -161,26 +165,98 @@ export function saveGuardianToken(
   chmodSync(tokenPath, 0o600);
 }
 
+/** Abort the refresh POST if the gateway is slow/unreachable (it's now on the
+ *  hot request path, so it must never hang indefinitely). */
+const REFRESH_FETCH_TIMEOUT_MS = 15_000;
+/** Max time to wait for the per-assistant refresh lock before proceeding. */
+const REFRESH_LOCK_WAIT_MS = 10_000;
+/** A lock older than this is treated as stale (holder crashed) and stolen. */
+const REFRESH_LOCK_STALE_MS = 30_000;
+const REFRESH_LOCK_POLL_MS = 100;
+
+function getRefreshLockPath(assistantId: string): string {
+  return join(dirname(getGuardianTokenPath(assistantId)), "refresh.lock");
+}
+
+const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Best-effort exclusive cross-process lock for a per-assistant token refresh.
+ * Created atomically with `wx`; a stale lock (crashed holder) is stolen.
+ * Returns true if acquired, false if it timed out (caller proceeds degraded).
+ */
+async function acquireRefreshLock(lockPath: string): Promise<boolean> {
+  mkdirSync(dirname(lockPath), { recursive: true, mode: 0o700 });
+  const deadline = Date.now() + REFRESH_LOCK_WAIT_MS;
+  for (;;) {
+    try {
+      const fd = openSync(lockPath, "wx", 0o600);
+      writeSync(fd, String(process.pid));
+      closeSync(fd);
+      return true;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "EEXIST") return false;
+      try {
+        if (Date.now() - statSync(lockPath).mtimeMs > REFRESH_LOCK_STALE_MS) {
+          unlinkSync(lockPath); // steal a stale lock, then retry
+          continue;
+        }
+      } catch {
+        continue; // lock vanished between open and stat — retry
+      }
+      if (Date.now() >= deadline) return false;
+      await delay(REFRESH_LOCK_POLL_MS);
+    }
+  }
+}
+
+function releaseRefreshLock(lockPath: string): void {
+  try {
+    unlinkSync(lockPath);
+  } catch {
+    /* already released/stolen */
+  }
+}
+
 /**
  * Call POST /v1/guardian/refresh on the remote gateway to obtain a new
  * access token using an existing (possibly expired) access token for auth.
  * Returns the refreshed token data (persisted locally), or null if the
  * refresh fails (e.g. no stored token, or refresh token itself is expired).
+ *
+ * Concurrency-safe: the gateway rotates refresh tokens and treats reuse of an
+ * already-rotated token as replay (revoking the whole token family), so two
+ * processes (e.g. `vellum message` + `vellum events`) refreshing the same
+ * stored token at once would self-revoke and force re-pairing. We serialize on
+ * a per-assistant lock and, once held, re-read the stored token: if another
+ * process already rotated it while we waited, we return that fresh token
+ * instead of replaying our now-stale refresh token.
  */
 export async function refreshGuardianToken(
   gatewayUrl: string,
   assistantId: string,
 ): Promise<GuardianTokenData | null> {
-  const tokenData = loadGuardianToken(assistantId);
-  if (!tokenData) return null;
+  const before = loadGuardianToken(assistantId);
+  if (!before) return null;
 
   // Gateway persists expiresAt as epoch-ms numbers; Date.parse("1234567890000")
   // returns NaN. new Date() accepts both ISO strings and epoch-ms numbers.
-  const refreshExpiry = new Date(tokenData.refreshTokenExpiresAt).getTime();
+  const refreshExpiry = new Date(before.refreshTokenExpiresAt).getTime();
   if (!Number.isFinite(refreshExpiry) || refreshExpiry <= Date.now())
     return null;
 
+  const lockPath = getRefreshLockPath(assistantId);
+  const locked = await acquireRefreshLock(lockPath);
   try {
+    // Re-read under the lock: a concurrent process may have rotated the token
+    // while we waited. If the stored refresh token changed, ours is now stale
+    // (replaying it would trip reuse-detection) — use the fresh token instead.
+    const current = loadGuardianToken(assistantId);
+    if (current && current.refreshToken !== before.refreshToken) {
+      return current;
+    }
+    const tokenData = current ?? before;
+
     const response = await fetch(`${gatewayUrl}/v1/guardian/refresh`, {
       method: "POST",
       headers: {
@@ -188,6 +264,7 @@ export async function refreshGuardianToken(
         Authorization: `Bearer ${tokenData.accessToken}`,
       },
       body: JSON.stringify({ refreshToken: tokenData.refreshToken }),
+      signal: AbortSignal.timeout(REFRESH_FETCH_TIMEOUT_MS),
     });
     if (!response.ok) return null;
 
@@ -212,6 +289,8 @@ export async function refreshGuardianToken(
     return refreshed;
   } catch {
     return null;
+  } finally {
+    if (locked) releaseRefreshLock(lockPath);
   }
 }
 


### PR DESCRIPTION
## Summary
- `vellum message` and `vellum events` now **auto-refresh** a paired assistant's expired access token: `AssistantClient.request()` (the single chokepoint both commands route through) does a reactive **401 → refresh → retry**, calling the existing `refreshGuardianToken` (which rotates + persists the token) and retrying the request once with the new bearer.
- **Self-gating:** `refreshGuardianToken` returns null unless a usable stored refresh token exists, so ephemeral `--token` sessions and access-only/legacy imports just see the original 401 — no behavior change. The retry is bounded to **once** (a second 401 surfaces, no loop).
- **Skips the platform session-auth path** (`cloud: "vellum"`, X-Session-Token) — those tokens are managed by the platform, not the guardian refresh endpoint.

## Effect
Combined with R1 (gateway issues the refresh token) + R2 (CLI bundle carries & persists it), a paired machine no longer has to re-run `vellum pair` when its access token expires — `message`/`events` renew transparently.

## Scope / follow-up
- The interactive **`vellum client` TUI** uses a separate request path (`DefaultMainScreen` runtimeRequest/streamEvents with a startup-built auth object + mid-stream SSE), so its auto-refresh is a focused follow-up (**R3b**). With the access token now 30 days, mid-session expiry is rare in the interim, and `message`/`events` cover the scripted/headless paths fully.
- No proactive pre-expiry refresh — reactive 401-retry is sufficient and keeps the change minimal; the gateway is the source of truth for expiry.

## Tests
`cli/src/__tests__/assistant-client-refresh.test.ts` (stubs `globalThis.fetch`, routes by URL): 401→refresh→retry happy path (asserts retry uses the new bearer + token persisted + refresh called once / two assistant attempts); no-refresh-token → no retry; session-auth → no refresh; bounded-retry (a second 401 isn't refreshed again).

## Original prompt
Final slice of refreshable pairing: R1 made the gateway issue a device-bound refresh token and R2 carried it into the CLI's stored credentials, but nothing consumed it yet. This wires the stored refresh token into the request path so `vellum message`/`events` renew an expired paired token automatically, via a self-gating 401→refresh→retry through AssistantClient's single request chokepoint — deferring the separate TUI client path to R3b.