### PR TITLE
feat(electron): add electron-log for structured main-process logging

### DIFF
--- a/apps/macos/bun.lock
+++ b/apps/macos/bun.lock
@@ -6,6 +6,7 @@
       "name": "@vellumai/macos",
       "dependencies": {
         "@vellumai/local-mode": "file:../../packages/local-mode",
+        "electron-log": "5.4.4",
         "electron-store": "11.0.2",
         "zod": "4.3.6",
       },
@@ -388,6 +389,8 @@
     "electron-builder": ["electron-builder@26.8.1", "", { "dependencies": { "app-builder-lib": "26.8.1", "builder-util": "26.8.1", "builder-util-runtime": "9.5.1", "chalk": "^4.1.2", "ci-info": "^4.2.0", "dmg-builder": "26.8.1", "fs-extra": "^10.1.0", "lazy-val": "^1.0.5", "simple-update-notifier": "2.0.0", "yargs": "^17.6.2" }, "bin": { "electron-builder": "cli.js", "install-app-deps": "install-app-deps.js" } }, "sha512-uWhx1r74NGpCagG0ULs/P9Nqv2nsoo+7eo4fLUOB8L8MdWltq9odW/uuLXMFCDGnPafknYLZgjNX0ZIFRzOQAw=="],
 
     "electron-builder-squirrel-windows": ["electron-builder-squirrel-windows@26.8.1", "", { "dependencies": { "app-builder-lib": "26.8.1", "builder-util": "26.8.1", "electron-winstaller": "5.4.0" } }, "sha512-o288fIdgPLHA76eDrFADHPoo7VyGkDCYbLV1GzndaMSAVBoZrGvM9m2IehdcVMzdAZJ2eV9bgyissQXHv5tGzA=="],
+
+    "electron-log": ["electron-log@5.4.4", "", {}, "sha512-istWgaXjBfURBSS8LWVW9C3jsc6+ac+tY1lXrQEOTp0lVj+a4OlO1Tmqb36GgnEUDv92DGC9VI1HNXwJinWpgA=="],
 
     "electron-publish": ["electron-publish@26.8.1", "", { "dependencies": { "@types/fs-extra": "^9.0.11", "builder-util": "26.8.1", "builder-util-runtime": "9.5.1", "chalk": "^4.1.2", "form-data": "^4.0.5", "fs-extra": "^10.1.0", "lazy-val": "^1.0.5", "mime": "^2.5.2" } }, "sha512-q+jrSTIh/Cv4eGZa7oVR+grEJo/FoLMYBAnSL5GCtqwUpr1T+VgKB/dn1pnzxIxqD8S/jP1yilT9VrwCqINR4w=="],
 

--- a/apps/macos/electron.vite.config.ts
+++ b/apps/macos/electron.vite.config.ts
@@ -22,6 +22,7 @@ import { defineConfig, externalizeDepsPlugin } from "electron-vite";
 // resolving to a `.ts` file the Electron main process can't load at runtime;
 // inlining lets Rollup compile the source into the bundle.
 const DEPS_TO_INLINE = [
+  "electron-log",
   "electron-store",
   "conf",
   "@vellumai/local-mode",

--- a/apps/macos/package.json
+++ b/apps/macos/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@vellumai/local-mode": "file:../../packages/local-mode",
+    "electron-log": "5.4.4",
     "electron-store": "11.0.2",
     "zod": "4.3.6"
   }

--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -25,6 +25,7 @@ import {
 import { installAvatarIpc } from "./avatar";
 import { installDock } from "./dock";
 import { installLocalMode } from "./local-mode";
+import log from "./logger";
 import {
   ensureVisible as ensureMainWindowVisible,
   installMainWindow,
@@ -342,7 +343,7 @@ app
     });
   })
   .catch((err: unknown) => {
-    console.error("[app] whenReady setup failed:", err);
+    log.error("[app] whenReady setup failed:", err);
   });
 
 app.on("second-instance", (_event, argv) => {

--- a/apps/macos/src/main/logger.ts
+++ b/apps/macos/src/main/logger.ts
@@ -1,0 +1,14 @@
+import log from "electron-log/main";
+
+log.initialize({ preload: true });
+
+log.transports.file.maxSize = 10 * 1024 * 1024; // 10 MB
+log.transports.file.fileName = "vellum.log";
+log.transports.file.format =
+  "[{y}-{m}-{d} {h}:{i}:{s}.{ms}] [{level}] [{processType}] {text}";
+
+export default log;
+
+export const getLogFilePaths = (): string[] => [
+  log.transports.file.getFile().path,
+];


### PR DESCRIPTION
## Summary
- Install `electron-log` (5.4.4) and configure structured file logging (10MB rotation, timestamped format)
- Export `log` and `getLogFilePaths()` for use by the feedback diagnostics system
- Replace bare `console.error` in main process with structured logger

Part of plan: feedback-log-export.md (PR 2 of 7)