### PR TITLE
chore(memory-v3): self-review cleanup (dedup + stale doc comments)

### DIFF
--- a/assistant/src/api/responses/memory-v3-selection-log.ts
+++ b/assistant/src/api/responses/memory-v3-selection-log.ts
@@ -1,7 +1,7 @@
 /**
  * Wire contract for the memory v3 selection set surfaced in the inspector's
  * Memory tab. Mirrors the return value of `getMemoryV3SelectionForInspector`
- * in `assistant/src/memory/v3/selection-log-store.ts`.
+ * in `assistant/src/plugins/defaults/memory-v3-shadow/selection-log-store.ts`.
  *
  * Canonical wire-contract source. Assistant code imports the types directly
  * from this file via relative paths; external consumers (web client, gateway,

--- a/assistant/src/config/schemas/memory-v3.ts
+++ b/assistant/src/config/schemas/memory-v3.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 /**
- * Memory v3 (topic-tree routing) working-set configuration.
+ * Memory v3 (section-grain lane retrieval) working-set configuration.
  *
  * The working set is the per-conversation set of concept pages carried
  * forward across turns. Eviction keeps it bounded: pages unseen for longer

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/dense.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/dense.test.ts
@@ -64,9 +64,9 @@ mock.module("@qdrant/js-client-rest", () => ({
   QdrantClient: MockQdrantClient,
 }));
 
-const { denseLane, OVERSAMPLE, _resetDenseLaneForTests } =
-  await import("../dense.js");
-const { SECTION_COLLECTION } = await import("../section-dense-store.js");
+const { denseLane, OVERSAMPLE } = await import("../dense.js");
+const { SECTION_COLLECTION, _resetSectionDenseStoreForTests } =
+  await import("../section-dense-store.js");
 
 const CONFIG = {
   memory: { qdrant: { vectorSize: 4, onDisk: true } },
@@ -82,7 +82,7 @@ function resetState(): void {
   state.points = [];
   state.queryThrows = null;
   state.queryCalls.length = 0;
-  _resetDenseLaneForTests();
+  _resetSectionDenseStoreForTests();
 }
 
 describe("memory v3 dense lane", () => {

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/orchestrate.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/orchestrate.test.ts
@@ -52,7 +52,7 @@ mock.module("../../../../util/logger.js", () => ({
 // the real `denseLane` unless this file's tests are running (`denseMockActive`),
 // so the process-global `mock.module` cannot leak fake behavior into
 // dense.test.ts (which exercises the real lane). Spread the real module so
-// every other export (`_resetDenseLaneForTests`, `OVERSAMPLE`) stays present.
+// every other export (`OVERSAMPLE`) stays present.
 const realDense = { ...(await import("../dense.js")) };
 let denseMockActive = false;
 let denseHits: Array<{ article: Slug; section: number }> = [];

--- a/assistant/src/plugins/defaults/memory-v3-shadow/dense.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/dense.ts
@@ -15,13 +15,13 @@
 // `[]`. The orchestrator unions the other lanes (needle, edge) plus carry-
 // forward regardless, so a dense outage narrows recall but never breaks a turn.
 
-import { QdrantClient as QdrantRestClient } from "@qdrant/js-client-rest";
-
 import type { AssistantConfig } from "../../../config/types.js";
 import { embedWithBackend } from "../../../memory/embedding-backend.js";
-import { resolveQdrantUrl } from "../../../memory/qdrant-client.js";
 import { getLogger } from "../../../util/logger.js";
-import { SECTION_COLLECTION } from "./section-dense-store.js";
+import {
+  getSectionDenseClient,
+  SECTION_COLLECTION,
+} from "./section-dense-store.js";
 import type { Slug } from "./types.js";
 
 const log = getLogger("memory-v3-dense-lane");
@@ -37,18 +37,6 @@ export const OVERSAMPLE = 6;
 export interface DenseHit {
   article: Slug;
   section: number;
-}
-
-let _client: QdrantRestClient | null = null;
-
-/** Lazily create a Qdrant REST client bound to the resolved URL. */
-function getClient(config: AssistantConfig): QdrantRestClient {
-  if (_client) return _client;
-  _client = new QdrantRestClient({
-    url: resolveQdrantUrl(config),
-    checkCompatibility: false,
-  });
-  return _client;
 }
 
 /**
@@ -73,11 +61,14 @@ export async function denseLane(
     const vector = vectors[0];
     if (!vector || vector.length === 0) return [];
 
-    const result = await getClient(config).query(SECTION_COLLECTION, {
-      query: vector,
-      limit: k * OVERSAMPLE,
-      with_payload: true,
-    });
+    const result = await getSectionDenseClient(config).query(
+      SECTION_COLLECTION,
+      {
+        query: vector,
+        limit: k * OVERSAMPLE,
+        with_payload: true,
+      },
+    );
     points = result.points;
   } catch (err) {
     log.warn({ err }, "memory v3 dense lane failed; degrading to no hits");
@@ -103,9 +94,4 @@ export async function denseLane(
   }
 
   return hits;
-}
-
-/** @internal Test-only: reset module-level singletons. */
-export function _resetDenseLaneForTests(): void {
-  _client = null;
 }

--- a/assistant/src/plugins/defaults/memory-v3-shadow/edge.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/edge.ts
@@ -29,7 +29,7 @@ import type { Slug } from "./types.js";
 
 /** Default in-degree above which an article is treated as a hub and excluded
  * from expansion (a hub neighbour is too generic to be a useful surface). */
-export const DEFAULT_HUB_DEGREE = 30;
+const DEFAULT_HUB_DEGREE = 30;
 
 const DEFAULT_SEED_COUNT = 18;
 const DEFAULT_PER_SEED = 6;

--- a/assistant/src/plugins/defaults/memory-v3-shadow/orchestrate.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/orchestrate.ts
@@ -16,8 +16,8 @@
  *      section against the query. The synthetic capability slugs (skills / CLI
  *      commands) are always appended (lane-ranking of synthetic pages is a
  *      documented fast-follow).
- *   3. A SINGLE forced-tool select (`selectPool`) over the whole pool, replacing
- *      the per-leaf L2 fan-out. The result is this turn's selections.
+ *   3. A SINGLE forced-tool select (`selectPool`) over the whole pool. The
+ *      result is this turn's selections.
  *   4. Age the carry-forward working set to this turn (evict stale non-pinned
  *      entries, then the cap) and snapshot it — the pages carried in from
  *      EARLIER turns.
@@ -50,12 +50,6 @@ import { WorkingSet } from "./working-set.js";
 export const DEFAULT_NEEDLE_K = 100;
 /** Default number of dense-lane articles to fold into the pool. */
 export const DEFAULT_DENSE_K = 100;
-/** Default number of top needle+dense seeds expanded by the edge lane. */
-export const DEFAULT_EDGE_SEEDS = 18;
-/** Default neighbours surfaced per expanded edge seed. */
-export const DEFAULT_EDGE_PER_SEED = 6;
-/** Default hard cap on the total number of articles the edge lane surfaces. */
-export const DEFAULT_EDGE_CAP = 45;
 
 export interface OrchestrateDeps {
   sectionIndex: SectionIndex;
@@ -72,14 +66,14 @@ export interface OrchestrateDeps {
   needleK?: number;
   /** Number of dense-lane articles. Defaults to {@link DEFAULT_DENSE_K}. */
   denseK?: number;
-  /** Number of top needle+dense seeds expanded. Defaults to
-   *  {@link DEFAULT_EDGE_SEEDS}. */
+  /** Number of top needle+dense seeds expanded. When omitted, the edge lane's
+   *  own default applies (canonical value: `memory.v3.edge.seedCount`). */
   edgeSeeds?: number;
-  /** Neighbours surfaced per expanded edge seed. Defaults to
-   *  {@link DEFAULT_EDGE_PER_SEED}. */
+  /** Neighbours surfaced per expanded edge seed. When omitted, the edge lane's
+   *  own default applies (canonical value: `memory.v3.edge.perSeed`). */
   edgePerSeed?: number;
-  /** Hard cap on total edge-lane surfaced articles. Defaults to
-   *  {@link DEFAULT_EDGE_CAP}. */
+  /** Hard cap on total edge-lane surfaced articles. When omitted, the edge
+   *  lane's own default applies (canonical value: `memory.v3.edge.cap`). */
   edgeCap?: number;
 }
 
@@ -92,8 +86,8 @@ export interface OrchestrateResult {
   /** Slugs to inject: this turn's selections ∪ the carried-forward working set. */
   finalInjection: Slug[];
   /** The matched `Section` for each pooled slug that had one, keyed by slug.
-   *  Populated from the lane hits; unused downstream until matched-section
-   *  injection lands (PR 8). */
+   *  Populated from the lane hits and consumed by the injector to render each
+   *  selected slug's matched section (progressive disclosure). */
   sectionBySlug: Map<Slug, Section>;
 }
 
@@ -108,9 +102,6 @@ export async function orchestrate(
 ): Promise<OrchestrateResult> {
   const needleK = deps.needleK ?? DEFAULT_NEEDLE_K;
   const denseK = deps.denseK ?? DEFAULT_DENSE_K;
-  const edgeSeeds = deps.edgeSeeds ?? DEFAULT_EDGE_SEEDS;
-  const edgePerSeed = deps.edgePerSeed ?? DEFAULT_EDGE_PER_SEED;
-  const edgeCap = deps.edgeCap ?? DEFAULT_EDGE_CAP;
   const { sections } = deps.sectionIndex;
 
   // Step 1: needle (sync BM25) and dense (async embed + Qdrant) lanes run in
@@ -169,9 +160,9 @@ export async function orchestrate(
     ...densed.map((h) => h.article),
   ]);
   const surfaced = edgeExpand(deps.edgeGraph, seeds, {
-    seedCount: edgeSeeds,
-    perSeed: edgePerSeed,
-    cap: edgeCap,
+    seedCount: deps.edgeSeeds,
+    perSeed: deps.edgePerSeed,
+    cap: deps.edgeCap,
     alive: (slug) => !poolBySlug.has(slug),
   });
   for (const neighbor of surfaced) {

--- a/assistant/src/plugins/defaults/memory-v3-shadow/page-content.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/page-content.ts
@@ -4,6 +4,16 @@ import { renderCapabilityContent } from "./capabilities.js";
 import type { Section, Slug } from "./types.js";
 
 /**
+ * Prefix `body` with the `# memory/concepts/<slug>.md` header marker the v3
+ * `<memory>` block uses. Both the full-page and matched-section renderers emit
+ * this exact marker, and the v2 stripper recognizes pages by it — so the two
+ * call sites MUST stay byte-identical, which is why this lives in one place.
+ */
+function withConceptHeader(slug: Slug, body: string): string {
+  return `# memory/concepts/${slug}.md\n${body}`;
+}
+
+/**
  * Render a selected page's full content for the v3 `<memory>` block. Mirrors
  * the v2 dynamic-memory layout (`# memory/concepts/<slug>.md\n<frontmatter+body>`)
  * so the working-set block reads like v2's. A missing page (or any read
@@ -27,7 +37,7 @@ export async function renderV3PageContent(slug: Slug): Promise<string> {
     if (!page) return "";
     const content = renderPageContent(page).trim();
     if (content.length === 0) return "";
-    return `# memory/concepts/${slug}.md\n${content}`;
+    return withConceptHeader(slug, content);
   } catch {
     return "";
   }
@@ -57,5 +67,5 @@ export async function renderV3SectionContent(
 
   const text = section.text.trim();
   if (text.length === 0) return "";
-  return `# memory/concepts/${slug}.md\n${text}`;
+  return withConceptHeader(slug, text);
 }

--- a/assistant/src/plugins/defaults/memory-v3-shadow/pool-select.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/pool-select.ts
@@ -1,22 +1,20 @@
 /**
  * Memory v3 — single pool selector.
  *
- * Where the per-leaf L2 selector (`./selector.ts`) runs ONE forced-tool call per
- * opened leaf over that leaf's static `<pages>` block, the pool selector runs a
- * SINGLE forced-tool call over one unified candidate pool. Each candidate is a
- * page slug paired with a per-candidate `descriptor` the caller supplies — the
- * matched section text for a needle/dense hit, or a curated link description for
- * an edge page. The caller assembles the pool by unioning the section lanes; the
- * pool selector only decides which of those candidates the reply will draw on.
+ * Runs a SINGLE forced-tool call over one unified candidate pool. Each candidate
+ * is a page slug paired with a per-candidate `descriptor` the caller supplies —
+ * the matched section text for a needle/dense hit, or a curated link description
+ * for an edge page. The caller assembles the pool by unioning the section lanes;
+ * the pool selector only decides which of those candidates the reply will draw
+ * on.
  *
- * No cache breakpoint. Unlike the per-leaf selector, whose `<pages>` block is
- * stable for a given leaf turn-after-turn (and so carries a `cache_control`
- * breakpoint), the pool is recomputed from per-turn section matches and is
- * therefore dynamic per turn. Caching a prefix that changes every turn would
- * never hit; carry-forward (the working set unioned in by the orchestrator) is
- * the cache mechanism here, not a static prefix breakpoint.
+ * No cache breakpoint. The pool is recomputed from per-turn section matches and
+ * is therefore dynamic per turn, so it carries no `cache_control` breakpoint:
+ * caching a prefix that changes every turn would never hit. Carry-forward (the
+ * working set unioned in by the orchestrator) is the cache mechanism here, not a
+ * static prefix breakpoint.
  *
- * Failure handling mirrors the per-leaf selector EXACTLY:
+ * Failure handling is recall-safe by construction:
  *   - explicit `ids` → select exactly those candidates,
  *   - explicit empty `ids: []` → select none (deliberate abstention),
  *   - omitted `ids` → keep ALL candidates (the recall-safe "all of these are
@@ -142,9 +140,9 @@ export async function selectPool(
     return [];
   }
 
-  // The pool is dynamic per turn, so — unlike the per-leaf selector — there is
-  // no static cache breakpoint here; carry-forward is the cache mechanism. The
-  // candidate list and the per-turn context go in a single plain text block.
+  // The pool is dynamic per turn, so there is no static cache breakpoint here;
+  // carry-forward is the cache mechanism. The candidate list and the per-turn
+  // context go in a single plain text block.
   const userMsg: Message = {
     role: "user",
     content: [

--- a/assistant/src/plugins/defaults/memory-v3-shadow/section-dense-store.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/section-dense-store.ts
@@ -9,14 +9,15 @@
 // collection embeds whole pages, this one embeds sub-page sections so a query
 // can match the single relevant block of a long article.
 //
-// Reuses the v2 Qdrant REST client (`resolveQdrantUrl` + `config.memory.qdrant.*`)
+// Reuses the v2 Qdrant URL/config (`resolveQdrantUrl` + `config.memory.qdrant.*`)
 // and the shared embedding backend (`embedWithBackend`) rather than standing up
 // new infrastructure. The collection carries a single dense named vector sized
 // to the configured embedding backend (`config.memory.qdrant.vectorSize`) — no
 // sparse channel, since the section dense lane is dense-only.
 //
-// Additive: nothing queries this collection yet. PR 3 of the section-lanes plan
-// only populates it; the retrieval read path lands in a later PR.
+// This module owns the write side (collection lifecycle + upserts) and the
+// shared Qdrant client; the read side (`dense.ts`) reuses that client to query
+// this collection.
 
 import { QdrantClient as QdrantRestClient } from "@qdrant/js-client-rest";
 import { v5 as uuidv5 } from "uuid";
@@ -44,8 +45,14 @@ const SECTION_NAMESPACE = "1d2c3b4a-5e6f-4a7b-8c9d-0e1f2a3b4c5d";
 let _client: QdrantRestClient | null = null;
 let _collectionReady = false;
 
-/** Lazily create a Qdrant REST client bound to the resolved URL. */
-function getClient(config: AssistantConfig): QdrantRestClient {
+/**
+ * Lazily create the shared Qdrant REST client bound to the resolved URL.
+ * Shared by both section-dense lanes (this store and the dense read lane in
+ * `dense.ts`) so they reuse one client instance and one reset hook.
+ */
+export function getSectionDenseClient(
+  config: AssistantConfig,
+): QdrantRestClient {
   if (_client) return _client;
   _client = new QdrantRestClient({
     url: resolveQdrantUrl(config),
@@ -74,7 +81,7 @@ export async function ensureSectionCollection(
 ): Promise<void> {
   if (_collectionReady) return;
 
-  const client = getClient(config);
+  const client = getSectionDenseClient(config);
   const vectorSize = config.memory.qdrant.vectorSize;
   const onDisk = config.memory.qdrant.onDisk;
 
@@ -161,7 +168,10 @@ export async function upsertSections(
     },
   }));
 
-  await getClient(config).upsert(SECTION_COLLECTION, { wait: true, points });
+  await getSectionDenseClient(config).upsert(SECTION_COLLECTION, {
+    wait: true,
+    points,
+  });
 }
 
 /**
@@ -176,7 +186,7 @@ export async function deleteSectionsForArticle(
 ): Promise<void> {
   await ensureSectionCollection(config);
 
-  await getClient(config).delete(SECTION_COLLECTION, {
+  await getSectionDenseClient(config).delete(SECTION_COLLECTION, {
     wait: true,
     filter: { must: [{ key: "article", match: { value: article } }] },
   });

--- a/assistant/src/plugins/defaults/memory-v3-shadow/section-needle.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/section-needle.ts
@@ -21,9 +21,9 @@ const k1 = 1.5;
 const b = 0.75;
 
 /** `head`-field weight in the BM25F term-frequency blend. */
-export const HEAD_WEIGHT = 2.5;
+const HEAD_WEIGHT = 2.5;
 /** `body`-field weight in the BM25F term-frequency blend. */
-export const BODY_WEIGHT = 1;
+const BODY_WEIGHT = 1;
 
 export interface SectionNeedle {
   /**
@@ -41,7 +41,7 @@ export interface SectionNeedle {
   bestSection(article: Slug, queryText: string): number;
 }
 
-/** Lowercase, split on non-alphanumeric, drop empties. Mirrors `needle.ts`. */
+/** Lowercase, split on non-alphanumeric, drop empties. */
 function tokenizeUnigrams(text: string): string[] {
   return text
     .toLowerCase()

--- a/assistant/src/plugins/defaults/memory-v3-shadow/types.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/types.ts
@@ -87,18 +87,14 @@ export interface MemoryRoutingTurn {
 }
 
 /**
- * Lane attribution recorded per selection. The section-lane pipeline writes one
- * of the lane literals below. The legacy tree literals (`"l1+l2" | "core+l2"`)
- * were dropped once the per-leaf/route selector was deleted — nothing writes
- * them anymore. The `memory_v3_selections.source` column is free-text, so this
- * tightening needs no migration (any historical rows with the old labels still
- * read back fine via the permissive `z.string()` row schema).
- */
-/**
- * Canonical ordered list of the lane sources. The {@link SelectionSource} type
- * is derived from this so a new lane is added in exactly one place and the
- * runtime list (used for telemetry roll-ups and source validation) can never
- * drift from the type.
+ * Canonical ordered list of the lane sources recorded per selection. The
+ * {@link SelectionSource} type is derived from this so a new lane is added in
+ * exactly one place and the runtime list (used for telemetry roll-ups and
+ * source validation) can never drift from the type.
+ *
+ * The `memory_v3_selections.source` column is free-text, so tightening this set
+ * needs no migration: any historical rows with older labels still read back
+ * fine via the permissive `z.string()` row schema.
  */
 export const SELECTION_SOURCES = [
   "needle",


### PR DESCRIPTION
## Summary
Behavior-preserving cleanup from plan self-review: consolidate the duplicated section-dense Qdrant client, single-source the lane tuning constants (drop duplicate/unused exports), extract the shared concept-header marker, and fix stale doc-comments that referenced the deleted selector.ts/needle.ts (per assistant/CLAUDE.md).

Fixes gaps identified during plan self-review for memory-v3-section-lanes.md.