### PR TITLE
fix: retry-safe pre-release npm publishes and self-contained Electron packaging

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -2012,6 +2012,12 @@ jobs:
           if ! bun install --frozen-lockfile; then
             rm -f bun.lock && rm -rf node_modules && bun install
           fi
+          PKG_NAME=$(node -p "require('./package.json').name")
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if npm view "$PKG_NAME@$PKG_VERSION" version >/dev/null 2>&1; then
+            echo "::notice::$PKG_NAME@$PKG_VERSION already published; skipping."
+            exit 0
+          fi
           npm publish --tag dev --access public --no-provenance
 
   publish-web-dev:
@@ -2059,7 +2065,14 @@ jobs:
         working-directory: apps/web
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --tag dev --access public --no-provenance
+        run: |
+          PKG_NAME=$(node -p "require('./package.json').name")
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if npm view "$PKG_NAME@$PKG_VERSION" version >/dev/null 2>&1; then
+            echo "::notice::$PKG_NAME@$PKG_VERSION already published; skipping."
+            exit 0
+          fi
+          npm publish --tag dev --access public --no-provenance
 
   publish-meta-dev:
     needs: [compute-version, publish-npm-dev, publish-web-dev]
@@ -2089,7 +2102,14 @@ jobs:
         working-directory: meta
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --tag dev --access public --no-provenance
+        run: |
+          PKG_NAME=$(node -p "require('./package.json').name")
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if npm view "$PKG_NAME@$PKG_VERSION" version >/dev/null 2>&1; then
+            echo "::notice::$PKG_NAME@$PKG_VERSION already published; skipping."
+            exit 0
+          fi
+          npm publish --tag dev --access public --no-provenance
 
   # ── Sparkle Rolling Release ────────────────────────────────────────────
   # ── Upload Sparkle artifacts to GCS ───────────────────────────────────

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1405,6 +1405,12 @@ jobs:
           if ! bun install --frozen-lockfile; then
             rm -f bun.lock && rm -rf node_modules && bun install
           fi
+          PKG_NAME=$(node -p "require('./package.json').name")
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if npm view "$PKG_NAME@$PKG_VERSION" version >/dev/null 2>&1; then
+            echo "::notice::$PKG_NAME@$PKG_VERSION already published; skipping."
+            exit 0
+          fi
           npm publish --tag staging --access public --no-provenance
 
   publish-web-staging:
@@ -1453,7 +1459,14 @@ jobs:
         working-directory: apps/web
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --tag staging --access public --no-provenance
+        run: |
+          PKG_NAME=$(node -p "require('./package.json').name")
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if npm view "$PKG_NAME@$PKG_VERSION" version >/dev/null 2>&1; then
+            echo "::notice::$PKG_NAME@$PKG_VERSION already published; skipping."
+            exit 0
+          fi
+          npm publish --tag staging --access public --no-provenance
 
   publish-meta-staging:
     needs: [extract-version, publish-npm-staging, publish-web-staging]
@@ -1484,7 +1497,14 @@ jobs:
         working-directory: meta
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --tag staging --access public --no-provenance
+        run: |
+          PKG_NAME=$(node -p "require('./package.json').name")
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if npm view "$PKG_NAME@$PKG_VERSION" version >/dev/null 2>&1; then
+            echo "::notice::$PKG_NAME@$PKG_VERSION already published; skipping."
+            exit 0
+          fi
+          npm publish --tag staging --access public --no-provenance
 
   publish-web-prod:
     needs: [extract-version, ci-cli, ci-gateway, ci-playwright, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image]

--- a/apps/macos/package.json
+++ b/apps/macos/package.json
@@ -17,7 +17,8 @@
     "test": "bun test",
     "test:ci": "bun scripts/run-tests.ts",
     "build:fetch-bun": "bash scripts/fetch-bun.sh",
-    "pack": "bash scripts/fetch-bun.sh --arch aarch64 && bash scripts/generate-icon.sh && electron-vite build && electron-builder"
+    "build:web": "cd ../web && bun install && bun run openapi-ts && bun run build && cd ../macos && mkdir -p resources && cp -R ../web/dist resources/web-dist",
+    "pack": "bash scripts/fetch-bun.sh --arch aarch64 && bash scripts/generate-icon.sh && bun run build:web && electron-vite build && electron-builder"
   },
   "devDependencies": {
     "@types/bun": "1.3.14",


### PR DESCRIPTION
## Summary
- Add `npm view` duplicate check before all pre-release `npm publish` calls (dev and staging) so partial failures are retryable
- Add `build:web` script to `apps/macos/package.json` and include it in `pack` so `bun run pack` works from a clean checkout without needing CI-only web build steps first

Addresses https://github.com/vellum-ai/vellum-assistant/pull/33696#pullrequestreview-4439718527