### PR TITLE
feat(design-library): make the package npm-publishable (tsc build, exports→dist)

### DIFF
--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -16,7 +16,9 @@
     "isolatedModules": true,
     "types": ["bun"],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@vellumai/design-library": ["./node_modules/@vellumai/design-library/src/index.ts"],
+      "@vellumai/design-library/*": ["./node_modules/@vellumai/design-library/src/*"]
     }
   },
   "include": [

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -105,6 +105,13 @@ export default defineConfig(({ mode }) => {
     resolve: {
       alias: [
         {
+          // Resolve the design library to its source via the node_modules
+          // symlink — the same module paths as the old exports-to-src route —
+          // so the package's exports can point at dist for npm consumers.
+          find: "@vellumai/design-library",
+          replacement: DESIGN_LIBRARY_SYMLINK,
+        },
+        {
           find: /^@\//,
           replacement: path.resolve(import.meta.dirname, "src") + "/",
         },

--- a/packages/design-library/package.json
+++ b/packages/design-library/package.json
@@ -19,6 +19,7 @@
   "scripts": {
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
+    "build": "rm -rf dist && tsc -p tsconfig.build.json && cp src/tokens.css dist/tokens.css",
     "test": "vitest",
     "typecheck": "bunx tsc --noEmit"
   },

--- a/packages/design-library/package.json
+++ b/packages/design-library/package.json
@@ -4,16 +4,18 @@
   "private": true,
   "license": "MIT",
   "type": "module",
-  "files": ["src/"],
+  "files": ["dist/", "src/", "!src/**/*.stories.*", "!src/**/*.test.*", "!src/introduction.mdx"],
   "exports": {
-    ".": "./src/index.ts",
-    "./tokens.css": "./src/tokens.css",
-    "./components/*": "./src/components/*.tsx",
-    "./components/panel-item": "./src/components/panel-item/panel-item.tsx",
-    "./components/panel-item/marquee-text": "./src/components/panel-item/marquee-text.tsx",
-    "./components/side-menu": "./src/components/side-menu/side-menu.tsx",
-    "./utils/*": "./src/utils/*.ts",
-    "./utils/portal-container": "./src/utils/portal-container.tsx"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./tokens.css": "./dist/tokens.css",
+    "./components/*": "./dist/components/*.js",
+    "./components/panel-item": "./dist/components/panel-item/panel-item.js",
+    "./components/panel-item/marquee-text": "./dist/components/panel-item/marquee-text.js",
+    "./components/side-menu": "./dist/components/side-menu/side-menu.js",
+    "./utils/*": "./dist/utils/*.js"
   },
   "trustedDependencies": ["@playwright/browser-chromium"],
   "scripts": {

--- a/packages/design-library/src/components/panel-item/index.ts
+++ b/packages/design-library/src/components/panel-item/index.ts
@@ -1,0 +1,1 @@
+export * from "./panel-item";

--- a/packages/design-library/src/components/side-menu/index.ts
+++ b/packages/design-library/src/components/side-menu/index.ts
@@ -1,0 +1,1 @@
+export * from "./side-menu";

--- a/packages/design-library/src/css.d.ts
+++ b/packages/design-library/src/css.d.ts
@@ -1,0 +1,4 @@
+// Side-effect CSS imports (e.g. `import "katex/dist/katex.min.css"`) carry no
+// types; declare them so tsc accepts the import and emits it for the consumer's
+// bundler to resolve.
+declare module "*.css";

--- a/packages/design-library/tsconfig.build.json
+++ b/packages/design-library/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": []
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["node_modules", "src/**/*.stories.*", "src/**/*.test.ts", "src/**/*.test.tsx"]
+}


### PR DESCRIPTION
ref ATL-789

Makes `@vellumai/design-library` installable by external consumers while web keeps compiling its source.

- **tsc build → `dist/`** — per-module ESM + `.d.ts` + `tokens.css`; no bundler, so peer deps stay external by construction
- **index barrels** for `panel-item`/`side-menu`, letting directory imports resolve by convention (no special-case mappings downstream)
- **web: one tsconfig `paths` pair + one Vite alias** resolving the library to the same node_modules source path it already used — web never consults `exports`. Verified: typecheck error set identical before/after
- **`exports`/`files` → `dist`** — `src/` ships for sourcemap resolution, stories/tests excluded; `private: true` stays until the release workflow lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Separately, we should really fix the hacky installation of `design-library` in web