### PR TITLE
Add loadSession/resumeSession to AcpAgentProcess with replay suppression in the client handler

### DIFF
--- a/assistant/src/acp/__tests__/agent-process.test.ts
+++ b/assistant/src/acp/__tests__/agent-process.test.ts
@@ -99,3 +99,63 @@ describe("AcpAgentProcess capability getters", () => {
     expect(proc.supportsSessionResume).toBe(false);
   });
 });
+
+describe("AcpAgentProcess loadSession/resumeSession", () => {
+  /** Injects a stub connection that records loadSession/resumeSession params. */
+  function stubSessionConnection(proc: AcpAgentProcess): {
+    loadCalls: unknown[];
+    resumeCalls: unknown[];
+  } {
+    const loadCalls: unknown[] = [];
+    const resumeCalls: unknown[] = [];
+    (proc as unknown as { connection: unknown }).connection = {
+      loadSession: (params: unknown) => {
+        loadCalls.push(params);
+        return Promise.resolve({});
+      },
+      resumeSession: (params: unknown) => {
+        resumeCalls.push(params);
+        return Promise.resolve({});
+      },
+    };
+    return { loadCalls, resumeCalls };
+  }
+
+  test("loadSession forwards { sessionId, cwd, mcpServers: [] } to the connection", async () => {
+    const proc = makeProcess();
+    const { loadCalls } = stubSessionConnection(proc);
+
+    await proc.loadSession("session-1", "/tmp/project");
+
+    expect(loadCalls).toEqual([
+      { sessionId: "session-1", cwd: "/tmp/project", mcpServers: [] },
+    ]);
+  });
+
+  test("resumeSession forwards { sessionId, cwd, mcpServers: [] } to the connection", async () => {
+    const proc = makeProcess();
+    const { resumeCalls } = stubSessionConnection(proc);
+
+    await proc.resumeSession("session-2", "/tmp/project");
+
+    expect(resumeCalls).toEqual([
+      { sessionId: "session-2", cwd: "/tmp/project", mcpServers: [] },
+    ]);
+  });
+
+  test("loadSession throws when the process is not spawned", async () => {
+    const proc = makeProcess();
+
+    await expect(proc.loadSession("session-1", "/tmp/project")).rejects.toThrow(
+      'ACP agent "test-agent" is not spawned',
+    );
+  });
+
+  test("resumeSession throws when the process is not spawned", async () => {
+    const proc = makeProcess();
+
+    await expect(
+      proc.resumeSession("session-1", "/tmp/project"),
+    ).rejects.toThrow('ACP agent "test-agent" is not spawned');
+  });
+});

--- a/assistant/src/acp/__tests__/client-handler.test.ts
+++ b/assistant/src/acp/__tests__/client-handler.test.ts
@@ -62,3 +62,43 @@ describe("VellumAcpClientHandler.sessionUpdate", () => {
     expect(handler.responseText).toBe("");
   });
 });
+
+describe("VellumAcpClientHandler replay suppression", () => {
+  function messageChunk(text: string): SessionNotification {
+    return {
+      sessionId: ACP_SESSION_ID,
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text },
+      },
+    };
+  }
+
+  test("updates received while suppressed are dropped", async () => {
+    const { handler, sent } = makeHandler();
+
+    handler.beginReplaySuppression();
+    await handler.sessionUpdate(messageChunk("replayed history"));
+
+    expect(sent).toHaveLength(0);
+    expect(handler.responseText).toBe("");
+  });
+
+  test("updates after endReplaySuppression() flow normally", async () => {
+    const { handler, sent } = makeHandler();
+
+    handler.beginReplaySuppression();
+    await handler.sessionUpdate(messageChunk("replayed history"));
+    handler.endReplaySuppression();
+    await handler.sessionUpdate(messageChunk("live response"));
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toEqual({
+      type: "acp_session_update",
+      acpSessionId: ACP_SESSION_ID,
+      updateType: "agent_message_chunk",
+      content: "live response",
+    });
+    expect(handler.responseText).toBe("live response");
+  });
+});

--- a/assistant/src/acp/agent-process.ts
+++ b/assistant/src/acp/agent-process.ts
@@ -152,6 +152,41 @@ export class AcpAgentProcess {
   }
 
   /**
+   * Loads a previously persisted ACP session via `session/load`.
+   *
+   * Per the ACP spec, the agent replays the session's conversation history
+   * as `session/update` notifications before the load response resolves;
+   * callers should suppress forwarding of those replayed updates (see
+   * VellumAcpClientHandler.beginReplaySuppression).
+   */
+  async loadSession(sessionId: string, cwd: string): Promise<void> {
+    if (!this.connection) {
+      throw new Error(`ACP agent "${this.agentId}" is not spawned`);
+    }
+
+    log.info({ agentId: this.agentId, sessionId, cwd }, "Loading ACP session");
+
+    await this.connection.loadSession({ sessionId, cwd, mcpServers: [] });
+  }
+
+  /**
+   * Resumes a previously persisted ACP session via `session/resume`.
+   *
+   * Unlike `session/load`, resume performs no history replay, so it is
+   * preferred when the agent advertises the capability
+   * (see supportsSessionResume).
+   */
+  async resumeSession(sessionId: string, cwd: string): Promise<void> {
+    if (!this.connection) {
+      throw new Error(`ACP agent "${this.agentId}" is not spawned`);
+    }
+
+    log.info({ agentId: this.agentId, sessionId, cwd }, "Resuming ACP session");
+
+    await this.connection.resumeSession({ sessionId, cwd, mcpServers: [] });
+  }
+
+  /**
    * Sends a prompt to an existing ACP session.
    * Returns the prompt response (includes stopReason).
    */

--- a/assistant/src/acp/client-handler.ts
+++ b/assistant/src/acp/client-handler.ts
@@ -51,6 +51,7 @@ interface TerminalState {
 export class VellumAcpClientHandler implements Client {
   private terminals = new Map<string, TerminalState>();
   private accumulatedText = "";
+  private suppressForwarding = false;
   /** Tracks pending ACP permission requestIds for cleanup on session close. */
   readonly pendingRequestIds = new Set<string>();
 
@@ -65,8 +66,38 @@ export class VellumAcpClientHandler implements Client {
     private readonly parentConversationId: string,
   ) {}
 
+  /**
+   * Begins suppressing session updates from being forwarded to Vellum.
+   *
+   * Per the ACP spec, `session/load` replays the entire conversation history
+   * as `session/update` notifications before the load response resolves. The
+   * parent conversation already received those events during the original
+   * run, so re-forwarding them would duplicate them into the conversation and
+   * the ring buffer. Callers wrap `loadSession` in
+   * beginReplaySuppression()/endReplaySuppression() to drop the replay.
+   * `session/resume` performs no replay, which is why it is preferred when
+   * the agent supports it.
+   */
+  beginReplaySuppression(): void {
+    this.suppressForwarding = true;
+  }
+
+  /** Ends replay suppression; subsequent updates flow normally. */
+  endReplaySuppression(): void {
+    this.suppressForwarding = false;
+  }
+
   async sessionUpdate(params: SessionNotification): Promise<void> {
     const update = params.update;
+
+    if (this.suppressForwarding) {
+      log.debug(
+        { acpSessionId: this.acpSessionId, updateType: update.sessionUpdate },
+        "Dropping replayed session update during suppression",
+      );
+      return;
+    }
+
     log.debug(
       { acpSessionId: this.acpSessionId, updateType: update.sessionUpdate },
       "ACP session update received",


### PR DESCRIPTION
## Summary
- AcpAgentProcess gains loadSession and resumeSession protocol calls (SDK 0.25.0 stable APIs)
- VellumAcpClientHandler gains replay suppression so session/load history replay is not re-forwarded into the conversation
- Unit tests for both

Part of plan: acp-native-agent-ux.md (PR 4 of 8)