### PR TITLE
fix: round-3 ACP review gaps (steer race window, docs secret policy, teardown reuse)

### DIFF
--- a/assistant/src/acp/__tests__/session-manager-resume.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-resume.test.ts
@@ -31,6 +31,12 @@ const fakeCaps = { loadSession: false, resume: false };
 let replayChunks: string[] = [];
 /** When set, prompt() throws synchronously (steerOrResume teardown tests). */
 let promptThrowsSync = false;
+/**
+ * When set, resumeSession() stalls on this gate. Lets tests observe the
+ * post-registration "initializing" window where the SessionEntry exists but
+ * the resume has not yet settled.
+ */
+let resumeSessionGate: Promise<void> | null = null;
 const fakeInstances: FakeAcpAgentProcess[] = [];
 
 class FakeAcpAgentProcess {
@@ -77,6 +83,7 @@ class FakeAcpAgentProcess {
   }
 
   async resumeSession(sessionId: string, cwd: string): Promise<void> {
+    if (resumeSessionGate) await resumeSessionGate;
     this.resumeSessionCalls.push({ sessionId, cwd });
   }
 
@@ -184,6 +191,7 @@ beforeEach(() => {
   replayChunks = [];
   promptThrowsSync = false;
   prepareAgentEnvGate = null;
+  resumeSessionGate = null;
   resolveImpl = () => ({
     ok: true,
     agent: { command: "claude-agent-acp", args: [] },
@@ -604,6 +612,65 @@ describe("AcpSessionManager.steerOrResume", () => {
       1,
     );
     expect((manager.getStatus("sor-race-1") as AcpSessionState).status).toBe(
+      "running",
+    );
+  });
+
+  test("steerOrResume arriving in the initializing window awaits the in-flight resume and steers", async () => {
+    fakeCaps.resume = true;
+    insertHistoryRow({ id: "sor-init-1" });
+    let release!: () => void;
+    resumeSessionGate = new Promise((res) => {
+      release = res;
+    });
+
+    const manager = new AcpSessionManager(4);
+    const sent: ServerMessage[] = [];
+    const first = manager.steerOrResume("sor-init-1", "first instruction", (msg) =>
+      sent.push(msg),
+    );
+
+    // Advance microtasks until the first call's resume has registered its
+    // SessionEntry but is still gated inside resumeSession: the session
+    // exists in memory with status "initializing".
+    while (!internals(manager).sessions.has("sor-init-1")) {
+      await Promise.resolve();
+    }
+    expect((manager.getStatus("sor-init-1") as AcpSessionState).status).toBe(
+      "initializing",
+    );
+
+    // A steerOrResume in this window previously rethrew the plain
+    // "is not running (status: initializing)" error and dropped the
+    // instruction. It must instead await the in-flight resume and retry.
+    const second = manager.steerOrResume(
+      "sor-init-1",
+      "second instruction",
+      (msg) => sent.push(msg),
+    );
+    // Let the second call hit the initializing steer failure and park on
+    // the in-flight resume before releasing the gate.
+    await Promise.resolve();
+    await Promise.resolve();
+    release();
+
+    const [a, b] = await Promise.all([first, second]);
+    expect(a).toEqual({ resumed: true });
+    expect(b).toEqual({ resumed: true });
+
+    // Exactly one process was constructed and one resume happened; both
+    // instructions landed on the single resumed session after it settled.
+    expect(fakeInstances).toHaveLength(1);
+    const fake = fakeInstances[0]!;
+    expect(fake.resumeSessionCalls).toHaveLength(1);
+    expect(fake.promptCalls.map((c) => c.text).sort()).toEqual([
+      "first instruction",
+      "second instruction",
+    ]);
+    expect(sent.filter((m) => m.type === "acp_session_spawned")).toHaveLength(
+      1,
+    );
+    expect((manager.getStatus("sor-init-1") as AcpSessionState).status).toBe(
       "running",
     );
   });

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -232,7 +232,8 @@ export class AcpSessionManager {
       );
     } catch (err) {
       log.error({ acpSessionId, agentId, err }, "ACP spawn failed");
-      this.cleanupFailedStartup(acpSessionId, agentProcess);
+      // No prompt has fired yet, so no permissions can be pending.
+      this.teardownSession(acpSessionId, entry);
       throw err;
     }
 
@@ -314,21 +315,6 @@ export class AcpSessionManager {
 
     this.sessions.set(acpSessionId, entry);
     return entry;
-  }
-
-  /**
-   * Failure cleanup shared by spawn() and the resume path: kill the
-   * orphaned child process and remove the reserved slot. A subset of
-   * teardownSession: at startup time no prompt has fired, so there are no
-   * pending permission requests to deny.
-   */
-  private cleanupFailedStartup(
-    acpSessionId: string,
-    agentProcess: AcpAgentProcess,
-  ): void {
-    agentProcess.kill();
-    this.sessions.delete(acpSessionId);
-    this.eventBuffers.delete(acpSessionId);
   }
 
   /**
@@ -518,7 +504,8 @@ export class AcpSessionManager {
         { acpSessionId, agentId: row.agentId, err },
         "ACP resume failed",
       );
-      this.cleanupFailedStartup(acpSessionId, agentProcess);
+      // No prompt has fired yet, so no permissions can be pending.
+      this.teardownSession(acpSessionId, entry);
       throw err;
     }
 
@@ -597,7 +584,17 @@ export class AcpSessionManager {
       await this.steer(acpSessionId, instruction);
       return { resumed: false };
     } catch (err) {
-      if (!(err instanceof AcpSessionNotFoundError)) throw err;
+      // Fall through to the in-flight-resume handling both when the session
+      // is entirely unknown and when a concurrent resume has already
+      // registered its entry but is still initializing: steer rejects with a
+      // plain not-running error in that window, yet the resume reservation
+      // is live and the retry below will land once it settles.
+      if (
+        !(err instanceof AcpSessionNotFoundError) &&
+        !this.pendingResumes.has(acpSessionId)
+      ) {
+        throw err;
+      }
     }
 
     // Another caller's resume of this id may already be in flight (the

--- a/assistant/src/config/bundled-skills/acp/SKILL.md
+++ b/assistant/src/config/bundled-skills/acp/SKILL.md
@@ -74,7 +74,11 @@ Gemini CLI speaks ACP natively (`gemini --acp`) - there is no separate adapter b
 
 **Authenticate** via either:
 - Browser OAuth: run `gemini` once interactively and complete the sign-in flow.
-- `GEMINI_API_KEY` environment variable. The simplest route is to set it in the assistant's own environment - spawned agents inherit it automatically. To set it via the workspace config instead, write a full `acp.agents.gemini` override (a config entry replaces the bundled default entirely, so it must include `command` and `args` - an env-only entry would fail validation or drop the required `--acp` flag):
+- `GEMINI_API_KEY` set in the assistant's own process environment - spawned agents inherit it automatically.
+
+Do NOT put API keys (or any secret) in the workspace config file - secrets never belong in the workspace directory. Use the assistant environment instead.
+
+A workspace `acp.agents.gemini` override is only for non-secret customization (custom binary path, extra args, non-secret env vars). It must spell out the full `command` and `args` - see "Critical: correct agent command" below for the replace-not-merge rule:
   ```json
   {
     "acp": {
@@ -82,7 +86,7 @@ Gemini CLI speaks ACP natively (`gemini --acp`) - there is no separate adapter b
         "gemini": {
           "command": "gemini",
           "args": ["--acp"],
-          "env": { "GEMINI_API_KEY": "..." }
+          "env": { "NO_COLOR": "1" }
         }
       }
     }


### PR DESCRIPTION
## Summary
Fixes round-3 review gaps for acp-native-agent-ux.md.

- steerOrResume now falls through to the in-flight resume retry when the session is mid-resume in the initializing window, instead of dropping the instruction with a misleading not-running error
- ACP skill docs no longer instruct storing GEMINI_API_KEY in workspace config (secrets policy); OAuth and assistant-environment are the documented paths; deduplicated the override-replaces-default rule
- Startup-failure cleanup reuses teardownSession instead of a duplicated subset helper