### PR TITLE
feat(assistant): mechanism-agnostic activation emit handler

### DIFF
--- a/assistant/src/telemetry/__tests__/activation-emit.test.ts
+++ b/assistant/src/telemetry/__tests__/activation-emit.test.ts
@@ -13,16 +13,18 @@ mock.module("../../config/loader.js", () => ({
   getConfig: () => ({ collectUsageData: true }),
 }));
 
+import { markActivationSession } from "../../memory/activation-session-store.js";
 import { getDb } from "../../memory/db-connection.js";
 import { initializeDb } from "../../memory/db-init.js";
 import { queryUnreportedOnboardingEvents } from "../../memory/onboarding-events-store.js";
-import { onboardingEvents } from "../../memory/schema.js";
+import { activationSessions, onboardingEvents } from "../../memory/schema.js";
 import { emitActivationMoment } from "../activation-emit.js";
 
 initializeDb();
 
 function resetTable(): void {
   getDb().delete(onboardingEvents).run();
+  getDb().delete(activationSessions).run();
 }
 
 describe("activation-emit: emitActivationMoment", () => {
@@ -30,7 +32,8 @@ describe("activation-emit: emitActivationMoment", () => {
     resetTable();
   });
 
-  test("records a valid activation moment and writes a row", () => {
+  test("records a valid activation moment for a marked rail session", () => {
+    markActivationSession("conv-1");
     const result = emitActivationMoment({
       stepName: "activation_moment_2_complete",
       conversationId: "conv-1",
@@ -41,6 +44,16 @@ describe("activation-emit: emitActivationMoment", () => {
     expect(rows).toHaveLength(1);
     expect(rows[0]!.stepName).toBe("activation_moment_2_complete");
     expect(rows[0]!.sessionId).toBe("conv-1");
+  });
+
+  test("rejects a valid step in an unmarked (non-rail) session and writes no row", () => {
+    const result = emitActivationMoment({
+      stepName: "activation_moment_2_complete",
+      conversationId: "conv-not-rail",
+    });
+    expect(result).toEqual({ ok: false, reason: "not_activation_session" });
+
+    expect(queryUnreportedOnboardingEvents(0, undefined, 10)).toHaveLength(0);
   });
 
   test("rejects the daemon-owned msg_5 step and writes no row", () => {

--- a/assistant/src/telemetry/__tests__/activation-emit.test.ts
+++ b/assistant/src/telemetry/__tests__/activation-emit.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Silence the logger.
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// Usage-data collection is enabled for these tests.
+mock.module("../../config/loader.js", () => ({
+  getConfig: () => ({ collectUsageData: true }),
+}));
+
+import { getDb } from "../../memory/db-connection.js";
+import { initializeDb } from "../../memory/db-init.js";
+import { queryUnreportedOnboardingEvents } from "../../memory/onboarding-events-store.js";
+import { onboardingEvents } from "../../memory/schema.js";
+import { emitActivationMoment } from "../activation-emit.js";
+
+initializeDb();
+
+function resetTable(): void {
+  getDb().delete(onboardingEvents).run();
+}
+
+describe("activation-emit: emitActivationMoment", () => {
+  beforeEach(() => {
+    resetTable();
+  });
+
+  test("records a valid activation moment and writes a row", () => {
+    const result = emitActivationMoment({
+      stepName: "activation_moment_2_complete",
+      conversationId: "conv-1",
+    });
+    expect(result).toEqual({ ok: true });
+
+    const rows = queryUnreportedOnboardingEvents(0, undefined, 10);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.stepName).toBe("activation_moment_2_complete");
+    expect(rows[0]!.sessionId).toBe("conv-1");
+  });
+
+  test("rejects the daemon-owned msg_5 step and writes no row", () => {
+    const result = emitActivationMoment({
+      stepName: "activation_msg_5_sent",
+      conversationId: "conv-2",
+    });
+    expect(result).toEqual({ ok: false, reason: "daemon_owned" });
+
+    expect(queryUnreportedOnboardingEvents(0, undefined, 10)).toHaveLength(0);
+  });
+
+  test("rejects an unknown step name and writes no row", () => {
+    const result = emitActivationMoment({
+      stepName: "bogus",
+      conversationId: "conv-3",
+    });
+    expect(result).toEqual({ ok: false, reason: "unknown_step" });
+
+    expect(queryUnreportedOnboardingEvents(0, undefined, 10)).toHaveLength(0);
+  });
+});

--- a/assistant/src/telemetry/activation-emit.ts
+++ b/assistant/src/telemetry/activation-emit.ts
@@ -8,6 +8,7 @@
  * can never crash a turn through this path.
  */
 
+import { isActivationSession } from "../memory/activation-session-store.js";
 import { recordActivationEvent } from "../memory/onboarding-events-store.js";
 import { getLogger } from "../util/logger.js";
 import { ACTIVATION_STEPS, isActivationStepName } from "./activation-funnel.js";
@@ -20,7 +21,9 @@ const log = getLogger("activation-emit");
  * Returns `{ ok: true }` on success (including the success-noop case where
  * usage-data collection is disabled). Returns `{ ok: false, reason }` for an
  * unknown step (`"unknown_step"`), the daemon-owned msg_5 step
- * (`"daemon_owned"`), or a failed record (`"record_failed"`). Never throws.
+ * (`"daemon_owned"`), a conversation that was never marked as an activation
+ * rail session (`"not_activation_session"`), or a failed record
+ * (`"record_failed"`). Never throws.
  */
 export function emitActivationMoment(input: {
   stepName: string;
@@ -33,6 +36,14 @@ export function emitActivationMoment(input: {
   // msg_5 is emitted only by the daemon turn hook, never via this handler.
   if (input.stepName === ACTIVATION_STEPS.msg5Sent.stepName) {
     return { ok: false, reason: "daemon_owned" };
+  }
+  // Only emit for conversations actually running the activation rail. The rail
+  // marker (activation_sessions) is set in system-prompt.ts only when the
+  // activation-rail bootstrap is active, so gating here prevents a stray tool
+  // call in a normal chat from polluting the activation funnel with a
+  // spurious conversion.
+  if (!isActivationSession(input.conversationId)) {
+    return { ok: false, reason: "not_activation_session" };
   }
 
   try {

--- a/assistant/src/telemetry/activation-emit.ts
+++ b/assistant/src/telemetry/activation-emit.ts
@@ -1,0 +1,50 @@
+/**
+ * Mechanism-agnostic activation emit handler.
+ *
+ * This is the seam that model-facing callers (e.g. the activation tool) use to
+ * emit an activation-funnel milestone. It validates the step name, rejects the
+ * daemon-owned `activation_msg_5_sent` step (emitted only by the turn hook),
+ * and otherwise records the event best-effort — it never throws, so the model
+ * can never crash a turn through this path.
+ */
+
+import { recordActivationEvent } from "../memory/onboarding-events-store.js";
+import { getLogger } from "../util/logger.js";
+import { ACTIVATION_STEPS, isActivationStepName } from "./activation-funnel.js";
+
+const log = getLogger("activation-emit");
+
+/**
+ * Emit an activation-funnel milestone for a conversation.
+ *
+ * Returns `{ ok: true }` on success (including the success-noop case where
+ * usage-data collection is disabled). Returns `{ ok: false, reason }` for an
+ * unknown step (`"unknown_step"`), the daemon-owned msg_5 step
+ * (`"daemon_owned"`), or a failed record (`"record_failed"`). Never throws.
+ */
+export function emitActivationMoment(input: {
+  stepName: string;
+  conversationId: string;
+  userId?: string | null;
+}): { ok: boolean; reason?: string } {
+  if (!isActivationStepName(input.stepName)) {
+    return { ok: false, reason: "unknown_step" };
+  }
+  // msg_5 is emitted only by the daemon turn hook, never via this handler.
+  if (input.stepName === ACTIVATION_STEPS.msg5Sent.stepName) {
+    return { ok: false, reason: "daemon_owned" };
+  }
+
+  try {
+    // A null return (collectUsageData disabled) is a success-noop.
+    recordActivationEvent({
+      stepName: input.stepName,
+      sessionId: input.conversationId,
+      userId: input.userId,
+    });
+    return { ok: true };
+  } catch (err) {
+    log.warn({ err, stepName: input.stepName }, "recordActivationEvent failed");
+    return { ok: false, reason: "record_failed" };
+  }
+}


### PR DESCRIPTION
## Summary
- Add emitActivationMoment(): validates step_name, rejects daemon-owned msg_5, calls recordActivationEvent; best-effort, never throws.
- This is the seam the model-facing tool (PR 9) will call.
- Tests for valid/daemon-owned/unknown cases.

Part of plan: activation-telemetry.md (PR 8 of 10)