### PR TITLE
feat(web): hide "Credits not included" note when credit bundles are available

### DIFF
--- a/apps/web/src/domains/settings/components/adjust-plan-modal.test.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.test.tsx
@@ -598,3 +598,21 @@ describe("AdjustPlanModal credit bundle — catalog gate", () => {
     ).toBeNull();
   });
 });
+
+describe("AdjustPlanModal credit bundle — '*Credits not included' note", () => {
+  test("omits the note on the Pro card when credit_tiers are available", () => {
+    const { queryByTestId } = renderModal(
+      subscription("base", null),
+      proPlansResponse(CREDIT_TIERS),
+    );
+    expect(queryByTestId("modal-credits-not-included")).toBeNull();
+  });
+
+  test("shows the note on the Pro card when no credit_tiers are available", () => {
+    const { queryByTestId } = renderModal(
+      subscription("base", null),
+      proPlansResponse(undefined),
+    );
+    expect(queryByTestId("modal-credits-not-included")).not.toBeNull();
+  });
+});

--- a/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
@@ -808,11 +808,12 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                             features={plan.included_features}
                             variant="checklist"
                           />
-                          {isProCard && (
+                          {isProCard && !creditTiersEnabled && (
                             <Typography
                               as="p"
                               variant="body-small-default"
                               className="text-[var(--content-tertiary)]"
+                              data-testid="modal-credits-not-included"
                             >
                               *Credits not included
                             </Typography>


### PR DESCRIPTION
## Summary
- Hide the '*Credits not included' footnote on the Pro card when the credit-bundle catalog gate (creditTiersEnabled) is on, since credits are then selectable via the bundle
- Flag-off behavior unchanged

Part of plan: pro-card-pricing-changes.md (PR 2 of 3)