### PR TITLE
ci(web): build + publish web Storybook to storybook bucket on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1448,6 +1448,113 @@ jobs:
           fi
           npm publish --access public --no-provenance
 
+  # Builds the web Storybook and publishes it to the storybook GCS bucket on a
+  # real production release (same needs/if gating as publish-web). Split into an
+  # unprivileged build half and a privileged deploy half so the build code never
+  # shares a runner with the GCP OIDC credentials, mirroring deploy-web-spa.yaml.
+  #
+  # Intentionally NOT a dependency of the final `release` gate: a Storybook
+  # upload failure must not fail the product release.
+  build-web-storybook:
+    needs: [extract-version, ci-cli, ci-gateway, ci-playwright, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image]
+    if: ${{ always() && !cancelled() && needs.extract-version.outputs.is_staging != 'true' && needs.ci-cli.result == 'success' && needs.ci-gateway.result == 'success' && (needs.ci-playwright.result == 'success' || inputs.playwright_blocks_release != true) && needs.push-assistant-manifest.result == 'success' && needs.push-gateway-manifest.result == 'success' && needs.push-credential-executor-manifest.result == 'success' && needs.push-dockerhub-image.result == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: '1.3.11'
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: .nvmrc
+          registry-url: https://registry.npmjs.org
+
+      - name: Install design-library dependencies
+        working-directory: packages/design-library
+        run: bun install --frozen-lockfile
+
+      - name: Install web dependencies
+        working-directory: apps/web
+        run: |
+          if ! bun install --frozen-lockfile; then
+            echo "bun install --frozen-lockfile failed; regenerating lockfile and retrying..."
+            rm -f bun.lock
+            rm -rf node_modules
+            bun install
+          fi
+
+      - name: Generate API clients
+        working-directory: apps/web
+        run: bun run openapi-ts
+
+      # apps/web's vite.config.ts imports vite-plugin-local-mode, which pulls in
+      # @vellumai/local-mode and its transitive @vellumai/environments file: dep.
+      # Both must have their own node_modules so the config loads at build time.
+      - name: Install shared packages
+        uses: ./.github/actions/install-shared-packages
+        with:
+          packages: packages/environments packages/local-mode
+
+      - name: Build Storybook
+        working-directory: apps/web
+        env:
+          STORYBOOK_BASE_PATH: /web/latest/
+        run: bun run build-storybook
+
+      - name: Generate versions.json
+        run: |
+          VERSION=$(node -p "require('./apps/web/package.json').version")
+          mkdir -p web
+          printf '{"versions":["latest"],"latest":"%s"}\n' "$VERSION" > web/versions.json
+
+      - name: Upload Storybook artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: web-storybook
+          path: |
+            apps/web/storybook-static
+            web/versions.json
+          if-no-files-found: error
+
+  deploy-web-storybook:
+    needs: [build-web-storybook]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: production
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download Storybook artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: web-storybook
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+
+      # No --cache-control: caching is owned by the serving layer (LB/Cloud CDN),
+      # not the upload. --delete-unmatched-destination-objects keeps web/latest
+      # clean across rebuilds (prunes stale hashed chunks). versions.json lives at
+      # a separate prefix so the rsync prune never touches it.
+      - name: Publish Storybook to GCS
+        env:
+          PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+          BUCKET="${PROJECT_ID}-assistant-storybook"
+          gcloud storage rsync -r --delete-unmatched-destination-objects \
+            storybook-static "gs://${BUCKET}/web/latest"
+          gcloud storage cp web/versions.json "gs://${BUCKET}/web/versions.json"
+
   publish-meta:
     needs: [extract-version, publish-npm, publish-web]
     if: ${{ needs.extract-version.outputs.is_staging != 'true' }}

--- a/apps/web/.storybook/main.ts
+++ b/apps/web/.storybook/main.ts
@@ -39,6 +39,7 @@ export default defineMain({
       ],
       preserveSymlinks: true,
     };
+    config.base = process.env.STORYBOOK_BASE_PATH ?? config.base;
     return config;
   },
 });


### PR DESCRIPTION
Builds the web Storybook on a real production release (`base=/web/latest/`) and publishes it to the storybook GCS bucket (`${PROJECT_ID}-assistant-storybook/web/latest`), plus a `web/versions.json`.

- New `build-web-storybook` (unprivileged) + `deploy-web-storybook` (`environment: production`, `id-token: write`) jobs in `release.yml`, mirroring the build/deploy trust split in `deploy-web-spa.yaml`. Build holds no cloud creds; only deploy has the GCP OIDC token.
- Same `needs`/`if` gating as `publish-web`, so it only runs on a non-staging production release.
- Not added to the final `release` gate's `needs` — a Storybook upload failure must not fail the product release.
- No `--cache-control` on the uploads; caching is the LB/CDN's job.
- `apps/web/.storybook/main.ts` honors `STORYBOOK_BASE_PATH` (local dev unaffected when unset).

The storybook GCS bucket + IAM already exist (platform-repo PR merged). This PR does not block the product release.