### PR TITLE
feat(web): open ShareFeedbackModal from Electron shareFeedback command

### DIFF
--- a/apps/web/src/root-layout.tsx
+++ b/apps/web/src/root-layout.tsx
@@ -1,5 +1,7 @@
+import { lazy, useState } from "react";
 import { Outlet, useNavigate } from "react-router";
 
+import { LazyBoundary } from "@/components/lazy-boundary";
 import { useAppTheme } from "@/hooks/use-app-theme";
 import { useEventBusInit } from "@/hooks/use-event-bus-init";
 import { useGlobalDeepLinkConsumer } from "@/hooks/use-global-deep-link-consumer";
@@ -32,6 +34,12 @@ import { useDynamicFavicon } from "@/hooks/use-dynamic-favicon";
 import { useElectronIconSync } from "@/hooks/use-electron-icon-sync";
 import { useElectronStatusSync } from "@/hooks/use-electron-status-sync";
 import { TimezoneSync } from "@/components/timezone-sync";
+
+const ShareFeedbackModal = lazy(() =>
+  import("@/components/share-feedback-modal").then((m) => ({
+    default: m.ShareFeedbackModal,
+  })),
+);
 
 /**
  * Threshold (in px) below which a `innerHeight − visualViewport.height` delta
@@ -120,6 +128,8 @@ export function RootLayout() {
   // hand off via `pending-deep-link-store`.
   useGlobalDeepLinkConsumer();
 
+  const [feedbackOpen, setFeedbackOpen] = useState(false);
+
   useVellumCommands({
     openSettings: () => {
       void navigate(routes.settings.root);
@@ -131,6 +141,7 @@ export function RootLayout() {
         navigate(getOnboardingEntrypoint());
       });
     },
+    shareFeedback: () => setFeedbackOpen(true),
   });
 
   const keyboardOpen =
@@ -181,6 +192,15 @@ export function RootLayout() {
       {/* Headless: keeps daemon config.ui.detectedTimezone fresh on
           focus/zone change. No-ops until an assistant id resolves. */}
       <TimezoneSync />
+
+      {feedbackOpen ? (
+        <LazyBoundary>
+          <ShareFeedbackModal
+            open={feedbackOpen}
+            onClose={() => setFeedbackOpen(false)}
+          />
+        </LazyBoundary>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Handle the `shareFeedback` command in root-layout via `useVellumCommands` so Help menu and tray open the modal from any route
- Lazy-load `ShareFeedbackModal` to keep it out of the initial bundle

Part of plan: feedback-log-export.md (PR 4 of 7)