### PR TITLE
feat(assistant): emit activation funnel fields in telemetry flush

### DIFF
--- a/assistant/src/telemetry/activation-funnel.ts
+++ b/assistant/src/telemetry/activation-funnel.ts
@@ -84,10 +84,18 @@ export function activationStepIndex(stepName: ActivationStepName): number {
  * `${funnel_version}:${sessionId}:${stepName}` lets the existing dbt
  * dedup (keyed on `daemon_event_id`, earliest-wins) collapse a moment that
  * fires more than once into a single row.
+ *
+ * `funnelVersion` defaults to the current `ACTIVATION_FUNNEL_VERSION` but
+ * callers that have a per-row stored version (e.g. the telemetry reporter
+ * flushing rows recorded under an older version) MUST pass the row's own
+ * `funnel_version` so the id stays stable across a version bump — otherwise
+ * queued/offline v1 rows would be keyed with the new binary's version and
+ * stop collapsing with already-ingested v1 rows from the same session.
  */
 export function buildActivationDaemonEventId(
   sessionId: string,
   stepName: ActivationStepName,
+  funnelVersion: string = ACTIVATION_FUNNEL_VERSION,
 ): string {
-  return `${ACTIVATION_FUNNEL_VERSION}:${sessionId}:${stepName}`;
+  return `${funnelVersion}:${sessionId}:${stepName}`;
 }

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -131,6 +131,11 @@ const mockQueryUnreportedOnboardingEvents = mock(
       googleScopesJson: string | null;
       priorAssistantsJson: string | null;
       abVariant: string | null;
+      sessionId: string | null;
+      stepName: string | null;
+      stepIndex: number | null;
+      completedAt: string | null;
+      funnelVersion: string | null;
     }[],
 );
 
@@ -152,6 +157,10 @@ import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import { authFallbackEvents } from "../memory/schema.js";
 import type { UsageEvent } from "../usage/types.js";
+import {
+  ACTIVATION_FUNNEL_VERSION,
+  buildActivationDaemonEventId,
+} from "./activation-funnel.js";
 import { UsageTelemetryReporter } from "./usage-telemetry-reporter.js";
 
 initializeDb();
@@ -197,6 +206,34 @@ function makeUsageEvent(
     assistantVersion: "test-app-version",
     conversationType: "standard",
     turnIndex: 1,
+    ...overrides,
+  };
+}
+
+type OnboardingEventFixture = ReturnType<
+  typeof mockQueryUnreportedOnboardingEvents
+>[number];
+
+function makeOnboardingEvent(
+  overrides: Partial<OnboardingEventFixture> = {},
+): OnboardingEventFixture {
+  eventIdCounter += 1;
+  return {
+    id: `onb-${eventIdCounter}`,
+    createdAt: 1700000000000 + eventIdCounter * 1000,
+    screen: "tools",
+    toolsJson: null,
+    tasksJson: null,
+    tone: null,
+    googleConnected: null,
+    googleScopesJson: null,
+    priorAssistantsJson: null,
+    abVariant: null,
+    sessionId: null,
+    stepName: null,
+    stepIndex: null,
+    completedAt: null,
+    funnelVersion: null,
     ...overrides,
   };
 }
@@ -1183,5 +1220,79 @@ describe("UsageTelemetryReporter", () => {
     );
     expect(idCalls.length).toBeGreaterThanOrEqual(1);
     expect(idCalls[idCalls.length - 1][1]).toBe(lastRow.id);
+  });
+
+  // -------------------------------------------------------------------------
+  // Onboarding / activation funnel events
+  // -------------------------------------------------------------------------
+
+  test("activation onboarding row serializes funnel fields + deterministic daemon_event_id", async () => {
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    const sessionId = "sess-activation-1";
+    const stepName = "activation_moment_1_complete";
+    mockQueryUnreportedOnboardingEvents.mockReturnValue([
+      makeOnboardingEvent({
+        id: "onb-activation-1",
+        screen: stepName,
+        abVariant: "variant-a",
+        sessionId,
+        stepName,
+        stepIndex: 1,
+        completedAt: "2026-06-06T00:00:00.000Z",
+        funnelVersion: ACTIVATION_FUNNEL_VERSION,
+      }),
+    ]);
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
+    );
+
+    const reporter = new UsageTelemetryReporter();
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect(body.events.length).toBe(1);
+    expect(body.events[0]).toMatchObject({
+      type: "onboarding",
+      session_id: sessionId,
+      step_name: stepName,
+      step_index: 1,
+      completed_at: "2026-06-06T00:00:00.000Z",
+      funnel_version: "activation_v1_2026_06",
+      daemon_event_id: buildActivationDaemonEventId(sessionId, stepName),
+    });
+  });
+
+  test("legacy onboarding row keeps daemon_event_id: e.id and omits funnel fields", async () => {
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    mockQueryUnreportedOnboardingEvents.mockReturnValue([
+      makeOnboardingEvent({
+        id: "onb-legacy-1",
+        screen: "tools",
+        toolsJson: JSON.stringify(["calendar"]),
+      }),
+    ]);
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
+    );
+
+    const reporter = new UsageTelemetryReporter();
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect(body.events.length).toBe(1);
+    const e = body.events[0];
+    expect(e.type).toBe("onboarding");
+    expect(e.daemon_event_id).toBe("onb-legacy-1");
+    expect(e.session_id).toBeUndefined();
+    expect(e.step_name).toBeUndefined();
+    expect(e.step_index).toBeUndefined();
+    expect(e.completed_at).toBeUndefined();
+    expect(e.funnel_version).toBeUndefined();
   });
 });

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -1265,6 +1265,49 @@ describe("UsageTelemetryReporter", () => {
     });
   });
 
+  test("activation daemon_event_id is keyed on the row's stored funnel_version, not the binary constant", async () => {
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    const sessionId = "sess-activation-old";
+    const stepName = "activation_moment_1_complete";
+    // A row recorded under an OLDER funnel version, queued across an upgrade.
+    const oldVersion = "activation_v0_2026_05";
+    expect(oldVersion).not.toBe(ACTIVATION_FUNNEL_VERSION);
+    mockQueryUnreportedOnboardingEvents.mockReturnValue([
+      makeOnboardingEvent({
+        id: "onb-activation-old",
+        screen: stepName,
+        abVariant: "variant-a",
+        sessionId,
+        stepName,
+        stepIndex: 1,
+        completedAt: "2026-05-01T00:00:00.000Z",
+        funnelVersion: oldVersion,
+      }),
+    ]);
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
+    );
+
+    const reporter = new UsageTelemetryReporter();
+    await reporter.flush();
+
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect(body.events[0]).toMatchObject({
+      funnel_version: oldVersion,
+      daemon_event_id: buildActivationDaemonEventId(
+        sessionId,
+        stepName,
+        oldVersion,
+      ),
+    });
+    // Guard: the id must carry the row's version, not the binary constant.
+    expect(body.events[0].daemon_event_id).toBe(
+      `${oldVersion}:${sessionId}:${stepName}`,
+    );
+  });
+
   test("legacy onboarding row keeps daemon_event_id: e.id and omits funnel fields", async () => {
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
     mockQueryUnreportedOnboardingEvents.mockReturnValue([

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -343,13 +343,18 @@ export class UsageTelemetryReporter {
             type: "onboarding",
             // Wire-only override for activation rows: a deterministic id keyed
             // on funnel_version/session/step lets dbt collapse a moment that
-            // fires more than once. The SQLite watermark cursor still uses
-            // `e.id`/`e.createdAt`, so this override is checkpoint-safe.
+            // fires more than once. Key on the ROW's stored `funnelVersion`
+            // (not the binary's current constant) so rows recorded under an
+            // older version — flushed offline or after an upgrade — keep a
+            // stable id and still collapse with already-ingested rows. The
+            // SQLite watermark cursor still uses `e.id`/`e.createdAt`, so this
+            // override is checkpoint-safe.
             daemon_event_id:
               e.sessionId && e.stepName && e.funnelVersion
                 ? buildActivationDaemonEventId(
                     e.sessionId,
                     e.stepName as ActivationStepName,
+                    e.funnelVersion,
                   )
                 : e.id,
             recorded_at: e.createdAt,

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -28,6 +28,10 @@ import { VellumPlatformClient } from "../platform/client.js";
 import { getDeviceId } from "../util/device-id.js";
 import { getLogger } from "../util/logger.js";
 import { APP_VERSION } from "../version.js";
+import {
+  type ActivationStepName,
+  buildActivationDaemonEventId,
+} from "./activation-funnel.js";
 import type { TelemetryEvent, TurnTelemetryClientInfo } from "./types.js";
 
 const log = getLogger("usage-telemetry");
@@ -337,7 +341,17 @@ export class UsageTelemetryReporter {
         ...onboardingEvents.map(
           (e): TelemetryEvent => ({
             type: "onboarding",
-            daemon_event_id: e.id,
+            // Wire-only override for activation rows: a deterministic id keyed
+            // on funnel_version/session/step lets dbt collapse a moment that
+            // fires more than once. The SQLite watermark cursor still uses
+            // `e.id`/`e.createdAt`, so this override is checkpoint-safe.
+            daemon_event_id:
+              e.sessionId && e.stepName && e.funnelVersion
+                ? buildActivationDaemonEventId(
+                    e.sessionId,
+                    e.stepName as ActivationStepName,
+                  )
+                : e.id,
             recorded_at: e.createdAt,
             screen: e.screen,
             ...(e.toolsJson ? { tools: JSON.parse(e.toolsJson) } : {}),
@@ -350,6 +364,12 @@ export class UsageTelemetryReporter {
               ? { google_scopes: JSON.parse(e.googleScopesJson) }
               : {}),
             ...(e.abVariant ? { ab_variant: e.abVariant } : {}),
+            // Activation funnel fields — only present on activation rows.
+            ...(e.sessionId ? { session_id: e.sessionId } : {}),
+            ...(e.stepName ? { step_name: e.stepName } : {}),
+            ...(e.stepIndex != null ? { step_index: e.stepIndex } : {}),
+            ...(e.completedAt ? { completed_at: e.completedAt } : {}),
+            ...(e.funnelVersion ? { funnel_version: e.funnelVersion } : {}),
             // Onboarding events fall back to the envelope `assistant_version`
             // — same upload-time attribution risk as before this PR. Adding
             // the record-time column to `onboarding_events` (#30733) is a


### PR DESCRIPTION
## Summary
- Map activation funnel fields (session_id/step_name/step_index/completed_at/funnel_version) onto the onboarding telemetry event when present.
- Override daemon_event_id with the deterministic buildActivationDaemonEventId for activation rows (wire-only; watermark cursor still uses row id).
- Reporter tests: activation row serializes funnel fields + deterministic id; legacy row unchanged.

Part of plan: activation-telemetry.md (PR 5 of 10)