### PR TITLE
fix(heartbeat): add missing countCompletedRunsToday to test mocks

### DIFF
--- a/assistant/src/__tests__/heartbeat-disk-pressure.test.ts
+++ b/assistant/src/__tests__/heartbeat-disk-pressure.test.ts
@@ -56,6 +56,7 @@ mock.module("../heartbeat/heartbeat-run-store.js", () => ({
   markStaleRunsAsMissed: mockMarkStaleRunsAsMissed,
   markStaleRunningAsError: mockMarkStaleRunningAsError,
   countCompletedHeartbeatRuns: mock(() => 10),
+  countCompletedRunsToday: mock(() => 0),
   countRecentConsecutiveRuns: mock(() => 0),
 }));
 

--- a/assistant/src/__tests__/heartbeat-service.test.ts
+++ b/assistant/src/__tests__/heartbeat-service.test.ts
@@ -32,6 +32,7 @@ mock.module("../heartbeat/heartbeat-run-store.js", () => ({
   markStaleRunningAsError: mockMarkStaleRunningAsError,
   listHeartbeatRuns: mockListHeartbeatRuns,
   countCompletedHeartbeatRuns: mockCountCompletedHeartbeatRuns,
+  countCompletedRunsToday: mock(() => 0),
   countRecentConsecutiveRuns: mock(() => 0),
 }));
 


### PR DESCRIPTION
## Summary
- Add `countCompletedRunsToday` to `mock.module` calls in `heartbeat-service.test.ts` and `heartbeat-disk-pressure.test.ts`
- The export was added to `heartbeat-run-store.ts` in #33629 but two test files that mock that module were not updated, causing CI failures

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/27022305337

🤖 Generated with [Claude Code](https://claude.com/claude-code)