### PR TITLE
docs(assistant): activation funnel telemetry runbook + analytics handoff

### DIFF
--- a/assistant/docs/activation-funnel-telemetry.md
+++ b/assistant/docs/activation-funnel-telemetry.md
@@ -1,0 +1,280 @@
+# Activation Funnel Telemetry — Runbook + Analytics Handoff
+
+> **Linear:** JARVIS-1102 (event emission) — gates JARVIS-1092 (10% rollout) and JARVIS-1093 (dashboard).
+> **Funnel version:** `activation_v1_2026_06`
+> **LD flag:** `experiment-activation-flow-2026-06-03`
+> **Cohort arm tag:** `ab_variant = "variant-a"` (treatment); `control` = the no-rail arm.
+
+This doc is the single executable reference for the activation-rail funnel
+telemetry: what it measures, how it flows, the event vocabulary, the dedup
+contract, the local smoke-test runbook, the BigQuery verification query, and the
+canonical handoff blurb for the dashboard work. It is meant to be runnable by
+another engineer without reading the implementation.
+
+---
+
+## 1. Overview — what it measures and how it flows
+
+The activation funnel measures how far a new user gets on their first run of the
+**activation rail** (the onboarding experience driven by
+`BOOTSTRAP-ACTIVATION-RAIL.md`). It emits six milestone ("funnel") events per
+session into the **existing onboarding telemetry substrate** — no new event type,
+no new ingest endpoint, no new BigQuery table.
+
+Flow, end to end:
+
+1. **Daemon records** an activation event into the SQLite `onboarding_events`
+   table. There are three record paths, all converging on
+   `recordActivationEvent()` in
+   `assistant/src/memory/onboarding-events-store.ts`:
+   - the model calls the **`emit_activation_event`** bundled-skill tool
+     (`assistant/src/config/bundled-skills/activation/`), which goes through the
+     pure handler `emitActivationMoment()`
+     (`assistant/src/telemetry/activation-emit.ts`) for moments 1/2/3 and the two
+     first-wow steps;
+   - the **daemon turn hook** `maybeEmitActivationMsg5()`
+     (`assistant/src/daemon/conversation-messaging.ts`) emits the north-star
+     `activation_msg_5_sent` at the 5th real user turn;
+   - both reuse `recordActivationEvent`, which respects the
+     `getConfig().collectUsageData` opt-out gate (returns `null` / no row when
+     disabled).
+2. **Reporter flushes** every ~5 min: `usage-telemetry-reporter.ts`
+   (`REPORT_INTERVAL_MS = 5 * 60 * 1000`, with a one-time
+   `INITIAL_FLUSH_DELAY_MS = 30_000` after startup) POSTs unreported onboarding
+   rows to `/v1/telemetry/ingest/` as `type: "onboarding"` events, mapping the
+   funnel columns onto the wire shape.
+3. **Platform ingests** the onboarding events and writes GCS NDJSON.
+4. **BigQuery** exposes them via the external table
+   `vellum-ai-prod.telemetry.onboarding_raw`, which already carries the
+   `session_id / step_name / step_index / completed_at / funnel_version /
+ab_variant` columns. The existing dbt model dedups on `daemon_event_id`
+   (earliest-wins).
+
+No platform / dbt / terraform change is required — the activation events ride the
+`type: "onboarding"` substrate that already exists end to end.
+
+---
+
+## 2. Event vocabulary
+
+The single source of truth is `assistant/src/telemetry/activation-funnel.ts`
+(`ACTIVATION_STEPS`). `funnel_version = "activation_v1_2026_06"`
+(`ACTIVATION_FUNNEL_VERSION`). `ab_variant = "variant-a"`
+(`ACTIVATION_AB_VARIANT`, the treatment arm).
+
+| step_index | step_name                         | Emitted by                                                                                      |
+| ---------- | --------------------------------- | ----------------------------------------------------------------------------------------------- |
+| 1          | `activation_moment_1_complete`    | model — `emit_activation_event` tool (background + top-of-mind captured, or explicitly skipped) |
+| 2          | `activation_moment_2_complete`    | model — `emit_activation_event` tool (bundle/intent selection resolved)                         |
+| 3          | `activation_moment_3_complete`    | model — `emit_activation_event` tool (first task selected)                                      |
+| 4          | `activation_first_wow_executed`   | model — `emit_activation_event` tool (execution surface rendered / wow ran)                     |
+| 5          | `activation_first_wow_interacted` | model — `emit_activation_event` tool (user clicked an action / sent a follow-up on the wow)     |
+| 6          | `activation_msg_5_sent`           | **daemon turn hook** (5th real user turn) — the north star                                      |
+
+The model emits 1–5 via the tool. The daemon emits 6; the model is **forbidden**
+from emitting `activation_msg_5_sent` — the handler rejects it as `daemon_owned`.
+
+On the wire, each onboarding event also sets `screen = step_name` (to satisfy the
+SQLite `screen TEXT NOT NULL` column and the platform's legacy-path validation),
+and `completed_at` is the ISO-8601 record time.
+
+---
+
+## 3. Dedup contract
+
+Activation rows carry a **deterministic** `daemon_event_id`:
+
+```
+daemon_event_id = `${funnel_version}:${session_id}:${step_name}`
+```
+
+Built by `buildActivationDaemonEventId()` in
+`assistant/src/telemetry/activation-funnel.ts`. The reporter overrides
+`daemon_event_id` for activation rows (where `session_id && step_name &&
+funnel_version` are all present) and keys it on the **row's stored
+`funnel_version`**, NOT the running binary's current constant. This keeps the id
+stable across a version bump so rows queued offline / flushed after an upgrade
+still collapse with already-ingested rows from the same session.
+
+A moment that fires more than once (e.g. a model double-emit) therefore lands
+with the same `daemon_event_id` and is collapsed downstream by the existing dbt
+earliest-wins dedup on `daemon_event_id`. For boolean "moment complete"
+semantics, earliest-wins is correct.
+
+**Checkpoint safety:** the SQLite watermark cursor in the reporter advances on the
+row `id` / `createdAt`, NOT on `daemon_event_id`. The deterministic id is a
+wire-only override, so overriding it never affects flush checkpointing.
+
+---
+
+## 4. Cohort scoping
+
+Events only emit for conversations explicitly marked as **activation-rail
+sessions**:
+
+- The marker lives in the `activation_sessions` table
+  (`assistant/src/memory/activation-session-store.ts`,
+  `markActivationSession` / `isActivationSession`).
+- It is set in `assistant/src/prompts/system-prompt.ts` **only when the
+  `BOOTSTRAP-ACTIVATION-RAIL.md` template is actually active** (i.e.
+  `bootstrapTemplate === ACTIVATION_RAIL_BOOTSTRAP_TEMPLATE`), which the web
+  prechat context selects only for users whose
+  `experiment-activation-flow-2026-06-03` cohort puts them on the rail.
+- The `emit_activation_event` tool is **preactivated and cohort-scoped to rail
+  sessions**: it is registered as a bundled-skill tool and is present, but
+  `emitActivationMoment()` returns `{ ok: false, reason: "not_activation_session"
+}` for any conversation that was never marked — so a stray tool call in a normal
+  chat never pollutes the funnel.
+- `activation_msg_5_sent` fires **once**, at the 5th real user turn, via the
+  daemon turn hook. It is idempotent: the hook short-circuits on
+  `isActivationSession` first, then checks `countRealUserTurns(...) >= 5`, then
+  `hasActivationEvent(sessionId, "activation_msg_5_sent")` so it writes exactly
+  one row regardless of which persist path (including slash-command paths) crossed
+  the threshold.
+
+The activation **session id is the daemon `conversation_id`** of the rail
+conversation. That same value is `session_id` on every activation event.
+
+---
+
+## 5. Local smoke-test runbook
+
+Goal: drive one dev session through the activation cohort, emit all six events,
+flush, and verify rows in BigQuery. Executable by another engineer.
+
+### 5.1 Put the dev user in the activation cohort
+
+The rail is gated by the LD flag `experiment-activation-flow-2026-06-03`. Two
+options:
+
+- **In-app feature-flags override (fastest):** open the in-app Feature Flags
+  panel and force `experiment-activation-flow-2026-06-03` ON for the dev user.
+- **LaunchDarkly targeting:** target the dev user for the flag in the LD
+  dashboard (per the LD-flag-two-repo convention, targeting is dashboard-side).
+
+When the flag is ON, the web prechat context selects
+`BOOTSTRAP-ACTIVATION-RAIL.md` as the bootstrap template, and the daemon marks
+the conversation in `activation_sessions` on first build of the system prompt.
+
+### 5.2 Confirm usage-data collection is enabled
+
+`recordActivationEvent` no-ops when `collectUsageData` is false. Make sure the dev
+build/config has usage-data collection enabled, or no rows will be written.
+
+### 5.3 Start a fresh activation conversation and capture its id
+
+Start a brand-new conversation with the flag ON (it must be the rail bootstrap, so
+start it from the web prechat flow / activation entry, not an existing chat).
+Note its `conversation_id` — this is the `session_id` you will query on.
+
+If multiple daemons are running, kill ALL `daemon/main.ts` processes, remove
+`~/.vellum/vellum.sock`, and start fresh, so the conversation is served by a known
+daemon writing to a known SQLite DB.
+
+### 5.4 Drive the rail through all five model moments
+
+Work the conversation through the rail moves so the model emits each milestone via
+`emit_activation_event` (firing conditions are documented in
+`BOOTSTRAP-ACTIVATION-RAIL.md`):
+
+1. Provide background / top-of-mind (or skip it) → `activation_moment_1_complete`.
+2. Resolve a bundle / intent selection → `activation_moment_2_complete`.
+3. Select the first task → `activation_moment_3_complete`.
+4. Let the wow execute / the execution surface render → `activation_first_wow_executed`.
+5. Click an action button / send a follow-up on the wow → `activation_first_wow_interacted`.
+
+### 5.5 Trigger the north-star event
+
+Send real user messages until the conversation has **5 real user turns**. The
+daemon turn hook fires `activation_msg_5_sent` exactly once at the 5th real user
+turn. (Tool-only / system turns don't count — only real user messages.)
+
+### 5.6 Force / await a telemetry flush
+
+The reporter flushes on a schedule: a first flush ~30s after startup
+(`INITIAL_FLUSH_DELAY_MS`) and then every ~5 min (`REPORT_INTERVAL_MS`). Either:
+
+- **Wait** for the next scheduled flush (≤ ~5 min), or
+- **Restart the daemon** to take the ~30s post-startup flush, or
+- call the reporter's `flush()` path directly if you have a dev hook into the
+  running daemon.
+
+A successful flush POSTs the unreported onboarding rows to
+`/v1/telemetry/ingest/` as `type: "onboarding"` events.
+
+### 5.7 Verify in BigQuery
+
+Wait for the platform → GCS NDJSON → BigQuery pipeline to land the events, then
+run the query in §6.
+
+---
+
+## 6. BigQuery verification query
+
+```sql
+SELECT step_name, step_index, COUNT(*) AS n
+FROM `vellum-ai-prod.telemetry.onboarding_raw`
+WHERE funnel_version = 'activation_v1_2026_06'
+  AND session_id = '<dev conversation id>'
+GROUP BY 1, 2
+ORDER BY 2;
+```
+
+**Expected:** all six `activation_*` step names for the one session, step_index
+1–6, each with `n = 1`:
+
+```
+activation_moment_1_complete      | 1 | 1
+activation_moment_2_complete      | 2 | 1
+activation_moment_3_complete      | 3 | 1
+activation_first_wow_executed     | 4 | 1
+activation_first_wow_interacted   | 5 | 1
+activation_msg_5_sent             | 6 | 1
+```
+
+A missing row means that milestone never emitted (re-drive that rail move); an
+`n > 1` before dbt dedup is harmless (the deterministic `daemon_event_id`
+collapses it earliest-wins).
+
+---
+
+## 7. Canonical handoff blurb (paste-ready for the final JARVIS-1102 PR description)
+
+> **Activation funnel telemetry — handoff for JARVIS-1093.** The activation rail
+> now emits six milestone funnel events into the existing onboarding telemetry
+> substrate (`type: "onboarding"` → `/v1/telemetry/ingest/` → GCS NDJSON →
+> `vellum-ai-prod.telemetry.onboarding_raw`), so no new event type, ingest
+> endpoint, or BigQuery table is involved. Cohort is gated by the LaunchDarkly
+> flag **`experiment-activation-flow-2026-06-03`**; only rail (treatment)
+> conversations emit. Every event carries **`funnel_version =
+"activation_v1_2026_06"`** and **`ab_variant`** tagged `"variant-a"` for
+> treatment (`"control"` is the no-rail arm, measured for now from generic `turn`
+> events). The event vocabulary (step_name → step_index): `activation_moment_1_complete`
+> (1), `activation_moment_2_complete` (2), `activation_moment_3_complete` (3),
+> `activation_first_wow_executed` (4), `activation_first_wow_interacted` (5),
+> `activation_msg_5_sent` (6, the north star). `session_id` is the rail
+> conversation's id. **Dedup contract:** each row's `daemon_event_id` is
+> deterministic, `${funnel_version}:${session_id}:${step_name}`, keyed on the
+> row's stored `funnel_version`; the existing dbt earliest-wins dedup on
+> `daemon_event_id` collapses any repeated moment to a single row. Build funnel
+> conversion as a step_index 1→6 progression per `session_id`, filtered to
+> `funnel_version = 'activation_v1_2026_06'`.
+
+---
+
+## 8. Notes
+
+- **JARVIS-1102 "naming check" (resolved).** Events fire from the **scoped tool
+  calls that do the rail work, not every text turn**. The model emits a milestone
+  via `emit_activation_event` only at the firing conditions bound to the rail's
+  moves (documented in `BOOTSTRAP-ACTIVATION-RAIL.md`); `activation_msg_5_sent` is
+  daemon-owned. This resolves the naming-check open interpretation.
+- **Stream B (multivariate cohort flag conversion) is NOT in this work.** It is
+  gated on Noa's platform string-flag serving — until the platform can serve
+  string/multivariate flags, flipping
+  `experiment-activation-flow-2026-06-03` boolean→multivariate client-side would
+  silently disable the live allowlisted rail. Until then, `ab_variant` is the
+  constant `"variant-a"` (only treatment runs the rail), and the **control side**
+  of the comparison is measured from generic `turn` events split by Noa's
+  exposure mapping. Once Stream B lands, the daemon tags the real assigned arm
+  and the cross-cohort comparison works with zero rework.

--- a/assistant/docs/activation-funnel-telemetry.md
+++ b/assistant/docs/activation-funnel-telemetry.md
@@ -156,10 +156,22 @@ When the flag is ON, the web prechat context selects
 `BOOTSTRAP-ACTIVATION-RAIL.md` as the bootstrap template, and the daemon marks
 the conversation in `activation_sessions` on first build of the system prompt.
 
-### 5.2 Confirm usage-data collection is enabled
+### 5.2 Confirm usage-data collection is enabled — and do NOT run in dev mode
 
-`recordActivationEvent` no-ops when `collectUsageData` is false. Make sure the dev
-build/config has usage-data collection enabled, or no rows will be written.
+Two gates must both be satisfied or no rows reach BigQuery:
+
+1. `recordActivationEvent` no-ops when `config.collectUsageData` is false, so the
+   dev build/config must have usage-data collection enabled, or no rows are
+   written to SQLite.
+2. **Dev mode disables the flush entirely.** `assistant/src/daemon/lifecycle.ts`
+   computes the effective setting as `collectUsageData = !isDevMode &&
+config.collectUsageData`, so when the daemon runs in dev mode (`VELLUM_DEV=1`)
+   the `UsageTelemetryReporter` is never started — rows accumulate in SQLite but
+   are never POSTed, and the "wait/restart for flush" steps below will never
+   reach BigQuery. For an end-to-end smoke test, run the daemon **outside dev
+   mode** (so the reporter starts), or explicitly invoke the reporter's
+   `flush()` via a dev hook. The SQLite rows can still be inspected directly in
+   dev mode, but the BigQuery verification (§6) requires a real flush.
 
 ### 5.3 Start a fresh activation conversation and capture its id
 
@@ -270,11 +282,11 @@ collapses it earliest-wins).
   moves (documented in `BOOTSTRAP-ACTIVATION-RAIL.md`); `activation_msg_5_sent` is
   daemon-owned. This resolves the naming-check open interpretation.
 - **Stream B (multivariate cohort flag conversion) is NOT in this work.** It is
-  gated on Noa's platform string-flag serving — until the platform can serve
-  string/multivariate flags, flipping
+  gated on the platform team's in-flight string-flag serving — until the platform
+  can serve string/multivariate flags, flipping
   `experiment-activation-flow-2026-06-03` boolean→multivariate client-side would
   silently disable the live allowlisted rail. Until then, `ab_variant` is the
   constant `"variant-a"` (only treatment runs the rail), and the **control side**
-  of the comparison is measured from generic `turn` events split by Noa's
-  exposure mapping. Once Stream B lands, the daemon tags the real assigned arm
-  and the cross-cohort comparison works with zero rework.
+  of the comparison is measured from generic `turn` events split by the
+  platform's experiment exposure mapping. Once Stream B lands, the daemon tags the
+  real assigned arm and the cross-cohort comparison works with zero rework.


### PR DESCRIPTION
## Summary
- Runbook + analytics handoff for the activation funnel telemetry (event vocab, dedup contract, cohort scoping, local smoke test, BigQuery verification query, canonical handoff blurb).

Part of plan: activation-telemetry.md (PR 10 of 10)