### PR TITLE
fix(web): unwrap flags envelope in feature-flags panel

### DIFF
--- a/apps/web/src/domains/settings/components/panels/feature-flags-panel.tsx
+++ b/apps/web/src/domains/settings/components/panels/feature-flags-panel.tsx
@@ -30,12 +30,13 @@ interface FlagDefinitionResponse {
 
 async function fetchFlagDefinitions(): Promise<FlagDefinitionResponse[]> {
   const { data, response } = await client.get<
-    FlagDefinitionResponse[],
+    { flags: FlagDefinitionResponse[] },
     Record<string, unknown>,
     false
   >({ url: "/v1/feature-flags/", throwOnError: false });
   if (!response?.ok) return [];
-  return (data as FlagDefinitionResponse[]) ?? [];
+  const parsed = data as { flags?: FlagDefinitionResponse[] } | undefined;
+  return parsed?.flags ?? [];
 }
 
 const SCOPE_TONE: Record<SingleScope, TagTone> = {


### PR DESCRIPTION
## Summary
- The `GET /v1/feature-flags/` endpoint returns `{ flags: [...] }`, but `fetchFlagDefinitions` was treating `data` as a bare array
- The resulting object was truthy (passing the `!definitions` null guard) but not iterable, crashing `FeatureFlagsPanel` with `TypeError: definitions is not iterable`
- Fixed by unwrapping `data.flags` before returning from the fetch function

## Test plan
- [ ] Open the feature flags settings panel — verify it loads without crashing
- [ ] Confirm flag definitions (including string-type dropdowns) render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)