### PR TITLE
Preserve chat scroll when opening assets

### DIFF
--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -718,9 +718,10 @@ export function ChatRouteContent({
   // Load older messages
   // -------------------------------------------------------------------------
 
+  const { fetchOlderPage } = historyPagination;
   const loadOlder = useCallback(() => {
-    historyPagination.fetchOlderPage();
-  }, [historyPagination.fetchOlderPage]);
+    fetchOlderPage();
+  }, [fetchOlderPage]);
 
   // -------------------------------------------------------------------------
   // Transcript items (projection of chat state onto flat list)
@@ -785,6 +786,34 @@ export function ChatRouteContent({
   // Scroll coordination
   // -------------------------------------------------------------------------
 
+  const transcriptLayoutKey = useMemo(() => {
+    if (mainView === "app-editing" && openedAppState && editingConversationId) {
+      return `app-editing:${openedAppState.appId}:${editingConversationId}`;
+    }
+    if (mainView === "app" && !isMobile) {
+      return openedAppState ? `app:${openedAppState.appId}` : "app:loading";
+    }
+    if (mainView === "document" && !isMobile && openedDocumentState && assistantId) {
+      return `document:${openedDocumentState.surfaceId}`;
+    }
+    if (mainView === "subagent-detail" && activeSubagentId && !isMobile) {
+      return `subagent-detail:${activeSubagentId}`;
+    }
+    if (mainView === "tool-detail" && activeToolDetail && !isMobile) {
+      return `tool-detail:${activeToolDetail.toolCallId}`;
+    }
+    return "chat";
+  }, [
+    activeSubagentId,
+    activeToolDetail,
+    assistantId,
+    editingConversationId,
+    isMobile,
+    mainView,
+    openedAppState,
+    openedDocumentState,
+  ]);
+
   const scrollCoordinator = useTranscriptScroll({
     transcriptRef,
     items: transcriptItems,
@@ -792,6 +821,7 @@ export function ChatRouteContent({
     hasMore: transcriptPagination.hasMore,
     isLoadingOlder: transcriptPagination.isLoadingOlder,
     onLoadOlder: loadOlder,
+    layoutKey: transcriptLayoutKey,
   });
 
   const handleScrollToLatest = useCallback(() => {

--- a/apps/web/src/domains/chat/transcript/transcript-scroll-utils.ts
+++ b/apps/web/src/domains/chat/transcript/transcript-scroll-utils.ts
@@ -34,11 +34,19 @@ export interface ScrollMetrics {
   clientHeight: number;
 }
 
+export interface ScrollPositionSnapshot extends ScrollMetrics {
+  distanceFromBottom: number;
+}
+
 export interface ScrollClassification {
   distanceFromBottom: number;
   isPinned: boolean;
   showScrollToLatest: boolean;
   shouldLoadOlder: boolean;
+}
+
+function maxScrollTop(metrics: Pick<ScrollMetrics, "scrollHeight" | "clientHeight">): number {
+  return Math.max(0, metrics.scrollHeight - metrics.clientHeight);
 }
 
 /** Pure classification of a scroll position against the load-bearing
@@ -55,11 +63,7 @@ export function classifyScrollPosition(
   metrics: ScrollMetrics,
   flags: { hasMore: boolean; isLoadingOlder: boolean; hasConversation: boolean },
 ): ScrollClassification {
-  const maxScrollTop = Math.max(
-    0,
-    metrics.scrollHeight - metrics.clientHeight,
-  );
-  const distanceFromBottom = Math.max(0, maxScrollTop - metrics.scrollTop);
+  const distanceFromBottom = Math.max(0, maxScrollTop(metrics) - metrics.scrollTop);
   const distanceFromTop = Math.max(0, metrics.scrollTop);
   const isPinned = distanceFromBottom <= PINNED_THRESHOLD_PX;
   const showScrollToLatest =
@@ -70,6 +74,26 @@ export function classifyScrollPosition(
     !flags.isLoadingOlder &&
     distanceFromTop <= LOAD_OLDER_THRESHOLD_PX;
   return { distanceFromBottom, isPinned, showScrollToLatest, shouldLoadOlder };
+}
+
+export function captureScrollPositionSnapshot(
+  metrics: ScrollMetrics,
+): ScrollPositionSnapshot {
+  return {
+    ...metrics,
+    distanceFromBottom: Math.max(0, maxScrollTop(metrics) - metrics.scrollTop),
+  };
+}
+
+export function resolveRemountScrollTop(
+  snapshot: ScrollPositionSnapshot,
+  nextMetrics: Pick<ScrollMetrics, "scrollHeight" | "clientHeight">,
+): number {
+  const nextMaxScrollTop = maxScrollTop(nextMetrics);
+  if (snapshot.distanceFromBottom <= PINNED_THRESHOLD_PX) {
+    return nextMaxScrollTop;
+  }
+  return Math.max(0, Math.min(snapshot.scrollTop, nextMaxScrollTop));
 }
 
 /** Find the new index of a previously saved anchor key inside a refreshed

--- a/apps/web/src/domains/chat/transcript/use-transcript-scroll.test.ts
+++ b/apps/web/src/domains/chat/transcript/use-transcript-scroll.test.ts
@@ -22,9 +22,11 @@ import type { TranscriptItem } from "@/domains/chat/transcript/types";
 import {
   classifyScrollPosition,
   decideItemsChangeAction,
+  captureScrollPositionSnapshot,
   findAnchorIndex,
   findLatestUserAnchorKey,
   PINNED_THRESHOLD_PX,
+  resolveRemountScrollTop,
   SHOW_SCROLL_BUTTON_THRESHOLD_PX,
 } from "@/domains/chat/transcript/transcript-scroll-utils";
 import type { TranscriptHandle } from "@/domains/chat/transcript/transcript";
@@ -235,6 +237,46 @@ describe("classifyScrollPosition — load-older threshold (200 px)", () => {
       { hasMore: true, isLoadingOlder: false, hasConversation: false },
     );
     expect(c.shouldLoadOlder).toBe(false);
+  });
+});
+
+describe("resolveRemountScrollTop", () => {
+  test("restores pinned snapshots to the new bottom", () => {
+    const snapshot = captureScrollPositionSnapshot({
+      scrollTop: 960,
+      scrollHeight: 1800,
+      clientHeight: 800,
+    });
+    expect(snapshot.distanceFromBottom).toBe(40);
+    expect(resolveRemountScrollTop(snapshot, {
+      scrollHeight: 2400,
+      clientHeight: 700,
+    })).toBe(1700);
+  });
+
+  test("restores mid-scroll snapshots by their previous top offset", () => {
+    const snapshot = captureScrollPositionSnapshot({
+      scrollTop: 420,
+      scrollHeight: 1800,
+      clientHeight: 800,
+    });
+    expect(snapshot.distanceFromBottom).toBe(580);
+    expect(resolveRemountScrollTop(snapshot, {
+      scrollHeight: 2400,
+      clientHeight: 700,
+    })).toBe(420);
+  });
+
+  test("clamps mid-scroll snapshots when the new scroll range is smaller", () => {
+    const snapshot = captureScrollPositionSnapshot({
+      scrollTop: 900,
+      scrollHeight: 2200,
+      clientHeight: 800,
+    });
+    expect(resolveRemountScrollTop(snapshot, {
+      scrollHeight: 1000,
+      clientHeight: 500,
+    })).toBe(500);
   });
 });
 

--- a/apps/web/src/domains/chat/transcript/use-transcript-scroll.ts
+++ b/apps/web/src/domains/chat/transcript/use-transcript-scroll.ts
@@ -34,9 +34,12 @@ import {
 import type { TranscriptItem } from "@/domains/chat/transcript/types";
 import {
   type AnchorSnapshot,
+  captureScrollPositionSnapshot,
   classifyScrollPosition,
   decideItemsChangeAction,
   findLatestUserAnchorKey,
+  resolveRemountScrollTop,
+  type ScrollPositionSnapshot,
   type ScrollMetrics,
 } from "@/domains/chat/transcript/transcript-scroll-utils";
 
@@ -53,6 +56,7 @@ export interface UseTranscriptScrollArgs {
   hasMore: boolean;
   isLoadingOlder: boolean;
   onLoadOlder: () => void;
+  layoutKey?: string | number | boolean | null;
 }
 
 export interface UseTranscriptScrollReturn {
@@ -74,10 +78,23 @@ export function useTranscriptScroll(
     hasMore,
     isLoadingOlder,
     onLoadOlder,
+    layoutKey,
   } = args;
 
   const [isPinnedToLatest, setIsPinnedToLatest] = useState(true);
   const [showScrollToLatest, setShowScrollToLatest] = useState(false);
+  const lastScrollSnapshotRef = useRef<ScrollPositionSnapshot | null>(null);
+  const mountedScrollElementRef = useRef<HTMLElement | null>(null);
+  const restoredConversationIdRef = useRef<string | null>(conversationId);
+
+  const recordScrollSnapshot = useCallback((el: HTMLElement | null) => {
+    if (!el) return;
+    lastScrollSnapshotRef.current = captureScrollPositionSnapshot({
+      scrollTop: el.scrollTop,
+      scrollHeight: el.scrollHeight,
+      clientHeight: el.clientHeight,
+    });
+  }, []);
 
   // ---------- Latest-props ref (ref-backed fresh-closure pattern) ---------
   // Synced in useLayoutEffect (declared BEFORE the items-effect below)
@@ -240,6 +257,44 @@ export function useTranscriptScroll(
     engageAutoPin();
   }, [conversationId, engageAutoPin]);
 
+  // Layout transitions (opening app-editing/document split panels) remount
+  // the Transcript without changing `items`. Preserve the last known scroll
+  // position across that DOM-node replacement so the chat pane does not jump
+  // to the oldest messages.
+  useLayoutEffect(() => {
+    const el = transcriptRef.current?.getScrollElement() ?? null;
+    const conversationChanged =
+      restoredConversationIdRef.current !== conversationId;
+    restoredConversationIdRef.current = conversationId;
+
+    if (conversationChanged) {
+      lastScrollSnapshotRef.current = null;
+      mountedScrollElementRef.current = el;
+      return;
+    }
+
+    if (!el) return;
+
+    if (el !== mountedScrollElementRef.current) {
+      const snapshot = lastScrollSnapshotRef.current;
+      mountedScrollElementRef.current = el;
+      if (snapshot) {
+        el.scrollTop = resolveRemountScrollTop(snapshot, {
+          scrollHeight: el.scrollHeight,
+          clientHeight: el.clientHeight,
+        });
+      }
+    }
+
+    recordScrollSnapshot(el);
+  }, [
+    conversationId,
+    items,
+    layoutKey,
+    recordScrollSnapshot,
+    transcriptRef,
+  ]);
+
   // -----------------------------------------------------------------------
   // Items change handler — runs in useLayoutEffect so the anchor correction
   // happens before the browser paints.
@@ -332,6 +387,7 @@ export function useTranscriptScroll(
     // the current commit).
     const el = transcriptRef.current?.getScrollElement();
     if (el) {
+      recordScrollSnapshot(el);
       const classification = classifyScrollPosition(
         {
           scrollTop: el.scrollTop,
@@ -374,7 +430,7 @@ export function useTranscriptScroll(
         latest.onLoadOlder();
       }
     }
-  }, [items, conversationId, transcriptRef, engageAutoPin]);
+  }, [items, conversationId, transcriptRef, engageAutoPin, recordScrollSnapshot]);
 
   // -----------------------------------------------------------------------
   // Container resize re-pin. When the scroll container resizes (e.g. the
@@ -410,11 +466,12 @@ export function useTranscriptScroll(
     const observer = new ResizeObserver(() => {
       if (latestRef.current.isPinnedToLatest) {
         transcriptRef.current?.scrollToLatest({ behavior: "auto" });
+        recordScrollSnapshot(transcriptRef.current?.getScrollElement() ?? null);
       }
     });
     observer.observe(el);
     resizeObserverRef.current = observer;
-  }, [items, transcriptRef]);
+  }, [items, transcriptRef, recordScrollSnapshot]);
 
   // Disconnect observer on hook unmount.
   useEffect(() => () => {
@@ -454,11 +511,12 @@ export function useTranscriptScroll(
     const observer = new ResizeObserver(() => {
       if (shouldAutoPinRef.current) {
         transcriptRef.current?.scrollToLatest({ behavior: "auto" });
+        recordScrollSnapshot(transcriptRef.current?.getScrollElement() ?? null);
       }
     });
     observer.observe(el);
     contentObserverRef.current = observer;
-  }, [items, transcriptRef]);
+  }, [items, transcriptRef, recordScrollSnapshot]);
 
   useEffect(() => () => {
     contentObserverRef.current?.disconnect();
@@ -495,6 +553,7 @@ export function useTranscriptScroll(
       scrollHeight: target.scrollHeight,
       clientHeight: target.clientHeight,
     };
+    lastScrollSnapshotRef.current = captureScrollPositionSnapshot(metrics);
     const latest = latestRef.current;
     const classification = classifyScrollPosition(metrics, {
       hasMore: latest.hasMore,
@@ -544,8 +603,9 @@ export function useTranscriptScroll(
       transcriptRef.current?.scrollToLatest({
         behavior: opts?.behavior ?? "smooth",
       });
+      recordScrollSnapshot(transcriptRef.current?.getScrollElement() ?? null);
     },
-    [transcriptRef, engageAutoPin],
+    [transcriptRef, engageAutoPin, recordScrollSnapshot],
   );
 
   // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Preserve transcript scroll when opening assets that switch chat into a document/app split panel.
- Track split-panel layout transitions in the transcript scroll coordinator so remounts restore the prior position instead of starting at the top.
- Add focused regression coverage for pinned and mid-scroll restoration math.

## Original prompt
The user reported that selecting an item from the conversation Assets panel makes the conversation jump to the top when the document editor or app builder panel opens, and asked for the chat to stay where it is.