### PR TITLE
fix: add bundledDependencies to gateway package.json for npm publish

### DIFF
--- a/gateway/package.json
+++ b/gateway/package.json
@@ -39,6 +39,14 @@
     "web-tree-sitter": "0.26.5",
     "zod": "4.3.6"
   },
+  "bundledDependencies": [
+    "@vellumai/assistant-client",
+    "@vellumai/ces-client",
+    "@vellumai/ipc-server-utils",
+    "@vellumai/service-contracts",
+    "@vellumai/slack-text",
+    "@vellumai/twilio-client"
+  ],
   "devDependencies": {
     "@types/bun": "1.3.9",
     "eslint": "10.0.0",


### PR DESCRIPTION
## Summary
- Add `bundledDependencies` to `gateway/package.json` listing all 6 `file:` dependencies
- Without this, `npm publish` ships a package with unresolvable `file:../packages/...` deps
- Matches the existing pattern in `assistant`, `cli`, and `credential-executor` package.json files
- Fixes both the new pre-release publish and the pre-existing production publish

Addresses https://github.com/vellum-ai/vellum-assistant/pull/33696#discussion_r3365075007