### PR TITLE
Simplify schedule usage UI polish tests and types

### DIFF
--- a/apps/web/src/domains/logs/components/usage-tab.tsx
+++ b/apps/web/src/domains/logs/components/usage-tab.tsx
@@ -467,7 +467,6 @@ function buildSelectedScheduleLegendItems(
   return legendSources.map((schedule, colorIndex) => ({
     seriesKey: usageSeriesKeyForGroupValue(schedule.id, "schedule"),
     label: schedule.label,
-    totalEstimatedCostUsd: 0,
     colorIndex,
     state: schedule.id === selectedScheduleId ? "active" : "inactive",
   }));

--- a/apps/web/src/domains/logs/components/usage-trend-chart.test.tsx
+++ b/apps/web/src/domains/logs/components/usage-trend-chart.test.tsx
@@ -73,14 +73,12 @@ describe("UsageTrendChart", () => {
           {
             seriesKey: "value:schedule-123",
             label: "Morning digest",
-            totalEstimatedCostUsd: 0,
             colorIndex: 0,
             state: "active",
           },
           {
             seriesKey: "value:schedule-456",
             label: "Evening digest",
-            totalEstimatedCostUsd: 0,
             colorIndex: 1,
             state: "inactive",
           },
@@ -162,14 +160,12 @@ describe("UsageTrendChart", () => {
           {
             seriesKey: inactiveSeriesKey,
             label: "Beta schedule",
-            totalEstimatedCostUsd: 0,
             colorIndex: 0,
             state: "inactive",
           },
           {
             seriesKey: activeSeriesKey,
             label: "Alpha schedule",
-            totalEstimatedCostUsd: 0.01,
             colorIndex: 1,
             state: "active",
           },
@@ -224,14 +220,12 @@ describe("UsageTrendChart", () => {
           {
             seriesKey: inactiveSeriesKey,
             label: "Beta schedule",
-            totalEstimatedCostUsd: 0,
             colorIndex: 0,
             state: "inactive",
           },
           {
             seriesKey: activeSeriesKey,
             label: "Alpha schedule",
-            totalEstimatedCostUsd: 0,
             colorIndex: 1,
             state: "active",
           },

--- a/apps/web/src/domains/logs/components/usage-trend-chart.tsx
+++ b/apps/web/src/domains/logs/components/usage-trend-chart.tsx
@@ -43,9 +43,12 @@ type SegmentTooltip = {
 type SegmentTooltipContent = Omit<SegmentTooltip, "x" | "y">;
 type UsageLegendState = "active" | "inactive";
 
-export interface UsageTrendChartLegendItem extends UsageSeriesLegendItem {
+export type UsageTrendChartLegendItem = Pick<
+  UsageSeriesLegendItem,
+  "seriesKey" | "label" | "colorIndex"
+> & {
   state?: UsageLegendState;
-}
+};
 
 interface UsageTrendChartProps {
   buckets: UsageSeriesBucket[];

--- a/apps/web/src/domains/settings/pages/schedules-page.test.ts
+++ b/apps/web/src/domains/settings/pages/schedules-page.test.ts
@@ -25,7 +25,9 @@ const navigateMock = (to: string) => {
   navigateCalls.push(to);
 };
 
+const reactRouter = await import("react-router");
 mock.module("react-router", () => ({
+  ...reactRouter,
   useNavigate: () => navigateMock,
   useParams: () => ({}),
 }));
@@ -471,12 +473,9 @@ describe("SystemTaskRow", () => {
     fireEvent.click(row);
 
     expect(detailClicks).toBe(1);
-    expect(row.className).toContain("cursor-pointer");
-    expect(row.className).toContain("hover:bg");
-    expect(row.className).toContain("focus-visible:");
   });
 
-  test("omits list-level run now while keeping status, usage, and chevron content", () => {
+  test("omits list-level run now while keeping status and usage content", () => {
     render(
       createElement(SystemTaskRow, {
         name: "Heartbeat",
@@ -495,6 +494,5 @@ describe("SystemTaskRow", () => {
     expect(screen.getByText("$0.42")).toBeTruthy();
     expect(screen.getByText("Runs")).toBeTruthy();
     expect(screen.getByText("2 runs")).toBeTruthy();
-    expect(document.querySelector(".lucide-chevron-right")).toBeTruthy();
   });
 });


### PR DESCRIPTION
Self-review remediation for the Schedules and Usage UI Polish plan: narrows the usage trend legend override type to the fields the chart consumes, removes dummy cost values from override callers/tests, and drops brittle implementation-detail assertions from system schedule row tests.