### PR TITLE
feat(electron): add Send Feedback command to Help menu and tray

### DIFF
--- a/apps/macos/src/main/commands.ts
+++ b/apps/macos/src/main/commands.ts
@@ -14,6 +14,7 @@ export type VellumCommand =
   | { kind: "currentConversation" }
   | { kind: "markCurrentUnread" }
   | { kind: "openSettings" }
+  | { kind: "shareFeedback" }
   | { kind: "logout" };
 
 export type VellumCommandKind = VellumCommand["kind"];
@@ -32,6 +33,7 @@ export const DEFAULT_ACCELERATORS: Record<VellumCommandKind, string> = {
   currentConversation: "CmdOrCtrl+Shift+N",
   markCurrentUnread: "CmdOrCtrl+Shift+U",
   openSettings: "CmdOrCtrl+,",
+  shareFeedback: "",
   logout: "",
 };
 

--- a/apps/macos/src/main/menu.ts
+++ b/apps/macos/src/main/menu.ts
@@ -96,6 +96,11 @@ const buildTemplate = (): MenuItemConstructorOptions[] => {
       role: "help",
       submenu: [
         {
+          label: "Send Feedback\u2026",
+          click: () => dispatchToFocused({ kind: "shareFeedback" }),
+        },
+        { type: "separator" },
+        {
           label: "Vellum Documentation",
           click: () => {
             void shell.openExternal("https://docs.vellum.ai");

--- a/apps/macos/src/main/tray.ts
+++ b/apps/macos/src/main/tray.ts
@@ -114,6 +114,13 @@ const buildTrayMenu = (handlers: TrayHandlers, status: AssistantStatus): Menu =>
       },
     },
     {
+      label: "Send Feedback\u2026",
+      click: async () => {
+        await handlers.ensureMainWindow();
+        dispatchToMain({ kind: "shareFeedback" });
+      },
+    },
+    {
       label: `About ${app.name}`,
       click: handlers.openAbout,
     },

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -13,6 +13,7 @@ export type VellumCommand =
   | { kind: "currentConversation" }
   | { kind: "markCurrentUnread" }
   | { kind: "openSettings" }
+  | { kind: "shareFeedback" }
   | { kind: "logout" };
 
 // Surface exposed to the renderer as `window.vellum`. `platform`, `settings`,

--- a/apps/web/src/runtime/is-electron.ts
+++ b/apps/web/src/runtime/is-electron.ts
@@ -33,6 +33,7 @@ export type VellumCommand =
   | { kind: "currentConversation" }
   | { kind: "markCurrentUnread" }
   | { kind: "openSettings" }
+  | { kind: "shareFeedback" }
   | { kind: "logout" };
 
 /**


### PR DESCRIPTION
## Summary
- Add `shareFeedback` variant to the `VellumCommand` union across all three mirrors (main, preload, renderer)
- Add "Send Feedback…" to the Help menu (before Vellum Documentation) and tray right-click menu (between Settings and About)
- Menu dispatches via `dispatchToFocused`, tray dispatches via `dispatchToMain` after ensuring the main window is visible

Part of plan: feedback-log-export.md (PR 3 of 7)