### PR TITLE
refactor(web): activity-run card cleanup — dead code + dedupe

### DIFF
--- a/apps/web/src/domains/chat/components/activity-run-card/activity-run-card.test.tsx
+++ b/apps/web/src/domains/chat/components/activity-run-card/activity-run-card.test.tsx
@@ -3,8 +3,8 @@
  *
  * Covers the post-unification rendering contract:
  *  - Non-web tool groups (bash, read, MCP, etc.) render via the shared
- *    `ToolProgressCardShell` with `useToolCallCardData`-derived header text
- *    and step pill.
+ *    `ToolProgressCardShell` with `useToolCallCardDataFromItems`-derived header
+ *    text and step pill.
  *  - Web-only groups continue to render through `WebSearchProgressCard` for
  *    regression parity.
  *  - Mixed groups (web + non-web) render through the unified shell with one

--- a/apps/web/src/domains/chat/components/activity-run-card/activity-run-card.tsx
+++ b/apps/web/src/domains/chat/components/activity-run-card/activity-run-card.tsx
@@ -24,6 +24,7 @@ import {
 import { useViewerStore } from "@/stores/viewer-store";
 import {
   WEB_TOOL_NAMES,
+  thinkingDetailPayload,
   toolDetailPayloadFromToolCall,
   type ToolCallCardData,
   type ToolCallCardItem,
@@ -106,8 +107,8 @@ export interface ActivityRunCardProps {
 
 /**
  * Default ordered items for the legacy `(toolCalls)` callers: one `toolCall`
- * item per tool call. Mirrors the delegate in `computeToolCallCardData` so the
- * single-hook path produces identical output to the legacy projection.
+ * item per tool call, so the single hook path (`useToolCallCardDataFromItems`)
+ * produces identical output whether or not the caller supplied ordered items.
  */
 function buildDefaultItems(
   toolCalls: ChatMessageToolCall[],
@@ -119,7 +120,7 @@ function buildDefaultItems(
  * Activity-run card. Renders a contiguous run of interleaved thinking + tool
  * steps as a single combined card. All tool groups — web search, bash, file
  * ops, MCP, computer use, skills — render through the shared
- * {@link ToolProgressCardShell} driven by {@link useToolCallCardData}.
+ * {@link ToolProgressCardShell} driven by {@link useToolCallCardDataFromItems}.
  *
  * Special cases short-circuit before the shell:
  *
@@ -127,7 +128,7 @@ function buildDefaultItems(
  *   render the inline confirmation UI via {@link ToolCallChip} so the
  *   approve/deny path is preserved bit-for-bit from the legacy card.
  * - Zero renderable steps (today: a group made up entirely of
- *   `subagent_spawn` calls, which `useToolCallCardData` filters out) → render
+ *   `subagent_spawn` calls, which `useToolCallCardDataFromItems` filters out) → render
  *   `null`; the spawned subagents render as inline
  *   `SubagentInlineProgressCard`s elsewhere in the transcript.
  */
@@ -271,7 +272,7 @@ function deriveWebShellState(
  * under a single phase header. Mixed groups carry `web_search` /
  * `web_search_error` / `thinking` (the latter from web tools, e.g.
  * `web_fetch` "Reading …") alongside the `tool` variant emitted by
- * `useToolCallCardData` for non-web tools.
+ * `useToolCallCardDataFromItems` for non-web tools.
  */
 function UnifiedActivityRunCard({
   toolCalls,
@@ -378,16 +379,9 @@ function UnifiedActivityRunCard({
                     // state. Persisting the user's intent keeps the accordion
                     // open across that remount (mirrors the tool pill).
                     onCardExpandChange(true);
-                    toggleToolDetail({
-                      kind: "thinking",
-                      toolCallId: "",
-                      toolName: "",
-                      title: "Thinking",
-                      activity: "",
-                      input: {},
-                      status: "completed",
-                      thinkingText: step.text,
-                    });
+                    toggleToolDetail(
+                      thinkingDetailPayload(step.text, "Thinking"),
+                    );
                   }}
                 />
               );

--- a/apps/web/src/domains/chat/components/thought-process-link/thought-process-link.tsx
+++ b/apps/web/src/domains/chat/components/thought-process-link/thought-process-link.tsx
@@ -12,6 +12,7 @@
 import { Brain } from "lucide-react";
 
 import { InlineActivityLink } from "@/domains/chat/components/inline-activity-link/inline-activity-link";
+import { thinkingDetailPayload } from "@/domains/chat/hooks/tool-call-card-utils";
 import { useViewerStore } from "@/stores/viewer-store";
 
 export interface ThoughtProcessLinkProps {
@@ -43,16 +44,7 @@ export function ThoughtProcessLink({
       label={isStreaming ? "Thinking…" : "Thought process"}
       active={isActive}
       onClick={() =>
-        toggleToolDetail({
-          kind: "thinking",
-          toolCallId: "",
-          toolName: "",
-          title: "Thought process",
-          activity: "",
-          input: {},
-          status: "completed",
-          thinkingText: content,
-        })
+        toggleToolDetail(thinkingDetailPayload(content, "Thought process"))
       }
     />
   );

--- a/apps/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.tsx
+++ b/apps/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.tsx
@@ -66,7 +66,7 @@ export const ICON_MAP: Record<IconName, LucideIcon> = {
  *   - Any other title falls back to the title itself so unrecognized tools
  *     still produce a sensible section heading.
  */
-export function phaseFromStep(step: ToolCallCardStep): string {
+function phaseFromStep(step: ToolCallCardStep): string {
   if (step.kind === "thinking") return "Thinking";
   if (step.kind === "web_search" || step.kind === "web_search_error") {
     return "Searching the web";
@@ -127,7 +127,7 @@ type PhaseHeaderStatus = "completed" | "failed" | "running";
  * (`tool_error` / `web_search_error` / `tool` status `error`|`denied`) →
  * "failed"; otherwise → "completed".
  *
- * `web_search` steps carry no explicit status field — `useToolCallCardData`
+ * `web_search` steps carry no explicit status field — the card projection
  * encodes "in-flight" via the present-tense title ("Searching the web" vs
  * "Searched the web"), so we treat any `web_search` step with that title
  * as in-flight. `thinking` is always neutral (no in-flight signal carried).
@@ -143,7 +143,7 @@ function phaseHeaderStatus(steps: ToolCallCardStep[]): PhaseHeaderStatus {
     }
     if (step.kind === "web_search") {
       // Title is the canonical in-flight signal — see `webSearchStepTitle`
-      // in `use-tool-call-card-data.ts`.
+      // in `tool-call-card-utils.ts`.
       if (step.title === "Searching the web") return "running";
       continue;
     }
@@ -162,7 +162,7 @@ interface PhaseSection {
 }
 
 /** Collapse contiguous same-phase steps into sections preserving order. */
-export function groupStepsByPhase(steps: ToolCallCardStep[]): PhaseSection[] {
+function groupStepsByPhase(steps: ToolCallCardStep[]): PhaseSection[] {
   const sections: PhaseSection[] = [];
   for (const step of steps) {
     const label = phaseFromStep(step);
@@ -364,7 +364,7 @@ function TimelinePhaseSection({
         className="flex items-center justify-between gap-2 py-[2px]"
       >
         <span className="flex min-w-0 items-center gap-2">
-          <TimelineNode status={status} />
+          <TimelineNodeIcon status={status} testId="phase-header-status-icon" />
           <Typography
             variant="body-medium-default"
             className="text-[var(--content-default)]"
@@ -394,15 +394,6 @@ function TimelinePhaseSection({
       </div>
     </div>
   );
-}
-
-/**
- * A timeline status node — the circular status icon. The connector lines start
- * below / end above each node (with a small gap), so the icon never needs to
- * mask the line passing behind it.
- */
-function TimelineNode({ status }: { status: PhaseHeaderStatus }) {
-  return <TimelineNodeIcon status={status} testId="phase-header-status-icon" />;
 }
 
 /**

--- a/apps/web/src/domains/chat/components/tool-progress-card/tool-progress-card-shell.tsx
+++ b/apps/web/src/domains/chat/components/tool-progress-card/tool-progress-card-shell.tsx
@@ -393,6 +393,3 @@ export function ToolProgressCardShell({
     </div>
   );
 }
-
-export { HeaderStepCarousel } from "@/domains/chat/components/tool-progress-card/header-step-carousel";
-export { ThreeDotIndicator } from "@/domains/chat/components/tool-progress-card/three-dot-indicator";

--- a/apps/web/src/domains/chat/components/web-search/web-search-progress-card.tsx
+++ b/apps/web/src/domains/chat/components/web-search/web-search-progress-card.tsx
@@ -33,9 +33,9 @@ import type { ToolCallCardStep } from "@/domains/chat/hooks/tool-call-card-utils
  *     with at least one completed `web_search` to feed the rotation)
  *
  * Matches Figma node 4922:103991. Pure presentational — no awareness of the
- * turn state machine. Wires up via the unified `useToolCallCardData` selector
- * hook that derives `StepDescriptor[]` plus the per-step header tuple from
- * live tool-call activity metadata.
+ * turn state machine. Wires up via the unified `useToolCallCardDataFromItems`
+ * selector hook that derives `StepDescriptor[]` plus the per-step header tuple
+ * from live tool-call activity metadata.
  *
  * Toggling between collapsed and expanded states honours
  * `prefers-reduced-motion` (height animation snaps when the user opts out)
@@ -117,9 +117,9 @@ export interface WebSearchProgressCardProps {
    * swaps from text (`currentStepInfo`) to a `WebsiteCarousel` rotating
    * through these favicon + title chips. Empty → text mode stays.
    *
-   * Populated by `useToolCallCardData` from the most recently completed
-   * `web_search`'s results — see `ToolCallCardData.carouselItems` for the
-   * derivation contract.
+   * Populated by `useToolCallCardDataFromItems` from the most recently
+   * completed `web_search`'s results — see `ToolCallCardData.carouselItems`
+   * for the derivation contract.
    */
   carouselItems?: WebSearchResultItem[];
 }

--- a/apps/web/src/domains/chat/hooks/tool-call-card-utils.ts
+++ b/apps/web/src/domains/chat/hooks/tool-call-card-utils.ts
@@ -1,7 +1,7 @@
 /** Pure projection and helpers for the unified tool-call progress card.
  *
- *  Separated from the React hook (`useToolCallCardData`) so they can be
- *  unit-tested without React context plumbing. The hook wires these into the
+ *  Separated from the React hook (`useToolCallCardDataFromItems`) so they can
+ *  be unit-tested without React context plumbing. The hook wires these into the
  *  Zustand turn store; these functions own the data mapping. */
 
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
@@ -15,7 +15,10 @@ import {
   deriveStepLabel,
   type IconName,
 } from "@/domains/chat/components/tool-progress-card/derive-step-label";
-import { isSubagentSpawnCall } from "@/domains/chat/transcript/message-content";
+import {
+  isSubagentSpawnCall,
+  renderableToolCalls,
+} from "@/domains/chat/transcript/message-content";
 import {
   extractDomain,
   parseWebSearchResultText,
@@ -336,6 +339,29 @@ export function toolDetailPayloadFromToolCall(
   };
 }
 
+/**
+ * Build the thinking-drawer payload for the shared tool-detail side drawer.
+ * Shared by the in-card thinking pill (title `"Thinking"`) and the lone
+ * `ThoughtProcessLink` (title `"Thought process"`) so the hand-written payload
+ * shape lives in one place. Thinking payloads carry an empty `toolCallId` /
+ * `toolName`; consumers match the active drawer on `thinkingText` instead.
+ */
+export function thinkingDetailPayload(
+  text: string,
+  title: string,
+): ToolDetailPayload {
+  return {
+    kind: "thinking",
+    toolCallId: "",
+    toolName: "",
+    title,
+    activity: "",
+    input: {},
+    status: "completed",
+    thinkingText: text,
+  };
+}
+
 function buildToolStep(tc: ChatMessageToolCall): ToolCallCardStep {
   const { title, info, activity, iconName } = deriveStepLabel(tc);
   return {
@@ -476,44 +502,25 @@ function deriveCarouselItems(
 // ---------------------------------------------------------------------------
 
 /**
- * Combine per-call/per-step states into a single card-level state using the
- * canonical precedence (highest first): `denied` > `loading` > `error` >
- * `complete`. Shared so the per-turn activity aggregate (`turn-activity.ts`)
- * and `deriveCardState` below cannot drift.
- */
-export function combineCardStates(
-  states: Array<"loading" | "complete" | "error" | "denied">,
-): "loading" | "complete" | "error" | "denied" {
-  if (states.includes("denied")) return "denied";
-  if (states.includes("loading")) return "loading";
-  if (states.includes("error")) return "error";
-  return "complete";
-}
-
-/**
- * Card-level state derivation. Maps each tool call to its narrowed state and
- * combines them via `combineCardStates`. Precedence (highest first):
+ * Card-level state derivation. Derives each tool call's per-step status via the
+ * shared {@link deriveToolStepStatus} ladder (so the per-call denied/error
+ * precedence lives in ONE place), then applies the aggregate card precedence
+ * (highest first):
  *   1. `denied` — any tool call whose confirmation was denied or timed-out.
- *   2. `loading` — any tool call still running.
+ *   2. `loading` — any tool call still running (`deriveToolStepStatus`'s
+ *      `running`).
  *   3. `error` — any tool ended in `status === "error"` (no still-running).
- *   4. `complete` — every tool call reached a terminal status without error.
+ *   4. `complete` — every tool call reached a terminal status without error
+ *      (`deriveToolStepStatus`'s `completed`).
  */
 function deriveCardState(
   toolCalls: ChatMessageToolCall[],
 ): "loading" | "complete" | "error" | "denied" {
-  return combineCardStates(
-    toolCalls.map((tc) => {
-      if (
-        tc.confirmationDecision === "denied" ||
-        tc.confirmationDecision === "timed_out"
-      ) {
-        return "denied";
-      }
-      if (isToolCallRunning(tc)) return "loading";
-      if (tc.isError) return "error";
-      return "complete";
-    }),
-  );
+  const statuses = toolCalls.map(deriveToolStepStatus);
+  if (statuses.includes("denied")) return "denied";
+  if (statuses.includes("running")) return "loading";
+  if (statuses.includes("error")) return "error";
+  return "complete";
 }
 
 // ---------------------------------------------------------------------------
@@ -533,10 +540,8 @@ export type ToolCallCardItem =
 
 /**
  * Build the per-tool {@link ToolCallCardStep} for a single tool call, mirroring
- * the web/non-web branch logic of {@link computeToolCallCardData}. Returns
- * `null` for a `subagent_spawn` call (rendered inline elsewhere). Shared by
- * both the legacy `(toolCalls, …)` projection and the ordered-items projection
- * so the per-tool behaviour cannot drift.
+ * the web/non-web branch logic of {@link computeToolCallCardDataFromItems}.
+ * Returns `null` for a `subagent_spawn` call (rendered inline elsewhere).
  */
 function buildStepForToolCall(
   tc: ChatMessageToolCall,
@@ -585,9 +590,7 @@ export function computeToolCallCardDataFromItems(
   // `subagent_spawn` calls are rendered inline by `SubagentInlineProgressCard`
   // at the transcript level — surfacing them as steps inside the unified card
   // would render the spawn twice.
-  const renderableToolCalls = toolCalls.filter(
-    (tc) => !isSubagentSpawnCall(tc),
-  );
+  const renderableCalls = renderableToolCalls(toolCalls);
 
   const steps: ToolCallCardStep[] = [];
   // Tracks the text of the most recently pushed step that originated from a
@@ -612,7 +615,7 @@ export function computeToolCallCardDataFromItems(
     }
   }
 
-  const state = deriveCardState(renderableToolCalls);
+  const state = deriveCardState(renderableCalls);
 
   // The collapsed header reflects the LATEST built step. When the run ends in
   // a genuine thinking segment (e.g. `tool → thinking`), the header carousels
@@ -629,18 +632,18 @@ export function computeToolCallCardDataFromItems(
     currentStepKind = "thinking";
   } else {
     currentStepTitle = deriveCurrentStepTitle(
-      renderableToolCalls,
+      renderableCalls,
       liveWebActivity,
     );
     currentStepInfo = deriveCurrentStepInfo(
-      renderableToolCalls,
+      renderableCalls,
       liveWebActivity,
     );
     currentStepKind = "tool";
   }
 
   const carouselItems = deriveCarouselItems(
-    renderableToolCalls,
+    renderableCalls,
     liveWebActivity,
   );
   const stepCount = `${steps.length} step${steps.length === 1 ? "" : "s"}`;
@@ -654,28 +657,4 @@ export function computeToolCallCardDataFromItems(
     state,
     carouselItems,
   };
-}
-
-/**
- * Pure projection of (toolCalls, liveWebActivity) → card data. Split out
- * from the hook so tests can drive it without React context plumbing.
- *
- * Always returns a `ToolCallCardData` (never null) so non-web groups still
- * render the unified card. Callers that need legacy "no web tools → bail
- * to legacy card" behaviour (the PR-6 cutover keeps the legacy card alive
- * for mixed/pending-confirmation groups) should layer that decision on top.
- *
- * Delegates to {@link computeToolCallCardDataFromItems} after wrapping the
- * tool calls into ordered items — producing output identical to the
- * historical inline loop.
- */
-export function computeToolCallCardData(
-  toolCalls: ChatMessageToolCall[],
-  liveWebActivity: Record<string, ToolActivityMetadata>,
-): ToolCallCardData {
-  const items: ToolCallCardItem[] = toolCalls.map((tc) => ({
-    kind: "toolCall",
-    toolCall: tc,
-  }));
-  return computeToolCallCardDataFromItems(items, liveWebActivity);
 }

--- a/apps/web/src/domains/chat/hooks/use-tool-call-card-data.test.ts
+++ b/apps/web/src/domains/chat/hooks/use-tool-call-card-data.test.ts
@@ -1,11 +1,10 @@
 /**
- * Tests for `computeToolCallCardData` — the pure projection that
- * `useToolCallCardData` wraps.
+ * Tests for `computeToolCallCardDataFromItems` — the pure projection that
+ * `useToolCallCardDataFromItems` wraps.
  *
  * Covered behaviours:
  *   - One case per `ToolCallCardStep` kind (`thinking` /
  *     `web_search` / `web_search_error` / `tool`).
- *   - Leading-thinking text prepending.
  *   - Card-level `state` transitions (loading → complete, mixed
  *     running+completed, denied present, error present).
  *   - Header `currentStepTitle` / `currentStepInfo` for non-web tools.
@@ -13,13 +12,17 @@
  *     through the unified path and produce the same step + state outputs as
  *     the previous web-only hook (regression-checked via the dedicated
  *     "regression vs. legacy web-search hook" suite below).
+ *
+ * Most cases drive the projection from a `toolCalls` array via the local
+ * `computeToolCallCardData` shim, which wraps each call into a `toolCall`
+ * ordered item (the same delegation `useToolCallCardDataFromItems`'s default
+ * callers perform) — there is no leading-thinking item.
  */
 
 import { describe, expect, test } from "bun:test";
 
 import {
   buildWebSearchErrorStep,
-  computeToolCallCardData,
   computeToolCallCardDataFromItems,
   type ToolCallCardItem,
   WEB_SEARCH_BACKEND_FAILURE_MESSAGE,
@@ -30,6 +33,23 @@ import type {
   ToolActivityMetadata,
   WebSearchResultItem,
 } from "@/assistant/web-activity-types";
+
+/**
+ * Test shim mirroring the deleted `computeToolCallCardData(toolCalls, …)`
+ * projection: wrap each tool call into a `toolCall` ordered item and delegate
+ * to `computeToolCallCardDataFromItems`. Keeps the `(toolCalls, liveWebActivity)`
+ * call sites below readable while exercising the single live projection.
+ */
+function computeToolCallCardData(
+  toolCalls: ChatMessageToolCall[],
+  liveWebActivity: Record<string, ToolActivityMetadata>,
+) {
+  const items: ToolCallCardItem[] = toolCalls.map((tc) => ({
+    kind: "toolCall",
+    toolCall: tc,
+  }));
+  return computeToolCallCardDataFromItems(items, liveWebActivity);
+}
 
 function makeResult(
   i: number,

--- a/apps/web/src/domains/chat/hooks/use-tool-call-card-data.ts
+++ b/apps/web/src/domains/chat/hooks/use-tool-call-card-data.ts
@@ -4,27 +4,13 @@
  *  Subscribes to the turn store's `liveWebActivity` map so the card data
  *  updates in lockstep with daemon-emitted metadata. */
 
-import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import { useTurnStore } from "@/domains/chat/turn-store";
 
 import {
-  computeToolCallCardData,
   computeToolCallCardDataFromItems,
   type ToolCallCardData,
   type ToolCallCardItem,
 } from "@/domains/chat/hooks/tool-call-card-utils";
-
-/**
- * React hook flavour of {@link computeToolCallCardData}. Subscribes to the
- * turn store's `liveWebActivity` map so the card data updates in lockstep
- * with daemon-emitted metadata, then delegates to the pure projection.
- */
-export function useToolCallCardData(
-  toolCalls: ChatMessageToolCall[],
-): ToolCallCardData {
-  const liveWebActivity = useTurnStore.use.liveWebActivity();
-  return computeToolCallCardData(toolCalls, liveWebActivity);
-}
 
 /**
  * React hook flavour of {@link computeToolCallCardDataFromItems}. Subscribes

--- a/apps/web/src/domains/chat/transcript/message-content.ts
+++ b/apps/web/src/domains/chat/transcript/message-content.ts
@@ -1,10 +1,9 @@
 // Pure, leaf helpers for projecting and rendering a `DisplayMessage`'s ordered
 // content. NO React/DOM imports so this can be exercised with `bun test` and
-// imported by both the pure activity projection (`turn-activity.ts`) and the
-// React render path (`transcript-message-body.tsx`) WITHOUT a circular
-// dependency. This module is the single source of truth for the grouping /
-// anchor / suppression logic so the projection and the rendered DOM anchors
-// cannot drift.
+// imported by the React render path (`transcript-message-body.tsx`) WITHOUT a
+// circular dependency. This module is the single source of truth for the
+// grouping / anchor / suppression logic so the projection and the rendered DOM
+// anchors cannot drift.
 
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import type { Surface } from "@/domains/chat/types/types";
@@ -15,7 +14,7 @@ import type { DisplayMessage } from "@/domains/chat/utils/reconcile";
  * A `thinking` item carries the contentOrder ids of a contiguous reasoning
  * run; a `tool` item carries a single tool-call/contentOrder id.
  */
-export type ActivityRunItem =
+type ActivityRunItem =
   | { kind: "thinking"; ids: string[] }
   | { kind: "tool"; id: string };
 
@@ -24,7 +23,7 @@ export type ActivityRunItem =
  * thinking + tool entries merge into one `activity` group (broken only by a
  * `text` or `surface` entry); `text`/`surface` pass through individually.
  */
-export type MergedContentGroup =
+type MergedContentGroup =
   | { type: "text"; id: string }
   | { type: "surface"; id: string }
   | { type: "activity"; items: ActivityRunItem[] };
@@ -140,6 +139,19 @@ export function isSubagentSpawnCall(toolCall: ChatMessageToolCall): boolean {
   const input = toolCall.input;
   if (input == null || typeof input !== "object") return false;
   return (input as Record<string, unknown>).tool === "subagent_spawn";
+}
+
+/**
+ * Filter a tool-call list down to the calls that render as steps inside the
+ * unified activity card. `subagent_spawn` calls are rendered inline by
+ * `SubagentInlineProgressCard` at the transcript level, so surfacing them as
+ * card steps would render the spawn twice — they are dropped here. Single
+ * source of truth shared by the card projection and the transcript render path.
+ */
+export function renderableToolCalls(
+  toolCalls: ChatMessageToolCall[],
+): ChatMessageToolCall[] {
+  return toolCalls.filter((tc) => !isSubagentSpawnCall(tc));
 }
 
 /**

--- a/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -28,6 +28,7 @@ import {
   groupMessageActivityRuns,
   isSubagentSpawnCall,
   isSuppressedUiTool,
+  renderableToolCalls,
   resolveThinkingContent,
   resolveToolCall,
 } from "@/domains/chat/transcript/message-content";
@@ -544,6 +545,75 @@ export function TranscriptMessageBody({
     );
   };
 
+  // Render the boxed `ActivityRunCard` with the shared ~12-prop block. Both the
+  // merged (interleaved) and legacy branches render an identical card; this
+  // closure is the single source of those props so they cannot drift. `items`
+  // is supplied only by the merged path (ordered thinking/tool interleaving);
+  // the legacy path omits it and the card synthesizes one item per tool call.
+  const renderActivityRunCard = ({
+    toolCalls,
+    items,
+    autoExpand,
+  }: {
+    toolCalls: ChatMessageToolCall[];
+    items?: ToolCallCardItem[];
+    autoExpand: boolean;
+  }): ReactNode => (
+    <div className="w-full">
+      <ActivityRunCard
+        toolCalls={toolCalls}
+        items={items}
+        expandedToolCallIds={expandedToolCallIds}
+        onExpandChange={handleExpandChange}
+        expandedCardIds={expandedCardIds}
+        autoExpand={autoExpand}
+        onOpenRuleEditor={onOpenRuleEditor}
+        isSubmittingConfirmation={isSubmittingConfirmation}
+        onConfirmationSubmit={onConfirmationSubmit}
+        onAllowAndCreateRule={onAllowAndCreateRule}
+        pendingConfirmationToolCallId={pendingConfirmationToolCallId}
+        unknownNudgeToolCallIds={unknownNudgeToolCallIds}
+        onDismissUnknownNudge={onDismissUnknownNudge}
+      />
+    </div>
+  );
+
+  // Outer message shell shared by both render branches: the `group/msg`
+  // wrapper (tap-to-reveal + hover-actions group), the inner flex column, the
+  // Slack attribution, and the hover-actions footer. The `align` prop drives
+  // the user-vs-assistant `justify`/`items` handling — the merged branch is
+  // assistant-only and always passes `"assistant"`; the legacy branch passes
+  // the message role so user messages stay right-aligned.
+  const renderMessageShell = (
+    align: "user" | "assistant",
+    children: ReactNode,
+  ): ReactNode => (
+    <div
+      ref={wrapperRef}
+      onClick={handleBubbleClick}
+      data-revealed={revealed}
+      className={`group/msg flex ${align === "user" ? "justify-end" : "justify-start"}`}
+    >
+      <div
+        className={`flex w-full flex-col gap-2 ${align === "user" ? "items-end" : "items-start"}`}
+      >
+        {children}
+        <SlackMessageAttribution
+          message={message}
+          assistantDisplayName={assistantDisplayName}
+        />
+        <div className="h-6 opacity-0 transition-opacity duration-150 group-hover/msg:opacity-100 has-[:focus-visible]:opacity-100 group-data-[revealed=true]/msg:opacity-100">
+          <MessageHoverActions
+            message={message}
+            openInSlackUrl={slackMessageUrl}
+            onFork={forkHandler}
+            onInspect={inspectHandler}
+          />
+        </div>
+      </div>
+    </div>
+  );
+
   // Render the user-message content from an ordered, tagged list. Walks the
   // items in canonical `contentOrder` sequence, grouping CONTIGUOUS runs of
   // text into one `userBubbleClass` bubble while each non-text element (surface
@@ -677,9 +747,7 @@ export function TranscriptMessageBody({
           cardItems.push({ kind: "toolCall", toolCall: tc });
         }
       }
-      const renderableToolCalls = groupToolCalls.filter(
-        (tc) => !isSubagentSpawnCall(tc),
-      );
+      const renderableCalls = renderableToolCalls(groupToolCalls);
       // Single-tool-inline: a lone run that resolves to exactly ONE simple
       // renderable tool — no thinking, no web rich-rendering, no inline
       // confirmation UI. Render the compact inline chip instead of the boxed
@@ -687,10 +755,10 @@ export function TranscriptMessageBody({
       const loneTool =
         cardItems.length === 1 &&
         cardItems[0]?.kind === "toolCall" &&
-        renderableToolCalls.length === 1 &&
-        !WEB_TOOL_NAMES.has(renderableToolCalls[0]!.name) &&
-        !renderableToolCalls[0]!.pendingConfirmation
-          ? renderableToolCalls[0]!
+        renderableCalls.length === 1 &&
+        !WEB_TOOL_NAMES.has(renderableCalls[0]!.name) &&
+        !renderableCalls[0]!.pendingConfirmation
+          ? renderableCalls[0]!
           : null;
       if (loneTool) {
         return (
@@ -700,30 +768,18 @@ export function TranscriptMessageBody({
           </Fragment>
         );
       }
-      if (renderableToolCalls.length > 0) {
+      if (renderableCalls.length > 0) {
         return (
           <Fragment key={`m-activity-${gi}`}>
-            <div className="w-full">
-              <ActivityRunCard
-                toolCalls={groupToolCalls}
-                items={cardItems}
-                expandedToolCallIds={expandedToolCallIds}
-                onExpandChange={handleExpandChange}
-                expandedCardIds={expandedCardIds}
-                autoExpand={shouldAutoExpandToolCallGroup({
-                  isCurrentGroup: isLastGroup,
-                  isStreaming,
-                  toolCalls: renderableToolCalls,
-                })}
-                onOpenRuleEditor={onOpenRuleEditor}
-                isSubmittingConfirmation={isSubmittingConfirmation}
-                onConfirmationSubmit={onConfirmationSubmit}
-                onAllowAndCreateRule={onAllowAndCreateRule}
-                pendingConfirmationToolCallId={pendingConfirmationToolCallId}
-                unknownNudgeToolCallIds={unknownNudgeToolCallIds}
-                onDismissUnknownNudge={onDismissUnknownNudge}
-              />
-            </div>
+            {renderActivityRunCard({
+              toolCalls: groupToolCalls,
+              items: cardItems,
+              autoExpand: shouldAutoExpandToolCallGroup({
+                isCurrentGroup: isLastGroup,
+                isStreaming,
+                toolCalls: renderableCalls,
+              }),
+            })}
             {renderInlineSubagentCards(groupToolCalls)}
           </Fragment>
         );
@@ -752,40 +808,20 @@ export function TranscriptMessageBody({
         ? renderTextWithInlineSurfaces(messageText, "fallback")
         : null;
 
-    return (
-      <div
-        ref={wrapperRef}
-        onClick={handleBubbleClick}
-        data-revealed={revealed}
-        className={`group/msg flex ${message.role === "user" ? "justify-end" : "justify-start"}`}
-      >
-        <div
-          className={`flex w-full flex-col gap-2 ${message.role === "user" ? "items-end" : "items-start"}`}
-        >
-          <>
-            {mergedGroupElements}
-            {interleavedFallback}
-            {hasAttachments && (
-              <MessageAttachments
-                attachments={message.attachments ?? []}
-                assistantId={assistantId}
-              />
-            )}
-          </>
-          <SlackMessageAttribution
-            message={message}
-            assistantDisplayName={assistantDisplayName}
+    // This branch is assistant-only (tool calls only ever come from the
+    // assistant), so the shell always aligns assistant-start.
+    return renderMessageShell(
+      "assistant",
+      <>
+        {mergedGroupElements}
+        {interleavedFallback}
+        {hasAttachments && (
+          <MessageAttachments
+            attachments={message.attachments ?? []}
+            assistantId={assistantId}
           />
-          <div className="h-6 opacity-0 transition-opacity duration-150 group-hover/msg:opacity-100 has-[:focus-visible]:opacity-100 group-data-[revealed=true]/msg:opacity-100">
-            <MessageHoverActions
-              message={message}
-              openInSlackUrl={slackMessageUrl}
-              onFork={forkHandler}
-              onInspect={inspectHandler}
-            />
-          </div>
-        </div>
-      </div>
+        )}
+      </>,
     );
   }
 
@@ -886,115 +922,81 @@ export function TranscriptMessageBody({
   // `ActivityRunCard` filters the spawns out and renders nothing — so
   // wrapping it in the flex child would emit a stray empty `gap-2` gap before
   // the inline subagent cards.
-  const hasRenderableLegacyToolCall = legacyToolCalls.some(
-    (tc) => !isSubagentSpawnCall(tc),
-  );
+  const hasRenderableLegacyToolCall =
+    renderableToolCalls(legacyToolCalls).length > 0;
   const hasVisibleLegacyContent = contentElements.some((el) => !!el);
 
-  return (
-    <div
-      ref={wrapperRef}
-      onClick={handleBubbleClick}
-      data-revealed={revealed}
-      className={`group/msg flex ${message.role === "user" ? "justify-end" : "justify-start"}`}
-    >
-      <div
-        className={`flex w-full flex-col gap-2 ${message.role === "user" ? "items-end" : "items-start"}`}
-      >
-        {legacyToolCalls.length > 0 && (
-          <>
-            {hasRenderableLegacyToolCall && (
-              <div className="w-full">
-                <ActivityRunCard
-                  toolCalls={legacyToolCalls}
-                  expandedToolCallIds={expandedToolCallIds}
-                  onExpandChange={handleExpandChange}
-                  expandedCardIds={expandedCardIds}
-                  autoExpand={shouldAutoExpandToolCallGroup({
-                    isCurrentGroup: !hasVisibleLegacyContent,
-                    isStreaming,
-                    toolCalls: legacyToolCalls,
-                  })}
-                  onOpenRuleEditor={onOpenRuleEditor}
-                  isSubmittingConfirmation={isSubmittingConfirmation}
-                  onConfirmationSubmit={onConfirmationSubmit}
-                  onAllowAndCreateRule={onAllowAndCreateRule}
-                  pendingConfirmationToolCallId={pendingConfirmationToolCallId}
-                  unknownNudgeToolCallIds={unknownNudgeToolCallIds}
-                  onDismissUnknownNudge={onDismissUnknownNudge}
-                />
-              </div>
-            )}
-            {renderInlineSubagentCards(legacyToolCalls)}
-          </>
-        )}
-        {isUser ? (
-          // User messages render contiguous text runs (plus attachments) inside
-          // surface-lift bubbles; surfaces (rare for user messages) render
-          // outside any bubble in their canonical position so `contentOrder` is
-          // preserved (see `renderUserContent`).
-          renderUserContent(legacyUserItems)
-        ) : (
-          <>
-            {(hasVisibleLegacyContent ||
-              (!message.toolCalls?.length && !hasAttachments)) && (
-              // Layout-only column: the bubble styling (textBubbleClass) is applied
-              // per text segment inside renderTextWithInlineSurfaces, mirroring the
-              // interleaved path above. Applying textBubbleClass here too would
-              // double-wrap text in two nested bubbles (doubled padding/background).
-              <div
-                className={`flex w-full flex-col gap-2 ${message.role === "user" ? "items-end" : "items-start"}`}
-              >
-                {contentElements}
-              </div>
-            )}
-            {hasAttachments && message.attachments && (
-              <MessageAttachments
-                attachments={message.attachments}
-                assistantId={assistantId}
-              />
-            )}
-          </>
-        )}
-        {/* Render surfaces attached to this message that aren't in contentOrder */}
-        {(() => {
-          if (!message.surfaces || message.surfaces.length === 0) return null;
-          const renderedSurfaceIds = new Set(
-            message.contentOrder
-              ?.filter((e) => e.type === "surface")
-              .map((e) => e.id) ?? [],
-          );
-          const unrendered = message.surfaces.filter(
-            (s) => !renderedSurfaceIds.has(s.surfaceId),
-          );
-          if (unrendered.length === 0) return null;
-          return unrendered.map((surface) => (
-            <div key={surface.surfaceId} className="w-full">
-              <SurfaceRouter
-                surface={surface}
-                onAction={onSurfaceAction}
-                onOpenApp={onOpenApp}
-                onOpenDocument={onOpenDocument}
-                assistantId={assistantId}
-                assistantDisplayName={assistantDisplayName}
-                toolCalls={message.toolCalls}
-              />
+  return renderMessageShell(
+    isUser ? "user" : "assistant",
+    <>
+      {legacyToolCalls.length > 0 && (
+        <>
+          {hasRenderableLegacyToolCall &&
+            renderActivityRunCard({
+              toolCalls: legacyToolCalls,
+              autoExpand: shouldAutoExpandToolCallGroup({
+                isCurrentGroup: !hasVisibleLegacyContent,
+                isStreaming,
+                toolCalls: legacyToolCalls,
+              }),
+            })}
+          {renderInlineSubagentCards(legacyToolCalls)}
+        </>
+      )}
+      {isUser ? (
+        // User messages render contiguous text runs (plus attachments) inside
+        // surface-lift bubbles; surfaces (rare for user messages) render
+        // outside any bubble in their canonical position so `contentOrder` is
+        // preserved (see `renderUserContent`).
+        renderUserContent(legacyUserItems)
+      ) : (
+        <>
+          {(hasVisibleLegacyContent ||
+            (!message.toolCalls?.length && !hasAttachments)) && (
+            // Layout-only column: the bubble styling (textBubbleClass) is applied
+            // per text segment inside renderTextWithInlineSurfaces, mirroring the
+            // interleaved path above. Applying textBubbleClass here too would
+            // double-wrap text in two nested bubbles (doubled padding/background).
+            <div
+              className={`flex w-full flex-col gap-2 ${message.role === "user" ? "items-end" : "items-start"}`}
+            >
+              {contentElements}
             </div>
-          ));
-        })()}
-        <SlackMessageAttribution
-          message={message}
-          assistantDisplayName={assistantDisplayName}
-        />
-        <div className="h-6 opacity-0 transition-opacity duration-150 group-hover/msg:opacity-100 has-[:focus-visible]:opacity-100 group-data-[revealed=true]/msg:opacity-100">
-          <MessageHoverActions
-            message={message}
-            openInSlackUrl={slackMessageUrl}
-            onFork={forkHandler}
-            onInspect={inspectHandler}
-          />
-        </div>
-      </div>
-    </div>
+          )}
+          {hasAttachments && message.attachments && (
+            <MessageAttachments
+              attachments={message.attachments}
+              assistantId={assistantId}
+            />
+          )}
+        </>
+      )}
+      {/* Render surfaces attached to this message that aren't in contentOrder */}
+      {(() => {
+        if (!message.surfaces || message.surfaces.length === 0) return null;
+        const renderedSurfaceIds = new Set(
+          message.contentOrder
+            ?.filter((e) => e.type === "surface")
+            .map((e) => e.id) ?? [],
+        );
+        const unrendered = message.surfaces.filter(
+          (s) => !renderedSurfaceIds.has(s.surfaceId),
+        );
+        if (unrendered.length === 0) return null;
+        return unrendered.map((surface) => (
+          <div key={surface.surfaceId} className="w-full">
+            <SurfaceRouter
+              surface={surface}
+              onAction={onSurfaceAction}
+              onOpenApp={onOpenApp}
+              onOpenDocument={onOpenDocument}
+              assistantId={assistantId}
+              assistantDisplayName={assistantDisplayName}
+              toolCalls={message.toolCalls}
+            />
+          </div>
+        ));
+      })()}
+    </>,
   );
 }

--- a/apps/web/src/domains/chat/turn-store.ts
+++ b/apps/web/src/domains/chat/turn-store.ts
@@ -57,7 +57,7 @@ export interface TurnState {
    * Keyed by `toolUseId`. Live-only — cleared on every terminal transition
    * so historical reopens fall back to the persisted
    * `ChatMessageToolCall.activityMetadata` instead. Drives the
-   * unified tool-call card selector hook (`useToolCallCardData`).
+   * unified tool-call card selector hook (`useToolCallCardDataFromItems`).
    */
   liveWebActivity: Record<string, ToolActivityMetadata>;
   /**

--- a/apps/web/src/domains/chat/utils/web-search-result-text.ts
+++ b/apps/web/src/domains/chat/utils/web-search-result-text.ts
@@ -2,7 +2,7 @@
  * Best-effort parser for the daemon's `tool_result.result` string when a
  * web_search tool's structured `activityMetadata` is unavailable.
  *
- * Used by `useToolCallCardData` as a fallback for reloaded conversations
+ * Used by `useToolCallCardDataFromItems` as a fallback for reloaded conversations
  * — the daemon doesn't persist `activityMetadata` per its v1 scope, so
  * after a page reload only the legacy `result: string` text dump survives.
  * Parsing it lets us reconstruct minimal `{ title, url, domain }` chips for


### PR DESCRIPTION
## Summary
Behavior-preserving cleanup of the merged activity-run chat UI (no visual/functional change):
- Delete dead `useToolCallCardData` + `computeToolCallCardData` (only the `…FromItems` path is used); repoint tests.
- Remove dead shell re-exports; un-export internal-only helpers/types.
- Inline `combineCardStates` + unify the per-call status ladder via `deriveToolStepStatus`.
- Shared `thinkingDetailPayload` + `renderableToolCalls` helpers (dedupe).
- De-dupe `transcript-message-body.tsx`: shared ActivityRunCard render + message shell; drop dead user-role branch in the assistant-only merged path.
- Fix stale comments referencing removed modules.