### PR TITLE
fix(migration): treat legacy profiles without source field as managed

### DIFF
--- a/assistant/src/workspace/migrations/097-enable-adaptive-thinking-managed-profiles.ts
+++ b/assistant/src/workspace/migrations/097-enable-adaptive-thinking-managed-profiles.ts
@@ -20,7 +20,8 @@ import type { WorkspaceMigration } from "./types.js";
 // explicitly disabled. It skips profiles that:
 //   - Don't exist (no profile to patch)
 //   - Already have thinking enabled (idempotent)
-//   - Are not source: "managed" (user-created profiles are untouched)
+//   - Are source: "user" (user-created profiles are untouched)
+//   - Have a non-managed, non-absent source (unknown origin)
 //   - Use a non-Anthropic provider (adaptive thinking is Anthropic-specific)
 
 const ADAPTIVE_THINKING = { enabled: true, streamThinking: true } as const;
@@ -65,7 +66,13 @@ export function repairAdaptiveThinkingOnManagedProfiles(
     if (profile === null) continue;
 
     // Only patch managed Anthropic profiles.
-    if (profile.source !== "managed") continue;
+    // Legacy profiles created before the `source` metadata field was introduced
+    // have source=undefined. Treat these as managed when the profile name is one
+    // of the canonical managed names (which TARGET_PROFILES already guarantees)
+    // and the provider is Anthropic (or absent). Explicit `source: "user"`
+    // profiles are always skipped.
+    if (profile.source === "user") continue;
+    if (profile.source !== undefined && profile.source !== "managed") continue;
     if (
       typeof profile.provider === "string" &&
       profile.provider !== "anthropic"


### PR DESCRIPTION
## Summary
- Addresses Codex review feedback from #33523
- Legacy platform profiles created before the `source` metadata field was introduced have `source=undefined`, causing the adaptive thinking migration to skip them
- Now treats profiles as managed when `source` is absent (undefined) for canonical profile names with Anthropic provider, while still respecting explicit `source: "user"` profiles

## Test plan
- [ ] Verify migration patches a profile with `source: "managed"` (existing behavior)
- [ ] Verify migration patches a profile with `source: undefined` (the fix)
- [ ] Verify migration skips a profile with `source: "user"`
- [ ] Verify migration skips a profile with a non-Anthropic provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)