### PR TITLE
feat(web): show Share Feedback menu item for local-mode Electron users

### DIFF
--- a/apps/web/src/domains/chat/components/preferences-menu.tsx
+++ b/apps/web/src/domains/chat/components/preferences-menu.tsx
@@ -31,6 +31,7 @@ import {
 } from "@/hooks/use-platform-gate";
 import { hardNavigate } from "@/lib/auth/hard-navigate";
 import { isLocalMode } from "@/lib/local-mode";
+import { isElectron } from "@/runtime/is-electron";
 import {
     useAuthStore,
     useHasPlatformSession,
@@ -219,7 +220,7 @@ function PreferencesMenuContent({
         }}
       />
 
-      {platformGate === "full" && (
+      {(platformGate === "full" || isElectron()) && (
         <PanelItem
           icon={MessageSquareText}
           label="Share Feedback"


### PR DESCRIPTION
## Summary
- Ungate the Share Feedback sidebar menu item for Electron users regardless of platform session state
- Local-mode users can now access feedback from the sidebar, consistent with the Help menu and tray

Part of plan: feedback-log-export.md (PR 7 of 7)