### PR TITLE
fix(web): preserve conversation-scoped logs for non-Electron feedback

### DIFF
--- a/apps/web/src/components/share-feedback-modal.tsx
+++ b/apps/web/src/components/share-feedback-modal.tsx
@@ -609,7 +609,7 @@ export function ShareFeedbackModal({
           ? await buildClientLogsFile(
               logTimeRange,
               assistantId ?? null,
-              includeConversation ? (activeConversationId ?? null) : null,
+              isElectron() ? (includeConversation ? (activeConversationId ?? null) : null) : (activeConversationId ?? null),
               getDiagnosticsSnapshot,
             )
           : null;


### PR DESCRIPTION
## Summary
Fixes regression where web feedback submissions lost conversation-scoped platform logs.

**Gap:** includeConversation gate applied unconditionally but toggle only renders in Electron
**What was expected:** Web users keep conversation-scoped logs as before
**What was found:** activeConversationId always passed as null on web