### PR TITLE
feat(gateway): add loopback-guarded GET /v1/devices + POST /v1/devices/revoke

### DIFF
--- a/gateway/src/__tests__/devices.test.ts
+++ b/gateway/src/__tests__/devices.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Tests for the loopback-guarded device endpoints: GET /v1/devices (list) and
+ * POST /v1/devices/revoke (revoke by hashedDeviceId), scoped to the local
+ * guardian principal.
+ */
+import { describe, test, expect, mock, beforeEach, afterEach } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { and, eq } from "drizzle-orm";
+
+import { initSigningKey } from "../auth/token-service.js";
+
+initSigningKey(Buffer.from("test-signing-key-at-least-32-bytes-long-xx"));
+
+// resolveLocalGuardianPrincipalId() queries the assistant DB; mock it to a
+// stable principal. Device records live in the (real) gateway DB below.
+const mockQuery = mock();
+mock.module("../db/assistant-db-proxy.js", () => ({
+  assistantDbQuery: mockQuery,
+  assistantDbRun: mock(),
+  assistantDbExec: mock(),
+}));
+
+const { initGatewayDb, resetGatewayDb, getGatewayDb } =
+  await import("../db/connection.js");
+const { actorTokenRecords, actorRefreshTokenRecords } =
+  await import("../db/schema.js");
+const { hashToken } = await import("../auth/guardian-bootstrap.js");
+const { handleListDevices, handleRevokeDevice } =
+  await import("../http/routes/devices.js");
+
+const LOOPBACK_IP = "127.0.0.1";
+const GUARDIAN_ID = "guardian-001";
+
+let testRoot: string;
+
+function seedActor(opts: {
+  device: string;
+  principal?: string;
+  status?: "active" | "revoked";
+  platform?: string;
+}): void {
+  const now = Date.now();
+  const principal = opts.principal ?? GUARDIAN_ID;
+  getGatewayDb()
+    .insert(actorTokenRecords)
+    .values({
+      id: randomUUID(),
+      tokenHash: hashToken(`acc-${principal}-${opts.device}`),
+      guardianPrincipalId: principal,
+      hashedDeviceId: hashToken(opts.device),
+      platform: opts.platform ?? "cli",
+      status: opts.status ?? "active",
+      issuedAt: now,
+      expiresAt: now + 86_400_000,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+function seedRefresh(opts: {
+  device: string;
+  lastUsedAt?: number | null;
+  status?: "active" | "revoked";
+}): void {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(actorRefreshTokenRecords)
+    .values({
+      id: randomUUID(),
+      tokenHash: hashToken(`ref-${opts.device}`),
+      familyId: randomUUID(),
+      guardianPrincipalId: GUARDIAN_ID,
+      hashedDeviceId: hashToken(opts.device),
+      platform: "cli",
+      status: opts.status ?? "active",
+      issuedAt: now,
+      absoluteExpiresAt: now + 365 * 86_400_000,
+      inactivityExpiresAt: now + 90 * 86_400_000,
+      lastUsedAt: opts.lastUsedAt ?? null,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+function listRequest(): Request {
+  return new Request("http://localhost:7830/v1/devices", {
+    method: "GET",
+    headers: { host: "localhost:7830" },
+  });
+}
+
+function revokeRequest(body?: Record<string, unknown>): Request {
+  return new Request("http://localhost:7830/v1/devices/revoke", {
+    method: "POST",
+    headers: { host: "localhost:7830", "content-type": "application/json" },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+function activeActorCount(device: string): number {
+  return getGatewayDb()
+    .select()
+    .from(actorTokenRecords)
+    .where(
+      and(
+        eq(actorTokenRecords.hashedDeviceId, hashToken(device)),
+        eq(actorTokenRecords.status, "active"),
+      ),
+    )
+    .all().length;
+}
+
+function activeRefreshCount(device: string): number {
+  return getGatewayDb()
+    .select()
+    .from(actorRefreshTokenRecords)
+    .where(
+      and(
+        eq(actorRefreshTokenRecords.hashedDeviceId, hashToken(device)),
+        eq(actorRefreshTokenRecords.status, "active"),
+      ),
+    )
+    .all().length;
+}
+
+beforeEach(async () => {
+  mockQuery.mockResolvedValue([{ principalId: GUARDIAN_ID }]);
+  testRoot = mkdtempSync(join(tmpdir(), "devices-test-"));
+  const securityDir = join(testRoot, "protected");
+  mkdirSync(securityDir, { recursive: true });
+  process.env.GATEWAY_SECURITY_DIR = securityDir;
+  await initGatewayDb();
+});
+
+afterEach(() => {
+  resetGatewayDb();
+  delete process.env.GATEWAY_SECURITY_DIR;
+  try {
+    rmSync(testRoot, { recursive: true, force: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+describe("GET /v1/devices", () => {
+  test("lists only the local principal's active devices", async () => {
+    seedActor({ device: "device-A" });
+    seedActor({ device: "device-B", platform: "webview" });
+    seedActor({ device: "device-C", principal: "other-guardian" });
+    seedActor({ device: "device-D", status: "revoked" });
+
+    const res = await handleListDevices(listRequest(), LOOPBACK_IP);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      devices: { hashedDeviceId: string; platform: string }[];
+    };
+
+    const ids = body.devices.map((d) => d.hashedDeviceId).sort();
+    expect(ids).toEqual([hashToken("device-A"), hashToken("device-B")].sort());
+    const a = body.devices.find(
+      (d) => d.hashedDeviceId === hashToken("device-A"),
+    );
+    expect(a?.platform).toBe("cli");
+  });
+
+  test("surfaces lastUsedAt from the refresh record (null when none)", async () => {
+    seedActor({ device: "device-A" });
+    seedActor({ device: "device-B" });
+    seedRefresh({ device: "device-A", lastUsedAt: 1_700_000_000_000 });
+
+    const res = await handleListDevices(listRequest(), LOOPBACK_IP);
+    const body = (await res.json()) as {
+      devices: { hashedDeviceId: string; lastUsedAt: number | null }[];
+    };
+    const a = body.devices.find(
+      (d) => d.hashedDeviceId === hashToken("device-A"),
+    );
+    const b = body.devices.find(
+      (d) => d.hashedDeviceId === hashToken("device-B"),
+    );
+    expect(a?.lastUsedAt).toBe(1_700_000_000_000);
+    expect(b?.lastUsedAt).toBeNull();
+  });
+
+  test("rejects a non-loopback caller (403)", async () => {
+    seedActor({ device: "device-A" });
+    const res = await handleListDevices(listRequest(), "8.8.8.8");
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("POST /v1/devices/revoke", () => {
+  test("revokes a device's actor + refresh tokens, leaving others active", async () => {
+    seedActor({ device: "device-A" });
+    seedRefresh({ device: "device-A" });
+    seedActor({ device: "device-B" });
+    seedRefresh({ device: "device-B" });
+
+    const res = await handleRevokeDevice(
+      revokeRequest({ hashedDeviceId: hashToken("device-A") }),
+      LOOPBACK_IP,
+    );
+    expect(res.status).toBe(200);
+    expect(
+      (await res.json()) as { revoked: boolean; hashedDeviceId: string },
+    ).toEqual({
+      revoked: true,
+      hashedDeviceId: hashToken("device-A"),
+    });
+
+    expect(activeActorCount("device-A")).toBe(0);
+    expect(activeRefreshCount("device-A")).toBe(0);
+    expect(activeActorCount("device-B")).toBe(1);
+    expect(activeRefreshCount("device-B")).toBe(1);
+  });
+
+  test("rejects a request without hashedDeviceId (400)", async () => {
+    const res = await handleRevokeDevice(revokeRequest({}), LOOPBACK_IP);
+    expect(res.status).toBe(400);
+  });
+
+  test("rejects a non-loopback caller (403)", async () => {
+    const res = await handleRevokeDevice(
+      revokeRequest({ hashedDeviceId: hashToken("device-A") }),
+      "8.8.8.8",
+    );
+    expect(res.status).toBe(403);
+  });
+});

--- a/gateway/src/__tests__/devices.test.ts
+++ b/gateway/src/__tests__/devices.test.ts
@@ -192,6 +192,19 @@ describe("GET /v1/devices", () => {
     const res = await handleListDevices(listRequest(), "8.8.8.8");
     expect(res.status).toBe(403);
   });
+
+  test("rejects a request carrying an Origin header (WebView vector, 403)", async () => {
+    // A real host CLI never sends an Origin; a present Origin means a
+    // browser/WebView (e.g. *.vellum.local) is calling and could read back
+    // device hashes via the gateway's WebView CORS allowance. Must be refused.
+    seedActor({ device: "device-A" });
+    const req = new Request("http://localhost:7830/v1/devices", {
+      method: "GET",
+      headers: { host: "localhost:7830", origin: "https://app.vellum.local" },
+    });
+    const res = await handleListDevices(req, LOOPBACK_IP);
+    expect(res.status).toBe(403);
+  });
 });
 
 describe("POST /v1/devices/revoke", () => {
@@ -230,5 +243,23 @@ describe("POST /v1/devices/revoke", () => {
       "8.8.8.8",
     );
     expect(res.status).toBe(403);
+  });
+
+  test("rejects a request carrying an Origin header (WebView vector, 403)", async () => {
+    seedActor({ device: "device-A" });
+    seedRefresh({ device: "device-A" });
+    const req = new Request("http://localhost:7830/v1/devices/revoke", {
+      method: "POST",
+      headers: {
+        host: "localhost:7830",
+        "content-type": "application/json",
+        origin: "https://app.vellum.local",
+      },
+      body: JSON.stringify({ hashedDeviceId: hashToken("device-A") }),
+    });
+    const res = await handleRevokeDevice(req, LOOPBACK_IP);
+    expect(res.status).toBe(403);
+    // Refused before touching state — device-A stays active.
+    expect(activeActorCount("device-A")).toBe(1);
   });
 });

--- a/gateway/src/__tests__/route-schema-guard.test.ts
+++ b/gateway/src/__tests__/route-schema-guard.test.ts
@@ -171,6 +171,9 @@ const EXCLUDED_FROM_SCHEMA = new Set([
   "catch-all",
   // Loopback-only pairing endpoint — not part of the public gateway API
   "/v1/pair",
+  // Loopback-only device management — not part of the public gateway API
+  "/v1/devices",
+  "/v1/devices/revoke",
   // A2A agent card discovery — read-only, unauthenticated per spec
   "/.well-known/agent-card.json",
   // Internal-only: reachable only via vembda's trusted gateway-query proxy

--- a/gateway/src/auth/guardian-bootstrap.ts
+++ b/gateway/src/auth/guardian-bootstrap.ts
@@ -415,7 +415,7 @@ export interface DeviceBoundTokenPair {
 /**
  * Revoke active actor tokens for a device binding.
  */
-function revokeActorTokensByDevice(
+export function revokeActorTokensByDevice(
   guardianPrincipalId: string,
   hashedDeviceId: string,
 ): void {
@@ -436,7 +436,7 @@ function revokeActorTokensByDevice(
 /**
  * Revoke active refresh tokens for a device binding.
  */
-function revokeRefreshTokensByDevice(
+export function revokeRefreshTokensByDevice(
   guardianPrincipalId: string,
   hashedDeviceId: string,
 ): void {

--- a/gateway/src/http/loopback-guard.ts
+++ b/gateway/src/http/loopback-guard.ts
@@ -53,16 +53,21 @@ export function isLoopbackHostHeader(host: string | null): boolean {
   return isLoopbackAddress(hostname);
 }
 
-function auditDeny(req: Request, peerIp: string, reason: string): void {
+function auditDeny(
+  req: Request,
+  peerIp: string,
+  auditTag: string,
+  reason: string,
+): void {
   log.warn(
     {
-      audit: "loopback-denied",
+      audit: `${auditTag}-denied`,
       peerIp,
       host: req.headers.get("host"),
       origin: req.headers.get("origin"),
       reason,
     },
-    `loopback_denied: ${reason}`,
+    `${auditTag}_denied: ${reason}`,
   );
 }
 
@@ -77,35 +82,59 @@ function auditDeny(req: Request, peerIp: string, reason: string): void {
 export function enforceLoopbackOnly(
   req: Request,
   clientIp: string,
+  auditTag = "loopback",
 ): Response | null {
   // The Velay bridge injects this header on every forwarded request; a Velay
   // client cannot strip it.
   if (req.headers.get(VELAY_FORWARDED_HEADER)) {
-    auditDeny(req, clientIp, "velay_bridged");
+    auditDeny(req, clientIp, auditTag, "velay_bridged");
     return errorResponse("FORBIDDEN", "endpoint is local-only", 403);
   }
 
   // The self-hosted nginx edge (e.g. the SPA over an ngrok tunnel) sets this
   // marker unconditionally; it cannot be spoofed or stripped by the client.
   if (requestArrivedViaEdgeProxy(req)) {
-    auditDeny(req, clientIp, "edge_proxy_forwarded");
+    auditDeny(req, clientIp, auditTag, "edge_proxy_forwarded");
     return errorResponse("FORBIDDEN", "endpoint is local-only", 403);
   }
 
   if (!clientIp || !isLoopbackAddress(clientIp)) {
-    auditDeny(req, clientIp, "non_loopback_peer");
+    auditDeny(req, clientIp, auditTag, "non_loopback_peer");
     return errorResponse("FORBIDDEN", "endpoint is local-only", 403);
   }
 
   if (!isLoopbackHostHeader(req.headers.get("host"))) {
-    auditDeny(req, clientIp, "non_loopback_host_header");
+    auditDeny(req, clientIp, auditTag, "non_loopback_host_header");
     return errorResponse("FORBIDDEN", "endpoint is local-only", 403);
   }
 
   if (req.headers.get("x-forwarded-for")) {
-    auditDeny(req, clientIp, "x_forwarded_for_present");
+    auditDeny(req, clientIp, auditTag, "x_forwarded_for_present");
     return errorResponse("FORBIDDEN", "endpoint is local-only", 403);
   }
 
+  return null;
+}
+
+/**
+ * Reject any request carrying an `Origin` header. Host-CLI loopback endpoints
+ * (device management, cli pairing) are only ever called by a terminal process,
+ * which never sends an Origin; a present Origin means a browser/WebView is
+ * driving the request. Because the gateway reflects CORS for matched
+ * `*.vellum.local` WebView origins, such JS could otherwise reach these
+ * loopback-only endpoints from inside the WebView sandbox (read device hashes,
+ * revoke devices, mint tokens). This closes that vector — mirroring the
+ * `/v1/pair` cli-interface guard. Returns a 403 `Response` if an Origin is
+ * present, or `null` if absent.
+ */
+export function rejectBrowserOrigin(
+  req: Request,
+  clientIp: string,
+  auditTag = "loopback",
+): Response | null {
+  if (req.headers.get("origin")) {
+    auditDeny(req, clientIp, auditTag, "browser_origin");
+    return errorResponse("FORBIDDEN", "endpoint is local-only", 403);
+  }
   return null;
 }

--- a/gateway/src/http/loopback-guard.ts
+++ b/gateway/src/http/loopback-guard.ts
@@ -1,0 +1,111 @@
+/**
+ * Shared loopback-only guard for local-machine HTTP endpoints (`/v1/pair`,
+ * `/v1/devices`, …). Centralizes the generic "this request must originate from
+ * the local machine" checks so every loopback endpoint enforces the SAME
+ * boundary and it can't drift between them.
+ *
+ * Callers run {@link enforceLoopbackOnly} first; any endpoint-specific gating
+ * (rate limiting, Origin/interface checks) happens afterward in the handler.
+ */
+
+import { getLogger } from "../logger.js";
+import { isLoopbackAddress } from "../util/is-loopback-address.js";
+import { VELAY_FORWARDED_HEADER } from "../velay/bridge-utils.js";
+import { requestArrivedViaEdgeProxy } from "./edge-forwarded-header.js";
+
+const log = getLogger("loopback-guard");
+
+/** JSON error response in the shared `{ error: { code, message } }` shape. */
+export function errorResponse(
+  code: string,
+  message: string,
+  status: number,
+): Response {
+  return Response.json({ error: { code, message } }, { status });
+}
+
+/** Extract the hostname from a `Host` header value (strips port; handles `[ipv6]`). */
+export function parseHostHeader(raw: string): string | null {
+  if (raw.length === 0) return null;
+  if (raw.startsWith("[")) {
+    const end = raw.indexOf("]");
+    if (end < 0) return null;
+    const after = raw.substring(end + 1);
+    if (after.length > 0 && !after.startsWith(":")) return null;
+    return raw.substring(1, end);
+  }
+  const firstColon = raw.indexOf(":");
+  if (firstColon < 0) return raw;
+  const secondColon = raw.indexOf(":", firstColon + 1);
+  if (secondColon >= 0) {
+    return raw;
+  }
+  return raw.substring(0, firstColon);
+}
+
+/** True if the `Host` header is absent or names a loopback address/localhost. */
+export function isLoopbackHostHeader(host: string | null): boolean {
+  if (!host) return true;
+  const parsed = parseHostHeader(host);
+  if (parsed === null) return false;
+  const hostname = parsed.toLowerCase();
+  if (hostname === "localhost") return true;
+  return isLoopbackAddress(hostname);
+}
+
+function auditDeny(req: Request, peerIp: string, reason: string): void {
+  log.warn(
+    {
+      audit: "loopback-denied",
+      peerIp,
+      host: req.headers.get("host"),
+      origin: req.headers.get("origin"),
+      reason,
+    },
+    `loopback_denied: ${reason}`,
+  );
+}
+
+/**
+ * Enforce that a request originates from the local machine. Returns a 403
+ * `Response` if any check fails, or `null` if the request is loopback-local.
+ *
+ * Rejects, in order: Velay-bridged requests, requests forwarded by the
+ * self-hosted nginx edge, non-loopback peer IPs, non-loopback `Host` headers,
+ * and any request carrying `X-Forwarded-For`.
+ */
+export function enforceLoopbackOnly(
+  req: Request,
+  clientIp: string,
+): Response | null {
+  // The Velay bridge injects this header on every forwarded request; a Velay
+  // client cannot strip it.
+  if (req.headers.get(VELAY_FORWARDED_HEADER)) {
+    auditDeny(req, clientIp, "velay_bridged");
+    return errorResponse("FORBIDDEN", "endpoint is local-only", 403);
+  }
+
+  // The self-hosted nginx edge (e.g. the SPA over an ngrok tunnel) sets this
+  // marker unconditionally; it cannot be spoofed or stripped by the client.
+  if (requestArrivedViaEdgeProxy(req)) {
+    auditDeny(req, clientIp, "edge_proxy_forwarded");
+    return errorResponse("FORBIDDEN", "endpoint is local-only", 403);
+  }
+
+  if (!clientIp || !isLoopbackAddress(clientIp)) {
+    auditDeny(req, clientIp, "non_loopback_peer");
+    return errorResponse("FORBIDDEN", "endpoint is local-only", 403);
+  }
+
+  if (!isLoopbackHostHeader(req.headers.get("host"))) {
+    auditDeny(req, clientIp, "non_loopback_host_header");
+    return errorResponse("FORBIDDEN", "endpoint is local-only", 403);
+  }
+
+  if (req.headers.get("x-forwarded-for")) {
+    auditDeny(req, clientIp, "x_forwarded_for_present");
+    return errorResponse("FORBIDDEN", "endpoint is local-only", 403);
+  }
+
+  return null;
+}

--- a/gateway/src/http/routes/devices.ts
+++ b/gateway/src/http/routes/devices.ts
@@ -1,0 +1,124 @@
+/**
+ * Loopback-guarded device management for the local assistant.
+ *
+ *   GET  /v1/devices         — list devices paired to this assistant
+ *   POST /v1/devices/revoke  — revoke a device's tokens (by hashedDeviceId)
+ *
+ * These are the host side of pairing lifecycle (the machine running the
+ * assistant manages the devices paired to it). The gateway only ever stores the
+ * HASHED device id, so list returns `hashedDeviceId` and revoke accepts the same
+ * value — the raw deviceId is never persisted. Both endpoints scope strictly to
+ * the local assistant's guardian principal.
+ */
+
+import { and, eq } from "drizzle-orm";
+
+import {
+  revokeActorTokensByDevice,
+  revokeRefreshTokensByDevice,
+} from "../../auth/guardian-bootstrap.js";
+import { getGatewayDb } from "../../db/connection.js";
+import {
+  actorRefreshTokenRecords,
+  actorTokenRecords,
+} from "../../db/schema.js";
+import { enforceLoopbackOnly, errorResponse } from "../loopback-guard.js";
+import { resolveLocalGuardianPrincipalId } from "./pair.js";
+
+export async function handleListDevices(
+  req: Request,
+  clientIp: string,
+): Promise<Response> {
+  if (req.method !== "GET") {
+    return new Response("method not allowed", {
+      status: 405,
+      headers: { Allow: "GET" },
+    });
+  }
+
+  const guardError = enforceLoopbackOnly(req, clientIp);
+  if (guardError) return guardError;
+
+  const guardianPrincipalId = await resolveLocalGuardianPrincipalId();
+  const db = getGatewayDb();
+
+  // One active actor token per (principal, device) via the unique index, so
+  // this already enumerates distinct devices.
+  const tokens = db
+    .select({
+      hashedDeviceId: actorTokenRecords.hashedDeviceId,
+      platform: actorTokenRecords.platform,
+      issuedAt: actorTokenRecords.issuedAt,
+      expiresAt: actorTokenRecords.expiresAt,
+    })
+    .from(actorTokenRecords)
+    .where(
+      and(
+        eq(actorTokenRecords.guardianPrincipalId, guardianPrincipalId),
+        eq(actorTokenRecords.status, "active"),
+      ),
+    )
+    .all();
+
+  // lastUsedAt lives on the refresh record; map by device for enrichment.
+  const refresh = db
+    .select({
+      hashedDeviceId: actorRefreshTokenRecords.hashedDeviceId,
+      lastUsedAt: actorRefreshTokenRecords.lastUsedAt,
+    })
+    .from(actorRefreshTokenRecords)
+    .where(
+      and(
+        eq(actorRefreshTokenRecords.guardianPrincipalId, guardianPrincipalId),
+        eq(actorRefreshTokenRecords.status, "active"),
+      ),
+    )
+    .all();
+  const lastUsedByDevice = new Map(
+    refresh.map((r) => [r.hashedDeviceId, r.lastUsedAt ?? null]),
+  );
+
+  const devices = tokens.map((t) => ({
+    hashedDeviceId: t.hashedDeviceId,
+    platform: t.platform,
+    issuedAt: t.issuedAt,
+    expiresAt: t.expiresAt ?? null,
+    lastUsedAt: lastUsedByDevice.get(t.hashedDeviceId) ?? null,
+  }));
+
+  return Response.json({ devices });
+}
+
+export async function handleRevokeDevice(
+  req: Request,
+  clientIp: string,
+): Promise<Response> {
+  if (req.method !== "POST") {
+    return new Response("method not allowed", {
+      status: 405,
+      headers: { Allow: "POST" },
+    });
+  }
+
+  const guardError = enforceLoopbackOnly(req, clientIp);
+  if (guardError) return guardError;
+
+  let body: { hashedDeviceId?: unknown };
+  try {
+    body = (await req.json()) as { hashedDeviceId?: unknown };
+  } catch {
+    body = {};
+  }
+  const hashedDeviceId =
+    typeof body.hashedDeviceId === "string" ? body.hashedDeviceId.trim() : "";
+  if (!hashedDeviceId) {
+    return errorResponse("BAD_REQUEST", "hashedDeviceId is required", 400);
+  }
+
+  // Idempotent: revoking an unknown/already-revoked device is a no-op success.
+  const guardianPrincipalId = await resolveLocalGuardianPrincipalId();
+  revokeActorTokensByDevice(guardianPrincipalId, hashedDeviceId);
+  revokeRefreshTokensByDevice(guardianPrincipalId, hashedDeviceId);
+
+  return Response.json({ revoked: true, hashedDeviceId });
+}

--- a/gateway/src/http/routes/devices.ts
+++ b/gateway/src/http/routes/devices.ts
@@ -22,7 +22,11 @@ import {
   actorRefreshTokenRecords,
   actorTokenRecords,
 } from "../../db/schema.js";
-import { enforceLoopbackOnly, errorResponse } from "../loopback-guard.js";
+import {
+  enforceLoopbackOnly,
+  errorResponse,
+  rejectBrowserOrigin,
+} from "../loopback-guard.js";
 import { resolveLocalGuardianPrincipalId } from "./pair.js";
 
 export async function handleListDevices(
@@ -36,8 +40,10 @@ export async function handleListDevices(
     });
   }
 
-  const guardError = enforceLoopbackOnly(req, clientIp);
+  const guardError = enforceLoopbackOnly(req, clientIp, "devices");
   if (guardError) return guardError;
+  const originError = rejectBrowserOrigin(req, clientIp, "devices");
+  if (originError) return originError;
 
   const guardianPrincipalId = await resolveLocalGuardianPrincipalId();
   const db = getGatewayDb();
@@ -100,8 +106,10 @@ export async function handleRevokeDevice(
     });
   }
 
-  const guardError = enforceLoopbackOnly(req, clientIp);
+  const guardError = enforceLoopbackOnly(req, clientIp, "devices");
   if (guardError) return guardError;
+  const originError = rejectBrowserOrigin(req, clientIp, "devices");
+  if (originError) return originError;
 
   let body: { hashedDeviceId?: unknown };
   try {

--- a/gateway/src/http/routes/pair.ts
+++ b/gateway/src/http/routes/pair.ts
@@ -33,9 +33,7 @@ import { mintToken } from "../../auth/token-service.js";
 import { KNOWN_EXTENSION_ORIGINS } from "../../chrome-extension-origins.js";
 import { assistantDbQuery } from "../../db/assistant-db-proxy.js";
 import { getLogger } from "../../logger.js";
-import { isLoopbackAddress } from "../../util/is-loopback-address.js";
-import { VELAY_FORWARDED_HEADER } from "../../velay/bridge-utils.js";
-import { requestArrivedViaEdgeProxy } from "../edge-forwarded-header.js";
+import { enforceLoopbackOnly, errorResponse } from "../loopback-guard.js";
 
 const log = getLogger("pair");
 
@@ -101,37 +99,6 @@ export function resetPairRateLimiterForTests(): void {
 }
 
 // ---------------------------------------------------------------------------
-// Host header parsing
-// ---------------------------------------------------------------------------
-
-export function parseHostHeader(raw: string): string | null {
-  if (raw.length === 0) return null;
-  if (raw.startsWith("[")) {
-    const end = raw.indexOf("]");
-    if (end < 0) return null;
-    const after = raw.substring(end + 1);
-    if (after.length > 0 && !after.startsWith(":")) return null;
-    return raw.substring(1, end);
-  }
-  const firstColon = raw.indexOf(":");
-  if (firstColon < 0) return raw;
-  const secondColon = raw.indexOf(":", firstColon + 1);
-  if (secondColon >= 0) {
-    return raw;
-  }
-  return raw.substring(0, firstColon);
-}
-
-function isLoopbackHostHeader(host: string | null): boolean {
-  if (!host) return true;
-  const parsed = parseHostHeader(host);
-  if (parsed === null) return false;
-  const hostname = parsed.toLowerCase();
-  if (hostname === "localhost") return true;
-  return isLoopbackAddress(hostname);
-}
-
-// ---------------------------------------------------------------------------
 // Guardian resolution
 // ---------------------------------------------------------------------------
 
@@ -139,7 +106,7 @@ interface GuardianPrincipalRow {
   principalId: string | null;
 }
 
-async function resolveLocalGuardianPrincipalId(): Promise<string> {
+export async function resolveLocalGuardianPrincipalId(): Promise<string> {
   try {
     const rows = await assistantDbQuery<GuardianPrincipalRow>(
       `SELECT c.principal_id AS principalId
@@ -190,14 +157,6 @@ function auditDeny(
 // Handler
 // ---------------------------------------------------------------------------
 
-function errorResponse(
-  code: string,
-  message: string,
-  status: number,
-): Response {
-  return Response.json({ error: { code, message } }, { status });
-}
-
 function getExternalAssistantId(): string {
   return (
     process.env.VELLUM_ASSISTANT_NAME?.trim() || DAEMON_INTERNAL_ASSISTANT_ID
@@ -215,38 +174,10 @@ export async function handlePair(
     });
   }
 
-  // Defense-in-depth: reject Velay-bridged requests. The bridge injects this
-  // header on every forwarded request; it cannot be stripped by a Velay client.
-  if (req.headers.get(VELAY_FORWARDED_HEADER)) {
-    auditDeny(req, clientIp, "velay_bridged");
-    return errorResponse("FORBIDDEN", "endpoint is local-only", 403);
-  }
-
-  // Defense-in-depth: reject requests forwarded by the self-hosted nginx edge
-  // (e.g. the SPA reached over an ngrok tunnel). The edge sets this marker
-  // unconditionally and it cannot be spoofed or stripped by the client — see
-  // edge-forwarded-header.ts. The X-Forwarded-For check below also catches the
-  // edge today, but this marker is the explicit, unspoofable signal.
-  if (requestArrivedViaEdgeProxy(req)) {
-    auditDeny(req, clientIp, "edge_proxy_forwarded");
-    return errorResponse("FORBIDDEN", "endpoint is local-only", 403);
-  }
-
-  if (!clientIp || !isLoopbackAddress(clientIp)) {
-    auditDeny(req, clientIp, "non_loopback_peer");
-    return errorResponse("FORBIDDEN", "endpoint is local-only", 403);
-  }
-
-  const host = req.headers.get("host");
-  if (!isLoopbackHostHeader(host)) {
-    auditDeny(req, clientIp, "non_loopback_host_header");
-    return errorResponse("FORBIDDEN", "endpoint is local-only", 403);
-  }
-
-  if (req.headers.get("x-forwarded-for")) {
-    auditDeny(req, clientIp, "x_forwarded_for_present");
-    return errorResponse("FORBIDDEN", "endpoint is local-only", 403);
-  }
+  // Loopback-only boundary (Velay/edge markers, peer IP, Host header,
+  // X-Forwarded-For) — shared with the other local-machine endpoints.
+  const guardError = enforceLoopbackOnly(req, clientIp);
+  if (guardError) return guardError;
 
   const rateResult = checkRateLimit(clientIp);
   if (!rateResult.allowed) {

--- a/gateway/src/http/routes/pair.ts
+++ b/gateway/src/http/routes/pair.ts
@@ -176,7 +176,7 @@ export async function handlePair(
 
   // Loopback-only boundary (Velay/edge markers, peer IP, Host header,
   // X-Forwarded-For) — shared with the other local-machine endpoints.
-  const guardError = enforceLoopbackOnly(req, clientIp);
+  const guardError = enforceLoopbackOnly(req, clientIp, "pair");
   if (guardError) return guardError;
 
   const rateResult = checkRateLimit(clientIp);

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -89,6 +89,10 @@ import { createTwilioControlPlaneProxyHandler } from "./http/routes/twilio-contr
 import { createVercelControlPlaneProxyHandler } from "./http/routes/vercel-control-plane-proxy.js";
 import { createContactsControlPlaneProxyHandler } from "./http/routes/contacts-control-plane-proxy.js";
 import { handleContactPromptSubmit } from "./http/routes/contact-prompt.js";
+import {
+  handleListDevices,
+  handleRevokeDevice,
+} from "./http/routes/devices.js";
 import { handlePair } from "./http/routes/pair.js";
 import { createSlackControlPlaneProxyHandler } from "./http/routes/slack-control-plane-proxy.js";
 import { createOAuthAppsProxyHandler } from "./http/routes/oauth-apps-proxy.js";
@@ -823,6 +827,21 @@ async function main() {
       method: "POST",
       auth: "none",
       handler: (req, _params, getClientIp) => handlePair(req, getClientIp()),
+    },
+    // ── Device management (localhost-only, auth: none; self-guards loopback) ──
+    {
+      path: "/v1/devices",
+      method: "GET",
+      auth: "none",
+      handler: (req, _params, getClientIp) =>
+        handleListDevices(req, getClientIp()),
+    },
+    {
+      path: "/v1/devices/revoke",
+      method: "POST",
+      auth: "none",
+      handler: (req, _params, getClientIp) =>
+        handleRevokeDevice(req, getClientIp()),
     },
 
     // ── Channel verification sessions ──


### PR DESCRIPTION
## Summary
- Adds two **loopback-guarded** gateway endpoints for the host side of pairing lifecycle: **`GET /v1/devices`** (list devices paired to the local assistant — `hashedDeviceId`, `platform`, `issuedAt`, `expiresAt`, `lastUsedAt`) and **`POST /v1/devices/revoke`** (revoke a device's actor + refresh tokens by `hashedDeviceId`). Both scope strictly to the local guardian principal and reuse the existing device-scoped revocation (`revokeActorTokensByDevice`/`revokeRefreshTokensByDevice`).
- **Extracted the loopback guard** pair used inline into a shared `gateway/src/http/loopback-guard.ts` (`enforceLoopbackOnly` + `isLoopbackHostHeader`/`parseHostHeader`/`errorResponse`), adopted by **both** pair and the new device endpoints so the local-only boundary can't drift between them. `pair.ts` behavior is unchanged (its rate-limit + Origin/interface gating still run after the shared guard) — verified by its existing tests.
- The gateway only ever stores the **hashed** device id, so list returns it and revoke accepts it (round-trips the hash; the raw deviceId is never persisted).

## Scope (Slice 3b of devices/unpair)
3a (`vellum unpair`, client-side) shipped (#33521). This is the gateway foundation; **3c** wires the host-side CLI (`vellum devices` list + revoke) on top of these endpoints.

## Tests
`gateway/src/__tests__/devices.test.ts`: list returns only the local principal's active devices (excludes other-principal + revoked); `lastUsedAt` surfaced from the refresh record (null when none); revoke flips a device's actor + refresh rows to revoked while leaving others active; 400 without `hashedDeviceId`; 403 for non-loopback callers on both. Plus the existing `pair-device-bound` suite still passes after the shared-guard refactor.

## Original prompt
You chose to build both sides of device management. After 3a (client-side `vellum unpair`), this adds the gateway endpoints the host needs to list and revoke devices paired to its assistant — loopback-guarded like `/v1/pair`, reusing the device-scoped revocation, with the shared loopback guard factored out so pair and devices enforce the identical boundary. The host CLI is the next slice.