### PR TITLE
feat(memory-v3): dense lane — query sections, dedupe to articles

### DIFF
--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/dense.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/dense.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { makeMockLogger } from "../../../../__tests__/helpers/mock-logger.js";
+import type { AssistantConfig } from "../../../../config/types.js";
+
+mock.module("../../../../util/logger.js", () => ({
+  getLogger: () => makeMockLogger(),
+}));
+
+mock.module("../../../../memory/qdrant-client.js", () => ({
+  resolveQdrantUrl: () => "http://127.0.0.1:6333",
+}));
+
+// Stub the shared embedding backend. Records the queries it was asked to embed
+// and returns one deterministic vector so `denseLane` can issue the search.
+const embedState = {
+  calls: [] as string[][],
+  throws: null as Error | null,
+};
+mock.module("../../../../memory/embedding-backend.js", () => ({
+  embedWithBackend: async (_config: unknown, inputs: string[]) => {
+    embedState.calls.push(inputs);
+    if (embedState.throws) throw embedState.throws;
+    return {
+      provider: "local",
+      model: "test-model",
+      vectors: inputs.map(() => [0.1, 0.2, 0.3, 0.4]),
+    };
+  },
+}));
+
+// Mock the @qdrant/js-client-rest client. The mock records the query params and
+// returns whatever section points the test programmed (in descending score
+// order, matching Qdrant's behavior).
+type MockPoint = {
+  payload: { article: string; ordinal: number };
+  score: number;
+};
+
+const state = {
+  points: [] as MockPoint[],
+  queryThrows: null as Error | null,
+  queryCalls: [] as Array<{
+    collection: string;
+    query: unknown;
+    limit: number;
+  }>,
+};
+
+class MockQdrantClient {
+  constructor(_opts: unknown) {}
+  async query(name: string, params: { query: unknown; limit: number }) {
+    state.queryCalls.push({
+      collection: name,
+      query: params.query,
+      limit: params.limit,
+    });
+    if (state.queryThrows) throw state.queryThrows;
+    return { points: state.points };
+  }
+}
+
+mock.module("@qdrant/js-client-rest", () => ({
+  QdrantClient: MockQdrantClient,
+}));
+
+const { denseLane, OVERSAMPLE, _resetDenseLaneForTests } =
+  await import("../dense.js");
+const { SECTION_COLLECTION } = await import("../section-dense-store.js");
+
+const CONFIG = {
+  memory: { qdrant: { vectorSize: 4, onDisk: true } },
+} as unknown as AssistantConfig;
+
+function point(article: string, ordinal: number, score: number): MockPoint {
+  return { payload: { article, ordinal }, score };
+}
+
+function resetState(): void {
+  embedState.calls.length = 0;
+  embedState.throws = null;
+  state.points = [];
+  state.queryThrows = null;
+  state.queryCalls.length = 0;
+  _resetDenseLaneForTests();
+}
+
+describe("memory v3 dense lane", () => {
+  beforeEach(resetState);
+  afterEach(resetState);
+
+  test("targets the section collection at k * OVERSAMPLE depth", async () => {
+    state.points = [point("page-a", 0, 0.9)];
+
+    await denseLane(CONFIG, "some query", 5);
+
+    // Embedded the query once.
+    expect(embedState.calls).toEqual([["some query"]]);
+    // Oversampled the section search so dedupe still yields k articles.
+    expect(state.queryCalls).toHaveLength(1);
+    expect(state.queryCalls[0]!.collection).toBe(SECTION_COLLECTION);
+    expect(state.queryCalls[0]!.limit).toBe(5 * OVERSAMPLE);
+    expect(state.queryCalls[0]!.query).toEqual([0.1, 0.2, 0.3, 0.4]);
+  });
+
+  test("dedupes section points to distinct articles with their best section", async () => {
+    // page-a's best section is ordinal 2 (highest score); the later page-a
+    // section is ignored once the article is already represented.
+    state.points = [
+      point("page-a", 2, 0.95),
+      point("topic-x", 0, 0.9),
+      point("page-a", 1, 0.5),
+    ];
+
+    const hits = await denseLane(CONFIG, "query", 5);
+
+    expect(hits).toEqual([
+      { article: "page-a", section: 2 },
+      { article: "topic-x", section: 0 },
+    ]);
+  });
+
+  test("oversamples then truncates to k distinct articles", async () => {
+    state.points = [
+      point("page-a", 0, 0.99),
+      point("page-b", 0, 0.98),
+      point("page-c", 0, 0.97),
+      point("page-d", 0, 0.96),
+    ];
+
+    const hits = await denseLane(CONFIG, "query", 2);
+
+    expect(hits).toEqual([
+      { article: "page-a", section: 0 },
+      { article: "page-b", section: 0 },
+    ]);
+  });
+
+  test("ignores malformed payloads", async () => {
+    state.points = [
+      {
+        payload: {
+          article: 123,
+          ordinal: 0,
+        } as unknown as MockPoint["payload"],
+        score: 0.9,
+      },
+      point("topic-x", 1, 0.8),
+    ];
+
+    const hits = await denseLane(CONFIG, "query", 5);
+
+    expect(hits).toEqual([{ article: "topic-x", section: 1 }]);
+  });
+
+  test("a thrown Qdrant search degrades to []", async () => {
+    state.queryThrows = new Error("qdrant unreachable");
+
+    const hits = await denseLane(CONFIG, "query", 5);
+
+    expect(hits).toEqual([]);
+  });
+
+  test("a failed embedding degrades to []", async () => {
+    embedState.throws = new Error("embed backend down");
+
+    const hits = await denseLane(CONFIG, "query", 5);
+
+    expect(hits).toEqual([]);
+    // No Qdrant round-trip when embedding fails.
+    expect(state.queryCalls).toHaveLength(0);
+  });
+
+  test("non-positive k short-circuits without a search", async () => {
+    const hits = await denseLane(CONFIG, "query", 0);
+
+    expect(hits).toEqual([]);
+    expect(embedState.calls).toEqual([]);
+    expect(state.queryCalls).toHaveLength(0);
+  });
+});

--- a/assistant/src/plugins/defaults/memory-v3-shadow/dense.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/dense.ts
@@ -1,0 +1,111 @@
+// ---------------------------------------------------------------------------
+// Memory v3 — dense retrieval lane (section-grain)
+// ---------------------------------------------------------------------------
+//
+// Read counterpart to `section-dense-store.ts`. Embeds the turn query and runs
+// a single cosine search against the `memory_v3_sections` collection, then
+// dedupes the matched section points down to the top-`k` distinct articles —
+// each carrying its best-scoring section ordinal. This is the dense lane of the
+// section-grain retrieval design: where the v2 dense lane matches whole pages,
+// this one matches the single most relevant section of a long article and hands
+// the orchestrator both the article and which section matched (so the selector
+// can show the matched section as the descriptor).
+//
+// Degrades safely: any embedding or Qdrant failure logs a warning and returns
+// `[]`. The orchestrator unions the other lanes (needle, edge) plus carry-
+// forward regardless, so a dense outage narrows recall but never breaks a turn.
+
+import { QdrantClient as QdrantRestClient } from "@qdrant/js-client-rest";
+
+import type { AssistantConfig } from "../../../config/types.js";
+import { embedWithBackend } from "../../../memory/embedding-backend.js";
+import { resolveQdrantUrl } from "../../../memory/qdrant-client.js";
+import { getLogger } from "../../../util/logger.js";
+import { SECTION_COLLECTION } from "./section-dense-store.js";
+import type { Slug } from "./types.js";
+
+const log = getLogger("memory-v3-dense-lane");
+
+/**
+ * Multiplier applied to `k` when fetching section points from Qdrant. Several
+ * sections can belong to the same article, so we oversample the section hits to
+ * leave room for the article-level dedupe to still yield `k` distinct articles.
+ */
+export const OVERSAMPLE = 6;
+
+/** A single dense-lane hit: an article plus the section ordinal that matched. */
+export interface DenseHit {
+  article: Slug;
+  section: number;
+}
+
+let _client: QdrantRestClient | null = null;
+
+/** Lazily create a Qdrant REST client bound to the resolved URL. */
+function getClient(config: AssistantConfig): QdrantRestClient {
+  if (_client) return _client;
+  _client = new QdrantRestClient({
+    url: resolveQdrantUrl(config),
+    checkCompatibility: false,
+  });
+  return _client;
+}
+
+/**
+ * Run the dense lane: embed `query`, search the section collection for the top
+ * `k * OVERSAMPLE` section points, then dedupe to the top-`k` distinct articles
+ * — each with its best-scoring section ordinal. Section points are returned by
+ * Qdrant in descending score order, so the first time an article is seen is its
+ * best section; subsequent sections of the same article are ignored.
+ *
+ * Returns `[]` on any embedding or Qdrant failure (logged at warn level).
+ */
+export async function denseLane(
+  config: AssistantConfig,
+  query: string,
+  k: number,
+): Promise<DenseHit[]> {
+  if (k <= 0) return [];
+
+  let points: Array<{ payload?: unknown; score?: number }>;
+  try {
+    const { vectors } = await embedWithBackend(config, [query]);
+    const vector = vectors[0];
+    if (!vector || vector.length === 0) return [];
+
+    const result = await getClient(config).query(SECTION_COLLECTION, {
+      query: vector,
+      limit: k * OVERSAMPLE,
+      with_payload: true,
+    });
+    points = result.points;
+  } catch (err) {
+    log.warn({ err }, "memory v3 dense lane failed; degrading to no hits");
+    return [];
+  }
+
+  // Walk hits in score order, keeping the first (best) section per article and
+  // stopping once we have `k` distinct articles.
+  const seen = new Set<Slug>();
+  const hits: DenseHit[] = [];
+  for (const point of points) {
+    const payload = point.payload as
+      | { article?: unknown; ordinal?: unknown }
+      | null
+      | undefined;
+    const article = payload?.article;
+    const ordinal = payload?.ordinal;
+    if (typeof article !== "string" || typeof ordinal !== "number") continue;
+    if (seen.has(article)) continue;
+    seen.add(article);
+    hits.push({ article, section: ordinal });
+    if (hits.length >= k) break;
+  }
+
+  return hits;
+}
+
+/** @internal Test-only: reset module-level singletons. */
+export function _resetDenseLaneForTests(): void {
+  _client = null;
+}


### PR DESCRIPTION
## Summary
- Add denseLane(): embed the query, search the memory_v3_sections collection, oversample then dedupe to top-k distinct articles each with a matched section ordinal; failures degrade to [].
- Additive; wired into orchestrate in a later PR.

Part of plan: memory-v3-section-lanes.md (PR 4 of 12)