### PR TITLE
feat(memory-v3): edge lane — link-graph expansion with hub exclusion

### DIFF
--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/edge.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/edge.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, test } from "bun:test";
+
+import type { PageIndexEntry } from "../../../../memory/v2/page-index.js";
+import { buildEdgeGraph, edgeExpand } from "../edge.js";
+import type { Slug } from "../types.js";
+
+/** Minimal page-index entry factory — only the fields the edge lane reads. */
+function entry(id: number, slug: Slug, edges: number[] = []): PageIndexEntry {
+  return { id, slug, summary: "", edges, leaves: [], modifiedAt: 0 };
+}
+
+/** Build a raw-page reader from a fixture map; missing slugs read as "". */
+function rawReader(pages: Record<string, string>) {
+  return async (slug: Slug): Promise<string> => pages[slug] ?? "";
+}
+
+/** Frontmatter helper: wrap a `links:` list around an optional body. */
+function withLinks(links: string[], body = "body"): string {
+  const block = links.map((l) => `  - "${l}"`).join("\n");
+  return `---\ntitle: x\nlinks:\n${block}\n---\n\n${body}`;
+}
+
+describe("buildEdgeGraph — links: frontmatter", () => {
+  test("parses target + description split on the first ' — '", async () => {
+    const articles = [entry(1, "page-a"), entry(2, "page-b")];
+    const graph = await buildEdgeGraph(
+      articles,
+      rawReader({
+        "page-a": withLinks(["page-b — the b page — with an extra dash"]),
+        "page-b": "no frontmatter",
+      }),
+    );
+    const out = graph.adjacency.get("page-a")!;
+    // Split on the FIRST ' — ' only: description keeps the trailing dash text.
+    expect(out.get("page-b")).toBe("the b page — with an extra dash");
+  });
+
+  test("drops unknown/dangling link targets", async () => {
+    const articles = [entry(1, "page-a"), entry(2, "page-b")];
+    const graph = await buildEdgeGraph(
+      articles,
+      rawReader({
+        "page-a": withLinks([
+          "page-b — known target",
+          "page-ghost — dangling target not in corpus",
+        ]),
+      }),
+    );
+    const out = graph.adjacency.get("page-a")!;
+    expect(out.has("page-b")).toBe(true);
+    expect(out.has("page-ghost")).toBe(false);
+    expect([...out.keys()]).toEqual(["page-b"]);
+  });
+
+  test("a page with no links: falls back to wikilinks and numeric edges", async () => {
+    const articles = [
+      entry(1, "page-a", [2]), // numeric edge → page-b
+      entry(2, "page-b"),
+      entry(3, "topic-x"),
+    ];
+    const graph = await buildEdgeGraph(
+      articles,
+      rawReader({
+        // No links: frontmatter; body has an inline wikilink to topic-x.
+        "page-a": "plain body referencing [[topic-x]] inline",
+      }),
+    );
+    const out = graph.adjacency.get("page-a")!;
+    expect(out.has("page-b")).toBe(true); // from numeric edge
+    expect(out.has("topic-x")).toBe(true); // from wikilink
+    // No curated descriptions on wikilink/numeric edges.
+    expect(out.get("page-b")).toBeUndefined();
+    expect(out.get("topic-x")).toBeUndefined();
+  });
+});
+
+describe("buildEdgeGraph — three-source union", () => {
+  test("links ∪ wikilinks ∪ numeric edges merge into one adjacency map", async () => {
+    const articles = [
+      entry(1, "page-a", [4]), // numeric edge → topic-y
+      entry(2, "page-b"),
+      entry(3, "topic-x"),
+      entry(4, "topic-y"),
+    ];
+    const graph = await buildEdgeGraph(
+      articles,
+      rawReader({
+        "page-a": withLinks(
+          ["page-b — authored neighbour"],
+          "and a [[topic-x]] wikilink in the body",
+        ),
+      }),
+    );
+    const out = graph.adjacency.get("page-a")!;
+    expect(new Set(out.keys())).toEqual(
+      new Set(["page-b", "topic-x", "topic-y"]),
+    );
+    expect(out.get("page-b")).toBe("authored neighbour"); // from links
+    expect(out.get("topic-x")).toBeUndefined(); // from wikilink
+    expect(out.get("topic-y")).toBeUndefined(); // from numeric edge
+  });
+
+  test("read failure still keeps numeric-edge fallback", async () => {
+    const articles = [entry(1, "page-a", [2]), entry(2, "page-b")];
+    const graph = await buildEdgeGraph(articles, async () => {
+      throw new Error("read failed");
+    });
+    const out = graph.adjacency.get("page-a")!;
+    expect(out.has("page-b")).toBe(true);
+  });
+});
+
+describe("buildEdgeGraph — hubs", () => {
+  test("marks articles with in-degree > hubDegree as hubs", async () => {
+    // hub receives 3 inbound edges; with hubDegree=2 it is a hub.
+    const articles = [
+      entry(1, "page-a"),
+      entry(2, "page-b"),
+      entry(3, "page-c"),
+      entry(4, "hub"),
+    ];
+    const graph = await buildEdgeGraph(
+      articles,
+      rawReader({
+        "page-a": withLinks(["hub — to hub"]),
+        "page-b": withLinks(["hub — to hub"]),
+        "page-c": withLinks(["hub — to hub"]),
+      }),
+      { hubDegree: 2 },
+    );
+    expect(graph.hubs.has("hub")).toBe(true);
+    expect(graph.hubs.has("page-a")).toBe(false);
+  });
+});
+
+describe("edgeExpand", () => {
+  /** Build a star/chain graph: page-a → b,c,d,e,f,g ; topic-x → b. */
+  async function fixtureGraph(hubDegree = 30) {
+    const articles = [
+      entry(1, "page-a"),
+      entry(2, "page-b"),
+      entry(3, "page-c"),
+      entry(4, "page-d"),
+      entry(5, "page-e"),
+      entry(6, "page-f"),
+      entry(7, "page-g"),
+      entry(8, "topic-x"),
+    ];
+    return buildEdgeGraph(
+      articles,
+      rawReader({
+        "page-a": withLinks([
+          "page-b — neighbour b",
+          "page-c — neighbour c",
+          "page-d — neighbour d",
+          "page-e — neighbour e",
+          "page-f — neighbour f",
+          "page-g — neighbour g",
+        ]),
+        "topic-x": withLinks(["page-b — also to b"]),
+      }),
+      { hubDegree },
+    );
+  }
+
+  test("carries the curated links description through expansion", async () => {
+    const graph = await fixtureGraph();
+    const out = edgeExpand(graph, ["page-a"]);
+    const b = out.find((n) => n.article === "page-b");
+    expect(b?.description).toBe("neighbour b");
+  });
+
+  test("respects perSeed", async () => {
+    const graph = await fixtureGraph();
+    const out = edgeExpand(graph, ["page-a"], { perSeed: 2 });
+    expect(out).toHaveLength(2);
+    expect(out.map((n) => n.article)).toEqual(["page-b", "page-c"]);
+  });
+
+  test("respects cap across seeds", async () => {
+    const graph = await fixtureGraph();
+    // Two seeds each could add many; cap=3 truncates the total.
+    const out = edgeExpand(graph, ["page-a", "topic-x"], {
+      perSeed: 6,
+      cap: 3,
+    });
+    expect(out).toHaveLength(3);
+  });
+
+  test("respects seedCount (only top-N seeds expanded)", async () => {
+    // seedCount=1: only the first seed expands; the second seed's unique
+    // neighbour is never reached.
+    const articles = [
+      entry(1, "seed-1"),
+      entry(2, "seed-2"),
+      entry(3, "only-via-2"),
+      entry(4, "via-1"),
+    ];
+    const g = await buildEdgeGraph(
+      articles,
+      rawReader({
+        "seed-1": withLinks(["via-1 — x"]),
+        "seed-2": withLinks(["only-via-2 — y"]),
+      }),
+    );
+    const out = edgeExpand(g, ["seed-1", "seed-2"], { seedCount: 1 });
+    expect(out.map((n) => n.article)).toEqual(["via-1"]);
+    expect(out.find((n) => n.article === "only-via-2")).toBeUndefined();
+  });
+
+  test("excludes hub neighbours from expansion", async () => {
+    // page-b has in-degree 2 (page-a + topic-x). At the default threshold it
+    // is not a hub; lowering hubDegree below 2 makes it one.
+    const nonHubGraph = await fixtureGraph();
+    expect(nonHubGraph.hubs.has("page-b")).toBe(false);
+
+    const hubGraph = await fixtureGraph(1); // page-b in-degree 2 > 1 → hub
+    expect(hubGraph.hubs.has("page-b")).toBe(true);
+    const out = edgeExpand(hubGraph, ["page-a"]);
+    expect(out.find((n) => n.article === "page-b")).toBeUndefined();
+    // non-hub neighbours still surface
+    expect(out.find((n) => n.article === "page-c")).toBeDefined();
+  });
+
+  test("respects the alive predicate", async () => {
+    const graph = await fixtureGraph();
+    const out = edgeExpand(graph, ["page-a"], {
+      alive: (slug) => slug !== "page-c",
+    });
+    expect(out.find((n) => n.article === "page-c")).toBeUndefined();
+    expect(out.find((n) => n.article === "page-b")).toBeDefined();
+  });
+
+  test("does not surface the seeds themselves", async () => {
+    const articles = [entry(1, "page-a"), entry(2, "page-b")];
+    const graph = await buildEdgeGraph(
+      articles,
+      rawReader({
+        "page-a": withLinks(["page-b — to b"]),
+        "page-b": withLinks(["page-a — back to a"]),
+      }),
+    );
+    const out = edgeExpand(graph, ["page-a", "page-b"]);
+    // page-a and page-b are both seeds; neither should be surfaced.
+    expect(out).toHaveLength(0);
+  });
+});

--- a/assistant/src/plugins/defaults/memory-v3-shadow/edge.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/edge.ts
@@ -1,0 +1,252 @@
+import type { PageIndexEntry } from "../../../memory/v2/page-index.js";
+import { parseFrontmatterFields } from "../../../skills/frontmatter.js";
+import type { Slug } from "./types.js";
+
+/**
+ * Edge lane for memory-v3 retrieval: a directed article link-graph used to
+ * expand a turn's lexical/dense seeds outward to their first-class neighbours.
+ *
+ * The graph unions THREE outbound-edge sources per article:
+ *
+ *   (a) The optional `links:` frontmatter — a YAML list of
+ *       `"<target-slug> — <description>"` strings (split on the first
+ *       ` — `, space-emdash-space). This is the authored, first-class edge
+ *       source: the curated description is carried through expansion so the
+ *       orchestrator can use it directly as a select descriptor.
+ *   (b) Inline `[[wikilink]]` targets parsed from the body.
+ *   (c) `PageIndexEntry.edges` numeric ids resolved to slugs — the fallback
+ *       for pages with no frontmatter `links`.
+ *
+ * All targets are resolved against the corpus slug set; unknown/dangling
+ * targets are dropped. A curated description is stored per (source → target)
+ * edge only when the `links` source supplied one; wikilink/numeric edges carry
+ * no description (the orchestrator falls back to a section descriptor).
+ *
+ * The build is pure given a `pageRaw` reader callback (no hard-coded I/O), so
+ * it is built once at lane-init and rebuilt by the maintain job, and is
+ * trivially unit-testable with a stub reader.
+ */
+
+/** Default in-degree above which an article is treated as a hub and excluded
+ * from expansion (a hub neighbour is too generic to be a useful surface). */
+export const DEFAULT_HUB_DEGREE = 30;
+
+const DEFAULT_SEED_COUNT = 18;
+const DEFAULT_PER_SEED = 6;
+const DEFAULT_CAP = 45;
+
+/** Matches the space-emdash-space separator in a `links:` entry. */
+const LINK_SEPARATOR = " — ";
+
+/** Matches `[[target]]` wikilinks; captures the raw target before any `|`
+ * display-text or `#section` anchor. */
+const WIKILINK_REGEX = /\[\[([^\]]+)\]\]/g;
+
+/**
+ * The directed link-graph. `adjacency` maps each source slug to its outbound
+ * edges (target slug → curated description, or `undefined` when the edge came
+ * from a wikilink/numeric source). `hubs` is the set of high-in-degree slugs
+ * excluded from expansion. `slugs` is the resolved corpus slug set.
+ */
+export interface EdgeGraph {
+  adjacency: Map<Slug, Map<Slug, string | undefined>>;
+  hubs: Set<Slug>;
+  slugs: Set<Slug>;
+}
+
+/** One article surfaced by {@link edgeExpand}, with the curated `links`
+ * description of the traversed edge when it carried one (else `undefined`). */
+export interface EdgeNeighbor {
+  article: Slug;
+  description?: string;
+}
+
+export interface EdgeExpandOptions {
+  /** Predicate gating which neighbours may be surfaced (e.g. liveness /
+   * not-already-selected). Neighbours failing `alive` are skipped. */
+  alive?: (slug: Slug) => boolean;
+  /** Only the top `seedCount` seeds (in input order) are expanded. */
+  seedCount?: number;
+  /** Up to `perSeed` neighbours are added per expanded seed. */
+  perSeed?: number;
+  /** Hard cap on the total number of distinct surfaced articles. */
+  cap?: number;
+}
+
+interface BuildEdgeGraphOptions {
+  /** In-degree above which an article is a hub. Defaults to
+   * {@link DEFAULT_HUB_DEGREE}. */
+  hubDegree?: number;
+}
+
+/**
+ * Split one `links:` entry (`"<target-slug> — <description>"`) into its target
+ * slug and curated description on the FIRST ` — ` (space-emdash-space).
+ * Entries with no separator are bare target slugs and carry no description.
+ */
+function parseLinkEntry(entry: string): {
+  target: Slug;
+  description: string | undefined;
+} {
+  const sep = entry.indexOf(LINK_SEPARATOR);
+  if (sep === -1) return { target: entry.trim(), description: undefined };
+  return {
+    target: entry.slice(0, sep).trim(),
+    description: entry.slice(sep + LINK_SEPARATOR.length).trim() || undefined,
+  };
+}
+
+/** Parse inline `[[wikilink]]` targets from a body. Strips `|display` and
+ * `#anchor` suffixes; returns trimmed target slugs (possibly with duplicates,
+ * deduped by the caller's map insertion). */
+function parseWikilinks(body: string): string[] {
+  const targets: string[] = [];
+  for (const match of body.matchAll(WIKILINK_REGEX)) {
+    let target = match[1];
+    const pipe = target.indexOf("|");
+    if (pipe !== -1) target = target.slice(0, pipe);
+    const hash = target.indexOf("#");
+    if (hash !== -1) target = target.slice(0, hash);
+    target = target.trim();
+    if (target) targets.push(target);
+  }
+  return targets;
+}
+
+/**
+ * Build the directed article link-graph from the page-index entries and a raw
+ * page reader. See the module docstring for the three unioned edge sources.
+ *
+ * Pure given `pageRaw`: the build performs no hard-coded I/O. A read that
+ * rejects drops that article's authored/wikilink edges but still keeps its
+ * numeric `PageIndexEntry.edges` fallback.
+ */
+export async function buildEdgeGraph(
+  articles: readonly PageIndexEntry[],
+  pageRaw: (slug: Slug) => Promise<string>,
+  opts: BuildEdgeGraphOptions = {},
+): Promise<EdgeGraph> {
+  const hubDegree = opts.hubDegree ?? DEFAULT_HUB_DEGREE;
+
+  const slugs = new Set<Slug>(articles.map((a) => a.slug));
+  const byId = new Map<number, Slug>(articles.map((a) => [a.id, a.slug]));
+
+  const raws = await Promise.all(
+    articles.map((a) =>
+      pageRaw(a.slug).then(
+        (text) => text,
+        () => null, // read failed — fall back to numeric edges only
+      ),
+    ),
+  );
+
+  const adjacency = new Map<Slug, Map<Slug, string | undefined>>();
+  const inDegree = new Map<Slug, number>();
+
+  const addEdge = (
+    source: Slug,
+    target: Slug,
+    description: string | undefined,
+  ): void => {
+    if (target === source) return; // no self-edges
+    if (!slugs.has(target)) return; // drop unknown/dangling targets
+    let out = adjacency.get(source);
+    if (!out) {
+      out = new Map();
+      adjacency.set(source, out);
+    }
+    if (!out.has(target)) {
+      out.set(target, description);
+      inDegree.set(target, (inDegree.get(target) ?? 0) + 1);
+    } else if (out.get(target) === undefined && description !== undefined) {
+      // A later source (the authored `links`) supplies a description for an
+      // edge first seen without one — upgrade it. In-degree already counted.
+      out.set(target, description);
+    }
+  };
+
+  for (let i = 0; i < articles.length; i++) {
+    const article = articles[i];
+    const source = article.slug;
+    const raw = raws[i];
+
+    // (a) authored `links:` frontmatter — primary, carries descriptions.
+    const parsed = raw !== null ? parseFrontmatterFields(raw) : null;
+    const links = parsed?.fields.links;
+    if (Array.isArray(links)) {
+      for (const entry of links) {
+        if (typeof entry !== "string") continue;
+        const { target, description } = parseLinkEntry(entry);
+        addEdge(source, target, description);
+      }
+    }
+
+    // (b) inline `[[wikilink]]` targets from the body. `parsed.body` strips
+    // the frontmatter; a page without frontmatter has `parsed === null`, so
+    // the whole raw text is the body.
+    const body = parsed ? parsed.body : raw;
+    if (body !== null) {
+      for (const target of parseWikilinks(body)) {
+        addEdge(source, target, undefined);
+      }
+    }
+
+    // (c) numeric page-index edges resolved to slugs — fallback.
+    for (const targetId of article.edges) {
+      const target = byId.get(targetId);
+      if (target) addEdge(source, target, undefined);
+    }
+  }
+
+  const hubs = new Set<Slug>();
+  for (const [slug, degree] of inDegree) {
+    if (degree > hubDegree) hubs.add(slug);
+  }
+
+  return { adjacency, hubs, slugs };
+}
+
+/**
+ * Expand `seeds` outward along the graph. For each of the top `seedCount`
+ * seeds (in input order), surface up to `perSeed` non-hub, `alive`-passing
+ * neighbours, capped at `cap` total distinct articles. Seeds themselves are
+ * not surfaced (they are already in the pool). Each surfaced article carries
+ * the curated `links` description of the traversed edge when it had one.
+ *
+ * Deterministic given the input seed order and the graph's insertion order.
+ */
+export function edgeExpand(
+  graph: EdgeGraph,
+  seeds: readonly Slug[],
+  opts: EdgeExpandOptions = {},
+): EdgeNeighbor[] {
+  const seedCount = opts.seedCount ?? DEFAULT_SEED_COUNT;
+  const perSeed = opts.perSeed ?? DEFAULT_PER_SEED;
+  const cap = opts.cap ?? DEFAULT_CAP;
+  const alive = opts.alive;
+
+  const seedSet = new Set<Slug>(seeds);
+  const surfaced = new Map<Slug, string | undefined>();
+
+  for (const seed of seeds.slice(0, seedCount)) {
+    if (surfaced.size >= cap) break;
+    const out = graph.adjacency.get(seed);
+    if (!out) continue;
+    let added = 0;
+    for (const [target, description] of out) {
+      if (added >= perSeed) break;
+      if (surfaced.size >= cap) break;
+      if (seedSet.has(target)) continue; // already in the pool
+      if (surfaced.has(target)) continue; // already surfaced via another seed
+      if (graph.hubs.has(target)) continue; // hubs excluded
+      if (alive && !alive(target)) continue;
+      surfaced.set(target, description);
+      added++;
+    }
+  }
+
+  return [...surfaced].map(([article, description]) => ({
+    article,
+    description,
+  }));
+}


### PR DESCRIPTION
## Summary
- Add edge lane: build the article link-graph from links: frontmatter (primary, with descriptions) ∪ inline [[wikilinks]] ∪ page-index numeric edges; expand seeds to non-hub neighbors with bounds; carry curated link descriptions as descriptors.
- Additive; not wired into orchestrate yet.

Part of plan: memory-v3-section-lanes.md (PR 5 of 12)