### PR TITLE
feat(electron): add text redaction pipeline for feedback log scrubbing

### DIFF
--- a/apps/macos/src/main/redact.test.ts
+++ b/apps/macos/src/main/redact.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { REDACTION_VERSION, redactText } from "./redact";
+
+describe("redactText", () => {
+  test("redacts Bearer tokens", () => {
+    const input = "Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.test+token/value=";
+    expect(redactText(input)).toBe("Authorization: Bearer [REDACTED]");
+  });
+
+  test("redacts sk-* API keys", () => {
+    const input = "Using key sk-abc123def456ghi789jklmnopqrst";
+    expect(redactText(input)).toBe("Using key [REDACTED_API_KEY]");
+  });
+
+  test("redacts email addresses", () => {
+    const input = "Contact user.name+tag@example.co.uk for details";
+    expect(redactText(input)).toBe("Contact [REDACTED_EMAIL] for details");
+  });
+
+  test("redacts /Users/<name>/ paths", () => {
+    const input = "Reading /Users/noaflaherty/Library/Application Support/config";
+    expect(redactText(input)).toBe("Reading ~/Library/Application Support/config");
+  });
+
+  test("redacts combined input with multiple patterns", () => {
+    const input = [
+      "Bearer sk-proj-AAAAAAAAAAAAAAAAAAAAAAAA",
+      "email: admin@vellum.ai",
+      "path: /Users/dev/src/app",
+    ].join("\n");
+
+    const result = redactText(input);
+    expect(result).not.toContain("sk-proj");
+    expect(result).not.toContain("admin@vellum.ai");
+    expect(result).not.toContain("/Users/dev");
+    expect(result).toContain("[REDACTED]");
+    expect(result).toContain("[REDACTED_EMAIL]");
+    expect(result).toContain("~");
+  });
+
+  test("does not false-positive on normal log lines", () => {
+    const input = "[2024-01-01 12:00:00] [info] App started";
+    expect(redactText(input)).toBe(input);
+  });
+
+  test("is idempotent", () => {
+    const input =
+      "Bearer eyJtoken123 sk-AAAAAAAAAAAAAAAAAAAABBBB user@test.com /Users/alice/docs";
+    const once = redactText(input);
+    expect(redactText(once)).toBe(once);
+  });
+});
+
+describe("REDACTION_VERSION", () => {
+  test("is exported as 1", () => {
+    expect(REDACTION_VERSION).toBe(1);
+  });
+});

--- a/apps/macos/src/main/redact.ts
+++ b/apps/macos/src/main/redact.ts
@@ -1,0 +1,16 @@
+export const REDACTION_VERSION = 1;
+
+const PATTERNS: [RegExp, string][] = [
+  [/Bearer\s+[A-Za-z0-9\-._~+/]+=*/g, "Bearer [REDACTED]"],
+  [/sk-[A-Za-z0-9]{20,}/g, "[REDACTED_API_KEY]"],
+  [/[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g, "[REDACTED_EMAIL]"],
+  [/\/Users\/[^/\s]+/g, "~"],
+];
+
+export function redactText(input: string): string {
+  let result = input;
+  for (const [pattern, replacement] of PATTERNS) {
+    result = result.replace(pattern, replacement);
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary
- Add `redactText()` function that strips Bearer tokens, API keys (`sk-*`), email addresses, and `/Users/<name>/` paths from text
- Add `REDACTION_VERSION` constant for bundle metadata verification
- Comprehensive test suite covering each pattern, combined input, false-positive safety, and idempotency

Part of plan: feedback-log-export.md (PR 1 of 7)