### PR TITLE
feat(assistant): mark conversations that run the activation rail

### DIFF
--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -557,6 +557,7 @@ export class Conversation {
               trustContext: this.currentTurnTrustContext,
               channelCapabilities: this.currentTurnChannelCapabilities,
               onboardingContext: this.getOnboardingContext(),
+              conversationId: this.conversationId,
             }),
       };
       if (configuredMaxTokens !== undefined) {
@@ -640,6 +641,7 @@ export class Conversation {
           trustContext: this.currentTurnTrustContext,
           channelCapabilities: this.currentTurnChannelCapabilities,
           onboardingContext: this.getOnboardingContext(),
+          conversationId: this.conversationId,
         });
     const tools = getAllToolDefinitions();
     const provider = this.provider;

--- a/assistant/src/memory/__tests__/activation-session-store.test.ts
+++ b/assistant/src/memory/__tests__/activation-session-store.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import {
+  isActivationSession,
+  markActivationSession,
+} from "../activation-session-store.js";
+import { getDb } from "../db-connection.js";
+import { initializeDb } from "../db-init.js";
+import { activationSessions } from "../schema.js";
+
+initializeDb();
+
+describe("activation-session-store", () => {
+  beforeEach(() => {
+    getDb().delete(activationSessions).run();
+  });
+
+  test("marks a conversation and reports it as an activation session", () => {
+    markActivationSession("c1");
+    expect(isActivationSession("c1")).toBe(true);
+  });
+
+  test("unmarked conversations are not activation sessions", () => {
+    expect(isActivationSession("nope")).toBe(false);
+  });
+
+  test("marking the same conversation twice is idempotent", () => {
+    markActivationSession("c1");
+    markActivationSession("c1");
+    expect(isActivationSession("c1")).toBe(true);
+    const rows = getDb().select().from(activationSessions).all();
+    expect(rows.length).toBe(1);
+  });
+});

--- a/assistant/src/memory/activation-session-store.ts
+++ b/assistant/src/memory/activation-session-store.ts
@@ -1,0 +1,43 @@
+import { eq } from "drizzle-orm";
+
+import { getLogger } from "../util/logger.js";
+import { getDb } from "./db-connection.js";
+import { activationSessions } from "./schema.js";
+
+const log = getLogger("activation-session-store");
+
+/**
+ * Mark a conversation as an activation-rail session. Idempotent (the row's
+ * primary key is the conversation id) and best-effort: a write failure is
+ * logged and swallowed so it never blocks the turn that triggered it.
+ */
+export function markActivationSession(conversationId: string): void {
+  try {
+    getDb()
+      .insert(activationSessions)
+      .values({ conversationId, createdAt: Date.now() })
+      .onConflictDoNothing()
+      .run();
+  } catch (err) {
+    log.warn({ err, conversationId }, "Failed to mark activation session");
+  }
+}
+
+/**
+ * Whether the given conversation was started on the activation rail. Best-effort:
+ * a read failure is logged and treated as "not an activation session".
+ */
+export function isActivationSession(conversationId: string): boolean {
+  try {
+    const row = getDb()
+      .select({ conversationId: activationSessions.conversationId })
+      .from(activationSessions)
+      .where(eq(activationSessions.conversationId, conversationId))
+      .limit(1)
+      .get();
+    return row !== undefined;
+  } catch (err) {
+    log.warn({ err, conversationId }, "Failed to read activation session");
+    return false;
+  }
+}

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -16,6 +16,7 @@ import { getDb, getSqlite } from "./db-connection.js";
 import { migrateToolCreatedItems } from "./graph/bootstrap.js";
 import {
   addCoreColumns,
+  createActivationSessionsTable,
   createApprovalPromptTsTrackerTable,
   createAssistantInboxTables,
   createAuthFallbackEventsTable,
@@ -482,6 +483,7 @@ export function initializeDb(): void {
     createAuthFallbackEventsTable,
     migrateAcpSessionHistoryCwd,
     migrateOnboardingEventsFunnelColumns,
+    createActivationSessionsTable,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/274-create-activation-sessions.ts
+++ b/assistant/src/memory/migrations/274-create-activation-sessions.ts
@@ -1,0 +1,15 @@
+import type { DrizzleDb } from "../db-connection.js";
+
+/**
+ * Create the activation_sessions table. One row per conversation that was
+ * started on the activation-rail bootstrap template, used by the activation
+ * funnel telemetry to scope events to activation conversations.
+ */
+export function createActivationSessionsTable(database: DrizzleDb): void {
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS activation_sessions (
+      conversation_id TEXT PRIMARY KEY,
+      created_at INTEGER NOT NULL
+    )
+  `);
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -261,6 +261,7 @@ export { migrateScheduleSourceConversation } from "./270-schedule-source-convers
 export { createAuthFallbackEventsTable } from "./271-create-auth-fallback-events.js";
 export { migrateAcpSessionHistoryCwd } from "./272-acp-session-history-cwd.js";
 export { migrateOnboardingEventsFunnelColumns } from "./273-onboarding-events-funnel-columns.js";
+export { createActivationSessionsTable } from "./274-create-activation-sessions.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/infrastructure.ts
+++ b/assistant/src/memory/schema/infrastructure.ts
@@ -299,6 +299,14 @@ export const authFallbackEvents = sqliteTable("auth_fallback_events", {
   windowEnd: integer("window_end").notNull(),
 });
 
+// One row per conversation started on the activation-rail bootstrap template.
+// Lets the activation funnel telemetry scope its events to activation
+// conversations without inspecting the bootstrap template at emit time.
+export const activationSessions = sqliteTable("activation_sessions", {
+  conversationId: text("conversation_id").primaryKey(),
+  createdAt: integer("created_at").notNull(),
+});
+
 export const traceEvents = sqliteTable(
   "trace_events",
   {

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -11,6 +11,8 @@ import { join } from "node:path";
 import { getIsContainerized } from "../config/env-registry.js";
 import type { ChannelCapabilities } from "../daemon/conversation-runtime-assembly.js";
 import type { TrustContext } from "../daemon/trust-context.js";
+import { markActivationSession } from "../memory/activation-session-store.js";
+import { ACTIVATION_RAIL_BOOTSTRAP_TEMPLATE } from "../telemetry/activation-funnel.js";
 import type { OnboardingContext } from "../types/onboarding-context.js";
 import { resolveBundledDir } from "../util/bundled-asset.js";
 import { getLogger } from "../util/logger.js";
@@ -268,6 +270,13 @@ export interface BuildSystemPromptOptions {
   trustContext?: TrustContext;
   channelCapabilities?: ChannelCapabilities;
   onboardingContext?: OnboardingContext;
+  /**
+   * Conversation this prompt is being built for. Optional because several
+   * callers build a prompt outside a conversation (e.g. home greeting,
+   * suggested prompts). When present and the activation-rail bootstrap template
+   * is selected, the conversation is marked as an activation session.
+   */
+  conversationId?: string;
 }
 
 /**
@@ -281,8 +290,18 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   // One-shot bootstrap swap: if the onboarding context specifies a bootstrap
   // template and BOOTSTRAP.md is still the generic template, replace it with
   // the specified variant before the prompt reads the file.
-  if (options?.onboardingContext?.bootstrapTemplate) {
-    maybeReseedBootstrap(options.onboardingContext.bootstrapTemplate);
+  const bootstrapTemplate = options?.onboardingContext?.bootstrapTemplate;
+  if (bootstrapTemplate) {
+    maybeReseedBootstrap(bootstrapTemplate);
+    // Mark activation-rail conversations so the funnel telemetry can scope its
+    // events. Best-effort and guarded inside the store; only when we know which
+    // conversation this prompt is for.
+    if (
+      bootstrapTemplate === ACTIVATION_RAIL_BOOTSTRAP_TEMPLATE &&
+      options?.conversationId
+    ) {
+      markActivationSession(options.conversationId);
+    }
   }
 
   // Slugs used by the persona sections (`10-user-persona`,

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -208,7 +208,7 @@ export function ensurePromptFiles(): void {
  * overwrite the workspace file with the specified variant.  No-op when
  * BOOTSTRAP.md has been deleted, modified, or the template file is missing.
  */
-export function maybeReseedBootstrap(templateFileName: string): void {
+export function maybeReseedBootstrap(templateFileName: string): boolean {
   // Path traversal guard: reject filenames containing directory separators or
   // parent-directory references, and require a `.md` extension.
   if (
@@ -220,11 +220,11 @@ export function maybeReseedBootstrap(templateFileName: string): void {
       { templateFileName },
       "Rejected bootstrap template filename: invalid characters or extension",
     );
-    return;
+    return false;
   }
 
   const bootstrapPath = getWorkspacePromptPath("BOOTSTRAP.md");
-  if (!existsSync(bootstrapPath)) return;
+  if (!existsSync(bootstrapPath)) return false;
 
   const currentContent = readPromptFile(bootstrapPath);
   // Compare against the GENERIC "BOOTSTRAP.md" template, not the specified
@@ -232,7 +232,7 @@ export function maybeReseedBootstrap(templateFileName: string): void {
   // template, so this guard returns false on subsequent calls — making the
   // swap idempotent.  Do NOT change the comparison target to the provided
   // template filename; that would re-swap on every prompt build.
-  if (!isTemplateContent(currentContent, "BOOTSTRAP.md")) return;
+  if (!isTemplateContent(currentContent, "BOOTSTRAP.md")) return false;
 
   const templatesDir = resolveBundledDir(
     import.meta.dirname ?? __dirname,
@@ -245,7 +245,7 @@ export function maybeReseedBootstrap(templateFileName: string): void {
       { templateFileName },
       "Bootstrap template not found, keeping generic BOOTSTRAP.md",
     );
-    return;
+    return false;
   }
 
   try {
@@ -255,11 +255,13 @@ export function maybeReseedBootstrap(templateFileName: string): void {
       { templateFileName },
       "Replaced generic BOOTSTRAP.md with specified template",
     );
+    return true;
   } catch (err) {
     log.warn(
       { err, templateFileName },
       "Failed to reseed BOOTSTRAP.md with template",
     );
+    return false;
   }
 }
 
@@ -292,13 +294,23 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   // the specified variant before the prompt reads the file.
   const bootstrapTemplate = options?.onboardingContext?.bootstrapTemplate;
   if (bootstrapTemplate) {
-    maybeReseedBootstrap(bootstrapTemplate);
+    const installedActivationRail = maybeReseedBootstrap(bootstrapTemplate);
     // Mark activation-rail conversations so the funnel telemetry can scope its
     // events. Best-effort and guarded inside the store; only when we know which
-    // conversation this prompt is for.
+    // conversation this prompt is for. Gate on the rail actually being the
+    // active bootstrap — either this build just installed it, OR BOOTSTRAP.md
+    // already holds the activation-rail template (idempotent re-marks on later
+    // turns). When the reseed no-ops because BOOTSTRAP.md is missing or has been
+    // customized to something else, the rail is NOT active, so we must NOT mark
+    // (otherwise non-rail conversations would pollute activation telemetry).
     if (
       bootstrapTemplate === ACTIVATION_RAIL_BOOTSTRAP_TEMPLATE &&
-      options?.conversationId
+      options?.conversationId &&
+      (installedActivationRail ||
+        isTemplateContent(
+          readPromptFile(getWorkspacePromptPath("BOOTSTRAP.md")),
+          ACTIVATION_RAIL_BOOTSTRAP_TEMPLATE,
+        ))
     ) {
       markActivationSession(options.conversationId);
     }

--- a/assistant/src/telemetry/activation-funnel.ts
+++ b/assistant/src/telemetry/activation-funnel.ts
@@ -14,6 +14,16 @@
 export const ACTIVATION_FUNNEL_VERSION = "activation_v1_2026_06";
 
 /**
+ * Filename of the bootstrap template that drives the activation rail. The web
+ * prechat-context sets this as `onboardingContext.bootstrapTemplate` (mirrored
+ * there as `ACTIVATION_RAIL_BOOTSTRAP_TEMPLATE`); the daemon recognizes it to
+ * mark the conversation as an activation session. Single source of truth on the
+ * daemon side so the literal isn't duplicated across modules.
+ */
+export const ACTIVATION_RAIL_BOOTSTRAP_TEMPLATE =
+  "BOOTSTRAP-ACTIVATION-RAIL.md";
+
+/**
  * Cohort arm tag for Stream-A emission. The daemon only runs the rail for
  * treatment users, so activation events are tagged with the treatment arm
  * name ("variant-a"), mirroring `pre-chat-onboarding-experiment-2026-06-06`.


### PR DESCRIPTION
## Summary
- Add activation-session marker store (markActivationSession/isActivationSession), best-effort.
- Mark the conversation when the activation-rail bootstrap template is selected in system-prompt.
- Tests.

Part of plan: activation-telemetry.md (PR 6 of 10)