### PR TITLE
Cap Auto Top-Up Retries — Frontend Notice (ATL-798, companion)

### DIFF
--- a/apps/web/src/domains/settings/components/auto-top-up-card.test.tsx
+++ b/apps/web/src/domains/settings/components/auto-top-up-card.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * Tests for the AutoTopUpCard repeated-decline cutoff notice: when the backend
+ * reports `disabled_due_to_repeated_failures`, the card renders a tailored
+ * warning telling the user to add a new payment method; a normally-disabled
+ * config renders no such notice.
+ *
+ * Strategy: pre-populate the React Query cache so the card's `useQuery` resolves
+ * synchronously — `renderToStaticMarkup` is single-pass, so a pending query
+ * would otherwise report `isLoading` and render the spinner.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { organizationsBillingAutoTopUpRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
+import type { AutoTopUpConfigResponse } from "@/generated/api/types.gen";
+
+import { AutoTopUpCard, DISABLED_CONFIG } from "./auto-top-up-card";
+
+function renderCard(config: AutoTopUpConfigResponse): string {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  client.setQueryData(
+    organizationsBillingAutoTopUpRetrieveQueryKey(),
+    config,
+  );
+  return renderToStaticMarkup(
+    <QueryClientProvider client={client}>
+      <AutoTopUpCard />
+    </QueryClientProvider>,
+  );
+}
+
+describe("AutoTopUpCard repeated-decline cutoff notice", () => {
+  test("renders the cutoff notice when disabled after repeated declines", () => {
+    const html = renderCard({
+      ...DISABLED_CONFIG,
+      has_payment_method: false,
+      disabled_due_to_repeated_failures: true,
+    });
+    expect(html).toContain("auto-top-up-declined-cutoff");
+    expect(html).toContain("We paused automatic reloads after several declined");
+  });
+
+  test("does not render the cutoff notice for a normally-disabled config", () => {
+    const html = renderCard({
+      ...DISABLED_CONFIG,
+      has_payment_method: false,
+      disabled_due_to_repeated_failures: false,
+    });
+    expect(html).not.toContain("auto-top-up-declined-cutoff");
+  });
+});

--- a/apps/web/src/domains/settings/components/auto-top-up-card.test.tsx
+++ b/apps/web/src/domains/settings/components/auto-top-up-card.test.tsx
@@ -1,16 +1,24 @@
 /**
- * Tests for the AutoTopUpCard repeated-decline cutoff notice: when the backend
- * reports `disabled_due_to_repeated_failures`, the card renders a tailored
- * warning telling the user to add a new payment method; a normally-disabled
- * config renders no such notice.
+ * Tests for the AutoTopUpCard repeated-decline cutoff notice and its enable
+ * gate:
+ *  - When the backend reports `disabled_due_to_repeated_failures` on a disabled
+ *    config, the card renders a tailored warning telling the user to add a new
+ *    payment method; a normally-disabled config renders no such notice.
+ *  - The cutoff notice is suppressed when the config is `enabled` (defensive
+ *    guard against contradictory copy from a raced/stale response).
+ *  - Toggling Enable on while the cutoff flag is set (even with a saved PM)
+ *    does NOT open the form — the user can't re-enable with the cut-off card.
  *
- * Strategy: pre-populate the React Query cache so the card's `useQuery` resolves
- * synchronously — `renderToStaticMarkup` is single-pass, so a pending query
- * would otherwise report `isLoading` and render the spinner.
+ * Strategy: the render-only cases pre-populate the React Query cache so the
+ * card's `useQuery` resolves synchronously — `renderToStaticMarkup` is
+ * single-pass, so a pending query would otherwise report `isLoading` and render
+ * the spinner. The enable-gate case needs a real DOM to drive a click, so it
+ * uses @testing-library/react (happy-dom is registered via the test preload).
  */
 
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import { organizationsBillingAutoTopUpRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
@@ -18,16 +26,17 @@ import type { AutoTopUpConfigResponse } from "@/generated/api/types.gen";
 
 import { AutoTopUpCard, DISABLED_CONFIG } from "./auto-top-up-card";
 
-function renderCard(config: AutoTopUpConfigResponse): string {
+function makeClient(config: AutoTopUpConfigResponse): QueryClient {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
-  client.setQueryData(
-    organizationsBillingAutoTopUpRetrieveQueryKey(),
-    config,
-  );
+  client.setQueryData(organizationsBillingAutoTopUpRetrieveQueryKey(), config);
+  return client;
+}
+
+function renderCard(config: AutoTopUpConfigResponse): string {
   return renderToStaticMarkup(
-    <QueryClientProvider client={client}>
+    <QueryClientProvider client={makeClient(config)}>
       <AutoTopUpCard />
     </QueryClientProvider>,
   );
@@ -51,5 +60,97 @@ describe("AutoTopUpCard repeated-decline cutoff notice", () => {
       disabled_due_to_repeated_failures: false,
     });
     expect(html).not.toContain("auto-top-up-declined-cutoff");
+  });
+
+  test("suppresses the cutoff notice when the config is enabled", () => {
+    // Defensive guard (Finding 2): the backend treats the cutoff as terminal
+    // (cutoff ⇒ enabled=false), but if a raced/stale response carried both
+    // `enabled: true` and the flag, the enabled summary and the cutoff notice
+    // must stay mutually exclusive — show the summary, not the contradictory
+    // "we paused reloads" copy.
+    const html = renderCard({
+      ...DISABLED_CONFIG,
+      enabled: true,
+      threshold_usd: "50.00",
+      amount_usd: "200.00",
+      has_payment_method: true,
+      disabled_due_to_repeated_failures: true,
+    });
+    expect(html).not.toContain("auto-top-up-declined-cutoff");
+    expect(html).toContain("auto-top-up-summary");
+  });
+
+  test("renders the cutoff notice (not the enabled summary) when cut off with a saved PM", () => {
+    // Finding 1 state: the saved card is still on file (`has_payment_method:
+    // true`) but the backend cut auto-reload off after repeated declines. The
+    // cutoff notice is the single message; the enabled summary is absent.
+    const html = renderCard({
+      ...DISABLED_CONFIG,
+      enabled: false,
+      has_payment_method: true,
+      disabled_due_to_repeated_failures: true,
+    });
+    expect(html).toContain("auto-top-up-declined-cutoff");
+    expect(html).not.toContain("auto-top-up-summary");
+  });
+});
+
+describe("AutoTopUpCard enable gate", () => {
+  afterEach(cleanup);
+
+  test("toggling Enable on while cut off (with a saved PM) does not open the form", () => {
+    // Finding 1: even though a PM is on file, the repeated-decline cutoff must
+    // block re-enabling with the same cut-off card. The toggle must not enter
+    // form mode (no AutoTopUpForm / Save button), and the cutoff notice stays.
+    const config: AutoTopUpConfigResponse = {
+      ...DISABLED_CONFIG,
+      enabled: false,
+      has_payment_method: true,
+      disabled_due_to_repeated_failures: true,
+    };
+
+    const { container, getByLabelText } = render(
+      <QueryClientProvider client={makeClient(config)}>
+        <AutoTopUpCard />
+      </QueryClientProvider>,
+    );
+    const form = () =>
+      container.querySelector('[data-testid="auto-top-up-save-button"]');
+
+    // The form is not present before the click.
+    expect(form()).toBeNull();
+
+    fireEvent.click(getByLabelText("Enable Auto-Reload"));
+
+    // The enable gate tripped: still no form, and the cutoff notice persists.
+    expect(form()).toBeNull();
+    expect(
+      container.querySelector('[data-testid="auto-top-up-declined-cutoff"]'),
+    ).not.toBeNull();
+  });
+
+  test("toggling Enable on with a saved PM and no cutoff opens the form", () => {
+    // Control case: without the cutoff flag, a saved PM lets the user enter the
+    // configure form — confirms the gate only blocks the cut-off state.
+    const config: AutoTopUpConfigResponse = {
+      ...DISABLED_CONFIG,
+      enabled: false,
+      has_payment_method: true,
+      disabled_due_to_repeated_failures: false,
+    };
+
+    const { container, getByLabelText } = render(
+      <QueryClientProvider client={makeClient(config)}>
+        <AutoTopUpCard />
+      </QueryClientProvider>,
+    );
+    const form = () =>
+      container.querySelector('[data-testid="auto-top-up-save-button"]');
+
+    expect(form()).toBeNull();
+
+    fireEvent.click(getByLabelText("Enable Auto-Reload"));
+
+    expect(form()).not.toBeNull();
   });
 });

--- a/apps/web/src/domains/settings/components/auto-top-up-card.tsx
+++ b/apps/web/src/domains/settings/components/auto-top-up-card.tsx
@@ -172,7 +172,17 @@ export function AutoTopUpCard() {
   // The backend pauses auto-reload after several declined charges and flips
   // this flag (it's reset once a fresh PM is attached). When set, the card
   // shows a tailored explanation instead of the generic add-PM gate copy.
-  const disabledAfterDeclines = config.disabled_due_to_repeated_failures === true;
+  //
+  // Guard on `!enabled` as well: the backend treats the cutoff as terminal
+  // (cutoff ⇒ enabled=false), but if a stale/raced response ever carried both
+  // `enabled: true` and the flag, we'd otherwise render the enabled summary
+  // ("Add $X when balance falls under $Y") next to the "we paused reloads"
+  // notice — contradictory copy. Folding `!enabled` in keeps the enabled
+  // summary and the cutoff notice mutually exclusive. The enable gate in
+  // `handleToggleChange` still trips correctly because that path only runs
+  // while the config is currently disabled (`if (next && !enabled)`).
+  const disabledAfterDeclines =
+    config.disabled_due_to_repeated_failures === true && !enabled;
 
   /**
    * Transition into form mode. Resets any prior mutation errors so stale
@@ -314,8 +324,17 @@ export function AutoTopUpCard() {
    */
   const handleToggleChange = (next: boolean) => {
     if (next && !enabled) {
-      if (!config.has_payment_method) {
-        // Block enable — PM must be added in the Payment Methods card.
+      if (!config.has_payment_method || disabledAfterDeclines) {
+        // Block enable — either no PM on file, or the backend cut auto-reload
+        // off after repeated declines. In the cutoff case the saved card is
+        // still attached (`has_payment_method: true`), so without this guard
+        // the user could re-enable with the SAME declined card, contradicting
+        // the cutoff notice that tells them to add a NEW payment method. The
+        // generic add-PM notice this sets is suppressed in the render while
+        // `disabledAfterDeclines` is true (the grid is gated on
+        // `showNoPmNotice && !disabledAfterDeclines`), so the cutoff notice
+        // stays the single message — keeping the two notices mutually
+        // exclusive.
         setShowNoPmNotice(true);
         return;
       }

--- a/apps/web/src/domains/settings/components/auto-top-up-card.tsx
+++ b/apps/web/src/domains/settings/components/auto-top-up-card.tsx
@@ -169,6 +169,10 @@ export function AutoTopUpCard() {
 
   const config = configQuery.data;
   const enabled = config.enabled === true;
+  // The backend pauses auto-reload after several declined charges and flips
+  // this flag (it's reset once a fresh PM is attached). When set, the card
+  // shows a tailored explanation instead of the generic add-PM gate copy.
+  const disabledAfterDeclines = config.disabled_due_to_repeated_failures === true;
 
   /**
    * Transition into form mode. Resets any prior mutation errors so stale
@@ -383,9 +387,23 @@ export function AutoTopUpCard() {
         )}
       </div>
 
+      {disabledAfterDeclines && (
+        <Notice
+          tone="warning"
+          className="mt-3"
+          data-testid="auto-top-up-declined-cutoff"
+        >
+          We paused automatic reloads after several declined payments. Add a new
+          payment method below to turn auto-reload back on.
+        </Notice>
+      )}
+
       <div
         className="grid transition-[grid-template-rows] duration-200 ease-in-out"
-        style={{ gridTemplateRows: showNoPmNotice ? "1fr" : "0fr" }}
+        style={{
+          gridTemplateRows:
+            showNoPmNotice && !disabledAfterDeclines ? "1fr" : "0fr",
+        }}
       >
         <div className="overflow-hidden">
           <Notice tone="warning" className="mt-3">


### PR DESCRIPTION
## Summary
Surfaces a tailored notice in the Settings → Billing auto-reload card when the backend reports auto top-up was disabled after repeated card declines (`disabled_due_to_repeated_failures`), so a cut-off user understands *why* and is told to add a new payment method — instead of only seeing the generic "add a Payment Method" gate. Messaging polish; the existing enable-toggle gate already enforces the safety behavior.

## Self-review result
PASS — all 4 self-review passes (external feedback, plan faithfulness, integration, slop/reuse) found no gaps. 0 fix PRs.

## PRs merged into feature branch
- #33902: Show tailored notice when auto-reload was disabled after repeated declines (card + component test)

## Notes
- Plan PR 1 ("sync generated OpenAPI client") was a no-op in this repo: `apps/web/src/generated/` is gitignored and regenerated on demand (`bun run openapi-ts` via the `pretypecheck`/`predev` hooks). The schema `apps/web/openapi-schemas/platform.yaml` already carries the `disabled_due_to_repeated_failures` field, so `AutoTopUpConfigResponse` gains it automatically at codegen — nothing to commit.
- Non-blocking: the cutoff notice gates purely on the backend boolean (no `enabled` guard), correct under the contract that a decline-cutoff config is `enabled=false`.

Part of plan: cap-auto-top-up-retries-ui.md