### PR TITLE
fix: ACP resume race, teardown ownership, bulk-delete guard, consolidation

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -141,7 +141,9 @@ paths:
     delete:
       operationId: acp_sessions_delete
       summary: Bulk-clear terminal ACP sessions
-      description: Remove every terminal-state row (completed/failed/cancelled) from the persisted acp_session_history table.
+      description:
+        Remove every terminal-state row (completed/failed/cancelled) from the persisted acp_session_history table.
+        Rows whose session is currently active in memory (e.g. resumed) are excluded.
       tags:
         - acp
       responses:

--- a/assistant/src/acp/__tests__/helpers/acp-history-db.ts
+++ b/assistant/src/acp/__tests__/helpers/acp-history-db.ts
@@ -1,0 +1,82 @@
+/**
+ * Shared test helpers for the `acp_session_history` table.
+ *
+ * Several suites (session-manager resume/persistence, the ACP route
+ * handlers) seed and read history rows directly via SQL; this module
+ * consolidates the copy-pasted row shape + insert/read/clear helpers.
+ * Tests must run `initializeDb()` themselves before calling these.
+ */
+
+import { getSqlite } from "../../../memory/db-connection.js";
+
+/** Raw column snapshot of an `acp_session_history` row. */
+export interface HistoryRow {
+  id: string;
+  agent_id: string;
+  acp_session_id: string;
+  parent_conversation_id: string;
+  started_at: number;
+  completed_at: number | null;
+  status: string;
+  stop_reason: string | null;
+  error: string | null;
+  event_log_json: string;
+  cwd: string | null;
+}
+
+export function clearHistory(): void {
+  getSqlite().run("DELETE FROM acp_session_history");
+}
+
+/**
+ * Inserts a history row. Every field except `id` defaults to the values
+ * the resume suites were built around (a completed claude run in
+ * /tmp/proj); pass explicit values to override, including `null` where the
+ * column is nullable (e.g. `cwd: null` for legacy rows).
+ */
+export function insertHistoryRow(row: {
+  id: string;
+  agentId?: string;
+  acpSessionId?: string;
+  parentConversationId?: string;
+  startedAt?: number;
+  completedAt?: number | null;
+  status?: string;
+  stopReason?: string | null;
+  error?: string | null;
+  eventLogJson?: string;
+  cwd?: string | null;
+}): void {
+  getSqlite()
+    .query(
+      `INSERT INTO acp_session_history (
+         id, agent_id, acp_session_id, parent_conversation_id,
+         started_at, completed_at, status, stop_reason, error,
+         event_log_json, cwd
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      row.id,
+      row.agentId ?? "claude",
+      row.acpSessionId ?? "proto-old",
+      row.parentConversationId ?? "conv-1",
+      row.startedAt ?? 1234,
+      row.completedAt === undefined ? 5678 : row.completedAt,
+      row.status ?? "completed",
+      row.stopReason === undefined ? "end_turn" : row.stopReason,
+      row.error ?? null,
+      row.eventLogJson ?? "[]",
+      row.cwd === undefined ? "/tmp/proj" : row.cwd,
+    );
+}
+
+export function readHistoryRow(id: string): HistoryRow | null {
+  return getSqlite()
+    .query(
+      `SELECT id, agent_id, acp_session_id, parent_conversation_id,
+              started_at, completed_at, status, stop_reason, error,
+              event_log_json, cwd
+       FROM acp_session_history WHERE id = ?`,
+    )
+    .get(id) as HistoryRow | null;
+}

--- a/assistant/src/acp/__tests__/session-manager-persistence.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-persistence.test.ts
@@ -23,35 +23,12 @@ import type { ServerMessage } from "../../daemon/message-protocol.js";
 import type { AcpSessionUpdate } from "../../daemon/message-types/acp.js";
 import { getSqlite } from "../../memory/db-connection.js";
 import { initializeDb } from "../../memory/db-init.js";
+import {
+  clearHistory,
+  insertHistoryRow,
+  readHistoryRow,
+} from "./helpers/acp-history-db.js";
 initializeDb();
-
-function clearHistory() {
-  getSqlite().run("DELETE FROM acp_session_history");
-}
-
-interface HistoryRow {
-  id: string;
-  agent_id: string;
-  acp_session_id: string;
-  parent_conversation_id: string;
-  started_at: number;
-  completed_at: number | null;
-  status: string;
-  stop_reason: string | null;
-  error: string | null;
-  event_log_json: string;
-  cwd: string | null;
-}
-
-function readHistoryRow(id: string): HistoryRow | null {
-  return getSqlite()
-    .query(
-      `SELECT id, agent_id, acp_session_id, parent_conversation_id,
-              started_at, completed_at, status, stop_reason, error, event_log_json, cwd
-       FROM acp_session_history WHERE id = ?`,
-    )
-    .get(id) as HistoryRow | null;
-}
 
 /**
  * Builds a manager with a fake session pre-injected and returns the handles
@@ -367,12 +344,17 @@ describe("AcpSessionManager — terminal persistence", () => {
   });
 
   test("legacy rows without a cwd read back as null", () => {
-    getSqlite().run(
-      `INSERT INTO acp_session_history (
-         id, agent_id, acp_session_id, parent_conversation_id,
-         started_at, status
-       ) VALUES ('legacy-row-1', 'agent-legacy', 'proto-legacy', 'conv-legacy', 1000, 'completed')`,
-    );
+    insertHistoryRow({
+      id: "legacy-row-1",
+      agentId: "agent-legacy",
+      acpSessionId: "proto-legacy",
+      parentConversationId: "conv-legacy",
+      startedAt: 1000,
+      completedAt: null,
+      status: "completed",
+      stopReason: null,
+      cwd: null,
+    });
 
     const row = readHistoryRow("legacy-row-1");
     expect(row).not.toBeNull();
@@ -383,13 +365,18 @@ describe("AcpSessionManager — terminal persistence", () => {
     const id = "session-upsert-1";
     // Simulate the row left behind by the original run that a resumed run
     // reuses the id of.
-    getSqlite().run(
-      `INSERT INTO acp_session_history (
-         id, agent_id, acp_session_id, parent_conversation_id,
-         started_at, completed_at, status, stop_reason, event_log_json, cwd
-       ) VALUES ('${id}', 'agent-up', 'proto-up', 'conv-up',
-                 1000, 2000, 'cancelled', 'daemon_restarted', '[{"old":true}]', '/old/cwd')`,
-    );
+    insertHistoryRow({
+      id,
+      agentId: "agent-up",
+      acpSessionId: "proto-up",
+      parentConversationId: "conv-up",
+      startedAt: 1000,
+      completedAt: 2000,
+      status: "cancelled",
+      stopReason: "daemon_restarted",
+      eventLogJson: '[{"old":true}]',
+      cwd: "/old/cwd",
+    });
 
     const handles = buildSessionWithFakeProcess({
       id,

--- a/assistant/src/acp/__tests__/session-manager-resume.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-resume.test.ts
@@ -29,6 +29,8 @@ interface FakeClient {
 const fakeCaps = { loadSession: false, resume: false };
 /** Chunks the fake replays through the client handler during loadSession. */
 let replayChunks: string[] = [];
+/** When set, prompt() throws synchronously (steerOrResume teardown tests). */
+let promptThrowsSync = false;
 const fakeInstances: FakeAcpAgentProcess[] = [];
 
 class FakeAcpAgentProcess {
@@ -90,6 +92,9 @@ class FakeAcpAgentProcess {
   }
 
   prompt(sessionId: string, text: string): Promise<{ stopReason: string }> {
+    if (promptThrowsSync) {
+      throw new Error("prompt transport dead");
+    }
     this.promptCalls.push({ sessionId, text });
     return new Promise((res) => {
       this.resolvePrompt = res;
@@ -131,69 +136,16 @@ import type { AcpSessionUpdate } from "../../daemon/message-types/acp.js";
 import { getSqlite } from "../../memory/db-connection.js";
 import { initializeDb } from "../../memory/db-init.js";
 import type { AcpSessionState } from "../types.js";
+import {
+  clearHistory,
+  insertHistoryRow,
+  readHistoryRow,
+} from "./helpers/acp-history-db.js";
 
-const { AcpSessionManager } = await import("../session-manager.js");
+const { AcpResumeError, AcpSessionManager, AcpSessionNotFoundError } =
+  await import("../session-manager.js");
 
 initializeDb();
-
-// ---------------------------------------------------------------------------
-// DB helpers
-// ---------------------------------------------------------------------------
-
-function clearHistory(): void {
-  getSqlite().run("DELETE FROM acp_session_history");
-}
-
-function insertHistoryRow(row: {
-  id: string;
-  agentId?: string;
-  acpSessionId?: string;
-  parentConversationId?: string;
-  startedAt?: number;
-  status?: string;
-  cwd?: string | null;
-  eventLogJson?: string;
-}): void {
-  getSqlite()
-    .query(
-      `INSERT INTO acp_session_history (
-         id, agent_id, acp_session_id, parent_conversation_id,
-         started_at, completed_at, status, stop_reason, error,
-         event_log_json, cwd
-       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-    )
-    .run(
-      row.id,
-      row.agentId ?? "claude",
-      row.acpSessionId ?? "proto-old",
-      row.parentConversationId ?? "conv-1",
-      row.startedAt ?? 1234,
-      5678,
-      row.status ?? "completed",
-      "end_turn",
-      null,
-      row.eventLogJson ?? "[]",
-      row.cwd === undefined ? "/tmp/proj" : row.cwd,
-    );
-}
-
-interface HistoryRow {
-  id: string;
-  started_at: number;
-  status: string;
-  stop_reason: string | null;
-  event_log_json: string;
-  cwd: string | null;
-}
-
-function readHistoryRow(id: string): HistoryRow | null {
-  return getSqlite()
-    .query(
-      `SELECT id, started_at, status, stop_reason, event_log_json, cwd
-       FROM acp_session_history WHERE id = ?`,
-    )
-    .get(id) as HistoryRow | null;
-}
 
 function countHistoryRows(): number {
   const row = getSqlite()
@@ -223,6 +175,7 @@ beforeEach(() => {
   fakeCaps.loadSession = false;
   fakeCaps.resume = false;
   replayChunks = [];
+  promptThrowsSync = false;
   resolveImpl = () => ({
     ok: true,
     agent: { command: "claude-agent-acp", args: [] },
@@ -422,5 +375,164 @@ describe("AcpSessionManager.resumeFromHistory", () => {
     expect(log).toHaveLength(2);
     expect(log[0]!.content).toBe("original-run-chunk");
     expect(log[1]!.content).toBe("resumed-run-chunk");
+  });
+
+  test("concurrent resumes of the same id: one wins, the loser fails cleanly without leaking a process", async () => {
+    fakeCaps.resume = true;
+    insertHistoryRow({ id: "race-1" });
+
+    const manager = new AcpSessionManager(4);
+    const sent: ServerMessage[] = [];
+    const [a, b] = await Promise.allSettled([
+      manager.resumeFromHistory("race-1", (msg) => sent.push(msg)),
+      manager.resumeFromHistory("race-1", (msg) => sent.push(msg)),
+    ]);
+
+    // Exactly one resume wins; the other fails the synchronous guard.
+    expect([a.status, b.status].sort()).toEqual(["fulfilled", "rejected"]);
+    const rejected = (a.status === "rejected" ? a : b) as PromiseRejectedResult;
+    expect(String(rejected.reason)).toContain("is already active");
+
+    // Only one child process was ever constructed and it is still alive
+    // (the loser never got far enough to spawn-and-leak a second one).
+    expect(fakeInstances).toHaveLength(1);
+    expect(fakeInstances[0]!.killed).toBe(false);
+    expect((manager.getStatus("race-1") as AcpSessionState).status).toBe(
+      "running",
+    );
+    // Exactly one spawned event went out (single stream, not doubled).
+    expect(sent.filter((m) => m.type === "acp_session_spawned")).toHaveLength(
+      1,
+    );
+  });
+
+  test("concurrent resumes of distinct ids cannot exceed maxConcurrent", async () => {
+    fakeCaps.resume = true;
+    insertHistoryRow({ id: "cap-1" });
+    insertHistoryRow({ id: "cap-2" });
+
+    const manager = new AcpSessionManager(1);
+    const [a, b] = await Promise.allSettled([
+      manager.resumeFromHistory("cap-1", () => {}),
+      manager.resumeFromHistory("cap-2", () => {}),
+    ]);
+
+    expect([a.status, b.status].sort()).toEqual(["fulfilled", "rejected"]);
+    const rejected = (a.status === "rejected" ? a : b) as PromiseRejectedResult;
+    expect(String(rejected.reason)).toMatch(
+      /ACP concurrency limit reached \(max 1\)/,
+    );
+    expect(fakeInstances).toHaveLength(1);
+    expect(manager.getStatus() as AcpSessionState[]).toHaveLength(1);
+  });
+
+  test("cancel on a resumed session with no in-flight prompt persists and tears down", async () => {
+    fakeCaps.resume = true;
+    insertHistoryRow({
+      id: "idle-1",
+      eventLogJson: JSON.stringify([PERSISTED_EVENT]),
+    });
+
+    const manager = new AcpSessionManager(4);
+    await manager.resumeFromHistory("idle-1", () => {});
+
+    // No prompt is in flight, so cancel() itself must own the terminal
+    // persistence + teardown (there is no prompt handler to do it).
+    await manager.cancel("idle-1");
+
+    expect(fakeInstances[0]!.killed).toBe(true);
+    expect(internals(manager).sessions.has("idle-1")).toBe(false);
+    expect(internals(manager).eventBuffers.has("idle-1")).toBe(false);
+
+    const row = readHistoryRow("idle-1")!;
+    expect(row.status).toBe("cancelled");
+    expect(row.completed_at).not.toBeNull();
+    // The re-seeded event log survived the cancel-side persistence.
+    const log = JSON.parse(row.event_log_json) as Array<{ content?: string }>;
+    expect(log).toHaveLength(1);
+    expect(log[0]!.content).toBe("original-run-chunk");
+  });
+});
+
+describe("AcpSessionManager.steerOrResume", () => {
+  test("steers an in-memory session directly without a resume", async () => {
+    fakeCaps.resume = true;
+    insertHistoryRow({ id: "sor-live-1" });
+
+    const manager = new AcpSessionManager(4);
+    await manager.resumeFromHistory("sor-live-1", () => {});
+    expect(fakeInstances).toHaveLength(1);
+
+    const result = await manager.steerOrResume(
+      "sor-live-1",
+      "go faster",
+      () => {},
+    );
+    expect(result).toEqual({ resumed: false });
+    // No second process was constructed.
+    expect(fakeInstances).toHaveLength(1);
+    expect(fakeInstances[0]!.promptCalls).toEqual([
+      { sessionId: "proto-old", text: "go faster" },
+    ]);
+  });
+
+  test("session not in memory: resumes from history and fires the instruction atomically", async () => {
+    fakeCaps.resume = true;
+    insertHistoryRow({ id: "sor-resume-1" });
+
+    const manager = new AcpSessionManager(4);
+    const sent: ServerMessage[] = [];
+    const result = await manager.steerOrResume(
+      "sor-resume-1",
+      "continue the work",
+      (msg) => sent.push(msg),
+    );
+
+    expect(result).toEqual({ resumed: true });
+    const fake = fakeInstances[0]!;
+    expect(fake.resumeSessionCalls).toEqual([
+      { sessionId: "proto-old", cwd: "/tmp/proj" },
+    ]);
+    // The instruction prompt fired immediately after the resume - the
+    // session never sat running-idle with no in-flight prompt.
+    expect(fake.promptCalls).toEqual([
+      { sessionId: "proto-old", text: "continue the work" },
+    ]);
+    expect(sent.filter((m) => m.type === "acp_session_spawned")).toHaveLength(
+      1,
+    );
+  });
+
+  test("missing history row keeps the typed not-found error", async () => {
+    const manager = new AcpSessionManager(4);
+    const promise = manager.steerOrResume("sor-missing-1", "go", () => {});
+    await expect(promise).rejects.toBeInstanceOf(AcpSessionNotFoundError);
+  });
+
+  test("resume failure surfaces as AcpResumeError with the actionable hint", async () => {
+    insertHistoryRow({ id: "sor-legacy-1", cwd: null });
+
+    const manager = new AcpSessionManager(4);
+    const promise = manager.steerOrResume("sor-legacy-1", "go", () => {});
+    await expect(promise).rejects.toBeInstanceOf(AcpResumeError);
+    await expect(promise).rejects.toThrow(/recorded before resume support/);
+  });
+
+  test("post-resume steer failure tears the resumed session down instead of leaving it idle", async () => {
+    fakeCaps.resume = true;
+    insertHistoryRow({ id: "sor-fail-1" });
+
+    const manager = new AcpSessionManager(4);
+    promptThrowsSync = true;
+    const promise = manager.steerOrResume("sor-fail-1", "go", () => {});
+    await expect(promise).rejects.toBeInstanceOf(AcpResumeError);
+    await expect(promise).rejects.toThrow("prompt transport dead");
+
+    // The resumed session did not leak: process killed, maps cleared,
+    // terminal row persisted.
+    expect(fakeInstances[0]!.killed).toBe(true);
+    expect(internals(manager).sessions.has("sor-fail-1")).toBe(false);
+    expect(internals(manager).eventBuffers.has("sor-fail-1")).toBe(false);
+    expect(readHistoryRow("sor-fail-1")!.status).toBe("cancelled");
   });
 });

--- a/assistant/src/acp/auto-install.ts
+++ b/assistant/src/acp/auto-install.ts
@@ -3,9 +3,9 @@
  *
  * When a spawn fails preflight with `binary_not_found`, callers (the
  * `acp_spawn` tool and the `/v1/acp/spawn` route) call
- * `ensureAdapterInstalled(command)` to try a global npm install of the
- * mapped adapter package, then re-resolve and continue. On failure they
- * fall back to the existing actionable install hint.
+ * `resolveAgentWithAutoInstall(agentId)`, which tries a global npm install
+ * of the mapped adapter package, then re-resolves and continues. On failure
+ * they fall back to the existing actionable install hint.
  *
  * Security boundary: only commands present in `DEFAULT_AGENT_NPM_PACKAGES`
  * are ever installed. The package names are vendored constants, NOT user
@@ -17,6 +17,10 @@ import { execFile } from "node:child_process";
 
 import { DEFAULT_AGENT_NPM_PACKAGES } from "../config/acp-defaults.js";
 import { getLogger } from "../util/logger.js";
+import {
+  resolveAcpAgent,
+  type ResolveAcpAgentResult,
+} from "./resolve-agent.js";
 
 const log = getLogger("acp:auto-install");
 
@@ -111,6 +115,57 @@ async function runInstall(
     );
     return { installed: false, error };
   }
+}
+
+export interface ResolveWithAutoInstallResult {
+  /** The final resolver outcome (post-install re-resolve when applicable). */
+  resolved: ResolveAcpAgentResult;
+  /** Set when a missing adapter binary was silently installed via npm. */
+  autoInstalledPackage?: string;
+  /**
+   * Set when the auto-install itself failed: the original install hint
+   * augmented with the npm failure reason. Callers should surface this
+   * instead of re-deriving a message from `resolved`.
+   */
+  failureMessage?: string;
+}
+
+/**
+ * Resolve an ACP agent id, silently auto-installing the mapped adapter
+ * package when (and only when) the failure is a missing allowlisted binary.
+ * Shared by the `acp_spawn` tool and the `/v1/acp/spawn` route so the
+ * resolve-install-re-resolve flow has a single implementation; callers map
+ * the result to their transport (tool error result vs. HTTP error class).
+ */
+export async function resolveAgentWithAutoInstall(
+  agentId: string,
+): Promise<ResolveWithAutoInstallResult> {
+  const resolved = resolveAcpAgent(agentId);
+  if (resolved.ok || resolved.reason !== "binary_not_found") {
+    return { resolved };
+  }
+
+  const { command, hint } = resolved;
+  const install = await ensureAdapterInstalled(command);
+  if (install.installed) {
+    const retried = resolveAcpAgent(agentId);
+    if (retried.ok) {
+      log.info(
+        { agentId, command },
+        "Auto-installed missing ACP adapter binary",
+      );
+      return {
+        resolved: retried,
+        autoInstalledPackage: DEFAULT_AGENT_NPM_PACKAGES[command],
+      };
+    }
+  } else if (install.error) {
+    return {
+      resolved,
+      failureMessage: `${command} is not on PATH. ${hint} (auto-install failed: ${install.error})`,
+    };
+  }
+  return { resolved };
 }
 
 /** @internal: exposed for tests only. */

--- a/assistant/src/acp/resolve-agent.ts
+++ b/assistant/src/acp/resolve-agent.ts
@@ -33,8 +33,11 @@ import { isAcpEnabled } from "./feature-gate.js";
  */
 type AcpAgentSource = "config" | "default";
 
-type ResolveAcpAgentResult =
+export type ResolveAcpAgentResult =
   | { ok: true; agent: AcpAgentConfig }
+  | ResolveAcpAgentFailure;
+
+export type ResolveAcpAgentFailure =
   | { ok: false; reason: "acp_disabled"; hint: string }
   | { ok: false; reason: "unknown_agent"; available: string[] }
   | {
@@ -43,6 +46,33 @@ type ResolveAcpAgentResult =
       hint: string;
       command: string;
     };
+
+/**
+ * Single source of truth for the user-facing message of each resolver
+ * failure reason. Every caller that surfaces a resolve failure (acp_spawn
+ * tool, /v1/acp/spawn route, AcpSessionManager.resumeFromHistory) renders
+ * the same copy through this helper; only the transport wrapping (tool
+ * error result vs. HTTP error class vs. thrown Error) differs per caller.
+ */
+export function formatResolveFailure(
+  agentId: string,
+  failure: ResolveAcpAgentFailure,
+): string {
+  switch (failure.reason) {
+    case "acp_disabled":
+      return failure.hint;
+    case "unknown_agent":
+      return `Unknown agent "${agentId}". Available: ${failure.available.join(", ")}.`;
+    case "binary_not_found":
+      return `${failure.command} is not on PATH. ${failure.hint}`;
+    default: {
+      const _exhaustive: never = failure;
+      throw new Error(
+        `Unexpected acp resolver reason: ${(_exhaustive as { reason: string }).reason}`,
+      );
+    }
+  }
+}
 
 interface AcpAgentEntry {
   id: string;

--- a/assistant/src/acp/resume-hint.ts
+++ b/assistant/src/acp/resume-hint.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared `claude --resume` hint for ACP sessions.
+ *
+ * `claude --resume <id>` is Claude Code-specific (the claude-agent-acp
+ * adapter binary). Other adapters resume differently or not at all, so the
+ * hint is gated by the resolved binary, not the agent id - this stays
+ * correct when a user aliases an id to a different binary.
+ *
+ * Used by the `acp_spawn` tool's success payload and the session manager's
+ * completion notification so both surfaces render identical copy. Returns
+ * an empty string for non-claude commands; callers add their own
+ * surrounding separators.
+ */
+export function claudeResumeHint(
+  command: string,
+  cwd: string,
+  sessionId: string,
+): string {
+  return command === "claude-agent-acp"
+    ? `To resume: cd ${cwd} && claude --resume ${sessionId}`
+    : "";
+}

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -17,28 +17,36 @@ import { getLogger } from "../util/logger.js";
 import { AcpAgentProcess } from "./agent-process.js";
 import { VellumAcpClientHandler } from "./client-handler.js";
 import { prepareAgentEnv } from "./prepare-agent-env.js";
-import { resolveAcpAgent } from "./resolve-agent.js";
+import { formatResolveFailure, resolveAcpAgent } from "./resolve-agent.js";
+import { claudeResumeHint } from "./resume-hint.js";
 import type { AcpAgentConfig, AcpSessionState } from "./types.js";
 
 const log = getLogger("acp:session-manager");
 
-/** Single source of truth for the "unknown session id" error message. */
-function sessionNotFoundMessage(acpSessionId: string): string {
-  return `ACP session "${acpSessionId}" not found`;
+/**
+ * The manager's "unknown session id" error. Thrown whenever an operation
+ * references an acpSessionId with no in-memory entry (and, for resume, no
+ * persisted history row). Callers (acp_steer tool, /v1/acp/:id/steer route)
+ * use `instanceof` checks to map this to their transport's not-found shape.
+ */
+export class AcpSessionNotFoundError extends Error {
+  constructor(public readonly acpSessionId: string) {
+    super(`ACP session "${acpSessionId}" not found`);
+    this.name = "AcpSessionNotFoundError";
+  }
 }
 
 /**
- * Whether `err` is the manager's "unknown session id" error for
- * `acpSessionId`. Callers (acp_steer tool, /v1/acp/:id/steer route) use this
- * to decide when a failed steer should fall back to resumeFromHistory.
+ * Wraps failures from the resume-then-steer phase of `steerOrResume` so
+ * transport callers can distinguish them (HTTP 424 with the actionable
+ * resume hint) from plain steer failures (404). The message mirrors the
+ * underlying error's message; the original error rides on `cause`.
  */
-export function isAcpSessionNotFoundError(
-  err: unknown,
-  acpSessionId: string,
-): boolean {
-  return (
-    err instanceof Error && err.message === sessionNotFoundMessage(acpSessionId)
-  );
+export class AcpResumeError extends Error {
+  constructor(cause: unknown) {
+    super(cause instanceof Error ? cause.message : String(cause), { cause });
+    this.name = "AcpResumeError";
+  }
 }
 
 /** Maximum number of update events kept in a session's ring buffer. */
@@ -76,6 +84,16 @@ export class AcpSessionManager {
    * `acp_session_history` on terminal transition, then cleared.
    */
   private eventBuffers = new Map<string, BufferedAcpUpdate[]>();
+  /**
+   * Ids whose resumeFromHistory has passed its guards but not yet
+   * registered a SessionEntry (it is awaiting prepareAgentEnv). Reserved
+   * SYNCHRONOUSLY before the first await so concurrent resumes of the same
+   * id cannot both pass the guards (the loser would overwrite the winner's
+   * map entry and leak its child process), and so N concurrent resumes of
+   * distinct ids cannot exceed maxConcurrent. The spawn path needs no such
+   * reservation: its check-then-register is synchronous.
+   */
+  private pendingResumes = new Set<string>();
 
   constructor(private readonly maxConcurrent: number) {
     this.cleanupStaleRunningRows();
@@ -113,6 +131,20 @@ export class AcpSessionManager {
   }
 
   /**
+   * Concurrency guard shared by spawn() and resumeFromHistory(). Counts
+   * both registered sessions and in-flight resume reservations so the cap
+   * holds even while a resume is still awaiting prepareAgentEnv.
+   */
+  private assertCapacity(): void {
+    if (this.sessions.size + this.pendingResumes.size >= this.maxConcurrent) {
+      throw new Error(
+        `ACP concurrency limit reached (max ${this.maxConcurrent}). ` +
+          `Close an existing session before spawning a new one.`,
+      );
+    }
+  }
+
+  /**
    * Spawns a new ACP agent session. Returns the generated acpSessionId.
    *
    * The prompt is fired in the background — results stream via sessionUpdate
@@ -126,12 +158,7 @@ export class AcpSessionManager {
     parentConversationId: string,
     sendToVellum: (msg: ServerMessage) => void,
   ): Promise<{ acpSessionId: string; protocolSessionId: string }> {
-    if (this.sessions.size >= this.maxConcurrent) {
-      throw new Error(
-        `ACP concurrency limit reached (max ${this.maxConcurrent}). ` +
-          `Close an existing session before spawning a new one.`,
-      );
-    }
+    this.assertCapacity();
 
     const acpSessionId = randomUUID();
     log.info(
@@ -286,15 +313,13 @@ export class AcpSessionManager {
     acpSessionId: string,
     sendToVellum: (msg: ServerMessage) => void,
   ): Promise<void> {
-    if (this.sessions.has(acpSessionId)) {
+    if (
+      this.sessions.has(acpSessionId) ||
+      this.pendingResumes.has(acpSessionId)
+    ) {
       throw new Error(`ACP session "${acpSessionId}" is already active`);
     }
-    if (this.sessions.size >= this.maxConcurrent) {
-      throw new Error(
-        `ACP concurrency limit reached (max ${this.maxConcurrent}). ` +
-          `Close an existing session before spawning a new one.`,
-      );
-    }
+    this.assertCapacity();
 
     const row = getDb()
       .select()
@@ -302,7 +327,7 @@ export class AcpSessionManager {
       .where(eq(acpSessionHistory.id, acpSessionId))
       .get();
     if (!row) {
-      throw new Error(sessionNotFoundMessage(acpSessionId));
+      throw new AcpSessionNotFoundError(acpSessionId);
     }
     if (!row.cwd) {
       throw new Error(
@@ -320,41 +345,36 @@ export class AcpSessionManager {
 
     const resolved = resolveAcpAgent(row.agentId);
     if (!resolved.ok) {
-      switch (resolved.reason) {
-        case "acp_disabled":
-          throw new Error(resolved.hint);
-        case "unknown_agent":
-          throw new Error(
-            `Unknown agent "${row.agentId}". Available: ${resolved.available.join(", ")}.`,
-          );
-        case "binary_not_found":
-          throw new Error(
-            `${resolved.command} is not on PATH. ${resolved.hint}`,
-          );
-        default: {
-          const _exhaustive: never = resolved;
-          throw new Error(
-            `Unexpected acp resolver reason: ${(_exhaustive as { reason: string }).reason}`,
-          );
-        }
-      }
+      throw new Error(formatResolveFailure(row.agentId, resolved));
     }
-    const agentConfig = await prepareAgentEnv(resolved.agent);
+
+    // Everything up to here is synchronous. Reserve the id + concurrency
+    // slot BEFORE the first await so a concurrent resume of the same id
+    // (or a spawn racing the cap) fails the guards above instead of
+    // double-registering and leaking the first child process.
+    this.pendingResumes.add(acpSessionId);
+    let entry: SessionEntry;
+    try {
+      const agentConfig = await prepareAgentEnv(resolved.agent);
+      entry = this.registerSession({
+        acpSessionId,
+        agentId: row.agentId,
+        agentConfig,
+        parentConversationId: row.parentConversationId,
+        cwd: row.cwd,
+        startedAt: row.startedAt,
+        sendToVellum,
+      });
+    } finally {
+      // The reservation is either transferred to the sessions map by
+      // registerSession or released on prepareAgentEnv failure.
+      this.pendingResumes.delete(acpSessionId);
+    }
 
     log.info(
       { acpSessionId, agentId: row.agentId, cwd: row.cwd },
       "ACP resume from history requested",
     );
-
-    const entry = this.registerSession({
-      acpSessionId,
-      agentId: row.agentId,
-      agentConfig,
-      parentConversationId: row.parentConversationId,
-      cwd: row.cwd,
-      startedAt: row.startedAt,
-      sendToVellum,
-    });
     const { process: agentProcess, state, sendToVellum: wrappedSend } = entry;
 
     // Re-seed the ring buffer from the persisted event log, routed through
@@ -441,7 +461,7 @@ export class AcpSessionManager {
   async steer(acpSessionId: string, instruction: string): Promise<void> {
     const entry = this.sessions.get(acpSessionId);
     if (!entry) {
-      throw new Error(sessionNotFoundMessage(acpSessionId));
+      throw new AcpSessionNotFoundError(acpSessionId);
     }
 
     if (entry.state.status !== "running") {
@@ -475,21 +495,88 @@ export class AcpSessionManager {
   }
 
   /**
+   * Steers a session, transparently resuming it from persisted history
+   * first when it is no longer in memory (it completed, or the daemon
+   * restarted). The resume and the instruction prompt are atomic from the
+   * caller's perspective: a successfully resumed session immediately gets
+   * the instruction fired, so it never sits running-idle with no in-flight
+   * prompt (and therefore no teardown owner). If the post-resume steer
+   * fails, the freshly resumed session is closed (process killed, terminal
+   * row persisted, maps cleared) instead of being leaked.
+   *
+   * Error contract for transport callers (acp_steer tool, steer route):
+   * - `AcpSessionNotFoundError`: no in-memory session AND no history row.
+   * - `AcpResumeError`: the resume (or the steer immediately after it)
+   *   failed; the message carries the actionable hint.
+   * - any other error: the plain steer on an in-memory session failed.
+   */
+  async steerOrResume(
+    acpSessionId: string,
+    instruction: string,
+    sendToVellum: (msg: ServerMessage) => void,
+  ): Promise<{ resumed: boolean }> {
+    try {
+      await this.steer(acpSessionId, instruction);
+      return { resumed: false };
+    } catch (err) {
+      if (!(err instanceof AcpSessionNotFoundError)) throw err;
+    }
+
+    try {
+      await this.resumeFromHistory(acpSessionId, sendToVellum);
+    } catch (err) {
+      // A missing history row keeps its not-found shape; everything else
+      // (legacy row without cwd, resolver failure, capability missing)
+      // is a resume failure with an actionable message.
+      if (err instanceof AcpSessionNotFoundError) throw err;
+      throw new AcpResumeError(err);
+    }
+
+    try {
+      await this.steer(acpSessionId, instruction);
+    } catch (err) {
+      // Tear down the just-resumed session rather than leaving it
+      // running-idle with no prompt handler to own its cleanup.
+      try {
+        this.close(acpSessionId);
+      } catch (closeErr) {
+        log.warn(
+          { acpSessionId, err: closeErr },
+          "Failed to close ACP session after post-resume steer failure",
+        );
+      }
+      throw new AcpResumeError(err);
+    }
+    return { resumed: true };
+  }
+
+  /**
    * Cancels an ongoing prompt in the specified session.
    *
-   * The session's in-flight `prompt()` will reject in response, and the
-   * catch handler in `firePromptInBackground` performs the terminal
-   * persistence + teardown. We just flip the status here so that handler
-   * preserves "cancelled" instead of overwriting with "failed".
+   * When a prompt is in flight, its `prompt()` call rejects in response
+   * and the catch handler in `firePromptInBackground` performs the
+   * terminal persistence + teardown; we just flip the status here so that
+   * handler preserves "cancelled" instead of overwriting with "failed".
+   *
+   * When NO prompt is in flight there is no handler to own cleanup, so
+   * cancel persists and tears down the session itself. (Sessions normally
+   * always have a prompt in flight, but a cancel can race the window in
+   * steer() between clearing the old prompt and firing the new one.)
    */
   async cancel(acpSessionId: string): Promise<void> {
     const entry = this.sessions.get(acpSessionId);
     if (!entry) {
-      throw new Error(sessionNotFoundMessage(acpSessionId));
+      throw new AcpSessionNotFoundError(acpSessionId);
     }
     await entry.process.cancel(entry.state.acpSessionId);
     entry.state.status = "cancelled";
     entry.state.completedAt = Date.now();
+    // Re-check the map after the await: the in-flight prompt's handler may
+    // have already torn the session down while process.cancel was pending.
+    if (!entry.currentPrompt && this.sessions.get(acpSessionId) === entry) {
+      this.persistTerminal(acpSessionId, entry);
+      this.teardownSession(acpSessionId, entry);
+    }
   }
 
   /**
@@ -504,7 +591,7 @@ export class AcpSessionManager {
   close(acpSessionId: string): void {
     const entry = this.sessions.get(acpSessionId);
     if (!entry) {
-      throw new Error(sessionNotFoundMessage(acpSessionId));
+      throw new AcpSessionNotFoundError(acpSessionId);
     }
     if (
       entry.state.status === "running" ||
@@ -551,7 +638,7 @@ export class AcpSessionManager {
     if (acpSessionId) {
       const entry = this.sessions.get(acpSessionId);
       if (!entry) {
-        throw new Error(sessionNotFoundMessage(acpSessionId));
+        throw new AcpSessionNotFoundError(acpSessionId);
       }
       return entry.state;
     }
@@ -681,10 +768,12 @@ export class AcpSessionManager {
           const agentLabel = current.state.agentId;
           const responseText = current.clientHandler.responseText;
           const sessionId = current.state.acpSessionId;
-          const resumeHint =
-            current.command === "claude-agent-acp"
-              ? `\n\nTo resume: cd ${current.cwd} && claude --resume ${sessionId}`
-              : "";
+          const hint = claudeResumeHint(
+            current.command,
+            current.cwd,
+            sessionId,
+          );
+          const resumeHint = hint ? `\n\n${hint}` : "";
           const notifyMessage = `[ACP agent "${agentLabel}" completed]\n\n${responseText}${resumeHint}`;
           const parentConversation = findConversation(
             current.parentConversationId,

--- a/assistant/src/runtime/routes/__tests__/acp-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/acp-routes.test.ts
@@ -58,24 +58,24 @@ const spawnMock = mock(async () => ({
   protocolSessionId: "proto-route-session",
 }));
 
-const defaultSteerImpl = async (_id: string, _instruction: string) => {};
-let steerImpl: (id: string, instruction: string) => Promise<void> =
-  defaultSteerImpl;
-const steerMock = mock((id: string, instruction: string) =>
-  steerImpl(id, instruction),
-);
-
-let resumeImpl: (id: string) => Promise<void> = async () => {};
-const resumeFromHistoryMock = mock((id: string, _send: unknown) =>
-  resumeImpl(id),
+const defaultSteerOrResumeImpl = async (
+  _id: string,
+  _instruction: string,
+): Promise<{ resumed: boolean }> => ({ resumed: false });
+let steerOrResumeImpl: (
+  id: string,
+  instruction: string,
+) => Promise<{ resumed: boolean }> = defaultSteerOrResumeImpl;
+const steerOrResumeMock = mock(
+  (id: string, instruction: string, _send: unknown) =>
+    steerOrResumeImpl(id, instruction),
 );
 
 mock.module("../../../acp/index.js", () => ({
   getAcpSessionManager: () => ({
     getStatus: () => fakeInMemorySessions,
     spawn: spawnMock,
-    steer: steerMock,
-    resumeFromHistory: resumeFromHistoryMock,
+    steerOrResume: steerOrResumeMock,
   }),
 }));
 
@@ -88,7 +88,14 @@ mock.module("../../../acp/prepare-agent-env.js", () => ({
 const config = await installAcpConfigStub();
 const which = installWhichStub();
 
-import { getSqlite } from "../../../memory/db-connection.js";
+import {
+  clearHistory,
+  insertHistoryRow,
+} from "../../../acp/__tests__/helpers/acp-history-db.js";
+import {
+  AcpResumeError,
+  AcpSessionNotFoundError,
+} from "../../../acp/session-manager.js";
 import { initializeDb } from "../../../memory/db-init.js";
 import { FailedDependencyError, NotFoundError } from "../errors.js";
 
@@ -101,53 +108,6 @@ initializeDb();
 afterAll(() => {
   which.restore();
 });
-
-function clearHistory(): void {
-  getSqlite().run("DELETE FROM acp_session_history");
-}
-
-function insertHistoryRow(row: {
-  id: string;
-  agentId: string;
-  acpSessionId: string;
-  parentConversationId: string;
-  startedAt: number;
-  completedAt?: number | null;
-  status: string;
-  stopReason?: string | null;
-  error?: string | null;
-  eventLogJson?: string;
-}): void {
-  getSqlite()
-    .query(
-      /*sql*/ `
-      INSERT INTO acp_session_history (
-        id,
-        agent_id,
-        acp_session_id,
-        parent_conversation_id,
-        started_at,
-        completed_at,
-        status,
-        stop_reason,
-        error,
-        event_log_json
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      `,
-    )
-    .run(
-      row.id,
-      row.agentId,
-      row.acpSessionId,
-      row.parentConversationId,
-      row.startedAt,
-      row.completedAt ?? null,
-      row.status,
-      row.stopReason ?? null,
-      row.error ?? null,
-      row.eventLogJson ?? "[]",
-    );
-}
 
 function getSessionsHandler() {
   const route = ROUTES.find(
@@ -177,10 +137,8 @@ beforeEach(() => {
   clearHistory();
   resetExecFileStub();
   spawnMock.mockClear();
-  steerMock.mockClear();
-  steerImpl = defaultSteerImpl;
-  resumeFromHistoryMock.mockClear();
-  resumeImpl = async () => {};
+  steerOrResumeMock.mockClear();
+  steerOrResumeImpl = defaultSteerOrResumeImpl;
   _resetAdapterInstallCacheForTests();
   config.setConfig({});
   which.setWhich((cmd) => `/usr/local/bin/${cmd}`);
@@ -561,18 +519,14 @@ describe("POST /v1/acp/:id/steer: resume fallback", () => {
     });
 
     expect(body).toEqual({ acpSessionId: "live-1", steered: true });
-    expect(steerMock).toHaveBeenCalledTimes(1);
-    expect(resumeFromHistoryMock).not.toHaveBeenCalled();
+    expect(steerOrResumeMock).toHaveBeenCalledTimes(1);
+    expect(steerOrResumeMock.mock.calls[0][0]).toBe("live-1");
+    expect(steerOrResumeMock.mock.calls[0][1]).toBe("redirect");
+    expect(typeof steerOrResumeMock.mock.calls[0][2]).toBe("function");
   });
 
-  test("not-found session resumes from history then retries the steer", async () => {
-    let firstCall = true;
-    steerImpl = async (id) => {
-      if (firstCall) {
-        firstCall = false;
-        throw new Error(`ACP session "${id}" not found`);
-      }
-    };
+  test("resumed session reports the resumed flag", async () => {
+    steerOrResumeImpl = async () => ({ resumed: true });
 
     const handler = getSteerHandler();
     const body = await handler({
@@ -585,18 +539,11 @@ describe("POST /v1/acp/:id/steer: resume fallback", () => {
       steered: true,
       resumed: true,
     });
-    expect(resumeFromHistoryMock).toHaveBeenCalledTimes(1);
-    expect(resumeFromHistoryMock.mock.calls[0][0]).toBe("gone-1");
-    expect(typeof resumeFromHistoryMock.mock.calls[0][1]).toBe("function");
-    expect(steerMock).toHaveBeenCalledTimes(2);
   });
 
-  test("resume failing with not-found maps to NotFoundError", async () => {
-    steerImpl = async (id) => {
-      throw new Error(`ACP session "${id}" not found`);
-    };
-    resumeImpl = async (id) => {
-      throw new Error(`ACP session "${id}" not found`);
+  test("typed not-found (no session, no history row) maps to NotFoundError", async () => {
+    steerOrResumeImpl = async (id) => {
+      throw new AcpSessionNotFoundError(id);
     };
 
     const handler = getSteerHandler();
@@ -607,15 +554,14 @@ describe("POST /v1/acp/:id/steer: resume fallback", () => {
     await expect(promise).rejects.toBeInstanceOf(NotFoundError);
   });
 
-  test("resume failing with an actionable hint surfaces as FailedDependencyError", async () => {
-    steerImpl = async (id) => {
-      throw new Error(`ACP session "${id}" not found`);
-    };
-    resumeImpl = async (id) => {
-      throw new Error(
-        `ACP session "${id}" was recorded before resume support ` +
-          `(no working directory persisted) and cannot be resumed. ` +
-          `Spawn a new session instead.`,
+  test("resume failure surfaces as FailedDependencyError with the actionable hint", async () => {
+    steerOrResumeImpl = async (id) => {
+      throw new AcpResumeError(
+        new Error(
+          `ACP session "${id}" was recorded before resume support ` +
+            `(no working directory persisted) and cannot be resumed. ` +
+            `Spawn a new session instead.`,
+        ),
       );
     };
 
@@ -628,8 +574,8 @@ describe("POST /v1/acp/:id/steer: resume fallback", () => {
     await expect(promise).rejects.toThrow(/recorded before resume support/);
   });
 
-  test("non-not-found steer errors map to NotFoundError without a resume", async () => {
-    steerImpl = async (id) => {
+  test("plain steer errors map to NotFoundError", async () => {
+    steerOrResumeImpl = async (id) => {
       throw new Error(
         `ACP session "${id}" is not running (status: initializing)`,
       );
@@ -641,6 +587,5 @@ describe("POST /v1/acp/:id/steer: resume fallback", () => {
       body: { instruction: "go" },
     });
     await expect(promise).rejects.toBeInstanceOf(NotFoundError);
-    expect(resumeFromHistoryMock).not.toHaveBeenCalled();
   });
 });

--- a/assistant/src/runtime/routes/acp-routes.test.ts
+++ b/assistant/src/runtime/routes/acp-routes.test.ts
@@ -243,8 +243,8 @@ describe("POST /v1/acp/spawn", () => {
     which.setWhich({});
     // codex-acp is an allowlisted adapter, so the route attempts a silent
     // `npm i -g @zed-industries/codex-acp` before failing. Script that
-    // install to fail so the augmented hint path is exercised without ever
-    // shelling out to real npm.
+    // install to fail; the full auto-install failure surface is covered in
+    // __tests__/acp-routes.test.ts.
     execScripts.set("npm i", {
       error: new Error("EACCES: permission denied"),
     });
@@ -258,9 +258,7 @@ describe("POST /v1/acp/spawn", () => {
           conversationId: "conv-1",
         },
       }),
-    ).rejects.toThrow(
-      /codex-acp is not on PATH.*auto-install failed.*EACCES/,
-    );
+    ).rejects.toThrow("codex-acp is not on PATH");
   });
 
   test("body-shape guard short-circuits before the resolver runs", async () => {
@@ -478,6 +476,7 @@ describe("DELETE /v1/acp/sessions?status=completed", () => {
   });
 
   beforeEach(() => {
+    inMemoryStates.clear();
     getSqlite().run("DELETE FROM acp_session_history");
   });
 
@@ -501,6 +500,34 @@ describe("DELETE /v1/acp/sessions?status=completed", () => {
       "initializing",
       "running",
     ]);
+  });
+
+  test("excludes terminal rows whose session is active in memory (resumed sessions)", async () => {
+    // A resumed session reuses its original id: the in-memory state is
+    // `running` while its history row still carries the old terminal
+    // status until the next terminal upsert. The bulk delete must not
+    // remove that row out from under the live session.
+    seedHistoryRow("row-resumed", "completed", 1000);
+    seedHistoryRow("row-completed", "completed", 2000);
+    inMemoryStates.set("row-resumed", {
+      id: "row-resumed",
+      agentId: "claude",
+      acpSessionId: "proto-resumed",
+      parentConversationId: "conv-test",
+      status: "running",
+      startedAt: 1000,
+    });
+
+    const handler = getBulkDeleteHandler();
+    const result = (await handler({
+      queryParams: { status: "completed" },
+    })) as {
+      deleted: number;
+    };
+    expect(result.deleted).toBe(1);
+
+    const remaining = listRows();
+    expect(remaining).toEqual([{ id: "row-resumed", status: "completed" }]);
   });
 
   test("returns deleted=0 when no terminal rows are present", async () => {

--- a/assistant/src/runtime/routes/acp-routes.ts
+++ b/assistant/src/runtime/routes/acp-routes.ts
@@ -4,14 +4,14 @@
  * Exposes spawn, steer, cancel, close, sessions, and permission operations
  * over HTTP and IPC.
  */
-import { desc, eq, inArray } from "drizzle-orm";
+import { and, desc, eq, inArray, notInArray } from "drizzle-orm";
 import { z } from "zod";
 
-import { ensureAdapterInstalled } from "../../acp/auto-install.js";
+import { resolveAgentWithAutoInstall } from "../../acp/auto-install.js";
 import { getAcpSessionManager } from "../../acp/index.js";
 import { prepareAgentEnv } from "../../acp/prepare-agent-env.js";
-import { resolveAcpAgent } from "../../acp/resolve-agent.js";
-import { isAcpSessionNotFoundError } from "../../acp/session-manager.js";
+import { formatResolveFailure } from "../../acp/resolve-agent.js";
+import { AcpResumeError } from "../../acp/session-manager.js";
 import type { AcpSessionState } from "../../acp/types.js";
 import { getDb } from "../../memory/db-connection.js";
 import { rawChanges } from "../../memory/raw-query.js";
@@ -63,51 +63,19 @@ async function spawnSession({ body }: RouteHandlerArgs) {
     throw new BadRequestError("agent, task, and conversationId are required");
   }
 
-  let resolved = resolveAcpAgent(agent);
-
-  // Missing adapter binary: silently try a global npm install of the mapped
-  // package (allowlisted commands only; see acp/auto-install.ts), then
-  // re-resolve and continue. Failures degrade to the existing install hint
-  // augmented with the failure reason. Mirrors the skill-tool path in
-  // tools/acp/spawn.ts.
-  if (!resolved.ok && resolved.reason === "binary_not_found") {
-    const { command, hint } = resolved;
-    const install = await ensureAdapterInstalled(command);
-    if (install.installed) {
-      const retried = resolveAcpAgent(agent);
-      if (retried.ok) {
-        log.info(
-          { agent, command },
-          "Auto-installed missing ACP adapter binary",
-        );
-        resolved = retried;
-      }
-    } else if (install.error) {
-      throw new FailedDependencyError(
-        `${command} is not on PATH. ${hint} (auto-install failed: ${install.error})`,
-      );
-    }
+  // Resolve the agent, silently auto-installing a missing allowlisted
+  // adapter binary (see acp/auto-install.ts). Shared with the skill-tool
+  // path in tools/acp/spawn.ts; only the transport mapping differs.
+  const { resolved, failureMessage } = await resolveAgentWithAutoInstall(agent);
+  if (failureMessage) {
+    throw new FailedDependencyError(failureMessage);
   }
-
   if (!resolved.ok) {
-    switch (resolved.reason) {
-      case "acp_disabled":
-        throw new BadRequestError(resolved.hint);
-      case "unknown_agent":
-        throw new BadRequestError(
-          `Unknown agent "${agent}". Available: ${resolved.available.join(", ")}.`,
-        );
-      case "binary_not_found":
-        throw new FailedDependencyError(
-          `${resolved.command} is not on PATH. ${resolved.hint}`,
-        );
-      default: {
-        const _exhaustive: never = resolved;
-        throw new Error(
-          `Unexpected acp resolver reason: ${(_exhaustive as { reason: string }).reason}`,
-        );
-      }
+    const message = formatResolveFailure(agent, resolved);
+    if (resolved.reason === "binary_not_found") {
+      throw new FailedDependencyError(message);
     }
+    throw new BadRequestError(message);
   }
 
   // Inject required env vars and preflight via the shared helper. See
@@ -143,34 +111,31 @@ async function steerSession({ pathParams, body }: RouteHandlerArgs) {
     throw new BadRequestError("instruction is required");
   }
 
+  // Sessions no longer in memory (completed, or lost to a daemon restart)
+  // are transparently resumed from persisted history with the instruction
+  // fired in the same call, mirroring the acp_steer skill tool.
+  // broadcastMessage plays the sender role spawnSession gives it, so
+  // connected clients render the session.
   const manager = getAcpSessionManager();
   try {
-    await manager.steer(id, instruction);
-    return { acpSessionId: id, steered: true };
+    const { resumed } = await manager.steerOrResume(
+      id,
+      instruction,
+      broadcastMessage,
+    );
+    return resumed
+      ? { acpSessionId: id, steered: true, resumed: true }
+      : { acpSessionId: id, steered: true };
   } catch (err) {
-    if (!isAcpSessionNotFoundError(err, id)) {
-      throw new NotFoundError("ACP session not found");
-    }
-  }
-
-  // The session is no longer in memory (it completed, or the daemon
-  // restarted). Transparently resume it from persisted history and retry,
-  // mirroring the acp_steer skill tool. broadcastMessage plays the sender
-  // role spawnSession gives it, so connected clients render the session.
-  try {
-    await manager.resumeFromHistory(id, broadcastMessage);
-    await manager.steer(id, instruction);
-  } catch (err) {
-    if (isAcpSessionNotFoundError(err, id)) {
-      throw new NotFoundError("ACP session not found");
-    }
     // Resume errors carry the actionable hint (legacy row without cwd,
     // agent capability missing, resolver failures, ...).
-    throw new FailedDependencyError(
-      err instanceof Error ? err.message : String(err),
-    );
+    if (err instanceof AcpResumeError) {
+      throw new FailedDependencyError(err.message);
+    }
+    // Unknown ids (no in-memory session, no history row) and plain steer
+    // failures both map to 404, as before.
+    throw new NotFoundError("ACP session not found");
   }
-  return { acpSessionId: id, steered: true, resumed: true };
 }
 
 async function cancelSession({ pathParams }: RouteHandlerArgs) {
@@ -209,9 +174,25 @@ function bulkDeleteSessions({ queryParams }: RouteHandlerArgs) {
       "status query param is required and must be 'completed'",
     );
   }
+  // Exclude sessions currently active in memory: a resumed session reuses
+  // its original id, and its history row keeps the old terminal status
+  // until the next terminal upsert - a status-only delete would remove the
+  // row out from under the live session. Mirrors the 409 guard on the
+  // single-id delete route.
+  const activeIds = (
+    getAcpSessionManager().getStatus() as AcpSessionState[]
+  ).map((s) => s.id);
+  const terminalFilter = inArray(
+    acpSessionHistory.status,
+    TERMINAL_SESSION_STATUSES,
+  );
   getDb()
     .delete(acpSessionHistory)
-    .where(inArray(acpSessionHistory.status, TERMINAL_SESSION_STATUSES))
+    .where(
+      activeIds.length > 0
+        ? and(terminalFilter, notInArray(acpSessionHistory.id, activeIds))
+        : terminalFilter,
+    )
     .run();
   const deleted = rawChanges();
   log.info({ deleted }, "Bulk-cleared terminal ACP session history");
@@ -382,7 +363,8 @@ export const ROUTES: RouteDefinition[] = [
     summary: "Bulk-clear terminal ACP sessions",
     description:
       "Remove every terminal-state row (completed/failed/cancelled) from " +
-      "the persisted acp_session_history table.",
+      "the persisted acp_session_history table. Rows whose session is " +
+      "currently active in memory (e.g. resumed) are excluded.",
     tags: ["acp"],
     queryParams: [
       {

--- a/assistant/src/tools/acp/context.ts
+++ b/assistant/src/tools/acp/context.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared ToolContext accessors for the ACP tools.
+ */
+
+import type { ServerMessage } from "../../daemon/message-protocol.js";
+import type { ToolContext } from "../types.js";
+
+/**
+ * Narrows `ToolContext.sendToClient` to the `ServerMessage` sender the ACP
+ * session manager expects. ToolContext types the callback against an
+ * index-signature message shape (`{ type: string; [key: string]: unknown }`)
+ * that ServerMessage's union members don't structurally satisfy, so the
+ * cast lives here once instead of being duplicated at every ACP tool call
+ * site.
+ */
+export function getSendToClient(
+  context: ToolContext,
+): ((msg: ServerMessage) => void) | undefined {
+  return context.sendToClient as ((msg: ServerMessage) => void) | undefined;
+}

--- a/assistant/src/tools/acp/spawn.test.ts
+++ b/assistant/src/tools/acp/spawn.test.ts
@@ -495,7 +495,7 @@ describe("executeAcpSpawn — per-agent resume hint", () => {
     const [payloadJson] = result.content.split("\n\n");
     const payload = JSON.parse(payloadJson);
     expect(payload.message).toContain("claude --resume");
-    expect(payload.message).toContain("To resume this session later");
+    expect(payload.message).toContain("To resume:");
   });
 
   test("non-claude payload omits the `claude --resume` hint", async () => {
@@ -513,7 +513,7 @@ describe("executeAcpSpawn — per-agent resume hint", () => {
     const [payloadJson] = result.content.split("\n\n");
     const payload = JSON.parse(payloadJson);
     expect(payload.message).not.toContain("claude --resume");
-    expect(payload.message).not.toContain("To resume this session later");
+    expect(payload.message).not.toContain("To resume:");
   });
 });
 

--- a/assistant/src/tools/acp/spawn.ts
+++ b/assistant/src/tools/acp/spawn.ts
@@ -1,13 +1,15 @@
 import {
-  ensureAdapterInstalled,
   execFileWithTimeout,
+  resolveAgentWithAutoInstall,
 } from "../../acp/auto-install.js";
 import { getAcpSessionManager } from "../../acp/index.js";
 import { prepareAgentEnv } from "../../acp/prepare-agent-env.js";
-import { resolveAcpAgent } from "../../acp/resolve-agent.js";
+import { formatResolveFailure } from "../../acp/resolve-agent.js";
+import { claudeResumeHint } from "../../acp/resume-hint.js";
 import { DEFAULT_AGENT_NPM_PACKAGES } from "../../config/acp-defaults.js";
 import { getLogger } from "../../util/logger.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
+import { getSendToClient } from "./context.js";
 
 const log = getLogger("acp:spawn");
 
@@ -111,9 +113,7 @@ export async function executeAcpSpawn(
   // Pure precondition: check for a connected client BEFORE any side effects
   // (auto-install mutates the host via `npm i -g` and can block for up to
   // the install timeout). Without a client the spawn cannot succeed anyway.
-  const sendToClient = context.sendToClient as
-    | ((msg: { type: string; [key: string]: unknown }) => void)
-    | undefined;
+  const sendToClient = getSendToClient(context);
   if (!sendToClient) {
     return {
       content: "No client connected - cannot spawn ACP agent.",
@@ -121,53 +121,15 @@ export async function executeAcpSpawn(
     };
   }
 
-  let resolved = resolveAcpAgent(agent);
-
-  // Missing adapter binary: silently try a global npm install of the mapped
-  // package (allowlisted commands only; see acp/auto-install.ts), then
-  // re-resolve and continue. Failures degrade to the existing install hint
-  // augmented with the failure reason.
-  let autoInstalledPackage: string | null = null;
-  if (!resolved.ok && resolved.reason === "binary_not_found") {
-    const { command, hint } = resolved;
-    const install = await ensureAdapterInstalled(command);
-    if (install.installed) {
-      const retried = resolveAcpAgent(agent);
-      if (retried.ok) {
-        autoInstalledPackage = DEFAULT_AGENT_NPM_PACKAGES[command] ?? null;
-        resolved = retried;
-      }
-    } else if (install.error) {
-      return {
-        content: `${command} is not on PATH. ${hint} (auto-install failed: ${install.error})`,
-        isError: true,
-      };
-    }
+  // Resolve the agent, silently auto-installing a missing allowlisted
+  // adapter binary (see acp/auto-install.ts). Shared with the HTTP route.
+  const { resolved, autoInstalledPackage, failureMessage } =
+    await resolveAgentWithAutoInstall(agent);
+  if (failureMessage) {
+    return { content: failureMessage, isError: true };
   }
-
   if (!resolved.ok) {
-    switch (resolved.reason) {
-      case "acp_disabled":
-        return { content: resolved.hint, isError: true };
-      case "unknown_agent":
-        return {
-          content: `Unknown agent "${agent}". Available: ${resolved.available.join(
-            ", ",
-          )}.`,
-          isError: true,
-        };
-      case "binary_not_found":
-        return {
-          content: `${resolved.command} is not on PATH. ${resolved.hint}`,
-          isError: true,
-        };
-      default: {
-        const _exhaustive: never = resolved;
-        throw new Error(
-          `Unexpected acp resolver reason: ${(_exhaustive as { reason: string }).reason}`,
-        );
-      }
-    }
+    return { content: formatResolveFailure(agent, resolved), isError: true };
   }
 
   // Inject required env vars and preflight via the shared helper. Mirrors
@@ -197,17 +159,13 @@ export async function executeAcpSpawn(
       task,
       cwd,
       context.conversationId,
-      sendToClient as (msg: unknown) => void,
+      sendToClient,
     );
 
-    // `claude --resume <id>` is Claude Code-specific (the claude-agent-acp
-    // adapter binary). Other adapters resume differently or not at all,
-    // so the hint is gated by the resolved binary, not the agent id —
-    // this stays correct when a user aliases an id to a different binary.
-    const resumeHint =
-      agentConfig.command === "claude-agent-acp"
-        ? ` To resume this session later, run: cd ${cwd} && claude --resume ${protocolSessionId}`
-        : "";
+    // Claude Code-only resume hint; empty for other adapters. See
+    // acp/resume-hint.ts for the gating rationale.
+    const hint = claudeResumeHint(agentConfig.command, cwd, protocolSessionId);
+    const resumeHint = hint ? ` ${hint}` : "";
     const installNote = autoInstalledPackage
       ? ` Installed ${autoInstalledPackage} automatically.`
       : "";

--- a/assistant/src/tools/acp/steer.test.ts
+++ b/assistant/src/tools/acp/steer.test.ts
@@ -7,6 +7,7 @@ interface SteerCall {
   instruction: string;
 }
 
+// Direct steer (no connected client -> no resume fallback).
 const steerCalls: SteerCall[] = [];
 const defaultSteer = (acpSessionId: string, instruction: string) => {
   steerCalls.push({ acpSessionId, instruction });
@@ -15,9 +16,12 @@ const defaultSteer = (acpSessionId: string, instruction: string) => {
 let steerImpl: (acpSessionId: string, instruction: string) => Promise<void> =
   defaultSteer;
 
-const resumeCalls: Array<{ acpSessionId: string; send: unknown }> = [];
-let resumeImpl: (acpSessionId: string) => Promise<void> = () =>
-  Promise.resolve();
+// steerOrResume (connected client path).
+const steerOrResumeCalls: Array<SteerCall & { send: unknown }> = [];
+let steerOrResumeImpl: (
+  acpSessionId: string,
+  instruction: string,
+) => Promise<{ resumed: boolean }> = async () => ({ resumed: false });
 
 // Spread the real module's exports so transitive importers that pull other
 // names from `../../acp/index.js` still resolve at parse time. Bun's `mock.module` is
@@ -28,9 +32,13 @@ mock.module("../../acp/index.js", () => ({
   getAcpSessionManager: () => ({
     steer: (acpSessionId: string, instruction: string) =>
       steerImpl(acpSessionId, instruction),
-    resumeFromHistory: (acpSessionId: string, send: unknown) => {
-      resumeCalls.push({ acpSessionId, send });
-      return resumeImpl(acpSessionId);
+    steerOrResume: (
+      acpSessionId: string,
+      instruction: string,
+      send: unknown,
+    ) => {
+      steerOrResumeCalls.push({ acpSessionId, instruction, send });
+      return steerOrResumeImpl(acpSessionId, instruction);
     },
   }),
 }));
@@ -48,23 +56,26 @@ function makeContext(opts?: { withClient?: boolean }): ToolContext {
 
 beforeEach(() => {
   steerCalls.length = 0;
-  resumeCalls.length = 0;
+  steerOrResumeCalls.length = 0;
   steerImpl = defaultSteer;
-  resumeImpl = () => Promise.resolve();
+  steerOrResumeImpl = async () => ({ resumed: false });
 });
 
 describe("executeAcpSteer", () => {
-  test("happy path: returns steered status and forwards args to manager", async () => {
+  test("happy path: returns steered status and forwards args to steerOrResume", async () => {
     const result = await executeAcpSteer(
       { acp_session_id: "acp-123", instruction: "stop, do X instead" },
-      makeContext(),
+      makeContext({ withClient: true }),
     );
 
     expect(result.isError).toBe(false);
-    expect(steerCalls).toEqual([
-      { acpSessionId: "acp-123", instruction: "stop, do X instead" },
-    ]);
-    expect(resumeCalls).toEqual([]);
+    expect(steerOrResumeCalls).toHaveLength(1);
+    expect(steerOrResumeCalls[0]).toMatchObject({
+      acpSessionId: "acp-123",
+      instruction: "stop, do X instead",
+    });
+    expect(typeof steerOrResumeCalls[0]!.send).toBe("function");
+    expect(steerCalls).toEqual([]);
 
     const parsed = JSON.parse(result.content as string);
     expect(parsed).toEqual({
@@ -83,6 +94,7 @@ describe("executeAcpSteer", () => {
     expect(result.isError).toBe(true);
     expect(result.content).toContain('"instruction" is required');
     expect(steerCalls).toEqual([]);
+    expect(steerOrResumeCalls).toEqual([]);
   });
 
   test("missing acp_session_id returns isError", async () => {
@@ -94,6 +106,20 @@ describe("executeAcpSteer", () => {
     expect(result.isError).toBe(true);
     expect(result.content).toContain('"acp_session_id" is required');
     expect(steerCalls).toEqual([]);
+    expect(steerOrResumeCalls).toEqual([]);
+  });
+
+  test("no connected client: steers directly and never resumes", async () => {
+    const result = await executeAcpSteer(
+      { acp_session_id: "acp-direct", instruction: "redirect" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(steerCalls).toEqual([
+      { acpSessionId: "acp-direct", instruction: "redirect" },
+    ]);
+    expect(steerOrResumeCalls).toEqual([]);
   });
 
   test("'session not found' without a connected client surfaces the error", async () => {
@@ -108,18 +134,11 @@ describe("executeAcpSteer", () => {
     expect(result.isError).toBe(true);
     expect(result.content).toContain('Could not steer ACP session "acp-x"');
     expect(result.content).toContain("not found");
-    expect(resumeCalls).toEqual([]);
+    expect(steerOrResumeCalls).toEqual([]);
   });
 
-  test("'session not found' with a client: resumes from history and retries the steer", async () => {
-    let firstCall = true;
-    steerImpl = (acpSessionId, instruction) => {
-      if (firstCall) {
-        firstCall = false;
-        return Promise.reject(new Error('ACP session "acp-gone" not found'));
-      }
-      return defaultSteer(acpSessionId, instruction);
-    };
+  test("resumed session reports the resumed flag and message", async () => {
+    steerOrResumeImpl = async () => ({ resumed: true });
 
     const result = await executeAcpSteer(
       { acp_session_id: "acp-gone", instruction: "keep going" },
@@ -127,13 +146,7 @@ describe("executeAcpSteer", () => {
     );
 
     expect(result.isError).toBe(false);
-    expect(resumeCalls).toHaveLength(1);
-    expect(resumeCalls[0]!.acpSessionId).toBe("acp-gone");
-    expect(typeof resumeCalls[0]!.send).toBe("function");
-    // The retry went through after the resume.
-    expect(steerCalls).toEqual([
-      { acpSessionId: "acp-gone", instruction: "keep going" },
-    ]);
+    expect(steerOrResumeCalls).toHaveLength(1);
 
     const parsed = JSON.parse(result.content as string);
     expect(parsed).toEqual({
@@ -146,9 +159,7 @@ describe("executeAcpSteer", () => {
   });
 
   test("resume failure returns its actionable error message", async () => {
-    steerImpl = () =>
-      Promise.reject(new Error('ACP session "acp-legacy" not found'));
-    resumeImpl = () =>
+    steerOrResumeImpl = () =>
       Promise.reject(
         new Error(
           'ACP session "acp-legacy" was recorded before resume support (no working directory persisted) and cannot be resumed. Spawn a new session instead.',
@@ -165,11 +176,10 @@ describe("executeAcpSteer", () => {
       'Could not steer ACP session "acp-legacy"',
     );
     expect(result.content).toContain("recorded before resume support");
-    expect(steerCalls).toEqual([]);
   });
 
-  test("non-not-found steer errors never trigger a resume", async () => {
-    steerImpl = () =>
+  test("plain steer errors surface unchanged", async () => {
+    steerOrResumeImpl = () =>
       Promise.reject(
         new Error(
           'ACP session "acp-init" is not running (status: initializing)',
@@ -183,6 +193,5 @@ describe("executeAcpSteer", () => {
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain("is not running");
-    expect(resumeCalls).toEqual([]);
   });
 });

--- a/assistant/src/tools/acp/steer.ts
+++ b/assistant/src/tools/acp/steer.ts
@@ -1,6 +1,6 @@
 import { getAcpSessionManager } from "../../acp/index.js";
-import { isAcpSessionNotFoundError } from "../../acp/session-manager.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
+import { getSendToClient } from "./context.js";
 
 export async function executeAcpSteer(
   input: Record<string, unknown>,
@@ -17,38 +17,30 @@ export async function executeAcpSteer(
   }
 
   const manager = getAcpSessionManager();
+  const sendToClient = getSendToClient(context);
 
   try {
-    await manager.steer(acpSessionId, instruction);
-    return steeredResult(acpSessionId, { resumed: false });
+    if (!sendToClient) {
+      // Without a connected client there is no one to receive a resumed
+      // session's events, so skip the transparent resume fallback and
+      // steer the in-memory session only.
+      await manager.steer(acpSessionId, instruction);
+      return steeredResult(acpSessionId, { resumed: false });
+    }
+    // Sessions no longer in memory (completed, or lost to a daemon
+    // restart) are transparently resumed from persisted history and the
+    // instruction fired in the same call. Failure messages carry the
+    // actionable hint (e.g. "recorded before resume support", agent
+    // capability missing).
+    const { resumed } = await manager.steerOrResume(
+      acpSessionId,
+      instruction,
+      sendToClient,
+    );
+    return steeredResult(acpSessionId, { resumed });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-
-    // "Not found" means the session is no longer in memory (it completed,
-    // or the daemon restarted). Transparently resume it from persisted
-    // history and retry, when a client is connected to receive the
-    // resumed session's events.
-    const sendToClient = context.sendToClient as
-      | ((msg: { type: string; [key: string]: unknown }) => void)
-      | undefined;
-    if (!isAcpSessionNotFoundError(err, acpSessionId) || !sendToClient) {
-      return steerError(acpSessionId, msg);
-    }
-
-    try {
-      await manager.resumeFromHistory(
-        acpSessionId,
-        sendToClient as (msg: unknown) => void,
-      );
-      await manager.steer(acpSessionId, instruction);
-    } catch (resumeErr) {
-      // The resume error carries the actionable hint (e.g. "recorded
-      // before resume support", agent capability missing).
-      const resumeMsg =
-        resumeErr instanceof Error ? resumeErr.message : String(resumeErr);
-      return steerError(acpSessionId, resumeMsg);
-    }
-    return steeredResult(acpSessionId, { resumed: true });
+    return steerError(acpSessionId, msg);
   }
 }
 


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for acp-native-agent-ux.md.

- Gap: resumeFromHistory reserved its session slot after an await, letting concurrent resumes leak processes or exceed maxConcurrent; the slot is now reserved synchronously
- Gap: resumed sessions could sit running-idle with no teardown owner; steer+resume is now atomic via AcpSessionManager.steerOrResume and cancel() tears down promptless sessions
- Gap: bulk session delete could remove the history row of an actively resumed session; active ids are now excluded
- Consolidation: shared auto-install resolve helper, single resolver-failure formatter, typed AcpSessionNotFoundError, single claude resume hint helper, deduplicated tests/helpers