### PR TITLE
fix(web): gate live Pro header total to adjustable flows + review cleanup

### DIFF
--- a/apps/web/src/domains/settings/components/adjust-plan-modal.test.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.test.tsx
@@ -151,6 +151,7 @@ function proPlansResponse(creditTiers?: CreditTier[]): PlanListResponse {
 function subscription(
   planId: "base" | "pro",
   selectedCreditTier: string | null,
+  overrides: Partial<SubscriptionResponse> = {},
 ): SubscriptionResponse {
   return {
     plan_id: planId,
@@ -161,13 +162,27 @@ function subscription(
     cancel_at: null,
     selected_credit_tier: selectedCreditTier,
     entitlements: { managed_email: false, phone_number: false },
+    ...overrides,
   } as unknown as SubscriptionResponse;
 }
+
+type OnboardingData = {
+  max_machine_tier: string;
+  selected_storage_tier: string;
+  selected_storage_gib: number;
+};
+
+const DEFAULT_ONBOARDING: OnboardingData = {
+  max_machine_tier: "machine_small",
+  selected_storage_tier: "storage_10",
+  selected_storage_gib: 10,
+};
 
 function renderModal(
   sub: SubscriptionResponse,
   plans: PlanListResponse,
   onTierUpgraded?: () => void,
+  onboarding: OnboardingData = DEFAULT_ONBOARDING,
 ): ReturnType<typeof render> & { client: QueryClient } {
   const client = new QueryClient({
     // `staleTime: Infinity` stops the pre-seeded reads from being marked stale
@@ -182,11 +197,7 @@ function renderModal(
   // Onboarding carries the current machine/storage tiers for the change flow.
   client.setQueryData(
     organizationsBillingSubscriptionOnboardingRetrieveQueryKey(),
-    {
-      max_machine_tier: "machine_small",
-      selected_storage_tier: "storage_10",
-      selected_storage_gib: 10,
-    },
+    onboarding,
   );
   const result = render(
     <QueryClientProvider client={client}>
@@ -196,20 +207,20 @@ function renderModal(
   return { ...result, client };
 }
 
-function openCreditDropdown(): void {
+function getDropdownTrigger(label: string): HTMLButtonElement {
   const trigger = document.querySelector<HTMLButtonElement>(
-    'button[role="combobox"][aria-label="Credit bundle"]',
+    `button[role="combobox"][aria-label="${label}"]`,
   );
-  if (!trigger) throw new Error("expected a Credit bundle dropdown trigger");
-  fireEvent.click(trigger);
+  if (!trigger) throw new Error(`expected a ${label} dropdown trigger`);
+  return trigger;
+}
+
+function openCreditDropdown(): void {
+  fireEvent.click(getDropdownTrigger("Credit bundle"));
 }
 
 function openMachineDropdown(): void {
-  const trigger = document.querySelector<HTMLButtonElement>(
-    'button[role="combobox"][aria-label="Machine tier"]',
-  );
-  if (!trigger) throw new Error("expected a Machine tier dropdown trigger");
-  fireEvent.click(trigger);
+  fireEvent.click(getDropdownTrigger("Machine tier"));
 }
 
 function clickOptionStartingWith(prefix: string): void {
@@ -579,6 +590,43 @@ describe("AdjustPlanModal credit bundle — headline total", () => {
   });
 });
 
+describe("AdjustPlanModal Pro header total — no picker shown", () => {
+  test("a cancellation-pending Pro card shows the current total, not the cheapest seeded one", async () => {
+    // A current Pro subscriber with a pending cancellation: no tier picker
+    // renders (only the "Keep your Plan" reactivation CTA). The header must show
+    // the user's CURRENT total, not the cheapest seeded total. Current tiers are
+    // deliberately more expensive than the cheapest so the two are observably
+    // different: base $20 + Large machine $30 + 20 GiB storage $9 = $59/mo,
+    // versus the cheapest base $20 + Small $10 + 10 GiB $5 = $35/mo.
+    const { getByTestId, queryByTestId } = renderModal(
+      subscription("pro", null, { cancel_at_period_end: true }),
+      proPlansResponse(CREDIT_TIERS),
+      undefined,
+      {
+        max_machine_tier: "machine_large",
+        selected_storage_tier: "storage_20",
+        selected_storage_gib: 20,
+      },
+    );
+
+    await waitFor(() => {
+      const text = getByTestId("modal-pro-price").textContent ?? "";
+      if (text.includes("Currently") && text.includes("$59/mo")) return;
+      throw new Error("current total not rendered yet");
+    });
+
+    const text = getByTestId("modal-pro-price").textContent ?? "";
+    expect(text).not.toContain("$35/mo");
+
+    // No tier picker and no "Update Plan" button render in this flow.
+    expect(
+      document.querySelector('button[role="combobox"][aria-label="Machine tier"]'),
+    ).toBeNull();
+    expect(queryByTestId("modal-change-tier-button")).toBeNull();
+    expect(queryByTestId("modal-upgrade-to-pro-button")).toBeNull();
+  });
+});
+
 describe("AdjustPlanModal credit bundle — catalog gate", () => {
   test("hides the credit UI when the plan has no credit_tiers (upgrade)", () => {
     renderModal(subscription("base", null), proPlansResponse(undefined));
@@ -622,15 +670,10 @@ describe("AdjustPlanModal credit bundle — selector order", () => {
     credit: HTMLButtonElement;
     machine: HTMLButtonElement;
   } {
-    const credit = document.querySelector<HTMLButtonElement>(
-      'button[role="combobox"][aria-label="Credit bundle"]',
-    );
-    const machine = document.querySelector<HTMLButtonElement>(
-      'button[role="combobox"][aria-label="Machine tier"]',
-    );
-    if (!credit) throw new Error("expected a Credit bundle dropdown trigger");
-    if (!machine) throw new Error("expected a Machine tier dropdown trigger");
-    return { credit, machine };
+    return {
+      credit: getDropdownTrigger("Credit bundle"),
+      machine: getDropdownTrigger("Machine tier"),
+    };
   }
 
   test("renders the credit bundle picker before the machine tier (upgrade)", () => {

--- a/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
@@ -298,9 +298,10 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
   const displayCreditTier: CreditTierEnum | null =
     selectedCreditTier === undefined ? currentCreditTier : selectedCreditTier;
 
-  // Folds into TierPicker's headline Total. `priceForCredit` returns 0 for "No
-  // bundle" and for catalogs without credit_tiers (empty `creditTiers`), so the
-  // total stays byte-identical to before when the feature is off.
+  // Folds into the Pro card-header live total (`proLiveTotalCents`).
+  // `priceForCredit` returns 0 for "No bundle" and for catalogs without
+  // credit_tiers (empty `creditTiers`), so the total stays byte-identical to
+  // before when the feature is off.
   const selectedCreditPriceCents = priceForCredit(displayCreditTier);
 
   // For an active Pro subscriber, disable any storage tier strictly below the
@@ -713,10 +714,19 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                     // that path shows only reactivation).
                     const showProTierChange =
                       isProCard && isCurrent && proTierChangeMode;
+                    // A tier picker is actually rendered on the Pro card only in
+                    // the Base→Pro upgrade flow or the active-Pro change flow.
+                    // When neither is shown (e.g. a current Pro card with a
+                    // pending cancellation), the live, selection-driven total
+                    // must not be displayed — the seeded cheapest tiers don't
+                    // reflect what keeping the plan retains.
+                    const proPickerShown =
+                      (!isCurrent && isProCard) || showProTierChange;
                     // Live running total for the Pro card header: base + the
                     // selected machine/storage/credit prices. Updates as the
-                    // user changes any dimension. In change mode it also carries
-                    // a delta vs. the current subscription.
+                    // user changes any dimension. The delta is shown when this
+                    // new total differs from the current subscription (i.e. when
+                    // a current total exists).
                     const proLiveTotalCents =
                       isProCard &&
                       nextMachinePrice != null &&
@@ -804,7 +814,8 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                                     variant="title-medium"
                                     data-testid="modal-pro-price"
                                   >
-                                    {proLiveTotalCents != null ? (
+                                    {proPickerShown &&
+                                    proLiveTotalCents != null ? (
                                       <>
                                         {formatMonthly(proLiveTotalCents)}
                                         {proTotalDelta != null &&
@@ -814,6 +825,10 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                                             </span>
                                           )}
                                       </>
+                                    ) : proCurrentTotalCents != null ? (
+                                      `Currently ${formatMonthly(
+                                        proCurrentTotalCents,
+                                      )}`
                                     ) : (
                                       `From ${formatMonthly(
                                         plan.base_price_cents +
@@ -824,6 +839,7 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                                   </Typography>
                                   <span
                                     title={
+                                      proPickerShown &&
                                       proTotalDelta != null &&
                                       proTotalDelta !== 0
                                         ? `Your Pro Plan subscription will change from ${formatMonthly(proCurrentTotalCents!)} to ${formatMonthly(proLiveTotalCents!)}. Includes a $10/month flat fee for Pro Features.`


### PR DESCRIPTION
## Summary
Fixes gaps from plan review for pro-card-pricing-changes.md.

- Gate the live Pro card header total to flows where a tier picker is actually shown; a current Pro card with no picker (e.g. cancellation pending) now shows the accurate current-subscription total instead of the cheapest seeded total.
- Extract a shared getDropdownTrigger test helper (dedup).
- Fix two stale comments referencing the removed TierPicker headline total.