### PR TITLE
Resume persisted ACP sessions from history and steer them transparently

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -95,7 +95,9 @@ paths:
     post:
       operationId: acp_by_id_steer_post
       summary: Steer ACP session
-      description: Send a steering instruction to an active ACP session.
+      description:
+        Send a steering instruction to an ACP session. Sessions no longer in memory (completed, or lost to a daemon
+        restart) are transparently resumed from persisted history first, when the agent supports ACP session loading.
       tags:
         - acp
       responses:
@@ -109,6 +111,9 @@ paths:
                   acpSessionId:
                     type: string
                   steered:
+                    type: boolean
+                  resumed:
+                    description: True when the session was resumed from persisted history before steering.
                     type: boolean
                 required:
                   - acpSessionId

--- a/assistant/src/acp/__tests__/session-manager-persistence.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-persistence.test.ts
@@ -379,6 +379,52 @@ describe("AcpSessionManager — terminal persistence", () => {
     expect(row!.cwd).toBeNull();
   });
 
+  test("upserts over a pre-existing row with the same id (resumed runs)", async () => {
+    const id = "session-upsert-1";
+    // Simulate the row left behind by the original run that a resumed run
+    // reuses the id of.
+    getSqlite().run(
+      `INSERT INTO acp_session_history (
+         id, agent_id, acp_session_id, parent_conversation_id,
+         started_at, completed_at, status, stop_reason, event_log_json, cwd
+       ) VALUES ('${id}', 'agent-up', 'proto-up', 'conv-up',
+                 1000, 2000, 'cancelled', 'daemon_restarted', '[{"old":true}]', '/old/cwd')`,
+    );
+
+    const handles = buildSessionWithFakeProcess({
+      id,
+      agentId: "agent-up",
+      protocolSessionId: "proto-up",
+      parentConversationId: "conv-up",
+      cwd: "/new/cwd",
+    });
+
+    handles.emitUpdate({
+      type: "acp_session_update",
+      acpSessionId: id,
+      updateType: "agent_message_chunk",
+      content: "from the resumed run",
+    });
+
+    handles.resolvePrompt({ stopReason: "end_turn" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const count = getSqlite()
+      .query(`SELECT COUNT(*) AS n FROM acp_session_history WHERE id = ?`)
+      .get(id) as { n: number };
+    expect(count.n).toBe(1);
+
+    const row = readHistoryRow(id);
+    expect(row).not.toBeNull();
+    expect(row!.status).toBe("completed");
+    expect(row!.stop_reason).toBe("end_turn");
+    expect(row!.cwd).toBe("/new/cwd");
+    const log = JSON.parse(row!.event_log_json) as AcpSessionUpdate[];
+    expect(log).toHaveLength(1);
+    expect(log[0]).toMatchObject({ content: "from the resumed run" });
+  });
+
   test("persists empty event log when no updates were emitted", async () => {
     const id = "session-empty-1";
     const handles = buildSessionWithFakeProcess({

--- a/assistant/src/acp/__tests__/session-manager-resume.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-resume.test.ts
@@ -1,0 +1,426 @@
+/**
+ * Tests for AcpSessionManager.resumeFromHistory: reattaching a terminal
+ * persisted session via ACP session/resume (preferred, no replay) or
+ * session/load (replayed history suppressed), plus the terminal upsert
+ * that lets a resumed run update its original history row.
+ *
+ * The agent process is replaced with a fake whose capabilities and replay
+ * behavior are scripted per test; the client handler is the real
+ * VellumAcpClientHandler so replay suppression is exercised end to end.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// ---------------------------------------------------------------------------
+// Fake AcpAgentProcess with scriptable capabilities and history replay.
+// ---------------------------------------------------------------------------
+
+interface FakeClient {
+  sessionUpdate(params: unknown): Promise<void>;
+}
+
+const fakeCaps = { loadSession: false, resume: false };
+/** Chunks the fake replays through the client handler during loadSession. */
+let replayChunks: string[] = [];
+const fakeInstances: FakeAcpAgentProcess[] = [];
+
+class FakeAcpAgentProcess {
+  killed = false;
+  spawnedCwd: string | null = null;
+  loadSessionCalls: Array<{ sessionId: string; cwd: string }> = [];
+  resumeSessionCalls: Array<{ sessionId: string; cwd: string }> = [];
+  promptCalls: Array<{ sessionId: string; text: string }> = [];
+  resolvePrompt: ((v: { stopReason: string }) => void) | null = null;
+
+  constructor(
+    public readonly agentId: string,
+    public readonly config: { command: string },
+    private readonly clientFactory: (agent: unknown) => FakeClient,
+  ) {
+    fakeInstances.push(this);
+  }
+
+  spawn(cwd: string): void {
+    this.spawnedCwd = cwd;
+  }
+
+  async initialize(): Promise<void> {}
+
+  get supportsLoadSession(): boolean {
+    return fakeCaps.loadSession;
+  }
+
+  get supportsSessionResume(): boolean {
+    return fakeCaps.resume;
+  }
+
+  async createSession(_cwd: string): Promise<string> {
+    return "proto-new";
+  }
+
+  async loadSession(sessionId: string, cwd: string): Promise<void> {
+    this.loadSessionCalls.push({ sessionId, cwd });
+    // Replay history through the client handler before resolving, exactly
+    // as a real agent does per the ACP spec for session/load.
+    for (const text of replayChunks) {
+      await this.emitChunk(text);
+    }
+  }
+
+  async resumeSession(sessionId: string, cwd: string): Promise<void> {
+    this.resumeSessionCalls.push({ sessionId, cwd });
+  }
+
+  /** Drives an agent_message_chunk through the real client handler. */
+  async emitChunk(text: string): Promise<void> {
+    await this.clientFactory(this).sessionUpdate({
+      sessionId: "proto-old",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text },
+      },
+    });
+  }
+
+  prompt(sessionId: string, text: string): Promise<{ stopReason: string }> {
+    this.promptCalls.push({ sessionId, text });
+    return new Promise((res) => {
+      this.resolvePrompt = res;
+    });
+  }
+
+  async cancel(): Promise<void> {}
+
+  kill(): void {
+    this.killed = true;
+  }
+}
+
+mock.module("../agent-process.js", () => ({
+  AcpAgentProcess: FakeAcpAgentProcess,
+}));
+
+// Identity env-prep: credential-broker plumbing has its own suite.
+mock.module("../prepare-agent-env.js", () => ({
+  prepareAgentEnv: async (agentConfig: unknown) => agentConfig,
+}));
+
+// Resolver stub: defaults to resolving every id to the claude adapter.
+type ResolveResult =
+  | { ok: true; agent: { command: string; args: string[] } }
+  | { ok: false; reason: "binary_not_found"; hint: string; command: string };
+let resolveImpl: (id: string) => ResolveResult = () => ({
+  ok: true,
+  agent: { command: "claude-agent-acp", args: [] },
+});
+const realResolveModule = await import("../resolve-agent.js");
+mock.module("../resolve-agent.js", () => ({
+  ...realResolveModule,
+  resolveAcpAgent: (id: string) => resolveImpl(id),
+}));
+
+import type { ServerMessage } from "../../daemon/message-protocol.js";
+import type { AcpSessionUpdate } from "../../daemon/message-types/acp.js";
+import { getSqlite } from "../../memory/db-connection.js";
+import { initializeDb } from "../../memory/db-init.js";
+import type { AcpSessionState } from "../types.js";
+
+const { AcpSessionManager } = await import("../session-manager.js");
+
+initializeDb();
+
+// ---------------------------------------------------------------------------
+// DB helpers
+// ---------------------------------------------------------------------------
+
+function clearHistory(): void {
+  getSqlite().run("DELETE FROM acp_session_history");
+}
+
+function insertHistoryRow(row: {
+  id: string;
+  agentId?: string;
+  acpSessionId?: string;
+  parentConversationId?: string;
+  startedAt?: number;
+  status?: string;
+  cwd?: string | null;
+  eventLogJson?: string;
+}): void {
+  getSqlite()
+    .query(
+      `INSERT INTO acp_session_history (
+         id, agent_id, acp_session_id, parent_conversation_id,
+         started_at, completed_at, status, stop_reason, error,
+         event_log_json, cwd
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      row.id,
+      row.agentId ?? "claude",
+      row.acpSessionId ?? "proto-old",
+      row.parentConversationId ?? "conv-1",
+      row.startedAt ?? 1234,
+      5678,
+      row.status ?? "completed",
+      "end_turn",
+      null,
+      row.eventLogJson ?? "[]",
+      row.cwd === undefined ? "/tmp/proj" : row.cwd,
+    );
+}
+
+interface HistoryRow {
+  id: string;
+  started_at: number;
+  status: string;
+  stop_reason: string | null;
+  event_log_json: string;
+  cwd: string | null;
+}
+
+function readHistoryRow(id: string): HistoryRow | null {
+  return getSqlite()
+    .query(
+      `SELECT id, started_at, status, stop_reason, event_log_json, cwd
+       FROM acp_session_history WHERE id = ?`,
+    )
+    .get(id) as HistoryRow | null;
+}
+
+function countHistoryRows(): number {
+  const row = getSqlite()
+    .query("SELECT COUNT(*) AS n FROM acp_session_history")
+    .get() as { n: number };
+  return row.n;
+}
+
+// ---------------------------------------------------------------------------
+// Manager internals accessors (mirrors session-manager-persistence.test.ts)
+// ---------------------------------------------------------------------------
+
+type ManagerInternals = {
+  sessions: Map<string, { clientHandler: FakeClient }>;
+  eventBuffers: Map<string, Array<{ update: AcpSessionUpdate }>>;
+};
+
+function internals(
+  manager: InstanceType<typeof AcpSessionManager>,
+): ManagerInternals {
+  return manager as unknown as ManagerInternals;
+}
+
+beforeEach(() => {
+  clearHistory();
+  fakeInstances.length = 0;
+  fakeCaps.loadSession = false;
+  fakeCaps.resume = false;
+  replayChunks = [];
+  resolveImpl = () => ({
+    ok: true,
+    agent: { command: "claude-agent-acp", args: [] },
+  });
+});
+
+const PERSISTED_EVENT: AcpSessionUpdate = {
+  type: "acp_session_update",
+  acpSessionId: "resume-1",
+  updateType: "agent_message_chunk",
+  content: "original-run-chunk",
+};
+
+describe("AcpSessionManager.resumeFromHistory", () => {
+  test("resumes via session/load with replay suppressed, then steers the loaded session", async () => {
+    fakeCaps.loadSession = true;
+    replayChunks = ["replayed-1", "replayed-2"];
+    insertHistoryRow({
+      id: "resume-1",
+      eventLogJson: JSON.stringify([PERSISTED_EVENT]),
+    });
+
+    const manager = new AcpSessionManager(4);
+    const sent: ServerMessage[] = [];
+    await manager.resumeFromHistory("resume-1", (msg) => sent.push(msg));
+
+    const fake = fakeInstances[0]!;
+    expect(fake.spawnedCwd).toBe("/tmp/proj");
+    expect(fake.loadSessionCalls).toEqual([
+      { sessionId: "proto-old", cwd: "/tmp/proj" },
+    ]);
+    expect(fake.resumeSessionCalls).toEqual([]);
+
+    // Replayed history was never forwarded to the sender; only the
+    // spawned event went out.
+    expect(sent.filter((m) => m.type === "acp_session_update")).toEqual([]);
+    expect(sent).toEqual([
+      {
+        type: "acp_session_spawned",
+        acpSessionId: "resume-1",
+        agent: "claude",
+        parentConversationId: "conv-1",
+      },
+    ]);
+
+    // State reuses the row's identity and is running again.
+    const state = manager.getStatus("resume-1") as AcpSessionState;
+    expect(state).toMatchObject({
+      id: "resume-1",
+      agentId: "claude",
+      acpSessionId: "proto-old",
+      parentConversationId: "conv-1",
+      status: "running",
+      startedAt: 1234,
+    });
+
+    // Ring buffer was re-seeded from the persisted log only; the replay
+    // never reached it.
+    const buffer = internals(manager).eventBuffers.get("resume-1")!;
+    expect(buffer.map((b) => b.update)).toEqual([PERSISTED_EVENT]);
+
+    // Updates after the load flow normally (suppression ended).
+    await fake.emitChunk("live-after-load");
+    expect(sent.filter((m) => m.type === "acp_session_update")).toHaveLength(1);
+    expect(internals(manager).eventBuffers.get("resume-1")).toHaveLength(2);
+
+    // The agent receives the new prompt in the loaded session.
+    await manager.steer("resume-1", "follow up please");
+    expect(fake.promptCalls).toEqual([
+      { sessionId: "proto-old", text: "follow up please" },
+    ]);
+  });
+
+  test("prefers session/resume when advertised and never calls loadSession", async () => {
+    fakeCaps.loadSession = true;
+    fakeCaps.resume = true;
+    insertHistoryRow({ id: "resume-2" });
+
+    const manager = new AcpSessionManager(4);
+    await manager.resumeFromHistory("resume-2", () => {});
+
+    const fake = fakeInstances[0]!;
+    expect(fake.resumeSessionCalls).toEqual([
+      { sessionId: "proto-old", cwd: "/tmp/proj" },
+    ]);
+    expect(fake.loadSessionCalls).toEqual([]);
+    const state = manager.getStatus("resume-2") as AcpSessionState;
+    expect(state.status).toBe("running");
+  });
+
+  test("legacy row with null cwd raises an actionable error", async () => {
+    insertHistoryRow({ id: "legacy-1", cwd: null });
+
+    const manager = new AcpSessionManager(4);
+    await expect(
+      manager.resumeFromHistory("legacy-1", () => {}),
+    ).rejects.toThrow(/recorded before resume support/);
+    expect(fakeInstances).toHaveLength(0);
+  });
+
+  test("missing row raises the spawn-style not-found error", async () => {
+    const manager = new AcpSessionManager(4);
+    await expect(manager.resumeFromHistory("nope-1", () => {})).rejects.toThrow(
+      'ACP session "nope-1" not found',
+    );
+  });
+
+  test("row with an empty protocol session id raises an actionable error", async () => {
+    insertHistoryRow({ id: "no-proto-1", acpSessionId: "" });
+
+    const manager = new AcpSessionManager(4);
+    await expect(
+      manager.resumeFromHistory("no-proto-1", () => {}),
+    ).rejects.toThrow(/no protocol session id/);
+  });
+
+  test("agent without either capability errors and kills the process", async () => {
+    insertHistoryRow({ id: "no-caps-1" });
+
+    const manager = new AcpSessionManager(4);
+    await expect(
+      manager.resumeFromHistory("no-caps-1", () => {}),
+    ).rejects.toThrow('ACP agent "claude" does not support session resume');
+
+    const fake = fakeInstances[0]!;
+    expect(fake.killed).toBe(true);
+    expect(internals(manager).sessions.has("no-caps-1")).toBe(false);
+    expect(internals(manager).eventBuffers.has("no-caps-1")).toBe(false);
+  });
+
+  test("resolver failures surface the actionable hint", async () => {
+    insertHistoryRow({ id: "no-bin-1" });
+    resolveImpl = () => ({
+      ok: false,
+      reason: "binary_not_found",
+      hint: "npm i -g @agentclientprotocol/claude-agent-acp",
+      command: "claude-agent-acp",
+    });
+
+    const manager = new AcpSessionManager(4);
+    await expect(
+      manager.resumeFromHistory("no-bin-1", () => {}),
+    ).rejects.toThrow(
+      "claude-agent-acp is not on PATH. npm i -g @agentclientprotocol/claude-agent-acp",
+    );
+  });
+
+  test("already-active id and concurrency limit reuse spawn's guards", async () => {
+    fakeCaps.resume = true;
+    insertHistoryRow({ id: "active-1" });
+
+    const manager = new AcpSessionManager(4);
+    await manager.resumeFromHistory("active-1", () => {});
+    await expect(
+      manager.resumeFromHistory("active-1", () => {}),
+    ).rejects.toThrow('ACP session "active-1" is already active');
+
+    const full = new AcpSessionManager(0);
+    await expect(full.resumeFromHistory("active-1", () => {})).rejects.toThrow(
+      /ACP concurrency limit reached \(max 0\)/,
+    );
+  });
+
+  test("terminal persistence after a resumed run upserts the original row with the merged event log", async () => {
+    fakeCaps.resume = true;
+    insertHistoryRow({
+      id: "resume-up-1",
+      eventLogJson: JSON.stringify([PERSISTED_EVENT]),
+    });
+
+    const manager = new AcpSessionManager(4);
+    await manager.resumeFromHistory("resume-up-1", () => {});
+    await manager.steer("resume-up-1", "continue the work");
+
+    const fake = fakeInstances[0]!;
+    expect(fake.promptCalls).toEqual([
+      { sessionId: "proto-old", text: "continue the work" },
+    ]);
+
+    // A new update lands during the resumed run.
+    await fake.emitChunk("resumed-run-chunk");
+
+    // Drive the prompt to completion; yield twice to flush the .then()
+    // and the persist call queued behind it.
+    fake.resolvePrompt!({ stopReason: "end_turn" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(countHistoryRows()).toBe(1);
+    const row = readHistoryRow("resume-up-1")!;
+    expect(row.status).toBe("completed");
+    expect(row.stop_reason).toBe("end_turn");
+    expect(row.started_at).toBe(1234);
+    expect(row.cwd).toBe("/tmp/proj");
+
+    const log = JSON.parse(row.event_log_json) as Array<{ content?: string }>;
+    expect(log).toHaveLength(2);
+    expect(log[0]!.content).toBe("original-run-chunk");
+    expect(log[1]!.content).toBe("resumed-run-chunk");
+  });
+});

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -5,7 +5,7 @@
 
 import { randomUUID } from "node:crypto";
 
-import { inArray } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 
 import { findConversation } from "../daemon/conversation-store.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
@@ -16,9 +16,30 @@ import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { getLogger } from "../util/logger.js";
 import { AcpAgentProcess } from "./agent-process.js";
 import { VellumAcpClientHandler } from "./client-handler.js";
+import { prepareAgentEnv } from "./prepare-agent-env.js";
+import { resolveAcpAgent } from "./resolve-agent.js";
 import type { AcpAgentConfig, AcpSessionState } from "./types.js";
 
 const log = getLogger("acp:session-manager");
+
+/** Single source of truth for the "unknown session id" error message. */
+function sessionNotFoundMessage(acpSessionId: string): string {
+  return `ACP session "${acpSessionId}" not found`;
+}
+
+/**
+ * Whether `err` is the manager's "unknown session id" error for
+ * `acpSessionId`. Callers (acp_steer tool, /v1/acp/:id/steer route) use this
+ * to decide when a failed steer should fall back to resumeFromHistory.
+ */
+export function isAcpSessionNotFoundError(
+  err: unknown,
+  acpSessionId: string,
+): boolean {
+  return (
+    err instanceof Error && err.message === sessionNotFoundMessage(acpSessionId)
+  );
+}
 
 /** Maximum number of update events kept in a session's ring buffer. */
 const MAX_BUFFER_EVENTS = 200;
@@ -124,54 +145,16 @@ export class AcpSessionManager {
       "ACP spawn requested",
     );
 
-    // Initialize the per-session ring buffer before any update can fire.
-    this.eventBuffers.set(acpSessionId, []);
-
-    // Wrap the sender so every emitted message is mirrored into the buffer
-    // when it's an `acp_session_update`. The wrapper preserves the original
-    // call semantics — it forwards every message unchanged.
-    const wrappedSend = (msg: ServerMessage) => {
-      if (msg.type === "acp_session_update") {
-        this.appendToBuffer(acpSessionId, msg);
-      }
-      sendToVellum(msg);
-    };
-
-    const clientHandler = new VellumAcpClientHandler(
+    const entry = this.registerSession({
       acpSessionId,
-      wrappedSend,
-      parentConversationId,
-    );
-
-    const agentProcess = new AcpAgentProcess(
       agentId,
       agentConfig,
-      (_agent) => clientHandler,
-    );
-
-    // Reserve a slot in the map before any async work to enforce the
-    // concurrency limit even when multiple spawn() calls race.
-    const state: AcpSessionState = {
-      id: acpSessionId,
-      agentId,
-      acpSessionId: "", // placeholder until createSession resolves
-      parentConversationId,
-      status: "initializing",
-      startedAt: Date.now(),
-    };
-
-    const entry: SessionEntry = {
-      process: agentProcess,
-      state,
-      clientHandler,
-      sendToVellum: wrappedSend,
-      currentPrompt: null,
       parentConversationId,
       cwd,
-      command: agentConfig.command,
-    };
-
-    this.sessions.set(acpSessionId, entry);
+      startedAt: Date.now(),
+      sendToVellum,
+    });
+    const { process: agentProcess, state, sendToVellum: wrappedSend } = entry;
 
     try {
       log.info({ acpSessionId, agentId }, "ACP spawning child process");
@@ -217,6 +200,239 @@ export class AcpSessionManager {
   }
 
   /**
+   * Wires up the in-memory plumbing shared by spawn() and
+   * resumeFromHistory(): the per-session ring buffer, the buffer-mirroring
+   * sender, the client handler, the agent process, and the SessionEntry.
+   * Registers the entry in the session map (reserving a concurrency slot
+   * before any async work) and returns it. Does NOT start the process.
+   */
+  private registerSession(opts: {
+    acpSessionId: string;
+    agentId: string;
+    agentConfig: AcpAgentConfig;
+    parentConversationId: string;
+    cwd: string;
+    startedAt: number;
+    sendToVellum: (msg: ServerMessage) => void;
+  }): SessionEntry {
+    const { acpSessionId } = opts;
+
+    // Initialize the per-session ring buffer before any update can fire.
+    this.eventBuffers.set(acpSessionId, []);
+
+    // Wrap the sender so every emitted message is mirrored into the buffer
+    // when it's an `acp_session_update`. The wrapper preserves the original
+    // call semantics: it forwards every message unchanged.
+    const wrappedSend = (msg: ServerMessage) => {
+      if (msg.type === "acp_session_update") {
+        this.appendToBuffer(acpSessionId, msg);
+      }
+      opts.sendToVellum(msg);
+    };
+
+    const clientHandler = new VellumAcpClientHandler(
+      acpSessionId,
+      wrappedSend,
+      opts.parentConversationId,
+    );
+
+    const agentProcess = new AcpAgentProcess(
+      opts.agentId,
+      opts.agentConfig,
+      (_agent) => clientHandler,
+    );
+
+    const state: AcpSessionState = {
+      id: acpSessionId,
+      agentId: opts.agentId,
+      acpSessionId: "", // placeholder until createSession/resume resolves
+      parentConversationId: opts.parentConversationId,
+      status: "initializing",
+      startedAt: opts.startedAt,
+    };
+
+    const entry: SessionEntry = {
+      process: agentProcess,
+      state,
+      clientHandler,
+      sendToVellum: wrappedSend,
+      currentPrompt: null,
+      parentConversationId: opts.parentConversationId,
+      cwd: opts.cwd,
+      command: opts.agentConfig.command,
+    };
+
+    this.sessions.set(acpSessionId, entry);
+    return entry;
+  }
+
+  /**
+   * Resumes a terminal-state session from its persisted
+   * `acp_session_history` row, reattaching to the agent's stored
+   * conversation via ACP `session/resume` (preferred: no history replay) or
+   * `session/load` (replayed history is suppressed; see
+   * VellumAcpClientHandler.beginReplaySuppression).
+   *
+   * The resumed session reuses the original vellum session id,
+   * parentConversationId, and startedAt, and re-seeds its ring buffer from
+   * the persisted event log so the terminal upsert after the resumed run
+   * merges new events into the original row instead of losing them.
+   *
+   * Throws with an actionable message when the row is missing, was recorded
+   * before resume support (no cwd), the agent cannot be resolved, or the
+   * agent advertises neither resume capability.
+   */
+  async resumeFromHistory(
+    acpSessionId: string,
+    sendToVellum: (msg: ServerMessage) => void,
+  ): Promise<void> {
+    if (this.sessions.has(acpSessionId)) {
+      throw new Error(`ACP session "${acpSessionId}" is already active`);
+    }
+    if (this.sessions.size >= this.maxConcurrent) {
+      throw new Error(
+        `ACP concurrency limit reached (max ${this.maxConcurrent}). ` +
+          `Close an existing session before spawning a new one.`,
+      );
+    }
+
+    const row = getDb()
+      .select()
+      .from(acpSessionHistory)
+      .where(eq(acpSessionHistory.id, acpSessionId))
+      .get();
+    if (!row) {
+      throw new Error(sessionNotFoundMessage(acpSessionId));
+    }
+    if (!row.cwd) {
+      throw new Error(
+        `ACP session "${acpSessionId}" was recorded before resume support ` +
+          `(no working directory persisted) and cannot be resumed. ` +
+          `Spawn a new session instead.`,
+      );
+    }
+    if (!row.acpSessionId) {
+      throw new Error(
+        `ACP session "${acpSessionId}" has no protocol session id ` +
+          `persisted and cannot be resumed. Spawn a new session instead.`,
+      );
+    }
+
+    const resolved = resolveAcpAgent(row.agentId);
+    if (!resolved.ok) {
+      switch (resolved.reason) {
+        case "acp_disabled":
+          throw new Error(resolved.hint);
+        case "unknown_agent":
+          throw new Error(
+            `Unknown agent "${row.agentId}". Available: ${resolved.available.join(", ")}.`,
+          );
+        case "binary_not_found":
+          throw new Error(
+            `${resolved.command} is not on PATH. ${resolved.hint}`,
+          );
+        default: {
+          const _exhaustive: never = resolved;
+          throw new Error(
+            `Unexpected acp resolver reason: ${(_exhaustive as { reason: string }).reason}`,
+          );
+        }
+      }
+    }
+    const agentConfig = await prepareAgentEnv(resolved.agent);
+
+    log.info(
+      { acpSessionId, agentId: row.agentId, cwd: row.cwd },
+      "ACP resume from history requested",
+    );
+
+    const entry = this.registerSession({
+      acpSessionId,
+      agentId: row.agentId,
+      agentConfig,
+      parentConversationId: row.parentConversationId,
+      cwd: row.cwd,
+      startedAt: row.startedAt,
+      sendToVellum,
+    });
+    const { process: agentProcess, state, sendToVellum: wrappedSend } = entry;
+
+    // Re-seed the ring buffer from the persisted event log, routed through
+    // appendToBuffer so the count/byte caps still apply. The terminal
+    // upsert then persists the merged (old + new) log.
+    try {
+      const persisted = JSON.parse(row.eventLogJson) as unknown;
+      if (Array.isArray(persisted)) {
+        for (const update of persisted) {
+          this.appendToBuffer(acpSessionId, update as AcpSessionUpdate);
+        }
+      }
+    } catch (err) {
+      log.warn(
+        { acpSessionId, err },
+        "Failed to re-seed ACP event buffer from persisted history",
+      );
+    }
+
+    try {
+      log.info(
+        { acpSessionId, agentId: row.agentId },
+        "ACP spawning child process for resume",
+      );
+      agentProcess.spawn(row.cwd);
+      await agentProcess.initialize();
+      if (agentProcess.supportsSessionResume) {
+        // session/resume reattaches without replaying history.
+        await agentProcess.resumeSession(row.acpSessionId, row.cwd);
+      } else if (agentProcess.supportsLoadSession) {
+        // session/load replays the full history as session/update
+        // notifications before resolving; suppress forwarding so the
+        // conversation and ring buffer don't receive duplicates.
+        entry.clientHandler.beginReplaySuppression();
+        try {
+          await agentProcess.loadSession(row.acpSessionId, row.cwd);
+        } finally {
+          entry.clientHandler.endReplaySuppression();
+        }
+      } else {
+        throw new Error(
+          `ACP agent "${row.agentId}" does not support session resume`,
+        );
+      }
+      state.acpSessionId = row.acpSessionId;
+      state.status = "running";
+      log.info(
+        {
+          acpSessionId,
+          agentId: row.agentId,
+          protocolSessionId: row.acpSessionId,
+        },
+        "ACP session resumed",
+      );
+    } catch (err) {
+      log.error(
+        { acpSessionId, agentId: row.agentId, err },
+        "ACP resume failed",
+      );
+      // Kill the orphaned child process and remove the reserved slot.
+      agentProcess.kill();
+      this.sessions.delete(acpSessionId);
+      this.eventBuffers.delete(acpSessionId);
+      throw err;
+    }
+
+    // Reuse the existing spawned event so connected clients render the
+    // session. A dedicated acp_session_resumed event is a possible
+    // follow-up, not in scope here.
+    wrappedSend({
+      type: "acp_session_spawned",
+      acpSessionId,
+      agent: row.agentId,
+      parentConversationId: row.parentConversationId,
+    });
+  }
+
+  /**
    * Sends a follow-up instruction to an existing session.
    *
    * Cancels any in-flight prompt first, then fires the new prompt in the
@@ -225,7 +441,7 @@ export class AcpSessionManager {
   async steer(acpSessionId: string, instruction: string): Promise<void> {
     const entry = this.sessions.get(acpSessionId);
     if (!entry) {
-      throw new Error(`ACP session "${acpSessionId}" not found`);
+      throw new Error(sessionNotFoundMessage(acpSessionId));
     }
 
     if (entry.state.status !== "running") {
@@ -269,7 +485,7 @@ export class AcpSessionManager {
   async cancel(acpSessionId: string): Promise<void> {
     const entry = this.sessions.get(acpSessionId);
     if (!entry) {
-      throw new Error(`ACP session "${acpSessionId}" not found`);
+      throw new Error(sessionNotFoundMessage(acpSessionId));
     }
     await entry.process.cancel(entry.state.acpSessionId);
     entry.state.status = "cancelled";
@@ -288,7 +504,7 @@ export class AcpSessionManager {
   close(acpSessionId: string): void {
     const entry = this.sessions.get(acpSessionId);
     if (!entry) {
-      throw new Error(`ACP session "${acpSessionId}" not found`);
+      throw new Error(sessionNotFoundMessage(acpSessionId));
     }
     if (
       entry.state.status === "running" ||
@@ -335,7 +551,7 @@ export class AcpSessionManager {
     if (acpSessionId) {
       const entry = this.sessions.get(acpSessionId);
       if (!entry) {
-        throw new Error(`ACP session "${acpSessionId}" not found`);
+        throw new Error(sessionNotFoundMessage(acpSessionId));
       }
       return entry.state;
     }
@@ -368,15 +584,18 @@ export class AcpSessionManager {
 
   /**
    * Persists the session's final state + buffered event log to
-   * `acp_session_history`, then frees the buffer entry. Best-effort: a DB
-   * failure is logged but does not propagate, since the session has already
-   * reached a terminal state and clients have been notified.
+   * `acp_session_history`, then frees the buffer entry. Upserts on id:
+   * resumed runs reuse the original vellum session id, so their terminal
+   * write must update the existing row (status, event log, etc.) instead of
+   * being silently skipped. Best-effort: a DB failure is logged but does
+   * not propagate, since the session has already reached a terminal state
+   * and clients have been notified.
    */
   private persistTerminal(acpSessionId: string, entry: SessionEntry): void {
     const buffer = this.eventBuffers.get(acpSessionId) ?? [];
     // Serialize only the wire-shaped updates — drop the byte-size accounting
     // metadata so persisted rows match the protocol shape clients receive.
-    const wireUpdates = buffer.map((buffered) => buffered.update);
+    const eventLogJson = JSON.stringify(buffer.map((b) => b.update));
     try {
       getDb()
         .insert(acpSessionHistory)
@@ -390,10 +609,20 @@ export class AcpSessionManager {
           status: entry.state.status,
           stopReason: entry.state.stopReason ?? null,
           error: entry.state.error ?? null,
-          eventLogJson: JSON.stringify(wireUpdates),
+          eventLogJson,
           cwd: entry.cwd,
         })
-        .onConflictDoNothing()
+        .onConflictDoUpdate({
+          target: acpSessionHistory.id,
+          set: {
+            status: entry.state.status,
+            completedAt: entry.state.completedAt ?? null,
+            stopReason: entry.state.stopReason ?? null,
+            error: entry.state.error ?? null,
+            eventLogJson,
+            cwd: entry.cwd,
+          },
+        })
         .run();
     } catch (err) {
       log.error(

--- a/assistant/src/config/bundled-skills/acp/TOOLS.json
+++ b/assistant/src/config/bundled-skills/acp/TOOLS.json
@@ -65,7 +65,7 @@
     },
     {
       "name": "acp_steer",
-      "description": "**Interrupts** the in-flight prompt of a running ACP session and replaces it with `instruction`. Use to redirect the agent (e.g., 'stop, do X instead'). For follow-up work that should happen *after* the current task, do NOT use this — wait for `acp_session_completed` and `acp_spawn` again.",
+      "description": "Sends `instruction` to an ACP session. On a running session this **interrupts** the in-flight prompt and replaces it - use it to redirect the agent (e.g., 'stop, do X instead'). A completed or daemon-restarted session is transparently resumed from persisted history via ACP session loading when the agent supports it, so follow-up work on an existing session id CAN go through this tool instead of spawning a new session. If resume is not possible (legacy session without a recorded working directory, or the agent lacks the capability), the error explains why; fall back to `acp_spawn`.",
       "category": "orchestration",
       "risk": "high",
       "input_schema": {

--- a/assistant/src/runtime/routes/__tests__/acp-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/acp-routes.test.ts
@@ -58,10 +58,24 @@ const spawnMock = mock(async () => ({
   protocolSessionId: "proto-route-session",
 }));
 
+const defaultSteerImpl = async (_id: string, _instruction: string) => {};
+let steerImpl: (id: string, instruction: string) => Promise<void> =
+  defaultSteerImpl;
+const steerMock = mock((id: string, instruction: string) =>
+  steerImpl(id, instruction),
+);
+
+let resumeImpl: (id: string) => Promise<void> = async () => {};
+const resumeFromHistoryMock = mock((id: string, _send: unknown) =>
+  resumeImpl(id),
+);
+
 mock.module("../../../acp/index.js", () => ({
   getAcpSessionManager: () => ({
     getStatus: () => fakeInMemorySessions,
     spawn: spawnMock,
+    steer: steerMock,
+    resumeFromHistory: resumeFromHistoryMock,
   }),
 }));
 
@@ -76,12 +90,11 @@ const which = installWhichStub();
 
 import { getSqlite } from "../../../memory/db-connection.js";
 import { initializeDb } from "../../../memory/db-init.js";
-import { FailedDependencyError } from "../errors.js";
+import { FailedDependencyError, NotFoundError } from "../errors.js";
 
 const { ROUTES } = await import("../acp-routes.js");
-const { _resetAdapterInstallCacheForTests } = await import(
-  "../../../acp/auto-install.js"
-);
+const { _resetAdapterInstallCacheForTests } =
+  await import("../../../acp/auto-install.js");
 
 initializeDb();
 
@@ -164,6 +177,10 @@ beforeEach(() => {
   clearHistory();
   resetExecFileStub();
   spawnMock.mockClear();
+  steerMock.mockClear();
+  steerImpl = defaultSteerImpl;
+  resumeFromHistoryMock.mockClear();
+  resumeImpl = async () => {};
   _resetAdapterInstallCacheForTests();
   config.setConfig({});
   which.setWhich((cmd) => `/usr/local/bin/${cmd}`);
@@ -351,7 +368,9 @@ describe("GET /v1/acp/sessions — merged in-memory + history", () => {
     });
 
     const handler = getSessionsHandler();
-    const body = (await handler({ queryParams: { limit: "2" } })) as ResponseShape;
+    const body = (await handler({
+      queryParams: { limit: "2" },
+    })) as ResponseShape;
     expect(body.sessions).toHaveLength(2);
     expect(body.sessions.map((s) => s.id)).toEqual(["live-newest", "hist-mid"]);
   });
@@ -518,5 +537,110 @@ describe("POST /v1/acp/spawn: auto-install on missing binary", () => {
     );
     expect(execFileMock).not.toHaveBeenCalled();
     expect(spawnMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /v1/acp/:id/steer: transparent resume of sessions not in memory
+// ---------------------------------------------------------------------------
+
+function getSteerHandler() {
+  const route = ROUTES.find(
+    (r) => r.endpoint === "acp/:id/steer" && r.method === "POST",
+  );
+  if (!route) throw new Error("acp/:id/steer POST route not found");
+  return route.handler;
+}
+
+describe("POST /v1/acp/:id/steer: resume fallback", () => {
+  test("in-memory session steers without a resume", async () => {
+    const handler = getSteerHandler();
+    const body = await handler({
+      pathParams: { id: "live-1" },
+      body: { instruction: "redirect" },
+    });
+
+    expect(body).toEqual({ acpSessionId: "live-1", steered: true });
+    expect(steerMock).toHaveBeenCalledTimes(1);
+    expect(resumeFromHistoryMock).not.toHaveBeenCalled();
+  });
+
+  test("not-found session resumes from history then retries the steer", async () => {
+    let firstCall = true;
+    steerImpl = async (id) => {
+      if (firstCall) {
+        firstCall = false;
+        throw new Error(`ACP session "${id}" not found`);
+      }
+    };
+
+    const handler = getSteerHandler();
+    const body = await handler({
+      pathParams: { id: "gone-1" },
+      body: { instruction: "keep going" },
+    });
+
+    expect(body).toEqual({
+      acpSessionId: "gone-1",
+      steered: true,
+      resumed: true,
+    });
+    expect(resumeFromHistoryMock).toHaveBeenCalledTimes(1);
+    expect(resumeFromHistoryMock.mock.calls[0][0]).toBe("gone-1");
+    expect(typeof resumeFromHistoryMock.mock.calls[0][1]).toBe("function");
+    expect(steerMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("resume failing with not-found maps to NotFoundError", async () => {
+    steerImpl = async (id) => {
+      throw new Error(`ACP session "${id}" not found`);
+    };
+    resumeImpl = async (id) => {
+      throw new Error(`ACP session "${id}" not found`);
+    };
+
+    const handler = getSteerHandler();
+    const promise = handler({
+      pathParams: { id: "missing-1" },
+      body: { instruction: "go" },
+    });
+    await expect(promise).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  test("resume failing with an actionable hint surfaces as FailedDependencyError", async () => {
+    steerImpl = async (id) => {
+      throw new Error(`ACP session "${id}" not found`);
+    };
+    resumeImpl = async (id) => {
+      throw new Error(
+        `ACP session "${id}" was recorded before resume support ` +
+          `(no working directory persisted) and cannot be resumed. ` +
+          `Spawn a new session instead.`,
+      );
+    };
+
+    const handler = getSteerHandler();
+    const promise = handler({
+      pathParams: { id: "legacy-1" },
+      body: { instruction: "go" },
+    });
+    await expect(promise).rejects.toBeInstanceOf(FailedDependencyError);
+    await expect(promise).rejects.toThrow(/recorded before resume support/);
+  });
+
+  test("non-not-found steer errors map to NotFoundError without a resume", async () => {
+    steerImpl = async (id) => {
+      throw new Error(
+        `ACP session "${id}" is not running (status: initializing)`,
+      );
+    };
+
+    const handler = getSteerHandler();
+    const promise = handler({
+      pathParams: { id: "init-1" },
+      body: { instruction: "go" },
+    });
+    await expect(promise).rejects.toBeInstanceOf(NotFoundError);
+    expect(resumeFromHistoryMock).not.toHaveBeenCalled();
   });
 });

--- a/assistant/src/runtime/routes/acp-routes.ts
+++ b/assistant/src/runtime/routes/acp-routes.ts
@@ -11,6 +11,7 @@ import { ensureAdapterInstalled } from "../../acp/auto-install.js";
 import { getAcpSessionManager } from "../../acp/index.js";
 import { prepareAgentEnv } from "../../acp/prepare-agent-env.js";
 import { resolveAcpAgent } from "../../acp/resolve-agent.js";
+import { isAcpSessionNotFoundError } from "../../acp/session-manager.js";
 import type { AcpSessionState } from "../../acp/types.js";
 import { getDb } from "../../memory/db-connection.js";
 import { rawChanges } from "../../memory/raw-query.js";
@@ -145,10 +146,31 @@ async function steerSession({ pathParams, body }: RouteHandlerArgs) {
   const manager = getAcpSessionManager();
   try {
     await manager.steer(id, instruction);
-  } catch {
-    throw new NotFoundError("ACP session not found");
+    return { acpSessionId: id, steered: true };
+  } catch (err) {
+    if (!isAcpSessionNotFoundError(err, id)) {
+      throw new NotFoundError("ACP session not found");
+    }
   }
-  return { acpSessionId: id, steered: true };
+
+  // The session is no longer in memory (it completed, or the daemon
+  // restarted). Transparently resume it from persisted history and retry,
+  // mirroring the acp_steer skill tool. broadcastMessage plays the sender
+  // role spawnSession gives it, so connected clients render the session.
+  try {
+    await manager.resumeFromHistory(id, broadcastMessage);
+    await manager.steer(id, instruction);
+  } catch (err) {
+    if (isAcpSessionNotFoundError(err, id)) {
+      throw new NotFoundError("ACP session not found");
+    }
+    // Resume errors carry the actionable hint (legacy row without cwd,
+    // agent capability missing, resolver failures, ...).
+    throw new FailedDependencyError(
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+  return { acpSessionId: id, steered: true, resumed: true };
 }
 
 async function cancelSession({ pathParams }: RouteHandlerArgs) {
@@ -259,7 +281,11 @@ export const ROUTES: RouteDefinition[] = [
     },
     handler: steerSession,
     summary: "Steer ACP session",
-    description: "Send a steering instruction to an active ACP session.",
+    description:
+      "Send a steering instruction to an ACP session. Sessions no longer " +
+      "in memory (completed, or lost to a daemon restart) are " +
+      "transparently resumed from persisted history first, when the agent " +
+      "supports ACP session loading.",
     tags: ["acp"],
     requestBody: z.object({
       instruction: z.string(),
@@ -267,6 +293,12 @@ export const ROUTES: RouteDefinition[] = [
     responseBody: z.object({
       acpSessionId: z.string(),
       steered: z.boolean(),
+      resumed: z
+        .boolean()
+        .optional()
+        .describe(
+          "True when the session was resumed from persisted history before steering.",
+        ),
     }),
   },
   {

--- a/assistant/src/tools/acp/steer.test.ts
+++ b/assistant/src/tools/acp/steer.test.ts
@@ -15,6 +15,10 @@ const defaultSteer = (acpSessionId: string, instruction: string) => {
 let steerImpl: (acpSessionId: string, instruction: string) => Promise<void> =
   defaultSteer;
 
+const resumeCalls: Array<{ acpSessionId: string; send: unknown }> = [];
+let resumeImpl: (acpSessionId: string) => Promise<void> = () =>
+  Promise.resolve();
+
 // Spread the real module's exports so transitive importers that pull other
 // names from `../../acp/index.js` still resolve at parse time. Bun's `mock.module` is
 // process-global and returns *exactly* the keys the factory returns.
@@ -24,22 +28,29 @@ mock.module("../../acp/index.js", () => ({
   getAcpSessionManager: () => ({
     steer: (acpSessionId: string, instruction: string) =>
       steerImpl(acpSessionId, instruction),
+    resumeFromHistory: (acpSessionId: string, send: unknown) => {
+      resumeCalls.push({ acpSessionId, send });
+      return resumeImpl(acpSessionId);
+    },
   }),
 }));
 
 const { executeAcpSteer } = await import("./steer.js");
 
-function makeContext(): ToolContext {
+function makeContext(opts?: { withClient?: boolean }): ToolContext {
   return {
     workingDir: "/tmp",
     conversationId: "conv-test",
     trustClass: "guardian",
-  };
+    ...(opts?.withClient ? { sendToClient: () => {} } : {}),
+  } as ToolContext;
 }
 
 beforeEach(() => {
   steerCalls.length = 0;
+  resumeCalls.length = 0;
   steerImpl = defaultSteer;
+  resumeImpl = () => Promise.resolve();
 });
 
 describe("executeAcpSteer", () => {
@@ -53,6 +64,7 @@ describe("executeAcpSteer", () => {
     expect(steerCalls).toEqual([
       { acpSessionId: "acp-123", instruction: "stop, do X instead" },
     ]);
+    expect(resumeCalls).toEqual([]);
 
     const parsed = JSON.parse(result.content as string);
     expect(parsed).toEqual({
@@ -84,7 +96,7 @@ describe("executeAcpSteer", () => {
     expect(steerCalls).toEqual([]);
   });
 
-  test("manager.steer throwing 'session not found' surfaces the error", async () => {
+  test("'session not found' without a connected client surfaces the error", async () => {
     steerImpl = () =>
       Promise.reject(new Error('ACP session "acp-x" not found'));
 
@@ -96,5 +108,81 @@ describe("executeAcpSteer", () => {
     expect(result.isError).toBe(true);
     expect(result.content).toContain('Could not steer ACP session "acp-x"');
     expect(result.content).toContain("not found");
+    expect(resumeCalls).toEqual([]);
+  });
+
+  test("'session not found' with a client: resumes from history and retries the steer", async () => {
+    let firstCall = true;
+    steerImpl = (acpSessionId, instruction) => {
+      if (firstCall) {
+        firstCall = false;
+        return Promise.reject(new Error('ACP session "acp-gone" not found'));
+      }
+      return defaultSteer(acpSessionId, instruction);
+    };
+
+    const result = await executeAcpSteer(
+      { acp_session_id: "acp-gone", instruction: "keep going" },
+      makeContext({ withClient: true }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(resumeCalls).toHaveLength(1);
+    expect(resumeCalls[0]!.acpSessionId).toBe("acp-gone");
+    expect(typeof resumeCalls[0]!.send).toBe("function");
+    // The retry went through after the resume.
+    expect(steerCalls).toEqual([
+      { acpSessionId: "acp-gone", instruction: "keep going" },
+    ]);
+
+    const parsed = JSON.parse(result.content as string);
+    expect(parsed).toEqual({
+      acpSessionId: "acp-gone",
+      status: "steered",
+      resumed: true,
+      message:
+        "Session was resumed from history; new instruction is now running.",
+    });
+  });
+
+  test("resume failure returns its actionable error message", async () => {
+    steerImpl = () =>
+      Promise.reject(new Error('ACP session "acp-legacy" not found'));
+    resumeImpl = () =>
+      Promise.reject(
+        new Error(
+          'ACP session "acp-legacy" was recorded before resume support (no working directory persisted) and cannot be resumed. Spawn a new session instead.',
+        ),
+      );
+
+    const result = await executeAcpSteer(
+      { acp_session_id: "acp-legacy", instruction: "more work" },
+      makeContext({ withClient: true }),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      'Could not steer ACP session "acp-legacy"',
+    );
+    expect(result.content).toContain("recorded before resume support");
+    expect(steerCalls).toEqual([]);
+  });
+
+  test("non-not-found steer errors never trigger a resume", async () => {
+    steerImpl = () =>
+      Promise.reject(
+        new Error(
+          'ACP session "acp-init" is not running (status: initializing)',
+        ),
+      );
+
+    const result = await executeAcpSteer(
+      { acp_session_id: "acp-init", instruction: "redirect" },
+      makeContext({ withClient: true }),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("is not running");
+    expect(resumeCalls).toEqual([]);
   });
 });

--- a/assistant/src/tools/acp/steer.ts
+++ b/assistant/src/tools/acp/steer.ts
@@ -1,9 +1,10 @@
 import { getAcpSessionManager } from "../../acp/index.js";
+import { isAcpSessionNotFoundError } from "../../acp/session-manager.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
 
 export async function executeAcpSteer(
   input: Record<string, unknown>,
-  _context: ToolContext,
+  context: ToolContext,
 ): Promise<ToolExecutionResult> {
   const acpSessionId = input.acp_session_id as string;
   if (!acpSessionId) {
@@ -15,24 +16,62 @@ export async function executeAcpSteer(
     return { content: '"instruction" is required.', isError: true };
   }
 
-  try {
-    const manager = getAcpSessionManager();
-    await manager.steer(acpSessionId, instruction);
+  const manager = getAcpSessionManager();
 
-    return {
-      content: JSON.stringify({
-        acpSessionId,
-        status: "steered",
-        message:
-          "Interrupted in-flight prompt; new instruction is now running.",
-      }),
-      isError: false,
-    };
+  try {
+    await manager.steer(acpSessionId, instruction);
+    return steeredResult(acpSessionId, { resumed: false });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    return {
-      content: `Could not steer ACP session "${acpSessionId}": ${msg}`,
-      isError: true,
-    };
+
+    // "Not found" means the session is no longer in memory (it completed,
+    // or the daemon restarted). Transparently resume it from persisted
+    // history and retry, when a client is connected to receive the
+    // resumed session's events.
+    const sendToClient = context.sendToClient as
+      | ((msg: { type: string; [key: string]: unknown }) => void)
+      | undefined;
+    if (!isAcpSessionNotFoundError(err, acpSessionId) || !sendToClient) {
+      return steerError(acpSessionId, msg);
+    }
+
+    try {
+      await manager.resumeFromHistory(
+        acpSessionId,
+        sendToClient as (msg: unknown) => void,
+      );
+      await manager.steer(acpSessionId, instruction);
+    } catch (resumeErr) {
+      // The resume error carries the actionable hint (e.g. "recorded
+      // before resume support", agent capability missing).
+      const resumeMsg =
+        resumeErr instanceof Error ? resumeErr.message : String(resumeErr);
+      return steerError(acpSessionId, resumeMsg);
+    }
+    return steeredResult(acpSessionId, { resumed: true });
   }
+}
+
+function steeredResult(
+  acpSessionId: string,
+  opts: { resumed: boolean },
+): ToolExecutionResult {
+  return {
+    content: JSON.stringify({
+      acpSessionId,
+      status: "steered",
+      ...(opts.resumed ? { resumed: true } : {}),
+      message: opts.resumed
+        ? "Session was resumed from history; new instruction is now running."
+        : "Interrupted in-flight prompt; new instruction is now running.",
+    }),
+    isError: false,
+  };
+}
+
+function steerError(acpSessionId: string, msg: string): ToolExecutionResult {
+  return {
+    content: `Could not steer ACP session "${acpSessionId}": ${msg}`,
+    isError: true,
+  };
 }


### PR DESCRIPTION
## Summary
- AcpSessionManager.resumeFromHistory: respawn the adapter and reattach via session/resume (preferred, no replay) or session/load with replay suppression
- acp_steer tool and /v1/acp/:id/steer route transparently resume sessions that are no longer in memory (e.g. after daemon restart)
- persistTerminal upserts so resumed runs update their original history row
- Fake-agent tests for resume paths, steer fallback, and upsert persistence

Part of plan: acp-native-agent-ux.md (PR 5 of 8)