### PR TITLE
fix(macos): run platform OAuth sign-in in the main window

### DIFF
--- a/apps/macos/src/main/auth-nav.test.ts
+++ b/apps/macos/src/main/auth-nav.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+
+import { advanceAuthFlow, decideNavigation } from "./auth-nav";
+
+const APP = { protocol: "http:", host: "localhost:3000" } as const;
+
+describe("decideNavigation", () => {
+  test("allows same-origin navigation", () => {
+    expect(
+      decideNavigation("http://localhost:3000/account/login", APP, false),
+    ).toEqual({ kind: "allow" });
+  });
+
+  test("ejects cross-origin http(s) to the system browser when not signing in", () => {
+    expect(
+      decideNavigation("https://accounts.google.com/signin", APP, false),
+    ).toEqual({ kind: "external", url: "https://accounts.google.com/signin" });
+  });
+
+  test("allows cross-origin http(s) in-window during a sign-in", () => {
+    expect(
+      decideNavigation("https://accounts.google.com/signin", APP, true),
+    ).toEqual({ kind: "allow" });
+    expect(
+      decideNavigation("https://auth.dev-platform.vellum.ai/x", APP, true),
+    ).toEqual({ kind: "allow" });
+  });
+
+  test("blocks non-http schemes regardless of sign-in state", () => {
+    expect(decideNavigation("mailto:hi@vellum.ai", APP, false)).toEqual({
+      kind: "block",
+    });
+    expect(decideNavigation("file:///etc/passwd", APP, true)).toEqual({
+      kind: "block",
+    });
+  });
+
+  test("blocks unparseable URLs", () => {
+    expect(decideNavigation("::::", APP, true)).toEqual({ kind: "block" });
+  });
+
+  test("always allows the app origin even mid-sign-in (the callback)", () => {
+    expect(
+      decideNavigation(
+        "http://localhost:3000/account/provider/callback",
+        APP,
+        true,
+      ),
+    ).toEqual({ kind: "allow" });
+  });
+});
+
+describe("advanceAuthFlow", () => {
+  test("marks sawExternal when navigating to a provider domain", () => {
+    expect(
+      advanceAuthFlow("https://accounts.google.com/o/oauth2", APP, false),
+    ).toEqual({ end: false, sawExternal: true });
+  });
+
+  test("does NOT end on the initial same-origin POST (before any provider visit)", () => {
+    // The flow kicks off with a same-origin POST to /accounts/oidc/redirect/;
+    // returning false here keeps the guard relaxed for the provider hops.
+    expect(
+      advanceAuthFlow("http://localhost:3000/accounts/oidc/redirect/", APP, false),
+    ).toEqual({ end: false, sawExternal: false });
+  });
+
+  test("ends once back on the app origin after a provider visit", () => {
+    expect(
+      advanceAuthFlow(
+        "http://localhost:3000/account/provider/callback",
+        APP,
+        true,
+      ),
+    ).toEqual({ end: true, sawExternal: true });
+  });
+
+  test("leaves state unchanged on an unparseable URL", () => {
+    expect(advanceAuthFlow("::::", APP, true)).toEqual({
+      end: false,
+      sawExternal: true,
+    });
+  });
+});

--- a/apps/macos/src/main/auth-nav.ts
+++ b/apps/macos/src/main/auth-nav.ts
@@ -1,0 +1,61 @@
+import { type AllowedOrigin, isAllowedOrigin } from "./app-origin";
+
+/**
+ * Navigation-guard decision logic for the main window, extracted so it can be
+ * unit-tested without booting the app.
+ *
+ * Normally the main window may only navigate within the app's own origin;
+ * cross-origin top-level navigations are ejected to the system browser. During
+ * a sign-in, though, the window must follow the OAuth provider chain
+ * (WorkOS → Google/Apple → back to our callback) as in-window navigations — so
+ * while `authFlowActive` is set, cross-origin http(s) hops are allowed.
+ */
+export type NavigationDecision =
+  | { kind: "allow" } // proceed in-window
+  | { kind: "external"; url: string } // eject to the system browser
+  | { kind: "block" }; // preventDefault, no fallback
+
+export const decideNavigation = (
+  url: string,
+  allowed: AllowedOrigin,
+  authFlowActive: boolean,
+): NavigationDecision => {
+  let target: URL;
+  try {
+    target = new URL(url);
+  } catch {
+    return { kind: "block" };
+  }
+  if (isAllowedOrigin(target, allowed)) return { kind: "allow" };
+
+  const isHttp = target.protocol === "https:" || target.protocol === "http:";
+  if (authFlowActive && isHttp) return { kind: "allow" };
+  if (isHttp) return { kind: "external", url };
+  return { kind: "block" };
+};
+
+/**
+ * On a committed top-level navigation (`did-navigate`), decide whether an
+ * in-progress sign-in has completed and the relaxed guard should re-arm.
+ *
+ * The guard re-arms only once the flow has actually left to a provider domain
+ * (`sawExternal`) and then returned to the app origin (the OAuth callback) —
+ * never on the initial same-origin POST that kicks the flow off. Returns the
+ * updated `sawExternal` so the caller can thread the per-flow state.
+ */
+export const advanceAuthFlow = (
+  url: string,
+  allowed: AllowedOrigin,
+  sawExternal: boolean,
+): { end: boolean; sawExternal: boolean } => {
+  let target: URL;
+  try {
+    target = new URL(url);
+  } catch {
+    return { end: false, sawExternal };
+  }
+  if (!isAllowedOrigin(target, allowed)) {
+    return { end: false, sawExternal: true };
+  }
+  return { end: sawExternal, sawExternal };
+};

--- a/apps/macos/src/main/main-window.ts
+++ b/apps/macos/src/main/main-window.ts
@@ -1,9 +1,10 @@
-import { BrowserWindow, app, shell } from "electron";
+import { BrowserWindow, type WebContents, app, shell } from "electron";
 import path from "node:path";
 import { z } from "zod";
 
 import { getRendererRootUrl } from "./app-config";
-import { isAllowedOrigin, resolveAllowedOrigin } from "./app-origin";
+import { resolveAllowedOrigin } from "./app-origin";
+import { advanceAuthFlow, decideNavigation } from "./auth-nav";
 import { type VellumCommand } from "./commands";
 import { handle } from "./ipc";
 import {
@@ -114,6 +115,47 @@ const armReadyState = (win: BrowserWindow): ReadyState => {
 // wait for, so callers can compose `await` uniformly.
 const ALREADY_READY: Promise<void> = Promise.resolve();
 
+// ── Sign-in navigation relaxation ───────────────────────────────────────────
+// Platform sign-in runs the OAuth provider chain (WorkOS → Google/Apple → our
+// callback) as top-level navigations in the main window. Those are cross-origin,
+// so the same-origin guard below would normally eject them to the system
+// browser mid-handshake. `beginAuthFlow` (renderer IPC, fired on "Continue
+// with …") relaxes the guard for the duration of the flow; it re-arms once the
+// flow returns to the app origin after visiting a provider (see `did-navigate`
+// below) or after a timeout backstop, so the relaxation can't linger.
+const AUTH_FLOW_TIMEOUT_MS = 5 * 60_000;
+const authFlowActive = new WeakSet<WebContents>();
+const authFlowSawExternal = new WeakSet<WebContents>();
+const authFlowTimers = new WeakMap<WebContents, ReturnType<typeof setTimeout>>();
+
+const endAuthFlow = (wc: WebContents): void => {
+  authFlowActive.delete(wc);
+  authFlowSawExternal.delete(wc);
+  const timer = authFlowTimers.get(wc);
+  if (timer) {
+    clearTimeout(timer);
+    authFlowTimers.delete(wc);
+  }
+};
+
+/**
+ * Relax the main window's navigation guard for an in-flight sign-in. Idempotent
+ * (resets the timeout). Re-armed by the `did-navigate` handler or the timeout.
+ */
+export const beginAuthFlow = (): void => {
+  const win = mainWindow;
+  if (!win || win.isDestroyed()) return;
+  const wc = win.webContents;
+  authFlowActive.add(wc);
+  authFlowSawExternal.delete(wc);
+  const existing = authFlowTimers.get(wc);
+  if (existing) clearTimeout(existing);
+  authFlowTimers.set(
+    wc,
+    setTimeout(() => endAuthFlow(wc), AUTH_FLOW_TIMEOUT_MS),
+  );
+};
+
 const installSameOriginNavigationGuard = (win: BrowserWindow): void => {
   // Scoped to the main window — popups (OAuth flows etc.) need to
   // redirect between provider domains and our callback origin, so
@@ -121,23 +163,32 @@ const installSameOriginNavigationGuard = (win: BrowserWindow): void => {
   // so a `VELLUM_DEV_URL` mutated mid-process can't desync the loader
   // and the guard.
   const allowedOrigin = resolveAllowedOrigin();
-  win.webContents.on("will-navigate", (event, url) => {
-    let target: URL;
-    try {
-      target = new URL(url);
-    } catch {
-      event.preventDefault();
-      return;
-    }
-    if (isAllowedOrigin(target, allowedOrigin)) return;
+  const wc = win.webContents;
+
+  wc.on("will-navigate", (event, url) => {
+    const decision = decideNavigation(url, allowedOrigin, authFlowActive.has(wc));
+    if (decision.kind === "allow") return;
     event.preventDefault();
     // External http(s) top-level navigations (e.g.
-    // `window.location.href = "https://billing.stripe.com/..."`) route
-    // to the system browser instead of silently failing. Other schemes
-    // stay blocked.
-    if (target.protocol === "https:" || target.protocol === "http:") {
-      void shell.openExternal(url);
+    // `window.location.href = "https://billing.stripe.com/..."`) route to the
+    // system browser instead of silently failing. Other schemes stay blocked.
+    if (decision.kind === "external") {
+      void shell.openExternal(decision.url);
     }
+  });
+
+  // Re-arm the relaxed guard once a sign-in returns to the app origin after
+  // visiting a provider domain. `did-navigate` reports each committed top-level
+  // URL (post-redirect), so it sees the provider page and then the callback.
+  wc.on("did-navigate", (_event, url) => {
+    if (!authFlowActive.has(wc)) return;
+    const { end, sawExternal } = advanceAuthFlow(
+      url,
+      allowedOrigin,
+      authFlowSawExternal.has(wc),
+    );
+    if (sawExternal) authFlowSawExternal.add(wc);
+    if (end) endAuthFlow(wc);
   });
 };
 
@@ -385,6 +436,17 @@ export const installMainWindow = (): void => {
     z.tuple([z.boolean()]),
     async ([active]): Promise<void> => {
       setOnboarding(active);
+    },
+  );
+
+  // Renderer-driven sign-in: relax the same-origin navigation guard for the
+  // duration of an OAuth flow so the provider chain runs in the main window
+  // instead of being ejected to the system browser.
+  handle(
+    "vellum:mainWindow:beginAuthFlow",
+    z.tuple([]),
+    async (): Promise<void> => {
+      beginAuthFlow();
     },
   );
 

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -242,6 +242,14 @@ export interface VellumBridge {
      * right size.
      */
     setOnboarding(active: boolean): Promise<void>;
+    /**
+     * Relax the main window's same-origin navigation guard for the duration
+     * of a sign-in so the OAuth provider chain (WorkOS → Google/Apple → our
+     * callback) runs in-window instead of being ejected to the system
+     * browser. Call right before kicking off the provider redirect; the guard
+     * re-arms automatically when the flow returns to the app.
+     */
+    beginAuthFlow(): Promise<void>;
   };
   power: {
     /**
@@ -387,6 +395,8 @@ const bridge: VellumBridge = {
         "vellum:mainWindow:setOnboarding",
         active,
       ) as Promise<void>,
+    beginAuthFlow: (): Promise<void> =>
+      ipcRenderer.invoke("vellum:mainWindow:beginAuthFlow") as Promise<void>,
   },
   power: {
     onEvent: (callback) => {

--- a/apps/web/src/runtime/is-electron.ts
+++ b/apps/web/src/runtime/is-electron.ts
@@ -115,6 +115,7 @@ declare global {
       mainWindow: {
         ensureVisible(): Promise<void>;
         setOnboarding(active: boolean): Promise<void>;
+        beginAuthFlow(): Promise<void>;
       };
       power: {
         onEvent(

--- a/apps/web/src/runtime/main-window.ts
+++ b/apps/web/src/runtime/main-window.ts
@@ -41,3 +41,18 @@ export async function setOnboardingWindow(active: boolean): Promise<void> {
   if (!isElectron()) return;
   await window.vellum?.mainWindow.setOnboarding(active);
 }
+
+/**
+ * Relax the Electron main window's same-origin navigation guard for the
+ * duration of a sign-in, so the OAuth provider chain (WorkOS → Google/Apple →
+ * our callback) runs in the main window instead of being ejected to the system
+ * browser. Call immediately before starting the provider redirect; the main
+ * process re-arms the guard once the flow returns to the app (or on a timeout).
+ *
+ * No-op off Electron — web runs OAuth as a normal top-level navigation and
+ * Capacitor iOS uses the native auth sheet.
+ */
+export async function beginMainWindowAuthFlow(): Promise<void> {
+  if (!isElectron()) return;
+  await window.vellum?.mainWindow.beginAuthFlow();
+}

--- a/apps/web/src/runtime/native-auth.ts
+++ b/apps/web/src/runtime/native-auth.ts
@@ -7,6 +7,8 @@ import {
 } from "@/domains/account/social-auth";
 import { sanitizeReturnTo } from "@/domains/account/return-to";
 import { getSession } from "@/lib/auth/allauth-client";
+import { isElectron } from "@/runtime/is-electron";
+import { beginMainWindowAuthFlow } from "@/runtime/main-window";
 import { isBiometricEnabled, storeBiometricToken } from "@/runtime/native-biometric";
 import { routes } from "@/utils/routes";
 
@@ -245,6 +247,14 @@ export async function startAuthFlow(
       throw err;
     }
     return;
+  }
+
+  // Desktop (Electron): run the OAuth flow in the main window like the web,
+  // but first relax the main window's navigation guard so the cross-origin
+  // provider chain isn't ejected to the system browser mid-handshake. The
+  // existing provider callback page completes the flow in-window.
+  if (isElectron()) {
+    await beginMainWindowAuthFlow();
   }
 
   // Web path: `options` carries an extra `returnTo` field that the web


### PR DESCRIPTION
## Problem

The Electron macOS app's sign-in is broken. The main window installs a same-origin navigation guard that ejects cross-origin top-level navigations to the system browser. Platform sign-in runs the WorkOS → Google/Apple OAuth chain as top-level navigations in the main window, so the flow gets kicked out to the system browser mid-handshake and never returns — the user ends up re-entering their email in a browser tab and hitting a Google 500.

The first hop slips through (it's a server `will-redirect`, which the guard doesn't intercept), but the next user-driven `will-navigate` on the provider domain is ejected — hence "the same page, but in the browser."

## Fix (in-window via a temporary guard relaxation)

Rather than moving OAuth into a popup, relax the main-window guard for the duration of a sign-in:

1. On "Continue with…", the renderer calls `beginMainWindowAuthFlow()` → IPC `vellum:mainWindow:beginAuthFlow`.
2. While armed, the guard allows the cross-origin provider hops (WorkOS → Google/Apple) to run **in the main window** instead of ejecting them.
3. The guard **re-arms automatically** once the flow returns to the app origin *after* visiting a provider (tracked via `did-navigate` + a `sawExternal` flag), with a **5-minute timeout backstop** so the relaxation can't linger.
4. The existing provider-callback page completes the flow in-window — no popup, no completion signaling, no callback-page changes.

## Changes

- **`auth-nav.ts`** (new) — pure, unit-tested `decideNavigation` (allow / eject-to-browser / block) and `advanceAuthFlow` (re-arm) logic for the guard.
- **`main-window.ts`** — per-`WebContents` auth-flow state, `beginAuthFlow`, the relaxed `will-navigate` guard, the `did-navigate` re-arm, and the `vellum:mainWindow:beginAuthFlow` IPC handler.
- **`preload/index.ts` + `is-electron.ts` + `runtime/main-window.ts`** — the `beginAuthFlow` bridge and the `beginMainWindowAuthFlow()` wrapper (no-op off Electron).
- **`native-auth.ts`** — `startAuthFlow` relaxes the guard before the redirect on Electron, then runs the normal web flow.

## Verification

- macOS `tsc` clean; `auth-nav` unit tests pass (allow/eject/block + re-arm cases); full macOS main test suite passes (pre-existing unrelated `local-mode.test.ts` lockfile failure aside).
- Web `tsc`/ESLint clean for the changed files.
- Manual: `cd apps/macos && bun run dev` → "Continue with Google" completes in-window and lands in the app.

## Notes / risks

- **Security:** this relaxes the main-window navigation guard during sign-in. It's bounded by the return-to-app re-arm + a 5-minute timeout, and the IPC sender-origin guard still protects `window.vellum` even while a provider page is loaded. Flagging for a careful look.
- **`disallowed_useragent`:** Google can block OAuth in embedded Chromium (the reason iOS uses a Safari sheet). It renders fine today; only a system-browser + loopback flow fully sidesteps this. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)