### PR TITLE
fix(calls): flush streaming transcript at utterance boundary (Deepgram speech_final)

### DIFF
--- a/assistant/src/__tests__/media-stream-stt-session.test.ts
+++ b/assistant/src/__tests__/media-stream-stt-session.test.ts
@@ -904,6 +904,116 @@ describe("MediaStreamSttSession", () => {
       session.dispose();
     });
 
+    test("accumulates Deepgram is_final segments and flushes one onTranscriptFinal at the utterance boundary", async () => {
+      telephonyStreamingFlag = true;
+      const fake = makeFakeStreamingTranscriber();
+      (resolveStreamingTranscriber as jest.Mock).mockResolvedValue(fake);
+
+      const onTranscriptFinal = jest.fn();
+      const session = new MediaStreamSttSession({}, { onTranscriptFinal });
+
+      session.handleMessage(makeStartMessage());
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+      fake.resolveStart();
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+
+      // Deepgram emits a final per is_final segment. Mid-sentence segments
+      // carry endOfUtterance:false and must NOT fire onTranscriptFinal — only
+      // the final segment at the speech_final boundary should flush.
+      fake.emit({ type: "final", text: "hello there", endOfUtterance: false });
+      expect(onTranscriptFinal).not.toHaveBeenCalled();
+
+      fake.emit({
+        type: "final",
+        text: "how are you",
+        endOfUtterance: true,
+      });
+
+      // Exactly one reply, with the concatenated utterance text.
+      expect(onTranscriptFinal).toHaveBeenCalledTimes(1);
+      expect(onTranscriptFinal).toHaveBeenCalledWith(
+        "hello there how are you",
+        expect.any(Number),
+      );
+
+      // A subsequent utterance starts fresh (buffer reset after flush).
+      fake.emit({ type: "final", text: "second", endOfUtterance: false });
+      fake.emit({ type: "final", text: "utterance", endOfUtterance: true });
+      expect(onTranscriptFinal).toHaveBeenCalledTimes(2);
+      expect(onTranscriptFinal).toHaveBeenLastCalledWith(
+        "second utterance",
+        expect.any(Number),
+      );
+
+      session.dispose();
+    });
+
+    test("flushes accumulated segments on a standalone UtteranceEnd boundary (empty-text final)", async () => {
+      telephonyStreamingFlag = true;
+      const fake = makeFakeStreamingTranscriber();
+      (resolveStreamingTranscriber as jest.Mock).mockResolvedValue(fake);
+
+      const onTranscriptFinal = jest.fn();
+      const session = new MediaStreamSttSession({}, { onTranscriptFinal });
+
+      session.handleMessage(makeStartMessage());
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+      fake.resolveStart();
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+
+      // is_final segment with no speech_final, then a Deepgram UtteranceEnd
+      // surfaced as an empty-text boundary final.
+      fake.emit({ type: "final", text: "mid segment", endOfUtterance: false });
+      expect(onTranscriptFinal).not.toHaveBeenCalled();
+
+      fake.emit({ type: "final", text: "", endOfUtterance: true });
+      expect(onTranscriptFinal).toHaveBeenCalledTimes(1);
+      expect(onTranscriptFinal).toHaveBeenCalledWith(
+        "mid segment",
+        expect.any(Number),
+      );
+
+      // A bare boundary with nothing buffered does not emit an empty reply.
+      fake.emit({ type: "final", text: "", endOfUtterance: true });
+      expect(onTranscriptFinal).toHaveBeenCalledTimes(1);
+
+      session.dispose();
+    });
+
+    test("provider without a boundary signal emits one onTranscriptFinal per final (no regression)", async () => {
+      telephonyStreamingFlag = true;
+      sttProvider = "xai"; // realtime-ws, no separate utterance boundary signal
+      const fake = makeFakeStreamingTranscriber();
+      (resolveStreamingTranscriber as jest.Mock).mockResolvedValue(fake);
+
+      const onTranscriptFinal = jest.fn();
+      const session = new MediaStreamSttSession({}, { onTranscriptFinal });
+
+      session.handleMessage(makeStartMessage());
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+      fake.resolveStart();
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+
+      // No endOfUtterance field (undefined) — each final is a complete
+      // utterance and flushes immediately.
+      fake.emit({ type: "final", text: "first reply" });
+      fake.emit({ type: "final", text: "second reply" });
+
+      expect(onTranscriptFinal).toHaveBeenCalledTimes(2);
+      expect(onTranscriptFinal).toHaveBeenNthCalledWith(
+        1,
+        "first reply",
+        expect.any(Number),
+      );
+      expect(onTranscriptFinal).toHaveBeenNthCalledWith(
+        2,
+        "second reply",
+        expect.any(Number),
+      );
+
+      session.dispose();
+    });
+
     test("maps transcriber error to onError", async () => {
       telephonyStreamingFlag = true;
       const fake = makeFakeStreamingTranscriber();

--- a/assistant/src/__tests__/media-stream-stt-session.test.ts
+++ b/assistant/src/__tests__/media-stream-stt-session.test.ts
@@ -980,6 +980,105 @@ describe("MediaStreamSttSession", () => {
       session.dispose();
     });
 
+    test("flushes a buffered final on transcriber close when no boundary arrived (caller hangs up mid-utterance)", async () => {
+      telephonyStreamingFlag = true;
+      const fake = makeFakeStreamingTranscriber();
+      (resolveStreamingTranscriber as jest.Mock).mockResolvedValue(fake);
+
+      const onTranscriptFinal = jest.fn();
+      const session = new MediaStreamSttSession({}, { onTranscriptFinal });
+
+      session.handleMessage(makeStartMessage());
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+      fake.resolveStart();
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+
+      // A mid-utterance committed segment buffers, awaiting a boundary.
+      fake.emit({ type: "final", text: "i was saying", endOfUtterance: false });
+      expect(onTranscriptFinal).not.toHaveBeenCalled();
+
+      // The caller hangs up: the transcriber closes WITHOUT a speech_final /
+      // UtteranceEnd boundary. The buffered text must be flushed as one final.
+      fake.emit({ type: "closed" });
+      expect(onTranscriptFinal).toHaveBeenCalledTimes(1);
+      expect(onTranscriptFinal).toHaveBeenCalledWith(
+        "i was saying",
+        expect.any(Number),
+      );
+
+      session.dispose();
+      // Buffer was reset on close, so dispose() does not double-flush.
+      expect(onTranscriptFinal).toHaveBeenCalledTimes(1);
+    });
+
+    test("flushes a buffered final on stop when no boundary arrived", async () => {
+      telephonyStreamingFlag = true;
+      const fake = makeFakeStreamingTranscriber();
+      (resolveStreamingTranscriber as jest.Mock).mockResolvedValue(fake);
+
+      const onTranscriptFinal = jest.fn();
+      const onStop = jest.fn();
+      const session = new MediaStreamSttSession(
+        {},
+        { onTranscriptFinal, onStop },
+      );
+
+      session.handleMessage(makeStartMessage());
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+      fake.resolveStart();
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+
+      fake.emit({
+        type: "final",
+        text: "partial words",
+        endOfUtterance: false,
+      });
+      expect(onTranscriptFinal).not.toHaveBeenCalled();
+
+      // Twilio stop arrives before any boundary final.
+      session.handleMessage(makeStopMessage());
+      expect(onTranscriptFinal).toHaveBeenCalledTimes(1);
+      expect(onTranscriptFinal).toHaveBeenCalledWith(
+        "partial words",
+        expect.any(Number),
+      );
+      expect(fake.stop).toHaveBeenCalledTimes(1);
+      expect(onStop).toHaveBeenCalledTimes(1);
+
+      // The provider's subsequent `closed` (triggered by stop()) must not
+      // double-flush, since the buffer was reset on stop.
+      fake.emit({ type: "closed" });
+      expect(onTranscriptFinal).toHaveBeenCalledTimes(1);
+
+      session.dispose();
+      expect(onTranscriptFinal).toHaveBeenCalledTimes(1);
+    });
+
+    test("does not emit an extra empty final on close when a boundary already flushed", async () => {
+      telephonyStreamingFlag = true;
+      const fake = makeFakeStreamingTranscriber();
+      (resolveStreamingTranscriber as jest.Mock).mockResolvedValue(fake);
+
+      const onTranscriptFinal = jest.fn();
+      const session = new MediaStreamSttSession({}, { onTranscriptFinal });
+
+      session.handleMessage(makeStartMessage());
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+      fake.resolveStart();
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+
+      // A real boundary flushes the utterance, leaving the buffer empty.
+      fake.emit({ type: "final", text: "all done", endOfUtterance: true });
+      expect(onTranscriptFinal).toHaveBeenCalledTimes(1);
+
+      // Close fires afterward with an empty buffer — no extra empty flush.
+      fake.emit({ type: "closed" });
+      expect(onTranscriptFinal).toHaveBeenCalledTimes(1);
+
+      session.dispose();
+      expect(onTranscriptFinal).toHaveBeenCalledTimes(1);
+    });
+
     test("provider without a boundary signal emits one onTranscriptFinal per final (no regression)", async () => {
       telephonyStreamingFlag = true;
       sttProvider = "xai"; // realtime-ws, no separate utterance boundary signal

--- a/assistant/src/__tests__/media-stream-stt-session.test.ts
+++ b/assistant/src/__tests__/media-stream-stt-session.test.ts
@@ -1011,7 +1011,7 @@ describe("MediaStreamSttSession", () => {
       expect(onTranscriptFinal).toHaveBeenCalledTimes(1);
     });
 
-    test("flushes a buffered final on stop when no boundary arrived", async () => {
+    test("does NOT pre-flush on stop; flushes the buffered final on the provider's post-stop close", async () => {
       telephonyStreamingFlag = true;
       const fake = makeFakeStreamingTranscriber();
       (resolveStreamingTranscriber as jest.Mock).mockResolvedValue(fake);
@@ -1035,22 +1035,82 @@ describe("MediaStreamSttSession", () => {
       });
       expect(onTranscriptFinal).not.toHaveBeenCalled();
 
-      // Twilio stop arrives before any boundary final.
+      // Twilio stop arrives before any boundary final. The session must NOT
+      // pre-flush here — it only signals end-of-audio to the transcriber and
+      // lets the provider drain. Flushing now would emit the buffered segment
+      // too early and split the utterance from any post-stop finals.
       session.handleMessage(makeStopMessage());
+      expect(onTranscriptFinal).not.toHaveBeenCalled();
+      expect(fake.stop).toHaveBeenCalledTimes(1);
+      expect(onStop).toHaveBeenCalledTimes(1);
+
+      // The provider's `closed` event (emitted after stop() drains) performs
+      // the single final flush of the complete utterance.
+      fake.emit({ type: "closed" });
       expect(onTranscriptFinal).toHaveBeenCalledTimes(1);
       expect(onTranscriptFinal).toHaveBeenCalledWith(
         "partial words",
         expect.any(Number),
       );
+
+      session.dispose();
+      // Buffer was reset on the close flush, so dispose() does not double-flush.
+      expect(onTranscriptFinal).toHaveBeenCalledTimes(1);
+    });
+
+    test("flushes buffered AND post-stop finals together once, after the provider drains on stop", async () => {
+      telephonyStreamingFlag = true;
+      const fake = makeFakeStreamingTranscriber();
+      (resolveStreamingTranscriber as jest.Mock).mockResolvedValue(fake);
+
+      const onTranscriptFinal = jest.fn();
+      const onStop = jest.fn();
+      const session = new MediaStreamSttSession(
+        {},
+        { onTranscriptFinal, onStop },
+      );
+
+      session.handleMessage(makeStartMessage());
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+      fake.resolveStart();
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+
+      // A mid-utterance committed segment buffers (speech_final:false), awaiting
+      // the boundary.
+      fake.emit({
+        type: "final",
+        text: "hello there",
+        endOfUtterance: false,
+      });
+      expect(onTranscriptFinal).not.toHaveBeenCalled();
+
+      // Twilio stop arrives. Deepgram still holds unprocessed audio: stop()
+      // makes it finalize and emit a further post-stop `final`, then `closed`.
+      // The session must NOT have flushed early on stop.
+      session.handleMessage(makeStopMessage());
+      expect(onTranscriptFinal).not.toHaveBeenCalled();
       expect(fake.stop).toHaveBeenCalledTimes(1);
       expect(onStop).toHaveBeenCalledTimes(1);
 
-      // The provider's subsequent `closed` (triggered by stop()) must not
-      // double-flush, since the buffer was reset on stop.
+      // Post-stop leftover final flows through the normal accumulation path.
+      fake.emit({
+        type: "final",
+        text: "general kenobi",
+        endOfUtterance: false,
+      });
+      expect(onTranscriptFinal).not.toHaveBeenCalled();
+
+      // Drain completes — `closed` flushes the COMPLETE utterance once, with
+      // BOTH the buffered segment and the post-stop segment concatenated.
       fake.emit({ type: "closed" });
       expect(onTranscriptFinal).toHaveBeenCalledTimes(1);
+      expect(onTranscriptFinal).toHaveBeenCalledWith(
+        "hello there general kenobi",
+        expect.any(Number),
+      );
 
       session.dispose();
+      // No double-emit on dispose: the buffer was reset by the close flush.
       expect(onTranscriptFinal).toHaveBeenCalledTimes(1);
     });
 

--- a/assistant/src/__tests__/media-stream-stt-session.test.ts
+++ b/assistant/src/__tests__/media-stream-stt-session.test.ts
@@ -1011,6 +1011,32 @@ describe("MediaStreamSttSession", () => {
       expect(onTranscriptFinal).toHaveBeenCalledTimes(1);
     });
 
+    test("dispose() with a buffered final but no prior close does NOT emit a late transcript (call already ended)", async () => {
+      telephonyStreamingFlag = true;
+      const fake = makeFakeStreamingTranscriber();
+      (resolveStreamingTranscriber as jest.Mock).mockResolvedValue(fake);
+
+      const onTranscriptFinal = jest.fn();
+      const session = new MediaStreamSttSession({}, { onTranscriptFinal });
+
+      session.handleMessage(makeStartMessage());
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+      fake.resolveStart();
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+
+      // A mid-utterance committed segment buffers, awaiting a boundary.
+      fake.emit({ type: "final", text: "i was saying", endOfUtterance: false });
+      expect(onTranscriptFinal).not.toHaveBeenCalled();
+
+      // The media WebSocket / session is torn down before the provider emits
+      // its `closed` event (e.g. Twilio `stop` then the WS closes while
+      // Deepgram is still draining). dispose() must NOT flush the buffered
+      // partial: the call is over, so emitting would start an LLM turn / reply
+      // on a dead call with no one to hear it.
+      session.dispose();
+      expect(onTranscriptFinal).not.toHaveBeenCalled();
+    });
+
     test("does NOT pre-flush on stop; flushes the buffered final on the provider's post-stop close", async () => {
       telephonyStreamingFlag = true;
       const fake = makeFakeStreamingTranscriber();

--- a/assistant/src/calls/media-stream-stt-session.ts
+++ b/assistant/src/calls/media-stream-stt-session.ts
@@ -333,14 +333,14 @@ export class MediaStreamSttSession {
    * Dispose of the session, clearing all timers and buffers.
    */
   dispose(): void {
-    // Flush any buffered accumulated streaming finals BEFORE marking the
-    // session disposed. dispose() is a teardown path, so treat it as an
-    // implicit utterance boundary — otherwise a caller's last partial
-    // utterance (buffered with speech_final:false, no boundary yet) would be
-    // dropped. Done before `disposed = true` so the callback still fires, and
-    // before the buffer is cleared below; flushStreamingUtterance resets the
-    // buffer so a prior real-boundary/close flush won't double-fire here.
-    this.handleStreamingClose();
+    // dispose() is a teardown path: the WS/session is gone, so the call is
+    // over. Do NOT flush buffered accumulated streaming finals here — emitting
+    // onTranscriptFinal during teardown would route to handleCallerUtterance
+    // and start an LLM turn / reply on an already-ended call (no one is left to
+    // hear it). The legitimate end-of-utterance flush happens on the provider
+    // `closed` event (handleStreamingClose), which fires after stop() drains.
+    // The buffer is still cleared below (`streamingUtteranceSegments = []`) so
+    // teardown leaves nothing behind — it just is not emitted.
     this.disposed = true;
     // If a streaming startup is still in flight, mark it aborted so the
     // pending resolver tears down (and does not leak) any late-resolved
@@ -610,10 +610,15 @@ export class MediaStreamSttSession {
    * `onTranscriptFinal`, then reset the buffer.
    *
    * Used both at a real provider utterance boundary
-   * ({@link handleStreamingFinal}) and on stream teardown
-   * ({@link handleStreamingClose}) — closing the stream is treated as an
-   * implicit utterance boundary so the caller's last partial utterance is not
-   * lost if they hang up mid-sentence before the provider emits its boundary.
+   * ({@link handleStreamingFinal}) and on the provider `closed` event
+   * ({@link handleStreamingClose}) — the `closed` event fires after `stop()`
+   * drains, so it is treated as an implicit utterance boundary and the caller's
+   * last partial utterance is not lost if they hang up mid-sentence before the
+   * provider emits its explicit boundary.
+   *
+   * NOTE: {@link dispose} deliberately does NOT flush — once the WS/session is
+   * being torn down the call is over, so emitting the buffered partial would
+   * start a reply on a dead call. dispose() only clears the buffer.
    *
    * Guards:
    * - A bare boundary / close with nothing buffered (e.g. a standalone
@@ -633,15 +638,16 @@ export class MediaStreamSttSession {
   }
 
   /**
-   * Handle stream teardown (transcriber `closed`, `stop()`/{@link handleStop},
-   * or {@link dispose}). Treats the close as an implicit utterance boundary and
+   * Handle the provider `closed` event, which fires after `stop()` drains the
+   * remaining audio. Treats the close as an implicit utterance boundary and
    * flushes any buffered accumulated `final` segments as one
-   * `onTranscriptFinal` before tearing down — otherwise a caller who hangs up
-   * mid-utterance (before the provider emits `speech_final`/`UtteranceEnd`)
-   * would lose their final partial utterance.
+   * `onTranscriptFinal` — otherwise a caller who hangs up mid-utterance (before
+   * the provider emits `speech_final`/`UtteranceEnd`) would lose their final
+   * partial utterance. This is the SOLE flush path on teardown; {@link dispose}
+   * does not flush (the call is already over).
    *
-   * Flushing here resets the buffer, so it is safe to call from multiple
-   * teardown paths: the second call finds an empty buffer and does nothing.
+   * Flushing here resets the buffer, so it is safe to call more than once: a
+   * second call finds an empty buffer and does nothing.
    */
   private handleStreamingClose(): void {
     this.flushStreamingUtterance();

--- a/assistant/src/calls/media-stream-stt-session.ts
+++ b/assistant/src/calls/media-stream-stt-session.ts
@@ -333,6 +333,14 @@ export class MediaStreamSttSession {
    * Dispose of the session, clearing all timers and buffers.
    */
   dispose(): void {
+    // Flush any buffered accumulated streaming finals BEFORE marking the
+    // session disposed. dispose() is a teardown path, so treat it as an
+    // implicit utterance boundary — otherwise a caller's last partial
+    // utterance (buffered with speech_final:false, no boundary yet) would be
+    // dropped. Done before `disposed = true` so the callback still fires, and
+    // before the buffer is cleared below; flushStreamingUtterance resets the
+    // buffer so a prior real-boundary/close flush won't double-fire here.
+    this.handleStreamingClose();
     this.disposed = true;
     // If a streaming startup is still in flight, mark it aborted so the
     // pending resolver tears down (and does not leak) any late-resolved
@@ -554,6 +562,9 @@ export class MediaStreamSttSession {
       case "closed":
         // Session-level `onStop` is driven by the Twilio `stop` event
         // (`handleStop`); the provider `closed` event is teardown only.
+        // Treat close as an implicit utterance boundary: flush any buffered
+        // accumulated finals so a mid-utterance hangup is not dropped.
+        this.handleStreamingClose();
         this.streamingReady = false;
         break;
       case "partial":
@@ -591,14 +602,49 @@ export class MediaStreamSttSession {
     // (undefined): flush the accumulated segments plus this one as a single
     // transcript.
     if (text.length > 0) this.streamingUtteranceSegments.push(text);
+    this.flushStreamingUtterance();
+  }
+
+  /**
+   * Flush any accumulated streaming `final` segments as a single
+   * `onTranscriptFinal`, then reset the buffer.
+   *
+   * Used both at a real provider utterance boundary
+   * ({@link handleStreamingFinal}) and on stream teardown
+   * ({@link handleStreamingClose}) — closing the stream is treated as an
+   * implicit utterance boundary so the caller's last partial utterance is not
+   * lost if they hang up mid-sentence before the provider emits its boundary.
+   *
+   * Guards:
+   * - A bare boundary / close with nothing buffered (e.g. a standalone
+   *   Deepgram `UtteranceEnd` after silence, or a close after a real boundary
+   *   already flushed) carries no transcript — drop it rather than firing an
+   *   empty reply.
+   * - The buffer is reset before invoking the callback so a re-entrant teardown
+   *   path cannot double-flush the same text.
+   */
+  private flushStreamingUtterance(): void {
     const combined = this.streamingUtteranceSegments.join(" ");
     this.streamingUtteranceSegments = [];
 
-    // A bare boundary (e.g. UtteranceEnd) with nothing buffered carries no
-    // transcript — drop it rather than firing an empty reply.
     if (combined.length === 0) return;
 
     this.callbacks.onTranscriptFinal?.(combined, 0);
+  }
+
+  /**
+   * Handle stream teardown (transcriber `closed`, `stop()`/{@link handleStop},
+   * or {@link dispose}). Treats the close as an implicit utterance boundary and
+   * flushes any buffered accumulated `final` segments as one
+   * `onTranscriptFinal` before tearing down — otherwise a caller who hangs up
+   * mid-utterance (before the provider emits `speech_final`/`UtteranceEnd`)
+   * would lose their final partial utterance.
+   *
+   * Flushing here resets the buffer, so it is safe to call from multiple
+   * teardown paths: the second call finds an empty buffer and does nothing.
+   */
+  private handleStreamingClose(): void {
+    this.flushStreamingUtterance();
   }
 
   private handleMedia(event: MediaStreamMediaEvent): void {
@@ -738,6 +784,12 @@ export class MediaStreamSttSession {
     if (this.mode === "streaming") {
       // Streaming mode: signal end-of-audio. The transcriber may emit a
       // final transcript and then a `closed` event (which drives onStop).
+      // Treat the stop as an implicit utterance boundary and flush any
+      // buffered accumulated finals first — the provider may close without
+      // emitting a real boundary for the caller's last partial utterance.
+      // flushStreamingUtterance resets the buffer, so the subsequent `closed`
+      // event won't double-flush.
+      this.handleStreamingClose();
       this.streamingTranscriber?.stop();
       this.callbacks.onStop?.();
       return;

--- a/assistant/src/calls/media-stream-stt-session.ts
+++ b/assistant/src/calls/media-stream-stt-session.ts
@@ -782,14 +782,21 @@ export class MediaStreamSttSession {
     // batch, losing the caller's final utterance on short calls / slow
     // handshakes.
     if (this.mode === "streaming") {
-      // Streaming mode: signal end-of-audio. The transcriber may emit a
-      // final transcript and then a `closed` event (which drives onStop).
-      // Treat the stop as an implicit utterance boundary and flush any
-      // buffered accumulated finals first — the provider may close without
-      // emitting a real boundary for the caller's last partial utterance.
-      // flushStreamingUtterance resets the buffer, so the subsequent `closed`
-      // event won't double-flush.
-      this.handleStreamingClose();
+      // Streaming mode: signal end-of-audio. Do NOT pre-flush the buffered
+      // accumulated finals here — when Twilio `stop` arrives the provider may
+      // still hold unprocessed audio. Calling stop() makes the provider
+      // finalize it and emit additional post-stop `final` (and boundary)
+      // results, so flushing before stop() would emit the buffered transcript
+      // too early and split the utterance (an early partial reply, then the
+      // leftover finals arriving afterward).
+      //
+      // Instead, let stop() drain: the post-stop finals flow through the
+      // normal handleStreamingFinal accumulation path, and the provider's
+      // `closed` event (which the Deepgram adapter emits after CloseStream
+      // drains, with a grace-timer backstop) performs the single final flush
+      // of the complete utterance. flushStreamingUtterance resets the buffer,
+      // so a normal boundary that already flushed leaves nothing for the
+      // closed-path flush to double-emit. dispose() is the final backstop.
       this.streamingTranscriber?.stop();
       this.callbacks.onStop?.();
       return;

--- a/assistant/src/calls/media-stream-stt-session.ts
+++ b/assistant/src/calls/media-stream-stt-session.ts
@@ -30,6 +30,7 @@ import type {
   StreamingTranscriber,
   SttCallContextHints,
   SttStreamServerEvent,
+  SttStreamServerFinalEvent,
 } from "../stt/types.js";
 import { getLogger } from "../util/logger.js";
 import { mulawToPcm16, resamplePcm16 } from "./media-stream-audio-transcode.js";
@@ -198,6 +199,22 @@ export class MediaStreamSttSession {
   private streamingReady = false;
 
   /**
+   * Accumulated committed (`final`) transcript segments for the in-progress
+   * caller utterance, awaiting the provider's utterance boundary.
+   *
+   * Some providers (Deepgram) commit multiple per-segment finals within a
+   * single spoken sentence (`is_final`) and only mark the natural pause
+   * separately (`speech_final` / `UtteranceEnd`, surfaced as
+   * `endOfUtterance: true`). Routing every committed segment to
+   * `onTranscriptFinal` would trigger an assistant reply mid-sentence, so we
+   * buffer segments here and flush a single concatenated `onTranscriptFinal`
+   * at the boundary. Providers without a separate boundary signal emit
+   * `endOfUtterance: undefined`, which flushes immediately — preserving the
+   * one-final-per-utterance behavior.
+   */
+  private streamingUtteranceSegments: string[] = [];
+
+  /**
    * Set when a Twilio `stop` arrives (or {@link dispose} is called) while the
    * session is still in `"streaming-pending"` — i.e. before the streaming
    * resolver/`start()` has settled. Once set, the in-flight
@@ -347,6 +364,7 @@ export class MediaStreamSttSession {
     }
     this.streamingReady = false;
     this.streamingStartupBuffer = [];
+    this.streamingUtteranceSegments = [];
   }
 
   // ── Event handlers ─────────────────────────────────────────────────
@@ -516,12 +534,19 @@ export class MediaStreamSttSession {
    * Handle a server event from the streaming transcriber. `onSpeechStart`
    * is driven by local VAD (for barge-in latency), so partials are not
    * surfaced here — only finals, errors, and close.
+   *
+   * `final` segments are gated on the provider's utterance boundary: we
+   * accumulate consecutive committed segments and only flush one
+   * concatenated `onTranscriptFinal` when the segment marks the end of the
+   * utterance (`endOfUtterance !== false`). Providers that do not signal a
+   * separate boundary emit `endOfUtterance: undefined`, so each `final`
+   * flushes immediately — see {@link handleStreamingFinal}.
    */
   private handleStreamingEvent(event: SttStreamServerEvent): void {
     if (this.disposed) return;
     switch (event.type) {
       case "final":
-        this.callbacks.onTranscriptFinal?.(event.text, 0);
+        this.handleStreamingFinal(event);
         break;
       case "error":
         this.callbacks.onError?.(event.category, event.message);
@@ -536,6 +561,44 @@ export class MediaStreamSttSession {
         // fast local VAD instead of waiting for the first partial.
         break;
     }
+  }
+
+  /**
+   * Gate a streaming `final` event on the provider's utterance boundary.
+   *
+   * - `endOfUtterance === false` — mid-utterance committed segment. Buffer the
+   *   text and wait; do NOT fire onTranscriptFinal yet (avoids a mid-sentence
+   *   assistant reply).
+   * - `endOfUtterance === true` or `undefined` — utterance boundary (or a
+   *   provider with no separate boundary signal). Concatenate any buffered
+   *   segments with this one, reset the buffer, and flush a single
+   *   onTranscriptFinal.
+   *
+   * Empty boundary finals with no buffered text (e.g. a standalone Deepgram
+   * `UtteranceEnd` after silence) are dropped so a bare boundary does not emit
+   * an empty transcript.
+   */
+  private handleStreamingFinal(event: SttStreamServerFinalEvent): void {
+    const text = event.text.trim();
+
+    if (event.endOfUtterance === false) {
+      // Mid-utterance committed segment — accumulate, do not flush.
+      if (text.length > 0) this.streamingUtteranceSegments.push(text);
+      return;
+    }
+
+    // Utterance boundary (true) or a provider with no boundary signal
+    // (undefined): flush the accumulated segments plus this one as a single
+    // transcript.
+    if (text.length > 0) this.streamingUtteranceSegments.push(text);
+    const combined = this.streamingUtteranceSegments.join(" ");
+    this.streamingUtteranceSegments = [];
+
+    // A bare boundary (e.g. UtteranceEnd) with nothing buffered carries no
+    // transcript — drop it rather than firing an empty reply.
+    if (combined.length === 0) return;
+
+    this.callbacks.onTranscriptFinal?.(combined, 0);
   }
 
   private handleMedia(event: MediaStreamMediaEvent): void {

--- a/assistant/src/providers/speech-to-text/deepgram-realtime.test.ts
+++ b/assistant/src/providers/speech-to-text/deepgram-realtime.test.ts
@@ -334,6 +334,75 @@ describe("DeepgramRealtimeTranscriber", () => {
     });
   });
 
+  test("emits final with endOfUtterance for speech_final even when is_final is false", async () => {
+    const { events } = await startSession();
+
+    // Deepgram can endpoint an utterance (speech_final:true) on a frame whose
+    // is_final is still false. The words in such a frame are the finalized
+    // endpoint, so it must surface as a `final` with endOfUtterance:true —
+    // NOT be swallowed as a partial — or the accumulation buffer never flushes.
+    mockWs.simulateMessage(
+      resultsFrame("hello world", { is_final: false, speech_final: true }),
+    );
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      type: "final",
+      text: "hello world",
+      endOfUtterance: true,
+      confidence: 0.95,
+    });
+  });
+
+  test("emits exactly one final when both is_final and speech_final are true", async () => {
+    const { events } = await startSession();
+
+    mockWs.simulateMessage(
+      resultsFrame("hello world", { is_final: true, speech_final: true }),
+    );
+
+    // No double-emit: the single final/boundary branch fires once.
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      type: "final",
+      text: "hello world",
+      endOfUtterance: true,
+      confidence: 0.95,
+    });
+  });
+
+  test("emits final with endOfUtterance:false for is_final without speech_final", async () => {
+    const { events } = await startSession();
+
+    // Mid-utterance committed segment — final, but not an utterance boundary.
+    mockWs.simulateMessage(
+      resultsFrame("hello", { is_final: true, speech_final: false }),
+    );
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      type: "final",
+      text: "hello",
+      endOfUtterance: false,
+      confidence: 0.95,
+    });
+  });
+
+  test("emits partial for a pure interim frame (is_final and speech_final both false)", async () => {
+    const { events } = await startSession();
+
+    mockWs.simulateMessage(
+      resultsFrame("hel", { is_final: false, speech_final: false }),
+    );
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      type: "partial",
+      text: "hel",
+      confidence: 0.95,
+    });
+  });
+
   test("handles missing channel field gracefully", async () => {
     const { events } = await startSession();
 

--- a/assistant/src/providers/speech-to-text/deepgram-realtime.test.ts
+++ b/assistant/src/providers/speech-to-text/deepgram-realtime.test.ts
@@ -296,6 +296,7 @@ describe("DeepgramRealtimeTranscriber", () => {
     expect(events[0]).toEqual({
       type: "final",
       text: "hello world",
+      endOfUtterance: true,
       confidence: 0.95,
     });
   });
@@ -309,6 +310,7 @@ describe("DeepgramRealtimeTranscriber", () => {
     expect(events[0]).toEqual({
       type: "final",
       text: "",
+      endOfUtterance: false,
       confidence: 0.95,
     });
   });
@@ -327,6 +329,7 @@ describe("DeepgramRealtimeTranscriber", () => {
     expect(events[0]).toEqual({
       type: "final",
       text: "",
+      endOfUtterance: false,
       confidence: 0.5,
     });
   });
@@ -341,7 +344,11 @@ describe("DeepgramRealtimeTranscriber", () => {
     mockWs.simulateMessage(frame);
 
     expect(events).toHaveLength(1);
-    expect(events[0]).toEqual({ type: "final", text: "" });
+    expect(events[0]).toEqual({
+      type: "final",
+      text: "",
+      endOfUtterance: false,
+    });
   });
 
   // ─────────────────────────────────────────────────────────────────
@@ -358,6 +365,7 @@ describe("DeepgramRealtimeTranscriber", () => {
     expect(events[0]).toEqual({
       type: "final",
       text: "hello world",
+      endOfUtterance: false,
       confidence: 0.95,
     });
     // `in` check: the key must not exist at all, not just be undefined.
@@ -382,6 +390,7 @@ describe("DeepgramRealtimeTranscriber", () => {
     expect(events[0]).toEqual({
       type: "final",
       text: "hello world",
+      endOfUtterance: false,
       speakerLabel: "0",
       confidence: 0.95,
     });
@@ -408,6 +417,7 @@ describe("DeepgramRealtimeTranscriber", () => {
     expect(events[0]).toEqual({
       type: "final",
       text: "yes exactly right here",
+      endOfUtterance: false,
       speakerLabel: "1",
       confidence: 0.95,
     });
@@ -434,6 +444,7 @@ describe("DeepgramRealtimeTranscriber", () => {
     expect(events[0]).toEqual({
       type: "final",
       text: "alpha beta gamma delta",
+      endOfUtterance: false,
       speakerLabel: "2",
       confidence: 0.95,
     });
@@ -475,6 +486,7 @@ describe("DeepgramRealtimeTranscriber", () => {
     expect(events[0]).toEqual({
       type: "final",
       text: "no speakers here",
+      endOfUtterance: false,
       confidence: 0.95,
     });
     expect("speakerLabel" in events[0]).toBe(false);
@@ -553,6 +565,7 @@ describe("DeepgramRealtimeTranscriber", () => {
     expect(events[2]).toEqual({
       type: "final",
       text: "hello world",
+      endOfUtterance: true,
       confidence: 0.95,
     });
   });
@@ -561,12 +574,20 @@ describe("DeepgramRealtimeTranscriber", () => {
   // Non-transcript frames
   // ─────────────────────────────────────────────────────────────────
 
-  test("ignores UtteranceEnd frames (no event emitted)", async () => {
+  test("emits a boundary-only final for UtteranceEnd frames", async () => {
     const { events } = await startSession();
 
     mockWs.simulateMessage(utteranceEndFrame());
 
-    expect(events).toHaveLength(0);
+    // UtteranceEnd marks the natural utterance boundary; we surface it as an
+    // empty-text final with endOfUtterance:true so accumulating consumers
+    // flush the committed segments so far.
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      type: "final",
+      text: "",
+      endOfUtterance: true,
+    });
   });
 
   test("ignores Metadata frames (no event emitted)", async () => {

--- a/assistant/src/providers/speech-to-text/deepgram-realtime.ts
+++ b/assistant/src/providers/speech-to-text/deepgram-realtime.ts
@@ -173,7 +173,10 @@ interface DeepgramStreamChannel {
  *   and will not be revised. When false, the transcript is interim (partial).
  * - `speech_final` — true when Deepgram's endpointing detects a natural
  *   speech pause. Combined with `is_final`, this signals a committed utterance
- *   boundary. We emit a `final` event only when `is_final` is true.
+ *   boundary. We emit a `final` event for every `is_final` segment and set
+ *   `endOfUtterance: true` on it only when `speech_final` is true (or on a
+ *   standalone `UtteranceEnd` frame), so consumers can accumulate
+ *   mid-utterance segments and flush only at the boundary.
  * - `type` — `"Results"` for transcript frames, `"Metadata"` for session info,
  *   `"UtteranceEnd"` for endpointing signals.
  */
@@ -495,12 +498,17 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
       return;
     }
 
-    // `UtteranceEnd` is an endpointing signal — no transcript text, but
-    // it confirms the previous is_final segment is a natural boundary.
-    // We don't need to emit an additional event since we already emit
-    // finals on is_final=true.
+    // `UtteranceEnd` is an endpointing signal carrying no transcript text.
+    // It marks the natural end of the caller's utterance when Deepgram did
+    // NOT already set `speech_final` on the trailing `is_final` segment
+    // (e.g. interim-results disabled, or a barge-in cut the segment short).
+    // We surface it as a boundary-only `final` (empty text,
+    // endOfUtterance=true) so utterance-accumulating consumers flush the
+    // segments committed so far. Consumers that treat each `final` as a
+    // complete utterance ignore empty finals, so this is a no-op for them.
     if (frame.type === "UtteranceEnd") {
       log.debug("Received UtteranceEnd signal");
+      this.emitEvent({ type: "final", text: "", endOfUtterance: true });
       return;
     }
 
@@ -543,10 +551,15 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
         : undefined;
 
     if (frame.is_final) {
-      // Committed transcript — emit as final.
+      // Committed transcript — emit as final. `speech_final` marks Deepgram's
+      // natural utterance boundary (endpointed pause); a bare `is_final`
+      // without `speech_final` is a mid-utterance committed segment. We carry
+      // this through `endOfUtterance` so the consumer can accumulate
+      // mid-utterance segments and only act on the true boundary.
       this.emitEvent({
         type: "final",
         text,
+        endOfUtterance: frame.speech_final === true,
         ...(speakerLabel !== undefined ? { speakerLabel } : {}),
         ...(confidence !== undefined ? { confidence } : {}),
       });

--- a/assistant/src/providers/speech-to-text/deepgram-realtime.ts
+++ b/assistant/src/providers/speech-to-text/deepgram-realtime.ts
@@ -550,12 +550,19 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
         ? alternative.confidence
         : undefined;
 
-    if (frame.is_final) {
-      // Committed transcript — emit as final. `speech_final` marks Deepgram's
-      // natural utterance boundary (endpointed pause); a bare `is_final`
-      // without `speech_final` is a mid-utterance committed segment. We carry
-      // this through `endOfUtterance` so the consumer can accumulate
-      // mid-utterance segments and only act on the true boundary.
+    if (frame.is_final || frame.speech_final === true) {
+      // Committed transcript or endpointed boundary — emit as final.
+      // `speech_final` marks Deepgram's natural utterance boundary
+      // (endpointed pause). Deepgram can set `speech_final: true` while
+      // `is_final` is still false; the words in such a frame are the
+      // finalized endpoint, so we must still emit a `final` with
+      // `endOfUtterance: true` — otherwise the boundary is missed and an
+      // accumulating consumer never flushes the completed utterance. A bare
+      // `is_final` without `speech_final` is a mid-utterance committed
+      // segment (endOfUtterance=false). We carry the boundary through
+      // `endOfUtterance` so the consumer can accumulate mid-utterance
+      // segments and only act on the true boundary. When both flags are
+      // true this branch fires exactly once (no double-emit).
       this.emitEvent({
         type: "final",
         text,

--- a/assistant/src/stt/types.ts
+++ b/assistant/src/stt/types.ts
@@ -263,6 +263,25 @@ export interface SttStreamServerFinalEvent {
    * provider does not surface confidence on this chunk.
    */
   readonly confidence?: number;
+  /**
+   * Whether this `final` segment completes the caller's utterance at the
+   * provider's natural pause/endpoint boundary.
+   *
+   * Some providers (e.g. Deepgram) commit multiple per-segment finals
+   * (`is_final`) within a single spoken sentence and only mark the true
+   * end of the utterance separately (`speech_final` / `UtteranceEnd`).
+   * Consumers that turn a completed utterance into a single reply (e.g. the
+   * media-stream call path) should accumulate consecutive `final` segments
+   * and only act when an utterance boundary is reached:
+   *
+   * - `true`  — this final is the end of the utterance; flush now.
+   * - `false` — this is a mid-utterance committed segment; keep accumulating.
+   * - `undefined` — the provider does not distinguish a separate boundary
+   *   signal, so each `final` is treated as a complete utterance (the
+   *   default behavior, e.g. xAI). This keeps non-boundary providers
+   *   unchanged.
+   */
+  readonly endOfUtterance?: boolean;
 }
 
 /** An error occurred during streaming transcription. */


### PR DESCRIPTION
## Summary
- Streaming media-stream STT now accumulates is_final segments and flushes one onTranscriptFinal at the provider's utterance boundary (Deepgram speech_final/UtteranceEnd), so long sentences don't trigger mid-sentence replies
- Providers without a separate boundary signal keep one-final-per-utterance behavior
Part of plan: migrate-phone-off-conversation-relay.md (deferred refinement)