### PR TITLE
feat(activity-run-card): expanded-state header, failure summary, brain nodes, animated drawer

### DIFF
--- a/apps/web/src/domains/chat/components/activity-run-card/activity-run-card.tsx
+++ b/apps/web/src/domains/chat/components/activity-run-card/activity-run-card.tsx
@@ -116,6 +116,87 @@ function buildDefaultItems(
 }
 
 /**
+ * Tally of how many terminal, non-thinking steps a run produced and how many
+ * of those failed. Thinking steps are excluded — they carry no success/failure
+ * semantics — so a `thinking → failed-bash` run reads as "every tool failed",
+ * not "half failed".
+ */
+function countStepOutcomes(steps: ToolCallCardStep[]): {
+  total: number;
+  failed: number;
+} {
+  let total = 0;
+  let failed = 0;
+  for (const step of steps) {
+    if (step.kind === "thinking") continue;
+    total += 1;
+    if (
+      step.kind === "tool_error" ||
+      step.kind === "web_search_error" ||
+      (step.kind === "tool" &&
+        (step.status === "error" || step.status === "denied"))
+    ) {
+      failed += 1;
+    }
+  }
+  return { total, failed };
+}
+
+/**
+ * Collapse the card's base state plus the per-step failure tally into the
+ * summary chrome shown on the header status icon:
+ *
+ * - every tool succeeded → `complete` (green check)
+ * - some — but not all — tools failed → `warning` (amber triangle); the run
+ *   still produced useful work, so a full red error overstates it
+ * - every tool failed → `error` (red); a true failure
+ *
+ * `loading` always wins while anything is still running. Thinking steps never
+ * count toward the tally (see {@link countStepOutcomes}).
+ */
+function deriveSummaryState(
+  baseState: ToolCallCardData["state"],
+  steps: ToolCallCardStep[],
+): ToolProgressCardState {
+  if (baseState === "loading" || baseState === "complete") return baseState;
+  // baseState is `error` / `denied` → at least one failure is present.
+  const { total, failed } = countStepOutcomes(steps);
+  if (failed > 0 && failed < total) return "warning";
+  return "error";
+}
+
+/**
+ * Stable header label shown in place of the live per-step title once the card
+ * is expanded. The status icon to its left already encodes the outcome, so
+ * this stays a short heading for the steps timeline rather than echoing the
+ * latest step.
+ *
+ * Once the run is terminal and we have timing data, the summary reports how
+ * long the agent worked ("Worked for 16s") regardless of outcome — the icon
+ * still carries success / partial / failure. Without timing data it falls back
+ * to an outcome label, and the `warning` fallback spells out how many tools
+ * failed.
+ */
+function expandedHeaderLabel(
+  state: ToolProgressCardState,
+  totalDurationLabel: string,
+  failedCount: number,
+): string {
+  if (state === "loading") return "Working";
+  if (totalDurationLabel) return `Worked for ${totalDurationLabel}`;
+  switch (state) {
+    case "warning":
+      return `${failedCount} ${failedCount === 1 ? "tool" : "tools"} failed`;
+    case "error":
+    case "denied":
+      return "Failed";
+    case "complete":
+    default:
+      return "Completed";
+  }
+}
+
+/**
  * Activity-run card. Renders a contiguous run of interleaved thinking + tool
  * steps as a single combined card. All tool groups — web search, bash, file
  * ops, MCP, computer use, skills — render through the shared
@@ -297,18 +378,39 @@ function UnifiedActivityRunCard({
   // currently open renders selected. `null` when the drawer is closed or
   // showing another view, so no pill reads as active.
   const openToolDetailId = activeDetail?.toolCallId ?? null;
-  const shellState: ToolProgressCardState = cardData.state;
+  // A partial failure (some tools failed, some succeeded) reads as an amber
+  // `warning` rather than a full red `error`; an all-failed run stays `error`.
+  const outcomes = countStepOutcomes(cardData.steps);
+  const shellState: ToolProgressCardState = deriveSummaryState(
+    cardData.state,
+    cardData.steps,
+  );
 
   // Nudge rows need the raw call (riskLevel, allowlistOptions, …) which
   // isn't carried on the step descriptor. The pill's click handler also
   // reads the raw call to build the tool-detail drawer payload.
   const toolCallById = new Map(toolCalls.map((tc) => [tc.id, tc]));
 
+  // Expanded, the full step timeline is visible below, so echoing the latest
+  // step's title + info in the header is pure repetition. Swap the live
+  // per-step title for a stable overall-status label ("Working" / "Completed" /
+  // "Failed") and drop the info entirely — the header then reads as a section
+  // heading for the expanded steps rather than a duplicate of the last row.
+  const headerTitle = expanded
+    ? expandedHeaderLabel(
+        shellState,
+        cardData.totalDurationLabel ?? "",
+        outcomes.failed,
+      )
+    : cardData.currentStepTitle;
+
   // When the latest step is a thinking segment, the collapsed header pairs a
-  // brain glyph with the thinking text. Memoized so the carousel (which
-  // compares the info node by reference via `Object.is`) doesn't re-animate on
-  // every parent render — only when the (kind, info) tuple actually changes.
+  // brain glyph with the thinking text. Suppressed when expanded (the timeline
+  // below already shows every step). Memoized so the carousel (which compares
+  // the info node by reference via `Object.is`) doesn't re-animate on every
+  // parent render — only when the (expanded, kind, info) tuple actually changes.
   const headerInfo = useMemo(() => {
+    if (expanded) return null;
     if (cardData.currentStepKind === "thinking") {
       return (
         // Fill the carousel's flex slot (`flex w-full min-w-0`) so the inner
@@ -330,7 +432,7 @@ function UnifiedActivityRunCard({
       );
     }
     return cardData.currentStepInfo;
-  }, [cardData.currentStepKind, cardData.currentStepInfo]);
+  }, [expanded, cardData.currentStepKind, cardData.currentStepInfo]);
 
   return (
     <ToolProgressCardShell
@@ -341,20 +443,19 @@ function UnifiedActivityRunCard({
       // (`WebSearchView`) and the subagent inline card stay boxed.
       bare
       state={shellState}
-      currentStepTitle={cardData.currentStepTitle}
+      currentStepTitle={headerTitle}
       currentStepInfo={headerInfo}
       stepCount={cardData.stepCount}
       expanded={expanded}
       onExpandChange={onCardExpandChange}
     >
-      {/* Bare body in TIMELINE mode. Left padding is ZERO so the timeline node
-          icons' left edge lines up EXACTLY with the bare header's status icon
-          (which sits at the card content-left, x≈0, via the header Button's
-          `-ml-1.5 px-1.5` net-zero offset). `pt-2` (8px) plus the connector
-          lead-in bridges the gap up to the header icon; `pr-3 pb-2` keep the
-          right/bottom breathing room. The body wrapper owns no `gap` — each
-          timeline section owns its own spacing via `pb-3`. */}
-      <div className="flex w-full flex-col pb-2 pl-px pr-3 pt-4">
+      {/* Bare body in TIMELINE mode. `pl-[18px]` indents the whole expanded
+          timeline in from the bare header's status icon so the steps read as
+          children nested under the header rather than flush with it. `pt-4`
+          plus the connector lead-in bridges the gap up to the header; `pr-3
+          pb-2` keep the right/bottom breathing room. The body wrapper owns no
+          `gap` — each timeline section owns its own spacing via `pb-3`. */}
+      <div className="flex w-full flex-col pb-2 pl-[18px] pr-3 pt-4">
         <PhaseGroupedStepList
           steps={cardData.steps}
           timeline

--- a/apps/web/src/domains/chat/components/animated-right-drawer.tsx
+++ b/apps/web/src/domains/chat/components/animated-right-drawer.tsx
@@ -1,0 +1,199 @@
+/**
+ * Animated right-hand drawer split — a drop-in for the tool-detail / thought-
+ * process side panel that opens by ANIMATING THE DRAWER WIDTH (0 → target)
+ * instead of reserving the full pane instantly.
+ *
+ * Why not `ResizablePanel`: that component sizes the left pane to a fixed width
+ * and lets the right pane fill the rest (`flex-1`), so the moment it mounts the
+ * chat column snaps to its narrow width and the full-size drawer pops in. The
+ * result reads as "the layout shifted early and the drawer started too large".
+ *
+ * Here the chat is `flex-1` and the drawer is the sized element: as the drawer's
+ * width eases 0 → target, the chat reflows in lockstep and the panel content —
+ * pinned to the right edge at its final width — is revealed by a left-moving
+ * wipe. Drag-to-resize + width persistence are preserved (ported from
+ * `ResizablePanel`), so only the open transition changes.
+ */
+
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+  type ReactNode,
+} from "react";
+import { motion, useReducedMotion } from "motion/react";
+
+import { cn } from "@/utils/misc";
+
+/** Width of the drag-handle column. Matches the `w-2` separator below (8px). */
+const SEPARATOR_WIDTH_PX = 8;
+
+/** Read a persisted pixel width from localStorage, validating shape/finiteness. */
+function readStoredWidth(
+  storageKey: string | undefined,
+  minWidth: number,
+): number | null {
+  if (!storageKey || typeof window === "undefined") return null;
+  try {
+    const stored = localStorage.getItem(storageKey);
+    if (stored == null) return null;
+    const parsed = Number(stored);
+    if (!Number.isFinite(parsed)) return null;
+    return Math.max(minWidth, parsed);
+  } catch {
+    return null;
+  }
+}
+
+export interface AnimatedRightDrawerProps {
+  /** Left (chat) content — fills the remaining space via `flex-1`. */
+  left: ReactNode;
+  /** Right (drawer) content — rendered at the resolved width. */
+  right: ReactNode;
+  /** Initial drawer width in px (default 400). */
+  defaultWidth?: number;
+  /** Minimum drawer width in px (default 400). */
+  minWidth?: number;
+  /** Minimum left-pane (chat) width in px (default 300). */
+  minLeftWidth?: number;
+  /** Optional localStorage key for persisting the drawer width across reloads. */
+  storageKey?: string;
+}
+
+export function AnimatedRightDrawer({
+  left,
+  right,
+  defaultWidth = 400,
+  minWidth = 400,
+  minLeftWidth = 300,
+  storageKey,
+}: AnimatedRightDrawerProps) {
+  const reduce = useReducedMotion();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [width, setWidth] = useState<number>(
+    () => readStoredWidth(storageKey, minWidth) ?? defaultWidth,
+  );
+  const dragRef = useRef<{ startX: number; startWidth: number } | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+
+  const clamp = useCallback(
+    (next: number) => {
+      const container = containerRef.current;
+      if (!container) return Math.max(minWidth, next);
+      const maxWidth = Math.max(
+        minWidth,
+        container.offsetWidth - minLeftWidth - SEPARATOR_WIDTH_PX,
+      );
+      return Math.max(minWidth, Math.min(next, maxWidth));
+    },
+    [minWidth, minLeftWidth],
+  );
+
+  const handlePointerDown = useCallback(
+    (e: ReactPointerEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      (e.target as HTMLElement).setPointerCapture(e.pointerId);
+      dragRef.current = { startX: e.clientX, startWidth: width };
+      setIsDragging(true);
+    },
+    [width],
+  );
+
+  const handlePointerMove = useCallback(
+    (e: ReactPointerEvent<HTMLDivElement>) => {
+      if (!dragRef.current) return;
+      // Dragging the handle LEFT (clientX decreases) widens the drawer.
+      const delta = dragRef.current.startX - e.clientX;
+      setWidth(clamp(dragRef.current.startWidth + delta));
+    },
+    [clamp],
+  );
+
+  const handlePointerUp = useCallback(
+    (e: ReactPointerEvent<HTMLDivElement>) => {
+      if (!dragRef.current) return;
+      (e.target as HTMLElement).releasePointerCapture(e.pointerId);
+      const finalWidth = clamp(
+        dragRef.current.startWidth + (dragRef.current.startX - e.clientX),
+      );
+      dragRef.current = null;
+      setIsDragging(false);
+      setWidth(finalWidth);
+      if (storageKey) {
+        try {
+          localStorage.setItem(storageKey, String(finalWidth));
+        } catch {
+          // Storage quota or security error — ignore.
+        }
+      }
+    },
+    [clamp, storageKey],
+  );
+
+  // Re-clamp on container resize so the drawer never overruns the chat min.
+  useEffect(() => {
+    setWidth((prev) => clamp(prev));
+    function onResize() {
+      setWidth((prev) => clamp(prev));
+    }
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, [clamp]);
+
+  return (
+    <div
+      ref={containerRef}
+      data-slot="animated-right-drawer"
+      className="flex h-full w-full overflow-hidden"
+    >
+      {/* Chat — fills whatever the drawer doesn't, reflowing as the drawer
+          animates open so there's no early snap to the narrow width. */}
+      <div className="h-full min-w-0 flex-1 overflow-hidden">{left}</div>
+
+      {/* Drag handle (matches ResizablePanel's hidden-divider look). */}
+      <div
+        role="separator"
+        aria-orientation="vertical"
+        className={cn(
+          "group relative z-10 flex h-full w-2 shrink-0 cursor-col-resize items-center justify-center",
+          isDragging && "select-none",
+        )}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerUp}
+      >
+        <div className="h-full w-px bg-transparent" />
+        <div
+          className={cn(
+            "absolute h-8 w-1 rounded-full bg-[var(--content-tertiary)] opacity-0 transition-opacity",
+            "group-hover:opacity-100",
+            isDragging && "opacity-100",
+          )}
+        />
+      </div>
+
+      {/* Drawer — its width is the animated dimension. The content sits in an
+          absolutely-positioned layer pinned to the right edge at the final
+          width, so growing the (overflow-hidden) wrapper reveals it with a
+          left-moving wipe rather than reflowing the content mid-animation.
+          Reduced motion: skip the enter (`initial={false}`) so it just appears. */}
+      <motion.div
+        className="relative h-full shrink-0 overflow-hidden"
+        initial={reduce ? false : { width: 0 }}
+        animate={{ width }}
+        transition={
+          isDragging || reduce
+            ? { duration: 0 }
+            : { duration: 0.34, ease: [0.16, 1, 0.3, 1] }
+        }
+      >
+        <div className="absolute right-0 top-0 h-full" style={{ width }}>
+          {right}
+        </div>
+      </motion.div>
+    </div>
+  );
+}

--- a/apps/web/src/domains/chat/components/chat-content-layout.tsx
+++ b/apps/web/src/domains/chat/components/chat-content-layout.tsx
@@ -14,6 +14,7 @@ import { lazy, useCallback } from "react";
 import { useNavigate } from "react-router";
 import { Loader2 } from "lucide-react";
 import { ResizablePanel } from "@vellumai/design-library";
+import { AnimatedRightDrawer } from "@/domains/chat/components/animated-right-drawer";
 import { LazyBoundary } from "@/components/lazy-boundary";
 import { AppViewerContainer } from "@/components/app-viewer-container";
 import { DocumentViewerContainer } from "@/domains/chat/components/document-viewer-container";
@@ -227,15 +228,16 @@ export function ChatContentLayout(props: ChatRouteContentProps) {
     }
   }
 
-  // Tool detail side panel
+  // Tool detail side panel — opens by animating the drawer width so the chat
+  // reflows in sync (no early layout snap) and the panel grows in instead of
+  // popping in at full size. Drag-to-resize + width persistence preserved.
   if (mainView === "tool-detail" && activeToolDetail && !isMobile) {
     return (
-      <ResizablePanel
-        storageKey="toolDetailPanelWidth"
-        defaultRightWidth={400}
+      <AnimatedRightDrawer
+        storageKey="toolDetailDrawerWidth"
+        defaultWidth={400}
+        minWidth={400}
         minLeftWidth={300}
-        minRightWidth={400}
-        hideDivider
         left={chatContent}
         right={
           <LazyBoundary>

--- a/apps/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.tsx
+++ b/apps/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.tsx
@@ -33,7 +33,7 @@ import {
 } from "lucide-react";
 import { Fragment, type ReactNode } from "react";
 
-import { Typography } from "@vellumai/design-library";
+import { Tooltip, Typography } from "@vellumai/design-library";
 
 import type { IconName } from "@/domains/chat/components/tool-progress-card/derive-step-label";
 import { ThreeDotIndicator } from "@/domains/chat/components/tool-progress-card/three-dot-indicator";
@@ -98,6 +98,61 @@ function parseDurationLabel(label: string): number {
   const match = /^(\d+)s$/.exec(label);
   if (!match) return 0;
   return Number(match[1]) * 1000;
+}
+
+/**
+ * Earliest known start time (epoch ms) across a phase's tool steps, or `null`
+ * when none carry timing. Drives the "Started at …" hover on the duration.
+ */
+function phaseStartedAt(steps: ToolCallCardStep[]): number | null {
+  let earliest: number | null = null;
+  for (const step of steps) {
+    if (step.kind === "tool" && step.startedAt != null) {
+      earliest =
+        earliest == null ? step.startedAt : Math.min(earliest, step.startedAt);
+    }
+  }
+  return earliest;
+}
+
+/** Format an epoch-ms timestamp as a local clock time for the duration tooltip. */
+function formatStartTime(ms: number): string {
+  return new Date(ms).toLocaleTimeString([], {
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}
+
+/**
+ * Phase duration label. When the phase carries a known start time, the duration
+ * becomes a tooltip trigger — hovering "3s" reveals when the work began.
+ */
+function PhaseDurationLabel({
+  durationLabel,
+  startedAt,
+}: {
+  durationLabel: string;
+  startedAt: number | null;
+}) {
+  const label = (
+    <Typography
+      variant="label-medium-default"
+      className="text-[var(--content-tertiary)]"
+    >
+      {durationLabel}
+    </Typography>
+  );
+  if (startedAt == null) return label;
+  return (
+    <Tooltip
+      content={`Started at ${formatStartTime(startedAt)}`}
+      side="top"
+      align="end"
+    >
+      <span className="cursor-default">{label}</span>
+    </Tooltip>
+  );
 }
 
 /** Total of `formatMs`-style labels, re-formatted via `formatMs`. */
@@ -326,6 +381,10 @@ function TimelinePhaseSection({
     section.steps.map((s) => ("durationLabel" in s ? s.durationLabel : "")),
   );
   const status = phaseHeaderStatus(section.steps);
+  // A thinking phase carries no real "completed" semantics — swap the green
+  // status check for the brain glyph so the node reads as a reasoning step
+  // (grouping guarantees a thinking section holds only thinking steps).
+  const isThinking = section.steps[0]?.kind === "thinking";
 
   return (
     <div
@@ -364,7 +423,7 @@ function TimelinePhaseSection({
         className="flex items-center justify-between gap-2 py-[2px]"
       >
         <span className="flex min-w-0 items-center gap-2">
-          <TimelineNode status={status} />
+          <TimelineNode status={status} isThinking={isThinking} />
           <Typography
             variant="body-medium-default"
             className="text-[var(--content-default)]"
@@ -373,17 +432,17 @@ function TimelinePhaseSection({
           </Typography>
         </span>
         {totalDuration ? (
-          <Typography
-            variant="label-medium-default"
-            className="text-[var(--content-tertiary)]"
-          >
-            {totalDuration}
-          </Typography>
+          <PhaseDurationLabel
+            durationLabel={totalDuration}
+            startedAt={phaseStartedAt(section.steps)}
+          />
         ) : null}
       </div>
-      {/* Steps indented to align under the title (icon 14px + the row's 8px
-          gap → 22px). Non-last sections add `pb-3` so the connector line runs
-          unbroken down to the next circle. */}
+      {/* Steps aligned under the phase title (icon 14px + the row's 8px gap →
+          22px). The whole timeline body is already indented under the card
+          header by its container, so the pills only need to align with their
+          own phase title here. Non-last sections add `pb-3` so the connector
+          line runs unbroken down to the next circle. */}
       <div
         className={cn(
           "flex min-w-0 flex-col items-start gap-1 pl-[22px]",
@@ -401,7 +460,23 @@ function TimelinePhaseSection({
  * below / end above each node (with a small gap), so the icon never needs to
  * mask the line passing behind it.
  */
-function TimelineNode({ status }: { status: PhaseHeaderStatus }) {
+function TimelineNode({
+  status,
+  isThinking,
+}: {
+  status: PhaseHeaderStatus;
+  isThinking: boolean;
+}) {
+  if (isThinking) {
+    return (
+      <Brain
+        aria-hidden="true"
+        data-testid="phase-header-status-icon"
+        data-status="thinking"
+        className="h-[14px] w-[14px] shrink-0 text-[var(--content-secondary)]"
+      />
+    );
+  }
   return <TimelineNodeIcon status={status} testId="phase-header-status-icon" />;
 }
 

--- a/apps/web/src/domains/chat/components/tool-progress-card/tool-progress-card-shell.tsx
+++ b/apps/web/src/domains/chat/components/tool-progress-card/tool-progress-card-shell.tsx
@@ -1,5 +1,5 @@
 
-import { AlertCircle, CheckCircle2 } from "lucide-react";
+import { AlertCircle, AlertTriangle, CheckCircle2 } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { useState, type ReactNode } from "react";
 
@@ -13,8 +13,10 @@ import { ThreeDotIndicator } from "@/domains/chat/components/tool-progress-card/
  *
  * - `loading`  → animated `ThreeDotIndicator`
  * - `complete` → green `CheckCircle2`
+ * - `warning`  → amber `AlertTriangle` (a PARTIAL failure — some steps failed
+ *   but not all, so the run still produced useful work)
  * - `denied`   → red `AlertCircle` (a request was blocked / denied)
- * - `error`    → red `AlertCircle` (the tool itself errored)
+ * - `error`    → red `AlertCircle` (the tool itself errored / EVERY step failed)
  *
  * `denied` and `error` render the same icon today and are kept distinct so
  * the two semantics can diverge visually later without a prop break.
@@ -22,6 +24,7 @@ import { ThreeDotIndicator } from "@/domains/chat/components/tool-progress-card/
 export type ToolProgressCardState =
   | "loading"
   | "complete"
+  | "warning"
   | "denied"
   | "error";
 
@@ -144,6 +147,15 @@ function StatusIndicator({
           aria-hidden="true"
           data-state="complete"
           className="h-[14px] w-[14px] shrink-0 text-[var(--system-positive-strong)]"
+        />
+      );
+    case "warning":
+      return (
+        <AlertTriangle
+          data-testid={testId}
+          aria-hidden="true"
+          data-state="warning"
+          className="h-[14px] w-[14px] shrink-0 text-[var(--system-mid-strong)]"
         />
       );
     case "denied":
@@ -353,7 +365,11 @@ export function ToolProgressCardShell({
                   // Button's default `--surface-active` hover so the header
                   // shares the exact same translucent surface-hover as the
                   // inline `InlineActivityLink` (consistent across light/dark).
-                  "h-auto min-w-0 justify-between gap-2 rounded-md px-1.5 py-1.5 -ml-1.5 w-[calc(100%+0.375rem)] hover:bg-[var(--surface-hover)]"
+                  // When expanded, that same surface-hover stays painted so the
+                  // header reads as the active/open summary above the timeline.
+                  `h-auto min-w-0 justify-between gap-2 rounded-md px-1.5 py-1.5 -ml-1.5 w-[calc(100%+0.375rem)] hover:bg-[var(--surface-hover)]${
+                    expanded ? " bg-[var(--surface-hover)]" : ""
+                  }`
                 : `h-auto w-full min-w-0 justify-between gap-2 p-3 ${
                     expanded
                       ? "rounded-t-[var(--radius-lg)] rounded-b-none"

--- a/apps/web/src/domains/chat/hooks/tool-call-card-utils.ts
+++ b/apps/web/src/domains/chat/hooks/tool-call-card-utils.ts
@@ -74,6 +74,12 @@ export type ToolCallCardStep =
   | {
       kind: "tool";
       durationLabel: string;
+      /**
+       * Epoch-ms start time of the call (`tc.startedAt`), when known. Surfaced
+       * as a tooltip on the phase duration so hovering "3s" reveals when the
+       * work began. Omitted when the daemon didn't stamp a start time.
+       */
+      startedAt?: number;
       title: string;
       info: string;
       /**
@@ -123,6 +129,14 @@ export interface ToolCallCardData {
   currentStepKind?: "thinking" | "tool";
   /** Pre-formatted step count, e.g. `"2 steps"`. */
   stepCount: string;
+  /**
+   * Total active work time across the group's tool calls (sum of per-call
+   * durations), formatted like `"16s"`. Empty when no call carries timing data
+   * or the total is sub-second. Drives the expanded card's "Worked for Xs"
+   * header summary. Optional so other `ToolCallCardData` constructors (e.g. the
+   * subagent card) are unaffected.
+   */
+  totalDurationLabel?: string;
   /** Ordered sub-steps to render when expanded. */
   steps: ToolCallCardStep[];
   /**
@@ -297,17 +311,44 @@ function deriveToolStepStatus(
 }
 
 /**
+ * Raw per-tool duration in ms (start time `startedAt` → completion time
+ * `completedAt`). Returns `null` when either timing is missing so callers can
+ * distinguish "no data" from a genuine `0ms`.
+ */
+function computeToolDurationMs(tc: ChatMessageToolCall): number | null {
+  if (tc.startedAt == null || tc.completedAt == null) return null;
+  return Math.max(0, tc.completedAt - tc.startedAt);
+}
+
+/**
  * Per-tool duration, mirroring the legacy generic card: start time
  * (`startedAt`) → completion time (`completedAt`) → `formatMs`. Returns an
  * empty string when timings are missing so the row chrome can hide the
  * meta cluster rather than render a misleading `<1s`.
  */
 function computeToolDurationLabel(tc: ChatMessageToolCall): string {
-  if (tc.startedAt == null) return "";
-  if (tc.completedAt == null) {
-    return "";
+  const ms = computeToolDurationMs(tc);
+  return ms == null ? "" : formatMs(ms);
+}
+
+/**
+ * Total active work time across a group's tool calls — the sum of each call's
+ * raw duration — formatted via `formatMs` (so a sub-second total reads `<1s`,
+ * matching the per-phase duration chips). Powers the expanded card's "Worked
+ * for Xs" summary. Returns an empty string only when NO call carries timing
+ * data, in which case the header falls back to its outcome label.
+ */
+function computeTotalDurationLabel(toolCalls: ChatMessageToolCall[]): string {
+  let total = 0;
+  let anyTimed = false;
+  for (const tc of toolCalls) {
+    const ms = computeToolDurationMs(tc);
+    if (ms == null) continue;
+    anyTimed = true;
+    total += ms;
   }
-  return formatMs(Math.max(0, tc.completedAt - tc.startedAt));
+  if (!anyTimed) return "";
+  return formatMs(total);
 }
 
 /**
@@ -341,6 +382,7 @@ function buildToolStep(tc: ChatMessageToolCall): ToolCallCardStep {
   return {
     kind: "tool",
     durationLabel: computeToolDurationLabel(tc),
+    startedAt: tc.startedAt ?? undefined,
     title,
     info,
     activity,
@@ -644,12 +686,14 @@ export function computeToolCallCardDataFromItems(
     liveWebActivity,
   );
   const stepCount = `${steps.length} step${steps.length === 1 ? "" : "s"}`;
+  const totalDurationLabel = computeTotalDurationLabel(renderableToolCalls);
 
   return {
     currentStepTitle,
     currentStepInfo,
     currentStepKind,
     stepCount,
+    totalDurationLabel,
     steps,
     state,
     carouselItems,

--- a/apps/web/src/domains/chat/hooks/use-subagent-card-data.ts
+++ b/apps/web/src/domains/chat/hooks/use-subagent-card-data.ts
@@ -36,7 +36,6 @@ import {
   type SubagentTimelineEvent,
 } from "@/domains/chat/subagent-store";
 import type { SubagentStatus } from "@vellumai/assistant-api";
-import type { ToolProgressCardState } from "@/domains/chat/components/tool-progress-card/tool-progress-card-shell";
 import { deriveStepLabelFromName } from "@/domains/chat/components/tool-progress-card/derive-step-label";
 import { titleCaseToolName } from "@/domains/chat/components/tool-call-chip/utils";
 import { truncate } from "@/domains/chat/utils/truncate";
@@ -178,7 +177,7 @@ function findMatchingInFlightToolIndex(
  * a human reply but the card chrome still reads as in-flight). `aborted`
  * surfaces as `"error"` so the card doesn't read as a clean completion.
  */
-function deriveCardState(status: SubagentStatus): ToolProgressCardState {
+function deriveCardState(status: SubagentStatus): ToolCallCardData["state"] {
   switch (status) {
     case "running":
     case "pending":

--- a/apps/web/src/domains/chat/hooks/use-tool-call-card-data.test.ts
+++ b/apps/web/src/domains/chat/hooks/use-tool-call-card-data.test.ts
@@ -77,6 +77,7 @@ describe("computeToolCallCardData — step kinds", () => {
     expect(data.steps[0]).toEqual({
       kind: "tool",
       durationLabel: "2s",
+      startedAt: 1000,
       title: "Working (bash)",
       info: "echo hello",
       activity: "",


### PR DESCRIPTION
## Summary

A UX pass on the expanded **activity run card** (the "Thinking / Working" timeline) plus a smoother **side drawer** open animation for tool calls and thought processes.

### Activity run card — header
- **Expanded header no longer repeats the latest step.** Collapsed still carousels the live title/info; expanded shows a stable summary instead:
  - **"Worked for Xs"** when we have timing data (sum of tool durations), regardless of outcome — the status icon carries success/partial/failure.
  - Falls back to **"Working" / "Completed" / "Failed" / "N tools failed"** when no timing data exists.
- **Header hover background persists while expanded**, so the open card header reads as the active summary above the timeline.

### Activity run card — failure summary
- Partial failures (some tools failed, not all) now read as an **amber `warning`** state (`--system-mid-strong` `AlertTriangle`) rather than a full red error.
- **All-failed** stays red `error`; **all-succeeded** stays green check.
- **Thinking steps are excluded** from the success/failure tally.

### Activity run card — timeline
- Expanded body indented **18px** so steps nest as children under the header.
- Step pills aligned under their phase title.
- **Thinking** phase nodes render a **brain glyph** instead of a green check.
- Hovering a phase **duration** shows a tooltip with the tool call's **start time** (`Started at 3:42:07 PM`).

### Side drawer (tool detail / thought process) — animation
- Root cause of the old "pops in / shifts early" feel: `ResizablePanel` reserves the full pane instantly (left fixed, right `flex-1`), so the chat snapped narrow on frame 0 and the drawer appeared at full size.
- New `AnimatedRightDrawer`: chat is `flex-1`, the **drawer width animates `0 → target`**, so the chat reflows in sync and the panel grows in (content pinned to the right edge at final width → clean wipe reveal). **Drag-to-resize + width persistence preserved**; respects `prefers-reduced-motion`.

## Testing
- `bun test` across the affected suites (activity-run-card, tool-progress-card, web-search, chat hooks): **486 pass, 0 fail**.
- `tsc --noEmit` and `eslint` clean on all changed files.

## Notes
- Drawer **close** is still instant (unchanged from before — animating it needs an `AnimatePresence` outliving the `mainView` flip). Easy follow-up if desired.
- Document/subagent/app side panels still use `ResizablePanel`; could get the same animated treatment as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)