### PR TITLE
[LUM-1980] Share feedback / log export — bundle + redact + send

### DIFF
--- a/apps/macos/bun.lock
+++ b/apps/macos/bun.lock
@@ -6,6 +6,7 @@
       "name": "@vellumai/macos",
       "dependencies": {
         "@vellumai/local-mode": "file:../../packages/local-mode",
+        "electron-log": "5.4.4",
         "electron-store": "11.0.2",
         "zod": "4.3.6",
       },
@@ -388,6 +389,8 @@
     "electron-builder": ["electron-builder@26.8.1", "", { "dependencies": { "app-builder-lib": "26.8.1", "builder-util": "26.8.1", "builder-util-runtime": "9.5.1", "chalk": "^4.1.2", "ci-info": "^4.2.0", "dmg-builder": "26.8.1", "fs-extra": "^10.1.0", "lazy-val": "^1.0.5", "simple-update-notifier": "2.0.0", "yargs": "^17.6.2" }, "bin": { "electron-builder": "cli.js", "install-app-deps": "install-app-deps.js" } }, "sha512-uWhx1r74NGpCagG0ULs/P9Nqv2nsoo+7eo4fLUOB8L8MdWltq9odW/uuLXMFCDGnPafknYLZgjNX0ZIFRzOQAw=="],
 
     "electron-builder-squirrel-windows": ["electron-builder-squirrel-windows@26.8.1", "", { "dependencies": { "app-builder-lib": "26.8.1", "builder-util": "26.8.1", "electron-winstaller": "5.4.0" } }, "sha512-o288fIdgPLHA76eDrFADHPoo7VyGkDCYbLV1GzndaMSAVBoZrGvM9m2IehdcVMzdAZJ2eV9bgyissQXHv5tGzA=="],
+
+    "electron-log": ["electron-log@5.4.4", "", {}, "sha512-istWgaXjBfURBSS8LWVW9C3jsc6+ac+tY1lXrQEOTp0lVj+a4OlO1Tmqb36GgnEUDv92DGC9VI1HNXwJinWpgA=="],
 
     "electron-publish": ["electron-publish@26.8.1", "", { "dependencies": { "@types/fs-extra": "^9.0.11", "builder-util": "26.8.1", "builder-util-runtime": "9.5.1", "chalk": "^4.1.2", "form-data": "^4.0.5", "fs-extra": "^10.1.0", "lazy-val": "^1.0.5", "mime": "^2.5.2" } }, "sha512-q+jrSTIh/Cv4eGZa7oVR+grEJo/FoLMYBAnSL5GCtqwUpr1T+VgKB/dn1pnzxIxqD8S/jP1yilT9VrwCqINR4w=="],
 

--- a/apps/macos/electron.vite.config.ts
+++ b/apps/macos/electron.vite.config.ts
@@ -22,6 +22,7 @@ import { defineConfig, externalizeDepsPlugin } from "electron-vite";
 // resolving to a `.ts` file the Electron main process can't load at runtime;
 // inlining lets Rollup compile the source into the bundle.
 const DEPS_TO_INLINE = [
+  "electron-log",
   "electron-store",
   "conf",
   "@vellumai/local-mode",

--- a/apps/macos/package.json
+++ b/apps/macos/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@vellumai/local-mode": "file:../../packages/local-mode",
+    "electron-log": "5.4.4",
     "electron-store": "11.0.2",
     "zod": "4.3.6"
   }

--- a/apps/macos/src/main/commands.ts
+++ b/apps/macos/src/main/commands.ts
@@ -14,6 +14,7 @@ export type VellumCommand =
   | { kind: "currentConversation" }
   | { kind: "markCurrentUnread" }
   | { kind: "openSettings" }
+  | { kind: "shareFeedback" }
   | { kind: "logout" };
 
 export type VellumCommandKind = VellumCommand["kind"];
@@ -32,6 +33,7 @@ export const DEFAULT_ACCELERATORS: Record<VellumCommandKind, string> = {
   currentConversation: "CmdOrCtrl+Shift+N",
   markCurrentUnread: "CmdOrCtrl+Shift+U",
   openSettings: "CmdOrCtrl+,",
+  shareFeedback: "",
   logout: "",
 };
 

--- a/apps/macos/src/main/feedback.ts
+++ b/apps/macos/src/main/feedback.ts
@@ -66,11 +66,7 @@ export function collectDiagnostics(): ElectronDiagnostics {
   };
 }
 
-export async function collectRedactedLogs(timeRange: {
-  startMs: number | null;
-  endMs: number;
-}): Promise<string> {
-  void timeRange; // reserved for future per-line filtering
+export async function collectRedactedLogs(): Promise<string> {
   const paths = getLogFilePaths();
   const parts: string[] = [];
   for (const p of paths) {
@@ -94,11 +90,5 @@ export function installFeedbackIpc(): void {
     collectDiagnostics(),
   );
 
-  handle(
-    "vellum:feedback:logs",
-    z.tuple([
-      z.object({ startMs: z.number().nullable(), endMs: z.number() }),
-    ]),
-    ([timeRange]) => collectRedactedLogs(timeRange),
-  );
+  handle("vellum:feedback:logs", z.tuple([]), () => collectRedactedLogs());
 }

--- a/apps/macos/src/main/feedback.ts
+++ b/apps/macos/src/main/feedback.ts
@@ -1,0 +1,104 @@
+import { app, powerMonitor } from "electron";
+import os from "node:os";
+import fs from "node:fs/promises";
+import { z } from "zod";
+
+import { handle } from "./ipc";
+import { getVersionInfo } from "./about";
+import { readSetting } from "./settings";
+import { getLogFilePaths } from "./logger";
+import { redactText, REDACTION_VERSION } from "./redact";
+
+export interface ElectronDiagnostics {
+  app: {
+    name: string;
+    version: string;
+    commitSha: string;
+  };
+  process: {
+    node: string;
+    electron: string;
+    chrome: string;
+    v8: string;
+    uptime: number;
+  };
+  platform: {
+    os: string;
+    arch: string;
+    release: string;
+    type: string;
+    totalMemory: number;
+    freeMemory: number;
+  };
+  appMetrics: Electron.ProcessMetric[];
+  idleTime: number;
+  featureFlags: unknown;
+  redactionVersion: number;
+}
+
+export function collectDiagnostics(): ElectronDiagnostics {
+  const versionInfo = getVersionInfo();
+  return {
+    app: {
+      name: versionInfo.appName,
+      version: versionInfo.version,
+      commitSha: versionInfo.commitSha,
+    },
+    process: {
+      node: process.versions.node,
+      electron: process.versions.electron,
+      chrome: process.versions.chrome,
+      v8: process.versions.v8,
+      uptime: process.uptime(),
+    },
+    platform: {
+      os: process.platform,
+      arch: process.arch,
+      release: os.release(),
+      type: os.type(),
+      totalMemory: os.totalmem(),
+      freeMemory: os.freemem(),
+    },
+    appMetrics: app.getAppMetrics(),
+    idleTime: powerMonitor.getSystemIdleTime(),
+    featureFlags: readSetting("featureFlags"),
+    redactionVersion: REDACTION_VERSION,
+  };
+}
+
+export async function collectRedactedLogs(timeRange: {
+  startMs: number | null;
+  endMs: number;
+}): Promise<string> {
+  void timeRange; // reserved for future per-line filtering
+  const paths = getLogFilePaths();
+  const parts: string[] = [];
+  for (const p of paths) {
+    try {
+      const content = await fs.readFile(p, "utf-8");
+      parts.push(content);
+    } catch {
+      // Missing or unreadable log file — skip gracefully
+    }
+  }
+  return redactText(parts.join("\n"));
+}
+
+let installed = false;
+
+export function installFeedbackIpc(): void {
+  if (installed) return;
+  installed = true;
+
+  handle("vellum:feedback:diagnostics", z.tuple([]), () =>
+    collectDiagnostics(),
+  );
+
+  handle(
+    "vellum:feedback:logs",
+    z.tuple([
+      z.object({ startMs: z.number().nullable(), endMs: z.number() }),
+    ]),
+    ([timeRange]) => collectRedactedLogs(timeRange),
+  );
+}

--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -24,6 +24,7 @@ import {
 } from "./deep-links";
 import { installAvatarIpc } from "./avatar";
 import { installDock } from "./dock";
+import { installFeedbackIpc } from "./feedback";
 import { installLocalMode } from "./local-mode";
 import log from "./logger";
 import {
@@ -315,6 +316,7 @@ app
     installSettingsIpc();
     installLocalMode();
     installAbout();
+    installFeedbackIpc();
     installApplicationMenu();
     // Register the avatar channel before the Dock and Tray install so their
     // initial render reflects any avatar the renderer publishes during

--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -25,6 +25,7 @@ import {
 import { installAvatarIpc } from "./avatar";
 import { installDock } from "./dock";
 import { installLocalMode } from "./local-mode";
+import log from "./logger";
 import {
   ensureVisible as ensureMainWindowVisible,
   installMainWindow,
@@ -342,7 +343,7 @@ app
     });
   })
   .catch((err: unknown) => {
-    console.error("[app] whenReady setup failed:", err);
+    log.error("[app] whenReady setup failed:", err);
   });
 
 app.on("second-instance", (_event, argv) => {

--- a/apps/macos/src/main/logger.ts
+++ b/apps/macos/src/main/logger.ts
@@ -1,0 +1,14 @@
+import log from "electron-log/main";
+
+log.initialize({ preload: true });
+
+log.transports.file.maxSize = 10 * 1024 * 1024; // 10 MB
+log.transports.file.fileName = "vellum.log";
+log.transports.file.format =
+  "[{y}-{m}-{d} {h}:{i}:{s}.{ms}] [{level}] [{processType}] {text}";
+
+export default log;
+
+export const getLogFilePaths = (): string[] => [
+  log.transports.file.getFile().path,
+];

--- a/apps/macos/src/main/menu.ts
+++ b/apps/macos/src/main/menu.ts
@@ -96,6 +96,11 @@ const buildTemplate = (): MenuItemConstructorOptions[] => {
       role: "help",
       submenu: [
         {
+          label: "Send Feedback\u2026",
+          click: () => dispatchToFocused({ kind: "shareFeedback" }),
+        },
+        { type: "separator" },
+        {
           label: "Vellum Documentation",
           click: () => {
             void shell.openExternal("https://docs.vellum.ai");

--- a/apps/macos/src/main/redact.test.ts
+++ b/apps/macos/src/main/redact.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { REDACTION_VERSION, redactText } from "./redact";
+
+describe("redactText", () => {
+  test("redacts Bearer tokens", () => {
+    const input = "Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.test+token/value=";
+    expect(redactText(input)).toBe("Authorization: Bearer [REDACTED]");
+  });
+
+  test("redacts sk-* API keys", () => {
+    const input = "Using key sk-abc123def456ghi789jklmnopqrst";
+    expect(redactText(input)).toBe("Using key [REDACTED_API_KEY]");
+  });
+
+  test("redacts email addresses", () => {
+    const input = "Contact user.name+tag@example.co.uk for details";
+    expect(redactText(input)).toBe("Contact [REDACTED_EMAIL] for details");
+  });
+
+  test("redacts /Users/<name>/ paths", () => {
+    const input = "Reading /Users/noaflaherty/Library/Application Support/config";
+    expect(redactText(input)).toBe("Reading ~/Library/Application Support/config");
+  });
+
+  test("redacts combined input with multiple patterns", () => {
+    const input = [
+      "Bearer sk-proj-AAAAAAAAAAAAAAAAAAAAAAAA",
+      "email: admin@vellum.ai",
+      "path: /Users/dev/src/app",
+    ].join("\n");
+
+    const result = redactText(input);
+    expect(result).not.toContain("sk-proj");
+    expect(result).not.toContain("admin@vellum.ai");
+    expect(result).not.toContain("/Users/dev");
+    expect(result).toContain("[REDACTED]");
+    expect(result).toContain("[REDACTED_EMAIL]");
+    expect(result).toContain("~");
+  });
+
+  test("does not false-positive on normal log lines", () => {
+    const input = "[2024-01-01 12:00:00] [info] App started";
+    expect(redactText(input)).toBe(input);
+  });
+
+  test("is idempotent", () => {
+    const input =
+      "Bearer eyJtoken123 sk-AAAAAAAAAAAAAAAAAAAABBBB user@test.com /Users/alice/docs";
+    const once = redactText(input);
+    expect(redactText(once)).toBe(once);
+  });
+});
+
+describe("REDACTION_VERSION", () => {
+  test("is exported as 1", () => {
+    expect(REDACTION_VERSION).toBe(1);
+  });
+});

--- a/apps/macos/src/main/redact.test.ts
+++ b/apps/macos/src/main/redact.test.ts
@@ -12,13 +12,18 @@ describe("redactText", () => {
     expect(redactText(input)).toBe("Using key [REDACTED_API_KEY]");
   });
 
+  test("redacts hyphenated sk-* API keys", () => {
+    const input = "OPENAI_API_KEY=sk-proj-abc123def456ghi789jklmnopqrst";
+    expect(redactText(input)).toBe("OPENAI_API_KEY=[REDACTED_API_KEY]");
+  });
+
   test("redacts email addresses", () => {
     const input = "Contact user.name+tag@example.co.uk for details";
     expect(redactText(input)).toBe("Contact [REDACTED_EMAIL] for details");
   });
 
   test("redacts /Users/<name>/ paths", () => {
-    const input = "Reading /Users/noaflaherty/Library/Application Support/config";
+    const input = "Reading /Users/alice/Library/Application Support/config";
     expect(redactText(input)).toBe("Reading ~/Library/Application Support/config");
   });
 

--- a/apps/macos/src/main/redact.ts
+++ b/apps/macos/src/main/redact.ts
@@ -1,0 +1,16 @@
+export const REDACTION_VERSION = 1;
+
+const PATTERNS: [RegExp, string][] = [
+  [/Bearer\s+[A-Za-z0-9\-._~+/]+=*/g, "Bearer [REDACTED]"],
+  [/sk-[A-Za-z0-9]{20,}/g, "[REDACTED_API_KEY]"],
+  [/[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g, "[REDACTED_EMAIL]"],
+  [/\/Users\/[^/\s]+/g, "~"],
+];
+
+export function redactText(input: string): string {
+  let result = input;
+  for (const [pattern, replacement] of PATTERNS) {
+    result = result.replace(pattern, replacement);
+  }
+  return result;
+}

--- a/apps/macos/src/main/redact.ts
+++ b/apps/macos/src/main/redact.ts
@@ -2,7 +2,7 @@ export const REDACTION_VERSION = 1;
 
 const PATTERNS: [RegExp, string][] = [
   [/Bearer\s+[A-Za-z0-9\-._~+/]+=*/g, "Bearer [REDACTED]"],
-  [/sk-[A-Za-z0-9]{20,}/g, "[REDACTED_API_KEY]"],
+  [/sk-[A-Za-z0-9\-]{20,}/g, "[REDACTED_API_KEY]"],
   [/[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g, "[REDACTED_EMAIL]"],
   [/\/Users\/[^/\s]+/g, "~"],
 ];

--- a/apps/macos/src/main/tray.ts
+++ b/apps/macos/src/main/tray.ts
@@ -114,6 +114,13 @@ const buildTrayMenu = (handlers: TrayHandlers, status: AssistantStatus): Menu =>
       },
     },
     {
+      label: "Send Feedback\u2026",
+      click: async () => {
+        await handlers.ensureMainWindow();
+        dispatchToMain({ kind: "shareFeedback" });
+      },
+    },
+    {
       label: `About ${app.name}`,
       click: handlers.openAbout,
     },

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -287,6 +287,12 @@ export interface VellumBridge {
      */
     onLink(callback: (link: DeepLink) => void): () => void;
   };
+  feedback: {
+    /** Collect Electron-specific diagnostics (versions, platform, metrics). */
+    diagnostics(): Promise<Record<string, unknown>>;
+    /** Read redacted log file content for the given time range. */
+    logs(timeRange: { startMs: number | null; endMs: number }): Promise<string>;
+  };
 }
 
 const notImplemented = (name: string) => (): Promise<never> =>
@@ -429,6 +435,14 @@ const bridge: VellumBridge = {
         ipcRenderer.send("vellum:deepLinks:unsubscribe");
       };
     },
+  },
+  feedback: {
+    diagnostics: () =>
+      ipcRenderer.invoke("vellum:feedback:diagnostics") as Promise<
+        Record<string, unknown>
+      >,
+    logs: (timeRange: { startMs: number | null; endMs: number }) =>
+      ipcRenderer.invoke("vellum:feedback:logs", timeRange) as Promise<string>,
   },
 };
 

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -13,6 +13,7 @@ export type VellumCommand =
   | { kind: "currentConversation" }
   | { kind: "markCurrentUnread" }
   | { kind: "openSettings" }
+  | { kind: "shareFeedback" }
   | { kind: "logout" };
 
 // Surface exposed to the renderer as `window.vellum`. `platform`, `settings`,

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -290,8 +290,8 @@ export interface VellumBridge {
   feedback: {
     /** Collect Electron-specific diagnostics (versions, platform, metrics). */
     diagnostics(): Promise<Record<string, unknown>>;
-    /** Read redacted log file content for the given time range. */
-    logs(timeRange: { startMs: number | null; endMs: number }): Promise<string>;
+    /** Read redacted log file content. */
+    logs(): Promise<string>;
   };
 }
 
@@ -441,8 +441,8 @@ const bridge: VellumBridge = {
       ipcRenderer.invoke("vellum:feedback:diagnostics") as Promise<
         Record<string, unknown>
       >,
-    logs: (timeRange: { startMs: number | null; endMs: number }) =>
-      ipcRenderer.invoke("vellum:feedback:logs", timeRange) as Promise<string>,
+    logs: () =>
+      ipcRenderer.invoke("vellum:feedback:logs") as Promise<string>,
   },
 };
 

--- a/apps/web/src/components/share-feedback-modal.tsx
+++ b/apps/web/src/components/share-feedback-modal.tsx
@@ -609,7 +609,7 @@ export function ShareFeedbackModal({
           ? await buildClientLogsFile(
               logTimeRange,
               assistantId ?? null,
-              includeConversation ? (activeConversationId ?? null) : null,
+              isElectron() ? (includeConversation ? (activeConversationId ?? null) : null) : (activeConversationId ?? null),
               getDiagnosticsSnapshot,
             )
           : null;

--- a/apps/web/src/components/share-feedback-modal.tsx
+++ b/apps/web/src/components/share-feedback-modal.tsx
@@ -391,10 +391,7 @@ async function buildClientLogsFile(
     } catch { /* best-effort */ }
 
     try {
-      const redactedLogs = await window.vellum.feedback.logs({
-        startMs: startTime,
-        endMs: endTime,
-      });
+      const redactedLogs = await window.vellum.feedback.logs();
       if (redactedLogs) {
         const logBytes = new TextEncoder().encode(redactedLogs);
         tarParts.push(buildTarEntry("electron-main-logs.txt", logBytes));

--- a/apps/web/src/components/share-feedback-modal.tsx
+++ b/apps/web/src/components/share-feedback-modal.tsx
@@ -381,6 +381,27 @@ async function buildClientLogsFile(
     // chat page hasn't mounted the API yet.
   }
 
+  if (isElectron() && window.vellum?.feedback) {
+    try {
+      const electronDiagnostics = await window.vellum.feedback.diagnostics();
+      const diagBytes = new TextEncoder().encode(
+        JSON.stringify(electronDiagnostics, null, 2),
+      );
+      tarParts.push(buildTarEntry("electron-diagnostics.json", diagBytes));
+    } catch { /* best-effort */ }
+
+    try {
+      const redactedLogs = await window.vellum.feedback.logs({
+        startMs: startTime,
+        endMs: endTime,
+      });
+      if (redactedLogs) {
+        const logBytes = new TextEncoder().encode(redactedLogs);
+        tarParts.push(buildTarEntry("electron-main-logs.txt", logBytes));
+      }
+    } catch { /* best-effort */ }
+  }
+
   if (assistantId) {
     const platformLogsData = await fetchPlatformLogs(assistantId, {
       window: { startTime, endTime },
@@ -452,6 +473,7 @@ export function ShareFeedbackModal({
   const [attachments, setAttachments] = useState<File[]>([]);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [isDragging, setIsDragging] = useState(false);
+  const [includeConversation, setIncludeConversation] = useState(false);
 
   const mutation = useMutation(feedbackCreateMutation());
   const [isBuildingLogs, setIsBuildingLogs] = useState(false);
@@ -476,6 +498,7 @@ export function ShareFeedbackModal({
     setHasManuallyToggledLogs(false);
     setLogTimeRange("past_hour");
     setAttachments([]);
+    setIncludeConversation(false);
     setSubmitError(null);
     setIsBuildingLogs(false);
     mutation.reset();
@@ -586,7 +609,7 @@ export function ShareFeedbackModal({
           ? await buildClientLogsFile(
               logTimeRange,
               assistantId ?? null,
-              activeConversationId ?? null,
+              includeConversation ? (activeConversationId ?? null) : null,
               getDiagnosticsSnapshot,
             )
           : null;
@@ -797,6 +820,19 @@ export function ShareFeedbackModal({
                 />
               )}
             </div>
+          )}
+
+          {isElectron() && activeConversationId && selectedReason !== "feature_request" && (
+            <label className="flex cursor-pointer items-center gap-2.5">
+              <Toggle
+                checked={includeConversation}
+                onChange={() => setIncludeConversation((v) => !v)}
+                aria-label="Include the most recent conversation"
+              />
+              <span className="text-body-medium-lighter leading-6 text-[var(--content-default)]">
+                Include the most recent conversation
+              </span>
+            </label>
           )}
 
           <div className="flex flex-col gap-2">

--- a/apps/web/src/domains/chat/components/preferences-menu.tsx
+++ b/apps/web/src/domains/chat/components/preferences-menu.tsx
@@ -31,6 +31,7 @@ import {
 } from "@/hooks/use-platform-gate";
 import { hardNavigate } from "@/lib/auth/hard-navigate";
 import { isLocalMode } from "@/lib/local-mode";
+import { isElectron } from "@/runtime/is-electron";
 import {
     useAuthStore,
     useHasPlatformSession,
@@ -219,7 +220,7 @@ function PreferencesMenuContent({
         }}
       />
 
-      {platformGate === "full" && (
+      {(platformGate === "full" || isElectron()) && (
         <PanelItem
           icon={MessageSquareText}
           label="Share Feedback"

--- a/apps/web/src/root-layout.tsx
+++ b/apps/web/src/root-layout.tsx
@@ -1,5 +1,7 @@
+import { lazy, useState } from "react";
 import { Outlet, useNavigate } from "react-router";
 
+import { LazyBoundary } from "@/components/lazy-boundary";
 import { useAppTheme } from "@/hooks/use-app-theme";
 import { useEventBusInit } from "@/hooks/use-event-bus-init";
 import { useGlobalDeepLinkConsumer } from "@/hooks/use-global-deep-link-consumer";
@@ -32,6 +34,12 @@ import { useDynamicFavicon } from "@/hooks/use-dynamic-favicon";
 import { useElectronIconSync } from "@/hooks/use-electron-icon-sync";
 import { useElectronStatusSync } from "@/hooks/use-electron-status-sync";
 import { TimezoneSync } from "@/components/timezone-sync";
+
+const ShareFeedbackModal = lazy(() =>
+  import("@/components/share-feedback-modal").then((m) => ({
+    default: m.ShareFeedbackModal,
+  })),
+);
 
 /**
  * Threshold (in px) below which a `innerHeight − visualViewport.height` delta
@@ -120,6 +128,8 @@ export function RootLayout() {
   // hand off via `pending-deep-link-store`.
   useGlobalDeepLinkConsumer();
 
+  const [feedbackOpen, setFeedbackOpen] = useState(false);
+
   useVellumCommands({
     openSettings: () => {
       void navigate(routes.settings.root);
@@ -131,6 +141,7 @@ export function RootLayout() {
         navigate(getOnboardingEntrypoint());
       });
     },
+    shareFeedback: () => setFeedbackOpen(true),
   });
 
   const keyboardOpen =
@@ -181,6 +192,15 @@ export function RootLayout() {
       {/* Headless: keeps daemon config.ui.detectedTimezone fresh on
           focus/zone change. No-ops until an assistant id resolves. */}
       <TimezoneSync />
+
+      {feedbackOpen ? (
+        <LazyBoundary>
+          <ShareFeedbackModal
+            open={feedbackOpen}
+            onClose={() => setFeedbackOpen(false)}
+          />
+        </LazyBoundary>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/root-layout.tsx
+++ b/apps/web/src/root-layout.tsx
@@ -29,6 +29,8 @@ import { useFeatureFlagBusSync } from "@/hooks/use-feature-flag-bus-sync";
 import { useClientFeatureFlagSync } from "@/hooks/use-client-feature-flag-sync";
 import { useAssistantFeatureFlagSync } from "@/hooks/use-assistant-feature-flag-sync";
 import { useAssistantSelectionStore } from "@/assistant/selection-store";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
+import { useConversationStore } from "@/stores/conversation-store";
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 import { useDynamicFavicon } from "@/hooks/use-dynamic-favicon";
 import { useElectronIconSync } from "@/hooks/use-electron-icon-sync";
@@ -91,6 +93,8 @@ export function RootLayout() {
   });
 
   const assistantId = useAssistantSelectionStore.use.activeAssistantId();
+  const assistantVersion = useAssistantIdentityStore.use.version();
+  const activeConversationId = useConversationStore.use.activeConversationId();
   const assistantStateKind = useAssistantLifecycleStore(
     (s) => s.assistantState.kind,
   );
@@ -198,6 +202,9 @@ export function RootLayout() {
           <ShareFeedbackModal
             open={feedbackOpen}
             onClose={() => setFeedbackOpen(false)}
+            assistantId={assistantId}
+            assistantVersion={assistantVersion}
+            activeConversationId={activeConversationId}
           />
         </LazyBoundary>
       ) : null}

--- a/apps/web/src/runtime/is-electron.ts
+++ b/apps/web/src/runtime/is-electron.ts
@@ -143,6 +143,13 @@ declare global {
           ) => void,
         ): () => void;
       };
+      feedback?: {
+        diagnostics(): Promise<Record<string, unknown>>;
+        logs(timeRange: {
+          startMs: number | null;
+          endMs: number;
+        }): Promise<string>;
+      };
     };
   }
 }

--- a/apps/web/src/runtime/is-electron.ts
+++ b/apps/web/src/runtime/is-electron.ts
@@ -145,10 +145,7 @@ declare global {
       };
       feedback?: {
         diagnostics(): Promise<Record<string, unknown>>;
-        logs(timeRange: {
-          startMs: number | null;
-          endMs: number;
-        }): Promise<string>;
+        logs(): Promise<string>;
       };
     };
   }

--- a/apps/web/src/runtime/is-electron.ts
+++ b/apps/web/src/runtime/is-electron.ts
@@ -33,6 +33,7 @@ export type VellumCommand =
   | { kind: "currentConversation" }
   | { kind: "markCurrentUnread" }
   | { kind: "openSettings" }
+  | { kind: "shareFeedback" }
   | { kind: "logout" };
 
 /**


### PR DESCRIPTION
## Summary
Add a "Send Feedback" feature to the Electron macOS app that lets users report bugs with attached logs and diagnostics. The existing `ShareFeedbackModal` is augmented with Electron-specific data: main-process logs (via `electron-log`), system diagnostics (app metrics, process versions, platform info), and a redaction pipeline that strips secrets before they leave the machine.

- Install `electron-log` for structured, rotating main-process file logging
- Add text redaction pipeline stripping Bearer tokens, API keys, emails, and user paths
- Wire `shareFeedback` command through Help menu, tray menu, and renderer command handler
- Add IPC channels (`vellum:feedback:diagnostics`, `vellum:feedback:logs`) for Electron-specific data
- Enhance `ShareFeedbackModal` with `electron-diagnostics.json` and `electron-main-logs.txt` tar entries
- Add "Include the most recent conversation" toggle (Electron-only, explicit consent)
- Ungate feedback for local-mode Electron users in the sidebar preferences menu

## Self-review result
GAPS FOUND — 3 gaps fixed across 3 fix PRs:
1. Web regression: conversation-scoped logs silently dropped on non-Electron platforms
2. ShareFeedbackModal in root-layout missing assistantId/activeConversationId props
3. Unused timeRange parameter wired across 3 IPC layers

## PRs merged into feature branch
- #33549: feat(electron): add text redaction pipeline for feedback log scrubbing
- #33551: feat(electron): add electron-log for structured main-process logging
- #33550: feat(electron): add Send Feedback command to Help menu and tray
- #33554: feat(web): open ShareFeedbackModal from Electron shareFeedback command
- #33555: feat(electron): add IPC channels for feedback diagnostics and redacted logs
- #33559: feat(web): include Electron diagnostics and redacted logs in feedback bundle
- #33557: feat(web): show Share Feedback menu item for local-mode Electron users

### Fix PRs
- #33564: fix(web): preserve conversation-scoped logs for non-Electron feedback
- #33566: fix(web): pass assistantId and activeConversationId to feedback modal in root-layout
- #33565: fix(electron): remove unused timeRange parameter from feedback logs IPC

Part of plan: feedback-log-export.md