### PR TITLE
feat(macos): declare .vellum file association in electron-builder config

### DIFF
--- a/apps/macos/electron-builder.yml
+++ b/apps/macos/electron-builder.yml
@@ -16,6 +16,10 @@ protocols:
     schemes:
       - vellum
       - vellum-assistant
+fileAssociations:
+  - ext: vellum
+    name: Vellum Bundle
+    role: Viewer
 mac:
   icon: build/icon.icns
   category: public.app-category.productivity


### PR DESCRIPTION
## Summary
- Add fileAssociations config for .vellum files as a top-level key in electron-builder.yml
- Registers Vellum as the default handler for .vellum bundle files on macOS

Part of plan: vellum-file-association.md (PR 4 of 7)