### PR TITLE
feat(web): show live plan total in the Pro card header instead of the tier picker

### DIFF
--- a/apps/web/src/domains/settings/components/adjust-plan-modal.test.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.test.tsx
@@ -539,7 +539,7 @@ describe("AdjustPlanModal credit bundle — headline total", () => {
     );
 
     await waitFor(() => {
-      if (getByTestId("tier-picker-total").textContent?.includes("$35/mo"))
+      if (getByTestId("modal-pro-price").textContent?.includes("$35/mo"))
         return;
       throw new Error("base total not rendered yet");
     });
@@ -548,7 +548,7 @@ describe("AdjustPlanModal credit bundle — headline total", () => {
     clickOption("50 credits — $50/mo");
 
     await waitFor(() => {
-      if (getByTestId("tier-picker-total").textContent?.includes("$85/mo"))
+      if (getByTestId("modal-pro-price").textContent?.includes("$85/mo"))
         return;
       throw new Error("total did not include the selected bundle");
     });
@@ -563,7 +563,7 @@ describe("AdjustPlanModal credit bundle — headline total", () => {
     );
 
     await waitFor(() => {
-      if (getByTestId("tier-picker-total").textContent?.includes("$35/mo"))
+      if (getByTestId("modal-pro-price").textContent?.includes("$35/mo"))
         return;
       throw new Error("current total not rendered yet");
     });
@@ -572,7 +572,7 @@ describe("AdjustPlanModal credit bundle — headline total", () => {
     clickOption("25 credits — $25/mo");
 
     await waitFor(() => {
-      const text = getByTestId("tier-picker-total").textContent ?? "";
+      const text = getByTestId("modal-pro-price").textContent ?? "";
       if (text.includes("$60/mo") && text.includes("+$25/mo")) return;
       throw new Error("total/delta did not reflect the swapped bundle");
     });

--- a/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
@@ -1,4 +1,11 @@
-import { AlertTriangle, ArrowLeft, Crown, Loader2, Palmtree } from "lucide-react";
+import {
+    AlertTriangle,
+    ArrowLeft,
+    Crown,
+    Info,
+    Loader2,
+    Palmtree,
+} from "lucide-react";
 import { useEffect, useState } from "react";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -43,6 +50,7 @@ import { CreditBundlePicker } from "./credit-bundle-picker";
 import { DowngradeReconfirmModal } from "./downgrade-reconfirm-modal";
 import { PlanFeatureList } from "./plan-feature-list";
 import { TierPicker, isTierDisabled } from "./tier-picker";
+import { formatDelta, formatMonthly } from "./tier-pricing";
 
 
 /**
@@ -482,6 +490,7 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
   // A machine downgrade (cheaper than current) routes through the reconfirm
   // modal first; an upgrade fires immediately.
   const nextMachinePrice = priceForMachine(selectedMachineTier);
+  const nextStoragePrice = priceForStorage(selectedStorageTier);
   const currentMachinePrice = priceForMachine(currentMachineTier);
   const currentStoragePrice = priceForStorage(currentStorageTier);
   const isMachineDowngrade =
@@ -704,6 +713,32 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                     // that path shows only reactivation).
                     const showProTierChange =
                       isProCard && isCurrent && proTierChangeMode;
+                    // Live running total for the Pro card header: base + the
+                    // selected machine/storage/credit prices. Updates as the
+                    // user changes any dimension. In change mode it also carries
+                    // a delta vs. the current subscription.
+                    const proLiveTotalCents =
+                      isProCard &&
+                      nextMachinePrice != null &&
+                      nextStoragePrice != null
+                        ? plan.base_price_cents +
+                          nextMachinePrice +
+                          nextStoragePrice +
+                          selectedCreditPriceCents
+                        : null;
+                    const proCurrentTotalCents =
+                      isProCard &&
+                      currentMachinePrice != null &&
+                      currentStoragePrice != null
+                        ? plan.base_price_cents +
+                          currentMachinePrice +
+                          currentStoragePrice +
+                          currentCreditPriceCents
+                        : null;
+                    const proTotalDelta =
+                      proLiveTotalCents != null && proCurrentTotalCents != null
+                        ? proLiveTotalCents - proCurrentTotalCents
+                        : null;
                     return (
                       <Card
                         key={plan.id}
@@ -761,39 +796,43 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                                   Forever
                                 </Typography>
                               </>
-                            ) : proTierChangeMode &&
-                              currentMachinePrice != null &&
-                              currentStoragePrice != null ? (
-                              <>
-                                <Typography as="p" variant="title-medium">
-                                  Currently $
-                                  {Math.round(
-                                    (plan.base_price_cents +
-                                      currentMachinePrice +
-                                      currentStoragePrice +
-                                      currentCreditPriceCents) /
-                                      100,
-                                  )}
-                                </Typography>
-                                <Typography
-                                  as="p"
-                                  variant="body-small-default"
-                                  className="text-[var(--content-tertiary)]"
-                                >
-                                  Billed monthly
-                                </Typography>
-                              </>
                             ) : (
                               <>
-                                <Typography as="p" variant="title-medium">
-                                  From $
-                                  {Math.round(
-                                    (plan.base_price_cents +
-                                      minTierPriceCents(plan.machine_tiers) +
-                                      minTierPriceCents(plan.storage_tiers)) /
-                                      100,
-                                  )}
-                                </Typography>
+                                <div className="flex items-center gap-1">
+                                  <Typography
+                                    as="p"
+                                    variant="title-medium"
+                                    data-testid="modal-pro-price"
+                                  >
+                                    {proLiveTotalCents != null ? (
+                                      <>
+                                        {formatMonthly(proLiveTotalCents)}
+                                        {proTotalDelta != null &&
+                                          proTotalDelta !== 0 && (
+                                            <span className="ml-1 text-[var(--content-tertiary)]">
+                                              ({formatDelta(proTotalDelta)})
+                                            </span>
+                                          )}
+                                      </>
+                                    ) : (
+                                      `From ${formatMonthly(
+                                        plan.base_price_cents +
+                                          minTierPriceCents(plan.machine_tiers) +
+                                          minTierPriceCents(plan.storage_tiers),
+                                      )}`
+                                    )}
+                                  </Typography>
+                                  <span
+                                    title={
+                                      proTotalDelta != null &&
+                                      proTotalDelta !== 0
+                                        ? `Your Pro Plan subscription will change from ${formatMonthly(proCurrentTotalCents!)} to ${formatMonthly(proLiveTotalCents!)}. Includes a $10/month flat fee for Pro Features.`
+                                        : "Includes a $10/month flat fee for Pro Features."
+                                    }
+                                  >
+                                    <Info className="h-3 w-3 text-[var(--content-tertiary)]" />
+                                  </span>
+                                </div>
                                 <Typography
                                   as="p"
                                   variant="body-small-default"
@@ -825,12 +864,10 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                               <TierPicker
                                 machineTiers={plan.machine_tiers}
                                 storageTiers={plan.storage_tiers}
-                                basePriceCents={plan.base_price_cents}
                                 selectedMachineTier={selectedMachineTier}
                                 selectedStorageTier={selectedStorageTier}
                                 onMachineTierChange={setSelectedMachineTier}
                                 onStorageTierChange={setSelectedStorageTier}
-                                creditPriceCents={selectedCreditPriceCents}
                               />
                               {creditTiersEnabled && (
                                 <CreditBundlePicker
@@ -872,17 +909,12 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                                 <TierPicker
                                   machineTiers={machineTiersForPicker}
                                   storageTiers={storageTiersForPicker}
-                                  basePriceCents={plan.base_price_cents}
                                   selectedMachineTier={selectedMachineTier}
                                   selectedStorageTier={selectedStorageTier}
                                   onMachineTierChange={setSelectedMachineTier}
                                   onStorageTierChange={setSelectedStorageTier}
                                   currentMachinePriceCents={currentMachinePrice}
                                   currentStoragePriceCents={currentStoragePrice}
-                                  creditPriceCents={selectedCreditPriceCents}
-                                  currentCreditPriceCents={
-                                    currentCreditPriceCents
-                                  }
                                 />
                                 {creditTiersEnabled && (
                                   <CreditBundlePicker

--- a/apps/web/src/domains/settings/components/tier-picker.tsx
+++ b/apps/web/src/domains/settings/components/tier-picker.tsx
@@ -37,60 +37,24 @@ export function isTierDisabled(tier: MachineTier | StorageTier): boolean {
 export interface TierPickerProps {
   machineTiers: MachineTier[];
   storageTiers: StorageTier[];
-  basePriceCents: number;
   selectedMachineTier: MachineTierEnum | null;
   selectedStorageTier: StorageTierEnum | null;
   onMachineTierChange: (tier: MachineTierEnum) => void;
   onStorageTierChange: (tier: StorageTierEnum) => void;
   currentMachinePriceCents?: number | null;
   currentStoragePriceCents?: number | null;
-  // The credit bundle is a changed "dimension" alongside machine/storage: its
-  // monthly price folds into the headline Total (and its delta) so the figure
-  // reflects the chosen bundle and reconciles with the modal's "Currently $X"
-  // baseline (which already includes the current bundle). Default 0 leaves
-  // non-credit callers byte-identical to before.
-  creditPriceCents?: number | null;
-  currentCreditPriceCents?: number | null;
 }
 
 export function TierPicker({
   machineTiers,
   storageTiers,
-  basePriceCents,
   selectedMachineTier,
   selectedStorageTier,
   onMachineTierChange,
   onStorageTierChange,
   currentMachinePriceCents,
   currentStoragePriceCents,
-  creditPriceCents,
-  currentCreditPriceCents,
 }: TierPickerProps) {
-  const selectedMachine = machineTiers.find(
-    (t) => t.tier === selectedMachineTier,
-  );
-  const selectedStorage = storageTiers.find(
-    (t) => t.tier === selectedStorageTier,
-  );
-  const totalCents =
-    selectedMachine && selectedStorage
-      ? basePriceCents +
-        selectedMachine.price_cents +
-        selectedStorage.price_cents +
-        (creditPriceCents ?? 0)
-      : null;
-  const currentTotalCents =
-    currentMachinePriceCents != null && currentStoragePriceCents != null
-      ? basePriceCents +
-        currentMachinePriceCents +
-        currentStoragePriceCents +
-        (currentCreditPriceCents ?? 0)
-      : null;
-  const totalDelta =
-    totalCents != null && currentTotalCents != null
-      ? totalCents - currentTotalCents
-      : null;
-
   const machineOptions = useMemo(
     () =>
       machineTiers.map((t) => {
@@ -172,32 +136,6 @@ export function TierPicker({
           options={storageOptions}
         />
       </div>
-      {totalCents !== null && (
-        <div className="flex items-center gap-1">
-          <Typography
-            as="p"
-            variant="body-small-emphasised"
-            data-testid="tier-picker-total"
-            className="text-[var(--content-default)]"
-          >
-            Total: {formatMonthly(totalCents)}
-            {totalDelta != null && totalDelta !== 0 && (
-              <span className="ml-1 text-[var(--content-tertiary)]">
-                ({formatDelta(totalDelta)})
-              </span>
-            )}
-          </Typography>
-          <span
-            title={
-              totalDelta != null && totalDelta !== 0
-                ? `Your Pro Plan subscription will change from ${formatMonthly(currentTotalCents!)} to ${formatMonthly(totalCents!)}. Includes a $10/month flat fee for Pro Features.`
-                : "Includes a $10/month flat fee for Pro Features."
-            }
-          >
-            <Info className="h-3 w-3 text-[var(--content-tertiary)]" />
-          </span>
-        </div>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Remove the live 'Total' line from the bottom of the tier picker
- Surface the running total (machine + storage + credit + base) as the live-updating big price at the top of the Pro card, in both upgrade and change modes, with change-mode delta and the $10 flat-fee tooltip

Part of plan: pro-card-pricing-changes.md (PR 1 of 3)