### PR TITLE
refactor(calls): remove conversation-relay-native telephony routing strategy

### DIFF
--- a/assistant/src/__tests__/telephony-stt-routing.test.ts
+++ b/assistant/src/__tests__/telephony-stt-routing.test.ts
@@ -27,14 +27,10 @@ mock.module("../config/loader.js", () => ({
 // ---------------------------------------------------------------------------
 
 import {
-  type ConversationRelayNativeStrategy,
   type MediaStreamCustomStrategy,
   resolveTelephonySttRouting,
 } from "../calls/telephony-stt-routing.js";
-import {
-  getProviderEntry,
-  listProviderEntries,
-} from "../providers/speech-to-text/provider-catalog.js";
+import { listProviderEntries } from "../providers/speech-to-text/provider-catalog.js";
 import type { SttProviderId } from "../stt/types.js";
 
 // ---------------------------------------------------------------------------
@@ -65,11 +61,32 @@ describe("resolveTelephonySttRouting", () => {
   });
 
   // -----------------------------------------------------------------------
-  // Deepgram → conversation-relay-native (from catalog)
+  // Every provider resolves to media-stream-custom (from catalog)
   // -----------------------------------------------------------------------
 
-  describe("deepgram", () => {
-    test("resolves to conversation-relay-native with Deepgram transcriptionProvider", () => {
+  describe("media-stream-custom routing", () => {
+    test.each([
+      "deepgram",
+      "google-gemini",
+      "openai-whisper",
+      "xai",
+    ] satisfies SttProviderId[])(
+      "%s resolves to media-stream-custom with its providerId",
+      (provider) => {
+        mockConfig = buildConfig({ provider });
+
+        const result = resolveTelephonySttRouting();
+
+        expect(result.status).toBe("resolved");
+        if (result.status !== "resolved") return;
+
+        expect(result.strategy.strategy).toBe("media-stream-custom");
+        const strategy = result.strategy as MediaStreamCustomStrategy;
+        expect(strategy.providerId).toBe(provider);
+      },
+    );
+
+    test("media-stream-custom strategy carries no Twilio-native fields", () => {
       mockConfig = buildConfig({ provider: "deepgram" });
 
       const result = resolveTelephonySttRouting();
@@ -77,116 +94,9 @@ describe("resolveTelephonySttRouting", () => {
       expect(result.status).toBe("resolved");
       if (result.status !== "resolved") return;
 
-      expect(result.strategy.strategy).toBe("conversation-relay-native");
-      const strategy = result.strategy as ConversationRelayNativeStrategy;
-      expect(strategy.providerId).toBe("deepgram");
-      expect(strategy.transcriptionProvider).toBe("Deepgram");
-    });
-
-    test("defaults speechModel to nova-3", () => {
-      mockConfig = buildConfig({ provider: "deepgram" });
-
-      const result = resolveTelephonySttRouting();
-
-      expect(result.status).toBe("resolved");
-      if (result.status !== "resolved") return;
-
-      const strategy = result.strategy as ConversationRelayNativeStrategy;
-      expect(strategy.speechModel).toBe("nova-3");
-    });
-
-    test("speechModel matches catalog telephonyRouting.twilioNativeMapping.defaultSpeechModel", () => {
-      mockConfig = buildConfig({ provider: "deepgram" });
-      const entry = getProviderEntry("deepgram");
-
-      const result = resolveTelephonySttRouting();
-
-      expect(result.status).toBe("resolved");
-      if (result.status !== "resolved") return;
-
-      const strategy = result.strategy as ConversationRelayNativeStrategy;
-      expect(strategy.speechModel).toBe(
-        entry?.telephonyRouting.twilioNativeMapping?.defaultSpeechModel,
-      );
-    });
-  });
-
-  // -----------------------------------------------------------------------
-  // Google Gemini → conversation-relay-native (from catalog)
-  // -----------------------------------------------------------------------
-
-  describe("google-gemini", () => {
-    test("resolves to conversation-relay-native with Google transcriptionProvider", () => {
-      mockConfig = buildConfig({ provider: "google-gemini" });
-
-      const result = resolveTelephonySttRouting();
-
-      expect(result.status).toBe("resolved");
-      if (result.status !== "resolved") return;
-
-      expect(result.strategy.strategy).toBe("conversation-relay-native");
-      const strategy = result.strategy as ConversationRelayNativeStrategy;
-      expect(strategy.providerId).toBe("google-gemini");
-      expect(strategy.transcriptionProvider).toBe("Google");
-    });
-
-    test("leaves speechModel undefined (uses provider default)", () => {
-      mockConfig = buildConfig({ provider: "google-gemini" });
-
-      const result = resolveTelephonySttRouting();
-
-      expect(result.status).toBe("resolved");
-      if (result.status !== "resolved") return;
-
-      const strategy = result.strategy as ConversationRelayNativeStrategy;
-      expect(strategy.speechModel).toBeUndefined();
-    });
-
-    test("speechModel matches catalog telephonyRouting.twilioNativeMapping.defaultSpeechModel", () => {
-      mockConfig = buildConfig({ provider: "google-gemini" });
-      const entry = getProviderEntry("google-gemini");
-
-      const result = resolveTelephonySttRouting();
-
-      expect(result.status).toBe("resolved");
-      if (result.status !== "resolved") return;
-
-      const strategy = result.strategy as ConversationRelayNativeStrategy;
-      expect(strategy.speechModel).toBe(
-        entry?.telephonyRouting.twilioNativeMapping?.defaultSpeechModel,
-      );
-    });
-  });
-
-  // -----------------------------------------------------------------------
-  // OpenAI Whisper → media-stream-custom (from catalog)
-  // -----------------------------------------------------------------------
-
-  describe("openai-whisper", () => {
-    test("resolves to media-stream-custom strategy", () => {
-      mockConfig = buildConfig({ provider: "openai-whisper" });
-
-      const result = resolveTelephonySttRouting();
-
-      expect(result.status).toBe("resolved");
-      if (result.status !== "resolved") return;
-
-      expect(result.strategy.strategy).toBe("media-stream-custom");
-      const strategy = result.strategy as MediaStreamCustomStrategy;
-      expect(strategy.providerId).toBe("openai-whisper");
-    });
-
-    test("media-stream-custom strategy does not include speechModel", () => {
-      mockConfig = buildConfig({ provider: "openai-whisper" });
-
-      const result = resolveTelephonySttRouting();
-
-      expect(result.status).toBe("resolved");
-      if (result.status !== "resolved") return;
-
-      // media-stream-custom has no speechModel property
       expect(result.strategy.strategy).toBe("media-stream-custom");
       expect("speechModel" in result.strategy).toBe(false);
+      expect("transcriptionProvider" in result.strategy).toBe(false);
     });
   });
 
@@ -218,90 +128,26 @@ describe("resolveTelephonySttRouting", () => {
   });
 
   // -----------------------------------------------------------------------
-  // Strategy discrimination correctness
-  // -----------------------------------------------------------------------
-
-  describe("strategy discrimination", () => {
-    test("conversation-relay-native strategies always have transcriptionProvider", () => {
-      for (const provider of ["deepgram", "google-gemini"]) {
-        mockConfig = buildConfig({ provider });
-
-        const result = resolveTelephonySttRouting();
-        expect(result.status).toBe("resolved");
-        if (result.status !== "resolved") return;
-
-        expect(result.strategy.strategy).toBe("conversation-relay-native");
-        const strategy = result.strategy as ConversationRelayNativeStrategy;
-        expect(strategy.transcriptionProvider).toBeDefined();
-        expect(strategy.transcriptionProvider.length).toBeGreaterThan(0);
-      }
-    });
-
-    test("media-stream-custom strategies never have transcriptionProvider", () => {
-      mockConfig = buildConfig({ provider: "openai-whisper" });
-
-      const result = resolveTelephonySttRouting();
-      expect(result.status).toBe("resolved");
-      if (result.status !== "resolved") return;
-
-      expect(result.strategy.strategy).toBe("media-stream-custom");
-      expect("transcriptionProvider" in result.strategy).toBe(false);
-    });
-
-    test("all resolved strategies include the original providerId", () => {
-      const providers: SttProviderId[] = [
-        "deepgram",
-        "google-gemini",
-        "openai-whisper",
-      ];
-      for (const provider of providers) {
-        mockConfig = buildConfig({ provider });
-
-        const result = resolveTelephonySttRouting();
-        expect(result.status).toBe("resolved");
-        if (result.status !== "resolved") return;
-
-        expect(result.strategy.providerId).toBe(provider);
-      }
-    });
-  });
-
-  // -----------------------------------------------------------------------
   // Catalog-driven mapping verification
   // -----------------------------------------------------------------------
 
   describe("catalog-driven mapping", () => {
-    test("every catalog entry with conversation-relay-native routing resolves to that strategy", () => {
+    test("no catalog entry declares conversation-relay-native routing", () => {
       const nativeEntries = listProviderEntries().filter(
-        (e) => e.telephonyRouting.strategyKind === "conversation-relay-native",
+        (e) =>
+          (e.telephonyRouting.strategyKind as string) ===
+          "conversation-relay-native",
       );
-      expect(nativeEntries.length).toBeGreaterThan(0);
-
-      for (const entry of nativeEntries) {
-        mockConfig = buildConfig({ provider: entry.id });
-
-        const result = resolveTelephonySttRouting();
-        expect(result.status).toBe("resolved");
-        if (result.status !== "resolved") return;
-
-        expect(result.strategy.strategy).toBe("conversation-relay-native");
-        const strategy = result.strategy as ConversationRelayNativeStrategy;
-        expect(strategy.transcriptionProvider).toBe(
-          entry.telephonyRouting.twilioNativeMapping!.provider,
-        );
-        expect(strategy.speechModel).toBe(
-          entry.telephonyRouting.twilioNativeMapping!.defaultSpeechModel,
-        );
-      }
+      expect(nativeEntries).toHaveLength(0);
     });
 
-    test("every catalog entry with media-stream-custom routing resolves to that strategy", () => {
-      const customEntries = listProviderEntries().filter(
-        (e) => e.telephonyRouting.strategyKind === "media-stream-custom",
-      );
-      expect(customEntries.length).toBeGreaterThan(0);
+    test("every catalog entry resolves to media-stream-custom", () => {
+      const entries = listProviderEntries();
+      expect(entries.length).toBeGreaterThan(0);
 
-      for (const entry of customEntries) {
+      for (const entry of entries) {
+        expect(entry.telephonyRouting.strategyKind).toBe("media-stream-custom");
+
         mockConfig = buildConfig({ provider: entry.id });
 
         const result = resolveTelephonySttRouting();

--- a/assistant/src/calls/telephony-stt-routing.ts
+++ b/assistant/src/calls/telephony-stt-routing.ts
@@ -1,59 +1,29 @@
 /**
  * Telephony STT routing resolver.
  *
- * Maps the `services.stt.provider` value to a discriminated telephony
- * setup strategy that downstream TwiML generation and media-stream
- * adapters can consume without re-deriving provider semantics.
+ * Maps the `services.stt.provider` value to a telephony setup strategy that
+ * downstream TwiML generation and media-stream adapters can consume without
+ * re-deriving provider semantics.
  *
- * Two strategy variants exist:
+ * A single strategy variant exists:
  *
- * - **`conversation-relay-native`** — the STT provider is natively
- *   supported by Twilio ConversationRelay. TwiML includes
- *   `transcriptionProvider` / `speechModel` attributes and Twilio
- *   handles audio ingestion. Used for `deepgram` and `google-gemini`.
+ * - **`media-stream-custom`** — a `<Stream>` media-stream is opened and the
+ *   daemon transcribes audio server-side via the provider's STT pipeline.
+ *   Every STT provider routes through this path; the legacy Twilio-native
+ *   ConversationRelay strategy has been removed.
  *
- * - **`media-stream-custom`** — the STT provider is not natively
- *   supported by Twilio. A `<Stream>` media-stream is opened instead
- *   and the daemon transcribes audio server-side via the provider's
- *   batch API. Used for `openai-whisper` and `xai`.
- *
- * Strategy selection and model normalization are driven entirely by
- * the provider catalog's `telephonyRouting` metadata — this module
- * contains no hardcoded provider-to-Twilio maps.
+ * Strategy selection is driven entirely by the provider catalog's
+ * `telephonyRouting` metadata — this module contains no hardcoded
+ * provider-to-Twilio maps.
  */
 
 import { getConfig } from "../config/loader.js";
-import {
-  getProviderEntry,
-  type TwilioNativeProvider,
-} from "../providers/speech-to-text/provider-catalog.js";
+import { getProviderEntry } from "../providers/speech-to-text/provider-catalog.js";
 import type { SttProviderId } from "../stt/types.js";
 
 // ---------------------------------------------------------------------------
 // Strategy types
 // ---------------------------------------------------------------------------
-
-/**
- * Twilio-native ConversationRelay transcription provider name.
- *
- * Re-exported from the provider catalog for downstream consumers that
- * reference the strategy types without importing the catalog directly.
- */
-export type TwilioNativeTranscriptionProvider = TwilioNativeProvider;
-
-/**
- * The configured STT provider maps to a Twilio-native
- * ConversationRelay transcription path.
- */
-export interface ConversationRelayNativeStrategy {
-  readonly strategy: "conversation-relay-native";
-  /** Provider ID from `services.stt.provider`. */
-  readonly providerId: SttProviderId;
-  /** Twilio-native provider name for the TwiML attribute. */
-  readonly transcriptionProvider: TwilioNativeTranscriptionProvider;
-  /** ASR model identifier, or undefined to use the provider default. */
-  readonly speechModel: string | undefined;
-}
 
 /**
  * The configured STT provider requires a media-stream for custom
@@ -66,11 +36,10 @@ export interface MediaStreamCustomStrategy {
 }
 
 /**
- * Discriminated union of telephony setup strategies.
+ * Telephony setup strategy. Currently a single variant; kept as a named
+ * type so future strategies can re-introduce a discriminated union.
  */
-export type TelephonySttStrategy =
-  | ConversationRelayNativeStrategy
-  | MediaStreamCustomStrategy;
+export type TelephonySttStrategy = MediaStreamCustomStrategy;
 
 /**
  * Result of resolving a telephony STT routing decision.
@@ -117,33 +86,7 @@ export function resolveTelephonySttRouting(): TelephonySttRoutingResult {
     };
   }
 
-  const { telephonyRouting } = entry;
-
-  // Derive strategy from catalog routing metadata.
-  if (telephonyRouting.strategyKind === "conversation-relay-native") {
-    const mapping = telephonyRouting.twilioNativeMapping;
-
-    // Defensive: conversation-relay-native entries must have a mapping.
-    if (!mapping) {
-      return {
-        status: "unknown-provider",
-        providerId: entry.id,
-        reason: `Provider "${entry.id}" declares conversation-relay-native strategy but has no twilioNativeMapping`,
-      };
-    }
-
-    return {
-      status: "resolved",
-      strategy: {
-        strategy: "conversation-relay-native",
-        providerId: entry.id,
-        transcriptionProvider: mapping.provider,
-        speechModel: mapping.defaultSpeechModel,
-      },
-    };
-  }
-
-  // media-stream-custom path.
+  // Every provider routes through the media-stream custom path.
   return {
     status: "resolved",
     strategy: {

--- a/assistant/src/calls/telephony-stt-routing.ts
+++ b/assistant/src/calls/telephony-stt-routing.ts
@@ -9,8 +9,7 @@
  *
  * - **`media-stream-custom`** — a `<Stream>` media-stream is opened and the
  *   daemon transcribes audio server-side via the provider's STT pipeline.
- *   Every STT provider routes through this path; the legacy Twilio-native
- *   ConversationRelay strategy has been removed.
+ *   Every STT provider routes through this path.
  *
  * Strategy selection is driven entirely by the provider catalog's
  * `telephonyRouting` metadata — this module contains no hardcoded
@@ -36,8 +35,8 @@ export interface MediaStreamCustomStrategy {
 }
 
 /**
- * Telephony setup strategy. Currently a single variant; kept as a named
- * type so future strategies can re-introduce a discriminated union.
+ * Telephony setup strategy. A single variant, expressed as a named type so
+ * additional strategies can extend it into a discriminated union.
  */
 export type TelephonySttStrategy = MediaStreamCustomStrategy;
 

--- a/assistant/src/providers/speech-to-text/__tests__/provider-catalog.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/provider-catalog.test.ts
@@ -140,64 +140,34 @@ describe("STT provider catalog", () => {
   // Telephony routing metadata
   // -----------------------------------------------------------------------
 
-  test("every entry has telephonyRouting metadata", () => {
+  test("every entry has media-stream-custom telephonyRouting metadata", () => {
     for (const entry of listProviderEntries()) {
       expect(entry.telephonyRouting).toBeDefined();
-      expect(["conversation-relay-native", "media-stream-custom"]).toContain(
-        entry.telephonyRouting.strategyKind,
+      expect(entry.telephonyRouting.strategyKind).toBe("media-stream-custom");
+    }
+  });
+
+  test("no entry declares conversation-relay-native routing", () => {
+    for (const entry of listProviderEntries()) {
+      expect(entry.telephonyRouting.strategyKind).not.toBe(
+        "conversation-relay-native",
       );
     }
   });
 
-  test("conversation-relay-native entries have twilioNativeMapping", () => {
-    for (const entry of listProviderEntries()) {
-      if (entry.telephonyRouting.strategyKind === "conversation-relay-native") {
-        expect(entry.telephonyRouting.twilioNativeMapping).toBeDefined();
-        expect(
-          entry.telephonyRouting.twilioNativeMapping!.provider.length,
-        ).toBeGreaterThan(0);
-      }
-    }
-  });
-
-  test("media-stream-custom entries do not have twilioNativeMapping", () => {
-    for (const entry of listProviderEntries()) {
-      if (entry.telephonyRouting.strategyKind === "media-stream-custom") {
-        expect(entry.telephonyRouting.twilioNativeMapping).toBeUndefined();
-      }
-    }
-  });
-
-  test("deepgram has conversation-relay-native strategy with Deepgram Twilio mapping", () => {
+  test("deepgram has media-stream-custom strategy", () => {
     const entry = getProviderEntry("deepgram");
-    expect(entry?.telephonyRouting.strategyKind).toBe(
-      "conversation-relay-native",
-    );
-    expect(entry?.telephonyRouting.twilioNativeMapping?.provider).toBe(
-      "Deepgram",
-    );
-    expect(
-      entry?.telephonyRouting.twilioNativeMapping?.defaultSpeechModel,
-    ).toBe("nova-3");
+    expect(entry?.telephonyRouting.strategyKind).toBe("media-stream-custom");
   });
 
-  test("google-gemini has conversation-relay-native strategy with Google Twilio mapping", () => {
+  test("google-gemini has media-stream-custom strategy", () => {
     const entry = getProviderEntry("google-gemini");
-    expect(entry?.telephonyRouting.strategyKind).toBe(
-      "conversation-relay-native",
-    );
-    expect(entry?.telephonyRouting.twilioNativeMapping?.provider).toBe(
-      "Google",
-    );
-    expect(
-      entry?.telephonyRouting.twilioNativeMapping?.defaultSpeechModel,
-    ).toBeUndefined();
+    expect(entry?.telephonyRouting.strategyKind).toBe("media-stream-custom");
   });
 
-  test("openai-whisper has media-stream-custom strategy without Twilio mapping", () => {
+  test("openai-whisper has media-stream-custom strategy", () => {
     const entry = getProviderEntry("openai-whisper");
     expect(entry?.telephonyRouting.strategyKind).toBe("media-stream-custom");
-    expect(entry?.telephonyRouting.twilioNativeMapping).toBeUndefined();
   });
 
   // -----------------------------------------------------------------------

--- a/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
@@ -469,66 +469,37 @@ describe("telephony routing catalog alignment", () => {
   // Telephony routing metadata invariants
   // -----------------------------------------------------------------------
 
-  test("every catalog provider has telephonyRouting metadata", () => {
+  test("every catalog provider has media-stream-custom telephonyRouting metadata", () => {
     for (const id of listProviderIds()) {
       const entry = getProviderEntry(id);
       expect(entry).toBeDefined();
       expect(entry!.telephonyRouting).toBeDefined();
-      expect(["conversation-relay-native", "media-stream-custom"]).toContain(
-        entry!.telephonyRouting.strategyKind,
+      expect(entry!.telephonyRouting.strategyKind).toBe("media-stream-custom");
+    }
+  });
+
+  test("no provider declares conversation-relay-native routing", () => {
+    for (const id of listProviderIds()) {
+      const entry = getProviderEntry(id)!;
+      expect(entry.telephonyRouting.strategyKind).not.toBe(
+        "conversation-relay-native",
       );
     }
   });
 
-  test("conversation-relay-native providers have twilioNativeMapping with non-empty provider name", () => {
-    for (const id of listProviderIds()) {
-      const entry = getProviderEntry(id)!;
-      if (entry.telephonyRouting.strategyKind === "conversation-relay-native") {
-        expect(entry.telephonyRouting.twilioNativeMapping).toBeDefined();
-        expect(
-          entry.telephonyRouting.twilioNativeMapping!.provider.length,
-        ).toBeGreaterThan(0);
-      }
-    }
-  });
-
-  test("media-stream-custom providers do not have twilioNativeMapping", () => {
-    for (const id of listProviderIds()) {
-      const entry = getProviderEntry(id)!;
-      if (entry.telephonyRouting.strategyKind === "media-stream-custom") {
-        expect(entry.telephonyRouting.twilioNativeMapping).toBeUndefined();
-      }
-    }
-  });
-
-  test("deepgram routing metadata maps to Twilio-native Deepgram with nova-3 speech model", () => {
+  test("deepgram routing metadata uses media-stream-custom", () => {
     const entry = getProviderEntry("deepgram")!;
-    expect(entry.telephonyRouting.strategyKind).toBe(
-      "conversation-relay-native",
-    );
-    expect(entry.telephonyRouting.twilioNativeMapping?.provider).toBe(
-      "Deepgram",
-    );
-    expect(entry.telephonyRouting.twilioNativeMapping?.defaultSpeechModel).toBe(
-      "nova-3",
-    );
+    expect(entry.telephonyRouting.strategyKind).toBe("media-stream-custom");
   });
 
-  test("google-gemini routing metadata maps to Twilio-native Google with no default speech model", () => {
+  test("google-gemini routing metadata uses media-stream-custom", () => {
     const entry = getProviderEntry("google-gemini")!;
-    expect(entry.telephonyRouting.strategyKind).toBe(
-      "conversation-relay-native",
-    );
-    expect(entry.telephonyRouting.twilioNativeMapping?.provider).toBe("Google");
-    expect(
-      entry.telephonyRouting.twilioNativeMapping?.defaultSpeechModel,
-    ).toBeUndefined();
+    expect(entry.telephonyRouting.strategyKind).toBe("media-stream-custom");
   });
 
-  test("openai-whisper routing metadata uses media-stream-custom without Twilio mapping", () => {
+  test("openai-whisper routing metadata uses media-stream-custom", () => {
     const entry = getProviderEntry("openai-whisper")!;
     expect(entry.telephonyRouting.strategyKind).toBe("media-stream-custom");
-    expect(entry.telephonyRouting.twilioNativeMapping).toBeUndefined();
   });
 
   // -----------------------------------------------------------------------

--- a/assistant/src/providers/speech-to-text/provider-catalog.ts
+++ b/assistant/src/providers/speech-to-text/provider-catalog.ts
@@ -29,8 +29,7 @@ import type {
  * - `"media-stream-custom"` — a `<Stream>` media-stream is opened and the
  *   daemon transcribes audio server-side via the provider's STT pipeline.
  *
- * All telephony audio flows through this single strategy; the legacy
- * Twilio-native ConversationRelay path has been removed.
+ * All telephony audio flows through this single strategy.
  */
 type TelephonyStrategyKind = "media-stream-custom";
 

--- a/assistant/src/providers/speech-to-text/provider-catalog.ts
+++ b/assistant/src/providers/speech-to-text/provider-catalog.ts
@@ -24,43 +24,15 @@ import type {
 /**
  * Strategy kind for telephony call setup.
  *
- * Determines how the telephony routing resolver (`telephony-stt-routing.ts`)
- * wires the STT provider into a Twilio call:
+ * Every STT provider is wired into a Twilio call the same way:
  *
- * - `"conversation-relay-native"` — the provider is natively supported by
- *   Twilio ConversationRelay. TwiML includes `transcriptionProvider` /
- *   `speechModel` attributes and Twilio handles audio ingestion.
- * - `"media-stream-custom"` — the provider is not natively supported by
- *   Twilio. A `<Stream>` media-stream is opened and the daemon transcribes
- *   audio server-side via the provider's batch API.
- */
-type TelephonyStrategyKind =
-  | "conversation-relay-native"
-  | "media-stream-custom";
-
-/**
- * Twilio-native ConversationRelay provider name.
+ * - `"media-stream-custom"` — a `<Stream>` media-stream is opened and the
+ *   daemon transcribes audio server-side via the provider's STT pipeline.
  *
- * These are the values Twilio accepts in the `transcriptionProvider` TwiML
- * attribute on `<ConversationRelay>`.
+ * All telephony audio flows through this single strategy; the legacy
+ * Twilio-native ConversationRelay path has been removed.
  */
-export type TwilioNativeProvider = "Deepgram" | "Google";
-
-/**
- * Twilio-native mapping details for providers routed through
- * ConversationRelay. Only present when `strategyKind` is
- * `"conversation-relay-native"`.
- */
-interface TwilioNativeMapping {
-  /** Twilio-native provider name for the TwiML `transcriptionProvider` attribute. */
-  readonly provider: TwilioNativeProvider;
-  /**
-   * Default ASR speech model identifier, or `undefined` to use the
-   * provider's default model. Individual providers override as needed
-   * (e.g. Deepgram defaults to `"nova-3"`).
-   */
-  readonly defaultSpeechModel: string | undefined;
-}
+type TelephonyStrategyKind = "media-stream-custom";
 
 /**
  * Telephony routing metadata — the single source of truth for how a
@@ -72,11 +44,6 @@ interface TwilioNativeMapping {
 interface TelephonyRouting {
   /** Which Twilio call-setup strategy this provider uses. */
   readonly strategyKind: TelephonyStrategyKind;
-  /**
-   * Twilio-native mapping details. Present when `strategyKind` is
-   * `"conversation-relay-native"`, absent for `"media-stream-custom"`.
-   */
-  readonly twilioNativeMapping?: TwilioNativeMapping;
 }
 
 // ---------------------------------------------------------------------------
@@ -164,7 +131,7 @@ interface SttProviderEntry {
   /**
    * Telephony routing metadata — describes how this provider is wired
    * into Twilio call setup. This is the single source of truth for
-   * strategy selection and Twilio-native mapping details.
+   * telephony strategy selection.
    */
   readonly telephonyRouting: TelephonyRouting;
 
@@ -207,11 +174,7 @@ const CATALOG: ReadonlyMap<SttProviderId, SttProviderEntry> = new Map<
       conversationStreamingMode: "realtime-ws",
       supportsDiarization: true,
       telephonyRouting: {
-        strategyKind: "conversation-relay-native",
-        twilioNativeMapping: {
-          provider: "Deepgram",
-          defaultSpeechModel: "nova-3",
-        },
+        strategyKind: "media-stream-custom",
       },
       credentialsGuide: {
         description:
@@ -240,11 +203,7 @@ const CATALOG: ReadonlyMap<SttProviderId, SttProviderEntry> = new Map<
       conversationStreamingMode: "realtime-ws",
       supportsDiarization: false,
       telephonyRouting: {
-        strategyKind: "conversation-relay-native",
-        twilioNativeMapping: {
-          provider: "Google",
-          defaultSpeechModel: undefined,
-        },
+        strategyKind: "media-stream-custom",
       },
       credentialsGuide: {
         description:

--- a/assistant/src/stt/types.ts
+++ b/assistant/src/stt/types.ts
@@ -30,19 +30,15 @@ export type SttProviderId =
  * Telephony-specific STT capability class.
  *
  * Describes the provider's native audio-ingestion capability when used in
- * a telephony context. This is a **capability classification**, not a direct
- * Twilio strategy selector — the telephony routing resolver
- * (`telephony-stt-routing.ts`) maps capability classes plus catalog routing
- * metadata to concrete Twilio setup strategies (conversation-relay-native
- * vs media-stream-custom).
+ * a telephony context. This is a **capability classification** that informs
+ * how the daemon transcribes media-stream audio for the provider; all
+ * telephony calls route through the media-stream custom path (see
+ * `telephony-stt-routing.ts`).
  *
  * - `"realtime-ws"` — provider offers a WebSocket streaming endpoint suitable
  *   for low-latency telephony audio (e.g. Deepgram live transcription).
  * - `"batch-only"` — provider supports only REST batch transcription as its
- *   native capability. A `batch-only` provider may still participate in
- *   telephony via Twilio-native ConversationRelay (e.g. Google Gemini) or
- *   via the media-stream custom path — the routing strategy is determined
- *   by the catalog's telephony routing metadata, not this field alone.
+ *   native capability.
  * - `"none"` — provider has no telephony support.
  */
 export type TelephonySttMode = "realtime-ws" | "batch-only" | "none";


### PR DESCRIPTION
## Summary
- Every STT provider now declares media-stream-custom telephony routing; dropped twilioNativeMapping + ConversationRelayNativeStrategy
- Simplified/removed telephony-stt-routing accordingly; updated consumers
Part of plan: migrate-phone-off-conversation-relay.md (PR 12 of 18)