### PR TITLE
fix(injection): detect flattened injection blocks to prevent duplicate re-injection

### DIFF
--- a/assistant/src/__tests__/memory-v2-static-injector.test.ts
+++ b/assistant/src/__tests__/memory-v2-static-injector.test.ts
@@ -195,4 +195,48 @@ describe("memory-v2-static injector", () => {
     expect(block!.id).toBe("memory-v2-static");
     expect(block!.text).toContain("## Essentials");
   });
+
+  test("skips (re)injection when the <info> block is carried in a flattened history block", async () => {
+    // Regression: when a historical user message's separate injection content
+    // blocks get collapsed into one text block (observed after a daemon restart
+    // / plugin hot-reload rebuilt the rendered history mid-conversation — the
+    // blocks are joined with "\n"), the `<info>` wrapper is no longer its own
+    // block but a newline-delimited section inside a larger block. Presence
+    // detection must still recognize it; otherwise the injector re-injects a
+    // duplicate `<info>` onto the new tail (the double-injection bug).
+    seedEssentials("Alice prefers VS Code.");
+    const ctx = makeContext();
+    const flattenedFirstUser = [
+      "<workspace>\nRoot: /ws\nFiles: a.md\n</workspace>",
+      "<turn_context>\ncurrent_time: now\n</turn_context>",
+      "<memory>\nactivated page summary\n</memory>",
+      "<info>\n## Essentials\n\nAlice prefers VS Code.\n</info>",
+      "what should we do next?",
+    ].join("\n");
+    const runMessages: Message[] = [
+      { role: "user", content: [{ type: "text", text: flattenedFirstUser }] },
+      { role: "assistant", content: [{ type: "text", text: "On it." }] },
+      { role: "user", content: [{ type: "text", text: "great, continue" }] },
+    ];
+    expect(await memoryV2StaticInjector.produce(ctx, runMessages)).toBeNull();
+  });
+
+  test("still injects when a user message opens an <info> tag without closing it", async () => {
+    // False-positive guard: the wrapper matcher requires BOTH the opening and
+    // closing tags, so user prose that merely opens an injection-like tag must
+    // not be mistaken for a carried block and suppress injection.
+    seedEssentials("Alice prefers VS Code.");
+    const ctx = makeContext();
+    const runMessages: Message[] = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "<info>\n is this how the tag works?" },
+        ],
+      },
+    ];
+    const block = await memoryV2StaticInjector.produce(ctx, runMessages);
+    expect(block).not.toBeNull();
+    expect(block!.id).toBe("memory-v2-static");
+  });
 });

--- a/assistant/src/plugins/defaults/memory-retrieval/injectors.ts
+++ b/assistant/src/plugins/defaults/memory-retrieval/injectors.ts
@@ -454,11 +454,19 @@ const MEMORY_V2_STATIC_BLOCK_MATCHERS: readonly InjectionMatcher[] = [
 
 /**
  * Whether a block matching any of the given matchers is already present in the
- * turn's working messages. Mirrors `stripUserTextBlocksByPrefix` (a
- * user-message text block whose content matches a bare-prefix or a
- * `{ prefix, suffix }` wrapper matcher), so presence detection stays in
- * lockstep with what compaction strips: a block is present here exactly when
- * compaction would strip it.
+ * turn's working messages — used to skip re-injection of a block the history
+ * already carries.
+ *
+ * Recognizes both the canonical standalone form (a text block that IS the
+ * wrapper) and the "flattened" form where the wrapper sits as a newline-
+ * delimited section inside a larger text block (see {@link textCarriesInjection}).
+ *
+ * Detection is intentionally BROADER than `stripUserTextBlocksByPrefix`, which
+ * stays whole-block-only: re-injection must be suppressed even when a historical
+ * user message's separate injection blocks have been collapsed into one text
+ * block, whereas the strip must never delete a block that also holds the user's
+ * own text. (A flattened block is summarized away at the next compaction, where
+ * fresh injection resumes.)
  */
 function hasInjectedUserTextBlock(
   runMessages: Message[] | undefined,
@@ -471,14 +479,42 @@ function hasInjectedUserTextBlock(
       message.content.some(
         (block) =>
           block.type === "text" &&
-          matchers.some((m) =>
-            typeof m === "string"
-              ? block.text.startsWith(m)
-              : block.text.startsWith(m.prefix) &&
-                block.text.endsWith(m.suffix),
-          ),
+          matchers.some((m) => textCarriesInjection(block.text, m)),
       ),
   );
+}
+
+/**
+ * Whether `text` carries an injected block matching `matcher`, recognizing both
+ * the canonical standalone form (the text IS the wrapper) and a "flattened"
+ * form where the wrapper sits as a newline-delimited section inside a larger
+ * text block.
+ *
+ * The flattened form arises when a historical user message's separate injection
+ * content blocks get collapsed into a single text block joined with "\n" —
+ * observed when a daemon restart / plugin hot-reload rebuilt the rendered
+ * history mid-conversation. Without recognizing it, the standalone-only check
+ * returns false for the carried block and the injector re-injects a duplicate
+ * `<workspace>` / `<info>` onto the new tail.
+ *
+ * Anchoring on line boundaries ("\n" before the opening tag, and "\n" or the
+ * block edge after the closing tag) keeps the false-positive surface as narrow
+ * as the standalone check: ordinary prose would have to contain the exact
+ * wrapper as its own line-delimited section to be mistaken for an injection. The
+ * `{ prefix, suffix }` form still requires BOTH tags, so a message that opens
+ * (but never closes) an injection-like tag never suppresses injection.
+ */
+function textCarriesInjection(
+  text: string,
+  matcher: InjectionMatcher,
+): boolean {
+  if (typeof matcher === "string") {
+    return text.startsWith(matcher) || text.includes(`\n${matcher}`);
+  }
+  const { prefix, suffix } = matcher;
+  const hasOpen = text.startsWith(prefix) || text.includes(`\n${prefix}`);
+  const hasClose = text.endsWith(suffix) || text.includes(`${suffix}\n`);
+  return hasOpen && hasClose;
 }
 
 /**


### PR DESCRIPTION
## Problem

The `<workspace>` and `<info>` runtime blocks were injected onto the **second** user message of a conversation as well as the first. By design these blocks are injected once (on the first user message of the post-compaction window) and re-injection is suppressed on later turns because the block already persists in history.

## Root cause

The injectors gate re-injection on `hasInjectedUserTextBlock`, which recognized an injection block only as a **standalone content block** — whole-block `startsWith(prefix) && endsWith(suffix)`. When a historical user message's separate injection content blocks get **collapsed into a single text block** (joined with `\n`), the wrapper is no longer standalone but a newline-delimited section *inside* a larger block:

```
<workspace>\n…\n</workspace>\n<turn_context>\n…\n</turn_context>\n<memory>…</memory>\n<info>\n…\n</info>\n<user text>
```

- `<workspace>` matcher: `startsWith("<workspace>\n")` ✓ but `endsWith("\n</workspace>")` ✗ (block continues) → not detected
- `<info>` matcher: `startsWith("<info>\n")` ✗ (block starts with `<workspace>`) → not detected

So the guard returned `false`, and `workspace-context` + `memory-v2-static` re-injected duplicates onto the new tail. This flattened-history state was observed when the rendered history is rebuilt mid-conversation (e.g. a daemon restart / plugin hot-reload joins the separate blocks).

## Fix

Recognize the wrapper as a newline-delimited section too (`textCarriesInjection`):

- opening present at the block start **or** after a `\n`
- closing present at the block end **or** before a `\n`
- `{ prefix, suffix }` form still requires **both** tags

Line-anchoring keeps the false-positive surface as narrow as the original standalone check — ordinary prose would have to contain the exact wrapper as its own line-delimited section to be mistaken for an injection.

## Note on the compaction strip

Detection is now intentionally **broader** than `stripUserTextBlocksByPrefix`, which stays whole-block-only. The strip must never delete a block that also holds the user's own text; detection only needs to avoid a duplicate splice. A flattened block is summarized away at the next compaction, where fresh injection resumes — so the two staying out of lockstep for the (anomalous) flattened case is safe and self-healing.

## Tests

`assistant/src/__tests__/memory-v2-static-injector.test.ts`:
- skips re-injection when `<info>` is carried inside a flattened history block (the regression)
- still injects when a user message opens an `<info>` tag without closing it (false-positive guard)

All injector tests pass; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)