### PR TITLE
feat: bundle @vellumai/web dist into Electron app resources

### DIFF
--- a/apps/macos/.gitignore
+++ b/apps/macos/.gitignore
@@ -3,3 +3,4 @@ out/
 dist/
 build/
 resources/bun
+resources/web-dist

--- a/apps/macos/electron-builder.yml
+++ b/apps/macos/electron-builder.yml
@@ -5,6 +5,8 @@ directories:
 extraResources:
   - from: resources/bun
     to: bun
+  - from: resources/web-dist
+    to: web-dist
   # The generated per-environment app icon, kept at a stable resources path so
   # the Dock can restore it when a custom avatar is cleared (Electron has no
   # "reset to bundle icon" API). Source is produced by scripts/generate-icon.sh.

--- a/apps/macos/src/main/cli-installer.test.ts
+++ b/apps/macos/src/main/cli-installer.test.ts
@@ -67,10 +67,7 @@ const {
   getCliInstallDir,
   getCliBinPath,
   getBundledBunPath,
-  getWebDistPath,
-  isWebInstalled,
   isCliInstalled,
-  ensureWebInstalled,
   ensureCliInstalled,
   cleanupOldVersions,
   _resetInstallLock,
@@ -111,28 +108,6 @@ describe("getBundledBunPath", () => {
   });
 });
 
-describe("getWebDistPath", () => {
-  test("returns <installDir>/node_modules/@vellumai/web/dist", () => {
-    expect(getWebDistPath()).toBe(
-      `${userDataPath}/cli/${PINNED_CLI_VERSION}/node_modules/@vellumai/web/dist`,
-    );
-  });
-});
-
-// --- isWebInstalled ---
-
-describe("isWebInstalled", () => {
-  test("returns true when web dist/index.html exists", () => {
-    existsSyncByPath[`${userDataPath}/cli/${PINNED_CLI_VERSION}/node_modules/@vellumai/web/dist/index.html`] = true;
-    expect(isWebInstalled()).toBe(true);
-  });
-
-  test("returns false when web dist is missing", () => {
-    existsSyncDefault = false;
-    expect(isWebInstalled()).toBe(false);
-  });
-});
-
 // --- isCliInstalled ---
 
 describe("isCliInstalled", () => {
@@ -144,59 +119,6 @@ describe("isCliInstalled", () => {
   test("returns false when the bin path is missing", () => {
     existsSyncDefault = false;
     expect(isCliInstalled()).toBe(false);
-  });
-});
-
-// --- ensureWebInstalled ---
-
-describe("ensureWebInstalled", () => {
-  test("skips install when web dist already exists", async () => {
-    existsSyncByPath[`${userDataPath}/cli/${PINNED_CLI_VERSION}/node_modules/@vellumai/web/dist/index.html`] = true;
-    await ensureWebInstalled();
-    expect(spawnCalls).toHaveLength(0);
-  });
-
-  test("spawns bun add @vellumai/web with correct args", async () => {
-    existsSyncDefault = false;
-
-    const promise = ensureWebInstalled();
-    lastChild.emit("close", 0);
-    await promise;
-
-    expect(spawnCalls).toHaveLength(1);
-    const [cmd, args, opts] = spawnCalls[0];
-    expect(cmd).toBe(`${mockResourcesPath}/bun`);
-    expect(args).toEqual(["add", `@vellumai/web@${PINNED_CLI_VERSION}`]);
-    expect(opts).toEqual({
-      cwd: `${userDataPath}/cli/${PINNED_CLI_VERSION}`,
-    });
-  });
-
-  test("concurrent calls share a single install", async () => {
-    existsSyncDefault = false;
-
-    const p1 = ensureWebInstalled();
-    const p2 = ensureWebInstalled();
-
-    expect(spawnCalls).toHaveLength(1);
-
-    lastChild.emit("close", 0);
-    await Promise.all([p1, p2]);
-  });
-
-  test("failed install resets the lock so retries are possible", async () => {
-    existsSyncDefault = false;
-
-    const p1 = ensureWebInstalled();
-    lastChild.stderr.emit("data", Buffer.from("network error"));
-    lastChild.emit("close", 1);
-
-    await expect(p1).rejects.toThrow(/Package install failed/);
-
-    const p2 = ensureWebInstalled();
-    expect(spawnCalls).toHaveLength(2);
-    lastChild.emit("close", 0);
-    await p2;
   });
 });
 

--- a/apps/macos/src/main/cli-installer.ts
+++ b/apps/macos/src/main/cli-installer.ts
@@ -26,22 +26,6 @@ export function getBundledBunPath(): string {
   return path.join(process.resourcesPath, "bun");
 }
 
-/** Absolute path to the installed `@vellumai/web` dist directory. */
-export function getWebDistPath(): string {
-  return path.join(
-    getCliInstallDir(),
-    "node_modules",
-    "@vellumai",
-    "web",
-    "dist",
-  );
-}
-
-/** Whether the web renderer package is installed. */
-export function isWebInstalled(): boolean {
-  return existsSync(path.join(getWebDistPath(), "index.html"));
-}
-
 /** Whether the pinned CLI version is already installed on disk. */
 export function isCliInstalled(): boolean {
   return existsSync(getCliBinPath());
@@ -92,33 +76,12 @@ function bunAdd(pkg: string): Promise<void> {
   });
 }
 
-// Singleton promises prevent concurrent installs from corrupting node_modules.
-let webInstallPromise: Promise<void> | null = null;
+// Singleton promise prevents concurrent installs from corrupting node_modules.
 let cliInstallPromise: Promise<void> | null = null;
 
-/** Reset the install locks. Exposed for testing only. */
+/** Reset the install lock. Exposed for testing only. */
 export function _resetInstallLock(): void {
-  webInstallPromise = null;
   cliInstallPromise = null;
-}
-
-/** Install just the web renderer package — fast path to unblock the UI. */
-export async function ensureWebInstalled(): Promise<void> {
-  if (isWebInstalled()) return;
-
-  if (webInstallPromise) return webInstallPromise;
-
-  webInstallPromise = (async () => {
-    await bunAdd("@vellumai/web");
-    cleanupOldVersions();
-  })();
-
-  try {
-    await webInstallPromise;
-  } catch (err) {
-    webInstallPromise = null;
-    throw err;
-  }
 }
 
 /**

--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -13,7 +13,6 @@ import {
 import { installAbout, openAboutWindow } from "./about";
 import { APP_HOST, APP_PROTOCOL } from "./app-config";
 import { installCsp } from "./csp";
-import { ensureWebInstalled, getWebDistPath } from "./cli-installer";
 import { handle, handleSync } from "./ipc";
 import { resolveAppProtocolPath } from "./app-protocol";
 import { planGatewayForward } from "./gateway-forward";
@@ -116,7 +115,7 @@ const RENDERER_MOUNT = "/assistant";
 
 const resolveRendererRoot = (): string => {
   if (app.isPackaged) {
-    return getWebDistPath();
+    return path.join(process.resourcesPath, "web-dist");
   }
   // Dev source tree: apps/web/dist — requires `bun run build` in apps/web/.
   const repoRoot = path.resolve(app.getAppPath(), "..", "..");
@@ -300,9 +299,6 @@ app
   .whenReady()
   .then(async () => {
     if (!isDev) {
-      // TODO(LUM-2214): a deep-link or second-instance activation during
-      // this await can create a window before the protocol handler exists.
-      await ensureWebInstalled();
       registerAppProtocol();
     }
     installPermissionHandler();


### PR DESCRIPTION
## Summary
- Add web-dist to electron-builder extraResources so the web SPA is bundled in the DMG
- Change resolveRendererRoot() to use bundled path instead of lazy-installed npm path
- Remove ensureWebInstalled() and all dead web-install code from cli-installer
- Remove corresponding web-install tests

Part of plan: electron-npm-bundle.md (PR 1 of 5)