### PR TITLE
feat(macos): add bundle storage manager for .vellum file unpacking

### DIFF
--- a/apps/macos/bun.lock
+++ b/apps/macos/bun.lock
@@ -9,6 +9,7 @@
         "@vellumai/local-mode": "file:../../packages/local-mode",
         "electron-log": "5.4.4",
         "electron-store": "11.0.2",
+        "jszip": "3.10.1",
         "zod": "4.3.6",
       },
       "devDependencies": {
@@ -507,11 +508,15 @@
 
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
+    "immediate": ["immediate@3.0.6", "", {}, "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="],
+
     "inflight": ["inflight@1.0.6", "", { "dependencies": { "once": "^1.3.0", "wrappy": "1" } }, "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
 
     "isbinaryfile": ["isbinaryfile@5.0.7", "", {}, "sha512-gnWD14Jh3FzS3CPhF0AxNOJ8CxqeblPTADzI38r0wt8ZyQl5edpy75myt08EG2oKvpyiqSqsx+Wkz9vtkbTqYQ=="],
 
@@ -541,9 +546,13 @@
 
     "jsonfile": ["jsonfile@6.2.1", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q=="],
 
+    "jszip": ["jszip@3.10.1", "", { "dependencies": { "lie": "~3.3.0", "pako": "~1.0.2", "readable-stream": "~2.3.6", "setimmediate": "^1.0.5" } }, "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g=="],
+
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
     "lazy-val": ["lazy-val@1.0.5", "", {}, "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q=="],
+
+    "lie": ["lie@3.3.0", "", { "dependencies": { "immediate": "~3.0.5" } }, "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ=="],
 
     "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
 
@@ -603,6 +612,8 @@
 
     "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
+    "pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
+
     "path-is-absolute": ["path-is-absolute@1.0.1", "", {}, "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
@@ -623,6 +634,8 @@
 
     "proc-log": ["proc-log@6.1.0", "", {}, "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ=="],
 
+    "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
+
     "progress": ["progress@2.0.3", "", {}, "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="],
 
     "promise-retry": ["promise-retry@2.0.1", "", { "dependencies": { "err-code": "^2.0.2", "retry": "^0.12.0" } }, "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g=="],
@@ -638,6 +651,8 @@
     "quick-lru": ["quick-lru@5.1.1", "", {}, "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="],
 
     "read-binary-file-arch": ["read-binary-file-arch@1.0.6", "", { "dependencies": { "debug": "^4.3.4" }, "bin": { "read-binary-file-arch": "cli.js" } }, "sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg=="],
+
+    "readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
@@ -659,6 +674,8 @@
 
     "rxjs": ["rxjs@7.8.2", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA=="],
 
+    "safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "sanitize-filename": ["sanitize-filename@1.6.4", "", { "dependencies": { "truncate-utf8-bytes": "^1.0.0" } }, "sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg=="],
@@ -670,6 +687,8 @@
     "semver-compare": ["semver-compare@1.0.0", "", {}, "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="],
 
     "serialize-error": ["serialize-error@7.0.1", "", { "dependencies": { "type-fest": "^0.13.1" } }, "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw=="],
+
+    "setimmediate": ["setimmediate@1.0.5", "", {}, "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
@@ -696,6 +715,8 @@
     "stat-mode": ["stat-mode@1.0.0", "", {}, "sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg=="],
 
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -746,6 +767,8 @@
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
     "utf8-byte-length": ["utf8-byte-length@1.0.5", "", {}, "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA=="],
+
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "verror": ["verror@1.10.1", "", { "dependencies": { "assert-plus": "^1.0.0", "core-util-is": "1.0.2", "extsprintf": "^1.2.0" } }, "sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg=="],
 

--- a/apps/macos/package.json
+++ b/apps/macos/package.json
@@ -35,6 +35,7 @@
     "@vellumai/local-mode": "file:../../packages/local-mode",
     "electron-log": "5.4.4",
     "electron-store": "11.0.2",
+    "jszip": "3.10.1",
     "zod": "4.3.6"
   }
 }

--- a/apps/macos/src/main/bundle-manager.test.ts
+++ b/apps/macos/src/main/bundle-manager.test.ts
@@ -1,0 +1,242 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+
+import {
+  listBundles,
+  readBundleMetadata,
+  removeBundle,
+  resolveEntryPath,
+  stripUnsafeEntries,
+  unpackBundle,
+  type BundleScanData,
+} from "./bundle-manager";
+
+let tmpDir: string;
+
+const makeScanData = (overrides?: Partial<BundleScanData>): BundleScanData => ({
+  manifest: {
+    format_version: 1,
+    name: "Test App",
+    description: "A test bundle",
+    icon: "🧪",
+    entry: "index.html",
+    capabilities: ["display"],
+    created_by: "user@example.com",
+    created_at: "2025-01-01T00:00:00Z",
+  },
+  scanResult: { passed: true, findings: [] },
+  signatureResult: { trustTier: "unsigned" },
+  bundleSizeBytes: 1024,
+  ...overrides,
+});
+
+async function createTestZip(
+  files: Record<string, string | Buffer>,
+): Promise<string> {
+  const zip = new JSZip();
+  for (const [name, content] of Object.entries(files)) {
+    zip.file(name, content);
+  }
+  const buf = await zip.generateAsync({ type: "nodebuffer" });
+  const zipPath = path.join(tmpDir, "test.vellum");
+  await fs.writeFile(zipPath, buf);
+  return zipPath;
+}
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mgr-test-"));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("unpackBundle", () => {
+  test("extracts files and writes metadata", async () => {
+    const zipPath = await createTestZip({
+      "index.html": "<h1>hello</h1>",
+      "assets/style.css": "body{}",
+    });
+    const bundlesRoot = path.join(tmpDir, "bundles");
+    await fs.mkdir(bundlesRoot, { recursive: true });
+
+    const meta = await unpackBundle(bundlesRoot, zipPath, makeScanData());
+
+    expect(meta.uuid).toBeTruthy();
+    expect(meta.name).toBe("Test App");
+    expect(meta.entry).toBe("index.html");
+    expect(meta.trustTier).toBe("unsigned");
+    expect(meta.capabilities).toEqual(["display"]);
+    expect(meta.bundleSizeBytes).toBe(1024);
+
+    const html = await fs.readFile(
+      path.join(bundlesRoot, meta.uuid, "index.html"),
+      "utf-8",
+    );
+    expect(html).toBe("<h1>hello</h1>");
+
+    const css = await fs.readFile(
+      path.join(bundlesRoot, meta.uuid, "assets/style.css"),
+      "utf-8",
+    );
+    expect(css).toBe("body{}");
+
+    const metaFile = await fs.readFile(
+      path.join(bundlesRoot, meta.uuid + "-meta.json"),
+      "utf-8",
+    );
+    const parsed = JSON.parse(metaFile);
+    expect(parsed.uuid).toBe(meta.uuid);
+    expect(parsed.installedAt).toBeTruthy();
+  });
+
+  test("rejects path traversal entries", () => {
+    // JSZip normalizes ../  in entry names, so we test the guard directly.
+    const bundleDir = "/bundles/uuid";
+    expect(() => resolveEntryPath(bundleDir, "sub/../../escape.txt")).toThrow(
+      "Path traversal detected",
+    );
+    expect(() => resolveEntryPath(bundleDir, "../../../etc/passwd")).toThrow(
+      "Path traversal detected",
+    );
+    // Safe paths resolve without throwing
+    expect(resolveEntryPath(bundleDir, "index.html")).toBe(
+      "/bundles/uuid/index.html",
+    );
+    expect(resolveEntryPath(bundleDir, "assets/style.css")).toBe(
+      "/bundles/uuid/assets/style.css",
+    );
+  });
+});
+
+describe("stripUnsafeEntries", () => {
+  test("removes symlinks", async () => {
+    const dir = path.join(tmpDir, "strip-test");
+    await fs.mkdir(dir, { recursive: true });
+
+    const realFile = path.join(dir, "real.txt");
+    await fs.writeFile(realFile, "content");
+
+    const linkPath = path.join(dir, "link.txt");
+    await fs.symlink(realFile, linkPath);
+
+    await stripUnsafeEntries(dir);
+
+    const remaining = await fs.readdir(dir);
+    expect(remaining).toContain("real.txt");
+    expect(remaining).not.toContain("link.txt");
+  });
+
+  test("walks nested directories", async () => {
+    const dir = path.join(tmpDir, "nested-test");
+    const sub = path.join(dir, "sub");
+    await fs.mkdir(sub, { recursive: true });
+
+    const realFile = path.join(sub, "real.txt");
+    await fs.writeFile(realFile, "content");
+
+    const linkPath = path.join(sub, "link.txt");
+    await fs.symlink(realFile, linkPath);
+
+    await stripUnsafeEntries(dir);
+
+    const remaining = await fs.readdir(sub);
+    expect(remaining).toContain("real.txt");
+    expect(remaining).not.toContain("link.txt");
+  });
+});
+
+describe("readBundleMetadata", () => {
+  test("reads existing metadata", async () => {
+    const zipPath = await createTestZip({ "index.html": "<h1>hi</h1>" });
+    const bundlesRoot = path.join(tmpDir, "bundles");
+    await fs.mkdir(bundlesRoot, { recursive: true });
+
+    const meta = await unpackBundle(bundlesRoot, zipPath, makeScanData());
+    const read = await readBundleMetadata(bundlesRoot, meta.uuid);
+
+    expect(read).not.toBeNull();
+    expect(read!.uuid).toBe(meta.uuid);
+    expect(read!.name).toBe("Test App");
+  });
+
+  test("returns null for missing metadata", async () => {
+    const bundlesRoot = path.join(tmpDir, "bundles");
+    await fs.mkdir(bundlesRoot, { recursive: true });
+
+    const result = await readBundleMetadata(
+      bundlesRoot,
+      "nonexistent-uuid-1234",
+    );
+    expect(result).toBeNull();
+  });
+});
+
+describe("listBundles", () => {
+  test("lists all installed bundles", async () => {
+    const bundlesRoot = path.join(tmpDir, "bundles");
+    await fs.mkdir(bundlesRoot, { recursive: true });
+
+    const zip1 = await createTestZip({ "index.html": "<h1>one</h1>" });
+    const zip2 = await createTestZip({ "index.html": "<h1>two</h1>" });
+
+    await unpackBundle(
+      bundlesRoot,
+      zip1,
+      makeScanData({ manifest: { ...makeScanData().manifest, name: "App 1" } }),
+    );
+    await unpackBundle(
+      bundlesRoot,
+      zip2,
+      makeScanData({ manifest: { ...makeScanData().manifest, name: "App 2" } }),
+    );
+
+    const bundles = await listBundles(bundlesRoot);
+    expect(bundles).toHaveLength(2);
+
+    const names = bundles.map((b) => b.name).sort();
+    expect(names).toEqual(["App 1", "App 2"]);
+  });
+
+  test("returns empty array for nonexistent directory", async () => {
+    const bundles = await listBundles(path.join(tmpDir, "nope"));
+    expect(bundles).toEqual([]);
+  });
+});
+
+describe("removeBundle", () => {
+  test("removes bundle directory and metadata", async () => {
+    const bundlesRoot = path.join(tmpDir, "bundles");
+    await fs.mkdir(bundlesRoot, { recursive: true });
+
+    const zipPath = await createTestZip({ "index.html": "<h1>bye</h1>" });
+    const meta = await unpackBundle(bundlesRoot, zipPath, makeScanData());
+
+    await removeBundle(bundlesRoot, meta.uuid);
+
+    const dirExists = await fs
+      .stat(path.join(bundlesRoot, meta.uuid))
+      .then(() => true)
+      .catch(() => false);
+    expect(dirExists).toBe(false);
+
+    const metaExists = await fs
+      .stat(path.join(bundlesRoot, meta.uuid + "-meta.json"))
+      .then(() => true)
+      .catch(() => false);
+    expect(metaExists).toBe(false);
+  });
+
+  test("does not throw for already-removed bundle", async () => {
+    const bundlesRoot = path.join(tmpDir, "bundles");
+    await fs.mkdir(bundlesRoot, { recursive: true });
+
+    await expect(
+      removeBundle(bundlesRoot, "already-gone-uuid"),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/macos/src/main/bundle-manager.ts
+++ b/apps/macos/src/main/bundle-manager.ts
@@ -1,0 +1,189 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import JSZip from "jszip";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface BundleMetadata {
+  uuid: string;
+  name: string;
+  description?: string;
+  icon?: string;
+  entry: string;
+  trustTier: "verified" | "signed" | "unsigned" | "tampered";
+  signerKeyId?: string;
+  signerDisplayName?: string;
+  signerAccount?: string;
+  installedAt: string;
+  bundleSizeBytes: number;
+  capabilities: string[];
+}
+
+export interface BundleScanData {
+  manifest: {
+    format_version: number;
+    name: string;
+    description?: string;
+    icon?: string;
+    entry: string;
+    capabilities: string[];
+    created_by: string;
+    created_at: string;
+  };
+  scanResult: {
+    passed: boolean;
+    findings: Array<{
+      category: string;
+      code: string;
+      message: string;
+      level: "block" | "warn";
+    }>;
+  };
+  signatureResult: {
+    trustTier: "verified" | "signed" | "unsigned" | "tampered";
+    signerKeyId?: string;
+    signerDisplayName?: string;
+    signerAccount?: string;
+    message?: string;
+  };
+  bundleSizeBytes: number;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Resolve an entry name inside a bundle directory, throwing on escape. */
+export function resolveEntryPath(bundleDir: string, entryName: string): string {
+  const resolved = path.normalize(path.join(bundleDir, entryName));
+  if (!resolved.startsWith(bundleDir + path.sep) && resolved !== bundleDir) {
+    throw new Error(`Path traversal detected: ${entryName}`);
+  }
+  return resolved;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export async function unpackBundle(
+  bundlesRoot: string,
+  zipPath: string,
+  scanData: BundleScanData,
+): Promise<BundleMetadata> {
+  const uuid = crypto.randomUUID();
+  const bundleDir = path.join(bundlesRoot, uuid);
+  await fs.mkdir(bundleDir, { recursive: true });
+
+  const zipData = await fs.readFile(zipPath);
+  const zip = await JSZip.loadAsync(zipData);
+
+  for (const [entryName, entry] of Object.entries(zip.files)) {
+    if (entry.dir) continue;
+
+    const resolved = resolveEntryPath(bundleDir, entryName);
+
+    await fs.mkdir(path.dirname(resolved), { recursive: true });
+    const data = await entry.async("nodebuffer");
+    await fs.writeFile(resolved, data);
+  }
+
+  await stripUnsafeEntries(bundleDir);
+
+  const metadata: BundleMetadata = {
+    uuid,
+    name: scanData.manifest.name,
+    description: scanData.manifest.description,
+    icon: scanData.manifest.icon,
+    entry: scanData.manifest.entry,
+    trustTier: scanData.signatureResult.trustTier,
+    signerKeyId: scanData.signatureResult.signerKeyId,
+    signerDisplayName: scanData.signatureResult.signerDisplayName,
+    signerAccount: scanData.signatureResult.signerAccount,
+    installedAt: new Date().toISOString(),
+    bundleSizeBytes: scanData.bundleSizeBytes,
+    capabilities: scanData.manifest.capabilities,
+  };
+
+  await fs.writeFile(
+    path.join(bundlesRoot, uuid + "-meta.json"),
+    JSON.stringify(metadata, null, 2),
+  );
+
+  return metadata;
+}
+
+export async function stripUnsafeEntries(dir: string): Promise<void> {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+
+    if (entry.isSymbolicLink()) {
+      await fs.rm(fullPath);
+      continue;
+    }
+
+    if (entry.isDirectory()) {
+      await stripUnsafeEntries(fullPath);
+      continue;
+    }
+
+    // lstat only for regular files to detect hardlinks (nlink > 1)
+    const stat = await fs.lstat(fullPath);
+    if (stat.nlink > 1) {
+      await fs.rm(fullPath);
+    }
+  }
+}
+
+export async function readBundleMetadata(
+  bundlesRoot: string,
+  uuid: string,
+): Promise<BundleMetadata | null> {
+  try {
+    const raw = await fs.readFile(
+      path.join(bundlesRoot, uuid + "-meta.json"),
+      "utf-8",
+    );
+    return JSON.parse(raw) as BundleMetadata;
+  } catch {
+    return null;
+  }
+}
+
+export async function listBundles(
+  bundlesRoot: string,
+): Promise<BundleMetadata[]> {
+  let entries: string[];
+  try {
+    entries = await fs.readdir(bundlesRoot);
+  } catch {
+    return [];
+  }
+
+  const metaFiles = entries.filter((e) => e.endsWith("-meta.json"));
+  const results: BundleMetadata[] = [];
+
+  for (const file of metaFiles) {
+    try {
+      const raw = await fs.readFile(path.join(bundlesRoot, file), "utf-8");
+      results.push(JSON.parse(raw) as BundleMetadata);
+    } catch {
+      // Skip malformed metadata files
+    }
+  }
+
+  return results;
+}
+
+export async function removeBundle(
+  bundlesRoot: string,
+  uuid: string,
+): Promise<void> {
+  await fs.rm(path.join(bundlesRoot, uuid), { recursive: true, force: true });
+  await fs.rm(path.join(bundlesRoot, uuid + "-meta.json"), { force: true });
+}


### PR DESCRIPTION
## Summary
- Add bundle-manager.ts with unpack, metadata, symlink stripping, and CRUD operations
- Add jszip dependency for ZIP file reading
- Include comprehensive test coverage for security and correctness

Part of plan: vellum-file-association.md (PR 2 of 7)