### PR TITLE
fix(gateway): honor trustProxy in the loopback auth fallback

### DIFF
--- a/gateway/src/__tests__/auth-token-trust-proxy.test.ts
+++ b/gateway/src/__tests__/auth-token-trust-proxy.test.ts
@@ -65,6 +65,20 @@ describe("handleCreateToken — trustProxy loopback gate", () => {
     expect(res.status).toBe(401);
   });
 
+  test("trustProxy=true: direct non-loopback peer cannot spoof XFF=127.0.0.1 → 403", async () => {
+    // Raw socket peer is NOT loopback (e.g. gateway port exposed directly), so
+    // X-Forwarded-For is not trusted and the loopback gate rejects.
+    const res = await handleCreateToken(
+      makeReq({
+        "x-forwarded-for": "127.0.0.1",
+        origin: LOOPBACK_ORIGIN,
+      }),
+      makeLoopbackServer("203.0.113.9"),
+      true,
+    );
+    expect(res.status).toBe(403);
+  });
+
   test("trustProxy=false (default): X-Forwarded-For is ignored, loopback socket passes the gate → reaches 401", async () => {
     const res = await handleCreateToken(
       makeReq({

--- a/gateway/src/__tests__/auth-token-trust-proxy.test.ts
+++ b/gateway/src/__tests__/auth-token-trust-proxy.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Tests for `handleCreateToken` (`POST /auth/token`) loopback gating under
+ * `trustProxy`.
+ *
+ * The endpoint is loopback-only. A same-host reverse proxy / tunnel always
+ * connects over 127.0.0.1, so without trustProxy a proxied REMOTE caller would
+ * pass the loopback gate. With trustProxy the gate judges by the real client IP
+ * (first X-Forwarded-For entry). trustProxy defaults false, so direct-loopback
+ * callers are unaffected.
+ *
+ * To distinguish "rejected at the loopback gate" (403) from "passed the
+ * loopback gate" we give requests that should proceed a valid same-origin
+ * `Origin` and no `Authorization`, so they fall through to the 401
+ * missing-Authorization check — proving they got past the loopback gate.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import "./test-preload.js";
+import { handleCreateToken } from "../http/routes/auth-token.js";
+
+// No module mocks: every case below stops at the loopback gate (403) or the
+// missing-Authorization gate (401) before any token verification / guardian
+// binding runs, so the real modules are never exercised at runtime. (Avoid
+// `mock.module` here — it is process-global in bun and would leak into other
+// test files in the same run.)
+
+const LOOPBACK_ORIGIN = "http://localhost:5173";
+
+function makeReq(headers: Record<string, string> = {}): Request {
+  return new Request("http://gateway.local/auth/token", {
+    method: "POST",
+    headers,
+  });
+}
+
+/** A server whose raw TCP peer is loopback (the same-host proxy case). */
+function makeLoopbackServer(address = "127.0.0.1") {
+  return {
+    requestIP: () => ({ address, port: 12345 }),
+  } as never;
+}
+
+describe("handleCreateToken — trustProxy loopback gate", () => {
+  test("trustProxy=true: proxied remote caller (XFF non-loopback) is rejected at the loopback gate → 403", async () => {
+    const res = await handleCreateToken(
+      makeReq({
+        "x-forwarded-for": "203.0.113.5",
+        origin: LOOPBACK_ORIGIN,
+      }),
+      makeLoopbackServer(),
+      true,
+    );
+    expect(res.status).toBe(403);
+  });
+
+  test("trustProxy=true: direct-local caller (no XFF) passes the loopback gate → reaches 401 missing-Authorization", async () => {
+    const res = await handleCreateToken(
+      makeReq({ origin: LOOPBACK_ORIGIN }),
+      makeLoopbackServer(),
+      true,
+    );
+    // Past the loopback gate (would be 403 otherwise) and past the Origin check,
+    // it stops at the missing Authorization header.
+    expect(res.status).toBe(401);
+  });
+
+  test("trustProxy=false (default): X-Forwarded-For is ignored, loopback socket passes the gate → reaches 401", async () => {
+    const res = await handleCreateToken(
+      makeReq({
+        "x-forwarded-for": "203.0.113.5",
+        origin: LOOPBACK_ORIGIN,
+      }),
+      makeLoopbackServer(),
+      false,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  test("trustProxy omitted defaults to false (X-Forwarded-For ignored) → reaches 401", async () => {
+    const res = await handleCreateToken(
+      makeReq({
+        "x-forwarded-for": "203.0.113.5",
+        origin: LOOPBACK_ORIGIN,
+      }),
+      makeLoopbackServer(),
+    );
+    expect(res.status).toBe(401);
+  });
+});

--- a/gateway/src/__tests__/edge-auth.test.ts
+++ b/gateway/src/__tests__/edge-auth.test.ts
@@ -448,6 +448,17 @@ describe("requireEdgeAuth — trustProxy loopback fallback", () => {
     expect(res).toBeNull();
   });
 
+  test("trustProxy=true: direct non-loopback peer cannot spoof XFF=127.0.0.1 → 401", async () => {
+    // Raw socket peer is NOT loopback (e.g. gateway port exposed directly), so
+    // X-Forwarded-For is not trusted and the fallback is refused.
+    const { requireEdgeAuth } = makeMiddleware(true);
+    const res = await requireEdgeAuth(
+      makeReq({ "x-forwarded-for": "127.0.0.1" }),
+      makeLoopbackServer("203.0.113.9"),
+    );
+    expect(res?.status).toBe(401);
+  });
+
   test("trustProxy=false (default): X-Forwarded-For is ignored, loopback socket still gets the fallback → null", async () => {
     const { requireEdgeAuth } = makeMiddleware(false);
     const res = await requireEdgeAuth(

--- a/gateway/src/__tests__/edge-auth.test.ts
+++ b/gateway/src/__tests__/edge-auth.test.ts
@@ -48,9 +48,9 @@ const { createAuthMiddleware, loopbackFallbackCountTracker } =
 
 const PLATFORM_USER_ID = "user-abc-123";
 
-function makeMiddleware() {
+function makeMiddleware(trustProxy = false) {
   const rl = new AuthRateLimiter();
-  return createAuthMiddleware(rl, () => "1.2.3.4");
+  return createAuthMiddleware(rl, () => "1.2.3.4", trustProxy);
 }
 
 function makeReq(headers: Record<string, string> = {}): Request {
@@ -408,6 +408,62 @@ describe("requireEdgeAuthWithScope — JWT mode", () => {
   test("401 when bearer token missing", async () => {
     const { requireEdgeAuthWithScope } = makeMiddleware();
     const res = await requireEdgeAuthWithScope(makeReq(), "chat.write");
+    expect(res?.status).toBe(401);
+  });
+});
+
+// =========================================================================
+// Loopback fallback + trustProxy — proxied-remote vs direct-local
+//
+// A same-host reverse proxy / tunnel always connects over 127.0.0.1, so the
+// raw socket peer is loopback for every forwarded request. trustProxy tells the
+// guard to judge by the real client IP (first X-Forwarded-For entry) instead,
+// which closes the loopback grace period for proxied REMOTE callers while
+// keeping it for genuinely-local clients (no X-Forwarded-For). trustProxy
+// defaults false, so existing deployments are unaffected.
+// =========================================================================
+
+describe("requireEdgeAuth — trustProxy loopback fallback", () => {
+  test("trustProxy=true: proxied remote caller (XFF non-loopback) is NOT granted the fallback → 401", async () => {
+    const { requireEdgeAuth } = makeMiddleware(true);
+    const res = await requireEdgeAuth(
+      makeReq({ "x-forwarded-for": "203.0.113.5" }),
+      makeLoopbackServer(),
+    );
+    expect(res?.status).toBe(401);
+  });
+
+  test("trustProxy=true: direct-local caller (no XFF, loopback socket) still gets the fallback → null", async () => {
+    const { requireEdgeAuth } = makeMiddleware(true);
+    const res = await requireEdgeAuth(makeReq(), makeLoopbackServer());
+    expect(res).toBeNull();
+  });
+
+  test("trustProxy=true: caller proxied from localhost (XFF=127.0.0.1) still gets the fallback → null", async () => {
+    const { requireEdgeAuth } = makeMiddleware(true);
+    const res = await requireEdgeAuth(
+      makeReq({ "x-forwarded-for": "127.0.0.1" }),
+      makeLoopbackServer(),
+    );
+    expect(res).toBeNull();
+  });
+
+  test("trustProxy=false (default): X-Forwarded-For is ignored, loopback socket still gets the fallback → null", async () => {
+    const { requireEdgeAuth } = makeMiddleware(false);
+    const res = await requireEdgeAuth(
+      makeReq({ "x-forwarded-for": "203.0.113.5" }),
+      makeLoopbackServer(),
+    );
+    expect(res).toBeNull();
+  });
+
+  test("platform bypass short-circuits before the fallback regardless of trustProxy", async () => {
+    process.env.DISABLE_HTTP_AUTH = "true";
+    process.env.IS_PLATFORM = "true";
+    const { requireEdgeAuth } = makeMiddleware(true);
+    // Missing X-Vellum-User-Id, loopback socket, trustProxy on: still the
+    // platform 401 (missing user header), NOT a loopback free pass.
+    const res = await requireEdgeAuth(makeReq(), makeLoopbackServer());
     expect(res?.status).toBe(401);
   });
 });

--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -139,9 +139,13 @@ export function loadConfig(): GatewayConfig {
   // from X-Forwarded-For for logging and rate limiting instead of the proxy's
   // loopback socket address. Defaults OFF — it must be explicitly opted into,
   // and only behind a proxy that overwrites client-supplied X-Forwarded-For.
-  // NOTE: loopback-only endpoint guards do NOT rely on this flag (or on the
-  // spoofable X-Forwarded-For); they use the unspoofable edge marker — see
-  // gateway/src/http/edge-forwarded-header.ts.
+  // The loopback auth fallback (allowLegacyLoopbackFallback) and the
+  // /auth/token loopback gate also honor this flag via isLoopbackPeer, so a
+  // proxied remote caller is judged by its real X-Forwarded-For IP rather than
+  // the proxy's loopback socket (X-Forwarded-For is only trusted when the raw
+  // peer is itself loopback). The strictly loopback-only mint endpoints
+  // (/v1/guardian/init, /v1/pair) do NOT rely on this flag — they use the
+  // unspoofable edge marker, see gateway/src/http/edge-forwarded-header.ts.
   const trustProxy =
     process.env.GATEWAY_TRUST_PROXY !== undefined
       ? process.env.GATEWAY_TRUST_PROXY === "true" ||

--- a/gateway/src/http/middleware/auth.ts
+++ b/gateway/src/http/middleware/auth.ts
@@ -105,6 +105,7 @@ export function logAuthBypassState(): void {
 export function createAuthMiddleware(
   authRateLimiter: AuthRateLimiter,
   getClientIp: GetClientIp,
+  trustProxy = false,
 ) {
   /**
    * Cross-check `X-Vellum-User-Id` against the stored
@@ -372,7 +373,13 @@ export function createAuthMiddleware(
     guard: string,
     extra?: Record<string, unknown>,
   ): boolean {
-    if (!server || !isLoopbackPeer(server, req)) return false;
+    // When a trusted reverse proxy is declared, judge loopback-ness by the
+    // real client IP (first X-Forwarded-For entry) rather than the raw socket
+    // peer. A same-host proxy/tunnel always connects over 127.0.0.1, so without
+    // this a proxied remote caller would be misclassified as local and granted
+    // the loopback grace period. trustProxy defaults false, so direct-loopback
+    // local clients (no X-Forwarded-For) are unaffected. See is-loopback-address.ts.
+    if (!server || !isLoopbackPeer(server, req, { trustProxy })) return false;
 
     const path = new URL(req.url).pathname;
     const failureKind =

--- a/gateway/src/http/router.ts
+++ b/gateway/src/http/router.ts
@@ -69,6 +69,12 @@ export interface RouteDefinition {
 
 export interface RouterDeps {
   authRateLimiter: AuthRateLimiter;
+  /**
+   * When true, a trusted reverse proxy is declared in front of the gateway, so
+   * the loopback auth fallback judges callers by the real client IP from
+   * X-Forwarded-For instead of the raw socket peer. Defaults to false.
+   */
+  trustProxy?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -91,7 +97,7 @@ export function createRouter(
   getClientIp: GetClientIp,
   server?: Server<unknown>,
 ) => Promise<Response | null> {
-  const { authRateLimiter } = deps;
+  const { authRateLimiter, trustProxy = false } = deps;
 
   return async (
     req: Request,
@@ -120,6 +126,7 @@ export function createRouter(
           const { requireEdgeAuth } = createAuthMiddleware(
             authRateLimiter,
             getClientIp,
+            trustProxy,
           );
           const authError = await requireEdgeAuth(req, server);
           if (authError) return authError;
@@ -130,6 +137,7 @@ export function createRouter(
           const { requireEdgeAuthWithScope } = createAuthMiddleware(
             authRateLimiter,
             getClientIp,
+            trustProxy,
           );
           const authError = await requireEdgeAuthWithScope(
             req,
@@ -144,6 +152,7 @@ export function createRouter(
           const { requireEdgeGuardianAuth } = createAuthMiddleware(
             authRateLimiter,
             getClientIp,
+            trustProxy,
           );
           const authError = await requireEdgeGuardianAuth(req, server);
           if (authError) return authError;

--- a/gateway/src/http/routes/auth-token.ts
+++ b/gateway/src/http/routes/auth-token.ts
@@ -16,8 +16,13 @@ const TOKEN_TTL_SECONDS = 30 * 24 * 60 * 60;
 export async function handleCreateToken(
   req: Request,
   server: Server<unknown> | undefined,
+  trustProxy = false,
 ): Promise<Response> {
-  if (!server || !isLoopbackPeer(server, req)) {
+  // With a trusted reverse proxy declared, judge loopback-ness by the real
+  // client IP (first X-Forwarded-For entry) rather than the raw socket peer,
+  // which is always 127.0.0.1 behind a same-host proxy/tunnel. Defaults false,
+  // so direct-loopback callers are unaffected.
+  if (!server || !isLoopbackPeer(server, req, { trustProxy })) {
     log.warn("Token create rejected: not a loopback peer");
     return Response.json({ error: "Forbidden" }, { status: 403 });
   }

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1518,7 +1518,7 @@ async function main() {
     path: "/auth/token",
     method: "POST",
     auth: "custom",
-    handler: (req) => handleCreateToken(req, server),
+    handler: (req) => handleCreateToken(req, server, config.trustProxy),
   });
 
   // Runtime proxy catch-all — must be last so specific routes are checked first.
@@ -1531,6 +1531,7 @@ async function main() {
 
   const router = createRouter(routes, {
     authRateLimiter,
+    trustProxy: config.trustProxy,
   });
 
   /** Stamp the assistant version header on a response. */

--- a/gateway/src/util/is-loopback-address.ts
+++ b/gateway/src/util/is-loopback-address.ts
@@ -3,26 +3,37 @@ import type { Server } from "bun";
 /**
  * Check whether the TCP peer of a Bun HTTP request is a loopback address.
  *
- * When `trustProxy` is set, the first entry in `X-Forwarded-For` is used
- * instead of the raw socket IP.
+ * When `trustProxy` is set, `X-Forwarded-For` is consulted to recover the real
+ * client behind a trusted reverse proxy — but ONLY when the raw socket peer is
+ * itself loopback (i.e. the request actually arrived over the same-host proxy
+ * hop). A direct connection from a non-loopback peer is never treated as
+ * loopback, so a remote caller hitting a directly-exposed gateway port cannot
+ * spoof `X-Forwarded-For: 127.0.0.1` to pass a loopback gate. (This assumes the
+ * proxy overwrites client-supplied X-Forwarded-For, which is the documented
+ * requirement for enabling trustProxy.)
  */
 export function isLoopbackPeer(
   server: Server<unknown>,
   req: Request,
   opts?: { trustProxy?: boolean },
 ): boolean {
+  const peer = server.requestIP(req);
+  const peerIsLoopback = peer ? isLoopbackAddress(peer.address) : false;
+
   if (opts?.trustProxy) {
+    // Direct (non-proxied) connection — don't trust X-Forwarded-For at all.
+    if (!peerIsLoopback) return false;
     const forwarded = req.headers.get("x-forwarded-for");
     if (forwarded) {
       const first = forwarded.split(",")[0]?.trim();
       if (!first) return false;
       return isLoopbackAddress(first);
     }
+    // Loopback socket, no X-Forwarded-For → a genuinely local direct client.
+    return true;
   }
 
-  const peer = server.requestIP(req);
-  if (!peer) return false;
-  return isLoopbackAddress(peer.address);
+  return peerIsLoopback;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Thread `config.trustProxy` into the legacy loopback auth fallback (`allowLegacyLoopbackFallback`) and the `/auth/token` loopback gate, so they call `isLoopbackPeer(server, req, { trustProxy })` and judge callers by the real client IP (first `X-Forwarded-For` entry) instead of the raw socket peer when a trusted reverse proxy is declared.
- Closes the gap where a same-host nginx/tunnel (always connecting over `127.0.0.1`) granted the loopback grace period to proxied **remote** callers across the ~100 `edge`/`edge-scoped`/`edge-guardian` routes and `/auth/token` — even with `GATEWAY_TRUST_PROXY=true`, which previously had no effect on these paths.
- **Default-off and backward compatible:** `trustProxy` defaults false, so existing deployments are byte-for-byte unchanged. Even when on, direct-loopback local clients (no `X-Forwarded-For`) still get the fallback, and platform-managed deployments are unaffected because the platform bypass short-circuits before the fallback.
- Adds regression tests: proxied-remote → denied, direct-local → fallback, `X-Forwarded-For: 127.0.0.1` → fallback, default-ignores-XFF, and platform-bypass-precedence.

## Original prompt
While designing public ingress for a self-hosted assistant on a GCP VM (nginx/tunnel → gateway, accessed via the Vellum CLI), we found the loopback auth fallback — an intentional migration grace period instrumented by the auth-fallback telemetry — keys on the raw TCP peer. Because a same-host proxy collapses every remote request to `127.0.0.1`, the fallback would serve edge routes and `/auth/token` unauthenticated over a tunnel, and `GATEWAY_TRUST_PROXY=true` did nothing because `trustProxy` was never passed to the loopback check. This wires `trustProxy` through so the documented "trustProxy makes a bearer token mandatory over a proxy" behavior actually holds, without removing the grace period for genuinely-local clients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)