### PR TITLE
feat(assistant): emit north-star msg_5 activation event

### DIFF
--- a/assistant/src/__tests__/activation-msg5-hook.test.ts
+++ b/assistant/src/__tests__/activation-msg5-hook.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests for the activation north-star (`activation_msg_5_sent`) emit hook.
+ *
+ * `maybeEmitActivationMsg5` runs after a real user turn is persisted. It fires
+ * exactly once — on the 5th real user turn of a MARKED activation conversation —
+ * and is a fire-and-forget no-op everywhere else.
+ *
+ * The test drives the real stores (`createConversation`, `addMessage`,
+ * `markActivationSession`, `recordActivationEvent`) so it exercises the actual
+ * `countRealUserTurns` filter and onboarding-event substrate end to end.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { makeMockLogger } from "./helpers/mock-logger.js";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => makeMockLogger(),
+}));
+
+// Activation events are gated on `collectUsageData`; keep it on for the test.
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({ collectUsageData: true }),
+}));
+
+import { maybeEmitActivationMsg5 } from "../daemon/conversation-messaging.js";
+import {
+  isActivationSession,
+  markActivationSession,
+} from "../memory/activation-session-store.js";
+import { addMessage, createConversation } from "../memory/conversation-crud.js";
+import { getDb } from "../memory/db-connection.js";
+import { initializeDb } from "../memory/db-init.js";
+import { queryUnreportedOnboardingEvents } from "../memory/onboarding-events-store.js";
+import {
+  activationSessions,
+  messages,
+  onboardingEvents,
+} from "../memory/schema.js";
+
+initializeDb();
+
+function purge(): void {
+  const db = getDb();
+  db.run("DELETE FROM messages");
+  db.run("DELETE FROM conversations");
+  db.delete(activationSessions).run();
+  db.delete(onboardingEvents).run();
+}
+
+beforeEach(() => {
+  purge();
+});
+
+/** Count the persisted `activation_msg_5_sent` rows for a session. */
+function msg5RowsFor(sessionId: string): number {
+  return queryUnreportedOnboardingEvents(0, undefined, 100).filter(
+    (e) =>
+      e.sessionId === sessionId &&
+      e.stepName === "activation_msg_5_sent" &&
+      e.stepIndex === 6,
+  ).length;
+}
+
+/**
+ * Persist one real user turn, then run the emit hook exactly as the persist
+ * path does (hook fires after the turn is durable).
+ */
+async function persistTurnAndRunHook(
+  conversationId: string,
+  content: string,
+): Promise<void> {
+  await addMessage(conversationId, "user", content, { skipIndexing: true });
+  maybeEmitActivationMsg5(conversationId);
+}
+
+describe("maybeEmitActivationMsg5", () => {
+  test("emits exactly one event on the 5th real user turn of an activation conversation", async () => {
+    const conv = createConversation({ conversationType: "standard" });
+    markActivationSession(conv.id);
+    expect(isActivationSession(conv.id)).toBe(true);
+
+    for (let i = 1; i <= 4; i++) {
+      await persistTurnAndRunHook(conv.id, `turn ${i}`);
+      expect(msg5RowsFor(conv.id)).toBe(0); // turns 1–4: no row
+    }
+
+    await persistTurnAndRunHook(conv.id, "turn 5");
+    expect(msg5RowsFor(conv.id)).toBe(1); // 5th real user turn fires
+  });
+
+  test("does not re-emit on turns 6+ (only the single row from turn 5)", async () => {
+    const conv = createConversation({ conversationType: "standard" });
+    markActivationSession(conv.id);
+
+    for (let i = 1; i <= 8; i++) {
+      await persistTurnAndRunHook(conv.id, `turn ${i}`);
+    }
+
+    expect(msg5RowsFor(conv.id)).toBe(1);
+  });
+
+  test("does nothing for a non-activation (unmarked) conversation", async () => {
+    const conv = createConversation({ conversationType: "standard" });
+    // Intentionally NOT marked as an activation session.
+
+    for (let i = 1; i <= 8; i++) {
+      await persistTurnAndRunHook(conv.id, `turn ${i}`);
+    }
+
+    expect(msg5RowsFor(conv.id)).toBe(0);
+  });
+
+  test("ignores tool_result role=user rows when counting to 5", async () => {
+    const conv = createConversation({ conversationType: "standard" });
+    markActivationSession(conv.id);
+
+    // 4 real turns, with synthetic tool_result user rows interleaved. The
+    // tool_result rows must not count toward the 5th-turn trigger.
+    const db = getDb();
+    for (let i = 1; i <= 4; i++) {
+      await persistTurnAndRunHook(conv.id, `turn ${i}`);
+      db.insert(messages)
+        .values({
+          id: `tool-result-${i}`,
+          conversationId: conv.id,
+          role: "user",
+          content: JSON.stringify([
+            { type: "tool_result", tool_use_id: `t${i}`, content: "" },
+          ]),
+          createdAt: Date.now() + i,
+        })
+        .run();
+      maybeEmitActivationMsg5(conv.id);
+    }
+    expect(msg5RowsFor(conv.id)).toBe(0); // still only 4 real turns
+
+    await persistTurnAndRunHook(conv.id, "turn 5");
+    expect(msg5RowsFor(conv.id)).toBe(1); // 5th REAL turn fires
+  });
+});

--- a/assistant/src/__tests__/activation-msg5-hook.test.ts
+++ b/assistant/src/__tests__/activation-msg5-hook.test.ts
@@ -111,6 +111,31 @@ describe("maybeEmitActivationMsg5", () => {
     expect(msg5RowsFor(conv.id)).toBe(0);
   });
 
+  test("emits once when the threshold is first crossed by a path that ran the hook only once", async () => {
+    // Simulates the slash-command persist scenario: 5 real user rows land in
+    // the DB but the hook runs only AFTER the threshold is already crossed
+    // (e.g. a slash message was the 5th turn and went through a path that now
+    // calls the hook). A threshold-based (>= 5) emit must still fire exactly
+    // once even though no `=== 5` transition was observed.
+    const conv = createConversation({ conversationType: "standard" });
+    markActivationSession(conv.id);
+
+    for (let i = 1; i <= 5; i++) {
+      await addMessage(conv.id, "user", `turn ${i}`, { skipIndexing: true });
+      // deliberately do NOT call the hook for turns 1–4
+    }
+
+    // First hook invocation at count >= 5 fires the single row.
+    maybeEmitActivationMsg5(conv.id);
+    expect(msg5RowsFor(conv.id)).toBe(1);
+
+    // Calling again (e.g. the next normal turn at count 6) is a no-op thanks
+    // to the hasActivationEvent exists-check.
+    await addMessage(conv.id, "user", "turn 6", { skipIndexing: true });
+    maybeEmitActivationMsg5(conv.id);
+    expect(msg5RowsFor(conv.id)).toBe(1);
+  });
+
   test("ignores tool_result role=user rows when counting to 5", async () => {
     const conv = createConversation({ conversationType: "standard" });
     markActivationSession(conv.id);

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -17,6 +17,7 @@ import type {
   TurnInterfaceContext,
 } from "../channels/types.js";
 import { parseChannelId, parseInterfaceId } from "../channels/types.js";
+import { isActivationSession } from "../memory/activation-session-store.js";
 import {
   attachInlineAttachmentToMessage,
   attachmentExists,
@@ -36,6 +37,8 @@ import {
   syncMessageToDisk,
   updateMetaFile,
 } from "../memory/conversation-disk-view.js";
+import { recordActivationEvent } from "../memory/onboarding-events-store.js";
+import { countRealUserTurns } from "../memory/turn-events-store.js";
 import {
   buildSlackTimezoneMetadata,
   type SlackMessageMetadata,
@@ -377,6 +380,37 @@ export interface PersistMessageOptions {
   clientMessageId?: string;
 }
 
+// ── activation north-star (msg_5) ────────────────────────────────────
+
+/**
+ * Emit the activation north-star event (`activation_msg_5_sent`) when the 5th
+ * real user turn lands in an activation-rail conversation.
+ *
+ * Best-effort and fire-and-forget: wrapped in try/catch so it can never throw
+ * into or block turn persistence. Triggers only on the exact `=== 5`
+ * transition so no row is written on turns 6, 7, …; the deterministic
+ * `daemon_event_id` (built by the reporter) dedups any residual double-emit
+ * downstream.
+ *
+ * Must be called AFTER the user turn is persisted so {@link countRealUserTurns}
+ * counts this turn as the conversation's Nth real user message.
+ */
+export function maybeEmitActivationMsg5(conversationId: string): void {
+  try {
+    if (!isActivationSession(conversationId)) return;
+    if (countRealUserTurns(conversationId) !== 5) return;
+    recordActivationEvent({
+      stepName: "activation_msg_5_sent",
+      sessionId: conversationId,
+    });
+  } catch (err) {
+    log.warn(
+      { err, conversationId },
+      "Failed to emit activation_msg_5_sent event",
+    );
+  }
+}
+
 // ── persistUserMessage ───────────────────────────────────────────────
 
 export async function persistUserMessage(
@@ -608,6 +642,8 @@ export async function persistQueuedMessageBody(
         conv.createdAt,
       );
     }
+
+    maybeEmitActivationMsg5(ctx.conversationId);
 
     return { id: persistedUserMessage.id, deduplicated: false };
   } catch (err) {

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -37,7 +37,10 @@ import {
   syncMessageToDisk,
   updateMetaFile,
 } from "../memory/conversation-disk-view.js";
-import { recordActivationEvent } from "../memory/onboarding-events-store.js";
+import {
+  hasActivationEvent,
+  recordActivationEvent,
+} from "../memory/onboarding-events-store.js";
 import { countRealUserTurns } from "../memory/turn-events-store.js";
 import {
   buildSlackTimezoneMetadata,
@@ -383,24 +386,36 @@ export interface PersistMessageOptions {
 // ── activation north-star (msg_5) ────────────────────────────────────
 
 /**
- * Emit the activation north-star event (`activation_msg_5_sent`) when the 5th
- * real user turn lands in an activation-rail conversation.
+ * Emit the activation north-star event (`activation_msg_5_sent`) once the
+ * conversation reaches its 5th real user turn in an activation-rail
+ * conversation.
+ *
+ * Idempotent and threshold-based: emits when there are `>= 5` real user turns
+ * AND no `activation_msg_5_sent` row exists yet for this session. This is
+ * resilient to ANY real-user persist path crossing the threshold — including
+ * slash-command paths that bypass {@link persistQueuedMessageBody} — where an
+ * exact `=== 5` check could be skipped if the 5th turn was persisted by a path
+ * that never called the hook, and the next turn already saw count 6. The
+ * exists-check also prevents duplicate rows on turns 6, 7, ….
+ *
+ * The {@link isActivationSession} short-circuit runs FIRST so non-activation
+ * traffic does no extra queries.
  *
  * Best-effort and fire-and-forget: wrapped in try/catch so it can never throw
- * into or block turn persistence. Triggers only on the exact `=== 5`
- * transition so no row is written on turns 6, 7, …; the deterministic
- * `daemon_event_id` (built by the reporter) dedups any residual double-emit
- * downstream.
+ * into or block turn persistence.
  *
  * Must be called AFTER the user turn is persisted so {@link countRealUserTurns}
  * counts this turn as the conversation's Nth real user message.
  */
+const ACTIVATION_MSG_5_STEP = "activation_msg_5_sent" as const;
+
 export function maybeEmitActivationMsg5(conversationId: string): void {
   try {
     if (!isActivationSession(conversationId)) return;
-    if (countRealUserTurns(conversationId) !== 5) return;
+    if (countRealUserTurns(conversationId) < 5) return;
+    if (hasActivationEvent(conversationId, ACTIVATION_MSG_5_STEP)) return;
     recordActivationEvent({
-      stepName: "activation_msg_5_sent",
+      stepName: ACTIVATION_MSG_5_STEP,
       sessionId: conversationId,
     });
   } catch (err) {

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -33,6 +33,7 @@ import { publishConversationMessagesChanged } from "../runtime/sync/resource-syn
 import { getLogger } from "../util/logger.js";
 import type { CleanResult, Conversation } from "./conversation.js";
 import {
+  maybeEmitActivationMsg5,
   persistQueuedMessageBody,
   serializePersistedUserMessageContent,
 } from "./conversation-messaging.js";
@@ -511,6 +512,7 @@ async function drainSingleMessage(
         metadata: drainChannelMeta,
       });
       conversation.messages.push(llmUserMsg);
+      maybeEmitActivationMsg5(conversation.conversationId);
 
       const assistantMsg = createAssistantMessage(slashResult.message);
       await addMessage(
@@ -624,6 +626,7 @@ async function drainSingleMessage(
       );
       persistedCompactMessage = true;
       conversation.messages.push(cleanUserMsg);
+      maybeEmitActivationMsg5(conversation.conversationId);
 
       conversation.emitActivityState("thinking", "context_compacting", {
         requestId: next.requestId,
@@ -715,6 +718,7 @@ async function drainSingleMessage(
       );
       persistedCleanMessage = true;
       conversation.messages.push(cleanUserMsg);
+      maybeEmitActivationMsg5(conversation.conversationId);
 
       const result = await conversation.forceClean();
       const responseText = formatCleanResult(result);
@@ -1457,6 +1461,7 @@ export async function processMessage(
         { metadata: routerChannelMeta },
       );
       conversation.messages.push(llmUserMsg);
+      maybeEmitActivationMsg5(conversation.conversationId);
 
       const replyText =
         routerResult.replyText ??
@@ -1550,6 +1555,7 @@ export async function processMessage(
       { metadata: pmChannelMeta },
     );
     conversation.messages.push(llmUserMsg);
+    maybeEmitActivationMsg5(conversation.conversationId);
 
     const assistantMsg = createAssistantMessage(slashResult.message);
     await addMessage(
@@ -1638,6 +1644,7 @@ export async function processMessage(
       );
       persistedCompactMessage = true;
       conversation.messages.push(cleanUserMsg);
+      maybeEmitActivationMsg5(conversation.conversationId);
 
       conversation.emitActivityState("thinking", "context_compacting", {
         requestId,
@@ -1720,6 +1727,7 @@ export async function processMessage(
       );
       persistedCleanMessage = true;
       conversation.messages.push(cleanUserMsg);
+      maybeEmitActivationMsg5(conversation.conversationId);
 
       const result = await conversation.forceClean();
       const responseText = formatCleanResult(result);

--- a/assistant/src/daemon/process-message.ts
+++ b/assistant/src/daemon/process-message.ts
@@ -36,6 +36,7 @@ import { getLogger } from "../util/logger.js";
 import type { Conversation } from "./conversation.js";
 import {
   buildSlackMetaForPersistence,
+  maybeEmitActivationMsg5,
   serializePersistedUserMessageContent,
 } from "./conversation-messaging.js";
 import {
@@ -342,6 +343,7 @@ export async function processMessage(
       { metadata: userMetaWithSlack },
     );
     conversation.getMessages().push(llmMsg);
+    maybeEmitActivationMsg5(conversationId);
 
     if (serverTurnCtx) {
       try {
@@ -435,6 +437,7 @@ export async function processMessage(
       { metadata: compactUserMeta },
     );
     conversation.getMessages().push(cleanMsg);
+    maybeEmitActivationMsg5(conversationId);
 
     conversation.emitActivityState("thinking", "context_compacting");
     const result = await conversation.forceCompact();
@@ -490,6 +493,7 @@ export async function processMessage(
       { metadata: cleanUserMeta },
     );
     conversation.getMessages().push(cleanMsg);
+    maybeEmitActivationMsg5(conversationId);
 
     const result = await conversation.forceClean();
     const responseText = formatCleanResult(result);

--- a/assistant/src/memory/onboarding-events-store.ts
+++ b/assistant/src/memory/onboarding-events-store.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, gt, or } from "drizzle-orm";
+import { and, asc, eq, gt, or, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getConfig } from "../config/loader.js";
@@ -112,6 +112,31 @@ export function recordActivationEvent(params: {
     completedAt: new Date(createdAt).toISOString(),
     funnelVersion: ACTIVATION_FUNNEL_VERSION,
   });
+}
+
+/**
+ * Returns true when an onboarding/activation event row already exists for the
+ * given `sessionId` + `stepName`. Used to make milestone emits idempotent:
+ * callers skip recording when the row is already present, guaranteeing exactly
+ * one row per session per step regardless of which persist path crossed the
+ * threshold.
+ */
+export function hasActivationEvent(
+  sessionId: string,
+  stepName: string,
+): boolean {
+  const row = getDb()
+    .select({ one: sql<number>`1`.as("one") })
+    .from(onboardingEvents)
+    .where(
+      and(
+        eq(onboardingEvents.sessionId, sessionId),
+        eq(onboardingEvents.stepName, stepName),
+      ),
+    )
+    .limit(1)
+    .get();
+  return row !== undefined;
 }
 
 /**

--- a/assistant/src/memory/turn-events-store.ts
+++ b/assistant/src/memory/turn-events-store.ts
@@ -87,6 +87,34 @@ function realUserTurnContentFilter(alias: string): ReturnType<typeof sql> {
 }
 
 /**
+ * Count the real user turns in a conversation — the 1-indexed position of the
+ * most-recently-persisted real user turn. Reuses {@link realUserTurnContentFilter}
+ * (the single source of truth) so this count stays in lockstep with the
+ * `turn_index` computed by {@link queryUnreportedTurnEvents}: tool-result rows
+ * persisted with role="user" are excluded.
+ *
+ * Intended to be called immediately after a real user turn is persisted, so the
+ * returned count is that turn's 1-indexed position within the conversation.
+ */
+export function countRealUserTurns(conversationId: string): number {
+  const db = getDb();
+  const row = db
+    .select({
+      count: sql<number>`COUNT(*)`.as("count"),
+    })
+    .from(messages)
+    .where(
+      and(
+        eq(messages.conversationId, conversationId),
+        eq(messages.role, "user"),
+        realUserTurnContentFilter("messages"),
+      ),
+    )
+    .get();
+  return row?.count ?? 0;
+}
+
+/**
  * Query user messages (turns) that haven't been reported to telemetry yet.
  * Uses a compound cursor (createdAt + id) for reliable watermarking.
  *


### PR DESCRIPTION
## Summary
- On the 5th real user turn in an activation-rail conversation, emit activation_msg_5_sent (best-effort, fire-and-forget).
- Triggers only on the exact ===5 transition; deterministic id dedups downstream.
- Tests for the 5th-turn trigger, non-activation no-op, and no duplicate on later turns.

Part of plan: activation-telemetry.md (PR 7 of 10)