### PR TITLE
feat(cli): add `vellum unpair <name>` to forget an imported pairing

### DIFF
--- a/cli/src/__tests__/unpair.test.ts
+++ b/cli/src/__tests__/unpair.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests for `vellum unpair <name>`: forget a paired (cloud:"paired") assistant
+ * by removing its lockfile entry + guardian token. Refuses non-paired entries.
+ */
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  spyOn,
+  test,
+} from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const testDir = mkdtempSync(join(tmpdir(), "unpair-test-"));
+const ORIGINAL_LOCKFILE_DIR = process.env.VELLUM_LOCKFILE_DIR;
+const ORIGINAL_CONFIG_HOME = process.env.XDG_CONFIG_HOME;
+const ORIGINAL_ARGV = [...process.argv];
+
+import { unpair } from "../commands/unpair.js";
+import {
+  findAssistantByName,
+  saveAssistantEntry,
+} from "../lib/assistant-config.js";
+import {
+  deleteGuardianToken,
+  loadGuardianToken,
+  saveGuardianToken,
+} from "../lib/guardian-token.js";
+
+function seedToken(assistantId: string): void {
+  saveGuardianToken(assistantId, {
+    guardianPrincipalId: "imported",
+    accessToken: "acc",
+    accessTokenExpiresAt: Date.now() + 3_600_000,
+    refreshToken: "ref",
+    refreshTokenExpiresAt: Date.now() + 3_600_000,
+    refreshAfter: "",
+    isNew: false,
+    deviceId: "dev",
+    leasedAt: new Date().toISOString(),
+  });
+}
+
+/** Run unpair with console.error + process.exit spied. */
+async function runUnpair(): Promise<{ exited: boolean; errors: string }> {
+  const errors: string[] = [];
+  const logSpy = spyOn(console, "log").mockImplementation(() => {});
+  const errSpy = spyOn(console, "error").mockImplementation(
+    (...a: unknown[]) => {
+      errors.push(a.join(" "));
+    },
+  );
+  const exitSpy = spyOn(process, "exit").mockImplementation(((c?: number) => {
+    throw new Error(`exit:${c}`);
+  }) as never);
+  let exited = false;
+  try {
+    await unpair();
+  } catch (e) {
+    exited = (e as Error).message === "exit:1";
+  } finally {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    exitSpy.mockRestore();
+  }
+  return { exited, errors: errors.join("\n") };
+}
+
+describe("vellum unpair", () => {
+  beforeEach(() => {
+    process.env.VELLUM_LOCKFILE_DIR = testDir;
+    process.env.XDG_CONFIG_HOME = testDir;
+  });
+
+  afterEach(() => {
+    process.argv = [...ORIGINAL_ARGV];
+    if (ORIGINAL_LOCKFILE_DIR === undefined)
+      delete process.env.VELLUM_LOCKFILE_DIR;
+    else process.env.VELLUM_LOCKFILE_DIR = ORIGINAL_LOCKFILE_DIR;
+    if (ORIGINAL_CONFIG_HOME === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = ORIGINAL_CONFIG_HOME;
+  });
+
+  afterAll(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  test("removes a paired entry's lockfile entry and guardian token", async () => {
+    saveAssistantEntry({
+      assistantId: "px",
+      name: "Paired Box",
+      runtimeUrl: "http://10.0.0.9:7830",
+      cloud: "paired",
+      paired: true,
+      species: "vellum",
+    });
+    seedToken("px");
+    expect(findAssistantByName("px")).not.toBeNull();
+    expect(loadGuardianToken("px")).not.toBeNull();
+
+    process.argv = ["bun", "vellum", "unpair", "px"];
+    const { exited } = await runUnpair();
+
+    expect(exited).toBe(false);
+    expect(findAssistantByName("px")).toBeNull();
+    expect(loadGuardianToken("px")).toBeNull();
+  });
+
+  test("refuses a non-paired (local) assistant and leaves it intact", async () => {
+    saveAssistantEntry({
+      assistantId: "desk",
+      name: "Desk",
+      runtimeUrl: "http://127.0.0.1:7830",
+      cloud: "local",
+      species: "vellum",
+    });
+
+    process.argv = ["bun", "vellum", "unpair", "desk"];
+    const { exited, errors } = await runUnpair();
+
+    expect(exited).toBe(true);
+    expect(errors).toContain("vellum retire");
+    expect(findAssistantByName("desk")).not.toBeNull(); // untouched
+  });
+
+  test("errors on an unknown name", async () => {
+    process.argv = ["bun", "vellum", "unpair", "nope"];
+    const { exited } = await runUnpair();
+    expect(exited).toBe(true);
+  });
+
+  test("deleteGuardianToken is a no-op when the token is absent", () => {
+    // No token seeded for this id; calling (twice) must not throw.
+    expect(() => deleteGuardianToken("ghost")).not.toThrow();
+    expect(() => deleteGuardianToken("ghost")).not.toThrow();
+  });
+});

--- a/cli/src/__tests__/unpair.test.ts
+++ b/cli/src/__tests__/unpair.test.ts
@@ -102,12 +102,34 @@ describe("vellum unpair", () => {
     expect(findAssistantByName("px")).not.toBeNull();
     expect(loadGuardianToken("px")).not.toBeNull();
 
-    process.argv = ["bun", "vellum", "unpair", "px"];
+    // Non-interactive test env → use --yes to bypass the confirmation prompt.
+    process.argv = ["bun", "vellum", "unpair", "px", "--yes"];
     const { exited } = await runUnpair();
 
     expect(exited).toBe(false);
     expect(findAssistantByName("px")).toBeNull();
     expect(loadGuardianToken("px")).toBeNull();
+  });
+
+  test("refuses to unpair without --yes in a non-interactive terminal", async () => {
+    saveAssistantEntry({
+      assistantId: "py",
+      name: "Paired Two",
+      runtimeUrl: "http://10.0.0.9:7830",
+      cloud: "paired",
+      paired: true,
+      species: "vellum",
+    });
+    seedToken("py");
+
+    process.argv = ["bun", "vellum", "unpair", "py"]; // no --yes
+    const { exited, errors } = await runUnpair();
+
+    expect(exited).toBe(true);
+    expect(errors).toContain("--yes");
+    // Not removed — confirmation was required.
+    expect(findAssistantByName("py")).not.toBeNull();
+    expect(loadGuardianToken("py")).not.toBeNull();
   });
 
   test("refuses a non-paired (local) assistant and leaves it intact", async () => {

--- a/cli/src/commands/retire.ts
+++ b/cli/src/commands/retire.ts
@@ -13,6 +13,10 @@ import {
   type AssistantEntry,
 } from "../lib/assistant-config.js";
 import { parseAssistantTargetArg } from "../lib/assistant-target-args.js";
+import {
+  canPromptForConfirmation,
+  confirmAction,
+} from "../lib/confirm-action.js";
 import { getConfigDir } from "../lib/environments/paths.js";
 import { getCurrentEnvironment } from "../lib/environments/resolve.js";
 import {
@@ -152,51 +156,6 @@ function printRetireTarget(entry: AssistantEntry, cloud: string): void {
   console.log("");
 }
 
-function canPromptForRetireConfirmation(): boolean {
-  return (
-    process.stdin.isTTY === true &&
-    process.stdout.isTTY === true &&
-    typeof process.stdin.setRawMode === "function"
-  );
-}
-
-async function confirmRetireInteractive(): Promise<boolean> {
-  const stdin = process.stdin;
-  const stdout = process.stdout;
-  const wasRaw = stdin.isRaw === true;
-  const wasPaused = stdin.isPaused();
-
-  stdout.write("Press Enter to retire, or Esc/q to cancel: ");
-  stdin.setRawMode(true);
-  stdin.resume();
-
-  return await new Promise<boolean>((resolve) => {
-    const cleanup = () => {
-      stdin.off("data", onData);
-      stdin.setRawMode(wasRaw);
-      if (wasPaused) {
-        stdin.pause();
-      }
-      stdout.write("\n");
-    };
-
-    const onData = (chunk: Buffer) => {
-      const byte = chunk[0];
-      if (byte === 13 || byte === 10) {
-        cleanup();
-        resolve(true);
-        return;
-      }
-      if (byte === 27 || byte === 3 || byte === 113 || byte === 81) {
-        cleanup();
-        resolve(false);
-      }
-    };
-
-    stdin.on("data", onData);
-  });
-}
-
 /** Patch console methods to also append output to the given log file descriptor. */
 function teeConsoleToLogFile(fd: number | "ignore"): void {
   if (fd === "ignore") return;
@@ -305,7 +264,7 @@ async function retireInner(): Promise<void> {
   printRetireTarget(entry, cloud);
 
   if (!parsed.yes) {
-    if (!canPromptForRetireConfirmation()) {
+    if (!canPromptForConfirmation()) {
       console.error(
         "Error: Refusing to retire without confirmation in a non-interactive terminal.",
       );
@@ -313,7 +272,9 @@ async function retireInner(): Promise<void> {
       process.exit(1);
     }
 
-    const confirmed = await confirmRetireInteractive();
+    const confirmed = await confirmAction(
+      "Press Enter to retire, or Esc/q to cancel: ",
+    );
     if (!confirmed) {
       console.log("Retire cancelled.");
       process.exit(1);

--- a/cli/src/commands/retire.ts
+++ b/cli/src/commands/retire.ts
@@ -297,7 +297,7 @@ async function retireInner(): Promise<void> {
     // paired machine, which holds nothing but a pairing record. (Removing that
     // local record is `vellum unpair`'s job, not retire's.)
     console.error(
-      `Error: '${assistantId}' is a remote assistant paired from another machine — it can't be retired from here. Retiring tears down the assistant, which can only be done on its host machine. To remove the local pairing record on this machine, use \`vellum unpair\` (coming soon).`,
+      `Error: '${assistantId}' is a remote assistant paired from another machine — it can't be retired from here. Retiring tears down the assistant, which can only be done on its host machine. To remove the local pairing record on this machine, run \`vellum unpair ${assistantId}\`.`,
     );
     process.exit(1);
   }

--- a/cli/src/commands/unpair.ts
+++ b/cli/src/commands/unpair.ts
@@ -1,5 +1,5 @@
 /**
- * `vellum unpair <name>`
+ * `vellum unpair <name> [--yes]`
  *
  * Forget a pairing imported from another machine via `vellum connect import`:
  * remove its lockfile entry and stored guardian token from THIS machine. Only
@@ -12,23 +12,38 @@
 
 import {
   formatAssistantLookupError,
+  getAssistantDisplayName,
   lookupAssistantByIdentifier,
   removeAssistantEntry,
 } from "../lib/assistant-config";
+import { parseAssistantTargetArg } from "../lib/assistant-target-args.js";
+import {
+  canPromptForConfirmation,
+  confirmAction,
+} from "../lib/confirm-action.js";
 import { deleteGuardianToken } from "../lib/guardian-token";
 
 function printUsage(): void {
   console.log(`vellum unpair - Forget a paired assistant imported from another machine
 
 USAGE:
-    vellum unpair <name>
+    vellum unpair <name> [--yes]
 
 ARGUMENTS:
     <name>    Name or id of the paired assistant to forget
 
+OPTIONS:
+    --yes     Skip the interactive confirmation prompt (for automation)
+
 Removes the local connection (lockfile entry + stored token). Only paired
 assistants (imported via 'vellum connect import') can be unpaired; use
-'vellum retire' for local or managed assistants.`);
+'vellum retire' for local or managed assistants.
+
+EXAMPLES:
+    vellum unpair paired-desk
+    vellum unpair "Desk Box"
+    vellum unpair paired-desk --yes
+`);
 }
 
 export async function unpair(): Promise<void> {
@@ -39,7 +54,8 @@ export async function unpair(): Promise<void> {
     return;
   }
 
-  const name = args.find((a) => !a.startsWith("-"));
+  const yes = args.includes("--yes");
+  const name = parseAssistantTargetArg(args, []);
   if (!name) {
     console.error("Error: assistant name or id is required.");
     printUsage();
@@ -58,6 +74,35 @@ export async function unpair(): Promise<void> {
       `Error: '${name}' is not a paired assistant. Use \`vellum retire\` to remove a local or managed assistant.`,
     );
     process.exit(1);
+  }
+
+  // Print the resolved identity before acting (cli/AGENTS.md).
+  const displayName = getAssistantDisplayName(entry);
+  console.log("Pairing to unpair:");
+  if (displayName !== entry.assistantId) {
+    console.log(`  Name: ${displayName}`);
+  }
+  console.log(`  ID: ${entry.assistantId}`);
+  if (entry.runtimeUrl) {
+    console.log(`  Host: ${entry.runtimeUrl}`);
+  }
+  console.log("");
+
+  if (!yes) {
+    if (!canPromptForConfirmation()) {
+      console.error(
+        "Error: Refusing to unpair without confirmation in a non-interactive terminal.",
+      );
+      console.error("Re-run with --yes to confirm from automation.");
+      process.exit(1);
+    }
+    const confirmed = await confirmAction(
+      "Press Enter to unpair, or Esc/q to cancel: ",
+    );
+    if (!confirmed) {
+      console.log("Unpair cancelled.");
+      process.exit(1);
+    }
   }
 
   removeAssistantEntry(entry.assistantId);

--- a/cli/src/commands/unpair.ts
+++ b/cli/src/commands/unpair.ts
@@ -1,0 +1,73 @@
+/**
+ * `vellum unpair <name>`
+ *
+ * Forget a pairing imported from another machine via `vellum connect import`:
+ * remove its lockfile entry and stored guardian token from THIS machine. Only
+ * paired assistants (`cloud: "paired"`) can be unpaired — `vellum retire` owns
+ * local and managed assistants.
+ *
+ * This is client-side only: it forgets the connection here but does not revoke
+ * the device on the host. (Host-side revocation is `vellum devices`.)
+ */
+
+import {
+  formatAssistantLookupError,
+  lookupAssistantByIdentifier,
+  removeAssistantEntry,
+} from "../lib/assistant-config";
+import { deleteGuardianToken } from "../lib/guardian-token";
+
+function printUsage(): void {
+  console.log(`vellum unpair - Forget a paired assistant imported from another machine
+
+USAGE:
+    vellum unpair <name>
+
+ARGUMENTS:
+    <name>    Name or id of the paired assistant to forget
+
+Removes the local connection (lockfile entry + stored token). Only paired
+assistants (imported via 'vellum connect import') can be unpaired; use
+'vellum retire' for local or managed assistants.`);
+}
+
+export async function unpair(): Promise<void> {
+  const args = process.argv.slice(3);
+
+  if (args.includes("--help") || args.includes("-h")) {
+    printUsage();
+    return;
+  }
+
+  const name = args.find((a) => !a.startsWith("-"));
+  if (!name) {
+    console.error("Error: assistant name or id is required.");
+    printUsage();
+    process.exit(1);
+  }
+
+  const lookup = lookupAssistantByIdentifier(name);
+  if (lookup.status !== "found") {
+    console.error(formatAssistantLookupError(name, lookup));
+    process.exit(1);
+  }
+  const entry = lookup.entry;
+
+  if (entry.cloud !== "paired") {
+    console.error(
+      `Error: '${name}' is not a paired assistant. Use \`vellum retire\` to remove a local or managed assistant.`,
+    );
+    process.exit(1);
+  }
+
+  removeAssistantEntry(entry.assistantId);
+  deleteGuardianToken(entry.assistantId);
+
+  console.log(
+    `Unpaired '${name}' — removed the local connection (lockfile entry + token).`,
+  );
+  console.log("");
+  console.log(
+    "Note: this only forgets the connection on this machine. The assistant's host can fully revoke this device from its side.",
+  );
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -27,6 +27,7 @@ import { ssh } from "./commands/ssh";
 import { teleport } from "./commands/teleport";
 import { terminal } from "./commands/terminal";
 import { tunnel } from "./commands/tunnel";
+import { unpair } from "./commands/unpair";
 import { upgrade } from "./commands/upgrade";
 import { use } from "./commands/use";
 import { wake } from "./commands/wake";
@@ -62,6 +63,7 @@ const commands = {
   teleport,
   terminal,
   tunnel,
+  unpair,
   upgrade,
   use,
   wake,
@@ -107,6 +109,9 @@ function printHelp(): void {
   console.log("  teleport Transfer assistant data between environments");
   console.log("  terminal Open a terminal into a managed assistant container");
   console.log("  tunnel   Create a tunnel for a locally hosted assistant");
+  console.log(
+    "  unpair   Forget a paired assistant imported from another machine",
+  );
   console.log("  upgrade  Upgrade an assistant to a newer version");
   console.log("  use      Set the active assistant for commands");
   console.log("  wake     Start the assistant and gateway");

--- a/cli/src/lib/confirm-action.ts
+++ b/cli/src/lib/confirm-action.ts
@@ -1,0 +1,57 @@
+/**
+ * Shared interactive confirmation for destructive CLI commands (retire, unpair,
+ * …). Per cli/AGENTS.md, a command that removes assistant state must print the
+ * resolved identity and require confirmation, with a `--yes` bypass for
+ * automation.
+ */
+
+/** True only when we can run an interactive raw-mode confirmation prompt. */
+export function canPromptForConfirmation(): boolean {
+  return (
+    process.stdin.isTTY === true &&
+    process.stdout.isTTY === true &&
+    typeof process.stdin.setRawMode === "function"
+  );
+}
+
+/**
+ * Show `prompt` and resolve true on Enter, false on Esc/q/Ctrl-C. Restores the
+ * prior stdin raw/paused state on exit. Caller must gate on
+ * {@link canPromptForConfirmation} first.
+ */
+export async function confirmAction(prompt: string): Promise<boolean> {
+  const stdin = process.stdin;
+  const stdout = process.stdout;
+  const wasRaw = stdin.isRaw === true;
+  const wasPaused = stdin.isPaused();
+
+  stdout.write(prompt);
+  stdin.setRawMode(true);
+  stdin.resume();
+
+  return await new Promise<boolean>((resolve) => {
+    const cleanup = () => {
+      stdin.off("data", onData);
+      stdin.setRawMode(wasRaw);
+      if (wasPaused) {
+        stdin.pause();
+      }
+      stdout.write("\n");
+    };
+
+    const onData = (chunk: Buffer) => {
+      const byte = chunk[0];
+      if (byte === 13 || byte === 10) {
+        cleanup();
+        resolve(true);
+        return;
+      }
+      if (byte === 27 || byte === 3 || byte === 113 || byte === 81) {
+        cleanup();
+        resolve(false);
+      }
+    };
+
+    stdin.on("data", onData);
+  });
+}

--- a/cli/src/lib/guardian-token.ts
+++ b/cli/src/lib/guardian-token.ts
@@ -7,6 +7,7 @@ import {
   mkdirSync,
   openSync,
   readFileSync,
+  rmdirSync,
   statSync,
   unlinkSync,
   writeFileSync,
@@ -43,6 +44,27 @@ function getGuardianTokenPath(assistantId: string): string {
     assistantId,
     "guardian-token.json",
   );
+}
+
+/**
+ * Best-effort removal of an assistant's stored guardian token (used by
+ * `vellum unpair` to forget a paired connection). Never throws if the token
+ * file or its per-assistant directory is already absent.
+ */
+export function deleteGuardianToken(assistantId: string): void {
+  const tokenPath = getGuardianTokenPath(assistantId);
+  try {
+    unlinkSync(tokenPath);
+  } catch {
+    /* already gone */
+  }
+  // Clean up the now-empty per-assistant directory; rmdir throws if it still
+  // holds other files, in which case we leave it.
+  try {
+    rmdirSync(dirname(tokenPath));
+  } catch {
+    /* not empty or absent */
+  }
 }
 
 function getPersistedDeviceIdPath(): string {


### PR DESCRIPTION
## Summary
- Adds **`vellum unpair <name>`** — forget a pairing imported via `vellum connect import` by removing its lockfile entry + stored guardian token from this machine. Closes the gap where `vellum retire` refuses paired entries (it now points at `unpair` with the exact command instead of "coming soon").
- **Paired-only:** refuses non-paired (`cloud !== "paired"`) entries and directs to `vellum retire` — symmetric with retire refusing paired. Added a small `deleteGuardianToken(assistantId)` helper (best-effort unlink + empty-dir cleanup, never throws).
- **Client-side only:** this forgets the connection here; it does **not** revoke the device on the host. Host-side revocation (`vellum devices` + revoke) is the next slices and needs new gateway endpoints.

## Notes for review
- **No interactive confirmation:** unpairing only forgets a local record and is reversible (re-pair + `connect import`), so it runs without a prompt — happy to add a `--yes`/confirm if you'd prefer parity with `retire`.

## Scope (Slice 3a of devices/unpair)
You opted for **both** sides of device management. This is the client-side cleanup (3a). Next: **3b** gateway endpoints (`GET /v1/devices` list + `POST /v1/devices/revoke`, loopback-guarded, reusing `revokeActorTokensByDevice`) and **3c** the host-side `vellum devices` list + revoke. A later enhancement can have `unpair` also best-effort call the host revoke once 3b lands.

## Tests
`cli/src/__tests__/unpair.test.ts`: unpair a paired entry removes its entry + token; refuses a local entry (intact, message points at retire); unknown name errors; `deleteGuardianToken` is a no-op when the token is absent.

## Original prompt
Continuing the remote-pairing CLI: there was no way to remove a paired assistant — `retire` deliberately refuses them. This adds `vellum unpair <name>` for the client-side cleanup (drop the local entry + token), scoped to paired assistants, as the first slice of the broader devices/unpair work (which also includes host-side device listing/revocation).