### PR TITLE
refactor(assistant): activation funnel slop cleanup (self-review)

### DIFF
--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -49,6 +49,7 @@ import {
 } from "../messaging/providers/slack/message-metadata.js";
 import type { SecretPrompter } from "../permissions/secret-prompter.js";
 import type { Message } from "../providers/types.js";
+import { ACTIVATION_STEPS } from "../telemetry/activation-funnel.js";
 import { getLogger } from "../util/logger.js";
 import type { MessageQueue } from "./conversation-queue-manager.js";
 import type { SlackInboundMessageMetadata } from "./handlers/shared.js";
@@ -407,15 +408,14 @@ export interface PersistMessageOptions {
  * Must be called AFTER the user turn is persisted so {@link countRealUserTurns}
  * counts this turn as the conversation's Nth real user message.
  */
-const ACTIVATION_MSG_5_STEP = "activation_msg_5_sent" as const;
-
 export function maybeEmitActivationMsg5(conversationId: string): void {
+  const msg5Step = ACTIVATION_STEPS.msg5Sent.stepName;
   try {
     if (!isActivationSession(conversationId)) return;
     if (countRealUserTurns(conversationId) < 5) return;
-    if (hasActivationEvent(conversationId, ACTIVATION_MSG_5_STEP)) return;
+    if (hasActivationEvent(conversationId, msg5Step)) return;
     recordActivationEvent({
-      stepName: ACTIVATION_MSG_5_STEP,
+      stepName: msg5Step,
       sessionId: conversationId,
     });
   } catch (err) {

--- a/assistant/src/telemetry/__tests__/activation-funnel.test.ts
+++ b/assistant/src/telemetry/__tests__/activation-funnel.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, test } from "bun:test";
 
 import {
-  ACTIVATION_STEP_NAMES,
   ACTIVATION_STEPS,
   activationStepIndex,
   buildActivationDaemonEventId,
   isActivationStepName,
 } from "../activation-funnel.js";
+
+const ALL_STEP_NAMES = Object.values(ACTIVATION_STEPS).map((s) => s.stepName);
 
 describe("activation funnel vocabulary", () => {
   test("step indices are 1-6 and unique", () => {
@@ -22,8 +23,8 @@ describe("activation funnel vocabulary", () => {
   });
 
   test("isActivationStepName accepts all six step names", () => {
-    expect(ACTIVATION_STEP_NAMES).toHaveLength(6);
-    for (const stepName of ACTIVATION_STEP_NAMES) {
+    expect(ALL_STEP_NAMES).toHaveLength(6);
+    for (const stepName of ALL_STEP_NAMES) {
       expect(isActivationStepName(stepName)).toBe(true);
     }
   });

--- a/assistant/src/telemetry/activation-funnel.ts
+++ b/assistant/src/telemetry/activation-funnel.ts
@@ -60,11 +60,6 @@ const STEP_INDEX_BY_NAME = new Map<ActivationStepName, number>(
   ]),
 );
 
-/** All activation step names, in funnel order. */
-export const ACTIVATION_STEP_NAMES: readonly ActivationStepName[] = [
-  ...STEP_INDEX_BY_NAME.keys(),
-];
-
 /** Type guard: is `value` one of the known activation step names? */
 export function isActivationStepName(
   value: string,


### PR DESCRIPTION
## Summary
Self-review (slop/reuse) cleanups on the activation funnel work:
- conversation-messaging.ts: use ACTIVATION_STEPS.msg5Sent.stepName instead of a re-declared ACTIVATION_MSG_5_STEP literal (single source of truth).
- activation-funnel.ts: drop the unused ACTIVATION_STEP_NAMES export; test derives names from ACTIVATION_STEPS.

Part of plan: activation-telemetry.md (self-review remediation)