### PR TITLE
fix: ACP in-flight resume edge cases (delete guards, dispose, concurrent steer)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -143,7 +143,7 @@ paths:
       summary: Bulk-clear terminal ACP sessions
       description:
         Remove every terminal-state row (completed/failed/cancelled) from the persisted acp_session_history table.
-        Rows whose session is currently active in memory (e.g. resumed) are excluded.
+        Rows whose session is currently active in memory (e.g. resumed) or has a resume in flight are excluded.
       tags:
         - acp
       responses:
@@ -245,8 +245,8 @@ paths:
       operationId: acp_sessions_by_id_delete
       summary: Delete ACP session from history
       description:
-        Remove a persisted ACP session row. Rejects with 409 when the session is still active in memory; idempotent
-        for unknown ids.
+        Remove a persisted ACP session row. Rejects with 409 when the session is still active in memory or has a
+        resume in flight; idempotent for unknown ids.
       tags:
         - acp
       responses:

--- a/assistant/src/acp/__tests__/session-manager-resume.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-resume.test.ts
@@ -112,9 +112,15 @@ mock.module("../agent-process.js", () => ({
   AcpAgentProcess: FakeAcpAgentProcess,
 }));
 
-// Identity env-prep: credential-broker plumbing has its own suite.
+// Identity env-prep: credential-broker plumbing has its own suite. Tests
+// that need to observe the manager mid-resume (dispose, pending-id
+// visibility) set `prepareAgentEnvGate` to stall the resume here.
+let prepareAgentEnvGate: Promise<void> | null = null;
 mock.module("../prepare-agent-env.js", () => ({
-  prepareAgentEnv: async (agentConfig: unknown) => agentConfig,
+  prepareAgentEnv: async (agentConfig: unknown) => {
+    if (prepareAgentEnvGate) await prepareAgentEnvGate;
+    return agentConfig;
+  },
 }));
 
 // Resolver stub: defaults to resolving every id to the claude adapter.
@@ -161,6 +167,7 @@ function countHistoryRows(): number {
 type ManagerInternals = {
   sessions: Map<string, { clientHandler: FakeClient }>;
   eventBuffers: Map<string, Array<{ update: AcpSessionUpdate }>>;
+  pendingResumes: Map<string, Promise<void>>;
 };
 
 function internals(
@@ -176,6 +183,7 @@ beforeEach(() => {
   fakeCaps.resume = false;
   replayChunks = [];
   promptThrowsSync = false;
+  prepareAgentEnvGate = null;
   resolveImpl = () => ({
     ok: true,
     agent: { command: "claude-agent-acp", args: [] },
@@ -426,6 +434,53 @@ describe("AcpSessionManager.resumeFromHistory", () => {
     expect(manager.getStatus() as AcpSessionState[]).toHaveLength(1);
   });
 
+  test("getActiveAndPendingIds surfaces a resume still awaiting env prep", async () => {
+    fakeCaps.resume = true;
+    insertHistoryRow({ id: "pending-vis-1" });
+    let release!: () => void;
+    prepareAgentEnvGate = new Promise((res) => {
+      release = res;
+    });
+
+    const manager = new AcpSessionManager(4);
+    const promise = manager.resumeFromHistory("pending-vis-1", () => {});
+
+    // Mid-resume: no SessionEntry yet (getStatus throws not-found), but the
+    // id must already be visible to the delete guards.
+    expect(() => manager.getStatus("pending-vis-1")).toThrow(/not found/);
+    expect(manager.getActiveAndPendingIds()).toEqual(["pending-vis-1"]);
+
+    release();
+    await promise;
+
+    // After the resume lands the id comes from the sessions map and the
+    // reservation is gone (no duplicate).
+    expect(manager.getActiveAndPendingIds()).toEqual(["pending-vis-1"]);
+    expect(internals(manager).pendingResumes.size).toBe(0);
+  });
+
+  test("dispose during prepareAgentEnv aborts the resume before any process spawns", async () => {
+    fakeCaps.resume = true;
+    insertHistoryRow({ id: "dispose-1" });
+    let release!: () => void;
+    prepareAgentEnvGate = new Promise((res) => {
+      release = res;
+    });
+
+    const manager = new AcpSessionManager(4);
+    const promise = manager.resumeFromHistory("dispose-1", () => {});
+    manager.dispose();
+    release();
+
+    await expect(promise).rejects.toThrow(/disposed/);
+    // No child process was ever constructed on the disposed manager, and
+    // the reservation was released.
+    expect(fakeInstances).toHaveLength(0);
+    expect(internals(manager).pendingResumes.size).toBe(0);
+    expect(internals(manager).sessions.size).toBe(0);
+    expect(internals(manager).eventBuffers.size).toBe(0);
+  });
+
   test("cancel on a resumed session with no in-flight prompt persists and tears down", async () => {
     fakeCaps.resume = true;
     insertHistoryRow({
@@ -516,6 +571,41 @@ describe("AcpSessionManager.steerOrResume", () => {
     const promise = manager.steerOrResume("sor-legacy-1", "go", () => {});
     await expect(promise).rejects.toBeInstanceOf(AcpResumeError);
     await expect(promise).rejects.toThrow(/recorded before resume support/);
+  });
+
+  test("concurrent steerOrResume on the same id: the loser awaits the in-flight resume and steers", async () => {
+    fakeCaps.resume = true;
+    insertHistoryRow({ id: "sor-race-1" });
+
+    const manager = new AcpSessionManager(4);
+    const sent: ServerMessage[] = [];
+    const [a, b] = await Promise.all([
+      manager.steerOrResume("sor-race-1", "first instruction", (msg) =>
+        sent.push(msg),
+      ),
+      manager.steerOrResume("sor-race-1", "second instruction", (msg) =>
+        sent.push(msg),
+      ),
+    ]);
+
+    // Neither caller got the misleading "already active" resume error;
+    // both landed their instruction on the single resumed session.
+    expect(a).toEqual({ resumed: true });
+    expect(b).toEqual({ resumed: true });
+    expect(fakeInstances).toHaveLength(1);
+    const fake = fakeInstances[0]!;
+    expect(fake.resumeSessionCalls).toHaveLength(1);
+    expect(fake.promptCalls.map((c) => c.text).sort()).toEqual([
+      "first instruction",
+      "second instruction",
+    ]);
+    // Single spawned event: one resume happened, not two.
+    expect(sent.filter((m) => m.type === "acp_session_spawned")).toHaveLength(
+      1,
+    );
+    expect((manager.getStatus("sor-race-1") as AcpSessionState).status).toBe(
+      "running",
+    );
   });
 
   test("post-resume steer failure tears the resumed session down instead of leaving it idle", async () => {

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -75,6 +75,15 @@ interface SessionEntry {
   command: string;
 }
 
+/**
+ * An `acp_session_history` row that passed resumeFromHistory's validation
+ * guards: `cwd` (nullable in the schema for pre-resume-support rows) is
+ * guaranteed present.
+ */
+type ResumableHistoryRow = typeof acpSessionHistory.$inferSelect & {
+  cwd: string;
+};
+
 export class AcpSessionManager {
   private sessions = new Map<string, SessionEntry>();
   /**
@@ -85,15 +94,24 @@ export class AcpSessionManager {
    */
   private eventBuffers = new Map<string, BufferedAcpUpdate[]>();
   /**
-   * Ids whose resumeFromHistory has passed its guards but not yet
-   * registered a SessionEntry (it is awaiting prepareAgentEnv). Reserved
-   * SYNCHRONOUSLY before the first await so concurrent resumes of the same
-   * id cannot both pass the guards (the loser would overwrite the winner's
-   * map entry and leak its child process), and so N concurrent resumes of
-   * distinct ids cannot exceed maxConcurrent. The spawn path needs no such
-   * reservation: its check-then-register is synchronous.
+   * In-flight resumes by session id, keyed to the promise of the resume's
+   * async body. Reserved SYNCHRONOUSLY before the first await so concurrent
+   * resumes of the same id cannot both pass the guards (the loser would
+   * overwrite the winner's map entry and leak its child process), and so N
+   * concurrent resumes of distinct ids cannot exceed maxConcurrent. The
+   * entry lives until the resume settles so `steerOrResume` can await a
+   * concurrent caller's resume instead of failing the already-active guard.
+   * The spawn path needs no such reservation: its check-then-register is
+   * synchronous.
    */
-  private pendingResumes = new Set<string>();
+  private pendingResumes = new Map<string, Promise<void>>();
+
+  /**
+   * Set by dispose() (the daemon-shutdown path). Resumes that are mid-await
+   * when the manager is disposed re-check this flag before spawning a child
+   * process nothing would ever kill.
+   */
+  private disposed = false;
 
   constructor(private readonly maxConcurrent: number) {
     this.cleanupStaleRunningRows();
@@ -131,12 +149,25 @@ export class AcpSessionManager {
   }
 
   /**
+   * Ids that must be treated as live: registered sessions plus in-flight
+   * resume reservations (deduped, since a resuming session appears in both maps
+   * between registration and settle). Delete guards use this so a history
+   * row cannot be removed out from under a resume that is still awaiting
+   * env preparation; the later terminal upsert would resurrect it.
+   */
+  getActiveAndPendingIds(): string[] {
+    return [
+      ...new Set([...this.sessions.keys(), ...this.pendingResumes.keys()]),
+    ];
+  }
+
+  /**
    * Concurrency guard shared by spawn() and resumeFromHistory(). Counts
    * both registered sessions and in-flight resume reservations so the cap
    * holds even while a resume is still awaiting prepareAgentEnv.
    */
   private assertCapacity(): void {
-    if (this.sessions.size + this.pendingResumes.size >= this.maxConcurrent) {
+    if (this.getActiveAndPendingIds().length >= this.maxConcurrent) {
       throw new Error(
         `ACP concurrency limit reached (max ${this.maxConcurrent}). ` +
           `Close an existing session before spawning a new one.`,
@@ -181,7 +212,7 @@ export class AcpSessionManager {
       startedAt: Date.now(),
       sendToVellum,
     });
-    const { process: agentProcess, state, sendToVellum: wrappedSend } = entry;
+    const { process: agentProcess, state } = entry;
 
     try {
       log.info({ acpSessionId, agentId }, "ACP spawning child process");
@@ -201,19 +232,11 @@ export class AcpSessionManager {
       );
     } catch (err) {
       log.error({ acpSessionId, agentId, err }, "ACP spawn failed");
-      // Kill the orphaned child process and remove the reserved slot.
-      agentProcess.kill();
-      this.sessions.delete(acpSessionId);
-      this.eventBuffers.delete(acpSessionId);
+      this.cleanupFailedStartup(acpSessionId, agentProcess);
       throw err;
     }
 
-    wrappedSend({
-      type: "acp_session_spawned",
-      acpSessionId,
-      agent: agentId,
-      parentConversationId,
-    });
+    this.sendSpawnedEvent(acpSessionId, entry);
 
     // Fire prompt in the background — don't await
     entry.currentPrompt = this.firePromptInBackground(
@@ -294,6 +317,36 @@ export class AcpSessionManager {
   }
 
   /**
+   * Failure cleanup shared by spawn() and the resume path: kill the
+   * orphaned child process and remove the reserved slot. A subset of
+   * teardownSession: at startup time no prompt has fired, so there are no
+   * pending permission requests to deny.
+   */
+  private cleanupFailedStartup(
+    acpSessionId: string,
+    agentProcess: AcpAgentProcess,
+  ): void {
+    agentProcess.kill();
+    this.sessions.delete(acpSessionId);
+    this.eventBuffers.delete(acpSessionId);
+  }
+
+  /**
+   * Notifies connected clients that a session is live. Shared by spawn()
+   * and the resume path (resumed sessions reuse the spawned event so
+   * clients render them; a dedicated acp_session_resumed event is a
+   * possible follow-up, not in scope here).
+   */
+  private sendSpawnedEvent(acpSessionId: string, entry: SessionEntry): void {
+    entry.sendToVellum({
+      type: "acp_session_spawned",
+      acpSessionId,
+      agent: entry.state.agentId,
+      parentConversationId: entry.parentConversationId,
+    });
+  }
+
+  /**
    * Resumes a terminal-state session from its persisted
    * `acp_session_history` row, reattaching to the agent's stored
    * conversation via ACP `session/resume` (preferred: no history replay) or
@@ -351,31 +404,62 @@ export class AcpSessionManager {
     // Everything up to here is synchronous. Reserve the id + concurrency
     // slot BEFORE the first await so a concurrent resume of the same id
     // (or a spawn racing the cap) fails the guards above instead of
-    // double-registering and leaking the first child process.
-    this.pendingResumes.add(acpSessionId);
-    let entry: SessionEntry;
+    // double-registering and leaking the first child process. The
+    // reservation holds the resume's promise until it settles so
+    // steerOrResume can await a concurrent caller's in-flight resume, and
+    // so the delete guards see the id as live while the row's terminal
+    // status still reflects the previous run.
+    const resumePromise = this.performResume(
+      acpSessionId,
+      row as ResumableHistoryRow,
+      resolved.agent,
+      sendToVellum,
+    );
+    this.pendingResumes.set(acpSessionId, resumePromise);
     try {
-      const agentConfig = await prepareAgentEnv(resolved.agent);
-      entry = this.registerSession({
-        acpSessionId,
-        agentId: row.agentId,
-        agentConfig,
-        parentConversationId: row.parentConversationId,
-        cwd: row.cwd,
-        startedAt: row.startedAt,
-        sendToVellum,
-      });
+      await resumePromise;
     } finally {
-      // The reservation is either transferred to the sessions map by
-      // registerSession or released on prepareAgentEnv failure.
       this.pendingResumes.delete(acpSessionId);
     }
+  }
+
+  /**
+   * The async body of resumeFromHistory, split out so the caller can store
+   * its promise in `pendingResumes` synchronously before the first await.
+   * All guards and row validation have already passed.
+   */
+  private async performResume(
+    acpSessionId: string,
+    row: ResumableHistoryRow,
+    agent: AcpAgentConfig,
+    sendToVellum: (msg: ServerMessage) => void,
+  ): Promise<void> {
+    const agentConfig = await prepareAgentEnv(agent);
+
+    // The daemon may have shut down while prepareAgentEnv was pending.
+    // Registering now would spawn a child process on a disposed manager
+    // that nothing would ever kill.
+    if (this.disposed) {
+      throw new Error(
+        `ACP session manager is disposed; cannot resume session "${acpSessionId}"`,
+      );
+    }
+
+    const entry = this.registerSession({
+      acpSessionId,
+      agentId: row.agentId,
+      agentConfig,
+      parentConversationId: row.parentConversationId,
+      cwd: row.cwd,
+      startedAt: row.startedAt,
+      sendToVellum,
+    });
 
     log.info(
       { acpSessionId, agentId: row.agentId, cwd: row.cwd },
       "ACP resume from history requested",
     );
-    const { process: agentProcess, state, sendToVellum: wrappedSend } = entry;
+    const { process: agentProcess, state } = entry;
 
     // Re-seed the ring buffer from the persisted event log, routed through
     // appendToBuffer so the count/byte caps still apply. The terminal
@@ -434,22 +518,11 @@ export class AcpSessionManager {
         { acpSessionId, agentId: row.agentId, err },
         "ACP resume failed",
       );
-      // Kill the orphaned child process and remove the reserved slot.
-      agentProcess.kill();
-      this.sessions.delete(acpSessionId);
-      this.eventBuffers.delete(acpSessionId);
+      this.cleanupFailedStartup(acpSessionId, agentProcess);
       throw err;
     }
 
-    // Reuse the existing spawned event so connected clients render the
-    // session. A dedicated acp_session_resumed event is a possible
-    // follow-up, not in scope here.
-    wrappedSend({
-      type: "acp_session_spawned",
-      acpSessionId,
-      agent: row.agentId,
-      parentConversationId: row.parentConversationId,
-    });
+    this.sendSpawnedEvent(acpSessionId, entry);
   }
 
   /**
@@ -504,10 +577,15 @@ export class AcpSessionManager {
    * fails, the freshly resumed session is closed (process killed, terminal
    * row persisted, maps cleared) instead of being leaked.
    *
+   * When a concurrent caller's resume of the same id is already in flight,
+   * this call awaits that resume and then retries the plain steer, so both
+   * callers' instructions land on the single resumed session.
+   *
    * Error contract for transport callers (acp_steer tool, steer route):
    * - `AcpSessionNotFoundError`: no in-memory session AND no history row.
-   * - `AcpResumeError`: the resume (or the steer immediately after it)
-   *   failed; the message carries the actionable hint.
+   * - `AcpResumeError`: the resume (own or a concurrent caller's awaited
+   *   one, or the steer immediately after an own resume) failed; the
+   *   message carries the actionable hint.
    * - any other error: the plain steer on an in-memory session failed.
    */
   async steerOrResume(
@@ -520,6 +598,25 @@ export class AcpSessionManager {
       return { resumed: false };
     } catch (err) {
       if (!(err instanceof AcpSessionNotFoundError)) throw err;
+    }
+
+    // Another caller's resume of this id may already be in flight (the
+    // session is not in memory yet, but its slot is reserved). Await that
+    // resume and retry the plain steer once instead of failing
+    // resumeFromHistory's already-active guard, which would surface a
+    // misleading resume error and drop this instruction.
+    const inFlightResume = this.pendingResumes.get(acpSessionId);
+    if (inFlightResume) {
+      try {
+        await inFlightResume;
+      } catch (err) {
+        throw new AcpResumeError(err);
+      }
+      // The resumed session is owned by the concurrent caller (its own
+      // post-resume steer handles teardown on failure), so a failure here
+      // propagates as a plain steer error without closing the session.
+      await this.steer(acpSessionId, instruction);
+      return { resumed: true };
     }
 
     try {
@@ -836,9 +933,12 @@ export class AcpSessionManager {
   }
 
   /**
-   * Kills all processes on shutdown.
+   * Kills all processes on shutdown. Also flags the manager as disposed so
+   * resumes that are mid-await when shutdown happens abort before spawning
+   * a child process nothing would ever kill.
    */
   dispose(): void {
+    this.disposed = true;
     this.closeAll();
   }
 }

--- a/assistant/src/runtime/routes/__tests__/acp-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/acp-routes.test.ts
@@ -481,7 +481,10 @@ describe("POST /v1/acp/spawn: auto-install on missing binary", () => {
     expect(spawnMock).not.toHaveBeenCalled();
   });
 
-  test("unknown command: never installs, plain hint surfaces", async () => {
+  test("unknown command: plain hint maps to FailedDependencyError", async () => {
+    // The allowlist itself (no npm invocation for unmapped commands) is
+    // pinned in auto-install.test.ts and spawn.test.ts; this asserts only
+    // the route's transport mapping of the plain-hint failure.
     config.setConfig({
       agents: { custom: { command: "custom-bin", args: [] } },
     });
@@ -493,8 +496,6 @@ describe("POST /v1/acp/spawn: auto-install on missing binary", () => {
     await expect(promise).rejects.toThrow(
       "custom-bin is not on PATH. Install 'custom-bin' and ensure it is on PATH.",
     );
-    expect(execFileMock).not.toHaveBeenCalled();
-    expect(spawnMock).not.toHaveBeenCalled();
   });
 });
 

--- a/assistant/src/runtime/routes/acp-routes.test.ts
+++ b/assistant/src/runtime/routes/acp-routes.test.ts
@@ -2,25 +2,28 @@
  * Tests for the ACP route handlers.
  *
  * Suites:
- *  - POST /v1/acp/spawn — the three failure paths produced by
- *    `resolveAcpAgent` (acp_disabled, unknown_agent, binary_not_found).
+ *  - POST /v1/acp/spawn: resolver failure paths (acp_disabled,
+ *    unknown_agent) and the body-shape guard. The binary_not_found /
+ *    auto-install surface is covered in `__tests__/acp-routes.test.ts`.
  *  - POST /v1/acp/spawn (env injection) — CLAUDE_CODE_OAUTH_TOKEN is read
  *    from the credential broker (policy-gated + audited) and merged into
  *    `agentConfig.env` ONLY for the `claude` agent.
  *  - DELETE /v1/acp/sessions?status=completed — the bulk-clear route that
  *    wipes terminal-state rows (completed/failed/cancelled) from
- *    `acp_session_history` while leaving running/initializing rows intact.
+ *    `acp_session_history` while leaving running/initializing rows and
+ *    rows with an in-flight resume intact.
  *  - DELETE /v1/acp/sessions/:id — single-row delete: completed → 200,
- *    running → 409, unknown id → idempotent { deleted: false }.
+ *    running or mid-resume → 409, unknown id → idempotent
+ *    { deleted: false }.
  *
  * The spawn tests mirror the resolver's test setup using the shared
  * `installAcpConfigStub` and `installWhichStub` helpers so the host
  * environment doesn't influence the resolver's PATH preflight.
  *
- * The single-id delete tests stub `getAcpSessionManager` so we can drive
- * the in-memory-status check without spawning real ACP child processes,
- * and use the real DB (initialized via the test preload's per-file
- * workspace) to verify the row is actually removed.
+ * The delete tests stub `getAcpSessionManager` so we can drive the
+ * in-memory-status and pending-resume checks without spawning real ACP
+ * child processes, and use the real DB (initialized via the test preload's
+ * per-file workspace) to verify the row is actually removed.
  */
 
 import {
@@ -34,18 +37,11 @@ import {
 } from "bun:test";
 
 import { installAcpConfigStub } from "../../acp/__tests__/helpers/acp-config-stub.js";
-import { installExecFileStub } from "../../acp/__tests__/helpers/exec-file-stub.js";
 import { installWhichStub } from "../../acp/__tests__/helpers/which-stub.js";
 import type { AcpSessionState } from "../../acp/index.js";
 
 const config = await installAcpConfigStub();
 const which = installWhichStub();
-
-// Stub `execFile` so the spawn route's auto-install path (`npm i -g ...` in
-// acp/auto-install.ts) never shells out to real npm. The binary-missing test
-// scripts the install to fail so the route falls through to the augmented
-// FailedDependencyError hint.
-const { execScripts, reset: resetExecFileStub } = installExecFileStub();
 
 afterAll(() => {
   which.restore();
@@ -55,8 +51,10 @@ afterAll(() => {
 // in-memory-status check without spawning real ACP processes, and so the
 // env-injection spawn tests can capture the `agentConfig` arg without
 // launching a real subprocess. Stored in mutable state so individual tests
-// can plant arbitrary states / inspect capture.
+// can plant arbitrary states / inspect capture. `pendingResumeIds` models
+// ids reserved by an in-flight resumeFromHistory (no SessionEntry yet).
 const inMemoryStates = new Map<string, AcpSessionState>();
+const pendingResumeIds = new Set<string>();
 
 interface CapturedSpawn {
   agent: string;
@@ -77,6 +75,9 @@ mock.module("../../acp/index.js", () => ({
       if (!state) throw new Error(`ACP session "${id}" not found`);
       return state;
     },
+    getActiveAndPendingIds: () => [
+      ...new Set([...inMemoryStates.keys(), ...pendingResumeIds]),
+    ],
     spawn: async (
       agent: string,
       agentConfig: { env?: Record<string, string> },
@@ -176,9 +177,6 @@ import { initializeDb } from "../../memory/db-init.js";
 import { acpSessionHistory } from "../../memory/schema.js";
 
 const { ROUTES } = await import("./acp-routes.js");
-const { _resetAdapterInstallCacheForTests } = await import(
-  "../../acp/auto-install.js"
-);
 
 function getSpawnHandler() {
   const route = ROUTES.find(
@@ -195,8 +193,6 @@ beforeEach(() => {
   capturedSpawns.length = 0;
   vaultStore.clear();
   metadataStore.clear();
-  resetExecFileStub();
-  _resetAdapterInstallCacheForTests();
 });
 
 // ---------------------------------------------------------------------------
@@ -236,29 +232,6 @@ describe("POST /v1/acp/spawn", () => {
         },
       }),
     ).rejects.toThrow('Unknown agent "nonexistent"');
-  });
-
-  test("throws FailedDependencyError when the agent binary is missing", async () => {
-    config.setConfig({ agents: {} });
-    which.setWhich({});
-    // codex-acp is an allowlisted adapter, so the route attempts a silent
-    // `npm i -g @zed-industries/codex-acp` before failing. Script that
-    // install to fail; the full auto-install failure surface is covered in
-    // __tests__/acp-routes.test.ts.
-    execScripts.set("npm i", {
-      error: new Error("EACCES: permission denied"),
-    });
-
-    const handler = getSpawnHandler();
-    await expect(
-      handler({
-        body: {
-          agent: "codex",
-          task: "do a thing",
-          conversationId: "conv-1",
-        },
-      }),
-    ).rejects.toThrow("codex-acp is not on PATH");
   });
 
   test("body-shape guard short-circuits before the resolver runs", async () => {
@@ -477,6 +450,7 @@ describe("DELETE /v1/acp/sessions?status=completed", () => {
 
   beforeEach(() => {
     inMemoryStates.clear();
+    pendingResumeIds.clear();
     getSqlite().run("DELETE FROM acp_session_history");
   });
 
@@ -528,6 +502,29 @@ describe("DELETE /v1/acp/sessions?status=completed", () => {
 
     const remaining = listRows();
     expect(remaining).toEqual([{ id: "row-resumed", status: "completed" }]);
+  });
+
+  test("excludes terminal rows whose session has a resume in flight", async () => {
+    // A resume that is still awaiting env preparation has no in-memory
+    // SessionEntry yet, but its history row (still terminal) must survive:
+    // deleting it mid-resume would let the later terminal upsert resurrect
+    // it as an orphan row.
+    seedHistoryRow("row-pending-resume", "completed", 1000);
+    seedHistoryRow("row-completed", "completed", 2000);
+    pendingResumeIds.add("row-pending-resume");
+
+    const handler = getBulkDeleteHandler();
+    const result = (await handler({
+      queryParams: { status: "completed" },
+    })) as {
+      deleted: number;
+    };
+    expect(result.deleted).toBe(1);
+
+    const remaining = listRows();
+    expect(remaining).toEqual([
+      { id: "row-pending-resume", status: "completed" },
+    ]);
   });
 
   test("returns deleted=0 when no terminal rows are present", async () => {
@@ -607,6 +604,7 @@ describe("DELETE /v1/acp/sessions/:id", () => {
 
   beforeEach(() => {
     inMemoryStates.clear();
+    pendingResumeIds.clear();
     getDb().delete(acpSessionHistory).run();
   });
 
@@ -657,6 +655,24 @@ describe("DELETE /v1/acp/sessions/:id", () => {
       expect(remaining).toHaveLength(1);
     },
   );
+
+  test("returns 409 when the session has a resume in flight (not yet in memory)", async () => {
+    pendingResumeIds.add("sess-resuming");
+    insertHistoryRow({ id: "sess-resuming", status: "completed" });
+
+    const handler = getDeleteSessionHandler();
+    expect(() => handler({ pathParams: { id: "sess-resuming" } })).toThrow(
+      "resume in flight",
+    );
+
+    // Row untouched.
+    const remaining = getDb()
+      .select()
+      .from(acpSessionHistory)
+      .where(eq(acpSessionHistory.id, "sess-resuming"))
+      .all();
+    expect(remaining).toHaveLength(1);
+  });
 
   test("idempotent for unknown id — returns { deleted: false }", async () => {
     const handler = getDeleteSessionHandler();

--- a/assistant/src/runtime/routes/acp-routes.ts
+++ b/assistant/src/runtime/routes/acp-routes.ts
@@ -174,14 +174,14 @@ function bulkDeleteSessions({ queryParams }: RouteHandlerArgs) {
       "status query param is required and must be 'completed'",
     );
   }
-  // Exclude sessions currently active in memory: a resumed session reuses
-  // its original id, and its history row keeps the old terminal status
-  // until the next terminal upsert - a status-only delete would remove the
-  // row out from under the live session. Mirrors the 409 guard on the
-  // single-id delete route.
-  const activeIds = (
-    getAcpSessionManager().getStatus() as AcpSessionState[]
-  ).map((s) => s.id);
+  // Exclude sessions currently active in memory AND ids with a resume in
+  // flight (reserved but not yet registered): a resumed session reuses its
+  // original id, and its history row keeps the old terminal status until
+  // the next terminal upsert - a status-only delete would remove the row
+  // out from under the live (or resuming) session, and the later terminal
+  // upsert would resurrect it. Mirrors the 409 guard on the single-id
+  // delete route.
+  const activeIds = getAcpSessionManager().getActiveAndPendingIds();
   const terminalFilter = inArray(
     acpSessionHistory.status,
     TERMINAL_SESSION_STATUSES,
@@ -201,9 +201,10 @@ function bulkDeleteSessions({ queryParams }: RouteHandlerArgs) {
 
 function deleteSession({ pathParams }: RouteHandlerArgs) {
   const id = pathParams?.id as string;
+  const manager = getAcpSessionManager();
 
   try {
-    const state = getAcpSessionManager().getStatus(id);
+    const state = manager.getStatus(id);
     if (
       !Array.isArray(state) &&
       (state.status === "running" || state.status === "initializing")
@@ -214,7 +215,16 @@ function deleteSession({ pathParams }: RouteHandlerArgs) {
     }
   } catch (err) {
     if (err instanceof ConflictError) throw err;
-    // Not in memory — fall through to the (idempotent) DB delete.
+    // Not registered in memory, but a resume may be in flight (id reserved
+    // while awaiting env preparation). Its history row must survive until
+    // the resume lands - the later terminal upsert would resurrect a
+    // deleted row.
+    if (manager.getActiveAndPendingIds().includes(id)) {
+      throw new ConflictError(
+        `ACP session "${id}" has a resume in flight. Wait for it to finish before deleting.`,
+      );
+    }
+    // Otherwise fall through to the (idempotent) DB delete.
   }
 
   getDb().delete(acpSessionHistory).where(eq(acpSessionHistory.id, id)).run();
@@ -364,7 +374,8 @@ export const ROUTES: RouteDefinition[] = [
     description:
       "Remove every terminal-state row (completed/failed/cancelled) from " +
       "the persisted acp_session_history table. Rows whose session is " +
-      "currently active in memory (e.g. resumed) are excluded.",
+      "currently active in memory (e.g. resumed) or has a resume in " +
+      "flight are excluded.",
     tags: ["acp"],
     queryParams: [
       {
@@ -390,7 +401,8 @@ export const ROUTES: RouteDefinition[] = [
     summary: "Delete ACP session from history",
     description:
       "Remove a persisted ACP session row. Rejects with 409 when the " +
-      "session is still active in memory; idempotent for unknown ids.",
+      "session is still active in memory or has a resume in flight; " +
+      "idempotent for unknown ids.",
     tags: ["acp"],
     responseBody: z.object({
       deleted: z.boolean(),


### PR DESCRIPTION
## Summary
Fixes round-2 review gaps for acp-native-agent-ux.md.

- Delete routes (bulk and single) now treat pending resumes as active, preventing mid-resume row deletion and resurrection
- Manager dispose() aborts in-flight resumes before they can spawn on a disposed manager
- Concurrent steerOrResume on the same id awaits the in-flight resume and retries the steer instead of returning a misleading 424
- Consolidates duplicated startup-failure cleanup and spawned-event emission between spawn and resume; trims subsumed route tests