### PR TITLE
fix(web): simplify Pro plan card base-fee copy

### DIFF
--- a/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
+++ b/apps/web/src/domains/settings/components/adjust-plan-modal.tsx
@@ -50,7 +50,7 @@ import { CreditBundlePicker } from "./credit-bundle-picker";
 import { DowngradeReconfirmModal } from "./downgrade-reconfirm-modal";
 import { PlanFeatureList } from "./plan-feature-list";
 import { TierPicker, isTierDisabled } from "./tier-picker";
-import { formatDelta, formatMonthly } from "./tier-pricing";
+import { formatDelta, formatDollars, formatMonthly } from "./tier-pricing";
 
 
 /**
@@ -899,17 +899,9 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                                   as="p"
                                   variant="body-small-default"
                                   className="text-[var(--content-tertiary)]"
-                                >
-                                  Billed monthly
-                                </Typography>
-                                <Typography
-                                  as="p"
-                                  variant="body-small-default"
-                                  className="text-[var(--content-tertiary)]"
                                   data-testid="modal-pro-base-fee"
                                 >
-                                  Includes a {formatMonthly(plan.base_price_cents)}{" "}
-                                  base fee for Pro features.
+                                  {formatDollars(plan.base_price_cents)} base fee
                                 </Typography>
                               </>
                             )}

--- a/apps/web/src/domains/settings/components/tier-pricing.ts
+++ b/apps/web/src/domains/settings/components/tier-pricing.ts
@@ -9,12 +9,15 @@
  * than rounding to `$10/mo` in one place and `$9.95/mo` in another.
  */
 
+/** "$50" for whole-dollar amounts; "$50.50" only when cents are present. */
+export function formatDollars(cents: number): string {
+  const dollars = cents / 100;
+  return Number.isInteger(dollars) ? `$${dollars}` : `$${dollars.toFixed(2)}`;
+}
+
 /** "$50/mo" for whole-dollar amounts; "$50.50/mo" only when cents are present. */
 export function formatMonthly(cents: number): string {
-  const dollars = cents / 100;
-  return Number.isInteger(dollars)
-    ? `$${dollars}/mo`
-    : `$${dollars.toFixed(2)}/mo`;
+  return `${formatDollars(cents)}/mo`;
 }
 
 /**
@@ -23,9 +26,5 @@ export function formatMonthly(cents: number): string {
  */
 export function formatDelta(deltaCents: number): string {
   const prefix = deltaCents > 0 ? "+" : "−";
-  const absDollars = Math.abs(deltaCents) / 100;
-  const formatted = Number.isInteger(absDollars)
-    ? `$${absDollars}`
-    : `$${absDollars.toFixed(2)}`;
-  return `${prefix}${formatted}/mo`;
+  return `${prefix}${formatDollars(Math.abs(deltaCents))}/mo`;
 }


### PR DESCRIPTION
## Summary
- Remove the "Billed monthly" line under the Pro plan top-line price on the adjust-plan modal Pro card.
- Change the base-fee note from "Includes a $10/mo base fee for Pro features." to "$10 base fee".
- Extract a `formatDollars` helper in `tier-pricing` (cents-aware whole-dollar, no `/mo` suffix) and reuse it from `formatMonthly`/`formatDelta` to avoid duplicating the formatting rule.

## Original prompt
On the Pro plan card in the adjust-plan modal, remove the "billed monthly" text under the top-line price, and shorten the base-fee line from "Includes a $10/mo base fee for Pro features." to "$10 base fee" — tightening the pricing copy on the Pro card.