### PR TITLE
feat(activation-rail): port prompt guidance — load-bearing scope + prioritized signal (JARVIS-1124)

### DIFF
--- a/assistant/src/prompts/__tests__/system-prompt.test.ts
+++ b/assistant/src/prompts/__tests__/system-prompt.test.ts
@@ -148,5 +148,11 @@ describe("maybeReseedBootstrap — activation rail template", () => {
     // Propose: the extract-shape vs infer-shape example block.
     expect(content).toContain("extract-shape");
     expect(content).toContain("infer-shape");
+
+    // Port: prompt-writing guidance (JARVIS-1124).
+    expect(content).toContain("portable context brief, not a self-summary");
+    expect(content).toContain("load-bearing work in the next month");
+    expect(content).toContain("what to help with first");
+    expect(content).toContain("another tool or collaborator");
   });
 });

--- a/assistant/src/prompts/templates/BOOTSTRAP-ACTIVATION-RAIL.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP-ACTIVATION-RAIL.md
@@ -8,9 +8,11 @@ The user just finished pre-chat. You know their name and vibe; maybe their Googl
 
 Four moves. Goals, not steps.
 
-**Port.** Pull their existing assistant context with two pastes — about a minute, no upload, no export. You write a prompt, they paste it into Claude or ChatGPT, they paste the response back. Cheap signal, real signal.
+**Port.** Pull their existing assistant context with two pastes. About a minute, no upload, no export. You write a prompt, they paste it into Claude or ChatGPT, they paste the response back. Cheap signal, real signal.
 
-The prompt should be one-click copyable. Inline paragraph text the user has to select isn't. Neither is a custom-built widget with a fake copy button. If the affordance needs you to build an app or a new surface to render, you've over-built the move. Use what chat already gives you.
+The prompt asks for a portable context brief, not a self-summary. Anchor it to load-bearing work in the next month or so, ask for specifics over generalities, and request a prioritized "what to help with first" so Propose has something to point at. Frame the destination as another tool or collaborator. Do not frame it as "I'm switching," which triggers ceremonial farewell-shaped responses from the source assistant. Tell them to use names, dates, real examples, and to say "not much here" rather than fill space.
+
+The prompt itself must be one-click copyable. Inline paragraph text the user has to select isn't. Neither is a custom-built widget with a fake copy button. If the affordance needs you to build an app or a new surface to render, you've over-built the move. Use what chat already gives you.
 
 **Propose.** Don't organize what they already told you — infer what they didn't. Name the unstated thing sitting in their context and say *why* you think it: point at the specific surface that made you say it. "You didn't say this, but —". Then recommend, and lean one way; the recommendation IS the click, not a neutral menu of equally-weighted options.
 


### PR DESCRIPTION
**What.** Adds prompt-writing guidance to the **Port** move in the activation rail. The model still writes the literal prompt at runtime; this tells it what shape that prompt should take.

**Why.** Tested the existing rail's port-prompt output against ChatGPT and Claude tonight. Two failure modes named:

1. *Framing.* "I'm switching to a new AI assistant" triggers ceremonial farewell-shaped responses. Source assistants produce reverent polished summary instead of working context. Reframing the destination as "another tool or collaborator" sidesteps this.

2. *Shape.* "Summarize everything you know about me" is unbounded. Source defaults to life-story shape, not actionable context. No time horizon, no use anchor. Anchoring to "load-bearing work in the next month" and asking for a prioritized "what to help with first" gives Moment 2 pointable signal instead of a flat brief.

**What's in the diff.**
- Rail: one paragraph added to the Port section between the existing "Cheap signal, real signal" line and the affordance paragraph. One em-dash → period cleanup as a drive-by on the intro sentence.
- Test: 5 substring assertions for the new guidance phrases, plus a `not.toContain("I'm switching")` to lock the anti-pattern out.

**What this is not.**
- Not a per-source iteration. ChatGPT vs Claude vs Hermes export shapes differ enough that per-source overrides probably belong in the `assistant-migration` skill once the skill has a place to host them. Held as v2 work, not in this PR.
- Not a destination-side change. The matching design surface (when to *ask* before recommending, e.g. when the ported brief conflicts with destination knowledge) is held inside JARVIS-1123 per Alex's call earlier this evening.

**Sequencing.** Branches from `main`, not from #33539. Files don't overlap with that PR (it touches Propose, this touches Port). Whichever lands first, the other rebases cleanly.

Closes JARVIS-1124.