### PR TITLE
Show tailored notice when auto-reload was disabled after repeated declines

### DIFF
--- a/apps/web/src/domains/settings/components/auto-top-up-card.test.tsx
+++ b/apps/web/src/domains/settings/components/auto-top-up-card.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * Tests for the AutoTopUpCard repeated-decline cutoff notice: when the backend
+ * reports `disabled_due_to_repeated_failures`, the card renders a tailored
+ * warning telling the user to add a new payment method; a normally-disabled
+ * config renders no such notice.
+ *
+ * Strategy: pre-populate the React Query cache so the card's `useQuery` resolves
+ * synchronously — `renderToStaticMarkup` is single-pass, so a pending query
+ * would otherwise report `isLoading` and render the spinner.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { organizationsBillingAutoTopUpRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
+import type { AutoTopUpConfigResponse } from "@/generated/api/types.gen";
+
+import { AutoTopUpCard, DISABLED_CONFIG } from "./auto-top-up-card";
+
+function renderCard(config: AutoTopUpConfigResponse): string {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  client.setQueryData(
+    organizationsBillingAutoTopUpRetrieveQueryKey(),
+    config,
+  );
+  return renderToStaticMarkup(
+    <QueryClientProvider client={client}>
+      <AutoTopUpCard />
+    </QueryClientProvider>,
+  );
+}
+
+describe("AutoTopUpCard repeated-decline cutoff notice", () => {
+  test("renders the cutoff notice when disabled after repeated declines", () => {
+    const html = renderCard({
+      ...DISABLED_CONFIG,
+      has_payment_method: false,
+      disabled_due_to_repeated_failures: true,
+    });
+    expect(html).toContain("auto-top-up-declined-cutoff");
+    expect(html).toContain("We paused automatic reloads after several declined");
+  });
+
+  test("does not render the cutoff notice for a normally-disabled config", () => {
+    const html = renderCard({
+      ...DISABLED_CONFIG,
+      has_payment_method: false,
+      disabled_due_to_repeated_failures: false,
+    });
+    expect(html).not.toContain("auto-top-up-declined-cutoff");
+  });
+});

--- a/apps/web/src/domains/settings/components/auto-top-up-card.tsx
+++ b/apps/web/src/domains/settings/components/auto-top-up-card.tsx
@@ -169,6 +169,10 @@ export function AutoTopUpCard() {
 
   const config = configQuery.data;
   const enabled = config.enabled === true;
+  // The backend pauses auto-reload after several declined charges and flips
+  // this flag (it's reset once a fresh PM is attached). When set, the card
+  // shows a tailored explanation instead of the generic add-PM gate copy.
+  const disabledAfterDeclines = config.disabled_due_to_repeated_failures === true;
 
   /**
    * Transition into form mode. Resets any prior mutation errors so stale
@@ -383,9 +387,23 @@ export function AutoTopUpCard() {
         )}
       </div>
 
+      {disabledAfterDeclines && (
+        <Notice
+          tone="warning"
+          className="mt-3"
+          data-testid="auto-top-up-declined-cutoff"
+        >
+          We paused automatic reloads after several declined payments. Add a new
+          payment method below to turn auto-reload back on.
+        </Notice>
+      )}
+
       <div
         className="grid transition-[grid-template-rows] duration-200 ease-in-out"
-        style={{ gridTemplateRows: showNoPmNotice ? "1fr" : "0fr" }}
+        style={{
+          gridTemplateRows:
+            showNoPmNotice && !disabledAfterDeclines ? "1fr" : "0fr",
+        }}
       >
         <div className="overflow-hidden">
           <Notice tone="warning" className="mt-3">


### PR DESCRIPTION
## Summary
- Render a tailored warning in the auto-reload card when the backend reports auto top-up was disabled after repeated card declines (disabled_due_to_repeated_failures), telling the user to add a new payment method.
- Suppress the generic add-PM gate copy in that state to avoid conflicting notices.
- Add a component test covering the true/false cases.

Part of plan: cap-auto-top-up-retries-ui.md (PR 2 of 2)