### PR TITLE
feat(calls): implement DTMF/speech verification sub-flows in call-setup-flow

### DIFF
--- a/assistant/src/__tests__/call-setup-flow-verification.test.ts
+++ b/assistant/src/__tests__/call-setup-flow-verification.test.ts
@@ -96,7 +96,10 @@ import type {
   SetupOutcome,
   SetupResolved,
 } from "../calls/relay-setup-router.js";
-import type { ActorTrustContext } from "../runtime/actor-trust-resolver.js";
+import type {
+  ActorTrustContext,
+  ResolveActorTrustInput,
+} from "../runtime/actor-trust-resolver.js";
 
 // ── Test doubles ─────────────────────────────────────────────────────
 
@@ -116,7 +119,10 @@ function makeTransport() {
   return { transport, calls };
 }
 
-function makeDeps(session: SetupFlowSession | null) {
+function makeDeps(
+  session: SetupFlowSession | null,
+  overrides: Partial<CallSetupFlowDeps> = {},
+) {
   const completed: SetupFlowResult[] = [];
   const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
   const spoken: string[] = [];
@@ -159,6 +165,7 @@ function makeDeps(session: SetupFlowSession | null) {
     schedule(fn, delayMs) {
       scheduled.push({ fn, delayMs });
     },
+    ...overrides,
   };
   return {
     deps,
@@ -455,5 +462,107 @@ describe("CallSetupFlow verification sub-flows", () => {
       },
     ]);
     expect(ctx.scheduled).toHaveLength(1);
+  });
+
+  // ── Post-verification trust re-resolution (Finding 1) ──────────────
+
+  test("inbound guardian: trust is re-resolved after success (not stale)", async () => {
+    const transport = makeTransport();
+    // Mocked resolveActorTrust returns an UPGRADED trust context, simulating
+    // the binding that only exists once the code has been consumed.
+    const resolveActorTrustArgs: ResolveActorTrustInput[] = [];
+    const resolveActorTrust = (input: ResolveActorTrustInput) => {
+      resolveActorTrustArgs.push(input);
+      return { trustClass: "guardian" } as unknown as ActorTrustContext;
+    };
+    const ctx = makeDeps(SESSION, { resolveActorTrust });
+    const flow = new CallSetupFlow("call_1", transport.transport, ctx.deps);
+
+    // Pre-verification (stale) trust is `unknown` — the caller is not yet bound.
+    const staleResolved: SetupResolved = {
+      assistantId: "asst_test",
+      isInbound: true,
+      otherPartyNumber: "+15550100",
+      actorTrust: { trustClass: "unknown" } as unknown as ActorTrustContext,
+    };
+
+    const started = flow.start(
+      {
+        action: "verification",
+        assistantId: "asst_test",
+        fromNumber: "+15550100",
+      },
+      staleResolved,
+    );
+    verificationOutcomes.push({
+      outcome: "success",
+      verificationType: "guardian",
+      eventName: "voice_verification_succeeded",
+    });
+    pushDigits(flow, "123456");
+
+    const result = await started;
+    expect(result.kind).toBe("proceed-initial-greeting");
+    // The dep was consulted with the verified party's number.
+    expect(resolveActorTrustArgs).toHaveLength(1);
+    expect(resolveActorTrustArgs[0]).toMatchObject({
+      assistantId: "asst_test",
+      sourceChannel: "phone",
+      conversationExternalId: "+15550100",
+      actorExternalId: "+15550100",
+    });
+    // The result carries the RECOMPUTED trust (guardian), not the stale unknown.
+    if (result.kind === "proceed-initial-greeting") {
+      expect(result.trustContext).toMatchObject({ trustClass: "guardian" });
+    }
+  });
+
+  // ── Race: completion delivered during code-post await (Finding 2) ───
+
+  test("callee: digit completion during code-post await still resolves start()", async () => {
+    const transport = makeTransport();
+
+    // A code-post that never settles until we release it — simulating an
+    // in-flight side effect during which the callee enters the code.
+    let releaseCodePost!: () => void;
+    const codePostGate = new Promise<void>((resolve) => {
+      releaseCodePost = resolve;
+    });
+    const codePosts: Array<{ code: string }> = [];
+
+    const ctx = makeDeps(SESSION, {
+      async postCalleeVerificationCode(_conversationId, _toNumber, code) {
+        codePosts.push({ code });
+        await codePostGate;
+      },
+    });
+    const flow = new CallSetupFlow("call_1", transport.transport, ctx.deps);
+
+    const started = flow.start(
+      {
+        action: "callee_verification",
+        verificationConfig: { maxAttempts: 3, codeLength: 4 },
+      },
+      RESOLVED,
+    );
+
+    // Let the synchronous setup + the (awaited) TTS settle so we're parked on
+    // the code-post await with the resolver already installed.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(flow.getState()).toBe("collecting_code");
+    expect(codePosts).toHaveLength(1);
+
+    // Callee enters the correct code WHILE the code-post await is still pending.
+    pushDigits(flow, codePosts[0]!.code);
+
+    // The completion must not be dropped: start() resolves even though the
+    // code-post promise is still in flight.
+    const result = await started;
+    expect(result.kind).toBe("proceed-initial-greeting");
+
+    // Releasing the stalled side effect afterwards is harmless.
+    releaseCodePost();
+    await Promise.resolve();
   });
 });

--- a/assistant/src/__tests__/call-setup-flow-verification.test.ts
+++ b/assistant/src/__tests__/call-setup-flow-verification.test.ts
@@ -565,4 +565,111 @@ describe("CallSetupFlow verification sub-flows", () => {
     releaseCodePost();
     await Promise.resolve();
   });
+
+  // ── Best-effort pointer writes (P1: rejection must not strand flow) ──
+  // A pointer write into the originating conversation can reject (origin
+  // conversation deleted, DB write fails). It must never propagate out of the
+  // verification handlers and leave the flow stuck in `collecting_code` after
+  // the code was already consumed — matching relay-server, which `.catch()`es
+  // every `addPointerMessage` write and continues.
+
+  test("outbound success: pointer-write rejection still resolves proceed + leaves collecting_code", async () => {
+    const transport = makeTransport();
+    const ctx = makeDeps(SESSION, {
+      async addPointerMessage() {
+        throw new Error("origin conversation deleted");
+      },
+    });
+    const flow = new CallSetupFlow("call_1", transport.transport, ctx.deps);
+
+    const started = flow.start(
+      {
+        action: "outbound_verification",
+        assistantId: "asst_test",
+        sessionId: "vs_1",
+        toNumber: "+15550199",
+      },
+      RESOLVED,
+    );
+    verificationOutcomes.push({
+      outcome: "success",
+      verificationType: "guardian",
+      eventName: "outbound_voice_verification_succeeded",
+    });
+    pushDigits(flow, "123456");
+
+    // Despite the rejected pointer write, the flow still finishes with the
+    // verification result and is no longer parked in collecting_code.
+    const result = await started;
+    expect(result.kind).toBe("proceed-post-verification-greeting");
+    expect(flow.getState()).toBe("completed");
+    expect(ctx.completed.at(-1)?.kind).toBe(
+      "proceed-post-verification-greeting",
+    );
+  });
+
+  test("outbound failure: pointer-write rejection still ends the flow", async () => {
+    const transport = makeTransport();
+    const ctx = makeDeps(SESSION, {
+      async addPointerMessage() {
+        throw new Error("db write failed");
+      },
+    });
+    const flow = new CallSetupFlow("call_1", transport.transport, ctx.deps);
+
+    const started = flow.start(
+      {
+        action: "outbound_verification",
+        assistantId: "asst_test",
+        sessionId: "vs_1",
+        toNumber: "+15550199",
+      },
+      RESOLVED,
+    );
+    verificationOutcomes.push({
+      outcome: "failure",
+      eventName: "outbound_voice_verification_failed",
+      ttsMessage: "[voice.failure:6]",
+      attempts: 3,
+    });
+    pushDigits(flow, "000000");
+
+    const result = await started;
+    expect(result.kind).toBe("ended");
+    expect(flow.getState()).toBe("completed");
+    // The terminal speech + deferred hangup still happen despite the rejection.
+    expect(ctx.spoken).toContain("[voice.failure:6]");
+    expect(ctx.scheduled).toHaveLength(1);
+  });
+
+  test("callee failure: pointer-write rejection still ends the flow", async () => {
+    const transport = makeTransport();
+    const ctx = makeDeps(SESSION, {
+      async addPointerMessage() {
+        throw new Error("db write failed");
+      },
+    });
+    const flow = new CallSetupFlow("call_1", transport.transport, ctx.deps);
+
+    const started = flow.start(
+      {
+        action: "callee_verification",
+        verificationConfig: { maxAttempts: 1, codeLength: 4 },
+      },
+      RESOLVED,
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    const correct = ctx.codePosts[0]!.code;
+    const wrong = correct === "9999" ? "0000" : "9999";
+
+    pushDigits(flow, wrong);
+    const result = await started;
+    expect(result.kind).toBe("ended");
+    expect(flow.getState()).toBe("completed");
+    expect(ctx.events.map((e) => e.type)).toContain(
+      "callee_verification_failed",
+    );
+    expect(ctx.scheduled).toHaveLength(1);
+  });
 });

--- a/assistant/src/__tests__/call-setup-flow-verification.test.ts
+++ b/assistant/src/__tests__/call-setup-flow-verification.test.ts
@@ -1,0 +1,459 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Logger mock (must come before any source imports) ────────────────
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// ── toTrustContext stub ──────────────────────────────────────────────
+
+mock.module("../runtime/actor-trust-resolver.js", () => ({
+  toTrustContext: (ctx: { trustClass: string }, externalId: string) => ({
+    sourceChannel: "phone",
+    trustClass: ctx.trustClass,
+    requesterExternalUserId: externalId,
+  }),
+}));
+
+// ── Verification template stub ───────────────────────────────────────
+// Deterministic, dependency-free copy so the flow's spoken prompts are
+// assertable without loading the real template/config machinery.
+
+mock.module("../runtime/verification-templates.js", () => ({
+  GUARDIAN_VERIFY_TEMPLATE_KEYS: {
+    VOICE_CALL_INTRO: "voice.call_intro",
+    VOICE_RETRY: "voice.retry",
+    VOICE_SUCCESS: "voice.success",
+    VOICE_FAILURE: "voice.failure",
+  },
+  composeVerificationVoice: (key: string, vars: { codeDigits: number }) =>
+    `[${key}:${vars.codeDigits}]`,
+}));
+
+// ── attemptVerificationCode stub ─────────────────────────────────────
+// Drive the guardian success/retry/failure branches deterministically
+// without the channel-verification service / config. parseDigitsFromSpeech
+// is kept real (it is pure and transport-agnostic).
+
+const verificationOutcomes: Array<
+  | {
+      outcome: "success";
+      verificationType: "guardian" | "trusted_contact";
+      eventName: string;
+    }
+  | {
+      outcome: "failure";
+      eventName: string;
+      ttsMessage: string;
+      attempts: number;
+    }
+  | {
+      outcome: "retry";
+      ttsMessage: string;
+      attempt: number;
+      maxAttempts: number;
+    }
+> = [];
+
+mock.module("../calls/relay-verification.js", () => ({
+  parseDigitsFromSpeech: (transcript: string) => {
+    const words: Record<string, string> = {
+      one: "1",
+      two: "2",
+      three: "3",
+      four: "4",
+      five: "5",
+      six: "6",
+    };
+    const digits: string[] = [];
+    for (const token of transcript.toLowerCase().split(/[\s,]+/)) {
+      if (/^\d+$/.test(token)) digits.push(...token.split(""));
+      else if (words[token]) digits.push(words[token]);
+    }
+    return digits.join("");
+  },
+  attemptVerificationCode: () => {
+    const next = verificationOutcomes.shift();
+    if (!next) throw new Error("no queued verification outcome");
+    return next;
+  },
+}));
+
+import {
+  CallSetupFlow,
+  type CallSetupFlowDeps,
+  type SetupFlowSession,
+} from "../calls/call-setup-flow.js";
+import type {
+  SetupFlowResult,
+  SetupFlowTransport,
+} from "../calls/call-setup-flow-types.js";
+import type {
+  SetupOutcome,
+  SetupResolved,
+} from "../calls/relay-setup-router.js";
+import type { ActorTrustContext } from "../runtime/actor-trust-resolver.js";
+
+// ── Test doubles ─────────────────────────────────────────────────────
+
+function makeTransport() {
+  const calls = {
+    ended: [] as Array<string | undefined>,
+  };
+  const transport: SetupFlowTransport = {
+    sendTextToken() {},
+    endSession(reason) {
+      calls.ended.push(reason);
+    },
+    getConnectionState() {
+      return "connected";
+    },
+  };
+  return { transport, calls };
+}
+
+function makeDeps(session: SetupFlowSession | null) {
+  const completed: SetupFlowResult[] = [];
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const spoken: string[] = [];
+  const pointers: Array<{
+    conversationId: string;
+    event: string;
+    phoneNumber: string;
+    extra?: Record<string, unknown>;
+  }> = [];
+  const codePosts: Array<{
+    conversationId: string;
+    toNumber: string;
+    code: string;
+  }> = [];
+  const transcripts: Array<{ speaker: string; text: string }> = [];
+  const scheduled: Array<{ fn: () => void; delayMs: number }> = [];
+
+  const deps: CallSetupFlowDeps = {
+    async speakSystemPrompt(_t, text) {
+      spoken.push(text);
+    },
+    recordCallEvent(_id, eventType, payload) {
+      events.push({ type: eventType, payload });
+    },
+    onComplete(result) {
+      completed.push(result);
+    },
+    getSession: () => session,
+    async postCalleeVerificationCode(conversationId, toNumber, code) {
+      codePosts.push({ conversationId, toNumber, code });
+    },
+    async addPointerMessage(conversationId, event, phoneNumber, extra) {
+      pointers.push({ conversationId, event, phoneNumber, extra });
+    },
+    fireTranscript(_conversationId, _callSessionId, speaker, text) {
+      transcripts.push({ speaker, text });
+    },
+    composeTrustedContactHandoffText: () => "Verified — welcome!",
+    hangupDelayMs: 999,
+    schedule(fn, delayMs) {
+      scheduled.push({ fn, delayMs });
+    },
+  };
+  return {
+    deps,
+    completed,
+    events,
+    spoken,
+    pointers,
+    codePosts,
+    transcripts,
+    scheduled,
+  };
+}
+
+const RESOLVED: SetupResolved = {
+  assistantId: "asst_test",
+  isInbound: true,
+  otherPartyNumber: "+15550100",
+  actorTrust: { trustClass: "guardian" } as unknown as ActorTrustContext,
+};
+
+const SESSION: SetupFlowSession = {
+  conversationId: "conv_voice",
+  toNumber: "+15550199",
+  initiatedFromConversationId: "conv_origin",
+};
+
+function pushDigits(flow: CallSetupFlow, code: string): void {
+  for (const d of code) flow.pushDtmfDigit(d);
+}
+
+describe("CallSetupFlow verification sub-flows", () => {
+  beforeEach(() => {
+    verificationOutcomes.length = 0;
+  });
+
+  // ── Inbound guardian verification ──────────────────────────────────
+
+  test("inbound guardian: correct DTMF code → proceed-initial-greeting", async () => {
+    const transport = makeTransport();
+    const ctx = makeDeps(SESSION);
+    const flow = new CallSetupFlow("call_1", transport.transport, ctx.deps);
+
+    const outcome: SetupOutcome = {
+      action: "verification",
+      assistantId: "asst_test",
+      fromNumber: "+15550100",
+    };
+    const started = flow.start(outcome, RESOLVED);
+    expect(flow.getState()).toBe("collecting_code");
+
+    verificationOutcomes.push({
+      outcome: "success",
+      verificationType: "guardian",
+      eventName: "voice_verification_succeeded",
+    });
+    pushDigits(flow, "123456");
+
+    const result = await started;
+    expect(result.kind).toBe("proceed-initial-greeting");
+    expect(flow.getState()).toBe("completed");
+    expect(ctx.events.map((e) => e.type)).toContain(
+      "voice_verification_started",
+    );
+    expect(ctx.events.map((e) => e.type)).toContain(
+      "voice_verification_succeeded",
+    );
+  });
+
+  test("inbound trusted_contact success → proceed-handoff-spoken + notifier", async () => {
+    const transport = makeTransport();
+    const ctx = makeDeps(SESSION);
+    const flow = new CallSetupFlow("call_1", transport.transport, ctx.deps);
+
+    const started = flow.start(
+      { action: "verification", assistantId: "asst_test", fromNumber: "+1" },
+      RESOLVED,
+    );
+    verificationOutcomes.push({
+      outcome: "success",
+      verificationType: "trusted_contact",
+      eventName: "voice_verification_succeeded",
+    });
+    pushDigits(flow, "123456");
+
+    const result = await started;
+    expect(result.kind).toBe("proceed-handoff-spoken");
+    // Handoff copy is spoken and an assistant_spoke event + transcript fire.
+    expect(ctx.spoken).toContain("Verified — welcome!");
+    expect(ctx.events.map((e) => e.type)).toContain("assistant_spoke");
+    expect(ctx.transcripts).toEqual([
+      { speaker: "assistant", text: "Verified — welcome!" },
+    ]);
+  });
+
+  test("inbound guardian: wrong code under max → retry (no completion)", async () => {
+    const transport = makeTransport();
+    const ctx = makeDeps(SESSION);
+    const flow = new CallSetupFlow("call_1", transport.transport, ctx.deps);
+
+    flow.start(
+      { action: "verification", assistantId: "asst_test", fromNumber: "+1" },
+      RESOLVED,
+    );
+    verificationOutcomes.push({
+      outcome: "retry",
+      ttsMessage: "That code was incorrect. Please try again.",
+      attempt: 1,
+      maxAttempts: 3,
+    });
+    pushDigits(flow, "000000");
+
+    expect(ctx.completed).toHaveLength(0);
+    expect(flow.getState()).toBe("collecting_code");
+    expect(ctx.spoken).toContain("That code was incorrect. Please try again.");
+  });
+
+  test("inbound guardian: exceed max attempts → ended with deferred hangup", async () => {
+    const transport = makeTransport();
+    const ctx = makeDeps(SESSION);
+    const flow = new CallSetupFlow("call_1", transport.transport, ctx.deps);
+
+    const started = flow.start(
+      { action: "verification", assistantId: "asst_test", fromNumber: "+1" },
+      RESOLVED,
+    );
+    verificationOutcomes.push({
+      outcome: "failure",
+      eventName: "voice_verification_failed",
+      ttsMessage: "Verification failed. Goodbye.",
+      attempts: 3,
+    });
+    pushDigits(flow, "000000");
+
+    const result = await started;
+    expect(result).toEqual({
+      kind: "ended",
+      reason: "Verification failed — challenge rejected",
+    });
+    // Hangup is deferred, not synchronous.
+    expect(transport.calls.ended).toHaveLength(0);
+    expect(ctx.scheduled).toHaveLength(1);
+    expect(ctx.scheduled[0]!.delayMs).toBe(999);
+    ctx.scheduled[0]!.fn();
+    expect(transport.calls.ended).toEqual([
+      "Verification failed — challenge rejected",
+    ]);
+  });
+
+  // ── Outbound guardian verification ─────────────────────────────────
+
+  test("outbound: spoken digits → proceed-post-verification-greeting + pointer", async () => {
+    const transport = makeTransport();
+    const ctx = makeDeps(SESSION);
+    const flow = new CallSetupFlow("call_1", transport.transport, ctx.deps);
+
+    const started = flow.start(
+      {
+        action: "outbound_verification",
+        assistantId: "asst_test",
+        sessionId: "vs_1",
+        toNumber: "+15550199",
+      },
+      RESOLVED,
+    );
+    verificationOutcomes.push({
+      outcome: "success",
+      verificationType: "guardian",
+      eventName: "outbound_voice_verification_succeeded",
+    });
+    // Spoken digits, parsed via parseDigitsFromSpeech.
+    flow.pushTranscriptFinal("one two three four five six");
+
+    const result = await started;
+    expect(result.kind).toBe("proceed-post-verification-greeting");
+    expect(ctx.pointers).toEqual([
+      {
+        conversationId: "conv_origin",
+        event: "verification_succeeded",
+        phoneNumber: "+15550199",
+        extra: { channel: "phone" },
+      },
+    ]);
+  });
+
+  test("outbound: failure → pointer + ended", async () => {
+    const transport = makeTransport();
+    const ctx = makeDeps(SESSION);
+    const flow = new CallSetupFlow("call_1", transport.transport, ctx.deps);
+
+    const started = flow.start(
+      {
+        action: "outbound_verification",
+        assistantId: "asst_test",
+        sessionId: "vs_1",
+        toNumber: "+15550199",
+      },
+      RESOLVED,
+    );
+    verificationOutcomes.push({
+      outcome: "failure",
+      eventName: "outbound_voice_verification_failed",
+      ttsMessage: "[voice.failure:6]",
+      attempts: 3,
+    });
+    pushDigits(flow, "000000");
+
+    const result = await started;
+    expect(result.kind).toBe("ended");
+    expect(ctx.pointers).toEqual([
+      {
+        conversationId: "conv_origin",
+        event: "verification_failed",
+        phoneNumber: "+15550199",
+        extra: {
+          channel: "phone",
+          reason: "Max verification attempts exceeded",
+        },
+      },
+    ]);
+  });
+
+  // ── Outbound callee verification ───────────────────────────────────
+
+  test("callee: posts code, correct entry → proceed-initial-greeting", async () => {
+    const transport = makeTransport();
+    const ctx = makeDeps(SESSION);
+    const flow = new CallSetupFlow("call_1", transport.transport, ctx.deps);
+
+    const started = flow.start(
+      {
+        action: "callee_verification",
+        verificationConfig: { maxAttempts: 3, codeLength: 4 },
+      },
+      RESOLVED,
+    );
+    // Let the async setup (speak + code post) settle before collecting.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(flow.getState()).toBe("collecting_code");
+
+    // The generated code was posted to the originating conversation.
+    expect(ctx.codePosts).toHaveLength(1);
+    const posted = ctx.codePosts[0]!;
+    expect(posted.conversationId).toBe("conv_origin");
+    expect(posted.toNumber).toBe("+15550199");
+    expect(posted.code).toHaveLength(4);
+
+    // Entering the correct code succeeds.
+    pushDigits(flow, posted.code);
+    const result = await started;
+    expect(result.kind).toBe("proceed-initial-greeting");
+    expect(ctx.events.map((e) => e.type)).toContain(
+      "callee_verification_succeeded",
+    );
+  });
+
+  test("callee: wrong code under max → retry; exceed max → ended + pointer", async () => {
+    const transport = makeTransport();
+    const ctx = makeDeps(SESSION);
+    const flow = new CallSetupFlow("call_1", transport.transport, ctx.deps);
+
+    const started = flow.start(
+      {
+        action: "callee_verification",
+        verificationConfig: { maxAttempts: 2, codeLength: 4 },
+      },
+      RESOLVED,
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    const correct = ctx.codePosts[0]!.code;
+    const wrong = correct === "9999" ? "0000" : "9999";
+
+    // First wrong attempt → retry.
+    pushDigits(flow, wrong);
+    expect(ctx.completed).toHaveLength(0);
+    expect(flow.getState()).toBe("collecting_code");
+    expect(ctx.spoken).toContain("That code was incorrect. Please try again.");
+
+    // Second wrong attempt → max reached → ended + pointer.
+    pushDigits(flow, wrong);
+    const result = await started;
+    expect(result.kind).toBe("ended");
+    expect(ctx.completed.at(-1)?.kind).toBe("ended");
+    expect(ctx.events.map((e) => e.type)).toContain(
+      "callee_verification_failed",
+    );
+    expect(ctx.pointers).toEqual([
+      {
+        conversationId: "conv_origin",
+        event: "failed",
+        phoneNumber: "+15550199",
+        extra: { reason: "Callee verification failed" },
+      },
+    ]);
+    expect(ctx.scheduled).toHaveLength(1);
+  });
+});

--- a/assistant/src/calls/call-setup-flow.ts
+++ b/assistant/src/calls/call-setup-flow.ts
@@ -20,8 +20,14 @@
  * {@link getState}; it never derives wait state from the transport.
  */
 
+import { randomInt } from "node:crypto";
+
 import type { TrustContext } from "../daemon/trust-context.js";
 import { toTrustContext } from "../runtime/actor-trust-resolver.js";
+import {
+  composeVerificationVoice,
+  GUARDIAN_VERIFY_TEMPLATE_KEYS,
+} from "../runtime/verification-templates.js";
 import { AssistantError, ErrorCode } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import { getTtsPlaybackDelayMs } from "./call-constants.js";
@@ -32,6 +38,10 @@ import type {
   SetupFlowTransport,
 } from "./call-setup-flow-types.js";
 import type { SetupOutcome, SetupResolved } from "./relay-setup-router.js";
+import {
+  attemptVerificationCode,
+  parseDigitsFromSpeech,
+} from "./relay-verification.js";
 
 const log = getLogger("call-setup-flow");
 
@@ -53,6 +63,17 @@ export class UnsupportedSetupFlowError extends AssistantError {
 // ── Dependencies ─────────────────────────────────────────────────────
 
 /**
+ * The structural subset of a call-session row the verification sub-flows
+ * read: the voice conversation, the dialed number, and the originating
+ * (desktop) conversation a pointer/code message is posted back to.
+ */
+export interface SetupFlowSession {
+  conversationId: string;
+  toNumber: string;
+  initiatedFromConversationId: string | null;
+}
+
+/**
  * Injected collaborators. Functions are injected (rather than imported
  * directly) so the flow can be unit-tested without a live transport, TTS
  * provider, or database.
@@ -69,6 +90,51 @@ export interface CallSetupFlowDeps {
   /** Invoked once the flow resolves, with its terminal result. */
   onComplete(result: SetupFlowResult): void;
   /**
+   * Read the call-session row backing this flow. Used by the verification
+   * sub-flows to find the originating conversation (for code-post / pointer
+   * messages) and to fire transcript notifiers. Returns `null` when the
+   * session is gone. Injected so the flow stays storage-agnostic.
+   */
+  getSession?(): SetupFlowSession | null;
+  /**
+   * Post the generated callee-verification code to the originating
+   * conversation so the user can relay it to the callee. Mirrors the
+   * `addMessage(...)` write in `relay-server.startVerification`.
+   */
+  postCalleeVerificationCode?(
+    conversationId: string,
+    toNumber: string,
+    code: string,
+  ): Promise<void>;
+  /**
+   * Write a lifecycle pointer message into the originating conversation
+   * (outbound verification success/failure). Mirrors `addPointerMessage`.
+   */
+  addPointerMessage?(
+    conversationId: string,
+    event: "verification_succeeded" | "verification_failed" | "failed",
+    phoneNumber: string,
+    extra?: { channel?: string; reason?: string },
+  ): Promise<void>;
+  /**
+   * Fire the call-transcript notifier for UI subscribers. Mirrors
+   * `fireCallTranscriptNotifier`. Injected so the flow needn't reach into
+   * the call-state module directly.
+   */
+  fireTranscript?(
+    conversationId: string,
+    callSessionId: string,
+    speaker: "caller" | "assistant",
+    text: string,
+  ): void;
+  /**
+   * Compose the deterministic trusted-contact handoff copy spoken on inbound
+   * trusted-contact verification success (the relay path's
+   * `continueCallAfterTrustedContactActivation`). The flow speaks the
+   * returned text itself and resolves `proceed-handoff-spoken`.
+   */
+  composeTrustedContactHandoffText?(): string;
+  /**
    * Delay (ms) to wait after speaking a terminal prompt before tearing down
    * the transport, so queued TTS playback isn't flushed by `endSession()`.
    * Defaults to {@link getTtsPlaybackDelayMs}; overridable (e.g. `0`) so unit
@@ -83,10 +149,52 @@ export interface CallSetupFlowDeps {
   schedule?: (fn: () => void, delayMs: number) => void;
 }
 
+// ── Digit-collection sub-flow ────────────────────────────────────────
+
+/**
+ * Which verification variant is collecting digits, plus its mutable buffer
+ * and attempt state. The discriminant selects the success / retry / failure
+ * branching when a full code arrives, mirroring the relay handlers.
+ */
+type CodeCollection = {
+  /** Per-attempt buffer fed by DTMF and parsed speech. */
+  buffer: string;
+  codeLength: number;
+  maxAttempts: number;
+  attempts: number;
+  resolved: SetupResolved;
+} & (
+  | {
+      kind: "guardian";
+      /** Inbound guardian challenge — validated via the channel service. */
+      assistantId: string;
+      fromNumber: string;
+    }
+  | {
+      kind: "outbound";
+      /** Outbound guardian verification — the dialed guardian's number. */
+      assistantId: string;
+      fromNumber: string;
+    }
+  | {
+      kind: "callee";
+      /** Outbound callee verification — compared against this generated code. */
+      expectedCode: string;
+    }
+);
+
 // ── Flow ─────────────────────────────────────────────────────────────
 
 export class CallSetupFlow implements SetupFlowInput {
   private state: SetupFlowState = "idle";
+
+  /**
+   * Active digit-collection sub-flow, if any. Holds the per-attempt buffer,
+   * attempt counters, and the success/failure branching specific to which
+   * verification action is in flight. Non-null exactly while
+   * `state === "collecting_code"`.
+   */
+  private collecting: CodeCollection | null = null;
 
   constructor(
     private readonly callSessionId: string,
@@ -121,18 +229,390 @@ export class CallSetupFlow implements SetupFlowInput {
       case "deny":
         return this.handleDeny(outcome);
 
+      case "verification":
+        return this.startGuardianVerification(outcome, resolved);
+
+      case "outbound_verification":
+        return this.startOutboundVerification(outcome, resolved);
+
+      case "callee_verification":
+        return this.startCalleeVerification(outcome, resolved);
+
       default:
         throw new UnsupportedSetupFlowError(outcome.action);
     }
   }
 
   // ── SetupFlowInput ──────────────────────────────────────────────────
-  // No-ops until a sub-flow (verification / name capture) is active; the
-  // sub-flows that consume caller input land in later PRs.
+  // Feed caller input into the active digit-collection sub-flow (if any).
+  // Both DTMF and parsed speech append to a single shared buffer; the buffer
+  // is consumed once `codeLength` digits have accumulated.
 
-  pushDtmfDigit(_digit: string): void {}
+  pushDtmfDigit(digit: string): void {
+    if (!this.collecting) return;
+    this.appendDigits(digit);
+  }
 
-  pushTranscriptFinal(_text: string): void {}
+  pushTranscriptFinal(text: string): void {
+    if (!this.collecting) return;
+    const digits = parseDigitsFromSpeech(text);
+    if (digits.length === 0) return;
+    this.appendDigits(digits);
+  }
+
+  // ── Verification sub-flows ──────────────────────────────────────────
+
+  /**
+   * Inbound guardian challenge: prompt for the six-digit code and begin
+   * collecting digits. Resolution happens later, in {@link onFullCode}.
+   * Ports `relay-server.startInboundVerification`.
+   */
+  private startGuardianVerification(
+    outcome: Extract<SetupOutcome, { action: "verification" }>,
+    resolved: SetupResolved,
+  ): Promise<SetupFlowResult> {
+    this.collecting = {
+      kind: "guardian",
+      assistantId: outcome.assistantId,
+      fromNumber: outcome.fromNumber,
+      buffer: "",
+      codeLength: 6,
+      maxAttempts: 3,
+      attempts: 0,
+      resolved,
+    };
+    this.state = "collecting_code";
+
+    this.deps.recordCallEvent(
+      this.callSessionId,
+      "voice_verification_started",
+      { assistantId: outcome.assistantId, maxAttempts: 3 },
+    );
+    return this.speakAndWait(
+      "Welcome. Please enter your six-digit verification code using your keypad, or speak the digits now.",
+    );
+  }
+
+  /**
+   * Outbound guardian verification: the system dialed the guardian; prompt
+   * them to enter the code. Ports `relay-server.startOutboundVerification`.
+   */
+  private startOutboundVerification(
+    outcome: Extract<SetupOutcome, { action: "outbound_verification" }>,
+    resolved: SetupResolved,
+  ): Promise<SetupFlowResult> {
+    const codeLength = 6;
+    this.collecting = {
+      kind: "outbound",
+      assistantId: outcome.assistantId,
+      // For outbound guardian calls the "to" number is the guardian's phone.
+      fromNumber: outcome.toNumber,
+      buffer: "",
+      codeLength,
+      maxAttempts: 3,
+      attempts: 0,
+      resolved,
+    };
+    this.state = "collecting_code";
+
+    this.deps.recordCallEvent(
+      this.callSessionId,
+      "outbound_voice_verification_started",
+      {
+        assistantId: outcome.assistantId,
+        verificationSessionId: outcome.sessionId,
+        maxAttempts: 3,
+      },
+    );
+    return this.speakAndWait(
+      composeVerificationVoice(GUARDIAN_VERIFY_TEMPLATE_KEYS.VOICE_CALL_INTRO, {
+        codeDigits: codeLength,
+      }),
+    );
+  }
+
+  /**
+   * Outbound callee verification: generate a code, speak it digit-by-digit,
+   * post it to the originating conversation, and collect the callee's entry.
+   * Ports `relay-server.startVerification`.
+   */
+  private async startCalleeVerification(
+    outcome: Extract<SetupOutcome, { action: "callee_verification" }>,
+    resolved: SetupResolved,
+  ): Promise<SetupFlowResult> {
+    const { codeLength, maxAttempts } = outcome.verificationConfig;
+    const code = randomInt(0, Math.pow(10, codeLength))
+      .toString()
+      .padStart(codeLength, "0");
+
+    this.collecting = {
+      kind: "callee",
+      expectedCode: code,
+      buffer: "",
+      codeLength,
+      maxAttempts,
+      attempts: 0,
+      resolved,
+    };
+    this.state = "collecting_code";
+
+    this.deps.recordCallEvent(
+      this.callSessionId,
+      "callee_verification_started",
+      { codeLength, maxAttempts },
+    );
+
+    // Speak the code digit-by-digit and prompt for entry.
+    const spokenCode = code.split("").join(". ");
+    await this.deps.speakSystemPrompt(
+      this.transport,
+      `Please enter the verification code: ${spokenCode}.`,
+    );
+
+    // Post the code to the originating conversation so the user can relay it.
+    const session = this.deps.getSession?.();
+    if (session?.initiatedFromConversationId) {
+      await this.deps.postCalleeVerificationCode?.(
+        session.initiatedFromConversationId,
+        session.toNumber,
+        code,
+      );
+    }
+
+    return new Promise<SetupFlowResult>((resolve) => {
+      this.resolveCollection = resolve;
+    });
+  }
+
+  /** Resolver for the pending digit-collection promise (set on start). */
+  private resolveCollection: ((result: SetupFlowResult) => void) | null = null;
+
+  /** Speak a prompt, then return a promise that resolves once digits land. */
+  private speakAndWait(prompt: string): Promise<SetupFlowResult> {
+    void this.deps.speakSystemPrompt(this.transport, prompt);
+    return new Promise<SetupFlowResult>((resolve) => {
+      this.resolveCollection = resolve;
+    });
+  }
+
+  /** Append digits to the active buffer; consume once a full code arrives. */
+  private appendDigits(digits: string): void {
+    const c = this.collecting;
+    if (!c) return;
+    c.buffer += digits;
+    if (c.buffer.length >= c.codeLength) {
+      const enteredCode = c.buffer.slice(0, c.codeLength);
+      c.buffer = "";
+      void this.onFullCode(enteredCode);
+    }
+  }
+
+  /** Branch on a fully-entered code per the active sub-flow. */
+  private async onFullCode(enteredCode: string): Promise<void> {
+    const c = this.collecting;
+    if (!c) return;
+    if (c.kind === "callee") {
+      await this.onCalleeCode(c, enteredCode);
+    } else {
+      await this.onGuardianCode(c, enteredCode);
+    }
+  }
+
+  /**
+   * Validate a guardian (inbound or outbound) code via the extracted
+   * `attemptVerificationCode` and apply the relay-parity side effects.
+   */
+  private async onGuardianCode(
+    c: Extract<CodeCollection, { kind: "guardian" | "outbound" }>,
+    enteredCode: string,
+  ): Promise<void> {
+    const isOutbound = c.kind === "outbound";
+    const result = attemptVerificationCode({
+      verificationAssistantId: c.assistantId,
+      verificationFromNumber: c.fromNumber,
+      enteredCode,
+      isOutbound,
+      codeDigits: c.codeLength,
+      verificationAttempts: c.attempts,
+      verificationMaxAttempts: c.maxAttempts,
+    });
+
+    if (result.outcome === "success") {
+      this.deps.recordCallEvent(this.callSessionId, result.eventName, {
+        verificationType: result.verificationType,
+      });
+
+      if (isOutbound) {
+        await this.postPointer("verification_succeeded", { channel: "phone" });
+        this.finishWith({
+          kind: "proceed-post-verification-greeting",
+          assistantId: c.assistantId,
+          trustContext: this.trustContextFor(c.resolved),
+        });
+        return;
+      }
+
+      if (result.verificationType === "trusted_contact") {
+        this.finishCollection(this.completeTrustedContactHandoff(c.resolved));
+        return;
+      }
+
+      // Inbound guardian success → normal call flow.
+      this.finishWith({
+        kind: "proceed-initial-greeting",
+        assistantId: c.assistantId,
+        trustContext: this.trustContextFor(c.resolved),
+      });
+      return;
+    }
+
+    if (result.outcome === "failure") {
+      c.attempts = result.attempts;
+      this.deps.recordCallEvent(this.callSessionId, result.eventName, {
+        attempts: result.attempts,
+      });
+
+      if (isOutbound) {
+        await this.postPointer("verification_failed", {
+          channel: "phone",
+          reason: "Max verification attempts exceeded",
+        });
+      }
+
+      await this.speakThenEnd(
+        result.ttsMessage,
+        "Verification failed — challenge rejected",
+      );
+      return;
+    }
+
+    // retry
+    c.attempts = result.attempt;
+    void this.deps.speakSystemPrompt(this.transport, result.ttsMessage);
+  }
+
+  /**
+   * Compare a callee-entered code against the generated code; on success
+   * proceed to the initial greeting, else retry up to max then end.
+   * Ports the callee branch of `relay-server.handleDtmf`.
+   */
+  private async onCalleeCode(
+    c: Extract<CodeCollection, { kind: "callee" }>,
+    enteredCode: string,
+  ): Promise<void> {
+    if (enteredCode === c.expectedCode) {
+      this.deps.recordCallEvent(
+        this.callSessionId,
+        "callee_verification_succeeded",
+        {},
+      );
+      this.finishWith({
+        kind: "proceed-initial-greeting",
+        assistantId: c.resolved.assistantId,
+        trustContext: this.trustContextFor(c.resolved),
+      });
+      return;
+    }
+
+    c.attempts += 1;
+    if (c.attempts >= c.maxAttempts) {
+      this.deps.recordCallEvent(
+        this.callSessionId,
+        "callee_verification_failed",
+        { attempts: c.attempts },
+      );
+      await this.postPointer("failed", {
+        reason: "Callee verification failed",
+      });
+      await this.speakThenEnd(
+        "Verification failed. Goodbye.",
+        "Verification failed",
+      );
+      return;
+    }
+
+    void this.deps.speakSystemPrompt(
+      this.transport,
+      "That code was incorrect. Please try again.",
+    );
+  }
+
+  /**
+   * Inbound trusted-contact success: speak the handoff copy, fire the
+   * `assistant_spoke` event + transcript notifier, and resolve
+   * `proceed-handoff-spoken`. Ports
+   * `relay-server.continueCallAfterTrustedContactActivation`.
+   */
+  private completeTrustedContactHandoff(
+    resolved: SetupResolved,
+  ): SetupFlowResult {
+    const handoffText =
+      this.deps.composeTrustedContactHandoffText?.() ??
+      "Great! You're verified. How can I help?";
+
+    void this.deps.speakSystemPrompt(this.transport, handoffText);
+    this.deps.recordCallEvent(this.callSessionId, "assistant_spoke", {
+      text: handoffText,
+    });
+    const session = this.deps.getSession?.();
+    if (session) {
+      this.deps.fireTranscript?.(
+        session.conversationId,
+        this.callSessionId,
+        "assistant",
+        handoffText,
+      );
+    }
+
+    return this.complete({
+      kind: "proceed-handoff-spoken",
+      assistantId: resolved.assistantId,
+      trustContext: this.trustContextFor(resolved),
+    });
+  }
+
+  /**
+   * Terminal "failure → ended" speech: speak the message, resolve `ended`,
+   * and defer the transport teardown by the playback delay (same deferral
+   * pattern as the deny path) so the failure audio has time to play.
+   */
+  private async speakThenEnd(message: string, reason: string): Promise<void> {
+    await this.deps.speakSystemPrompt(this.transport, message);
+    this.finishWith({ kind: "ended", reason });
+    this.scheduleHangup(() => this.transport.endSession(reason));
+  }
+
+  /** Complete the flow and resolve the pending collection start() promise. */
+  private finishWith(result: SetupFlowResult): void {
+    this.finishCollection(this.complete(result));
+  }
+
+  /** Clear the collection state and resolve the pending start() promise. */
+  private finishCollection(result: SetupFlowResult): void {
+    this.collecting = null;
+    const resolve = this.resolveCollection;
+    this.resolveCollection = null;
+    resolve?.(result);
+  }
+
+  /**
+   * Post a lifecycle pointer message to the originating conversation, if one
+   * exists. No-op when the session has no originating conversation or the
+   * `addPointerMessage` dep is absent.
+   */
+  private async postPointer(
+    event: "verification_succeeded" | "verification_failed" | "failed",
+    extra?: { channel?: string; reason?: string },
+  ): Promise<void> {
+    const session = this.deps.getSession?.();
+    if (!session?.initiatedFromConversationId) return;
+    await this.deps.addPointerMessage?.(
+      session.initiatedFromConversationId,
+      event,
+      session.toNumber,
+      extra,
+    );
+  }
 
   // ── Internal ────────────────────────────────────────────────────────
 

--- a/assistant/src/calls/call-setup-flow.ts
+++ b/assistant/src/calls/call-setup-flow.ts
@@ -23,6 +23,10 @@
 import { randomInt } from "node:crypto";
 
 import type { TrustContext } from "../daemon/trust-context.js";
+import type {
+  ActorTrustContext,
+  ResolveActorTrustInput,
+} from "../runtime/actor-trust-resolver.js";
 import { toTrustContext } from "../runtime/actor-trust-resolver.js";
 import {
   composeVerificationVoice,
@@ -134,6 +138,18 @@ export interface CallSetupFlowDeps {
    * returned text itself and resolves `proceed-handoff-spoken`.
    */
   composeTrustedContactHandoffText?(): string;
+  /**
+   * Re-resolve the caller's actor-trust context after a successful
+   * verification, mirroring the relay path's post-validation
+   * `resolveActorTrust(...)` call (see `relay-server.handleVerificationCodeResult`
+   * and `continueCallAfterTrustedContactActivation`). The trust context resolved
+   * by `routeSetup` is computed BEFORE the verification code is consumed, so a
+   * caller who just verified would otherwise still be classified `unknown` and
+   * lose guardian / trusted-contact permissions. When this dep is absent the
+   * flow falls back to the (stale) `resolved.actorTrust`. Injected so the flow
+   * stays transport- and storage-agnostic; PR 9 wires the real implementation.
+   */
+  resolveActorTrust?(input: ResolveActorTrustInput): ActorTrustContext;
   /**
    * Delay (ms) to wait after speaking a terminal prompt before tearing down
    * the transport, so queued TTS playback isn't flushed by `endSession()`.
@@ -336,7 +352,7 @@ export class CallSetupFlow implements SetupFlowInput {
    * post it to the originating conversation, and collect the callee's entry.
    * Ports `relay-server.startVerification`.
    */
-  private async startCalleeVerification(
+  private startCalleeVerification(
     outcome: Extract<SetupOutcome, { action: "callee_verification" }>,
     resolved: SetupResolved,
   ): Promise<SetupFlowResult> {
@@ -362,6 +378,34 @@ export class CallSetupFlow implements SetupFlowInput {
       { codeLength, maxAttempts },
     );
 
+    // Install the collection resolver BEFORE awaiting any side effects. The
+    // collecting state is already set above, so a digit completion (DTMF or
+    // parsed speech) that arrives *while* the TTS/code-post side effects below
+    // are still in flight would otherwise reach `finishCollection()` with a
+    // null resolver, drop the completion, and hang `start()` forever.
+    // Registering the resolver atomically with the collecting state — and
+    // buffering an early completion in `finishCollection` as a backstop —
+    // closes that race. The side effects run detached so the returned
+    // `pending` promise resolves as soon as the code lands, even if a side
+    // effect (e.g. the code-post write) is still outstanding.
+    const pending = new Promise<SetupFlowResult>((resolve) => {
+      this.resolveCollection = resolve;
+    });
+    // Flush any completion that landed before the resolver was installed.
+    this.flushPendingCollectionResult();
+
+    void this.runCalleeSetupSideEffects(code);
+
+    return pending;
+  }
+
+  /**
+   * Detached TTS + code-post side effects for callee verification. Run after
+   * the collection resolver is installed so a completion that arrives while
+   * these are in flight is captured rather than dropped (and `start()` is not
+   * blocked on them). Mirrors `relay-server.startVerification`.
+   */
+  private async runCalleeSetupSideEffects(code: string): Promise<void> {
     // Speak the code digit-by-digit and prompt for entry.
     const spokenCode = code.split("").join(". ");
     await this.deps.speakSystemPrompt(
@@ -378,21 +422,27 @@ export class CallSetupFlow implements SetupFlowInput {
         code,
       );
     }
-
-    return new Promise<SetupFlowResult>((resolve) => {
-      this.resolveCollection = resolve;
-    });
   }
 
   /** Resolver for the pending digit-collection promise (set on start). */
   private resolveCollection: ((result: SetupFlowResult) => void) | null = null;
 
+  /**
+   * Backstop buffer for a collection result that arrives before the resolver
+   * is installed (e.g. a digit completion delivered while an awaited TTS /
+   * code-post side effect in `startCalleeVerification` is still in flight).
+   * Flushed by {@link flushPendingCollectionResult} once the resolver lands.
+   */
+  private pendingCollectionResult: SetupFlowResult | null = null;
+
   /** Speak a prompt, then return a promise that resolves once digits land. */
   private speakAndWait(prompt: string): Promise<SetupFlowResult> {
     void this.deps.speakSystemPrompt(this.transport, prompt);
-    return new Promise<SetupFlowResult>((resolve) => {
+    const pending = new Promise<SetupFlowResult>((resolve) => {
       this.resolveCollection = resolve;
     });
+    this.flushPendingCollectionResult();
+    return pending;
   }
 
   /** Append digits to the active buffer; consume once a full code arrives. */
@@ -447,13 +497,18 @@ export class CallSetupFlow implements SetupFlowInput {
         this.finishWith({
           kind: "proceed-post-verification-greeting",
           assistantId: c.assistantId,
-          trustContext: this.trustContextFor(c.resolved),
+          trustContext: this.recomputedTrustContextFor(
+            c.resolved,
+            c.fromNumber,
+          ),
         });
         return;
       }
 
       if (result.verificationType === "trusted_contact") {
-        this.finishCollection(this.completeTrustedContactHandoff(c.resolved));
+        this.finishCollection(
+          this.completeTrustedContactHandoff(c.resolved, c.fromNumber),
+        );
         return;
       }
 
@@ -461,7 +516,7 @@ export class CallSetupFlow implements SetupFlowInput {
       this.finishWith({
         kind: "proceed-initial-greeting",
         assistantId: c.assistantId,
-        trustContext: this.trustContextFor(c.resolved),
+        trustContext: this.recomputedTrustContextFor(c.resolved, c.fromNumber),
       });
       return;
     }
@@ -509,7 +564,10 @@ export class CallSetupFlow implements SetupFlowInput {
       this.finishWith({
         kind: "proceed-initial-greeting",
         assistantId: c.resolved.assistantId,
-        trustContext: this.trustContextFor(c.resolved),
+        trustContext: this.recomputedTrustContextFor(
+          c.resolved,
+          c.resolved.otherPartyNumber,
+        ),
       });
       return;
     }
@@ -545,6 +603,7 @@ export class CallSetupFlow implements SetupFlowInput {
    */
   private completeTrustedContactHandoff(
     resolved: SetupResolved,
+    partyNumber: string,
   ): SetupFlowResult {
     const handoffText =
       this.deps.composeTrustedContactHandoffText?.() ??
@@ -567,7 +626,7 @@ export class CallSetupFlow implements SetupFlowInput {
     return this.complete({
       kind: "proceed-handoff-spoken",
       assistantId: resolved.assistantId,
-      trustContext: this.trustContextFor(resolved),
+      trustContext: this.recomputedTrustContextFor(resolved, partyNumber),
     });
   }
 
@@ -592,7 +651,24 @@ export class CallSetupFlow implements SetupFlowInput {
     this.collecting = null;
     const resolve = this.resolveCollection;
     this.resolveCollection = null;
-    resolve?.(result);
+    if (resolve) {
+      resolve(result);
+      return;
+    }
+    // Resolver not yet installed (an early completion landed mid-await) —
+    // buffer the result so it isn't dropped; flushed once the resolver lands.
+    this.pendingCollectionResult = result;
+  }
+
+  /**
+   * Resolve a buffered collection result, if one landed before the resolver
+   * was installed. Called right after the resolver is registered.
+   */
+  private flushPendingCollectionResult(): void {
+    const buffered = this.pendingCollectionResult;
+    if (buffered == null) return;
+    this.pendingCollectionResult = null;
+    this.finishCollection(buffered);
   }
 
   /**
@@ -660,5 +736,33 @@ export class CallSetupFlow implements SetupFlowInput {
 
   private trustContextFor(resolved: SetupResolved): TrustContext {
     return toTrustContext(resolved.actorTrust, resolved.otherPartyNumber);
+  }
+
+  /**
+   * Re-resolve the actor-trust context after a successful verification so the
+   * controller is created with POST-verification trust. Mirrors the relay
+   * path's `resolveActorTrust(...)` re-resolution
+   * (`relay-server.handleVerificationCodeResult` /
+   * `continueCallAfterTrustedContactActivation`). Falls back to the stale
+   * `resolved.actorTrust` when the `resolveActorTrust` dep is not wired.
+   *
+   * @param resolved   The pre-verification routing context.
+   * @param partyNumber The verified party's number (E.164) — the guardian's
+   *   number for guardian/outbound, the called party for callee verification.
+   */
+  private recomputedTrustContextFor(
+    resolved: SetupResolved,
+    partyNumber: string,
+  ): TrustContext {
+    if (!this.deps.resolveActorTrust) {
+      return this.trustContextFor(resolved);
+    }
+    const updatedTrust = this.deps.resolveActorTrust({
+      assistantId: resolved.assistantId,
+      sourceChannel: "phone",
+      conversationExternalId: partyNumber,
+      actorExternalId: partyNumber || undefined,
+    });
+    return toTrustContext(updatedTrust, partyNumber);
   }
 }

--- a/assistant/src/calls/call-setup-flow.ts
+++ b/assistant/src/calls/call-setup-flow.ts
@@ -675,6 +675,14 @@ export class CallSetupFlow implements SetupFlowInput {
    * Post a lifecycle pointer message to the originating conversation, if one
    * exists. No-op when the session has no originating conversation or the
    * `addPointerMessage` dep is absent.
+   *
+   * Best-effort: the pointer write is wrapped in a try/catch (log + continue)
+   * so a rejection — e.g. the originating desktop conversation was deleted, or
+   * a DB write fails — can never propagate out of the verification handlers and
+   * strand the flow in `collecting_code` after the code was already consumed.
+   * Mirrors relay-server, which `.catch()`es every `addPointerMessage` write
+   * and continues. The verification result (proceed/ended) must be emitted
+   * regardless of the pointer-write outcome.
    */
   private async postPointer(
     event: "verification_succeeded" | "verification_failed" | "failed",
@@ -682,12 +690,24 @@ export class CallSetupFlow implements SetupFlowInput {
   ): Promise<void> {
     const session = this.deps.getSession?.();
     if (!session?.initiatedFromConversationId) return;
-    await this.deps.addPointerMessage?.(
-      session.initiatedFromConversationId,
-      event,
-      session.toNumber,
-      extra,
-    );
+    try {
+      await this.deps.addPointerMessage?.(
+        session.initiatedFromConversationId,
+        event,
+        session.toNumber,
+        extra,
+      );
+    } catch (err) {
+      log.warn(
+        {
+          callSessionId: this.callSessionId,
+          conversationId: session.initiatedFromConversationId,
+          event,
+          err,
+        },
+        "Skipping pointer write — origin conversation may no longer exist",
+      );
+    }
   }
 
   // ── Internal ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Port guardian/outbound/callee verification into CallSetupFlow (DTMF + spoken digits)
- Reuse attemptVerificationCode/parseDigitsFromSpeech; preserve code-post/pointer/notifier side effects
- Correct proceed-* / ended variants; tests

Part of plan: migrate-phone-off-conversation-relay.md (PR 5 of 18)