### PR TITLE
feat(calls): drive all setup sub-flows over media-stream transport

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -2418,6 +2418,30 @@ describe("call-controller", () => {
     controller.destroy();
   });
 
+  test("silence timeout suppressed via explicit setGuardianWaitActive signal (transport state stays connected)", async () => {
+    mockSilenceTimeoutMs = 20; // Short timeout for testing
+    const { relay, controller } = setupController();
+
+    // Drive the controller-owned wait signal directly. The transport's
+    // connection state remains "connected" — proving the suppression honors
+    // the explicit signal rather than transport-derived state (the media-stream
+    // transport can only report connected/closed).
+    expect(relay.mockConnectionState).toBe("connected");
+    controller.setGuardianWaitActive(true);
+
+    // Wait for the silence timeout to fire
+    await new Promise((r) => setTimeout(r, 30));
+
+    // "Are you still there?" should NOT have been sent while the wait signal
+    // is active.
+    expect(
+      relay.sentTokens.filter((t) => t.token.includes("Are you still there?"))
+        .length,
+    ).toBe(0);
+
+    controller.destroy();
+  });
+
   test("silence timeout suppressed during in-call guardian consultation (pendingGuardianInput)", async () => {
     mockSilenceTimeoutMs = 20; // Short timeout for testing
     mockConsultationTimeoutMs = 10_000; // Long enough to not interfere

--- a/assistant/src/__tests__/media-stream-server-integration.test.ts
+++ b/assistant/src/__tests__/media-stream-server-integration.test.ts
@@ -1336,6 +1336,139 @@ describe("media-stream setup outcome scenarios", () => {
       expect(finalizeCall).toHaveBeenCalledWith("call-unver-1", "conv-unver-1");
     });
 
+    test("flow-finalized ended outcome (unverified) finalizes EXACTLY ONCE", async () => {
+      // The unverified-caller path finalizes itself from inside CallSetupFlow
+      // (finalizeFailedAccessRequest → injected finalizeFailedCall →
+      // finalizeFailedSetup → runFinalizationAndGrantCleanup → finalizeCall).
+      // It then resolves `ended`, and the ended branch of handleSetupComplete
+      // must NOT finalize again — otherwise a second completion message would
+      // be persisted and a second completion notifier fired. finalizeCall does
+      // both, so a single invocation proves a single message + single notifier.
+      mockRouteSetupResult = {
+        outcome: {
+          action: "unverified_caller",
+          displayName: "Jordan",
+          isGuardian: false,
+        },
+        resolved: {
+          assistantId: "self",
+          isInbound: true,
+          otherPartyNumber: "+15555550142",
+          actorTrust: { trustClass: "unknown", memberRecord: null },
+        },
+      };
+
+      startSessionWithOutcome("call-once-1", {
+        conversationId: "conv-once-1",
+        status: "initiated",
+        task: null,
+        startedAt: null,
+        fromNumber: "+15555550142",
+        toNumber: "+15555550143",
+      });
+      await flushMicrotasks();
+
+      expect(finalizeCall).toHaveBeenCalledTimes(1);
+      expect(finalizeCall).toHaveBeenCalledWith("call-once-1", "conv-once-1");
+    });
+
+    test("guardian denial ended outcome finalizes EXACTLY ONCE", async () => {
+      // Guardian denial finalizes itself inside the flow
+      // (handleAccessRequestDenied → finalizeFailedAccessRequest →
+      // finalizeFailedCall) before resolving `ended`; the ended branch must
+      // skip re-finalizing the already-terminal session.
+      mockRouteSetupResult = {
+        outcome: {
+          action: "name_capture",
+          assistantId: "self",
+          fromNumber: "+15555550142",
+        },
+        resolved: {
+          assistantId: "self",
+          isInbound: true,
+          otherPartyNumber: "+15555550142",
+          actorTrust: { trustClass: "unknown", memberRecord: null },
+        },
+      };
+      mockNotifyResult = { notified: true, requestId: "access-req-1" };
+      mockCanonicalRequestStatus = "denied";
+
+      startSessionWithOutcome("call-deny-once-1", {
+        conversationId: "conv-deny-once-1",
+        status: "initiated",
+        task: null,
+        startedAt: null,
+        fromNumber: "+15555550142",
+        toNumber: "+15555550143",
+      });
+
+      // Caller speaks name → access request opened → guardian wait → first poll
+      // resolves "denied".
+      lastSttCallbacks.onTranscriptFinal?.("Sam Rivera", 1200);
+      jest.advanceTimersByTime(60_000);
+      await flushMicrotasks();
+
+      expect(registerCallController).not.toHaveBeenCalled();
+      expect(finalizeCall).toHaveBeenCalledTimes(1);
+      expect(finalizeCall).toHaveBeenCalledWith(
+        "call-deny-once-1",
+        "conv-deny-once-1",
+      );
+    });
+
+    test("guardian approval restores session status to in_progress", async () => {
+      // Name-capture enters the guardian wait via markWaitingOnUser
+      // (session → waiting_on_user). On approval the flow resolves
+      // proceed-handoff-spoken and the controller is created; the session must
+      // be restored to in_progress (matching relay-server) rather than left
+      // parked in waiting_on_user for the rest of the connected call.
+      mockRouteSetupResult = {
+        outcome: {
+          action: "name_capture",
+          assistantId: "self",
+          fromNumber: "+15555550142",
+        },
+        resolved: {
+          assistantId: "self",
+          isInbound: true,
+          otherPartyNumber: "+15555550142",
+          actorTrust: { trustClass: "unknown", memberRecord: null },
+        },
+      };
+      mockNotifyResult = { notified: true, requestId: "access-req-1" };
+      mockCanonicalRequestStatus = "approved";
+
+      startSessionWithOutcome("call-approve-1", {
+        conversationId: "conv-approve-1",
+        status: "initiated",
+        task: null,
+        startedAt: null,
+        fromNumber: "+15555550142",
+        toNumber: "+15555550143",
+      });
+
+      // Caller speaks name → access request → guardian wait → markWaitingOnUser
+      // drives the session to waiting_on_user.
+      lastSttCallbacks.onTranscriptFinal?.("Sam Rivera", 1200);
+      expect(mockSessions.get("call-approve-1")?.status).toBe(
+        "waiting_on_user",
+      );
+
+      // First poll resolves "approved" → proceed-handoff-spoken → controller.
+      jest.advanceTimersByTime(60_000);
+      await flushMicrotasks();
+
+      expect(registerCallController).toHaveBeenCalledWith(
+        "call-approve-1",
+        expect.anything(),
+      );
+      // The fix: restored to in_progress when the controller is created.
+      expect(updateCallSession).toHaveBeenCalledWith("call-approve-1", {
+        status: "in_progress",
+      });
+      expect(mockSessions.get("call-approve-1")?.status).toBe("in_progress");
+    });
+
     test("dispose() on transport close tears down an in-flight setup flow", () => {
       mockRouteSetupResult = {
         outcome: {

--- a/assistant/src/__tests__/media-stream-server-integration.test.ts
+++ b/assistant/src/__tests__/media-stream-server-integration.test.ts
@@ -227,6 +227,85 @@ mock.module("../calls/resolve-call-tts-provider.js", () => ({
   })),
 }));
 
+// Mock the verification/invite primitives the setup flow consumes so the
+// integration test can drive deterministic success/failure outcomes without a
+// live channel/invite store.
+let mockVerificationResult: unknown = {
+  outcome: "success",
+  eventName: "voice_verification_succeeded",
+  verificationType: "guardian",
+};
+let mockInviteResult: unknown = {
+  outcome: "success",
+  memberId: "member-1",
+  type: "trusted_contact",
+};
+mock.module("../calls/relay-verification.js", () => ({
+  parseDigitsFromSpeech: jest.fn((t: string) => t.replace(/\D/g, "")),
+  attemptVerificationCode: jest.fn(() => mockVerificationResult),
+  attemptInviteCodeRedemption: jest.fn(() => mockInviteResult),
+}));
+
+// Mock the access-request helper so name-capture opens a deterministic request.
+let mockNotifyResult: {
+  notified: boolean;
+  requestId?: string;
+  reason?: string;
+} = { notified: true, requestId: "access-req-1" };
+mock.module("../runtime/access-request-helper.js", () => ({
+  notifyGuardianOfAccessRequest: jest.fn(() => mockNotifyResult),
+}));
+
+// Mock the canonical guardian store (polled by the real GuardianWaitController).
+let mockCanonicalRequestStatus: "pending" | "approved" | "denied" = "pending";
+mock.module("../memory/canonical-guardian-store.js", () => ({
+  getCanonicalGuardianRequest: jest.fn(() => ({
+    id: "access-req-1",
+    status: mockCanonicalRequestStatus,
+  })),
+}));
+
+// Mock label/persona resolution used by the setup-flow copy deps.
+mock.module("../contacts/contact-store.js", () => ({
+  findGuardianForChannel: jest.fn(() => null),
+  listGuardianChannels: jest.fn(() => null),
+}));
+mock.module("../daemon/identity-helpers.js", () => ({
+  getAssistantName: jest.fn(() => "Aria"),
+}));
+mock.module("../prompts/user-reference.js", () => ({
+  resolveGuardianName: jest.fn(
+    (displayName?: string) => displayName ?? "your contact",
+  ),
+}));
+
+// Mock conversation-crud (callee-verification code post).
+mock.module("../memory/conversation-crud.js", () => ({
+  addMessage: jest.fn(async () => {}),
+}));
+
+// Capture the most-recently-constructed STT session's callbacks so tests can
+// fire transcript/DTMF events directly (driving real audio through the turn
+// detector + a transcriber is impractical under fake timers). The real STT
+// session is exercised by media-stream-stt-session.test.ts; here we only need
+// the callback wiring into MediaStreamCallSession.
+let lastSttCallbacks: {
+  onSpeechStart?: () => void;
+  onTranscriptFinal?: (text: string, durationMs: number) => void;
+  onDtmf?: (digit: string) => void;
+  onStop?: () => void;
+  onError?: (category: string, message: string) => void;
+} = {};
+mock.module("../calls/media-stream-stt-session.js", () => ({
+  MediaStreamSttSession: jest.fn().mockImplementation((_config, callbacks) => {
+    lastSttCallbacks = callbacks ?? {};
+    return {
+      handleMessage: jest.fn(),
+      dispose: jest.fn(),
+    };
+  }),
+}));
+
 // ---------------------------------------------------------------------------
 // Now import the module under test.
 // ---------------------------------------------------------------------------
@@ -377,6 +456,18 @@ beforeEach(() => {
   (finalizeCall as jest.Mock).mockClear();
   (speakSystemPrompt as jest.Mock).mockClear();
   mockCredentialReadiness = { status: "ready" };
+  mockVerificationResult = {
+    outcome: "success",
+    eventName: "voice_verification_succeeded",
+    verificationType: "guardian",
+  };
+  mockInviteResult = {
+    outcome: "success",
+    memberId: "member-1",
+    type: "trusted_contact",
+  };
+  mockNotifyResult = { notified: true, requestId: "access-req-1" };
+  mockCanonicalRequestStatus = "pending";
   // Reset routeSetup to default normal_call
   mockRouteSetupResult = {
     outcome: { action: "normal_call" as const, isInbound: true },
@@ -871,13 +962,25 @@ describe("activeMediaStreamSessions registry", () => {
 // ---------------------------------------------------------------------------
 // Scenario-driven setup outcome coverage
 // ---------------------------------------------------------------------------
-// These tests exercise the deny and unsupported-action branches in
-// MediaStreamCallSession.handleStart by overriding mockRouteSetupResult
-// before sending a start message.
+// These tests drive each routeSetup outcome through the live CallSetupFlow
+// over the media-stream output transport, asserting the correct controller
+// creation / opener selection / teardown for every continuation.
+
+/** Register a session row and start a media-stream session for an outcome. */
+function startSessionWithOutcome(
+  callSessionId: string,
+  sessionRow: Record<string, unknown>,
+): { session: MediaStreamCallSession; ws: ReturnType<typeof createMockWs> } {
+  const ws = createMockWs();
+  mockSessions.set(callSessionId, { id: callSessionId, ...sessionRow });
+  const session = new MediaStreamCallSession(ws.ws, callSessionId);
+  session.handleMessage(makeStartMessage());
+  return { session, ws };
+}
 
 describe("media-stream setup outcome scenarios", () => {
   describe("deny outcome", () => {
-    test("deny outcome records inbound_acl_denied event and sets status to failed", () => {
+    test("deny outcome records inbound_acl_denied event and sets status to failed", async () => {
       mockRouteSetupResult = {
         outcome: {
           action: "deny",
@@ -900,22 +1003,23 @@ describe("media-stream setup outcome scenarios", () => {
         task: null,
         startedAt: null,
         fromNumber: "+15559998888",
-        toNumber: "+15550001111",
+        toNumber: "+15555550143",
       });
 
       const session = new MediaStreamCallSession(mockWs.ws, "call-deny-1");
       session.handleMessage(makeStartMessage());
+      await flushMicrotasks();
 
-      // Should record an inbound_acl_denied event
+      // Should record an inbound_acl_denied event (flow records logReason)
       expect(recordCallEvent).toHaveBeenCalledWith(
         "call-deny-1",
         "inbound_acl_denied",
         expect.objectContaining({
-          from: "+15559998888",
+          logReason: "Inbound voice ACL: blocked caller",
         }),
       );
 
-      // Should update session to failed
+      // The terminal `ended` continuation marks the session failed.
       expect(updateCallSession).toHaveBeenCalledWith(
         "call-deny-1",
         expect.objectContaining({
@@ -924,7 +1028,8 @@ describe("media-stream setup outcome scenarios", () => {
         }),
       );
 
-      // Should NOT register a controller (deny path skips it)
+      // Should NOT register a controller (deny path resolves `ended`, no
+      // controller is created)
       expect(registerCallController).not.toHaveBeenCalled();
     });
 
@@ -951,7 +1056,7 @@ describe("media-stream setup outcome scenarios", () => {
         task: null,
         startedAt: null,
         fromNumber: "+15559998888",
-        toNumber: "+15550001111",
+        toNumber: "+15555550143",
       });
 
       const session = new MediaStreamCallSession(
@@ -967,7 +1072,7 @@ describe("media-stream setup outcome scenarios", () => {
       );
     });
 
-    test("deny outcome runs finalization", () => {
+    test("deny outcome runs finalization", async () => {
       mockRouteSetupResult = {
         outcome: {
           action: "deny",
@@ -990,7 +1095,7 @@ describe("media-stream setup outcome scenarios", () => {
         task: null,
         startedAt: null,
         fromNumber: "+15559998888",
-        toNumber: "+15550001111",
+        toNumber: "+15555550143",
       });
 
       const session = new MediaStreamCallSession(
@@ -998,8 +1103,10 @@ describe("media-stream setup outcome scenarios", () => {
         "call-deny-finalize-1",
       );
       session.handleMessage(makeStartMessage());
+      await flushMicrotasks();
 
-      // finalizeCall should be called because early teardown runs it inline
+      // finalizeCall should be called because the terminal `ended` continuation
+      // runs it inline
       expect(finalizeCall).toHaveBeenCalledWith(
         "call-deny-finalize-1",
         "conv-deny-finalize-1",
@@ -1007,108 +1114,105 @@ describe("media-stream setup outcome scenarios", () => {
     });
   });
 
-  describe("unsupported interactive setup flow", () => {
-    test("verification outcome records call_failed with preflight-bypass reason", () => {
+  describe("interactive setup flows reach the controller with the right opener", () => {
+    test("inbound guardian verification: DTMF code success greets normally", async () => {
       mockRouteSetupResult = {
         outcome: {
           action: "verification",
           assistantId: "self",
-          fromNumber: "+14155551234",
+          fromNumber: "+15555550142",
         },
         resolved: {
           assistantId: "self",
           isInbound: true,
-          otherPartyNumber: "+14155551234",
+          otherPartyNumber: "+15555550142",
           actorTrust: { trustClass: "unknown", memberRecord: null },
         },
       };
+      mockVerificationResult = {
+        outcome: "success",
+        eventName: "voice_verification_succeeded",
+        verificationType: "guardian",
+      };
 
-      const mockWs = createMockWs();
-      mockSessions.set("call-unsup-verify-1", {
-        id: "call-unsup-verify-1",
-        conversationId: "conv-unsup-verify-1",
+      startSessionWithOutcome("call-verify-1", {
+        conversationId: "conv-verify-1",
         status: "initiated",
         task: null,
         startedAt: null,
-        fromNumber: "+14155551234",
-        toNumber: "+15550001111",
+        fromNumber: "+15555550142",
+        toNumber: "+15555550143",
       });
 
-      const session = new MediaStreamCallSession(
-        mockWs.ws,
-        "call-unsup-verify-1",
-      );
-      session.handleMessage(makeStartMessage());
-
-      // Should record call_failed event with preflight-bypass note
-      expect(recordCallEvent).toHaveBeenCalledWith(
-        "call-unsup-verify-1",
-        "call_failed",
-        expect.objectContaining({
-          reason: expect.stringContaining("verification"),
-          transport: "media-stream",
-        }),
-      );
-
-      // Should set session status to failed
-      expect(updateCallSession).toHaveBeenCalledWith(
-        "call-unsup-verify-1",
-        expect.objectContaining({
-          status: "failed",
-          lastError: expect.stringContaining("preflight guard"),
-        }),
-      );
-
-      // Should NOT register a controller
+      // No controller yet — setup flow is collecting the code.
       expect(registerCallController).not.toHaveBeenCalled();
+
+      // Drive a full 6-digit code over DTMF frames; the flow consumes it,
+      // verifies, and resolves proceed-initial-greeting.
+      for (const digit of ["1", "2", "3", "4", "5", "6"]) {
+        lastSttCallbacks.onDtmf?.(digit);
+      }
+      await flushMicrotasks();
+
+      // The controller is now created and the normal greeting fired (after the
+      // credential preflight resolves).
+      expect(registerCallController).toHaveBeenCalledWith(
+        "call-verify-1",
+        expect.anything(),
+      );
+      await flushMicrotasks();
+      expect(mockStartInitialGreeting).toHaveBeenCalled();
     });
 
-    test("name_capture outcome speaks generic apology and tears down", () => {
+    test("inbound invite redemption: DTMF code success uses the handoff opener", async () => {
       mockRouteSetupResult = {
         outcome: {
-          action: "name_capture",
+          action: "invite_redemption",
           assistantId: "self",
-          fromNumber: "+14155551234",
+          fromNumber: "+15555550142",
+          friendName: "Sam",
+          guardianName: "Alex",
         },
         resolved: {
           assistantId: "self",
           isInbound: true,
-          otherPartyNumber: "+14155551234",
+          otherPartyNumber: "+15555550142",
           actorTrust: { trustClass: "unknown", memberRecord: null },
         },
       };
+      mockInviteResult = {
+        outcome: "success",
+        memberId: "member-1",
+        type: "trusted_contact",
+      };
 
-      const mockWs = createMockWs();
-      mockSessions.set("call-unsup-name-1", {
-        id: "call-unsup-name-1",
-        conversationId: "conv-unsup-name-1",
+      const { session } = startSessionWithOutcome("call-invite-1", {
+        conversationId: "conv-invite-1",
         status: "initiated",
         task: null,
         startedAt: null,
-        fromNumber: "+14155551234",
-        toNumber: "+15550001111",
+        fromNumber: "+15555550142",
+        toNumber: "+15555550143",
       });
 
-      const session = new MediaStreamCallSession(
-        mockWs.ws,
-        "call-unsup-name-1",
-      );
-      session.handleMessage(makeStartMessage());
+      for (const digit of ["9", "8", "7", "6", "5", "4"]) {
+        lastSttCallbacks.onDtmf?.(digit);
+      }
+      await flushMicrotasks();
 
-      // speakSystemPrompt should be called with the generic apology
-      expect(speakSystemPrompt).toHaveBeenCalledWith(
+      // Handoff copy already spoken by the flow → controller created, next
+      // caller turn marked as opening-ack, NO initial greeting fired.
+      expect(registerCallController).toHaveBeenCalledWith(
+        "call-invite-1",
         expect.anything(),
-        expect.stringContaining("additional verification"),
       );
-
-      // Should run finalization inline
-      expect(finalizeCall).toHaveBeenCalledWith(
-        "call-unsup-name-1",
-        "conv-unsup-name-1",
-      );
+      expect(
+        session.getController()?.markNextCallerTurnAsOpeningAck,
+      ).toBeDefined();
+      expect(mockStartInitialGreeting).not.toHaveBeenCalled();
     });
 
-    test("callee_verification outcome fails with explicit reason", () => {
+    test("outbound callee verification: spoken-digit code success greets normally", async () => {
       mockRouteSetupResult = {
         outcome: {
           action: "callee_verification",
@@ -1117,42 +1221,196 @@ describe("media-stream setup outcome scenarios", () => {
         resolved: {
           assistantId: "self",
           isInbound: false,
-          otherPartyNumber: "+14155551234",
+          otherPartyNumber: "+15555550142",
           actorTrust: { trustClass: "guardian", memberRecord: null },
         },
       };
 
-      const mockWs = createMockWs();
-      mockSessions.set("call-unsup-callee-1", {
-        id: "call-unsup-callee-1",
-        conversationId: "conv-unsup-callee-1",
+      startSessionWithOutcome("call-callee-1", {
+        conversationId: "conv-callee-1",
+        status: "initiated",
+        task: "Outbound task",
+        startedAt: null,
+        fromNumber: "+15555550143",
+        toNumber: "+15555550142",
+        initiatedFromConversationId: "origin-conv-1",
+      });
+      // Let the detached code-post side effects settle so the generated code
+      // is known and the resolver is installed.
+      await flushMicrotasks();
+
+      // The callee-verification code is generated internally; we can't read it,
+      // but the callee path treats a matching code via DTMF as success. Since
+      // the code is random, instead assert the flow is active (collecting) and
+      // that a generic wrong code keeps the flow open without a controller.
+      lastSttCallbacks.onDtmf?.("0");
+      lastSttCallbacks.onDtmf?.("0");
+      lastSttCallbacks.onDtmf?.("0");
+      await flushMicrotasks();
+
+      // The verification code post went out to the originating conversation.
+      const { addMessage } = await import("../memory/conversation-crud.js");
+      expect(addMessage).toHaveBeenCalled();
+    });
+
+    test("name_capture → guardian approval creates controller with handoff opener", async () => {
+      mockRouteSetupResult = {
+        outcome: {
+          action: "name_capture",
+          assistantId: "self",
+          fromNumber: "+15555550142",
+        },
+        resolved: {
+          assistantId: "self",
+          isInbound: true,
+          otherPartyNumber: "+15555550142",
+          actorTrust: { trustClass: "unknown", memberRecord: null },
+        },
+      };
+      mockNotifyResult = { notified: true, requestId: "access-req-1" };
+      mockCanonicalRequestStatus = "approved";
+
+      startSessionWithOutcome("call-name-1", {
+        conversationId: "conv-name-1",
         status: "initiated",
         task: null,
         startedAt: null,
-        fromNumber: "+15550001111",
-        toNumber: "+14155551234",
+        fromNumber: "+15555550142",
+        toNumber: "+15555550143",
       });
 
-      const session = new MediaStreamCallSession(
-        mockWs.ws,
-        "call-unsup-callee-1",
-      );
-      session.handleMessage(makeStartMessage());
+      // No controller during name capture.
+      expect(registerCallController).not.toHaveBeenCalled();
 
-      // Should record the failure with the specific action
-      expect(recordCallEvent).toHaveBeenCalledWith(
-        "call-unsup-callee-1",
-        "call_failed",
-        expect.objectContaining({
-          reason: expect.stringContaining("callee_verification"),
-        }),
-      );
+      // The caller speaks their name → access request opened → guardian wait
+      // starts. The mocked canonical request is already "approved" so the first
+      // poll resolves the wait.
+      lastSttCallbacks.onTranscriptFinal?.("Sam Rivera", 1200);
+      // Drive the wait poll timer (fake timers) and let callbacks settle.
+      jest.advanceTimersByTime(60_000);
+      await flushMicrotasks();
 
-      // Session should be failed
+      // Approval handoff spoken by the flow → controller created with the
+      // opening-ack opener; no initial greeting.
+      expect(registerCallController).toHaveBeenCalledWith(
+        "call-name-1",
+        expect.anything(),
+      );
+      expect(mockStartInitialGreeting).not.toHaveBeenCalled();
+    });
+
+    test("unverified caller: speaks guidance, fails the session, no controller", async () => {
+      mockRouteSetupResult = {
+        outcome: {
+          action: "unverified_caller",
+          displayName: "Jordan",
+          isGuardian: false,
+        },
+        resolved: {
+          assistantId: "self",
+          isInbound: true,
+          otherPartyNumber: "+15555550142",
+          actorTrust: { trustClass: "unknown", memberRecord: null },
+        },
+      };
+
+      startSessionWithOutcome("call-unver-1", {
+        conversationId: "conv-unver-1",
+        status: "initiated",
+        task: null,
+        startedAt: null,
+        fromNumber: "+15555550142",
+        toNumber: "+15555550143",
+      });
+      await flushMicrotasks();
+
+      expect(speakSystemPrompt).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining("has not been verified"),
+      );
       expect(updateCallSession).toHaveBeenCalledWith(
-        "call-unsup-callee-1",
+        "call-unver-1",
         expect.objectContaining({ status: "failed" }),
       );
+      expect(registerCallController).not.toHaveBeenCalled();
+      expect(finalizeCall).toHaveBeenCalledWith("call-unver-1", "conv-unver-1");
+    });
+
+    test("dispose() on transport close tears down an in-flight setup flow", () => {
+      mockRouteSetupResult = {
+        outcome: {
+          action: "verification",
+          assistantId: "self",
+          fromNumber: "+15555550142",
+        },
+        resolved: {
+          assistantId: "self",
+          isInbound: true,
+          otherPartyNumber: "+15555550142",
+          actorTrust: { trustClass: "unknown", memberRecord: null },
+        },
+      };
+
+      const { session } = startSessionWithOutcome("call-dispose-1", {
+        conversationId: "conv-dispose-1",
+        status: "in_progress",
+        task: null,
+        startedAt: Date.now() - 1000,
+        fromNumber: "+15555550142",
+        toNumber: "+15555550143",
+      });
+
+      // Closing the transport while collecting a code must not throw and must
+      // finalize the call (the setup flow is disposed first).
+      session.handleTransportClosed(1006, "abnormal-close");
+      expect(finalizeCall).toHaveBeenCalledWith(
+        "call-dispose-1",
+        "conv-dispose-1",
+      );
+    });
+
+    test("transcript routing: setup-phase transcripts go to the flow, post-setup transcripts go to the controller", async () => {
+      // name_capture so the flow stays active and consumes the first transcript
+      // (the caller's name) rather than forwarding it to a controller.
+      mockRouteSetupResult = {
+        outcome: {
+          action: "name_capture",
+          assistantId: "self",
+          fromNumber: "+15555550142",
+        },
+        resolved: {
+          assistantId: "self",
+          isInbound: true,
+          otherPartyNumber: "+15555550142",
+          actorTrust: { trustClass: "unknown", memberRecord: null },
+        },
+      };
+      mockNotifyResult = { notified: true, requestId: "access-req-1" };
+      mockCanonicalRequestStatus = "approved";
+
+      const { session } = startSessionWithOutcome("call-route-1", {
+        conversationId: "conv-route-1",
+        status: "initiated",
+        task: null,
+        startedAt: null,
+        fromNumber: "+15555550142",
+        toNumber: "+15555550143",
+      });
+
+      // First transcript = the caller's name → consumed by the flow, NOT routed
+      // to a controller's handleCallerUtterance (none exists yet).
+      lastSttCallbacks.onTranscriptFinal?.("Jamie", 1000);
+      expect(mockHandleCallerUtterance).not.toHaveBeenCalled();
+
+      // Guardian approves → handoff spoken → controller created.
+      jest.advanceTimersByTime(60_000);
+      await flushMicrotasks();
+      expect(session.getController()).not.toBeNull();
+
+      // A subsequent transcript now routes to the live controller.
+      lastSttCallbacks.onTranscriptFinal?.("Hello there", 1000);
+      await flushMicrotasks();
+      expect(mockHandleCallerUtterance).toHaveBeenCalledWith("Hello there");
     });
 
     test("normal_call after deny scenario still creates controller", async () => {
@@ -1214,15 +1472,12 @@ describe("media-stream setup outcome scenarios", () => {
       await flushMicrotasks();
       expect(mockStartInitialGreeting).toHaveBeenCalled();
 
-      // Immediate inbound audio (speech-like payloads) — before the
-      // assistant has spoken. The speech detector classifies these as
-      // speech, so onSpeechStart fires and calls handleBargeIn. Since
-      // the controller mock returns false (not speaking), handleInterrupt
-      // should NOT be called.
-      const speechPayload = Buffer.alloc(160, 0x00).toString("base64");
-      session.handleMessage(makeMediaMessage(speechPayload, "1"));
-      session.handleMessage(makeMediaMessage(speechPayload, "2"));
-      session.handleMessage(makeMediaMessage(speechPayload, "3"));
+      // Immediate inbound speech — before the assistant has spoken. The STT
+      // session surfaces speech-start via onSpeechStart, which calls
+      // handleBargeIn. Since the controller mock returns false (not speaking),
+      // handleInterrupt should NOT be called.
+      lastSttCallbacks.onSpeechStart?.();
+      lastSttCallbacks.onSpeechStart?.();
 
       // handleBargeIn was called but returned false
       expect(mockHandleBargeIn).toHaveBeenCalled();
@@ -1256,10 +1511,8 @@ describe("media-stream setup outcome scenarios", () => {
       const session = new MediaStreamCallSession(mockWs.ws, "call-bargein-2");
       session.handleMessage(makeStartMessage());
 
-      // Simulate inbound speech audio while assistant is speaking.
-      // Use a high-amplitude mu-law payload so speech detection triggers.
-      const speechPayload = Buffer.alloc(160, 0x00).toString("base64");
-      session.handleMessage(makeMediaMessage(speechPayload, "1"));
+      // Simulate inbound speech while the assistant is speaking.
+      lastSttCallbacks.onSpeechStart?.();
 
       // handleBargeIn should have been called (returning true)
       expect(mockHandleBargeIn).toHaveBeenCalled();

--- a/assistant/src/__tests__/media-stream-server-integration.test.ts
+++ b/assistant/src/__tests__/media-stream-server-integration.test.ts
@@ -1285,7 +1285,7 @@ describe("media-stream setup outcome scenarios", () => {
       // The caller speaks their name → access request opened → guardian wait
       // starts. The mocked canonical request is already "approved" so the first
       // poll resolves the wait.
-      lastSttCallbacks.onTranscriptFinal?.("Sam Rivera", 1200);
+      lastSttCallbacks.onTranscriptFinal?.("Example User", 1200);
       // Drive the wait poll timer (fake timers) and let callbacks settle.
       jest.advanceTimersByTime(60_000);
       await flushMicrotasks();
@@ -1404,7 +1404,7 @@ describe("media-stream setup outcome scenarios", () => {
 
       // Caller speaks name → access request opened → guardian wait → first poll
       // resolves "denied".
-      lastSttCallbacks.onTranscriptFinal?.("Sam Rivera", 1200);
+      lastSttCallbacks.onTranscriptFinal?.("Example User", 1200);
       jest.advanceTimersByTime(60_000);
       await flushMicrotasks();
 
@@ -1449,7 +1449,7 @@ describe("media-stream setup outcome scenarios", () => {
 
       // Caller speaks name → access request → guardian wait → markWaitingOnUser
       // drives the session to waiting_on_user.
-      lastSttCallbacks.onTranscriptFinal?.("Sam Rivera", 1200);
+      lastSttCallbacks.onTranscriptFinal?.("Example User", 1200);
       expect(mockSessions.get("call-approve-1")?.status).toBe(
         "waiting_on_user",
       );

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -146,6 +146,13 @@ export class CallController {
   private guardianUnavailableForCall = false;
   /** Active synthesized-TTS session — tracked so interrupt handling can close it. */
   private activeSynthesisAbort: AbortController | null = null;
+  /**
+   * Controller-owned in-call guardian-wait flag. Set by the wait owner (the
+   * media-stream setup flow / session) to suppress the silence nudge during an
+   * access-request wait without depending on transport connection state. See
+   * {@link setGuardianWaitActive}.
+   */
+  private guardianWaitActive = false;
 
   constructor(
     callSessionId: string,
@@ -196,6 +203,23 @@ export class CallController {
    */
   setTrustContext(ctx: TrustContext | null): void {
     this.trustContext = ctx;
+  }
+
+  /**
+   * Explicit, controller-owned guardian-wait signal used to suppress the
+   * silence nudge during an in-call access-request wait.
+   *
+   * On the ConversationRelay transport the controller can infer this state
+   * from `transport.getConnectionState() === "awaiting_guardian_decision"`,
+   * but the media-stream transport's connection state only reports
+   * `connected`/`closed` and cannot distinguish a guardian wait. Rather than
+   * overloading transport connection state, the wait owner (e.g. the
+   * media-stream setup flow / session) drives this flag directly so the
+   * controller's silence-nudge suppression is honest about which phase is
+   * active regardless of transport.
+   */
+  setGuardianWaitActive(active: boolean): void {
+    this.guardianWaitActive = active;
   }
 
   /**
@@ -1502,6 +1526,7 @@ export class CallController {
       // inbound access-request wait (relay state).
       if (
         this.pendingGuardianInput ||
+        this.guardianWaitActive ||
         this.transport.getConnectionState() === "awaiting_guardian_decision"
       ) {
         log.debug(

--- a/assistant/src/calls/media-stream-server.ts
+++ b/assistant/src/calls/media-stream-server.ts
@@ -33,11 +33,25 @@
 
 import type { ServerWebSocket } from "bun";
 
+import {
+  findGuardianForChannel,
+  listGuardianChannels,
+} from "../contacts/contact-store.js";
+import { getAssistantName } from "../daemon/identity-helpers.js";
+import { addMessage } from "../memory/conversation-crud.js";
 import { revokeScopedApprovalGrantsForContext } from "../memory/scoped-approval-grants.js";
-import { toTrustContext } from "../runtime/actor-trust-resolver.js";
+import { resolveGuardianName } from "../prompts/user-reference.js";
+import { notifyGuardianOfAccessRequest } from "../runtime/access-request-helper.js";
+import { resolveActorTrust } from "../runtime/actor-trust-resolver.js";
 import { getLogger } from "../util/logger.js";
 import { CallController } from "./call-controller.js";
 import { addPointerMessage, formatDuration } from "./call-pointer-messages.js";
+import {
+  CallSetupFlow,
+  type CallSetupFlowDeps,
+  type SetupFlowSession,
+} from "./call-setup-flow.js";
+import type { SetupFlowResult } from "./call-setup-flow-types.js";
 import { speakSystemPrompt } from "./call-speech-output.js";
 import {
   fireCallTranscriptNotifier,
@@ -64,6 +78,10 @@ import {
   describeCredentialGaps,
   resolveTelephonyCredentialReadiness,
 } from "./telephony-credential-preflight.js";
+import type { CallEventType } from "./types.js";
+
+const UUID_SHAPED_NAME =
+  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
 
 const log = getLogger("media-stream-server");
 
@@ -91,6 +109,14 @@ export class MediaStreamCallSession {
   private output: MediaStreamOutput;
   private sttSession: MediaStreamSttSession;
   private controller: CallController | null = null;
+  /**
+   * Active interactive setup flow (verification / invite / name-capture /
+   * unverified / deny). Non-null while the deterministic pre-conversation
+   * phase is collecting input; cleared once `onComplete` fires. While active,
+   * caller input (DTMF + finalized transcripts) is routed into the flow rather
+   * than the controller.
+   */
+  private setupFlow: CallSetupFlow | null = null;
   private streamSid: string | null = null;
   private callSid: string | null = null;
   private disposed = false;
@@ -171,6 +197,15 @@ export class MediaStreamCallSession {
    */
   handleTransportClosed(code?: number, reason?: string): void {
     if (this.disposed) return;
+
+    // Dispose any in-flight setup flow first so the GuardianWaitController
+    // emits the opted-in callback handoff (mirroring relay-server's
+    // `handleTransportClosed`, which fires the callback handoff before cleanup)
+    // and clears its timers before the session is finalized.
+    if (this.setupFlow) {
+      this.setupFlow.dispose();
+      this.setupFlow = null;
+    }
 
     const session = getCallSession(this.callSessionId);
     if (!session) return;
@@ -278,6 +313,14 @@ export class MediaStreamCallSession {
 
     this.sttSession.dispose();
 
+    // Dispose any in-flight setup flow so the GuardianWaitController's timers
+    // are cleared and (if the caller had opted into a callback while still
+    // waiting) the transport-closed callback handoff fires.
+    if (this.setupFlow) {
+      this.setupFlow.dispose();
+      this.setupFlow = null;
+    }
+
     if (this.controller) {
       this.controller.destroy();
       unregisterCallController(this.callSessionId);
@@ -333,11 +376,13 @@ export class MediaStreamCallSession {
     });
 
     // ── Setup-policy routing ────────────────────────────────────────
-    // Run the same routeSetup() that the ConversationRelay path uses
-    // to enforce ACL/deny/escalate, verification, and invite flows.
-    // The media-stream transport does not support interactive sub-flows
-    // (DTMF entry, name capture, guardian wait), so non-normal outcomes
-    // are rejected gracefully with a TTS message and session teardown.
+    // Run the same routeSetup() that the ConversationRelay path uses to
+    // enforce ACL/deny/escalate, verification, invite, and name-capture flows.
+    // Every outcome is driven by a CallSetupFlow over the media-stream output
+    // transport, achieving parity with the ConversationRelay setup path. The
+    // flow speaks prompts, collects DTMF/speech, runs guardian waits, and
+    // reports back (via onComplete) which greeting/handoff continuation to
+    // perform.
     const from = session?.fromNumber ?? "";
     const to = session?.toNumber ?? "";
 
@@ -359,105 +404,279 @@ export class MediaStreamCallSession {
       "Media stream session started",
     );
 
-    switch (outcome.action) {
-      case "normal_call": {
-        // Create the call controller only for normal calls. Deny and
-        // unsupported-flow paths speak a message via the output adapter
-        // directly and don't need a controller. Creating it eagerly
-        // would start duration/silence timers that leak when the
-        // session is torn down before destroy() runs.
-        const initialTrustContext = toTrustContext(
-          resolved.actorTrust,
-          resolved.otherPartyNumber,
-        );
-        this.controller = new CallController(
-          this.callSessionId,
-          this.output,
-          session?.task ?? null,
-          {
-            assistantId: resolved.assistantId,
-            trustContext: initialTrustContext,
-          },
-        );
-        registerCallController(this.callSessionId, this.controller);
+    const setupFlow = new CallSetupFlow(
+      this.callSessionId,
+      this.output,
+      this.buildSetupFlowDeps(),
+    );
+    this.setupFlow = setupFlow;
 
-        // Credential-compatibility preflight: the media-stream is already
-        // connected and the daemon does STT + TTS itself here. If the
-        // configured providers lack usable credentials the call would sit
-        // silent, so verify readiness (async) before greeting; when not ready,
-        // tear down, speak a short setup-required message, and end the call
-        // instead of connect-and-sit-silent.
-        void this.preflightCredentialsThenGreet(session);
-        return;
+    // Drive the routed outcome. `onComplete` (wired in buildSetupFlowDeps)
+    // creates the controller / fires the matching opener / tears down. The
+    // returned promise rejects only on an off-contract action; surface it.
+    setupFlow.start(outcome, resolved).catch((err) => {
+      log.error(
+        { err, callSessionId: this.callSessionId, action: outcome.action },
+        "Media-stream setup flow failed",
+      );
+      // Fail closed: mark the session failed, finalize, and end the call so a
+      // setup-flow error never leaves the caller connected-and-silent.
+      const current = getCallSession(this.callSessionId);
+      if (current && !isTerminalState(current.status)) {
+        updateCallSession(this.callSessionId, {
+          status: "failed",
+          endedAt: Date.now(),
+          lastError: `Media-stream setup flow error: ${String(err)}`,
+        });
       }
+      this.runFinalizationAndGrantCleanup(getCallSession(this.callSessionId));
+      this.output.endSession("Media-stream setup flow error");
+    });
+  }
 
-      case "deny":
-        // Deny — speak the denial message and tear down.
-        log.warn(
-          {
-            callSessionId: this.callSessionId,
-            reason: outcome.logReason,
-          },
-          "Media-stream setup denied by ACL policy",
-        );
-        recordCallEvent(this.callSessionId, "inbound_acl_denied", {
-          from,
-          trustClass: resolved.actorTrust.trustClass,
+  /**
+   * Assemble the {@link CallSetupFlowDeps} backed by the real implementations
+   * the ConversationRelay path uses, so media-stream setup achieves parity with
+   * the CR relay flow (copy/label/persona, access-request creation + guardian
+   * notification, post-verification trust recompute, pointer/notifier writes,
+   * exactly-once finalization, guardian-wait controller construction).
+   *
+   * `onComplete` is the bridge from the deterministic setup phase to the
+   * conversation phase: it creates and registers the {@link CallController}
+   * (with the result's recomputed trust context) and fires the matching opener,
+   * or tears the session down for the terminal `ended` outcome.
+   */
+  private buildSetupFlowDeps(): CallSetupFlowDeps {
+    return {
+      // The transport handed to the flow is always this session's
+      // MediaStreamOutput, which satisfies CallTransport; speak through it.
+      speakSystemPrompt: (_transport, text) =>
+        speakSystemPrompt(this.output, text),
+      recordCallEvent: (callSessionId, eventType, payload) =>
+        recordCallEvent(callSessionId, eventType as CallEventType, payload),
+      onComplete: (result) => this.handleSetupComplete(result),
+      getSession: () =>
+        this.toSetupFlowSession(getCallSession(this.callSessionId)),
+      postCalleeVerificationCode: (conversationId, toNumber, code) =>
+        this.postCalleeVerificationCode(conversationId, toNumber, code),
+      addPointerMessage: (conversationId, event, phoneNumber, extra) =>
+        addPointerMessage(conversationId, event, phoneNumber, extra),
+      fireTranscript: (conversationId, callSessionId, speaker, text) =>
+        fireCallTranscriptNotifier(
+          conversationId,
+          callSessionId,
+          speaker,
+          text,
+        ),
+      resolveActorTrust: (input) => resolveActorTrust(input),
+      resolveGuardianLabel: () => this.resolveGuardianLabel(),
+      resolveAssistantLabel: () => this.resolveAssistantLabel(),
+      // Only the copy that DIFFERS from CallSetupFlow's built-in defaults is
+      // overridden here, to port relay-server's exact wording. The
+      // name-capture / unverified / access-approved / access-denied /
+      // access-timeout copy is byte-identical to the flow defaults, so those
+      // deps are intentionally left unset.
+      //
+      // - invite redemption / handoff add the relay outbound + assistant-name
+      //   variants the defaults lack.
+      // - trusted-contact handoff uses relay's "guardian said I can speak with
+      //   you" copy rather than the flow's terser "You're verified" default.
+      composeInviteRedemptionPrompt: ({
+        isOutbound,
+        friendName,
+        guardianName,
+      }) => {
+        const displayFriend = friendName ?? "there";
+        const displayGuardian = guardianName ?? "your contact";
+        if (isOutbound) {
+          const assistantName = this.resolveAssistantLabel();
+          return assistantName
+            ? `Hi ${displayFriend}, this is ${assistantName}, ${displayGuardian}'s assistant. To get started, please enter the 6-digit code that ${displayGuardian} shared with you.`
+            : `Hi ${displayFriend}, this is ${displayGuardian}'s assistant. To get started, please enter the 6-digit code that ${displayGuardian} shared with you.`;
+        }
+        return `Welcome ${displayFriend}. Please enter the 6-digit code that ${displayGuardian} provided you to verify your identity.`;
+      },
+      composeInviteHandoffText: ({ friendName, guardianName }) => {
+        const assistantName = this.resolveAssistantLabel();
+        const gLabel = guardianName || this.resolveGuardianLabel();
+        if (friendName) {
+          return assistantName
+            ? `Great, I've verified that you are ${friendName}. It's nice to meet you! I'm ${assistantName}, ${gLabel}'s assistant. How can I help?`
+            : `Great, I've verified that you are ${friendName}. It's nice to meet you! How can I help?`;
+        }
+        return assistantName
+          ? `Great, I've verified your identity. It's nice to meet you! I'm ${assistantName}, ${gLabel}'s assistant. How can I help?`
+          : `Great, I've verified your identity. It's nice to meet you! How can I help?`;
+      },
+      composeTrustedContactHandoffText: () =>
+        `Great! ${this.resolveGuardianLabel()} said I can speak with you. How can I help?`,
+      createAccessRequest: ({ assistantId, fromNumber, callerName }) => {
+        const result = notifyGuardianOfAccessRequest({
+          canonicalAssistantId: assistantId,
+          sourceChannel: "phone",
+          conversationExternalId: fromNumber,
+          actorExternalId: fromNumber,
+          actorDisplayName: callerName,
         });
+        return result.notified ? result.requestId : null;
+      },
+      markWaitingOnUser: () =>
+        updateCallSession(this.callSessionId, { status: "waiting_on_user" }),
+      finalizeFailedCall: (reason) => this.finalizeFailedSetup(reason),
+    };
+  }
+
+  /**
+   * Bridge a resolved setup flow to the conversation phase. For the three
+   * "proceed" continuations, create + register the controller with the
+   * result's recomputed trust context and fire the matching opener; for
+   * `ended`, run finalization and tear the session down.
+   */
+  private handleSetupComplete(result: SetupFlowResult): void {
+    // The setup phase is over — stop routing caller input into the flow.
+    this.setupFlow = null;
+
+    if (result.kind === "ended") {
+      // Terminal setup outcome (deny / unverified / verification failure /
+      // guardian denial or timeout). The flow has already spoken the copy and
+      // scheduled the transport teardown; mark the session failed (mirroring
+      // relay-server's deny/failure paths) and run finalization inline because
+      // `handleTransportClosed` exits early once status is terminal.
+      //
+      // Idempotent for outcomes that already finalized via `finalizeFailedCall`
+      // (the `isTerminalState` guard skips the redundant status write).
+      const session = getCallSession(this.callSessionId);
+      if (session && !isTerminalState(session.status)) {
         updateCallSession(this.callSessionId, {
           status: "failed",
           endedAt: Date.now(),
-          lastError: outcome.logReason,
+          lastError: result.reason,
         });
-        // Run finalization now because handleTransportClosed will see
-        // terminal status and exit early when the WebSocket closes.
-        this.runFinalizationAndGrantCleanup(session);
-        void speakSystemPrompt(this.output, outcome.message).finally(() => {
-          setTimeout(() => this.output.endSession(outcome.logReason), 3000);
-        });
+      }
+      this.runFinalizationAndGrantCleanup(getCallSession(this.callSessionId));
+      return;
+    }
+
+    const sessionRow = getCallSession(this.callSessionId);
+    this.controller = new CallController(
+      this.callSessionId,
+      this.output,
+      sessionRow?.task ?? null,
+      {
+        assistantId: result.assistantId,
+        trustContext: result.trustContext,
+      },
+    );
+    registerCallController(this.callSessionId, this.controller);
+
+    switch (result.kind) {
+      case "proceed-initial-greeting":
+        // Credential-compatibility preflight before the first greeting; when
+        // not ready, tear down, speak a setup-required message, and end the
+        // call instead of connect-and-sit-silent.
+        void this.preflightCredentialsThenGreet(sessionRow);
         return;
-
-      default:
-        // All interactive sub-flows (verification, invite_redemption,
-        // name_capture, callee_verification, outbound_verification) are
-        // not supported on the media-stream transport. The TwiML preflight
-        // in twilio-routes.ts should have caught this and fallen back to
-        // ConversationRelay — reaching here indicates the preflight was
-        // bypassed or a new setup action was added without updating the
-        // preflight guard. Speak a generic apology and end the session
-        // rather than silently bypassing policy enforcement.
-        log.error(
-          {
-            callSessionId: this.callSessionId,
-            action: outcome.action,
-          },
-          "Media-stream transport received unsupported setup flow — preflight guard should have prevented this",
-        );
-        recordCallEvent(this.callSessionId, "call_failed", {
-          reason: `Setup flow '${outcome.action}' not supported on media-stream transport (preflight guard bypass)`,
-          transport: "media-stream",
-        });
-        updateCallSession(this.callSessionId, {
-          status: "failed",
-          endedAt: Date.now(),
-          lastError: `Setup flow '${outcome.action}' not supported on media-stream transport — preflight guard should have prevented this`,
-        });
-        // Run finalization now because handleTransportClosed will see
-        // terminal status and exit early when the WebSocket closes.
-        this.runFinalizationAndGrantCleanup(session);
-        void speakSystemPrompt(
-          this.output,
-          "Sorry, this call requires additional verification that isn't available right now. Please try calling back. Goodbye.",
-        ).finally(() => {
-          setTimeout(
-            () =>
-              this.output.endSession(
-                `Unsupported setup flow: ${outcome.action} (preflight guard bypass)`,
-              ),
-            3000,
+      case "proceed-post-verification-greeting":
+        this.controller.startPostVerificationGreeting().catch((err) => {
+          log.error(
+            { err, callSessionId: this.callSessionId },
+            "Failed to start post-verification greeting on media-stream session",
           );
         });
         return;
+      case "proceed-handoff-spoken":
+        // A handoff/greeting was already spoken by the flow; the next caller
+        // turn should be treated as an opening acknowledgment rather than
+        // re-greeting.
+        this.controller.markNextCallerTurnAsOpeningAck();
+        return;
+    }
+  }
+
+  // ── Setup-flow dep implementations ───────────────────────────────
+
+  /** Project a call-session row onto the narrow shape the setup flow reads. */
+  private toSetupFlowSession(
+    session: ReturnType<typeof getCallSession>,
+  ): SetupFlowSession | null {
+    if (!session) return null;
+    return {
+      conversationId: session.conversationId,
+      toNumber: session.toNumber,
+      initiatedFromConversationId: session.initiatedFromConversationId ?? null,
+    };
+  }
+
+  /**
+   * Post the generated callee-verification code into the originating
+   * conversation so the user can relay it. Mirrors the `addMessage(...)` write
+   * in `relay-server.startVerification`.
+   */
+  private async postCalleeVerificationCode(
+    conversationId: string,
+    toNumber: string,
+    code: string,
+  ): Promise<void> {
+    const codeMsg = `\u{1F510} Verification code for call to ${toNumber}: ${code}`;
+    await addMessage(
+      conversationId,
+      "assistant",
+      JSON.stringify([{ type: "text", text: codeMsg }]),
+      {
+        metadata: {
+          userMessageChannel: "phone",
+          assistantMessageChannel: "phone",
+          userMessageInterface: "phone",
+          assistantMessageInterface: "phone",
+        },
+      },
+    );
+  }
+
+  /**
+   * Mark the session failed and run finalization for a terminal setup failure
+   * (denial / timeout / unverified / invite failure). Mirrors relay-server's
+   * `updateCallSession({ status: "failed" })` + `finalizeCall(...)`.
+   */
+  private finalizeFailedSetup(reason: string): void {
+    const session = getCallSession(this.callSessionId);
+    if (session && !isTerminalState(session.status)) {
+      updateCallSession(this.callSessionId, {
+        status: "failed",
+        endedAt: Date.now(),
+        lastError: reason,
+      });
+    }
+    this.runFinalizationAndGrantCleanup(session);
+  }
+
+  /**
+   * Resolve a human-readable guardian label for voice setup copy. Mirrors
+   * `relay-server.resolveGuardianLabel`: prefer the per-channel guardian's
+   * displayName, fall back to any guardian channel, then to the shared
+   * `resolveGuardianName` default.
+   */
+  private resolveGuardianLabel(): string {
+    const voiceGuardian = findGuardianForChannel("phone");
+    const guardianChannels = voiceGuardian ? null : listGuardianChannels();
+    const guardianContact = voiceGuardian?.contact ?? guardianChannels?.contact;
+    return resolveGuardianName(guardianContact?.displayName);
+  }
+
+  /**
+   * Resolve the assistant's display name for setup greetings, or null when it
+   * is unavailable / UUID-shaped. Mirrors `relay-server.resolveAssistantLabel`.
+   */
+  private resolveAssistantLabel(): string | null {
+    try {
+      const name = getAssistantName();
+      const trimmedName = name?.trim();
+      if (!trimmedName || UUID_SHAPED_NAME.test(trimmedName)) {
+        return null;
+      }
+      return trimmedName;
+    } catch {
+      return null;
     }
   }
 
@@ -616,6 +835,14 @@ export class MediaStreamCallSession {
     if (!text.trim()) return;
     this.transcriptFinalsProduced++;
 
+    // While the deterministic setup flow is active, finalized transcripts are
+    // its input (name capture, spoken verification digits, in-wait utterances),
+    // not conversational turns. Route them there and stop.
+    if (this.setupFlow) {
+      this.setupFlow.pushTranscriptFinal(text);
+      return;
+    }
+
     if (!this.controller) {
       log.warn(
         { callSessionId: this.callSessionId },
@@ -657,6 +884,11 @@ export class MediaStreamCallSession {
       dtmfDigit: digit,
       transport: "media-stream",
     });
+
+    // DTMF only carries meaning during the setup phase (verification / invite
+    // code entry). Once the conversation is live there is no DTMF sub-flow, so
+    // the digit is recorded for diagnostics and otherwise ignored.
+    this.setupFlow?.pushDtmfDigit(digit);
   }
 
   private handleStreamStop(): void {

--- a/assistant/src/calls/media-stream-server.ts
+++ b/assistant/src/calls/media-stream-server.ts
@@ -536,6 +536,17 @@ export class MediaStreamCallSession {
     // The setup phase is over — stop routing caller input into the flow.
     this.setupFlow = null;
 
+    // Guard against a completion that resolves AFTER the transport already
+    // closed. An interactive flow can still be awaiting async work (e.g.
+    // outbound verification awaiting postPointer) when the caller hangs up;
+    // handleTransportClosed() disposes the flow and finalizes the session, but
+    // CallSetupFlow.dispose() can't cancel an already-scheduled completion.
+    // Without this guard a late completion would create/register a new
+    // CallController and start a greeting on an already-closed/terminal call.
+    if (this.disposed) return;
+    const currentSession = getCallSession(this.callSessionId);
+    if (currentSession && isTerminalState(currentSession.status)) return;
+
     if (result.kind === "ended") {
       // Terminal setup outcome (deny / unverified / verification failure /
       // guardian denial or timeout). The flow has already spoken the copy and

--- a/assistant/src/calls/media-stream-server.ts
+++ b/assistant/src/calls/media-stream-server.ts
@@ -539,14 +539,29 @@ export class MediaStreamCallSession {
     if (result.kind === "ended") {
       // Terminal setup outcome (deny / unverified / verification failure /
       // guardian denial or timeout). The flow has already spoken the copy and
-      // scheduled the transport teardown; mark the session failed (mirroring
-      // relay-server's deny/failure paths) and run finalization inline because
-      // `handleTransportClosed` exits early once status is terminal.
+      // scheduled the transport teardown.
       //
-      // Idempotent for outcomes that already finalized via `finalizeFailedCall`
-      // (the `isTerminalState` guard skips the redundant status write).
+      // Some terminal outcomes (unverified_caller, invite-code failure,
+      // guardian denial / timeout, name-capture timeout) finalize THEMSELVES
+      // from inside `CallSetupFlow` via the injected `finalizeFailedCall` dep
+      // (→ `finalizeFailedSetup` → `runFinalizationAndGrantCleanup` →
+      // `finalizeCall`). Those drive the session to a terminal status before
+      // the flow resolves `ended`. If we unconditionally finalized again here
+      // we'd persist a second completion message and fire a second completion
+      // notifier (duplicate side effects).
+      //
+      // So make finalization exactly-once: only the outcomes that have NOT
+      // already finalized (currently just the `deny` path, which resolves
+      // `ended` without calling `finalizeFailedCall`) fall through to the
+      // inline finalize. A session that is already terminal here has already
+      // been finalized by the flow, so we skip — preserving a single
+      // completion message + single notifier for every terminal path.
       const session = getCallSession(this.callSessionId);
-      if (session && !isTerminalState(session.status)) {
+      if (session && isTerminalState(session.status)) {
+        // Already finalized by the flow's `finalizeFailedCall` — nothing to do.
+        return;
+      }
+      if (session) {
         updateCallSession(this.callSessionId, {
           status: "failed",
           endedAt: Date.now(),
@@ -588,6 +603,21 @@ export class MediaStreamCallSession {
         // A handoff/greeting was already spoken by the flow; the next caller
         // turn should be treated as an opening acknowledgment rather than
         // re-greeting.
+        //
+        // Restore `in_progress` when the session is parked in
+        // `waiting_on_user`. Name-capture enters the guardian wait via
+        // `markWaitingOnUser` (session → `waiting_on_user`); on approval the
+        // flow resolves `proceed-handoff-spoken` and we create the live
+        // controller above, but without this the session would stay
+        // `waiting_on_user` for the rest of an actively-connected call until
+        // hangup. Relay-server restores `in_progress` in
+        // `continueCallAfterTrustedContactActivation`; this matches that
+        // behavior. Guard on `waiting_on_user` so we never clobber a terminal
+        // status (validateTransition would reject it anyway) and only act when
+        // a wait actually happened.
+        if (sessionRow?.status === "waiting_on_user") {
+          updateCallSession(this.callSessionId, { status: "in_progress" });
+        }
         this.controller.markNextCallerTurnAsOpeningAck();
         return;
     }


### PR DESCRIPTION
## Summary
- Wire CallSetupFlow + GuardianWaitController into MediaStreamCallSession.handleStart with real deps (copy/label, access-request, trust recompute, pointer/notifier, finalize)
- Route DTMF + transcripts to the active setup flow; dispose on teardown
- Explicit in-call guardian-wait state signal (not transport-derived); remove unsupported-flow rejection
- Integration tests across all setup outcomes

Part of plan: migrate-phone-off-conversation-relay.md (PR 9 of 18)