### PR TITLE
refactor(web): remove onboardingCompleted flag and replay parameter

### DIFF
--- a/apps/web/src/domains/onboarding/gate.ts
+++ b/apps/web/src/domains/onboarding/gate.ts
@@ -1,22 +1,13 @@
 import { resolveNavigation } from "@/lib/navigation/navigation-resolver";
 import { buildNavigationState } from "@/lib/navigation/build-state";
 import { routes } from "@/utils/routes";
-import { isLocalMode, hasAssistants } from "@/lib/local-mode";
-import {
-  readOnboardingCompleted,
-  clearOnboardingCompleted,
-} from "@/domains/onboarding/prefs";
+import { isLocalMode } from "@/lib/local-mode";
 
 export function resolveOnboardingRedirect({
   intendedDestination,
 }: {
   intendedDestination: string;
 }): string | null {
-  // Best-effort stale flag cleanup
-  if (isLocalMode() && !hasAssistants() && readOnboardingCompleted()) {
-    clearOnboardingCompleted();
-  }
-
   const decision = resolveNavigation(
     buildNavigationState(),
     { kind: "onboarding-intercept", intendedDestination },

--- a/apps/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
+++ b/apps/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
@@ -49,7 +49,6 @@ const getAssistantMock = mock(async () => ({
 
 const fetchCharacterTraitsMock = mock(async () => null);
 const saveCharacterTraitsMock = mock(async () => undefined);
-const setOnboardingCompletedMock = mock(() => {});
 const writeSelectedVersionMock = mock(() => {});
 
 type TestOnboardingRecipe = {
@@ -62,7 +61,6 @@ type TestOnboardingRecipe = {
   skipPrechat: boolean;
 };
 
-let onboardingCompleted = false;
 let preChatOnboardingExperiment = "variant-a";
 let activationFlowExperiment = false;
 let selfIntroGreeting = true;
@@ -153,16 +151,11 @@ mock.module("@sentry/react", () => ({
 
 mock.module("@/domains/onboarding/prefs", () => ({
   readAiDataConsent: () => true,
-  readOnboardingCompleted: () => onboardingCompleted,
   readSelectedVersion: () => null,
   readShareAnalytics: () => true,
   readTosAccepted: () => true,
-  clearOnboardingCompleted: mock(() => {}),
-  useOnboardingCompleted: () =>
-    [onboardingCompleted, setOnboardingCompletedMock] as const,
   writeSelectedVersion: writeSelectedVersionMock,
 }));
-
 
 mock.module("@/domains/onboarding/recipe-client.js", () => ({
   fetchOnboardingRecipe: fetchOnboardingRecipeMock,
@@ -180,10 +173,8 @@ mock.module("@/lib/navigation/build-state", () => ({
     sessionSettled: true,
     isAuthenticated: true,
     platformSession: platformSessionValue,
-    onboardingCompleted: onboardingCompleted,
     tosAccepted: true,
     aiDataConsent: true,
-    isReplay: false,
     ...overrides,
   }),
 }));
@@ -363,7 +354,6 @@ const { PreChatFlow } = await import(
 beforeEach(() => {
   searchParams = new URLSearchParams();
   checkAssistantImpl = async () => {};
-  onboardingCompleted = false;
   preChatOnboardingExperiment = "variant-a";
   activationFlowExperiment = false;
   selfIntroGreeting = true;
@@ -383,7 +373,6 @@ beforeEach(() => {
   getAssistantMock.mockClear();
   fetchCharacterTraitsMock.mockClear();
   saveCharacterTraitsMock.mockClear();
-  setOnboardingCompletedMock.mockClear();
   writeSelectedVersionMock.mockClear();
   fetchOnboardingRecipeMock.mockClear();
 });
@@ -414,23 +403,6 @@ describe("onboarding lifecycle sync", () => {
       expect(navigateMock).toHaveBeenCalledWith(routes.onboarding.prechat, {
         replace: true,
       }),
-    );
-  });
-
-  test("hatching replay preserves the replay flag when onboarding is already completed", async () => {
-    searchParams = new URLSearchParams("replay=1");
-    onboardingCompleted = true;
-
-    render(<HatchingScreen />);
-
-    await waitFor(() => expect(getAssistantMock).toHaveBeenCalled());
-    expect(hatchAssistantMock).not.toHaveBeenCalled();
-
-    await waitFor(() =>
-      expect(navigateMock).toHaveBeenCalledWith(
-        `${routes.onboarding.prechat}?replay=1`,
-        { replace: true },
-      ),
     );
   });
 
@@ -593,7 +565,6 @@ describe("onboarding lifecycle sync", () => {
       ),
     );
 
-    expect(setOnboardingCompletedMock).toHaveBeenCalledWith(true);
     expect(JSON.parse(sessionStorage.getItem(STORAGE_KEY) ?? "null")).toEqual({
       tools: [],
       tasks: recipe.tasks,
@@ -605,26 +576,6 @@ describe("onboarding lifecycle sync", () => {
       bootstrapTemplate: recipe.bootstrapTemplate,
       skills: recipe.skills,
     });
-  });
-
-  test("pre-chat replay ignores recipe skip so the standard screens are visible", async () => {
-    searchParams = new URLSearchParams("replay=1");
-    onboardingCompleted = true;
-    fetchOnboardingRecipeImpl = async () => ({
-      cohort: "content-automation",
-      tasks: ["writing", "research"],
-      tone: "grounded",
-      bootstrapTemplate: "BOOTSTRAP-CONTENT-AUTOMATION.md",
-      initialMessage: "I want to write articles that rank better in GEO",
-      skills: ["content-automation"],
-      skipPrechat: true,
-    });
-
-    render(<PreChatFlow />);
-
-    await waitFor(() => expect(fetchOnboardingRecipeMock).toHaveBeenCalled());
-    expect(await screen.findByTestId("name-continue")).toBeTruthy();
-    expect(checkAssistantMock).not.toHaveBeenCalled();
   });
 
   test("local mode never fetches the platform-only onboarding recipe", async () => {

--- a/apps/web/src/domains/onboarding/onboarding-store.ts
+++ b/apps/web/src/domains/onboarding/onboarding-store.ts
@@ -1,11 +1,11 @@
 /**
  * Zustand store for onboarding boolean preferences.
  *
- * Owns the five onboarding/privacy flags consumed by the privacy page,
- * the onboarding pages, the chat-gate, and Sentry. `prefs.ts` exposes
- * thin hooks (`useShareAnalytics`, `useShareDiagnostics`,
- * `useTosAccepted`, `useAiDataConsent`, `useOnboardingCompleted`) that
- * wrap `.use.field()` selectors and setter actions on this store.
+ * Owns the four onboarding/privacy flags consumed by the privacy page,
+ * the onboarding pages, and Sentry. `prefs.ts` exposes thin hooks
+ * (`useShareAnalytics`, `useShareDiagnostics`, `useTosAccepted`,
+ * `useAiDataConsent`) that wrap `.use.field()` selectors and setter
+ * actions on this store.
  *
  * **Storage model — strict per-key, with absence semantics preserved:**
  *
@@ -17,7 +17,6 @@
  * | `shareDiagnostics`| `device:share_diagnostics`    | privacy page + Sentry  |
  * | `tosAccepted`     | `vellum:onboarding:tosAccepted`  | onboarding pages       |
  * | `aiDataConsent`   | `vellum:onboarding:aiDataConsent`| onboarding pages       |
- * | `completed`       | `vellum:onboarding:completed`    | onboarding + chat gate |
  *
  * We deliberately do **not** use Zustand's `persist` middleware here.
  * `persist` writes the full state envelope on every update, which would
@@ -58,7 +57,6 @@ import { deviceKey } from "@/utils/device-settings";
 import {
   KEY_TOS_ACCEPTED,
   KEY_AI_DATA_CONSENT,
-  KEY_COMPLETED,
 } from "@/utils/onboarding-cleanup";
 
 // ---------------------------------------------------------------------------
@@ -80,7 +78,6 @@ const KEY_TO_FIELD: ReadonlyMap<string, keyof OnboardingState> = new Map([
   [KEY_SHARE_DIAGNOSTICS, "shareDiagnostics" as const],
   [KEY_TOS_ACCEPTED, "tosAccepted" as const],
   [KEY_AI_DATA_CONSENT, "aiDataConsent" as const],
-  [KEY_COMPLETED, "completed" as const],
 ]);
 
 // ---------------------------------------------------------------------------
@@ -96,8 +93,6 @@ export interface OnboardingState {
   tosAccepted: boolean;
   /** Explicit AI-data-sharing consent. Default `false`. */
   aiDataConsent: boolean;
-  /** Onboarding flow completed. Default `false`. */
-  completed: boolean;
 }
 
 export interface OnboardingActions {
@@ -105,7 +100,6 @@ export interface OnboardingActions {
   setShareDiagnostics: (value: boolean) => void;
   setTosAccepted: (value: boolean) => void;
   setAiDataConsent: (value: boolean) => void;
-  setOnboardingCompleted: (value: boolean) => void;
 }
 
 export type OnboardingStore = OnboardingState & OnboardingActions;
@@ -119,7 +113,6 @@ const FIELD_DEFAULTS: Record<keyof OnboardingState, boolean> = {
   shareDiagnostics: true,
   tosAccepted: false,
   aiDataConsent: false,
-  completed: false,
 };
 
 function computeInitialFromLS(): OnboardingState {
@@ -128,7 +121,6 @@ function computeInitialFromLS(): OnboardingState {
     shareDiagnostics: getLocalBool(KEY_SHARE_DIAGNOSTICS, true),
     tosAccepted: getLocalBool(KEY_TOS_ACCEPTED, false),
     aiDataConsent: getLocalBool(KEY_AI_DATA_CONSENT, false),
-    completed: getLocalBool(KEY_COMPLETED, false),
   };
 }
 
@@ -154,10 +146,6 @@ const useOnboardingStoreBase = create<OnboardingStore>()((set) => ({
   setAiDataConsent: (value) => {
     set({ aiDataConsent: value });
     setLocalBool(KEY_AI_DATA_CONSENT, value);
-  },
-  setOnboardingCompleted: (value) => {
-    set({ completed: value });
-    setLocalBool(KEY_COMPLETED, value);
   },
 }));
 

--- a/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -15,7 +15,6 @@ import { lifecycleService } from "@/assistant/lifecycle-service";
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
 import {
     readSelectedVersion,
-    useOnboardingCompleted,
     writeSelectedVersion,
 } from "@/domains/onboarding/prefs";
 import { applyPendingProviderKey } from "@/domains/onboarding/provider-key";
@@ -78,11 +77,9 @@ export type HatchGateDecision =
   | { kind: "wait" }
   | { kind: "redirect"; to: string };
 
-export function decideHatchGate(input: {
-  isReplay: boolean;
-}): HatchGateDecision {
+export function decideHatchGate(): HatchGateDecision {
   const decision = resolveNavigation(
-    buildNavigationState({ isReplay: input.isReplay }),
+    buildNavigationState(),
     { kind: "hatch-gate" },
   );
   if (decision.action === "redirect") return { kind: "redirect", to: decision.to };
@@ -93,11 +90,9 @@ export function decideHatchGate(input: {
 export function HatchingScreen() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const isReplay = searchParams.get("replay") === "1";
   const hostingParam = searchParams.get("hosting");
   const useLocalHatch = isLocalMode() && hostingParam !== null && hostingParam !== "vellum-cloud";
   const sessionStatus = useAuthStore.use.sessionStatus();
-  const [, setOnboardingCompleted] = useOnboardingCompleted();
   const [hatchTraits] = useState<CharacterTraits>(() =>
     randomCharacterTraits(BUNDLED_COMPONENTS),
   );
@@ -133,7 +128,7 @@ export function HatchingScreen() {
 
 
   useEffect(() => {
-    const decision = decideHatchGate({ isReplay });
+    const decision = decideHatchGate();
     if (decision.kind === "redirect") {
       void navigate(decision.to, { replace: true });
       return;
@@ -167,11 +162,6 @@ export function HatchingScreen() {
           await lifecycleService.checkAssistant();
           if (cancelled) return;
           if (isNativePlatform()) {
-            try {
-              setOnboardingCompleted(true);
-            } catch (err) {
-              captureError(err, { context: "hatching_mark_onboarding_completed_native" });
-            }
             // Native flow skips the pre-chat screen, so there's no
             // typed message to drive the auto-greet gate. Mark the
             // lifecycle one-shot so the destination chat mount shows
@@ -183,9 +173,7 @@ export function HatchingScreen() {
             return;
           }
           void navigate(
-            isReplay
-              ? `${routes.onboarding.prechat}?replay=1`
-              : routes.onboarding.prechat,
+            routes.onboarding.prechat,
             { replace: true },
           );
         })();
@@ -194,10 +182,19 @@ export function HatchingScreen() {
 
     const startHatch = async () => {
       transitionPhase("provisioning");
-      if (isReplay) {
-        scheduleNextPoll(0);
-        return;
+
+      // If an assistant is already active (debug replay, returning user),
+      // skip the hatch request and go straight to readiness polling.
+      try {
+        const existing = await getAssistant();
+        if (!cancelled && existing.ok && resolveAssistantLifecycleState(existing).kind === "active") {
+          handleHatchReady();
+          return;
+        }
+      } catch {
+        // Fall through to normal hatch
       }
+      if (cancelled) return;
 
       // Local/Docker hatch lifecycle:
       // 1. hatchLocalAssistant() runs the CLI (Vite middleware on web/dev,
@@ -396,9 +393,7 @@ export function HatchingScreen() {
     attempt,
     hatchTraits,
     sessionStatus,
-    isReplay,
     navigate,
-    setOnboardingCompleted,
     transitionPhase,
     useLocalHatch,
   ]);
@@ -495,9 +490,7 @@ export function HatchingScreen() {
                 void navigate(
                   useLocalHatch
                     ? routes.onboarding.hosting
-                    : isReplay
-                      ? `${routes.onboarding.privacy}?replay=1`
-                      : routes.onboarding.privacy,
+                    : routes.onboarding.privacy,
                   { replace: true },
                 )
               }

--- a/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -183,18 +183,22 @@ export function HatchingScreen() {
     const startHatch = async () => {
       transitionPhase("provisioning");
 
-      // If an assistant is already active (debug replay, returning user),
-      // skip the hatch request and go straight to readiness polling.
-      try {
-        const existing = await getAssistant();
-        if (!cancelled && existing.ok && resolveAssistantLifecycleState(existing).kind === "active") {
-          handleHatchReady();
-          return;
+      // For platform hatches, check if an assistant is already active
+      // (debug replay, returning user) and skip the hatch request.
+      // Local hatches always need to run hatchLocalAssistant() to
+      // create the local daemon, even when a cloud assistant exists.
+      if (!useLocalHatch) {
+        try {
+          const existing = await getAssistant();
+          if (!cancelled && existing.ok && resolveAssistantLifecycleState(existing).kind === "active") {
+            handleHatchReady();
+            return;
+          }
+        } catch {
+          // Fall through to normal hatch
         }
-      } catch {
-        // Fall through to normal hatch
+        if (cancelled) return;
       }
-      if (cancelled) return;
 
       // Local/Docker hatch lifecycle:
       // 1. hatchLocalAssistant() runs the CLI (Vite middleware on web/dev,

--- a/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -191,6 +191,14 @@ export function HatchingScreen() {
         try {
           const existing = await getAssistant();
           if (!cancelled && existing.ok && resolveAssistantLifecycleState(existing).kind === "active") {
+            if (isLocalMode()) {
+              void saveLockfileAssistant({
+                assistantId: existing.data.id,
+                cloud: "vellum",
+                runtimeUrl: getPlatformRuntimeUrl(),
+                hatchedAt: new Date().toISOString(),
+              });
+            }
             handleHatchReady();
             return;
           }

--- a/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
+++ b/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
@@ -1,4 +1,3 @@
-import { captureError } from "@/lib/sentry/capture-error";
 import { useQuery } from "@tanstack/react-query";
 import {
   useCallback,
@@ -6,7 +5,7 @@ import {
   useLayoutEffect,
   useState,
 } from "react";
-import { useNavigate, useSearchParams } from "react-router";
+import { useNavigate } from "react-router";
 
 import { useIsIOSWeb } from "@/runtime/platform-detection";
 import { readIOSAppDownloaded } from "@/hooks/use-ios-app-nudge";
@@ -51,9 +50,7 @@ import {
 import { GOOGLE_TOOL_IDS } from "@/domains/onboarding/prechat-tools";
 import {
   readAiDataConsent,
-  readOnboardingCompleted,
   readTosAccepted,
-  useOnboardingCompleted,
 } from "@/domains/onboarding/prefs";
 import {
   getPlatformAssistants,
@@ -84,7 +81,6 @@ function readLocalPlatformAssistantId(): string | null {
 
 export function PreChatFlow() {
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
   const user = useAuthStore.use.user();
   const isAuthenticated = useIsAuthenticated();
   const isAuthInitializing = useIsSessionInitializing();
@@ -94,10 +90,7 @@ export function PreChatFlow() {
   const isNative = useIsNativePlatform();
   const activeAssistantId =
     useAssistantSelectionStore.use.activeAssistantId();
-  const [, setOnboardingCompleted] = useOnboardingCompleted();
-
   const localMode = isLocalMode();
-  const isReplay = searchParams.get("replay") === "1";
   const isIOSWeb = useIsIOSWeb();
   const showIOSAppStep = isIOSWeb && !readIOSAppDownloaded();
   const preChatExperimentArm =
@@ -254,10 +247,6 @@ export function PreChatFlow() {
       void navigate(routes.account.login, { replace: true });
       return;
     }
-    if (readOnboardingCompleted() && !isReplay) {
-      void navigateToChatAfterLifecycleRefresh();
-      return;
-    }
     if (consentDecision === "missing" && !isNative) {
       void navigate(routes.onboarding.privacy, { replace: true });
       return;
@@ -268,10 +257,8 @@ export function PreChatFlow() {
     isAuthInitializing,
     isAuthenticated,
     isNative,
-    isReplay,
     navigate,
     navigateToChatAfterLifecycleRefresh,
-    setOnboardingCompleted,
     userId,
   ]);
 
@@ -281,14 +268,12 @@ export function PreChatFlow() {
     isAuthInitializing ||
     !isAuthenticated ||
     !consentReady ||
-    !recipeReady ||
-    (readOnboardingCompleted() && !isReplay);
+    !recipeReady;
 
   function emitWebFunnelStep(
     step: (typeof ONBOARDING_FUNNEL_STEPS)[keyof typeof ONBOARDING_FUNNEL_STEPS],
     variant = webFunnelVariant,
   ): void {
-    if (isReplay) return;
     emitOnboardingFunnelStepCompleted(step, {
       userId,
       variant: resolveOnboardingFunnelVariant(variant),
@@ -336,11 +321,6 @@ export function PreChatFlow() {
     setPendingPreChatContext(context);
     const trimmedAssistant = assistantName.trim();
     if (trimmedAssistant) setPendingAssistantName(trimmedAssistant);
-    try {
-      setOnboardingCompleted(true);
-    } catch (err) {
-      captureError(err, { context: "prechat_mark_onboarding_completed" });
-    }
     // User finished pre-chat; the post-hatch greeting is forthcoming.
     // Mark before navigating so the destination chat mount shows the
     // loading gate until the greeting arrives.

--- a/apps/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -13,7 +13,6 @@ import {
     resolveOnboardingFunnelVariant,
 } from "@/domains/onboarding/funnel-events";
 import {
-    readOnboardingCompleted,
     useAiDataConsent,
     useShareAnalytics,
     useShareDiagnostics,
@@ -70,7 +69,6 @@ const CONSENT_CHECKBOX_CLASS =
 export function PrivacyScreen() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const isReplay = searchParams.get("replay") === "1";
   const userId = useAuthStore.use.user()?.id ?? null;
   const isNative = useIsNativePlatform();
   const preChatExperimentArm =
@@ -83,16 +81,10 @@ export function PrivacyScreen() {
   const [aiDataConsent, setAiDataConsent] = useAiDataConsent();
 
   useEffect(() => {
-    if (!isNative && !isReplay) {
+    if (!isNative) {
       getOnboardingFunnelSessionId();
     }
-  }, [isNative, isReplay]);
-
-  useEffect(() => {
-    if (readOnboardingCompleted() && !isReplay) {
-      void navigate(routes.assistant, { replace: true });
-    }
-  }, [isReplay, navigate]);
+  }, [isNative]);
 
   const onStart = useCallback(() => {
     try {
@@ -101,7 +93,7 @@ export function PrivacyScreen() {
     } catch (err) {
       captureError(err, { context: "onboarding_persist_share_prefs" });
     }
-    if (!isNative && !isReplay) {
+    if (!isNative) {
       const variant = resolveOnboardingFunnelVariant(preferredFunnelVariant);
       emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.privacyTos, {
         userId,
@@ -113,12 +105,10 @@ export function PrivacyScreen() {
     const hostingParam = searchParams.get("hosting");
     const params = new URLSearchParams();
     if (hostingParam) params.set("hosting", hostingParam);
-    if (isReplay) params.set("replay", "1");
     const qs = params.toString();
     void navigate(`${routes.onboarding.hatching}${qs ? `?${qs}` : ""}`);
   }, [
     isNative,
-    isReplay,
     navigate,
     preferredFunnelVariant,
     searchParams,

--- a/apps/web/src/domains/onboarding/prefs.ts
+++ b/apps/web/src/domains/onboarding/prefs.ts
@@ -2,7 +2,7 @@
  * Onboarding preference public API.
  *
  * Boolean preferences (`shareAnalytics`, `shareDiagnostics`, `tosAccepted`,
- * `aiDataConsent`, `completed`) are owned by `useOnboardingStore` — a
+ * `aiDataConsent`) are owned by `useOnboardingStore` — a
  * Zustand store with a custom per-key `persist` adapter that maps each
  * field to its existing localStorage key. This file exposes the hook +
  * non-React shim around the store, plus the non-store helpers for the
@@ -24,7 +24,6 @@ import { getDeviceBool, getDeviceSetting } from "@/utils/device-settings";
 import {
   KEY_TOS_ACCEPTED,
   KEY_AI_DATA_CONSENT,
-  KEY_COMPLETED,
 } from "@/utils/onboarding-cleanup";
 import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
 
@@ -92,28 +91,9 @@ export function useAiDataConsent(): [boolean, (next: boolean) => void] {
   return [value, setter];
 }
 
-/** Whether the user completed the onboarding flow. Defaults to `false`. */
-export function useOnboardingCompleted(): [boolean, (next: boolean) => void] {
-  const value = useOnboardingStore.use.completed();
-  const setter = useCallback((next: boolean) => {
-    useOnboardingStore.getState().setOnboardingCompleted(next);
-  }, []);
-  return [value, setter];
-}
-
 // ---------------------------------------------------------------------------
 // Non-hook readers (for gates/guards outside React render)
 // ---------------------------------------------------------------------------
-
-/** SSR-safe, non-hook read of the onboarding completion flag. */
-export function readOnboardingCompleted(): boolean {
-  return useOnboardingStore.getState().completed;
-}
-
-/** SSR-safe, non-hook clear of the completion flag. */
-export function clearOnboardingCompleted(): void {
-  useOnboardingStore.getState().setOnboardingCompleted(false);
-}
 
 /**
  * SSR-safe, non-hook read of the TOS-accepted flag. Used by
@@ -208,5 +188,4 @@ export function writeSelectedVersion(version: string): void {
 export const __testing = {
   KEY_TOS_ACCEPTED,
   KEY_AI_DATA_CONSENT,
-  KEY_COMPLETED,
 };

--- a/apps/web/src/domains/settings/components/panels/debug-controls-panel.tsx
+++ b/apps/web/src/domains/settings/components/panels/debug-controls-panel.tsx
@@ -33,7 +33,7 @@ export function DebugControlsPanel() {
   const handleReplayOnboarding = useCallback(() => {
     clearOnboardingFlags();
     toast.success("Onboarding flags cleared.");
-    navigate(`${routes.onboarding.privacy}?replay=1`);
+    navigate(routes.onboarding.privacy);
   }, [navigate]);
 
   const fetchAssistant = useCallback(async (force?: boolean) => {

--- a/apps/web/src/lib/auth/auth-middleware.ts
+++ b/apps/web/src/lib/auth/auth-middleware.ts
@@ -9,10 +9,6 @@ import { isSessionSettled } from "@/stores/session-status";
 import { isLocalMode, hasAssistants } from "@/lib/local-mode";
 import { resolveNavigation } from "@/lib/navigation/navigation-resolver";
 import { buildNavigationState } from "@/lib/navigation/build-state";
-import {
-  clearOnboardingCompleted,
-  readOnboardingCompleted,
-} from "@/domains/onboarding/prefs";
 import { whenStoreState } from "@/utils/when-store-state";
 
 export const authUserContext = createRouterContext<AuthUser | null>(null);
@@ -22,9 +18,7 @@ const PLATFORM_SESSION_PROBE_TIMEOUT_MS = 5_000;
 export const authMiddleware: MiddlewareFunction = async ({ request, context }, next) => {
   const url = new URL(request.url);
 
-  const state = buildNavigationState({
-    isReplay: url.searchParams.has("replay"),
-  });
+  const state = buildNavigationState();
 
   const decision = resolveNavigation(state, {
     kind: "route-guard",
@@ -44,11 +38,6 @@ export const authMiddleware: MiddlewareFunction = async ({ request, context }, n
   }
 
   if (decision.action === "redirect") {
-    // Best-effort cleanup: clear stale onboarding flag when the lockfile
-    // has no assistants but localStorage still remembers a prior completion.
-    if (isLocalMode() && !hasAssistants() && readOnboardingCompleted()) {
-      clearOnboardingCompleted();
-    }
     throw redirect(decision.to);
   }
 

--- a/apps/web/src/lib/navigation/build-state.ts
+++ b/apps/web/src/lib/navigation/build-state.ts
@@ -3,7 +3,6 @@ import { isSessionSettled, isAuthenticated } from "@/stores/session-status";
 import { isGatewayAuthMode } from "@/lib/auth/gateway-session";
 import { isLocalMode, hasAssistants } from "@/lib/local-mode";
 import {
-  readOnboardingCompleted,
   readTosAccepted,
   readAiDataConsent,
 } from "@/domains/onboarding/prefs";
@@ -20,10 +19,8 @@ export function buildNavigationState(
     sessionSettled: isSessionSettled(sessionStatus),
     isAuthenticated: isAuthenticated(sessionStatus),
     platformSession,
-    onboardingCompleted: readOnboardingCompleted(),
     tosAccepted: readTosAccepted(),
     aiDataConsent: readAiDataConsent(),
-    isReplay: false,
     ...overrides,
   };
 }

--- a/apps/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/apps/web/src/lib/navigation/navigation-resolver.test.ts
@@ -13,10 +13,8 @@ const base: NavigationState = {
   sessionSettled: true,
   isAuthenticated: true,
   platformSession: "present",
-  onboardingCompleted: true,
   tosAccepted: true,
   aiDataConsent: true,
-  isReplay: false,
 };
 
 function s(overrides: Partial<NavigationState>): NavigationState {
@@ -62,7 +60,7 @@ describe("resolveNavigation", () => {
     test("allows unauthenticated local-mode user on onboarding route", () => {
       expect(
         guard(
-          s({ isAuthenticated: false, isLocalMode: true, hasAssistants: false, onboardingCompleted: false }),
+          s({ isAuthenticated: false, isLocalMode: true, hasAssistants: false }),
           "/assistant/onboarding/welcome",
         ),
       ).toEqual(ALLOW);
@@ -70,7 +68,7 @@ describe("resolveNavigation", () => {
 
     test("redirects unauthenticated local-mode fresh user to welcome", () => {
       expect(
-        guard(s({ isAuthenticated: false, isLocalMode: true, hasAssistants: false, onboardingCompleted: false })),
+        guard(s({ isAuthenticated: false, isLocalMode: true, hasAssistants: false })),
       ).toEqual({ action: "redirect", to: "/assistant/onboarding/welcome" });
     });
 
@@ -82,40 +80,19 @@ describe("resolveNavigation", () => {
 
     // -- authenticated, onboarding routes ---------------------------------
 
-    test("redirects away from onboarding when completed", () => {
+    test("allows authenticated user on onboarding route", () => {
       expect(
-        guard(s({ onboardingCompleted: true }), "/assistant/onboarding/welcome"),
-      ).toEqual({ action: "redirect", to: "/assistant" });
-    });
-
-    test("allows onboarding route with replay param (shared screen)", () => {
-      expect(
-        guard(s({ onboardingCompleted: true, isReplay: true }), "/assistant/onboarding/privacy"),
-      ).toEqual(ALLOW);
-    });
-
-    test("redirects platform user from local-only screen even with replay", () => {
-      expect(
-        guard(s({ isLocalMode: false, onboardingCompleted: true, isReplay: true }), "/assistant/onboarding/welcome"),
-      ).toEqual({ action: "redirect", to: "/assistant" });
-    });
-
-    test("treats onboardingCompleted as stale when local mode with no assistants", () => {
-      expect(
-        guard(
-          s({ isLocalMode: true, hasAssistants: false, onboardingCompleted: true }),
-          "/assistant/onboarding/welcome",
-        ),
+        guard(s({}), "/assistant/onboarding/privacy"),
       ).toEqual(ALLOW);
     });
 
     test("query strings do not break onboarding path matching", () => {
       expect(
-        guard(s({ onboardingCompleted: true, isReplay: true }), "/assistant/onboarding/privacy?replay=1"),
+        guard(s({}), "/assistant/onboarding/privacy?replay=1"),
       ).toEqual(ALLOW);
       expect(
         guard(
-          s({ onboardingCompleted: false, tosAccepted: true, aiDataConsent: true }),
+          s({ tosAccepted: true, aiDataConsent: true }),
           "/assistant/onboarding/hatching?hosting=local",
         ),
       ).toEqual(ALLOW);
@@ -123,29 +100,29 @@ describe("resolveNavigation", () => {
 
     test("redirects non-local user from local-only onboarding screen", () => {
       expect(
-        guard(s({ isLocalMode: false, onboardingCompleted: false }), "/assistant/onboarding/welcome"),
+        guard(s({ isLocalMode: false }), "/assistant/onboarding/welcome"),
       ).toEqual({ action: "redirect", to: "/assistant" });
       expect(
-        guard(s({ isLocalMode: false, onboardingCompleted: false }), "/assistant/onboarding/hosting"),
+        guard(s({ isLocalMode: false }), "/assistant/onboarding/hosting"),
       ).toEqual({ action: "redirect", to: "/assistant" });
       expect(
-        guard(s({ isLocalMode: false, onboardingCompleted: false }), "/assistant/onboarding/api-key"),
+        guard(s({ isLocalMode: false }), "/assistant/onboarding/api-key"),
       ).toEqual({ action: "redirect", to: "/assistant" });
     });
 
     test("allows non-local user on shared onboarding screens", () => {
       expect(
-        guard(s({ isLocalMode: false, onboardingCompleted: false }), "/assistant/onboarding/privacy"),
+        guard(s({ isLocalMode: false }), "/assistant/onboarding/privacy"),
       ).toEqual(ALLOW);
       expect(
-        guard(s({ isLocalMode: false, onboardingCompleted: false }), "/assistant/onboarding/prechat"),
+        guard(s({ isLocalMode: false }), "/assistant/onboarding/prechat"),
       ).toEqual(ALLOW);
     });
 
     test("redirects from hatching without consent", () => {
       expect(
         guard(
-          s({ onboardingCompleted: false, tosAccepted: false, aiDataConsent: false }),
+          s({ tosAccepted: false, aiDataConsent: false }),
           "/assistant/onboarding/hatching",
         ),
       ).toEqual({ action: "redirect", to: "/assistant/onboarding/privacy" });
@@ -154,7 +131,7 @@ describe("resolveNavigation", () => {
     test("redirects from hatching without consent in local mode", () => {
       expect(
         guard(
-          s({ isLocalMode: true, onboardingCompleted: false, tosAccepted: false, aiDataConsent: false }),
+          s({ isLocalMode: true, tosAccepted: false, aiDataConsent: false }),
           "/assistant/onboarding/hatching",
         ),
       ).toEqual({ action: "redirect", to: "/assistant/onboarding/welcome" });
@@ -163,7 +140,7 @@ describe("resolveNavigation", () => {
     test("allows hatching with consent", () => {
       expect(
         guard(
-          s({ onboardingCompleted: false, tosAccepted: true, aiDataConsent: true }),
+          s({ tosAccepted: true, aiDataConsent: true }),
           "/assistant/onboarding/hatching",
         ),
       ).toEqual(ALLOW);
@@ -172,7 +149,7 @@ describe("resolveNavigation", () => {
     test("allows hatching with only tos (not ai data consent) — should redirect", () => {
       expect(
         guard(
-          s({ onboardingCompleted: false, tosAccepted: true, aiDataConsent: false }),
+          s({ tosAccepted: true, aiDataConsent: false }),
           "/assistant/onboarding/hatching",
         ),
       ).toEqual({ action: "redirect", to: "/assistant/onboarding/privacy" });
@@ -182,19 +159,19 @@ describe("resolveNavigation", () => {
 
     test("waits for platform probe in local mode with no assistants", () => {
       expect(
-        guard(s({ isLocalMode: true, hasAssistants: false, platformSession: "unknown", onboardingCompleted: false })),
+        guard(s({ isLocalMode: true, hasAssistants: false, platformSession: "unknown" })),
       ).toEqual(WAIT);
     });
 
     test("redirects to hosting when local mode + platform session present", () => {
       expect(
-        guard(s({ isLocalMode: true, hasAssistants: false, platformSession: "present", onboardingCompleted: false })),
+        guard(s({ isLocalMode: true, hasAssistants: false, platformSession: "present" })),
       ).toEqual({ action: "redirect", to: "/assistant/onboarding/hosting" });
     });
 
     test("redirects to welcome when local mode + no platform session", () => {
       expect(
-        guard(s({ isLocalMode: true, hasAssistants: false, platformSession: "absent", onboardingCompleted: false })),
+        guard(s({ isLocalMode: true, hasAssistants: false, platformSession: "absent" })),
       ).toEqual({ action: "redirect", to: "/assistant/onboarding/welcome" });
     });
 
@@ -224,37 +201,28 @@ describe("resolveNavigation", () => {
       expect(intercept(s({ isLocalMode: true, hasAssistants: true }), "/assistant")).toEqual(ALLOW);
     });
 
-    test("allows when onboarding completed", () => {
-      expect(intercept(s({ onboardingCompleted: true }), "/assistant")).toEqual(ALLOW);
-    });
-
-    test("treats completion as stale when local mode has no assistants", () => {
-      expect(
-        intercept(
-          s({ isLocalMode: true, hasAssistants: false, onboardingCompleted: true }),
-          "/assistant",
-        ),
-      ).toEqual({ action: "redirect", to: "/assistant/onboarding/welcome" });
+    test("allows when tos and consent accepted", () => {
+      expect(intercept(s({ tosAccepted: true, aiDataConsent: true }), "/assistant")).toEqual(ALLOW);
     });
 
     test("allows destination outside /assistant", () => {
-      expect(intercept(s({ onboardingCompleted: false }), "/account/login")).toEqual(ALLOW);
+      expect(intercept(s({ tosAccepted: false, aiDataConsent: false }), "/account/login")).toEqual(ALLOW);
     });
 
     test("allows destination in /assistant/onboarding", () => {
       expect(
-        intercept(s({ onboardingCompleted: false }), "/assistant/onboarding/privacy"),
+        intercept(s({ tosAccepted: false, aiDataConsent: false }), "/assistant/onboarding/privacy"),
       ).toEqual(ALLOW);
     });
 
     test("redirects to welcome in local mode", () => {
       expect(
-        intercept(s({ isLocalMode: true, hasAssistants: false, onboardingCompleted: false }), "/assistant"),
+        intercept(s({ isLocalMode: true, hasAssistants: false, tosAccepted: false, aiDataConsent: false }), "/assistant"),
       ).toEqual({ action: "redirect", to: "/assistant/onboarding/welcome" });
     });
 
     test("redirects to privacy in platform mode", () => {
-      expect(intercept(s({ onboardingCompleted: false }), "/assistant")).toEqual({
+      expect(intercept(s({ tosAccepted: false, aiDataConsent: false }), "/assistant")).toEqual({
         action: "redirect",
         to: "/assistant/onboarding/privacy",
       });
@@ -262,19 +230,19 @@ describe("resolveNavigation", () => {
 
     test("handles absolute URL destinations", () => {
       expect(
-        intercept(s({ onboardingCompleted: false }), "https://assistant.vellum.ai/assistant"),
+        intercept(s({ tosAccepted: false, aiDataConsent: false }), "https://assistant.vellum.ai/assistant"),
       ).toEqual({ action: "redirect", to: "/assistant/onboarding/privacy" });
     });
 
     test("handles protocol-relative URL destinations", () => {
       expect(
-        intercept(s({ onboardingCompleted: false }), "//assistant.vellum.ai/assistant"),
+        intercept(s({ tosAccepted: false, aiDataConsent: false }), "//assistant.vellum.ai/assistant"),
       ).toEqual({ action: "redirect", to: "/assistant/onboarding/privacy" });
     });
 
     test("allows absolute URL outside /assistant", () => {
       expect(
-        intercept(s({ onboardingCompleted: false }), "https://vellum.ai/account"),
+        intercept(s({ tosAccepted: false, aiDataConsent: false }), "https://vellum.ai/account"),
       ).toEqual(ALLOW);
     });
   });
@@ -297,30 +265,22 @@ describe("resolveNavigation", () => {
       });
     });
 
-    test("allows unauthenticated local-mode user (gateway auth)", () => {
-      expect(hatch(s({ isAuthenticated: false, isLocalMode: true, onboardingCompleted: false }))).toEqual(ALLOW);
-    });
-
-    test("redirects when onboarding completed and not replay", () => {
-      expect(hatch(s({ onboardingCompleted: true, isReplay: false }))).toEqual({
+    test("redirects unauthenticated local-mode user without consent to welcome", () => {
+      expect(hatch(s({ isAuthenticated: false, isLocalMode: true, tosAccepted: false, aiDataConsent: false }))).toEqual({
         action: "redirect",
-        to: "/assistant",
+        to: "/assistant/onboarding/welcome",
       });
     });
 
-    test("allows when onboarding completed but replay", () => {
-      expect(hatch(s({ onboardingCompleted: true, isReplay: true }))).toEqual(ALLOW);
-    });
-
     test("redirects when missing consent", () => {
-      expect(hatch(s({ onboardingCompleted: false, tosAccepted: false, aiDataConsent: false }))).toEqual({
+      expect(hatch(s({ tosAccepted: false, aiDataConsent: false }))).toEqual({
         action: "redirect",
         to: "/assistant/onboarding/privacy",
       });
     });
 
     test("redirects when missing ai data consent only", () => {
-      expect(hatch(s({ onboardingCompleted: false, tosAccepted: true, aiDataConsent: false }))).toEqual({
+      expect(hatch(s({ tosAccepted: true, aiDataConsent: false }))).toEqual({
         action: "redirect",
         to: "/assistant/onboarding/privacy",
       });
@@ -328,12 +288,12 @@ describe("resolveNavigation", () => {
 
     test("redirects to welcome in local mode when missing consent", () => {
       expect(
-        hatch(s({ isLocalMode: true, onboardingCompleted: false, tosAccepted: false, aiDataConsent: false })),
+        hatch(s({ isLocalMode: true, tosAccepted: false, aiDataConsent: false })),
       ).toEqual({ action: "redirect", to: "/assistant/onboarding/welcome" });
     });
 
     test("allows with full consent", () => {
-      expect(hatch(s({ onboardingCompleted: false, tosAccepted: true, aiDataConsent: true }))).toEqual(ALLOW);
+      expect(hatch(s({ tosAccepted: true, aiDataConsent: true }))).toEqual(ALLOW);
     });
   });
 

--- a/apps/web/src/lib/navigation/navigation-resolver.ts
+++ b/apps/web/src/lib/navigation/navigation-resolver.ts
@@ -13,10 +13,8 @@ export interface NavigationState {
   sessionSettled: boolean;
   isAuthenticated: boolean;
   platformSession: PlatformSessionStatus;
-  onboardingCompleted: boolean;
   tosAccepted: boolean;
   aiDataConsent: boolean;
-  isReplay: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -61,11 +59,6 @@ function isOnboardingPath(pathname: string): boolean {
 
 function onboardingEntrypoint(isLocalMode: boolean): string {
   return isLocalMode ? routes.onboarding.welcome : routes.onboarding.privacy;
-}
-
-function effectiveOnboardingCompleted(state: NavigationState): boolean {
-  if (state.isLocalMode && !state.hasAssistants) return false;
-  return state.onboardingCompleted;
 }
 
 function extractPathname(destination: string): string {
@@ -125,7 +118,7 @@ function resolveRouteGuard(
   // 3. Unauthenticated
   if (!state.isAuthenticated) {
     if (state.isLocalMode && isOnboardingPath(path)) return { action: "allow" };
-    if (state.isLocalMode && !state.hasAssistants && !effectiveOnboardingCompleted(state)) {
+    if (state.isLocalMode && !state.hasAssistants) {
       return { action: "redirect", to: routes.onboarding.welcome };
     }
     return {
@@ -136,9 +129,6 @@ function resolveRouteGuard(
 
   // 4. Authenticated, on an onboarding route
   if (isOnboardingPath(path)) {
-    if (effectiveOnboardingCompleted(state) && !state.isReplay) {
-      return { action: "redirect", to: routes.assistant };
-    }
     if (LOCAL_ONLY_ONBOARDING_PATHS.has(path) && !state.isLocalMode) {
       return { action: "redirect", to: routes.assistant };
     }
@@ -170,7 +160,7 @@ function resolveOnboardingIntercept(
   intendedDestination: string,
 ): NavigationDecision {
   if (state.isLocalMode && state.hasAssistants) return { action: "allow" };
-  if (effectiveOnboardingCompleted(state)) return { action: "allow" };
+  if (state.tosAccepted && state.aiDataConsent) return { action: "allow" };
 
   const path = extractPathname(intendedDestination);
   if (!path.startsWith(routes.assistant)) return { action: "allow" };
@@ -190,9 +180,6 @@ function resolveHatchGate(state: NavigationState): NavigationDecision {
   if (!state.sessionSettled) return { action: "wait" };
   if (!state.isAuthenticated && !state.isLocalMode) {
     return { action: "redirect", to: routes.account.login };
-  }
-  if (state.onboardingCompleted && !state.isReplay) {
-    return { action: "redirect", to: routes.assistant };
   }
   if (!(state.tosAccepted && state.aiDataConsent)) {
     return { action: "redirect", to: onboardingEntrypoint(state.isLocalMode) };

--- a/apps/web/src/lib/onboarding-middleware.test.ts
+++ b/apps/web/src/lib/onboarding-middleware.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
 import { onboardingCompletedMiddleware } from "@/lib/onboarding-middleware";
 import { routes } from "@/utils/routes";
 
@@ -8,19 +7,10 @@ function makeRequest(path: string): Request {
   return new Request(`https://example.com${path}`);
 }
 
-async function captureRedirect(
-  middlewareCall: ReturnType<typeof onboardingCompletedMiddleware>,
-): Promise<Response> {
-  return (await Promise.resolve(middlewareCall).catch(
-    (err: unknown) => err,
-  )) as Response;
-}
-
 describe("onboardingCompletedMiddleware", () => {
   beforeEach(() => {
     localStorage.clear();
     sessionStorage.clear();
-    useOnboardingStore.getState().setOnboardingCompleted(false);
   });
 
   test("allows local pre-chat after hatch when onboarding is not complete", async () => {
@@ -50,34 +40,4 @@ describe("onboardingCompletedMiddleware", () => {
     expect(next).toHaveBeenCalled();
   });
 
-  test("redirects completed onboarding unless replay is present", async () => {
-    useOnboardingStore.getState().setOnboardingCompleted(true);
-
-    const redirectResponse = await captureRedirect(
-      onboardingCompletedMiddleware(
-        { request: makeRequest(routes.onboarding.prechat) } as Parameters<
-          typeof onboardingCompletedMiddleware
-        >[0],
-        mock(async () => "ok"),
-      ),
-    );
-
-    expect(redirectResponse).toBeInstanceOf(Response);
-    expect(redirectResponse.headers.get("Location")).toBe(routes.assistant);
-  });
-
-  test("allows replay even when onboarding is complete", async () => {
-    useOnboardingStore.getState().setOnboardingCompleted(true);
-    const next = mock(async () => "ok");
-
-    const result = await onboardingCompletedMiddleware(
-      {
-        request: makeRequest(`${routes.onboarding.prechat}?replay=1`),
-      } as Parameters<typeof onboardingCompletedMiddleware>[0],
-      next,
-    );
-
-    expect(result).toBe("ok");
-    expect(next).toHaveBeenCalled();
-  });
 });

--- a/apps/web/src/lib/onboarding-middleware.ts
+++ b/apps/web/src/lib/onboarding-middleware.ts
@@ -23,11 +23,7 @@ export const onboardingCompletedMiddleware: MiddlewareFunction = async (
   const url = new URL(request.url);
   // Auth has already been verified by the parent auth middleware.
   const decision = resolveNavigation(
-    buildNavigationState({
-      sessionSettled: true,
-      isAuthenticated: true,
-      isReplay: url.searchParams.has("replay"),
-    }),
+    buildNavigationState({ sessionSettled: true, isAuthenticated: true }),
     { kind: "route-guard", pathname: url.pathname },
   );
   if (decision.action === "redirect") throw redirect(decision.to);

--- a/apps/web/src/utils/onboarding-cleanup.ts
+++ b/apps/web/src/utils/onboarding-cleanup.ts
@@ -17,7 +17,6 @@ import { getDeviceSetting, setDeviceSetting } from "@/utils/device-settings";
  * `onboarding-store.ts`, `prefs.ts`, and `storage-migration.ts`. */
 export const KEY_TOS_ACCEPTED = "vellum:onboarding:tosAccepted";
 export const KEY_AI_DATA_CONSENT = "vellum:onboarding:aiDataConsent";
-export const KEY_COMPLETED = "vellum:onboarding:completed";
 const KEY_SELECTED_VERSION = "vellum:onboarding:selectedVersion";
 
 /**
@@ -34,7 +33,6 @@ const KEY_SELECTED_VERSION = "vellum:onboarding:selectedVersion";
 export function clearOnboardingFlags(): void {
   removeLocalSetting(KEY_TOS_ACCEPTED);
   removeLocalSetting(KEY_AI_DATA_CONSENT);
-  removeLocalSetting(KEY_COMPLETED);
   removeLocalSetting(KEY_SELECTED_VERSION);
 }
 

--- a/apps/web/src/utils/storage-migration.test.ts
+++ b/apps/web/src/utils/storage-migration.test.ts
@@ -173,7 +173,9 @@ describe("runStorageMigrations", () => {
 
     expect(localStorage.getItem("vellum:onboarding:tosAccepted")).toBe("true");
     expect(localStorage.getItem("vellum:onboarding:aiDataConsent")).toBe("true");
-    expect(localStorage.getItem("vellum:onboarding:completed")).toBe("true");
+    // completed key is removed (no longer used), not migrated
+    expect(localStorage.getItem("onboarding.completed")).toBeNull();
+    expect(localStorage.getItem("vellum:onboarding:completed")).toBeNull();
     expect(localStorage.getItem("vellum:onboarding:selectedVersion")).toBe("v1.0");
     expect(localStorage.getItem("onboarding.tosAccepted")).toBeNull();
   });
@@ -313,7 +315,7 @@ describe("runStorageMigrations", () => {
   test("full migration is idempotent", () => {
     localStorage.setItem("assistantSidebarCollapsed", "true");
     localStorage.setItem("voice:ttsProvider", "openai");
-    localStorage.setItem("onboarding.completed", "true");
+    localStorage.setItem("onboarding.tosAccepted", "true");
     localStorage.setItem("ff:client:flag", "true");
 
     runStorageMigrations();

--- a/apps/web/src/utils/storage-migration.ts
+++ b/apps/web/src/utils/storage-migration.ts
@@ -122,7 +122,8 @@ export function runStorageMigrations(): void {
   // onboarding. → vellum:onboarding:
   migrateKey("onboarding.tosAccepted", "vellum:onboarding:tosAccepted");
   migrateKey("onboarding.aiDataConsent", "vellum:onboarding:aiDataConsent");
-  migrateKey("onboarding.completed", "vellum:onboarding:completed");
+  removeKey("onboarding.completed");
+  removeKey("vellum:onboarding:completed");
   migrateKey("onboarding.selectedVersion", "vellum:onboarding:selectedVersion");
 
   // vellum:skillsTabTipDismissed → vellum:skills:tipDismissed (consistent naming)


### PR DESCRIPTION
## Summary

- Remove the persistent `onboardingCompleted` localStorage flag and `?replay=1` URL parameter from the onboarding flow
- Replace routing decisions with derived state: `hasAssistants()` for local mode and `tosAccepted && aiDataConsent` for cloud mode
- Replace the `isReplay` skip-hatch logic in the hatching screen with a pre-flight `getAssistant()` check that detects already-active assistants

## Original prompt

While debugging why locally-hosted assistants in the Electron app landed on an empty chat state after onboarding (while cloud-hosted worked correctly), we traced the root cause to a race condition: after hatching, `hasAssistants()` flips to true, causing `effectiveOnboardingCompleted()` to return the raw `onboardingCompleted` localStorage value — which is stale from a prior session. This redirected the user from pre-chat to `/assistant` without staging any onboarding context. Rather than patching the race, we simplified by removing `onboardingCompleted` entirely, deriving routing decisions from existing state (`hasAssistants`, `tosAccepted`, `aiDataConsent`), and dropping the `?replay=1` parameter that only existed to bypass the removed guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)