### PR TITLE
feat(billing): tidy Pro plan credit picker and surface base fee

### DIFF
--- a/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
@@ -885,17 +885,15 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                                       )}`
                                     )}
                                   </Typography>
-                                  <span
-                                    title={
-                                      proPickerShown &&
-                                      proTotalDelta != null &&
-                                      proTotalDelta !== 0
-                                        ? `Your Pro Plan subscription will change from ${formatMonthly(proCurrentTotalCents!)} to ${formatMonthly(proLiveTotalCents!)}. Includes a $10/month flat fee for Pro Features.`
-                                        : "Includes a $10/month flat fee for Pro Features."
-                                    }
-                                  >
-                                    <Info className="h-3 w-3 text-[var(--content-tertiary)]" />
-                                  </span>
+                                  {proPickerShown &&
+                                    proTotalDelta != null &&
+                                    proTotalDelta !== 0 && (
+                                      <span
+                                        title={`Your Pro Plan subscription will change from ${formatMonthly(proCurrentTotalCents!)} to ${formatMonthly(proLiveTotalCents!)}.`}
+                                      >
+                                        <Info className="h-3 w-3 text-[var(--content-tertiary)]" />
+                                      </span>
+                                    )}
                                 </div>
                                 <Typography
                                   as="p"
@@ -903,6 +901,15 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                                   className="text-[var(--content-tertiary)]"
                                 >
                                   Billed monthly
+                                </Typography>
+                                <Typography
+                                  as="p"
+                                  variant="body-small-default"
+                                  className="text-[var(--content-tertiary)]"
+                                  data-testid="modal-pro-base-fee"
+                                >
+                                  Includes a {formatMonthly(plan.base_price_cents)}{" "}
+                                  base fee for Pro features.
                                 </Typography>
                               </>
                             )}
@@ -976,9 +983,6 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                                     creditTiers={creditTiers}
                                     selectedCreditTier={displayCreditTier}
                                     onCreditTierChange={setSelectedCreditTier}
-                                    currentCreditPriceCents={
-                                      currentCreditPriceCents
-                                    }
                                     disabled={tierChangePending}
                                   />
                                 )}

--- a/apps/web/src/domains/settings/components/credit-bundle-picker.test.tsx
+++ b/apps/web/src/domains/settings/components/credit-bundle-picker.test.tsx
@@ -153,44 +153,4 @@ describe("CreditBundlePicker", () => {
     expect(onCreditTierChange).toHaveBeenCalledTimes(1);
     expect(onCreditTierChange.mock.calls[0]?.[0]).toBeNull();
   });
-
-  test("shows a positive delta in change mode when upgrading", () => {
-    const { getByTestId } = render(
-      <CreditBundlePicker
-        creditTiers={TIERS}
-        selectedCreditTier="credits_50"
-        onCreditTierChange={() => {}}
-        currentCreditPriceCents={2500}
-      />,
-    );
-    expect(getByTestId("credit-bundle-picker-delta").textContent).toBe(
-      "+$25/mo",
-    );
-  });
-
-  test("shows a negative delta in change mode when dropping to no bundle", () => {
-    const { getByTestId } = render(
-      <CreditBundlePicker
-        creditTiers={TIERS}
-        selectedCreditTier={null}
-        onCreditTierChange={() => {}}
-        currentCreditPriceCents={5000}
-      />,
-    );
-    expect(getByTestId("credit-bundle-picker-delta").textContent).toBe(
-      "−$50/mo",
-    );
-  });
-
-  test("renders no delta when the selection matches the current price", () => {
-    const { queryByTestId } = render(
-      <CreditBundlePicker
-        creditTiers={TIERS}
-        selectedCreditTier="credits_50"
-        onCreditTierChange={() => {}}
-        currentCreditPriceCents={5000}
-      />,
-    );
-    expect(queryByTestId("credit-bundle-picker-delta")).toBeNull();
-  });
 });

--- a/apps/web/src/domains/settings/components/credit-bundle-picker.tsx
+++ b/apps/web/src/domains/settings/components/credit-bundle-picker.tsx
@@ -4,7 +4,7 @@ import { useMemo } from "react";
 import type { CreditTier, CreditTierEnum } from "@/generated/api/types.gen";
 import { Dropdown } from "@vellumai/design-library/components/dropdown";
 import { Typography } from "@vellumai/design-library/components/typography";
-import { formatDelta, formatMonthly } from "./tier-pricing";
+import { formatMonthly } from "./tier-pricing";
 
 /**
  * Sentinel option value for the synthesized "No credit bundle" entry. The
@@ -25,7 +25,6 @@ export interface CreditBundlePickerProps {
   creditTiers: CreditTier[];
   selectedCreditTier: CreditTierEnum | null;
   onCreditTierChange: (tier: CreditTierEnum | null) => void;
-  currentCreditPriceCents?: number | null;
   disabled?: boolean;
 }
 
@@ -33,16 +32,8 @@ export function CreditBundlePicker({
   creditTiers,
   selectedCreditTier,
   onCreditTierChange,
-  currentCreditPriceCents,
   disabled = false,
 }: CreditBundlePickerProps) {
-  const selectedTier = creditTiers.find((t) => t.tier === selectedCreditTier);
-  const selectedPriceCents = selectedTier?.price_cents ?? 0;
-  const delta =
-    currentCreditPriceCents != null
-      ? selectedPriceCents - currentCreditPriceCents
-      : null;
-
   const options = useMemo(() => {
     const noBundle = {
       value: NO_BUNDLE_VALUE as CreditOptionValue,
@@ -56,43 +47,31 @@ export function CreditBundlePicker({
   }, [creditTiers]);
 
   return (
-    <div className="flex flex-col gap-3">
-      <div className="flex flex-col gap-1.5">
-        <div className="flex items-center gap-1">
-          <Typography
-            as="p"
-            variant="label-small-default"
-            className="text-[var(--content-secondary)]"
-          >
-            Credit bundle
-          </Typography>
-          <span title="A monthly allotment of credits added to your Pro Plan subscription">
-            <Info className="h-3 w-3 text-[var(--content-tertiary)]" />
-          </span>
-        </div>
-        <Dropdown<CreditOptionValue>
-          aria-label="Credit bundle"
-          placeholder="Select a credit bundle"
-          disabled={disabled}
-          value={selectedCreditTier ?? NO_BUNDLE_VALUE}
-          onChange={(value) =>
-            onCreditTierChange(
-              value === NO_BUNDLE_VALUE ? null : (value as CreditTierEnum),
-            )
-          }
-          options={options}
-        />
-      </div>
-      {delta != null && delta !== 0 && (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center gap-1">
         <Typography
           as="p"
-          variant="body-small-emphasised"
-          data-testid="credit-bundle-picker-delta"
-          className="text-[var(--content-tertiary)]"
+          variant="label-small-default"
+          className="text-[var(--content-secondary)]"
         >
-          {formatDelta(delta)}
+          Credit bundle
         </Typography>
-      )}
+        <span title="A monthly allotment of credits added to your Pro Plan subscription">
+          <Info className="h-3 w-3 text-[var(--content-tertiary)]" />
+        </span>
+      </div>
+      <Dropdown<CreditOptionValue>
+        aria-label="Credit bundle"
+        placeholder="Select a credit bundle"
+        disabled={disabled}
+        value={selectedCreditTier ?? NO_BUNDLE_VALUE}
+        onChange={(value) =>
+          onCreditTierChange(
+            value === NO_BUNDLE_VALUE ? null : (value as CreditTierEnum),
+          )
+        }
+        options={options}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Remove the grey price-delta text (e.g. `+$15/mo`) shown below the credit bundle dropdown when selecting/changing a bundle. Drops the now-unused `currentCreditPriceCents` prop, its delta computation, and the three delta tests.
- Surface the Pro plan's base price as a visible line on the Pro card — "Includes a $10/mo base fee for Pro features." — derived from `plan.base_price_cents` so it stays accurate. Removes the duplicated, hardcoded `$10/month flat fee` copy from the price tooltip, leaving the tooltip to explain only the price change.

Note: the "Pay-as-you-go credits" → "Pay-as-you-go and bundled credits" relabel was also requested, but that string is server-driven (`plan.included_features` from the vellum-assistant-platform backend) and not authored in this repo — it must change in the platform backend. Per the user's "Ship #2 only" decision, it's out of scope here.

## Original prompt
Tweak the Pro plan card: drop the grey delta hint (`+$15/mo`) that appears under the credit-bundle dropdown while a bundle is being selected/changed, and make the Pro plan's $10 base price visible somewhere sensible rather than only in a tooltip. (The requested "Pay-as-you-go credits" feature-label rename is server-driven and tracked separately in the platform backend.)