### PR TITLE
fix(web): sync Electron menu platform session on login and logout

### DIFF
--- a/apps/web/src/domains/account/pages/platform-loopback-page.tsx
+++ b/apps/web/src/domains/account/pages/platform-loopback-page.tsx
@@ -3,6 +3,7 @@ import { useSearchParams, useNavigate } from "react-router";
 
 import { listAssistants } from "@/assistant/api";
 import { syncPlatformAssistantsToLockfile } from "@/lib/local-mode";
+import { setMenuPlatformSession } from "@/runtime/menu";
 import { useAuthStore } from "@/stores/auth-store";
 import { routes } from "@/utils/routes";
 
@@ -58,6 +59,7 @@ export function PlatformLoopbackPage() {
       // sessionStatus to "authenticated" so the auth middleware lets
       // navigation through.
       await useAuthStore.getState().initSession();
+      await setMenuPlatformSession(true);
 
       try {
         const result = await listAssistants();

--- a/apps/web/src/lib/auth/handle-logout.ts
+++ b/apps/web/src/lib/auth/handle-logout.ts
@@ -16,6 +16,7 @@ export async function handleLogout(navigate: NavigateFunction): Promise<void> {
     const active = getActiveAssistant();
     if (active && isLocalAssistant(active)) {
       await setMenuPlatformSession(false);
+      useAuthStore.setState({ platformSession: "absent" });
       return;
     }
 

--- a/apps/web/src/runtime/native-auth.ts
+++ b/apps/web/src/runtime/native-auth.ts
@@ -10,6 +10,7 @@ import { getSession } from "@/lib/auth/allauth-client";
 import { isPlatformLocal, startLoopbackAuth } from "@/lib/auth/loopback-auth";
 import { isLocalMode } from "@/lib/local-mode";
 import { isElectron } from "@/runtime/is-electron";
+import { setMenuPlatformSession } from "@/runtime/menu";
 import { isBiometricEnabled, storeBiometricToken } from "@/runtime/native-biometric";
 import { routes } from "@/utils/routes";
 
@@ -262,6 +263,7 @@ export async function startAuthFlow(
       intent: options.intent,
     });
     if (result?.sessionToken) {
+      await setMenuPlatformSession(true);
       const destination = sanitizeReturnTo(
         options.intent === "signup"
           ? routes.onboarding.privacy


### PR DESCRIPTION
## Summary
- **Logout fix**: Clear `platformSession` in the auth store when logging out from a local assistant, so the preferences menu hides the Log Out button
- **Login fix (loopback)**: Call `setMenuPlatformSession(true)` in `PlatformLoopbackPage` after `initSession()` succeeds
- **Login fix (Electron OAuth)**: Call `setMenuPlatformSession(true)` in the Electron OAuth callback path before navigating to the destination

## Original prompt
The user reported that clicking Log Out while on a self-hosted local assistant didn't actually hide the Log Out button — it persisted in the preferences menu. Investigation revealed `handleLogout` was clearing the Electron menu state but not the auth store, and that login flows also weren't updating the Electron menu since `useElectronDockSync` isn't mounted during those flows.