### PR TITLE
[LUM-2208] Bundle first-party catalog skills for offline mode in Electron app

### DIFF
--- a/apps/macos/.gitignore
+++ b/apps/macos/.gitignore
@@ -3,3 +3,4 @@ out/
 dist/
 build/
 resources/bun
+resources/first-party-skills

--- a/apps/macos/electron-builder.yml
+++ b/apps/macos/electron-builder.yml
@@ -10,6 +10,8 @@ extraResources:
   # "reset to bundle icon" API). Source is produced by scripts/generate-icon.sh.
   - from: build/icon.icns
     to: icon.icns
+  - from: resources/first-party-skills
+    to: first-party-skills
 afterPack: ./scripts/afterPack.js
 protocols:
   - name: Vellum Deep Links

--- a/apps/macos/package.json
+++ b/apps/macos/package.json
@@ -17,7 +17,7 @@
     "test": "bun test",
     "test:ci": "bun scripts/run-tests.ts",
     "build:fetch-bun": "bash scripts/fetch-bun.sh",
-    "pack": "bash scripts/fetch-bun.sh --arch aarch64 && bash scripts/generate-icon.sh && electron-vite build && electron-builder"
+    "pack": "bash scripts/fetch-bun.sh --arch aarch64 && bash scripts/generate-icon.sh && bash scripts/stage-skills.sh && electron-vite build && electron-builder"
   },
   "devDependencies": {
     "@types/bun": "1.3.14",

--- a/apps/macos/scripts/stage-skills.sh
+++ b/apps/macos/scripts/stage-skills.sh
@@ -26,6 +26,8 @@ rsync -a \
   --exclude='__tests__/' \
   --exclude='meet-join/bot/' \
   --exclude='meet-join/meet-controller-ext/' \
+  --exclude='meet-join/package.json' \
+  --exclude='meet-join/bun.lock' \
   "$SKILLS_SRC/" "$DEST/"
 
 # Emit meet-join manifest (matches emit_meet_join_manifest() in build.sh)

--- a/apps/macos/scripts/stage-skills.sh
+++ b/apps/macos/scripts/stage-skills.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# stage-skills.sh -- Copy the first-party skills catalog into
+# apps/macos/resources/first-party-skills/ for bundling via
+# electron-builder. Mirrors the rsync in clients/macos/build.sh.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR/../../.."
+SKILLS_SRC="$REPO_ROOT/skills"
+DEST="$SCRIPT_DIR/../resources/first-party-skills"
+
+if [ ! -d "$SKILLS_SRC" ]; then
+  echo "ERROR: skills directory not found at $SKILLS_SRC" >&2
+  exit 1
+fi
+
+rm -rf "$DEST"
+mkdir -p "$DEST"
+
+rsync -a \
+  --exclude='node_modules/' \
+  --exclude='*.tsbuildinfo' \
+  --exclude='dist/' \
+  --exclude='build/' \
+  --exclude='.git/' \
+  --exclude='__tests__/' \
+  --exclude='meet-join/bot/' \
+  --exclude='meet-join/meet-controller-ext/' \
+  "$SKILLS_SRC/" "$DEST/"
+
+# Emit meet-join manifest (matches emit_meet_join_manifest() in build.sh)
+EMIT_SCRIPT="$SKILLS_SRC/meet-join/scripts/emit-manifest.ts"
+if [ -f "$EMIT_SCRIPT" ]; then
+  if command -v bun &>/dev/null; then
+    mkdir -p "$DEST/meet-join"
+    (cd "$SKILLS_SRC/meet-join" && bun run scripts/emit-manifest.ts \
+      --output "$DEST/meet-join/manifest.json")
+  else
+    echo "WARNING: bun not on PATH -- skipping meet-join manifest emission" >&2
+  fi
+fi
+
+echo "Staged first-party skills: $(du -sh "$DEST" | cut -f1)"

--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -1,4 +1,5 @@
 import { app, net, protocol, session, shell } from "electron";
+import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import { pathToFileURL } from "node:url";
 import path from "node:path";
@@ -305,6 +306,10 @@ app
   .whenReady()
   .then(async () => {
     if (!isDev) {
+      const skillsDir = path.join(process.resourcesPath, "first-party-skills");
+      if (existsSync(skillsDir)) {
+        process.env.VELLUM_FIRST_PARTY_SKILLS_DIR = skillsDir;
+      }
       // TODO(LUM-2214): a deep-link or second-instance activation during
       // this await can create a window before the protocol handler exists.
       await ensureWebInstalled();

--- a/assistant/src/skills/catalog-install.ts
+++ b/assistant/src/skills/catalog-install.ts
@@ -85,6 +85,11 @@ export function getRepoSkillsDir(): string | undefined {
     return undefined;
   }
 
+  const envSkillsDir = process.env.VELLUM_FIRST_PARTY_SKILLS_DIR;
+  if (envSkillsDir && existsSync(join(envSkillsDir, "catalog.json"))) {
+    return envSkillsDir;
+  }
+
   if (!process.env.VELLUM_DEV) return undefined;
 
   // assistant/src/skills/catalog-install.ts -> ../../../skills/

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -950,6 +950,7 @@ export async function startLocalDaemon(
         "GATEWAY_SECURITY_DIR",
         "CREDENTIAL_SECURITY_DIR",
         "VELLUM_ENVIRONMENT",
+        "VELLUM_FIRST_PARTY_SKILLS_DIR",
         "VELLUM_PLATFORM_URL",
         "QDRANT_HTTP_PORT",
         "QDRANT_URL",


### PR DESCRIPTION
## Summary
- Added `scripts/stage-skills.sh` that rsyncs the repo's `skills/` directory into `resources/first-party-skills/` (2.5MB, excluding meet-join's 210MB bot/extension and all node_modules), emits the meet-join manifest, and is wired into the `pack` build script
- Electron main process sets `VELLUM_FIRST_PARTY_SKILLS_DIR` env var pointing to the bundled directory in packaged mode; the env var propagates through the spawn chain to the daemon
- `getRepoSkillsDir()` in the daemon now checks `VELLUM_FIRST_PARTY_SKILLS_DIR` before the `VELLUM_DEV` fallback, and the env var is added to the compiled-daemon forwarding allowlist

## Original prompt
The Electron app cannot discover or install first-party catalog skills when offline because the daemon's `getRepoSkillsDir()` returns `undefined` in packaged mode — neither the compiled-binary path nor the dev-mode path applies. The plan was to mirror the legacy Swift build's approach: bundle the skills directory into the app's resources at build time and introduce a new `VELLUM_FIRST_PARTY_SKILLS_DIR` env var so the daemon can find the bundled catalog without network access.

## Test plan
- [ ] Run `bash apps/macos/scripts/stage-skills.sh` and verify `resources/first-party-skills/` contains `catalog.json`, 66+ skill dirs with `SKILL.md`, `meet-join/manifest.json`, no `node_modules/`, no `meet-join/bot/`, total < 5MB
- [ ] Run `bun run pack` in `apps/macos/` and verify `Vellum.app/Contents/Resources/first-party-skills/catalog.json` exists
- [ ] Launch packaged app with network disabled; verify skills catalog loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)