### PR TITLE
refactor(service-contracts): drop Twilio relay ingress URL/path

### DIFF
--- a/assistant/src/__tests__/public-ingress-urls.test.ts
+++ b/assistant/src/__tests__/public-ingress-urls.test.ts
@@ -33,7 +33,6 @@ import {
   getTelegramWebhookUrl,
   getTwilioConnectActionUrl,
   getTwilioMediaStreamUrl,
-  getTwilioRelayUrl,
   getTwilioStatusCallbackUrl,
   getTwilioVoiceWebhookUrl,
 } from "../inbound/public-ingress-urls.js";
@@ -66,7 +65,6 @@ describe("IngressConfigSchema", () => {
       }),
     ).toThrow(/ingress\.publicBaseUrl must be an absolute URL/);
   });
-
 });
 
 // ---------------------------------------------------------------------------
@@ -217,9 +215,6 @@ describe("Twilio URL builders use publicBaseUrl", () => {
     expect(getTwilioConnectActionUrl(config)).toBe(
       "https://example.com/webhooks/twilio/connect-action",
     );
-    expect(getTwilioRelayUrl(config)).toBe(
-      "wss://example.com/webhooks/twilio/relay",
-    );
     expect(getTwilioMediaStreamUrl(config)).toBe(
       "wss://example.com/webhooks/twilio/media-stream",
     );
@@ -301,33 +296,6 @@ describe("getTwilioConnectActionUrl", () => {
       ingress: { publicBaseUrl: "https://example.com" },
     });
     expect(url).toBe("https://example.com/webhooks/twilio/connect-action");
-  });
-});
-
-// ---------------------------------------------------------------------------
-// getTwilioRelayUrl — scheme conversion
-// ---------------------------------------------------------------------------
-
-describe("getTwilioRelayUrl", () => {
-  test("converts https to wss", () => {
-    const url = getTwilioRelayUrl({
-      ingress: { publicBaseUrl: "https://example.com" },
-    });
-    expect(url).toBe("wss://example.com/webhooks/twilio/relay");
-  });
-
-  test("converts http to ws", () => {
-    const url = getTwilioRelayUrl({
-      ingress: { publicBaseUrl: "http://localhost:7821" },
-    });
-    expect(url).toBe("ws://localhost:7821/webhooks/twilio/relay");
-  });
-
-  test("normalizes trailing slash before conversion", () => {
-    const url = getTwilioRelayUrl({
-      ingress: { publicBaseUrl: "https://example.com/" },
-    });
-    expect(url).toBe("wss://example.com/webhooks/twilio/relay");
   });
 });
 

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -297,11 +297,6 @@ mock.module("../inbound/platform-callback-registration.js", () => ({
 }));
 
 mock.module("../inbound/public-ingress-urls.js", () => ({
-  getTwilioRelayUrl: (ingressConfig: unknown) => {
-    const base = resolveIngressBaseUrlFromConfig(ingressConfig);
-    const wsBase = base.replace(/^http(s?)/, "ws$1");
-    return `${wsBase}/webhooks/twilio/relay`;
-  },
   getTwilioMediaStreamUrl: (ingressConfig: unknown) => {
     const base = resolveIngressBaseUrlFromConfig(ingressConfig);
     const wsBase = base.replace(/^http(s?)/, "ws$1");

--- a/assistant/src/inbound/public-ingress-urls.ts
+++ b/assistant/src/inbound/public-ingress-urls.ts
@@ -30,7 +30,6 @@
 import {
   buildTwilioConnectActionUrl,
   buildTwilioMediaStreamUrl,
-  buildTwilioRelayUrl,
   buildTwilioStatusWebhookUrl,
   buildTwilioVoiceWebhookUrl,
   normalizePublicBaseUrl,
@@ -92,10 +91,7 @@ export function getTwilioVoiceWebhookUrl(
   config: IngressConfig,
   callSessionId?: string,
 ): string {
-  return buildTwilioVoiceWebhookUrl(
-    getPublicBaseUrl(config),
-    callSessionId,
-  );
+  return buildTwilioVoiceWebhookUrl(getPublicBaseUrl(config), callSessionId);
 }
 
 /**
@@ -110,14 +106,6 @@ export function getTwilioStatusCallbackUrl(config: IngressConfig): string {
  */
 export function getTwilioConnectActionUrl(config: IngressConfig): string {
   return buildTwilioConnectActionUrl(getPublicBaseUrl(config));
-}
-
-/**
- * Build the Twilio ConversationRelay WebSocket URL.
- * Converts http:// → ws:// and https:// → wss://.
- */
-export function getTwilioRelayUrl(config: IngressConfig): string {
-  return buildTwilioRelayUrl(getPublicBaseUrl(config));
 }
 
 /**

--- a/packages/service-contracts/src/__tests__/ingress.test.ts
+++ b/packages/service-contracts/src/__tests__/ingress.test.ts
@@ -8,7 +8,6 @@ import {
   buildTwilioConnectActionUrl,
   buildTwilioMediaStreamUrl,
   buildTwilioPhoneNumberWebhookUrls,
-  buildTwilioRelayUrl,
   buildTwilioVoiceWebhookUrl,
   resolveTwilioPublicBaseUrl,
 } from "../twilio-ingress.js";
@@ -92,9 +91,6 @@ describe("Twilio ingress helpers", () => {
     );
     expect(buildTwilioConnectActionUrl("https://example.test")).toBe(
       "https://example.test/webhooks/twilio/connect-action",
-    );
-    expect(buildTwilioRelayUrl("https://example.test")).toBe(
-      "wss://example.test/webhooks/twilio/relay",
     );
     expect(buildTwilioMediaStreamUrl("http://example.test")).toBe(
       "ws://example.test/webhooks/twilio/media-stream",

--- a/packages/service-contracts/src/twilio-ingress.ts
+++ b/packages/service-contracts/src/twilio-ingress.ts
@@ -4,7 +4,6 @@ export const TWILIO_VOICE_WEBHOOK_PATH = "/webhooks/twilio/voice";
 export const TWILIO_STATUS_WEBHOOK_PATH = "/webhooks/twilio/status";
 export const TWILIO_CONNECT_ACTION_WEBHOOK_PATH =
   "/webhooks/twilio/connect-action";
-export const TWILIO_RELAY_WEBHOOK_PATH = "/webhooks/twilio/relay";
 export const TWILIO_MEDIA_STREAM_WEBHOOK_PATH = "/webhooks/twilio/media-stream";
 
 /**
@@ -13,9 +12,9 @@ export const TWILIO_MEDIA_STREAM_WEBHOOK_PATH = "/webhooks/twilio/media-stream";
  * with the actual public URL (from Velay registration, config, or the
  * `X-Vellum-Ingress-URL` header) before returning TwiML to Twilio.
  *
- * The placeholder uses `https://` so that `buildTwilioRelayUrl` /
- * `buildTwilioMediaStreamUrl` can apply the standard `http→ws` scheme
- * conversion, producing `wss://__VELLUM_PUBLIC_BASE_URL__/…` in the output.
+ * The placeholder uses `https://` so that `buildTwilioMediaStreamUrl` can
+ * apply the standard `http→ws` scheme conversion, producing
+ * `wss://__VELLUM_PUBLIC_BASE_URL__/…` in the output.
  */
 export const TWILIO_PUBLIC_BASE_URL_PLACEHOLDER =
   "https://__VELLUM_PUBLIC_BASE_URL__";
@@ -60,10 +59,6 @@ export function buildTwilioStatusWebhookUrl(baseUrl: string): string {
 
 export function buildTwilioConnectActionUrl(baseUrl: string): string {
   return `${baseUrl}${TWILIO_CONNECT_ACTION_WEBHOOK_PATH}`;
-}
-
-export function buildTwilioRelayUrl(baseUrl: string): string {
-  return `${toTwilioWebSocketBaseUrl(baseUrl)}${TWILIO_RELAY_WEBHOOK_PATH}`;
 }
 
 export function buildTwilioMediaStreamUrl(baseUrl: string): string {


### PR DESCRIPTION
## Summary
- Remove buildTwilioRelayUrl + TWILIO_RELAY_WEBHOOK_PATH from service-contracts and getTwilioRelayUrl (+ import) from public-ingress-urls
- Keep media-stream + voice/status + connect-action (connect-action removed in PR 18)
Part of plan: migrate-phone-off-conversation-relay.md (PR 17 of 18)