### PR TITLE
test(db): raise timeouts on cold-start-bound repair + embed tests

### DIFF
--- a/assistant/src/cli/commands/db/__tests__/repair.test.ts
+++ b/assistant/src/cli/commands/db/__tests__/repair.test.ts
@@ -507,7 +507,9 @@ describe("assistant db repair — conversation-backfill step", () => {
     expect(parsed.steps[1].result.data.recovered).toBe(0);
     expect(parsed.steps[1].result.data.skipped).toBe(1);
     expect(parsed.steps[1].result.status).toBe("ok");
-  });
+    // Two full repair passes (each walks the DB via integrity-check) exceed
+    // bun's 5s per-test default, so raise the ceiling to keep CI stable.
+  }, 30_000);
 
   test("reports nothing-to-backfill on an empty conversations dir", async () => {
     await initSchema();

--- a/assistant/src/memory/jobs/__tests__/embed-concept-page.test.ts
+++ b/assistant/src/memory/jobs/__tests__/embed-concept-page.test.ts
@@ -143,9 +143,8 @@ afterAll(() => {
 // `getWorkspaceDir()` resolves to the tmpdir.
 const { DEFAULT_CONFIG } = await import("../../../config/defaults.js");
 const { getDb } = await import("../../db-connection.js");
-const { resetDbForTesting } = await import(
-  "../../../__tests__/db-test-helpers.js"
-);
+const { resetDbForTesting } =
+  await import("../../../__tests__/db-test-helpers.js");
 const { initializeDb } = await import("../../db-init.js");
 const { memoryEmbeddings, memoryJobs } = await import("../../schema.js");
 const { claimMemoryJobs } = await import("../../jobs-store.js");
@@ -187,12 +186,14 @@ function makeJob(payload: Record<string, unknown>): MemoryJob {
 
 beforeEach(() => {
   resetDbForTesting();
+  // The first run pays the full cold-start migration chain; bump the hook
+  // timeout above bun's 5s default so the leading test doesn't flake in CI.
   initializeDb();
   embedWithBackendCalls.length = 0;
   upsertCalls.length = 0;
   deleteCalls.length = 0;
   _resetQdrantBreaker();
-});
+}, 30_000);
 
 afterEach(() => {
   // Clean up any pages written between tests so each scenario starts fresh.


### PR DESCRIPTION
## Summary
- Fixes the two intermittent failures in `CI Main / Assistant Checks` (run 27059150851): both are bun **5s timeout** trips, not assertion failures.
- `embed-concept-page.test.ts` — the `beforeEach` runs the full `initializeDb()` migration chain; the first test pays the cold-start cost (~6.3s) and the hook times out. Bumped the hook timeout to 30s.
- `repair.test.ts` "skips conversations already present (idempotent)" — runs the full repair **twice** (each walks the DB via `PRAGMA integrity_check`), ~7.1s, over the 5s per-test default. Bumped the test timeout to 30s.

30s matches the repo's existing convention for heavy DB/migration tests (e.g. `migration-import-from-gcs.test.ts`, `db-maintenance.test.ts`). The change is behavior-preserving — only the timeout ceiling moves; the tests do identical work. The pre-commit hook also rewrapped one pre-existing import line in the embed test to canonical prettier 3.8.1 formatting.

## Original prompt
Fix the specific CI issue in the failing `Test` job of run 27059150851 (Assistant Checks on main) — and only that job. Investigation showed the two failing test files (`embed-concept-page.test.ts`, `repair.test.ts`) were not failing on logic; both were tripping bun's default 5000ms per-test/per-hook timeout under CI cold-start load (full migration chain + double repair pass). The fix raises the relevant timeouts rather than touching production code.