### PR TITLE
feat(memory-v3): precise per-lane source attribution in selection log

### DIFF
--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/orchestrate.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/orchestrate.test.ts
@@ -311,6 +311,50 @@ describe("orchestrate — candidate pool composition", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Lane provenance: each pooled slug records the candgen lane that FIRST
+// surfaced it (needle → dense → edge precedence), exposed via
+// `result.laneBySlug` so the selection telemetry can attribute true sources.
+// ---------------------------------------------------------------------------
+
+describe("orchestrate — lane provenance (laneBySlug)", () => {
+  test("laneBySlug tags each pooled slug with its surfacing lane", async () => {
+    const lanes = await buildLanes();
+    // "apple" hits topic-a (needle). Dense returns topic-b. topic-a links to
+    // topic-d (edge). So each lane contributes exactly one distinct slug.
+    denseHits = [{ article: "topic-b", section: 0 }];
+    providerStub = selectProvider([]); // selection irrelevant to pool provenance
+    const result = await orchestrate(makeTurn(1, "apple"), {
+      sectionIndex: lanes.sectionIndex,
+      needle: lanes.needle,
+      denseConfig: config,
+      edgeGraph: lanes.edgeGraph,
+      workingSet: new WorkingSet(),
+    });
+
+    expect(result.laneBySlug.get("topic-a")).toBe("needle");
+    expect(result.laneBySlug.get("topic-b")).toBe("dense");
+    expect(result.laneBySlug.get("topic-d")).toBe("edge");
+  });
+
+  test("a slug surfaced by needle AND dense keeps the needle lane (first wins)", async () => {
+    const lanes = await buildLanes();
+    // topic-a is surfaced by the needle on "apple"; dense ALSO returns topic-a.
+    // Needle runs first (step 2a before 2b), so the recorded lane stays needle.
+    denseHits = [{ article: "topic-a", section: 0 }];
+    providerStub = selectProvider([]);
+    const result = await orchestrate(makeTurn(1, "apple"), {
+      sectionIndex: lanes.sectionIndex,
+      needle: lanes.needle,
+      denseConfig: config,
+      edgeGraph: lanes.edgeGraph,
+      workingSet: new WorkingSet(),
+    });
+
+    expect(result.laneBySlug.get("topic-a")).toBe("needle");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Carry-forward: same working-set semantics as the prior tree pipeline.
 // ---------------------------------------------------------------------------
 

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-plugin.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-plugin.test.ts
@@ -29,7 +29,7 @@ import { drizzle } from "drizzle-orm/bun-sqlite";
 
 import { migrateAddMemoryV3Selections } from "../../../../memory/migrations/268-add-memory-v3-selections.js";
 import * as schema from "../../../../memory/schema.js";
-import type { SectionIndex, SelectionSource } from "../types.js";
+import type { CandidateLane, SectionIndex, SelectionSource } from "../types.js";
 
 // `mock.module` is process-global and, in Bun, neither `mock.restore()` nor a
 // re-mock in `afterAll` reverts it for files that load LATER in the same
@@ -77,9 +77,12 @@ let messages: Array<{ role: string; content: string }> = [];
 const CAPABILITY_SLUG = "skills/example";
 const CAPABILITY_CONTENT = "use the kumquat skill to do the thing";
 
-// The orchestrate result the spy returns. page-1 + page-2 matched a section
-// this turn (→ "needle"); page-3 is an edge-only candidate (no matched section
-// → "edge"); carried is a carry-forward slug not re-selected this turn.
+// The orchestrate result the spy returns. `laneBySlug` records the lane that
+// surfaced each pooled slug: page-1 → "needle", page-2 → "dense", page-3 →
+// "edge"; `attributeSelections` reads it directly. `carried` is a carry-forward
+// slug not re-selected this turn. `sectionBySlug` carries the matched section
+// for the slugs that had one (page-1/page-2) — consumed by the live injector's
+// progressive disclosure, independent of source attribution.
 const orchestrateSpy = mock(async () => ({
   currentSelections: [
     { slug: "page-1", pinned: true },
@@ -91,6 +94,11 @@ const orchestrateSpy = mock(async () => ({
   sectionBySlug: new Map([
     ["page-1", { article: "page-1", title: "", text: "x", ordinal: 0 }],
     ["page-2", { article: "page-2", title: "", text: "y", ordinal: 0 }],
+  ]),
+  laneBySlug: new Map<string, CandidateLane>([
+    ["page-1", "needle"],
+    ["page-2", "dense"],
+    ["page-3", "edge"],
   ]),
 }));
 
@@ -350,19 +358,22 @@ describe("memory-v3 shadow plugin", () => {
     expect(readRows()).toHaveLength(0);
   });
 
-  test("shadow flag ON → orchestrate runs and rows are written with lane sources", async () => {
+  test("shadow flag ON → orchestrate runs and rows are written with per-lane sources", async () => {
     shadowEnabled = true;
     await runShadowObservation("conv-1", 2);
 
     expect(orchestrateSpy).toHaveBeenCalledTimes(1);
     const rows = readRows();
+    // Each selection is attributed to the lane that surfaced it
+    // (`result.laneBySlug`), not re-derived from section presence — so the
+    // dense-only page-2 logs "dense", not "needle".
     expect(rows).toEqual([
       { slug: "carried", source: "carry-forward", pinned: 0 },
-      // page-1 matched a section this turn → "needle", pinned.
+      // page-1 was surfaced by the needle lane → "needle", pinned.
       { slug: "page-1", source: "needle", pinned: 1 },
-      // page-2 matched a section this turn → "needle".
-      { slug: "page-2", source: "needle", pinned: 0 },
-      // page-3 had no matched section (edge-only) → "edge".
+      // page-2 was surfaced by the dense lane → "dense".
+      { slug: "page-2", source: "dense", pinned: 0 },
+      // page-3 was surfaced by the edge lane → "edge".
       { slug: "page-3", source: "edge", pinned: 0 },
     ]);
   });
@@ -443,6 +454,7 @@ describe("memory-v3 shadow plugin", () => {
       workingSetUnion: new Set<string>(),
       finalInjection: [],
       sectionBySlug: new Map(),
+      laneBySlug: new Map(),
     }));
     const block = await produce("conv-1", 0);
     expect(block).toBeNull();

--- a/assistant/src/plugins/defaults/memory-v3-shadow/orchestrate.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/orchestrate.ts
@@ -38,6 +38,7 @@ import type { PoolCandidate } from "./pool-select.js";
 import { selectPool } from "./pool-select.js";
 import type { SectionNeedle } from "./section-needle.js";
 import type {
+  CandidateLane,
   MemoryRoutingTurn,
   Section,
   SectionIndex,
@@ -86,6 +87,11 @@ export interface OrchestrateResult {
    *  Populated from the lane hits and consumed by the injector to render each
    *  selected slug's matched section (progressive disclosure). */
   sectionBySlug: Map<Slug, Section>;
+  /** The candgen lane that FIRST surfaced each pooled slug, keyed by slug.
+   *  Insertion order is needle → dense → edge, so a page surfaced by more than
+   *  one lane records the highest-precedence one. Consumed by the selection
+   *  telemetry to attribute each selection to its true lane. */
+  laneBySlug: Map<Slug, CandidateLane>;
 }
 
 /** Stable-order de-duplication preserving first occurrence. */
@@ -110,23 +116,29 @@ export async function orchestrate(
   ]);
 
   // The pool accumulates one entry per distinct article. `sectionBySlug` records
-  // the matched `Section` (when one is known) for downstream injection.
+  // the matched `Section` (when one is known) for downstream injection;
+  // `laneBySlug` records the lane that first surfaced each slug for telemetry.
   const poolBySlug = new Map<Slug, PoolCandidate>();
   const sectionBySlug = new Map<Slug, Section>();
+  const laneBySlug = new Map<Slug, CandidateLane>();
 
   // Add one pool candidate, recording its matched `Section` (when known) for
-  // downstream injection. `descriptor` overrides the section text when supplied
-  // (the edge lane prefers a curated `links` description). The first lane to
-  // surface a slug wins both the pool entry and the recorded section.
+  // downstream injection and the `lane` that surfaced it for telemetry.
+  // `descriptor` overrides the section text when supplied (the edge lane prefers
+  // a curated `links` description). The first lane to surface a slug wins the
+  // pool entry, the recorded section, AND the recorded lane — so the
+  // needle → dense → edge call order encodes lane precedence.
   const addCandidate = (
     slug: Slug,
     section: Section | undefined,
-    descriptor?: string,
+    descriptor: string | undefined,
+    lane: CandidateLane,
   ): void => {
     if (section && !sectionBySlug.has(slug)) {
       sectionBySlug.set(slug, section);
     }
     if (poolBySlug.has(slug)) return;
+    laneBySlug.set(slug, lane);
     poolBySlug.set(slug, {
       slug,
       descriptor: descriptor ?? section?.text ?? "",
@@ -136,7 +148,7 @@ export async function orchestrate(
   // Step 2a: needle hits — descriptor is the matched section's text. `section`
   // is an index into `sections`.
   for (const hit of needled) {
-    addCandidate(hit.article, sections[hit.section]);
+    addCandidate(hit.article, sections[hit.section], undefined, "needle");
   }
 
   // Step 2b: dense hits — `section` is the matched ORDINAL; resolve it to the
@@ -146,6 +158,8 @@ export async function orchestrate(
     addCandidate(
       hit.article,
       sectionByOrdinal(deps.sectionIndex, hit.article, hit.section),
+      undefined,
+      "dense",
     );
   }
 
@@ -165,7 +179,7 @@ export async function orchestrate(
   for (const neighbor of surfaced) {
     const best = deps.needle.bestSection(neighbor.article, turn.currentMessage);
     const section = best >= 0 ? sections[best] : undefined;
-    addCandidate(neighbor.article, section, neighbor.description);
+    addCandidate(neighbor.article, section, neighbor.description, "edge");
   }
 
   // Step 3: a SINGLE forced-tool select over the unified pool.
@@ -201,7 +215,13 @@ export async function orchestrate(
     deps.workingSet.recordSelection(sel.slug, turn.turnNumber, sel.pinned);
   }
 
-  return { currentSelections, workingSetUnion, finalInjection, sectionBySlug };
+  return {
+    currentSelections,
+    workingSetUnion,
+    finalInjection,
+    sectionBySlug,
+    laneBySlug,
+  };
 }
 
 /**

--- a/assistant/src/plugins/defaults/memory-v3-shadow/shadow-plugin.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/shadow-plugin.ts
@@ -260,19 +260,15 @@ interface SelectionRow {
 }
 
 /**
- * Map an orchestrate result onto telemetry rows with best-effort lane
+ * Map an orchestrate result onto telemetry rows with precise per-lane source
  * attribution.
  *
- * - A current selection whose page matched a section this turn → `"needle"` or
- *   `"dense"`; an edge-only candidate that survived selection → `"edge"`. The
- *   pool is a union of lanes that only ever adds candidates, so a page can be
- *   surfaced by more than one lane; this coarse mapping records the lane that
- *   provided the matched section (needle/dense) and falls back to `"edge"` for
- *   candidates with no matched section.
+ * - A current selection is tagged with the candgen lane that FIRST surfaced its
+ *   page this turn — `result.laneBySlug` (`"needle"` / `"dense"` / `"edge"`),
+ *   recorded at pool-build time. (`"needle"` is the fallback if a selected slug
+ *   is somehow absent from the lane map, which should not happen since every
+ *   pooled candidate is recorded there.)
  * - A slug in `finalInjection` but NOT re-selected this turn → `"carry-forward"`.
- *
- * Precise per-lane attribution (which lane FIRST surfaced a page) is a
- * documented follow-up; this is acceptable for v0 shadow telemetry.
  */
 function attributeSelections(result: OrchestrateResult): SelectionRow[] {
   const rows: SelectionRow[] = [];
@@ -281,7 +277,7 @@ function attributeSelections(result: OrchestrateResult): SelectionRow[] {
     seen.add(sel.slug);
     rows.push({
       slug: sel.slug,
-      source: result.sectionBySlug.has(sel.slug) ? "needle" : "edge",
+      source: result.laneBySlug.get(sel.slug) ?? "needle",
       pinned: sel.pinned ? 1 : 0,
     });
   }

--- a/assistant/src/plugins/defaults/memory-v3-shadow/types.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/types.ts
@@ -104,3 +104,13 @@ export const SELECTION_SOURCES = [
 ] as const;
 
 export type SelectionSource = (typeof SELECTION_SOURCES)[number];
+
+/**
+ * The candidate-generation lanes — the strict subset of {@link SelectionSource}
+ * a pooled candidate can be tagged with at pool-build time. (`carry-forward` is
+ * the one source assigned later, by the orchestrator's working-set union, not by
+ * a candgen lane.) Defined as `Exclude<SelectionSource, "carry-forward">` so it
+ * can never drift from {@link SELECTION_SOURCES}: adding a lane there widens this
+ * automatically.
+ */
+export type CandidateLane = Exclude<SelectionSource, "carry-forward">;


### PR DESCRIPTION
## Summary
- Tag each pool candidate with the lane that first surfaced it (needle/dense/edge) at pool-build time and thread it via OrchestrateResult.laneBySlug, so attributeSelections logs the true lane instead of re-deriving needle/edge from section presence (which conflated dense with needle).

Follow-up to plan: memory-v3-section-lanes.md