### PR TITLE
Add Gemini CLI default profile and natural agent-id aliases

### DIFF
--- a/assistant/src/acp/resolve-agent.test.ts
+++ b/assistant/src/acp/resolve-agent.test.ts
@@ -97,6 +97,79 @@ describe("resolveAcpAgent", () => {
     expect(result.agent.command).toBe("claude-agent-acp");
   });
 
+  test("falls back to the gemini default profile when no user entry", () => {
+    config.setConfig({ agents: {} });
+
+    const result = resolveAcpAgent("gemini");
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.agent.command).toBe("gemini");
+    expect(result.agent.args).toEqual(["--acp"]);
+  });
+
+  test.each([
+    ["claude code", "claude-agent-acp"],
+    ["Claude Code", "claude-agent-acp"],
+    ["claude-code", "claude-agent-acp"],
+    ["claude_code", "claude-agent-acp"],
+    ["codex cli", "codex-acp"],
+    ["OpenAI Codex", "codex-acp"],
+    ["gemini cli", "gemini"],
+    ["Gemini CLI", "gemini"],
+    ["google gemini", "gemini"],
+  ])("alias %p resolves to the %p profile", (alias, command) => {
+    config.setConfig({ agents: {} });
+
+    const result = resolveAcpAgent(alias);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.agent.command).toBe(command);
+  });
+
+  test("user config entry literally keyed 'claude code' beats the alias", () => {
+    config.setConfig({
+      agents: {
+        "claude code": {
+          command: "my-claude-fork",
+          args: [],
+          description: "user-defined agent that happens to share an alias",
+        },
+      },
+    });
+
+    const result = resolveAcpAgent("claude code");
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.agent.command).toBe("my-claude-fork");
+  });
+
+  test("alias re-runs the normal lookup, so a user override of the canonical id wins", () => {
+    config.setConfig({
+      agents: {
+        claude: { command: "my-custom-claude", args: [] },
+      },
+    });
+
+    const result = resolveAcpAgent("claude code");
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.agent.command).toBe("my-custom-claude");
+  });
+
+  test("non-alias unknown id still returns unknown_agent", () => {
+    config.setConfig({ agents: {} });
+
+    const result = resolveAcpAgent("cursor cli");
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("unknown_agent");
+  });
+
   test("returns unknown_agent with merged available list when id not found", () => {
     config.setConfig({
       agents: {
@@ -111,7 +184,12 @@ describe("resolveAcpAgent", () => {
     expect(result.reason).toBe("unknown_agent");
     if (result.reason !== "unknown_agent") return;
     // Defaults plus user-only ids, deduped, in stable order (defaults first).
-    expect(result.available).toEqual(["claude", "codex", "user-only"]);
+    expect(result.available).toEqual([
+      "claude",
+      "codex",
+      "gemini",
+      "user-only",
+    ]);
   });
 
   test("unknown_agent available list contains both defaults when user config is empty", () => {
@@ -125,6 +203,7 @@ describe("resolveAcpAgent", () => {
     if (result.reason !== "unknown_agent") return;
     expect(result.available).toContain("claude");
     expect(result.available).toContain("codex");
+    expect(result.available).toContain("gemini");
   });
 
   test("returns binary_not_found with the registered install hint", () => {
@@ -242,17 +321,21 @@ describe("listAcpAgents", () => {
     const result = listAcpAgents();
 
     expect(result.enabled).toBe(true);
-    expect(result.agents.map((a) => a.id)).toEqual(["claude", "codex"]);
+    expect(result.agents.map((a) => a.id)).toEqual([
+      "claude",
+      "codex",
+      "gemini",
+    ]);
   });
 
-  test("includes both bundled defaults when user config is empty", () => {
+  test("includes all bundled defaults when user config is empty", () => {
     config.setConfig({ agents: {} });
 
     const result = listAcpAgents();
 
     expect(result.enabled).toBe(true);
     const ids = result.agents.map((a) => a.id);
-    expect(ids).toEqual(["claude", "codex"]);
+    expect(ids).toEqual(["claude", "codex", "gemini"]);
     for (const entry of result.agents) {
       expect(entry.source).toBe("default");
       expect(entry.available).toBe(true);
@@ -274,6 +357,7 @@ describe("listAcpAgents", () => {
     which.setWhich({
       "my-claude": "/usr/bin/my-claude",
       "codex-acp": "/usr/bin/codex-acp",
+      gemini: "/usr/bin/gemini",
     });
 
     const result = listAcpAgents();
@@ -298,6 +382,32 @@ describe("listAcpAgents", () => {
     expect(codex?.setupHint).toBe("npm i -g @zed-industries/codex-acp");
   });
 
+  test("unavailable gemini surfaces the @google/gemini-cli install hint", () => {
+    config.setConfig({ agents: {} });
+    which.setWhich({
+      "claude-agent-acp": "/usr/bin/claude-agent-acp",
+      "codex-acp": "/usr/bin/codex-acp",
+    });
+
+    const result = listAcpAgents();
+
+    const gemini = result.agents.find((a) => a.id === "gemini");
+    expect(gemini?.available).toBe(false);
+    expect(gemini?.unavailableReason).toBe("'gemini' is not on PATH");
+    expect(gemini?.setupHint).toBe("npm i -g @google/gemini-cli");
+  });
+
+  test("aliases are resolution sugar, not catalog entries", () => {
+    config.setConfig({ agents: {} });
+
+    // "gemini cli" resolves via the alias...
+    expect(resolveAcpAgent("gemini cli").ok).toBe(true);
+
+    // ...but the catalog lists only canonical ids.
+    const ids = listAcpAgents().agents.map((a) => a.id);
+    expect(ids).toEqual(["claude", "codex", "gemini"]);
+  });
+
   test("user-only agent appended after defaults in stable order", () => {
     config.setConfig({
       agents: {
@@ -311,6 +421,7 @@ describe("listAcpAgents", () => {
     which.setWhich({
       "claude-agent-acp": "/x",
       "codex-acp": "/x",
+      gemini: "/x",
       "my-binary": "/x",
     });
 
@@ -319,9 +430,10 @@ describe("listAcpAgents", () => {
     expect(result.agents.map((a) => a.id)).toEqual([
       "claude",
       "codex",
+      "gemini",
       "my-agent",
     ]);
-    const userOnly = result.agents[2];
+    const userOnly = result.agents[3];
     expect(userOnly.source).toBe("config");
     expect(userOnly.description).toBe("user-only");
   });

--- a/assistant/src/acp/resolve-agent.ts
+++ b/assistant/src/acp/resolve-agent.ts
@@ -5,7 +5,9 @@
  * overlap) with the bundled `DEFAULT_ACP_AGENT_PROFILES` so common agents like
  * `claude` and `codex` Just Work whenever ACP is enabled (the `acp` feature
  * flag or `acp.enabled: true`; see `feature-gate.ts`), with no per-user
- * config required. The result is a discriminated union covering every reason
+ * config required. Natural names ("claude code", "Gemini CLI") resolve via
+ * `AGENT_ID_ALIASES` when the raw id misses both maps. The result is a
+ * discriminated union covering every reason
  * a spawn might fail before we even start the agent process: ACP disabled,
  * unknown agent id, or binary missing from PATH. Callers (acp_spawn,
  * acp_list_agents, and the `/v1/acp/spawn` HTTP route) get a single source
@@ -79,11 +81,51 @@ function findAgentBinary(agent: AcpAgentConfig): string | null {
 }
 
 /**
+ * Natural-name aliases for the bundled agent ids, keyed by normalized form
+ * (see `normalizeAgentId`). Resolution sugar only: aliases are consulted as a
+ * last-resort fallback in `lookupAgent` and never appear in the
+ * `listAcpAgents` catalog.
+ */
+const AGENT_ID_ALIASES: Record<string, string> = {
+  claudecode: "claude",
+  codexcli: "codex",
+  openaicodex: "codex",
+  geminicli: "gemini",
+  googlegemini: "gemini",
+};
+
+/**
+ * Normalize a raw agent id for alias matching: lowercase and strip spaces,
+ * underscores, and hyphens so "Claude Code", "claude-code", and
+ * "claude_code" all hit the same alias entry.
+ */
+function normalizeAgentId(id: string): string {
+  return id.toLowerCase().replace(/[\s_-]/g, "");
+}
+
+/**
  * Resolve an id against user config first, then bundled defaults. Returns the
  * resolved entry plus a `source` label so callers can surface "user override
  * vs bundled default" without re-deriving it.
+ *
+ * When the raw id misses both maps, fall back to `AGENT_ID_ALIASES` so
+ * natural names like "claude code" or "Gemini CLI" resolve to the canonical
+ * id. The alias is consulted ONLY after both direct lookups miss, so a user
+ * config entry literally keyed "claude code" always wins over the alias.
  */
 function lookupAgent(
+  userAgents: Record<string, AcpAgentConfig>,
+  id: string,
+): { agent: AcpAgentConfig; source: AcpAgentSource } | undefined {
+  const direct = directLookup(userAgents, id);
+  if (direct) return direct;
+  const canonicalId = AGENT_ID_ALIASES[normalizeAgentId(id)];
+  return canonicalId !== undefined
+    ? directLookup(userAgents, canonicalId)
+    : undefined;
+}
+
+function directLookup(
   userAgents: Record<string, AcpAgentConfig>,
   id: string,
 ): { agent: AcpAgentConfig; source: AcpAgentSource } | undefined {

--- a/assistant/src/config/acp-defaults.test.ts
+++ b/assistant/src/config/acp-defaults.test.ts
@@ -10,6 +10,7 @@ describe("DEFAULT_ACP_AGENT_PROFILES", () => {
     expect(Object.keys(DEFAULT_ACP_AGENT_PROFILES).sort()).toEqual([
       "claude",
       "codex",
+      "gemini",
     ]);
   });
 
@@ -29,6 +30,14 @@ describe("DEFAULT_ACP_AGENT_PROFILES", () => {
     });
   });
 
+  test("gemini profile speaks native ACP via gemini --acp (no adapter binary)", () => {
+    expect(DEFAULT_ACP_AGENT_PROFILES.gemini).toEqual({
+      command: "gemini",
+      args: ["--acp"],
+      description: "Google Gemini CLI (native ACP via gemini --acp)",
+    });
+  });
+
   test("is deeply frozen so mutation throws in strict mode", () => {
     expect(Object.isFrozen(DEFAULT_ACP_AGENT_PROFILES)).toBe(true);
     for (const profile of Object.values(DEFAULT_ACP_AGENT_PROFILES)) {
@@ -39,6 +48,18 @@ describe("DEFAULT_ACP_AGENT_PROFILES", () => {
       expect(Object.isFrozen(profile.args)).toBe(true);
     }
   });
+
+  test("mutating gemini's non-empty args throws in strict mode", () => {
+    // gemini is the one default with non-empty args, frozen via a dedicated
+    // array rather than the shared FROZEN_EMPTY_ARGS: verify the deep-freeze
+    // invariant actually rejects writes, not just that isFrozen reports true.
+    const args = DEFAULT_ACP_AGENT_PROFILES.gemini.args;
+    expect(() => args.push("--oops")).toThrow();
+    expect(() => {
+      args[0] = "--mutated";
+    }).toThrow();
+    expect(args).toEqual(["--acp"]);
+  });
 });
 
 describe("DEFAULT_AGENT_NPM_PACKAGES", () => {
@@ -46,6 +67,7 @@ describe("DEFAULT_AGENT_NPM_PACKAGES", () => {
     expect(DEFAULT_AGENT_NPM_PACKAGES).toEqual({
       "claude-agent-acp": "@agentclientprotocol/claude-agent-acp",
       "codex-acp": "@zed-industries/codex-acp",
+      gemini: "@google/gemini-cli",
     });
   });
 

--- a/assistant/src/config/acp-defaults.ts
+++ b/assistant/src/config/acp-defaults.ts
@@ -30,6 +30,14 @@ export const DEFAULT_ACP_AGENT_PROFILES: Readonly<
     args: FROZEN_EMPTY_ARGS,
     description: "OpenAI Codex CLI (via @zed-industries/codex-acp)",
   }),
+  gemini: Object.freeze({
+    command: "gemini",
+    // Dedicated frozen array (not FROZEN_EMPTY_ARGS): gemini is the one
+    // default profile with non-empty args, and it must uphold the same
+    // deep-freeze invariant documented above.
+    args: Object.freeze(["--acp"]) as unknown as string[],
+    description: "Google Gemini CLI (native ACP via gemini --acp)",
+  }),
 });
 
 /**
@@ -44,4 +52,5 @@ export const DEFAULT_AGENT_NPM_PACKAGES: Readonly<Record<string, string>> =
   Object.freeze({
     "claude-agent-acp": "@agentclientprotocol/claude-agent-acp",
     "codex-acp": "@zed-industries/codex-acp",
+    gemini: "@google/gemini-cli",
   });

--- a/assistant/src/tools/acp/list-agents.test.ts
+++ b/assistant/src/tools/acp/list-agents.test.ts
@@ -47,7 +47,7 @@ describe("executeAcpListAgents", () => {
     expect(parsed.hint).toContain("config.json");
   });
 
-  test("enabled, no user config: both defaults present with source 'default' and available based on Bun.which", async () => {
+  test("enabled, no user config: all defaults present with source 'default' and available based on Bun.which", async () => {
     config.setConfig({ agents: {} });
 
     const result = await executeAcpListAgents({}, makeContext());
@@ -58,6 +58,7 @@ describe("executeAcpListAgents", () => {
     expect(parsed.agents.map((a: { id: string }) => a.id)).toEqual([
       "claude",
       "codex",
+      "gemini",
     ]);
     for (const entry of parsed.agents) {
       expect(entry.source).toBe("default");
@@ -107,6 +108,11 @@ describe("executeAcpListAgents", () => {
     expect(codex.available).toBe(false);
     expect(codex.unavailableReason).toBe("'codex-acp' is not on PATH");
     expect(codex.setupHint).toBe("npm i -g @zed-industries/codex-acp");
+
+    const gemini = parsed.agents.find((a: { id: string }) => a.id === "gemini");
+    expect(gemini.available).toBe(false);
+    expect(gemini.unavailableReason).toBe("'gemini' is not on PATH");
+    expect(gemini.setupHint).toBe("npm i -g @google/gemini-cli");
 
     const claude = parsed.agents.find((a: { id: string }) => a.id === "claude");
     expect(claude.available).toBe(true);


### PR DESCRIPTION
## Summary
- New gemini default profile (gemini --acp, native ACP, no adapter binary) with @google/gemini-cli install mapping
- Alias resolution so natural names like claude code, gemini cli, openai codex resolve to canonical agent ids; user config always wins
- Tests for freeze invariants, alias precedence, and setup hints

Part of plan: acp-native-agent-ux.md (PR 6 of 8)