### PR TITLE
feat(web): show billing for self-hosted assistants, hide plan management

### DIFF
--- a/apps/web/src/domains/settings/billing/billing-page.tsx
+++ b/apps/web/src/domains/settings/billing/billing-page.tsx
@@ -1,7 +1,7 @@
 import { Loader2 } from "lucide-react";
 import { Suspense, useCallback, useEffect, useState } from "react";
 
-import { useNavigate, useSearchParams } from "react-router";
+import { Navigate, useNavigate, useSearchParams } from "react-router";
 
 import { useQueryClient } from "@tanstack/react-query";
 
@@ -21,7 +21,6 @@ import {
     useActiveAssistantLifecycleIsLoading,
     usePlatformGate,
 } from "@/hooks/use-platform-gate";
-import { useHasPlatformSession } from "@/stores/auth-store";
 import { routes } from "@/utils/routes";
 import { Notice } from "@vellumai/design-library/components/notice";
 import { toast } from "@vellumai/design-library/components/toast";
@@ -61,7 +60,7 @@ function BillingStatusHandler() {
 
 export function BillingPage() {
   const platformGate = usePlatformGate({ platformHostedOnly: true });
-  const hasPlatformSession = useHasPlatformSession();
+  const billingGate = usePlatformGate();
   const isPlatformHosted = useActiveAssistantIsPlatformHosted();
   const isLifecycleLoading = useActiveAssistantLifecycleIsLoading();
 
@@ -92,14 +91,8 @@ export function BillingPage() {
     }, { replace: true });
   }, [setSearchParams]);
 
-  if (!hasPlatformSession) {
-    return (
-      <div className="space-y-4">
-        <Notice tone="info">
-          Log in to the Vellum platform to manage billing and usage.
-        </Notice>
-      </div>
-    );
+  if (billingGate !== "full") {
+    return <Navigate replace to={routes.settings.general} />;
   }
 
   if (isLifecycleLoading) {

--- a/apps/web/src/domains/settings/billing/billing-page.tsx
+++ b/apps/web/src/domains/settings/billing/billing-page.tsx
@@ -1,7 +1,7 @@
 import { Loader2 } from "lucide-react";
 import { Suspense, useCallback, useEffect, useState } from "react";
 
-import { Navigate, useNavigate, useSearchParams } from "react-router";
+import { useNavigate, useSearchParams } from "react-router";
 
 import { useQueryClient } from "@tanstack/react-query";
 
@@ -21,6 +21,7 @@ import {
     useActiveAssistantLifecycleIsLoading,
     usePlatformGate,
 } from "@/hooks/use-platform-gate";
+import { useHasPlatformSession } from "@/stores/auth-store";
 import { routes } from "@/utils/routes";
 import { Notice } from "@vellumai/design-library/components/notice";
 import { toast } from "@vellumai/design-library/components/toast";
@@ -59,33 +60,9 @@ function BillingStatusHandler() {
 }
 
 export function BillingPage() {
-  // Billing is fully platform-routed — plan management, payment methods,
-  // credit balance, referrals, and usage all live behind organization-scoped
-  // APIs that have no meaningful target on a self-hosted assistant. Use
-  // `platformHostedOnly` so the gate flips to `"gated"` in any self-hosted
-  // state (lifecycle `kind: "self_hosted"` or `kind: "active"` + `isLocal:
-  // true`) regardless of platform session, and to `"disabled"` when there's
-  // no platform session at all.
   const platformGate = usePlatformGate({ platformHostedOnly: true });
-  // Strict hosting predicate. The page-level `platformGate` is the
-  // *Render*-tier predicate — intentionally permissive during the
-  // lifecycle-loading window so the page chrome / Navigate decision
-  // doesn't flash. But every subcomponent below this page mounts unguarded
-  // `useQuery` hooks against org-scoped billing endpoints (PlanCard,
-  // PaymentMethodsCard, AdjustPlanModal, BillingPanel, BillingUsagePanel,
-  // GracePeriodBanner, ReferralPanel — none have their own `enabled`
-  // predicates). Hold the subcomponent mount until lifecycle resolves
-  // positively to platform-hosted so a logged-in self-hosted user
-  // deep-linking here can't fire billing requests during the race window
-  // before `<Navigate />` takes over below.
+  const hasPlatformSession = useHasPlatformSession();
   const isPlatformHosted = useActiveAssistantIsPlatformHosted();
-  // Distinguish the genuine *resolving* window (`kind: "loading"`) from
-  // already-resolved-but-not-hosted states (`retired`, `error`,
-  // `awaiting_version_selection`). `!isPlatformHosted` is true for both —
-  // conflating them turns the lifecycle-loading spinner into a permanent
-  // spinner when the lifecycle has already terminated in a non-hosted
-  // non-self-hosted state (Trap 6 cached-state variant: rule applies to
-  // body-level guards too, not just `disabled`/`isResolving` predicates).
   const isLifecycleLoading = useActiveAssistantLifecycleIsLoading();
 
   const [searchParams, setSearchParams] = useSearchParams();
@@ -115,17 +92,7 @@ export function BillingPage() {
     }, { replace: true });
   }, [setSearchParams]);
 
-  // Whole-page gate: bookmarks/shared-links to /settings/billing on a
-  // self-hosted assistant should land somewhere sensible rather than render
-  // nothing. Sidebar entry is also filtered out in `settings-layout.tsx` as
-  // defense in depth for in-app navigation.
-  if (platformGate === "gated") {
-    return <Navigate replace to={routes.settings.general} />;
-  }
-
-  // Logged-out (no platform session, not self-hosted) renders the page
-  // chrome with a login notice — better UX than redirecting to general.
-  if (platformGate === "disabled") {
+  if (!hasPlatformSession) {
     return (
       <div className="space-y-4">
         <Notice tone="info">
@@ -135,14 +102,6 @@ export function BillingPage() {
     );
   }
 
-  // Lifecycle-loading race: `platformGate === "full"` is permissive during
-  // the loading window, so without this guard a logged-in user deep-linking
-  // here while the assistant is still resolving would mount every
-  // subcomponent and fire their org-scoped billing queries before we know
-  // whether the assistant is platform-hosted. Show a spinner *only* during
-  // the genuine resolving window; once lifecycle resolves we either render
-  // the body (hosted) or fall through to the terminal-non-hosted branch
-  // below.
   if (isLifecycleLoading) {
     return (
       <div className="space-y-4">
@@ -154,16 +113,9 @@ export function BillingPage() {
     );
   }
 
-  // Terminal non-hosted resolved states (`retired`, `error`,
-  // `awaiting_version_selection`): no platform-hosted assistant to manage
-  // billing for, but not self-hosted either so the `"gated"` branch above
-  // didn't match. Render a terminal Notice instead of a spinner that
-  // would wait for a hosting transition that will never happen — and
-  // keep the subcomponent queries silent. Transitional `initializing` /
-  // `cleaning_up` are now caught by the spinner branch above (they're
-  // pending a terminal hosting verdict from a successful platform
-  // response — see `useActiveAssistantLifecycleIsLoading()` docstring).
-  if (!isPlatformHosted) {
+  const showPlanManagement = isPlatformHosted;
+
+  if (!isPlatformHosted && platformGate !== "gated") {
     return (
       <div className="space-y-4">
         <Notice tone="warning">
@@ -179,20 +131,26 @@ export function BillingPage() {
         <BillingStatusHandler />
         <BillingPortalReturnHandler />
       </Suspense>
-      <GracePeriodBanner />
-      <PlanCard onManage={openPlanModal} />
-      <AdjustPlanModal open={planModalOpen} onClose={closePlanModal} onTierUpgraded={onTierUpgraded} />
+      {showPlanManagement && <GracePeriodBanner />}
+      {showPlanManagement && <PlanCard onManage={openPlanModal} />}
+      {showPlanManagement && (
+        <AdjustPlanModal open={planModalOpen} onClose={closePlanModal} onTierUpgraded={onTierUpgraded} />
+      )}
       <PaymentMethodsCard />
       <Suspense fallback={null}>
         <BillingPanel />
       </Suspense>
       <ReferralPanel />
       <BillingUsagePanel />
-      <BillingOnboardingModal open={hasSessionId} onClose={closeOnboarding} />
-      <TierUpgradeResizeModal
-        open={resizeModalOpen}
-        onClose={() => setResizeModalOpen(false)}
-      />
+      {showPlanManagement && (
+        <BillingOnboardingModal open={hasSessionId} onClose={closeOnboarding} />
+      )}
+      {showPlanManagement && (
+        <TierUpgradeResizeModal
+          open={resizeModalOpen}
+          onClose={() => setResizeModalOpen(false)}
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/src/domains/settings/billing/billing-page.tsx
+++ b/apps/web/src/domains/settings/billing/billing-page.tsx
@@ -91,8 +91,18 @@ export function BillingPage() {
     }, { replace: true });
   }, [setSearchParams]);
 
-  if (billingGate !== "full") {
+  if (billingGate === "gated") {
     return <Navigate replace to={routes.settings.general} />;
+  }
+
+  if (billingGate === "disabled") {
+    return (
+      <div className="space-y-4">
+        <Notice tone="info">
+          Log in to the Vellum platform to manage billing and usage.
+        </Notice>
+      </div>
+    );
   }
 
   if (isLifecycleLoading) {

--- a/apps/web/src/domains/settings/settings-layout.tsx
+++ b/apps/web/src/domains/settings/settings-layout.tsx
@@ -31,28 +31,20 @@ export function SettingsLayout() {
   const settingsDeveloperNav = useAssistantFeatureFlagStore.use.settingsDeveloperNav();
   const platformNotifications = useClientFeatureFlagStore.use.platformNotifications();
   const sounds = useAssistantFeatureFlagStore.use.sounds();
-  // platformHostedOnly so the sidebar filter fires on self-hosted active
-  // assistants (lifecycle `kind: "self_hosted"` OR `kind: "active",
-  // isLocal: true`) — not just on local-mode-with-features-off, which is
-  // what the standard gate's `"gated"` state means.
   const platformGate = usePlatformGate({ platformHostedOnly: true });
+  const billingGate = usePlatformGate();
   const { pathname } = useLocation();
 
   const filteredItems = useMemo(
     () =>
       SETTINGS_SIDEBAR.filter((item) => {
-        // Notifications and billing are both organization-scoped platform
-        // concepts. Hide the sidebar items entirely when the active assistant
-        // is self-hosted so users don't land on an empty page. Each page
-        // also redirects to `routes.settings.general` for the same gate, as
-        // defense in depth for direct URL / bookmark navigation.
         if (
           item.id === "notifications" &&
           (!platformNotifications || platformGate === "gated")
         ) {
           return false;
         }
-        if (item.id === "billing" && platformGate === "gated") {
+        if (item.id === "billing" && billingGate !== "full") {
           return false;
         }
         if (item.id === "devices" && platformGate === "gated") {
@@ -72,7 +64,7 @@ export function SettingsLayout() {
         }
         return true;
       }),
-    [platformNotifications, sounds, platformGate],
+    [platformNotifications, sounds, platformGate, billingGate],
   );
 
   const bottomItems = useMemo(


### PR DESCRIPTION
## Summary
- Changed billing sidebar visibility to depend on platform session/features (not hosting mode) — self-hosted users who are logged in now see the billing nav item
- Billing page now conditionally hides plan management UI (PlanCard, AdjustPlanModal, GracePeriodBanner, TierUpgradeResizeModal) for self-hosted assistants
- Payment methods, credits purchasing, referrals, and usage remain accessible regardless of hosting mode as long as the user is logged in

## Original prompt
The billing page was previously hidden entirely for self-hosted assistants. The user wanted to relax this: billing should only be hidden when not logged in or when platform features are disabled. Within the billing page, plan management should be conditionally hidden for self-hosted assistants, but payment methods and credit purchasing should remain accessible for any logged-in user.