### PR TITLE
fix(electron): blank white screen from duplicate React instances

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -1234,7 +1234,7 @@ jobs:
   # SLACK_RELEASES_WEBHOOK_URL (releases). The job no-ops if the secret is unset.
 
   notify-dev-release:
-    needs: [compute-version, register-release, register-preview-release]
+    needs: [compute-version, register-release, register-preview-release, build-electron]
     # Run on success and failure alike, but not when the run was cancelled
     # (e.g. superseded by a newer hourly run via cancel-in-progress) — a
     # cancelled run is not a real failure and should not alert the channel.
@@ -1792,7 +1792,6 @@ jobs:
     needs: [compute-version, publish-meta-dev]
     runs-on: macos-26
     timeout-minutes: 30
-    continue-on-error: true
     defaults:
       run:
         working-directory: apps/macos
@@ -2021,6 +2020,7 @@ jobs:
           npm publish --tag dev --access public --no-provenance
 
   publish-web-dev:
+    name: publish-npm-dev (web)
     needs: [compute-version, ci-assistant, ci-cli, ci-gateway, ci-credential-executor]
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -2075,6 +2075,7 @@ jobs:
           npm publish --tag dev --access public --no-provenance
 
   publish-meta-dev:
+    name: publish-npm-dev (meta)
     needs: [compute-version, publish-npm-dev, publish-web-dev]
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1414,6 +1414,7 @@ jobs:
           npm publish --tag staging --access public --no-provenance
 
   publish-web-staging:
+    name: publish-npm-staging (web)
     needs: [extract-version, ci-assistant, ci-cli, ci-gateway, ci-credential-executor]
     if: ${{ needs.extract-version.outputs.is_staging == 'true' }}
     runs-on: ubuntu-latest
@@ -1469,6 +1470,7 @@ jobs:
           npm publish --tag staging --access public --no-provenance
 
   publish-meta-staging:
+    name: publish-npm-staging (meta)
     needs: [extract-version, publish-npm-staging, publish-web-staging]
     if: ${{ needs.extract-version.outputs.is_staging == 'true' }}
     runs-on: ubuntu-latest
@@ -1507,6 +1509,7 @@ jobs:
           npm publish --tag staging --access public --no-provenance
 
   publish-web-prod:
+    name: publish-npm-prod (web)
     needs: [extract-version, ci-cli, ci-gateway, ci-playwright, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image]
     if: ${{ always() && !cancelled() && needs.extract-version.outputs.is_staging != 'true' && needs.ci-cli.result == 'success' && needs.ci-gateway.result == 'success' && (needs.ci-playwright.result == 'success' || inputs.playwright_blocks_release != true) && needs.push-assistant-manifest.result == 'success' && needs.push-gateway-manifest.result == 'success' && needs.push-credential-executor-manifest.result == 'success' && needs.push-dockerhub-image.result == 'success' }}
     runs-on: ubuntu-latest
@@ -1578,6 +1581,7 @@ jobs:
           npm publish --access public --no-provenance
 
   publish-meta-prod:
+    name: publish-npm-prod (meta)
     needs: [extract-version, publish-npm-prod, publish-web-prod]
     if: ${{ needs.extract-version.outputs.is_staging != 'true' }}
     runs-on: ubuntu-latest

--- a/apps/macos/src/main/csp.ts
+++ b/apps/macos/src/main/csp.ts
@@ -16,7 +16,7 @@ export const CSP_POLICY = [
   "img-src 'self' https: data: blob:",
   "media-src 'self' blob:",
   "worker-src 'self' blob: https://cdn.jsdelivr.net",
-  "font-src 'self'",
+  "font-src 'self' data:",
   "object-src 'none'",
   "base-uri 'none'",
   "frame-ancestors 'none'",

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -109,6 +109,7 @@ export default defineConfig(({ mode }) => {
           replacement: path.resolve(import.meta.dirname, "src") + "/",
         },
       ],
+      dedupe: ["react", "react-dom"],
       preserveSymlinks: true,
     },
     server: {


### PR DESCRIPTION
## Summary

- **Root cause**: The Electron app's packaged build shows a blank white screen because `preserveSymlinks: true` in the web Vite config causes `react` to be resolved via two different `node_modules` paths — once from `apps/web/node_modules/react` and once from `packages/design-library/node_modules/react` (a symlink). Rolldown (Vite 8's bundler) creates separate CJS factory wrappers for each path, producing two independent React instances. `react-dom` initializes only one, so hooks called through the other hit a null dispatcher (`TypeError: Cannot read properties of null (reading 'useRef')`).
- **Fix**: Add `resolve.dedupe: ["react", "react-dom"]` so Vite always resolves React from a single location regardless of the import origin.
- Also allow `data:` in the CSP `font-src` directive — the web app embeds fonts as data URIs which the previous `'self'`-only policy blocked (visible as console errors in the packaged build).

## Test plan

- [ ] Build `apps/web` (`bun run build`) — verify only one `react-*.js` chunk exists in `dist/assets/` and the `cn-*.js` chunk imports from it rather than containing its own React copy
- [ ] Package the Electron app (`bun run pack`) — verify the app renders instead of showing a blank white screen
- [ ] Verify `bun test` in `apps/macos` — CSP tests should pass
- [ ] Dev mode (`bun run dev`) continues to work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)