### PR TITLE
feat(memory-v3): single forced-tool select over the unified candidate pool

### DIFF
--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/pool-select.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/pool-select.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Tests for `pool-select.ts` — the single forced-tool selector over the unified
+ * candidate pool.
+ *
+ * Coverage matrix:
+ *   - Numbered candidates render with their descriptors (truncated).
+ *   - Returned IDs map to the right candidate slugs by 1-based index, with
+ *     `pinned` driven by `pinned_ids`.
+ *   - Omitted `ids` → keep ALL candidates (recall-safe).
+ *   - Explicit `ids: []` → keep none (deliberate abstention).
+ *   - Out-of-range / duplicate IDs ignored without throwing.
+ *   - No provider / missing tool_use / schema mismatch / throw → keep none
+ *     (degrade to deterministic lanes), the last three after a re-prompt retry.
+ *   - One forced-tool `select_pages` call on the v3 L2 call site, with NO cache
+ *     breakpoint (the pool is dynamic per turn).
+ *
+ * The provider is stubbed so no network calls fire; mirrors selector.test.ts.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type {
+  Message,
+  Provider,
+  ProviderResponse,
+  SendMessageOptions,
+  ToolUseContent,
+} from "../../../../providers/types.js";
+import type { MemoryRoutingTurn } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Mocks installed BEFORE the pool-select import so the module observes them at
+// load time.
+// ---------------------------------------------------------------------------
+
+let providerStub: Provider | null = null;
+
+interface ProviderCall {
+  messages: Message[];
+  options: SendMessageOptions | undefined;
+}
+const providerCalls: ProviderCall[] = [];
+
+mock.module("../../../../providers/provider-send-message.js", () => ({
+  getConfiguredProvider: async () => providerStub,
+  extractToolUse: (response: ProviderResponse) =>
+    response.content.find((b): b is ToolUseContent => b.type === "tool_use"),
+}));
+
+mock.module("../../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: (_t, prop) => (prop === "child" ? () => ({}) : () => {}),
+    }),
+}));
+
+const { selectPool } = await import("../pool-select.js");
+type PoolCandidate = Parameters<typeof selectPool>[0][number];
+
+// ---------------------------------------------------------------------------
+// Helpers.
+// ---------------------------------------------------------------------------
+
+function makeProvider(response: ProviderResponse): Provider {
+  return {
+    name: "stub",
+    sendMessage: async (messages, options) => {
+      providerCalls.push({ messages, options });
+      return response;
+    },
+  };
+}
+
+function toolUseResponse(input: Record<string, unknown>): ProviderResponse {
+  return {
+    model: "stub-model",
+    stopReason: "tool_use",
+    usage: { inputTokens: 0, outputTokens: 0 },
+    content: [{ type: "tool_use", id: "tu-1", name: "select_pages", input }],
+  };
+}
+
+/** A 200 response that carries no tool_use — the malformed-but-successful case
+ * the re-prompt retry exists to recover from. */
+function noToolResponse(): ProviderResponse {
+  return {
+    model: "stub-model",
+    stopReason: "end_turn",
+    usage: { inputTokens: 0, outputTokens: 0 },
+    content: [{ type: "text", text: "no tool call" }],
+  };
+}
+
+/** Provider returning a different response per call (the i-th call returns
+ * responses[i], or the last entry once exhausted). */
+function makeSequenceProvider(responses: ProviderResponse[]): Provider {
+  let i = 0;
+  return {
+    name: "sequence",
+    sendMessage: async (messages, options) => {
+      providerCalls.push({ messages, options });
+      const response = responses[Math.min(i, responses.length - 1)];
+      i += 1;
+      return response;
+    },
+  };
+}
+
+/** Provider that records each call and then throws — the throw-after-retries
+ * path (the provider's own RetryProvider has already exhausted its backoff). */
+function makeThrowingProvider(): Provider {
+  return {
+    name: "throwing",
+    sendMessage: async (messages, options) => {
+      providerCalls.push({ messages, options });
+      throw new Error("boom");
+    },
+  };
+}
+
+function makePool(): PoolCandidate[] {
+  return [
+    { slug: "page-a", descriptor: "section: the alpha rollout plan" },
+    { slug: "page-b", descriptor: "section: beta metrics dashboard" },
+    { slug: "topic-x", descriptor: "linked page about topic x" },
+  ];
+}
+
+function makeTurn(currentMessage: string): MemoryRoutingTurn {
+  return {
+    conversationId: "conv-xyz",
+    turnNumber: 1,
+    currentMessage,
+    recentContext: "earlier we talked about the timeline",
+  };
+}
+
+beforeEach(() => {
+  providerStub = null;
+  providerCalls.length = 0;
+});
+
+// ---------------------------------------------------------------------------
+// selectPool — id mapping.
+// ---------------------------------------------------------------------------
+
+describe("selectPool — id mapping", () => {
+  test("returned IDs map to candidate slugs, pinned driven by pinned_ids", async () => {
+    providerStub = makeProvider(
+      toolUseResponse({ ids: [3, 1], pinned_ids: [1] }),
+    );
+    const result = await selectPool(makePool(), makeTurn("how's the rollout?"));
+    expect(result).toEqual([
+      { slug: "topic-x", pinned: false },
+      { slug: "page-a", pinned: true },
+    ]);
+  });
+
+  test("omitted ids keeps ALL candidates (recall-safe)", async () => {
+    providerStub = makeProvider(toolUseResponse({}));
+    const result = await selectPool(makePool(), makeTurn("anything"));
+    expect(result).toEqual([
+      { slug: "page-a", pinned: false },
+      { slug: "page-b", pinned: false },
+      { slug: "topic-x", pinned: false },
+    ]);
+  });
+
+  test("explicit empty ids keeps no candidates (abstention)", async () => {
+    providerStub = makeProvider(toolUseResponse({ ids: [] }));
+    const result = await selectPool(makePool(), makeTurn("nothing relevant"));
+    expect(result).toEqual([]);
+  });
+
+  test("out-of-range and duplicate IDs are ignored without throwing", async () => {
+    providerStub = makeProvider(toolUseResponse({ ids: [2, 99, 0, -1, 2] }));
+    const result = await selectPool(makePool(), makeTurn("the metrics"));
+    expect(result).toEqual([{ slug: "page-b", pinned: false }]);
+  });
+
+  test("empty pool returns no pages and never calls the provider", async () => {
+    providerStub = makeProvider(toolUseResponse({ ids: [1] }));
+    const result = await selectPool([], makeTurn("hi"));
+    expect(result).toEqual([]);
+    expect(providerCalls).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// selectPool — recall-safe fallbacks.
+// ---------------------------------------------------------------------------
+
+describe("selectPool — degradation on failure", () => {
+  test("no provider → no pages, without calling the provider", async () => {
+    providerStub = null;
+    const result = await selectPool(makePool(), makeTurn("x"));
+    expect(result).toEqual([]);
+    expect(providerCalls).toHaveLength(0);
+  });
+
+  test("missing tool_use → no pages after retrying", async () => {
+    providerStub = makeProvider(noToolResponse());
+    const result = await selectPool(makePool(), makeTurn("x"));
+    expect(result).toEqual([]);
+    expect(providerCalls).toHaveLength(3);
+  });
+
+  test("schema mismatch → no pages after retrying", async () => {
+    providerStub = makeProvider(toolUseResponse({ ids: "not-an-array" }));
+    const result = await selectPool(makePool(), makeTurn("x"));
+    expect(result).toEqual([]);
+    expect(providerCalls).toHaveLength(3);
+  });
+
+  test("provider throw → no pages after retrying", async () => {
+    providerStub = makeThrowingProvider();
+    const result = await selectPool(makePool(), makeTurn("x"));
+    expect(result).toEqual([]);
+    expect(providerCalls).toHaveLength(3);
+  });
+
+  test("a malformed response that recovers on retry returns its pages", async () => {
+    providerStub = makeSequenceProvider([
+      noToolResponse(),
+      toolUseResponse({ ids: [2] }),
+    ]);
+    const result = await selectPool(makePool(), makeTurn("the metrics"));
+    expect(result).toEqual([{ slug: "page-b", pinned: false }]);
+    expect(providerCalls).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// selectPool — request shape (no cache breakpoint; pool is dynamic per turn).
+// ---------------------------------------------------------------------------
+
+describe("selectPool — request shape", () => {
+  test("forces tool_choice to select_pages with the v3 L2 call site", async () => {
+    providerStub = makeProvider(toolUseResponse({ ids: [1] }));
+    await selectPool(makePool(), makeTurn("rollout?"));
+
+    expect(providerCalls).toHaveLength(1);
+    const [call] = providerCalls;
+    const cfg = call.options?.config as Record<string, unknown>;
+    expect(cfg?.callSite).toBe("memoryV3SelectL2");
+    expect(cfg?.tool_choice).toEqual({ type: "tool", name: "select_pages" });
+    expect(call.options?.tools?.[0]?.name).toBe("select_pages");
+  });
+
+  test("renders numbered candidates with descriptors and NO cache breakpoint", async () => {
+    providerStub = makeProvider(toolUseResponse({ ids: [1] }));
+    await selectPool(makePool(), makeTurn("rollout?"));
+
+    const content = providerCalls[0].messages[0].content as Array<{
+      type: string;
+      text: string;
+      cache_control?: unknown;
+    }>;
+    // A single text block — the dynamic pool has no static prefix to cache.
+    expect(content).toHaveLength(1);
+    const [block] = content;
+    expect(block.type).toBe("text");
+    expect(block.text).toContain(
+      "[1] page-a — section: the alpha rollout plan",
+    );
+    expect(block.text).toContain(
+      "[2] page-b — section: beta metrics dashboard",
+    );
+    expect(block.text).toContain("[3] topic-x — linked page about topic x");
+    expect(block.text).toContain("<current_message>rollout?</current_message>");
+    expect(block.text).toContain("<recent_context>");
+    expect(block.cache_control).toBeUndefined();
+  });
+
+  test("long descriptors are truncated in the candidate list", async () => {
+    providerStub = makeProvider(toolUseResponse({ ids: [1] }));
+    const longDescriptor = "z".repeat(1000);
+    await selectPool(
+      [{ slug: "page-a", descriptor: longDescriptor }],
+      makeTurn("x"),
+    );
+    const text = (providerCalls[0].messages[0].content[0] as { text: string })
+      .text;
+    expect(text).toContain("...");
+    expect(text).not.toContain("z".repeat(1000));
+  });
+
+  test("situational context renders in the user message when present", async () => {
+    providerStub = makeProvider(toolUseResponse({ ids: [1] }));
+    await selectPool(makePool(), {
+      ...makeTurn("rollout?"),
+      situationalContext: "Today is Saturday. The launch is today.",
+    });
+    const text = (providerCalls[0].messages[0].content[0] as { text: string })
+      .text;
+    expect(text).toContain(
+      "<situation>Today is Saturday. The launch is today.</situation>",
+    );
+  });
+
+  test("system prompt mentions pinned (locks the pinning commitment)", async () => {
+    providerStub = makeProvider(toolUseResponse({ ids: [1] }));
+    await selectPool(makePool(), makeTurn("x"));
+    expect(providerCalls[0].options?.systemPrompt).toMatch(/pinned/);
+  });
+});

--- a/assistant/src/plugins/defaults/memory-v3-shadow/pool-select.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/pool-select.ts
@@ -1,0 +1,209 @@
+/**
+ * Memory v3 — single pool selector.
+ *
+ * Where the per-leaf L2 selector (`./selector.ts`) runs ONE forced-tool call per
+ * opened leaf over that leaf's static `<pages>` block, the pool selector runs a
+ * SINGLE forced-tool call over one unified candidate pool. Each candidate is a
+ * page slug paired with a per-candidate `descriptor` the caller supplies — the
+ * matched section text for a needle/dense hit, or a curated link description for
+ * an edge page. The caller assembles the pool by unioning the section lanes; the
+ * pool selector only decides which of those candidates the reply will draw on.
+ *
+ * No cache breakpoint. Unlike the per-leaf selector, whose `<pages>` block is
+ * stable for a given leaf turn-after-turn (and so carries a `cache_control`
+ * breakpoint), the pool is recomputed from per-turn section matches and is
+ * therefore dynamic per turn. Caching a prefix that changes every turn would
+ * never hit; carry-forward (the working set unioned in by the orchestrator) is
+ * the cache mechanism here, not a static prefix breakpoint.
+ *
+ * Failure handling mirrors the per-leaf selector EXACTLY:
+ *   - explicit `ids` → select exactly those candidates,
+ *   - explicit empty `ids: []` → select none (deliberate abstention),
+ *   - omitted `ids` → keep ALL candidates (the recall-safe "all of these are
+ *     relevant" signal),
+ *   - infrastructure failure (provider unavailable, a throw that survived the
+ *     provider's own retries, no usable `tool_use`, or a schema mismatch) →
+ *     select nothing after a short re-prompt retry, degrading to the
+ *     deterministic recall lanes the orchestrator unions in regardless.
+ */
+
+import { z } from "zod";
+
+import {
+  extractToolUse,
+  getConfiguredProvider,
+} from "../../../providers/provider-send-message.js";
+import type { Message, ToolDefinition } from "../../../providers/types.js";
+import { getLogger } from "../../../util/logger.js";
+import { truncate } from "../../../util/truncate.js";
+import { retryForResult } from "./llm-retry.js";
+import type { SelectedPage } from "./selector.js";
+import type { MemoryRoutingTurn, Slug } from "./types.js";
+
+const log = getLogger("memory-v3-pool-select");
+
+export type { SelectedPage } from "./selector.js";
+
+/** A candidate page in the unified pool, with the descriptor that justifies it. */
+export interface PoolCandidate {
+  slug: Slug;
+  /**
+   * The text that justifies this candidate: a matched section for a
+   * needle/dense hit, or a curated link description for an edge page. Rendered
+   * (truncated) in the numbered candidate list the selector judges against.
+   */
+  descriptor: string;
+}
+
+/** Tool name forced via `tool_choice`. Shared constant so tests can match it. */
+const SELECT_PAGES_TOOL_NAME = "select_pages";
+
+/** Descriptors are truncated to keep the candidate list compact. */
+const DESCRIPTOR_MAX_CHARS = 400;
+
+const SelectPagesSchema = z.object({
+  // Optional: an omitted `ids` field is the recall-safe "keep everything"
+  // signal, distinct from an explicit empty array (deliberate abstention).
+  ids: z.array(z.number().int()).optional(),
+  pinned_ids: z.array(z.number().int()).optional(),
+});
+
+const SELECT_PAGES_TOOL: ToolDefinition = {
+  name: SELECT_PAGES_TOOL_NAME,
+  description:
+    "Select the candidate pages whose content the reply would directly draw " +
+    "on. Lean inclusive — when in doubt, keep a candidate; for a list or " +
+    '"all of X" request keep every candidate that belongs. Pass `pinned_ids` ' +
+    "for pages the conversation is centrally about. Omit `ids` only as a " +
+    "recall-safe fallback when you cannot judge the pool (keeps every " +
+    "candidate); return `[]` when candidates are present but none are " +
+    "relevant.",
+  input_schema: {
+    type: "object",
+    properties: {
+      ids: {
+        type: "array",
+        items: { type: "integer" },
+      },
+      pinned_ids: {
+        type: "array",
+        items: { type: "integer" },
+      },
+    },
+  },
+};
+
+const SYSTEM_PROMPT = `You are given a pool of candidate memory pages, each surfaced because some part of it matched the conversation. Select every page whose specific content the reply to THIS message would directly draw on.
+
+Lean inclusive: recall matters more than precision here, so when a candidate could plausibly inform the reply, keep it. For a list or an "all of X" request, keep EVERY candidate that belongs to X rather than guessing a representative subset.
+
+A page can be relevant because of the current situation — the date or the live scratchpad — not only the message: keep a page the situation makes pertinent (e.g. a person whose anniversary is today).
+
+If the conversation is centrally ABOUT a page (rather than only peripherally relevant to it), mark that page as pinned. Call \`select_pages\` with the chosen IDs. Omit \`ids\` only as a recall-safe fallback when you cannot judge the pool (keeps every candidate); return \`[]\` when candidates are present but none are relevant.`;
+
+/** Collapse a descriptor to one line and cap its length for the candidate list. */
+function renderDescriptor(descriptor: string): string {
+  return truncate(descriptor.replace(/\s+/g, " ").trim(), DESCRIPTOR_MAX_CHARS);
+}
+
+/**
+ * Render the numbered candidate list: one `[i] slug — descriptor` line per
+ * candidate, descriptors collapsed to one line and length-capped. The pool is
+ * dynamic per turn, so this block is NOT cached (see the module doc).
+ */
+function renderCandidateList(pool: PoolCandidate[]): string {
+  const lines = pool.map(
+    (c, i) => `[${i + 1}] ${c.slug} — ${renderDescriptor(c.descriptor)}`,
+  );
+  return `<candidates>\n${lines.join("\n")}\n</candidates>`;
+}
+
+/**
+ * Run the single forced-tool selector over the unified candidate pool. Returns
+ * the pages to inject.
+ *
+ * An omitted `ids` keeps ALL candidates (the recall-safe "all of these are
+ * relevant" signal); an explicit `[]` keeps none; an infrastructure failure
+ * (after a short re-prompt retry) keeps none, degrading to the deterministic
+ * recall lanes the orchestrator unions in.
+ */
+export async function selectPool(
+  pool: PoolCandidate[],
+  turn: MemoryRoutingTurn,
+): Promise<SelectedPage[]> {
+  if (pool.length === 0) return [];
+
+  const keepAll = (): SelectedPage[] =>
+    pool.map((c) => ({ slug: c.slug, pinned: false }));
+
+  const provider = await getConfiguredProvider("memoryV3SelectL2");
+  if (!provider) {
+    log.warn(
+      { candidateCount: pool.length },
+      "pool selector provider unavailable; degrading to deterministic lanes",
+    );
+    return [];
+  }
+
+  // The pool is dynamic per turn, so — unlike the per-leaf selector — there is
+  // no static cache breakpoint here; carry-forward is the cache mechanism. The
+  // candidate list and the per-turn context go in a single plain text block.
+  const userMsg: Message = {
+    role: "user",
+    content: [
+      {
+        type: "text",
+        text:
+          `${renderCandidateList(pool)}\n` +
+          (turn.situationalContext
+            ? `<situation>${turn.situationalContext}</situation>\n`
+            : "") +
+          `<recent_context>${turn.recentContext}</recent_context>\n` +
+          `<current_message>${turn.currentMessage}</current_message>`,
+      },
+    ],
+  };
+
+  // One forced-tool call, retried a few times so a transient malformed response
+  // (no usable tool_use, or tool input that fails the schema) re-prompts before
+  // we give up. `null` from an attempt means "unusable, retry"; the provider
+  // layer already backs off transient throws, so this loop adds no delay.
+  const parsed = await retryForResult(async () => {
+    const response = await provider.sendMessage([userMsg], {
+      tools: [SELECT_PAGES_TOOL],
+      systemPrompt: SYSTEM_PROMPT,
+      config: {
+        callSite: "memoryV3SelectL2" as const,
+        tool_choice: { type: "tool" as const, name: SELECT_PAGES_TOOL_NAME },
+      },
+    });
+    const toolBlock = extractToolUse(response);
+    if (!toolBlock || toolBlock.name !== SELECT_PAGES_TOOL_NAME) return null;
+    const result = SelectPagesSchema.safeParse(toolBlock.input);
+    return result.success ? result.data : null;
+  });
+
+  if (parsed === null) {
+    log.warn(
+      { candidateCount: pool.length },
+      "pool selector could not obtain a selection after retries; degrading to deterministic lanes",
+    );
+    return [];
+  }
+
+  // Omitted `ids` is the recall-safe "keep all candidates" signal.
+  if (parsed.ids === undefined) return keepAll();
+
+  const pinned = new Set(parsed.pinned_ids ?? []);
+
+  // Map 1-based IDs back to candidate slugs, dropping out-of-range IDs without
+  // throwing. De-duplicate while preserving model-returned order.
+  const seen = new Set<number>();
+  const selected: SelectedPage[] = [];
+  for (const id of parsed.ids) {
+    if (id < 1 || id > pool.length || seen.has(id)) continue;
+    seen.add(id);
+    selected.push({ slug: pool[id - 1]!.slug, pinned: pinned.has(id) });
+  }
+  return selected;
+}


### PR DESCRIPTION
## Summary
- Add selectPool(): one forced-tool select_pages call over a unified candidate pool with per-candidate descriptors, reusing the selector mechanism + recall-safe fallbacks; replaces per-leaf L2 fan-out (wired in a later PR).
- Additive; existing selector.ts untouched.

Part of plan: memory-v3-section-lanes.md (PR 6 of 12)