### PR TITLE
fix(web): prevent 404 when fetching draft conversation after onboarding

### DIFF
--- a/apps/web/src/contacts-page-route.tsx
+++ b/apps/web/src/contacts-page-route.tsx
@@ -1,14 +1,15 @@
 import { useNavigate } from "react-router";
+import { useQueryClient } from "@tanstack/react-query";
 
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
-import { createDraftConversationId } from "@/domains/chat/utils/conversation-selection";
-import { useConversationStore } from "@/stores/conversation-store";
+import { startDraftConversation } from "@/domains/chat/utils/conversation-selection";
 import { ContactsPage } from "@/domains/contacts/contacts-page";
 import { useViewerStore } from "@/stores/viewer-store";
 import { routes } from "@/utils/routes";
 
 export function ContactsPageRoute() {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const assistantId = useActiveAssistantId();
 
   return (
@@ -17,8 +18,7 @@ export function ContactsPageRoute() {
       assistantId={assistantId}
       onStartSetupConversation={(prompt) => {
         useViewerStore.getState().setMainView("chat");
-        const draftConversationId = createDraftConversationId();
-        useConversationStore.getState().setActiveConversationId(draftConversationId);
+        const draftConversationId = startDraftConversation(queryClient, assistantId);
         void navigate(
           `${routes.conversation(draftConversationId)}?prompt=${encodeURIComponent(prompt)}`,
         );

--- a/apps/web/src/domains/chat/active-chat-view.tsx
+++ b/apps/web/src/domains/chat/active-chat-view.tsx
@@ -157,7 +157,7 @@ export function ActiveChatView() {
     onboardingConversationId,
     pendingOnboardingContextRef,
     onboardingDraftConversationIdRef,
-  } = useOnboardingOrchestrator();
+  } = useOnboardingOrchestrator(assistantId);
 
   // -------------------------------------------------------------------------
   // Reachability

--- a/apps/web/src/domains/chat/chat-layout.tsx
+++ b/apps/web/src/domains/chat/chat-layout.tsx
@@ -61,7 +61,7 @@ import { ConversationActionsMenu } from "@/domains/chat/components/conversation-
 import { PreferencesMenu } from "@/domains/chat/components/preferences-menu";
 import { useCommandPaletteOrchestrator } from "@/domains/chat/hooks/use-command-palette-orchestrator";
 import { isChannelConversation } from "@/domains/chat/utils/conversation-channel";
-import { createDraftConversationId } from "@/domains/chat/utils/conversation-selection";
+import { startDraftConversation } from "@/domains/chat/utils/conversation-selection";
 import { buildMoveToGroupTargets } from "@/domains/chat/utils/group-conversations";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import { ChatLayoutHeader } from "./chat-layout-header";
@@ -161,6 +161,7 @@ interface SideMenuRenderArgs {
 export function ChatLayout() {
   const navigate = useNavigate();
   const location = useLocation();
+  const queryClient = useQueryClient();
 
   // Capture pop-out mode once at mount so it persists across in-window
   // navigations (e.g. conversation switching via Cmd+Up/Down). ChatLayout is a
@@ -271,11 +272,10 @@ export function ChatLayout() {
   const handleStartNewConversation = useCallback(() => {
     haptic.light();
     useViewerStore.getState().setMainView("chat");
-    const draftConversationId = createDraftConversationId();
-    useConversationStore.getState().setActiveConversationId(draftConversationId);
+    const draftConversationId = startDraftConversation(queryClient, assistantId);
     void navigate(routes.conversation(draftConversationId));
     requestComposerFocus();
-  }, [navigate]);
+  }, [navigate, assistantId, queryClient]);
 
   const handleOpenHome = useCallback(() => {
     navigate(routes.home);
@@ -470,12 +470,11 @@ export function ChatLayout() {
     ({ silent }: { silent?: boolean } = {}) => {
       if (!silent) haptic.light();
       useViewerStore.getState().setMainView("chat");
-      const draftConversationId = createDraftConversationId();
-      useConversationStore.getState().setActiveConversationId(draftConversationId);
+      const draftConversationId = startDraftConversation(queryClient, assistantId);
       void navigate(routes.conversation(draftConversationId));
       requestComposerFocus();
     },
-    [navigate],
+    [navigate, assistantId, queryClient],
   );
 
   const {
@@ -882,6 +881,7 @@ function RenameDialogFromStore({ assistantId }: { assistantId: string | null }) 
 // ---------------------------------------------------------------------------
 
 function ChatConversationHeader() {
+  const queryClient = useQueryClient();
   const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
   const activeConversationId = useConversationStore.use.activeConversationId();
   const assistantState = useAssistantLifecycleStore.use.assistantState();
@@ -921,12 +921,11 @@ function ChatConversationHeader() {
       if (!silent) haptic.light();
       useViewerStore.getState().setMainView("chat");
       useSubagentStore.getState().reset();
-      const draftId = createDraftConversationId();
-      useConversationStore.getState().setActiveConversationId(draftId);
+      const draftId = startDraftConversation(queryClient, assistantId);
       void navigate(routes.conversation(draftId));
       requestComposerFocus();
     },
-    [navigate],
+    [navigate, assistantId, queryClient],
   );
 
   const prePinGroupIdsRef = useRef<Map<string, string | undefined>>(new Map());

--- a/apps/web/src/domains/chat/hooks/use-conversation-loader.ts
+++ b/apps/web/src/domains/chat/hooks/use-conversation-loader.ts
@@ -39,6 +39,7 @@ import { conversationGroupsQueryKey } from "@/lib/sync/query-tags";
 import type { Conversation } from "@/types/conversation-types";
 import { ApiError } from "@/utils/api-errors";
 import { invalidateConversationQueries } from "@/utils/conversation-cache";
+import { prependConversation } from "@/utils/conversation-cache-mutations";
 import { isBackgroundConversation } from "@/utils/conversation-predicates";
 
 // ---------------------------------------------------------------------------
@@ -432,10 +433,15 @@ export function useConversationLoader({
       useViewerStore.getState().setMainView("chat");
       const draftConversationId = createDraftConversationId();
       useConversationStore.getState().setActiveConversationId(draftConversationId);
+      prependConversation(queryClient, assistantId, {
+        conversationId: draftConversationId,
+        lastMessageAt: Date.now(),
+        draft: true,
+      } as Conversation);
       void navigate(routes.conversation(draftConversationId));
       requestComposerFocus();
     },
-    [navigate],
+    [navigate, assistantId, queryClient],
   );
 
   return {

--- a/apps/web/src/domains/chat/hooks/use-conversation-loader.ts
+++ b/apps/web/src/domains/chat/hooks/use-conversation-loader.ts
@@ -14,6 +14,7 @@ import {
 import {
     createDraftConversationId,
     resolveBootstrappedConversationId,
+    startDraftConversation,
 } from "@/domains/chat/utils/conversation-selection";
 import {
     loadLastViewedConversationId,
@@ -39,7 +40,6 @@ import { conversationGroupsQueryKey } from "@/lib/sync/query-tags";
 import type { Conversation } from "@/types/conversation-types";
 import { ApiError } from "@/utils/api-errors";
 import { invalidateConversationQueries } from "@/utils/conversation-cache";
-import { prependConversation } from "@/utils/conversation-cache-mutations";
 import { isBackgroundConversation } from "@/utils/conversation-predicates";
 
 // ---------------------------------------------------------------------------
@@ -431,13 +431,7 @@ export function useConversationLoader({
       if (!silent) haptic.light();
       useSubagentStore.getState().reset();
       useViewerStore.getState().setMainView("chat");
-      const draftConversationId = createDraftConversationId();
-      useConversationStore.getState().setActiveConversationId(draftConversationId);
-      prependConversation(queryClient, assistantId, {
-        conversationId: draftConversationId,
-        lastMessageAt: Date.now(),
-        draft: true,
-      } as Conversation);
+      const draftConversationId = startDraftConversation(queryClient, assistantId);
       void navigate(routes.conversation(draftConversationId));
       requestComposerFocus();
     },

--- a/apps/web/src/domains/chat/hooks/use-onboarding-orchestrator.ts
+++ b/apps/web/src/domains/chat/hooks/use-onboarding-orchestrator.ts
@@ -22,10 +22,13 @@
 
 import { type MutableRefObject, useEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router";
+import { useQueryClient } from "@tanstack/react-query";
 
 import { useConversationStore } from "@/stores/conversation-store";
 import { type PreChatOnboardingContext } from "@/domains/onboarding/prechat";
 import { createDraftConversationId } from "@/domains/chat/utils/conversation-selection";
+import { prependConversation } from "@/utils/conversation-cache-mutations";
+import type { Conversation } from "@/types/conversation-types";
 import { routes } from "@/utils/routes";
 
 export interface UseOnboardingOrchestratorResult {
@@ -41,8 +44,11 @@ export interface UseOnboardingOrchestratorResult {
   onboardingDraftConversationIdRef: MutableRefObject<string | null>;
 }
 
-export function useOnboardingOrchestrator(): UseOnboardingOrchestratorResult {
+export function useOnboardingOrchestrator(
+  assistantId: string | null,
+): UseOnboardingOrchestratorResult {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const [searchParams] = useSearchParams();
 
   const pendingOnboardingContextRef = useRef<PreChatOnboardingContext | null>(null);
@@ -65,8 +71,15 @@ export function useOnboardingOrchestrator(): UseOnboardingOrchestratorResult {
     onboardingDraftConversationIdRef.current = draftId;
     setOnboardingConversationId(draftId);
     useConversationStore.getState().setActiveConversationId(draftId);
+    if (assistantId) {
+      prependConversation(queryClient, assistantId, {
+        conversationId: draftId,
+        lastMessageAt: Date.now(),
+        draft: true,
+      } as Conversation);
+    }
     void navigate(routes.conversation(draftId), { replace: true });
-  }, [searchParams, navigate]);
+  }, [searchParams, navigate, assistantId, queryClient]);
 
   // Derive onboardingTasksEmpty from the pending context in sessionStorage.
   // Runs once on mount — if initial message key is present, this is an

--- a/apps/web/src/domains/chat/hooks/use-send-message.ts
+++ b/apps/web/src/domains/chat/hooks/use-send-message.ts
@@ -695,6 +695,8 @@ export function useSendMessage({
             useConversationStore.getState().setActiveConversationId(newConversationId);
             void navigate(routes.conversation(newConversationId), { replace: true });
           }
+        } else if (isDraft) {
+          patchConversation(queryClient, assistantId, activeConversationId, { draft: false });
         }
 
         void refreshConversations();

--- a/apps/web/src/domains/chat/hooks/use-send-message.ts
+++ b/apps/web/src/domains/chat/hooks/use-send-message.ts
@@ -618,7 +618,7 @@ export function useSendMessage({
 
       cancelReconciliation();
 
-      const isDraft = !currentConv;
+      const isDraft = !currentConv || currentConv.draft === true;
       let resolvedId: string | undefined;
 
       try {

--- a/apps/web/src/domains/chat/utils/conversation-selection.ts
+++ b/apps/web/src/domains/chat/utils/conversation-selection.ts
@@ -1,4 +1,8 @@
+import type { QueryClient } from "@tanstack/react-query";
+
 import type { Conversation } from "@/types/conversation-types";
+import { useConversationStore } from "@/stores/conversation-store";
+import { prependConversation } from "@/utils/conversation-cache-mutations";
 
 interface ResolveBootstrappedConversationIdArgs {
   queryParamKey: string | null;
@@ -21,6 +25,25 @@ export function createDraftConversationId(): string {
       // cases (older Safari / non-secure context) so draft creation does not
       // hard-crash.
       `draft-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+/**
+ * Create a local draft conversation: generate an ID, set it as active in
+ * the store, and seed a `draft: true` stub in the foreground list cache so
+ * `useActiveConversation` never fires a server fetch for it.
+ */
+export function startDraftConversation(
+  queryClient: QueryClient,
+  assistantId: string | null,
+): string {
+  const id = createDraftConversationId();
+  useConversationStore.getState().setActiveConversationId(id);
+  prependConversation(queryClient, assistantId, {
+    conversationId: id,
+    lastMessageAt: Date.now(),
+    draft: true,
+  } as Conversation);
+  return id;
 }
 
 function isStoredConversationSelectable(

--- a/apps/web/src/home-page-route.tsx
+++ b/apps/web/src/home-page-route.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useMemo } from "react";
 import { useNavigate } from "react-router";
+import { useQueryClient } from "@tanstack/react-query";
 
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { useChatLayoutSlotsStore } from "@/components/layout/chat-layout-slots-store";
 import { requestComposerFocus } from "@/domains/chat/composer-focus";
-import { createDraftConversationId } from "@/domains/chat/utils/conversation-selection";
+import { startDraftConversation } from "@/domains/chat/utils/conversation-selection";
 import { HomePage } from "@/domains/home/home-page";
 import {
     useBackgroundConversationListQuery,
@@ -12,7 +13,6 @@ import {
     useScheduledConversationListQuery,
 } from "@/hooks/conversation-queries";
 import { useIsMobile } from "@/hooks/use-is-mobile";
-import { useConversationStore } from "@/stores/conversation-store";
 import { useViewerStore } from "@/stores/viewer-store";
 import { mergeConversationLists } from "@/utils/conversation-cache";
 import { routes } from "@/utils/routes";
@@ -20,6 +20,7 @@ import { Typography } from "@vellumai/design-library";
 
 export function HomePageRoute() {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const assistantId = useActiveAssistantId();
   const setTopBarCenter = useChatLayoutSlotsStore.use.setTopBarCenter();
   const isMobile = useIsMobile();
@@ -66,8 +67,7 @@ export function HomePageRoute() {
       validConversationIds={validConversationIds}
       onStartNewChat={() => {
         useViewerStore.getState().setMainView("chat");
-        const draftConversationId = createDraftConversationId();
-        useConversationStore.getState().setActiveConversationId(draftConversationId);
+        const draftConversationId = startDraftConversation(queryClient, assistantId);
         navigate(routes.conversation(draftConversationId));
         requestComposerFocus();
       }}
@@ -76,8 +76,7 @@ export function HomePageRoute() {
       }
       onSuggestionSelected={(prompt) => {
         useViewerStore.getState().setMainView("chat");
-        const draftConversationId = createDraftConversationId();
-        useConversationStore.getState().setActiveConversationId(draftConversationId);
+        const draftConversationId = startDraftConversation(queryClient, assistantId);
         navigate(
           `${routes.conversation(draftConversationId)}?prompt=${encodeURIComponent(prompt)}`,
         );

--- a/apps/web/src/identity-page-route.tsx
+++ b/apps/web/src/identity-page-route.tsx
@@ -1,14 +1,15 @@
 import { useNavigate } from "react-router";
+import { useQueryClient } from "@tanstack/react-query";
 
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
-import { createDraftConversationId } from "@/domains/chat/utils/conversation-selection";
-import { useConversationStore } from "@/stores/conversation-store";
+import { startDraftConversation } from "@/domains/chat/utils/conversation-selection";
 import { IdentityPage } from "@/domains/intelligence/identity-page";
 import { useViewerStore } from "@/stores/viewer-store";
 import { routes } from "@/utils/routes";
 
 export function IdentityPageRoute() {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const assistantId = useActiveAssistantId();
 
   return (
@@ -16,8 +17,7 @@ export function IdentityPageRoute() {
       key={assistantId}
       onOpenThread={(message) => {
         useViewerStore.getState().setMainView("chat");
-        const draftConversationId = createDraftConversationId();
-        useConversationStore.getState().setActiveConversationId(draftConversationId);
+        const draftConversationId = startDraftConversation(queryClient, assistantId);
         void navigate(
           `${routes.conversation(draftConversationId)}?prompt=${encodeURIComponent(message)}`,
         );

--- a/apps/web/src/root-layout.tsx
+++ b/apps/web/src/root-layout.tsx
@@ -1,5 +1,6 @@
 import { lazy, useState } from "react";
 import { Outlet, useNavigate } from "react-router";
+import { useQueryClient } from "@tanstack/react-query";
 
 import { LazyBoundary } from "@/components/lazy-boundary";
 import { useAppTheme } from "@/hooks/use-app-theme";
@@ -31,7 +32,7 @@ import { useAssistantFeatureFlagSync } from "@/hooks/use-assistant-feature-flag-
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import { useConversationStore } from "@/stores/conversation-store";
-import { createDraftConversationId } from "@/domains/chat/utils/conversation-selection";
+import { startDraftConversation } from "@/domains/chat/utils/conversation-selection";
 import { useViewerStore } from "@/stores/viewer-store";
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 import { useDynamicFavicon } from "@/hooks/use-dynamic-favicon";
@@ -86,6 +87,7 @@ export function RootLayout() {
   const visibleViewport = useVisibleViewport();
 
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const sessionStatus = useAuthStore.use.sessionStatus();
   const isSessionInitializing = useIsSessionInitializing();
   const hasPlatformSession = useHasPlatformSession();
@@ -184,8 +186,7 @@ export function RootLayout() {
       if (command.kind !== "quickInputSubmit") {
         return;
       }
-      const draftId = createDraftConversationId();
-      useConversationStore.getState().setActiveConversationId(draftId);
+      const draftId = startDraftConversation(queryClient, assistantId);
       useViewerStore.getState().setMainView("chat");
       void navigate(
         `${routes.conversation(draftId)}?prompt=${encodeURIComponent(command.message)}`,

--- a/apps/web/src/utils/conversation-list-fetchers.ts
+++ b/apps/web/src/utils/conversation-list-fetchers.ts
@@ -251,6 +251,17 @@ export function conversationListOptions(assistantId: string) {
     queryKey: conversationsQueryKey(assistantId),
     queryFn: () => listConversations(assistantId),
     staleTime: QUERY_STALE_TIME_MS,
+    structuralSharing(oldData, newData) {
+      if (!oldData || !Array.isArray(oldData) || !Array.isArray(newData)) {
+        return newData;
+      }
+      const drafts = (oldData as Conversation[]).filter((c) => c.draft);
+      if (drafts.length === 0) return newData;
+      const newIds = new Set((newData as Conversation[]).map((c) => c.conversationId));
+      const surviving = drafts.filter((d) => !newIds.has(d.conversationId));
+      if (surviving.length === 0) return newData;
+      return [...surviving, ...(newData as Conversation[])];
+    },
   });
 }
 


### PR DESCRIPTION
## Summary
- Prepend a `draft: true` conversation stub to the TanStack Query cache at the moment a local draft ID is created (in the onboarding orchestrator and `startNewConversation`), so that `useActiveConversation` finds it in the cache and skips the server fetch that would 404.
- Update `isDraft` detection in `useSendMessage` to check `currentConv.draft === true` (not just `!currentConv`), since the stub is now prepended before the first message is sent.

## Original prompt
After initial onboarding, the web app fetches `/v1/assistants/{id}/conversations/{draftId}` which 404s because the conversation is a locally-generated draft that doesn't exist on the server until the first message is sent. The race condition exists because `useActiveConversation` fires a server fetch for any conversation ID not found in the list caches — but local drafts are never in those caches until much later. The fix seeds the cache with a `draft: true` stub immediately so the fetch is short-circuited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)