### PR TITLE
Pro Plan Credit Bundles — Frontend (apps/web)

### DIFF
--- a/apps/web/src/domains/settings/components/adjust-plan-modal.test.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.test.tsx
@@ -478,6 +478,56 @@ describe("AdjustPlanModal credit bundle — resize flow", () => {
   });
 });
 
+describe("AdjustPlanModal credit bundle — headline total", () => {
+  test("upgrade total includes the selected bundle's monthly price", async () => {
+    // Base→Pro. Defaults: base $20 + Small machine $10 + 10 GiB storage $5 =
+    // $35/mo with no bundle. Picking the $50 bundle must add $50 → $85/mo.
+    const { getByTestId } = renderModal(
+      subscription("base", null),
+      proPlansResponse(CREDIT_TIERS),
+    );
+
+    await waitFor(() => {
+      if (getByTestId("tier-picker-total").textContent?.includes("$35/mo"))
+        return;
+      throw new Error("base total not rendered yet");
+    });
+
+    openCreditDropdown();
+    clickOption("50 credits — $50/mo");
+
+    await waitFor(() => {
+      if (getByTestId("tier-picker-total").textContent?.includes("$85/mo"))
+        return;
+      throw new Error("total did not include the selected bundle");
+    });
+  });
+
+  test("change-mode total and delta reflect swapping bundles", async () => {
+    // Pro with no current bundle. Current = base $20 + Small $10 + 10 GiB $5 =
+    // $35/mo. Picking the $25 bundle makes the new total $60/mo (+$25 delta).
+    const { getByTestId } = renderModal(
+      subscription("pro", null),
+      proPlansResponse(CREDIT_TIERS),
+    );
+
+    await waitFor(() => {
+      if (getByTestId("tier-picker-total").textContent?.includes("$35/mo"))
+        return;
+      throw new Error("current total not rendered yet");
+    });
+
+    openCreditDropdown();
+    clickOption("25 credits — $25/mo");
+
+    await waitFor(() => {
+      const text = getByTestId("tier-picker-total").textContent ?? "";
+      if (text.includes("$60/mo") && text.includes("+$25/mo")) return;
+      throw new Error("total/delta did not reflect the swapped bundle");
+    });
+  });
+});
+
 describe("AdjustPlanModal credit bundle — catalog gate", () => {
   test("hides the credit UI when the plan has no credit_tiers (upgrade)", () => {
     renderModal(subscription("base", null), proPlansResponse(undefined));

--- a/apps/web/src/domains/settings/components/adjust-plan-modal.test.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.test.tsx
@@ -361,6 +361,33 @@ describe("AdjustPlanModal credit bundle — unseeded sentinel", () => {
     expect(changeCreditTierCall).toBeNull();
   });
 
+  test("a current bundle absent from the catalog does not enable a spurious removal", async () => {
+    // A Pro user holds a deprecated tier (`credits_legacy`) that the live
+    // catalog no longer advertises. Opening the modal must NOT coerce that into
+    // a "remove bundle" pending change: the Update Plan CTA stays disabled and
+    // clicking it submits no credit mutation (which would have sent
+    // `credit_tier: null`, silently dropping the user's paid bundle).
+    const { getByTestId } = renderModal(
+      subscription("pro", "credits_legacy"),
+      proPlansResponse(CREDIT_TIERS),
+    );
+
+    await waitFor(() => {
+      const trigger = document.querySelector(
+        'button[role="combobox"][aria-label="Credit bundle"]',
+      );
+      if (!trigger) throw new Error("picker not rendered yet");
+    });
+
+    const button = getByTestId("modal-change-tier-button") as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+
+    fireEvent.click(button);
+    // Give any (erroneous) mutation a tick to fire.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(changeCreditTierCall).toBeNull();
+  });
+
   test("preserves an explicit 'No bundle' choice across a plans refetch", async () => {
     // Pro user with credits_50 picks "No credit bundle" (selection becomes
     // null). A subsequent plans refetch re-runs the seeding effect; the explicit

--- a/apps/web/src/domains/settings/components/adjust-plan-modal.test.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.test.tsx
@@ -18,7 +18,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import * as sdkGen from "@/generated/api/sdk.gen";
@@ -384,6 +384,57 @@ describe("AdjustPlanModal credit bundle — unseeded sentinel", () => {
 
     fireEvent.click(button);
     // Give any (erroneous) mutation a tick to fire.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(changeCreditTierCall).toBeNull();
+  });
+
+  test("preserves a held legacy bundle across a plans refetch when applying an unrelated change", async () => {
+    // A Pro user holds a deprecated tier (`credits_legacy`) absent from the
+    // catalog. The first seed preserves it. A mid-modal plans refetch re-runs
+    // the seeding effect with `prev` = the legacy tier; since it equals the
+    // current bundle it must be KEPT (not coerced to null). Applying an
+    // unrelated machine change must then send only the machine mutation and
+    // never `credit_tier: null` — which would silently drop the paid bundle.
+    const { getByTestId, client } = renderModal(
+      subscription("pro", "credits_legacy"),
+      proPlansResponse(CREDIT_TIERS),
+    );
+
+    await waitFor(() => {
+      const trigger = document.querySelector(
+        'button[role="combobox"][aria-label="Credit bundle"]',
+      );
+      if (!trigger) throw new Error("picker not rendered yet");
+    });
+
+    // Simulate a mid-modal refetch: re-seed by replacing the plans object so the
+    // seeding effect re-runs with `prev` = credits_legacy (held, not in catalog).
+    // React Query's structural sharing keeps the cached object's reference when
+    // the payload is deep-equal, so we mutate an unrelated field (the Pro plan
+    // name) to force a fresh `proPlan` identity that re-triggers the effect.
+    // Tiers (machine/storage/credit) stay identical so only the credit re-seed
+    // is under test. With the bug, `prev` would be coerced to null here, marking
+    // creditChanged and queuing a spurious `credit_tier: null`.
+    const refetched = proPlansResponse(CREDIT_TIERS);
+    refetched.plans[1]!.name = "Pro (refetched)";
+    await act(async () => {
+      client.setQueryData(organizationsBillingPlansRetrieveQueryKey(), refetched);
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    // Make an unrelated machine change so the CTA enables via that dimension.
+    openMachineDropdown();
+    clickOptionStartingWith("Large");
+
+    fireEvent.click(getByTestId("modal-change-tier-button"));
+
+    await waitFor(() => {
+      if (!changeMachineTierCall) throw new Error("machine change not called");
+    });
+    expect(
+      (changeMachineTierCall!.body as Record<string, unknown>).machine_tier,
+    ).toBe("machine_large");
+    // The held legacy bundle must survive the refetch: no credit mutation fires.
     await new Promise((r) => setTimeout(r, 0));
     expect(changeCreditTierCall).toBeNull();
   });

--- a/apps/web/src/domains/settings/components/adjust-plan-modal.test.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.test.tsx
@@ -1,0 +1,472 @@
+/**
+ * Tests for the credit-bundle wiring in `AdjustPlanModal` (PR 4 of the
+ * pro-credit-bundles-frontend plan).
+ *
+ * Strategy: mock the generated API SDK so the upgrade / change-credit-tier
+ * mutations resolve without network calls and we can capture the request
+ * bodies. The modal's React Query reads are pre-seeded into the cache so they
+ * resolve synchronously. The credit-bundle Dropdown is the design-library
+ * combobox (not a native <select>): open it via its trigger, then click the
+ * option whose visible label matches.
+ *
+ * Coverage:
+ *  - upgrade (Base→Pro) forwards `credit_tier` (a selected bundle, and null for
+ *    "No bundle"),
+ *  - change mode (existing Pro) calls change-credit-tier with the selected
+ *    value and with null on removal,
+ *  - the credit UI is hidden when the catalog has no `credit_tiers`.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import * as sdkGen from "@/generated/api/sdk.gen";
+import {
+  organizationsBillingPlansRetrieveQueryKey,
+  organizationsBillingSubscriptionOnboardingRetrieveQueryKey,
+  organizationsBillingSubscriptionRetrieveQueryKey,
+} from "@/generated/api/@tanstack/react-query.gen";
+import type {
+  CreditTier,
+  PlanListResponse,
+  SubscriptionResponse,
+} from "@/generated/api/types.gen";
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+type Captured = { body?: unknown };
+let upgradeCall: Captured | null = null;
+let changeCreditTierCall: Captured | null = null;
+let changeMachineTierCall: Captured | null = null;
+let changeStorageTierCall: Captured | null = null;
+
+mock.module("@/generated/api/sdk.gen", () => ({
+  ...sdkGen,
+  organizationsBillingSubscriptionUpgradeCreate: (opts: Captured) => {
+    upgradeCall = opts;
+    return Promise.resolve({ data: { status: "ok" }, response: { ok: true } });
+  },
+  organizationsBillingSubscriptionChangeCreditTierCreate: (opts: Captured) => {
+    changeCreditTierCall = opts;
+    return Promise.resolve({
+      data: { status: "ok", credit_tier: null },
+      response: { ok: true },
+    });
+  },
+  organizationsBillingSubscriptionChangeMachineTierCreate: (opts: Captured) => {
+    changeMachineTierCall = opts;
+    return Promise.resolve({ data: { status: "ok" }, response: { ok: true } });
+  },
+  organizationsBillingSubscriptionChangeStorageTierCreate: (opts: Captured) => {
+    changeStorageTierCall = opts;
+    return Promise.resolve({ data: { status: "ok" }, response: { ok: true } });
+  },
+}));
+
+// Avoid pulling the real billing-portal hook's network fan-out; the downgrade /
+// portal paths are unrelated to credit-bundle wiring.
+mock.module("@/domains/settings/hooks/use-billing-portal-session", () => ({
+  buildPortalReturnSnapshot: () => ({}),
+  formatGraceDate: () => "",
+  getEffectiveCancelDate: () => null,
+  useBillingPortalSession: () => ({ isPending: false, mutate: () => {} }),
+}));
+
+import { AdjustPlanModal } from "./adjust-plan-modal";
+
+const CREDIT_TIERS: CreditTier[] = [
+  {
+    tier: "credits_25",
+    label: "25 credits",
+    credits_usd: 25,
+    price_cents: 2500,
+    lookup_key: "credits_25_lk",
+  },
+  {
+    tier: "credits_50",
+    label: "50 credits",
+    credits_usd: 50,
+    price_cents: 5000,
+    lookup_key: "credits_50_lk",
+  },
+];
+
+function proPlansResponse(creditTiers?: CreditTier[]): PlanListResponse {
+  return {
+    plans: [
+      {
+        id: "base",
+        name: "Base",
+        base_price_cents: 0,
+        base_lookup_key: "base",
+        billing_interval: "month",
+        included_features: [],
+      },
+      {
+        id: "pro",
+        name: "Pro",
+        base_price_cents: 2000,
+        base_lookup_key: "pro_base",
+        billing_interval: "month",
+        machine_tiers: [
+          {
+            tier: "machine_small",
+            label: "Small",
+            price_cents: 1000,
+            cpu: "1",
+            memory: "2Gi",
+          },
+          {
+            tier: "machine_large",
+            label: "Large",
+            price_cents: 3000,
+            cpu: "4",
+            memory: "8Gi",
+          },
+        ],
+        storage_tiers: [
+          {
+            tier: "storage_10",
+            label: "10 GiB",
+            price_cents: 500,
+            storage_gib: 10,
+          },
+          {
+            tier: "storage_20",
+            label: "20 GiB",
+            price_cents: 900,
+            storage_gib: 20,
+          },
+        ],
+        included_features: [],
+        ...(creditTiers ? { credit_tiers: creditTiers } : {}),
+      },
+    ],
+  } as unknown as PlanListResponse;
+}
+
+function subscription(
+  planId: "base" | "pro",
+  selectedCreditTier: string | null,
+): SubscriptionResponse {
+  return {
+    plan_id: planId,
+    status: "active",
+    renewal_date: null,
+    current_period_end: null,
+    cancel_at_period_end: false,
+    cancel_at: null,
+    selected_credit_tier: selectedCreditTier,
+    entitlements: { managed_email: false, phone_number: false },
+  } as unknown as SubscriptionResponse;
+}
+
+function renderModal(
+  sub: SubscriptionResponse,
+  plans: PlanListResponse,
+  onTierUpgraded?: () => void,
+): ReturnType<typeof render> & { client: QueryClient } {
+  const client = new QueryClient({
+    // `staleTime: Infinity` stops the pre-seeded reads from being marked stale
+    // and refetched on mount. Without it, the seeded queries fire background
+    // fetches: locally those hit a listening dev server (a soft 502 React Query
+    // swallows while keeping the cached data), but CI is hermetic so the same
+    // fetch rejects with ECONNREFUSED and the change-tier button never renders.
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
+  client.setQueryData(organizationsBillingSubscriptionRetrieveQueryKey(), sub);
+  client.setQueryData(organizationsBillingPlansRetrieveQueryKey(), plans);
+  // Onboarding carries the current machine/storage tiers for the change flow.
+  client.setQueryData(
+    organizationsBillingSubscriptionOnboardingRetrieveQueryKey(),
+    {
+      max_machine_tier: "machine_small",
+      selected_storage_tier: "storage_10",
+      selected_storage_gib: 10,
+    },
+  );
+  const result = render(
+    <QueryClientProvider client={client}>
+      <AdjustPlanModal open onClose={() => {}} onTierUpgraded={onTierUpgraded} />
+    </QueryClientProvider>,
+  );
+  return { ...result, client };
+}
+
+function openCreditDropdown(): void {
+  const trigger = document.querySelector<HTMLButtonElement>(
+    'button[role="combobox"][aria-label="Credit bundle"]',
+  );
+  if (!trigger) throw new Error("expected a Credit bundle dropdown trigger");
+  fireEvent.click(trigger);
+}
+
+function openMachineDropdown(): void {
+  const trigger = document.querySelector<HTMLButtonElement>(
+    'button[role="combobox"][aria-label="Machine tier"]',
+  );
+  if (!trigger) throw new Error("expected a Machine tier dropdown trigger");
+  fireEvent.click(trigger);
+}
+
+function clickOptionStartingWith(prefix: string): void {
+  const option = Array.from(
+    document.querySelectorAll<HTMLElement>('[role="option"]'),
+  ).find((o) => o.textContent?.trim().startsWith(prefix));
+  if (!option) throw new Error(`expected option starting with "${prefix}"`);
+  fireEvent.click(option);
+}
+
+function clickOption(label: string): void {
+  const option = Array.from(
+    document.querySelectorAll<HTMLElement>('[role="option"]'),
+  ).find((o) => o.textContent?.trim() === label);
+  if (!option) throw new Error(`expected option "${label}"`);
+  fireEvent.click(option);
+}
+
+beforeEach(() => {
+  upgradeCall = null;
+  changeCreditTierCall = null;
+  changeMachineTierCall = null;
+  changeStorageTierCall = null;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("AdjustPlanModal credit bundle — upgrade", () => {
+  test("forwards the selected credit_tier in the upgrade body", async () => {
+    const { getByTestId } = renderModal(
+      subscription("base", null),
+      proPlansResponse(CREDIT_TIERS),
+    );
+
+    openCreditDropdown();
+    clickOption("50 credits — $50/mo");
+
+    fireEvent.click(getByTestId("modal-upgrade-to-pro-button"));
+
+    await waitFor(() => {
+      if (!upgradeCall) throw new Error("upgrade not called");
+    });
+    expect((upgradeCall!.body as Record<string, unknown>).credit_tier).toBe(
+      "credits_50",
+    );
+  });
+
+  test("forwards credit_tier: null when 'No bundle' is selected (default)", async () => {
+    const { getByTestId } = renderModal(
+      subscription("base", null),
+      proPlansResponse(CREDIT_TIERS),
+    );
+
+    fireEvent.click(getByTestId("modal-upgrade-to-pro-button"));
+
+    await waitFor(() => {
+      if (!upgradeCall) throw new Error("upgrade not called");
+    });
+    expect(
+      (upgradeCall!.body as Record<string, unknown>).credit_tier,
+    ).toBeNull();
+  });
+});
+
+describe("AdjustPlanModal credit bundle — change mode", () => {
+  test("calls change-credit-tier with the newly selected value", async () => {
+    const { getByTestId } = renderModal(
+      subscription("pro", null),
+      proPlansResponse(CREDIT_TIERS),
+    );
+
+    openCreditDropdown();
+    clickOption("25 credits — $25/mo");
+
+    fireEvent.click(getByTestId("modal-change-tier-button"));
+
+    await waitFor(() => {
+      if (!changeCreditTierCall) throw new Error("change not called");
+    });
+    expect(
+      (changeCreditTierCall!.body as Record<string, unknown>).credit_tier,
+    ).toBe("credits_25");
+  });
+
+  test("calls change-credit-tier with null when removing the bundle", async () => {
+    const { getByTestId } = renderModal(
+      subscription("pro", "credits_50"),
+      proPlansResponse(CREDIT_TIERS),
+    );
+
+    openCreditDropdown();
+    clickOption("No credit bundle — $0/mo");
+
+    fireEvent.click(getByTestId("modal-change-tier-button"));
+
+    await waitFor(() => {
+      if (!changeCreditTierCall) throw new Error("change not called");
+    });
+    expect(
+      (changeCreditTierCall!.body as Record<string, unknown>).credit_tier,
+    ).toBeNull();
+  });
+});
+
+describe("AdjustPlanModal credit bundle — unseeded sentinel", () => {
+  test("does not enable Update Plan from a spurious pre-seed creditChanged", async () => {
+    // A Pro user with an existing bundle and no other pending change. Once the
+    // seed effect lands, selectedCreditTier equals currentCreditTier, so no
+    // dimension changed and the CTA stays disabled. The unseeded `undefined`
+    // sentinel must never read as a credit diff vs. the existing bundle.
+    const { getByTestId } = renderModal(
+      subscription("pro", "credits_50"),
+      proPlansResponse(CREDIT_TIERS),
+    );
+
+    await waitFor(() => {
+      const trigger = document.querySelector(
+        'button[role="combobox"][aria-label="Credit bundle"]',
+      );
+      if (!trigger) throw new Error("picker not rendered yet");
+    });
+
+    const button = getByTestId("modal-change-tier-button") as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+  });
+
+  test("does not send credit_tier: null before the user changes anything", async () => {
+    // Even if the CTA were clicked, no credit mutation should fire because the
+    // seeded selection matches the current bundle. Guards against the pre-seed
+    // `null` removing a paid bundle without intent.
+    const { getByTestId } = renderModal(
+      subscription("pro", "credits_50"),
+      proPlansResponse(CREDIT_TIERS),
+    );
+
+    await waitFor(() => {
+      const trigger = document.querySelector(
+        'button[role="combobox"][aria-label="Credit bundle"]',
+      );
+      if (!trigger) throw new Error("picker not rendered yet");
+    });
+
+    fireEvent.click(getByTestId("modal-change-tier-button"));
+
+    // Give any (erroneous) mutation a tick to fire.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(changeCreditTierCall).toBeNull();
+  });
+
+  test("preserves an explicit 'No bundle' choice across a plans refetch", async () => {
+    // Pro user with credits_50 picks "No credit bundle" (selection becomes
+    // null). A subsequent plans refetch re-runs the seeding effect; the explicit
+    // null must NOT be coalesced back to the existing bundle.
+    const { getByTestId, client } = renderModal(
+      subscription("pro", "credits_50"),
+      proPlansResponse(CREDIT_TIERS),
+    );
+
+    await waitFor(() => {
+      const trigger = document.querySelector(
+        'button[role="combobox"][aria-label="Credit bundle"]',
+      );
+      if (!trigger) throw new Error("picker not rendered yet");
+    });
+
+    openCreditDropdown();
+    clickOption("No credit bundle — $0/mo");
+
+    // Simulate a mid-modal refetch: re-seed by replacing the plans object so the
+    // seeding effect re-runs with a fresh `proPlan` identity.
+    client.setQueryData(
+      organizationsBillingPlansRetrieveQueryKey(),
+      proPlansResponse(CREDIT_TIERS),
+    );
+
+    // The pending removal must survive the re-seed.
+    fireEvent.click(getByTestId("modal-change-tier-button"));
+
+    await waitFor(() => {
+      if (!changeCreditTierCall) throw new Error("change not called");
+    });
+    expect(
+      (changeCreditTierCall!.body as Record<string, unknown>).credit_tier,
+    ).toBeNull();
+  });
+});
+
+describe("AdjustPlanModal credit bundle — resize flow", () => {
+  test("a credit-only change refreshes without invoking onTierUpgraded", async () => {
+    let upgraded = false;
+    const { getByTestId } = renderModal(
+      subscription("pro", null),
+      proPlansResponse(CREDIT_TIERS),
+      () => {
+        upgraded = true;
+      },
+    );
+
+    openCreditDropdown();
+    clickOption("25 credits — $25/mo");
+
+    fireEvent.click(getByTestId("modal-change-tier-button"));
+
+    await waitFor(() => {
+      if (!changeCreditTierCall) throw new Error("change not called");
+    });
+    // The credit mutation fired (refresh path), but the resize flow must not.
+    expect(upgraded).toBe(false);
+    expect(changeMachineTierCall).toBeNull();
+    expect(changeStorageTierCall).toBeNull();
+  });
+
+  test("a machine tier change still invokes onTierUpgraded", async () => {
+    let upgraded = false;
+    const { getByTestId } = renderModal(
+      subscription("pro", null),
+      proPlansResponse(CREDIT_TIERS),
+      () => {
+        upgraded = true;
+      },
+    );
+
+    openMachineDropdown();
+    // Switching from the current "Small" tier to "Large" is an upgrade, which
+    // fires immediately (no downgrade reconfirm) and opens the resize flow.
+    clickOptionStartingWith("Large");
+
+    fireEvent.click(getByTestId("modal-change-tier-button"));
+
+    await waitFor(() => {
+      if (!changeMachineTierCall) throw new Error("machine change not called");
+    });
+    await waitFor(() => {
+      if (!upgraded) throw new Error("onTierUpgraded not called");
+    });
+    expect(changeCreditTierCall).toBeNull();
+  });
+});
+
+describe("AdjustPlanModal credit bundle — catalog gate", () => {
+  test("hides the credit UI when the plan has no credit_tiers (upgrade)", () => {
+    renderModal(subscription("base", null), proPlansResponse(undefined));
+    expect(
+      document.querySelector(
+        'button[role="combobox"][aria-label="Credit bundle"]',
+      ),
+    ).toBeNull();
+  });
+
+  test("hides the credit UI when the plan has no credit_tiers (change)", () => {
+    renderModal(subscription("pro", null), proPlansResponse(undefined));
+    expect(
+      document.querySelector(
+        'button[role="combobox"][aria-label="Credit bundle"]',
+      ),
+    ).toBeNull();
+  });
+});

--- a/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
@@ -115,21 +115,35 @@ export function resolveTierSelection<T extends string>(
  * `resolveTierSelection` but for credit bundles, which have no disabled state
  * and where both `null` ("No bundle") and a catalog tier are valid selections.
  *
- * `prev` carries the sentinel meaning: `undefined` is un-seeded (the effect has
- * not yet seeded a value), so we seed to `current`. A non-undefined `prev`
- * (including an explicit `null` for "No bundle") is the user's standing choice
- * and must be preserved — we keep it, only revalidating a concrete tier against
- * the catalog so a refetch that removes the selected bundle falls back to
- * "No bundle" rather than leaving a stale tier the CTA would submit.
+ * `prev` carries the sentinel meaning:
+ *   - `undefined` is un-seeded (the effect has not yet seeded a value), so we
+ *     seed to `current`. The seed is preserved verbatim — including a non-null
+ *     current tier that the live catalog does not (yet) advertise (e.g. a
+ *     deprecated tier the user still holds). Coercing such a tier to `null`
+ *     would make `creditChanged` read true purely from opening the modal and
+ *     silently submit `credit_tier: null`, removing a paid bundle the user
+ *     never touched. Preserving it keeps `creditChanged` false until the user
+ *     actively changes the selection.
+ *   - a non-undefined `prev` (including an explicit `null` for "No bundle") is
+ *     the user's standing choice and must be preserved — we keep it, only
+ *     revalidating a concrete tier against the catalog so a mid-modal refetch
+ *     that removes the selected bundle falls back to "No bundle" rather than
+ *     leaving a stale tier the CTA would submit.
  */
 export function resolveCreditTierSelection(
   tiers: CreditTier[],
   prev: CreditTierEnum | null | undefined,
   current: CreditTierEnum | null,
 ): CreditTierEnum | null {
-  const seeded = prev === undefined ? current : prev;
-  if (seeded !== null && tiers.some((t) => t.tier === seeded)) {
-    return seeded;
+  // Seeding (un-seeded `prev`): preserve the current bundle as-is so a tier
+  // absent from the catalog is not coerced into a spurious "remove bundle".
+  if (prev === undefined) {
+    return current;
+  }
+  // Standing user choice: revalidate a concrete tier against the catalog so a
+  // refetch that drops it falls back to "No bundle".
+  if (prev !== null && tiers.some((t) => t.tier === prev)) {
+    return prev;
   }
   return null;
 }

--- a/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
@@ -286,6 +286,11 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
   const displayCreditTier: CreditTierEnum | null =
     selectedCreditTier === undefined ? currentCreditTier : selectedCreditTier;
 
+  // Folds into TierPicker's headline Total. `priceForCredit` returns 0 for "No
+  // bundle" and for catalogs without credit_tiers (empty `creditTiers`), so the
+  // total stays byte-identical to before when the feature is off.
+  const selectedCreditPriceCents = priceForCredit(displayCreditTier);
+
   // For an active Pro subscriber, disable any storage tier strictly below the
   // current selection — downgrading storage is not allowed. TierPicker honors
   // the `disabled` flag via `isTierDisabled`; machine tiers stay fully enabled
@@ -821,6 +826,7 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                                 selectedStorageTier={selectedStorageTier}
                                 onMachineTierChange={setSelectedMachineTier}
                                 onStorageTierChange={setSelectedStorageTier}
+                                creditPriceCents={selectedCreditPriceCents}
                               />
                               {creditTiersEnabled && (
                                 <CreditBundlePicker
@@ -869,6 +875,10 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                                   onStorageTierChange={setSelectedStorageTier}
                                   currentMachinePriceCents={currentMachinePrice}
                                   currentStoragePriceCents={currentStoragePrice}
+                                  creditPriceCents={selectedCreditPriceCents}
+                                  currentCreditPriceCents={
+                                    currentCreditPriceCents
+                                  }
                                 />
                                 {creditTiersEnabled && (
                                   <CreditBundlePicker

--- a/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
@@ -126,9 +126,11 @@ export function resolveTierSelection<T extends string>(
  *     actively changes the selection.
  *   - a non-undefined `prev` (including an explicit `null` for "No bundle") is
  *     the user's standing choice and must be preserved — we keep it, only
- *     revalidating a concrete tier against the catalog so a mid-modal refetch
- *     that removes the selected bundle falls back to "No bundle" rather than
- *     leaving a stale tier the CTA would submit.
+ *     coercing a concrete tier to "No bundle" when it is BOTH absent from the
+ *     catalog AND not the held current bundle. A held-but-delisted tier (equal
+ *     to `current`) survives a mid-modal refetch; only a genuinely stale choice
+ *     (a delisted tier the user actively picked) falls back to "No bundle" so
+ *     the CTA never submits a tier the catalog no longer offers.
  */
 export function resolveCreditTierSelection(
   tiers: CreditTier[],
@@ -141,8 +143,10 @@ export function resolveCreditTierSelection(
     return current;
   }
   // Standing user choice: revalidate a concrete tier against the catalog so a
-  // refetch that drops it falls back to "No bundle".
-  if (prev !== null && tiers.some((t) => t.tier === prev)) {
+  // refetch that drops it falls back to "No bundle" — but keep a tier the user
+  // still holds (equal to `current`) even when the catalog omits it, so a
+  // refetch doesn't coerce a held-but-delisted bundle to a spurious removal.
+  if (prev !== null && (prev === current || tiers.some((t) => t.tier === prev))) {
     return prev;
   }
   return null;

--- a/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
@@ -10,10 +10,13 @@ import { Notice } from "@vellum/design-library/components/notice";
 import { Tag } from "@vellum/design-library/components/tag";
 import { toast } from "@vellum/design-library/components/toast";
 import { Typography } from "@vellum/design-library/components/typography";
+import { CreditBundlePicker } from "./credit-bundle-picker";
 import { DowngradeReconfirmModal } from "./downgrade-reconfirm-modal";
 import { PlanFeatureList } from "./plan-feature-list";
 import { TierPicker, isTierDisabled } from "./tier-picker";
 import type {
+  CreditTier,
+  CreditTierEnum,
   MachineTier,
   MachineTierEnum,
   ProPlan,
@@ -24,6 +27,7 @@ import type {
 import {
   organizationsBillingPlansRetrieveOptions,
   organizationsBillingPlansRetrieveQueryKey,
+  organizationsBillingSubscriptionChangeCreditTierCreateMutation,
   organizationsBillingSubscriptionChangeMachineTierCreateMutation,
   organizationsBillingSubscriptionChangeStorageTierCreateMutation,
   organizationsBillingSubscriptionOnboardingRetrieveOptions,
@@ -63,6 +67,7 @@ const DRF_FIELD_KEYS = [
   "confirm",
   "machine_tier",
   "storage_tier",
+  "credit_tier",
   "non_field_errors",
 ] as const;
 
@@ -105,6 +110,31 @@ export function resolveTierSelection<T extends string>(
 }
 
 /**
+ * Resolve which credit tier should be selected given the previous selection,
+ * the resolved current bundle, and the live catalog. Mirrors
+ * `resolveTierSelection` but for credit bundles, which have no disabled state
+ * and where both `null` ("No bundle") and a catalog tier are valid selections.
+ *
+ * `prev` carries the sentinel meaning: `undefined` is un-seeded (the effect has
+ * not yet seeded a value), so we seed to `current`. A non-undefined `prev`
+ * (including an explicit `null` for "No bundle") is the user's standing choice
+ * and must be preserved — we keep it, only revalidating a concrete tier against
+ * the catalog so a refetch that removes the selected bundle falls back to
+ * "No bundle" rather than leaving a stale tier the CTA would submit.
+ */
+export function resolveCreditTierSelection(
+  tiers: CreditTier[],
+  prev: CreditTierEnum | null | undefined,
+  current: CreditTierEnum | null,
+): CreditTierEnum | null {
+  const seeded = prev === undefined ? current : prev;
+  if (seeded !== null && tiers.some((t) => t.tier === seeded)) {
+    return seeded;
+  }
+  return null;
+}
+
+/**
  * Cheapest tier price in cents, or 0 when the list is empty. Guards the
  * "From $" summary against `Math.min(...[])` → `Infinity` (which would render
  * "From $Infinity"). Production plans always carry populated tier arrays, so
@@ -135,6 +165,9 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
   const changeStorageTierMutation = useMutation(
     organizationsBillingSubscriptionChangeStorageTierCreateMutation(),
   );
+  const changeCreditTierMutation = useMutation(
+    organizationsBillingSubscriptionChangeCreditTierCreateMutation(),
+  );
   const portalSnapshot = buildPortalReturnSnapshot(subscriptionQuery.data);
   const portalMutation = useBillingPortalSession(portalSnapshot);
   const [view, setView] = useState<"plans" | "downgrade-confirm">("plans");
@@ -143,6 +176,13 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
     useState<MachineTierEnum | null>(null);
   const [selectedStorageTier, setSelectedStorageTier] =
     useState<StorageTierEnum | null>(null);
+  // `undefined` is the un-seeded sentinel (before the seeding effect runs);
+  // `null` is the user's explicit "No bundle" choice. Machine/storage don't need
+  // this distinction because `null` is never a valid selection for them, but for
+  // credits both values are meaningful — see `creditChanged` and the seeding
+  // effect for why conflating them caused spurious bundle removals.
+  const [selectedCreditTier, setSelectedCreditTier] =
+    useState<CreditTierEnum | null | undefined>(undefined);
 
   // On native (Capacitor iOS), Stripe Checkout / the billing portal opens in
   // SFSafariViewController as a popover on top of the app. When the user
@@ -209,6 +249,29 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
     (p): p is ProPlan => p.id === "pro",
   );
 
+  // Credit bundles are server-flag-gated via the catalog: render the picker and
+  // run the credit logic only when the Pro plan ships a non-empty `credit_tiers`
+  // list. When absent, the modal behaves exactly as before.
+  const creditTiers = proPlan?.credit_tiers ?? [];
+  const creditTiersEnabled = creditTiers.length > 0;
+
+  // Unlike machine/storage (read from the onboarding endpoint), the current
+  // credit bundle lives on the subscription response. Coerce to the enum so the
+  // picker seed and price lookup share one source of truth.
+  const currentCreditTier =
+    (subscriptionQuery.data?.selected_credit_tier as CreditTierEnum | null) ??
+    null;
+  const priceForCredit = (tier: CreditTierEnum | null): number =>
+    creditTiers.find((t) => t.tier === tier)?.price_cents ?? 0;
+  const currentCreditPriceCents = priceForCredit(currentCreditTier);
+
+  // The picker and the mutation bodies require `CreditTierEnum | null` — never
+  // the un-seeded `undefined` sentinel. While un-seeded, fall back to the
+  // current bundle (which is `null` for a Base user upgrading), matching what
+  // the seeding effect will resolve to so display and the pre-seed value agree.
+  const displayCreditTier: CreditTierEnum | null =
+    selectedCreditTier === undefined ? currentCreditTier : selectedCreditTier;
+
   // For an active Pro subscriber, disable any storage tier strictly below the
   // current selection — downgrading storage is not allowed. TierPicker honors
   // the `disabled` flag via `isTierDisabled`; machine tiers stay fully enabled
@@ -234,6 +297,9 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
     if (!open) {
       setSelectedMachineTier(null);
       setSelectedStorageTier(null);
+      // Reset to the un-seeded sentinel (not null, which is a valid "No bundle"
+      // choice) so the next open re-seeds from the current bundle.
+      setSelectedCreditTier(undefined);
       return;
     }
     if (!proPlan) return;
@@ -253,6 +319,15 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
           prev ?? currentStorageTier,
         ),
       );
+      // Seed the credit bundle from the subscription's current selection only
+      // while un-seeded (`prev === undefined`); once the user has chosen,
+      // `resolveCreditTierSelection` preserves their choice — including an
+      // explicit `null` ("No bundle") — and only revalidates a concrete tier
+      // against the live catalog. This stops a mid-modal refetch from snapping a
+      // pending removal back to the existing bundle.
+      setSelectedCreditTier((prev) =>
+        resolveCreditTierSelection(creditTiers, prev, currentCreditTier),
+      );
       return;
     }
     setSelectedMachineTier((prev) =>
@@ -261,15 +336,22 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
     setSelectedStorageTier((prev) =>
       resolveTierSelection<StorageTierEnum>(proPlan.storage_tiers, prev),
     );
-    // machineTiersForPicker/storageTiersForPicker are derived from proPlan +
-    // onboarding values already in the dep list; omitting them keeps the effect
-    // from re-running on each render's fresh array identity.
+    // Base upgrade has no current bundle, so it seeds to null ("No bundle",
+    // $0); `resolveCreditTierSelection` then preserves any prior choice and
+    // revalidates a concrete tier against the live catalog.
+    setSelectedCreditTier((prev) =>
+      resolveCreditTierSelection(creditTiers, prev, null),
+    );
+    // machineTiersForPicker/storageTiersForPicker/creditTiers are derived from
+    // proPlan + onboarding values already in the dep list; omitting them keeps
+    // the effect from re-running on each render's fresh array identity.
   }, [
     open,
     proPlan,
     proTierChangeMode,
     currentMachineTier,
     currentStorageTier,
+    currentCreditTier,
   ]);
 
   const basePlan = plansQuery.data?.plans.find((p) => p.id === "base");
@@ -293,6 +375,9 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
           confirm: true,
           machine_tier: selectedMachineTier,
           storage_tier: selectedStorageTier,
+          // null = "No bundle". The backend ignores this when the credit-bundles
+          // flag is off, so always sending it is safe.
+          credit_tier: displayCreditTier,
         },
       },
       {
@@ -345,14 +430,27 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
   };
 
   const tierChangePending =
-    changeMachineTierMutation.isPending || changeStorageTierMutation.isPending;
+    changeMachineTierMutation.isPending ||
+    changeStorageTierMutation.isPending ||
+    changeCreditTierMutation.isPending;
 
   // What changed vs. the current selection. Storage downgrades are impossible
-  // (those tiers are disabled), so a storage diff is always an upgrade.
+  // (those tiers are disabled), so a storage diff is always an upgrade. The
+  // credit bundle is its own dimension; `null` ("No bundle") is a valid value,
+  // so we compare directly rather than gating on non-null.
   const machineChanged =
     selectedMachineTier != null && selectedMachineTier !== currentMachineTier;
   const storageChanged =
     selectedStorageTier != null && selectedStorageTier !== currentStorageTier;
+  // Gate on `!== undefined` (un-seeded) the way machine/storage gate on
+  // `!= null` — until the effect seeds, there is no user-intended change, so a
+  // pre-seed `undefined` vs. existing `currentCreditTier` must not enable the
+  // CTA or submit `credit_tier: null`. Once seeded, `null` ("No bundle") is a
+  // valid value, so we compare directly rather than gating on non-null.
+  const creditChanged =
+    creditTiersEnabled &&
+    selectedCreditTier !== undefined &&
+    selectedCreditTier !== currentCreditTier;
 
   const priceForMachine = (tier: MachineTierEnum | null): number | null =>
     machineTiersForPicker.find((t) => t.tier === tier)?.price_cents ?? null;
@@ -423,10 +521,43 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
     );
   };
 
+  const submitCreditTierChange = () => {
+    if (tierChangePending) return;
+    changeCreditTierMutation.mutate(
+      // null removes the bundle ("No bundle"). Bundle changes apply at the next
+      // cycle — no proration/immediate-charge subtleties — so no reconfirm.
+      // `creditChanged` already gates out the un-seeded state, so this only runs
+      // with a seeded value, but coalesce defensively to never send `undefined`.
+      { body: { credit_tier: displayCreditTier } },
+      {
+        onSuccess: () => {
+          // Refresh billing so the plan card and this modal reflect the new
+          // bundle. A credit change never alters machine/storage resources, so
+          // it must not invoke `onTierUpgraded` (the assistant resize flow) —
+          // that would show an unrelated resize prompt and fire needless
+          // resource queries. `submitTierChanges` still opens the resize flow
+          // when a machine or storage dimension also changed.
+          invalidateBillingQueries();
+          toast.success("Credit bundle updated.", { id: "pro-tier-change" });
+        },
+        onError: (error) => {
+          toast.error(
+            extractMutationError(
+              error,
+              "Failed to change credit bundle. Please try again.",
+            ),
+            { id: "pro-tier-change-error" },
+          );
+        },
+      },
+    );
+  };
+
   // Fire only the dimension(s) that actually changed.
   const submitTierChanges = () => {
     if (machineChanged) submitMachineTierChange();
     if (storageChanged) submitStorageTierChange();
+    if (creditChanged) submitCreditTierChange();
   };
 
   // When the machine tier is being lowered, defer the whole apply behind the
@@ -616,7 +747,8 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                                   {Math.round(
                                     (plan.base_price_cents +
                                       currentMachinePrice +
-                                      currentStoragePrice) /
+                                      currentStoragePrice +
+                                      currentCreditPriceCents) /
                                       100,
                                   )}
                                 </Typography>
@@ -676,6 +808,14 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                                 onMachineTierChange={setSelectedMachineTier}
                                 onStorageTierChange={setSelectedStorageTier}
                               />
+                              {creditTiersEnabled && (
+                                <CreditBundlePicker
+                                  creditTiers={creditTiers}
+                                  selectedCreditTier={displayCreditTier}
+                                  onCreditTierChange={setSelectedCreditTier}
+                                  disabled={upgradeMutation.isPending}
+                                />
+                              )}
                               <Button
                                 variant="primary"
                                 className="w-full"
@@ -716,10 +856,25 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                                   currentMachinePriceCents={currentMachinePrice}
                                   currentStoragePriceCents={currentStoragePrice}
                                 />
-                                {(changeMachineTierMutation.isError || changeStorageTierMutation.isError) && (
+                                {creditTiersEnabled && (
+                                  <CreditBundlePicker
+                                    creditTiers={creditTiers}
+                                    selectedCreditTier={displayCreditTier}
+                                    onCreditTierChange={setSelectedCreditTier}
+                                    currentCreditPriceCents={
+                                      currentCreditPriceCents
+                                    }
+                                    disabled={tierChangePending}
+                                  />
+                                )}
+                                {(changeMachineTierMutation.isError ||
+                                  changeStorageTierMutation.isError ||
+                                  changeCreditTierMutation.isError) && (
                                   <Notice tone="error">
                                     {extractMutationError(
-                                      changeMachineTierMutation.error ?? changeStorageTierMutation.error,
+                                      changeMachineTierMutation.error ??
+                                        changeStorageTierMutation.error ??
+                                        changeCreditTierMutation.error,
                                       "Failed to update plan. Please try again.",
                                     )}
                                   </Notice>
@@ -730,7 +885,9 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                                   onClick={handleApplyTierChange}
                                   disabled={
                                     tierChangePending ||
-                                    (!machineChanged && !storageChanged)
+                                    (!machineChanged &&
+                                      !storageChanged &&
+                                      !creditChanged)
                                   }
                                   data-testid="modal-change-tier-button"
                                 >

--- a/apps/web/src/domains/settings/components/credit-bundle-picker.test.tsx
+++ b/apps/web/src/domains/settings/components/credit-bundle-picker.test.tsx
@@ -1,0 +1,196 @@
+/**
+ * Tests for the presentational `CreditBundlePicker`.
+ *
+ * Renders via `@testing-library/react` (happy-dom registered in test-setup.ts)
+ * and drives the design-library Dropdown — a custom combobox, not a native
+ * <select> — by clicking the trigger to open the listbox, then clicking the
+ * option whose visible label matches. No jest-dom matchers; we assert with
+ * plain bun `expect` against query results.
+ */
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import type { CreditTier, CreditTierEnum } from "@/generated/api/types.gen";
+
+import {
+  CreditBundlePicker,
+  formatBundleOptionLabel,
+} from "./credit-bundle-picker";
+
+afterEach(() => {
+  cleanup();
+});
+
+const TIERS: CreditTier[] = [
+  {
+    tier: "credits_10",
+    label: "10 credits",
+    credits_usd: 10,
+    price_cents: 1000,
+    lookup_key: "credits_10",
+  },
+  {
+    tier: "credits_25",
+    label: "25 credits",
+    credits_usd: 25,
+    price_cents: 2500,
+    lookup_key: "credits_25",
+  },
+  {
+    tier: "credits_50",
+    label: "50 credits",
+    credits_usd: 50,
+    price_cents: 5000,
+    lookup_key: "credits_50",
+  },
+  {
+    tier: "credits_100",
+    label: "100 credits",
+    credits_usd: 100,
+    price_cents: 10000,
+    lookup_key: "credits_100",
+  },
+  {
+    tier: "credits_200",
+    label: "200 credits",
+    credits_usd: 200,
+    price_cents: 20000,
+    lookup_key: "credits_200",
+  },
+];
+
+function openDropdown(): void {
+  const trigger = document.querySelector<HTMLButtonElement>(
+    'button[role="combobox"][aria-label="Credit bundle"]',
+  );
+  if (!trigger) {
+    throw new Error("expected a Credit bundle dropdown trigger");
+  }
+  fireEvent.click(trigger);
+}
+
+function optionLabels(): string[] {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>('[role="option"]'),
+  ).map((o) => o.textContent?.trim() ?? "");
+}
+
+function clickOption(label: string): void {
+  const option = Array.from(
+    document.querySelectorAll<HTMLElement>('[role="option"]'),
+  ).find((o) => o.textContent?.trim() === label);
+  if (!option) {
+    throw new Error(
+      `expected option "${label}" — saw: ${optionLabels()
+        .map((l) => `"${l}"`)
+        .join(", ")}`,
+    );
+  }
+  fireEvent.click(option);
+}
+
+describe("formatBundleOptionLabel", () => {
+  test("formats whole-dollar tiers", () => {
+    expect(formatBundleOptionLabel(TIERS[2]!)).toBe("50 credits — $50/mo");
+  });
+
+  test("formats sub-dollar cents with two decimals", () => {
+    expect(
+      formatBundleOptionLabel({ ...TIERS[0]!, price_cents: 1050 }),
+    ).toBe("10 credits — $10.50/mo");
+  });
+});
+
+describe("CreditBundlePicker", () => {
+  test("renders the no-bundle option first, then all five tiers with prices", () => {
+    render(
+      <CreditBundlePicker
+        creditTiers={TIERS}
+        selectedCreditTier={null}
+        onCreditTierChange={() => {}}
+      />,
+    );
+    openDropdown();
+
+    expect(optionLabels()).toEqual([
+      "No credit bundle — $0/mo",
+      "10 credits — $10/mo",
+      "25 credits — $25/mo",
+      "50 credits — $50/mo",
+      "100 credits — $100/mo",
+      "200 credits — $200/mo",
+    ]);
+  });
+
+  test("selecting a tier emits its CreditTierEnum value", () => {
+    const onCreditTierChange = mock((_t: CreditTierEnum | null) => {});
+    render(
+      <CreditBundlePicker
+        creditTiers={TIERS}
+        selectedCreditTier={null}
+        onCreditTierChange={onCreditTierChange}
+      />,
+    );
+    openDropdown();
+    clickOption("50 credits — $50/mo");
+
+    expect(onCreditTierChange).toHaveBeenCalledTimes(1);
+    expect(onCreditTierChange.mock.calls[0]?.[0]).toBe("credits_50");
+  });
+
+  test("selecting the no-bundle option emits null", () => {
+    const onCreditTierChange = mock((_t: CreditTierEnum | null) => {});
+    render(
+      <CreditBundlePicker
+        creditTiers={TIERS}
+        selectedCreditTier="credits_50"
+        onCreditTierChange={onCreditTierChange}
+      />,
+    );
+    openDropdown();
+    clickOption("No credit bundle — $0/mo");
+
+    expect(onCreditTierChange).toHaveBeenCalledTimes(1);
+    expect(onCreditTierChange.mock.calls[0]?.[0]).toBeNull();
+  });
+
+  test("shows a positive delta in change mode when upgrading", () => {
+    const { getByTestId } = render(
+      <CreditBundlePicker
+        creditTiers={TIERS}
+        selectedCreditTier="credits_50"
+        onCreditTierChange={() => {}}
+        currentCreditPriceCents={2500}
+      />,
+    );
+    expect(getByTestId("credit-bundle-picker-delta").textContent).toBe(
+      "+$25/mo",
+    );
+  });
+
+  test("shows a negative delta in change mode when dropping to no bundle", () => {
+    const { getByTestId } = render(
+      <CreditBundlePicker
+        creditTiers={TIERS}
+        selectedCreditTier={null}
+        onCreditTierChange={() => {}}
+        currentCreditPriceCents={5000}
+      />,
+    );
+    expect(getByTestId("credit-bundle-picker-delta").textContent).toBe(
+      "−$50/mo",
+    );
+  });
+
+  test("renders no delta when the selection matches the current price", () => {
+    const { queryByTestId } = render(
+      <CreditBundlePicker
+        creditTiers={TIERS}
+        selectedCreditTier="credits_50"
+        onCreditTierChange={() => {}}
+        currentCreditPriceCents={5000}
+      />,
+    );
+    expect(queryByTestId("credit-bundle-picker-delta")).toBeNull();
+  });
+});

--- a/apps/web/src/domains/settings/components/credit-bundle-picker.tsx
+++ b/apps/web/src/domains/settings/components/credit-bundle-picker.tsx
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 import { Dropdown } from "@vellum/design-library/components/dropdown";
 import { Typography } from "@vellum/design-library/components/typography";
 import type { CreditTier, CreditTierEnum } from "@/generated/api/types.gen";
+import { formatDelta, formatMonthly } from "./tier-pricing";
 
 /**
  * Sentinel option value for the synthesized "No credit bundle" entry. The
@@ -14,23 +15,6 @@ import type { CreditTier, CreditTierEnum } from "@/generated/api/types.gen";
 const NO_BUNDLE_VALUE = "__none__";
 
 type CreditOptionValue = CreditTierEnum | typeof NO_BUNDLE_VALUE;
-
-/** "$50/mo" for whole-dollar tiers; "$50.50/mo" only when cents are present. */
-function formatMonthly(totalCents: number): string {
-  const dollars = totalCents / 100;
-  return Number.isInteger(dollars)
-    ? `$${dollars}/mo`
-    : `$${dollars.toFixed(2)}/mo`;
-}
-
-function formatDelta(deltaCents: number): string {
-  const prefix = deltaCents > 0 ? "+" : "−";
-  const absDollars = Math.abs(deltaCents) / 100;
-  const formatted = Number.isInteger(absDollars)
-    ? `$${absDollars}`
-    : `$${absDollars.toFixed(2)}`;
-  return `${prefix}${formatted}/mo`;
-}
 
 /** "50 credits — $50/mo" for a catalog tier. */
 export function formatBundleOptionLabel(tier: CreditTier): string {

--- a/apps/web/src/domains/settings/components/credit-bundle-picker.tsx
+++ b/apps/web/src/domains/settings/components/credit-bundle-picker.tsx
@@ -1,0 +1,114 @@
+import { Info } from "lucide-react";
+import { useMemo } from "react";
+
+import { Dropdown } from "@vellum/design-library/components/dropdown";
+import { Typography } from "@vellum/design-library/components/typography";
+import type { CreditTier, CreditTierEnum } from "@/generated/api/types.gen";
+
+/**
+ * Sentinel option value for the synthesized "No credit bundle" entry. The
+ * design-library Dropdown is generic over `T extends string`, so it cannot
+ * carry a real `null` value — we map this sentinel to/from `null` at the
+ * component boundary so callers see a clean `CreditTierEnum | null`.
+ */
+const NO_BUNDLE_VALUE = "__none__";
+
+type CreditOptionValue = CreditTierEnum | typeof NO_BUNDLE_VALUE;
+
+/** "$50/mo" for whole-dollar tiers; "$50.50/mo" only when cents are present. */
+function formatMonthly(totalCents: number): string {
+  const dollars = totalCents / 100;
+  return Number.isInteger(dollars)
+    ? `$${dollars}/mo`
+    : `$${dollars.toFixed(2)}/mo`;
+}
+
+function formatDelta(deltaCents: number): string {
+  const prefix = deltaCents > 0 ? "+" : "−";
+  const absDollars = Math.abs(deltaCents) / 100;
+  const formatted = Number.isInteger(absDollars)
+    ? `$${absDollars}`
+    : `$${absDollars.toFixed(2)}`;
+  return `${prefix}${formatted}/mo`;
+}
+
+/** "50 credits — $50/mo" for a catalog tier. */
+export function formatBundleOptionLabel(tier: CreditTier): string {
+  return `${tier.label} — ${formatMonthly(tier.price_cents)}`;
+}
+
+export interface CreditBundlePickerProps {
+  creditTiers: CreditTier[];
+  selectedCreditTier: CreditTierEnum | null;
+  onCreditTierChange: (tier: CreditTierEnum | null) => void;
+  currentCreditPriceCents?: number | null;
+  disabled?: boolean;
+}
+
+export function CreditBundlePicker({
+  creditTiers,
+  selectedCreditTier,
+  onCreditTierChange,
+  currentCreditPriceCents,
+  disabled = false,
+}: CreditBundlePickerProps) {
+  const selectedTier = creditTiers.find((t) => t.tier === selectedCreditTier);
+  const selectedPriceCents = selectedTier?.price_cents ?? 0;
+  const delta =
+    currentCreditPriceCents != null
+      ? selectedPriceCents - currentCreditPriceCents
+      : null;
+
+  const options = useMemo(() => {
+    const noBundle = {
+      value: NO_BUNDLE_VALUE as CreditOptionValue,
+      label: `No credit bundle — ${formatMonthly(0)}`,
+    };
+    const tierOptions = creditTiers.map((t) => ({
+      value: t.tier as CreditOptionValue,
+      label: formatBundleOptionLabel(t),
+    }));
+    return [noBundle, ...tierOptions];
+  }, [creditTiers]);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-1.5">
+        <div className="flex items-center gap-1">
+          <Typography
+            as="p"
+            variant="label-small-default"
+            className="text-[var(--content-secondary)]"
+          >
+            Credit bundle
+          </Typography>
+          <span title="A monthly allotment of credits added to your Pro Plan subscription">
+            <Info className="h-3 w-3 text-[var(--content-tertiary)]" />
+          </span>
+        </div>
+        <Dropdown<CreditOptionValue>
+          aria-label="Credit bundle"
+          placeholder="Select a credit bundle"
+          disabled={disabled}
+          value={selectedCreditTier ?? NO_BUNDLE_VALUE}
+          onChange={(value) =>
+            onCreditTierChange(
+              value === NO_BUNDLE_VALUE ? null : (value as CreditTierEnum),
+            )
+          }
+          options={options}
+        />
+      </div>
+      {delta != null && delta !== 0 && (
+        <Typography
+          as="p"
+          variant="body-small-emphasised"
+          data-testid="credit-bundle-picker-delta"
+          className="text-[var(--content-tertiary)]"
+        >
+          {formatDelta(delta)}
+        </Typography>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/domains/settings/components/plan-card.test.tsx
+++ b/apps/web/src/domains/settings/components/plan-card.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * Tests for the PlanCard credit-bundle row: a Pro org with a selected credit
+ * tier shows the catalog label + monthly price; null shows no row; the row is
+ * catalog-gated (suppressed when the Pro plan has no `credit_tiers`).
+ *
+ * Strategy: pre-populate the React Query cache so the card's `useQuery` calls
+ * resolve synchronously — `renderToStaticMarkup` is single-pass, so a pending
+ * query would otherwise report `isLoading` and render the spinner.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import {
+  organizationsBillingPlansRetrieveQueryKey,
+  organizationsBillingSubscriptionRetrieveQueryKey,
+} from "@/generated/api/@tanstack/react-query.gen";
+import type {
+  CreditTier,
+  PlanListResponse,
+  SubscriptionResponse,
+} from "@/generated/api/types.gen";
+
+import { PlanCard } from "./plan-card";
+
+const CREDIT_TIERS: CreditTier[] = [
+  {
+    tier: "credits_25",
+    label: "25 credits",
+    credits_usd: 25,
+    price_cents: 2500,
+    lookup_key: "credits_25_lk",
+  },
+  {
+    tier: "credits_50",
+    label: "50 credits",
+    credits_usd: 50,
+    price_cents: 5000,
+    lookup_key: "credits_50_lk",
+  },
+];
+
+function proPlansResponse(creditTiers?: CreditTier[]): PlanListResponse {
+  return {
+    plans: [
+      {
+        id: "pro",
+        name: "Pro",
+        base_price_cents: 2000,
+        base_lookup_key: "pro_base",
+        billing_interval: "month",
+        machine_tiers: [],
+        storage_tiers: [],
+        included_features: [],
+        ...(creditTiers ? { credit_tiers: creditTiers } : {}),
+      },
+    ],
+  };
+}
+
+function proSubscription(
+  selectedCreditTier: string | null,
+): SubscriptionResponse {
+  return {
+    plan_id: "pro",
+    status: "active",
+    renewal_date: null,
+    current_period_end: null,
+    cancel_at_period_end: false,
+    cancel_at: null,
+    selected_credit_tier: selectedCreditTier,
+    entitlements: { managed_email: false, phone_number: false },
+  };
+}
+
+function renderCard(
+  subscription: SubscriptionResponse,
+  plans: PlanListResponse,
+): string {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  client.setQueryData(
+    organizationsBillingSubscriptionRetrieveQueryKey(),
+    subscription,
+  );
+  client.setQueryData(organizationsBillingPlansRetrieveQueryKey(), plans);
+  return renderToStaticMarkup(
+    <QueryClientProvider client={client}>
+      <PlanCard onManage={() => {}} />
+    </QueryClientProvider>,
+  );
+}
+
+describe("PlanCard credit bundle", () => {
+  test("shows the bundle row with the catalog label and monthly price", () => {
+    const html = renderCard(
+      proSubscription("credits_50"),
+      proPlansResponse(CREDIT_TIERS),
+    );
+    expect(html).toContain("plan-card-credit-bundle");
+    expect(html).toContain("Monthly credits: 50 credits ($50/mo)");
+  });
+
+  test("renders no bundle row when the selected tier is null", () => {
+    const html = renderCard(
+      proSubscription(null),
+      proPlansResponse(CREDIT_TIERS),
+    );
+    expect(html).not.toContain("plan-card-credit-bundle");
+  });
+
+  test("is catalog-gated: no bundle row when the plan has no credit_tiers", () => {
+    const html = renderCard(
+      proSubscription("credits_50"),
+      proPlansResponse(undefined),
+    );
+    expect(html).not.toContain("plan-card-credit-bundle");
+  });
+
+  test("falls back to the raw tier key when no catalog match exists", () => {
+    const html = renderCard(
+      proSubscription("credits_200"),
+      proPlansResponse(CREDIT_TIERS),
+    );
+    expect(html).toContain("plan-card-credit-bundle");
+    expect(html).toContain("Monthly credits: credits_200");
+  });
+});

--- a/apps/web/src/domains/settings/components/plan-card.tsx
+++ b/apps/web/src/domains/settings/components/plan-card.tsx
@@ -12,6 +12,7 @@ import { Typography } from "@vellum/design-library/components/typography";
 import type { ProPlan } from "@/generated/api/types.gen";
 import { InvoicesModal } from "./invoices-modal";
 import { PlanFeatureList } from "./plan-feature-list";
+import { formatMonthly } from "./tier-pricing";
 import {
   organizationsBillingPlansRetrieveOptions,
   organizationsBillingSubscriptionRetrieveOptions,
@@ -131,7 +132,7 @@ export function PlanCard({ onManage }: PlanCardProps) {
     selectedCreditTier != null ? proPlan?.credit_tiers : undefined;
   const creditTier = creditTiers?.find((t) => t.tier === selectedCreditTier);
   const creditBundleLabel = creditTier
-    ? `${creditTier.label} ($${Math.round(creditTier.price_cents / 100)}/mo)`
+    ? `${creditTier.label} (${formatMonthly(creditTier.price_cents)})`
     : creditTiers?.length
       ? selectedCreditTier
       : null;

--- a/apps/web/src/domains/settings/components/plan-card.tsx
+++ b/apps/web/src/domains/settings/components/plan-card.tsx
@@ -9,6 +9,7 @@ import { Button } from "@vellum/design-library/components/button";
 import { Card } from "@vellum/design-library/components/card";
 import { Notice } from "@vellum/design-library/components/notice";
 import { Typography } from "@vellum/design-library/components/typography";
+import type { ProPlan } from "@/generated/api/types.gen";
 import { InvoicesModal } from "./invoices-modal";
 import { PlanFeatureList } from "./plan-feature-list";
 import {
@@ -120,6 +121,21 @@ export function PlanCard({ onManage }: PlanCardProps) {
   const showRenewal = display.showsRenewal && !isCancelling && !isCanceled && subscription.current_period_end;
   const showCancellation = display.showsRenewal && isCancelling && !isCanceled && cancelDate;
 
+  // Catalog-gated current credit bundle, shown only for a Pro org with a
+  // non-null selected tier when the catalog advertises `credit_tiers`. Resolve
+  // the label/price from the catalog, falling back to the raw tier key. A null
+  // selection (no bundle / $0) renders nothing.
+  const proPlan = currentPlan.id === "pro" ? (currentPlan as ProPlan) : undefined;
+  const selectedCreditTier = subscription.selected_credit_tier ?? null;
+  const creditTiers =
+    selectedCreditTier != null ? proPlan?.credit_tiers : undefined;
+  const creditTier = creditTiers?.find((t) => t.tier === selectedCreditTier);
+  const creditBundleLabel = creditTier
+    ? `${creditTier.label} ($${Math.round(creditTier.price_cents / 100)}/mo)`
+    : creditTiers?.length
+      ? selectedCreditTier
+      : null;
+
   return (
     <Card padding="lg">
       <div className="flex flex-col gap-4">
@@ -157,6 +173,16 @@ export function PlanCard({ onManage }: PlanCardProps) {
             {display.actionLabel}
           </Button>
         </div>
+        {creditBundleLabel && (
+          <Typography
+            as="p"
+            variant="body-small-default"
+            className="text-[var(--content-tertiary)]"
+            data-testid="plan-card-credit-bundle"
+          >
+            Monthly credits: {creditBundleLabel}
+          </Typography>
+        )}
         {showRenewal && (
           <Typography
             as="p"

--- a/apps/web/src/domains/settings/components/tier-picker.tsx
+++ b/apps/web/src/domains/settings/components/tier-picker.tsx
@@ -9,6 +9,7 @@ import type {
   StorageTier,
   StorageTierEnum,
 } from "@/generated/api/types.gen";
+import { formatDelta, formatMonthly } from "./tier-pricing";
 
 /**
  * Display labels for the Pro machine tiers. Uses a static label map so casing
@@ -31,23 +32,6 @@ const MACHINE_TIER_LABEL: Record<string, string> = {
  */
 export function isTierDisabled(tier: MachineTier | StorageTier): boolean {
   return (tier as unknown as { disabled?: boolean }).disabled === true;
-}
-
-/** "$50/mo" for whole-dollar tiers; "$50.50/mo" only when cents are present. */
-function formatMonthly(totalCents: number): string {
-  const dollars = totalCents / 100;
-  return Number.isInteger(dollars)
-    ? `$${dollars}/mo`
-    : `$${dollars.toFixed(2)}/mo`;
-}
-
-function formatDelta(deltaCents: number): string {
-  const prefix = deltaCents > 0 ? "+" : "−";
-  const absDollars = Math.abs(deltaCents) / 100;
-  const formatted = Number.isInteger(absDollars)
-    ? `$${absDollars}`
-    : `$${absDollars.toFixed(2)}`;
-  return `${prefix}${formatted}/mo`;
 }
 
 export interface TierPickerProps {

--- a/apps/web/src/domains/settings/components/tier-picker.tsx
+++ b/apps/web/src/domains/settings/components/tier-picker.tsx
@@ -44,6 +44,13 @@ export interface TierPickerProps {
   onStorageTierChange: (tier: StorageTierEnum) => void;
   currentMachinePriceCents?: number | null;
   currentStoragePriceCents?: number | null;
+  // The credit bundle is a changed "dimension" alongside machine/storage: its
+  // monthly price folds into the headline Total (and its delta) so the figure
+  // reflects the chosen bundle and reconciles with the modal's "Currently $X"
+  // baseline (which already includes the current bundle). Default 0 leaves
+  // non-credit callers byte-identical to before.
+  creditPriceCents?: number | null;
+  currentCreditPriceCents?: number | null;
 }
 
 export function TierPicker({
@@ -56,6 +63,8 @@ export function TierPicker({
   onStorageTierChange,
   currentMachinePriceCents,
   currentStoragePriceCents,
+  creditPriceCents,
+  currentCreditPriceCents,
 }: TierPickerProps) {
   const selectedMachine = machineTiers.find(
     (t) => t.tier === selectedMachineTier,
@@ -67,11 +76,15 @@ export function TierPicker({
     selectedMachine && selectedStorage
       ? basePriceCents +
         selectedMachine.price_cents +
-        selectedStorage.price_cents
+        selectedStorage.price_cents +
+        (creditPriceCents ?? 0)
       : null;
   const currentTotalCents =
     currentMachinePriceCents != null && currentStoragePriceCents != null
-      ? basePriceCents + currentMachinePriceCents + currentStoragePriceCents
+      ? basePriceCents +
+        currentMachinePriceCents +
+        currentStoragePriceCents +
+        (currentCreditPriceCents ?? 0)
       : null;
   const totalDelta =
     totalCents != null && currentTotalCents != null

--- a/apps/web/src/domains/settings/components/tier-pricing.test.ts
+++ b/apps/web/src/domains/settings/components/tier-pricing.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+
+import { formatDelta, formatMonthly } from "./tier-pricing";
+
+describe("formatMonthly", () => {
+  test("renders whole-dollar amounts without cents", () => {
+    expect(formatMonthly(5000)).toBe("$50/mo");
+  });
+
+  test("renders sub-dollar cents with two decimals", () => {
+    expect(formatMonthly(995)).toBe("$9.95/mo");
+  });
+
+  test("renders zero as $0/mo", () => {
+    expect(formatMonthly(0)).toBe("$0/mo");
+  });
+});
+
+describe("formatDelta", () => {
+  test("prefixes a positive delta with +", () => {
+    expect(formatDelta(2500)).toBe("+$25/mo");
+  });
+
+  test("prefixes a negative delta with the U+2212 minus sign", () => {
+    expect(formatDelta(-5000)).toBe("−$50/mo");
+  });
+
+  test("keeps cents on a fractional delta", () => {
+    expect(formatDelta(-1050)).toBe("−$10.50/mo");
+  });
+
+  test("treats a zero delta as non-positive (minus prefix)", () => {
+    expect(formatDelta(0)).toBe("−$0/mo");
+  });
+});

--- a/apps/web/src/domains/settings/components/tier-pricing.ts
+++ b/apps/web/src/domains/settings/components/tier-pricing.ts
@@ -1,0 +1,31 @@
+/**
+ * Shared price formatters for the Pro plan tier/credit pickers.
+ *
+ * Both `tier-picker` (machine/storage) and `credit-bundle-picker` render
+ * monthly prices and price deltas in the same style, and `plan-card` shows the
+ * current credit bundle's monthly price. Centralising the formatting here keeps
+ * those surfaces byte-for-byte consistent — in particular the cents-aware
+ * whole-dollar rule, so a sub-dollar tier reads as `$9.95/mo` everywhere rather
+ * than rounding to `$10/mo` in one place and `$9.95/mo` in another.
+ */
+
+/** "$50/mo" for whole-dollar amounts; "$50.50/mo" only when cents are present. */
+export function formatMonthly(cents: number): string {
+  const dollars = cents / 100;
+  return Number.isInteger(dollars)
+    ? `$${dollars}/mo`
+    : `$${dollars.toFixed(2)}/mo`;
+}
+
+/**
+ * Signed monthly delta, e.g. `+$25/mo` or `−$25/mo`. Uses the U+2212 minus
+ * sign (not an ASCII hyphen) so a negative delta typesets cleanly.
+ */
+export function formatDelta(deltaCents: number): string {
+  const prefix = deltaCents > 0 ? "+" : "−";
+  const absDollars = Math.abs(deltaCents) / 100;
+  const formatted = Number.isInteger(absDollars)
+    ? `$${absDollars}`
+    : `$${absDollars.toFixed(2)}`;
+  return `${prefix}${formatted}/mo`;
+}


### PR DESCRIPTION
## Summary
Adds the web UI for selectable monthly credit bundles on the Pro plan, consuming the Django backend from platform PR #8184. Users pick a bundle during Base→Pro upgrade, existing Pro subscribers add/swap/remove a bundle, and the current bundle is surfaced on the plan card. All credit UI is gated entirely on the server-flag-gated catalog (`proPlan.credit_tiers` present and non-empty) — no client flag. "No bundle" maps to `credit_tier: null`.

## Self-review result
PASS after 2 remediation rounds (4-pass fresh-eyes review: external, plan-faithfulness, integration, slop/reuse).

## PRs merged into feature branch
- #33476: feat(web): add CreditBundlePicker component for credit bundle selection
- #33477: feat(web): show current credit bundle on the billing plan card
- #33480: feat(web): credit bundle selection in upgrade and change flows

### Fix PRs (review remediation)
- #33492: refactor(web): share tier price formatters; guard credit bundle removal
- #33494: fix(web): include credit bundle in adjust-plan total

## Notes
- PR 1 of the plan (sync platform OpenAPI schema + regenerate client) was a no-op — the schema was already synced to `main` via #33468 (`platform-source.json` sourceSha `1bf8b67bf5fc...`), and the generated client is gitignored/regenerated locally.
- **Known limitation:** a credit tier a user holds but that the catalog no longer lists reads as $0 in the adjust-plan total. Sourcing its price requires the subscription response to expose the held bundle's price — a platform change out of this frontend plan's scope. Delisting an in-use tier is an unsupported operational scenario.

Part of plan: pro-credit-bundles-frontend.md