### PR TITLE
fix(web): redirect platform-mode users to onboarding when consent is missing

### DIFF
--- a/apps/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/apps/web/src/lib/navigation/navigation-resolver.test.ts
@@ -209,6 +209,26 @@ describe("resolveNavigation", () => {
       expect(guard(s({ isLocalMode: true, hasAssistants: true }))).toEqual(ALLOW);
     });
 
+    // -- authenticated, platform mode, not onboarded ----------------------
+
+    test("redirects platform-mode user without consent to privacy", () => {
+      expect(
+        guard(s({ isLocalMode: false, tosAccepted: false, aiDataConsent: false })),
+      ).toEqual({ action: "redirect", to: "/assistant/onboarding/privacy" });
+    });
+
+    test("redirects platform-mode user with partial consent to privacy", () => {
+      expect(
+        guard(s({ isLocalMode: false, tosAccepted: true, aiDataConsent: false })),
+      ).toEqual({ action: "redirect", to: "/assistant/onboarding/privacy" });
+    });
+
+    test("does not redirect local-mode user without consent (handled by step 5)", () => {
+      expect(
+        guard(s({ isLocalMode: true, hasAssistants: true, tosAccepted: false, aiDataConsent: false })),
+      ).toEqual(ALLOW);
+    });
+
     // -- normal authenticated access --------------------------------------
 
     test("allows authenticated user on normal route", () => {

--- a/apps/web/src/lib/navigation/navigation-resolver.ts
+++ b/apps/web/src/lib/navigation/navigation-resolver.ts
@@ -159,7 +159,12 @@ function resolveRouteGuard(
     return { action: "redirect", to: routes.onboarding.welcome };
   }
 
-  // 6. All clear
+  // 6. Authenticated, platform mode, onboarding not completed
+  if (!state.isLocalMode && !(state.tosAccepted && state.aiDataConsent)) {
+    return { action: "redirect", to: routes.onboarding.privacy };
+  }
+
+  // 7. All clear
   return { action: "allow" };
 }
 


### PR DESCRIPTION
## Summary
- Add a route guard check that redirects authenticated platform-mode users to `/onboarding/privacy` when ToS or AI data consent hasn't been accepted
- Previously, new users signing up through `vellum.ai` could briefly see the main app ("Connecting...") before the lifecycle service's delayed `auto_hatch` redirect fired
- The new guard catches this at the middleware level, eliminating the flash

## Test plan
- [ ] Sign up as a new user on `vellum.ai` (platform mode) — should go directly to `/onboarding/privacy`, no "Connecting..." flash
- [ ] Existing users with consent accepted should not be affected — normal `/assistant` access works
- [ ] Local-mode users with existing assistants are unaffected (consent not enforced at route level)
- [ ] Verify onboarding screens (privacy, prechat, hatching) remain accessible for platform users

## Original prompt
A new user signing up through `www.vellum.ai` (platform mode) reported seeing the main assistant UI with "Connecting..." instead of being routed to onboarding. On page refresh they'd correctly land on `/onboarding/*`. The root cause was that the route guard had no consent check for authenticated platform-mode users — it fell straight through to "All clear". The lifecycle service's `auto_hatch` → `resolveOnboardingRedirect` path acted as a safety net but required a round-trip API call, creating a visible delay. The fix adds the consent check directly to the route guard so it fires at the middleware level before any page renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)