### PR TITLE
[LUM-2178] Forward platform data-plane routes through app:// protocol handler

### DIFF
--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -6,15 +6,17 @@ import { z } from "zod";
 
 import {
   readAllowedGatewayPorts,
+  resolveLocalConfigFromEnv,
   resolveLockfilePaths,
 } from "@vellumai/local-mode";
 
 import { installAbout, openAboutWindow } from "./about";
-import { APP_PROTOCOL } from "./app-config";
+import { APP_HOST, APP_PROTOCOL } from "./app-config";
 import { ensureWebInstalled, getWebDistPath } from "./cli-installer";
 import { handle } from "./ipc";
 import { resolveAppProtocolPath } from "./app-protocol";
 import { planGatewayForward } from "./gateway-forward";
+import { planPlatformForward } from "./platform-forward";
 import {
   extractDeepLinkFromArgv,
   handleDeepLink,
@@ -120,6 +122,7 @@ const registerAppProtocol = (): void => {
   const lockfilePaths = resolveLockfilePaths(process.env);
   const getAllowedGatewayPorts = (): Set<number> =>
     readAllowedGatewayPorts(lockfilePaths);
+  const { platformUrl } = resolveLocalConfigFromEnv(process.env);
 
   protocol.handle(APP_PROTOCOL, async (request) => {
     // The renderer addresses local gateways at the same `app://` origin via
@@ -129,6 +132,12 @@ const registerAppProtocol = (): void => {
     // Vite dev-server proxy (`apps/web/vite-plugin-local-mode.ts`).
     const proxied = await forwardGatewayRequest(request, getAllowedGatewayPorts);
     if (proxied) return proxied;
+
+    // Platform API routes (`/v1/*`, `/_allauth/*`, `/accounts/*`) forward to
+    // the cloud platform so managed mode works in packaged builds. Mirrors the
+    // Vite dev-server proxy (`apps/web/vite.config.ts` server.proxy entries).
+    const platformProxied = await forwardPlatformRequest(request, platformUrl);
+    if (platformProxied) return platformProxied;
 
     const result = resolveAppProtocolPath(
       rendererRoot,
@@ -189,6 +198,66 @@ const forwardGatewayRequest = async (
         ...(plan.hasBody ? { duplex: "half" } : {}),
         redirect: "manual",
       });
+  }
+};
+
+/**
+ * Forward a platform API request (`/v1/*`, `/_allauth/*`, `/accounts/*`) to
+ * the cloud platform, or return `null` for non-platform paths. Mirrors the
+ * gateway forward: `net.fetch` runs in main so the renderer stays same-origin.
+ *
+ * After a successful response, CSRF cookies from the platform are mirrored
+ * into the renderer's session so `document.cookie` can read the token for
+ * mutating requests.
+ */
+const forwardPlatformRequest = async (
+  request: GlobalRequest,
+  platformUrl: string,
+): Promise<Response | null> => {
+  const plan = planPlatformForward(request, platformUrl);
+  if (plan.kind === "pass") return null;
+
+  let response: Response;
+  try {
+    response = await net.fetch(plan.url, {
+      method: plan.method,
+      headers: plan.headers,
+      body: plan.hasBody ? request.body : undefined,
+      ...(plan.hasBody ? { duplex: "half" } : {}),
+      redirect: "manual",
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Platform unreachable";
+    return new Response(message, { status: 502 });
+  }
+
+  await mirrorCsrfCookie(response);
+  return response;
+};
+
+const CSRF_COOKIE_RE = /(?:__Secure-)?csrftoken=([^;]+)/;
+
+/**
+ * Mirror the CSRF token cookie from a platform response into the renderer's
+ * session cookie store so `document.cookie` can read it. The session cookie
+ * (`sessionid`) stays in `net.fetch`'s own jar for the platform domain —
+ * only the CSRF token needs to be visible to the renderer's JS interceptor.
+ */
+const mirrorCsrfCookie = async (response: Response): Promise<void> => {
+  const setCookies = response.headers.getSetCookie?.() ?? [];
+  for (const raw of setCookies) {
+    const match = CSRF_COOKIE_RE.exec(raw);
+    if (match?.[1]) {
+      const name = raw.startsWith("__Secure-")
+        ? "__Secure-csrftoken"
+        : "csrftoken";
+      await session.defaultSession.cookies.set({
+        url: `app://${APP_HOST}`,
+        name,
+        value: match[1],
+        secure: true,
+      });
+    }
   }
 };
 

--- a/apps/macos/src/main/platform-forward.test.ts
+++ b/apps/macos/src/main/platform-forward.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, test } from "bun:test";
+
+import { planPlatformForward } from "./platform-forward";
+
+const PLATFORM = "https://platform.vellum.ai";
+
+const request = (
+  pathname: string,
+  init: { method?: string; origin?: string; headers?: Record<string, string> } = {},
+) => ({
+  url: `app://vellum.ai${pathname}`,
+  method: init.method ?? "GET",
+  headers: new Headers({
+    ...(init.origin !== undefined ? { origin: init.origin } : {}),
+    ...init.headers,
+  }),
+});
+
+describe("planPlatformForward", () => {
+  test("passes non-platform requests through to static serving", () => {
+    expect(
+      planPlatformForward(request("/assistant/assets/app.js"), PLATFORM),
+    ).toEqual({ kind: "pass" });
+  });
+
+  test("passes gateway requests through", () => {
+    expect(
+      planPlatformForward(request("/__gateway/8080/v1/foo"), PLATFORM),
+    ).toEqual({ kind: "pass" });
+  });
+
+  test("forwards /v1/* requests to platform", () => {
+    const plan = planPlatformForward(
+      request("/v1/assistants"),
+      PLATFORM,
+    );
+    expect(plan.kind).toBe("forward");
+    if (plan.kind !== "forward") throw new Error("expected forward");
+    expect(plan.url).toBe("https://platform.vellum.ai/v1/assistants");
+    expect(plan.method).toBe("GET");
+    expect(plan.hasBody).toBe(false);
+  });
+
+  test("forwards /_allauth/* requests to platform", () => {
+    const plan = planPlatformForward(
+      request("/_allauth/browser/v1/auth/session"),
+      PLATFORM,
+    );
+    if (plan.kind !== "forward") throw new Error("expected forward");
+    expect(plan.url).toBe(
+      "https://platform.vellum.ai/_allauth/browser/v1/auth/session",
+    );
+  });
+
+  test("forwards /accounts/* requests to platform", () => {
+    const plan = planPlatformForward(
+      request("/accounts/login"),
+      PLATFORM,
+    );
+    if (plan.kind !== "forward") throw new Error("expected forward");
+    expect(plan.url).toBe("https://platform.vellum.ai/accounts/login");
+  });
+
+  test("forwards exact prefix without trailing slash", () => {
+    const plan = planPlatformForward(request("/v1"), PLATFORM);
+    if (plan.kind !== "forward") throw new Error("expected forward");
+    expect(plan.url).toBe("https://platform.vellum.ai/v1");
+  });
+
+  test("preserves query string on forwarded requests", () => {
+    const plan = planPlatformForward(
+      request("/v1/assistants?page=2&limit=10"),
+      PLATFORM,
+    );
+    if (plan.kind !== "forward") throw new Error("expected forward");
+    expect(plan.url).toBe(
+      "https://platform.vellum.ai/v1/assistants?page=2&limit=10",
+    );
+  });
+
+  test("rewrites Origin from app:// to platform origin", () => {
+    const plan = planPlatformForward(
+      request("/v1/assistants", { origin: "app://vellum.ai" }),
+      PLATFORM,
+    );
+    if (plan.kind !== "forward") throw new Error("expected forward");
+    expect(plan.headers.get("origin")).toBe("https://platform.vellum.ai");
+  });
+
+  test("sets a platform Origin even when the renderer sent none", () => {
+    const plan = planPlatformForward(request("/v1/assistants"), PLATFORM);
+    if (plan.kind !== "forward") throw new Error("expected forward");
+    expect(plan.headers.get("origin")).toBe("https://platform.vellum.ai");
+  });
+
+  test("preserves non-Origin headers", () => {
+    const plan = planPlatformForward(
+      request("/_allauth/browser/v1/auth/session", {
+        method: "POST",
+        origin: "app://vellum.ai",
+        headers: {
+          authorization: "Bearer api-token",
+          "content-type": "application/json",
+          "x-csrftoken": "csrf123",
+        },
+      }),
+      PLATFORM,
+    );
+    if (plan.kind !== "forward") throw new Error("expected forward");
+    expect(plan.headers.get("authorization")).toBe("Bearer api-token");
+    expect(plan.headers.get("content-type")).toBe("application/json");
+    expect(plan.headers.get("x-csrftoken")).toBe("csrf123");
+  });
+
+  test("marks POST/PUT/PATCH/DELETE as hasBody, GET/HEAD as no body", () => {
+    for (const method of ["POST", "PUT", "PATCH", "DELETE"]) {
+      const plan = planPlatformForward(
+        request("/v1/assistants", { method }),
+        PLATFORM,
+      );
+      if (plan.kind !== "forward") throw new Error("expected forward");
+      expect(plan.hasBody).toBe(true);
+    }
+    for (const method of ["GET", "HEAD"]) {
+      const plan = planPlatformForward(
+        request("/v1/assistants", { method }),
+        PLATFORM,
+      );
+      if (plan.kind !== "forward") throw new Error("expected forward");
+      expect(plan.hasBody).toBe(false);
+    }
+  });
+
+  test("works with custom platform URL (staging)", () => {
+    const plan = planPlatformForward(
+      request("/v1/assistants"),
+      "https://staging-platform.vellum.ai",
+    );
+    if (plan.kind !== "forward") throw new Error("expected forward");
+    expect(plan.url).toBe(
+      "https://staging-platform.vellum.ai/v1/assistants",
+    );
+    expect(plan.headers.get("origin")).toBe(
+      "https://staging-platform.vellum.ai",
+    );
+  });
+
+  test("works with local platform URL", () => {
+    const plan = planPlatformForward(
+      request("/v1/assistants"),
+      "http://localhost:8000",
+    );
+    if (plan.kind !== "forward") throw new Error("expected forward");
+    expect(plan.url).toBe("http://localhost:8000/v1/assistants");
+    expect(plan.headers.get("origin")).toBe("http://localhost:8000");
+  });
+
+  test("does not forward paths that merely start with a prefix string", () => {
+    expect(
+      planPlatformForward(request("/v1something/else"), PLATFORM),
+    ).toEqual({ kind: "pass" });
+
+    expect(
+      planPlatformForward(request("/accountsettings"), PLATFORM),
+    ).toEqual({ kind: "pass" });
+  });
+});

--- a/apps/macos/src/main/platform-forward.ts
+++ b/apps/macos/src/main/platform-forward.ts
@@ -1,0 +1,62 @@
+/**
+ * Pure planning for the platform API proxy (`/v1/*`, `/_allauth/*`, `/accounts/*`).
+ *
+ * Mirrors `gateway-forward.ts`: the URL/header logic is testable without
+ * importing `src/main/index.ts` or mocking Electron's `net`. The caller in
+ * `index.ts` turns a `forward` plan into a single `net.fetch` and returns its
+ * streaming `Response` verbatim.
+ */
+
+export type PlatformForwardPlan =
+  | { kind: "pass" }
+  | {
+      kind: "forward";
+      url: string;
+      method: string;
+      headers: Headers;
+      hasBody: boolean;
+    };
+
+export interface PlatformForwardRequest {
+  url: string;
+  method: string;
+  headers: Headers;
+}
+
+const PLATFORM_PREFIXES = ["/v1", "/_allauth", "/accounts"] as const;
+
+function isPlatformPath(pathname: string): boolean {
+  return PLATFORM_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
+}
+
+/**
+ * Resolve a renderer request to a platform-proxy plan.
+ *
+ * On `forward`, the request's `Origin` is rewritten to the platform's own
+ * origin. The renderer issues this request from `app://vellum.ai` but the
+ * platform expects its own origin for CORS/CSRF purposes. All other headers
+ * (Authorization, X-CSRFToken, Content-Type, etc.) pass through unchanged.
+ */
+export function planPlatformForward(
+  request: PlatformForwardRequest,
+  platformUrl: string,
+): PlatformForwardPlan {
+  const url = new URL(request.url);
+  if (!isPlatformPath(url.pathname)) {
+    return { kind: "pass" };
+  }
+
+  const target = new URL(platformUrl);
+  const headers = new Headers(request.headers);
+  headers.set("origin", target.origin);
+
+  return {
+    kind: "forward",
+    url: `${target.origin}${url.pathname}${url.search}`,
+    method: request.method,
+    headers,
+    hasBody: request.method !== "GET" && request.method !== "HEAD",
+  };
+}


### PR DESCRIPTION
## Summary
- Adds `platform-forward.ts` — a pure planning module (mirroring `gateway-forward.ts`) that matches `/v1/*`, `/_allauth/*`, `/accounts/*` and produces a forward plan targeting the cloud platform URL
- Wires the plan into the `app://` protocol handler in `index.ts`, slotted between gateway forwarding and static file resolution, with `net.fetch` execution, 502 error handling, and CSRF cookie mirroring into the renderer's session
- Includes 14 unit tests covering path matching, Origin rewriting, header passthrough, body detection, query string preservation, and custom platform URLs

## Original prompt
The user reviewed Linear ticket LUM-2178 which identified that the packaged Electron build silently breaks cloud/managed mode because the `app://` protocol handler only forwards gateway requests and serves static files — platform API calls (`/v1`, `/_allauth`, `/accounts`) fall through to the SPA fallback. The approved plan was to mirror the existing gateway-forward pattern with a new platform-forward layer, using `resolveLocalConfigFromEnv` for the platform URL and `net.fetch` in the main process so the renderer stays same-origin. CSRF cookie mirroring bridges the token to `document.cookie` for the renderer's mutating-request interceptor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)