### PR TITLE
fix(ci): add bundle-flow.ts to gateway-only guard allowlist

### DIFF
--- a/assistant/src/__tests__/gateway-only-guard.test.ts
+++ b/assistant/src/__tests__/gateway-only-guard.test.ts
@@ -45,9 +45,6 @@ const ALLOWLIST = new Set([
   // --- Shared client packages (transport helpers that proxy to the runtime by design) ---
   "packages/assistant-client/src/proxy-forward.ts",
   "packages/assistant-client/src/websocket-upstream.ts",
-
-  // --- macOS Electron bundle-open flow (talks to gateway port, not runtime) ---
-  "apps/macos/src/main/bundle-flow.ts",
 ]);
 
 /** Patterns that indicate a direct runtime URL reference via hardcoded port. */
@@ -87,12 +84,21 @@ function isGatewayInternal(filePath: string): boolean {
   return filePath.startsWith("gateway/");
 }
 
+/** Additional files allowed for the interpolated-port check only (use gateway port, not runtime). */
+const INTERPOLATED_PORT_ALLOWLIST = new Set([
+  "apps/macos/src/main/bundle-flow.ts",
+]);
+
 /** Shared violation filter: exempt test files, gateway internals, and allowlisted paths. */
-function filterViolations(files: string[]): string[] {
+function filterViolations(
+  files: string[],
+  extraAllowlist?: Set<string>,
+): string[] {
   return files.filter((f) => {
     if (isTestFile(f)) return false;
     if (isGatewayInternal(f)) return false;
     if (ALLOWLIST.has(f)) return false;
+    if (extraAllowlist?.has(f)) return false;
     return true;
   });
 }
@@ -184,7 +190,7 @@ describe("gateway-only API consumption guard", () => {
     }
 
     const files = grepOutput.split("\n").filter((f) => f.length > 0);
-    const violations = filterViolations(files);
+    const violations = filterViolations(files, INTERPOLATED_PORT_ALLOWLIST);
 
     if (violations.length > 0) {
       const message = [

--- a/assistant/src/__tests__/gateway-only-guard.test.ts
+++ b/assistant/src/__tests__/gateway-only-guard.test.ts
@@ -45,6 +45,9 @@ const ALLOWLIST = new Set([
   // --- Shared client packages (transport helpers that proxy to the runtime by design) ---
   "packages/assistant-client/src/proxy-forward.ts",
   "packages/assistant-client/src/websocket-upstream.ts",
+
+  // --- macOS Electron bundle-open flow (talks to gateway port, not runtime) ---
+  "apps/macos/src/main/bundle-flow.ts",
 ]);
 
 /** Patterns that indicate a direct runtime URL reference via hardcoded port. */


### PR DESCRIPTION
## Summary
- Add `apps/macos/src/main/bundle-flow.ts` to the gateway-only guard test allowlist
- This file constructs a URL using the **gateway** port (from the lockfile's `gatewayPort`), not the runtime port — the guard regex is a false positive

## Original prompt
Fix the CI build failure on main caused by the gateway-only guard test (`gateway-only-guard.test.ts`) flagging `apps/macos/src/main/bundle-flow.ts`. The file was introduced in PR #33720 and uses the gateway port to talk to the daemon, which the interpolated-port regex catches as a false positive.