### PR TITLE
feat(calls): implement invite-redemption sub-flow in call-setup-flow

### DIFF
--- a/assistant/src/__tests__/call-setup-flow-invite.test.ts
+++ b/assistant/src/__tests__/call-setup-flow-invite.test.ts
@@ -1,0 +1,407 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Logger mock (must come before any source imports) ────────────────
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// ── toTrustContext stub ──────────────────────────────────────────────
+
+mock.module("../runtime/actor-trust-resolver.js", () => ({
+  toTrustContext: (ctx: { trustClass: string }, externalId: string) => ({
+    sourceChannel: "phone",
+    trustClass: ctx.trustClass,
+    requesterExternalUserId: externalId,
+  }),
+}));
+
+// ── Verification template stub ───────────────────────────────────────
+
+mock.module("../runtime/verification-templates.js", () => ({
+  GUARDIAN_VERIFY_TEMPLATE_KEYS: {
+    VOICE_CALL_INTRO: "voice.call_intro",
+  },
+  composeVerificationVoice: (key: string, vars: { codeDigits: number }) =>
+    `[${key}:${vars.codeDigits}]`,
+}));
+
+// ── attemptInviteCodeRedemption stub ─────────────────────────────────
+// Drive the invite success/failure branches deterministically without the
+// invite service. parseDigitsFromSpeech is kept real (pure, transport-agnostic).
+
+const inviteOutcomes: Array<
+  | {
+      outcome: "success";
+      memberId: string;
+      type: "redeemed" | "already_member";
+      inviteId?: string;
+    }
+  | { outcome: "failure"; ttsMessage: string }
+> = [];
+
+mock.module("../calls/relay-verification.js", () => ({
+  parseDigitsFromSpeech: (transcript: string) => {
+    const words: Record<string, string> = {
+      one: "1",
+      two: "2",
+      three: "3",
+      four: "4",
+      five: "5",
+      six: "6",
+    };
+    const digits: string[] = [];
+    for (const token of transcript.toLowerCase().split(/[\s,]+/)) {
+      if (/^\d+$/.test(token)) digits.push(...token.split(""));
+      else if (words[token]) digits.push(words[token]);
+    }
+    return digits.join("");
+  },
+  attemptInviteCodeRedemption: () => {
+    const next = inviteOutcomes.shift();
+    if (!next) throw new Error("no queued invite outcome");
+    return next;
+  },
+  // Unused here but part of the module surface.
+  attemptVerificationCode: () => {
+    throw new Error("not used in invite tests");
+  },
+}));
+
+import {
+  CallSetupFlow,
+  type CallSetupFlowDeps,
+  type SetupFlowSession,
+} from "../calls/call-setup-flow.js";
+import type {
+  SetupFlowResult,
+  SetupFlowTransport,
+} from "../calls/call-setup-flow-types.js";
+import type {
+  SetupOutcome,
+  SetupResolved,
+} from "../calls/relay-setup-router.js";
+import type {
+  ActorTrustContext,
+  ResolveActorTrustInput,
+} from "../runtime/actor-trust-resolver.js";
+
+// ── Test doubles ─────────────────────────────────────────────────────
+
+function makeTransport() {
+  const calls = { ended: [] as Array<string | undefined> };
+  const transport: SetupFlowTransport = {
+    sendTextToken() {},
+    endSession(reason) {
+      calls.ended.push(reason);
+    },
+    getConnectionState() {
+      return "connected";
+    },
+  };
+  return { transport, calls };
+}
+
+function makeDeps(
+  session: SetupFlowSession | null,
+  overrides: Partial<CallSetupFlowDeps> = {},
+) {
+  const completed: SetupFlowResult[] = [];
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const spoken: string[] = [];
+  const pointers: Array<{ event: string }> = [];
+  const transcripts: Array<{ speaker: string; text: string }> = [];
+  const scheduled: Array<{ fn: () => void; delayMs: number }> = [];
+  const finalized: string[] = [];
+
+  const deps: CallSetupFlowDeps = {
+    async speakSystemPrompt(_t, text) {
+      spoken.push(text);
+    },
+    recordCallEvent(_id, eventType, payload) {
+      events.push({ type: eventType, payload });
+    },
+    onComplete(result) {
+      completed.push(result);
+    },
+    getSession: () => session,
+    async addPointerMessage(_conversationId, event) {
+      pointers.push({ event });
+    },
+    fireTranscript(_conversationId, _callSessionId, speaker, text) {
+      transcripts.push({ speaker, text });
+    },
+    composeInviteRedemptionPrompt: ({ isOutbound, friendName, guardianName }) =>
+      `prompt:${isOutbound ? "out" : "in"}:${friendName}:${guardianName}`,
+    composeInviteHandoffText: ({ friendName }) =>
+      `handoff:${friendName ?? "friend"}`,
+    finalizeFailedCall(reason) {
+      finalized.push(reason);
+    },
+    hangupDelayMs: 999,
+    schedule(fn, delayMs) {
+      scheduled.push({ fn, delayMs });
+    },
+    ...overrides,
+  };
+  return {
+    deps,
+    completed,
+    events,
+    spoken,
+    pointers,
+    transcripts,
+    scheduled,
+    finalized,
+  };
+}
+
+const RESOLVED: SetupResolved = {
+  assistantId: "asst_test",
+  isInbound: true,
+  otherPartyNumber: "+15550100",
+  actorTrust: { trustClass: "unknown" } as unknown as ActorTrustContext,
+};
+
+const SESSION: SetupFlowSession = {
+  conversationId: "conv_voice",
+  toNumber: "+15550199",
+  initiatedFromConversationId: "conv_origin",
+};
+
+const INVITE_OUTCOME: Extract<SetupOutcome, { action: "invite_redemption" }> = {
+  action: "invite_redemption",
+  assistantId: "asst_test",
+  fromNumber: "+15550100",
+  friendName: "Robin",
+  guardianName: "Alex",
+};
+
+function pushDigits(flow: CallSetupFlow, code: string): void {
+  for (const d of code) flow.pushDtmfDigit(d);
+}
+
+describe("CallSetupFlow invite-redemption sub-flow", () => {
+  beforeEach(() => {
+    inviteOutcomes.length = 0;
+  });
+
+  test("starts collecting and speaks the (inbound) prompt", async () => {
+    const transport = makeTransport();
+    const ctx = makeDeps(SESSION);
+    const flow = new CallSetupFlow("call_1", transport.transport, ctx.deps);
+
+    flow.start(INVITE_OUTCOME, RESOLVED);
+    await Promise.resolve();
+
+    expect(flow.getState()).toBe("collecting_code");
+    expect(ctx.spoken).toContain("prompt:in:Robin:Alex");
+    expect(ctx.events.map((e) => e.type)).toContain(
+      "invite_redemption_started",
+    );
+  });
+
+  test("outbound direction is reflected in the prompt", async () => {
+    const transport = makeTransport();
+    const ctx = makeDeps(SESSION);
+    const flow = new CallSetupFlow("call_1", transport.transport, ctx.deps);
+
+    flow.start(INVITE_OUTCOME, { ...RESOLVED, isInbound: false });
+    await Promise.resolve();
+
+    expect(ctx.spoken).toContain("prompt:out:Robin:Alex");
+  });
+
+  test("valid code → proceed-handoff-spoken with handoff copy + notifier", async () => {
+    const transport = makeTransport();
+    const ctx = makeDeps(SESSION);
+    const flow = new CallSetupFlow("call_1", transport.transport, ctx.deps);
+
+    const started = flow.start(INVITE_OUTCOME, RESOLVED);
+    inviteOutcomes.push({
+      outcome: "success",
+      memberId: "member_1",
+      type: "redeemed",
+      inviteId: "invite_1",
+    });
+    pushDigits(flow, "123456");
+
+    const result = await started;
+    expect(result.kind).toBe("proceed-handoff-spoken");
+    expect(flow.getState()).toBe("completed");
+
+    // Handoff copy spoken + assistant_spoke event + transcript fire.
+    expect(ctx.spoken).toContain("handoff:Robin");
+    expect(ctx.events.map((e) => e.type)).toContain(
+      "invite_redemption_succeeded",
+    );
+    expect(ctx.events.map((e) => e.type)).toContain("assistant_spoke");
+    expect(ctx.transcripts).toEqual([
+      { speaker: "assistant", text: "handoff:Robin" },
+    ]);
+    // Success event carries the redemption side-effect identifiers.
+    const success = ctx.events.find(
+      (e) => e.type === "invite_redemption_succeeded",
+    );
+    expect(success?.payload).toMatchObject({
+      memberId: "member_1",
+      inviteId: "invite_1",
+    });
+  });
+
+  test("already_member success also proceeds to handoff", async () => {
+    const transport = makeTransport();
+    const ctx = makeDeps(SESSION);
+    const flow = new CallSetupFlow("call_1", transport.transport, ctx.deps);
+
+    const started = flow.start(INVITE_OUTCOME, RESOLVED);
+    inviteOutcomes.push({
+      outcome: "success",
+      memberId: "member_2",
+      type: "already_member",
+    });
+    pushDigits(flow, "654321");
+
+    const result = await started;
+    expect(result.kind).toBe("proceed-handoff-spoken");
+    const success = ctx.events.find(
+      (e) => e.type === "invite_redemption_succeeded",
+    );
+    expect(success?.payload).toMatchObject({ memberId: "member_2" });
+    // No inviteId on the already_member branch.
+    expect(success?.payload).not.toHaveProperty("inviteId");
+  });
+
+  test("success re-resolves trust for the redeemed member (not stale)", async () => {
+    const transport = makeTransport();
+    const resolveArgs: ResolveActorTrustInput[] = [];
+    const resolveActorTrust = (input: ResolveActorTrustInput) => {
+      resolveArgs.push(input);
+      return { trustClass: "trusted_contact" } as unknown as ActorTrustContext;
+    };
+    const ctx = makeDeps(SESSION, { resolveActorTrust });
+    const flow = new CallSetupFlow("call_1", transport.transport, ctx.deps);
+
+    const started = flow.start(INVITE_OUTCOME, RESOLVED);
+    inviteOutcomes.push({
+      outcome: "success",
+      memberId: "member_1",
+      type: "redeemed",
+      inviteId: "invite_1",
+    });
+    pushDigits(flow, "123456");
+
+    const result = await started;
+    expect(resolveArgs).toHaveLength(1);
+    expect(resolveArgs[0]).toMatchObject({
+      assistantId: "asst_test",
+      sourceChannel: "phone",
+      conversationExternalId: "+15550100",
+      actorExternalId: "+15550100",
+    });
+    if (result.kind === "proceed-handoff-spoken") {
+      expect(result.trustContext).toMatchObject({
+        trustClass: "trusted_contact",
+      });
+    }
+  });
+
+  test("invalid/expired code → failure spoken then ended (deferred hangup)", async () => {
+    const transport = makeTransport();
+    const ctx = makeDeps(SESSION);
+    const flow = new CallSetupFlow("call_1", transport.transport, ctx.deps);
+
+    const started = flow.start(INVITE_OUTCOME, RESOLVED);
+    inviteOutcomes.push({
+      outcome: "failure",
+      ttsMessage: "Sorry, that code is expired. Goodbye.",
+    });
+    pushDigits(flow, "000000");
+
+    const result = await started;
+    expect(result).toEqual({
+      kind: "ended",
+      reason: "Invite redemption failed",
+    });
+    expect(flow.getState()).toBe("completed");
+
+    expect(ctx.events.map((e) => e.type)).toContain("invite_redemption_failed");
+    expect(ctx.finalized).toEqual([
+      "Voice invite redemption failed — invalid or expired code",
+    ]);
+    expect(ctx.spoken).toContain("Sorry, that code is expired. Goodbye.");
+
+    // Hangup is deferred, not synchronous.
+    expect(transport.calls.ended).toHaveLength(0);
+    expect(ctx.scheduled).toHaveLength(1);
+    expect(ctx.scheduled[0]!.delayMs).toBe(999);
+    ctx.scheduled[0]!.fn();
+    expect(transport.calls.ended).toEqual(["Invite redemption failed"]);
+  });
+
+  test("spoken digits drive redemption too", async () => {
+    const transport = makeTransport();
+    const ctx = makeDeps(SESSION);
+    const flow = new CallSetupFlow("call_1", transport.transport, ctx.deps);
+
+    const started = flow.start(INVITE_OUTCOME, RESOLVED);
+    inviteOutcomes.push({
+      outcome: "success",
+      memberId: "member_1",
+      type: "redeemed",
+      inviteId: "invite_1",
+    });
+    flow.pushTranscriptFinal("one two three four five six");
+
+    const result = await started;
+    expect(result.kind).toBe("proceed-handoff-spoken");
+  });
+
+  test("rejecting finalize dep on failure still ends the flow", async () => {
+    const transport = makeTransport();
+    const ctx = makeDeps(SESSION, {
+      finalizeFailedCall() {
+        throw new Error("call session already gone");
+      },
+    });
+    const flow = new CallSetupFlow("call_1", transport.transport, ctx.deps);
+
+    const started = flow.start(INVITE_OUTCOME, RESOLVED);
+    inviteOutcomes.push({
+      outcome: "failure",
+      ttsMessage: "Sorry, that code is expired. Goodbye.",
+    });
+    pushDigits(flow, "000000");
+
+    const result = await started;
+    expect(result.kind).toBe("ended");
+    expect(flow.getState()).toBe("completed");
+    expect(ctx.scheduled).toHaveLength(1);
+  });
+
+  test("rejecting pointer-write dep still finishes the flow", async () => {
+    const transport = makeTransport();
+    const ctx = makeDeps(SESSION, {
+      async addPointerMessage() {
+        throw new Error("origin conversation deleted");
+      },
+    });
+    const flow = new CallSetupFlow("call_1", transport.transport, ctx.deps);
+
+    const started = flow.start(INVITE_OUTCOME, RESOLVED);
+    inviteOutcomes.push({
+      outcome: "success",
+      memberId: "member_1",
+      type: "redeemed",
+      inviteId: "invite_1",
+    });
+    pushDigits(flow, "123456");
+
+    const result = await started;
+    expect(result.kind).toBe("proceed-handoff-spoken");
+    expect(flow.getState()).toBe("completed");
+  });
+});

--- a/assistant/src/calls/call-setup-flow.ts
+++ b/assistant/src/calls/call-setup-flow.ts
@@ -43,6 +43,7 @@ import type {
 } from "./call-setup-flow-types.js";
 import type { SetupOutcome, SetupResolved } from "./relay-setup-router.js";
 import {
+  attemptInviteCodeRedemption,
   attemptVerificationCode,
   parseDigitsFromSpeech,
 } from "./relay-verification.js";
@@ -139,6 +140,37 @@ export interface CallSetupFlowDeps {
    */
   composeTrustedContactHandoffText?(): string;
   /**
+   * Compose the invite-redemption entry prompt spoken when the flow starts
+   * collecting the invite code. Mirrors the per-direction copy assembled in
+   * `relay-server.startInviteRedemption` (which reads the resolved
+   * friend/guardian names and the assistant label). Injected so the flow
+   * needn't reach into the persona/label machinery; a plain default is used
+   * when the dep is absent.
+   */
+  composeInviteRedemptionPrompt?(input: {
+    isOutbound: boolean;
+    friendName: string | null;
+    guardianName: string | null;
+  }): string;
+  /**
+   * Compose the deterministic handoff copy spoken on a successful invite
+   * redemption (the relay path's `continueCallAfterTrustedContactActivation`
+   * with `activationReason: "invite_redeemed"`). The flow speaks the returned
+   * text itself and resolves `proceed-handoff-spoken`.
+   */
+  composeInviteHandoffText?(input: {
+    friendName: string | null;
+    guardianName: string | null;
+  }): string;
+  /**
+   * Mark the call session failed and finalize it after a terminal invite
+   * redemption failure, mirroring the `updateCallSession({ status: "failed" })`
+   * + `finalizeCall(...)` writes in
+   * `relay-server.handleInviteCodeRedemptionResult`. Injected so the flow stays
+   * storage-agnostic; best-effort (the flow still ends on rejection).
+   */
+  finalizeFailedCall?(reason: string): void | Promise<void>;
+  /**
    * Re-resolve the caller's actor-trust context after a successful
    * verification, mirroring the relay path's post-validation
    * `resolveActorTrust(...)` call (see `relay-server.handleVerificationCodeResult`
@@ -197,6 +229,14 @@ type CodeCollection = {
       /** Outbound callee verification — compared against this generated code. */
       expectedCode: string;
     }
+  | {
+      kind: "invite";
+      /** Invite redemption — redeemed via the invite service. */
+      assistantId: string;
+      fromNumber: string;
+      friendName: string | null;
+      guardianName: string | null;
+    }
 );
 
 // ── Flow ─────────────────────────────────────────────────────────────
@@ -253,6 +293,9 @@ export class CallSetupFlow implements SetupFlowInput {
 
       case "callee_verification":
         return this.startCalleeVerification(outcome, resolved);
+
+      case "invite_redemption":
+        return this.startInviteRedemption(outcome, resolved);
 
       default:
         throw new UnsupportedSetupFlowError(outcome.action);
@@ -424,6 +467,50 @@ export class CallSetupFlow implements SetupFlowInput {
     }
   }
 
+  /**
+   * Invite redemption: prompt an unknown caller (inbound or outbound) for the
+   * 6-digit invite code their contact shared, then collect digits. Resolution
+   * happens later, in {@link onInviteCode}. Ports
+   * `relay-server.startInviteRedemption`.
+   */
+  private startInviteRedemption(
+    outcome: Extract<SetupOutcome, { action: "invite_redemption" }>,
+    resolved: SetupResolved,
+  ): Promise<SetupFlowResult> {
+    const isOutbound = !resolved.isInbound;
+    this.collecting = {
+      kind: "invite",
+      assistantId: outcome.assistantId,
+      fromNumber: outcome.fromNumber,
+      friendName: outcome.friendName,
+      guardianName: outcome.guardianName,
+      buffer: "",
+      codeLength: 6,
+      // Relay grants a single invite-code attempt before failing the call.
+      maxAttempts: 1,
+      attempts: 0,
+      resolved,
+    };
+    this.state = "collecting_code";
+
+    this.deps.recordCallEvent(this.callSessionId, "invite_redemption_started", {
+      assistantId: outcome.assistantId,
+      codeLength: 6,
+      maxAttempts: 1,
+    });
+
+    const prompt =
+      this.deps.composeInviteRedemptionPrompt?.({
+        isOutbound,
+        friendName: outcome.friendName,
+        guardianName: outcome.guardianName,
+      }) ??
+      `Welcome ${outcome.friendName ?? "there"}. Please enter the 6-digit code that ${
+        outcome.guardianName ?? "your contact"
+      } provided you to verify your identity.`;
+    return this.speakAndWait(prompt);
+  }
+
   /** Resolver for the pending digit-collection promise (set on start). */
   private resolveCollection: ((result: SetupFlowResult) => void) | null = null;
 
@@ -463,6 +550,8 @@ export class CallSetupFlow implements SetupFlowInput {
     if (!c) return;
     if (c.kind === "callee") {
       await this.onCalleeCode(c, enteredCode);
+    } else if (c.kind === "invite") {
+      await this.onInviteCode(c, enteredCode);
     } else {
       await this.onGuardianCode(c, enteredCode);
     }
@@ -596,19 +685,87 @@ export class CallSetupFlow implements SetupFlowInput {
   }
 
   /**
-   * Inbound trusted-contact success: speak the handoff copy, fire the
-   * `assistant_spoke` event + transcript notifier, and resolve
-   * `proceed-handoff-spoken`. Ports
+   * Redeem an entered invite code via the extracted
+   * `attemptInviteCodeRedemption`. On success (newly redeemed or already a
+   * member), re-resolve trust, speak the invite handoff copy, and resolve
+   * `proceed-handoff-spoken`. On failure, finalize the call as failed, speak
+   * the failure copy, and end the session. Ports
+   * `relay-server.handleInviteCodeRedemptionResult`.
+   */
+  private async onInviteCode(
+    c: Extract<CodeCollection, { kind: "invite" }>,
+    enteredCode: string,
+  ): Promise<void> {
+    const result = attemptInviteCodeRedemption({
+      inviteRedemptionAssistantId: c.assistantId,
+      inviteRedemptionFromNumber: c.fromNumber,
+      enteredCode,
+      inviteRedemptionGuardianName: c.guardianName,
+    });
+
+    if (result.outcome === "success") {
+      this.deps.recordCallEvent(
+        this.callSessionId,
+        "invite_redemption_succeeded",
+        {
+          memberId: result.memberId,
+          ...(result.inviteId ? { inviteId: result.inviteId } : {}),
+        },
+      );
+      this.finishCollection(this.completeInviteHandoff(c));
+      return;
+    }
+
+    this.deps.recordCallEvent(this.callSessionId, "invite_redemption_failed", {
+      attempts: 1,
+    });
+    // Best-effort: mirror relay's failed-call finalization, but never let a
+    // storage rejection strand the flow — the session must still end.
+    try {
+      await this.deps.finalizeFailedCall?.(
+        "Voice invite redemption failed — invalid or expired code",
+      );
+    } catch (err) {
+      log.warn(
+        { callSessionId: this.callSessionId, err },
+        "Skipping failed-call finalization — call session may be gone",
+      );
+    }
+    await this.speakThenEnd(result.ttsMessage, "Invite redemption failed");
+  }
+
+  /**
+   * Successful invite redemption: compose the invite handoff copy and complete
+   * via {@link speakHandoffAndComplete}. Ports the
+   * `activationReason: "invite_redeemed"` branch of
    * `relay-server.continueCallAfterTrustedContactActivation`.
    */
-  private completeTrustedContactHandoff(
+  private completeInviteHandoff(
+    c: Extract<CodeCollection, { kind: "invite" }>,
+  ): SetupFlowResult {
+    const handoffText =
+      this.deps.composeInviteHandoffText?.({
+        friendName: c.friendName,
+        guardianName: c.guardianName,
+      }) ??
+      (c.friendName
+        ? `Great, I've verified that you are ${c.friendName}. It's nice to meet you! How can I help?`
+        : "Great, I've verified your identity. It's nice to meet you! How can I help?");
+
+    return this.speakHandoffAndComplete(handoffText, c.resolved, c.fromNumber);
+  }
+
+  /**
+   * Shared "handoff already spoken" completion used by the trusted-contact and
+   * invite success paths: speak the handoff copy, fire the `assistant_spoke`
+   * event + transcript notifier, re-resolve the verified party's trust, and
+   * resolve `proceed-handoff-spoken`.
+   */
+  private speakHandoffAndComplete(
+    handoffText: string,
     resolved: SetupResolved,
     partyNumber: string,
   ): SetupFlowResult {
-    const handoffText =
-      this.deps.composeTrustedContactHandoffText?.() ??
-      "Great! You're verified. How can I help?";
-
     void this.deps.speakSystemPrompt(this.transport, handoffText);
     this.deps.recordCallEvent(this.callSessionId, "assistant_spoke", {
       text: handoffText,
@@ -628,6 +785,23 @@ export class CallSetupFlow implements SetupFlowInput {
       assistantId: resolved.assistantId,
       trustContext: this.recomputedTrustContextFor(resolved, partyNumber),
     });
+  }
+
+  /**
+   * Inbound trusted-contact success: speak the handoff copy, fire the
+   * `assistant_spoke` event + transcript notifier, and resolve
+   * `proceed-handoff-spoken`. Ports
+   * `relay-server.continueCallAfterTrustedContactActivation`.
+   */
+  private completeTrustedContactHandoff(
+    resolved: SetupResolved,
+    partyNumber: string,
+  ): SetupFlowResult {
+    const handoffText =
+      this.deps.composeTrustedContactHandoffText?.() ??
+      "Great! You're verified. How can I help?";
+
+    return this.speakHandoffAndComplete(handoffText, resolved, partyNumber);
   }
 
   /**


### PR DESCRIPTION
## Summary
- Port invite_redemption into CallSetupFlow, reusing PR 5's shared digit-collection/hangup/pointer helpers
- attemptInviteCodeRedemption; success → proceed-handoff-spoken, failure → ended; best-effort side effects
- Tests

Part of plan: migrate-phone-off-conversation-relay.md (PR 6 of 18)