### PR TITLE
fix(macos): page-1-only refetch on conversation-list invalidation instead of full drain

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
@@ -676,8 +676,10 @@ final class ConversationRestorer {
 
     /// Trailing-edge debounce for `conversation_list_invalidated` events.
     /// Cancels any pending refetch and schedules a new one after 250 ms,
-    /// reusing the existing page-1 fetch + merge path so that selection,
-    /// scroll position, and per-conversation history are preserved.
+    /// then does a cheap page-1-only refetch (`refetchRecentConversations`)
+    /// that merges into the loaded list, preserving selection, scroll
+    /// position, and per-conversation history. This deliberately does NOT
+    /// re-drain the full paginated list — see `refetchRecentConversations`.
     /// If pagination is in flight, defers the refetch until pagination settles
     /// to avoid misrouting the page-1 response through the append path.
     func scheduleInvalidationRefetch() {
@@ -695,13 +697,19 @@ final class ConversationRestorer {
                 guard !Task.isCancelled else { return }
             }
             self.fetchConversationListTask?.cancel()
-            self.fetchConversationList()
+            self.refetchRecentConversations()
         }
     }
 
     // MARK: - Private
 
-    private func fetchConversationList() {
+    /// Full cold-start drain: fetches **every** conversation across the three
+    /// streams (foreground/background/archived), each paginated to exhaustion.
+    /// Used only on first connect and reconnect (see `startObserving`). The
+    /// frequent invalidation path uses `refetchRecentConversations` instead —
+    /// this drain is ~`pages × 3` requests and must not run on every
+    /// `conversation_list_invalidated` event.
+    func fetchConversationList() {
         fetchConversationListTask = Task { [weak self] in
             guard let self else { return }
             // Cap at 2 attempts to limit worst-case restore delay (~32s with 15s
@@ -764,6 +772,67 @@ final class ConversationRestorer {
             }
             log.warning("All \(maxAttempts) conversation list fetch attempts failed, falling back to last active conversation")
             self.delegate?.restoreLastActiveConversation()
+        }
+    }
+
+    /// Cheap refetch for `conversation_list_invalidated` events: fetches only
+    /// **page 1** of each stream (foreground/background/archived) — three
+    /// requests, no pagination loop — and merges into the loaded list.
+    ///
+    /// This relies on `handleConversationListResponse` being a merge (not a
+    /// replace) for an established user: it updates matched rows in place by
+    /// daemon id, prepends only brand-new rows, and keeps every already-loaded
+    /// row that isn't in the response. New conversations (the dominant shape
+    /// change) are most-recent and therefore on page 1, so they're picked up;
+    /// reorders/renames within the recent window are refreshed too.
+    ///
+    /// Pagination state is deliberately preserved: the merged response carries
+    /// `hasMore: nil` (so `hasMoreConversations` is not clobbered) and
+    /// `updateServerOffset: false` (so the "load more" cursor is untouched).
+    ///
+    /// Accepted tradeoff: a conversation deleted or reordered on another device
+    /// that sits OUTSIDE page 1 of all three streams won't be reflected until
+    /// the next cold-start/reconnect full drain (`fetchConversationList`).
+    /// That's fine — creation lands on page 1, single deletes are usually
+    /// optimistic-local on the deleting client, and reconnect re-drains fully.
+    private func refetchRecentConversations() {
+        fetchConversationListTask = Task { [weak self] in
+            guard let self else { return }
+            let pageSize = Self.conversationListPageSize
+            async let foregroundResult = self.conversationListClient.fetchConversationList(
+                offset: 0, limit: pageSize, conversationType: nil, archiveStatus: nil
+            )
+            async let backgroundResult = self.conversationListClient.fetchConversationList(
+                offset: 0, limit: pageSize, conversationType: "background", archiveStatus: nil
+            )
+            async let archivedResult = self.conversationListClient.fetchConversationList(
+                offset: 0, limit: pageSize, conversationType: nil, archiveStatus: "archived"
+            )
+            let foreground = await foregroundResult
+            let background = await backgroundResult
+            let archived = await archivedResult
+
+            // Best-effort: if the foreground page fails, leave the loaded list
+            // untouched. A subsequent invalidation or reconnect will retry.
+            guard let foreground else { return }
+
+            // Same dedup as the full drain: foreground ids win, then filter
+            // background/archived against them so overlapping rows from daemons
+            // that ignore the query params don't duplicate.
+            var seenIds = Set(foreground.conversations.map(\.id))
+            let uniqueBackground = (background?.conversations ?? []).filter {
+                seenIds.insert($0.id).inserted
+            }
+            let uniqueArchived = (archived?.conversations ?? []).filter {
+                seenIds.insert($0.id).inserted
+            }
+            let merged = ConversationListResponse(
+                type: foreground.type,
+                conversations: foreground.conversations + uniqueBackground + uniqueArchived,
+                hasMore: nil,
+                groups: foreground.groups
+            )
+            self.handleConversationListResponse(merged, updateServerOffset: false)
         }
     }
 

--- a/clients/macos/vellum-assistantTests/ConversationRestorerTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationRestorerTests.swift
@@ -1058,7 +1058,7 @@ struct ConversationRestorerTests {
     }
 
     @Test @MainActor
-    func syncConversationListRouteTriggersFullRefetchNotSingleRow() async {
+    func syncConversationListRouteTriggersRecentRefetchNotSingleRow() async {
         let dc = GatewayConnectionManager()
         let listClient = RecordingConversationListClient()
         let detailClient = RecordingConversationDetailClient()
@@ -1076,11 +1076,61 @@ struct ConversationRestorerTests {
 
         try? await Task.sleep(nanoseconds: 500_000_000)
 
-        // A shape change refetches the full list (3 parallel streams: foreground,
-        // background, archived)...
+        // A shape change triggers a cheap page-1 refetch of the 3 streams
+        // (foreground, background, archived) — NOT a full paginated drain, and
+        // NOT the single-conversation endpoint (RecordingConversationListClient
+        // returns one empty page per stream, so exactly 3 requests).
         #expect(await listClient.fetchRequests.count == 3)
-        // ...and never falls back to the single-conversation endpoint.
+        #expect(await listClient.fetchRequests.allSatisfy { $0.offset == 0 })
         #expect(await detailClient.fetchedConversationIds.isEmpty)
+    }
+
+    @Test @MainActor
+    func invalidationRefetchFetchesRecentPageOnlyAndPreservesExistingRows() async {
+        let dc = GatewayConnectionManager()
+        // totalForeground 450 / background 700 means a full drain would paginate
+        // (3 + 4 pages); a page-1-only refetch must issue exactly one request
+        // per stream at offset 0.
+        let listClient = PagedConversationListClient(totalForeground: 450, totalBackground: 700)
+        let restorer = ConversationRestorer(
+            connectionManager: dc,
+            eventStreamClient: dc.eventStreamClient,
+            conversationHistoryClient: NoopConversationHistoryClient(),
+            conversationListClient: listClient
+        )
+        let delegate = MockConversationRestorerDelegate(connectionManager: dc, eventStreamClient: dc.eventStreamClient)
+        restorer.delegate = delegate
+
+        // Seed two already-loaded rows that the page-1 fetch will NOT return,
+        // plus sentinel pagination state that a recent refetch must not reset.
+        delegate.conversations = [
+            ConversationModel(title: "Old 1", conversationId: "old-1"),
+            ConversationModel(title: "Old 2", conversationId: "old-2"),
+        ]
+        delegate.serverOffset = 999
+        delegate.hasMoreConversations = true
+
+        restorer.scheduleInvalidationRefetch()
+        // 250ms debounce + the (fast, non-paginating) 3-stream page-1 fetch.
+        try? await Task.sleep(nanoseconds: 800_000_000)
+
+        let requests = await listClient.fetchRequests
+        // Exactly one request per stream, all at offset 0 — no pagination loop.
+        #expect(requests.count == 3)
+        #expect(requests.allSatisfy { $0.offset == 0 })
+        #expect(requests.contains { $0.conversationType == nil && $0.archiveStatus == nil })
+        #expect(requests.contains { $0.conversationType == "background" })
+        #expect(requests.contains { $0.archiveStatus == "archived" })
+
+        // The out-of-window rows are preserved (merge, not replace)...
+        #expect(delegate.conversations.contains { $0.conversationId == "old-1" })
+        #expect(delegate.conversations.contains { $0.conversationId == "old-2" })
+        // ...and the recent page-1 rows were merged in.
+        #expect(delegate.conversations.contains { $0.conversationId == "fg-0" })
+
+        // Pagination state is untouched by the recent refetch.
+        #expect(delegate.serverOffset == 999)
+        #expect(delegate.hasMoreConversations == true)
     }
 
     @Test @MainActor
@@ -1096,10 +1146,12 @@ struct ConversationRestorerTests {
         let delegate = MockConversationRestorerDelegate(connectionManager: dc, eventStreamClient: dc.eventStreamClient)
         restorer.delegate = delegate
 
-        restorer.scheduleInvalidationRefetch()
+        // Cold-start full drain — the path that paginates every stream to
+        // exhaustion. The invalidation path is now page-1-only, so exercise the
+        // drain directly via fetchConversationList().
+        restorer.fetchConversationList()
 
-        // scheduleInvalidationRefetch debounces 250ms before fetching; give the
-        // pagination loop enough time to drain both endpoints.
+        // Give the pagination loop enough time to drain both endpoints.
         try? await Task.sleep(nanoseconds: 1_500_000_000)
 
         // Foreground (archiveStatus == nil → daemon active default): 450 rows
@@ -1143,7 +1195,9 @@ struct ConversationRestorerTests {
         let delegate = MockConversationRestorerDelegate(connectionManager: dc, eventStreamClient: dc.eventStreamClient)
         restorer.delegate = delegate
 
-        restorer.scheduleInvalidationRefetch()
+        // Cold-start full drain — exercised directly (the invalidation path is
+        // page-1-only and would not paginate the archived stream).
+        restorer.fetchConversationList()
         try? await Task.sleep(nanoseconds: 1_500_000_000)
 
         let requests = await listClient.fetchRequests


### PR DESCRIPTION
## Summary
- After #33588 (fix #1) narrowed the per-conversation `metadata`/`messages` tags, the remaining 429 driver is the broad `conversationsList` tag (genuine shape changes — created/deleted/reordered), which still ran the full `fetchConversationList()` drain: 3 streams paginated to exhaustion, ~80 `GET /v1/conversations` over 10k+ conversations.
- `scheduleInvalidationRefetch` now calls a new `refetchRecentConversations()` that fetches only **page 1** of each stream (3 requests) and merges into the loaded list. Safe because `handleConversationListResponse` already merges (updates matched rows, prepends new, keeps out-of-window rows) rather than replaces — and new conversations are most-recent, so they land on page 1.
- Pagination state is preserved: the merged response carries `hasMore: nil` + `updateServerOffset: false`, so `hasMoreConversations`/`serverOffset` (the "load more" cursor) are untouched.
- The full drain (`fetchConversationList`, now internal) is unchanged and used only for cold start / reconnect.
- **Accepted tradeoff** (documented in-code): a delete/reorder on another device that's outside page 1 of all 3 streams isn't reflected until the next cold-start/reconnect drain — creation lands on page 1, single deletes are optimistic-local, and reconnect re-drains fully.

## Original prompt
Second of two fixes for the macOS 429 storm traced earlier in this session. Fix #1 (#33588) stopped narrow per-conversation tags from refetching the whole list; fix #2 makes the *genuine* list refetch cheap so the frequent `conversationsList` shape-change events (driven by heavy background/scheduled conversation creation) cost ~3 requests instead of ~80, without re-draining all 10k+ conversations on every invalidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)