### PR TITLE
feat(activation): enforce task_progress on long/post-submit rail turns (JARVIS-1114)

### DIFF
--- a/assistant/src/prompts/templates/BOOTSTRAP-ACTIVATION-RAIL.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP-ACTIVATION-RAIL.md
@@ -63,6 +63,8 @@ These are enforcement rules, not advice.
 
 **Self-check before final emit.** If this turn contains an offer or a follow-up, render it via `ui_show`, not prose.
 
+**Long turns show progress.** Any post-submit / post-skill-load turn must render a `task_progress` card within ~5s, or fall back to streaming text. Bind "long turn" → "task_progress emitted": a long-running turn that produces neither a progress card nor streaming text didn't satisfy this move.
+
 **Action Trust-Guarantee.** Sibling to the OAuth Trust-Guarantee. Before a bulk write / delete / destructive op, render a `ui_show` preview — a table surface showing total count, breakdown, sample rows, and the categories to confirm. The user commits or refines on that surface; only then do you execute. Single-item actions use the natural draft instead. Threshold for the preview gate: bulk *and* low recoverability. One of the two alone doesn't trip it.
 
 **Start Small.** On first execution of any skill, prefer the smallest meaningful result over the most complete result. Show, then offer to expand.

--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -73,11 +73,10 @@ function isDynamicPageAppSubstitute(input: Record<string, unknown>): boolean {
   return isSubstantialInteractiveHtml(input);
 }
 
-const INTERACTIVE_HTML_RE = /<script\b|on[a-z]+\s*=|addEventListener|new Chart\b|window\.vellum\b/i;
+const INTERACTIVE_HTML_RE =
+  /<script\b|on[a-z]+\s*=|addEventListener|new Chart\b|window\.vellum\b/i;
 
-function isSubstantialInteractiveHtml(
-  input: Record<string, unknown>,
-): boolean {
+function isSubstantialInteractiveHtml(input: Record<string, unknown>): boolean {
   const data = asRecord(input.data);
   const html = data?.html;
   if (typeof html !== "string") {
@@ -137,7 +136,7 @@ export const uiShowTool = {
     "- file_upload: { prompt, acceptedTypes?, maxFiles? }\n" +
     "- task_preferences: {} (no data needed — categories are rendered client-side)\n" +
     '- work_result: { eyebrow?, status?: "completed"|"partial"|"failed"|"in_progress", summary?, metrics?: [{ label, value, detail?, tone?: "neutral"|"positive"|"warning"|"negative" }], sections?: [{ id?, title, description?, type?: "items"|"timeline"|"diff"|"artifacts"|"warnings", items?: [{ id?, title, description?, status?, tone?, metadata?: [{ label, value }], href? }], diffs?: [{ label?, before?, after? }] }] }. Shows a structured receipt after real work: what changed, what was skipped, proof points, and next actions. Keep display-only unless explicit follow-up buttons are needed.\n\n' +
-    "Proactively show a task_progress card before multi-step or long-running work (web searches, file operations, research). Show it before your first tool call, then update steps as work progresses.",
+    "Emit a task_progress card BEFORE your first tool call on any multi-step, long-running, or post-form turn (web searches, file operations, research), and keep its steps updated as work progresses. Skills that estimate >30s of work should declare progress upfront with concrete step labels (and counts when known).",
   category: "ui-surface",
   defaultRiskLevel: RiskLevel.Low,
   executionTarget: "host",


### PR DESCRIPTION
## Summary
- Rail rule: post-submit/post-skill-load turn must render task_progress within ~5s or stream text
- Strengthen the ui_show task_progress guidance from awareness to enforcement (emit before first tool call; >30s skills declare progress upfront)

Part of plan: activation-flow-qa-followups.md (PR 2 of 6)