### PR TITLE
refactor(memory-v3): lane config knobs + selection-source telemetry

### DIFF
--- a/assistant/src/api/responses/memory-v3-selection-log.ts
+++ b/assistant/src/api/responses/memory-v3-selection-log.ts
@@ -22,9 +22,10 @@ import { z } from "zod";
 
 /**
  * One selected page in the v3 set. `source` is the lane that surfaced it —
- * the daemon emits `l1+l2`, `core+l2`, `needle`, or `carry-forward` — but the
- * schema stays a permissive string so a new lane label doesn't break parsing
- * on the FE. `pinned` marks a slug carried forward across turns.
+ * the daemon emits `needle`, `dense`, `edge`, or `carry-forward` — but the
+ * schema stays a permissive string so a new lane label (or a historical
+ * pre-lane row) doesn't break parsing on the FE. `pinned` marks a slug carried
+ * forward across turns.
  */
 export const MemoryV3SelectionRowSchema = z.object({
   slug: z.string(),

--- a/assistant/src/config/schemas/__tests__/memory-v3.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v3.test.ts
@@ -7,19 +7,35 @@ describe("MemoryV3ConfigSchema", () => {
     const parsed = MemoryV3ConfigSchema.parse({});
     expect(parsed).toEqual({
       workingSet: { maxPages: 150, evictWindow: 5 },
-      l2Concurrency: 16,
+      needleK: 100,
+      denseK: 100,
+      edge: { hubDegree: 30, seedCount: 18, perSeed: 6, cap: 45 },
     });
   });
 
-  test("accepts an explicit l2Concurrency override", () => {
-    expect(MemoryV3ConfigSchema.parse({ l2Concurrency: 8 }).l2Concurrency).toBe(
-      8,
-    );
+  test("accepts explicit lane-K overrides", () => {
+    const parsed = MemoryV3ConfigSchema.parse({ needleK: 50, denseK: 75 });
+    expect(parsed.needleK).toBe(50);
+    expect(parsed.denseK).toBe(75);
   });
 
-  test("rejects a non-positive or non-integer l2Concurrency", () => {
-    expect(() => MemoryV3ConfigSchema.parse({ l2Concurrency: 0 })).toThrow();
-    expect(() => MemoryV3ConfigSchema.parse({ l2Concurrency: -4 })).toThrow();
-    expect(() => MemoryV3ConfigSchema.parse({ l2Concurrency: 1.5 })).toThrow();
+  test("accepts a partial edge override, defaulting the rest", () => {
+    const parsed = MemoryV3ConfigSchema.parse({ edge: { hubDegree: 10 } });
+    expect(parsed.edge).toEqual({
+      hubDegree: 10,
+      seedCount: 18,
+      perSeed: 6,
+      cap: 45,
+    });
+  });
+
+  test("rejects non-positive or non-integer lane knobs", () => {
+    expect(() => MemoryV3ConfigSchema.parse({ needleK: 0 })).toThrow();
+    expect(() => MemoryV3ConfigSchema.parse({ denseK: -4 })).toThrow();
+    expect(() => MemoryV3ConfigSchema.parse({ needleK: 1.5 })).toThrow();
+    expect(() =>
+      MemoryV3ConfigSchema.parse({ edge: { perSeed: 0 } }),
+    ).toThrow();
+    expect(() => MemoryV3ConfigSchema.parse({ edge: { cap: -1 } })).toThrow();
   });
 });

--- a/assistant/src/config/schemas/memory-v3.ts
+++ b/assistant/src/config/schemas/memory-v3.ts
@@ -28,20 +28,70 @@ export const MemoryV3WorkingSetSchema = z
   })
   .describe("Memory v3 working-set retention/eviction tuning.");
 
+/**
+ * Edge-lane tuning for the link-graph expansion that folds a turn's lexical and
+ * dense seeds outward to their first-class neighbours.
+ */
+export const MemoryV3EdgeSchema = z
+  .object({
+    hubDegree: z
+      .number({ error: "memory.v3.edge.hubDegree must be a number" })
+      .int("memory.v3.edge.hubDegree must be an integer")
+      .positive("memory.v3.edge.hubDegree must be a positive integer")
+      .default(30)
+      .describe(
+        "In-degree above which an article is treated as a hub and excluded from edge expansion (too generic to be a useful surface).",
+      ),
+    seedCount: z
+      .number({ error: "memory.v3.edge.seedCount must be a number" })
+      .int("memory.v3.edge.seedCount must be an integer")
+      .positive("memory.v3.edge.seedCount must be a positive integer")
+      .default(18)
+      .describe(
+        "Number of top needle+dense seeds (in rank order) expanded by the edge lane.",
+      ),
+    perSeed: z
+      .number({ error: "memory.v3.edge.perSeed must be a number" })
+      .int("memory.v3.edge.perSeed must be an integer")
+      .positive("memory.v3.edge.perSeed must be a positive integer")
+      .default(6)
+      .describe("Maximum neighbours surfaced per expanded seed."),
+    cap: z
+      .number({ error: "memory.v3.edge.cap must be a number" })
+      .int("memory.v3.edge.cap must be an integer")
+      .positive("memory.v3.edge.cap must be a positive integer")
+      .default(45)
+      .describe(
+        "Hard cap on the total number of distinct articles surfaced by the edge lane.",
+      ),
+  })
+  .describe("Memory v3 edge-lane (link-graph expansion) tuning.");
+
 export const MemoryV3ConfigSchema = z
   .object({
     workingSet: MemoryV3WorkingSetSchema.default(
       MemoryV3WorkingSetSchema.parse({}),
     ),
-    l2Concurrency: z
-      .number({ error: "memory.v3.l2Concurrency must be a number" })
-      .int("memory.v3.l2Concurrency must be an integer")
-      .positive("memory.v3.l2Concurrency must be a positive integer")
-      .default(16)
+    needleK: z
+      .number({ error: "memory.v3.needleK must be a number" })
+      .int("memory.v3.needleK must be an integer")
+      .positive("memory.v3.needleK must be a positive integer")
+      .default(100)
       .describe(
-        "Bounded fan-out for the per-leaf L2 selection (number of leaf selector calls in flight at once).",
+        "Number of section-grain BM25 needle articles folded into the candidate pool each turn.",
       ),
+    denseK: z
+      .number({ error: "memory.v3.denseK must be a number" })
+      .int("memory.v3.denseK must be an integer")
+      .positive("memory.v3.denseK must be a positive integer")
+      .default(100)
+      .describe(
+        "Number of dense-lane articles folded into the candidate pool each turn.",
+      ),
+    edge: MemoryV3EdgeSchema.default(MemoryV3EdgeSchema.parse({})),
   })
-  .describe("Memory v3 — topic-tree routing with a carry-forward working set");
+  .describe(
+    "Memory v3 — section-grain lane retrieval with a carry-forward working set",
+  );
 
 export type MemoryV3Config = z.infer<typeof MemoryV3ConfigSchema>;

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/selection-log-store.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/selection-log-store.test.ts
@@ -122,7 +122,7 @@ afterAll(() => {
 
 describe("getMemoryV3SelectionForInspector", () => {
   test("returns null for a null/undefined turn", async () => {
-    seed("conv-x", 3, [{ slug: "domain-a/page-1", source: "l1+l2" }]);
+    seed("conv-x", 3, [{ slug: "domain-a/page-1", source: "needle" }]);
     expect(await getMemoryV3SelectionForInspector("conv-x", null)).toBeNull();
     expect(
       await getMemoryV3SelectionForInspector("conv-x", undefined),
@@ -130,8 +130,8 @@ describe("getMemoryV3SelectionForInspector", () => {
   });
 
   test("returns the selection for the exact turn", async () => {
-    seed("conv-2", 2, [{ slug: "domain-a/page-1", source: "l1+l2" }]);
-    seed("conv-2", 7, [{ slug: "domain-b/page-9", source: "l1+l2" }]);
+    seed("conv-2", 2, [{ slug: "domain-a/page-1", source: "needle" }]);
+    seed("conv-2", 7, [{ slug: "domain-b/page-9", source: "needle" }]);
 
     const log = await getMemoryV3SelectionForInspector("conv-2", 2);
     expect(log?.turn).toBe(2);
@@ -139,26 +139,26 @@ describe("getMemoryV3SelectionForInspector", () => {
   });
 
   test("returns null when the turn has no v3 rows", async () => {
-    seed("conv-1", 3, [{ slug: "domain-a/page-1", source: "l1+l2" }]);
+    seed("conv-1", 3, [{ slug: "domain-a/page-1", source: "needle" }]);
     expect(await getMemoryV3SelectionForInspector("conv-1", 4)).toBeNull();
   });
 
   test("does NOT fall back to another turn for an unmatched lookup", async () => {
     // Turn 5 has rows, but inspecting turn 3 (no rows) must return null —
     // never turn 5's selection, which would misattribute it to turn 3.
-    seed("conv-3", 5, [{ slug: "domain-a/page-1", source: "l1+l2" }]);
+    seed("conv-3", 5, [{ slug: "domain-a/page-1", source: "needle" }]);
     expect(await getMemoryV3SelectionForInspector("conv-3", 3)).toBeNull();
   });
 
   test("maps source/pinned and renders the <memory> block", async () => {
     seed("conv-4", 1, [
-      { slug: "domain-a/page-1", source: "core+l2", pinned: true },
+      { slug: "domain-a/page-1", source: "edge", pinned: true },
       { slug: "domain-b/page-2", source: "carry-forward", pinned: false },
     ]);
 
     const log = await getMemoryV3SelectionForInspector("conv-4", 1);
     expect(log?.selections).toEqual([
-      { slug: "domain-a/page-1", source: "core+l2", pinned: true },
+      { slug: "domain-a/page-1", source: "edge", pinned: true },
       { slug: "domain-b/page-2", source: "carry-forward", pinned: false },
     ]);
     expect(log?.injectedText).toContain("<memory>");
@@ -167,7 +167,7 @@ describe("getMemoryV3SelectionForInspector", () => {
   });
 
   test("live/shadow reflect the flag resolver", async () => {
-    seed("conv-5", 1, [{ slug: "domain-a/page-1", source: "l1+l2" }]);
+    seed("conv-5", 1, [{ slug: "domain-a/page-1", source: "needle" }]);
 
     const off = await getMemoryV3SelectionForInspector("conv-5", 1);
     expect(off?.live).toBe(false);

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-plugin.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-plugin.test.ts
@@ -114,7 +114,12 @@ mock.module("../../../../config/assistant-feature-flags.js", () => ({
 mock.module("../../../../config/loader.js", () => ({
   getConfig: () => ({
     memory: {
-      v3: { workingSet: { maxPages: 150, evictWindow: 5 } },
+      v3: {
+        workingSet: { maxPages: 150, evictWindow: 5 },
+        needleK: 100,
+        denseK: 100,
+        edge: { hubDegree: 30, seedCount: 18, perSeed: 6, cap: 45 },
+      },
       qdrant: { vectorSize: 8, onDisk: false },
     },
   }),

--- a/assistant/src/plugins/defaults/memory-v3-shadow/orchestrate.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/orchestrate.ts
@@ -52,6 +52,10 @@ export const DEFAULT_NEEDLE_K = 100;
 export const DEFAULT_DENSE_K = 100;
 /** Default number of top needle+dense seeds expanded by the edge lane. */
 export const DEFAULT_EDGE_SEEDS = 18;
+/** Default neighbours surfaced per expanded edge seed. */
+export const DEFAULT_EDGE_PER_SEED = 6;
+/** Default hard cap on the total number of articles the edge lane surfaces. */
+export const DEFAULT_EDGE_CAP = 45;
 
 export interface OrchestrateDeps {
   sectionIndex: SectionIndex;
@@ -71,6 +75,12 @@ export interface OrchestrateDeps {
   /** Number of top needle+dense seeds expanded. Defaults to
    *  {@link DEFAULT_EDGE_SEEDS}. */
   edgeSeeds?: number;
+  /** Neighbours surfaced per expanded edge seed. Defaults to
+   *  {@link DEFAULT_EDGE_PER_SEED}. */
+  edgePerSeed?: number;
+  /** Hard cap on total edge-lane surfaced articles. Defaults to
+   *  {@link DEFAULT_EDGE_CAP}. */
+  edgeCap?: number;
 }
 
 export interface OrchestrateResult {
@@ -99,6 +109,8 @@ export async function orchestrate(
   const needleK = deps.needleK ?? DEFAULT_NEEDLE_K;
   const denseK = deps.denseK ?? DEFAULT_DENSE_K;
   const edgeSeeds = deps.edgeSeeds ?? DEFAULT_EDGE_SEEDS;
+  const edgePerSeed = deps.edgePerSeed ?? DEFAULT_EDGE_PER_SEED;
+  const edgeCap = deps.edgeCap ?? DEFAULT_EDGE_CAP;
   const { sections } = deps.sectionIndex;
 
   // Step 1: needle (sync BM25) and dense (async embed + Qdrant) lanes run in
@@ -158,6 +170,8 @@ export async function orchestrate(
   ]);
   const surfaced = edgeExpand(deps.edgeGraph, seeds, {
     seedCount: edgeSeeds,
+    perSeed: edgePerSeed,
+    cap: edgeCap,
     alive: (slug) => !poolBySlug.has(slug),
   });
   for (const neighbor of surfaced) {

--- a/assistant/src/plugins/defaults/memory-v3-shadow/shadow-plugin.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/shadow-plugin.ts
@@ -147,7 +147,9 @@ async function initLanes(config: AssistantConfig): Promise<ShadowLanes> {
 
   const sectionIndex = await buildSectionIndex(slugs, pageBody);
   const needle = buildSectionNeedle(sectionIndex);
-  const edgeGraph = await buildEdgeGraph(pageIndex.entries, pageRaw);
+  const edgeGraph = await buildEdgeGraph(pageIndex.entries, pageRaw, {
+    hubDegree: config.memory.v3.edge.hubDegree,
+  });
   await ensureSectionCollection(config);
 
   // Synthetic capability slugs (skills + CLI commands) the page index already
@@ -329,6 +331,7 @@ export async function observeTurn(
 
     const cfg = getConfig();
     const lanes = await getLanes(cfg);
+    const v3 = cfg.memory.v3;
     const result = await orchestrate(turn, {
       sectionIndex: lanes.sectionIndex,
       needle: lanes.needle,
@@ -336,6 +339,11 @@ export async function observeTurn(
       edgeGraph: lanes.edgeGraph,
       workingSet: lanes.workingSet,
       capabilitySlugs: lanes.capabilitySlugs,
+      needleK: v3.needleK,
+      denseK: v3.denseK,
+      edgeSeeds: v3.edge.seedCount,
+      edgePerSeed: v3.edge.perSeed,
+      edgeCap: v3.edge.cap,
     });
 
     const rows = attributeSelections(result);

--- a/assistant/src/plugins/defaults/memory-v3-shadow/types.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/types.ts
@@ -87,16 +87,11 @@ export interface MemoryRoutingTurn {
 }
 
 /**
- * Lane attribution recorded per selection. The section-lane pipeline writes the
- * lane literals (`"needle" | "dense" | "edge" | "carry-forward"`); the legacy
- * tree literals (`"l1+l2" | "core+l2"`) are retained until the tree pipeline is
- * deleted. PR 11 tightens this to the lane literals only. The DB column is
- * free-text, so widening here needs no migration.
+ * Lane attribution recorded per selection. The section-lane pipeline writes one
+ * of the lane literals below. The legacy tree literals (`"l1+l2" | "core+l2"`)
+ * were dropped once the per-leaf/route selector was deleted — nothing writes
+ * them anymore. The `memory_v3_selections.source` column is free-text, so this
+ * tightening needs no migration (any historical rows with the old labels still
+ * read back fine via the permissive `z.string()` row schema).
  */
-export type SelectionSource =
-  | "l1+l2"
-  | "core+l2"
-  | "needle"
-  | "dense"
-  | "edge"
-  | "carry-forward";
+export type SelectionSource = "needle" | "dense" | "edge" | "carry-forward";


### PR DESCRIPTION
## Summary
- Add needleK/denseK/edge lane knobs to MemoryV3ConfigSchema and wire orchestrate/initLanes to read them instead of literals. Tighten SelectionSource / remove l2Concurrency only where grep-confirmed unused (tree-gardening subsystem retained from PR 10 keeps whatever it still references).

Part of plan: memory-v3-section-lanes.md (PR 11 of 12)