### PR TITLE
Fix chat microphone button

### DIFF
--- a/apps/macos/electron-builder.config.cjs
+++ b/apps/macos/electron-builder.config.cjs
@@ -50,6 +50,8 @@ module.exports = {
     entitlements: "./scripts/entitlements/app.plist",
     entitlementsInherit: "./scripts/entitlements/inherit.plist",
     extendInfo: {
+      NSMicrophoneUsageDescription:
+        "Vellum uses the microphone to record voice input for chat.",
       NSUserNotificationAlertStyle: "alert",
     },
     target: [

--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -1,6 +1,6 @@
 import "./env-seed";
 
-import { app, net, protocol, session, shell } from "electron";
+import { app, net, protocol, shell } from "electron";
 import fs from "node:fs/promises";
 import { pathToFileURL } from "node:url";
 import path from "node:path";
@@ -46,6 +46,7 @@ import { installApplicationMenu } from "./menu";
 import { installNativeAuth } from "./native-auth";
 import { installConnectivityProbe } from "./connectivity-probe";
 import { installNotifications } from "./notifications";
+import { installPermissionHandler } from "./permissions";
 import { installPowerEvents } from "./power-events";
 import { installConnectivityIpc, installStatusIpc } from "./status";
 import { installTray } from "./tray";
@@ -283,18 +284,6 @@ const forwardPlatformRequest = async (
 
   captureCsrfToken(response);
   return response;
-};
-
-// Deny renderer permission requests by default. Specific permissions
-// (microphone for voice input, notifications, etc.) are allowlisted in the
-// follow-up tickets that wire each feature, so the bridge surface stays
-// honest about what the app can actually do at any given commit.
-const installPermissionHandler = (): void => {
-  session.defaultSession.setPermissionRequestHandler(
-    (_webContents, _permission, callback) => {
-      callback(false);
-    },
-  );
 };
 
 // ---------------------------------------------------------------------------

--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -215,16 +215,19 @@ const forwardGatewayRequest = async (
       return null;
     case "reject":
       return new Response(plan.message, { status: plan.status });
-    case "forward":
+    case "forward": {
+      const body = plan.hasBody ? await request.arrayBuffer() : undefined;
       return net.fetch(plan.url, {
         method: plan.method,
         headers: plan.headers,
-        body: plan.hasBody ? request.body : undefined,
-        // Stream the request body instead of buffering it; required by the
-        // fetch spec whenever a `ReadableStream` body is supplied.
-        ...(plan.hasBody ? { duplex: "half" } : {}),
+        body,
+        // Electron's protocol-handler Request body arrives as a stream.
+        // Forwarding that stream through net.fetch can trip Chromium's
+        // chunked upload path for JSON/audio uploads; a finite ArrayBuffer
+        // gives the loopback gateway a regular request body instead.
         redirect: "manual",
       });
+    }
   }
 };
 

--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -215,19 +215,16 @@ const forwardGatewayRequest = async (
       return null;
     case "reject":
       return new Response(plan.message, { status: plan.status });
-    case "forward": {
-      const body = plan.hasBody ? await request.arrayBuffer() : undefined;
+    case "forward":
       return net.fetch(plan.url, {
         method: plan.method,
         headers: plan.headers,
-        body,
-        // Electron's protocol-handler Request body arrives as a stream.
-        // Forwarding that stream through net.fetch can trip Chromium's
-        // chunked upload path for JSON/audio uploads; a finite ArrayBuffer
-        // gives the loopback gateway a regular request body instead.
+        body: plan.hasBody ? request.body : undefined,
+        // Stream the request body instead of buffering it; required by the
+        // fetch spec whenever a `ReadableStream` body is supplied.
+        ...(plan.hasBody ? { duplex: "half" } : {}),
         redirect: "manual",
       });
-    }
   }
 };
 

--- a/apps/macos/src/main/permissions.test.ts
+++ b/apps/macos/src/main/permissions.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+type PermissionCheckHandler = NonNullable<
+  Parameters<Electron.Session["setPermissionCheckHandler"]>[0]
+>;
+type PermissionRequestHandler = NonNullable<
+  Parameters<Electron.Session["setPermissionRequestHandler"]>[0]
+>;
+
+let permissionCheckHandler: PermissionCheckHandler | null = null;
+let permissionRequestHandler: PermissionRequestHandler | null = null;
+
+const setPermissionCheckHandlerMock = mock(
+  (handler: typeof permissionCheckHandler) => {
+    permissionCheckHandler = handler;
+  },
+);
+const setPermissionRequestHandlerMock = mock(
+  (handler: typeof permissionRequestHandler) => {
+    permissionRequestHandler = handler;
+  },
+);
+
+mock.module("electron", () => ({
+  app: { isPackaged: true },
+  session: {
+    defaultSession: {
+      setPermissionCheckHandler: setPermissionCheckHandlerMock,
+      setPermissionRequestHandler: setPermissionRequestHandlerMock,
+    },
+  },
+}));
+
+const {
+  installPermissionHandler,
+  shouldGrantPermissionCheck,
+  shouldGrantPermissionRequest,
+} = await import("./permissions");
+
+beforeEach(() => {
+  permissionCheckHandler = null;
+  permissionRequestHandler = null;
+  setPermissionCheckHandlerMock.mockClear();
+  setPermissionRequestHandlerMock.mockClear();
+});
+
+describe("permission policy", () => {
+  test("allows audio-only media requests from the app renderer", () => {
+    expect(
+      shouldGrantPermissionRequest("media", {
+        mediaTypes: ["audio"],
+        securityOrigin: "app://vellum.ai",
+      }),
+    ).toBe(true);
+  });
+
+  test("denies camera and mixed media requests", () => {
+    expect(
+      shouldGrantPermissionRequest("media", {
+        mediaTypes: ["video"],
+        securityOrigin: "app://vellum.ai",
+      }),
+    ).toBe(false);
+    expect(
+      shouldGrantPermissionRequest("media", {
+        mediaTypes: ["audio", "video"],
+        securityOrigin: "app://vellum.ai",
+      }),
+    ).toBe(false);
+  });
+
+  test("denies audio requests from untrusted origins", () => {
+    expect(
+      shouldGrantPermissionRequest("media", {
+        mediaTypes: ["audio"],
+        securityOrigin: "https://example.com",
+      }),
+    ).toBe(false);
+  });
+
+  test("denies non-media permissions", () => {
+    expect(
+      shouldGrantPermissionRequest("notifications", {
+        mediaTypes: ["audio"],
+        securityOrigin: "app://vellum.ai",
+      }),
+    ).toBe(false);
+  });
+
+  test("allows matching audio permission checks", () => {
+    expect(
+      shouldGrantPermissionCheck("media", "app://vellum.ai", {
+        mediaType: "audio",
+      }),
+    ).toBe(true);
+  });
+
+  test("denies video permission checks", () => {
+    expect(
+      shouldGrantPermissionCheck("media", "app://vellum.ai", {
+        mediaType: "video",
+      }),
+    ).toBe(false);
+  });
+
+  test("installs check and request handlers on the default session", () => {
+    installPermissionHandler();
+
+    expect(setPermissionCheckHandlerMock).toHaveBeenCalledTimes(1);
+    expect(setPermissionRequestHandlerMock).toHaveBeenCalledTimes(1);
+    expect(permissionCheckHandler).toBeTruthy();
+    expect(permissionRequestHandler).toBeTruthy();
+  });
+
+  test("installed request handler grants renderer audio requests", () => {
+    installPermissionHandler();
+
+    let granted: boolean | null = null;
+    permissionRequestHandler?.(
+      { getURL: () => "app://vellum.ai/assistant" } as Electron.WebContents,
+      "media",
+      (value) => {
+        granted = value;
+      },
+      { mediaTypes: ["audio"] } as Electron.MediaAccessPermissionRequest,
+    );
+
+    expect(granted).toBe(true);
+  });
+});

--- a/apps/macos/src/main/permissions.test.ts
+++ b/apps/macos/src/main/permissions.test.ts
@@ -115,8 +115,11 @@ describe("permission policy", () => {
   test("installed request handler grants renderer audio requests", () => {
     installPermissionHandler();
 
-    let granted: boolean | null = null;
-    permissionRequestHandler?.(
+    const handler = permissionRequestHandler;
+    if (!handler) throw new Error("expected permission request handler");
+
+    let granted = false;
+    handler(
       { getURL: () => "app://vellum.ai/assistant" } as Electron.WebContents,
       "media",
       (value) => {

--- a/apps/macos/src/main/permissions.ts
+++ b/apps/macos/src/main/permissions.ts
@@ -1,0 +1,82 @@
+import {
+  session,
+  type MediaAccessPermissionRequest,
+  type PermissionCheckHandlerHandlerDetails,
+} from "electron";
+
+import { isAllowedOrigin, resolveAllowedOrigin } from "./app-origin";
+
+type PermissionRequestName = Parameters<
+  NonNullable<
+    Parameters<typeof session.defaultSession.setPermissionRequestHandler>[0]
+  >
+>[1];
+
+type PermissionCheckName = Parameters<
+  NonNullable<
+    Parameters<typeof session.defaultSession.setPermissionCheckHandler>[0]
+  >
+>[1];
+
+const isTrustedRendererOrigin = (
+  origin: string | URL | null | undefined,
+): boolean => isAllowedOrigin(origin, resolveAllowedOrigin());
+
+const isAudioOnlyMediaRequest = (
+  details: Pick<MediaAccessPermissionRequest, "mediaTypes">,
+): boolean => {
+  const mediaTypes = details.mediaTypes ?? [];
+  return mediaTypes.length > 0 && mediaTypes.every((type) => type === "audio");
+};
+
+/**
+ * Permission requests are denied by default. Voice input needs audio capture,
+ * but the renderer should not gain camera, notification, or arbitrary
+ * web-platform permissions through the shared default session.
+ */
+export const shouldGrantPermissionRequest = (
+  permission: PermissionRequestName,
+  details: Pick<MediaAccessPermissionRequest, "mediaTypes" | "securityOrigin">,
+  fallbackOrigin?: string,
+): boolean =>
+  permission === "media" &&
+  isAudioOnlyMediaRequest(details) &&
+  isTrustedRendererOrigin(details.securityOrigin ?? fallbackOrigin);
+
+/**
+ * Chromium often performs a permission check before issuing the request. Keep
+ * this in sync with the request handler so `getUserMedia({ audio: true })` can
+ * proceed while unrelated permission checks still fail closed.
+ */
+export const shouldGrantPermissionCheck = (
+  permission: PermissionCheckName,
+  requestingOrigin: string,
+  details: Pick<
+    PermissionCheckHandlerHandlerDetails,
+    "mediaType" | "securityOrigin" | "requestingUrl"
+  >,
+): boolean =>
+  permission === "media" &&
+  details.mediaType === "audio" &&
+  (isTrustedRendererOrigin(details.securityOrigin) ||
+    isTrustedRendererOrigin(requestingOrigin) ||
+    isTrustedRendererOrigin(details.requestingUrl));
+
+export const installPermissionHandler = (): void => {
+  session.defaultSession.setPermissionCheckHandler(
+    (_webContents, permission, requestingOrigin, details) =>
+      shouldGrantPermissionCheck(permission, requestingOrigin, details),
+  );
+
+  session.defaultSession.setPermissionRequestHandler(
+    (webContents, permission, callback, details) => {
+      callback(
+        shouldGrantPermissionRequest(
+          permission,
+          details as MediaAccessPermissionRequest,
+          webContents.getURL(),
+        ),
+      );
+    },
+  );
+};

--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -36,6 +36,7 @@ import { ComposerNotices } from "@/domains/chat/components/composer-notices";
 import { ComposerSettingsMenu } from "@/domains/chat/components/composer-settings-menu";
 import { ContextWindowIndicator } from "@/domains/chat/components/context-window-indicator";
 import { CreditsExhaustedBanner } from "@/domains/chat/components/credits-exhausted-banner";
+import { MicPermissionPrimer } from "@/domains/chat/components/mic-permission-primer";
 import { OnboardingChoiceCard } from "@/domains/chat/components/onboarding-choice-card";
 import { ProviderBillingBanner } from "@/domains/chat/components/provider-billing-banner";
 import { SendErrorModal } from "@/domains/chat/components/send-error-modal";
@@ -217,9 +218,12 @@ export function ChatMainPanel({
     voiceError,
     clearVoiceError,
     setVoiceError,
+    showPrimer,
     handleVoiceBeforeStart,
     handleVoiceTranscript,
     setVoiceInterim,
+    handlePrimerContinue,
+    handlePrimerCancel,
     handleRetryMicPermission,
   } = useVoiceInput({ assistantId, inputRef, setInput });
 
@@ -801,6 +805,11 @@ export function ChatMainPanel({
         queuedDrawerSlot={isSidePanel ? undefined : mainQueuedDrawerSlot}
         readonlyBannerSlot={slackReadonlyBannerSlot}
         startersSlot={startersSlot}
+      />
+      <MicPermissionPrimer
+        open={showPrimer}
+        onContinue={handlePrimerContinue}
+        onCancel={handlePrimerCancel}
       />
       {sendErrorModalNode}
       {ruleEditorModalNode}


### PR DESCRIPTION
## Summary
- Allow the Electron renderer to request audio-only media permissions from the trusted app origin while continuing to deny camera and unrelated permissions.
- Add the packaged macOS microphone usage description so the OS can present the mic permission prompt.
- Cover the permission policy with focused main-process tests.

## Original prompt
The Electron app's chat composer microphone button appeared to do nothing when clicked. The request was to investigate that behavior and ship whatever fix was needed through the `/do` workflow, preserving the repo's review and CI process.