### PR TITLE
Give profile advanced params adequate vertical spacing

### DIFF
--- a/apps/web/src/domains/settings/ai/profile-advanced-params.tsx
+++ b/apps/web/src/domains/settings/ai/profile-advanced-params.tsx
@@ -106,7 +106,11 @@ export function ProfileAdvancedParams({
   onThinkingLevelChange,
 }: ProfileAdvancedParamsProps) {
   return (
-    <>
+    // space-y-4 matches the modal body's rhythm so each advanced param gets
+    // the same vertical breathing room as the "normal" fields above. Without
+    // a spacing wrapper the fragment stacked these blocks flush against each
+    // other (and against the disclosure edges).
+    <div className="space-y-4">
       {/* Max Output Tokens */}
       {visibility.maxTokens && (
         <div className="space-y-1">
@@ -317,6 +321,6 @@ export function ProfileAdvancedParams({
           />
         </div>
       )}
-    </>
+    </div>
   );
 }

--- a/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -794,7 +794,7 @@ function ProfileEditorModalInner({
           <span>Advanced</span>
         </button>
         {advancedExpanded ? (
-          <div className="mt-2">{advancedParamsNode}</div>
+          <div className="mt-4">{advancedParamsNode}</div>
         ) : null}
       </div>
     ) : null;


### PR DESCRIPTION
## What

When the profile editor's **Advanced** parameters were shown (create-mode disclosure or edit/view mode), the individual controls — Max Output Tokens, Context Window, Effort, Speed, Verbosity, Temperature, Thinking — stacked **flush against each other with no gap**. They rendered inside a bare React fragment, so they didn't get the `space-y-4` vertical rhythm that the "normal" form fields above them inherit from the modal body.

## Changes

- `profile-advanced-params.tsx`: wrap the params in a `space-y-4` container so each control gets the same vertical breathing room as the rest of the form.
- `profile-editor-modal.tsx`: bump the create-mode Advanced disclosure's expanded content from `mt-2` to `mt-4` so the section has sufficient top spacing below the toggle.

The modal itself already scrolls (design-library `Modal.Content` is capped at `max-h-[calc(100vh-2rem)]` with a `flex-1 overflow-y-auto` body), so no scroll changes were needed — this is purely the internal spacing the advanced section was missing.