### PR TITLE
fix(macos): forward all .vellum argv paths and reuse resolveRelativePath in bundle manager

### DIFF
--- a/apps/macos/src/main/bundle-manager.test.ts
+++ b/apps/macos/src/main/bundle-manager.test.ts
@@ -9,11 +9,11 @@ import {
   listBundles,
   readBundleMetadata,
   removeBundle,
-  resolveEntryPath,
   stripUnsafeEntries,
   unpackBundle,
   type BundleScanData,
 } from "./bundle-manager";
+import { resolveRelativePath } from "./app-protocol";
 
 let tmpDir: string;
 
@@ -95,21 +95,25 @@ describe("unpackBundle", () => {
   });
 
   test("rejects path traversal entries", () => {
-    // JSZip normalizes ../  in entry names, so we test the guard directly.
+    // JSZip normalizes ../  in entry names, so we test the guard directly
+    // via resolveRelativePath (the shared path-traversal predicate that
+    // bundle-manager delegates to internally).
     const bundleDir = "/bundles/uuid";
-    expect(() => resolveEntryPath(bundleDir, "sub/../../escape.txt")).toThrow(
-      "Path traversal detected",
-    );
-    expect(() => resolveEntryPath(bundleDir, "../../../etc/passwd")).toThrow(
-      "Path traversal detected",
-    );
-    // Safe paths resolve without throwing
-    expect(resolveEntryPath(bundleDir, "index.html")).toBe(
-      "/bundles/uuid/index.html",
-    );
-    expect(resolveEntryPath(bundleDir, "assets/style.css")).toBe(
-      "/bundles/uuid/assets/style.css",
-    );
+    expect(resolveRelativePath(bundleDir, "sub/../../escape.txt")).toEqual({
+      kind: "forbidden",
+    });
+    expect(resolveRelativePath(bundleDir, "../../../etc/passwd")).toEqual({
+      kind: "forbidden",
+    });
+    // Safe paths resolve without error
+    expect(resolveRelativePath(bundleDir, "index.html")).toEqual({
+      kind: "ok",
+      resolved: "/bundles/uuid/index.html",
+    });
+    expect(resolveRelativePath(bundleDir, "assets/style.css")).toEqual({
+      kind: "ok",
+      resolved: "/bundles/uuid/assets/style.css",
+    });
   });
 });
 

--- a/apps/macos/src/main/bundle-manager.ts
+++ b/apps/macos/src/main/bundle-manager.ts
@@ -4,6 +4,8 @@ import path from "node:path";
 
 import JSZip from "jszip";
 
+import { resolveRelativePath } from "./app-protocol";
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -58,12 +60,12 @@ export interface BundleScanData {
 // ---------------------------------------------------------------------------
 
 /** Resolve an entry name inside a bundle directory, throwing on escape. */
-export function resolveEntryPath(bundleDir: string, entryName: string): string {
-  const resolved = path.normalize(path.join(bundleDir, entryName));
-  if (!resolved.startsWith(bundleDir + path.sep) && resolved !== bundleDir) {
+function resolveEntryPath(bundleDir: string, entryName: string): string {
+  const result = resolveRelativePath(bundleDir, entryName);
+  if (result.kind === "forbidden") {
     throw new Error(`Path traversal detected: ${entryName}`);
   }
-  return resolved;
+  return result.resolved;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -384,7 +384,6 @@ app.on("second-instance", (_event, argv) => {
   for (const arg of argv) {
     if (/\.vellum$/i.test(arg)) {
       handleFileOpen(arg);
-      break;
     }
   }
 });


### PR DESCRIPTION
## Summary
Fixes two minor gaps from plan review for vellum-file-association.md:
- Remove break in second-instance handler so all .vellum paths in argv are forwarded
- Replace resolveEntryPath with resolveRelativePath from app-protocol.ts to eliminate duplication