### PR TITLE
fix(activation-rail): de-duplicate the four-surface list in Moment 2 Propose

### DIFF
--- a/assistant/src/prompts/templates/BOOTSTRAP-ACTIVATION-RAIL.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP-ACTIVATION-RAIL.md
@@ -12,9 +12,9 @@ Four moves. Goals, not steps.
 
 The prompt should be one-click copyable. Inline paragraph text the user has to select isn't. Neither is a custom-built widget with a fake copy button. If the affordance needs you to build an app or a new surface to render, you've over-built the move. Use what chat already gives you.
 
-**Propose.** Don't organize what they already told you — infer what they didn't. Name the unstated thing sitting in their context and say *why* you think it: point at the date, the repeated name, the status word, or the gap. "You didn't say this, but —". Then recommend, and lean one way; the recommendation IS the click, not a neutral menu of equally-weighted options.
+**Propose.** Don't organize what they already told you — infer what they didn't. Name the unstated thing sitting in their context and say *why* you think it: point at the specific surface that made you say it. "You didn't say this, but —". Then recommend, and lean one way; the recommendation IS the click, not a neutral menu of equally-weighted options.
 
-"Unstated" is inference, not invention. Read only four surfaces: dates / recency / time gaps; entities that recur (people, projects, accounts named more than once); status words ("stuck", "behind", "waiting on", "still"); and gaps — something the structure implies should be there but isn't. If you can't point to the date, the repeated name, the status word, or the gap that made you say it, don't say it. Don't free-speculate about goals, feelings, or facts that aren't traceable to the paste.
+"Unstated" is inference, not invention. Read only four surfaces: dates / recency / time gaps; entities that recur (people, projects, accounts named more than once); status words ("stuck", "behind", "waiting on", "still"); and gaps — something the structure implies should be there but isn't. If you can't point to the surface that made you say it, don't say it — no free-speculating about goals, feelings, or facts that aren't traceable to the paste.
 
 Surface the outcome as a clickable component, strongest first. The component is the question — don't follow it with a prose "or something else?" Pick from skills you already have loaded first; fall back to `vellum-skills-catalog` `skill_search` for what's missing. Compose the offer in their language, not in skill names.
 


### PR DESCRIPTION
## Summary
Fixes redundancy gap from plan review for moment-2-infer-shift.md.

**Gap:** the four-surface list (date / repeated name / status word / gap) was restated three times across consecutive Propose paragraphs, against the template's 'People don't read' thesis.
**Fix:** enumerate the list once (canonical definition), replace the two restatements with generic 'the surface' pointers, and fold the two trailing boundary sentences into one. Test substrings preserved.