### PR TITLE
refactor(web): share tier price formatters; guard credit bundle removal

### DIFF
--- a/apps/web/src/domains/settings/components/adjust-plan-modal.test.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.test.tsx
@@ -361,6 +361,33 @@ describe("AdjustPlanModal credit bundle — unseeded sentinel", () => {
     expect(changeCreditTierCall).toBeNull();
   });
 
+  test("a current bundle absent from the catalog does not enable a spurious removal", async () => {
+    // A Pro user holds a deprecated tier (`credits_legacy`) that the live
+    // catalog no longer advertises. Opening the modal must NOT coerce that into
+    // a "remove bundle" pending change: the Update Plan CTA stays disabled and
+    // clicking it submits no credit mutation (which would have sent
+    // `credit_tier: null`, silently dropping the user's paid bundle).
+    const { getByTestId } = renderModal(
+      subscription("pro", "credits_legacy"),
+      proPlansResponse(CREDIT_TIERS),
+    );
+
+    await waitFor(() => {
+      const trigger = document.querySelector(
+        'button[role="combobox"][aria-label="Credit bundle"]',
+      );
+      if (!trigger) throw new Error("picker not rendered yet");
+    });
+
+    const button = getByTestId("modal-change-tier-button") as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+
+    fireEvent.click(button);
+    // Give any (erroneous) mutation a tick to fire.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(changeCreditTierCall).toBeNull();
+  });
+
   test("preserves an explicit 'No bundle' choice across a plans refetch", async () => {
     // Pro user with credits_50 picks "No credit bundle" (selection becomes
     // null). A subsequent plans refetch re-runs the seeding effect; the explicit

--- a/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
@@ -115,21 +115,35 @@ export function resolveTierSelection<T extends string>(
  * `resolveTierSelection` but for credit bundles, which have no disabled state
  * and where both `null` ("No bundle") and a catalog tier are valid selections.
  *
- * `prev` carries the sentinel meaning: `undefined` is un-seeded (the effect has
- * not yet seeded a value), so we seed to `current`. A non-undefined `prev`
- * (including an explicit `null` for "No bundle") is the user's standing choice
- * and must be preserved — we keep it, only revalidating a concrete tier against
- * the catalog so a refetch that removes the selected bundle falls back to
- * "No bundle" rather than leaving a stale tier the CTA would submit.
+ * `prev` carries the sentinel meaning:
+ *   - `undefined` is un-seeded (the effect has not yet seeded a value), so we
+ *     seed to `current`. The seed is preserved verbatim — including a non-null
+ *     current tier that the live catalog does not (yet) advertise (e.g. a
+ *     deprecated tier the user still holds). Coercing such a tier to `null`
+ *     would make `creditChanged` read true purely from opening the modal and
+ *     silently submit `credit_tier: null`, removing a paid bundle the user
+ *     never touched. Preserving it keeps `creditChanged` false until the user
+ *     actively changes the selection.
+ *   - a non-undefined `prev` (including an explicit `null` for "No bundle") is
+ *     the user's standing choice and must be preserved — we keep it, only
+ *     revalidating a concrete tier against the catalog so a mid-modal refetch
+ *     that removes the selected bundle falls back to "No bundle" rather than
+ *     leaving a stale tier the CTA would submit.
  */
 export function resolveCreditTierSelection(
   tiers: CreditTier[],
   prev: CreditTierEnum | null | undefined,
   current: CreditTierEnum | null,
 ): CreditTierEnum | null {
-  const seeded = prev === undefined ? current : prev;
-  if (seeded !== null && tiers.some((t) => t.tier === seeded)) {
-    return seeded;
+  // Seeding (un-seeded `prev`): preserve the current bundle as-is so a tier
+  // absent from the catalog is not coerced into a spurious "remove bundle".
+  if (prev === undefined) {
+    return current;
+  }
+  // Standing user choice: revalidate a concrete tier against the catalog so a
+  // refetch that drops it falls back to "No bundle".
+  if (prev !== null && tiers.some((t) => t.tier === prev)) {
+    return prev;
   }
   return null;
 }

--- a/apps/web/src/domains/settings/components/credit-bundle-picker.tsx
+++ b/apps/web/src/domains/settings/components/credit-bundle-picker.tsx
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 import { Dropdown } from "@vellum/design-library/components/dropdown";
 import { Typography } from "@vellum/design-library/components/typography";
 import type { CreditTier, CreditTierEnum } from "@/generated/api/types.gen";
+import { formatDelta, formatMonthly } from "./tier-pricing";
 
 /**
  * Sentinel option value for the synthesized "No credit bundle" entry. The
@@ -14,23 +15,6 @@ import type { CreditTier, CreditTierEnum } from "@/generated/api/types.gen";
 const NO_BUNDLE_VALUE = "__none__";
 
 type CreditOptionValue = CreditTierEnum | typeof NO_BUNDLE_VALUE;
-
-/** "$50/mo" for whole-dollar tiers; "$50.50/mo" only when cents are present. */
-function formatMonthly(totalCents: number): string {
-  const dollars = totalCents / 100;
-  return Number.isInteger(dollars)
-    ? `$${dollars}/mo`
-    : `$${dollars.toFixed(2)}/mo`;
-}
-
-function formatDelta(deltaCents: number): string {
-  const prefix = deltaCents > 0 ? "+" : "−";
-  const absDollars = Math.abs(deltaCents) / 100;
-  const formatted = Number.isInteger(absDollars)
-    ? `$${absDollars}`
-    : `$${absDollars.toFixed(2)}`;
-  return `${prefix}${formatted}/mo`;
-}
 
 /** "50 credits — $50/mo" for a catalog tier. */
 export function formatBundleOptionLabel(tier: CreditTier): string {

--- a/apps/web/src/domains/settings/components/plan-card.tsx
+++ b/apps/web/src/domains/settings/components/plan-card.tsx
@@ -12,6 +12,7 @@ import { Typography } from "@vellum/design-library/components/typography";
 import type { ProPlan } from "@/generated/api/types.gen";
 import { InvoicesModal } from "./invoices-modal";
 import { PlanFeatureList } from "./plan-feature-list";
+import { formatMonthly } from "./tier-pricing";
 import {
   organizationsBillingPlansRetrieveOptions,
   organizationsBillingSubscriptionRetrieveOptions,
@@ -131,7 +132,7 @@ export function PlanCard({ onManage }: PlanCardProps) {
     selectedCreditTier != null ? proPlan?.credit_tiers : undefined;
   const creditTier = creditTiers?.find((t) => t.tier === selectedCreditTier);
   const creditBundleLabel = creditTier
-    ? `${creditTier.label} ($${Math.round(creditTier.price_cents / 100)}/mo)`
+    ? `${creditTier.label} (${formatMonthly(creditTier.price_cents)})`
     : creditTiers?.length
       ? selectedCreditTier
       : null;

--- a/apps/web/src/domains/settings/components/tier-picker.tsx
+++ b/apps/web/src/domains/settings/components/tier-picker.tsx
@@ -9,6 +9,7 @@ import type {
   StorageTier,
   StorageTierEnum,
 } from "@/generated/api/types.gen";
+import { formatDelta, formatMonthly } from "./tier-pricing";
 
 /**
  * Display labels for the Pro machine tiers. Uses a static label map so casing
@@ -31,23 +32,6 @@ const MACHINE_TIER_LABEL: Record<string, string> = {
  */
 export function isTierDisabled(tier: MachineTier | StorageTier): boolean {
   return (tier as unknown as { disabled?: boolean }).disabled === true;
-}
-
-/** "$50/mo" for whole-dollar tiers; "$50.50/mo" only when cents are present. */
-function formatMonthly(totalCents: number): string {
-  const dollars = totalCents / 100;
-  return Number.isInteger(dollars)
-    ? `$${dollars}/mo`
-    : `$${dollars.toFixed(2)}/mo`;
-}
-
-function formatDelta(deltaCents: number): string {
-  const prefix = deltaCents > 0 ? "+" : "−";
-  const absDollars = Math.abs(deltaCents) / 100;
-  const formatted = Number.isInteger(absDollars)
-    ? `$${absDollars}`
-    : `$${absDollars.toFixed(2)}`;
-  return `${prefix}${formatted}/mo`;
 }
 
 export interface TierPickerProps {

--- a/apps/web/src/domains/settings/components/tier-pricing.test.ts
+++ b/apps/web/src/domains/settings/components/tier-pricing.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+
+import { formatDelta, formatMonthly } from "./tier-pricing";
+
+describe("formatMonthly", () => {
+  test("renders whole-dollar amounts without cents", () => {
+    expect(formatMonthly(5000)).toBe("$50/mo");
+  });
+
+  test("renders sub-dollar cents with two decimals", () => {
+    expect(formatMonthly(995)).toBe("$9.95/mo");
+  });
+
+  test("renders zero as $0/mo", () => {
+    expect(formatMonthly(0)).toBe("$0/mo");
+  });
+});
+
+describe("formatDelta", () => {
+  test("prefixes a positive delta with +", () => {
+    expect(formatDelta(2500)).toBe("+$25/mo");
+  });
+
+  test("prefixes a negative delta with the U+2212 minus sign", () => {
+    expect(formatDelta(-5000)).toBe("−$50/mo");
+  });
+
+  test("keeps cents on a fractional delta", () => {
+    expect(formatDelta(-1050)).toBe("−$10.50/mo");
+  });
+
+  test("treats a zero delta as non-positive (minus prefix)", () => {
+    expect(formatDelta(0)).toBe("−$0/mo");
+  });
+});

--- a/apps/web/src/domains/settings/components/tier-pricing.ts
+++ b/apps/web/src/domains/settings/components/tier-pricing.ts
@@ -1,0 +1,31 @@
+/**
+ * Shared price formatters for the Pro plan tier/credit pickers.
+ *
+ * Both `tier-picker` (machine/storage) and `credit-bundle-picker` render
+ * monthly prices and price deltas in the same style, and `plan-card` shows the
+ * current credit bundle's monthly price. Centralising the formatting here keeps
+ * those surfaces byte-for-byte consistent — in particular the cents-aware
+ * whole-dollar rule, so a sub-dollar tier reads as `$9.95/mo` everywhere rather
+ * than rounding to `$10/mo` in one place and `$9.95/mo` in another.
+ */
+
+/** "$50/mo" for whole-dollar amounts; "$50.50/mo" only when cents are present. */
+export function formatMonthly(cents: number): string {
+  const dollars = cents / 100;
+  return Number.isInteger(dollars)
+    ? `$${dollars}/mo`
+    : `$${dollars.toFixed(2)}/mo`;
+}
+
+/**
+ * Signed monthly delta, e.g. `+$25/mo` or `−$25/mo`. Uses the U+2212 minus
+ * sign (not an ASCII hyphen) so a negative delta typesets cleanly.
+ */
+export function formatDelta(deltaCents: number): string {
+  const prefix = deltaCents > 0 ? "+" : "−";
+  const absDollars = Math.abs(deltaCents) / 100;
+  const formatted = Number.isInteger(absDollars)
+    ? `$${absDollars}`
+    : `$${absDollars.toFixed(2)}`;
+  return `${prefix}${formatted}/mo`;
+}


### PR DESCRIPTION
## Summary
Fixes two gaps found during plan review for pro-credit-bundles-frontend.md.

- Extract formatMonthly/formatDelta into a shared module; reuse in tier-picker, credit-bundle-picker, and plan-card (removes byte-for-byte duplication and the plan-card cents-rounding inconsistency).
- Guard credit-tier seeding so a current paid bundle absent from the live catalog is not spuriously coerced into a 'remove bundle' pending change.

Part of plan: pro-credit-bundles-frontend.md (review remediation)