### PR TITLE
feat(memory-v3): inject matched sections instead of full page bodies

### DIFF
--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/live-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/live-integration.test.ts
@@ -183,7 +183,11 @@ async function runTurn(
     workingSet: deps.workingSet,
     capabilitySlugs: [],
   });
-  const block = await renderMemoryBlock(result.finalInjection, contentOf);
+  const block = await renderMemoryBlock(
+    result.finalInjection,
+    result.sectionBySlug,
+    contentOf,
+  );
   return { result, block };
 }
 

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/render-injection.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/render-injection.test.ts
@@ -2,47 +2,76 @@ import { describe, expect, test } from "bun:test";
 
 import { wrapMemoryBlock } from "../../../../memory/memory-marker.js";
 import { renderMemoryBlock } from "../render-injection.js";
-import { Slug } from "../types.js";
+import type { Section, Slug } from "../types.js";
 
+function section(article: Slug, text: string): Section {
+  return { article, title: "", text, ordinal: 0 };
+}
+
+/**
+ * Stub resolver mirroring `renderV3SectionContent`'s branch: render the matched
+ * section's text when present, otherwise fall back to a "full body" stand-in.
+ */
 const resolver =
-  (pages: Record<Slug, string>) =>
-  async (slug: Slug): Promise<string> =>
-    pages[slug] ?? "";
+  (fullBodies: Record<Slug, string>) =>
+  async (slug: Slug, sec: Section | undefined): Promise<string> =>
+    sec ? sec.text : (fullBodies[slug] ?? "");
 
 describe("renderMemoryBlock", () => {
-  test("wraps the selection in a single <memory> block, in order", async () => {
-    const pages: Record<Slug, string> = {
-      "page-a": "alpha body",
-      "page-b": "beta body",
-    };
+  test("renders the matched section (not the full body) for each slug", async () => {
+    const sections = new Map<Slug, Section>([
+      ["page-a", section("page-a", "matched section A")],
+      ["topic-x", section("topic-x", "matched section X")],
+    ]);
 
     const block = await renderMemoryBlock(
-      ["page-a", "page-b"],
-      resolver(pages),
+      ["page-a", "topic-x"],
+      sections,
+      resolver({ "page-a": "FULL body A", "topic-x": "FULL body X" }),
     );
 
-    expect(block).toBe("<memory>\nalpha body\nbeta body\n</memory>");
+    expect(block).toBe(
+      "<memory>\nmatched section A\nmatched section X\n</memory>",
+    );
+    expect(block).not.toContain("FULL body");
+  });
+
+  test("falls back to the full/lead body for a slug with no matched section", async () => {
+    const sections = new Map<Slug, Section>([
+      ["page-a", section("page-a", "matched section A")],
+    ]);
+
+    const block = await renderMemoryBlock(
+      ["page-a", "topic-x"],
+      sections,
+      resolver({ "topic-x": "lead body X" }),
+    );
+
+    // page-a renders its matched section; topic-x (no entry) falls back.
+    expect(block).toBe("<memory>\nmatched section A\nlead body X\n</memory>");
   });
 
   test("empty selection renders the empty string", async () => {
-    const block = await renderMemoryBlock([], async () => "unused");
+    const block = await renderMemoryBlock([], new Map(), async () => "unused");
     expect(block).toBe("");
   });
 
   test("preserves input order deterministically", async () => {
-    const pages: Record<Slug, string> = {
-      "page-a": "A",
-      "page-b": "B",
-      "page-c": "C",
-    };
+    const sections = new Map<Slug, Section>([
+      ["page-a", section("page-a", "A")],
+      ["page-b", section("page-b", "B")],
+      ["page-c", section("page-c", "C")],
+    ]);
 
     const forward = await renderMemoryBlock(
       ["page-a", "page-b", "page-c"],
-      resolver(pages),
+      sections,
+      resolver({}),
     );
     const reversed = await renderMemoryBlock(
       ["page-c", "page-b", "page-a"],
-      resolver(pages),
+      sections,
+      resolver({}),
     );
 
     expect(forward).toBe("<memory>\nA\nB\nC\n</memory>");
@@ -52,7 +81,8 @@ describe("renderMemoryBlock", () => {
   test("emits the shared wrapMemoryBlock marker the v2 stripper recognizes", async () => {
     const block = await renderMemoryBlock(
       ["page-a"],
-      resolver({ "page-a": "x" }),
+      new Map([["page-a", section("page-a", "x")]]),
+      resolver({}),
     );
     // Guard the v2/v3 marker contract: the rendered block must be byte-identical
     // to wrapping the joined content with the shared helper.

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/selection-log-store.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/selection-log-store.test.ts
@@ -97,10 +97,13 @@ mock.module("../../../../memory/db-connection.js", () => ({
 
 mock.module("../page-content.js", () => ({
   ...realPageContent,
-  renderV3PageContent: async (slug: string) =>
+  // The inspector store renders via `renderV3SectionContent` with an empty
+  // section map (sections are unavailable post-orchestration), so it falls back
+  // to the full page. The mock stands in for that full-page render.
+  renderV3SectionContent: async (slug: string) =>
     storeMockActive
       ? `body for ${slug}`
-      : realPageContent.renderV3PageContent(slug),
+      : realPageContent.renderV3SectionContent(slug, undefined),
 }));
 
 const { getMemoryV3SelectionForInspector } =

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-plugin.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-plugin.test.ts
@@ -364,8 +364,11 @@ describe("memory-v3 shadow plugin", () => {
     expect(block!.placement).toBe("after-memory-prefix");
     expect(block!.text.startsWith("<memory>\n")).toBe(true);
     expect(block!.text.endsWith("\n</memory>")).toBe(true);
-    // finalInjection slugs are rendered into the block in order.
-    expect(block!.text).toContain("body for page-1");
+    // Progressive disclosure: a slug with a matched section renders that
+    // section's text (page-1 → "x"), NOT the full page body.
+    expect(block!.text).toContain("# memory/concepts/page-1.md\nx");
+    expect(block!.text).not.toContain("body for page-1");
+    // A slug with no matched section (carry-forward) falls back to the full body.
     expect(block!.text).toContain("body for carried");
     // Selections are still logged in live mode.
     expect(readRows().length).toBeGreaterThan(0);

--- a/assistant/src/plugins/defaults/memory-v3-shadow/injector.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/injector.ts
@@ -22,7 +22,7 @@ import {
   type Injector,
   type TurnContext,
 } from "../../types.js";
-import { renderV3PageContent } from "./page-content.js";
+import { renderV3SectionContent } from "./page-content.js";
 import { renderMemoryBlock } from "./render-injection.js";
 import {
   MEMORY_V3_LIVE,
@@ -52,7 +52,8 @@ export const memoryV3Injector: Injector = {
       // `renderMemoryBlock` returns "" for an empty selection; inject nothing.
       const text = await renderMemoryBlock(
         result.finalInjection,
-        renderV3PageContent,
+        result.sectionBySlug,
+        renderV3SectionContent,
       );
       if (text.length === 0) return null;
       return {

--- a/assistant/src/plugins/defaults/memory-v3-shadow/page-content.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/page-content.ts
@@ -1,7 +1,7 @@
 import { readPage, renderPageContent } from "../../../memory/v2/page-store.js";
 import { getWorkspaceDir } from "../../../util/platform.js";
 import { renderCapabilityContent } from "./capabilities.js";
-import type { Slug } from "./types.js";
+import type { Section, Slug } from "./types.js";
 
 /**
  * Render a selected page's full content for the v3 `<memory>` block. Mirrors
@@ -31,4 +31,31 @@ export async function renderV3PageContent(slug: Slug): Promise<string> {
   } catch {
     return "";
   }
+}
+
+/**
+ * Render a slug's matched section for the v3 `<memory>` block (progressive
+ * disclosure: inject only the section the lanes matched, not the full page).
+ * Uses the same `# memory/concepts/<slug>.md` header marker as
+ * {@link renderV3PageContent} so the block reads like v2's and the v2 stripper
+ * recognizes it.
+ *
+ * - Capability slugs (skills, `assistant` CLI commands) have no on-disk
+ *   section, so they always render their capability content via
+ *   {@link renderCapabilityContent}, never a section.
+ * - When `section` is undefined (e.g. a carry-forward page with no current
+ *   match), fall back to {@link renderV3PageContent} (the full/lead page) so the
+ *   slug still contributes content.
+ */
+export async function renderV3SectionContent(
+  slug: Slug,
+  section: Section | undefined,
+): Promise<string> {
+  const capability = renderCapabilityContent(slug);
+  if (capability !== null) return capability;
+  if (!section) return renderV3PageContent(slug);
+
+  const text = section.text.trim();
+  if (text.length === 0) return "";
+  return `# memory/concepts/${slug}.md\n${text}`;
 }

--- a/assistant/src/plugins/defaults/memory-v3-shadow/render-injection.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/render-injection.ts
@@ -1,13 +1,15 @@
 import { wrapMemoryBlock } from "../../../memory/memory-marker.js";
-import { Slug } from "./types.js";
+import { Section, Slug } from "./types.js";
 
 /**
  * Render a v3 working-set selection into a single `<memory>…</memory>` text
- * block.
+ * block, injecting each slug's matched section (progressive disclosure) rather
+ * than its full page body.
  *
  * Pure and side-effect-free: all I/O is delegated to the injected
- * `pageContent` resolver, which is awaited once per slug in input order. The
- * resulting block uses the shared {@link wrapMemoryBlock} marker — the same
+ * `pageContent` resolver, which is awaited once per slug in input order with
+ * that slug's matched section (`sectionBySlug.get(slug)`, possibly undefined).
+ * The resulting block uses the shared {@link wrapMemoryBlock} marker — the same
  * wrapper the v2 graph-memory path emits — so the existing strip machinery in
  * `conversation-graph-memory.ts` already recognizes (and evicts) it.
  *
@@ -16,17 +18,23 @@ import { Slug } from "./types.js";
  *
  * @param finalInjection - The working-set selection for the turn, in the order
  *   it should appear in the rendered block.
- * @param pageContent - Resolver returning a page's rendered content for a slug.
+ * @param sectionBySlug - The matched `Section` per slug; a slug with no entry
+ *   (e.g. carry-forward with no current match) renders its full/lead page.
+ * @param pageContent - Resolver returning a slug's rendered content given its
+ *   matched section (or undefined).
  * @returns The wrapped `<memory>` block, or `""` for an empty selection (the
  *   caller injects nothing).
  */
 export async function renderMemoryBlock(
   finalInjection: Slug[],
-  pageContent: (slug: Slug) => Promise<string>,
+  sectionBySlug: Map<Slug, Section>,
+  pageContent: (slug: Slug, section: Section | undefined) => Promise<string>,
 ): Promise<string> {
   if (finalInjection.length === 0) return "";
 
-  const contents = await Promise.all(finalInjection.map(pageContent));
+  const contents = await Promise.all(
+    finalInjection.map((slug) => pageContent(slug, sectionBySlug.get(slug))),
+  );
 
   return wrapMemoryBlock(contents.join("\n"));
 }

--- a/assistant/src/plugins/defaults/memory-v3-shadow/selection-log-store.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/selection-log-store.ts
@@ -11,9 +11,9 @@ import type { MemoryV3SelectionLog } from "../../../api/responses/memory-v3-sele
 import { isAssistantFeatureFlagEnabled } from "../../../config/assistant-feature-flags.js";
 import { getConfig } from "../../../config/loader.js";
 import { getDb, getSqliteFrom } from "../../../memory/db-connection.js";
-import { renderV3PageContent } from "./page-content.js";
+import { renderV3SectionContent } from "./page-content.js";
 import { renderMemoryBlock } from "./render-injection.js";
-import type { Slug } from "./types.js";
+import type { Section, Slug } from "./types.js";
 
 const MEMORY_V3_SHADOW = "memory-v3-shadow" as const;
 const MEMORY_V3_LIVE = "memory-v3-live" as const;
@@ -72,7 +72,16 @@ export async function getMemoryV3SelectionForInspector(
     pinned: r.pinned === 1,
   }));
   const slugs: Slug[] = selections.map((s) => s.slug);
-  const injectedText = await renderMemoryBlock(slugs, renderV3PageContent);
+  // The inspector re-renders from persisted rows without re-running
+  // orchestration, so the per-slug matched section is unavailable. An empty map
+  // makes `renderV3SectionContent` fall back to the full/lead page for every
+  // slug — the same full-page rendering the inspector showed before
+  // matched-section injection.
+  const injectedText = await renderMemoryBlock(
+    slugs,
+    new Map<Slug, Section>(),
+    renderV3SectionContent,
+  );
 
   return {
     turn,


### PR DESCRIPTION
## Summary
- Render the matched section (progressive disclosure) for each injected page instead of the full body; undefined-section pages fall back to the lead; capability slugs still render capability content. Injector flag/placement/fallback unchanged.

Part of plan: memory-v3-section-lanes.md (PR 8 of 12)