### PR TITLE
fix(macos): handle CSRF token in platform proxy without cookies

### DIFF
--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -204,14 +204,27 @@ const forwardGatewayRequest = async (
   }
 };
 
+const CSRF_COOKIE_RE = /(?:__Secure-)?csrftoken=([^;]+)/;
+
+// `app://` is not a cookieable scheme, so the renderer can't read the CSRF
+// token via `document.cookie`. Main caches it here and injects it into
+// forwarded requests; `net.fetch`'s own cookie jar supplies the cookie side.
+let cachedCsrfToken: string | null = null;
+
+const captureCsrfToken = (response: Response): void => {
+  const setCookies = response.headers.getSetCookie?.() ?? [];
+  for (const raw of setCookies) {
+    const match = CSRF_COOKIE_RE.exec(raw);
+    if (match?.[1]) {
+      cachedCsrfToken = match[1];
+    }
+  }
+};
+
 /**
  * Forward a platform API request (`/v1/*`, `/_allauth/*`, `/accounts/*`) to
  * the cloud platform, or return `null` for non-platform paths. Mirrors the
  * gateway forward: `net.fetch` runs in main so the renderer stays same-origin.
- *
- * After a successful response, CSRF cookies from the platform are mirrored
- * into the renderer's session so `document.cookie` can read the token for
- * mutating requests.
  */
 const forwardPlatformRequest = async (
   request: GlobalRequest,
@@ -219,6 +232,10 @@ const forwardPlatformRequest = async (
 ): Promise<Response | null> => {
   const plan = planPlatformForward(request, platformUrl);
   if (plan.kind === "pass") return null;
+
+  if (cachedCsrfToken && !plan.headers.has("X-CSRFToken")) {
+    plan.headers.set("X-CSRFToken", cachedCsrfToken);
+  }
 
   let response: Response;
   try {
@@ -234,34 +251,8 @@ const forwardPlatformRequest = async (
     return new Response(message, { status: 502 });
   }
 
-  await mirrorCsrfCookie(response);
+  captureCsrfToken(response);
   return response;
-};
-
-const CSRF_COOKIE_RE = /(?:__Secure-)?csrftoken=([^;]+)/;
-
-/**
- * Mirror the CSRF token cookie from a platform response into the renderer's
- * session cookie store so `document.cookie` can read it. The session cookie
- * (`sessionid`) stays in `net.fetch`'s own jar for the platform domain —
- * only the CSRF token needs to be visible to the renderer's JS interceptor.
- */
-const mirrorCsrfCookie = async (response: Response): Promise<void> => {
-  const setCookies = response.headers.getSetCookie?.() ?? [];
-  for (const raw of setCookies) {
-    const match = CSRF_COOKIE_RE.exec(raw);
-    if (match?.[1]) {
-      const name = raw.startsWith("__Secure-")
-        ? "__Secure-csrftoken"
-        : "csrftoken";
-      await session.defaultSession.cookies.set({
-        url: `app://${APP_HOST}`,
-        name,
-        value: match[1],
-        secure: true,
-      });
-    }
-  }
 };
 
 // Deny renderer permission requests by default. Specific permissions

--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -14,7 +14,7 @@ import { installAbout, openAboutWindow } from "./about";
 import { APP_HOST, APP_PROTOCOL } from "./app-config";
 import { installCsp } from "./csp";
 import { ensureWebInstalled, getWebDistPath } from "./cli-installer";
-import { handle } from "./ipc";
+import { handle, handleSync } from "./ipc";
 import { resolveAppProtocolPath } from "./app-protocol";
 import { planGatewayForward } from "./gateway-forward";
 import { planPlatformForward } from "./platform-forward";
@@ -210,6 +210,7 @@ const CSRF_COOKIE_RE = /(?:__Secure-)?csrftoken=([^;]+)/;
 // token via `document.cookie`. Main caches it here and injects it into
 // forwarded requests; `net.fetch`'s own cookie jar supplies the cookie side.
 let cachedCsrfToken: string | null = null;
+handleSync("vellum:csrf:getToken", () => cachedCsrfToken);
 
 const captureCsrfToken = (response: Response): void => {
   const setCookies = response.headers.getSetCookie?.() ?? [];

--- a/apps/macos/src/main/ipc.ts
+++ b/apps/macos/src/main/ipc.ts
@@ -60,6 +60,20 @@ export const handle = <Args extends unknown[], R>(
  * the accounting messages that use this path (there's no promise to
  * reject).
  */
+/**
+ * Register a synchronous (`ipcRenderer.sendSync`) handler. Same sender
+ * validation as `handle`/`on`; returns `null` for rejected senders so the
+ * renderer's `sendSync` never hangs.
+ */
+export const handleSync = <R>(
+  channel: string,
+  fn: () => R,
+): void => {
+  ipcMain.on(channel, (event) => {
+    event.returnValue = isAllowedSender(event) ? fn() : null;
+  });
+};
+
 export const on = <Args extends unknown[]>(
   channel: string,
   schema: z.ZodType<Args>,

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -100,6 +100,9 @@ export interface VellumBridge {
      */
     openWebsite(): Promise<void>;
   };
+  csrf: {
+    getToken(): string | null;
+  };
   auth: {
     signIn(): Promise<void>;
     signOut(): Promise<void>;
@@ -306,6 +309,10 @@ const bridge: VellumBridge = {
       ipcRenderer.invoke("vellum:app:versionInfo") as Promise<AppVersionInfo>,
     openWebsite: (): Promise<void> =>
       ipcRenderer.invoke("vellum:app:openWebsite") as Promise<void>,
+  },
+  csrf: {
+    getToken: (): string | null =>
+      ipcRenderer.sendSync("vellum:csrf:getToken") as string | null,
   },
   auth: {
     signIn: notImplemented("auth.signIn"),

--- a/apps/web/src/lib/auth/csrf.ts
+++ b/apps/web/src/lib/auth/csrf.ts
@@ -23,6 +23,12 @@ const CSRF_COOKIE_NAME = import.meta.env.PROD
  * last-wins semantics.
  */
 export function getCsrfToken(): string | undefined {
+  // In Electron the `app://` scheme doesn't support cookies, so
+  // `document.cookie` is always empty. Read from the preload bridge
+  // which pulls the token from main's cache via sync IPC.
+  const bridgeToken = window.vellum?.csrf?.getToken();
+  if (bridgeToken) return bridgeToken;
+
   const match = document.cookie
     .split("; ")
     .findLast((row) => row.startsWith(`${CSRF_COOKIE_NAME}=`));

--- a/apps/web/src/runtime/is-electron.ts
+++ b/apps/web/src/runtime/is-electron.ts
@@ -67,6 +67,9 @@ declare global {
         }>;
         openWebsite(): Promise<void>;
       };
+      csrf?: {
+        getToken(): string | null;
+      };
       settings: {
         get<T = unknown>(key: string): Promise<T | null>;
         set<T = unknown>(key: string, value: T): Promise<void>;


### PR DESCRIPTION
## Summary
- Removed `mirrorCsrfCookie` which tried to set cookies on the `app://` scheme (unsupported by Chromium's cookie store, causing an unhandled rejection that crashed the protocol handler)
- Replaced with main-side CSRF injection: `captureCsrfToken` extracts the token from platform `Set-Cookie` headers into a module-level cache, and `forwardPlatformRequest` injects `X-CSRFToken` into forwarded requests before they hit the platform
- `net.fetch`'s own cookie jar handles the cookie side of Django's CSRF check; the cached token supplies the header side — no renderer-side cookie access needed

## Original prompt
The Electron DMG build was showing a blank white screen on launch. Debugging revealed a terminal error: `Failed to set cookie - Attempted to set a cookie from a scheme that does not support cookies.EXCLUDE_NONCOOKIEABLE_SCHEME`. The `app://` protocol scheme isn't cookieable in Chromium, so the old `mirrorCsrfCookie` approach (writing the CSRF token into the renderer's cookie jar) threw an unhandled rejection that crashed the protocol handler. This broke all platform API calls, preventing the web UI from rendering. The fix needed to work in both packaged DMG builds and local dev-from-source, and avoid changes to the platform repo.