### PR TITLE
feat(electron): add IPC channels for feedback diagnostics and redacted logs

### DIFF
--- a/apps/macos/src/main/feedback.ts
+++ b/apps/macos/src/main/feedback.ts
@@ -1,0 +1,104 @@
+import { app, powerMonitor } from "electron";
+import os from "node:os";
+import fs from "node:fs/promises";
+import { z } from "zod";
+
+import { handle } from "./ipc";
+import { getVersionInfo } from "./about";
+import { readSetting } from "./settings";
+import { getLogFilePaths } from "./logger";
+import { redactText, REDACTION_VERSION } from "./redact";
+
+export interface ElectronDiagnostics {
+  app: {
+    name: string;
+    version: string;
+    commitSha: string;
+  };
+  process: {
+    node: string;
+    electron: string;
+    chrome: string;
+    v8: string;
+    uptime: number;
+  };
+  platform: {
+    os: string;
+    arch: string;
+    release: string;
+    type: string;
+    totalMemory: number;
+    freeMemory: number;
+  };
+  appMetrics: Electron.ProcessMetric[];
+  idleTime: number;
+  featureFlags: unknown;
+  redactionVersion: number;
+}
+
+export function collectDiagnostics(): ElectronDiagnostics {
+  const versionInfo = getVersionInfo();
+  return {
+    app: {
+      name: versionInfo.appName,
+      version: versionInfo.version,
+      commitSha: versionInfo.commitSha,
+    },
+    process: {
+      node: process.versions.node,
+      electron: process.versions.electron,
+      chrome: process.versions.chrome,
+      v8: process.versions.v8,
+      uptime: process.uptime(),
+    },
+    platform: {
+      os: process.platform,
+      arch: process.arch,
+      release: os.release(),
+      type: os.type(),
+      totalMemory: os.totalmem(),
+      freeMemory: os.freemem(),
+    },
+    appMetrics: app.getAppMetrics(),
+    idleTime: powerMonitor.getSystemIdleTime(),
+    featureFlags: readSetting("featureFlags"),
+    redactionVersion: REDACTION_VERSION,
+  };
+}
+
+export async function collectRedactedLogs(timeRange: {
+  startMs: number | null;
+  endMs: number;
+}): Promise<string> {
+  void timeRange; // reserved for future per-line filtering
+  const paths = getLogFilePaths();
+  const parts: string[] = [];
+  for (const p of paths) {
+    try {
+      const content = await fs.readFile(p, "utf-8");
+      parts.push(content);
+    } catch {
+      // Missing or unreadable log file — skip gracefully
+    }
+  }
+  return redactText(parts.join("\n"));
+}
+
+let installed = false;
+
+export function installFeedbackIpc(): void {
+  if (installed) return;
+  installed = true;
+
+  handle("vellum:feedback:diagnostics", z.tuple([]), () =>
+    collectDiagnostics(),
+  );
+
+  handle(
+    "vellum:feedback:logs",
+    z.tuple([
+      z.object({ startMs: z.number().nullable(), endMs: z.number() }),
+    ]),
+    ([timeRange]) => collectRedactedLogs(timeRange),
+  );
+}

--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -24,6 +24,7 @@ import {
 } from "./deep-links";
 import { installAvatarIpc } from "./avatar";
 import { installDock } from "./dock";
+import { installFeedbackIpc } from "./feedback";
 import { installLocalMode } from "./local-mode";
 import log from "./logger";
 import {
@@ -315,6 +316,7 @@ app
     installSettingsIpc();
     installLocalMode();
     installAbout();
+    installFeedbackIpc();
     installApplicationMenu();
     // Register the avatar channel before the Dock and Tray install so their
     // initial render reflects any avatar the renderer publishes during

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -287,6 +287,12 @@ export interface VellumBridge {
      */
     onLink(callback: (link: DeepLink) => void): () => void;
   };
+  feedback: {
+    /** Collect Electron-specific diagnostics (versions, platform, metrics). */
+    diagnostics(): Promise<Record<string, unknown>>;
+    /** Read redacted log file content for the given time range. */
+    logs(timeRange: { startMs: number | null; endMs: number }): Promise<string>;
+  };
 }
 
 const notImplemented = (name: string) => (): Promise<never> =>
@@ -429,6 +435,14 @@ const bridge: VellumBridge = {
         ipcRenderer.send("vellum:deepLinks:unsubscribe");
       };
     },
+  },
+  feedback: {
+    diagnostics: () =>
+      ipcRenderer.invoke("vellum:feedback:diagnostics") as Promise<
+        Record<string, unknown>
+      >,
+    logs: (timeRange: { startMs: number | null; endMs: number }) =>
+      ipcRenderer.invoke("vellum:feedback:logs", timeRange) as Promise<string>,
   },
 };
 

--- a/apps/web/src/runtime/is-electron.ts
+++ b/apps/web/src/runtime/is-electron.ts
@@ -143,6 +143,13 @@ declare global {
           ) => void,
         ): () => void;
       };
+      feedback?: {
+        diagnostics(): Promise<Record<string, unknown>>;
+        logs(timeRange: {
+          startMs: number | null;
+          endMs: number;
+        }): Promise<string>;
+      };
     };
   }
 }


### PR DESCRIPTION
## Summary
- Add `collectDiagnostics()` gathering app version, process versions, platform info, app metrics, idle time, and feature flags
- Add `collectRedactedLogs()` that reads log files and applies the redaction pipeline before returning content
- Wire both as IPC handlers (`vellum:feedback:diagnostics`, `vellum:feedback:logs`) with Zod validation
- Extend preload bridge and renderer type mirror with `feedback` namespace

Part of plan: feedback-log-export.md (PR 5 of 7)