### PR TITLE
feat(assistant): add optional funnel fields to onboarding telemetry type

### DIFF
--- a/assistant/src/telemetry/types.ts
+++ b/assistant/src/telemetry/types.ts
@@ -183,6 +183,19 @@ export interface OnboardingTelemetryEvent extends TelemetryEventBase {
   google_connected?: boolean;
   google_scopes?: string[];
   ab_variant?: string;
+  /**
+   * Activation-funnel fields (mirror the web funnel shape and the platform
+   * serializer). The platform accepts an onboarding event via either the
+   * legacy `screen` path or the all-funnel-fields path (`session_id` +
+   * `step_name` + `step_index` + `completed_at` + `funnel_version` +
+   * `ab_variant`).
+   */
+  session_id?: string;
+  step_name?: string;
+  step_index?: number;
+  completed_at?: string;
+  funnel_version?: string;
+  user_id?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add optional session_id/step_name/step_index/completed_at/funnel_version/user_id to OnboardingTelemetryEvent (activation funnel fields). Pure additive type change.

Part of plan: activation-telemetry.md (PR 3 of 10)