### PR TITLE
refactor(calls): extract GuardianWaitController from relay-server wait loop

### DIFF
--- a/assistant/src/__tests__/guardian-wait-controller.test.ts
+++ b/assistant/src/__tests__/guardian-wait-controller.test.ts
@@ -128,6 +128,8 @@ interface Harness {
   approved: Array<{ assistantId: string; fromNumber: string }>;
   denied: Array<{ guardianLabel: string }>;
   timedOut: Array<{ guardianLabel: string; callbackOptIn: boolean }>;
+  /** Count of markWaitingOnUser() invocations. */
+  waitingOnUserMarks: { count: number };
   /** Current canonical request status returned by the injected lookup. */
   setRequestStatus: (status: string | null) => void;
 }
@@ -139,6 +141,7 @@ function makeHarness(): Harness {
   const approved: Harness["approved"] = [];
   const denied: Harness["denied"] = [];
   const timedOut: Harness["timedOut"] = [];
+  const waitingOnUserMarks = { count: 0 };
   let requestStatus: string | null = "pending";
 
   const deps: GuardianWaitControllerDeps = {
@@ -146,6 +149,9 @@ function makeHarness(): Harness {
       spokenPrompts.push(text);
     },
     resolveGuardianLabel: () => "Alex",
+    markWaitingOnUser: () => {
+      waitingOnUserMarks.count++;
+    },
     onApproved: (p) =>
       approved.push({ assistantId: p.assistantId, fromNumber: p.fromNumber }),
     onDenied: (p) => denied.push({ guardianLabel: p.guardianLabel }),
@@ -186,6 +192,7 @@ function makeHarness(): Harness {
     approved,
     denied,
     timedOut,
+    waitingOnUserMarks,
     setRequestStatus: (s) => {
       requestStatus = s;
     },
@@ -221,6 +228,16 @@ describe("GuardianWaitController", () => {
     // poll + timeout + initial heartbeat-delay timers are pending.
     expect(h.clock.pendingIntervals()).toBe(1);
     expect(h.clock.pendingOneShots()).toBe(2);
+  });
+
+  test("persists waiting_on_user when the wait starts", () => {
+    expect(h.waitingOnUserMarks.count).toBe(0);
+
+    controller.start(START);
+
+    // Mirrors relay-server.ts: status is persisted to waiting_on_user exactly
+    // once, at wait start, so recovery/UI observe the call is blocked on the user.
+    expect(h.waitingOnUserMarks.count).toBe(1);
   });
 
   test("approval → onApproved with caller identity", () => {

--- a/assistant/src/__tests__/guardian-wait-controller.test.ts
+++ b/assistant/src/__tests__/guardian-wait-controller.test.ts
@@ -1,0 +1,359 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Logger mock (must come before any source imports) ────────────────
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// ── call-store mock ───────────────────────────────────────────────────
+// recordCallEvent persists to the call DB; stub it and capture events so the
+// controller (and the real relay-access-wait helpers it reuses) can run
+// without a live store.
+
+const recordedEvents: Array<{ type: string; payload?: unknown }> = [];
+mock.module("../calls/call-store.js", () => ({
+  recordCallEvent: (_id: string, type: string, payload?: unknown) => {
+    recordedEvents.push({ type, payload });
+  },
+}));
+
+// ── notification / contact / canonical-store mocks ───────────────────
+// Transitive deps of the REAL emitAccessRequestCallbackHandoff helper (which
+// the controller reuses). Stub them so the timeout handoff path runs without
+// emitting a real signal or hitting the DB, while letting us assert it fired.
+
+const emittedSignals: Array<{ sourceEventName: string; dedupeKey?: string }> =
+  [];
+mock.module("../notifications/emit-signal.js", () => ({
+  emitNotificationSignal: (params: {
+    sourceEventName: string;
+    dedupeKey?: string;
+  }) => {
+    emittedSignals.push({
+      sourceEventName: params.sourceEventName,
+      dedupeKey: params.dedupeKey,
+    });
+    return Promise.resolve();
+  },
+}));
+
+mock.module("../contacts/contact-store.js", () => ({
+  findContactChannel: () => null,
+}));
+
+mock.module("../memory/canonical-guardian-store.js", () => ({
+  getCanonicalGuardianRequest: () => null,
+}));
+
+import type { SetupFlowTransport } from "../calls/call-setup-flow-types.js";
+import {
+  GuardianWaitController,
+  type GuardianWaitControllerDeps,
+} from "../calls/guardian-wait-controller.js";
+
+// ── Test doubles ─────────────────────────────────────────────────────
+
+function makeTransport(): SetupFlowTransport {
+  // The controller speaks through the injected `speakSystemPrompt`, never the
+  // transport directly, so these are inert — present only to satisfy the shape.
+  return {
+    sendTextToken() {},
+    endSession() {},
+    getConnectionState: () => "connected",
+  };
+}
+
+/**
+ * Manual fake-timer harness. One-shot and repeating timers are tracked
+ * separately so tests can fire/inspect them deterministically — no real
+ * delays, and `dispose()` cleanup can be asserted by checking nothing is left.
+ */
+function makeClock() {
+  const now = 1_000_000;
+  let nextId = 1;
+  const oneShots = new Map<number, { fn: () => void; delayMs: number }>();
+  const intervals = new Map<number, { fn: () => void; intervalMs: number }>();
+
+  return {
+    now: () => now,
+    setTimer(fn: () => void, delayMs: number) {
+      const id = nextId++;
+      oneShots.set(id, { fn, delayMs });
+      return id as unknown as ReturnType<typeof setTimeout>;
+    },
+    clearTimer(handle: ReturnType<typeof setTimeout>) {
+      oneShots.delete(handle as unknown as number);
+    },
+    setPollTimer(fn: () => void, intervalMs: number) {
+      const id = nextId++;
+      intervals.set(id, { fn, intervalMs });
+      return id as unknown as ReturnType<typeof setInterval>;
+    },
+    clearPollTimer(handle: ReturnType<typeof setInterval>) {
+      intervals.delete(handle as unknown as number);
+    },
+    /** Fire all currently-pending one-shot timers (FIFO). */
+    fireOneShots() {
+      const pending = [...oneShots.values()];
+      oneShots.clear();
+      for (const t of pending) t.fn();
+    },
+    /** Fire only pending one-shots whose delay is at most `maxDelayMs`. */
+    fireOneShotsUpTo(maxDelayMs: number) {
+      for (const [id, t] of [...oneShots.entries()]) {
+        if (t.delayMs <= maxDelayMs) {
+          oneShots.delete(id);
+          t.fn();
+        }
+      }
+    },
+    /** Fire one tick of every active interval. */
+    tickPolls() {
+      for (const t of [...intervals.values()]) t.fn();
+    },
+    pendingOneShots: () => oneShots.size,
+    pendingIntervals: () => intervals.size,
+  };
+}
+
+interface Harness {
+  clock: ReturnType<typeof makeClock>;
+  transport: SetupFlowTransport;
+  deps: GuardianWaitControllerDeps;
+  spokenPrompts: string[];
+  approved: Array<{ assistantId: string; fromNumber: string }>;
+  denied: Array<{ guardianLabel: string }>;
+  timedOut: Array<{ guardianLabel: string; callbackOptIn: boolean }>;
+  /** Current canonical request status returned by the injected lookup. */
+  setRequestStatus: (status: string | null) => void;
+}
+
+function makeHarness(): Harness {
+  const clock = makeClock();
+  const transport = makeTransport();
+  const spokenPrompts: string[] = [];
+  const approved: Harness["approved"] = [];
+  const denied: Harness["denied"] = [];
+  const timedOut: Harness["timedOut"] = [];
+  let requestStatus: string | null = "pending";
+
+  const deps: GuardianWaitControllerDeps = {
+    speakSystemPrompt: async (_transport, text) => {
+      spokenPrompts.push(text);
+    },
+    resolveGuardianLabel: () => "Alex",
+    onApproved: (p) =>
+      approved.push({ assistantId: p.assistantId, fromNumber: p.fromNumber }),
+    onDenied: (p) => denied.push({ guardianLabel: p.guardianLabel }),
+    onTimeout: (p) =>
+      timedOut.push({
+        guardianLabel: p.guardianLabel,
+        callbackOptIn: p.callbackOptIn,
+      }),
+    now: () => clock.now(),
+    setTimer: (fn, ms) => clock.setTimer(fn, ms),
+    clearTimer: (h) => clock.clearTimer(h),
+    setPollTimer: (fn, ms) => clock.setPollTimer(fn, ms),
+    clearPollTimer: (h) => clock.clearPollTimer(h),
+    getCanonicalGuardianRequest: () =>
+      requestStatus ? ({ status: requestStatus } as never) : null,
+    // Deterministic heartbeat scheduler driven by the fake clock. Mirrors the
+    // shared helper's contract (re-schedules itself) without real setTimeout.
+    scheduleHeartbeat: (params) => {
+      if (!params.isWaitActive()) return null;
+      return clock.setTimer(() => {
+        if (!params.isWaitActive()) return;
+        const seq = params.consumeSequence();
+        params.sendTextToken(`heartbeat-${seq}`, true);
+        params.scheduleNext();
+      }, 100);
+    },
+    timeoutMs: 30_000,
+    pollIntervalMs: 1_000,
+    initialHeartbeatDelayMs: 500,
+    inWaitReplyCooldownMs: 3_000,
+  };
+
+  return {
+    clock,
+    transport,
+    deps,
+    spokenPrompts,
+    approved,
+    denied,
+    timedOut,
+    setRequestStatus: (s) => {
+      requestStatus = s;
+    },
+  };
+}
+
+const START = {
+  accessRequestId: "req_1",
+  assistantId: "asst_1",
+  fromNumber: "+15550100",
+  callerName: "Sam",
+};
+
+describe("GuardianWaitController", () => {
+  let h: Harness;
+  let controller: GuardianWaitController;
+
+  beforeEach(() => {
+    recordedEvents.length = 0;
+    emittedSignals.length = 0;
+    h = makeHarness();
+    controller = new GuardianWaitController("call_1", h.transport, h.deps);
+  });
+
+  test("starts idle, transitions to awaiting on start, speaks the hold message", () => {
+    expect(controller.getState()).toBe("idle");
+
+    controller.start(START);
+
+    expect(controller.getState()).toBe("awaiting_guardian_decision");
+    expect(h.spokenPrompts[0]).toContain("Please hold");
+    expect(h.spokenPrompts[0]).toContain("Alex");
+    // poll + timeout + initial heartbeat-delay timers are pending.
+    expect(h.clock.pendingIntervals()).toBe(1);
+    expect(h.clock.pendingOneShots()).toBe(2);
+  });
+
+  test("approval → onApproved with caller identity", () => {
+    controller.start(START);
+    h.setRequestStatus("approved");
+
+    h.clock.tickPolls();
+
+    expect(h.approved).toEqual([
+      { assistantId: "asst_1", fromNumber: "+15550100" },
+    ]);
+    expect(controller.getState()).toBe("resolved");
+    expect(
+      recordedEvents.some((e) => e.type === "inbound_acl_access_approved"),
+    ).toBe(true);
+    // All timers cleared on resolution.
+    expect(h.clock.pendingIntervals()).toBe(0);
+    expect(h.clock.pendingOneShots()).toBe(0);
+  });
+
+  test("denial → onDenied", () => {
+    controller.start(START);
+    h.setRequestStatus("denied");
+
+    h.clock.tickPolls();
+
+    expect(h.denied).toEqual([{ guardianLabel: "Alex" }]);
+    expect(controller.getState()).toBe("resolved");
+    expect(
+      recordedEvents.some((e) => e.type === "inbound_acl_access_denied"),
+    ).toBe(true);
+    expect(h.clock.pendingIntervals()).toBe(0);
+    expect(h.clock.pendingOneShots()).toBe(0);
+  });
+
+  test("heartbeats fire in sequence while waiting", () => {
+    controller.start(START);
+
+    // Fire only short-delay one-shots (initial 500ms delay + 100ms heartbeats),
+    // never the 30s timeout. Each call drains the currently-pending heartbeat.
+    h.clock.fireOneShotsUpTo(500); // initial delay → schedules first heartbeat
+    h.clock.fireOneShotsUpTo(500); // heartbeat-0 → schedules next
+    h.clock.fireOneShotsUpTo(500); // heartbeat-1 → schedules next
+
+    const heartbeats = h.spokenPrompts.filter((p) =>
+      p.startsWith("heartbeat-"),
+    );
+    expect(heartbeats).toEqual(["heartbeat-0", "heartbeat-1"]);
+  });
+
+  test("timeout → callback handoff + onTimeout + timeout event", () => {
+    controller.start(START);
+    // An offer must be made before "yes" is read as a callback opt-in.
+    controller.handleTranscript("this is taking too long"); // → callback offer
+    controller.handleTranscript("yes, call me back"); // → opt-in
+    expect(controller.getState()).toBe("awaiting_guardian_decision");
+
+    // Fire pending one-shots until the timeout handler runs. The timeout timer
+    // is among the pending one-shots; firing them invokes it.
+    h.clock.fireOneShots();
+
+    expect(h.timedOut).toEqual([
+      { guardianLabel: "Alex", callbackOptIn: true },
+    ]);
+    expect(controller.getState()).toBe("resolved");
+    expect(
+      recordedEvents.some((e) => e.type === "inbound_acl_access_timeout"),
+    ).toBe(true);
+    // The reused emitAccessRequestCallbackHandoff helper emitted a signal.
+    expect(emittedSignals).toHaveLength(1);
+    expect(emittedSignals[0]!.sourceEventName).toBe(
+      "ingress.access_request.callback_handoff",
+    );
+    expect(h.clock.pendingIntervals()).toBe(0);
+    expect(h.clock.pendingOneShots()).toBe(0);
+  });
+
+  test("wait-state utterances are classified and answered", () => {
+    controller.start(START);
+    const before = h.spokenPrompts.length;
+
+    // Patience check → reassurance.
+    controller.handleTranscript("hello? are you still there?");
+    const patienceReply = h.spokenPrompts[before];
+    expect(patienceReply).toContain("still here");
+
+    expect(
+      recordedEvents.some(
+        (e) => e.type === "voice_guardian_wait_prompt_classified",
+      ),
+    ).toBe(true);
+  });
+
+  test("impatience offers a callback, opt-in records the flag", () => {
+    controller.start(START);
+
+    controller.handleTranscript("this is taking too long");
+    expect(h.spokenPrompts.some((p) => p.includes("call you back"))).toBe(true);
+    expect(
+      recordedEvents.some(
+        (e) => e.type === "voice_guardian_wait_callback_offer_sent",
+      ),
+    ).toBe(true);
+
+    // Now that an offer was made, "yes, call me back" is a callback opt-in.
+    controller.handleTranscript("yes, call me back");
+    expect(
+      recordedEvents.some(
+        (e) => e.type === "voice_guardian_wait_callback_opt_in_set",
+      ),
+    ).toBe(true);
+  });
+
+  test("handleTranscript is a no-op once resolved", () => {
+    controller.start(START);
+    controller.dispose();
+    const before = h.spokenPrompts.length;
+
+    controller.handleTranscript("hello?");
+
+    expect(h.spokenPrompts.length).toBe(before);
+  });
+
+  test("dispose() clears every pending timer", () => {
+    controller.start(START);
+    // After start: poll interval + (timeout + initial heartbeat-delay) one-shots.
+    expect(h.clock.pendingIntervals()).toBe(1);
+    expect(h.clock.pendingOneShots()).toBe(2);
+
+    controller.dispose();
+
+    expect(controller.getState()).toBe("resolved");
+    expect(h.clock.pendingIntervals()).toBe(0);
+    expect(h.clock.pendingOneShots()).toBe(0);
+  });
+});

--- a/assistant/src/__tests__/guardian-wait-controller.test.ts
+++ b/assistant/src/__tests__/guardian-wait-controller.test.ts
@@ -373,4 +373,86 @@ describe("GuardianWaitController", () => {
     expect(h.clock.pendingIntervals()).toBe(0);
     expect(h.clock.pendingOneShots()).toBe(0);
   });
+
+  test("dispose() while opted-in (transport close) emits callback handoff", () => {
+    controller.start(START);
+    // An offer must be made before "yes" is read as a callback opt-in.
+    controller.handleTranscript("this is taking too long"); // → callback offer
+    controller.handleTranscript("yes, call me back"); // → opt-in
+    expect(controller.getState()).toBe("awaiting_guardian_decision");
+
+    // Transport closes before any decision/timeout.
+    controller.dispose();
+
+    expect(controller.getState()).toBe("resolved");
+    // Mirrors relay-server's handleTransportClosed: emits the handoff under the
+    // same active+opt-in condition, with reason "transport_closed".
+    expect(emittedSignals).toHaveLength(1);
+    expect(emittedSignals[0]!.sourceEventName).toBe(
+      "ingress.access_request.callback_handoff",
+    );
+    expect(h.clock.pendingIntervals()).toBe(0);
+    expect(h.clock.pendingOneShots()).toBe(0);
+  });
+
+  test("dispose() without callback opt-in emits no handoff", () => {
+    controller.start(START);
+    expect(controller.getState()).toBe("awaiting_guardian_decision");
+
+    controller.dispose();
+
+    expect(emittedSignals).toHaveLength(0);
+  });
+
+  test("dispose() after approval emits no handoff", () => {
+    controller.start(START);
+    controller.handleTranscript("this is taking too long");
+    controller.handleTranscript("yes, call me back"); // opt-in
+    h.setRequestStatus("approved");
+    h.clock.tickPolls();
+    expect(controller.getState()).toBe("resolved");
+
+    controller.dispose();
+
+    // No handoff: the wait was already resolved normally, not by transport close.
+    expect(emittedSignals).toHaveLength(0);
+  });
+
+  test("dispose() after denial emits no handoff", () => {
+    controller.start(START);
+    controller.handleTranscript("this is taking too long");
+    controller.handleTranscript("yes, call me back"); // opt-in
+    h.setRequestStatus("denied");
+    h.clock.tickPolls();
+    expect(controller.getState()).toBe("resolved");
+
+    controller.dispose();
+
+    expect(emittedSignals).toHaveLength(0);
+  });
+
+  test("dispose() after timeout does not emit a second handoff", () => {
+    controller.start(START);
+    controller.handleTranscript("this is taking too long");
+    controller.handleTranscript("yes, call me back"); // opt-in
+    h.clock.fireOneShots(); // fires the timeout handler → handoff #1
+    expect(controller.getState()).toBe("resolved");
+    expect(emittedSignals).toHaveLength(1);
+
+    controller.dispose();
+
+    // Timeout already emitted; dispose must not emit again.
+    expect(emittedSignals).toHaveLength(1);
+  });
+
+  test("double dispose() while opted-in emits the handoff at most once", () => {
+    controller.start(START);
+    controller.handleTranscript("this is taking too long");
+    controller.handleTranscript("yes, call me back"); // opt-in
+
+    controller.dispose();
+    controller.dispose();
+
+    expect(emittedSignals).toHaveLength(1);
+  });
 });

--- a/assistant/src/calls/guardian-wait-controller.ts
+++ b/assistant/src/calls/guardian-wait-controller.ts
@@ -431,8 +431,40 @@ export class GuardianWaitController {
     }
   }
 
-  /** Clear all timers and mark the wait resolved. Safe to call repeatedly. */
+  /**
+   * Clear all timers and mark the wait resolved. Safe to call repeatedly.
+   *
+   * Models the transport closing (caller hangs up / stream disconnects). If the
+   * wait is still active AND the caller had opted into a callback, emit the
+   * callback-handoff notification before clearing state — mirroring
+   * `relay-server.ts`'s `handleTransportClosed`, which fires
+   * `emitAccessRequestCallbackHandoff(reason: "transport_closed")` under the
+   * same `accessRequestWaitActive && callbackOptIn` condition. Without this, a
+   * caller who opted in then hung up before any decision/timeout would silently
+   * lose the guardian callback notification.
+   *
+   * Idempotent: a dispose after a normal resolution (approve/deny/timeout) does
+   * not emit a handoff (the wait is no longer active), and double-dispose cannot
+   * emit twice (the second call sees a resolved state, and
+   * `callbackHandoffNotified` guards the helper regardless).
+   */
   dispose(): void {
+    if (this.state === "awaiting_guardian_decision" && this.callbackOptIn) {
+      // Emit before clearing wait state so the opt-in flag and request identity
+      // are still available. Matches the timeout path's call shape.
+      const handoff = emitAccessRequestCallbackHandoff({
+        reason: "transport_closed",
+        callbackOptIn: this.callbackOptIn,
+        accessRequestId: this.accessRequestId,
+        callbackHandoffNotified: this.callbackHandoffNotified,
+        accessRequestAssistantId: this.assistantId,
+        accessRequestFromNumber: this.fromNumber,
+        accessRequestCallerName: this.callerName,
+        callSessionId: this.callSessionId,
+      });
+      this.callbackHandoffNotified = handoff.callbackHandoffNotified;
+    }
+
     this.clearWait();
     this.state = "resolved";
   }

--- a/assistant/src/calls/guardian-wait-controller.ts
+++ b/assistant/src/calls/guardian-wait-controller.ts
@@ -90,6 +90,15 @@ export interface GuardianWaitControllerDeps {
   /** Resolve a human-readable label for the guardian (wait copy). */
   resolveGuardianLabel(): string;
   /**
+   * Persist the call session's transition to `waiting_on_user` when the wait
+   * starts. Mirrors `relay-server.ts`'s
+   * `updateCallSession(callSessionId, { status: "waiting_on_user" })` so
+   * recovery/UI paths that key off the persisted status observe that the call
+   * is blocked on the user. Injected (rather than calling the store directly)
+   * to keep the controller transport-agnostic and unit-testable.
+   */
+  markWaitingOnUser(): void;
+  /**
    * Continue the call once the guardian approves. The controller has already
    * cleared its timers when this fires.
    */
@@ -240,6 +249,12 @@ export class GuardianWaitController {
       this.transport,
       `Thank you. I've let ${guardianLabel} know. Please hold while I check if I have permission to speak with you.`,
     );
+
+    // Persist the wait transition so recovery/UI paths that key off the
+    // canonical call-session status observe the call is blocked on the user.
+    // Mirrors relay-server.ts's `startAccessRequestWait`, which persists
+    // `waiting_on_user` here, right after speaking the hold prompt.
+    this.deps.markWaitingOnUser();
 
     // Start the heartbeat timer for periodic progress updates. Delay the first
     // heartbeat by the estimated TTS playback duration so the initial hold

--- a/assistant/src/calls/guardian-wait-controller.ts
+++ b/assistant/src/calls/guardian-wait-controller.ts
@@ -1,0 +1,550 @@
+/**
+ * Transport-agnostic guardian access-request wait controller.
+ *
+ * When an unknown inbound caller asks to speak with the user, the assistant
+ * notifies the user's guardian and then *holds the line* while polling the
+ * canonical request for a decision. This controller owns that bounded wait:
+ * it speaks the hold message, schedules heartbeat progress updates, polls the
+ * canonical request status, enforces a timeout, and handles caller utterances
+ * spoken during the wait (patience checks, impatience, callback opt-in/decline).
+ *
+ * Ported from the stateful wait orchestration that previously lived as private
+ * methods on `RelayConnection` (`startAccessRequestWait` and its handlers in
+ * `relay-server.ts`). The pure, side-effect-light helpers it depends on already
+ * live in {@link ./relay-access-wait.js} — this controller REUSES them rather
+ * than duplicating their logic.
+ *
+ * Design notes:
+ * - **Transport-agnostic.** The controller drives any {@link SetupFlowTransport}
+ *   (including `MediaStreamOutput`), speaking through an injected
+ *   `speakSystemPrompt`.
+ * - **Owns its wait state explicitly.** The `awaiting_guardian_decision` state
+ *   lives on the controller, NOT on `transport.getConnectionState()`. On the
+ *   media-stream transport that method only reports `connected`/`closed`, so it
+ *   cannot distinguish "awaiting a guardian decision" from any other phase.
+ * - **Injected timing.** Clock, timers, poll/timeout intervals, and the
+ *   heartbeat scheduler are all injectable so unit tests run with no real
+ *   delays and can drive the timeline deterministically.
+ *
+ * This file is fresh transport-agnostic code; it does NOT refactor
+ * `relay-server.ts` (which is removed later in the migration). PR 8 wires it
+ * into `call-setup-flow`.
+ */
+
+import type { CanonicalGuardianRequest } from "../memory/canonical-guardian-store.js";
+import { getCanonicalGuardianRequest } from "../memory/canonical-guardian-store.js";
+import { getLogger } from "../util/logger.js";
+import {
+  getAccessRequestPollIntervalMs,
+  getTtsPlaybackDelayMs,
+  getUserConsultationTimeoutMs,
+} from "./call-constants.js";
+import type { SetupFlowTransport } from "./call-setup-flow-types.js";
+import { recordCallEvent } from "./call-store.js";
+import {
+  classifyWaitUtterance,
+  emitAccessRequestCallbackHandoff,
+  scheduleNextHeartbeat,
+} from "./relay-access-wait.js";
+
+const log = getLogger("guardian-wait-controller");
+
+// ── State ────────────────────────────────────────────────────────────
+
+/**
+ * Explicit wait state, owned by the controller (never transport-derived).
+ *
+ * - `idle`: no wait in progress (before `start()` / after resolution).
+ * - `awaiting_guardian_decision`: actively holding for a guardian decision.
+ * - `resolved`: the wait ended (approved / denied / timed out / disposed).
+ */
+export type GuardianWaitState =
+  | "idle"
+  | "awaiting_guardian_decision"
+  | "resolved";
+
+// ── Parameters ───────────────────────────────────────────────────────
+
+/** Identifying context for the access request being waited on. */
+export interface GuardianWaitStartParams {
+  /** Canonical access-request id to poll for a decision. */
+  accessRequestId: string;
+  /** Assistant the call is targeting. */
+  assistantId: string;
+  /** Caller's phone number (E.164). */
+  fromNumber: string;
+  /** Caller's spoken name, if captured. */
+  callerName: string | null;
+}
+
+// ── Dependencies ─────────────────────────────────────────────────────
+
+/**
+ * Injected collaborators. Functions/timers are injected (rather than imported
+ * directly) so the controller can be unit-tested without a live transport, TTS
+ * provider, database, or real timers.
+ */
+export interface GuardianWaitControllerDeps {
+  /** Speak a deterministic prompt through the transport's TTS path. */
+  speakSystemPrompt(transport: SetupFlowTransport, text: string): Promise<void>;
+  /** Resolve a human-readable label for the guardian (wait copy). */
+  resolveGuardianLabel(): string;
+  /**
+   * Continue the call once the guardian approves. The controller has already
+   * cleared its timers when this fires.
+   */
+  onApproved(params: {
+    assistantId: string;
+    fromNumber: string;
+    callerName: string | null;
+  }): void;
+  /** The guardian denied the request. The controller has cleared its timers. */
+  onDenied(params: { guardianLabel: string }): void;
+  /**
+   * The wait timed out (or failed closed). Fires after the callback-handoff
+   * notification is emitted and timers are cleared. `callbackOptIn` reflects
+   * whether the caller asked for a callback during the wait.
+   */
+  onTimeout(params: { guardianLabel: string; callbackOptIn: boolean }): void;
+
+  // ── Injected timing (defaults wrap the real clock/timers/config) ──────
+
+  /** Current epoch ms. Defaults to `Date.now`. */
+  now?: () => number;
+  /** One-shot timer. Defaults to `setTimeout`. */
+  setTimer?: (fn: () => void, delayMs: number) => ReturnType<typeof setTimeout>;
+  /** Clears a one-shot timer. Defaults to `clearTimeout`. */
+  clearTimer?: (handle: ReturnType<typeof setTimeout>) => void;
+  /** Repeating timer (polling). Defaults to `setInterval`. */
+  setPollTimer?: (
+    fn: () => void,
+    intervalMs: number,
+  ) => ReturnType<typeof setInterval>;
+  /** Clears a repeating timer. Defaults to `clearInterval`. */
+  clearPollTimer?: (handle: ReturnType<typeof setInterval>) => void;
+  /**
+   * Schedule the next heartbeat. Defaults to the shared
+   * {@link scheduleNextHeartbeat} helper (which uses real `setTimeout` +
+   * config intervals); overridable so tests drive heartbeats deterministically.
+   */
+  scheduleHeartbeat?: typeof scheduleNextHeartbeat;
+  /** Look up the canonical request being polled. Defaults to the real store. */
+  getCanonicalGuardianRequest?: (
+    id: string,
+  ) => CanonicalGuardianRequest | null | undefined;
+  /** Wait timeout (ms). Defaults to {@link getUserConsultationTimeoutMs}. */
+  timeoutMs?: number;
+  /** Poll interval (ms). Defaults to {@link getAccessRequestPollIntervalMs}. */
+  pollIntervalMs?: number;
+  /**
+   * Delay before the first heartbeat (so the hold message finishes first).
+   * Defaults to {@link getTtsPlaybackDelayMs}.
+   */
+  initialHeartbeatDelayMs?: number;
+  /**
+   * Cooldown (ms) between reassurance replies to non-callback utterances, to
+   * avoid spamming the caller. Defaults to 3000 (matching `relay-server.ts`).
+   */
+  inWaitReplyCooldownMs?: number;
+}
+
+const DEFAULT_IN_WAIT_REPLY_COOLDOWN_MS = 3000;
+
+// ── Controller ───────────────────────────────────────────────────────
+
+export class GuardianWaitController {
+  private state: GuardianWaitState = "idle";
+
+  private accessRequestId: string | null = null;
+  private assistantId: string | null = null;
+  private fromNumber: string | null = null;
+  private callerName: string | null = null;
+
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
+  private timeoutTimer: ReturnType<typeof setTimeout> | null = null;
+  private heartbeatTimer: ReturnType<typeof setTimeout> | null = null;
+
+  private waitStartedAt = 0;
+  private heartbeatSequence = 0;
+
+  private lastInWaitReplyAt = 0;
+  private callbackOfferMade = false;
+  private callbackOptIn = false;
+  private callbackHandoffNotified = false;
+
+  constructor(
+    private readonly callSessionId: string,
+    private readonly transport: SetupFlowTransport,
+    private readonly deps: GuardianWaitControllerDeps,
+  ) {}
+
+  // ── Injected-timing accessors ───────────────────────────────────────
+
+  private now(): number {
+    return (this.deps.now ?? Date.now)();
+  }
+
+  private setTimer(
+    fn: () => void,
+    delayMs: number,
+  ): ReturnType<typeof setTimeout> {
+    return this.deps.setTimer
+      ? this.deps.setTimer(fn, delayMs)
+      : setTimeout(fn, delayMs);
+  }
+
+  private clearTimer(handle: ReturnType<typeof setTimeout>): void {
+    (this.deps.clearTimer ?? clearTimeout)(handle);
+  }
+
+  private setPollTimer(
+    fn: () => void,
+    intervalMs: number,
+  ): ReturnType<typeof setInterval> {
+    return this.deps.setPollTimer
+      ? this.deps.setPollTimer(fn, intervalMs)
+      : setInterval(fn, intervalMs);
+  }
+
+  private clearPollTimer(handle: ReturnType<typeof setInterval>): void {
+    (this.deps.clearPollTimer ?? clearInterval)(handle);
+  }
+
+  // ── Public surface ──────────────────────────────────────────────────
+
+  /** Explicit wait-state surface — the source of truth, never transport-derived. */
+  getState(): GuardianWaitState {
+    return this.state;
+  }
+
+  /**
+   * Begin the bounded wait: speak the hold message, then start the heartbeat,
+   * poll, and timeout timers. Polls the canonical request until it is approved
+   * or denied; if neither happens within the timeout, fires `onTimeout`.
+   */
+  start(params: GuardianWaitStartParams): void {
+    this.accessRequestId = params.accessRequestId;
+    this.assistantId = params.assistantId;
+    this.fromNumber = params.fromNumber;
+    this.callerName = params.callerName;
+    this.state = "awaiting_guardian_decision";
+
+    const timeoutMs = this.deps.timeoutMs ?? getUserConsultationTimeoutMs();
+    const pollIntervalMs =
+      this.deps.pollIntervalMs ?? getAccessRequestPollIntervalMs();
+    const initialHeartbeatDelayMs =
+      this.deps.initialHeartbeatDelayMs ?? getTtsPlaybackDelayMs();
+
+    const guardianLabel = this.deps.resolveGuardianLabel();
+    void this.deps.speakSystemPrompt(
+      this.transport,
+      `Thank you. I've let ${guardianLabel} know. Please hold while I check if I have permission to speak with you.`,
+    );
+
+    // Start the heartbeat timer for periodic progress updates. Delay the first
+    // heartbeat by the estimated TTS playback duration so the initial hold
+    // message finishes before any heartbeat fires.
+    //
+    // Set the wait start time now so scheduleNextHeartbeat() always has a valid
+    // reference point — even if the delay timer is cancelled early (e.g. by a
+    // caller utterance during playback). The callback below re-stamps it to
+    // exclude the TTS delay if it fires.
+    this.heartbeatSequence = 0;
+    this.waitStartedAt = this.now();
+    this.heartbeatTimer = this.setTimer(() => {
+      this.waitStartedAt = this.now();
+      this.scheduleNextHeartbeat();
+    }, initialHeartbeatDelayMs);
+
+    // Poll the canonical request status.
+    this.pollTimer = this.setPollTimer(() => {
+      if (
+        this.state !== "awaiting_guardian_decision" ||
+        !this.accessRequestId
+      ) {
+        this.clearWait();
+        return;
+      }
+
+      const request = this.lookupRequest(this.accessRequestId);
+      if (!request) return;
+
+      if (request.status === "approved") {
+        this.handleApproved();
+      } else if (request.status === "denied") {
+        this.handleDenied();
+      }
+      // 'pending' continues polling; 'expired'/'cancelled' handled by timeout.
+    }, pollIntervalMs);
+
+    // Timeout: give up waiting for the guardian.
+    this.timeoutTimer = this.setTimer(() => {
+      if (this.state !== "awaiting_guardian_decision") return;
+      log.info(
+        { callSessionId: this.callSessionId, requestId: this.accessRequestId },
+        "Guardian access-request wait timed out",
+      );
+      this.handleTimeout();
+    }, timeoutMs);
+
+    log.info(
+      {
+        callSessionId: this.callSessionId,
+        requestId: this.accessRequestId,
+        timeoutMs,
+      },
+      "Guardian access-request wait started",
+    );
+  }
+
+  /**
+   * Route a finalized caller transcript spoken during the wait: patience
+   * checks, impatience (→ callback offer), and callback opt-in/decline.
+   * No-op unless a wait is active.
+   */
+  handleTranscript(text: string): void {
+    if (this.state !== "awaiting_guardian_decision") return;
+
+    const now = this.now();
+    const classification = classifyWaitUtterance(text, this.callbackOfferMade);
+
+    recordCallEvent(
+      this.callSessionId,
+      "voice_guardian_wait_prompt_classified",
+      { classification, transcript: text },
+    );
+
+    if (classification === "empty") return;
+
+    const guardianLabel = this.deps.resolveGuardianLabel();
+
+    // Callback decisions must always be processed regardless of cooldown — the
+    // caller is answering a direct question and dropping their response would
+    // silently discard their decision.
+    switch (classification) {
+      case "callback_opt_in": {
+        this.callbackOptIn = true;
+        this.lastInWaitReplyAt = now;
+        recordCallEvent(
+          this.callSessionId,
+          "voice_guardian_wait_callback_opt_in_set",
+          {},
+        );
+        this.resetHeartbeatTimer();
+        void this.deps.speakSystemPrompt(
+          this.transport,
+          `Noted, I'll make sure ${guardianLabel} knows you'd like a callback. For now, I'll keep trying to reach them.`,
+        );
+        this.scheduleNextHeartbeat();
+        return;
+      }
+      case "callback_decline": {
+        this.callbackOptIn = false;
+        this.lastInWaitReplyAt = now;
+        recordCallEvent(
+          this.callSessionId,
+          "voice_guardian_wait_callback_opt_in_declined",
+          {},
+        );
+        this.resetHeartbeatTimer();
+        void this.deps.speakSystemPrompt(
+          this.transport,
+          `No problem, I'll keep holding. Still waiting on ${guardianLabel}.`,
+        );
+        this.scheduleNextHeartbeat();
+        return;
+      }
+      default:
+        break;
+    }
+
+    // Enforce cooldown on non-callback utterances to prevent spam.
+    const cooldownMs =
+      this.deps.inWaitReplyCooldownMs ?? DEFAULT_IN_WAIT_REPLY_COOLDOWN_MS;
+    if (now - this.lastInWaitReplyAt < cooldownMs) {
+      log.debug(
+        { callSessionId: this.callSessionId },
+        "In-wait reply suppressed by cooldown",
+      );
+      return;
+    }
+    this.lastInWaitReplyAt = now;
+
+    switch (classification) {
+      case "impatient": {
+        this.resetHeartbeatTimer();
+        if (!this.callbackOfferMade) {
+          this.callbackOfferMade = true;
+          recordCallEvent(
+            this.callSessionId,
+            "voice_guardian_wait_callback_offer_sent",
+            {},
+          );
+          void this.deps.speakSystemPrompt(
+            this.transport,
+            `I understand this is taking a while. I can have ${guardianLabel} call you back once I hear from them. Would you like that, or would you prefer to keep holding?`,
+          );
+        } else {
+          // Already offered callback — just reassure.
+          void this.deps.speakSystemPrompt(
+            this.transport,
+            `I hear you, I'm sorry for the wait. Still trying to reach ${guardianLabel}.`,
+          );
+        }
+        this.scheduleNextHeartbeat();
+        break;
+      }
+      case "patience_check": {
+        this.resetHeartbeatTimer();
+        void this.deps.speakSystemPrompt(
+          this.transport,
+          `Yes, I'm still here. Still waiting to hear back from ${guardianLabel}.`,
+        );
+        this.scheduleNextHeartbeat();
+        break;
+      }
+      case "neutral":
+      default: {
+        this.resetHeartbeatTimer();
+        void this.deps.speakSystemPrompt(
+          this.transport,
+          `Thanks for that. I'm still waiting on ${guardianLabel}. I'll let you know as soon as I hear back.`,
+        );
+        this.scheduleNextHeartbeat();
+        break;
+      }
+    }
+  }
+
+  /** Clear all timers and mark the wait resolved. Safe to call repeatedly. */
+  dispose(): void {
+    this.clearWait();
+    this.state = "resolved";
+  }
+
+  // ── Internal ────────────────────────────────────────────────────────
+
+  private lookupRequest(
+    id: string,
+  ): CanonicalGuardianRequest | null | undefined {
+    return (
+      this.deps.getCanonicalGuardianRequest ?? getCanonicalGuardianRequest
+    )(id);
+  }
+
+  /** Clear the heartbeat timer (without touching poll/timeout). */
+  private resetHeartbeatTimer(): void {
+    if (this.heartbeatTimer) {
+      this.clearTimer(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+  }
+
+  /** Clear every wait timer and mark the wait inactive (state untouched). */
+  private clearWait(): void {
+    if (this.pollTimer) {
+      this.clearPollTimer(this.pollTimer);
+      this.pollTimer = null;
+    }
+    if (this.timeoutTimer) {
+      this.clearTimer(this.timeoutTimer);
+      this.timeoutTimer = null;
+    }
+    this.resetHeartbeatTimer();
+  }
+
+  private scheduleNextHeartbeat(): void {
+    const scheduler = this.deps.scheduleHeartbeat ?? scheduleNextHeartbeat;
+    this.heartbeatTimer = scheduler({
+      isWaitActive: () => this.state === "awaiting_guardian_decision",
+      accessRequestWaitStartedAt: this.waitStartedAt,
+      callSessionId: this.callSessionId,
+      consumeSequence: () => this.heartbeatSequence++,
+      resolveGuardianLabel: () => this.deps.resolveGuardianLabel(),
+      sendTextToken: (text) =>
+        void this.deps.speakSystemPrompt(this.transport, text),
+      scheduleNext: () => this.scheduleNextHeartbeat(),
+    });
+  }
+
+  /** Approved: clear timers, mark resolved, hand off to `onApproved`. */
+  private handleApproved(): void {
+    if (this.state !== "awaiting_guardian_decision") return;
+    this.clearWait();
+    this.state = "resolved";
+
+    recordCallEvent(this.callSessionId, "inbound_acl_access_approved", {
+      from: this.fromNumber,
+      callerName: this.callerName,
+      requestId: this.accessRequestId,
+    });
+    log.info(
+      { callSessionId: this.callSessionId, from: this.fromNumber },
+      "Guardian access request approved — caller activated and continuing call",
+    );
+
+    this.deps.onApproved({
+      assistantId: this.assistantId!,
+      fromNumber: this.fromNumber!,
+      callerName: this.callerName,
+    });
+  }
+
+  /** Denied: clear timers, mark resolved, hand off to `onDenied`. */
+  private handleDenied(): void {
+    if (this.state !== "awaiting_guardian_decision") return;
+    this.clearWait();
+    this.state = "resolved";
+
+    recordCallEvent(this.callSessionId, "inbound_acl_access_denied", {
+      from: this.fromNumber,
+      requestId: this.accessRequestId,
+    });
+    log.info(
+      { callSessionId: this.callSessionId },
+      "Guardian access request denied — ending call",
+    );
+
+    this.deps.onDenied({ guardianLabel: this.deps.resolveGuardianLabel() });
+  }
+
+  /**
+   * Timeout (or fail-closed): emit the callback-handoff notification, clear
+   * timers, mark resolved, then hand off to `onTimeout`.
+   */
+  private handleTimeout(): void {
+    if (this.state !== "awaiting_guardian_decision") return;
+
+    // Emit the callback handoff notification before clearing wait state so the
+    // opt-in flag and request identity are still available.
+    const handoff = emitAccessRequestCallbackHandoff({
+      reason: "timeout",
+      callbackOptIn: this.callbackOptIn,
+      accessRequestId: this.accessRequestId,
+      callbackHandoffNotified: this.callbackHandoffNotified,
+      accessRequestAssistantId: this.assistantId,
+      accessRequestFromNumber: this.fromNumber,
+      accessRequestCallerName: this.callerName,
+      callSessionId: this.callSessionId,
+    });
+    this.callbackHandoffNotified = handoff.callbackHandoffNotified;
+
+    this.clearWait();
+    this.state = "resolved";
+
+    recordCallEvent(this.callSessionId, "inbound_acl_access_timeout", {
+      from: this.fromNumber,
+      requestId: this.accessRequestId,
+      callbackOptIn: this.callbackOptIn,
+    });
+    log.info(
+      { callSessionId: this.callSessionId },
+      "Guardian access request timed out — ending call",
+    );
+
+    this.deps.onTimeout({
+      guardianLabel: this.deps.resolveGuardianLabel(),
+      callbackOptIn: this.callbackOptIn,
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- New transport-agnostic GuardianWaitController (timers/poll/heartbeats/wait-state utterances/callback opt-in/timeout handoff)
- Owns explicit wait state (not transport-derived); reuses relay-access-wait.ts pure helpers
- Injected timing for fast deterministic tests

Part of plan: migrate-phone-off-conversation-relay.md (PR 7 of 18)