### PR TITLE
fix(web): allow cancelling stuck login pending state on welcome screen

### DIFF
--- a/apps/macos/src/main/native-auth.ts
+++ b/apps/macos/src/main/native-auth.ts
@@ -197,6 +197,10 @@ export const installNativeAuth = (): void => {
       return startOAuth(options);
     },
   );
+
+  handle("vellum:auth:cancelOAuth", z.tuple([]), () => {
+    cancelPendingFlows();
+  });
 };
 
 export const __resetForTesting = (): void => {

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -219,6 +219,7 @@ export interface VellumBridge {
       loginHint?: string;
       intent?: string;
     }): Promise<{ sessionToken: string }>;
+    cancelOAuth(): Promise<void>;
   };
   hotkeys: {
     /** Resolved catalog of rebindable commands and their effective bindings. */

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -510,6 +510,8 @@ const bridge: VellumBridge = {
       ipcRenderer.invoke("vellum:auth:startOAuth", options) as Promise<{
         sessionToken: string;
       }>,
+    cancelOAuth: (): Promise<void> =>
+      ipcRenderer.invoke("vellum:auth:cancelOAuth") as Promise<void>,
   },
   hotkeys: {
     get: (): Promise<ResolvedHotkey[]> =>

--- a/apps/web/src/domains/onboarding/pages/welcome-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/welcome-screen.tsx
@@ -45,6 +45,7 @@ export function WelcomeScreen() {
   };
 
   const handleContinueWithoutAccount = () => {
+    if (loading) handleCancel();
     void navigate(routes.onboarding.hosting);
   };
 

--- a/apps/web/src/domains/onboarding/pages/welcome-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/welcome-screen.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from "react-router";
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
 import { isPlatformLocal } from "@/lib/auth/loopback-auth";
 import { isLocalMode } from "@/lib/local-mode";
+import { isElectron } from "@/runtime/is-electron";
 import { startAuthFlow } from "@/runtime/native-auth";
 import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
@@ -38,6 +39,9 @@ export function WelcomeScreen() {
     flowIdRef.current++;
     setLoading(false);
     setError(null);
+    if (isElectron()) {
+      void window.vellum?.auth?.cancelOAuth();
+    }
   };
 
   const handleContinueWithoutAccount = () => {

--- a/apps/web/src/domains/onboarding/pages/welcome-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/welcome-screen.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useNavigate } from "react-router";
 
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
@@ -12,6 +12,7 @@ export function WelcomeScreen() {
   const navigate = useNavigate();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const flowIdRef = useRef(0);
 
   const handleLogin = async () => {
     if (isLocalMode() && isPlatformLocal()) {
@@ -19,6 +20,7 @@ export function WelcomeScreen() {
       void navigate(`${routes.account.login}?returnTo=${encodeURIComponent(returnTo)}`);
       return;
     }
+    const flowId = ++flowIdRef.current;
     setError(null);
     setLoading(true);
     try {
@@ -26,9 +28,16 @@ export function WelcomeScreen() {
       const callbackUrl = `${routes.account.providerCallback}?returnTo=${encodeURIComponent(returnTo)}`;
       await startAuthFlow("workos-oidc", callbackUrl, { returnTo });
     } catch {
+      if (flowId !== flowIdRef.current) return;
       setError("Something went wrong. Please try again.");
       setLoading(false);
     }
+  };
+
+  const handleCancel = () => {
+    flowIdRef.current++;
+    setLoading(false);
+    setError(null);
   };
 
   const handleContinueWithoutAccount = () => {
@@ -67,10 +76,9 @@ export function WelcomeScreen() {
               size="regular"
               fullWidth
               className="h-11 text-base"
-              onClick={() => void handleLogin()}
-              disabled={loading}
+              onClick={loading ? handleCancel : () => void handleLogin()}
             >
-              {loading ? "Logging in…" : "Log In"}
+              {loading ? "Cancel" : "Log In"}
             </Button>
             <Button
               variant="ghost"
@@ -78,7 +86,6 @@ export function WelcomeScreen() {
               fullWidth
               className="h-11 text-base"
               onClick={handleContinueWithoutAccount}
-              disabled={loading}
             >
               Continue without account
             </Button>

--- a/apps/web/src/runtime/is-electron.ts
+++ b/apps/web/src/runtime/is-electron.ts
@@ -261,6 +261,7 @@ declare global {
           loginHint?: string;
           intent?: string;
         }): Promise<{ sessionToken: string }>;
+        cancelOAuth(): Promise<void>;
       };
       mainWindow: {
         ensureVisible(): Promise<void>;


### PR DESCRIPTION
## Summary
- When the user clicks "Log In" and closes the browser tab before completing OAuth, the "Logging in..." state was stuck with no way to recover without restarting the app
- Changed the button to show "Cancel" during the pending state, allowing users to click it to reset back to "Log In"
- Used a flow ID ref to prevent stale promise rejections from corrupting state after cancellation
- Also re-enabled "Continue without account" during the pending state

## Original prompt
The Electron mac app's welcome screen shows a "Logging in..." pending state after clicking Log In, which opens the browser for OAuth. If the user closes that browser tab before completing login, the pending state remains indefinitely with no way to recover — the user has to quit and restart the app. The fix makes the button clickable as a "Cancel" action during the pending state, resetting back to the initial "Log In" view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)