### PR TITLE
Run missing ACP adapters via bun x instead of requiring npm

### DIFF
--- a/assistant/src/acp/__tests__/prepare-agent-env.test.ts
+++ b/assistant/src/acp/__tests__/prepare-agent-env.test.ts
@@ -216,6 +216,22 @@ describe("prepareAgentEnv — claude-agent-acp gating", () => {
     expect(prepared.env?.CLAUDE_CODE_OAUTH_TOKEN).toBe("vault-FFF");
   });
 
+  test("injects the token for the bunx-rewritten claude adapter (adapterCommand gate)", async () => {
+    // The resolver rewrites a missing claude-agent-acp binary to run via
+    // `bun x --bun <pkg>` and preserves the canonical identity on
+    // `adapterCommand`. Without this gate, bunx-resolved spawns would start
+    // with no auth and die as zombies on the first prompt.
+    seedVaultToken("vault-bunx");
+
+    const prepared = await prepareAgentEnv({
+      command: "bun",
+      args: ["x", "--bun", "@agentclientprotocol/claude-agent-acp"],
+      adapterCommand: "claude-agent-acp",
+    });
+
+    expect(prepared.env?.CLAUDE_CODE_OAUTH_TOKEN).toBe("vault-bunx");
+  });
+
   test("does NOT mutate the caller's agentConfig", async () => {
     seedVaultToken("vault-GGG");
     const original = {
@@ -239,6 +255,18 @@ describe("prepareAgentEnv — non-claude commands", () => {
     const prepared = await prepareAgentEnv({
       command: "codex-acp",
       args: [],
+    });
+
+    expect(prepared.env).toEqual({});
+  });
+
+  test("no injection for a bunx-rewritten non-claude adapter", async () => {
+    seedVaultToken("vault-should-not-leak");
+
+    const prepared = await prepareAgentEnv({
+      command: "bun",
+      args: ["x", "--bun", "@zed-industries/codex-acp"],
+      adapterCommand: "codex-acp",
     });
 
     expect(prepared.env).toEqual({});

--- a/assistant/src/acp/__tests__/session-manager-resume.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-resume.test.ts
@@ -49,7 +49,11 @@ class FakeAcpAgentProcess {
 
   constructor(
     public readonly agentId: string,
-    public readonly config: { command: string },
+    public readonly config: {
+      command: string;
+      args: string[];
+      adapterCommand?: string;
+    },
     private readonly clientFactory: (agent: unknown) => FakeClient,
   ) {
     fakeInstances.push(this);
@@ -132,7 +136,10 @@ mock.module("../prepare-agent-env.js", () => ({
 
 // Resolver stub: defaults to resolving every id to the claude adapter.
 type ResolveResult =
-  | { ok: true; agent: { command: string; args: string[] } }
+  | {
+      ok: true;
+      agent: { command: string; args: string[]; adapterCommand?: string };
+    }
   | { ok: false; reason: "binary_not_found"; hint: string; command: string };
 let resolveImpl: (id: string) => ResolveResult = () => ({
   ok: true,
@@ -172,7 +179,7 @@ function countHistoryRows(): number {
 // ---------------------------------------------------------------------------
 
 type ManagerInternals = {
-  sessions: Map<string, { clientHandler: FakeClient }>;
+  sessions: Map<string, { clientHandler: FakeClient; command: string }>;
   eventBuffers: Map<string, Array<{ update: AcpSessionUpdate }>>;
   pendingResumes: Map<string, Promise<void>>;
 };
@@ -320,6 +327,40 @@ describe("AcpSessionManager.resumeFromHistory", () => {
     expect(fake.killed).toBe(true);
     expect(internals(manager).sessions.has("no-caps-1")).toBe(false);
     expect(internals(manager).eventBuffers.has("no-caps-1")).toBe(false);
+  });
+
+  test("bunx-rewritten resolver output flows through resume with the canonical adapter command", async () => {
+    // resolveAcpAgent rewrites a missing claude-agent-acp binary to run via
+    // `bun x --bun <pkg>`; resumeFromHistory re-resolves through it, so the
+    // rewritten config must reach the agent process while the SessionEntry
+    // keeps the canonical adapter command (resume hints gate on it).
+    fakeCaps.resume = true;
+    insertHistoryRow({ id: "bunx-resume-1" });
+    resolveImpl = () => ({
+      ok: true,
+      agent: {
+        command: "bun",
+        args: ["x", "--bun", "@agentclientprotocol/claude-agent-acp"],
+        adapterCommand: "claude-agent-acp",
+      },
+    });
+
+    const manager = new AcpSessionManager(4);
+    await manager.resumeFromHistory("bunx-resume-1", () => {});
+
+    const fake = fakeInstances[0]!;
+    expect(fake.config.command).toBe("bun");
+    expect(fake.config.args).toEqual([
+      "x",
+      "--bun",
+      "@agentclientprotocol/claude-agent-acp",
+    ]);
+    expect(fake.resumeSessionCalls).toEqual([
+      { sessionId: "proto-old", cwd: "/tmp/proj" },
+    ]);
+    expect(
+      internals(manager).sessions.get("bunx-resume-1")!.command,
+    ).toBe("claude-agent-acp");
   });
 
   test("resolver failures surface the actionable hint", async () => {

--- a/assistant/src/acp/auto-install.test.ts
+++ b/assistant/src/acp/auto-install.test.ts
@@ -3,14 +3,24 @@
  *
  * `execFile` is stubbed via the shared `installExecFileStub` helper: a
  * process-global `mock.module("node:child_process", ...)` driven by per-call
- * scripted responses keyed on `${command} ${args[0]}`.
+ * scripted responses keyed on `${command} ${args[0]}`. The
+ * `resolveAgentWithAutoInstall` ordering suite additionally stubs the ACP
+ * config and `Bun.which` so it can flip bun / adapter-binary presence.
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { installAcpConfigStub } from "./__tests__/helpers/acp-config-stub.js";
 import { installExecFileStub } from "./__tests__/helpers/exec-file-stub.js";
+import { installWhichStub } from "./__tests__/helpers/which-stub.js";
 
 const { execScripts, execFileMock, reset } = installExecFileStub();
+const config = await installAcpConfigStub();
+const which = installWhichStub();
+
+afterAll(() => {
+  which.restore();
+});
 
 // Spread the real module so other test files that load logger consumers
 // (e.g. `truncateForLog` importers) after this process-global mock still
@@ -24,12 +34,17 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-const { ensureAdapterInstalled, _resetAdapterInstallCacheForTests } =
-  await import("./auto-install.js");
+const {
+  ensureAdapterInstalled,
+  resolveAgentWithAutoInstall,
+  _resetAdapterInstallCacheForTests,
+} = await import("./auto-install.js");
 
 beforeEach(() => {
   reset();
   _resetAdapterInstallCacheForTests();
+  config.setConfig({ agents: {} });
+  which.setWhich({});
 });
 
 describe("ensureAdapterInstalled", () => {
@@ -121,5 +136,61 @@ describe("ensureAdapterInstalled", () => {
       "@agentclientprotocol/claude-agent-acp",
       "@zed-industries/codex-acp",
     ]);
+  });
+});
+
+describe("resolveAgentWithAutoInstall - resolution order", () => {
+  test("binary missing + bun present: resolves via bunx without invoking npm", async () => {
+    which.setWhich({ bun: "/usr/local/bin/bun" });
+
+    const result = await resolveAgentWithAutoInstall("claude");
+
+    expect(result.resolved.ok).toBe(true);
+    if (!result.resolved.ok) return;
+    expect(result.resolved.agent.command).toBe("bun");
+    expect(result.resolved.agent.adapterCommand).toBe("claude-agent-acp");
+    expect(result.autoInstalledPackage).toBeUndefined();
+    expect(result.failureMessage).toBeUndefined();
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  test("binary + bun missing, npm install succeeds: falls back to the npm flow", async () => {
+    let installed = false;
+    which.setWhich((cmd) =>
+      installed && cmd === "claude-agent-acp"
+        ? "/usr/local/bin/claude-agent-acp"
+        : null,
+    );
+    execScripts.set("npm i", {
+      stdout: "",
+      onCall: () => {
+        installed = true;
+      },
+    });
+
+    const result = await resolveAgentWithAutoInstall("claude");
+
+    expect(result.resolved.ok).toBe(true);
+    if (!result.resolved.ok) return;
+    expect(result.resolved.agent.command).toBe("claude-agent-acp");
+    expect(result.autoInstalledPackage).toBe(
+      "@agentclientprotocol/claude-agent-acp",
+    );
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("binary, bun, and npm all missing: failure message carries the hint and install error", async () => {
+    execScripts.set("npm i", { error: new Error("spawn npm ENOENT") });
+
+    const result = await resolveAgentWithAutoInstall("claude");
+
+    expect(result.resolved.ok).toBe(false);
+    expect(result.failureMessage).toContain(
+      "claude-agent-acp is not on PATH",
+    );
+    expect(result.failureMessage).toContain(
+      "npm i -g @agentclientprotocol/claude-agent-acp",
+    );
+    expect(result.failureMessage).toContain("ENOENT");
   });
 });

--- a/assistant/src/acp/auto-install.ts
+++ b/assistant/src/acp/auto-install.ts
@@ -1,11 +1,14 @@
 /**
  * Silent auto-install for known ACP adapter binaries.
  *
- * When a spawn fails preflight with `binary_not_found`, callers (the
- * `acp_spawn` tool and the `/v1/acp/spawn` route) call
- * `resolveAgentWithAutoInstall(agentId)`, which tries a global npm install
- * of the mapped adapter package, then re-resolves and continues. On failure
- * they fall back to the existing actionable install hint.
+ * Fallback path: the resolver (`resolve-agent.ts`) already rewrites missing
+ * allowlisted adapters to run via `bun x` when `bun` is on PATH, so
+ * `binary_not_found` only reaches this module when bun is absent (or the
+ * command has no package mapping). When a spawn does fail preflight with
+ * `binary_not_found`, callers (the `acp_spawn` tool and the `/v1/acp/spawn`
+ * route) call `resolveAgentWithAutoInstall(agentId)`, which tries a global
+ * npm install of the mapped adapter package, then re-resolves and continues.
+ * On failure they fall back to the existing actionable install hint.
  *
  * Security boundary: only commands present in `DEFAULT_AGENT_NPM_PACKAGES`
  * are ever installed. The package names are vendored constants, NOT user

--- a/assistant/src/acp/prepare-agent-env.ts
+++ b/assistant/src/acp/prepare-agent-env.ts
@@ -20,14 +20,13 @@
  * owns the plaintext read boundary.
  */
 
-import { basename } from "node:path";
-
 import { FailedDependencyError } from "../runtime/routes/errors.js";
 import { credentialBroker } from "../tools/credentials/broker.js";
 import {
   getCredentialMetadata,
   upsertCredentialMetadata,
 } from "../tools/credentials/metadata-store.js";
+import { adapterCommandOf } from "./resolve-agent.js";
 import type { AcpAgentConfig } from "./types.js";
 
 const ACP_SPAWN_TOOL = "acp_spawn";
@@ -67,9 +66,13 @@ function ensureAcpTokenPolicy(): void {
  * credential is missing from both the user-supplied env override and the
  * secure store.
  *
- * Gating is keyed off the resolved agent COMMAND (basename), not the
- * user-facing agent id, so a custom `acp.agents.my-claude = { command:
- * "claude-agent-acp", ... }` alias still gets the env it needs.
+ * Gating is keyed off the canonical adapter identity (`adapterCommand` set
+ * by the resolver, falling back to the command basename for plain configs),
+ * not the user-facing agent id. A custom `acp.agents.my-claude = { command:
+ * "claude-agent-acp", ... }` alias still gets the env it needs, and so does
+ * the bunx-rewritten claude adapter (whose `command` is "bun"). Without
+ * the adapterCommand gate, bunx-resolved spawns would start with no auth
+ * and die as zombies on the first prompt.
  *
  * For `claude-agent-acp` the only required env var is
  * `CLAUDE_CODE_OAUTH_TOKEN`. Two provisioning routes converge on it, with
@@ -92,9 +95,8 @@ export async function prepareAgentEnv(
   // agent reference. The local `env` binding sidesteps TS narrowing
   // limitations on the optional `AcpAgentConfig.env` field.
   const env: Record<string, string> = { ...(agentConfig.env ?? {}) };
-  const commandBasename = basename(agentConfig.command);
 
-  if (commandBasename === "claude-agent-acp") {
+  if (adapterCommandOf(agentConfig) === "claude-agent-acp") {
     if (!env.CLAUDE_CODE_OAUTH_TOKEN) {
       ensureAcpTokenPolicy();
       await credentialBroker.serverUse<void>({

--- a/assistant/src/acp/resolve-agent.test.ts
+++ b/assistant/src/acp/resolve-agent.test.ts
@@ -13,7 +13,8 @@ afterAll(() => {
   setOverridesForTesting({});
 });
 
-const { resolveAcpAgent, listAcpAgents } = await import("./resolve-agent.js");
+const { resolveAcpAgent, listAcpAgents, adapterCommandOf, runsViaBunx } =
+  await import("./resolve-agent.js");
 
 beforeEach(() => {
   config.setConfig({});
@@ -298,6 +299,158 @@ describe("resolveAcpAgent", () => {
     if (!result.ok) return;
     expect(result.agent.args).toEqual(["--verbose"]);
   });
+
+  test("direct resolution sets adapterCommand to the command basename", () => {
+    config.setConfig({
+      agents: {
+        custom: { command: "/opt/bin/claude-agent-acp", args: [] },
+      },
+    });
+
+    const direct = resolveAcpAgent("claude");
+    expect(direct.ok).toBe(true);
+    if (!direct.ok) return;
+    expect(direct.agent.adapterCommand).toBe("claude-agent-acp");
+    expect(runsViaBunx(direct.agent)).toBe(false);
+
+    const fullPath = resolveAcpAgent("custom");
+    expect(fullPath.ok).toBe(true);
+    if (!fullPath.ok) return;
+    expect(fullPath.agent.adapterCommand).toBe("claude-agent-acp");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveAcpAgent - bunx fallback for missing binaries
+// ---------------------------------------------------------------------------
+
+describe("resolveAcpAgent - bunx fallback", () => {
+  test("binary missing + bun present: rewrites to `bun x --bun <pkg>` with adapterCommand preserved", () => {
+    config.setConfig({ agents: {} });
+    which.setWhich({ bun: "/usr/local/bin/bun" });
+
+    const result = resolveAcpAgent("claude");
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.agent.command).toBe("bun");
+    expect(result.agent.args).toEqual([
+      "x",
+      "--bun",
+      "@agentclientprotocol/claude-agent-acp",
+    ]);
+    expect(result.agent.adapterCommand).toBe("claude-agent-acp");
+    expect(runsViaBunx(result.agent)).toBe(true);
+    expect(adapterCommandOf(result.agent)).toBe("claude-agent-acp");
+  });
+
+  test("bunx rewrite appends the original args after the package (gemini --acp)", () => {
+    config.setConfig({ agents: {} });
+    which.setWhich({ bun: "/usr/local/bin/bun" });
+
+    const result = resolveAcpAgent("gemini");
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.agent.command).toBe("bun");
+    expect(result.agent.args).toEqual([
+      "x",
+      "--bun",
+      "@google/gemini-cli",
+      "--acp",
+    ]);
+    expect(result.agent.adapterCommand).toBe("gemini");
+  });
+
+  test("bunx rewrite leaves env unchanged", () => {
+    config.setConfig({
+      agents: {
+        claude: {
+          command: "claude-agent-acp",
+          args: [],
+          env: { KEEP_ME: "yes" },
+        },
+      },
+    });
+    which.setWhich({ bun: "/usr/local/bin/bun" });
+
+    const result = resolveAcpAgent("claude");
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.agent.command).toBe("bun");
+    expect(result.agent.env).toEqual({ KEEP_ME: "yes" });
+  });
+
+  test("bun lookup honors agent.env.PATH override (matches spawn env)", () => {
+    config.setConfig({
+      agents: {
+        claude: {
+          command: "claude-agent-acp",
+          args: [],
+          env: { PATH: "/opt/custom/bin" },
+        },
+      },
+    });
+    which.setWhich((cmd, options) =>
+      cmd === "bun" && options?.PATH === "/opt/custom/bin"
+        ? "/opt/custom/bin/bun"
+        : null,
+    );
+
+    const result = resolveAcpAgent("claude");
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.agent.command).toBe("bun");
+  });
+
+  test("user-config command without a package mapping is NOT rewritten even when bun is present", () => {
+    config.setConfig({
+      agents: {
+        custom: { command: "unknown-binary", args: [] },
+      },
+    });
+    which.setWhich({ bun: "/usr/local/bin/bun" });
+
+    const result = resolveAcpAgent("custom");
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("binary_not_found");
+  });
+
+  test("binary missing + bun missing: binary_not_found with the npm hint", () => {
+    config.setConfig({ agents: {} });
+    which.setWhich({});
+
+    const result = resolveAcpAgent("claude");
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("binary_not_found");
+    if (result.reason !== "binary_not_found") return;
+    expect(result.hint).toBe("npm i -g @agentclientprotocol/claude-agent-acp");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// adapterCommandOf - fallback for plain configs
+// ---------------------------------------------------------------------------
+
+describe("adapterCommandOf", () => {
+  test("falls back to the command basename for configs without adapterCommand", () => {
+    expect(adapterCommandOf({ command: "/opt/bin/claude-agent-acp" })).toBe(
+      "claude-agent-acp",
+    );
+    expect(adapterCommandOf({ command: "codex-acp" })).toBe("codex-acp");
+  });
+
+  test("prefers an explicit adapterCommand over the command", () => {
+    expect(
+      adapterCommandOf({ command: "bun", adapterCommand: "claude-agent-acp" }),
+    ).toBe("claude-agent-acp");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -368,6 +521,25 @@ describe("listAcpAgents", () => {
     expect(claude?.command).toBe("my-claude");
     expect(claude?.description).toBe("custom");
     expect(codex?.source).toBe("default");
+  });
+
+  test("missing binaries with bun present are listed available (bunx fallback)", () => {
+    config.setConfig({ agents: {} });
+    which.setWhich({ bun: "/usr/local/bin/bun" });
+
+    const result = listAcpAgents();
+
+    for (const entry of result.agents) {
+      expect(entry.available).toBe(true);
+      expect(entry.unavailableReason).toBeUndefined();
+      expect(entry.setupHint).toBeUndefined();
+    }
+    // The catalog keeps the canonical adapter commands, not the rewrite.
+    expect(result.agents.map((a) => a.command)).toEqual([
+      "claude-agent-acp",
+      "codex-acp",
+      "gemini",
+    ]);
   });
 
   test("unavailable agent surfaces install hint derived from DEFAULT_AGENT_NPM_PACKAGES", () => {

--- a/assistant/src/acp/resolve-agent.ts
+++ b/assistant/src/acp/resolve-agent.ts
@@ -13,10 +13,21 @@
  * acp_list_agents, and the `/v1/acp/spawn` HTTP route) get a single source
  * of truth and matching actionable hints.
  *
+ * When the adapter binary is NOT on PATH but `bun` is and the command has a
+ * vendored entry in `DEFAULT_AGENT_NPM_PACKAGES`, the resolver rewrites the
+ * agent to run via `bun x --bun <package>` instead of failing. bunx fetches
+ * the package into its cache on first use, so platform-hosted assistants
+ * whose image ships bun (but no node and no npm) work out of the box with
+ * no global install. The original command is preserved as `adapterCommand`
+ * so downstream consumers (env injection, resume hints, version probe) keep
+ * gating on the canonical adapter identity.
+ *
  * `listAcpAgents()` exposes the merged catalog with availability info for
  * the `acp_list_agents` tool — same merge semantics, plus per-entry
- * `available` / `setupHint` derived from `Bun.which` + `DEFAULT_AGENT_NPM_PACKAGES`.
+ * `available` / `setupHint` derived from the same binary-or-bunx resolution.
  */
+
+import { basename } from "node:path";
 
 import {
   DEFAULT_ACP_AGENT_PROFILES,
@@ -33,8 +44,48 @@ import { isAcpEnabled } from "./feature-gate.js";
  */
 type AcpAgentSource = "config" | "default";
 
+/**
+ * A resolver-produced agent config, ready to spawn. `adapterCommand` carries
+ * the canonical adapter identity (e.g. "claude-agent-acp") even when the
+ * spawn command was rewritten to run via `bun x`, so consumers that gate
+ * behavior on the adapter (env injection in `prepare-agent-env.ts`, resume
+ * hints, the version probe in `tools/acp/spawn.ts`) stay correct for
+ * bunx-resolved agents.
+ */
+export interface ResolvedAcpAgent extends AcpAgentConfig {
+  adapterCommand: string;
+}
+
+/**
+ * Canonical adapter identity for a (possibly rewritten) agent config.
+ * Resolver-produced configs carry `adapterCommand` explicitly; plain configs
+ * that never went through the resolver fall back to the command basename so
+ * user-supplied agent configs keep working.
+ */
+export function adapterCommandOf(config: {
+  command: string;
+  adapterCommand?: string;
+}): string {
+  return config.adapterCommand ?? basename(config.command);
+}
+
+/**
+ * Whether the config was rewritten by the resolver to run through `bun x`
+ * (the only path where the canonical adapter identity diverges from the
+ * actual spawn command).
+ */
+export function runsViaBunx(config: {
+  command: string;
+  adapterCommand?: string;
+}): boolean {
+  return (
+    config.adapterCommand !== undefined &&
+    config.adapterCommand !== basename(config.command)
+  );
+}
+
 export type ResolveAcpAgentResult =
-  | { ok: true; agent: AcpAgentConfig }
+  | { ok: true; agent: ResolvedAcpAgent }
   | ResolveAcpAgentFailure;
 
 export type ResolveAcpAgentFailure =
@@ -100,14 +151,49 @@ function installHintFor(command: string): string {
 }
 
 /**
- * Resolve the binary using the same PATH the spawn will see. `AcpAgentProcess`
+ * Resolve a binary using the same PATH the spawn will see. `AcpAgentProcess`
  * spawns with `{ ...process.env, ...config.env }`, so a per-agent `env.PATH`
- * override wins over the daemon's PATH. Mirror that here so a config that
- * relies on a custom PATH to locate the binary doesn't fail preflight.
+ * override wins over the assistant's PATH. Mirror that here so a config that
+ * relies on a custom PATH to locate the binary (or `bun`, for the bunx
+ * rewrite) doesn't fail preflight.
  */
-function findAgentBinary(agent: AcpAgentConfig): string | null {
+function whichOnAgentPath(
+  agent: AcpAgentConfig,
+  command: string,
+): string | null {
   const PATH = agent.env?.PATH ?? process.env.PATH;
-  return Bun.which(agent.command, PATH != null ? { PATH } : undefined);
+  return Bun.which(command, PATH != null ? { PATH } : undefined);
+}
+
+/**
+ * Resolve an agent config to its runnable form, or `null` when it cannot
+ * spawn. The ONLY place the bunx rewrite happens:
+ *
+ * 1. Binary on PATH → use it directly (`adapterCommand` = command basename).
+ * 2. Binary missing, command has a vendored npm package mapping, and `bun`
+ *    is on PATH → rewrite to `bun x --bun <package> <original args>`. bunx
+ *    fetches the package on first use, preserving the
+ *    install-latest-on-first-use design with no global install.
+ * 3. Otherwise → null (callers fall back to npm auto-install or surface the
+ *    install hint).
+ *
+ * Security boundary (mirrors `auto-install.ts`): only commands present in
+ * `DEFAULT_AGENT_NPM_PACKAGES` are ever rewritten. The package names are
+ * vendored constants, NOT user input: an arbitrary command from user config
+ * must never be turned into a `bun x <attacker-controlled-name>` execution.
+ */
+function resolveRunnableAgent(agent: AcpAgentConfig): ResolvedAcpAgent | null {
+  if (whichOnAgentPath(agent, agent.command)) {
+    return { ...agent, adapterCommand: basename(agent.command) };
+  }
+  const packageName = DEFAULT_AGENT_NPM_PACKAGES[agent.command];
+  if (!packageName || !whichOnAgentPath(agent, "bun")) return null;
+  return {
+    ...agent,
+    command: "bun",
+    args: ["x", "--bun", packageName, ...agent.args],
+    adapterCommand: agent.command,
+  };
 }
 
 /**
@@ -185,7 +271,8 @@ function mergedAgentIds(userAgents: Record<string, AcpAgentConfig>): string[] {
  * Order of checks:
  * 1. ACP must be enabled (feature flag or config; see `isAcpEnabled`).
  * 2. The id must resolve to an agent (user config wins; falls back to defaults).
- * 3. The agent's `command` must be discoverable via `Bun.which` (PATH lookup).
+ * 3. The agent must be runnable: its `command` on PATH, or the bunx rewrite
+ *    applies (see `resolveRunnableAgent`).
  *
  * Each failure mode carries an actionable hint so callers can surface a
  * single user-facing message without re-deriving the remediation.
@@ -207,7 +294,8 @@ export function resolveAcpAgent(id: string): ResolveAcpAgentResult {
   }
 
   const { agent } = found;
-  if (!findAgentBinary(agent)) {
+  const runnable = resolveRunnableAgent(agent);
+  if (!runnable) {
     return {
       ok: false,
       reason: "binary_not_found",
@@ -216,7 +304,7 @@ export function resolveAcpAgent(id: string): ResolveAcpAgentResult {
     };
   }
 
-  return { ok: true, agent };
+  return { ok: true, agent: runnable };
 }
 
 /**
@@ -242,7 +330,9 @@ export function listAcpAgents(): {
   const agents: AcpAgentEntry[] = mergedAgentIds(userAgents).map((id) => {
     // Non-null: ids come from `mergedAgentIds` so the lookup always resolves.
     const { agent, source } = lookupAgent(userAgents, id)!;
-    const available = findAgentBinary(agent) !== null;
+    // Same binary-or-bunx resolution as `resolveAcpAgent`: an agent whose
+    // binary is missing but would spawn via `bun x` IS available.
+    const available = resolveRunnableAgent(agent) !== null;
     const entry: AcpAgentEntry = {
       id,
       command: agent.command,

--- a/assistant/src/acp/resume-hint.ts
+++ b/assistant/src/acp/resume-hint.ts
@@ -3,12 +3,15 @@
  *
  * `claude --resume <id>` is Claude Code-specific (the claude-agent-acp
  * adapter binary). Other adapters resume differently or not at all, so the
- * hint is gated by the resolved binary, not the agent id - this stays
- * correct when a user aliases an id to a different binary.
+ * hint is gated by the resolved adapter, not the agent id - this stays
+ * correct when a user aliases an id to a different binary. Callers pass the
+ * CANONICAL adapter command (`adapterCommandOf` in `resolve-agent.ts`), not
+ * the raw spawn command, so the hint still fires when the claude adapter is
+ * run via `bun x` (spawn command "bun").
  *
  * Used by the `acp_spawn` tool's success payload and the session manager's
  * completion notification so both surfaces render identical copy. Returns
- * an empty string for non-claude commands; callers add their own
+ * an empty string for non-claude adapters; callers add their own
  * surrounding separators.
  */
 export function claudeResumeHint(

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -17,7 +17,11 @@ import { getLogger } from "../util/logger.js";
 import { AcpAgentProcess } from "./agent-process.js";
 import { VellumAcpClientHandler } from "./client-handler.js";
 import { prepareAgentEnv } from "./prepare-agent-env.js";
-import { formatResolveFailure, resolveAcpAgent } from "./resolve-agent.js";
+import {
+  adapterCommandOf,
+  formatResolveFailure,
+  resolveAcpAgent,
+} from "./resolve-agent.js";
 import { claudeResumeHint } from "./resume-hint.js";
 import type { AcpAgentConfig, AcpSessionState } from "./types.js";
 
@@ -70,8 +74,10 @@ interface SessionEntry {
   currentPrompt: Promise<unknown> | null;
   parentConversationId: string;
   cwd: string;
-  /** The adapter binary that was spawned. Used to gate resume hints to
-   *  the only adapter (claude-agent-acp) whose CLI accepts `--resume`. */
+  /** Canonical adapter command for the spawned config (e.g.
+   *  "claude-agent-acp" even when the adapter runs via `bun x`). Used to
+   *  gate resume hints to the only adapter (claude-agent-acp) whose CLI
+   *  accepts `--resume`. */
   command: string;
 }
 
@@ -310,7 +316,7 @@ export class AcpSessionManager {
       currentPrompt: null,
       parentConversationId: opts.parentConversationId,
       cwd: opts.cwd,
-      command: opts.agentConfig.command,
+      command: adapterCommandOf(opts.agentConfig),
     };
 
     this.sessions.set(acpSessionId, entry);

--- a/assistant/src/acp/types.ts
+++ b/assistant/src/acp/types.ts
@@ -12,6 +12,14 @@ export interface AcpAgentConfig {
   args: string[];
   description?: string;
   env?: Record<string, string>;
+  /**
+   * Canonical adapter identity (e.g. "claude-agent-acp"), set by the
+   * resolver. It survives the bunx rewrite, where `command` becomes "bun"
+   * and the adapter package moves into `args`. Optional because plain user
+   * configs that bypass the resolver never set it; consumers fall back to
+   * the command basename via `adapterCommandOf` in `resolve-agent.ts`.
+   */
+  adapterCommand?: string;
 }
 
 /**

--- a/assistant/src/config/bundled-skills/acp/SKILL.md
+++ b/assistant/src/config/bundled-skills/acp/SKILL.md
@@ -43,13 +43,15 @@ When the user first tries to use ACP and it's not enabled, set it up automatical
 
 2. Then retry the `acp_spawn` call. Do NOT run `vellum sleep && vellum wake` - that kills the conversation.
 
-No manual binary installation is needed first: missing adapter binaries are installed automatically (see below).
+No manual binary installation is needed first: missing adapter binaries are run on demand via bun, or installed automatically (see below).
 
-## Automatic adapter installation
+## Automatic adapter availability
 
-When `acp_spawn` finds the agent's binary missing from PATH, the assistant silently installs the matching npm package globally and proceeds in the same call. Only the allowlisted out-of-box packages are ever auto-installed (`@agentclientprotocol/claude-agent-acp`, `@zed-industries/codex-acp`, `@google/gemini-cli`); user-configured agents with custom commands are never installed automatically.
+When `acp_spawn` finds the agent's binary missing from PATH, the assistant runs the adapter through bun instead (`bun x --bun <package>`). Bun fetches the package into its cache on first use, so there is no global install and it works on hosts without node or npm (platform-hosted assistants ship bun only). When bun itself is not on PATH, the assistant falls back to silently installing the matching npm package globally and proceeds in the same call.
 
-Manual installation is fallback guidance for unusual setups: npm unavailable, restricted global installs, or an auto-install failure (the failure reason is surfaced in the tool result).
+Only the allowlisted out-of-box packages are ever run or installed this way (`@agentclientprotocol/claude-agent-acp`, `@zed-industries/codex-acp`, `@google/gemini-cli`); user-configured agents with custom commands are never fetched or installed automatically.
+
+Manual installation is fallback guidance for unusual setups: bun and npm both unavailable, restricted global installs, or an auto-install failure (the failure reason is surfaced in the tool result).
 
 ```bash
 npm i -g @agentclientprotocol/claude-agent-acp   # claude
@@ -59,7 +61,7 @@ npm i -g @google/gemini-cli                      # gemini
 
 ## Codex setup
 
-The `codex-acp` adapter is auto-installed, but it shells out to the underlying `codex` CLI, which must also be on PATH:
+The `codex-acp` adapter is fetched automatically when missing, but it shells out to the underlying `codex` CLI, which must also be on PATH:
 
 1. **Install the Codex CLI** (version 0.111 or higher) via OpenAI's distribution channel of choice. The adapter will fail if `codex` isn't on PATH.
 
@@ -70,7 +72,7 @@ The `codex-acp` adapter is auto-installed, but it shells out to the underlying `
 
 ## Gemini setup
 
-Gemini CLI speaks ACP natively (`gemini --acp`) - there is no separate adapter binary. The CLI itself is auto-installed from `@google/gemini-cli` when missing.
+Gemini CLI speaks ACP natively (`gemini --acp`) - there is no separate adapter binary. The CLI itself is fetched from `@google/gemini-cli` when missing.
 
 **Authenticate** via either:
 - Browser OAuth: run `gemini` once interactively and complete the sign-in flow.
@@ -102,7 +104,7 @@ A workspace `acp.agents.gemini` override is only for non-secret customization (c
 
 ## Updating an adapter
 
-If `acp_spawn` reports that an adapter is outdated, ask the user before updating. To update:
+This applies only to adapters installed globally via npm; adapters run via bun are fetched on first use and have no global install to update. If `acp_spawn` reports that an adapter is outdated, ask the user before updating. To update:
 
 ```bash
 npm i -g @agentclientprotocol/claude-agent-acp@latest
@@ -122,7 +124,7 @@ Then retry the `acp_spawn` call.
 
 ## Discoverability
 
-Use `acp_list_agents` to see what's set up and what's missing. It returns each available agent profile, whether ACP is enabled, whether the agent's binary is on PATH, and an install hint if not. This is the right tool to call when deciding between `claude`, `codex`, and `gemini`, or when the user asks "what coding agents do I have?"
+Use `acp_list_agents` to see what's set up and what's missing. It returns each available agent profile, whether ACP is enabled, whether the agent is runnable (its binary is on PATH, or the assistant can run it via bun), and an install hint if not. This is the right tool to call when deciding between `claude`, `codex`, and `gemini`, or when the user asks "what coding agents do I have?"
 
 ## Working directory
 

--- a/assistant/src/config/bundled-skills/acp/TOOLS.json
+++ b/assistant/src/config/bundled-skills/acp/TOOLS.json
@@ -3,7 +3,7 @@
   "tools": [
     {
       "name": "acp_spawn",
-      "description": "Spawn an external coding agent (e.g. Claude Code, Codex, Gemini) via ACP to work on a task. Default profiles ship for `claude` (`claude-agent-acp`), `codex` (`codex-acp`), and `gemini` (`gemini --acp`); the assistant resolves the agent id to the right binary. The agent runs as a subprocess and streams results back. Use this when you want to delegate a coding task to an external agent that has its own tools, file editing, and terminal access. If a default agent's binary is missing, the assistant auto-installs it and proceeds in the same call; if that fails, an actionable install hint is returned - do NOT alter `agents.<id>.command` to swap binaries. If ACP is disabled, follow the setup instructions in SKILL.md.",
+      "description": "Spawn an external coding agent (e.g. Claude Code, Codex, Gemini) via ACP to work on a task. Default profiles ship for `claude` (`claude-agent-acp`), `codex` (`codex-acp`), and `gemini` (`gemini --acp`); the assistant resolves the agent id to the right binary. The agent runs as a subprocess and streams results back. Use this when you want to delegate a coding task to an external agent that has its own tools, file editing, and terminal access. If a default agent's binary is missing, the assistant runs it via bun (fetching the package on first use, no global install) or falls back to an npm auto-install, proceeding in the same call; if neither works, an actionable install hint is returned - do NOT alter `agents.<id>.command` to swap binaries. If ACP is disabled, follow the setup instructions in SKILL.md.",
       "category": "orchestration",
       "risk": "high",
       "input_schema": {
@@ -87,7 +87,7 @@
     },
     {
       "name": "acp_list_agents",
-      "description": "Lists ACP coding agents available to spawn. Each entry includes whether ACP is enabled, whether the agent's binary is on PATH, and an install command if not. Use this to decide between 'claude', 'codex', and 'gemini' or to surface setup steps to the user.",
+      "description": "Lists ACP coding agents available to spawn. Each entry includes whether ACP is enabled, whether the agent is runnable (its binary is on PATH, or the assistant can run it via bun), and an install command if not. Use this to decide between 'claude', 'codex', and 'gemini' or to surface setup steps to the user.",
       "category": "orchestration",
       "risk": "low",
       "input_schema": {

--- a/assistant/src/runtime/routes/__tests__/acp-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/acp-routes.test.ts
@@ -434,6 +434,36 @@ const SPAWN_BODY = {
 };
 
 describe("POST /v1/acp/spawn: auto-install on missing binary", () => {
+  test("binary missing + bun present: spawn proceeds via bunx without npm", async () => {
+    which.setWhich({ bun: "/usr/local/bin/bun" });
+
+    const handler = getSpawnHandler();
+    const body = (await handler({ body: SPAWN_BODY })) as Record<
+      string,
+      unknown
+    >;
+
+    expect(body).toEqual({
+      acpSessionId: "acp-route-session",
+      protocolSessionId: "proto-route-session",
+      agent: "claude",
+    });
+    expect(execFileMock).not.toHaveBeenCalled();
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const agentConfigArg = (spawnMock.mock.calls[0] as unknown[])[1] as {
+      command: string;
+      args: string[];
+      adapterCommand?: string;
+    };
+    expect(agentConfigArg.command).toBe("bun");
+    expect(agentConfigArg.args).toEqual([
+      "x",
+      "--bun",
+      "@agentclientprotocol/claude-agent-acp",
+    ]);
+    expect(agentConfigArg.adapterCommand).toBe("claude-agent-acp");
+  });
+
   test("known command: installs the mapped package and spawn proceeds", async () => {
     // Binary appears on PATH only after `npm i -g` runs, simulating a
     // successful global install.

--- a/assistant/src/tools/acp/spawn.test.ts
+++ b/assistant/src/tools/acp/spawn.test.ts
@@ -481,6 +481,54 @@ describe("executeAcpSpawn: auto-install on missing binary", () => {
   });
 });
 
+describe("executeAcpSpawn - bunx fallback when binary missing", () => {
+  test("binary missing + bun present: spawns via `bun x` with env injection and resume hint, no npm calls", async () => {
+    // Only bun is on PATH - the platform-hosted image (bun, no node/npm).
+    which.setWhich({ bun: "/usr/local/bin/bun" });
+
+    const result = await executeAcpSpawn(
+      { agent: "claude", task: "do something" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    // No npm install AND no npm version probe: bunx fetches the package on
+    // first use and there is no global install to compare.
+    expect(execFileMock).not.toHaveBeenCalled();
+    expect(result.content).not.toContain("outdated");
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const agentConfigArg = spawnMock.mock.calls[0][1] as {
+      command: string;
+      args: string[];
+      adapterCommand?: string;
+      env?: Record<string, string>;
+    };
+    expect(agentConfigArg.command).toBe("bun");
+    expect(agentConfigArg.args).toEqual([
+      "x",
+      "--bun",
+      "@agentclientprotocol/claude-agent-acp",
+    ]);
+    expect(agentConfigArg.adapterCommand).toBe("claude-agent-acp");
+    // CLAUDE_CODE_OAUTH_TOKEN injection still applies to the bunx-resolved
+    // claude adapter (gated on adapterCommand, not the spawn command).
+    expect(agentConfigArg.env?.CLAUDE_CODE_OAUTH_TOKEN).toBe(
+      "default-test-token",
+    );
+
+    const [payloadJson] = result.content.split("\n\n");
+    const payload = JSON.parse(payloadJson);
+    // No auto-install happened; the claude resume hint still fires.
+    expect(payload.message).not.toContain("Installed");
+    expect(payload.message).toContain("claude --resume");
+  });
+
+  // The bun-absent npm fallback is covered by the existing auto-install
+  // suite below ("known command: installs the mapped package..."), whose
+  // which-stub leaves bun off PATH until the install completes.
+});
+
 describe("executeAcpSpawn — per-agent resume hint", () => {
   test("claude payload includes the `claude --resume` hint", async () => {
     execScripts.set("npm ls", { error: new Error("npm not installed") });

--- a/assistant/src/tools/acp/spawn.ts
+++ b/assistant/src/tools/acp/spawn.ts
@@ -4,7 +4,11 @@ import {
 } from "../../acp/auto-install.js";
 import { getAcpSessionManager } from "../../acp/index.js";
 import { prepareAgentEnv } from "../../acp/prepare-agent-env.js";
-import { formatResolveFailure } from "../../acp/resolve-agent.js";
+import {
+  adapterCommandOf,
+  formatResolveFailure,
+  runsViaBunx,
+} from "../../acp/resolve-agent.js";
 import { claudeResumeHint } from "../../acp/resume-hint.js";
 import { DEFAULT_AGENT_NPM_PACKAGES } from "../../config/acp-defaults.js";
 import { getLogger } from "../../util/logger.js";
@@ -147,8 +151,12 @@ export async function executeAcpSpawn(
   }
 
   // Best-effort version check — never blocks the spawn. If outdated, we
-  // append a non-blocking warning to the success payload.
-  const versionInfo = await checkAdapterVersion(agentConfig.command);
+  // append a non-blocking warning to the success payload. Skipped for
+  // bunx-resolved agents: there is no global npm install to compare (bun
+  // fetches the package on first use), and npm may not exist on the host.
+  const versionInfo = runsViaBunx(agentConfig)
+    ? null
+    : await checkAdapterVersion(adapterCommandOf(agentConfig));
 
   try {
     const manager = getAcpSessionManager();
@@ -162,9 +170,14 @@ export async function executeAcpSpawn(
       sendToClient,
     );
 
-    // Claude Code-only resume hint; empty for other adapters. See
+    // Claude Code-only resume hint; empty for other adapters. Keyed off the
+    // canonical adapter command so it survives the bunx rewrite. See
     // acp/resume-hint.ts for the gating rationale.
-    const hint = claudeResumeHint(agentConfig.command, cwd, protocolSessionId);
+    const hint = claudeResumeHint(
+      adapterCommandOf(agentConfig),
+      cwd,
+      protocolSessionId,
+    );
     const resumeHint = hint ? ` ${hint}` : "";
     const installNote = autoInstalledPackage
       ? ` Installed ${autoInstalledPackage} automatically.`


### PR DESCRIPTION
## Summary
- When an ACP adapter binary is not on PATH, the resolver now rewrites the agent to run via bun x --bun <package> (bun fetches the package on first use), so hosted assistants with bun but no node/npm work out of the box
- Canonical adapter identity is carried through resolution so Claude OAuth env injection, resume hints, and the version probe keep working for bun-resolved adapters; npm auto-install remains as fallback when bun is absent
- Docs and tests updated for the new resolution order (PATH binary, then bunx, then npm install, then hint)

## Original prompt
Follow-up to the ACP overhaul (#33692): the platform-hosted assistant image ships bun only (no node/npm), so the npm-based adapter auto-install cannot work there. Verified empirically that all three default adapters complete the ACP handshake under bun (codex-acp is a native binary), so the requested change is to automatically use bun to run missing adapters instead of installing them globally via npm.