### PR TITLE
feat(feature-flags): show dropdown for string flags with known variants

### DIFF
--- a/apps/web/src/domains/settings/components/panels/feature-flags-panel.tsx
+++ b/apps/web/src/domains/settings/components/panels/feature-flags-panel.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 
 import { DetailCard } from "@/components/detail-card";
 import { assistantsActiveRetrieveOptions } from "@/generated/api/@tanstack/react-query.gen";
+import { client } from "@/generated/api/client.gen";
 import { fetchAssistantFlagValues } from "@/hooks/use-assistant-feature-flag-sync";
 import { useFlagQueryFreshness } from "@/lib/backwards-compat/flag-query-freshness";
 import {
@@ -16,8 +17,25 @@ import {
 import { assistantFlagValuesQueryKey } from "@/lib/sync/query-tags";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
+import { Dropdown } from "@vellumai/design-library/components/dropdown";
 import { Tag, type TagTone } from "@vellumai/design-library/components/tag";
 import { Toggle } from "@vellumai/design-library/components/toggle";
+
+interface FlagDefinitionResponse {
+  key: string;
+  type: "boolean" | "string";
+  values?: string[];
+}
+
+async function fetchFlagDefinitions(): Promise<FlagDefinitionResponse[]> {
+  const { data, response } = await client.get<
+    FlagDefinitionResponse[],
+    Record<string, unknown>,
+    false
+  >({ url: "/v1/feature-flags/", throwOnError: false });
+  if (!response?.ok) return [];
+  return (data as FlagDefinitionResponse[]) ?? [];
+}
 
 const SCOPE_TONE: Record<SingleScope, TagTone> = {
   client: "warning",
@@ -42,6 +60,7 @@ type FlagDisplayEntry =
       description: string;
       value: string;
       defaultValue: string;
+      values?: string[];
     };
 
 export function FeatureFlagsPanel() {
@@ -60,6 +79,23 @@ export function FeatureFlagsPanel() {
     ...freshness,
     retry: 1,
   });
+
+  const { data: definitions } = useQuery({
+    queryKey: ["feature-flag-definitions"],
+    queryFn: fetchFlagDefinitions,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const valuesMap = useMemo(() => {
+    const map = new Map<string, string[]>();
+    if (!definitions) return map;
+    for (const def of definitions) {
+      if (def.type === "string" && def.values?.length) {
+        map.set(def.key, def.values);
+      }
+    }
+    return map;
+  }, [definitions]);
 
   const [searchText, setSearchText] = useState("");
   const clientState = useClientFeatureFlagStore();
@@ -104,13 +140,14 @@ export function FeatureFlagsPanel() {
           description: flag.description,
           value,
           defaultValue: flag.defaultEnabled,
+          values: valuesMap.get(flag.key),
         });
       }
     }
     return entries.sort((a, b) =>
       a.label.localeCompare(b.label, undefined, { sensitivity: "base" }),
     );
-  }, [clientState, assistantState]);
+  }, [clientState, assistantState, valuesMap]);
 
   const filteredFlags = useMemo(() => {
     if (!searchText.trim()) {
@@ -253,21 +290,25 @@ function StringFlagRow({
     setLocalValue(flag.value);
   }, [flag.value]);
 
-  const handleBlur = () => {
-    if (localValue === flag.value) return;
+  const commitValue = (next: string) => {
+    if (next === flag.value) return;
     if (scopeIncludes(flag.scope, "client")) {
-      clientSetStringFlag(flag.storeKey, localValue);
+      clientSetStringFlag(flag.storeKey, next);
     }
     if (scopeIncludes(flag.scope, "assistant")) {
-      assistantSetStringFlag(flag.storeKey, localValue, assistantId);
+      assistantSetStringFlag(flag.storeKey, next, assistantId);
     }
   };
+
+  const handleBlur = () => commitValue(localValue);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {
       e.currentTarget.blur();
     }
   };
+
+  const hasDropdown = flag.values && flag.values.length > 0;
 
   return (
     <div className="flex items-start gap-3 py-3">
@@ -281,15 +322,27 @@ function StringFlagRow({
         <span className="block text-body-small-default text-[var(--content-tertiary)]">
           {flag.description}
         </span>
-        <input
-          type="text"
-          value={localValue}
-          onChange={(e) => setLocalValue(e.target.value)}
-          onBlur={handleBlur}
-          onKeyDown={handleKeyDown}
-          className="w-full rounded-lg border border-[var(--border-base)] bg-[var(--surface-default)] px-3 py-1.5 text-body-small-default text-[var(--content-default)] placeholder:text-[var(--content-tertiary)] focus:border-[var(--border-focus)] focus:outline-none"
-          placeholder={flag.defaultValue || "Enter value..."}
-        />
+        {hasDropdown ? (
+          <Dropdown
+            value={flag.value}
+            onChange={(next) => {
+              setLocalValue(next);
+              commitValue(next);
+            }}
+            options={flag.values!.map((v) => ({ value: v, label: v }))}
+            aria-label={`${flag.label} value`}
+          />
+        ) : (
+          <input
+            type="text"
+            value={localValue}
+            onChange={(e) => setLocalValue(e.target.value)}
+            onBlur={handleBlur}
+            onKeyDown={handleKeyDown}
+            className="w-full rounded-lg border border-[var(--border-base)] bg-[var(--surface-default)] px-3 py-1.5 text-body-small-default text-[var(--content-default)] placeholder:text-[var(--content-tertiary)] focus:border-[var(--border-focus)] focus:outline-none"
+            placeholder={flag.defaultValue || "Enter value..."}
+          />
+        )}
         <div className="flex items-center gap-1">
           <span className="text-body-small-default text-[var(--content-tertiary)]">
             Default:

--- a/apps/web/src/domains/settings/components/panels/feature-flags-panel.tsx
+++ b/apps/web/src/domains/settings/components/panels/feature-flags-panel.tsx
@@ -6,6 +6,7 @@ import { DetailCard } from "@/components/detail-card";
 import { assistantsActiveRetrieveOptions } from "@/generated/api/@tanstack/react-query.gen";
 import { client } from "@/generated/api/client.gen";
 import { fetchAssistantFlagValues } from "@/hooks/use-assistant-feature-flag-sync";
+import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import { useFlagQueryFreshness } from "@/lib/backwards-compat/flag-query-freshness";
 import {
     ALL_FLAGS,
@@ -80,9 +81,11 @@ export function FeatureFlagsPanel() {
     retry: 1,
   });
 
+  const isOrgReady = useIsOrgReady();
   const { data: definitions } = useQuery({
     queryKey: ["feature-flag-definitions"],
     queryFn: fetchFlagDefinitions,
+    enabled: isOrgReady,
     staleTime: 5 * 60 * 1000,
   });
 
@@ -308,7 +311,8 @@ function StringFlagRow({
     }
   };
 
-  const hasDropdown = flag.values && flag.values.length > 0;
+  const hasDropdown =
+    flag.values && flag.values.length > 0 && flag.values.includes(flag.value);
 
   return (
     <div className="flex items-start gap-3 py-3">

--- a/apps/web/src/lib/feature-flags/feature-flag-catalog.ts
+++ b/apps/web/src/lib/feature-flags/feature-flag-catalog.ts
@@ -17,6 +17,7 @@ export interface FlagDefinition {
   label: string;
   description: string;
   defaultEnabled: boolean | string;
+  values?: string[];
 }
 
 const flags = registry.flags as FlagDefinition[];


### PR DESCRIPTION
## Summary

- Fetch flag definitions from `GET /v1/feature-flags/` to discover which string flags have known variant values
- Render a `<Dropdown>` instead of a free-text `<input>` in `StringFlagRow` when variant values are available; falls back to the existing text input when they aren't
- Add optional `values` field to `FlagDefinition` and `FlagDisplayEntry` types

## Original prompt

The user wanted to upgrade the feature flags developer panel so that string flags with known variant values (surfaced by the platform's `GET /v1/feature-flags/` definitions endpoint, added in platform PR #8232) show a dropdown selector instead of a free-text input. The change should gracefully degrade to the existing text input when the definitions API is unavailable or a flag has no known values.