### PR TITLE
Show schedule provenance in scheduled chats

### DIFF
--- a/apps/web/src/domains/chat/components/chat-body.test.tsx
+++ b/apps/web/src/domains/chat/components/chat-body.test.tsx
@@ -25,7 +25,12 @@ import type { ChatBodyProps } from "@/domains/chat/components/chat-body";
 mock.module(
   "@/domains/chat/transcript/transcript",
   () => ({
-    Transcript: () => <div data-testid="transcript">TRANSCRIPT</div>,
+    Transcript: ({ topSlot }: { topSlot?: ReactNode }) => (
+      <>
+        {topSlot}
+        <div data-testid="transcript">TRANSCRIPT</div>
+      </>
+    ),
   }),
 );
 
@@ -217,6 +222,25 @@ describe("ChatBody — startersSlot rendering", () => {
     expect(html).not.toContain("STARTER_CHIPS");
   });
 
+});
+
+describe("ChatBody — transcript top slot", () => {
+  test("renders scrollAreaProps.topSlot above the transcript when messages exist", () => {
+    const html = renderToStaticMarkup(
+      <ChatBody
+        {...baseProps({
+          scrollAreaProps: {
+            ...baseProps().scrollAreaProps,
+            messageCount: 1,
+            topSlot: <div data-testid="top-slot">TOP_SLOT</div>,
+          },
+        })}
+      />,
+    );
+
+    expect(html).toContain("TOP_SLOT");
+    expect(html.indexOf("TOP_SLOT")).toBeLessThan(html.indexOf("TRANSCRIPT"));
+  });
 });
 
 describe("ChatBody — read-only cancellation", () => {

--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -40,6 +40,7 @@ import { QueuedMessagesDrawer } from "@/domains/chat/components/queued-messages-
 import { SecretPromptCard } from "@/domains/chat/components/secret-prompt-card";
 import { SendErrorModal } from "@/domains/chat/components/send-error-modal";
 import { SlackChannelFooter } from "@/domains/chat/components/slack-channel-footer";
+import { ScheduledConversationOriginBanner } from "@/domains/chat/components/scheduled-conversation-origin-banner";
 import { liveAssistantRowId } from "@/domains/chat/hooks/stream-message-updaters";
 import { useConversationStarters } from "@/domains/chat/hooks/use-conversation-starters";
 import { useEditMessage } from "@/domains/chat/hooks/use-edit-message";
@@ -1321,6 +1322,12 @@ export function ChatRouteContent({
     emptyStateProps: chatEmptyStateProps,
     transcriptRef,
     transcriptProps: chatTranscriptProps,
+    topSlot: (
+      <ScheduledConversationOriginBanner
+        assistantId={assistantId}
+        conversation={activeConversation ?? null}
+      />
+    ),
   };
 
   const mainBannerSlot = nudges.showBanner ? (

--- a/apps/web/src/domains/chat/components/chat-scroll-area.tsx
+++ b/apps/web/src/domains/chat/components/chat-scroll-area.tsx
@@ -1,4 +1,4 @@
-import { type ForwardedRef } from "react";
+import { type ForwardedRef, type ReactNode } from "react";
 
 import {
   Transcript,
@@ -57,6 +57,8 @@ export interface ChatScrollAreaProps {
   transcriptRef: ForwardedRef<TranscriptHandle>;
   /** {@link TranscriptProps} forwarded to {@link Transcript}. */
   transcriptProps: TranscriptProps;
+  /** Optional content rendered at the top of non-empty transcripts. */
+  topSlot?: ReactNode;
 }
 
 export function ChatScrollArea({
@@ -67,6 +69,7 @@ export function ChatScrollArea({
   emptyStateProps,
   transcriptRef,
   transcriptProps,
+  topSlot,
 }: ChatScrollAreaProps) {
   // When the empty state is shown, this wrapper must NOT take `flex-1` so
   // the parent `ChatBody` can center it together with the composer +
@@ -81,7 +84,9 @@ export function ChatScrollArea({
       {isLoadingHistory && messageCount === 0 && <ChatSkeleton />}
       {showMaintenanceRecoveryCard && <MaintenanceRecoveryCard />}
       {showEmptyState && <ChatEmptyState {...emptyStateProps} />}
-      {messageCount > 0 && <Transcript ref={transcriptRef} {...transcriptProps} />}
+      {messageCount > 0 && (
+        <Transcript ref={transcriptRef} {...transcriptProps} topSlot={topSlot} />
+      )}
     </div>
   );
 }

--- a/apps/web/src/domains/chat/components/scheduled-conversation-origin-banner.test.tsx
+++ b/apps/web/src/domains/chat/components/scheduled-conversation-origin-banner.test.tsx
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { createElement, type ReactElement } from "react";
+import { MemoryRouter } from "react-router";
+
+import { routes } from "@/utils/routes";
+
+import type { AssistantSchedule } from "@/utils/schedules";
+import type { Conversation } from "@/types/conversation-types";
+
+const fetchSchedulesMock = mock(
+  async (_assistantId: string): Promise<AssistantSchedule[]> => [],
+);
+
+mock.module("@/utils/schedules", () => ({
+  fetchSchedules: fetchSchedulesMock,
+  getOpenableScheduleSourceConversationId: (schedule: AssistantSchedule) =>
+    schedule.createdFromConversationId &&
+    schedule.createdFromConversationExists === true &&
+    schedule.createdFromConversationArchivedAt == null
+      ? schedule.createdFromConversationId
+      : null,
+}));
+
+const { ScheduledConversationOriginBanner } = await import(
+  "@/domains/chat/components/scheduled-conversation-origin-banner"
+);
+
+afterEach(() => {
+  cleanup();
+  fetchSchedulesMock.mockClear();
+});
+
+function renderWithProviders(element: ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+  return render(
+    createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      createElement(MemoryRouter, null, element),
+    ),
+  );
+}
+
+function scheduledConversation(
+  overrides: Partial<Conversation> = {},
+): Conversation {
+  return {
+    conversationId: "conv-run",
+    conversationType: "scheduled",
+    scheduleJobId: "schedule-1",
+    ...overrides,
+  };
+}
+
+function schedule(overrides: Partial<AssistantSchedule> = {}): AssistantSchedule {
+  return {
+    id: "schedule-1",
+    name: "Water reminder 6/10",
+    message: "💧 Sip #6.",
+    createdFromConversationId: "conv-source",
+    createdFromConversationExists: true,
+    createdFromConversationArchivedAt: null,
+    ...overrides,
+  } as AssistantSchedule;
+}
+
+describe("ScheduledConversationOriginBanner", () => {
+  test("shows the schedule prompt and original conversation link", async () => {
+    fetchSchedulesMock.mockResolvedValueOnce([schedule()]);
+
+    renderWithProviders(
+      <ScheduledConversationOriginBanner
+        assistantId="assistant-1"
+        conversation={scheduledConversation()}
+      />,
+    );
+
+    expect(fetchSchedulesMock).toHaveBeenCalledWith("assistant-1");
+    expect(await screen.findByText("Started by schedule")).toBeTruthy();
+    expect(screen.getByText("Water reminder 6/10")).toBeTruthy();
+    expect(screen.getByText("Prompt:")).toBeTruthy();
+    expect(screen.getByText("💧 Sip #6.")).toBeTruthy();
+
+    const link = screen.getByRole("link", { name: "Original conversation" });
+    expect(link.getAttribute("href")).toBe(routes.conversation("conv-source"));
+    const scheduleLink = screen.getByRole("link", { name: "Schedule" });
+    expect(scheduleLink.getAttribute("href")).toBe(
+      routes.settings.schedule("schedule-1"),
+    );
+  });
+
+  test("keeps scheduled conversations identifiable when schedule details are missing", async () => {
+    fetchSchedulesMock.mockResolvedValueOnce([]);
+
+    renderWithProviders(
+      <ScheduledConversationOriginBanner
+        assistantId="assistant-1"
+        conversation={scheduledConversation()}
+      />,
+    );
+
+    await waitFor(() => expect(fetchSchedulesMock).toHaveBeenCalledTimes(1));
+    expect(screen.getByText("Started by schedule")).toBeTruthy();
+    expect(screen.getByText("Schedule details unavailable")).toBeTruthy();
+    expect(screen.queryByRole("link", { name: "Original conversation" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "Schedule" })).toBeNull();
+  });
+
+  test("does not fetch or render for regular conversations", () => {
+    renderWithProviders(
+      <ScheduledConversationOriginBanner
+        assistantId="assistant-1"
+        conversation={scheduledConversation({
+          conversationType: "standard",
+          scheduleJobId: undefined,
+        })}
+      />,
+    );
+
+    expect(fetchSchedulesMock).not.toHaveBeenCalled();
+    expect(screen.queryByText("Started by schedule")).toBeNull();
+  });
+});

--- a/apps/web/src/domains/chat/components/scheduled-conversation-origin-banner.test.tsx
+++ b/apps/web/src/domains/chat/components/scheduled-conversation-origin-banner.test.tsx
@@ -12,6 +12,7 @@ import type { Conversation } from "@/types/conversation-types";
 const fetchSchedulesMock = mock(
   async (_assistantId: string): Promise<AssistantSchedule[]> => [],
 );
+let isOrgReady = true;
 
 mock.module("@/utils/schedules", () => ({
   fetchSchedules: fetchSchedulesMock,
@@ -23,6 +24,10 @@ mock.module("@/utils/schedules", () => ({
       : null,
 }));
 
+mock.module("@/hooks/use-is-org-ready", () => ({
+  useIsOrgReady: () => isOrgReady,
+}));
+
 const { ScheduledConversationOriginBanner } = await import(
   "@/domains/chat/components/scheduled-conversation-origin-banner"
 );
@@ -30,6 +35,7 @@ const { ScheduledConversationOriginBanner } = await import(
 afterEach(() => {
   cleanup();
   fetchSchedulesMock.mockClear();
+  isOrgReady = true;
 });
 
 function renderWithProviders(element: ReactElement) {
@@ -126,5 +132,20 @@ describe("ScheduledConversationOriginBanner", () => {
 
     expect(fetchSchedulesMock).not.toHaveBeenCalled();
     expect(screen.queryByText("Started by schedule")).toBeNull();
+  });
+
+  test("waits for org readiness before fetching schedule details", () => {
+    isOrgReady = false;
+
+    renderWithProviders(
+      <ScheduledConversationOriginBanner
+        assistantId="assistant-1"
+        conversation={scheduledConversation()}
+      />,
+    );
+
+    expect(fetchSchedulesMock).not.toHaveBeenCalled();
+    expect(screen.getByText("Started by schedule")).toBeTruthy();
+    expect(screen.getByText("Scheduled automation")).toBeTruthy();
   });
 });

--- a/apps/web/src/domains/chat/components/scheduled-conversation-origin-banner.tsx
+++ b/apps/web/src/domains/chat/components/scheduled-conversation-origin-banner.tsx
@@ -4,6 +4,7 @@ import { Link } from "react-router";
 
 import { Button } from "@vellumai/design-library/components/button";
 
+import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import { assistantSchedulesQueryKey } from "@/lib/sync/query-tags";
 import type { Conversation } from "@/types/conversation-types";
 import { isScheduledConversation } from "@/utils/conversation-predicates";
@@ -27,11 +28,12 @@ export function ScheduledConversationOriginBanner({
     conversation != null &&
     isScheduledConversation(conversation) &&
     scheduleJobId != null;
+  const isOrgReady = useIsOrgReady();
 
   const { data: schedules, isFetched } = useQuery({
     queryKey: assistantSchedulesQueryKey(assistantId),
     queryFn: () => fetchSchedules(assistantId!),
-    enabled: shouldRender && !!assistantId,
+    enabled: shouldRender && !!assistantId && isOrgReady,
     staleTime: 30_000,
   });
 

--- a/apps/web/src/domains/chat/components/scheduled-conversation-origin-banner.tsx
+++ b/apps/web/src/domains/chat/components/scheduled-conversation-origin-banner.tsx
@@ -1,0 +1,112 @@
+import { useQuery } from "@tanstack/react-query";
+import { CalendarClock, MessageSquare, Settings } from "lucide-react";
+import { Link } from "react-router";
+
+import { Button } from "@vellumai/design-library/components/button";
+
+import { assistantSchedulesQueryKey } from "@/lib/sync/query-tags";
+import type { Conversation } from "@/types/conversation-types";
+import { isScheduledConversation } from "@/utils/conversation-predicates";
+import { routes } from "@/utils/routes";
+import {
+  fetchSchedules,
+  getOpenableScheduleSourceConversationId,
+} from "@/utils/schedules";
+
+interface ScheduledConversationOriginBannerProps {
+  assistantId: string | null | undefined;
+  conversation: Conversation | null;
+}
+
+export function ScheduledConversationOriginBanner({
+  assistantId,
+  conversation,
+}: ScheduledConversationOriginBannerProps) {
+  const scheduleJobId = conversation?.scheduleJobId ?? null;
+  const shouldRender =
+    conversation != null &&
+    isScheduledConversation(conversation) &&
+    scheduleJobId != null;
+
+  const { data: schedules, isFetched } = useQuery({
+    queryKey: assistantSchedulesQueryKey(assistantId),
+    queryFn: () => fetchSchedules(assistantId!),
+    enabled: shouldRender && !!assistantId,
+    staleTime: 30_000,
+  });
+
+  if (!shouldRender) return null;
+
+  const schedule = schedules?.find((candidate) => candidate.id === scheduleJobId);
+  const hasResolvedMissingSchedule = isFetched && !schedule;
+  const title =
+    schedule?.name?.trim() ||
+    (hasResolvedMissingSchedule
+      ? "Schedule details unavailable"
+      : "Scheduled automation");
+  const prompt = schedule?.message?.trim() || null;
+  const sourceConversationId =
+    schedule ? getOpenableScheduleSourceConversationId(schedule) : null;
+  const showScheduleLink = !hasResolvedMissingSchedule;
+
+  return (
+    <div className="px-3 pt-4 pb-2 sm:px-6">
+      <section
+        aria-label="Scheduled conversation context"
+        className="mx-auto flex max-w-[var(--chat-max-width)] flex-col gap-3 rounded-lg border border-[var(--border-element)] bg-[var(--surface-lift)] px-3 py-3 text-body-small-default text-[var(--content-default)] sm:flex-row sm:items-start sm:justify-between"
+      >
+        <div className="flex min-w-0 gap-3">
+          <div className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-[var(--surface-active)] text-[var(--content-secondary)]">
+            <CalendarClock className="h-4 w-4" aria-hidden="true" />
+          </div>
+          <div className="min-w-0 space-y-1">
+            <div className="flex min-w-0 flex-wrap items-baseline gap-x-1.5 gap-y-0.5">
+              <span className="text-label-medium-default text-[var(--content-secondary)]">
+                Started by schedule
+              </span>
+              <span className="min-w-0 truncate text-label-medium-default text-[var(--content-default)]">
+                {title}
+              </span>
+            </div>
+            {prompt ? (
+              <p className="line-clamp-2 break-words text-[var(--content-secondary)]">
+                <span className="text-[var(--content-tertiary)]">Prompt:</span>{" "}
+                {prompt}
+              </p>
+            ) : hasResolvedMissingSchedule ? (
+              <p className="text-[var(--content-secondary)]">
+                The schedule that started this conversation is no longer available.
+              </p>
+            ) : null}
+          </div>
+        </div>
+        <div className="flex shrink-0 flex-wrap gap-2 sm:justify-end">
+          {sourceConversationId ? (
+            <Button
+              asChild
+              variant="outlined"
+              size="compact"
+            >
+              <Link to={routes.conversation(sourceConversationId)}>
+                <MessageSquare className="h-2.5 w-2.5" aria-hidden="true" />
+                Original conversation
+              </Link>
+            </Button>
+          ) : null}
+          {showScheduleLink ? (
+            <Button
+              asChild
+              variant="ghost"
+              size="compact"
+            >
+              <Link to={routes.settings.schedule(scheduleJobId)}>
+                <Settings className="h-2.5 w-2.5" aria-hidden="true" />
+                Schedule
+              </Link>
+            </Button>
+          ) : null}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/domains/chat/transcript/transcript.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript.tsx
@@ -38,6 +38,8 @@ export type RefreshOutcome =
 export interface TranscriptProps {
   items: TranscriptItem[];
   conversationId: string | null;
+  /** Optional content rendered before the first transcript row. */
+  topSlot?: ReactNode;
   assistantDisplayName?: string | null;
   onSecretSubmit: (requestId: string, value: string) => void;
   onConfirmationDecision: (requestId: string, decision: string) => void;
@@ -152,8 +154,14 @@ export interface TranscriptHandle {
 
 export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(
   function Transcript(props, ref) {
-    const { items, conversationId, onPullRefresh, pullRefreshEnabled, ...rest } =
-      props;
+    const {
+      items,
+      conversationId,
+      topSlot,
+      onPullRefresh,
+      pullRefreshEnabled,
+      ...rest
+    } = props;
     const scrollRef = useRef<HTMLDivElement | null>(null);
     const contentRef = useRef<HTMLDivElement | null>(null);
     const viewportMinHeight = useViewportMinHeight(scrollRef);
@@ -265,6 +273,7 @@ export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(
          *  streaming growth). Wrapping all rows in a single observed
          *  element is cheaper than observing each row individually. */}
         <div ref={contentRef} className="flex w-full flex-col">
+          {topSlot}
           {/* History items in chronological order — oldest at top. */}
           {partition.historyItems.map((item) => (
             <Fragment key={item.key}>

--- a/apps/web/src/domains/settings/pages/schedules-page.tsx
+++ b/apps/web/src/domains/settings/pages/schedules-page.tsx
@@ -37,6 +37,10 @@ import {
     assistantSchedulesQueryKey,
 } from "@/lib/sync/query-tags";
 import { routes } from "@/utils/routes";
+import {
+    canOpenScheduleSourceConversation,
+    getOpenableScheduleSourceConversationId,
+} from "@/utils/schedules";
 import { useEffectiveTimezone } from "@/utils/use-effective-timezone";
 import { Button } from "@vellumai/design-library/components/button";
 import { Input } from "@vellumai/design-library/components/input";
@@ -60,6 +64,8 @@ import type {
     HeartbeatConfigGetResponse,
 } from "@/generated/daemon/types.gen";
 import type { TagTone } from "@vellumai/design-library/components/tag";
+
+export { canOpenScheduleSourceConversation };
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -99,28 +105,12 @@ function formatScheduleRunCount(count: number): string {
   return `${formatted} ${count === 1 ? "run" : "runs"}`;
 }
 
-export function canOpenScheduleSourceConversation(schedule: Schedule): boolean {
-  return (
-    !!schedule.createdFromConversationId &&
-    schedule.createdFromConversationExists === true &&
-    schedule.createdFromConversationArchivedAt == null
-  );
-}
-
 export function canOpenScheduleRunConversation(run: ScheduleRun): boolean {
   return (
     !!run.conversationId &&
     run.conversationExists === true &&
     run.conversationArchivedAt == null
   );
-}
-
-function getOpenableScheduleSourceConversationId(
-  schedule: Schedule,
-): string | null {
-  return canOpenScheduleSourceConversation(schedule)
-    ? (schedule.createdFromConversationId ?? null)
-    : null;
 }
 
 function getOpenableScheduleRunConversationId(run: ScheduleRun): string | null {

--- a/apps/web/src/utils/schedules.ts
+++ b/apps/web/src/utils/schedules.ts
@@ -8,6 +8,30 @@ import {
 
 export type AssistantSchedule = SchedulesGetResponse["schedules"][number];
 
+export interface ScheduleSourceConversationFields {
+  createdFromConversationId?: string | null;
+  createdFromConversationExists?: boolean;
+  createdFromConversationArchivedAt?: number | null;
+}
+
+export function canOpenScheduleSourceConversation(
+  schedule: ScheduleSourceConversationFields,
+): boolean {
+  return (
+    !!schedule.createdFromConversationId &&
+    schedule.createdFromConversationExists === true &&
+    schedule.createdFromConversationArchivedAt == null
+  );
+}
+
+export function getOpenableScheduleSourceConversationId(
+  schedule: ScheduleSourceConversationFields,
+): string | null {
+  return canOpenScheduleSourceConversation(schedule)
+    ? (schedule.createdFromConversationId ?? null)
+    : null;
+}
+
 export async function fetchSchedules(
   assistantId: string,
 ): Promise<AssistantSchedule[]> {


### PR DESCRIPTION
## Summary
- Add a scheduled conversation banner at the top of non-empty transcripts showing the schedule name and prompt that started the thread.
- Link scheduled conversations back to the source conversation when the schedule has one, and to schedule settings while the schedule exists.
- Share the schedule source-conversation helper between chat and settings, with focused tests for the new banner and transcript top slot.

## Original prompt
The user noticed that conversations started by scheduled events look random and asked whether we could make it obvious what prompted the message and link back to where the schedule was created.