### PR TITLE
fix: add prepack script to gateway for materializing bundled file: deps

### DIFF
--- a/gateway/package.json
+++ b/gateway/package.json
@@ -21,6 +21,7 @@
     "lint:unused": "knip --include files,dependencies,unlisted",
     "typecheck": "bunx tsc --noEmit",
     "prebuild": "cd .. && bun run meta/feature-flags/sync-bundled-copies.ts",
+    "prepack": "node ../scripts/prepack-bundled-deps.mjs",
     "postinstall": "cd .. && (git config core.hooksPath || git config core.hooksPath .githooks 2>/dev/null || true) && ([ -f meta/feature-flags/sync-bundled-copies.ts ] && bun run meta/feature-flags/sync-bundled-copies.ts 2>/dev/null || true)"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- Add `prepack` script to `gateway/package.json` that runs `prepack-bundled-deps.mjs`
- This materializes symlinked `file:` dependencies before `npm pack`/`npm publish`
- Without this, bun's symlink-based `file:` resolution causes `npm pack` to produce a tarball with `bundled: []` — the `@vellumai/*` deps are missing
- Matches the existing pattern in `assistant`, `cli`, and `credential-executor` package.json files

Addresses https://github.com/vellum-ai/vellum-assistant/pull/33696#discussion_r3365145501