### PR TITLE
feat(gateway): bind /v1/guardian/refresh to the issuing device

### DIFF
--- a/cli/src/lib/guardian-token.ts
+++ b/cli/src/lib/guardian-token.ts
@@ -272,7 +272,13 @@ export async function refreshGuardianToken(
         "Content-Type": "application/json",
         Authorization: `Bearer ${tokenData.accessToken}`,
       },
-      body: JSON.stringify({ refreshToken: tokenData.refreshToken }),
+      body: JSON.stringify({
+        refreshToken: tokenData.refreshToken,
+        // The refresh token is device-bound; send the device id used at init
+        // (falling back to a fresh computation for tokens persisted before the
+        // field was stored) so the gateway can verify the binding.
+        deviceId: tokenData.deviceId || computeDeviceId(),
+      }),
       signal: AbortSignal.timeout(REFRESH_FETCH_TIMEOUT_MS),
     });
     if (!response.ok) return null;

--- a/gateway/src/__tests__/pair-device-bound.test.ts
+++ b/gateway/src/__tests__/pair-device-bound.test.ts
@@ -122,7 +122,10 @@ describe("/v1/pair device-bound minting", () => {
     );
     const body = (await res.json()) as { token: string; refreshToken: string };
 
-    const rotated = rotateCredentials({ refreshToken: body.refreshToken });
+    const rotated = rotateCredentials({
+      refreshToken: body.refreshToken,
+      hashedDeviceId: hashToken("device-A"),
+    });
     expect(rotated.ok).toBe(true);
     if (rotated.ok) {
       // A new access token (and rotated refresh token) is minted.

--- a/gateway/src/__tests__/refresh-device-binding.test.ts
+++ b/gateway/src/__tests__/refresh-device-binding.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for device binding on guardian credential rotation: a refresh token
+ * is bound to the device it was issued to, so a leaked refresh token cannot be
+ * redeemed from a different device. The binding is verified before any side
+ * effects so a wrong-device request cannot disturb the legitimate token family.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { initSigningKey } from "../auth/token-service.js";
+
+initSigningKey(Buffer.from("test-signing-key-at-least-32-bytes-long-xx"));
+
+const { initGatewayDb, resetGatewayDb, getGatewayDb } =
+  await import("../db/connection.js");
+const { actorRefreshTokenRecords } = await import("../db/schema.js");
+const { hashToken } = await import("../auth/guardian-bootstrap.js");
+const { rotateCredentials } = await import("../auth/guardian-refresh.js");
+
+const PRINCIPAL = "guardian-001";
+const DEVICE_A = "device-A";
+const DEVICE_B = "device-B";
+const FAMILY = "family-001";
+
+let testRoot: string;
+
+function insertRefreshRecord(
+  rawToken: string,
+  deviceId: string,
+  status: "active" | "rotated" | "revoked" = "active",
+) {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(actorRefreshTokenRecords)
+    .values({
+      id: `id-${rawToken}`,
+      tokenHash: hashToken(rawToken),
+      familyId: FAMILY,
+      guardianPrincipalId: PRINCIPAL,
+      hashedDeviceId: hashToken(deviceId),
+      platform: "cli",
+      status,
+      issuedAt: now,
+      absoluteExpiresAt: now + 365 * 86_400_000,
+      inactivityExpiresAt: now + 90 * 86_400_000,
+      lastUsedAt: null,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+function recordStatus(rawToken: string): string | undefined {
+  const rows = getGatewayDb().select().from(actorRefreshTokenRecords).all();
+  return rows.find((r) => r.tokenHash === hashToken(rawToken))?.status;
+}
+
+beforeEach(async () => {
+  testRoot = mkdtempSync(join(tmpdir(), "refresh-device-binding-"));
+  const securityDir = join(testRoot, "protected");
+  mkdirSync(securityDir, { recursive: true });
+  process.env.GATEWAY_SECURITY_DIR = securityDir;
+  await initGatewayDb();
+});
+
+afterEach(() => {
+  resetGatewayDb();
+  delete process.env.GATEWAY_SECURITY_DIR;
+  try {
+    rmSync(testRoot, { recursive: true, force: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+describe("rotateCredentials device binding", () => {
+  test("rotates when the device id matches the record's binding", () => {
+    insertRefreshRecord("rt-match", DEVICE_A);
+    const result = rotateCredentials({
+      refreshToken: "rt-match",
+      hashedDeviceId: hashToken(DEVICE_A),
+    });
+    expect(result.ok).toBe(true);
+    // Old token is consumed (rotated), proving the happy path ran end-to-end.
+    expect(recordStatus("rt-match")).toBe("rotated");
+  });
+
+  test("rejects with device_binding_mismatch from a different device", () => {
+    insertRefreshRecord("rt-leaked", DEVICE_A);
+    const result = rotateCredentials({
+      refreshToken: "rt-leaked",
+      hashedDeviceId: hashToken(DEVICE_B),
+    });
+    expect(result).toEqual({ ok: false, error: "device_binding_mismatch" });
+  });
+
+  test("a wrong-device request has no side effects on the token family", () => {
+    insertRefreshRecord("rt-leaked", DEVICE_A);
+    rotateCredentials({
+      refreshToken: "rt-leaked",
+      hashedDeviceId: hashToken(DEVICE_B),
+    });
+    // The legitimate token must remain active and usable.
+    expect(recordStatus("rt-leaked")).toBe("active");
+    const legit = rotateCredentials({
+      refreshToken: "rt-leaked",
+      hashedDeviceId: hashToken(DEVICE_A),
+    });
+    expect(legit.ok).toBe(true);
+  });
+
+  test("device binding is checked before reuse detection (no family revocation from wrong device)", () => {
+    // A previously-rotated token presented from the wrong device must not
+    // trigger the reuse-detection family revocation — that would let an
+    // attacker with a leaked, already-spent token DoS the real user.
+    insertRefreshRecord("rt-active", DEVICE_A, "active");
+    insertRefreshRecord("rt-spent", DEVICE_A, "rotated");
+    const result = rotateCredentials({
+      refreshToken: "rt-spent",
+      hashedDeviceId: hashToken(DEVICE_B),
+    });
+    expect(result).toEqual({ ok: false, error: "device_binding_mismatch" });
+    // The still-active sibling token in the same family is untouched.
+    expect(recordStatus("rt-active")).toBe("active");
+  });
+
+  test("still returns refresh_invalid for an unknown token regardless of device", () => {
+    const result = rotateCredentials({
+      refreshToken: "rt-unknown",
+      hashedDeviceId: hashToken(DEVICE_A),
+    });
+    expect(result).toEqual({ ok: false, error: "refresh_invalid" });
+  });
+});

--- a/gateway/src/auth/guardian-refresh.ts
+++ b/gateway/src/auth/guardian-refresh.ts
@@ -8,10 +8,7 @@ import { randomBytes } from "node:crypto";
 import { and, eq } from "drizzle-orm";
 
 import { getGatewayDb } from "../db/connection.js";
-import {
-  actorRefreshTokenRecords,
-  actorTokenRecords,
-} from "../db/schema.js";
+import { actorRefreshTokenRecords, actorTokenRecords } from "../db/schema.js";
 import { getLogger } from "../logger.js";
 
 import {
@@ -35,6 +32,7 @@ export type RefreshErrorCode =
   | "refresh_invalid"
   | "refresh_expired"
   | "refresh_reuse_detected"
+  | "device_binding_mismatch"
   | "revoked";
 
 export interface RotateResult {
@@ -198,9 +196,17 @@ function mintRefreshTokenInFamily(params: {
  * Rotate credentials: validate refresh token, revoke old, mint new pair.
  *
  * All token operations run against the gateway's SQLite database.
+ *
+ * The refresh token is bound to the device it was issued to: the caller must
+ * supply the hashed device id, and it must match the record's stored binding.
+ * This ensures a leaked refresh token cannot be redeemed from a different
+ * device. The binding is checked before any side effects (rotation, family
+ * revocation) so a request from a non-matching device cannot disturb the
+ * legitimate token family.
  */
 export function rotateCredentials(params: {
   refreshToken: string;
+  hashedDeviceId: string;
 }):
   | { ok: true; result: RotateResult }
   | { ok: false; error: RefreshErrorCode } {
@@ -210,6 +216,14 @@ export function rotateCredentials(params: {
 
   if (!record) {
     return { ok: false, error: "refresh_invalid" };
+  }
+
+  if (record.hashedDeviceId !== params.hashedDeviceId) {
+    log.warn(
+      { familyId: record.familyId },
+      "Refresh rejected — device binding mismatch",
+    );
+    return { ok: false, error: "device_binding_mismatch" };
   }
 
   if (record.status === "rotated") {

--- a/gateway/src/http/routes/channel-verification-session-proxy.ts
+++ b/gateway/src/http/routes/channel-verification-session-proxy.ts
@@ -10,7 +10,7 @@ import { join } from "node:path";
 
 import { proxyForwardToResponse } from "@vellumai/assistant-client";
 
-import { bootstrapGuardian } from "../../auth/guardian-bootstrap.js";
+import { bootstrapGuardian, hashToken } from "../../auth/guardian-bootstrap.js";
 import { rotateCredentials } from "../../auth/guardian-refresh.js";
 import { mintServiceToken } from "../../auth/token-exchange.js";
 import type { GatewayConfig } from "../../config.js";
@@ -425,6 +425,7 @@ export function createChannelVerificationSessionProxyHandler(
         const body = (await req.json()) as Record<string, unknown>;
         const refreshToken =
           typeof body.refreshToken === "string" ? body.refreshToken : "";
+        const deviceId = typeof body.deviceId === "string" ? body.deviceId : "";
 
         if (!refreshToken) {
           return Response.json(
@@ -438,15 +439,35 @@ export function createChannelVerificationSessionProxyHandler(
           );
         }
 
-        const result = rotateCredentials({ refreshToken });
+        // The refresh token is bound to the device it was issued to. Require
+        // the caller to prove the device so a leaked refresh token cannot be
+        // redeemed from a different device.
+        if (!deviceId) {
+          return Response.json(
+            {
+              error: {
+                code: "BAD_REQUEST",
+                message: "Missing required field: deviceId",
+              },
+            },
+            { status: 400 },
+          );
+        }
+
+        const result = rotateCredentials({
+          refreshToken,
+          hashedDeviceId: hashToken(deviceId),
+        });
 
         if (!result.ok) {
-          const statusCode =
-            result.error === "refresh_reuse_detected"
-              ? 403
-              : result.error === "revoked"
-                ? 403
-                : 401;
+          // 403 for tokens that are valid-but-forbidden (revoked, reused, or
+          // presented from the wrong device); 401 for invalid/expired tokens.
+          const forbidden: Array<typeof result.error> = [
+            "refresh_reuse_detected",
+            "device_binding_mismatch",
+            "revoked",
+          ];
+          const statusCode = forbidden.includes(result.error) ? 403 : 401;
 
           log.warn({ error: result.error }, "Refresh token rotation failed");
           return Response.json({ error: result.error }, { status: statusCode });

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -1981,7 +1981,7 @@ export function buildSchema(): Record<string, unknown> {
         post: {
           summary: "Refresh guardian access token",
           description:
-            "Refreshes an expired guardian access token. Accepts expired JWTs (signature, audience, and policy epoch are still verified — only the expiration check is relaxed).",
+            "Refreshes an expired guardian access token. Accepts expired JWTs (signature, audience, and policy epoch are still verified — only the expiration check is relaxed). Requires `refreshToken` and the `deviceId` the token was issued to; the refresh token is device-bound and is rejected if the device does not match.",
           operationId: "guardianRefresh",
           security: [{ BearerAuth: [] }],
           requestBody: {
@@ -1994,7 +1994,14 @@ export function buildSchema(): Record<string, unknown> {
           },
           responses: {
             "200": { description: "New access token returned" },
+            "400": {
+              description: "Missing required field (refreshToken or deviceId)",
+            },
             "401": { description: "Unauthorized — invalid token" },
+            "403": {
+              description:
+                "Refresh token revoked, reused, or presented from a non-matching device",
+            },
             "502": { description: "Failed to reach assistant runtime" },
           },
         },
@@ -3330,8 +3337,14 @@ export function buildSchema(): Record<string, unknown> {
               name: "n",
               in: "query",
               required: false,
-              schema: { type: "integer", minimum: 1, maximum: 1000, default: 10 },
-              description: "Number of log entries to return (1–1000, default: 10)",
+              schema: {
+                type: "integer",
+                minimum: 1,
+                maximum: 1000,
+                default: 10,
+              },
+              description:
+                "Number of log entries to return (1–1000, default: 10)",
             },
             {
               name: "level",
@@ -3364,11 +3377,13 @@ export function buildSchema(): Record<string, unknown> {
                       lines: {
                         type: "array",
                         items: { type: "object" },
-                        description: "Matching log entries in chronological order",
+                        description:
+                          "Matching log entries in chronological order",
                       },
                       truncated: {
                         type: "boolean",
-                        description: "True if earlier matching entries exist beyond n",
+                        description:
+                          "True if earlier matching entries exist beyond n",
                       },
                     },
                   },
@@ -4022,7 +4037,8 @@ export function buildSchema(): Record<string, unknown> {
                   properties: {
                     type: {
                       type: "string",
-                      description: "Email provider type (e.g. resend, mailgun, vellum)",
+                      description:
+                        "Email provider type (e.g. resend, mailgun, vellum)",
                     },
                     guardian_email: {
                       type: "string",
@@ -4314,7 +4330,13 @@ export function buildSchema(): Record<string, unknown> {
       schemas: {
         BackupSnapshot: {
           type: "object",
-          required: ["path", "filename", "created_at", "size_bytes", "encrypted"],
+          required: [
+            "path",
+            "filename",
+            "created_at",
+            "size_bytes",
+            "encrypted",
+          ],
           properties: {
             path: { type: "string" },
             filename: { type: "string" },


### PR DESCRIPTION
## Summary

- `/v1/guardian/refresh` now requires the `deviceId` the refresh token was issued to and verifies it against the record's stored `hashedDeviceId`, so a leaked refresh token can't be redeemed from a different device.
- The device-binding check runs before any side effects (rotation, family revocation), so a wrong-device request can't disturb the legitimate token family (avoids a DoS vector). A mismatch returns the `device_binding_mismatch` terminal error (403) that the native Swift client already handles; the CLI now sends `deviceId` on refresh (the macOS/iOS client already did).
- Adds a DB-backed test for the binding (match rotates, mismatch rejected with no family side effects, ordering vs. reuse detection) and updates the OpenAPI description/responses.

## Original prompt

Close the refresh-endpoint device-binding gap deferred during R1 planning: have `/v1/guardian/refresh` verify the deviceId so a leaked refresh token can't be redeemed from a different device. Refresh tokens are already stored bound to a `hashedDeviceId` and the native clients already send `deviceId` and treat `device_binding_mismatch` as terminal — this PR is the missing server-side enforcement plus the CLI sender.