### PR TITLE
fix: don't show error glyph on a connect/verify step that recovers silently (JARVIS-1113)

### DIFF
--- a/apps/web/src/domains/chat/components/surfaces/card-surface.test.tsx
+++ b/apps/web/src/domains/chat/components/surfaces/card-surface.test.tsx
@@ -77,4 +77,56 @@ describe("CardSurface", () => {
     expect(rendered).toContain("Envelope fallback");
     expect(countOccurrences(rendered, "Envelope fallback")).toBe(1);
   });
+
+  test("does not render an error glyph for a failed step once the overall task completes", () => {
+    const rendered = renderToStaticMarkup(
+      <CardSurface
+        surface={surface({
+          title: "Connect Gmail",
+          data: {
+            title: "Connect Gmail",
+            body: "",
+            template: "task_progress",
+            templateData: {
+              title: "Connect Gmail",
+              status: "completed",
+              steps: [
+                { label: "Verifying Gmail connection", status: "failed" },
+                { label: "Finishing setup", status: "completed" },
+              ],
+            },
+          },
+        })}
+        onAction={() => undefined}
+      />,
+    );
+
+    // lucide CircleX renders an `<svg>` with the `lucide-circle-x` class; a
+    // recovered step must not surface it.
+    expect(rendered).not.toContain("lucide-circle-x");
+    expect(rendered).toContain("Verifying Gmail connection");
+  });
+
+  test("still renders an error glyph for a failed step while the task is in progress", () => {
+    const rendered = renderToStaticMarkup(
+      <CardSurface
+        surface={surface({
+          title: "Connect Gmail",
+          data: {
+            title: "Connect Gmail",
+            body: "",
+            template: "task_progress",
+            templateData: {
+              title: "Connect Gmail",
+              status: "in_progress",
+              steps: [{ label: "Verifying Gmail connection", status: "failed" }],
+            },
+          },
+        })}
+        onAction={() => undefined}
+      />,
+    );
+
+    expect(rendered).toContain("lucide-circle-x");
+  });
 });

--- a/apps/web/src/domains/chat/components/surfaces/card-surface.tsx
+++ b/apps/web/src/domains/chat/components/surfaces/card-surface.tsx
@@ -65,6 +65,23 @@ function getStatusConfig(status: string | undefined) {
   return STATUS_CONFIG[status ?? ""] ?? DEFAULT_STATUS;
 }
 
+// A connect/verify flow (e.g. Gmail) routinely emits a step as `failed` for a
+// recoverable, expected state — the first `oauth ping` fails, the silent
+// reconnect succeeds, and the overall task finishes. The model does not always
+// send a corrective per-step `ui_update`, so the stale `failed` step keeps
+// rendering a red error glyph even though the flow completed. Once the overall
+// task is `completed`, treat any lingering `failed` step as recovered so we
+// never show a persistent error on a successful flow.
+function effectiveStepStatus(
+  stepStatus: string | undefined,
+  taskCompleted: boolean,
+): string | undefined {
+  if (taskCompleted && stepStatus === "failed") {
+    return "completed";
+  }
+  return stepStatus;
+}
+
 function normalizedTitle(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
 }
@@ -147,11 +164,18 @@ function InProgressDetail({ value }: { value: string }) {
   );
 }
 
-function TaskStepList({ steps }: { steps: TaskStepItem[] }) {
+function TaskStepList({
+  steps,
+  taskCompleted,
+}: {
+  steps: TaskStepItem[];
+  taskCompleted: boolean;
+}) {
   return (
     <div className="mt-5 divide-y divide-[var(--border-base)]">
       {steps.map((step, index) => {
-        const showDetailOnRight = step.status === "in_progress" && !!step.detail;
+        const status = effectiveStepStatus(step.status, taskCompleted);
+        const showDetailOnRight = status === "in_progress" && !!step.detail;
         return (
           <div key={step.id || index} className="flex items-center gap-2.5 py-2 first:pt-0 last:pb-0">
             <span className="inline-flex h-6 min-w-6 shrink-0 items-center justify-center rounded-md bg-[var(--tag-bg-neutral)] px-1.5 text-label-medium-default tabular-nums text-[var(--content-tertiary)]">
@@ -169,7 +193,7 @@ function TaskStepList({ steps }: { steps: TaskStepItem[] }) {
             </div>
             {showDetailOnRight && <InProgressDetail value={step.detail!} />}
             <div className="shrink-0">
-              <StepIcon status={step.status} />
+              <StepIcon status={status} />
             </div>
           </div>
         );
@@ -199,7 +223,7 @@ function TaskProgressDisplay({
           <span className="text-title-small text-[var(--content-strong)]">{title}</span>
           <StatusBadge status={status} />
         </div>
-        <TaskStepList steps={steps} />
+        <TaskStepList steps={steps} taskCompleted={status === "completed"} />
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- Root cause (best-effort): the task_progress card's per-step statuses are driven entirely by the model via `ui_show`/`ui_update` — there is no deterministic backend code that marks a "Verifying Gmail connection" step `failed`. During the Gmail connect path the model probes `assistant oauth ping/status google`, which per the gmail skill "often resolves expired tokens automatically" — i.e. the first ping failing is an expected, recoverable state. The model surfaces that as a `failed` step, then proceeds and the flow completes. Because `ui_update` merges templateData via `Object.assign` (assistant/src/daemon/conversation-surfaces.ts `normalizeTaskProgressCardPatch`), the model must re-send the full `steps` array to clear a step; it doesn't always send a corrective per-step update, so the stale `failed` entry keeps rendering a red CircleX even after the overall card reaches `completed`. I could not pin a single backend line that deterministically sets the step to `failed`, so the fix is the documented presentational guard.
- The fix: in `apps/web/src/domains/chat/components/surfaces/card-surface.tsx`, once the overall task `status === "completed"`, treat any lingering `failed` step as recovered (render the completed glyph) via a small pure helper `effectiveStepStatus`. A `failed` step still renders the red error glyph while the task is `in_progress`/incomplete, so genuine in-flight failures are unaffected. Added two card-surface tests covering both cases.

Residual uncertainty: the underlying behavior is model/skill-driven, so a step can still flash `failed` mid-flow before the task completes; this guard only suppresses the *persistent* error on a successfully completed flow. A follow-up could tighten skill guidance so the model doesn't mark a recoverable ping-retry as `failed` in the first place.

Part of plan: activation-flow-qa-followups.md (PR 6 of 6)