### PR TITLE
Auto-install known ACP adapter binaries on first spawn

### DIFF
--- a/assistant/src/acp/__tests__/helpers/exec-file-stub.ts
+++ b/assistant/src/acp/__tests__/helpers/exec-file-stub.ts
@@ -1,0 +1,101 @@
+/**
+ * Shared test helper: stub `execFile` from `node:child_process` for ACP tests.
+ *
+ * Several ACP suites (the `acp_spawn` tool's version probes, the adapter
+ * auto-installer, and the `/v1/acp/spawn` route) shell out via
+ * `execFileWithTimeout`. Each test file used to duplicate the same
+ * `mock.module("node:child_process", ...)` + scripted-responses boilerplate;
+ * this helper consolidates it, mirroring `which-stub.ts`.
+ *
+ * Like the other helpers here, the hook is process-global by design (Bun's
+ * `mock.module` is process-global). Each test file should call
+ * `installExecFileStub()` once at the top level, script calls per test via
+ * `execScripts`, and clear state in `beforeEach` via `reset()`.
+ */
+
+import * as realChildProcess from "node:child_process";
+import { mock } from "bun:test";
+
+type ExecCallback = (
+  err: Error | null,
+  stdout: string | Buffer,
+  stderr: string | Buffer,
+) => void;
+
+export interface ExecScript {
+  /** When set, the call rejects with this error. */
+  error?: Error;
+  /** When set, the call resolves with this stdout. */
+  stdout?: string;
+  /** When set, runs as the call executes (e.g. flip a which-stub flag). */
+  onCall?: () => void;
+}
+
+type ExecFileMock = ReturnType<
+  typeof mock<
+    (
+      command: string,
+      args: string[],
+      options: unknown,
+      callback?: ExecCallback,
+    ) => ReturnType<typeof realChildProcess.execFile>
+  >
+>;
+
+export interface ExecFileStubHandle {
+  /**
+   * Per-call scripted responses, keyed by `${command} ${args[0]}` so tests
+   * can target `npm ls`, `npm view`, and `npm i` independently. Calls with
+   * no script reject with a recognizable "No script for <key>" error.
+   */
+  execScripts: Map<string, ExecScript>;
+  execFileMock: ExecFileMock;
+  /** Clears scripts and recorded calls. Call from `beforeEach`. */
+  reset(): void;
+}
+
+/** Installs a process-global `execFile` mock. Returns handles to drive it. */
+export function installExecFileStub(): ExecFileStubHandle {
+  const execScripts: Map<string, ExecScript> = new Map();
+
+  const execFileMock: ExecFileMock = mock(
+    (
+      command: string,
+      args: string[],
+      _options: unknown,
+      callback?: ExecCallback,
+    ) => {
+      const key = `${command} ${args[0]}`;
+      const script = execScripts.get(key);
+      queueMicrotask(() => {
+        if (!callback) return;
+        if (!script) {
+          callback(new Error(`No script for ${key}`), "", "");
+          return;
+        }
+        script.onCall?.();
+        if (script.error) {
+          callback(script.error, "", "");
+          return;
+        }
+        callback(null, script.stdout ?? "", "");
+      });
+      // Return value is not used by execFileWithTimeout.
+      return {} as ReturnType<typeof realChildProcess.execFile>;
+    },
+  );
+
+  mock.module("node:child_process", () => ({
+    ...realChildProcess,
+    execFile: execFileMock,
+  }));
+
+  return {
+    execScripts,
+    execFileMock,
+    reset(): void {
+      execScripts.clear();
+      execFileMock.mockClear();
+    },
+  };
+}

--- a/assistant/src/acp/auto-install.test.ts
+++ b/assistant/src/acp/auto-install.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Tests for the silent ACP adapter auto-installer.
+ *
+ * `execFile` is stubbed via the shared `installExecFileStub` helper: a
+ * process-global `mock.module("node:child_process", ...)` driven by per-call
+ * scripted responses keyed on `${command} ${args[0]}`.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { installExecFileStub } from "./__tests__/helpers/exec-file-stub.js";
+
+const { execScripts, execFileMock, reset } = installExecFileStub();
+
+// Spread the real module so other test files that load logger consumers
+// (e.g. `truncateForLog` importers) after this process-global mock still
+// resolve every named export.
+const realLogger = await import("../util/logger.js");
+mock.module("../util/logger.js", () => ({
+  ...realLogger,
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+const { ensureAdapterInstalled, _resetAdapterInstallCacheForTests } =
+  await import("./auto-install.js");
+
+beforeEach(() => {
+  reset();
+  _resetAdapterInstallCacheForTests();
+});
+
+describe("ensureAdapterInstalled", () => {
+  test("known command: runs `npm i -g <pkg>` and reports installed", async () => {
+    execScripts.set("npm i", { stdout: "" });
+
+    const result = await ensureAdapterInstalled("claude-agent-acp");
+
+    expect(result).toEqual({ installed: true });
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+    const [command, args] = execFileMock.mock.calls[0];
+    expect(command).toBe("npm");
+    expect(args).toEqual([
+      "i",
+      "-g",
+      "@agentclientprotocol/claude-agent-acp",
+    ]);
+  });
+
+  test("unknown command: never invokes npm (security allowlist)", async () => {
+    const result = await ensureAdapterInstalled("some-arbitrary-binary");
+
+    expect(result.installed).toBe(false);
+    expect(result.error).toBeUndefined();
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  test("npm failure: reports the error and does not install", async () => {
+    execScripts.set("npm i", {
+      error: new Error("EACCES: permission denied"),
+    });
+
+    const result = await ensureAdapterInstalled("codex-acp");
+
+    expect(result.installed).toBe(false);
+    expect(result.error).toContain("EACCES");
+  });
+
+  test("failed install is retried on the next call", async () => {
+    execScripts.set("npm i", { error: new Error("network down") });
+    const first = await ensureAdapterInstalled("claude-agent-acp");
+    expect(first.installed).toBe(false);
+
+    execScripts.set("npm i", { stdout: "" });
+    const second = await ensureAdapterInstalled("claude-agent-acp");
+    expect(second.installed).toBe(true);
+    expect(execFileMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("successful install is cached for the process lifetime", async () => {
+    execScripts.set("npm i", { stdout: "" });
+
+    await ensureAdapterInstalled("claude-agent-acp");
+    await ensureAdapterInstalled("claude-agent-acp");
+
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("concurrent calls dedupe to exactly one `npm i -g`", async () => {
+    execScripts.set("npm i", { stdout: "" });
+
+    const [a, b, c] = await Promise.all([
+      ensureAdapterInstalled("claude-agent-acp"),
+      ensureAdapterInstalled("claude-agent-acp"),
+      ensureAdapterInstalled("claude-agent-acp"),
+    ]);
+
+    expect(a.installed).toBe(true);
+    expect(b.installed).toBe(true);
+    expect(c.installed).toBe(true);
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("different commands install independently", async () => {
+    execScripts.set("npm i", { stdout: "" });
+
+    const [claude, codex] = await Promise.all([
+      ensureAdapterInstalled("claude-agent-acp"),
+      ensureAdapterInstalled("codex-acp"),
+    ]);
+
+    expect(claude.installed).toBe(true);
+    expect(codex.installed).toBe(true);
+    expect(execFileMock).toHaveBeenCalledTimes(2);
+    const installedPackages = execFileMock.mock.calls.map(
+      (call) => (call[1] as string[])[2],
+    );
+    expect(installedPackages.sort()).toEqual([
+      "@agentclientprotocol/claude-agent-acp",
+      "@zed-industries/codex-acp",
+    ]);
+  });
+});

--- a/assistant/src/acp/auto-install.ts
+++ b/assistant/src/acp/auto-install.ts
@@ -1,0 +1,119 @@
+/**
+ * Silent auto-install for known ACP adapter binaries.
+ *
+ * When a spawn fails preflight with `binary_not_found`, callers (the
+ * `acp_spawn` tool and the `/v1/acp/spawn` route) call
+ * `ensureAdapterInstalled(command)` to try a global npm install of the
+ * mapped adapter package, then re-resolve and continue. On failure they
+ * fall back to the existing actionable install hint.
+ *
+ * Security boundary: only commands present in `DEFAULT_AGENT_NPM_PACKAGES`
+ * are ever installed. The package names are vendored constants, NOT user
+ * input: an arbitrary command from user config must never be turned into
+ * an `npm i -g <attacker-controlled-name>` execution.
+ */
+
+import { execFile } from "node:child_process";
+
+import { DEFAULT_AGENT_NPM_PACKAGES } from "../config/acp-defaults.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("acp:auto-install");
+
+/** Per-install timeout for `npm i -g`. Generous: cold npm caches are slow. */
+const NPM_INSTALL_TIMEOUT_MS = 120_000;
+
+export interface AdapterInstallResult {
+  installed: boolean;
+  error?: string;
+}
+
+/**
+ * Per-command install promises. Concurrent spawns for the same missing
+ * binary dedupe to a single `npm i -g`; successful results are cached for
+ * the process lifetime. Failed installs are evicted so a later spawn can
+ * retry (e.g. after the user fixes network or npm permissions).
+ */
+const installPromises = new Map<string, Promise<AdapterInstallResult>>();
+
+/**
+ * Run `execFile` with an AbortController-driven timeout. Returns the stdout
+ * on success; throws on error or timeout. Shared by the adapter installer
+ * here and the version probes in `tools/acp/spawn.ts`.
+ */
+export function execFileWithTimeout(
+  command: string,
+  args: string[],
+  timeoutMs: number,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    execFile(
+      command,
+      args,
+      { signal: controller.signal, encoding: "utf8" },
+      (err, stdout) => {
+        clearTimeout(timer);
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve(stdout);
+      },
+    );
+  });
+}
+
+/**
+ * Install the npm package mapped to `command` if (and only if) the command
+ * is a known adapter binary. Unknown commands resolve to
+ * `{ installed: false }` without ever invoking npm (see the security
+ * boundary note in the module doc).
+ */
+export function ensureAdapterInstalled(
+  command: string,
+): Promise<AdapterInstallResult> {
+  const packageName = DEFAULT_AGENT_NPM_PACKAGES[command];
+  if (!packageName) {
+    return Promise.resolve({ installed: false });
+  }
+
+  const inFlight = installPromises.get(command);
+  if (inFlight) return inFlight;
+
+  const promise = runInstall(command, packageName).then((result) => {
+    if (!result.installed) installPromises.delete(command);
+    return result;
+  });
+  installPromises.set(command, promise);
+  return promise;
+}
+
+async function runInstall(
+  command: string,
+  packageName: string,
+): Promise<AdapterInstallResult> {
+  log.info({ command, packageName }, "Auto-installing missing ACP adapter");
+  try {
+    await execFileWithTimeout(
+      "npm",
+      ["i", "-g", packageName],
+      NPM_INSTALL_TIMEOUT_MS,
+    );
+    log.info({ command, packageName }, "ACP adapter auto-install succeeded");
+    return { installed: true };
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    log.warn(
+      { err, command, packageName },
+      "ACP adapter auto-install failed (falling back to install hint)",
+    );
+    return { installed: false, error };
+  }
+}
+
+/** @internal: exposed for tests only. */
+export function _resetAdapterInstallCacheForTests(): void {
+  installPromises.clear();
+}

--- a/assistant/src/runtime/routes/__tests__/acp-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/acp-routes.test.ts
@@ -1,13 +1,23 @@
 /**
- * Tests for `GET /v1/acp/sessions`.
+ * Tests for ACP route handlers.
  *
- * The handler merges in-memory `AcpSessionManager.getStatus()` output with
- * persisted `acp_session_history` rows, deduping by id (in-memory wins),
- * filtering by `?conversationId`, sorting newest-first, and truncating to
- * `?limit` (default 50, max 500).
+ * `GET /v1/acp/sessions`: the handler merges in-memory
+ * `AcpSessionManager.getStatus()` output with persisted
+ * `acp_session_history` rows, deduping by id (in-memory wins), filtering by
+ * `?conversationId`, sorting newest-first, and truncating to `?limit`
+ * (default 50, max 500).
+ *
+ * `POST /v1/acp/spawn`: when the adapter binary is missing, the handler
+ * silently auto-installs allowlisted adapter packages before failing with
+ * the install hint. `execFile` is stubbed via the shared
+ * `installExecFileStub` helper so tests can script `npm i -g` outcomes.
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { installAcpConfigStub } from "../../../acp/__tests__/helpers/acp-config-stub.js";
+import { installExecFileStub } from "../../../acp/__tests__/helpers/exec-file-stub.js";
+import { installWhichStub } from "../../../acp/__tests__/helpers/which-stub.js";
 
 mock.module("../../../util/logger.js", () => ({
   getLogger: () =>
@@ -15,6 +25,12 @@ mock.module("../../../util/logger.js", () => ({
       get: () => () => {},
     }),
 }));
+
+const {
+  execScripts,
+  execFileMock,
+  reset: resetExecFileStub,
+} = installExecFileStub();
 
 // ---------------------------------------------------------------------------
 // Stub the ACP session manager so tests control the in-memory side without
@@ -37,17 +53,41 @@ interface FakeSessionState {
 
 let fakeInMemorySessions: FakeSessionState[] = [];
 
+const spawnMock = mock(async () => ({
+  acpSessionId: "acp-route-session",
+  protocolSessionId: "proto-route-session",
+}));
+
 mock.module("../../../acp/index.js", () => ({
   getAcpSessionManager: () => ({
     getStatus: () => fakeInMemorySessions,
+    spawn: spawnMock,
   }),
 }));
 
+// Identity env-prep: the credential-broker plumbing it wraps is exercised in
+// its own suite; spawn tests here only care about the resolve/install flow.
+mock.module("../../../acp/prepare-agent-env.js", () => ({
+  prepareAgentEnv: async (agentConfig: unknown) => agentConfig,
+}));
+
+const config = await installAcpConfigStub();
+const which = installWhichStub();
+
 import { getSqlite } from "../../../memory/db-connection.js";
 import { initializeDb } from "../../../memory/db-init.js";
-import { ROUTES } from "../acp-routes.js";
+import { FailedDependencyError } from "../errors.js";
+
+const { ROUTES } = await import("../acp-routes.js");
+const { _resetAdapterInstallCacheForTests } = await import(
+  "../../../acp/auto-install.js"
+);
 
 initializeDb();
+
+afterAll(() => {
+  which.restore();
+});
 
 function clearHistory(): void {
   getSqlite().run("DELETE FROM acp_session_history");
@@ -122,6 +162,11 @@ interface ResponseShape {
 beforeEach(() => {
   fakeInMemorySessions = [];
   clearHistory();
+  resetExecFileStub();
+  spawnMock.mockClear();
+  _resetAdapterInstallCacheForTests();
+  config.setConfig({});
+  which.setWhich((cmd) => `/usr/local/bin/${cmd}`);
 });
 
 describe("GET /v1/acp/sessions — merged in-memory + history", () => {
@@ -390,5 +435,88 @@ describe("GET /v1/acp/sessions — merged in-memory + history", () => {
       queryParams: { limit: "9999" },
     })) as ResponseShape;
     expect(body.sessions).toHaveLength(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /v1/acp/spawn: auto-install on missing adapter binary
+// ---------------------------------------------------------------------------
+
+function getSpawnHandler() {
+  const route = ROUTES.find(
+    (r) => r.endpoint === "acp/spawn" && r.method === "POST",
+  );
+  if (!route) throw new Error("acp/spawn POST route not found");
+  return route.handler;
+}
+
+const SPAWN_BODY = {
+  agent: "claude",
+  task: "do something",
+  conversationId: "conv-1",
+};
+
+describe("POST /v1/acp/spawn: auto-install on missing binary", () => {
+  test("known command: installs the mapped package and spawn proceeds", async () => {
+    // Binary appears on PATH only after `npm i -g` runs, simulating a
+    // successful global install.
+    let binaryOnPath = false;
+    which.setWhich((cmd) => (binaryOnPath ? `/usr/local/bin/${cmd}` : null));
+    execScripts.set("npm i", {
+      stdout: "",
+      onCall: () => {
+        binaryOnPath = true;
+      },
+    });
+
+    const handler = getSpawnHandler();
+    const body = (await handler({ body: SPAWN_BODY })) as Record<
+      string,
+      unknown
+    >;
+
+    expect(body).toEqual({
+      acpSessionId: "acp-route-session",
+      protocolSessionId: "proto-route-session",
+      agent: "claude",
+    });
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+    expect(execFileMock.mock.calls[0][1]).toEqual([
+      "i",
+      "-g",
+      "@agentclientprotocol/claude-agent-acp",
+    ]);
+  });
+
+  test("npm failure: FailedDependencyError carries hint and failure reason", async () => {
+    which.setWhich({});
+    execScripts.set("npm i", {
+      error: new Error("EACCES: permission denied"),
+    });
+
+    const handler = getSpawnHandler();
+    const promise = handler({ body: SPAWN_BODY });
+    await expect(promise).rejects.toBeInstanceOf(FailedDependencyError);
+    await expect(promise).rejects.toThrow(
+      /claude-agent-acp is not on PATH.*npm i -g @agentclientprotocol\/claude-agent-acp.*auto-install failed.*EACCES/,
+    );
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  test("unknown command: never installs, plain hint surfaces", async () => {
+    config.setConfig({
+      agents: { custom: { command: "custom-bin", args: [] } },
+    });
+    which.setWhich({});
+
+    const handler = getSpawnHandler();
+    const promise = handler({ body: { ...SPAWN_BODY, agent: "custom" } });
+    await expect(promise).rejects.toBeInstanceOf(FailedDependencyError);
+    await expect(promise).rejects.toThrow(
+      "custom-bin is not on PATH. Install 'custom-bin' and ensure it is on PATH.",
+    );
+    expect(execFileMock).not.toHaveBeenCalled();
+    expect(spawnMock).not.toHaveBeenCalled();
   });
 });

--- a/assistant/src/runtime/routes/acp-routes.test.ts
+++ b/assistant/src/runtime/routes/acp-routes.test.ts
@@ -34,11 +34,18 @@ import {
 } from "bun:test";
 
 import { installAcpConfigStub } from "../../acp/__tests__/helpers/acp-config-stub.js";
+import { installExecFileStub } from "../../acp/__tests__/helpers/exec-file-stub.js";
 import { installWhichStub } from "../../acp/__tests__/helpers/which-stub.js";
 import type { AcpSessionState } from "../../acp/index.js";
 
 const config = await installAcpConfigStub();
 const which = installWhichStub();
+
+// Stub `execFile` so the spawn route's auto-install path (`npm i -g ...` in
+// acp/auto-install.ts) never shells out to real npm. The binary-missing test
+// scripts the install to fail so the route falls through to the augmented
+// FailedDependencyError hint.
+const { execScripts, reset: resetExecFileStub } = installExecFileStub();
 
 afterAll(() => {
   which.restore();
@@ -169,6 +176,9 @@ import { initializeDb } from "../../memory/db-init.js";
 import { acpSessionHistory } from "../../memory/schema.js";
 
 const { ROUTES } = await import("./acp-routes.js");
+const { _resetAdapterInstallCacheForTests } = await import(
+  "../../acp/auto-install.js"
+);
 
 function getSpawnHandler() {
   const route = ROUTES.find(
@@ -185,6 +195,8 @@ beforeEach(() => {
   capturedSpawns.length = 0;
   vaultStore.clear();
   metadataStore.clear();
+  resetExecFileStub();
+  _resetAdapterInstallCacheForTests();
 });
 
 // ---------------------------------------------------------------------------
@@ -229,6 +241,13 @@ describe("POST /v1/acp/spawn", () => {
   test("throws FailedDependencyError when the agent binary is missing", async () => {
     config.setConfig({ agents: {} });
     which.setWhich({});
+    // codex-acp is an allowlisted adapter, so the route attempts a silent
+    // `npm i -g @zed-industries/codex-acp` before failing. Script that
+    // install to fail so the augmented hint path is exercised without ever
+    // shelling out to real npm.
+    execScripts.set("npm i", {
+      error: new Error("EACCES: permission denied"),
+    });
 
     const handler = getSpawnHandler();
     await expect(
@@ -239,7 +258,9 @@ describe("POST /v1/acp/spawn", () => {
           conversationId: "conv-1",
         },
       }),
-    ).rejects.toThrow("codex-acp is not on PATH");
+    ).rejects.toThrow(
+      /codex-acp is not on PATH.*auto-install failed.*EACCES/,
+    );
   });
 
   test("body-shape guard short-circuits before the resolver runs", async () => {

--- a/assistant/src/runtime/routes/acp-routes.ts
+++ b/assistant/src/runtime/routes/acp-routes.ts
@@ -7,6 +7,7 @@
 import { desc, eq, inArray } from "drizzle-orm";
 import { z } from "zod";
 
+import { ensureAdapterInstalled } from "../../acp/auto-install.js";
 import { getAcpSessionManager } from "../../acp/index.js";
 import { prepareAgentEnv } from "../../acp/prepare-agent-env.js";
 import { resolveAcpAgent } from "../../acp/resolve-agent.js";
@@ -61,7 +62,32 @@ async function spawnSession({ body }: RouteHandlerArgs) {
     throw new BadRequestError("agent, task, and conversationId are required");
   }
 
-  const resolved = resolveAcpAgent(agent);
+  let resolved = resolveAcpAgent(agent);
+
+  // Missing adapter binary: silently try a global npm install of the mapped
+  // package (allowlisted commands only; see acp/auto-install.ts), then
+  // re-resolve and continue. Failures degrade to the existing install hint
+  // augmented with the failure reason. Mirrors the skill-tool path in
+  // tools/acp/spawn.ts.
+  if (!resolved.ok && resolved.reason === "binary_not_found") {
+    const { command, hint } = resolved;
+    const install = await ensureAdapterInstalled(command);
+    if (install.installed) {
+      const retried = resolveAcpAgent(agent);
+      if (retried.ok) {
+        log.info(
+          { agent, command },
+          "Auto-installed missing ACP adapter binary",
+        );
+        resolved = retried;
+      }
+    } else if (install.error) {
+      throw new FailedDependencyError(
+        `${command} is not on PATH. ${hint} (auto-install failed: ${install.error})`,
+      );
+    }
+  }
+
   if (!resolved.ok) {
     switch (resolved.reason) {
       case "acp_disabled":

--- a/assistant/src/tools/acp/spawn.test.ts
+++ b/assistant/src/tools/acp/spawn.test.ts
@@ -1,7 +1,7 @@
-import * as realChildProcess from "node:child_process";
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { installAcpConfigStub } from "../../acp/__tests__/helpers/acp-config-stub.js";
+import { installExecFileStub } from "../../acp/__tests__/helpers/exec-file-stub.js";
 import { installWhichStub } from "../../acp/__tests__/helpers/which-stub.js";
 import type { ToolContext } from "../types.js";
 
@@ -9,55 +9,11 @@ import type { ToolContext } from "../types.js";
 // Mock infrastructure
 // ---------------------------------------------------------------------------
 
-type ExecCallback = (
-  err: Error | null,
-  stdout: string | Buffer,
-  stderr: string | Buffer,
-) => void;
-
-interface ExecScript {
-  /** When set, the call rejects with this error. */
-  error?: Error;
-  /** When set, the call resolves with this stdout. */
-  stdout?: string;
-}
-
-/**
- * Per-call scripted responses for `execFile`. Keyed by `${command} ${args[0]}`
- * so tests can target `npm ls` and `npm view` independently.
- */
-const execScripts: Map<string, ExecScript> = new Map();
-
-const execFileMock = mock(
-  (
-    command: string,
-    args: string[],
-    _options: unknown,
-    callback?: ExecCallback,
-  ) => {
-    const key = `${command} ${args[0]}`;
-    const script = execScripts.get(key);
-    queueMicrotask(() => {
-      if (!callback) return;
-      if (!script) {
-        callback(new Error(`No script for ${key}`), "", "");
-        return;
-      }
-      if (script.error) {
-        callback(script.error, "", "");
-        return;
-      }
-      callback(null, script.stdout ?? "", "");
-    });
-    // Return value is not used by execFileWithTimeout.
-    return {} as ReturnType<typeof realChildProcess.execFile>;
-  },
-);
-
-mock.module("node:child_process", () => ({
-  ...realChildProcess,
-  execFile: execFileMock,
-}));
+const {
+  execScripts,
+  execFileMock,
+  reset: resetExecFileStub,
+} = installExecFileStub();
 
 // Default ACP config used by these tests: the `unknown-agent` entry is here
 // to give the "no version check" test a configured agent whose binary isn't
@@ -189,6 +145,9 @@ mock.module("../../acp/index.js", () => ({
 
 const { executeAcpSpawn, _resetAdapterVersionCacheForTests } =
   await import("./spawn.js");
+const { _resetAdapterInstallCacheForTests } = await import(
+  "../../acp/auto-install.js"
+);
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -204,10 +163,10 @@ function makeContext(): ToolContext {
 }
 
 beforeEach(() => {
-  execScripts.clear();
-  execFileMock.mockClear();
+  resetExecFileStub();
   spawnMock.mockClear();
   _resetAdapterVersionCacheForTests();
+  _resetAdapterInstallCacheForTests();
   config.setConfig({ agents: DEFAULT_TEST_AGENTS });
   which.setWhich((cmd) => `/usr/local/bin/${cmd}`);
   // Default: vault has a claude token so the preflight in `prepareAgentEnv`
@@ -391,8 +350,9 @@ describe("executeAcpSpawn — input validation", () => {
     expect(result.content).toContain("acp.enabled");
   });
 
-  test("missing binary returns install hint", async () => {
+  test("missing binary returns install hint when auto-install fails", async () => {
     which.setWhich({});
+    execScripts.set("npm i", { error: new Error("npm not installed") });
     const result = await executeAcpSpawn(
       { agent: "claude", task: "do something" },
       makeContext(),
@@ -423,6 +383,83 @@ describe("executeAcpSpawn — input validation", () => {
     // The agentConfig handed to spawn() should be the bundled default.
     const agentConfigArg = spawnMock.mock.calls[0][1] as { command: string };
     expect(agentConfigArg.command).toBe("codex-acp");
+  });
+});
+
+describe("executeAcpSpawn: auto-install on missing binary", () => {
+  test("known command: installs the mapped package and spawn proceeds with a note", async () => {
+    // Binary appears on PATH only after `npm i -g` runs, simulating a
+    // successful global install.
+    let binaryOnPath = false;
+    which.setWhich((cmd) => (binaryOnPath ? `/usr/local/bin/${cmd}` : null));
+    execScripts.set("npm i", {
+      stdout: "",
+      onCall: () => {
+        binaryOnPath = true;
+      },
+    });
+    // Version probes after the install: best-effort, scripted to skip.
+    execScripts.set("npm ls", { error: new Error("skip") });
+    execScripts.set("npm view", { error: new Error("skip") });
+
+    const result = await executeAcpSpawn(
+      { agent: "claude", task: "do something" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const [payloadJson] = result.content.split("\n\n");
+    const payload = JSON.parse(payloadJson);
+    expect(payload.message).toContain(
+      "Installed @agentclientprotocol/claude-agent-acp automatically.",
+    );
+    const installCalls = execFileMock.mock.calls.filter(
+      (call) => (call[1] as string[])[0] === "i",
+    );
+    expect(installCalls).toHaveLength(1);
+    expect(installCalls[0][1]).toEqual([
+      "i",
+      "-g",
+      "@agentclientprotocol/claude-agent-acp",
+    ]);
+  });
+
+  test("unknown command: no install attempted, plain hint returned", async () => {
+    which.setWhich({});
+
+    const result = await executeAcpSpawn(
+      { agent: "unknown-agent", task: "do something" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("some-other-binary is not on PATH");
+    expect(result.content).toContain("Install 'some-other-binary'");
+    expect(result.content).not.toContain("auto-install failed");
+    expect(execFileMock).not.toHaveBeenCalled();
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  test("npm failure: hint and install failure both surface", async () => {
+    which.setWhich({});
+    execScripts.set("npm i", {
+      error: new Error("EACCES: permission denied"),
+    });
+
+    const result = await executeAcpSpawn(
+      { agent: "claude", task: "do something" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("claude-agent-acp is not on PATH");
+    expect(result.content).toContain(
+      "npm i -g @agentclientprotocol/claude-agent-acp",
+    );
+    expect(result.content).toContain("auto-install failed");
+    expect(result.content).toContain("EACCES");
+    expect(spawnMock).not.toHaveBeenCalled();
   });
 });
 

--- a/assistant/src/tools/acp/spawn.test.ts
+++ b/assistant/src/tools/acp/spawn.test.ts
@@ -441,6 +441,24 @@ describe("executeAcpSpawn: auto-install on missing binary", () => {
     expect(spawnMock).not.toHaveBeenCalled();
   });
 
+  test("no client connected: no install attempted even when the binary is missing", async () => {
+    // The no-client guard is a pure precondition and must run BEFORE the
+    // auto-install side effect: without a client the spawn fails anyway, so
+    // the host must not be mutated by `npm i -g` (which can also block for
+    // up to the install timeout).
+    which.setWhich({});
+
+    const result = await executeAcpSpawn(
+      { agent: "claude", task: "do something" },
+      { ...makeContext(), sendToClient: undefined },
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("No client connected");
+    expect(execFileMock).not.toHaveBeenCalled();
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
   test("npm failure: hint and install failure both surface", async () => {
     which.setWhich({});
     execScripts.set("npm i", {

--- a/assistant/src/tools/acp/spawn.ts
+++ b/assistant/src/tools/acp/spawn.ts
@@ -108,6 +108,19 @@ export async function executeAcpSpawn(
     return { content: '"task" is required.', isError: true };
   }
 
+  // Pure precondition: check for a connected client BEFORE any side effects
+  // (auto-install mutates the host via `npm i -g` and can block for up to
+  // the install timeout). Without a client the spawn cannot succeed anyway.
+  const sendToClient = context.sendToClient as
+    | ((msg: { type: string; [key: string]: unknown }) => void)
+    | undefined;
+  if (!sendToClient) {
+    return {
+      content: "No client connected - cannot spawn ACP agent.",
+      isError: true,
+    };
+  }
+
   let resolved = resolveAcpAgent(agent);
 
   // Missing adapter binary: silently try a global npm install of the mapped
@@ -155,15 +168,6 @@ export async function executeAcpSpawn(
         );
       }
     }
-  }
-  const sendToClient = context.sendToClient as
-    | ((msg: { type: string; [key: string]: unknown }) => void)
-    | undefined;
-  if (!sendToClient) {
-    return {
-      content: "No client connected - cannot spawn ACP agent.",
-      isError: true,
-    };
   }
 
   // Inject required env vars and preflight via the shared helper. Mirrors

--- a/assistant/src/tools/acp/spawn.ts
+++ b/assistant/src/tools/acp/spawn.ts
@@ -1,5 +1,7 @@
-import { execFile } from "node:child_process";
-
+import {
+  ensureAdapterInstalled,
+  execFileWithTimeout,
+} from "../../acp/auto-install.js";
 import { getAcpSessionManager } from "../../acp/index.js";
 import { prepareAgentEnv } from "../../acp/prepare-agent-env.js";
 import { resolveAcpAgent } from "../../acp/resolve-agent.js";
@@ -23,35 +25,6 @@ interface AdapterVersionInfo {
   installed: string;
   latest: string;
   packageName: string;
-}
-
-/**
- * Run `execFile` with an AbortController-driven timeout. Returns the stdout
- * on success; throws on error or timeout. Caller treats any throw as a
- * best-effort skip.
- */
-function execFileWithTimeout(
-  command: string,
-  args: string[],
-  timeoutMs: number,
-): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
-    execFile(
-      command,
-      args,
-      { signal: controller.signal, encoding: "utf8" },
-      (err, stdout) => {
-        clearTimeout(timer);
-        if (err) {
-          reject(err);
-          return;
-        }
-        resolve(stdout);
-      },
-    );
-  });
 }
 
 /**
@@ -135,7 +108,30 @@ export async function executeAcpSpawn(
     return { content: '"task" is required.', isError: true };
   }
 
-  const resolved = resolveAcpAgent(agent);
+  let resolved = resolveAcpAgent(agent);
+
+  // Missing adapter binary: silently try a global npm install of the mapped
+  // package (allowlisted commands only; see acp/auto-install.ts), then
+  // re-resolve and continue. Failures degrade to the existing install hint
+  // augmented with the failure reason.
+  let autoInstalledPackage: string | null = null;
+  if (!resolved.ok && resolved.reason === "binary_not_found") {
+    const { command, hint } = resolved;
+    const install = await ensureAdapterInstalled(command);
+    if (install.installed) {
+      const retried = resolveAcpAgent(agent);
+      if (retried.ok) {
+        autoInstalledPackage = DEFAULT_AGENT_NPM_PACKAGES[command] ?? null;
+        resolved = retried;
+      }
+    } else if (install.error) {
+      return {
+        content: `${command} is not on PATH. ${hint} (auto-install failed: ${install.error})`,
+        isError: true,
+      };
+    }
+  }
+
   if (!resolved.ok) {
     switch (resolved.reason) {
       case "acp_disabled":
@@ -208,6 +204,9 @@ export async function executeAcpSpawn(
       agentConfig.command === "claude-agent-acp"
         ? ` To resume this session later, run: cd ${cwd} && claude --resume ${protocolSessionId}`
         : "";
+    const installNote = autoInstalledPackage
+      ? ` Installed ${autoInstalledPackage} automatically.`
+      : "";
     const payload = JSON.stringify({
       acpSessionId,
       protocolSessionId,
@@ -216,7 +215,8 @@ export async function executeAcpSpawn(
       status: "running",
       message:
         `ACP agent "${agent}" spawned (session: ${protocolSessionId}). ` +
-        `Results stream back via SSE. You will be notified when it completes.${resumeHint}`,
+        `Results stream back via SSE. You will be notified when it completes.` +
+        `${installNote}${resumeHint}`,
     });
 
     let content = payload;


### PR DESCRIPTION
## Summary
- New ensureAdapterInstalled helper: silent npm i -g for allowlisted adapter packages only, with in-flight dedupe and 120s timeout
- acp_spawn tool and /v1/acp/spawn route auto-install missing adapters before failing with a hint
- Tests with stubbed execFile

Part of plan: acp-native-agent-ux.md (PR 7 of 8)