### PR TITLE
fix(macos): patch single conversation row on narrow sync tags instead of full list refetch

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationListStore.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationListStore.swift
@@ -1241,6 +1241,39 @@ final class ConversationListStore {
         conversations[index] = conversation
     }
 
+    /// Patch a single conversation row in place from a server item, used for
+    /// narrow `conversation:<id>:metadata` sync tags (seen / rename /
+    /// attention / title). Rebuilds the row from the item — preserving the
+    /// local identity, creation time, and archive state — then reconciles
+    /// attention, mirroring the existing-row branch of `appendConversations`.
+    ///
+    /// This is the cheap alternative to draining the full paginated list (3
+    /// parallel streams over every conversation) when only one existing row's
+    /// content changed. No-ops when the row isn't loaded locally: a narrow
+    /// metadata tag only updates a row that already exists, and brand-new rows
+    /// arrive via the shape-changing `conversations:list` tag instead.
+    func mergeConversationRow(from item: ConversationListResponseItem) {
+        guard let index = conversations.firstIndex(where: { $0.conversationId == item.id }) else { return }
+        let existing = conversations[index]
+        var updated = conversationModel(
+            from: item,
+            localId: existing.id,
+            createdAt: existing.createdAt,
+            isArchived: existing.isArchived
+        )
+        // Preserve a user-set local title, adopting the server title only when
+        // the local row still has the placeholder name. Matches the existing-row
+        // merge in `handleConversationListResponse` and avoids clobbering an
+        // optimistic local rename the daemon hasn't persisted yet; genuine
+        // renames arrive via the dedicated `conversation_title_updated` event.
+        if existing.title != "New Conversation" {
+            updated.title = existing.title
+        }
+        applyAssistantAttention(from: item, into: &updated)
+        guard updated != existing else { return }
+        conversations[index] = updated
+    }
+
     // MARK: - Signal Emission
 
     /// Send a `conversation_seen_signal` message to the daemon.

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -427,6 +427,10 @@ final class ConversationManager: ConversationRestorerDelegate {
         listStore.applyAssistantAttention(from: item, into: &conversation)
     }
 
+    func mergeConversationRow(from item: ConversationListResponseItem) {
+        listStore.mergeConversationRow(from: item)
+    }
+
     func handleSyncRoutes(_ routes: [SyncTagRoute]) {
         conversationRestorer.handleSyncRoutes(
             routes,

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
@@ -50,6 +50,10 @@ protocol ConversationRestorerDelegate: AnyObject {
         from item: ConversationListResponseItem,
         into conversation: inout ConversationModel
     )
+    /// Patch a single already-loaded conversation row from a server item,
+    /// used for narrow per-conversation metadata sync tags so the client
+    /// avoids refetching the entire paginated list.
+    func mergeConversationRow(from item: ConversationListResponseItem)
 }
 
 /// Handles daemon conversation restoration: fetching the conversation list on connect,
@@ -77,6 +81,7 @@ final class ConversationRestorer {
     private let eventStreamClient: EventStreamClient
     private let conversationListClient: any ConversationListClientProtocol
     private let conversationHistoryClient: any ConversationHistoryClientProtocol
+    private let conversationDetailClient: any ConversationDetailClientProtocol
     private var disconnectObservationTask: Task<Void, Never>?
     private var fetchConversationListTask: Task<Void, Never>?
     /// Debounce task for `conversation_list_invalidated` refetch.
@@ -104,12 +109,14 @@ final class ConversationRestorer {
         connectionManager: GatewayConnectionManager,
         eventStreamClient: EventStreamClient,
         conversationHistoryClient: any ConversationHistoryClientProtocol = ConversationHistoryClient(),
-        conversationListClient: any ConversationListClientProtocol = ConversationListClient()
+        conversationListClient: any ConversationListClientProtocol = ConversationListClient(),
+        conversationDetailClient: any ConversationDetailClientProtocol = ConversationDetailClient()
     ) {
         self.connectionManager = connectionManager
         self.eventStreamClient = eventStreamClient
         self.conversationHistoryClient = conversationHistoryClient
         self.conversationListClient = conversationListClient
+        self.conversationDetailClient = conversationDetailClient
     }
 
     deinit {
@@ -294,11 +301,22 @@ final class ConversationRestorer {
         for route in routes {
             switch route {
             case .conversationList:
+                // Shape change (created / deleted / reordered): the *set* of
+                // rows changed, so the paginated list must be refetched.
                 shouldRefetchConversationList = true
-            case .conversationMetadata:
-                shouldRefetchConversationList = true
+            case .conversationMetadata(let conversationId):
+                // Content-only change to one existing row (seen / rename /
+                // attention). Patch just that row via a single
+                // `GET /v1/conversations/:id` instead of draining the full
+                // paginated list (3 parallel streams over every conversation),
+                // which is what otherwise exhausts the daemon's per-client
+                // request budget and 429s the app. Mirrors web's single-row
+                // GET-and-patch.
+                refreshConversationRow(conversationId: conversationId)
             case .conversationMessages(let conversationId):
-                shouldRefetchConversationList = true
+                // A messages-only change doesn't alter the list shape, so it
+                // must not trigger a full list refetch — only the active
+                // conversation needs its history reconciled.
                 guard activeConversationId == conversationId else { continue }
                 requestReconnectHistory(conversationId: conversationId)
             case .assistantAvatar, .assistantIdentity, .assistantConfig, .assistantSounds, .assistantSchedules:
@@ -308,6 +326,20 @@ final class ConversationRestorer {
 
         if shouldRefetchConversationList {
             scheduleInvalidationRefetch()
+        }
+    }
+
+    /// Fetch a single conversation and patch its sidebar row in place. Used for
+    /// narrow `conversation:<id>:metadata` sync tags so a content-only change
+    /// to one row costs one request instead of a full paginated list drain.
+    /// No-ops silently when the fetch fails or the row isn't loaded locally —
+    /// a subsequent shape-changing `conversations:list` tag or cold restore
+    /// reconciles anything missed.
+    private func refreshConversationRow(conversationId: String) {
+        Task { [weak self] in
+            guard let self else { return }
+            guard let item = await self.conversationDetailClient.fetchConversation(conversationId: conversationId) else { return }
+            self.delegate?.mergeConversationRow(from: item)
         }
     }
 

--- a/clients/macos/vellum-assistantTests/ConversationRestorerTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationRestorerTests.swift
@@ -19,6 +19,7 @@ final class MockConversationRestorerDelegate: ConversationRestorerDelegate {
     var createConversationCallCount = 0
     var archivedConversationIds: Set<String> = []
     var loadedHistoryReconciliationRequests: [(localId: UUID, daemonConversationId: String)] = []
+    var mergedConversationRows: [ConversationListResponseItem] = []
     private let connectionManager: GatewayConnectionManager
     private let eventStreamClient: EventStreamClient
 
@@ -107,6 +108,17 @@ final class MockConversationRestorerDelegate: ConversationRestorerDelegate {
         applyAssistantAttention(from: item, into: &conversation)
         conversations[index] = conversation
     }
+
+    func mergeConversationRow(from item: ConversationListResponseItem) {
+        mergedConversationRows.append(item)
+        guard let index = conversations.firstIndex(where: { $0.conversationId == item.id }) else { return }
+        var conversation = conversations[index]
+        if conversation.title == "New Conversation" {
+            conversation.title = item.title
+        }
+        applyAssistantAttention(from: item, into: &conversation)
+        conversations[index] = conversation
+    }
 }
 
 private struct NoopConversationHistoryClient: ConversationHistoryClientProtocol {
@@ -144,6 +156,23 @@ private actor RecordingConversationListClient: ConversationListClientProtocol {
     func searchConversations(query: String, limit: Int?, maxMessagesPerConversation: Int?) async -> ConversationSearchResponse? { nil }
     func reorderConversations(updates: [ReorderConversationsRequestUpdate]) async -> Bool { true }
     func sendConversationSeen(_ signal: ConversationSeenSignal) async -> Bool { true }
+}
+
+/// Records single-conversation fetches and returns a preconfigured item per id,
+/// so tests can assert a metadata sync tag patches one row instead of draining
+/// the full paginated list.
+private actor RecordingConversationDetailClient: ConversationDetailClientProtocol {
+    private(set) var fetchedConversationIds: [String] = []
+    private let items: [String: ConversationListResponseItem]
+
+    init(items: [String: ConversationListResponseItem] = [:]) {
+        self.items = items
+    }
+
+    func fetchConversation(conversationId: String) async -> ConversationListResponseItem? {
+        fetchedConversationIds.append(conversationId)
+        return items[conversationId]
+    }
 }
 
 /// Mock that returns paged responses (`hasMore=true` until the configured
@@ -270,6 +299,17 @@ private func makeConversationTitleUpdated(conversationId: String, title: String)
     let dict: [String: Any] = ["type": "conversation_title_updated", "conversationId": conversationId, "title": title]
     let data = try! JSONSerialization.data(withJSONObject: dict)
     return try! JSONDecoder().decode(ConversationTitleUpdatedMessage.self, from: data)
+}
+
+/// Build a single ConversationListResponseItem via JSON round-trip, used to
+/// stub `RecordingConversationDetailClient` responses.
+private func makeConversationItem(id: String, title: String, updatedAt: Int = 1_700_000_000, hasUnseen: Bool? = nil) -> ConversationListResponseItem {
+    var dict: [String: Any] = ["id": id, "title": title, "updatedAt": updatedAt]
+    if let hasUnseen {
+        dict["assistantAttention"] = ["hasUnseenLatestAssistantMessage": hasUnseen]
+    }
+    let data = try! JSONSerialization.data(withJSONObject: dict)
+    return try! JSONDecoder().decode(ConversationListResponseItem.self, from: data)
 }
 
 // MARK: - Tests
@@ -950,7 +990,7 @@ struct ConversationRestorerTests {
     }
 
     @Test @MainActor
-    func syncMessageRouteQueuesActiveConversationHistoryAndRefreshesList() async {
+    func syncMessageRouteQueuesActiveConversationHistoryWithoutListRefetch() async {
         let dc = GatewayConnectionManager()
         let listClient = RecordingConversationListClient()
         let restorer = ConversationRestorer(
@@ -974,14 +1014,73 @@ struct ConversationRestorerTests {
             activeConversationId: "conv-active"
         )
 
+        // Only the active conversation's history is reconciled.
         #expect(restorer.pendingHistoryByConversationId["conv-active"] == active.id)
         #expect(restorer.pendingHistoryByConversationId["conv-inactive"] == nil)
 
         try? await Task.sleep(nanoseconds: 500_000_000)
-        // Three parallel streams on cold restore: foreground (active),
-        // background (active), and archived. See
-        // `fetchConversationList` in ConversationRestorer.swift.
+        // A messages-only change doesn't alter the list shape, so the full
+        // paginated list is never refetched (previously this drained 3 streams).
+        #expect(await listClient.fetchRequests.isEmpty)
+    }
+
+    @Test @MainActor
+    func syncMetadataRoutePatchesSingleRowWithoutListRefetch() async {
+        let dc = GatewayConnectionManager()
+        let listClient = RecordingConversationListClient()
+        let detailClient = RecordingConversationDetailClient(items: [
+            "conv-1": makeConversationItem(id: "conv-1", title: "Renamed", updatedAt: 5_000, hasUnseen: true)
+        ])
+        let restorer = ConversationRestorer(
+            connectionManager: dc,
+            eventStreamClient: dc.eventStreamClient,
+            conversationHistoryClient: NoopConversationHistoryClient(),
+            conversationListClient: listClient,
+            conversationDetailClient: detailClient
+        )
+        let delegate = MockConversationRestorerDelegate(connectionManager: dc, eventStreamClient: dc.eventStreamClient)
+        restorer.delegate = delegate
+
+        let conversation = ConversationModel(title: "Original", conversationId: "conv-1")
+        delegate.conversations = [conversation]
+
+        restorer.handleSyncRoutes([.conversationMetadata(conversationId: "conv-1")], activeConversationId: nil)
+
+        try? await Task.sleep(nanoseconds: 500_000_000)
+
+        // The single-conversation endpoint was hit for exactly the changed row...
+        #expect(await detailClient.fetchedConversationIds == ["conv-1"])
+        // ...and the full paginated list was NOT refetched.
+        #expect(await listClient.fetchRequests.isEmpty)
+        // The row was patched in place (attention merged from the fetched item).
+        #expect(delegate.mergedConversationRows.map(\.id) == ["conv-1"])
+        #expect(delegate.conversations.first(where: { $0.conversationId == "conv-1" })?.hasUnseenLatestAssistantMessage == true)
+    }
+
+    @Test @MainActor
+    func syncConversationListRouteTriggersFullRefetchNotSingleRow() async {
+        let dc = GatewayConnectionManager()
+        let listClient = RecordingConversationListClient()
+        let detailClient = RecordingConversationDetailClient()
+        let restorer = ConversationRestorer(
+            connectionManager: dc,
+            eventStreamClient: dc.eventStreamClient,
+            conversationHistoryClient: NoopConversationHistoryClient(),
+            conversationListClient: listClient,
+            conversationDetailClient: detailClient
+        )
+        let delegate = MockConversationRestorerDelegate(connectionManager: dc, eventStreamClient: dc.eventStreamClient)
+        restorer.delegate = delegate
+
+        restorer.handleSyncRoutes([.conversationList], activeConversationId: nil)
+
+        try? await Task.sleep(nanoseconds: 500_000_000)
+
+        // A shape change refetches the full list (3 parallel streams: foreground,
+        // background, archived)...
         #expect(await listClient.fetchRequests.count == 3)
+        // ...and never falls back to the single-conversation endpoint.
+        #expect(await detailClient.fetchedConversationIds.isEmpty)
     }
 
     @Test @MainActor


### PR DESCRIPTION
## Summary
- macOS refetched the full paginated conversation list (~80 `GET /v1/conversations` requests across 3 parallel streams over 10k+ conversations) on *any* conversation sync tag, including the narrow per-conversation `metadata`/`messages` tags the daemon sends precisely to avoid full refetches. A few content-only changes per minute (seen/rename/attention, fired every turn) exhausted the daemon's 300 req/min per-IP limit and 429'd the whole app (all endpoints share one loopback bucket).
- Narrow `conversationMetadata` tags now patch a single row via `GET /v1/conversations/:id` (`ConversationDetailClient`) + an in-place merge mirroring the existing-row path in `appendConversations`/`handleConversationListResponse` (preserves local identity, archive state, and optimistic titles).
- `conversationMessages` tags no longer trigger a list refetch — only the active conversation's history is reconciled. Only the broad `conversationList` tag (created/deleted/reordered) still does a full refetch.
- Cold-start drain and `ConversationListStore` "load more" paths are unchanged.

## Original prompt
While investigating 429s from the daemon when running the macOS Swift app, we traced them to a `GET /v1/conversations` storm: the per-IP limiter (`rate-limiter.ts`, 300 req/min authenticated) was being exhausted because the macOS client did a full paginated list refetch on every conversation sync invalidation — amplified ~80x by pagination over 10k+ conversations. This is fix #1 of the plan: route the narrow per-conversation tags to a single-row fetch-and-patch so only genuine list-shape changes refetch the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)