### PR TITLE
Route memory v2 consolidation through its callsite

### DIFF
--- a/assistant/src/memory/v2/__tests__/consolidation-job.test.ts
+++ b/assistant/src/memory/v2/__tests__/consolidation-job.test.ts
@@ -279,7 +279,7 @@ describe("memoryV2ConsolidateJob — non-empty buffer", () => {
     expect(runnerLastArgs).not.toBeNull();
     expect(runnerLastArgs?.jobName).toBe("memory.consolidate");
     expect(runnerLastArgs?.source).toBe("memory_v2_consolidation");
-    expect(runnerLastArgs?.callSite).toBe("mainAgent");
+    expect(runnerLastArgs?.callSite).toBe("memoryV2Consolidation");
     expect(runnerLastArgs?.origin).toBe("memory_consolidation");
     // The whole point of this PR: opt out of activity.failed notifications
     // because consolidation runs on tight intervals and transient failures

--- a/assistant/src/memory/v2/consolidation-job.ts
+++ b/assistant/src/memory/v2/consolidation-job.ts
@@ -197,7 +197,7 @@ export async function memoryV2ConsolidateJob(
       source: MEMORY_V2_CONSOLIDATION_SOURCE,
       prompt,
       trustContext: { sourceChannel: "vellum", trustClass: "guardian" },
-      callSite: "mainAgent",
+      callSite: "memoryV2Consolidation",
       timeoutMs: CONSOLIDATION_TIMEOUT_MS,
       origin: "memory_consolidation",
       suppressFailureNotifications: true,


### PR DESCRIPTION
## Summary
- Route memory v2 consolidation background runs through `memoryV2Consolidation` instead of `mainAgent` for provider/profile resolution and usage attribution.
- Update the consolidation job test expectation to match the callsite.

## Tests
- `cd assistant && bun test src/memory/v2/__tests__/consolidation-job.test.ts`