### PR TITLE
Add selected-series legend support to usage trend chart

### DIFF
--- a/apps/web/src/domains/logs/components/usage-trend-chart.test.tsx
+++ b/apps/web/src/domains/logs/components/usage-trend-chart.test.tsx
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { cleanup, render } from "@testing-library/react";
+
+import { UsageTrendChart } from "@/domains/logs/components/usage-trend-chart";
+import { usageSeriesKeyForGroupValue } from "@/domains/logs/usage-series";
+import type { UsageSeriesBucket } from "@/domains/logs/usage-types";
+
+afterEach(() => {
+  cleanup();
+});
+
+function bucket(
+  bucketId: string,
+  totalEstimatedCostUsd: number,
+  groups: UsageSeriesBucket["groups"],
+): UsageSeriesBucket {
+  return {
+    bucketId,
+    date: bucketId,
+    displayLabel: bucketId,
+    totalInputTokens: 100,
+    totalOutputTokens: 50,
+    totalEstimatedCostUsd,
+    eventCount: 1,
+    groups,
+  };
+}
+
+function group(
+  label: string,
+  groupKey: string | null,
+  totalEstimatedCostUsd: number,
+): UsageSeriesBucket["groups"][string] {
+  return {
+    group: label,
+    groupKey,
+    totalInputTokens: 100,
+    totalOutputTokens: 50,
+    totalEstimatedCostUsd,
+    eventCount: 1,
+  };
+}
+
+describe("usageSeriesKeyForGroupValue", () => {
+  test("matches the backend grouped-series key convention", () => {
+    expect(usageSeriesKeyForGroupValue("schedule-123")).toBe(
+      "value:schedule-123",
+    );
+    expect(usageSeriesKeyForGroupValue(null, "schedule")).toBe(
+      "null:schedule",
+    );
+    expect(usageSeriesKeyForGroupValue("null:schedule")).toBe(
+      "value:null:schedule",
+    );
+  });
+});
+
+describe("UsageTrendChart", () => {
+  test("renders the bucket-derived legend as active by default", () => {
+    const buckets = [
+      bucket("2026-04-01", 0.03, {
+        "value:schedule-a": group("Alpha schedule", "schedule-a", 0.01),
+        "value:schedule-b": group("Beta schedule", "schedule-b", 0.02),
+      }),
+    ];
+
+    const { getByText, container } = render(
+      <UsageTrendChart buckets={buckets} isHourly={false} />,
+    );
+
+    const legendItems = Array.from(
+      container.querySelectorAll("[data-usage-legend-state]"),
+    );
+    expect(legendItems.map((item) => item.textContent)).toEqual([
+      "Beta schedule",
+      "Alpha schedule",
+    ]);
+    expect(
+      legendItems.map((item) =>
+        item.getAttribute("data-usage-legend-state"),
+      ),
+    ).toEqual(["active", "active"]);
+    expect(getByText("Beta schedule").className).not.toContain("line-through");
+  });
+
+  test("renders selected-series legend overrides with inactive entries", () => {
+    const activeSeriesKey = "value:schedule-a";
+    const inactiveSeriesKey = "value:schedule-b";
+    const buckets = [
+      bucket("2026-04-01", 0.01, {
+        [activeSeriesKey]: group("Alpha schedule", "schedule-a", 0.01),
+      }),
+    ];
+
+    const { getByText, container } = render(
+      <UsageTrendChart
+        buckets={buckets}
+        isHourly={false}
+        legendItems={[
+          {
+            seriesKey: inactiveSeriesKey,
+            label: "Beta schedule",
+            totalEstimatedCostUsd: 0,
+            colorIndex: 0,
+            state: "inactive",
+          },
+          {
+            seriesKey: activeSeriesKey,
+            label: "Alpha schedule",
+            totalEstimatedCostUsd: 0.01,
+            colorIndex: 1,
+            state: "active",
+          },
+        ]}
+      />,
+    );
+
+    const inactiveLabel = getByText("Beta schedule");
+    const inactiveItem = inactiveLabel.closest("[data-usage-legend-state]");
+    expect(inactiveItem?.getAttribute("data-usage-legend-state")).toBe(
+      "inactive",
+    );
+    expect(inactiveLabel.className).toContain("line-through");
+    const inactiveSegment = container.querySelector(
+      `[data-usage-series-segment="${inactiveSeriesKey}"]`,
+    );
+    expect(inactiveSegment).toBeNull();
+
+    const activeLabel = getByText("Alpha schedule");
+    const activeItem = activeLabel.closest("[data-usage-legend-state]");
+    expect(activeItem?.getAttribute("data-usage-legend-state")).toBe("active");
+    expect(activeLabel.className).not.toContain("line-through");
+
+    const activeDot = activeItem!.querySelector("[aria-hidden='true']");
+    const activeSegment = container.querySelector(
+      `[data-usage-series-segment="${activeSeriesKey}"]`,
+    );
+    expect(activeDot).not.toBeNull();
+    expect(activeSegment).not.toBeNull();
+    expect(activeSegment!.getAttribute("data-usage-series-color-index")).toBe(
+      activeDot!.getAttribute("data-usage-series-color-index"),
+    );
+  });
+});

--- a/apps/web/src/domains/logs/components/usage-trend-chart.test.tsx
+++ b/apps/web/src/domains/logs/components/usage-trend-chart.test.tsx
@@ -153,4 +153,68 @@ describe("UsageTrendChart", () => {
       activeDot!.getAttribute("data-usage-series-color-index"),
     );
   });
+
+  test("does not render a fallback segment when selected active series have no bucket data", () => {
+    const activeSeriesKey = "value:schedule-a";
+    const inactiveSeriesKey = "value:schedule-b";
+    const buckets = [
+      bucket("2026-04-01", 0.02, {
+        [inactiveSeriesKey]: group("Beta schedule", "schedule-b", 0.02),
+      }),
+    ];
+
+    const { container } = render(
+      <UsageTrendChart
+        buckets={buckets}
+        isHourly={false}
+        legendItems={[
+          {
+            seriesKey: inactiveSeriesKey,
+            label: "Beta schedule",
+            totalEstimatedCostUsd: 0,
+            colorIndex: 0,
+            state: "inactive",
+          },
+          {
+            seriesKey: activeSeriesKey,
+            label: "Alpha schedule",
+            totalEstimatedCostUsd: 0,
+            colorIndex: 1,
+            state: "active",
+          },
+        ]}
+      />,
+    );
+
+    const bar = container.querySelector(
+      `[data-usage-series-bar="${buckets[0]!.bucketId}"]`,
+    );
+    expect(bar).not.toBeNull();
+    expect(bar!.querySelector("[data-usage-fallback-segment]")).toBeNull();
+    expect(bar!.querySelector("[data-usage-series-segment]")).toBeNull();
+    expect(
+      bar!.querySelector(
+        `[data-usage-series-segment="${activeSeriesKey}"]`,
+      ),
+    ).toBeNull();
+  });
+
+  test("renders the total fallback segment for ungrouped buckets", () => {
+    const buckets = [bucket("2026-04-01", 0.02, {})];
+
+    const { container } = render(
+      <UsageTrendChart buckets={buckets} isHourly={false} />,
+    );
+
+    const bar = container.querySelector(
+      `[data-usage-series-bar="${buckets[0]!.bucketId}"]`,
+    );
+    const fallbackSegment = bar?.querySelector(
+      "[data-usage-fallback-segment]",
+    );
+    expect(fallbackSegment).not.toBeNull();
+    expect(
+      fallbackSegment?.getAttribute("data-usage-series-segment-label"),
+    ).toBe("Total");
+  });
 });

--- a/apps/web/src/domains/logs/components/usage-trend-chart.test.tsx
+++ b/apps/web/src/domains/logs/components/usage-trend-chart.test.tsx
@@ -50,8 +50,15 @@ describe("usageSeriesKeyForGroupValue", () => {
     expect(usageSeriesKeyForGroupValue(null, "schedule")).toBe(
       "null:schedule",
     );
+    expect(usageSeriesKeyForGroupValue(null, "task")).toBe("null:call_site");
+    expect(usageSeriesKeyForGroupValue(null, "profile")).toBe(
+      "null:inference_profile",
+    );
     expect(usageSeriesKeyForGroupValue("null:schedule")).toBe(
       "value:null:schedule",
+    );
+    expect(usageSeriesKeyForGroupValue("profile-123", "profile")).toBe(
+      "value:profile-123",
     );
   });
 });
@@ -88,8 +95,9 @@ describe("UsageTrendChart", () => {
     const activeSeriesKey = "value:schedule-a";
     const inactiveSeriesKey = "value:schedule-b";
     const buckets = [
-      bucket("2026-04-01", 0.01, {
+      bucket("2026-04-01", 0.03, {
         [activeSeriesKey]: group("Alpha schedule", "schedule-a", 0.01),
+        [inactiveSeriesKey]: group("Beta schedule", "schedule-b", 0.02),
       }),
     ];
 
@@ -126,6 +134,9 @@ describe("UsageTrendChart", () => {
       `[data-usage-series-segment="${inactiveSeriesKey}"]`,
     );
     expect(inactiveSegment).toBeNull();
+    expect(
+      container.querySelectorAll("[data-usage-series-segment]"),
+    ).toHaveLength(1);
 
     const activeLabel = getByText("Alpha schedule");
     const activeItem = activeLabel.closest("[data-usage-legend-state]");

--- a/apps/web/src/domains/logs/components/usage-trend-chart.tsx
+++ b/apps/web/src/domains/logs/components/usage-trend-chart.tsx
@@ -41,6 +41,17 @@ type SegmentTooltip = {
 };
 
 type SegmentTooltipContent = Omit<SegmentTooltip, "x" | "y">;
+type UsageLegendState = "active" | "inactive";
+
+export interface UsageTrendChartLegendItem extends UsageSeriesLegendItem {
+  state?: UsageLegendState;
+}
+
+interface UsageTrendChartProps {
+  buckets: UsageSeriesBucket[];
+  isHourly: boolean;
+  legendItems?: UsageTrendChartLegendItem[];
+}
 
 function colorForIndex(index: number): string {
   return STACK_COLORS[index % STACK_COLORS.length];
@@ -72,13 +83,13 @@ function resolveTooltipPosition(
 export function UsageTrendChart({
   buckets,
   isHourly,
-}: {
-  buckets: UsageSeriesBucket[];
-  isHourly: boolean;
-}) {
+  legendItems,
+}: UsageTrendChartProps) {
   const [tooltip, setTooltip] = useState<SegmentTooltip | null>(null);
   const sorted = useMemo(() => sortUsageSeriesBuckets(buckets), [buckets]);
-  const legend = useMemo(() => buildUsageSeriesLegend(buckets), [buckets]);
+  const bucketLegend = useMemo(() => buildUsageSeriesLegend(buckets), [buckets]);
+  const stackLegendItems = legendItems ?? bucketLegend.items;
+  const visibleLegendItems = legendItems ?? bucketLegend.visibleItems;
   const maxCost = useMemo(
     () =>
       sorted.reduce(
@@ -143,7 +154,7 @@ export function UsageTrendChart({
                 <StackedBar
                   bucket={bucket}
                   height={height}
-                  legendItems={legend.items}
+                  legendItems={stackLegendItems}
                   onSegmentHover={showTooltip}
                   onSegmentLeave={hideTooltip}
                 />
@@ -176,8 +187,8 @@ export function UsageTrendChart({
             </div>
           ))}
         </div>
-        {legend.visibleItems.length > 0 ? (
-          <UsageSeriesLegendDisplay items={legend.visibleItems} />
+        {visibleLegendItems.length > 0 ? (
+          <UsageSeriesLegendDisplay items={visibleLegendItems} />
         ) : null}
       </div>
       {tooltip ? <SegmentTooltipBubble tooltip={tooltip} /> : null}
@@ -219,7 +230,7 @@ function StackedBar({
 }: {
   bucket: UsageSeriesBucket;
   height: number;
-  legendItems: UsageSeriesLegendItem[];
+  legendItems: UsageTrendChartLegendItem[];
   onSegmentHover: (
     event: MouseEvent<HTMLElement>,
     content: SegmentTooltipContent,
@@ -287,6 +298,7 @@ function StackedBar({
             }}
             data-usage-series-segment={item.seriesKey}
             data-usage-series-segment-label={item.label}
+            data-usage-series-color-index={item.colorIndex}
           />
         );
       })}
@@ -325,25 +337,46 @@ function SegmentTooltipBubble({ tooltip }: { tooltip: SegmentTooltip }) {
 function UsageSeriesLegendDisplay({
   items,
 }: {
-  items: UsageSeriesLegendItem[];
+  items: UsageTrendChartLegendItem[];
 }) {
   return (
     <div className="flex flex-wrap items-center gap-x-3 gap-y-1 pt-1">
-      {items.map((item) => (
-        <div key={item.seriesKey} className="flex min-w-0 items-center gap-1">
-          <span
-            className="h-[7px] w-[7px] shrink-0 rounded-full"
-            style={{ background: colorForIndex(item.colorIndex) }}
-            aria-hidden="true"
-          />
-          <span
-            className="truncate text-[10px]"
-            style={{ color: "var(--content-tertiary)" }}
+      {items.map((item) => {
+        const state = item.state ?? "active";
+        const isInactive = state === "inactive";
+        return (
+          <div
+            key={item.seriesKey}
+            className="flex min-w-0 items-center gap-1"
+            data-usage-legend-state={state}
           >
-            {item.label}
-          </span>
-        </div>
-      ))}
+            <span
+              className="h-[7px] w-[7px] shrink-0 rounded-full"
+              style={{
+                background: isInactive
+                  ? "var(--content-tertiary)"
+                  : colorForIndex(item.colorIndex),
+                opacity: isInactive ? 0.45 : 1,
+              }}
+              aria-hidden="true"
+              data-usage-series-color-index={item.colorIndex}
+            />
+            <span
+              className={
+                isInactive
+                  ? "truncate text-[10px] line-through"
+                  : "truncate text-[10px]"
+              }
+              style={{
+                color: "var(--content-tertiary)",
+                opacity: isInactive ? 0.65 : 1,
+              }}
+            >
+              {item.label}
+            </span>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/apps/web/src/domains/logs/components/usage-trend-chart.tsx
+++ b/apps/web/src/domains/logs/components/usage-trend-chart.tsx
@@ -237,6 +237,7 @@ function StackedBar({
   ) => void;
   onSegmentLeave: () => void;
 }) {
+  const hasGroupedData = Object.keys(bucket.groups).length > 0;
   const activeLegendItems = legendItems.filter(
     (item) => (item.state ?? "active") === "active",
   );
@@ -248,7 +249,7 @@ function StackedBar({
     return [{ item, value }];
   });
 
-  if (nonEmptyGroups.length === 0) {
+  if (nonEmptyGroups.length === 0 && !hasGroupedData) {
     const bucketLabel = formatBucketLabel(bucket);
     const tooltipContent = {
       label: "Total",
@@ -270,6 +271,9 @@ function StackedBar({
         data-usage-fallback-segment="true"
       />
     );
+  }
+  if (nonEmptyGroups.length === 0) {
+    return null;
   }
 
   return (

--- a/apps/web/src/domains/logs/components/usage-trend-chart.tsx
+++ b/apps/web/src/domains/logs/components/usage-trend-chart.tsx
@@ -237,7 +237,10 @@ function StackedBar({
   ) => void;
   onSegmentLeave: () => void;
 }) {
-  const nonEmptyGroups = legendItems.flatMap((item) => {
+  const activeLegendItems = legendItems.filter(
+    (item) => (item.state ?? "active") === "active",
+  );
+  const nonEmptyGroups = activeLegendItems.flatMap((item) => {
     const value = bucket.groups[item.seriesKey];
     if (!value || value.totalEstimatedCostUsd <= 0) {
       return [];

--- a/apps/web/src/domains/logs/usage-series.ts
+++ b/apps/web/src/domains/logs/usage-series.ts
@@ -1,3 +1,4 @@
+import { isLlmUsageDimension, toDaemonGroupBy } from "@/utils/llm-dimension";
 import type { UsageGroupLabelMetadata } from "./group-labels";
 import { resolveUsageGroupLabel } from "./group-labels";
 import type {
@@ -34,7 +35,10 @@ export function usageSeriesKeyForGroupValue(
   if (groupKey !== null) {
     return `${VALUE_GROUP_PREFIX}${groupKey}`;
   }
-  return `${NULL_GROUP_PREFIX}${groupBy}`;
+  const backendGroupBy = isLlmUsageDimension(groupBy)
+    ? toDaemonGroupBy(groupBy)
+    : groupBy;
+  return `${NULL_GROUP_PREFIX}${backendGroupBy}`;
 }
 
 export function sortUsageSeriesBuckets(

--- a/apps/web/src/domains/logs/usage-series.ts
+++ b/apps/web/src/domains/logs/usage-series.ts
@@ -8,6 +8,8 @@ import type {
 } from "./usage-types";
 
 const VISIBLE_LEGEND_ITEM_LIMIT = 6;
+const VALUE_GROUP_PREFIX = "value:";
+const NULL_GROUP_PREFIX = "null:";
 
 export interface UsageSeriesLegendItem {
   seriesKey: string;
@@ -19,6 +21,20 @@ export interface UsageSeriesLegendItem {
 export interface UsageSeriesLegend {
   items: UsageSeriesLegendItem[];
   visibleItems: UsageSeriesLegendItem[];
+}
+
+/**
+ * Mirrors the backend's grouped-series key shape so filtered charts can keep
+ * legend items aligned with the buckets returned by the usage series route.
+ */
+export function usageSeriesKeyForGroupValue(
+  groupKey: string | null,
+  groupBy: UsageSeriesGroupBy = "schedule",
+): string {
+  if (groupKey !== null) {
+    return `${VALUE_GROUP_PREFIX}${groupKey}`;
+  }
+  return `${NULL_GROUP_PREFIX}${groupBy}`;
 }
 
 export function sortUsageSeriesBuckets(


### PR DESCRIPTION
Implements PR 2 of the Schedules and Usage UI Polish plan: UsageTrendChart now supports an optional selected-series legend override with active/inactive states while preserving the existing bucket-derived legend fallback.