### PR TITLE
refactor(calls): rename TwilioConversationRelayProvider to TwilioVoiceProvider

### DIFF
--- a/assistant/src/__tests__/call-domain.test.ts
+++ b/assistant/src/__tests__/call-domain.test.ts
@@ -32,7 +32,7 @@ mock.module("../calls/twilio-config.js", () => ({
 }));
 
 mock.module("../calls/twilio-provider.js", () => ({
-  TwilioConversationRelayProvider: class {
+  TwilioVoiceProvider: class {
     async checkCallerIdEligibility(number: string) {
       if (number === "+15550002222") return { eligible: true };
       return {

--- a/assistant/src/__tests__/call-routes-http.test.ts
+++ b/assistant/src/__tests__/call-routes-http.test.ts
@@ -71,7 +71,7 @@ mock.module("../config/loader.js", () => ({
 
 // Mock Twilio provider to avoid real API calls
 mock.module("../calls/twilio-provider.js", () => ({
-  TwilioConversationRelayProvider: class {
+  TwilioVoiceProvider: class {
     static getAuthToken() {
       return "mock-auth-token";
     }

--- a/assistant/src/__tests__/gateway-only-enforcement.test.ts
+++ b/assistant/src/__tests__/gateway-only-enforcement.test.ts
@@ -74,7 +74,7 @@ mock.module("../config/loader.js", () => ({
 
 // Mock Twilio provider
 mock.module("../calls/twilio-provider.js", () => ({
-  TwilioConversationRelayProvider: class {
+  TwilioVoiceProvider: class {
     static getAuthToken() {
       return "mock-auth-token";
     }

--- a/assistant/src/__tests__/guardian-verification-voice-binding.test.ts
+++ b/assistant/src/__tests__/guardian-verification-voice-binding.test.ts
@@ -20,7 +20,7 @@ mock.module("../calls/twilio-config.js", () => ({
 }));
 
 mock.module("../calls/twilio-provider.js", () => ({
-  TwilioConversationRelayProvider: class {
+  TwilioVoiceProvider: class {
     async checkCallerIdEligibility() {
       return { eligible: true };
     }

--- a/assistant/src/__tests__/twilio-provider.test.ts
+++ b/assistant/src/__tests__/twilio-provider.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for TwilioConversationRelayProvider — signature validation,
+ * Tests for TwilioVoiceProvider — signature validation,
  * fail-closed auth token behavior, and caller ID eligibility checks.
  */
 import { createHmac } from "node:crypto";
@@ -32,7 +32,7 @@ mock.module("../security/secure-keys.js", () => ({
   },
 }));
 
-import { TwilioConversationRelayProvider } from "../calls/twilio-provider.js";
+import { TwilioVoiceProvider } from "../calls/twilio-provider.js";
 
 // ── Helpers ────────────────────────────────────────────────────────────
 
@@ -51,7 +51,7 @@ function computeValidSignature(
 
 // ── Tests ──────────────────────────────────────────────────────────────
 
-describe("TwilioConversationRelayProvider", () => {
+describe("TwilioVoiceProvider", () => {
   beforeEach(() => {
     mockAuthToken = "test-auth-token-secret";
     mockAccountSid = "AC_test_account";
@@ -64,7 +64,7 @@ describe("TwilioConversationRelayProvider", () => {
     test("returns true for a valid signature", () => {
       const authToken = "test-auth-token-secret";
       const sig = computeValidSignature(testUrl, testParams, authToken);
-      const result = TwilioConversationRelayProvider.verifyWebhookSignature(
+      const result = TwilioVoiceProvider.verifyWebhookSignature(
         testUrl,
         testParams,
         sig,
@@ -75,7 +75,7 @@ describe("TwilioConversationRelayProvider", () => {
 
     test("returns false for an invalid signature", () => {
       const authToken = "test-auth-token-secret";
-      const result = TwilioConversationRelayProvider.verifyWebhookSignature(
+      const result = TwilioVoiceProvider.verifyWebhookSignature(
         testUrl,
         testParams,
         "invalid-signature-base64",
@@ -91,7 +91,7 @@ describe("TwilioConversationRelayProvider", () => {
         testParams,
         "wrong-token",
       );
-      const result = TwilioConversationRelayProvider.verifyWebhookSignature(
+      const result = TwilioVoiceProvider.verifyWebhookSignature(
         testUrl,
         testParams,
         wrongTokenSig,
@@ -103,7 +103,7 @@ describe("TwilioConversationRelayProvider", () => {
     test("handles empty params", () => {
       const authToken = "test-auth-token-secret";
       const sig = computeValidSignature(testUrl, {}, authToken);
-      const result = TwilioConversationRelayProvider.verifyWebhookSignature(
+      const result = TwilioVoiceProvider.verifyWebhookSignature(
         testUrl,
         {},
         sig,
@@ -116,7 +116,7 @@ describe("TwilioConversationRelayProvider", () => {
       const authToken = "test-auth-token-secret";
       const params = { Zebra: "1", Alpha: "2", Middle: "3" };
       const sig = computeValidSignature(testUrl, params, authToken);
-      const result = TwilioConversationRelayProvider.verifyWebhookSignature(
+      const result = TwilioVoiceProvider.verifyWebhookSignature(
         testUrl,
         params,
         sig,
@@ -129,20 +129,20 @@ describe("TwilioConversationRelayProvider", () => {
   describe("getAuthToken", () => {
     test("returns the auth token when configured", async () => {
       mockAuthToken = "my-secret-token";
-      const token = await TwilioConversationRelayProvider.getAuthToken();
+      const token = await TwilioVoiceProvider.getAuthToken();
       expect(token).toBe("my-secret-token");
     });
 
     test("returns null when auth token is not configured", async () => {
       mockAuthToken = undefined;
-      const token = await TwilioConversationRelayProvider.getAuthToken();
+      const token = await TwilioVoiceProvider.getAuthToken();
       expect(token).toBeNull();
     });
   });
 
   describe("initiateCall", () => {
     test("sends repeated StatusCallbackEvent parameters", async () => {
-      const provider = new TwilioConversationRelayProvider();
+      const provider = new TwilioVoiceProvider();
       const originalFetch = globalThis.fetch;
       let capturedBody = "";
 
@@ -191,7 +191,7 @@ describe("TwilioConversationRelayProvider", () => {
     });
 
     test("returns eligible when number is found in IncomingPhoneNumbers", async () => {
-      const provider = new TwilioConversationRelayProvider();
+      const provider = new TwilioVoiceProvider();
 
       globalThis.fetch = (async (url: RequestInfo | URL): Promise<Response> => {
         const urlStr = String(url);
@@ -217,7 +217,7 @@ describe("TwilioConversationRelayProvider", () => {
     });
 
     test("returns eligible when number is found in OutgoingCallerIds", async () => {
-      const provider = new TwilioConversationRelayProvider();
+      const provider = new TwilioVoiceProvider();
 
       globalThis.fetch = (async (url: RequestInfo | URL): Promise<Response> => {
         const urlStr = String(url);
@@ -245,7 +245,7 @@ describe("TwilioConversationRelayProvider", () => {
     });
 
     test("returns ineligible when number is not found in either endpoint", async () => {
-      const provider = new TwilioConversationRelayProvider();
+      const provider = new TwilioVoiceProvider();
 
       globalThis.fetch = (async (url: RequestInfo | URL): Promise<Response> => {
         const urlStr = String(url);
@@ -269,7 +269,7 @@ describe("TwilioConversationRelayProvider", () => {
     });
 
     test("throws when both API calls return non-ok responses", async () => {
-      const provider = new TwilioConversationRelayProvider();
+      const provider = new TwilioVoiceProvider();
 
       globalThis.fetch = (async (url: RequestInfo | URL): Promise<Response> => {
         const urlStr = String(url);
@@ -288,7 +288,7 @@ describe("TwilioConversationRelayProvider", () => {
     });
 
     test("throws when only one API call fails but the other succeeds with no match", async () => {
-      const provider = new TwilioConversationRelayProvider();
+      const provider = new TwilioVoiceProvider();
 
       globalThis.fetch = (async (url: RequestInfo | URL): Promise<Response> => {
         const urlStr = String(url);
@@ -309,7 +309,7 @@ describe("TwilioConversationRelayProvider", () => {
     });
 
     test("passes correct phone number as query parameter", async () => {
-      const provider = new TwilioConversationRelayProvider();
+      const provider = new TwilioVoiceProvider();
       const capturedUrls: string[] = [];
 
       globalThis.fetch = (async (url: RequestInfo | URL): Promise<Response> => {

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -197,7 +197,7 @@ mock.module("../security/secure-keys.js", () => ({
 }));
 
 mock.module("../calls/twilio-provider.js", () => ({
-  TwilioConversationRelayProvider: class {
+  TwilioVoiceProvider: class {
     readonly name = "twilio";
     static getAuthToken(): string | null {
       return null;

--- a/assistant/src/__tests__/twilio-validation.test.ts
+++ b/assistant/src/__tests__/twilio-validation.test.ts
@@ -20,7 +20,7 @@ mock.module("../config/loader.js", () => ({
 }));
 
 mock.module("../calls/twilio-provider.js", () => ({
-  TwilioConversationRelayProvider: class {
+  TwilioVoiceProvider: class {
     static getAuthToken() {
       return "test-auth-token";
     }

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -45,7 +45,7 @@ import {
   resolveTelephonyCredentialReadiness,
 } from "./telephony-credential-preflight.js";
 import { getTwilioConfig } from "./twilio-config.js";
-import { TwilioConversationRelayProvider } from "./twilio-provider.js";
+import { TwilioVoiceProvider } from "./twilio-provider.js";
 import { outboundWillUseMediaStream } from "./twilio-routes.js";
 import type { CallSession } from "./types.js";
 import { preflightVoiceIngress } from "./voice-ingress-preflight.js";
@@ -233,7 +233,7 @@ export async function resolveCallerIdentity(
   }
 
   // Verify the user number is eligible as a caller ID with Twilio
-  const provider = new TwilioConversationRelayProvider();
+  const provider = new TwilioVoiceProvider();
   const eligibility = await provider.checkCallerIdEligibility(userNumber);
   if (!eligibility.eligible) {
     log.warn(
@@ -438,7 +438,7 @@ export async function startCall(
     }
 
     const ingressConfig = preflightResult.ingressConfig;
-    const provider = new TwilioConversationRelayProvider();
+    const provider = new TwilioVoiceProvider();
 
     const session = createCallSession({
       conversationId,
@@ -701,7 +701,7 @@ export async function cancelCall(
   // Terminate the call via the provider API
   if (session.providerCallSid) {
     try {
-      const provider = new TwilioConversationRelayProvider();
+      const provider = new TwilioVoiceProvider();
       await provider.endCall(session.providerCallSid);
     } catch (endErr) {
       log.warn(
@@ -964,7 +964,7 @@ export async function startVerificationCall(
 
   try {
     const config = loadConfig();
-    const provider = new TwilioConversationRelayProvider();
+    const provider = new TwilioVoiceProvider();
 
     // Resolve the assistant's Twilio number as the caller ID
     const identityResult = await resolveCallerIdentity(config);
@@ -1096,7 +1096,7 @@ export async function startInviteCall(
 
   try {
     const config = loadConfig();
-    const provider = new TwilioConversationRelayProvider();
+    const provider = new TwilioVoiceProvider();
 
     // Resolve the assistant's Twilio number as the caller ID
     const identityResult = await resolveCallerIdentity(config);

--- a/assistant/src/calls/twilio-provider.ts
+++ b/assistant/src/calls/twilio-provider.ts
@@ -14,12 +14,14 @@ import type { InitiateCallOptions, VoiceProvider } from "./voice-provider.js";
 const log = getLogger("twilio-provider");
 
 /**
- * Twilio ConversationRelay voice provider.
+ * Twilio voice provider.
  *
- * Uses the Twilio REST API directly via fetch() — no twilio npm package.
- * Credentials are resolved lazily from config on each call.
+ * Owns the generic Twilio integration: outbound call initiation via the
+ * Twilio REST API (no twilio npm package — direct fetch()) and inbound
+ * webhook HMAC signature verification. Credentials are resolved lazily
+ * from config on each call.
  */
-export class TwilioConversationRelayProvider implements VoiceProvider {
+export class TwilioVoiceProvider implements VoiceProvider {
   readonly name = "twilio";
 
   // ── Credential helpers ──────────────────────────────────────────────

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -6,7 +6,7 @@ import { refreshBackgroundWakeIntent } from "../background-wake/publisher.js";
 import { registerBackgroundWakeRuntime } from "../background-wake/runtime-registry.js";
 import { setPointerMessageProcessor } from "../calls/call-pointer-messages.js";
 import { reconcileCallsOnStartup } from "../calls/call-recovery.js";
-import { TwilioConversationRelayProvider } from "../calls/twilio-provider.js";
+import { TwilioVoiceProvider } from "../calls/twilio-provider.js";
 import { setVoiceBridgeDeps } from "../calls/voice-session-bridge.js";
 import { initFeatureFlagOverrides } from "../config/assistant-feature-flags.js";
 import {
@@ -536,7 +536,7 @@ export async function runDaemon(): Promise<void> {
       }
 
       try {
-        const twilioProvider = new TwilioConversationRelayProvider();
+        const twilioProvider = new TwilioVoiceProvider();
         await reconcileCallsOnStartup(twilioProvider, log);
       } catch (err) {
         log.warn({ err }, "Call recovery failed — continuing startup");

--- a/assistant/src/runtime/middleware/twilio-validation.ts
+++ b/assistant/src/runtime/middleware/twilio-validation.ts
@@ -2,7 +2,7 @@
  * Twilio webhook signature validation and related constants.
  */
 
-import { TwilioConversationRelayProvider } from "../../calls/twilio-provider.js";
+import { TwilioVoiceProvider } from "../../calls/twilio-provider.js";
 import { loadConfig } from "../../config/loader.js";
 import { getPublicBaseUrl } from "../../inbound/public-ingress-urls.js";
 import { getLogger } from "../../util/logger.js";
@@ -57,7 +57,7 @@ export async function validateTwilioWebhook(
 ): Promise<{ body: string } | Response> {
   const rawBody = await req.text();
 
-  const authToken = await TwilioConversationRelayProvider.getAuthToken();
+  const authToken = await TwilioVoiceProvider.getAuthToken();
 
   if (!authToken) {
     log.error(
@@ -95,7 +95,7 @@ export async function validateTwilioWebhook(
     ? publicBaseUrl + parsedUrl.pathname + parsedUrl.search
     : req.url;
 
-  const isValid = TwilioConversationRelayProvider.verifyWebhookSignature(
+  const isValid = TwilioVoiceProvider.verifyWebhookSignature(
     publicUrl,
     params,
     signature,


### PR DESCRIPTION
## Summary
- Rename the generic Twilio REST/signature provider (initiateCall + webhook HMAC) to a neutral name; ConversationRelayTransport was already removed in PR 13
- Pure rename + doc update; all references updated
Part of plan: migrate-phone-off-conversation-relay.md (PR 15 of 18)