### PR TITLE
feat(macos): add sandboxed bundle renderer window with session isolation

### DIFF
--- a/apps/macos/src/main/bundle-window.test.ts
+++ b/apps/macos/src/main/bundle-window.test.ts
@@ -1,0 +1,226 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Stubs
+// ---------------------------------------------------------------------------
+
+type WillNavigateListener = (event: { preventDefault: () => void }, url: string) => void;
+
+interface StubWebContents {
+  on: (event: string, listener: (...args: unknown[]) => void) => StubWebContents;
+  setWindowOpenHandler: (
+    handler: (details: { url: string }) => { action: "deny" | "allow" },
+  ) => void;
+  willNavigateListeners: WillNavigateListener[];
+  windowOpenHandler: ((details: { url: string }) => { action: "deny" | "allow" }) | null;
+}
+
+interface StubWindow {
+  focus: () => void;
+  close: () => void;
+  isDestroyed: () => boolean;
+  on: (event: string, listener: () => void) => StubWindow;
+  loadURL: (url: string) => Promise<void>;
+  webContents: StubWebContents;
+  emit: (event: string) => void;
+  constructorOptions: Record<string, unknown>;
+}
+
+let constructed: StubWindow[] = [];
+const focusMock = mock(() => undefined);
+const closeMock = mock(() => undefined);
+const loadURLMock = mock((_url: string) => Promise.resolve());
+
+const makeWindow = (options: Record<string, unknown>): StubWindow => {
+  const listeners = new Map<string, Array<() => void>>();
+  const willNavigateListeners: WillNavigateListener[] = [];
+  let destroyed = false;
+
+  const webContents: StubWebContents = {
+    on: (event, listener) => {
+      if (event === "will-navigate") {
+        willNavigateListeners.push(listener as WillNavigateListener);
+      }
+      return webContents;
+    },
+    setWindowOpenHandler: (handler) => {
+      webContents.windowOpenHandler = handler;
+    },
+    willNavigateListeners,
+    windowOpenHandler: null,
+  };
+
+  const win: StubWindow = {
+    focus: focusMock,
+    close: () => {
+      closeMock();
+      win.emit("closed");
+    },
+    isDestroyed: () => destroyed,
+    on: (event, listener) => {
+      const arr = listeners.get(event) ?? [];
+      arr.push(listener);
+      listeners.set(event, arr);
+      return win;
+    },
+    loadURL: loadURLMock,
+    webContents,
+    emit: (event) => {
+      if (event === "closed") destroyed = true;
+      for (const l of listeners.get(event) ?? []) l();
+    },
+    constructorOptions: options,
+  };
+  return win;
+};
+
+const fromPartitionMock = mock((_partition: string, _opts?: { cache: boolean }) => ({}));
+
+mock.module("electron", () => ({
+  app: { isPackaged: false },
+  session: { fromPartition: fromPartitionMock },
+  BrowserWindow: class {
+    constructor(options: Record<string, unknown>) {
+      const win = makeWindow(options);
+      constructed.push(win);
+      Object.assign(this, win);
+    }
+  },
+}));
+
+const {
+  openBundleWindow,
+  closeBundleWindow,
+  getOpenBundleWindows,
+} = await import("./bundle-window");
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  constructed = [];
+  focusMock.mockClear();
+  closeMock.mockClear();
+  loadURLMock.mockClear();
+  fromPartitionMock.mockClear();
+});
+
+afterEach(() => {
+  // Drain open windows so module-scope tracking resets between tests.
+  for (const win of constructed) {
+    if (!win.isDestroyed()) win.emit("closed");
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const UUID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+const UUID_2 = "11111111-2222-3333-4444-555555555555";
+
+describe("openBundleWindow", () => {
+  test("creates a window with the correct session partition", () => {
+    openBundleWindow(UUID, "index.html", "Test Bundle");
+
+    expect(constructed).toHaveLength(1);
+    expect(fromPartitionMock).toHaveBeenCalledWith(`persist:bundle-${UUID}`, {
+      cache: true,
+    });
+
+    const opts = constructed[0]!.constructorOptions;
+    expect(opts.width).toBe(1024);
+    expect(opts.height).toBe(768);
+    expect(opts.title).toBe("Test Bundle");
+
+    const prefs = opts.webPreferences as Record<string, unknown>;
+    expect(prefs.contextIsolation).toBe(true);
+    expect(prefs.sandbox).toBe(true);
+    expect(prefs.nodeIntegration).toBe(false);
+    expect(prefs.preload).toBeUndefined();
+  });
+
+  test("loads the correct vellumapp:// URL", () => {
+    openBundleWindow(UUID, "index.html", "Test Bundle");
+    expect(loadURLMock).toHaveBeenCalledWith(`vellumapp://${UUID}/index.html`);
+  });
+
+  test("focuses the existing window when opening the same UUID twice", () => {
+    openBundleWindow(UUID, "index.html", "Test Bundle");
+    openBundleWindow(UUID, "index.html", "Test Bundle");
+
+    expect(constructed).toHaveLength(1);
+    expect(focusMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("allows navigation within the same bundle", () => {
+    openBundleWindow(UUID, "index.html", "Test Bundle");
+    const win = constructed[0]!;
+
+    const handler = win.webContents.willNavigateListeners[0]!;
+    const preventDefault = mock(() => undefined);
+    handler({ preventDefault }, `vellumapp://${UUID}/page2.html`);
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
+
+  test("blocks navigation to a different UUID", () => {
+    openBundleWindow(UUID, "index.html", "Test Bundle");
+    const win = constructed[0]!;
+
+    const handler = win.webContents.willNavigateListeners[0]!;
+    const preventDefault = mock(() => undefined);
+    handler({ preventDefault }, `vellumapp://${UUID_2}/index.html`);
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+  });
+
+  test("blocks navigation to external URLs", () => {
+    openBundleWindow(UUID, "index.html", "Test Bundle");
+    const win = constructed[0]!;
+
+    const handler = win.webContents.willNavigateListeners[0]!;
+    const preventDefault = mock(() => undefined);
+    handler({ preventDefault }, "https://evil.com");
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+  });
+
+  test("denies window.open", () => {
+    openBundleWindow(UUID, "index.html", "Test Bundle");
+    const win = constructed[0]!;
+    expect(win.webContents.windowOpenHandler).not.toBeNull();
+    expect(win.webContents.windowOpenHandler!({ url: "https://example.com" })).toEqual({
+      action: "deny",
+    });
+  });
+});
+
+describe("closeBundleWindow", () => {
+  test("closes and removes the window from tracking", () => {
+    openBundleWindow(UUID, "index.html", "Test Bundle");
+    expect(getOpenBundleWindows()).toEqual([UUID]);
+
+    closeBundleWindow(UUID);
+    expect(closeMock).toHaveBeenCalledTimes(1);
+    expect(getOpenBundleWindows()).toEqual([]);
+  });
+
+  test("is a no-op for an unknown UUID", () => {
+    closeBundleWindow("nonexistent");
+    expect(closeMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("getOpenBundleWindows", () => {
+  test("returns list of open UUIDs", () => {
+    openBundleWindow(UUID, "index.html", "Bundle A");
+    openBundleWindow(UUID_2, "index.html", "Bundle B");
+
+    expect(getOpenBundleWindows().sort()).toEqual([UUID, UUID_2].sort());
+  });
+
+  test("removes UUID when the window is closed", () => {
+    openBundleWindow(UUID, "index.html", "Test Bundle");
+    constructed[0]!.emit("closed");
+    expect(getOpenBundleWindows()).toEqual([]);
+  });
+});

--- a/apps/macos/src/main/bundle-window.ts
+++ b/apps/macos/src/main/bundle-window.ts
@@ -1,0 +1,77 @@
+/**
+ * Sandboxed renderer window for `.vellum` bundles.
+ *
+ * Each bundle gets its own `BrowserWindow` backed by a dedicated
+ * `persist:bundle-{uuid}` session partition — cookies, localStorage, and
+ * cache are isolated per bundle. The window intentionally omits the main
+ * preload script so there is no `window.vellum` bridge; the renderer runs
+ * in full sandbox mode with only the web-platform APIs available.
+ *
+ * Navigation is restricted to the bundle's own `vellumapp://{uuid}/`
+ * origin, and `window.open` is blocked outright, so a bundle cannot
+ * reach another bundle's content or escape into arbitrary web pages.
+ */
+import { BrowserWindow, session } from "electron";
+
+import { VELLUMAPP_PROTOCOL } from "./app-config";
+import { hardenedWebPreferences } from "./windows";
+
+const openBundleWindows = new Map<string, BrowserWindow>();
+
+export const openBundleWindow = (
+  uuid: string,
+  entry: string,
+  name: string,
+): BrowserWindow => {
+  const existing = openBundleWindows.get(uuid);
+  if (existing && !existing.isDestroyed()) {
+    existing.focus();
+    return existing;
+  }
+
+  const bundleSession = session.fromPartition(`persist:bundle-${uuid}`, {
+    cache: true,
+  });
+
+  const win = new BrowserWindow({
+    width: 1024,
+    height: 768,
+    title: name,
+    webPreferences: {
+      ...hardenedWebPreferences(),
+      session: bundleSession,
+      preload: undefined,
+    },
+  });
+
+  const allowedPrefix = `${VELLUMAPP_PROTOCOL}://${uuid}/`;
+
+  win.webContents.on("will-navigate", (event, url) => {
+    if (!url.startsWith(allowedPrefix)) {
+      event.preventDefault();
+    }
+  });
+
+  win.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
+
+  void win.loadURL(`${VELLUMAPP_PROTOCOL}://${uuid}/${entry}`);
+
+  openBundleWindows.set(uuid, win);
+  win.on("closed", () => {
+    openBundleWindows.delete(uuid);
+  });
+
+  return win;
+};
+
+export const closeBundleWindow = (uuid: string): void => {
+  const win = openBundleWindows.get(uuid);
+  if (win && !win.isDestroyed()) {
+    win.close();
+  }
+  openBundleWindows.delete(uuid);
+};
+
+export const getOpenBundleWindows = (): string[] => [
+  ...openBundleWindows.keys(),
+];


### PR DESCRIPTION
## Summary
- Add bundle-window.ts for creating sandboxed renderer windows per bundle UUID
- Per-bundle session isolation via session.fromPartition
- No preload (full sandbox), navigation restricted to own vellumapp:// URLs

Part of plan: vellum-file-association.md (PR 6 of 7)