### PR TITLE
fix(web): remove stale userId dep from hatching effect to prevent double-hatch 401

### DIFF
--- a/apps/macos/src/main/redact.test.ts
+++ b/apps/macos/src/main/redact.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { REDACTION_VERSION, redactText } from "./redact";
+
+describe("redactText", () => {
+  test("redacts Bearer tokens", () => {
+    const input = "Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.test+token/value=";
+    expect(redactText(input)).toBe("Authorization: Bearer [REDACTED]");
+  });
+
+  test("redacts sk-* API keys", () => {
+    const input = "Using key sk-abc123def456ghi789jklmnopqrst";
+    expect(redactText(input)).toBe("Using key [REDACTED_API_KEY]");
+  });
+
+  test("redacts email addresses", () => {
+    const input = "Contact user.name+tag@example.co.uk for details";
+    expect(redactText(input)).toBe("Contact [REDACTED_EMAIL] for details");
+  });
+
+  test("redacts /Users/<name>/ paths", () => {
+    const input = "Reading /Users/noaflaherty/Library/Application Support/config";
+    expect(redactText(input)).toBe("Reading ~/Library/Application Support/config");
+  });
+
+  test("redacts combined input with multiple patterns", () => {
+    const input = [
+      "Bearer sk-proj-AAAAAAAAAAAAAAAAAAAAAAAA",
+      "email: admin@vellum.ai",
+      "path: /Users/dev/src/app",
+    ].join("\n");
+
+    const result = redactText(input);
+    expect(result).not.toContain("sk-proj");
+    expect(result).not.toContain("admin@vellum.ai");
+    expect(result).not.toContain("/Users/dev");
+    expect(result).toContain("[REDACTED]");
+    expect(result).toContain("[REDACTED_EMAIL]");
+    expect(result).toContain("~");
+  });
+
+  test("does not false-positive on normal log lines", () => {
+    const input = "[2024-01-01 12:00:00] [info] App started";
+    expect(redactText(input)).toBe(input);
+  });
+
+  test("is idempotent", () => {
+    const input =
+      "Bearer eyJtoken123 sk-AAAAAAAAAAAAAAAAAAAABBBB user@test.com /Users/alice/docs";
+    const once = redactText(input);
+    expect(redactText(once)).toBe(once);
+  });
+});
+
+describe("REDACTION_VERSION", () => {
+  test("is exported as 1", () => {
+    expect(REDACTION_VERSION).toBe(1);
+  });
+});

--- a/apps/macos/src/main/redact.ts
+++ b/apps/macos/src/main/redact.ts
@@ -1,0 +1,16 @@
+export const REDACTION_VERSION = 1;
+
+const PATTERNS: [RegExp, string][] = [
+  [/Bearer\s+[A-Za-z0-9\-._~+/]+=*/g, "Bearer [REDACTED]"],
+  [/sk-[A-Za-z0-9]{20,}/g, "[REDACTED_API_KEY]"],
+  [/[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g, "[REDACTED_EMAIL]"],
+  [/\/Users\/[^/\s]+/g, "~"],
+];
+
+export function redactText(input: string): string {
+  let result = input;
+  for (const [pattern, replacement] of PATTERNS) {
+    result = result.replace(pattern, replacement);
+  }
+  return result;
+}

--- a/apps/web/debug-storybook.log
+++ b/apps/web/debug-storybook.log
@@ -1,0 +1,18 @@
+[20:23:34.022] [INFO] storybook v10.4.0
+[20:23:36.149] [DEBUG] Getting package.json info for /Users/noaflaherty/Repos/vellum-ai/vellum-assistant/apps/web/package.json...
+[20:23:37.251] [INFO] Starting...
+[20:23:37.630] [DEBUG] Starting preview..
+[20:23:37.718] [ERROR] Failed to build the preview
+[20:23:37.718] [ERROR] [38;2;241;97;97mError: Cannot find package '/Users/noaflaherty/Repos/vellum-ai/vellum-assistant/packages/local-mode/node_modules/@vellumai/environments/index.js' imported from /Users/noaflaherty/Repos/vellum-ai/vellum-assistant/packages/local-mode/src/config.ts[39m
+    at legacyMainResolve (node:internal/modules/esm/resolve:215:26)
+    at packageResolve (node:internal/modules/esm/resolve:860:14)
+    at moduleResolve (node:internal/modules/esm/resolve:946:18)
+    at defaultResolve (node:internal/modules/esm/resolve:1188:11)
+    at nextResolve (node:internal/modules/esm/hooks:864:28)
+    at o (file://./node_modules/@tailwindcss/node/dist/esm-cache.loader.mjs:1:74)
+    at nextResolve (node:internal/modules/esm/hooks:864:28)
+    at Hooks.resolve (node:internal/modules/esm/hooks:306:30)
+    at handleMessage (node:internal/modules/esm/worker:196:24)
+    at Immediate.checkForMessages (node:internal/modules/esm/worker:138:28)
+[20:23:37.722] [WARN] Broken build, fix the error above.
+You may need to refresh the browser.

--- a/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/domains/onboarding/prefs";
 import { applyPendingProviderKey } from "@/domains/onboarding/provider-key";
 import { getLocalGatewayUrl, isLocalMode, loadLockfile, primeLocalGatewayConnection, saveLockfileAssistant, setSelectedAssistantId } from "@/lib/local-mode";
+import { clearGatewayToken } from "@/lib/auth/gateway-session";
 import { resolveNavigation } from "@/lib/navigation/navigation-resolver";
 import { buildNavigationState } from "@/lib/navigation/build-state";
 import { hatchLocalAssistant } from "@/runtime/local-mode-host";
@@ -95,7 +96,6 @@ export function HatchingScreen() {
   const isReplay = searchParams.get("replay") === "1";
   const hostingParam = searchParams.get("hosting");
   const useLocalHatch = isLocalMode() && hostingParam !== null && hostingParam !== "vellum-cloud";
-  const userId = useAuthStore.use.user()?.id ?? null;
   const sessionStatus = useAuthStore.use.sessionStatus();
   const [, setOnboardingCompleted] = useOnboardingCompleted();
   const [hatchTraits] = useState<CharacterTraits>(() =>
@@ -244,6 +244,7 @@ export function HatchingScreen() {
                     "status" in body &&
                     body.status === "ok"
                   ) {
+                    clearGatewayToken();
                     await primeLocalGatewayConnection();
                     gatewayReady = true;
                     break;
@@ -400,7 +401,6 @@ export function HatchingScreen() {
     setOnboardingCompleted,
     transitionPhase,
     useLocalHatch,
-    userId,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Removed stale `userId` dependency from hatching screen's `useEffect` — it was left behind when PR #33499 removed the privacy consent logic that used it, causing spurious effect re-runs that triggered a double-hatch race
- Added `clearGatewayToken()` before `primeLocalGatewayConnection()` during local hatch so a fresh token is always acquired, guarding against stale-token-same-port edge cases

## Original prompt
After going through the onboarding flow with platform mode disabled and local hosting, the hatched assistant was unreachable — gateway API calls (e.g. `pending-interactions`) returned 401. The user suspected a regression from PR #33499 (navigation resolver consolidation). Investigation revealed a double-hatch race: the PR's added async work in `probePlatformSession` delayed a `userId` store update into the hatching screen's 800ms navigation delay, re-triggering the effect and spawning a second assistant with a different signing key while `ensureGatewayToken` reused the stale token from the first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)