### PR TITLE
ci: gate build-electron on npm meta-package publish

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -1789,7 +1789,7 @@ jobs:
   # ── Electron DMG ──────────────────────────────────────────────────────
 
   build-electron:
-    needs: [compute-version]
+    needs: [compute-version, publish-meta-dev]
     runs-on: macos-26
     timeout-minutes: 30
     continue-on-error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2343,7 +2343,8 @@ jobs:
   # DMG, and uploads it as a release asset. Non-blocking (continue-on-error)
   # while the Electron client is WIP.
   build-electron:
-    needs: [extract-version]
+    needs: [extract-version, publish-meta-prod, publish-meta-staging]
+    if: ${{ always() && !cancelled() && (needs.publish-meta-prod.result == 'success' || needs.publish-meta-staging.result == 'success') }}
     runs-on: macos-26
     timeout-minutes: 30
     continue-on-error: true


### PR DESCRIPTION
## Summary
- Gate `build-electron` on `publish-meta-dev` in dev-release.yaml
- Gate `build-electron` on `publish-meta-prod` / `publish-meta-staging` in release.yml (with `always()` since only one runs per invocation)
- Ensures the Electron DMG is only produced after the npm packages it lazy-installs at runtime are available on the registry