### PR TITLE
refactor(memory-v3): orchestrate over lanes + pool-select, keep carry-forward

### DIFF
--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/live-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/live-integration.test.ts
@@ -4,9 +4,9 @@
  * SCOPE / ALTITUDE. A full daemon-assembly integration (plugin registry → flag
  * read → runtime assembly → provider call) is too heavy and too mock-fragile
  * for a unit test. Instead this composes the REAL v3 live-path units with a
- * mocked routing/selection provider and synthetic fixtures:
+ * mocked select provider + stubbed dense lane and synthetic fixtures:
  *
- *   orchestrate (routeL1 + selectAcrossLeaves over a shared WorkingSet)
+ *   orchestrate (needle ∪ dense ∪ edge → selectPool over a shared WorkingSet)
  *     → renderMemoryBlock (the rendered `<memory>` working-set block)
  *     → stripAllMemoryInjections (all-turns history strip)
  *
@@ -16,35 +16,26 @@
  * message so exactly one block exists. Driving these real units across turns
  * exercises carry-forward, eviction, single-source, and strip-all end-to-end at
  * the v3 layer without the daemon. The provider is stubbed (no network).
- *
- * Mock-leak safety: the only `mock.module` here stub the provider + logger,
- * which are pure inputs to orchestrate and carry no real behavior siblings
- * depend on (orchestrate.test.ts installs the identical stubs). No
- * snapshot-real-modules dance is needed because nothing is partially stubbed.
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { stripAllMemoryInjections } from "../../../../memory/graph/conversation-graph-memory.js";
+import type { PageIndexEntry } from "../../../../memory/v2/page-index.js";
 import type {
   ContentBlock,
   Message,
   Provider,
   ProviderResponse,
 } from "../../../../providers/types.js";
-import type { NeedleIndex } from "../needle.js";
-import type {
-  LeafNode,
-  LeafPath,
-  LeafTree,
-  MemoryRoutingTurn,
-  Slug,
-} from "../types.js";
-import liveTurns from "./fixtures/live-turns.json" with { type: "json" };
+import type { EdgeGraph } from "../edge.js";
+import { buildEdgeGraph } from "../edge.js";
+import { buildSectionNeedle } from "../section-needle.js";
+import { buildSectionIndex } from "../sections.js";
+import type { MemoryRoutingTurn, SectionIndex, Slug } from "../types.js";
 
 // ---------------------------------------------------------------------------
-// Provider mock installed BEFORE the orchestrator import so router.ts and
-// selector.ts observe it at load time. Mirrors orchestrate.test.ts.
+// Module stubs installed BEFORE the orchestrator import.
 // ---------------------------------------------------------------------------
 
 let providerStub: Provider | null = null;
@@ -62,60 +53,61 @@ mock.module("../../../../util/logger.js", () => ({
     }),
 }));
 
+// The dense lane never hits in this fixture — the needle drives the pool. The
+// stub DELEGATES to the real `denseLane` unless this file's tests are running
+// (`denseMockActive`), so the process-global `mock.module` cannot leak fake
+// behavior into dense.test.ts (which exercises the real lane).
+const realDense = { ...(await import("../dense.js")) };
+let denseMockActive = false;
+mock.module("../dense.js", () => ({
+  ...realDense,
+  denseLane: async (...args: Parameters<typeof realDense.denseLane>) =>
+    denseMockActive ? [] : realDense.denseLane(...args),
+}));
+
 const { orchestrate } = await import("../orchestrate.js");
 const { WorkingSet } = await import("../working-set.js");
 const { renderMemoryBlock } = await import("../render-injection.js");
 
 // ---------------------------------------------------------------------------
-// Fixture types + helpers.
+// Fixtures: a tiny corpus whose section text contains a distinctive term per
+// page so a query selects exactly that page via the needle.
 // ---------------------------------------------------------------------------
 
-interface LeafSelection {
-  ids: number[];
-  pinned_ids: number[];
-}
-interface LiveTurn {
-  name: string;
-  currentMessage: string;
-  routeIds: number[];
-  leafSelections: Record<LeafPath, LeafSelection>;
-}
-const TURNS = (liveTurns as unknown as { turns: LiveTurn[] }).turns;
+const PAGES: Record<Slug, string> = {
+  "page-a": "lead a\n## Body\napple content for page a",
+  "page-b": "lead b\n## Body\nbanana content for page b",
+  "page-c": "lead c\n## Body\ncherry content for page c",
+};
+const SLUGS = Object.keys(PAGES);
 
-function makeLeaf(path: LeafPath, members: Slug[]): LeafNode {
-  return {
-    path,
-    frontmatter: { path, in_core: false },
-    description: `description for ${path}`,
-    members,
-    domain: path.split("/")[0],
-  };
+function makeEntries(): PageIndexEntry[] {
+  return SLUGS.map((slug, i) => ({
+    id: i + 1,
+    slug,
+    summary: `summary of ${slug}`,
+    edges: [],
+    leaves: [],
+    modifiedAt: 0,
+  }));
 }
 
-/**
- * Synthetic tree. Sorted leaf order is [domain-a/topic-x, domain-a/topic-y],
- * so L1 id 1 → topic-x, id 2 → topic-y.
- */
-function makeTree(): LeafTree {
-  const leaves: LeafNode[] = [
-    makeLeaf("domain-a/topic-x", ["page-a", "page-b"]),
-    makeLeaf("domain-a/topic-y", ["page-c"]),
-  ];
-  const byPage = new Map<Slug, LeafPath[]>();
-  for (const leaf of leaves) {
-    for (const slug of leaf.members) {
-      byPage.set(slug, [...(byPage.get(slug) ?? []), leaf.path]);
-    }
-  }
-  return { leaves: new Map(leaves.map((n) => [n.path, n])), byPage };
-}
-
-const summaryOf = async (slug: Slug): Promise<string> => `summary of ${slug}`;
-/** Deterministic per-slug body so the rendered `<memory>` block is assertable. */
+const config = {} as never;
 const contentOf = async (slug: Slug): Promise<string> => `body for ${slug}`;
 
-/** Needle that never hits — routing alone drives the open set in this fixture. */
-const emptyNeedle: NeedleIndex = { query: () => [] };
+async function buildLanes(): Promise<{
+  sectionIndex: SectionIndex;
+  needle: ReturnType<typeof buildSectionNeedle>;
+  edgeGraph: EdgeGraph;
+}> {
+  const sectionIndex = await buildSectionIndex(SLUGS, async (s) => PAGES[s]!);
+  const needle = buildSectionNeedle(sectionIndex);
+  const edgeGraph = await buildEdgeGraph(
+    makeEntries(),
+    async (s) => PAGES[s]!, // no `links:` frontmatter → edge graph is empty
+  );
+  return { sectionIndex, needle, edgeGraph };
+}
 
 function makeTurn(
   turnNumber: number,
@@ -129,69 +121,67 @@ function makeTurn(
   };
 }
 
-function toolUseResponse(
-  name: string,
-  input: Record<string, unknown>,
-): ProviderResponse {
+function toolUseResponse(input: Record<string, unknown>): ProviderResponse {
   return {
     model: "stub-model",
     stopReason: "tool_use",
     usage: { inputTokens: 0, outputTokens: 0 },
-    content: [{ type: "tool_use", id: "tu-1", name, input }],
+    content: [{ type: "tool_use", id: "tu-1", name: "select_pages", input }],
   };
 }
 
-/** Last `<leaf>X</leaf>` tag found in an L2 request, or undefined. */
-function leafFromMessages(messages: Message[]): LeafPath | undefined {
+/** Parse the numbered `<candidates>` block into an ordered slug list. */
+function candidateSlugs(messages: Message[]): Slug[] {
   for (const msg of messages) {
     for (const block of msg.content) {
-      if (block.type === "text") {
-        const m = /<leaf>([^<]+)<\/leaf>/.exec(block.text);
-        if (m) return m[1];
-      }
+      if (block.type !== "text") continue;
+      const m = /<candidates>\n([\s\S]*?)\n<\/candidates>/.exec(block.text);
+      if (!m) continue;
+      return m[1]
+        .split("\n")
+        .map((line) => /^\[\d+\] (\S+) —/.exec(line)?.[1])
+        .filter((s): s is string => !!s);
     }
   }
-  return undefined;
+  return [];
 }
 
-/**
- * Build a provider that answers L1 `open_leaves` with `routeIds` and each L2
- * `select_pages` call with the per-leaf selection from the fixture turn.
- */
-function providerForTurn(turn: LiveTurn): Provider {
+/** Provider that selects (and optionally pins) the pooled candidates in `keep`. */
+function selectProvider(keep: Slug[], pin: Slug[] = []): Provider {
   return {
     name: "stub",
-    sendMessage: async (messages, options) => {
-      const toolName = options?.tools?.[0]?.name;
-      if (toolName === "open_leaves") {
-        return toolUseResponse("open_leaves", { ids: turn.routeIds });
-      }
-      const leaf = leafFromMessages(messages);
-      const sel = (leaf ? turn.leafSelections[leaf] : undefined) ?? {
-        ids: [],
-        pinned_ids: [],
-      };
-      return toolUseResponse("select_pages", {
-        ids: sel.ids,
-        pinned_ids: sel.pinned_ids,
+    sendMessage: async (messages) => {
+      const pool = candidateSlugs(messages);
+      const ids: number[] = [];
+      const pinned_ids: number[] = [];
+      pool.forEach((slug, i) => {
+        if (keep.includes(slug)) ids.push(i + 1);
+        if (pin.includes(slug)) pinned_ids.push(i + 1);
       });
+      return toolUseResponse({ ids, pinned_ids });
     },
   };
 }
 
 /** Run one turn through orchestrate over the shared working set + render it. */
 async function runTurn(
-  turn: LiveTurn,
   turnNumber: number,
-  deps: { tree: LeafTree; workingSet: InstanceType<typeof WorkingSet> },
+  query: string,
+  keep: Slug[],
+  pin: Slug[],
+  deps: {
+    lanes: Awaited<ReturnType<typeof buildLanes>>;
+    workingSet: InstanceType<typeof WorkingSet>;
+  },
 ) {
-  providerStub = providerForTurn(turn);
-  const result = await orchestrate(makeTurn(turnNumber, turn.currentMessage), {
-    tree: deps.tree,
-    core: new Set(),
-    needle: emptyNeedle,
+  providerStub = selectProvider(keep, pin);
+  const result = await orchestrate(makeTurn(turnNumber, query), {
+    sectionIndex: deps.lanes.sectionIndex,
+    needle: deps.lanes.needle,
+    denseConfig: config,
+    edgeGraph: deps.lanes.edgeGraph,
     workingSet: deps.workingSet,
-    pageSummary: summaryOf,
+    capabilitySlugs: [],
   });
   const block = await renderMemoryBlock(result.finalInjection, contentOf);
   return { result, block };
@@ -203,7 +193,12 @@ function countMemoryBlocks(text: string): number {
 }
 
 beforeEach(() => {
+  denseMockActive = true;
   providerStub = null;
+});
+
+afterAll(() => {
+  denseMockActive = false;
 });
 
 // ---------------------------------------------------------------------------
@@ -213,20 +208,23 @@ beforeEach(() => {
 
 describe("memory-v3 live — carry-forward across turns", () => {
   test("a page pinned in turn 1 is injected in turn 2 without re-selection", async () => {
-    const tree = makeTree();
+    const lanes = await buildLanes();
     const workingSet = new WorkingSet();
 
-    const t1 = await runTurn(TURNS[0], 1, { tree, workingSet });
-    // page-a was selected (and pinned) this turn and rendered into the block.
+    const t1 = await runTurn(1, "apple", ["page-a"], ["page-a"], {
+      lanes,
+      workingSet,
+    });
     expect(t1.result.currentSelections.map((s) => s.slug)).toContain("page-a");
     expect(t1.block).toContain("body for page-a");
 
-    const t2 = await runTurn(TURNS[1], 2, { tree, workingSet });
-    // Turn 2 opens a DIFFERENT leaf (topic-y) and never re-selects page-a…
+    const t2 = await runTurn(2, "cherry", ["page-c"], [], {
+      lanes,
+      workingSet,
+    });
     expect(t2.result.currentSelections.map((s) => s.slug)).not.toContain(
       "page-a",
     );
-    // …yet page-a carries forward into the injected block via the working set.
     expect(t2.result.finalInjection).toContain("page-a");
     expect(t2.block).toContain("body for page-a");
   });
@@ -239,24 +237,36 @@ describe("memory-v3 live — carry-forward across turns", () => {
 
 describe("memory-v3 live — eviction reflected in the injected block", () => {
   test("a stale non-pinned page drops out; the pinned page persists", async () => {
-    const tree = makeTree();
+    const lanes = await buildLanes();
     // Small window: a non-pinned entry unseen for >2 turns evicts. page-b is
     // selected only in turn 1, so by turn 4 (4-1=3 > 2) it ages out; pinned
     // page-a never evicts; page-c is re-selected every later turn.
     const workingSet = new WorkingSet(150, 2);
 
-    const t1 = await runTurn(TURNS[0], 1, { tree, workingSet });
+    const t1 = await runTurn(
+      1,
+      "apple banana",
+      ["page-a", "page-b"],
+      ["page-a"],
+      { lanes, workingSet },
+    );
     expect(t1.result.finalInjection).toContain("page-b");
     expect(t1.block).toContain("body for page-b");
 
-    // Turns 2–3 keep page-b inside the window (3-1=2, not > 2).
-    await runTurn(TURNS[1], 2, { tree, workingSet });
-    const t3 = await runTurn(TURNS[2], 3, { tree, workingSet });
+    // Turns 2–3 keep page-b inside the window (3-1=2, not > 2); re-select page-c.
+    await runTurn(2, "cherry", ["page-c"], [], { lanes, workingSet });
+    const t3 = await runTurn(3, "cherry", ["page-c"], [], {
+      lanes,
+      workingSet,
+    });
     expect(t3.result.finalInjection).toContain("page-b");
 
     // Turn 4: page-b is now stale (4-1=3 > 2) and must be gone from the block;
     // pinned page-a and freshly-selected page-c remain.
-    const t4 = await runTurn(TURNS[3], 4, { tree, workingSet });
+    const t4 = await runTurn(4, "cherry", ["page-c"], [], {
+      lanes,
+      workingSet,
+    });
     expect(t4.result.finalInjection).not.toContain("page-b");
     expect(t4.block).not.toContain("body for page-b");
     expect(t4.result.finalInjection).toContain("page-a");
@@ -266,17 +276,20 @@ describe("memory-v3 live — eviction reflected in the injected block", () => {
 
 // ---------------------------------------------------------------------------
 // Single source: orchestrate → render produces exactly one coherent `<memory>`
-// block per turn. (Assembly-level v2 suppression is covered by the assembly
-// tests; here we assert the v3 producer never emits more than one block.)
+// block per turn.
 // ---------------------------------------------------------------------------
 
 describe("memory-v3 live — single memory source", () => {
   test("each turn renders exactly one <memory> block", async () => {
-    const tree = makeTree();
+    const lanes = await buildLanes();
     const workingSet = new WorkingSet();
 
-    for (const [i, turn] of TURNS.entries()) {
-      const { block } = await runTurn(turn, i + 1, { tree, workingSet });
+    const queries = ["apple", "banana", "cherry"];
+    for (const [i, query] of queries.entries()) {
+      const { block } = await runTurn(i + 1, query, [SLUGS[i]!], [], {
+        lanes,
+        workingSet,
+      });
       expect(countMemoryBlocks(block)).toBe(1);
       expect(block.startsWith("<memory>\n")).toBe(true);
       expect(block.endsWith("\n</memory>")).toBe(true);
@@ -291,10 +304,9 @@ describe("memory-v3 live — single memory source", () => {
 
 describe("memory-v3 live — all-turns history strip", () => {
   test("historical <memory> blocks strip back to byte-stable user history", async () => {
-    const tree = makeTree();
+    const lanes = await buildLanes();
     const workingSet = new WorkingSet();
 
-    // The canonical (un-injected) user history the strip must converge to.
     const baseHistory: Message[] = [
       { role: "user", content: [{ type: "text", text: "first user message" }] },
       { role: "assistant", content: [{ type: "text", text: "ok" }] },
@@ -306,17 +318,14 @@ describe("memory-v3 live — all-turns history strip", () => {
       { role: "user", content: [{ type: "text", text: "third user message" }] },
     ];
 
-    // Simulate prior turns having injected a v3 `<memory>` block onto EVERY
-    // historical user message (prepended, as the live path does).
     const memBlock = (text: string): ContentBlock => ({ type: "text", text });
+    const queries = ["apple", "banana", "cherry"];
     let injected: Message[] = baseHistory;
-    for (let turnNumber = 1; turnNumber <= TURNS.length; turnNumber++) {
-      const { block } = await runTurn(TURNS[turnNumber - 1], turnNumber, {
-        tree,
+    for (const [i, query] of queries.entries()) {
+      const { block } = await runTurn(i + 1, query, [SLUGS[i]!], [], {
+        lanes,
         workingSet,
       });
-      // Re-inject this turn's freshly-rendered block onto each user message,
-      // after stripping the prior turn's block (what the live assembly does).
       const stripped = stripAllMemoryInjections(injected);
       injected = stripped.map((m) =>
         m.role === "user"
@@ -325,8 +334,6 @@ describe("memory-v3 live — all-turns history strip", () => {
       );
     }
 
-    // After a final all-turns strip, history is byte-identical to the canonical
-    // base — every injected block was recognized and removed.
     const finalStripped = stripAllMemoryInjections(injected);
     expect(finalStripped).toEqual(baseHistory);
   });

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/orchestrate.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/orchestrate.test.ts
@@ -1,36 +1,35 @@
 /**
- * Tests for `assistant/src/memory/v3/orchestrate.ts`.
+ * Tests for `orchestrate.ts` (section-lane pipeline).
  *
- * The orchestrator composes four lanes: L1 routing + BM25 needle (parallel) →
- * open set (routed ∪ core ∪ needle-owning leaves) → bounded per-leaf L2
- * selection → carry-forward working set (record + evict) → final injection.
+ * The orchestrator composes three deterministic candidate lanes — the
+ * section-grain BM25 needle, the dense lane, and link-graph edge expansion —
+ * into ONE unified pool, appends the synthetic capability slugs, runs a SINGLE
+ * forced-tool select over the pool, then carries forward the working set.
  *
- * The provider is stubbed (no network). A single stub answers BOTH the L1
- * `open_leaves` call and the per-leaf L2 `select_pages` calls by inspecting the
- * forced tool name and, for L2, the `<leaf>...</leaf>` tag in the prompt. The
- * needle is a hand-built fake so we control its hits directly.
+ * The select provider is stubbed (no network); a single stub answers the one
+ * `select_pages` call per turn by reading the numbered `<candidates>` block.
+ * The dense lane is stubbed at the module boundary. The needle and edge graph
+ * are real, built from tiny inline fixtures so the pool union is exercised
+ * end-to-end.
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import type { PageIndexEntry } from "../../../../memory/v2/page-index.js";
 import type {
   Message,
   Provider,
   ProviderResponse,
 } from "../../../../providers/types.js";
-import type { NeedleIndex } from "../needle.js";
-import type {
-  LeafNode,
-  LeafPath,
-  LeafTree,
-  MemoryRoutingTurn,
-  Slug,
-} from "../types.js";
-import evalTurns from "./fixtures/eval-turns.json" with { type: "json" };
+import type { EdgeGraph } from "../edge.js";
+import { buildEdgeGraph } from "../edge.js";
+import { buildSectionNeedle } from "../section-needle.js";
+import { buildSectionIndex } from "../sections.js";
+import type { MemoryRoutingTurn, SectionIndex, Slug } from "../types.js";
 
 // ---------------------------------------------------------------------------
-// Provider mock installed BEFORE the orchestrator import so router.ts and
-// selector.ts observe it at load time.
+// Module stubs installed BEFORE the orchestrator import so pool-select and the
+// dense lane observe them at load time.
 // ---------------------------------------------------------------------------
 
 let providerStub: Provider | null = null;
@@ -48,61 +47,69 @@ mock.module("../../../../util/logger.js", () => ({
     }),
 }));
 
-const { orchestrate, DEFAULT_NEEDLE_K } = await import("../orchestrate.js");
+// The dense lane is stubbed: each test sets `denseHits` to control which
+// articles (+ matched ordinals) the dense lane returns. The stub DELEGATES to
+// the real `denseLane` unless this file's tests are running (`denseMockActive`),
+// so the process-global `mock.module` cannot leak fake behavior into
+// dense.test.ts (which exercises the real lane). Spread the real module so
+// every other export (`_resetDenseLaneForTests`, `OVERSAMPLE`) stays present.
+const realDense = { ...(await import("../dense.js")) };
+let denseMockActive = false;
+let denseHits: Array<{ article: Slug; section: number }> = [];
+mock.module("../dense.js", () => ({
+  ...realDense,
+  denseLane: async (...args: Parameters<typeof realDense.denseLane>) =>
+    denseMockActive ? denseHits : realDense.denseLane(...args),
+}));
+
+const { orchestrate, DEFAULT_NEEDLE_K, DEFAULT_DENSE_K } =
+  await import("../orchestrate.js");
 const { WorkingSet } = await import("../working-set.js");
 
 // ---------------------------------------------------------------------------
-// Fixture types + helpers.
+// Fixtures: a tiny corpus of pages with bodies + `links:` frontmatter.
 // ---------------------------------------------------------------------------
 
-interface LeafSelection {
-  ids: number[];
-  pinned_ids: number[];
-}
-interface EvalTurn {
-  name: string;
-  currentMessage: string;
-  routeIds: number[];
-  leafSelections: Record<LeafPath, LeafSelection>;
-  expectedOpenedLeaves: LeafPath[];
-  expectedFinalInjection: Slug[];
-}
-const TURNS = (evalTurns as { turns: EvalTurn[] }).turns;
+const PAGES: Record<Slug, string> = {
+  "topic-a": "lead for topic a\n## Details\napple banana about topic a",
+  "topic-b": "lead for topic b\n## More\ncherry date about topic b",
+  "topic-c": "lead for topic c\n## Notes\nelderberry fig about topic c",
+  "topic-d": "lead for topic d\n## Notes\ngrape about topic d",
+};
 
-function makeLeaf(path: LeafPath, members: Slug[]): LeafNode {
-  return {
-    path,
-    frontmatter: { path, in_core: false },
-    description: `description for ${path}`,
-    members,
-    domain: path.split("/")[0],
-  };
-}
+/** Raw page = frontmatter (with `links:`) + body. */
+const RAW: Record<Slug, string> = {
+  "topic-a": `---\nlinks:\n  - "topic-d — the curated edge from a to d"\n---\n${PAGES["topic-a"]}`,
+  "topic-b": `---\nedges: []\n---\n${PAGES["topic-b"]}`,
+  "topic-c": `---\nedges: []\n---\n${PAGES["topic-c"]}`,
+  "topic-d": `---\nedges: []\n---\n${PAGES["topic-d"]}`,
+};
 
-/**
- * Synthetic tree. Sorted leaf order is [domain-a/topic-x, domain-a/topic-y],
- * so L1 id 1 → topic-x, id 2 → topic-y.
- */
-function makeTree(): LeafTree {
-  const leaves: LeafNode[] = [
-    makeLeaf("domain-a/topic-x", ["page-a", "page-b"]),
-    makeLeaf("domain-a/topic-y", ["page-c"]),
-  ];
-  const byPage = new Map<Slug, LeafPath[]>();
-  for (const leaf of leaves) {
-    for (const slug of leaf.members) {
-      byPage.set(slug, [...(byPage.get(slug) ?? []), leaf.path]);
-    }
-  }
-  return { leaves: new Map(leaves.map((n) => [n.path, n])), byPage };
+const SLUGS = Object.keys(PAGES);
+
+function makeEntries(): PageIndexEntry[] {
+  return SLUGS.map((slug, i) => ({
+    id: i + 1,
+    slug,
+    summary: `summary of ${slug}`,
+    edges: [],
+    leaves: [],
+    modifiedAt: 0,
+  }));
 }
 
-const summaryOf = async (slug: Slug): Promise<string> => `summary of ${slug}`;
-
-/** Needle that returns a fixed slug list, ignoring the query. */
-function fakeNeedle(hits: Slug[]): NeedleIndex {
-  return { query: (_text, k) => hits.slice(0, k) };
+async function buildLanes(): Promise<{
+  sectionIndex: SectionIndex;
+  needle: ReturnType<typeof buildSectionNeedle>;
+  edgeGraph: EdgeGraph;
+}> {
+  const sectionIndex = await buildSectionIndex(SLUGS, async (s) => PAGES[s]!);
+  const needle = buildSectionNeedle(sectionIndex);
+  const edgeGraph = await buildEdgeGraph(makeEntries(), async (s) => RAW[s]!);
+  return { sectionIndex, needle, edgeGraph };
 }
+
+const config = {} as never;
 
 function makeTurn(
   turnNumber: number,
@@ -116,324 +123,331 @@ function makeTurn(
   };
 }
 
-function toolUseResponse(
-  name: string,
-  input: Record<string, unknown>,
-): ProviderResponse {
+function toolUseResponse(input: Record<string, unknown>): ProviderResponse {
   return {
     model: "stub-model",
     stopReason: "tool_use",
     usage: { inputTokens: 0, outputTokens: 0 },
-    content: [{ type: "tool_use", id: "tu-1", name, input }],
+    content: [{ type: "tool_use", id: "tu-1", name: "select_pages", input }],
   };
 }
 
-/** Last `<leaf>X</leaf>` tag found in an L2 request, or undefined. */
-function leafFromMessages(messages: Message[]): LeafPath | undefined {
+/** Parse the numbered `<candidates>` block back into an ordered slug list. */
+function candidateSlugs(messages: Message[]): Slug[] {
   for (const msg of messages) {
     for (const block of msg.content) {
-      if (block.type === "text") {
-        const m = /<leaf>([^<]+)<\/leaf>/.exec(block.text);
-        if (m) return m[1];
-      }
+      if (block.type !== "text") continue;
+      const m = /<candidates>\n([\s\S]*?)\n<\/candidates>/.exec(block.text);
+      if (!m) continue;
+      return m[1]
+        .split("\n")
+        .map((line) => /^\[\d+\] (\S+) —/.exec(line)?.[1])
+        .filter((s): s is string => !!s);
     }
   }
-  return undefined;
+  return [];
 }
 
 /**
- * Build a provider that answers L1 `open_leaves` with `routeIds` and each L2
- * `select_pages` call with the per-leaf selection from the fixture turn.
+ * Provider that selects the pool candidates whose slug is in `keep` (mapping
+ * each back to its 1-based id), pinning those in `pin`. Captures the rendered
+ * candidate list for pool assertions.
  */
-function providerForTurn(turn: EvalTurn): Provider {
+let lastPool: Slug[] = [];
+let selectCalls = 0;
+function selectProvider(keep: Slug[], pin: Slug[] = []): Provider {
   return {
     name: "stub",
-    sendMessage: async (messages, options) => {
-      const toolName = options?.tools?.[0]?.name;
-      if (toolName === "open_leaves") {
-        return toolUseResponse("open_leaves", { ids: turn.routeIds });
-      }
-      // L2 select_pages — pick the selection for the leaf under selection.
-      const leaf = leafFromMessages(messages);
-      const sel = (leaf ? turn.leafSelections[leaf] : undefined) ?? {
-        ids: [],
-        pinned_ids: [],
-      };
-      return toolUseResponse("select_pages", {
-        ids: sel.ids,
-        pinned_ids: sel.pinned_ids,
+    sendMessage: async (messages) => {
+      selectCalls++;
+      const pool = candidateSlugs(messages);
+      lastPool = pool;
+      const ids: number[] = [];
+      const pinned_ids: number[] = [];
+      pool.forEach((slug, i) => {
+        if (keep.includes(slug)) ids.push(i + 1);
+        if (pin.includes(slug)) pinned_ids.push(i + 1);
       });
+      return toolUseResponse({ ids, pinned_ids });
     },
   };
 }
 
 beforeEach(() => {
+  denseMockActive = true;
   providerStub = null;
+  denseHits = [];
+  lastPool = [];
+  selectCalls = 0;
+});
+
+afterAll(() => {
+  denseMockActive = false;
 });
 
 // ---------------------------------------------------------------------------
-// Integration: drive the whole fixture sequence through ONE shared WorkingSet.
+// Pool composition: the candidate pool is the union of the lanes + capabilities.
 // ---------------------------------------------------------------------------
 
-describe("orchestrate — fixture sequence (carry-forward)", () => {
-  test("each turn's finalInjection matches the fixture", async () => {
-    const tree = makeTree();
-    const workingSet = new WorkingSet();
-    const needle = fakeNeedle([]);
+describe("orchestrate — candidate pool composition", () => {
+  test("pool unions needle ∪ dense ∪ edge ∪ capabilities; one select runs", async () => {
+    const lanes = await buildLanes();
+    // "apple" hits topic-a (needle). Dense returns topic-b. topic-a links to
+    // topic-d (edge). Capability slug always appended.
+    denseHits = [{ article: "topic-b", section: 0 }];
+    providerStub = selectProvider([]); // selection is irrelevant to pool union
 
-    for (const turn of TURNS) {
-      providerStub = providerForTurn(turn);
-      const result = await orchestrate(
-        makeTurn(TURNS.indexOf(turn) + 1, turn.currentMessage),
-        { tree, core: new Set(), needle, workingSet, pageSummary: summaryOf },
-      );
-      expect(result.openedLeaves).toEqual(turn.expectedOpenedLeaves);
-      expect(result.finalInjection).toEqual(turn.expectedFinalInjection);
-    }
+    await orchestrate(makeTurn(1, "apple"), {
+      sectionIndex: lanes.sectionIndex,
+      needle: lanes.needle,
+      denseConfig: config,
+      edgeGraph: lanes.edgeGraph,
+      workingSet: new WorkingSet(),
+      capabilitySlugs: ["skills/example"],
+    });
+
+    expect(selectCalls).toBe(1);
+    expect(new Set(lastPool)).toEqual(
+      new Set(["topic-a", "topic-b", "topic-d", "skills/example"]),
+    );
   });
 
-  test("a slug pinned in turn 1 carries into turn 2 without re-selection", async () => {
-    const tree = makeTree();
+  test("edge curated link description becomes the edge candidate's descriptor", async () => {
+    const lanes = await buildLanes();
+    let descriptorLine = "";
+    providerStub = {
+      name: "stub",
+      sendMessage: async (messages) => {
+        for (const msg of messages) {
+          for (const block of msg.content) {
+            if (block.type !== "text") continue;
+            const m = /\[\d+\] topic-d — ([^\n]+)/.exec(block.text);
+            if (m) descriptorLine = m[1]!;
+          }
+        }
+        return toolUseResponse({ ids: [] });
+      },
+    };
+
+    await orchestrate(makeTurn(1, "apple"), {
+      sectionIndex: lanes.sectionIndex,
+      needle: lanes.needle,
+      denseConfig: config,
+      edgeGraph: lanes.edgeGraph,
+      workingSet: new WorkingSet(),
+      capabilitySlugs: [],
+    });
+
+    expect(descriptorLine).toContain("the curated edge from a to d");
+  });
+
+  test("needleK and denseK default to their constants", async () => {
+    const lanes = await buildLanes();
+    let needleK = -1;
+    const needle = {
+      query: (_t: string, k: number) => {
+        needleK = k;
+        return [];
+      },
+      bestSection: () => -1,
+    };
+    providerStub = selectProvider([]);
+    await orchestrate(makeTurn(1, "x"), {
+      sectionIndex: lanes.sectionIndex,
+      needle,
+      denseConfig: config,
+      edgeGraph: lanes.edgeGraph,
+      workingSet: new WorkingSet(),
+      capabilitySlugs: [],
+    });
+    expect(needleK).toBe(DEFAULT_NEEDLE_K);
+    expect(DEFAULT_DENSE_K).toBe(100);
+  });
+
+  test("sectionBySlug is populated from matched lane sections", async () => {
+    const lanes = await buildLanes();
+    denseHits = [];
+    providerStub = selectProvider(["topic-a"]);
+    const result = await orchestrate(makeTurn(1, "apple"), {
+      sectionIndex: lanes.sectionIndex,
+      needle: lanes.needle,
+      denseConfig: config,
+      edgeGraph: lanes.edgeGraph,
+      workingSet: new WorkingSet(),
+      capabilitySlugs: [],
+    });
+    // topic-a matched "apple" in its `## Details` section.
+    expect(result.sectionBySlug.get("topic-a")?.article).toBe("topic-a");
+    expect(result.sectionBySlug.get("topic-a")?.text).toContain("apple");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Carry-forward: same working-set semantics as the prior tree pipeline.
+// ---------------------------------------------------------------------------
+
+describe("orchestrate — carry-forward", () => {
+  test("a page selected+pinned in turn 1 carries into turn 2 without re-selection", async () => {
+    const lanes = await buildLanes();
     const workingSet = new WorkingSet();
-    const needle = fakeNeedle([]);
 
-    // Turn 1 selects+pins page-a.
-    providerStub = providerForTurn(TURNS[0]);
-    await orchestrate(makeTurn(1, TURNS[0].currentMessage), {
-      tree,
-      core: new Set(),
-      needle,
+    // Turn 1 selects+pins topic-a.
+    providerStub = selectProvider(["topic-a"], ["topic-a"]);
+    await orchestrate(makeTurn(1, "apple"), {
+      sectionIndex: lanes.sectionIndex,
+      needle: lanes.needle,
+      denseConfig: config,
+      edgeGraph: lanes.edgeGraph,
       workingSet,
-      pageSummary: summaryOf,
+      capabilitySlugs: [],
     });
 
-    // Turn 2 opens a DIFFERENT leaf and never re-selects page-a.
-    providerStub = providerForTurn(TURNS[1]);
-    const t2 = await orchestrate(makeTurn(2, TURNS[1].currentMessage), {
-      tree,
-      core: new Set(),
-      needle,
+    // Turn 2 selects a DIFFERENT page and never re-selects topic-a.
+    denseHits = [{ article: "topic-b", section: 0 }];
+    providerStub = selectProvider(["topic-b"]);
+    const t2 = await orchestrate(makeTurn(2, "cherry"), {
+      sectionIndex: lanes.sectionIndex,
+      needle: lanes.needle,
+      denseConfig: config,
+      edgeGraph: lanes.edgeGraph,
       workingSet,
-      pageSummary: summaryOf,
+      capabilitySlugs: [],
     });
 
-    expect(t2.currentSelections.map((s) => s.slug)).not.toContain("page-a");
-    expect(t2.finalInjection).toContain("page-a");
+    expect(t2.currentSelections.map((s) => s.slug)).not.toContain("topic-a");
+    expect(t2.finalInjection).toContain("topic-a");
   });
 
   test("carry-forward survives a turn whose selections fill the cap", async () => {
-    const tree = makeTree();
+    const lanes = await buildLanes();
     // Cap of 1: under a naive record-then-cap order this turn's own selection
     // would evict the carried page before injection. Snapshotting the carry
     // BEFORE recording this turn keeps the earlier page in the injection.
     const workingSet = new WorkingSet(1);
-    const needle = fakeNeedle([]);
-    const stub = (selectIds: number[]): Provider => ({
-      name: "stub",
-      sendMessage: async (_messages, options) =>
-        options?.tools?.[0]?.name === "open_leaves"
-          ? toolUseResponse("open_leaves", { ids: [1] })
-          : toolUseResponse("select_pages", { ids: selectIds, pinned_ids: [] }),
-    });
 
-    providerStub = stub([1]); // turn 1 → page-a
-    await orchestrate(makeTurn(1, "page a"), {
-      tree,
-      core: new Set(),
-      needle,
+    providerStub = selectProvider(["topic-a"]); // turn 1 → topic-a
+    await orchestrate(makeTurn(1, "apple"), {
+      sectionIndex: lanes.sectionIndex,
+      needle: lanes.needle,
+      denseConfig: config,
+      edgeGraph: lanes.edgeGraph,
       workingSet,
-      pageSummary: summaryOf,
+      capabilitySlugs: [],
     });
 
-    providerStub = stub([2]); // turn 2 → page-b, never re-selects page-a
-    const t2 = await orchestrate(makeTurn(2, "page b"), {
-      tree,
-      core: new Set(),
-      needle,
+    denseHits = [{ article: "topic-b", section: 0 }];
+    providerStub = selectProvider(["topic-b"]); // turn 2 → topic-b
+    const t2 = await orchestrate(makeTurn(2, "cherry"), {
+      sectionIndex: lanes.sectionIndex,
+      needle: lanes.needle,
+      denseConfig: config,
+      edgeGraph: lanes.edgeGraph,
       workingSet,
-      pageSummary: summaryOf,
+      capabilitySlugs: [],
     });
 
-    expect(t2.currentSelections.map((s) => s.slug)).toEqual(["page-b"]);
-    expect(t2.finalInjection).toContain("page-a"); // carried despite the cap
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Lane composition: needle and core fold into the open set.
-// ---------------------------------------------------------------------------
-
-describe("orchestrate — open set composition", () => {
-  test("needle hits add their owning leaves to the open set", async () => {
-    const tree = makeTree();
-    // L1 routes only topic-x; the needle hit page-c lives in topic-y, so the
-    // open set must include topic-y too.
-    providerStub = {
-      name: "stub",
-      sendMessage: async (messages, options) => {
-        if (options?.tools?.[0]?.name === "open_leaves") {
-          return toolUseResponse("open_leaves", { ids: [1] });
-        }
-        const leaf = leafFromMessages(messages);
-        const ids = leaf === "domain-a/topic-y" ? [1] : [];
-        return toolUseResponse("select_pages", { ids, pinned_ids: [] });
-      },
-    };
-    const result = await orchestrate(makeTurn(1, "anything"), {
-      tree,
-      core: new Set(),
-      needle: fakeNeedle(["page-c"]),
-      workingSet: new WorkingSet(),
-      pageSummary: summaryOf,
-    });
-    expect(result.openedLeaves).toContain("domain-a/topic-y");
-    expect(result.finalInjection).toContain("page-c");
+    expect(t2.currentSelections.map((s) => s.slug)).toEqual(["topic-b"]);
+    expect(t2.finalInjection).toContain("topic-a"); // carried despite the cap
   });
 
-  test("core leaves are always opened even when routing abstains", async () => {
-    const tree = makeTree();
-    // L1 abstains (empty ids); only the core leaf should open.
-    providerStub = {
-      name: "stub",
-      sendMessage: async (messages, options) => {
-        if (options?.tools?.[0]?.name === "open_leaves") {
-          return toolUseResponse("open_leaves", { ids: [] });
-        }
-        const leaf = leafFromMessages(messages);
-        const ids = leaf === "domain-a/topic-y" ? [1] : [];
-        return toolUseResponse("select_pages", { ids, pinned_ids: [] });
-      },
-    };
-    const result = await orchestrate(makeTurn(1, "nothing topical"), {
-      tree,
-      core: new Set(["domain-a/topic-y"]),
-      needle: fakeNeedle([]),
-      workingSet: new WorkingSet(),
-      pageSummary: summaryOf,
-    });
-    expect(result.openedLeaves).toEqual(["domain-a/topic-y"]);
-    // page-c (topic-y member) is core, so the working set must NOT retain it.
-    expect(result.workingSetUnion.has("page-c")).toBe(false);
-    // It still injects this turn via the current selection.
-    expect(result.finalInjection).toContain("page-c");
-  });
-});
+  test("a stale non-pinned page ages out of the carry-forward window", async () => {
+    const lanes = await buildLanes();
+    // window 2: a non-pinned entry unseen for >2 turns evicts.
+    const workingSet = new WorkingSet(150, 2);
 
-// ---------------------------------------------------------------------------
-// Edge cases.
-// ---------------------------------------------------------------------------
-
-describe("orchestrate — edge cases", () => {
-  test("empty needle results do not break orchestration", async () => {
-    const tree = makeTree();
-    providerStub = providerForTurn(TURNS[0]);
-    const result = await orchestrate(makeTurn(1, "tell me about page a"), {
-      tree,
-      core: new Set(),
-      needle: fakeNeedle([]),
-      workingSet: new WorkingSet(),
-      pageSummary: summaryOf,
+    providerStub = selectProvider(["topic-a"]); // turn 1 selects topic-a
+    const t1 = await orchestrate(makeTurn(1, "apple"), {
+      sectionIndex: lanes.sectionIndex,
+      needle: lanes.needle,
+      denseConfig: config,
+      edgeGraph: lanes.edgeGraph,
+      workingSet,
+      capabilitySlugs: [],
     });
-    expect(result.openedLeaves).toEqual(["domain-a/topic-x"]);
-    expect(result.finalInjection).toEqual(["page-a", "page-b"]);
-  });
+    expect(t1.finalInjection).toContain("topic-a");
 
-  test("omitted L1 ids opens only the deterministic lanes, not the whole tree", async () => {
-    const tree = makeTree();
-    // L1 omits ids → routeL1 opens NO routed leaves; only the needle/core lanes
-    // drive the open set, so the whole tree is never fanned out (topic-y, which
-    // nothing routes or needles to, stays closed).
-    providerStub = {
-      name: "stub",
-      sendMessage: async (_messages, options) => {
-        if (options?.tools?.[0]?.name === "open_leaves") {
-          return toolUseResponse("open_leaves", {}); // omitted ids → []
-        }
-        return toolUseResponse("select_pages", {}); // omitted → all members
-      },
-    };
-    const result = await orchestrate(makeTurn(1, "x"), {
-      tree,
-      core: new Set(),
-      needle: fakeNeedle(["page-a"]), // needle opens domain-a/topic-x only
-      workingSet: new WorkingSet(),
-      pageSummary: summaryOf,
+    // Turns 2–4 never re-select topic-a. By turn 4 (4-1=3 > 2) it ages out.
+    providerStub = selectProvider([]);
+    await orchestrate(makeTurn(2, "x"), {
+      sectionIndex: lanes.sectionIndex,
+      needle: lanes.needle,
+      denseConfig: config,
+      edgeGraph: lanes.edgeGraph,
+      workingSet,
+      capabilitySlugs: [],
     });
-    expect(result.openedLeaves).toEqual(["domain-a/topic-x"]);
-    expect(result.finalInjection).toEqual(["page-a", "page-b"]);
+    await orchestrate(makeTurn(3, "x"), {
+      sectionIndex: lanes.sectionIndex,
+      needle: lanes.needle,
+      denseConfig: config,
+      edgeGraph: lanes.edgeGraph,
+      workingSet,
+      capabilitySlugs: [],
+    });
+    const t4 = await orchestrate(makeTurn(4, "x"), {
+      sectionIndex: lanes.sectionIndex,
+      needle: lanes.needle,
+      denseConfig: config,
+      edgeGraph: lanes.edgeGraph,
+      workingSet,
+      capabilitySlugs: [],
+    });
+    expect(t4.finalInjection).not.toContain("topic-a");
   });
 
   test("pinned current-turn selections land in the working set", async () => {
-    const tree = makeTree();
-    providerStub = providerForTurn(TURNS[0]); // pins page-a
+    const lanes = await buildLanes();
     const ws = new WorkingSet();
-    await orchestrate(makeTurn(1, "tell me about page a"), {
-      tree,
-      core: new Set(),
-      needle: fakeNeedle([]),
+    providerStub = selectProvider(["topic-a"], ["topic-a"]);
+    await orchestrate(makeTurn(1, "apple"), {
+      sectionIndex: lanes.sectionIndex,
+      needle: lanes.needle,
+      denseConfig: config,
+      edgeGraph: lanes.edgeGraph,
       workingSet: ws,
-      pageSummary: summaryOf,
+      capabilitySlugs: [],
     });
-    expect(ws.union().has("page-a")).toBe(true);
-    expect(ws.union().has("page-b")).toBe(true);
+    expect(ws.union().has("topic-a")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Degradation: an empty pool and a provider-unavailable path are recall-safe.
+// ---------------------------------------------------------------------------
+
+describe("orchestrate — degradation", () => {
+  test("an empty pool yields no selections and an empty injection", async () => {
+    const lanes = await buildLanes();
+    providerStub = selectProvider([]);
+    const result = await orchestrate(makeTurn(1, "zzzzz no-match"), {
+      sectionIndex: lanes.sectionIndex,
+      needle: { query: () => [], bestSection: () => -1 },
+      denseConfig: config,
+      edgeGraph: lanes.edgeGraph,
+      workingSet: new WorkingSet(),
+      capabilitySlugs: [],
+    });
+    expect(result.currentSelections).toEqual([]);
+    expect(result.finalInjection).toEqual([]);
   });
 
-  test("a page in multiple opened leaves is deduped with pinned ORed", async () => {
-    // Build a tree where page-shared belongs to BOTH leaves; pin it in one.
-    const leaves: LeafNode[] = [
-      makeLeaf("domain-a/topic-x", ["page-shared"]),
-      makeLeaf("domain-a/topic-y", ["page-shared"]),
-    ];
-    const byPage = new Map<Slug, LeafPath[]>([
-      ["page-shared", ["domain-a/topic-x", "domain-a/topic-y"]],
-    ]);
-    const tree: LeafTree = {
-      leaves: new Map(leaves.map((n) => [n.path, n])),
-      byPage,
-    };
+  test("omitted ids keeps ALL pooled candidates (recall-safe)", async () => {
+    const lanes = await buildLanes();
+    denseHits = [{ article: "topic-b", section: 0 }];
     providerStub = {
       name: "stub",
-      sendMessage: async (messages, options) => {
-        if (options?.tools?.[0]?.name === "open_leaves") {
-          return toolUseResponse("open_leaves", { ids: [1, 2] });
-        }
-        const leaf = leafFromMessages(messages);
-        // Pin only in topic-x; select (unpinned) in topic-y.
-        const pinned_ids = leaf === "domain-a/topic-x" ? [1] : [];
-        return toolUseResponse("select_pages", { ids: [1], pinned_ids });
-      },
+      sendMessage: async () => toolUseResponse({}), // omitted ids → keep all
     };
-    const result = await orchestrate(makeTurn(1, "x"), {
-      tree,
-      core: new Set(),
-      needle: fakeNeedle([]),
+    const result = await orchestrate(makeTurn(1, "apple"), {
+      sectionIndex: lanes.sectionIndex,
+      needle: lanes.needle,
+      denseConfig: config,
+      edgeGraph: lanes.edgeGraph,
       workingSet: new WorkingSet(),
-      pageSummary: summaryOf,
+      capabilitySlugs: ["skills/example"],
     });
-    // One deduped selection, pinned because it was pinned in topic-x.
-    expect(result.currentSelections).toEqual([
-      { slug: "page-shared", pinned: true },
-    ]);
-    expect(result.finalInjection).toEqual(["page-shared"]);
-  });
-
-  test("needleK defaults to DEFAULT_NEEDLE_K", async () => {
-    const tree = makeTree();
-    let seenK = -1;
-    const needle: NeedleIndex = {
-      query: (_text, k) => {
-        seenK = k;
-        return [];
-      },
-    };
-    providerStub = providerForTurn(TURNS[0]);
-    await orchestrate(makeTurn(1, "x"), {
-      tree,
-      core: new Set(),
-      needle,
-      workingSet: new WorkingSet(),
-      pageSummary: summaryOf,
-    });
-    expect(seenK).toBe(DEFAULT_NEEDLE_K);
+    expect(new Set(result.finalInjection)).toEqual(
+      new Set(["topic-a", "topic-b", "topic-d", "skills/example"]),
+    );
   });
 });

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-plugin.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-plugin.test.ts
@@ -1,20 +1,22 @@
 /**
- * Tests for `assistant/src/memory/v3/shadow-plugin.ts`.
+ * Tests for `shadow-plugin.ts` (section-lane pipeline).
  *
  * The v3 plugin is flag-gated. These tests assert:
  *   - both flags OFF → orchestrate is never called and no DB rows are written;
  *   - either flag ON → orchestrate runs and selection rows land in
- *     `memory_v3_selections`;
+ *     `memory_v3_selections` with the new lane source tags;
  *   - shadow-only (live off) → the injector returns `null` (never mutates the
  *     turn) but still logs;
  *   - live on → the injector returns the rendered `<memory>` block;
  *   - an empty selection under live → `null`;
- *   - lazy-init runs the loaders only once across multiple turns.
+ *   - lazy-init runs the lane builders only once across multiple turns, and
+ *     `invalidateLanes` forces exactly one rebuild.
  *
  * All heavy dependencies (config, flag resolver, conversation reads, v2 page
- * index + page store, v3 loaders, orchestrate) are mocked BEFORE importing the
- * plugin so the module observes them at load time. A real in-memory SQLite DB
- * backs the write assertions via the `memory_v3_selections` migration.
+ * index + page store, the lane builders, orchestrate) are mocked BEFORE
+ * importing the plugin so the module observes them at load time. A real
+ * in-memory SQLite DB backs the write assertions via the
+ * `memory_v3_selections` migration.
  */
 
 import { Database } from "bun:sqlite";
@@ -24,22 +26,25 @@ import { drizzle } from "drizzle-orm/bun-sqlite";
 
 import { migrateAddMemoryV3Selections } from "../../../../memory/migrations/268-add-memory-v3-selections.js";
 import * as schema from "../../../../memory/schema.js";
-import type { LeafTree, SelectionSource } from "../types.js";
+import type { SectionIndex, SelectionSource } from "../types.js";
 
 // `mock.module` is process-global and, in Bun, neither `mock.restore()` nor a
 // re-mock in `afterAll` reverts it for files that load LATER in the same
-// `bun test src/memory/v3/` run. Sibling files (orchestrate.test.ts,
-// tree.test.ts) import these same modules for real, so an unconditional stub
-// here would leak in and break them. Instead each stub below DELEGATES to the
-// real implementation unless this test is actively running (`shadowMockActive`,
-// toggled in beforeEach/afterAll).
+// `bun test src/plugins/defaults/memory-v3-shadow/` run. Sibling files import
+// these same modules for real, so an unconditional stub here would leak in and
+// break them. Instead each stub below DELEGATES to the real implementation
+// unless this test is actively running (`shadowMockActive`, toggled in
+// beforeEach/afterAll).
 //
 // Snapshot the real exports into plain objects NOW: a module namespace object
-// is a live view, so reading `realTree.loadLeafTree` *after* the stub is
-// installed would resolve back to the stub (infinite recursion).
-const realTree = { ...(await import("../tree.js")) };
-const realCore = { ...(await import("../core.js")) };
-const realNeedle = { ...(await import("../needle.js")) };
+// is a live view, so reading the real export *after* the stub is installed
+// would resolve back to the stub (infinite recursion).
+const realSections = { ...(await import("../sections.js")) };
+const realSectionNeedle = { ...(await import("../section-needle.js")) };
+const realEdge = { ...(await import("../edge.js")) };
+const realSectionDenseStore = {
+  ...(await import("../section-dense-store.js")),
+};
 const realOrchestrate = { ...(await import("../orchestrate.js")) };
 const realPlatform = { ...(await import("../../../../util/platform.js")) };
 const realPageStore = {
@@ -53,28 +58,33 @@ let shadowMockActive = false;
 
 // ─── mutable test state, read by the mocks below ────────────────────────────
 
-// Per-flag toggles. The plugin reads `memory-v3-live` and `memory-v3-shadow`
-// independently, so the mock resolves by flag key rather than a single boolean.
 let liveEnabled = false;
 let shadowEnabled = false;
 let messages: Array<{ role: string; content: string }> = [];
-const orchestrateSpy = mock(async () => ({
-  openedLeaves: [],
-  currentSelections: [
-    { slug: "domain-a/page-1", pinned: true },
-    { slug: "domain-b/page-2", pinned: false },
-  ],
-  workingSetUnion: new Set<string>(["domain-a/page-1", "domain-b/page-2"]),
-  finalInjection: ["domain-a/page-1", "domain-b/page-2", "domain-a/carried"],
-}));
-let treeLoads = 0;
-let coreLoads = 0;
-let needleBuilds = 0;
-let configL2Concurrency = 16;
 
-// Shared in-memory DB so writes are observable from the test. We hold the raw
-// sqlite handle alongside the drizzle wrapper so the test can both read rows
-// directly and feed the same handle through the mocked `getSqliteFrom`.
+// The orchestrate result the spy returns. page-1 + page-2 matched a section
+// this turn (→ "needle"); page-3 is an edge-only candidate (no matched section
+// → "edge"); carried is a carry-forward slug not re-selected this turn.
+const orchestrateSpy = mock(async () => ({
+  currentSelections: [
+    { slug: "page-1", pinned: true },
+    { slug: "page-2", pinned: false },
+    { slug: "page-3", pinned: false },
+  ],
+  workingSetUnion: new Set<string>(["page-1", "page-2", "page-3"]),
+  finalInjection: ["page-1", "page-2", "page-3", "carried"],
+  sectionBySlug: new Map([
+    ["page-1", { article: "page-1", title: "", text: "x", ordinal: 0 }],
+    ["page-2", { article: "page-2", title: "", text: "y", ordinal: 0 }],
+  ]),
+}));
+
+let sectionBuilds = 0;
+let needleBuilds = 0;
+let edgeBuilds = 0;
+let ensureCollectionCalls = 0;
+
+// Shared in-memory DB so writes are observable from the test.
 let testSqlite: Database;
 let testDb = makeDb();
 function makeDb() {
@@ -85,15 +95,10 @@ function makeDb() {
   return db;
 }
 
-// A tree where `domain-a/*` pages are owned by a core leaf and `domain-b/*`
-// are not, so attribution maps to core+l2 / l1+l2 respectively.
-const FAKE_TREE = {
-  leaves: new Map([
-    ["domain-a", { members: ["domain-a/page-1", "domain-a/carried"] }],
-    ["domain-b", { members: ["domain-b/page-2"] }],
-  ]),
-  byPage: new Map(),
-} as unknown as LeafTree;
+const FAKE_SECTION_INDEX: SectionIndex = {
+  sections: [],
+  byArticle: new Map(),
+};
 
 // ─── module mocks (installed before the plugin import) ──────────────────────
 
@@ -109,18 +114,14 @@ mock.module("../../../../config/assistant-feature-flags.js", () => ({
 mock.module("../../../../config/loader.js", () => ({
   getConfig: () => ({
     memory: {
-      v3: {
-        workingSet: { maxPages: 150, evictWindow: 5 },
-        l2Concurrency: configL2Concurrency,
-      },
+      v3: { workingSet: { maxPages: 150, evictWindow: 5 } },
+      qdrant: { vectorSize: 8, onDisk: false },
     },
   }),
 }));
 
 // Spread the real module so every export the live path transitively imports
-// (e.g. `getMessageById` via page-content.ts) stays present — replacing the
-// whole module with a bare `{ getMessages }` made those consumers fail to load.
-// Only `getMessages` is overridden, since that's the one the plugin reads.
+// stays present; only `getMessages` is overridden.
 mock.module("../../../../memory/conversation-crud.js", () => ({
   ...realConversationCrud,
   getMessages: () => messages.map((m, i) => ({ ...m, id: `m${i}` })),
@@ -131,13 +132,31 @@ mock.module("../../../../memory/db-connection.js", () => ({
   getSqliteFrom: () => testSqlite,
 }));
 
-mock.module("../v2/page-index.js", () => ({
-  getPageIndex: async () => ({ bySlug: new Map() }),
+mock.module("../../../../memory/v2/page-index.js", () => ({
+  getPageIndex: async () => ({
+    entries: [
+      {
+        slug: "page-1",
+        id: 1,
+        summary: "",
+        edges: [],
+        leaves: [],
+        modifiedAt: 0,
+      },
+      {
+        slug: "page-2",
+        id: 2,
+        summary: "",
+        edges: [],
+        leaves: [],
+        modifiedAt: 0,
+      },
+    ],
+    bySlug: new Map(),
+  }),
 }));
 
 // `pageContent` (live mode) reads the full page via `readPage`/`renderPageContent`.
-// Stub them to return a deterministic body per slug so the rendered `<memory>`
-// block is assertable without touching the filesystem.
 mock.module("../../../../memory/v2/page-store.js", () => ({
   ...realPageStore,
   readPage: async (workspaceDir: string, slug: string) =>
@@ -160,41 +179,48 @@ mock.module("../../../../util/platform.js", () => ({
       : realPlatform.getWorkspaceDir(),
 }));
 
-mock.module("../tree.js", () => ({
-  ...realTree,
-  resolveDataDir: () =>
-    shadowMockActive ? "/tmp/shadow-test-data" : realTree.resolveDataDir(),
-  loadLeafTree: async (dataDir: string) => {
-    if (!shadowMockActive) return realTree.loadLeafTree(dataDir);
-    treeLoads++;
-    return FAKE_TREE;
-  },
-  membersOf: (tree: LeafTree, leaf: string) =>
-    shadowMockActive
-      ? ((tree.leaves.get(leaf) as unknown as { members?: string[] })
-          ?.members ?? [])
-      : realTree.membersOf(tree, leaf),
-}));
-
-mock.module("../core.js", () => ({
-  ...realCore,
-  loadCore: async (dataDir: string) => {
-    if (!shadowMockActive) return realCore.loadCore(dataDir);
-    coreLoads++;
-    return new Set(["domain-a"]);
-  },
-}));
-
-mock.module("../needle.js", () => ({
-  ...realNeedle,
-  buildNeedleIndex: async (
-    ...args: Parameters<typeof realNeedle.buildNeedleIndex>
+mock.module("../sections.js", () => ({
+  ...realSections,
+  buildSectionIndex: async (
+    ...args: Parameters<typeof realSections.buildSectionIndex>
   ) => {
-    if (!shadowMockActive) return realNeedle.buildNeedleIndex(...args);
+    if (!shadowMockActive) return realSections.buildSectionIndex(...args);
+    sectionBuilds++;
+    return FAKE_SECTION_INDEX;
+  },
+}));
+
+mock.module("../section-needle.js", () => ({
+  ...realSectionNeedle,
+  buildSectionNeedle: (
+    ...args: Parameters<typeof realSectionNeedle.buildSectionNeedle>
+  ) => {
+    if (!shadowMockActive) return realSectionNeedle.buildSectionNeedle(...args);
     needleBuilds++;
-    return { query: () => [] } as unknown as Awaited<
-      ReturnType<typeof realNeedle.buildNeedleIndex>
-    >;
+    return { query: () => [], bestSection: () => -1 };
+  },
+}));
+
+mock.module("../edge.js", () => ({
+  ...realEdge,
+  buildEdgeGraph: async (
+    ...args: Parameters<typeof realEdge.buildEdgeGraph>
+  ) => {
+    if (!shadowMockActive) return realEdge.buildEdgeGraph(...args);
+    edgeBuilds++;
+    return { adjacency: new Map(), hubs: new Set(), slugs: new Set() };
+  },
+}));
+
+mock.module("../section-dense-store.js", () => ({
+  ...realSectionDenseStore,
+  ensureSectionCollection: async (
+    ...args: Parameters<typeof realSectionDenseStore.ensureSectionCollection>
+  ) => {
+    if (!shadowMockActive) {
+      return realSectionDenseStore.ensureSectionCollection(...args);
+    }
+    ensureCollectionCalls++;
   },
 }));
 
@@ -211,9 +237,6 @@ const { runShadowObservation, resetShadowLanesForTests, invalidateLanes } =
   await import("../shadow-plugin.js");
 const { memoryV3Injector } = await import("../injector.js");
 
-// The module stubs above stay installed for the rest of the process (Bun can't
-// reliably uninstall them), but `shadowMockActive` gates their fake behavior to
-// this file's tests only, so later-loaded sibling files see real behavior.
 afterAll(() => {
   shadowMockActive = false;
 });
@@ -237,10 +260,10 @@ beforeEach(() => {
     },
   ];
   orchestrateSpy.mockClear();
-  treeLoads = 0;
-  coreLoads = 0;
+  sectionBuilds = 0;
   needleBuilds = 0;
-  configL2Concurrency = 16;
+  edgeBuilds = 0;
+  ensureCollectionCalls = 0;
   testDb = makeDb();
   resetShadowLanesForTests();
 });
@@ -260,22 +283,24 @@ describe("memory-v3 shadow plugin", () => {
     shadowEnabled = false;
     await runShadowObservation("conv-1", 0);
     expect(orchestrateSpy).not.toHaveBeenCalled();
-    expect(treeLoads).toBe(0);
+    expect(sectionBuilds).toBe(0);
     expect(readRows()).toHaveLength(0);
   });
 
-  test("shadow flag ON → orchestrate runs and rows are written", async () => {
+  test("shadow flag ON → orchestrate runs and rows are written with lane sources", async () => {
     shadowEnabled = true;
     await runShadowObservation("conv-1", 2);
 
     expect(orchestrateSpy).toHaveBeenCalledTimes(1);
     const rows = readRows();
     expect(rows).toEqual([
-      { slug: "domain-a/carried", source: "carry-forward", pinned: 0 },
-      // page-1 belongs to the core leaf `domain-a` → core+l2, pinned.
-      { slug: "domain-a/page-1", source: "core+l2", pinned: 1 },
-      // page-2 belongs to non-core `domain-b` → l1+l2.
-      { slug: "domain-b/page-2", source: "l1+l2", pinned: 0 },
+      { slug: "carried", source: "carry-forward", pinned: 0 },
+      // page-1 matched a section this turn → "needle", pinned.
+      { slug: "page-1", source: "needle", pinned: 1 },
+      // page-2 matched a section this turn → "needle".
+      { slug: "page-2", source: "needle", pinned: 0 },
+      // page-3 had no matched section (edge-only) → "edge".
+      { slug: "page-3", source: "edge", pinned: 0 },
     ]);
   });
 
@@ -294,16 +319,23 @@ describe("memory-v3 shadow plugin", () => {
     expect(turn.currentMessage).toBe("hello world");
   });
 
-  test("orchestrate receives the configured L2 concurrency", async () => {
+  test("orchestrate receives the lane deps", async () => {
     shadowEnabled = true;
-    configL2Concurrency = 9;
     await runShadowObservation("conv-1", 0);
     const deps = (
       orchestrateSpy.mock.calls as unknown as unknown[][]
     )[0]![1] as {
-      l2Concurrency?: number;
+      sectionIndex?: unknown;
+      needle?: unknown;
+      edgeGraph?: unknown;
+      workingSet?: unknown;
+      capabilitySlugs?: unknown;
     };
-    expect(deps.l2Concurrency).toBe(9);
+    expect(deps.sectionIndex).toBeDefined();
+    expect(deps.needle).toBeDefined();
+    expect(deps.edgeGraph).toBeDefined();
+    expect(deps.workingSet).toBeDefined();
+    expect(Array.isArray(deps.capabilitySlugs)).toBe(true);
   });
 
   test("both flags OFF → produce returns null, no orchestrate, no writes", async () => {
@@ -333,8 +365,8 @@ describe("memory-v3 shadow plugin", () => {
     expect(block!.text.startsWith("<memory>\n")).toBe(true);
     expect(block!.text.endsWith("\n</memory>")).toBe(true);
     // finalInjection slugs are rendered into the block in order.
-    expect(block!.text).toContain("body for domain-a/page-1");
-    expect(block!.text).toContain("body for domain-a/carried");
+    expect(block!.text).toContain("body for page-1");
+    expect(block!.text).toContain("body for carried");
     // Selections are still logged in live mode.
     expect(readRows().length).toBeGreaterThan(0);
   });
@@ -343,26 +375,26 @@ describe("memory-v3 shadow plugin", () => {
     liveEnabled = true;
     shadowEnabled = false;
     orchestrateSpy.mockImplementationOnce(async () => ({
-      openedLeaves: [],
       currentSelections: [],
       workingSetUnion: new Set<string>(),
       finalInjection: [],
+      sectionBySlug: new Map(),
     }));
     const block = await produce("conv-1", 0);
     expect(block).toBeNull();
-    // Orchestration still ran (and logged nothing, since there were no rows).
     expect(orchestrateSpy).toHaveBeenCalledTimes(1);
     expect(readRows()).toHaveLength(0);
   });
 
-  test("lazy-init runs the loaders only once across turns", async () => {
+  test("lazy-init runs the lane builders only once across turns", async () => {
     shadowEnabled = true;
     await runShadowObservation("conv-1", 0);
     await runShadowObservation("conv-1", 1);
     await runShadowObservation("conv-1", 2);
-    expect(treeLoads).toBe(1);
-    expect(coreLoads).toBe(1);
+    expect(sectionBuilds).toBe(1);
     expect(needleBuilds).toBe(1);
+    expect(edgeBuilds).toBe(1);
+    expect(ensureCollectionCalls).toBe(1);
     expect(orchestrateSpy).toHaveBeenCalledTimes(3);
   });
 
@@ -370,49 +402,46 @@ describe("memory-v3 shadow plugin", () => {
     shadowEnabled = true;
     await runShadowObservation("conv-1", 0);
     await runShadowObservation("conv-1", 1);
-    // One build so far; invalidation drops it.
-    expect(treeLoads).toBe(1);
+    expect(sectionBuilds).toBe(1);
     expect(needleBuilds).toBe(1);
 
     invalidateLanes();
 
-    // The next turn rebuilds (fresh tree load + fresh needle index)...
     await runShadowObservation("conv-1", 2);
-    expect(treeLoads).toBe(2);
-    expect(coreLoads).toBe(2);
+    expect(sectionBuilds).toBe(2);
     expect(needleBuilds).toBe(2);
+    expect(edgeBuilds).toBe(2);
 
     // ...and the rebuild is memoized again — no further builds until the next
     // invalidation.
     await runShadowObservation("conv-1", 3);
-    expect(treeLoads).toBe(2);
+    expect(sectionBuilds).toBe(2);
     expect(needleBuilds).toBe(2);
   });
 
   test("resetShadowLanesForTests invalidates like invalidateLanes", async () => {
     shadowEnabled = true;
     await runShadowObservation("conv-1", 0);
-    expect(treeLoads).toBe(1);
+    expect(sectionBuilds).toBe(1);
 
     resetShadowLanesForTests();
 
     await runShadowObservation("conv-1", 1);
-    expect(treeLoads).toBe(2);
+    expect(sectionBuilds).toBe(2);
   });
 
   test("concurrent first turns after invalidation share a single build", async () => {
     shadowEnabled = true;
     await runShadowObservation("conv-1", 0);
-    expect(treeLoads).toBe(1);
+    expect(sectionBuilds).toBe(1);
 
     invalidateLanes();
 
-    // Both turns race the rebuild; memoization must collapse them to one build.
     await Promise.all([
       runShadowObservation("conv-1", 1),
       runShadowObservation("conv-1", 2),
     ]);
-    expect(treeLoads).toBe(2);
+    expect(sectionBuilds).toBe(2);
     expect(needleBuilds).toBe(2);
   });
 

--- a/assistant/src/plugins/defaults/memory-v3-shadow/orchestrate.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/orchestrate.ts
@@ -1,21 +1,26 @@
 /**
- * Memory v3 — orchestrator composing the four routing lanes into one turn.
+ * Memory v3 — orchestrator composing the section-grain lanes into one turn.
  *
  * Each turn runs:
- *   1. L1 topical routing (`routeL1`) and the lexical BM25 needle
- *      (`NeedleIndex.query`) IN PARALLEL. Routing is the slow LLM arm; the
- *      needle is a synchronous in-memory lookup, so we wrap it in a resolved
- *      promise and let them settle together.
- *   2. Open set = unique union of routed leaves ∪ always-on core leaves ∪ the
- *      leaves that own each needle hit. Every lane only ever ADDS leaves — the
- *      union is recall-safe by construction.
- *   3. Bounded per-leaf L2 selection (`selectAcrossLeaves`) over the open set,
- *      then dedup by slug (a page assigned to multiple opened leaves comes back
- *      once per leaf) ORing the pinned flag so a page pinned anywhere stays
- *      pinned.
- *   4. Age the carry-forward working set to this turn (evict core slugs, stale
- *      non-pinned entries, then the cap) and snapshot it — the pages carried in
- *      from EARLIER turns.
+ *   1. Candidate generation over three deterministic lanes:
+ *        - the section-grain BM25 needle (`SectionNeedle.query`, KB articles),
+ *        - the dense lane (`denseLane`, KD articles), and
+ *        - link-graph edge expansion (`edgeExpand`) over the top needle+dense
+ *          article seeds.
+ *      Each lane only ever ADDS candidates, so the pool is recall-safe by
+ *      construction.
+ *   2. Build the unified candidate pool of `{ slug, descriptor }`. The
+ *      descriptor is the matched section's text for needle/dense hits (resolved
+ *      via the section index); for edge-only pages it is the curated `links`
+ *      description when the traversed edge carried one, else the page's best
+ *      section against the query. The synthetic capability slugs (skills / CLI
+ *      commands) are always appended (lane-ranking of synthetic pages is a
+ *      documented fast-follow).
+ *   3. A SINGLE forced-tool select (`selectPool`) over the whole pool, replacing
+ *      the per-leaf L2 fan-out. The result is this turn's selections.
+ *   4. Age the carry-forward working set to this turn (evict stale non-pinned
+ *      entries, then the cap) and snapshot it — the pages carried in from
+ *      EARLIER turns.
  *   5. Final injection = unique union of this turn's selected slugs and that
  *      carried-forward set, so pages selected on earlier turns carry forward
  *      even when this turn does not re-select them.
@@ -25,39 +30,60 @@
  *      turn selecting more pages than the cap would evict the entire carry.
  */
 
-import type { NeedleIndex } from "./needle.js";
-import { routeL1 } from "./router.js";
-import type { SelectedPage } from "./selector.js";
-import { selectAcrossLeaves } from "./selector.js";
-import { coreSlugs, leavesOf } from "./tree.js";
-import type { LeafPath, LeafTree, MemoryRoutingTurn, Slug } from "./types.js";
+import type { AssistantConfig } from "../../../config/schema.js";
+import { denseLane } from "./dense.js";
+import type { EdgeGraph } from "./edge.js";
+import { edgeExpand } from "./edge.js";
+import type { PoolCandidate, SelectedPage } from "./pool-select.js";
+import { selectPool } from "./pool-select.js";
+import type { SectionNeedle } from "./section-needle.js";
+import type {
+  MemoryRoutingTurn,
+  Section,
+  SectionIndex,
+  Slug,
+} from "./types.js";
 import { WorkingSet } from "./working-set.js";
 
-/** Default number of needle hits to fold into the open set when unspecified. */
-export const DEFAULT_NEEDLE_K = 10;
+/** Default number of BM25 needle articles to fold into the pool. */
+export const DEFAULT_NEEDLE_K = 100;
+/** Default number of dense-lane articles to fold into the pool. */
+export const DEFAULT_DENSE_K = 100;
+/** Default number of top needle+dense seeds expanded by the edge lane. */
+export const DEFAULT_EDGE_SEEDS = 18;
 
 export interface OrchestrateDeps {
-  tree: LeafTree;
-  core: Set<LeafPath>;
-  needle: NeedleIndex;
+  sectionIndex: SectionIndex;
+  needle: SectionNeedle;
+  /** Config the dense lane needs to embed the query + search the section
+   *  collection. */
+  denseConfig: AssistantConfig;
+  edgeGraph: EdgeGraph;
   workingSet: WorkingSet;
-  pageSummary: (slug: Slug) => Promise<string>;
-  /** Number of BM25 needle hits to fold in. Defaults to {@link DEFAULT_NEEDLE_K}. */
+  /** Synthetic capability slugs (skills / CLI commands) always added to the
+   *  pool. Lane-ranking of synthetic pages is a documented fast-follow. */
+  capabilitySlugs: Slug[];
+  /** Number of BM25 needle articles. Defaults to {@link DEFAULT_NEEDLE_K}. */
   needleK?: number;
-  /** Bounded fan-out for per-leaf L2 selection. */
-  l2Concurrency?: number;
+  /** Number of dense-lane articles. Defaults to {@link DEFAULT_DENSE_K}. */
+  denseK?: number;
+  /** Number of top needle+dense seeds expanded. Defaults to
+   *  {@link DEFAULT_EDGE_SEEDS}. */
+  edgeSeeds?: number;
 }
 
 export interface OrchestrateResult {
-  /** The unique open set: routed ∪ core ∪ needle-owning leaves. */
-  openedLeaves: LeafPath[];
-  /** This turn's L2 selections, deduped by slug (pinned flags ORed). */
+  /** This turn's selections, deduped by slug (pinned flags ORed). */
   currentSelections: SelectedPage[];
   /** The carried-forward set: selections from EARLIER turns, aged to this turn
    *  (snapshotted before this turn's selections are recorded). */
   workingSetUnion: Set<Slug>;
   /** Slugs to inject: this turn's selections ∪ the carried-forward working set. */
   finalInjection: Slug[];
+  /** The matched `Section` for each pooled slug that had one, keyed by slug.
+   *  Populated from the lane hits; unused downstream until matched-section
+   *  injection lands (PR 8). */
+  sectionBySlug: Map<Slug, Section>;
 }
 
 /** Stable-order de-duplication preserving first occurrence. */
@@ -69,28 +95,85 @@ export async function orchestrate(
   turn: MemoryRoutingTurn,
   deps: OrchestrateDeps,
 ): Promise<OrchestrateResult> {
-  // Step 1: routing (LLM) and needle (sync BM25) run in parallel.
   const needleK = deps.needleK ?? DEFAULT_NEEDLE_K;
-  const [routed, needled] = await Promise.all([
-    routeL1(turn, deps.tree),
+  const denseK = deps.denseK ?? DEFAULT_DENSE_K;
+  const edgeSeeds = deps.edgeSeeds ?? DEFAULT_EDGE_SEEDS;
+  const { sections } = deps.sectionIndex;
+
+  // Step 1: needle (sync BM25) and dense (async embed + Qdrant) lanes run in
+  // parallel. Both return distinct articles each tagged with their best-scoring
+  // section index/ordinal.
+  const [needled, densed] = await Promise.all([
     Promise.resolve(deps.needle.query(turn.currentMessage, needleK)),
+    denseLane(deps.denseConfig, turn.currentMessage, denseK),
   ]);
 
-  // Step 2: open set = routed ∪ core ∪ leaves owning each needle hit.
-  const openedLeaves = unique<LeafPath>([
-    ...routed,
-    ...deps.core,
-    ...needled.flatMap((slug) => leavesOf(deps.tree, slug)),
-  ]);
+  // The pool accumulates one entry per distinct article. `sectionBySlug` records
+  // the matched `Section` (when one is known) for downstream injection.
+  const poolBySlug = new Map<Slug, PoolCandidate>();
+  const sectionBySlug = new Map<Slug, Section>();
 
-  // Step 3: per-leaf L2 selection, then dedup by slug ORing pinned flags.
-  const selected = await selectAcrossLeaves(
-    openedLeaves,
-    turn,
-    deps.tree,
-    deps.pageSummary,
-    deps.l2Concurrency,
-  );
+  // Add one pool candidate, recording its matched `Section` (when known) for
+  // downstream injection. `descriptor` overrides the section text when supplied
+  // (the edge lane prefers a curated `links` description). The first lane to
+  // surface a slug wins both the pool entry and the recorded section.
+  const addCandidate = (
+    slug: Slug,
+    section: Section | undefined,
+    descriptor?: string,
+  ): void => {
+    if (section && !sectionBySlug.has(slug)) {
+      sectionBySlug.set(slug, section);
+    }
+    if (poolBySlug.has(slug)) return;
+    poolBySlug.set(slug, {
+      slug,
+      descriptor: descriptor ?? section?.text ?? "",
+    });
+  };
+
+  // Step 2a: needle hits — descriptor is the matched section's text. `section`
+  // is an index into `sections`.
+  for (const hit of needled) {
+    addCandidate(hit.article, sections[hit.section]);
+  }
+
+  // Step 2b: dense hits — `section` is the matched ORDINAL; resolve it to the
+  // concrete `Section` via the section index. Falls back to undefined (blank
+  // descriptor) if the ordinal is not in the in-memory index.
+  for (const hit of densed) {
+    addCandidate(
+      hit.article,
+      sectionByOrdinal(deps.sectionIndex, hit.article, hit.section),
+    );
+  }
+
+  // Step 2c: edge expansion over the top needle+dense article seeds. Each
+  // surfaced article prefers its curated `links` description; else its best
+  // section against the query. `alive` skips slugs already pooled.
+  const seeds = unique<Slug>([
+    ...needled.map((h) => h.article),
+    ...densed.map((h) => h.article),
+  ]);
+  const surfaced = edgeExpand(deps.edgeGraph, seeds, {
+    seedCount: edgeSeeds,
+    alive: (slug) => !poolBySlug.has(slug),
+  });
+  for (const neighbor of surfaced) {
+    const best = deps.needle.bestSection(neighbor.article, turn.currentMessage);
+    const section = best >= 0 ? sections[best] : undefined;
+    addCandidate(neighbor.article, section, neighbor.description);
+  }
+
+  // Step 2d: always-add the synthetic capability slugs (skills / CLI commands)
+  // with a blank descriptor — they have no matched section. Proper lane-ranking
+  // of synthetic pages is a documented fast-follow.
+  for (const slug of deps.capabilitySlugs) {
+    addCandidate(slug, undefined);
+  }
+
+  // Step 3: a SINGLE forced-tool select over the unified pool.
+  const selected = await selectPool([...poolBySlug.values()], turn);
   const bySlug = new Map<Slug, SelectedPage>();
   for (const page of selected) {
     const existing = bySlug.get(page.slug);
@@ -101,12 +184,12 @@ export async function orchestrate(
   }
   const currentSelections = [...bySlug.values()];
 
-  // Step 4: age the carry-forward set to this turn (drop core slugs, stale
-  // non-pinned entries, then the cap) and snapshot it. This is the set carried
-  // in from EARLIER turns; recording this turn happens afterward (step 6) so the
-  // cap is spent on genuinely carried pages, not on this turn's selections
-  // (which are injected directly anyway).
-  deps.workingSet.evict(turn.turnNumber, coreSlugs(deps.tree, deps.core));
+  // Step 4: age the carry-forward set to this turn (drop stale non-pinned
+  // entries, then the cap) and snapshot it. This is the set carried in from
+  // EARLIER turns; recording this turn happens afterward (step 6) so the cap is
+  // spent on genuinely carried pages, not on this turn's selections (which are
+  // injected directly anyway).
+  deps.workingSet.evict(turn.turnNumber);
   const workingSetUnion = deps.workingSet.union();
 
   // Step 5: final injection = this turn's selections ∪ the carried-forward set,
@@ -122,5 +205,26 @@ export async function orchestrate(
     deps.workingSet.recordSelection(sel.slug, turn.turnNumber, sel.pinned);
   }
 
-  return { openedLeaves, currentSelections, workingSetUnion, finalInjection };
+  return { currentSelections, workingSetUnion, finalInjection, sectionBySlug };
+}
+
+/**
+ * Resolve a dense-lane hit's matched ordinal to the concrete `Section` in the
+ * in-memory index. The dense store keys sections by `(article, ordinal)`, so we
+ * scan the article's sections for the matching ordinal. Returns `undefined`
+ * when the article or ordinal is not in the index (e.g. the dense store is
+ * ahead of the in-memory rebuild).
+ */
+function sectionByOrdinal(
+  index: SectionIndex,
+  article: Slug,
+  ordinal: number,
+): Section | undefined {
+  const indices = index.byArticle.get(article);
+  if (!indices) return undefined;
+  for (const i of indices) {
+    const section = index.sections[i];
+    if (section && section.ordinal === ordinal) return section;
+  }
+  return undefined;
 }

--- a/assistant/src/plugins/defaults/memory-v3-shadow/shadow-plugin.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/shadow-plugin.ts
@@ -15,9 +15,10 @@
  *   - both OFF: orchestration is skipped entirely.
  *
  * On each turn (either flag on):
- *   1. Lazy-init the v3 lanes ONCE across the whole process (leaf tree, core
- *      set, BM25 needle, carry-forward working set), memoizing the init
- *      promise so concurrent first turns share a single build.
+ *   1. Lazy-init the v3 lanes ONCE across the whole process (section index,
+ *      section-grain BM25 needle, dense lane config, link-graph edge graph,
+ *      carry-forward working set), memoizing the init promise so concurrent
+ *      first turns share a single build.
  *   2. Build a {@link MemoryRoutingTurn} from the conversation's recent messages.
  *   3. Run {@link orchestrate} and record its selection set to
  *      `memory_v3_selections` with a best-effort lane attribution.
@@ -37,23 +38,25 @@ import { getMessages } from "../../../memory/conversation-crud.js";
 import { getDb, getSqliteFrom } from "../../../memory/db-connection.js";
 import { stringifyMessageContent } from "../../../memory/message-content.js";
 import { getPageIndex } from "../../../memory/v2/page-index.js";
+import { readPage, renderPageContent } from "../../../memory/v2/page-store.js";
 import { getLogger } from "../../../util/logger.js";
 import {
   getWorkspaceDir,
   getWorkspacePromptPath,
 } from "../../../util/platform.js";
 import { stripCommentLines } from "../../../util/strip-comment-lines.js";
-import { injectCapabilitiesLeaf, isCapabilitySlug } from "./capabilities.js";
-import { loadCore } from "./core.js";
-import type { NeedleIndex } from "./needle.js";
-import { buildNeedleIndex } from "./needle.js";
+import { isCapabilitySlug } from "./capabilities.js";
+import type { EdgeGraph } from "./edge.js";
+import { buildEdgeGraph } from "./edge.js";
 import type { OrchestrateResult } from "./orchestrate.js";
 import { orchestrate } from "./orchestrate.js";
-import { coreSlugs, loadLeafTree, resolveDataDir } from "./tree.js";
+import { ensureSectionCollection } from "./section-dense-store.js";
+import type { SectionNeedle } from "./section-needle.js";
+import { buildSectionNeedle } from "./section-needle.js";
+import { buildSectionIndex } from "./sections.js";
 import {
-  type LeafPath,
-  type LeafTree,
   type MemoryRoutingTurn,
+  type SectionIndex,
   type SelectionSource,
   type Slug,
 } from "./types.js";
@@ -74,26 +77,32 @@ const RECENT_CONTEXT_MESSAGES = 6;
  * carry-forward lane.
  */
 export interface ShadowLanes {
-  tree: LeafTree;
-  core: Set<LeafPath>;
-  needle: NeedleIndex;
+  sectionIndex: SectionIndex;
+  needle: SectionNeedle;
+  /** Config the dense lane needs to embed the query + search the section
+   *  collection. */
+  denseConfig: AssistantConfig;
+  edgeGraph: EdgeGraph;
   workingSet: WorkingSet;
+  /** Synthetic capability slugs (skills / CLI commands), always added to the
+   *  candidate pool in {@link orchestrate}. */
+  capabilitySlugs: Slug[];
 }
 
 /**
  * Memoized init promise. Caching the PROMISE (not the resolved value) means
  * concurrent first turns all await the same build instead of racing several
- * `loadLeafTree`/`buildNeedleIndex` passes.
+ * section-index / needle / edge-graph passes.
  */
 let lanesPromise: Promise<ShadowLanes> | null = null;
 
 /**
  * Drop the memoized lanes so the NEXT `getLanes` rebuilds them from scratch
- * (fresh topic-tree load + fresh needle index). The rebuild is lazy — this only
- * clears the cache, so the cost is paid by the next caller, and concurrent
- * first-callers after the invalidation still share a single build via the
- * re-memoized promise. Call this whenever the underlying tree or needle sources
- * change on disk.
+ * (fresh section index + fresh needle + fresh edge graph). The rebuild is lazy
+ * — this only clears the cache, so the cost is paid by the next caller, and
+ * concurrent first-callers after the invalidation still share a single build via
+ * the re-memoized promise. Call this whenever the underlying pages change on
+ * disk.
  */
 export function invalidateLanes(): void {
   lanesPromise = null;
@@ -104,48 +113,61 @@ export function resetShadowLanesForTests(): void {
   invalidateLanes();
 }
 
-/**
- * Pull a page's summary from the existing v2 page index. Missing summaries
- * (and any read failure) degrade to "" — the needle and L2 selector treat an
- * empty summary as "no signal" rather than throwing.
- */
-async function pageSummary(slug: Slug): Promise<string> {
-  try {
-    const index = await getPageIndex(getWorkspaceDir());
-    return index.bySlug.get(slug)?.summary ?? "";
-  } catch {
-    return "";
-  }
-}
-
 async function initLanes(config: AssistantConfig): Promise<ShadowLanes> {
-  const dataDir = resolveDataDir();
   const pageIndex = await getPageIndex(getWorkspaceDir());
-  const pageLeaves = new Map<Slug, LeafPath[]>();
-  for (const entry of pageIndex.entries) {
-    pageLeaves.set(entry.slug, entry.leaves);
+  const slugs = pageIndex.entries.map((entry) => entry.slug);
+
+  // Read each page ONCE and feed BOTH forms downstream: the frontmatter-stripped
+  // body to the section index (lexical/dense matching), and the raw page
+  // (frontmatter + body) to the edge graph (so the `links:` frontmatter is
+  // available). A per-slug cache holds the parsed page so the second consumer
+  // reuses the first read.
+  const pageCache = new Map<Slug, { body: string; raw: string } | null>();
+  async function loadPage(
+    slug: Slug,
+  ): Promise<{ body: string; raw: string } | null> {
+    if (pageCache.has(slug)) return pageCache.get(slug)!;
+    let loaded: { body: string; raw: string } | null = null;
+    try {
+      const page = await readPage(getWorkspaceDir(), slug);
+      if (page) loaded = { body: page.body, raw: renderPageContent(page) };
+    } catch {
+      loaded = null;
+    }
+    pageCache.set(slug, loaded);
+    return loaded;
   }
-  const tree = await loadLeafTree(dataDir, pageLeaves);
-  const core = await loadCore(dataDir);
+  const pageBody = async (slug: Slug): Promise<string> =>
+    (await loadPage(slug))?.body ?? "";
+  const pageRaw = async (slug: Slug): Promise<string> => {
+    const loaded = await loadPage(slug);
+    if (!loaded) throw new Error(`page not found: ${slug}`);
+    return loaded.raw;
+  };
 
-  // Always-on synthetic capabilities leaf: skill + CLI-command rows the page
-  // index already carries (with summaries). Injecting them as leaf members puts
-  // them in the needle corpus (`tree.byPage`) and, via `core`, makes L1 always
-  // open the leaf so L2 selects the relevant subset each turn — matching v2's
-  // "always in the pool, router-selected" capability surfacing. Done before
-  // `buildNeedleIndex` so the synthetic members are indexed.
-  const capabilitySlugs = pageIndex.entries
-    .map((entry) => entry.slug)
-    .filter(isCapabilitySlug);
-  injectCapabilitiesLeaf(tree, core, capabilitySlugs);
+  const sectionIndex = await buildSectionIndex(slugs, pageBody);
+  const needle = buildSectionNeedle(sectionIndex);
+  const edgeGraph = await buildEdgeGraph(pageIndex.entries, pageRaw);
+  await ensureSectionCollection(config);
 
-  const needle = await buildNeedleIndex(tree, pageSummary);
+  // Synthetic capability slugs (skills + CLI commands) the page index already
+  // carries. Always added to the candidate pool in `orchestrate`; proper
+  // lane-ranking of synthetic pages is a documented fast-follow.
+  const capabilitySlugs = slugs.filter(isCapabilitySlug);
+
   const workingSet = new WorkingSet(
     config.memory.v3.workingSet.maxPages,
     config.memory.v3.workingSet.evictWindow,
   );
 
-  return { tree, core, needle, workingSet };
+  return {
+    sectionIndex,
+    needle,
+    denseConfig: config,
+    edgeGraph,
+    workingSet,
+    capabilitySlugs,
+  };
 }
 
 /** Lazy, memoized accessor for the shadow lanes. */
@@ -180,11 +202,11 @@ function readNowContext(): string | null {
 }
 
 /**
- * Compose the situational signal threaded into L1 routing and L2 selection: the
- * current date plus the live NOW.md scratchpad. The date alone is a weak signal,
- * but together with the scratchpad it lets retrieval surface a leaf the message
- * never names (e.g. an anniversary that falls today). Always returns at least
- * the date line — this mirrors the `c_now`/NOW.md signal the v2 retriever uses.
+ * Compose the situational signal threaded into pool selection: the current date
+ * plus the live NOW.md scratchpad. The date alone is a weak signal, but together
+ * with the scratchpad it lets retrieval surface a page the message never names
+ * (e.g. an anniversary that falls today). Always returns at least the date line
+ * — this mirrors the `c_now`/NOW.md signal the v2 retriever uses.
  */
 function buildSituationalContext(): string {
   const now = readNowContext();
@@ -240,29 +262,25 @@ interface SelectionRow {
  * Map an orchestrate result onto telemetry rows with best-effort lane
  * attribution.
  *
- * - A current selection whose page belongs to a core leaf → `"core+l2"`,
- *   otherwise `"l1+l2"`.
+ * - A current selection whose page matched a section this turn → `"needle"` or
+ *   `"dense"`; an edge-only candidate that survived selection → `"edge"`. The
+ *   pool is a union of lanes that only ever adds candidates, so a page can be
+ *   surfaced by more than one lane; this coarse mapping records the lane that
+ *   provided the matched section (needle/dense) and falls back to `"edge"` for
+ *   candidates with no matched section.
  * - A slug in `finalInjection` but NOT re-selected this turn → `"carry-forward"`.
  *
- * Precise needle attribution is a documented follow-up: the needle lane only
- * widens the open set, so a needle-surfaced page that survives L2 selection is
- * indistinguishable here from an L1-routed one. This coarse mapping is
- * acceptable for v0 shadow telemetry.
+ * Precise per-lane attribution (which lane FIRST surfaced a page) is a
+ * documented follow-up; this is acceptable for v0 shadow telemetry.
  */
-function attributeSelections(
-  tree: LeafTree,
-  core: Set<LeafPath>,
-  result: OrchestrateResult,
-): SelectionRow[] {
-  const coreOwnedSlugs = coreSlugs(tree, core);
-
+function attributeSelections(result: OrchestrateResult): SelectionRow[] {
   const rows: SelectionRow[] = [];
   const seen = new Set<Slug>();
   for (const sel of result.currentSelections) {
     seen.add(sel.slug);
     rows.push({
       slug: sel.slug,
-      source: coreOwnedSlugs.has(sel.slug) ? "core+l2" : "l1+l2",
+      source: result.sectionBySlug.has(sel.slug) ? "needle" : "edge",
       pinned: sel.pinned ? 1 : 0,
     });
   }
@@ -312,15 +330,15 @@ export async function observeTurn(
     const cfg = getConfig();
     const lanes = await getLanes(cfg);
     const result = await orchestrate(turn, {
-      tree: lanes.tree,
-      core: lanes.core,
+      sectionIndex: lanes.sectionIndex,
       needle: lanes.needle,
+      denseConfig: lanes.denseConfig,
+      edgeGraph: lanes.edgeGraph,
       workingSet: lanes.workingSet,
-      pageSummary,
-      l2Concurrency: cfg.memory.v3.l2Concurrency,
+      capabilitySlugs: lanes.capabilitySlugs,
     });
 
-    const rows = attributeSelections(lanes.tree, lanes.core, result);
+    const rows = attributeSelections(result);
     writeSelections(conversationId, turnIndex, rows);
     return result;
   } catch (err) {

--- a/assistant/src/plugins/defaults/memory-v3-shadow/types.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/types.ts
@@ -80,4 +80,17 @@ export interface MemoryRoutingTurn {
   situationalContext?: string;
 }
 
-export type SelectionSource = "l1+l2" | "core+l2" | "needle" | "carry-forward";
+/**
+ * Lane attribution recorded per selection. The section-lane pipeline writes the
+ * lane literals (`"needle" | "dense" | "edge" | "carry-forward"`); the legacy
+ * tree literals (`"l1+l2" | "core+l2"`) are retained until the tree pipeline is
+ * deleted. PR 11 tightens this to the lane literals only. The DB column is
+ * free-text, so widening here needs no migration.
+ */
+export type SelectionSource =
+  | "l1+l2"
+  | "core+l2"
+  | "needle"
+  | "dense"
+  | "edge"
+  | "carry-forward";

--- a/assistant/src/plugins/defaults/memory-v3-shadow/working-set.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/working-set.ts
@@ -42,13 +42,16 @@ export class WorkingSet {
   /**
    * Prune the working set, in order:
    *   1. Core slugs never belong here — drop any entry whose slug is core.
+   *      The section-lane pipeline has no core set, so `coreSlugs` defaults to
+   *      empty (no-op); the tree pipeline passed its core slugs here. Stale and
+   *      cap eviction semantics are identical either way.
    *   2. Pinned entries never evict.
    *   3. Window eviction: drop a non-pinned entry unseen for more than
    *      `evictWindow` turns.
    *   4. Cap eviction: while over `maxPages`, evict the lowest-scoring
    *      non-pinned entry first (ties broken deterministically).
    */
-  evict(currentTurn: number, coreSlugs: Set<Slug>): void {
+  evict(currentTurn: number, coreSlugs: Set<Slug> = new Set()): void {
     // 1. Core slugs are owned by core, not the working set.
     for (const slug of this.entries.keys()) {
       if (coreSlugs.has(slug)) {


### PR DESCRIPTION
## Summary
- Rewire orchestrate: needle∪dense∪edge candidate-gen + a single pool-select, replacing tree route + per-leaf L2; carry-forward steps kept verbatim; finalInjection: Slug[] seam stable.
- initLanes now builds the section index + edge graph (one page read each, stripped + raw) and ensures the section Qdrant collection; ShadowLanes drops tree/core. Selection sources now needle/dense/edge/carry-forward.
- Still shadow-only (injector untouched). Synthetic capability pages kept as a simple always-add (proper lane-ranking is a fast-follow).

Part of plan: memory-v3-section-lanes.md (PR 7 of 12)