### PR TITLE
fix(web): include credit bundle in adjust-plan total

### DIFF
--- a/apps/web/src/domains/settings/components/adjust-plan-modal.test.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.test.tsx
@@ -478,6 +478,56 @@ describe("AdjustPlanModal credit bundle — resize flow", () => {
   });
 });
 
+describe("AdjustPlanModal credit bundle — headline total", () => {
+  test("upgrade total includes the selected bundle's monthly price", async () => {
+    // Base→Pro. Defaults: base $20 + Small machine $10 + 10 GiB storage $5 =
+    // $35/mo with no bundle. Picking the $50 bundle must add $50 → $85/mo.
+    const { getByTestId } = renderModal(
+      subscription("base", null),
+      proPlansResponse(CREDIT_TIERS),
+    );
+
+    await waitFor(() => {
+      if (getByTestId("tier-picker-total").textContent?.includes("$35/mo"))
+        return;
+      throw new Error("base total not rendered yet");
+    });
+
+    openCreditDropdown();
+    clickOption("50 credits — $50/mo");
+
+    await waitFor(() => {
+      if (getByTestId("tier-picker-total").textContent?.includes("$85/mo"))
+        return;
+      throw new Error("total did not include the selected bundle");
+    });
+  });
+
+  test("change-mode total and delta reflect swapping bundles", async () => {
+    // Pro with no current bundle. Current = base $20 + Small $10 + 10 GiB $5 =
+    // $35/mo. Picking the $25 bundle makes the new total $60/mo (+$25 delta).
+    const { getByTestId } = renderModal(
+      subscription("pro", null),
+      proPlansResponse(CREDIT_TIERS),
+    );
+
+    await waitFor(() => {
+      if (getByTestId("tier-picker-total").textContent?.includes("$35/mo"))
+        return;
+      throw new Error("current total not rendered yet");
+    });
+
+    openCreditDropdown();
+    clickOption("25 credits — $25/mo");
+
+    await waitFor(() => {
+      const text = getByTestId("tier-picker-total").textContent ?? "";
+      if (text.includes("$60/mo") && text.includes("+$25/mo")) return;
+      throw new Error("total/delta did not reflect the swapped bundle");
+    });
+  });
+});
+
 describe("AdjustPlanModal credit bundle — catalog gate", () => {
   test("hides the credit UI when the plan has no credit_tiers (upgrade)", () => {
     renderModal(subscription("base", null), proPlansResponse(undefined));

--- a/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
@@ -286,6 +286,11 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
   const displayCreditTier: CreditTierEnum | null =
     selectedCreditTier === undefined ? currentCreditTier : selectedCreditTier;
 
+  // Folds into TierPicker's headline Total. `priceForCredit` returns 0 for "No
+  // bundle" and for catalogs without credit_tiers (empty `creditTiers`), so the
+  // total stays byte-identical to before when the feature is off.
+  const selectedCreditPriceCents = priceForCredit(displayCreditTier);
+
   // For an active Pro subscriber, disable any storage tier strictly below the
   // current selection — downgrading storage is not allowed. TierPicker honors
   // the `disabled` flag via `isTierDisabled`; machine tiers stay fully enabled
@@ -821,6 +826,7 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                                 selectedStorageTier={selectedStorageTier}
                                 onMachineTierChange={setSelectedMachineTier}
                                 onStorageTierChange={setSelectedStorageTier}
+                                creditPriceCents={selectedCreditPriceCents}
                               />
                               {creditTiersEnabled && (
                                 <CreditBundlePicker
@@ -869,6 +875,10 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                                   onStorageTierChange={setSelectedStorageTier}
                                   currentMachinePriceCents={currentMachinePrice}
                                   currentStoragePriceCents={currentStoragePrice}
+                                  creditPriceCents={selectedCreditPriceCents}
+                                  currentCreditPriceCents={
+                                    currentCreditPriceCents
+                                  }
                                 />
                                 {creditTiersEnabled && (
                                   <CreditBundlePicker

--- a/apps/web/src/domains/settings/components/tier-picker.tsx
+++ b/apps/web/src/domains/settings/components/tier-picker.tsx
@@ -44,6 +44,13 @@ export interface TierPickerProps {
   onStorageTierChange: (tier: StorageTierEnum) => void;
   currentMachinePriceCents?: number | null;
   currentStoragePriceCents?: number | null;
+  // The credit bundle is a changed "dimension" alongside machine/storage: its
+  // monthly price folds into the headline Total (and its delta) so the figure
+  // reflects the chosen bundle and reconciles with the modal's "Currently $X"
+  // baseline (which already includes the current bundle). Default 0 leaves
+  // non-credit callers byte-identical to before.
+  creditPriceCents?: number | null;
+  currentCreditPriceCents?: number | null;
 }
 
 export function TierPicker({
@@ -56,6 +63,8 @@ export function TierPicker({
   onStorageTierChange,
   currentMachinePriceCents,
   currentStoragePriceCents,
+  creditPriceCents,
+  currentCreditPriceCents,
 }: TierPickerProps) {
   const selectedMachine = machineTiers.find(
     (t) => t.tier === selectedMachineTier,
@@ -67,11 +76,15 @@ export function TierPicker({
     selectedMachine && selectedStorage
       ? basePriceCents +
         selectedMachine.price_cents +
-        selectedStorage.price_cents
+        selectedStorage.price_cents +
+        (creditPriceCents ?? 0)
       : null;
   const currentTotalCents =
     currentMachinePriceCents != null && currentStoragePriceCents != null
-      ? basePriceCents + currentMachinePriceCents + currentStoragePriceCents
+      ? basePriceCents +
+        currentMachinePriceCents +
+        currentStoragePriceCents +
+        (currentCreditPriceCents ?? 0)
       : null;
   const totalDelta =
     totalCents != null && currentTotalCents != null


### PR DESCRIPTION
## Summary
Fixes a gap found during plan review for pro-credit-bundles-frontend.md: the running 'Total' in AdjustPlanModal did not include the selected credit bundle's price, so the headline total understated the cost and didn't reconcile with the 'Currently $X' baseline (which already includes the current bundle).

- TierPicker accepts optional creditPriceCents/currentCreditPriceCents and folds them into totalCents/currentTotalCents/delta (default 0 → no change for non-credit callers).
- AdjustPlanModal passes the selected and current credit prices (only when the catalog has credit_tiers).

Part of plan: pro-credit-bundles-frontend.md (review remediation, round 2)