### PR TITLE
Upgrade @agentclientprotocol/sdk 0.16.1 -> 0.25.0; capture agent capabilities at initialize

### DIFF
--- a/assistant/bun.lock
+++ b/assistant/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@vellumai/assistant",
       "dependencies": {
-        "@agentclientprotocol/sdk": "0.16.1",
+        "@agentclientprotocol/sdk": "0.25.0",
         "@anthropic-ai/sdk": "0.78.0",
         "@google/genai": "1.45.0",
         "@modelcontextprotocol/sdk": "1.27.1",
@@ -71,7 +71,7 @@
     "path-to-regexp": "8.4.2",
   },
   "packages": {
-    "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@0.16.1", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-1ad+Sc/0sCtZGHthxxvgEUo5Wsbw16I+aF+YwdiLnPwkZG8KAGUEAPK6LM6Pf69lCyJPt1Aomk1d+8oE3C4ZEw=="],
+    "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@0.25.0", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-wU1VgXNtMvdVotX49txc3WJUDV+/QbLpsgjMvFhlRmp37osdLbI7L7y+iwAlQATwfjLxcv1r1p3ZxZBcXlGhcQ=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.78.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-PzQhR715td/m1UaaN5hHXjYB8Gl2lF9UVhrrGrZeysiF6Rb74Wc9GCB8hzLdzmQtBd1qe89F9OptgB9Za1Ib5w=="],
 

--- a/assistant/package.json
+++ b/assistant/package.json
@@ -33,7 +33,7 @@
     "prepack": "node ../scripts/prepack-bundled-deps.mjs"
   },
   "dependencies": {
-    "@agentclientprotocol/sdk": "0.16.1",
+    "@agentclientprotocol/sdk": "0.25.0",
     "@anthropic-ai/sdk": "0.78.0",
     "@google/genai": "1.45.0",
     "@modelcontextprotocol/sdk": "1.27.1",

--- a/assistant/src/acp/__tests__/agent-process.test.ts
+++ b/assistant/src/acp/__tests__/agent-process.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Unit tests for AcpAgentProcess capability getters.
+ *
+ * The getters reflect the InitializeResponse captured during initialize();
+ * before that resolves (or after kill()) they must report false. The
+ * connection is stubbed directly so no child process is spawned.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { InitializeResponse } from "@agentclientprotocol/sdk";
+
+import { AcpAgentProcess } from "../agent-process.js";
+
+function makeProcess(): AcpAgentProcess {
+  return new AcpAgentProcess(
+    "test-agent",
+    { command: "echo", args: [] },
+    () => {
+      throw new Error("client factory should not be called in this test");
+    },
+  );
+}
+
+/** Injects a stub connection whose initialize() resolves with `response`. */
+function stubConnection(
+  proc: AcpAgentProcess,
+  response: InitializeResponse,
+): void {
+  (
+    proc as unknown as {
+      connection: { initialize: () => Promise<InitializeResponse> };
+    }
+  ).connection = {
+    initialize: () => Promise.resolve(response),
+  };
+}
+
+describe("AcpAgentProcess capability getters", () => {
+  test("both getters return false before initialize() resolves", () => {
+    const proc = makeProcess();
+    expect(proc.supportsLoadSession).toBe(false);
+    expect(proc.supportsSessionResume).toBe(false);
+  });
+
+  test("supportsLoadSession reflects agentCapabilities.loadSession", async () => {
+    const proc = makeProcess();
+    stubConnection(proc, {
+      protocolVersion: 1,
+      agentCapabilities: { loadSession: true },
+    });
+
+    await proc.initialize();
+
+    expect(proc.supportsLoadSession).toBe(true);
+    expect(proc.supportsSessionResume).toBe(false);
+  });
+
+  test("supportsSessionResume reflects agentCapabilities.sessionCapabilities.resume", async () => {
+    const proc = makeProcess();
+    stubConnection(proc, {
+      protocolVersion: 1,
+      agentCapabilities: { sessionCapabilities: { resume: {} } },
+    });
+
+    await proc.initialize();
+
+    expect(proc.supportsSessionResume).toBe(true);
+    expect(proc.supportsLoadSession).toBe(false);
+  });
+
+  test("both getters return false when the agent advertises no capabilities", async () => {
+    const proc = makeProcess();
+    stubConnection(proc, { protocolVersion: 1 });
+
+    await proc.initialize();
+
+    expect(proc.supportsLoadSession).toBe(false);
+    expect(proc.supportsSessionResume).toBe(false);
+  });
+
+  test("kill() clears the captured initialize response", async () => {
+    const proc = makeProcess();
+    stubConnection(proc, {
+      protocolVersion: 1,
+      agentCapabilities: {
+        loadSession: true,
+        sessionCapabilities: { resume: {} },
+      },
+    });
+
+    await proc.initialize();
+    expect(proc.supportsLoadSession).toBe(true);
+    expect(proc.supportsSessionResume).toBe(true);
+
+    proc.kill();
+
+    expect(proc.supportsLoadSession).toBe(false);
+    expect(proc.supportsSessionResume).toBe(false);
+  });
+});

--- a/assistant/src/acp/agent-process.ts
+++ b/assistant/src/acp/agent-process.ts
@@ -34,6 +34,7 @@ export type AcpClientFactory = (agent: Agent) => Client;
 export class AcpAgentProcess {
   private proc: ChildProcess | null = null;
   private connection: acp.ClientSideConnection | null = null;
+  private initializeResponse: InitializeResponse | null = null;
 
   constructor(
     public readonly agentId: string,
@@ -99,7 +100,7 @@ export class AcpAgentProcess {
 
     log.info({ agentId: this.agentId }, "Initializing ACP connection");
 
-    return this.connection.initialize({
+    const response = await this.connection.initialize({
       protocolVersion: acp.PROTOCOL_VERSION,
       clientInfo: { name: "vellum", version: "1.0.0" },
       clientCapabilities: {
@@ -107,6 +108,28 @@ export class AcpAgentProcess {
         terminal: true,
       },
     });
+
+    this.initializeResponse = response;
+    return response;
+  }
+
+  /**
+   * Whether the agent advertised support for `session/load` at initialize.
+   * Returns false before initialize() resolves.
+   */
+  get supportsLoadSession(): boolean {
+    return this.initializeResponse?.agentCapabilities?.loadSession === true;
+  }
+
+  /**
+   * Whether the agent advertised support for `session/resume` at initialize.
+   * Returns false before initialize() resolves.
+   */
+  get supportsSessionResume(): boolean {
+    return (
+      this.initializeResponse?.agentCapabilities?.sessionCapabilities?.resume !=
+      null
+    );
   }
 
   /**
@@ -175,6 +198,7 @@ export class AcpAgentProcess {
       this.proc = null;
     }
     this.connection = null;
+    this.initializeResponse = null;
   }
 
   /**
@@ -205,5 +229,6 @@ export class AcpAgentProcess {
 
     this.proc = null;
     this.connection = null;
+    this.initializeResponse = null;
   }
 }


### PR DESCRIPTION
## Summary
- Bump @agentclientprotocol/sdk from 0.16.1 to 0.25.0
- Store the InitializeResponse on AcpAgentProcess and expose supportsLoadSession / supportsSessionResume getters
- Fixture/type fixes for the SDK bump

Part of plan: acp-native-agent-ux.md (PR 2 of 8)