### PR TITLE
fix(web): skip onboarding hatching for returning users with existing assistant

### DIFF
--- a/apps/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -21,6 +21,7 @@ import {
 import { useIsNativePlatform } from "@/runtime/native-auth";
 import { useAuthStore } from "@/stores/auth-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
+import { sanitizeReturnTo } from "@/domains/account/return-to";
 import { legalUrl, routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
 import { Card } from "@vellumai/design-library/components/card";
@@ -100,6 +101,15 @@ export function PrivacyScreen() {
         variant,
       });
     }
+    // If the caller told us where to go after consent, go there instead of
+    // hatching a new assistant (e.g. returning user whose consent flags were
+    // cleared on logout).
+    const returnTo = sanitizeReturnTo(searchParams.get("returnTo"), "");
+    if (returnTo) {
+      void navigate(returnTo, { replace: true });
+      return;
+    }
+
     // Preserve the hosting param (Local/Docker need it so hatching runs the
     // local hatch instead of a platform hatch).
     const hostingParam = searchParams.get("hosting");

--- a/apps/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -21,7 +21,6 @@ import {
 import { useIsNativePlatform } from "@/runtime/native-auth";
 import { useAuthStore } from "@/stores/auth-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
-import { sanitizeReturnTo } from "@/domains/account/return-to";
 import { legalUrl, routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
 import { Card } from "@vellumai/design-library/components/card";
@@ -104,8 +103,8 @@ export function PrivacyScreen() {
     // If the caller told us where to go after consent, go there instead of
     // hatching a new assistant (e.g. returning user whose consent flags were
     // cleared on logout).
-    const returnTo = sanitizeReturnTo(searchParams.get("returnTo"), "");
-    if (returnTo) {
+    const returnTo = searchParams.get("returnTo");
+    if (returnTo && returnTo.startsWith("/") && !returnTo.startsWith("//")) {
       void navigate(returnTo, { replace: true });
       return;
     }

--- a/apps/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/apps/web/src/lib/navigation/navigation-resolver.test.ts
@@ -224,6 +224,12 @@ describe("resolveNavigation", () => {
       ).toEqual({ action: "redirect", to: "/assistant/onboarding/privacy?returnTo=%2Fassistant" });
     });
 
+    test("redirects platform-mode user without consent and no assistants to privacy without returnTo", () => {
+      expect(
+        guard(s({ isLocalMode: false, tosAccepted: false, aiDataConsent: false, hasAssistants: false })),
+      ).toEqual({ action: "redirect", to: "/assistant/onboarding/privacy" });
+    });
+
     test("does not redirect local-mode user without consent (handled by step 5)", () => {
       expect(
         guard(s({ isLocalMode: true, hasAssistants: true, tosAccepted: false, aiDataConsent: false })),

--- a/apps/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/apps/web/src/lib/navigation/navigation-resolver.test.ts
@@ -212,16 +212,16 @@ describe("resolveNavigation", () => {
 
     // -- authenticated, platform mode, not onboarded ----------------------
 
-    test("redirects platform-mode user without consent to privacy", () => {
+    test("redirects platform-mode user without consent to privacy with returnTo", () => {
       expect(
         guard(s({ isLocalMode: false, tosAccepted: false, aiDataConsent: false })),
-      ).toEqual({ action: "redirect", to: "/assistant/onboarding/privacy" });
+      ).toEqual({ action: "redirect", to: "/assistant/onboarding/privacy?returnTo=%2Fassistant" });
     });
 
-    test("redirects platform-mode user with partial consent to privacy", () => {
+    test("redirects platform-mode user with partial consent to privacy with returnTo", () => {
       expect(
         guard(s({ isLocalMode: false, tosAccepted: true, aiDataConsent: false })),
-      ).toEqual({ action: "redirect", to: "/assistant/onboarding/privacy" });
+      ).toEqual({ action: "redirect", to: "/assistant/onboarding/privacy?returnTo=%2Fassistant" });
     });
 
     test("does not redirect local-mode user without consent (handled by step 5)", () => {

--- a/apps/web/src/lib/navigation/navigation-resolver.ts
+++ b/apps/web/src/lib/navigation/navigation-resolver.ts
@@ -180,8 +180,11 @@ function resolveRouteGuard(
 
   // 6. Authenticated, platform mode, onboarding not completed
   if (!state.isLocalMode && !(state.tosAccepted && state.aiDataConsent)) {
-    const returnTo = encodeURIComponent(pathnameWithSearch);
-    return { action: "redirect", to: `${routes.onboarding.privacy}?returnTo=${returnTo}` };
+    if (state.hasAssistants) {
+      const returnTo = encodeURIComponent(pathnameWithSearch);
+      return { action: "redirect", to: `${routes.onboarding.privacy}?returnTo=${returnTo}` };
+    }
+    return { action: "redirect", to: routes.onboarding.privacy };
   }
 
   // 7. All clear

--- a/apps/web/src/lib/navigation/navigation-resolver.ts
+++ b/apps/web/src/lib/navigation/navigation-resolver.ts
@@ -180,7 +180,8 @@ function resolveRouteGuard(
 
   // 6. Authenticated, platform mode, onboarding not completed
   if (!state.isLocalMode && !(state.tosAccepted && state.aiDataConsent)) {
-    return { action: "redirect", to: routes.onboarding.privacy };
+    const returnTo = encodeURIComponent(pathnameWithSearch);
+    return { action: "redirect", to: `${routes.onboarding.privacy}?returnTo=${returnTo}` };
   }
 
   // 7. All clear


### PR DESCRIPTION
## Summary
- The route guard now passes a `returnTo` query param when redirecting platform-mode users without consent to `/onboarding/privacy`
- The privacy screen respects `returnTo` after consent — navigates back to the original destination instead of always entering the hatching flow
- Returning users whose consent flags were cleared on logout are now sent straight back to `/assistant` after re-consenting, instead of being forced through the hatching/onboarding flow again

## Test plan
- [ ] Log out and back in as a platform user with an existing assistant — after consenting on the privacy screen, verify you're taken to `/assistant` (not hatching)
- [ ] Sign up as a new user — verify the full onboarding flow (privacy → hatching → prechat) still works
- [ ] Verify navigation-resolver tests pass (`bun test src/lib/navigation/navigation-resolver.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)