### PR TITLE
fix(macos): unwrap optional index comparison in ChatViewModel

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1448,7 +1448,7 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         let lastUserIndex = messages.lastIndex(where: { $0.role == .user })
         let lastAssistantIndex = messages.lastIndex(where: { $0.role == .assistant })
         guard let lastAssistantIndex,
-              lastUserIndex == nil || lastAssistantIndex > lastUserIndex else { return }
+              lastUserIndex.map({ lastAssistantIndex > $0 }) ?? true else { return }
         clearCurrentTurnTracking()
         isThinking = false
         isSending = false


### PR DESCRIPTION
## Summary
- Fix Swift compilation error in `ChatViewModel.swift:1451` where `lastAssistantIndex > lastUserIndex` compares a non-optional `Int` with an optional `Int?`
- Use `lastUserIndex.map({ lastAssistantIndex > $0 }) ?? true` to safely unwrap the optional while preserving the original semantics

## Original prompt
The macOS CI `build-macos` job was failing due to a Swift compilation error in `ChatViewModel.swift`. The `reconcileStuckSendStateAfterCatchUp` method compared an unwrapped `lastAssistantIndex` (via `guard let`) with the still-optional `lastUserIndex`, which Swift's type system rejects. This was blocking dev release builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)