### PR TITLE
fix(web): honor returnTo in provider callback when in local mode

### DIFF
--- a/apps/web/src/domains/account/login-flow.test.ts
+++ b/apps/web/src/domains/account/login-flow.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   buildProviderCallbackUrl,
   readAuthCallbackIntent,
+  requiresFullPageNavigation,
   resolvePostAuthDestination,
 } from "@/domains/account/login-flow";
 import { routes } from "@/utils/routes";
@@ -47,5 +48,28 @@ describe("login flow routing", () => {
       destination: routes.home,
       requiresFullPageNavigation: false,
     });
+  });
+
+  test("resolves CLI login callback returnTo with full-page navigation", () => {
+    const cliCallback = "/accounts/cli/callback?port=54321&state=abc123";
+    expect(
+      resolvePostAuthDestination({
+        returnTo: cliCallback,
+        fallback: routes.assistant,
+        authIntent: "login",
+      }),
+    ).toEqual({
+      destination: cliCallback,
+      requiresFullPageNavigation: true,
+    });
+  });
+
+  test("requiresFullPageNavigation for /accounts/ paths", () => {
+    expect(requiresFullPageNavigation("/accounts/cli/callback?port=12345&state=xyz")).toBe(true);
+    expect(requiresFullPageNavigation("/accounts/native/callback?scheme=vellum&state=abc")).toBe(true);
+    expect(requiresFullPageNavigation("/v1/some-api")).toBe(true);
+    expect(requiresFullPageNavigation("https://www.vellum.ai/assistant")).toBe(true);
+    expect(requiresFullPageNavigation("/assistant")).toBe(false);
+    expect(requiresFullPageNavigation("/onboarding/privacy")).toBe(false);
   });
 });

--- a/apps/web/src/domains/account/pages/provider-callback-page.tsx
+++ b/apps/web/src/domains/account/pages/provider-callback-page.tsx
@@ -57,13 +57,15 @@ export function ProviderCallbackPage() {
           case "authenticated": {
             await refreshSession();
 
-            if (isLocalMode() && !returnTo) {
+            if (isLocalMode()) {
               try {
                 const assistants = await listAssistants();
                 if (assistants.ok && assistants.data.length > 0) {
                   await syncPlatformAssistantsToLockfile(assistants.data);
-                  navigate(routes.assistant, { replace: true });
-                  break;
+                  if (!returnTo) {
+                    navigate(routes.assistant, { replace: true });
+                    break;
+                  }
                 }
               } catch {
                 // Fall through to normal destination

--- a/apps/web/src/domains/account/pages/provider-callback-page.tsx
+++ b/apps/web/src/domains/account/pages/provider-callback-page.tsx
@@ -57,7 +57,7 @@ export function ProviderCallbackPage() {
           case "authenticated": {
             await refreshSession();
 
-            if (isLocalMode()) {
+            if (isLocalMode() && !returnTo) {
               try {
                 const assistants = await listAssistants();
                 if (assistants.ok && assistants.data.length > 0) {


### PR DESCRIPTION
## Summary
- Fix `vellum login` CLI flow in local development: the SPA's provider callback page had a local-mode shortcut that synced platform assistants and immediately navigated to `/assistant`, ignoring the `returnTo=/accounts/cli/callback?port=...&state=...` parameter
- Add `&& !returnTo` guard so the shortcut only fires when there's no explicit redirect target
- Add unit tests for CLI callback path routing and `requiresFullPageNavigation` behavior

## Original prompt
When running `vellum login` from source in the local environment, the OAuth login completes successfully but the browser navigates to the web UI instead of completing the CLI callback. After tracing the full redirect chain (CLI → Caddy edge proxy → SPA login page → WorkOS OAuth → provider callback → Django CLI endpoint → CLI local server), the root cause was identified: the SPA's `ProviderCallbackPage` has a local-mode shortcut that unconditionally navigates to `/assistant` when platform assistants exist, skipping the `returnTo` parameter that carries the CLI callback URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)