### PR TITLE
[LUM-1967] Multi-assistant: honor selection + tray switch/create + core fixes

### DIFF
--- a/apps/macos/src/main/tray.ts
+++ b/apps/macos/src/main/tray.ts
@@ -119,7 +119,11 @@ const buildTrayMenu = (handlers: TrayHandlers, status: AssistantStatus): Menu =>
   // Reads from the lockfile watcher's in-memory cache (no disk I/O).
   if (isMultiAssistantEnabled() && !onboarding) {
     const lockfile = getWatchedLockfile();
-    const assistants = lockfile.assistants;
+    // Only managed (platform-hosted) assistants belong in the switcher,
+    // mirroring the native client's `isManaged` filter (cloud === "vellum").
+    // Local/Docker lockfile entries are handled by separate flows and would
+    // mis-route through the platform selection path.
+    const assistants = lockfile.assistants.filter((a) => a.cloud === "vellum");
     const activeId = lockfile.activeAssistant;
 
     items.push({ type: "separator" });

--- a/apps/web/src/assistant/api.ts
+++ b/apps/web/src/assistant/api.ts
@@ -59,9 +59,27 @@ export type AcknowledgeAssistantDiskPressureResult =
   | { ok: true; status: number; data: DiskPressureStatusResponse }
   | { ok: false; status: number; error: Record<string, unknown> };
 
-export async function hatchAssistant(input?: HatchInput): Promise<HatchResult> {
+/**
+ * Hatch a managed assistant.
+ *
+ * `mode` maps to the platform's hatch semantics:
+ *   - `ensure` (server default when omitted): return an existing managed
+ *     assistant when possible, else create one. This is the auto-hatch /
+ *     first-run behavior — callers should leave `mode` unset for it.
+ *   - `create`: provision an *additional* assistant (when multi-assistant
+ *     hatching is enabled). Pass this to actually add a new one rather than
+ *     get handed back the existing assistant.
+ *
+ * `status` distinguishes the outcome: 201 = newly created, 200 = an existing
+ * assistant was returned (a `create` that the server deduped/declined).
+ */
+export async function hatchAssistant(
+  input?: HatchInput,
+  mode?: "create" | "ensure",
+): Promise<HatchResult> {
   const { data, error, response } = await assistantsHatchCreate({
     body: input ?? {},
+    query: mode ? { mode } : undefined,
     throwOnError: false,
   });
 

--- a/apps/web/src/assistant/create-platform-assistant.test.ts
+++ b/apps/web/src/assistant/create-platform-assistant.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Unit tests for `createPlatformAssistant` — the primitive behind the tray
+ * "New Assistant…" command. It must hatch with `mode: "create"` (so an
+ * *additional* assistant is provisioned, not the existing one returned),
+ * refresh the lockfile, and switch to the new assistant.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+let hatchResult:
+  | { ok: true; status: number; data: { id: string } }
+  | { ok: false; status: number; error: Record<string, unknown> } = {
+  ok: true,
+  status: 201,
+  data: { id: "ast-new" },
+};
+
+const hatchAssistantMock = mock(
+  async (_input?: unknown, _mode?: string) => hatchResult,
+);
+const listAssistantsMock = mock(async () => ({
+  ok: true as const,
+  status: 200,
+  data: [{ id: "ast-new", is_local: false, created: "" }],
+}));
+const selectPlatformAssistantMock = mock(async (_id: string) => {});
+const syncPlatformAssistantsToLockfileMock = mock(async (_a: unknown) => {});
+
+mock.module("@/assistant/api", () => ({
+  hatchAssistant: hatchAssistantMock,
+  listAssistants: listAssistantsMock,
+}));
+mock.module("@/assistant/select-platform-assistant", () => ({
+  selectPlatformAssistant: selectPlatformAssistantMock,
+}));
+mock.module("@/lib/local-mode", () => ({
+  syncPlatformAssistantsToLockfile: syncPlatformAssistantsToLockfileMock,
+}));
+mock.module("@/utils/api-errors", () => ({
+  extractErrorMessage: (e: unknown, _r: unknown, fallback?: string) =>
+    e && typeof e === "object" && typeof (e as { detail?: unknown }).detail === "string"
+      ? (e as { detail: string }).detail
+      : (fallback ?? "error"),
+}));
+
+const { createPlatformAssistant } = await import("./create-platform-assistant");
+
+beforeEach(() => {
+  hatchResult = { ok: true, status: 201, data: { id: "ast-new" } };
+  hatchAssistantMock.mockClear();
+  listAssistantsMock.mockClear();
+  selectPlatformAssistantMock.mockClear();
+  syncPlatformAssistantsToLockfileMock.mockClear();
+});
+
+describe("createPlatformAssistant", () => {
+  test("hatches with mode=create, syncs the lockfile, and switches to the new id", async () => {
+    const result = await createPlatformAssistant("My Bot");
+    expect(hatchAssistantMock).toHaveBeenCalledWith({ name: "My Bot" }, "create");
+    expect(syncPlatformAssistantsToLockfileMock).toHaveBeenCalled();
+    expect(selectPlatformAssistantMock).toHaveBeenCalledWith("ast-new");
+    expect(result).toEqual({ ok: true, id: "ast-new" });
+  });
+
+  test("omits the body when no name is given (still mode=create)", async () => {
+    await createPlatformAssistant();
+    expect(hatchAssistantMock).toHaveBeenCalledWith(undefined, "create");
+  });
+
+  test("returns an error and does not switch when hatch fails", async () => {
+    hatchResult = { ok: false, status: 500, error: { detail: "boom" } };
+    const result = await createPlatformAssistant("x");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBe("boom");
+    expect(selectPlatformAssistantMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/assistant/create-platform-assistant.ts
+++ b/apps/web/src/assistant/create-platform-assistant.ts
@@ -1,0 +1,50 @@
+import { hatchAssistant, listAssistants } from "@/assistant/api";
+import { selectPlatformAssistant } from "@/assistant/select-platform-assistant";
+import { syncPlatformAssistantsToLockfile } from "@/lib/local-mode";
+import { extractErrorMessage } from "@/utils/api-errors";
+
+export type CreatePlatformAssistantResult =
+  | { ok: true; id: string }
+  | { ok: false; error: string };
+
+/**
+ * Create a new managed (platform-hosted) assistant and switch to it.
+ *
+ * Mirrors the native client's "New Assistant" flow: hatch with `mode: "create"`
+ * so the platform provisions an *additional* assistant (rather than `ensure`,
+ * which hands back the existing one), refresh the lockfile so the new entry is
+ * present for the tray/CLI, then select it via `selectPlatformAssistant`.
+ *
+ * The new assistant starts in `initializing`; the lifecycle resolves it to
+ * `active` once the platform finishes provisioning. Never throws — failures
+ * come back as `{ ok: false, error }`.
+ */
+export async function createPlatformAssistant(
+  name?: string,
+): Promise<CreatePlatformAssistantResult> {
+  const result = await hatchAssistant(name ? { name } : undefined, "create");
+  if (!result.ok) {
+    return {
+      ok: false,
+      error: extractErrorMessage(
+        result.error,
+        undefined,
+        "Failed to create assistant.",
+      ),
+    };
+  }
+
+  // Best-effort: refresh the lockfile so the new assistant shows up for the
+  // tray/CLI. The assistant was created regardless of whether this succeeds.
+  try {
+    const remaining = await listAssistants();
+    if (remaining.ok) {
+      await syncPlatformAssistantsToLockfile(remaining.data);
+    }
+  } catch {
+    // non-fatal
+  }
+
+  await selectPlatformAssistant(result.data.id);
+  return { ok: true, id: result.data.id };
+}

--- a/apps/web/src/assistant/hatch-assistant.test.ts
+++ b/apps/web/src/assistant/hatch-assistant.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit test for `hatchAssistant`'s `mode` passthrough.
+ *
+ * The developer "Hatch New Assistant" button needs `mode=create` to actually
+ * provision an additional assistant; omitting it lets the platform default to
+ * `ensure` and hand back the existing one. This pins that the query param is
+ * sent only when a mode is given (so the auto-hatch callers stay on `ensure`).
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+type HatchCall = { body?: unknown; query?: unknown; throwOnError?: boolean };
+
+const hatchCreateMock = mock(async (_opts: HatchCall) => ({
+  data: { id: "ast-new" },
+  error: undefined,
+  response: { ok: true, status: 201 },
+}));
+
+// `api.ts` imports many names from sdk.gen at module load, and bun throws on
+// any missing named export — so stub them all. Only assistantsHatchCreate is
+// exercised here.
+const noop = mock(async () => ({
+  data: undefined,
+  error: undefined,
+  response: { ok: true, status: 200 },
+}));
+mock.module("@/generated/api/sdk.gen", () => ({
+  assistantsActivateCreate: noop,
+  assistantsBackupsCreate: noop,
+  assistantsBackupsRestoreCreate: noop,
+  assistantsBackupsRetrieve: noop,
+  assistantsHatchCreate: hatchCreateMock,
+  assistantsList: noop,
+  assistantsRestartDetailCreate: noop,
+  assistantsRetireDetailDestroy: noop,
+  assistantsRetireDestroy: noop,
+  assistantsRetrieve: noop,
+}));
+
+const { hatchAssistant } = await import("./api");
+
+beforeEach(() => {
+  hatchCreateMock.mockClear();
+});
+
+describe("hatchAssistant", () => {
+  test("omits the mode query by default (ensure semantics for auto-hatch)", async () => {
+    await hatchAssistant();
+    expect(hatchCreateMock.mock.calls[0]?.[0].query).toBeUndefined();
+  });
+
+  test("sends mode=create to provision an additional assistant", async () => {
+    const result = await hatchAssistant(undefined, "create");
+    expect(hatchCreateMock.mock.calls[0]?.[0].query).toEqual({ mode: "create" });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.status).toBe(201);
+      expect(result.data.id).toBe("ast-new");
+    }
+  });
+});

--- a/apps/web/src/assistant/lifecycle-service.ts
+++ b/apps/web/src/assistant/lifecycle-service.ts
@@ -39,7 +39,11 @@ import {
   resolveAssistantLifecycleState,
   shouldRecoverFromHatchFailure,
 } from "@/assistant/lifecycle";
-import { ASSISTANT_QUERY_KEY, POLL_INTERVAL_MS } from "@/assistant/queries";
+import {
+  ASSISTANT_QUERY_KEY,
+  assistantQueryKey,
+  POLL_INTERVAL_MS,
+} from "@/assistant/queries";
 import { useAssistantSelectionStore } from "@/assistant/selection-store";
 import type { AssistantState } from "@/assistant/types";
 import { extractErrorMessage } from "@/utils/api-errors";
@@ -73,6 +77,12 @@ export interface LifecycleServiceInputs {
   }) => string | null;
   /** The TanStack Query client owned by `RootLayout`'s provider. */
   queryClient: QueryClient;
+  /**
+   * The platform assistant the user has selected (multi-assistant). `null`
+   * resolves the default first-listed assistant — the pre-multi-assistant
+   * behavior. Optional so existing `setInputs` callers/tests need no change.
+   */
+  selectedPlatformAssistantId?: string | null;
 }
 
 const NOOP_REDIRECT = (_: string) => {};
@@ -112,6 +122,7 @@ class AssistantLifecycleService {
     onRedirect: NOOP_REDIRECT,
     resolveOnboardingRedirect: NOOP_RESOLVE,
     queryClient: null as unknown as QueryClient,
+    selectedPlatformAssistantId: null,
   };
 
   // ---------------------------------------------------------------------------
@@ -222,9 +233,10 @@ class AssistantLifecycleService {
       // network so a 10s-old cached 404 or initializing result
       // doesn't silently replay. Poll-driven projections go through
       // `applyServerResult` to avoid the read-back loop.
+      const selectedId = this.inputs.selectedPlatformAssistantId ?? null;
       const result = await this.inputs.queryClient.fetchQuery({
-        queryKey: ASSISTANT_QUERY_KEY,
-        queryFn: () => getAssistant(),
+        queryKey: assistantQueryKey(selectedId),
+        queryFn: () => getAssistant(selectedId ?? undefined),
         staleTime: 0,
       });
       if (generation !== this.generation) return;

--- a/apps/web/src/assistant/queries.test.ts
+++ b/apps/web/src/assistant/queries.test.ts
@@ -9,8 +9,29 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { pollIntervalFor, POLL_INTERVAL_MS } from "@/assistant/queries";
+import {
+  ASSISTANT_QUERY_KEY,
+  assistantQueryKey,
+  pollIntervalFor,
+  POLL_INTERVAL_MS,
+} from "@/assistant/queries";
 import type { Assistant, GetAssistantResult } from "@/assistant/api";
+
+describe("assistantQueryKey", () => {
+  test("returns the base key by reference when nothing is selected (off-path is byte-identical)", () => {
+    // Same reference, not just a deep-equal copy — so every existing
+    // setQueryData / invalidate site that uses ASSISTANT_QUERY_KEY keeps
+    // matching when multi-assistant is off.
+    expect(assistantQueryKey()).toBe(ASSISTANT_QUERY_KEY);
+    expect(assistantQueryKey(null)).toBe(ASSISTANT_QUERY_KEY);
+  });
+
+  test("suffixes the selected id so a switch is a distinct cache key", () => {
+    expect(assistantQueryKey("ast-2")).toEqual([...ASSISTANT_QUERY_KEY, "ast-2"]);
+    expect(assistantQueryKey("ast-2")).not.toBe(ASSISTANT_QUERY_KEY);
+    expect(assistantQueryKey("ast-2")).not.toEqual(assistantQueryKey("ast-3"));
+  });
+});
 
 function okResult(
   status: "active" | "initializing" | "to_be_deleted",

--- a/apps/web/src/assistant/queries.ts
+++ b/apps/web/src/assistant/queries.ts
@@ -77,6 +77,24 @@ export function pollIntervalFor(
   return TRANSIENT_PHASES.has(phase.kind) ? POLL_INTERVAL_MS : false;
 }
 
+/**
+ * Cache key for the `/assistant/` resolution.
+ *
+ * When no platform assistant is explicitly selected (single-assistant
+ * accounts, or the `multi-platform-assistant` flag off) this is exactly
+ * `ASSISTANT_QUERY_KEY` — so every existing `setQueryData` / `invalidate`
+ * site keeps matching and the resolution path is byte-identical to before
+ * multi-assistant. When an id is selected the key is suffixed with it, so
+ * switching assistants is a key change that triggers a fresh resolve.
+ */
+export function assistantQueryKey(
+  selectedPlatformAssistantId?: string | null,
+): readonly unknown[] {
+  return selectedPlatformAssistantId
+    ? [...ASSISTANT_QUERY_KEY, selectedPlatformAssistantId]
+    : ASSISTANT_QUERY_KEY;
+}
+
 export interface UseAssistantQueryOptions {
   /**
    * Disables the query when false. Used to short-circuit the fetch
@@ -84,12 +102,19 @@ export interface UseAssistantQueryOptions {
    * session is actually available.
    */
   enabled: boolean;
+  /**
+   * The platform assistant the user has selected, when multi-assistant
+   * is active. `null`/absent resolves the default (first listed) assistant —
+   * the pre-multi-assistant behavior.
+   */
+  selectedPlatformAssistantId?: string | null;
 }
 
 export function useAssistantQuery(options: UseAssistantQueryOptions) {
+  const selectedId = options.selectedPlatformAssistantId ?? null;
   return useQuery<GetAssistantResult>({
-    queryKey: ASSISTANT_QUERY_KEY,
-    queryFn: () => getAssistant(),
+    queryKey: assistantQueryKey(selectedId),
+    queryFn: () => getAssistant(selectedId ?? undefined),
     enabled: options.enabled,
     retry: false,
     refetchInterval: (query) => pollIntervalFor(query.state.data),

--- a/apps/web/src/assistant/select-platform-assistant.test.ts
+++ b/apps/web/src/assistant/select-platform-assistant.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Unit tests for `selectPlatformAssistant` — the single primitive both the
+ * settings picker and (later) the tray use to switch the active platform
+ * assistant. It records the per-org selection (the source the lifecycle
+ * re-resolves from) and mirrors it into the lockfile for the tray/CLI/native.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+let orgId: string | null = "org-1";
+
+const setAssistantIdMock = mock((_orgId: string, _id: string | null) => {});
+const setActiveLockfileAssistantMock = mock(async (_id: string) => {});
+
+mock.module("@/lib/local-mode", () => ({
+  setActiveLockfileAssistant: setActiveLockfileAssistantMock,
+}));
+mock.module("@/stores/current-platform-assistant-store", () => ({
+  useCurrentPlatformAssistantStore: {
+    getState: () => ({ setAssistantId: setAssistantIdMock }),
+  },
+}));
+mock.module("@/stores/organization-store", () => ({
+  useOrganizationStore: {
+    getState: () => ({ currentOrganizationId: orgId }),
+  },
+}));
+
+const { selectPlatformAssistant } = await import("./select-platform-assistant");
+
+beforeEach(() => {
+  orgId = "org-1";
+  setAssistantIdMock.mockClear();
+  setActiveLockfileAssistantMock.mockClear();
+});
+
+describe("selectPlatformAssistant", () => {
+  test("records the per-org selection and mirrors it into the lockfile", async () => {
+    await selectPlatformAssistant("ast-2");
+    expect(setAssistantIdMock).toHaveBeenCalledWith("org-1", "ast-2");
+    expect(setActiveLockfileAssistantMock).toHaveBeenCalledWith("ast-2");
+  });
+
+  test("skips the per-org write when there is no current org but still mirrors the lockfile", async () => {
+    orgId = null;
+    await selectPlatformAssistant("ast-2");
+    expect(setAssistantIdMock).not.toHaveBeenCalled();
+    expect(setActiveLockfileAssistantMock).toHaveBeenCalledWith("ast-2");
+  });
+});

--- a/apps/web/src/assistant/select-platform-assistant.ts
+++ b/apps/web/src/assistant/select-platform-assistant.ts
@@ -1,0 +1,28 @@
+import { setActiveLockfileAssistant } from "@/lib/local-mode";
+import { useCurrentPlatformAssistantStore } from "@/stores/current-platform-assistant-store";
+import { useOrganizationStore } from "@/stores/organization-store";
+
+/**
+ * Switch the active platform assistant.
+ *
+ * Writes the per-org selection — the source `use-lifecycle.ts` resolves the
+ * active assistant from when the `multi-platform-assistant` flag is on — and
+ * mirrors it into the lockfile `activeAssistant` so the macOS tray, the CLI,
+ * and the native client agree (a no-op in the browser, where there is no
+ * lockfile host).
+ *
+ * The lifecycle reacts to the per-org store change (it subscribes to `byOrg`)
+ * and re-resolves to the selected assistant, so callers don't need to drive
+ * the switch imperatively — just record the selection here.
+ */
+export async function selectPlatformAssistant(
+  assistantId: string,
+): Promise<void> {
+  const orgId = useOrganizationStore.getState().currentOrganizationId;
+  if (orgId) {
+    useCurrentPlatformAssistantStore
+      .getState()
+      .setAssistantId(orgId, assistantId);
+  }
+  await setActiveLockfileAssistant(assistantId);
+}

--- a/apps/web/src/assistant/use-lifecycle.ts
+++ b/apps/web/src/assistant/use-lifecycle.ts
@@ -20,6 +20,9 @@ import { useAssistantQuery } from "@/assistant/queries";
 import { isGatewayAuthMode } from "@/lib/auth/gateway-session";
 import { isLocalMode } from "@/lib/local-mode";
 import { isAuthenticated, type SessionStatus } from "@/stores/session-status";
+import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
+import { useCurrentPlatformAssistantStore } from "@/stores/current-platform-assistant-store";
+import { useOrganizationStore } from "@/stores/organization-store";
 
 interface UseAssistantLifecycleOptions {
   sessionStatus: SessionStatus;
@@ -57,8 +60,29 @@ export function useAssistantLifecycle({
     !isGatewayAuthMode() &&
     (hasPlatformSession || !isLocalMode());
 
+  // Which platform assistant the user has selected, gated by the
+  // multi-platform-assistant flag and to platform mode only. When the flag
+  // is off (or no selection / not platform mode) this stays null, so the
+  // resolution falls back to the default first-listed assistant — identical
+  // to the pre-multi-assistant behavior. A change here flows into the
+  // service via `setInputs` → `respondToInputs` → `checkAssistant`, which
+  // re-resolves and projects the newly selected assistant.
+  const multiAssistantEnabled =
+    useAssistantFeatureFlagStore.use.multiPlatformAssistant();
+  const currentOrganizationId =
+    useOrganizationStore.use.currentOrganizationId();
+  const byOrg = useCurrentPlatformAssistantStore.use.byOrg();
+  const selectedPlatformAssistantId =
+    multiAssistantEnabled &&
+    !isGatewayAuthMode() &&
+    !isLocalMode() &&
+    currentOrganizationId
+      ? (byOrg[currentOrganizationId] ?? null)
+      : null;
+
   const { data: assistantResult } = useAssistantQuery({
     enabled: shouldQueryServer,
+    selectedPlatformAssistantId,
   });
 
   // Push inputs into the service and let it react. The service is a
@@ -74,6 +98,7 @@ export function useAssistantLifecycle({
       onRedirect,
       resolveOnboardingRedirect,
       queryClient,
+      selectedPlatformAssistantId,
     });
     void lifecycleService.respondToInputs();
   }, [
@@ -84,6 +109,7 @@ export function useAssistantLifecycle({
     onRedirect,
     resolveOnboardingRedirect,
     queryClient,
+    selectedPlatformAssistantId,
   ]);
 
   // Hand poll results to the service — it decides whether to

--- a/apps/web/src/components/create-assistant-dialog.tsx
+++ b/apps/web/src/components/create-assistant-dialog.tsx
@@ -1,0 +1,86 @@
+import { Loader2 } from "lucide-react";
+import { useState } from "react";
+
+import { createPlatformAssistant } from "@/assistant/create-platform-assistant";
+import { Button } from "@vellumai/design-library/components/button";
+import { Input } from "@vellumai/design-library/components/input";
+import { Modal } from "@vellumai/design-library/components/modal";
+import { toast } from "@vellumai/design-library/components/toast";
+
+interface CreateAssistantDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Name-prompt dialog for the tray "New Assistant…" command. Mirrors the native
+ * client: prompt for an optional name, hatch an *additional* managed assistant
+ * (`mode: "create"`), and switch to it. Hosted in RootLayout and opened by the
+ * `createAssistant` command handler. (Electron disables `window.prompt`, so a
+ * real dialog is required rather than a native prompt.)
+ */
+export function CreateAssistantDialog({
+  open,
+  onClose,
+}: CreateAssistantDialogProps) {
+  const [name, setName] = useState("");
+  const [pending, setPending] = useState(false);
+
+  const handleCreate = async () => {
+    setPending(true);
+    const result = await createPlatformAssistant(name.trim() || undefined);
+    setPending(false);
+    if (result.ok) {
+      toast.success("New assistant created.");
+      setName("");
+      onClose();
+      return;
+    }
+    toast.error(result.error);
+  };
+
+  return (
+    <Modal.Root
+      open={open}
+      onOpenChange={(next) => {
+        if (!next && !pending) onClose();
+      }}
+    >
+      <Modal.Content size="sm">
+        <Modal.Header>
+          <Modal.Title>New Assistant</Modal.Title>
+          <Modal.Description>
+            Provision a new assistant. It will start up in the background.
+          </Modal.Description>
+        </Modal.Header>
+        <Modal.Body>
+          <Input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Assistant name (optional)"
+            autoFocus
+            disabled={pending}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !pending) void handleCreate();
+            }}
+          />
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="outlined" onClick={onClose} disabled={pending}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            onClick={() => void handleCreate()}
+            disabled={pending}
+            leftIcon={
+              pending ? <Loader2 className="animate-spin" /> : undefined
+            }
+          >
+            Create
+          </Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal.Root>
+  );
+}

--- a/apps/web/src/domains/settings/components/assistant-picker.tsx
+++ b/apps/web/src/domains/settings/components/assistant-picker.tsx
@@ -1,5 +1,6 @@
 import { Check, Monitor } from "lucide-react";
 
+import { selectPlatformAssistant } from "@/assistant/select-platform-assistant";
 import { DetailCard } from "@/components/detail-card";
 import { useCurrentPlatformAssistant } from "@/hooks/use-current-platform-assistant";
 import { Button } from "@vellumai/design-library/components/button";
@@ -9,7 +10,6 @@ import { toast } from "@vellumai/design-library/components/toast";
 export function AssistantPicker() {
   const {
     assistantId: activeAssistantId,
-    setAssistantId,
     isLoading,
     platformAssistants,
   } = useCurrentPlatformAssistant();
@@ -62,7 +62,7 @@ export function AssistantPicker() {
                     size="compact"
                     disabled={a.status !== "active"}
                     onClick={() => {
-                      setAssistantId(a.id);
+                      void selectPlatformAssistant(a.id);
                       toast.success("Switched active assistant.");
                     }}
                   >

--- a/apps/web/src/domains/settings/components/panels/assistant-lifecycle-panel.tsx
+++ b/apps/web/src/domains/settings/components/panels/assistant-lifecycle-panel.tsx
@@ -2,8 +2,9 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Loader2 } from "lucide-react";
 import { useState } from "react";
 
-import { hatchAssistant } from "@/assistant/api";
+import { hatchAssistant, listAssistants } from "@/assistant/api";
 import { DetailCard } from "@/components/detail-card";
+import { isLocalMode, syncPlatformAssistantsToLockfile } from "@/lib/local-mode";
 import {
     assistantsActiveRetrieveOptions,
     assistantsListOptions,
@@ -39,6 +40,23 @@ export function AssistantLifecyclePanel() {
       // existing assistant — the button then looked like a no-op.
       const result = await hatchAssistant(undefined, "create");
       if (result.ok) {
+        // Mirror the freshly hatched assistant into the lockfile so the macOS
+        // tray and CLI pick it up immediately. Unlike onboarding / the tray
+        // "New Assistant" flow, this developer button is otherwise the one
+        // managed-assistant creation path that never reconciled the lockfile —
+        // newly hatched assistants stayed invisible to the tray until the next
+        // session refresh. Best-effort and local-mode only; the hatch already
+        // succeeded regardless of the sync outcome.
+        if (isLocalMode()) {
+          try {
+            const list = await listAssistants();
+            if (list.ok) {
+              await syncPlatformAssistantsToLockfile(list.data);
+            }
+          } catch {
+            // Sync failed — the assistant was still created.
+          }
+        }
         // 201 = newly created; 200 = server returned the existing assistant
         // (multi-assistant hatching disabled / deduped). Report honestly
         // instead of always claiming a new one was made.

--- a/apps/web/src/domains/settings/components/panels/assistant-lifecycle-panel.tsx
+++ b/apps/web/src/domains/settings/components/panels/assistant-lifecycle-panel.tsx
@@ -34,10 +34,29 @@ export function AssistantLifecyclePanel() {
     setHatchConfirmOpen(false);
     setHatching(true);
     try {
-      const result = await hatchAssistant();
+      // `create` mode so this actually provisions an *additional* assistant.
+      // Without it the platform defaults to `ensure` and hands back the
+      // existing assistant — the button then looked like a no-op.
+      const result = await hatchAssistant(undefined, "create");
       if (result.ok) {
-        toast.success("New assistant hatched successfully.");
-        void queryClient.invalidateQueries({ queryKey: ["assistants"] });
+        // 201 = newly created; 200 = server returned the existing assistant
+        // (multi-assistant hatching disabled / deduped). Report honestly
+        // instead of always claiming a new one was made.
+        toast.success(
+          result.status === 201
+            ? "New assistant hatched successfully."
+            : "Returned your existing assistant — no new one was created.",
+        );
+        // Invalidate the panel's own queries by their real generated keys so
+        // the info + list cards refresh (the previous `["assistants"]` key
+        // matched none of them).
+        void queryClient.invalidateQueries({
+          queryKey: assistantsActiveRetrieveOptions().queryKey,
+        });
+        void queryClient.invalidateQueries({
+          queryKey: assistantsListOptions({ query: { hosting: "all" } })
+            .queryKey,
+        });
       } else {
         const detail =
           typeof result.error?.detail === "string"

--- a/apps/web/src/lib/local-mode.ts
+++ b/apps/web/src/lib/local-mode.ts
@@ -133,6 +133,26 @@ export async function saveLockfileAssistant(
 }
 
 /**
+ * Mark an already-known assistant as the lockfile's active assistant, leaving
+ * its other fields untouched. Used when switching managed assistants so the
+ * lockfile `activeAssistant` — read by the macOS tray, the CLI, and the native
+ * client — tracks the in-app selection. No-ops in the browser (no lockfile
+ * host) and when the id isn't a known entry.
+ */
+export async function setActiveLockfileAssistant(
+  assistantId: string,
+): Promise<void> {
+  const entry = getLockfile().assistants.find(
+    (a) => a.assistantId === assistantId,
+  );
+  if (!entry) return;
+  const result = await saveLockfileAssistantHost({ ...entry }, assistantId);
+  if (result.ok) {
+    commitLockfile(result.lockfile);
+  }
+}
+
+/**
  * Replace all platform-hosted assistant entries in the lockfile with the
  * current set from the API. Removes stale entries and adds new ones atomically.
  */

--- a/apps/web/src/root-layout.tsx
+++ b/apps/web/src/root-layout.tsx
@@ -41,6 +41,7 @@ import { useElectronStatusSync } from "@/hooks/use-electron-status-sync";
 import { useElectronFeatureFlagBridge } from "@/runtime/electron-feature-flags";
 import { TimezoneSync } from "@/components/timezone-sync";
 import { retireAssistant } from "@/assistant/retire-service";
+import { selectPlatformAssistant } from "@/assistant/select-platform-assistant";
 import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
 import { toast } from "@vellumai/design-library/components/toast";
 
@@ -167,7 +168,10 @@ export function RootLayout() {
     shareFeedback: () => setFeedbackOpen(true),
     selectAssistant: (command) => {
       if (command.kind === "selectAssistant") {
-        void useAuthStore.getState().connectLocalAssistant(command.assistantId);
+        // The tray lists managed (platform-hosted) assistants, so switching
+        // goes through the platform selection path — not connectLocalAssistant,
+        // which primes a local gateway and no-ops for managed assistants.
+        void selectPlatformAssistant(command.assistantId);
       }
     },
     createAssistant: () => {

--- a/apps/web/src/root-layout.tsx
+++ b/apps/web/src/root-layout.tsx
@@ -42,6 +42,7 @@ import { useElectronFeatureFlagBridge } from "@/runtime/electron-feature-flags";
 import { TimezoneSync } from "@/components/timezone-sync";
 import { retireAssistant } from "@/assistant/retire-service";
 import { selectPlatformAssistant } from "@/assistant/select-platform-assistant";
+import { CreateAssistantDialog } from "@/components/create-assistant-dialog";
 import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
 import { toast } from "@vellumai/design-library/components/toast";
 
@@ -147,6 +148,8 @@ export function RootLayout() {
   // the retire can run without first routing the user to settings.
   const [retireId, setRetireId] = useState<string | null>(null);
   const [retirePending, setRetirePending] = useState(false);
+  // Whether the tray "New Assistant…" name-prompt dialog is open.
+  const [createOpen, setCreateOpen] = useState(false);
 
   useVellumCommands({
     openSettings: () => {
@@ -175,7 +178,7 @@ export function RootLayout() {
       }
     },
     createAssistant: () => {
-      void navigate(routes.onboarding.prechat);
+      setCreateOpen(true);
     },
     retireAssistant: (command) => {
       if (command.kind === "retireAssistant") {
@@ -284,6 +287,13 @@ export function RootLayout() {
         isPending={retirePending}
         onConfirm={handleConfirmRetire}
         onCancel={() => setRetireId(null)}
+      />
+
+      {/* Name-prompt for the tray "New Assistant…" command — hatches an
+          additional managed assistant and switches to it. */}
+      <CreateAssistantDialog
+        open={createOpen}
+        onClose={() => setCreateOpen(false)}
       />
     </div>
   );

--- a/apps/web/src/stores/auth-store.test.ts
+++ b/apps/web/src/stores/auth-store.test.ts
@@ -37,6 +37,14 @@ let mockBiometricToken: string | null = null;
 const installSessionCookiesMock = mock((_token: string) => {});
 const retrieveBiometricTokenMock = mock(async () => mockBiometricToken);
 
+// Controls the managed-assistant list returned to the lockfile-sync path and
+// spies on the sync itself. Default `listAssistants` to the legacy `[]` shape
+// (whose missing `.ok` short-circuits the sync) so existing tests are
+// unaffected; the reconciliation tests override it to a well-formed result.
+let mockListAssistantsResult: unknown = [];
+const listAssistantsMock = mock(async () => mockListAssistantsResult);
+const syncPlatformAssistantsToLockfileMock = mock(async (_list: unknown) => {});
+
 mock.module("@/lib/auth/allauth-client", () => ({
   getSession: async () => {
     getSessionCallCount++;
@@ -73,7 +81,7 @@ mock.module("@/lib/local-mode", () => ({
   primeLocalGatewayConnection: primeLocalGatewayConnectionMock,
   primeLocalGatewayConnectionWithRepair:
     primeLocalGatewayConnectionWithRepairMock,
-  syncPlatformAssistantsToLockfile: async () => {},
+  syncPlatformAssistantsToLockfile: syncPlatformAssistantsToLockfileMock,
 }));
 
 mock.module("@/runtime/native-auth", () => ({
@@ -122,7 +130,7 @@ mock.module("@/assistant/lifecycle-service", () => ({
 // `auth-store` actually uses; the real module load would crash
 // before any test runs.
 mock.module("@/assistant/api", () => ({
-  listAssistants: async () => [],
+  listAssistants: listAssistantsMock,
 }));
 
 const { useAuthStore } = await import("@/stores/auth-store");
@@ -159,6 +167,9 @@ beforeEach(() => {
   installSessionCookiesMock.mockClear();
   retrieveBiometricTokenMock.mockClear();
   lifecycleResetForLogoutMock.mockClear();
+  mockListAssistantsResult = [];
+  listAssistantsMock.mockClear();
+  syncPlatformAssistantsToLockfileMock.mockClear();
   resetAuthStore();
 });
 
@@ -179,6 +190,42 @@ describe("auth store onboarding flag reconciliation", () => {
 
     expect(syncOnboardingUserMock).toHaveBeenCalledWith("user-2");
     expect(useAuthStore.getState().user?.id).toBe("user-2");
+  });
+
+  test("refreshSession reconciles the lockfile mirror in local mode", async () => {
+    // Regression: a session refresh (app resume, profile save, provider
+    // callback) must re-sync managed assistants into the lockfile — not only
+    // cold `initSession` — so the macOS tray and CLI don't keep a stale list
+    // until the next full boot.
+    mockIsLocalMode = true;
+    sessionUser = { id: "user-3", email: "user@example.com" };
+    mockListAssistantsResult = {
+      ok: true,
+      status: 200,
+      data: [{ id: "assistant-3", is_local: false, created: "2026-06-05T00:00:00Z" }],
+    };
+
+    await expect(useAuthStore.getState().refreshSession()).resolves.toBe(true);
+
+    expect(listAssistantsMock).toHaveBeenCalled();
+    expect(syncPlatformAssistantsToLockfileMock).toHaveBeenCalledWith([
+      { id: "assistant-3", is_local: false, created: "2026-06-05T00:00:00Z" },
+    ]);
+  });
+
+  test("refreshSession skips lockfile sync outside local mode", async () => {
+    // Platform mode has no lockfile host — the sync must not run there.
+    mockIsLocalMode = false;
+    sessionUser = { id: "user-4", email: "user@example.com" };
+    mockListAssistantsResult = {
+      ok: true,
+      status: 200,
+      data: [{ id: "assistant-4", is_local: false, created: "2026-06-05T00:00:00Z" }],
+    };
+
+    await expect(useAuthStore.getState().refreshSession()).resolves.toBe(true);
+
+    expect(syncPlatformAssistantsToLockfileMock).not.toHaveBeenCalled();
   });
 
   test("logout clears onboarding flags directly", async () => {

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -444,6 +444,22 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
       if (result.ok && result.data.user) {
         const user = toAuthUser(result.data.user);
         syncUserScopedState(user?.id ?? null);
+        // Reconcile the lockfile mirror on refresh too — not just cold
+        // `initSession`. App resume, profile save, and the provider callback
+        // all route through here; without this the macOS tray and CLI keep a
+        // stale managed-assistant list until the next full boot. Best-effort
+        // and local-mode only (platform mode has no lockfile host); the
+        // refresh has already succeeded regardless of the sync outcome.
+        if (isLocalMode()) {
+          try {
+            const apiAssistants = await listAssistants();
+            if (apiAssistants.ok) {
+              await syncPlatformAssistantsToLockfile(apiAssistants.data);
+            }
+          } catch {
+            // Sync failed — continue with cached lockfile data.
+          }
+        }
         set(authenticatedPlatformUser(user));
         return true;
       }


### PR DESCRIPTION
## Summary

Wires up the multi-assistant tray feature (follow-up to #33654). It makes the app actually honor a *selected* platform assistant, makes the settings picker and the tray **switch** real, adds tray **"New Assistant"** (create), and fixes the developer hatch button along the way. (The tray **Retire** action shipped separately in #33715, now merged.)

All behind the `multi-platform-assistant` flag (default off) — when off, the off-path is byte-identical to today.

## The bug this fixes

The app's active assistant was always resolved to **the first platform assistant the server lists**:
- `useAssistantQuery` fetched `getAssistant()` with no id, under a static cache key → `platformResults[0]`.
- The settings `AssistantPicker`'s `setAssistantId` wrote a per-org store that the **chat/lifecycle path never read** (it only re-scoped the logs pages).
- The tray's `selectAssistant` handler called `connectLocalAssistant`, which primes a **local gateway** and no-ops for managed/platform-hosted assistants.

So nothing could actually switch the assistant you chat with.

## Commits

**1. `feat(web): honor the selected platform assistant + make settings switch real` (Phase 0 — core)**
- `assistant/queries.ts` — `assistantQueryKey(id)`: returns the base `ASSISTANT_QUERY_KEY` **by reference** when nothing is selected (off-path byte-identical — every `setQueryData`/`invalidate` site keeps matching), suffixed with the id when one is selected. `useAssistantQuery` threads `selectedPlatformAssistantId` into the key + `getAssistant(id)`.
- `assistant/lifecycle-service.ts` — optional `selectedPlatformAssistantId` input; `checkAssistant` resolves `getAssistant(selectedId)` under the matching key. (`applyServerStateUpdate` already projects `active` unconditionally, so a re-resolve switches a stable app.)
- `assistant/use-lifecycle.ts` — computes the selected id from the per-org store, **gated by the flag + platform mode only** (null otherwise). A change flows through the existing `setInputs → respondToInputs → checkAssistant`.
- `assistant/select-platform-assistant.ts` (new) — `selectPlatformAssistant(id)` = per-org `setAssistantId` + lockfile `activeAssistant` mirror (`setActiveLockfileAssistant` in `lib/local-mode.ts`, no-op in the browser) so the tray/CLI/native client agree.
- `domains/settings/components/assistant-picker.tsx` — now calls `selectPlatformAssistant`, so settings switching actually switches.

**2. `fix(web): make the developer "Hatch New Assistant" button actually create one`**
- `hatchAssistant(input?, mode?)` — forwards `query: { mode }`. Auto-hatch callers leave it unset (`ensure`); the dev panel passes `mode: "create"` (was a no-op that returned the existing assistant + a misleading success toast). Now reports created (201) vs existing-returned (200), and invalidates the panel's real generated query keys (`["assistants"]` matched none of them, so the cards never refreshed).

**3. `feat: wire tray assistant switch to the platform selection (Phase 1)`**
- `apps/macos/.../tray.ts` — switcher list filtered to managed assistants (`cloud === "vellum"`), mirroring the native client's `isManaged` filter.
- `root-layout` — `selectAssistant` routes through `selectPlatformAssistant` instead of `connectLocalAssistant`.

**4. `feat(web): tray "New Assistant" creates an additional managed assistant (Phase 2)`**
- `assistant/create-platform-assistant.ts` (new) — `createPlatformAssistant(name?)`: hatch `mode: "create"` → refresh the lockfile → switch to the new assistant. It starts `initializing`; the lifecycle resolves it once provisioning completes.
- `components/create-assistant-dialog.tsx` (new) — name-prompt modal (Electron disables `window.prompt`, so a real dialog is required), hosted in RootLayout.
- `root-layout` — `createAssistant` opens the dialog (was: navigate to onboarding, which bounced an already-onboarded user back to chat).

## Why it's low-risk

When the flag is off (or no selection / not platform mode), `selectedPlatformAssistantId` is `null`, `assistantQueryKey(null) === ASSISTANT_QUERY_KEY` (same reference), and `getAssistant()` runs exactly as before. New UI surfaces (tray switch/create, settings picker) only render with the flag on.

## Test plan

- `assistant/queries.test.ts` — `assistantQueryKey` off-path identity (same reference) + suffixing.
- `assistant/select-platform-assistant.test.ts` — per-org selection + lockfile mirror; skips per-org write with no org.
- `assistant/hatch-assistant.test.ts` — `mode` passthrough (omitted by default, `{ mode: "create" }` when requested).
- `assistant/create-platform-assistant.test.ts` — hatch `mode:create` + lockfile sync + switch to new id; error path doesn't switch.
- Existing `lifecycle-service.test.ts`, `queries.test.ts`, and the 17 `tray.test.ts` tests still pass.
- `bunx tsc --noEmit` + `bun run lint` clean (web + macOS). CI runs each test file in its own process, so the `mock.module` graph is isolated.

## Open items / verification (can't fully run the app from here)

- **Electron platform-mode gate:** Phase 0's selected id is gated to `!isLocalMode()`. Confirm the Electron app reports *platform* mode (not local) for managed assistants — if it reports local, the tray switch won't take effect and the gate needs adjusting.
- **Functional E2E needs 2 active assistants:** a freshly hatched managed assistant only reaches `active` once the platform's post-hatch provisioning (API key + Vembda/k8s machine) completes — which doesn't happen on a local backend. Verify switch/create end-to-end on staging; locally you can DB-flip a row to `active` to smoke-test the switch *plumbing* (won't be a functional assistant).
- Manual happy path (flag on, org with ≥2 active platform assistants): Settings → Switch, and tray → switch / New Assistant → the **chat** assistant follows (sidebar/identity/conversations), not just logs scope.

## Follow-up (deferred)

- Unify the per-org store, lockfile `activeAssistant`, and `selection-store` into one `selectedPlatformAssistant` source of truth (broad refactor; out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)