### PR TITLE
Persist cwd in acp_session_history (migration 272)

### DIFF
--- a/assistant/src/__tests__/db-acp-history.test.ts
+++ b/assistant/src/__tests__/db-acp-history.test.ts
@@ -5,6 +5,7 @@ import { drizzle } from "drizzle-orm/bun-sqlite";
 
 import { getSqliteFrom } from "../memory/db-connection.js";
 import { migrate230AcpSessionHistory } from "../memory/migrations/230-acp-session-history.js";
+import { migrateAcpSessionHistoryCwd } from "../memory/migrations/272-acp-session-history-cwd.js";
 import * as schema from "../memory/schema.js";
 
 function createTestDb() {
@@ -280,5 +281,105 @@ describe("acp_session_history migration", () => {
       .query(`SELECT id FROM acp_session_history WHERE id = 'history-rerun'`)
       .get() as { id: string } | null;
     expect(row?.id).toBe("history-rerun");
+  });
+});
+
+describe("acp_session_history cwd migration (272)", () => {
+  function readColumns(raw: Database): Map<string, ColumnRow> {
+    const columns = raw
+      .query(`PRAGMA table_info(acp_session_history)`)
+      .all() as ColumnRow[];
+    return new Map(columns.map((c) => [c.name, c]));
+  }
+
+  test("adds a nullable cwd TEXT column to an upgraded table", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    bootstrapCheckpointsTable(raw);
+
+    migrate230AcpSessionHistory(db);
+    expect(readColumns(raw).has("cwd")).toBe(false);
+
+    migrateAcpSessionHistoryCwd(db);
+
+    const cwd = readColumns(raw).get("cwd");
+    expect(cwd).toBeDefined();
+    expect(cwd?.type).toBe("TEXT");
+    expect(cwd?.notnull).toBe(0);
+  });
+
+  test("re-running is a no-op, including with a cleared checkpoint", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    bootstrapCheckpointsTable(raw);
+
+    migrate230AcpSessionHistory(db);
+    migrateAcpSessionHistoryCwd(db);
+
+    // Second run short-circuits on the completed checkpoint.
+    expect(() => migrateAcpSessionHistoryCwd(db)).not.toThrow();
+
+    // Even with the checkpoint cleared (simulating crash recovery), the
+    // column-existence guard makes the ALTER a no-op.
+    raw
+      .query(`DELETE FROM memory_checkpoints WHERE key = ?`)
+      .run("migration_acp_session_history_cwd_v1");
+    expect(() => migrateAcpSessionHistoryCwd(db)).not.toThrow();
+
+    const columns = raw
+      .query(`PRAGMA table_info(acp_session_history)`)
+      .all() as ColumnRow[];
+    expect(columns.filter((c) => c.name === "cwd")).toHaveLength(1);
+  });
+
+  test("legacy rows read back with cwd null; new rows round-trip cwd", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    bootstrapCheckpointsTable(raw);
+
+    migrate230AcpSessionHistory(db);
+
+    // Legacy row inserted before the cwd column existed.
+    raw
+      .query(
+        /*sql*/ `
+        INSERT INTO acp_session_history (
+          id, agent_id, acp_session_id, parent_conversation_id,
+          started_at, status
+        ) VALUES (?, ?, ?, ?, ?, ?)
+      `,
+      )
+      .run("legacy-1", "agent-old", "acp-old", "conv-old", 100, "completed");
+
+    migrateAcpSessionHistoryCwd(db);
+
+    const legacy = raw
+      .query(`SELECT cwd FROM acp_session_history WHERE id = 'legacy-1'`)
+      .get() as { cwd: string | null } | null;
+    expect(legacy?.cwd).toBeNull();
+
+    raw
+      .query(
+        /*sql*/ `
+        INSERT INTO acp_session_history (
+          id, agent_id, acp_session_id, parent_conversation_id,
+          started_at, status, cwd
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+      `,
+      )
+      .run(
+        "new-1",
+        "agent-new",
+        "acp-new",
+        "conv-new",
+        200,
+        "completed",
+        "/Users/me/project",
+      );
+
+    const fresh = raw
+      .query(`SELECT cwd FROM acp_session_history WHERE id = 'new-1'`)
+      .get() as { cwd: string | null } | null;
+    expect(fresh?.cwd).toBe("/Users/me/project");
   });
 });

--- a/assistant/src/acp/__tests__/session-manager-persistence.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-persistence.test.ts
@@ -40,13 +40,14 @@ interface HistoryRow {
   stop_reason: string | null;
   error: string | null;
   event_log_json: string;
+  cwd: string | null;
 }
 
 function readHistoryRow(id: string): HistoryRow | null {
   return getSqlite()
     .query(
       `SELECT id, agent_id, acp_session_id, parent_conversation_id,
-              started_at, completed_at, status, stop_reason, error, event_log_json
+              started_at, completed_at, status, stop_reason, error, event_log_json, cwd
        FROM acp_session_history WHERE id = ?`,
     )
     .get(id) as HistoryRow | null;
@@ -61,6 +62,7 @@ function buildSessionWithFakeProcess(opts: {
   agentId: string;
   protocolSessionId: string;
   parentConversationId: string;
+  cwd?: string;
 }): {
   manager: AcpSessionManager;
   resolvePrompt: (v: { stopReason: string }) => void;
@@ -126,7 +128,7 @@ function buildSessionWithFakeProcess(opts: {
     sendToVellum: wrappedSend,
     currentPrompt: null as Promise<unknown> | null,
     parentConversationId: opts.parentConversationId,
-    cwd: "/tmp",
+    cwd: opts.cwd ?? "/tmp",
     command: "claude-agent-acp",
   };
   sessions.set(opts.id, entry);
@@ -343,6 +345,38 @@ describe("AcpSessionManager — terminal persistence", () => {
     // Persisted JSON must respect the 256 KB cap (allowing a small margin
     // for the surrounding `[…]` and inter-element commas).
     expect(row!.event_log_json.length).toBeLessThan(256 * 1024 + 1024);
+  });
+
+  test("persists the spawn cwd on terminal transition", async () => {
+    const id = "session-cwd-1";
+    const handles = buildSessionWithFakeProcess({
+      id,
+      agentId: "agent-cwd",
+      protocolSessionId: "proto-cwd",
+      parentConversationId: "conv-cwd",
+      cwd: "/Users/me/projects/widget",
+    });
+
+    handles.resolvePrompt({ stopReason: "end_turn" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const row = readHistoryRow(id);
+    expect(row).not.toBeNull();
+    expect(row!.cwd).toBe("/Users/me/projects/widget");
+  });
+
+  test("legacy rows without a cwd read back as null", () => {
+    getSqlite().run(
+      `INSERT INTO acp_session_history (
+         id, agent_id, acp_session_id, parent_conversation_id,
+         started_at, status
+       ) VALUES ('legacy-row-1', 'agent-legacy', 'proto-legacy', 'conv-legacy', 1000, 'completed')`,
+    );
+
+    const row = readHistoryRow("legacy-row-1");
+    expect(row).not.toBeNull();
+    expect(row!.cwd).toBeNull();
   });
 
   test("persists empty event log when no updates were emitted", async () => {

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -391,6 +391,7 @@ export class AcpSessionManager {
           stopReason: entry.state.stopReason ?? null,
           error: entry.state.error ?? null,
           eventLogJson: JSON.stringify(wireUpdates),
+          cwd: entry.cwd,
         })
         .onConflictDoNothing()
         .run();

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -41,6 +41,7 @@ import {
   migrate230AcpSessionHistory,
   migrate231RepairMemoryGraphEventDates,
   migrateA2ATasks,
+  migrateAcpSessionHistoryCwd,
   migrateActivationState,
   migrateActivationStateFkCascade,
   migrateAddConversationInferenceProfile,
@@ -478,6 +479,7 @@ export function initializeDb(): void {
     migrateScheduleSourceConversation,
     migrateMessagesRoleCreatedAtIndex,
     createAuthFallbackEventsTable,
+    migrateAcpSessionHistoryCwd,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/272-acp-session-history-cwd.ts
+++ b/assistant/src/memory/migrations/272-acp-session-history-cwd.ts
@@ -1,0 +1,36 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+const CHECKPOINT_KEY = "migration_acp_session_history_cwd_v1";
+
+const TABLE = "acp_session_history";
+const COLUMN = "cwd";
+
+/**
+ * Add a nullable `cwd TEXT` column to `acp_session_history`.
+ *
+ * Records the working directory the ACP agent process was spawned with so
+ * that a persisted session can later be resumed (`session/load` /
+ * `session/resume` both require the original cwd to reconstruct params).
+ *
+ * `NULL` for rows persisted before this migration ran — legacy sessions
+ * simply are not resumable.
+ *
+ * Idempotent — the PRAGMA guard makes re-running a no-op once the column
+ * exists.
+ */
+export function migrateAcpSessionHistoryCwd(database: DrizzleDb): void {
+  withCrashRecovery(database, CHECKPOINT_KEY, () => {
+    const raw = getSqliteFrom(database);
+
+    const columns = raw.query(`PRAGMA table_info(${TABLE})`).all() as Array<{
+      name: string;
+    }>;
+    const columnNames = new Set(columns.map((c) => c.name));
+
+    if (!columnNames.has(COLUMN)) {
+      raw.exec(`ALTER TABLE ${TABLE} ADD COLUMN ${COLUMN} TEXT`);
+    }
+  });
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -259,6 +259,7 @@ export { migrateScheduleScriptTimeout } from "./269-schedule-script-timeout.js";
 export { migrateMessagesRoleCreatedAtIndex } from "./270-messages-role-created-at-index.js";
 export { migrateScheduleSourceConversation } from "./270-schedule-source-conversation.js";
 export { createAuthFallbackEventsTable } from "./271-create-auth-fallback-events.js";
+export { migrateAcpSessionHistoryCwd } from "./272-acp-session-history-cwd.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/acp.ts
+++ b/assistant/src/memory/schema/acp.ts
@@ -20,6 +20,10 @@ export const acpSessionHistory = sqliteTable(
     stopReason: text("stop_reason"),
     error: text("error"),
     eventLogJson: text("event_log_json").notNull().default("[]"),
+    // Working directory the agent process was spawned with. Required to
+    // resume a persisted session; null for rows written before migration
+    // 272 (those sessions are not resumable).
+    cwd: text("cwd"),
   },
   (table) => [
     index("idx_acp_session_history_started_at").on(table.startedAt),


### PR DESCRIPTION
## Summary
- Migration 272: add nullable cwd column to acp_session_history (271 was taken by create-auth-fallback-events on main, so the plan's 271 shifted to 272)
- Persist the spawn cwd on terminal session rows so future session resume can reconstruct session/load params
- Schema + tests

Part of plan: acp-native-agent-ux.md (PR 3 of 8)