### PR TITLE
feat(calls): preflight STT/TTS credentials before media-stream calls

### DIFF
--- a/assistant/src/__tests__/call-domain.test.ts
+++ b/assistant/src/__tests__/call-domain.test.ts
@@ -114,14 +114,7 @@ let credentialReadiness: Awaited<
   >
 > = { status: "ready" };
 
-// Whether the outbound preflight gate considers the call a media-stream call.
-// Default true so the existing not-ready test exercises the preflight; the gate
-// only skips the preflight for conversation-relay-native routing (PR 11 makes
-// it always-on).
-let usesMediaStreamTransport = true;
-
 mock.module("../calls/telephony-credential-preflight.js", () => ({
-  willUseMediaStreamTransport: () => usesMediaStreamTransport,
   resolveTelephonyCredentialReadiness: async () => credentialReadiness,
   describeCredentialGaps: (
     missing: Array<{ kind: string; providerId: string | null; reason: string }>,
@@ -134,6 +127,22 @@ mock.module("../calls/telephony-credential-preflight.js", () => ({
           } (${g.reason})`,
       )
       .join(", "),
+}));
+
+// Whether the outbound preflight gate considers the call a media-stream call.
+// The gate (`outboundWillUseMediaStream`, in twilio-routes.js) mirrors the FULL
+// transport decision: media-stream only when STT routing is media-stream-custom
+// AND routeSetup's outcome is normal_call/deny. It returns false for CR-native
+// STT AND for interactive outbound flows (e.g. verification) that CR-fall-back,
+// in which case the preflight is skipped. Default true so the existing
+// not-ready test exercises the preflight; the skip tests toggle it false.
+let usesMediaStreamTransport = true;
+
+mock.module("../calls/twilio-routes.js", () => ({
+  outboundWillUseMediaStream: () => usesMediaStreamTransport,
+  // call-domain.ts only consumes `outboundWillUseMediaStream` from this module;
+  // the remaining exports are unused on the startCall/cancelCall paths exercised
+  // by these tests.
 }));
 
 import {
@@ -437,11 +446,16 @@ describe("startCall — pointer message regression", () => {
     expect(text!).toContain("openai-whisper");
   });
 
-  test("conversation-relay-native routing skips the outbound credential preflight and dials", async () => {
-    // PR 10 lands before the routing flip: CR-native STT providers (deepgram /
-    // google) use Twilio ConversationRelay for STT + native TTS, so they need
-    // no local credentials. The gate must skip the preflight even when the
-    // preflight would report not-ready, so default setups still dial.
+  test("non-media-stream transport (CR-native or interactive CR-fallback) skips the outbound credential preflight and dials", async () => {
+    // `outboundWillUseMediaStream` returns false both for CR-native STT
+    // (deepgram / google — Twilio CR does STT + native TTS) AND for interactive
+    // outbound flows that buildVoiceWebhookTwiml CR-falls-back (e.g.
+    // calls.verification.enabled → callee_verification). In both cases the call
+    // is served by ConversationRelay and needs no local credentials, so the
+    // gate must skip the preflight even when it would report not-ready —
+    // otherwise the call is wrongly blocked. (The full STT-routing +
+    // routeSetup-outcome decision is unit-tested directly against the real
+    // helper in twilio-routes.test.ts.)
     const convId = "conv-domain-cred-preflight-skipped";
     ensureConversation(convId);
     usesMediaStreamTransport = false;

--- a/assistant/src/__tests__/call-domain.test.ts
+++ b/assistant/src/__tests__/call-domain.test.ts
@@ -105,6 +105,30 @@ mock.module("../daemon/handlers/config-ingress.js", () => ({
   syncTwilioWebhooks: async () => ({ success: true }),
 }));
 
+// Credential-compatibility preflight (PR 10). Default ready so existing dial
+// tests are unaffected; the not-ready test toggles this to assert the call is
+// blocked before Twilio dialing.
+let credentialReadiness: Awaited<
+  ReturnType<
+    typeof import("../calls/telephony-credential-preflight.js").resolveTelephonyCredentialReadiness
+  >
+> = { status: "ready" };
+
+mock.module("../calls/telephony-credential-preflight.js", () => ({
+  resolveTelephonyCredentialReadiness: async () => credentialReadiness,
+  describeCredentialGaps: (
+    missing: Array<{ kind: string; providerId: string | null; reason: string }>,
+  ) =>
+    missing
+      .map(
+        (g) =>
+          `${g.kind === "stt" ? "speech-to-text" : "text-to-speech"} provider ${
+            g.providerId ? `"${g.providerId}"` : "(unconfigured)"
+          } (${g.reason})`,
+      )
+      .join(", "),
+}));
+
 import {
   clearActiveCallLeases,
   getActiveCallLease,
@@ -131,6 +155,7 @@ beforeEach(() => {
   twilioInitiateCallArgs = [];
   mockIngressEnabled = true;
   mockIngressPublicBaseUrl = "https://test.example.com";
+  credentialReadiness = { status: "ready" };
 });
 
 let ensuredConvIds = new Set<string>();
@@ -308,7 +333,7 @@ describe("startCall — pointer message regression", () => {
     ensureConversation(convId);
 
     const result = await startCall({
-      phoneNumber: "+15559876543",
+      phoneNumber: "+12025550123",
       task: "Test call",
       conversationId: convId,
     });
@@ -318,7 +343,7 @@ describe("startCall — pointer message regression", () => {
     expect(twilioInitiateCallArgs).toEqual([
       {
         from: "+15550001111",
-        to: "+15559876543",
+        to: "+12025550123",
         webhookUrl: "https://test.example.com/webhooks/twilio/voice/test",
         statusCallbackUrl: "https://test.example.com/webhooks/twilio/status",
       },
@@ -337,7 +362,7 @@ describe("startCall — pointer message regression", () => {
 
     const text = getLatestAssistantText(convId);
     expect(text).not.toBeNull();
-    expect(text!).toContain("+15559876543");
+    expect(text!).toContain("+12025550123");
     expect(text!).toContain("started");
   });
 
@@ -347,7 +372,7 @@ describe("startCall — pointer message regression", () => {
     mockIngressEnabled = false;
 
     const result = await startCall({
-      phoneNumber: "+15559876543",
+      phoneNumber: "+12025550123",
       task: "Test call",
       conversationId: convId,
     });
@@ -363,8 +388,45 @@ describe("startCall — pointer message regression", () => {
 
     const text = getLatestAssistantText(convId);
     expect(text).not.toBeNull();
-    expect(text!).toContain("+15559876543");
+    expect(text!).toContain("+12025550123");
     expect(text!).toContain("failed");
+  });
+
+  test("credential preflight not-ready blocks dialing and writes a setup pointer", async () => {
+    const convId = "conv-domain-cred-preflight";
+    ensureConversation(convId);
+    credentialReadiness = {
+      status: "not-ready",
+      missing: [
+        {
+          kind: "stt",
+          providerId: "openai-whisper",
+          reason: "missing-credentials",
+        },
+      ],
+    };
+
+    const result = await startCall({
+      phoneNumber: "+12025550123",
+      task: "Test call",
+      conversationId: convId,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(400);
+      expect(result.error).toContain("openai-whisper");
+    }
+    // Never reached Twilio dialing.
+    expect(twilioInitiateCallCount).toBe(0);
+    expect(listActiveCallLeases()).toHaveLength(0);
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    const text = getLatestAssistantText(convId);
+    expect(text).not.toBeNull();
+    expect(text!).toContain("+12025550123");
+    expect(text!).toContain("openai-whisper");
   });
 
   test("failed call writes a failed pointer to the initiating conversation", async () => {
@@ -373,7 +435,7 @@ describe("startCall — pointer message regression", () => {
     twilioInitiateCallBehavior = "error";
 
     const result = await startCall({
-      phoneNumber: "+15559876543",
+      phoneNumber: "+12025550123",
       task: "Test call",
       conversationId: convId,
     });
@@ -386,7 +448,7 @@ describe("startCall — pointer message regression", () => {
 
     const text = getLatestAssistantText(convId);
     expect(text).not.toBeNull();
-    expect(text!).toContain("+15559876543");
+    expect(text!).toContain("+12025550123");
     expect(text!).toContain("failed");
   });
 
@@ -395,7 +457,7 @@ describe("startCall — pointer message regression", () => {
     ensureConversation(convId);
 
     const startResult = await startCall({
-      phoneNumber: "+15559876543",
+      phoneNumber: "+12025550123",
       task: "Test call",
       conversationId: convId,
     });

--- a/assistant/src/__tests__/call-domain.test.ts
+++ b/assistant/src/__tests__/call-domain.test.ts
@@ -114,7 +114,14 @@ let credentialReadiness: Awaited<
   >
 > = { status: "ready" };
 
+// Whether the outbound preflight gate considers the call a media-stream call.
+// Default true so the existing not-ready test exercises the preflight; the gate
+// only skips the preflight for conversation-relay-native routing (PR 11 makes
+// it always-on).
+let usesMediaStreamTransport = true;
+
 mock.module("../calls/telephony-credential-preflight.js", () => ({
+  willUseMediaStreamTransport: () => usesMediaStreamTransport,
   resolveTelephonyCredentialReadiness: async () => credentialReadiness,
   describeCredentialGaps: (
     missing: Array<{ kind: string; providerId: string | null; reason: string }>,
@@ -156,6 +163,7 @@ beforeEach(() => {
   mockIngressEnabled = true;
   mockIngressPublicBaseUrl = "https://test.example.com";
   credentialReadiness = { status: "ready" };
+  usesMediaStreamTransport = true;
 });
 
 let ensuredConvIds = new Set<string>();
@@ -427,6 +435,36 @@ describe("startCall — pointer message regression", () => {
     expect(text).not.toBeNull();
     expect(text!).toContain("+12025550123");
     expect(text!).toContain("openai-whisper");
+  });
+
+  test("conversation-relay-native routing skips the outbound credential preflight and dials", async () => {
+    // PR 10 lands before the routing flip: CR-native STT providers (deepgram /
+    // google) use Twilio ConversationRelay for STT + native TTS, so they need
+    // no local credentials. The gate must skip the preflight even when the
+    // preflight would report not-ready, so default setups still dial.
+    const convId = "conv-domain-cred-preflight-skipped";
+    ensureConversation(convId);
+    usesMediaStreamTransport = false;
+    credentialReadiness = {
+      status: "not-ready",
+      missing: [
+        {
+          kind: "stt",
+          providerId: "openai-whisper",
+          reason: "missing-credentials",
+        },
+      ],
+    };
+
+    const result = await startCall({
+      phoneNumber: "+12025550123",
+      task: "Test call",
+      conversationId: convId,
+    });
+
+    expect(result.ok).toBe(true);
+    // The preflight was skipped, so Twilio dialing proceeded.
+    expect(twilioInitiateCallCount).toBe(1);
   });
 
   test("failed call writes a failed pointer to the initiating conversation", async () => {

--- a/assistant/src/__tests__/media-stream-server-integration.test.ts
+++ b/assistant/src/__tests__/media-stream-server-integration.test.ts
@@ -181,6 +181,37 @@ mock.module("../memory/scoped-approval-grants.js", () => ({
   revokeScopedApprovalGrantsForContext: jest.fn(),
 }));
 
+// Mock the credential-compatibility preflight (PR 10). Default ready so a
+// normal_call still bootstraps a controller; the inbound not-ready test
+// toggles this to assert the spoken-setup-message + end-call behavior.
+let mockCredentialReadiness: {
+  status: "ready" | "not-ready";
+  missing?: Array<{ kind: string; providerId: string | null; reason: string }>;
+} = { status: "ready" };
+
+mock.module("../calls/telephony-credential-preflight.js", () => ({
+  resolveTelephonyCredentialReadiness: jest.fn(
+    async () => mockCredentialReadiness,
+  ),
+  describeCredentialGaps: jest.fn(
+    (
+      missing: Array<{
+        kind: string;
+        providerId: string | null;
+        reason: string;
+      }>,
+    ) =>
+      missing
+        .map(
+          (g) =>
+            `${g.kind === "stt" ? "speech-to-text" : "text-to-speech"} provider ${
+              g.providerId ? `"${g.providerId}"` : "(unconfigured)"
+            } (${g.reason})`,
+        )
+        .join(", "),
+  ),
+}));
+
 // Mock the TTS provider resolution so that the dynamic import inside
 // MediaStreamOutput.processSynthesizeItem() doesn't pull in the real
 // config/provider chain (which would hang or error in a test environment).
@@ -208,6 +239,22 @@ import {
   activeMediaStreamSessions,
   MediaStreamCallSession,
 } from "../calls/media-stream-server.js";
+
+// ---------------------------------------------------------------------------
+// Async helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Flush pending microtasks (promise continuations). Used to let the async
+ * credential preflight kicked off by `handleStart` resolve before asserting on
+ * the controller's initial greeting / not-ready teardown. Works under jest fake
+ * timers because it relies on microtasks, not the timer queue.
+ */
+async function flushMicrotasks(): Promise<void> {
+  for (let i = 0; i < 5; i++) {
+    await Promise.resolve();
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Mock WebSocket factory
@@ -329,6 +376,7 @@ beforeEach(() => {
   (updateCallSession as jest.Mock).mockClear();
   (finalizeCall as jest.Mock).mockClear();
   (speakSystemPrompt as jest.Mock).mockClear();
+  mockCredentialReadiness = { status: "ready" };
   // Reset routeSetup to default normal_call
   mockRouteSetupResult = {
     outcome: { action: "normal_call" as const, isInbound: true },
@@ -363,7 +411,7 @@ describe("MediaStreamCallSession", () => {
   });
 
   describe("start event handling", () => {
-    test("start event registers a controller and records call_connected", () => {
+    test("start event registers a controller and records call_connected", async () => {
       const mock = createMockWs();
       // Set up a call session in the mock store
       mockSessions.set("call-1", {
@@ -378,13 +426,12 @@ describe("MediaStreamCallSession", () => {
       const session = new MediaStreamCallSession(mock.ws, "call-1");
       session.handleMessage(makeStartMessage());
 
-      // Controller should have been registered
+      // Controller registration and the lifecycle event/update happen
+      // synchronously in handleStart.
       expect(registerCallController).toHaveBeenCalledWith(
         "call-1",
         expect.anything(),
       );
-
-      // call_connected event should have been recorded
       expect(recordCallEvent).toHaveBeenCalledWith(
         "call-1",
         "call_connected",
@@ -393,8 +440,6 @@ describe("MediaStreamCallSession", () => {
           transport: "media-stream",
         }),
       );
-
-      // Call session should have been updated
       expect(updateCallSession).toHaveBeenCalledWith(
         "call-1",
         expect.objectContaining({
@@ -403,7 +448,9 @@ describe("MediaStreamCallSession", () => {
         }),
       );
 
-      // Initial greeting should have been fired
+      // The initial greeting fires after the async credential preflight
+      // resolves — flush microtasks before asserting.
+      await flushMicrotasks();
       expect(mockStartInitialGreeting).toHaveBeenCalled();
     });
 
@@ -422,6 +469,62 @@ describe("MediaStreamCallSession", () => {
       session.handleMessage(makeStartMessage({ streamSid: "MZ-custom-sid" }));
 
       expect(session.getOutput().getStreamSid()).toBe("MZ-custom-sid");
+    });
+
+    test("credential preflight not-ready speaks a setup message, records the event, and ends the call without a controller", async () => {
+      const mock = createMockWs();
+      mockSessions.set("call-1", {
+        id: "call-1",
+        conversationId: "conv-1",
+        status: "initiated",
+        task: "Test task",
+        startedAt: null,
+        toNumber: "+12025550123",
+      });
+      mockCredentialReadiness = {
+        status: "not-ready",
+        missing: [
+          {
+            kind: "stt",
+            providerId: "openai-whisper",
+            reason: "missing-credentials",
+          },
+        ],
+      };
+
+      const session = new MediaStreamCallSession(mock.ws, "call-1");
+      session.handleMessage(makeStartMessage());
+
+      // The controller is bootstrapped synchronously, then the async preflight
+      // tears it down when not-ready. Flush microtasks to let it resolve.
+      await flushMicrotasks();
+
+      // Controller was torn down (destroyed + unregistered) and never greeted.
+      expect(mockDestroy).toHaveBeenCalled();
+      expect(mockStartInitialGreeting).not.toHaveBeenCalled();
+
+      // Failure event recorded with direction + missing details.
+      expect(recordCallEvent).toHaveBeenCalledWith(
+        "call-1",
+        "telephony_credential_preflight_failed",
+        expect.objectContaining({
+          direction: "inbound",
+          transport: "media-stream",
+          missing: mockCredentialReadiness.missing,
+        }),
+      );
+
+      // Session marked failed.
+      expect(updateCallSession).toHaveBeenCalledWith(
+        "call-1",
+        expect.objectContaining({ status: "failed" }),
+      );
+
+      // A spoken setup-required message went out over the media-stream TTS path.
+      expect(speakSystemPrompt).toHaveBeenCalledTimes(1);
+
+      // The call was finalized (teardown) rather than left connected silent.
+      expect(finalizeCall).toHaveBeenCalledWith("call-1", "conv-1");
     });
   });
 
@@ -1052,7 +1155,7 @@ describe("media-stream setup outcome scenarios", () => {
       );
     });
 
-    test("normal_call after deny scenario still creates controller", () => {
+    test("normal_call after deny scenario still creates controller", async () => {
       // Verify that after a deny-scenario test, resetting to normal_call
       // properly creates a controller (no cross-test pollution).
       mockRouteSetupResult = {
@@ -1084,7 +1187,8 @@ describe("media-stream setup outcome scenarios", () => {
         expect.anything(),
       );
 
-      // Initial greeting should fire
+      // Initial greeting fires after the async preflight resolves.
+      await flushMicrotasks();
       expect(mockStartInitialGreeting).toHaveBeenCalled();
     });
   });
@@ -1092,7 +1196,7 @@ describe("media-stream setup outcome scenarios", () => {
   // ── Barge-in regression ──────────────────────────────────────────
 
   describe("barge-in gating", () => {
-    test("immediate inbound audio after stream start does not trigger handleInterrupt", () => {
+    test("immediate inbound audio after stream start does not trigger handleInterrupt", async () => {
       const mockWs = createMockWs();
       mockSessions.set("call-bargein-1", {
         id: "call-bargein-1",
@@ -1105,8 +1209,9 @@ describe("media-stream setup outcome scenarios", () => {
 
       const session = new MediaStreamCallSession(mockWs.ws, "call-bargein-1");
 
-      // Stream start bootstraps the controller
+      // Stream start bootstraps the controller; greeting fires post-preflight.
       session.handleMessage(makeStartMessage());
+      await flushMicrotasks();
       expect(mockStartInitialGreeting).toHaveBeenCalled();
 
       // Immediate inbound audio (speech-like payloads) — before the
@@ -1166,7 +1271,7 @@ describe("media-stream setup outcome scenarios", () => {
   // ── E2E regression scenario ──────────────────────────────────────
 
   describe("end-to-end regression: connected call that stays active", () => {
-    test("stream connects, inbound audio starts, call remains active for a turn, controller only destroyed at stop/hangup", () => {
+    test("stream connects, inbound audio starts, call remains active for a turn, controller only destroyed at stop/hangup", async () => {
       const mockWs = createMockWs();
       mockSessions.set("call-e2e-1", {
         id: "call-e2e-1",
@@ -1185,6 +1290,7 @@ describe("media-stream setup outcome scenarios", () => {
         "call-e2e-1",
         expect.anything(),
       );
+      await flushMicrotasks();
       expect(mockStartInitialGreeting).toHaveBeenCalled();
 
       // Verify session was updated to in_progress

--- a/assistant/src/__tests__/telephony-credential-preflight.test.ts
+++ b/assistant/src/__tests__/telephony-credential-preflight.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Credential-compatibility preflight for media-stream telephony calls.
+ *
+ * On the media-stream call path the daemon does STT + TTS itself, so both
+ * providers need real, usable credentials or the call connects silent. These
+ * tests verify that `resolveTelephonyCredentialReadiness` validates BOTH legs
+ * (reusing the merged telephony-tts-capability helpers and the STT resolver's
+ * adapter-accurate key lookup), and that the not-ready behavior is wired into
+ * the outbound (no dial + pointer + event) and inbound (spoken setup message +
+ * event + end call) call paths.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type {
+  MediaStreamPlaybackFormat,
+  TtsCredentialLookup,
+} from "../tts/provider-catalog.js";
+
+// ---------------------------------------------------------------------------
+// Mocks — declared before subject imports
+// ---------------------------------------------------------------------------
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+// Configured providers (mutated per test).
+let configuredStt = "openai-whisper";
+let configuredTts = "elevenlabs";
+// Per-TTS-provider config blocks (mutated per test).
+let ttsProviderConfigs: Record<string, Record<string, unknown>> = {};
+
+mock.module("../config/loader.js", () => {
+  const config = () => ({
+    services: {
+      stt: { provider: configuredStt },
+      tts: { provider: configuredTts },
+    },
+  });
+  return { loadConfig: config, getConfig: config };
+});
+
+mock.module("../tts/tts-config-resolver.js", () => ({
+  resolveTtsConfig: () => ({
+    provider: configuredTts,
+    providerConfig: ttsProviderConfigs[configuredTts] ?? {},
+  }),
+  resolveProviderTtsConfig: (_config: unknown, provider: string) =>
+    ttsProviderConfigs[provider] ?? {},
+}));
+
+// Synthetic TTS catalog: each entry declares a media-stream output format and a
+// credential lookup the probe must mirror. Mirrors the telephony-tts-guard test.
+const fakeTtsCatalog: Record<
+  string,
+  {
+    mediaStreamPlayback: { outputFormat: MediaStreamPlaybackFormat };
+    key: string;
+    credentialLookup: TtsCredentialLookup;
+  }
+> = {
+  elevenlabs: {
+    mediaStreamPlayback: { outputFormat: "pcm" },
+    key: "credential/elevenlabs/api_key",
+    credentialLookup: "namespaced-only",
+  },
+  "compressed-only": {
+    mediaStreamPlayback: { outputFormat: "none" },
+    key: "credential/compressed-only/api_key",
+    credentialLookup: "namespaced-only",
+  },
+};
+
+mock.module("../tts/provider-catalog.js", () => ({
+  getCatalogProvider: (id: string) => {
+    const entry = fakeTtsCatalog[id];
+    if (!entry) throw new Error(`Unknown TTS provider "${id}"`);
+    return {
+      id,
+      mediaStreamPlayback: entry.mediaStreamPlayback,
+      secretRequirements: [
+        {
+          credentialStoreKey: entry.key,
+          credentialLookup: entry.credentialLookup,
+          displayName: `${id} key`,
+          setCommand: "set",
+        },
+      ],
+    };
+  },
+}));
+
+// Stored credentials keyed by credential store key (mutated per test).
+let storedKeys: Record<string, string> = {};
+// Provider key lookup (STT resolver + provider-key TTS lookups) by provider id.
+let providerKeys: Record<string, string> = {};
+
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKeyAsync: async (account: string) => storedKeys[account],
+  // Mirror the real getProviderKeyAsync lookup: namespaced, then bare, then env.
+  getProviderKeyAsync: async (provider: string) =>
+    providerKeys[provider] ??
+    storedKeys[`credential/${provider}/api_key`] ??
+    storedKeys[provider],
+}));
+
+// ---------------------------------------------------------------------------
+// Subject imports (after mocks). Uses the REAL STT provider catalog so the
+// STT credential probe stays adapter-accurate.
+// ---------------------------------------------------------------------------
+
+import {
+  describeCredentialGaps,
+  resolveTelephonyCredentialReadiness,
+} from "../calls/telephony-credential-preflight.js";
+
+beforeEach(() => {
+  configuredStt = "openai-whisper"; // credentialProvider: "openai"
+  configuredTts = "elevenlabs";
+  storedKeys = {};
+  providerKeys = {};
+  ttsProviderConfigs = {};
+});
+
+// ---------------------------------------------------------------------------
+// resolveTelephonyCredentialReadiness
+// ---------------------------------------------------------------------------
+
+describe("resolveTelephonyCredentialReadiness", () => {
+  test("STT key present + TTS playable → ready", async () => {
+    providerKeys.openai = "sk_openai"; // STT credential
+    storedKeys["credential/elevenlabs/api_key"] = "sk_eleven"; // TTS credential
+
+    const result = await resolveTelephonyCredentialReadiness();
+    expect(result.status).toBe("ready");
+  });
+
+  test("missing STT key → not-ready (stt / missing-credentials)", async () => {
+    // No openai key; TTS is fine.
+    storedKeys["credential/elevenlabs/api_key"] = "sk_eleven";
+
+    const result = await resolveTelephonyCredentialReadiness();
+    expect(result.status).toBe("not-ready");
+    if (result.status === "not-ready") {
+      expect(result.missing).toHaveLength(1);
+      expect(result.missing[0]).toEqual({
+        kind: "stt",
+        providerId: "openai-whisper",
+        reason: "missing-credentials",
+      });
+    }
+  });
+
+  test("non-playable TTS → not-ready (tts)", async () => {
+    providerKeys.openai = "sk_openai"; // STT fine
+    configuredTts = "compressed-only"; // format "none"
+    storedKeys["credential/compressed-only/api_key"] = "sk_test"; // credentialed but unplayable
+    // No elevenlabs default key, so the fallback is not playable either.
+
+    const result = await resolveTelephonyCredentialReadiness();
+    expect(result.status).toBe("not-ready");
+    if (result.status === "not-ready") {
+      expect(result.missing).toHaveLength(1);
+      expect(result.missing[0].kind).toBe("tts");
+      expect(result.missing[0].providerId).toBe("compressed-only");
+      expect(result.missing[0].reason).toBe("not-playable");
+    }
+  });
+
+  test("both missing → not-ready lists both gaps", async () => {
+    // No STT key, unplayable TTS with no usable fallback.
+    configuredTts = "compressed-only";
+    storedKeys["credential/compressed-only/api_key"] = "sk_test";
+
+    const result = await resolveTelephonyCredentialReadiness();
+    expect(result.status).toBe("not-ready");
+    if (result.status === "not-ready") {
+      const kinds = result.missing.map((g) => g.kind).sort();
+      expect(kinds).toEqual(["stt", "tts"]);
+    }
+  });
+
+  test("unconfigured STT provider → not-ready (unconfigured-provider)", async () => {
+    configuredStt = "not-a-real-provider";
+    storedKeys["credential/elevenlabs/api_key"] = "sk_eleven";
+
+    const result = await resolveTelephonyCredentialReadiness();
+    expect(result.status).toBe("not-ready");
+    if (result.status === "not-ready") {
+      expect(result.missing[0]).toEqual({
+        kind: "stt",
+        providerId: null,
+        reason: "unconfigured-provider",
+      });
+    }
+  });
+
+  // Fallback: a verified-ready configured provider (or default) is the ONLY
+  // accepted substitute. Here the configured TTS is unplayable but the default
+  // (elevenlabs) is credentialed + playable, so TTS is treated as ready.
+  test("fallback only chosen when the default TTS provider verifies ready", async () => {
+    providerKeys.openai = "sk_openai"; // STT fine
+    configuredTts = "compressed-only"; // unplayable configured provider
+    storedKeys["credential/compressed-only/api_key"] = "sk_test";
+    storedKeys["credential/elevenlabs/api_key"] = "sk_default"; // default verifies ready
+
+    const result = await resolveTelephonyCredentialReadiness();
+    // The default is verified ready, so the call may proceed via fallback.
+    expect(result.status).toBe("ready");
+  });
+
+  test("fallback NOT chosen when the default TTS provider is also uncredentialed", async () => {
+    providerKeys.openai = "sk_openai";
+    configuredTts = "compressed-only";
+    storedKeys["credential/compressed-only/api_key"] = "sk_test";
+    // elevenlabs default has NO namespaced key — not a verified substitute.
+
+    const result = await resolveTelephonyCredentialReadiness();
+    expect(result.status).toBe("not-ready");
+    if (result.status === "not-ready") {
+      expect(result.missing.some((g) => g.kind === "tts")).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// describeCredentialGaps
+// ---------------------------------------------------------------------------
+
+describe("describeCredentialGaps", () => {
+  test("names each missing provider credential", () => {
+    const text = describeCredentialGaps([
+      {
+        kind: "stt",
+        providerId: "openai-whisper",
+        reason: "missing-credentials",
+      },
+      { kind: "tts", providerId: "elevenlabs", reason: "missing-credentials" },
+    ]);
+    expect(text).toContain("speech-to-text");
+    expect(text).toContain('"openai-whisper"');
+    expect(text).toContain("text-to-speech");
+    expect(text).toContain('"elevenlabs"');
+    expect(text).toContain("missing-credentials");
+  });
+
+  test("renders an unconfigured provider without a quoted id", () => {
+    const text = describeCredentialGaps([
+      { kind: "stt", providerId: null, reason: "unconfigured-provider" },
+    ]);
+    expect(text).toContain("(unconfigured)");
+  });
+});

--- a/assistant/src/__tests__/telephony-credential-preflight.test.ts
+++ b/assistant/src/__tests__/telephony-credential-preflight.test.ts
@@ -32,7 +32,11 @@ mock.module("../util/logger.js", () => ({
 
 // Configured providers (mutated per test).
 let configuredStt = "openai-whisper";
-let configuredTts = "elevenlabs";
+let configuredTts: string | undefined = "elevenlabs";
+// When true, the config has NO `services.tts` block at all (partial/edge
+// config). The capability resolver must treat this as "unconfigured" and not
+// throw on the missing block.
+let omitTtsBlock = false;
 // Per-TTS-provider config blocks (mutated per test).
 let ttsProviderConfigs: Record<string, Record<string, unknown>> = {};
 
@@ -40,7 +44,7 @@ mock.module("../config/loader.js", () => {
   const config = () => ({
     services: {
       stt: { provider: configuredStt },
-      tts: { provider: configuredTts },
+      ...(omitTtsBlock ? {} : { tts: { provider: configuredTts } }),
     },
   });
   return { loadConfig: config, getConfig: config };
@@ -49,7 +53,9 @@ mock.module("../config/loader.js", () => {
 mock.module("../tts/tts-config-resolver.js", () => ({
   resolveTtsConfig: () => ({
     provider: configuredTts,
-    providerConfig: ttsProviderConfigs[configuredTts] ?? {},
+    providerConfig: configuredTts
+      ? (ttsProviderConfigs[configuredTts] ?? {})
+      : {},
   }),
   resolveProviderTtsConfig: (_config: unknown, provider: string) =>
     ttsProviderConfigs[provider] ?? {},
@@ -77,23 +83,30 @@ const fakeTtsCatalog: Record<
   },
 };
 
+const buildFakeTtsEntry = (id: string) => {
+  const entry = fakeTtsCatalog[id];
+  if (!entry) return null;
+  return {
+    id,
+    mediaStreamPlayback: entry.mediaStreamPlayback,
+    secretRequirements: [
+      {
+        credentialStoreKey: entry.key,
+        credentialLookup: entry.credentialLookup,
+        displayName: `${id} key`,
+        setCommand: "set",
+      },
+    ],
+  };
+};
+
 mock.module("../tts/provider-catalog.js", () => ({
   getCatalogProvider: (id: string) => {
-    const entry = fakeTtsCatalog[id];
+    const entry = buildFakeTtsEntry(id);
     if (!entry) throw new Error(`Unknown TTS provider "${id}"`);
-    return {
-      id,
-      mediaStreamPlayback: entry.mediaStreamPlayback,
-      secretRequirements: [
-        {
-          credentialStoreKey: entry.key,
-          credentialLookup: entry.credentialLookup,
-          displayName: `${id} key`,
-          setCommand: "set",
-        },
-      ],
-    };
+    return entry;
   },
+  getCatalogProviderOrNull: (id: string) => buildFakeTtsEntry(id),
 }));
 
 // Stored credentials keyed by credential store key (mutated per test).
@@ -123,6 +136,7 @@ import {
 beforeEach(() => {
   configuredStt = "openai-whisper"; // credentialProvider: "openai"
   configuredTts = "elevenlabs";
+  omitTtsBlock = false;
   storedKeys = {};
   providerKeys = {};
   ttsProviderConfigs = {};
@@ -198,6 +212,40 @@ describe("resolveTelephonyCredentialReadiness", () => {
         providerId: null,
         reason: "unconfigured-provider",
       });
+    }
+  });
+
+  // Malformed config: no `services.tts` block at all. The TTS leg must NOT
+  // throw (which would surface as a generic 500 outbound, or be swallowed as
+  // "ready" inbound and dial into silence) — it returns a not-ready tts gap.
+  test("missing services.tts block → not-ready (tts) with no throw", async () => {
+    providerKeys.openai = "sk_openai"; // STT fine
+    omitTtsBlock = true;
+
+    const result = await resolveTelephonyCredentialReadiness();
+    expect(result.status).toBe("not-ready");
+    if (result.status === "not-ready") {
+      const ttsGaps = result.missing.filter((g) => g.kind === "tts");
+      expect(ttsGaps).toHaveLength(1);
+      expect(ttsGaps[0].providerId).toBeNull();
+      expect(ttsGaps[0].reason).toBe("unconfigured-provider");
+    }
+  });
+
+  // Malformed config: `services.tts.provider` is set but is not in the TTS
+  // catalog. The TTS leg must NOT throw on the catalog lookup — it returns a
+  // not-ready tts gap naming the unknown provider.
+  test("unknown services.tts.provider → not-ready (tts) with no throw", async () => {
+    providerKeys.openai = "sk_openai"; // STT fine
+    configuredTts = "not-a-real-tts-provider";
+
+    const result = await resolveTelephonyCredentialReadiness();
+    expect(result.status).toBe("not-ready");
+    if (result.status === "not-ready") {
+      const ttsGaps = result.missing.filter((g) => g.kind === "tts");
+      expect(ttsGaps).toHaveLength(1);
+      expect(ttsGaps[0].providerId).toBe("not-a-real-tts-provider");
+      expect(ttsGaps[0].reason).toBe("unconfigured-provider");
     }
   });
 

--- a/assistant/src/__tests__/telephony-tts-guard.test.ts
+++ b/assistant/src/__tests__/telephony-tts-guard.test.ts
@@ -35,8 +35,15 @@ let configuredProvider: TtsProviderId = "elevenlabs";
 // provider, e.g. the fallback default).
 let providerConfigs: Record<string, Record<string, unknown>> = {};
 
+// When true, the config has NO `services.tts` block at all (partial/edge
+// config). The capability resolver must treat this as "unconfigured" and not
+// throw on the missing block.
+let omitTtsBlock = false;
+
 mock.module("../config/loader.js", () => ({
-  loadConfig: () => ({ services: { tts: { provider: configuredProvider } } }),
+  loadConfig: () => ({
+    services: omitTtsBlock ? {} : { tts: { provider: configuredProvider } },
+  }),
 }));
 
 mock.module("../tts/tts-config-resolver.js", () => ({
@@ -91,23 +98,30 @@ const fakeCatalog: Record<
   },
 };
 
+const buildFakeEntry = (id: string) => {
+  const entry = fakeCatalog[id];
+  if (!entry) return null;
+  return {
+    id,
+    mediaStreamPlayback: entry.mediaStreamPlayback,
+    secretRequirements: [
+      {
+        credentialStoreKey: entry.key,
+        credentialLookup: entry.credentialLookup,
+        displayName: `${id} key`,
+        setCommand: "set",
+      },
+    ],
+  };
+};
+
 mock.module("../tts/provider-catalog.js", () => ({
   getCatalogProvider: (id: string) => {
-    const entry = fakeCatalog[id];
+    const entry = buildFakeEntry(id);
     if (!entry) throw new Error(`Unknown TTS provider "${id}"`);
-    return {
-      id,
-      mediaStreamPlayback: entry.mediaStreamPlayback,
-      secretRequirements: [
-        {
-          credentialStoreKey: entry.key,
-          credentialLookup: entry.credentialLookup,
-          displayName: `${id} key`,
-          setCommand: "set",
-        },
-      ],
-    };
+    return entry;
   },
+  getCatalogProviderOrNull: (id: string) => buildFakeEntry(id),
 }));
 
 // Stored credentials keyed by credential store key (mutated per test).
@@ -165,6 +179,7 @@ function makeProvider(id: string): TtsProvider {
 
 beforeEach(() => {
   configuredProvider = "elevenlabs";
+  omitTtsBlock = false;
   storedKeys = {};
   envProviderKeys = {};
   providerConfigs = {};
@@ -228,6 +243,28 @@ describe("resolveTelephonyTtsCapability", () => {
     expect(result.status).toBe("not-playable");
     if (result.status === "not-playable") {
       expect(result.reason).toBe("missing-credentials");
+    }
+  });
+
+  test("missing services.tts block is not-playable (unconfigured), no throw", async () => {
+    omitTtsBlock = true;
+
+    const result = await resolveTelephonyTtsCapability();
+    expect(result.status).toBe("not-playable");
+    if (result.status === "not-playable") {
+      expect(result.reason).toBe("unconfigured");
+      expect(result.providerId).toBeNull();
+    }
+  });
+
+  test("unknown provider is not-playable (unknown-provider), no throw", async () => {
+    configuredProvider = "not-a-real-tts-provider" as TtsProviderId;
+
+    const result = await resolveTelephonyTtsCapability();
+    expect(result.status).toBe("not-playable");
+    if (result.status === "not-playable") {
+      expect(result.reason).toBe("unknown-provider");
+      expect(result.providerId).toBe("not-a-real-tts-provider");
     }
   });
 

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -335,6 +335,7 @@ import {
   buildWelcomeGreeting,
   handleStatusCallback,
   handleVoiceWebhook,
+  outboundWillUseMediaStream,
 } from "../calls/twilio-routes.js";
 import { DEFAULT_ELEVENLABS_VOICE_ID } from "../config/schemas/elevenlabs.js";
 import { getDb } from "../memory/db-connection.js";
@@ -1376,6 +1377,91 @@ describe("twilio webhook routes", () => {
       // ConversationRelay should be emitted regardless of setup outcome
       expect(twiml).toContain("<ConversationRelay");
       expect(twiml).not.toContain("<Stream");
+    });
+  });
+
+  // ── Outbound preflight transport gate ───────────────────────────────
+  // `outboundWillUseMediaStream` is the SHARED predicate the outbound
+  // credential preflight (call-domain.startCall) uses to decide whether to run
+  // the local STT/TTS credential check. It must mirror buildVoiceWebhookTwiml's
+  // FULL transport decision: media-stream is used ONLY when STT routing is
+  // media-stream-custom AND the routeSetup outcome is normal_call / deny. For
+  // CR-native STT, or for interactive outcomes that buildVoiceWebhookTwiml
+  // CR-falls-back, it must return false so the preflight is skipped.
+
+  describe("outboundWillUseMediaStream (preflight transport gate)", () => {
+    test("media-stream-custom STT + normal_call outcome → true (preflight runs)", () => {
+      mockConfigObj.services.stt.provider = "openai-whisper" as any;
+      mockRouteSetupResult = {
+        outcome: { action: "normal_call", isInbound: false },
+        resolved: {
+          assistantId: "self",
+          isInbound: false,
+          otherPartyNumber: "+14155550199",
+          actorTrust: { trustClass: "guardian", memberRecord: null },
+        },
+      };
+      const session = createTestSession("conv-gate-ms-normal", "CA_gate_ms_1");
+
+      expect(outboundWillUseMediaStream(session)).toBe(true);
+    });
+
+    test("media-stream-custom STT + interactive (callee_verification) outcome → false (preflight skipped, CR-fallback)", () => {
+      // calls.verification.enabled makes routeSetup return callee_verification
+      // for an interactive outbound flow; buildVoiceWebhookTwiml CR-falls-back,
+      // so the call needs no local creds and the gate must skip the preflight.
+      mockConfigObj.services.stt.provider = "openai-whisper" as any;
+      mockRouteSetupResult = {
+        outcome: {
+          action: "callee_verification",
+          verificationConfig: { maxAttempts: 3, codeLength: 6 },
+        },
+        resolved: {
+          assistantId: "self",
+          isInbound: false,
+          otherPartyNumber: "+14155550199",
+          actorTrust: { trustClass: "guardian", memberRecord: null },
+        },
+      };
+      const session = createTestSession("conv-gate-ms-verify", "CA_gate_ms_2");
+
+      expect(outboundWillUseMediaStream(session)).toBe(false);
+    });
+
+    test("media-stream-custom STT + deny outcome → true (media-stream serves deny)", () => {
+      mockConfigObj.services.stt.provider = "openai-whisper" as any;
+      mockRouteSetupResult = {
+        outcome: {
+          action: "deny",
+          message: "Not authorized.",
+          logReason: "test",
+        },
+        resolved: {
+          assistantId: "self",
+          isInbound: false,
+          otherPartyNumber: "+14155550199",
+          actorTrust: { trustClass: "unknown", memberRecord: null },
+        },
+      };
+      const session = createTestSession("conv-gate-ms-deny", "CA_gate_ms_3");
+
+      expect(outboundWillUseMediaStream(session)).toBe(true);
+    });
+
+    test("CR-native STT (deepgram) → false regardless of outcome (preflight skipped)", () => {
+      mockConfigObj.services.stt.provider = "deepgram" as any;
+      mockRouteSetupResult = {
+        outcome: { action: "normal_call", isInbound: false },
+        resolved: {
+          assistantId: "self",
+          isInbound: false,
+          otherPartyNumber: "+14155550199",
+          actorTrust: { trustClass: "guardian", memberRecord: null },
+        },
+      };
+      const session = createTestSession("conv-gate-cr", "CA_gate_cr_1");
+
+      expect(outboundWillUseMediaStream(session)).toBe(false);
     });
   });
 

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -44,6 +44,7 @@ import { activeRelayConnections } from "./relay-server.js";
 import {
   describeCredentialGaps,
   resolveTelephonyCredentialReadiness,
+  willUseMediaStreamTransport,
 } from "./telephony-credential-preflight.js";
 import { getTwilioConfig } from "./twilio-config.js";
 import { TwilioConversationRelayProvider } from "./twilio-provider.js";
@@ -458,7 +459,21 @@ export async function startCall(
     // or the call connects silent. Fail BEFORE placing the Twilio call —
     // record the failure event, point the user at the missing credential, and
     // do not dial.
-    const credentialReadiness = await resolveTelephonyCredentialReadiness();
+    //
+    // GATE: only run this for calls that will actually use the media-stream
+    // transport (`<Connect><Stream>`). For conversation-relay-native STT
+    // providers (deepgram / google) Twilio CR does STT + native TTS itself and
+    // needs no local credentials, so the preflight would wrongly block default
+    // setups. `willUseMediaStreamTransport()` mirrors the branch
+    // buildVoiceWebhookTwiml takes (routing === "media-stream-custom").
+    //
+    // CROSS-PR NOTE (PR 11): PR 11 flips routing so ALL calls use the
+    // media-stream transport. When that lands, the gate must become always-on
+    // — update willUseMediaStreamTransport() (the shared seam) to return true
+    // unconditionally; this call site then needs no change.
+    const credentialReadiness = willUseMediaStreamTransport()
+      ? await resolveTelephonyCredentialReadiness()
+      : ({ status: "ready" } as const);
     if (credentialReadiness.status === "not-ready") {
       const summary = describeCredentialGaps(credentialReadiness.missing);
       recordCallEvent(session.id, "telephony_credential_preflight_failed", {

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -44,10 +44,10 @@ import { activeRelayConnections } from "./relay-server.js";
 import {
   describeCredentialGaps,
   resolveTelephonyCredentialReadiness,
-  willUseMediaStreamTransport,
 } from "./telephony-credential-preflight.js";
 import { getTwilioConfig } from "./twilio-config.js";
 import { TwilioConversationRelayProvider } from "./twilio-provider.js";
+import { outboundWillUseMediaStream } from "./twilio-routes.js";
 import type { CallSession } from "./types.js";
 import { preflightVoiceIngress } from "./voice-ingress-preflight.js";
 
@@ -460,18 +460,27 @@ export async function startCall(
     // record the failure event, point the user at the missing credential, and
     // do not dial.
     //
-    // GATE: only run this for calls that will actually use the media-stream
-    // transport (`<Connect><Stream>`). For conversation-relay-native STT
-    // providers (deepgram / google) Twilio CR does STT + native TTS itself and
-    // needs no local credentials, so the preflight would wrongly block default
-    // setups. `willUseMediaStreamTransport()` mirrors the branch
-    // buildVoiceWebhookTwiml takes (routing === "media-stream-custom").
+    // GATE: only run this for calls that will actually be served by the
+    // media-stream transport (`<Connect><Stream>`). `outboundWillUseMediaStream`
+    // mirrors the FULL transport decision buildVoiceWebhookTwiml makes for this
+    // exact session: media-stream is used ONLY when STT routing is
+    // `media-stream-custom` AND routeSetup's outcome is one media-stream can
+    // serve (normal_call / deny). It returns false for:
+    //   - conversation-relay-native STT (deepgram / google): Twilio CR does STT
+    //     + native TTS, so no local credentials are needed; AND
+    //   - interactive outbound flows that buildVoiceWebhookTwiml CR-falls-back
+    //     (e.g. calls.verification.enabled → callee_verification): these are
+    //     served by CR too, so the preflight must be skipped or it would
+    //     wrongly block the call for missing local STT/TTS creds.
+    // Sharing the predicate with buildVoiceWebhookTwiml guarantees the gate and
+    // the real TwiML branch cannot drift.
     //
-    // CROSS-PR NOTE (PR 11): PR 11 flips routing so ALL calls use the
-    // media-stream transport. When that lands, the gate must become always-on
-    // — update willUseMediaStreamTransport() (the shared seam) to return true
-    // unconditionally; this call site then needs no change.
-    const credentialReadiness = willUseMediaStreamTransport()
+    // CROSS-PR NOTE (PR 11): PR 11 removes the CR-fallback entirely — all setup
+    // outcomes route to the media-stream transport. When that lands,
+    // outboundWillUseMediaStream collapses to "strategy === media-stream-custom"
+    // (and, once routing always selects it, to always-true); PR 11 must
+    // simplify that shared helper accordingly. This call site needs no change.
+    const credentialReadiness = outboundWillUseMediaStream(session)
       ? await resolveTelephonyCredentialReadiness()
       : ({ status: "ready" } as const);
     if (credentialReadiness.status === "not-ready") {

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -36,10 +36,15 @@ import {
   getCallSession,
   getCallSessionByCallSid,
   getPendingQuestion,
+  recordCallEvent,
   updateCallSession,
 } from "./call-store.js";
 import { activeMediaStreamSessions } from "./media-stream-server.js";
 import { activeRelayConnections } from "./relay-server.js";
+import {
+  describeCredentialGaps,
+  resolveTelephonyCredentialReadiness,
+} from "./telephony-credential-preflight.js";
 import { getTwilioConfig } from "./twilio-config.js";
 import { TwilioConversationRelayProvider } from "./twilio-provider.js";
 import type { CallSession } from "./types.js";
@@ -447,6 +452,32 @@ export async function startCall(
       initiatedFromConversationId: conversationId,
     });
     sessionId = session.id;
+
+    // Credential-compatibility preflight: on the media-stream call path the
+    // daemon does STT + TTS itself, so both providers need usable credentials
+    // or the call connects silent. Fail BEFORE placing the Twilio call —
+    // record the failure event, point the user at the missing credential, and
+    // do not dial.
+    const credentialReadiness = await resolveTelephonyCredentialReadiness();
+    if (credentialReadiness.status === "not-ready") {
+      const summary = describeCredentialGaps(credentialReadiness.missing);
+      recordCallEvent(session.id, "telephony_credential_preflight_failed", {
+        direction: "outbound",
+        missing: credentialReadiness.missing,
+      });
+      updateCallSession(session.id, {
+        status: "failed",
+        endedAt: Date.now(),
+        lastError: `Telephony credential preflight failed: ${summary}`,
+      });
+      const reason = `Call setup is incomplete — configure the missing voice provider credential(s): ${summary}.`;
+      postFailedCallPointer(conversationId, phoneNumber, reason);
+      log.warn(
+        { callSessionId: session.id, missing: credentialReadiness.missing },
+        "Outbound call blocked by telephony credential preflight",
+      );
+      return { ok: false, error: reason, status: 400 };
+    }
 
     // Create a dedicated voice conversation for this call so that voice
     // transcripts live in their own conversation, separate from the chat that

--- a/assistant/src/calls/media-stream-server.ts
+++ b/assistant/src/calls/media-stream-server.ts
@@ -60,6 +60,10 @@ import {
   type MediaStreamSttSessionConfig,
 } from "./media-stream-stt-session.js";
 import { routeSetup } from "./relay-setup-router.js";
+import {
+  describeCredentialGaps,
+  resolveTelephonyCredentialReadiness,
+} from "./telephony-credential-preflight.js";
 
 const log = getLogger("media-stream-server");
 
@@ -377,13 +381,13 @@ export class MediaStreamCallSession {
         );
         registerCallController(this.callSessionId, this.controller);
 
-        // Fire the initial greeting.
-        this.controller.startInitialGreeting().catch((err) => {
-          log.error(
-            { err, callSessionId: this.callSessionId },
-            "Failed to start initial greeting on media-stream session",
-          );
-        });
+        // Credential-compatibility preflight: the media-stream is already
+        // connected and the daemon does STT + TTS itself here. If the
+        // configured providers lack usable credentials the call would sit
+        // silent, so verify readiness (async) before greeting; when not ready,
+        // tear down, speak a short setup-required message, and end the call
+        // instead of connect-and-sit-silent.
+        void this.preflightCredentialsThenGreet(session);
         return;
       }
 
@@ -455,6 +459,91 @@ export class MediaStreamCallSession {
         });
         return;
     }
+  }
+
+  /**
+   * Run the media-stream credential preflight for a normal call. When ready,
+   * fire the initial greeting through the already-created controller. When NOT
+   * ready, tear the just-bootstrapped controller down, record the failure
+   * event, speak a short setup-required message over the normal media-stream
+   * TTS path, and end the call — never connect-and-sit-silent.
+   *
+   * The not-ready teardown mirrors the deny branch: mark the session failed,
+   * run finalization (since `handleTransportClosed` exits early on terminal
+   * status), speak, then end after the play URL has been delivered.
+   */
+  private async preflightCredentialsThenGreet(
+    session: ReturnType<typeof getCallSession>,
+  ): Promise<void> {
+    let readiness: Awaited<
+      ReturnType<typeof resolveTelephonyCredentialReadiness>
+    >;
+    try {
+      readiness = await resolveTelephonyCredentialReadiness();
+    } catch (err) {
+      // Treat a preflight error as ready so a transient config-read failure
+      // doesn't hang up an otherwise-valid call; downstream synthesis/STT
+      // already degrade safely (TTS via the playability guard).
+      log.error(
+        { err, callSessionId: this.callSessionId },
+        "Telephony credential preflight threw — proceeding with call setup",
+      );
+      readiness = { status: "ready" };
+    }
+
+    if (readiness.status === "not-ready") {
+      const summary = describeCredentialGaps(readiness.missing);
+      log.warn(
+        { callSessionId: this.callSessionId, missing: readiness.missing },
+        "Inbound media-stream call blocked by telephony credential preflight",
+      );
+
+      // Tear down the controller bootstrapped synchronously above before its
+      // greeting can attempt (silent) synthesis.
+      if (this.controller) {
+        this.controller.destroy();
+        this.controller = null;
+        unregisterCallController(this.callSessionId);
+      }
+
+      recordCallEvent(
+        this.callSessionId,
+        "telephony_credential_preflight_failed",
+        {
+          direction: "inbound",
+          missing: readiness.missing,
+          transport: "media-stream",
+        },
+      );
+      updateCallSession(this.callSessionId, {
+        status: "failed",
+        endedAt: Date.now(),
+        lastError: `Telephony credential preflight failed: ${summary}`,
+      });
+      // Run finalization now because handleTransportClosed will see terminal
+      // status and exit early when the WebSocket closes.
+      this.runFinalizationAndGrantCleanup(session);
+      void speakSystemPrompt(
+        this.output,
+        "Sorry, this assistant isn't set up to take calls right now. Please try again later. Goodbye.",
+      ).finally(() => {
+        setTimeout(
+          () =>
+            this.output.endSession(`Credential preflight failed: ${summary}`),
+          3000,
+        );
+      });
+      return;
+    }
+
+    // Ready — fire the initial greeting on the already-registered controller.
+    if (!this.controller) return;
+    this.controller.startInitialGreeting().catch((err) => {
+      log.error(
+        { err, callSessionId: this.callSessionId },
+        "Failed to start initial greeting on media-stream session",
+      );
+    });
   }
 
   // ── Finalization helper for early-teardown paths ─────────────────

--- a/assistant/src/calls/telephony-credential-preflight.ts
+++ b/assistant/src/calls/telephony-credential-preflight.ts
@@ -60,6 +60,7 @@ import {
   DEFAULT_PLAYABLE_TTS_PROVIDER,
   resolveTelephonyTtsCapability,
   resolveTelephonyTtsCapabilityFor,
+  type TelephonyTtsCapability,
 } from "./telephony-tts-capability.js";
 
 const log = getLogger("telephony-credential-preflight");
@@ -161,11 +162,31 @@ async function resolveTtsGap(): Promise<TelephonyCredentialGap | null> {
   return {
     kind: "tts",
     providerId: configured.providerId,
-    reason:
-      configured.reason === "missing-credentials"
-        ? "missing-credentials"
-        : "not-playable",
+    reason: ttsReasonToGapReason(configured.reason),
   };
+}
+
+/**
+ * Map a TTS not-playable reason to the preflight's credential-gap reason.
+ *
+ * A missing/unknown `services.tts.provider` (the resolver now returns these as
+ * non-throwing `unconfigured`/`unknown-provider` reasons, mirroring the STT
+ * leg) becomes `unconfigured-provider`, so a malformed TTS config produces a
+ * not-ready gap — never a throw and never a silent-continue.
+ */
+function ttsReasonToGapReason(
+  reason: Exclude<TelephonyTtsCapability, { status: "playable" }>["reason"],
+): TelephonyCredentialMissingReason {
+  switch (reason) {
+    case "missing-credentials":
+      return "missing-credentials";
+    case "unconfigured":
+    case "unknown-provider":
+      return "unconfigured-provider";
+    case "unsupported-format":
+    case "missing-required-config":
+      return "not-playable";
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/calls/telephony-credential-preflight.ts
+++ b/assistant/src/calls/telephony-credential-preflight.ts
@@ -1,0 +1,220 @@
+/**
+ * Credential-compatibility preflight for media-stream telephony calls.
+ *
+ * On the media-stream call path the daemon performs BOTH speech-to-text and
+ * text-to-speech itself (Twilio ConversationRelay used to do this with its own
+ * managed providers, so no caller credentials were required). Once a call runs
+ * over `<Connect><Stream>`, the configured STT and TTS providers must have real,
+ * usable credentials or the call connects and then sits silent — the daemon
+ * cannot transcribe the caller and cannot synthesize a reply.
+ *
+ * This module turns "are the configured STT + TTS providers actually able to
+ * run a media-stream call?" into one explicit, testable decision via
+ * {@link resolveTelephonyCredentialReadiness}.
+ *
+ * ## Contract
+ *
+ * Readiness requires BOTH:
+ *   1. **STT** — the configured `services.stt.provider` is telephony-eligible
+ *      and has a usable credential under the SAME lookup its resolver uses
+ *      (`getProviderKeyAsync(entry.credentialProvider)` via the STT provider
+ *      catalog). This is the boundary the media-stream STT session will use
+ *      (`daemon-streaming` for realtime-ws providers, `daemon-batch` for
+ *      batch-only providers) — both are gated by the catalog's `telephonyMode`.
+ *   2. **TTS** — the configured `services.tts.provider` can feed the
+ *      media-stream PCM -> mu-law transcoder per
+ *      {@link resolveTelephonyTtsCapability} (playable format + credential +
+ *      required config). The TTS credential probe is NOT re-implemented here:
+ *      it is fully delegated to the merged `telephony-tts-capability` helpers
+ *      (`resolveTelephonyTtsCapability`, `isTtsProviderCredentialAvailable`),
+ *      whose probes are adapter-accurate per provider.
+ *
+ * ## Fallback
+ *
+ * A managed/credentialed substitute provider is only ever accepted when it is
+ * **actually configured AND verified ready by this same preflight**. For TTS,
+ * that means the configured provider OR the verified-ready PCM-capable default
+ * ({@link DEFAULT_PLAYABLE_TTS_PROVIDER}) — mirroring
+ * {@link resolvePlayableCallTtsProvider}. No default lacking a verified
+ * credential is ever invented. STT has no default substitute, so a missing STT
+ * credential is always not-ready.
+ *
+ * ## Not-ready behavior (enforced by the call ingress/setup callers)
+ *
+ * - **Outbound** (`call-domain.ts`): fail BEFORE placing the Twilio call. Write
+ *   a user-facing setup-pointer message to the originating conversation naming
+ *   the missing provider credential, record `telephony_credential_preflight_failed`,
+ *   and do not place the call.
+ * - **Inbound** (`media-stream-server.ts` `handleStart`): the media-stream is
+ *   already connected, so speak a short "setup required" message via the normal
+ *   media-stream TTS path, record `telephony_credential_preflight_failed`, then
+ *   end the call. Never connect-and-sit-silent.
+ */
+
+import {
+  resolveTelephonySttCapability,
+  type TelephonySttCapability,
+} from "../providers/speech-to-text/resolve.js";
+import { getLogger } from "../util/logger.js";
+import {
+  DEFAULT_PLAYABLE_TTS_PROVIDER,
+  resolveTelephonyTtsCapability,
+  resolveTelephonyTtsCapabilityFor,
+} from "./telephony-tts-capability.js";
+
+const log = getLogger("telephony-credential-preflight");
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** Why a missing credential blocks a media-stream call. */
+export type TelephonyCredentialMissingReason =
+  | "missing-credentials"
+  | "unsupported-provider"
+  | "unconfigured-provider"
+  | "not-playable";
+
+/** A single provider whose credential/playability blocks the call. */
+export interface TelephonyCredentialGap {
+  /** Which leg of the pipeline is missing a usable credential. */
+  kind: "stt" | "tts";
+  /** Provider id, or `null` when the configured provider is unknown. */
+  providerId: string | null;
+  /** Machine-readable reason the provider is not usable. */
+  reason: TelephonyCredentialMissingReason;
+}
+
+/** Result of {@link resolveTelephonyCredentialReadiness}. */
+export type TelephonyCredentialReadiness =
+  | { status: "ready" }
+  | { status: "not-ready"; missing: TelephonyCredentialGap[] };
+
+// ---------------------------------------------------------------------------
+// STT readiness
+// ---------------------------------------------------------------------------
+
+/**
+ * Map an STT telephony capability to a preflight gap, or `null` when ready.
+ *
+ * The credential check is delegated to {@link resolveTelephonySttCapability},
+ * which reads the key via `getProviderKeyAsync(entry.credentialProvider)` —
+ * the exact lookup the streaming/batch transcriber resolvers use — so the probe
+ * cannot disagree with the adapter at call time.
+ */
+function sttCapabilityToGap(
+  capability: TelephonySttCapability,
+): TelephonyCredentialGap | null {
+  switch (capability.status) {
+    case "supported":
+      return null;
+    case "missing-credentials":
+      return {
+        kind: "stt",
+        providerId: capability.providerId,
+        reason: "missing-credentials",
+      };
+    case "unsupported":
+      return {
+        kind: "stt",
+        providerId: capability.providerId,
+        reason: "unsupported-provider",
+      };
+    case "unconfigured":
+      return { kind: "stt", providerId: null, reason: "unconfigured-provider" };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// TTS readiness
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the TTS gap for the media-stream path, or `null` when ready.
+ *
+ * Mirrors {@link resolvePlayableCallTtsProvider}: the configured provider is
+ * accepted when playable; otherwise the PCM-capable default is accepted ONLY
+ * when it is itself verified playable (credentialed + required config). This is
+ * the only fallback — no uncredentialed substitute is ever invented. When
+ * neither is playable, the configured provider's gap is reported.
+ */
+async function resolveTtsGap(): Promise<TelephonyCredentialGap | null> {
+  const configured = await resolveTelephonyTtsCapability();
+  if (configured.status === "playable") return null;
+
+  const fallback = await resolveTelephonyTtsCapabilityFor(
+    DEFAULT_PLAYABLE_TTS_PROVIDER,
+  );
+  if (fallback.status === "playable") {
+    log.warn(
+      {
+        configuredProvider: configured.providerId,
+        configuredReason: configured.reason,
+        fallbackProvider: DEFAULT_PLAYABLE_TTS_PROVIDER,
+      },
+      "Configured telephony TTS provider not playable — a verified-ready " +
+        "PCM-capable default is available, so the call may proceed via fallback",
+    );
+    return null;
+  }
+
+  return {
+    kind: "tts",
+    providerId: configured.providerId,
+    reason:
+      configured.reason === "missing-credentials"
+        ? "missing-credentials"
+        : "not-playable",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate that the configured STT and TTS providers both have usable
+ * credentials/playability before a media-stream call proceeds.
+ *
+ * Returns `{ status: "ready" }` only when STT is telephony-eligible and
+ * credentialed AND TTS is playable (configured provider or a verified-ready
+ * default). Otherwise returns `{ status: "not-ready"; missing }` listing every
+ * provider gap, so callers can name each missing credential to the user.
+ */
+export async function resolveTelephonyCredentialReadiness(): Promise<TelephonyCredentialReadiness> {
+  const [sttCapability, ttsGap] = await Promise.all([
+    resolveTelephonySttCapability(),
+    resolveTtsGap(),
+  ]);
+
+  const missing: TelephonyCredentialGap[] = [];
+  const sttGap = sttCapabilityToGap(sttCapability);
+  if (sttGap) missing.push(sttGap);
+  if (ttsGap) missing.push(ttsGap);
+
+  if (missing.length > 0) {
+    return { status: "not-ready", missing };
+  }
+  return { status: "ready" };
+}
+
+/**
+ * Human-readable, single-line summary of the missing credentials for use in
+ * user-facing setup-pointer copy and spoken setup-required prompts.
+ *
+ * Example: `speech-to-text provider "openai-whisper" (missing-credentials),
+ * text-to-speech provider "elevenlabs" (missing-credentials)`.
+ */
+export function describeCredentialGaps(
+  missing: readonly TelephonyCredentialGap[],
+): string {
+  return missing
+    .map((gap) => {
+      const leg = gap.kind === "stt" ? "speech-to-text" : "text-to-speech";
+      const provider = gap.providerId
+        ? `"${gap.providerId}"`
+        : "(unconfigured)";
+      return `${leg} provider ${provider} (${gap.reason})`;
+    })
+    .join(", ");
+}

--- a/assistant/src/calls/telephony-credential-preflight.ts
+++ b/assistant/src/calls/telephony-credential-preflight.ts
@@ -56,7 +56,6 @@ import {
   type TelephonySttCapability,
 } from "../providers/speech-to-text/resolve.js";
 import { getLogger } from "../util/logger.js";
-import { resolveTelephonySttRouting } from "./telephony-stt-routing.js";
 import {
   DEFAULT_PLAYABLE_TTS_PROVIDER,
   resolveTelephonyTtsCapability,
@@ -172,34 +171,14 @@ async function resolveTtsGap(): Promise<TelephonyCredentialGap | null> {
 // ---------------------------------------------------------------------------
 // Transport gate
 // ---------------------------------------------------------------------------
-
-/**
- * Decide whether a call will actually use the daemon media-stream transport
- * (`<Connect><Stream>`) — the ONLY path that needs local STT + TTS credentials.
- *
- * This mirrors the branch {@link buildVoiceWebhookTwiml} takes: a call uses the
- * media-stream transport iff `resolveTelephonySttRouting()` resolves to the
- * `media-stream-custom` strategy. For `conversation-relay-native` STT providers
- * (deepgram / google) Twilio ConversationRelay runs STT + native TTS itself, so
- * no caller credentials are required and the outbound preflight must be skipped.
- * An unresolved/unknown routing result is treated as NOT-media-stream (skip the
- * preflight; the CR path handles itself), and — together with the safe-access
- * hardening in the resolvers — guarantees a partial/malformed config can never
- * crash call setup.
- *
- * CROSS-PR NOTE (PR 11): PR 11 flips routing so ALL calls use the media-stream
- * transport regardless of STT strategy. When that lands, this gate must become
- * always-on — return `true` unconditionally here (this single helper is the
- * intended seam, so the outbound call site in call-domain.ts needs no change).
- * Until then, gate on resolveTelephonySttRouting() === "media-stream-custom".
- */
-export function willUseMediaStreamTransport(): boolean {
-  const routing = resolveTelephonySttRouting();
-  return (
-    routing.status === "resolved" &&
-    routing.strategy.strategy === "media-stream-custom"
-  );
-}
+//
+// The outbound transport gate lives in `twilio-routes.ts` as
+// `outboundWillUseMediaStream(session)`, NOT here, because it must mirror the
+// FULL transport decision `buildVoiceWebhookTwiml` makes — both the STT routing
+// strategy AND the `routeSetup` outcome (interactive flows that CR-fall-back
+// must skip the preflight). Sharing the predicate with the TwiML builder keeps
+// the gate and the real transport branch from drifting. See that helper's
+// doc comment (and its PR 11 simplification note) for details.
 
 // ---------------------------------------------------------------------------
 // Public API

--- a/assistant/src/calls/telephony-credential-preflight.ts
+++ b/assistant/src/calls/telephony-credential-preflight.ts
@@ -56,6 +56,7 @@ import {
   type TelephonySttCapability,
 } from "../providers/speech-to-text/resolve.js";
 import { getLogger } from "../util/logger.js";
+import { resolveTelephonySttRouting } from "./telephony-stt-routing.js";
 import {
   DEFAULT_PLAYABLE_TTS_PROVIDER,
   resolveTelephonyTtsCapability,
@@ -166,6 +167,38 @@ async function resolveTtsGap(): Promise<TelephonyCredentialGap | null> {
         ? "missing-credentials"
         : "not-playable",
   };
+}
+
+// ---------------------------------------------------------------------------
+// Transport gate
+// ---------------------------------------------------------------------------
+
+/**
+ * Decide whether a call will actually use the daemon media-stream transport
+ * (`<Connect><Stream>`) — the ONLY path that needs local STT + TTS credentials.
+ *
+ * This mirrors the branch {@link buildVoiceWebhookTwiml} takes: a call uses the
+ * media-stream transport iff `resolveTelephonySttRouting()` resolves to the
+ * `media-stream-custom` strategy. For `conversation-relay-native` STT providers
+ * (deepgram / google) Twilio ConversationRelay runs STT + native TTS itself, so
+ * no caller credentials are required and the outbound preflight must be skipped.
+ * An unresolved/unknown routing result is treated as NOT-media-stream (skip the
+ * preflight; the CR path handles itself), and — together with the safe-access
+ * hardening in the resolvers — guarantees a partial/malformed config can never
+ * crash call setup.
+ *
+ * CROSS-PR NOTE (PR 11): PR 11 flips routing so ALL calls use the media-stream
+ * transport regardless of STT strategy. When that lands, this gate must become
+ * always-on — return `true` unconditionally here (this single helper is the
+ * intended seam, so the outbound call site in call-domain.ts needs no change).
+ * Until then, gate on resolveTelephonySttRouting() === "media-stream-custom".
+ */
+export function willUseMediaStreamTransport(): boolean {
+  const routing = resolveTelephonySttRouting();
+  return (
+    routing.status === "resolved" &&
+    routing.strategy.strategy === "media-stream-custom"
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/calls/telephony-stt-routing.ts
+++ b/assistant/src/calls/telephony-stt-routing.ts
@@ -95,8 +95,17 @@ export type TelephonySttRoutingResult =
  * `telephonyRouting` metadata.
  */
 export function resolveTelephonySttRouting(): TelephonySttRoutingResult {
-  const config = getConfig();
-  const providerId = config.services.stt.provider;
+  // Safe access: a partial/edge config (e.g. no `services` block) must resolve
+  // to "unknown-provider" rather than throwing — telephony routing/preflight
+  // must never crash call setup on a malformed config.
+  const providerId = getConfig().services?.stt?.provider;
+  if (!providerId) {
+    return {
+      status: "unknown-provider",
+      providerId: "",
+      reason: "No STT provider configured (services.stt.provider is unset)",
+    };
+  }
 
   // Validate the provider exists in the catalog.
   const entry = getProviderEntry(providerId as SttProviderId);

--- a/assistant/src/calls/telephony-tts-capability.ts
+++ b/assistant/src/calls/telephony-tts-capability.ts
@@ -27,6 +27,7 @@ import {
 } from "../security/secure-keys.js";
 import {
   getCatalogProvider,
+  getCatalogProviderOrNull,
   type MediaStreamPlaybackFormat,
 } from "../tts/provider-catalog.js";
 import {
@@ -62,18 +63,34 @@ export const DEFAULT_PLAYABLE_TTS_PROVIDER: TtsProviderId = "elevenlabs";
  *                              value is missing, so synthesis would throw
  *                              before producing audio (e.g. fish-audio's
  *                              `referenceId`).
+ * - `unconfigured`          — no `services.tts.provider` is configured (a
+ *                              partial/edge config, e.g. no `services.tts`
+ *                              block). The resolver returns this instead of
+ *                              throwing so the preflight can report a not-ready
+ *                              gap rather than crash.
+ * - `unknown-provider`      — the configured `services.tts.provider` is not in
+ *                              the TTS catalog. Returned (not thrown) for the
+ *                              same reason as `unconfigured`.
  */
 export type TelephonyTtsNotPlayableReason =
   | "unsupported-format"
   | "missing-credentials"
-  | "missing-required-config";
+  | "missing-required-config"
+  | "unconfigured"
+  | "unknown-provider";
 
-/** Result of {@link resolveTelephonyTtsCapability}. */
+/**
+ * Result of {@link resolveTelephonyTtsCapability}.
+ *
+ * `providerId` is `null` only when the configured provider is missing
+ * (`unconfigured`); for an `unknown-provider` it is the raw configured id so
+ * callers can name it.
+ */
 export type TelephonyTtsCapability =
   | { status: "playable"; providerId: TtsProviderId }
   | {
       status: "not-playable";
-      providerId: TtsProviderId;
+      providerId: TtsProviderId | null;
       reason: TelephonyTtsNotPlayableReason;
     };
 
@@ -191,7 +208,14 @@ export async function resolveProviderTelephonyCapability(
   providerId: TtsProviderId,
   providerConfig: Record<string, unknown>,
 ): Promise<TelephonyTtsCapability> {
-  const entry = getCatalogProvider(providerId);
+  // Non-throwing catalog lookup: an unknown/malformed `services.tts.provider`
+  // must resolve to a not-playable gap rather than throw, so the telephony
+  // preflight can fail-before-dial (outbound) or speak setup-required + end
+  // (inbound) instead of crashing or silently continuing into a silent call.
+  const entry = getCatalogProviderOrNull(providerId);
+  if (!entry) {
+    return { status: "not-playable", providerId, reason: "unknown-provider" };
+  }
 
   if (!isPlayableFormat(entry.mediaStreamPlayback.outputFormat)) {
     return { status: "not-playable", providerId, reason: "unsupported-format" };
@@ -228,6 +252,17 @@ export async function resolveProviderTelephonyCapability(
  */
 export async function resolveTelephonyTtsCapability(): Promise<TelephonyTtsCapability> {
   const config = loadConfig();
+
+  // Safe access: a partial/edge config (e.g. no `services.tts` block) must
+  // resolve to a not-playable "unconfigured" gap rather than throwing — call
+  // setup must never crash on a malformed config. This mirrors the STT leg
+  // (`resolveTelephonySttCapability`), which returns "unconfigured" for the
+  // same shape.
+  const configuredProvider = config.services?.tts?.provider;
+  if (!configuredProvider) {
+    return { status: "not-playable", providerId: null, reason: "unconfigured" };
+  }
+
   const resolved = resolveTtsConfig(config);
   return resolveProviderTelephonyCapability(
     resolved.provider,

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -54,10 +54,10 @@ import {
   releaseCallbackClaim,
   updateCallSession,
 } from "./call-store.js";
-import { routeSetup } from "./relay-setup-router.js";
+import { routeSetup, type SetupOutcome } from "./relay-setup-router.js";
 import { resolveCallHints } from "./stt-hints.js";
 import { resolveTelephonySttRouting } from "./telephony-stt-routing.js";
-import type { CallStatus } from "./types.js";
+import type { CallSession, CallStatus } from "./types.js";
 import { resolveVoiceQualityProfile } from "./voice-quality.js";
 
 const log = getLogger("twilio-routes");
@@ -381,6 +381,69 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
 }
 
 /**
+ * The set of {@link routeSetup} outcomes that the media-stream transport
+ * (`<Connect><Stream>`) can serve directly.
+ *
+ * The media-stream transport supports `normal_call` and `deny` (which speaks a
+ * message and tears down). Every OTHER outcome requires an interactive
+ * sub-flow (DTMF entry, name capture, guardian wait, verification, invite
+ * redemption) that media-stream cannot perform, so {@link buildVoiceWebhookTwiml}
+ * CR-falls-back for those. This predicate is the single source of truth for
+ * that branch, shared with the outbound preflight gate so the two can never
+ * drift.
+ */
+function setupOutcomeUsesMediaStream(outcome: SetupOutcome): boolean {
+  return outcome.action === "normal_call" || outcome.action === "deny";
+}
+
+/**
+ * Decide whether an OUTBOUND call will actually be served by the media-stream
+ * transport (`<Connect><Stream>`) — the ONLY path that needs local STT + TTS
+ * credentials — mirroring the FULL transport decision {@link buildVoiceWebhookTwiml}
+ * makes for the same call/session.
+ *
+ * Media-stream is used iff BOTH hold:
+ *   1. STT routing resolves to the `media-stream-custom` strategy
+ *      (CR-native providers — deepgram / google — let Twilio do STT + native
+ *      TTS, so no local credentials are needed); AND
+ *   2. the {@link routeSetup} outcome for this session is one the media-stream
+ *      transport serves directly ({@link setupOutcomeUsesMediaStream}). When
+ *      `calls.verification.enabled` (or any other interactive flow) makes
+ *      `routeSetup` return e.g. `callee_verification`, `buildVoiceWebhookTwiml`
+ *      CR-falls-back, so this call is served by CR and needs NO local creds.
+ *
+ * Returning `false` for the CR-fallback case is what lets the outbound preflight
+ * gate skip the credential check for interactive flows that don't use the
+ * media-stream transport. Any unresolved/unknown STT routing is treated as
+ * NOT-media-stream (skip the preflight; the CR path handles itself), so a
+ * partial/malformed config can never crash call setup.
+ *
+ * CROSS-PR NOTE (PR 11): PR 11 removes the CR-fallback entirely — ALL outcomes
+ * route to the media-stream transport. When that lands, condition (2) becomes
+ * vacuous and this helper collapses to "strategy === media-stream-custom" (and,
+ * once routing always selects media-stream-custom, to always-true). PR 11 must
+ * simplify both this helper and {@link buildVoiceWebhookTwiml}'s setup-outcome
+ * branch together so they stay in lockstep.
+ */
+export function outboundWillUseMediaStream(session: CallSession): boolean {
+  const routing = resolveTelephonySttRouting();
+  if (
+    routing.status !== "resolved" ||
+    routing.strategy.strategy !== "media-stream-custom"
+  ) {
+    return false;
+  }
+
+  const { outcome } = routeSetup({
+    callSessionId: session.id,
+    session,
+    from: session.fromNumber ?? "",
+    to: session.toNumber ?? "",
+  });
+  return setupOutcomeUsesMediaStream(outcome);
+}
+
+/**
  * Shared TwiML generation for both inbound and outbound voice webhooks.
  *
  * Resolves the telephony STT routing strategy from `services.stt.provider`
@@ -487,7 +550,9 @@ function buildVoiceWebhookTwiml(
   // a message and tears down). All other outcomes require interactive
   // sub-flows (DTMF entry, name capture, guardian wait) that media-stream
   // cannot perform. Reject these deterministically before stream bootstrap.
-  if (outcome.action !== "normal_call" && outcome.action !== "deny") {
+  // `setupOutcomeUsesMediaStream` is the shared predicate the outbound
+  // preflight gate (`outboundWillUseMediaStream`) reuses so the two cannot drift.
+  if (!setupOutcomeUsesMediaStream(outcome)) {
     log.warn(
       {
         callSessionId,

--- a/assistant/src/calls/types.ts
+++ b/assistant/src/calls/types.ts
@@ -47,7 +47,8 @@ export type CallEventType =
   | "voice_guardian_wait_callback_opt_in_declined"
   | "inbound_acl_post_approval_handoff_spoken"
   | "callback_handoff_notified"
-  | "callback_handoff_failed";
+  | "callback_handoff_failed"
+  | "telephony_credential_preflight_failed";
 export type PendingQuestionStatus =
   | "pending"
   | "answered"

--- a/assistant/src/providers/speech-to-text/resolve.ts
+++ b/assistant/src/providers/speech-to-text/resolve.ts
@@ -104,8 +104,16 @@ export type TelephonySttCapability =
  * - `"missing-credentials"` — the provider is eligible but has no API key.
  */
 export async function resolveTelephonySttCapability(): Promise<TelephonySttCapability> {
-  const config = getConfig();
-  const provider = config.services.stt.provider;
+  // Safe access: a partial/edge config (e.g. no `services` block) must resolve
+  // to "unconfigured" rather than throwing — call setup must never crash on a
+  // malformed config.
+  const provider = getConfig().services?.stt?.provider;
+  if (!provider) {
+    return {
+      status: "unconfigured",
+      reason: "No STT provider configured (services.stt.provider is unset)",
+    };
+  }
 
   const entry = getProviderEntry(provider as SttProviderId);
   if (!entry) {

--- a/assistant/src/tts/provider-catalog.ts
+++ b/assistant/src/tts/provider-catalog.ts
@@ -377,3 +377,18 @@ export function getCatalogProvider(id: TtsProviderId): TtsProviderCatalogEntry {
   }
   return entry;
 }
+
+/**
+ * Non-throwing variant of {@link getCatalogProvider}: returns the catalog entry
+ * for the given id, or `null` when the id is not in the catalog (e.g. a
+ * malformed/unknown `services.tts.provider`).
+ *
+ * Use this on paths that must degrade gracefully on a bad config rather than
+ * crash — notably the telephony credential preflight, which must turn an
+ * unknown provider into a not-ready gap instead of throwing.
+ */
+export function getCatalogProviderOrNull(
+  id: string,
+): TtsProviderCatalogEntry | null {
+  return catalogById.get(id as TtsProviderId) ?? null;
+}


### PR DESCRIPTION
## Summary
- resolveTelephonyCredentialReadiness() validates STT + TTS creds (reuses telephony-tts-capability)
- Outbound: fail before dialing + pointer message + telephony_credential_preflight_failed event
- Inbound: media-stream TwiML + spoken setup-required message + event + end call
- Fallback only to a verified-ready configured provider

Part of plan: migrate-phone-off-conversation-relay.md (PR 10 of 18)