### PR TITLE
feat(memory-v3): add section-embedding backfill command

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -15854,6 +15854,31 @@ paths:
               type: object
               properties: {}
               additionalProperties: false
+  /v1/memory/v3/backfill-sections:
+    post:
+      operationId: memory_v3_backfillsections_post
+      summary: "One-time: embed every page's sections (incl synthetic skill/CLI rows) into the dense store"
+      tags:
+        - memory
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  articles:
+                    type: number
+                  sections:
+                    type: number
+                  failures:
+                    type: number
+                required:
+                  - articles
+                  - sections
+                  - failures
+                additionalProperties: false
   /v1/memory/v3/health:
     post:
       operationId: memory_v3_health_post

--- a/assistant/src/cli/commands/memory-v3.ts
+++ b/assistant/src/cli/commands/memory-v3.ts
@@ -20,6 +20,10 @@
  *     leaf exists, previews the resulting always-on page count, and writes only
  *     on `--yes`.
  *   - `rebuild-index` — invalidate the v3 lanes so the next turn rebuilds.
+ *   - `backfill-sections` — one-time: embed every page's sections (including
+ *     synthetic skill/CLI rows) into the dense store, then advance the maintain
+ *     checkpoint. For the transition before A/B/cutover, since the collection
+ *     starts empty and the incremental maintain pass only re-embeds deltas.
  *
  * Deferred to follow-ups: thin `add-leaf` / `rename-leaf` / `delete-leaf`
  * wrappers (edit the leaf file[s] then reconcile).
@@ -29,6 +33,7 @@ import type { Command } from "commander";
 
 import { cliIpcCall } from "../../ipc/cli-client.js";
 import type {
+  MemoryV3BackfillSectionsResult,
   MemoryV3HealthResult,
   MemoryV3RebuildIndexResult,
   MemoryV3ReconcileResult,
@@ -70,7 +75,8 @@ Examples:
   $ assistant memory v3 set-core --add domain-a/topic-x
   $ assistant memory v3 set-core --remove domain-a/topic-y --yes
   $ assistant memory v3 reconcile
-  $ assistant memory v3 rebuild-index`,
+  $ assistant memory v3 rebuild-index
+  $ assistant memory v3 backfill-sections`,
       );
 
       // ── health ────────────────────────────────────────────────────────────
@@ -275,6 +281,54 @@ Examples:
             return;
           }
           log.info("v3 lanes invalidated; next turn will rebuild.");
+        });
+
+      // ── backfill-sections ─────────────────────────────────────────────────
+
+      v3.command("backfill-sections")
+        .description(
+          "One-time: embed every page's sections into the dense store (incl skills/CLI)",
+        )
+        .option("--json", "Emit raw JSON instead of a formatted summary")
+        .addHelpText(
+          "after",
+          `
+Embeds EVERY concept page's sections — including synthetic skill and CLI
+capability rows — into the section dense store in one pass, then advances
+the maintain checkpoint so the next incremental pass only re-embeds future
+edits. Use this once on an existing install before the section-lane A/B and
+cutover: the dense collection starts empty, and the periodic maintenance
+pass only re-embeds pages edited since its last run (and never the synthetic
+rows), so most of the corpus would otherwise never be embedded.
+
+Idempotent and safe to re-run. Runs inside the assistant so it uses the live
+configuration and advances the checkpoint the assistant reads.
+
+Examples:
+  $ assistant memory v3 backfill-sections
+  $ assistant memory v3 backfill-sections --json | jq '.sections'`,
+        )
+        .action(async (opts: { json?: boolean }) => {
+          const result = await cliIpcCall<MemoryV3BackfillSectionsResult>(
+            "memory_v3_backfill_sections",
+            { body: {} },
+          );
+          if (!result.ok) {
+            log.error(result.error ?? "Failed to backfill section embeddings");
+            process.exitCode = 1;
+            return;
+          }
+          const payload = result.result!;
+          if (opts.json === true) {
+            log.info(JSON.stringify(payload, null, 2));
+            return;
+          }
+          log.info(
+            `Embedded ${payload.sections} sections across ${payload.articles} pages` +
+              (payload.failures > 0
+                ? ` (${payload.failures} page(s) failed — see assistant logs).`
+                : "."),
+          );
         });
     },
   });

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/maintain-job.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/maintain-job.test.ts
@@ -3,12 +3,16 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { setOverridesForTesting } from "../../../../__tests__/feature-flag-test-helpers.js";
 import type { AssistantConfig } from "../../../../config/types.js";
 import type { MemoryJob } from "../../../../memory/jobs-store.js";
+import { renderCapabilityContent } from "../capabilities.js";
 import {
+  backfillAllSections,
+  type BackfillJobDeps,
   type ChangedPageCandidate,
   computeChangedPages,
   maintainJob,
   type MaintainJobDeps,
 } from "../maintain-job.js";
+import { buildSectionIndex } from "../sections.js";
 import type { Section, SectionIndex, Slug } from "../types.js";
 
 const FLAG_SHADOW = "memory-v3-shadow";
@@ -241,5 +245,125 @@ describe("computeChangedPages", () => {
       null,
     );
     expect(changed).toEqual(["real"]);
+  });
+});
+
+describe("backfillAllSections", () => {
+  afterEach(() => {
+    setOverridesForTesting({});
+  });
+
+  function deps(overrides: Partial<BackfillJobDeps> = {}): {
+    deps: BackfillJobDeps;
+    calls: {
+      ensured: number;
+      built: Slug[][];
+      deleted: string[];
+      upserted: Section[][];
+      committed: number[];
+    };
+  } {
+    const calls = {
+      ensured: 0,
+      built: [] as Slug[][],
+      deleted: [] as string[],
+      upserted: [] as Section[][],
+      committed: [] as number[],
+    };
+    const base: BackfillJobDeps = {
+      config: CONFIG,
+      selectAllPages: async () => [],
+      ensureSectionCollection: async () => {
+        calls.ensured += 1;
+      },
+      // Real builder + chunker so the synthetic capability content is genuinely
+      // turned into section points (not a hand-rolled stub).
+      buildSectionIndex: async (slugs, pageBody) => {
+        calls.built.push(slugs);
+        return buildSectionIndex(slugs, pageBody);
+      },
+      readPageBody: async (slug) => `body for ${slug}`,
+      deleteSectionsForArticle: async (_config, article) => {
+        calls.deleted.push(article);
+      },
+      upsertSections: async (_config, sections) => {
+        calls.upserted.push(sections);
+      },
+      commitEmbedHighWater: (ms) => {
+        calls.committed.push(ms);
+      },
+      nowMs: () => 4242,
+    };
+    return { deps: { ...base, ...overrides }, calls };
+  }
+
+  test("embeds EVERY page incl a synthetic capability slug, with its capability content", async () => {
+    // A capability-aware reader, exactly as the production default deps wire it:
+    // the real renderer resolves the synthetic skill row's content (injected
+    // resolvers keep it deterministic, mirroring `capabilities.test.ts`).
+    const resolvers = {
+      skill: (slug: Slug) =>
+        slug === "skills/example"
+          ? { id: "example", content: "example capability body" }
+          : null,
+      cli: () => null,
+    };
+    const readPageBody = async (slug: Slug): Promise<string> =>
+      renderCapabilityContent(slug, resolvers) ?? `body for ${slug}`;
+
+    const { deps: d, calls } = deps({
+      selectAllPages: async () => ["page-a", "skills/example"],
+      readPageBody,
+    });
+    const outcome = await backfillAllSections(CONFIG, d);
+
+    // Both the real page AND the synthetic capability row were embedded.
+    expect(outcome.articles).toBe(2);
+    expect(outcome.failures).toBe(0);
+    expect(calls.ensured).toBe(1);
+    expect(calls.built).toEqual([["page-a"], ["skills/example"]]);
+    expect(calls.deleted).toEqual(["page-a", "skills/example"]);
+
+    // The synthetic slug's upsert carries its rendered capability content, not a
+    // blank/on-disk read.
+    const syntheticSections = calls.upserted
+      .flat()
+      .filter((s) => s.article === "skills/example");
+    expect(syntheticSections.length).toBeGreaterThan(0);
+    expect(syntheticSections.map((s) => s.text).join("\n")).toContain(
+      "example capability body",
+    );
+    expect(outcome.sections).toBe(calls.upserted.flat().length);
+  });
+
+  test("advances the high-water checkpoint to the injected now", async () => {
+    const { deps: d, calls } = deps({
+      selectAllPages: async () => ["page-a"],
+      nowMs: () => 99999,
+    });
+    await backfillAllSections(CONFIG, d);
+    expect(calls.committed).toEqual([99999]);
+  });
+
+  test("contains a single failing page; others still embed and checkpoint advances", async () => {
+    const { deps: d, calls } = deps({
+      selectAllPages: async () => ["page-ok", "page-bad", "page-ok-2"],
+      upsertSections: async (_config, sections) => {
+        if (sections.some((s) => s.article === "page-bad")) {
+          throw new Error("embed boom");
+        }
+        calls.upserted.push(sections);
+      },
+    });
+    const outcome = await backfillAllSections(CONFIG, d);
+
+    expect(outcome.articles).toBe(2);
+    expect(outcome.failures).toBe(1);
+    expect(calls.upserted.flat().map((s) => s.article)).toEqual([
+      "page-ok",
+      "page-ok-2",
+    ]);
+    // A contained per-article failure does not block the checkpoint advance.
+    expect(calls.committed).toEqual([4242]);
   });
 });

--- a/assistant/src/plugins/defaults/memory-v3-shadow/maintain-job.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/maintain-job.ts
@@ -39,8 +39,10 @@ import { getPageIndex } from "../../../memory/v2/page-index.js";
 import { readPage } from "../../../memory/v2/page-store.js";
 import { getLogger } from "../../../util/logger.js";
 import { getWorkspaceDir } from "../../../util/platform.js";
+import { isCapabilitySlug, renderCapabilityContent } from "./capabilities.js";
 import {
   deleteSectionsForArticle as realDeleteSectionsForArticle,
+  ensureSectionCollection as realEnsureSectionCollection,
   upsertSections as realUpsertSections,
 } from "./section-dense-store.js";
 import { buildSectionIndex as realBuildSectionIndex } from "./sections.js";
@@ -95,6 +97,44 @@ export interface MaintainJobDeps {
   invalidateLanes: () => void;
   /** Active assistant config (for the dense-store/embedding calls). */
   config: AssistantConfig;
+}
+
+/**
+ * Injectable collaborators for the one-time {@link backfillAllSections} pass.
+ * Distinct from {@link MaintainJobDeps}: the backfill embeds EVERY page
+ * (including synthetic capability rows the incremental selector excludes), so it
+ * uses an all-pages selector, a capability-aware body reader, and an explicit
+ * collection-ensure step rather than the change-delta machinery.
+ */
+export interface BackfillJobDeps {
+  /** All page-index slugs, including synthetic skill/CLI capability rows. */
+  selectAllPages: () => Promise<Slug[]>;
+  /** Create the section collection if absent before the first upsert. */
+  ensureSectionCollection: typeof realEnsureSectionCollection;
+  /** Re-chunk pages into the flat section index (pure; reads page bodies). */
+  buildSectionIndex: typeof realBuildSectionIndex;
+  /** Read a page's body; capability slugs resolve their rendered content. */
+  readPageBody: (slug: Slug) => Promise<string>;
+  /** Clear an article's stale section points before re-upserting. */
+  deleteSectionsForArticle: typeof realDeleteSectionsForArticle;
+  /** Embed + upsert an article's current sections into the dense store. */
+  upsertSections: typeof realUpsertSections;
+  /** Persist the high-water mark after the backfill completes. */
+  commitEmbedHighWater: (highWaterMs: number) => void;
+  /** Epoch-ms stamped as the new high-water mark; injectable for tests. */
+  nowMs: () => number;
+  /** Active assistant config (for the dense-store/embedding calls). */
+  config: AssistantConfig;
+}
+
+/** Counts surfaced by {@link backfillAllSections}. */
+export interface BackfillOutcome {
+  /** Pages whose sections were (re-)embedded this pass. */
+  articles: number;
+  /** Total section points upserted across all articles. */
+  sections: number;
+  /** Pages whose embed threw (and was contained). */
+  failures: number;
 }
 
 /** Per-stage outcome surfaced in the structured log line. */
@@ -166,6 +206,29 @@ async function readPageBodyFromWorkspace(
   }
 }
 
+/**
+ * Capability-aware page-body reader for the full backfill: synthetic skill/CLI
+ * slugs have no on-disk page, so they contribute their rendered capability
+ * content (exactly what `page-content.ts` injects for them) while real pages
+ * read from disk. Mirrors `shadow-plugin.ts` `initLanes`' `pageBody`; the two
+ * could later share a small helper.
+ */
+async function backfillPageBodyFromWorkspace(
+  workspaceDir: string,
+  slug: Slug,
+): Promise<string> {
+  if (isCapabilitySlug(slug)) return renderCapabilityContent(slug) ?? "";
+  return readPageBodyFromWorkspace(workspaceDir, slug);
+}
+
+/** All page-index slugs, including synthetic skill/CLI capability rows. */
+async function selectAllPagesFromWorkspace(
+  workspaceDir: string,
+): Promise<Slug[]> {
+  const index = await getPageIndex(workspaceDir);
+  return index.entries.map((entry) => entry.slug);
+}
+
 function defaultDeps(config: AssistantConfig): MaintainJobDeps {
   const workspaceDir = getWorkspaceDir();
   return {
@@ -176,6 +239,21 @@ function defaultDeps(config: AssistantConfig): MaintainJobDeps {
     upsertSections: realUpsertSections,
     commitEmbedHighWater,
     invalidateLanes: realInvalidateLanes,
+    config,
+  };
+}
+
+function defaultBackfillDeps(config: AssistantConfig): BackfillJobDeps {
+  const workspaceDir = getWorkspaceDir();
+  return {
+    selectAllPages: () => selectAllPagesFromWorkspace(workspaceDir),
+    ensureSectionCollection: realEnsureSectionCollection,
+    buildSectionIndex: realBuildSectionIndex,
+    readPageBody: (slug) => backfillPageBodyFromWorkspace(workspaceDir, slug),
+    deleteSectionsForArticle: realDeleteSectionsForArticle,
+    upsertSections: realUpsertSections,
+    commitEmbedHighWater,
+    nowMs: () => Date.now(),
     config,
   };
 }
@@ -207,6 +285,65 @@ async function reembedChangedPages(
     }
   }
   return { reembedded, reembedFailures };
+}
+
+/**
+ * One-time full backfill of the section dense store. Unlike {@link maintainJob}
+ * (which only re-embeds pages changed since the high-water mark and EXCLUDES
+ * synthetic capability rows), this embeds EVERY page in the index — including
+ * synthetic skill/CLI rows, whose `modifiedAt` is 0 and which the incremental
+ * selector therefore never picks. It exists for the operator transition before
+ * A/B/cutover: the `memory_v3_sections` collection starts empty, so on an
+ * existing install most pages were never embedded into the dense lane.
+ *
+ * Each article is refreshed independently (delete its stale points, then
+ * re-upsert its current sections); a single article whose build/delete/upsert
+ * throws is logged and counted in `failures` without aborting the rest. After
+ * the pass completes the high-water mark is advanced to the timestamp captured
+ * BEFORE the pass, so the next incremental maintain run deltas from here instead
+ * of re-embedding the whole corpus again. The timestamp is captured up-front (as
+ * in `maintainJob`) so an embed write that bumps a page's mtime does not
+ * re-trigger it next pass.
+ */
+export async function backfillAllSections(
+  config: AssistantConfig,
+  deps: BackfillJobDeps = defaultBackfillDeps(config),
+): Promise<BackfillOutcome> {
+  // Capture the high-water stamp before any writes (see the function docstring).
+  const startedAtMs = deps.nowMs();
+
+  const slugs = await deps.selectAllPages();
+  await deps.ensureSectionCollection(deps.config);
+
+  let articles = 0;
+  let sections = 0;
+  let failures = 0;
+  for (const slug of slugs) {
+    try {
+      const index = await deps.buildSectionIndex([slug], deps.readPageBody);
+      await deps.deleteSectionsForArticle(deps.config, slug);
+      await deps.upsertSections(deps.config, index.sections);
+      articles += 1;
+      sections += index.sections.length;
+    } catch (err) {
+      failures += 1;
+      log.warn(
+        { slug, err: err instanceof Error ? err.message : String(err) },
+        "memory-v3 backfill: page embed failed (non-fatal)",
+      );
+    }
+  }
+
+  // Advance the maintain high-water mark so the next incremental pass deltas
+  // from here rather than re-embedding everything.
+  deps.commitEmbedHighWater(startedAtMs);
+
+  log.info(
+    { articles, sections, failures },
+    "memory-v3 section backfill complete",
+  );
+
+  return { articles, sections, failures };
 }
 
 /**

--- a/assistant/src/runtime/routes/memory-v3-routes.ts
+++ b/assistant/src/runtime/routes/memory-v3-routes.ts
@@ -20,12 +20,15 @@ import { join } from "node:path";
 
 import { z } from "zod";
 
+import { getConfig } from "../../config/loader.js";
+import type { AssistantConfig } from "../../config/types.js";
 import { getPageIndex } from "../../memory/v2/page-index.js";
 import { loadCore } from "../../plugins/defaults/memory-v3-shadow/core.js";
 import {
   computeV3Health,
   renderV3Health,
 } from "../../plugins/defaults/memory-v3-shadow/health.js";
+import { backfillAllSections } from "../../plugins/defaults/memory-v3-shadow/maintain-job.js";
 import {
   type LeafRef,
   reconcileTree,
@@ -296,6 +299,40 @@ export async function handleMemoryV3RebuildIndex(): Promise<MemoryV3RebuildIndex
 }
 
 // ---------------------------------------------------------------------------
+// backfill-sections
+// ---------------------------------------------------------------------------
+
+const MemoryV3BackfillSectionsResultSchema = z.object({
+  /** Pages whose sections were embedded this pass. */
+  articles: z.number(),
+  /** Total section points upserted across all articles. */
+  sections: z.number(),
+  /** Pages whose embed threw (and was contained). */
+  failures: z.number(),
+});
+export type MemoryV3BackfillSectionsResult = z.infer<
+  typeof MemoryV3BackfillSectionsResultSchema
+>;
+
+/**
+ * One-time full backfill of the section dense store: embed EVERY page in the
+ * index — including synthetic skill/CLI rows the incremental maintain pass
+ * skips — into the `memory_v3_sections` collection, then advance the maintain
+ * high-water mark so the next incremental run deltas from here. Runs in-daemon
+ * so it uses the live config and so the maintain checkpoint it advances is the
+ * one the daemon's incremental pass reads.
+ *
+ * `config` is injectable for tests; production resolves the live config.
+ */
+export async function handleMemoryV3BackfillSections(
+  config: AssistantConfig = getConfig(),
+): Promise<MemoryV3BackfillSectionsResult> {
+  const outcome = await backfillAllSections(config);
+  log.info(outcome, "memory-v3 section backfill complete (route)");
+  return outcome;
+}
+
+// ---------------------------------------------------------------------------
 // Route definitions (RouteHandlerArgs adapters over the handlers above)
 // ---------------------------------------------------------------------------
 
@@ -368,5 +405,16 @@ export const ROUTES: RouteDefinition[] = [
     summary: "Invalidate the v3 lanes so the next turn rebuilds",
     tags: ["memory"],
     responseBody: MemoryV3RebuildIndexResultSchema,
+  },
+  {
+    operationId: "memory_v3_backfill_sections",
+    method: "POST",
+    policy: WRITE_POLICY,
+    endpoint: "memory/v3/backfill-sections",
+    handler: () => handleMemoryV3BackfillSections(),
+    summary:
+      "One-time: embed every page's sections (incl synthetic skill/CLI rows) into the dense store",
+    tags: ["memory"],
+    responseBody: MemoryV3BackfillSectionsResultSchema,
   },
 ];


### PR DESCRIPTION
## Summary
- Add `assistant memory v3 backfill-sections` (CLI + daemon route + `backfillAllSections`) to embed the whole corpus's sections — including synthetic skill/CLI pages — into the `memory_v3_sections` collection in one pass, then advance the maintain checkpoint so the delta job resumes from there. Needed before A/B/cutover since the maintain job only re-embeds deltas and the collection starts empty.

Follow-up to plan: memory-v3-section-lanes.md