### PR TITLE
feat(cli): proactively refresh a stale guardian token at TUI startup

### DIFF
--- a/cli/src/__tests__/client-tui-refresh.test.ts
+++ b/cli/src/__tests__/client-tui-refresh.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Tests for resolveFreshBearerToken: the `vellum client` TUI proactively
+ * refreshes a stale STORED guardian token at startup, while leaving platform
+ * session auth, ephemeral --token overrides, and still-fresh tokens untouched.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const ORIGINAL_XDG = process.env.XDG_CONFIG_HOME;
+const ORIGINAL_ENV = process.env.VELLUM_ENVIRONMENT;
+const ORIGINAL_FETCH = globalThis.fetch;
+
+import { resolveFreshBearerToken } from "../commands/client.js";
+import { saveGuardianToken } from "../lib/guardian-token.js";
+
+const RUNTIME = "http://10.0.0.9:7830";
+const past = () => new Date(Date.now() - 60_000).toISOString();
+const future = () => new Date(Date.now() + 60 * 60 * 1000).toISOString();
+
+function seed(opts: {
+  accessToken: string;
+  refreshToken: string;
+  refreshAfter: string;
+}): void {
+  saveGuardianToken("px", {
+    guardianPrincipalId: "imported",
+    accessToken: opts.accessToken,
+    accessTokenExpiresAt: future(),
+    refreshToken: opts.refreshToken,
+    refreshTokenExpiresAt: future(),
+    refreshAfter: opts.refreshAfter,
+    isNew: false,
+    deviceId: "dev",
+    leasedAt: new Date().toISOString(),
+  });
+}
+
+/** Stub global fetch; returns whether the refresh endpoint was hit. */
+function stubRefresh(ok: boolean): { hit: () => boolean } {
+  let called = false;
+  globalThis.fetch = (async (url: unknown, _init?: RequestInit) => {
+    if (String(url).includes("/v1/guardian/refresh")) {
+      called = true;
+      return new Response(
+        ok ? JSON.stringify({ accessToken: "new-acc" }) : "nope",
+        {
+          status: ok ? 200 : 401,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    }
+    return new Response("", { status: 200 });
+  }) as typeof fetch;
+  return { hit: () => called };
+}
+
+describe("resolveFreshBearerToken", () => {
+  let tempHome: string;
+
+  beforeEach(() => {
+    tempHome = mkdtempSync(join(tmpdir(), "client-tui-refresh-test-"));
+    process.env.XDG_CONFIG_HOME = tempHome;
+    delete process.env.VELLUM_ENVIRONMENT; // prod config dir
+  });
+
+  afterEach(() => {
+    globalThis.fetch = ORIGINAL_FETCH;
+    if (ORIGINAL_XDG === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = ORIGINAL_XDG;
+    if (ORIGINAL_ENV === undefined) delete process.env.VELLUM_ENVIRONMENT;
+    else process.env.VELLUM_ENVIRONMENT = ORIGINAL_ENV;
+    rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  test("refreshes a stale stored token and returns the new access token", async () => {
+    seed({ accessToken: "old-acc", refreshToken: "ref", refreshAfter: past() });
+    const refresh = stubRefresh(true);
+
+    const token = await resolveFreshBearerToken(
+      RUNTIME,
+      "px",
+      "old-acc",
+      "paired",
+    );
+
+    expect(token).toBe("new-acc");
+    expect(refresh.hit()).toBe(true);
+  });
+
+  test("leaves a still-fresh stored token unchanged (no refresh)", async () => {
+    seed({
+      accessToken: "old-acc",
+      refreshToken: "ref",
+      refreshAfter: future(),
+    });
+    const refresh = stubRefresh(true);
+
+    const token = await resolveFreshBearerToken(
+      RUNTIME,
+      "px",
+      "old-acc",
+      "paired",
+    );
+
+    expect(token).toBe("old-acc");
+    expect(refresh.hit()).toBe(false);
+  });
+
+  test("does not refresh an ephemeral --token (mismatches the store)", async () => {
+    seed({ accessToken: "old-acc", refreshToken: "ref", refreshAfter: past() });
+    const refresh = stubRefresh(true);
+
+    // bearerToken differs from the stored accessToken => ephemeral override.
+    const token = await resolveFreshBearerToken(
+      RUNTIME,
+      "px",
+      "ephemeral-tok",
+      "paired",
+    );
+
+    expect(token).toBe("ephemeral-tok");
+    expect(refresh.hit()).toBe(false);
+  });
+
+  test("never refreshes on the platform session-auth path", async () => {
+    seed({ accessToken: "old-acc", refreshToken: "ref", refreshAfter: past() });
+    const refresh = stubRefresh(true);
+
+    const token = await resolveFreshBearerToken(
+      RUNTIME,
+      "px",
+      "old-acc",
+      "vellum",
+    );
+
+    expect(token).toBe("old-acc");
+    expect(refresh.hit()).toBe(false);
+  });
+
+  test("falls back to the existing token when refresh fails", async () => {
+    seed({ accessToken: "old-acc", refreshToken: "ref", refreshAfter: past() });
+    stubRefresh(false); // refresh endpoint returns non-ok
+
+    const token = await resolveFreshBearerToken(
+      RUNTIME,
+      "px",
+      "old-acc",
+      "paired",
+    );
+
+    expect(token).toBe("old-acc");
+  });
+
+  test("does not refresh an access-only stored token (no refresh credential)", async () => {
+    seed({ accessToken: "old-acc", refreshToken: "", refreshAfter: past() });
+    const refresh = stubRefresh(true);
+
+    const token = await resolveFreshBearerToken(
+      RUNTIME,
+      "px",
+      "old-acc",
+      "paired",
+    );
+
+    expect(token).toBe("old-acc");
+    expect(refresh.hit()).toBe(false);
+  });
+});

--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -17,7 +17,7 @@ import {
   GATEWAY_PORT,
   type Species,
 } from "../lib/constants";
-import { loadGuardianToken } from "../lib/guardian-token";
+import { loadGuardianToken, refreshGuardianToken } from "../lib/guardian-token";
 import { getLocalLanIPv4 } from "../lib/local";
 import {
   CLI_INTERFACE_ID,
@@ -821,6 +821,42 @@ async function runViteDevServer(webSourceDir: string): Promise<void> {
   });
 }
 
+/**
+ * Return a possibly-refreshed bearer token for the TUI's startup auth.
+ *
+ * Only a STORED guardian token is refreshable: platform session auth
+ * (`cloud === "vellum"`) and ephemeral `--token` overrides (whose token won't
+ * match the store) are left untouched, as is a token that's still fresh. When
+ * the stored token has passed its `refreshAfter` (or expiry) and a refresh
+ * token is available, refresh once via the concurrency-safe refreshGuardianToken
+ * and use the rotated access token. Falls back to the existing token if refresh
+ * isn't possible/fails — the session still starts (same as before).
+ */
+export async function resolveFreshBearerToken(
+  runtimeUrl: string,
+  assistantId: string,
+  bearerToken: string | undefined,
+  cloud: string | undefined,
+): Promise<string | undefined> {
+  if (cloud === "vellum" || !bearerToken || !assistantId) return bearerToken;
+
+  const stored = loadGuardianToken(assistantId);
+  // Refresh only the stored token (an ephemeral --token won't match), and only
+  // when a refresh credential is present.
+  if (!stored || stored.accessToken !== bearerToken || !stored.refreshToken) {
+    return bearerToken;
+  }
+
+  // new Date() handles both ISO strings and epoch-ms numbers; Date.parse of an
+  // epoch-ms string would be NaN.
+  const renewAtRaw = stored.refreshAfter || stored.accessTokenExpiresAt;
+  const renewAt = new Date(renewAtRaw).getTime();
+  if (!Number.isFinite(renewAt) || renewAt > Date.now()) return bearerToken;
+
+  const refreshed = await refreshGuardianToken(runtimeUrl, assistantId);
+  return refreshed?.accessToken ?? bearerToken;
+}
+
 export async function client(): Promise<void> {
   const {
     runtimeUrl,
@@ -868,8 +904,19 @@ export async function client(): Promise<void> {
       ...getClientRegistrationHeaders(interfaceId),
     };
   } else {
+    // Proactively refresh a stale STORED guardian token before opening the TUI,
+    // so launching after the access token expired renews transparently rather
+    // than erroring. (Mid-session expiry — the token dying while the TUI is
+    // already open — is a separate follow-up, since the TUI threads a static
+    // auth object through React.)
+    const token = await resolveFreshBearerToken(
+      runtimeUrl,
+      assistantId,
+      bearerToken,
+      cloud,
+    );
     auth = {
-      ...(bearerToken ? { Authorization: `Bearer ${bearerToken}` } : {}),
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
       ...getClientRegistrationHeaders(interfaceId),
     };
   }


### PR DESCRIPTION
## Summary
- `vellum client` (the interactive TUI) now **proactively refreshes a stale stored guardian token at startup**, before building its request auth — so launching after the paired access token has expired/aged renews transparently instead of erroring. Implemented as an exported, unit-tested helper `resolveFreshBearerToken` called in `client()`'s guardian-auth branch.
- **Tightly gated:** only the *stored* guardian token is refreshed — platform session auth (`cloud:"vellum"`) and ephemeral `--token` overrides (whose token won't match the store) are skipped, as is a token that's still before its `refreshAfter`/expiry. Reuses the concurrency-safe `refreshGuardianToken` (per-assistant lock + timeout from R3). Falls back to the existing token if refresh isn't possible/fails — the session still starts, exactly as today.

## Scope / follow-up
- This completes the **common** TUI case (launch-after-expiry). **Mid-session** refresh (the token expiring while the TUI is already open) remains a follow-up (**R3c**): the TUI threads a static `auth` object through many React components, so renewing mid-flight needs that auth re-threaded through state/SSE-reconnect — deliberately out of scope here. With 30-day access tokens, mid-session expiry is rare.
- With R1+R2+R3+R3b, every routine paired CLI surface (`message`, `events`, and now the `client` TUI at startup) renews without re-pairing.

## Tests
`cli/src/__tests__/client-tui-refresh.test.ts` exercises `resolveFreshBearerToken` directly (stubbed `globalThis.fetch`, seeded guardian token): stale stored token → refreshes & returns new token; fresh token → no refresh; ephemeral token (mismatches store) → no refresh; `cloud:"vellum"` → no refresh; refresh fails → falls back to existing token; access-only token → no refresh.

## Original prompt
Final reachable piece of the refreshable-pairing UX: R3 covered `message`/`events` via AssistantClient's 401-retry, but the `vellum client` TUI uses a separate request path with a startup-built static auth object. This adds a startup proactive refresh so opening the TUI after token expiry just works, while leaving the deeper mid-session React/SSE re-auth as a separate follow-up.