### PR TITLE
fix(macos): augment PATH in bunAdd so postinstall scripts can find node

### DIFF
--- a/apps/macos/src/main/cli-installer.test.ts
+++ b/apps/macos/src/main/cli-installer.test.ts
@@ -67,6 +67,7 @@ const {
   getCliInstallDir,
   getCliBinPath,
   getBundledBunPath,
+  buildInstallEnv,
   isCliInstalled,
   ensureCliInstalled,
   cleanupOldVersions,
@@ -131,7 +132,7 @@ describe("ensureCliInstalled", () => {
     expect(spawnCalls).toHaveLength(0);
   });
 
-  test("spawns bun add with correct args and cwd", async () => {
+  test("spawns bun add with correct args, cwd, and augmented env", async () => {
     existsSyncDefault = false;
 
     const promise = ensureCliInstalled();
@@ -144,9 +145,13 @@ describe("ensureCliInstalled", () => {
     const [cmd, args, opts] = spawnCalls[0];
     expect(cmd).toBe(`${mockResourcesPath}/bun`);
     expect(args).toEqual(["add", `vellum@${PINNED_CLI_VERSION}`]);
-    expect(opts).toEqual({
-      cwd: `${userDataPath}/cli/${PINNED_CLI_VERSION}`,
-    });
+    expect((opts as { cwd: string }).cwd).toBe(
+      `${userDataPath}/cli/${PINNED_CLI_VERSION}`,
+    );
+    const env = (opts as { env: NodeJS.ProcessEnv }).env;
+    expect(env).toBeDefined();
+    expect(env!.PATH).toContain("/opt/homebrew/bin");
+    expect(env!.PATH).toContain("/usr/local/bin");
   });
 
   test("creates the install directory before spawning", async () => {
@@ -227,6 +232,27 @@ describe("ensureCliInstalled", () => {
     expect(spawnCalls).toHaveLength(2);
     lastChild.emit("close", 0);
     await p2;
+  });
+});
+
+// --- buildInstallEnv ---
+
+describe("buildInstallEnv", () => {
+  test("includes /opt/homebrew/bin and /usr/local/bin in PATH", () => {
+    const env = buildInstallEnv();
+    expect(env.PATH).toContain("/opt/homebrew/bin");
+    expect(env.PATH).toContain("/usr/local/bin");
+  });
+
+  test("includes ~/.bun/bin and ~/.volta/bin in PATH", () => {
+    const env = buildInstallEnv();
+    expect(env.PATH).toContain(".bun/bin");
+    expect(env.PATH).toContain(".volta/bin");
+  });
+
+  test("preserves existing process.env entries", () => {
+    const env = buildInstallEnv();
+    expect(env.HOME).toBeDefined();
   });
 });
 

--- a/apps/macos/src/main/cli-installer.ts
+++ b/apps/macos/src/main/cli-installer.ts
@@ -6,6 +6,7 @@ import {
   readdirSync,
   rmSync,
 } from "node:fs";
+import { homedir } from "node:os";
 import path from "node:path";
 
 // Auto-stamped by create-release-branch workflow.
@@ -31,6 +32,41 @@ export function isCliInstalled(): boolean {
   return existsSync(getCliBinPath());
 }
 
+function findNvmNodeBinDir(home: string): string[] {
+  try {
+    const nvmDir = process.env.NVM_DIR || path.join(home, ".nvm");
+    const versionsDir = path.join(nvmDir, "versions", "node");
+    for (const entry of readdirSync(versionsDir)) {
+      if (!entry.startsWith("v")) continue;
+      const binDir = path.join(versionsDir, entry, "bin");
+      if (existsSync(path.join(binDir, "node"))) return [binDir];
+    }
+  } catch {
+    // nvm not installed
+  }
+  return [];
+}
+
+export function buildInstallEnv(): NodeJS.ProcessEnv {
+  const home = homedir();
+  const basePath =
+    process.env.PATH || "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin";
+  const pathParts = basePath.split(":");
+  const extraDirs = [
+    path.join(home, ".bun", "bin"),
+    path.join(home, ".local", "bin"),
+    "/opt/homebrew/bin",
+    "/usr/local/bin",
+    path.join(home, ".volta", "bin"),
+    ...findNvmNodeBinDir(home),
+  ].filter((d) => !pathParts.includes(d));
+
+  return {
+    ...process.env,
+    PATH: [...extraDirs, basePath].filter(Boolean).join(":"),
+  };
+}
+
 function bunAdd(pkg: string): Promise<void> {
   const installDir = getCliInstallDir();
   mkdirSync(installDir, { recursive: true });
@@ -40,6 +76,7 @@ function bunAdd(pkg: string): Promise<void> {
   return new Promise<void>((resolve, reject) => {
     const child = spawn(bunPath, ["add", `${pkg}@${PINNED_CLI_VERSION}`], {
       cwd: installDir,
+      env: buildInstallEnv(),
     });
 
     let stdout = "";


### PR DESCRIPTION
## Summary
- `bunAdd()` in `cli-installer.ts` spawned bun without an `env` option, so it inherited the Electron app's minimal PATH when launched from the macOS Dock
- esbuild's postinstall script needs `node`, which isn't on the minimal Dock PATH (`/usr/bin:/bin:/usr/sbin:/sbin`), causing exit code 127
- Added `buildInstallEnv()` that prepends common tool directories (`/opt/homebrew/bin`, `/usr/local/bin`, `~/.bun/bin`, `~/.local/bin`, `~/.volta/bin`) and probes for nvm-managed node installations

## Original prompt
User encountered a "Package install failed with exit code 127: /bin/bash: node: command not found" error when hatching a local assistant through the Electron macOS app. The root cause was traced to `bunAdd()` in `cli-installer.ts` not augmenting PATH for the spawned bun process, so esbuild's postinstall script couldn't find `node` when the app was launched from the Dock (which provides a minimal PATH).

## Test plan
- [x] Existing `cli-installer.test.ts` tests updated and passing (20 tests, 37 assertions)
- [x] New `buildInstallEnv` tests verify PATH includes `/opt/homebrew/bin`, `/usr/local/bin`, `~/.bun/bin`, `~/.volta/bin`
- [x] Spawn opts test updated to verify `env` is passed with augmented PATH

🤖 Generated with [Claude Code](https://claude.com/claude-code)