### PR TITLE
feat(macos): add open-file event handler with pre-ready buffering for .vellum files

### DIFF
--- a/apps/macos/src/main/file-open.test.ts
+++ b/apps/macos/src/main/file-open.test.ts
@@ -1,0 +1,292 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+type Listener = (...args: unknown[]) => void;
+
+const makeSender = (): {
+  sender: { once: (event: string, handler: () => void) => void };
+  fireDestroyed: () => void;
+} => {
+  let destroyedHandler: (() => void) | null = null;
+  return {
+    sender: {
+      once: (event, handler) => {
+        if (event === "destroyed") destroyedHandler = handler;
+      },
+    },
+    fireDestroyed: () => destroyedHandler?.(),
+  };
+};
+
+const subscribeWith = (s: ReturnType<typeof makeSender>) =>
+  ipcOnListeners
+    .get("vellum:fileOpen:subscribe")
+    ?.({ sender: s.sender, senderFrame: allowedSenderFrame });
+const unsubscribeWith = (s: ReturnType<typeof makeSender>) =>
+  ipcOnListeners
+    .get("vellum:fileOpen:unsubscribe")
+    ?.({ sender: s.sender, senderFrame: allowedSenderFrame });
+
+const appListeners = new Map<string, Listener>();
+const appOnMock = mock((event: string, listener: Listener) => {
+  appListeners.set(event, listener);
+});
+const ipcHandleMock = mock(
+  (_channel: string, _handler: (...args: unknown[]) => unknown) => undefined,
+);
+const ipcOnListeners = new Map<string, Listener>();
+const ipcOnMock = mock((event: string, listener: Listener) => {
+  ipcOnListeners.set(event, listener);
+});
+let windows: Array<{
+  isDestroyed: () => boolean;
+  webContents: { send: ReturnType<typeof mock> };
+}> = [];
+
+let appIsReady = true;
+mock.module("electron", () => ({
+  app: {
+    on: appOnMock,
+    isReady: () => appIsReady,
+  },
+  ipcMain: { handle: ipcHandleMock, on: ipcOnMock },
+  BrowserWindow: { getAllWindows: () => windows },
+}));
+
+const ensureMainWindowVisibleMock = mock(async () => undefined);
+mock.module("./main-window", () => ({
+  ensureVisible: ensureMainWindowVisibleMock,
+}));
+
+const { __resetForTesting, handleFileOpen, installFileOpen } = await import(
+  "./file-open"
+);
+const { resolveAllowedOrigin } = await import("./app-origin");
+
+const { protocol: allowedProtocol, host: allowedHost } = resolveAllowedOrigin();
+const allowedSenderFrame = { origin: `${allowedProtocol}//${allowedHost}` };
+const allowedEvent = { senderFrame: allowedSenderFrame };
+
+const makeWindow = (destroyed = false) => ({
+  isDestroyed: () => destroyed,
+  webContents: { send: mock(() => undefined) },
+});
+
+beforeEach(() => {
+  __resetForTesting();
+  appListeners.clear();
+  ipcOnListeners.clear();
+  appOnMock.mockClear();
+  ipcHandleMock.mockClear();
+  ipcOnMock.mockClear();
+  ensureMainWindowVisibleMock.mockClear();
+  windows = [];
+  appIsReady = true;
+});
+
+afterEach(() => {
+  windows = [];
+});
+
+describe("handleFileOpen", () => {
+  test(".vellum files are buffered when no subscribers exist", () => {
+    installFileOpen();
+
+    handleFileOpen("/tmp/example.vellum");
+
+    const drainHandler = ipcHandleMock.mock.calls.find(
+      (c) => c[0] === "vellum:fileOpen:drain",
+    )![1] as (event: unknown) => unknown[];
+    expect(drainHandler(allowedEvent)).toEqual(["/tmp/example.vellum"]);
+  });
+
+  test("non-.vellum files are silently ignored", () => {
+    installFileOpen();
+
+    handleFileOpen("/tmp/example.txt");
+    handleFileOpen("/tmp/example.vellum.bak");
+    handleFileOpen("/tmp/readme.md");
+
+    const drainHandler = ipcHandleMock.mock.calls.find(
+      (c) => c[0] === "vellum:fileOpen:drain",
+    )![1] as (event: unknown) => unknown[];
+    expect(drainHandler(allowedEvent)).toEqual([]);
+  });
+
+  test(".VELLUM extension is accepted (case-insensitive)", () => {
+    installFileOpen();
+
+    handleFileOpen("/tmp/example.VELLUM");
+
+    const drainHandler = ipcHandleMock.mock.calls.find(
+      (c) => c[0] === "vellum:fileOpen:drain",
+    )![1] as (event: unknown) => unknown[];
+    expect(drainHandler(allowedEvent)).toEqual(["/tmp/example.VELLUM"]);
+  });
+
+  test("calls ensureMainWindowVisible when app is ready", () => {
+    handleFileOpen("/tmp/example.vellum");
+    expect(ensureMainWindowVisibleMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("defers activation when app is not yet ready", () => {
+    appIsReady = false;
+    handleFileOpen("/tmp/example.vellum");
+    expect(ensureMainWindowVisibleMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("drain", () => {
+  test("returns buffered paths and clears buffer", () => {
+    installFileOpen();
+
+    handleFileOpen("/tmp/a.vellum");
+    handleFileOpen("/tmp/b.vellum");
+
+    const drainHandler = ipcHandleMock.mock.calls.find(
+      (c) => c[0] === "vellum:fileOpen:drain",
+    )![1] as (event: unknown) => unknown[];
+
+    expect(drainHandler(allowedEvent)).toEqual([
+      "/tmp/a.vellum",
+      "/tmp/b.vellum",
+    ]);
+    // Second drain returns empty.
+    expect(drainHandler(allowedEvent)).toEqual([]);
+  });
+
+  test("drain adds the sender to subscribers", () => {
+    installFileOpen();
+
+    handleFileOpen("/tmp/backlog.vellum");
+
+    const drainHandler = ipcHandleMock.mock.calls.find(
+      (c) => c[0] === "vellum:fileOpen:drain",
+    )![1] as (event: unknown) => unknown[];
+    drainHandler(allowedEvent);
+
+    // With a subscriber, the next file should NOT enter the buffer.
+    handleFileOpen("/tmp/live.vellum");
+    expect(drainHandler(allowedEvent)).toEqual([]);
+  });
+});
+
+describe("broadcast", () => {
+  test("fires event to all non-destroyed windows", () => {
+    const w1 = makeWindow();
+    const w2 = makeWindow();
+    windows = [w1, w2];
+
+    handleFileOpen("/tmp/example.vellum");
+
+    expect(w1.webContents.send).toHaveBeenCalledWith(
+      "vellum:fileOpen:event",
+      "/tmp/example.vellum",
+    );
+    expect(w2.webContents.send).toHaveBeenCalledWith(
+      "vellum:fileOpen:event",
+      "/tmp/example.vellum",
+    );
+  });
+
+  test("skips destroyed windows", () => {
+    const alive = makeWindow();
+    const dead = makeWindow(true);
+    windows = [alive, dead];
+
+    handleFileOpen("/tmp/example.vellum");
+
+    expect(alive.webContents.send).toHaveBeenCalled();
+    expect(dead.webContents.send).not.toHaveBeenCalled();
+  });
+});
+
+describe("subscriber lifecycle", () => {
+  test("with a subscriber present, live files broadcast but do NOT enter the buffer", () => {
+    installFileOpen();
+    const drainHandler = ipcHandleMock.mock.calls.find(
+      (c) => c[0] === "vellum:fileOpen:drain",
+    )![1] as (event: unknown) => unknown[];
+
+    handleFileOpen("/tmp/backlog.vellum");
+
+    const s1 = makeSender();
+    subscribeWith(s1);
+    expect(drainHandler(allowedEvent)).toEqual(["/tmp/backlog.vellum"]);
+
+    handleFileOpen("/tmp/live.vellum");
+
+    unsubscribeWith(s1);
+    const s2 = makeSender();
+    subscribeWith(s2);
+    expect(drainHandler(allowedEvent)).toEqual([]);
+  });
+
+  test("file arriving while unsubscribed lands in the buffer for the next subscriber", () => {
+    installFileOpen();
+    const drainHandler = ipcHandleMock.mock.calls.find(
+      (c) => c[0] === "vellum:fileOpen:drain",
+    )![1] as (event: unknown) => unknown[];
+
+    const s1 = makeSender();
+    subscribeWith(s1);
+    expect(drainHandler(allowedEvent)).toEqual([]);
+
+    unsubscribeWith(s1);
+    handleFileOpen("/tmp/post-logout.vellum");
+
+    const s2 = makeSender();
+    subscribeWith(s2);
+    expect(drainHandler(allowedEvent)).toEqual(["/tmp/post-logout.vellum"]);
+  });
+
+  test("destroyed webContents auto-clears its subscription", () => {
+    installFileOpen();
+    const drainHandler = ipcHandleMock.mock.calls.find(
+      (c) => c[0] === "vellum:fileOpen:drain",
+    )![1] as (event: unknown) => unknown[];
+
+    const s = makeSender();
+    subscribeWith(s);
+    expect(drainHandler(allowedEvent)).toEqual([]);
+
+    s.fireDestroyed();
+
+    handleFileOpen("/tmp/after-crash.vellum");
+    expect(drainHandler(allowedEvent)).toEqual(["/tmp/after-crash.vellum"]);
+  });
+});
+
+describe("installFileOpen", () => {
+  test("is idempotent", () => {
+    installFileOpen();
+    installFileOpen();
+    installFileOpen();
+
+    // will-finish-launching registered only once.
+    const wflCalls = appOnMock.mock.calls.filter(
+      (c) => c[0] === "will-finish-launching",
+    );
+    expect(wflCalls.length).toBe(1);
+  });
+
+  test("subscribes to will-finish-launching and registers an open-file listener under it", () => {
+    installFileOpen();
+    const wfl = appListeners.get("will-finish-launching");
+    expect(wfl).toBeDefined();
+
+    wfl?.();
+    expect(appListeners.has("open-file")).toBe(true);
+  });
+
+  test("open-file calls preventDefault on the event and routes through handleFileOpen", () => {
+    installFileOpen();
+    appListeners.get("will-finish-launching")?.();
+    const openFile = appListeners.get("open-file");
+    expect(openFile).toBeDefined();
+
+    const preventDefault = mock(() => undefined);
+    openFile?.({ preventDefault } as unknown, "/tmp/example.vellum");
+
+    expect(preventDefault).toHaveBeenCalled();
+  });
+});

--- a/apps/macos/src/main/file-open.ts
+++ b/apps/macos/src/main/file-open.ts
@@ -1,0 +1,92 @@
+import { BrowserWindow, app, type WebContents } from "electron";
+import { z } from "zod";
+
+import { handle, on } from "./ipc";
+import { ensureVisible as ensureMainWindowVisible } from "./main-window";
+
+/**
+ * Inbound file-open events — `.vellum` bundle double-clicks in Finder.
+ *
+ * The OS delivers `open-file` when the user double-clicks a `.vellum`
+ * bundle (or drags it onto the Dock icon). This module captures the
+ * file path, validates it, and routes it to the renderer via the same
+ * buffer/broadcast/subscriber pattern used by `deep-links.ts`.
+ *
+ * Lifecycle hooks (all required):
+ *
+ *   - `app.on("will-finish-launching", () => app.on("open-file", ...))`
+ *     captures file paths delivered AT launch. Registering in
+ *     `whenReady` misses the launching file — same pitfall as deep links.
+ *   - `app.on("second-instance")` forwards `.vellum` paths from argv
+ *     when a second launch attempt occurs.
+ *
+ * Buffering: file paths arriving before the renderer subscribes are
+ * queued in `pending[]`. The renderer drains via
+ * `window.vellum.fileOpen.drain()` once mounted. Live file-open events
+ * arriving after drain are broadcast to subscribers; unsubscribed
+ * windows still receive broadcasts (same model as deep links).
+ */
+
+const VELLUM_EXT_RE = /\.vellum$/i;
+
+const pending: string[] = [];
+
+const subscribers = new Set<WebContents>();
+
+const broadcast = (filePath: string): void => {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (win.isDestroyed()) continue;
+    win.webContents.send("vellum:fileOpen:event", filePath);
+  }
+};
+
+export const handleFileOpen = (filePath: string): void => {
+  if (!VELLUM_EXT_RE.test(filePath)) return;
+  if (subscribers.size === 0) pending.push(filePath);
+  broadcast(filePath);
+  if (app.isReady()) {
+    void ensureMainWindowVisible();
+  }
+};
+
+let installed = false;
+
+export const installFileOpen = (): void => {
+  if (installed) return;
+  installed = true;
+
+  app.on("will-finish-launching", () => {
+    app.on("open-file", (event, filePath) => {
+      event.preventDefault();
+      handleFileOpen(filePath);
+    });
+  });
+
+  handle("vellum:fileOpen:drain", z.tuple([]), (_args, event): string[] => {
+    if (!subscribers.has(event.sender)) {
+      subscribers.add(event.sender);
+      event.sender.once("destroyed", () => {
+        subscribers.delete(event.sender);
+      });
+    }
+    return pending.splice(0, pending.length);
+  });
+
+  on("vellum:fileOpen:subscribe", z.tuple([]), (_args, event) => {
+    if (subscribers.has(event.sender)) return;
+    subscribers.add(event.sender);
+    event.sender.once("destroyed", () => {
+      subscribers.delete(event.sender);
+    });
+  });
+
+  on("vellum:fileOpen:unsubscribe", z.tuple([]), (_args, event) => {
+    subscribers.delete(event.sender);
+  });
+};
+
+export const __resetForTesting = (): void => {
+  installed = false;
+  subscribers.clear();
+  pending.length = 0;
+};

--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -23,6 +23,7 @@ import {
   handleDeepLink,
   installDeepLinks,
 } from "./deep-links";
+import { handleFileOpen, installFileOpen } from "./file-open";
 import { installAvatarIpc } from "./avatar";
 import { installDock } from "./dock";
 import { installFeedbackIpc } from "./feedback";
@@ -100,6 +101,7 @@ protocol.registerSchemesAsPrivileged([
 // can fire before `whenReady`). Registering in `whenReady` misses
 // the launching URL — the #1 deep-link bug in Electron apps.
 installDeepLinks();
+installFileOpen();
 
 // Serve apps/web/dist/ as static files via `app://vellum.ai/...`. Route-like
 // paths (no file extension, or `.html`) fall back to index.html so React
@@ -360,6 +362,14 @@ app.on("second-instance", (_event, argv) => {
   // / broadcast pipeline is platform-agnostic.
   const deepLink = extractDeepLinkFromArgv(argv);
   if (deepLink) handleDeepLink(deepLink);
+  // Forward .vellum file paths from second-instance argv so the
+  // buffer/broadcast pipeline handles them identically to open-file.
+  for (const arg of argv) {
+    if (/\.vellum$/i.test(arg)) {
+      handleFileOpen(arg);
+      break;
+    }
+  }
 });
 
 app.on("web-contents-created", (_event, contents) => {

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -350,6 +350,21 @@ export interface VellumBridge {
      */
     onLink(callback: (link: DeepLink) => void): () => void;
   };
+  fileOpen: {
+    /**
+     * Drain and return the buffer of `.vellum` file paths that arrived
+     * before the renderer was ready. Returns ALL pending paths and clears
+     * the buffer. Also registers the caller as a subscriber so subsequent
+     * file-open events broadcast directly rather than buffering.
+     */
+    drain(): Promise<string[]>;
+    /**
+     * Subscribe to live file-open events (files opened after the renderer
+     * is up). Returns an unsubscribe function; callers invoke it on
+     * cleanup.
+     */
+    onFile(callback: (filePath: string) => void): () => void;
+  };
   feedback: {
     /** Collect Electron-specific diagnostics (versions, platform, metrics). */
     diagnostics(): Promise<Record<string, unknown>>;
@@ -527,6 +542,21 @@ const bridge: VellumBridge = {
       return () => {
         ipcRenderer.off("vellum:deepLinks:event", handler);
         ipcRenderer.send("vellum:deepLinks:unsubscribe");
+      };
+    },
+  },
+  fileOpen: {
+    drain: (): Promise<string[]> =>
+      ipcRenderer.invoke("vellum:fileOpen:drain") as Promise<string[]>,
+    onFile: (callback) => {
+      ipcRenderer.send("vellum:fileOpen:subscribe");
+      const handler = (_event: IpcRendererEvent, filePath: string) => {
+        callback(filePath);
+      };
+      ipcRenderer.on("vellum:fileOpen:event", handler);
+      return () => {
+        ipcRenderer.send("vellum:fileOpen:unsubscribe");
+        ipcRenderer.off("vellum:fileOpen:event", handler);
       };
     },
   },


### PR DESCRIPTION
## Summary
- Add file-open.ts with open-file event handler, pre-ready buffering, and subscriber tracking
- Add fileOpen bridge to preload for renderer drain/subscribe
- Wire into index.ts at module top-level and second-instance handler

Part of plan: vellum-file-association.md (PR 3 of 7)