### PR TITLE
feat(plugins): add pre-model-call + assistant-message hooks for output transformation

### DIFF
--- a/assistant/src/__tests__/agent-loop-output-hooks.test.ts
+++ b/assistant/src/__tests__/agent-loop-output-hooks.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Tests for the `pre-model-call` and `assistant-message` plugin hooks: a plugin
+ * can edit the outbound request, transform the finalized assistant message
+ * (persisted + streamed), and defer the live stream so the transformed text is
+ * emitted once. All hooks here use neutral transforms (redaction / uppercasing).
+ */
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import type { AgentEvent } from "../agent/loop.js";
+import { AgentLoop } from "../agent/loop.js";
+import type {
+  AssistantMessageContext,
+  PreModelCallContext,
+} from "../plugin-api/types.js";
+import { resetPluginRegistryAndRegisterDefaults } from "../plugins/defaults/index.js";
+import { registerPlugin } from "../plugins/registry.js";
+import type {
+  ContentBlock,
+  Message,
+  ProviderResponse,
+} from "../providers/types.js";
+import { createMockProvider, textResponse } from "./helpers/mock-provider.js";
+
+const userMessage: Message = {
+  role: "user",
+  content: [{ type: "text", text: "Hello" }],
+};
+
+function collect(events: AgentEvent[]): (event: AgentEvent) => void {
+  return (event) => events.push(event);
+}
+
+function streamedText(events: AgentEvent[]): string {
+  return events
+    .filter(
+      (e): e is Extract<AgentEvent, { type: "text_delta" }> =>
+        e.type === "text_delta",
+    )
+    .map((e) => e.text)
+    .join("");
+}
+
+function textOf(content: ReadonlyArray<ContentBlock>): string {
+  let out = "";
+  for (const block of content) if (block.type === "text") out += block.text;
+  return out;
+}
+
+function lastAssistant(history: Message[]): Message {
+  for (let i = history.length - 1; i >= 0; i--) {
+    if (history[i].role === "assistant") return history[i];
+  }
+  throw new Error("no assistant message in history");
+}
+
+function registerOutputHookPlugin(hooks: {
+  preModelCall?: (ctx: PreModelCallContext) => void;
+  assistantMessage?: (ctx: AssistantMessageContext) => void;
+}): void {
+  registerPlugin({
+    manifest: { name: "test-output-hooks", version: "0.0.0" },
+    hooks: {
+      ...(hooks.preModelCall
+        ? {
+            "pre-model-call": async (ctx: PreModelCallContext) => {
+              hooks.preModelCall!(ctx);
+            },
+          }
+        : {}),
+      ...(hooks.assistantMessage
+        ? {
+            "assistant-message": async (ctx: AssistantMessageContext) => {
+              hooks.assistantMessage!(ctx);
+            },
+          }
+        : {}),
+    },
+  });
+}
+
+describe("agent loop output hooks", () => {
+  beforeEach(() => {
+    resetPluginRegistryAndRegisterDefaults();
+  });
+
+  test("assistant-message transforms the persisted message content", async () => {
+    registerOutputHookPlugin({
+      assistantMessage: (ctx) => {
+        ctx.content = ctx.content.map((b) =>
+          b.type === "text"
+            ? { type: "text", text: b.text.replace("secret", "[redacted]") }
+            : b,
+        );
+      },
+    });
+    const { provider } = createMockProvider([textResponse("my secret value")]);
+    const loop = new AgentLoop(provider, "system");
+    const events: AgentEvent[] = [];
+    const { history } = await loop.run([userMessage], collect(events));
+    expect(textOf(lastAssistant(history).content)).toBe("my [redacted] value");
+  });
+
+  test("deferred output: the real stream is suppressed and the transformed text is emitted once", async () => {
+    registerOutputHookPlugin({
+      preModelCall: (ctx) => {
+        ctx.deferAssistantOutput = true;
+      },
+      assistantMessage: (ctx) => {
+        ctx.content = [{ type: "text", text: "[filtered]" }];
+      },
+    });
+    const { provider } = createMockProvider([textResponse("my secret value")]);
+    const loop = new AgentLoop(provider, "system");
+    const events: AgentEvent[] = [];
+    const { history } = await loop.run([userMessage], collect(events));
+    // Her real words never streamed; only the transformed text did, once.
+    expect(streamedText(events)).not.toContain("secret");
+    expect(streamedText(events)).toBe("[filtered]");
+    expect(textOf(lastAssistant(history).content)).toBe("[filtered]");
+  });
+
+  test("without defer, the real text still streams while storage is transformed", async () => {
+    registerOutputHookPlugin({
+      assistantMessage: (ctx) => {
+        ctx.content = [{ type: "text", text: "[stored]" }];
+      },
+    });
+    const { provider } = createMockProvider([textResponse("live text")]);
+    const loop = new AgentLoop(provider, "system");
+    const events: AgentEvent[] = [];
+    const { history } = await loop.run([userMessage], collect(events));
+    expect(streamedText(events)).toBe("live text"); // streamed live, untransformed
+    expect(textOf(lastAssistant(history).content)).toBe("[stored]"); // storage transformed
+  });
+
+  test("transforms text but leaves tool_use blocks intact", async () => {
+    const toolAndText: ProviderResponse = {
+      content: [
+        { type: "text", text: "calling" },
+        { type: "tool_use", id: "t1", name: "noop", input: {} },
+      ],
+      model: "mock-model",
+      usage: { inputTokens: 1, outputTokens: 1 },
+      stopReason: "tool_use",
+    };
+    registerOutputHookPlugin({
+      assistantMessage: (ctx) => {
+        ctx.content = ctx.content.map((b) =>
+          b.type === "text" ? { type: "text", text: b.text.toUpperCase() } : b,
+        );
+      },
+    });
+    const { provider } = createMockProvider([
+      toolAndText,
+      textResponse("done"),
+    ]);
+    const loop = new AgentLoop(provider, "system", {
+      tools: [
+        {
+          name: "noop",
+          description: "",
+          input_schema: { type: "object", properties: {} },
+        },
+      ],
+      toolExecutor: async () => ({ content: "ok", isError: false }),
+    });
+    const { history } = await loop.run([userMessage], collect([]));
+    const toolTurn = history.find(
+      (m) =>
+        m.role === "assistant" && m.content.some((b) => b.type === "tool_use"),
+    )!;
+    expect(toolTurn.content.find((b) => b.type === "text")).toEqual({
+      type: "text",
+      text: "CALLING",
+    });
+    expect(toolTurn.content.find((b) => b.type === "tool_use")).toMatchObject({
+      type: "tool_use",
+      id: "t1",
+      name: "noop",
+    });
+  });
+
+  test("pre-model-call can edit the outbound system prompt", async () => {
+    registerOutputHookPlugin({
+      preModelCall: (ctx) => {
+        ctx.systemPrompt = `${ctx.systemPrompt ?? ""} [EDITED]`;
+      },
+    });
+    const { provider, calls } = createMockProvider([textResponse("hi")]);
+    const loop = new AgentLoop(provider, "base prompt");
+    await loop.run([userMessage], collect([]));
+    expect(calls[0].systemPrompt).toContain("[EDITED]");
+  });
+
+  test("fail-open: a throwing assistant-message hook keeps the original content", async () => {
+    registerOutputHookPlugin({
+      assistantMessage: () => {
+        throw new Error("boom");
+      },
+    });
+    const { provider } = createMockProvider([textResponse("untouched")]);
+    const loop = new AgentLoop(provider, "system");
+    const { history } = await loop.run([userMessage], collect([]));
+    expect(textOf(lastAssistant(history).content)).toBe("untouched");
+  });
+});

--- a/assistant/src/__tests__/agent-loop-output-hooks.test.ts
+++ b/assistant/src/__tests__/agent-loop-output-hooks.test.ts
@@ -192,15 +192,104 @@ describe("agent loop output hooks", () => {
     expect(calls[0].systemPrompt).toContain("[EDITED]");
   });
 
-  test("fail-open: a throwing assistant-message hook keeps the original content", async () => {
+  test("fail-open: a hook that mutates in place AND then throws cannot corrupt the persisted content", async () => {
+    // The hook mutates the array it receives before throwing. If the loop
+    // handed the hook the real `assistantMessage.content` array, the
+    // mid-mutation would survive into history. The loop must clone the
+    // content before invoking the hook.
     registerOutputHookPlugin({
-      assistantMessage: () => {
+      assistantMessage: (ctx) => {
+        ctx.content.push({ type: "text", text: "[INJECTED]" });
         throw new Error("boom");
       },
     });
     const { provider } = createMockProvider([textResponse("untouched")]);
     const loop = new AgentLoop(provider, "system");
     const { history } = await loop.run([userMessage], collect([]));
-    expect(textOf(lastAssistant(history).content)).toBe("untouched");
+    const finalContent = lastAssistant(history).content;
+    expect(textOf(finalContent)).toBe("untouched");
+    expect(
+      finalContent.some((b) => b.type === "text" && b.text === "[INJECTED]"),
+    ).toBe(false);
+  });
+
+  test("max_tokens turn: the hook fires and the deferred final text is emitted", async () => {
+    // Without this, an output-filter plugin misses the truncated reply; with
+    // defer set, the live stream was suppressed and the client would see
+    // nothing at all.
+    const seen: { calls: number } = { calls: 0 };
+    registerOutputHookPlugin({
+      preModelCall: (ctx) => {
+        ctx.deferAssistantOutput = true;
+      },
+      assistantMessage: (ctx) => {
+        seen.calls += 1;
+        ctx.content = ctx.content.map((b) =>
+          b.type === "text" ? { type: "text", text: b.text.toUpperCase() } : b,
+        );
+      },
+    });
+    const truncated: ProviderResponse = {
+      content: [{ type: "text", text: "partial answer" }],
+      model: "mock-model",
+      usage: { inputTokens: 1, outputTokens: 1 },
+      stopReason: "max_tokens",
+    };
+    const { provider } = createMockProvider([truncated]);
+    const loop = new AgentLoop(provider, "system");
+    const events: AgentEvent[] = [];
+    const { history } = await loop.run([userMessage], collect(events));
+    expect(seen.calls).toBe(1);
+    expect(textOf(lastAssistant(history).content)).toBe("PARTIAL ANSWER");
+    // Real stream suppressed; transformed final text emitted once.
+    expect(streamedText(events)).toBe("PARTIAL ANSWER");
+  });
+
+  test("deferred final text passes through sensitive-output substitution", async () => {
+    // A tool returns a sensitive binding; the next assistant turn uses the
+    // placeholder (the persisted message must keep it — model never sees real
+    // values on reload), but the deferred final stream must show the real
+    // value, just like the normal live stream would.
+    registerOutputHookPlugin({
+      preModelCall: (ctx) => {
+        ctx.deferAssistantOutput = true;
+      },
+    });
+    const placeholder = "VELLUM_ASSISTANT_INVITE_CODE_TESTXXXX";
+    const real = "real-invite-code-xyz";
+    const toolThenText = [
+      {
+        content: [{ type: "tool_use", id: "t1", name: "issue", input: {} }],
+        model: "mock-model",
+        usage: { inputTokens: 1, outputTokens: 1 },
+        stopReason: "tool_use",
+      } as ProviderResponse,
+      textResponse(`Your code is ${placeholder}.`),
+    ];
+    const { provider } = createMockProvider(toolThenText);
+    const loop = new AgentLoop(provider, "system", {
+      tools: [
+        {
+          name: "issue",
+          description: "",
+          input_schema: { type: "object", properties: {} },
+        },
+      ],
+      toolExecutor: async () => ({
+        content: `code=${placeholder}`,
+        isError: false,
+        sensitiveBindings: [{ kind: "invite_code", placeholder, value: real }],
+      }),
+    });
+    const events: AgentEvent[] = [];
+    const { history } = await loop.run([userMessage], collect(events));
+    // Persisted message keeps the placeholder — model must never see real
+    // values on reload.
+    expect(textOf(lastAssistant(history).content)).toContain(placeholder);
+    expect(textOf(lastAssistant(history).content)).not.toContain(real);
+    // Streamed final text shows the substituted real value, matching the
+    // behavior of the normal live stream.
+    expect(streamedText(events)).toContain(real);
+    expect(streamedText(events)).not.toContain(placeholder);
   });
 });

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -1189,6 +1189,46 @@ export class AgentLoop {
           streamingPending = "";
         }
 
+        // Run the `assistant-message` hook on a finalized message and, when
+        // output was deferred, emit the finalized text once (with sensitive-output
+        // substitution applied, matching the live stream). Fail-open: the hook
+        // receives a clone, so a throw — even mid in-place mutation — leaves the
+        // original message intact.
+        const finalizeAssistantMessage = async (
+          message: Message,
+        ): Promise<Message> => {
+          let finalized = message;
+          try {
+            const ctx: AssistantMessageContext = {
+              conversationId: turnCtx.conversationId,
+              callSite: turnCtx.callSite,
+              content: structuredClone(message.content),
+              stopReason: response.stopReason,
+              logger: rlog,
+            };
+            const result = await runHook(HOOKS.ASSISTANT_MESSAGE, ctx);
+            finalized = { role: "assistant", content: result.content };
+          } catch (assistantMessageError) {
+            rlog.error(
+              { err: assistantMessageError },
+              "assistant-message hook failed — keeping the original content",
+            );
+            finalized = message;
+          }
+          if (deferAssistantOutput) {
+            // The persisted message keeps sensitive-output placeholders; the
+            // stream shows real values — substitute before emitting.
+            const finalText = applySubstitutions(
+              assistantTextOf(finalized.content),
+              substitutionMap,
+            );
+            if (finalText.length > 0) {
+              onEvent({ type: "text_delta", text: finalText });
+            }
+          }
+          return finalized;
+        };
+
         // Build the assistant message with placeholder-only text.
         // Both provider history and persisted conversation store must retain
         // placeholders so the model never sees real sensitive values — neither
@@ -1223,10 +1263,6 @@ export class AgentLoop {
               block.type !== "server_tool_use" &&
               block.type !== "web_search_tool_result",
           );
-          const safeAssistantMessage: Message = {
-            role: "assistant",
-            content: safeContent,
-          };
           rlog.warn(
             {
               turn: toolUseTurns,
@@ -1237,6 +1273,13 @@ export class AgentLoop {
             },
             "LLM response reached output token limit",
           );
+          // Run the hook on the truncated reply so output-filter plugins still
+          // see it, and so a deferred turn gets its synthetic final emit (the
+          // live stream was suppressed; without this the client would see nothing).
+          const safeAssistantMessage = await finalizeAssistantMessage({
+            role: "assistant",
+            content: safeContent,
+          });
           history.push(safeAssistantMessage);
           appendedNewMessages = true;
           await onEvent({
@@ -1308,44 +1351,11 @@ export class AgentLoop {
           }
         }
 
-        // Let plugins transform the finalized assistant message before it is
-        // persisted and streamed-final. Fires for every finalized message
-        // (tool-bearing turns included), so a reply carrying both text and tool
-        // calls is covered; hooks transform their own blocks and leave others —
-        // notably `tool_use` — intact. Fail-open: a throwing hook keeps the
-        // original content.
-        try {
-          const assistantMessageCtx: AssistantMessageContext = {
-            conversationId: turnCtx.conversationId,
-            callSite: turnCtx.callSite,
-            content: assistantMessage.content,
-            stopReason: response.stopReason,
-            logger: rlog,
-          };
-          const finalAssistantMessageCtx = await runHook(
-            HOOKS.ASSISTANT_MESSAGE,
-            assistantMessageCtx,
-          );
-          assistantMessage = {
-            role: "assistant",
-            content: finalAssistantMessageCtx.content,
-          };
-        } catch (assistantMessageError) {
-          rlog.error(
-            { err: assistantMessageError },
-            "assistant-message hook failed — keeping the original content",
-          );
-        }
-
-        // When this turn's output was deferred, its live text stream was
-        // suppressed; emit the finalized (possibly transformed) text once so the
-        // client renders it.
-        if (deferAssistantOutput) {
-          const finalText = assistantTextOf(assistantMessage.content);
-          if (finalText.length > 0) {
-            onEvent({ type: "text_delta", text: finalText });
-          }
-        }
+        // Run the `assistant-message` hook + emit any deferred final text.
+        // On a no-tool turn this point is reached only after the `stop` hook
+        // resolves to "stop" (a `continue` already re-queried above), so a
+        // re-queried reply is never transformed-then-discarded.
+        assistantMessage = await finalizeAssistantMessage(assistantMessage);
 
         history.push(assistantMessage);
         appendedNewMessages = true;

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -11,7 +11,12 @@ import {
 import type { ContextWindowResult } from "../context/window-manager.js";
 import type { ToolActivityMetadata } from "../daemon/message-types/web-activity.js";
 import { HOOKS } from "../plugin-api/constants.js";
-import type { PostToolUseContext, StopContext } from "../plugin-api/types.js";
+import type {
+  AssistantMessageContext,
+  PostToolUseContext,
+  PreModelCallContext,
+  StopContext,
+} from "../plugin-api/types.js";
 import {
   DEFAULT_COMPACTION_PLUGIN_NAME,
   defaultCompact,
@@ -376,6 +381,20 @@ export function isMaxTokensStopReason(
 ): boolean {
   if (!stopReason) return false;
   return MAX_TOKENS_STOP_REASONS.has(stopReason.trim().toLowerCase());
+}
+
+/**
+ * Concatenate the text of an assistant message's `text` blocks (ignoring
+ * `tool_use`, `thinking`, and other non-text blocks). Used to re-emit the
+ * finalized text as a single `text_delta` when a turn's live output was
+ * deferred by a `pre-model-call` hook.
+ */
+function assistantTextOf(content: ReadonlyArray<ContentBlock>): string {
+  let text = "";
+  for (const block of content) {
+    if (block.type === "text") text += block.text;
+  }
+  return text;
 }
 
 /**
@@ -977,6 +996,12 @@ export class AgentLoop {
           stripOldMediaBlocks(history),
         );
 
+        // A `pre-model-call` hook (below) can defer this turn's assistant
+        // output; when set, the live text stream is held so an
+        // `assistant-message` hook can emit the finalized (transformed) text
+        // instead. Reset per model call.
+        let deferAssistantOutput = false;
+
         // The `onEvent` wrapping below applies sensitive-output placeholder
         // substitution to streamed text while forwarding every other event
         // type through unchanged.
@@ -986,6 +1011,9 @@ export class AgentLoop {
           config: providerConfig,
           onEvent: (event) => {
             if (event.type === "text_delta") {
+              // Held when the turn's output is deferred — the final text is
+              // emitted once, after the `assistant-message` hook runs.
+              if (deferAssistantOutput) return;
               // Apply sensitive-output placeholder substitution (chunk-safe)
               if (substitutionMap.size > 0) {
                 const combined = streamingPending + event.text;
@@ -1047,6 +1075,33 @@ export class AgentLoop {
         // back to a synthesized placeholder scoped to the tool-use iteration.
         const turnCtx =
           turnContext ?? buildLoopTurnContext(requestId, toolUseTurns);
+
+        // Let plugins edit the outbound request and opt this call into deferred
+        // output streaming. Runs for every provider call; hooks self-gate on
+        // call site / conversation. Fail-open: a throwing hook leaves the
+        // request unchanged and streaming live.
+        try {
+          const preModelCtx: PreModelCallContext = {
+            conversationId: turnCtx.conversationId,
+            callSite: turnCtx.callSite,
+            systemPrompt: providerOptions.systemPrompt,
+            deferAssistantOutput: false,
+            logger: rlog,
+          };
+          const finalPreModelCtx = await runHook(
+            HOOKS.PRE_MODEL_CALL,
+            preModelCtx,
+          );
+          providerOptions.systemPrompt = finalPreModelCtx.systemPrompt;
+          // The hook owns the policy (it sees `callSite`/conversation and
+          // self-gates); the loop honors whatever it decides.
+          deferAssistantOutput = finalPreModelCtx.deferAssistantOutput;
+        } catch (preModelCallError) {
+          rlog.error(
+            { err: preModelCallError },
+            "pre-model-call hook failed — proceeding with the original request",
+          );
+        }
 
         // Announce the LLM-call boundary so downstream handlers (the
         // daemon's persistence pipeline) can reserve an empty assistant row
@@ -1139,7 +1194,7 @@ export class AgentLoop {
         // placeholders so the model never sees real sensitive values — neither
         // on subsequent loop turns nor on session reload from the database.
         // Substitution to real values happens only in streamed text_delta events.
-        const assistantMessage: Message = {
+        let assistantMessage: Message = {
           role: "assistant",
           content: response.content,
         };
@@ -1250,6 +1305,45 @@ export class AgentLoop {
                 "Model returned empty response after tool results — retries exhausted",
               );
             }
+          }
+        }
+
+        // Let plugins transform the finalized assistant message before it is
+        // persisted and streamed-final. Fires for every finalized message
+        // (tool-bearing turns included), so a reply carrying both text and tool
+        // calls is covered; hooks transform their own blocks and leave others —
+        // notably `tool_use` — intact. Fail-open: a throwing hook keeps the
+        // original content.
+        try {
+          const assistantMessageCtx: AssistantMessageContext = {
+            conversationId: turnCtx.conversationId,
+            callSite: turnCtx.callSite,
+            content: assistantMessage.content,
+            stopReason: response.stopReason,
+            logger: rlog,
+          };
+          const finalAssistantMessageCtx = await runHook(
+            HOOKS.ASSISTANT_MESSAGE,
+            assistantMessageCtx,
+          );
+          assistantMessage = {
+            role: "assistant",
+            content: finalAssistantMessageCtx.content,
+          };
+        } catch (assistantMessageError) {
+          rlog.error(
+            { err: assistantMessageError },
+            "assistant-message hook failed — keeping the original content",
+          );
+        }
+
+        // When this turn's output was deferred, its live text stream was
+        // suppressed; emit the finalized (possibly transformed) text once so the
+        // client renders it.
+        if (deferAssistantOutput) {
+          const finalText = assistantTextOf(assistantMessage.content);
+          if (finalText.length > 0) {
+            onEvent({ type: "text_delta", text: finalText });
           }
         }
 

--- a/assistant/src/plugin-api/constants.ts
+++ b/assistant/src/plugin-api/constants.ts
@@ -20,10 +20,14 @@ export const HOOKS = {
   SHUTDOWN: "shutdown",
   /** Fires once per user turn, immediately before the agent loop receives `runMessages`. */
   USER_PROMPT_SUBMIT: "user-prompt-submit",
+  /** Fires immediately before each provider call. A hook may edit the outbound request (e.g. the system prompt) and opt the turn into deferred output streaming. */
+  PRE_MODEL_CALL: "pre-model-call",
   /** Fires once per tool result, after the tool returns and before the result is sent to the provider. */
   POST_TOOL_USE: "post-tool-use",
   /** Fires when the model yields a response with no tool calls — the run's stop boundary. Decides whether to stop or continue with a follow-up turn. */
   STOP: "stop",
+  /** Fires for each finalized assistant message, before it is persisted/streamed-final. A hook may transform the message content. */
+  ASSISTANT_MESSAGE: "assistant-message",
 } as const;
 
 /** Union of every hook name declared in {@link HOOKS}. */

--- a/assistant/src/plugin-api/index.ts
+++ b/assistant/src/plugin-api/index.ts
@@ -24,10 +24,14 @@
  * - {@link PluginShutdownContext} — passed to `shutdown` hook at teardown
  * - {@link UserPromptSubmitContext} — passed to `user-prompt-submit` hook,
  *   fired immediately before the agent loop receives a user's prompt
+ * - {@link PreModelCallContext} — passed to `pre-model-call` hook, fired
+ *   before each provider call to edit the request / defer output streaming
  * - {@link PostToolUseContext} — passed to `post-tool-use` hook, fired once
  *   per tool result before it joins the provider-bound history
  * - {@link StopContext} — passed to `stop` hook, fired when the model yields
  *   a response with no tool calls
+ * - {@link AssistantMessageContext} — passed to `assistant-message` hook,
+ *   fired for each finalized assistant message to transform its content
  * - {@link PluginHookFn} — signature every lifecycle hook implements
  * - {@link PluginLogger} — pino-compatible logger shape on the contexts
  * - {@link ToolDefinition} — author-facing tool spec (default-export shape
@@ -39,11 +43,13 @@
 export type { HookName } from "./constants.js";
 export { HOOKS } from "./constants.js";
 export type {
+  AssistantMessageContext,
   PluginHookFn,
   PluginInitContext,
   PluginLogger,
   PluginShutdownContext,
   PostToolUseContext,
+  PreModelCallContext,
   StopContext,
   StopDecision,
   ToolContext,

--- a/assistant/src/plugin-api/types.ts
+++ b/assistant/src/plugin-api/types.ts
@@ -4,6 +4,7 @@
  * removing is breaking and gated on a major bump.
  */
 
+import type { LLMCallSite } from "../config/schemas/llm.js";
 import type {
   ContentBlock,
   Message,
@@ -51,8 +52,10 @@ export interface PluginLogger {
  *   - `init` — {@link PluginInitContext}
  *   - `shutdown` — {@link PluginShutdownContext}
  *   - `user-prompt-submit` — {@link UserPromptSubmitContext}
+ *   - `pre-model-call` — {@link PreModelCallContext}
  *   - `post-tool-use` — {@link PostToolUseContext}
  *   - `stop` — {@link StopContext}
+ *   - `assistant-message` — {@link AssistantMessageContext}
  */
 export type PluginHookFn<TCtx = unknown> = (ctx: TCtx) => Promise<TCtx | void>;
 
@@ -286,5 +289,77 @@ export interface StopContext {
    * every hook in the chain, so plugins should tag their structured log
    * fields (e.g. `{ plugin: "<name>" }`) for attribution.
    */
+  readonly logger: PluginLogger;
+}
+
+// ─── Pre-model-call hook context ─────────────────────────────────────────────
+
+/**
+ * Context passed to the `pre-model-call` hook. Fires immediately before each
+ * provider call — once per model call within a turn, including tool-result
+ * follow-up calls. Because it runs for every provider call (background, subagent,
+ * and compaction work can share a conversation), hooks MUST self-gate on
+ * {@link callSite} / {@link conversationId} before acting.
+ *
+ * A hook may edit the outbound request by replacing {@link systemPrompt}, and may
+ * opt this turn into deferred output streaming via {@link deferAssistantOutput}.
+ * Mutate the context in place or return a new one; throwing is contained by the
+ * loop (the call proceeds with the original request).
+ */
+export interface PreModelCallContext {
+  /** Conversation ID the call belongs to. */
+  readonly conversationId: string;
+  /**
+   * The call site this provider call serves — `"mainAgent"` for the user-facing
+   * reply, or a background/utility site. Omitted by call sites that don't tag one.
+   */
+  readonly callSite?: LLMCallSite;
+  /**
+   * The system prompt about to be sent. A hook may replace it (e.g. strip or
+   * append a section); the loop sends the resulting value.
+   */
+  systemPrompt: string | undefined;
+  /**
+   * Seeded `false`. When a hook sets it `true`, the loop suppresses this turn's
+   * live assistant `text_delta` stream; an `assistant-message` hook is then
+   * expected to produce the text the client sees (emitted once, after the reply
+   * is finalized). Lets a plugin replace streamed output wholesale — e.g.
+   * redaction that needs the full message — instead of leaking the raw stream.
+   */
+  deferAssistantOutput: boolean;
+  /** Logger scoped to the current turn (tag structured fields with `{ plugin }`). */
+  readonly logger: PluginLogger;
+}
+
+// ─── Assistant-message hook context ──────────────────────────────────────────
+
+/**
+ * Context passed to the `assistant-message` hook. Fires for each finalized
+ * assistant message — once per model call, at the message-complete boundary —
+ * before the message is persisted and (if deferred) streamed-final. Unlike
+ * {@link StopContext}'s read-only `responseContent` (which exists for the stop
+ * decision), {@link content} is mutable: the loop adopts the hook's result as the
+ * persisted and streamed message.
+ *
+ * Fires on tool-bearing turns too (a reply can carry both text and `tool_use`),
+ * so a hook should transform only the blocks it owns and leave others — notably
+ * `tool_use` — intact. Runs for every finalized message regardless of call site;
+ * hooks MUST self-gate on {@link callSite} / {@link conversationId}. Mutate in
+ * place or return a new context; throwing is contained by the loop (the original
+ * content is kept).
+ */
+export interface AssistantMessageContext {
+  /** Conversation ID the message belongs to. */
+  readonly conversationId: string;
+  /** The call site this message serves — `"mainAgent"` for the user-facing reply. */
+  readonly callSite?: LLMCallSite;
+  /**
+   * The finalized message content. Mutable — transform the text blocks and leave
+   * `tool_use` (and other non-text blocks) intact.
+   */
+  content: ContentBlock[];
+  /** Provider-reported stop reason for the turn, when reported. */
+  readonly stopReason: string | null | undefined;
+  /** Logger scoped to the current turn (tag structured fields with `{ plugin }`). */
   readonly logger: PluginLogger;
 }

--- a/experimental/plugins/README.md
+++ b/experimental/plugins/README.md
@@ -51,8 +51,10 @@ my-plugin/
 │   ├── init.ts                # Bootstrap
 │   ├── shutdown.ts            # Teardown
 │   ├── user-prompt-submit.ts  # Per-turn message-list transform
+│   ├── pre-model-call.ts      # Per-call request edit / output-defer
 │   ├── post-tool-use.ts       # Per-tool-result transform
 │   ├── stop.ts                # Per-run stop-boundary decision
+│   ├── assistant-message.ts   # Per-message reply transform
 │   └── <future-hook>.ts       # Forward-compat slot
 ├── tools/
 │   ├── my_tool.ts             # Default export = tool definition
@@ -210,6 +212,35 @@ The hook fires **exactly once per user turn**, at the primary
 sites further down in the conversation agent loop deliberately do
 **not** refire: they're not new user submissions.
 
+### `pre-model-call`
+
+Fires **immediately before each provider call** — once per model call within a
+turn, including the follow-up calls after tool results. Because it runs for every
+provider call (background, subagent, and compaction work can share a
+conversation), a hook **must self-gate** on `ctx.callSite` / `ctx.conversationId`
+before acting.
+
+```ts
+// hooks/pre-model-call.ts
+import type { PreModelCallContext } from "@vellumai/plugin-api";
+
+// In-place mutation style (return void):
+export default async function preModelCall(
+  ctx: PreModelCallContext,
+): Promise<void> {
+  // ctx.conversationId       — ID of the conversation the call belongs to
+  // ctx.callSite             — call site ("mainAgent" for the user-facing reply)
+  // ctx.systemPrompt         — system prompt about to be sent; replace to edit it
+  // ctx.deferAssistantOutput — set true to suppress this turn's live text stream
+  //                            (an `assistant-message` hook then emits the text)
+  // ctx.logger               — turn-scoped; tag log fields with { plugin: <name> }
+}
+```
+
+Multiple plugins' hooks chain in registration order — each sees the previous
+hook's edits. Throwing is contained by the loop: the provider call proceeds with
+the original request.
+
 ### `post-tool-use`
 
 Fires once per tool result, **after** the tool returns and
@@ -280,6 +311,39 @@ previous hook's `decision` and `messages` mutations. The default
 with a nudge when a turn comes back empty after tool use, or with a
 refusal nudge on a first-call refusal; because defaults register first,
 it runs ahead of user hooks.
+
+### `assistant-message`
+
+Fires for **each finalized assistant message** — once per model call, at the
+message-complete boundary, before the message is persisted and (if deferred)
+streamed-final. Unlike `stop`'s read-only `responseContent`, `ctx.content` is
+**mutable**: the loop adopts the hook's result as the persisted and streamed
+message. Fires on tool-bearing turns too (a reply can carry both text and
+`tool_use`), so transform only the blocks you own and leave others — notably
+`tool_use` — intact. Runs for every finalized message; **self-gate** on
+`ctx.callSite` / `ctx.conversationId`.
+
+```ts
+// hooks/assistant-message.ts
+import type { AssistantMessageContext } from "@vellumai/plugin-api";
+
+// In-place mutation style (return void):
+export default async function assistantMessage(
+  ctx: AssistantMessageContext,
+): Promise<void> {
+  // ctx.conversationId — ID of the conversation the message belongs to
+  // ctx.callSite       — call site ("mainAgent" for the user-facing reply)
+  // ctx.content        — finalized message content; transform text blocks and
+  //                      leave tool_use (and other non-text blocks) intact
+  // ctx.stopReason     — provider stop reason, when reported
+  // ctx.logger         — turn-scoped; tag log fields with { plugin: <name> }
+}
+```
+
+A `pre-model-call` hook can set `deferAssistantOutput` to suppress the live
+stream; the loop then emits this hook's finalized text once. Multiple plugins'
+hooks chain in registration order — each sees the previous hook's mutations.
+Throwing is contained by the loop: the original content is kept.
 
 ### Forward-compatible hooks
 


### PR DESCRIPTION
## What

Adds two plugin hooks at the model-call boundary, symmetric with the existing `user-prompt-submit` (input) and `post-tool-use` (tool output) hooks:

- **`pre-model-call`** — fires before each `provider.sendMessage`. A hook may edit the outbound system prompt and opt the turn into deferred output streaming (`deferAssistantOutput`).
- **`assistant-message`** — fires for each finalized assistant message (per model call, at the message-complete boundary). A hook may transform the mutable `content`; the loop adopts it for both persistence and the streamed-final text.

## Why

The agent loop already transforms assistant output before it streams and persists — that's the sensitive-output placeholder substitution in `agent/loop.ts` (streamed `text_delta` carries real values while the persisted message keeps placeholders). This generalizes that capability into plugin hooks so plugins can do output redaction, filtering, or formatting in the same place. `assistant-message` is the mutable counterpart to `stop`'s read-only `responseContent`.

## Behavior

- **No-op by default** — when no plugin registers either hook, `runHook` returns the context unchanged; the streaming/persistence path is byte-for-byte unchanged.
- **Fail-open** — a throwing hook leaves the request/content unchanged and never breaks a turn.
- **Deferred streaming** — when `pre-model-call` sets `deferAssistantOutput`, the loop suppresses the live `text_delta` stream and emits the finalized text once, after `assistant-message`. Reuses the existing stream-vs-store split.
- **Tool-bearing turns** — `assistant-message` fires for every finalized message (text emitted alongside a tool call included) and transforms text blocks while leaving `tool_use` intact.
- Hooks run for every provider call / finalized message, so they **self-gate** on `callSite` / `conversationId`.

## Tests

`agent-loop-output-hooks.test.ts`: content transform (persisted + streamed), deferred-stream suppression + single synthetic emit, no-defer behavior, `tool_use` preservation, system-prompt edit, fail-open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)