### PR TITLE
fix(web): use local logout flow in non-platform mode for preferences menu

### DIFF
--- a/apps/web/src/domains/chat/components/preferences-menu.tsx
+++ b/apps/web/src/domains/chat/components/preferences-menu.tsx
@@ -29,7 +29,7 @@ import {
     useActiveAssistantIsPlatformHosted,
     usePlatformGate,
 } from "@/hooks/use-platform-gate";
-import { hardNavigate } from "@/lib/auth/hard-navigate";
+import { handleLogout } from "@/lib/auth/handle-logout";
 import { isLocalMode } from "@/lib/local-mode";
 import { isElectron } from "@/runtime/is-electron";
 import {
@@ -157,7 +157,6 @@ function PreferencesMenuContent({
   onEarnCredits,
 }: PreferencesMenuContentProps) {
   const navigate = useNavigate();
-  const logout = useAuthStore.use.logout();
   const user = useAuthStore.use.user();
   const platformGate = usePlatformGate();
   const billingPlatformGate = usePlatformGate({ platformHostedOnly: true });
@@ -247,9 +246,8 @@ function PreferencesMenuContent({
           icon={LogOut}
           label="Log Out"
           onSelect={async () => {
-            await logout();
+            await handleLogout(navigate);
             onClose();
-            hardNavigate(routes.account.login);
           }}
         />
       ) : null}

--- a/apps/web/src/lib/auth/handle-logout.ts
+++ b/apps/web/src/lib/auth/handle-logout.ts
@@ -1,0 +1,19 @@
+import type { NavigateFunction } from "react-router";
+
+import { getOnboardingEntrypoint } from "@/domains/onboarding/gate";
+import { hardNavigate } from "@/lib/auth/hard-navigate";
+import { isLocalMode } from "@/lib/local-mode";
+import { setMenuPlatformSession } from "@/runtime/menu";
+import { useAuthStore } from "@/stores/auth-store";
+import { routes } from "@/utils/routes";
+
+export async function handleLogout(navigate: NavigateFunction): Promise<void> {
+  if (isLocalMode()) {
+    await setMenuPlatformSession(false);
+    await useAuthStore.getState().logout();
+    navigate(getOnboardingEntrypoint());
+  } else {
+    await useAuthStore.getState().logout();
+    hardNavigate(routes.account.login);
+  }
+}

--- a/apps/web/src/root-layout.tsx
+++ b/apps/web/src/root-layout.tsx
@@ -14,9 +14,8 @@ import {
   useIsSessionInitializing,
   useHasPlatformSession,
 } from "@/stores/auth-store";
-import { getOnboardingEntrypoint } from "@/domains/onboarding/gate";
+import { handleLogout } from "@/lib/auth/handle-logout";
 import { getSelectedAssistant } from "@/lib/local-mode";
-import { setMenuPlatformSession } from "@/runtime/menu";
 import { useVellumCommands } from "@/runtime/vellum-commands";
 import { routes } from "@/utils/routes";
 import { useEnvironmentStore } from "@/stores/environment-store";
@@ -156,11 +155,7 @@ export function RootLayout() {
       void navigate(routes.settings.root);
     },
     logout: () => {
-      void setMenuPlatformSession(false).then(() =>
-        useAuthStore.getState().logout(),
-      ).then(() => {
-        navigate(getOnboardingEntrypoint());
-      });
+      void handleLogout(navigate);
     },
     rePair: () => {
       const id = getSelectedAssistant()?.assistantId;


### PR DESCRIPTION
## Summary
- Extract `handleLogout` helper into `apps/web/src/lib/auth/handle-logout.ts` that branches on `isLocalMode()`: in local/Electron mode it clears menu state and SPA-navigates to the onboarding entrypoint; in platform mode it calls the allauth API and hard-navigates to the login page.
- Replace the preferences menu's direct `hardNavigate(routes.account.login)` with the shared helper, fixing the bug where logout opened the browser to a WorkOS AuthKit URL.
- Refactor the root-layout menu bar logout handler to use the same shared helper.

## Original prompt
The Electron macOS app had two different logout behaviors: the menu bar "Log Out" worked correctly (local state clear + SPA navigation), but the preferences popper "Log Out" button called `hardNavigate("/account/login")` which triggered a server-side redirect to WorkOS AuthKit, opening the user's browser. The fix unifies both paths through a shared `handleLogout` helper that uses SPA navigation in non-platform mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)