### PR TITLE
fix(macos): use env-specific userData path for packaged builds

### DIFF
--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -79,6 +79,20 @@ if (!app.isPackaged) {
 }
 const isDev = !app.isPackaged;
 
+// Packaged builds all share the same package.json `name` (`@vellumai/macos`),
+// so Electron resolves `app.getPath("userData")` to the same directory for
+// every environment. This causes `requestSingleInstanceLock()` collisions
+// when multiple environment builds (dev, staging, production) run side-by-side.
+// Append an environment suffix for non-production builds; production keeps the
+// original path for backwards compatibility.
+if (app.isPackaged) {
+  const env = process.env.VELLUM_ENVIRONMENT || "production";
+  if (env !== "production") {
+    const base = app.getPath("userData");
+    app.setPath("userData", `${base}-${env}`);
+  }
+}
+
 // Single-instance lock: relaunches focus the existing window instead of
 // spawning a parallel main process. The second-instance handler fires on the
 // instance that holds the lock (the primary). The instance that fails to

--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -85,8 +85,12 @@ const isDev = !app.isPackaged;
 // when multiple environment builds (dev, staging, production) run side-by-side.
 // Append an environment suffix for non-production builds; production keeps the
 // original path for backwards compatibility.
+declare const __VELLUM_ENVIRONMENT__: string;
 if (app.isPackaged) {
-  const env = process.env.VELLUM_ENVIRONMENT || "production";
+  const env =
+    typeof __VELLUM_ENVIRONMENT__ === "string"
+      ? __VELLUM_ENVIRONMENT__
+      : "production";
   if (env !== "production") {
     const base = app.getPath("userData");
     app.setPath("userData", `${base}-${env}`);


### PR DESCRIPTION
## Summary
- Packaged Electron builds (dev, staging, local, production) all shared the same `@vellumai/macos` userData directory because Electron derives it from the `package.json` name, which is identical across environments
- When multiple environment builds run side-by-side, `requestSingleInstanceLock()` collides and the second instance silently quits with exit code 0 — no crash, no logs, no error
- Non-production packaged builds now append an environment suffix to the userData path (e.g., `@vellumai/macos-staging`). Production keeps the original path for backwards compatibility

## Original prompt
The staging DMG build of the Electron app was silently failing to start when the installed Dev build was already running. Investigation revealed all packaged builds share the same userData directory (`~/Library/Application Support/@vellumai/macos/`), causing Electron's single-instance lock to collide. The fix gates the userData path on `VELLUM_ENVIRONMENT`, appending a suffix for non-production builds while keeping production's path unchanged for backwards compatibility.