### PR TITLE
fix(web): use platform URL from config instead of window.location.origin for runtimeUrl

### DIFF
--- a/apps/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
+++ b/apps/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
@@ -197,6 +197,7 @@ mock.module("@/lib/local-mode", () => ({
   isLocalMode: () => isLocalModeValue,
   hasAssistants: () => false,
   getPlatformAssistants: () => [],
+  getPlatformRuntimeUrl: () => "https://platform.vellum.ai",
   getSelectedAssistant: () => undefined,
   loadLockfile: async () => ({ assistants: [], activeAssistant: null }),
   setSelectedAssistantId: () => {},

--- a/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -19,7 +19,7 @@ import {
     writeSelectedVersion,
 } from "@/domains/onboarding/prefs";
 import { applyPendingProviderKey } from "@/domains/onboarding/provider-key";
-import { getLocalGatewayUrl, isLocalMode, loadLockfile, primeLocalGatewayConnection, saveLockfileAssistant, setSelectedAssistantId } from "@/lib/local-mode";
+import { getLocalGatewayUrl, getPlatformRuntimeUrl, isLocalMode, loadLockfile, primeLocalGatewayConnection, saveLockfileAssistant, setSelectedAssistantId } from "@/lib/local-mode";
 import { clearGatewayToken } from "@/lib/auth/gateway-session";
 import { resolveNavigation } from "@/lib/navigation/navigation-resolver";
 import { buildNavigationState } from "@/lib/navigation/build-state";
@@ -360,7 +360,7 @@ export function HatchingScreen() {
               void saveLockfileAssistant({
                 assistantId,
                 cloud: "vellum",
-                runtimeUrl: window.location.origin,
+                runtimeUrl: getPlatformRuntimeUrl(),
                 hatchedAt: new Date().toISOString(),
               });
             }

--- a/apps/web/src/lib/local-mode.ts
+++ b/apps/web/src/lib/local-mode.ts
@@ -58,6 +58,15 @@ const EMPTY_LOCKFILE: Lockfile = { assistants: [], activeAssistant: null };
 const LOCKFILE_STORAGE_KEY = "vellum:local:lockfile";
 const SELECTED_ASSISTANT_STORAGE_KEY = "vellum:local:selectedAssistantId";
 
+export function getPlatformRuntimeUrl(): string {
+  const injected = (
+    window as unknown as {
+      __VELLUM_CONFIG__?: { platformUrl?: string };
+    }
+  ).__VELLUM_CONFIG__;
+  return injected?.platformUrl || window.location.origin;
+}
+
 // Advance the in-memory cache and mirror the lockfile to persisted storage in
 // one step. The mirror lets the synchronous `getLockfile()` hydrate from
 // storage on a cold read before the host transport has responded.
@@ -164,7 +173,7 @@ export async function syncPlatformAssistantsToLockfile(
     .map((a) => ({
       assistantId: a.id,
       cloud: "vellum",
-      runtimeUrl: window.location.origin,
+      runtimeUrl: getPlatformRuntimeUrl(),
       hatchedAt: a.created,
     }));
 


### PR DESCRIPTION
## Summary
- Added `getPlatformRuntimeUrl()` helper to `local-mode.ts` that reads the actual platform URL from `__VELLUM_CONFIG__` (injected by the Electron preload script) instead of using `window.location.origin`, which is `app://vellum.ai` in the Electron app
- Fixed two call sites that wrote `runtimeUrl: window.location.origin` into the lockfile: `syncPlatformAssistantsToLockfile` and the hatching screen's `saveLockfileAssistant` call

## Original prompt
The `vellum ps` CLI command was showing an `error (auth)` status for platform-hosted assistants (e.g. "Wren") with the message "Failed to fetch organization: protocol must be http:, https: or s3:". The root cause was that the macOS Electron app wrote `app://vellum.ai` as the `runtimeUrl` in the lockfile (from `window.location.origin`), and the CLI then tried to use this invalid URL scheme for HTTP requests to the platform API.

## Test plan
- [ ] Run `vellum ps` after syncing a platform-hosted assistant from the macOS app — should no longer show `error (auth)` with a protocol error
- [ ] Verify the lockfile entry for platform assistants has a proper `https://` runtimeUrl instead of `app://vellum.ai`
- [ ] Hatch a new platform-hosted assistant and verify its lockfile entry also gets the correct runtimeUrl

🤖 Generated with [Claude Code](https://claude.com/claude-code)