### PR TITLE
fix(web): stop doubled 'Connect Connect Gmail' on oauth connect surface + header (JARVIS-1113)

### DIFF
--- a/apps/web/src/domains/chat/components/surfaces/choice-copy-surfaces.test.tsx
+++ b/apps/web/src/domains/chat/components/surfaces/choice-copy-surfaces.test.tsx
@@ -240,6 +240,31 @@ describe("OAuthConnectSurface", () => {
     });
   });
 
+  test("does not double the verb when displayName already includes 'Connect'", () => {
+    const oauthClient: ManagedOAuthConnectClient = {
+      fetchProvider: mock(async () => null),
+      connect: mock(async () => ({ status: "cancelled" as const })),
+    };
+
+    const { getByText, queryByText } = render(
+      <OAuthConnectSurface
+        surface={makeSurface({
+          surfaceType: "oauth_connect",
+          data: {
+            providerKey: "google",
+            displayName: "Connect Gmail",
+          },
+        })}
+        assistantId="assistant-1"
+        oauthClient={oauthClient}
+        onAction={mock(() => {})}
+      />,
+    );
+
+    expect(getByText("Connect Gmail")).toBeTruthy();
+    expect(queryByText("Connect Connect Gmail")).toBeNull();
+  });
+
   test("lets the user cancel without opening OAuth", () => {
     const onAction = mock(() => {});
     const oauthClient: ManagedOAuthConnectClient = {

--- a/apps/web/src/domains/chat/components/surfaces/oauth-connect-surface.tsx
+++ b/apps/web/src/domains/chat/components/surfaces/oauth-connect-surface.tsx
@@ -56,6 +56,15 @@ function getProviderLabel(
   return "this account";
 }
 
+/**
+ * Strip a leading "Connect "/"Connected " verb from a provider label so a
+ * caller-supplied `displayName` like "Connect Gmail" doesn't double the verb
+ * when prefixed (e.g. avoids "Connect Connect Gmail").
+ */
+function stripConnectVerb(label: string): string {
+  return label.replace(/^connect(?:ed)?\s+/i, "");
+}
+
 function OAuthApprovalInfo({
   assistantDisplayName,
 }: {
@@ -178,7 +187,7 @@ export function OAuthConnectSurface({
 
           <div className="min-w-0 flex-1">
             <div className="text-title-small text-[var(--content-strong)]">
-              {surface.title ?? `Connect ${providerLabel}`}
+              {surface.title ?? `Connect ${stripConnectVerb(providerLabel)}`}
             </div>
             <p className="mt-1 text-body-medium-lighter text-[var(--content-quiet)]">
               <span>{description}</span>

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -1960,6 +1960,15 @@ export function refreshSurfacesForApp(
   return refreshed;
 }
 
+/**
+ * Strip a leading "Connect "/"Connected " verb from an OAuth provider label so
+ * a supplied displayName like "Connect Gmail" doesn't double the verb when
+ * prefixed (e.g. avoids "Connected Connect Gmail").
+ */
+function stripConnectVerb(label: string): string {
+  return label.replace(/^connect(?:ed)?\s+/i, "");
+}
+
 export function buildCompletionSummary(
   surfaceType: string | undefined,
   actionId: string,
@@ -2029,9 +2038,10 @@ export function buildCompletionSummary(
     const accountLabel =
       typeof data?.accountLabel === "string" ? data.accountLabel : undefined;
     if (actionId === "connect" || data?.status === "connected") {
+      const connectedLabel = stripConnectVerb(providerLabel);
       return accountLabel
-        ? `Connected ${providerLabel}: ${accountLabel}`
-        : `Connected ${providerLabel}`;
+        ? `Connected ${connectedLabel}: ${accountLabel}`
+        : `Connected ${connectedLabel}`;
     }
     if (actionId === "cancel" || data?.status === "cancelled") {
       return `Cancelled ${providerLabel} connection`;
@@ -2123,9 +2133,10 @@ function buildUserFacingLabel(
     const accountLabel =
       typeof data?.accountLabel === "string" ? data.accountLabel : undefined;
     if (actionId === "connect" || data?.status === "connected") {
+      const connectedLabel = stripConnectVerb(providerLabel);
       return accountLabel
-        ? `Connected ${providerLabel}: ${accountLabel}`
-        : `Connected ${providerLabel}`;
+        ? `Connected ${connectedLabel}: ${accountLabel}`
+        : `Connected ${connectedLabel}`;
     }
     if (actionId === "cancel" || data?.status === "cancelled") {
       return "Cancelled";


### PR DESCRIPTION
## Summary
- Normalize provider label so the connect title shows the verb once
- Same normalization on the post-OAuth 'Connected …' system header
- Test covers a displayName already containing 'Connect'

Part of plan: activation-flow-qa-followups.md (PR 5 of 6)