### PR TITLE
feat(calls): route all phone calls through media-stream TwiML

### DIFF
--- a/assistant/src/__tests__/call-routes-http.test.ts
+++ b/assistant/src/__tests__/call-routes-http.test.ts
@@ -28,6 +28,20 @@ const mockCallsConfig = {
   },
 };
 
+// A COMPLETE credentialed services block so the now-always-on outbound
+// media-stream credential preflight (resolveTelephonyCredentialReadiness) passes:
+// an STT provider (deepgram, telephony-eligible) whose key is available via
+// getProviderKeyAsync, AND a TTS provider (elevenlabs, PCM-capable) whose key is
+// available via getSecureKeyAsync. This mirrors production, where services.stt /
+// services.tts always exist with defaults.
+const mockServicesConfig = {
+  stt: { provider: "deepgram" },
+  tts: {
+    provider: "elevenlabs",
+    providers: { elevenlabs: {} },
+  },
+};
+
 mock.module("../config/loader.js", () => ({
   getConfig: () => ({
     ui: {},
@@ -38,6 +52,7 @@ mock.module("../config/loader.js", () => ({
     rateLimit: { maxRequestsPerMinute: 0 },
     secretDetection: { enabled: false },
     calls: mockCallsConfig,
+    services: mockServicesConfig,
   }),
   loadConfig: () => ({
     model: "test",
@@ -46,6 +61,7 @@ mock.module("../config/loader.js", () => ({
     rateLimit: { maxRequestsPerMinute: 0 },
     secretDetection: { enabled: false },
     calls: mockCallsConfig,
+    services: mockServicesConfig,
     ingress: {
       enabled: true,
       publicBaseUrl: "https://test.example.com",
@@ -80,9 +96,18 @@ mock.module("../calls/twilio-config.js", () => ({
   }),
 }));
 
-// Mock secure keys
+// Mock secure keys. Both lookups must return a key so the always-on outbound
+// credential preflight resolves ready:
+//   - getProviderKeyAsync("deepgram")  → STT leg credential (resolve.ts)
+//   - getSecureKeyAsync("credential/elevenlabs/api_key") → TTS leg credential
+//     (telephony-tts-capability.ts, "namespaced-only" lookup)
+// getSecureKeyAsync is key-specific: it returns a credential for the TTS api_key
+// lookup but null for everything else (notably the twilio user-phone-number key),
+// so the user_number caller-identity test still sees an unconfigured user number.
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKeyAsync: async () => null,
+  getSecureKeyAsync: async (key: string) =>
+    key === "credential/elevenlabs/api_key" ? "test-secure-key" : null,
+  getProviderKeyAsync: async () => "test-provider-key",
 }));
 
 mock.module("../calls/voice-ingress-preflight.js", () => ({

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -457,10 +457,18 @@ describe("twilio webhook routes", () => {
     mockSecureKeyStore = {
       [credentialKey("twilio", "account_sid")]: "AC_existing",
       [credentialKey("twilio", "auth_token")]: "test-auth-token",
-      // Usable STT (openai) + TTS (elevenlabs) credentials so the telephony TTS
-      // playability check passes by default and inbound webhooks emit
-      // <Connect><Stream>. The TTS-missing test clears the elevenlabs key.
+      // Usable STT (deepgram default + openai for openai-whisper tests) AND TTS
+      // (elevenlabs) credentials so the inbound full-readiness guard
+      // (resolveTelephonyCredentialReadiness: STT + TTS) passes by default and
+      // inbound webhooks emit <Connect><Stream>. The setup-required tests clear
+      // a specific key (TTS or STT) to exercise the <Say> setup-required path.
+      [credentialKey("deepgram", "api_key")]: "sk-deepgram-test",
       [credentialKey("openai", "api_key")]: "sk-openai-test",
+      // STT keys for the remaining providers so the inbound full-readiness
+      // guard (STT + TTS) emits <Stream> across every provider. Credential
+      // providers: google-gemini → "gemini", xai → "xai" (per the STT catalog).
+      [credentialKey("gemini", "api_key")]: "sk-gemini-test",
+      [credentialKey("xai", "api_key")]: "sk-xai-test",
       [credentialKey("elevenlabs", "api_key")]: "sk-eleven-test",
     };
     mockAvailableNumbers = [{ phoneNumber: "+15556667777" }];
@@ -1258,12 +1266,14 @@ describe("twilio webhook routes", () => {
     }
   });
 
-  // ── Inbound TTS-missing → Twilio-native <Say> ───────────────────────
-  // Carried-over fix: when no TTS provider is playable, the media-stream
-  // transport can't synthesize the setup-required message (silent call), so
-  // the inbound webhook emits a TwiML-level <Say> + <Hangup/> instead.
+  // ── Inbound credentials-not-ready → Twilio-native <Say> ─────────────
+  // An interactive inbound call needs BOTH legs. If TTS is not playable the
+  // media-stream transport can't synthesize the setup-required message (silent
+  // call); if STT is missing/unsupported the interactive setup flow waits
+  // forever on transcripts that never arrive. In EITHER case the inbound
+  // webhook emits a TwiML-level <Say> + <Hangup/> instead of <Connect><Stream>.
 
-  describe("inbound TTS-missing setup-required <Say>", () => {
+  describe("inbound credentials-not-ready setup-required <Say>", () => {
     test("inbound: no playable TTS -> audible <Say> + <Hangup/> (no Stream)", async () => {
       mockConfigObj.services.stt.provider = "openai-whisper" as any;
       // Remove the only playable TTS credential (configured + default are
@@ -1285,6 +1295,48 @@ describe("twilio webhook routes", () => {
       expect(twiml).toContain("<Hangup/>");
       expect(twiml).not.toContain("<Stream");
       expect(twiml).not.toContain("<ConversationRelay");
+    });
+
+    test("inbound: missing STT credential (TTS fine) -> <Say> + <Hangup/> (no Stream)", async () => {
+      // STT is openai-whisper (credentialProvider "openai"); remove its key so
+      // the STT leg is not-ready while TTS (elevenlabs) stays playable. The
+      // inbound guard must still divert to <Say> — an interactive inbound flow
+      // with no transcripts would otherwise stream into a dead STT and hang.
+      mockConfigObj.services.stt.provider = "openai-whisper" as any;
+      delete mockSecureKeyStore[credentialKey("openai", "api_key")];
+
+      const req = makeInboundVoiceRequest({
+        CallSid: "CA_stt_missing_in",
+        From: "+14155551234",
+        To: "+15550001111",
+      });
+
+      const res = await handleVoiceWebhook(req);
+      expect(res.status).toBe(200);
+
+      const twiml = await res.text();
+      expect(twiml).toContain("<Say>");
+      expect(twiml).toContain("</Say>");
+      expect(twiml).toContain("<Hangup/>");
+      expect(twiml).not.toContain("<Stream");
+      expect(twiml).not.toContain("<ConversationRelay");
+    });
+
+    test("inbound: both STT + TTS ready -> <Connect><Stream> (no Say)", async () => {
+      // Default beforeEach seeds deepgram (STT) + elevenlabs (TTS) keys, so the
+      // full-readiness guard passes and the webhook streams normally.
+      const req = makeInboundVoiceRequest({
+        CallSid: "CA_both_ready_in",
+        From: "+14155551234",
+        To: "+15550001111",
+      });
+
+      const res = await handleVoiceWebhook(req);
+      expect(res.status).toBe(200);
+
+      const twiml = await res.text();
+      expect(twiml).toContain("<Stream");
+      expect(twiml).not.toContain("<Say>");
     });
 
     test("outbound: no playable TTS still emits Stream (preflight gates outbound before dial)", async () => {
@@ -1353,7 +1405,10 @@ describe("twilio webhook routes", () => {
       },
     ];
 
-    for (const [i, { label, provider, outcome, trustClass }] of cases.entries()) {
+    for (const [
+      i,
+      { label, provider, outcome, trustClass },
+    ] of cases.entries()) {
       test(`${label} → true (preflight runs)`, () => {
         mockConfigObj.services.stt.provider = provider as any;
         mockRouteSetupResult = {

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -184,6 +184,16 @@ mock.module("../security/secure-keys.js", () => ({
     delete mockSecureKeyStore[key];
     return "deleted";
   },
+  // Read paths used by the telephony TTS playability check
+  // (resolveTelephonyTtsPlayable → isTtsProviderCredentialAvailable). The
+  // default store is seeded in beforeEach with a usable ElevenLabs key so the
+  // inbound webhook emits <Connect><Stream>; the TTS-missing test clears it to
+  // exercise the <Say> setup-required path.
+  getSecureKeyAsync: async (key: string) => mockSecureKeyStore[key],
+  getProviderKeyAsync: async (provider: string) =>
+    mockSecureKeyStore[credentialKey(provider, "api_key")] ??
+    mockSecureKeyStore[`credential/${provider}/api_key`] ??
+    mockSecureKeyStore[provider],
 }));
 
 mock.module("../calls/twilio-provider.js", () => ({
@@ -447,6 +457,11 @@ describe("twilio webhook routes", () => {
     mockSecureKeyStore = {
       [credentialKey("twilio", "account_sid")]: "AC_existing",
       [credentialKey("twilio", "auth_token")]: "test-auth-token",
+      // Usable STT (openai) + TTS (elevenlabs) credentials so the telephony TTS
+      // playability check passes by default and inbound webhooks emit
+      // <Connect><Stream>. The TTS-missing test clears the elevenlabs key.
+      [credentialKey("openai", "api_key")]: "sk-openai-test",
+      [credentialKey("elevenlabs", "api_key")]: "sk-eleven-test",
     };
     mockAvailableNumbers = [{ phoneNumber: "+15556667777" }];
     mockProvisionedNumber = { phoneNumber: "+15556667777" };
@@ -812,8 +827,8 @@ describe("twilio webhook routes", () => {
   // ── TwiML relay URL generation ──────────────────────────────────────
   // Call handleVoiceWebhook directly since direct routes are blocked.
 
-  describe("voice webhook TwiML relay URL", () => {
-    test("TwiML relay URL uses placeholder for gateway resolution", async () => {
+  describe("voice webhook TwiML media-stream URL", () => {
+    test("TwiML media-stream URL uses placeholder for gateway resolution", async () => {
       const session = createTestSession("conv-twiml-1", "CA_twiml_1");
       const req = makeVoiceRequest(session.id, { CallSid: "CA_twiml_1" });
 
@@ -821,8 +836,9 @@ describe("twilio webhook routes", () => {
 
       expect(res.status).toBe(200);
       const twiml = await res.text();
+      expect(twiml).toContain("<Stream");
       expect(twiml).toContain(
-        "wss://__VELLUM_PUBLIC_BASE_URL__/webhooks/twilio/relay",
+        "wss://__VELLUM_PUBLIC_BASE_URL__/webhooks/twilio/media-stream",
       );
     });
 
@@ -995,8 +1011,9 @@ describe("twilio webhook routes", () => {
 
       expect(res.status).toBe(200);
       const twiml = await res.text();
-      expect(twiml).toContain("<ConversationRelay");
-      expect(twiml).toContain("callSessionId=");
+      expect(twiml).toContain("<Stream");
+      expect(twiml).not.toContain("<ConversationRelay");
+      expect(twiml).toContain("callSessionId");
 
       // Verify session was created with the CallSid
       const session = getCallSessionByCallSid("CA_inbound_new_1");
@@ -1068,99 +1085,71 @@ describe("twilio webhook routes", () => {
 
       expect(res.status).toBe(200);
       const twiml = await res.text();
-      expect(twiml).toContain("<ConversationRelay");
-      expect(twiml).toContain(`callSessionId=${session.id}`);
+      expect(twiml).toContain("<Stream");
+      expect(twiml).not.toContain("<ConversationRelay");
+      // callSessionId is a path segment on the media-stream URL
+      expect(twiml).toContain(`/media-stream/${session.id}`);
     });
   });
 
-  // ── services.stt-driven TwiML routing ───────────────────────────────
-  // These tests assert that the voice webhook TwiML path is determined
-  // by services.stt.provider via resolveTelephonySttRouting — the
-  // canonical telephony STT routing resolver.
+  // ── Always-media-stream TwiML routing ───────────────────────────────
+  // PR 11 flip: EVERY phone call routes through the media-stream transport
+  // (`<Connect><Stream>`) regardless of services.stt.provider — the daemon
+  // performs STT, TTS, and all interactive setup sub-flows server-side. The
+  // legacy ConversationRelay path is never emitted by the voice webhook.
 
-  describe("services.stt-driven TwiML routing", () => {
-    test("outbound: deepgram -> ConversationRelay with transcriptionProvider=Deepgram", async () => {
-      mockConfigObj.services.stt.provider = "deepgram" as any;
-      const session = createTestSession("conv-stt-dg-1", "CA_stt_dg_1");
-      const req = makeVoiceRequest(session.id, { CallSid: "CA_stt_dg_1" });
+  describe("always-media-stream TwiML routing (every provider)", () => {
+    const sttProviders = [
+      "deepgram",
+      "google-gemini",
+      "openai-whisper",
+      "xai",
+    ] as const;
 
-      const res = await handleVoiceWebhook(req);
-      expect(res.status).toBe(200);
+    for (const provider of sttProviders) {
+      test(`outbound: ${provider} -> Stream TwiML (no ConversationRelay)`, async () => {
+        mockConfigObj.services.stt.provider = provider as any;
+        const session = createTestSession(
+          `conv-stt-${provider}-out`,
+          `CA_stt_${provider}_out`,
+        );
+        const req = makeVoiceRequest(session.id, {
+          CallSid: `CA_stt_${provider}_out`,
+        });
 
-      const twiml = await res.text();
-      expect(twiml).toContain("<ConversationRelay");
-      expect(twiml).not.toContain("<Stream");
-      expect(twiml).toContain('transcriptionProvider="Deepgram"');
-    });
+        const res = await handleVoiceWebhook(req);
+        expect(res.status).toBe(200);
 
-    test("inbound: deepgram -> ConversationRelay with transcriptionProvider=Deepgram", async () => {
-      mockConfigObj.services.stt.provider = "deepgram" as any;
-      const req = makeInboundVoiceRequest({
-        CallSid: "CA_stt_dg_inbound_1",
-        From: "+14155551234",
-        To: "+15550001111",
+        const twiml = await res.text();
+        expect(twiml).toContain("<Stream");
+        expect(twiml).not.toContain("<ConversationRelay");
+        expect(twiml).not.toContain("transcriptionProvider=");
+        // callSessionId is a path segment on the media-stream URL
+        expect(twiml).toContain(
+          `wss://__VELLUM_PUBLIC_BASE_URL__/webhooks/twilio/media-stream/${session.id}`,
+        );
+        expect(twiml).not.toContain("?callSessionId=");
       });
 
-      const res = await handleVoiceWebhook(req);
-      expect(res.status).toBe(200);
+      test(`inbound: ${provider} -> Stream TwiML (no ConversationRelay)`, async () => {
+        mockConfigObj.services.stt.provider = provider as any;
+        const req = makeInboundVoiceRequest({
+          CallSid: `CA_stt_${provider}_in`,
+          From: "+14155551234",
+          To: "+15550001111",
+        });
 
-      const twiml = await res.text();
-      expect(twiml).toContain("<ConversationRelay");
-      expect(twiml).toContain('transcriptionProvider="Deepgram"');
-      expect(twiml).not.toContain("<Stream");
-    });
+        const res = await handleVoiceWebhook(req);
+        expect(res.status).toBe(200);
 
-    test("outbound: google-gemini -> ConversationRelay with transcriptionProvider=Google", async () => {
-      mockConfigObj.services.stt.provider = "google-gemini" as any;
-      const session = createTestSession("conv-stt-gg-1", "CA_stt_gg_1");
-      const req = makeVoiceRequest(session.id, { CallSid: "CA_stt_gg_1" });
-
-      const res = await handleVoiceWebhook(req);
-      expect(res.status).toBe(200);
-
-      const twiml = await res.text();
-      expect(twiml).toContain("<ConversationRelay");
-      expect(twiml).not.toContain("<Stream");
-      expect(twiml).toContain('transcriptionProvider="Google"');
-    });
-
-    test("outbound: openai-whisper -> Stream TwiML with path-based metadata (no ConversationRelay)", async () => {
-      mockConfigObj.services.stt.provider = "openai-whisper" as any;
-      const session = createTestSession("conv-stt-ow-1", "CA_stt_ow_1");
-      const req = makeVoiceRequest(session.id, { CallSid: "CA_stt_ow_1" });
-
-      const res = await handleVoiceWebhook(req);
-      expect(res.status).toBe(200);
-
-      const twiml = await res.text();
-      expect(twiml).toContain("<Stream");
-      expect(twiml).not.toContain("<ConversationRelay");
-      expect(twiml).not.toContain("transcriptionProvider=");
-      // callSessionId is in the URL path, not as a query param
-      expect(twiml).toContain(
-        `wss://__VELLUM_PUBLIC_BASE_URL__/webhooks/twilio/media-stream/${session.id}`,
-      );
-      expect(twiml).not.toContain("?callSessionId=");
-    });
-
-    test("inbound: openai-whisper -> Stream TwiML (no ConversationRelay)", async () => {
-      mockConfigObj.services.stt.provider = "openai-whisper" as any;
-      const req = makeInboundVoiceRequest({
-        CallSid: "CA_stt_ow_inbound_1",
-        From: "+14155551234",
-        To: "+15550001111",
+        const twiml = await res.text();
+        expect(twiml).toContain("<Stream");
+        expect(twiml).not.toContain("<ConversationRelay");
+        expect(twiml).not.toContain("transcriptionProvider=");
       });
+    }
 
-      const res = await handleVoiceWebhook(req);
-      expect(res.status).toBe(200);
-
-      const twiml = await res.text();
-      expect(twiml).toContain("<Stream");
-      expect(twiml).not.toContain("<ConversationRelay");
-      expect(twiml).not.toContain("transcriptionProvider=");
-    });
-
-    test("Stream TwiML includes auth token as Parameter", async () => {
+    test("Stream TwiML includes auth token and callSessionId Parameters", async () => {
       mockConfigObj.services.stt.provider = "openai-whisper" as any;
       const session = createTestSession(
         "conv-stt-ow-token-1",
@@ -1177,147 +1166,61 @@ describe("twilio webhook routes", () => {
       expect(twiml).toContain('<Parameter name="token"');
       expect(twiml).toContain('<Parameter name="callSessionId"');
     });
-
-    test("routing is driven exclusively by services.stt.provider", async () => {
-      // Telephony STT routing reads services.stt.provider only.
-      // calls.voice.transcriptionProvider is a legacy config field that
-      // no longer participates in the call setup path.
-      mockConfigObj.services.stt.provider = "openai-whisper" as any;
-      const session = createTestSession(
-        "conv-stt-routing-1",
-        "CA_stt_routing_1",
-      );
-      const req = makeVoiceRequest(session.id, { CallSid: "CA_stt_routing_1" });
-
-      const res = await handleVoiceWebhook(req);
-      expect(res.status).toBe(200);
-
-      const twiml = await res.text();
-      // Must be Stream (from services.stt), NOT ConversationRelay
-      expect(twiml).toContain("<Stream");
-      expect(twiml).not.toContain("<ConversationRelay");
-    });
   });
 
-  // ── Media-stream preflight setup guardrails ──────────────────────────
-  // These tests assert that the TwiML preflight guard in
-  // buildVoiceWebhookTwiml rejects unsupported interactive setup actions
-  // for media-stream-custom calls before stream bootstrap, falling back
-  // to ConversationRelay for interactive flows.
+  // ── Every setup outcome routes to media-stream ──────────────────────
+  // PR 11 removed the CR-fallback for interactive setup flows. Outcomes that
+  // previously fell back to ConversationRelay (verification, name_capture,
+  // invite_redemption, …) now route to the media-stream transport, which
+  // drives those sub-flows server-side.
 
-  describe("media-stream preflight setup guardrails", () => {
-    test("media-stream: normal_call setup proceeds with Stream TwiML", async () => {
-      mockConfigObj.services.stt.provider = "openai-whisper" as any;
-      mockRouteSetupResult = {
-        outcome: { action: "normal_call", isInbound: true },
-        resolved: {
-          assistantId: "self",
-          isInbound: true,
-          otherPartyNumber: "+15559998888",
-          actorTrust: { trustClass: "guardian", memberRecord: null },
-        },
-      };
-
-      const session = createTestSession("conv-ms-normal-1", "CA_ms_normal_1");
-      const req = makeVoiceRequest(session.id, { CallSid: "CA_ms_normal_1" });
-
-      const res = await handleVoiceWebhook(req);
-      expect(res.status).toBe(200);
-
-      const twiml = await res.text();
-      expect(twiml).toContain("<Stream");
-      expect(twiml).not.toContain("<ConversationRelay");
+  describe("every setup outcome routes to media-stream", () => {
+    const makeResolved = (trustClass: string) => ({
+      assistantId: "self",
+      isInbound: true,
+      otherPartyNumber: "+14155551234",
+      actorTrust: { trustClass, memberRecord: null },
     });
 
-    test("media-stream: deny setup proceeds with Stream TwiML (deny is handled at stream level)", async () => {
-      mockConfigObj.services.stt.provider = "openai-whisper" as any;
-      mockRouteSetupResult = {
+    const outcomes: Array<{
+      label: string;
+      outcome: { action: string; [key: string]: unknown };
+      trustClass: string;
+    }> = [
+      {
+        label: "normal_call",
+        outcome: { action: "normal_call", isInbound: true },
+        trustClass: "guardian",
+      },
+      {
+        label: "deny",
         outcome: {
           action: "deny",
           message: "This number is not authorized.",
           logReason: "Inbound voice ACL: blocked caller",
         },
-        resolved: {
-          assistantId: "self",
-          isInbound: true,
-          otherPartyNumber: "+15559998888",
-          actorTrust: { trustClass: "unknown", memberRecord: null },
-        },
-      };
-
-      const session = createTestSession("conv-ms-deny-1", "CA_ms_deny_1");
-      const req = makeVoiceRequest(session.id, { CallSid: "CA_ms_deny_1" });
-
-      const res = await handleVoiceWebhook(req);
-      expect(res.status).toBe(200);
-
-      const twiml = await res.text();
-      // Deny is supported on media-stream — should still produce Stream TwiML
-      expect(twiml).toContain("<Stream");
-      expect(twiml).not.toContain("<ConversationRelay");
-    });
-
-    test("media-stream: verification setup falls back to ConversationRelay", async () => {
-      mockConfigObj.services.stt.provider = "openai-whisper" as any;
-      mockRouteSetupResult = {
+        trustClass: "unknown",
+      },
+      {
+        label: "verification",
         outcome: {
           action: "verification",
           assistantId: "self",
           fromNumber: "+14155551234",
         },
-        resolved: {
-          assistantId: "self",
-          isInbound: true,
-          otherPartyNumber: "+14155551234",
-          actorTrust: { trustClass: "unknown", memberRecord: null },
-        },
-      };
-
-      const session = createTestSession("conv-ms-verify-1", "CA_ms_verify_1");
-      const req = makeVoiceRequest(session.id, { CallSid: "CA_ms_verify_1" });
-
-      const res = await handleVoiceWebhook(req);
-      expect(res.status).toBe(200);
-
-      const twiml = await res.text();
-      // Interactive verification cannot work on media-stream — must fall back
-      expect(twiml).toContain("<ConversationRelay");
-      expect(twiml).not.toContain("<Stream");
-      expect(twiml).toContain('transcriptionProvider="Deepgram"');
-    });
-
-    test("media-stream: name_capture setup falls back to ConversationRelay", async () => {
-      mockConfigObj.services.stt.provider = "openai-whisper" as any;
-      mockRouteSetupResult = {
+        trustClass: "unknown",
+      },
+      {
+        label: "name_capture",
         outcome: {
           action: "name_capture",
           assistantId: "self",
           fromNumber: "+14155551234",
         },
-        resolved: {
-          assistantId: "self",
-          isInbound: true,
-          otherPartyNumber: "+14155551234",
-          actorTrust: { trustClass: "unknown", memberRecord: null },
-        },
-      };
-
-      const session = createTestSession("conv-ms-namecap-1", "CA_ms_namecap_1");
-      const req = makeVoiceRequest(session.id, {
-        CallSid: "CA_ms_namecap_1",
-      });
-
-      const res = await handleVoiceWebhook(req);
-      expect(res.status).toBe(200);
-
-      const twiml = await res.text();
-      expect(twiml).toContain("<ConversationRelay");
-      expect(twiml).not.toContain("<Stream");
-    });
-
-    test("media-stream: invite_redemption setup falls back to ConversationRelay", async () => {
-      mockConfigObj.services.stt.provider = "openai-whisper" as any;
-      mockRouteSetupResult = {
+        trustClass: "unknown",
+      },
+      {
+        label: "invite_redemption",
         outcome: {
           action: "invite_redemption",
           assistantId: "self",
@@ -1325,144 +1228,148 @@ describe("twilio webhook routes", () => {
           friendName: "Alice",
           guardianName: "Bob",
         },
-        resolved: {
-          assistantId: "self",
-          isInbound: true,
-          otherPartyNumber: "+14155551234",
-          actorTrust: { trustClass: "unknown", memberRecord: null },
-        },
-      };
+        trustClass: "unknown",
+      },
+    ];
 
-      const session = createTestSession("conv-ms-invite-1", "CA_ms_invite_1");
-      const req = makeVoiceRequest(session.id, {
-        CallSid: "CA_ms_invite_1",
+    for (const { label, outcome, trustClass } of outcomes) {
+      test(`${label} outcome -> Stream TwiML (no CR-fallback)`, async () => {
+        mockConfigObj.services.stt.provider = "openai-whisper" as any;
+        mockRouteSetupResult = {
+          outcome,
+          resolved: makeResolved(trustClass),
+        };
+
+        const session = createTestSession(
+          `conv-outcome-${label}`,
+          `CA_outcome_${label}`,
+        );
+        const req = makeVoiceRequest(session.id, {
+          CallSid: `CA_outcome_${label}`,
+        });
+
+        const res = await handleVoiceWebhook(req);
+        expect(res.status).toBe(200);
+
+        const twiml = await res.text();
+        expect(twiml).toContain("<Stream");
+        expect(twiml).not.toContain("<ConversationRelay");
+      });
+    }
+  });
+
+  // ── Inbound TTS-missing → Twilio-native <Say> ───────────────────────
+  // Carried-over fix: when no TTS provider is playable, the media-stream
+  // transport can't synthesize the setup-required message (silent call), so
+  // the inbound webhook emits a TwiML-level <Say> + <Hangup/> instead.
+
+  describe("inbound TTS-missing setup-required <Say>", () => {
+    test("inbound: no playable TTS -> audible <Say> + <Hangup/> (no Stream)", async () => {
+      mockConfigObj.services.stt.provider = "openai-whisper" as any;
+      // Remove the only playable TTS credential (configured + default are
+      // both elevenlabs here), so telephony TTS is not playable.
+      delete mockSecureKeyStore[credentialKey("elevenlabs", "api_key")];
+
+      const req = makeInboundVoiceRequest({
+        CallSid: "CA_tts_missing_in",
+        From: "+14155551234",
+        To: "+15550001111",
       });
 
       const res = await handleVoiceWebhook(req);
       expect(res.status).toBe(200);
 
       const twiml = await res.text();
-      expect(twiml).toContain("<ConversationRelay");
+      expect(twiml).toContain("<Say>");
+      expect(twiml).toContain("</Say>");
+      expect(twiml).toContain("<Hangup/>");
       expect(twiml).not.toContain("<Stream");
+      expect(twiml).not.toContain("<ConversationRelay");
     });
 
-    test("conversation-relay-native: unsupported setup does not trigger preflight (not media-stream)", async () => {
-      // When the STT provider is deepgram (conversation-relay-native),
-      // the preflight guard is not invoked — setup flows are handled
-      // natively by the relay server.
-      mockConfigObj.services.stt.provider = "deepgram" as any;
-      mockRouteSetupResult = {
-        outcome: {
-          action: "verification",
-          assistantId: "self",
-          fromNumber: "+14155551234",
-        },
-        resolved: {
-          assistantId: "self",
-          isInbound: true,
-          otherPartyNumber: "+14155551234",
-          actorTrust: { trustClass: "unknown", memberRecord: null },
-        },
-      };
+    test("outbound: no playable TTS still emits Stream (preflight gates outbound before dial)", async () => {
+      // The outbound webhook is reached only after call-domain's credential
+      // preflight has already passed, so the webhook itself never emits <Say>
+      // for outbound — it always connects the media-stream.
+      mockConfigObj.services.stt.provider = "openai-whisper" as any;
+      delete mockSecureKeyStore[credentialKey("elevenlabs", "api_key")];
 
-      const session = createTestSession("conv-cr-verify-1", "CA_cr_verify_1");
+      const session = createTestSession(
+        "conv-tts-missing-out",
+        "CA_tts_missing_out",
+      );
       const req = makeVoiceRequest(session.id, {
-        CallSid: "CA_cr_verify_1",
+        CallSid: "CA_tts_missing_out",
       });
 
       const res = await handleVoiceWebhook(req);
       expect(res.status).toBe(200);
 
       const twiml = await res.text();
-      // ConversationRelay should be emitted regardless of setup outcome
-      expect(twiml).toContain("<ConversationRelay");
-      expect(twiml).not.toContain("<Stream");
+      expect(twiml).toContain("<Stream");
+      expect(twiml).not.toContain("<Say>");
     });
   });
 
   // ── Outbound preflight transport gate ───────────────────────────────
-  // `outboundWillUseMediaStream` is the SHARED predicate the outbound
-  // credential preflight (call-domain.startCall) uses to decide whether to run
-  // the local STT/TTS credential check. It must mirror buildVoiceWebhookTwiml's
-  // FULL transport decision: media-stream is used ONLY when STT routing is
-  // media-stream-custom AND the routeSetup outcome is normal_call / deny. For
-  // CR-native STT, or for interactive outcomes that buildVoiceWebhookTwiml
-  // CR-falls-back, it must return false so the preflight is skipped.
+  // PR 11 flip: every call routes through the media-stream transport, so
+  // `outboundWillUseMediaStream` is effectively always-true and the outbound
+  // credential preflight (call-domain.startCall) runs for EVERY call —
+  // regardless of STT provider or routeSetup outcome.
 
-  describe("outboundWillUseMediaStream (preflight transport gate)", () => {
-    test("media-stream-custom STT + normal_call outcome → true (preflight runs)", () => {
-      mockConfigObj.services.stt.provider = "openai-whisper" as any;
-      mockRouteSetupResult = {
+  describe("outboundWillUseMediaStream (preflight runs for every call)", () => {
+    const cases: Array<{
+      label: string;
+      provider: string;
+      outcome: { action: string; [key: string]: unknown };
+      trustClass: string;
+    }> = [
+      {
+        label: "media-stream-custom STT + normal_call",
+        provider: "openai-whisper",
         outcome: { action: "normal_call", isInbound: false },
-        resolved: {
-          assistantId: "self",
-          isInbound: false,
-          otherPartyNumber: "+14155550199",
-          actorTrust: { trustClass: "guardian", memberRecord: null },
-        },
-      };
-      const session = createTestSession("conv-gate-ms-normal", "CA_gate_ms_1");
-
-      expect(outboundWillUseMediaStream(session)).toBe(true);
-    });
-
-    test("media-stream-custom STT + interactive (callee_verification) outcome → false (preflight skipped, CR-fallback)", () => {
-      // calls.verification.enabled makes routeSetup return callee_verification
-      // for an interactive outbound flow; buildVoiceWebhookTwiml CR-falls-back,
-      // so the call needs no local creds and the gate must skip the preflight.
-      mockConfigObj.services.stt.provider = "openai-whisper" as any;
-      mockRouteSetupResult = {
+        trustClass: "guardian",
+      },
+      {
+        label: "media-stream-custom STT + interactive callee_verification",
+        provider: "openai-whisper",
         outcome: {
           action: "callee_verification",
           verificationConfig: { maxAttempts: 3, codeLength: 6 },
         },
-        resolved: {
-          assistantId: "self",
-          isInbound: false,
-          otherPartyNumber: "+14155550199",
-          actorTrust: { trustClass: "guardian", memberRecord: null },
-        },
-      };
-      const session = createTestSession("conv-gate-ms-verify", "CA_gate_ms_2");
-
-      expect(outboundWillUseMediaStream(session)).toBe(false);
-    });
-
-    test("media-stream-custom STT + deny outcome → true (media-stream serves deny)", () => {
-      mockConfigObj.services.stt.provider = "openai-whisper" as any;
-      mockRouteSetupResult = {
-        outcome: {
-          action: "deny",
-          message: "Not authorized.",
-          logReason: "test",
-        },
-        resolved: {
-          assistantId: "self",
-          isInbound: false,
-          otherPartyNumber: "+14155550199",
-          actorTrust: { trustClass: "unknown", memberRecord: null },
-        },
-      };
-      const session = createTestSession("conv-gate-ms-deny", "CA_gate_ms_3");
-
-      expect(outboundWillUseMediaStream(session)).toBe(true);
-    });
-
-    test("CR-native STT (deepgram) → false regardless of outcome (preflight skipped)", () => {
-      mockConfigObj.services.stt.provider = "deepgram" as any;
-      mockRouteSetupResult = {
+        trustClass: "guardian",
+      },
+      {
+        label: "media-stream-custom STT + deny",
+        provider: "openai-whisper",
+        outcome: { action: "deny", message: "Not authorized.", logReason: "t" },
+        trustClass: "unknown",
+      },
+      {
+        label: "formerly-CR-native STT (deepgram) + normal_call",
+        provider: "deepgram",
         outcome: { action: "normal_call", isInbound: false },
-        resolved: {
-          assistantId: "self",
-          isInbound: false,
-          otherPartyNumber: "+14155550199",
-          actorTrust: { trustClass: "guardian", memberRecord: null },
-        },
-      };
-      const session = createTestSession("conv-gate-cr", "CA_gate_cr_1");
+        trustClass: "guardian",
+      },
+    ];
 
-      expect(outboundWillUseMediaStream(session)).toBe(false);
-    });
+    for (const [i, { label, provider, outcome, trustClass }] of cases.entries()) {
+      test(`${label} → true (preflight runs)`, () => {
+        mockConfigObj.services.stt.provider = provider as any;
+        mockRouteSetupResult = {
+          outcome,
+          resolved: {
+            assistantId: "self",
+            isInbound: false,
+            otherPartyNumber: "+14155550199",
+            actorTrust: { trustClass, memberRecord: null },
+          },
+        };
+        const session = createTestSession(`conv-gate-${i}`, `CA_gate_${i}`);
+
+        expect(outboundWillUseMediaStream(session)).toBe(true);
+      });
+    }
   });
 
   describe("Twilio control-plane credential and number operations", () => {

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -1322,6 +1322,36 @@ describe("twilio webhook routes", () => {
       expect(twiml).not.toContain("<ConversationRelay");
     });
 
+    test("inbound: deny outcome + missing STT (TTS fine) -> <Stream> (denial speaks; STT not needed)", async () => {
+      // A blocked/deny caller only needs TTS to voice the denial then hang up —
+      // it never consumes transcripts, so a missing STT must NOT divert to the
+      // generic setup-required <Say>. The deny flow runs over media-stream.
+      mockConfigObj.services.stt.provider = "openai-whisper" as any;
+      delete mockSecureKeyStore[credentialKey("openai", "api_key")];
+      const prevRouteSetup = mockRouteSetupResult;
+      mockRouteSetupResult = {
+        outcome: { action: "deny", isInbound: true } as any,
+        resolved: prevRouteSetup.resolved,
+      };
+      try {
+        const req = makeInboundVoiceRequest({
+          CallSid: "CA_deny_stt_missing_in",
+          From: "+14155551234",
+          To: "+15550001111",
+        });
+
+        const res = await handleVoiceWebhook(req);
+        expect(res.status).toBe(200);
+
+        const twiml = await res.text();
+        expect(twiml).toContain("<Stream");
+        expect(twiml).not.toContain("<Say>");
+        expect(twiml).not.toContain("<ConversationRelay");
+      } finally {
+        mockRouteSetupResult = prevRouteSetup;
+      }
+    });
+
     test("inbound: both STT + TTS ready -> <Connect><Stream> (no Say)", async () => {
       // Default beforeEach seeds deepgram (STT) + elevenlabs (TTS) keys, so the
       // full-readiness guard passes and the webhook streams normally.

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -460,26 +460,11 @@ export async function startCall(
     // record the failure event, point the user at the missing credential, and
     // do not dial.
     //
-    // GATE: only run this for calls that will actually be served by the
-    // media-stream transport (`<Connect><Stream>`). `outboundWillUseMediaStream`
-    // mirrors the FULL transport decision buildVoiceWebhookTwiml makes for this
-    // exact session: media-stream is used ONLY when STT routing is
-    // `media-stream-custom` AND routeSetup's outcome is one media-stream can
-    // serve (normal_call / deny). It returns false for:
-    //   - conversation-relay-native STT (deepgram / google): Twilio CR does STT
-    //     + native TTS, so no local credentials are needed; AND
-    //   - interactive outbound flows that buildVoiceWebhookTwiml CR-falls-back
-    //     (e.g. calls.verification.enabled → callee_verification): these are
-    //     served by CR too, so the preflight must be skipped or it would
-    //     wrongly block the call for missing local STT/TTS creds.
-    // Sharing the predicate with buildVoiceWebhookTwiml guarantees the gate and
-    // the real TwiML branch cannot drift.
-    //
-    // CROSS-PR NOTE (PR 11): PR 11 removes the CR-fallback entirely — all setup
-    // outcomes route to the media-stream transport. When that lands,
-    // outboundWillUseMediaStream collapses to "strategy === media-stream-custom"
-    // (and, once routing always selects it, to always-true); PR 11 must
-    // simplify that shared helper accordingly. This call site needs no change.
+    // GATE: every call now routes through the media-stream transport
+    // (`<Connect><Stream>`), where the daemon performs both STT and TTS, so the
+    // preflight is always relevant. `outboundWillUseMediaStream` is the shared
+    // seam with buildVoiceWebhookTwiml's transport decision and is now
+    // effectively always-true, so the credential check runs for EVERY call.
     const credentialReadiness = outboundWillUseMediaStream(session)
       ? await resolveTelephonyCredentialReadiness()
       : ({ status: "ready" } as const);

--- a/assistant/src/calls/media-stream-server.ts
+++ b/assistant/src/calls/media-stream-server.ts
@@ -77,6 +77,7 @@ import { routeSetup } from "./relay-setup-router.js";
 import {
   describeCredentialGaps,
   resolveTelephonyCredentialReadiness,
+  TELEPHONY_SETUP_REQUIRED_MESSAGE,
 } from "./telephony-credential-preflight.js";
 import type { CallEventType } from "./types.js";
 
@@ -785,7 +786,7 @@ export class MediaStreamCallSession {
       this.runFinalizationAndGrantCleanup(session);
       void speakSystemPrompt(
         this.output,
-        "Sorry, this assistant isn't set up to take calls right now. Please try again later. Goodbye.",
+        TELEPHONY_SETUP_REQUIRED_MESSAGE,
       ).finally(() => {
         setTimeout(
           () =>

--- a/assistant/src/calls/telephony-credential-preflight.ts
+++ b/assistant/src/calls/telephony-credential-preflight.ts
@@ -65,6 +65,16 @@ import {
 
 const log = getLogger("telephony-credential-preflight");
 
+/**
+ * Short spoken/displayed message for a call that can't proceed because the
+ * telephony providers aren't set up. Shared by the inbound media-stream
+ * teardown (spoken via daemon TTS for STT-missing) and the inbound voice
+ * webhook (Twilio-native `<Say>` for TTS-missing) so the two never drift.
+ */
+export const TELEPHONY_SETUP_REQUIRED_MESSAGE =
+  "Sorry, this assistant isn't set up to take calls right now. " +
+  "Please try again later. Goodbye.";
+
 // ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
@@ -167,6 +177,22 @@ async function resolveTtsGap(): Promise<TelephonyCredentialGap | null> {
 }
 
 /**
+ * Whether the telephony TTS path can produce audible bytes — i.e. the
+ * configured provider OR the verified-ready PCM-capable default
+ * ({@link DEFAULT_PLAYABLE_TTS_PROVIDER}) is playable. This mirrors
+ * {@link resolveTtsGap}: it is playable exactly when that helper finds NO gap.
+ *
+ * Used by the inbound voice webhook (`buildVoiceWebhookTwiml`) to decide whether
+ * the media-stream transport can speak the "setup required" prompt. When TTS is
+ * NOT playable, the media-stream `speakSystemPrompt` would synthesize nothing
+ * (silent call), so the webhook instead emits a Twilio-native `<Say>` at the
+ * TwiML level. STT-missing cases are unaffected — TTS can still speak.
+ */
+export async function resolveTelephonyTtsPlayable(): Promise<boolean> {
+  return (await resolveTtsGap()) === null;
+}
+
+/**
  * Map a TTS not-playable reason to the preflight's credential-gap reason.
  *
  * A missing/unknown `services.tts.provider` (the resolver now returns these as
@@ -194,12 +220,10 @@ function ttsReasonToGapReason(
 // ---------------------------------------------------------------------------
 //
 // The outbound transport gate lives in `twilio-routes.ts` as
-// `outboundWillUseMediaStream(session)`, NOT here, because it must mirror the
-// FULL transport decision `buildVoiceWebhookTwiml` makes — both the STT routing
-// strategy AND the `routeSetup` outcome (interactive flows that CR-fall-back
-// must skip the preflight). Sharing the predicate with the TwiML builder keeps
-// the gate and the real transport branch from drifting. See that helper's
-// doc comment (and its PR 11 simplification note) for details.
+// `outboundWillUseMediaStream(session)`, NOT here, because it is the shared seam
+// with the transport decision `buildVoiceWebhookTwiml` makes. Now that EVERY
+// call routes through the media-stream transport, that helper is effectively
+// always-true, so the outbound credential preflight runs for every call.
 
 // ---------------------------------------------------------------------------
 // Public API

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -52,6 +52,7 @@ import {
   releaseCallbackClaim,
   updateCallSession,
 } from "./call-store.js";
+import { routeSetup } from "./relay-setup-router.js";
 import { resolveCallHints } from "./stt-hints.js";
 import {
   describeCredentialGaps,
@@ -444,12 +445,37 @@ async function buildVoiceWebhookTwiml(
   if (sessionContext?.direction === "inbound") {
     const readiness = await resolveTelephonyCredentialReadiness();
     if (readiness.status !== "ready") {
-      log.warn(
-        { callSessionId, missing: describeCredentialGaps(readiness.missing) },
-        "Inbound call: telephony STT/TTS credentials not ready — returning " +
-          "<Say> setup-required (no media-stream)",
-      );
-      return buildSetupRequiredSayTwiml();
+      const ttsMissing = readiness.missing.some((g) => g.kind === "tts");
+      const sttMissing = readiness.missing.some((g) => g.kind === "stt");
+
+      // Scope the STT requirement to outcomes that actually consume caller
+      // transcripts. Terminal speak-then-hangup outcomes (`deny`,
+      // `unverified_caller`) need only TTS to voice their message — gating them
+      // on STT would replace the denial/guidance with a generic setup-required
+      // prompt, regressing the relay path (which denies without STT). TTS being
+      // unavailable always blocks, since even those outcomes can't speak then.
+      const session = getCallSession(callSessionId);
+      const { outcome } = routeSetup({
+        callSessionId,
+        session: session ?? null,
+        from: sessionContext.fromNumber,
+        to: sessionContext.toNumber,
+      });
+      const sttConsumed =
+        outcome.action !== "deny" && outcome.action !== "unverified_caller";
+
+      if (ttsMissing || (sttMissing && sttConsumed)) {
+        log.warn(
+          {
+            callSessionId,
+            setupAction: outcome.action,
+            missing: describeCredentialGaps(readiness.missing),
+          },
+          "Inbound call: required telephony credentials not ready — returning " +
+            "<Say> setup-required (no media-stream)",
+        );
+        return buildSetupRequiredSayTwiml();
+      }
     }
   }
 

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -54,7 +54,8 @@ import {
 } from "./call-store.js";
 import { resolveCallHints } from "./stt-hints.js";
 import {
-  resolveTelephonyTtsPlayable,
+  describeCredentialGaps,
+  resolveTelephonyCredentialReadiness,
   TELEPHONY_SETUP_REQUIRED_MESSAGE,
 } from "./telephony-credential-preflight.js";
 import type { CallSession, CallStatus } from "./types.js";
@@ -407,12 +408,12 @@ export function outboundWillUseMediaStream(_session: CallSession): boolean {
  * sub-flows, and the credential preflight server-side. This is the single
  * deploy-flip point — reverting this PR restores ConversationRelay routing.
  *
- * The ONE exception is the inbound TTS-unavailable case: when neither the
- * configured TTS provider nor the verified-ready default can synthesize audio,
- * the media-stream `speakSystemPrompt` would emit nothing (a silent call that
- * defeats the preflight), so a Twilio-native `<Say>` setup-required message is
- * returned instead. STT-missing cases are unaffected — TTS can still speak the
- * setup prompt over the media-stream transport.
+ * The ONE exception is the inbound credentials-not-ready case: an interactive
+ * inbound call needs BOTH legs. If TTS cannot synthesize audio the call goes
+ * silent; if STT is missing/unsupported the interactive setup flow waits forever
+ * on transcripts that never arrive (and so never even speaks the setup-required
+ * prompt). In either case a Twilio-native `<Say>` setup-required message is
+ * returned instead of a media-stream that cannot run the call.
  *
  * When `verificationSessionId` is provided, it is included as a `<Parameter>` in
  * the Stream TwiML for observability and compatibility with the Twilio setup
@@ -430,17 +431,23 @@ async function buildVoiceWebhookTwiml(
   } | null,
   verificationSessionId?: string | null,
 ): Promise<string> {
-  // Inbound TTS-unavailable guard: the media-stream transport cannot speak the
-  // setup-required prompt when no TTS provider is playable, so detect that here
-  // and emit a TwiML-level <Say> instead of connecting a stream that would sit
-  // silent. Only inbound calls reach the daemon connected (outbound is gated by
-  // the credential preflight in call-domain.ts before dialing).
+  // Inbound credential-readiness guard: an inbound media-stream call requires
+  // BOTH legs to be usable. If TTS is not playable the media-stream
+  // `speakSystemPrompt` would emit nothing (a silent call). If STT is missing or
+  // unsupported, interactive inbound flows (e.g. name_capture) wait on caller
+  // transcripts that never arrive — the call sits, never speaks the
+  // setup-required prompt, and never ends. In EITHER case, emit a TwiML-level
+  // <Say> setup-required + <Hangup/> instead of connecting a stream that cannot
+  // run an interactive call. Only inbound calls reach the daemon connected
+  // (outbound is gated by the credential preflight in call-domain.ts before
+  // dialing).
   if (sessionContext?.direction === "inbound") {
-    const ttsPlayable = await resolveTelephonyTtsPlayable();
-    if (!ttsPlayable) {
+    const readiness = await resolveTelephonyCredentialReadiness();
+    if (readiness.status !== "ready") {
       log.warn(
-        { callSessionId },
-        "Inbound call: telephony TTS is not playable — returning <Say> setup-required (no media-stream)",
+        { callSessionId, missing: describeCredentialGaps(readiness.missing) },
+        "Inbound call: telephony STT/TTS credentials not ready — returning " +
+          "<Say> setup-required (no media-stream)",
       );
       return buildSetupRequiredSayTwiml();
     }
@@ -450,10 +457,11 @@ async function buildVoiceWebhookTwiml(
 }
 
 /**
- * Twilio-native `<Say>` + `<Hangup/>` TwiML for the inbound TTS-unavailable
- * case. Synthesis is performed by Twilio at the TwiML level (no daemon TTS), so
- * the caller hears an audible setup-required message even when the daemon has no
- * playable TTS provider — then the call ends.
+ * Twilio-native `<Say>` + `<Hangup/>` TwiML for the inbound credentials-not-ready
+ * case (TTS not playable, or STT missing/unsupported). Synthesis is performed by
+ * Twilio at the TwiML level (no daemon TTS), so the caller hears an audible
+ * setup-required message even when the daemon cannot run the media-stream call —
+ * then the call ends.
  */
 function buildSetupRequiredSayTwiml(): string {
   return `<?xml version="1.0" encoding="UTF-8"?>

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -1,24 +1,24 @@
 /**
  * HTTP route handlers for Twilio voice webhooks.
  *
- * - handleVoiceWebhook: initial voice webhook; returns TwiML to connect
- *   ConversationRelay (Twilio-native STT) or Stream (custom media-stream STT)
+ * - handleVoiceWebhook: initial voice webhook; returns TwiML to connect the
+ *   media-stream transport (`<Connect><Stream>`) — the daemon performs STT, TTS,
+ *   the interactive setup sub-flows, and the credential preflight server-side.
  * - handleStatusCallback: call status updates (ringing, in-progress, completed, etc.)
- * - handleConnectAction: called when the ConversationRelay connection ends
+ * - handleConnectAction: called when the relay connection ends.
  *
- * ## STT routing
+ * ## Transport
  *
- * TwiML generation is driven by `services.stt.provider` via
- * {@link resolveTelephonySttRouting}. The resolver returns a discriminated
- * strategy that determines which TwiML path to use:
+ * EVERY phone call now routes through the media-stream transport, regardless of
+ * `services.stt.provider` or the `routeSetup` outcome: Twilio opens a WebSocket
+ * to the daemon, which transcribes raw audio, drives all setup sub-flows, and
+ * synthesizes replies. The legacy ConversationRelay TwiML path
+ * ({@link buildConversationRelayTwiml}) is unreferenced and removed in a later PR.
  *
- * - **`conversation-relay-native`** (deepgram, google-gemini) — emits
- *   `<Connect><ConversationRelay>` with Twilio-native `transcriptionProvider`
- *   and `speechModel` attributes.
- *
- * - **`media-stream-custom`** (openai-whisper) — emits
- *   `<Connect><Stream>` so the daemon receives raw audio and transcribes
- *   server-side.
+ * The ONE exception is the inbound TTS-unavailable case: when neither the
+ * configured TTS provider nor the verified-ready default can synthesize audio,
+ * the media-stream `speakSystemPrompt` would emit nothing (silent call), so the
+ * webhook instead returns a Twilio-native `<Say>` setup-required message.
  */
 
 import {
@@ -27,8 +27,6 @@ import {
   TWILIO_PUBLIC_BASE_URL_PLACEHOLDER,
 } from "@vellumai/service-contracts/twilio-ingress";
 
-import { loadConfig } from "../config/loader.js";
-import { getProviderEntry } from "../providers/speech-to-text/provider-catalog.js";
 import {
   BadRequestError,
   GoneError,
@@ -54,9 +52,11 @@ import {
   releaseCallbackClaim,
   updateCallSession,
 } from "./call-store.js";
-import { routeSetup, type SetupOutcome } from "./relay-setup-router.js";
 import { resolveCallHints } from "./stt-hints.js";
-import { resolveTelephonySttRouting } from "./telephony-stt-routing.js";
+import {
+  resolveTelephonyTtsPlayable,
+  TELEPHONY_SETUP_REQUIRED_MESSAGE,
+} from "./telephony-credential-preflight.js";
 import type { CallSession, CallStatus } from "./types.js";
 import { resolveVoiceQualityProfile } from "./voice-quality.js";
 
@@ -277,10 +277,10 @@ const TWIML_HEADERS = { "Content-Type": "text/xml" } as const;
  * query for outbound calls). Returns a TwiML string. Throws RouteError
  * subclasses on failure.
  */
-function processVoiceWebhook(
+async function processVoiceWebhook(
   params: Record<string, string>,
   callSessionId: string | null,
-): string {
+): Promise<string> {
   const callSid = params.CallSid ?? null;
   const callerFrom = params.From ?? "";
   const callerTo = params.To ?? "";
@@ -303,7 +303,7 @@ function processVoiceWebhook(
       toNumber: callerTo,
     });
 
-    return buildVoiceWebhookTwiml(
+    return await buildVoiceWebhookTwiml(
       session.id,
       {
         task: session.task,
@@ -338,7 +338,7 @@ function processVoiceWebhook(
     log.info({ callSessionId, callSid }, "Stored CallSid from voice webhook");
   }
 
-  return buildVoiceWebhookTwiml(
+  return await buildVoiceWebhookTwiml(
     callSessionId,
     {
       task: session.task,
@@ -371,7 +371,7 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
   const params = Object.fromEntries(formBody.entries());
 
   try {
-    return twimlResponse(processVoiceWebhook(params, callSessionId));
+    return twimlResponse(await processVoiceWebhook(params, callSessionId));
   } catch (err) {
     if (err instanceof RouteError) {
       return new Response(err.message, { status: err.statusCode });
@@ -381,88 +381,44 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
 }
 
 /**
- * The set of {@link routeSetup} outcomes that the media-stream transport
- * (`<Connect><Stream>`) can serve directly.
+ * Decide whether an OUTBOUND call needs the local STT + TTS credential
+ * preflight to run before dialing.
  *
- * The media-stream transport supports `normal_call` and `deny` (which speaks a
- * message and tears down). Every OTHER outcome requires an interactive
- * sub-flow (DTMF entry, name capture, guardian wait, verification, invite
- * redemption) that media-stream cannot perform, so {@link buildVoiceWebhookTwiml}
- * CR-falls-back for those. This predicate is the single source of truth for
- * that branch, shared with the outbound preflight gate so the two can never
- * drift.
+ * EVERY call now routes through the media-stream transport (`<Connect><Stream>`),
+ * where the daemon performs both STT and TTS itself, so the credential preflight
+ * is always relevant — this helper is effectively always-true. It is kept as the
+ * seam the outbound preflight gate (`call-domain.ts`) calls so that the gate and
+ * the real transport decision share one source of truth.
+ *
+ * (Before PR 11 this gated on the STT routing strategy AND the `routeSetup`
+ * outcome, because CR-native STT and interactive CR-fallback flows were served
+ * by ConversationRelay and needed no local credentials. With CR routing removed,
+ * both conditions collapse to true.)
  */
-function setupOutcomeUsesMediaStream(outcome: SetupOutcome): boolean {
-  return outcome.action === "normal_call" || outcome.action === "deny";
-}
-
-/**
- * Decide whether an OUTBOUND call will actually be served by the media-stream
- * transport (`<Connect><Stream>`) — the ONLY path that needs local STT + TTS
- * credentials — mirroring the FULL transport decision {@link buildVoiceWebhookTwiml}
- * makes for the same call/session.
- *
- * Media-stream is used iff BOTH hold:
- *   1. STT routing resolves to the `media-stream-custom` strategy
- *      (CR-native providers — deepgram / google — let Twilio do STT + native
- *      TTS, so no local credentials are needed); AND
- *   2. the {@link routeSetup} outcome for this session is one the media-stream
- *      transport serves directly ({@link setupOutcomeUsesMediaStream}). When
- *      `calls.verification.enabled` (or any other interactive flow) makes
- *      `routeSetup` return e.g. `callee_verification`, `buildVoiceWebhookTwiml`
- *      CR-falls-back, so this call is served by CR and needs NO local creds.
- *
- * Returning `false` for the CR-fallback case is what lets the outbound preflight
- * gate skip the credential check for interactive flows that don't use the
- * media-stream transport. Any unresolved/unknown STT routing is treated as
- * NOT-media-stream (skip the preflight; the CR path handles itself), so a
- * partial/malformed config can never crash call setup.
- *
- * CROSS-PR NOTE (PR 11): PR 11 removes the CR-fallback entirely — ALL outcomes
- * route to the media-stream transport. When that lands, condition (2) becomes
- * vacuous and this helper collapses to "strategy === media-stream-custom" (and,
- * once routing always selects media-stream-custom, to always-true). PR 11 must
- * simplify both this helper and {@link buildVoiceWebhookTwiml}'s setup-outcome
- * branch together so they stay in lockstep.
- */
-export function outboundWillUseMediaStream(session: CallSession): boolean {
-  const routing = resolveTelephonySttRouting();
-  if (
-    routing.status !== "resolved" ||
-    routing.strategy.strategy !== "media-stream-custom"
-  ) {
-    return false;
-  }
-
-  const { outcome } = routeSetup({
-    callSessionId: session.id,
-    session,
-    from: session.fromNumber ?? "",
-    to: session.toNumber ?? "",
-  });
-  return setupOutcomeUsesMediaStream(outcome);
+export function outboundWillUseMediaStream(_session: CallSession): boolean {
+  return true;
 }
 
 /**
  * Shared TwiML generation for both inbound and outbound voice webhooks.
  *
- * Resolves the telephony STT routing strategy from `services.stt.provider`
- * and branches:
+ * Always emits the media-stream transport (`<Connect><Stream>`): Twilio opens a
+ * WebSocket to the daemon, which performs STT, TTS, the interactive setup
+ * sub-flows, and the credential preflight server-side. This is the single
+ * deploy-flip point — reverting this PR restores ConversationRelay routing.
  *
- * - **`conversation-relay-native`** — emits `<Connect><ConversationRelay>`
- *   TwiML with Twilio-native STT attributes (`transcriptionProvider`,
- *   `speechModel`). Used for deepgram and google-gemini.
+ * The ONE exception is the inbound TTS-unavailable case: when neither the
+ * configured TTS provider nor the verified-ready default can synthesize audio,
+ * the media-stream `speakSystemPrompt` would emit nothing (a silent call that
+ * defeats the preflight), so a Twilio-native `<Say>` setup-required message is
+ * returned instead. STT-missing cases are unaffected — TTS can still speak the
+ * setup prompt over the media-stream transport.
  *
- * - **`media-stream-custom`** — emits `<Connect><Stream>` TwiML so the
- *   daemon receives raw audio for server-side transcription. Used for
- *   openai-whisper.
- *
- * When `verificationSessionId` is provided, it is included as a
- * `<Parameter>` in the TwiML for observability and compatibility with
- * the Twilio setup payload. The persisted call session mode is the
- * primary signal for deterministic flow selection in the relay server.
+ * When `verificationSessionId` is provided, it is included as a `<Parameter>` in
+ * the Stream TwiML for observability and compatibility with the Twilio setup
+ * payload.
  */
-function buildVoiceWebhookTwiml(
+async function buildVoiceWebhookTwiml(
   callSessionId: string,
   sessionContext: {
     task: string | null;
@@ -473,111 +429,49 @@ function buildVoiceWebhookTwiml(
     inviteGuardianName: string | null;
   } | null,
   verificationSessionId?: string | null,
-): string {
-  const cfg = loadConfig();
-  const profile = resolveVoiceQualityProfile(cfg);
-
-  log.info(
-    { callSessionId, ttsProvider: profile.ttsProvider, voice: profile.voice },
-    "Voice quality profile resolved",
-  );
-
-  // Resolve telephony STT strategy from services.stt.provider.
-  // The routing resolver handles speech-model defaults internally per provider.
-  const routingResult = resolveTelephonySttRouting();
-
-  // Derive Deepgram fallback values from the provider catalog so they stay
-  // in sync with the single source of truth. Hardcoded strings are kept only
-  // as a final safety net in case the catalog entry is missing.
-  const dgEntry = getProviderEntry("deepgram");
-  const fallbackProvider =
-    dgEntry?.telephonyRouting.twilioNativeMapping?.provider ?? "Deepgram";
-  const fallbackModel =
-    dgEntry?.telephonyRouting.twilioNativeMapping?.defaultSpeechModel ??
-    "nova-3";
-
-  if (routingResult.status === "unknown-provider") {
-    log.error(
-      {
-        callSessionId,
-        providerId: routingResult.providerId,
-        reason: routingResult.reason,
-      },
-      "Telephony STT routing failed — unknown provider; falling back to ConversationRelay with Deepgram",
-    );
-    // Graceful degradation: fall back to Deepgram ConversationRelay so
-    // calls don't fail entirely on a misconfigured provider.
-    return buildConversationRelayTwiml(
-      callSessionId,
-      profile,
-      sessionContext,
-      verificationSessionId,
-      { transcriptionProvider: fallbackProvider, speechModel: fallbackModel },
-    );
-  }
-
-  const { strategy } = routingResult;
-
-  if (strategy.strategy === "conversation-relay-native") {
-    return buildConversationRelayTwiml(
-      callSessionId,
-      profile,
-      sessionContext,
-      verificationSessionId,
-      {
-        transcriptionProvider: strategy.transcriptionProvider,
-        speechModel: strategy.speechModel,
-      },
-    );
-  }
-
-  // media-stream-custom path — preflight check to reject interactive setup
-  // flows that the media-stream transport cannot support. The media-stream
-  // server has a defensive fallback for these cases, but catching them here
-  // avoids bootstrapping a WebSocket session that will immediately fail.
-  const session = getCallSession(callSessionId);
-  const from = sessionContext?.fromNumber ?? "";
-  const to = sessionContext?.toNumber ?? "";
-
-  const { outcome } = routeSetup({
-    callSessionId,
-    session: session ?? null,
-    from,
-    to,
-  });
-
-  // The media-stream transport supports normal_call and deny (which speaks
-  // a message and tears down). All other outcomes require interactive
-  // sub-flows (DTMF entry, name capture, guardian wait) that media-stream
-  // cannot perform. Reject these deterministically before stream bootstrap.
-  // `setupOutcomeUsesMediaStream` is the shared predicate the outbound
-  // preflight gate (`outboundWillUseMediaStream`) reuses so the two cannot drift.
-  if (!setupOutcomeUsesMediaStream(outcome)) {
-    log.warn(
-      {
-        callSessionId,
-        setupAction: outcome.action,
-        strategy: "media-stream-custom",
-      },
-      "Media-stream preflight rejected unsupported interactive setup flow — falling back to ConversationRelay with Deepgram",
-    );
-    // Fall back to ConversationRelay so the interactive flow can proceed
-    // through the relay server which supports it natively.
-    return buildConversationRelayTwiml(
-      callSessionId,
-      profile,
-      sessionContext,
-      verificationSessionId,
-      { transcriptionProvider: fallbackProvider, speechModel: fallbackModel },
-    );
+): Promise<string> {
+  // Inbound TTS-unavailable guard: the media-stream transport cannot speak the
+  // setup-required prompt when no TTS provider is playable, so detect that here
+  // and emit a TwiML-level <Say> instead of connecting a stream that would sit
+  // silent. Only inbound calls reach the daemon connected (outbound is gated by
+  // the credential preflight in call-domain.ts before dialing).
+  if (sessionContext?.direction === "inbound") {
+    const ttsPlayable = await resolveTelephonyTtsPlayable();
+    if (!ttsPlayable) {
+      log.warn(
+        { callSessionId },
+        "Inbound call: telephony TTS is not playable — returning <Say> setup-required (no media-stream)",
+      );
+      return buildSetupRequiredSayTwiml();
+    }
   }
 
   return buildMediaStreamTwiml(callSessionId, verificationSessionId);
 }
 
 /**
- * Build ConversationRelay TwiML for Twilio-native STT providers.
+ * Twilio-native `<Say>` + `<Hangup/>` TwiML for the inbound TTS-unavailable
+ * case. Synthesis is performed by Twilio at the TwiML level (no daemon TTS), so
+ * the caller hears an audible setup-required message even when the daemon has no
+ * playable TTS provider — then the call ends.
  */
+function buildSetupRequiredSayTwiml(): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Say>${escapeXml(TELEPHONY_SETUP_REQUIRED_MESSAGE)}</Say>
+  <Hangup/>
+</Response>`;
+}
+
+/**
+ * Build ConversationRelay TwiML for Twilio-native STT providers.
+ *
+ * Intentionally unreferenced as of the PR 11 routing flip — every call now
+ * emits media-stream TwiML. Kept in place so reverting that flip restores CR
+ * routing; this helper (and `generateTwiML` / `TwilioRelaySpeechConfig`) is
+ * deleted in a later PR of the migration.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- kept for the PR 11 rollback window; removed in a later PR
 function buildConversationRelayTwiml(
   callSessionId: string,
   profile: ReturnType<typeof resolveVoiceQualityProfile>,
@@ -845,9 +739,9 @@ const EMPTY_TWIML = '<?xml version="1.0" encoding="UTF-8"?><Response/>';
  * Internal voice-webhook handler for gateway→runtime forwarding.
  * Accepts JSON body `{ params, originalUrl? }` from the gateway.
  */
-export function handleInternalVoiceWebhook({
+export async function handleInternalVoiceWebhook({
   body = {},
-}: RouteHandlerArgs): RouteResponse {
+}: RouteHandlerArgs): Promise<RouteResponse> {
   const { params = {}, originalUrl } = body as {
     params?: Record<string, string>;
     originalUrl?: string;
@@ -863,7 +757,7 @@ export function handleInternalVoiceWebhook({
     }
   }
 
-  const twiml = processVoiceWebhook(params, callSessionId);
+  const twiml = await processVoiceWebhook(params, callSessionId);
   return new RouteResponse(twiml, TWIML_HEADERS);
 }
 

--- a/assistant/src/tts/tts-config-resolver.ts
+++ b/assistant/src/tts/tts-config-resolver.ts
@@ -41,9 +41,13 @@ const DEFAULT_TTS_PROVIDER: TtsProviderId = "elevenlabs";
  * `services.tts.providers.<id>`. No legacy fallback logic.
  */
 export function resolveTtsConfig(config: AssistantConfig): ResolvedTtsConfig {
-  const ttsService = config.services.tts;
+  // Safe access: a partial/edge config (e.g. no `services.tts` block) must not
+  // throw — the telephony preflight relies on the resolver staying non-throwing
+  // so it can report a not-ready gap rather than crash call setup. The default
+  // provider is applied when no provider is configured.
+  const ttsService = config.services?.tts;
 
-  const provider: TtsProviderId = ttsService.provider ?? DEFAULT_TTS_PROVIDER;
+  const provider: TtsProviderId = ttsService?.provider ?? DEFAULT_TTS_PROVIDER;
 
   // Resolve provider-specific config from the canonical providers map.
   const providerConfig = resolveProviderConfig(config, provider);
@@ -82,9 +86,15 @@ function resolveProviderConfig(
   config: AssistantConfig,
   provider: TtsProviderId,
 ): Record<string, unknown> {
-  const ttsProviders = config.services.tts.providers as Record<string, unknown>;
+  // Safe access: a partial/edge config may lack `services.tts` (or its
+  // `providers` map) entirely. Treat a missing map as "no provider-specific
+  // config" rather than throwing, so the telephony preflight can resolve a
+  // not-ready gap instead of crashing.
+  const ttsProviders = config.services?.tts?.providers as
+    | Record<string, unknown>
+    | undefined;
 
-  const providerBlock = ttsProviders[provider];
+  const providerBlock = ttsProviders?.[provider];
   if (providerBlock != null && typeof providerBlock === "object") {
     return { ...providerBlock } as Record<string, unknown>;
   }

--- a/gateway/src/http/routes/twilio-voice-verify-callback.ts
+++ b/gateway/src/http/routes/twilio-voice-verify-callback.ts
@@ -6,7 +6,8 @@
  * it returns <Gather> TwiML pointing to this endpoint. Twilio POSTs the
  * collected DTMF digits here. The gateway validates the code, creates
  * the guardian binding on success, and then forwards to the assistant
- * for ConversationRelay setup.
+ * for media-stream setup (the assistant voice webhook always emits
+ * <Connect><Stream>).
  *
  * The assistant is never involved in verification — it only receives
  * calls from callers whose identity the gateway has already confirmed.
@@ -213,7 +214,8 @@ export function createTwilioVoiceVerifyCallbackHandler(
       }
     }
 
-    // Forward to the assistant for ConversationRelay setup.
+    // Forward to the assistant for media-stream setup (the assistant voice
+    // webhook always emits <Connect><Stream>).
     // The assistant will see the caller as already verified.
     log.info(
       { callSid, fromNumber },

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -483,7 +483,7 @@ export function buildSchema(): Record<string, unknown> {
         post: {
           summary: "Twilio voice verification callback",
           description:
-            "Receives DTMF digits from Twilio <Gather> during gateway-owned voice verification. Validates the verification code, creates the guardian binding on success, and returns TwiML to either re-prompt or forward to the assistant for ConversationRelay setup.",
+            "Receives DTMF digits from Twilio <Gather> during gateway-owned voice verification. Validates the verification code, creates the guardian binding on success, and returns TwiML to either re-prompt or forward to the assistant for media-stream setup.",
           operationId: "twilioVoiceVerifyCallback",
           security: [{ TwilioSignature: [] }],
           parameters: [
@@ -509,7 +509,7 @@ export function buildSchema(): Record<string, unknown> {
           responses: {
             "200": {
               description:
-                "TwiML response — either a re-prompt <Gather>, a failure <Say>, or forwarded ConversationRelay setup.",
+                "TwiML response — either a re-prompt <Gather>, a failure <Say>, or forwarded media-stream setup.",
               content: {
                 "text/xml": {
                   schema: { type: "string" },

--- a/gateway/src/voice/verification.ts
+++ b/gateway/src/voice/verification.ts
@@ -2,7 +2,7 @@
  * Gateway-owned voice verification.
  *
  * Handles the DTMF challenge-response flow for inbound phone calls
- * entirely within the gateway, BEFORE the ConversationRelay WebSocket
+ * entirely within the gateway, BEFORE the media-stream WebSocket
  * is established. The assistant never touches verification — it only
  * receives calls from verified callers.
  *
@@ -11,7 +11,7 @@
  *   2. Gateway returns <Gather> TwiML prompting for the verification code
  *   3. Twilio collects DTMF → POSTs digits back to gateway action URL
  *   4. Gateway validates code, creates guardian binding, returns TwiML
- *      that forwards to the assistant for ConversationRelay setup
+ *      that forwards to the assistant for media-stream setup
  *
  * Verification sessions are read from the assistant DB (via IPC proxy)
  * because the session creation still happens on the assistant side (the


### PR DESCRIPTION
## Summary
- buildVoiceWebhookTwiml always emits <Connect><Stream> (CR-native + interactive CR-fallback removed)
- Flip outboundWillUseMediaStream to always-true so the outbound credential preflight runs for every call; drop dead setupOutcomeUsesMediaStream
- Gateway <Gather> voice-verify forwards to media-stream
- Inbound TTS-missing → Twilio-native <Say> setup-required (no silent call)
- Keep TWILIO_RELAY_TOKEN_PLACEHOLDER (media-stream WS auth)

Single deploy-flip / rollback point. Part of plan: migrate-phone-off-conversation-relay.md (PR 11 of 18)