### PR TITLE
fix(electron): remove unused timeRange parameter from feedback logs IPC

### DIFF
--- a/apps/macos/src/main/feedback.ts
+++ b/apps/macos/src/main/feedback.ts
@@ -66,11 +66,7 @@ export function collectDiagnostics(): ElectronDiagnostics {
   };
 }
 
-export async function collectRedactedLogs(timeRange: {
-  startMs: number | null;
-  endMs: number;
-}): Promise<string> {
-  void timeRange; // reserved for future per-line filtering
+export async function collectRedactedLogs(): Promise<string> {
   const paths = getLogFilePaths();
   const parts: string[] = [];
   for (const p of paths) {
@@ -94,11 +90,5 @@ export function installFeedbackIpc(): void {
     collectDiagnostics(),
   );
 
-  handle(
-    "vellum:feedback:logs",
-    z.tuple([
-      z.object({ startMs: z.number().nullable(), endMs: z.number() }),
-    ]),
-    ([timeRange]) => collectRedactedLogs(timeRange),
-  );
+  handle("vellum:feedback:logs", z.tuple([]), () => collectRedactedLogs());
 }

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -290,8 +290,8 @@ export interface VellumBridge {
   feedback: {
     /** Collect Electron-specific diagnostics (versions, platform, metrics). */
     diagnostics(): Promise<Record<string, unknown>>;
-    /** Read redacted log file content for the given time range. */
-    logs(timeRange: { startMs: number | null; endMs: number }): Promise<string>;
+    /** Read redacted log file content. */
+    logs(): Promise<string>;
   };
 }
 
@@ -441,8 +441,8 @@ const bridge: VellumBridge = {
       ipcRenderer.invoke("vellum:feedback:diagnostics") as Promise<
         Record<string, unknown>
       >,
-    logs: (timeRange: { startMs: number | null; endMs: number }) =>
-      ipcRenderer.invoke("vellum:feedback:logs", timeRange) as Promise<string>,
+    logs: () =>
+      ipcRenderer.invoke("vellum:feedback:logs") as Promise<string>,
   },
 };
 

--- a/apps/web/src/components/share-feedback-modal.tsx
+++ b/apps/web/src/components/share-feedback-modal.tsx
@@ -391,10 +391,7 @@ async function buildClientLogsFile(
     } catch { /* best-effort */ }
 
     try {
-      const redactedLogs = await window.vellum.feedback.logs({
-        startMs: startTime,
-        endMs: endTime,
-      });
+      const redactedLogs = await window.vellum.feedback.logs();
       if (redactedLogs) {
         const logBytes = new TextEncoder().encode(redactedLogs);
         tarParts.push(buildTarEntry("electron-main-logs.txt", logBytes));

--- a/apps/web/src/runtime/is-electron.ts
+++ b/apps/web/src/runtime/is-electron.ts
@@ -145,10 +145,7 @@ declare global {
       };
       feedback?: {
         diagnostics(): Promise<Record<string, unknown>>;
-        logs(timeRange: {
-          startMs: number | null;
-          endMs: number;
-        }): Promise<string>;
+        logs(): Promise<string>;
       };
     };
   }


### PR DESCRIPTION
## Summary
Removes unused timeRange parameter that was wired across 3 layers (main, preload, renderer) but discarded in the handler.

**Gap:** timeRange parameter wired but voided in collectRedactedLogs
**What was expected:** Clean IPC surface with no unused parameters
**What was found:** Parameter crosses 3 layers for zero benefit