### PR TITLE
Show "Default" instead of "Inherit" for un-pinned advanced params

### DIFF
--- a/apps/web/src/domains/settings/ai/profile-advanced-params.tsx
+++ b/apps/web/src/domains/settings/ai/profile-advanced-params.tsx
@@ -117,7 +117,7 @@ export function ProfileAdvancedParams({
             <span className="text-body-small-default text-[var(--content-tertiary)]">
               {maxTokens !== null
                 ? formatCompactTokens(maxTokens)
-                : "Inherit"}
+                : "Default"}
             </span>
           </div>
           <div className="flex items-center gap-2">
@@ -157,7 +157,7 @@ export function ProfileAdvancedParams({
             <span className="text-body-small-default text-[var(--content-tertiary)]">
               {contextWindowMaxInputTokens !== null
                 ? formatCompactTokens(contextWindowMaxInputTokens)
-                : "Inherit"}
+                : "Default"}
             </span>
           </div>
           <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
In the profile editor's Advanced params, the Max Output Tokens and Context Window value labels now read **"Default"** (instead of "Inherit") when the param is not pinned to an explicit value. Pairs with the earlier "Reset" button rename: the top-right shows the state (a number when pinned, "Default" when not), and the button is the action.

Note: the lowercase helper texts on Effort ("(none = inherit)") and Gemini Thinking level ("(default = inherit)") were left as-is, since changing the latter would read "(default = default)". Let me know if you want those reworded too.