### PR TITLE
feat(cli): `vellum devices` — list + revoke devices paired to a local assistant

### DIFF
--- a/cli/src/__tests__/devices.test.ts
+++ b/cli/src/__tests__/devices.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Tests for `vellum devices` (list) and `vellum devices revoke <hashedDeviceId>`:
+ * the host-side CLI that calls the loopback `GET /v1/devices` and
+ * `POST /v1/devices/revoke` endpoints. Verifies host-gating (refuses paired
+ * connections), the destructive-revoke confirmation, and that requests carry no
+ * browser/proxy headers.
+ */
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  spyOn,
+  test,
+} from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const testDir = mkdtempSync(join(tmpdir(), "devices-test-"));
+const ORIGINAL_LOCKFILE_DIR = process.env.VELLUM_LOCKFILE_DIR;
+const ORIGINAL_CONFIG_HOME = process.env.XDG_CONFIG_HOME;
+const ORIGINAL_ARGV = [...process.argv];
+const ORIGINAL_FETCH = globalThis.fetch;
+
+import { devices } from "../commands/devices.js";
+import { saveAssistantEntry } from "../lib/assistant-config.js";
+
+interface FetchCall {
+  url: string;
+  init?: RequestInit;
+}
+
+let fetchCalls: FetchCall[] = [];
+
+/** Stub global fetch (spyOn does not intercept fetch in Bun). */
+function stubFetch(
+  handler: (url: string, init?: RequestInit) => Response,
+): void {
+  globalThis.fetch = (async (url: unknown, init?: RequestInit) => {
+    fetchCalls.push({ url: String(url), init });
+    return handler(String(url), init);
+  }) as typeof fetch;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+interface RunResult {
+  exited: boolean;
+  logs: string;
+  errors: string;
+}
+
+/** Run devices() with console + process.exit spied. */
+async function runDevices(): Promise<RunResult> {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  const logSpy = spyOn(console, "log").mockImplementation((...a: unknown[]) => {
+    logs.push(a.join(" "));
+  });
+  const errSpy = spyOn(console, "error").mockImplementation(
+    (...a: unknown[]) => {
+      errors.push(a.join(" "));
+    },
+  );
+  const exitSpy = spyOn(process, "exit").mockImplementation(((c?: number) => {
+    throw new Error(`exit:${c}`);
+  }) as never);
+  let exited = false;
+  try {
+    await devices();
+  } catch (e) {
+    exited = (e as Error).message?.startsWith("exit:") ?? false;
+  } finally {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    exitSpy.mockRestore();
+  }
+  return { exited, logs: logs.join("\n"), errors: errors.join("\n") };
+}
+
+function headerKeys(init?: RequestInit): string[] {
+  const h = init?.headers as Record<string, string> | undefined;
+  return h ? Object.keys(h).map((k) => k.toLowerCase()) : [];
+}
+
+describe("vellum devices", () => {
+  beforeEach(() => {
+    process.env.VELLUM_LOCKFILE_DIR = testDir;
+    process.env.XDG_CONFIG_HOME = testDir;
+    fetchCalls = [];
+    // Default stub: any unexpected call is recorded and 500s.
+    stubFetch(() => jsonResponse({ error: "unexpected" }, 500));
+  });
+
+  afterEach(() => {
+    process.argv = [...ORIGINAL_ARGV];
+    globalThis.fetch = ORIGINAL_FETCH;
+    if (ORIGINAL_LOCKFILE_DIR === undefined)
+      delete process.env.VELLUM_LOCKFILE_DIR;
+    else process.env.VELLUM_LOCKFILE_DIR = ORIGINAL_LOCKFILE_DIR;
+    if (ORIGINAL_CONFIG_HOME === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = ORIGINAL_CONFIG_HOME;
+  });
+
+  afterAll(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  function seedLocal(id: string, localUrl = "http://127.0.0.1:7830"): void {
+    saveAssistantEntry({
+      assistantId: id,
+      name: id,
+      runtimeUrl: "http://127.0.0.1:7830",
+      localUrl,
+      cloud: "local",
+      species: "vellum",
+    });
+  }
+
+  test("--help prints usage including Examples", async () => {
+    process.argv = ["bun", "vellum", "devices", "--help"];
+    const { logs } = await runDevices();
+    expect(logs).toContain("USAGE:");
+    expect(logs).toContain("EXAMPLES:");
+    expect(logs).toContain("vellum devices revoke");
+  });
+
+  test("lists active devices over loopback with no browser/proxy headers", async () => {
+    seedLocal("list-host", "http://127.0.0.1:7833");
+    stubFetch((url) => {
+      if (url.endsWith("/v1/devices")) {
+        return jsonResponse({
+          devices: [
+            {
+              hashedDeviceId: "hashAAA111",
+              platform: "cli",
+              issuedAt: 1_700_000_000_000,
+              expiresAt: 1_800_000_000_000,
+              lastUsedAt: 1_750_000_000_000,
+            },
+            {
+              hashedDeviceId: "hashBBB222",
+              platform: "webview",
+              issuedAt: 1_700_000_000_000,
+              expiresAt: null,
+              lastUsedAt: null,
+            },
+          ],
+        });
+      }
+      return jsonResponse({ error: "unexpected" }, 500);
+    });
+
+    process.argv = ["bun", "vellum", "devices", "list-host"];
+    const { exited, logs } = await runDevices();
+
+    expect(exited).toBe(false);
+    // Both full hashes + platforms surfaced; null lastUsedAt → "never".
+    expect(logs).toContain("hashAAA111");
+    expect(logs).toContain("hashBBB222");
+    expect(logs).toContain("cli");
+    expect(logs).toContain("webview");
+    expect(logs).toContain("never");
+
+    expect(fetchCalls).toHaveLength(1);
+    const call = fetchCalls[0];
+    expect(call.url).toBe("http://127.0.0.1:7833/v1/devices");
+    expect(call.init?.method).toBe("GET");
+    const keys = headerKeys(call.init);
+    expect(keys).not.toContain("origin");
+    expect(keys).not.toContain("x-forwarded-for");
+  });
+
+  test("prints a clear message when no devices are paired", async () => {
+    seedLocal("empty-host");
+    stubFetch(() => jsonResponse({ devices: [] }));
+
+    process.argv = ["bun", "vellum", "devices", "empty-host"];
+    const { exited, logs } = await runDevices();
+
+    expect(exited).toBe(false);
+    expect(logs).toContain("No devices are paired to empty-host");
+  });
+
+  test("revoke posts the hashedDeviceId with --yes (no prompt)", async () => {
+    seedLocal("revoke-host", "http://127.0.0.1:7834");
+    stubFetch((url) => {
+      if (url.endsWith("/v1/devices/revoke")) {
+        return jsonResponse({ revoked: true, hashedDeviceId: "hashAAA111" });
+      }
+      return jsonResponse({ error: "unexpected" }, 500);
+    });
+
+    process.argv = [
+      "bun",
+      "vellum",
+      "devices",
+      "revoke",
+      "hashAAA111",
+      "revoke-host",
+      "--yes",
+    ];
+    const { exited, logs } = await runDevices();
+
+    expect(exited).toBe(false);
+    expect(logs).toContain("Revoked device hashAAA111");
+
+    expect(fetchCalls).toHaveLength(1);
+    const call = fetchCalls[0];
+    expect(call.url).toBe("http://127.0.0.1:7834/v1/devices/revoke");
+    expect(call.init?.method).toBe("POST");
+    expect(JSON.parse(String(call.init?.body))).toEqual({
+      hashedDeviceId: "hashAAA111",
+    });
+  });
+
+  test("revoke without a hashedDeviceId errors and makes no request", async () => {
+    process.argv = ["bun", "vellum", "devices", "revoke", "--yes"];
+    const { exited, errors } = await runDevices();
+
+    expect(exited).toBe(true);
+    expect(errors).toContain("hashedDeviceId is required");
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  test("revoke refuses without --yes in a non-interactive terminal", async () => {
+    seedLocal("rh3");
+    // process.stdin.isTTY is falsy under the test runner → not promptable.
+    process.argv = ["bun", "vellum", "devices", "revoke", "hashZZZ", "rh3"];
+    const { exited, errors } = await runDevices();
+
+    expect(exited).toBe(true);
+    expect(errors).toContain("--yes");
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  test("host-gates a paired connection (points to the host / unpair)", async () => {
+    saveAssistantEntry({
+      assistantId: "paired-box",
+      name: "Paired Box",
+      runtimeUrl: "http://10.0.0.9:7830",
+      cloud: "paired",
+      paired: true,
+      species: "vellum",
+    });
+
+    process.argv = ["bun", "vellum", "devices", "paired-box"];
+    const { exited, errors } = await runDevices();
+
+    expect(exited).toBe(true);
+    expect(errors).toContain("vellum unpair");
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  test("surfaces a non-2xx gateway response on list", async () => {
+    seedLocal("err-host");
+    stubFetch(() => jsonResponse({ error: { code: "FORBIDDEN" } }, 403));
+
+    process.argv = ["bun", "vellum", "devices", "err-host"];
+    const { exited, errors } = await runDevices();
+
+    expect(exited).toBe(true);
+    expect(errors).toContain("403");
+  });
+});

--- a/cli/src/commands/devices.ts
+++ b/cli/src/commands/devices.ts
@@ -1,0 +1,247 @@
+/**
+ * `vellum devices [name]` and `vellum devices revoke <hashedDeviceId> [name] [--yes]`
+ *
+ * Host-side of pairing lifecycle: list and revoke the devices paired to a LOCAL
+ * self-hosted assistant. Calls the loopback-only gateway endpoints
+ * `GET /v1/devices` and `POST /v1/devices/revoke` (added in the gateway slice),
+ * which self-guard loopback + reject any browser/WebView Origin. The gateway
+ * only ever stores the HASHED device id, so list returns and revoke accepts the
+ * same `hashedDeviceId` (the raw device id is never persisted anywhere).
+ *
+ * This is the counterpart to `vellum unpair`: `unpair` forgets a connection on
+ * the *paired* machine (client side); `devices` revokes a device from the *host*
+ * that runs the assistant (server side).
+ */
+
+import {
+  type AssistantEntry,
+  formatAssistantReference,
+  getAssistantDisplayName,
+  resolveTargetAssistant,
+} from "../lib/assistant-config";
+import { parseAssistantTargetArg } from "../lib/assistant-target-args.js";
+import {
+  CLI_INTERFACE_ID,
+  getClientRegistrationHeaders,
+} from "../lib/client-identity.js";
+import {
+  canPromptForConfirmation,
+  confirmAction,
+} from "../lib/confirm-action.js";
+
+interface DeviceRecord {
+  hashedDeviceId: string;
+  platform: string;
+  issuedAt: number | null;
+  expiresAt: number | null;
+  lastUsedAt: number | null;
+}
+
+function printUsage(): void {
+  console.log(`vellum devices - List and revoke devices paired to a local assistant
+
+USAGE:
+    vellum devices [name]
+    vellum devices revoke <hashedDeviceId> [name] [--yes]
+
+ARGUMENTS:
+    [name]              Name or id of the local assistant (defaults to the active/sole one)
+    <hashedDeviceId>    The device's hashed id (copy it from the list output)
+
+OPTIONS:
+    --yes              Skip the interactive confirmation prompt when revoking (for automation)
+
+Lists the devices paired to a local (host-side) assistant, or revokes one by its
+hashed id. Runs on the machine that hosts the assistant — paired connections
+imported from another machine are managed with 'vellum unpair' instead.
+
+EXAMPLES:
+    vellum devices
+    vellum devices my-desk
+    vellum devices revoke 3f9a1c...
+    vellum devices revoke 3f9a1c... my-desk --yes
+`);
+}
+
+/**
+ * Resolve the LOOPBACK gateway base URL for a host-side assistant, or exit with
+ * a helpful error. Refuses paired connections (they have no local gateway here)
+ * and never falls back to a non-loopback URL.
+ */
+function resolveLoopbackBase(entry: AssistantEntry): string {
+  const displayName = getAssistantDisplayName(entry);
+
+  if (entry.cloud === "paired") {
+    console.error(
+      `Error: '${displayName}' is a paired connection imported from another machine.`,
+    );
+    console.error(
+      "Run `vellum devices` on the host that runs the assistant to manage its devices.",
+    );
+    console.error("To forget this connection here, use `vellum unpair`.");
+    process.exit(1);
+  }
+
+  const base =
+    entry.localUrl ||
+    (entry.resources?.gatewayPort
+      ? `http://127.0.0.1:${entry.resources.gatewayPort}`
+      : undefined);
+  if (!base) {
+    console.error(
+      `Error: no local gateway found for '${displayName}'. \`vellum devices\` runs on the machine hosting the assistant.`,
+    );
+    process.exit(1);
+  }
+
+  return base.replace(/\/+$/, "");
+}
+
+/** Format an epoch-ms timestamp as ISO, or a placeholder when absent. */
+function formatTimestamp(ms: number | null, absent: string): string {
+  if (typeof ms !== "number" || !Number.isFinite(ms)) return absent;
+  return new Date(ms).toISOString();
+}
+
+async function listDevices(entry: AssistantEntry, base: string): Promise<void> {
+  const displayName = getAssistantDisplayName(entry);
+
+  let response: Response;
+  try {
+    response = await fetch(`${base}/v1/devices`, {
+      method: "GET",
+      headers: getClientRegistrationHeaders(CLI_INTERFACE_ID),
+    });
+  } catch (err) {
+    console.error(
+      `Error: could not reach the gateway for '${displayName}' at ${base}: ${
+        (err as Error).message
+      }`,
+    );
+    process.exit(1);
+  }
+
+  if (!response.ok) {
+    console.error(
+      `Error: gateway returned ${response.status} listing devices for '${displayName}'.`,
+    );
+    process.exit(1);
+  }
+
+  const body = (await response.json()) as { devices?: DeviceRecord[] };
+  const devices = body.devices ?? [];
+
+  if (devices.length === 0) {
+    console.log(`No devices are paired to ${displayName}.`);
+    return;
+  }
+
+  console.log(`Devices paired to ${formatAssistantReference(entry)}:`);
+  console.log("");
+  for (const device of devices) {
+    console.log(`  ${device.hashedDeviceId}`);
+    console.log(`    platform:   ${device.platform}`);
+    console.log(`    issued:     ${formatTimestamp(device.issuedAt, "—")}`);
+    console.log(`    expires:    ${formatTimestamp(device.expiresAt, "—")}`);
+    console.log(
+      `    last used:  ${formatTimestamp(device.lastUsedAt, "never")}`,
+    );
+    console.log("");
+  }
+  console.log(
+    `${devices.length} device(s). Revoke one with: vellum devices revoke <hashedDeviceId>`,
+  );
+}
+
+async function revokeDevice(
+  entry: AssistantEntry,
+  base: string,
+  hashedDeviceId: string,
+  yes: boolean,
+): Promise<void> {
+  const displayName = getAssistantDisplayName(entry);
+
+  // Print the resolved identity before acting (cli/AGENTS.md).
+  console.log("Device to revoke:");
+  console.log(`  Assistant: ${formatAssistantReference(entry)}`);
+  console.log(`  Device:    ${hashedDeviceId}`);
+  console.log("");
+
+  if (!yes) {
+    if (!canPromptForConfirmation()) {
+      console.error(
+        "Error: Refusing to revoke without confirmation in a non-interactive terminal.",
+      );
+      console.error("Re-run with --yes to confirm from automation.");
+      process.exit(1);
+    }
+    const confirmed = await confirmAction(
+      "Press Enter to revoke, or Esc/q to cancel: ",
+    );
+    if (!confirmed) {
+      console.log("Revoke cancelled.");
+      process.exit(1);
+    }
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(`${base}/v1/devices/revoke`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...getClientRegistrationHeaders(CLI_INTERFACE_ID),
+      },
+      body: JSON.stringify({ hashedDeviceId }),
+    });
+  } catch (err) {
+    console.error(
+      `Error: could not reach the gateway for '${displayName}' at ${base}: ${
+        (err as Error).message
+      }`,
+    );
+    process.exit(1);
+  }
+
+  if (!response.ok) {
+    console.error(
+      `Error: gateway returned ${response.status} revoking device for '${displayName}'.`,
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `Revoked device ${hashedDeviceId} from ${displayName}. Its tokens are invalidated; that machine must re-pair to reconnect.`,
+  );
+}
+
+export async function devices(): Promise<void> {
+  const args = process.argv.slice(3);
+
+  if (args.includes("--help") || args.includes("-h")) {
+    printUsage();
+    return;
+  }
+
+  if (args[0] === "revoke") {
+    const rest = args.slice(1);
+    const yes = rest.includes("--yes");
+    const positionals = rest.filter((a) => !a.startsWith("-"));
+    const hashedDeviceId = positionals[0];
+    if (!hashedDeviceId) {
+      console.error("Error: a hashedDeviceId is required to revoke.");
+      printUsage();
+      process.exit(1);
+    }
+    const nameArg = positionals.slice(1).join(" ") || undefined;
+    const entry = resolveTargetAssistant(nameArg);
+    const base = resolveLoopbackBase(entry);
+    await revokeDevice(entry, base, hashedDeviceId, yes);
+    return;
+  }
+
+  const nameArg = parseAssistantTargetArg(args, []);
+  const entry = resolveTargetAssistant(nameArg);
+  const base = resolveLoopbackBase(entry);
+  await listDevices(entry, base);
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -5,6 +5,7 @@ import { backup } from "./commands/backup";
 import { clean } from "./commands/clean";
 import { client } from "./commands/client";
 import { connect } from "./commands/connect";
+import { devices } from "./commands/devices";
 import { env } from "./commands/env";
 import { events } from "./commands/events";
 import { exec } from "./commands/exec";
@@ -40,6 +41,7 @@ const commands = {
   clean,
   client,
   connect,
+  devices,
   env,
   events,
   exec,
@@ -80,6 +82,7 @@ function printHelp(): void {
   console.log("  clean    Kill orphaned vellum processes");
   console.log("  client   Connect to a hatched assistant");
   console.log("  connect  Import an assistant paired from another machine");
+  console.log("  devices  List or revoke devices paired to a local assistant");
   console.log("  env      Manage the default CLI environment");
   console.log("  events   Stream events from a running assistant");
   console.log("  exec     Execute a command inside an assistant's container");


### PR DESCRIPTION
## Summary
- Adds `vellum devices [name]` (list) and `vellum devices revoke <hashedDeviceId> [name] [--yes]` — the **host side** of pairing lifecycle: it lists and revokes the devices paired to a local self-hosted assistant by calling the loopback-only `GET /v1/devices` and `POST /v1/devices/revoke` endpoints added in slice 3b.
- Round-trips the gateway's stored `hashedDeviceId` (the raw device id is never persisted anywhere); list shows the full hash so it can be copied into revoke.
- Revoke is **destructive**: prints the resolved assistant + device identity and requires interactive confirmation (or `--yes`), reusing the shared `confirm-action` helper (same pattern as `retire`/`unpair`).
- **Host-gates**: refuses `cloud:"paired"` connections (those are imported from another machine — pointing to `vellum unpair` for the client side) and any entry with no local loopback gateway. Never sends a browser `Origin`/proxy header, so it passes the endpoints' loopback guard.
- Completes the devices/unpair work: 3a `vellum unpair` (client cleanup), 3b gateway endpoints, **3c this host CLI**.

## Original prompt
Build the host-side CLI for the remote-pairing feature: a `vellum devices` command that lists and revokes the devices paired to a local self-hosted assistant, consuming the loopback gateway endpoints shipped in slice 3b. It should reuse the existing CLI conventions and shared helpers (confirmation, assistant resolution, client identity), host-gate to local assistants, and keep revoke safely confirmed. This is slice 3c of the devices/unpair work.