### PR TITLE
fix(conversation-starters): reduce stale TTL, add variety, fix failed-gen retry

### DIFF
--- a/assistant/src/__tests__/conversation-starter-routes.test.ts
+++ b/assistant/src/__tests__/conversation-starter-routes.test.ts
@@ -339,8 +339,8 @@ describe("GET /v1/conversation-starters", () => {
 
   test("does not re-enqueue for invalid items when within cooldown period", async () => {
     const now = Date.now();
-    // Generation happened 30 seconds ago (within the 60s cooldown)
-    const recentGenAt = now - 30_000;
+    // Last attempt 30 seconds ago (within the 5-minute cooldown)
+    const recentAttemptAt = now - 30_000;
     insertStarter({
       label: "Let me check calendar",
       prompt: "Let me check what Alice has today.",
@@ -354,8 +354,12 @@ describe("GET /v1/conversation-starters", () => {
       createdAt: now - 1,
     });
     setCheckpoint(
+      "conversation_starters:last_attempt_at:default",
+      String(recentAttemptAt),
+    );
+    setCheckpoint(
       "conversation_starters:last_gen_at:default",
-      String(recentGenAt),
+      String(recentAttemptAt),
     );
     setCheckpoint("conversation_starters:item_count_at_last_gen:default", "1");
     insertMemoryItem();
@@ -375,8 +379,8 @@ describe("GET /v1/conversation-starters", () => {
 
   test("re-enqueues for invalid items after cooldown expires", async () => {
     const now = Date.now();
-    // Generation happened 90 seconds ago (past the 60s cooldown)
-    const oldGenAt = now - 90_000;
+    // Last attempt 6 minutes ago (past the 5-minute cooldown)
+    const oldAttemptAt = now - 6 * 60_000;
     insertStarter({
       label: "Let me check calendar",
       prompt: "Let me check what Alice has today.",
@@ -390,8 +394,12 @@ describe("GET /v1/conversation-starters", () => {
       createdAt: now - 1,
     });
     setCheckpoint(
+      "conversation_starters:last_attempt_at:default",
+      String(oldAttemptAt),
+    );
+    setCheckpoint(
       "conversation_starters:last_gen_at:default",
-      String(oldGenAt),
+      String(oldAttemptAt),
     );
     setCheckpoint("conversation_starters:item_count_at_last_gen:default", "1");
     insertMemoryItem();

--- a/assistant/src/memory/conversation-starter-checkpoints.ts
+++ b/assistant/src/memory/conversation-starter-checkpoints.ts
@@ -15,6 +15,7 @@ import { memoryCheckpoints } from "./schema.js";
 export const CK_ITEM_COUNT = "conversation_starters:item_count_at_last_gen";
 export const CK_BATCH = "conversation_starters:generation_batch";
 export const CK_LAST_GEN_AT = "conversation_starters:last_gen_at";
+export const CK_LAST_ATTEMPT_AT = "conversation_starters:last_attempt_at";
 
 export function checkpointKey(base: string, scopeId: string): string {
   return `${base}:${scopeId}`;

--- a/assistant/src/memory/job-handlers/conversation-starters.ts
+++ b/assistant/src/memory/job-handlers/conversation-starters.ts
@@ -22,6 +22,7 @@ import {
   checkpointKey,
   CK_BATCH,
   CK_ITEM_COUNT,
+  CK_LAST_ATTEMPT_AT,
   CK_LAST_GEN_AT,
   countActiveMemoryNodes,
   getCheckpointValue,
@@ -336,6 +337,7 @@ Bad → Good (incomplete phrase → complete):
         config: {
           callSite: "conversationStarters" as const,
           max_tokens: 2048,
+          temperature: 1,
           tool_choice: {
             type: "tool" as const,
             name: "store_conversation_starters",
@@ -395,18 +397,27 @@ export async function generateConversationStartersJob(
   const db = getDb();
   const now = Date.now();
 
+  // Record attempt time so the route handler's cooldown prevents rapid retries
+  // even when generation produces 0 valid starters.
+  upsertCheckpoint(
+    checkpointKey(CK_LAST_ATTEMPT_AT, scopeId),
+    String(now),
+    now,
+  );
+
   const starters = await generateStarters(scopeId);
   if (starters.length === 0) {
     log.info({ scopeId }, "No conversation starters generated");
 
-    // Sync checkpoints so both `staleByAge` and `checkpointAhead` clear.
+    // Sync the item count checkpoint so `checkpointAhead` clears, but do NOT
+    // update `CK_LAST_GEN_AT` — the stale TTL should trigger a retry on the
+    // next GET rather than blocking retries for the full TTL window.
     const totalActive = countActiveMemoryNodes(scopeId);
     upsertCheckpoint(
       checkpointKey(CK_ITEM_COUNT, scopeId),
       String(totalActive),
       now,
     );
-    upsertCheckpoint(checkpointKey(CK_LAST_GEN_AT, scopeId), String(now), now);
     return;
   }
 

--- a/assistant/src/runtime/routes/conversation-starter-routes.ts
+++ b/assistant/src/runtime/routes/conversation-starter-routes.ts
@@ -11,6 +11,7 @@ import { z } from "zod";
 import {
   checkpointKey,
   CK_ITEM_COUNT,
+  CK_LAST_ATTEMPT_AT,
   CK_LAST_GEN_AT,
   countActiveMemoryNodes,
   getCheckpointValue,
@@ -42,10 +43,11 @@ const starterItemSchema = z.object({
 
 type StarterItem = z.infer<typeof starterItemSchema>;
 
-export const CONVERSATION_STARTERS_STALE_TTL_MS = 24 * 60 * 60 * 1000;
+export const CONVERSATION_STARTERS_STALE_TTL_MS = 4 * 60 * 60 * 1000;
 
-/** Minimum interval between re-enqueue attempts triggered by invalid items. */
-const REFRESH_COOLDOWN_MS = 60_000;
+/** Minimum interval between re-enqueue attempts (prevents tight retry loops
+ *  when generation repeatedly fails or produces 0 valid starters). */
+const REFRESH_COOLDOWN_MS = 5 * 60 * 1000;
 
 function hasActiveConversationStarterJob(
   db: ReturnType<typeof getDb>,
@@ -199,12 +201,16 @@ function handleListConversationStarters({
       Date.now() - lastGenAt >= CONVERSATION_STARTERS_STALE_TTL_MS;
     const checkpointAhead = lastCount != null && totalActive < lastCount;
     let hasActiveJob = hasActiveConversationStarterJob(db, scopeId);
+    const lastAttemptAt = parseCheckpointInt(
+      getCheckpointValue(checkpointKey(CK_LAST_ATTEMPT_AT, scopeId)),
+    );
     const withinCooldown =
-      lastGenAt != null && Date.now() - lastGenAt < REFRESH_COOLDOWN_MS;
+      lastAttemptAt != null && Date.now() - lastAttemptAt < REFRESH_COOLDOWN_MS;
     const shouldRefresh =
-      staleByAge ||
-      checkpointAhead ||
-      (invalidItemCount > 0 && totalActive > 0 && !withinCooldown);
+      !withinCooldown &&
+      (staleByAge ||
+        checkpointAhead ||
+        (invalidItemCount > 0 && totalActive > 0));
 
     if (shouldRefresh && !hasActiveJob && isMemoryEnabled()) {
       enqueueMemoryJob("generate_conversation_starters", { scopeId });


### PR DESCRIPTION
## Summary

- Reduce `CONVERSATION_STARTERS_STALE_TTL_MS` from 24h to 4h so chips regenerate more frequently
- Add `temperature: 1` to the generation LLM call so the same memory context produces varied starters instead of deterministic identical output
- Stop updating `CK_LAST_GEN_AT` when generation produces 0 valid starters — previously a failed generation reset the 24h timer, freezing stale chips indefinitely. Now uses a separate `CK_LAST_ATTEMPT_AT` checkpoint (restoring Alex's original design from the deleted `conversation-starters-policy.ts`) with a 5-minute cooldown

## Test plan

- [x] `bunx tsc --noEmit` passes
- [x] `bun test conversation-starter-routes.test.ts` — 19 pass
- [x] `bun test conversation-starters-cadence.test.ts` — 7 pass
- [ ] Verify on web: opening new empty conversations shows varied chips over time

🤖 Generated with [Claude Code](https://claude.com/claude-code)