### PR TITLE
[LUM-1981] Connectivity state machine + in-app banners

### DIFF
--- a/apps/macos/src/main/connectivity-probe.ts
+++ b/apps/macos/src/main/connectivity-probe.ts
@@ -1,0 +1,79 @@
+import { app, BrowserWindow, net, powerMonitor } from "electron";
+
+import { getLockfileData } from "@vellumai/local-mode";
+
+import { setBackendReachable } from "./status";
+
+const PROBE_INTERVAL_MS = 10_000;
+const PROBE_TIMEOUT_MS = 5_000;
+
+let probeTimer: ReturnType<typeof setInterval> | null = null;
+let probing = false;
+
+function resolveProbeTarget(lockfilePaths: string[]): string | null {
+  const result = getLockfileData(lockfilePaths);
+  if (!result.ok) return null;
+  const { assistants, activeAssistant } = result.data;
+  if (!activeAssistant) return null;
+  const entry = assistants.find((a) => a.assistantId === activeAssistant);
+  if (!entry?.resources?.gatewayPort) return null;
+  return `http://127.0.0.1:${entry.resources.gatewayPort}/healthz`;
+}
+
+async function runProbeOnce(lockfilePaths: string[]): Promise<void> {
+  if (probing) return;
+  probing = true;
+  try {
+    const target = resolveProbeTarget(lockfilePaths);
+    if (!target) return;
+    const ok = await net
+      .fetch(target, {
+        method: "GET",
+        signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+      })
+      .then((r) => r.ok)
+      .catch(() => false);
+    setBackendReachable(ok);
+  } finally {
+    probing = false;
+  }
+}
+
+function hasVisibleWindow(): boolean {
+  return BrowserWindow.getAllWindows().some(
+    (w) => !w.isDestroyed() && w.isVisible(),
+  );
+}
+
+function startProbing(lockfilePaths: string[]): void {
+  if (probeTimer) return;
+  void runProbeOnce(lockfilePaths);
+  probeTimer = setInterval(
+    () => void runProbeOnce(lockfilePaths),
+    PROBE_INTERVAL_MS,
+  );
+}
+
+function stopProbing(): void {
+  if (!probeTimer) return;
+  clearInterval(probeTimer);
+  probeTimer = null;
+}
+
+export function installConnectivityProbe(lockfilePaths: string[]): () => void {
+  const runProbe = () => void runProbeOnce(lockfilePaths);
+
+  powerMonitor.on("suspend", stopProbing);
+  powerMonitor.on("resume", () => startProbing(lockfilePaths));
+
+  app.on("browser-window-focus", () => {
+    if (!probeTimer) startProbing(lockfilePaths);
+  });
+
+  app.on("browser-window-blur", () => {
+    if (!hasVisibleWindow()) stopProbing();
+  });
+
+  startProbing(lockfilePaths);
+  return runProbe;
+}

--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -34,9 +34,10 @@ import {
   toggleVisibility as toggleMainWindowVisibility,
 } from "./main-window";
 import { installApplicationMenu } from "./menu";
+import { installConnectivityProbe } from "./connectivity-probe";
 import { installPowerEvents } from "./power-events";
 import { readSetting, writeSetting } from "./settings";
-import { installStatusIpc } from "./status";
+import { installConnectivityIpc, installStatusIpc } from "./status";
 import { installTray } from "./tray";
 
 // Dev-only: override the workspace `name` (`@vellumai/macos`) so the
@@ -326,6 +327,9 @@ app
     // initial render reflects any status the renderer publishes during
     // bootstrap rather than briefly showing the default idle dot.
     installStatusIpc();
+    const lockfilePaths = resolveLockfilePaths(process.env);
+    const runProbe = installConnectivityProbe(lockfilePaths);
+    installConnectivityIpc(runProbe);
     installTray({
       toggleMainWindow: toggleMainWindowVisibility,
       ensureMainWindow: ensureMainWindowVisible,

--- a/apps/macos/src/main/status-icon.test.ts
+++ b/apps/macos/src/main/status-icon.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 // `./status` transitively imports `./ipc` (→ `ipcMain`) at module load; stub
 // it so this test only needs the `nativeImage` surface, mocked below.
-mock.module("./ipc", () => ({ on: () => undefined }));
+mock.module("./ipc", () => ({ on: () => undefined, handle: () => undefined }));
 
 const setTemplateImageMock = mock((_flag: boolean) => undefined);
 const createFromBitmapMock = mock((_buf: unknown, _opts: unknown) => ({

--- a/apps/macos/src/main/status-icon.test.ts
+++ b/apps/macos/src/main/status-icon.test.ts
@@ -20,6 +20,7 @@ const createFromBufferMock = mock((_buf: unknown) => ({ resize: resizeMock }));
 const getSystemColorMock = mock((_name: string) => "#34c759ff");
 
 mock.module("electron", () => ({
+  BrowserWindow: { getAllWindows: () => [] },
   nativeImage: {
     createFromBuffer: createFromBufferMock,
     createFromBitmap: createFromBitmapMock,

--- a/apps/macos/src/main/status.test.ts
+++ b/apps/macos/src/main/status.test.ts
@@ -2,6 +2,22 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { z } from "zod";
 
+const sentMessages: Array<{ channel: string; payload: unknown }> = [];
+mock.module("electron", () => ({
+  BrowserWindow: {
+    getAllWindows: () => [
+      {
+        isDestroyed: () => false,
+        webContents: {
+          send: (channel: string, payload: unknown) => {
+            sentMessages.push({ channel, payload });
+          },
+        },
+      },
+    ],
+  },
+}));
+
 // Capture the channel + schema + handler that `installStatusIpc` registers,
 // without dragging in the real `ipcMain` / sender-origin guard (that guard is
 // covered by `ipc.test.ts`). The captured schema is exercised directly so we
@@ -21,13 +37,20 @@ mock.module("./ipc", () => ({ on: onMock }));
 
 const {
   ASSISTANT_STATUSES,
+  CONNECTIVITY_STATES,
   PULSE_FRAME_COUNT,
   PULSE_MAX_OPACITY,
   PULSE_MIN_OPACITY,
+  getConnectivity,
   getStatus,
+  installConnectivityIpc,
   installStatusIpc,
+  onConnectivityChange,
   onStatusChange,
   pulseOpacityFrames,
+  setBackendReachable,
+  setConnectivity,
+  setDeviceOnline,
   setStatus,
   shouldPulse,
   statusMenuTitle,
@@ -37,6 +60,7 @@ const {
 beforeEach(() => {
   __resetForTesting();
   registrations.length = 0;
+  sentMessages.length = 0;
   onMock.mockClear();
 });
 
@@ -152,5 +176,109 @@ describe("installStatusIpc", () => {
     registrations[0]!.fn(["thinking"]);
     expect(getStatus()).toBe("thinking");
     expect(seen).toEqual(["thinking"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Connectivity state machine
+// ---------------------------------------------------------------------------
+
+describe("connectivity state machine", () => {
+  test("starts online", () => {
+    expect(getConnectivity()).toBe("online");
+  });
+
+  test("device-offline wins over backend-unreachable", () => {
+    setBackendReachable(false);
+    expect(getConnectivity()).toBe("backend-unreachable");
+    setDeviceOnline(false);
+    expect(getConnectivity()).toBe("device-offline");
+  });
+
+  test("recovering device online falls through to backend state", () => {
+    setDeviceOnline(false);
+    setBackendReachable(false);
+    expect(getConnectivity()).toBe("device-offline");
+    setDeviceOnline(true);
+    expect(getConnectivity()).toBe("backend-unreachable");
+    setBackendReachable(true);
+    expect(getConnectivity()).toBe("online");
+  });
+
+  test("deduplicates — same state does not re-broadcast", () => {
+    const seen: string[] = [];
+    onConnectivityChange((s) => seen.push(s));
+    setDeviceOnline(false);
+    setDeviceOnline(false);
+    expect(seen).toEqual(["device-offline"]);
+  });
+
+  test("broadcasts to all BrowserWindows on change", () => {
+    setDeviceOnline(false);
+    const msg = sentMessages.find(
+      (m) => m.channel === "vellum:connectivity:state",
+    );
+    expect(msg).toBeDefined();
+    expect(msg!.payload).toBe("device-offline");
+  });
+
+  test("setConnectivity directly updates state and notifies listeners", () => {
+    const seen: string[] = [];
+    onConnectivityChange((s) => seen.push(s));
+    setConnectivity("backend-unreachable");
+    expect(getConnectivity()).toBe("backend-unreachable");
+    expect(seen).toEqual(["backend-unreachable"]);
+  });
+
+  test("unsubscribe stops further notifications", () => {
+    const seen: string[] = [];
+    const unsub = onConnectivityChange((s) => seen.push(s));
+    setDeviceOnline(false);
+    unsub();
+    setDeviceOnline(true);
+    expect(seen).toEqual(["device-offline"]);
+  });
+});
+
+describe("installConnectivityIpc", () => {
+  test("registers device and retry channels once", () => {
+    installConnectivityIpc();
+    installConnectivityIpc();
+    const channels = registrations.map((r) => r.channel);
+    expect(
+      channels.filter((c) => c === "vellum:connectivity:device"),
+    ).toHaveLength(1);
+    expect(
+      channels.filter((c) => c === "vellum:connectivity:retry"),
+    ).toHaveLength(1);
+  });
+
+  test("device channel drives deviceOnline signal", () => {
+    installConnectivityIpc();
+    const deviceReg = registrations.find(
+      (r) => r.channel === "vellum:connectivity:device",
+    )!;
+    deviceReg.fn([false]);
+    expect(getConnectivity()).toBe("device-offline");
+    deviceReg.fn([true]);
+    expect(getConnectivity()).toBe("online");
+  });
+
+  test("retry channel calls the onRetry callback", () => {
+    const onRetry = mock(() => {});
+    installConnectivityIpc(onRetry);
+    const retryReg = registrations.find(
+      (r) => r.channel === "vellum:connectivity:retry",
+    )!;
+    retryReg.fn([]);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  test("CONNECTIVITY_STATES contains the three expected values", () => {
+    expect([...CONNECTIVITY_STATES]).toEqual([
+      "online",
+      "device-offline",
+      "backend-unreachable",
+    ]);
   });
 });

--- a/apps/macos/src/main/status.test.ts
+++ b/apps/macos/src/main/status.test.ts
@@ -33,7 +33,19 @@ const onMock = mock(
     registrations.push({ channel, schema, fn });
   },
 );
-mock.module("./ipc", () => ({ on: onMock }));
+
+type HandleRegistration = {
+  channel: string;
+  schema: z.ZodType<unknown[]>;
+  fn: (args: unknown[]) => unknown;
+};
+const handleRegistrations: HandleRegistration[] = [];
+const handleMock = mock(
+  (channel: string, schema: z.ZodType<unknown[]>, fn: (args: unknown[]) => unknown) => {
+    handleRegistrations.push({ channel, schema, fn });
+  },
+);
+mock.module("./ipc", () => ({ on: onMock, handle: handleMock }));
 
 const {
   ASSISTANT_STATUSES,
@@ -60,8 +72,10 @@ const {
 beforeEach(() => {
   __resetForTesting();
   registrations.length = 0;
+  handleRegistrations.length = 0;
   sentMessages.length = 0;
   onMock.mockClear();
+  handleMock.mockClear();
 });
 
 describe("statusMenuTitle", () => {
@@ -272,6 +286,24 @@ describe("installConnectivityIpc", () => {
     )!;
     retryReg.fn([]);
     expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  test("registers the get channel for current state queries", () => {
+    installConnectivityIpc();
+    const getReg = handleRegistrations.find(
+      (r) => r.channel === "vellum:connectivity:get",
+    );
+    expect(getReg).toBeDefined();
+  });
+
+  test("get channel returns the current connectivity state", () => {
+    installConnectivityIpc();
+    const getReg = handleRegistrations.find(
+      (r) => r.channel === "vellum:connectivity:get",
+    )!;
+    expect(getReg.fn([])).toBe("online");
+    setDeviceOnline(false);
+    expect(getReg.fn([])).toBe("device-offline");
   });
 
   test("CONNECTIVITY_STATES contains the three expected values", () => {

--- a/apps/macos/src/main/status.ts
+++ b/apps/macos/src/main/status.ts
@@ -1,3 +1,4 @@
+import { BrowserWindow } from "electron";
 import { z } from "zod";
 
 import { on } from "./ipc";
@@ -150,10 +151,102 @@ export const installStatusIpc = (): void => {
   });
 };
 
+// ---------------------------------------------------------------------------
+// Connectivity state machine
+// ---------------------------------------------------------------------------
+// Orthogonal to AssistantStatus — you can be "thinking" AND "device-offline".
+// Assistant status drives the tray icon (renderer is source of truth);
+// connectivity drives in-app banners (main is source of truth).
+
+export const CONNECTIVITY_STATES = [
+  "online",
+  "device-offline",
+  "backend-unreachable",
+] as const;
+
+export type ConnectivityState = (typeof CONNECTIVITY_STATES)[number];
+
+type ConnectivityListener = (state: ConnectivityState) => void;
+
+let currentConnectivity: ConnectivityState = "online";
+let deviceOnline = true;
+let backendReachable = true;
+const connectivityListeners = new Set<ConnectivityListener>();
+
+export const getConnectivity = (): ConnectivityState => currentConnectivity;
+
+const broadcastConnectivity = (): void => {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (win.isDestroyed()) continue;
+    win.webContents.send("vellum:connectivity:state", currentConnectivity);
+  }
+};
+
+export const setConnectivity = (state: ConnectivityState): void => {
+  if (state === currentConnectivity) return;
+  currentConnectivity = state;
+  broadcastConnectivity();
+  for (const listener of connectivityListeners) listener(state);
+};
+
+const recomputeConnectivity = (): void => {
+  if (!deviceOnline) {
+    setConnectivity("device-offline");
+  } else if (!backendReachable) {
+    setConnectivity("backend-unreachable");
+  } else {
+    setConnectivity("online");
+  }
+};
+
+export const setDeviceOnline = (online: boolean): void => {
+  deviceOnline = online;
+  recomputeConnectivity();
+};
+
+export const setBackendReachable = (reachable: boolean): void => {
+  backendReachable = reachable;
+  recomputeConnectivity();
+};
+
+export const onConnectivityChange = (
+  listener: ConnectivityListener,
+): (() => void) => {
+  connectivityListeners.add(listener);
+  return () => {
+    connectivityListeners.delete(listener);
+  };
+};
+
+let connectivityInstalled = false;
+export const installConnectivityIpc = (
+  onRetry?: () => void,
+): void => {
+  if (connectivityInstalled) return;
+  connectivityInstalled = true;
+
+  on(
+    "vellum:connectivity:device",
+    z.tuple([z.boolean()]),
+    ([online]) => {
+      setDeviceOnline(online);
+    },
+  );
+
+  on("vellum:connectivity:retry", z.tuple([]), () => {
+    onRetry?.();
+  });
+};
+
 // Test seam — exported only for unit-test setup so each test starts from a
 // known state. Production code never calls this.
 export const __resetForTesting = (): void => {
   installed = false;
   currentStatus = "idle";
   listeners.clear();
+  connectivityInstalled = false;
+  currentConnectivity = "online";
+  deviceOnline = true;
+  backendReachable = true;
+  connectivityListeners.clear();
 };

--- a/apps/macos/src/main/status.ts
+++ b/apps/macos/src/main/status.ts
@@ -1,7 +1,7 @@
 import { BrowserWindow } from "electron";
 import { z } from "zod";
 
-import { on } from "./ipc";
+import { handle, on } from "./ipc";
 
 /**
  * Assistant connection status driving the menu-bar (Tray) indicator.
@@ -224,6 +224,8 @@ export const installConnectivityIpc = (
 ): void => {
   if (connectivityInstalled) return;
   connectivityInstalled = true;
+
+  handle("vellum:connectivity:get", z.tuple([]), () => currentConnectivity);
 
   on(
     "vellum:connectivity:device",

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -83,6 +83,16 @@ export type AssistantStatus =
   | "disconnected"
   | "authFailed";
 
+/**
+ * Mirror of `ConnectivityState` in `apps/macos/src/main/status.ts`. Main is
+ * the source of truth for connectivity (health probes + renderer device
+ * signals fused), and broadcasts state changes to all windows.
+ */
+export type ConnectivityState =
+  | "online"
+  | "device-offline"
+  | "backend-unreachable";
+
 export interface VellumBridge {
   platform: "electron";
   app: {
@@ -294,6 +304,14 @@ export interface VellumBridge {
     /** Read redacted log file content. */
     logs(): Promise<string>;
   };
+  connectivity: {
+    /** Subscribe to connectivity state changes broadcast by main. */
+    onState(callback: (state: ConnectivityState) => void): () => void;
+    /** Report browser online/offline to main. */
+    setDevice(online: boolean): void;
+    /** User-triggered retry — kicks an immediate health probe. */
+    retry(): void;
+  };
 }
 
 const notImplemented = (name: string) => (): Promise<never> =>
@@ -444,6 +462,26 @@ const bridge: VellumBridge = {
       >,
     logs: () =>
       ipcRenderer.invoke("vellum:feedback:logs") as Promise<string>,
+  },
+  connectivity: {
+    onState: (callback) => {
+      const handler = (
+        _event: IpcRendererEvent,
+        state: ConnectivityState,
+      ) => {
+        callback(state);
+      };
+      ipcRenderer.on("vellum:connectivity:state", handler);
+      return () => {
+        ipcRenderer.off("vellum:connectivity:state", handler);
+      };
+    },
+    setDevice: (online: boolean): void => {
+      ipcRenderer.send("vellum:connectivity:device", online);
+    },
+    retry: (): void => {
+      ipcRenderer.send("vellum:connectivity:retry");
+    },
   },
 };
 

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -472,6 +472,11 @@ const bridge: VellumBridge = {
         callback(state);
       };
       ipcRenderer.on("vellum:connectivity:state", handler);
+      // Emit the current state so late subscribers (window loaded after
+      // the first probe) don't wait for the next state transition.
+      void (
+        ipcRenderer.invoke("vellum:connectivity:get") as Promise<ConnectivityState>
+      ).then(callback);
       return () => {
         ipcRenderer.off("vellum:connectivity:state", handler);
       };

--- a/apps/web/src/components/offline-banner.test.tsx
+++ b/apps/web/src/components/offline-banner.test.tsx
@@ -3,6 +3,9 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 let isNativePlatformMock = false;
 let connectedMock = true;
+let connectivityStateMock: "online" | "device-offline" | "backend-unreachable" =
+  "online";
+let isElectronMock = false;
 
 mock.module("@/runtime/native-auth", () => ({
   isNativePlatform: () => isNativePlatformMock,
@@ -13,9 +16,30 @@ mock.module("@/hooks/use-network-status", () => ({
   useNetworkStatus: () => connectedMock,
 }));
 
+mock.module("@/hooks/use-connectivity-state", () => ({
+  useConnectivityState: () => connectivityStateMock,
+}));
+
+mock.module("@/runtime/is-electron", () => ({
+  isElectron: () => isElectronMock,
+}));
+
+mock.module("@/runtime/connectivity", () => ({
+  retryConnectivity: () => {},
+}));
+
 mock.module("@vellumai/design-library/components/notice", () => ({
-  Notice: (props: { title: string }) => (
-    <div data-testid="notice">{props.title}</div>
+  Notice: (props: { title: string; actions?: React.ReactNode }) => (
+    <div data-testid="notice">
+      {props.title}
+      {props.actions}
+    </div>
+  ),
+}));
+
+mock.module("@vellumai/design-library/components/button", () => ({
+  Button: (props: { children: string }) => (
+    <button data-testid="button">{props.children}</button>
   ),
 }));
 
@@ -24,27 +48,53 @@ import { OfflineBanner } from "@/components/offline-banner";
 beforeEach(() => {
   isNativePlatformMock = false;
   connectedMock = true;
+  connectivityStateMock = "online";
+  isElectronMock = false;
 });
 
 describe("OfflineBanner", () => {
-  test("renders nothing on web (non-native)", () => {
-    isNativePlatformMock = false;
-    connectedMock = false;
+  test("renders nothing on web (non-native, non-electron)", () => {
     const html = renderToStaticMarkup(<OfflineBanner />);
     expect(html).toBe("");
   });
 
-  test("renders nothing when connected on native", () => {
-    isNativePlatformMock = true;
-    connectedMock = true;
-    const html = renderToStaticMarkup(<OfflineBanner />);
-    expect(html).toBe("");
+  describe("Capacitor iOS", () => {
+    test("renders nothing when connected on native", () => {
+      isNativePlatformMock = true;
+      connectedMock = true;
+      const html = renderToStaticMarkup(<OfflineBanner />);
+      expect(html).toBe("");
+    });
+
+    test("renders banner when offline on native", () => {
+      isNativePlatformMock = true;
+      connectedMock = false;
+      const html = renderToStaticMarkup(<OfflineBanner />);
+      expect(html).toContain("offline");
+    });
   });
 
-  test("renders banner when offline on native", () => {
-    isNativePlatformMock = true;
-    connectedMock = false;
-    const html = renderToStaticMarkup(<OfflineBanner />);
-    expect(html).toContain("offline");
+  describe("Electron", () => {
+    test("renders nothing when online", () => {
+      isElectronMock = true;
+      connectivityStateMock = "online";
+      const html = renderToStaticMarkup(<OfflineBanner />);
+      expect(html).toBe("");
+    });
+
+    test("renders device-offline banner", () => {
+      isElectronMock = true;
+      connectivityStateMock = "device-offline";
+      const html = renderToStaticMarkup(<OfflineBanner />);
+      expect(html).toContain("offline");
+    });
+
+    test("renders backend-unreachable banner with retry button", () => {
+      isElectronMock = true;
+      connectivityStateMock = "backend-unreachable";
+      const html = renderToStaticMarkup(<OfflineBanner />);
+      expect(html).toContain("Trying to reach Vellum");
+      expect(html).toContain("Retry now");
+    });
   });
 });

--- a/apps/web/src/components/offline-banner.tsx
+++ b/apps/web/src/components/offline-banner.tsx
@@ -1,21 +1,50 @@
-import { WifiOff } from "lucide-react";
+import { CloudOff, WifiOff } from "lucide-react";
 
+import { useConnectivityState } from "@/hooks/use-connectivity-state";
 import { useNetworkStatus } from "@/hooks/use-network-status";
+import { retryConnectivity } from "@/runtime/connectivity";
+import { isElectron } from "@/runtime/is-electron";
 import { useIsNativePlatform } from "@/runtime/native-auth";
+import { Button } from "@vellumai/design-library/components/button";
 import { Notice } from "@vellumai/design-library/components/notice";
 
-/**
- * Non-intrusive banner shown when the Capacitor iOS app loses network
- * connectivity. Auto-dismisses when the connection is restored.
- *
- * Renders nothing on web — gated by `useIsNativePlatform()` to avoid
- * console errors from the Network plugin.
- */
-export function OfflineBanner() {
-  const isNative = useIsNativePlatform();
+function ElectronConnectivityBanner() {
+  const state = useConnectivityState();
+
+  if (state === "online") return null;
+
+  if (state === "device-offline") {
+    return (
+      <div className="px-4 pt-2">
+        <Notice
+          tone="warning"
+          title="You're offline"
+          icon={<WifiOff className="h-4 w-4" aria-hidden="true" />}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="px-4 pt-2">
+      <Notice
+        tone="warning"
+        title="Trying to reach Vellum…"
+        icon={<CloudOff className="h-4 w-4" aria-hidden="true" />}
+        actions={
+          <Button variant="outlined" size="compact" onClick={retryConnectivity}>
+            Retry now
+          </Button>
+        }
+      />
+    </div>
+  );
+}
+
+function NativeOfflineBanner() {
   const connected = useNetworkStatus();
 
-  if (!isNative || connected) return null;
+  if (connected) return null;
 
   return (
     <div className="px-4 pt-2">
@@ -26,4 +55,12 @@ export function OfflineBanner() {
       />
     </div>
   );
+}
+
+export function OfflineBanner() {
+  const isNative = useIsNativePlatform();
+
+  if (isElectron()) return <ElectronConnectivityBanner />;
+  if (isNative) return <NativeOfflineBanner />;
+  return null;
 }

--- a/apps/web/src/hooks/use-connectivity-state.ts
+++ b/apps/web/src/hooks/use-connectivity-state.ts
@@ -1,0 +1,50 @@
+import { useEffect, useRef, useState } from "react";
+
+import {
+  subscribeToConnectivity,
+  type ConnectivityState,
+} from "@/runtime/connectivity";
+
+export type { ConnectivityState };
+
+const RECOVERY_DEBOUNCE_MS = 2_000;
+
+/**
+ * React hook that tracks the Electron host's connectivity state.
+ *
+ * Returns `"online"` off Electron. Degraded states appear immediately;
+ * recovery to `"online"` is debounced by 2 seconds so the banner
+ * doesn't flicker on flaky networks.
+ */
+export function useConnectivityState(): ConnectivityState {
+  const [state, setState] = useState<ConnectivityState>("online");
+  const recoveryTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    const unsub = subscribeToConnectivity((next) => {
+      if (next === "online") {
+        if (recoveryTimer.current) return;
+        recoveryTimer.current = setTimeout(() => {
+          recoveryTimer.current = null;
+          setState("online");
+        }, RECOVERY_DEBOUNCE_MS);
+      } else {
+        if (recoveryTimer.current) {
+          clearTimeout(recoveryTimer.current);
+          recoveryTimer.current = null;
+        }
+        setState(next);
+      }
+    });
+
+    return () => {
+      unsub();
+      if (recoveryTimer.current) {
+        clearTimeout(recoveryTimer.current);
+        recoveryTimer.current = null;
+      }
+    };
+  }, []);
+
+  return state;
+}

--- a/apps/web/src/hooks/use-event-bus-init.ts
+++ b/apps/web/src/hooks/use-event-bus-init.ts
@@ -27,6 +27,7 @@ import { sseService } from "@/assistant/sse-service";
 import { subscribeLifecycleDiagnostics } from "@/lib/lifecycle-diagnostics";
 import { publishCapacitorAppStateSource } from "@/runtime/event-sources/capacitor-app-state";
 import { publishVisibilitySource } from "@/runtime/event-sources/dom-visibility";
+import { publishElectronConnectivitySource } from "@/runtime/event-sources/electron-connectivity";
 import { publishElectronDeepLinksSource } from "@/runtime/event-sources/electron-deep-links";
 import { publishElectronPowerSource } from "@/runtime/event-sources/electron-power";
 import { publishWindowOnlineSource } from "@/runtime/event-sources/window-online";
@@ -57,6 +58,7 @@ export function useEventBusInit({
       publishCapacitorAppStateSource(),
       publishElectronPowerSource(),
       publishElectronDeepLinksSource(),
+      publishElectronConnectivitySource(),
       subscribeLifecycleDiagnostics(),
     ];
     return () => {

--- a/apps/web/src/lib/event-bus.ts
+++ b/apps/web/src/lib/event-bus.ts
@@ -124,6 +124,16 @@ export interface BusEventMap {
   "deeplink.send": { message: string };
   "deeplink.openThread": { threadId: string };
   "deeplink.unknown": { url: string };
+  /**
+   * Connectivity state change from the Electron host. Main fuses
+   * device-level online/offline with backend health-probe results into
+   * three states: `"online"`, `"device-offline"`, `"backend-unreachable"`.
+   *
+   * Off Electron this never fires.
+   */
+  "connectivity.state": {
+    state: "online" | "device-offline" | "backend-unreachable";
+  };
 }
 
 export type BusEventName = keyof BusEventMap;

--- a/apps/web/src/runtime/connectivity.ts
+++ b/apps/web/src/runtime/connectivity.ts
@@ -1,0 +1,32 @@
+import { isElectron, type ConnectivityState } from "@/runtime/is-electron";
+
+export type { ConnectivityState };
+
+/**
+ * Subscribe to connectivity state changes from the Electron host.
+ * No-op off Electron — returns an unsubscribe-noop.
+ */
+export function subscribeToConnectivity(
+  callback: (state: ConnectivityState) => void,
+): () => void {
+  if (!isElectron()) return () => undefined;
+  return window.vellum?.connectivity?.onState(callback) ?? (() => undefined);
+}
+
+/**
+ * Report browser online/offline to the Electron host so main can fuse it
+ * with backend health probes. No-op off Electron.
+ */
+export function reportDeviceOnline(online: boolean): void {
+  if (!isElectron()) return;
+  window.vellum?.connectivity?.setDevice(online);
+}
+
+/**
+ * Trigger an immediate connectivity retry from the Electron host.
+ * No-op off Electron.
+ */
+export function retryConnectivity(): void {
+  if (!isElectron()) return;
+  window.vellum?.connectivity?.retry();
+}

--- a/apps/web/src/runtime/event-sources/electron-connectivity.ts
+++ b/apps/web/src/runtime/event-sources/electron-connectivity.ts
@@ -1,0 +1,36 @@
+import { publish, subscribe } from "@/lib/event-bus";
+import {
+  reportDeviceOnline,
+  subscribeToConnectivity,
+} from "@/runtime/connectivity";
+
+/**
+ * Two concerns in one source:
+ *
+ * 1. Forward main→renderer connectivity state broadcasts into the bus
+ *    so domain consumers subscribe to `connectivity.state` uniformly.
+ *
+ * 2. Forward browser online/offline bus events to main via
+ *    `reportDeviceOnline` so the main-process state machine fuses
+ *    device-level reachability with its own health probes. Subscribes
+ *    to `app.online`/`app.offline` rather than re-adding window
+ *    listeners — `publishWindowOnlineSource` already owns those.
+ *
+ * Off Electron both halves are no-ops.
+ */
+export function publishElectronConnectivitySource(): () => void {
+  const unsubConnectivity = subscribeToConnectivity((state) => {
+    publish("connectivity.state", { state });
+  });
+
+  const unsubOnline = subscribe("app.online", () => reportDeviceOnline(true));
+  const unsubOffline = subscribe("app.offline", () =>
+    reportDeviceOnline(false),
+  );
+
+  return () => {
+    unsubConnectivity();
+    unsubOnline();
+    unsubOffline();
+  };
+}

--- a/apps/web/src/runtime/event-sources/electron-connectivity.ts
+++ b/apps/web/src/runtime/event-sources/electron-connectivity.ts
@@ -19,6 +19,10 @@ import {
  * Off Electron both halves are no-ops.
  */
 export function publishElectronConnectivitySource(): () => void {
+  // Seed main with the current device online state so it doesn't
+  // assume online when the app launched while the device was offline.
+  reportDeviceOnline(navigator.onLine);
+
   const unsubConnectivity = subscribeToConnectivity((state) => {
     publish("connectivity.state", { state });
   });

--- a/apps/web/src/runtime/is-electron.ts
+++ b/apps/web/src/runtime/is-electron.ts
@@ -53,6 +53,18 @@ export type AssistantStatus =
   | "disconnected"
   | "authFailed";
 
+/**
+ * Renderer-side mirror of `ConnectivityState` in
+ * `apps/macos/src/main/status.ts`. Inline for the same reason as
+ * `AssistantStatus`. Main is the source of truth — it fuses device-level
+ * online/offline and backend health-probe signals, then broadcasts to
+ * all windows.
+ */
+export type ConnectivityState =
+  | "online"
+  | "device-offline"
+  | "backend-unreachable";
+
 declare global {
   interface Window {
     vellum?: {
@@ -148,6 +160,14 @@ declare global {
       feedback?: {
         diagnostics(): Promise<Record<string, unknown>>;
         logs(): Promise<string>;
+      };
+      // Optional: older Electron shells predate the connectivity channel.
+      connectivity?: {
+        onState(
+          callback: (state: ConnectivityState) => void,
+        ): () => void;
+        setDevice(online: boolean): void;
+        retry(): void;
       };
     };
   }


### PR DESCRIPTION
## Summary
- Add a connectivity state machine to `status.ts` that fuses device-level online/offline (from renderer) with backend health probes (from main) into three states: `online`, `device-offline`, `backend-unreachable`
- Add a health probe loop (`connectivity-probe.ts`) that pings the local daemon's `/healthz` endpoint every 10s, with battery-aware pause on suspend / no visible windows
- Wire in-app banners via the existing `OfflineBanner` component — "You're offline" (device) and "Trying to reach Vellum…" with a Retry button (backend unreachable), with 2s debounce on recovery to avoid flicker

## Original prompt
The user reviewed Linear ticket LUM-1981 and asked to plan a connectivity state machine integrated into the existing `src/main/status.ts` module. We designed a system where main is the source of truth for connectivity (orthogonal to the existing renderer-driven assistant status), with two fused signals: device-level from the renderer's `online`/`offline` events, and backend-level from main-process health probes to the local daemon. The full IPC bridge, event bus integration, React hook with debounce, and banner UI were specified in a plan that this PR implements.

## Test plan
- [ ] `bun test src/main/status.test.ts` — 23 tests pass (connectivity state machine, IPC registration, priority, dedup, broadcast)
- [ ] `bun test src/components/offline-banner.test.tsx` — 6 tests pass (web/Capacitor/Electron paths, all three banner states)
- [ ] Manual: disable WiFi → "You're offline" banner appears within ~1s
- [ ] Manual: re-enable WiFi → banner clears after ~2s
- [ ] Manual: kill local daemon → "Trying to reach Vellum…" with retry button appears within ~10s
- [ ] Manual: click "Retry now" → triggers immediate health probe

🤖 Generated with [Claude Code](https://claude.com/claude-code)