### PR TITLE
ci: publish pre-release npm packages with --tag dev in dev-release workflow

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -1922,6 +1922,117 @@ jobs:
           security delete-keychain "$KEYCHAIN_PATH" 2>/dev/null || true
           rm -rf ~/.private_keys 2>/dev/null || true
 
+  # ── Dev npm publishing ─────────────────────────────────────────────────
+
+  publish-npm-dev:
+    needs: [compute-version, ci-assistant, ci-gateway, ci-credential-executor]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        package: [assistant, cli, credential-executor, gateway]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: '1.3.11'
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: .nvmrc
+          registry-url: https://registry.npmjs.org
+      - name: Sync feature flag registry
+        run: bun run meta/feature-flags/sync-bundled-copies.ts
+      - name: Stamp dev version
+        run: jq --arg v "${{ needs.compute-version.outputs.version }}" '.version = $v' ${{ matrix.package }}/package.json > ${{ matrix.package }}/package.json.tmp && mv ${{ matrix.package }}/package.json.tmp ${{ matrix.package }}/package.json
+      - name: Install and publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          cd "${{ matrix.package }}"
+          if ! bun install --frozen-lockfile; then
+            rm -f bun.lock && rm -rf node_modules && bun install
+          fi
+          npm publish --tag dev --access public --no-provenance
+
+  publish-web-dev:
+    needs: [compute-version, ci-assistant, ci-gateway, ci-credential-executor]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: '1.3.11'
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: .nvmrc
+          registry-url: https://registry.npmjs.org
+      - name: Install design-library dependencies
+        working-directory: packages/design-library
+        run: bun install --frozen-lockfile
+      - name: Install web dependencies
+        working-directory: apps/web
+        run: |
+          if ! bun install --frozen-lockfile; then
+            rm -f bun.lock && rm -rf node_modules && bun install
+          fi
+      - name: Generate API clients
+        working-directory: apps/web
+        run: bun run openapi-ts
+      - name: Install shared packages
+        uses: ./.github/actions/install-shared-packages
+        with:
+          packages: packages/environments packages/local-mode
+      - name: Build
+        working-directory: apps/web
+        env:
+          VITE_PLATFORM_MODE: "true"
+        run: bun run build
+      - name: Rewrite package.json for publish
+        working-directory: apps/web
+        run: |
+          VERSION="${{ needs.compute-version.outputs.version }}"
+          jq --arg v "$VERSION" '{name, version: $v, license, type, description, files}' package.json > tmp && mv tmp package.json
+      - name: Publish
+        working-directory: apps/web
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --tag dev --access public --no-provenance
+
+  publish-meta-dev:
+    needs: [compute-version, publish-npm-dev, publish-web-dev]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: .nvmrc
+          registry-url: https://registry.npmjs.org
+      - name: Stamp dev version into meta package.json
+        run: |
+          VERSION="${{ needs.compute-version.outputs.version }}"
+          cd meta
+          jq --arg v "$VERSION" '
+            .version = $v |
+            .dependencies["@vellumai/assistant"] = $v |
+            .dependencies["@vellumai/cli"] = $v |
+            .dependencies["@vellumai/credential-executor"] = $v |
+            .dependencies["@vellumai/vellum-gateway"] = $v |
+            .dependencies["@vellumai/web"] = $v
+          ' package.json > tmp && mv tmp package.json
+      - name: Publish
+        working-directory: meta
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --tag dev --access public --no-provenance
+
   # ── Sparkle Rolling Release ────────────────────────────────────────────
   # ── Upload Sparkle artifacts to GCS ───────────────────────────────────
   # Push appcast.xml + ZIP to the public vellum-nonprod-sparkle GCS bucket.


### PR DESCRIPTION
## Summary
- Add publish-npm-dev job to publish assistant, cli, credential-executor, gateway with --tag dev
- Add publish-web-dev job to build and publish @vellumai/web with --tag dev
- Add publish-meta-dev job to publish vellum meta-package with --tag dev (after sub-packages)

Part of plan: electron-npm-bundle.md (PR 4 of 5)