### PR TITLE
fix(electron): default VELLUM_ENVIRONMENT to local when vel up is detected

### DIFF
--- a/apps/macos/scripts/dev.ts
+++ b/apps/macos/scripts/dev.ts
@@ -52,13 +52,19 @@ async function isVelUp(): Promise<boolean> {
 
 const velRunning = await isVelUp();
 const downstreamScript = velRunning ? "dev:electron-only" : "dev:standalone";
+
+// Match the native Swift app's default of "local" when vel up is running.
 const env: NodeJS.ProcessEnv = velRunning
-  ? { ...process.env, VELLUM_DEV_URL: VEL_RENDERER_URL }
+  ? {
+      ...process.env,
+      VELLUM_DEV_URL: VEL_RENDERER_URL,
+      VELLUM_ENVIRONMENT: process.env.VELLUM_ENVIRONMENT || "local",
+    }
   : process.env;
 
 if (velRunning) {
   console.log(
-    `[dev] detected vel up at ${VEL_EDGE_PROXY_ORIGIN} — attaching Electron to ${VEL_RENDERER_URL}`,
+    `[dev] detected vel up at ${VEL_EDGE_PROXY_ORIGIN} — attaching Electron to ${VEL_RENDERER_URL} (env: ${env.VELLUM_ENVIRONMENT})`,
   );
 } else {
   console.log(


### PR DESCRIPTION
## Summary

- When `vel up` is detected, the Electron dev launcher now sets `VELLUM_ENVIRONMENT=local` unless the user has explicitly exported a different value — matching the native Swift app's compile-time default under `vel up`.
- The resolved environment is logged at startup so mismatches are immediately visible.

## Original prompt

LUM-2238 reported that the Electron app and native Swift app silently disagree on `VELLUM_ENVIRONMENT`: native bakes `local` at compile time under `vel up`, while Electron inherits whatever the shell exports (often `production`). This caused confusing guardian-token 404s. The fix makes the dev launcher default to `local` when `vel up` is running, preserving explicit overrides.

## Test plan

- [ ] Run `bun run dev` with `vel up` running and no `VELLUM_ENVIRONMENT` set — confirm log shows `(env: local)`
- [ ] Run `VELLUM_ENVIRONMENT=staging bun run dev` with `vel up` — confirm log shows `(env: staging)`
- [ ] Run `bun run dev` without `vel up` — confirm standalone mode, no environment override

🤖 Generated with [Claude Code](https://claude.com/claude-code)