### PR TITLE
fix: keep ACP skill discoverable when ACP is disabled

### DIFF
--- a/assistant/src/__tests__/conversation-app-control-instantiation.test.ts
+++ b/assistant/src/__tests__/conversation-app-control-instantiation.test.ts
@@ -60,11 +60,6 @@ mock.module("../config/assistant-feature-flags.js", () => ({
 mock.module("../config/skill-state.js", () => ({
   skillFlagKey: (skill: { featureFlag?: string }) =>
     skill.featureFlag ?? undefined,
-  // Mirror the real helper: route through the mocked flag resolver.
-  isSkillFeatureFlagEnabled: (key: string) => {
-    if (key === "app-control") return appControlFlagEnabled;
-    return true;
-  },
 }));
 
 mock.module("../config/loader.js", () => ({

--- a/assistant/src/__tests__/conversation-skill-tools.test.ts
+++ b/assistant/src/__tests__/conversation-skill-tools.test.ts
@@ -225,7 +225,6 @@ mock.module("../config/assistant-feature-flags.js", () => ({
 mock.module("../config/skill-state.js", () => ({
   skillFlagKey: (skill: { featureFlag?: string }) =>
     skill.featureFlag || undefined,
-  isSkillFeatureFlagEnabled: () => true,
 }));
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/handlers-skills-memory-v2-reseed.test.ts
+++ b/assistant/src/__tests__/handlers-skills-memory-v2-reseed.test.ts
@@ -71,7 +71,6 @@ mock.module("../config/loader.js", () => ({
 mock.module("../config/skill-state.js", () => ({
   resolveSkillStates: () => [],
   skillFlagKey: () => null,
-  isSkillFeatureFlagEnabled: () => true,
 }));
 
 mock.module("../skills/clawhub.js", () => ({

--- a/assistant/src/__tests__/skill-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/skill-feature-flags-integration.test.ts
@@ -5,6 +5,8 @@
  * parses it via the real frontmatter parser, and verifies that `skillFlagKey()`
  * returns the correct key and `resolveSkillStates()` correctly gates the skill.
  */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
@@ -223,5 +225,36 @@ describe("frontmatter feature-flag integration", () => {
 
     const resolvedOff = resolveSkillStates([skill], configOff);
     expect(resolvedOff.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bundled ACP skill: discoverability when ACP is disabled
+// ---------------------------------------------------------------------------
+
+describe("bundled acp skill discoverability", () => {
+  test("acp skill resolves with the flag off and config.acp disabled (no frontmatter flag gate)", () => {
+    // The ACP skill carries its own first-time-setup instructions, so it must
+    // stay visible even when the acp flag and config.acp.enabled are both off.
+    // Runtime enforcement happens in the ACP tools via isAcpEnabled instead.
+    const skillMdPath = fileURLToPath(
+      new URL("../config/bundled-skills/acp/SKILL.md", import.meta.url),
+    );
+    const skillMd = readFileSync(skillMdPath, "utf8");
+
+    const skill = buildSkillSummary("acp", skillMd);
+    expect(skill).not.toBeNull();
+    expect(skill!.featureFlag).toBeUndefined();
+    expect(skillFlagKey(skill!)).toBeUndefined();
+
+    // acp flag at its registry default (off) and config.acp disabled.
+    const config = makeConfig({
+      acp: { enabled: false, maxConcurrentSessions: 4, agents: {} },
+    } as Partial<AssistantConfig>);
+
+    const resolved = resolveSkillStates([skill!], config);
+    expect(resolved.length).toBe(1);
+    expect(resolved[0].summary.id).toBe("acp");
+    expect(resolved[0].state).toBe("enabled");
   });
 });

--- a/assistant/src/__tests__/skill-feature-flags.test.ts
+++ b/assistant/src/__tests__/skill-feature-flags.test.ts
@@ -2,11 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import type { AssistantConfig } from "../config/schema.js";
-import {
-  isSkillFeatureFlagEnabled,
-  resolveSkillStates,
-  skillFlagKey,
-} from "../config/skill-state.js";
+import { resolveSkillStates, skillFlagKey } from "../config/skill-state.js";
 import type { SkillSummary } from "../config/skills.js";
 import { setOverridesForTesting } from "./feature-flag-test-helpers.js";
 
@@ -279,78 +275,6 @@ describe("resolveSkillStates with feature flags", () => {
 
     // a2a-channel and deploy explicitly false; one unrelated skill explicitly true
     expect(ids).toEqual([ENABLED_UNDECLARED_SKILL_ID]);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Per-flag predicate overrides (config-aware gating)
-// ---------------------------------------------------------------------------
-
-describe("skill flag predicate overrides (acp)", () => {
-  /** Config with the `acp` section the ACP gate reads. */
-  function makeAcpConfig(acpEnabled: boolean): AssistantConfig {
-    return makeConfig({
-      acp: { enabled: acpEnabled, maxConcurrentSessions: 4, agents: {} },
-    } as Partial<AssistantConfig>);
-  }
-
-  test("isSkillFeatureFlagEnabled: acp flag routes through isAcpEnabled (config-on, flag-off)", () => {
-    // Flag at registry default (false), but config.acp.enabled is true:
-    // the OR semantics must keep the gate open.
-    expect(isSkillFeatureFlagEnabled("acp", makeAcpConfig(true))).toBe(true);
-  });
-
-  test("isSkillFeatureFlagEnabled: acp gate closed when both flag and config are off", () => {
-    expect(isSkillFeatureFlagEnabled("acp", makeAcpConfig(false))).toBe(false);
-  });
-
-  test("isSkillFeatureFlagEnabled: acp gate open when flag is on and config is off", () => {
-    setOverridesForTesting({ acp: true });
-    expect(isSkillFeatureFlagEnabled("acp", makeAcpConfig(false))).toBe(true);
-  });
-
-  test("isSkillFeatureFlagEnabled: non-overridden flags fall back to the flag resolver", () => {
-    setOverridesForTesting({ [DECLARED_FLAG_KEY]: true });
-    expect(
-      isSkillFeatureFlagEnabled(DECLARED_FLAG_KEY, makeAcpConfig(false)),
-    ).toBe(true);
-    setOverridesForTesting({ [DECLARED_FLAG_KEY]: false });
-    expect(
-      isSkillFeatureFlagEnabled(DECLARED_FLAG_KEY, makeAcpConfig(true)),
-    ).toBe(false);
-  });
-
-  test("resolveSkillStates keeps the ACP skill when config.acp.enabled is true and the flag is off", () => {
-    const catalog = [makeSkill("acp", "bundled", "acp")];
-
-    const resolved = resolveSkillStates(catalog, makeAcpConfig(true));
-    const ids = resolved.map((r) => r.summary.id);
-    expect(ids).toContain("acp");
-  });
-
-  test("resolveSkillStates drops the ACP skill when both the flag and config.acp.enabled are off", () => {
-    const catalog = [makeSkill("acp", "bundled", "acp")];
-
-    const resolved = resolveSkillStates(catalog, makeAcpConfig(false));
-    expect(resolved.length).toBe(0);
-  });
-
-  test("resolveSkillStates keeps the ACP skill when the flag is on and config.acp.enabled is off", () => {
-    setOverridesForTesting({ acp: true });
-    const catalog = [makeSkill("acp", "bundled", "acp")];
-
-    const resolved = resolveSkillStates(catalog, makeAcpConfig(false));
-    const ids = resolved.map((r) => r.summary.id);
-    expect(ids).toContain("acp");
-  });
-
-  test("explicit acp flag-off override does not defeat config.acp.enabled", () => {
-    setOverridesForTesting({ acp: false });
-    const catalog = [makeSkill("acp", "bundled", "acp")];
-
-    const resolved = resolveSkillStates(catalog, makeAcpConfig(true));
-    const ids = resolved.map((r) => r.summary.id);
-    expect(ids).toContain("acp");
   });
 });
 

--- a/assistant/src/__tests__/skill-projection-feature-flag.test.ts
+++ b/assistant/src/__tests__/skill-projection-feature-flag.test.ts
@@ -41,12 +41,6 @@ mock.module("../config/loader.js", () => ({
 mock.module("../config/skill-state.js", () => ({
   skillFlagKey: (skill: { featureFlag?: string }) =>
     skill.featureFlag || undefined,
-  // Mirror the real helper: route through the (mocked) flag resolver.
-  isSkillFeatureFlagEnabled: (key: string, _config: unknown): boolean => {
-    const explicit = _mockOverrides[key];
-    if (typeof explicit === "boolean") return explicit;
-    return false;
-  },
 }));
 
 // Mock assistant-feature-flags to avoid loading the real module (which

--- a/assistant/src/__tests__/skill-projection.benchmark.test.ts
+++ b/assistant/src/__tests__/skill-projection.benchmark.test.ts
@@ -66,7 +66,6 @@ mock.module("../config/skills.js", () => ({
 mock.module("../config/skill-state.js", () => ({
   skillFlagKey: (skill: { featureFlag?: string }) =>
     skill.featureFlag || undefined,
-  isSkillFeatureFlagEnabled: () => true,
   resolveSkillStates: () => [],
 }));
 

--- a/assistant/src/acp/feature-gate.test.ts
+++ b/assistant/src/acp/feature-gate.test.ts
@@ -46,9 +46,3 @@ describe("isAcpEnabled", () => {
     expect(isAcpEnabled(makeConfig(true))).toBe(true);
   });
 });
-
-describe("ACP flag key format", () => {
-  test(`${ACP_FLAG_KEY} uses simple kebab-case format`, () => {
-    expect(ACP_FLAG_KEY).toMatch(/^[a-z0-9][a-z0-9-]*$/);
-  });
-});

--- a/assistant/src/config/acp-defaults.test.ts
+++ b/assistant/src/config/acp-defaults.test.ts
@@ -48,18 +48,6 @@ describe("DEFAULT_ACP_AGENT_PROFILES", () => {
       expect(Object.isFrozen(profile.args)).toBe(true);
     }
   });
-
-  test("mutating gemini's non-empty args throws in strict mode", () => {
-    // gemini is the one default with non-empty args, frozen via a dedicated
-    // array rather than the shared FROZEN_EMPTY_ARGS: verify the deep-freeze
-    // invariant actually rejects writes, not just that isFrozen reports true.
-    const args = DEFAULT_ACP_AGENT_PROFILES.gemini.args;
-    expect(() => args.push("--oops")).toThrow();
-    expect(() => {
-      args[0] = "--mutated";
-    }).toThrow();
-    expect(args).toEqual(["--acp"]);
-  });
 });
 
 describe("DEFAULT_AGENT_NPM_PACKAGES", () => {

--- a/assistant/src/config/acp-defaults.ts
+++ b/assistant/src/config/acp-defaults.ts
@@ -32,9 +32,6 @@ export const DEFAULT_ACP_AGENT_PROFILES: Readonly<
   }),
   gemini: Object.freeze({
     command: "gemini",
-    // Dedicated frozen array (not FROZEN_EMPTY_ARGS): gemini is the one
-    // default profile with non-empty args, and it must uphold the same
-    // deep-freeze invariant documented above.
     args: Object.freeze(["--acp"]) as unknown as string[],
     description: "Google Gemini CLI (native ACP via gemini --acp)",
   }),

--- a/assistant/src/config/bundled-skills/acp/SKILL.md
+++ b/assistant/src/config/bundled-skills/acp/SKILL.md
@@ -6,7 +6,6 @@ metadata:
   emoji: "🔗"
   vellum:
     display-name: "ACP"
-    feature-flag: acp
     activation-hints:
       - "User asks to use Claude Code, Codex, or Gemini to do something"
       - "User wants to delegate a coding task to Claude Code, Codex, Gemini, or another ACP agent"

--- a/assistant/src/config/skill-state.ts
+++ b/assistant/src/config/skill-state.ts
@@ -1,38 +1,8 @@
-import { ACP_FLAG_KEY, isAcpEnabled } from "../acp/feature-gate.js";
 import { isAssistantFeatureFlagEnabled } from "./assistant-feature-flags.js";
 import type { AssistantConfig, SkillEntryConfig } from "./schema.js";
 import type { SkillSummary } from "./skills.js";
 
 export type SkillState = "enabled" | "disabled";
-
-/**
- * Per-flag predicate overrides for skill gating. Most skill feature flags are
- * resolved purely through the flag system, but some subsystems have richer
- * enablement semantics (e.g. ACP is flag OR `config.acp.enabled`). Routing the
- * skill gate through the subsystem's own feature gate keeps the skill
- * available whenever the subsystem itself is enabled.
- */
-const SKILL_FLAG_PREDICATES: Record<
-  string,
-  (config: AssistantConfig) => boolean
-> = {
-  [ACP_FLAG_KEY]: isAcpEnabled,
-};
-
-/**
- * Whether the feature flag declared by a skill's frontmatter should be
- * considered enabled. Used by every skill flag-gating enforcement point so
- * that per-flag predicate overrides (see {@link SKILL_FLAG_PREDICATES}) apply
- * consistently everywhere.
- */
-export function isSkillFeatureFlagEnabled(
-  flagKey: string,
-  config: AssistantConfig,
-): boolean {
-  const predicate = SKILL_FLAG_PREDICATES[flagKey];
-  if (predicate) return predicate(config);
-  return isAssistantFeatureFlagEnabled(flagKey, config);
-}
 
 export interface ResolvedSkill {
   summary: SkillSummary;
@@ -63,7 +33,7 @@ export function resolveSkillStates(
   for (const skill of catalog) {
     // Assistant feature flag gate: if the skill declares a flag and it's disabled, skip it
     const flagKey = skillFlagKey(skill);
-    if (flagKey && !isSkillFeatureFlagEnabled(flagKey, config)) {
+    if (flagKey && !isAssistantFeatureFlagEnabled(flagKey, config)) {
       continue;
     }
 

--- a/assistant/src/daemon/conversation-skill-tools.ts
+++ b/assistant/src/daemon/conversation-skill-tools.ts
@@ -11,11 +11,9 @@
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getConfig } from "../config/loader.js";
-import {
-  isSkillFeatureFlagEnabled,
-  skillFlagKey,
-} from "../config/skill-state.js";
+import { skillFlagKey } from "../config/skill-state.js";
 import type { SkillSummary, SkillToolManifest } from "../config/skills.js";
 import { loadSkillCatalog } from "../config/skills.js";
 import type { Message, ToolDefinition } from "../providers/types.js";
@@ -257,7 +255,7 @@ export function projectSkillTools(
   for (const id of allCandidateIds) {
     const skill = catalogById.get(id);
     const flagKey = skill ? skillFlagKey(skill) : undefined;
-    if (!flagKey || isSkillFeatureFlagEnabled(flagKey, config)) {
+    if (!flagKey || isAssistantFeatureFlagEnabled(flagKey, config)) {
       activeIds.add(id);
     }
   }

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -9,17 +9,14 @@ import {
 } from "node:fs";
 import { basename, join, relative, sep } from "node:path";
 
+import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import {
   getConfig,
   invalidateConfigCache,
   loadRawConfig,
   saveRawConfig,
 } from "../../config/loader.js";
-import {
-  isSkillFeatureFlagEnabled,
-  resolveSkillStates,
-  skillFlagKey,
-} from "../../config/skill-state.js";
+import { resolveSkillStates, skillFlagKey } from "../../config/skill-state.js";
 import type { SkillSummary } from "../../config/skills.js";
 import { loadSkillCatalog } from "../../config/skills.js";
 import { deleteSkillCapabilityNode } from "../../memory/graph/capability-seed.js";
@@ -1139,7 +1136,7 @@ export async function installSkill(spec: {
     const flaggedSkill = catalog.find((s) => s.id === spec.slug);
     if (flaggedSkill) {
       const flagKey = skillFlagKey(flaggedSkill);
-      if (flagKey && !isSkillFeatureFlagEnabled(flagKey, config)) {
+      if (flagKey && !isAssistantFeatureFlagEnabled(flagKey, config)) {
         return {
           success: false,
           error: `Skill "${spec.slug}" is currently unavailable (disabled by feature flag)`,

--- a/assistant/src/memory/graph/capability-seed.ts
+++ b/assistant/src/memory/graph/capability-seed.ts
@@ -8,11 +8,9 @@
 import { and, eq, like, sql } from "drizzle-orm";
 
 import { buildCliProgram } from "../../cli/program.js";
+import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import { getConfig } from "../../config/loader.js";
-import {
-  isSkillFeatureFlagEnabled,
-  resolveSkillStates,
-} from "../../config/skill-state.js";
+import { resolveSkillStates } from "../../config/skill-state.js";
 import { loadSkillCatalog } from "../../config/skills.js";
 import {
   getCachedCatalogSync,
@@ -137,7 +135,8 @@ export function seedSkillGraphNodes(): void {
     } else {
       for (const entry of cachedCatalog) {
         const flagKey = entry.metadata?.vellum?.["feature-flag"];
-        if (flagKey && !isSkillFeatureFlagEnabled(flagKey, config)) continue;
+        if (flagKey && !isAssistantFeatureFlagEnabled(flagKey, config))
+          continue;
         seenKeys.add(`${SKILL_SOURCE_PREFIX}${entry.id}`);
       }
       pruneStaleCapabilities(SKILL_SOURCE_PREFIX, seenKeys);
@@ -192,7 +191,7 @@ export async function seedUninstalledCatalogSkillMemories(): Promise<void> {
       if (installedIds.has(entry.id)) continue;
 
       const flagKey = entry.metadata?.vellum?.["feature-flag"];
-      if (flagKey && !isSkillFeatureFlagEnabled(flagKey, config)) continue;
+      if (flagKey && !isAssistantFeatureFlagEnabled(flagKey, config)) continue;
 
       upsertSkillCapabilityNode(entry.id, fromCatalogSkill(entry));
     }

--- a/assistant/src/memory/v2/__tests__/skill-store.test.ts
+++ b/assistant/src/memory/v2/__tests__/skill-store.test.ts
@@ -109,8 +109,6 @@ mock.module("../../../config/skills.js", () => ({
 }));
 
 mock.module("../../../config/skill-state.js", () => ({
-  // Mirror the real helper: route through the mocked flag state.
-  isSkillFeatureFlagEnabled: (key: string) => state.flagsEnabled[key] ?? true,
   resolveSkillStates: (
     catalog: SkillSummary[],
     config: { skills?: { allowBundled?: string[] | null } },

--- a/assistant/src/memory/v2/skill-store.ts
+++ b/assistant/src/memory/v2/skill-store.ts
@@ -19,11 +19,9 @@
 // The cache is replaced atomically at the end of a successful seed run; on
 // error the prior cache stays intact (skills are best-effort).
 
+import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import { getConfig } from "../../config/loader.js";
-import {
-  isSkillFeatureFlagEnabled,
-  resolveSkillStates,
-} from "../../config/skill-state.js";
+import { resolveSkillStates } from "../../config/skill-state.js";
 import { loadSkillCatalog } from "../../config/skills.js";
 import { getCatalog } from "../../skills/catalog-cache.js";
 import {
@@ -187,7 +185,7 @@ async function runSeedV2SkillEntries(generation: number): Promise<void> {
     const seeds: SkillEntry[] = [];
     for (const { summary } of enabled) {
       const flagKey = summary.featureFlag;
-      if (flagKey && !isSkillFeatureFlagEnabled(flagKey, config)) continue;
+      if (flagKey && !isAssistantFeatureFlagEnabled(flagKey, config)) continue;
 
       const augmented = augmentMcpSetupDescription(fromSkillSummary(summary));
       const content = buildSkillContent(augmented);
@@ -212,7 +210,8 @@ async function runSeedV2SkillEntries(generation: number): Promise<void> {
         knownSkillIds.add(entry.id);
         if (installedIds.has(entry.id)) continue;
         const flagKey = entry.metadata?.vellum?.["feature-flag"];
-        if (flagKey && !isSkillFeatureFlagEnabled(flagKey, config)) continue;
+        if (flagKey && !isAssistantFeatureFlagEnabled(flagKey, config))
+          continue;
         const content = buildSkillContent(fromCatalogSkill(entry));
         seeds.push({ id: entry.id, content });
       }

--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -1,11 +1,9 @@
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 
+import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import { getConfig } from "../../config/loader.js";
-import {
-  isSkillFeatureFlagEnabled,
-  skillFlagKey,
-} from "../../config/skill-state.js";
+import { skillFlagKey } from "../../config/skill-state.js";
 import type { SkillSummary, SkillToolManifest } from "../../config/skills.js";
 import {
   listReferenceFiles,
@@ -199,7 +197,7 @@ export const skillLoadTool = {
     // Assistant feature flag gate: reject loading if the skill's flag is OFF
     const config = getConfig();
     const flagKey = skillFlagKey(skill);
-    if (flagKey && !isSkillFeatureFlagEnabled(flagKey, config)) {
+    if (flagKey && !isAssistantFeatureFlagEnabled(flagKey, config)) {
       return {
         content: `Error: skill "${skill.id}" is currently unavailable (disabled by feature flag)`,
         isError: true,
@@ -348,7 +346,10 @@ export const skillLoadTool = {
         const child = catalogIndex.get(childId);
         if (!child) continue;
         const childFlagKey = skillFlagKey(child);
-        if (childFlagKey && !isSkillFeatureFlagEnabled(childFlagKey, config))
+        if (
+          childFlagKey &&
+          !isAssistantFeatureFlagEnabled(childFlagKey, config)
+        )
           continue;
 
         childLines.push(
@@ -474,7 +475,10 @@ export const skillLoadTool = {
         const child = catalogIndex.get(childId);
         if (!child) continue;
         const childFlagKey2 = skillFlagKey(child);
-        if (childFlagKey2 && !isSkillFeatureFlagEnabled(childFlagKey2, config))
+        if (
+          childFlagKey2 &&
+          !isAssistantFeatureFlagEnabled(childFlagKey2, config)
+        )
           continue;
         let childHash: string | undefined;
         try {

--- a/meta/feature-flags/AGENTS.md
+++ b/meta/feature-flags/AGENTS.md
@@ -71,8 +71,6 @@ featureFlag: my-new-flag
 
 Skills without a `featureFlag` field are always available. Skills that declare one are gated at six independent enforcement points — when the flag is OFF the skill is unavailable everywhere.
 
-All enforcement points resolve the skill's flag through `isSkillFeatureFlagEnabled` in `assistant/src/config/skill-state.ts`. Most flags resolve directly through the flag system, but flags listed in `SKILL_FLAG_PREDICATES` route through the subsystem's own feature gate instead (e.g. `acp` resolves via `isAcpEnabled`, which is flag OR `config.acp.enabled`). Add an entry there when a subsystem has enablement semantics beyond the bare flag, so its skill stays available whenever the subsystem itself is enabled.
-
 ## Auth Scopes Are Unrelated
 
 The OAuth/API scopes `feature_flags.read` and `feature_flags.write` control access to the feature-flag management API. They are **not** flag keys and should not be modified when adding or renaming flags.


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for acp-native-agent-ux.md.

- Gap: the ACP skill was gated by the same flag its first-time-setup instructions enable, making self-setup unreachable when ACP was off; the skill is now always visible (runtime tool gating via isAcpEnabled is unchanged)
- Removes the now-unused per-flag skill predicate registry and its six call-site conversions
- Test cleanup: single home for the flag-OR-config truth table, drop constant-literal and Object.freeze re-verification tests