### PR TITLE
fix(electron): suppress MaxListenersExceededWarning on WebContents

### DIFF
--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -282,6 +282,11 @@ app.on("second-instance", (_event, argv) => {
 });
 
 app.on("web-contents-created", (_event, contents) => {
+  // Electron internals + our own cleanup listeners (deep-links, power-events)
+  // exceed the default 10-listener cap per WebContents, triggering a spurious
+  // MaxListenersExceededWarning. Bump the limit to silence it.
+  contents.setMaxListeners(20);
+
   contents.setWindowOpenHandler(({ url, disposition }) => {
     // Only http(s) is ever opened — file:, javascript:, custom schemes are
     // denied with no fallback.


### PR DESCRIPTION
## Summary
- Bump `maxListeners` from the default 10 to 20 on each `WebContents` instance to suppress the spurious `MaxListenersExceededWarning` that fires at startup
- Electron internals combined with our own cleanup listeners (deep-links, power-events) push the count to 11, just past the default cap — there is no actual leak

## Original prompt
The Electron dev server prints a `MaxListenersExceededWarning` about 11 `destroyed` listeners on `WebContents` during startup. After investigating, the warning is a false positive caused by Electron internals plus our own cleanup listeners slightly exceeding the default limit of 10. The user asked to suppress it so other developers don't waste time worrying about it.