### PR TITLE
refactor(web): centralize auth-method selection in startAuthFlow

### DIFF
--- a/apps/web/src/domains/account/pages/local-mode-login-page.tsx
+++ b/apps/web/src/domains/account/pages/local-mode-login-page.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/domains/account/components/login-shell";
 import { PlatformLoginButtons } from "@/domains/account/components/platform-login-buttons";
 import { PROVIDER_ID, buildProviderCallbackUrl } from "@/domains/account/login-flow";
-import { startLoopbackAuth, useIsPlatformLocal } from "@/lib/auth/loopback-auth";
+import { useIsPlatformLocal } from "@/lib/auth/loopback-auth";
 import {
     getActiveAssistant,
     isLocalAssistant,
@@ -113,14 +113,10 @@ export function LocalModeLoginPage({ returnTo }: { returnTo: string | null }) {
       setPlatformError(null);
       setPlatformLoading(true);
       try {
-        if (isPlatformLocal || isElectron()) {
-          await startAuthFlow(PROVIDER_ID, callbackUrl, {
-            ...(providerHint ? { providerHint } : {}),
-            returnTo,
-          });
-        } else {
-          await startLoopbackAuth(returnTo ?? undefined);
-        }
+        await startAuthFlow(PROVIDER_ID, callbackUrl, {
+          ...(providerHint ? { providerHint } : {}),
+          returnTo,
+        });
       } catch (err) {
         console.error("[local-login] platform auth flow failed:", err);
         setPlatformError("Something went wrong. Please try again.");

--- a/apps/web/src/domains/onboarding/pages/welcome-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/welcome-screen.tsx
@@ -2,9 +2,8 @@ import { useState } from "react";
 import { useNavigate } from "react-router";
 
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
-import { isPlatformLocal, startLoopbackAuth } from "@/lib/auth/loopback-auth";
+import { isPlatformLocal } from "@/lib/auth/loopback-auth";
 import { isLocalMode } from "@/lib/local-mode";
-import { isElectron } from "@/runtime/is-electron";
 import { startAuthFlow } from "@/runtime/native-auth";
 import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
@@ -15,13 +14,9 @@ export function WelcomeScreen() {
   const [error, setError] = useState<string | null>(null);
 
   const handleLogin = async () => {
-    if (isLocalMode()) {
-      if (isPlatformLocal() || isElectron()) {
-        const returnTo = routes.onboarding.hosting;
-        void navigate(`${routes.account.login}?returnTo=${encodeURIComponent(returnTo)}`);
-        return;
-      }
-      await startLoopbackAuth(routes.onboarding.hosting);
+    if (isLocalMode() && isPlatformLocal()) {
+      const returnTo = routes.onboarding.hosting;
+      void navigate(`${routes.account.login}?returnTo=${encodeURIComponent(returnTo)}`);
       return;
     }
     setError(null);

--- a/apps/web/src/lib/auth/loopback-auth.ts
+++ b/apps/web/src/lib/auth/loopback-auth.ts
@@ -38,7 +38,10 @@ export function useIsPlatformLocal(): boolean {
   return isPlatformLocal();
 }
 
-export async function startLoopbackAuth(returnTo?: string): Promise<void> {
+export async function startLoopbackAuth(
+  returnTo?: string,
+  options?: { intent?: string },
+): Promise<void> {
   const { webUrl } = getLocalConfig();
   const state = generateState();
   const port = window.location.port || "3000";
@@ -49,7 +52,8 @@ export async function startLoopbackAuth(returnTo?: string): Promise<void> {
   }
 
   const callbackReturnTo = `/accounts/cli/callback?port=${port}&state=${state}`;
-  const loginUrl = `${webUrl}/account/login?returnTo=${encodeURIComponent(callbackReturnTo)}`;
+  const page = options?.intent === "signup" ? "signup" : "login";
+  const loginUrl = `${webUrl}/account/${page}?returnTo=${encodeURIComponent(callbackReturnTo)}`;
 
   window.location.href = loginUrl;
 }

--- a/apps/web/src/runtime/native-auth.ts
+++ b/apps/web/src/runtime/native-auth.ts
@@ -276,7 +276,9 @@ export async function startAuthFlow(
   // Standalone local mode (no local Django serving the SPA): redirect
   // through the platform's login page and back to a loopback callback.
   if (isLocalMode() && !isPlatformLocal()) {
-    await startLoopbackAuth(options.returnTo ?? undefined);
+    await startLoopbackAuth(options.returnTo ?? undefined, {
+      intent: options.intent,
+    });
     return;
   }
 

--- a/apps/web/src/runtime/native-auth.ts
+++ b/apps/web/src/runtime/native-auth.ts
@@ -7,6 +7,8 @@ import {
 } from "@/domains/account/social-auth";
 import { sanitizeReturnTo } from "@/domains/account/return-to";
 import { getSession } from "@/lib/auth/allauth-client";
+import { isPlatformLocal, startLoopbackAuth } from "@/lib/auth/loopback-auth";
+import { isLocalMode } from "@/lib/local-mode";
 import { isElectron } from "@/runtime/is-electron";
 import { isBiometricEnabled, storeBiometricToken } from "@/runtime/native-biometric";
 import { routes } from "@/utils/routes";
@@ -268,6 +270,13 @@ export async function startAuthFlow(
       );
       window.location.href = destination;
     }
+    return;
+  }
+
+  // Standalone local mode (no local Django serving the SPA): redirect
+  // through the platform's login page and back to a loopback callback.
+  if (isLocalMode() && !isPlatformLocal()) {
+    await startLoopbackAuth(options.returnTo ?? undefined);
     return;
   }
 


### PR DESCRIPTION
## Summary

- Move the loopback-vs-OAuth auth-method decision into `startAuthFlow()` as a fourth branch (after Capacitor, Electron, before web form POST), so page components never import `startLoopbackAuth` or branch on `isElectron()` for auth routing
- `local-mode-login-page.tsx`: remove `startLoopbackAuth` import and the `isPlatformLocal || isElectron()` fork in `handlePlatformProvider` — just call `startAuthFlow()`
- `welcome-screen.tsx`: remove `startLoopbackAuth` and `isElectron` imports, collapse the nested local-mode branches

## Original prompt

The Electron login flow had `isElectron()` checks scattered across three components to choose between loopback auth and the native OAuth flow. Since `startAuthFlow()` already centralized the Capacitor and Electron branches, the loopback case should live there too — making it the single entry point for all auth methods and removing platform-awareness from page components.