### PR TITLE
[LUM-1967] Wire tray Retire command to actually retire the assistant

### DIFF
--- a/apps/web/src/assistant/retire-service.test.ts
+++ b/apps/web/src/assistant/retire-service.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Unit tests for the retire service. The point of extracting it from the
+ * settings component was so a retire can run for an arbitrary assistant id
+ * (e.g. the tray "Retire <assistant>…" command) and route local-vs-platform by
+ * the *target* assistant rather than the currently selected one. These tests
+ * pin that routing plus the failure/404/cleanup behavior.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// --- mutable mock state (set per test) --- //
+
+let isLocalModeValue = false;
+let isNativeValue = false;
+let lockfileAssistants: Array<{ assistantId: string; cloud?: string }> = [];
+let retireByIdResult: { ok: true } | { ok: false; status: number; error: Record<string, unknown> } = { ok: true };
+let retireLocalResult: { ok: true } | { ok: false; error?: string } = { ok: true };
+
+// --- module mocks --- //
+
+const retireAssistantByIdMock = mock(async (_id: string) => retireByIdResult);
+const listAssistantsMock = mock(async () => ({ ok: true as const, status: 200, data: [{ id: "p1", is_local: false, created: "" }] }));
+mock.module("@/assistant/api", () => ({
+  retireAssistantById: retireAssistantByIdMock,
+  listAssistants: listAssistantsMock,
+}));
+
+const retireLocalAssistantMock = mock(async (_id: string) => retireLocalResult);
+const syncPlatformAssistantsToLockfileMock = mock(async (_a: unknown) => {});
+mock.module("@/lib/local-mode", () => ({
+  getLockfile: () => ({ assistants: lockfileAssistants, activeAssistant: null }),
+  isLocalAssistant: (a: { cloud?: string }) => a.cloud !== "vellum",
+  isLocalMode: () => isLocalModeValue,
+  retireLocalAssistant: retireLocalAssistantMock,
+  syncPlatformAssistantsToLockfile: syncPlatformAssistantsToLockfileMock,
+}));
+
+mock.module("@/lib/navigation/navigation-resolver", () => ({
+  // "allow" → assistant route still reachable → service falls back to privacy.
+  resolveNavigation: () => ({ action: "allow" }),
+}));
+mock.module("@/lib/navigation/build-state", () => ({
+  buildNavigationState: () => ({}),
+}));
+
+mock.module("@/runtime/native-auth", () => ({
+  isNativePlatform: () => isNativeValue,
+}));
+
+const clearOnboardingFlagsMock = mock(() => {});
+mock.module("@/utils/onboarding-cleanup", () => ({
+  clearOnboardingFlags: clearOnboardingFlagsMock,
+}));
+
+mock.module("@/utils/routes", () => ({
+  routes: {
+    assistant: "/assistant",
+    onboarding: {
+      prechat: "/assistant/onboarding/prechat",
+      privacy: "/assistant/onboarding/privacy",
+    },
+  },
+}));
+
+const { retireAssistant } = await import("./retire-service");
+
+beforeEach(() => {
+  isLocalModeValue = false;
+  isNativeValue = false;
+  lockfileAssistants = [];
+  retireByIdResult = { ok: true };
+  retireLocalResult = { ok: true };
+  retireAssistantByIdMock.mockClear();
+  listAssistantsMock.mockClear();
+  retireLocalAssistantMock.mockClear();
+  syncPlatformAssistantsToLockfileMock.mockClear();
+  clearOnboardingFlagsMock.mockClear();
+});
+
+afterEach(() => {
+  // keep mock state isolated between tests
+});
+
+describe("retireAssistant", () => {
+  test("platform assistant routes through the platform delete by id", async () => {
+    // GIVEN a platform-hosted target in web mode
+    lockfileAssistants = [{ assistantId: "p1", cloud: "vellum" }];
+
+    // WHEN retiring it
+    const outcome = await retireAssistant("p1");
+
+    // THEN the platform delete ran with that id and the local path did not
+    expect(retireAssistantByIdMock).toHaveBeenCalledWith("p1");
+    expect(retireLocalAssistantMock).not.toHaveBeenCalled();
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.nextRoute).toBe("/assistant/onboarding/privacy");
+    }
+    expect(clearOnboardingFlagsMock).toHaveBeenCalled();
+  });
+
+  test("local assistant in local mode routes through the local retire", async () => {
+    // GIVEN a local target in local mode
+    isLocalModeValue = true;
+    lockfileAssistants = [{ assistantId: "l1", cloud: "local" }];
+
+    // WHEN retiring it
+    const outcome = await retireAssistant("l1");
+
+    // THEN the local retire ran and the platform path did not
+    expect(retireLocalAssistantMock).toHaveBeenCalledWith("l1");
+    expect(retireAssistantByIdMock).not.toHaveBeenCalled();
+    expect(outcome.ok).toBe(true);
+  });
+
+  test("routes by the TARGET assistant, not local-mode alone", async () => {
+    // GIVEN local mode but the *target* is a platform assistant
+    isLocalModeValue = true;
+    lockfileAssistants = [{ assistantId: "p1", cloud: "vellum" }];
+
+    // WHEN retiring the platform target
+    const outcome = await retireAssistant("p1");
+
+    // THEN it uses the platform delete (not local) and re-syncs the lockfile
+    expect(retireAssistantByIdMock).toHaveBeenCalledWith("p1");
+    expect(retireLocalAssistantMock).not.toHaveBeenCalled();
+    expect(syncPlatformAssistantsToLockfileMock).toHaveBeenCalled();
+    expect(outcome.ok).toBe(true);
+  });
+
+  test("a 404 from the platform delete is treated as success", async () => {
+    lockfileAssistants = [{ assistantId: "p1", cloud: "vellum" }];
+    retireByIdResult = { ok: false, status: 404, error: {} };
+
+    const outcome = await retireAssistant("p1");
+
+    expect(outcome.ok).toBe(true);
+    expect(clearOnboardingFlagsMock).toHaveBeenCalled();
+  });
+
+  test("a non-404 platform failure surfaces the error detail", async () => {
+    lockfileAssistants = [{ assistantId: "p1", cloud: "vellum" }];
+    retireByIdResult = { ok: false, status: 500, error: { detail: "boom" } };
+
+    const outcome = await retireAssistant("p1");
+
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect(outcome.error).toBe("boom");
+    }
+    expect(clearOnboardingFlagsMock).not.toHaveBeenCalled();
+  });
+
+  test("native post-retire route is the pre-chat onboarding entry", async () => {
+    isNativeValue = true;
+    lockfileAssistants = [{ assistantId: "p1", cloud: "vellum" }];
+
+    const outcome = await retireAssistant("p1");
+
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.nextRoute).toBe("/assistant/onboarding/prechat");
+    }
+  });
+});

--- a/apps/web/src/assistant/retire-service.ts
+++ b/apps/web/src/assistant/retire-service.ts
@@ -1,0 +1,100 @@
+import { listAssistants, retireAssistantById } from "@/assistant/api";
+import {
+  getLockfile,
+  isLocalAssistant,
+  isLocalMode,
+  retireLocalAssistant,
+  syncPlatformAssistantsToLockfile,
+} from "@/lib/local-mode";
+import { resolveNavigation } from "@/lib/navigation/navigation-resolver";
+import { buildNavigationState } from "@/lib/navigation/build-state";
+import { isNativePlatform } from "@/runtime/native-auth";
+import { clearOnboardingFlags } from "@/utils/onboarding-cleanup";
+import { routes } from "@/utils/routes";
+
+/**
+ * Outcome of a retire attempt. On success carries the route the caller should
+ * navigate to; navigation and toasts are left to the caller (a hook-free
+ * service can't own routing). On failure carries a user-facing message.
+ */
+export type RetireOutcome =
+  | { ok: true; nextRoute: string }
+  | { ok: false; error: string };
+
+/**
+ * Resolve where to send the user after a retire. Native always returns to the
+ * pre-chat onboarding entry; web asks the navigation resolver whether the
+ * assistant route is still reachable (it won't be when the active assistant was
+ * retired) and falls back to the privacy step.
+ */
+async function getPostRetireRoute(): Promise<string> {
+  if (isNativePlatform()) return routes.onboarding.prechat;
+  const decision = resolveNavigation(buildNavigationState(), {
+    kind: "route-guard",
+    pathname: routes.assistant,
+  });
+  return decision.action === "redirect"
+    ? decision.to
+    : routes.onboarding.privacy;
+}
+
+/**
+ * Retire the assistant identified by `assistantId`.
+ *
+ * Routes local vs platform by the **target** assistant's type — the entry in
+ * the lockfile with this id — rather than the currently selected assistant.
+ * This is what lets a caller (e.g. the tray "Retire <assistant>…" command)
+ * retire a managed assistant by id correctly, where the previous settings-only
+ * flow always assumed the target was the active assistant.
+ *
+ * On success performs the shared post-retire cleanup (onboarding flags, and a
+ * best-effort lockfile platform-sync in local mode) and returns the route the
+ * caller should navigate to. Never throws — failures come back as
+ * `{ ok: false, error }`.
+ */
+export async function retireAssistant(
+  assistantId: string,
+): Promise<RetireOutcome> {
+  try {
+    const target = getLockfile().assistants.find(
+      (a) => a.assistantId === assistantId,
+    );
+    const useLocal = isLocalMode() && !!target && isLocalAssistant(target);
+
+    if (useLocal) {
+      const result = await retireLocalAssistant(assistantId);
+      if (!result.ok) {
+        return {
+          ok: false,
+          error: result.error || "Failed to retire assistant.",
+        };
+      }
+    } else {
+      const result = await retireAssistantById(assistantId);
+      // A 404 means the assistant is already gone — treat as success so the
+      // local lockfile and onboarding flags still get reconciled.
+      if (!(result.ok || result.status === 404)) {
+        const detail =
+          typeof result.error?.detail === "string"
+            ? result.error.detail
+            : "Failed to retire assistant.";
+        return { ok: false, error: detail };
+      }
+      if (isLocalMode()) {
+        try {
+          const remaining = await listAssistants();
+          if (remaining.ok) {
+            await syncPlatformAssistantsToLockfile(remaining.data);
+          }
+        } catch {
+          // Best-effort sync — the retire itself already succeeded.
+        }
+      }
+    }
+
+    clearOnboardingFlags();
+    return { ok: true, nextRoute: await getPostRetireRoute() };
+  } catch {
+    return { ok: false, error: "Failed to retire assistant." };
+  }
+}

--- a/apps/web/src/domains/settings/components/retire-assistant.tsx
+++ b/apps/web/src/domains/settings/components/retire-assistant.tsx
@@ -1,31 +1,10 @@
 import { useState } from "react";
 import { useNavigate } from "react-router";
 
-import { listAssistants, retireAssistantById } from "@/assistant/api";
-import {
-    getSelectedAssistant,
-    isLocalAssistant,
-    isLocalMode,
-    retireLocalAssistant,
-    syncPlatformAssistantsToLockfile,
-} from "@/lib/local-mode";
-import { resolveNavigation } from "@/lib/navigation/navigation-resolver";
-import { buildNavigationState } from "@/lib/navigation/build-state";
-import { isNativePlatform } from "@/runtime/native-auth";
-import { clearOnboardingFlags } from "@/utils/onboarding-cleanup";
-import { routes } from "@/utils/routes";
+import { retireAssistant } from "@/assistant/retire-service";
 import { Button } from "@vellumai/design-library/components/button";
 import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
 import { toast } from "@vellumai/design-library/components/toast";
-
-async function getPostRetireRoute(): Promise<string> {
-  if (isNativePlatform()) return routes.onboarding.prechat;
-  const decision = resolveNavigation(
-    buildNavigationState(),
-    { kind: "route-guard", pathname: routes.assistant },
-  );
-  return decision.action === "redirect" ? decision.to : routes.onboarding.privacy;
-}
 
 interface RetireAssistantProps {
   assistantId: string;
@@ -38,51 +17,14 @@ export function RetireAssistant({ assistantId }: RetireAssistantProps) {
 
   const handleRetire = async () => {
     setIsPending(true);
-    try {
-      const selected = getSelectedAssistant();
-      const useLocal =
-        isLocalMode() && selected && isLocalAssistant(selected);
-
-      if (useLocal) {
-        const result = await retireLocalAssistant(assistantId);
-        if (result.ok) {
-          clearOnboardingFlags();
-          setConfirmOpen(false);
-          toast.success("Assistant retired.");
-          navigate(await getPostRetireRoute(), { replace: true });
-          return;
-        } else {
-          toast.error(result.error || "Failed to retire assistant.");
-        }
-      } else {
-        const result = await retireAssistantById(assistantId);
-        if (result.ok || result.status === 404) {
-          if (isLocalMode()) {
-            try {
-              const remaining = await listAssistants();
-              if (remaining.ok) {
-                await syncPlatformAssistantsToLockfile(remaining.data);
-              }
-            } catch {
-              // Best-effort sync
-            }
-          }
-          clearOnboardingFlags();
-          setConfirmOpen(false);
-          toast.success("Assistant retired.");
-          navigate(await getPostRetireRoute(), { replace: true });
-          return;
-        } else {
-          const detail =
-            typeof result.error?.detail === "string"
-              ? result.error.detail
-              : "Failed to retire assistant.";
-          toast.error(detail);
-        }
-      }
-    } catch {
-      toast.error("Failed to retire assistant.");
+    const outcome = await retireAssistant(assistantId);
+    if (outcome.ok) {
+      setConfirmOpen(false);
+      toast.success("Assistant retired.");
+      navigate(outcome.nextRoute, { replace: true });
+      return;
     }
+    toast.error(outcome.error);
     setIsPending(false);
     setConfirmOpen(false);
   };

--- a/apps/web/src/root-layout.tsx
+++ b/apps/web/src/root-layout.tsx
@@ -38,6 +38,9 @@ import { useElectronIconSync } from "@/hooks/use-electron-icon-sync";
 import { useElectronStatusSync } from "@/hooks/use-electron-status-sync";
 import { useElectronFeatureFlagBridge } from "@/runtime/electron-feature-flags";
 import { TimezoneSync } from "@/components/timezone-sync";
+import { retireAssistant } from "@/assistant/retire-service";
+import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
+import { toast } from "@vellumai/design-library/components/toast";
 
 const ShareFeedbackModal = lazy(() =>
   import("@/components/share-feedback-modal").then((m) => ({
@@ -136,6 +139,11 @@ export function RootLayout() {
   useGlobalDeepLinkConsumer();
 
   const [feedbackOpen, setFeedbackOpen] = useState(false);
+  // Id of the assistant a tray "Retire <assistant>…" command targets. The tray
+  // dispatches by id; the destructive confirmation lives here in the layout so
+  // the retire can run without first routing the user to settings.
+  const [retireId, setRetireId] = useState<string | null>(null);
+  const [retirePending, setRetirePending] = useState(false);
 
   useVellumCommands({
     openSettings: () => {
@@ -163,10 +171,28 @@ export function RootLayout() {
     createAssistant: () => {
       void navigate(routes.onboarding.prechat);
     },
-    retireAssistant: () => {
-      void navigate(routes.settings.root);
+    retireAssistant: (command) => {
+      if (command.kind === "retireAssistant") {
+        setRetireId(command.assistantId);
+      }
     },
   });
+
+  const handleConfirmRetire = async () => {
+    if (!retireId) return;
+    setRetirePending(true);
+    const outcome = await retireAssistant(retireId);
+    if (outcome.ok) {
+      setRetireId(null);
+      setRetirePending(false);
+      toast.success("Assistant retired.");
+      navigate(outcome.nextRoute, { replace: true });
+      return;
+    }
+    toast.error(outcome.error);
+    setRetirePending(false);
+    setRetireId(null);
+  };
 
   const keyboardOpen =
     isMobile &&
@@ -228,6 +254,20 @@ export function RootLayout() {
           />
         </LazyBoundary>
       ) : null}
+
+      {/* Destructive confirmation for the tray "Retire <assistant>…" command.
+          Mirrors the settings RetireAssistant dialog so a retire triggered from
+          the menu bar carries the same irreversible-action warning. */}
+      <ConfirmDialog
+        open={retireId !== null}
+        title="Retire Assistant"
+        message="This will permanently retire this assistant and all of its data. You will need to go through the onboarding flow again to create a new one. This action cannot be undone."
+        confirmLabel="Retire"
+        destructive
+        isPending={retirePending}
+        onConfirm={handleConfirmRetire}
+        onCancel={() => setRetireId(null)}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Follow-up to #33654 (multi-assistant tray switcher). That PR added the menu surface but left the renderer command handlers as stubs — "Retire <assistant>…" only navigated to the settings page instead of retiring. This wires **retire** end-to-end.

This is the first of three follow-ups. **Switch** and **New Assistant** are intentionally **not** included — investigation surfaced that those paths in #33654 are wired to the local-gateway layer while the feature targets platform/managed assistants, which need a different selection path (`setAssistantId` on the per-org platform store). That redesign is tracked separately. Retire is unaffected by that issue and correct on its own.

## What changed

- **New `apps/web/src/assistant/retire-service.ts`** — extracts the retire orchestration out of the settings `RetireAssistant` component into a hook-free `retireAssistant(assistantId)` service. Crucially, it routes local-vs-platform by the **target** assistant (looked up in the lockfile by id) rather than the *currently selected* assistant — so a tray command can retire a managed assistant by id correctly. Returns `{ ok, nextRoute } | { ok: false, error }`; callers own toast + navigation.
- **`root-layout.tsx`** — the `retireAssistant` tray command now opens the same destructive `ConfirmDialog` and runs the retire on confirm (was: `navigate(routes.settings.root)`).
- **`retire-assistant.tsx`** (settings) — delegates to the shared service; behavior unchanged, ~70 lines of duplicated orchestration removed.

## Why route by target, not selected

The previous component computed `useLocal` from `getSelectedAssistant()`. For a tray retire of a non-active managed assistant that could route a platform delete down the local path (or vice-versa). The service resolves the type from the lockfile entry matching the passed id.

## Test plan

- `bun test src/assistant/retire-service.test.ts` — 6 tests: platform routing, local routing, **routes-by-target-not-selected**, 404-as-success, error surfacing, native post-retire route.
- `bunx tsc --noEmit` (apps/web) — clean.
- `bun run lint` on changed files — clean.

## Manual verification (requested — I can't run the Electron app here)

Behind the `multi-platform-assistant` flag:
1. Right-click tray → "Retire <assistant>…" → confirm dialog appears with the irreversible-action copy.
2. Confirm → assistant is retired (platform DELETE by id) and the app routes to onboarding.
3. Cancel → no-op.
4. Settings → Retire Assistant still behaves exactly as before.

## Not in scope / follow-ups

- **Switch**: should route through the per-org platform selection (`setAssistantId`) + sync lockfile `activeAssistant`; the merged handler uses `connectLocalAssistant` (local-gateway), which no-ops for platform assistants.
- **New Assistant**: needs an "add assistant" intent that bypasses the onboarding guard *and* actually hatches (the `replay` path deliberately skips hatch) plus selection of the new assistant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)