### PR TITLE
feat(cli): style login callback page to match OAuth completion aesthetic

### DIFF
--- a/cli/src/commands/login.ts
+++ b/cli/src/commands/login.ts
@@ -32,6 +32,131 @@ import { syncCloudAssistants } from "../lib/sync-cloud-assistants";
 
 const LOGIN_TIMEOUT_MS = 120_000; // 2 minutes
 
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function renderLoginPage(title: string, subtitle: string, success: boolean): string {
+  const checkmarkSvg = `<svg class="icon" viewBox="0 0 56 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <circle cx="28" cy="28" r="28" fill="var(--positive-bg)"/>
+      <path class="check" d="M17 28.5L24.5 36L39 21" stroke="var(--positive-fg)" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+    </svg>`;
+
+  const errorSvg = `<svg class="icon" viewBox="0 0 56 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <circle cx="28" cy="28" r="28" fill="var(--negative-bg)"/>
+      <path class="cross cross-1" d="M20 20L36 36" stroke="var(--negative-fg)" stroke-width="3.5" stroke-linecap="round" fill="none"/>
+      <path class="cross cross-2" d="M36 20L20 36" stroke="var(--negative-fg)" stroke-width="3.5" stroke-linecap="round" fill="none"/>
+    </svg>`;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${escapeHtml(title)}</title>
+  <style>
+    :root {
+      --surface: #F5F3EB;
+      --surface-card: #FFFFFF;
+      --card-border: #E8E6DA;
+      --text-primary: #2A2A28;
+      --text-secondary: #4A4A46;
+      --positive-bg: #D4DFD0;
+      --positive-fg: #516748;
+      --negative-bg: #F7DAC9;
+      --negative-fg: #DA491A;
+      --shadow: 0 1px 3px rgba(0,0,0,0.04), 0 4px 12px rgba(0,0,0,0.06);
+      --font: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --surface: #1A1A18;
+        --surface-card: #2A2A28;
+        --card-border: #3A3A37;
+        --text-primary: #F5F3EB;
+        --text-secondary: #BDB9A9;
+        --positive-bg: #1A2316;
+        --positive-fg: #7A8B6F;
+        --negative-bg: #4E281D;
+        --negative-fg: #E86B40;
+        --shadow: 0 1px 3px rgba(0,0,0,0.2), 0 4px 12px rgba(0,0,0,0.3);
+      }
+    }
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: var(--font);
+      background: var(--surface);
+      color: var(--text-primary);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      -webkit-font-smoothing: antialiased;
+    }
+    .card {
+      text-align: center;
+      padding: 48px 40px 40px;
+      background: var(--surface-card);
+      border: 1px solid var(--card-border);
+      border-radius: 16px;
+      box-shadow: var(--shadow);
+      max-width: 380px;
+      width: 100%;
+      opacity: 0;
+      transform: translateY(8px) scale(0.98);
+      animation: cardIn 0.5s cubic-bezier(0.16, 1, 0.3, 1) 0.1s forwards;
+    }
+    @keyframes cardIn {
+      to { opacity: 1; transform: translateY(0) scale(1); }
+    }
+    .icon {
+      width: 56px;
+      height: 56px;
+      margin-bottom: 20px;
+    }
+    .check {
+      stroke-dasharray: 32;
+      stroke-dashoffset: 32;
+      animation: draw 0.4s ease-out 0.45s forwards;
+    }
+    .cross {
+      stroke-dasharray: 22;
+      stroke-dashoffset: 22;
+    }
+    .cross-1 { animation: draw 0.3s ease-out 0.45s forwards; }
+    .cross-2 { animation: draw 0.3s ease-out 0.55s forwards; }
+    @keyframes draw {
+      to { stroke-dashoffset: 0; }
+    }
+    h1 {
+      font-size: 18px;
+      font-weight: 600;
+      letter-spacing: -0.2px;
+      color: var(--text-primary);
+      margin-bottom: 6px;
+    }
+    p {
+      font-size: 13px;
+      line-height: 1.5;
+      color: var(--text-secondary);
+    }
+  </style>
+</head>
+<body>
+  <div class="card">
+    ${success ? checkmarkSvg : errorSvg}
+    <h1>${escapeHtml(title)}</h1>
+    <p>${escapeHtml(subtitle)}</p>
+  </div>
+</body>
+</html>`;
+}
+
 /**
  * Open a URL in the user's default browser.
  */
@@ -72,26 +197,20 @@ function browserLogin(webUrl: string): Promise<string> {
 
       if (receivedState !== state) {
         res.writeHead(400, { "Content-Type": "text/html" });
-        res.end(
-          "<html><body><h2>Login failed</h2><p>State mismatch. Please try again.</p></body></html>",
-        );
+        res.end(renderLoginPage("Login Failed", "State mismatch. Please try again.", false));
         cleanup("State mismatch — possible CSRF attack.");
         return;
       }
 
       if (!sessionToken) {
         res.writeHead(400, { "Content-Type": "text/html" });
-        res.end(
-          "<html><body><h2>Login failed</h2><p>No session token received. Please try again.</p></body></html>",
-        );
+        res.end(renderLoginPage("Login Failed", "No session token received. Please try again.", false));
         cleanup("No session token received from platform.");
         return;
       }
 
       res.writeHead(200, { "Content-Type": "text/html" });
-      res.end(
-        "<html><body><h2>Login successful!</h2><p>You can close this window and return to your terminal.</p></body></html>",
-      );
+      res.end(renderLoginPage("Login Successful", "You can close this window and return to your terminal.", true));
       cleanup(null, sessionToken);
     });
 


### PR DESCRIPTION
## Summary
- Replace the bare HTML login success/error pages served by `vellum login` with the polished completion-page design used by OAuth flows and the platform's native auth callback.
- The new pages use the same warm-surface color palette, animated checkmark/error icons, card layout, and dark mode support as `assistant/src/security/oauth-completion-page.ts` and `vellum-assistant-platform`'s `completion-page.tsx`.

## Original prompt
The CLI's `vellum login` browser callback page was a bare `<h2>` + `<p>` with no styling, while our OAuth success pages and platform native auth callbacks use an animated card-based design with proper theming. The ask was to bring the CLI login page in line with that shared aesthetic so all browser-facing auth completion pages look consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)