### PR TITLE
feat(assistant): add funnel columns to onboarding_events table

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -161,6 +161,7 @@ import {
   migrateOAuthProvidersScopeSeparator,
   migrateOAuthProvidersTokenAuthMethodDefault,
   migrateOAuthProvidersTokenExchangeBodyFormat,
+  migrateOnboardingEventsFunnelColumns,
   migrateOnboardingEventsPriorAssistants,
   migrateProviderConnectionBaseUrlAndModels,
   migrateProviderConnectionStatusLabel,
@@ -480,6 +481,7 @@ export function initializeDb(): void {
     migrateMessagesRoleCreatedAtIndex,
     createAuthFallbackEventsTable,
     migrateAcpSessionHistoryCwd,
+    migrateOnboardingEventsFunnelColumns,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/273-onboarding-events-funnel-columns.ts
+++ b/assistant/src/memory/migrations/273-onboarding-events-funnel-columns.ts
@@ -1,0 +1,46 @@
+import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+
+const TABLE = "onboarding_events";
+const COLUMNS: Array<{ name: string; type: string }> = [
+  { name: "session_id", type: "TEXT" },
+  { name: "step_name", type: "TEXT" },
+  { name: "step_index", type: "INTEGER" },
+  { name: "completed_at", type: "TEXT" },
+  { name: "funnel_version", type: "TEXT" },
+];
+
+/**
+ * Add nullable funnel-tracking columns to `onboarding_events`.
+ *
+ * The original table (#30733) recorded one row per onboarding screen but had
+ * no way to stitch those rows into an ordered, per-attempt funnel: there was
+ * no session correlator, no step ordering, and no completion timestamp. These
+ * columns let the activation-funnel reporting attribute each event to a single
+ * onboarding attempt (`session_id`), order steps within it (`step_name` /
+ * `step_index`), record when a step finished (`completed_at`), and version the
+ * funnel shape so changes to the step set don't silently corrupt historical
+ * conversion math (`funnel_version`).
+ *
+ * All columns are nullable — `NULL` for rows persisted before this migration
+ * ran.
+ *
+ * Idempotent — re-running is a no-op once the columns exist. Pure DDL with a
+ * PRAGMA guard, no registry entry needed (matches the 252 / 261 / 264 / 265 /
+ * 267 pattern).
+ */
+export function migrateOnboardingEventsFunnelColumns(
+  database: DrizzleDb,
+): void {
+  const raw = getSqliteFrom(database);
+
+  const columns = raw.query(`PRAGMA table_info(${TABLE})`).all() as Array<{
+    name: string;
+  }>;
+  const columnNames = new Set(columns.map((c) => c.name));
+
+  for (const { name, type } of COLUMNS) {
+    if (!columnNames.has(name)) {
+      raw.exec(`ALTER TABLE ${TABLE} ADD COLUMN ${name} ${type}`);
+    }
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -260,6 +260,7 @@ export { migrateMessagesRoleCreatedAtIndex } from "./270-messages-role-created-a
 export { migrateScheduleSourceConversation } from "./270-schedule-source-conversation.js";
 export { createAuthFallbackEventsTable } from "./271-create-auth-fallback-events.js";
 export { migrateAcpSessionHistoryCwd } from "./272-acp-session-history-cwd.js";
+export { migrateOnboardingEventsFunnelColumns } from "./273-onboarding-events-funnel-columns.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/infrastructure.ts
+++ b/assistant/src/memory/schema/infrastructure.ts
@@ -277,6 +277,11 @@ export const onboardingEvents = sqliteTable("onboarding_events", {
   googleScopesJson: text("google_scopes_json"),
   priorAssistantsJson: text("prior_assistants_json"),
   abVariant: text("ab_variant"),
+  sessionId: text("session_id"),
+  stepName: text("step_name"),
+  stepIndex: integer("step_index"),
+  completedAt: text("completed_at"),
+  funnelVersion: text("funnel_version"),
 });
 
 // Aggregated legacy-loopback auth-fallback counts forwarded by the gateway.


### PR DESCRIPTION
## Summary
- Migration 273: add nullable session_id/step_name/step_index/completed_at/funnel_version columns to onboarding_events (idempotent PRAGMA guard, additive).
- Extend Drizzle onboardingEvents schema to match.

Part of plan: activation-telemetry.md (PR 2 of 10)