### PR TITLE
fix(memory-v2): stop dynamic <memory> block from suppressing the static <info> injection

### DIFF
--- a/assistant/src/__tests__/memory-v2-static-injector.test.ts
+++ b/assistant/src/__tests__/memory-v2-static-injector.test.ts
@@ -11,6 +11,9 @@
  *   - Skips (re)injection when the `<info>` block is already present in the
  *     turn's working messages (presence detection — the block persists in
  *     history between compactions).
+ *   - Still injects when only a dynamic `<memory>` activation block is present
+ *     (that wrapper must not be mistaken for the static block) — both on a
+ *     normal turn and after compaction strips the prior `<info>` block.
  *
  * The injector sources its content itself via `readMemoryV2StaticContent()`
  * behind the personal-memory trust gate, so each test seeds the workspace
@@ -140,10 +143,12 @@ describe("memory-v2-static injector", () => {
     expect(await memoryV2StaticInjector.produce(ctx, runMessages)).toBeNull();
   });
 
-  test("skips (re)injection when a legacy <memory>-wrapped static block is present", async () => {
-    // Rows persisted before the `<info>` switch rehydrate the static block as
-    // `<memory>…</memory>`. Re-injecting a fresh `<info>` copy alongside it
-    // would duplicate the content until the next compaction.
+  test("injects the <info> block even when a dynamic <memory> activation block is present", async () => {
+    // Regression (#33612): the v2 *dynamic* activation block uses the
+    // `<memory>…</memory>` wrapper and `prepareMemory` prepends it to the tail
+    // user message every turn, before this injector runs. The static injector
+    // must NOT treat that as its own `<info>` block — doing so suppressed the
+    // static block on essentially every turn.
     seedEssentials("Alice prefers VS Code.");
     const ctx = makeContext();
     const runMessages: Message[] = [
@@ -152,12 +157,42 @@ describe("memory-v2-static injector", () => {
         content: [
           {
             type: "text",
-            text: "<memory>\n## Essentials\n\nAlice prefers VS Code.\n</memory>",
+            text: "<memory>\n# memory/concepts/foo.md\nactivated page summary\n</memory>",
           },
           { type: "text", text: "What next?" },
         ],
       },
     ];
-    expect(await memoryV2StaticInjector.produce(ctx, runMessages)).toBeNull();
+    const block = await memoryV2StaticInjector.produce(ctx, runMessages);
+    expect(block).not.toBeNull();
+    expect(block!.id).toBe("memory-v2-static");
+    expect(block!.text).toBe(
+      "<info>\n## Essentials\n\nAlice prefers VS Code.\n</info>",
+    );
+  });
+
+  test("reinjects the <info> block after compaction strips it, alongside a fresh <memory> block", async () => {
+    // Post-compaction state: `stripInjectionsForCompaction` removed the prior
+    // `<info>` block, and the next turn's `prepareMemory` re-added a fresh
+    // dynamic `<memory>` block ahead of the chain. With no `<info>` present, the
+    // injector must reinject it rather than skip on the `<memory>` block.
+    seedEssentials("Alice prefers VS Code.");
+    const ctx = makeContext();
+    const postCompactMessages: Message[] = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "<memory>\nactivated page summary\n</memory>" },
+          { type: "text", text: "Continue please." },
+        ],
+      },
+    ];
+    const block = await memoryV2StaticInjector.produce(
+      ctx,
+      postCompactMessages,
+    );
+    expect(block).not.toBeNull();
+    expect(block!.id).toBe("memory-v2-static");
+    expect(block!.text).toContain("## Essentials");
   });
 });

--- a/assistant/src/plugins/defaults/memory-retrieval/injectors.ts
+++ b/assistant/src/plugins/defaults/memory-retrieval/injectors.ts
@@ -433,18 +433,23 @@ const NOW_MD_BLOCK_PREFIXES = [
  * merely starting with `<info>\n` is never mistaken for an injection — matching
  * the full-wrapper requirement the compaction strip uses for this block.
  *
- * The static block is wrapped in `<info>…</info>` today, but rows persisted
- * before that switch rehydrate verbatim as `<memory>…</memory>` (see
- * `conversation-lifecycle`), so the legacy wrapper counts as present too.
- * Matching `<memory>` cannot wrongly skip a needed injection: the static block
- * is only (re)injected on the first turn (empty history) and right after
- * compaction (which strips both wrappers), and on neither is a `<memory>` block
- * present — the dynamic activation `<memory>` block only survives on normal
- * cached turns, which is exactly when this injector must skip anyway.
+ * Match ONLY the `<info>…</info>` wrapper — the form the static block is always
+ * written as today (see {@link buildMemoryV2StaticBlock}). The matcher must NOT
+ * also match `<memory>…</memory>`: the v2 *dynamic* activation block uses that
+ * same wrapper and `prepareMemory` prepends it to the tail user message every
+ * turn, before this injector chain runs. Counting `<memory>` as "static block
+ * already present" made the static injector skip on essentially every turn —
+ * including the first turn and right after compaction, where the dynamic block
+ * is re-added ahead of the chain — which dropped the `<info>` block entirely.
+ *
+ * Tradeoff: a conversation whose static block was persisted under the legacy
+ * `<memory>` wrapper (pre-`<info>` switch) is no longer recognized here, so its
+ * first post-fix turn may briefly carry both the stale `<memory>` view and a
+ * fresh `<info>` block. That is rare (ancient histories only), cosmetic, and
+ * self-heals on the next compaction (which strips both wrappers).
  */
 const MEMORY_V2_STATIC_BLOCK_MATCHERS: readonly InjectionMatcher[] = [
   { prefix: "<info>\n", suffix: "\n</info>" },
-  { prefix: "<memory>\n", suffix: "\n</memory>" },
 ];
 
 /**


### PR DESCRIPTION
## Summary
- The `memory-v2-static` injector skipped (re)injecting the static `<info>` block (essentials/threads/recent/buffer) whenever a block matching `<memory>…</memory>` was already on the tail user message. The v2 *dynamic* activation block uses that exact wrapper and `prepareMemory` prepends it every turn **before** the injector chain runs — so the static block was suppressed on essentially every turn (live request logs showed ~85%/day `<info>` presence cliffing to <10% after the #33612 deploy).
- Fix: `MEMORY_V2_STATIC_BLOCK_MATCHERS` now matches **only** the `<info>…</info>` wrapper (the form the static block is always written as today). This also restores post-compaction reinjection: compaction already strips `<info>` (via `stripInjectionsForCompaction`), and the static injector now reinjects it even alongside the freshly re-added dynamic `<memory>` block.
- Tests: replaced the test that asserted the buggy behavior with regression tests proving the `<info>` block is injected when a dynamic `<memory>` block coexists (normal turn) and reinjected after compaction; kept the no-duplicate guard (an existing real `<info>` block still suppresses re-injection).

## Tradeoff
A conversation whose static block was persisted under the legacy `<memory>` wrapper (pre-`<info>` switch, #31845) is no longer recognized by the presence check, so its first post-fix turn may briefly carry both the stale `<memory>` view and a fresh `<info>` block. That is rare (ancient histories only), cosmetic, and self-heals on the next compaction (which strips both wrappers).

## Original prompt
Investigated why the `<info>` memory block (the static essentials/threads/recent/buffer view) stopped being injected into conversations. Traced it to the #33612 presence-detection refactor: the static injector's presence check conflated the dynamic `<memory>` activation block with its own `<info>` block and skipped re-injection. The ask was to fix the suppression and ensure the `<info>` block is also reinjected after compaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)