### PR TITLE
fix(web): show loading placeholder (not cheapest price) for current Pro card pre-onboarding

### DIFF
--- a/apps/web/src/domains/settings/components/adjust-plan-modal.test.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.test.tsx
@@ -64,6 +64,11 @@ mock.module("@/generated/api/sdk.gen", () => ({
     changeStorageTierCall = opts;
     return Promise.resolve({ data: { status: "ok" }, response: { ok: true } });
   },
+  // The onboarding query carries the current tiers. Tests that need it pre-seed
+  // the cache (so this never runs). When a test deliberately leaves it unseeded
+  // to exercise the error path, this rejection keeps it hermetic.
+  organizationsBillingSubscriptionOnboardingRetrieve: () =>
+    Promise.reject(new Error("onboarding unavailable")),
 }));
 
 // Avoid pulling the real billing-portal hook's network fan-out; the downgrade /
@@ -624,6 +629,37 @@ describe("AdjustPlanModal Pro header total — no picker shown", () => {
     ).toBeNull();
     expect(queryByTestId("modal-change-tier-button")).toBeNull();
     expect(queryByTestId("modal-upgrade-to-pro-button")).toBeNull();
+  });
+
+  test("a current Pro card shows a loading placeholder (not the cheapest price) when onboarding has not resolved", async () => {
+    // A cancellation-pending Pro subscriber whose onboarding query errors (so
+    // the current total is never available). The header must NOT fall back to
+    // the cheapest seeded `From $35/mo` — that understates what the subscriber
+    // pays. Instead it shows the neutral "Loading your plan..." placeholder.
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+    client.setQueryData(
+      organizationsBillingSubscriptionRetrieveQueryKey(),
+      subscription("pro", null, { cancel_at_period_end: true }),
+    );
+    client.setQueryData(
+      organizationsBillingPlansRetrieveQueryKey(),
+      proPlansResponse(CREDIT_TIERS),
+    );
+    // Deliberately leave the onboarding query unseeded: it fires, the mocked
+    // SDK fn rejects, and with retry:false it settles into an error state.
+    const { findByText, queryByTestId } = render(
+      <QueryClientProvider client={client}>
+        <AdjustPlanModal open onClose={() => {}} />
+      </QueryClientProvider>,
+    );
+
+    await findByText("Loading your plan...");
+
+    // The cheapest fallback price must never render for a current Pro card.
+    const price = queryByTestId("modal-pro-price");
+    expect(price?.textContent ?? "").not.toContain("$35/mo");
   });
 });
 

--- a/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
@@ -806,6 +806,24 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                                   Forever
                                 </Typography>
                               </>
+                            ) : isCurrent &&
+                              proCurrentTotalCents == null &&
+                              !(proPickerShown && proLiveTotalCents != null) ? (
+                              // Current Pro card whose current total isn't
+                              // available yet (onboarding still loading or
+                              // errored). Showing the cheapest `From $X` here
+                              // would understate what this subscriber actually
+                              // pays, so render the same neutral placeholder
+                              // used by the tier-change block instead.
+                              <div className="flex items-center gap-2 text-[var(--content-tertiary)]">
+                                <Loader2 className="h-4 w-4 animate-spin" />
+                                <Typography
+                                  as="span"
+                                  variant="body-medium-lighter"
+                                >
+                                  Loading your plan...
+                                </Typography>
+                              </div>
                             ) : (
                               <>
                                 <div className="flex items-center gap-1">
@@ -830,6 +848,10 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                                         proCurrentTotalCents,
                                       )}`
                                     ) : (
+                                      // Reachable only for the prospective
+                                      // upgrade card (!isCurrent); the current
+                                      // Pro card shows the loading placeholder
+                                      // above instead of this cheapest price.
                                       `From ${formatMonthly(
                                         plan.base_price_cents +
                                           minTierPriceCents(plan.machine_tiers) +


### PR DESCRIPTION
## Summary
Fixes a gap from plan review for pro-card-pricing-changes.md: a current Pro card (e.g. cancellation pending) could show the cheapest 'From $X' price while the onboarding query loads — or permanently if it errors — because the modal's loading gate doesn't wait on onboarding. The 'From $X' starting price is now only used for the prospective-upgrade card; a current Pro card without a resolved current total shows a loading placeholder instead of a wrong, lower price.