### PR TITLE
[codex] fix live voice velay auth proof

### DIFF
--- a/gateway/src/__tests__/live-voice-websocket.test.ts
+++ b/gateway/src/__tests__/live-voice-websocket.test.ts
@@ -18,6 +18,7 @@ import {
   getLiveVoiceWebsocketHandlers,
   type LiveVoiceSocketData,
 } from "../http/routes/live-voice-websocket.js";
+import { setVelayBridgeAuthHeader } from "../velay/bridge-auth.js";
 
 const TEST_SIGNING_KEY = Buffer.from("test-signing-key-at-least-32-bytes-long");
 initSigningKey(TEST_SIGNING_KEY);
@@ -269,9 +270,14 @@ describe("createLiveVoiceWebsocketHandler — velay-attested managed auth", () =
       "x-velay-org-id": VELAY_ORG_ID,
       "x-velay-actor": "user",
     },
+    opts: { bridgeAuth?: boolean } = {},
   ) {
+    const requestHeaders = new Headers({ upgrade: "websocket", ...headers });
+    if (opts.bridgeAuth !== false) {
+      setVelayBridgeAuthHeader(requestHeaders);
+    }
     return new Request("http://localhost:7830/v1/live-voice", {
-      headers: { upgrade: "websocket", ...headers },
+      headers: requestHeaders,
     });
   }
 
@@ -283,7 +289,7 @@ describe("createLiveVoiceWebsocketHandler — velay-attested managed auth", () =
     }
   });
 
-  test("managed mode + valid X-Velay-* headers authorizes the upgrade", () => {
+  test("managed mode + valid X-Velay-* headers with bridge proof authorizes the upgrade", () => {
     setPlatform(true);
     const handler = createLiveVoiceWebsocketHandler(makeConfig());
     const server = makeFakeServer();
@@ -291,6 +297,17 @@ describe("createLiveVoiceWebsocketHandler — velay-attested managed auth", () =
 
     expect(res).toBeUndefined();
     expect(server.upgrade).toHaveBeenCalledTimes(1);
+  });
+
+  test("managed mode + spoofed X-Velay-* headers without bridge proof is rejected", () => {
+    setPlatform(true);
+    const handler = createLiveVoiceWebsocketHandler(makeConfig());
+    const server = makeFakeServer();
+    const res = handler(makeVelayReq(undefined, { bridgeAuth: false }), server);
+
+    expect(res).toBeInstanceOf(Response);
+    expect(res!.status).toBe(401);
+    expect(server.upgrade).not.toHaveBeenCalled();
   });
 
   test("managed mode without velay headers and without actor JWT is rejected", () => {
@@ -342,7 +359,7 @@ describe("createLiveVoiceWebsocketHandler — velay-attested managed auth", () =
     expect(server.upgrade).not.toHaveBeenCalled();
   });
 
-  test("local mode does NOT trust client-supplied X-Velay-* headers", () => {
+  test("local mode does NOT trust X-Velay-* headers even with bridge proof", () => {
     setPlatform(false);
     const handler = createLiveVoiceWebsocketHandler(makeConfig());
     const server = makeFakeServer();

--- a/gateway/src/http/routes/live-voice-websocket.ts
+++ b/gateway/src/http/routes/live-voice-websocket.ts
@@ -8,6 +8,7 @@ import { isActorTokenRevoked } from "../../auth/actor-token-revocation.js";
 import { parseSub } from "../../auth/subject.js";
 import type { GatewayConfig } from "../../config.js";
 import { getLogger } from "../../logger.js";
+import { requestHasVelayBridgeAuth } from "../../velay/bridge-auth.js";
 
 const log = getLogger("live-voice-ws");
 
@@ -18,15 +19,12 @@ const MAX_PENDING_MESSAGES = 100;
 // Velay-attested managed auth headers
 // ---------------------------------------------------------------------------
 //
-// In managed/cloud deployments the only ingress is the velay tunnel. On a
-// validated `/v1/live-voice` upgrade, velay authenticates the browser's
-// wsToken against the platform, STRIPS any client-supplied copies of these
-// headers, and INJECTS trusted ones before forwarding the upgrade through the
-// tunnel to the gateway. A browser on a managed assistant cannot mint the
-// local actor edge JWT the self-hosted path requires, so the gateway trusts
-// this velay attestation INSTEAD — but only in managed mode, where velay is
-// the sole ingress. In self-hosted mode there is no velay to strip/inject
-// these headers, so they are never trusted (a client could spoof them).
+// In managed/cloud deployments, velay validates the browser's live-voice
+// wsToken, strips any client-supplied copies of these headers, and injects the
+// authenticated caller context into the tunnel frame. The gateway only trusts
+// that context when the loopback WebSocket open also carries the process-local
+// bridge proof injected by this gateway's VelayWebSocketBridge; IS_PLATFORM
+// alone is not a per-request proof that the caller traversed velay.
 const VELAY_USER_ID_HEADER = "x-velay-user-id";
 const VELAY_ORG_ID_HEADER = "x-velay-org-id";
 const VELAY_ACTOR_HEADER = "x-velay-actor";
@@ -115,18 +113,22 @@ function checkLiveVoiceAuth(
     return null;
   }
 
-  // Managed/cloud path: velay (the sole ingress) validates the browser wsToken
-  // and injects trusted X-Velay-* headers. We trust them ONLY in managed mode —
-  // a self-hosted gateway has no velay to strip client-supplied copies, so it
-  // must never honor these headers and instead requires the actor edge JWT.
+  // Managed/cloud path: velay validates the browser wsToken and injects
+  // X-Velay-* context into the tunnel frame. Trust it only when this request
+  // also has the process-local proof injected by the gateway's own loopback
+  // bridge. A direct request to a reachable gateway can spoof X-Velay-* names,
+  // but cannot know the bridge proof value.
   if (isPlatformManaged()) {
     const velayContext = extractVelayAttestedContext(req);
     if (velayContext) {
-      log.info(
-        { userId: velayContext.userId, orgId: velayContext.orgId },
-        "Live voice WS: authenticated via velay-attested managed context",
-      );
-      return null;
+      if (requestHasVelayBridgeAuth(req)) {
+        log.info(
+          { userId: velayContext.userId, orgId: velayContext.orgId },
+          "Live voice WS: authenticated via velay-attested managed context",
+        );
+        return null;
+      }
+      log.warn("Live voice WS: ignoring velay context without bridge proof");
     }
     // No (or incomplete) velay attestation — fall through to the actor-JWT
     // path below so a managed deployment still accepts a valid actor edge JWT.

--- a/gateway/src/log-redact.ts
+++ b/gateway/src/log-redact.ts
@@ -40,6 +40,7 @@ const SENSITIVE_HEADERS = new Set([
   "set-cookie",
   "x-api-key",
   "x-auth-token",
+  "x-vellum-velay-bridge-auth",
 ]);
 
 // ---------------------------------------------------------------------------

--- a/gateway/src/velay/bridge-auth.ts
+++ b/gateway/src/velay/bridge-auth.ts
@@ -1,0 +1,32 @@
+import { Buffer } from "node:buffer";
+import { randomBytes, timingSafeEqual } from "node:crypto";
+import type { OutgoingHttpHeaders } from "node:http";
+
+/**
+ * Process-local proof that a loopback request was opened by this gateway's
+ * Velay tunnel bridge. Direct callers can know the header name, but not the
+ * per-process value.
+ */
+export const VELAY_BRIDGE_AUTH_HEADER = "x-vellum-velay-bridge-auth" as const;
+
+const bridgeAuthValue = randomBytes(32).toString("base64url");
+
+export function addVelayBridgeAuthHeader(
+  headers: OutgoingHttpHeaders,
+): OutgoingHttpHeaders {
+  headers[VELAY_BRIDGE_AUTH_HEADER] = bridgeAuthValue;
+  return headers;
+}
+
+export function setVelayBridgeAuthHeader(headers: Headers): void {
+  headers.set(VELAY_BRIDGE_AUTH_HEADER, bridgeAuthValue);
+}
+
+export function requestHasVelayBridgeAuth(req: Request): boolean {
+  const value = req.headers.get(VELAY_BRIDGE_AUTH_HEADER);
+  if (!value) return false;
+
+  const actual = Buffer.from(value);
+  const expected = Buffer.from(bridgeAuthValue);
+  return actual.length === expected.length && timingSafeEqual(actual, expected);
+}

--- a/gateway/src/velay/bridge-utils.ts
+++ b/gateway/src/velay/bridge-utils.ts
@@ -6,8 +6,11 @@ import type { VelayHeaders } from "./protocol.js";
 
 const MAX_WEBSOCKET_CLOSE_REASON_BYTES = 123;
 
-
 const VELAY_ALLOWED_HTTP_PATH_PREFIXES = ["/webhooks/twilio/"] as const;
+const VELAY_ALLOWED_WEBSOCKET_EXACT_PATHS = [
+  "/v1/live-voice",
+  "/v1/stt/stream",
+] as const;
 
 /**
  * Injected unconditionally by the HTTP bridge on every request forwarded to
@@ -22,6 +25,15 @@ export const VELAY_FORWARDED_HEADER = "x-velay-forwarded" as const;
 export function isAllowedVelayHttpPath(path: string): boolean {
   return VELAY_ALLOWED_HTTP_PATH_PREFIXES.some((prefix) =>
     path.startsWith(prefix),
+  );
+}
+
+export function isAllowedVelayWebSocketPath(path: string): boolean {
+  return (
+    isAllowedVelayHttpPath(path) ||
+    VELAY_ALLOWED_WEBSOCKET_EXACT_PATHS.includes(
+      path as (typeof VELAY_ALLOWED_WEBSOCKET_EXACT_PATHS)[number],
+    )
   );
 }
 
@@ -63,8 +75,15 @@ export function buildLoopbackWebSocketUrl(
   path: string,
   rawQuery?: string,
 ): string | undefined {
-  const httpUrl = buildLoopbackHttpUrl(gatewayLoopbackBaseUrl, path, rawQuery);
-  if (!httpUrl) return undefined;
+  if (!isSafeOriginRelativePath(path) || !isAllowedVelayWebSocketPath(path)) {
+    return undefined;
+  }
+
+  const httpUrl = buildUpstreamUrl(
+    gatewayLoopbackBaseUrl,
+    path,
+    formatRawQuery(rawQuery),
+  );
 
   try {
     const url = new URL(httpUrl);

--- a/gateway/src/velay/websocket-bridge.test.ts
+++ b/gateway/src/velay/websocket-bridge.test.ts
@@ -1,6 +1,7 @@
 import { Buffer } from "node:buffer";
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { VELAY_BRIDGE_AUTH_HEADER } from "./bridge-auth.js";
 import {
   VELAY_FRAME_TYPES,
   VELAY_WEBSOCKET_MESSAGE_TYPES,
@@ -65,6 +66,7 @@ describe("VelayWebSocketBridge", () => {
           host: ["public.example.com"],
           "sec-websocket-key": ["client-key"],
           "x-twilio-signature": ["sig-123"],
+          [VELAY_BRIDGE_AUTH_HEADER]: ["spoofed"],
         },
         subprotocol: "twilio-relay",
       }),
@@ -84,6 +86,8 @@ describe("VelayWebSocketBridge", () => {
     expect(options.headers.authorization).toBe("Bearer edge-token");
     expect(options.headers.host).toBe("public.example.com");
     expect(options.headers["x-twilio-signature"]).toBe("sig-123");
+    expect(options.headers[VELAY_BRIDGE_AUTH_HEADER]).toBeString();
+    expect(options.headers[VELAY_BRIDGE_AUTH_HEADER]).not.toBe("spoofed");
     expect(options.headers.connection).toBeUndefined();
     expect(options.headers["sec-websocket-key"]).toBeUndefined();
 
@@ -334,6 +338,27 @@ describe("VelayWebSocketBridge", () => {
         reason: "Invalid WebSocket path",
       },
     ]);
+  });
+
+  test("allows live voice and STT websocket paths declared in the tunnel allowlist", () => {
+    bridge.open(
+      makeOpenFrame({ path: "/v1/live-voice", raw_query: "token=t" }),
+    );
+    bridge.open(
+      makeOpenFrame({
+        connection_id: "conn-stt",
+        path: "/v1/stt/stream",
+        raw_query: "token=t",
+      }),
+    );
+
+    expect(WebSocketMock).toHaveBeenCalledTimes(2);
+    expect((WebSocketMock.mock.calls[0] as [string])[0]).toBe(
+      "ws://127.0.0.1:7830/v1/live-voice?token=t",
+    );
+    expect((WebSocketMock.mock.calls[1] as [string])[0]).toBe(
+      "ws://127.0.0.1:7830/v1/stt/stream?token=t",
+    );
   });
 
   test("forwards local close frames back to Velay and cleans up", () => {

--- a/gateway/src/velay/websocket-bridge.ts
+++ b/gateway/src/velay/websocket-bridge.ts
@@ -1,5 +1,6 @@
 import type { OutgoingHttpHeaders } from "node:http";
 
+import { addVelayBridgeAuthHeader } from "./bridge-auth.js";
 import {
   binaryLikeToBytes,
   buildLoopbackWebSocketUrl,
@@ -85,7 +86,9 @@ export class VelayWebSocketBridge {
       const WebSocketWithHeaders =
         WebSocket as unknown as WebSocketConstructorWithHeaders;
       ws = new WebSocketWithHeaders(url, {
-        headers: websocketHeadersFromVelay(frame.headers),
+        headers: addVelayBridgeAuthHeader(
+          websocketHeadersFromVelay(frame.headers),
+        ),
         ...(frame.subprotocol ? { protocols: [frame.subprotocol] } : {}),
       });
     } catch {


### PR DESCRIPTION
## Summary

- Require a process-local Velay bridge proof before `/v1/live-voice` trusts managed-mode `X-Velay-*` caller context.
- Inject that proof from the gateway's own Velay WebSocket bridge and redact the proof header in logs.
- Add regression coverage for spoofed `X-Velay-*` headers without the bridge proof and for the live-voice/STT Velay WebSocket allowlist paths.

## Why

Codex finding: `27d69afc13dc8191b9dde0cced01e97e`

`IS_PLATFORM` is deployment state, not per-request proof that a live-voice upgrade traversed Velay. Before this change, a directly reachable managed gateway could accept spoofed `X-Velay-User-Id`, `X-Velay-Org-Id`, and `X-Velay-Actor: user` headers and proxy a live-voice socket to the runtime with a service token.

## Validation

- `cd gateway && bun test src/__tests__/live-voice-websocket.test.ts src/velay/websocket-bridge.test.ts src/velay/allowed-paths.test.ts`
- `cd gateway && bunx tsc --noEmit`
- Pre-commit/pre-push gateway lint hooks passed