### PR TITLE
refactor: rename publish-npm/publish-meta to publish-npm-prod/publish-meta-prod

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1264,7 +1264,7 @@ jobs:
           git push origin "v${VERSION}"
           echo "Tagged staging release: v${VERSION}"
 
-  publish-npm:
+  publish-npm-prod:
     needs: [extract-version, ci-cli, ci-gateway, ci-playwright, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image]
     if: ${{ always() && !cancelled() && needs.extract-version.outputs.is_staging != 'true' && needs.ci-cli.result == 'success' && needs.ci-gateway.result == 'success' && (needs.ci-playwright.result == 'success' || inputs.playwright_blocks_release != true) && needs.push-assistant-manifest.result == 'success' && needs.push-gateway-manifest.result == 'success' && needs.push-credential-executor-manifest.result == 'success' && needs.push-dockerhub-image.result == 'success' }}
     runs-on: ubuntu-latest
@@ -1560,8 +1560,8 @@ jobs:
           fi
           npm publish --access public --no-provenance
 
-  publish-meta:
-    needs: [extract-version, publish-npm, publish-web-platform]
+  publish-meta-prod:
+    needs: [extract-version, publish-npm-prod, publish-web-platform]
     if: ${{ needs.extract-version.outputs.is_staging != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -2522,8 +2522,8 @@ jobs:
           rm -rf ~/.private_keys 2>/dev/null || true
 
   release:
-    needs: [extract-version, publish-npm, publish-web-platform, publish-meta, build-macos-arm64, build-macos-x64, build-electron, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image, ci-playwright, build-chrome-extension]
-    if: ${{ always() && !cancelled() && needs.extract-version.outputs.is_staging != 'true' && needs.extract-version.result == 'success' && needs.publish-npm.result == 'success' && needs.publish-web-platform.result == 'success' && needs.publish-meta.result == 'success' && needs.build-macos-arm64.result == 'success' && (needs.ci-playwright.result == 'success' || inputs.playwright_blocks_release != true) && needs.push-assistant-manifest.result == 'success' && needs.push-gateway-manifest.result == 'success' && needs.push-credential-executor-manifest.result == 'success' && needs.push-dockerhub-image.result == 'success' }}
+    needs: [extract-version, publish-npm-prod, publish-web-platform, publish-meta-prod, build-macos-arm64, build-macos-x64, build-electron, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image, ci-playwright, build-chrome-extension]
+    if: ${{ always() && !cancelled() && needs.extract-version.outputs.is_staging != 'true' && needs.extract-version.result == 'success' && needs.publish-npm-prod.result == 'success' && needs.publish-web-platform.result == 'success' && needs.publish-meta-prod.result == 'success' && needs.build-macos-arm64.result == 'success' && (needs.ci-playwright.result == 'success' || inputs.playwright_blocks_release != true) && needs.push-assistant-manifest.result == 'success' && needs.push-gateway-manifest.result == 'success' && needs.push-credential-executor-manifest.result == 'success' && needs.push-dockerhub-image.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -2728,7 +2728,7 @@ jobs:
           fi
 
   update-platform:
-    needs: [extract-version, publish-npm]
+    needs: [extract-version, publish-npm-prod]
     if: ${{ needs.extract-version.outputs.is_staging != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -2786,7 +2786,7 @@ jobs:
   # ── iOS release (same-repo reusable workflow) ────────────────────────
 
   release-ios:
-    needs: [extract-version, publish-npm, publish-web-platform, publish-meta, build-macos-arm64, build-macos-x64, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image, build-chrome-extension]
+    needs: [extract-version, publish-npm-prod, publish-web-platform, publish-meta-prod, build-macos-arm64, build-macos-x64, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image, build-chrome-extension]
     if: >-
       ${{
         always() && !cancelled()
@@ -2797,9 +2797,9 @@ jobs:
         && needs.push-gateway-manifest.result == 'success'
         && needs.push-credential-executor-manifest.result == 'success'
         && (needs.build-chrome-extension.result == 'success' || needs.build-chrome-extension.result == 'skipped')
-        && (needs.publish-npm.result == 'success' || needs.publish-npm.result == 'skipped')
+        && (needs.publish-npm-prod.result == 'success' || needs.publish-npm-prod.result == 'skipped')
         && (needs.publish-web-platform.result == 'success' || needs.publish-web-platform.result == 'skipped')
-        && (needs.publish-meta.result == 'success' || needs.publish-meta.result == 'skipped')
+        && (needs.publish-meta-prod.result == 'success' || needs.publish-meta-prod.result == 'skipped')
         && (needs.push-dockerhub-image.result == 'success' || needs.push-dockerhub-image.result == 'skipped')
       }}
     uses: ./.github/workflows/release-ios.yaml
@@ -3175,7 +3175,7 @@ jobs:
   notify-release:
     name: Slack Notification (Release)
     if: ${{ always() && !cancelled() }}
-    needs: [extract-version, publish-npm, publish-web-platform, publish-meta, build-macos-arm64, build-macos-x64, build-electron, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image, register-release, release, merge-release-branch, update-platform, pack-cli, trigger-platform-qa, release-ios, ci-assistant, ci-cli, ci-credential-executor, ci-gateway, ci-playwright, build-chrome-extension, publish-chrome-extension]
+    needs: [extract-version, publish-npm-prod, publish-web-platform, publish-meta-prod, build-macos-arm64, build-macos-x64, build-electron, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image, register-release, release, merge-release-branch, update-platform, pack-cli, trigger-platform-qa, release-ios, ci-assistant, ci-cli, ci-credential-executor, ci-gateway, ci-playwright, build-chrome-extension, publish-chrome-extension]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     continue-on-error: true


### PR DESCRIPTION
## Summary
- Rename `publish-npm` to `publish-npm-prod` and `publish-meta` to `publish-meta-prod` in release.yml
- Makes naming consistent: all publish jobs now have an environment suffix (prod/staging/dev)
- No behavioral changes — just job name renames and reference updates