### PR TITLE
feat(macos): size Electron onboarding window to 440×630 default

### DIFF
--- a/apps/macos/src/main/main-window.test.ts
+++ b/apps/macos/src/main/main-window.test.ts
@@ -18,6 +18,14 @@ type StubWindow = {
   isFocused: () => boolean;
   on: ReturnType<typeof mock>;
   once: (event: string, handler: () => void) => StubWindow;
+  isResizable: () => boolean;
+  setResizable: ReturnType<typeof mock>;
+  setMaximizable: ReturnType<typeof mock>;
+  setFullScreenable: ReturnType<typeof mock>;
+  setContentSize: ReturnType<typeof mock>;
+  setBounds: ReturnType<typeof mock>;
+  setPosition: ReturnType<typeof mock>;
+  center: ReturnType<typeof mock>;
   webContents: StubWebContents;
   // Test seam — emits a `closed` event so the production code's
   // module-scope `mainWindow = null` cleanup runs.
@@ -29,20 +37,46 @@ type WindowState = {
   minimized: boolean;
   visible: boolean;
   focused: boolean;
+  resizable: boolean;
 };
 
-let constructed: Array<{ stub: StubWindow; state: WindowState }> = [];
+let constructed: Array<{
+  stub: StubWindow;
+  state: WindowState;
+  opts: Record<string, unknown>;
+}> = [];
+
+// Controls what the mocked `readOnboardingActive()` returns when the
+// next window is constructed. Toggled by tests that exercise the
+// onboarding (small/fixed) vs. main (resizable) creation branches.
+let onboardingActive = false;
+const writeOnboardingActiveMock = mock((active: boolean) => {
+  onboardingActive = active;
+});
 let listeners: Map<string, Array<() => void>>;
 
-const makeWindow = (): StubWindow => {
+const makeWindow = (opts: Record<string, unknown> = {}): StubWindow => {
   const state: WindowState = {
     destroyed: false,
     minimized: false,
     visible: false,
     focused: false,
+    // Mirrors the BrowserWindow default (resizable) unless the
+    // constructor opts opt out, as the onboarding branch does.
+    resizable: opts.resizable !== false,
   };
   listeners = new Map();
   const stub: StubWindow = {
+    isResizable: () => state.resizable,
+    setResizable: mock((value: boolean) => {
+      state.resizable = value;
+    }),
+    setMaximizable: mock(() => undefined),
+    setFullScreenable: mock(() => undefined),
+    setContentSize: mock(() => undefined),
+    setBounds: mock(() => undefined),
+    setPosition: mock(() => undefined),
+    center: mock(() => undefined),
     show: mock(() => {
       state.visible = true;
     }),
@@ -94,7 +128,7 @@ const makeWindow = (): StubWindow => {
       for (const h of listeners.get(event) ?? []) h();
     },
   };
-  constructed.push({ stub, state });
+  constructed.push({ stub, state, opts });
   return stub;
 };
 
@@ -110,8 +144,8 @@ mock.module("electron", () => ({
     isPackaged: false,
   },
   BrowserWindow: class {
-    constructor(_opts: unknown) {
-      Object.assign(this, makeWindow());
+    constructor(opts: Record<string, unknown>) {
+      Object.assign(this, makeWindow(opts));
     }
   },
   ipcMain: { handle: ipcHandleMock },
@@ -121,9 +155,11 @@ mock.module("electron", () => ({
 mock.module("./window-state", () => ({
   restoreBounds: () => ({ width: 1280, height: 800 }),
   track: () => undefined,
+  readOnboardingActive: () => onboardingActive,
+  writeOnboardingActive: writeOnboardingActiveMock,
 }));
 
-const { __resetForTesting, current, dispatchToMain, ensureVisible, hide, installMainWindow, isVisibleAndFocused, toggleVisibility } =
+const { __resetForTesting, current, dispatchToMain, ensureVisible, hide, installMainWindow, isVisibleAndFocused, setOnboarding, toggleVisibility } =
   await import("./main-window");
 const { resolveAllowedOrigin } = await import("./app-origin");
 
@@ -149,6 +185,8 @@ beforeEach(() => {
   __resetForTesting();
   ipcHandlers.clear();
   ipcHandleMock.mockClear();
+  onboardingActive = false;
+  writeOnboardingActiveMock.mockClear();
 });
 
 afterEach(() => {
@@ -402,6 +440,97 @@ describe("installMainWindow", () => {
 
     expect(win.stub.show.mock.calls.length).toBeGreaterThan(showsBefore);
     expect(win.stub.focus.mock.calls.length).toBeGreaterThan(focusBefore);
+  });
+});
+
+describe("onboarding window sizing", () => {
+  test("creates a 440×630 default-size but still resizable window when onboarding is active", () => {
+    onboardingActive = true;
+    ensureVisible();
+    const win = constructed[0];
+    if (!win) throw new Error("expected a window");
+    expect(win.opts.width).toBe(440);
+    expect(win.opts.height).toBe(630);
+    expect(win.opts.useContentSize).toBe(true);
+    // Onboarding is the default size only — the window stays resizable
+    // (no `resizable: false` opt), so it inherits the Electron default.
+    expect(win.opts.resizable).toBeUndefined();
+    expect(win.stub.isResizable()).toBe(true);
+  });
+
+  test("creates a resizable restored-bounds window when onboarding is inactive", () => {
+    onboardingActive = false;
+    ensureVisible();
+    const win = constructed[0];
+    if (!win) throw new Error("expected a window");
+    expect(win.opts.width).toBe(1280);
+    expect(win.opts.height).toBe(800);
+    expect(win.opts.useContentSize).toBeUndefined();
+    expect(win.opts.resizable).toBeUndefined();
+    expect(win.stub.isResizable()).toBe(true);
+  });
+
+  test("setOnboarding(true) shrinks an existing main window to the default", () => {
+    onboardingActive = false;
+    ensureVisible();
+    const win = constructed[0];
+    if (!win) throw new Error("expected a window");
+
+    setOnboarding(true);
+
+    expect(writeOnboardingActiveMock).toHaveBeenCalledWith(true);
+    expect(win.stub.setContentSize).toHaveBeenCalledWith(440, 630);
+    expect(win.stub.center).toHaveBeenCalled();
+    // The window stays resizable across the transition — never locked.
+    expect(win.stub.setResizable).not.toHaveBeenCalled();
+  });
+
+  test("setOnboarding(false) grows an existing onboarding window to the main bounds", () => {
+    onboardingActive = true;
+    ensureVisible();
+    const win = constructed[0];
+    if (!win) throw new Error("expected a window");
+
+    setOnboarding(false);
+
+    expect(writeOnboardingActiveMock).toHaveBeenCalledWith(false);
+    expect(win.stub.setBounds).toHaveBeenCalledWith({ width: 1280, height: 800 });
+    expect(win.stub.setResizable).not.toHaveBeenCalled();
+  });
+
+  test("re-asserting the current mode persists but does not resize the window", () => {
+    onboardingActive = false;
+    ensureVisible();
+    const win = constructed[0];
+    if (!win) throw new Error("expected a window");
+
+    setOnboarding(false);
+
+    expect(writeOnboardingActiveMock).toHaveBeenCalledWith(false);
+    expect(win.stub.setContentSize).not.toHaveBeenCalled();
+    expect(win.stub.setBounds).not.toHaveBeenCalled();
+  });
+
+  test("persists the mode even when no window exists yet", () => {
+    setOnboarding(true);
+    expect(writeOnboardingActiveMock).toHaveBeenCalledWith(true);
+    expect(constructed).toHaveLength(0);
+  });
+
+  test("installMainWindow registers the setOnboarding IPC handler routing through setOnboarding", async () => {
+    installMainWindow();
+    expect(ipcHandlers.has("vellum:mainWindow:setOnboarding")).toBe(true);
+    const win = constructed[0];
+    if (!win) throw new Error("expected a window");
+
+    const handler = ipcHandlers.get("vellum:mainWindow:setOnboarding");
+    await (handler as (event: unknown, active: boolean) => Promise<void>)(
+      allowedEvent,
+      true,
+    );
+
+    expect(writeOnboardingActiveMock).toHaveBeenCalledWith(true);
+    expect(win.stub.setContentSize).toHaveBeenCalledWith(440, 630);
   });
 });
 

--- a/apps/macos/src/main/main-window.ts
+++ b/apps/macos/src/main/main-window.ts
@@ -153,11 +153,13 @@ const createWindow = (): BrowserWindow => {
   const loadTarget = getRendererRootUrl(app.isPackaged);
 
   // Onboarding opens at the 440×630 default (matching the Swift client);
-  // the post-onboarding app restores the user's saved bounds. Both layouts
-  // are fully resizable — onboarding just starts smaller. The flag is
-  // persisted main-side so this first window is built at the correct size
-  // with no open-large-then-shrink flash; the renderer reconciles via
-  // `setOnboarding` once it knows the live route.
+  // otherwise restore the user's saved main-app bounds. Both layouts are
+  // fully resizable — onboarding just starts smaller. The persisted flag
+  // lets a relaunch *during* onboarding rebuild the small window directly
+  // (no flash); the absent-flag default is `false` (open large) so we
+  // never cramp the `/account/*` screens that render outside RootLayout —
+  // a brand-new user entering onboarding briefly sees large then the
+  // renderer's `setOnboarding` reconcile shrinks it.
   const onboardingActive = readOnboardingActive();
   const sizing = onboardingActive
     ? { ...ONBOARDING_CONTENT_SIZE, useContentSize: true }

--- a/apps/macos/src/main/main-window.ts
+++ b/apps/macos/src/main/main-window.ts
@@ -6,7 +6,24 @@ import { getRendererRootUrl } from "./app-config";
 import { isAllowedOrigin, resolveAllowedOrigin } from "./app-origin";
 import { type VellumCommand } from "./commands";
 import { handle } from "./ipc";
-import { restoreBounds, track as trackWindowState } from "./window-state";
+import {
+  readOnboardingActive,
+  restoreBounds,
+  track as trackWindowState,
+  writeOnboardingActive,
+} from "./window-state";
+
+// Default content-area size of the onboarding flow, mirroring the macOS
+// Swift client's onboarding window (`OnboardingWindow.swift`: `contentRect`
+// 440×630). Applied as the *content* size (`useContentSize`) so the usable
+// area matches the Swift app's `.fullSizeContentView` content rect rather
+// than including the Electron title bar. Unlike the Swift window this is
+// only the *default* — the window stays resizable, so a user who wants more
+// room can drag it larger.
+const ONBOARDING_CONTENT_SIZE = { width: 440, height: 630 } as const;
+
+// Default bounds for the main window once onboarding is done.
+const MAIN_DEFAULT_BOUNDS = { width: 1280, height: 800 } as const;
 
 /**
  * Main BrowserWindow lifecycle owner.
@@ -135,8 +152,19 @@ const createWindow = (): BrowserWindow => {
   // Vite's `base`; see `getRendererRootUrl`.
   const loadTarget = getRendererRootUrl(app.isPackaged);
 
+  // Onboarding opens at the 440×630 default (matching the Swift client);
+  // the post-onboarding app restores the user's saved bounds. Both layouts
+  // are fully resizable — onboarding just starts smaller. The flag is
+  // persisted main-side so this first window is built at the correct size
+  // with no open-large-then-shrink flash; the renderer reconciles via
+  // `setOnboarding` once it knows the live route.
+  const onboardingActive = readOnboardingActive();
+  const sizing = onboardingActive
+    ? { ...ONBOARDING_CONTENT_SIZE, useContentSize: true }
+    : restoreBounds("main", MAIN_DEFAULT_BOUNDS);
+
   const win = new BrowserWindow({
-    ...restoreBounds("main", { width: 1280, height: 800 }),
+    ...sizing,
     show: false,
     webPreferences: {
       preload: path.join(__dirname, "../preload/index.js"),
@@ -150,7 +178,12 @@ const createWindow = (): BrowserWindow => {
     },
   });
 
-  trackWindowState("main", win);
+  // Persist bounds only when NOT in onboarding mode. Both layouts are
+  // resizable, so resize events fire in either mode — but the small
+  // onboarding default must not be saved as the user's "main" size, or
+  // their next post-onboarding launch would come up tiny. The mode flag
+  // (not resizability, which no longer distinguishes them) is the gate.
+  trackWindowState("main", win, () => !readOnboardingActive());
 
   // Readiness resolves only after BOTH the renderer has loaded AND
   // the window has shown + focused. Per-window state keyed via
@@ -284,6 +317,47 @@ export const dispatchToMain = (command: VellumCommand): void => {
 };
 
 /**
+ * Switch the main window between the onboarding layout (440×630 default)
+ * and the main-app layout. Both are fully resizable; the only difference
+ * is the default/restored size. Persists the mode so the next launch's
+ * window is constructed at the right size, then resizes the current window
+ * if the mode actually changed.
+ *
+ * The mode of record is the persisted flag (read before the write), not
+ * resizability — both layouts are resizable now, so `isResizable()` can no
+ * longer distinguish them. Writing the flag *before* the resize means
+ * `window-state`'s persistence gate (`!readOnboardingActive()`) already
+ * reflects the new mode when the programmatic resize fires its event:
+ * the entry shrink is skipped, the exit restore is captured under "main".
+ * Re-asserting the current mode (the renderer fires this on every
+ * navigation) is a cheap no-op past the early return.
+ */
+export const setOnboarding = (active: boolean): void => {
+  const wasActive = readOnboardingActive();
+  writeOnboardingActive(active);
+
+  const win = mainWindow;
+  if (!win || win.isDestroyed()) return;
+  if (active === wasActive) return;
+
+  if (active) {
+    win.setContentSize(
+      ONBOARDING_CONTENT_SIZE.width,
+      ONBOARDING_CONTENT_SIZE.height,
+    );
+    win.center();
+  } else {
+    const bounds = restoreBounds("main", MAIN_DEFAULT_BOUNDS);
+    win.setBounds({ width: bounds.width, height: bounds.height });
+    if (bounds.x !== undefined && bounds.y !== undefined) {
+      win.setPosition(bounds.x, bounds.y);
+    } else {
+      win.center();
+    }
+  }
+};
+
+/**
  * Create the initial main window. Call once from `whenReady`.
  * Idempotent: if a window is already alive, no-op.
  */
@@ -300,6 +374,17 @@ export const installMainWindow = (): void => {
   handle("vellum:mainWindow:ensureVisible", z.tuple([]), async (): Promise<void> => {
     await ensureVisible();
   });
+
+  // Renderer-driven onboarding-window sizing. The renderer is the only
+  // side that knows whether the current route is an onboarding step, so it
+  // toggles the 440×630 onboarding default on/off as the user navigates.
+  handle(
+    "vellum:mainWindow:setOnboarding",
+    z.tuple([z.boolean()]),
+    async ([active]): Promise<void> => {
+      setOnboarding(active);
+    },
+  );
 
   void ensureVisible();
 };

--- a/apps/macos/src/main/window-state.test.ts
+++ b/apps/macos/src/main/window-state.test.ts
@@ -20,7 +20,9 @@ const storeSetMock = mock((_key: string, _value: unknown) => {});
 mock.module("electron-store", () => ({
   default: class {
     get(key: string, fallback?: unknown) {
-      if (key === "onboardingActive") return savedOnboardingActive;
+      // Mirror electron-store: return the stored value, or the fallback
+      // when the key is absent.
+      if (key === "onboardingActive") return savedOnboardingActive ?? fallback;
       if (key === "windows") return savedWindows;
       return fallback;
     }
@@ -213,13 +215,15 @@ describe("track persistence gating", () => {
 });
 
 describe("readOnboardingActive default", () => {
-  test("fresh install (no flag, no saved main window) → onboarding", () => {
+  test("absent flag defaults to false — open large, not onboarding", () => {
+    // Erring large is recoverable (onboarding self-shrinks via the hook);
+    // erring small would strand the out-of-RootLayout /account/* screens.
     savedOnboardingActive = undefined;
     savedWindows = {};
-    expect(readOnboardingActive()).toBe(true);
+    expect(readOnboardingActive()).toBe(false);
   });
 
-  test("upgraded install (no flag, but saved main window) → not onboarding", () => {
+  test("absent flag stays false regardless of saved window state", () => {
     savedOnboardingActive = undefined;
     savedWindows.main = {
       x: 0,
@@ -231,32 +235,18 @@ describe("readOnboardingActive default", () => {
     expect(readOnboardingActive()).toBe(false);
   });
 
-  test("an explicit persisted flag wins over the derived default", () => {
-    savedWindows.main = {
-      x: 0,
-      y: 0,
-      width: 1000,
-      height: 700,
-      isFullScreen: false,
-    };
+  test("an explicit persisted flag wins over the default", () => {
     savedOnboardingActive = true;
     expect(readOnboardingActive()).toBe(true);
 
     savedOnboardingActive = false;
-    savedWindows = {};
     expect(readOnboardingActive()).toBe(false);
   });
 
   test("writeOnboardingActive skips persisting when the effective value is unchanged", () => {
-    // Upgraded install: derived default is already `false`, so re-asserting
-    // `false` must not write.
-    savedWindows.main = {
-      x: 0,
-      y: 0,
-      width: 1000,
-      height: 700,
-      isFullScreen: false,
-    };
+    // Absent flag → effective value is already `false`, so re-asserting
+    // `false` must not write; flipping to `true` does.
+    savedOnboardingActive = undefined;
     writeOnboardingActive(false);
     expect(storeSetMock).not.toHaveBeenCalled();
 

--- a/apps/macos/src/main/window-state.test.ts
+++ b/apps/macos/src/main/window-state.test.ts
@@ -10,6 +10,7 @@ type SavedState = {
 
 let savedWindows: Record<string, SavedState> = {};
 let workArea = { x: 0, y: 0, width: 1920, height: 1080 };
+const storeSetMock = mock((_key: string, _value: unknown) => {});
 
 // Mock `electron-store` so `restoreBounds` reads from `savedWindows`
 // without touching disk. The store wrapper in `window-state.ts` uses the
@@ -19,8 +20,8 @@ mock.module("electron-store", () => ({
     get(_key: string, _fallback: { windows: Record<string, SavedState> }) {
       return savedWindows;
     }
-    set() {
-      // no-op
+    set(key: string, value: unknown) {
+      storeSetMock(key, value);
     }
   },
 }));
@@ -34,13 +35,32 @@ mock.module("electron", () => ({
   },
 }));
 
-const { restoreBounds } = await import("./window-state");
+const { restoreBounds, track } = await import("./window-state");
 
 const DEFAULTS = { width: 800, height: 600 };
+
+// Minimal `BrowserWindow` stub for `track`: captures registered event
+// handlers so a test can fire `close` (the synchronous persist path) and
+// assert whether the store was written.
+function makeTrackableWindow() {
+  const handlers = new Map<string, () => void>();
+  return {
+    on(event: string, cb: () => void) {
+      handlers.set(event, cb);
+    },
+    emit(event: string) {
+      handlers.get(event)?.();
+    },
+    isDestroyed: () => false,
+    getNormalBounds: () => ({ x: 1, y: 2, width: 440, height: 630 }),
+    isFullScreen: () => false,
+  };
+}
 
 beforeEach(() => {
   savedWindows = {};
   workArea = { x: 0, y: 0, width: 1920, height: 1080 };
+  storeSetMock.mockClear();
 });
 
 afterEach(() => {
@@ -152,5 +172,36 @@ describe("restoreBounds", () => {
     };
     expect(restoreBounds("main", DEFAULTS).x).toBe(10);
     expect(restoreBounds("thread.abc", DEFAULTS).x).toBe(500);
+  });
+});
+
+describe("track persistence gating", () => {
+  test("persists on close by default", () => {
+    const win = makeTrackableWindow();
+    track("main", win as never);
+    win.emit("close");
+    expect(storeSetMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("skips persistence while shouldPersist returns false", () => {
+    const win = makeTrackableWindow();
+    track("main", win as never, () => false);
+    win.emit("close");
+    expect(storeSetMock).not.toHaveBeenCalled();
+  });
+
+  test("re-evaluates shouldPersist at save time, not bind time", () => {
+    // Models the onboarding gate: don't persist the small onboarding
+    // default, but capture the main bounds once the mode flips.
+    let onboarding = true;
+    const win = makeTrackableWindow();
+    track("main", win as never, () => !onboarding);
+
+    win.emit("close");
+    expect(storeSetMock).not.toHaveBeenCalled();
+
+    onboarding = false;
+    win.emit("close");
+    expect(storeSetMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/macos/src/main/window-state.test.ts
+++ b/apps/macos/src/main/window-state.test.ts
@@ -9,16 +9,20 @@ type SavedState = {
 };
 
 let savedWindows: Record<string, SavedState> = {};
+let savedOnboardingActive: boolean | undefined = undefined;
 let workArea = { x: 0, y: 0, width: 1920, height: 1080 };
 const storeSetMock = mock((_key: string, _value: unknown) => {});
 
-// Mock `electron-store` so `restoreBounds` reads from `savedWindows`
-// without touching disk. The store wrapper in `window-state.ts` uses the
-// default export, so the mock returns a class.
+// Mock `electron-store` so the wrappers read from the per-key test state
+// without touching disk. Key-aware so `readOnboardingActive` can be
+// exercised independently of the saved-windows map. The store wrapper in
+// `window-state.ts` uses the default export, so the mock returns a class.
 mock.module("electron-store", () => ({
   default: class {
-    get(_key: string, _fallback: { windows: Record<string, SavedState> }) {
-      return savedWindows;
+    get(key: string, fallback?: unknown) {
+      if (key === "onboardingActive") return savedOnboardingActive;
+      if (key === "windows") return savedWindows;
+      return fallback;
     }
     set(key: string, value: unknown) {
       storeSetMock(key, value);
@@ -35,7 +39,8 @@ mock.module("electron", () => ({
   },
 }));
 
-const { restoreBounds, track } = await import("./window-state");
+const { restoreBounds, track, readOnboardingActive, writeOnboardingActive } =
+  await import("./window-state");
 
 const DEFAULTS = { width: 800, height: 600 };
 
@@ -59,6 +64,7 @@ function makeTrackableWindow() {
 
 beforeEach(() => {
   savedWindows = {};
+  savedOnboardingActive = undefined;
   workArea = { x: 0, y: 0, width: 1920, height: 1080 };
   storeSetMock.mockClear();
 });
@@ -203,5 +209,58 @@ describe("track persistence gating", () => {
     onboarding = false;
     win.emit("close");
     expect(storeSetMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("readOnboardingActive default", () => {
+  test("fresh install (no flag, no saved main window) → onboarding", () => {
+    savedOnboardingActive = undefined;
+    savedWindows = {};
+    expect(readOnboardingActive()).toBe(true);
+  });
+
+  test("upgraded install (no flag, but saved main window) → not onboarding", () => {
+    savedOnboardingActive = undefined;
+    savedWindows.main = {
+      x: 0,
+      y: 0,
+      width: 1000,
+      height: 700,
+      isFullScreen: false,
+    };
+    expect(readOnboardingActive()).toBe(false);
+  });
+
+  test("an explicit persisted flag wins over the derived default", () => {
+    savedWindows.main = {
+      x: 0,
+      y: 0,
+      width: 1000,
+      height: 700,
+      isFullScreen: false,
+    };
+    savedOnboardingActive = true;
+    expect(readOnboardingActive()).toBe(true);
+
+    savedOnboardingActive = false;
+    savedWindows = {};
+    expect(readOnboardingActive()).toBe(false);
+  });
+
+  test("writeOnboardingActive skips persisting when the effective value is unchanged", () => {
+    // Upgraded install: derived default is already `false`, so re-asserting
+    // `false` must not write.
+    savedWindows.main = {
+      x: 0,
+      y: 0,
+      width: 1000,
+      height: 700,
+      isFullScreen: false,
+    };
+    writeOnboardingActive(false);
+    expect(storeSetMock).not.toHaveBeenCalled();
+
+    writeOnboardingActive(true);
+    expect(storeSetMock).toHaveBeenCalledWith("onboardingActive", true);
   });
 });

--- a/apps/macos/src/main/window-state.ts
+++ b/apps/macos/src/main/window-state.ts
@@ -25,9 +25,10 @@ interface StoreSchema {
   // default; see `main-window.ts`). Persisted here — rather than read from
   // the renderer's localStorage onboarding store — so the very first
   // window of a launch is constructed at the right size with no
-  // open-large-then-shrink flash. Defaults to `true`: a fresh install has
-  // not completed onboarding, so the first window is the small one.
-  onboardingActive: boolean;
+  // open-large-then-shrink flash. Optional: when absent, the default is
+  // derived from saved window state (see `readOnboardingActive`) so an
+  // upgraded install that predates this key isn't forced into onboarding.
+  onboardingActive?: boolean;
 }
 
 let instance: Store<StoreSchema> | null = null;
@@ -36,7 +37,7 @@ const store = (): Store<StoreSchema> => {
   if (!instance) {
     instance = new Store<StoreSchema>({
       name: "window-state",
-      defaults: { windows: {}, onboardingActive: true },
+      defaults: { windows: {} },
     });
   }
   return instance;
@@ -44,19 +45,29 @@ const store = (): Store<StoreSchema> => {
 
 /**
  * Whether the main window should open in onboarding (440×630 default)
- * mode. Defaults to `true` so a first launch — which has not completed
- * onboarding — opens the small window directly.
+ * mode.
+ *
+ * The flag is the source of truth once written. When it's absent, the
+ * default is derived from saved main-window bounds rather than assumed
+ * `true`: a fresh install has no saved `windows.main` and should onboard,
+ * but an install upgraded from a build that predates this key already has
+ * saved bounds and is past onboarding — forcing it small would open at
+ * 440×630 (and stick there on the `/account/*` routes, which render
+ * outside `RootLayout` and never call the reconcile hook).
  */
-export const readOnboardingActive = (): boolean =>
-  store().get("onboardingActive", true);
+export const readOnboardingActive = (): boolean => {
+  const stored = store().get("onboardingActive");
+  if (typeof stored === "boolean") return stored;
+  return store().get("windows", {}).main === undefined;
+};
 
 /**
- * Persist the onboarding-window-mode flag. No-op when unchanged so a
- * renderer that re-asserts the current mode on every navigation doesn't
- * churn the store file.
+ * Persist the onboarding-window-mode flag. No-op when the effective value
+ * is unchanged so a renderer that re-asserts the current mode on every
+ * navigation doesn't churn the store file.
  */
 export const writeOnboardingActive = (active: boolean): void => {
-  if (store().get("onboardingActive", true) === active) return;
+  if (readOnboardingActive() === active) return;
   store().set("onboardingActive", active);
 };
 

--- a/apps/macos/src/main/window-state.ts
+++ b/apps/macos/src/main/window-state.ts
@@ -21,6 +21,13 @@ interface SavedWindowState extends Rectangle {
 
 interface StoreSchema {
   windows: Record<string, SavedWindowState>;
+  // Whether the main window should open in the onboarding layout (440×630
+  // default; see `main-window.ts`). Persisted here — rather than read from
+  // the renderer's localStorage onboarding store — so the very first
+  // window of a launch is constructed at the right size with no
+  // open-large-then-shrink flash. Defaults to `true`: a fresh install has
+  // not completed onboarding, so the first window is the small one.
+  onboardingActive: boolean;
 }
 
 let instance: Store<StoreSchema> | null = null;
@@ -29,10 +36,28 @@ const store = (): Store<StoreSchema> => {
   if (!instance) {
     instance = new Store<StoreSchema>({
       name: "window-state",
-      defaults: { windows: {} },
+      defaults: { windows: {}, onboardingActive: true },
     });
   }
   return instance;
+};
+
+/**
+ * Whether the main window should open in onboarding (440×630 default)
+ * mode. Defaults to `true` so a first launch — which has not completed
+ * onboarding — opens the small window directly.
+ */
+export const readOnboardingActive = (): boolean =>
+  store().get("onboardingActive", true);
+
+/**
+ * Persist the onboarding-window-mode flag. No-op when unchanged so a
+ * renderer that re-asserts the current mode on every navigation doesn't
+ * churn the store file.
+ */
+export const writeOnboardingActive = (active: boolean): void => {
+  if (store().get("onboardingActive", true) === active) return;
+  store().set("onboardingActive", active);
 };
 
 interface Defaults {
@@ -100,13 +125,24 @@ export const restoreBounds = (
  * Cmd+Q" path. `isFullScreen()` is tracked separately and passed
  * through to the `BrowserWindow` constructor on restore, so the window
  * comes back in the same display mode it was left in.
+ *
+ * `shouldPersist` gates each save. It defaults to always-on, but callers
+ * that reuse one window across multiple layouts (the main window's
+ * onboarding vs. main modes) pass a predicate so a transient layout's
+ * size isn't saved under this key. Evaluated at save time, not bind time,
+ * so it reflects the current mode.
  */
-export const track = (key: string, win: BrowserWindow): void => {
+export const track = (
+  key: string,
+  win: BrowserWindow,
+  shouldPersist: () => boolean = () => true,
+): void => {
   const SAVE_DEBOUNCE_MS = 500;
   let saveTimer: NodeJS.Timeout | null = null;
 
   const persist = (): void => {
     if (win.isDestroyed()) return;
+    if (!shouldPersist()) return;
     const bounds = win.getNormalBounds();
     const existing = store().get("windows", {});
     store().set("windows", {

--- a/apps/macos/src/main/window-state.ts
+++ b/apps/macos/src/main/window-state.ts
@@ -21,13 +21,11 @@ interface SavedWindowState extends Rectangle {
 
 interface StoreSchema {
   windows: Record<string, SavedWindowState>;
-  // Whether the main window should open in the onboarding layout (440×630
-  // default; see `main-window.ts`). Persisted here — rather than read from
-  // the renderer's localStorage onboarding store — so the very first
-  // window of a launch is constructed at the right size with no
-  // open-large-then-shrink flash. Optional: when absent, the default is
-  // derived from saved window state (see `readOnboardingActive`) so an
-  // upgraded install that predates this key isn't forced into onboarding.
+  // Whether the main window should open in the onboarding layout (440×630)
+  // rather than the full main-app size. Persisted here — not read from the
+  // renderer's localStorage onboarding store — so the first window of a
+  // launch is built at the right size before the renderer loads. Optional:
+  // absent means "not yet decided" (see `readOnboardingActive`).
   onboardingActive?: boolean;
 }
 
@@ -44,22 +42,20 @@ const store = (): Store<StoreSchema> => {
 };
 
 /**
- * Whether the main window should open in onboarding (440×630 default)
- * mode.
+ * Whether the main window should open in onboarding (440×630) mode.
  *
- * The flag is the source of truth once written. When it's absent, the
- * default is derived from saved main-window bounds rather than assumed
- * `true`: a fresh install has no saved `windows.main` and should onboard,
- * but an install upgraded from a build that predates this key already has
- * saved bounds and is past onboarding — forcing it small would open at
- * 440×630 (and stick there on the `/account/*` routes, which render
- * outside `RootLayout` and never call the reconcile hook).
+ * The flag is the source of truth once written. When it's absent we
+ * default to `false` (open the full main-app size). The bias is
+ * deliberate: opening too large is recoverable — onboarding routes live
+ * inside `RootLayout` and the reconcile hook shrinks the window once they
+ * render — but opening too small is not, since `/account/*` routes
+ * (login, signup, OAuth callbacks) render outside `RootLayout` and never
+ * call the hook, so a too-small window there would stay cramped. The app
+ * is built for the larger size, so we err large and let onboarding shrink
+ * itself.
  */
-export const readOnboardingActive = (): boolean => {
-  const stored = store().get("onboardingActive");
-  if (typeof stored === "boolean") return stored;
-  return store().get("windows", {}).main === undefined;
-};
+export const readOnboardingActive = (): boolean =>
+  store().get("onboardingActive", false);
 
 /**
  * Persist the onboarding-window-mode flag. No-op when the effective value

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -197,6 +197,14 @@ export interface VellumBridge {
      * `ensureVisible`.
      */
     ensureVisible(): Promise<void>;
+    /**
+     * Switch the main window between the onboarding layout (440×630
+     * default) and the main-app layout. Both stay resizable. The renderer
+     * calls this as the user navigates into / out of the onboarding
+     * routes; main persists the mode so the next launch opens at the
+     * right size.
+     */
+    setOnboarding(active: boolean): Promise<void>;
   };
   power: {
     /**
@@ -327,6 +335,11 @@ const bridge: VellumBridge = {
   mainWindow: {
     ensureVisible: (): Promise<void> =>
       ipcRenderer.invoke("vellum:mainWindow:ensureVisible") as Promise<void>,
+    setOnboarding: (active: boolean): Promise<void> =>
+      ipcRenderer.invoke(
+        "vellum:mainWindow:setOnboarding",
+        active,
+      ) as Promise<void>,
   },
   power: {
     onEvent: (callback) => {

--- a/apps/web/src/domains/account/account-layout.tsx
+++ b/apps/web/src/domains/account/account-layout.tsx
@@ -3,11 +3,17 @@ import { Outlet } from "react-router";
 import { useOnboardingWindowSize } from "@/hooks/use-onboarding-window-size";
 
 /**
- * Layout for the standalone `/account/*` auth screens (login, signup,
- * password reset, OAuth callbacks). These render outside `RootLayout`, so
- * this is where the compact-window sizing hook is mounted for them — the
- * auth screens use the same small (440×630) window as onboarding. Renders
- * no chrome of its own; the pages own their layout.
+ * Layout for the `/account/*` auth screens that render in the MAIN window —
+ * login, signup, provider sign-in callbacks, password reset. These live
+ * outside `RootLayout`, so this is where the compact-window sizing hook is
+ * mounted for them: they use the same small (440×630) window as onboarding.
+ *
+ * Deliberately does NOT wrap the OAuth completion / loopback pages
+ * (`oauth/popup-complete`, `oauth/complete`, `platform-callback`). Those
+ * render inside an OAuth popup child window, and the sizing IPC targets the
+ * module-scoped main window — so signalling from a popup would shrink the
+ * wrong (main) window and persist `onboardingActive`. They're kept out of
+ * this layout in `routes.tsx`. Renders no chrome of its own.
  */
 export function AccountLayout() {
   useOnboardingWindowSize();

--- a/apps/web/src/domains/account/account-layout.tsx
+++ b/apps/web/src/domains/account/account-layout.tsx
@@ -1,0 +1,15 @@
+import { Outlet } from "react-router";
+
+import { useOnboardingWindowSize } from "@/hooks/use-onboarding-window-size";
+
+/**
+ * Layout for the standalone `/account/*` auth screens (login, signup,
+ * password reset, OAuth callbacks). These render outside `RootLayout`, so
+ * this is where the compact-window sizing hook is mounted for them — the
+ * auth screens use the same small (440×630) window as onboarding. Renders
+ * no chrome of its own; the pages own their layout.
+ */
+export function AccountLayout() {
+  useOnboardingWindowSize();
+  return <Outlet />;
+}

--- a/apps/web/src/hooks/use-onboarding-window-size.test.tsx
+++ b/apps/web/src/hooks/use-onboarding-window-size.test.tsx
@@ -42,6 +42,22 @@ describe("useOnboardingWindowSize", () => {
     expect(setOnboardingWindowMock).toHaveBeenLastCalledWith(false);
   });
 
+  test("requests the small window on the /account auth screens", () => {
+    for (const path of [
+      "/account",
+      "/account/login",
+      "/account/signup",
+      "/account/provider/callback",
+      "/account/password/reset",
+    ]) {
+      setOnboardingWindowMock.mockClear();
+      currentPath = path;
+      const { unmount } = renderHook(() => useOnboardingWindowSize());
+      expect(setOnboardingWindowMock).toHaveBeenLastCalledWith(true);
+      unmount();
+    }
+  });
+
   test("covers every onboarding step under the shared prefix", () => {
     for (const step of [
       "/assistant/onboarding/welcome",

--- a/apps/web/src/hooks/use-onboarding-window-size.test.tsx
+++ b/apps/web/src/hooks/use-onboarding-window-size.test.tsx
@@ -1,0 +1,71 @@
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// The hook reads the current route via react-router's `useLocation` and
+// pushes the onboarding window mode to the Electron host. Drive both from
+// mutable test doubles: flip `currentPath` between renders and capture the
+// host calls.
+let currentPath = "/assistant";
+const setOnboardingWindowMock = mock((_active: boolean) => Promise.resolve());
+
+mock.module("react-router", () => ({
+  useLocation: () => ({ pathname: currentPath }),
+}));
+
+mock.module("@/runtime/main-window", () => ({
+  setOnboardingWindow: setOnboardingWindowMock,
+}));
+
+const { useOnboardingWindowSize } = await import(
+  "@/hooks/use-onboarding-window-size"
+);
+
+beforeEach(() => {
+  currentPath = "/assistant";
+  setOnboardingWindowMock.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useOnboardingWindowSize", () => {
+  test("requests the small onboarding window on an onboarding route", () => {
+    currentPath = "/assistant/onboarding/welcome";
+    renderHook(() => useOnboardingWindowSize());
+    expect(setOnboardingWindowMock).toHaveBeenLastCalledWith(true);
+  });
+
+  test("requests the full window on a non-onboarding route", () => {
+    currentPath = "/assistant";
+    renderHook(() => useOnboardingWindowSize());
+    expect(setOnboardingWindowMock).toHaveBeenLastCalledWith(false);
+  });
+
+  test("covers every onboarding step under the shared prefix", () => {
+    for (const step of [
+      "/assistant/onboarding/welcome",
+      "/assistant/onboarding/hosting",
+      "/assistant/onboarding/api-key",
+      "/assistant/onboarding/privacy",
+      "/assistant/onboarding/prechat",
+      "/assistant/onboarding/hatching",
+    ]) {
+      setOnboardingWindowMock.mockClear();
+      currentPath = step;
+      const { unmount } = renderHook(() => useOnboardingWindowSize());
+      expect(setOnboardingWindowMock).toHaveBeenLastCalledWith(true);
+      unmount();
+    }
+  });
+
+  test("re-applies when navigating from onboarding to the main app", () => {
+    currentPath = "/assistant/onboarding/hatching";
+    const { rerender } = renderHook(() => useOnboardingWindowSize());
+    expect(setOnboardingWindowMock).toHaveBeenLastCalledWith(true);
+
+    currentPath = "/assistant";
+    rerender();
+    expect(setOnboardingWindowMock).toHaveBeenLastCalledWith(false);
+  });
+});

--- a/apps/web/src/hooks/use-onboarding-window-size.ts
+++ b/apps/web/src/hooks/use-onboarding-window-size.ts
@@ -4,33 +4,43 @@ import { useLocation } from "react-router";
 import { setOnboardingWindow } from "@/runtime/main-window";
 
 /**
- * Shared path prefix of every onboarding step route (welcome, hosting,
- * api-key, privacy, prechat, hatching — all under
- * `/assistant/onboarding/*`; see `routes.onboarding` in `@/utils/routes`).
- * Matching the prefix keeps the onboarding window size applied for the
- * whole flow without re-listing each step.
+ * Route prefixes that should render in the compact (440×630) window: the
+ * onboarding flow (`/assistant/onboarding/*`) and the standalone auth
+ * screens (`/account/*` — login, signup, password reset, OAuth callbacks).
+ * Both are chrome-less, narrow, pre-app surfaces. Everything else (the main
+ * app) uses the large window.
+ *
+ * `/assistant/about` is deliberately NOT here, and the hook is never mounted
+ * on it — it renders in a separate About `BrowserWindow` off the same SPA,
+ * and the resize IPC targets the main window, so signalling from there would
+ * resize the wrong window.
  */
-const ONBOARDING_PATH_PREFIX = "/assistant/onboarding/";
+const COMPACT_PATH_PREFIXES = ["/assistant/onboarding/", "/account"];
+
+function isCompactRoute(pathname: string): boolean {
+  return COMPACT_PATH_PREFIXES.some((prefix) => pathname.startsWith(prefix));
+}
 
 /**
- * Keep the Electron main window sized to the onboarding layout (440×630,
- * matching the macOS Swift client) while an onboarding step is showing,
- * and let it grow back to the resizable main-app size everywhere else.
+ * Keep the Electron main window sized to the compact layout (440×630,
+ * matching the macOS Swift client) while on a compact route — onboarding or
+ * the `/account/*` auth screens — and large everywhere else in the app.
  *
- * Mounted once at the app root (`RootLayout`). Off Electron the call is a
- * no-op, so this is inert on web and iOS. Driving it from the route — not
- * the `onboarding.completed` flag — keeps the small window applied across
- * every step (including the post-completion-flag prechat/hatching screens,
- * which the macOS client also shows in the small window).
+ * Mounted on every route group whose content lives in the main window:
+ * `RootLayout` (the `/assistant` app, incl. onboarding) and the `/account`
+ * layout. Off Electron the call is a no-op, so this is inert on web and iOS.
+ * Driving it from the route — not the `onboarding.completed` flag — keeps
+ * the small window applied across the whole pre-app surface, including the
+ * post-completion-flag prechat/hatching screens.
  */
 export function useOnboardingWindowSize(): void {
   const { pathname } = useLocation();
-  const isOnboarding = pathname.startsWith(ONBOARDING_PATH_PREFIX);
+  const isCompact = isCompactRoute(pathname);
 
-  // Depend on the derived boolean, not the raw pathname, so the effect
-  // (and its IPC round-trip) only runs when onboarding-ness actually flips
-  // — not on every navigation within the app or within the flow.
+  // Depend on the derived boolean, not the raw pathname, so the effect (and
+  // its IPC round-trip) only runs when compact-ness actually flips — not on
+  // every navigation within a group.
   useEffect(() => {
-    void setOnboardingWindow(isOnboarding);
-  }, [isOnboarding]);
+    void setOnboardingWindow(isCompact);
+  }, [isCompact]);
 }

--- a/apps/web/src/hooks/use-onboarding-window-size.ts
+++ b/apps/web/src/hooks/use-onboarding-window-size.ts
@@ -1,0 +1,36 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router";
+
+import { setOnboardingWindow } from "@/runtime/main-window";
+
+/**
+ * Shared path prefix of every onboarding step route (welcome, hosting,
+ * api-key, privacy, prechat, hatching — all under
+ * `/assistant/onboarding/*`; see `routes.onboarding` in `@/utils/routes`).
+ * Matching the prefix keeps the onboarding window size applied for the
+ * whole flow without re-listing each step.
+ */
+const ONBOARDING_PATH_PREFIX = "/assistant/onboarding/";
+
+/**
+ * Keep the Electron main window sized to the onboarding layout (440×630,
+ * matching the macOS Swift client) while an onboarding step is showing,
+ * and let it grow back to the resizable main-app size everywhere else.
+ *
+ * Mounted once at the app root (`RootLayout`). Off Electron the call is a
+ * no-op, so this is inert on web and iOS. Driving it from the route — not
+ * the `onboarding.completed` flag — keeps the small window applied across
+ * every step (including the post-completion-flag prechat/hatching screens,
+ * which the macOS client also shows in the small window).
+ */
+export function useOnboardingWindowSize(): void {
+  const { pathname } = useLocation();
+  const isOnboarding = pathname.startsWith(ONBOARDING_PATH_PREFIX);
+
+  // Depend on the derived boolean, not the raw pathname, so the effect
+  // (and its IPC round-trip) only runs when onboarding-ness actually flips
+  // — not on every navigation within the app or within the flow.
+  useEffect(() => {
+    void setOnboardingWindow(isOnboarding);
+  }, [isOnboarding]);
+}

--- a/apps/web/src/hooks/use-onboarding-window-size.ts
+++ b/apps/web/src/hooks/use-onboarding-window-size.ts
@@ -10,9 +10,14 @@ import { setOnboardingWindow } from "@/runtime/main-window";
  * Both are chrome-less, narrow, pre-app surfaces. Everything else (the main
  * app) uses the large window.
  *
- * `/assistant/about` is deliberately NOT here, and the hook is never mounted
- * on it — it renders in a separate About `BrowserWindow` off the same SPA,
- * and the resize IPC targets the main window, so signalling from there would
+ * The `/account` prefix assumes the hook is only mounted on `/account`
+ * routes that render in the MAIN window (login, signup, etc., via
+ * `AccountLayout`). The OAuth completion pages (`oauth/popup-complete` etc.)
+ * also match this prefix but render inside a popup child window — they're
+ * kept OUT of `AccountLayout` in `routes.tsx` so the hook never mounts
+ * there. Same hazard as `/assistant/about`, which renders in a separate
+ * About `BrowserWindow` and likewise never mounts this hook: the resize IPC
+ * targets the main window, so signalling from any non-main window would
  * resize the wrong window.
  */
 const COMPACT_PATH_PREFIXES = ["/assistant/onboarding/", "/account"];

--- a/apps/web/src/root-layout.tsx
+++ b/apps/web/src/root-layout.tsx
@@ -19,6 +19,7 @@ import { useEnvironmentStore } from "@/stores/environment-store";
 import { useAssistantResourceSync } from "@/hooks/use-assistant-resource-sync";
 import { useDocumentEditorSync } from "@/hooks/use-document-editor-sync";
 import { useNotificationIntentSync } from "@/hooks/use-notification-intent-sync";
+import { useOnboardingWindowSize } from "@/hooks/use-onboarding-window-size";
 import { useConversationSync } from "@/hooks/use-conversation-sync";
 import { resolveOnboardingRedirect } from "@/domains/onboarding/gate";
 import { useFeatureFlagBusSync } from "@/hooks/use-feature-flag-bus-sync";
@@ -95,6 +96,12 @@ export function RootLayout() {
   // so the favicon persists when navigating between sibling layouts.
   const avatar = useAssistantAvatar(assistantId);
   useDynamicFavicon(avatar.customImageUrl, avatar.components, avatar.traits);
+
+  // Size the Electron main window to the onboarding layout (440×630
+  // default) while on an onboarding step, and back to the main-app size
+  // elsewhere. No-op off Electron. Mounted at the app root so it tracks
+  // navigation across the whole onboarding flow.
+  useOnboardingWindowSize();
 
   useEventBusInit({ assistantId, isAssistantActive });
   // Inbound deep-link navigation + window activation. Mounted here

--- a/apps/web/src/routes.test.ts
+++ b/apps/web/src/routes.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { matchRoutes } from "react-router";
+
+import { routeTree } from "@/routes";
+
+// Walk the matched route chain for `path` and report whether `AccountLayout`
+// is one of its layout components. Matching runs against the raw `routeTree`
+// (not the constructed `router`) because `createBrowserRouter` consumes the
+// `Component` field, leaving nothing to inspect.
+function isUnderAccountLayout(path: string): boolean {
+  const matches = matchRoutes(routeTree as never, path) ?? [];
+  return matches.some(
+    (m) =>
+      (m.route as { Component?: { name?: string } }).Component?.name ===
+      "AccountLayout",
+  );
+}
+
+describe("account route compact-window grouping", () => {
+  // The auth screens that render in the main window opt into the compact
+  // (440×630) window via AccountLayout's sizing hook.
+  test.each([
+    "/account",
+    "/account/login",
+    "/account/signup",
+    "/account/provider/callback",
+    "/account/provider/signup",
+    "/account/password/reset",
+    "/account/password/reset/key/abc123",
+  ])("%s is sized by AccountLayout", (path) => {
+    expect(isUnderAccountLayout(path)).toBe(true);
+  });
+
+  // The OAuth completion / loopback pages render inside a popup child window
+  // (or are transient redirects). They must stay OUT of AccountLayout — the
+  // resize IPC targets the main window, so sizing from a popup would shrink
+  // the wrong window and persist `onboardingActive`.
+  test.each([
+    "/account/oauth/popup-complete",
+    "/account/oauth/complete",
+    "/account/oauth/desktop-complete",
+    "/account/platform-callback",
+  ])("%s is NOT sized by AccountLayout", (path) => {
+    expect(isUnderAccountLayout(path)).toBe(false);
+  });
+});

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -47,17 +47,17 @@ function OAuthDesktopCompleteRedirect() {
 // - React Router lazy (data mode): https://reactrouter.com/start/data/custom#3-lazy-loading
 // - React Router error boundaries: https://reactrouter.com/how-to/error-boundary
 // - React Router middleware: https://reactrouter.com/how-to/middleware
-export const router = createBrowserRouter(
-  [
+// Exported separately from `router` so the route tree can be asserted in
+// tests: `createBrowserRouter` consumes `Component`, so structural checks
+// (e.g. "the OAuth popup pages are NOT under AccountLayout") must run against
+// these raw definitions.
+export const routeTree = [
     // Account routes — standalone auth pages, no app chrome.
     // Lazy-loaded: only needed for unauthenticated flows.
     {
       path: "/account",
       ErrorBoundary: RouteErrorBoundary,
       HydrateFallback: RootHydrateFallback,
-      // Sizes the main window compact (440×630) for the auth screens, which
-      // render outside RootLayout. Renders the child routes via <Outlet/>.
-      Component: AccountLayout,
       children: [
         // Pathless wrapper so lazy-chunk failures render the chunk-fail
         // variant of `RouteErrorBoundary` (inline copy + Reload button)
@@ -65,17 +65,30 @@ export const router = createBrowserRouter(
         {
           ErrorBoundary: RouteErrorBoundary,
           children: [
-            { index: true, lazy: { Component: () => import("@/domains/account/pages/account-page").then((m) => m.AccountPage) } },
-            { path: "login", lazy: { Component: () => import("@/domains/account/pages/login-page").then((m) => m.LoginPage) } },
-            { path: "signup", lazy: { Component: () => import("@/domains/account/pages/signup-page").then((m) => m.SignupPage) } },
-            { path: "provider/callback", lazy: { Component: () => import("@/domains/account/pages/provider-callback-page").then((m) => m.ProviderCallbackPage) } },
-            { path: "provider/signup", lazy: { Component: () => import("@/domains/account/pages/provider-signup-page").then((m) => m.ProviderSignupPage) } },
+            // Auth screens that render in the MAIN window. AccountLayout sizes
+            // it compact (440×630) for these, matching onboarding.
+            {
+              Component: AccountLayout,
+              children: [
+                { index: true, lazy: { Component: () => import("@/domains/account/pages/account-page").then((m) => m.AccountPage) } },
+                { path: "login", lazy: { Component: () => import("@/domains/account/pages/login-page").then((m) => m.LoginPage) } },
+                { path: "signup", lazy: { Component: () => import("@/domains/account/pages/signup-page").then((m) => m.SignupPage) } },
+                { path: "provider/callback", lazy: { Component: () => import("@/domains/account/pages/provider-callback-page").then((m) => m.ProviderCallbackPage) } },
+                { path: "provider/signup", lazy: { Component: () => import("@/domains/account/pages/provider-signup-page").then((m) => m.ProviderSignupPage) } },
+                { path: "password/reset", lazy: { Component: () => import("@/domains/account/pages/password-reset-page").then((m) => m.PasswordResetPage) } },
+                { path: "password/reset/key/:key", lazy: { Component: () => import("@/domains/account/pages/password-reset-page").then((m) => m.PasswordResetPage) } },
+              ],
+            },
+            // OAuth completion / loopback machinery. These render inside the
+            // OAuth popup child window (or are transient redirects), NOT the
+            // main window — so they're deliberately OUTSIDE AccountLayout and
+            // never mount the sizing hook. The resize IPC targets the
+            // module-scoped main window, so sizing from a popup would shrink
+            // the wrong window. See `use-onboarding-window-size`.
             { path: "oauth/popup-complete", lazy: { Component: () => import("@/domains/account/pages/oauth-popup-complete-page").then((m) => m.OAuthPopupCompletePage) } },
             { path: "oauth/complete", lazy: { Component: () => import("@/domains/account/pages/oauth-complete-page").then((m) => m.OAuthCompletePage) } },
             { path: "oauth/desktop-complete", Component: OAuthDesktopCompleteRedirect },
             { path: "platform-callback", lazy: { Component: () => import("@/domains/account/pages/platform-loopback-page").then((m) => m.PlatformLoopbackPage) } },
-            { path: "password/reset", lazy: { Component: () => import("@/domains/account/pages/password-reset-page").then((m) => m.PasswordResetPage) } },
-            { path: "password/reset/key/:key", lazy: { Component: () => import("@/domains/account/pages/password-reset-page").then((m) => m.PasswordResetPage) } },
           ],
         },
       ],
@@ -269,8 +282,8 @@ export const router = createBrowserRouter(
 
     // Top-level catch-all
     { path: "*", ErrorBoundary: RouteErrorBoundary, Component: NotFound },
-  ],
-  {
-    future: { v8_middleware: true },
-  },
-);
+];
+
+export const router = createBrowserRouter(routeTree as never, {
+  future: { v8_middleware: true },
+});

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -6,6 +6,7 @@ import {
   onboardingCompletedMiddleware,
 } from "@/lib/onboarding-middleware";
 import { RootLayout } from "@/root-layout";
+import { AccountLayout } from "@/domains/account/account-layout";
 import { ChatLayout } from "@/domains/chat/chat-layout";
 import { ChatPage } from "@/domains/chat/chat-page";
 import { ConversationRedirect } from "@/domains/chat/conversation-redirect";
@@ -54,6 +55,9 @@ export const router = createBrowserRouter(
       path: "/account",
       ErrorBoundary: RouteErrorBoundary,
       HydrateFallback: RootHydrateFallback,
+      // Sizes the main window compact (440×630) for the auth screens, which
+      // render outside RootLayout. Renders the child routes via <Outlet/>.
+      Component: AccountLayout,
       children: [
         // Pathless wrapper so lazy-chunk failures render the chunk-fail
         // variant of `RouteErrorBoundary` (inline copy + Reload button)

--- a/apps/web/src/runtime/is-electron.ts
+++ b/apps/web/src/runtime/is-electron.ts
@@ -90,6 +90,7 @@ declare global {
       };
       mainWindow: {
         ensureVisible(): Promise<void>;
+        setOnboarding(active: boolean): Promise<void>;
       };
       power: {
         onEvent(

--- a/apps/web/src/runtime/main-window.ts
+++ b/apps/web/src/runtime/main-window.ts
@@ -25,3 +25,19 @@ export async function ensureMainWindowVisible(): Promise<void> {
   if (!isElectron()) return;
   await window.vellum?.mainWindow.ensureVisible();
 }
+
+/**
+ * Switch the Electron main window between the onboarding layout (440×630
+ * default, matching the macOS Swift client) and the main-app layout. Drive
+ * it from the active route — `true` while an onboarding step is showing,
+ * `false` otherwise.
+ *
+ * No-op off Electron: web is a single resizable browser viewport and
+ * Capacitor iOS is system-managed, so neither has a window to resize.
+ * Safe to call on every navigation — the main process treats re-asserting
+ * the current mode as a no-op.
+ */
+export async function setOnboardingWindow(active: boolean): Promise<void> {
+  if (!isElectron()) return;
+  await window.vellum?.mainWindow.setOnboarding(active);
+}


### PR DESCRIPTION
## What

Match the macOS Swift client's onboarding window dimensions (**440×630**) in the new Electron app (`apps/macos`). Onboarding opens at that content size in the single main window, then grows back to the normal app size once onboarding completes. Both layouts stay **fully resizable** — onboarding just starts smaller.

## Why

The Swift client (`OnboardingWindow.swift`) shows onboarding in a 440×630 window; the Electron app was opening onboarding at the full 1280×800 main-window size. This brings the two clients in line.

## How

**Main process**
- `window-state.ts` — persist an `onboardingActive` flag (default `true`) so the very first window of a launch is constructed at the right size with **no open-large-then-shrink flash**; `track()` gains a `shouldPersist` predicate so the small onboarding default never clobbers the user's saved main-window size.
- `main-window.ts` — create the window at 440×630 content size when onboarding; `setOnboarding()` resizes the live window on transition; new `vellum:mainWindow:setOnboarding` IPC.

**Bridge + renderer**
- `preload/index.ts` + `runtime/is-electron.ts` — expose/type `mainWindow.setOnboarding`.
- `runtime/main-window.ts` — `setOnboardingWindow()` wrapper (no-op off Electron).
- `hooks/use-onboarding-window-size.ts` (new) — drives the resize from the active route (`/assistant/onboarding/*` → small, else → full); effect keyed on the derived boolean so it only fires when onboarding-ness flips. Mounted in `RootLayout`.

## Notes

- Onboarding intentionally **always reopens at the 440×630 default** (in-session resizes aren't persisted); the main window remembers its size as before.
- No native-dependency changes — pushed with `SKIP_IOS_BUILD=1 SKIP_SWIFT_BUILD=1`.

## Test plan

- [x] `apps/macos` + `apps/web` typecheck clean
- [x] `main-window.test.ts`, `window-state.test.ts`, `use-onboarding-window-size.test.tsx` pass (creation modes, resize transitions, persistence gating, IPC, route→size mapping)
- [ ] Manual: fresh launch opens small (440×630), stays small through the whole onboarding flow incl. prechat/hatching, grows to 1280×800 on entering chat, and onboarding window is draggable/resizable

🤖 Generated with [Claude Code](https://claude.com/claude-code)