### PR TITLE
fix(web): disable disk pressure warnings for non-platform-hosted assistants

### DIFF
--- a/apps/web/src/domains/chat/active-chat-view.tsx
+++ b/apps/web/src/domains/chat/active-chat-view.tsx
@@ -42,6 +42,7 @@ import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 import { useAssistantReachability } from "@/assistant/use-assistant-reachability";
 import { useDiskPressureMonitor } from "@/assistant/use-disk-pressure-monitor";
 import { getDiskPressureChatBlockReason } from "@/assistant/disk-pressure";
+import { useActiveAssistantIsPlatformHosted } from "@/hooks/use-platform-gate";
 import { useComposerStore } from "@/domains/chat/composer-store";
 
 import { useConversationLoader } from "@/domains/chat/hooks/use-conversation-loader";
@@ -168,11 +169,12 @@ export function ActiveChatView() {
   }, [reachability.state.phase, refreshEpoch]);
 
   // -------------------------------------------------------------------------
-  // Disk pressure
+  // Disk pressure (only relevant for platform-hosted assistants)
   // -------------------------------------------------------------------------
+  const isPlatformHosted = useActiveAssistantIsPlatformHosted();
   const diskPressure = useDiskPressureMonitor({
     assistantId,
-    enabled: true,
+    enabled: isPlatformHosted,
   });
   const diskPressureChatBlockReason = getDiskPressureChatBlockReason({
     monitorEnabled: diskPressure.mode !== null,

--- a/apps/web/src/domains/settings/pages/general-page.tsx
+++ b/apps/web/src/domains/settings/pages/general-page.tsx
@@ -31,7 +31,7 @@ import {
     writeStoredThemePreference,
 } from "@/domains/settings/utils/theme-preferences";
 import { client } from "@/generated/api/client.gen";
-import { usePlatformGate } from "@/hooks/use-platform-gate";
+import { useActiveAssistantIsPlatformHosted, usePlatformGate } from "@/hooks/use-platform-gate";
 import {
     getSelectedAssistant,
     isLocalAssistant,
@@ -224,9 +224,10 @@ export function GeneralPage() {
   const navigate = useNavigate();
   const platformGate = usePlatformGate();
   const infraGate = usePlatformGate({ platformHostedOnly: true });
+  const isPlatformHosted = useActiveAssistantIsPlatformHosted();
   const diskPressure = useDiskPressureMonitor({
     assistantId: assistant?.id ?? null,
-    enabled: infraGate === "full",
+    enabled: isPlatformHosted,
   });
 
   const platformAssistant = assistant?.is_local && !isLocalMode() ? null : assistant;

--- a/apps/web/src/domains/settings/pages/general-page.tsx
+++ b/apps/web/src/domains/settings/pages/general-page.tsx
@@ -227,7 +227,7 @@ export function GeneralPage() {
   const isPlatformHosted = useActiveAssistantIsPlatformHosted();
   const diskPressure = useDiskPressureMonitor({
     assistantId: assistant?.id ?? null,
-    enabled: isPlatformHosted,
+    enabled: infraGate === "full" && isPlatformHosted,
   });
 
   const platformAssistant = assistant?.is_local && !isLocalMode() ? null : assistant;

--- a/apps/web/src/domains/settings/pages/general-page.tsx
+++ b/apps/web/src/domains/settings/pages/general-page.tsx
@@ -226,7 +226,7 @@ export function GeneralPage() {
   const infraGate = usePlatformGate({ platformHostedOnly: true });
   const diskPressure = useDiskPressureMonitor({
     assistantId: assistant?.id ?? null,
-    enabled: true,
+    enabled: infraGate === "full",
   });
 
   const platformAssistant = assistant?.is_local && !isLocalMode() ? null : assistant;


### PR DESCRIPTION
## Summary
- Gate `useDiskPressureMonitor` on platform-hosted status in both the chat view (`active-chat-view.tsx`) and the settings page (`general-page.tsx`), so the "Storage is running low" banner and its background polling are skipped entirely for self-hosted assistants.
- Chat view uses `useActiveAssistantIsPlatformHosted()` for a clean boolean gate; settings page reuses the existing `infraGate` value it already computes.

## Original prompt
The disk pressure warning banners ("Storage is running low") were appearing for all assistants, but they're only meaningful when the assistant is hosted on the Vellum platform — self-hosted assistants manage their own storage. The task was to hide these warnings and disable the underlying polling when the assistant isn't platform-hosted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)