### PR TITLE
feat(web): show the credit bundle selector first in the Pro plan card

### DIFF
--- a/apps/web/src/domains/settings/components/adjust-plan-modal.test.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.test.tsx
@@ -616,3 +616,38 @@ describe("AdjustPlanModal credit bundle — '*Credits not included' note", () =>
     expect(queryByTestId("modal-credits-not-included")).not.toBeNull();
   });
 });
+
+describe("AdjustPlanModal credit bundle — selector order", () => {
+  function creditAndMachineTriggers(): {
+    credit: HTMLButtonElement;
+    machine: HTMLButtonElement;
+  } {
+    const credit = document.querySelector<HTMLButtonElement>(
+      'button[role="combobox"][aria-label="Credit bundle"]',
+    );
+    const machine = document.querySelector<HTMLButtonElement>(
+      'button[role="combobox"][aria-label="Machine tier"]',
+    );
+    if (!credit) throw new Error("expected a Credit bundle dropdown trigger");
+    if (!machine) throw new Error("expected a Machine tier dropdown trigger");
+    return { credit, machine };
+  }
+
+  test("renders the credit bundle picker before the machine tier (upgrade)", () => {
+    renderModal(subscription("base", null), proPlansResponse(CREDIT_TIERS));
+    const { credit, machine } = creditAndMachineTriggers();
+    expect(
+      credit.compareDocumentPosition(machine) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  test("renders the credit bundle picker before the machine tier (change)", () => {
+    renderModal(subscription("pro", null), proPlansResponse(CREDIT_TIERS));
+    const { credit, machine } = creditAndMachineTriggers();
+    expect(
+      credit.compareDocumentPosition(machine) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+});

--- a/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
@@ -862,14 +862,6 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                           {!isCurrent && isProCard && (
                             <>
                               <hr className="border-t border-[var(--border-base)]" />
-                              <TierPicker
-                                machineTiers={plan.machine_tiers}
-                                storageTiers={plan.storage_tiers}
-                                selectedMachineTier={selectedMachineTier}
-                                selectedStorageTier={selectedStorageTier}
-                                onMachineTierChange={setSelectedMachineTier}
-                                onStorageTierChange={setSelectedStorageTier}
-                              />
                               {creditTiersEnabled && (
                                 <CreditBundlePicker
                                   creditTiers={creditTiers}
@@ -878,6 +870,14 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                                   disabled={upgradeMutation.isPending}
                                 />
                               )}
+                              <TierPicker
+                                machineTiers={plan.machine_tiers}
+                                storageTiers={plan.storage_tiers}
+                                selectedMachineTier={selectedMachineTier}
+                                selectedStorageTier={selectedStorageTier}
+                                onMachineTierChange={setSelectedMachineTier}
+                                onStorageTierChange={setSelectedStorageTier}
+                              />
                               <Button
                                 variant="primary"
                                 className="w-full"
@@ -907,16 +907,6 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                             ) : (
                               <>
                                 <hr className="border-t border-[var(--border-base)]" />
-                                <TierPicker
-                                  machineTiers={machineTiersForPicker}
-                                  storageTiers={storageTiersForPicker}
-                                  selectedMachineTier={selectedMachineTier}
-                                  selectedStorageTier={selectedStorageTier}
-                                  onMachineTierChange={setSelectedMachineTier}
-                                  onStorageTierChange={setSelectedStorageTier}
-                                  currentMachinePriceCents={currentMachinePrice}
-                                  currentStoragePriceCents={currentStoragePrice}
-                                />
                                 {creditTiersEnabled && (
                                   <CreditBundlePicker
                                     creditTiers={creditTiers}
@@ -928,6 +918,16 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                                     disabled={tierChangePending}
                                   />
                                 )}
+                                <TierPicker
+                                  machineTiers={machineTiersForPicker}
+                                  storageTiers={storageTiersForPicker}
+                                  selectedMachineTier={selectedMachineTier}
+                                  selectedStorageTier={selectedStorageTier}
+                                  onMachineTierChange={setSelectedMachineTier}
+                                  onStorageTierChange={setSelectedStorageTier}
+                                  currentMachinePriceCents={currentMachinePrice}
+                                  currentStoragePriceCents={currentStoragePrice}
+                                />
                                 {(changeMachineTierMutation.isError ||
                                   changeStorageTierMutation.isError ||
                                   changeCreditTierMutation.isError) && (


### PR DESCRIPTION
## Summary
- Reorder the AdjustPlanModal Pro card so the credit bundle selector appears above the machine/storage selectors, in both the upgrade and change flows

Part of plan: pro-card-pricing-changes.md (PR 3 of 3)