### PR TITLE
fix: ensure resources/ directory exists before copying web-dist

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -1840,7 +1840,7 @@ jobs:
         run: bun run build
 
       - name: Bundle web dist into Electron resources
-        run: cp -R ../../apps/web/dist resources/web-dist
+        run: mkdir -p resources && cp -R ../../apps/web/dist resources/web-dist
 
       - name: Stamp dev version into package.json
         run: jq --arg v "${{ needs.compute-version.outputs.version }}" '.version = $v' package.json > package.json.tmp && mv package.json.tmp package.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2406,7 +2406,7 @@ jobs:
         run: bun run build
 
       - name: Bundle web dist into Electron resources
-        run: cp -R ../../apps/web/dist resources/web-dist
+        run: mkdir -p resources && cp -R ../../apps/web/dist resources/web-dist
 
       - name: Stamp release version into package.json
         run: jq --arg v "${{ needs.extract-version.outputs.version }}" '.version = $v' package.json > package.json.tmp && mv package.json.tmp package.json


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for electron-npm-bundle.md.

**Gap:** `cp -R` fails because `resources/` directory does not exist yet
**What was expected:** The web dist copy should succeed before `bun run pack`
**What was found:** `resources/` is gitignored and only created later by `fetch-bun.sh` inside `bun run pack`

Adds `mkdir -p resources &&` before `cp -R` in both dev-release.yaml and release.yml.