### PR TITLE
feat(calls): stream media-stream audio into StreamingTranscriber for low latency

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -820,6 +820,7 @@ describe("AssistantConfigSchema", () => {
         language: "en-US",
         hints: [],
         interruptSensitivity: "low",
+        telephonyStreaming: true,
       },
       callerIdentity: {
         allowPerCallOverride: true,

--- a/assistant/src/__tests__/media-stream-stt-session.test.ts
+++ b/assistant/src/__tests__/media-stream-stt-session.test.ts
@@ -1141,6 +1141,67 @@ describe("MediaStreamSttSession", () => {
       session.dispose();
     });
 
+    test("stop while start() is pending (transcriber resolved, start() unresolved) replays buffered frames through the batch path", async () => {
+      telephonyStreamingFlag = true;
+      sttProvider = "deepgram"; // realtime-ws → streaming path attempted
+      // Resolver resolves a transcriber, but its start() never settles, so the
+      // session lingers in "streaming-pending" with streamingTranscriber set.
+      const fake = makeFakeStreamingTranscriber();
+      (resolveStreamingTranscriber as jest.Mock).mockResolvedValue(fake);
+
+      const mockTranscriber = makeMockTranscriber("buffered during handshake");
+      (resolveBatchTranscriber as jest.Mock).mockResolvedValue(mockTranscriber);
+
+      const onTranscriptFinal = jest.fn();
+      const onStop = jest.fn();
+      const session = new MediaStreamSttSession(
+        { turnDetector: { silenceThresholdMs: 300 } },
+        { onTranscriptFinal, onStop },
+      );
+
+      session.handleMessage(makeStartMessage());
+      // Resolver settles and start() is invoked — but start() is NOT resolved,
+      // so mode is still "streaming-pending" while streamingTranscriber is set.
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+      expect(fake.start).toHaveBeenCalledTimes(1);
+
+      // Caller's final utterance arrives during the start() handshake window —
+      // buffered (not sent to the streaming transcriber, which is not ready).
+      const speechPayload = Buffer.alloc(160, 0x00).toString("base64");
+      for (let i = 0; i < 5; i++) {
+        session.handleMessage(makeMediaMessage(speechPayload));
+      }
+      expect(fake.sent.length).toBe(0);
+
+      // Twilio sends stop before start() resolves. This must take the
+      // pending-fallback path (NOT the "transcriber is live" branch), replaying
+      // the buffered utterance through the batch pipeline.
+      session.handleMessage(makeStopMessage());
+      expect(onStop).toHaveBeenCalledTimes(1);
+      for (let i = 0; i < 20; i++) await Promise.resolve();
+
+      // The buffered utterance was transcribed via the batch path — not lost.
+      expect(onTranscriptFinal).toHaveBeenCalledTimes(1);
+      expect(onTranscriptFinal).toHaveBeenCalledWith(
+        "buffered during handshake",
+        expect.any(Number),
+      );
+      const transcribeMock = mockTranscriber.transcribe as jest.Mock;
+      expect(transcribeMock).toHaveBeenCalledTimes(1);
+      const req = transcribeMock.mock.calls[0][0] as SttTranscribeRequest;
+      expect(req.audio.length).toBeGreaterThan(0);
+
+      // When start() finally settles it must NOT resurrect streaming: the late
+      // transcriber is stopped and never receives the buffered frames.
+      fake.resolveStart();
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+      expect(fake.sent.length).toBe(0);
+      expect(fake.stop).toHaveBeenCalledTimes(1);
+      expect(onTranscriptFinal).toHaveBeenCalledTimes(1);
+
+      session.dispose();
+    });
+
     test("dispose during streaming-pending stops a late-resolved transcriber and does not leak", async () => {
       telephonyStreamingFlag = true;
       sttProvider = "deepgram";
@@ -1164,6 +1225,103 @@ describe("MediaStreamSttSession", () => {
       for (let i = 0; i < 10; i++) await Promise.resolve();
       expect(fake.start).not.toHaveBeenCalled();
       expect(fake.stop).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ── Streaming speech-start coalescing (Finding 2) ────────────────
+  describe("streaming onSpeechStart coalescing", () => {
+    test("fires once across a run of consecutive speech frames, then again after a silence gap", async () => {
+      telephonyStreamingFlag = true;
+      sttProvider = "deepgram"; // realtime-ws → streaming path
+      const fake = makeFakeStreamingTranscriber();
+      (resolveStreamingTranscriber as jest.Mock).mockResolvedValue(fake);
+
+      const onSpeechStart = jest.fn();
+      // silenceThresholdMs 200 / 20ms frame = 10 silence frames re-arm the gate.
+      const session = new MediaStreamSttSession(
+        { turnDetector: { silenceThresholdMs: 200 } },
+        { onSpeechStart },
+      );
+
+      session.handleMessage(makeStartMessage());
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+      fake.resolveStart();
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+
+      const speechPayload = Buffer.alloc(160, 0x00).toString("base64");
+      const silencePayload = Buffer.alloc(160, 0xff).toString("base64");
+
+      // Turn 1: a run of consecutive speech frames fires onSpeechStart once.
+      for (let i = 0; i < 8; i++) {
+        session.handleMessage(makeMediaMessage(speechPayload));
+      }
+      expect(onSpeechStart).toHaveBeenCalledTimes(1);
+
+      // A short silence gap (below the 10-frame reset) does NOT re-arm the gate;
+      // resumed speech must not re-fire.
+      for (let i = 0; i < 3; i++) {
+        session.handleMessage(makeMediaMessage(silencePayload));
+      }
+      session.handleMessage(makeMediaMessage(speechPayload));
+      expect(onSpeechStart).toHaveBeenCalledTimes(1);
+
+      // A long silence gap (>= 10 frames) re-arms the gate.
+      for (let i = 0; i < 12; i++) {
+        session.handleMessage(makeMediaMessage(silencePayload));
+      }
+
+      // Turn 2: the next speech run fires onSpeechStart again, exactly once.
+      for (let i = 0; i < 6; i++) {
+        session.handleMessage(makeMediaMessage(speechPayload));
+      }
+      expect(onSpeechStart).toHaveBeenCalledTimes(2);
+
+      session.dispose();
+    });
+
+    test("coalesces across the pending->streaming boundary", async () => {
+      telephonyStreamingFlag = true;
+      sttProvider = "deepgram";
+      // Keep the resolver pending so the first speech run lands in the
+      // streaming-pending window, then resolve to cross into streaming.
+      let resolveResolver: (t: StreamingTranscriber | null) => void = () => {};
+      (resolveStreamingTranscriber as jest.Mock).mockReturnValue(
+        new Promise<StreamingTranscriber | null>((resolve) => {
+          resolveResolver = resolve;
+        }),
+      );
+
+      const fake = makeFakeStreamingTranscriber();
+      const onSpeechStart = jest.fn();
+      const session = new MediaStreamSttSession(
+        { turnDetector: { silenceThresholdMs: 200 } },
+        { onSpeechStart },
+      );
+
+      session.handleMessage(makeStartMessage());
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+
+      const speechPayload = Buffer.alloc(160, 0x00).toString("base64");
+
+      // Speech during the pending window fires onSpeechStart once.
+      for (let i = 0; i < 5; i++) {
+        session.handleMessage(makeMediaMessage(speechPayload));
+      }
+      expect(onSpeechStart).toHaveBeenCalledTimes(1);
+
+      // Cross into committed streaming mode (no intervening silence gap).
+      resolveResolver(fake);
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+      fake.resolveStart();
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+
+      // Continued speech in streaming mode must NOT re-fire — same turn.
+      for (let i = 0; i < 5; i++) {
+        session.handleMessage(makeMediaMessage(speechPayload));
+      }
+      expect(onSpeechStart).toHaveBeenCalledTimes(1);
+
+      session.dispose();
     });
   });
 });

--- a/assistant/src/__tests__/media-stream-stt-session.test.ts
+++ b/assistant/src/__tests__/media-stream-stt-session.test.ts
@@ -8,7 +8,12 @@ import {
   test,
 } from "bun:test";
 
-import type { BatchTranscriber, SttTranscribeRequest } from "../stt/types.js";
+import type {
+  BatchTranscriber,
+  StreamingTranscriber,
+  SttStreamServerEvent,
+  SttTranscribeRequest,
+} from "../stt/types.js";
 
 // ---------------------------------------------------------------------------
 // Module mocks — must be declared before the module under test is imported.
@@ -18,6 +23,15 @@ import type { BatchTranscriber, SttTranscribeRequest } from "../stt/types.js";
 mock.module("../providers/speech-to-text/resolve.js", () => ({
   resolveTelephonySttCapability: jest.fn(),
   resolveBatchTranscriber: jest.fn(),
+  resolveStreamingTranscriber: jest.fn(),
+}));
+
+// Controllable streaming flag, read by the session via getConfig().
+let telephonyStreamingFlag = false;
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    calls: { voice: { telephonyStreaming: telephonyStreamingFlag } },
+  }),
 }));
 
 // Mock the logger to suppress output during tests
@@ -34,6 +48,7 @@ mock.module("../util/logger.js", () => ({
 import { MediaStreamSttSession } from "../calls/media-stream-stt-session.js";
 import {
   resolveBatchTranscriber,
+  resolveStreamingTranscriber,
   resolveTelephonySttCapability,
 } from "../providers/speech-to-text/resolve.js";
 
@@ -110,6 +125,45 @@ function makeMockTranscriber(text = "hello world"): BatchTranscriber {
   };
 }
 
+/**
+ * A controllable fake {@link StreamingTranscriber}. `start()` does not resolve
+ * until {@link resolveStart} is called, letting tests assert that frames
+ * arriving before startup are buffered, then flushed on resolution.
+ */
+interface FakeStreamingTranscriber extends StreamingTranscriber {
+  /** Frames passed to sendAudio, in order. */
+  readonly sent: Buffer[];
+  /** Resolve the pending `start()` promise. */
+  resolveStart: () => void;
+  /** Emit a server event to the registered onEvent callback. */
+  emit: (event: SttStreamServerEvent) => void;
+  stop: jest.Mock;
+}
+
+function makeFakeStreamingTranscriber(): FakeStreamingTranscriber {
+  const sent: Buffer[] = [];
+  let onEvent: ((event: SttStreamServerEvent) => void) | null = null;
+  let resolveStartFn: () => void = () => {};
+
+  return {
+    providerId: "deepgram",
+    boundaryId: "daemon-streaming",
+    sent,
+    start: jest.fn((cb: (event: SttStreamServerEvent) => void) => {
+      onEvent = cb;
+      return new Promise<void>((resolve) => {
+        resolveStartFn = resolve;
+      });
+    }),
+    sendAudio: jest.fn((audio: Buffer) => {
+      sent.push(audio);
+    }),
+    stop: jest.fn(),
+    resolveStart: () => resolveStartFn(),
+    emit: (event: SttStreamServerEvent) => onEvent?.(event),
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -117,6 +171,11 @@ function makeMockTranscriber(text = "hello world"): BatchTranscriber {
 describe("MediaStreamSttSession", () => {
   beforeEach(() => {
     jest.useFakeTimers();
+
+    // Default to the batch path so existing batch tests are unaffected.
+    telephonyStreamingFlag = false;
+    (resolveStreamingTranscriber as jest.Mock).mockClear();
+    (resolveStreamingTranscriber as jest.Mock).mockResolvedValue(null);
 
     // Default: provider is supported and transcriber is available
     (resolveTelephonySttCapability as jest.Mock).mockResolvedValue({
@@ -581,6 +640,212 @@ describe("MediaStreamSttSession", () => {
       // No turn should have started, so no transcript emitted
       expect(onSpeechStart).not.toHaveBeenCalled();
       expect(onTranscriptFinal).not.toHaveBeenCalled();
+
+      session.dispose();
+    });
+  });
+
+  // ── Streaming mode ───────────────────────────────────────────────
+
+  describe("streaming mode", () => {
+    test("buffers frames during startup then flushes on start()", async () => {
+      telephonyStreamingFlag = true;
+      const fake = makeFakeStreamingTranscriber();
+      (resolveStreamingTranscriber as jest.Mock).mockResolvedValue(fake);
+
+      const session = new MediaStreamSttSession({}, {});
+
+      session.handleMessage(makeStartMessage());
+      // Let resolveStreamingTranscriber resolve and start() be invoked.
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+      expect(fake.start).toHaveBeenCalledTimes(1);
+
+      // Frames arriving before start() resolves are buffered, not sent.
+      session.handleMessage(makeMediaMessage());
+      session.handleMessage(makeMediaMessage());
+      expect(fake.sent.length).toBe(0);
+
+      // Resolve start() — buffered frames flush in order.
+      fake.resolveStart();
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+      expect(fake.sent.length).toBe(2);
+
+      // Subsequent frames go straight through.
+      session.handleMessage(makeMediaMessage());
+      expect(fake.sent.length).toBe(3);
+
+      session.dispose();
+    });
+
+    test("drops oldest over-cap startup frames and counts them", async () => {
+      telephonyStreamingFlag = true;
+      const fake = makeFakeStreamingTranscriber();
+      (resolveStreamingTranscriber as jest.Mock).mockResolvedValue(fake);
+
+      const session = new MediaStreamSttSession({}, {});
+      session.handleMessage(makeStartMessage());
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+
+      // Feed more than the 500-frame cap while still in startup.
+      const total = 600;
+      for (let i = 0; i < total; i++) {
+        session.handleMessage(makeMediaMessage());
+      }
+      expect(fake.sent.length).toBe(0);
+
+      // Flush — only the most recent 500 frames survive.
+      fake.resolveStart();
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+      expect(fake.sent.length).toBe(500);
+
+      session.dispose();
+    });
+
+    test("fires onSpeechStart from local VAD before any partial", async () => {
+      telephonyStreamingFlag = true;
+      const fake = makeFakeStreamingTranscriber();
+      (resolveStreamingTranscriber as jest.Mock).mockResolvedValue(fake);
+
+      const onSpeechStart = jest.fn();
+      const session = new MediaStreamSttSession({}, { onSpeechStart });
+
+      session.handleMessage(makeStartMessage());
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+
+      // A speech frame fires local-VAD onSpeechStart even before start()
+      // resolves and before any transcriber partial arrives.
+      session.handleMessage(makeMediaMessage());
+      expect(onSpeechStart).toHaveBeenCalledTimes(1);
+
+      session.dispose();
+    });
+
+    test("ignores transcriber partials for barge-in", async () => {
+      telephonyStreamingFlag = true;
+      const fake = makeFakeStreamingTranscriber();
+      (resolveStreamingTranscriber as jest.Mock).mockResolvedValue(fake);
+
+      const onSpeechStart = jest.fn();
+      const onTranscriptFinal = jest.fn();
+      const session = new MediaStreamSttSession(
+        {},
+        { onSpeechStart, onTranscriptFinal },
+      );
+
+      session.handleMessage(makeStartMessage());
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+      fake.resolveStart();
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+
+      fake.emit({ type: "partial", text: "hel" });
+      expect(onSpeechStart).not.toHaveBeenCalled();
+      expect(onTranscriptFinal).not.toHaveBeenCalled();
+
+      session.dispose();
+    });
+
+    test("maps transcriber final to onTranscriptFinal", async () => {
+      telephonyStreamingFlag = true;
+      const fake = makeFakeStreamingTranscriber();
+      (resolveStreamingTranscriber as jest.Mock).mockResolvedValue(fake);
+
+      const onTranscriptFinal = jest.fn();
+      const session = new MediaStreamSttSession({}, { onTranscriptFinal });
+
+      session.handleMessage(makeStartMessage());
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+      fake.resolveStart();
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+
+      fake.emit({ type: "final", text: "hello streaming" });
+      expect(onTranscriptFinal).toHaveBeenCalledTimes(1);
+      expect(onTranscriptFinal).toHaveBeenCalledWith(
+        "hello streaming",
+        expect.any(Number),
+      );
+
+      session.dispose();
+    });
+
+    test("maps transcriber error to onError", async () => {
+      telephonyStreamingFlag = true;
+      const fake = makeFakeStreamingTranscriber();
+      (resolveStreamingTranscriber as jest.Mock).mockResolvedValue(fake);
+
+      const onError = jest.fn();
+      const session = new MediaStreamSttSession({}, { onError });
+
+      session.handleMessage(makeStartMessage());
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+      fake.resolveStart();
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+
+      fake.emit({ type: "error", category: "provider-error", message: "boom" });
+      expect(onError).toHaveBeenCalledWith("provider-error", "boom");
+
+      session.dispose();
+    });
+
+    test("calls transcriber.stop() on dispose", async () => {
+      telephonyStreamingFlag = true;
+      const fake = makeFakeStreamingTranscriber();
+      (resolveStreamingTranscriber as jest.Mock).mockResolvedValue(fake);
+
+      const session = new MediaStreamSttSession({}, {});
+      session.handleMessage(makeStartMessage());
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+      fake.resolveStart();
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+
+      session.dispose();
+      expect(fake.stop).toHaveBeenCalledTimes(1);
+    });
+
+    test("flag disabled falls back to batch path", async () => {
+      telephonyStreamingFlag = false;
+      const fake = makeFakeStreamingTranscriber();
+      (resolveStreamingTranscriber as jest.Mock).mockResolvedValue(fake);
+
+      const onTranscriptFinal = jest.fn();
+      const session = new MediaStreamSttSession(
+        { turnDetector: { silenceThresholdMs: 300 } },
+        { onTranscriptFinal },
+      );
+
+      session.handleMessage(makeStartMessage());
+      session.handleMessage(makeMediaMessage());
+
+      // Streaming transcriber must not be touched in batch mode.
+      expect(resolveStreamingTranscriber as jest.Mock).not.toHaveBeenCalled();
+      expect(fake.start).not.toHaveBeenCalled();
+
+      // Batch transcription still completes.
+      jest.advanceTimersByTime(400);
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+      expect(onTranscriptFinal).toHaveBeenCalledTimes(1);
+
+      session.dispose();
+    });
+
+    test("falls back to batch when no streaming transcriber resolves", async () => {
+      telephonyStreamingFlag = true;
+      (resolveStreamingTranscriber as jest.Mock).mockResolvedValue(null);
+
+      const onTranscriptFinal = jest.fn();
+      const session = new MediaStreamSttSession(
+        { turnDetector: { silenceThresholdMs: 300 } },
+        { onTranscriptFinal },
+      );
+
+      session.handleMessage(makeStartMessage());
+      // Let startStreamingMode resolve and fall through to batch capability.
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+
+      session.handleMessage(makeMediaMessage());
+      jest.advanceTimersByTime(400);
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+
+      expect(onTranscriptFinal).toHaveBeenCalledTimes(1);
 
       session.dispose();
     });

--- a/assistant/src/__tests__/media-stream-stt-session.test.ts
+++ b/assistant/src/__tests__/media-stream-stt-session.test.ts
@@ -677,6 +677,118 @@ describe("MediaStreamSttSession", () => {
       session.dispose();
     });
 
+    test("frames arriving before the resolver resolves are buffered, never sent to the batch turn detector, then flushed in order", async () => {
+      telephonyStreamingFlag = true;
+      const fake = makeFakeStreamingTranscriber();
+      // Keep the resolver pending until we explicitly resolve it, so media
+      // frames land in the "streaming-pending" window.
+      let resolveResolver: (t: StreamingTranscriber) => void = () => {};
+      (resolveStreamingTranscriber as jest.Mock).mockReturnValue(
+        new Promise<StreamingTranscriber>((resolve) => {
+          resolveResolver = resolve;
+        }),
+      );
+
+      const onTranscriptFinal = jest.fn();
+      const onSpeechStart = jest.fn();
+      const session = new MediaStreamSttSession(
+        { turnDetector: { silenceThresholdMs: 300 } },
+        { onTranscriptFinal, onSpeechStart },
+      );
+
+      session.handleMessage(makeStartMessage());
+      // Resolver is still pending — start() has NOT been called yet.
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+      expect(fake.start).not.toHaveBeenCalled();
+
+      // Frames arrive during the resolver-pending window. They must be
+      // buffered (not sent) and must NOT reach the batch turn detector.
+      session.handleMessage(makeMediaMessage());
+      session.handleMessage(makeMediaMessage());
+      // Local-VAD barge-in still fires immediately during the pending window.
+      expect(onSpeechStart).toHaveBeenCalled();
+      expect(fake.sent.length).toBe(0);
+
+      // Advancing past the batch silence threshold must NOT emit a batch
+      // transcript — the frames never entered the batch turn detector.
+      jest.advanceTimersByTime(500);
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+      expect(onTranscriptFinal).not.toHaveBeenCalled();
+
+      // Resolver now yields a live transcriber; start() runs, buffer flushes.
+      resolveResolver(fake);
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+      expect(fake.start).toHaveBeenCalledTimes(1);
+      fake.resolveStart();
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+
+      // Both buffered frames flushed to the streaming transcriber in order.
+      expect(fake.sent.length).toBe(2);
+
+      // Steady state: subsequent frames go straight through, none to batch.
+      session.handleMessage(makeMediaMessage());
+      expect(fake.sent.length).toBe(3);
+      expect(onTranscriptFinal).not.toHaveBeenCalled();
+
+      session.dispose();
+    });
+
+    test("resolver resolving null hands buffered frames to the batch path with no loss or double-processing", async () => {
+      telephonyStreamingFlag = true;
+      let resolveResolver: (t: StreamingTranscriber | null) => void = () => {};
+      (resolveStreamingTranscriber as jest.Mock).mockReturnValue(
+        new Promise<StreamingTranscriber | null>((resolve) => {
+          resolveResolver = resolve;
+        }),
+      );
+
+      const mockTranscriber = makeMockTranscriber("buffered then batched");
+      (resolveBatchTranscriber as jest.Mock).mockResolvedValue(mockTranscriber);
+
+      const onTranscriptFinal = jest.fn();
+      const session = new MediaStreamSttSession(
+        { turnDetector: { silenceThresholdMs: 300 } },
+        { onTranscriptFinal },
+      );
+
+      session.handleMessage(makeStartMessage());
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+
+      // Speech frames arrive during the pending window.
+      const speechPayload = Buffer.alloc(160, 0x00).toString("base64");
+      for (let i = 0; i < 5; i++) {
+        session.handleMessage(makeMediaMessage(speechPayload));
+      }
+
+      // Resolver definitively returns null → fall back to batch, replaying
+      // the buffered frames into the batch pipeline.
+      resolveResolver(null);
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+
+      // Trailing silence ends the (replayed) turn → single batch transcript.
+      const silencePayload = Buffer.alloc(160, 0xff).toString("base64");
+      for (let i = 0; i < 5; i++) {
+        session.handleMessage(makeMediaMessage(silencePayload));
+        jest.advanceTimersByTime(20);
+      }
+      jest.advanceTimersByTime(400);
+      for (let i = 0; i < 20; i++) await Promise.resolve();
+
+      // Buffered frames were transcribed exactly once via the batch path.
+      expect(onTranscriptFinal).toHaveBeenCalledTimes(1);
+      expect(onTranscriptFinal).toHaveBeenCalledWith(
+        "buffered then batched",
+        expect.any(Number),
+      );
+      // The batch transcriber received the buffered speech audio (non-empty).
+      const transcribeMock = mockTranscriber.transcribe as jest.Mock;
+      expect(transcribeMock).toHaveBeenCalledTimes(1);
+      const req = transcribeMock.mock.calls[0][0] as SttTranscribeRequest;
+      expect(req.audio.length).toBeGreaterThan(0);
+
+      session.dispose();
+    });
+
     test("drops oldest over-cap startup frames and counts them", async () => {
       telephonyStreamingFlag = true;
       const fake = makeFakeStreamingTranscriber();

--- a/assistant/src/__tests__/media-stream-stt-session.test.ts
+++ b/assistant/src/__tests__/media-stream-stt-session.test.ts
@@ -19,18 +19,40 @@ import type {
 // Module mocks — must be declared before the module under test is imported.
 // ---------------------------------------------------------------------------
 
-// Mock the STT resolve module
+// Controllable streaming flag + configured STT provider, read by the session
+// via getConfig(). The provider drives isRealtimeStreamingProvider(), which
+// gates the realtime streaming path against the (real, unmocked) catalog:
+// "deepgram"/"google-gemini"/"xai" are realtime-ws; "openai-whisper" is
+// incremental-batch and must use the batch path even when the flag is on.
+// Declared before the resolve.js mock factory so its
+// isRealtimeStreamingProvider stub can read the current provider.
+let telephonyStreamingFlag = false;
+let sttProvider = "deepgram";
+
+// Realtime-streaming providers per the catalog's conversationStreamingMode.
+// Mirrors provider-catalog.ts: deepgram/google-gemini/xai are "realtime-ws";
+// openai-whisper is "incremental-batch". Kept in sync with the catalog so the
+// streaming-gating behaviour under test matches production semantics.
+const REALTIME_STREAMING_PROVIDERS = new Set([
+  "deepgram",
+  "google-gemini",
+  "xai",
+]);
+
+// Mock the STT resolve module. isRealtimeStreamingProvider reflects the
+// configured `sttProvider` against the realtime-provider set above, so the
+// streaming-gating behaviour under test is exercised faithfully.
 mock.module("../providers/speech-to-text/resolve.js", () => ({
   resolveTelephonySttCapability: jest.fn(),
   resolveBatchTranscriber: jest.fn(),
   resolveStreamingTranscriber: jest.fn(),
+  isRealtimeStreamingProvider: () =>
+    REALTIME_STREAMING_PROVIDERS.has(sttProvider),
 }));
-
-// Controllable streaming flag, read by the session via getConfig().
-let telephonyStreamingFlag = false;
 mock.module("../config/loader.js", () => ({
   getConfig: () => ({
     calls: { voice: { telephonyStreaming: telephonyStreamingFlag } },
+    services: { stt: { provider: sttProvider } },
   }),
 }));
 
@@ -174,6 +196,9 @@ describe("MediaStreamSttSession", () => {
 
     // Default to the batch path so existing batch tests are unaffected.
     telephonyStreamingFlag = false;
+    // Default to a realtime-ws provider so streaming-path tests (which set the
+    // flag on) take the streaming path unless they opt into a batch provider.
+    sttProvider = "deepgram";
     (resolveStreamingTranscriber as jest.Mock).mockClear();
     (resolveStreamingTranscriber as jest.Mock).mockResolvedValue(null);
 
@@ -960,6 +985,185 @@ describe("MediaStreamSttSession", () => {
       expect(onTranscriptFinal).toHaveBeenCalledTimes(1);
 
       session.dispose();
+    });
+  });
+
+  // ── Realtime-provider gating (Finding 1) ─────────────────────────
+  //
+  // The realtime streaming path emits mid-call finals only for providers
+  // whose streaming is genuinely realtime (conversationStreamingMode
+  // "realtime-ws"). incremental-batch providers (OpenAI Whisper) only emit a
+  // final on stop(), so they MUST use the batch turn-segmenting path even when
+  // the telephonyStreaming flag is on.
+  describe("realtime-provider gating", () => {
+    test("incremental-batch provider (whisper) uses the BATCH path even when telephonyStreaming is on", async () => {
+      telephonyStreamingFlag = true;
+      sttProvider = "openai-whisper"; // conversationStreamingMode: incremental-batch
+      // If the session wrongly took the streaming path, this fake would be used.
+      const fake = makeFakeStreamingTranscriber();
+      (resolveStreamingTranscriber as jest.Mock).mockResolvedValue(fake);
+
+      const mockTranscriber = makeMockTranscriber("whisper mid-call");
+      (resolveBatchTranscriber as jest.Mock).mockResolvedValue(mockTranscriber);
+
+      const onTranscriptFinal = jest.fn();
+      const onSpeechStart = jest.fn();
+      const session = new MediaStreamSttSession(
+        { turnDetector: { silenceThresholdMs: 300 } },
+        { onTranscriptFinal, onSpeechStart },
+      );
+
+      session.handleMessage(makeStartMessage());
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+
+      // Streaming resolver must never be consulted for a batch provider.
+      expect(resolveStreamingTranscriber as jest.Mock).not.toHaveBeenCalled();
+      expect(fake.start).not.toHaveBeenCalled();
+
+      // Speech then silence segments a turn mid-"call" via the batch path.
+      const speechPayload = Buffer.alloc(160, 0x00).toString("base64");
+      for (let i = 0; i < 5; i++) {
+        session.handleMessage(makeMediaMessage(speechPayload));
+        jest.advanceTimersByTime(20);
+      }
+      expect(onSpeechStart).toHaveBeenCalledTimes(1);
+
+      const silencePayload = Buffer.alloc(160, 0xff).toString("base64");
+      for (let i = 0; i < 5; i++) {
+        session.handleMessage(makeMediaMessage(silencePayload));
+        jest.advanceTimersByTime(20);
+      }
+      jest.advanceTimersByTime(400);
+      for (let i = 0; i < 20; i++) await Promise.resolve();
+
+      // Turn-detector final fired mid-call (before any stop), via batch STT.
+      expect(onTranscriptFinal).toHaveBeenCalledTimes(1);
+      expect(onTranscriptFinal).toHaveBeenCalledWith(
+        "whisper mid-call",
+        expect.any(Number),
+      );
+      expect(fake.start).not.toHaveBeenCalled();
+
+      session.dispose();
+    });
+
+    test("realtime-ws provider (deepgram) still uses the streaming path", async () => {
+      telephonyStreamingFlag = true;
+      sttProvider = "deepgram"; // conversationStreamingMode: realtime-ws
+      const fake = makeFakeStreamingTranscriber();
+      (resolveStreamingTranscriber as jest.Mock).mockResolvedValue(fake);
+
+      const onTranscriptFinal = jest.fn();
+      const session = new MediaStreamSttSession({}, { onTranscriptFinal });
+
+      session.handleMessage(makeStartMessage());
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+
+      // The realtime path resolved and started a streaming transcriber.
+      expect(resolveStreamingTranscriber as jest.Mock).toHaveBeenCalledTimes(1);
+      expect(fake.start).toHaveBeenCalledTimes(1);
+
+      fake.resolveStart();
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+
+      // Provider final maps straight through (no stop needed).
+      fake.emit({ type: "final", text: "realtime final" });
+      expect(onTranscriptFinal).toHaveBeenCalledWith(
+        "realtime final",
+        expect.any(Number),
+      );
+
+      session.dispose();
+    });
+  });
+
+  // ── Stop/dispose during streaming-pending (Finding 2) ────────────
+  describe("stop during streaming-pending", () => {
+    test("stop while the resolver is still pending replays buffered frames through the batch path so the final utterance is transcribed", async () => {
+      telephonyStreamingFlag = true;
+      sttProvider = "deepgram"; // realtime-ws → streaming path attempted
+      // Keep the resolver pending so frames land in the streaming-pending window.
+      let resolveResolver: (t: StreamingTranscriber | null) => void = () => {};
+      (resolveStreamingTranscriber as jest.Mock).mockReturnValue(
+        new Promise<StreamingTranscriber | null>((resolve) => {
+          resolveResolver = resolve;
+        }),
+      );
+
+      const mockTranscriber = makeMockTranscriber("buffered utterance");
+      (resolveBatchTranscriber as jest.Mock).mockResolvedValue(mockTranscriber);
+
+      const onTranscriptFinal = jest.fn();
+      const onStop = jest.fn();
+      const session = new MediaStreamSttSession(
+        { turnDetector: { silenceThresholdMs: 300 } },
+        { onTranscriptFinal, onStop },
+      );
+
+      session.handleMessage(makeStartMessage());
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+      // Resolver still pending — start() not yet called.
+      expect((resolveStreamingTranscriber as jest.Mock).mock.calls.length).toBe(
+        1,
+      );
+
+      // Caller's final utterance arrives during the pending window — buffered.
+      const speechPayload = Buffer.alloc(160, 0x00).toString("base64");
+      for (let i = 0; i < 5; i++) {
+        session.handleMessage(makeMediaMessage(speechPayload));
+      }
+
+      // Twilio sends stop before the resolver settles (short call / slow handshake).
+      session.handleMessage(makeStopMessage());
+      expect(onStop).toHaveBeenCalledTimes(1);
+      for (let i = 0; i < 20; i++) await Promise.resolve();
+
+      // The buffered utterance was replayed through the batch path and
+      // transcribed — not lost.
+      expect(onTranscriptFinal).toHaveBeenCalledTimes(1);
+      expect(onTranscriptFinal).toHaveBeenCalledWith(
+        "buffered utterance",
+        expect.any(Number),
+      );
+      const transcribeMock = mockTranscriber.transcribe as jest.Mock;
+      expect(transcribeMock).toHaveBeenCalledTimes(1);
+      const req = transcribeMock.mock.calls[0][0] as SttTranscribeRequest;
+      expect(req.audio.length).toBeGreaterThan(0);
+
+      // A late-resolving transcriber must NOT resurrect the streaming path or
+      // re-transcribe; it is stopped and discarded.
+      const fake = makeFakeStreamingTranscriber();
+      resolveResolver(fake);
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+      expect(fake.start).not.toHaveBeenCalled();
+      expect(onTranscriptFinal).toHaveBeenCalledTimes(1);
+
+      session.dispose();
+    });
+
+    test("dispose during streaming-pending stops a late-resolved transcriber and does not leak", async () => {
+      telephonyStreamingFlag = true;
+      sttProvider = "deepgram";
+      let resolveResolver: (t: StreamingTranscriber | null) => void = () => {};
+      (resolveStreamingTranscriber as jest.Mock).mockReturnValue(
+        new Promise<StreamingTranscriber | null>((resolve) => {
+          resolveResolver = resolve;
+        }),
+      );
+
+      const session = new MediaStreamSttSession({}, {});
+      session.handleMessage(makeStartMessage());
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+
+      // Dispose before the resolver settles.
+      session.dispose();
+
+      // Resolver settles late — its transcriber must be torn down, never started.
+      const fake = makeFakeStreamingTranscriber();
+      resolveResolver(fake);
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+      expect(fake.start).not.toHaveBeenCalled();
+      expect(fake.stop).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/assistant/src/calls/media-stream-stt-session.ts
+++ b/assistant/src/calls/media-stream-stt-session.ts
@@ -19,6 +19,7 @@
 
 import { getConfig } from "../config/loader.js";
 import {
+  isRealtimeStreamingProvider,
   resolveStreamingTranscriber,
   resolveTelephonySttCapability,
   type TelephonySttCapability,
@@ -181,6 +182,17 @@ export class MediaStreamSttSession {
   private streamingReady = false;
 
   /**
+   * Set when a Twilio `stop` arrives (or {@link dispose} is called) while the
+   * session is still in `"streaming-pending"` — i.e. before the streaming
+   * resolver/`start()` has settled. Once set, the in-flight
+   * {@link startStreamingMode} must NOT commit to streaming: a late-resolved
+   * transcriber is stopped and discarded so it doesn't resurrect the streaming
+   * path after the call has already ended (and its buffered frames flushed to
+   * batch).
+   */
+  private streamingAborted = false;
+
+  /**
    * Inbound raw base64 mu-law payloads buffered during the
    * `"streaming-pending"` window. Held as raw payloads (not decoded PCM) so
    * they can be flushed into EITHER path once the mode resolves: decoded and
@@ -255,6 +267,10 @@ export class MediaStreamSttSession {
    */
   dispose(): void {
     this.disposed = true;
+    // If a streaming startup is still in flight, mark it aborted so the
+    // pending resolver tears down (and does not leak) any late-resolved
+    // transcriber rather than committing to streaming on a dead session.
+    this.streamingAborted = true;
     this.activeTranscriptionAbort?.abort();
     this.activeTranscriptionAbort = null;
     this.turnDetector.dispose();
@@ -312,19 +328,37 @@ export class MediaStreamSttSession {
   }
 
   /**
-   * Whether streaming STT should be attempted for this session, per the
-   * `calls.voice.telephonyStreaming` config flag (or an explicit override).
+   * Whether the realtime streaming STT path should be attempted for this
+   * session.
+   *
+   * Two conditions must hold:
+   * 1. The `calls.voice.telephonyStreaming` config flag is on (or
+   *    `forceStreaming` overrides it — primarily for tests).
+   * 2. The configured STT provider's streaming is *genuinely realtime*
+   *    (`conversationStreamingMode === "realtime-ws"`). Providers like OpenAI
+   *    Whisper are `incremental-batch`: their streaming transcriber only emits
+   *    a `final` on `stop()`, so the realtime path would never produce a
+   *    mid-call transcript. Those must use the batch turn-segmenting path.
+   *
+   * When `forceStreaming` is set it bypasses BOTH the config flag and the
+   * provider realtime check, so tests can exercise the streaming path with a
+   * fake transcriber regardless of the configured provider.
    */
   private streamingEnabled(): boolean {
     if (this.config.forceStreaming !== undefined) {
       return this.config.forceStreaming;
     }
+    let flagOn = false;
     try {
-      return getConfig().calls.voice.telephonyStreaming;
+      flagOn = getConfig().calls.voice.telephonyStreaming;
     } catch {
       // Config unavailable (early startup / tests) — default to batch path.
       return false;
     }
+    if (!flagOn) return false;
+    // Only take the realtime path for providers that stream in true realtime;
+    // incremental-batch providers (e.g. Whisper) use the batch path.
+    return isRealtimeStreamingProvider();
   }
 
   /**
@@ -341,7 +375,7 @@ export class MediaStreamSttSession {
         sampleRate: STREAMING_SAMPLE_RATE,
       });
     } catch (err) {
-      if (this.disposed) return;
+      if (this.disposed || this.streamingAborted) return;
       // Resolver threw — definitively fall back to batch and replay the
       // frames buffered during the pending window so none are lost.
       const normalized = normalizeSttError(err);
@@ -349,7 +383,9 @@ export class MediaStreamSttSession {
       this.fallBackToBatch();
       return;
     }
-    if (this.disposed) {
+    if (this.disposed || this.streamingAborted) {
+      // Stop/dispose landed during the pending window; the buffered frames
+      // were already flushed to the batch path. Discard the late transcriber.
       transcriber?.stop();
       return;
     }
@@ -370,7 +406,10 @@ export class MediaStreamSttSession {
     try {
       await transcriber.start((event) => this.handleStreamingEvent(event));
     } catch (err) {
-      if (this.disposed) return;
+      if (this.disposed || this.streamingAborted) {
+        this.streamingTranscriber = null;
+        return;
+      }
       // `start()` threw — drop the transcriber and fall back to batch,
       // replaying the buffered frames into the batch path.
       this.streamingTranscriber = null;
@@ -379,8 +418,11 @@ export class MediaStreamSttSession {
       this.fallBackToBatch();
       return;
     }
-    if (this.disposed) {
+    if (this.disposed || this.streamingAborted) {
+      // Stop/dispose landed during the pending window; buffered frames already
+      // went to the batch path. Tear the late transcriber down.
       transcriber.stop();
+      this.streamingTranscriber = null;
       return;
     }
 
@@ -541,6 +583,16 @@ export class MediaStreamSttSession {
       this.streamingTranscriber.stop();
       this.callbacks.onStop?.();
       return;
+    }
+
+    if (this.mode === "streaming-pending") {
+      // Stop arrived before the streaming resolver settled. The buffered
+      // startup frames live only in streamingStartupBuffer and have not
+      // reached the turn detector. Abort the in-flight streaming startup and
+      // replay those frames through the batch path so the caller's final
+      // utterance is transcribed instead of lost.
+      this.streamingAborted = true;
+      this.fallBackToBatch();
     }
 
     // Batch path: finalize any in-flight turn.

--- a/assistant/src/calls/media-stream-stt-session.ts
+++ b/assistant/src/calls/media-stream-stt-session.ts
@@ -69,6 +69,22 @@ export interface MediaStreamSttSessionConfig {
 const DEFAULT_TRANSCRIPTION_TIMEOUT_MS = 10_000;
 
 /**
+ * Approximate wall-clock duration of a single Twilio media frame, in
+ * milliseconds. Twilio sends 8 kHz mu-law in ~20 ms (160-sample) frames. Used
+ * to convert the turn-detector silence threshold (ms) into a frame count for
+ * the streaming speech-start gate.
+ */
+const TELEPHONY_FRAME_MS = 20;
+
+/**
+ * Default silence threshold (ms) used to reset the streaming speech-start gate
+ * when no explicit turn-detector silence threshold is configured. Mirrors the
+ * batch {@link MediaTurnDetector} default so streaming barge-in turns are
+ * debounced on the same cadence as batch turns.
+ */
+const DEFAULT_STREAMING_SILENCE_THRESHOLD_MS = 800;
+
+/**
  * Sample rate (Hz) of Twilio telephony media-stream audio.
  */
 const TELEPHONY_SAMPLE_RATE = 8_000;
@@ -207,6 +223,28 @@ export class MediaStreamSttSession {
    */
   private streamingStartupFramesDropped = 0;
 
+  // ── Streaming speech-start gate ────────────────────────────────────
+  //
+  // In streaming mode the local VAD classifies EVERY 20 ms media frame, so a
+  // single utterance produces a long run of speech-bearing frames. Firing
+  // onSpeechStart for each one repeatedly clears outbound audio and inflates
+  // turn diagnostics. We gate it to once per speech turn (the silence→speech
+  // rising edge), then arm it again only after an intervening silence gap —
+  // mirroring how the batch MediaTurnDetector debounces turn starts.
+
+  /** Whether a streaming speech turn is currently in progress. */
+  private streamingSpeechActive = false;
+
+  /** Consecutive silence (non-speech) frames seen since the last speech frame. */
+  private streamingSilenceFrames = 0;
+
+  /**
+   * Number of consecutive silence frames that resets the speech-start gate.
+   * Derived from the configured turn-detector silence threshold so streaming
+   * barge-in is debounced on the same cadence as batch turn segmentation.
+   */
+  private readonly streamingSilenceResetFrames: number;
+
   constructor(
     config: MediaStreamSttSessionConfig = {},
     callbacks: MediaStreamSttSessionCallbacks = {},
@@ -215,6 +253,18 @@ export class MediaStreamSttSession {
     this.callbacks = callbacks;
     this.transcriptionTimeoutMs =
       config.transcriptionTimeoutMs ?? DEFAULT_TRANSCRIPTION_TIMEOUT_MS;
+
+    // Convert the configured silence threshold (ms) into a frame count so the
+    // streaming speech-start gate resets after the same amount of silence that
+    // ends a batch turn. At least one frame so a single silent frame can never
+    // be required to be fractional.
+    const silenceThresholdMs =
+      config.turnDetector?.silenceThresholdMs ??
+      DEFAULT_STREAMING_SILENCE_THRESHOLD_MS;
+    this.streamingSilenceResetFrames = Math.max(
+      1,
+      Math.round(silenceThresholdMs / TELEPHONY_FRAME_MS),
+    );
 
     this.turnDetector = new MediaTurnDetector(config.turnDetector, {
       onTurnStart: () => {
@@ -286,7 +336,12 @@ export class MediaStreamSttSession {
       );
     }
 
-    if (this.streamingTranscriber) {
+    // Only tear the transcriber down here when streaming has fully committed
+    // (`mode === "streaming"`). While `"streaming-pending"`, the in-flight
+    // startStreamingMode owns the (local) transcriber: streamingAborted is set
+    // above, so when its `start()` settles it stops and discards the late
+    // transcriber itself — stopping it here too would double-stop it.
+    if (this.mode === "streaming" && this.streamingTranscriber) {
       this.streamingTranscriber.stop();
       this.streamingTranscriber = null;
     }
@@ -492,12 +547,11 @@ export class MediaStreamSttSession {
     switch (this.mode) {
       case "streaming-pending":
         // Streaming resolver still in flight. Drive barge-in immediately from
-        // the local VAD, but buffer the raw payload — it must NOT reach the
-        // batch turn detector, or the first utterance would be split across
-        // both paths. The buffer is replayed into whichever path wins.
-        if (detectSpeechActivity(payload)) {
-          this.callbacks.onSpeechStart?.();
-        }
+        // the local VAD (coalesced to once per speech turn), but buffer the raw
+        // payload — it must NOT reach the batch turn detector, or the first
+        // utterance would be split across both paths. The buffer is replayed
+        // into whichever path wins.
+        this.noteStreamingSpeechActivity(detectSpeechActivity(payload));
         this.bufferStartupFrame(payload);
         return;
 
@@ -519,16 +573,50 @@ export class MediaStreamSttSession {
    * barge-in, and send to the (ready) transcriber.
    */
   private handleStreamingMedia(base64Payload: string): void {
-    // Drive barge-in from the fast local VAD (energy heuristic).
-    if (detectSpeechActivity(base64Payload)) {
-      this.callbacks.onSpeechStart?.();
-    }
+    // Drive barge-in from the fast local VAD (energy heuristic), coalesced to
+    // once per speech turn so a normal utterance does not repeatedly clear
+    // outbound audio or inflate turn diagnostics.
+    this.noteStreamingSpeechActivity(detectSpeechActivity(base64Payload));
 
     const pcm = this.decodeForStreaming(base64Payload);
     if (!pcm) return;
 
     if (this.streamingReady) {
       this.streamingTranscriber?.sendAudio(pcm, STREAMING_PCM_MIME);
+    }
+  }
+
+  /**
+   * Coalesce streaming speech-start callbacks to once per speech turn.
+   *
+   * Fires `onSpeechStart` only on the silence→speech rising edge (immediately,
+   * to keep barge-in responsive), then suppresses further callbacks until an
+   * intervening run of {@link streamingSilenceResetFrames} consecutive silence
+   * frames re-arms the gate. This mirrors how the batch {@link MediaTurnDetector}
+   * debounces `onTurnStart` to once per turn.
+   *
+   * @param hasSpeech - Whether the current 20 ms frame contains speech.
+   */
+  private noteStreamingSpeechActivity(hasSpeech: boolean): void {
+    if (hasSpeech) {
+      this.streamingSilenceFrames = 0;
+      if (!this.streamingSpeechActive) {
+        // Rising edge: start of a new speech turn. Fire once.
+        this.streamingSpeechActive = true;
+        this.callbacks.onSpeechStart?.();
+      }
+      return;
+    }
+
+    // Silence frame: count toward the reset threshold while a turn is active.
+    if (this.streamingSpeechActive) {
+      this.streamingSilenceFrames++;
+      if (this.streamingSilenceFrames >= this.streamingSilenceResetFrames) {
+        // Silence gap long enough to close the turn — re-arm the gate so the
+        // next speech frame fires onSpeechStart again.
+        this.streamingSpeechActive = false;
+        this.streamingSilenceFrames = 0;
+      }
     }
   }
 
@@ -577,20 +665,29 @@ export class MediaStreamSttSession {
   }
 
   private handleStop(): void {
-    if (this.streamingTranscriber) {
+    // Treat the streaming transcriber as live ONLY when the mode has fully
+    // committed to `"streaming"`. While `"streaming-pending"`, the transcriber
+    // object may already be set (resolver returned, but `start()` is still
+    // awaiting the provider handshake) — taking the "live" branch there would
+    // stop()/onStop() and return WITHOUT replaying streamingStartupBuffer to
+    // batch, losing the caller's final utterance on short calls / slow
+    // handshakes.
+    if (this.mode === "streaming") {
       // Streaming mode: signal end-of-audio. The transcriber may emit a
       // final transcript and then a `closed` event (which drives onStop).
-      this.streamingTranscriber.stop();
+      this.streamingTranscriber?.stop();
       this.callbacks.onStop?.();
       return;
     }
 
     if (this.mode === "streaming-pending") {
-      // Stop arrived before the streaming resolver settled. The buffered
+      // Stop arrived before the streaming startup settled (resolver pending,
+      // or resolver returned but `start()` still in flight). The buffered
       // startup frames live only in streamingStartupBuffer and have not
-      // reached the turn detector. Abort the in-flight streaming startup and
-      // replay those frames through the batch path so the caller's final
-      // utterance is transcribed instead of lost.
+      // reached the turn detector. Abort the in-flight streaming startup so a
+      // late-resolved transcriber does not resurrect streaming, and replay
+      // those frames through the batch path so the caller's final utterance is
+      // transcribed instead of lost.
       this.streamingAborted = true;
       this.fallBackToBatch();
     }

--- a/assistant/src/calls/media-stream-stt-session.ts
+++ b/assistant/src/calls/media-stream-stt-session.ts
@@ -17,14 +17,21 @@
  *   are reported through `onError` without tearing down the session.
  */
 
+import { getConfig } from "../config/loader.js";
 import {
+  resolveStreamingTranscriber,
   resolveTelephonySttCapability,
   type TelephonySttCapability,
 } from "../providers/speech-to-text/resolve.js";
 import { resolveBatchTranscriber } from "../providers/speech-to-text/resolve.js";
 import { normalizeSttError } from "../stt/daemon-batch-transcriber.js";
-import type { SttCallContextHints } from "../stt/types.js";
+import type {
+  StreamingTranscriber,
+  SttCallContextHints,
+  SttStreamServerEvent,
+} from "../stt/types.js";
 import { getLogger } from "../util/logger.js";
+import { mulawToPcm16, resamplePcm16 } from "./media-stream-audio-transcode.js";
 import { parseMediaStreamFrame } from "./media-stream-parser.js";
 import type {
   MediaStreamMediaEvent,
@@ -50,9 +57,39 @@ export interface MediaStreamSttSessionConfig {
 
   /** Optional call-context hints forwarded to the STT provider. */
   callContextHints?: SttCallContextHints;
+
+  /**
+   * Force streaming on/off, bypassing the `calls.voice.telephonyStreaming`
+   * config flag. Primarily for tests. When omitted, the config flag decides.
+   */
+  forceStreaming?: boolean;
 }
 
 const DEFAULT_TRANSCRIPTION_TIMEOUT_MS = 10_000;
+
+/**
+ * Sample rate (Hz) of Twilio telephony media-stream audio.
+ */
+const TELEPHONY_SAMPLE_RATE = 8_000;
+
+/**
+ * Sample rate (Hz) we upsample telephony audio to before feeding the
+ * streaming transcriber. Streaming adapters default to 16 kHz, so we
+ * resample once and configure the transcriber for the same rate.
+ */
+const STREAMING_SAMPLE_RATE = 16_000;
+
+/** MIME type for the raw PCM16 frames sent to the streaming transcriber. */
+const STREAMING_PCM_MIME = "audio/pcm";
+
+/**
+ * Maximum number of inbound PCM frames buffered while the streaming
+ * transcriber is starting up. Each frame is ~20 ms of audio, so this caps
+ * the startup buffer at roughly 10 seconds — far longer than any real
+ * provider handshake. Frames beyond the cap drop oldest-first and increment
+ * a diagnostic counter logged on teardown.
+ */
+const MAX_STREAMING_STARTUP_FRAMES = 500;
 
 // ---------------------------------------------------------------------------
 // Callback hooks
@@ -115,6 +152,29 @@ export class MediaStreamSttSession {
 
   /** Session-level abort controller for the active transcription request. */
   private activeTranscriptionAbort: AbortController | null = null;
+
+  // ── Streaming-mode state ───────────────────────────────────────────
+
+  /**
+   * Active streaming transcriber, set once at `handleStart` when streaming
+   * mode is selected. `null` means the batch fallback path is in use.
+   */
+  private streamingTranscriber: StreamingTranscriber | null = null;
+
+  /** Whether the streaming transcriber's `start()` promise has resolved. */
+  private streamingReady = false;
+
+  /**
+   * Inbound PCM frames buffered while the streaming transcriber starts up.
+   * Flushed (and cleared) once `start()` resolves.
+   */
+  private streamingStartupBuffer: Buffer[] = [];
+
+  /**
+   * Count of frames dropped from the bounded startup buffer because it
+   * exceeded {@link MAX_STREAMING_STARTUP_FRAMES}. Logged on teardown.
+   */
+  private streamingStartupFramesDropped = 0;
 
   constructor(
     config: MediaStreamSttSessionConfig = {},
@@ -180,6 +240,23 @@ export class MediaStreamSttSession {
     this.activeTranscriptionAbort = null;
     this.turnDetector.dispose();
     this.currentTurnChunks = [];
+
+    if (this.streamingStartupFramesDropped > 0) {
+      log.warn(
+        {
+          streamSid: this.streamSid,
+          dropped: this.streamingStartupFramesDropped,
+        },
+        "Dropped media frames from streaming startup buffer (over cap)",
+      );
+    }
+
+    if (this.streamingTranscriber) {
+      this.streamingTranscriber.stop();
+      this.streamingTranscriber = null;
+    }
+    this.streamingReady = false;
+    this.streamingStartupBuffer = [];
   }
 
   // ── Event handlers ─────────────────────────────────────────────────
@@ -199,18 +276,135 @@ export class MediaStreamSttSession {
       "Media stream STT session started",
     );
 
-    // Eagerly resolve capability so it's cached by the time the first
-    // turn completes.
+    // Select streaming vs batch ONCE at start; do not mix paths thereafter.
+    if (this.streamingEnabled()) {
+      void this.startStreamingMode();
+      return;
+    }
+
+    // Batch fallback path: eagerly resolve capability so it's cached by the
+    // time the first turn completes.
     this.capabilityPromise = resolveTelephonySttCapability();
+  }
+
+  /**
+   * Whether streaming STT should be attempted for this session, per the
+   * `calls.voice.telephonyStreaming` config flag (or an explicit override).
+   */
+  private streamingEnabled(): boolean {
+    if (this.config.forceStreaming !== undefined) {
+      return this.config.forceStreaming;
+    }
+    try {
+      return getConfig().calls.voice.telephonyStreaming;
+    } catch {
+      // Config unavailable (early startup / tests) — default to batch path.
+      return false;
+    }
+  }
+
+  /**
+   * Open a streaming transcriber for the session. Inbound frames that arrive
+   * before `start()` resolves are buffered (bounded) and flushed on success.
+   * Falls back to the batch path if no streaming transcriber is available.
+   */
+  private async startStreamingMode(): Promise<void> {
+    let transcriber: StreamingTranscriber | null;
+    try {
+      transcriber = await resolveStreamingTranscriber({
+        // We resample telephony audio up to STREAMING_SAMPLE_RATE before
+        // sending, so configure the transcriber for that selected rate.
+        sampleRate: STREAMING_SAMPLE_RATE,
+      });
+    } catch (err) {
+      if (this.disposed) return;
+      const normalized = normalizeSttError(err);
+      this.callbacks.onError?.(normalized.category, normalized.message);
+      return;
+    }
+    if (this.disposed) {
+      transcriber?.stop();
+      return;
+    }
+
+    if (!transcriber) {
+      // No streaming transcriber — fall back to the batch path.
+      log.info(
+        { streamSid: this.streamSid },
+        "No streaming transcriber available; falling back to batch STT",
+      );
+      this.capabilityPromise = resolveTelephonySttCapability();
+      return;
+    }
+
+    this.streamingTranscriber = transcriber;
+
+    try {
+      await transcriber.start((event) => this.handleStreamingEvent(event));
+    } catch (err) {
+      if (this.disposed) return;
+      this.streamingTranscriber = null;
+      this.streamingStartupBuffer = [];
+      const normalized = normalizeSttError(err);
+      this.callbacks.onError?.(normalized.category, normalized.message);
+      return;
+    }
+    if (this.disposed) {
+      transcriber.stop();
+      return;
+    }
+
+    // Flush any frames buffered during startup, then enter steady state.
+    this.streamingReady = true;
+    const buffered = this.streamingStartupBuffer;
+    this.streamingStartupBuffer = [];
+    for (const frame of buffered) {
+      transcriber.sendAudio(frame, STREAMING_PCM_MIME);
+    }
+  }
+
+  /**
+   * Handle a server event from the streaming transcriber. `onSpeechStart`
+   * is driven by local VAD (for barge-in latency), so partials are not
+   * surfaced here — only finals, errors, and close.
+   */
+  private handleStreamingEvent(event: SttStreamServerEvent): void {
+    if (this.disposed) return;
+    switch (event.type) {
+      case "final":
+        this.callbacks.onTranscriptFinal?.(event.text, 0);
+        break;
+      case "error":
+        this.callbacks.onError?.(event.category, event.message);
+        break;
+      case "closed":
+        // Session-level `onStop` is driven by the Twilio `stop` event
+        // (`handleStop`); the provider `closed` event is teardown only.
+        this.streamingReady = false;
+        break;
+      case "partial":
+        // Partials are intentionally ignored — barge-in is driven by the
+        // fast local VAD instead of waiting for the first partial.
+        break;
+    }
   }
 
   private handleMedia(event: MediaStreamMediaEvent): void {
     // Only process inbound (caller) audio
     if (event.media.track !== "inbound") return;
 
-    // Compute speech activity from the audio payload using a lightweight
-    // energy heuristic. mu-law encoded audio has a companded dynamic
-    // range — silence sits near 0xFF/0x7F while speech has higher energy.
+    // Streaming mode: route decoded PCM into the transcriber and drive
+    // barge-in (`onSpeechStart`) from the fast local energy VAD rather than
+    // waiting for the transcriber's first partial.
+    if (this.streamingTranscriber) {
+      this.handleStreamingMedia(event.media.payload);
+      return;
+    }
+
+    // Batch path: compute speech activity from the audio payload using a
+    // lightweight energy heuristic. mu-law encoded audio has a companded
+    // dynamic range — silence sits near 0xFF/0x7F while speech has higher
+    // energy.
     //
     // The detector call runs BEFORE the push so that the onTurnStart
     // callback can clear stale inter-turn silence from the buffer
@@ -221,8 +415,56 @@ export class MediaStreamSttSession {
     this.currentTurnChunks.push(event.media.payload);
   }
 
+  /**
+   * Route a single inbound media frame through the streaming pipeline:
+   * decode mu-law → PCM16, resample to the streaming rate, fire local-VAD
+   * barge-in, and either send to the transcriber or buffer during startup.
+   */
+  private handleStreamingMedia(base64Payload: string): void {
+    // Drive barge-in from the fast local VAD (energy heuristic).
+    if (detectSpeechActivity(base64Payload)) {
+      this.callbacks.onSpeechStart?.();
+    }
+
+    let mulaw: Buffer;
+    try {
+      mulaw = Buffer.from(base64Payload, "base64");
+    } catch {
+      return;
+    }
+    if (mulaw.length === 0) return;
+
+    const pcm8k = mulawToPcm16(mulaw);
+    const pcm = resamplePcm16(
+      pcm8k,
+      TELEPHONY_SAMPLE_RATE,
+      STREAMING_SAMPLE_RATE,
+    );
+
+    if (this.streamingReady) {
+      this.streamingTranscriber?.sendAudio(pcm, STREAMING_PCM_MIME);
+      return;
+    }
+
+    // Transcriber still starting up — buffer with a bounded cap, dropping
+    // oldest frames (and counting them) rather than growing unbounded.
+    this.streamingStartupBuffer.push(pcm);
+    while (this.streamingStartupBuffer.length > MAX_STREAMING_STARTUP_FRAMES) {
+      this.streamingStartupBuffer.shift();
+      this.streamingStartupFramesDropped++;
+    }
+  }
+
   private handleStop(): void {
-    // Finalize any in-flight turn
+    if (this.streamingTranscriber) {
+      // Streaming mode: signal end-of-audio. The transcriber may emit a
+      // final transcript and then a `closed` event (which drives onStop).
+      this.streamingTranscriber.stop();
+      this.callbacks.onStop?.();
+      return;
+    }
+
+    // Batch path: finalize any in-flight turn.
     this.turnDetector.forceEnd();
     this.callbacks.onStop?.();
   }

--- a/assistant/src/calls/media-stream-stt-session.ts
+++ b/assistant/src/calls/media-stream-stt-session.ts
@@ -156,8 +156,24 @@ export class MediaStreamSttSession {
   // ── Streaming-mode state ───────────────────────────────────────────
 
   /**
-   * Active streaming transcriber, set once at `handleStart` when streaming
-   * mode is selected. `null` means the batch fallback path is in use.
+   * Mode decided synchronously at {@link handleStart}, before any resolver is
+   * awaited:
+   * - `"batch"` — streaming flag is off; use the batch turn detector.
+   * - `"streaming-pending"` — streaming flag is on and the transcriber
+   *   resolver is still in flight. ALL inbound media frames are buffered into
+   *   {@link streamingStartupBuffer} during this window; none reach the batch
+   *   turn detector, so an utterance is never split across the two paths.
+   * - `"streaming"` — a live transcriber resolved and started.
+   *
+   * Once the resolver settles, `"streaming-pending"` transitions to either
+   * `"streaming"` (live transcriber → flush buffer into it) or `"batch"`
+   * (resolver returned null/threw → feed buffered frames into the batch path).
+   */
+  private mode: "batch" | "streaming-pending" | "streaming" = "batch";
+
+  /**
+   * Active streaming transcriber, set once the resolver yields a live
+   * transcriber. `null` while pending or when the batch fallback is in use.
    */
   private streamingTranscriber: StreamingTranscriber | null = null;
 
@@ -165,10 +181,13 @@ export class MediaStreamSttSession {
   private streamingReady = false;
 
   /**
-   * Inbound PCM frames buffered while the streaming transcriber starts up.
-   * Flushed (and cleared) once `start()` resolves.
+   * Inbound raw base64 mu-law payloads buffered during the
+   * `"streaming-pending"` window. Held as raw payloads (not decoded PCM) so
+   * they can be flushed into EITHER path once the mode resolves: decoded and
+   * sent to the streaming transcriber, or fed through the batch turn detector.
+   * Flushed (and cleared) once the resolver settles.
    */
-  private streamingStartupBuffer: Buffer[] = [];
+  private streamingStartupBuffer: string[] = [];
 
   /**
    * Count of frames dropped from the bounded startup buffer because it
@@ -277,13 +296,18 @@ export class MediaStreamSttSession {
     );
 
     // Select streaming vs batch ONCE at start; do not mix paths thereafter.
+    // The decision is recorded SYNCHRONOUSLY here so that media frames arriving
+    // before the (async) streaming resolver settles are buffered into the
+    // startup buffer rather than leaking into the batch turn detector.
     if (this.streamingEnabled()) {
+      this.mode = "streaming-pending";
       void this.startStreamingMode();
       return;
     }
 
     // Batch fallback path: eagerly resolve capability so it's cached by the
     // time the first turn completes.
+    this.mode = "batch";
     this.capabilityPromise = resolveTelephonySttCapability();
   }
 
@@ -318,8 +342,11 @@ export class MediaStreamSttSession {
       });
     } catch (err) {
       if (this.disposed) return;
+      // Resolver threw — definitively fall back to batch and replay the
+      // frames buffered during the pending window so none are lost.
       const normalized = normalizeSttError(err);
       this.callbacks.onError?.(normalized.category, normalized.message);
+      this.fallBackToBatch();
       return;
     }
     if (this.disposed) {
@@ -328,12 +355,13 @@ export class MediaStreamSttSession {
     }
 
     if (!transcriber) {
-      // No streaming transcriber — fall back to the batch path.
+      // No streaming transcriber — fall back to the batch path and replay the
+      // frames buffered during the pending window.
       log.info(
         { streamSid: this.streamSid },
         "No streaming transcriber available; falling back to batch STT",
       );
-      this.capabilityPromise = resolveTelephonySttCapability();
+      this.fallBackToBatch();
       return;
     }
 
@@ -343,10 +371,12 @@ export class MediaStreamSttSession {
       await transcriber.start((event) => this.handleStreamingEvent(event));
     } catch (err) {
       if (this.disposed) return;
+      // `start()` threw — drop the transcriber and fall back to batch,
+      // replaying the buffered frames into the batch path.
       this.streamingTranscriber = null;
-      this.streamingStartupBuffer = [];
       const normalized = normalizeSttError(err);
       this.callbacks.onError?.(normalized.category, normalized.message);
+      this.fallBackToBatch();
       return;
     }
     if (this.disposed) {
@@ -354,12 +384,34 @@ export class MediaStreamSttSession {
       return;
     }
 
-    // Flush any frames buffered during startup, then enter steady state.
+    // Live transcriber is ready. Commit to streaming mode and flush the frames
+    // buffered during the pending window (decode → resample → send) in order.
+    this.mode = "streaming";
     this.streamingReady = true;
     const buffered = this.streamingStartupBuffer;
     this.streamingStartupBuffer = [];
-    for (const frame of buffered) {
-      transcriber.sendAudio(frame, STREAMING_PCM_MIME);
+    for (const payload of buffered) {
+      const pcm = this.decodeForStreaming(payload);
+      if (pcm) transcriber.sendAudio(pcm, STREAMING_PCM_MIME);
+    }
+  }
+
+  /**
+   * Resolver did not yield a usable streaming transcriber (flag-on but null,
+   * or `start()`/resolver threw). Commit to the batch path, eagerly resolve
+   * telephony capability, and replay any frames buffered during the pending
+   * window through the batch pipeline so the first utterance is not lost.
+   */
+  private fallBackToBatch(): void {
+    this.mode = "batch";
+    this.streamingTranscriber = null;
+    this.streamingReady = false;
+    this.capabilityPromise = resolveTelephonySttCapability();
+
+    const buffered = this.streamingStartupBuffer;
+    this.streamingStartupBuffer = [];
+    for (const payload of buffered) {
+      this.feedBatch(payload);
     }
   }
 
@@ -393,32 +445,36 @@ export class MediaStreamSttSession {
     // Only process inbound (caller) audio
     if (event.media.track !== "inbound") return;
 
-    // Streaming mode: route decoded PCM into the transcriber and drive
-    // barge-in (`onSpeechStart`) from the fast local energy VAD rather than
-    // waiting for the transcriber's first partial.
-    if (this.streamingTranscriber) {
-      this.handleStreamingMedia(event.media.payload);
-      return;
+    const payload = event.media.payload;
+
+    switch (this.mode) {
+      case "streaming-pending":
+        // Streaming resolver still in flight. Drive barge-in immediately from
+        // the local VAD, but buffer the raw payload — it must NOT reach the
+        // batch turn detector, or the first utterance would be split across
+        // both paths. The buffer is replayed into whichever path wins.
+        if (detectSpeechActivity(payload)) {
+          this.callbacks.onSpeechStart?.();
+        }
+        this.bufferStartupFrame(payload);
+        return;
+
+      case "streaming":
+        // Live streaming: decode/resample and send, driving barge-in from the
+        // fast local VAD rather than waiting for the transcriber's partial.
+        this.handleStreamingMedia(payload);
+        return;
+
+      case "batch":
+        this.feedBatch(payload);
+        return;
     }
-
-    // Batch path: compute speech activity from the audio payload using a
-    // lightweight energy heuristic. mu-law encoded audio has a companded
-    // dynamic range — silence sits near 0xFF/0x7F while speech has higher
-    // energy.
-    //
-    // The detector call runs BEFORE the push so that the onTurnStart
-    // callback can clear stale inter-turn silence from the buffer
-    // without also wiping the first speech chunk of the new turn.
-    const hasSpeech = detectSpeechActivity(event.media.payload);
-    this.turnDetector.onMediaChunk(hasSpeech);
-
-    this.currentTurnChunks.push(event.media.payload);
   }
 
   /**
    * Route a single inbound media frame through the streaming pipeline:
    * decode mu-law → PCM16, resample to the streaming rate, fire local-VAD
-   * barge-in, and either send to the transcriber or buffer during startup.
+   * barge-in, and send to the (ready) transcriber.
    */
   private handleStreamingMedia(base64Payload: string): void {
     // Drive barge-in from the fast local VAD (energy heuristic).
@@ -426,33 +482,56 @@ export class MediaStreamSttSession {
       this.callbacks.onSpeechStart?.();
     }
 
-    let mulaw: Buffer;
-    try {
-      mulaw = Buffer.from(base64Payload, "base64");
-    } catch {
-      return;
-    }
-    if (mulaw.length === 0) return;
-
-    const pcm8k = mulawToPcm16(mulaw);
-    const pcm = resamplePcm16(
-      pcm8k,
-      TELEPHONY_SAMPLE_RATE,
-      STREAMING_SAMPLE_RATE,
-    );
+    const pcm = this.decodeForStreaming(base64Payload);
+    if (!pcm) return;
 
     if (this.streamingReady) {
       this.streamingTranscriber?.sendAudio(pcm, STREAMING_PCM_MIME);
-      return;
     }
+  }
 
-    // Transcriber still starting up — buffer with a bounded cap, dropping
-    // oldest frames (and counting them) rather than growing unbounded.
-    this.streamingStartupBuffer.push(pcm);
+  /**
+   * Feed a single inbound media frame through the batch pipeline: compute
+   * speech activity from the audio payload using a lightweight energy
+   * heuristic, drive the turn detector, and accumulate the chunk.
+   *
+   * The detector call runs BEFORE the push so that the onTurnStart callback
+   * can clear stale inter-turn silence from the buffer without also wiping the
+   * first speech chunk of the new turn.
+   */
+  private feedBatch(base64Payload: string): void {
+    const hasSpeech = detectSpeechActivity(base64Payload);
+    this.turnDetector.onMediaChunk(hasSpeech);
+    this.currentTurnChunks.push(base64Payload);
+  }
+
+  /**
+   * Append a raw payload to the bounded streaming startup buffer, dropping
+   * oldest frames (and counting them) rather than growing unbounded.
+   */
+  private bufferStartupFrame(base64Payload: string): void {
+    this.streamingStartupBuffer.push(base64Payload);
     while (this.streamingStartupBuffer.length > MAX_STREAMING_STARTUP_FRAMES) {
       this.streamingStartupBuffer.shift();
       this.streamingStartupFramesDropped++;
     }
+  }
+
+  /**
+   * Decode a base64 mu-law payload into resampled PCM16 ready for the
+   * streaming transcriber, or `null` if the payload is empty/undecodable.
+   */
+  private decodeForStreaming(base64Payload: string): Buffer | null {
+    let mulaw: Buffer;
+    try {
+      mulaw = Buffer.from(base64Payload, "base64");
+    } catch {
+      return null;
+    }
+    if (mulaw.length === 0) return null;
+
+    const pcm8k = mulawToPcm16(mulaw);
+    return resamplePcm16(pcm8k, TELEPHONY_SAMPLE_RATE, STREAMING_SAMPLE_RATE);
   }
 
   private handleStop(): void {

--- a/assistant/src/config/schemas/calls.ts
+++ b/assistant/src/config/schemas/calls.ts
@@ -62,6 +62,12 @@ const CallsVoiceConfigSchema = z
       .describe(
         "How aggressively the STT provider detects the start of caller speech — low reduces false interrupts from background noise",
       ),
+    telephonyStreaming: z
+      .boolean({ error: "calls.voice.telephonyStreaming must be a boolean" })
+      .default(true)
+      .describe(
+        "Whether to use realtime streaming STT for telephony audio instead of batch transcription. When enabled and the configured provider supports the `daemon-streaming` boundary, media-stream call audio is fed into a streaming transcriber for lower latency; otherwise the batch path is used.",
+      ),
   })
   .describe("Voice and speech settings for phone calls");
 

--- a/assistant/src/providers/speech-to-text/resolve.ts
+++ b/assistant/src/providers/speech-to-text/resolve.ts
@@ -17,6 +17,39 @@ import {
 const log = getLogger("stt-resolver");
 
 // ---------------------------------------------------------------------------
+// Realtime-streaming capability check
+// ---------------------------------------------------------------------------
+
+/**
+ * Whether the configured `services.stt` provider's streaming is *genuinely
+ * realtime* — i.e. it emits partial/final transcript events continuously while
+ * audio is flowing, rather than only producing a final transcript when the
+ * stream is stopped.
+ *
+ * This gates the media-stream realtime streaming path. Providers whose
+ * `conversationStreamingMode` is `"realtime-ws"` (e.g. Deepgram, Google
+ * Gemini Live, xAI) can drive mid-call responses through the streaming path.
+ * Providers whose mode is `"incremental-batch"` (e.g. OpenAI Whisper) only
+ * emit a `final` on `stop()`, so the streaming path would never fire
+ * `onTranscriptFinal` until hangup — those must use the batch turn-segmenting
+ * path instead.
+ *
+ * Returns `false` for unknown providers or any non-`realtime-ws` mode,
+ * defaulting safely to the batch path.
+ */
+export function isRealtimeStreamingProvider(): boolean {
+  let provider: string;
+  try {
+    provider = getConfig().services.stt.provider;
+  } catch {
+    // Config unavailable (early startup / tests) — default to the batch path.
+    return false;
+  }
+  const entry = getProviderEntry(provider as SttProviderId);
+  return entry?.conversationStreamingMode === "realtime-ws";
+}
+
+// ---------------------------------------------------------------------------
 // Batch transcriber resolver (existing public API — unchanged contract)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Add calls.voice.telephonyStreaming (default true)
- Stream decoded PCM frames into StreamingTranscriber with bounded async-start buffer + drop metric
- Local-VAD barge-in; batch path retained as fallback

Part of plan: migrate-phone-off-conversation-relay.md (PR 4 of 18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)