### PR TITLE
fix(memory-v3): hold embed checkpoint on failure; long backfill IPC timeout

### DIFF
--- a/assistant/src/cli/commands/__tests__/memory-v3.test.ts
+++ b/assistant/src/cli/commands/__tests__/memory-v3.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Tests for the `assistant memory v3` CLI subgroup (section-lane model).
+ *
+ * Validates:
+ *   - Subcommand registration (rebuild-index, backfill-sections) under
+ *     `memory v3`.
+ *   - Each subcommand maps to the right `cliIpcCall` method.
+ *   - `backfill-sections` passes a long IPC timeout (the one-time full-corpus
+ *     embed easily outlasts the default 60s), while `rebuild-index` does not.
+ *   - IPC error paths return a non-zero exit code without throwing.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+/** The last `cliIpcCall` invocation captured for assertions. */
+let lastIpcCall: {
+  method: string;
+
+  params?: any;
+  options?: { timeoutMs?: number; signal?: AbortSignal };
+} | null = null;
+
+/** The result that cliIpcCall will return. */
+let mockIpcResult: {
+  ok: boolean;
+  result?: unknown;
+  error?: string;
+} = { ok: true, result: { articles: 3, sections: 12, failures: 0 } };
+
+/** Captured log output for assertion. */
+let logOutput: string[] = [];
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+mock.module("../../../ipc/cli-client.js", () => ({
+  cliIpcCall: async (
+    method: string,
+    params?: any,
+    options?: { timeoutMs?: number; signal?: AbortSignal },
+  ) => {
+    lastIpcCall = { method, params, options };
+    return mockIpcResult;
+  },
+}));
+
+const capture = (...args: unknown[]) => {
+  logOutput.push(args.map(String).join(" "));
+};
+const fakeLogger = {
+  info: capture,
+  warn: capture,
+  error: capture,
+  debug: () => {},
+};
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () => fakeLogger,
+  getCliLogger: () => fakeLogger,
+}));
+
+// ---------------------------------------------------------------------------
+// Import modules under test (after mocks)
+// ---------------------------------------------------------------------------
+
+const { registerMemoryV3Command } = await import("../memory-v3.js");
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function buildProgram(): Command {
+  const program = new Command();
+  program.exitOverride();
+  program.configureOutput({
+    writeErr: () => {},
+    writeOut: () => {},
+  });
+  registerMemoryV3Command(program);
+  return program;
+}
+
+async function runCommand(
+  args: string[],
+): Promise<{ stdout: string; exitCode: number }> {
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  const stdoutChunks: string[] = [];
+
+  process.stdout.write = ((chunk: unknown) => {
+    stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+
+  process.stderr.write = (() => true) as typeof process.stderr.write;
+
+  process.exitCode = 0;
+
+  try {
+    const program = buildProgram();
+    await program.parseAsync(["node", "assistant", ...args]);
+  } catch {
+    if (process.exitCode === 0) process.exitCode = 1;
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+
+  const exitCode = process.exitCode ?? 0;
+  process.exitCode = 0;
+
+  return { exitCode, stdout: stdoutChunks.join("") };
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  lastIpcCall = null;
+  mockIpcResult = {
+    ok: true,
+    result: { articles: 3, sections: 12, failures: 0 },
+  };
+  logOutput = [];
+  process.exitCode = 0;
+});
+
+// ---------------------------------------------------------------------------
+// Subcommand registration
+// ---------------------------------------------------------------------------
+
+describe("subcommand registration", () => {
+  test("registers v3 under memory with the expected subcommands", () => {
+    const program = buildProgram();
+    const memory = program.commands.find((c) => c.name() === "memory");
+    expect(memory).toBeDefined();
+    const v3 = memory!.commands.find((c) => c.name() === "v3");
+    expect(v3).toBeDefined();
+    const subcommandNames = v3!.commands.map((c) => c.name()).sort();
+    expect(subcommandNames).toEqual(["backfill-sections", "rebuild-index"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rebuild-index
+// ---------------------------------------------------------------------------
+
+describe("memory v3 rebuild-index", () => {
+  test("sends memory_v3_rebuild_index with the default (no) timeout", async () => {
+    mockIpcResult = { ok: true, result: { invalidated: true } };
+
+    const { exitCode } = await runCommand(["memory", "v3", "rebuild-index"]);
+
+    expect(exitCode).toBe(0);
+    expect(lastIpcCall!.method).toBe("memory_v3_rebuild_index");
+    expect(lastIpcCall!.params!.body).toEqual({});
+    // rebuild-index is fast; it relies on the default call timeout.
+    expect(lastIpcCall!.options).toBeUndefined();
+  });
+
+  test("exits with code 1 on IPC failure", async () => {
+    mockIpcResult = { ok: false, error: "Daemon down" };
+
+    const { exitCode } = await runCommand(["memory", "v3", "rebuild-index"]);
+
+    expect(exitCode).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// backfill-sections
+// ---------------------------------------------------------------------------
+
+describe("memory v3 backfill-sections", () => {
+  test("sends memory_v3_backfill_sections with a long (30-min) IPC timeout", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: { articles: 50, sections: 400, failures: 0 },
+    };
+
+    const { exitCode } = await runCommand([
+      "memory",
+      "v3",
+      "backfill-sections",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(lastIpcCall!.method).toBe("memory_v3_backfill_sections");
+    expect(lastIpcCall!.params!.body).toEqual({});
+    // The one-time full-corpus embed is long-running, so the CLI must override
+    // the default 60s timeout with a generous ceiling (30 min).
+    expect(lastIpcCall!.options!.timeoutMs).toBe(30 * 60 * 1000);
+  });
+
+  test("summarizes embedded sections on success", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: { articles: 7, sections: 42, failures: 0 },
+    };
+
+    await runCommand(["memory", "v3", "backfill-sections"]);
+
+    expect(
+      logOutput.some((line) => line.includes("42") && line.includes("7")),
+    ).toBe(true);
+  });
+
+  test("exits with code 1 on IPC failure", async () => {
+    mockIpcResult = { ok: false, error: "Memory v3 not enabled" };
+
+    const { exitCode } = await runCommand([
+      "memory",
+      "v3",
+      "backfill-sections",
+    ]);
+
+    expect(exitCode).toBe(1);
+  });
+});

--- a/assistant/src/cli/commands/memory-v3.ts
+++ b/assistant/src/cli/commands/memory-v3.ts
@@ -25,6 +25,15 @@ import type {
 import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
 
+/**
+ * IPC timeout for `backfill-sections`. The one-time full-corpus section embed
+ * runs every page's chunks through the embedder sequentially, which easily
+ * outlasts `cliIpcCall`'s default 60s — so we give it a generous 30-minute
+ * ceiling rather than report a spurious "Request timed out" while the assistant
+ * keeps working.
+ */
+const BACKFILL_IPC_TIMEOUT_MS = 30 * 60 * 1000;
+
 export function registerMemoryV3Command(program: Command): void {
   // Reuse an existing `memory` parent if some other registrar attached to it
   // first; otherwise create one. This keeps the registration order between
@@ -106,6 +115,7 @@ Examples:
           const result = await cliIpcCall<MemoryV3BackfillSectionsResult>(
             "memory_v3_backfill_sections",
             { body: {} },
+            { timeoutMs: BACKFILL_IPC_TIMEOUT_MS },
           );
           if (!result.ok) {
             log.error(result.error ?? "Failed to backfill section embeddings");

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/maintain-job.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/maintain-job.test.ts
@@ -166,6 +166,11 @@ describe("maintainJob", () => {
     ]);
     expect(calls.invalidate).toBe(1);
     expect(outcome.invalidated).toBe(true);
+    // The checkpoint is HELD when any page failed: the failed page was
+    // delete-then-upsert'd (so its sections are gone), and advancing past its
+    // mtime would hide it from `computeChangedPages` forever. Holding the mark
+    // lets the next pass re-select and re-embed it.
+    expect(calls.commit).toBe(0);
   });
 
   test("a thrown re-embed stage does not abort lane invalidation", async () => {
@@ -345,7 +350,7 @@ describe("backfillAllSections", () => {
     expect(calls.committed).toEqual([99999]);
   });
 
-  test("contains a single failing page; others still embed and checkpoint advances", async () => {
+  test("contains a single failing page; others still embed but checkpoint is HELD", async () => {
     const { deps: d, calls } = deps({
       selectAllPages: async () => ["page-ok", "page-bad", "page-ok-2"],
       upsertSections: async (_config, sections) => {
@@ -363,7 +368,10 @@ describe("backfillAllSections", () => {
       "page-ok",
       "page-ok-2",
     ]);
-    // A contained per-article failure does not block the checkpoint advance.
-    expect(calls.committed).toEqual([4242]);
+    // The checkpoint is HELD on any failure: the failed page was
+    // delete-then-upsert'd (sections gone), so advancing past its mtime would
+    // hide it from the incremental selector forever. Holding the mark lets the
+    // next pass re-embed it.
+    expect(calls.committed).toEqual([]);
   });
 });

--- a/assistant/src/plugins/defaults/memory-v3-shadow/maintain-job.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/maintain-job.ts
@@ -11,8 +11,10 @@
  *      (`deleteSectionsForArticle` + `upsertSections`). This keeps the
  *      section-grain Qdrant collection in sync with on-disk page edits so the
  *      dense lane retrieves against current content. The high-water mark is
- *      advanced only after the pass completes (captured before any potential
- *      mtime bumps) so a page is not re-embedded forever.
+ *      advanced only after the pass completes with zero page failures (and is
+ *      captured before any potential mtime bumps) so a page is not re-embedded
+ *      forever, yet a page whose embed failed (and whose sections were therefore
+ *      left deleted) stays above the mark and is retried next pass.
  *   2. **Lane invalidation** — `invalidateLanes()` so the next turn rebuilds the
  *      in-memory section index, needle, and edge graph from the freshly-updated
  *      pages.
@@ -97,8 +99,9 @@ export interface MaintainJobDeps {
   /** Embed + upsert an article's current sections into the dense store. */
   upsertSections: typeof realUpsertSections;
   /**
-   * Persist the high-water mark after a successful re-embed pass. The value is
-   * captured before the pass's writes (see the key docstring).
+   * Persist the high-water mark after a re-embed pass with zero failures. The
+   * value is captured before the pass's writes (see the key docstring); the
+   * caller skips this when any page failed so failed pages retry next pass.
    */
   commitEmbedHighWater: (highWaterMs: number) => void;
   /** Drop the memoized v3 lanes so the next turn rebuilds them. */
@@ -127,7 +130,10 @@ export interface BackfillJobDeps {
   deleteSectionsForArticle: typeof realDeleteSectionsForArticle;
   /** Embed + upsert an article's current sections into the dense store. */
   upsertSections: typeof realUpsertSections;
-  /** Persist the high-water mark after the backfill completes. */
+  /**
+   * Persist the high-water mark after the backfill completes with zero
+   * failures. Skipped when any page failed so failed pages retry next pass.
+   */
   commitEmbedHighWater: (highWaterMs: number) => void;
   /** Epoch-ms stamped as the new high-water mark; injectable for tests. */
   nowMs: () => number;
@@ -307,12 +313,15 @@ async function reembedChangedPages(
  *
  * Each article is refreshed independently (delete its stale points, then
  * re-upsert its current sections); a single article whose build/delete/upsert
- * throws is logged and counted in `failures` without aborting the rest. After
- * the pass completes the high-water mark is advanced to the timestamp captured
- * BEFORE the pass, so the next incremental maintain run deltas from here instead
- * of re-embedding the whole corpus again. The timestamp is captured up-front (as
- * in `maintainJob`) so an embed write that bumps a page's mtime does not
- * re-trigger it next pass.
+ * throws is logged and counted in `failures` without aborting the rest. When the
+ * pass completes with zero failures the high-water mark is advanced to the
+ * timestamp captured BEFORE the pass, so the next incremental maintain run
+ * deltas from here instead of re-embedding the whole corpus again. The timestamp
+ * is captured up-front (as in `maintainJob`) so an embed write that bumps a
+ * page's mtime does not re-trigger it next pass. If any page failed the
+ * checkpoint is held (not advanced): a failed page was delete-then-upsert'd and
+ * so has no sections, and advancing past its mtime would hide it from the
+ * incremental selector forever — holding the mark lets the next pass re-embed it.
  */
 export async function backfillAllSections(
   config: AssistantConfig,
@@ -343,9 +352,21 @@ export async function backfillAllSections(
     }
   }
 
-  // Advance the maintain high-water mark so the next incremental pass deltas
-  // from here rather than re-embedding everything.
-  deps.commitEmbedHighWater(startedAtMs);
+  // Advance the maintain high-water mark only when every page embedded cleanly,
+  // so the next incremental pass deltas from here rather than re-embedding
+  // everything. A failed page was delete-then-upsert'd, so it now has no
+  // sections; advancing past its mtime would hide it from `computeChangedPages`
+  // forever. Holding the checkpoint keeps failed pages above the mark so the
+  // next pass re-embeds them — re-embedding the succeeded pages too is
+  // idempotent and cheap.
+  if (failures === 0) {
+    deps.commitEmbedHighWater(startedAtMs);
+  } else {
+    log.info(
+      { articles, sections, failures },
+      "memory-v3 backfill: embed checkpoint held (page failures) — failed pages retry next pass",
+    );
+  }
 
   log.info(
     { articles, sections, failures },
@@ -383,7 +404,7 @@ export async function maintainJob(
 
   // Stage 1: re-chunk + re-embed pages changed since the last pass. Capture the
   // high-water mark BEFORE the pass so an embed write that bumps a page's mtime
-  // does not re-trigger it next pass; advance it only on success.
+  // does not re-trigger it next pass; advance it only when every page succeeded.
   try {
     const startedAtMs = Date.now();
     const changed = await deps.selectChangedPages();
@@ -393,7 +414,21 @@ export async function maintainJob(
     );
     outcome.reembedded = reembedded;
     outcome.reembedFailures = reembedFailures;
-    deps.commitEmbedHighWater(startedAtMs);
+    // Only advance the high-water mark when nothing failed. A failed page is
+    // processed as delete-then-upsert, so a transient embed/Qdrant error leaves
+    // its sections deleted; if we advanced past its mtime, `computeChangedPages`
+    // would never re-select it (mtime <= high-water) and it would stay missing.
+    // Holding the checkpoint keeps every failed page above the mark so it
+    // retries next pass — the handful of already-succeeded pages re-embedding
+    // again is idempotent and cheap.
+    if (reembedFailures === 0) {
+      deps.commitEmbedHighWater(startedAtMs);
+    } else {
+      log.info(
+        { reembedded, reembedFailures },
+        "memory-v3 maintain: embed checkpoint held (page failures) — failed pages retry next pass",
+      );
+    }
   } catch (err) {
     outcome.failures.push("reembed");
     log.warn(


### PR DESCRIPTION
## Summary
- **P2 (checkpoint on failure):** maintainJob + backfillAllSections only advance the section-embed high-water when there were zero failures. Previously a page that failed after deleteSectionsForArticle was left with deleted sections AND skipped on future runs (mtime fell below the advanced checkpoint). Now failed pages stay above the high-water and retry next pass.
- **P2 (backfill IPC timeout):** the backfill-sections CLI call now uses a 30-min timeout instead of the default 60s, since the one-time full-corpus embed is long-running and otherwise reports a spurious 'Request timed out'.

Addresses Codex review comments on #33874. Follow-up to plan: memory-v3-section-lanes.md