### PR TITLE
feat(memory-v3): BM25F needle over sections returning matched section

### DIFF
--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/section-needle.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/section-needle.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "bun:test";
+
+import { buildSectionNeedle } from "../section-needle.js";
+import { buildSectionIndex } from "../sections.js";
+import type { SectionIndex, Slug } from "../types.js";
+
+/**
+ * Build a `SectionIndex` from a fixture page-body map. All slugs and content
+ * are invented placeholders — no real content.
+ */
+async function index(pages: Record<string, string>): Promise<SectionIndex> {
+  const reader = async (slug: Slug): Promise<string> => pages[slug] ?? "";
+  return buildSectionIndex(Object.keys(pages), reader);
+}
+
+describe("buildSectionNeedle", () => {
+  test("a term present only in one section ranks that section's article", async () => {
+    const idx = await index({
+      "page-a": [
+        "## Intro",
+        "general background prose",
+        "",
+        "## Details",
+        "the elephant appears only here",
+      ].join("\n"),
+      "topic-x": "## Notes\nunrelated material about gardens",
+    });
+
+    const needle = buildSectionNeedle(idx);
+    const results = needle.query("elephant", 5);
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]!.article).toBe("page-a");
+    // The matched section is the "Details" section, not the lead/intro.
+    expect(idx.sections[results[0]!.section]!.title).toBe("Details");
+  });
+
+  test("dedupe keeps one entry per article with its top section", async () => {
+    const idx = await index({
+      "page-a": [
+        "## First",
+        "zebra zebra zebra mention",
+        "",
+        "## Second",
+        "single zebra mention",
+      ].join("\n"),
+    });
+
+    const needle = buildSectionNeedle(idx);
+    const results = needle.query("zebra", 5);
+
+    // Only one entry for page-a despite two matching sections.
+    expect(results).toHaveLength(1);
+    expect(results[0]!.article).toBe("page-a");
+    // The denser "First" section wins.
+    expect(idx.sections[results[0]!.section]!.title).toBe("First");
+  });
+
+  test("bestSection returns the highest-scoring section for an article", async () => {
+    const idx = await index({
+      "page-a": [
+        "## Alpha",
+        "background filler text",
+        "",
+        "## Beta",
+        "the keyword giraffe lives here",
+      ].join("\n"),
+    });
+
+    const needle = buildSectionNeedle(idx);
+    const best = needle.bestSection("page-a", "giraffe");
+
+    expect(idx.sections[best]!.title).toBe("Beta");
+  });
+
+  test("bestSection falls back to first section when no term matches", async () => {
+    const idx = await index({
+      "page-a": "## Alpha\nfiller\n\n## Beta\nmore filler",
+    });
+
+    const needle = buildSectionNeedle(idx);
+    const best = needle.bestSection("page-a", "nonexistentterm");
+
+    // First section index for the article (the lead, ordinal 0).
+    expect(best).toBe(idx.byArticle.get("page-a")![0]!);
+    expect(idx.sections[best]!.ordinal).toBe(0);
+  });
+
+  test("bestSection returns -1 for an unknown article", async () => {
+    const idx = await index({ "page-a": "## Alpha\nfiller" });
+    const needle = buildSectionNeedle(idx);
+    expect(needle.bestSection("missing-page", "anything")).toBe(-1);
+  });
+
+  test("k truncation is respected", async () => {
+    const idx = await index({
+      "page-a": "## S\nshared keyword apple here",
+      "page-b": "## S\nshared keyword apple here too",
+      "page-c": "## S\nshared keyword apple again",
+    });
+
+    const needle = buildSectionNeedle(idx);
+    expect(needle.query("apple", 2)).toHaveLength(2);
+    expect(needle.query("apple", 0)).toHaveLength(0);
+  });
+
+  test("head-field term outranks the same term in body", async () => {
+    // Same term in the head line (title) of page-a vs in the body of topic-x.
+    // Bodies are padded to comparable length so the only edge is field weight.
+    const idx = await index({
+      "page-a": "## Mango\nfiller words to balance length across the docs here",
+      "topic-x":
+        "## Notes\nfiller words mango plus more padding to balance length",
+    });
+
+    const needle = buildSectionNeedle(idx);
+    const results = needle.query("mango", 5);
+
+    expect(results[0]!.article).toBe("page-a");
+  });
+
+  test("deterministic tie-breaking by (article, ordinal)", async () => {
+    // Identical content across two articles → identical scores; the lexically
+    // smaller article wins the tie.
+    const idx = await index({
+      "page-b": "## S\nidentical pineapple content",
+      "page-a": "## S\nidentical pineapple content",
+    });
+
+    const needle = buildSectionNeedle(idx);
+    const results = needle.query("pineapple", 5);
+
+    expect(results.map((r) => r.article)).toEqual(["page-a", "page-b"]);
+  });
+});

--- a/assistant/src/plugins/defaults/memory-v3-shadow/section-needle.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/section-needle.ts
@@ -1,0 +1,200 @@
+import { b, k1 } from "./needle.js";
+import type { SectionIndex, Slug } from "./types.js";
+
+/**
+ * Section-grain "needle" lane for memory-v3 retrieval: a lexical BM25F search
+ * over a {@link SectionIndex}. Each section is a tiny two-field document — a
+ * weighted `head` line (`${lastSlugSegment} — ${title}`) and the remaining
+ * `body` text — so a literal term in a heading outranks the same term buried in
+ * prose. Scoring happens at section grain; results are deduped to distinct
+ * articles, each tagged with its best-scoring section.
+ *
+ * This is additive: it does not touch the page-grain {@link buildNeedleIndex}
+ * in `needle.ts`, which tree-based routing still uses. The Okapi parameters and
+ * tokenizer are shared so both lanes stay calibrated to the same harness.
+ *
+ * Implementation notes:
+ * - Hand-rolled Okapi BM25F (no dependency). The corpus is bounded (one doc per
+ *   section), so a plain inverted index is plenty.
+ * - To match the validated harness the term stream includes adjacent-token
+ *   bigrams (`token[i] + "_" + token[i+1]`) in addition to unigrams.
+ */
+
+/** `head`-field weight in the BM25F term-frequency blend. */
+export const HEAD_WEIGHT = 2.5;
+/** `body`-field weight in the BM25F term-frequency blend. */
+export const BODY_WEIGHT = 1;
+
+export interface SectionNeedle {
+  /**
+   * Returns up to `k` distinct articles ranked by BM25F score (descending),
+   * each tagged with its best-scoring section index (into the underlying
+   * `SectionIndex.sections`). Ties break by `(article, ordinal)`.
+   */
+  query(text: string, k: number): { article: Slug; section: number }[];
+  /**
+   * Highest-scoring section index (into `SectionIndex.sections`) for `article`
+   * against `queryText`. Returns the article's first section index when no term
+   * matches (or `-1` if the article has no sections). Used by other lanes to
+   * attach a matched-section descriptor to an article they surface.
+   */
+  bestSection(article: Slug, queryText: string): number;
+}
+
+/** Lowercase, split on non-alphanumeric, drop empties. Mirrors `needle.ts`. */
+function tokenizeUnigrams(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((token) => token.length > 0);
+}
+
+/** Unigrams plus adjacent-token bigrams (`a_b`), matching the harness. */
+function tokenize(text: string): string[] {
+  const unigrams = tokenizeUnigrams(text);
+  const terms = [...unigrams];
+  for (let i = 0; i + 1 < unigrams.length; i++) {
+    terms.push(`${unigrams[i]}_${unigrams[i + 1]}`);
+  }
+  return terms;
+}
+
+/** Split a section's text into its head line and the remaining body. */
+function splitHeadBody(text: string): { head: string; body: string } {
+  const newline = text.indexOf("\n");
+  if (newline === -1) return { head: text, body: "" };
+  return { head: text.slice(0, newline), body: text.slice(newline + 1) };
+}
+
+interface Posting {
+  doc: number;
+  /** Field-weighted term frequency: HEAD_WEIGHT*tf_head + BODY_WEIGHT*tf_body. */
+  weightedTf: number;
+}
+
+export function buildSectionNeedle(index: SectionIndex): SectionNeedle {
+  const { sections } = index;
+  const docCount = sections.length;
+
+  // term -> postings (section index + weighted term frequency).
+  const postings = new Map<string, Posting[]>();
+  // BM25F effective document length = weighted token count per section.
+  const docLengths: number[] = new Array(docCount).fill(0);
+  let totalLength = 0;
+
+  for (let doc = 0; doc < docCount; doc++) {
+    const { head, body } = splitHeadBody(sections[doc]!.text);
+    const headTerms = tokenize(head);
+    const bodyTerms = tokenize(body);
+
+    const length =
+      HEAD_WEIGHT * headTerms.length + BODY_WEIGHT * bodyTerms.length;
+    docLengths[doc] = length;
+    totalLength += length;
+
+    const weightedTf = new Map<string, number>();
+    for (const term of headTerms) {
+      weightedTf.set(term, (weightedTf.get(term) ?? 0) + HEAD_WEIGHT);
+    }
+    for (const term of bodyTerms) {
+      weightedTf.set(term, (weightedTf.get(term) ?? 0) + BODY_WEIGHT);
+    }
+
+    for (const [term, tf] of weightedTf) {
+      let list = postings.get(term);
+      if (!list) {
+        list = [];
+        postings.set(term, list);
+      }
+      list.push({ doc, weightedTf: tf });
+    }
+  }
+
+  const avgDocLength = docCount > 0 ? totalLength / docCount : 0;
+
+  /** BM25F score per section for the given query terms. */
+  function scoreSections(queryTerms: Set<string>): Map<number, number> {
+    const scores = new Map<number, number>();
+    if (docCount === 0) return scores;
+
+    for (const term of queryTerms) {
+      const list = postings.get(term);
+      if (!list) continue;
+
+      const idf = Math.log(
+        1 + (docCount - list.length + 0.5) / (list.length + 0.5),
+      );
+
+      for (const { doc, weightedTf } of list) {
+        const norm = weightedTf * (k1 + 1);
+        const denom =
+          weightedTf + k1 * (1 - b + b * (docLengths[doc]! / avgDocLength));
+        scores.set(doc, (scores.get(doc) ?? 0) + idf * (norm / denom));
+      }
+    }
+
+    return scores;
+  }
+
+  /** Deterministic order: score desc, then (article, ordinal) asc. */
+  function rankSection(
+    a: number,
+    c: number,
+    scores: Map<number, number>,
+  ): number {
+    const byScore = (scores.get(c) ?? 0) - (scores.get(a) ?? 0);
+    if (byScore !== 0) return byScore;
+    const sa = sections[a]!;
+    const sc = sections[c]!;
+    return sa.article.localeCompare(sc.article) || sa.ordinal - sc.ordinal;
+  }
+
+  function query(
+    text: string,
+    k: number,
+  ): { article: Slug; section: number }[] {
+    if (k <= 0 || docCount === 0) return [];
+
+    const queryTerms = new Set(tokenize(text));
+    const scores = scoreSections(queryTerms);
+    if (scores.size === 0) return [];
+
+    const ranked = [...scores.keys()].sort((a, c) => rankSection(a, c, scores));
+
+    // Dedupe to distinct articles, keeping each article's best (first-ranked)
+    // section, until we have `k` articles.
+    const seen = new Set<Slug>();
+    const result: { article: Slug; section: number }[] = [];
+    for (const doc of ranked) {
+      const article = sections[doc]!.article;
+      if (seen.has(article)) continue;
+      seen.add(article);
+      result.push({ article, section: doc });
+      if (result.length >= k) break;
+    }
+    return result;
+  }
+
+  function bestSection(article: Slug, queryText: string): number {
+    const docs = index.byArticle.get(article);
+    if (!docs || docs.length === 0) return -1;
+
+    const queryTerms = new Set(tokenize(queryText));
+    const scores = scoreSections(queryTerms);
+
+    let best = docs[0]!;
+    let bestScore = scores.get(best) ?? 0;
+    for (const doc of docs) {
+      const score = scores.get(doc) ?? 0;
+      // Strictly-greater keeps the earliest (lowest ordinal) section on ties,
+      // since `docs` is in ascending section order.
+      if (score > bestScore) {
+        best = doc;
+        bestScore = score;
+      }
+    }
+    return best;
+  }
+
+  return { query, bestSection };
+}


### PR DESCRIPTION
## Summary
- Add section-grain BM25F needle (head/body fields, bigrams) returning ranked distinct articles each with a matched section + a bestSection helper.
- Additive; existing needle.ts untouched.

Part of plan: memory-v3-section-lanes.md (PR 2 of 12)