### PR TITLE
feat(web): add UI support for string feature flags

### DIFF
--- a/apps/web/src/domains/settings/components/panels/feature-flags-panel.tsx
+++ b/apps/web/src/domains/settings/components/panels/feature-flags-panel.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { Search } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { DetailCard } from "@/components/detail-card";
 import { assistantsActiveRetrieveOptions } from "@/generated/api/@tanstack/react-query.gen";
@@ -24,14 +24,25 @@ const SCOPE_TONE: Record<SingleScope, TagTone> = {
   assistant: "positive",
 };
 
-interface FlagDisplayEntry {
-  storeKey: string;
-  scope: FlagScope;
-  label: string;
-  description: string;
-  value: boolean;
-  defaultValue: boolean;
-}
+type FlagDisplayEntry =
+  | {
+      kind: "boolean";
+      storeKey: string;
+      scope: FlagScope;
+      label: string;
+      description: string;
+      value: boolean;
+      defaultValue: boolean;
+    }
+  | {
+      kind: "string";
+      storeKey: string;
+      scope: FlagScope;
+      label: string;
+      description: string;
+      value: string;
+      defaultValue: string;
+    };
 
 export function FeatureFlagsPanel() {
   const { data: activeAssistant } = useQuery(assistantsActiveRetrieveOptions());
@@ -58,24 +69,43 @@ export function FeatureFlagsPanel() {
     const entries: FlagDisplayEntry[] = [];
     for (const flag of ALL_FLAGS) {
       const storeKey = flagKeyToStoreKey(flag.key);
-      const clientVal = clientState[storeKey];
-      const assistantVal = assistantState[storeKey];
-      const value =
-        flag.scope === "both"
-          ? clientVal === true || assistantVal === true
-          : flag.scope === "assistant"
-            ? assistantVal
-            : clientVal;
-      if (typeof value !== "boolean") continue;
-      if (typeof flag.defaultEnabled !== "boolean") continue;
-      entries.push({
-        storeKey,
-        scope: flag.scope as FlagScope,
-        label: flag.label,
-        description: flag.description,
-        value,
-        defaultValue: flag.defaultEnabled,
-      });
+
+      if (typeof flag.defaultEnabled === "boolean") {
+        const clientVal = clientState[storeKey];
+        const assistantVal = assistantState[storeKey];
+        const value =
+          flag.scope === "both"
+            ? clientVal === true || assistantVal === true
+            : flag.scope === "assistant"
+              ? assistantVal
+              : clientVal;
+        if (typeof value !== "boolean") continue;
+        entries.push({
+          kind: "boolean",
+          storeKey,
+          scope: flag.scope as FlagScope,
+          label: flag.label,
+          description: flag.description,
+          value,
+          defaultValue: flag.defaultEnabled,
+        });
+      } else if (typeof flag.defaultEnabled === "string") {
+        const clientStr = clientState.stringFlags?.[storeKey];
+        const assistantStr = assistantState.stringFlags?.[storeKey];
+        const value =
+          flag.scope === "assistant"
+            ? (assistantStr ?? flag.defaultEnabled)
+            : (clientStr ?? flag.defaultEnabled);
+        entries.push({
+          kind: "string",
+          storeKey,
+          scope: flag.scope as FlagScope,
+          label: flag.label,
+          description: flag.description,
+          value,
+          defaultValue: flag.defaultEnabled,
+        });
+      }
     }
     return entries.sort((a, b) =>
       a.label.localeCompare(b.label, undefined, { sensitivity: "base" }),
@@ -159,7 +189,13 @@ function ScopeChips({ scope }: { scope: FlagScope }) {
   return <Tag tone={SCOPE_TONE[scope]}>{scope}</Tag>;
 }
 
-function FeatureFlagRow({ flag, assistantId }: FeatureFlagRowProps) {
+function BooleanFlagRow({
+  flag,
+  assistantId,
+}: {
+  flag: Extract<FlagDisplayEntry, { kind: "boolean" }>;
+  assistantId: string | null;
+}) {
   const clientSetFlag = useClientFeatureFlagStore.use.setFlag();
   const assistantSetFlag = useAssistantFeatureFlagStore.use.setFlag();
 
@@ -200,4 +236,74 @@ function FeatureFlagRow({ flag, assistantId }: FeatureFlagRowProps) {
       </div>
     </div>
   );
+}
+
+function StringFlagRow({
+  flag,
+  assistantId,
+}: {
+  flag: Extract<FlagDisplayEntry, { kind: "string" }>;
+  assistantId: string | null;
+}) {
+  const clientSetStringFlag = useClientFeatureFlagStore.use.setStringFlag();
+  const assistantSetStringFlag = useAssistantFeatureFlagStore.use.setStringFlag();
+  const [localValue, setLocalValue] = useState(flag.value);
+
+  useEffect(() => {
+    setLocalValue(flag.value);
+  }, [flag.value]);
+
+  const handleBlur = () => {
+    if (localValue === flag.value) return;
+    if (scopeIncludes(flag.scope, "client")) {
+      clientSetStringFlag(flag.storeKey, localValue);
+    }
+    if (scopeIncludes(flag.scope, "assistant")) {
+      assistantSetStringFlag(flag.storeKey, localValue, assistantId);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.currentTarget.blur();
+    }
+  };
+
+  return (
+    <div className="flex items-start gap-3 py-3">
+      <div className="min-w-0 flex-1 space-y-1.5">
+        <div className="flex items-center gap-2">
+          <span className="text-body-medium-default text-[var(--content-default)]">
+            {flag.label}
+          </span>
+          <ScopeChips scope={flag.scope} />
+        </div>
+        <span className="block text-body-small-default text-[var(--content-tertiary)]">
+          {flag.description}
+        </span>
+        <input
+          type="text"
+          value={localValue}
+          onChange={(e) => setLocalValue(e.target.value)}
+          onBlur={handleBlur}
+          onKeyDown={handleKeyDown}
+          className="w-full rounded-lg border border-[var(--border-base)] bg-[var(--surface-default)] px-3 py-1.5 text-body-small-default text-[var(--content-default)] placeholder:text-[var(--content-tertiary)] focus:border-[var(--border-focus)] focus:outline-none"
+          placeholder={flag.defaultValue || "Enter value..."}
+        />
+        <div className="flex items-center gap-1">
+          <span className="text-body-small-default text-[var(--content-tertiary)]">
+            Default:
+          </span>
+          <Tag tone="neutral">{flag.defaultValue || "(empty)"}</Tag>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function FeatureFlagRow({ flag, assistantId }: FeatureFlagRowProps) {
+  if (flag.kind === "string") {
+    return <StringFlagRow flag={flag} assistantId={assistantId} />;
+  }
+  return <BooleanFlagRow flag={flag} assistantId={assistantId} />;
 }

--- a/apps/web/src/hooks/use-assistant-feature-flag-sync.ts
+++ b/apps/web/src/hooks/use-assistant-feature-flag-sync.ts
@@ -6,6 +6,7 @@ import { assertHasResponse } from "@/utils/api-errors";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import {
   ASSISTANT_FLAG_DEFAULTS,
+  ASSISTANT_STRING_FLAG_DEFAULTS,
   flagKeyToStoreKey,
 } from "@/lib/feature-flags/feature-flag-catalog";
 import { useFlagQueryFreshness } from "@/lib/backwards-compat/flag-query-freshness";
@@ -23,20 +24,23 @@ interface AssistantFlagValuesResponse {
   flags: FeatureFlagEntry[];
 }
 
-const VALID_KEYS = new Set(Object.keys(ASSISTANT_FLAG_DEFAULTS));
+const VALID_BOOL_KEYS = new Set(Object.keys(ASSISTANT_FLAG_DEFAULTS));
+const VALID_STRING_KEYS = new Set(Object.keys(ASSISTANT_STRING_FLAG_DEFAULTS));
 
 function mapFlags(
   entries: FeatureFlagEntry[],
-): Record<string, boolean> {
-  const mapped: Record<string, boolean> = {};
+): { boolFlags: Record<string, boolean>; stringFlags: Record<string, string> } {
+  const boolFlags: Record<string, boolean> = {};
+  const stringFlags: Record<string, string> = {};
   for (const entry of entries) {
-    if (typeof entry.enabled !== "boolean") continue;
     const storeKey = flagKeyToStoreKey(entry.key);
-    if (VALID_KEYS.has(storeKey)) {
-      mapped[storeKey] = entry.enabled;
+    if (typeof entry.enabled === "boolean" && VALID_BOOL_KEYS.has(storeKey)) {
+      boolFlags[storeKey] = entry.enabled;
+    } else if (typeof entry.enabled === "string" && VALID_STRING_KEYS.has(storeKey)) {
+      stringFlags[storeKey] = entry.enabled;
     }
   }
-  return mapped;
+  return { boolFlags, stringFlags };
 }
 
 export async function fetchAssistantFlagValues(
@@ -93,7 +97,11 @@ export function useAssistantFeatureFlagSync(assistantId: string | null) {
   useEffect(() => {
     if (data?.flags) {
       const store = useAssistantFeatureFlagStore.getState();
-      store.setFlags(mapFlags(data.flags));
+      const { boolFlags, stringFlags } = mapFlags(data.flags);
+      store.setFlags(boolFlags);
+      if (Object.keys(stringFlags).length > 0) {
+        store.setStringFlags(stringFlags);
+      }
       // Mark hydrated AFTER values are written so a consumer subscribing
       // to both fields sees the real flag in the same render that
       // hasHydrated flips to true.

--- a/apps/web/src/hooks/use-client-feature-flag-sync.ts
+++ b/apps/web/src/hooks/use-client-feature-flag-sync.ts
@@ -7,12 +7,14 @@ import { assertHasResponse } from "@/utils/api-errors";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import {
   CLIENT_FLAG_DEFAULTS,
+  CLIENT_STRING_FLAG_DEFAULTS,
   flagKeyToStoreKey,
 } from "@/lib/feature-flags/feature-flag-catalog";
 import { useFlagQueryFreshness } from "@/lib/backwards-compat/flag-query-freshness";
 import { CLIENT_FLAG_QUERY_KEY } from "@/lib/sync/query-tags";
 
-const VALID_KEYS = new Set(Object.keys(CLIENT_FLAG_DEFAULTS));
+const VALID_BOOL_KEYS = new Set(Object.keys(CLIENT_FLAG_DEFAULTS));
+const VALID_STRING_KEYS = new Set(Object.keys(CLIENT_STRING_FLAG_DEFAULTS));
 
 async function fetchClientFlagValues(): Promise<ClientFeatureFlagsResponse> {
   const { data, error, response } = await featureFlagsClientFlagValuesRetrieve({
@@ -27,16 +29,18 @@ async function fetchClientFlagValues(): Promise<ClientFeatureFlagsResponse> {
 
 function mapFlags(
   serverFlags: Record<string, boolean | string>,
-): Record<string, boolean> {
-  const mapped: Record<string, boolean> = {};
+): { boolFlags: Record<string, boolean>; stringFlags: Record<string, string> } {
+  const boolFlags: Record<string, boolean> = {};
+  const stringFlags: Record<string, string> = {};
   for (const [flagKey, value] of Object.entries(serverFlags)) {
-    if (typeof value !== "boolean") continue;
     const storeKey = flagKeyToStoreKey(flagKey);
-    if (VALID_KEYS.has(storeKey)) {
-      mapped[storeKey] = value;
+    if (typeof value === "boolean" && VALID_BOOL_KEYS.has(storeKey)) {
+      boolFlags[storeKey] = value;
+    } else if (typeof value === "string" && VALID_STRING_KEYS.has(storeKey)) {
+      stringFlags[storeKey] = value;
     }
   }
-  return mapped;
+  return { boolFlags, stringFlags };
 }
 
 export function useClientFeatureFlagSync(enabled: boolean) {
@@ -51,7 +55,12 @@ export function useClientFeatureFlagSync(enabled: boolean) {
 
   useEffect(() => {
     if (data?.flags) {
-      useClientFeatureFlagStore.getState().setFlags(mapFlags(data.flags));
+      const { boolFlags, stringFlags } = mapFlags(data.flags);
+      const store = useClientFeatureFlagStore.getState();
+      store.setFlags(boolFlags);
+      if (Object.keys(stringFlags).length > 0) {
+        store.setStringFlags(stringFlags);
+      }
     }
   }, [data]);
 }

--- a/apps/web/src/lib/feature-flags/feature-flag-catalog.ts
+++ b/apps/web/src/lib/feature-flags/feature-flag-catalog.ts
@@ -49,8 +49,21 @@ function buildScopeDefaults(scope: SingleScope): Record<string, boolean> {
   return defaults;
 }
 
+function buildStringScopeDefaults(scope: SingleScope): Record<string, string> {
+  const defaults: Record<string, string> = {};
+  for (const flag of flags) {
+    if (typeof flag.defaultEnabled !== "string") continue;
+    if (scopeIncludes(flag.scope, scope)) {
+      defaults[kebabToStoreKey(flag.key)] = flag.defaultEnabled;
+    }
+  }
+  return defaults;
+}
+
 export const CLIENT_FLAG_DEFAULTS = buildScopeDefaults("client");
 export const ASSISTANT_FLAG_DEFAULTS = buildScopeDefaults("assistant");
+export const CLIENT_STRING_FLAG_DEFAULTS = buildStringScopeDefaults("client");
+export const ASSISTANT_STRING_FLAG_DEFAULTS = buildStringScopeDefaults("assistant");
 
 export type ClientFeatureFlags = Record<string, boolean>;
 export type AssistantFeatureFlags = Record<string, boolean>;

--- a/apps/web/src/stores/assistant-feature-flag-store.ts
+++ b/apps/web/src/stores/assistant-feature-flag-store.ts
@@ -2,7 +2,11 @@ import { create } from "zustand";
 
 import { createSelectors } from "@/utils/create-selectors";
 import { client } from "@/generated/api/client.gen";
-import { ASSISTANT_FLAG_DEFAULTS, storeKeyToFlagKey } from "@/lib/feature-flags/feature-flag-catalog";
+import {
+  ASSISTANT_FLAG_DEFAULTS,
+  ASSISTANT_STRING_FLAG_DEFAULTS,
+  storeKeyToFlagKey,
+} from "@/lib/feature-flags/feature-flag-catalog";
 
 /**
  * Internal store fields that are NOT feature flag values. Surfaces that
@@ -19,6 +23,7 @@ interface AssistantFeatureFlagMeta {
    * before treating a `false` flag as authoritative.
    */
   hasHydrated: boolean;
+  stringFlags: Record<string, string>;
 }
 
 interface AssistantFeatureFlagActions {
@@ -35,6 +40,8 @@ interface AssistantFeatureFlagActions {
   markHydrated: () => void;
   /** Called on assistant switch: resets to defaults + clears hasHydrated. */
   resetForAssistantSwitch: () => void;
+  setStringFlags: (flags: Record<string, string>) => void;
+  setStringFlag: (key: string, value: string, assistantId: string | null) => void;
 }
 
 type AssistantFeatureFlagStore = Record<string, boolean> &
@@ -43,6 +50,9 @@ type AssistantFeatureFlagStore = Record<string, boolean> &
 
 let confirmedAssistantFlagValues: Record<string, boolean> = {
   ...ASSISTANT_FLAG_DEFAULTS,
+};
+let confirmedAssistantStringFlagValues: Record<string, string> = {
+  ...ASSISTANT_STRING_FLAG_DEFAULTS,
 };
 let nextFlagRequestId = 0;
 const pendingFlagRequestIds: Record<string, number> = {};
@@ -54,8 +64,21 @@ function resetConfirmedFlags(flags: Record<string, boolean> = {}) {
   }
 }
 
+function resetConfirmedStringFlags(flags: Record<string, string> = {}) {
+  confirmedAssistantStringFlagValues = { ...ASSISTANT_STRING_FLAG_DEFAULTS, ...flags };
+}
+
+function resetAllConfirmed() {
+  resetConfirmedFlags();
+  resetConfirmedStringFlags();
+}
+
 function latestConfirmedValue(key: string): boolean {
   return confirmedAssistantFlagValues[key] ?? ASSISTANT_FLAG_DEFAULTS[key] ?? false;
+}
+
+function latestConfirmedStringValue(key: string): string {
+  return confirmedAssistantStringFlagValues[key] ?? ASSISTANT_STRING_FLAG_DEFAULTS[key] ?? "";
 }
 
 const useAssistantFeatureFlagStoreBase = create<AssistantFeatureFlagStore>()(
@@ -63,6 +86,7 @@ const useAssistantFeatureFlagStoreBase = create<AssistantFeatureFlagStore>()(
     ({
       ...ASSISTANT_FLAG_DEFAULTS,
       hasHydrated: false,
+      stringFlags: { ...ASSISTANT_STRING_FLAG_DEFAULTS },
 
       setFlags: (flags: Record<string, boolean>) =>
         set((prev) => {
@@ -123,9 +147,68 @@ const useAssistantFeatureFlagStoreBase = create<AssistantFeatureFlagStore>()(
 
       resetForAssistantSwitch: () =>
         set(() => {
-          resetConfirmedFlags();
-          return { ...ASSISTANT_FLAG_DEFAULTS, hasHydrated: false };
+          resetAllConfirmed();
+          return {
+            ...ASSISTANT_FLAG_DEFAULTS,
+            hasHydrated: false,
+            stringFlags: { ...ASSISTANT_STRING_FLAG_DEFAULTS },
+          };
         }),
+
+      setStringFlags: (flags: Record<string, string>) =>
+        set((prev) => {
+          resetConfirmedStringFlags(flags);
+          const prevStr = prev.stringFlags;
+          const changed = Object.keys(flags).some(
+            (k) => flags[k] !== prevStr[k],
+          );
+          return changed ? { stringFlags: flags } : prev;
+        }),
+
+      setStringFlag: (key: string, value: string, assistantId: string | null) => {
+        const requestId = ++nextFlagRequestId;
+        const revertIfLatestRejectedRequest = () => {
+          if (pendingFlagRequestIds[key] !== requestId) {
+            return;
+          }
+          delete pendingFlagRequestIds[key];
+          const confirmedValue = latestConfirmedStringValue(key);
+          set((prev) => {
+            if (prev.stringFlags[key] !== value) {
+              return prev;
+            }
+            return { stringFlags: { ...prev.stringFlags, [key]: confirmedValue } };
+          });
+        };
+        const flagKey = storeKeyToFlagKey(key);
+        if (assistantId && flagKey) {
+          pendingFlagRequestIds[key] = requestId;
+          void client
+            .patch({
+              url: `/v1/assistants/${assistantId}/feature-flags/${flagKey}`,
+              body: { enabled: value },
+              throwOnError: false,
+            } as Parameters<typeof client.patch>[0])
+            .then((result) => {
+              const response = (result as { response?: Response }).response;
+              if (response?.ok) {
+                confirmedAssistantStringFlagValues[key] = value;
+                if (pendingFlagRequestIds[key] === requestId) {
+                  delete pendingFlagRequestIds[key];
+                }
+              } else {
+                revertIfLatestRejectedRequest();
+              }
+            })
+            .catch(revertIfLatestRejectedRequest);
+        } else {
+          confirmedAssistantStringFlagValues[key] = value;
+        }
+
+        set((prev) => ({
+          stringFlags: { ...prev.stringFlags, [key]: value },
+        }));
+      },
     }) as AssistantFeatureFlagStore,
 );
 

--- a/apps/web/src/stores/assistant-feature-flag-store.ts
+++ b/apps/web/src/stores/assistant-feature-flag-store.ts
@@ -81,15 +81,18 @@ function latestConfirmedStringValue(key: string): string {
   return confirmedAssistantStringFlagValues[key] ?? ASSISTANT_STRING_FLAG_DEFAULTS[key] ?? "";
 }
 
-// The store type intersects `Record<string, boolean>` with meta/action
-// interfaces. TypeScript's index signature makes `Partial<Store>` reject
-// `{ stringFlags: Record<string, string> }` because it expects `boolean`
-// for every string key. Casting `set` to accept `any` partials is safe —
-// the public API (selectors, actions) is still fully typed.
+// The store type intersects Record<string, boolean> with meta/action
+// interfaces. Zustand's set() expects Partial<Store>, but the index
+// signature makes { stringFlags: Record<string, string> } incompatible.
+// setStr() bypasses this for string-flag-only partials.
 const useAssistantFeatureFlagStoreBase = create<AssistantFeatureFlagStore>()(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (rawSet: (...args: any[]) => void) => {
-    const set = rawSet;
+  (set) => {
+    const setStr = set as unknown as (
+      partial:
+        | { stringFlags: Record<string, string> }
+        | ((state: AssistantFeatureFlagStore) => { stringFlags: Record<string, string> } | AssistantFeatureFlagStore),
+    ) => void;
+
     return ({
       ...ASSISTANT_FLAG_DEFAULTS,
       hasHydrated: false,
@@ -152,18 +155,14 @@ const useAssistantFeatureFlagStoreBase = create<AssistantFeatureFlagStore>()(
 
       markHydrated: () => set({ hasHydrated: true }),
 
-      resetForAssistantSwitch: () =>
-        set(() => {
-          resetAllConfirmed();
-          return {
-            ...ASSISTANT_FLAG_DEFAULTS,
-            hasHydrated: false,
-            stringFlags: { ...ASSISTANT_STRING_FLAG_DEFAULTS },
-          };
-        }),
+      resetForAssistantSwitch: () => {
+        resetAllConfirmed();
+        set({ ...ASSISTANT_FLAG_DEFAULTS, hasHydrated: false });
+        setStr({ stringFlags: { ...ASSISTANT_STRING_FLAG_DEFAULTS } });
+      },
 
       setStringFlags: (flags: Record<string, string>) =>
-        set((prev) => {
+        setStr((prev) => {
           resetConfirmedStringFlags(flags);
           const prevStr = prev.stringFlags;
           const changed = Object.keys(flags).some(
@@ -180,7 +179,7 @@ const useAssistantFeatureFlagStoreBase = create<AssistantFeatureFlagStore>()(
           }
           delete pendingFlagRequestIds[key];
           const confirmedValue = latestConfirmedStringValue(key);
-          set((prev) => {
+          setStr((prev) => {
             if (prev.stringFlags[key] !== value) {
               return prev;
             }
@@ -212,7 +211,7 @@ const useAssistantFeatureFlagStoreBase = create<AssistantFeatureFlagStore>()(
           confirmedAssistantStringFlagValues[key] = value;
         }
 
-        set((prev) => ({
+        setStr((prev) => ({
           stringFlags: { ...prev.stringFlags, [key]: value },
         }));
       },

--- a/apps/web/src/stores/assistant-feature-flag-store.ts
+++ b/apps/web/src/stores/assistant-feature-flag-store.ts
@@ -81,9 +81,16 @@ function latestConfirmedStringValue(key: string): string {
   return confirmedAssistantStringFlagValues[key] ?? ASSISTANT_STRING_FLAG_DEFAULTS[key] ?? "";
 }
 
+// The store type intersects `Record<string, boolean>` with meta/action
+// interfaces. TypeScript's index signature makes `Partial<Store>` reject
+// `{ stringFlags: Record<string, string> }` because it expects `boolean`
+// for every string key. Casting `set` to accept `any` partials is safe —
+// the public API (selectors, actions) is still fully typed.
 const useAssistantFeatureFlagStoreBase = create<AssistantFeatureFlagStore>()(
-  (set) =>
-    ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (rawSet: (...args: any[]) => void) => {
+    const set = rawSet;
+    return ({
       ...ASSISTANT_FLAG_DEFAULTS,
       hasHydrated: false,
       stringFlags: { ...ASSISTANT_STRING_FLAG_DEFAULTS },
@@ -209,7 +216,8 @@ const useAssistantFeatureFlagStoreBase = create<AssistantFeatureFlagStore>()(
           stringFlags: { ...prev.stringFlags, [key]: value },
         }));
       },
-    }) as AssistantFeatureFlagStore,
+    }) as AssistantFeatureFlagStore;
+  },
 );
 
 export const useAssistantFeatureFlagStore = createSelectors(

--- a/apps/web/src/stores/client-feature-flag-store.ts
+++ b/apps/web/src/stores/client-feature-flag-store.ts
@@ -61,11 +61,15 @@ type ClientFeatureFlagStore = Record<string, boolean> &
   ClientFeatureFlagMeta &
   ClientFeatureFlagActions;
 
-// See assistant-feature-flag-store.ts for why `set` is widened.
+// See assistant-feature-flag-store.ts for why setStr() is needed.
 const useClientFeatureFlagStoreBase = create<ClientFeatureFlagStore>()(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (rawSet: (...args: any[]) => void) => {
-    const set = rawSet;
+  (set) => {
+    const setStr = set as unknown as (
+      partial:
+        | { stringFlags: Record<string, string> }
+        | ((state: ClientFeatureFlagStore) => { stringFlags: Record<string, string> } | ClientFeatureFlagStore),
+    ) => void;
+
     return ({
       ...CLIENT_FLAG_DEFAULTS,
       ...localOverrides,
@@ -103,7 +107,7 @@ const useClientFeatureFlagStoreBase = create<ClientFeatureFlagStore>()(
       },
 
       setStringFlags: (flags: Record<string, string>) =>
-        set((prev) => {
+        setStr((prev) => {
           const overrides = readStringOverrides();
           const merged = { ...flags, ...overrides };
           const prevStr = prev.stringFlags;
@@ -119,7 +123,7 @@ const useClientFeatureFlagStoreBase = create<ClientFeatureFlagStore>()(
         } catch {
           // localStorage unavailable
         }
-        set((prev) => ({
+        setStr((prev) => ({
           stringFlags: { ...prev.stringFlags, [key]: value },
         }));
       },
@@ -131,7 +135,7 @@ const useClientFeatureFlagStoreBase = create<ClientFeatureFlagStore>()(
           // localStorage unavailable
         }
         const defaultValue = CLIENT_STRING_FLAG_DEFAULTS[key];
-        set((prev) => ({
+        setStr((prev) => ({
           stringFlags: {
             ...prev.stringFlags,
             [key]: defaultValue ?? "",

--- a/apps/web/src/stores/client-feature-flag-store.ts
+++ b/apps/web/src/stores/client-feature-flag-store.ts
@@ -61,9 +61,12 @@ type ClientFeatureFlagStore = Record<string, boolean> &
   ClientFeatureFlagMeta &
   ClientFeatureFlagActions;
 
+// See assistant-feature-flag-store.ts for why `set` is widened.
 const useClientFeatureFlagStoreBase = create<ClientFeatureFlagStore>()(
-  (set) =>
-    ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (rawSet: (...args: any[]) => void) => {
+    const set = rawSet;
+    return ({
       ...CLIENT_FLAG_DEFAULTS,
       ...localOverrides,
       stringFlags: { ...CLIENT_STRING_FLAG_DEFAULTS, ...localStringOverrides },
@@ -135,7 +138,8 @@ const useClientFeatureFlagStoreBase = create<ClientFeatureFlagStore>()(
           },
         }));
       },
-    }) as ClientFeatureFlagStore,
+    }) as ClientFeatureFlagStore;
+  },
 );
 
 export const useClientFeatureFlagStore = createSelectors(

--- a/apps/web/src/stores/client-feature-flag-store.ts
+++ b/apps/web/src/stores/client-feature-flag-store.ts
@@ -1,9 +1,13 @@
 import { create } from "zustand";
 
 import { createSelectors } from "@/utils/create-selectors";
-import { CLIENT_FLAG_DEFAULTS } from "@/lib/feature-flags/feature-flag-catalog";
+import {
+  CLIENT_FLAG_DEFAULTS,
+  CLIENT_STRING_FLAG_DEFAULTS,
+} from "@/lib/feature-flags/feature-flag-catalog";
 
 const LS_PREFIX = "vellum:ff:";
+const LS_STRING_PREFIX = "vellum:ff-str:";
 
 function readOverrides(): Record<string, boolean> {
   if (typeof window === "undefined") return {};
@@ -21,15 +25,40 @@ function readOverrides(): Record<string, boolean> {
   return overrides;
 }
 
+function readStringOverrides(): Record<string, string> {
+  if (typeof window === "undefined") return {};
+  const overrides: Record<string, string> = {};
+  try {
+    for (const key of Object.keys(CLIENT_STRING_FLAG_DEFAULTS)) {
+      const stored = localStorage.getItem(LS_STRING_PREFIX + key);
+      if (stored !== null) {
+        overrides[key] = stored;
+      }
+    }
+  } catch {
+    // localStorage unavailable
+  }
+  return overrides;
+}
+
 const localOverrides = readOverrides();
+const localStringOverrides = readStringOverrides();
+
+interface ClientFeatureFlagMeta {
+  stringFlags: Record<string, string>;
+}
 
 interface ClientFeatureFlagActions {
   setFlags: (flags: Record<string, boolean>) => void;
   setFlag: (key: string, value: boolean) => void;
   clearOverride: (key: string) => void;
+  setStringFlags: (flags: Record<string, string>) => void;
+  setStringFlag: (key: string, value: string) => void;
+  clearStringOverride: (key: string) => void;
 }
 
 type ClientFeatureFlagStore = Record<string, boolean> &
+  ClientFeatureFlagMeta &
   ClientFeatureFlagActions;
 
 const useClientFeatureFlagStoreBase = create<ClientFeatureFlagStore>()(
@@ -37,6 +66,7 @@ const useClientFeatureFlagStoreBase = create<ClientFeatureFlagStore>()(
     ({
       ...CLIENT_FLAG_DEFAULTS,
       ...localOverrides,
+      stringFlags: { ...CLIENT_STRING_FLAG_DEFAULTS, ...localStringOverrides },
 
       setFlags: (flags: Record<string, boolean>) =>
         set((prev) => {
@@ -67,6 +97,43 @@ const useClientFeatureFlagStoreBase = create<ClientFeatureFlagStore>()(
         if (defaultValue !== undefined) {
           set({ [key]: defaultValue });
         }
+      },
+
+      setStringFlags: (flags: Record<string, string>) =>
+        set((prev) => {
+          const overrides = readStringOverrides();
+          const merged = { ...flags, ...overrides };
+          const prevStr = prev.stringFlags;
+          const changed = Object.keys(merged).some(
+            (k) => merged[k] !== prevStr[k],
+          );
+          return changed ? { stringFlags: merged } : prev;
+        }),
+
+      setStringFlag: (key: string, value: string) => {
+        try {
+          localStorage.setItem(LS_STRING_PREFIX + key, value);
+        } catch {
+          // localStorage unavailable
+        }
+        set((prev) => ({
+          stringFlags: { ...prev.stringFlags, [key]: value },
+        }));
+      },
+
+      clearStringOverride: (key: string) => {
+        try {
+          localStorage.removeItem(LS_STRING_PREFIX + key);
+        } catch {
+          // localStorage unavailable
+        }
+        const defaultValue = CLIENT_STRING_FLAG_DEFAULTS[key];
+        set((prev) => ({
+          stringFlags: {
+            ...prev.stringFlags,
+            [key]: defaultValue ?? "",
+          },
+        }));
       },
     }) as ClientFeatureFlagStore,
 );


### PR DESCRIPTION
## Summary
- Widen web feature flag stores and sync hooks to handle string flag values from the backend (PR #33573), stored in a separate `stringFlags` map to avoid breaking the ~50 existing boolean-typed consumer sites
- Add a `StringFlagRow` component to the Developer > Feature Flags panel with a text input (commit-on-blur/Enter), localStorage persistence under `vellum:ff-str:` prefix, and optimistic PATCH with revert for assistant-scoped flags
- Add `CLIENT_STRING_FLAG_DEFAULTS` / `ASSISTANT_STRING_FLAG_DEFAULTS` exports from the catalog for string-default flags

## Original prompt
The platform recently added string feature flag support (PR #8204) and the backend was updated to handle them (PR #33573), but string flags were filtered out of the web UI. This PR adds full UI support: syncing string values from the backend, displaying them with editable text inputs in the feature flags panel, and persisting local overrides — reaching parity with boolean flags across the entire stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)