### PR TITLE
feat(web): robust wake-up ceremony for local & cloud hatch

### DIFF
--- a/apps/web/src/assistant/use-assistant-reachability.ts
+++ b/apps/web/src/assistant/use-assistant-reachability.ts
@@ -185,7 +185,7 @@ export function useAssistantReachability(
             const res = await fetch(`${ingressUrl}/readyz`);
             response = res.ok
               ? ({ state: "ready" } as AssistantsConnectionStatusResponse)
-              : null;
+              : ({ state: "waking" } as AssistantsConnectionStatusResponse);
           } catch {
             response = null;
           }

--- a/apps/web/src/assistant/use-assistant-reachability.ts
+++ b/apps/web/src/assistant/use-assistant-reachability.ts
@@ -182,7 +182,7 @@ export function useAssistantReachability(
         const ingressUrl = getSelfHostedIngressUrl();
         if (ingressUrl) {
           try {
-            const res = await fetch(`${ingressUrl}/healthz`);
+            const res = await fetch(`${ingressUrl}/readyz`);
             response = res.ok
               ? ({ state: "ready" } as AssistantsConnectionStatusResponse)
               : null;

--- a/apps/web/src/domains/chat/active-chat-view.tsx
+++ b/apps/web/src/domains/chat/active-chat-view.tsx
@@ -56,7 +56,9 @@ import { useDeepLinkConsumer } from "@/domains/chat/hooks/use-deep-link-consumer
 
 import { useChatDebugRegistration } from "@/domains/chat/hooks/use-chat-debug-registration";
 import { useDeepLinkApp } from "@/domains/chat/hooks/use-deep-link-app";
+import { lifecycleService } from "@/assistant/lifecycle-service";
 import { ConnectingToAssistant } from "@/domains/chat/components/connecting-to-assistant";
+import { Button } from "@vellumai/design-library/components/button";
 
 const AddCreditsModal = lazy(() =>
   import("@/components/add-credits-modal").then((m) => ({
@@ -299,11 +301,23 @@ export function ActiveChatView() {
 
   // Post-hatch "Connecting…" overlay lifecycle — pre-chat detector,
   // messages-arrived clear, safety timer, conversation-switch clear.
-  const autoGreetPending = useAutoGreetGate(
+  const autoGreet = useAutoGreetGate(
     activeConversationId,
     peekPendingPreChatContext()?.initialMessage != null,
     onboardingConversationId,
   );
+
+  // Stash the initial message before the first send consumes it from
+  // sessionStorage, so the retry callback can re-send it.
+  const initialMessageRef = useRef(
+    peekPendingPreChatContext()?.initialMessage ?? null,
+  );
+  const handleAutoGreetRetry = useCallback(() => {
+    const message = initialMessageRef.current;
+    if (!message) return;
+    lifecycleService.markExpectingFirstMessage();
+    void sendMessage(message);
+  }, [sendMessage]);
 
   // Deep-link: ?app=<id> auto-opens the app viewer on initial load.
   useDeepLinkApp(assistantId, searchParams);
@@ -360,12 +374,23 @@ export function ActiveChatView() {
   // message after hatching. Hooks continue running (SSE, queries) so the
   // gate clears when the first message arrives.
   // -------------------------------------------------------------------------
-  if (autoGreetPending) {
+  if (autoGreet.show) {
     return (
-      <div className="flex h-full items-center justify-center">
+      <div className="flex h-full flex-col items-center justify-center gap-4">
         <p className="text-[var(--text-secondary)]">
-          Starting your first conversation…
+          {autoGreet.timedOut
+            ? "Your assistant is taking longer than expected."
+            : "Starting your first conversation…"}
         </p>
+        {autoGreet.timedOut && (
+          <Button
+            variant="outlined"
+            size="regular"
+            onClick={handleAutoGreetRetry}
+          >
+            Try again
+          </Button>
+        )}
       </div>
     );
   }

--- a/apps/web/src/domains/chat/active-chat-view.tsx
+++ b/apps/web/src/domains/chat/active-chat-view.tsx
@@ -95,6 +95,7 @@ export function ActiveChatView() {
   const assistantId = useAssistantSelectionStore.use.activeAssistantId();
   const assistantState = useAssistantLifecycleStore.use.assistantState();
   const conversationGroupsUI = useAssistantFeatureFlagStore.use.conversationGroupsUI();
+  const turnPhase = useTurnStore.use.phase();
 
   // -------------------------------------------------------------------------
   // Chat session store — reactive selectors for per-conversation state
@@ -380,7 +381,7 @@ export function ActiveChatView() {
   // gate clears when the first message arrives.
   // -------------------------------------------------------------------------
   if (autoGreet.show) {
-    const turnActive = isSending(useTurnStore.getState());
+    const turnActive = turnPhase !== "idle";
     return (
       <div className="flex h-full flex-col items-center justify-center gap-4">
         <p className="text-[var(--text-secondary)]">

--- a/apps/web/src/domains/chat/active-chat-view.tsx
+++ b/apps/web/src/domains/chat/active-chat-view.tsx
@@ -380,14 +380,17 @@ export function ActiveChatView() {
   // gate clears when the first message arrives.
   // -------------------------------------------------------------------------
   if (autoGreet.show) {
+    const turnActive = isSending(useTurnStore.getState());
     return (
       <div className="flex h-full flex-col items-center justify-center gap-4">
         <p className="text-[var(--text-secondary)]">
           {autoGreet.timedOut
-            ? "Your assistant is taking longer than expected."
+            ? turnActive
+              ? "Your assistant is still working…"
+              : "Your assistant is taking longer than expected."
             : "Starting your first conversation…"}
         </p>
-        {autoGreet.timedOut && (
+        {autoGreet.timedOut && !turnActive && (
           <Button
             variant="outlined"
             size="regular"

--- a/apps/web/src/domains/chat/active-chat-view.tsx
+++ b/apps/web/src/domains/chat/active-chat-view.tsx
@@ -58,6 +58,7 @@ import { useChatDebugRegistration } from "@/domains/chat/hooks/use-chat-debug-re
 import { useDeepLinkApp } from "@/domains/chat/hooks/use-deep-link-app";
 import { lifecycleService } from "@/assistant/lifecycle-service";
 import { ConnectingToAssistant } from "@/domains/chat/components/connecting-to-assistant";
+import { isSending, useTurnStore } from "@/domains/chat/turn-store";
 import { Button } from "@vellumai/design-library/components/button";
 
 const AddCreditsModal = lazy(() =>
@@ -315,6 +316,7 @@ export function ActiveChatView() {
   const handleAutoGreetRetry = useCallback(() => {
     const message = initialMessageRef.current;
     if (!message) return;
+    if (isSending(useTurnStore.getState())) return;
     lifecycleService.markExpectingFirstMessage();
     void sendMessage(message);
   }, [sendMessage]);

--- a/apps/web/src/domains/chat/active-chat-view.tsx
+++ b/apps/web/src/domains/chat/active-chat-view.tsx
@@ -315,7 +315,10 @@ export function ActiveChatView() {
   );
   const handleAutoGreetRetry = useCallback(() => {
     const message = initialMessageRef.current;
-    if (!message) return;
+    if (!message) {
+      lifecycleService.clearExpectingFirstMessage();
+      return;
+    }
     if (isSending(useTurnStore.getState())) return;
     lifecycleService.markExpectingFirstMessage();
     void sendMessage(message);

--- a/apps/web/src/domains/chat/hooks/use-auto-greet-gate.ts
+++ b/apps/web/src/domains/chat/hooks/use-auto-greet-gate.ts
@@ -10,14 +10,14 @@
  *    so the auto-send hook can fire without the user seeing the raw chat UI.
  * 2. **Assistant-output clear** — once assistant output appears, the gate
  *    drops immediately.
- * 3. **Safety timer** — a 10-second backstop prevents the user from being
- *    stranded on the overlay if auto-send or greeting fails.
+ * 3. **Safety timer** — a 30-second backstop surfaces a retry prompt
+ *    if auto-send or greeting fails, instead of silently dismissing.
  * 4. **Conversation-switch clear** — switching away from the hatched
  *    conversation dismisses the gate, except for the onboarding draft→real
  *    conversation handoff while assistant output is still pending.
  */
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
 import { lifecycleService } from "@/assistant/lifecycle-service";
@@ -27,15 +27,21 @@ import {
   shouldClearFirstMessageGateOnConversationChange,
 } from "@/domains/chat/utils/chat";
 
+export interface AutoGreetGateResult {
+  show: boolean;
+  timedOut: boolean;
+}
+
 export function useAutoGreetGate(
   activeConversationId: string | null,
   hasPendingPreChatMessage: boolean,
   onboardingDraftConversationId: string | null,
-): boolean {
+): AutoGreetGateResult {
   const autoGreetPending =
     useAssistantLifecycleStore.use.expectingFirstMessage();
   const messages = useChatSessionStore.use.messages();
   const firstAssistantMessageArrived = hasAssistantMessage(messages);
+  const [timedOut, setTimedOut] = useState(false);
 
   // 1. Pre-chat sessionStorage detector — re-arm gate on reload.
   useEffect(() => {
@@ -48,17 +54,19 @@ export function useAutoGreetGate(
   useEffect(() => {
     if (!autoGreetPending) return;
     if (firstAssistantMessageArrived) {
+      setTimedOut(false);
       lifecycleService.clearExpectingFirstMessage();
     }
   }, [autoGreetPending, firstAssistantMessageArrived]);
 
-  // 3. Safety timer — 10s backstop.
+  // 3. Safety timer — 30s backstop. Surfaces a retry prompt instead
+  // of silently dismissing the overlay.
   useEffect(() => {
-    if (!autoGreetPending) return;
-    const timeout = setTimeout(
-      () => lifecycleService.clearExpectingFirstMessage(),
-      10_000,
-    );
+    if (!autoGreetPending) {
+      setTimedOut(false);
+      return;
+    }
+    const timeout = setTimeout(() => setTimedOut(true), 30_000);
     return () => clearTimeout(timeout);
   }, [autoGreetPending]);
 
@@ -88,5 +96,5 @@ export function useAutoGreetGate(
     onboardingDraftConversationId,
   ]);
 
-  return autoGreetPending;
+  return { show: autoGreetPending, timedOut };
 }


### PR DESCRIPTION
## Summary
- Switched local gateway reachability probe from `/healthz` (gateway-only) to `/readyz` (gateway + daemon), fixing the root cause of auto-wake failing for locally-hosted assistants
- Extended auto-greet gate timeout from 10s to 30s and changed it to surface a "Try again" button instead of silently dismissing the overlay
- Added retry mechanism that re-arms `expectingFirstMessage` and re-sends the initial message with onboarding context intact

## Original prompt
After onboarding with local hosting, the wake-up ceremony (auto-drop into new conversation with assistant greeting) was failing silently. Cloud-hosted hatching worked fine. The user asked to make both flows consistent and referenced LUM-1970 for ideas on building a robust bootstrap ceremony. The fix addresses the root cause (`/healthz` reporting ready before the daemon can handle messages) and adds resilience (retry surface when the ceremony stalls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)