### PR TITLE
docs(memory-v3): document inspector injectedText approximation

### DIFF
--- a/assistant/src/plugins/defaults/memory-v3-shadow/selection-log-store.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/selection-log-store.ts
@@ -77,11 +77,15 @@ export async function getMemoryV3SelectionForInspector(
     pinned: r.pinned === 1,
   }));
   const slugs: Slug[] = selections.map((s) => s.slug);
-  // The inspector re-renders from persisted rows without re-running
-  // orchestration, so the per-slug matched section is unavailable. An empty map
-  // makes `renderV3SectionContent` fall back to the full/lead page for every
-  // slug — the same full-page rendering the inspector showed before
-  // matched-section injection.
+  // NOTE: `injectedText` is APPROXIMATE — it renders the full/lead page for
+  // every slug, not the exact matched section live injection used. The inspector
+  // re-renders from persisted rows without re-running orchestration, and the
+  // section identity is not persisted (`memory_v3_selections` stores
+  // slug/source/pinned, not the section ordinal), so the section map is empty
+  // and `renderV3SectionContent` falls back to the full page. Persisting the
+  // injected section (a schema migration) is deliberately deferred: the A/B's
+  // primary signal is slug-level recall via `summarizeSelections`, which is
+  // exact — only this debug-oriented injected text is an approximation.
   const injectedText = await renderMemoryBlock(
     slugs,
     new Map<Slug, Section>(),


### PR DESCRIPTION
## Summary
- Document that the selection-log inspector's `injectedText` is approximate (renders the full page, not the exact matched section live injection used), because the section identity isn't persisted. Persisting it (a schema migration) is deliberately deferred — the A/B's primary signal (slug-level recall via `summarizeSelections`) is exact. Addresses Codex P2 on #33874 as a documented limitation.

Follow-up to plan: memory-v3-section-lanes.md