### PR TITLE
feat(memory-v3): rank synthetic skill/CLI pages via the lanes

### DIFF
--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/live-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/live-integration.test.ts
@@ -181,7 +181,6 @@ async function runTurn(
     denseConfig: config,
     edgeGraph: deps.lanes.edgeGraph,
     workingSet: deps.workingSet,
-    capabilitySlugs: [],
   });
   const block = await renderMemoryBlock(
     result.finalInjection,

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/orchestrate.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/orchestrate.test.ts
@@ -3,8 +3,10 @@
  *
  * The orchestrator composes three deterministic candidate lanes — the
  * section-grain BM25 needle, the dense lane, and link-graph edge expansion —
- * into ONE unified pool, appends the synthetic capability slugs, runs a SINGLE
- * forced-tool select over the pool, then carries forward the working set.
+ * into ONE unified pool, runs a SINGLE forced-tool select over the pool, then
+ * carries forward the working set. Synthetic capability pages (skills / CLI
+ * commands) are indexed like any other page, so they enter the pool through the
+ * lanes (e.g. the needle) rather than being always-added.
  *
  * The select provider is stubbed (no network); a single stub answers the one
  * `select_pages` call per turn by reading the numbered `<candidates>` block.
@@ -186,14 +188,16 @@ afterAll(() => {
 });
 
 // ---------------------------------------------------------------------------
-// Pool composition: the candidate pool is the union of the lanes + capabilities.
+// Pool composition: the candidate pool is the union of the lanes. Synthetic
+// capability pages are no longer always-added — they enter through a lane (see
+// the dedicated test below).
 // ---------------------------------------------------------------------------
 
 describe("orchestrate — candidate pool composition", () => {
-  test("pool unions needle ∪ dense ∪ edge ∪ capabilities; one select runs", async () => {
+  test("pool unions needle ∪ dense ∪ edge; one select runs", async () => {
     const lanes = await buildLanes();
     // "apple" hits topic-a (needle). Dense returns topic-b. topic-a links to
-    // topic-d (edge). Capability slug always appended.
+    // topic-d (edge).
     denseHits = [{ article: "topic-b", section: 0 }];
     providerStub = selectProvider([]); // selection is irrelevant to pool union
 
@@ -203,13 +207,40 @@ describe("orchestrate — candidate pool composition", () => {
       denseConfig: config,
       edgeGraph: lanes.edgeGraph,
       workingSet: new WorkingSet(),
-      capabilitySlugs: ["skills/example"],
     });
 
     expect(selectCalls).toBe(1);
     expect(new Set(lastPool)).toEqual(
-      new Set(["topic-a", "topic-b", "topic-d", "skills/example"]),
+      new Set(["topic-a", "topic-b", "topic-d"]),
     );
+  });
+
+  test("a synthetic capability page enters the pool via the needle lane", async () => {
+    // A capability slug indexed with body content (the section index treats it
+    // like any other page) is ranked by the real needle when the query matches
+    // its text — this is how synthetic pages reach the pool now that they are no
+    // longer always-added.
+    const CAP: Slug = "skills/example";
+    const sectionIndex = await buildSectionIndex([...SLUGS, CAP], async (s) =>
+      s === CAP
+        ? "# Skill: example\nuse the kumquat skill to do the thing"
+        : PAGES[s]!,
+    );
+    const needle = buildSectionNeedle(sectionIndex);
+    const edgeGraph = await buildEdgeGraph(makeEntries(), async (s) => RAW[s]!);
+
+    providerStub = selectProvider([]); // selection irrelevant to pool union
+    await orchestrate(makeTurn(1, "kumquat"), {
+      sectionIndex,
+      needle,
+      denseConfig: config,
+      edgeGraph,
+      workingSet: new WorkingSet(),
+    });
+
+    // The needle ranked the capability page on the "kumquat" term, so it is in
+    // the candidate pool.
+    expect(lastPool).toContain(CAP);
   });
 
   test("edge curated link description becomes the edge candidate's descriptor", async () => {
@@ -235,7 +266,6 @@ describe("orchestrate — candidate pool composition", () => {
       denseConfig: config,
       edgeGraph: lanes.edgeGraph,
       workingSet: new WorkingSet(),
-      capabilitySlugs: [],
     });
 
     expect(descriptorLine).toContain("the curated edge from a to d");
@@ -258,7 +288,6 @@ describe("orchestrate — candidate pool composition", () => {
       denseConfig: config,
       edgeGraph: lanes.edgeGraph,
       workingSet: new WorkingSet(),
-      capabilitySlugs: [],
     });
     expect(needleK).toBe(DEFAULT_NEEDLE_K);
     expect(DEFAULT_DENSE_K).toBe(100);
@@ -274,7 +303,6 @@ describe("orchestrate — candidate pool composition", () => {
       denseConfig: config,
       edgeGraph: lanes.edgeGraph,
       workingSet: new WorkingSet(),
-      capabilitySlugs: [],
     });
     // topic-a matched "apple" in its `## Details` section.
     expect(result.sectionBySlug.get("topic-a")?.article).toBe("topic-a");
@@ -299,7 +327,6 @@ describe("orchestrate — carry-forward", () => {
       denseConfig: config,
       edgeGraph: lanes.edgeGraph,
       workingSet,
-      capabilitySlugs: [],
     });
 
     // Turn 2 selects a DIFFERENT page and never re-selects topic-a.
@@ -311,7 +338,6 @@ describe("orchestrate — carry-forward", () => {
       denseConfig: config,
       edgeGraph: lanes.edgeGraph,
       workingSet,
-      capabilitySlugs: [],
     });
 
     expect(t2.currentSelections.map((s) => s.slug)).not.toContain("topic-a");
@@ -332,7 +358,6 @@ describe("orchestrate — carry-forward", () => {
       denseConfig: config,
       edgeGraph: lanes.edgeGraph,
       workingSet,
-      capabilitySlugs: [],
     });
 
     denseHits = [{ article: "topic-b", section: 0 }];
@@ -343,7 +368,6 @@ describe("orchestrate — carry-forward", () => {
       denseConfig: config,
       edgeGraph: lanes.edgeGraph,
       workingSet,
-      capabilitySlugs: [],
     });
 
     expect(t2.currentSelections.map((s) => s.slug)).toEqual(["topic-b"]);
@@ -362,7 +386,6 @@ describe("orchestrate — carry-forward", () => {
       denseConfig: config,
       edgeGraph: lanes.edgeGraph,
       workingSet,
-      capabilitySlugs: [],
     });
     expect(t1.finalInjection).toContain("topic-a");
 
@@ -374,7 +397,6 @@ describe("orchestrate — carry-forward", () => {
       denseConfig: config,
       edgeGraph: lanes.edgeGraph,
       workingSet,
-      capabilitySlugs: [],
     });
     await orchestrate(makeTurn(3, "x"), {
       sectionIndex: lanes.sectionIndex,
@@ -382,7 +404,6 @@ describe("orchestrate — carry-forward", () => {
       denseConfig: config,
       edgeGraph: lanes.edgeGraph,
       workingSet,
-      capabilitySlugs: [],
     });
     const t4 = await orchestrate(makeTurn(4, "x"), {
       sectionIndex: lanes.sectionIndex,
@@ -390,7 +411,6 @@ describe("orchestrate — carry-forward", () => {
       denseConfig: config,
       edgeGraph: lanes.edgeGraph,
       workingSet,
-      capabilitySlugs: [],
     });
     expect(t4.finalInjection).not.toContain("topic-a");
   });
@@ -405,7 +425,6 @@ describe("orchestrate — carry-forward", () => {
       denseConfig: config,
       edgeGraph: lanes.edgeGraph,
       workingSet: ws,
-      capabilitySlugs: [],
     });
     expect(ws.union().has("topic-a")).toBe(true);
   });
@@ -425,7 +444,6 @@ describe("orchestrate — degradation", () => {
       denseConfig: config,
       edgeGraph: lanes.edgeGraph,
       workingSet: new WorkingSet(),
-      capabilitySlugs: [],
     });
     expect(result.currentSelections).toEqual([]);
     expect(result.finalInjection).toEqual([]);
@@ -444,10 +462,9 @@ describe("orchestrate — degradation", () => {
       denseConfig: config,
       edgeGraph: lanes.edgeGraph,
       workingSet: new WorkingSet(),
-      capabilitySlugs: ["skills/example"],
     });
     expect(new Set(result.finalInjection)).toEqual(
-      new Set(["topic-a", "topic-b", "topic-d", "skills/example"]),
+      new Set(["topic-a", "topic-b", "topic-d"]),
     );
   });
 });

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-integration.test.ts
@@ -8,19 +8,20 @@
  * with a mocked select provider, a stubbed dense lane, an in-memory selections
  * DB, and synthetic fixtures, driving them over a MULTI-TURN sequence:
  *
- *   orchestrate (needle ∪ dense ∪ edge ∪ capabilities → selectPool over a
- *     shared WorkingSet → carry-forward)
+ *   orchestrate (needle ∪ dense ∪ edge → selectPool over a shared WorkingSet
+ *     → carry-forward)
  *       → attribute selections to lane sources (the shadow plugin's coarse
  *         mapping, replicated here)
  *       → write to `memory_v3_selections`
  *       → summarizeSelections (the offline A/B readout)
  *
  * This is exactly the side-effect contract shadow mode observes each turn: the
- * candidate pool is the union of the lanes plus the synthetic capability slugs,
- * a SINGLE select runs per turn, the working set carries selections forward
- * across turns, and each selection is logged tagged with its lane source. None
- * of this changes live injection — shadow mode is observation-only; cutover is
- * the `memory-v3-live` flag flip.
+ * candidate pool is the union of the lanes — synthetic capability pages are
+ * indexed like any other page, so they enter through the needle lane rather than
+ * being always-added — a SINGLE select runs per turn, the working set carries
+ * selections forward across turns, and each selection is logged tagged with its
+ * lane source. None of this changes live injection — shadow mode is
+ * observation-only; cutover is the `memory-v3-live` flag flip.
  *
  * Slugs are generic placeholders (`page-a`, `topic-x`, `page-b`, …) — this is a
  * public repo.
@@ -141,10 +142,23 @@ const RAW: Record<Slug, string> = {
 };
 
 const SLUGS = Object.keys(PAGES);
+
+// A synthetic capability page (skill). Its content carries a distinctive term
+// ("durian") so the real needle ranks it — synthetic pages are indexed and
+// lane-ranked like any other page, not always-added to the pool.
 const CAPABILITY_SLUG = "skills/example";
+const CAPABILITY_CONTENT =
+  "# Skill: example\ndurian content for the example skill";
+const INDEX_SLUGS = [...SLUGS, CAPABILITY_SLUG];
+
+/** Page-body resolver mirroring `initLanes`: capability slug → its rendered
+ *  content, on-disk slug → its page body. */
+function bodyOf(slug: Slug): string {
+  return slug === CAPABILITY_SLUG ? CAPABILITY_CONTENT : PAGES[slug]!;
+}
 
 function makeEntries(): PageIndexEntry[] {
-  return SLUGS.map((slug, i) => ({
+  return INDEX_SLUGS.map((slug, i) => ({
     id: i + 1,
     slug,
     summary: `summary of ${slug}`,
@@ -159,9 +173,15 @@ async function buildLanes(): Promise<{
   needle: ReturnType<typeof buildSectionNeedle>;
   edgeGraph: EdgeGraph;
 }> {
-  const sectionIndex = await buildSectionIndex(SLUGS, async (s) => PAGES[s]!);
+  const sectionIndex = await buildSectionIndex(INDEX_SLUGS, async (s) =>
+    bodyOf(s),
+  );
   const needle = buildSectionNeedle(sectionIndex);
-  const edgeGraph = await buildEdgeGraph(makeEntries(), async (s) => RAW[s]!);
+  // The capability slug has no `links:` frontmatter, so the edge graph reads
+  // through `RAW` for the on-disk pages and its raw content otherwise.
+  const edgeGraph = await buildEdgeGraph(makeEntries(), async (s) =>
+    s === CAPABILITY_SLUG ? CAPABILITY_CONTENT : RAW[s]!,
+  );
   return { sectionIndex, needle, edgeGraph };
 }
 
@@ -305,7 +325,6 @@ async function runTurn(
     denseConfig: config,
     edgeGraph: deps.lanes.edgeGraph,
     workingSet: deps.workingSet,
-    capabilitySlugs: [CAPABILITY_SLUG],
   });
   writeSelections(turnNumber, attributeSelections(result));
   return result;
@@ -325,22 +344,33 @@ afterAll(() => {
 });
 
 // ---------------------------------------------------------------------------
-// Pool composition: the candidate pool is the union of the lanes plus the
-// always-added capability slugs, and exactly one select runs per turn.
+// Pool composition: the candidate pool is the union of the lanes, and exactly
+// one select runs per turn. Synthetic capability pages are indexed like any
+// other page, so they enter through the needle lane when the query matches
+// their content — not by always being appended.
 // ---------------------------------------------------------------------------
 
 describe("memory-v3 shadow integration — candidate pool", () => {
-  test("pool unions needle ∪ dense ∪ edge ∪ capabilities; one select per turn", async () => {
+  test("pool unions needle ∪ dense ∪ edge; one select per turn", async () => {
     const lanes = await buildLanes();
     // "apple" hits page-a (needle). Dense returns page-b. page-a links to
-    // topic-x (edge). The capability slug is always appended.
+    // topic-x (edge). "apple" does NOT match the capability page, so it is not
+    // pooled this turn — capability pages are lane-ranked, not always-added.
     denseHits = [{ article: "page-b", section: 0 }];
     await runTurn(1, "apple", [], [], { lanes, workingSet: new WorkingSet() });
 
     expect(selectCalls).toBe(1);
-    expect(new Set(lastPool)).toEqual(
-      new Set(["page-a", "page-b", "topic-x", CAPABILITY_SLUG]),
-    );
+    expect(new Set(lastPool)).toEqual(new Set(["page-a", "page-b", "topic-x"]));
+  });
+
+  test("a synthetic capability page enters the pool via the needle lane", async () => {
+    const lanes = await buildLanes();
+    // "durian" is the distinctive term in the capability page's content, so the
+    // real needle ranks it and folds it into the pool.
+    await runTurn(1, "durian", [], [], { lanes, workingSet: new WorkingSet() });
+
+    expect(selectCalls).toBe(1);
+    expect(lastPool).toContain(CAPABILITY_SLUG);
   });
 });
 
@@ -383,21 +413,18 @@ describe("memory-v3 shadow integration — carry-forward", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Lane-source attribution: the edge lane surfaces a page with no matched
-// section, which is logged as `edge`.
+// Lane-source attribution: a synthetic capability page now carries a section
+// (its rendered content), so when the needle ranks it the selection has a
+// matched section and is attributed `needle` — exactly like a concept page.
 // ---------------------------------------------------------------------------
 
 describe("memory-v3 shadow integration — lane-source attribution", () => {
-  test("a sectionless selection is logged with the edge source", async () => {
+  test("a needle-ranked capability selection is logged with the needle source", async () => {
     const lanes = await buildLanes();
-    // The capability slug is pooled with no matched section (capabilities have
-    // no section body), so a selection of it has no `sectionBySlug` entry and
-    // the shadow plugin's coarse mapping attributes it `edge` — the fallback
-    // for any candidate without a matched section. Selecting only it isolates
-    // the edge tag. (Edge-graph neighbours that DO have sections resolve a
-    // best-section and are attributed `needle`; precise per-lane attribution is
-    // a documented follow-up.)
-    const result = await runTurn(1, "apple", [CAPABILITY_SLUG], [], {
+    // "durian" matches the capability page's content section, so selecting it
+    // records a `sectionBySlug` entry and the coarse mapping attributes it
+    // `needle` (capabilities are indexed pages now, not sectionless add-ins).
+    const result = await runTurn(1, "durian", [CAPABILITY_SLUG], [], {
       lanes,
       workingSet: new WorkingSet(),
     });
@@ -405,7 +432,7 @@ describe("memory-v3 shadow integration — lane-source attribution", () => {
       CAPABILITY_SLUG,
     ]);
     expect(loggedSources(1)).toEqual([
-      { slug: CAPABILITY_SLUG, source: "edge" },
+      { slug: CAPABILITY_SLUG, source: "needle" },
     ]);
   });
 });
@@ -425,23 +452,23 @@ describe("memory-v3 shadow integration — selection-log readout", () => {
     // Turn 2: needle selects page-b (matched "banana"); page-a carries forward.
     denseHits = [{ article: "page-b", section: 0 }];
     await runTurn(2, "banana", ["page-b"], [], { lanes, workingSet });
-    // Turn 3: the sectionless capability slug is selected (→ edge); page-a and
-    // page-b carry forward.
+    // Turn 3: needle selects the capability page (matched "durian" in its
+    // content); page-a and page-b carry forward.
     denseHits = [];
-    await runTurn(3, "apple", [CAPABILITY_SLUG], [], { lanes, workingSet });
+    await runTurn(3, "durian", [CAPABILITY_SLUG], [], { lanes, workingSet });
 
     const summary = summarizeSelections(CONV);
-    // needle: page-a (t1) + page-b (t2) = 2.
-    expect(summary.bySource.needle).toBe(2);
-    // edge: the capability slug (t3) = 1.
-    expect(summary.bySource.edge).toBe(1);
+    // needle: page-a (t1) + page-b (t2) + capability page (t3) = 3.
+    expect(summary.bySource.needle).toBe(3);
+    // No selection was attributed to the edge lane in this run.
+    expect(summary.bySource.edge).toBe(0);
     // carry-forward: page-a (t2) + page-a & page-b (t3) = 3.
     expect(summary.bySource["carry-forward"]).toBe(3);
     // dense lane surfaced candidates but none were selected.
     expect(summary.bySource.dense).toBe(0);
     // Three turns logged selections.
     expect(summary.turns).toBe(3);
-    // Distinct slugs across the run: page-a, page-b, the capability slug.
+    // Distinct slugs across the run: page-a, page-b, the capability page.
     expect(summary.distinctSlugs).toBe(3);
   });
 

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-plugin.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-plugin.test.ts
@@ -10,7 +10,10 @@
  *   - live on → the injector returns the rendered `<memory>` block;
  *   - an empty selection under live → `null`;
  *   - lazy-init runs the lane builders only once across multiple turns, and
- *     `invalidateLanes` forces exactly one rebuild.
+ *     `invalidateLanes` forces exactly one rebuild;
+ *   - `initLanes` feeds synthetic capability pages (skills / CLI commands) into
+ *     the section index via `renderCapabilityContent`, so the needle lane ranks
+ *     them like any other page (they are no longer always-added to the pool).
  *
  * All heavy dependencies (config, flag resolver, conversation reads, v2 page
  * index + page store, the lane builders, orchestrate) are mocked BEFORE
@@ -53,6 +56,12 @@ const realPageStore = {
 const realConversationCrud = {
   ...(await import("../../../../memory/conversation-crud.js")),
 };
+const realSkillStore = {
+  ...(await import("../../../../memory/v2/skill-store.js")),
+};
+const realCliCommandStore = {
+  ...(await import("../../../../memory/v2/cli-command-store.js")),
+};
 
 let shadowMockActive = false;
 
@@ -61,6 +70,12 @@ let shadowMockActive = false;
 let liveEnabled = false;
 let shadowEnabled = false;
 let messages: Array<{ role: string; content: string }> = [];
+
+// A synthetic skill capability slug the page index carries. Its rendered
+// content holds a distinctive term ("kumquat") so the real needle, built over
+// the section index `initLanes` feeds, ranks it. Generic placeholder only.
+const CAPABILITY_SLUG = "skills/example";
+const CAPABILITY_CONTENT = "use the kumquat skill to do the thing";
 
 // The orchestrate result the spy returns. page-1 + page-2 matched a section
 // this turn (→ "needle"); page-3 is an edge-only candidate (no matched section
@@ -83,6 +98,12 @@ let sectionBuilds = 0;
 let needleBuilds = 0;
 let edgeBuilds = 0;
 let ensureCollectionCalls = 0;
+
+// The `pageBody` resolver `initLanes` passes to `buildSectionIndex` (its second
+// arg), captured by the stub below so a test can drive it directly: a capability
+// slug must resolve to its rendered capability content, an on-disk slug to its
+// page body.
+let capturedPageBody: ((slug: string) => Promise<string>) | null = null;
 
 // Shared in-memory DB so writes are observable from the test.
 let testSqlite: Database;
@@ -156,6 +177,17 @@ mock.module("../../../../memory/v2/page-index.js", () => ({
         leaves: [],
         modifiedAt: 0,
       },
+      // A synthetic capability row — same shape the v2 page index appends for
+      // skills/CLI commands. `initLanes` must route it through the capability
+      // resolver, not an on-disk read.
+      {
+        slug: CAPABILITY_SLUG,
+        id: 3,
+        summary: "",
+        edges: [],
+        leaves: [],
+        modifiedAt: 0,
+      },
     ],
     bySlug: new Map(),
   }),
@@ -184,6 +216,28 @@ mock.module("../../../../util/platform.js", () => ({
       : realPlatform.getWorkspaceDir(),
 }));
 
+// Capability stores: `renderCapabilityContent` (reached from `initLanes`' pageBody
+// and from the live injector) resolves synthetic slugs through these. Spread the
+// real module so the prefix predicates (`isSkillSlug`/`isCliCommandSlug`) stay
+// intact; override only the content lookup so the capability slug resolves.
+mock.module("../../../../memory/v2/skill-store.js", () => ({
+  ...realSkillStore,
+  getSkillCapability: (idOrSlug: string) =>
+    shadowMockActive
+      ? idOrSlug === CAPABILITY_SLUG
+        ? { id: "example", content: CAPABILITY_CONTENT }
+        : null
+      : realSkillStore.getSkillCapability(idOrSlug),
+}));
+
+mock.module("../../../../memory/v2/cli-command-store.js", () => ({
+  ...realCliCommandStore,
+  getCliCommandCapability: (idOrSlug: string) =>
+    shadowMockActive
+      ? null
+      : realCliCommandStore.getCliCommandCapability(idOrSlug),
+}));
+
 mock.module("../sections.js", () => ({
   ...realSections,
   buildSectionIndex: async (
@@ -191,6 +245,9 @@ mock.module("../sections.js", () => ({
   ) => {
     if (!shadowMockActive) return realSections.buildSectionIndex(...args);
     sectionBuilds++;
+    // Capture the `pageBody` resolver so a test can exercise the capability
+    // branch directly. Returning the FAKE index keeps the other tests cheap.
+    capturedPageBody = args[1];
     return FAKE_SECTION_INDEX;
   },
 }));
@@ -269,6 +326,7 @@ beforeEach(() => {
   needleBuilds = 0;
   edgeBuilds = 0;
   ensureCollectionCalls = 0;
+  capturedPageBody = null;
   testDb = makeDb();
   resetShadowLanesForTests();
 });
@@ -334,13 +392,11 @@ describe("memory-v3 shadow plugin", () => {
       needle?: unknown;
       edgeGraph?: unknown;
       workingSet?: unknown;
-      capabilitySlugs?: unknown;
     };
     expect(deps.sectionIndex).toBeDefined();
     expect(deps.needle).toBeDefined();
     expect(deps.edgeGraph).toBeDefined();
     expect(deps.workingSet).toBeDefined();
-    expect(Array.isArray(deps.capabilitySlugs)).toBe(true);
   });
 
   test("both flags OFF → produce returns null, no orchestrate, no writes", async () => {
@@ -464,5 +520,45 @@ describe("memory-v3 shadow plugin", () => {
     await runShadowObservation("conv-1", 0);
     expect(orchestrateSpy).not.toHaveBeenCalled();
     expect(readRows()).toHaveLength(0);
+  });
+
+  describe("initLanes feeds synthetic capability pages into the section index", () => {
+    test("the pageBody resolver returns capability content for a synthetic slug and disk body otherwise", async () => {
+      shadowEnabled = true;
+      await runShadowObservation("conv-1", 0);
+
+      // `initLanes` ran the real pageBody-building closure and handed it to
+      // `buildSectionIndex`; the stub captured it.
+      expect(capturedPageBody).not.toBeNull();
+      const pageBody = capturedPageBody!;
+
+      // A capability slug resolves to its rendered capability content (NOT an
+      // on-disk read, which would miss), so the needle can rank it.
+      const capBody = await pageBody(CAPABILITY_SLUG);
+      expect(capBody).toContain("kumquat");
+      // On-disk slugs still resolve to their page body.
+      expect(await pageBody("page-1")).toBe("body for page-1");
+    });
+
+    test("a synthetic slug's capability content yields a section the needle ranks", async () => {
+      shadowEnabled = true;
+      await runShadowObservation("conv-1", 0);
+      const pageBody = capturedPageBody!;
+
+      // Feed the captured resolver through the REAL section builder + needle:
+      // the capability slug yields ≥1 section and is ranked on a term from its
+      // capability content — the path that makes synthetic pages lane-rankable.
+      const index = await realSections.buildSectionIndex(
+        [CAPABILITY_SLUG],
+        pageBody,
+      );
+      expect(index.byArticle.get(CAPABILITY_SLUG)?.length ?? 0).toBeGreaterThan(
+        0,
+      );
+
+      const needle = realSectionNeedle.buildSectionNeedle(index);
+      const hits = needle.query("kumquat", 5);
+      expect(hits.map((h) => h.article)).toContain(CAPABILITY_SLUG);
+    });
   });
 });

--- a/assistant/src/plugins/defaults/memory-v3-shadow/orchestrate.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/orchestrate.ts
@@ -13,9 +13,9 @@
  *      descriptor is the matched section's text for needle/dense hits (resolved
  *      via the section index); for edge-only pages it is the curated `links`
  *      description when the traversed edge carried one, else the page's best
- *      section against the query. The synthetic capability slugs (skills / CLI
- *      commands) are always appended (lane-ranking of synthetic pages is a
- *      documented fast-follow).
+ *      section against the query. Synthetic capability pages (skills / CLI
+ *      commands) carry sections in the section index too, so they enter the pool
+ *      through the lanes like any other page rather than being always-added.
  *   3. A SINGLE forced-tool select (`selectPool`) over the whole pool. The
  *      result is this turn's selections.
  *   4. Age the carry-forward working set to this turn (evict stale non-pinned
@@ -59,9 +59,6 @@ export interface OrchestrateDeps {
   denseConfig: AssistantConfig;
   edgeGraph: EdgeGraph;
   workingSet: WorkingSet;
-  /** Synthetic capability slugs (skills / CLI commands) always added to the
-   *  pool. Lane-ranking of synthetic pages is a documented fast-follow. */
-  capabilitySlugs: Slug[];
   /** Number of BM25 needle articles. Defaults to {@link DEFAULT_NEEDLE_K}. */
   needleK?: number;
   /** Number of dense-lane articles. Defaults to {@link DEFAULT_DENSE_K}. */
@@ -169,13 +166,6 @@ export async function orchestrate(
     const best = deps.needle.bestSection(neighbor.article, turn.currentMessage);
     const section = best >= 0 ? sections[best] : undefined;
     addCandidate(neighbor.article, section, neighbor.description);
-  }
-
-  // Step 2d: always-add the synthetic capability slugs (skills / CLI commands)
-  // with a blank descriptor — they have no matched section. Proper lane-ranking
-  // of synthetic pages is a documented fast-follow.
-  for (const slug of deps.capabilitySlugs) {
-    addCandidate(slug, undefined);
   }
 
   // Step 3: a SINGLE forced-tool select over the unified pool.

--- a/assistant/src/plugins/defaults/memory-v3-shadow/shadow-plugin.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/shadow-plugin.ts
@@ -45,7 +45,7 @@ import {
   getWorkspacePromptPath,
 } from "../../../util/platform.js";
 import { stripCommentLines } from "../../../util/strip-comment-lines.js";
-import { isCapabilitySlug } from "./capabilities.js";
+import { isCapabilitySlug, renderCapabilityContent } from "./capabilities.js";
 import type { EdgeGraph } from "./edge.js";
 import { buildEdgeGraph } from "./edge.js";
 import type { OrchestrateResult } from "./orchestrate.js";
@@ -84,9 +84,6 @@ export interface ShadowLanes {
   denseConfig: AssistantConfig;
   edgeGraph: EdgeGraph;
   workingSet: WorkingSet;
-  /** Synthetic capability slugs (skills / CLI commands), always added to the
-   *  candidate pool in {@link orchestrate}. */
-  capabilitySlugs: Slug[];
 }
 
 /**
@@ -137,8 +134,16 @@ async function initLanes(config: AssistantConfig): Promise<ShadowLanes> {
     pageCache.set(slug, loaded);
     return loaded;
   }
-  const pageBody = async (slug: Slug): Promise<string> =>
-    (await loadPage(slug))?.body ?? "";
+  // Synthetic capability slugs (skills / CLI commands) have no on-disk page, so
+  // they contribute their rendered capability content to the section index —
+  // exactly the content `page-content.ts` injects for them. This puts them in
+  // the section index, so the needle lane (and, once a backfill embeds them, the
+  // dense lane) ranks them by relevance like any other page, instead of being
+  // blindly added to the select pool every turn.
+  const pageBody = async (slug: Slug): Promise<string> => {
+    if (isCapabilitySlug(slug)) return renderCapabilityContent(slug) ?? "";
+    return (await loadPage(slug))?.body ?? "";
+  };
   const pageRaw = async (slug: Slug): Promise<string> => {
     const loaded = await loadPage(slug);
     if (!loaded) throw new Error(`page not found: ${slug}`);
@@ -152,11 +157,6 @@ async function initLanes(config: AssistantConfig): Promise<ShadowLanes> {
   });
   await ensureSectionCollection(config);
 
-  // Synthetic capability slugs (skills + CLI commands) the page index already
-  // carries. Always added to the candidate pool in `orchestrate`; proper
-  // lane-ranking of synthetic pages is a documented fast-follow.
-  const capabilitySlugs = slugs.filter(isCapabilitySlug);
-
   const workingSet = new WorkingSet(
     config.memory.v3.workingSet.maxPages,
     config.memory.v3.workingSet.evictWindow,
@@ -168,7 +168,6 @@ async function initLanes(config: AssistantConfig): Promise<ShadowLanes> {
     denseConfig: config,
     edgeGraph,
     workingSet,
-    capabilitySlugs,
   };
 }
 
@@ -338,7 +337,6 @@ export async function observeTurn(
       denseConfig: lanes.denseConfig,
       edgeGraph: lanes.edgeGraph,
       workingSet: lanes.workingSet,
-      capabilitySlugs: lanes.capabilitySlugs,
       needleK: v3.needleK,
       denseK: v3.denseK,
       edgeSeeds: v3.edge.seedCount,


### PR DESCRIPTION
## Summary
- Synthetic capability pages (skills + CLI subcommands) now enter the section index via initLanes' pageBody (renderCapabilityContent) so the needle lane ranks them by relevance, instead of being blindly always-added to the select pool every turn. Drops the always-add block + capabilitySlugs plumbing. Dense ranking of synthetics follows once the backfill embeds them; needle covers them immediately (no coverage regression).

Follow-up to plan: memory-v3-section-lanes.md