### PR TITLE
ci(electron): add Electron DMG build to dev-release workflow

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -1757,6 +1757,171 @@ jobs:
           KEYCHAIN_PATH="$HOME/Library/Keychains/$KEYCHAIN_NAME-db"
           security delete-keychain "$KEYCHAIN_PATH" 2>/dev/null || true
 
+  # ── Electron DMG ──────────────────────────────────────────────────────
+
+  build-electron:
+    needs: [compute-version]
+    runs-on: macos-26
+    timeout-minutes: 30
+    continue-on-error: true
+    defaults:
+      run:
+        working-directory: apps/macos
+    env:
+      KEYCHAIN_NAME: build-electron.keychain
+      KEYCHAIN_PASSWORD: temporary-ci-password
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Select Xcode 26.2
+        run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
+
+      - name: Import code-signing certificate
+        env:
+          CERT_P12: ${{ secrets.DEVID_CERTIFICATE_P12 }}
+          CERT_PASSWORD: ${{ secrets.DEVID_CERTIFICATE_PASSWORD }}
+        run: |
+          KEYCHAIN_PATH="$HOME/Library/Keychains/$KEYCHAIN_NAME-db"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_NAME"
+          security set-keychain-settings -lut 3600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          echo "$CERT_P12" | base64 -D > /tmp/certificate.p12
+          security import /tmp/certificate.p12 \
+            -k "$KEYCHAIN_PATH" \
+            -P "$CERT_PASSWORD" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/security
+          rm /tmp/certificate.p12
+
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
+          security default-keychain -s "$KEYCHAIN_PATH"
+          security find-identity -v -p codesigning "$KEYCHAIN_PATH"
+
+      - name: Verify signing identity
+        run: |
+          security find-identity -v -p codesigning | grep -q "Developer ID Application" \
+            || { echo "::error::Developer ID Application identity not found"; exit 1; }
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: '1.3.11'
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Install shared packages
+        uses: ./.github/actions/install-shared-packages
+        with:
+          packages: packages/environments packages/local-mode
+
+      - name: Stamp dev version into package.json
+        run: jq --arg v "${{ needs.compute-version.outputs.version }}" '.version = $v' package.json > package.json.tmp && mv package.json.tmp package.json
+
+      - name: Build and package Electron app
+        env:
+          VELLUM_ENVIRONMENT: dev
+          CSC_NAME: Developer ID Application
+        run: bun run pack
+
+      - name: Rename DMG for release
+        id: dmg
+        run: |
+          ELECTRON_DMG=$(find dist -name "*.dmg" -type f | grep -m1 .)
+          if [ -z "$ELECTRON_DMG" ]; then
+            echo "::error::No DMG found in dist/"
+            ls -la dist/
+            exit 1
+          fi
+          echo "Found DMG: $ELECTRON_DMG"
+          FINAL_DMG="dist/vellum-assistant-electron-dev.dmg"
+          mv "$ELECTRON_DMG" "$FINAL_DMG"
+          echo "dmg_path=$FINAL_DMG" >> "$GITHUB_OUTPUT"
+
+      - name: Sign DMG
+        run: |
+          codesign --sign "Developer ID Application" \
+            --timestamp \
+            "${{ steps.dmg.outputs.dmg_path }}"
+          codesign --verify --verbose "${{ steps.dmg.outputs.dmg_path }}"
+
+      - name: Notarize DMG
+        env:
+          ASC_KEY_P8: ${{ secrets.ASC_KEY_P8 }}
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+        run: |
+          mkdir -p ~/.private_keys
+          echo "$ASC_KEY_P8" > ~/.private_keys/AuthKey_${ASC_KEY_ID}.p8
+
+          echo "Submitting Electron DMG for notarization..."
+          NOTARIZE_OUTPUT=$(xcrun notarytool submit "${{ steps.dmg.outputs.dmg_path }}" \
+            --key ~/.private_keys/AuthKey_${ASC_KEY_ID}.p8 \
+            --key-id "$ASC_KEY_ID" \
+            --issuer "$ASC_ISSUER_ID" \
+            --wait \
+            --timeout 30m \
+            2>&1) || NOTARIZE_FAILED=true
+
+          echo "$NOTARIZE_OUTPUT"
+
+          SUBMISSION_ID=$(echo "$NOTARIZE_OUTPUT" | grep -oE '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' | grep -m1 .)
+
+          if [ "$NOTARIZE_FAILED" = "true" ] || echo "$NOTARIZE_OUTPUT" | grep -q "status: Invalid"; then
+            echo "::error::Electron notarization failed"
+            if [ -n "$SUBMISSION_ID" ]; then
+              xcrun notarytool log "$SUBMISSION_ID" \
+                --key ~/.private_keys/AuthKey_${ASC_KEY_ID}.p8 \
+                --key-id "$ASC_KEY_ID" \
+                --issuer "$ASC_ISSUER_ID" \
+                || echo "::warning::Could not fetch notarization log"
+            fi
+            exit 1
+          fi
+
+      - name: Staple notarization ticket
+        run: |
+          MAX_ATTEMPTS=15
+          WAIT_SECS=60
+          for i in $(seq 1 $MAX_ATTEMPTS); do
+            STAPLE_OUTPUT=$(xcrun stapler staple "${{ steps.dmg.outputs.dmg_path }}" 2>&1)
+            STAPLE_EXIT=$?
+            if [ $STAPLE_EXIT -eq 0 ]; then
+              echo "Stapling succeeded on attempt $i"
+              echo "$STAPLE_OUTPUT"
+              break
+            fi
+            echo "::warning::Stapling attempt $i/$MAX_ATTEMPTS failed (exit code $STAPLE_EXIT):"
+            echo "$STAPLE_OUTPUT"
+            if [ "$i" -eq "$MAX_ATTEMPTS" ]; then
+              echo "::error::Stapling failed after $MAX_ATTEMPTS attempts"
+              exit 1
+            fi
+            echo "Waiting ${WAIT_SECS}s for CDN propagation..."
+            sleep $WAIT_SECS
+            WAIT_SECS=$((WAIT_SECS + 15))
+          done
+
+          xcrun stapler validate "${{ steps.dmg.outputs.dmg_path }}"
+
+      - name: Upload Electron DMG artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: dev-electron-dmg
+          path: apps/macos/dist/vellum-assistant-electron-dev.dmg
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Cleanup keychain and keys
+        if: always()
+        run: |
+          KEYCHAIN_PATH="$HOME/Library/Keychains/$KEYCHAIN_NAME-db"
+          security delete-keychain "$KEYCHAIN_PATH" 2>/dev/null || true
+          rm -rf ~/.private_keys 2>/dev/null || true
+
   # ── Sparkle Rolling Release ────────────────────────────────────────────
   # ── Upload Sparkle artifacts to GCS ───────────────────────────────────
   # Push appcast.xml + ZIP to the public vellum-nonprod-sparkle GCS bucket.


### PR DESCRIPTION
## Summary
- Add `build-electron` job to the dev-release workflow, mirroring the release workflow's electron build (PR #33518)
- Builds, code-signs, notarizes, and staples the Electron DMG with `VELLUM_ENVIRONMENT=dev`
- Uploads the DMG as a `dev-electron-dmg` artifact with 30-day retention; non-blocking (`continue-on-error: true`)

## Original prompt
The user wanted the Electron DMG — recently added to the production release flow in PR #33518 — to also be produced during hourly dev releases. The goal is to have the dev Electron DMG stored as an artifact alongside the existing native Swift dev DMG, so it's available for testing without cutting a full release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)