### PR TITLE
fix(web): use native OAuth flow in Electron instead of loopback auth

### DIFF
--- a/apps/web/src/domains/account/pages/local-mode-login-page.tsx
+++ b/apps/web/src/domains/account/pages/local-mode-login-page.tsx
@@ -19,6 +19,7 @@ import {
     loadLockfile,
 } from "@/lib/local-mode";
 import { captureError, normalizeToError } from "@/lib/sentry/capture-error";
+import { isElectron } from "@/runtime/is-electron";
 import { startAuthFlow } from "@/runtime/native-auth";
 import { useAuthStore } from "@/stores/auth-store";
 import { useLockfileStore } from "@/stores/lockfile-store";
@@ -112,7 +113,7 @@ export function LocalModeLoginPage({ returnTo }: { returnTo: string | null }) {
       setPlatformError(null);
       setPlatformLoading(true);
       try {
-        if (isPlatformLocal) {
+        if (isPlatformLocal || isElectron()) {
           await startAuthFlow(PROVIDER_ID, callbackUrl, {
             ...(providerHint ? { providerHint } : {}),
             returnTo,
@@ -143,7 +144,7 @@ export function LocalModeLoginPage({ returnTo }: { returnTo: string | null }) {
     }
   }, [autoConnectId, connectingId, connectError, connectToLocal]);
 
-  // Auto-redirect to loopback login when only platform assistants exist
+  // Auto-redirect to platform login when only platform assistants exist
   // and we're in standalone mode (no local Django).
   useEffect(() => {
     if (

--- a/apps/web/src/domains/account/pages/local-mode-login-page.tsx
+++ b/apps/web/src/domains/account/pages/local-mode-login-page.tsx
@@ -181,7 +181,7 @@ export function LocalModeLoginPage({ returnTo }: { returnTo: string | null }) {
     </DarkLoginShell>
   );
 
-  if (!hasLocal && isPlatformLocal) {
+  if (!hasLocal && (isPlatformLocal || isElectron())) {
     return platformLoginCard;
   }
 

--- a/apps/web/src/domains/onboarding/pages/welcome-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/welcome-screen.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from "react-router";
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
 import { isPlatformLocal, startLoopbackAuth } from "@/lib/auth/loopback-auth";
 import { isLocalMode } from "@/lib/local-mode";
+import { isElectron } from "@/runtime/is-electron";
 import { startAuthFlow } from "@/runtime/native-auth";
 import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
@@ -15,7 +16,7 @@ export function WelcomeScreen() {
 
   const handleLogin = async () => {
     if (isLocalMode()) {
-      if (isPlatformLocal()) {
+      if (isPlatformLocal() || isElectron()) {
         const returnTo = routes.onboarding.hosting;
         void navigate(`${routes.account.login}?returnTo=${encodeURIComponent(returnTo)}`);
         return;


### PR DESCRIPTION
## Summary

- In Electron, `isPlatformLocal()` is always false (origin is `app://vellum.ai`), so both the login page and welcome screen fell through to `startLoopbackAuth()` — which redirects to the platform login expecting a callback on `http://127.0.0.1:3000`, but no HTTP server is listening in Electron (and port 3000 conflicts with the local dev server).
- Route Electron through `startAuthFlow()` instead, which already has an Electron branch calling `window.vellum.auth.startOAuth()` — system browser + `vellum://` deep link callback + code exchange. This is the industry-standard pattern for Electron OAuth.
- Loopback auth is preserved for non-Electron local mode (CLI `vellum client`).

## Test plan

- [x] Tested locally — clicking Log In in the packaged Electron app opens the system browser, completes OAuth, and returns to the app with a valid session

🤖 Generated with [Claude Code](https://claude.com/claude-code)