### PR TITLE
feat(web): support login cancellation on select-assistant screen

### DIFF
--- a/apps/web/src/domains/onboarding/pages/hosting-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hosting-screen.tsx
@@ -1,15 +1,12 @@
 import { Cloud, Laptop, Package } from "lucide-react";
-import { useRef, useState, type ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
 import { setPendingProviderKey } from "@/domains/onboarding/provider-key";
+import { useOnboardingLogin } from "@/hooks/use-onboarding-login";
 import { clearGatewayToken } from "@/lib/auth/gateway-session";
-import { isPlatformLocal } from "@/lib/auth/loopback-auth";
-import { isLocalMode } from "@/lib/local-mode";
 import { setSelfHostedConnection } from "@/lib/self-hosted/connection";
-import { isElectron } from "@/runtime/is-electron";
-import { startAuthFlow } from "@/runtime/native-auth";
 import { useHasPlatformSession } from "@/stores/auth-store";
 import { docsUrl, routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
@@ -67,9 +64,15 @@ export function HostingScreen() {
   const [selected, setSelected] = useState<HostingMode>(
     hasPlatformSession ? "vellum-cloud" : "local",
   );
-  const [loginLoading, setLoginLoading] = useState(false);
-  const [loginError, setLoginError] = useState<string | null>(null);
-  const loginFlowIdRef = useRef(0);
+
+  const {
+    loading: loginLoading,
+    error: loginError,
+    login,
+    cancel: cancelLogin,
+  } = useOnboardingLogin(
+    `${routes.onboarding.hosting}?from=select-assistant`,
+  );
 
   const showLogin = fromSelectAssistant && !hasPlatformSession;
 
@@ -92,37 +95,6 @@ export function HostingScreen() {
         ? routes.onboarding.selectAssistant
         : routes.onboarding.welcome,
     );
-  };
-
-  const handleLogin = async () => {
-    const returnTo = `${routes.onboarding.hosting}?from=select-assistant`;
-
-    if (isLocalMode() && isPlatformLocal()) {
-      void navigate(
-        `${routes.account.login}?returnTo=${encodeURIComponent(returnTo)}`,
-      );
-      return;
-    }
-    const flowId = ++loginFlowIdRef.current;
-    setLoginError(null);
-    setLoginLoading(true);
-    try {
-      const callbackUrl = `${routes.account.providerCallback}?returnTo=${encodeURIComponent(returnTo)}`;
-      await startAuthFlow("workos-oidc", callbackUrl, { returnTo });
-    } catch {
-      if (flowId !== loginFlowIdRef.current) return;
-      setLoginError("Something went wrong. Please try again.");
-      setLoginLoading(false);
-    }
-  };
-
-  const handleCancelLogin = () => {
-    loginFlowIdRef.current++;
-    setLoginLoading(false);
-    setLoginError(null);
-    if (isElectron()) {
-      void window.vellum?.auth?.cancelOAuth();
-    }
   };
 
   return (
@@ -182,9 +154,7 @@ export function HostingScreen() {
               size="regular"
               fullWidth
               className="h-11 text-base"
-              onClick={
-                loginLoading ? handleCancelLogin : () => void handleLogin()
-              }
+              onClick={loginLoading ? cancelLogin : () => void login()}
             >
               {loginLoading ? "Cancel" : "Log In"}
             </Button>

--- a/apps/web/src/domains/onboarding/pages/hosting-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hosting-screen.tsx
@@ -1,11 +1,15 @@
 import { Cloud, Laptop, Package } from "lucide-react";
-import { useState, type ReactNode } from "react";
-import { useNavigate } from "react-router";
+import { useRef, useState, type ReactNode } from "react";
+import { useNavigate, useSearchParams } from "react-router";
 
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
 import { setPendingProviderKey } from "@/domains/onboarding/provider-key";
 import { clearGatewayToken } from "@/lib/auth/gateway-session";
+import { isPlatformLocal } from "@/lib/auth/loopback-auth";
+import { isLocalMode } from "@/lib/local-mode";
 import { setSelfHostedConnection } from "@/lib/self-hosted/connection";
+import { isElectron } from "@/runtime/is-electron";
+import { startAuthFlow } from "@/runtime/native-auth";
 import { useHasPlatformSession } from "@/stores/auth-store";
 import { docsUrl, routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
@@ -56,11 +60,18 @@ function useHostingOptions(): HostingOption[] {
 
 export function HostingScreen() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const fromSelectAssistant = searchParams.get("from") === "select-assistant";
   const hasPlatformSession = useHasPlatformSession();
   const options = useHostingOptions();
   const [selected, setSelected] = useState<HostingMode>(
     hasPlatformSession ? "vellum-cloud" : "local",
   );
+  const [loginLoading, setLoginLoading] = useState(false);
+  const [loginError, setLoginError] = useState<string | null>(null);
+  const loginFlowIdRef = useRef(0);
+
+  const showLogin = fromSelectAssistant && !hasPlatformSession;
 
   const onContinue = () => {
     if (selected === "vellum-cloud") {
@@ -76,7 +87,42 @@ export function HostingScreen() {
   };
 
   const onBack = () => {
-    void navigate(routes.onboarding.welcome);
+    void navigate(
+      fromSelectAssistant
+        ? routes.onboarding.selectAssistant
+        : routes.onboarding.welcome,
+    );
+  };
+
+  const handleLogin = async () => {
+    const returnTo = `${routes.onboarding.hosting}?from=select-assistant`;
+
+    if (isLocalMode() && isPlatformLocal()) {
+      void navigate(
+        `${routes.account.login}?returnTo=${encodeURIComponent(returnTo)}`,
+      );
+      return;
+    }
+    const flowId = ++loginFlowIdRef.current;
+    setLoginError(null);
+    setLoginLoading(true);
+    try {
+      const callbackUrl = `${routes.account.providerCallback}?returnTo=${encodeURIComponent(returnTo)}`;
+      await startAuthFlow("workos-oidc", callbackUrl, { returnTo });
+    } catch {
+      if (flowId !== loginFlowIdRef.current) return;
+      setLoginError("Something went wrong. Please try again.");
+      setLoginLoading(false);
+    }
+  };
+
+  const handleCancelLogin = () => {
+    loginFlowIdRef.current++;
+    setLoginLoading(false);
+    setLoginError(null);
+    if (isElectron()) {
+      void window.vellum?.auth?.cancelOAuth();
+    }
   };
 
   return (
@@ -94,6 +140,12 @@ export function HostingScreen() {
         >
           Where do you want your assistant to live?
         </p>
+
+        {loginError && (
+          <p className="mt-4 text-body-small-default text-[var(--system-negative-strong)]">
+            {loginError}
+          </p>
+        )}
 
         <div
           className="mt-10 grid w-full auto-rows-fr gap-3"
@@ -124,12 +176,26 @@ export function HostingScreen() {
           >
             Continue
           </Button>
+          {showLogin && (
+            <Button
+              variant="outlined"
+              size="regular"
+              fullWidth
+              className="h-11 text-base"
+              onClick={
+                loginLoading ? handleCancelLogin : () => void handleLogin()
+              }
+            >
+              {loginLoading ? "Cancel" : "Log In"}
+            </Button>
+          )}
           <Button
             variant="outlined"
             size="regular"
             fullWidth
             className="h-11 text-base"
             onClick={onBack}
+            disabled={loginLoading}
           >
             Back
           </Button>

--- a/apps/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -6,6 +6,7 @@ import { selectPlatformAssistant } from "@/assistant/select-platform-assistant";
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
 import { isPlatformLocal } from "@/lib/auth/loopback-auth";
 import { isLocalMode } from "@/lib/local-mode";
+import { isElectron } from "@/runtime/is-electron";
 import { startAuthFlow } from "@/runtime/native-auth";
 import { useAuthStore, useHasPlatformSession } from "@/stores/auth-store";
 import {
@@ -87,6 +88,15 @@ export function SelectAssistantScreen() {
 
   const onBack = () => {
     void navigate(routes.onboarding.welcome);
+  };
+
+  const handleCancelLogin = () => {
+    loginFlowIdRef.current++;
+    setLoginLoading(false);
+    setError(null);
+    if (isElectron()) {
+      void window.vellum?.auth?.cancelOAuth();
+    }
   };
 
   const handleLogin = async () => {
@@ -187,10 +197,10 @@ export function SelectAssistantScreen() {
               size="regular"
               fullWidth
               className="h-11 text-base"
-              onClick={() => void handleLogin()}
-              disabled={connecting || loginLoading}
+              onClick={loginLoading ? handleCancelLogin : () => void handleLogin()}
+              disabled={connecting}
             >
-              {loginLoading ? "Logging in…" : "Log In"}
+              {loginLoading ? "Cancel" : "Log In"}
             </Button>
           )}
           <Button

--- a/apps/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -191,6 +191,20 @@ export function SelectAssistantScreen() {
               {connecting ? "Connecting…" : "Continue"}
             </Button>
           )}
+          <Button
+            variant="outlined"
+            size="regular"
+            fullWidth
+            className="h-11 text-base"
+            onClick={() =>
+              void navigate(
+                `${routes.onboarding.hosting}?from=select-assistant`,
+              )
+            }
+            disabled={connecting || loginLoading}
+          >
+            Create New Assistant
+          </Button>
           {showLogin && (
             <Button
               variant="outlined"

--- a/apps/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -1,13 +1,10 @@
 import { Cloud, Laptop } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router";
 
 import { selectPlatformAssistant } from "@/assistant/select-platform-assistant";
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
-import { isPlatformLocal } from "@/lib/auth/loopback-auth";
-import { isLocalMode } from "@/lib/local-mode";
-import { isElectron } from "@/runtime/is-electron";
-import { startAuthFlow } from "@/runtime/native-auth";
+import { useOnboardingLogin } from "@/hooks/use-onboarding-login";
 import { useAuthStore, useHasPlatformSession } from "@/stores/auth-store";
 import {
   useResolvedAssistantsStore,
@@ -31,6 +28,12 @@ export function SelectAssistantScreen() {
   const navigate = useNavigate();
   const hasPlatformSession = useHasPlatformSession();
   const assistants = useResolvedAssistantsStore.use.assistants();
+  const {
+    loading: loginLoading,
+    error: loginError,
+    login,
+    cancel: cancelLogin,
+  } = useOnboardingLogin();
 
   const isAccessible = (a: ResolvedAssistant): boolean =>
     a.isLocal || hasPlatformSession;
@@ -43,9 +46,7 @@ export function SelectAssistantScreen() {
   const [selected, setSelected] = useState<string | null>(null);
   const [connecting, setConnecting] = useState(false);
   const [autoSkipping, setAutoSkipping] = useState(false);
-  const [loginLoading, setLoginLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const loginFlowIdRef = useRef(0);
 
   // Default selection to first accessible assistant
   useEffect(() => {
@@ -90,37 +91,10 @@ export function SelectAssistantScreen() {
     void navigate(routes.onboarding.welcome);
   };
 
-  const handleCancelLogin = () => {
-    loginFlowIdRef.current++;
-    setLoginLoading(false);
-    setError(null);
-    if (isElectron()) {
-      void window.vellum?.auth?.cancelOAuth();
-    }
-  };
-
-  const handleLogin = async () => {
-    const returnTo = routes.onboarding.selectAssistant;
-
-    if (isLocalMode() && isPlatformLocal()) {
-      void navigate(`${routes.account.login}?returnTo=${encodeURIComponent(returnTo)}`);
-      return;
-    }
-    const flowId = ++loginFlowIdRef.current;
-    setError(null);
-    setLoginLoading(true);
-    try {
-      const callbackUrl = `${routes.account.providerCallback}?returnTo=${encodeURIComponent(returnTo)}`;
-      await startAuthFlow("workos-oidc", callbackUrl, { returnTo });
-    } catch {
-      if (flowId !== loginFlowIdRef.current) return;
-      setError("Something went wrong. Please try again.");
-      setLoginLoading(false);
-    }
-  };
+  const displayError = loginError ?? error;
 
   // Loading state during auto-skip
-  if (autoSkipping && !error) {
+  if (autoSkipping && !displayError) {
     return (
       <OnboardingLayout>
         <div className="mx-auto flex min-h-screen w-full max-w-xl flex-col items-center justify-center px-6 text-[var(--content-default)]">
@@ -148,9 +122,9 @@ export function SelectAssistantScreen() {
           Select which assistant you&rsquo;d like to use.
         </p>
 
-        {error && (
+        {displayError && (
           <p className="mt-4 text-body-small-default text-[var(--system-negative-strong)]">
-            {error}
+            {displayError}
           </p>
         )}
 
@@ -211,7 +185,7 @@ export function SelectAssistantScreen() {
               size="regular"
               fullWidth
               className="h-11 text-base"
-              onClick={loginLoading ? handleCancelLogin : () => void handleLogin()}
+              onClick={loginLoading ? cancelLogin : () => void login()}
               disabled={connecting}
             >
               {loginLoading ? "Cancel" : "Log In"}

--- a/apps/web/src/domains/onboarding/pages/welcome-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/welcome-screen.tsx
@@ -1,53 +1,17 @@
-import { useRef, useState } from "react";
 import { useNavigate } from "react-router";
 
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
-import { isPlatformLocal } from "@/lib/auth/loopback-auth";
-import { hasAssistants, isLocalMode } from "@/lib/local-mode";
-import { isElectron } from "@/runtime/is-electron";
-import { startAuthFlow } from "@/runtime/native-auth";
+import { useOnboardingLogin } from "@/hooks/use-onboarding-login";
+import { hasAssistants } from "@/lib/local-mode";
 import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
 
 export function WelcomeScreen() {
   const navigate = useNavigate();
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const flowIdRef = useRef(0);
-
-  const handleLogin = async () => {
-    const returnTo = hasAssistants()
-      ? routes.onboarding.selectAssistant
-      : routes.onboarding.hosting;
-
-    if (isLocalMode() && isPlatformLocal()) {
-      void navigate(`${routes.account.login}?returnTo=${encodeURIComponent(returnTo)}`);
-      return;
-    }
-    const flowId = ++flowIdRef.current;
-    setError(null);
-    setLoading(true);
-    try {
-      const callbackUrl = `${routes.account.providerCallback}?returnTo=${encodeURIComponent(returnTo)}`;
-      await startAuthFlow("workos-oidc", callbackUrl, { returnTo });
-    } catch {
-      if (flowId !== flowIdRef.current) return;
-      setError("Something went wrong. Please try again.");
-      setLoading(false);
-    }
-  };
-
-  const handleCancel = () => {
-    flowIdRef.current++;
-    setLoading(false);
-    setError(null);
-    if (isElectron()) {
-      void window.vellum?.auth?.cancelOAuth();
-    }
-  };
+  const { loading, error, login, cancel } = useOnboardingLogin();
 
   const handleContinueWithoutAccount = () => {
-    if (loading) handleCancel();
+    if (loading) cancel();
     if (hasAssistants()) {
       void navigate(routes.onboarding.selectAssistant);
     } else {
@@ -87,7 +51,7 @@ export function WelcomeScreen() {
               size="regular"
               fullWidth
               className="h-11 text-base"
-              onClick={loading ? handleCancel : () => void handleLogin()}
+              onClick={loading ? cancel : () => void login()}
             >
               {loading ? "Cancel" : "Log In"}
             </Button>

--- a/apps/web/src/hooks/use-onboarding-login.ts
+++ b/apps/web/src/hooks/use-onboarding-login.ts
@@ -1,0 +1,56 @@
+import { useRef, useState } from "react";
+import { useLocation, useNavigate } from "react-router";
+
+import { isPlatformLocal } from "@/lib/auth/loopback-auth";
+import { isLocalMode } from "@/lib/local-mode";
+import { buildNavigationState } from "@/lib/navigation/build-state";
+import { resolveLoginReturnTo } from "@/lib/navigation/navigation-resolver";
+import { isElectron } from "@/runtime/is-electron";
+import { startAuthFlow } from "@/runtime/native-auth";
+import { routes } from "@/utils/routes";
+
+export function useOnboardingLogin(returnToOverride?: string) {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const flowIdRef = useRef(0);
+
+  const login = async () => {
+    const returnTo =
+      returnToOverride ??
+      resolveLoginReturnTo(
+        buildNavigationState({ sessionSettled: true, isAuthenticated: true }),
+        location.pathname,
+      );
+
+    if (isLocalMode() && isPlatformLocal()) {
+      void navigate(
+        `${routes.account.login}?returnTo=${encodeURIComponent(returnTo)}`,
+      );
+      return;
+    }
+    const flowId = ++flowIdRef.current;
+    setError(null);
+    setLoading(true);
+    try {
+      const callbackUrl = `${routes.account.providerCallback}?returnTo=${encodeURIComponent(returnTo)}`;
+      await startAuthFlow("workos-oidc", callbackUrl, { returnTo });
+    } catch {
+      if (flowId !== flowIdRef.current) return;
+      setError("Something went wrong. Please try again.");
+      setLoading(false);
+    }
+  };
+
+  const cancel = () => {
+    flowIdRef.current++;
+    setLoading(false);
+    setError(null);
+    if (isElectron()) {
+      void window.vellum?.auth?.cancelOAuth();
+    }
+  };
+
+  return { loading, error, login, cancel };
+}

--- a/apps/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/apps/web/src/lib/navigation/navigation-resolver.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect } from "bun:test";
 
 import {
   resolveNavigation,
+  resolveLoginReturnTo,
   type NavigationState,
   type NavigationDecision,
 } from "./navigation-resolver";
@@ -434,6 +435,32 @@ describe("resolveNavigation", () => {
         action: "redirect",
         to: "/assistant",
       });
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // resolveLoginReturnTo
+  // -----------------------------------------------------------------------
+  describe("resolveLoginReturnTo", () => {
+    test("returns select-assistant from welcome when assistants exist", () => {
+      expect(
+        resolveLoginReturnTo(s({ hasAssistants: true }), "/assistant/onboarding/welcome"),
+      ).toBe("/assistant/onboarding/select-assistant");
+    });
+
+    test("returns hosting from welcome when no assistants", () => {
+      expect(
+        resolveLoginReturnTo(s({ hasAssistants: false }), "/assistant/onboarding/hosting"),
+      ).toBe("/assistant/onboarding/hosting");
+    });
+
+    test("returns the same path for non-welcome pages", () => {
+      expect(
+        resolveLoginReturnTo(s({}), "/assistant/onboarding/select-assistant"),
+      ).toBe("/assistant/onboarding/select-assistant");
+      expect(
+        resolveLoginReturnTo(s({}), "/assistant/onboarding/hosting"),
+      ).toBe("/assistant/onboarding/hosting");
     });
   });
 });

--- a/apps/web/src/lib/navigation/navigation-resolver.ts
+++ b/apps/web/src/lib/navigation/navigation-resolver.ts
@@ -79,6 +79,22 @@ function extractPathname(destination: string): string {
 }
 
 // ---------------------------------------------------------------------------
+// Login return-to
+// ---------------------------------------------------------------------------
+
+export function resolveLoginReturnTo(
+  state: NavigationState,
+  fromPath: string,
+): string {
+  if (fromPath === routes.onboarding.welcome) {
+    return state.hasAssistants
+      ? routes.onboarding.selectAssistant
+      : routes.onboarding.hosting;
+  }
+  return fromPath;
+}
+
+// ---------------------------------------------------------------------------
 // Core resolver
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Add `handleCancelLogin` to the select-assistant screen, mirroring the welcome screen's cancellation pattern (invalidate flow ID, reset state, call `cancelOAuth` in Electron)
- Change the login button from a disabled "Logging in…" state to a clickable "Cancel" button during active login flows

## Original prompt
The "Choose an Assistant" onboarding screen showed a disabled "Logging in…" button during OAuth login with no way to cancel. The user asked to add login cancellation support matching the pattern already used on `/onboarding/welcome`, where the button toggles between "Log In" and "Cancel".