### PR TITLE
Pro Plan Card: header live total, credit-first ordering, hide credits note

### DIFF
--- a/apps/web/src/domains/settings/components/adjust-plan-modal.test.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.test.tsx
@@ -64,6 +64,11 @@ mock.module("@/generated/api/sdk.gen", () => ({
     changeStorageTierCall = opts;
     return Promise.resolve({ data: { status: "ok" }, response: { ok: true } });
   },
+  // The onboarding query carries the current tiers. Tests that need it pre-seed
+  // the cache (so this never runs). When a test deliberately leaves it unseeded
+  // to exercise the error path, this rejection keeps it hermetic.
+  organizationsBillingSubscriptionOnboardingRetrieve: () =>
+    Promise.reject(new Error("onboarding unavailable")),
 }));
 
 // Avoid pulling the real billing-portal hook's network fan-out; the downgrade /
@@ -624,6 +629,37 @@ describe("AdjustPlanModal Pro header total — no picker shown", () => {
     ).toBeNull();
     expect(queryByTestId("modal-change-tier-button")).toBeNull();
     expect(queryByTestId("modal-upgrade-to-pro-button")).toBeNull();
+  });
+
+  test("a current Pro card shows a loading placeholder (not the cheapest price) when onboarding has not resolved", async () => {
+    // A cancellation-pending Pro subscriber whose onboarding query errors (so
+    // the current total is never available). The header must NOT fall back to
+    // the cheapest seeded `From $35/mo` — that understates what the subscriber
+    // pays. Instead it shows the neutral "Loading your plan..." placeholder.
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+    client.setQueryData(
+      organizationsBillingSubscriptionRetrieveQueryKey(),
+      subscription("pro", null, { cancel_at_period_end: true }),
+    );
+    client.setQueryData(
+      organizationsBillingPlansRetrieveQueryKey(),
+      proPlansResponse(CREDIT_TIERS),
+    );
+    // Deliberately leave the onboarding query unseeded: it fires, the mocked
+    // SDK fn rejects, and with retry:false it settles into an error state.
+    const { findByText, queryByTestId } = render(
+      <QueryClientProvider client={client}>
+        <AdjustPlanModal open onClose={() => {}} />
+      </QueryClientProvider>,
+    );
+
+    await findByText("Loading your plan...");
+
+    // The cheapest fallback price must never render for a current Pro card.
+    const price = queryByTestId("modal-pro-price");
+    expect(price?.textContent ?? "").not.toContain("$35/mo");
   });
 });
 

--- a/apps/web/src/domains/settings/components/adjust-plan-modal.test.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.test.tsx
@@ -598,3 +598,21 @@ describe("AdjustPlanModal credit bundle — catalog gate", () => {
     ).toBeNull();
   });
 });
+
+describe("AdjustPlanModal credit bundle — '*Credits not included' note", () => {
+  test("omits the note on the Pro card when credit_tiers are available", () => {
+    const { queryByTestId } = renderModal(
+      subscription("base", null),
+      proPlansResponse(CREDIT_TIERS),
+    );
+    expect(queryByTestId("modal-credits-not-included")).toBeNull();
+  });
+
+  test("shows the note on the Pro card when no credit_tiers are available", () => {
+    const { queryByTestId } = renderModal(
+      subscription("base", null),
+      proPlansResponse(undefined),
+    );
+    expect(queryByTestId("modal-credits-not-included")).not.toBeNull();
+  });
+});

--- a/apps/web/src/domains/settings/components/adjust-plan-modal.test.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.test.tsx
@@ -631,11 +631,12 @@ describe("AdjustPlanModal Pro header total — no picker shown", () => {
     expect(queryByTestId("modal-upgrade-to-pro-button")).toBeNull();
   });
 
-  test("a current Pro card shows a loading placeholder (not the cheapest price) when onboarding has not resolved", async () => {
+  test("a current Pro card shows a distinct fallback (not a perpetual spinner, not the cheapest price) when onboarding errors", async () => {
     // A cancellation-pending Pro subscriber whose onboarding query errors (so
     // the current total is never available). The header must NOT fall back to
-    // the cheapest seeded `From $35/mo` — that understates what the subscriber
-    // pays. Instead it shows the neutral "Loading your plan..." placeholder.
+    // the cheapest seeded `From $35/mo` (it understates what the subscriber
+    // pays), and must NOT show a perpetual "Loading your plan..." spinner for a
+    // settled error — it shows a distinct "pricing unavailable" fallback.
     const client = new QueryClient({
       defaultOptions: { queries: { retry: false, staleTime: Infinity } },
     });
@@ -649,17 +650,19 @@ describe("AdjustPlanModal Pro header total — no picker shown", () => {
     );
     // Deliberately leave the onboarding query unseeded: it fires, the mocked
     // SDK fn rejects, and with retry:false it settles into an error state.
-    const { findByText, queryByTestId } = render(
+    const { findByTestId, queryByText, queryByTestId } = render(
       <QueryClientProvider client={client}>
         <AdjustPlanModal open onClose={() => {}} />
       </QueryClientProvider>,
     );
 
-    await findByText("Loading your plan...");
+    // Settled error → distinct fallback, not the infinite spinner.
+    await findByTestId("modal-pro-price-unavailable");
+    expect(queryByText("Loading your plan...")).toBeNull();
 
     // The cheapest fallback price must never render for a current Pro card.
     const price = queryByTestId("modal-pro-price");
-    expect(price?.textContent ?? "").not.toContain("$35/mo");
+    expect(price).toBeNull();
   });
 });
 

--- a/apps/web/src/domains/settings/components/adjust-plan-modal.test.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.test.tsx
@@ -616,3 +616,38 @@ describe("AdjustPlanModal credit bundle — '*Credits not included' note", () =>
     expect(queryByTestId("modal-credits-not-included")).not.toBeNull();
   });
 });
+
+describe("AdjustPlanModal credit bundle — selector order", () => {
+  function creditAndMachineTriggers(): {
+    credit: HTMLButtonElement;
+    machine: HTMLButtonElement;
+  } {
+    const credit = document.querySelector<HTMLButtonElement>(
+      'button[role="combobox"][aria-label="Credit bundle"]',
+    );
+    const machine = document.querySelector<HTMLButtonElement>(
+      'button[role="combobox"][aria-label="Machine tier"]',
+    );
+    if (!credit) throw new Error("expected a Credit bundle dropdown trigger");
+    if (!machine) throw new Error("expected a Machine tier dropdown trigger");
+    return { credit, machine };
+  }
+
+  test("renders the credit bundle picker before the machine tier (upgrade)", () => {
+    renderModal(subscription("base", null), proPlansResponse(CREDIT_TIERS));
+    const { credit, machine } = creditAndMachineTriggers();
+    expect(
+      credit.compareDocumentPosition(machine) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  test("renders the credit bundle picker before the machine tier (change)", () => {
+    renderModal(subscription("pro", null), proPlansResponse(CREDIT_TIERS));
+    const { credit, machine } = creditAndMachineTriggers();
+    expect(
+      credit.compareDocumentPosition(machine) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+});

--- a/apps/web/src/domains/settings/components/adjust-plan-modal.test.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.test.tsx
@@ -539,7 +539,7 @@ describe("AdjustPlanModal credit bundle — headline total", () => {
     );
 
     await waitFor(() => {
-      if (getByTestId("tier-picker-total").textContent?.includes("$35/mo"))
+      if (getByTestId("modal-pro-price").textContent?.includes("$35/mo"))
         return;
       throw new Error("base total not rendered yet");
     });
@@ -548,7 +548,7 @@ describe("AdjustPlanModal credit bundle — headline total", () => {
     clickOption("50 credits — $50/mo");
 
     await waitFor(() => {
-      if (getByTestId("tier-picker-total").textContent?.includes("$85/mo"))
+      if (getByTestId("modal-pro-price").textContent?.includes("$85/mo"))
         return;
       throw new Error("total did not include the selected bundle");
     });
@@ -563,7 +563,7 @@ describe("AdjustPlanModal credit bundle — headline total", () => {
     );
 
     await waitFor(() => {
-      if (getByTestId("tier-picker-total").textContent?.includes("$35/mo"))
+      if (getByTestId("modal-pro-price").textContent?.includes("$35/mo"))
         return;
       throw new Error("current total not rendered yet");
     });
@@ -572,7 +572,7 @@ describe("AdjustPlanModal credit bundle — headline total", () => {
     clickOption("25 credits — $25/mo");
 
     await waitFor(() => {
-      const text = getByTestId("tier-picker-total").textContent ?? "";
+      const text = getByTestId("modal-pro-price").textContent ?? "";
       if (text.includes("$60/mo") && text.includes("+$25/mo")) return;
       throw new Error("total/delta did not reflect the swapped bundle");
     });

--- a/apps/web/src/domains/settings/components/adjust-plan-modal.test.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.test.tsx
@@ -664,6 +664,29 @@ describe("AdjustPlanModal Pro header total — no picker shown", () => {
     const price = queryByTestId("modal-pro-price");
     expect(price).toBeNull();
   });
+
+  test("a current Pro card whose held bundle is no longer in the catalog shows unavailable, not an understated Currently total", async () => {
+    // A cancellation-pending Pro subscriber holding a bundle that the live
+    // catalog no longer lists. `priceForCredit` can't resolve its price (0), so
+    // the authoritative no-picker "Currently $X" would understate what the user
+    // pays. With onboarding fully resolved (so machine/storage are known), the
+    // header must show the "unavailable" fallback rather than a wrong, lower
+    // "Currently $X".
+    const { findByTestId, queryByTestId } = renderModal(
+      subscription("pro", "credits_legacy", { cancel_at_period_end: true }),
+      proPlansResponse(CREDIT_TIERS),
+      undefined,
+      {
+        max_machine_tier: "machine_large",
+        selected_storage_tier: "storage_20",
+        selected_storage_gib: 20,
+      },
+    );
+
+    await findByTestId("modal-pro-price-unavailable");
+    // No authoritative price is shown when the held bundle isn't priceable.
+    expect(queryByTestId("modal-pro-price")).toBeNull();
+  });
 });
 
 describe("AdjustPlanModal credit bundle — catalog gate", () => {

--- a/apps/web/src/domains/settings/components/adjust-plan-modal.test.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.test.tsx
@@ -151,6 +151,7 @@ function proPlansResponse(creditTiers?: CreditTier[]): PlanListResponse {
 function subscription(
   planId: "base" | "pro",
   selectedCreditTier: string | null,
+  overrides: Partial<SubscriptionResponse> = {},
 ): SubscriptionResponse {
   return {
     plan_id: planId,
@@ -161,13 +162,27 @@ function subscription(
     cancel_at: null,
     selected_credit_tier: selectedCreditTier,
     entitlements: { managed_email: false, phone_number: false },
+    ...overrides,
   } as unknown as SubscriptionResponse;
 }
+
+type OnboardingData = {
+  max_machine_tier: string;
+  selected_storage_tier: string;
+  selected_storage_gib: number;
+};
+
+const DEFAULT_ONBOARDING: OnboardingData = {
+  max_machine_tier: "machine_small",
+  selected_storage_tier: "storage_10",
+  selected_storage_gib: 10,
+};
 
 function renderModal(
   sub: SubscriptionResponse,
   plans: PlanListResponse,
   onTierUpgraded?: () => void,
+  onboarding: OnboardingData = DEFAULT_ONBOARDING,
 ): ReturnType<typeof render> & { client: QueryClient } {
   const client = new QueryClient({
     // `staleTime: Infinity` stops the pre-seeded reads from being marked stale
@@ -182,11 +197,7 @@ function renderModal(
   // Onboarding carries the current machine/storage tiers for the change flow.
   client.setQueryData(
     organizationsBillingSubscriptionOnboardingRetrieveQueryKey(),
-    {
-      max_machine_tier: "machine_small",
-      selected_storage_tier: "storage_10",
-      selected_storage_gib: 10,
-    },
+    onboarding,
   );
   const result = render(
     <QueryClientProvider client={client}>
@@ -196,20 +207,20 @@ function renderModal(
   return { ...result, client };
 }
 
-function openCreditDropdown(): void {
+function getDropdownTrigger(label: string): HTMLButtonElement {
   const trigger = document.querySelector<HTMLButtonElement>(
-    'button[role="combobox"][aria-label="Credit bundle"]',
+    `button[role="combobox"][aria-label="${label}"]`,
   );
-  if (!trigger) throw new Error("expected a Credit bundle dropdown trigger");
-  fireEvent.click(trigger);
+  if (!trigger) throw new Error(`expected a ${label} dropdown trigger`);
+  return trigger;
+}
+
+function openCreditDropdown(): void {
+  fireEvent.click(getDropdownTrigger("Credit bundle"));
 }
 
 function openMachineDropdown(): void {
-  const trigger = document.querySelector<HTMLButtonElement>(
-    'button[role="combobox"][aria-label="Machine tier"]',
-  );
-  if (!trigger) throw new Error("expected a Machine tier dropdown trigger");
-  fireEvent.click(trigger);
+  fireEvent.click(getDropdownTrigger("Machine tier"));
 }
 
 function clickOptionStartingWith(prefix: string): void {
@@ -579,6 +590,43 @@ describe("AdjustPlanModal credit bundle — headline total", () => {
   });
 });
 
+describe("AdjustPlanModal Pro header total — no picker shown", () => {
+  test("a cancellation-pending Pro card shows the current total, not the cheapest seeded one", async () => {
+    // A current Pro subscriber with a pending cancellation: no tier picker
+    // renders (only the "Keep your Plan" reactivation CTA). The header must show
+    // the user's CURRENT total, not the cheapest seeded total. Current tiers are
+    // deliberately more expensive than the cheapest so the two are observably
+    // different: base $20 + Large machine $30 + 20 GiB storage $9 = $59/mo,
+    // versus the cheapest base $20 + Small $10 + 10 GiB $5 = $35/mo.
+    const { getByTestId, queryByTestId } = renderModal(
+      subscription("pro", null, { cancel_at_period_end: true }),
+      proPlansResponse(CREDIT_TIERS),
+      undefined,
+      {
+        max_machine_tier: "machine_large",
+        selected_storage_tier: "storage_20",
+        selected_storage_gib: 20,
+      },
+    );
+
+    await waitFor(() => {
+      const text = getByTestId("modal-pro-price").textContent ?? "";
+      if (text.includes("Currently") && text.includes("$59/mo")) return;
+      throw new Error("current total not rendered yet");
+    });
+
+    const text = getByTestId("modal-pro-price").textContent ?? "";
+    expect(text).not.toContain("$35/mo");
+
+    // No tier picker and no "Update Plan" button render in this flow.
+    expect(
+      document.querySelector('button[role="combobox"][aria-label="Machine tier"]'),
+    ).toBeNull();
+    expect(queryByTestId("modal-change-tier-button")).toBeNull();
+    expect(queryByTestId("modal-upgrade-to-pro-button")).toBeNull();
+  });
+});
+
 describe("AdjustPlanModal credit bundle — catalog gate", () => {
   test("hides the credit UI when the plan has no credit_tiers (upgrade)", () => {
     renderModal(subscription("base", null), proPlansResponse(undefined));
@@ -622,15 +670,10 @@ describe("AdjustPlanModal credit bundle — selector order", () => {
     credit: HTMLButtonElement;
     machine: HTMLButtonElement;
   } {
-    const credit = document.querySelector<HTMLButtonElement>(
-      'button[role="combobox"][aria-label="Credit bundle"]',
-    );
-    const machine = document.querySelector<HTMLButtonElement>(
-      'button[role="combobox"][aria-label="Machine tier"]',
-    );
-    if (!credit) throw new Error("expected a Credit bundle dropdown trigger");
-    if (!machine) throw new Error("expected a Machine tier dropdown trigger");
-    return { credit, machine };
+    return {
+      credit: getDropdownTrigger("Credit bundle"),
+      machine: getDropdownTrigger("Machine tier"),
+    };
   }
 
   test("renders the credit bundle picker before the machine tier (upgrade)", () => {

--- a/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
@@ -298,9 +298,10 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
   const displayCreditTier: CreditTierEnum | null =
     selectedCreditTier === undefined ? currentCreditTier : selectedCreditTier;
 
-  // Folds into TierPicker's headline Total. `priceForCredit` returns 0 for "No
-  // bundle" and for catalogs without credit_tiers (empty `creditTiers`), so the
-  // total stays byte-identical to before when the feature is off.
+  // Folds into the Pro card-header live total (`proLiveTotalCents`).
+  // `priceForCredit` returns 0 for "No bundle" and for catalogs without
+  // credit_tiers (empty `creditTiers`), so the total stays byte-identical to
+  // before when the feature is off.
   const selectedCreditPriceCents = priceForCredit(displayCreditTier);
 
   // For an active Pro subscriber, disable any storage tier strictly below the
@@ -713,10 +714,19 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                     // that path shows only reactivation).
                     const showProTierChange =
                       isProCard && isCurrent && proTierChangeMode;
+                    // A tier picker is actually rendered on the Pro card only in
+                    // the Base→Pro upgrade flow or the active-Pro change flow.
+                    // When neither is shown (e.g. a current Pro card with a
+                    // pending cancellation), the live, selection-driven total
+                    // must not be displayed — the seeded cheapest tiers don't
+                    // reflect what keeping the plan retains.
+                    const proPickerShown =
+                      (!isCurrent && isProCard) || showProTierChange;
                     // Live running total for the Pro card header: base + the
                     // selected machine/storage/credit prices. Updates as the
-                    // user changes any dimension. In change mode it also carries
-                    // a delta vs. the current subscription.
+                    // user changes any dimension. The delta is shown when this
+                    // new total differs from the current subscription (i.e. when
+                    // a current total exists).
                     const proLiveTotalCents =
                       isProCard &&
                       nextMachinePrice != null &&
@@ -804,7 +814,8 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                                     variant="title-medium"
                                     data-testid="modal-pro-price"
                                   >
-                                    {proLiveTotalCents != null ? (
+                                    {proPickerShown &&
+                                    proLiveTotalCents != null ? (
                                       <>
                                         {formatMonthly(proLiveTotalCents)}
                                         {proTotalDelta != null &&
@@ -814,6 +825,10 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                                             </span>
                                           )}
                                       </>
+                                    ) : proCurrentTotalCents != null ? (
+                                      `Currently ${formatMonthly(
+                                        proCurrentTotalCents,
+                                      )}`
                                     ) : (
                                       `From ${formatMonthly(
                                         plan.base_price_cents +
@@ -824,6 +839,7 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                                   </Typography>
                                   <span
                                     title={
+                                      proPickerShown &&
                                       proTotalDelta != null &&
                                       proTotalDelta !== 0
                                         ? `Your Pro Plan subscription will change from ${formatMonthly(proCurrentTotalCents!)} to ${formatMonthly(proLiveTotalCents!)}. Includes a $10/month flat fee for Pro Features.`

--- a/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
@@ -290,6 +290,15 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
   const priceForCredit = (tier: CreditTierEnum | null): number =>
     creditTiers.find((t) => t.tier === tier)?.price_cents ?? 0;
   const currentCreditPriceCents = priceForCredit(currentCreditTier);
+  // A held bundle that is no longer in the live catalog has no resolvable price
+  // (`priceForCredit` returns 0), so any total that folds it in understates what
+  // the subscriber actually pays. In the no-picker header — where the price is
+  // presented as authoritative — we surface "unavailable" rather than a
+  // confidently-wrong lower number. (In the change picker this is the documented
+  // accepted limitation.)
+  const currentCreditPriceUnknown =
+    currentCreditTier != null &&
+    !creditTiers.some((t) => t.tier === currentCreditTier);
 
   // The picker and the mutation bodies require `CreditTierEnum | null` — never
   // the un-seeded `undefined` sentinel. While un-seeded, fall back to the
@@ -807,26 +816,21 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                                 </Typography>
                               </>
                             ) : isCurrent &&
-                              proCurrentTotalCents == null &&
-                              !(proPickerShown && proLiveTotalCents != null) ? (
+                              !(proPickerShown && proLiveTotalCents != null) &&
+                              (proCurrentTotalCents == null ||
+                                currentCreditPriceUnknown) ? (
                               // Current Pro card whose current total isn't
-                              // available. Showing the cheapest `From $X` here
-                              // would understate what this subscriber actually
-                              // pays. While onboarding is still loading, show a
-                              // neutral spinner; once it has settled in an error
-                              // state, show a distinct fallback instead — an
-                              // infinite spinner would misleadingly imply the
-                              // price is still on its way.
-                              onboardingQuery.isError ? (
-                                <Typography
-                                  as="p"
-                                  variant="body-medium-lighter"
-                                  className="text-[var(--content-tertiary)]"
-                                  data-testid="modal-pro-price-unavailable"
-                                >
-                                  Current plan pricing unavailable
-                                </Typography>
-                              ) : (
+                              // reliably known — onboarding hasn't resolved, or
+                              // the held bundle is no longer priceable. Showing
+                              // the cheapest `From $X` (or an understated
+                              // `Currently $X`) would misstate what this
+                              // subscriber pays. While onboarding is actively
+                              // loading, show a neutral spinner; otherwise (a
+                              // settled error or an unpriceable held bundle) show
+                              // a distinct "unavailable" fallback — an infinite
+                              // spinner would misleadingly imply the price is
+                              // still on its way.
+                              onboardingQuery.isLoading ? (
                                 <div className="flex items-center gap-2 text-[var(--content-tertiary)]">
                                   <Loader2 className="h-4 w-4 animate-spin" />
                                   <Typography
@@ -836,6 +840,15 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                                     Loading your plan...
                                   </Typography>
                                 </div>
+                              ) : (
+                                <Typography
+                                  as="p"
+                                  variant="body-medium-lighter"
+                                  className="text-[var(--content-tertiary)]"
+                                  data-testid="modal-pro-price-unavailable"
+                                >
+                                  Current plan pricing unavailable
+                                </Typography>
                               )
                             ) : (
                               <>

--- a/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
@@ -1,4 +1,11 @@
-import { AlertTriangle, ArrowLeft, Crown, Loader2, Palmtree } from "lucide-react";
+import {
+    AlertTriangle,
+    ArrowLeft,
+    Crown,
+    Info,
+    Loader2,
+    Palmtree,
+} from "lucide-react";
 import { useEffect, useState } from "react";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -43,6 +50,7 @@ import { CreditBundlePicker } from "./credit-bundle-picker";
 import { DowngradeReconfirmModal } from "./downgrade-reconfirm-modal";
 import { PlanFeatureList } from "./plan-feature-list";
 import { TierPicker, isTierDisabled } from "./tier-picker";
+import { formatDelta, formatMonthly } from "./tier-pricing";
 
 
 /**
@@ -482,6 +490,7 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
   // A machine downgrade (cheaper than current) routes through the reconfirm
   // modal first; an upgrade fires immediately.
   const nextMachinePrice = priceForMachine(selectedMachineTier);
+  const nextStoragePrice = priceForStorage(selectedStorageTier);
   const currentMachinePrice = priceForMachine(currentMachineTier);
   const currentStoragePrice = priceForStorage(currentStorageTier);
   const isMachineDowngrade =
@@ -704,6 +713,32 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                     // that path shows only reactivation).
                     const showProTierChange =
                       isProCard && isCurrent && proTierChangeMode;
+                    // Live running total for the Pro card header: base + the
+                    // selected machine/storage/credit prices. Updates as the
+                    // user changes any dimension. In change mode it also carries
+                    // a delta vs. the current subscription.
+                    const proLiveTotalCents =
+                      isProCard &&
+                      nextMachinePrice != null &&
+                      nextStoragePrice != null
+                        ? plan.base_price_cents +
+                          nextMachinePrice +
+                          nextStoragePrice +
+                          selectedCreditPriceCents
+                        : null;
+                    const proCurrentTotalCents =
+                      isProCard &&
+                      currentMachinePrice != null &&
+                      currentStoragePrice != null
+                        ? plan.base_price_cents +
+                          currentMachinePrice +
+                          currentStoragePrice +
+                          currentCreditPriceCents
+                        : null;
+                    const proTotalDelta =
+                      proLiveTotalCents != null && proCurrentTotalCents != null
+                        ? proLiveTotalCents - proCurrentTotalCents
+                        : null;
                     return (
                       <Card
                         key={plan.id}
@@ -761,39 +796,43 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                                   Forever
                                 </Typography>
                               </>
-                            ) : proTierChangeMode &&
-                              currentMachinePrice != null &&
-                              currentStoragePrice != null ? (
-                              <>
-                                <Typography as="p" variant="title-medium">
-                                  Currently $
-                                  {Math.round(
-                                    (plan.base_price_cents +
-                                      currentMachinePrice +
-                                      currentStoragePrice +
-                                      currentCreditPriceCents) /
-                                      100,
-                                  )}
-                                </Typography>
-                                <Typography
-                                  as="p"
-                                  variant="body-small-default"
-                                  className="text-[var(--content-tertiary)]"
-                                >
-                                  Billed monthly
-                                </Typography>
-                              </>
                             ) : (
                               <>
-                                <Typography as="p" variant="title-medium">
-                                  From $
-                                  {Math.round(
-                                    (plan.base_price_cents +
-                                      minTierPriceCents(plan.machine_tiers) +
-                                      minTierPriceCents(plan.storage_tiers)) /
-                                      100,
-                                  )}
-                                </Typography>
+                                <div className="flex items-center gap-1">
+                                  <Typography
+                                    as="p"
+                                    variant="title-medium"
+                                    data-testid="modal-pro-price"
+                                  >
+                                    {proLiveTotalCents != null ? (
+                                      <>
+                                        {formatMonthly(proLiveTotalCents)}
+                                        {proTotalDelta != null &&
+                                          proTotalDelta !== 0 && (
+                                            <span className="ml-1 text-[var(--content-tertiary)]">
+                                              ({formatDelta(proTotalDelta)})
+                                            </span>
+                                          )}
+                                      </>
+                                    ) : (
+                                      `From ${formatMonthly(
+                                        plan.base_price_cents +
+                                          minTierPriceCents(plan.machine_tiers) +
+                                          minTierPriceCents(plan.storage_tiers),
+                                      )}`
+                                    )}
+                                  </Typography>
+                                  <span
+                                    title={
+                                      proTotalDelta != null &&
+                                      proTotalDelta !== 0
+                                        ? `Your Pro Plan subscription will change from ${formatMonthly(proCurrentTotalCents!)} to ${formatMonthly(proLiveTotalCents!)}. Includes a $10/month flat fee for Pro Features.`
+                                        : "Includes a $10/month flat fee for Pro Features."
+                                    }
+                                  >
+                                    <Info className="h-3 w-3 text-[var(--content-tertiary)]" />
+                                  </span>
+                                </div>
                                 <Typography
                                   as="p"
                                   variant="body-small-default"
@@ -825,12 +864,10 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                               <TierPicker
                                 machineTiers={plan.machine_tiers}
                                 storageTiers={plan.storage_tiers}
-                                basePriceCents={plan.base_price_cents}
                                 selectedMachineTier={selectedMachineTier}
                                 selectedStorageTier={selectedStorageTier}
                                 onMachineTierChange={setSelectedMachineTier}
                                 onStorageTierChange={setSelectedStorageTier}
-                                creditPriceCents={selectedCreditPriceCents}
                               />
                               {creditTiersEnabled && (
                                 <CreditBundlePicker
@@ -872,17 +909,12 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                                 <TierPicker
                                   machineTiers={machineTiersForPicker}
                                   storageTiers={storageTiersForPicker}
-                                  basePriceCents={plan.base_price_cents}
                                   selectedMachineTier={selectedMachineTier}
                                   selectedStorageTier={selectedStorageTier}
                                   onMachineTierChange={setSelectedMachineTier}
                                   onStorageTierChange={setSelectedStorageTier}
                                   currentMachinePriceCents={currentMachinePrice}
                                   currentStoragePriceCents={currentStoragePrice}
-                                  creditPriceCents={selectedCreditPriceCents}
-                                  currentCreditPriceCents={
-                                    currentCreditPriceCents
-                                  }
                                 />
                                 {creditTiersEnabled && (
                                   <CreditBundlePicker

--- a/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
@@ -806,6 +806,24 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                                   Forever
                                 </Typography>
                               </>
+                            ) : isCurrent &&
+                              proCurrentTotalCents == null &&
+                              !(proPickerShown && proLiveTotalCents != null) ? (
+                              // Current Pro card whose current total isn't
+                              // available yet (onboarding still loading or
+                              // errored). Showing the cheapest `From $X` here
+                              // would understate what this subscriber actually
+                              // pays, so render the same neutral placeholder
+                              // used by the tier-change block instead.
+                              <div className="flex items-center gap-2 text-[var(--content-tertiary)]">
+                                <Loader2 className="h-4 w-4 animate-spin" />
+                                <Typography
+                                  as="span"
+                                  variant="body-medium-lighter"
+                                >
+                                  Loading your plan...
+                                </Typography>
+                              </div>
                             ) : (
                               <>
                                 <div className="flex items-center gap-1">
@@ -830,6 +848,10 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                                         proCurrentTotalCents,
                                       )}`
                                     ) : (
+                                      // Reachable only for the prospective
+                                      // upgrade card (!isCurrent); the current
+                                      // Pro card shows the loading placeholder
+                                      // above instead of this cheapest price.
                                       `From ${formatMonthly(
                                         plan.base_price_cents +
                                           minTierPriceCents(plan.machine_tiers) +

--- a/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
@@ -810,20 +810,33 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                               proCurrentTotalCents == null &&
                               !(proPickerShown && proLiveTotalCents != null) ? (
                               // Current Pro card whose current total isn't
-                              // available yet (onboarding still loading or
-                              // errored). Showing the cheapest `From $X` here
+                              // available. Showing the cheapest `From $X` here
                               // would understate what this subscriber actually
-                              // pays, so render the same neutral placeholder
-                              // used by the tier-change block instead.
-                              <div className="flex items-center gap-2 text-[var(--content-tertiary)]">
-                                <Loader2 className="h-4 w-4 animate-spin" />
+                              // pays. While onboarding is still loading, show a
+                              // neutral spinner; once it has settled in an error
+                              // state, show a distinct fallback instead — an
+                              // infinite spinner would misleadingly imply the
+                              // price is still on its way.
+                              onboardingQuery.isError ? (
                                 <Typography
-                                  as="span"
+                                  as="p"
                                   variant="body-medium-lighter"
+                                  className="text-[var(--content-tertiary)]"
+                                  data-testid="modal-pro-price-unavailable"
                                 >
-                                  Loading your plan...
+                                  Current plan pricing unavailable
                                 </Typography>
-                              </div>
+                              ) : (
+                                <div className="flex items-center gap-2 text-[var(--content-tertiary)]">
+                                  <Loader2 className="h-4 w-4 animate-spin" />
+                                  <Typography
+                                    as="span"
+                                    variant="body-medium-lighter"
+                                  >
+                                    Loading your plan...
+                                  </Typography>
+                                </div>
+                              )
                             ) : (
                               <>
                                 <div className="flex items-center gap-1">

--- a/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
@@ -862,14 +862,6 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                           {!isCurrent && isProCard && (
                             <>
                               <hr className="border-t border-[var(--border-base)]" />
-                              <TierPicker
-                                machineTiers={plan.machine_tiers}
-                                storageTiers={plan.storage_tiers}
-                                selectedMachineTier={selectedMachineTier}
-                                selectedStorageTier={selectedStorageTier}
-                                onMachineTierChange={setSelectedMachineTier}
-                                onStorageTierChange={setSelectedStorageTier}
-                              />
                               {creditTiersEnabled && (
                                 <CreditBundlePicker
                                   creditTiers={creditTiers}
@@ -878,6 +870,14 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                                   disabled={upgradeMutation.isPending}
                                 />
                               )}
+                              <TierPicker
+                                machineTiers={plan.machine_tiers}
+                                storageTiers={plan.storage_tiers}
+                                selectedMachineTier={selectedMachineTier}
+                                selectedStorageTier={selectedStorageTier}
+                                onMachineTierChange={setSelectedMachineTier}
+                                onStorageTierChange={setSelectedStorageTier}
+                              />
                               <Button
                                 variant="primary"
                                 className="w-full"
@@ -907,16 +907,6 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                             ) : (
                               <>
                                 <hr className="border-t border-[var(--border-base)]" />
-                                <TierPicker
-                                  machineTiers={machineTiersForPicker}
-                                  storageTiers={storageTiersForPicker}
-                                  selectedMachineTier={selectedMachineTier}
-                                  selectedStorageTier={selectedStorageTier}
-                                  onMachineTierChange={setSelectedMachineTier}
-                                  onStorageTierChange={setSelectedStorageTier}
-                                  currentMachinePriceCents={currentMachinePrice}
-                                  currentStoragePriceCents={currentStoragePrice}
-                                />
                                 {creditTiersEnabled && (
                                   <CreditBundlePicker
                                     creditTiers={creditTiers}
@@ -928,6 +918,16 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                                     disabled={tierChangePending}
                                   />
                                 )}
+                                <TierPicker
+                                  machineTiers={machineTiersForPicker}
+                                  storageTiers={storageTiersForPicker}
+                                  selectedMachineTier={selectedMachineTier}
+                                  selectedStorageTier={selectedStorageTier}
+                                  onMachineTierChange={setSelectedMachineTier}
+                                  onStorageTierChange={setSelectedStorageTier}
+                                  currentMachinePriceCents={currentMachinePrice}
+                                  currentStoragePriceCents={currentStoragePrice}
+                                />
                                 {(changeMachineTierMutation.isError ||
                                   changeStorageTierMutation.isError ||
                                   changeCreditTierMutation.isError) && (

--- a/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
@@ -847,11 +847,12 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                             features={plan.included_features}
                             variant="checklist"
                           />
-                          {isProCard && (
+                          {isProCard && !creditTiersEnabled && (
                             <Typography
                               as="p"
                               variant="body-small-default"
                               className="text-[var(--content-tertiary)]"
+                              data-testid="modal-credits-not-included"
                             >
                               *Credits not included
                             </Typography>

--- a/apps/web/src/domains/settings/components/tier-picker.tsx
+++ b/apps/web/src/domains/settings/components/tier-picker.tsx
@@ -37,60 +37,24 @@ export function isTierDisabled(tier: MachineTier | StorageTier): boolean {
 export interface TierPickerProps {
   machineTiers: MachineTier[];
   storageTiers: StorageTier[];
-  basePriceCents: number;
   selectedMachineTier: MachineTierEnum | null;
   selectedStorageTier: StorageTierEnum | null;
   onMachineTierChange: (tier: MachineTierEnum) => void;
   onStorageTierChange: (tier: StorageTierEnum) => void;
   currentMachinePriceCents?: number | null;
   currentStoragePriceCents?: number | null;
-  // The credit bundle is a changed "dimension" alongside machine/storage: its
-  // monthly price folds into the headline Total (and its delta) so the figure
-  // reflects the chosen bundle and reconciles with the modal's "Currently $X"
-  // baseline (which already includes the current bundle). Default 0 leaves
-  // non-credit callers byte-identical to before.
-  creditPriceCents?: number | null;
-  currentCreditPriceCents?: number | null;
 }
 
 export function TierPicker({
   machineTiers,
   storageTiers,
-  basePriceCents,
   selectedMachineTier,
   selectedStorageTier,
   onMachineTierChange,
   onStorageTierChange,
   currentMachinePriceCents,
   currentStoragePriceCents,
-  creditPriceCents,
-  currentCreditPriceCents,
 }: TierPickerProps) {
-  const selectedMachine = machineTiers.find(
-    (t) => t.tier === selectedMachineTier,
-  );
-  const selectedStorage = storageTiers.find(
-    (t) => t.tier === selectedStorageTier,
-  );
-  const totalCents =
-    selectedMachine && selectedStorage
-      ? basePriceCents +
-        selectedMachine.price_cents +
-        selectedStorage.price_cents +
-        (creditPriceCents ?? 0)
-      : null;
-  const currentTotalCents =
-    currentMachinePriceCents != null && currentStoragePriceCents != null
-      ? basePriceCents +
-        currentMachinePriceCents +
-        currentStoragePriceCents +
-        (currentCreditPriceCents ?? 0)
-      : null;
-  const totalDelta =
-    totalCents != null && currentTotalCents != null
-      ? totalCents - currentTotalCents
-      : null;
-
   const machineOptions = useMemo(
     () =>
       machineTiers.map((t) => {
@@ -172,32 +136,6 @@ export function TierPicker({
           options={storageOptions}
         />
       </div>
-      {totalCents !== null && (
-        <div className="flex items-center gap-1">
-          <Typography
-            as="p"
-            variant="body-small-emphasised"
-            data-testid="tier-picker-total"
-            className="text-[var(--content-default)]"
-          >
-            Total: {formatMonthly(totalCents)}
-            {totalDelta != null && totalDelta !== 0 && (
-              <span className="ml-1 text-[var(--content-tertiary)]">
-                ({formatDelta(totalDelta)})
-              </span>
-            )}
-          </Typography>
-          <span
-            title={
-              totalDelta != null && totalDelta !== 0
-                ? `Your Pro Plan subscription will change from ${formatMonthly(currentTotalCents!)} to ${formatMonthly(totalCents!)}. Includes a $10/month flat fee for Pro Features.`
-                : "Includes a $10/month flat fee for Pro Features."
-            }
-          >
-            <Info className="h-3 w-3 text-[var(--content-tertiary)]" />
-          </span>
-        </div>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Three UX tweaks to the Pro plan card in `AdjustPlanModal` (apps/web):
- The live running total moved from the bottom of the tier picker to the **big price at the top of the card**, updating with machine/storage/credit selections (with a change-mode delta and the $10 flat-fee tooltip).
- The **credit bundle selector now renders first**, above machine/storage, in both the upgrade and change flows.
- The "*Credits not included" footnote is **hidden when the credit-bundle flag is on** (`creditTiersEnabled`), since credits are then selectable via the bundle.

## Self-review result
PASS after 2 remediation rounds (4-pass fresh-eyes review: external, plan-faithfulness, integration, slop/reuse).

## PRs merged into feature branch
- #33627: show live plan total in the Pro card header instead of the tier picker
- #33628: hide "Credits not included" note when credit bundles are available
- #33630: show the credit bundle selector first in the Pro plan card

### Fix PRs (review remediation)
- #33631: gate the live Pro header total to adjustable flows; a current Pro card with no picker (e.g. cancellation pending) shows its current total, not the cheapest price
- #33633: show a loading placeholder (not the cheapest price) for a current Pro card while/if the onboarding current-tier data hasn't loaded

## Notes
- Inherits the prior feature's accepted limitation: a credit tier a user holds but the catalog no longer lists reads as $0 in totals (needs a backend price field; out of scope).

Part of plan: pro-card-pricing-changes.md