### PR TITLE
Add macOS support for recent chat surfaces

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
@@ -51,6 +51,9 @@ struct SurfaceContainerView: View {
             switch surface.data {
             case .card(let data):
                 CardSurfaceView(data: data)
+            case .choice, .copyBlock, .oauthConnect, .taskPreferences, .workResult:
+                // These recent surfaces are rendered inline in chat, not in floating panels.
+                EmptyView()
             case .form(let data):
                 FormSurfaceView(data: data, onSubmit: { values in
                     let actionId = surface.actions.first?.id ?? "submit"
@@ -118,7 +121,7 @@ struct SurfaceContainerView: View {
         switch surface.data {
         case .form, .confirmation, .dynamicPage, .fileUpload:
             return true
-        case .card, .list, .table, .documentPreview, .callSummary, .stripped, .strippedFailed:
+        case .card, .choice, .copyBlock, .oauthConnect, .list, .table, .documentPreview, .taskPreferences, .callSummary, .workResult, .stripped, .strippedFailed:
             return false
         }
     }

--- a/clients/shared/App/Auth/OAuthConnectSurfaceCoordinator.swift
+++ b/clients/shared/App/Auth/OAuthConnectSurfaceCoordinator.swift
@@ -1,0 +1,198 @@
+#if os(macOS)
+import AuthenticationServices
+import Foundation
+import os
+
+private let oauthSurfaceLog = Logger(
+    subsystem: Bundle.appBundleIdentifier,
+    category: "OAuthConnectSurface"
+)
+
+public enum OAuthConnectSurfaceResult: Sendable {
+    case connected(connection: OAuthConnectionEntry?)
+    case cancelled
+    case error(String)
+}
+
+@MainActor
+public final class OAuthConnectSurfaceCoordinator {
+    public static let shared = OAuthConnectSurfaceCoordinator()
+
+    private let credentialStorage = SharedFileCredentialStorage()
+    private var activeSession: ASWebAuthenticationSession?
+
+    private init() {}
+
+    public func connect(providerKey: String, providerLabel: String) async -> OAuthConnectSurfaceResult {
+        do {
+            let assistantId = try await resolvePlatformAssistantId()
+            let baseline = connectionSignatures(
+                await listConnectionsSafely(assistantId: assistantId),
+                providerKey: providerKey
+            )
+
+            let response = try await PlatformOAuthService.shared.startOAuthConnect(
+                provider: providerKey,
+                assistantId: assistantId,
+                redirectAfterConnect: "vellum-assistant://oauth/\(providerKey)/callback"
+            )
+
+            guard let connectURL = URL(string: response.connect_url) else {
+                return .error("Invalid authorization URL.")
+            }
+
+            let callbackURL = try await performWebAuth(url: connectURL)
+            let components = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false)
+            let oauthStatus = components?.queryItems?.first(where: { $0.name == "oauth_status" })?.value
+
+            if oauthStatus == "connected" {
+                if let connection = await waitForProviderConnection(
+                    assistantId: assistantId,
+                    providerKey: providerKey,
+                    baselineSignatures: baseline
+                ) {
+                    return .connected(connection: connection)
+                }
+                return .error("\(providerLabel) connection finished, but no connected account was found.")
+            }
+
+            if oauthStatus == "error" {
+                let errorCode = components?.queryItems?.first(where: { $0.name == "oauth_code" })?.value
+                return .error(errorCode.map { "\(providerLabel) authorization failed: \($0)" } ?? "\(providerLabel) authorization failed.")
+            }
+
+            return .cancelled
+        } catch let error as ASWebAuthenticationSessionError where error.code == .canceledLogin {
+            oauthSurfaceLog.info("User cancelled OAuth connect for \(providerKey, privacy: .public)")
+            return .cancelled
+        } catch {
+            oauthSurfaceLog.error("OAuth connect failed for \(providerKey, privacy: .public): \(error.localizedDescription)")
+            return .error("Unable to connect \(providerLabel). Please try again.")
+        }
+    }
+
+    private func performWebAuth(url: URL) async throws -> URL {
+        try await withCheckedThrowingContinuation { continuation in
+            let session = ASWebAuthenticationSession(url: url, callbackURLScheme: "vellum-assistant") { [weak self] callbackURL, error in
+                self?.activeSession = nil
+                if let error {
+                    continuation.resume(throwing: error)
+                } else if let callbackURL {
+                    continuation.resume(returning: callbackURL)
+                } else {
+                    continuation.resume(throwing: URLError(.badServerResponse))
+                }
+            }
+            session.prefersEphemeralWebBrowserSession = false
+            session.presentationContextProvider = WebAuthPresentationContext.shared
+            activeSession = session
+            session.start()
+        }
+    }
+
+    private func resolvePlatformAssistantId() async throws -> String {
+        let connectedId = LockfileAssistant.loadActiveAssistantId()
+            ?? UserDefaults.standard.string(forKey: "connectedAssistantId")
+        guard let connectedId, !connectedId.isEmpty,
+              let assistant = LockfileAssistant.loadByName(connectedId) else {
+            throw PlatformAPIError.authenticationRequired
+        }
+
+        let orgId = UserDefaults.standard.string(forKey: AuthService.connectedOrganizationIdKey)
+        let userId = try? await AuthService.shared.getSession().data?.user?.id
+
+        if let resolved = PlatformAssistantIdResolver.resolve(
+            lockfileAssistantId: assistant.assistantId,
+            isManaged: assistant.isManaged,
+            organizationId: orgId,
+            userId: userId,
+            credentialStorage: credentialStorage
+        ) {
+            return resolved
+        }
+
+        guard !assistant.isManaged else {
+            throw PlatformAPIError.authenticationRequired
+        }
+
+        do {
+            return try await LocalAssistantBootstrapService(credentialStorage: credentialStorage)
+                .bootstrap(runtimeAssistantId: assistant.assistantId, clientPlatform: "macos")
+        } catch {
+            let refreshedUserId = (try? await AuthService.shared.getSession().data?.user?.id) ?? userId
+            if let resolved = PlatformAssistantIdResolver.resolve(
+                lockfileAssistantId: assistant.assistantId,
+                isManaged: assistant.isManaged,
+                organizationId: UserDefaults.standard.string(forKey: AuthService.connectedOrganizationIdKey) ?? orgId,
+                userId: refreshedUserId,
+                credentialStorage: credentialStorage
+            ) {
+                return resolved
+            }
+            throw error
+        }
+    }
+
+    private func listConnectionsSafely(assistantId: String) async -> [OAuthConnectionEntry] {
+        do {
+            return try await PlatformOAuthService.shared.listConnections(assistantId: assistantId)
+        } catch {
+            return []
+        }
+    }
+
+    private func waitForProviderConnection(
+        assistantId: String,
+        providerKey: String,
+        baselineSignatures: [String: String]
+    ) async -> OAuthConnectionEntry? {
+        for attempt in 0..<8 {
+            if attempt > 0 {
+                try? await Task.sleep(for: .milliseconds(750))
+            }
+            let connections = await listConnectionsSafely(assistantId: assistantId)
+            if let connection = findNewOrChangedProviderConnection(
+                connections,
+                providerKey: providerKey,
+                baselineSignatures: baselineSignatures
+            ) {
+                return connection
+            }
+        }
+        return nil
+    }
+
+    private func findNewOrChangedProviderConnection(
+        _ connections: [OAuthConnectionEntry],
+        providerKey: String,
+        baselineSignatures: [String: String]
+    ) -> OAuthConnectionEntry? {
+        connections.first { connection in
+            connection.provider == providerKey
+                && connection.connected
+                && baselineSignatures[connection.id] != connectionSignature(connection)
+        }
+    }
+
+    private func connectionSignatures(
+        _ connections: [OAuthConnectionEntry],
+        providerKey: String
+    ) -> [String: String] {
+        Dictionary(
+            uniqueKeysWithValues: connections
+                .filter { $0.provider == providerKey }
+                .map { ($0.id, connectionSignature($0)) }
+        )
+    }
+
+    private func connectionSignature(_ connection: OAuthConnectionEntry) -> String {
+        [
+            connection.status,
+            String(connection.connected),
+            connection.account_label ?? "",
+            (connection.scopes_granted ?? []).sorted().joined(separator: ","),
+            connection.expires_at ?? ""
+        ].joined(separator: "|")
+    }
+}
+#endif

--- a/clients/shared/App/Auth/OAuthConnectSurfaceCoordinator.swift
+++ b/clients/shared/App/Auth/OAuthConnectSurfaceCoordinator.swift
@@ -8,6 +8,10 @@ private let oauthSurfaceLog = Logger(
     category: "OAuthConnectSurface"
 )
 
+private struct OAuthWebAuthStartError: LocalizedError {
+    let errorDescription: String? = "Unable to start the authorization session."
+}
+
 public enum OAuthConnectSurfaceResult: Sendable {
     case connected(connection: OAuthConnectionEntry?)
     case cancelled
@@ -86,7 +90,11 @@ public final class OAuthConnectSurfaceCoordinator {
             session.prefersEphemeralWebBrowserSession = false
             session.presentationContextProvider = WebAuthPresentationContext.shared
             activeSession = session
-            session.start()
+            guard session.start() else {
+                activeSession = nil
+                continuation.resume(throwing: OAuthWebAuthStartError())
+                return
+            }
         }
     }
 

--- a/clients/shared/App/Auth/SharedFileCredentialStorage.swift
+++ b/clients/shared/App/Auth/SharedFileCredentialStorage.swift
@@ -1,0 +1,95 @@
+#if os(macOS)
+import Foundation
+import os
+
+private let sharedCredentialLog = Logger(
+    subsystem: Bundle.appBundleIdentifier,
+    category: "SharedFileCredentialStorage"
+)
+
+/// File-backed credential storage for shared client code that needs the same
+/// persisted assistant/platform mappings as the macOS app target.
+public struct SharedFileCredentialStorage: CredentialStorage {
+    private static var credentialsDir: URL {
+        VellumPaths.current.credentialsDir
+    }
+
+    public init() {}
+
+    private func fileURL(for account: String) -> URL {
+        let safeName = account.replacingOccurrences(
+            of: "[^a-zA-Z0-9_\\-:]",
+            with: "_",
+            options: .regularExpression
+        )
+        return Self.credentialsDir.appendingPathComponent(safeName)
+    }
+
+    private func ensureDirectory() -> Bool {
+        let dir = Self.credentialsDir
+        if FileManager.default.fileExists(atPath: dir.path) {
+            return true
+        }
+        do {
+            try FileManager.default.createDirectory(
+                at: dir,
+                withIntermediateDirectories: true
+            )
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o700],
+                ofItemAtPath: dir.path
+            )
+            return true
+        } catch {
+            sharedCredentialLog.error("Failed to create credentials directory: \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    public func get(account: String) -> String? {
+        let url = fileURL(for: account)
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return nil
+        }
+        do {
+            let data = try Data(contentsOf: url)
+            return String(data: data, encoding: .utf8)
+        } catch {
+            sharedCredentialLog.error("Failed to read credential: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    @discardableResult
+    public func set(account: String, value: String) -> Bool {
+        guard ensureDirectory() else { return false }
+        let url = fileURL(for: account)
+        do {
+            try value.write(to: url, atomically: true, encoding: .utf8)
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o600],
+                ofItemAtPath: url.path
+            )
+            return true
+        } catch {
+            sharedCredentialLog.error("Failed to write credential: \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    @discardableResult
+    public func delete(account: String) -> Bool {
+        let url = fileURL(for: account)
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return true
+        }
+        do {
+            try FileManager.default.removeItem(at: url)
+            return true
+        } catch {
+            sharedCredentialLog.error("Failed to delete credential: \(error.localizedDescription)")
+            return false
+        }
+    }
+}
+#endif

--- a/clients/shared/Features/Chat/InlineWidgets/InlineRecentSurfaceWidgets.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineRecentSurfaceWidgets.swift
@@ -1,0 +1,897 @@
+#if os(macOS)
+import SwiftUI
+
+public struct InlineChoiceWidget: View {
+    public let data: ChoiceSurfaceData
+    public let onAction: (String, [String: AnyCodable]?) -> Void
+
+    @State private var selectedIds: Set<String> = []
+    @State private var submittingActionId: String?
+
+    public init(data: ChoiceSurfaceData, onAction: @escaping (String, [String: AnyCodable]?) -> Void) {
+        self.data = data
+        self.onAction = onAction
+    }
+
+    private var commitOnSelect: Bool {
+        data.selectionMode == .single ? data.commitOnSelect != false : false
+    }
+
+    private var selectedOptions: [ChoiceOptionData] {
+        data.options.filter { selectedIds.contains($0.id) }
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            if let description = data.description, !description.isEmpty {
+                Text(markdown(description))
+                    .font(VFont.bodyMediumLighter)
+                    .foregroundStyle(VColor.contentSecondary)
+                    .textSelection(.enabled)
+            }
+
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                ForEach(data.options) { option in
+                    optionRow(option)
+                }
+            }
+
+            if !commitOnSelect {
+                HStack {
+                    Spacer()
+                    VButton(
+                        label: data.submitLabel ?? "Continue",
+                        style: .primary,
+                        isDisabled: selectedOptions.isEmpty || submittingActionId != nil
+                    ) {
+                        submitSelectedOptions()
+                    }
+                }
+            }
+        }
+        .onAppear {
+            guard selectedIds.isEmpty, data.selectionMode == .multiple else { return }
+            selectedIds = Set(data.options.filter(\.recommended).map(\.id))
+        }
+    }
+
+    private func optionRow(_ option: ChoiceOptionData) -> some View {
+        let isSelected = selectedIds.contains(option.id)
+        let isSubmitting = submittingActionId == option.id
+        return Button {
+            toggleOption(option)
+        } label: {
+            HStack(alignment: .top, spacing: VSpacing.sm) {
+                ZStack {
+                    Circle()
+                        .stroke(isSelected || option.recommended ? VColor.primaryBase : VColor.borderBase, lineWidth: 1)
+                        .background(
+                            Circle()
+                                .fill(isSelected ? VColor.primaryBase : VColor.surfaceBase)
+                        )
+                    if isSubmitting {
+                        VLoadingIndicator(size: 12, color: isSelected ? VColor.auxWhite : VColor.primaryBase)
+                    } else if isSelected {
+                        VIconView(.check, size: 11)
+                            .foregroundStyle(VColor.auxWhite)
+                    }
+                }
+                .frame(width: 18, height: 18)
+                .padding(.top, 2)
+
+                VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                    HStack(spacing: VSpacing.sm) {
+                        Text(option.title)
+                            .font(VFont.bodyMediumDefault)
+                            .foregroundStyle(VColor.contentDefault)
+                            .multilineTextAlignment(.leading)
+
+                        if option.recommended {
+                            Text("Recommended")
+                                .font(VFont.labelDefault)
+                                .foregroundStyle(VColor.primaryBase)
+                                .padding(.horizontal, VSpacing.sm)
+                                .padding(.vertical, 2)
+                                .background(
+                                    Capsule()
+                                        .fill(VColor.primaryBase.opacity(0.12))
+                                )
+                        }
+                    }
+
+                    if let description = option.description, !description.isEmpty {
+                        Text(description)
+                            .font(VFont.labelDefault)
+                            .foregroundStyle(VColor.contentSecondary)
+                            .multilineTextAlignment(.leading)
+                    }
+                }
+
+                Spacer(minLength: 0)
+            }
+            .padding(VSpacing.md)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .fill(isSelected || option.recommended ? VColor.primaryBase.opacity(0.08) : VColor.surfaceBase)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .stroke(isSelected || option.recommended ? VColor.primaryBase : VColor.borderBase, lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .disabled(submittingActionId != nil)
+        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+    }
+
+    private func toggleOption(_ option: ChoiceOptionData) {
+        if commitOnSelect {
+            submitOption(option)
+            return
+        }
+
+        if data.selectionMode == .single {
+            selectedIds = selectedIds.contains(option.id) ? [] : [option.id]
+        } else {
+            if selectedIds.contains(option.id) {
+                selectedIds.remove(option.id)
+            } else {
+                selectedIds.insert(option.id)
+            }
+        }
+    }
+
+    private func submitOption(_ option: ChoiceOptionData) {
+        guard submittingActionId == nil else { return }
+        submittingActionId = option.id
+        onAction(option.id, payload(for: option))
+    }
+
+    private func submitSelectedOptions() {
+        guard !selectedOptions.isEmpty, submittingActionId == nil else { return }
+        submittingActionId = "submit"
+        onAction("submit", selectedOptionsPayload())
+    }
+
+    private func payload(for option: ChoiceOptionData) -> [String: AnyCodable] {
+        var payload: [String: AnyCodable] = [
+            "choiceId": AnyCodable(option.id),
+            "choiceTitle": AnyCodable(option.title),
+            "selectedIds": AnyCodable([option.id as Any?]),
+            "selectedTitles": AnyCodable([option.title as Any?])
+        ]
+        if let description = option.description {
+            payload["choiceDescription"] = AnyCodable(description)
+        }
+        if option.recommended {
+            payload["recommended"] = AnyCodable(true)
+        }
+        if let data = option.data {
+            for (key, value) in data {
+                payload[key] = value
+            }
+        }
+        return payload
+    }
+
+    private func selectedOptionsPayload() -> [String: AnyCodable] {
+        let choices: [Any?] = selectedOptions.map { option in
+            var dict: [String: Any?] = [
+                "id": option.id,
+                "title": option.title
+            ]
+            if let description = option.description {
+                dict["description"] = description
+            }
+            if option.recommended {
+                dict["recommended"] = true
+            }
+            if let data = option.data {
+                dict["data"] = data.mapValues { $0.value }
+            }
+            return dict
+        }
+
+        return [
+            "selectedIds": AnyCodable(selectedOptions.map { $0.id as Any? }),
+            "selectedTitles": AnyCodable(selectedOptions.map { $0.title as Any? }),
+            "choices": AnyCodable(choices)
+        ]
+    }
+
+    private func markdown(_ value: String) -> AttributedString {
+        let options = AttributedString.MarkdownParsingOptions(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+        return (try? AttributedString(markdown: value, options: options)) ?? AttributedString(value)
+    }
+}
+
+public struct InlineTaskPreferencesWidget: View {
+    public let title: String?
+    public let onAction: (String, [String: AnyCodable]?) -> Void
+
+    @State private var selectedTasks: Set<String> = []
+    @State private var otherSelected = false
+    @State private var otherText = ""
+    @State private var isSubmitting = false
+
+    public init(title: String?, onAction: @escaping (String, [String: AnyCodable]?) -> Void) {
+        self.title = title
+        self.onAction = onAction
+    }
+
+    private struct TaskCategory: Identifiable {
+        let id: String
+        let icon: VIcon
+        let label: String
+        let sublabel: String
+    }
+
+    private let taskCategories: [TaskCategory] = [
+        TaskCategory(id: "code-building", icon: .wrench, label: "Building", sublabel: "code, apps, tools"),
+        TaskCategory(id: "writing", icon: .pencil, label: "Writing", sublabel: "docs, emails, content"),
+        TaskCategory(id: "research", icon: .search, label: "Researching", sublabel: "digging into stuff, analysis"),
+        TaskCategory(id: "project-management", icon: .clipboardList, label: "Planning & coordinating", sublabel: "roadmaps, specs, tracking work"),
+        TaskCategory(id: "scheduling", icon: .calendar, label: "Scheduling", sublabel: "meetings, calendar, logistics"),
+        TaskCategory(id: "personal", icon: .user, label: "Life admin", sublabel: "bills, travel, household, errands"),
+    ]
+
+    private var trimmedOtherText: String {
+        otherText.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var canSubmit: Bool {
+        !selectedTasks.isEmpty || (otherSelected && !trimmedOtherText.isEmpty)
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                Text(title ?? "What can I help with?")
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(VColor.contentDefault)
+
+                Text("Select all that apply")
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
+
+            LazyVGrid(columns: [GridItem(.flexible(), spacing: VSpacing.sm), GridItem(.flexible(), spacing: VSpacing.sm)], alignment: .leading, spacing: VSpacing.sm) {
+                ForEach(taskCategories) { category in
+                    taskTile(category)
+                }
+            }
+
+            otherTile
+
+            VButton(
+                label: "Continue",
+                style: .primary,
+                isFullWidth: true,
+                isDisabled: !canSubmit || isSubmitting
+            ) {
+                submit()
+            }
+        }
+    }
+
+    private func taskTile(_ category: TaskCategory) -> some View {
+        let isSelected = selectedTasks.contains(category.id)
+        return Button {
+            toggleTask(category.id)
+        } label: {
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                HStack {
+                    VIconView(category.icon, size: 16)
+                        .foregroundStyle(isSelected ? VColor.primaryBase : VColor.contentSecondary)
+                    Spacer(minLength: 0)
+                    if isSelected {
+                        VIconView(.check, size: 12)
+                            .foregroundStyle(VColor.contentInset)
+                            .frame(width: 18, height: 18)
+                            .background(RoundedRectangle(cornerRadius: VRadius.sm).fill(VColor.primaryBase))
+                    }
+                }
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(category.label)
+                        .font(VFont.bodySmallDefault)
+                        .foregroundStyle(VColor.contentDefault)
+                        .lineLimit(2)
+                    Text(category.sublabel)
+                        .font(VFont.labelDefault)
+                        .foregroundStyle(VColor.contentTertiary)
+                        .lineLimit(2)
+                }
+            }
+            .frame(maxWidth: .infinity, minHeight: 88, alignment: .topLeading)
+            .padding(VSpacing.md)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .fill(isSelected ? VColor.primaryBase.opacity(0.08) : VColor.surfaceBase)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .stroke(isSelected ? VColor.primaryBase : VColor.borderBase, lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .disabled(isSubmitting)
+        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+    }
+
+    private var otherTile: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            Button {
+                otherSelected.toggle()
+                if !otherSelected {
+                    otherText = ""
+                }
+            } label: {
+                HStack(alignment: .top, spacing: VSpacing.sm) {
+                    VIconView(.messageSquare, size: 16)
+                        .foregroundStyle(otherSelected ? VColor.primaryBase : VColor.contentSecondary)
+                        .frame(width: 22, height: 22)
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Other")
+                            .font(VFont.bodyMediumDefault)
+                            .foregroundStyle(VColor.contentDefault)
+                        Text("something else entirely")
+                            .font(VFont.labelDefault)
+                            .foregroundStyle(VColor.contentTertiary)
+                    }
+
+                    Spacer(minLength: 0)
+
+                    if otherSelected {
+                        VIconView(.check, size: 12)
+                            .foregroundStyle(VColor.contentInset)
+                            .frame(width: 18, height: 18)
+                            .background(RoundedRectangle(cornerRadius: VRadius.sm).fill(VColor.primaryBase))
+                    }
+                }
+                .padding(VSpacing.md)
+                .background(
+                    RoundedRectangle(cornerRadius: VRadius.md)
+                        .fill(otherSelected ? VColor.primaryBase.opacity(0.08) : VColor.surfaceBase)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.md)
+                        .stroke(otherSelected ? VColor.primaryBase : VColor.borderBase, lineWidth: 1)
+                )
+            }
+            .buttonStyle(.plain)
+            .disabled(isSubmitting)
+
+            if otherSelected {
+                TextField("Describe what you need help with...", text: $otherText, axis: .vertical)
+                    .font(VFont.bodyMediumDefault)
+                    .textFieldStyle(.plain)
+                    .lineLimit(1...4)
+                    .padding(VSpacing.md)
+                    .background(RoundedRectangle(cornerRadius: VRadius.md).fill(VColor.surfaceBase))
+                    .overlay(RoundedRectangle(cornerRadius: VRadius.md).stroke(VColor.borderBase, lineWidth: 1))
+            }
+        }
+    }
+
+    private func toggleTask(_ id: String) {
+        if selectedTasks.contains(id) {
+            selectedTasks.remove(id)
+        } else {
+            selectedTasks.insert(id)
+        }
+    }
+
+    private func submit() {
+        guard canSubmit, !isSubmitting else { return }
+        isSubmitting = true
+        var payload: [String: AnyCodable] = [
+            "tasks": AnyCodable(taskCategories.filter { selectedTasks.contains($0.id) }.map { $0.id as Any? })
+        ]
+        if !trimmedOtherText.isEmpty {
+            payload["customText"] = AnyCodable(trimmedOtherText)
+        }
+        onAction("submit", payload)
+    }
+}
+
+public struct InlineCopyBlockWidget: View {
+    public let data: CopyBlockSurfaceData
+
+    public init(data: CopyBlockSurfaceData) {
+        self.data = data
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            if let label = data.label ?? data.language, !label.isEmpty {
+                Text(label)
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+                    .lineLimit(1)
+            }
+
+            ScrollView {
+                Text(data.text)
+                    .font(Font(VFont.nsMono))
+                    .foregroundStyle(VColor.contentDefault)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .frame(maxHeight: 320)
+
+            HStack {
+                Spacer()
+                VCopyButton(text: data.text, size: .compact)
+            }
+        }
+    }
+}
+
+public struct InlineOAuthConnectWidget: View {
+    public let data: OAuthConnectSurfaceData
+    public let title: String?
+    public let onAction: (String, [String: AnyCodable]?) -> Void
+
+    @State private var state: ConnectState = .idle
+    @State private var errorMessage: String?
+
+    public init(
+        data: OAuthConnectSurfaceData,
+        title: String?,
+        onAction: @escaping (String, [String: AnyCodable]?) -> Void
+    ) {
+        self.data = data
+        self.title = title
+        self.onAction = onAction
+    }
+
+    private enum ConnectState {
+        case idle
+        case connecting
+        case connected
+    }
+
+    private var providerLabel: String {
+        if let displayName = data.displayName, !displayName.isEmpty {
+            return displayName
+        }
+        return data.providerKey
+            .split { $0 == "-" || $0 == "_" }
+            .map { $0.prefix(1).uppercased() + $0.dropFirst() }
+            .joined(separator: " ")
+    }
+
+    private var description: String {
+        data.description ?? "Connect \(providerLabel) so I can use it for this task."
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            HStack(alignment: .top, spacing: VSpacing.md) {
+                providerAvatar
+
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text(title ?? "Connect \(providerLabel)")
+                        .font(VFont.bodySmallEmphasised)
+                        .foregroundStyle(VColor.contentDefault)
+
+                    Text(description)
+                        .font(VFont.bodyMediumLighter)
+                        .foregroundStyle(VColor.contentSecondary)
+
+                    if let errorMessage {
+                        HStack(spacing: VSpacing.xs) {
+                            VIconView(.circleX, size: 12)
+                            Text(errorMessage)
+                                .font(VFont.labelDefault)
+                        }
+                        .foregroundStyle(VColor.systemNegativeStrong)
+                    } else if state == .connected {
+                        HStack(spacing: VSpacing.xs) {
+                            VIconView(.circleCheck, size: 12)
+                            Text("Connected")
+                                .font(VFont.labelDefault)
+                        }
+                        .foregroundStyle(VColor.systemPositiveStrong)
+                    }
+                }
+
+                Spacer(minLength: 0)
+            }
+
+            HStack(spacing: VSpacing.sm) {
+                Spacer()
+                VButton(
+                    label: "Dismiss",
+                    iconOnly: VIcon.x.rawValue,
+                    style: .ghost,
+                    isDisabled: state == .connecting
+                ) {
+                    submitCancel()
+                }
+                VButton(
+                    label: state == .connecting ? "Waiting..." : "Connect",
+                    icon: state == .connecting ? nil : VIcon.externalLink.rawValue,
+                    style: .primary,
+                    isDisabled: state == .connecting || state == .connected
+                ) {
+                    connect()
+                }
+            }
+        }
+    }
+
+    private var providerAvatar: some View {
+        let initials = String(providerLabel.prefix(2)).uppercased()
+        return ZStack {
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .fill(providerColor.opacity(0.14))
+            Text(initials)
+                .font(.system(size: 14, weight: .semibold, design: .rounded))
+                .foregroundStyle(providerColor)
+        }
+        .frame(width: 40, height: 40)
+    }
+
+    private var providerColor: Color {
+        let palette: [Color] = [
+            VColor.primaryBase,
+            VColor.systemPositiveStrong,
+            VColor.systemMidStrong,
+            VColor.systemNegativeStrong,
+            VColor.contentSecondary
+        ]
+        let index = Int(data.providerKey.utf8.reduce(0 as UInt32) { $0 &+ UInt32($1) }) % palette.count
+        return palette[index]
+    }
+
+    private func submitCancel() {
+        onAction("cancel", [
+            "status": AnyCodable("cancelled"),
+            "providerKey": AnyCodable(data.providerKey),
+            "providerLabel": AnyCodable(providerLabel)
+        ])
+    }
+
+    private func connect() {
+        guard state != .connecting else { return }
+        state = .connecting
+        errorMessage = nil
+        Task {
+            let result = await OAuthConnectSurfaceCoordinator.shared.connect(
+                providerKey: data.providerKey,
+                providerLabel: providerLabel
+            )
+            switch result {
+            case .connected(let connection):
+                state = .connected
+                onAction("connect", connectedPayload(connection: connection))
+            case .cancelled:
+                state = .idle
+                submitCancel()
+            case .error(let message):
+                state = .idle
+                errorMessage = message
+            }
+        }
+    }
+
+    private func connectedPayload(connection: OAuthConnectionEntry?) -> [String: AnyCodable] {
+        var payload: [String: AnyCodable] = [
+            "status": AnyCodable("connected"),
+            "providerKey": AnyCodable(data.providerKey),
+            "providerLabel": AnyCodable(providerLabel),
+            "scopesGranted": AnyCodable((connection?.scopes_granted ?? []).map { $0 as Any? })
+        ]
+        if let id = connection?.id {
+            payload["connectionId"] = AnyCodable(id)
+        }
+        if let accountLabel = connection?.account_label {
+            payload["accountLabel"] = AnyCodable(accountLabel)
+        }
+        return payload
+    }
+}
+
+public struct InlineWorkResultWidget: View {
+    public let title: String
+    public let data: WorkResultSurfaceData
+
+    public init(title: String, data: WorkResultSurfaceData) {
+        self.title = title
+        self.data = data
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.lg) {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                HStack(alignment: .top, spacing: VSpacing.md) {
+                    VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                        if let eyebrow = data.eyebrow {
+                            Text(eyebrow.uppercased())
+                                .font(VFont.labelDefault)
+                                .foregroundStyle(VColor.contentTertiary)
+                        }
+                        Text(title)
+                            .font(VFont.titleSmall)
+                            .foregroundStyle(VColor.contentDefault)
+                    }
+                    Spacer(minLength: 0)
+                    if let status = data.status {
+                        statusBadge(status)
+                    }
+                }
+
+                if let summary = data.summary {
+                    Text(summary)
+                        .font(VFont.bodyMediumLighter)
+                        .foregroundStyle(VColor.contentSecondary)
+                        .textSelection(.enabled)
+                }
+            }
+
+            metricGrid
+
+            if !data.sections.isEmpty {
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
+                    ForEach(data.sections) { section in
+                        sectionView(section)
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var metricGrid: some View {
+        if !data.metrics.isEmpty {
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 120), spacing: VSpacing.sm)], alignment: .leading, spacing: VSpacing.sm) {
+                ForEach(Array(data.metrics.enumerated()), id: \.offset) { _, metric in
+                    VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                        Text(metric.value)
+                            .font(VFont.titleSmall)
+                            .foregroundStyle(toneForeground(metric.tone))
+                            .lineLimit(1)
+                        Text(metric.label)
+                            .font(VFont.labelDefault)
+                            .foregroundStyle(VColor.contentSecondary)
+                            .lineLimit(1)
+                        if let detail = metric.detail {
+                            Text(detail)
+                                .font(VFont.labelDefault)
+                                .foregroundStyle(VColor.contentTertiary)
+                                .lineLimit(1)
+                        }
+                    }
+                    .padding(VSpacing.md)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(
+                        RoundedRectangle(cornerRadius: VRadius.md)
+                            .fill(VColor.surfaceBase)
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VRadius.md)
+                            .stroke(VColor.borderBase, lineWidth: 1)
+                    )
+                }
+            }
+        }
+    }
+
+    private func sectionView(_ section: WorkResultSection) -> some View {
+        HStack(alignment: .top, spacing: VSpacing.md) {
+            sectionIcon(section.type)
+
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                Text(section.title)
+                    .font(VFont.bodySmallEmphasised)
+                    .foregroundStyle(VColor.contentDefault)
+
+                if let description = section.description {
+                    Text(description)
+                        .font(VFont.labelDefault)
+                        .foregroundStyle(VColor.contentSecondary)
+                }
+
+                if section.type == .diff {
+                    diffList(section.diffs)
+                } else {
+                    itemList(section.items, sectionType: section.type)
+                }
+            }
+        }
+        .padding(.top, VSpacing.md)
+        .overlay(alignment: .top) {
+            Rectangle()
+                .fill(VColor.borderBase)
+                .frame(height: 1)
+        }
+    }
+
+    private func itemList(_ items: [WorkResultItem], sectionType: WorkResultSectionType) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(items) { item in
+                HStack(alignment: .top, spacing: VSpacing.sm) {
+                    VIconView(itemIcon(item, sectionType: sectionType), size: 16)
+                        .foregroundStyle(toneForeground(item.tone))
+                        .frame(width: 22, height: 22)
+
+                    VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                        HStack(spacing: VSpacing.sm) {
+                            if let href = item.href, let url = URL(string: href), ["http", "https"].contains(url.scheme?.lowercased() ?? "") {
+                                Link(item.title, destination: url)
+                                    .font(VFont.bodyMediumDefault)
+                            } else {
+                                Text(item.title)
+                                    .font(VFont.bodyMediumDefault)
+                                    .foregroundStyle(VColor.contentDefault)
+                            }
+
+                            if let status = item.status {
+                                Text(status)
+                                    .font(VFont.labelDefault)
+                                    .foregroundStyle(VColor.contentSecondary)
+                                    .padding(.horizontal, VSpacing.sm)
+                                    .padding(.vertical, 2)
+                                    .background(Capsule().fill(VColor.surfaceActive))
+                            }
+                        }
+
+                        if let description = item.description {
+                            Text(description)
+                                .font(VFont.labelDefault)
+                                .foregroundStyle(VColor.contentSecondary)
+                        }
+
+                        if !item.metadata.isEmpty {
+                            metadataRow(item.metadata)
+                        }
+                    }
+                }
+                .padding(.vertical, VSpacing.sm)
+            }
+        }
+    }
+
+    private func diffList(_ diffs: [WorkResultDiff]) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            ForEach(diffs) { diff in
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    if let label = diff.label {
+                        Text(label)
+                            .font(VFont.labelDefault)
+                            .foregroundStyle(VColor.contentSecondary)
+                    }
+
+                    HStack(alignment: .top, spacing: VSpacing.sm) {
+                        diffColumn(label: "Before", value: diff.before ?? "Not set", emphasized: false)
+                        VIconView(.arrowRight, size: 14)
+                            .foregroundStyle(VColor.contentTertiary)
+                            .padding(.top, VSpacing.lg)
+                        diffColumn(label: "After", value: diff.after ?? "Removed", emphasized: true)
+                    }
+                }
+            }
+        }
+    }
+
+    private func diffColumn(label: String, value: String, emphasized: Bool) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.xxs) {
+            Text(label)
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentTertiary)
+            Text(value)
+                .font(VFont.labelDefault)
+                .foregroundStyle(emphasized ? VColor.contentDefault : VColor.contentSecondary)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(VSpacing.sm)
+        .background(RoundedRectangle(cornerRadius: VRadius.sm).fill(VColor.surfaceBase))
+        .overlay(RoundedRectangle(cornerRadius: VRadius.sm).stroke(VColor.borderBase, lineWidth: 1))
+    }
+
+    private func metadataRow(_ metadata: [WorkResultMetadata]) -> some View {
+        HStack(spacing: VSpacing.xs) {
+            ForEach(Array(metadata.enumerated()), id: \.offset) { _, metadata in
+                Text("\(metadata.label): \(metadata.value)")
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+                    .padding(.horizontal, VSpacing.sm)
+                    .padding(.vertical, 2)
+                    .background(Capsule().fill(VColor.surfaceActive))
+            }
+        }
+    }
+
+    private func statusBadge(_ status: WorkResultStatus) -> some View {
+        let label: String
+        let icon: VIcon
+        let tone: WorkResultTone
+        switch status {
+        case .completed:
+            label = "Completed"
+            icon = .circleCheck
+            tone = .positive
+        case .partial:
+            label = "Partial"
+            icon = .triangleAlert
+            tone = .warning
+        case .failed:
+            label = "Needs attention"
+            icon = .circleX
+            tone = .negative
+        case .inProgress:
+            label = "In progress"
+            icon = .clock
+            tone = .neutral
+        }
+
+        return HStack(spacing: VSpacing.xs) {
+            VIconView(icon, size: 12)
+            Text(label)
+                .font(VFont.labelDefault)
+        }
+        .foregroundStyle(toneForeground(tone))
+        .padding(.horizontal, VSpacing.sm)
+        .padding(.vertical, 4)
+        .background(Capsule().fill(toneBackground(tone)))
+    }
+
+    private func sectionIcon(_ type: WorkResultSectionType) -> some View {
+        let icon: VIcon = switch type {
+        case .warnings: .triangleAlert
+        case .artifacts: .fileText
+        case .diff: .arrowRight
+        case .timeline: .clock
+        case .items: .sparkles
+        }
+        let tone: WorkResultTone = switch type {
+        case .warnings: .warning
+        case .artifacts: .positive
+        default: .neutral
+        }
+        return VIconView(icon, size: 16)
+            .foregroundStyle(toneForeground(tone))
+            .frame(width: 28, height: 28)
+            .background(RoundedRectangle(cornerRadius: VRadius.md).fill(toneBackground(tone)))
+    }
+
+    private func itemIcon(_ item: WorkResultItem, sectionType: WorkResultSectionType) -> VIcon {
+        if item.tone == .positive { return .circleCheck }
+        if item.tone == .warning { return .triangleAlert }
+        if item.tone == .negative { return .circleX }
+        if sectionType == .artifacts { return .fileText }
+        if sectionType == .timeline { return .circleDot }
+        return .listChecks
+    }
+
+    private func toneForeground(_ tone: WorkResultTone?) -> Color {
+        switch tone {
+        case .positive:
+            return VColor.systemPositiveStrong
+        case .warning:
+            return VColor.systemMidStrong
+        case .negative:
+            return VColor.systemNegativeStrong
+        default:
+            return VColor.contentSecondary
+        }
+    }
+
+    private func toneBackground(_ tone: WorkResultTone?) -> Color {
+        switch tone {
+        case .positive:
+            return VColor.systemPositiveWeak
+        case .warning:
+            return VColor.systemMidWeak
+        case .negative:
+            return VColor.systemNegativeWeak
+        default:
+            return VColor.surfaceBase
+        }
+    }
+}
+#endif

--- a/clients/shared/Features/Chat/InlineWidgets/InlineRecentSurfaceWidgets.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineRecentSurfaceWidgets.swift
@@ -1,5 +1,54 @@
 #if os(macOS)
+import AppKit
 import SwiftUI
+
+private enum InlineOAuthProviderLogoBundle {
+    private static var nsImageStore: [String: NSImage] = [:]
+    private static var missStore: Set<String> = []
+    private static let nsImageLock = NSLock()
+
+    static func bundledImage(providerKey: String) -> NSImage? {
+        let key = normalizedProviderKey(providerKey)
+
+        nsImageLock.lock()
+        if let cached = nsImageStore[key] {
+            nsImageLock.unlock()
+            return cached
+        }
+        if missStore.contains(key) {
+            nsImageLock.unlock()
+            return nil
+        }
+        nsImageLock.unlock()
+
+        guard
+            let url = Bundle.vellumShared.url(
+                forResource: key,
+                withExtension: "pdf",
+                subdirectory: "IntegrationLogos"
+            ),
+            let image = NSImage(contentsOf: url)
+        else {
+            nsImageLock.lock()
+            missStore.insert(key)
+            nsImageLock.unlock()
+            return nil
+        }
+
+        nsImageLock.lock()
+        if let existing = nsImageStore[key] {
+            nsImageLock.unlock()
+            return existing
+        }
+        nsImageStore[key] = image
+        nsImageLock.unlock()
+        return image
+    }
+
+    private static func normalizedProviderKey(_ providerKey: String) -> String {
+        providerKey.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+}
 
 public struct InlineChoiceWidget: View {
     public let data: ChoiceSurfaceData
@@ -467,6 +516,12 @@ public struct InlineOAuthConnectWidget: View {
         data.description ?? "Connect \(providerLabel) so I can use it for this task."
     }
 
+    private var logoURL: URL? {
+        guard let logoUrl = data.logoUrl?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !logoUrl.isEmpty else { return nil }
+        return URL(string: logoUrl)
+    }
+
     public var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
             HStack(alignment: .top, spacing: VSpacing.md) {
@@ -524,15 +579,51 @@ public struct InlineOAuthConnectWidget: View {
     }
 
     private var providerAvatar: some View {
-        let initials = String(providerLabel.prefix(2)).uppercased()
-        return ZStack {
+        ZStack {
             RoundedRectangle(cornerRadius: VRadius.md)
-                .fill(providerColor.opacity(0.14))
-            Text(initials)
-                .font(.system(size: 14, weight: .semibold, design: .rounded))
-                .foregroundStyle(providerColor)
+                .fill(VColor.surfaceBase)
+
+            if let image = InlineOAuthProviderLogoBundle.bundledImage(providerKey: data.providerKey) {
+                Image(nsImage: image)
+                    .resizable()
+                    .interpolation(.high)
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 28, height: 28)
+            } else if let logoURL {
+                VCachedRemoteImage(
+                    url: logoURL,
+                    content: { image in
+                        image
+                            .resizable()
+                            .interpolation(.high)
+                            .aspectRatio(contentMode: .fit)
+                    },
+                    placeholder: {
+                        providerInitialsAvatar
+                    }
+                )
+                .frame(width: 28, height: 28)
+            } else {
+                providerInitialsAvatar
+            }
         }
         .frame(width: 40, height: 40)
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .stroke(VColor.borderBase, lineWidth: 1)
+        )
+    }
+
+    private var providerInitialsAvatar: some View {
+        let initials = String(providerLabel.prefix(2)).uppercased()
+        return ZStack {
+            Circle()
+                .fill(providerColor)
+            Text(initials)
+                .font(.system(size: 11, weight: .semibold, design: .rounded))
+                .foregroundStyle(VColor.auxWhite)
+        }
+        .frame(width: 28, height: 28)
     }
 
     private var providerColor: Color {

--- a/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
@@ -65,6 +65,16 @@ public struct InlineSurfaceRouter: View {
         return false
     }
 
+    private var shouldRenderGenericActionButtons: Bool {
+        guard !surface.actions.isEmpty else { return false }
+        switch surface.data {
+        case .choice, .form, .confirmation, .oauthConnect, .taskPreferences:
+            return false
+        default:
+            return true
+        }
+    }
+
     private var standardWidgetMaxWidth: CGFloat {
         // Tables should use the full chat bubble width before falling back to horizontal scroll.
         isTableSurface ? VSpacing.chatBubbleMaxWidth : 540
@@ -123,7 +133,7 @@ public struct InlineSurfaceRouter: View {
 
             surfaceContent
 
-            if !surface.actions.isEmpty {
+            if shouldRenderGenericActionButtons {
                 actionButtons
             }
         }

--- a/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
@@ -240,6 +240,23 @@ public struct InlineSurfaceRouter: View {
             let onPopOut: (() -> Void)? = nil
             #endif
             InlineCardWidget(data: data, onPopOut: onPopOut)
+        case .choice(let data):
+            InlineChoiceWidget(data: data) { actionId, payload in
+                onAction(surface.id, actionId, payload)
+            }
+        case .copyBlock(let data):
+            InlineCopyBlockWidget(data: data)
+        case .oauthConnect(let data):
+            InlineOAuthConnectWidget(
+                data: data,
+                title: surface.title
+            ) { actionId, payload in
+                onAction(surface.id, actionId, payload)
+            }
+        case .taskPreferences:
+            InlineTaskPreferencesWidget(title: surface.title) { actionId, payload in
+                onAction(surface.id, actionId, payload)
+            }
         case .documentPreview(let data):
             InlineDocumentPreview(data: data) {
                 NotificationCenter.default.post(
@@ -368,6 +385,8 @@ public struct InlineSurfaceRouter: View {
         #endif
         case .callSummary(let data):
             InlineCallSummaryWidget(data: data)
+        case .workResult(let data):
+            InlineWorkResultWidget(title: surface.title ?? "Work completed", data: data)
         default:
             InlineFallbackChip(surfaceType: surface.surfaceType)
         }

--- a/clients/shared/Features/Surfaces/SurfaceTypes.swift
+++ b/clients/shared/Features/Surfaces/SurfaceTypes.swift
@@ -4,6 +4,9 @@ import Foundation
 
 public enum SurfaceType: String, Codable, Sendable {
     case card
+    case choice
+    case copyBlock = "copy_block"
+    case oauthConnect = "oauth_connect"
     case form
     case list
     case table
@@ -11,7 +14,9 @@ public enum SurfaceType: String, Codable, Sendable {
     case dynamicPage = "dynamic_page"
     case fileUpload = "file_upload"
     case documentPreview = "document_preview"
+    case taskPreferences = "task_preferences"
     case callSummary = "call_summary"
+    case workResult = "work_result"
 }
 
 public enum SurfaceActionStyle: String, Codable, Sendable {
@@ -255,6 +260,68 @@ public struct ListSurfaceData: Sendable, Equatable {
     }
 }
 
+public struct ChoiceOptionData: Identifiable, Sendable, Equatable {
+    public let id: String
+    public let title: String
+    public let description: String?
+    public let recommended: Bool
+    public let data: [String: AnyCodable]?
+
+    public init(id: String, title: String, description: String? = nil, recommended: Bool = false, data: [String: AnyCodable]? = nil) {
+        self.id = id
+        self.title = title
+        self.description = description
+        self.recommended = recommended
+        self.data = data
+    }
+}
+
+public struct ChoiceSurfaceData: Sendable, Equatable {
+    public let description: String?
+    public let options: [ChoiceOptionData]
+    public let selectionMode: SelectionMode
+    public let commitOnSelect: Bool?
+    public let submitLabel: String?
+
+    public init(description: String? = nil, options: [ChoiceOptionData], selectionMode: SelectionMode = .single, commitOnSelect: Bool? = nil, submitLabel: String? = nil) {
+        self.description = description
+        self.options = options
+        self.selectionMode = selectionMode
+        self.commitOnSelect = commitOnSelect
+        self.submitLabel = submitLabel
+    }
+}
+
+public struct CopyBlockSurfaceData: Sendable, Equatable {
+    public let text: String
+    public let label: String?
+    public let language: String?
+
+    public init(text: String, label: String? = nil, language: String? = nil) {
+        self.text = text
+        self.label = label
+        self.language = language
+    }
+}
+
+public struct OAuthConnectSurfaceData: Sendable, Equatable {
+    public let providerKey: String
+    public let displayName: String?
+    public let description: String?
+    public let logoUrl: String?
+
+    public init(providerKey: String, displayName: String? = nil, description: String? = nil, logoUrl: String? = nil) {
+        self.providerKey = providerKey
+        self.displayName = displayName
+        self.description = description
+        self.logoUrl = logoUrl
+    }
+}
+
+public struct TaskPreferencesSurfaceData: Sendable, Equatable {
+    public init() {}
+}
+
 public struct ConfirmationSurfaceData: Sendable, Equatable {
     public let message: String
     public let detail: String?
@@ -494,8 +561,125 @@ public struct TableSurfaceData: Sendable, Equatable {
     }
 }
 
+public enum WorkResultStatus: String, Sendable, Equatable {
+    case completed
+    case partial
+    case failed
+    case inProgress = "in_progress"
+}
+
+public enum WorkResultTone: String, Sendable, Equatable {
+    case neutral
+    case positive
+    case warning
+    case negative
+}
+
+public enum WorkResultSectionType: String, Sendable, Equatable {
+    case items
+    case timeline
+    case diff
+    case artifacts
+    case warnings
+}
+
+public struct WorkResultMetric: Sendable, Equatable {
+    public let label: String
+    public let value: String
+    public let detail: String?
+    public let tone: WorkResultTone?
+
+    public init(label: String, value: String, detail: String? = nil, tone: WorkResultTone? = nil) {
+        self.label = label
+        self.value = value
+        self.detail = detail
+        self.tone = tone
+    }
+}
+
+public struct WorkResultMetadata: Sendable, Equatable {
+    public let label: String
+    public let value: String
+
+    public init(label: String, value: String) {
+        self.label = label
+        self.value = value
+    }
+}
+
+public struct WorkResultItem: Identifiable, Sendable, Equatable {
+    public let id: String
+    public let title: String
+    public let description: String?
+    public let status: String?
+    public let tone: WorkResultTone?
+    public let metadata: [WorkResultMetadata]
+    public let href: String?
+
+    public init(id: String, title: String, description: String? = nil, status: String? = nil, tone: WorkResultTone? = nil, metadata: [WorkResultMetadata] = [], href: String? = nil) {
+        self.id = id
+        self.title = title
+        self.description = description
+        self.status = status
+        self.tone = tone
+        self.metadata = metadata
+        self.href = href
+    }
+}
+
+public struct WorkResultDiff: Identifiable, Sendable, Equatable {
+    public let id: String
+    public let label: String?
+    public let before: String?
+    public let after: String?
+
+    public init(id: String, label: String? = nil, before: String? = nil, after: String? = nil) {
+        self.id = id
+        self.label = label
+        self.before = before
+        self.after = after
+    }
+}
+
+public struct WorkResultSection: Identifiable, Sendable, Equatable {
+    public let id: String
+    public let title: String
+    public let description: String?
+    public let type: WorkResultSectionType
+    public let items: [WorkResultItem]
+    public let diffs: [WorkResultDiff]
+
+    public init(id: String, title: String, description: String? = nil, type: WorkResultSectionType = .items, items: [WorkResultItem] = [], diffs: [WorkResultDiff] = []) {
+        self.id = id
+        self.title = title
+        self.description = description
+        self.type = type
+        self.items = items
+        self.diffs = diffs
+    }
+}
+
+public struct WorkResultSurfaceData: Sendable, Equatable {
+    public let eyebrow: String?
+    public let status: WorkResultStatus?
+    public let summary: String?
+    public let metrics: [WorkResultMetric]
+    public let sections: [WorkResultSection]
+
+    public init(eyebrow: String? = nil, status: WorkResultStatus? = nil, summary: String? = nil, metrics: [WorkResultMetric] = [], sections: [WorkResultSection] = []) {
+        self.eyebrow = eyebrow
+        self.status = status
+        self.summary = summary
+        self.metrics = metrics
+        self.sections = sections
+    }
+}
+
 public enum SurfaceData: Sendable, Equatable {
     case card(CardSurfaceData)
+    case choice(ChoiceSurfaceData)
+    case copyBlock(CopyBlockSurfaceData)
+    case oauthConnect(OAuthConnectSurfaceData)
     case form(FormSurfaceData)
     case list(ListSurfaceData)
     case table(TableSurfaceData)
@@ -503,7 +687,9 @@ public enum SurfaceData: Sendable, Equatable {
     case dynamicPage(DynamicPageSurfaceData)
     case fileUpload(FileUploadSurfaceData)
     case documentPreview(DocumentPreviewSurfaceData)
+    case taskPreferences(TaskPreferencesSurfaceData)
     case callSummary(CallSummaryData)
+    case workResult(WorkResultSurfaceData)
     /// Placeholder for data that was cleared during memory compaction.
     /// The surface can be re-fetched from the daemon if the user scrolls back.
     case stripped
@@ -674,6 +860,12 @@ public extension Surface {
         switch type {
         case .card:
             return parseCardData(dict).map { .card($0) }
+        case .choice:
+            return parseChoiceData(dict).map { .choice($0) }
+        case .copyBlock:
+            return parseCopyBlockData(dict).map { .copyBlock($0) }
+        case .oauthConnect:
+            return parseOAuthConnectData(dict).map { .oauthConnect($0) }
         case .form:
             return parseFormData(dict).map { .form($0) }
         case .list:
@@ -688,8 +880,12 @@ public extension Surface {
             return parseFileUploadData(dict).map { .fileUpload($0) }
         case .documentPreview:
             return parseDocumentPreviewData(dict).map { .documentPreview($0) }
+        case .taskPreferences:
+            return .taskPreferences(TaskPreferencesSurfaceData())
         case .callSummary:
             return parseCallSummaryData(dict).map { .callSummary($0) }
+        case .workResult:
+            return parseWorkResultData(dict).map { .workResult($0) }
         }
     }
 
@@ -702,6 +898,12 @@ public extension Surface {
         switch existing {
         case .card(let card):
             return .card(mergeCardData(existing: card, update: update))
+        case .choice(let choice):
+            return .choice(mergeChoiceData(existing: choice, update: update))
+        case .copyBlock(let copyBlock):
+            return .copyBlock(mergeCopyBlockData(existing: copyBlock, update: update))
+        case .oauthConnect(let oauthConnect):
+            return .oauthConnect(mergeOAuthConnectData(existing: oauthConnect, update: update))
         case .form(let form):
             return .form(mergeFormData(existing: form, update: update))
         case .list(let list):
@@ -716,8 +918,12 @@ public extension Surface {
             return .fileUpload(mergeFileUploadData(existing: fu, update: update))
         case .documentPreview(let dp):
             return .documentPreview(dp)
+        case .taskPreferences:
+            return .taskPreferences(TaskPreferencesSurfaceData())
         case .callSummary(let cs):
             return .callSummary(cs)
+        case .workResult(let workResult):
+            return .workResult(mergeWorkResultData(existing: workResult, update: update))
         case .stripped:
             return .stripped
         case .strippedFailed:
@@ -749,6 +955,56 @@ public extension Surface {
             ? (update["templateData"] as? [String: Any?]) : existing.templateData
 
         return CardSurfaceData(title: title, subtitle: subtitle, body: body, metadata: metadata, template: template, templateData: templateData)
+    }
+
+    private static func mergeChoiceData(existing: ChoiceSurfaceData, update: [String: Any?]) -> ChoiceSurfaceData {
+        let description: String? = update.keys.contains("description")
+            ? (update["description"] as? String)
+            : existing.description
+        let options: [ChoiceOptionData]
+        if let optionsArray = update["options"] as? [[String: Any?]] {
+            options = parseChoiceOptions(optionsArray)
+        } else {
+            options = existing.options
+        }
+        let selectionMode: SelectionMode
+        if let modeStr = update["selectionMode"] as? String,
+           let mode = SelectionMode(rawValue: modeStr) {
+            selectionMode = mode
+        } else {
+            selectionMode = existing.selectionMode
+        }
+        let commitOnSelect: Bool? = update.keys.contains("commitOnSelect")
+            ? (update["commitOnSelect"] as? Bool)
+            : existing.commitOnSelect
+        let submitLabel: String? = update.keys.contains("submitLabel")
+            ? (update["submitLabel"] as? String)
+            : existing.submitLabel
+
+        return ChoiceSurfaceData(
+            description: description,
+            options: options,
+            selectionMode: selectionMode,
+            commitOnSelect: commitOnSelect,
+            submitLabel: submitLabel
+        )
+    }
+
+    private static func mergeCopyBlockData(existing: CopyBlockSurfaceData, update: [String: Any?]) -> CopyBlockSurfaceData {
+        CopyBlockSurfaceData(
+            text: (update["text"] as? String) ?? existing.text,
+            label: update.keys.contains("label") ? (update["label"] as? String) : existing.label,
+            language: update.keys.contains("language") ? (update["language"] as? String) : existing.language
+        )
+    }
+
+    private static func mergeOAuthConnectData(existing: OAuthConnectSurfaceData, update: [String: Any?]) -> OAuthConnectSurfaceData {
+        OAuthConnectSurfaceData(
+            providerKey: (update["providerKey"] as? String) ?? existing.providerKey,
+            displayName: update.keys.contains("displayName") ? (update["displayName"] as? String) : existing.displayName,
+            description: update.keys.contains("description") ? (update["description"] as? String) : existing.description,
+            logoUrl: update.keys.contains("logoUrl") ? (update["logoUrl"] as? String) : existing.logoUrl
+        )
     }
 
     private static func mergeFormData(existing: FormSurfaceData, update: [String: Any?]) -> FormSurfaceData {
@@ -887,6 +1143,23 @@ public extension Surface {
         }
     }
 
+    private static func parseChoiceOptions(_ optionsArray: [[String: Any?]]) -> [ChoiceOptionData] {
+        optionsArray.compactMap { optionDict in
+            guard let id = optionDict["id"] as? String,
+                  let title = optionDict["title"] as? String else {
+                return nil
+            }
+            let rawData = optionDict["data"] as? [String: Any?]
+            return ChoiceOptionData(
+                id: id,
+                title: title,
+                description: optionDict["description"] as? String,
+                recommended: optionDict["recommended"] as? Bool ?? false,
+                data: rawData?.mapValues { AnyCodable($0) }
+            )
+        }
+    }
+
     // MARK: - Full Parse Helpers
 
     private static func parseCardData(_ dict: [String: Any?]) -> CardSurfaceData? {
@@ -919,6 +1192,42 @@ public extension Surface {
             metadata: metadata,
             template: template,
             templateData: templateData
+        )
+    }
+
+    private static func parseChoiceData(_ dict: [String: Any?]) -> ChoiceSurfaceData? {
+        guard let optionsArray = dict["options"] as? [[String: Any?]] else {
+            return nil
+        }
+        let selectionModeStr = dict["selectionMode"] as? String ?? "single"
+        let selectionMode = SelectionMode(rawValue: selectionModeStr) ?? .single
+        return ChoiceSurfaceData(
+            description: dict["description"] as? String,
+            options: parseChoiceOptions(optionsArray),
+            selectionMode: selectionMode,
+            commitOnSelect: dict["commitOnSelect"] as? Bool,
+            submitLabel: dict["submitLabel"] as? String
+        )
+    }
+
+    private static func parseCopyBlockData(_ dict: [String: Any?]) -> CopyBlockSurfaceData? {
+        guard let text = dict["text"] as? String else { return nil }
+        return CopyBlockSurfaceData(
+            text: text,
+            label: dict["label"] as? String,
+            language: dict["language"] as? String
+        )
+    }
+
+    private static func parseOAuthConnectData(_ dict: [String: Any?]) -> OAuthConnectSurfaceData? {
+        guard let providerKey = dict["providerKey"] as? String, !providerKey.isEmpty else {
+            return nil
+        }
+        return OAuthConnectSurfaceData(
+            providerKey: providerKey,
+            displayName: dict["displayName"] as? String,
+            description: dict["description"] as? String,
+            logoUrl: dict["logoUrl"] as? String
         )
     }
 
@@ -1087,6 +1396,22 @@ public extension Surface {
         return TableSurfaceData(columns: columns, rows: rows, selectionMode: selectionMode, caption: caption)
     }
 
+    private static func mergeWorkResultData(existing: WorkResultSurfaceData, update: [String: Any?]) -> WorkResultSurfaceData {
+        WorkResultSurfaceData(
+            eyebrow: update.keys.contains("eyebrow") ? (update["eyebrow"] as? String) : existing.eyebrow,
+            status: update.keys.contains("status")
+                ? parseWorkResultStatus(rawValue(update, "status"))
+                : existing.status,
+            summary: update.keys.contains("summary") ? (update["summary"] as? String) : existing.summary,
+            metrics: update.keys.contains("metrics")
+                ? parseWorkResultMetrics(rawValue(update, "metrics"))
+                : existing.metrics,
+            sections: update.keys.contains("sections")
+                ? parseWorkResultSections(rawValue(update, "sections"))
+                : existing.sections
+        )
+    }
+
     private static func mergeTableData(existing: TableSurfaceData, update: [String: Any?]) -> TableSurfaceData {
         var columns = existing.columns
         if let columnsArray = update["columns"] as? [[String: Any?]] {
@@ -1167,10 +1492,123 @@ public extension Surface {
     /// Convert an untyped value to Double, accepting both Int and Double.
     /// AnyCodable decodes whole-number JSON numbers as Int before Double,
     /// so we need to handle both types.
+    private static func rawValue(_ dict: [String: Any?], _ key: String) -> Any? {
+        dict[key] ?? nil
+    }
+
     private static func asDouble(_ value: Any?) -> Double? {
         if let d = value as? Double { return d }
         if let i = value as? Int { return Double(i) }
         return nil
+    }
+
+    private static func asDisplayString(_ value: Any?) -> String? {
+        if let string = value as? String { return string }
+        if let int = value as? Int { return String(int) }
+        if let double = value as? Double {
+            if double.rounded(.towardZero) == double && !double.isNaN && !double.isInfinite {
+                return String(Int(double))
+            }
+            return String(double)
+        }
+        return nil
+    }
+
+    private static func parseWorkResultStatus(_ value: Any?) -> WorkResultStatus? {
+        guard let raw = value as? String else { return nil }
+        return WorkResultStatus(rawValue: raw)
+    }
+
+    private static func parseWorkResultTone(_ value: Any?) -> WorkResultTone? {
+        guard let raw = value as? String else { return nil }
+        return WorkResultTone(rawValue: raw)
+    }
+
+    private static func parseWorkResultSectionType(_ value: Any?) -> WorkResultSectionType {
+        guard let raw = value as? String,
+              let type = WorkResultSectionType(rawValue: raw) else {
+            return .items
+        }
+        return type
+    }
+
+    private static func parseWorkResultMetadata(_ value: Any?) -> [WorkResultMetadata] {
+        guard let array = value as? [[String: Any?]] else { return [] }
+        return array.compactMap { item in
+            guard let label = item["label"] as? String,
+                  let value = asDisplayString(rawValue(item, "value")) else { return nil }
+            return WorkResultMetadata(label: label, value: value)
+        }
+    }
+
+    private static func parseWorkResultItems(_ value: Any?) -> [WorkResultItem] {
+        guard let array = value as? [[String: Any?]] else { return [] }
+        return array.enumerated().compactMap { index, item in
+            guard let title = item["title"] as? String else { return nil }
+            return WorkResultItem(
+                id: (item["id"] as? String) ?? "\(index)",
+                title: title,
+                description: item["description"] as? String,
+                status: item["status"] as? String,
+                tone: parseWorkResultTone(rawValue(item, "tone")),
+                metadata: parseWorkResultMetadata(rawValue(item, "metadata")),
+                href: item["href"] as? String
+            )
+        }
+    }
+
+    private static func parseWorkResultDiffs(_ value: Any?) -> [WorkResultDiff] {
+        guard let array = value as? [[String: Any?]] else { return [] }
+        return array.enumerated().compactMap { index, diff in
+            let before = diff["before"] as? String
+            let after = diff["after"] as? String
+            guard before != nil || after != nil else { return nil }
+            return WorkResultDiff(
+                id: (diff["id"] as? String) ?? "\(index)",
+                label: diff["label"] as? String,
+                before: before,
+                after: after
+            )
+        }
+    }
+
+    private static func parseWorkResultMetrics(_ value: Any?) -> [WorkResultMetric] {
+        guard let array = value as? [[String: Any?]] else { return [] }
+        return array.compactMap { metric in
+            guard let label = metric["label"] as? String,
+                  let value = asDisplayString(rawValue(metric, "value")) else { return nil }
+            return WorkResultMetric(
+                label: label,
+                value: value,
+                detail: metric["detail"] as? String,
+                tone: parseWorkResultTone(rawValue(metric, "tone"))
+            )
+        }
+    }
+
+    private static func parseWorkResultSections(_ value: Any?) -> [WorkResultSection] {
+        guard let array = value as? [[String: Any?]] else { return [] }
+        return array.enumerated().compactMap { index, section in
+            guard let title = section["title"] as? String else { return nil }
+            return WorkResultSection(
+                id: (section["id"] as? String) ?? "\(index)",
+                title: title,
+                description: section["description"] as? String,
+                type: parseWorkResultSectionType(rawValue(section, "type")),
+                items: parseWorkResultItems(rawValue(section, "items")),
+                diffs: parseWorkResultDiffs(rawValue(section, "diffs"))
+            )
+        }
+    }
+
+    private static func parseWorkResultData(_ dict: [String: Any?]) -> WorkResultSurfaceData? {
+        WorkResultSurfaceData(
+            eyebrow: dict["eyebrow"] as? String,
+            status: parseWorkResultStatus(rawValue(dict, "status")),
+            summary: dict["summary"] as? String,
+            metrics: parseWorkResultMetrics(rawValue(dict, "metrics")),
+            sections: parseWorkResultSections(rawValue(dict, "sections"))
+        )
     }
 
     private static func parseDocumentPreviewData(_ dict: [String: Any?]) -> DocumentPreviewSurfaceData? {

--- a/clients/shared/Tests/SurfaceTypesTests.swift
+++ b/clients/shared/Tests/SurfaceTypesTests.swift
@@ -1,0 +1,147 @@
+import XCTest
+@testable import VellumAssistantShared
+
+final class SurfaceTypesTests: XCTestCase {
+    func testParsesChoiceSurface() {
+        let message = UiSurfaceShowMessage(
+            conversationId: "conv-123",
+            surfaceId: "surface-choice",
+            surfaceType: "choice",
+            title: "Pick an option",
+            data: AnyCodable([
+                "description": "Choose one.",
+                "selectionMode": "single",
+                "options": [
+                    [
+                        "id": "option-a",
+                        "title": "Option A",
+                        "description": "First option",
+                        "recommended": true,
+                        "data": ["priority": "high"]
+                    ]
+                ]
+            ] as [String: Any?]),
+            actions: nil,
+            display: "inline",
+            messageId: nil
+        )
+
+        let surface = Surface.from(message)
+        XCTAssertEqual(surface?.type, .choice)
+        guard case .choice(let data) = surface?.data else {
+            return XCTFail("Expected choice surface data")
+        }
+        XCTAssertEqual(data.options.first?.id, "option-a")
+        XCTAssertEqual(data.options.first?.data?["priority"], AnyCodable("high"))
+    }
+
+    func testParsesCopyBlockSurface() {
+        let message = UiSurfaceShowMessage(
+            conversationId: "conv-123",
+            surfaceId: "surface-copy",
+            surfaceType: "copy_block",
+            title: nil,
+            data: AnyCodable([
+                "text": "hello world",
+                "label": "Example",
+                "language": "text"
+            ] as [String: Any?]),
+            actions: nil,
+            display: "inline",
+            messageId: nil
+        )
+
+        let surface = Surface.from(message)
+        XCTAssertEqual(surface?.type, .copyBlock)
+        guard case .copyBlock(let data) = surface?.data else {
+            return XCTFail("Expected copy block surface data")
+        }
+        XCTAssertEqual(data.text, "hello world")
+        XCTAssertEqual(data.label, "Example")
+    }
+
+    func testParsesOAuthConnectSurface() {
+        let message = UiSurfaceShowMessage(
+            conversationId: "conv-123",
+            surfaceId: "surface-oauth",
+            surfaceType: "oauth_connect",
+            title: "Connect Gmail",
+            data: AnyCodable([
+                "providerKey": "google",
+                "displayName": "Google",
+                "description": "Connect your account.",
+                "logoUrl": NSNull()
+            ] as [String: Any?]),
+            actions: nil,
+            display: "inline",
+            messageId: nil
+        )
+
+        let surface = Surface.from(message)
+        XCTAssertEqual(surface?.type, .oauthConnect)
+        guard case .oauthConnect(let data) = surface?.data else {
+            return XCTFail("Expected OAuth connect surface data")
+        }
+        XCTAssertEqual(data.providerKey, "google")
+        XCTAssertEqual(data.displayName, "Google")
+        XCTAssertNil(data.logoUrl)
+    }
+
+    func testParsesTaskPreferencesSurface() {
+        let message = UiSurfaceShowMessage(
+            conversationId: "conv-123",
+            surfaceId: "surface-tasks",
+            surfaceType: "task_preferences",
+            title: "What can I help with?",
+            data: AnyCodable([:] as [String: Any?]),
+            actions: nil,
+            display: "inline",
+            messageId: nil
+        )
+
+        let surface = Surface.from(message)
+        XCTAssertEqual(surface?.type, .taskPreferences)
+        guard case .taskPreferences = surface?.data else {
+            return XCTFail("Expected task preferences surface data")
+        }
+    }
+
+    func testParsesWorkResultSurface() {
+        let message = UiSurfaceShowMessage(
+            conversationId: "conv-123",
+            surfaceId: "surface-work",
+            surfaceType: "work_result",
+            title: "Work completed",
+            data: AnyCodable([
+                "eyebrow": "Summary",
+                "status": "completed",
+                "summary": "Finished the requested work.",
+                "metrics": [
+                    ["label": "Files", "value": 3, "tone": "positive"]
+                ],
+                "sections": [
+                    [
+                        "id": "changes",
+                        "title": "Changes",
+                        "type": "items",
+                        "items": [
+                            ["title": "Updated settings", "tone": "positive"]
+                        ]
+                    ]
+                ]
+            ] as [String: Any?]),
+            actions: nil,
+            display: "inline",
+            messageId: nil
+        )
+
+        let surface = Surface.from(message)
+        XCTAssertEqual(surface?.type, .workResult)
+        guard case .workResult(let data) = surface?.data else {
+            return XCTFail("Expected work result surface data")
+        }
+        XCTAssertEqual(data.status, .completed)
+        XCTAssertEqual(data.metrics.first?.value, "3")
+        XCTAssertEqual(data.sections.first?.items.first?.title, "Updated settings")
+    }
+}


### PR DESCRIPTION
## Summary
- Adds Swift surface parsing and inline widgets for recently added web-only surfaces: choice, copy_block, oauth_connect, task_preferences, and work_result.
- Adds a native macOS OAuth connect coordinator for oauth_connect surfaces using ASWebAuthenticationSession.
- Keeps those surfaces inline-only in the legacy macOS panel container.

## Context
No Linear issue; ad hoc bug report from macOS surface parity regression.

## Tests
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter SurfaceTypesTests
- Pre-push hook: clients/ Swift build
- Pre-push hook: clients/ design token guard

## Apple Refs Checked
- https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession
- https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession/prefersephemeralwebbrowsersession