### PR TITLE
fix(memory-v3): edge-only injection + deleted-page section pruning

### DIFF
--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/maintain-job.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/maintain-job.test.ts
@@ -80,6 +80,10 @@ describe("maintainJob", () => {
       commitEmbedHighWater: () => {
         calls.commit += 1;
       },
+      // Prune stage off by default: no stored articles ⇒ nothing to prune. The
+      // dedicated prune tests below override both collaborators.
+      listSectionArticles: async () => [],
+      listIndexedSlugs: async () => [],
       invalidateLanes: () => {
         calls.invalidate += 1;
       },
@@ -206,6 +210,81 @@ describe("maintainJob", () => {
     const outcome = await maintainJob(JOB, CONFIG, d);
     expect(outcome.failures).toContain("reembed");
     expect(calls.commit).toBe(0);
+  });
+
+  test("prunes sections for an article absent from the page index", async () => {
+    setOverridesForTesting({ [FLAG_SHADOW]: true });
+    // The dense store holds points for a live page, a deleted page, and a
+    // synthetic capability row; the page index holds only the live + synthetic
+    // slugs. Only the deleted page's sections are pruned. `selectChangedPages`
+    // stays empty so `calls.deleted` reflects prune deletes only.
+    const { deps: d, calls } = deps({
+      listSectionArticles: async () => [
+        "page-live",
+        "page-deleted",
+        "skills/example",
+      ],
+      listIndexedSlugs: async () => ["page-live", "skills/example"],
+    });
+    const outcome = await maintainJob(JOB, CONFIG, d);
+
+    expect(outcome.pruned).toBe(1);
+    expect(outcome.pruneFailures).toBe(0);
+    // The live page and the synthetic capability row are NOT pruned.
+    expect(calls.deleted).toEqual(["page-deleted"]);
+    // The pass still invalidates the lanes.
+    expect(calls.invalidate).toBe(1);
+    expect(outcome.invalidated).toBe(true);
+  });
+
+  test("prunes nothing when every stored article is still in the index", async () => {
+    setOverridesForTesting({ [FLAG_SHADOW]: true });
+    const { deps: d, calls } = deps({
+      listSectionArticles: async () => ["page-a", "page-b"],
+      listIndexedSlugs: async () => ["page-a", "page-b", "page-c"],
+    });
+    const outcome = await maintainJob(JOB, CONFIG, d);
+
+    expect(outcome.pruned).toBe(0);
+    expect(calls.deleted).toEqual([]);
+  });
+
+  test("a single failing prune delete is contained; other deletions proceed", async () => {
+    setOverridesForTesting({ [FLAG_SHADOW]: true });
+    const { deps: d, calls } = deps({
+      listSectionArticles: async () => ["gone-1", "gone-bad", "gone-2"],
+      listIndexedSlugs: async () => [],
+      deleteSectionsForArticle: async (_config, article) => {
+        if (article === "gone-bad") throw new Error("delete boom");
+        calls.deleted.push(article);
+      },
+    });
+    const outcome = await maintainJob(JOB, CONFIG, d);
+
+    expect(outcome.pruned).toBe(2);
+    expect(outcome.pruneFailures).toBe(1);
+    // Both good deletions ran; the contained failure did not abort them.
+    expect(calls.deleted).toEqual(["gone-1", "gone-2"]);
+    // A contained per-article failure is NOT a stage failure, and the lanes
+    // were still invalidated.
+    expect(outcome.failures).not.toContain("prune");
+    expect(calls.invalidate).toBe(1);
+  });
+
+  test("a thrown prune stage is contained and does not abort lane invalidation", async () => {
+    setOverridesForTesting({ [FLAG_SHADOW]: true });
+    const { deps: d, calls } = deps({
+      listSectionArticles: async () => {
+        throw new Error("scroll boom");
+      },
+    });
+    const outcome = await maintainJob(JOB, CONFIG, d);
+
+    expect(outcome.failures).toContain("prune");
+    expect(outcome.pruned).toBe(0);
+    // Invalidation still runs after a thrown prune stage.
+    expect(calls.invalidate).toBe(1);
+    expect(outcome.invalidated).toBe(true);
   });
 });
 

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/orchestrate.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/orchestrate.test.ts
@@ -311,6 +311,154 @@ describe("orchestrate — candidate pool composition", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Edge-only injection: a page surfaced ONLY by the edge lane (the query did not
+// lexically hit it) records NO matched section, so injection falls back to the
+// FULL page (the curated `links` description — not the often-empty lead the
+// query never hit — is what made the candidate relevant). The best-section text
+// is kept only as the select-pool descriptor fallback.
+// ---------------------------------------------------------------------------
+
+describe("orchestrate — edge-only injection", () => {
+  test("an edge-only page records NO sectionBySlug entry (→ full-page inject)", async () => {
+    const lanes = await buildLanes();
+    // "apple" hits topic-a (needle); topic-a links to topic-d (edge-only — the
+    // query never hits topic-d). Select topic-d so it is in the result.
+    denseHits = [];
+    providerStub = selectProvider(["topic-d"]);
+    const result = await orchestrate(makeTurn(1, "apple"), {
+      sectionIndex: lanes.sectionIndex,
+      needle: lanes.needle,
+      denseConfig: config,
+      edgeGraph: lanes.edgeGraph,
+      workingSet: new WorkingSet(),
+    });
+
+    // topic-d was selected and injected, but with NO matched section — so
+    // `renderV3SectionContent(slug, undefined)` falls back to the full page.
+    expect(result.finalInjection).toContain("topic-d");
+    expect(result.sectionBySlug.has("topic-d")).toBe(false);
+  });
+
+  test("an edge-only page still carries the curated links description as its descriptor", async () => {
+    const lanes = await buildLanes();
+    let descriptorLine = "";
+    providerStub = {
+      name: "stub",
+      sendMessage: async (messages) => {
+        for (const msg of messages) {
+          for (const block of msg.content) {
+            if (block.type !== "text") continue;
+            const m = /\[\d+\] topic-d — ([^\n]+)/.exec(block.text);
+            if (m) descriptorLine = m[1]!;
+          }
+        }
+        return toolUseResponse({ ids: [] });
+      },
+    };
+
+    await orchestrate(makeTurn(1, "apple"), {
+      sectionIndex: lanes.sectionIndex,
+      needle: lanes.needle,
+      denseConfig: config,
+      edgeGraph: lanes.edgeGraph,
+      workingSet: new WorkingSet(),
+    });
+
+    // The curated `links` description (not the lead text) is the descriptor.
+    expect(descriptorLine).toContain("the curated edge from a to d");
+  });
+
+  test("an edge-only page with no curated description falls back to bestSection text as the descriptor", async () => {
+    // A bare `links:` entry (no ` — `) carries NO description, so the edge
+    // candidate's descriptor falls back to the page's best section against the
+    // query. The query never hits dst-page, so bestSection returns its lead;
+    // that lead text becomes the descriptor (and the page is still injected in
+    // full, with no sectionBySlug entry).
+    const pages: Record<Slug, string> = {
+      "src-page": "lead for src\n## Body\nalpha bravo about src",
+      "dst-page": "lead content for dst page\n## Extra\nnothing relevant here",
+    };
+    const raw: Record<Slug, string> = {
+      // bare slug — no ` — ` separator → undefined curated description.
+      "src-page": `---\nlinks:\n  - "dst-page"\n---\n${pages["src-page"]}`,
+      "dst-page": `---\nedges: []\n---\n${pages["dst-page"]}`,
+    };
+    const slugs = Object.keys(pages);
+    const entries: PageIndexEntry[] = slugs.map((slug, i) => ({
+      id: i + 1,
+      slug,
+      summary: `summary of ${slug}`,
+      edges: [],
+      leaves: [],
+      modifiedAt: 0,
+    }));
+    const sectionIndex = await buildSectionIndex(slugs, async (s) => pages[s]!);
+    const needle = buildSectionNeedle(sectionIndex);
+    const edgeGraph = await buildEdgeGraph(entries, async (s) => raw[s]!);
+
+    let descriptorLine = "";
+    providerStub = {
+      name: "stub",
+      sendMessage: async (messages) => {
+        for (const msg of messages) {
+          for (const block of msg.content) {
+            if (block.type !== "text") continue;
+            const m = /\[\d+\] dst-page — ([^\n]+)/.exec(block.text);
+            if (m) descriptorLine = m[1]!;
+          }
+        }
+        return toolUseResponse({ ids: [] });
+      },
+    };
+
+    // "alpha" hits src-page (needle); src-page links to dst-page (edge-only, no
+    // curated description).
+    const result = await orchestrate(makeTurn(1, "alpha"), {
+      sectionIndex,
+      needle,
+      denseConfig: config,
+      edgeGraph,
+      workingSet: new WorkingSet(),
+    });
+
+    // Descriptor fell back to dst-page's lead text; still no matched section.
+    expect(descriptorLine).toContain("lead content for dst page");
+    expect(result.sectionBySlug.has("dst-page")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dense liveness: a dense hit whose article is no longer in the live section
+// index (its page was deleted; its Qdrant points linger) is dropped from the
+// pool, so a deleted page can never be surfaced via the dense lane.
+// ---------------------------------------------------------------------------
+
+describe("orchestrate — dense liveness filter", () => {
+  test("a dense hit absent from sectionIndex.byArticle is dropped from the pool", async () => {
+    const lanes = await buildLanes();
+    // Dense returns a live page (topic-b) AND a deleted page (gone-page) whose
+    // points still linger in Qdrant but which is absent from the section index.
+    denseHits = [
+      { article: "topic-b", section: 0 },
+      { article: "gone-page", section: 0 },
+    ];
+    providerStub = selectProvider([]); // selection irrelevant to pool membership
+    const result = await orchestrate(makeTurn(1, "apple"), {
+      sectionIndex: lanes.sectionIndex,
+      needle: lanes.needle,
+      denseConfig: config,
+      edgeGraph: lanes.edgeGraph,
+      workingSet: new WorkingSet(),
+    });
+
+    // The live dense hit is pooled; the deleted page is dropped entirely.
+    expect(lastPool).toContain("topic-b");
+    expect(lastPool).not.toContain("gone-page");
+    expect(result.laneBySlug.has("gone-page")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Lane provenance: each pooled slug records the candgen lane that FIRST
 // surfaced it (needle → dense → edge precedence), exposed via
 // `result.laneBySlug` so the selection telemetry can attribute true sources.

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/section-dense-store.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/section-dense-store.test.ts
@@ -39,6 +39,12 @@ type MockPoint = {
   payload: { article: string; ordinal: number; title: string };
 };
 
+/** One programmed `scroll` page: the points to return and the next offset. */
+type ScrollPage = {
+  points: Array<{ id: string; payload: { article?: unknown } }>;
+  next_page_offset: string | number | null;
+};
+
 const state = {
   collectionExists: false,
   collectionExistsCalls: 0,
@@ -48,6 +54,9 @@ const state = {
   upsertCalls: [] as Array<{ wait: boolean; points: MockPoint[] }>,
   deleteCalls: [] as Array<{ wait: boolean; filter: unknown }>,
   createCollectionThrows: null as Error | null,
+  // Programmed `scroll` pages, consumed in order; each `scroll` call shifts one.
+  scrollPages: [] as ScrollPage[],
+  scrollCalls: [] as Array<{ limit: number; offset: unknown }>,
 };
 
 class MockQdrantClient {
@@ -78,6 +87,13 @@ class MockQdrantClient {
     state.deleteCalls.push(params);
     return {};
   }
+  async scroll(
+    _name: string,
+    params: { limit: number; offset?: unknown },
+  ): Promise<ScrollPage> {
+    state.scrollCalls.push({ limit: params.limit, offset: params.offset });
+    return state.scrollPages.shift() ?? { points: [], next_page_offset: null };
+  }
 }
 
 mock.module("@qdrant/js-client-rest", () => ({
@@ -88,6 +104,7 @@ const {
   ensureSectionCollection,
   upsertSections,
   deleteSectionsForArticle,
+  listSectionArticles,
   SECTION_COLLECTION,
   _resetSectionDenseStoreForTests,
 } = await import("../section-dense-store.js");
@@ -114,6 +131,8 @@ function resetState(): void {
   state.upsertCalls.length = 0;
   state.deleteCalls.length = 0;
   state.createCollectionThrows = null;
+  state.scrollPages.length = 0;
+  state.scrollCalls.length = 0;
   embedState.calls.length = 0;
   embedState.dim = 4;
   _resetSectionDenseStoreForTests();
@@ -306,5 +325,70 @@ describe("memory v3 section-dense-store — delete", () => {
     await deleteSectionsForArticle(CONFIG, "people/alice");
 
     expect(state.deleteCalls).toHaveLength(2);
+  });
+});
+
+describe("memory v3 section-dense-store — listSectionArticles", () => {
+  beforeEach(resetState);
+  afterEach(resetState);
+
+  test("returns the distinct articles across all scrolled points", async () => {
+    state.collectionExists = true;
+    // Two scroll pages; `page-a` repeats within and across pages (one article,
+    // many section points) — the result must be the DISTINCT article set.
+    state.scrollPages = [
+      {
+        points: [
+          { id: "1", payload: { article: "page-a" } },
+          { id: "2", payload: { article: "page-a" } },
+          { id: "3", payload: { article: "topic-x" } },
+        ],
+        next_page_offset: "cursor-1",
+      },
+      {
+        points: [
+          { id: "4", payload: { article: "page-a" } },
+          { id: "5", payload: { article: "skills/example" } },
+        ],
+        next_page_offset: null,
+      },
+    ];
+
+    const articles = await listSectionArticles(CONFIG);
+
+    expect(new Set(articles)).toEqual(
+      new Set(["page-a", "topic-x", "skills/example"]),
+    );
+    // Both pages were scrolled, and the second carried the prior page's cursor.
+    expect(state.scrollCalls).toHaveLength(2);
+    expect(state.scrollCalls[0]!.offset).toBeUndefined();
+    expect(state.scrollCalls[1]!.offset).toBe("cursor-1");
+  });
+
+  test("skips points whose payload has no string article", async () => {
+    state.collectionExists = true;
+    state.scrollPages = [
+      {
+        points: [
+          { id: "1", payload: { article: "page-a" } },
+          { id: "2", payload: {} },
+          { id: "3", payload: { article: 42 } },
+        ],
+        next_page_offset: null,
+      },
+    ];
+
+    const articles = await listSectionArticles(CONFIG);
+
+    expect(articles).toEqual(["page-a"]);
+  });
+
+  test("returns an empty list for an empty collection", async () => {
+    state.collectionExists = true;
+    state.scrollPages = [{ points: [], next_page_offset: null }];
+
+    const articles = await listSectionArticles(CONFIG);
+
+    expect(articles).toEqual([]);
   });
 });

--- a/assistant/src/plugins/defaults/memory-v3-shadow/maintain-job.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/maintain-job.ts
@@ -2,7 +2,7 @@
  * Memory v3 — `memory_v3_maintain` job handler.
  *
  * A flag-gated, best-effort self-maintenance pass over the v3 section dense
- * store and the in-memory lanes. It runs two independent stages, in order:
+ * store and the in-memory lanes. It runs three independent stages, in order:
  *
  *   1. **Section re-embed** — diff the page index by `modifiedAt` against the
  *      last successful pass (the high-water mark below), and for every page that
@@ -15,19 +15,28 @@
  *      captured before any potential mtime bumps) so a page is not re-embedded
  *      forever, yet a page whose embed failed (and whose sections were therefore
  *      left deleted) stays above the mark and is retried next pass.
- *   2. **Lane invalidation** — `invalidateLanes()` so the next turn rebuilds the
+ *   2. **Deleted-page prune** — diff the dense store's stored articles
+ *      (`listSectionArticles`) against the live page-index slugs and
+ *      `deleteSectionsForArticle` for any article that is no longer in the
+ *      index. A deleted page's slug never reaches the re-embed delta selector
+ *      (it only names live pages), so without this its section points would
+ *      linger in Qdrant and the dense lane could still surface the deleted page.
+ *      Synthetic capability rows are in the page index, so they are never pruned.
+ *   3. **Lane invalidation** — `invalidateLanes()` so the next turn rebuilds the
  *      in-memory section index, needle, and edge graph from the freshly-updated
  *      pages.
  *
  * Best-effort by construction: each stage is wrapped so a failure in one is
  * logged and recorded in the outcome but does NOT abort the others. A single
- * page whose embed fails does not abort the rest of the re-embed stage. The job
- * is a no-op (returns a disabled outcome) unless `memory-v3-shadow` OR
+ * page whose embed fails does not abort the rest of the re-embed stage, and a
+ * single prune delete that throws does not abort the rest of the prune stage.
+ * The job is a no-op (returns a disabled outcome) unless `memory-v3-shadow` OR
  * `memory-v3-live` is enabled — the same flags that gate the v3 plugin.
  *
  * Dependency-injectable: `deps` lets tests substitute the page-index reader,
- * section builder, dense-store ops, and `invalidateLanes` without process-global
- * module mocks.
+ * section builder, dense-store ops (including the prune-stage
+ * `listSectionArticles`/`listIndexedSlugs` collaborators), and `invalidateLanes`
+ * without process-global module mocks.
  */
 
 import { isAssistantFeatureFlagEnabled } from "../../../config/assistant-feature-flags.js";
@@ -45,6 +54,7 @@ import { capabilityOrDiskBody } from "./capabilities.js";
 import {
   deleteSectionsForArticle as realDeleteSectionsForArticle,
   ensureSectionCollection as realEnsureSectionCollection,
+  listSectionArticles as realListSectionArticles,
   upsertSections as realUpsertSections,
 } from "./section-dense-store.js";
 import { buildSectionIndex as realBuildSectionIndex } from "./sections.js";
@@ -104,6 +114,18 @@ export interface MaintainJobDeps {
    * caller skips this when any page failed so failed pages retry next pass.
    */
   commitEmbedHighWater: (highWaterMs: number) => void;
+  /**
+   * Every distinct `article` slug that currently has section points in the
+   * dense store. The prune stage diffs this against the live page-index slugs
+   * to find articles whose points linger after the page was deleted.
+   */
+  listSectionArticles: () => Promise<string[]>;
+  /**
+   * The slugs currently in the page index (the live set the lanes are rebuilt
+   * from). The prune stage keeps these and deletes any section article absent
+   * from this set. Includes synthetic capability rows so they are never pruned.
+   */
+  listIndexedSlugs: () => Promise<Slug[]>;
   /** Drop the memoized v3 lanes so the next turn rebuilds them. */
   invalidateLanes: () => void;
   /** Active assistant config (for the dense-store/embedding calls). */
@@ -159,6 +181,13 @@ export interface MaintainOutcome {
   reembedded: number;
   /** Pages whose re-embed threw (and was contained). */
   reembedFailures: number;
+  /**
+   * Deleted-page articles whose lingering section points were pruned this pass
+   * (present in the dense store but absent from the page index).
+   */
+  pruned: number;
+  /** Prune deletes that threw (and were contained). */
+  pruneFailures: number;
   /** Whether the in-memory lanes were invalidated. */
   invalidated: boolean;
   /** Stages that threw (and were contained). */
@@ -253,6 +282,8 @@ function defaultDeps(config: AssistantConfig): MaintainJobDeps {
     deleteSectionsForArticle: realDeleteSectionsForArticle,
     upsertSections: realUpsertSections,
     commitEmbedHighWater,
+    listSectionArticles: () => realListSectionArticles(config),
+    listIndexedSlugs: () => selectAllPagesFromWorkspace(workspaceDir),
     invalidateLanes: realInvalidateLanes,
     config,
   };
@@ -300,6 +331,46 @@ async function reembedChangedPages(
     }
   }
   return { reembedded, reembedFailures };
+}
+
+/**
+ * Prune section points for articles that no longer exist in the page index. A
+ * deleted concept page leaves `getPageIndex` (so the needle and edge lanes both
+ * drop it on the next rebuild) but its section points linger in Qdrant, where
+ * the dense lane could still surface it. The incremental selector
+ * ({@link computeChangedPages}) never names a slug that is gone, so a deleted
+ * page's stale points are only reachable by reading the collection back and
+ * diffing against the live slug set.
+ *
+ * Each deletion is independent: a single `deleteSectionsForArticle` throw is
+ * logged and counted in `pruneFailures` without aborting the rest. Synthetic
+ * capability rows are in the page index, so they are never pruned.
+ */
+async function pruneDeletedPages(
+  deps: MaintainJobDeps,
+): Promise<{ pruned: number; pruneFailures: number }> {
+  const [storedArticles, indexedSlugs] = await Promise.all([
+    deps.listSectionArticles(),
+    deps.listIndexedSlugs(),
+  ]);
+  const live = new Set(indexedSlugs);
+  const deleted = storedArticles.filter((article) => !live.has(article));
+
+  let pruned = 0;
+  let pruneFailures = 0;
+  for (const article of deleted) {
+    try {
+      await deps.deleteSectionsForArticle(deps.config, article);
+      pruned += 1;
+    } catch (err) {
+      pruneFailures += 1;
+      log.warn(
+        { article, err: err instanceof Error ? err.message : String(err) },
+        "memory-v3 maintain: deleted-page section prune failed (non-fatal)",
+      );
+    }
+  }
+  return { pruned, pruneFailures };
 }
 
 /**
@@ -390,6 +461,8 @@ export async function maintainJob(
     disabled: false,
     reembedded: 0,
     reembedFailures: 0,
+    pruned: 0,
+    pruneFailures: 0,
     invalidated: false,
     failures: [],
   };
@@ -437,7 +510,24 @@ export async function maintainJob(
     );
   }
 
-  // Stage 2: rebuild section index + needle + edge graph on the next turn.
+  // Stage 2: prune section points for pages deleted from the index. A deleted
+  // page's slug never appears in `selectChangedPages` (the delta selector only
+  // names live pages), so its lingering points are cleared by diffing the dense
+  // store's stored articles against the live page-index slugs. Contained: a
+  // failure is logged + recorded in `failures` without aborting invalidation.
+  try {
+    const { pruned, pruneFailures } = await pruneDeletedPages(deps);
+    outcome.pruned = pruned;
+    outcome.pruneFailures = pruneFailures;
+  } catch (err) {
+    outcome.failures.push("prune");
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "memory-v3 maintain: deleted-page prune failed (non-fatal)",
+    );
+  }
+
+  // Stage 3: rebuild section index + needle + edge graph on the next turn.
   try {
     deps.invalidateLanes();
     outcome.invalidated = true;
@@ -453,6 +543,8 @@ export async function maintainJob(
     {
       reembedded: outcome.reembedded,
       reembedFailures: outcome.reembedFailures,
+      pruned: outcome.pruned,
+      pruneFailures: outcome.pruneFailures,
       invalidated: outcome.invalidated,
       failures: outcome.failures,
     },

--- a/assistant/src/plugins/defaults/memory-v3-shadow/orchestrate.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/orchestrate.ts
@@ -13,9 +13,12 @@
  *      descriptor is the matched section's text for needle/dense hits (resolved
  *      via the section index); for edge-only pages it is the curated `links`
  *      description when the traversed edge carried one, else the page's best
- *      section against the query. Synthetic capability pages (skills / CLI
- *      commands) carry sections in the section index too, so they enter the pool
- *      through the lanes like any other page rather than being always-added.
+ *      section against the query. Edge-only pages record NO matched section, so
+ *      they inject the FULL page (the lead the query never hit is often empty;
+ *      the link-relevant content is elsewhere) — the best-section text is only a
+ *      descriptor fallback. Synthetic capability pages (skills / CLI commands)
+ *      carry sections in the section index too, so they enter the pool through
+ *      the lanes like any other page rather than being always-added.
  *   3. A SINGLE forced-tool select (`selectPool`) over the whole pool. The
  *      result is this turn's selections.
  *   4. Age the carry-forward working set to this turn (evict stale non-pinned
@@ -155,6 +158,11 @@ export async function orchestrate(
   // concrete `Section` via the section index. Falls back to undefined (blank
   // descriptor) if the ordinal is not in the in-memory index.
   for (const hit of densed) {
+    // A deleted page's points can linger in Qdrant; keep only live-index
+    // articles. The section index is rebuilt from `getPageIndex` at `initLanes`,
+    // so `byArticle` holds exactly the live pages (synthetic capability slugs
+    // included) — only truly-deleted pages are dropped here.
+    if (!deps.sectionIndex.byArticle.has(hit.article)) continue;
     addCandidate(
       hit.article,
       sectionByOrdinal(deps.sectionIndex, hit.article, hit.section),
@@ -163,9 +171,16 @@ export async function orchestrate(
     );
   }
 
-  // Step 2c: edge expansion over the top needle+dense article seeds. Each
-  // surfaced article prefers its curated `links` description; else its best
-  // section against the query. `alive` skips slugs already pooled.
+  // Step 2c: edge expansion over the top needle+dense article seeds. `alive`
+  // skips slugs already pooled. An edge-only page was surfaced because its
+  // NEIGHBOUR matched — the query did not lexically hit the page itself, so
+  // `bestSection` returns its first/lead section on a zero-score match. That
+  // lead is often empty for heading-structured pages, and it is the curated
+  // `links` description (not the lead) that made the candidate relevant. So we
+  // record NO matched section for edge-only pages (pass `undefined`), which
+  // makes injection fall back to the FULL page — where the link-relevant content
+  // lives. `bestSection`'s text is kept only as the select-pool DESCRIPTOR
+  // fallback for when the traversed edge carried no curated `links` description.
   const seeds = unique<Slug>([
     ...needled.map((h) => h.article),
     ...densed.map((h) => h.article),
@@ -178,8 +193,13 @@ export async function orchestrate(
   });
   for (const neighbor of surfaced) {
     const best = deps.needle.bestSection(neighbor.article, turn.currentMessage);
-    const section = best >= 0 ? sections[best] : undefined;
-    addCandidate(neighbor.article, section, neighbor.description, "edge");
+    const fallbackDescriptor = best >= 0 ? sections[best]?.text : undefined;
+    addCandidate(
+      neighbor.article,
+      undefined,
+      neighbor.description ?? fallbackDescriptor,
+      "edge",
+    );
   }
 
   // Step 3: a SINGLE forced-tool select over the unified pool.

--- a/assistant/src/plugins/defaults/memory-v3-shadow/section-dense-store.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/section-dense-store.ts
@@ -192,6 +192,46 @@ export async function deleteSectionsForArticle(
   });
 }
 
+/**
+ * Return every distinct `article` slug that currently has at least one section
+ * point in the collection. Scrolls the whole collection (payload only, no
+ * vectors) in bounded batches and collects the distinct `article` values.
+ *
+ * Used by the maintain job's prune stage to find articles whose points linger
+ * after the page was deleted from the index — the change-delta selector never
+ * names a slug that is gone, so a deleted page's stale points are only
+ * observable by reading the collection back. An empty/absent collection yields
+ * an empty list.
+ */
+export async function listSectionArticles(
+  config: AssistantConfig,
+): Promise<string[]> {
+  await ensureSectionCollection(config);
+
+  const client = getSectionDenseClient(config);
+  const articles = new Set<string>();
+  let offset: string | number | undefined = undefined;
+  const maxIterations = 10_000;
+  const batchSize = 256;
+  for (let i = 0; i < maxIterations; i++) {
+    const result = await client.scroll(SECTION_COLLECTION, {
+      limit: batchSize,
+      with_payload: true,
+      with_vector: false,
+      ...(offset !== undefined ? { offset } : {}),
+    });
+    for (const point of result.points) {
+      const article = (point.payload as { article?: unknown } | null)?.article;
+      if (typeof article === "string") articles.add(article);
+    }
+    const next = result.next_page_offset;
+    if (next == null) break;
+    offset = typeof next === "string" ? next : (next as number);
+  }
+
+  return [...articles];
+}
+
 /** @internal Test-only: reset module-level singletons. */
 export function _resetSectionDenseStoreForTests(): void {
   _client = null;


### PR DESCRIPTION
## Summary
- **Edge-only injection (P2):** edge-only candidates now inject the full page instead of an arbitrary first/lead section (the lead is often empty for heading-structured pages, and the curated links description — not the lead — is what made the edge candidate relevant). bestSection text is kept only as the select descriptor fallback.
- **Deleted-page sections (P2):** filter dense-lane hits to articles in the live section index (a deleted page's points can linger in Qdrant), and add a maintain-job prune stage (listSectionArticles − page index → deleteSectionsForArticle) so the collection doesn't accumulate dead points.

Addresses Codex review comments on #33874. Follow-up to plan: memory-v3-section-lanes.md