### PR TITLE
Gate ACP behind a new acp assistant feature flag

### DIFF
--- a/apps/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/apps/web/src/lib/feature-flags/feature-flag-registry.json
@@ -488,6 +488,14 @@
       "label": "Provider-First Profile Creation",
       "description": "New profile creation flow: pick (or inline-create) a provider first, then a model, with pre-filled provider and profile name/key, plus a quick-add \"+\" in the chat composer's Model Profile menu. When off, profile creation uses the previous field order and there is no composer quick-add.",
       "defaultEnabled": false
+    },
+    {
+      "id": "acp",
+      "scope": "assistant",
+      "key": "acp",
+      "label": "ACP Coding Agents",
+      "description": "Enable spawning and steering external coding agents (Claude Code, Codex, Gemini) via the Agent Client Protocol. Alternative gate to the acp.enabled workspace config field; either enables the subsystem.",
+      "defaultEnabled": false
     }
   ]
 }

--- a/assistant/src/__tests__/conversation-app-control-instantiation.test.ts
+++ b/assistant/src/__tests__/conversation-app-control-instantiation.test.ts
@@ -60,6 +60,11 @@ mock.module("../config/assistant-feature-flags.js", () => ({
 mock.module("../config/skill-state.js", () => ({
   skillFlagKey: (skill: { featureFlag?: string }) =>
     skill.featureFlag ?? undefined,
+  // Mirror the real helper: route through the mocked flag resolver.
+  isSkillFeatureFlagEnabled: (key: string) => {
+    if (key === "app-control") return appControlFlagEnabled;
+    return true;
+  },
 }));
 
 mock.module("../config/loader.js", () => ({

--- a/assistant/src/__tests__/conversation-skill-tools.test.ts
+++ b/assistant/src/__tests__/conversation-skill-tools.test.ts
@@ -225,6 +225,7 @@ mock.module("../config/assistant-feature-flags.js", () => ({
 mock.module("../config/skill-state.js", () => ({
   skillFlagKey: (skill: { featureFlag?: string }) =>
     skill.featureFlag || undefined,
+  isSkillFeatureFlagEnabled: () => true,
 }));
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/handlers-skills-memory-v2-reseed.test.ts
+++ b/assistant/src/__tests__/handlers-skills-memory-v2-reseed.test.ts
@@ -71,6 +71,7 @@ mock.module("../config/loader.js", () => ({
 mock.module("../config/skill-state.js", () => ({
   resolveSkillStates: () => [],
   skillFlagKey: () => null,
+  isSkillFeatureFlagEnabled: () => true,
 }));
 
 mock.module("../skills/clawhub.js", () => ({

--- a/assistant/src/__tests__/skill-feature-flags.test.ts
+++ b/assistant/src/__tests__/skill-feature-flags.test.ts
@@ -2,7 +2,11 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import type { AssistantConfig } from "../config/schema.js";
-import { resolveSkillStates, skillFlagKey } from "../config/skill-state.js";
+import {
+  isSkillFeatureFlagEnabled,
+  resolveSkillStates,
+  skillFlagKey,
+} from "../config/skill-state.js";
 import type { SkillSummary } from "../config/skills.js";
 import { setOverridesForTesting } from "./feature-flag-test-helpers.js";
 
@@ -275,6 +279,78 @@ describe("resolveSkillStates with feature flags", () => {
 
     // a2a-channel and deploy explicitly false; one unrelated skill explicitly true
     expect(ids).toEqual([ENABLED_UNDECLARED_SKILL_ID]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-flag predicate overrides (config-aware gating)
+// ---------------------------------------------------------------------------
+
+describe("skill flag predicate overrides (acp)", () => {
+  /** Config with the `acp` section the ACP gate reads. */
+  function makeAcpConfig(acpEnabled: boolean): AssistantConfig {
+    return makeConfig({
+      acp: { enabled: acpEnabled, maxConcurrentSessions: 4, agents: {} },
+    } as Partial<AssistantConfig>);
+  }
+
+  test("isSkillFeatureFlagEnabled: acp flag routes through isAcpEnabled (config-on, flag-off)", () => {
+    // Flag at registry default (false), but config.acp.enabled is true:
+    // the OR semantics must keep the gate open.
+    expect(isSkillFeatureFlagEnabled("acp", makeAcpConfig(true))).toBe(true);
+  });
+
+  test("isSkillFeatureFlagEnabled: acp gate closed when both flag and config are off", () => {
+    expect(isSkillFeatureFlagEnabled("acp", makeAcpConfig(false))).toBe(false);
+  });
+
+  test("isSkillFeatureFlagEnabled: acp gate open when flag is on and config is off", () => {
+    setOverridesForTesting({ acp: true });
+    expect(isSkillFeatureFlagEnabled("acp", makeAcpConfig(false))).toBe(true);
+  });
+
+  test("isSkillFeatureFlagEnabled: non-overridden flags fall back to the flag resolver", () => {
+    setOverridesForTesting({ [DECLARED_FLAG_KEY]: true });
+    expect(
+      isSkillFeatureFlagEnabled(DECLARED_FLAG_KEY, makeAcpConfig(false)),
+    ).toBe(true);
+    setOverridesForTesting({ [DECLARED_FLAG_KEY]: false });
+    expect(
+      isSkillFeatureFlagEnabled(DECLARED_FLAG_KEY, makeAcpConfig(true)),
+    ).toBe(false);
+  });
+
+  test("resolveSkillStates keeps the ACP skill when config.acp.enabled is true and the flag is off", () => {
+    const catalog = [makeSkill("acp", "bundled", "acp")];
+
+    const resolved = resolveSkillStates(catalog, makeAcpConfig(true));
+    const ids = resolved.map((r) => r.summary.id);
+    expect(ids).toContain("acp");
+  });
+
+  test("resolveSkillStates drops the ACP skill when both the flag and config.acp.enabled are off", () => {
+    const catalog = [makeSkill("acp", "bundled", "acp")];
+
+    const resolved = resolveSkillStates(catalog, makeAcpConfig(false));
+    expect(resolved.length).toBe(0);
+  });
+
+  test("resolveSkillStates keeps the ACP skill when the flag is on and config.acp.enabled is off", () => {
+    setOverridesForTesting({ acp: true });
+    const catalog = [makeSkill("acp", "bundled", "acp")];
+
+    const resolved = resolveSkillStates(catalog, makeAcpConfig(false));
+    const ids = resolved.map((r) => r.summary.id);
+    expect(ids).toContain("acp");
+  });
+
+  test("explicit acp flag-off override does not defeat config.acp.enabled", () => {
+    setOverridesForTesting({ acp: false });
+    const catalog = [makeSkill("acp", "bundled", "acp")];
+
+    const resolved = resolveSkillStates(catalog, makeAcpConfig(true));
+    const ids = resolved.map((r) => r.summary.id);
+    expect(ids).toContain("acp");
   });
 });
 

--- a/assistant/src/__tests__/skill-projection-feature-flag.test.ts
+++ b/assistant/src/__tests__/skill-projection-feature-flag.test.ts
@@ -41,6 +41,12 @@ mock.module("../config/loader.js", () => ({
 mock.module("../config/skill-state.js", () => ({
   skillFlagKey: (skill: { featureFlag?: string }) =>
     skill.featureFlag || undefined,
+  // Mirror the real helper: route through the (mocked) flag resolver.
+  isSkillFeatureFlagEnabled: (key: string, _config: unknown): boolean => {
+    const explicit = _mockOverrides[key];
+    if (typeof explicit === "boolean") return explicit;
+    return false;
+  },
 }));
 
 // Mock assistant-feature-flags to avoid loading the real module (which

--- a/assistant/src/__tests__/skill-projection.benchmark.test.ts
+++ b/assistant/src/__tests__/skill-projection.benchmark.test.ts
@@ -66,6 +66,7 @@ mock.module("../config/skills.js", () => ({
 mock.module("../config/skill-state.js", () => ({
   skillFlagKey: (skill: { featureFlag?: string }) =>
     skill.featureFlag || undefined,
+  isSkillFeatureFlagEnabled: () => true,
   resolveSkillStates: () => [],
 }));
 

--- a/assistant/src/acp/feature-gate.test.ts
+++ b/assistant/src/acp/feature-gate.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Tests for the ACP feature gate.
+ *
+ * `isAcpEnabled` is an OR of the `acp` feature flag and the legacy
+ * `config.acp.enabled` field: either switch enables the subsystem, and
+ * neither implicitly flips the other.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { setOverridesForTesting } from "../__tests__/feature-flag-test-helpers.js";
+import type { AssistantConfig } from "../config/schema.js";
+import { ACP_FLAG_KEY, isAcpEnabled } from "./feature-gate.js";
+
+beforeEach(() => {
+  setOverridesForTesting({});
+});
+
+afterEach(() => {
+  setOverridesForTesting({});
+});
+
+/** Minimal AssistantConfig carrying only the `acp` section the gate reads. */
+function makeConfig(acpEnabled: boolean): AssistantConfig {
+  return {
+    acp: { enabled: acpEnabled, maxConcurrentSessions: 4, agents: {} },
+  } as AssistantConfig;
+}
+
+describe("isAcpEnabled", () => {
+  test("returns false when both the flag and config.acp.enabled are off", () => {
+    expect(isAcpEnabled(makeConfig(false))).toBe(false);
+  });
+
+  test("returns true when config.acp.enabled is true and the flag is off", () => {
+    expect(isAcpEnabled(makeConfig(true))).toBe(true);
+  });
+
+  test("returns true when the flag is on and config.acp.enabled is false", () => {
+    setOverridesForTesting({ [ACP_FLAG_KEY]: true });
+    expect(isAcpEnabled(makeConfig(false))).toBe(true);
+  });
+
+  test("explicit flag-off override does not defeat config.acp.enabled", () => {
+    setOverridesForTesting({ [ACP_FLAG_KEY]: false });
+    expect(isAcpEnabled(makeConfig(true))).toBe(true);
+  });
+});
+
+describe("ACP flag key format", () => {
+  test(`${ACP_FLAG_KEY} uses simple kebab-case format`, () => {
+    expect(ACP_FLAG_KEY).toMatch(/^[a-z0-9][a-z0-9-]*$/);
+  });
+});

--- a/assistant/src/acp/feature-gate.ts
+++ b/assistant/src/acp/feature-gate.ts
@@ -1,0 +1,33 @@
+/**
+ * ACP (Agent Client Protocol) feature gate.
+ *
+ * Single source of truth for whether the ACP subsystem is enabled. Modeled
+ * on `credential-execution/feature-gates.ts`: the flag key is declared in
+ * `meta/feature-flags/feature-flag-registry.json` and resolved through the
+ * unified feature-flag resolver.
+ *
+ * The gate is an OR of two independent switches:
+ *   1. `config.acp.enabled` — the original workspace config field. Preserved
+ *      so existing workspaces with `acp.enabled: true` keep working without
+ *      any migration.
+ *   2. The `acp` feature flag — adds a UI toggle. Flag state is persisted by
+ *      the gateway and hot-refreshed in the daemon via the
+ *      `feature_flags_changed` SSE event, so toggling it takes effect
+ *      without a restart or config-file edit.
+ */
+
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import type { AssistantConfig } from "../config/schema.js";
+
+/** Gate for the ACP coding-agent subsystem (must match the registry). */
+export const ACP_FLAG_KEY = "acp" as const;
+
+/**
+ * Whether ACP agent spawning/steering is enabled, via either the legacy
+ * `acp.enabled` config field or the `acp` feature flag (see module doc).
+ */
+export function isAcpEnabled(config: AssistantConfig): boolean {
+  return (
+    config.acp.enabled || isAssistantFeatureFlagEnabled(ACP_FLAG_KEY, config)
+  );
+}

--- a/assistant/src/acp/feature-gate.ts
+++ b/assistant/src/acp/feature-gate.ts
@@ -28,6 +28,7 @@ export const ACP_FLAG_KEY = "acp" as const;
  */
 export function isAcpEnabled(config: AssistantConfig): boolean {
   return (
-    config.acp.enabled || isAssistantFeatureFlagEnabled(ACP_FLAG_KEY, config)
+    config.acp?.enabled === true ||
+    isAssistantFeatureFlagEnabled(ACP_FLAG_KEY, config)
   );
 }

--- a/assistant/src/acp/resolve-agent.test.ts
+++ b/assistant/src/acp/resolve-agent.test.ts
@@ -1,19 +1,25 @@
 import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 
+import { setOverridesForTesting } from "../__tests__/feature-flag-test-helpers.js";
 import { installAcpConfigStub } from "./__tests__/helpers/acp-config-stub.js";
 import { installWhichStub } from "./__tests__/helpers/which-stub.js";
+import { ACP_FLAG_KEY } from "./feature-gate.js";
 
 const config = await installAcpConfigStub();
 const which = installWhichStub();
 
 afterAll(() => {
   which.restore();
+  setOverridesForTesting({});
 });
 
 const { resolveAcpAgent, listAcpAgents } = await import("./resolve-agent.js");
 
 beforeEach(() => {
   config.setConfig({});
+  // Default: no flag overrides, so the `acp` flag falls back to its registry
+  // default (false) and enablement comes from the config stub alone.
+  setOverridesForTesting({});
   // Default: every command on PATH so binary preflight passes unless a test
   // explicitly says otherwise.
   which.setWhich((cmd) => `/usr/local/bin/${cmd}`);
@@ -24,7 +30,7 @@ beforeEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("resolveAcpAgent", () => {
-  test("returns acp_disabled when config.acp.enabled is false", () => {
+  test("returns acp_disabled when both the feature flag and config.acp.enabled are off", () => {
     config.setConfig({ enabled: false });
 
     const result = resolveAcpAgent("claude");
@@ -33,8 +39,21 @@ describe("resolveAcpAgent", () => {
     if (result.ok) return;
     expect(result.reason).toBe("acp_disabled");
     if (result.reason !== "acp_disabled") return;
+    expect(result.hint).toContain("ACP Coding Agents");
+    expect(result.hint).toContain("feature flag");
     expect(result.hint).toContain("acp.enabled");
     expect(result.hint).toContain("config.json");
+  });
+
+  test("resolution proceeds when the acp feature flag is on and config.acp.enabled is false", () => {
+    config.setConfig({ enabled: false });
+    setOverridesForTesting({ [ACP_FLAG_KEY]: true });
+
+    const result = resolveAcpAgent("claude");
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.agent.command).toBe("claude-agent-acp");
   });
 
   test("user config wins over default profile", () => {
@@ -207,13 +226,23 @@ describe("resolveAcpAgent", () => {
 // ---------------------------------------------------------------------------
 
 describe("listAcpAgents", () => {
-  test("returns enabled: false with empty agents when ACP is disabled", () => {
+  test("returns enabled: false with empty agents when both the flag and config are off", () => {
     config.setConfig({ enabled: false });
 
     const result = listAcpAgents();
 
     expect(result.enabled).toBe(false);
     expect(result.agents).toEqual([]);
+  });
+
+  test("returns the catalog when the acp feature flag is on and config.acp.enabled is false", () => {
+    config.setConfig({ enabled: false });
+    setOverridesForTesting({ [ACP_FLAG_KEY]: true });
+
+    const result = listAcpAgents();
+
+    expect(result.enabled).toBe(true);
+    expect(result.agents.map((a) => a.id)).toEqual(["claude", "codex"]);
   });
 
   test("includes both bundled defaults when user config is empty", () => {

--- a/assistant/src/acp/resolve-agent.ts
+++ b/assistant/src/acp/resolve-agent.ts
@@ -3,7 +3,8 @@
  *
  * `resolveAcpAgent(id)` merges user-provided `config.acp.agents[id]` (wins on
  * overlap) with the bundled `DEFAULT_ACP_AGENT_PROFILES` so common agents like
- * `claude` and `codex` Just Work whenever `acp.enabled: true` — no per-user
+ * `claude` and `codex` Just Work whenever ACP is enabled (the `acp` feature
+ * flag or `acp.enabled: true`; see `feature-gate.ts`), with no per-user
  * config required. The result is a discriminated union covering every reason
  * a spawn might fail before we even start the agent process: ACP disabled,
  * unknown agent id, or binary missing from PATH. Callers (acp_spawn,
@@ -21,6 +22,7 @@ import {
 } from "../config/acp-defaults.js";
 import type { AcpAgentConfig } from "../config/acp-schema.js";
 import { getConfig } from "../config/loader.js";
+import { isAcpEnabled } from "./feature-gate.js";
 
 /**
  * Whether this agent's entry came from user config (wins over default) or
@@ -56,7 +58,7 @@ interface AcpAgentEntry {
  * the same string instead of duplicating near-identical copy.
  */
 export const ACP_DISABLED_HINT =
-  "Set 'acp.enabled': true in ~/.vellum/workspace/config.json (or via the runtime config endpoint).";
+  "Enable the \"ACP Coding Agents\" feature flag in the client's feature flags UI (or set 'acp.enabled': true in ~/.vellum/workspace/config.json).";
 
 function installHintFor(command: string): string {
   const pkg = DEFAULT_AGENT_NPM_PACKAGES[command];
@@ -109,7 +111,7 @@ function mergedAgentIds(userAgents: Record<string, AcpAgentConfig>): string[] {
  * Resolve an ACP agent id to its config + binary preflight result.
  *
  * Order of checks:
- * 1. ACP must be enabled in config.
+ * 1. ACP must be enabled (feature flag or config; see `isAcpEnabled`).
  * 2. The id must resolve to an agent (user config wins; falls back to defaults).
  * 3. The agent's `command` must be discoverable via `Bun.which` (PATH lookup).
  *
@@ -118,7 +120,7 @@ function mergedAgentIds(userAgents: Record<string, AcpAgentConfig>): string[] {
  */
 export function resolveAcpAgent(id: string): ResolveAcpAgentResult {
   const config = getConfig();
-  if (!config.acp.enabled) {
+  if (!isAcpEnabled(config)) {
     return { ok: false, reason: "acp_disabled", hint: ACP_DISABLED_HINT };
   }
 
@@ -160,7 +162,7 @@ export function listAcpAgents(): {
   agents: AcpAgentEntry[];
 } {
   const config = getConfig();
-  if (!config.acp.enabled) {
+  if (!isAcpEnabled(config)) {
     return { enabled: false, agents: [] };
   }
 

--- a/assistant/src/config/bundled-skills/acp/SKILL.md
+++ b/assistant/src/config/bundled-skills/acp/SKILL.md
@@ -29,7 +29,9 @@ When the user first tries to use ACP and it's not configured, set it up automati
    npm i -g @agentclientprotocol/claude-agent-acp
    ```
 
-2. **Enable ACP in the workspace config** by editing the config file to add the `acp` section. Default profiles for `claude` and `codex` ship out-of-box, so the minimal config is just:
+2. **Enable the `acp` feature flag** (the primary enablement path). Either PATCH it via the gateway feature-flags endpoint or direct the user to toggle "ACP Coding Agents" in the client's feature flags UI. Flag changes are hot-refreshed in the daemon - no restart needed.
+
+   As a supported alternative, edit the workspace config file to add the `acp` section. Default profiles for `claude` and `codex` ship out-of-box, so the minimal config is just:
    ```json
    {
      "acp": {
@@ -38,10 +40,9 @@ When the user first tries to use ACP and it's not configured, set it up automati
      }
    }
    ```
+   If you go the config route, **wait a few seconds** for the config watcher to pick up the change (it hot-reloads automatically - no restart needed).
 
-3. **Wait a few seconds** for the config watcher to pick up the change (it hot-reloads automatically - no restart needed).
-
-4. Then retry the `acp_spawn` call. Do NOT run `vellum sleep && vellum wake` - that kills the conversation.
+3. Then retry the `acp_spawn` call. Do NOT run `vellum sleep && vellum wake` - that kills the conversation.
 
 ## Codex setup
 

--- a/assistant/src/config/bundled-skills/acp/SKILL.md
+++ b/assistant/src/config/bundled-skills/acp/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   emoji: "🔗"
   vellum:
     display-name: "ACP"
+    feature-flag: acp
     activation-hints:
       - "User wants to delegate a coding task to Claude Code, Codex, or another ACP agent"
       - "User wants to spawn an external coding agent that runs autonomously and streams results back"
@@ -29,7 +30,7 @@ When the user first tries to use ACP and it's not configured, set it up automati
    npm i -g @agentclientprotocol/claude-agent-acp
    ```
 
-2. **Enable the `acp` feature flag** (the primary enablement path). Either PATCH it via the gateway feature-flags endpoint or direct the user to toggle "ACP Coding Agents" in the client's feature flags UI. Flag changes are hot-refreshed in the daemon - no restart needed.
+2. **Enable the `acp` feature flag** (the primary enablement path). Either PATCH it via the gateway feature-flags endpoint or direct the user to toggle "ACP Coding Agents" in the client's feature flags UI. Flag changes are hot-refreshed in the assistant - no restart needed.
 
    As a supported alternative, edit the workspace config file to add the `acp` section. Default profiles for `claude` and `codex` ship out-of-box, so the minimal config is just:
    ```json

--- a/assistant/src/config/skill-state.ts
+++ b/assistant/src/config/skill-state.ts
@@ -1,8 +1,38 @@
+import { ACP_FLAG_KEY, isAcpEnabled } from "../acp/feature-gate.js";
 import { isAssistantFeatureFlagEnabled } from "./assistant-feature-flags.js";
 import type { AssistantConfig, SkillEntryConfig } from "./schema.js";
 import type { SkillSummary } from "./skills.js";
 
 export type SkillState = "enabled" | "disabled";
+
+/**
+ * Per-flag predicate overrides for skill gating. Most skill feature flags are
+ * resolved purely through the flag system, but some subsystems have richer
+ * enablement semantics (e.g. ACP is flag OR `config.acp.enabled`). Routing the
+ * skill gate through the subsystem's own feature gate keeps the skill
+ * available whenever the subsystem itself is enabled.
+ */
+const SKILL_FLAG_PREDICATES: Record<
+  string,
+  (config: AssistantConfig) => boolean
+> = {
+  [ACP_FLAG_KEY]: isAcpEnabled,
+};
+
+/**
+ * Whether the feature flag declared by a skill's frontmatter should be
+ * considered enabled. Used by every skill flag-gating enforcement point so
+ * that per-flag predicate overrides (see {@link SKILL_FLAG_PREDICATES}) apply
+ * consistently everywhere.
+ */
+export function isSkillFeatureFlagEnabled(
+  flagKey: string,
+  config: AssistantConfig,
+): boolean {
+  const predicate = SKILL_FLAG_PREDICATES[flagKey];
+  if (predicate) return predicate(config);
+  return isAssistantFeatureFlagEnabled(flagKey, config);
+}
 
 export interface ResolvedSkill {
   summary: SkillSummary;
@@ -33,7 +63,7 @@ export function resolveSkillStates(
   for (const skill of catalog) {
     // Assistant feature flag gate: if the skill declares a flag and it's disabled, skip it
     const flagKey = skillFlagKey(skill);
-    if (flagKey && !isAssistantFeatureFlagEnabled(flagKey, config)) {
+    if (flagKey && !isSkillFeatureFlagEnabled(flagKey, config)) {
       continue;
     }
 

--- a/assistant/src/daemon/conversation-skill-tools.ts
+++ b/assistant/src/daemon/conversation-skill-tools.ts
@@ -11,9 +11,11 @@
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 
-import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getConfig } from "../config/loader.js";
-import { skillFlagKey } from "../config/skill-state.js";
+import {
+  isSkillFeatureFlagEnabled,
+  skillFlagKey,
+} from "../config/skill-state.js";
 import type { SkillSummary, SkillToolManifest } from "../config/skills.js";
 import { loadSkillCatalog } from "../config/skills.js";
 import type { Message, ToolDefinition } from "../providers/types.js";
@@ -255,7 +257,7 @@ export function projectSkillTools(
   for (const id of allCandidateIds) {
     const skill = catalogById.get(id);
     const flagKey = skill ? skillFlagKey(skill) : undefined;
-    if (!flagKey || isAssistantFeatureFlagEnabled(flagKey, config)) {
+    if (!flagKey || isSkillFeatureFlagEnabled(flagKey, config)) {
       activeIds.add(id);
     }
   }

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -9,14 +9,17 @@ import {
 } from "node:fs";
 import { basename, join, relative, sep } from "node:path";
 
-import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import {
   getConfig,
   invalidateConfigCache,
   loadRawConfig,
   saveRawConfig,
 } from "../../config/loader.js";
-import { resolveSkillStates, skillFlagKey } from "../../config/skill-state.js";
+import {
+  isSkillFeatureFlagEnabled,
+  resolveSkillStates,
+  skillFlagKey,
+} from "../../config/skill-state.js";
 import type { SkillSummary } from "../../config/skills.js";
 import { loadSkillCatalog } from "../../config/skills.js";
 import { deleteSkillCapabilityNode } from "../../memory/graph/capability-seed.js";
@@ -31,7 +34,10 @@ import {
   isTextMimeType as isTextMime,
   MAX_INLINE_TEXT_SIZE,
 } from "../../runtime/routes/workspace-utils.js";
-import { getCachedCatalogSync, getCatalog } from "../../skills/catalog-cache.js";
+import {
+  getCachedCatalogSync,
+  getCatalog,
+} from "../../skills/catalog-cache.js";
 import type { SkillFileEntry } from "../../skills/catalog-files.js";
 import {
   catalogSkillToSlim,
@@ -1133,7 +1139,7 @@ export async function installSkill(spec: {
     const flaggedSkill = catalog.find((s) => s.id === spec.slug);
     if (flaggedSkill) {
       const flagKey = skillFlagKey(flaggedSkill);
-      if (flagKey && !isAssistantFeatureFlagEnabled(flagKey, config)) {
+      if (flagKey && !isSkillFeatureFlagEnabled(flagKey, config)) {
         return {
           success: false,
           error: `Skill "${spec.slug}" is currently unavailable (disabled by feature flag)`,

--- a/assistant/src/memory/graph/capability-seed.ts
+++ b/assistant/src/memory/graph/capability-seed.ts
@@ -8,9 +8,11 @@
 import { and, eq, like, sql } from "drizzle-orm";
 
 import { buildCliProgram } from "../../cli/program.js";
-import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import { getConfig } from "../../config/loader.js";
-import { resolveSkillStates } from "../../config/skill-state.js";
+import {
+  isSkillFeatureFlagEnabled,
+  resolveSkillStates,
+} from "../../config/skill-state.js";
 import { loadSkillCatalog } from "../../config/skills.js";
 import {
   getCachedCatalogSync,
@@ -135,8 +137,7 @@ export function seedSkillGraphNodes(): void {
     } else {
       for (const entry of cachedCatalog) {
         const flagKey = entry.metadata?.vellum?.["feature-flag"];
-        if (flagKey && !isAssistantFeatureFlagEnabled(flagKey, config))
-          continue;
+        if (flagKey && !isSkillFeatureFlagEnabled(flagKey, config)) continue;
         seenKeys.add(`${SKILL_SOURCE_PREFIX}${entry.id}`);
       }
       pruneStaleCapabilities(SKILL_SOURCE_PREFIX, seenKeys);
@@ -191,7 +192,7 @@ export async function seedUninstalledCatalogSkillMemories(): Promise<void> {
       if (installedIds.has(entry.id)) continue;
 
       const flagKey = entry.metadata?.vellum?.["feature-flag"];
-      if (flagKey && !isAssistantFeatureFlagEnabled(flagKey, config)) continue;
+      if (flagKey && !isSkillFeatureFlagEnabled(flagKey, config)) continue;
 
       upsertSkillCapabilityNode(entry.id, fromCatalogSkill(entry));
     }

--- a/assistant/src/memory/v2/__tests__/skill-store.test.ts
+++ b/assistant/src/memory/v2/__tests__/skill-store.test.ts
@@ -109,6 +109,8 @@ mock.module("../../../config/skills.js", () => ({
 }));
 
 mock.module("../../../config/skill-state.js", () => ({
+  // Mirror the real helper: route through the mocked flag state.
+  isSkillFeatureFlagEnabled: (key: string) => state.flagsEnabled[key] ?? true,
   resolveSkillStates: (
     catalog: SkillSummary[],
     config: { skills?: { allowBundled?: string[] | null } },

--- a/assistant/src/memory/v2/skill-store.ts
+++ b/assistant/src/memory/v2/skill-store.ts
@@ -19,9 +19,11 @@
 // The cache is replaced atomically at the end of a successful seed run; on
 // error the prior cache stays intact (skills are best-effort).
 
-import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import { getConfig } from "../../config/loader.js";
-import { resolveSkillStates } from "../../config/skill-state.js";
+import {
+  isSkillFeatureFlagEnabled,
+  resolveSkillStates,
+} from "../../config/skill-state.js";
 import { loadSkillCatalog } from "../../config/skills.js";
 import { getCatalog } from "../../skills/catalog-cache.js";
 import {
@@ -185,7 +187,7 @@ async function runSeedV2SkillEntries(generation: number): Promise<void> {
     const seeds: SkillEntry[] = [];
     for (const { summary } of enabled) {
       const flagKey = summary.featureFlag;
-      if (flagKey && !isAssistantFeatureFlagEnabled(flagKey, config)) continue;
+      if (flagKey && !isSkillFeatureFlagEnabled(flagKey, config)) continue;
 
       const augmented = augmentMcpSetupDescription(fromSkillSummary(summary));
       const content = buildSkillContent(augmented);
@@ -210,8 +212,7 @@ async function runSeedV2SkillEntries(generation: number): Promise<void> {
         knownSkillIds.add(entry.id);
         if (installedIds.has(entry.id)) continue;
         const flagKey = entry.metadata?.vellum?.["feature-flag"];
-        if (flagKey && !isAssistantFeatureFlagEnabled(flagKey, config))
-          continue;
+        if (flagKey && !isSkillFeatureFlagEnabled(flagKey, config)) continue;
         const content = buildSkillContent(fromCatalogSkill(entry));
         seeds.push({ id: entry.id, content });
       }

--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -1,9 +1,11 @@
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 
-import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import { getConfig } from "../../config/loader.js";
-import { skillFlagKey } from "../../config/skill-state.js";
+import {
+  isSkillFeatureFlagEnabled,
+  skillFlagKey,
+} from "../../config/skill-state.js";
 import type { SkillSummary, SkillToolManifest } from "../../config/skills.js";
 import {
   listReferenceFiles,
@@ -197,7 +199,7 @@ export const skillLoadTool = {
     // Assistant feature flag gate: reject loading if the skill's flag is OFF
     const config = getConfig();
     const flagKey = skillFlagKey(skill);
-    if (flagKey && !isAssistantFeatureFlagEnabled(flagKey, config)) {
+    if (flagKey && !isSkillFeatureFlagEnabled(flagKey, config)) {
       return {
         content: `Error: skill "${skill.id}" is currently unavailable (disabled by feature flag)`,
         isError: true,
@@ -346,10 +348,7 @@ export const skillLoadTool = {
         const child = catalogIndex.get(childId);
         if (!child) continue;
         const childFlagKey = skillFlagKey(child);
-        if (
-          childFlagKey &&
-          !isAssistantFeatureFlagEnabled(childFlagKey, config)
-        )
+        if (childFlagKey && !isSkillFeatureFlagEnabled(childFlagKey, config))
           continue;
 
         childLines.push(
@@ -475,10 +474,7 @@ export const skillLoadTool = {
         const child = catalogIndex.get(childId);
         if (!child) continue;
         const childFlagKey2 = skillFlagKey(child);
-        if (
-          childFlagKey2 &&
-          !isAssistantFeatureFlagEnabled(childFlagKey2, config)
-        )
+        if (childFlagKey2 && !isSkillFeatureFlagEnabled(childFlagKey2, config))
           continue;
         let childHash: string | undefined;
         try {

--- a/meta/feature-flags/AGENTS.md
+++ b/meta/feature-flags/AGENTS.md
@@ -71,6 +71,8 @@ featureFlag: my-new-flag
 
 Skills without a `featureFlag` field are always available. Skills that declare one are gated at six independent enforcement points — when the flag is OFF the skill is unavailable everywhere.
 
+All enforcement points resolve the skill's flag through `isSkillFeatureFlagEnabled` in `assistant/src/config/skill-state.ts`. Most flags resolve directly through the flag system, but flags listed in `SKILL_FLAG_PREDICATES` route through the subsystem's own feature gate instead (e.g. `acp` resolves via `isAcpEnabled`, which is flag OR `config.acp.enabled`). Add an entry there when a subsystem has enablement semantics beyond the bare flag, so its skill stays available whenever the subsystem itself is enabled.
+
 ## Auth Scopes Are Unrelated
 
 The OAuth/API scopes `feature_flags.read` and `feature_flags.write` control access to the feature-flag management API. They are **not** flag keys and should not be modified when adding or renaming flags.

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -488,6 +488,14 @@
       "label": "Provider-First Profile Creation",
       "description": "New profile creation flow: pick (or inline-create) a provider first, then a model, with pre-filled provider and profile name/key, plus a quick-add \"+\" in the chat composer's Model Profile menu. When off, profile creation uses the previous field order and there is no composer quick-add.",
       "defaultEnabled": false
+    },
+    {
+      "id": "acp",
+      "scope": "assistant",
+      "key": "acp",
+      "label": "ACP Coding Agents",
+      "description": "Enable spawning and steering external coding agents (Claude Code, Codex, Gemini) via the Agent Client Protocol. Alternative gate to the acp.enabled workspace config field; either enables the subsystem.",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add acp assistant-scope feature flag (defaultEnabled: false) to the canonical registry and synced copies
- New isAcpEnabled gate: feature flag OR existing config.acp.enabled, used by the ACP resolver
- Update ACP skill docs and disabled-state hint to lead with the flag

Part of plan: acp-native-agent-ux.md (PR 1 of 8)