### PR TITLE
feat(memory-v3): section-grain Qdrant collection + embedding upsert

### DIFF
--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/section-dense-store.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/section-dense-store.test.ts
@@ -1,0 +1,310 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { makeMockLogger } from "../../../../__tests__/helpers/mock-logger.js";
+import type { AssistantConfig } from "../../../../config/types.js";
+import type { Section } from "../types.js";
+
+mock.module("../../../../util/logger.js", () => ({
+  getLogger: () => makeMockLogger(),
+}));
+
+mock.module("../../../../memory/qdrant-client.js", () => ({
+  resolveQdrantUrl: () => "http://127.0.0.1:6333",
+}));
+
+// Stub the shared embedding backend. Records inputs and returns one
+// deterministic vector per input so `upsertSections` can map vectors → points.
+const embedState = {
+  calls: [] as string[][],
+  dim: 4,
+};
+mock.module("../../../../memory/embedding-backend.js", () => ({
+  embedWithBackend: async (_config: unknown, inputs: string[]) => {
+    embedState.calls.push(inputs);
+    return {
+      provider: "local",
+      model: "test-model",
+      vectors: inputs.map((_input, i) =>
+        Array.from({ length: embedState.dim }, (_v, j) => (i + 1) * (j + 1)),
+      ),
+    };
+  },
+}));
+
+// Mock the underlying @qdrant/js-client-rest package. The mock client records
+// every call and lets each test program collection existence.
+type MockPoint = {
+  id: string;
+  vector: number[];
+  payload: { article: string; ordinal: number; title: string };
+};
+
+const state = {
+  collectionExists: false,
+  collectionExistsCalls: 0,
+  createCollectionCalls: 0,
+  createCollectionParams: null as unknown,
+  createIndexCalls: [] as Array<{ field_name: string; field_schema: string }>,
+  upsertCalls: [] as Array<{ wait: boolean; points: MockPoint[] }>,
+  deleteCalls: [] as Array<{ wait: boolean; filter: unknown }>,
+  createCollectionThrows: null as Error | null,
+};
+
+class MockQdrantClient {
+  constructor(_opts: unknown) {}
+  async collectionExists(_name: string) {
+    state.collectionExistsCalls++;
+    return { exists: state.collectionExists };
+  }
+  async createCollection(_name: string, params: unknown) {
+    state.createCollectionCalls++;
+    state.createCollectionParams = params;
+    if (state.createCollectionThrows) throw state.createCollectionThrows;
+    state.collectionExists = true;
+    return {};
+  }
+  async createPayloadIndex(
+    _name: string,
+    params: { field_name: string; field_schema: string },
+  ) {
+    state.createIndexCalls.push(params);
+    return {};
+  }
+  async upsert(_name: string, params: { wait: boolean; points: MockPoint[] }) {
+    state.upsertCalls.push(params);
+    return {};
+  }
+  async delete(_name: string, params: { wait: boolean; filter: unknown }) {
+    state.deleteCalls.push(params);
+    return {};
+  }
+}
+
+mock.module("@qdrant/js-client-rest", () => ({
+  QdrantClient: MockQdrantClient,
+}));
+
+const {
+  ensureSectionCollection,
+  upsertSections,
+  deleteSectionsForArticle,
+  SECTION_COLLECTION,
+  _resetSectionDenseStoreForTests,
+} = await import("../section-dense-store.js");
+
+const CONFIG = {
+  memory: { qdrant: { vectorSize: 4, onDisk: true } },
+} as unknown as AssistantConfig;
+
+function section(
+  article: string,
+  ordinal: number,
+  text: string,
+  title = "",
+): Section {
+  return { article, ordinal, text, title };
+}
+
+function resetState(): void {
+  state.collectionExists = false;
+  state.collectionExistsCalls = 0;
+  state.createCollectionCalls = 0;
+  state.createCollectionParams = null;
+  state.createIndexCalls.length = 0;
+  state.upsertCalls.length = 0;
+  state.deleteCalls.length = 0;
+  state.createCollectionThrows = null;
+  embedState.calls.length = 0;
+  embedState.dim = 4;
+  _resetSectionDenseStoreForTests();
+}
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+describe("memory v3 section-dense-store — collection lifecycle", () => {
+  beforeEach(resetState);
+  afterEach(resetState);
+
+  test("uses the documented collection name", () => {
+    expect(SECTION_COLLECTION).toBe("memory_v3_sections");
+  });
+
+  test("creates the collection with a single dense vector at the configured dimension", async () => {
+    state.collectionExists = false;
+
+    await ensureSectionCollection(CONFIG);
+
+    expect(state.createCollectionCalls).toBe(1);
+    const params = state.createCollectionParams as {
+      vectors: { size: number; distance: string; on_disk: boolean };
+    };
+    // Dimension comes from config.memory.qdrant.vectorSize, never hard-coded.
+    expect(params.vectors).toEqual({
+      size: 4,
+      distance: "Cosine",
+      on_disk: true,
+    });
+    // `article` payload index is created so delete-by-filter works in strict mode.
+    expect(state.createIndexCalls).toEqual([
+      { field_name: "article", field_schema: "keyword" },
+    ]);
+  });
+
+  test("creates at whatever dimension the backend is configured for", async () => {
+    const config = {
+      memory: { qdrant: { vectorSize: 1536, onDisk: false } },
+    } as unknown as AssistantConfig;
+
+    await ensureSectionCollection(config);
+
+    const params = state.createCollectionParams as {
+      vectors: { size: number };
+    };
+    expect(params.vectors.size).toBe(1536);
+  });
+
+  test("is a no-op when the collection already exists", async () => {
+    state.collectionExists = true;
+
+    await ensureSectionCollection(CONFIG);
+
+    expect(state.createCollectionCalls).toBe(0);
+    expect(state.createIndexCalls).toEqual([]);
+  });
+
+  test("re-running ensure latches readiness (single existence probe)", async () => {
+    state.collectionExists = false;
+
+    await ensureSectionCollection(CONFIG);
+    await ensureSectionCollection(CONFIG);
+
+    expect(state.collectionExistsCalls).toBe(1);
+    expect(state.createCollectionCalls).toBe(1);
+  });
+
+  test("treats a 409-on-create as success", async () => {
+    state.collectionExists = false;
+    state.createCollectionThrows = Object.assign(new Error("Conflict"), {
+      status: 409,
+    });
+
+    await ensureSectionCollection(CONFIG);
+
+    // No throw; index creation is skipped because the racing peer created it.
+    expect(state.createCollectionCalls).toBe(1);
+    expect(state.createIndexCalls).toEqual([]);
+  });
+});
+
+describe("memory v3 section-dense-store — upsert", () => {
+  beforeEach(resetState);
+  afterEach(resetState);
+
+  test("embeds each section's text and upserts one point per section", async () => {
+    state.collectionExists = true;
+    const sections = [
+      section("people/alice", 0, "alice lead text"),
+      section("people/alice", 1, "alice section one", "History"),
+      section("people/bob", 0, "bob lead text"),
+    ];
+
+    await upsertSections(CONFIG, sections);
+
+    // Embedded exactly the section texts, in order.
+    expect(embedState.calls).toEqual([
+      ["alice lead text", "alice section one", "bob lead text"],
+    ]);
+
+    expect(state.upsertCalls).toHaveLength(1);
+    const call = state.upsertCalls[0]!;
+    expect(call.wait).toBe(true);
+    expect(call.points).toHaveLength(3);
+
+    expect(call.points.map((p) => p.payload)).toEqual([
+      { article: "people/alice", ordinal: 0, title: "" },
+      { article: "people/alice", ordinal: 1, title: "History" },
+      { article: "people/bob", ordinal: 0, title: "" },
+    ]);
+
+    // Each point carries its matching embedding vector and a UUID-shaped id.
+    for (const point of call.points) {
+      expect(point.id).toMatch(UUID_RE);
+      expect(point.vector).toHaveLength(4);
+    }
+    // Vectors are positional: section i gets backend vector i.
+    expect(call.points[0]!.vector).toEqual([1, 2, 3, 4]);
+    expect(call.points[1]!.vector).toEqual([2, 4, 6, 8]);
+  });
+
+  test("re-upserting the same sections is idempotent (stable point ids)", async () => {
+    state.collectionExists = true;
+    const sections = [section("people/alice", 0, "alice lead text")];
+
+    await upsertSections(CONFIG, sections);
+    await upsertSections(CONFIG, sections);
+
+    expect(state.upsertCalls).toHaveLength(2);
+    expect(state.upsertCalls[0]!.points[0]!.id).toBe(
+      state.upsertCalls[1]!.points[0]!.id,
+    );
+  });
+
+  test("distinct (article, ordinal) pairs map to distinct point ids", async () => {
+    state.collectionExists = true;
+
+    await upsertSections(CONFIG, [
+      section("people/alice", 0, "x"),
+      section("people/alice", 1, "y"),
+      section("people/bob", 0, "z"),
+    ]);
+
+    const ids = state.upsertCalls[0]!.points.map((p) => p.id);
+    expect(new Set(ids).size).toBe(3);
+  });
+
+  test("empty sections array is a no-op (no embedding, no upsert)", async () => {
+    state.collectionExists = true;
+
+    await upsertSections(CONFIG, []);
+
+    expect(embedState.calls).toEqual([]);
+    expect(state.upsertCalls).toHaveLength(0);
+  });
+
+  test("ensures the collection before upserting", async () => {
+    state.collectionExists = false;
+
+    await upsertSections(CONFIG, [section("people/alice", 0, "x")]);
+
+    expect(state.createCollectionCalls).toBe(1);
+    expect(state.upsertCalls).toHaveLength(1);
+  });
+});
+
+describe("memory v3 section-dense-store — delete", () => {
+  beforeEach(resetState);
+  afterEach(resetState);
+
+  test("deletes section points filtered by the article payload", async () => {
+    state.collectionExists = true;
+
+    await deleteSectionsForArticle(CONFIG, "people/alice");
+
+    expect(state.deleteCalls).toHaveLength(1);
+    const call = state.deleteCalls[0]!;
+    expect(call.wait).toBe(true);
+    expect(call.filter).toEqual({
+      must: [{ key: "article", match: { value: "people/alice" } }],
+    });
+  });
+
+  test("delete is idempotent across repeated calls", async () => {
+    state.collectionExists = true;
+
+    await deleteSectionsForArticle(CONFIG, "people/alice");
+    await deleteSectionsForArticle(CONFIG, "people/alice");
+
+    expect(state.deleteCalls).toHaveLength(2);
+  });
+});

--- a/assistant/src/plugins/defaults/memory-v3-shadow/section-dense-store.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/section-dense-store.ts
@@ -1,0 +1,189 @@
+// ---------------------------------------------------------------------------
+// Memory v3 — section-grain dense Qdrant collection
+// ---------------------------------------------------------------------------
+//
+// Owns a dedicated Qdrant collection holding one dense embedding per page
+// *section* (the lead block plus each `## `-delimited heading section, chunked
+// to fit the embedding window — see `sections.ts`). This is the dense lane for
+// the section-grain retrieval design: where the v2 `memory_v2_concept_pages`
+// collection embeds whole pages, this one embeds sub-page sections so a query
+// can match the single relevant block of a long article.
+//
+// Reuses the v2 Qdrant REST client (`resolveQdrantUrl` + `config.memory.qdrant.*`)
+// and the shared embedding backend (`embedWithBackend`) rather than standing up
+// new infrastructure. The collection carries a single dense named vector sized
+// to the configured embedding backend (`config.memory.qdrant.vectorSize`) — no
+// sparse channel, since the section dense lane is dense-only.
+//
+// Additive: nothing queries this collection yet. PR 3 of the section-lanes plan
+// only populates it; the retrieval read path lands in a later PR.
+
+import { QdrantClient as QdrantRestClient } from "@qdrant/js-client-rest";
+import { v5 as uuidv5 } from "uuid";
+
+import type { AssistantConfig } from "../../../config/types.js";
+import { embedWithBackend } from "../../../memory/embedding-backend.js";
+import { resolveQdrantUrl } from "../../../memory/qdrant-client.js";
+import { getLogger } from "../../../util/logger.js";
+import type { Section } from "./types.js";
+
+const log = getLogger("memory-v3-section-dense-store");
+
+/** Name of the dedicated Qdrant collection holding section-grain embeddings. */
+export const SECTION_COLLECTION = "memory_v3_sections";
+
+/**
+ * Stable UUIDv5 namespace used to derive a deterministic Qdrant point ID from a
+ * section's `(article, ordinal)` pair. The namespace itself is an arbitrary
+ * fixed UUID; what matters is that the same section always maps to the same
+ * point ID so re-upserts replace the prior point in place instead of
+ * accumulating duplicates.
+ */
+const SECTION_NAMESPACE = "1d2c3b4a-5e6f-4a7b-8c9d-0e1f2a3b4c5d";
+
+let _client: QdrantRestClient | null = null;
+let _collectionReady = false;
+
+/** Lazily create a Qdrant REST client bound to the resolved URL. */
+function getClient(config: AssistantConfig): QdrantRestClient {
+  if (_client) return _client;
+  _client = new QdrantRestClient({
+    url: resolveQdrantUrl(config),
+    checkCompatibility: false,
+  });
+  return _client;
+}
+
+/**
+ * Derive the deterministic Qdrant point ID for a section. Qdrant requires
+ * UUID/integer IDs; UUIDv5 over `${article}#${ordinal}` keeps the mapping
+ * stable across processes so upserts replace in place.
+ */
+function pointIdForSection(article: string, ordinal: number): string {
+  return uuidv5(`${article}#${ordinal}`, SECTION_NAMESPACE);
+}
+
+/**
+ * Create the section-grain collection if it does not already exist, with a
+ * single dense vector sized to the configured embedding backend. Idempotent:
+ * an already-ready collection is a no-op, and a concurrent 409-on-create is
+ * treated as success.
+ */
+export async function ensureSectionCollection(
+  config: AssistantConfig,
+): Promise<void> {
+  if (_collectionReady) return;
+
+  const client = getClient(config);
+  const vectorSize = config.memory.qdrant.vectorSize;
+  const onDisk = config.memory.qdrant.onDisk;
+
+  const exists = await client.collectionExists(SECTION_COLLECTION);
+  if (exists.exists) {
+    _collectionReady = true;
+    return;
+  }
+
+  log.info(
+    { collection: SECTION_COLLECTION, vectorSize },
+    "Creating Qdrant collection for memory v3 sections",
+  );
+
+  try {
+    await client.createCollection(SECTION_COLLECTION, {
+      vectors: {
+        size: vectorSize,
+        distance: "Cosine",
+        on_disk: onDisk,
+      },
+      hnsw_config: {
+        on_disk: onDisk,
+        m: 16,
+        ef_construct: 100,
+      },
+      optimizers_config: {
+        default_segment_number: 2,
+      },
+      on_disk_payload: onDisk,
+    });
+  } catch (err) {
+    // 409 = a concurrent caller created the collection — that's fine.
+    if (
+      err instanceof Error &&
+      "status" in err &&
+      (err as { status: number }).status === 409
+    ) {
+      _collectionReady = true;
+      return;
+    }
+    throw err;
+  }
+
+  // Index the `article` payload so `deleteSectionsForArticle` can filter on it
+  // under strict-mode Qdrant (which rejects filters on unindexed fields).
+  await client.createPayloadIndex(SECTION_COLLECTION, {
+    field_name: "article",
+    field_schema: "keyword",
+  });
+
+  _collectionReady = true;
+}
+
+/**
+ * Embed each section's `text` and upsert one point per section, keyed by a
+ * deterministic `(article, ordinal)`-derived ID. Stable IDs mean re-upserting
+ * the same sections overwrites in place rather than accumulating duplicates,
+ * so the operation is idempotent. Payload carries `{ article, ordinal, title }`
+ * for downstream filtering and rendering.
+ *
+ * An empty `sections` array is a no-op (no embedding round-trip).
+ */
+export async function upsertSections(
+  config: AssistantConfig,
+  sections: Section[],
+): Promise<void> {
+  if (sections.length === 0) return;
+
+  await ensureSectionCollection(config);
+
+  const { vectors } = await embedWithBackend(
+    config,
+    sections.map((s) => s.text),
+  );
+
+  const points = sections.map((section, i) => ({
+    id: pointIdForSection(section.article, section.ordinal),
+    vector: vectors[i]!,
+    payload: {
+      article: section.article,
+      ordinal: section.ordinal,
+      title: section.title,
+    },
+  }));
+
+  await getClient(config).upsert(SECTION_COLLECTION, { wait: true, points });
+}
+
+/**
+ * Delete every section point belonging to an article. Used by incremental
+ * rebuilds (in a later PR) to clear an article's stale sections before
+ * re-upserting its current ones. Idempotent: deleting an absent article's
+ * sections is a no-op server-side.
+ */
+export async function deleteSectionsForArticle(
+  config: AssistantConfig,
+  article: string,
+): Promise<void> {
+  await ensureSectionCollection(config);
+
+  await getClient(config).delete(SECTION_COLLECTION, {
+    wait: true,
+    filter: { must: [{ key: "article", match: { value: article } }] },
+  });
+}
+
+/** @internal Test-only: reset module-level singletons. */
+export function _resetSectionDenseStoreForTests(): void {
+  _client = null;
+  _collectionReady = false;
+}


### PR DESCRIPTION
## Summary
- Add memory_v3_sections Qdrant collection (configured embedding dim) + idempotent upsertSections/deleteSectionsForArticle reusing the v2 qdrant client and embedding backend.
- Additive; nothing queries the collection yet.

Part of plan: memory-v3-section-lanes.md (PR 3 of 12)