### PR TITLE
Inject Gemini API key from the credential vault for ACP spawns

### DIFF
--- a/apps/macos/src/main/bundle-flow.ts
+++ b/apps/macos/src/main/bundle-flow.ts
@@ -85,14 +85,13 @@ export async function scanBundleViaDaemon(
     if (token) {
       headers["Authorization"] = `Bearer ${token}`;
     }
-    const response = await net.fetch(
-      `http://127.0.0.1:${port}/v1/apps/open-bundle`,
-      {
-        method: "POST",
-        body: JSON.stringify({ filePath }),
-        headers,
-      },
-    );
+    // Local gateway base URL (gatewayPort from the lockfile, not the runtime port).
+    const gatewayBaseUrl = `http://127.0.0.1:${port}`;
+    const response = await net.fetch(`${gatewayBaseUrl}/v1/apps/open-bundle`, {
+      method: "POST",
+      body: JSON.stringify({ filePath }),
+      headers,
+    });
     if (!response.ok) return null;
     return (await response.json()) as BundleScanData;
   } catch {

--- a/assistant/src/acp/__tests__/prepare-agent-env.test.ts
+++ b/assistant/src/acp/__tests__/prepare-agent-env.test.ts
@@ -250,6 +250,115 @@ describe("prepareAgentEnv — claude-agent-acp gating", () => {
   });
 });
 
+describe("prepareAgentEnv - gemini gating", () => {
+  function seedVaultGeminiKey(key: string): void {
+    vaultStore.set("acp/gemini_api_key", key);
+  }
+
+  test("injects GEMINI_API_KEY from the vault via the broker when agent.env has no override", async () => {
+    seedVaultGeminiKey("vault-gem-AAA");
+
+    const prepared = await prepareAgentEnv({
+      command: "gemini",
+      args: ["--acp"],
+    });
+
+    expect(prepared.env?.GEMINI_API_KEY).toBe("vault-gem-AAA");
+  });
+
+  test("auto-registers metadata with acp_spawn in allowedTools when none exists", async () => {
+    seedVaultGeminiKey("vault-gem-auto-meta");
+
+    await prepareAgentEnv({ command: "gemini", args: ["--acp"] });
+
+    const meta = metadataStore.get("acp/gemini_api_key");
+    expect(meta).toBeDefined();
+    expect(meta!.allowedTools).toContain("acp_spawn");
+  });
+
+  test("injects the key for the bunx-rewritten gemini CLI (adapterCommand gate)", async () => {
+    seedVaultGeminiKey("vault-gem-bunx");
+
+    const prepared = await prepareAgentEnv({
+      command: "bun",
+      args: ["x", "--bun", "@google/gemini-cli", "--acp"],
+      adapterCommand: "gemini",
+    });
+
+    expect(prepared.env?.GEMINI_API_KEY).toBe("vault-gem-bunx");
+  });
+
+  test("a vault miss does NOT throw and spawns without GEMINI_API_KEY (key is optional)", async () => {
+    const prepared = await prepareAgentEnv({
+      command: "gemini",
+      args: ["--acp"],
+    });
+
+    expect(prepared.env).not.toHaveProperty("GEMINI_API_KEY");
+  });
+
+  test("respects explicit tool policy that excludes acp_spawn without failing the spawn", async () => {
+    metadataStore.set("acp/gemini_api_key", {
+      allowedTools: ["other_tool"],
+    });
+    seedVaultGeminiKey("vault-gem-restricted");
+
+    const prepared = await prepareAgentEnv({
+      command: "gemini",
+      args: ["--acp"],
+    });
+
+    expect(prepared.env).not.toHaveProperty("GEMINI_API_KEY");
+    const meta = metadataStore.get("acp/gemini_api_key");
+    expect(meta!.allowedTools).toEqual(["other_tool"]);
+  });
+
+  test("agent.env override wins over the vault entry and skips the broker (precedence pin)", async () => {
+    // Seed a vault value but no metadata: if the override path consulted the
+    // broker anyway, ensureAcpCredentialPolicy would create metadata here.
+    seedVaultGeminiKey("vault-gem-CCC");
+
+    const prepared = await prepareAgentEnv({
+      command: "gemini",
+      args: ["--acp"],
+      env: { GEMINI_API_KEY: "config-gem-DDD" },
+    });
+
+    expect(prepared.env?.GEMINI_API_KEY).toBe("config-gem-DDD");
+    expect(metadataStore.has("acp/gemini_api_key")).toBe(false);
+  });
+
+  test("preserves unrelated env vars on agent.env when injecting from the vault", async () => {
+    seedVaultGeminiKey("vault-gem-EEE");
+
+    const prepared = await prepareAgentEnv({
+      command: "gemini",
+      args: ["--acp"],
+      env: { NO_COLOR: "1" },
+    });
+
+    expect(prepared.env?.GEMINI_API_KEY).toBe("vault-gem-EEE");
+    expect(prepared.env?.NO_COLOR).toBe("1");
+  });
+
+  test("does NOT mutate the caller's agentConfig", async () => {
+    seedVaultGeminiKey("vault-gem-GGG");
+    const original = {
+      command: "gemini",
+      args: ["--acp"],
+      env: { OTHER: "keep" },
+    };
+    const beforeEnv = { ...original.env };
+
+    const prepared = await prepareAgentEnv(original);
+
+    expect(prepared).not.toBe(original);
+    expect(prepared.env).not.toBe(original.env);
+    expect(original.env).toEqual(beforeEnv);
+    expect(original.env).not.toHaveProperty("GEMINI_API_KEY");
+  });
+});
+
 describe("prepareAgentEnv — non-claude commands", () => {
   test("returns the config unchanged for codex-acp (no required env vars today)", async () => {
     const prepared = await prepareAgentEnv({

--- a/assistant/src/acp/prepare-agent-env.ts
+++ b/assistant/src/acp/prepare-agent-env.ts
@@ -26,38 +26,70 @@ import {
   getCredentialMetadata,
   upsertCredentialMetadata,
 } from "../tools/credentials/metadata-store.js";
+import { getLogger } from "../util/logger.js";
 import { adapterCommandOf } from "./resolve-agent.js";
 import type { AcpAgentConfig } from "./types.js";
 
+const log = getLogger("acp:prepare-agent-env");
+
 const ACP_SPAWN_TOOL = "acp_spawn";
+const ACP_SERVICE = "acp";
 
 /**
- * Ensure the `acp/claude_oauth_token` credential has metadata that allows
- * the `acp_spawn` tool to read it, but only for legacy/unmanaged cases:
+ * Ensure an `acp/<field>` credential has metadata that allows the
+ * `acp_spawn` tool to read it, but only for legacy/unmanaged cases:
  *
- * - No metadata at all → create with `allowedTools: ["acp_spawn"]`.
- * - Metadata exists with an empty `allowedTools` → default provisioning
+ * - No metadata at all: create with `allowedTools: ["acp_spawn"]`.
+ * - Metadata exists with an empty `allowedTools`: default provisioning
  *   path (user ran `credentials set` without `--allowed-tools`), add it.
- * - Metadata exists with a non-empty `allowedTools` → explicit policy set
- *   by the user/admin. Respect it even if `acp_spawn` is absent — the
- *   broker will deny the read and the preflight will throw.
+ * - Metadata exists with a non-empty `allowedTools`: explicit policy set
+ *   by the user/admin. Respect it even if `acp_spawn` is absent; the
+ *   broker will deny the read and the caller decides whether that's fatal.
  */
-function ensureAcpTokenPolicy(): void {
-  const meta = getCredentialMetadata("acp", "claude_oauth_token");
+function ensureAcpCredentialPolicy(
+  field: string,
+  usageDescription: string,
+): void {
+  const meta = getCredentialMetadata(ACP_SERVICE, field);
   if (!meta) {
-    upsertCredentialMetadata("acp", "claude_oauth_token", {
+    upsertCredentialMetadata(ACP_SERVICE, field, {
       allowedTools: [ACP_SPAWN_TOOL],
-      usageDescription:
-        "Claude OAuth token for ACP agent authentication",
+      usageDescription,
     });
     return;
   }
   const tools = meta.allowedTools ?? [];
   if (tools.length === 0) {
-    upsertCredentialMetadata("acp", "claude_oauth_token", {
+    upsertCredentialMetadata(ACP_SERVICE, field, {
       allowedTools: [ACP_SPAWN_TOOL],
     });
   }
+}
+
+/**
+ * Read an `acp/<field>` credential through the broker and inject it into
+ * `env` under `envVar`. Returns the broker's failure reason when the value
+ * was not injected (missing credential, denied policy, no stored value),
+ * or undefined on success. Never throws: `serverUse` signals every failure
+ * mode, including a simply-absent credential, as `{ success: false,
+ * reason }`, so callers choose whether a miss is fatal.
+ */
+async function injectCredential(
+  env: Record<string, string>,
+  field: string,
+  envVar: string,
+  usageDescription: string,
+): Promise<string | undefined> {
+  ensureAcpCredentialPolicy(field, usageDescription);
+  const result = await credentialBroker.serverUse<void>({
+    service: ACP_SERVICE,
+    field,
+    toolName: ACP_SPAWN_TOOL,
+    execute: async (value) => {
+      env[envVar] = value;
+    },
+  });
+  return result.success ? undefined : result.reason;
 }
 
 /**
@@ -87,6 +119,11 @@ function ensureAcpTokenPolicy(): void {
  * before spawning. The "fail-fast" throw is symmetric with the existing
  * `binary_not_found` preflight in `resolveAcpAgent` and strictly better
  * than a `warn` + zombie subprocess 10 seconds later.
+ *
+ * For `gemini` the env var is `GEMINI_API_KEY`, provisioned the same two
+ * ways (config.json override wins, vault field `gemini_api_key` second),
+ * but it is OPTIONAL: the Gemini CLI supports its own OAuth login, so a
+ * vault miss proceeds without the key instead of failing the spawn.
  */
 export async function prepareAgentEnv(
   agentConfig: AcpAgentConfig,
@@ -95,18 +132,16 @@ export async function prepareAgentEnv(
   // agent reference. The local `env` binding sidesteps TS narrowing
   // limitations on the optional `AcpAgentConfig.env` field.
   const env: Record<string, string> = { ...(agentConfig.env ?? {}) };
+  const adapterCommand = adapterCommandOf(agentConfig);
 
-  if (adapterCommandOf(agentConfig) === "claude-agent-acp") {
+  if (adapterCommand === "claude-agent-acp") {
     if (!env.CLAUDE_CODE_OAUTH_TOKEN) {
-      ensureAcpTokenPolicy();
-      await credentialBroker.serverUse<void>({
-        service: "acp",
-        field: "claude_oauth_token",
-        toolName: ACP_SPAWN_TOOL,
-        execute: async (token) => {
-          env.CLAUDE_CODE_OAUTH_TOKEN = token;
-        },
-      });
+      await injectCredential(
+        env,
+        "claude_oauth_token",
+        "CLAUDE_CODE_OAUTH_TOKEN",
+        "Claude OAuth token for ACP agent authentication",
+      );
     }
     if (!env.CLAUDE_CODE_OAUTH_TOKEN) {
       throw new FailedDependencyError(
@@ -114,6 +149,23 @@ export async function prepareAgentEnv(
           "Run: assistant credentials set --service acp --field claude_oauth_token <token> " +
           "(or set it under acp.agents.<id>.env in config.json).",
       );
+    }
+  } else if (adapterCommand === "gemini") {
+    if (!env.GEMINI_API_KEY) {
+      const missReason = await injectCredential(
+        env,
+        "gemini_api_key",
+        "GEMINI_API_KEY",
+        "Gemini API key for ACP agent authentication",
+      );
+      if (missReason !== undefined) {
+        // Optional credential: Gemini CLI can authenticate via its own
+        // OAuth login, so a vault miss must not fail the spawn.
+        log.debug(
+          { reason: missReason },
+          "Gemini API key unavailable from the vault; spawning without GEMINI_API_KEY",
+        );
+      }
     }
   }
 

--- a/assistant/src/config/bundled-skills/acp/SKILL.md
+++ b/assistant/src/config/bundled-skills/acp/SKILL.md
@@ -59,6 +59,16 @@ npm i -g @zed-industries/codex-acp               # codex
 npm i -g @google/gemini-cli                      # gemini
 ```
 
+## Claude setup
+
+The `claude-agent-acp` adapter requires a Claude OAuth token. Store it once in the credential store and every spawn injects it as `CLAUDE_CODE_OAUTH_TOKEN` automatically:
+
+```bash
+assistant credentials set --service acp --field claude_oauth_token <token>
+```
+
+When the token is missing, do NOT ask the user to paste it into chat. Collect it via the secret-request flow instead: `credential_store` with action `prompt`, service `acp`, field `claude_oauth_token`. That prompts the user through a secure UI so the token never enters the conversation or the workspace config. Users generate the token by running `claude setup-token` on a machine where they are logged in to Claude.
+
 ## Codex setup
 
 The `codex-acp` adapter is fetched automatically when missing, but it shells out to the underlying `codex` CLI, which must also be on PATH:
@@ -74,11 +84,17 @@ The `codex-acp` adapter is fetched automatically when missing, but it shells out
 
 Gemini CLI speaks ACP natively (`gemini --acp`) - there is no separate adapter binary. The CLI itself is fetched from `@google/gemini-cli` when missing.
 
-**Authenticate** via either:
-- Browser OAuth: run `gemini` once interactively and complete the sign-in flow.
-- `GEMINI_API_KEY` set in the assistant's own process environment - spawned agents inherit it automatically.
+**Authenticate** with an API key through the credential store (the primary path):
 
-Do NOT put API keys (or any secret) in the workspace config file - secrets never belong in the workspace directory. Use the assistant environment instead.
+```bash
+assistant credentials set --service acp --field gemini_api_key <key>
+```
+
+Or collect the key via the secret-request flow: `credential_store` with action `prompt`, service `acp`, field `gemini_api_key`. Either way the key never appears in chat or workspace config, and every spawn injects it as `GEMINI_API_KEY` automatically. The key is optional - a spawn proceeds without it when the vault has no entry.
+
+The alternative is browser OAuth: run `gemini` once interactively and complete the sign-in flow. This is impractical on hosted assistants (no browser), so prefer the credential store there.
+
+Do NOT put API keys (or any secret) in the workspace config file - secrets never belong in the workspace directory. Use the credential store instead.
 
 A workspace `acp.agents.gemini` override is only for non-secret customization (custom binary path, extra args, non-secret env vars). It must spell out the full `command` and `args` - see "Critical: correct agent command" below for the replace-not-merge rule:
   ```json


### PR DESCRIPTION
## Summary
- prepareAgentEnv now reads acp/gemini_api_key through the credential broker and injects GEMINI_API_KEY for gemini ACP spawns (including bun-resolved ones), policy-gated and audit-logged like the Claude token
- The key is optional: a vault miss proceeds without env (Gemini CLI OAuth remains supported); explicit per-agent env overrides always win
- ACP skill docs now steer both Claude and Gemini auth through the credential store and the secret-request flow instead of pasting keys in chat or config

## Original prompt
Follow-up to the ACP hosted-assistant work: Gemini auth previously relied on the assistant process environment, which is not user-settable on platform-hosted assistants and tempted secrets into workspace config. The request was to mirror the Claude OAuth vault flow for the Gemini API key so users can hand the key to their assistant once via the secret-request flow and have every spawn inject it.