### PR TITLE
fix(ci): consistent publish-npm job names and blocking build-electron in dev-release

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -1234,7 +1234,7 @@ jobs:
   # SLACK_RELEASES_WEBHOOK_URL (releases). The job no-ops if the secret is unset.
 
   notify-dev-release:
-    needs: [compute-version, register-release, register-preview-release]
+    needs: [compute-version, register-release, register-preview-release, build-electron]
     # Run on success and failure alike, but not when the run was cancelled
     # (e.g. superseded by a newer hourly run via cancel-in-progress) — a
     # cancelled run is not a real failure and should not alert the channel.
@@ -1792,7 +1792,6 @@ jobs:
     needs: [compute-version, publish-meta-dev]
     runs-on: macos-26
     timeout-minutes: 30
-    continue-on-error: true
     defaults:
       run:
         working-directory: apps/macos
@@ -2021,6 +2020,7 @@ jobs:
           npm publish --tag dev --access public --no-provenance
 
   publish-web-dev:
+    name: publish-npm-dev (web)
     needs: [compute-version, ci-assistant, ci-cli, ci-gateway, ci-credential-executor]
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -2075,6 +2075,7 @@ jobs:
           npm publish --tag dev --access public --no-provenance
 
   publish-meta-dev:
+    name: publish-npm-dev (meta)
     needs: [compute-version, publish-npm-dev, publish-web-dev]
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1414,6 +1414,7 @@ jobs:
           npm publish --tag staging --access public --no-provenance
 
   publish-web-staging:
+    name: publish-npm-staging (web)
     needs: [extract-version, ci-assistant, ci-cli, ci-gateway, ci-credential-executor]
     if: ${{ needs.extract-version.outputs.is_staging == 'true' }}
     runs-on: ubuntu-latest
@@ -1469,6 +1470,7 @@ jobs:
           npm publish --tag staging --access public --no-provenance
 
   publish-meta-staging:
+    name: publish-npm-staging (meta)
     needs: [extract-version, publish-npm-staging, publish-web-staging]
     if: ${{ needs.extract-version.outputs.is_staging == 'true' }}
     runs-on: ubuntu-latest
@@ -1507,6 +1509,7 @@ jobs:
           npm publish --tag staging --access public --no-provenance
 
   publish-web-prod:
+    name: publish-npm-prod (web)
     needs: [extract-version, ci-cli, ci-gateway, ci-playwright, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image]
     if: ${{ always() && !cancelled() && needs.extract-version.outputs.is_staging != 'true' && needs.ci-cli.result == 'success' && needs.ci-gateway.result == 'success' && (needs.ci-playwright.result == 'success' || inputs.playwright_blocks_release != true) && needs.push-assistant-manifest.result == 'success' && needs.push-gateway-manifest.result == 'success' && needs.push-credential-executor-manifest.result == 'success' && needs.push-dockerhub-image.result == 'success' }}
     runs-on: ubuntu-latest
@@ -1578,6 +1581,7 @@ jobs:
           npm publish --access public --no-provenance
 
   publish-meta-prod:
+    name: publish-npm-prod (meta)
     needs: [extract-version, publish-npm-prod, publish-web-prod]
     if: ${{ needs.extract-version.outputs.is_staging != 'true' }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Rename `publish-web-*` and `publish-meta-*` display names to `publish-npm-* (web)` / `publish-npm-* (meta)` so they visually match the matrix-expanded `publish-npm-*` jobs in the GitHub Actions UI
- Make `build-electron` a hard-failing, blocking step in dev-release: removed `continue-on-error` and added it to `notify-dev-release` needs so Slack notification waits for it to complete
- Staging/prod releases keep `build-electron` as non-blocking

## Test plan
- [ ] Verify dev-release workflow parses correctly
- [ ] Confirm job display names render as `publish-npm-dev (web)`, `publish-npm-dev (meta)`, etc.
- [ ] Confirm `build-electron` failure blocks `notify-dev-release` and fails the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)