### PR TITLE
feat(macos): register vellumapp:// privileged scheme and protocol handler

### DIFF
--- a/apps/macos/src/main/app-config.ts
+++ b/apps/macos/src/main/app-config.ts
@@ -20,6 +20,8 @@
 
 export const APP_PROTOCOL = "app";
 export const APP_HOST = "vellum.ai";
+export const VELLUMAPP_PROTOCOL = "vellumapp";
+export const BUNDLES_DIR_NAME = "bundles";
 
 const DEV_SERVER_FALLBACK_URL = "http://localhost:5173/assistant";
 

--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -11,11 +11,12 @@ import {
 } from "@vellumai/local-mode";
 
 import { installAbout, openAboutWindow } from "./about";
-import { APP_HOST, APP_PROTOCOL } from "./app-config";
+import { APP_HOST, APP_PROTOCOL, BUNDLES_DIR_NAME, VELLUMAPP_PROTOCOL } from "./app-config";
 import { installCsp } from "./csp";
 import { ensureWebInstalled, getWebDistPath } from "./cli-installer";
 import { handle, handleSync } from "./ipc";
 import { resolveAppProtocolPath } from "./app-protocol";
+import { registerVellumAppProtocol } from "./vellumapp-protocol";
 import { planGatewayForward } from "./gateway-forward";
 import { planPlatformForward } from "./platform-forward";
 import {
@@ -84,6 +85,16 @@ if (!app.requestSingleInstanceLock()) {
 protocol.registerSchemesAsPrivileged([
   {
     scheme: APP_PROTOCOL,
+    privileges: {
+      standard: true,
+      secure: true,
+      supportFetchAPI: true,
+      stream: true,
+      corsEnabled: true,
+    },
+  },
+  {
+    scheme: VELLUMAPP_PROTOCOL,
     privileges: {
       standard: true,
       secure: true,
@@ -304,6 +315,9 @@ app
       // this await can create a window before the protocol handler exists.
       await ensureWebInstalled();
       registerAppProtocol();
+      registerVellumAppProtocol(
+        path.join(app.getPath("userData"), BUNDLES_DIR_NAME),
+      );
     }
     installPermissionHandler();
     installCsp();

--- a/apps/macos/src/main/vellumapp-protocol.test.ts
+++ b/apps/macos/src/main/vellumapp-protocol.test.ts
@@ -1,0 +1,161 @@
+import path from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import { resolveRelativePath } from "./app-protocol";
+import { mimeTypeForPath, resolveBundlePath } from "./vellumapp-protocol";
+
+const BUNDLES_ROOT = "/data/bundles";
+const VALID_UUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+const BUNDLE_ROOT = path.join(BUNDLES_ROOT, VALID_UUID);
+
+describe("resolveBundlePath — valid inputs", () => {
+  test("resolves a top-level file inside the bundle", () => {
+    expect(
+      resolveBundlePath(
+        BUNDLES_ROOT,
+        `vellumapp://${VALID_UUID}/index.html`,
+      ),
+    ).toEqual({
+      kind: "ok",
+      uuid: VALID_UUID,
+      resolved: path.join(BUNDLE_ROOT, "index.html"),
+    });
+  });
+
+  test("resolves a nested asset path", () => {
+    expect(
+      resolveBundlePath(
+        BUNDLES_ROOT,
+        `vellumapp://${VALID_UUID}/assets/style.css`,
+      ),
+    ).toEqual({
+      kind: "ok",
+      uuid: VALID_UUID,
+      resolved: path.join(BUNDLE_ROOT, "assets/style.css"),
+    });
+  });
+
+  test("resolves the bare root to the bundle directory itself", () => {
+    expect(
+      resolveBundlePath(BUNDLES_ROOT, `vellumapp://${VALID_UUID}/`),
+    ).toEqual({
+      kind: "ok",
+      uuid: VALID_UUID,
+      resolved: BUNDLE_ROOT,
+    });
+  });
+});
+
+// The `URL` parser collapses `..` and `%2e%2e` segments during parsing
+// (RFC 3986 path normalization), so most traversal-style inputs never
+// reach `resolveRelativePath` with any `..` left to escape. This is the
+// first line of defense; these tests document its behavior. The
+// `resolveRelativePath` guard (tested below) is defense-in-depth.
+describe("resolveBundlePath — URL parser collapses `..` segments", () => {
+  test("literal `..` resolves to a safe in-bundle path", () => {
+    expect(
+      resolveBundlePath(
+        BUNDLES_ROOT,
+        `vellumapp://${VALID_UUID}/../etc/passwd`,
+      ),
+    ).toEqual({
+      kind: "ok",
+      uuid: VALID_UUID,
+      resolved: path.join(BUNDLE_ROOT, "etc/passwd"),
+    });
+  });
+
+  test("deeply nested `..` chains resolve to a safe in-bundle path", () => {
+    expect(
+      resolveBundlePath(
+        BUNDLES_ROOT,
+        `vellumapp://${VALID_UUID}/a/../../etc/passwd`,
+      ),
+    ).toEqual({
+      kind: "ok",
+      uuid: VALID_UUID,
+      resolved: path.join(BUNDLE_ROOT, "etc/passwd"),
+    });
+  });
+
+  test("percent-encoded `..` (`%2e%2e`) resolves to a safe in-bundle path", () => {
+    expect(
+      resolveBundlePath(
+        BUNDLES_ROOT,
+        `vellumapp://${VALID_UUID}/%2e%2e/etc/passwd`,
+      ),
+    ).toEqual({
+      kind: "ok",
+      uuid: VALID_UUID,
+      resolved: path.join(BUNDLE_ROOT, "etc/passwd"),
+    });
+  });
+});
+
+// Direct probes of `resolveRelativePath` scoped to a bundle root —
+// bypasses URL normalization to exercise the `startsWith` guard for real.
+describe("resolveRelativePath — bundle-root guard (defense-in-depth)", () => {
+  test("`..` segments surviving normalization are rejected", () => {
+    expect(resolveRelativePath(BUNDLE_ROOT, "../etc/passwd")).toEqual({
+      kind: "forbidden",
+    });
+  });
+
+  test("deeply nested `..` that escape the bundle root are rejected", () => {
+    expect(resolveRelativePath(BUNDLE_ROOT, "a/../../etc/passwd")).toEqual({
+      kind: "forbidden",
+    });
+  });
+
+  test("sibling bundle directories are rejected", () => {
+    expect(
+      resolveRelativePath(BUNDLE_ROOT, "../other-uuid/index.html"),
+    ).toEqual({ kind: "forbidden" });
+  });
+});
+
+describe("resolveBundlePath — invalid UUID", () => {
+  test("malformed UUID returns forbidden", () => {
+    expect(
+      resolveBundlePath(BUNDLES_ROOT, "vellumapp://not-a-uuid/index.html"),
+    ).toEqual({ kind: "forbidden" });
+  });
+
+  test("UUID with extra characters returns forbidden", () => {
+    expect(
+      resolveBundlePath(
+        BUNDLES_ROOT,
+        `vellumapp://${VALID_UUID}extra/index.html`,
+      ),
+    ).toEqual({ kind: "forbidden" });
+  });
+
+  test("empty hostname returns forbidden", () => {
+    expect(
+      resolveBundlePath(BUNDLES_ROOT, "vellumapp:///index.html"),
+    ).toEqual({ kind: "forbidden" });
+  });
+});
+
+describe("mimeTypeForPath", () => {
+  test("returns text/html for .html files", () => {
+    expect(mimeTypeForPath("index.html")).toBe("text/html");
+  });
+
+  test("returns application/javascript for .js files", () => {
+    expect(mimeTypeForPath("bundle.js")).toBe("application/javascript");
+  });
+
+  test("returns text/css for .css files", () => {
+    expect(mimeTypeForPath("styles.css")).toBe("text/css");
+  });
+
+  test("returns application/octet-stream for unknown extensions", () => {
+    expect(mimeTypeForPath("data.xyz")).toBe("application/octet-stream");
+  });
+
+  test("is case-insensitive for file extensions", () => {
+    expect(mimeTypeForPath("image.PNG")).toBe("image/png");
+  });
+});

--- a/apps/macos/src/main/vellumapp-protocol.ts
+++ b/apps/macos/src/main/vellumapp-protocol.ts
@@ -1,0 +1,102 @@
+/**
+ * Protocol handler for `vellumapp://` — serves bundle assets from
+ * `userData/bundles/{uuid}/`. The hostname of the URL is the bundle
+ * UUID; the pathname maps to a file inside that bundle directory.
+ *
+ * Same structural pattern as `app-protocol.ts`: the core path-resolution
+ * logic is pure (no Electron imports) so tests can exercise it without
+ * standing up the full main-process lifecycle. The Electron-dependent
+ * `registerVellumAppProtocol` wires the pure logic into `protocol.handle`.
+ */
+import fs from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { net, protocol } from "electron";
+
+import { VELLUMAPP_PROTOCOL } from "./app-config";
+import { resolveRelativePath } from "./app-protocol";
+
+const MIME_TYPES: Record<string, string> = {
+  ".html": "text/html",
+  ".css": "text/css",
+  ".js": "application/javascript",
+  ".json": "application/json",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".svg": "image/svg+xml",
+  ".woff": "font/woff",
+  ".woff2": "font/woff2",
+  ".wasm": "application/wasm",
+  ".ico": "image/x-icon",
+};
+
+export const mimeTypeForPath = (filePath: string): string =>
+  MIME_TYPES[path.extname(filePath).toLowerCase()] ??
+  "application/octet-stream";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export type ResolveBundleResult =
+  | { kind: "ok"; uuid: string; resolved: string }
+  | { kind: "forbidden" };
+
+export const resolveBundlePath = (
+  bundlesRoot: string,
+  requestUrl: string,
+): ResolveBundleResult => {
+  const url = new URL(requestUrl);
+  const uuid = url.hostname;
+
+  if (!UUID_RE.test(uuid)) {
+    return { kind: "forbidden" };
+  }
+
+  const bundleRoot = path.join(bundlesRoot, uuid);
+
+  let relativePath: string;
+  try {
+    relativePath = decodeURIComponent(url.pathname).replace(/^\/+/, "");
+  } catch {
+    return { kind: "forbidden" };
+  }
+
+  const result = resolveRelativePath(bundleRoot, relativePath);
+  if (result.kind === "forbidden") {
+    return { kind: "forbidden" };
+  }
+
+  return { kind: "ok", uuid, resolved: result.resolved };
+};
+
+export const registerVellumAppProtocol = (bundlesRoot: string): void => {
+  protocol.handle(VELLUMAPP_PROTOCOL, async (request) => {
+    const result = resolveBundlePath(bundlesRoot, request.url);
+    if (result.kind === "forbidden") {
+      return new Response("Forbidden", { status: 403 });
+    }
+
+    const { resolved } = result;
+
+    try {
+      const stat = await fs.stat(resolved);
+      if (!stat.isFile()) {
+        return new Response("Not Found", { status: 404 });
+      }
+    } catch {
+      return new Response("Not Found", { status: 404 });
+    }
+
+    const response = await net.fetch(pathToFileURL(resolved).toString());
+    return new Response(response.body, {
+      status: response.status,
+      headers: {
+        "Content-Type": mimeTypeForPath(resolved),
+      },
+    });
+  });
+};


### PR DESCRIPTION
## Summary
- Register vellumapp:// as a privileged custom scheme alongside app://
- Implement protocol handler serving files from userData/bundles/{uuid}/ with path-traversal guard
- Add MIME type detection and UUID validation

Part of plan: vellum-file-association.md (PR 1 of 7)