### PR TITLE
fix(conversation-starters): lower generation temperature from 1 to 0.7

### DIFF
--- a/assistant/src/memory/job-handlers/conversation-starters.ts
+++ b/assistant/src/memory/job-handlers/conversation-starters.ts
@@ -337,7 +337,7 @@ Bad → Good (incomplete phrase → complete):
         config: {
           callSite: "conversationStarters" as const,
           max_tokens: 2048,
-          temperature: 1,
+          temperature: 0.7,
           tool_choice: {
             type: "tool" as const,
             name: "store_conversation_starters",


### PR DESCRIPTION
## Summary

- Lower conversation starters generation temperature from 1 to 0.7 — temp 1 is too aggressive for structured tool-use output, risking malformed JSON and validation failures

Follow-up to #33672.

🤖 Generated with [Claude Code](https://claude.com/claude-code)