### PR TITLE
[codex] Add costs to LLM inspector call cards

### DIFF
--- a/apps/web/src/domains/chat/inspector/components/call-rail.test.tsx
+++ b/apps/web/src/domains/chat/inspector/components/call-rail.test.tsx
@@ -48,6 +48,7 @@ function makeRealEntry(overrides: Partial<LLMRequestLogEntry> = {}): LLMRequestL
     summary: {
       provider: "anthropic",
       model: "claude-sonnet-4",
+      estimatedCostUsd: 0.0123,
     },
     ...overrides,
   };
@@ -84,6 +85,8 @@ describe("CallRail — synthetic vs real rows", () => {
     // title-cases the known providers, so we assert on "Anthropic".
     expect(html).toContain("Anthropic");
     expect(html).toContain("claude-sonnet-4");
+    expect(html).toContain("Cost");
+    expect(html).toContain("$0.0123");
     // The warning border token must NOT appear for a real call.
     expect(html).not.toContain("var(--system-negative-strong)");
   });
@@ -136,6 +139,8 @@ describe("CallRail — synthetic vs real rows", () => {
       makeRealEntry({ summary: null, callSite: "mainAgent" }),
     ]);
     expect(html).toContain("Unrecognized call");
+    expect(html).toContain("Cost");
+    expect(html).toContain("Unavailable");
     expect(html).not.toContain("var(--system-negative-strong)");
   });
 });

--- a/apps/web/src/domains/chat/inspector/components/call-rail.tsx
+++ b/apps/web/src/domains/chat/inspector/components/call-rail.tsx
@@ -5,6 +5,7 @@ import { Link } from "react-router";
 import {
   displayProvider,
   displayText,
+  formatCost,
   formattedCreatedAt,
   MISSING_VALUE,
 } from "@/domains/chat/inspector/inspector-formatters";
@@ -97,6 +98,7 @@ function CallRow({
 }: CallRowProps): ReactNode {
   const isSynthetic = isSyntheticAgentErrorMessage(entry);
   const subtitle = buildCallSubtitle(entry) ?? "Unrecognized call";
+  const estimatedCost = formatCost(entry.summary?.estimatedCostUsd ?? null);
 
   // Synthetic rows (e.g. budget_yield_unrecovered) represent agent-loop
   // error messages with no LLM call backing them. Render with a
@@ -114,7 +116,7 @@ function CallRow({
       to={href}
       onClick={onSelect}
       aria-current={isSelected ? "page" : undefined}
-      className="flex flex-col gap-1 rounded-md p-3 text-left no-underline transition-colors hover:opacity-90"
+      className="flex flex-col gap-2 rounded-md p-3 text-left no-underline transition-colors hover:opacity-90"
       style={{
         background: isSelected
           ? "var(--surface-active)"
@@ -142,8 +144,11 @@ function CallRow({
         </span>
         {isLatest ? (
           <span
-            className="text-label-default"
-            style={{ color: "var(--primary-default, var(--content-default))" }}
+            className="rounded-[4px] px-1.5 py-0.5 text-label-default"
+            style={{
+              background: "var(--surface-base)",
+              color: "var(--primary-default, var(--content-default))",
+            }}
           >
             Latest
           </span>
@@ -160,10 +165,22 @@ function CallRow({
         {subtitle}
       </div>
       <div
-        className="text-label-default"
+        className="flex flex-wrap items-center gap-x-2 gap-y-1 text-label-default"
         style={{ color: "var(--content-tertiary)" }}
       >
-        {formattedCreatedAt(entry.createdAt)}
+        <span
+          className="inline-flex items-baseline gap-1 rounded-[4px] px-1.5 py-0.5"
+          style={{
+            background: "var(--surface-base)",
+            color: "var(--content-default)",
+          }}
+        >
+          <span style={{ color: "var(--content-secondary)" }}>Cost</span>
+          <span className="font-medium">{estimatedCost}</span>
+        </span>
+        <span className="min-w-0 flex-1 text-right">
+          {formattedCreatedAt(entry.createdAt)}
+        </span>
       </div>
     </Link>
   );


### PR DESCRIPTION
## What changed

- Added an estimated-cost slot to each LLM context inspector call rail card.
- Reworked the rail card footer so cost and timestamp fit cleanly at inspector rail width.
- Added component coverage for priced and unpriced call-card states.

## Why

The LLM context inspector card rail showed call identity and timing, but the per-call cost was only available deeper in the Overview tab. Surfacing cost on every card makes expensive calls easier to spot while scanning the rail.

## Validation

- `cd apps/web && bun test src/domains/chat/inspector/components/call-rail.test.tsx`
- `cd apps/web && bun run lint -- src/domains/chat/inspector/components/call-rail.tsx src/domains/chat/inspector/components/call-rail.test.tsx`
- `cd apps/web && bun run typecheck`
