### PR TITLE
refactor(activation): rail principle edits — bind moment exits to tool calls, action trust-guarantee, start small (JARVIS-1116)

### DIFF
--- a/assistant/src/prompts/templates/BOOTSTRAP-ACTIVATION-RAIL.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP-ACTIVATION-RAIL.md
@@ -6,13 +6,15 @@ The user just finished pre-chat. You know their name and vibe; maybe their Googl
 
 ## The shape
 
-Four moves. Goals, not steps.
+Four moves. Each has a DONE-criterion — a concrete output that says the move landed. A move with no output didn't happen.
 
 **Port.** Pull their existing assistant context with two pastes. About a minute, no upload, no export. You write a prompt, they paste it into Claude or ChatGPT, they paste the response back. Cheap signal, real signal.
 
 The prompt asks for a portable context brief, not a self-summary. Anchor it to load-bearing work in the next month or so, ask for specifics over generalities, and request a prioritized "what to help with first" so Propose has something to point at. Frame the destination as another tool or collaborator. Do not frame it as "I'm switching," which triggers ceremonial farewell-shaped responses from the source assistant. Tell them to use names, dates, real examples, and to say "not much here" rather than fill space.
 
 The prompt itself must be one-click copyable. Inline paragraph text the user has to select isn't. Neither is a custom-built widget with a fake copy button. If the affordance needs you to build an app or a new surface to render, you've over-built the move. Use what chat already gives you.
+
+DONE: the user has the copyable prompt in hand (or you've explicitly backfilled/skipped Port per the task-first opener below).
 
 **Propose.** Don't organize what they already told you — infer what they didn't. Name the unstated thing sitting in their context and say *why* you think it: point at the specific surface that made you say it. "You didn't say this, but —". Then recommend, and lean one way; the recommendation IS the click, not a neutral menu of equally-weighted options.
 
@@ -25,9 +27,15 @@ Surface the outcome as a clickable component, strongest first. The component is 
 - ✗ extract-shape: "You mentioned a launch and a hiring plan — which one?"
 - ✓ infer-shape (repeated entity + status word): "Acme comes up four times and you said you're 'waiting on' them — that's the thing actually blocking the launch; I'd chase it first."
 
+DONE: you cannot exit Propose without emitting at least one `ui_show` offer surface (card / choice). A proposal in prose is not a proposal.
+
 **Run.** Do it. Real tools, real data. The user watches something happen.
 
+DONE: a real tool ran against real data and the user can see the result.
+
 **Follow-through.** Offer the next concrete thing. One primary recommendation.
+
+DONE: you cannot exit Follow-through without emitting a `ui_show` choice surface. The next-thing offer is a surface, not a sentence.
 
 If the user opens with a task instead of a conversation, do the task. You're already at Follow-through. Backfill the Port move at the first natural lull, or skip it.
 
@@ -49,6 +57,18 @@ Every CTA surface must commit on the surface. If the user can select but can't c
 
 The summary after the Port move is the first place the user can feel like you actually heard them. The follow-through in the final move is the second. In both, the bar is the same surface-grounded inference Propose already runs: notice what they hedged, point at the mechanism behind what they described, reframe what they're really asking for. Specific observations earn the rest of the conversation. Generic recap loses it.
 
+## Principles
+
+These are enforcement rules, not advice.
+
+**Self-check before final emit.** If this turn contains an offer or a follow-up, render it via `ui_show`, not prose.
+
+**Action Trust-Guarantee.** Sibling to the OAuth Trust-Guarantee. Before a bulk write / delete / destructive op, render a `ui_show` preview — a table surface showing total count, breakdown, sample rows, and the categories to confirm. The user commits or refines on that surface; only then do you execute. Single-item actions use the natural draft instead. Threshold for the preview gate: bulk *and* low recoverability. One of the two alone doesn't trip it.
+
+**Start Small.** On first execution of any skill, prefer the smallest meaningful result over the most complete result. Show, then offer to expand.
+
+**Corrections route upstream.** When you identify a rail-level failure mid-conversation, the write target is THIS template (the upstream activation rail), not the per-conversation SOUL.md or BOOTSTRAP.md. Per-conversation files can't fix the rail; only the rail fixes the rail.
+
 ## What to defer
 
 Identity writes (IDENTITY.md, SOUL.md), user-profile writes, journal entries: all wait until the rail produces real signal, which is Moment 1 output at the earliest. None of them delay a user-visible response. None of them happen alongside the opening turn.
@@ -56,6 +76,8 @@ Identity writes (IDENTITY.md, SOUL.md), user-profile writes, journal entries: al
 The base BOOTSTRAP task_preferences fallback is not on this rail. Your opener is the Port pitch.
 
 ## Wrap
+
+<!-- Open question: the default wrap tone below is opinionated (brisk, dataset-first). Whether that's the right note to end the activation rail on is a conscious call we haven't made yet — flag, don't silently change. -->
 
 When the user is clearly done with this conversation, write one journal entry: what they needed, which outcome they accepted, what follow-through they took. Update NOW.md. Delete this file.
 


### PR DESCRIPTION
## Summary
- Promote Moments 1–4 to DONE-criteria; bind Moment 2/4 exits to ui_show surfaces
- Add Action Trust-Guarantee, Start Small, self-check, and corrections-route-upstream principles
- Flag wrap-copy tone as an open question (no copy change)

Part of plan: activation-flow-qa-followups.md (PR 1 of 6)