### PR TITLE
feat(macos): open OAuth login in system browser instead of in-window

### DIFF
--- a/apps/macos/src/main/auth-nav.test.ts
+++ b/apps/macos/src/main/auth-nav.test.ts
@@ -1,84 +1,41 @@
 import { describe, expect, test } from "bun:test";
 
-import { advanceAuthFlow, decideNavigation } from "./auth-nav";
+import { decideNavigation } from "./auth-nav";
 
 const APP = { protocol: "http:", host: "localhost:3000" } as const;
 
 describe("decideNavigation", () => {
   test("allows same-origin navigation", () => {
     expect(
-      decideNavigation("http://localhost:3000/account/login", APP, false),
+      decideNavigation("http://localhost:3000/account/login", APP),
     ).toEqual({ kind: "allow" });
   });
 
-  test("ejects cross-origin http(s) to the system browser when not signing in", () => {
+  test("ejects cross-origin http(s) to the system browser", () => {
     expect(
-      decideNavigation("https://accounts.google.com/signin", APP, false),
+      decideNavigation("https://accounts.google.com/signin", APP),
     ).toEqual({ kind: "external", url: "https://accounts.google.com/signin" });
   });
 
-  test("allows cross-origin http(s) in-window during a sign-in", () => {
-    expect(
-      decideNavigation("https://accounts.google.com/signin", APP, true),
-    ).toEqual({ kind: "allow" });
-    expect(
-      decideNavigation("https://auth.dev-platform.vellum.ai/x", APP, true),
-    ).toEqual({ kind: "allow" });
-  });
-
-  test("blocks non-http schemes regardless of sign-in state", () => {
-    expect(decideNavigation("mailto:hi@vellum.ai", APP, false)).toEqual({
+  test("blocks non-http schemes", () => {
+    expect(decideNavigation("mailto:hi@vellum.ai", APP)).toEqual({
       kind: "block",
     });
-    expect(decideNavigation("file:///etc/passwd", APP, true)).toEqual({
+    expect(decideNavigation("file:///etc/passwd", APP)).toEqual({
       kind: "block",
     });
   });
 
   test("blocks unparseable URLs", () => {
-    expect(decideNavigation("::::", APP, true)).toEqual({ kind: "block" });
+    expect(decideNavigation("::::", APP)).toEqual({ kind: "block" });
   });
 
-  test("always allows the app origin even mid-sign-in (the callback)", () => {
+  test("allows the app origin", () => {
     expect(
       decideNavigation(
         "http://localhost:3000/account/provider/callback",
         APP,
-        true,
       ),
     ).toEqual({ kind: "allow" });
-  });
-});
-
-describe("advanceAuthFlow", () => {
-  test("marks sawExternal when navigating to a provider domain", () => {
-    expect(
-      advanceAuthFlow("https://accounts.google.com/o/oauth2", APP, false),
-    ).toEqual({ end: false, sawExternal: true });
-  });
-
-  test("does NOT end on the initial same-origin POST (before any provider visit)", () => {
-    // The flow kicks off with a same-origin POST to /accounts/oidc/redirect/;
-    // returning false here keeps the guard relaxed for the provider hops.
-    expect(
-      advanceAuthFlow("http://localhost:3000/accounts/oidc/redirect/", APP, false),
-    ).toEqual({ end: false, sawExternal: false });
-  });
-
-  test("ends once back on the app origin after a provider visit", () => {
-    expect(
-      advanceAuthFlow(
-        "http://localhost:3000/account/provider/callback",
-        APP,
-        true,
-      ),
-    ).toEqual({ end: true, sawExternal: true });
-  });
-
-  test("leaves state unchanged on an unparseable URL", () => {
-    expect(advanceAuthFlow("::::", APP, true)).toEqual({
-      end: false,
-      sawExternal: true,
-    });
   });
 });

--- a/apps/macos/src/main/auth-nav.ts
+++ b/apps/macos/src/main/auth-nav.ts
@@ -4,11 +4,9 @@ import { type AllowedOrigin, isAllowedOrigin } from "./app-origin";
  * Navigation-guard decision logic for the main window, extracted so it can be
  * unit-tested without booting the app.
  *
- * Normally the main window may only navigate within the app's own origin;
- * cross-origin top-level navigations are ejected to the system browser. During
- * a sign-in, though, the window must follow the OAuth provider chain
- * (WorkOS → Google/Apple → back to our callback) as in-window navigations — so
- * while `authFlowActive` is set, cross-origin http(s) hops are allowed.
+ * The main window may only navigate within the app's own origin; cross-origin
+ * http(s) navigations are ejected to the system browser, and non-http schemes
+ * are blocked outright.
  */
 export type NavigationDecision =
   | { kind: "allow" } // proceed in-window
@@ -18,7 +16,6 @@ export type NavigationDecision =
 export const decideNavigation = (
   url: string,
   allowed: AllowedOrigin,
-  authFlowActive: boolean,
 ): NavigationDecision => {
   let target: URL;
   try {
@@ -29,33 +26,6 @@ export const decideNavigation = (
   if (isAllowedOrigin(target, allowed)) return { kind: "allow" };
 
   const isHttp = target.protocol === "https:" || target.protocol === "http:";
-  if (authFlowActive && isHttp) return { kind: "allow" };
   if (isHttp) return { kind: "external", url };
   return { kind: "block" };
-};
-
-/**
- * On a committed top-level navigation (`did-navigate`), decide whether an
- * in-progress sign-in has completed and the relaxed guard should re-arm.
- *
- * The guard re-arms only once the flow has actually left to a provider domain
- * (`sawExternal`) and then returned to the app origin (the OAuth callback) —
- * never on the initial same-origin POST that kicks the flow off. Returns the
- * updated `sawExternal` so the caller can thread the per-flow state.
- */
-export const advanceAuthFlow = (
-  url: string,
-  allowed: AllowedOrigin,
-  sawExternal: boolean,
-): { end: boolean; sawExternal: boolean } => {
-  let target: URL;
-  try {
-    target = new URL(url);
-  } catch {
-    return { end: false, sawExternal };
-  }
-  if (!isAllowedOrigin(target, allowed)) {
-    return { end: false, sawExternal: true };
-  }
-  return { end: sawExternal, sawExternal };
 };

--- a/apps/macos/src/main/deep-links.test.ts
+++ b/apps/macos/src/main/deep-links.test.ts
@@ -242,6 +242,26 @@ describe("parseVellumUrl", () => {
       error: undefined,
     });
   });
+
+  test("auth callback works with environment-specific scheme (e.g. vellum-assistant-dev)", () => {
+    // The dev scheme is registered when VELLUM_ENVIRONMENT=dev (or persisted default is dev).
+    // On this dev machine the scheme is in ACCEPTED_SCHEMES; on production it isn't,
+    // but the server would use the production scheme there. Verify the parser accepts it.
+    const devUrl = "vellum-assistant-dev://auth/callback?code=abc&state=xyz";
+    const result = parseVellumUrl(devUrl);
+    // If the dev scheme is registered (dev environment), we get authCallback;
+    // if not (production CI), it falls through to unknown — both are correct.
+    if (result.kind === "authCallback") {
+      expect(result).toEqual({
+        kind: "authCallback",
+        state: "xyz",
+        code: "abc",
+        error: undefined,
+      });
+    } else {
+      expect(result.kind).toBe("unknown");
+    }
+  });
 });
 
 describe("extractDeepLinkFromArgv", () => {

--- a/apps/macos/src/main/deep-links.test.ts
+++ b/apps/macos/src/main/deep-links.test.ts
@@ -67,6 +67,12 @@ mock.module("./main-window", () => ({
   ensureVisible: ensureMainWindowVisibleMock,
 }));
 
+// `./native-auth` is called from `handleDeepLink` for auth callbacks.
+const handleAuthCallbackMock = mock(async () => undefined);
+mock.module("./native-auth", () => ({
+  handleAuthCallback: handleAuthCallbackMock,
+}));
+
 const {
   __resetForTesting,
   extractDeepLinkFromArgv,
@@ -99,6 +105,7 @@ beforeEach(() => {
   ipcHandleMock.mockClear();
   ipcOnMock.mockClear();
   ensureMainWindowVisibleMock.mockClear();
+  handleAuthCallbackMock.mockClear();
   windows = [];
   appIsReady = true;
 });
@@ -191,6 +198,50 @@ describe("parseVellumUrl", () => {
       url: "vellum://garbage",
     });
   });
+
+  test("vellum-assistant://auth/callback?code=abc&state=xyz → authCallback", () => {
+    expect(
+      parseVellumUrl("vellum-assistant://auth/callback?code=abc&state=xyz"),
+    ).toEqual({
+      kind: "authCallback",
+      state: "xyz",
+      code: "abc",
+      error: undefined,
+    });
+  });
+
+  test("auth callback with error and no code", () => {
+    expect(
+      parseVellumUrl(
+        "vellum-assistant://auth/callback?state=xyz&error=signup_closed",
+      ),
+    ).toEqual({
+      kind: "authCallback",
+      state: "xyz",
+      code: undefined,
+      error: "signup_closed",
+    });
+  });
+
+  test("auth callback without state → unknown", () => {
+    expect(
+      parseVellumUrl("vellum-assistant://auth/callback?code=abc"),
+    ).toEqual({
+      kind: "unknown",
+      url: "vellum-assistant://auth/callback?code=abc",
+    });
+  });
+
+  test("auth callback works with vellum:// scheme too", () => {
+    expect(
+      parseVellumUrl("vellum://auth/callback?code=abc&state=xyz"),
+    ).toEqual({
+      kind: "authCallback",
+      state: "xyz",
+      code: "abc",
+      error: undefined,
+    });
+  });
 });
 
 describe("extractDeepLinkFromArgv", () => {
@@ -217,16 +268,18 @@ describe("extractDeepLinkFromArgv", () => {
 });
 
 describe("installDeepLinks", () => {
-  test("registers both schemes with Launch Services and is idempotent across repeated calls", () => {
+  test("registers schemes with Launch Services and is idempotent across repeated calls", () => {
     installDeepLinks();
+    const firstCallCount = setAsDefaultProtocolClientMock.mock.calls.length;
+
     installDeepLinks();
     installDeepLinks();
 
     const schemes = setAsDefaultProtocolClientMock.mock.calls.map((c) => c[0]);
     expect(schemes).toContain("vellum");
     expect(schemes).toContain("vellum-assistant");
-    // 2 schemes × 1 install = 2 calls total (idempotent).
-    expect(setAsDefaultProtocolClientMock).toHaveBeenCalledTimes(2);
+    // Idempotent — repeated calls don't register again.
+    expect(setAsDefaultProtocolClientMock).toHaveBeenCalledTimes(firstCallCount);
   });
 
   test("subscribes to will-finish-launching and registers an open-url listener under it", () => {
@@ -486,5 +539,45 @@ describe("handleDeepLink — window activation", () => {
     expect(drain(allowedEvent)).toEqual([
       { kind: "send", message: "delivered" },
     ]);
+  });
+});
+
+describe("handleDeepLink — auth callback", () => {
+  test("routes auth callbacks to native-auth instead of broadcasting", () => {
+    const w = makeWindow();
+    windows = [w];
+
+    handleDeepLink("vellum-assistant://auth/callback?code=abc&state=xyz");
+
+    expect(handleAuthCallbackMock).toHaveBeenCalledWith("xyz", "abc", undefined);
+    expect(w.webContents.send).not.toHaveBeenCalled();
+  });
+
+  test("auth callbacks with errors are forwarded to native-auth", () => {
+    handleDeepLink(
+      "vellum-assistant://auth/callback?state=xyz&error=signup_closed",
+    );
+
+    expect(handleAuthCallbackMock).toHaveBeenCalledWith(
+      "xyz",
+      undefined,
+      "signup_closed",
+    );
+  });
+
+  test("auth callbacks bring the main window forward", () => {
+    handleDeepLink("vellum-assistant://auth/callback?code=abc&state=xyz");
+    expect(ensureMainWindowVisibleMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("auth callbacks are not buffered for the renderer", () => {
+    installDeepLinks();
+    const drainHandler = ipcHandleMock.mock.calls.find(
+      (c) => c[0] === "vellum:deepLinks:drain",
+    )![1] as (event: unknown) => unknown[];
+
+    handleDeepLink("vellum-assistant://auth/callback?code=abc&state=xyz");
+
+    expect(drainHandler(allowedEvent)).toEqual([]);
   });
 });

--- a/apps/macos/src/main/deep-links.ts
+++ b/apps/macos/src/main/deep-links.ts
@@ -60,7 +60,7 @@ const BASE_SCHEMES = ["vellum:", "vellum-assistant:"] as const;
 const SCHEME_BY_ENV: Record<string, string> = {
   production: "vellum-assistant",
   staging: "vellum-assistant-staging",
-  development: "vellum-assistant-dev",
+  dev: "vellum-assistant-dev",
   local: "vellum-assistant-local",
 };
 

--- a/apps/macos/src/main/deep-links.ts
+++ b/apps/macos/src/main/deep-links.ts
@@ -1,8 +1,11 @@
 import { BrowserWindow, app, type WebContents } from "electron";
 import { z } from "zod";
 
+import { resolveEnvironmentName } from "@vellumai/local-mode";
+
 import { handle, on } from "./ipc";
 import { ensureVisible as ensureMainWindowVisible } from "./main-window";
+import { handleAuthCallback } from "./native-auth";
 
 /**
  * Inbound deep links — `vellum://` and `vellum-assistant://` URL
@@ -49,9 +52,30 @@ import { ensureVisible as ensureMainWindowVisible } from "./main-window";
 export type DeepLink =
   | { kind: "send"; message: string }
   | { kind: "openThread"; threadId: string }
+  | { kind: "authCallback"; state: string; code?: string; error?: string }
   | { kind: "unknown"; url: string };
 
-const ACCEPTED_SCHEMES = ["vellum:", "vellum-assistant:"] as const;
+const BASE_SCHEMES = ["vellum:", "vellum-assistant:"] as const;
+
+const SCHEME_BY_ENV: Record<string, string> = {
+  production: "vellum-assistant",
+  staging: "vellum-assistant-staging",
+  development: "vellum-assistant-dev",
+  local: "vellum-assistant-local",
+};
+
+function resolveAcceptedSchemes(): string[] {
+  const schemes = [...BASE_SCHEMES] as string[];
+  const env = resolveEnvironmentName(process.env);
+  const envScheme = SCHEME_BY_ENV[env];
+  if (envScheme) {
+    const withColon = `${envScheme}:`;
+    if (!schemes.includes(withColon)) schemes.push(withColon);
+  }
+  return schemes;
+}
+
+const ACCEPTED_SCHEMES = resolveAcceptedSchemes();
 
 /**
  * Pure parser: URL string → typed `DeepLink`. Exported for unit tests.
@@ -78,7 +102,7 @@ export const parseVellumUrl = (input: string): DeepLink => {
   } catch {
     return { kind: "unknown", url: input };
   }
-  if (!ACCEPTED_SCHEMES.includes(url.protocol as (typeof ACCEPTED_SCHEMES)[number])) {
+  if (!ACCEPTED_SCHEMES.includes(url.protocol)) {
     return { kind: "unknown", url: input };
   }
   if (url.host === "send") {
@@ -88,6 +112,13 @@ export const parseVellumUrl = (input: string): DeepLink => {
     const threadId = url.pathname.replace(/^\/+/, "").split("/")[0] ?? "";
     if (threadId) return { kind: "openThread", threadId };
     return { kind: "unknown", url: input };
+  }
+  if (url.host === "auth" && url.pathname.startsWith("/callback")) {
+    const state = url.searchParams.get("state");
+    if (!state) return { kind: "unknown", url: input };
+    const code = url.searchParams.get("code") ?? undefined;
+    const error = url.searchParams.get("error") ?? undefined;
+    return { kind: "authCallback", state, code, error };
   }
   return { kind: "unknown", url: input };
 };
@@ -99,7 +130,7 @@ export const parseVellumUrl = (input: string): DeepLink => {
  */
 export const extractDeepLinkFromArgv = (argv: readonly string[]): string | null => {
   for (const arg of argv) {
-    if (ACCEPTED_SCHEMES.some((scheme) => arg.startsWith(scheme))) return arg;
+    if (ACCEPTED_SCHEMES.some((s) => arg.startsWith(s))) return arg;
   }
   return null;
 };
@@ -158,6 +189,16 @@ const broadcast = (link: DeepLink): void => {
  */
 export const handleDeepLink = (input: string): void => {
   const link = parseVellumUrl(input);
+
+  // Auth callbacks are a main-process concern — the renderer doesn't
+  // need to see them. Route directly to the native-auth module and
+  // bring the window forward so the user sees the result.
+  if (link.kind === "authCallback") {
+    void handleAuthCallback(link.state, link.code, link.error);
+    if (app.isReady()) void ensureMainWindowVisible();
+    return;
+  }
+
   if (subscribers.size === 0) pending.push(link);
   broadcast(link);
   // Activation is gated on `app.isReady()`. On cold launch, the
@@ -186,7 +227,9 @@ export const installDeepLinks = (): void => {
   // Dynamic registration. Packaged builds also declare these in
   // `electron-builder.yml`'s `protocols` (so `Info.plist` carries
   // `CFBundleURLTypes`); the dynamic call is required for dev and
-  // defensive for prod.
+  // defensive for prod. Includes the environment-specific callback
+  // scheme (e.g. `vellum-assistant-dev`) so the OS routes OAuth
+  // callbacks from the system browser back to this instance.
   for (const scheme of ACCEPTED_SCHEMES) {
     app.setAsDefaultProtocolClient(scheme.replace(/:$/, ""));
   }

--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -35,6 +35,7 @@ import {
   toggleVisibility as toggleMainWindowVisibility,
 } from "./main-window";
 import { installApplicationMenu } from "./menu";
+import { installNativeAuth } from "./native-auth";
 import { installConnectivityProbe } from "./connectivity-probe";
 import { installNotifications } from "./notifications";
 import { installPowerEvents } from "./power-events";
@@ -332,6 +333,7 @@ app
       ensureMainWindow: ensureMainWindowVisible,
       openAbout: openAboutWindow,
     });
+    installNativeAuth();
     installMainWindow();
 
     // Dock-icon click / Cmd-Tab re-activation: bring the main window

--- a/apps/macos/src/main/main-window.ts
+++ b/apps/macos/src/main/main-window.ts
@@ -1,9 +1,9 @@
-import { BrowserWindow, type WebContents, app, shell } from "electron";
+import { BrowserWindow, app, shell } from "electron";
 import { z } from "zod";
 
 import { getRendererRootUrl } from "./app-config";
 import { resolveAllowedOrigin } from "./app-origin";
-import { advanceAuthFlow, decideNavigation } from "./auth-nav";
+import { decideNavigation } from "./auth-nav";
 import { type VellumCommand } from "./commands";
 import { handle } from "./ipc";
 import { createWindow } from "./windows";
@@ -115,80 +115,16 @@ const armReadyState = (win: BrowserWindow): ReadyState => {
 // wait for, so callers can compose `await` uniformly.
 const ALREADY_READY: Promise<void> = Promise.resolve();
 
-// ── Sign-in navigation relaxation ───────────────────────────────────────────
-// Platform sign-in runs the OAuth provider chain (WorkOS → Google/Apple → our
-// callback) as top-level navigations in the main window. Those are cross-origin,
-// so the same-origin guard below would normally eject them to the system
-// browser mid-handshake. `beginAuthFlow` (renderer IPC, fired on "Continue
-// with …") relaxes the guard for the duration of the flow; it re-arms once the
-// flow returns to the app origin after visiting a provider (see `did-navigate`
-// below) or after a timeout backstop, so the relaxation can't linger.
-const AUTH_FLOW_TIMEOUT_MS = 5 * 60_000;
-const authFlowActive = new WeakSet<WebContents>();
-const authFlowSawExternal = new WeakSet<WebContents>();
-const authFlowTimers = new WeakMap<WebContents, ReturnType<typeof setTimeout>>();
-
-const endAuthFlow = (wc: WebContents): void => {
-  authFlowActive.delete(wc);
-  authFlowSawExternal.delete(wc);
-  const timer = authFlowTimers.get(wc);
-  if (timer) {
-    clearTimeout(timer);
-    authFlowTimers.delete(wc);
-  }
-};
-
-/**
- * Relax the main window's navigation guard for an in-flight sign-in. Idempotent
- * (resets the timeout). Re-armed by the `did-navigate` handler or the timeout.
- */
-export const beginAuthFlow = (): void => {
-  const win = mainWindow;
-  if (!win || win.isDestroyed()) return;
-  const wc = win.webContents;
-  authFlowActive.add(wc);
-  authFlowSawExternal.delete(wc);
-  const existing = authFlowTimers.get(wc);
-  if (existing) clearTimeout(existing);
-  authFlowTimers.set(
-    wc,
-    setTimeout(() => endAuthFlow(wc), AUTH_FLOW_TIMEOUT_MS),
-  );
-};
-
 const installSameOriginNavigationGuard = (win: BrowserWindow): void => {
-  // Scoped to the main window — popups (OAuth flows etc.) need to
-  // redirect between provider domains and our callback origin, so
-  // they're left unrestricted. Resolved once per window construction
-  // so a `VELLUM_DEV_URL` mutated mid-process can't desync the loader
-  // and the guard.
   const allowedOrigin = resolveAllowedOrigin();
-  const wc = win.webContents;
 
-  wc.on("will-navigate", (event, url) => {
-    const decision = decideNavigation(url, allowedOrigin, authFlowActive.has(wc));
+  win.webContents.on("will-navigate", (event, url) => {
+    const decision = decideNavigation(url, allowedOrigin);
     if (decision.kind === "allow") return;
     event.preventDefault();
-    // External http(s) top-level navigations (e.g.
-    // `window.location.href = "https://billing.stripe.com/..."`) route to the
-    // system browser instead of silently failing. Other schemes stay blocked.
     if (decision.kind === "external") {
       void shell.openExternal(decision.url);
     }
-  });
-
-  // Re-arm the relaxed guard once a sign-in returns to the app origin after
-  // visiting a provider domain. `did-navigate` reports each committed top-level
-  // URL (post-redirect), so it sees the provider page and then the callback.
-  wc.on("did-navigate", (_event, url) => {
-    if (!authFlowActive.has(wc)) return;
-    const { end, sawExternal } = advanceAuthFlow(
-      url,
-      allowedOrigin,
-      authFlowSawExternal.has(wc),
-    );
-    if (sawExternal) authFlowSawExternal.add(wc);
-    if (end) endAuthFlow(wc);
   });
 };
 
@@ -216,10 +152,6 @@ const createMainWindow = (): BrowserWindow => {
     ? { ...ONBOARDING_CONTENT_SIZE, useContentSize: true }
     : restoreBounds("main", MAIN_DEFAULT_BOUNDS);
 
-  // The main window relaxes same-origin navigation during the OAuth sign-in
-  // chain, so it hands the seam its own guard rather than the static
-  // `deny-all` policy; `window.open` stays governed by the global
-  // `web-contents-created` handler in `index.ts`.
   const win = createWindow({
     browserWindow: { ...sizing, show: false },
     navigation: { installGuard: installSameOriginNavigationGuard },
@@ -428,17 +360,6 @@ export const installMainWindow = (): void => {
     z.tuple([z.boolean()]),
     async ([active]): Promise<void> => {
       setOnboarding(active);
-    },
-  );
-
-  // Renderer-driven sign-in: relax the same-origin navigation guard for the
-  // duration of an OAuth flow so the provider chain runs in the main window
-  // instead of being ejected to the system browser.
-  handle(
-    "vellum:mainWindow:beginAuthFlow",
-    z.tuple([]),
-    async (): Promise<void> => {
-      beginAuthFlow();
     },
   );
 

--- a/apps/macos/src/main/native-auth.test.ts
+++ b/apps/macos/src/main/native-auth.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import { buildStartUrl, generateState } from "./native-auth";
+
+describe("generateState", () => {
+  test("returns a base64url-encoded string of sufficient length", () => {
+    const state = generateState();
+    expect(state.length).toBeGreaterThanOrEqual(16);
+    expect(/^[A-Za-z0-9_-]+$/.test(state)).toBe(true);
+  });
+
+  test("generates unique values", () => {
+    const a = generateState();
+    const b = generateState();
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("buildStartUrl", () => {
+  test("builds URL with required state param", () => {
+    const url = buildStartUrl("https://platform.vellum.ai", "abc123", {});
+    expect(url).toBe(
+      "https://platform.vellum.ai/accounts/native/start?state=abc123",
+    );
+  });
+
+  test("includes optional params when provided", () => {
+    const url = buildStartUrl("https://platform.vellum.ai", "abc123", {
+      providerHint: "GoogleOAuth",
+      loginHint: "user@example.com",
+      clientVersion: "1.0.0",
+    });
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get("state")).toBe("abc123");
+    expect(parsed.searchParams.get("provider_hint")).toBe("GoogleOAuth");
+    expect(parsed.searchParams.get("login_hint")).toBe("user@example.com");
+    expect(parsed.searchParams.get("client_version")).toBe("1.0.0");
+  });
+
+  test("omits optional params when not provided", () => {
+    const url = buildStartUrl("https://platform.vellum.ai", "abc123", {});
+    const parsed = new URL(url);
+    expect(parsed.searchParams.has("provider_hint")).toBe(false);
+    expect(parsed.searchParams.has("login_hint")).toBe(false);
+    expect(parsed.searchParams.has("client_version")).toBe(false);
+  });
+});

--- a/apps/macos/src/main/native-auth.ts
+++ b/apps/macos/src/main/native-auth.ts
@@ -2,8 +2,7 @@ import crypto from "node:crypto";
 import { app, net, session, shell } from "electron";
 import { z } from "zod";
 
-import { SEEDS } from "@vellumai/environments";
-import { resolveEnvironmentName, resolveLocalConfigFromEnv } from "@vellumai/local-mode";
+import { resolveLocalConfigFromEnv } from "@vellumai/local-mode";
 
 import { handle } from "./ipc";
 
@@ -102,13 +101,13 @@ function cancelPendingFlows(): void {
   pendingFlows.clear();
 }
 
-// The OAuth start/exchange endpoints must hit the remote platform whose
-// redirect URI is registered in WorkOS — not the local dev server, whose
-// localhost URL isn't (and can't practically be) registered.
+// The OAuth start/exchange endpoints must go through the web origin (not
+// the platform origin) because WorkOS redirect URIs are registered against
+// the web domain (e.g. dev-assistant.vellum.ai, localhost:3000). The web
+// server proxies /accounts/* to Django, so Django sees the web host and
+// builds a matching callback URL.
 function resolveAuthPlatformUrl(): string {
-  const env = resolveEnvironmentName(process.env);
-  const seed = SEEDS[env] ?? SEEDS["production"];
-  return seed!.platformUrl;
+  return resolveLocalConfigFromEnv(process.env).webUrl;
 }
 
 // The cookie must be installed against the platform URL the renderer's

--- a/apps/macos/src/main/native-auth.ts
+++ b/apps/macos/src/main/native-auth.ts
@@ -2,7 +2,8 @@ import crypto from "node:crypto";
 import { app, net, session, shell } from "electron";
 import { z } from "zod";
 
-import { resolveLocalConfigFromEnv } from "@vellumai/local-mode";
+import { SEEDS } from "@vellumai/environments";
+import { resolveEnvironmentName, resolveLocalConfigFromEnv } from "@vellumai/local-mode";
 
 import { handle } from "./ipc";
 
@@ -101,7 +102,18 @@ function cancelPendingFlows(): void {
   pendingFlows.clear();
 }
 
-function resolvePlatformUrl(): string {
+// The OAuth start/exchange endpoints must hit the remote platform whose
+// redirect URI is registered in WorkOS — not the local dev server, whose
+// localhost URL isn't (and can't practically be) registered.
+function resolveAuthPlatformUrl(): string {
+  const env = resolveEnvironmentName(process.env);
+  const seed = SEEDS[env] ?? SEEDS["production"];
+  return seed!.platformUrl;
+}
+
+// The cookie must be installed against the platform URL the renderer's
+// proxy actually talks to (which may be localhost in dev).
+function resolveProxyPlatformUrl(): string {
   return resolveLocalConfigFromEnv(process.env).platformUrl;
 }
 
@@ -113,10 +125,10 @@ async function startOAuth(options: {
   cancelPendingFlows();
 
   const state = generateState();
-  const platformUrl = resolvePlatformUrl();
+  const authPlatformUrl = resolveAuthPlatformUrl();
   const clientVersion = app.getVersion();
 
-  const url = buildStartUrl(platformUrl, state, {
+  const url = buildStartUrl(authPlatformUrl, state, {
     providerHint: options.providerHint,
     loginHint: options.loginHint,
     clientVersion,
@@ -132,7 +144,7 @@ async function startOAuth(options: {
     void shell.openExternal(url);
   });
 
-  await installSessionCookie(platformUrl, sessionToken);
+  await installSessionCookie(resolveProxyPlatformUrl(), sessionToken);
   return { sessionToken };
 }
 
@@ -158,8 +170,7 @@ export async function handleAuthCallback(
   }
 
   try {
-    const platformUrl = resolvePlatformUrl();
-    const sessionToken = await exchangeCode(platformUrl, code);
+    const sessionToken = await exchangeCode(resolveAuthPlatformUrl(), code);
     flow.resolve(sessionToken);
   } catch (err) {
     flow.reject(err instanceof Error ? err : new Error(String(err)));

--- a/apps/macos/src/main/native-auth.ts
+++ b/apps/macos/src/main/native-auth.ts
@@ -1,0 +1,195 @@
+import crypto from "node:crypto";
+import { app, net, session, shell } from "electron";
+import { z } from "zod";
+
+import { resolveLocalConfigFromEnv } from "@vellumai/local-mode";
+
+import { handle } from "./ipc";
+
+const AUTH_FLOW_TIMEOUT_MS = 5 * 60_000;
+
+interface PendingFlow {
+  resolve: (sessionToken: string) => void;
+  reject: (err: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+const pendingFlows = new Map<string, PendingFlow>();
+
+export function generateState(): string {
+  return crypto.randomBytes(32).toString("base64url");
+}
+
+export function buildStartUrl(
+  platformUrl: string,
+  state: string,
+  options: {
+    providerHint?: string;
+    loginHint?: string;
+    clientVersion?: string;
+  },
+): string {
+  const url = new URL("/accounts/native/start", platformUrl);
+  url.searchParams.set("state", state);
+  if (options.providerHint) url.searchParams.set("provider_hint", options.providerHint);
+  if (options.loginHint) url.searchParams.set("login_hint", options.loginHint);
+  if (options.clientVersion) url.searchParams.set("client_version", options.clientVersion);
+  return url.toString();
+}
+
+async function exchangeCode(
+  platformUrl: string,
+  code: string,
+): Promise<string> {
+  const url = `${new URL(platformUrl).origin}/accounts/native/exchange`;
+  const response = await net.fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ code }),
+  });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Code exchange failed (${response.status}): ${body}`);
+  }
+  const data = (await response.json()) as { session_token: string };
+  return data.session_token;
+}
+
+async function installSessionCookie(
+  platformUrl: string,
+  sessionToken: string,
+): Promise<void> {
+  const target = new URL(platformUrl);
+  const domain = target.hostname.includes("vellum.ai")
+    ? ".vellum.ai"
+    : target.hostname;
+  const isSecure = target.protocol === "https:";
+  const expirationDate = Math.floor(Date.now() / 1000) + 14 * 24 * 3600;
+
+  await session.defaultSession.cookies.set({
+    url: platformUrl,
+    name: "sessionid",
+    value: sessionToken,
+    domain,
+    path: "/",
+    secure: isSecure,
+    httpOnly: true,
+    sameSite: "lax",
+    expirationDate,
+  });
+
+  if (isSecure) {
+    await session.defaultSession.cookies.set({
+      url: platformUrl,
+      name: "__Secure-sessionid",
+      value: sessionToken,
+      domain,
+      path: "/",
+      secure: true,
+      httpOnly: true,
+      sameSite: "lax",
+      expirationDate,
+    });
+  }
+}
+
+function cancelPendingFlows(): void {
+  for (const flow of pendingFlows.values()) {
+    clearTimeout(flow.timer);
+    flow.reject(new Error("Auth flow cancelled — a new flow was started."));
+  }
+  pendingFlows.clear();
+}
+
+function resolvePlatformUrl(): string {
+  return resolveLocalConfigFromEnv(process.env).platformUrl;
+}
+
+async function startOAuth(options: {
+  providerHint?: string;
+  loginHint?: string;
+  intent?: string;
+}): Promise<{ sessionToken: string }> {
+  cancelPendingFlows();
+
+  const state = generateState();
+  const platformUrl = resolvePlatformUrl();
+  const clientVersion = app.getVersion();
+
+  const url = buildStartUrl(platformUrl, state, {
+    providerHint: options.providerHint,
+    loginHint: options.loginHint,
+    clientVersion,
+  });
+
+  const sessionToken = await new Promise<string>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      pendingFlows.delete(state);
+      reject(new Error("Sign-in timed out. Please try again."));
+    }, AUTH_FLOW_TIMEOUT_MS);
+
+    pendingFlows.set(state, { resolve, reject, timer });
+    void shell.openExternal(url);
+  });
+
+  await installSessionCookie(platformUrl, sessionToken);
+  return { sessionToken };
+}
+
+export async function handleAuthCallback(
+  state: string,
+  code?: string,
+  error?: string,
+): Promise<void> {
+  const flow = pendingFlows.get(state);
+  if (!flow) return;
+
+  pendingFlows.delete(state);
+  clearTimeout(flow.timer);
+
+  if (error) {
+    flow.reject(new Error(`Authentication failed: ${error}`));
+    return;
+  }
+
+  if (!code) {
+    flow.reject(new Error("Authentication failed: no authorization code received."));
+    return;
+  }
+
+  try {
+    const platformUrl = resolvePlatformUrl();
+    const sessionToken = await exchangeCode(platformUrl, code);
+    flow.resolve(sessionToken);
+  } catch (err) {
+    flow.reject(err instanceof Error ? err : new Error(String(err)));
+  }
+}
+
+const startOAuthSchema = z.tuple([
+  z.object({
+    providerHint: z.string().optional(),
+    loginHint: z.string().optional(),
+    intent: z.string().optional(),
+  }),
+]);
+
+let installed = false;
+
+export const installNativeAuth = (): void => {
+  if (installed) return;
+  installed = true;
+
+  handle(
+    "vellum:auth:startOAuth",
+    startOAuthSchema,
+    async ([options]): Promise<{ sessionToken: string }> => {
+      return startOAuth(options);
+    },
+  );
+};
+
+export const __resetForTesting = (): void => {
+  installed = false;
+  cancelPendingFlows();
+};

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -163,9 +163,11 @@ export interface VellumBridge {
     getToken(): string | null;
   };
   auth: {
-    signIn(): Promise<void>;
-    signOut(): Promise<void>;
-    getToken(): Promise<string | null>;
+    startOAuth(options: {
+      providerHint?: string;
+      loginHint?: string;
+      intent?: string;
+    }): Promise<{ sessionToken: string }>;
   };
   settings: {
     get<T = unknown>(key: string): Promise<T | null>;
@@ -307,14 +309,6 @@ export interface VellumBridge {
      * right size.
      */
     setOnboarding(active: boolean): Promise<void>;
-    /**
-     * Relax the main window's same-origin navigation guard for the duration
-     * of a sign-in so the OAuth provider chain (WorkOS → Google/Apple → our
-     * callback) runs in-window instead of being ejected to the system
-     * browser. Call right before kicking off the provider redirect; the guard
-     * re-arms automatically when the flow returns to the app.
-     */
-    beginAuthFlow(): Promise<void>;
   };
   power: {
     /**
@@ -401,9 +395,14 @@ const bridge: VellumBridge = {
       ipcRenderer.sendSync("vellum:csrf:getToken") as string | null,
   },
   auth: {
-    signIn: notImplemented("auth.signIn"),
-    signOut: notImplemented("auth.signOut"),
-    getToken: notImplemented("auth.getToken"),
+    startOAuth: (options: {
+      providerHint?: string;
+      loginHint?: string;
+      intent?: string;
+    }): Promise<{ sessionToken: string }> =>
+      ipcRenderer.invoke("vellum:auth:startOAuth", options) as Promise<{
+        sessionToken: string;
+      }>,
   },
   settings: {
     get: <T>(key: string): Promise<T | null> =>
@@ -497,8 +496,6 @@ const bridge: VellumBridge = {
         "vellum:mainWindow:setOnboarding",
         active,
       ) as Promise<void>,
-    beginAuthFlow: (): Promise<void> =>
-      ipcRenderer.invoke("vellum:mainWindow:beginAuthFlow") as Promise<void>,
   },
   power: {
     onEvent: (callback) => {

--- a/apps/web/src/runtime/is-electron.ts
+++ b/apps/web/src/runtime/is-electron.ts
@@ -181,10 +181,17 @@ declare global {
           | { ok: false; status: number; error: string }
         >;
       };
+      // Optional: older Electron shells predate the native OAuth IPC channel.
+      auth?: {
+        startOAuth(options: {
+          providerHint?: string;
+          loginHint?: string;
+          intent?: string;
+        }): Promise<{ sessionToken: string }>;
+      };
       mainWindow: {
         ensureVisible(): Promise<void>;
         setOnboarding(active: boolean): Promise<void>;
-        beginAuthFlow(): Promise<void>;
       };
       power: {
         onEvent(

--- a/apps/web/src/runtime/main-window.ts
+++ b/apps/web/src/runtime/main-window.ts
@@ -42,17 +42,3 @@ export async function setOnboardingWindow(active: boolean): Promise<void> {
   await window.vellum?.mainWindow.setOnboarding(active);
 }
 
-/**
- * Relax the Electron main window's same-origin navigation guard for the
- * duration of a sign-in, so the OAuth provider chain (WorkOS → Google/Apple →
- * our callback) runs in the main window instead of being ejected to the system
- * browser. Call immediately before starting the provider redirect; the main
- * process re-arms the guard once the flow returns to the app (or on a timeout).
- *
- * No-op off Electron — web runs OAuth as a normal top-level navigation and
- * Capacitor iOS uses the native auth sheet.
- */
-export async function beginMainWindowAuthFlow(): Promise<void> {
-  if (!isElectron()) return;
-  await window.vellum?.mainWindow.beginAuthFlow();
-}

--- a/apps/web/src/runtime/native-auth.ts
+++ b/apps/web/src/runtime/native-auth.ts
@@ -8,7 +8,6 @@ import {
 import { sanitizeReturnTo } from "@/domains/account/return-to";
 import { getSession } from "@/lib/auth/allauth-client";
 import { isElectron } from "@/runtime/is-electron";
-import { beginMainWindowAuthFlow } from "@/runtime/main-window";
 import { isBiometricEnabled, storeBiometricToken } from "@/runtime/native-biometric";
 import { routes } from "@/utils/routes";
 
@@ -249,12 +248,26 @@ export async function startAuthFlow(
     return;
   }
 
-  // Desktop (Electron): run the OAuth flow in the main window like the web,
-  // but first relax the main window's navigation guard so the cross-origin
-  // provider chain isn't ejected to the system browser mid-handshake. The
-  // existing provider callback page completes the flow in-window.
+  // Desktop (Electron): open the system browser for OAuth so the user can
+  // leverage existing Google/Apple sessions. The main process handles the
+  // full flow (nonce, browser, deep-link callback, code exchange, cookie
+  // install) and returns the session token.
   if (isElectron()) {
-    await beginMainWindowAuthFlow();
+    const result = await window.vellum?.auth?.startOAuth({
+      providerHint: options.providerHint,
+      loginHint: options.loginHint,
+      intent: options.intent,
+    });
+    if (result?.sessionToken) {
+      const destination = sanitizeReturnTo(
+        options.intent === "signup"
+          ? routes.onboarding.privacy
+          : options.returnTo ?? null,
+        DEFAULT_POST_AUTH_DESTINATION,
+      );
+      window.location.href = destination;
+    }
+    return;
   }
 
   // Web path: `options` carries an extra `returnTo` field that the web

--- a/apps/web/src/runtime/native-auth.ts
+++ b/apps/web/src/runtime/native-auth.ts
@@ -251,9 +251,10 @@ export async function startAuthFlow(
   // Desktop (Electron): open the system browser for OAuth so the user can
   // leverage existing Google/Apple sessions. The main process handles the
   // full flow (nonce, browser, deep-link callback, code exchange, cookie
-  // install) and returns the session token.
-  if (isElectron()) {
-    const result = await window.vellum?.auth?.startOAuth({
+  // install) and returns the session token. Falls through to the web
+  // form-POST path when the bridge method is absent (older preload).
+  if (isElectron() && window.vellum?.auth?.startOAuth) {
+    const result = await window.vellum.auth.startOAuth({
       providerHint: options.providerHint,
       loginHint: options.loginHint,
       intent: options.intent,


### PR DESCRIPTION
## Summary
- Migrated Electron OAuth (Google/Apple) from in-window BrowserWindow flow to system browser via `shell.openExternal()`, so users can leverage existing browser sessions (SSO) instead of re-authenticating every time
- Added new `native-auth.ts` main-process module that mirrors the iOS `NativeAuthPlugin.swift` pattern: generates state nonce, opens system browser to `/accounts/native/start`, intercepts `vellum-assistant://auth/callback` deep link, exchanges code for session token, installs cookie into Electron's session
- Removed all dead code from the old in-window auth flow: `beginAuthFlow`, `advanceAuthFlow`, auth flow navigation guard relaxation, and the `beginAuthFlow` IPC handler

## Original prompt
The macOS Electron app's onboarding flow opens Google OAuth inside the Electron window rather than the system browser, requiring users to re-log into Google every time. The user wanted to change this to open the system browser instead, leveraging existing Google sessions for a smoother login experience. The plan was to reuse the existing backend `/accounts/native/*` endpoints (already used by iOS) and mirror the iOS `NativeAuthPlugin.swift` flow in Node.js, with full dead code cleanup of the old in-window auth relaxation infrastructure.

## Test plan
- [ ] `vel up`, launch the Electron app, click "Continue with Google" — system browser opens, complete OAuth, app receives callback, lands on authenticated home
- [ ] Click "Continue with Apple" — same flow, different provider
- [ ] Start auth, close browser tab without completing — verify 5-minute timeout
- [ ] Verify non-auth cross-origin links (e.g. Stripe billing) still open in system browser
- [ ] Run `bun test` in `apps/macos` — auth-nav, deep-links, native-auth, main-window tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)