### PR TITLE
feat(feature-flags): add backend support for string feature flag values

### DIFF
--- a/apps/web/src/domains/settings/components/panels/feature-flags-panel.tsx
+++ b/apps/web/src/domains/settings/components/panels/feature-flags-panel.tsx
@@ -67,6 +67,7 @@ export function FeatureFlagsPanel() {
             ? assistantVal
             : clientVal;
       if (typeof value !== "boolean") continue;
+      if (typeof flag.defaultEnabled !== "boolean") continue;
       entries.push({
         storeKey,
         scope: flag.scope as FlagScope,

--- a/apps/web/src/hooks/use-assistant-feature-flag-sync.ts
+++ b/apps/web/src/hooks/use-assistant-feature-flag-sync.ts
@@ -13,9 +13,9 @@ import { assistantFlagValuesQueryKey } from "@/lib/sync/query-tags";
 
 interface FeatureFlagEntry {
   key: string;
-  enabled: boolean;
+  enabled: boolean | string;
   label: string;
-  defaultEnabled: boolean;
+  defaultEnabled: boolean | string;
   description: string;
 }
 
@@ -30,6 +30,7 @@ function mapFlags(
 ): Record<string, boolean> {
   const mapped: Record<string, boolean> = {};
   for (const entry of entries) {
+    if (typeof entry.enabled !== "boolean") continue;
     const storeKey = flagKeyToStoreKey(entry.key);
     if (VALID_KEYS.has(storeKey)) {
       mapped[storeKey] = entry.enabled;

--- a/apps/web/src/hooks/use-client-feature-flag-sync.ts
+++ b/apps/web/src/hooks/use-client-feature-flag-sync.ts
@@ -26,10 +26,11 @@ async function fetchClientFlagValues(): Promise<ClientFeatureFlagsResponse> {
 }
 
 function mapFlags(
-  serverFlags: Record<string, boolean>,
+  serverFlags: Record<string, boolean | string>,
 ): Record<string, boolean> {
   const mapped: Record<string, boolean> = {};
   for (const [flagKey, value] of Object.entries(serverFlags)) {
+    if (typeof value !== "boolean") continue;
     const storeKey = flagKeyToStoreKey(flagKey);
     if (VALID_KEYS.has(storeKey)) {
       mapped[storeKey] = value;

--- a/apps/web/src/lib/feature-flags/feature-flag-catalog.ts
+++ b/apps/web/src/lib/feature-flags/feature-flag-catalog.ts
@@ -16,7 +16,7 @@ export interface FlagDefinition {
   key: string;
   label: string;
   description: string;
-  defaultEnabled: boolean;
+  defaultEnabled: boolean | string;
 }
 
 const flags = registry.flags as FlagDefinition[];
@@ -41,6 +41,7 @@ function kebabToStoreKey(kebabKey: string): string {
 function buildScopeDefaults(scope: SingleScope): Record<string, boolean> {
   const defaults: Record<string, boolean> = {};
   for (const flag of flags) {
+    if (typeof flag.defaultEnabled !== "boolean") continue;
     if (scopeIncludes(flag.scope, scope)) {
       defaults[kebabToStoreKey(flag.key)] = flag.defaultEnabled;
     }

--- a/assistant/src/__tests__/feature-flag-test-helpers.ts
+++ b/assistant/src/__tests__/feature-flag-test-helpers.ts
@@ -19,7 +19,7 @@
 // Mirrors `src/config/feature-flag-cache.ts`. Duplicated by design — see
 // the "No source-module imports" section above.
 type FlagSlot = {
-  overrides: Record<string, boolean> | null;
+  overrides: Record<string, boolean | string> | null;
   fromGateway: boolean;
 };
 
@@ -45,7 +45,7 @@ function flagSlot(): FlagSlot {
  * `clearFeatureFlagOverridesCache()` from `assistant-feature-flags.ts`.
  */
 export function setOverridesForTesting(
-  overrides: Record<string, boolean>,
+  overrides: Record<string, boolean | string>,
 ): void {
   const s = flagSlot();
   s.overrides = { ...overrides };

--- a/assistant/src/config/assistant-feature-flags.ts
+++ b/assistant/src/config/assistant-feature-flags.ts
@@ -33,7 +33,7 @@ const log = getLogger("assistant-feature-flags");
 // ---------------------------------------------------------------------------
 
 export interface FeatureFlagDefault {
-  defaultEnabled: boolean;
+  defaultEnabled: boolean | string;
   description: string;
   label: string;
 }
@@ -103,7 +103,7 @@ function parseRegistryToDefaults(parsed: unknown): FeatureFlagDefaultsRegistry {
     const entry = flag as Record<string, unknown>;
     if (entry.scope !== "assistant" && entry.scope !== "both") continue;
     if (typeof entry.key !== "string") continue;
-    if (typeof entry.defaultEnabled !== "boolean") continue;
+    if (typeof entry.defaultEnabled !== "boolean" && typeof entry.defaultEnabled !== "string") continue;
 
     result[entry.key as string] = {
       defaultEnabled: entry.defaultEnabled,
@@ -133,7 +133,7 @@ function parseRegistryToDefaults(parsed: unknown): FeatureFlagDefaultsRegistry {
  */
 async function fetchOverridesFromGateway(
   timeoutMs?: number,
-): Promise<Record<string, boolean>> {
+): Promise<Record<string, boolean | string>> {
   try {
     return await ipcGetFeatureFlags(timeoutMs);
   } catch {
@@ -238,7 +238,7 @@ export async function initFeatureFlagOverrides(options?: {
  * Returns the gateway-populated cache if `initFeatureFlagOverrides()` was
  * called at startup, or an empty record otherwise.
  */
-function loadOverrides(): Record<string, boolean> {
+function loadOverrides(): Record<string, boolean | string> {
   return getCachedOverrides() ?? {};
 }
 
@@ -273,7 +273,7 @@ export async function refreshOverridesFromGateway(): Promise<void> {
 // ---------------------------------------------------------------------------
 
 /**
- * Resolve whether an assistant feature flag is enabled.
+ * Resolve the raw value for an assistant feature flag.
  *
  * Resolution order:
  *   1. Override from the gateway IPC fetch (includes platform-pushed remote
@@ -282,21 +282,32 @@ export async function refreshOverridesFromGateway(): Promise<void> {
  *   2. Registry `defaultEnabled` (for declared assistant-scope keys)
  *   3. `false` (for undeclared keys with no override)
  */
-export function isAssistantFeatureFlagEnabled(
+export function getAssistantFeatureFlagValue(
   key: string,
   _config: AssistantConfig,
-): boolean {
+): boolean | string {
   const defaults = loadDefaultsRegistry();
   const declared = defaults[key];
   const overrides = loadOverrides();
 
-  // 1. Check overrides from the gateway IPC cache.
   const explicit = overrides[key];
-  if (typeof explicit === "boolean") return explicit;
+  if (explicit !== undefined) return explicit;
 
-  // 2. For declared keys, use the registry default.
   if (declared) return declared.defaultEnabled;
 
-  // 3. Undeclared keys with no override fail closed.
   return false;
+}
+
+/**
+ * Resolve whether an assistant feature flag is enabled (boolean coercion).
+ *
+ * For boolean flags, returns the resolved value directly.
+ * For string flags, returns true if the value is non-empty.
+ * Undeclared keys return `false` (fail closed).
+ */
+export function isAssistantFeatureFlagEnabled(
+  key: string,
+  config: AssistantConfig,
+): boolean {
+  return !!getAssistantFeatureFlagValue(key, config);
 }

--- a/assistant/src/config/feature-flag-cache.ts
+++ b/assistant/src/config/feature-flag-cache.ts
@@ -29,7 +29,7 @@
  */
 
 type FlagSlot = {
-  overrides: Record<string, boolean> | null;
+  overrides: Record<string, boolean | string> | null;
   fromGateway: boolean;
 };
 
@@ -44,7 +44,7 @@ function slot(): FlagSlot {
 }
 
 /** Read the current override cache. `null` means not yet populated. */
-export function getCachedOverrides(): Record<string, boolean> | null {
+export function getCachedOverrides(): Record<string, boolean | string> | null {
   return slot().overrides;
 }
 
@@ -66,7 +66,7 @@ export function isCachedFromGateway(): boolean {
  * `initFeatureFlagOverrides()` calls are no-ops.
  */
 export function setCachedOverrides(
-  overrides: Record<string, boolean>,
+  overrides: Record<string, boolean | string>,
   options: { fromGateway: boolean },
 ): void {
   const s = slot();

--- a/assistant/src/ipc/gateway-client.test.ts
+++ b/assistant/src/ipc/gateway-client.test.ts
@@ -91,7 +91,7 @@ describe("ipcGetFeatureFlags", () => {
     expect(flags).toEqual({ "flag-a": true, "flag-b": false });
   });
 
-  test("filters non-boolean values from response", async () => {
+  test("accepts boolean and string values, filters other types from response", async () => {
     mockGatewayIpc(null, {
       results: {
         get_feature_flags: {
@@ -104,7 +104,7 @@ describe("ipcGetFeatureFlags", () => {
     });
 
     const flags = await ipcGetFeatureFlags();
-    expect(flags).toEqual({ valid: true });
+    expect(flags).toEqual({ valid: true, string: "yes" });
   });
 
   test("returns empty record when IPC returns undefined", async () => {

--- a/assistant/src/ipc/gateway-client.ts
+++ b/assistant/src/ipc/gateway-client.ts
@@ -98,12 +98,12 @@ export function resetPersistentClient(): void {
  */
 export async function ipcGetFeatureFlags(
   timeoutMs?: number,
-): Promise<Record<string, boolean>> {
+): Promise<Record<string, boolean | string>> {
   const result = await ipcCall("get_feature_flags", undefined, timeoutMs);
   if (result && typeof result === "object" && !Array.isArray(result)) {
-    const filtered: Record<string, boolean> = {};
+    const filtered: Record<string, boolean | string> = {};
     for (const [k, v] of Object.entries(result as Record<string, unknown>)) {
-      if (typeof v === "boolean") filtered[k] = v;
+      if (typeof v === "boolean" || typeof v === "string") filtered[k] = v;
     }
     return filtered;
   }

--- a/gateway/src/__tests__/feature-flag-resolver.test.ts
+++ b/gateway/src/__tests__/feature-flag-resolver.test.ts
@@ -25,6 +25,22 @@ const TEST_REGISTRY = {
       description: "A2A channel integration",
       defaultEnabled: false,
     },
+    {
+      id: "default-model",
+      scope: "assistant",
+      key: "default-model",
+      label: "Default Model",
+      description: "Default LLM model identifier",
+      defaultEnabled: "claude-sonnet-4-6",
+    },
+    {
+      id: "empty-string-flag",
+      scope: "assistant",
+      key: "empty-string-flag",
+      label: "Empty String Flag",
+      description: "A string flag with empty default",
+      defaultEnabled: "",
+    },
   ],
 };
 
@@ -50,7 +66,7 @@ afterEach(() => {
   clearRemoteFeatureFlagStoreCache();
 });
 
-const { isFeatureFlagEnabled } = await import("../feature-flag-resolver.js");
+const { isFeatureFlagEnabled, getFeatureFlagValue } = await import("../feature-flag-resolver.js");
 const { resetFeatureFlagDefaultsCache, _setRegistryCandidateOverrides } =
   await import("../feature-flag-defaults.js");
 const { clearFeatureFlagStoreCache, writeFeatureFlag } =
@@ -87,5 +103,50 @@ describe("isFeatureFlagEnabled", () => {
     writeRemoteFeatureFlags({ unknown: true });
 
     expect(isFeatureFlagEnabled("unknown")).toBe(false);
+  });
+
+  test("coerces non-empty string to true", () => {
+    expect(isFeatureFlagEnabled("default-model")).toBe(true);
+  });
+
+  test("coerces empty string to false", () => {
+    expect(isFeatureFlagEnabled("empty-string-flag")).toBe(false);
+  });
+
+  test("coerces persisted string override to true", () => {
+    writeFeatureFlag("empty-string-flag", "overridden");
+    expect(isFeatureFlagEnabled("empty-string-flag")).toBe(true);
+  });
+});
+
+describe("getFeatureFlagValue", () => {
+  test("returns string default for string flags", () => {
+    expect(getFeatureFlagValue("default-model")).toBe("claude-sonnet-4-6");
+    expect(getFeatureFlagValue("empty-string-flag")).toBe("");
+  });
+
+  test("returns boolean default for boolean flags", () => {
+    expect(getFeatureFlagValue("browser")).toBe(true);
+    expect(getFeatureFlagValue("a2a-channel")).toBe(false);
+  });
+
+  test("returns false for undeclared flags", () => {
+    expect(getFeatureFlagValue("nonexistent")).toBe(false);
+  });
+
+  test("persisted string value overrides default", () => {
+    writeFeatureFlag("default-model", "gpt-4");
+    expect(getFeatureFlagValue("default-model")).toBe("gpt-4");
+  });
+
+  test("remote string value overrides default when no persisted value", () => {
+    writeRemoteFeatureFlags({ "default-model": "gpt-4" });
+    expect(getFeatureFlagValue("default-model")).toBe("gpt-4");
+  });
+
+  test("persisted takes precedence over remote for string flags", () => {
+    writeRemoteFeatureFlags({ "default-model": "remote-model" });
+    writeFeatureFlag("default-model", "persisted-model");
+    expect(getFeatureFlagValue("default-model")).toBe("persisted-model");
   });
 });

--- a/gateway/src/__tests__/feature-flags-route.test.ts
+++ b/gateway/src/__tests__/feature-flags-route.test.ts
@@ -47,6 +47,14 @@ const TEST_REGISTRY = {
       description: "Enable user-hosted onboarding flow",
       defaultEnabled: false,
     },
+    {
+      id: "default-model",
+      scope: "assistant",
+      key: "default-model",
+      label: "Default Model",
+      description: "Default LLM model identifier",
+      defaultEnabled: "claude-sonnet-4-6",
+    },
   ],
 };
 
@@ -111,8 +119,8 @@ describe("GET /v1/feature-flags handler", () => {
     for (const flag of body.flags) {
       expect(typeof flag.key).toBe("string");
       expect(typeof flag.label).toBe("string");
-      expect(typeof flag.enabled).toBe("boolean");
-      expect(typeof flag.defaultEnabled).toBe("boolean");
+      expect(["boolean", "string"]).toContain(typeof flag.enabled);
+      expect(["boolean", "string"]).toContain(typeof flag.defaultEnabled);
       expect(typeof flag.description).toBe("string");
       expect(flag.key).toMatch(/^[a-z0-9][a-z0-9-]*$/);
     }
@@ -215,14 +223,13 @@ describe("GET /v1/feature-flags handler", () => {
     expect(browserFlag.defaultEnabled).toBe(true);
   });
 
-  test("ignores non-boolean values in persisted feature flags", async () => {
-    // Write a feature-flags.json with an invalid non-boolean value manually
+  test("accepts string values in persisted feature flags", async () => {
     writeFileSync(
       featureFlagStorePath,
       JSON.stringify({
         version: 1,
         values: {
-          browser: "no",
+          "default-model": "gpt-4",
         },
       }),
     );
@@ -236,9 +243,34 @@ describe("GET /v1/feature-flags handler", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
 
-    // readPersistedFeatureFlags filters out non-boolean values, so the
-    // invalid "no" string is dropped and the flag falls back to its
-    // registry default (true).
+    const modelFlag = body.flags.find(
+      (f: { key: string }) => f.key === "default-model",
+    );
+    expect(modelFlag).toBeDefined();
+    expect(modelFlag.enabled).toBe("gpt-4");
+    expect(modelFlag.defaultEnabled).toBe("claude-sonnet-4-6");
+  });
+
+  test("ignores non-boolean non-string values in persisted feature flags", async () => {
+    writeFileSync(
+      featureFlagStorePath,
+      JSON.stringify({
+        version: 1,
+        values: {
+          browser: 42,
+        },
+      }),
+    );
+    clearFeatureFlagStoreCache();
+
+    const handler = createFeatureFlagsGetHandler();
+    const res = await handler(
+      new Request("http://gateway.test/v1/feature-flags"),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
     const browserFlag = body.flags.find(
       (f: { key: string }) => f.key === "browser",
     );
@@ -437,6 +469,48 @@ describe("GET /v1/feature-flags handler", () => {
     expect(browserFlag.defaultEnabled).toBe(true);
   });
 
+  test("string flag uses registry default when no override exists", async () => {
+    if (existsSync(featureFlagStorePath)) rmSync(featureFlagStorePath);
+    if (existsSync(remoteFeatureFlagStorePath)) rmSync(remoteFeatureFlagStorePath);
+    clearFeatureFlagStoreCache();
+    clearRemoteFeatureFlagStoreCache();
+
+    const handler = createFeatureFlagsGetHandler();
+    const res = await handler(
+      new Request("http://gateway.test/v1/feature-flags"),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    const modelFlag = body.flags.find(
+      (f: { key: string }) => f.key === "default-model",
+    );
+    expect(modelFlag).toBeDefined();
+    expect(modelFlag.enabled).toBe("claude-sonnet-4-6");
+    expect(modelFlag.defaultEnabled).toBe("claude-sonnet-4-6");
+  });
+
+  test("remote string value overrides registry default for string flag", async () => {
+    writeRemoteFeatureFlags({ "default-model": "gpt-4" });
+    if (existsSync(featureFlagStorePath)) rmSync(featureFlagStorePath);
+    clearFeatureFlagStoreCache();
+
+    const handler = createFeatureFlagsGetHandler();
+    const res = await handler(
+      new Request("http://gateway.test/v1/feature-flags"),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    const modelFlag = body.flags.find(
+      (f: { key: string }) => f.key === "default-model",
+    );
+    expect(modelFlag).toBeDefined();
+    expect(modelFlag.enabled).toBe("gpt-4");
+  });
+
   test("returns flags when invoked via assistants path without trailing slash", async () => {
     // The macOS client sends GET /v1/assistants/<id>/feature-flags (no trailing slash).
     // The gateway route regex must accept this path.
@@ -454,7 +528,7 @@ describe("GET /v1/feature-flags handler", () => {
     expect(body.flags.length).toBeGreaterThan(0);
     for (const flag of body.flags) {
       expect(typeof flag.key).toBe("string");
-      expect(typeof flag.enabled).toBe("boolean");
+      expect(["boolean", "string"]).toContain(typeof flag.enabled);
     }
 
     // Verify a known flag is present
@@ -650,10 +724,31 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
     }
   });
 
-  test("rejects non-boolean enabled value", async () => {
+  test("accepts string enabled value", async () => {
     const handler = createFeatureFlagsPatchHandler();
 
-    const invalidValues = ["true", 1, null, undefined];
+    const res = await handler(
+      new Request("http://gateway.test/v1/feature-flags/default-model", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ enabled: "gpt-4" }),
+      }),
+      "default-model",
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ key: "default-model", enabled: "gpt-4" });
+
+    clearFeatureFlagStoreCache();
+    const persisted = readPersistedFeatureFlags();
+    expect(persisted["default-model"]).toBe("gpt-4");
+  });
+
+  test("rejects non-boolean non-string enabled value", async () => {
+    const handler = createFeatureFlagsPatchHandler();
+
+    const invalidValues = [1, null, undefined];
     for (const value of invalidValues) {
       const res = await handler(
         new Request("http://gateway.test/v1/feature-flags/browser", {
@@ -666,7 +761,7 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
 
       expect(res.status).toBe(400);
       const body = await res.json();
-      expect(body.error).toContain("boolean");
+      expect(body.error).toContain("boolean or string");
     }
   });
 

--- a/gateway/src/__tests__/ipc-feature-flag-routes.test.ts
+++ b/gateway/src/__tests__/ipc-feature-flag-routes.test.ts
@@ -45,6 +45,14 @@ const TEST_REGISTRY = {
       description: "Enable user-hosted onboarding flow",
       defaultEnabled: false,
     },
+    {
+      id: "default-model",
+      scope: "assistant",
+      key: "default-model",
+      label: "Default Model",
+      description: "Default LLM model identifier",
+      defaultEnabled: "claude-sonnet-4-6",
+    },
   ],
 };
 
@@ -237,6 +245,28 @@ describe("IPC feature flag routes", () => {
     const flags = res.result as Record<string, boolean>;
     expect(flags["a2a-channel"]).toBe(true);
     expect(flags["browser"]).toBe(true);
+  });
+
+  test("get_feature_flags includes string flag values", async () => {
+    if (existsSync(featureFlagStorePath)) rmSync(featureFlagStorePath);
+    clearFeatureFlagStoreCache();
+
+    await startServerAndConnect();
+    const res = await sendRequest(client, "get_feature_flags");
+
+    expect(res.error).toBeUndefined();
+    const flags = res.result as Record<string, boolean | string>;
+    expect(flags["default-model"]).toBe("claude-sonnet-4-6");
+  });
+
+  test("get_feature_flag returns string value for string flag", async () => {
+    await startServerAndConnect();
+    const res = await sendRequest(client, "get_feature_flag", {
+      flag: "default-model",
+    });
+
+    expect(res.error).toBeUndefined();
+    expect(res.result).toBe("claude-sonnet-4-6");
   });
 
   test("get_feature_flag returns value for a known flag", async () => {

--- a/gateway/src/__tests__/remote-feature-flag-sync.test.ts
+++ b/gateway/src/__tests__/remote-feature-flag-sync.test.ts
@@ -489,14 +489,15 @@ describe("RemoteFeatureFlagSync", () => {
     );
   });
 
-  test("filters non-boolean values from response", async () => {
+  test("accepts boolean and string values, filters other types from response", async () => {
     fetchMock = mock(async () =>
       Response.json({
         flags: {
           browser: true,
-          contacts: "yes" as unknown,
+          "default-model": "claude-sonnet-4-6",
           other: 1 as unknown,
           valid: false,
+          nullVal: null as unknown,
         },
       }),
     );
@@ -511,6 +512,7 @@ describe("RemoteFeatureFlagSync", () => {
     const cached = readRemoteFeatureFlags();
     expect(cached).toEqual({
       browser: true,
+      "default-model": "claude-sonnet-4-6",
       valid: false,
     });
   });
@@ -606,6 +608,30 @@ describe("RemoteFeatureFlagSync", () => {
     expect(cached["test-ga-flag-true"]).toBe(true);
     // unknown-flag (not in registry, remote false) should be present
     expect(cached["unknown-flag"]).toBe(false);
+  });
+
+  test("GA normalization does not affect string flag values", async () => {
+    fetchMock = mock(async () =>
+      Response.json({
+        flags: {
+          "test-ga-flag": false,
+          "a2a-channel": "custom-value",
+        },
+      }),
+    );
+
+    const sync = new RemoteFeatureFlagSync({
+      credentials: fakeCredentialCache(defaultCredentials()),
+    });
+    await sync.start();
+    sync.stop();
+
+    clearRemoteFeatureFlagStoreCache();
+    const cached = readRemoteFeatureFlags();
+    // Boolean false for GA flag is normalized to true
+    expect(cached["test-ga-flag"]).toBe(true);
+    // String values are never subject to GA normalization
+    expect(cached["a2a-channel"]).toBe("custom-value");
   });
 
   test("calls onChanged when remote flags change", async () => {

--- a/gateway/src/feature-flag-defaults.ts
+++ b/gateway/src/feature-flag-defaults.ts
@@ -5,7 +5,7 @@ import { getLogger } from "./logger.js";
 const log = getLogger("feature-flag-defaults");
 
 export type FeatureFlagDefault = {
-  defaultEnabled: boolean;
+  defaultEnabled: boolean | string;
   description: string;
   label: string;
 };
@@ -85,7 +85,7 @@ function parseRegistryToDefaults(parsed: unknown): FeatureFlagDefaultsRegistry {
     const entry = flag as Record<string, unknown>;
     if (entry.scope !== "assistant" && entry.scope !== "both") continue;
     if (typeof entry.key !== "string") continue;
-    if (typeof entry.defaultEnabled !== "boolean") continue;
+    if (typeof entry.defaultEnabled !== "boolean" && typeof entry.defaultEnabled !== "string") continue;
     if (typeof entry.description !== "string") {
       log.warn(
         { key: entry.key },

--- a/gateway/src/feature-flag-remote-store.ts
+++ b/gateway/src/feature-flag-remote-store.ts
@@ -32,7 +32,7 @@ const log = getLogger("feature-flag-remote-store");
 
 interface FeatureFlagFileData {
   version: 1;
-  values: Record<string, boolean>;
+  values: Record<string, boolean | string>;
 }
 
 // ---------------------------------------------------------------------------
@@ -47,9 +47,9 @@ export function getRemoteFeatureFlagStorePath(): string {
 // Disk I/O with caching
 // ---------------------------------------------------------------------------
 
-let cachedRemoteValues: Record<string, boolean> | null = null;
+let cachedRemoteValues: Record<string, boolean | string> | null = null;
 
-export function readRemoteFeatureFlags(): Record<string, boolean> {
+export function readRemoteFeatureFlags(): Record<string, boolean | string> {
   if (cachedRemoteValues != null) return cachedRemoteValues;
 
   const path = getRemoteFeatureFlagStorePath();
@@ -76,9 +76,9 @@ export function readRemoteFeatureFlags(): Record<string, boolean> {
       typeof data.values === "object" &&
       !Array.isArray(data.values)
     ) {
-      const filtered: Record<string, boolean> = {};
+      const filtered: Record<string, boolean | string> = {};
       for (const [k, v] of Object.entries(data.values)) {
-        if (typeof v === "boolean") filtered[k] = v;
+        if (typeof v === "boolean" || typeof v === "string") filtered[k] = v;
       }
       cachedRemoteValues = filtered;
     } else {
@@ -97,7 +97,7 @@ export function readRemoteFeatureFlags(): Record<string, boolean> {
  * Returns `true` when the new values differ from the previous cache.
  */
 export function writeRemoteFeatureFlags(
-  values: Record<string, boolean>,
+  values: Record<string, boolean | string>,
 ): boolean {
   const path = getRemoteFeatureFlagStorePath();
   const dir = dirname(path);
@@ -130,8 +130,8 @@ export function writeRemoteFeatureFlags(
  * cached. Only used for log-level gating — correctness doesn't depend on it.
  */
 function shallowEqual(
-  a: Record<string, boolean> | null,
-  b: Record<string, boolean>,
+  a: Record<string, boolean | string> | null,
+  b: Record<string, boolean | string>,
 ): boolean {
   if (a == null) return false;
   const aKeys = Object.keys(a);

--- a/gateway/src/feature-flag-resolver.ts
+++ b/gateway/src/feature-flag-resolver.ts
@@ -3,13 +3,13 @@ import { readRemoteFeatureFlags } from "./feature-flag-remote-store.js";
 import { readPersistedFeatureFlags } from "./feature-flag-store.js";
 
 /**
- * Resolve the effective enabled/disabled state for a feature flag.
+ * Resolve the raw value for a feature flag.
  *
  * Priority: persisted (user-toggled) > remote (platform-pushed) > registry default.
  * Undeclared keys return `false` (fail closed), even if stale local/remote
  * state contains a value for them.
  */
-export function isFeatureFlagEnabled(key: string): boolean {
+export function getFeatureFlagValue(key: string): boolean | string {
   const defaults = loadFeatureFlagDefaults();
   const defaultDef = defaults[key];
   if (defaultDef === undefined) return false;
@@ -23,6 +23,17 @@ export function isFeatureFlagEnabled(key: string): boolean {
   if (remoteValue !== undefined) return remoteValue;
 
   return defaultDef.defaultEnabled;
+}
+
+/**
+ * Resolve whether a feature flag is enabled (boolean coercion).
+ *
+ * For boolean flags, returns the resolved value directly.
+ * For string flags, returns true if the value is non-empty.
+ * Undeclared keys return `false` (fail closed).
+ */
+export function isFeatureFlagEnabled(key: string): boolean {
+  return !!getFeatureFlagValue(key);
 }
 
 function isPlatformMode(): boolean {

--- a/gateway/src/feature-flag-store.ts
+++ b/gateway/src/feature-flag-store.ts
@@ -28,7 +28,7 @@ const log = getLogger("feature-flag-store");
 
 interface FeatureFlagFileData {
   version: 1;
-  values: Record<string, boolean>;
+  values: Record<string, boolean | string>;
 }
 
 // ---------------------------------------------------------------------------
@@ -43,9 +43,9 @@ export function getFeatureFlagStorePath(): string {
 // Disk I/O with caching
 // ---------------------------------------------------------------------------
 
-let cachedValues: Record<string, boolean> | null = null;
+let cachedValues: Record<string, boolean | string> | null = null;
 
-export function readPersistedFeatureFlags(): Record<string, boolean> {
+export function readPersistedFeatureFlags(): Record<string, boolean | string> {
   if (cachedValues != null) return cachedValues;
 
   const path = getFeatureFlagStorePath();
@@ -72,9 +72,9 @@ export function readPersistedFeatureFlags(): Record<string, boolean> {
       typeof data.values === "object" &&
       !Array.isArray(data.values)
     ) {
-      const filtered: Record<string, boolean> = {};
+      const filtered: Record<string, boolean | string> = {};
       for (const [k, v] of Object.entries(data.values)) {
-        if (typeof v === "boolean") filtered[k] = v;
+        if (typeof v === "boolean" || typeof v === "string") filtered[k] = v;
       }
       cachedValues = filtered;
     } else {
@@ -88,11 +88,11 @@ export function readPersistedFeatureFlags(): Record<string, boolean> {
   }
 }
 
-export function writeFeatureFlag(key: string, enabled: boolean): void {
+export function writeFeatureFlag(key: string, value: boolean | string): void {
   // Re-read from disk to avoid lost updates
   cachedValues = null;
   const values = { ...readPersistedFeatureFlags() };
-  values[key] = enabled;
+  values[key] = value;
 
   const path = getFeatureFlagStorePath();
   const dir = dirname(path);
@@ -107,7 +107,7 @@ export function writeFeatureFlag(key: string, enabled: boolean): void {
   chmodSync(path, 0o600);
 
   cachedValues = values;
-  log.info({ key, enabled }, "Wrote feature flag");
+  log.info({ key, value }, "Wrote feature flag");
 }
 
 export function clearFeatureFlagStoreCache(): void {

--- a/gateway/src/http/routes/feature-flags.ts
+++ b/gateway/src/http/routes/feature-flags.ts
@@ -19,8 +19,8 @@ const ALLOWED_KEY_RE = /^[a-z0-9][a-z0-9-]*$/;
 export type FeatureFlagEntry = {
   key: string;
   label: string;
-  enabled: boolean;
-  defaultEnabled: boolean;
+  enabled: boolean | string;
+  defaultEnabled: boolean | string;
   description: string;
 };
 
@@ -31,7 +31,6 @@ export function createFeatureFlagsGetHandler() {
       const persisted = readPersistedFeatureFlags();
       const remote = readRemoteFeatureFlags();
 
-      // Build entries for ALL declared flags, merging persisted values.
       const entries: FeatureFlagEntry[] = [];
       for (const [key, def] of Object.entries(defaults)) {
         const persistedValue = persisted[key];
@@ -106,9 +105,9 @@ export function createFeatureFlagsPatchHandler() {
     }
 
     const { enabled } = body as { enabled?: unknown };
-    if (typeof enabled !== "boolean") {
+    if (typeof enabled !== "boolean" && typeof enabled !== "string") {
       return Response.json(
-        { error: '"enabled" must be a boolean' },
+        { error: '"enabled" must be a boolean or string' },
         { status: 400 },
       );
     }

--- a/gateway/src/ipc/feature-flag-handlers.ts
+++ b/gateway/src/ipc/feature-flag-handlers.ts
@@ -19,14 +19,14 @@ const GetFeatureFlagParamsSchema = z.object({
 
 /**
  * Compute the merged feature flag state: defaults < remote < persisted.
- * Returns a `Record<string, boolean>` keyed by flag name.
+ * Returns a `Record<string, boolean | string>` keyed by flag name.
  */
-export function getMergedFeatureFlags(): Record<string, boolean> {
+export function getMergedFeatureFlags(): Record<string, boolean | string> {
   const defaults = loadFeatureFlagDefaults();
   const persisted = readPersistedFeatureFlags();
   const remote = readRemoteFeatureFlags();
 
-  const result: Record<string, boolean> = {};
+  const result: Record<string, boolean | string> = {};
   for (const [key, def] of Object.entries(defaults)) {
     const persistedValue = persisted[key];
     const remoteValue = remote[key];
@@ -51,7 +51,7 @@ export const featureFlagRoutes: IpcRoute[] = [
   {
     method: "get_feature_flag",
     schema: GetFeatureFlagParamsSchema,
-    handler: (params?: Record<string, unknown>): boolean | null => {
+    handler: (params?: Record<string, unknown>): boolean | string | null => {
       const flag = params?.flag as string | undefined;
       if (!flag) return null;
 

--- a/gateway/src/remote-feature-flag-sync.ts
+++ b/gateway/src/remote-feature-flag-sync.ts
@@ -33,7 +33,7 @@ function getMaxPollIntervalMs(): number {
 
 /** Discriminated result from a remote feature flag fetch attempt. */
 type RemoteFetchResult =
-  | { status: "success"; values: Record<string, boolean> }
+  | { status: "success"; values: Record<string, boolean | string> }
   | { status: "missing_credentials" }
   | { status: "error" };
 
@@ -386,24 +386,24 @@ export class RemoteFeatureFlagSync {
     }
 
     const body = (await response.json()) as {
-      flags?: Record<string, boolean>;
+      flags?: Record<string, boolean | string>;
     };
     if (!body.flags || typeof body.flags !== "object") {
       log.warn("Platform feature flags response missing 'flags' field");
       return { status: "error" };
     }
 
-    // Filter to boolean values only (defensive), and prevent the platform
-    // from disabling flags that are already GA (defaultEnabled: true in the
-    // registry). The platform uses a blanket-deny posture, sending false for
-    // every flag it knows about. Store GA false values as true rather than
-    // omitting them so the persisted snapshot cannot be interpreted as an
-    // explicit disable by any consumer.
+    // Accept boolean and string values from the platform. Prevent the
+    // platform from disabling boolean flags that are already GA
+    // (defaultEnabled: true in the registry). The platform uses a
+    // blanket-deny posture, sending false for every flag it knows about.
+    // GA normalization only applies to boolean false values; string flag
+    // values pass through unchanged.
     const registry = loadFeatureFlagDefaults();
-    const values: Record<string, boolean> = {};
+    const values: Record<string, boolean | string> = {};
     for (const [key, value] of Object.entries(body.flags)) {
-      if (typeof value !== "boolean") continue;
-      if (!value && registry[key]?.defaultEnabled) {
+      if (typeof value !== "boolean" && typeof value !== "string") continue;
+      if (value === false && registry[key]?.defaultEnabled === true) {
         log.debug(
           { key },
           "Normalizing remote false for GA flag to true (defaultEnabled: true)",

--- a/meta/feature-flags/loader.ts
+++ b/meta/feature-flags/loader.ts
@@ -16,13 +16,15 @@ import { join } from 'path';
 
 export type FeatureFlagScope = 'assistant' | 'client' | 'both';
 
+export type FeatureFlagValue = boolean | string;
+
 export interface FeatureFlagDefinition {
   id: string;
   scope: FeatureFlagScope;
   key: string;
   label: string;
   description: string;
-  defaultEnabled: boolean;
+  defaultEnabled: FeatureFlagValue;
 }
 
 export interface FeatureFlagRegistry {


### PR DESCRIPTION
## Summary
- Widen feature flag value type from `boolean` to `boolean | string` across the full backend stack: gateway stores, resolver, IPC handlers, HTTP routes, remote platform sync, and assistant-side cache/resolver
- Add `getFeatureFlagValue()` and `getAssistantFeatureFlagValue()` for raw string value access; existing `isFeatureFlagEnabled()` uses `!!` coercion (non-empty string → true, empty → false)
- Filter string flags out of web UI sync hooks and catalog — stores remain boolean-only for now, to be handled in a separate UI pass

## Original prompt
The vellum platform recently added support for string feature flags (in addition to boolean flags) via PR #8204. The request was to add backend support for handling these flags, reaching parity with boolean flags across the stack. String flags should be stored, resolved, and served just like boolean flags, but filtered out of web/mac UIs for now — UI support will come in a separate pass.

## Test plan
- [x] Gateway resolver tests: string default resolution, `!!` coercion (non-empty → true, empty → false), persisted/remote override precedence for string flags
- [x] Gateway HTTP route tests: string flag in GET response, PATCH with string value, rejection of non-boolean non-string values
- [x] Gateway IPC tests: string flag values in merged results and single-flag lookup
- [x] Remote sync tests: string values accepted from platform, GA normalization skips string values, non-boolean non-string values filtered
- [x] All 68 non-IPC gateway tests passing (IPC socket tests have pre-existing infrastructure failures on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)