### PR TITLE
feat(macos): wire end-to-end .vellum bundle open flow

### DIFF
--- a/apps/macos/src/main/bundle-flow.test.ts
+++ b/apps/macos/src/main/bundle-flow.test.ts
@@ -1,0 +1,272 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { BundleScanData, BundleMetadata } from "./bundle-manager";
+
+// ---------------------------------------------------------------------------
+// Stubs and mocks
+// ---------------------------------------------------------------------------
+
+const showErrorBoxMock = mock((_title: string, _content: string) => undefined);
+const getPathMock = mock((_name: string) => "/fake/user-data");
+const netFetchMock = mock(
+  async (_url: string, _opts?: RequestInit) =>
+    new Response(null, { status: 500 }),
+);
+
+mock.module("electron", () => ({
+  app: { getPath: getPathMock },
+  dialog: { showErrorBox: showErrorBoxMock },
+  net: { fetch: netFetchMock },
+  ipcMain: {
+    handle: mock(() => undefined),
+    on: mock(() => undefined),
+  },
+  BrowserWindow: class {},
+}));
+
+const getLockfileDataMock = mock((_paths: string[]) => ({
+  ok: false as const,
+  status: 500,
+}));
+const resolveLockfilePathsMock = mock((_env: NodeJS.ProcessEnv) => [
+  "/fake/lockfile",
+]);
+
+mock.module("@vellumai/local-mode", () => ({
+  getLockfileData: getLockfileDataMock,
+  resolveLockfilePaths: resolveLockfilePathsMock,
+}));
+
+const openBundleConfirmationMock = mock(
+  async (_data: BundleScanData) => true,
+);
+const installBundleConfirmationMock = mock(() => undefined);
+
+mock.module("./bundle-confirmation", () => ({
+  openBundleConfirmation: openBundleConfirmationMock,
+  installBundleConfirmation: installBundleConfirmationMock,
+}));
+
+const unpackBundleMock = mock(
+  async (
+    _root: string,
+    _zip: string,
+    _scan: BundleScanData,
+  ): Promise<BundleMetadata> => ({
+    uuid: "test-uuid",
+    name: "Test",
+    entry: "index.html",
+    trustTier: "signed",
+    installedAt: new Date().toISOString(),
+    bundleSizeBytes: 100,
+    capabilities: [],
+  }),
+);
+
+mock.module("./bundle-manager", () => ({
+  unpackBundle: unpackBundleMock,
+}));
+
+const openBundleWindowMock = mock(
+  (_uuid: string, _entry: string, _name: string) => ({}) as unknown,
+);
+
+mock.module("./bundle-window", () => ({
+  openBundleWindow: openBundleWindowMock,
+}));
+
+mock.module("./app-config", () => ({
+  BUNDLES_DIR_NAME: "bundles",
+}));
+
+const { handleBundleFile, resolveDaemonPort, installBundleFlow } =
+  await import("./bundle-flow");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const SAMPLE_SCAN: BundleScanData = {
+  manifest: {
+    format_version: 1,
+    name: "Test Bundle",
+    description: "A test",
+    entry: "index.html",
+    capabilities: [],
+    created_by: "user@example.com",
+    created_at: "2025-01-01T00:00:00Z",
+  },
+  scanResult: { passed: true, findings: [] },
+  signatureResult: { trustTier: "signed", signerDisplayName: "Example User" },
+  bundleSizeBytes: 1234,
+};
+
+const makeLockfileWithPort = (port: number) => ({
+  ok: true as const,
+  data: {
+    assistants: [
+      {
+        assistantId: "a1",
+        resources: { gatewayPort: port, daemonPort: port + 1 },
+      },
+    ],
+    activeAssistant: "a1",
+  },
+});
+
+beforeEach(() => {
+  showErrorBoxMock.mockClear();
+  netFetchMock.mockClear();
+  getLockfileDataMock.mockClear();
+  openBundleConfirmationMock.mockClear();
+  installBundleConfirmationMock.mockClear();
+  unpackBundleMock.mockClear();
+  openBundleWindowMock.mockClear();
+
+  getLockfileDataMock.mockReturnValue({ ok: false, status: 500 });
+  openBundleConfirmationMock.mockResolvedValue(true);
+  netFetchMock.mockResolvedValue(
+    new Response(JSON.stringify(SAMPLE_SCAN), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }),
+  );
+  unpackBundleMock.mockResolvedValue({
+    uuid: "test-uuid",
+    name: "Test",
+    entry: "index.html",
+    trustTier: "signed",
+    installedAt: new Date().toISOString(),
+    bundleSizeBytes: 100,
+    capabilities: [],
+  });
+});
+
+afterEach(() => {
+  getLockfileDataMock.mockReset();
+  netFetchMock.mockReset();
+  openBundleConfirmationMock.mockReset();
+  unpackBundleMock.mockReset();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("resolveDaemonPort", () => {
+  test("returns null when lockfile read fails", () => {
+    getLockfileDataMock.mockReturnValue({ ok: false, status: 500 });
+    expect(resolveDaemonPort()).toBeNull();
+  });
+
+  test("returns null when no assistants have a gateway port", () => {
+    getLockfileDataMock.mockReturnValue({
+      ok: true,
+      data: { assistants: [{ assistantId: "a1" }], activeAssistant: "a1" },
+    });
+    expect(resolveDaemonPort()).toBeNull();
+  });
+
+  test("returns the first assistant gateway port", () => {
+    getLockfileDataMock.mockReturnValue(makeLockfileWithPort(9000));
+    expect(resolveDaemonPort()).toBe(9000);
+  });
+});
+
+describe("handleBundleFile", () => {
+  test("shows error when daemon is unavailable", async () => {
+    getLockfileDataMock.mockReturnValue({ ok: false, status: 500 });
+
+    await handleBundleFile("/tmp/test.vellum");
+
+    expect(showErrorBoxMock).toHaveBeenCalledTimes(1);
+    expect(showErrorBoxMock.mock.calls[0]?.[0]).toBe("Cannot open bundle");
+    expect(openBundleConfirmationMock).not.toHaveBeenCalled();
+  });
+
+  test("shows error when scan fails", async () => {
+    getLockfileDataMock.mockReturnValue(makeLockfileWithPort(9000));
+    netFetchMock.mockResolvedValue(new Response(null, { status: 500 }));
+
+    await handleBundleFile("/tmp/test.vellum");
+
+    expect(showErrorBoxMock).toHaveBeenCalledTimes(1);
+    expect(showErrorBoxMock.mock.calls[0]?.[1]).toContain("Failed to scan");
+    expect(openBundleConfirmationMock).not.toHaveBeenCalled();
+  });
+
+  test("shows error for blocked findings without opening confirmation", async () => {
+    getLockfileDataMock.mockReturnValue(makeLockfileWithPort(9000));
+    const blockedScan: BundleScanData = {
+      ...SAMPLE_SCAN,
+      scanResult: {
+        passed: false,
+        findings: [
+          {
+            category: "security",
+            code: "MALICIOUS_SCRIPT",
+            message: "Detected malicious script",
+            level: "block",
+          },
+        ],
+      },
+    };
+    netFetchMock.mockResolvedValue(
+      new Response(JSON.stringify(blockedScan), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await handleBundleFile("/tmp/test.vellum");
+
+    expect(showErrorBoxMock).toHaveBeenCalledTimes(1);
+    expect(showErrorBoxMock.mock.calls[0]?.[0]).toBe("Bundle blocked");
+    expect(showErrorBoxMock.mock.calls[0]?.[1]).toContain("Detected malicious script");
+    expect(openBundleConfirmationMock).not.toHaveBeenCalled();
+  });
+
+  test("does not unpack when user cancels confirmation", async () => {
+    getLockfileDataMock.mockReturnValue(makeLockfileWithPort(9000));
+    openBundleConfirmationMock.mockResolvedValue(false);
+
+    await handleBundleFile("/tmp/test.vellum");
+
+    expect(openBundleConfirmationMock).toHaveBeenCalledTimes(1);
+    expect(unpackBundleMock).not.toHaveBeenCalled();
+    expect(openBundleWindowMock).not.toHaveBeenCalled();
+  });
+
+  test("shows error when unpack fails", async () => {
+    getLockfileDataMock.mockReturnValue(makeLockfileWithPort(9000));
+    unpackBundleMock.mockRejectedValue(new Error("disk full"));
+
+    await handleBundleFile("/tmp/test.vellum");
+
+    expect(showErrorBoxMock).toHaveBeenCalledTimes(1);
+    expect(showErrorBoxMock.mock.calls[0]?.[1]).toContain("disk full");
+    expect(openBundleWindowMock).not.toHaveBeenCalled();
+  });
+
+  test("success flow: scans, confirms, unpacks, opens window", async () => {
+    getLockfileDataMock.mockReturnValue(makeLockfileWithPort(9000));
+
+    await handleBundleFile("/tmp/test.vellum");
+
+    expect(netFetchMock).toHaveBeenCalledTimes(1);
+    expect(openBundleConfirmationMock).toHaveBeenCalledWith(SAMPLE_SCAN);
+    expect(unpackBundleMock).toHaveBeenCalledTimes(1);
+    expect(openBundleWindowMock).toHaveBeenCalledWith(
+      "test-uuid",
+      "index.html",
+      "Test Bundle",
+    );
+  });
+});
+
+describe("installBundleFlow", () => {
+  test("delegates to installBundleConfirmation", () => {
+    installBundleFlow();
+    expect(installBundleConfirmationMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/macos/src/main/bundle-flow.ts
+++ b/apps/macos/src/main/bundle-flow.ts
@@ -1,0 +1,100 @@
+/**
+ * Bundle-open orchestration: file-open -> daemon scan -> confirm -> unpack -> render.
+ *
+ * When the user double-clicks a `.vellum` file in Finder, this module coordinates
+ * the full flow: resolves the daemon port from the lockfile, asks the daemon to
+ * scan the bundle, shows the confirmation dialog, unpacks the bundle on acceptance,
+ * and opens the sandboxed renderer window.
+ */
+import { app, dialog, net } from "electron";
+import path from "node:path";
+
+import {
+  getLockfileData,
+  resolveLockfilePaths,
+} from "@vellumai/local-mode";
+
+import { BUNDLES_DIR_NAME } from "./app-config";
+import { openBundleConfirmation, installBundleConfirmation } from "./bundle-confirmation";
+import { unpackBundle, type BundleScanData } from "./bundle-manager";
+import { openBundleWindow } from "./bundle-window";
+
+export function resolveDaemonPort(): number | null {
+  const result = getLockfileData(resolveLockfilePaths(process.env));
+  if (!result.ok) return null;
+
+  for (const assistant of result.data.assistants) {
+    if (assistant.resources?.gatewayPort) {
+      return assistant.resources.gatewayPort;
+    }
+  }
+  return null;
+}
+
+export async function scanBundleViaDaemon(
+  filePath: string,
+  port: number,
+): Promise<BundleScanData | null> {
+  try {
+    const response = await net.fetch(
+      `http://127.0.0.1:${port}/v1/apps/open-bundle`,
+      {
+        method: "POST",
+        body: JSON.stringify({ filePath }),
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+    if (!response.ok) return null;
+    return (await response.json()) as BundleScanData;
+  } catch {
+    return null;
+  }
+}
+
+export async function handleBundleFile(filePath: string): Promise<void> {
+  const port = resolveDaemonPort();
+  if (port == null) {
+    dialog.showErrorBox(
+      "Cannot open bundle",
+      "Vellum assistant is not running. Please start Vellum first.",
+    );
+    return;
+  }
+
+  const scanData = await scanBundleViaDaemon(filePath, port);
+  if (!scanData) {
+    dialog.showErrorBox("Cannot open bundle", "Failed to scan bundle.");
+    return;
+  }
+
+  if (!scanData.scanResult.passed) {
+    const blocked = scanData.scanResult.findings
+      .filter((f) => f.level === "block")
+      .map((f) => `• ${f.message}`)
+      .join("\n");
+    dialog.showErrorBox(
+      "Bundle blocked",
+      `This bundle cannot be opened due to security findings:\n\n${blocked}`,
+    );
+    return;
+  }
+
+  const accepted = await openBundleConfirmation(scanData);
+  if (!accepted) return;
+
+  const bundlesRoot = path.join(app.getPath("userData"), BUNDLES_DIR_NAME);
+  let metadata;
+  try {
+    metadata = await unpackBundle(bundlesRoot, filePath, scanData);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    dialog.showErrorBox("Cannot open bundle", `Failed to unpack bundle: ${message}`);
+    return;
+  }
+
+  openBundleWindow(metadata.uuid, scanData.manifest.entry, scanData.manifest.name);
+}
+
+export function installBundleFlow(): void {
+  installBundleConfirmation();
+}

--- a/apps/macos/src/main/file-open.ts
+++ b/apps/macos/src/main/file-open.ts
@@ -33,6 +33,8 @@ const pending: string[] = [];
 
 const subscribers = new Set<WebContents>();
 
+const fileOpenCallbacks = new Set<(path: string) => void>();
+
 const broadcast = (filePath: string): void => {
   for (const win of BrowserWindow.getAllWindows()) {
     if (win.isDestroyed()) continue;
@@ -40,13 +42,30 @@ const broadcast = (filePath: string): void => {
   }
 };
 
+const notifyCallbacks = (filePath: string): void => {
+  for (const cb of fileOpenCallbacks) cb(filePath);
+};
+
 export const handleFileOpen = (filePath: string): void => {
   if (!VELLUM_EXT_RE.test(filePath)) return;
   if (subscribers.size === 0) pending.push(filePath);
   broadcast(filePath);
+  notifyCallbacks(filePath);
   if (app.isReady()) {
     void ensureMainWindowVisible();
   }
+};
+
+/**
+ * Register a main-process callback invoked for every `.vellum` file-open event.
+ * Returns an unsubscribe function. When files are drained by the renderer, the
+ * callback is also invoked for each drained path.
+ */
+export const onFileOpen = (callback: (path: string) => void): (() => void) => {
+  fileOpenCallbacks.add(callback);
+  return () => {
+    fileOpenCallbacks.delete(callback);
+  };
 };
 
 let installed = false;
@@ -88,5 +107,6 @@ export const installFileOpen = (): void => {
 export const __resetForTesting = (): void => {
   installed = false;
   subscribers.clear();
+  fileOpenCallbacks.clear();
   pending.length = 0;
 };

--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -24,7 +24,8 @@ import {
   handleDeepLink,
   installDeepLinks,
 } from "./deep-links";
-import { handleFileOpen, installFileOpen } from "./file-open";
+import { handleBundleFile, installBundleFlow } from "./bundle-flow";
+import { handleFileOpen, installFileOpen, onFileOpen } from "./file-open";
 import { installAvatarIpc } from "./avatar";
 import { installDock } from "./dock";
 import { installFeedbackIpc } from "./feedback";
@@ -321,6 +322,8 @@ app
         path.join(app.getPath("userData"), BUNDLES_DIR_NAME),
       );
     }
+    installBundleFlow();
+    onFileOpen(handleBundleFile);
     installPermissionHandler();
     installCsp();
     installSettingsIpc();


### PR DESCRIPTION
## Summary
- Add bundle-flow.ts orchestrating file-open → daemon scan → confirm → unpack → render
- Add onFileOpen callback hook to file-open.ts for main-process-level reactions
- Wire installBundleFlow and onFileOpen(handleBundleFile) into index.ts

Part of plan: vellum-file-association.md (PR 7 of 7)