### PR TITLE
fix(migration): run adaptive thinking repair after overlay merge

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -98,6 +98,7 @@ import {
   updateWorkItem,
 } from "../work-items/work-item-store.js";
 import { WorkspaceHeartbeatService } from "../workspace/heartbeat-service.js";
+import { repairAdaptiveThinkingOnManagedProfiles } from "../workspace/migrations/097-enable-adaptive-thinking-managed-profiles.js";
 import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
 import { runWorkspaceMigrations } from "../workspace/migrations/runner.js";
 import {
@@ -587,6 +588,26 @@ export async function runDaemon(): Promise<void> {
         { err },
         "Inference profile seeding failed — continuing startup",
       );
+    }
+
+    // Re-run the adaptive thinking repair after overlay merge + profile seeding.
+    // Workspace migration 097 enables adaptive thinking on managed profiles, but
+    // it runs before mergeDefaultWorkspaceConfig() which can overwrite the fix
+    // with overlay profiles that have thinking disabled or absent. On-platform
+    // instances where the overlay supplies "balanced" / "quality-optimized"
+    // profiles without thinking enabled would be stuck permanently because the
+    // migration is already checkpointed as completed. This idempotent repair
+    // ensures thinking is enabled regardless of overlay ordering.
+    if (defaultConfigMerge.hadOverlay) {
+      try {
+        repairAdaptiveThinkingOnManagedProfiles(getWorkspaceDir());
+        log.info("Post-overlay adaptive thinking repair complete");
+      } catch (err) {
+        log.warn(
+          { err },
+          "Post-overlay adaptive thinking repair failed — continuing startup",
+        );
+      }
     }
 
     log.info("Daemon startup: loading config");

--- a/assistant/src/workspace/migrations/097-enable-adaptive-thinking-managed-profiles.ts
+++ b/assistant/src/workspace/migrations/097-enable-adaptive-thinking-managed-profiles.ts
@@ -26,59 +26,76 @@ import type { WorkspaceMigration } from "./types.js";
 const ADAPTIVE_THINKING = { enabled: true, streamThinking: true } as const;
 const TARGET_PROFILES = ["balanced", "quality-optimized"] as const;
 
+/**
+ * Patch managed Anthropic profiles that are missing adaptive thinking.
+ *
+ * Exported so lifecycle.ts can re-run the repair after mergeDefaultWorkspaceConfig()
+ * and seedInferenceProfiles(). On-platform instances with a config overlay have their
+ * profiles overwritten by the overlay merge (which runs after workspace migrations),
+ * so the migration alone is insufficient — the post-overlay call ensures the repair
+ * sticks even when the overlay supplies profiles without thinking enabled.
+ *
+ * The function is idempotent: profiles that already have thinking enabled are skipped.
+ */
+export function repairAdaptiveThinkingOnManagedProfiles(
+  workspaceDir: string,
+): void {
+  const configPath = join(workspaceDir, "config.json");
+  if (!existsSync(configPath)) return;
+
+  let config: Record<string, unknown>;
+  try {
+    const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+    config = raw as Record<string, unknown>;
+  } catch {
+    return;
+  }
+
+  const llm = readObject(config.llm);
+  if (llm === null) return;
+
+  const profiles = readObject(llm.profiles);
+  if (profiles === null) return;
+
+  let changed = false;
+
+  for (const name of TARGET_PROFILES) {
+    const profile = readObject(profiles[name]);
+    if (profile === null) continue;
+
+    // Only patch managed Anthropic profiles.
+    if (profile.source !== "managed") continue;
+    if (
+      typeof profile.provider === "string" &&
+      profile.provider !== "anthropic"
+    ) {
+      continue;
+    }
+
+    // Skip if thinking is already enabled.
+    const thinking = readObject(profile.thinking);
+    if (thinking !== null && thinking.enabled === true) continue;
+
+    profile.thinking = { ...ADAPTIVE_THINKING };
+    profiles[name] = profile;
+    changed = true;
+  }
+
+  if (changed) {
+    llm.profiles = profiles;
+    config.llm = llm;
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  }
+}
+
 export const enableAdaptiveThinkingManagedProfilesMigration: WorkspaceMigration =
   {
     id: "097-enable-adaptive-thinking-managed-profiles",
     description:
       "Enable adaptive thinking on managed balanced and quality-optimized profiles",
     run(workspaceDir: string): void {
-      const configPath = join(workspaceDir, "config.json");
-      if (!existsSync(configPath)) return;
-
-      let config: Record<string, unknown>;
-      try {
-        const raw = JSON.parse(readFileSync(configPath, "utf-8"));
-        if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
-        config = raw as Record<string, unknown>;
-      } catch {
-        return;
-      }
-
-      const llm = readObject(config.llm);
-      if (llm === null) return;
-
-      const profiles = readObject(llm.profiles);
-      if (profiles === null) return;
-
-      let changed = false;
-
-      for (const name of TARGET_PROFILES) {
-        const profile = readObject(profiles[name]);
-        if (profile === null) continue;
-
-        // Only patch managed Anthropic profiles.
-        if (profile.source !== "managed") continue;
-        if (
-          typeof profile.provider === "string" &&
-          profile.provider !== "anthropic"
-        ) {
-          continue;
-        }
-
-        // Skip if thinking is already enabled.
-        const thinking = readObject(profile.thinking);
-        if (thinking !== null && thinking.enabled === true) continue;
-
-        profile.thinking = { ...ADAPTIVE_THINKING };
-        profiles[name] = profile;
-        changed = true;
-      }
-
-      if (changed) {
-        llm.profiles = profiles;
-        config.llm = llm;
-        writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
-      }
+      repairAdaptiveThinkingOnManagedProfiles(workspaceDir);
     },
     down(_workspaceDir: string): void {
       // Forward-only.


### PR DESCRIPTION
## Summary
- Addresses Codex review feedback from #33522
- Workspace migration 097 enables adaptive thinking on managed profiles, but runs before `mergeDefaultWorkspaceConfig()` — meaning platform overlay profiles could overwrite the fix and the migration checkpoint prevents re-running
- Extracts the repair logic into `repairAdaptiveThinkingOnManagedProfiles()` and calls it again in lifecycle.ts after overlay merge + profile seeding, gated on `hadOverlay`
- The repair is idempotent (skips profiles that already have thinking enabled)

## Test plan
- [ ] Verify on-platform instance with overlay that supplies balanced/quality-optimized profiles without thinking gets thinking enabled after startup
- [ ] Verify off-platform (BYOK) instances are unaffected (no overlay, repair skipped)
- [ ] Verify idempotency: profiles with thinking already enabled are not modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)