### PR TITLE
feat(assistant): emit_activation_event tool wired into activation rail

### DIFF
--- a/assistant/src/__tests__/conversation-tool-setup-activation-preactivation.test.ts
+++ b/assistant/src/__tests__/conversation-tool-setup-activation-preactivation.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Cohort-scoped preactivation of the `activation` skill.
+ *
+ * The activation rail asks the model to emit milestone events via
+ * `emit_activation_event`, which lives in the `activation` bundled skill. That
+ * tool is only registered for a turn when its skill is preactivated, so the
+ * skill must be preactivated automatically for activation-rail conversations —
+ * but NOT product-wide (it would leak the tool into every conversation).
+ *
+ * These tests assert the cohort scoping directly against the real DB-backed
+ * `markActivationSession`/`isActivationSession` so a marked conversation gets
+ * `activation` in its effective preactivated set and an unmarked one does not.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import { computeEffectivePreactivatedSkillIds } from "../daemon/conversation-tool-setup.js";
+import { markActivationSession } from "../memory/activation-session-store.js";
+import { getDb } from "../memory/db-connection.js";
+import { initializeDb } from "../memory/db-init.js";
+import { activationSessions } from "../memory/schema.js";
+
+initializeDb();
+
+describe("computeEffectivePreactivatedSkillIds — activation cohort scoping", () => {
+  beforeEach(() => {
+    getDb().delete(activationSessions).run();
+  });
+
+  test("marked activation conversation includes the activation skill", () => {
+    markActivationSession("rail-conv");
+
+    const ids = computeEffectivePreactivatedSkillIds({
+      conversationId: "rail-conv",
+    });
+
+    expect(ids).toContain("activation");
+    // Global defaults are still present.
+    expect(ids).toContain("tasks");
+    expect(ids).toContain("notifications");
+    expect(ids).toContain("subagent");
+  });
+
+  test("non-activation conversation does NOT include the activation skill", () => {
+    const ids = computeEffectivePreactivatedSkillIds({
+      conversationId: "regular-conv",
+    });
+
+    expect(ids).not.toContain("activation");
+    // Global defaults remain.
+    expect(ids).toContain("tasks");
+  });
+
+  test("missing conversation id does not include the activation skill", () => {
+    const ids = computeEffectivePreactivatedSkillIds({});
+
+    expect(ids).not.toContain("activation");
+  });
+
+  test("conversation-explicit preactivated ids are preserved alongside cohort scoping", () => {
+    markActivationSession("rail-conv-2");
+
+    const ids = computeEffectivePreactivatedSkillIds({
+      conversationId: "rail-conv-2",
+      preactivatedSkillIds: ["guardian-verify-setup"],
+    });
+
+    expect(ids).toContain("guardian-verify-setup");
+    expect(ids).toContain("activation");
+  });
+});

--- a/assistant/src/config/bundled-skills/activation/SKILL.md
+++ b/assistant/src/config/bundled-skills/activation/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: activation
+description: Record activation funnel milestones for the activation rail
+compatibility: "Designed for Vellum personal assistants"
+metadata:
+  emoji: "🚀"
+  vellum:
+    display-name: "Activation"
+---
+
+Records activation-funnel milestone events for the activation rail. The single
+tool, `emit_activation_event`, takes a `step_name` and persists a funnel
+milestone so we can measure how far new users get on their first run.
+
+This tool is always available but does nothing outside the activation rail: it
+is gated at runtime. `emitActivationMoment` returns `not_activation_session` for
+any conversation that was not started on the activation rail, so a stray call in
+a normal chat never pollutes the funnel. Only the activation-rail bootstrap
+instructs the model to call it.
+
+## Firing the milestones
+
+Emit each milestone from the scoped tool call that does the rail work — not on
+every text turn. See `BOOTSTRAP-ACTIVATION-RAIL.md` for the exact firing
+conditions bound to the rail's moves.
+
+## Boundaries
+
+- The tool never errors a turn. An expected rejection (unknown step, wrong
+  session, the daemon-owned step) returns a terse non-error result.
+- `activation_msg_5_sent` is emitted **automatically by the daemon**. The model
+  must NEVER pass it here — it is rejected as `daemon_owned`.

--- a/assistant/src/config/bundled-skills/activation/TOOLS.json
+++ b/assistant/src/config/bundled-skills/activation/TOOLS.json
@@ -1,0 +1,23 @@
+{
+  "version": 1,
+  "tools": [
+    {
+      "name": "emit_activation_event",
+      "description": "Record an activation-funnel milestone for the current activation-rail conversation. Used only by the activation rail to mark when a rail move lands (e.g. context captured, bundle selected, first task chosen, first wow executed/interacted). No-op outside an activation session.",
+      "category": "activation",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "step_name": {
+            "type": "string",
+            "description": "Activation funnel step name to record. One of: activation_moment_1_complete, activation_moment_2_complete, activation_moment_3_complete, activation_first_wow_executed, activation_first_wow_interacted. NEVER pass activation_msg_5_sent (daemon-owned)."
+          }
+        },
+        "required": ["step_name"]
+      },
+      "executor": "tools/emit-activation-event.ts",
+      "execution_target": "host"
+    }
+  ]
+}

--- a/assistant/src/config/bundled-skills/activation/TOOLS.json
+++ b/assistant/src/config/bundled-skills/activation/TOOLS.json
@@ -13,8 +13,7 @@
             "type": "string",
             "description": "Activation funnel step name to record. One of: activation_moment_1_complete, activation_moment_2_complete, activation_moment_3_complete, activation_first_wow_executed, activation_first_wow_interacted. NEVER pass activation_msg_5_sent (daemon-owned)."
           }
-        },
-        "required": ["step_name"]
+        }
       },
       "executor": "tools/emit-activation-event.ts",
       "execution_target": "host"

--- a/assistant/src/config/bundled-skills/activation/icon.svg
+++ b/assistant/src/config/bundled-skills/activation/icon.svg
@@ -1,0 +1,16 @@
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <rect width="16" height="16" fill="#f5f5f5"/>
+
+  <!-- Rocket body -->
+  <path d="M8 2 C10.5 4 10.5 8 8 11 C5.5 8 5.5 4 8 2 Z" fill="#4a90e2" stroke="#2c5aa0" stroke-width="0.6"/>
+
+  <!-- Window -->
+  <circle cx="8" cy="5.5" r="1.2" fill="#ffffff" stroke="#2c5aa0" stroke-width="0.4"/>
+
+  <!-- Fins -->
+  <path d="M6.4 8.5 L4.8 11 L6.4 10.4 Z" fill="#357abd"/>
+  <path d="M9.6 8.5 L11.2 11 L9.6 10.4 Z" fill="#357abd"/>
+
+  <!-- Exhaust flame -->
+  <path d="M7.2 11 L8 14 L8.8 11 Z" fill="#ff6b6b" stroke="#c92a2a" stroke-width="0.3"/>
+</svg>

--- a/assistant/src/config/bundled-skills/activation/tools/__tests__/emit-activation-event.test.ts
+++ b/assistant/src/config/bundled-skills/activation/tools/__tests__/emit-activation-event.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 // Silence the logger.
@@ -13,6 +16,7 @@ mock.module("../../../../../config/loader.js", () => ({
   getConfig: () => ({ collectUsageData: true }),
 }));
 
+import type { SkillToolEntry } from "../../../../../config/skills.js";
 import { markActivationSession } from "../../../../../memory/activation-session-store.js";
 import { getDb } from "../../../../../memory/db-connection.js";
 import { initializeDb } from "../../../../../memory/db-init.js";
@@ -21,8 +25,13 @@ import {
   activationSessions,
   onboardingEvents,
 } from "../../../../../memory/schema.js";
+import { createSkillTool } from "../../../../../tools/skills/skill-tool-factory.js";
 import type { ToolContext } from "../../../../../tools/types.js";
 import { run } from "../emit-activation-event.js";
+
+// Skill root is three levels up from this test file:
+// activation/tools/__tests__/ → activation/.
+const SKILL_DIR = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
 
 initializeDb();
 
@@ -76,5 +85,62 @@ describe("emit_activation_event tool", () => {
     expect(missing.isError).toBe(false);
 
     expect(queryUnreportedOnboardingEvents(0, undefined, 10)).toHaveLength(0);
+  });
+});
+
+// The direct-run tests above bypass the manifest schema validation that
+// `createSkillTool` runs before `run()`. These exercise the PRODUCTION path:
+// the model-facing tool built from the real TOOLS.json manifest. They guard
+// against `step_name` becoming `required` again, which would error the turn on
+// a malformed emit and violate the never-error contract.
+describe("emit_activation_event via createSkillTool (production path)", () => {
+  beforeEach(resetTables);
+
+  function manifestEntry(): SkillToolEntry {
+    const manifest = JSON.parse(
+      readFileSync(join(SKILL_DIR, "TOOLS.json"), "utf-8"),
+    ) as { tools: SkillToolEntry[] };
+    const entry = manifest.tools.find(
+      (t) => t.name === "emit_activation_event",
+    );
+    expect(entry).toBeDefined();
+    return entry!;
+  }
+
+  // bundled: true routes to the pre-imported registry; no version hash so the
+  // runner skips the integrity check.
+  function makeProductionTool() {
+    return createSkillTool(manifestEntry(), SKILL_DIR, "", true);
+  }
+
+  test("manifest no longer marks step_name required", () => {
+    const schema = manifestEntry().input_schema as { required?: unknown };
+    expect(schema.required ?? []).not.toContain("step_name");
+  });
+
+  test("missing step_name: non-error result, no row, no validation error", async () => {
+    markActivationSession("conv-prod-1");
+    const tool = makeProductionTool();
+
+    const result = await tool.execute({}, ctx("conv-prod-1"));
+
+    expect(result.isError).toBe(false);
+    expect(result.content).not.toContain("Invalid input");
+    expect(queryUnreportedOnboardingEvents(0, undefined, 10)).toHaveLength(0);
+  });
+
+  test("valid step records a row through the production path", async () => {
+    markActivationSession("conv-prod-2");
+    const tool = makeProductionTool();
+
+    const result = await tool.execute(
+      { step_name: "activation_moment_1_complete" },
+      ctx("conv-prod-2"),
+    );
+
+    expect(result.isError).toBe(false);
+    const rows = queryUnreportedOnboardingEvents(0, undefined, 10);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.stepName).toBe("activation_moment_1_complete");
   });
 });

--- a/assistant/src/config/bundled-skills/activation/tools/__tests__/emit-activation-event.test.ts
+++ b/assistant/src/config/bundled-skills/activation/tools/__tests__/emit-activation-event.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Silence the logger.
+mock.module("../../../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// Usage-data collection is enabled for these tests.
+mock.module("../../../../../config/loader.js", () => ({
+  getConfig: () => ({ collectUsageData: true }),
+}));
+
+import { markActivationSession } from "../../../../../memory/activation-session-store.js";
+import { getDb } from "../../../../../memory/db-connection.js";
+import { initializeDb } from "../../../../../memory/db-init.js";
+import { queryUnreportedOnboardingEvents } from "../../../../../memory/onboarding-events-store.js";
+import {
+  activationSessions,
+  onboardingEvents,
+} from "../../../../../memory/schema.js";
+import type { ToolContext } from "../../../../../tools/types.js";
+import { run } from "../emit-activation-event.js";
+
+initializeDb();
+
+function resetTables(): void {
+  getDb().delete(onboardingEvents).run();
+  getDb().delete(activationSessions).run();
+}
+
+function ctx(conversationId: string): ToolContext {
+  return {
+    workingDir: "/tmp",
+    conversationId,
+    trustClass: "guardian",
+  };
+}
+
+describe("emit_activation_event tool", () => {
+  beforeEach(resetTables);
+
+  test("records one row for a valid step in a marked rail session", async () => {
+    markActivationSession("conv-1");
+    const result = await run(
+      { step_name: "activation_moment_2_complete" },
+      ctx("conv-1"),
+    );
+    expect(result.isError).toBe(false);
+
+    const rows = queryUnreportedOnboardingEvents(0, undefined, 10);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.stepName).toBe("activation_moment_2_complete");
+    expect(rows[0]!.sessionId).toBe("conv-1");
+  });
+
+  test("rejects the daemon-owned msg_5 step: non-error result, no row", async () => {
+    markActivationSession("conv-2");
+    const result = await run(
+      { step_name: "activation_msg_5_sent" },
+      ctx("conv-2"),
+    );
+    expect(result.isError).toBe(false);
+    expect(queryUnreportedOnboardingEvents(0, undefined, 10)).toHaveLength(0);
+  });
+
+  test("malformed/unknown input: non-error result, no row", async () => {
+    markActivationSession("conv-3");
+
+    const unknown = await run({ step_name: "bogus" }, ctx("conv-3"));
+    expect(unknown.isError).toBe(false);
+
+    const missing = await run({}, ctx("conv-3"));
+    expect(missing.isError).toBe(false);
+
+    expect(queryUnreportedOnboardingEvents(0, undefined, 10)).toHaveLength(0);
+  });
+});

--- a/assistant/src/config/bundled-skills/activation/tools/emit-activation-event.ts
+++ b/assistant/src/config/bundled-skills/activation/tools/emit-activation-event.ts
@@ -1,0 +1,40 @@
+import { emitActivationMoment } from "../../../../telemetry/activation-emit.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+
+/**
+ * Record an activation-funnel milestone for the current conversation.
+ *
+ * This executor is a thin wrapper around `emitActivationMoment`, which owns all
+ * gating (unknown step, daemon-owned msg_5, non-rail session) and is itself
+ * best-effort: it never throws. To preserve that guarantee at the tool boundary
+ * we likewise never error the turn — an expected rejection (unknown step, wrong
+ * session, daemon-owned step) returns a terse, non-error result so the model can
+ * keep going. The only signal the model needs is "recorded" vs "skipped".
+ */
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const stepName = typeof input.step_name === "string" ? input.step_name : "";
+
+  const result = emitActivationMoment({
+    stepName,
+    conversationId: context.conversationId,
+  });
+
+  if (result.ok) {
+    return {
+      content: `Recorded activation milestone: ${stepName}`,
+      isError: false,
+    };
+  }
+
+  // Expected, benign rejection — never error the turn.
+  return {
+    content: `Activation milestone not recorded (${result.reason ?? "skipped"}).`,
+    isError: false,
+  };
+}

--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -19,6 +19,8 @@ import * as acpListAgents from "./bundled-skills/acp/tools/acp-list-agents.js";
 import * as acpSpawn from "./bundled-skills/acp/tools/acp-spawn.js";
 import * as acpStatus from "./bundled-skills/acp/tools/acp-status.js";
 import * as acpSteer from "./bundled-skills/acp/tools/acp-steer.js";
+// ── activation ─────────────────────────────────────────────────────────────────
+import * as emitActivationEvent from "./bundled-skills/activation/tools/emit-activation-event.js";
 // ── app-builder ────────────────────────────────────────────────────────────────
 import * as appCreate from "./bundled-skills/app-builder/tools/app-create.js";
 import * as appDelete from "./bundled-skills/app-builder/tools/app-delete.js";
@@ -137,6 +139,9 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
   ["acp:tools/acp-abort.ts", acpAbort],
   ["acp:tools/acp-steer.ts", acpSteer],
   ["acp:tools/acp-list-agents.ts", acpListAgents],
+
+  // activation
+  ["activation:tools/emit-activation-event.ts", emitActivationEvent],
 
   // app-builder
   ["app-builder:tools/app-create.ts", appCreate],

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -13,6 +13,7 @@ import {
 } from "../channels/types.js";
 import { getIsPlatform } from "../config/env-registry.js";
 import { getConfig } from "../config/loader.js";
+import { isActivationSession } from "../memory/activation-session-store.js";
 import { getBindingByConversation } from "../memory/external-conversation-store.js";
 import type { PermissionPrompter } from "../permissions/prompter.js";
 import type { SecretPrompter } from "../permissions/secret-prompter.js";
@@ -290,10 +291,44 @@ export function createProxyApprovalCallback(
 const DEFAULT_PREACTIVATED_SKILL_IDS = ["tasks", "notifications", "subagent"];
 
 /**
+ * Skill id of the activation-rail telemetry skill, cohort-scoped (see
+ * {@link computeEffectivePreactivatedSkillIds}) so its `emit_activation_event`
+ * tool is only registered for activation-rail conversations, never globally.
+ */
+const ACTIVATION_SKILL_ID = "activation";
+
+/**
+ * Resolve the skills to preactivate for a turn: the global default set, plus
+ * any conversation-explicit ids, plus `activation` when this conversation is an
+ * activation-rail session. Evaluated each turn (not at conversation init) so it
+ * survives the per-turn `preactivatedSkillIds` resets in conversation-process.
+ * The indexed PK `isActivationSession` lookup runs only when a conversation id
+ * is present and never throws (it is internally best-effort).
+ */
+export function computeEffectivePreactivatedSkillIds(
+  ctx: Pick<SkillProjectionContext, "conversationId" | "preactivatedSkillIds">,
+): string[] {
+  const ids = [
+    ...DEFAULT_PREACTIVATED_SKILL_IDS,
+    ...(ctx.preactivatedSkillIds ?? []),
+  ];
+  if (ctx.conversationId && isActivationSession(ctx.conversationId)) {
+    ids.push(ACTIVATION_SKILL_ID);
+  }
+  return ids;
+}
+
+/**
  * Subset of Conversation state that the resolveTools callback reads at each
  * agent turn. Properties are read lazily from this reference.
  */
 export interface SkillProjectionContext {
+  /**
+   * Stable conversation id. Read each turn to cohort-scope preactivation
+   * (e.g. the `activation` skill is preactivated only for activation-rail
+   * sessions, never product-wide).
+   */
+  readonly conversationId?: string;
   preactivatedSkillIds?: string[];
   readonly skillProjectionState: Map<string, string>;
   readonly skillProjectionCache: SkillProjectionCache;
@@ -584,10 +619,7 @@ export function createResolveToolsCallback(
       (d) => !excluded.has(d.name),
     );
 
-    const effectivePreactivated = [
-      ...DEFAULT_PREACTIVATED_SKILL_IDS,
-      ...(ctx.preactivatedSkillIds ?? []),
-    ];
+    const effectivePreactivated = computeEffectivePreactivatedSkillIds(ctx);
     const projection = projectSkillTools(history, {
       preactivatedSkillIds: effectivePreactivated,
       previouslyActiveSkillIds: ctx.skillProjectionState,

--- a/assistant/src/prompts/templates/BOOTSTRAP-ACTIVATION-RAIL.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP-ACTIVATION-RAIL.md
@@ -83,6 +83,36 @@ Identity writes (IDENTITY.md, SOUL.md), user-profile writes, journal entries: al
 
 The base BOOTSTRAP task_preferences fallback is not on this rail. Your opener is the Port pitch.
 
+## Telemetry: emit_activation_event
+
+The activation funnel is measured by the `emit_activation_event` tool. Call it
+with a single `step_name` to record a milestone. This is the JARVIS-1102 "naming
+check" intent: emit from the SCOPED tool call that does the rail work, NOT on
+every text turn. A milestone records once; a duplicate emit is harmless (deduped
+downstream) but don't fire one just because you produced text.
+
+Firing conditions, bound to the moves above:
+
+- `activation_moment_1_complete` — background + top-of-mind captured, OR the user
+  explicitly skipped. Fire at the end of the Port move (after the paste lands, or
+  after the no-port intake `choice` resolves / the single context question is
+  answered).
+- `activation_moment_2_complete` — the bundle/intent selection is resolved: the
+  user picked an offer in Propose (the `ui_show` offer surface was committed).
+- `activation_moment_3_complete` — the first task is selected (the specific thing
+  you're about to run is chosen).
+- `activation_first_wow_executed` — the execution surface rendered / the wow
+  action actually ran against real data in Run.
+- `activation_first_wow_interacted` — the user clicked an action button on the
+  result surface, or sent a follow-up after the wow.
+
+`activation_msg_5_sent` is emitted AUTOMATICALLY by the daemon turn hook. The
+model must NEVER emit it — passing it to `emit_activation_event` is rejected.
+
+The tool no-ops outside an activation session and never errors a turn, so a
+missed or mistimed emit is non-fatal — but accurate, move-bound emits are what
+make the funnel meaningful.
+
 ## Wrap
 
 <!-- Open question: the default wrap tone below is opinionated (brisk, dataset-first). Whether that's the right note to end the activation rail on is a conscious call we haven't made yet — flag, don't silently change. -->


### PR DESCRIPTION
## Summary
- Add emit_activation_event as a bundled-skill tool (mirrors followups), wrapping emitActivationMoment. Never errors the turn.
- Document firing conditions for the 5 model-emitted moments in BOOTSTRAP-ACTIVATION-RAIL.md; msg_5 stays daemon-owned.
- Tool test.

Mechanism decision: bundled-skill tool (not core) per src/tools/AGENTS.md.

Part of plan: activation-telemetry.md (PR 9 of 10)