### PR TITLE
fix(web): skip redirect on logout for locally-hosted assistants

### DIFF
--- a/apps/web/src/lib/auth/handle-logout.ts
+++ b/apps/web/src/lib/auth/handle-logout.ts
@@ -13,14 +13,13 @@ import { routes } from "@/utils/routes";
 
 export async function handleLogout(navigate: NavigateFunction): Promise<void> {
   if (isLocalMode()) {
-    await setMenuPlatformSession(false);
-    await useAuthStore.getState().logout();
-
     const active = getActiveAssistant();
     if (active && isLocalAssistant(active)) {
       return;
     }
 
+    await setMenuPlatformSession(false);
+    await useAuthStore.getState().logout();
     navigate(getOnboardingEntrypoint());
   } else {
     await useAuthStore.getState().logout();

--- a/apps/web/src/lib/auth/handle-logout.ts
+++ b/apps/web/src/lib/auth/handle-logout.ts
@@ -15,6 +15,7 @@ export async function handleLogout(navigate: NavigateFunction): Promise<void> {
   if (isLocalMode()) {
     const active = getActiveAssistant();
     if (active && isLocalAssistant(active)) {
+      await setMenuPlatformSession(false);
       return;
     }
 

--- a/apps/web/src/lib/auth/handle-logout.ts
+++ b/apps/web/src/lib/auth/handle-logout.ts
@@ -2,7 +2,11 @@ import type { NavigateFunction } from "react-router";
 
 import { getOnboardingEntrypoint } from "@/domains/onboarding/gate";
 import { hardNavigate } from "@/lib/auth/hard-navigate";
-import { isLocalMode } from "@/lib/local-mode";
+import {
+  getActiveAssistant,
+  isLocalAssistant,
+  isLocalMode,
+} from "@/lib/local-mode";
 import { setMenuPlatformSession } from "@/runtime/menu";
 import { useAuthStore } from "@/stores/auth-store";
 import { routes } from "@/utils/routes";
@@ -11,6 +15,12 @@ export async function handleLogout(navigate: NavigateFunction): Promise<void> {
   if (isLocalMode()) {
     await setMenuPlatformSession(false);
     await useAuthStore.getState().logout();
+
+    const active = getActiveAssistant();
+    if (active && isLocalAssistant(active)) {
+      return;
+    }
+
     navigate(getOnboardingEntrypoint());
   } else {
     await useAuthStore.getState().logout();


### PR DESCRIPTION
## Summary
- When logging out with a locally-hosted assistant active, clear session state but skip the redirect to onboarding/login — locally-hosted assistants don't require a platform session
- Wrap settings routes in `ActiveAssistantGate` so local-only assistants (not registered on the platform) resolve a non-null `assistantId` for daemon config hooks
- Simplify `useAssistantId` in daemon config to use the guaranteed-present active assistant ID instead of fetching from the platform API

## Original prompt
The user wanted `handleLogout` updated so that locally-hosted assistants clear session state on logout but don't redirect, since they don't need a platform login. The settings route and daemon config changes ensure local-only assistants can access settings pages without a platform-registered assistant ID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)