### PR TITLE
fix(macos): align BundleScanData with daemon API response shape and use semantic tokens

### DIFF
--- a/apps/macos/src/main/bundle-confirmation.test.ts
+++ b/apps/macos/src/main/bundle-confirmation.test.ts
@@ -110,7 +110,8 @@ const SAMPLE_DATA: BundleScanData = {
   },
   scanResult: {
     passed: true,
-    findings: [],
+    blocked: [],
+    warnings: [],
   },
   signatureResult: {
     trustTier: "signed",

--- a/apps/macos/src/main/bundle-flow.test.ts
+++ b/apps/macos/src/main/bundle-flow.test.ts
@@ -98,7 +98,7 @@ const SAMPLE_SCAN: BundleScanData = {
     created_by: "user@example.com",
     created_at: "2025-01-01T00:00:00Z",
   },
-  scanResult: { passed: true, findings: [] },
+  scanResult: { passed: true, blocked: [], warnings: [] },
   signatureResult: { trustTier: "signed", signerDisplayName: "Example User" },
   bundleSizeBytes: 1234,
 };
@@ -203,14 +203,8 @@ describe("handleBundleFile", () => {
       ...SAMPLE_SCAN,
       scanResult: {
         passed: false,
-        findings: [
-          {
-            category: "security",
-            code: "MALICIOUS_SCRIPT",
-            message: "Detected malicious script",
-            level: "block",
-          },
-        ],
+        blocked: ["Detected malicious script"],
+        warnings: [],
       },
     };
     netFetchMock.mockResolvedValue(

--- a/apps/macos/src/main/bundle-flow.ts
+++ b/apps/macos/src/main/bundle-flow.ts
@@ -68,9 +68,8 @@ export async function handleBundleFile(filePath: string): Promise<void> {
   }
 
   if (!scanData.scanResult.passed) {
-    const blocked = scanData.scanResult.findings
-      .filter((f) => f.level === "block")
-      .map((f) => `• ${f.message}`)
+    const blocked = scanData.scanResult.blocked
+      .map((msg) => `• ${msg}`)
       .join("\n");
     dialog.showErrorBox(
       "Bundle blocked",

--- a/apps/macos/src/main/bundle-manager.test.ts
+++ b/apps/macos/src/main/bundle-manager.test.ts
@@ -28,7 +28,7 @@ const makeScanData = (overrides?: Partial<BundleScanData>): BundleScanData => ({
     created_by: "user@example.com",
     created_at: "2025-01-01T00:00:00Z",
   },
-  scanResult: { passed: true, findings: [] },
+  scanResult: { passed: true, blocked: [], warnings: [] },
   signatureResult: { trustTier: "unsigned" },
   bundleSizeBytes: 1024,
   ...overrides,

--- a/apps/macos/src/main/bundle-manager.ts
+++ b/apps/macos/src/main/bundle-manager.ts
@@ -38,12 +38,8 @@ export interface BundleScanData {
   };
   scanResult: {
     passed: boolean;
-    findings: Array<{
-      category: string;
-      code: string;
-      message: string;
-      level: "block" | "warn";
-    }>;
+    blocked: string[];
+    warnings: string[];
   };
   signatureResult: {
     trustTier: "verified" | "signed" | "unsigned" | "tampered";

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -161,12 +161,8 @@ export interface BundleScanData {
   };
   scanResult: {
     passed: boolean;
-    findings: Array<{
-      category: string;
-      code: string;
-      message: string;
-      level: "block" | "warn";
-    }>;
+    blocked: string[];
+    warnings: string[];
   };
   signatureResult: {
     trustTier: "verified" | "signed" | "unsigned" | "tampered";

--- a/apps/web/src/pages/BundleConfirmPage.tsx
+++ b/apps/web/src/pages/BundleConfirmPage.tsx
@@ -10,19 +10,19 @@ const TRUST_BADGE: Record<
 > = {
   verified: {
     label: "Verified",
-    className: "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
+    className: "bg-[var(--system-positive-weak)] text-[var(--system-positive-strong)]",
   },
   signed: {
     label: "Signed",
-    className: "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200",
+    className: "bg-[var(--system-info-weak)] text-[var(--system-info-strong)]",
   },
   unsigned: {
     label: "Unsigned",
-    className: "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300",
+    className: "bg-[var(--surface-active)] text-[var(--content-secondary)]",
   },
   tampered: {
     label: "Tampered — signature invalid",
-    className: "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200",
+    className: "bg-[var(--system-negative-weak)] text-[var(--system-negative-strong)]",
   },
 };
 
@@ -47,7 +47,7 @@ export function BundleConfirmPage() {
   const { manifest, scanResult, signatureResult, bundleSizeBytes } = data;
   const badge = TRUST_BADGE[signatureResult.trustTier];
   const isTampered = signatureResult.trustTier === "tampered";
-  const warnings = scanResult.findings.filter((f) => f.level === "warn");
+  const warnings = scanResult.warnings;
 
   return (
     <div className="flex h-svh w-screen flex-col bg-background px-6 pt-14 pb-6 text-foreground select-none">
@@ -112,12 +112,12 @@ export function BundleConfirmPage() {
           </button>
           {warningsOpen && (
             <ul className="mt-1.5 space-y-1 text-xs">
-              {warnings.map((w, i) => (
+              {warnings.map((msg, i) => (
                 <li
-                  key={`${w.code}-${i}`}
-                  className="rounded bg-yellow-50 px-2 py-1 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-200"
+                  key={i}
+                  className="rounded bg-[var(--system-mid-weak)] px-2 py-1 text-[var(--system-mid-strong)]"
                 >
-                  <span className="font-medium">{w.code}</span>: {w.message}
+                  {msg}
                 </li>
               ))}
             </ul>

--- a/apps/web/src/runtime/is-electron.ts
+++ b/apps/web/src/runtime/is-electron.ts
@@ -134,12 +134,8 @@ export interface BundleScanData {
   };
   scanResult: {
     passed: boolean;
-    findings: Array<{
-      category: string;
-      code: string;
-      message: string;
-      level: "block" | "warn";
-    }>;
+    blocked: string[];
+    warnings: string[];
   };
   signatureResult: {
     trustTier: "verified" | "signed" | "unsigned" | "tampered";


### PR DESCRIPTION
## Summary
- Fix BundleScanData.scanResult to match daemon's actual response: `{ passed, blocked: string[], warnings: string[] }` instead of `findings` array
- Replace `dark:` color-scale utilities with semantic tokens in BundleConfirmPage.tsx to fix lint errors
- Update all 3 copies of BundleScanData (bundle-manager, preload, is-electron) and consuming code (bundle-flow, BundleConfirmPage, tests)

Addresses Codex review feedback and CI lint failures on PR #33720.