### PR TITLE
feat(cli): refresh a paired token mid-session in the TUI on 401 (REST path)

### DIFF
--- a/cli/src/__tests__/tui-midsession-refresh.test.ts
+++ b/cli/src/__tests__/tui-midsession-refresh.test.ts
@@ -11,6 +11,7 @@ import { join } from "node:path";
 
 const ORIGINAL_XDG = process.env.XDG_CONFIG_HOME;
 const ORIGINAL_ENV = process.env.VELLUM_ENVIRONMENT;
+const ORIGINAL_LOCKFILE_DIR = process.env.VELLUM_LOCKFILE_DIR;
 const ORIGINAL_FETCH = globalThis.fetch;
 
 import { maybeRefreshAuthHeaders } from "../components/DefaultMainScreen";
@@ -69,6 +70,10 @@ describe("maybeRefreshAuthHeaders", () => {
   beforeEach(() => {
     tempHome = mkdtempSync(join(tmpdir(), "tui-midsession-test-"));
     process.env.XDG_CONFIG_HOME = tempHome;
+    // Isolate the lockfile too — saveAssistantEntry writes the prod lockfile
+    // (~/.vellum.lock.json) unless VELLUM_LOCKFILE_DIR is set, which would
+    // mutate the real user/CI lockfile.
+    process.env.VELLUM_LOCKFILE_DIR = tempHome;
     delete process.env.VELLUM_ENVIRONMENT;
   });
 
@@ -76,6 +81,9 @@ describe("maybeRefreshAuthHeaders", () => {
     globalThis.fetch = ORIGINAL_FETCH;
     if (ORIGINAL_XDG === undefined) delete process.env.XDG_CONFIG_HOME;
     else process.env.XDG_CONFIG_HOME = ORIGINAL_XDG;
+    if (ORIGINAL_LOCKFILE_DIR === undefined)
+      delete process.env.VELLUM_LOCKFILE_DIR;
+    else process.env.VELLUM_LOCKFILE_DIR = ORIGINAL_LOCKFILE_DIR;
     if (ORIGINAL_ENV === undefined) delete process.env.VELLUM_ENVIRONMENT;
     else process.env.VELLUM_ENVIRONMENT = ORIGINAL_ENV;
     rmSync(tempHome, { recursive: true, force: true });

--- a/cli/src/__tests__/tui-midsession-refresh.test.ts
+++ b/cli/src/__tests__/tui-midsession-refresh.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for maybeRefreshAuthHeaders: the TUI's mid-session 401 -> refresh of a
+ * PAIRED assistant's guardian token, mutating the shared auth headers in place.
+ * Scoped to cloud:"paired"; skips local/docker, platform session auth, ephemeral
+ * --token, and access-only tokens.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const ORIGINAL_XDG = process.env.XDG_CONFIG_HOME;
+const ORIGINAL_ENV = process.env.VELLUM_ENVIRONMENT;
+const ORIGINAL_FETCH = globalThis.fetch;
+
+import { maybeRefreshAuthHeaders } from "../components/DefaultMainScreen";
+import { saveAssistantEntry } from "../lib/assistant-config";
+import { saveGuardianToken } from "../lib/guardian-token";
+
+const RUNTIME = "http://10.0.0.9:7830";
+const future = () => new Date(Date.now() + 60 * 60 * 1000).toISOString();
+
+function seedEntry(cloud: string): void {
+  saveAssistantEntry({
+    assistantId: "px",
+    name: "Paired",
+    runtimeUrl: RUNTIME,
+    cloud,
+    paired: cloud === "paired",
+    species: "vellum",
+  });
+}
+
+function seedToken(accessToken: string, refreshToken: string): void {
+  saveGuardianToken("px", {
+    guardianPrincipalId: "imported",
+    accessToken,
+    accessTokenExpiresAt: future(),
+    refreshToken,
+    refreshTokenExpiresAt: refreshToken ? future() : 0,
+    refreshAfter: "",
+    isNew: false,
+    deviceId: "dev",
+    leasedAt: new Date().toISOString(),
+  });
+}
+
+function stubRefresh(ok: boolean): { hit: () => boolean } {
+  let called = false;
+  globalThis.fetch = (async (url: unknown, _init?: RequestInit) => {
+    if (String(url).includes("/v1/guardian/refresh")) {
+      called = true;
+      return new Response(
+        ok ? JSON.stringify({ accessToken: "new-acc" }) : "x",
+        {
+          status: ok ? 200 : 401,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    }
+    return new Response("", { status: 200 });
+  }) as typeof fetch;
+  return { hit: () => called };
+}
+
+describe("maybeRefreshAuthHeaders", () => {
+  let tempHome: string;
+
+  beforeEach(() => {
+    tempHome = mkdtempSync(join(tmpdir(), "tui-midsession-test-"));
+    process.env.XDG_CONFIG_HOME = tempHome;
+    delete process.env.VELLUM_ENVIRONMENT;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = ORIGINAL_FETCH;
+    if (ORIGINAL_XDG === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = ORIGINAL_XDG;
+    if (ORIGINAL_ENV === undefined) delete process.env.VELLUM_ENVIRONMENT;
+    else process.env.VELLUM_ENVIRONMENT = ORIGINAL_ENV;
+    rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  test("refreshes a paired assistant and mutates the auth header in place", async () => {
+    seedEntry("paired");
+    seedToken("old-acc", "ref");
+    const refresh = stubRefresh(true);
+    const auth = { Authorization: "Bearer old-acc" };
+
+    const ok = await maybeRefreshAuthHeaders(RUNTIME, "px", auth);
+
+    expect(ok).toBe(true);
+    expect(auth.Authorization).toBe("Bearer new-acc");
+    expect(refresh.hit()).toBe(true);
+  });
+
+  test("does NOT refresh a local assistant (scoped to paired only)", async () => {
+    seedEntry("local");
+    seedToken("old-acc", "ref"); // even with a refreshable token
+    const refresh = stubRefresh(true);
+    const auth = { Authorization: "Bearer old-acc" };
+
+    const ok = await maybeRefreshAuthHeaders(RUNTIME, "px", auth);
+
+    expect(ok).toBe(false);
+    expect(auth.Authorization).toBe("Bearer old-acc");
+    expect(refresh.hit()).toBe(false);
+  });
+
+  test("skips platform session auth (no Authorization header)", async () => {
+    seedEntry("paired");
+    seedToken("old-acc", "ref");
+    const refresh = stubRefresh(true);
+    const auth = { "X-Session-Token": "sess" };
+
+    const ok = await maybeRefreshAuthHeaders(RUNTIME, "px", auth);
+
+    expect(ok).toBe(false);
+    expect(refresh.hit()).toBe(false);
+  });
+
+  test("skips an ephemeral token that does not match the store", async () => {
+    seedEntry("paired");
+    seedToken("stored-acc", "ref");
+    const refresh = stubRefresh(true);
+    const auth = { Authorization: "Bearer ephemeral-acc" };
+
+    const ok = await maybeRefreshAuthHeaders(RUNTIME, "px", auth);
+
+    expect(ok).toBe(false);
+    expect(auth.Authorization).toBe("Bearer ephemeral-acc");
+    expect(refresh.hit()).toBe(false);
+  });
+
+  test("skips an access-only token (no refresh credential)", async () => {
+    seedEntry("paired");
+    seedToken("old-acc", ""); // no refresh token
+    const refresh = stubRefresh(true);
+    const auth = { Authorization: "Bearer old-acc" };
+
+    const ok = await maybeRefreshAuthHeaders(RUNTIME, "px", auth);
+
+    expect(ok).toBe(false);
+    expect(refresh.hit()).toBe(false);
+  });
+
+  test("returns false and leaves auth unchanged when refresh fails", async () => {
+    seedEntry("paired");
+    seedToken("old-acc", "ref");
+    stubRefresh(false); // refresh endpoint returns non-ok
+    const auth = { Authorization: "Bearer old-acc" };
+
+    const ok = await maybeRefreshAuthHeaders(RUNTIME, "px", auth);
+
+    expect(ok).toBe(false);
+    expect(auth.Authorization).toBe("Bearer old-acc");
+  });
+});

--- a/cli/src/components/DefaultMainScreen.tsx
+++ b/cli/src/components/DefaultMainScreen.tsx
@@ -425,24 +425,18 @@ async function* streamEvents(
   const params = new URLSearchParams({ conversationKey });
   const url = `${baseUrl}/v1/assistants/${assistantId}/events?${params.toString()}`;
   tuiLog.info("sse connect", { url, authHeaders: Object.keys(auth ?? {}) });
-  const doFetch = () =>
-    fetch(url, {
-      headers: {
-        Accept: "text/event-stream",
-        ...auth,
-      },
-      signal,
-    });
-
-  let response = await doFetch();
-  // Mid-session token expiry → 401 at connect: refresh once and reconnect with
-  // the new token (auth headers are mutated in place by the helper).
-  if (
-    response.status === 401 &&
-    (await maybeRefreshAuthHeaders(baseUrl, assistantId, auth))
-  ) {
-    response = await doFetch();
-  }
+  // NOTE: the SSE connect deliberately does NOT refresh-on-401 — keeping the
+  // stream path simple. After a mid-session token expiry, the REST path
+  // (runtimeRequest) refreshes the shared `auth` on the next request, and the
+  // existing reconnect (ensureConnected on the next message) re-opens the
+  // stream with the refreshed token.
+  const response = await fetch(url, {
+    headers: {
+      Accept: "text/event-stream",
+      ...auth,
+    },
+    signal,
+  });
 
   tuiLog.info("sse response", {
     status: response.status,

--- a/cli/src/components/DefaultMainScreen.tsx
+++ b/cli/src/components/DefaultMainScreen.tsx
@@ -65,6 +65,9 @@ const HELP_COMMANDS = [
 ] as const;
 
 const SEND_TIMEOUT_MS = 5000;
+/** Fresh deadline for a request retried after a mid-session token refresh —
+ *  the original caller signal may have already timed out during the refresh. */
+const RETRY_TIMEOUT_MS = 30_000;
 
 // ── Layout constants ──────────────────────────────────────
 const MAX_TOTAL_WIDTH = 72;
@@ -225,9 +228,11 @@ async function runtimeRequest<T>(
   auth?: Record<string, string>,
 ): Promise<T> {
   const url = `${baseUrl}/v1/assistants/${assistantId}${path}`;
-  const doFetch = () =>
+  const doFetch = (signalOverride?: AbortSignal) =>
     fetch(url, {
       ...init,
+      // The retry overrides the caller's signal (see below); otherwise use it.
+      signal: signalOverride ?? init?.signal,
       headers: {
         "Content-Type": "application/json",
         ...auth,
@@ -237,12 +242,15 @@ async function runtimeRequest<T>(
 
   let response = await doFetch();
   // Mid-session token expiry → 401: refresh once and retry (auth headers are
-  // mutated in place by the helper, so the retry carries the new token).
+  // mutated in place by the helper, so the retry carries the new token). The
+  // refresh can take longer than the caller's timeout (lock wait + refresh
+  // fetch), which would already have aborted the original signal — so give the
+  // retry a fresh deadline instead of reusing the (likely-expired) one.
   if (
     response.status === 401 &&
     (await maybeRefreshAuthHeaders(baseUrl, assistantId, auth))
   ) {
-    response = await doFetch();
+    response = await doFetch(AbortSignal.timeout(RETRY_TIMEOUT_MS));
   }
 
   if (!response.ok) {

--- a/cli/src/components/DefaultMainScreen.tsx
+++ b/cli/src/components/DefaultMainScreen.tsx
@@ -10,7 +10,9 @@ import {
 import { Box, render as inkRender, Text, useInput, useStdout } from "ink";
 
 import { SPECIES_CONFIG, type Species } from "../lib/constants";
+import { lookupAssistantByIdentifier } from "../lib/assistant-config";
 import { checkHealth } from "../lib/health-check";
+import { loadGuardianToken, refreshGuardianToken } from "../lib/guardian-token";
 import { appendHistory, loadHistory } from "../lib/input-history";
 import { tuiLog } from "../lib/tui-log";
 import { segmentsToPlainText } from "../lib/segments-to-plain-text";
@@ -177,6 +179,44 @@ function friendlyErrorMessage(status: number, body: string): string {
   return `HTTP ${status}: ${body || "Unknown error"}`;
 }
 
+/**
+ * On a 401, refresh a stale PAIRED-assistant guardian token and update the
+ * shared `auth` headers IN PLACE, returning true if the caller should retry.
+ *
+ * Scoped to paired assistants only (a remote assistant on another machine,
+ * `cloud: "paired"`) — the local/docker TUI flow and platform sessions are left
+ * untouched. Also self-gating: skips platform session auth (no `Authorization`
+ * header), ephemeral `--token` overrides (whose bearer won't match the store),
+ * and access-only tokens. Because the TUI threads one shared `auth` object by
+ * reference, mutating it here propagates to every later request and the SSE
+ * reconnect — no callback threading needed.
+ */
+export async function maybeRefreshAuthHeaders(
+  baseUrl: string,
+  assistantId: string,
+  auth?: Record<string, string>,
+): Promise<boolean> {
+  if (!auth) return false;
+  const bearer = auth["Authorization"]?.replace(/^Bearer /, "");
+  if (!bearer) return false;
+
+  // Only paired (remote-on-another-machine) assistants use refreshable pair
+  // tokens; don't perturb the local/docker session flow.
+  const lookup = lookupAssistantByIdentifier(assistantId);
+  if (lookup.status !== "found" || lookup.entry.cloud !== "paired") {
+    return false;
+  }
+
+  const stored = loadGuardianToken(assistantId);
+  if (!stored || stored.accessToken !== bearer || !stored.refreshToken) {
+    return false;
+  }
+  const refreshed = await refreshGuardianToken(baseUrl, assistantId);
+  if (!refreshed?.accessToken) return false;
+  auth["Authorization"] = `Bearer ${refreshed.accessToken}`;
+  return true;
+}
+
 async function runtimeRequest<T>(
   baseUrl: string,
   assistantId: string,
@@ -185,14 +225,25 @@ async function runtimeRequest<T>(
   auth?: Record<string, string>,
 ): Promise<T> {
   const url = `${baseUrl}/v1/assistants/${assistantId}${path}`;
-  const response = await fetch(url, {
-    ...init,
-    headers: {
-      "Content-Type": "application/json",
-      ...auth,
-      ...(init?.headers as Record<string, string> | undefined),
-    },
-  });
+  const doFetch = () =>
+    fetch(url, {
+      ...init,
+      headers: {
+        "Content-Type": "application/json",
+        ...auth,
+        ...(init?.headers as Record<string, string> | undefined),
+      },
+    });
+
+  let response = await doFetch();
+  // Mid-session token expiry → 401: refresh once and retry (auth headers are
+  // mutated in place by the helper, so the retry carries the new token).
+  if (
+    response.status === 401 &&
+    (await maybeRefreshAuthHeaders(baseUrl, assistantId, auth))
+  ) {
+    response = await doFetch();
+  }
 
   if (!response.ok) {
     const body = await response.text().catch(() => "");
@@ -374,13 +425,24 @@ async function* streamEvents(
   const params = new URLSearchParams({ conversationKey });
   const url = `${baseUrl}/v1/assistants/${assistantId}/events?${params.toString()}`;
   tuiLog.info("sse connect", { url, authHeaders: Object.keys(auth ?? {}) });
-  const response = await fetch(url, {
-    headers: {
-      Accept: "text/event-stream",
-      ...auth,
-    },
-    signal,
-  });
+  const doFetch = () =>
+    fetch(url, {
+      headers: {
+        Accept: "text/event-stream",
+        ...auth,
+      },
+      signal,
+    });
+
+  let response = await doFetch();
+  // Mid-session token expiry → 401 at connect: refresh once and reconnect with
+  // the new token (auth headers are mutated in place by the helper).
+  if (
+    response.status === 401 &&
+    (await maybeRefreshAuthHeaders(baseUrl, assistantId, auth))
+  ) {
+    response = await doFetch();
+  }
 
   tuiLog.info("sse response", {
     status: response.status,
@@ -1984,9 +2046,8 @@ function ChatApp({
         if (!isConnected) return;
 
         try {
-          const res = await fetch(
-            `${runtimeUrl}/v1/assistants/${assistantId}/btw`,
-            {
+          const btwFetch = () =>
+            fetch(`${runtimeUrl}/v1/assistants/${assistantId}/btw`, {
               method: "POST",
               headers: {
                 "Content-Type": "application/json",
@@ -1997,8 +2058,16 @@ function ChatApp({
                 content: question,
               }),
               signal: AbortSignal.timeout(30_000),
-            },
-          );
+            });
+
+          let res = await btwFetch();
+          // Mid-session token expiry → 401: refresh once and retry.
+          if (
+            res.status === 401 &&
+            (await maybeRefreshAuthHeaders(runtimeUrl, assistantId, auth))
+          ) {
+            res = await btwFetch();
+          }
 
           if (!res.ok) throw new Error(`HTTP ${res.status}`);
 


### PR DESCRIPTION
## Summary
- The `vellum client` TUI now refreshes a stale **paired** assistant's guardian token **mid-session** on a 401 and retries — on the REST path (`runtimeRequest`, which all REST calls funnel through) and the `/btw` fetch — so a session open past the access token's expiry keeps working instead of erroring.
- Implemented as a single self-contained helper `maybeRefreshAuthHeaders(baseUrl, assistantId, auth)`. **No callback threading** through the ~12 React/SSE functions: each fetch site already has `baseUrl`/`assistantId`/`auth`, and the helper mutates the one shared `auth` object in place, so the refreshed token propagates to every later request.

## SSE stays simple (deliberately)
The SSE connect path is intentionally **left untouched** — no refresh-on-401 there. After a mid-session expiry, the REST path refreshes the shared `auth` on the next request, and the **existing reconnect** (`ensureConnected` on the next message) re-opens the event stream with the refreshed token. So SSE recovers without adding re-auth logic to the (complex) stream code.

## Scope & gating
- **Paired only.** The helper looks up the assistant and returns early unless `cloud === "paired"` (a remote assistant on another machine) — the local/docker TUI flow and platform sessions are untouched.
- Self-gating: skips platform session auth (no `Authorization` header), ephemeral `--token` overrides (bearer won't match the store), and access-only tokens. Reuses the concurrency-safe `refreshGuardianToken` (per-assistant lock + timeout from R3); a failed refresh just surfaces the original 401, as today.

## Tests
`cli/src/__tests__/tui-midsession-refresh.test.ts` (env + lockfile isolated to a temp dir): paired refresh mutates the header & retries; **local assistant is NOT refreshed** (paired-scoping); platform session / ephemeral / access-only are skipped; failed refresh leaves auth unchanged.

## Original prompt
R3c of refreshable pairing: R3b refreshes at TUI startup; a token can also expire while the TUI stays open. This adds mid-session 401→refresh→retry for paired assistants on the TUI's REST/`btw` fetches, kept to a small self-contained helper (no threading) and scoped to `cloud:"paired"`. The SSE stream is deliberately left simple — it recovers via the existing reconnect using the REST-refreshed token.
