### PR TITLE
feat(macos): add bundle confirmation window with trust tier UI

### DIFF
--- a/apps/macos/src/main/bundle-confirmation.test.ts
+++ b/apps/macos/src/main/bundle-confirmation.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { BundleScanData } from "./bundle-manager";
+
+type StubWebContents = {
+  on: (event: string, listener: (...args: unknown[]) => void) => StubWebContents;
+  setWindowOpenHandler: (
+    handler: (details: { url: string }) => { action: "deny" | "allow" },
+  ) => void;
+  events: Map<string, Array<(...args: unknown[]) => void>>;
+};
+
+type StubWindow = {
+  show: () => void;
+  focus: () => void;
+  close: () => void;
+  isDestroyed: () => boolean;
+  on: (event: string, listener: () => void) => StubWindow;
+  once: (event: string, listener: () => void) => StubWindow;
+  loadURL: (url: string) => Promise<void>;
+  webContents: StubWebContents;
+  emit: (event: string) => void;
+};
+
+let constructed: StubWindow[] = [];
+const showMock = mock(() => undefined);
+const focusMock = mock(() => undefined);
+const loadURLMock = mock((_url: string) => Promise.resolve());
+
+const makeWindow = (): StubWindow => {
+  const listeners = new Map<string, Array<() => void>>();
+  const webContentsListeners = new Map<
+    string,
+    Array<(...args: unknown[]) => void>
+  >();
+  let destroyed = false;
+  const webContents: StubWebContents = {
+    on: (event, listener) => {
+      const arr = webContentsListeners.get(event) ?? [];
+      arr.push(listener);
+      webContentsListeners.set(event, arr);
+      return webContents;
+    },
+    setWindowOpenHandler: () => undefined,
+    events: webContentsListeners,
+  };
+  const win: StubWindow = {
+    show: showMock,
+    focus: focusMock,
+    close() {
+      win.emit("closed");
+    },
+    isDestroyed: () => destroyed,
+    on: (event, listener) => {
+      const arr = listeners.get(event) ?? [];
+      arr.push(listener);
+      listeners.set(event, arr);
+      return win;
+    },
+    once: (event, listener) => {
+      const arr = listeners.get(event) ?? [];
+      arr.push(listener);
+      listeners.set(event, arr);
+      return win;
+    },
+    loadURL: loadURLMock,
+    webContents,
+    emit: (event) => {
+      if (event === "closed") destroyed = true;
+      for (const l of listeners.get(event) ?? []) l();
+    },
+  };
+  return win;
+};
+
+const ipcHandleMock = mock((_channel: string, _handler: unknown) => undefined);
+const ipcOnMock = mock((_channel: string, _handler: unknown) => undefined);
+
+mock.module("electron", () => ({
+  app: {
+    isPackaged: false,
+  },
+  BrowserWindow: class {
+    constructor() {
+      const win = makeWindow();
+      constructed.push(win);
+      Object.assign(this, win);
+    }
+  },
+  ipcMain: {
+    handle: ipcHandleMock,
+    on: ipcOnMock,
+  },
+}));
+
+const { openBundleConfirmation, installBundleConfirmation } = await import(
+  "./bundle-confirmation"
+);
+
+const SAMPLE_DATA: BundleScanData = {
+  manifest: {
+    format_version: 1,
+    name: "Test Bundle",
+    description: "A test bundle",
+    icon: "🧪",
+    entry: "index.html",
+    capabilities: ["network"],
+    created_by: "user@example.com",
+    created_at: "2025-01-01T00:00:00Z",
+  },
+  scanResult: {
+    passed: true,
+    findings: [],
+  },
+  signatureResult: {
+    trustTier: "signed",
+    signerDisplayName: "Example User",
+  },
+  bundleSizeBytes: 12345,
+};
+
+beforeEach(() => {
+  constructed = [];
+  showMock.mockClear();
+  focusMock.mockClear();
+  loadURLMock.mockClear();
+  ipcHandleMock.mockClear();
+  ipcOnMock.mockClear();
+});
+
+afterEach(() => {
+  for (const win of constructed) {
+    if (!win.isDestroyed()) win.emit("closed");
+  }
+});
+
+describe("openBundleConfirmation", () => {
+  test("creates a window with the confirmation route URL", () => {
+    void openBundleConfirmation(SAMPLE_DATA);
+    expect(constructed).toHaveLength(1);
+    expect(loadURLMock).toHaveBeenCalledTimes(1);
+    expect(loadURLMock.mock.calls[0]?.[0]).toMatch(/\/bundle\/confirm$/);
+  });
+
+  test("closing the window resolves with false", async () => {
+    const promise = openBundleConfirmation(SAMPLE_DATA);
+    constructed[0]?.emit("closed");
+    expect(await promise).toBe(false);
+  });
+
+  test("focuses existing window instead of creating a second one", async () => {
+    const p1 = openBundleConfirmation(SAMPLE_DATA);
+    const p2 = openBundleConfirmation(SAMPLE_DATA);
+
+    expect(constructed).toHaveLength(1);
+    expect(showMock).toHaveBeenCalled();
+    expect(focusMock).toHaveBeenCalledTimes(1);
+    expect(await p2).toBe(false);
+
+    constructed[0]?.emit("closed");
+    await p1;
+  });
+
+  test("reconstructs after the previous window was closed", () => {
+    void openBundleConfirmation(SAMPLE_DATA);
+    constructed[0]?.emit("closed");
+    void openBundleConfirmation(SAMPLE_DATA);
+    expect(constructed).toHaveLength(2);
+  });
+
+  test("blocks top-level navigation and popups", () => {
+    void openBundleConfirmation(SAMPLE_DATA);
+    const win = constructed[0];
+    expect(win).toBeDefined();
+
+    const willNavigateHandlers = win?.webContents.events.get("will-navigate");
+    expect(willNavigateHandlers?.length).toBe(1);
+    const preventDefault = mock(() => undefined);
+    willNavigateHandlers?.[0]?.({ preventDefault });
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("installBundleConfirmation", () => {
+  test("registers getData (handle) and respond (on) IPC channels", () => {
+    installBundleConfirmation();
+
+    const handleChannels = ipcHandleMock.mock.calls.map((c) => c[0]);
+    expect(handleChannels).toContain("vellum:bundleConfirm:getData");
+
+    const onChannels = ipcOnMock.mock.calls.map((c) => c[0]);
+    expect(onChannels).toContain("vellum:bundleConfirm:respond");
+  });
+});

--- a/apps/macos/src/main/bundle-confirmation.ts
+++ b/apps/macos/src/main/bundle-confirmation.ts
@@ -1,0 +1,85 @@
+import { BrowserWindow, app } from "electron";
+import { z } from "zod";
+
+import { RENDERER_BASE_PROD, getDevRendererBase } from "./app-config";
+import type { BundleScanData } from "./bundle-manager";
+import { handle, on } from "./ipc";
+import { createWindow } from "./windows";
+
+// Mirrors `routes.bundleConfirm` in `apps/web/src/utils/routes.ts`.
+// Duplicated rather than imported — same convention as `about.ts`.
+const CONFIRM_PATH = "/bundle/confirm";
+
+const confirmWindowUrl = (): string => {
+  const base = app.isPackaged ? RENDERER_BASE_PROD : getDevRendererBase();
+  return `${base}${CONFIRM_PATH}`;
+};
+
+let confirmationWindow: BrowserWindow | null = null;
+let pendingResolve: ((accepted: boolean) => void) | null = null;
+let pendingData: BundleScanData | null = null;
+
+export const openBundleConfirmation = (
+  data: BundleScanData,
+): Promise<boolean> => {
+  if (confirmationWindow && !confirmationWindow.isDestroyed()) {
+    confirmationWindow.show();
+    confirmationWindow.focus();
+    return Promise.resolve(false);
+  }
+
+  pendingData = data;
+
+  confirmationWindow = createWindow({
+    browserWindow: {
+      width: 480,
+      height: 440,
+      resizable: false,
+      minimizable: false,
+      maximizable: false,
+      fullscreenable: false,
+      titleBarStyle: "hiddenInset",
+      show: false,
+    },
+    navigation: "deny-all",
+  });
+
+  confirmationWindow.once("ready-to-show", () => {
+    confirmationWindow?.show();
+  });
+
+  const promise = new Promise<boolean>((resolve) => {
+    pendingResolve = resolve;
+  });
+
+  confirmationWindow.on("closed", () => {
+    confirmationWindow = null;
+    pendingData = null;
+    if (pendingResolve) {
+      pendingResolve(false);
+      pendingResolve = null;
+    }
+  });
+
+  void confirmationWindow.loadURL(confirmWindowUrl());
+
+  return promise;
+};
+
+export const installBundleConfirmation = (): void => {
+  handle("vellum:bundleConfirm:getData", z.tuple([]), () => pendingData);
+
+  on(
+    "vellum:bundleConfirm:respond",
+    z.tuple([z.boolean()]),
+    ([accepted]) => {
+      if (pendingResolve) {
+        pendingResolve(accepted);
+        pendingResolve = null;
+      }
+      if (confirmationWindow) {
+        confirmationWindow.close();
+      }
+    },
+  );
+};

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -142,6 +142,42 @@ export interface NotificationActionEvent {
   deepLinkMetadata?: Record<string, unknown>;
 }
 
+/**
+ * Mirror of `BundleScanData` in `apps/macos/src/main/bundle-manager.ts`.
+ * Inlined for the same reason as the other bridge types: preload + main +
+ * renderer each have their own TS project. Drift surfaces as a renderer
+ * field that's `undefined` at runtime rather than a build error.
+ */
+export interface BundleScanData {
+  manifest: {
+    format_version: number;
+    name: string;
+    description?: string;
+    icon?: string;
+    entry: string;
+    capabilities: string[];
+    created_by: string;
+    created_at: string;
+  };
+  scanResult: {
+    passed: boolean;
+    findings: Array<{
+      category: string;
+      code: string;
+      message: string;
+      level: "block" | "warn";
+    }>;
+  };
+  signatureResult: {
+    trustTier: "verified" | "signed" | "unsigned" | "tampered";
+    signerKeyId?: string;
+    signerDisplayName?: string;
+    signerAccount?: string;
+    message?: string;
+  };
+  bundleSizeBytes: number;
+}
+
 export interface VellumBridge {
   platform: "electron";
   app: {
@@ -398,6 +434,12 @@ export interface VellumBridge {
      */
     onAction(callback: (event: NotificationActionEvent) => void): () => void;
   };
+  bundleConfirm: {
+    /** Fetch the scan data for the bundle awaiting confirmation. */
+    getData(): Promise<BundleScanData | null>;
+    /** Accept or cancel the pending bundle installation. */
+    respond(accepted: boolean): void;
+  };
 }
 
 const notImplemented = (name: string) => (): Promise<never> =>
@@ -612,6 +654,15 @@ const bridge: VellumBridge = {
       return () => {
         ipcRenderer.off("vellum:notifications:action", handler);
       };
+    },
+  },
+  bundleConfirm: {
+    getData: () =>
+      ipcRenderer.invoke(
+        "vellum:bundleConfirm:getData",
+      ) as Promise<BundleScanData | null>,
+    respond: (accepted: boolean): void => {
+      ipcRenderer.send("vellum:bundleConfirm:respond", accepted);
     },
   },
 };

--- a/apps/web/src/pages/BundleConfirmPage.tsx
+++ b/apps/web/src/pages/BundleConfirmPage.tsx
@@ -1,0 +1,152 @@
+import { useEffect, useState } from "react";
+
+import { formatFileSize } from "@/domains/workspace/utils/format-file-size";
+import type { BundleScanData } from "@/runtime/is-electron";
+import { cn } from "@/utils/misc";
+
+const TRUST_BADGE: Record<
+  BundleScanData["signatureResult"]["trustTier"],
+  { label: string; className: string }
+> = {
+  verified: {
+    label: "Verified",
+    className: "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
+  },
+  signed: {
+    label: "Signed",
+    className: "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200",
+  },
+  unsigned: {
+    label: "Unsigned",
+    className: "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300",
+  },
+  tampered: {
+    label: "Tampered — signature invalid",
+    className: "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200",
+  },
+};
+
+export function BundleConfirmPage() {
+  const [data, setData] = useState<BundleScanData | null>(null);
+  const [warningsOpen, setWarningsOpen] = useState(false);
+
+  useEffect(() => {
+    void window.vellum?.bundleConfirm?.getData().then((d) => {
+      if (d) setData(d);
+    });
+  }, []);
+
+  if (!data) {
+    return (
+      <div className="flex h-svh w-screen items-center justify-center bg-background text-muted-foreground select-none">
+        Loading...
+      </div>
+    );
+  }
+
+  const { manifest, scanResult, signatureResult, bundleSizeBytes } = data;
+  const badge = TRUST_BADGE[signatureResult.trustTier];
+  const isTampered = signatureResult.trustTier === "tampered";
+  const warnings = scanResult.findings.filter((f) => f.level === "warn");
+
+  return (
+    <div className="flex h-svh w-screen flex-col bg-background px-6 pt-14 pb-6 text-foreground select-none">
+      {/* Header */}
+      <div className="flex items-start gap-3">
+        {manifest.icon ? (
+          <span className="text-5xl leading-none">{manifest.icon}</span>
+        ) : (
+          <span className="text-5xl leading-none">📦</span>
+        )}
+        <div className="min-w-0 flex-1">
+          <h1 className="truncate text-lg font-semibold">{manifest.name}</h1>
+          {manifest.description && (
+            <p className="text-muted-foreground mt-0.5 text-sm leading-snug">
+              {manifest.description}
+            </p>
+          )}
+        </div>
+      </div>
+
+      {/* Trust badge */}
+      <div className="mt-4 flex items-center gap-2">
+        <span
+          className={cn(
+            "inline-block rounded-full px-2.5 py-0.5 text-xs font-medium",
+            badge.className,
+          )}
+        >
+          {badge.label}
+        </span>
+        {signatureResult.trustTier === "signed" &&
+          signatureResult.signerDisplayName && (
+            <span className="text-muted-foreground text-xs">
+              by {signatureResult.signerDisplayName}
+            </span>
+          )}
+      </div>
+
+      {/* Details */}
+      <dl className="mt-4 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1.5 text-sm">
+        <dt className="text-muted-foreground">Size</dt>
+        <dd>{formatFileSize(bundleSizeBytes)}</dd>
+        <dt className="text-muted-foreground">Created by</dt>
+        <dd className="truncate">{manifest.created_by}</dd>
+        {manifest.capabilities.length > 0 && (
+          <>
+            <dt className="text-muted-foreground">Capabilities</dt>
+            <dd className="truncate">{manifest.capabilities.join(", ")}</dd>
+          </>
+        )}
+      </dl>
+
+      {/* Warnings */}
+      {warnings.length > 0 && (
+        <div className="mt-4">
+          <button
+            type="button"
+            className="text-muted-foreground text-xs font-medium hover:underline"
+            onClick={() => setWarningsOpen((v) => !v)}
+          >
+            {warningsOpen ? "Hide" : "Show"} Warnings ({warnings.length})
+          </button>
+          {warningsOpen && (
+            <ul className="mt-1.5 space-y-1 text-xs">
+              {warnings.map((w, i) => (
+                <li
+                  key={`${w.code}-${i}`}
+                  className="rounded bg-yellow-50 px-2 py-1 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-200"
+                >
+                  <span className="font-medium">{w.code}</span>: {w.message}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+
+      {/* Footer */}
+      <div className="mt-auto flex items-center justify-end gap-3 pt-4">
+        <button
+          type="button"
+          className="rounded-md border border-border px-4 py-1.5 text-sm font-medium text-foreground hover:bg-muted"
+          onClick={() => window.vellum?.bundleConfirm?.respond(false)}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          className={cn(
+            "rounded-md px-4 py-1.5 text-sm font-medium text-white",
+            isTampered
+              ? "bg-red-600 hover:bg-red-700"
+              : "bg-primary hover:bg-primary/90",
+          )}
+          onClick={() => window.vellum?.bundleConfirm?.respond(true)}
+        >
+          {isTampered ? "Install Anyway" : "Install"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -105,6 +105,11 @@ export const routeTree = [
     // Vite's SPA fallback in dev (which is scoped to the `base`).
     { path: "/assistant/about", ErrorBoundary: RouteErrorBoundary, HydrateFallback: RootHydrateFallback, lazy: { Component: () => import("@/components/about-page").then((m) => m.AboutPage) } },
 
+    // Bundle confirmation — standalone page rendered inside the Electron
+    // bundle-confirmation BrowserWindow. No auth required so bundles can
+    // be opened before the user logs in. Same sibling pattern as About.
+    { path: "/assistant/bundle/confirm", ErrorBoundary: RouteErrorBoundary, HydrateFallback: RootHydrateFallback, lazy: { Component: () => import("@/pages/BundleConfirmPage").then((m) => m.BundleConfirmPage) } },
+
     // Assistant routes — auth-protected app with layout
     {
       path: "/assistant",

--- a/apps/web/src/runtime/is-electron.ts
+++ b/apps/web/src/runtime/is-electron.ts
@@ -115,6 +115,42 @@ export interface ElectronNotificationActionEvent {
   deepLinkMetadata?: Record<string, unknown>;
 }
 
+/**
+ * Renderer-side mirror of `BundleScanData` in
+ * `apps/macos/src/main/bundle-manager.ts`. Inline for the same reason
+ * as `VellumCommand` — main, preload, and renderer each have their
+ * own TS project.
+ */
+export interface BundleScanData {
+  manifest: {
+    format_version: number;
+    name: string;
+    description?: string;
+    icon?: string;
+    entry: string;
+    capabilities: string[];
+    created_by: string;
+    created_at: string;
+  };
+  scanResult: {
+    passed: boolean;
+    findings: Array<{
+      category: string;
+      code: string;
+      message: string;
+      level: "block" | "warn";
+    }>;
+  };
+  signatureResult: {
+    trustTier: "verified" | "signed" | "unsigned" | "tampered";
+    signerKeyId?: string;
+    signerDisplayName?: string;
+    signerAccount?: string;
+    message?: string;
+  };
+  bundleSizeBytes: number;
+}
+
 declare global {
   interface Window {
     vellum?: {
@@ -230,6 +266,11 @@ declare global {
         onAction(
           callback: (event: ElectronNotificationActionEvent) => void,
         ): () => void;
+      };
+      // Optional: older Electron shells predate the bundleConfirm channel.
+      bundleConfirm?: {
+        getData(): Promise<BundleScanData | null>;
+        respond(accepted: boolean): void;
       };
     };
   }

--- a/apps/web/src/utils/routes.ts
+++ b/apps/web/src/utils/routes.ts
@@ -30,6 +30,14 @@ export const routes = {
    * the web build, where the runtime wrapper degrades to a "—" fallback.
    */
   about: r("/assistant/about"),
+  /**
+   * Bundle confirmation page. Standalone like About — sits under
+   * `/assistant/*` for Vite SPA fallback but outside the auth tree so
+   * bundles can be confirmed before sign-in. Mounted by the Electron
+   * host (`apps/macos/src/main/bundle-confirmation.ts`) into a
+   * dedicated BrowserWindow.
+   */
+  bundleConfirm: r("/assistant/bundle/confirm"),
   conversation: (key: string) => dyn(r("/assistant/conversations"), key),
   /**
    * LLM-context inspector for a single conversation. The conversation id


### PR DESCRIPTION
## Summary
- Add bundle-confirmation.ts for managing the confirmation window lifecycle and IPC
- Add BundleConfirmPage.tsx React component with trust tier badges and warning display
- Add bundleConfirm bridge to preload with getData/respond methods

Part of plan: vellum-file-association.md (PR 5 of 7)