### PR TITLE
fix: connect-verb doubling — fix at resolver + all branches (JARVIS-1113 follow-up)

### DIFF
--- a/apps/web/src/domains/chat/components/surfaces/choice-copy-surfaces.test.tsx
+++ b/apps/web/src/domains/chat/components/surfaces/choice-copy-surfaces.test.tsx
@@ -263,6 +263,13 @@ describe("OAuthConnectSurface", () => {
 
     expect(getByText("Connect Gmail")).toBeTruthy();
     expect(queryByText("Connect Connect Gmail")).toBeNull();
+    // The description fallback resolves through the same normalized label,
+    // so it must not double the verb either.
+    expect(
+      getByText("Connect Gmail so I can use it for this task.", {
+        exact: false,
+      }),
+    ).toBeTruthy();
   });
 
   test("lets the user cancel without opening OAuth", () => {

--- a/apps/web/src/domains/chat/components/surfaces/oauth-connect-surface.tsx
+++ b/apps/web/src/domains/chat/components/surfaces/oauth-connect-surface.tsx
@@ -50,10 +50,14 @@ function getProviderLabel(
   data: OAuthConnectSurfaceData,
   provider: ManagedOAuthProviderSummary | null,
 ): string {
-  if (data.displayName) return data.displayName;
-  if (provider?.display_name) return provider.display_name;
-  if (data.providerKey) return titleizeProviderKey(data.providerKey);
-  return "this account";
+  const raw =
+    data.displayName ||
+    provider?.display_name ||
+    (data.providerKey ? titleizeProviderKey(data.providerKey) : "this account");
+  // Normalize once at the resolver so the title, description, icon, and
+  // action payloads never double the verb (e.g. "Connect Connect Gmail")
+  // when a caller-supplied displayName already begins with "Connect ".
+  return stripConnectVerb(raw);
 }
 
 /**
@@ -187,7 +191,7 @@ export function OAuthConnectSurface({
 
           <div className="min-w-0 flex-1">
             <div className="text-title-small text-[var(--content-strong)]">
-              {surface.title ?? `Connect ${stripConnectVerb(providerLabel)}`}
+              {surface.title ?? `Connect ${providerLabel}`}
             </div>
             <p className="mt-1 text-body-medium-lighter text-[var(--content-quiet)]">
               <span>{description}</span>

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -2035,21 +2035,24 @@ export function buildCompletionSummary(
           : typeof data?.providerKey === "string"
             ? data.providerKey
             : "OAuth";
+    // Strip the verb once so every branch (connected/cancelled/failed/
+    // fallback) is normalized — a displayName like "Connect Gmail" must not
+    // produce "Cancelled Connect Gmail connection".
+    const label = stripConnectVerb(providerLabel);
     const accountLabel =
       typeof data?.accountLabel === "string" ? data.accountLabel : undefined;
     if (actionId === "connect" || data?.status === "connected") {
-      const connectedLabel = stripConnectVerb(providerLabel);
       return accountLabel
-        ? `Connected ${connectedLabel}: ${accountLabel}`
-        : `Connected ${connectedLabel}`;
+        ? `Connected ${label}: ${accountLabel}`
+        : `Connected ${label}`;
     }
     if (actionId === "cancel" || data?.status === "cancelled") {
-      return `Cancelled ${providerLabel} connection`;
+      return `Cancelled ${label} connection`;
     }
     if (data?.status === "error") {
-      return `${providerLabel} connection failed`;
+      return `${label} connection failed`;
     }
-    return `${providerLabel} connection ${actionId}`;
+    return `${label} connection ${actionId}`;
   }
   if (surfaceType === "list" && data) {
     const selectedIds = data.selectedIds as string[] | undefined;
@@ -2130,19 +2133,21 @@ function buildUserFacingLabel(
           : typeof data?.providerKey === "string"
             ? data.providerKey
             : "OAuth";
+    // Strip the verb once so every branch is normalized (e.g. a displayName
+    // like "Connect Gmail" must not produce "Connect Gmail connection failed").
+    const label = stripConnectVerb(providerLabel);
     const accountLabel =
       typeof data?.accountLabel === "string" ? data.accountLabel : undefined;
     if (actionId === "connect" || data?.status === "connected") {
-      const connectedLabel = stripConnectVerb(providerLabel);
       return accountLabel
-        ? `Connected ${connectedLabel}: ${accountLabel}`
-        : `Connected ${connectedLabel}`;
+        ? `Connected ${label}: ${accountLabel}`
+        : `Connected ${label}`;
     }
     if (actionId === "cancel" || data?.status === "cancelled") {
       return "Cancelled";
     }
     if (data?.status === "error") {
-      return `${providerLabel} connection failed`;
+      return `${label} connection failed`;
     }
     return `Selected: ${actionId}`;
   }


### PR DESCRIPTION
## Summary
Self-review remediation for the connect-label fix:
- apps/web: move stripConnectVerb into getProviderLabel so title, description, icon, and payloads are all normalized; drop the redundant title-only wrap
- assistant: apply the stripped label to ALL branches (cancelled/failed/fallback), not just 'Connected'
- test: assert the description no longer doubles the verb

Part of plan: activation-flow-qa-followups.md (self-review fix)