### PR TITLE
ci: build and bundle web SPA in release Electron job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2384,8 +2384,37 @@ jobs:
         with:
           packages: packages/environments packages/local-mode
 
+      - name: Install design-library dependencies
+        working-directory: packages/design-library
+        run: bun install --frozen-lockfile
+
+      - name: Install web dependencies
+        working-directory: apps/web
+        run: |
+          if ! bun install --frozen-lockfile; then
+            rm -f bun.lock && rm -rf node_modules && bun install
+          fi
+
+      - name: Generate API clients
+        working-directory: apps/web
+        run: bun run openapi-ts
+
+      - name: Build web SPA
+        working-directory: apps/web
+        env:
+          VITE_PLATFORM_MODE: "true"
+        run: bun run build
+
+      - name: Bundle web dist into Electron resources
+        run: cp -R ../../apps/web/dist resources/web-dist
+
       - name: Stamp release version into package.json
         run: jq --arg v "${{ needs.extract-version.outputs.version }}" '.version = $v' package.json > package.json.tmp && mv package.json.tmp package.json
+
+      - name: Stamp PINNED_CLI_VERSION
+        run: |
+          VERSION="${{ needs.extract-version.outputs.version }}"
+          sed -i '' "s/export const PINNED_CLI_VERSION = \".*\"/export const PINNED_CLI_VERSION = \"$VERSION\"/" src/main/cli-installer.ts
 
       - name: Build and package Electron app
         env:


### PR DESCRIPTION
## Summary
- Add steps to build web SPA (design-library, web deps, openapi-ts, vite build) in build-electron job
- Copy web dist to Electron resources/web-dist before packaging
- Stamp PINNED_CLI_VERSION to release/staging version before Electron build

Part of plan: electron-npm-bundle.md (PR 3 of 5)