### PR TITLE
feat(memory-v3): add section model + section-index builder

### DIFF
--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/sections.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/sections.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "bun:test";
+
+import { buildSectionIndex, SECTION_CHUNK_CHARS } from "../sections.js";
+import type { Slug } from "../types.js";
+
+/** Build a page-body reader from a fixture map. */
+function reader(pages: Record<string, string>) {
+  return async (slug: Slug): Promise<string> => pages[slug] ?? "";
+}
+
+describe("buildSectionIndex", () => {
+  test("lead + two ## sections yield 3 ordered sections with titles", async () => {
+    const body = [
+      "Lead paragraph before any heading.",
+      "",
+      "## First Heading",
+      "first body line",
+      "",
+      "## Second Heading",
+      "second body line",
+    ].join("\n");
+
+    const index = await buildSectionIndex(
+      ["page-a"],
+      reader({ "page-a": body }),
+    );
+
+    expect(index.sections).toHaveLength(3);
+
+    expect(index.sections[0]!.ordinal).toBe(0);
+    expect(index.sections[0]!.title).toBe("");
+    expect(index.sections[0]!.text).toContain("page-a — ");
+    expect(index.sections[0]!.text).toContain("Lead paragraph");
+
+    expect(index.sections[1]!.ordinal).toBe(1);
+    expect(index.sections[1]!.title).toBe("First Heading");
+    expect(index.sections[1]!.text).toContain("page-a — First Heading");
+    expect(index.sections[1]!.text).toContain("first body line");
+
+    expect(index.sections[2]!.ordinal).toBe(2);
+    expect(index.sections[2]!.title).toBe("Second Heading");
+    expect(index.sections[2]!.text).toContain("second body line");
+  });
+
+  test("section over the chunk cap splits into ordered chunks", async () => {
+    const big = "x".repeat(SECTION_CHUNK_CHARS * 2 + 100);
+    const body = `## Big Section\n${big}`;
+
+    const index = await buildSectionIndex(
+      ["topic-x"],
+      reader({ "topic-x": body }),
+    );
+
+    // Lead (empty) + the chunked big section.
+    const bigChunks = index.sections.filter((s) => s.title === "Big Section");
+    expect(bigChunks.length).toBeGreaterThan(1);
+
+    // Every chunk fits the embedding window.
+    for (const section of index.sections) {
+      expect(section.text.length).toBeLessThanOrEqual(SECTION_CHUNK_CHARS);
+    }
+
+    // Ordinals are strictly increasing in array order (chunks ordered).
+    for (let i = 1; i < index.sections.length; i++) {
+      expect(index.sections[i]!.ordinal).toBe(
+        index.sections[i - 1]!.ordinal + 1,
+      );
+    }
+  });
+
+  test("byArticle maps each article to its section indices", async () => {
+    const index = await buildSectionIndex(
+      ["page-a", "topic-x"],
+      reader({
+        "page-a": "lead a\n\n## Sec A\nbody a",
+        "topic-x": "lead x",
+      }),
+    );
+
+    expect([...index.byArticle.keys()].sort()).toEqual(["page-a", "topic-x"]);
+
+    for (const [article, indices] of index.byArticle) {
+      for (const i of indices) {
+        expect(index.sections[i]!.article).toBe(article);
+      }
+    }
+
+    // page-a has lead + one heading section; topic-x is headingless (lead only).
+    expect(index.byArticle.get("page-a")).toHaveLength(2);
+    expect(index.byArticle.get("topic-x")).toHaveLength(1);
+  });
+
+  test("empty / headingless page yields a single ordinal-0 section", async () => {
+    const empty = await buildSectionIndex(["page-a"], reader({ "page-a": "" }));
+    expect(empty.sections).toHaveLength(1);
+    expect(empty.sections[0]!.ordinal).toBe(0);
+    expect(empty.sections[0]!.title).toBe("");
+
+    const headingless = await buildSectionIndex(
+      ["topic-x"],
+      reader({ "topic-x": "just a paragraph\nand another line" }),
+    );
+    expect(headingless.sections).toHaveLength(1);
+    expect(headingless.sections[0]!.ordinal).toBe(0);
+    expect(headingless.sections[0]!.text).toContain("just a paragraph");
+  });
+
+  test("sections are deterministic, sorted by (article, ordinal)", async () => {
+    const pages = {
+      "topic-x": "lead x\n\n## X1\nbody",
+      "page-a": "lead a\n\n## A1\nbody",
+    };
+    const first = await buildSectionIndex(["topic-x", "page-a"], reader(pages));
+    const second = await buildSectionIndex(
+      ["page-a", "topic-x"],
+      reader(pages),
+    );
+
+    const shape = (s: { article: Slug; ordinal: number }) =>
+      `${s.article}#${s.ordinal}`;
+    expect(first.sections.map(shape)).toEqual(second.sections.map(shape));
+    // page-a sorts before topic-x regardless of input order.
+    expect(first.sections[0]!.article).toBe("page-a");
+  });
+});

--- a/assistant/src/plugins/defaults/memory-v3-shadow/sections.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/sections.ts
@@ -1,0 +1,115 @@
+import type { Section, SectionIndex, Slug } from "./types.js";
+
+/**
+ * Section-grain index builder for memory-v3 lane retrieval.
+ *
+ * Splits each page body into sections at `## ` headings — text before the
+ * first heading is the page lead (ordinal 0) — and emits a flat, deterministic
+ * `SectionIndex`. Over-long sections are chunked so each `Section.text` fits a
+ * typical embedding window. The function is pure: it does no I/O of its own
+ * (the caller supplies `pageBody`), no LLM calls, and no Qdrant/daemon wiring.
+ */
+
+/**
+ * Max `Section.text` length in characters. Sections longer than this are split
+ * into multiple ordered `Section`s sharing the same `(article, ordinal)` so the
+ * embedding backend never receives an over-window input.
+ */
+export const SECTION_CHUNK_CHARS = 6000;
+
+/** Last `/`- or `.`-delimited segment of a slug (used for the head line). */
+function lastSlugSegment(slug: Slug): string {
+  const segments = slug.split(/[/.]/);
+  return segments[segments.length - 1] ?? slug;
+}
+
+interface RawSection {
+  title: string;
+  body: string;
+}
+
+/**
+ * Split a frontmatter-stripped markdown body into raw sections. The text before
+ * the first `## ` heading is the lead (title `""`); each subsequent `## `
+ * heading starts a new section whose title is the heading text.
+ */
+function splitIntoRawSections(body: string): RawSection[] {
+  // Always seed a lead section (title `""`). The lead may stay empty, so a
+  // headingless or empty page still yields a single ordinal-0 section.
+  const sections: { title: string; lines: string[] }[] = [
+    { title: "", lines: [] },
+  ];
+
+  for (const line of body.split("\n")) {
+    const heading = /^## (.*)$/.exec(line);
+    if (heading) {
+      sections.push({ title: heading[1]!.trim(), lines: [] });
+    } else {
+      sections[sections.length - 1]!.lines.push(line);
+    }
+  }
+
+  return sections.map((s) => ({ title: s.title, body: s.lines.join("\n") }));
+}
+
+/**
+ * Split `text` into chunks no longer than `SECTION_CHUNK_CHARS`, preferring to
+ * break on newlines so chunks stay readable. Order is preserved.
+ */
+function chunkText(text: string): string[] {
+  if (text.length <= SECTION_CHUNK_CHARS) return [text];
+
+  const chunks: string[] = [];
+  let remaining = text;
+  while (remaining.length > SECTION_CHUNK_CHARS) {
+    const window = remaining.slice(0, SECTION_CHUNK_CHARS);
+    const newlineBreak = window.lastIndexOf("\n");
+    // Only break on a newline if it leaves a non-trivial chunk; otherwise hard
+    // split at the window boundary to guarantee forward progress.
+    const breakAt = newlineBreak > 0 ? newlineBreak : SECTION_CHUNK_CHARS;
+    chunks.push(remaining.slice(0, breakAt));
+    remaining = remaining.slice(breakAt).replace(/^\n/, "");
+  }
+  if (remaining.length > 0) chunks.push(remaining);
+  return chunks;
+}
+
+export async function buildSectionIndex(
+  slugs: Slug[],
+  pageBody: (slug: Slug) => Promise<string>,
+): Promise<SectionIndex> {
+  const sections: Section[] = [];
+
+  // Sort slugs so the flat `sections` array is deterministic across runs.
+  for (const article of [...slugs].sort((a, b) => a.localeCompare(b))) {
+    const body = await pageBody(article);
+    const segment = lastSlugSegment(article);
+
+    let ordinal = 0;
+    for (const raw of splitIntoRawSections(body)) {
+      const head = `${segment} — ${raw.title}`;
+      const fullText = `${head}\n${raw.body}`;
+      for (const chunk of chunkText(fullText)) {
+        sections.push({
+          article,
+          title: raw.title,
+          text: chunk,
+          ordinal: ordinal++,
+        });
+      }
+    }
+  }
+
+  const byArticle = new Map<Slug, number[]>();
+  for (let i = 0; i < sections.length; i++) {
+    const article = sections[i]!.article;
+    let indices = byArticle.get(article);
+    if (!indices) {
+      indices = [];
+      byArticle.set(article, indices);
+    }
+    indices.push(i);
+  }
+
+  return { sections, byArticle };
+}

--- a/assistant/src/plugins/defaults/memory-v3-shadow/types.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/types.ts
@@ -34,6 +34,30 @@ export interface LeafTree {
   byPage: Map<Slug, LeafPath[]>;
 }
 
+/**
+ * A single section of a page: the lead (text before the first `## heading`,
+ * ordinal 0) or a heading-delimited block. Over-long sections are split into
+ * multiple ordered `Section`s, each with its own consecutive `ordinal`, so each
+ * fits a typical embedding window. `text` is prefixed with a
+ * `${lastSlugSegment} — ${title}` head line for lexical/dense matching.
+ */
+export interface Section {
+  article: Slug;
+  title: string;
+  text: string;
+  ordinal: number;
+}
+
+/**
+ * A flat, deterministic index of every page's sections plus an article→section
+ * lookup. `byArticle` maps each article slug to the indices (into `sections`)
+ * of that article's sections, in order.
+ */
+export interface SectionIndex {
+  sections: Section[];
+  byArticle: Map<Slug, number[]>;
+}
+
 export interface WorkingSetEntry {
   slug: Slug;
   selectedAtTurn: number;


### PR DESCRIPTION
## Summary
- Add Section / SectionIndex types and a pure buildSectionIndex() that chunks page bodies into sections (lead = ordinal 0, split on ## headings, 6000-char chunk cap).
- Additive scaffolding for the section-grain lane retrieval; nothing wired up yet, plugin still runs tree-based.

Part of plan: memory-v3-section-lanes.md (PR 1 of 12)