### PR TITLE
fix(web): use identity intro tagline as chat empty-state greeting fallback

### DIFF
--- a/assistant/src/runtime/routes/identity-routes.ts
+++ b/assistant/src/runtime/routes/identity-routes.ts
@@ -33,6 +33,7 @@ import { NotFoundError } from "./errors.js";
 import {
   getCachedIntro,
   readWorkspaceGreetings,
+  readWorkspaceIdentityIntro,
   setCachedIntro,
 } from "./identity-intro-cache.js";
 import type { RouteDefinition } from "./types.js";
@@ -455,16 +456,30 @@ function getIdentityIntro(): IdentityIntroResponse {
     return identityIntroResponse(FALLBACK_GREETINGS, "fallback");
   }
 
-  // 2. Cached LLM-generated greetings
+  // 2. Cached LLM-generated greetings (populated by background refresh)
   const cached = getCachedIntro();
   if (cached) {
     return identityIntroResponse(cached.greetings, "cache");
   }
 
-  // 3. Trigger fresh generation without blocking the empty-state UI.
+  // 3. Identity intro tagline from `## Identity Intro` in IDENTITY.md
+  //    (written during onboarding by BOOTSTRAP.md instructions)
+  const identityIntro = readWorkspaceIdentityIntro();
+  if (identityIntro) {
+    // Still trigger background generation so the next request gets
+    // LLM-generated greetings instead of the static tagline.
+    const refreshing = triggerEmptyStateGreetingGeneration();
+    return identityIntroResponse(
+      [identityIntro, ...FALLBACK_GREETINGS],
+      "workspace",
+      refreshing,
+    );
+  }
+
+  // 4. Trigger fresh generation without blocking the empty-state UI.
   const refreshing = triggerEmptyStateGreetingGeneration();
 
-  // 4. Generic fallback only when generation is unavailable.
+  // 5. Generic fallback only when generation is unavailable.
   return identityIntroResponse(FALLBACK_GREETINGS, "fallback", refreshing);
 }
 


### PR DESCRIPTION
## Summary

- The chat empty-state greeting on web fell through to static fallbacks ("Hi, I'm {name}!" or generic text) because the `## Identity Intro` tagline — written during onboarding by BOOTSTRAP.md — was never consulted by the `GET /v1/identity/intro` endpoint
- Adds `readWorkspaceIdentityIntro()` as priority 3 in the greeting resolution chain (after SOUL.md greetings and cached LLM greetings, before the generic fallback)
- When the identity intro tagline is returned, also kicks off background LLM generation so the next request returns a fully personalized greeting

**Resolution order is now:**
1. User-defined `## Greetings` in SOUL.md
2. Cached LLM-generated greetings
3. `## Identity Intro` tagline from IDENTITY.md ← **new**
4. Fire-and-forget LLM generation (returns fallback immediately)
5. Generic fallback greetings

## Test plan

- [x] `bunx tsc --noEmit` passes
- [x] `bun test identity-intro-cache.test.ts` passes
- [x] `bun test btw-routes.test.ts` passes
- [ ] Verify on web: empty-state shows identity intro tagline on first load, then LLM greeting on subsequent loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)