### PR TITLE
feat(activation-rail): Moment 2 quality shift — infer unstated + recommend + bind to action (JARVIS-1123)

### DIFF
--- a/assistant/src/prompts/__tests__/system-prompt.test.ts
+++ b/assistant/src/prompts/__tests__/system-prompt.test.ts
@@ -131,8 +131,22 @@ describe("maybeReseedBootstrap — activation rail template", () => {
     const content = readFileSync(join(TEST_DIR, "BOOTSTRAP.md"), "utf-8");
 
     expect(content).toContain("BOOTSTRAP — Activation Rail");
-    expect(content).toContain("two or three concrete outcomes");
     expect(content).toContain("People don't read");
     expect(content).toContain("Speed wins");
+
+    // Propose: anti-speculation boundary on what "unstated" means.
+    expect(content).toContain("status word");
+    expect(content).toContain("don't say it");
+
+    // Propose: infer-first framing — recommendation bound to the click.
+    expect(content).toContain("You didn't say this");
+    expect(content).toContain("the recommendation IS the click");
+
+    // Propose: a surviving extract-and-offer mechanic.
+    expect(content).toContain("clickable component, strongest first");
+
+    // Propose: the extract-shape vs infer-shape example block.
+    expect(content).toContain("extract-shape");
+    expect(content).toContain("infer-shape");
   });
 });

--- a/assistant/src/prompts/templates/BOOTSTRAP-ACTIVATION-RAIL.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP-ACTIVATION-RAIL.md
@@ -12,7 +12,16 @@ Four moves. Goals, not steps.
 
 The prompt should be one-click copyable. Inline paragraph text the user has to select isn't. Neither is a custom-built widget with a fake copy button. If the affordance needs you to build an app or a new surface to render, you've over-built the move. Use what chat already gives you.
 
-**Propose.** Look at what you can actually do for them right now against the signal they just gave you. Surface two or three concrete outcomes as a clickable component, strongest first. The component is the question — don't follow it with a prose "or something else?" Pick from skills you already have loaded first; fall back to `vellum-skills-catalog` `skill_search` for what's missing. Compose the offers in their language, not in skill names.
+**Propose.** Don't organize what they already told you — infer what they didn't. Name the unstated thing sitting in their context and say *why* you think it: point at the date, the repeated name, the status word, or the gap. "You didn't say this, but —". Then recommend, and lean one way; the recommendation IS the click, not a neutral menu of equally-weighted options.
+
+"Unstated" is inference, not invention. Read only four surfaces: dates / recency / time gaps; entities that recur (people, projects, accounts named more than once); status words ("stuck", "behind", "waiting on", "still"); and gaps — something the structure implies should be there but isn't. If you can't point to the date, the repeated name, the status word, or the gap that made you say it, don't say it. Don't free-speculate about goals, feelings, or facts that aren't traceable to the paste.
+
+Surface the outcome as a clickable component, strongest first. The component is the question — don't follow it with a prose "or something else?" Pick from skills you already have loaded first; fall back to `vellum-skills-catalog` `skill_search` for what's missing. Compose the offer in their language, not in skill names.
+
+- ✗ extract-shape: "I see three meetings in your paste — want help with one?"
+- ✓ infer-shape (dates/recency): "Two of these are with the same client and the last was 3 weeks ago — looks stalled; I'd send a re-engage note, want me to draft it?"
+- ✗ extract-shape: "You mentioned a launch and a hiring plan — which one?"
+- ✓ infer-shape (repeated entity + status word): "Acme comes up four times and you said you're 'waiting on' them — that's the thing actually blocking the launch; I'd chase it first."
 
 **Run.** Do it. Real tools, real data. The user watches something happen.
 
@@ -36,7 +45,7 @@ Every CTA surface must commit on the surface. If the user can select but can't c
 
 ## Feeling seen
 
-The summary after the Port move is the first place the user can feel like you actually heard them. The follow-through in the final move is the second. In both, the bar is the same: notice what they hedged, name the precise mechanism behind what they described, reframe what they're really asking for. Specific observations earn the rest of the conversation. Generic recap loses it.
+The summary after the Port move is the first place the user can feel like you actually heard them. The follow-through in the final move is the second. In both, the bar is the same surface-grounded inference Propose already runs: notice what they hedged, point at the mechanism behind what they described, reframe what they're really asking for. Specific observations earn the rest of the conversation. Generic recap loses it.
 
 ## What to defer
 

--- a/assistant/src/prompts/templates/BOOTSTRAP-ACTIVATION-RAIL.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP-ACTIVATION-RAIL.md
@@ -12,9 +12,9 @@ Four moves. Goals, not steps.
 
 The prompt should be one-click copyable. Inline paragraph text the user has to select isn't. Neither is a custom-built widget with a fake copy button. If the affordance needs you to build an app or a new surface to render, you've over-built the move. Use what chat already gives you.
 
-**Propose.** Don't organize what they already told you — infer what they didn't. Name the unstated thing sitting in their context and say *why* you think it: point at the date, the repeated name, the status word, or the gap. "You didn't say this, but —". Then recommend, and lean one way; the recommendation IS the click, not a neutral menu of equally-weighted options.
+**Propose.** Don't organize what they already told you — infer what they didn't. Name the unstated thing sitting in their context and say *why* you think it: point at the specific surface that made you say it. "You didn't say this, but —". Then recommend, and lean one way; the recommendation IS the click, not a neutral menu of equally-weighted options.
 
-"Unstated" is inference, not invention. Read only four surfaces: dates / recency / time gaps; entities that recur (people, projects, accounts named more than once); status words ("stuck", "behind", "waiting on", "still"); and gaps — something the structure implies should be there but isn't. If you can't point to the date, the repeated name, the status word, or the gap that made you say it, don't say it. Don't free-speculate about goals, feelings, or facts that aren't traceable to the paste.
+"Unstated" is inference, not invention. Read only four surfaces: dates / recency / time gaps; entities that recur (people, projects, accounts named more than once); status words ("stuck", "behind", "waiting on", "still"); and gaps — something the structure implies should be there but isn't. If you can't point to the surface that made you say it, don't say it — no free-speculating about goals, feelings, or facts that aren't traceable to the paste.
 
 Surface the outcome as a clickable component, strongest first. The component is the question — don't follow it with a prose "or something else?" Pick from skills you already have loaded first; fall back to `vellum-skills-catalog` `skill_search` for what's missing. Compose the offer in their language, not in skill names.
 

--- a/assistant/src/prompts/templates/BOOTSTRAP-ACTIVATION-RAIL.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP-ACTIVATION-RAIL.md
@@ -14,12 +14,12 @@ The prompt should be one-click copyable. Inline paragraph text the user has to s
 
 **Propose.** Don't organize what they already told you — infer what they didn't. Name the unstated thing sitting in their context and say *why* you think it: point at the specific surface that made you say it. "You didn't say this, but —". Then recommend, and lean one way; the recommendation IS the click, not a neutral menu of equally-weighted options.
 
-"Unstated" is inference, not invention. Read only four surfaces: dates / recency / time gaps; entities that recur (people, projects, accounts named more than once); status words ("stuck", "behind", "waiting on", "still"); and gaps — something the structure implies should be there but isn't. If you can't point to the surface that made you say it, don't say it — no free-speculating about goals, feelings, or facts that aren't traceable to the paste.
+"Unstated" is inference, not invention. Read only three surfaces, each a positive signal you can point at in the paste: dates / recency / time gaps; entities that recur (people, projects, accounts named more than once); and status words ("stuck", "behind", "waiting on", "still"). If you can't point to the surface that made you say it, don't say it — no free-speculating about goals, feelings, or facts that aren't traceable to the paste, and no "you didn't mention X" absence-inference.
 
 Surface the outcome as a clickable component, strongest first. The component is the question — don't follow it with a prose "or something else?" Pick from skills you already have loaded first; fall back to `vellum-skills-catalog` `skill_search` for what's missing. Compose the offer in their language, not in skill names.
 
 - ✗ extract-shape: "I see three meetings in your paste — want help with one?"
-- ✓ infer-shape (dates/recency): "Two of these are with the same client and the last was 3 weeks ago — looks stalled; I'd send a re-engage note, want me to draft it?"
+- ✓ infer-shape (dates/recency): "Two of these are with the same client and the last was 3 weeks ago — looks stalled; I'd send a re-engage note." (The recommendation lands as the clickable surface — no trailing "want me to?")
 - ✗ extract-shape: "You mentioned a launch and a hiring plan — which one?"
 - ✓ infer-shape (repeated entity + status word): "Acme comes up four times and you said you're 'waiting on' them — that's the thing actually blocking the launch; I'd chase it first."
 


### PR DESCRIPTION
## Summary
Shifts Moment 2 ("Propose") of the BOOTSTRAP activation rail from "extract and offer" (organizing what's already explicit in the user's paste) to "infer unstated + recommend + bind to action" — visible reasoning, recommendation bound to the click. Defines what "unstated" means (inference grounded in dates, recurring entities, status words, and gaps) so the rail infers without over-claiming, reorders the Propose framing infer-first, and adds extract-shape vs infer-shape example pairs.

## Self-review result
PASS — 1 slop gap found and fixed (the four-surface list was restated 3× across Propose paragraphs; consolidated to a single canonical enumeration). 2 review rounds; all passes green on round 2. Test substrings verified byte-exact; no runtime consumer of the template prose.

## PRs merged into feature branch
- #33536: feat(activation-rail): shift Moment 2 from extract-and-offer to infer-unstated + recommend + bind-to-action
- #33537: fix(activation-rail): de-duplicate the four-surface list in Moment 2 Propose

Closes JARVIS-1123

Part of plan: moment-2-infer-shift.md