### PR TITLE
Replace Usage schedule picker with selected-series legend

### DIFF
--- a/apps/web/src/domains/logs/components/usage-tab.test.tsx
+++ b/apps/web/src/domains/logs/components/usage-tab.test.tsx
@@ -1,0 +1,235 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { createElement, type ReactElement } from "react";
+import { createMemoryRouter, RouterProvider } from "react-router";
+
+import { usageSeriesKeyForGroupValue } from "@/domains/logs/usage-series";
+import type {
+  UsageBreakdownResponse,
+  UsageSeriesResponse,
+  UsageTotals,
+} from "@/domains/logs/usage-types";
+import type { AssistantSchedule } from "@/utils/schedules";
+
+const defaultSchedules = [
+  { id: "schedule-123", name: "Morning digest" } as AssistantSchedule,
+  { id: "schedule-456", name: "Evening digest" } as AssistantSchedule,
+] as const;
+let schedulesResponse: AssistantSchedule[] = [...defaultSchedules];
+const fetchSchedulesMock = mock(
+  async (): Promise<AssistantSchedule[]> => schedulesResponse,
+);
+const fetchUsageTotalsMock = mock(
+  async (
+    _assistantId: string,
+    _params: { scheduleId?: string },
+  ): Promise<UsageTotals> => ({
+    totalInputTokens: 120,
+    totalOutputTokens: 80,
+    totalCacheCreationTokens: 0,
+    totalCacheReadTokens: 0,
+    totalEstimatedCostUsd: 0.03,
+    eventCount: 2,
+    pricedEventCount: 2,
+    unpricedEventCount: 0,
+  }),
+);
+const fetchUsageBreakdownMock = mock(
+  async (
+    _assistantId: string,
+    params: { scheduleId?: string },
+  ): Promise<UsageBreakdownResponse> => {
+    const selectedScheduleId = params.scheduleId ?? "schedule-123";
+    const selectedSchedule = defaultSchedules.find(
+      (schedule) => schedule.id === selectedScheduleId,
+    );
+    return {
+      breakdown: [
+        {
+          group: selectedSchedule?.name ?? "Deleted schedule",
+          groupId: selectedScheduleId,
+          groupKey: selectedScheduleId,
+          totalInputTokens: 120,
+          totalOutputTokens: 80,
+          totalCacheCreationTokens: 0,
+          totalCacheReadTokens: 0,
+          totalEstimatedCostUsd: 0.03,
+          eventCount: 2,
+        },
+      ],
+    };
+  },
+);
+const fetchUsageSeriesMock = mock(
+  async (
+    _assistantId: string,
+    params: { scheduleId?: string },
+  ): Promise<UsageSeriesResponse> => {
+    const selectedScheduleId = params.scheduleId ?? "schedule-123";
+    const selectedSeriesKey = usageSeriesKeyForGroupValue(
+      selectedScheduleId,
+      "schedule",
+    );
+    const selectedSchedule = defaultSchedules.find(
+      (schedule) => schedule.id === selectedScheduleId,
+    );
+    return {
+      buckets: [
+        {
+          bucketId: "2026-06-01",
+          date: "2026-06-01",
+          displayLabel: "Jun 1",
+          totalInputTokens: 120,
+          totalOutputTokens: 80,
+          totalEstimatedCostUsd: 0.03,
+          eventCount: 2,
+          groups: {
+            [selectedSeriesKey]: {
+              group: selectedSchedule?.name ?? "Deleted schedule",
+              groupKey: selectedScheduleId,
+              totalInputTokens: 120,
+              totalOutputTokens: 80,
+              totalEstimatedCostUsd: 0.03,
+              eventCount: 2,
+            },
+          },
+        },
+      ],
+    };
+  },
+);
+const fetchUsageDailyMock = mock(async () => ({ buckets: [] }));
+class UsageRequestError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "UsageRequestError";
+    this.status = status;
+  }
+}
+
+mock.module("@/utils/schedules", () => ({
+  fetchSchedules: fetchSchedulesMock,
+}));
+mock.module("@/utils/use-effective-timezone", () => ({
+  useEffectiveTimezone: () => "UTC",
+}));
+mock.module("@/domains/logs/usage-api", () => ({
+  UsageRequestError,
+  fetchUsageBreakdown: fetchUsageBreakdownMock,
+  fetchUsageDaily: fetchUsageDailyMock,
+  fetchUsageSeries: fetchUsageSeriesMock,
+  fetchUsageTotals: fetchUsageTotalsMock,
+}));
+
+const { UsageTab } = await import("./usage-tab");
+
+afterEach(() => {
+  cleanup();
+  schedulesResponse = [...defaultSchedules];
+  fetchSchedulesMock.mockClear();
+  fetchUsageTotalsMock.mockClear();
+  fetchUsageBreakdownMock.mockClear();
+  fetchUsageSeriesMock.mockClear();
+  fetchUsageDailyMock.mockClear();
+});
+
+function renderUsageTab(initialEntry: string) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+  const router = createMemoryRouter(
+    [
+      {
+        path: "/assistant/logs/usage",
+        element: createElement(UsageTab, { assistantId: "assistant-1" }),
+      },
+    ],
+    { initialEntries: [initialEntry] },
+  );
+  const element: ReactElement = createElement(
+    QueryClientProvider,
+    { client: queryClient },
+    createElement(RouterProvider, { router }),
+  );
+
+  return render(element);
+}
+
+function readLegendItems(container: HTMLElement) {
+  return Array.from(container.querySelectorAll("[data-usage-legend-state]")).map(
+    (item) => ({
+      label: item.querySelectorAll("span")[1]!,
+      state: item.getAttribute("data-usage-legend-state"),
+    }),
+  );
+}
+
+describe("UsageTab", () => {
+  test("renders URL-selected schedule filters as an active legend instead of picker controls", async () => {
+    const { container } = renderUsageTab(
+      "/assistant/logs/usage?range=7d&groupBy=schedule&scheduleId=schedule-123",
+    );
+
+    await waitFor(() =>
+      expect(fetchUsageSeriesMock.mock.calls).toHaveLength(1),
+    );
+
+    expect(
+      screen.queryByLabelText("Schedule usage filter"),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Clear schedule filter" }),
+    ).toBeNull();
+    expect(screen.getByText("Schedule")).toBeTruthy();
+    expect(fetchUsageTotalsMock.mock.calls[0]?.[1]?.scheduleId).toBe(
+      "schedule-123",
+    );
+    expect(fetchUsageBreakdownMock.mock.calls[0]?.[1]?.scheduleId).toBe(
+      "schedule-123",
+    );
+    expect(fetchUsageSeriesMock.mock.calls[0]?.[1]?.scheduleId).toBe(
+      "schedule-123",
+    );
+
+    const legendItems = readLegendItems(container);
+    expect(legendItems.map((item) => item.label.textContent)).toEqual([
+      "Morning digest",
+      "Evening digest",
+    ]);
+    expect(legendItems.map((item) => item.state)).toEqual([
+      "active",
+      "inactive",
+    ]);
+
+    expect(legendItems[0]!.label.className).not.toContain("line-through");
+    expect(legendItems[1]!.label.className).toContain("line-through");
+  });
+
+  test("renders an active fallback legend item for an unknown selected schedule", async () => {
+    schedulesResponse = [
+      { id: "schedule-456", name: "Evening digest" } as AssistantSchedule,
+    ];
+    const { container } = renderUsageTab(
+      "/assistant/logs/usage?range=7d&groupBy=schedule&scheduleId=schedule-deleted",
+    );
+
+    await waitFor(() =>
+      expect(fetchUsageSeriesMock.mock.calls).toHaveLength(1),
+    );
+
+    const legendItems = readLegendItems(container);
+    expect(legendItems.map((item) => item.label.textContent)).toEqual([
+      "Unknown schedule (schedule-deleted)",
+      "Evening digest",
+    ]);
+    expect(legendItems.map((item) => item.state)).toEqual([
+      "active",
+      "inactive",
+    ]);
+  });
+});

--- a/apps/web/src/domains/logs/components/usage-tab.tsx
+++ b/apps/web/src/domains/logs/components/usage-tab.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { AlertTriangle, Sparkles, Wand2, X } from "lucide-react";
+import { AlertTriangle, Sparkles, Wand2 } from "lucide-react";
 import { useCallback, useMemo, useState, type ReactNode } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 
@@ -12,6 +12,7 @@ import {
 import {
     UsageTrendChart,
     UsageTrendSkeleton,
+    type UsageTrendChartLegendItem,
 } from "@/domains/logs/components/usage-trend-chart";
 import { formatCost, formatTokens } from "@/domains/logs/format";
 import { decorateUsageBreakdownGroups } from "@/domains/logs/group-labels";
@@ -29,6 +30,7 @@ import {
 import {
     decorateUsageSeriesGroups,
     seriesFromDailyBuckets,
+    usageSeriesKeyForGroupValue,
 } from "@/domains/logs/usage-series";
 import {
     buildUsageSearchParams,
@@ -74,7 +76,6 @@ const RANGE_OPTIONS: { value: UsageTimeRange; label: string }[] = [
   { value: "all", label: "All time" },
 ];
 
-const ALL_USAGE_FILTER_VALUE = "";
 const PROFILE_METADATA_STALE_TIME_MS = 5 * 60 * 1000;
 const COST_ANALYSIS_PROMPT = [
   "Please load the llm-cost-optimizer skill.",
@@ -134,17 +135,6 @@ export function UsageTab({ assistantId }: UsageTabProps) {
     },
     [updateUsageSearchParams],
   );
-
-  const handleScheduleFilterChange = useCallback(
-    (nextScheduleId: string | null) => {
-      updateUsageSearchParams({ scheduleId: nextScheduleId });
-    },
-    [updateUsageSearchParams],
-  );
-
-  const handleClearScheduleFilter = useCallback(() => {
-    updateUsageSearchParams({ scheduleId: null });
-  }, [updateUsageSearchParams]);
 
   const totalsQuery = useQuery({
     queryKey: [
@@ -367,7 +357,13 @@ export function UsageTab({ assistantId }: UsageTabProps) {
   const isHourly = effectiveGranularity === "hourly";
   const trendGroupBy =
     seriesGroupBy && seriesQuery.error ? undefined : effectiveGroupBy;
-  const showScheduleFilter = effectiveGroupBy === "schedule";
+  const selectedScheduleLegendItems = useMemo(() => {
+    if (effectiveGroupBy !== "schedule" || !scheduleId) {
+      return undefined;
+    }
+
+    return buildSelectedScheduleLegendItems(schedulesQuery.data, scheduleId);
+  }, [effectiveGroupBy, scheduleId, schedulesQuery.data]);
 
   const handleGroupByChange = (nextGroupBy: UsageGroupBy) => {
     if (nextGroupBy === groupBy && effectiveGroupBy !== groupBy) {
@@ -412,14 +408,6 @@ export function UsageTab({ assistantId }: UsageTabProps) {
               {trendTitle(effectiveGranularity, trendGroupBy)}
             </h4>
             <div className="flex flex-wrap items-center justify-end gap-2">
-              {showScheduleFilter ? (
-                <ScheduleFilterPicker
-                  scheduleId={scheduleId}
-                  schedules={schedulesQuery.data}
-                  onChange={handleScheduleFilterChange}
-                  onClear={handleClearScheduleFilter}
-                />
-              ) : null}
               <GroupByPicker
                 value={effectiveGroupBy}
                 onChange={handleGroupByChange}
@@ -430,7 +418,11 @@ export function UsageTab({ assistantId }: UsageTabProps) {
             query={trendQuery}
             skeleton={<UsageTrendSkeleton isHourly={isHourly} />}
             render={(buckets) => (
-              <UsageTrendChart buckets={buckets} isHourly={isHourly} />
+              <UsageTrendChart
+                buckets={buckets}
+                isHourly={isHourly}
+                legendItems={selectedScheduleLegendItems}
+              />
             )}
           />
         </div>
@@ -449,82 +441,36 @@ export function UsageTab({ assistantId }: UsageTabProps) {
   );
 }
 
-function ScheduleFilterPicker({
-  scheduleId,
-  schedules,
-  onChange,
-  onClear,
-}: {
-  scheduleId: string | undefined;
-  schedules: AssistantSchedule[] | undefined;
-  onChange: (scheduleId: string | null) => void;
-  onClear: () => void;
-}) {
-  const options = useMemo(
-    () => buildScheduleFilterOptions(schedules, scheduleId),
-    [schedules, scheduleId],
-  );
-
-  return (
-    <div className="flex items-center gap-1">
-      <Dropdown<string>
-        value={scheduleId ?? ALL_USAGE_FILTER_VALUE}
-        onChange={(value) =>
-          onChange(value === ALL_USAGE_FILTER_VALUE ? null : value)
-        }
-        options={options}
-        className="w-44"
-        menuMinWidth={220}
-        aria-label="Schedule usage filter"
-      />
-      {scheduleId ? (
-        <button
-          type="button"
-          onClick={onClear}
-          className="inline-flex h-9 w-9 items-center justify-center rounded-md border transition-colors"
-          style={{
-            borderColor: "var(--border-base)",
-            color: "var(--content-secondary)",
-            background: "transparent",
-          }}
-          aria-label="Clear schedule filter"
-          title="Clear schedule filter"
-        >
-          <X className="h-3.5 w-3.5" aria-hidden />
-        </button>
-      ) : null}
-    </div>
-  );
-}
-
-function buildScheduleFilterOptions(
+function buildSelectedScheduleLegendItems(
   schedules: readonly Pick<AssistantSchedule, "id" | "name">[] | undefined,
-  selectedScheduleId: string | undefined,
-): Array<{ value: string; label: string }> {
-  const options: Array<{ value: string; label: string }> = [
-    { value: ALL_USAGE_FILTER_VALUE, label: "All usage" },
-  ];
-  const knownScheduleIds = new Set<string>();
-
-  for (const schedule of schedules ?? []) {
-    knownScheduleIds.add(schedule.id);
-  }
-
-  if (selectedScheduleId && !knownScheduleIds.has(selectedScheduleId)) {
-    options.push({
-      value: selectedScheduleId,
-      label: unknownScheduleLabel(selectedScheduleId),
-    });
-  }
-
-  for (const schedule of schedules ?? []) {
-    options.push({
-      value: schedule.id,
+  selectedScheduleId: string,
+): UsageTrendChartLegendItem[] {
+  const knownSchedules = schedules ?? [];
+  const hasSelectedSchedule = knownSchedules.some(
+    (schedule) => schedule.id === selectedScheduleId,
+  );
+  const legendSources = [
+    ...(hasSelectedSchedule
+      ? []
+      : [
+          {
+            id: selectedScheduleId,
+            label: unknownScheduleLabel(selectedScheduleId),
+          },
+        ]),
+    ...knownSchedules.map((schedule) => ({
+      id: schedule.id,
       label: schedule.name || schedule.id,
-    });
-  }
+    })),
+  ];
 
-  return options;
+  return legendSources.map((schedule, colorIndex) => ({
+    seriesKey: usageSeriesKeyForGroupValue(schedule.id, "schedule"),
+    label: schedule.label,
+    totalEstimatedCostUsd: 0,
+    colorIndex,
+    state: schedule.id === selectedScheduleId ? "active" : "inactive",
+  }));
 }
 
 function unknownScheduleLabel(scheduleId: string) {

--- a/apps/web/src/domains/logs/components/usage-trend-chart.test.tsx
+++ b/apps/web/src/domains/logs/components/usage-trend-chart.test.tsx
@@ -64,6 +64,59 @@ describe("usageSeriesKeyForGroupValue", () => {
 });
 
 describe("UsageTrendChart", () => {
+  test("renders selected-series legend overrides in the empty state", () => {
+    const { container, getByText } = render(
+      <UsageTrendChart
+        buckets={[]}
+        isHourly={false}
+        legendItems={[
+          {
+            seriesKey: "value:schedule-123",
+            label: "Morning digest",
+            totalEstimatedCostUsd: 0,
+            colorIndex: 0,
+            state: "active",
+          },
+          {
+            seriesKey: "value:schedule-456",
+            label: "Evening digest",
+            totalEstimatedCostUsd: 0,
+            colorIndex: 1,
+            state: "inactive",
+          },
+        ]}
+      />,
+    );
+
+    expect(getByText("No daily data")).toBeTruthy();
+    const legendItems = Array.from(
+      container.querySelectorAll("[data-usage-legend-state]"),
+    );
+    expect(legendItems.map((item) => item.textContent)).toEqual([
+      "Morning digest",
+      "Evening digest",
+    ]);
+    expect(
+      legendItems.map((item) =>
+        item.getAttribute("data-usage-legend-state"),
+      ),
+    ).toEqual(["active", "inactive"]);
+
+    const activeLabel = getByText("Morning digest");
+    const inactiveLabel = getByText("Evening digest");
+    expect(activeLabel.className).not.toContain("line-through");
+    expect(inactiveLabel.className).toContain("line-through");
+  });
+
+  test("keeps the default empty state legend-free without overrides", () => {
+    const { container, getByText } = render(
+      <UsageTrendChart buckets={[]} isHourly={false} />,
+    );
+
+    expect(getByText("No daily data")).toBeTruthy();
+    expect(container.querySelector("[data-usage-legend-state]")).toBeNull();
+  });
+
   test("renders the bucket-derived legend as active by default", () => {
     const buckets = [
       bucket("2026-04-01", 0.03, {

--- a/apps/web/src/domains/logs/components/usage-trend-chart.tsx
+++ b/apps/web/src/domains/logs/components/usage-trend-chart.tsx
@@ -112,11 +112,20 @@ export function UsageTrendChart({
   const hideTooltip = useCallback(() => setTooltip(null), []);
 
   if (sorted.length === 0) {
-    return (
+    const emptyState = (
       <EmptyState
         title={isHourly ? "No hourly data" : "No daily data"}
         subtitle="No usage recorded in this time range"
       />
+    );
+    if (visibleLegendItems.length === 0) {
+      return emptyState;
+    }
+    return (
+      <div className="flex flex-col gap-2">
+        {emptyState}
+        <UsageSeriesLegendDisplay items={visibleLegendItems} />
+      </div>
     );
   }
 


### PR DESCRIPTION
Implements PR 3 of the Schedules and Usage UI Polish plan: the Usage chart header no longer shows the selected schedule dropdown/clear control, and URL-selected schedule filters are represented by an active/inactive legend while preserving scheduleId query filtering.