### PR TITLE
fix(calls): treat fish-audio w/o referenceId unplayable; verify TTS fallback is playable

### DIFF
--- a/assistant/src/__tests__/telephony-tts-guard.test.ts
+++ b/assistant/src/__tests__/telephony-tts-guard.test.ts
@@ -27,6 +27,10 @@ mock.module("../util/logger.js", () => ({
 
 // Configured provider id (mutated per test).
 let configuredProvider: TtsProviderId = "elevenlabs";
+// Per-provider config blocks (mutated per test), keyed by provider id. Used by
+// both resolveTtsConfig (active provider) and resolveProviderTtsConfig (any
+// provider, e.g. the fallback default).
+let providerConfigs: Record<string, Record<string, unknown>> = {};
 
 mock.module("../config/loader.js", () => ({
   loadConfig: () => ({ services: { tts: { provider: configuredProvider } } }),
@@ -35,8 +39,10 @@ mock.module("../config/loader.js", () => ({
 mock.module("../tts/tts-config-resolver.js", () => ({
   resolveTtsConfig: () => ({
     provider: configuredProvider,
-    providerConfig: {},
+    providerConfig: providerConfigs[configuredProvider] ?? {},
   }),
+  resolveProviderTtsConfig: (_config: unknown, provider: string) =>
+    providerConfigs[provider] ?? {},
 }));
 
 // Synthetic catalog: each entry declares a media-stream output format and a
@@ -64,6 +70,12 @@ const fakeCatalog: Record<
   "legacy-keyed": {
     mediaStreamPlayback: { outputFormat: "pcm" },
     key: "credential/legacy-keyed/api_key",
+  },
+  // Fish Audio: PCM-capable and credentialed, but requires a non-empty
+  // referenceId in its provider config before it can synthesize any audio.
+  "fish-audio": {
+    mediaStreamPlayback: { outputFormat: "pcm" },
+    key: "k/fish",
   },
 };
 
@@ -142,6 +154,7 @@ beforeEach(() => {
   configuredProvider = "elevenlabs";
   storedKeys = {};
   envProviderKeys = {};
+  providerConfigs = {};
   for (const key of Object.keys(registeredProviders)) {
     delete registeredProviders[key];
   }
@@ -237,6 +250,40 @@ describe("resolveTelephonyTtsCapability", () => {
       expect(result.providerId).toBe("legacy-keyed");
     }
   });
+
+  test("fish-audio with API key but empty referenceId is not-playable (missing-required-config)", async () => {
+    configuredProvider = "fish-audio";
+    storedKeys["k/fish"] = "sk_test"; // credentialed
+    providerConfigs["fish-audio"] = { referenceId: "   " }; // blank reference id
+
+    const result = await resolveTelephonyTtsCapability();
+    expect(result.status).toBe("not-playable");
+    if (result.status === "not-playable") {
+      expect(result.reason).toBe("missing-required-config");
+      expect(result.providerId).toBe("fish-audio");
+    }
+  });
+
+  test("fish-audio with API key but missing referenceId is not-playable (missing-required-config)", async () => {
+    configuredProvider = "fish-audio";
+    storedKeys["k/fish"] = "sk_test"; // credentialed, no referenceId in config
+
+    const result = await resolveTelephonyTtsCapability();
+    expect(result.status).toBe("not-playable");
+    if (result.status === "not-playable") {
+      expect(result.reason).toBe("missing-required-config");
+    }
+  });
+
+  test("fish-audio with API key and referenceId is playable", async () => {
+    configuredProvider = "fish-audio";
+    storedKeys["k/fish"] = "sk_test";
+    providerConfigs["fish-audio"] = { referenceId: "voice_abc123" };
+
+    const result = await resolveTelephonyTtsCapability();
+    expect(result.status).toBe("playable");
+    expect(result.providerId).toBe("fish-audio");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -300,5 +347,31 @@ describe("resolvePlayableCallTtsProvider", () => {
     const result = await resolvePlayableCallTtsProvider();
     expect(result.provider).not.toBeNull();
     expect(result.provider!.id).toBe("elevenlabs");
+  });
+
+  test("falls back to the default for fish-audio without a referenceId", async () => {
+    configuredProvider = "fish-audio";
+    storedKeys["k/fish"] = "sk_fish"; // credentialed but no referenceId
+    storedKeys["k/eleven"] = "sk_default"; // default is playable
+    registeredProviders["fish-audio"] = makeProvider("fish-audio");
+
+    const result = await resolvePlayableCallTtsProvider();
+    // fish-audio would throw FISH_AUDIO_TTS_NO_REFERENCE_ID at synthesis, so
+    // the guard must NOT return it; it falls back to the playable default.
+    expect(result.provider).not.toBeNull();
+    expect(result.provider!.id).toBe("elevenlabs");
+  });
+
+  test("returns no-playable-provider signal when configured AND default are both unplayable", async () => {
+    // Configured provider can't emit a transcodable format...
+    configuredProvider = "compressed-only";
+    storedKeys["k/compressed"] = "sk_test";
+    // ...and the default (elevenlabs) is NOT credentialed, so it is also not
+    // playable. The guard must surface null rather than a silent provider.
+    // (no k/eleven key stored)
+
+    const result = await resolvePlayableCallTtsProvider();
+    expect(result.provider).toBeNull();
+    expect(result.audioFormat).toBe("wav");
   });
 });

--- a/assistant/src/__tests__/telephony-tts-guard.test.ts
+++ b/assistant/src/__tests__/telephony-tts-guard.test.ts
@@ -9,7 +9,10 @@
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import type { MediaStreamPlaybackFormat } from "../tts/provider-catalog.js";
+import type {
+  MediaStreamPlaybackFormat,
+  TtsCredentialLookup,
+} from "../tts/provider-catalog.js";
 import type { TtsProvider, TtsProviderId } from "../tts/types.js";
 
 // ---------------------------------------------------------------------------
@@ -45,37 +48,46 @@ mock.module("../tts/tts-config-resolver.js", () => ({
     providerConfigs[provider] ?? {},
 }));
 
-// Synthetic catalog: each entry declares a media-stream output format and a
-// credential store key. Real adapter behavior is irrelevant to the guard.
+// Synthetic catalog: each entry declares a media-stream output format, a
+// credential store key, and the lookup semantics its adapter uses. The probe
+// MUST mirror that lookup, so the catalog declares it.
 const fakeCatalog: Record<
   string,
   {
     mediaStreamPlayback: { outputFormat: MediaStreamPlaybackFormat };
     key: string;
+    credentialLookup: TtsCredentialLookup;
   }
 > = {
-  elevenlabs: { mediaStreamPlayback: { outputFormat: "pcm" }, key: "k/eleven" },
+  // ElevenLabs reads ONLY the namespaced key (no legacy bare/env fallback).
+  elevenlabs: {
+    mediaStreamPlayback: { outputFormat: "pcm" },
+    key: "credential/elevenlabs/api_key",
+    credentialLookup: "namespaced-only",
+  },
   "wav-provider": {
     mediaStreamPlayback: { outputFormat: "wav" },
-    key: "k/wav",
+    key: "credential/wav-provider/api_key",
+    credentialLookup: "namespaced-only",
   },
   "compressed-only": {
     mediaStreamPlayback: { outputFormat: "none" },
-    key: "k/compressed",
+    key: "credential/compressed-only/api_key",
+    credentialLookup: "namespaced-only",
   },
-  // Provider whose catalog requirement uses the standard namespaced api_key
-  // store key (credential/{id}/api_key), exercising the getProviderKeyAsync
-  // path: a key configured only under the legacy bare or env form must still
-  // be recognized as available.
-  "legacy-keyed": {
+  // Deepgram-style provider: reads via getProviderKeyAsync, so a key
+  // configured only under the legacy bare or env form is still recognized.
+  "deepgram-like": {
     mediaStreamPlayback: { outputFormat: "pcm" },
-    key: "credential/legacy-keyed/api_key",
+    key: "credential/deepgram-like/api_key",
+    credentialLookup: "provider-key",
   },
-  // Fish Audio: PCM-capable and credentialed, but requires a non-empty
-  // referenceId in its provider config before it can synthesize any audio.
+  // Fish Audio: namespaced-only key; PCM-capable and credentialed, but
+  // requires a non-empty referenceId before it can synthesize any audio.
   "fish-audio": {
     mediaStreamPlayback: { outputFormat: "pcm" },
-    key: "k/fish",
+    key: "credential/fish-audio/api_key",
+    credentialLookup: "namespaced-only",
   },
 };
 
@@ -89,6 +101,7 @@ mock.module("../tts/provider-catalog.js", () => ({
       secretRequirements: [
         {
           credentialStoreKey: entry.key,
+          credentialLookup: entry.credentialLookup,
           displayName: `${id} key`,
           setCommand: "set",
         },
@@ -168,7 +181,7 @@ beforeEach(() => {
 describe("resolveTelephonyTtsCapability", () => {
   test("pcm provider with credentials is playable", async () => {
     configuredProvider = "elevenlabs";
-    storedKeys["k/eleven"] = "sk_test";
+    storedKeys["credential/elevenlabs/api_key"] = "sk_test";
 
     const result = await resolveTelephonyTtsCapability();
     expect(result.status).toBe("playable");
@@ -177,7 +190,7 @@ describe("resolveTelephonyTtsCapability", () => {
 
   test("wav provider with credentials is playable", async () => {
     configuredProvider = "wav-provider";
-    storedKeys["k/wav"] = "sk_test";
+    storedKeys["credential/wav-provider/api_key"] = "sk_test";
 
     const result = await resolveTelephonyTtsCapability();
     expect(result.status).toBe("playable");
@@ -185,7 +198,7 @@ describe("resolveTelephonyTtsCapability", () => {
 
   test("none-format provider is not-playable (unsupported-format)", async () => {
     configuredProvider = "compressed-only";
-    storedKeys["k/compressed"] = "sk_test"; // credential present, format still no good
+    storedKeys["credential/compressed-only/api_key"] = "sk_test"; // credential present, format still no good
 
     const result = await resolveTelephonyTtsCapability();
     expect(result.status).toBe("not-playable");
@@ -209,7 +222,7 @@ describe("resolveTelephonyTtsCapability", () => {
 
   test("blank credential is treated as missing", async () => {
     configuredProvider = "elevenlabs";
-    storedKeys["k/eleven"] = "   ";
+    storedKeys["credential/elevenlabs/api_key"] = "   ";
 
     const result = await resolveTelephonyTtsCapability();
     expect(result.status).toBe("not-playable");
@@ -218,42 +231,77 @@ describe("resolveTelephonyTtsCapability", () => {
     }
   });
 
-  test("playable when key exists only under the legacy bare store key", async () => {
-    configuredProvider = "legacy-keyed";
-    // Namespaced credential/legacy-keyed/api_key is absent; only the legacy
+  test("provider-key provider is playable when key exists only under the legacy bare store key", async () => {
+    configuredProvider = "deepgram-like";
+    // Namespaced credential/deepgram-like/api_key is absent; only the legacy
     // bare key is present — the adapter (getProviderKeyAsync) would find it.
-    storedKeys["legacy-keyed"] = "sk_legacy";
+    storedKeys["deepgram-like"] = "sk_legacy";
 
     const result = await resolveTelephonyTtsCapability();
     expect(result.status).toBe("playable");
-    expect(result.providerId).toBe("legacy-keyed");
+    expect(result.providerId).toBe("deepgram-like");
   });
 
-  test("playable when key exists only via the env-var fallback", async () => {
-    configuredProvider = "legacy-keyed";
+  test("provider-key provider is playable when key exists only via the env-var fallback", async () => {
+    configuredProvider = "deepgram-like";
     // Neither store key is set; only the provider env-var fallback resolves.
-    envProviderKeys["legacy-keyed"] = "sk_from_env";
+    envProviderKeys["deepgram-like"] = "sk_from_env";
 
     const result = await resolveTelephonyTtsCapability();
     expect(result.status).toBe("playable");
-    expect(result.providerId).toBe("legacy-keyed");
+    expect(result.providerId).toBe("deepgram-like");
   });
 
-  test("missing-credentials when no key resolves under any lookup", async () => {
-    configuredProvider = "legacy-keyed";
+  test("provider-key provider is missing-credentials when no key resolves under any lookup", async () => {
+    configuredProvider = "deepgram-like";
     // No namespaced, bare, or env key present.
 
     const result = await resolveTelephonyTtsCapability();
     expect(result.status).toBe("not-playable");
     if (result.status === "not-playable") {
       expect(result.reason).toBe("missing-credentials");
-      expect(result.providerId).toBe("legacy-keyed");
+      expect(result.providerId).toBe("deepgram-like");
     }
+  });
+
+  test("namespaced-only provider is NOT playable when only the legacy bare key is set", async () => {
+    // ElevenLabs reads only the namespaced key — a legacy bare key must NOT
+    // satisfy the probe, or synthesis would throw ELEVENLABS_TTS_NO_API_KEY.
+    configuredProvider = "elevenlabs";
+    storedKeys["elevenlabs"] = "sk_legacy_bare";
+
+    const result = await resolveTelephonyTtsCapability();
+    expect(result.status).toBe("not-playable");
+    if (result.status === "not-playable") {
+      expect(result.reason).toBe("missing-credentials");
+      expect(result.providerId).toBe("elevenlabs");
+    }
+  });
+
+  test("namespaced-only provider is NOT playable when only the env-var fallback resolves", async () => {
+    configuredProvider = "elevenlabs";
+    envProviderKeys["elevenlabs"] = "sk_from_env";
+
+    const result = await resolveTelephonyTtsCapability();
+    expect(result.status).toBe("not-playable");
+    if (result.status === "not-playable") {
+      expect(result.reason).toBe("missing-credentials");
+      expect(result.providerId).toBe("elevenlabs");
+    }
+  });
+
+  test("namespaced-only provider is playable with the namespaced key", async () => {
+    configuredProvider = "elevenlabs";
+    storedKeys["credential/elevenlabs/api_key"] = "sk_namespaced";
+
+    const result = await resolveTelephonyTtsCapability();
+    expect(result.status).toBe("playable");
+    expect(result.providerId).toBe("elevenlabs");
   });
 
   test("fish-audio with API key but empty referenceId is not-playable (missing-required-config)", async () => {
     configuredProvider = "fish-audio";
-    storedKeys["k/fish"] = "sk_test"; // credentialed
+    storedKeys["credential/fish-audio/api_key"] = "sk_test"; // credentialed
     providerConfigs["fish-audio"] = { referenceId: "   " }; // blank reference id
 
     const result = await resolveTelephonyTtsCapability();
@@ -266,7 +314,7 @@ describe("resolveTelephonyTtsCapability", () => {
 
   test("fish-audio with API key but missing referenceId is not-playable (missing-required-config)", async () => {
     configuredProvider = "fish-audio";
-    storedKeys["k/fish"] = "sk_test"; // credentialed, no referenceId in config
+    storedKeys["credential/fish-audio/api_key"] = "sk_test"; // credentialed, no referenceId in config
 
     const result = await resolveTelephonyTtsCapability();
     expect(result.status).toBe("not-playable");
@@ -277,12 +325,26 @@ describe("resolveTelephonyTtsCapability", () => {
 
   test("fish-audio with API key and referenceId is playable", async () => {
     configuredProvider = "fish-audio";
-    storedKeys["k/fish"] = "sk_test";
+    storedKeys["credential/fish-audio/api_key"] = "sk_test";
     providerConfigs["fish-audio"] = { referenceId: "voice_abc123" };
 
     const result = await resolveTelephonyTtsCapability();
     expect(result.status).toBe("playable");
     expect(result.providerId).toBe("fish-audio");
+  });
+
+  test("fish-audio is NOT playable when only a legacy bare key is set", async () => {
+    // Fish Audio reads only the namespaced key — a legacy bare key must not
+    // satisfy the probe even when referenceId is present.
+    configuredProvider = "fish-audio";
+    storedKeys["fish-audio"] = "sk_legacy_bare";
+    providerConfigs["fish-audio"] = { referenceId: "voice_abc123" };
+
+    const result = await resolveTelephonyTtsCapability();
+    expect(result.status).toBe("not-playable");
+    if (result.status === "not-playable") {
+      expect(result.reason).toBe("missing-credentials");
+    }
   });
 });
 
@@ -291,8 +353,8 @@ describe("resolveTelephonyTtsCapability", () => {
 // ---------------------------------------------------------------------------
 
 describe("isTtsProviderCredentialAvailable", () => {
-  test("true when the catalog credential key has a value", async () => {
-    storedKeys["k/eleven"] = "sk_test";
+  test("true when the namespaced credential key has a value", async () => {
+    storedKeys["credential/elevenlabs/api_key"] = "sk_test";
     expect(await isTtsProviderCredentialAvailable("elevenlabs")).toBe(true);
   });
 
@@ -300,14 +362,24 @@ describe("isTtsProviderCredentialAvailable", () => {
     expect(await isTtsProviderCredentialAvailable("elevenlabs")).toBe(false);
   });
 
-  test("true when only the legacy bare key is set", async () => {
-    storedKeys["legacy-keyed"] = "sk_legacy";
-    expect(await isTtsProviderCredentialAvailable("legacy-keyed")).toBe(true);
+  test("namespaced-only provider: false when only the legacy bare key is set", async () => {
+    storedKeys["elevenlabs"] = "sk_legacy";
+    expect(await isTtsProviderCredentialAvailable("elevenlabs")).toBe(false);
   });
 
-  test("true when only the env-var fallback resolves", async () => {
-    envProviderKeys["legacy-keyed"] = "sk_from_env";
-    expect(await isTtsProviderCredentialAvailable("legacy-keyed")).toBe(true);
+  test("namespaced-only provider: false when only the env-var fallback resolves", async () => {
+    envProviderKeys["elevenlabs"] = "sk_from_env";
+    expect(await isTtsProviderCredentialAvailable("elevenlabs")).toBe(false);
+  });
+
+  test("provider-key provider: true when only the legacy bare key is set", async () => {
+    storedKeys["deepgram-like"] = "sk_legacy";
+    expect(await isTtsProviderCredentialAvailable("deepgram-like")).toBe(true);
+  });
+
+  test("provider-key provider: true when only the env-var fallback resolves", async () => {
+    envProviderKeys["deepgram-like"] = "sk_from_env";
+    expect(await isTtsProviderCredentialAvailable("deepgram-like")).toBe(true);
   });
 });
 
@@ -318,7 +390,7 @@ describe("isTtsProviderCredentialAvailable", () => {
 describe("resolvePlayableCallTtsProvider", () => {
   test("returns the configured provider when it is playable", async () => {
     configuredProvider = "wav-provider";
-    storedKeys["k/wav"] = "sk_test";
+    storedKeys["credential/wav-provider/api_key"] = "sk_test";
     registeredProviders["wav-provider"] = makeProvider("wav-provider");
 
     const result = await resolvePlayableCallTtsProvider();
@@ -329,8 +401,8 @@ describe("resolvePlayableCallTtsProvider", () => {
 
   test("falls back to the PCM-capable default when format is unsupported", async () => {
     configuredProvider = "compressed-only";
-    storedKeys["k/compressed"] = "sk_test";
-    storedKeys["k/eleven"] = "sk_default"; // default provider is credentialed
+    storedKeys["credential/compressed-only/api_key"] = "sk_test";
+    storedKeys["credential/elevenlabs/api_key"] = "sk_default"; // default provider is credentialed
 
     const result = await resolvePlayableCallTtsProvider();
     // No silent path: a usable provider is returned (the default), not null.
@@ -341,7 +413,7 @@ describe("resolvePlayableCallTtsProvider", () => {
 
   test("falls back to the PCM-capable default when credentials are missing", async () => {
     configuredProvider = "wav-provider"; // playable format but no key
-    storedKeys["k/eleven"] = "sk_default";
+    storedKeys["credential/elevenlabs/api_key"] = "sk_default";
     registeredProviders["wav-provider"] = makeProvider("wav-provider");
 
     const result = await resolvePlayableCallTtsProvider();
@@ -351,8 +423,8 @@ describe("resolvePlayableCallTtsProvider", () => {
 
   test("falls back to the default for fish-audio without a referenceId", async () => {
     configuredProvider = "fish-audio";
-    storedKeys["k/fish"] = "sk_fish"; // credentialed but no referenceId
-    storedKeys["k/eleven"] = "sk_default"; // default is playable
+    storedKeys["credential/fish-audio/api_key"] = "sk_fish"; // credentialed but no referenceId
+    storedKeys["credential/elevenlabs/api_key"] = "sk_default"; // default is playable
     registeredProviders["fish-audio"] = makeProvider("fish-audio");
 
     const result = await resolvePlayableCallTtsProvider();
@@ -365,10 +437,25 @@ describe("resolvePlayableCallTtsProvider", () => {
   test("returns no-playable-provider signal when configured AND default are both unplayable", async () => {
     // Configured provider can't emit a transcodable format...
     configuredProvider = "compressed-only";
-    storedKeys["k/compressed"] = "sk_test";
+    storedKeys["credential/compressed-only/api_key"] = "sk_test";
     // ...and the default (elevenlabs) is NOT credentialed, so it is also not
     // playable. The guard must surface null rather than a silent provider.
-    // (no k/eleven key stored)
+    // (no namespaced elevenlabs key stored)
+
+    const result = await resolvePlayableCallTtsProvider();
+    expect(result.provider).toBeNull();
+    expect(result.audioFormat).toBe("wav");
+  });
+
+  test("does NOT accept the ElevenLabs fallback when it only has a legacy bare key", async () => {
+    // Configured provider is unplayable, and the ElevenLabs default has ONLY a
+    // legacy bare key — which the namespaced-only adapter would not read. The
+    // fallback must be rejected and the no-playable-provider signal returned,
+    // rather than dialing into silence.
+    configuredProvider = "compressed-only";
+    storedKeys["credential/compressed-only/api_key"] = "sk_test";
+    storedKeys["elevenlabs"] = "sk_legacy_bare"; // legacy bare key only
+    envProviderKeys["elevenlabs"] = "sk_from_env"; // env fallback also ignored
 
     const result = await resolvePlayableCallTtsProvider();
     expect(result.provider).toBeNull();

--- a/assistant/src/calls/resolve-call-tts-provider.ts
+++ b/assistant/src/calls/resolve-call-tts-provider.ts
@@ -15,6 +15,7 @@ import { getLogger } from "../util/logger.js";
 import {
   DEFAULT_PLAYABLE_TTS_PROVIDER,
   resolveTelephonyTtsCapability,
+  resolveTelephonyTtsCapabilityFor,
 } from "./telephony-tts-capability.js";
 import { resolveCallStrategy } from "./tts-call-strategy.js";
 
@@ -123,9 +124,18 @@ export function resolveCallTtsProvider(): ResolvedCallTts {
 // Media-stream playability guard
 // ---------------------------------------------------------------------------
 
-/** A media-stream TTS provider guaranteed to emit transcodable audio. */
+/**
+ * A media-stream TTS provider guaranteed to emit transcodable audio.
+ *
+ * `provider` is `null` to signal **no playable provider** — neither the
+ * configured provider nor the fallback default could synthesize transcodable,
+ * credentialed audio (or the registry is unavailable). Callers MUST treat a
+ * null provider as "do not attempt synthesized media-stream playback" and
+ * degrade safely (native token path / end-of-turn signal) rather than dialing
+ * into silence.
+ */
 export interface PlayableCallTts {
-  /** The resolved, PCM/WAV-capable, credentialed provider (or null). */
+  /** The resolved, PCM/WAV-capable, credentialed provider, or `null`. */
   provider: TtsProvider | null;
 
   /** Audio format to request for synthesized audio (always `"wav"`). */
@@ -137,16 +147,18 @@ export interface PlayableCallTts {
  * that the returned provider can actually feed the PCM -> mu-law transcoder.
  *
  * On media-stream every byte of telephony audio is daemon-synthesized and
- * transcoded, so a provider that cannot emit PCM/WAV (or whose credential is
- * missing) would produce a silent call. When the configured provider is
- * {@link resolveTelephonyTtsCapability not playable}, this falls back to a
- * known PCM-capable, credentialed default ({@link DEFAULT_PLAYABLE_TTS_PROVIDER})
- * instead of leaving the call silent, logging a clear warning with the
- * configured provider id and the reason.
+ * transcoded, so a provider that cannot emit PCM/WAV (or whose credential or
+ * required config is missing) would produce a silent call. When the configured
+ * provider is {@link resolveTelephonyTtsCapability not playable}, this falls
+ * back to a known PCM-capable default ({@link DEFAULT_PLAYABLE_TTS_PROVIDER}) —
+ * **but only after re-running the same playability check on that default**, so
+ * an uncredentialed default is never silently returned.
  *
- * Returns `{ provider: null }` only when neither the configured provider nor
- * the fallback can be resolved (e.g. registry empty in tests / early startup),
- * so callers can degrade without throwing.
+ * Returns `{ provider: null }` when neither the configured provider nor the
+ * fallback default is playable (e.g. the default is also uncredentialed), or
+ * when the registry/config is unavailable (tests / early startup). This is the
+ * explicit "no playable provider" signal: callers (and the call preflight)
+ * fail loudly / degrade safely rather than dialing into silence.
  */
 export async function resolvePlayableCallTtsProvider(): Promise<PlayableCallTts> {
   try {
@@ -159,9 +171,29 @@ export async function resolvePlayableCallTtsProvider(): Promise<PlayableCallTts>
       };
     }
 
-    // Configured provider cannot feed the media-stream transcoder. Fall back
-    // to a known PCM-capable, credentialed default rather than emitting a
-    // silent call.
+    // Configured provider cannot feed the media-stream transcoder. Before
+    // falling back to the default, verify the default is ITSELF playable
+    // (credentialed + required config present) so we never return an unusable
+    // provider that would dial into silence.
+    const fallbackCapability = await resolveTelephonyTtsCapabilityFor(
+      DEFAULT_PLAYABLE_TTS_PROVIDER,
+    );
+
+    if (fallbackCapability.status !== "playable") {
+      log.error(
+        {
+          configuredProvider: capability.providerId,
+          configuredReason: capability.reason,
+          fallbackProvider: DEFAULT_PLAYABLE_TTS_PROVIDER,
+          fallbackReason: fallbackCapability.reason,
+        },
+        "No playable media-stream TTS provider — configured provider cannot " +
+          "synthesize playable audio and the default fallback is also not " +
+          "playable; degrading instead of returning a silent provider",
+      );
+      return { provider: null, audioFormat: "wav" };
+    }
+
     log.warn(
       {
         configuredProvider: capability.providerId,

--- a/assistant/src/calls/telephony-tts-capability.ts
+++ b/assistant/src/calls/telephony-tts-capability.ts
@@ -30,7 +30,10 @@ import {
   getCatalogProvider,
   type MediaStreamPlaybackFormat,
 } from "../tts/provider-catalog.js";
-import { resolveTtsConfig } from "../tts/tts-config-resolver.js";
+import {
+  resolveProviderTtsConfig,
+  resolveTtsConfig,
+} from "../tts/tts-config-resolver.js";
 import type { TtsProviderId } from "../tts/types.js";
 
 // ---------------------------------------------------------------------------
@@ -51,14 +54,20 @@ export const DEFAULT_PLAYABLE_TTS_PROVIDER: TtsProviderId = "elevenlabs";
 /**
  * Why a configured provider cannot feed the media-stream transcoder.
  *
- * - `unsupported-format`  — the provider's declared media-stream output
- *                            format is `"none"` (it cannot emit PCM/WAV).
- * - `missing-credentials` — the provider could emit PCM/WAV but its
- *                            credential is not available.
+ * - `unsupported-format`    — the provider's declared media-stream output
+ *                              format is `"none"` (it cannot emit PCM/WAV).
+ * - `missing-credentials`   — the provider could emit PCM/WAV but its
+ *                              credential is not available.
+ * - `missing-required-config` — the provider is credentialed and can emit
+ *                              PCM/WAV, but a required provider-specific config
+ *                              value is missing, so synthesis would throw
+ *                              before producing audio (e.g. fish-audio's
+ *                              `referenceId`).
  */
 export type TelephonyTtsNotPlayableReason =
   | "unsupported-format"
-  | "missing-credentials";
+  | "missing-credentials"
+  | "missing-required-config";
 
 /** Result of {@link resolveTelephonyTtsCapability}. */
 export type TelephonyTtsCapability =
@@ -129,17 +138,60 @@ function isPlayableFormat(format: MediaStreamPlaybackFormat): boolean {
 }
 
 /**
- * Resolve whether the currently configured `services.tts.provider` can feed
- * the media-stream transcoder with playable audio.
+ * Provider-specific required-config invariants that must hold before the
+ * provider can synthesize ANY audio on the telephony path.
  *
- * Returns `{ status: "playable" }` only when the provider's declared
- * media-stream output format is PCM/WAV **and** its credential is available.
+ * A provider listed here will throw at first synthesis (not emit silence)
+ * when the predicate returns false, so the capability check must treat it as
+ * NOT playable — the media-stream path has no native fallback, so it would go
+ * silent otherwise.
+ *
+ * Each predicate receives the provider's resolved `services.tts.providers.<id>`
+ * config block and returns true when the required config is present.
+ *
+ * - `fish-audio`: `createFishAudioProvider().synthesize()` throws
+ *   `FISH_AUDIO_TTS_NO_REFERENCE_ID` when neither a per-request voiceId nor a
+ *   configured `referenceId` is available. Telephony synthesis does not pass a
+ *   voiceId, so a non-empty configured `referenceId` is required.
+ */
+const REQUIRED_CONFIG_CHECKS: Partial<
+  Record<TtsProviderId, (providerConfig: Record<string, unknown>) => boolean>
+> = {
+  "fish-audio": (providerConfig) => {
+    const referenceId = providerConfig.referenceId;
+    return typeof referenceId === "string" && referenceId.trim().length > 0;
+  },
+};
+
+/**
+ * Whether the provider's required provider-specific config is present.
+ *
+ * Providers without a registered check are considered to have no required
+ * config (always satisfied).
+ */
+function hasRequiredProviderConfig(
+  providerId: TtsProviderId,
+  providerConfig: Record<string, unknown>,
+): boolean {
+  const check = REQUIRED_CONFIG_CHECKS[providerId];
+  return check ? check(providerConfig) : true;
+}
+
+/**
+ * Resolve whether a specific provider (with its resolved config block) can
+ * feed the media-stream transcoder with playable audio.
+ *
+ * Returns `{ status: "playable" }` only when ALL of the following hold:
+ *   1. the provider's declared media-stream output format is PCM/WAV,
+ *   2. its credential is available, and
+ *   3. any provider-specific required config (e.g. fish-audio's `referenceId`)
+ *      is present.
  * Otherwise returns `{ status: "not-playable"; providerId; reason }`.
  */
-export async function resolveTelephonyTtsCapability(): Promise<TelephonyTtsCapability> {
-  const config = loadConfig();
-  const resolved = resolveTtsConfig(config);
-  const providerId = resolved.provider;
+export async function resolveProviderTelephonyCapability(
+  providerId: TtsProviderId,
+  providerConfig: Record<string, unknown>,
+): Promise<TelephonyTtsCapability> {
   const entry = getCatalogProvider(providerId);
 
   if (!isPlayableFormat(entry.mediaStreamPlayback.outputFormat)) {
@@ -155,5 +207,44 @@ export async function resolveTelephonyTtsCapability(): Promise<TelephonyTtsCapab
     };
   }
 
+  if (!hasRequiredProviderConfig(providerId, providerConfig)) {
+    return {
+      status: "not-playable",
+      providerId,
+      reason: "missing-required-config",
+    };
+  }
+
   return { status: "playable", providerId };
+}
+
+/**
+ * Resolve whether the currently configured `services.tts.provider` can feed
+ * the media-stream transcoder with playable audio.
+ *
+ * Returns `{ status: "playable" }` only when the provider's declared
+ * media-stream output format is PCM/WAV, its credential is available, **and**
+ * any provider-specific required config (e.g. fish-audio's `referenceId`) is
+ * present. Otherwise returns `{ status: "not-playable"; providerId; reason }`.
+ */
+export async function resolveTelephonyTtsCapability(): Promise<TelephonyTtsCapability> {
+  const config = loadConfig();
+  const resolved = resolveTtsConfig(config);
+  return resolveProviderTelephonyCapability(
+    resolved.provider,
+    resolved.providerConfig,
+  );
+}
+
+/**
+ * Resolve whether an explicit provider id (e.g. the fallback default) can feed
+ * the media-stream transcoder, reading that provider's config from the active
+ * assistant config regardless of which provider is currently selected.
+ */
+export async function resolveTelephonyTtsCapabilityFor(
+  providerId: TtsProviderId,
+): Promise<TelephonyTtsCapability> {
+  const config = loadConfig();
+  const providerConfig = resolveProviderTtsConfig(config, providerId);
+  return resolveProviderTelephonyCapability(providerId, providerConfig);
 }

--- a/assistant/src/calls/telephony-tts-capability.ts
+++ b/assistant/src/calls/telephony-tts-capability.ts
@@ -21,7 +21,6 @@
  */
 
 import { loadConfig } from "../config/loader.js";
-import { credentialKey } from "../security/credential-key.js";
 import {
   getProviderKeyAsync,
   getSecureKeyAsync,
@@ -82,25 +81,32 @@ export type TelephonyTtsCapability =
 // Credential availability (reusable)
 // ---------------------------------------------------------------------------
 
+/** Whether a resolved credential string counts as present. */
+function isPresent(value: string | undefined): boolean {
+  return value != null && value.trim().length > 0;
+}
+
 /**
  * Returns true when the given provider's credential is available under the
- * SAME lookup semantics the TTS adapters use to read their key.
+ * SAME lookup semantics the provider's adapter uses to read its key.
  *
- * The real adapters (e.g. the Deepgram adapter) resolve their key via
- * {@link getProviderKeyAsync}, which consults — in order — the namespaced
- * `credential/{provider}/api_key` store key, the legacy bare `{provider}`
- * store key, and the provider's env-var fallback. Probing only the catalog's
- * namespaced `credentialStoreKey` here would report a legacy- or
- * env-configured key as missing, wrongly triggering the fallback (or silence)
- * even though synthesis would actually succeed.
+ * Adapters do NOT all read credentials the same way, and the probe MUST mirror
+ * each one or it will disagree with reality (mark a provider playable, then
+ * synthesis throws a no-key error → silent media-stream call). The lookup each
+ * adapter performs is declared per requirement on the catalog as
+ * {@link TtsCredentialLookup}:
  *
- * Behavior is preserved for providers that declare a non-standard catalog
- * `credentialStoreKey` (one that is not `credential/{providerId}/api_key`):
- * those keys are still probed directly via {@link getSecureKeyAsync}, since
- * {@link getProviderKeyAsync} would not know to look for them.
+ * - `"provider-key"` (e.g. Deepgram): probed via {@link getProviderKeyAsync},
+ *   which honors the namespaced `credential/{provider}/api_key` key, the legacy
+ *   bare `{provider}` key, and the env-var fallback.
+ * - `"namespaced-only"` (e.g. ElevenLabs, Fish Audio, xAI): probed via
+ *   {@link getSecureKeyAsync} against the requirement's exact
+ *   `credentialStoreKey` — the legacy bare key and env fallback are NOT
+ *   honored, because the adapter doesn't honor them either.
  *
- * A provider with no declared secret requirements is treated as
- * always-available (e.g. keyless local providers).
+ * A provider is available when EVERY declared secret requirement resolves a
+ * non-blank value under its own lookup. A provider with no declared secret
+ * requirements is treated as always-available (e.g. keyless local providers).
  *
  * Exported for reuse by the call preflight path so the daemon can warn about
  * an unplayable telephony TTS config before a call connects.
@@ -111,21 +117,14 @@ export async function isTtsProviderCredentialAvailable(
   const entry = getCatalogProvider(providerId);
   if (entry.secretRequirements.length === 0) return true;
 
-  // Primary probe: match the adapter's `getProviderKeyAsync` semantics so
-  // legacy bare keys and env-var fallbacks are recognized.
-  const providerKey = await getProviderKeyAsync(providerId);
-  if (providerKey && providerKey.trim().length > 0) return true;
-
-  // Preserve behavior for any requirement that uses a non-standard catalog
-  // key (i.e. not the provider-namespaced api_key that getProviderKeyAsync
-  // already covered above).
-  const standardKey = credentialKey(providerId, "api_key");
   for (const requirement of entry.secretRequirements) {
-    if (requirement.credentialStoreKey === standardKey) continue;
-    const value = await getSecureKeyAsync(requirement.credentialStoreKey);
-    if (value && value.trim().length > 0) return true;
+    const value =
+      requirement.credentialLookup === "provider-key"
+        ? await getProviderKeyAsync(providerId)
+        : await getSecureKeyAsync(requirement.credentialStoreKey);
+    if (!isPresent(value)) return false;
   }
-  return false;
+  return true;
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/tts/provider-catalog.ts
+++ b/assistant/src/tts/provider-catalog.ts
@@ -18,6 +18,24 @@ import type { TtsCallMode, TtsProviderId } from "./types.js";
 // ---------------------------------------------------------------------------
 
 /**
+ * How a provider's adapter actually resolves its API key at synthesis time.
+ *
+ * This is the contract any credential-presence probe MUST mirror so that a
+ * "credential available" verdict agrees with whether the adapter would in
+ * fact obtain a key. Mismatching it lets a probe mark a provider playable
+ * while synthesis throws a no-key error (silent media-stream call).
+ *
+ * - `"namespaced-only"` — the adapter reads ONLY the namespaced
+ *   `credential/{provider}/api_key` store key via `getSecureKeyAsync`. It does
+ *   NOT honor the legacy bare `{provider}` key or any env-var fallback.
+ *   (ElevenLabs, Fish Audio, xAI.)
+ * - `"provider-key"` — the adapter reads via `getProviderKeyAsync`, which
+ *   consults the namespaced key, then the legacy bare `{provider}` key, then
+ *   the provider's env-var fallback. (Deepgram, which shares its key with STT.)
+ */
+export type TtsCredentialLookup = "namespaced-only" | "provider-key";
+
+/**
  * Metadata about a secret (API key / credential) required by a provider.
  */
 interface TtsProviderSecretRequirement {
@@ -29,6 +47,15 @@ interface TtsProviderSecretRequirement {
    * convention (e.g. `"credential/fish-audio/api_key"`).
    */
   readonly credentialStoreKey: string;
+
+  /**
+   * The lookup semantics the provider's adapter uses to read THIS secret.
+   *
+   * A credential-presence probe must use the matching lookup so its verdict
+   * agrees with whether the adapter would actually obtain the key. See
+   * {@link TtsCredentialLookup}.
+   */
+  readonly credentialLookup: TtsCredentialLookup;
 
   /** Human-readable label shown in settings UI and error messages. */
   readonly displayName: string;
@@ -184,6 +211,10 @@ const CATALOG: readonly TtsProviderCatalogEntry[] = [
     secretRequirements: [
       {
         credentialStoreKey: "credential/elevenlabs/api_key",
+        // The ElevenLabs adapter reads ONLY the namespaced key
+        // (getSecureKeyAsync(credentialKey("elevenlabs","api_key"))) — no
+        // legacy bare key or env fallback.
+        credentialLookup: "namespaced-only",
         displayName: "ElevenLabs API Key",
         setCommand:
           "assistant credentials set --service elevenlabs --field api_key <key>",
@@ -214,6 +245,10 @@ const CATALOG: readonly TtsProviderCatalogEntry[] = [
     secretRequirements: [
       {
         credentialStoreKey: "credential/fish-audio/api_key",
+        // The Fish Audio client reads ONLY the namespaced key
+        // (getSecureKeyAsync(credentialKey("fish-audio","api_key"))) — no
+        // legacy bare key or env fallback.
+        credentialLookup: "namespaced-only",
         displayName: "Fish Audio API Key",
         setCommand:
           "assistant credentials set --service fish-audio --field api_key <key>",
@@ -244,6 +279,10 @@ const CATALOG: readonly TtsProviderCatalogEntry[] = [
     secretRequirements: [
       {
         credentialStoreKey: "credential/deepgram/api_key",
+        // The Deepgram adapter reads via getProviderKeyAsync("deepgram"),
+        // which honors the namespaced key, the legacy bare "deepgram" key, and
+        // the env-var fallback (key is shared with Deepgram STT).
+        credentialLookup: "provider-key",
         displayName: "Deepgram API Key",
         setCommand: "assistant keys set deepgram <key>",
       },
@@ -273,6 +312,10 @@ const CATALOG: readonly TtsProviderCatalogEntry[] = [
     secretRequirements: [
       {
         credentialStoreKey: "credential/xai/api_key",
+        // The xAI adapter reads ONLY the namespaced key
+        // (getSecureKeyAsync(credentialKey("xai","api_key"))) — no legacy bare
+        // key or env fallback.
+        credentialLookup: "namespaced-only",
         displayName: "xAI API Key",
         setCommand:
           "assistant credentials set --service xai --field api_key <key>",

--- a/assistant/src/tts/tts-config-resolver.ts
+++ b/assistant/src/tts/tts-config-resolver.ts
@@ -51,6 +51,21 @@ export function resolveTtsConfig(config: AssistantConfig): ResolvedTtsConfig {
   return { provider, providerConfig };
 }
 
+/**
+ * Build the provider-specific config object for an explicit provider id from
+ * the canonical `services.tts.providers.<id>` block.
+ *
+ * Unlike {@link resolveTtsConfig}, this does NOT key off the active
+ * `services.tts.provider` — it lets callers inspect the config of any provider
+ * (e.g. a fallback default) regardless of which one is currently selected.
+ */
+export function resolveProviderTtsConfig(
+  config: AssistantConfig,
+  provider: TtsProviderId,
+): Record<string, unknown> {
+  return resolveProviderConfig(config, provider);
+}
+
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- fish-audio with empty referenceId is now NOT playable (was silently 'playable' → silence)
- resolvePlayableCallTtsProvider verifies the default is playable; surfaces a no-playable-provider signal instead of returning an unusable provider
- Addresses Codex P2 findings on #33473

Part of plan: migrate-phone-off-conversation-relay.md (PR 3 follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)