### PR TITLE
ci: publish pre-release npm packages with --tag staging in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1374,6 +1374,118 @@ jobs:
             --field version="${{ needs.extract-version.outputs.version }}" \
             --field run_id="${{ github.run_id }}"
 
+  publish-npm-staging:
+    needs: [extract-version, ci-assistant, ci-cli, ci-gateway, ci-credential-executor]
+    if: ${{ needs.extract-version.outputs.is_staging == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        package: [assistant, cli, credential-executor, gateway]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: '1.3.11'
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: .nvmrc
+          registry-url: https://registry.npmjs.org
+      - name: Sync feature flag registry
+        run: bun run meta/feature-flags/sync-bundled-copies.ts
+      - name: Stamp staging version
+        run: jq --arg v "${{ needs.extract-version.outputs.version }}" '.version = $v' ${{ matrix.package }}/package.json > ${{ matrix.package }}/package.json.tmp && mv ${{ matrix.package }}/package.json.tmp ${{ matrix.package }}/package.json
+      - name: Install and publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          cd "${{ matrix.package }}"
+          if ! bun install --frozen-lockfile; then
+            rm -f bun.lock && rm -rf node_modules && bun install
+          fi
+          npm publish --tag staging --access public --no-provenance
+
+  publish-web-staging:
+    needs: [extract-version, ci-assistant, ci-cli, ci-gateway, ci-credential-executor]
+    if: ${{ needs.extract-version.outputs.is_staging == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: '1.3.11'
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: .nvmrc
+          registry-url: https://registry.npmjs.org
+      - name: Install design-library dependencies
+        working-directory: packages/design-library
+        run: bun install --frozen-lockfile
+      - name: Install web dependencies
+        working-directory: apps/web
+        run: |
+          if ! bun install --frozen-lockfile; then
+            rm -f bun.lock && rm -rf node_modules && bun install
+          fi
+      - name: Generate API clients
+        working-directory: apps/web
+        run: bun run openapi-ts
+      - name: Install shared packages
+        uses: ./.github/actions/install-shared-packages
+        with:
+          packages: packages/environments packages/local-mode
+      - name: Build
+        working-directory: apps/web
+        env:
+          VITE_PLATFORM_MODE: "true"
+        run: bun run build
+      - name: Rewrite package.json for publish
+        working-directory: apps/web
+        run: |
+          VERSION="${{ needs.extract-version.outputs.version }}"
+          jq --arg v "$VERSION" '{name, version: $v, license, type, description, files}' package.json > tmp && mv tmp package.json
+      - name: Publish
+        working-directory: apps/web
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --tag staging --access public --no-provenance
+
+  publish-meta-staging:
+    needs: [extract-version, publish-npm-staging, publish-web-staging]
+    if: ${{ needs.extract-version.outputs.is_staging == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: .nvmrc
+          registry-url: https://registry.npmjs.org
+      - name: Stamp staging version into meta package.json
+        run: |
+          VERSION="${{ needs.extract-version.outputs.version }}"
+          cd meta
+          jq --arg v "$VERSION" '
+            .version = $v |
+            .dependencies["@vellumai/assistant"] = $v |
+            .dependencies["@vellumai/cli"] = $v |
+            .dependencies["@vellumai/credential-executor"] = $v |
+            .dependencies["@vellumai/vellum-gateway"] = $v |
+            .dependencies["@vellumai/web"] = $v
+          ' package.json > tmp && mv tmp package.json
+      - name: Publish
+        working-directory: meta
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --tag staging --access public --no-provenance
+
   publish-web:
     needs: [extract-version, ci-cli, ci-gateway, ci-playwright, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image]
     if: ${{ always() && !cancelled() && needs.extract-version.outputs.is_staging != 'true' && needs.ci-cli.result == 'success' && needs.ci-gateway.result == 'success' && (needs.ci-playwright.result == 'success' || inputs.playwright_blocks_release != true) && needs.push-assistant-manifest.result == 'success' && needs.push-gateway-manifest.result == 'success' && needs.push-credential-executor-manifest.result == 'success' && needs.push-dockerhub-image.result == 'success' }}


### PR DESCRIPTION
## Summary
- Add publish-npm-staging job to publish assistant, cli, credential-executor, gateway with --tag staging
- Add publish-web-staging job to build and publish @vellumai/web with --tag staging
- Add publish-meta-staging job to publish vellum meta-package with --tag staging (after sub-packages)
- All three jobs gated on is_staging == true; production publish jobs unchanged

Part of plan: electron-npm-bundle.md (PR 5 of 5)