### PR TITLE
feat(heartbeat): add daily run cap (default 2 per day)

### DIFF
--- a/assistant/src/background-wake/next-wake.ts
+++ b/assistant/src/background-wake/next-wake.ts
@@ -97,6 +97,7 @@ function getHeartbeatWakeSource(now: number): HeartbeatWakeSource | null {
 
   const service = HeartbeatService.getInstance();
   if (service?.isConsecutiveRunCapReached) return null;
+  if (service?.isDailyCapReached) return null;
 
   const serviceNextRunAt = service?.nextRunAt ?? null;
   let nextRunAt = serviceNextRunAt;

--- a/assistant/src/config/schemas/heartbeat.ts
+++ b/assistant/src/config/schemas/heartbeat.ts
@@ -56,6 +56,15 @@ export const HeartbeatConfigSchema = z
       .describe(
         "Maximum heartbeats that can run consecutively without a guardian message. Counter resets when the guardian sends a message. Set to null for unlimited.",
       ),
+    maxDailyRuns: z
+      .number({ error: "heartbeat.maxDailyRuns must be a number" })
+      .int("heartbeat.maxDailyRuns must be an integer")
+      .positive("heartbeat.maxDailyRuns must be a positive integer")
+      .nullable()
+      .default(2)
+      .describe(
+        "Maximum heartbeats that can run per calendar day. Resets at midnight local time. Set to null for unlimited.",
+      ),
     disposition: z
       .string({ error: "heartbeat.disposition must be a string" })
       .default(

--- a/assistant/src/heartbeat/__tests__/heartbeat-service.test.ts
+++ b/assistant/src/heartbeat/__tests__/heartbeat-service.test.ts
@@ -85,6 +85,7 @@ const stubConfig: {
     activeHoursStart: number | null;
     activeHoursEnd: number | null;
     maxConsecutiveRuns: number | null;
+    maxDailyRuns: number | null;
     disposition: string;
   };
 } = {
@@ -94,6 +95,7 @@ const stubConfig: {
     activeHoursStart: null,
     activeHoursEnd: null,
     maxConsecutiveRuns: null,
+    maxDailyRuns: null,
     disposition: "Default disposition text.",
   },
 };
@@ -195,6 +197,7 @@ mock.module("../heartbeat-run-store.js", () => ({
   markStaleRunsAsMissed: () => 0,
   markStaleRunningAsError: () => 0,
   countCompletedHeartbeatRuns: () => 10,
+  countCompletedRunsToday: () => 0,
   countRecentConsecutiveRuns: () => 0,
 }));
 

--- a/assistant/src/heartbeat/heartbeat-run-store.ts
+++ b/assistant/src/heartbeat/heartbeat-run-store.ts
@@ -24,7 +24,8 @@ export type HeartbeatSkipReason =
   | "outside_active_hours"
   | "overlap"
   | "pre_first_user_message"
-  | "max_consecutive_runs";
+  | "max_consecutive_runs"
+  | "max_daily_runs";
 
 export interface HeartbeatRunRecord {
   id: string;
@@ -213,6 +214,27 @@ export function countCompletedHeartbeatRuns(): number {
     .select({ count: sql<number>`count(*)` })
     .from(heartbeatRuns)
     .where(eq(heartbeatRuns.status, "ok"))
+    .get();
+  return row?.count ?? 0;
+}
+
+/**
+ * Count heartbeat runs that completed with status `ok` today (local midnight).
+ */
+export function countCompletedRunsToday(): number {
+  const db = getDb();
+  const now = new Date();
+  const startOfDay = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate(),
+  ).getTime();
+  const row = db
+    .select({ count: sql<number>`count(*)` })
+    .from(heartbeatRuns)
+    .where(
+      sql`${heartbeatRuns.status} = 'ok' AND ${heartbeatRuns.scheduledFor} >= ${startOfDay}`,
+    )
     .get();
   return row?.count ?? 0;
 }

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -25,6 +25,7 @@ import { stripCommentLines } from "../util/strip-comment-lines.js";
 import {
   completeHeartbeatRun,
   countCompletedHeartbeatRuns,
+  countCompletedRunsToday,
   countRecentConsecutiveRuns,
   insertPendingHeartbeatRun,
   markStaleRunningAsError,
@@ -185,6 +186,13 @@ export class HeartbeatService {
       countRecentConsecutiveRuns(config.maxConsecutiveRuns) >=
       config.maxConsecutiveRuns
     );
+  }
+
+  /** Whether the daily run cap has been reached. */
+  get isDailyCapReached(): boolean {
+    const config = getConfig().heartbeat;
+    if (config.maxDailyRuns == null) return false;
+    return countCompletedRunsToday() >= config.maxDailyRuns;
   }
 
   async runManagedWakeIfDue(
@@ -545,6 +553,24 @@ export class HeartbeatService {
         "Max consecutive runs reached, skipping",
       );
       if (runId) skipHeartbeatRun(runId, "max_consecutive_runs");
+      if (!this.cronMode) {
+        this.scheduleNextRun(config.intervalMs);
+      }
+      return false;
+    }
+
+    // Daily run cap — stop burning tokens when the daily budget is exhausted.
+    // Force runs bypass the cap.
+    if (
+      !force &&
+      config.maxDailyRuns != null &&
+      countCompletedRunsToday() >= config.maxDailyRuns
+    ) {
+      log.debug(
+        { maxDailyRuns: config.maxDailyRuns },
+        "Daily run cap reached, skipping",
+      );
+      if (runId) skipHeartbeatRun(runId, "max_daily_runs");
       if (!this.cronMode) {
         this.scheduleNextRun(config.intervalMs);
       }


### PR DESCRIPTION
## Summary
- Adds `maxDailyRuns` config field (default 2, nullable for unlimited) that caps how many heartbeats can complete per calendar day
- Resets at midnight local time; force runs bypass the cap
- Background wake respects the cap to avoid waking just to skip

## Test plan
- [x] Type-check passes
- [x] Heartbeat service tests pass
- [x] Run store tests pass
- [x] Background wake tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)