### PR TITLE
feat(web): route to select-assistant after retire when other assistants remain

### DIFF
--- a/apps/web/src/assistant/retire-service.test.ts
+++ b/apps/web/src/assistant/retire-service.test.ts
@@ -41,7 +41,7 @@ mock.module("@/lib/navigation/navigation-resolver", () => ({
   ) => {
     if (query.kind !== "post-retire") return { action: "allow" };
     if (state.hasAssistants) return { action: "redirect", to: "/assistant/onboarding/select-assistant" };
-    if (state.isAuthenticated || state.platformSession === "present") return { action: "redirect", to: "/assistant/onboarding/hosting" };
+    if (state.platformSession === "present" || (!state.isLocalMode && state.isAuthenticated)) return { action: "redirect", to: "/assistant/onboarding/hosting" };
     return { action: "redirect", to: "/assistant/onboarding/welcome" };
   },
 }));

--- a/apps/web/src/assistant/retire-service.test.ts
+++ b/apps/web/src/assistant/retire-service.test.ts
@@ -35,7 +35,10 @@ mock.module("@/lib/local-mode", () => ({
 }));
 
 mock.module("@/lib/navigation/navigation-resolver", () => ({
-  resolveNavigation: (state: any, query: any) => {
+  resolveNavigation: (
+    state: Record<string, unknown>,
+    query: { kind: string },
+  ) => {
     if (query.kind !== "post-retire") return { action: "allow" };
     if (state.hasAssistants) return { action: "redirect", to: "/assistant/onboarding/select-assistant" };
     if (state.isAuthenticated || state.platformSession === "present") return { action: "redirect", to: "/assistant/onboarding/hosting" };
@@ -43,7 +46,7 @@ mock.module("@/lib/navigation/navigation-resolver", () => ({
   },
 }));
 mock.module("@/lib/navigation/build-state", () => ({
-  buildNavigationState: (overrides?: any) => ({
+  buildNavigationState: (overrides?: Record<string, unknown>) => ({
     isLocalMode: isLocalModeValue,
     isAuthenticated: false,
     platformSession: "absent",

--- a/apps/web/src/assistant/retire-service.test.ts
+++ b/apps/web/src/assistant/retire-service.test.ts
@@ -11,7 +11,6 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 // --- mutable mock state (set per test) --- //
 
 let isLocalModeValue = false;
-let isNativeValue = false;
 let lockfileAssistants: Array<{ assistantId: string; cloud?: string }> = [];
 let retireByIdResult: { ok: true } | { ok: false; status: number; error: Record<string, unknown> } = { ok: true };
 let retireLocalResult: { ok: true } | { ok: false; error?: string } = { ok: true };
@@ -36,15 +35,20 @@ mock.module("@/lib/local-mode", () => ({
 }));
 
 mock.module("@/lib/navigation/navigation-resolver", () => ({
-  // "allow" → assistant route still reachable → service falls back to privacy.
-  resolveNavigation: () => ({ action: "allow" }),
+  resolveNavigation: (state: any, query: any) => {
+    if (query.kind !== "post-retire") return { action: "allow" };
+    if (state.hasAssistants) return { action: "redirect", to: "/assistant/onboarding/select-assistant" };
+    if (state.isAuthenticated || state.platformSession === "present") return { action: "redirect", to: "/assistant/onboarding/hosting" };
+    return { action: "redirect", to: "/assistant/onboarding/welcome" };
+  },
 }));
 mock.module("@/lib/navigation/build-state", () => ({
-  buildNavigationState: () => ({}),
-}));
-
-mock.module("@/runtime/native-auth", () => ({
-  isNativePlatform: () => isNativeValue,
+  buildNavigationState: (overrides?: any) => ({
+    isLocalMode: isLocalModeValue,
+    isAuthenticated: false,
+    platformSession: "absent",
+    ...overrides,
+  }),
 }));
 
 const clearOnboardingFlagsMock = mock(() => {});
@@ -56,6 +60,9 @@ mock.module("@/utils/routes", () => ({
   routes: {
     assistant: "/assistant",
     onboarding: {
+      welcome: "/assistant/onboarding/welcome",
+      selectAssistant: "/assistant/onboarding/select-assistant",
+      hosting: "/assistant/onboarding/hosting",
       prechat: "/assistant/onboarding/prechat",
       privacy: "/assistant/onboarding/privacy",
     },
@@ -66,7 +73,6 @@ const { retireAssistant } = await import("./retire-service");
 
 beforeEach(() => {
   isLocalModeValue = false;
-  isNativeValue = false;
   lockfileAssistants = [];
   retireByIdResult = { ok: true };
   retireLocalResult = { ok: true };
@@ -94,7 +100,7 @@ describe("retireAssistant", () => {
     expect(retireLocalAssistantMock).not.toHaveBeenCalled();
     expect(outcome.ok).toBe(true);
     if (outcome.ok) {
-      expect(outcome.nextRoute).toBe("/assistant/onboarding/privacy");
+      expect(outcome.nextRoute).toBe("/assistant/onboarding/welcome");
     }
     expect(clearOnboardingFlagsMock).toHaveBeenCalled();
   });
@@ -151,15 +157,30 @@ describe("retireAssistant", () => {
     expect(clearOnboardingFlagsMock).not.toHaveBeenCalled();
   });
 
-  test("native post-retire route is the pre-chat onboarding entry", async () => {
-    isNativeValue = true;
-    lockfileAssistants = [{ assistantId: "p1", cloud: "vellum" }];
+  test("post-retire redirects to select-assistant when other assistants remain", async () => {
+    isLocalModeValue = true;
+    lockfileAssistants = [
+      { assistantId: "l1", cloud: "local" },
+      { assistantId: "p1", cloud: "vellum" },
+    ];
 
-    const outcome = await retireAssistant("p1");
+    const outcome = await retireAssistant("l1");
 
     expect(outcome.ok).toBe(true);
     if (outcome.ok) {
-      expect(outcome.nextRoute).toBe("/assistant/onboarding/prechat");
+      expect(outcome.nextRoute).toBe("/assistant/onboarding/select-assistant");
+    }
+  });
+
+  test("post-retire redirects to welcome when no assistants and not logged in", async () => {
+    isLocalModeValue = true;
+    lockfileAssistants = [{ assistantId: "l1", cloud: "local" }];
+
+    const outcome = await retireAssistant("l1");
+
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.nextRoute).toBe("/assistant/onboarding/welcome");
     }
   });
 });

--- a/apps/web/src/assistant/retire-service.test.ts
+++ b/apps/web/src/assistant/retire-service.test.ts
@@ -40,8 +40,9 @@ mock.module("@/lib/navigation/navigation-resolver", () => ({
     query: { kind: string },
   ) => {
     if (query.kind !== "post-retire") return { action: "allow" };
-    if (state.hasAssistants) return { action: "redirect", to: "/assistant/onboarding/select-assistant" };
-    if (state.platformSession === "present" || (!state.isLocalMode && state.isAuthenticated)) return { action: "redirect", to: "/assistant/onboarding/hosting" };
+    if (state.hasAssistants) return { action: "redirect", to: state.isLocalMode ? "/assistant/onboarding/select-assistant" : "/assistant" };
+    if (!state.isLocalMode) return { action: "redirect", to: "/assistant/onboarding/privacy" };
+    if (state.platformSession === "present") return { action: "redirect", to: "/assistant/onboarding/hosting" };
     return { action: "redirect", to: "/assistant/onboarding/welcome" };
   },
 }));
@@ -103,7 +104,7 @@ describe("retireAssistant", () => {
     expect(retireLocalAssistantMock).not.toHaveBeenCalled();
     expect(outcome.ok).toBe(true);
     if (outcome.ok) {
-      expect(outcome.nextRoute).toBe("/assistant/onboarding/welcome");
+      expect(outcome.nextRoute).toBe("/assistant/onboarding/privacy");
     }
     expect(clearOnboardingFlagsMock).toHaveBeenCalled();
   });

--- a/apps/web/src/assistant/retire-service.test.ts
+++ b/apps/web/src/assistant/retire-service.test.ts
@@ -12,6 +12,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 let isLocalModeValue = false;
 let lockfileAssistants: Array<{ assistantId: string; cloud?: string }> = [];
+let storeAssistants: Array<{ id: string }> = [];
 let retireByIdResult: { ok: true } | { ok: false; status: number; error: Record<string, unknown> } = { ok: true };
 let retireLocalResult: { ok: true } | { ok: false; error?: string } = { ok: true };
 
@@ -47,12 +48,21 @@ mock.module("@/lib/navigation/navigation-resolver", () => ({
   },
 }));
 mock.module("@/lib/navigation/build-state", () => ({
-  buildNavigationState: (overrides?: Record<string, unknown>) => ({
+  buildNavigationState: () => ({
     isLocalMode: isLocalModeValue,
     isAuthenticated: false,
     platformSession: "absent",
-    ...overrides,
+    hasAssistants: storeAssistants.length > 0,
   }),
+}));
+
+const removeMock = mock((assistantId: string) => {
+  storeAssistants = storeAssistants.filter((a) => a.id !== assistantId);
+});
+mock.module("@/stores/resolved-assistants-store", () => ({
+  useResolvedAssistantsStore: {
+    getState: () => ({ remove: removeMock }),
+  },
 }));
 
 const clearOnboardingFlagsMock = mock(() => {});
@@ -78,6 +88,7 @@ const { retireAssistant } = await import("./retire-service");
 beforeEach(() => {
   isLocalModeValue = false;
   lockfileAssistants = [];
+  storeAssistants = [];
   retireByIdResult = { ok: true };
   retireLocalResult = { ok: true };
   retireAssistantByIdMock.mockClear();
@@ -85,6 +96,7 @@ beforeEach(() => {
   retireLocalAssistantMock.mockClear();
   syncPlatformAssistantsToLockfileMock.mockClear();
   clearOnboardingFlagsMock.mockClear();
+  removeMock.mockClear();
 });
 
 afterEach(() => {
@@ -95,6 +107,7 @@ describe("retireAssistant", () => {
   test("platform assistant routes through the platform delete by id", async () => {
     // GIVEN a platform-hosted target in web mode
     lockfileAssistants = [{ assistantId: "p1", cloud: "vellum" }];
+    storeAssistants = [{ id: "p1" }];
 
     // WHEN retiring it
     const outcome = await retireAssistant("p1");
@@ -113,6 +126,7 @@ describe("retireAssistant", () => {
     // GIVEN a local target in local mode
     isLocalModeValue = true;
     lockfileAssistants = [{ assistantId: "l1", cloud: "local" }];
+    storeAssistants = [{ id: "l1" }];
 
     // WHEN retiring it
     const outcome = await retireAssistant("l1");
@@ -127,6 +141,7 @@ describe("retireAssistant", () => {
     // GIVEN local mode but the *target* is a platform assistant
     isLocalModeValue = true;
     lockfileAssistants = [{ assistantId: "p1", cloud: "vellum" }];
+    storeAssistants = [{ id: "p1" }];
 
     // WHEN retiring the platform target
     const outcome = await retireAssistant("p1");
@@ -140,6 +155,7 @@ describe("retireAssistant", () => {
 
   test("a 404 from the platform delete is treated as success", async () => {
     lockfileAssistants = [{ assistantId: "p1", cloud: "vellum" }];
+    storeAssistants = [{ id: "p1" }];
     retireByIdResult = { ok: false, status: 404, error: {} };
 
     const outcome = await retireAssistant("p1");
@@ -150,6 +166,7 @@ describe("retireAssistant", () => {
 
   test("a non-404 platform failure surfaces the error detail", async () => {
     lockfileAssistants = [{ assistantId: "p1", cloud: "vellum" }];
+    storeAssistants = [{ id: "p1" }];
     retireByIdResult = { ok: false, status: 500, error: { detail: "boom" } };
 
     const outcome = await retireAssistant("p1");
@@ -167,6 +184,7 @@ describe("retireAssistant", () => {
       { assistantId: "l1", cloud: "local" },
       { assistantId: "p1", cloud: "vellum" },
     ];
+    storeAssistants = [{ id: "l1" }, { id: "p1" }];
 
     const outcome = await retireAssistant("l1");
 
@@ -179,6 +197,7 @@ describe("retireAssistant", () => {
   test("post-retire redirects to welcome when no assistants and not logged in", async () => {
     isLocalModeValue = true;
     lockfileAssistants = [{ assistantId: "l1", cloud: "local" }];
+    storeAssistants = [{ id: "l1" }];
 
     const outcome = await retireAssistant("l1");
 

--- a/apps/web/src/assistant/retire-service.ts
+++ b/apps/web/src/assistant/retire-service.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/local-mode";
 import { resolveNavigation } from "@/lib/navigation/navigation-resolver";
 import { buildNavigationState } from "@/lib/navigation/build-state";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { clearOnboardingFlags } from "@/utils/onboarding-cleanup";
 import { routes } from "@/utils/routes";
 
@@ -21,19 +22,14 @@ export type RetireOutcome =
   | { ok: false; error: string };
 
 /**
- * Resolve where to send the user after a retire. Computes remaining assistants
- * from the lockfile (excluding the just-retired one, in case the in-memory
- * cache hasn't flushed yet) and delegates to the navigation resolver's
- * post-retire query.
+ * Resolve where to send the user after a retire. Reads `hasAssistants`
+ * from the resolved assistants store (already updated via `remove()`
+ * before this runs) and delegates to the navigation resolver.
  */
-function getPostRetireRoute(assistantId: string): string {
-  const remaining = getLockfile().assistants.filter(
-    (a) => a.assistantId !== assistantId,
-  );
-  const decision = resolveNavigation(
-    buildNavigationState({ hasAssistants: remaining.length > 0 }),
-    { kind: "post-retire" },
-  );
+function getPostRetireRoute(): string {
+  const decision = resolveNavigation(buildNavigationState(), {
+    kind: "post-retire",
+  });
   return decision.action === "redirect"
     ? decision.to
     : routes.onboarding.welcome;
@@ -93,8 +89,9 @@ export async function retireAssistant(
       }
     }
 
+    useResolvedAssistantsStore.getState().remove(assistantId);
     clearOnboardingFlags();
-    return { ok: true, nextRoute: getPostRetireRoute(assistantId) };
+    return { ok: true, nextRoute: getPostRetireRoute() };
   } catch {
     return { ok: false, error: "Failed to retire assistant." };
   }

--- a/apps/web/src/assistant/retire-service.ts
+++ b/apps/web/src/assistant/retire-service.ts
@@ -8,7 +8,6 @@ import {
 } from "@/lib/local-mode";
 import { resolveNavigation } from "@/lib/navigation/navigation-resolver";
 import { buildNavigationState } from "@/lib/navigation/build-state";
-import { isNativePlatform } from "@/runtime/native-auth";
 import { clearOnboardingFlags } from "@/utils/onboarding-cleanup";
 import { routes } from "@/utils/routes";
 
@@ -22,20 +21,22 @@ export type RetireOutcome =
   | { ok: false; error: string };
 
 /**
- * Resolve where to send the user after a retire. Native always returns to the
- * pre-chat onboarding entry; web asks the navigation resolver whether the
- * assistant route is still reachable (it won't be when the active assistant was
- * retired) and falls back to the privacy step.
+ * Resolve where to send the user after a retire. Computes remaining assistants
+ * from the lockfile (excluding the just-retired one, in case the in-memory
+ * cache hasn't flushed yet) and delegates to the navigation resolver's
+ * post-retire query.
  */
-async function getPostRetireRoute(): Promise<string> {
-  if (isNativePlatform()) return routes.onboarding.prechat;
-  const decision = resolveNavigation(buildNavigationState(), {
-    kind: "route-guard",
-    pathname: routes.assistant,
-  });
+function getPostRetireRoute(assistantId: string): string {
+  const remaining = getLockfile().assistants.filter(
+    (a) => a.assistantId !== assistantId,
+  );
+  const decision = resolveNavigation(
+    buildNavigationState({ hasAssistants: remaining.length > 0 }),
+    { kind: "post-retire" },
+  );
   return decision.action === "redirect"
     ? decision.to
-    : routes.onboarding.privacy;
+    : routes.onboarding.welcome;
 }
 
 /**
@@ -93,7 +94,7 @@ export async function retireAssistant(
     }
 
     clearOnboardingFlags();
-    return { ok: true, nextRoute: await getPostRetireRoute() };
+    return { ok: true, nextRoute: getPostRetireRoute(assistantId) };
   } catch {
     return { ok: false, error: "Failed to retire assistant." };
   }

--- a/apps/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/apps/web/src/lib/navigation/navigation-resolver.test.ts
@@ -328,6 +328,46 @@ describe("resolveNavigation", () => {
   });
 
   // -----------------------------------------------------------------------
+  // post-retire
+  // -----------------------------------------------------------------------
+  describe("post-retire", () => {
+    const postRetire = (state: NavigationState) =>
+      resolveNavigation(state, { kind: "post-retire" });
+
+    test("redirects to select-assistant when other assistants remain", () => {
+      expect(postRetire(s({ hasAssistants: true }))).toEqual({
+        action: "redirect",
+        to: "/assistant/onboarding/select-assistant",
+      });
+    });
+
+    test("redirects to hosting when no assistants and authenticated", () => {
+      expect(postRetire(s({ hasAssistants: false, isAuthenticated: true }))).toEqual({
+        action: "redirect",
+        to: "/assistant/onboarding/hosting",
+      });
+    });
+
+    test("redirects to hosting when no assistants and platform session present", () => {
+      expect(
+        postRetire(s({ hasAssistants: false, isAuthenticated: false, platformSession: "present" })),
+      ).toEqual({
+        action: "redirect",
+        to: "/assistant/onboarding/hosting",
+      });
+    });
+
+    test("redirects to welcome when no assistants and not logged in", () => {
+      expect(
+        postRetire(s({ hasAssistants: false, isAuthenticated: false, platformSession: "absent" })),
+      ).toEqual({
+        action: "redirect",
+        to: "/assistant/onboarding/welcome",
+      });
+    });
+  });
+
+  // -----------------------------------------------------------------------
   // post-auth
   // -----------------------------------------------------------------------
   describe("post-auth", () => {

--- a/apps/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/apps/web/src/lib/navigation/navigation-resolver.test.ts
@@ -341,19 +341,30 @@ describe("resolveNavigation", () => {
       });
     });
 
-    test("redirects to hosting when no assistants and authenticated", () => {
-      expect(postRetire(s({ hasAssistants: false, isAuthenticated: true }))).toEqual({
+    test("redirects to hosting when no assistants and platform session present", () => {
+      expect(
+        postRetire(s({ hasAssistants: false, platformSession: "present" })),
+      ).toEqual({
         action: "redirect",
         to: "/assistant/onboarding/hosting",
       });
     });
 
-    test("redirects to hosting when no assistants and platform session present", () => {
+    test("redirects to hosting when no assistants and authenticated in non-local mode", () => {
       expect(
-        postRetire(s({ hasAssistants: false, isAuthenticated: false, platformSession: "present" })),
+        postRetire(s({ hasAssistants: false, isAuthenticated: true, isLocalMode: false })),
       ).toEqual({
         action: "redirect",
         to: "/assistant/onboarding/hosting",
+      });
+    });
+
+    test("redirects to welcome when local-mode gateway auth but no platform session", () => {
+      expect(
+        postRetire(s({ hasAssistants: false, isAuthenticated: true, isLocalMode: true, platformSession: "absent" })),
+      ).toEqual({
+        action: "redirect",
+        to: "/assistant/onboarding/welcome",
       });
     });
 

--- a/apps/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/apps/web/src/lib/navigation/navigation-resolver.test.ts
@@ -334,43 +334,39 @@ describe("resolveNavigation", () => {
     const postRetire = (state: NavigationState) =>
       resolveNavigation(state, { kind: "post-retire" });
 
-    test("redirects to select-assistant when other assistants remain", () => {
-      expect(postRetire(s({ hasAssistants: true }))).toEqual({
+    test("redirects to select-assistant in local mode when other assistants remain", () => {
+      expect(postRetire(s({ hasAssistants: true, isLocalMode: true }))).toEqual({
         action: "redirect",
         to: "/assistant/onboarding/select-assistant",
       });
     });
 
-    test("redirects to hosting when no assistants and platform session present", () => {
+    test("redirects to /assistant in platform mode when other assistants remain", () => {
+      expect(postRetire(s({ hasAssistants: true, isLocalMode: false }))).toEqual({
+        action: "redirect",
+        to: "/assistant",
+      });
+    });
+
+    test("redirects to privacy in platform mode when no assistants remain", () => {
+      expect(postRetire(s({ hasAssistants: false, isLocalMode: false }))).toEqual({
+        action: "redirect",
+        to: "/assistant/onboarding/privacy",
+      });
+    });
+
+    test("redirects to hosting in local mode when platform session present", () => {
       expect(
-        postRetire(s({ hasAssistants: false, platformSession: "present" })),
+        postRetire(s({ hasAssistants: false, isLocalMode: true, platformSession: "present" })),
       ).toEqual({
         action: "redirect",
         to: "/assistant/onboarding/hosting",
       });
     });
 
-    test("redirects to hosting when no assistants and authenticated in non-local mode", () => {
+    test("redirects to welcome in local mode when no platform session", () => {
       expect(
-        postRetire(s({ hasAssistants: false, isAuthenticated: true, isLocalMode: false })),
-      ).toEqual({
-        action: "redirect",
-        to: "/assistant/onboarding/hosting",
-      });
-    });
-
-    test("redirects to welcome when local-mode gateway auth but no platform session", () => {
-      expect(
-        postRetire(s({ hasAssistants: false, isAuthenticated: true, isLocalMode: true, platformSession: "absent" })),
-      ).toEqual({
-        action: "redirect",
-        to: "/assistant/onboarding/welcome",
-      });
-    });
-
-    test("redirects to welcome when no assistants and not logged in", () => {
-      expect(
-        postRetire(s({ hasAssistants: false, isAuthenticated: false, platformSession: "absent" })),
+        postRetire(s({ hasAssistants: false, isLocalMode: true, platformSession: "absent" })),
       ).toEqual({
         action: "redirect",
         to: "/assistant/onboarding/welcome",

--- a/apps/web/src/lib/navigation/navigation-resolver.ts
+++ b/apps/web/src/lib/navigation/navigation-resolver.ts
@@ -30,7 +30,8 @@ export type NavigationQuery =
       authIntent: "login" | "signup";
       returnTo: string | null;
       fallback: string;
-    };
+    }
+  | { kind: "post-retire" };
 
 // ---------------------------------------------------------------------------
 // Decision — what the caller should do
@@ -94,6 +95,8 @@ export function resolveNavigation(
       return resolveHatchGate(state);
     case "post-auth":
       return resolvePostAuth(query.authIntent, query.returnTo, query.fallback);
+    case "post-retire":
+      return resolvePostRetire(state);
   }
 }
 
@@ -212,5 +215,19 @@ function resolvePostAuth(
     return { action: "redirect", to: routes.onboarding.privacy };
   }
   return { action: "redirect", to: sanitizeReturnTo(returnTo, fallback) };
+}
+
+// ---------------------------------------------------------------------------
+// post-retire
+// ---------------------------------------------------------------------------
+
+function resolvePostRetire(state: NavigationState): NavigationDecision {
+  if (state.hasAssistants) {
+    return { action: "redirect", to: routes.onboarding.selectAssistant };
+  }
+  if (state.isAuthenticated || state.platformSession === "present") {
+    return { action: "redirect", to: routes.onboarding.hosting };
+  }
+  return { action: "redirect", to: routes.onboarding.welcome };
 }
 

--- a/apps/web/src/lib/navigation/navigation-resolver.ts
+++ b/apps/web/src/lib/navigation/navigation-resolver.ts
@@ -223,11 +223,17 @@ function resolvePostAuth(
 
 function resolvePostRetire(state: NavigationState): NavigationDecision {
   if (state.hasAssistants) {
-    return { action: "redirect", to: routes.onboarding.selectAssistant };
+    // select-assistant is local-only; platform users go straight to /assistant
+    // where the app picks up the next available assistant.
+    return {
+      action: "redirect",
+      to: state.isLocalMode ? routes.onboarding.selectAssistant : routes.assistant,
+    };
   }
-  // In local mode, gateway auth sets isAuthenticated without a platform login,
-  // so only platformSession is a reliable signal for "logged into the platform".
-  if (state.platformSession === "present" || (!state.isLocalMode && state.isAuthenticated)) {
+  if (!state.isLocalMode) {
+    return { action: "redirect", to: routes.onboarding.privacy };
+  }
+  if (state.platformSession === "present") {
     return { action: "redirect", to: routes.onboarding.hosting };
   }
   return { action: "redirect", to: routes.onboarding.welcome };

--- a/apps/web/src/lib/navigation/navigation-resolver.ts
+++ b/apps/web/src/lib/navigation/navigation-resolver.ts
@@ -225,7 +225,9 @@ function resolvePostRetire(state: NavigationState): NavigationDecision {
   if (state.hasAssistants) {
     return { action: "redirect", to: routes.onboarding.selectAssistant };
   }
-  if (state.isAuthenticated || state.platformSession === "present") {
+  // In local mode, gateway auth sets isAuthenticated without a platform login,
+  // so only platformSession is a reliable signal for "logged into the platform".
+  if (state.platformSession === "present" || (!state.isLocalMode && state.isAuthenticated)) {
     return { action: "redirect", to: routes.onboarding.hosting };
   }
   return { action: "redirect", to: routes.onboarding.welcome };

--- a/apps/web/src/stores/resolved-assistants-store.ts
+++ b/apps/web/src/stores/resolved-assistants-store.ts
@@ -100,6 +100,7 @@ interface ResolvedAssistantsState {
 interface ResolvedAssistantsActions {
   setFromLockfile: (lockfile: Lockfile) => void;
   setFromApi: (assistants: Assistant[]) => void;
+  remove: (assistantId: string) => void;
   clear: () => void;
   setActiveAssistantId: (assistantId: string | null) => void;
   setSelectedPlatformAssistant: (orgId: string, id: string | null) => void;
@@ -131,6 +132,11 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
           isLocal: a.is_local,
         })),
       }),
+
+    remove: (assistantId) =>
+      set((state) => ({
+        assistants: state.assistants.filter((a) => a.id !== assistantId),
+      })),
 
     clear: () => set({ assistants: [] }),
 


### PR DESCRIPTION
## Summary
- Add `post-retire` query kind to the navigation resolver with three-way routing: select-assistant (has remaining assistants), hosting (logged into platform), or welcome (not logged in)
- Replace the `isNativePlatform()` short-circuit in the retire service that always sent native users to pre-chat onboarding, regardless of remaining assistants
- Retire service now computes remaining assistants from the lockfile (excluding the just-retired one) and delegates routing entirely to the resolver

## Original prompt
When a user retires their active assistant in the native macOS app while having other assistants available, they should be redirected to the "Choose an Assistant" screen instead of being dumped into the beginning of onboarding. The previous behavior unconditionally routed native users to pre-chat onboarding after any retire. The fix adds a dedicated `post-retire` query to the navigation resolver so the routing logic is centralized and testable, with three cases: other assistants remain → select-assistant, no assistants + logged in → hosting, no assistants + not logged in → welcome.