### PR TITLE
fix(macos): handle string-typed feature flags in Swift registry decoder

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -917,11 +917,12 @@ struct SettingsDeveloperTab: View {
             // Fall back to the bundled registry + cached gateway flags
             if let registry = loadFeatureFlagRegistry() {
                 let resolved = AssistantFeatureFlagResolver.resolvedFlags(registry: registry)
-                assistantFlags = registry.assistantScopeFlags().map { def in
-                    AssistantFeatureFlag(
+                assistantFlags = registry.assistantScopeFlags().compactMap { def in
+                    guard let defaultBool = def.defaultEnabled.boolValue else { return nil }
+                    return AssistantFeatureFlag(
                         key: def.key,
-                        enabled: resolved[def.key] ?? def.defaultEnabled,
-                        defaultEnabled: def.defaultEnabled,
+                        enabled: resolved[def.key] ?? defaultBool,
+                        defaultEnabled: defaultBool,
                         description: def.description,
                         label: def.label
                     )

--- a/clients/macos/vellum-assistant/Services/AssistantFeatureFlagResolver.swift
+++ b/clients/macos/vellum-assistant/Services/AssistantFeatureFlagResolver.swift
@@ -64,9 +64,10 @@ enum AssistantFeatureFlagResolver {
 
     static func registryDefaults(from registry: FeatureFlagRegistry?) -> [String: Bool] {
         Dictionary(
-            uniqueKeysWithValues: (registry?.assistantScopeFlags() ?? []).map {
-                ($0.key, $0.defaultEnabled)
-            }
+            uniqueKeysWithValues: (registry?.assistantScopeFlags() ?? [])
+                .compactMap { def in
+                    def.defaultEnabled.boolValue.map { (def.key, $0) }
+                }
         )
     }
 

--- a/clients/macos/vellum-assistantTests/AssistantFeatureFlagResolverTests.swift
+++ b/clients/macos/vellum-assistantTests/AssistantFeatureFlagResolverTests.swift
@@ -15,7 +15,7 @@ final class AssistantFeatureFlagResolverTests: XCTestCase {
                     key: conversationStartersKey,
                     label: "Recommended Starts",
                     description: "Show conversation starter chips",
-                    defaultEnabled: defaultEnabled
+                    defaultEnabled: .bool(defaultEnabled)
                 )
             ]
         )

--- a/clients/shared/Network/FeatureFlagClient.swift
+++ b/clients/shared/Network/FeatureFlagClient.swift
@@ -128,7 +128,7 @@ public struct FeatureFlagClient: FeatureFlagClientProtocol {
             return AssistantFeatureFlag(
                 key: registryKey,
                 enabled: enabled,
-                defaultEnabled: def?.defaultEnabled,
+                defaultEnabled: def?.defaultEnabled.boolValue,
                 description: def?.description,
                 label: def?.label
             )

--- a/clients/shared/Network/FeatureFlagClient.swift
+++ b/clients/shared/Network/FeatureFlagClient.swift
@@ -75,6 +75,28 @@ private struct FeatureFlagsResponse<Flag: Decodable>: Decodable {
     let flags: [Flag]
 }
 
+/// Mixed-value DTO for the gateway array format where `enabled` and
+/// `defaultEnabled` may be booleans or strings (for experiment flags).
+/// Decodes both shapes, then callers filter to boolean-only entries.
+private struct MixedFeatureFlag: Decodable {
+    let key: String
+    let enabled: FlagDefault
+    let defaultEnabled: FlagDefault?
+    let description: String?
+    let label: String?
+
+    func toBooleanFlag() -> AssistantFeatureFlag? {
+        guard let enabledBool = enabled.boolValue else { return nil }
+        return AssistantFeatureFlag(
+            key: key,
+            enabled: enabledBool,
+            defaultEnabled: defaultEnabled?.boolValue,
+            description: description,
+            label: label
+        )
+    }
+}
+
 /// Wrapper for the platform's dict-format response: `{ "flags": { "key": bool } }`.
 private struct PlatformFeatureFlagsResponse: Decodable {
     let flags: [String: Bool]
@@ -106,8 +128,10 @@ public struct FeatureFlagClient: FeatureFlagClientProtocol {
             throw FeatureFlagError.requestFailed(response.statusCode)
         }
         // Try gateway array format first: { "flags": [{ key, enabled, ... }] }
-        if let decoded = try? JSONDecoder().decode(FeatureFlagsResponse<AssistantFeatureFlag>.self, from: response.data) {
-            return decoded.flags
+        // Use MixedFeatureFlag to tolerate string-typed experiment flags, then
+        // filter to boolean-only entries the UI can represent.
+        if let decoded = try? JSONDecoder().decode(FeatureFlagsResponse<MixedFeatureFlag>.self, from: response.data) {
+            return decoded.flags.compactMap { $0.toBooleanFlag() }
         }
         // Fall back to platform dict format: { "flags": { "key": bool } }
         let platform = try JSONDecoder().decode(PlatformFeatureFlagsResponse.self, from: response.data)

--- a/clients/shared/Utilities/FeatureFlagRegistry.swift
+++ b/clients/shared/Utilities/FeatureFlagRegistry.swift
@@ -10,6 +10,29 @@ public enum FeatureFlagScope: String, Decodable {
     case both
 }
 
+/// The `defaultEnabled` value in the registry is either a `Bool` (for boolean
+/// flags) or a `String` (for string/experiment flags).
+public enum FlagDefault: Decodable, Equatable {
+    case bool(Bool)
+    case string(String)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let b = try? container.decode(Bool.self) {
+            self = .bool(b)
+        } else {
+            self = .string(try container.decode(String.self))
+        }
+    }
+
+    public var boolValue: Bool? {
+        if case .bool(let v) = self { return v }
+        return nil
+    }
+
+    public var isBoolean: Bool { boolValue != nil }
+}
+
 /// A single entry in the unified feature flag registry.
 public struct FeatureFlagDefinition: Decodable {
     public let id: String
@@ -17,7 +40,7 @@ public struct FeatureFlagDefinition: Decodable {
     public let key: String
     public let label: String
     public let description: String
-    public let defaultEnabled: Bool
+    public let defaultEnabled: FlagDefault
 }
 
 /// Top-level schema for `feature-flag-registry.json`.
@@ -30,6 +53,12 @@ public struct FeatureFlagRegistry: Decodable {
     /// Return flags consumed by clients (`scope == .client` or `.both`).
     public func clientScopeFlags() -> [FeatureFlagDefinition] {
         flags.filter { $0.scope == .client || $0.scope == .both }
+    }
+
+    /// Boolean-only client flags — excludes string/experiment flags that the
+    /// macOS toggle UI cannot represent.
+    public func clientBooleanFlags() -> [FeatureFlagDefinition] {
+        clientScopeFlags().filter { $0.defaultEnabled.isBoolean }
     }
 
     /// Return flags consumed by the assistant backend (`scope == .assistant` or `.both`).

--- a/clients/shared/Utilities/MacOSClientFeatureFlagManager.swift
+++ b/clients/shared/Utilities/MacOSClientFeatureFlagManager.swift
@@ -52,10 +52,12 @@ public final class MacOSClientFeatureFlagManager: @unchecked Sendable {
         loadRegistry()
     }
 
-    /// Load client-scope flag definitions from the bundled registry.
+    /// Load client-scope boolean flag definitions from the bundled registry.
+    /// String-typed flags (experiments) are excluded — the macOS UI only
+    /// supports boolean toggles.
     private func loadRegistry() {
         if let registry = loadFeatureFlagRegistry() {
-            flagDefinitions = registry.clientScopeFlags()
+            flagDefinitions = registry.clientBooleanFlags()
         } else {
             log.warning("Failed to load feature flag registry from bundle — falling back to empty definitions")
             flagDefinitions = []
@@ -70,25 +72,25 @@ public final class MacOSClientFeatureFlagManager: @unchecked Sendable {
         if let override = overrides[Self.normalize(key)] {
             return override
         }
-        // Fall back to registry default
         if let def = flagDefinitions.first(where: { Self.normalize($0.key) == Self.normalize(key) }) {
-            return def.defaultEnabled
+            return def.defaultEnabled.boolValue ?? false
         }
         return false
     }
 
-    /// Return the resolved state of all client-scope flag definitions for UI display.
+    /// Return the resolved state of all client-scope boolean flag definitions for UI display.
     public func allFlagStates() -> [MacOSFeatureFlagState] {
         lock.lock()
         defer { lock.unlock() }
-        return flagDefinitions.map { def in
-            let enabled = overrides[Self.normalize(def.key)] ?? def.defaultEnabled
+        return flagDefinitions.compactMap { def in
+            guard let defaultBool = def.defaultEnabled.boolValue else { return nil }
+            let enabled = overrides[Self.normalize(def.key)] ?? defaultBool
             return MacOSFeatureFlagState(
                 id: def.id,
                 key: def.key,
                 label: def.label,
                 description: def.description,
-                defaultEnabled: def.defaultEnabled,
+                defaultEnabled: defaultBool,
                 enabled: enabled
             )
         }


### PR DESCRIPTION
## Summary
- Introduce a `FlagDefault` enum in the Swift registry model that decodes both `Bool` and `String` values for `defaultEnabled`, preventing `JSONDecoder` from failing the entire registry when string-typed flags are present
- Filter out string-typed flags from the macOS client flag manager, assistant flag resolver, and developer settings UI — these code paths only support boolean toggles
- Update the `AssistantFeatureFlagResolverTests` helper to use the new `.bool()` case

## Original prompt
After merging the `pre-chat-onboarding-experiment-2026-06-06` string-typed feature flag (#33689), a [review comment](https://github.com/vellum-ai/vellum-assistant/pull/33689#discussion_r3365014482) flagged that the macOS Swift loader decodes `defaultEnabled` as a `Bool`. The string `"control"` value causes `JSONDecoder` to fail the entire registry, leaving the macOS app with empty feature flag definitions. This PR fixes the decoder to accept string defaults and filters string flags from the boolean-only UI/resolution paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)