### PR TITLE
Resolve ACP adapters via sandboxed bun install, never in the task cwd (ATL-808)

### DIFF
--- a/assistant/src/acp/__tests__/helpers/exec-file-stub.ts
+++ b/assistant/src/acp/__tests__/helpers/exec-file-stub.ts
@@ -1,11 +1,15 @@
 /**
  * Shared test helper: stub `execFile` from `node:child_process` for ACP tests.
  *
- * Several ACP suites (the `acp_spawn` tool's version probes, the adapter
- * auto-installer, and the `/v1/acp/spawn` route) shell out via
- * `execFileWithTimeout`. Each test file used to duplicate the same
- * `mock.module("node:child_process", ...)` + scripted-responses boilerplate;
- * this helper consolidates it, mirroring `which-stub.ts`.
+ * Several ACP suites (the adapter auto-installer and the `/v1/acp/spawn`
+ * route) shell out via `execFileWithTimeout` (e.g. `bun add --global`). Each
+ * test file used to duplicate the same `mock.module("node:child_process",
+ * ...)` + scripted-responses boilerplate; this helper consolidates it,
+ * mirroring `which-stub.ts`.
+ *
+ * The mock records every call's args, INCLUDING the options object (cwd, env,
+ * ...) at `execFileMock.mock.calls[i][2]`, so tests can assert the installer's
+ * sandboxed cwd and sanitized env.
  *
  * Like the other helpers here, the hook is process-global by design (Bun's
  * `mock.module` is process-global). Each test file should call
@@ -45,8 +49,9 @@ type ExecFileMock = ReturnType<
 export interface ExecFileStubHandle {
   /**
    * Per-call scripted responses, keyed by `${command} ${args[0]}` so tests
-   * can target `npm ls`, `npm view`, and `npm i` independently. Calls with
-   * no script reject with a recognizable "No script for <key>" error.
+   * can target distinct subcommands (e.g. `<bunPath> add`) independently.
+   * Calls with no script reject with a recognizable "No script for <key>"
+   * error.
    */
   execScripts: Map<string, ExecScript>;
   execFileMock: ExecFileMock;

--- a/assistant/src/acp/__tests__/prepare-agent-env.test.ts
+++ b/assistant/src/acp/__tests__/prepare-agent-env.test.ts
@@ -216,22 +216,6 @@ describe("prepareAgentEnv — claude-agent-acp gating", () => {
     expect(prepared.env?.CLAUDE_CODE_OAUTH_TOKEN).toBe("vault-FFF");
   });
 
-  test("injects the token for the bunx-rewritten claude adapter (adapterCommand gate)", async () => {
-    // The resolver rewrites a missing claude-agent-acp binary to run via
-    // `bun x --bun <pkg>` and preserves the canonical identity on
-    // `adapterCommand`. Without this gate, bunx-resolved spawns would start
-    // with no auth and die as zombies on the first prompt.
-    seedVaultToken("vault-bunx");
-
-    const prepared = await prepareAgentEnv({
-      command: "bun",
-      args: ["x", "--bun", "@agentclientprotocol/claude-agent-acp"],
-      adapterCommand: "claude-agent-acp",
-    });
-
-    expect(prepared.env?.CLAUDE_CODE_OAUTH_TOKEN).toBe("vault-bunx");
-  });
-
   test("does NOT mutate the caller's agentConfig", async () => {
     seedVaultToken("vault-GGG");
     const original = {
@@ -274,18 +258,6 @@ describe("prepareAgentEnv - gemini gating", () => {
     const meta = metadataStore.get("acp/gemini_api_key");
     expect(meta).toBeDefined();
     expect(meta!.allowedTools).toContain("acp_spawn");
-  });
-
-  test("injects the key for the bunx-rewritten gemini CLI (adapterCommand gate)", async () => {
-    seedVaultGeminiKey("vault-gem-bunx");
-
-    const prepared = await prepareAgentEnv({
-      command: "bun",
-      args: ["x", "--bun", "@google/gemini-cli", "--acp"],
-      adapterCommand: "gemini",
-    });
-
-    expect(prepared.env?.GEMINI_API_KEY).toBe("vault-gem-bunx");
   });
 
   test("a vault miss does NOT throw and spawns without GEMINI_API_KEY (key is optional)", async () => {
@@ -364,18 +336,6 @@ describe("prepareAgentEnv — non-claude commands", () => {
     const prepared = await prepareAgentEnv({
       command: "codex-acp",
       args: [],
-    });
-
-    expect(prepared.env).toEqual({});
-  });
-
-  test("no injection for a bunx-rewritten non-claude adapter", async () => {
-    seedVaultToken("vault-should-not-leak");
-
-    const prepared = await prepareAgentEnv({
-      command: "bun",
-      args: ["x", "--bun", "@zed-industries/codex-acp"],
-      adapterCommand: "codex-acp",
     });
 
     expect(prepared.env).toEqual({});

--- a/assistant/src/acp/__tests__/session-manager-resume.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-resume.test.ts
@@ -52,7 +52,6 @@ class FakeAcpAgentProcess {
     public readonly config: {
       command: string;
       args: string[];
-      adapterCommand?: string;
     },
     private readonly clientFactory: (agent: unknown) => FakeClient,
   ) {
@@ -138,7 +137,7 @@ mock.module("../prepare-agent-env.js", () => ({
 type ResolveResult =
   | {
       ok: true;
-      agent: { command: string; args: string[]; adapterCommand?: string };
+      agent: { command: string; args: string[] };
     }
   | { ok: false; reason: "binary_not_found"; hint: string; command: string };
 let resolveImpl: (id: string) => ResolveResult = () => ({
@@ -329,46 +328,41 @@ describe("AcpSessionManager.resumeFromHistory", () => {
     expect(internals(manager).eventBuffers.has("no-caps-1")).toBe(false);
   });
 
-  test("bunx-rewritten resolver output flows through resume with the canonical adapter command", async () => {
-    // resolveAcpAgent rewrites a missing claude-agent-acp binary to run via
-    // `bun x --bun <pkg>`; resumeFromHistory re-resolves through it, so the
-    // rewritten config must reach the agent process while the SessionEntry
-    // keeps the canonical adapter command (resume hints gate on it).
+  test("re-resolves via resolveAcpAgent: the installed real binary flows through resume", async () => {
+    // resumeFromHistory re-resolves through resolveAcpAgent, so the one-time
+    // sandboxed install performed at spawn time benefits resume too: the
+    // resolver now returns the real installed binary (a full path here), and
+    // the SessionEntry tracks its basename for resume-hint gating.
     fakeCaps.resume = true;
-    insertHistoryRow({ id: "bunx-resume-1" });
+    insertHistoryRow({ id: "installed-resume-1" });
     resolveImpl = () => ({
       ok: true,
       agent: {
-        command: "bun",
-        args: ["x", "--bun", "@agentclientprotocol/claude-agent-acp"],
-        adapterCommand: "claude-agent-acp",
+        command: "/usr/local/bin/claude-agent-acp",
+        args: [],
       },
     });
 
     const manager = new AcpSessionManager(4);
-    await manager.resumeFromHistory("bunx-resume-1", () => {});
+    await manager.resumeFromHistory("installed-resume-1", () => {});
 
     const fake = fakeInstances[0]!;
-    expect(fake.config.command).toBe("bun");
-    expect(fake.config.args).toEqual([
-      "x",
-      "--bun",
-      "@agentclientprotocol/claude-agent-acp",
-    ]);
+    expect(fake.config.command).toBe("/usr/local/bin/claude-agent-acp");
     expect(fake.resumeSessionCalls).toEqual([
       { sessionId: "proto-old", cwd: "/tmp/proj" },
     ]);
+    // The SessionEntry command is the basename (resume hints gate on it).
     expect(
-      internals(manager).sessions.get("bunx-resume-1")!.command,
+      internals(manager).sessions.get("installed-resume-1")!.command,
     ).toBe("claude-agent-acp");
   });
 
-  test("resolver failures surface the actionable hint", async () => {
+  test("missing binary on resume surfaces the actionable bun install hint", async () => {
     insertHistoryRow({ id: "no-bin-1" });
     resolveImpl = () => ({
       ok: false,
       reason: "binary_not_found",
-      hint: "npm i -g @agentclientprotocol/claude-agent-acp",
+      hint: "bun add -g @agentclientprotocol/claude-agent-acp",
       command: "claude-agent-acp",
     });
 
@@ -376,7 +370,7 @@ describe("AcpSessionManager.resumeFromHistory", () => {
     await expect(
       manager.resumeFromHistory("no-bin-1", () => {}),
     ).rejects.toThrow(
-      "claude-agent-acp is not on PATH. npm i -g @agentclientprotocol/claude-agent-acp",
+      "claude-agent-acp is not on PATH. bun add -g @agentclientprotocol/claude-agent-acp",
     );
   });
 

--- a/assistant/src/acp/__tests__/session-manager-resume.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-resume.test.ts
@@ -9,7 +9,8 @@
  * VellumAcpClientHandler so replay suppression is exercised end to end.
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { tmpdir } from "node:os";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 mock.module("../../util/logger.js", () => ({
   getLogger: () =>
@@ -52,6 +53,7 @@ class FakeAcpAgentProcess {
     public readonly config: {
       command: string;
       args: string[];
+      env?: Record<string, string | undefined>;
     },
     private readonly clientFactory: (agent: unknown) => FakeClient,
   ) {
@@ -122,14 +124,30 @@ mock.module("../agent-process.js", () => ({
   AcpAgentProcess: FakeAcpAgentProcess,
 }));
 
-// Identity env-prep: credential-broker plumbing has its own suite. Tests
-// that need to observe the manager mid-resume (dispose, pending-id
-// visibility) set `prepareAgentEnvGate` to stall the resume here.
+// Env-prep stub: credential-broker plumbing has its own suite. Tests that
+// need to observe the manager mid-resume (dispose, pending-id visibility)
+// set `prepareAgentEnvGate` to stall the resume here. Each resolved command
+// it is called with is recorded so resume tests can assert it ran AFTER
+// resolution (the real helper is the sole token-injection point), and it
+// mirrors that contract by injecting CLAUDE_CODE_OAUTH_TOKEN into the
+// returned config — at spawn time only, never during the auto-install phase.
 let prepareAgentEnvGate: Promise<void> | null = null;
+let prepareAgentEnvCommands: string[] = [];
 mock.module("../prepare-agent-env.js", () => ({
-  prepareAgentEnv: async (agentConfig: unknown) => {
+  prepareAgentEnv: async (agentConfig: {
+    command: string;
+    args: string[];
+    env?: Record<string, string | undefined>;
+  }) => {
     if (prepareAgentEnvGate) await prepareAgentEnvGate;
-    return agentConfig;
+    prepareAgentEnvCommands.push(agentConfig.command);
+    return {
+      ...agentConfig,
+      env: {
+        ...agentConfig.env,
+        CLAUDE_CODE_OAUTH_TOKEN: process.env.CLAUDE_CODE_OAUTH_TOKEN,
+      },
+    };
   },
 }));
 
@@ -150,6 +168,23 @@ mock.module("../resolve-agent.js", () => ({
   resolveAcpAgent: (id: string) => resolveImpl(id),
 }));
 
+// Auto-install stubs: resume now resolves through resolveAgentWithAutoInstall
+// (the same sandboxed `bun` path as spawn), so a binary_not_found resolution
+// reaches `ensureAdapterInstalled`, which probes `bun` via Bun.which and
+// shells out via execFile. Stub both — process-global, installed BEFORE the
+// session-manager (and thus auto-install) module is imported below — so the
+// install is never a real one. Default: bun absent (no install attempted).
+import { installExecFileStub } from "./helpers/exec-file-stub.js";
+import { installWhichStub } from "./helpers/which-stub.js";
+
+const { execScripts, execFileMock, reset: resetExecStub } =
+  installExecFileStub();
+const which = installWhichStub();
+/** Fixed resolved `bun` path so install script keys are predictable. */
+const BUN_BIN = "/usr/local/bin/bun";
+/** Key the exec stub uses for the global install. */
+const BUN_ADD_KEY = `${BUN_BIN} add`;
+
 import type { ServerMessage } from "../../daemon/message-protocol.js";
 import type { AcpSessionUpdate } from "../../daemon/message-types/acp.js";
 import { getSqlite } from "../../memory/db-connection.js";
@@ -163,6 +198,9 @@ import {
 
 const { AcpResumeError, AcpSessionManager, AcpSessionNotFoundError } =
   await import("../session-manager.js");
+// Imported dynamically (after the exec/which stubs above) so auto-install.js
+// binds to the mocked node:child_process, exactly like session-manager.js.
+const { _resetAdapterInstallCacheForTests } = await import("../auto-install.js");
 
 initializeDb();
 
@@ -189,6 +227,10 @@ function internals(
   return manager as unknown as ManagerInternals;
 }
 
+afterAll(() => {
+  which.restore();
+});
+
 beforeEach(() => {
   clearHistory();
   fakeInstances.length = 0;
@@ -197,11 +239,17 @@ beforeEach(() => {
   replayChunks = [];
   promptThrowsSync = false;
   prepareAgentEnvGate = null;
+  prepareAgentEnvCommands = [];
   resumeSessionGate = null;
   resolveImpl = () => ({
     ok: true,
     agent: { command: "claude-agent-acp", args: [] },
   });
+  // Default: bun absent, no install scripts, install cache cleared. Tests
+  // that exercise the auto-install path opt in via which/execScripts.
+  resetExecStub();
+  _resetAdapterInstallCacheForTests();
+  which.setWhich({});
 });
 
 const PERSISTED_EVENT: AcpSessionUpdate = {
@@ -328,11 +376,11 @@ describe("AcpSessionManager.resumeFromHistory", () => {
     expect(internals(manager).eventBuffers.has("no-caps-1")).toBe(false);
   });
 
-  test("re-resolves via resolveAcpAgent: the installed real binary flows through resume", async () => {
-    // resumeFromHistory re-resolves through resolveAcpAgent, so the one-time
-    // sandboxed install performed at spawn time benefits resume too: the
-    // resolver now returns the real installed binary (a full path here), and
-    // the SessionEntry tracks its basename for resume-hint gating.
+  test("re-resolves via resolveAgentWithAutoInstall: an already-installed real binary flows through resume", async () => {
+    // resumeFromHistory resolves through resolveAgentWithAutoInstall. When the
+    // adapter is already on PATH the resolver returns the real binary (a full
+    // path here) with no install, and the SessionEntry tracks its basename for
+    // resume-hint gating.
     fakeCaps.resume = true;
     insertHistoryRow({ id: "installed-resume-1" });
     resolveImpl = () => ({
@@ -357,7 +405,115 @@ describe("AcpSessionManager.resumeFromHistory", () => {
     ).toBe("claude-agent-acp");
   });
 
-  test("missing binary on resume surfaces the actionable bun install hint", async () => {
+  test("missing adapter on resume: installs via sandboxed bun, then resumes against the real binary", async () => {
+    // The adapter binary is missing but maps to an allowlisted package and
+    // bun is present. resumeFromHistory must trigger the same one-time
+    // sandboxed install as spawn, then resume against the now-installed real
+    // binary, with the OAuth token injected only at spawn (never during the
+    // install).
+    fakeCaps.resume = true;
+    insertHistoryRow({ id: "resume-install-1" });
+
+    // Resolver: binary missing until the install flips `installed`, then the
+    // real installed binary (a full path, as a global bin would resolve).
+    let installed = false;
+    resolveImpl = () =>
+      installed
+        ? {
+            ok: true,
+            agent: { command: "/usr/local/bin/claude-agent-acp", args: [] },
+          }
+        : {
+            ok: false,
+            reason: "binary_not_found",
+            hint: "bun add -g @agentclientprotocol/claude-agent-acp",
+            command: "claude-agent-acp",
+          };
+    which.setWhich({ bun: BUN_BIN });
+    execScripts.set(BUN_ADD_KEY, {
+      stdout: "",
+      onCall: () => {
+        installed = true;
+      },
+    });
+
+    // Seed the secrets on the ambient env so we can assert they are stripped
+    // from the installer env and only reappear at spawn time.
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = "should-not-leak";
+    process.env.GEMINI_API_KEY = "should-not-leak-either";
+
+    const manager = new AcpSessionManager(4);
+    try {
+      await manager.resumeFromHistory("resume-install-1", () => {});
+    } finally {
+      delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+      delete process.env.GEMINI_API_KEY;
+    }
+
+    // The install ran via bun (never npm) in a sandboxed temp dir (NOT the
+    // project dir), with the secrets stripped from its env.
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+    const [command, args, options] = execFileMock.mock.calls[0];
+    expect(command).toBe(BUN_BIN);
+    expect(command).not.toBe("npm");
+    expect(args).toEqual([
+      "add",
+      "--global",
+      "@agentclientprotocol/claude-agent-acp",
+    ]);
+    const { cwd, env } = options as { cwd?: string; env?: NodeJS.ProcessEnv };
+    expect(cwd).toBeDefined();
+    expect(cwd!.startsWith(tmpdir())).toBe(true);
+    expect(cwd).not.toBe(process.cwd());
+    expect(cwd).toContain("vellum-acp-install-");
+    expect(env!.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+    expect(env!.GEMINI_API_KEY).toBeUndefined();
+
+    // Resume then succeeded against the now-installed real binary.
+    const fake = fakeInstances[0]!;
+    expect(fake.config.command).toBe("/usr/local/bin/claude-agent-acp");
+    expect(fake.resumeSessionCalls).toEqual([
+      { sessionId: "proto-old", cwd: "/tmp/proj" },
+    ]);
+    expect(
+      (manager.getStatus("resume-install-1") as AcpSessionState).status,
+    ).toBe("running");
+
+    // prepareAgentEnv ran AFTER resolution, on the resolved real binary, and
+    // injected the token at spawn time — the sole point the token is in scope.
+    expect(prepareAgentEnvCommands).toEqual(["/usr/local/bin/claude-agent-acp"]);
+    expect(fake.config.env?.CLAUDE_CODE_OAUTH_TOKEN).toBe("should-not-leak");
+  });
+
+  test("install failure on resume surfaces the actionable error (no process spawned)", async () => {
+    fakeCaps.resume = true;
+    insertHistoryRow({ id: "resume-install-fail-1" });
+    resolveImpl = () => ({
+      ok: false,
+      reason: "binary_not_found",
+      hint: "bun add -g @agentclientprotocol/claude-agent-acp",
+      command: "claude-agent-acp",
+    });
+    which.setWhich({ bun: BUN_BIN });
+    execScripts.set(BUN_ADD_KEY, { error: new Error("network is down") });
+
+    const manager = new AcpSessionManager(4);
+    const promise = manager.resumeFromHistory("resume-install-fail-1", () => {});
+    await expect(promise).rejects.toThrow(/claude-agent-acp is not on PATH/);
+    await expect(promise).rejects.toThrow(
+      /auto-install failed: .*network is down/,
+    );
+
+    // The install was attempted via bun (never npm) but no child process
+    // spawned, and the reservation was released.
+    for (const call of execFileMock.mock.calls) {
+      expect(call[0]).not.toBe("npm");
+    }
+    expect(fakeInstances).toHaveLength(0);
+    expect(internals(manager).pendingResumes.size).toBe(0);
+  });
+
+  test("bun absent on resume surfaces the actionable install hint, attempts no install", async () => {
     insertHistoryRow({ id: "no-bin-1" });
     resolveImpl = () => ({
       ok: false,
@@ -365,6 +521,7 @@ describe("AcpSessionManager.resumeFromHistory", () => {
       hint: "bun add -g @agentclientprotocol/claude-agent-acp",
       command: "claude-agent-acp",
     });
+    which.setWhich({}); // bun not on PATH (the beforeEach default, made explicit)
 
     const manager = new AcpSessionManager(4);
     await expect(
@@ -372,6 +529,7 @@ describe("AcpSessionManager.resumeFromHistory", () => {
     ).rejects.toThrow(
       "claude-agent-acp is not on PATH. bun add -g @agentclientprotocol/claude-agent-acp",
     );
+    expect(execFileMock).not.toHaveBeenCalled();
   });
 
   test("already-active id and concurrency limit reuse spawn's guards", async () => {

--- a/assistant/src/acp/auto-install.test.ts
+++ b/assistant/src/acp/auto-install.test.ts
@@ -1,12 +1,19 @@
 /**
- * Tests for the silent ACP adapter auto-installer.
+ * Tests for the sandboxed ACP adapter auto-installer.
  *
  * `execFile` is stubbed via the shared `installExecFileStub` helper: a
  * process-global `mock.module("node:child_process", ...)` driven by per-call
- * scripted responses keyed on `${command} ${args[0]}`. The
- * `resolveAgentWithAutoInstall` ordering suite additionally stubs the ACP
- * config and `Bun.which` so it can flip bun / adapter-binary presence.
+ * scripted responses keyed on `${command} ${args[0]}`. `Bun.which` is stubbed
+ * via `installWhichStub` so each test controls whether `bun` is on PATH and
+ * whether the adapter binary resolves after the install.
+ *
+ * The security-critical assertions live here: the installer must be `bun`
+ * (never `npm`), run in a fresh temp dir (NOT the task cwd), with the ACP
+ * secrets stripped from its env and the registry pinned to the public npm
+ * registry.
  */
+
+import { tmpdir } from "node:os";
 
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
@@ -17,6 +24,11 @@ import { installWhichStub } from "./__tests__/helpers/which-stub.js";
 const { execScripts, execFileMock, reset } = installExecFileStub();
 const config = await installAcpConfigStub();
 const which = installWhichStub();
+
+/** Fixed resolved `bun` path so script keys are predictable. */
+const BUN_BIN = "/usr/local/bin/bun";
+/** Key the exec stub uses for the global install. */
+const BUN_ADD_KEY = `${BUN_BIN} add`;
 
 afterAll(() => {
   which.restore();
@@ -40,31 +52,75 @@ const {
   _resetAdapterInstallCacheForTests,
 } = await import("./auto-install.js");
 
+/** Latest call's execFile options ({ cwd, env, ... }). */
+function lastInstallOptions(): { cwd?: string; env?: NodeJS.ProcessEnv } {
+  const call = execFileMock.mock.calls.at(-1)!;
+  return call[2] as { cwd?: string; env?: NodeJS.ProcessEnv };
+}
+
 beforeEach(() => {
   reset();
   _resetAdapterInstallCacheForTests();
   config.setConfig({ agents: {} });
-  which.setWhich({});
+  // Default: bun on PATH, nothing else.
+  which.setWhich({ bun: BUN_BIN });
 });
 
 describe("ensureAdapterInstalled", () => {
-  test("known command: runs `npm i -g <pkg>` and reports installed", async () => {
-    execScripts.set("npm i", { stdout: "" });
+  test("known command: runs `bun add --global <pkg>` and reports installed", async () => {
+    execScripts.set(BUN_ADD_KEY, { stdout: "" });
 
     const result = await ensureAdapterInstalled("claude-agent-acp");
 
     expect(result).toEqual({ installed: true });
     expect(execFileMock).toHaveBeenCalledTimes(1);
     const [command, args] = execFileMock.mock.calls[0];
-    expect(command).toBe("npm");
+    expect(command).toBe(BUN_BIN);
     expect(args).toEqual([
-      "i",
-      "-g",
+      "add",
+      "--global",
       "@agentclientprotocol/claude-agent-acp",
     ]);
   });
 
-  test("unknown command: never invokes npm (security allowlist)", async () => {
+  test("installer never invokes npm", async () => {
+    execScripts.set(BUN_ADD_KEY, { stdout: "" });
+
+    await ensureAdapterInstalled("claude-agent-acp");
+
+    for (const call of execFileMock.mock.calls) {
+      expect(call[0]).not.toBe("npm");
+    }
+  });
+
+  test("runs in a fresh temp dir (NOT the task cwd), token-free env, public registry", async () => {
+    // Seed the secrets on the ambient env so we can assert they are stripped.
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = "should-not-leak";
+    process.env.GEMINI_API_KEY = "should-not-leak-either";
+    execScripts.set(BUN_ADD_KEY, { stdout: "" });
+
+    try {
+      await ensureAdapterInstalled("claude-agent-acp");
+    } finally {
+      delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+      delete process.env.GEMINI_API_KEY;
+    }
+
+    const { cwd, env } = lastInstallOptions();
+    // Sandboxed cwd: a temp dir under the OS temp root, never the process cwd.
+    expect(cwd).toBeDefined();
+    expect(cwd!.startsWith(tmpdir())).toBe(true);
+    expect(cwd).not.toBe(process.cwd());
+    expect(cwd).toContain("vellum-acp-install-");
+
+    // Secrets stripped, registry pinned.
+    expect(env).toBeDefined();
+    expect(env!.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+    expect(env!.GEMINI_API_KEY).toBeUndefined();
+    expect(env!.BUN_CONFIG_REGISTRY).toBe("https://registry.npmjs.org/");
+  });
+
+  test("unknown command: never invokes a package manager (security allowlist)", async () => {
     const result = await ensureAdapterInstalled("some-arbitrary-binary");
 
     expect(result.installed).toBe(false);
@@ -72,8 +128,18 @@ describe("ensureAdapterInstalled", () => {
     expect(execFileMock).not.toHaveBeenCalled();
   });
 
-  test("npm failure: reports the error and does not install", async () => {
-    execScripts.set("npm i", {
+  test("bun absent: no install attempted, reports not installed", async () => {
+    which.setWhich({}); // bun not on PATH
+
+    const result = await ensureAdapterInstalled("claude-agent-acp");
+
+    expect(result.installed).toBe(false);
+    expect(result.error).toBeUndefined();
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  test("install failure: reports the error and does not install", async () => {
+    execScripts.set(BUN_ADD_KEY, {
       error: new Error("EACCES: permission denied"),
     });
 
@@ -84,18 +150,18 @@ describe("ensureAdapterInstalled", () => {
   });
 
   test("failed install is retried on the next call", async () => {
-    execScripts.set("npm i", { error: new Error("network down") });
+    execScripts.set(BUN_ADD_KEY, { error: new Error("network down") });
     const first = await ensureAdapterInstalled("claude-agent-acp");
     expect(first.installed).toBe(false);
 
-    execScripts.set("npm i", { stdout: "" });
+    execScripts.set(BUN_ADD_KEY, { stdout: "" });
     const second = await ensureAdapterInstalled("claude-agent-acp");
     expect(second.installed).toBe(true);
     expect(execFileMock).toHaveBeenCalledTimes(2);
   });
 
   test("successful install is cached for the process lifetime", async () => {
-    execScripts.set("npm i", { stdout: "" });
+    execScripts.set(BUN_ADD_KEY, { stdout: "" });
 
     await ensureAdapterInstalled("claude-agent-acp");
     await ensureAdapterInstalled("claude-agent-acp");
@@ -103,8 +169,8 @@ describe("ensureAdapterInstalled", () => {
     expect(execFileMock).toHaveBeenCalledTimes(1);
   });
 
-  test("concurrent calls dedupe to exactly one `npm i -g`", async () => {
-    execScripts.set("npm i", { stdout: "" });
+  test("concurrent calls dedupe to exactly one install", async () => {
+    execScripts.set(BUN_ADD_KEY, { stdout: "" });
 
     const [a, b, c] = await Promise.all([
       ensureAdapterInstalled("claude-agent-acp"),
@@ -119,7 +185,7 @@ describe("ensureAdapterInstalled", () => {
   });
 
   test("different commands install independently", async () => {
-    execScripts.set("npm i", { stdout: "" });
+    execScripts.set(BUN_ADD_KEY, { stdout: "" });
 
     const [claude, codex] = await Promise.all([
       ensureAdapterInstalled("claude-agent-acp"),
@@ -140,28 +206,16 @@ describe("ensureAdapterInstalled", () => {
 });
 
 describe("resolveAgentWithAutoInstall - resolution order", () => {
-  test("binary missing + bun present: resolves via bunx without invoking npm", async () => {
-    which.setWhich({ bun: "/usr/local/bin/bun" });
-
-    const result = await resolveAgentWithAutoInstall("claude");
-
-    expect(result.resolved.ok).toBe(true);
-    if (!result.resolved.ok) return;
-    expect(result.resolved.agent.command).toBe("bun");
-    expect(result.resolved.agent.adapterCommand).toBe("claude-agent-acp");
-    expect(result.autoInstalledPackage).toBeUndefined();
-    expect(result.failureMessage).toBeUndefined();
-    expect(execFileMock).not.toHaveBeenCalled();
-  });
-
-  test("binary + bun missing, npm install succeeds: falls back to the npm flow", async () => {
+  test("binary missing + bun present: installs then resolves to the real binary", async () => {
     let installed = false;
-    which.setWhich((cmd) =>
-      installed && cmd === "claude-agent-acp"
-        ? "/usr/local/bin/claude-agent-acp"
-        : null,
-    );
-    execScripts.set("npm i", {
+    which.setWhich((cmd) => {
+      if (cmd === "bun") return BUN_BIN;
+      if (cmd === "claude-agent-acp" && installed) {
+        return "/usr/local/bin/claude-agent-acp";
+      }
+      return null;
+    });
+    execScripts.set(BUN_ADD_KEY, {
       stdout: "",
       onCall: () => {
         installed = true;
@@ -172,25 +226,56 @@ describe("resolveAgentWithAutoInstall - resolution order", () => {
 
     expect(result.resolved.ok).toBe(true);
     if (!result.resolved.ok) return;
+    // The resolved command is the REAL binary, not a `bun x` wrapper.
     expect(result.resolved.agent.command).toBe("claude-agent-acp");
     expect(result.autoInstalledPackage).toBe(
       "@agentclientprotocol/claude-agent-acp",
     );
+    expect(result.failureMessage).toBeUndefined();
     expect(execFileMock).toHaveBeenCalledTimes(1);
+    expect(execFileMock.mock.calls[0][0]).toBe(BUN_BIN);
   });
 
-  test("binary, bun, and npm all missing: failure message carries the hint and install error", async () => {
-    execScripts.set("npm i", { error: new Error("spawn npm ENOENT") });
+  test("binary missing + bun absent: no install, plain failure with the hint", async () => {
+    which.setWhich({}); // neither bun nor the adapter on PATH
 
     const result = await resolveAgentWithAutoInstall("claude");
 
     expect(result.resolved.ok).toBe(false);
+    expect(result.autoInstalledPackage).toBeUndefined();
+    // No augmented failure message (the plain binary_not_found hint is
+    // surfaced by the caller via formatResolveFailure).
+    expect(result.failureMessage).toBeUndefined();
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  test("install fails: failure message carries the hint and install error, never npm", async () => {
+    which.setWhich({ bun: BUN_BIN });
+    execScripts.set(BUN_ADD_KEY, { error: new Error("network is down") });
+
+    const result = await resolveAgentWithAutoInstall("claude");
+
+    expect(result.resolved.ok).toBe(false);
+    expect(result.failureMessage).toContain("claude-agent-acp is not on PATH");
     expect(result.failureMessage).toContain(
-      "claude-agent-acp is not on PATH",
+      "bun add -g @agentclientprotocol/claude-agent-acp",
     );
-    expect(result.failureMessage).toContain(
-      "npm i -g @agentclientprotocol/claude-agent-acp",
+    expect(result.failureMessage).toContain("network is down");
+    for (const call of execFileMock.mock.calls) {
+      expect(call[0]).not.toBe("npm");
+    }
+  });
+
+  test("codex unaffected: already on PATH resolves with no install", async () => {
+    which.setWhich((cmd) =>
+      cmd === "codex-acp" ? "/usr/local/bin/codex-acp" : null,
     );
-    expect(result.failureMessage).toContain("ENOENT");
+
+    const result = await resolveAgentWithAutoInstall("codex");
+
+    expect(result.resolved.ok).toBe(true);
+    if (!result.resolved.ok) return;
+    expect(result.resolved.agent.command).toBe("codex-acp");
+    expect(execFileMock).not.toHaveBeenCalled();
   });
 });

--- a/assistant/src/acp/auto-install.test.ts
+++ b/assistant/src/acp/auto-install.test.ts
@@ -14,7 +14,6 @@
  */
 
 import { tmpdir } from "node:os";
-
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { installAcpConfigStub } from "./__tests__/helpers/acp-config-stub.js";

--- a/assistant/src/acp/auto-install.ts
+++ b/assistant/src/acp/auto-install.ts
@@ -1,22 +1,35 @@
 /**
- * Silent auto-install for known ACP adapter binaries.
+ * Sandboxed auto-install for known ACP adapter binaries.
  *
- * Fallback path: the resolver (`resolve-agent.ts`) already rewrites missing
- * allowlisted adapters to run via `bun x` when `bun` is on PATH, so
- * `binary_not_found` only reaches this module when bun is absent (or the
- * command has no package mapping). When a spawn does fail preflight with
- * `binary_not_found`, callers (the `acp_spawn` tool and the `/v1/acp/spawn`
- * route) call `resolveAgentWithAutoInstall(agentId)`, which tries a global
- * npm install of the mapped adapter package, then re-resolves and continues.
- * On failure they fall back to the existing actionable install hint.
+ * When a spawn fails preflight with `binary_not_found`, callers (the
+ * `acp_spawn` tool and the `/v1/acp/spawn` route) call
+ * `resolveAgentWithAutoInstall(agentId)`, which performs a ONE-TIME global
+ * install of the mapped adapter package via `bun`, then re-resolves and
+ * continues. After the install the adapter is a normal trusted binary on
+ * PATH, and the session manager spawns it the usual way (project cwd, token
+ * injected only at spawn).
  *
- * Security boundary: only commands present in `DEFAULT_AGENT_NPM_PACKAGES`
- * are ever installed. The package names are vendored constants, NOT user
- * input: an arbitrary command from user config must never be turned into
- * an `npm i -g <attacker-controlled-name>` execution.
+ * Security boundaries (this is the ATL-808 fix):
+ *  - Only commands present in `DEFAULT_AGENT_NPM_PACKAGES` are ever
+ *    installed. The package names are vendored constants, NOT user input.
+ *  - The install runs `bun` with cwd = a FRESH empty daemon-owned temp dir,
+ *    never the untrusted task project dir. A clean cwd has no project-local
+ *    `node_modules/.bin`, `bunfig.toml`, or `.npmrc`, so none of the
+ *    cwd-based package-resolution hijacks apply.
+ *  - The installer env is a SANITIZED copy of `process.env` with
+ *    `CLAUDE_CODE_OAUTH_TOKEN` and `GEMINI_API_KEY` stripped, so the secret
+ *    is never in scope during package resolution, and `BUN_CONFIG_REGISTRY`
+ *    forced to the public npm registry so a redirected registry cannot serve
+ *    a malicious package.
+ *  - The token is injected ONLY later, at spawn time, on the real installed
+ *    binary (see `prepare-agent-env.ts`). `prepareAgentEnv` is never called
+ *    here.
  */
 
 import { execFile } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import { DEFAULT_AGENT_NPM_PACKAGES } from "../config/acp-defaults.js";
 import { getLogger } from "../util/logger.js";
@@ -27,8 +40,15 @@ import {
 
 const log = getLogger("acp:auto-install");
 
-/** Per-install timeout for `npm i -g`. Generous: cold npm caches are slow. */
-const NPM_INSTALL_TIMEOUT_MS = 120_000;
+/** Per-install timeout for the global install. Generous: cold caches are slow. */
+const BUN_INSTALL_TIMEOUT_MS = 120_000;
+
+/**
+ * The trusted public npm registry. Forced via `BUN_CONFIG_REGISTRY` on the
+ * installer env so a stray `.npmrc`/`bunfig.toml` in the ambient environment
+ * cannot redirect package downloads to an attacker-controlled registry.
+ */
+const PUBLIC_NPM_REGISTRY = "https://registry.npmjs.org/";
 
 export interface AdapterInstallResult {
   installed: boolean;
@@ -37,21 +57,22 @@ export interface AdapterInstallResult {
 
 /**
  * Per-command install promises. Concurrent spawns for the same missing
- * binary dedupe to a single `npm i -g`; successful results are cached for
+ * binary dedupe to a single global install; successful results are cached for
  * the process lifetime. Failed installs are evicted so a later spawn can
- * retry (e.g. after the user fixes network or npm permissions).
+ * retry (e.g. after the user fixes network or install permissions).
  */
 const installPromises = new Map<string, Promise<AdapterInstallResult>>();
 
 /**
  * Run `execFile` with an AbortController-driven timeout. Returns the stdout
- * on success; throws on error or timeout. Shared by the adapter installer
- * here and the version probes in `tools/acp/spawn.ts`.
+ * on success; throws on error or timeout. The optional `cwd`/`env` let the
+ * installer run in a sandboxed working directory with a sanitized env.
  */
-export function execFileWithTimeout(
+function execFileWithTimeout(
   command: string,
   args: string[],
   timeoutMs: number,
+  options?: { cwd?: string; env?: NodeJS.ProcessEnv },
 ): Promise<string> {
   return new Promise((resolve, reject) => {
     const controller = new AbortController();
@@ -59,7 +80,12 @@ export function execFileWithTimeout(
     execFile(
       command,
       args,
-      { signal: controller.signal, encoding: "utf8" },
+      {
+        signal: controller.signal,
+        encoding: "utf8",
+        cwd: options?.cwd,
+        env: options?.env,
+      },
       (err, stdout) => {
         clearTimeout(timer);
         if (err) {
@@ -73,10 +99,24 @@ export function execFileWithTimeout(
 }
 
 /**
- * Install the npm package mapped to `command` if (and only if) the command
- * is a known adapter binary. Unknown commands resolve to
- * `{ installed: false }` without ever invoking npm (see the security
- * boundary note in the module doc).
+ * A copy of `process.env` safe to hand to the package installer: the ACP
+ * secrets are stripped so they can never leak into a resolved package's
+ * lifecycle/runtime, and the registry is pinned to the trusted public one.
+ */
+function sanitizedInstallEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  delete env.CLAUDE_CODE_OAUTH_TOKEN;
+  delete env.GEMINI_API_KEY;
+  env.BUN_CONFIG_REGISTRY = PUBLIC_NPM_REGISTRY;
+  return env;
+}
+
+/**
+ * Install the npm-registry package mapped to `command` via a sandboxed `bun`
+ * global install, if (and only if) the command is a known adapter binary and
+ * `bun` is on PATH. Unknown commands, or hosts without `bun`, resolve to
+ * `{ installed: false }` without ever invoking a package manager (see the
+ * security boundary note in the module doc).
  */
 export function ensureAdapterInstalled(
   command: string,
@@ -86,10 +126,15 @@ export function ensureAdapterInstalled(
     return Promise.resolve({ installed: false });
   }
 
+  const bunPath = Bun.which("bun");
+  if (!bunPath) {
+    return Promise.resolve({ installed: false });
+  }
+
   const inFlight = installPromises.get(command);
   if (inFlight) return inFlight;
 
-  const promise = runInstall(command, packageName).then((result) => {
+  const promise = runInstall(bunPath, command, packageName).then((result) => {
     if (!result.installed) installPromises.delete(command);
     return result;
   });
@@ -98,15 +143,23 @@ export function ensureAdapterInstalled(
 }
 
 async function runInstall(
+  bunPath: string,
   command: string,
   packageName: string,
 ): Promise<AdapterInstallResult> {
   log.info({ command, packageName }, "Auto-installing missing ACP adapter");
+  // Fresh empty dir guaranteed to have no project-local node_modules,
+  // bunfig.toml, or .npmrc - this neutralizes the cwd-based resolution
+  // hijacks the untrusted task dir would otherwise enable.
+  const installDir = await mkdtemp(join(tmpdir(), "vellum-acp-install-"));
   try {
     await execFileWithTimeout(
-      "npm",
-      ["i", "-g", packageName],
-      NPM_INSTALL_TIMEOUT_MS,
+      bunPath,
+      // `bun add --global` installs AND links the package bin into bun's
+      // global bin dir (on PATH in every image).
+      ["add", "--global", packageName],
+      BUN_INSTALL_TIMEOUT_MS,
+      { cwd: installDir, env: sanitizedInstallEnv() },
     );
     log.info({ command, packageName }, "ACP adapter auto-install succeeded");
     return { installed: true };
@@ -117,17 +170,19 @@ async function runInstall(
       "ACP adapter auto-install failed (falling back to install hint)",
     );
     return { installed: false, error };
+  } finally {
+    await rm(installDir, { recursive: true, force: true }).catch(() => {});
   }
 }
 
 export interface ResolveWithAutoInstallResult {
   /** The final resolver outcome (post-install re-resolve when applicable). */
   resolved: ResolveAcpAgentResult;
-  /** Set when a missing adapter binary was silently installed via npm. */
+  /** Set when a missing adapter binary was silently installed via bun. */
   autoInstalledPackage?: string;
   /**
    * Set when the auto-install itself failed: the original install hint
-   * augmented with the npm failure reason. Callers should surface this
+   * augmented with the install failure reason. Callers should surface this
    * instead of re-deriving a message from `resolved`.
    */
   failureMessage?: string;

--- a/assistant/src/acp/prepare-agent-env.ts
+++ b/assistant/src/acp/prepare-agent-env.ts
@@ -20,6 +20,8 @@
  * owns the plaintext read boundary.
  */
 
+import { basename } from "node:path";
+
 import { FailedDependencyError } from "../runtime/routes/errors.js";
 import { credentialBroker } from "../tools/credentials/broker.js";
 import {
@@ -27,7 +29,6 @@ import {
   upsertCredentialMetadata,
 } from "../tools/credentials/metadata-store.js";
 import { getLogger } from "../util/logger.js";
-import { adapterCommandOf } from "./resolve-agent.js";
 import type { AcpAgentConfig } from "./types.js";
 
 const log = getLogger("acp:prepare-agent-env");
@@ -98,13 +99,11 @@ async function injectCredential(
  * credential is missing from both the user-supplied env override and the
  * secure store.
  *
- * Gating is keyed off the canonical adapter identity (`adapterCommand` set
- * by the resolver, falling back to the command basename for plain configs),
- * not the user-facing agent id. A custom `acp.agents.my-claude = { command:
- * "claude-agent-acp", ... }` alias still gets the env it needs, and so does
- * the bunx-rewritten claude adapter (whose `command` is "bun"). Without
- * the adapterCommand gate, bunx-resolved spawns would start with no auth
- * and die as zombies on the first prompt.
+ * Gating is keyed off the resolved command basename, not the user-facing
+ * agent id. A custom `acp.agents.my-claude = { command: "claude-agent-acp",
+ * ... }` alias (or a full path like `/opt/bin/claude-agent-acp`) still gets
+ * the env it needs. Because resolution always yields the real adapter binary
+ * (never a `bun x` wrapper), the basename is the canonical adapter identity.
  *
  * For `claude-agent-acp` the only required env var is
  * `CLAUDE_CODE_OAUTH_TOKEN`. Two provisioning routes converge on it, with
@@ -132,7 +131,7 @@ export async function prepareAgentEnv(
   // agent reference. The local `env` binding sidesteps TS narrowing
   // limitations on the optional `AcpAgentConfig.env` field.
   const env: Record<string, string> = { ...(agentConfig.env ?? {}) };
-  const adapterCommand = adapterCommandOf(agentConfig);
+  const adapterCommand = basename(agentConfig.command);
 
   if (adapterCommand === "claude-agent-acp") {
     if (!env.CLAUDE_CODE_OAUTH_TOKEN) {

--- a/assistant/src/acp/resolve-agent.test.ts
+++ b/assistant/src/acp/resolve-agent.test.ts
@@ -13,8 +13,7 @@ afterAll(() => {
   setOverridesForTesting({});
 });
 
-const { resolveAcpAgent, listAcpAgents, adapterCommandOf, runsViaBunx } =
-  await import("./resolve-agent.js");
+const { resolveAcpAgent, listAcpAgents } = await import("./resolve-agent.js");
 
 beforeEach(() => {
   config.setConfig({});
@@ -217,7 +216,7 @@ describe("resolveAcpAgent", () => {
     if (result.ok) return;
     expect(result.reason).toBe("binary_not_found");
     if (result.reason !== "binary_not_found") return;
-    expect(result.hint).toBe("npm i -g @agentclientprotocol/claude-agent-acp");
+    expect(result.hint).toBe("bun add -g @agentclientprotocol/claude-agent-acp");
     expect(result.command).toBe("claude-agent-acp");
   });
 
@@ -257,7 +256,7 @@ describe("resolveAcpAgent", () => {
     if (result.ok) return;
     expect(result.reason).toBe("binary_not_found");
     if (result.reason !== "binary_not_found") return;
-    expect(result.hint).toBe("npm i -g @zed-industries/codex-acp");
+    expect(result.hint).toBe("bun add -g @zed-industries/codex-acp");
   });
 
   test("binary preflight honors agent.env.PATH override (matches spawn env)", () => {
@@ -300,7 +299,7 @@ describe("resolveAcpAgent", () => {
     expect(result.agent.args).toEqual(["--verbose"]);
   });
 
-  test("direct resolution sets adapterCommand to the command basename", () => {
+  test("resolves a full-path command directly without rewriting it", () => {
     config.setConfig({
       agents: {
         custom: { command: "/opt/bin/claude-agent-acp", args: [] },
@@ -310,117 +309,38 @@ describe("resolveAcpAgent", () => {
     const direct = resolveAcpAgent("claude");
     expect(direct.ok).toBe(true);
     if (!direct.ok) return;
-    expect(direct.agent.adapterCommand).toBe("claude-agent-acp");
-    expect(runsViaBunx(direct.agent)).toBe(false);
+    expect(direct.agent.command).toBe("claude-agent-acp");
 
     const fullPath = resolveAcpAgent("custom");
     expect(fullPath.ok).toBe(true);
     if (!fullPath.ok) return;
-    expect(fullPath.agent.adapterCommand).toBe("claude-agent-acp");
+    expect(fullPath.agent.command).toBe("/opt/bin/claude-agent-acp");
   });
 });
 
 // ---------------------------------------------------------------------------
-// resolveAcpAgent - bunx fallback for missing binaries
+// resolveAcpAgent - missing binaries are never run from the task cwd
 // ---------------------------------------------------------------------------
 
-describe("resolveAcpAgent - bunx fallback", () => {
-  test("binary missing + bun present: rewrites to `bun x --bun <pkg>` with adapterCommand preserved", () => {
+describe("resolveAcpAgent - missing binary", () => {
+  test("binary missing + bun present: still binary_not_found (no bunx rewrite)", () => {
+    // bun on PATH no longer makes a missing adapter "runnable" at resolve
+    // time: the sandboxed install happens separately, never as a `bun x`
+    // rewrite in the untrusted cwd.
     config.setConfig({ agents: {} });
     which.setWhich({ bun: "/usr/local/bin/bun" });
 
     const result = resolveAcpAgent("claude");
-
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(result.agent.command).toBe("bun");
-    expect(result.agent.args).toEqual([
-      "x",
-      "--bun",
-      "@agentclientprotocol/claude-agent-acp",
-    ]);
-    expect(result.agent.adapterCommand).toBe("claude-agent-acp");
-    expect(runsViaBunx(result.agent)).toBe(true);
-    expect(adapterCommandOf(result.agent)).toBe("claude-agent-acp");
-  });
-
-  test("bunx rewrite appends the original args after the package (gemini --acp)", () => {
-    config.setConfig({ agents: {} });
-    which.setWhich({ bun: "/usr/local/bin/bun" });
-
-    const result = resolveAcpAgent("gemini");
-
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(result.agent.command).toBe("bun");
-    expect(result.agent.args).toEqual([
-      "x",
-      "--bun",
-      "@google/gemini-cli",
-      "--acp",
-    ]);
-    expect(result.agent.adapterCommand).toBe("gemini");
-  });
-
-  test("bunx rewrite leaves env unchanged", () => {
-    config.setConfig({
-      agents: {
-        claude: {
-          command: "claude-agent-acp",
-          args: [],
-          env: { KEEP_ME: "yes" },
-        },
-      },
-    });
-    which.setWhich({ bun: "/usr/local/bin/bun" });
-
-    const result = resolveAcpAgent("claude");
-
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(result.agent.command).toBe("bun");
-    expect(result.agent.env).toEqual({ KEEP_ME: "yes" });
-  });
-
-  test("bun lookup honors agent.env.PATH override (matches spawn env)", () => {
-    config.setConfig({
-      agents: {
-        claude: {
-          command: "claude-agent-acp",
-          args: [],
-          env: { PATH: "/opt/custom/bin" },
-        },
-      },
-    });
-    which.setWhich((cmd, options) =>
-      cmd === "bun" && options?.PATH === "/opt/custom/bin"
-        ? "/opt/custom/bin/bun"
-        : null,
-    );
-
-    const result = resolveAcpAgent("claude");
-
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(result.agent.command).toBe("bun");
-  });
-
-  test("user-config command without a package mapping is NOT rewritten even when bun is present", () => {
-    config.setConfig({
-      agents: {
-        custom: { command: "unknown-binary", args: [] },
-      },
-    });
-    which.setWhich({ bun: "/usr/local/bin/bun" });
-
-    const result = resolveAcpAgent("custom");
 
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.reason).toBe("binary_not_found");
+    if (result.reason !== "binary_not_found") return;
+    expect(result.command).toBe("claude-agent-acp");
+    expect(result.hint).toBe("bun add -g @agentclientprotocol/claude-agent-acp");
   });
 
-  test("binary missing + bun missing: binary_not_found with the npm hint", () => {
+  test("binary missing + bun missing: binary_not_found with the bun hint", () => {
     config.setConfig({ agents: {} });
     which.setWhich({});
 
@@ -430,26 +350,7 @@ describe("resolveAcpAgent - bunx fallback", () => {
     if (result.ok) return;
     expect(result.reason).toBe("binary_not_found");
     if (result.reason !== "binary_not_found") return;
-    expect(result.hint).toBe("npm i -g @agentclientprotocol/claude-agent-acp");
-  });
-});
-
-// ---------------------------------------------------------------------------
-// adapterCommandOf - fallback for plain configs
-// ---------------------------------------------------------------------------
-
-describe("adapterCommandOf", () => {
-  test("falls back to the command basename for configs without adapterCommand", () => {
-    expect(adapterCommandOf({ command: "/opt/bin/claude-agent-acp" })).toBe(
-      "claude-agent-acp",
-    );
-    expect(adapterCommandOf({ command: "codex-acp" })).toBe("codex-acp");
-  });
-
-  test("prefers an explicit adapterCommand over the command", () => {
-    expect(
-      adapterCommandOf({ command: "bun", adapterCommand: "claude-agent-acp" }),
-    ).toBe("claude-agent-acp");
+    expect(result.hint).toBe("bun add -g @agentclientprotocol/claude-agent-acp");
   });
 });
 
@@ -523,18 +424,20 @@ describe("listAcpAgents", () => {
     expect(codex?.source).toBe("default");
   });
 
-  test("missing binaries with bun present are listed available (bunx fallback)", () => {
+  test("missing binaries are listed unavailable even when bun is present", () => {
+    // bun presence no longer makes a missing adapter available: it is
+    // installed on demand at spawn time, not run via `bun x` from the cwd.
     config.setConfig({ agents: {} });
     which.setWhich({ bun: "/usr/local/bin/bun" });
 
     const result = listAcpAgents();
 
     for (const entry of result.agents) {
-      expect(entry.available).toBe(true);
-      expect(entry.unavailableReason).toBeUndefined();
-      expect(entry.setupHint).toBeUndefined();
+      expect(entry.available).toBe(false);
+      expect(entry.unavailableReason).toBeDefined();
+      expect(entry.setupHint).toContain("bun add -g");
     }
-    // The catalog keeps the canonical adapter commands, not the rewrite.
+    // The catalog keeps the canonical adapter commands.
     expect(result.agents.map((a) => a.command)).toEqual([
       "claude-agent-acp",
       "codex-acp",
@@ -551,7 +454,7 @@ describe("listAcpAgents", () => {
     const codex = result.agents.find((a) => a.id === "codex");
     expect(codex?.available).toBe(false);
     expect(codex?.unavailableReason).toBe("'codex-acp' is not on PATH");
-    expect(codex?.setupHint).toBe("npm i -g @zed-industries/codex-acp");
+    expect(codex?.setupHint).toBe("bun add -g @zed-industries/codex-acp");
   });
 
   test("unavailable gemini surfaces the @google/gemini-cli install hint", () => {
@@ -566,7 +469,7 @@ describe("listAcpAgents", () => {
     const gemini = result.agents.find((a) => a.id === "gemini");
     expect(gemini?.available).toBe(false);
     expect(gemini?.unavailableReason).toBe("'gemini' is not on PATH");
-    expect(gemini?.setupHint).toBe("npm i -g @google/gemini-cli");
+    expect(gemini?.setupHint).toBe("bun add -g @google/gemini-cli");
   });
 
   test("aliases are resolution sugar, not catalog entries", () => {

--- a/assistant/src/acp/resolve-agent.ts
+++ b/assistant/src/acp/resolve-agent.ts
@@ -13,21 +13,19 @@
  * acp_list_agents, and the `/v1/acp/spawn` HTTP route) get a single source
  * of truth and matching actionable hints.
  *
- * When the adapter binary is NOT on PATH but `bun` is and the command has a
- * vendored entry in `DEFAULT_AGENT_NPM_PACKAGES`, the resolver rewrites the
- * agent to run via `bun x --bun <package>` instead of failing. bunx fetches
- * the package into its cache on first use, so platform-hosted assistants
- * whose image ships bun (but no node and no npm) work out of the box with
- * no global install. The original command is preserved as `adapterCommand`
- * so downstream consumers (env injection, resume hints, version probe) keep
- * gating on the canonical adapter identity.
+ * The resolver NEVER fetches or runs packages in the (untrusted) task cwd.
+ * When the adapter binary is missing, resolution simply fails with
+ * `binary_not_found`; the `resolveAgentWithAutoInstall` flow in
+ * `auto-install.ts` then performs a one-time sandboxed `bun` global install
+ * (clean temp cwd, secrets stripped from the installer env) and re-resolves.
+ * The resolved command is therefore ALWAYS the real adapter binary on PATH,
+ * so downstream gates (env injection, resume hints) key off the command
+ * basename directly.
  *
  * `listAcpAgents()` exposes the merged catalog with availability info for
  * the `acp_list_agents` tool — same merge semantics, plus per-entry
- * `available` / `setupHint` derived from the same binary-or-bunx resolution.
+ * `available` / `setupHint` derived from the same binary resolution.
  */
-
-import { basename } from "node:path";
 
 import {
   DEFAULT_ACP_AGENT_PROFILES,
@@ -44,48 +42,8 @@ import { isAcpEnabled } from "./feature-gate.js";
  */
 type AcpAgentSource = "config" | "default";
 
-/**
- * A resolver-produced agent config, ready to spawn. `adapterCommand` carries
- * the canonical adapter identity (e.g. "claude-agent-acp") even when the
- * spawn command was rewritten to run via `bun x`, so consumers that gate
- * behavior on the adapter (env injection in `prepare-agent-env.ts`, resume
- * hints, the version probe in `tools/acp/spawn.ts`) stay correct for
- * bunx-resolved agents.
- */
-export interface ResolvedAcpAgent extends AcpAgentConfig {
-  adapterCommand: string;
-}
-
-/**
- * Canonical adapter identity for a (possibly rewritten) agent config.
- * Resolver-produced configs carry `adapterCommand` explicitly; plain configs
- * that never went through the resolver fall back to the command basename so
- * user-supplied agent configs keep working.
- */
-export function adapterCommandOf(config: {
-  command: string;
-  adapterCommand?: string;
-}): string {
-  return config.adapterCommand ?? basename(config.command);
-}
-
-/**
- * Whether the config was rewritten by the resolver to run through `bun x`
- * (the only path where the canonical adapter identity diverges from the
- * actual spawn command).
- */
-export function runsViaBunx(config: {
-  command: string;
-  adapterCommand?: string;
-}): boolean {
-  return (
-    config.adapterCommand !== undefined &&
-    config.adapterCommand !== basename(config.command)
-  );
-}
-
 export type ResolveAcpAgentResult =
-  | { ok: true; agent: ResolvedAcpAgent }
+  | { ok: true; agent: AcpAgentConfig }
   | ResolveAcpAgentFailure;
 
 export type ResolveAcpAgentFailure =
@@ -146,7 +104,7 @@ export const ACP_DISABLED_HINT =
 function installHintFor(command: string): string {
   const pkg = DEFAULT_AGENT_NPM_PACKAGES[command];
   return pkg
-    ? `npm i -g ${pkg}`
+    ? `bun add -g ${pkg}`
     : `Install '${command}' and ensure it is on PATH.`;
 }
 
@@ -154,8 +112,7 @@ function installHintFor(command: string): string {
  * Resolve a binary using the same PATH the spawn will see. `AcpAgentProcess`
  * spawns with `{ ...process.env, ...config.env }`, so a per-agent `env.PATH`
  * override wins over the assistant's PATH. Mirror that here so a config that
- * relies on a custom PATH to locate the binary (or `bun`, for the bunx
- * rewrite) doesn't fail preflight.
+ * relies on a custom PATH to locate the binary doesn't fail preflight.
  */
 function whichOnAgentPath(
   agent: AcpAgentConfig,
@@ -166,34 +123,17 @@ function whichOnAgentPath(
 }
 
 /**
- * Resolve an agent config to its runnable form, or `null` when it cannot
- * spawn. The ONLY place the bunx rewrite happens:
+ * Resolve an agent config to its runnable form, or `null` when its `command`
+ * is not on PATH. Resolution is pure preflight: the binary is used directly
+ * when present, and otherwise the agent cannot spawn (callers fall back to
+ * the sandboxed `bun` global install in `auto-install.ts`, then re-resolve).
  *
- * 1. Binary on PATH → use it directly (`adapterCommand` = command basename).
- * 2. Binary missing, command has a vendored npm package mapping, and `bun`
- *    is on PATH → rewrite to `bun x --bun <package> <original args>`. bunx
- *    fetches the package on first use, preserving the
- *    install-latest-on-first-use design with no global install.
- * 3. Otherwise → null (callers fall back to npm auto-install or surface the
- *    install hint).
- *
- * Security boundary (mirrors `auto-install.ts`): only commands present in
- * `DEFAULT_AGENT_NPM_PACKAGES` are ever rewritten. The package names are
- * vendored constants, NOT user input: an arbitrary command from user config
- * must never be turned into a `bun x <attacker-controlled-name>` execution.
+ * Crucially, this never fetches or executes anything in the task cwd: a
+ * missing binary returns `null` rather than running a package manager from
+ * the (untrusted) project directory.
  */
-function resolveRunnableAgent(agent: AcpAgentConfig): ResolvedAcpAgent | null {
-  if (whichOnAgentPath(agent, agent.command)) {
-    return { ...agent, adapterCommand: basename(agent.command) };
-  }
-  const packageName = DEFAULT_AGENT_NPM_PACKAGES[agent.command];
-  if (!packageName || !whichOnAgentPath(agent, "bun")) return null;
-  return {
-    ...agent,
-    command: "bun",
-    args: ["x", "--bun", packageName, ...agent.args],
-    adapterCommand: agent.command,
-  };
+function resolveRunnableAgent(agent: AcpAgentConfig): AcpAgentConfig | null {
+  return whichOnAgentPath(agent, agent.command) ? agent : null;
 }
 
 /**
@@ -271,8 +211,8 @@ function mergedAgentIds(userAgents: Record<string, AcpAgentConfig>): string[] {
  * Order of checks:
  * 1. ACP must be enabled (feature flag or config; see `isAcpEnabled`).
  * 2. The id must resolve to an agent (user config wins; falls back to defaults).
- * 3. The agent must be runnable: its `command` on PATH, or the bunx rewrite
- *    applies (see `resolveRunnableAgent`).
+ * 3. The agent must be runnable: its `command` on PATH (see
+ *    `resolveRunnableAgent`).
  *
  * Each failure mode carries an actionable hint so callers can surface a
  * single user-facing message without re-deriving the remediation.
@@ -330,8 +270,9 @@ export function listAcpAgents(): {
   const agents: AcpAgentEntry[] = mergedAgentIds(userAgents).map((id) => {
     // Non-null: ids come from `mergedAgentIds` so the lookup always resolves.
     const { agent, source } = lookupAgent(userAgents, id)!;
-    // Same binary-or-bunx resolution as `resolveAcpAgent`: an agent whose
-    // binary is missing but would spawn via `bun x` IS available.
+    // Same binary preflight as `resolveAcpAgent`: available iff the command
+    // is on PATH. A missing binary is auto-installed at spawn time, but the
+    // catalog reflects what is runnable right now.
     const available = resolveRunnableAgent(agent) !== null;
     const entry: AcpAgentEntry = {
       id,

--- a/assistant/src/acp/resume-hint.ts
+++ b/assistant/src/acp/resume-hint.ts
@@ -5,9 +5,7 @@
  * adapter binary). Other adapters resume differently or not at all, so the
  * hint is gated by the resolved adapter, not the agent id - this stays
  * correct when a user aliases an id to a different binary. Callers pass the
- * CANONICAL adapter command (`adapterCommandOf` in `resolve-agent.ts`), not
- * the raw spawn command, so the hint still fires when the claude adapter is
- * run via `bun x` (spawn command "bun").
+ * resolved command basename, which is always the real adapter binary.
  *
  * Used by the `acp_spawn` tool's success payload and the session manager's
  * completion notification so both surfaces render identical copy. Returns

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -16,9 +16,10 @@ import { acpSessionHistory } from "../memory/schema.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { getLogger } from "../util/logger.js";
 import { AcpAgentProcess } from "./agent-process.js";
+import { resolveAgentWithAutoInstall } from "./auto-install.js";
 import { VellumAcpClientHandler } from "./client-handler.js";
 import { prepareAgentEnv } from "./prepare-agent-env.js";
-import { formatResolveFailure, resolveAcpAgent } from "./resolve-agent.js";
+import { formatResolveFailure } from "./resolve-agent.js";
 import { claudeResumeHint } from "./resume-hint.js";
 import type { AcpAgentConfig, AcpSessionState } from "./types.js";
 
@@ -347,8 +348,8 @@ export class AcpSessionManager {
    * merges new events into the original row instead of losing them.
    *
    * Throws with an actionable message when the row is missing, was recorded
-   * before resume support (no cwd), the agent cannot be resolved, or the
-   * agent advertises neither resume capability.
+   * before resume support (no cwd), the agent cannot be resolved or
+   * auto-installed, or the agent advertises neither resume capability.
    */
   async resumeFromHistory(
     acpSessionId: string,
@@ -384,11 +385,6 @@ export class AcpSessionManager {
       );
     }
 
-    const resolved = resolveAcpAgent(row.agentId);
-    if (!resolved.ok) {
-      throw new Error(formatResolveFailure(row.agentId, resolved));
-    }
-
     // Everything up to here is synchronous. Reserve the id + concurrency
     // slot BEFORE the first await so a concurrent resume of the same id
     // (or a spawn racing the cap) fails the guards above instead of
@@ -396,11 +392,12 @@ export class AcpSessionManager {
     // reservation holds the resume's promise until it settles so
     // steerOrResume can await a concurrent caller's in-flight resume, and
     // so the delete guards see the id as live while the row's terminal
-    // status still reflects the previous run.
+    // status still reflects the previous run. Agent resolution (which may
+    // auto-install a missing adapter) is therefore deferred into
+    // performResume, after the slot is reserved.
     const resumePromise = this.performResume(
       acpSessionId,
       row as ResumableHistoryRow,
-      resolved.agent,
       sendToVellum,
     );
     this.pendingResumes.set(acpSessionId, resumePromise);
@@ -414,15 +411,34 @@ export class AcpSessionManager {
   /**
    * The async body of resumeFromHistory, split out so the caller can store
    * its promise in `pendingResumes` synchronously before the first await.
-   * All guards and row validation have already passed.
+   * All guards and row validation have already passed; this resolves the
+   * adapter (auto-installing a missing allowlisted binary), prepares its
+   * env, and reattaches.
    */
   private async performResume(
     acpSessionId: string,
     row: ResumableHistoryRow,
-    agent: AcpAgentConfig,
     sendToVellum: (msg: ServerMessage) => void,
   ): Promise<void> {
-    const agentConfig = await prepareAgentEnv(agent);
+    // Resolve the adapter, silently auto-installing a missing allowlisted
+    // binary via the same sandboxed `bun` path as spawn (see
+    // acp/auto-install.ts). A fresh container, or a session created under
+    // the old bunx fallback, may have no adapter on PATH; resume installs it
+    // transparently instead of failing with binary_not_found. The token is
+    // NEVER in scope here — resolveAgentWithAutoInstall strips it from the
+    // installer env; it is injected only by prepareAgentEnv below, at spawn
+    // time, on the real installed binary.
+    const { resolved, failureMessage } = await resolveAgentWithAutoInstall(
+      row.agentId,
+    );
+    if (failureMessage) {
+      throw new Error(failureMessage);
+    }
+    if (!resolved.ok) {
+      throw new Error(formatResolveFailure(row.agentId, resolved));
+    }
+
+    const agentConfig = await prepareAgentEnv(resolved.agent);
 
     // The daemon may have shut down while prepareAgentEnv was pending.
     // Registering now would spawn a child process on a disposed manager

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -4,6 +4,7 @@
  */
 
 import { randomUUID } from "node:crypto";
+import { basename } from "node:path";
 
 import { eq, inArray } from "drizzle-orm";
 
@@ -17,11 +18,7 @@ import { getLogger } from "../util/logger.js";
 import { AcpAgentProcess } from "./agent-process.js";
 import { VellumAcpClientHandler } from "./client-handler.js";
 import { prepareAgentEnv } from "./prepare-agent-env.js";
-import {
-  adapterCommandOf,
-  formatResolveFailure,
-  resolveAcpAgent,
-} from "./resolve-agent.js";
+import { formatResolveFailure, resolveAcpAgent } from "./resolve-agent.js";
 import { claudeResumeHint } from "./resume-hint.js";
 import type { AcpAgentConfig, AcpSessionState } from "./types.js";
 
@@ -74,8 +71,7 @@ interface SessionEntry {
   currentPrompt: Promise<unknown> | null;
   parentConversationId: string;
   cwd: string;
-  /** Canonical adapter command for the spawned config (e.g.
-   *  "claude-agent-acp" even when the adapter runs via `bun x`). Used to
+  /** Resolved adapter command basename (e.g. "claude-agent-acp"). Used to
    *  gate resume hints to the only adapter (claude-agent-acp) whose CLI
    *  accepts `--resume`. */
   command: string;
@@ -316,7 +312,7 @@ export class AcpSessionManager {
       currentPrompt: null,
       parentConversationId: opts.parentConversationId,
       cwd: opts.cwd,
-      command: adapterCommandOf(opts.agentConfig),
+      command: basename(opts.agentConfig.command),
     };
 
     this.sessions.set(acpSessionId, entry);

--- a/assistant/src/acp/types.ts
+++ b/assistant/src/acp/types.ts
@@ -12,14 +12,6 @@ export interface AcpAgentConfig {
   args: string[];
   description?: string;
   env?: Record<string, string>;
-  /**
-   * Canonical adapter identity (e.g. "claude-agent-acp"), set by the
-   * resolver. It survives the bunx rewrite, where `command` becomes "bun"
-   * and the adapter package moves into `args`. Optional because plain user
-   * configs that bypass the resolver never set it; consumers fall back to
-   * the command basename via `adapterCommandOf` in `resolve-agent.ts`.
-   */
-  adapterCommand?: string;
 }
 
 /**

--- a/assistant/src/config/bundled-skills/acp/SKILL.md
+++ b/assistant/src/config/bundled-skills/acp/SKILL.md
@@ -43,20 +43,20 @@ When the user first tries to use ACP and it's not enabled, set it up automatical
 
 2. Then retry the `acp_spawn` call. Do NOT run `vellum sleep && vellum wake` - that kills the conversation.
 
-No manual binary installation is needed first: missing adapter binaries are run on demand via bun, or installed automatically (see below).
+No manual binary installation is needed first: missing adapter binaries are installed automatically (see below).
 
 ## Automatic adapter availability
 
-When `acp_spawn` finds the agent's binary missing from PATH, the assistant runs the adapter through bun instead (`bun x --bun <package>`). Bun fetches the package into its cache on first use, so there is no global install and it works on hosts without node or npm (platform-hosted assistants ship bun only). When bun itself is not on PATH, the assistant falls back to silently installing the matching npm package globally and proceeds in the same call.
+When `acp_spawn` finds the agent's binary missing from PATH, the assistant installs it once via a sandboxed bun global install and then runs the real installed binary. The install runs in a fresh empty temporary directory (never the task's project directory), with the Claude/Gemini secrets stripped from the installer environment and the registry pinned to the public npm registry, so a malicious project directory cannot hijack package resolution or capture a token. After this one-time install, the adapter is a normal trusted binary on PATH and every later spawn (and resume) uses it directly.
 
-Only the allowlisted out-of-box packages are ever run or installed this way (`@agentclientprotocol/claude-agent-acp`, `@zed-industries/codex-acp`, `@google/gemini-cli`); user-configured agents with custom commands are never fetched or installed automatically.
+Only the allowlisted out-of-box packages are ever installed this way (`@agentclientprotocol/claude-agent-acp`, `@zed-industries/codex-acp`, `@google/gemini-cli`); user-configured agents with custom commands are never installed automatically.
 
-Manual installation is fallback guidance for unusual setups: bun and npm both unavailable, restricted global installs, or an auto-install failure (the failure reason is surfaced in the tool result).
+Manual installation is fallback guidance for unusual setups: bun unavailable, restricted global installs, or an auto-install failure (the failure reason is surfaced in the tool result).
 
 ```bash
-npm i -g @agentclientprotocol/claude-agent-acp   # claude
-npm i -g @zed-industries/codex-acp               # codex
-npm i -g @google/gemini-cli                      # gemini
+bun add -g @agentclientprotocol/claude-agent-acp   # claude
+bun add -g @zed-industries/codex-acp               # codex
+bun add -g @google/gemini-cli                       # gemini
 ```
 
 ## Claude setup
@@ -71,7 +71,7 @@ When the token is missing, do NOT ask the user to paste it into chat. Collect it
 
 ## Codex setup
 
-The `codex-acp` adapter is fetched automatically when missing, but it shells out to the underlying `codex` CLI, which must also be on PATH:
+The `codex-acp` adapter is installed automatically when missing, but it shells out to the underlying `codex` CLI, which must also be on PATH:
 
 1. **Install the Codex CLI** (version 0.111 or higher) via OpenAI's distribution channel of choice. The adapter will fail if `codex` isn't on PATH.
 
@@ -82,7 +82,7 @@ The `codex-acp` adapter is fetched automatically when missing, but it shells out
 
 ## Gemini setup
 
-Gemini CLI speaks ACP natively (`gemini --acp`) - there is no separate adapter binary. The CLI itself is fetched from `@google/gemini-cli` when missing.
+Gemini CLI speaks ACP natively (`gemini --acp`) - there is no separate adapter binary. The CLI itself is installed from `@google/gemini-cli` when missing.
 
 **Authenticate** with an API key through the credential store (the primary path):
 
@@ -120,14 +120,14 @@ A workspace `acp.agents.gemini` override is only for non-secret customization (c
 
 ## Updating an adapter
 
-This applies only to adapters installed globally via npm; adapters run via bun are fetched on first use and have no global install to update. If `acp_spawn` reports that an adapter is outdated, ask the user before updating. To update:
+Adapters are installed once via a bun global install. To update one to the latest version, ask the user first, then re-install it globally:
 
 ```bash
-npm i -g @agentclientprotocol/claude-agent-acp@latest
+bun add -g @agentclientprotocol/claude-agent-acp@latest
 # or
-npm i -g @zed-industries/codex-acp@latest
+bun add -g @zed-industries/codex-acp@latest
 # or
-npm i -g @google/gemini-cli@latest
+bun add -g @google/gemini-cli@latest
 ```
 
 Then retry the `acp_spawn` call.
@@ -140,7 +140,7 @@ Then retry the `acp_spawn` call.
 
 ## Discoverability
 
-Use `acp_list_agents` to see what's set up and what's missing. It returns each available agent profile, whether ACP is enabled, whether the agent is runnable (its binary is on PATH, or the assistant can run it via bun), and an install hint if not. This is the right tool to call when deciding between `claude`, `codex`, and `gemini`, or when the user asks "what coding agents do I have?"
+Use `acp_list_agents` to see what's set up and what's missing. It returns each available agent profile, whether ACP is enabled, whether the agent's binary is on PATH (missing binaries are installed automatically on first spawn), and an install hint if not. This is the right tool to call when deciding between `claude`, `codex`, and `gemini`, or when the user asks "what coding agents do I have?"
 
 ## Working directory
 

--- a/assistant/src/config/bundled-skills/acp/TOOLS.json
+++ b/assistant/src/config/bundled-skills/acp/TOOLS.json
@@ -3,7 +3,7 @@
   "tools": [
     {
       "name": "acp_spawn",
-      "description": "Spawn an external coding agent (e.g. Claude Code, Codex, Gemini) via ACP to work on a task. Default profiles ship for `claude` (`claude-agent-acp`), `codex` (`codex-acp`), and `gemini` (`gemini --acp`); the assistant resolves the agent id to the right binary. The agent runs as a subprocess and streams results back. Use this when you want to delegate a coding task to an external agent that has its own tools, file editing, and terminal access. If a default agent's binary is missing, the assistant runs it via bun (fetching the package on first use, no global install) or falls back to an npm auto-install, proceeding in the same call; if neither works, an actionable install hint is returned - do NOT alter `agents.<id>.command` to swap binaries. If ACP is disabled, follow the setup instructions in SKILL.md.",
+      "description": "Spawn an external coding agent (e.g. Claude Code, Codex, Gemini) via ACP to work on a task. Default profiles ship for `claude` (`claude-agent-acp`), `codex` (`codex-acp`), and `gemini` (`gemini --acp`); the assistant resolves the agent id to the right binary. The agent runs as a subprocess and streams results back. Use this when you want to delegate a coding task to an external agent that has its own tools, file editing, and terminal access. If a default agent's binary is missing, the assistant installs it once via a sandboxed bun global install and proceeds in the same call; if that fails (e.g. bun unavailable), an actionable install hint is returned - do NOT alter `agents.<id>.command` to swap binaries. If ACP is disabled, follow the setup instructions in SKILL.md.",
       "category": "orchestration",
       "risk": "high",
       "input_schema": {
@@ -87,7 +87,7 @@
     },
     {
       "name": "acp_list_agents",
-      "description": "Lists ACP coding agents available to spawn. Each entry includes whether ACP is enabled, whether the agent is runnable (its binary is on PATH, or the assistant can run it via bun), and an install command if not. Use this to decide between 'claude', 'codex', and 'gemini' or to surface setup steps to the user.",
+      "description": "Lists ACP coding agents available to spawn. Each entry includes whether ACP is enabled, whether the agent's binary is on PATH (missing binaries are installed automatically on first spawn), and an install command if not. Use this to decide between 'claude', 'codex', and 'gemini' or to surface setup steps to the user.",
       "category": "orchestration",
       "risk": "low",
       "input_schema": {

--- a/assistant/src/runtime/routes/__tests__/acp-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/acp-routes.test.ts
@@ -8,9 +8,10 @@
  * (default 50, max 500).
  *
  * `POST /v1/acp/spawn`: when the adapter binary is missing, the handler
- * silently auto-installs allowlisted adapter packages before failing with
- * the install hint. `execFile` is stubbed via the shared
- * `installExecFileStub` helper so tests can script `npm i -g` outcomes.
+ * silently auto-installs allowlisted adapter packages via a sandboxed `bun`
+ * global install before failing with the install hint. `execFile` is stubbed
+ * via the shared `installExecFileStub` helper so tests can script
+ * `bun add --global` outcomes.
  */
 
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -433,43 +434,20 @@ const SPAWN_BODY = {
   conversationId: "conv-1",
 };
 
-describe("POST /v1/acp/spawn: auto-install on missing binary", () => {
-  test("binary missing + bun present: spawn proceeds via bunx without npm", async () => {
-    which.setWhich({ bun: "/usr/local/bin/bun" });
+const BUN_BIN = "/usr/local/bin/bun";
+const BUN_ADD_KEY = `${BUN_BIN} add`;
 
-    const handler = getSpawnHandler();
-    const body = (await handler({ body: SPAWN_BODY })) as Record<
-      string,
-      unknown
-    >;
-
-    expect(body).toEqual({
-      acpSessionId: "acp-route-session",
-      protocolSessionId: "proto-route-session",
-      agent: "claude",
-    });
-    expect(execFileMock).not.toHaveBeenCalled();
-    expect(spawnMock).toHaveBeenCalledTimes(1);
-    const agentConfigArg = (spawnMock.mock.calls[0] as unknown[])[1] as {
-      command: string;
-      args: string[];
-      adapterCommand?: string;
-    };
-    expect(agentConfigArg.command).toBe("bun");
-    expect(agentConfigArg.args).toEqual([
-      "x",
-      "--bun",
-      "@agentclientprotocol/claude-agent-acp",
-    ]);
-    expect(agentConfigArg.adapterCommand).toBe("claude-agent-acp");
-  });
-
-  test("known command: installs the mapped package and spawn proceeds", async () => {
-    // Binary appears on PATH only after `npm i -g` runs, simulating a
-    // successful global install.
+describe("POST /v1/acp/spawn: sandboxed bun auto-install on missing binary", () => {
+  test("known command + bun present: installs via bun, then spawns the real binary", async () => {
+    // Binary appears on PATH only after `bun add --global` runs, simulating a
+    // successful global install that links the adapter bin onto PATH.
     let binaryOnPath = false;
-    which.setWhich((cmd) => (binaryOnPath ? `/usr/local/bin/${cmd}` : null));
-    execScripts.set("npm i", {
+    which.setWhich((cmd) => {
+      if (cmd === "bun") return BUN_BIN;
+      if (binaryOnPath) return `/usr/local/bin/${cmd}`;
+      return null;
+    });
+    execScripts.set(BUN_ADD_KEY, {
       stdout: "",
       onCall: () => {
         binaryOnPath = true;
@@ -488,17 +466,68 @@ describe("POST /v1/acp/spawn: auto-install on missing binary", () => {
       agent: "claude",
     });
     expect(spawnMock).toHaveBeenCalledTimes(1);
+    // The real adapter binary is spawned, not a `bun x` wrapper.
+    const agentConfigArg = (spawnMock.mock.calls[0] as unknown[])[1] as {
+      command: string;
+    };
+    expect(agentConfigArg.command).toBe("claude-agent-acp");
+    // Exactly one install, and it was `bun add --global` (never npm).
     expect(execFileMock).toHaveBeenCalledTimes(1);
-    expect(execFileMock.mock.calls[0][1]).toEqual([
-      "i",
-      "-g",
+    const [command, args] = execFileMock.mock.calls[0];
+    expect(command).toBe(BUN_BIN);
+    expect(args).toEqual([
+      "add",
+      "--global",
       "@agentclientprotocol/claude-agent-acp",
     ]);
   });
 
-  test("npm failure: FailedDependencyError carries hint and failure reason", async () => {
-    which.setWhich({});
-    execScripts.set("npm i", {
+  test("install runs in a temp dir (not the task cwd) with secrets stripped", async () => {
+    let binaryOnPath = false;
+    which.setWhich((cmd) => {
+      if (cmd === "bun") return BUN_BIN;
+      if (binaryOnPath) return `/usr/local/bin/${cmd}`;
+      return null;
+    });
+    execScripts.set(BUN_ADD_KEY, {
+      stdout: "",
+      onCall: () => {
+        binaryOnPath = true;
+      },
+    });
+
+    const handler = getSpawnHandler();
+    await handler({ body: { ...SPAWN_BODY, cwd: "/untrusted/project" } });
+
+    const options = execFileMock.mock.calls[0][2] as {
+      cwd?: string;
+      env?: NodeJS.ProcessEnv;
+    };
+    expect(options.cwd).not.toBe("/untrusted/project");
+    expect(options.cwd).toContain("vellum-acp-install-");
+    expect(options.env?.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+    expect(options.env?.GEMINI_API_KEY).toBeUndefined();
+    expect(options.env?.BUN_CONFIG_REGISTRY).toBe(
+      "https://registry.npmjs.org/",
+    );
+  });
+
+  test("bun absent: no install attempted, FailedDependencyError with the hint", async () => {
+    which.setWhich({}); // neither bun nor the adapter on PATH
+
+    const handler = getSpawnHandler();
+    const promise = handler({ body: SPAWN_BODY });
+    await expect(promise).rejects.toBeInstanceOf(FailedDependencyError);
+    await expect(promise).rejects.toThrow(
+      /claude-agent-acp is not on PATH.*bun add -g @agentclientprotocol\/claude-agent-acp/,
+    );
+    expect(execFileMock).not.toHaveBeenCalled();
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  test("install failure: FailedDependencyError carries hint and failure reason, never npm", async () => {
+    which.setWhich({ bun: BUN_BIN });
+    execScripts.set(BUN_ADD_KEY, {
       error: new Error("EACCES: permission denied"),
     });
 
@@ -506,8 +535,11 @@ describe("POST /v1/acp/spawn: auto-install on missing binary", () => {
     const promise = handler({ body: SPAWN_BODY });
     await expect(promise).rejects.toBeInstanceOf(FailedDependencyError);
     await expect(promise).rejects.toThrow(
-      /claude-agent-acp is not on PATH.*npm i -g @agentclientprotocol\/claude-agent-acp.*auto-install failed.*EACCES/,
+      /claude-agent-acp is not on PATH.*bun add -g @agentclientprotocol\/claude-agent-acp.*auto-install failed.*EACCES/,
     );
+    for (const call of execFileMock.mock.calls) {
+      expect(call[0]).not.toBe("npm");
+    }
     expect(spawnMock).not.toHaveBeenCalled();
   });
 

--- a/assistant/src/tools/acp/list-agents.test.ts
+++ b/assistant/src/tools/acp/list-agents.test.ts
@@ -107,12 +107,12 @@ describe("executeAcpListAgents", () => {
     const codex = parsed.agents.find((a: { id: string }) => a.id === "codex");
     expect(codex.available).toBe(false);
     expect(codex.unavailableReason).toBe("'codex-acp' is not on PATH");
-    expect(codex.setupHint).toBe("npm i -g @zed-industries/codex-acp");
+    expect(codex.setupHint).toBe("bun add -g @zed-industries/codex-acp");
 
     const gemini = parsed.agents.find((a: { id: string }) => a.id === "gemini");
     expect(gemini.available).toBe(false);
     expect(gemini.unavailableReason).toBe("'gemini' is not on PATH");
-    expect(gemini.setupHint).toBe("npm i -g @google/gemini-cli");
+    expect(gemini.setupHint).toBe("bun add -g @google/gemini-cli");
 
     const claude = parsed.agents.find((a: { id: string }) => a.id === "claude");
     expect(claude.available).toBe(true);

--- a/assistant/src/tools/acp/spawn.test.ts
+++ b/assistant/src/tools/acp/spawn.test.ts
@@ -15,8 +15,12 @@ const {
   reset: resetExecFileStub,
 } = installExecFileStub();
 
+/** Fixed resolved `bun` path so install script keys are predictable. */
+const BUN_BIN = "/usr/local/bin/bun";
+const BUN_ADD_KEY = `${BUN_BIN} add`;
+
 // Default ACP config used by these tests: the `unknown-agent` entry is here
-// to give the "no version check" test a configured agent whose binary isn't
+// to give the "unmapped binary" tests a configured agent whose command isn't
 // in DEFAULT_AGENT_NPM_PACKAGES.
 const DEFAULT_TEST_AGENTS = {
   claude: { command: "claude-agent-acp", args: [] },
@@ -143,8 +147,7 @@ mock.module("../../acp/index.js", () => ({
   getAcpSessionManager: () => ({ spawn: spawnMock }),
 }));
 
-const { executeAcpSpawn, _resetAdapterVersionCacheForTests } =
-  await import("./spawn.js");
+const { executeAcpSpawn } = await import("./spawn.js");
 const { _resetAdapterInstallCacheForTests } = await import(
   "../../acp/auto-install.js"
 );
@@ -165,9 +168,10 @@ function makeContext(): ToolContext {
 beforeEach(() => {
   resetExecFileStub();
   spawnMock.mockClear();
-  _resetAdapterVersionCacheForTests();
   _resetAdapterInstallCacheForTests();
   config.setConfig({ agents: DEFAULT_TEST_AGENTS });
+  // Default: every command (including bun and the adapters) on PATH, so
+  // spawns resolve directly with no install.
   which.setWhich((cmd) => `/usr/local/bin/${cmd}`);
   // Default: vault has a claude token so the preflight in `prepareAgentEnv`
   // succeeds for tests that don't care about env injection. Env-injection
@@ -181,135 +185,41 @@ beforeEach(() => {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("executeAcpSpawn — version check", () => {
-  test("execFile failure: spawn proceeds without warning", async () => {
-    execScripts.set("npm ls", { error: new Error("npm not installed") });
-    execScripts.set("npm view", { error: new Error("npm not installed") });
-
+describe("executeAcpSpawn - happy path", () => {
+  test("binary on PATH: spawns directly with no install and no npm probe", async () => {
     const result = await executeAcpSpawn(
       { agent: "claude", task: "do something" },
       makeContext(),
     );
 
     expect(result.isError).toBe(false);
+    // No package manager is ever invoked when the binary is already present.
+    expect(execFileMock).not.toHaveBeenCalled();
     expect(result.content).not.toContain("outdated");
-    expect(result.content).not.toContain("Note:");
-    // Spawn was actually invoked.
     expect(spawnMock).toHaveBeenCalledTimes(1);
-    // Sanity: payload shape preserved.
-    const lines = result.content.split("\n\n");
-    const payload = JSON.parse(lines[0]);
+    const payload = JSON.parse(result.content);
     expect(payload.acpSessionId).toBe("acp-session-test");
     expect(payload.status).toBe("running");
+    // The real adapter binary is spawned (no `bun x` wrapper).
+    const agentConfigArg = spawnMock.mock.calls[0][1] as { command: string };
+    expect(agentConfigArg.command).toBe("claude-agent-acp");
   });
 
-  test("outdated version: spawn proceeds AND warning appears in content", async () => {
-    execScripts.set("npm ls", {
-      stdout: JSON.stringify({
-        dependencies: {
-          "@agentclientprotocol/claude-agent-acp": { version: "0.1.0" },
-        },
-      }),
-    });
-    execScripts.set("npm view", { stdout: "0.2.0\n" });
+  test("default-profile fallback when user config is empty", async () => {
+    // No user `agents.codex` entry, but `agent: "codex"` works via the bundled
+    // default profile (command: "codex-acp"). The resolver merges defaults
+    // automatically.
+    config.setConfig({ agents: {} });
 
     const result = await executeAcpSpawn(
-      { agent: "claude", task: "do something" },
+      { agent: "codex", task: "do something" },
       makeContext(),
     );
 
     expect(result.isError).toBe(false);
-    expect(result.content).toContain("outdated");
-    expect(result.content).toContain("@agentclientprotocol/claude-agent-acp");
-    expect(result.content).toContain("0.1.0");
-    expect(result.content).toContain("0.2.0");
-    expect(result.content).toContain(
-      "npm install -g @agentclientprotocol/claude-agent-acp@0.2.0",
-    );
     expect(spawnMock).toHaveBeenCalledTimes(1);
-    // Payload still parses as JSON before the warning suffix.
-    const [payloadJson] = result.content.split("\n\n");
-    const payload = JSON.parse(payloadJson);
-    expect(payload.acpSessionId).toBe("acp-session-test");
-  });
-
-  test("up-to-date version: spawn proceeds, no warning", async () => {
-    execScripts.set("npm ls", {
-      stdout: JSON.stringify({
-        dependencies: {
-          "@agentclientprotocol/claude-agent-acp": { version: "0.2.0" },
-        },
-      }),
-    });
-    execScripts.set("npm view", { stdout: "0.2.0\n" });
-
-    const result = await executeAcpSpawn(
-      { agent: "claude", task: "do something" },
-      makeContext(),
-    );
-
-    expect(result.isError).toBe(false);
-    expect(result.content).not.toContain("outdated");
-    expect(spawnMock).toHaveBeenCalledTimes(1);
-  });
-
-  test("unknown command: no version check is performed", async () => {
-    // No execScripts set — if the implementation tried to run npm, the
-    // mock would callback with "No script for ..." and we could detect
-    // the failure. But since the registry doesn't include this command,
-    // the implementation should skip the check entirely without calling
-    // execFile.
-    execFileMock.mockClear();
-
-    const result = await executeAcpSpawn(
-      { agent: "unknown-agent", task: "do something" },
-      makeContext(),
-    );
-
-    expect(result.isError).toBe(false);
-    expect(execFileMock).not.toHaveBeenCalled();
-    expect(spawnMock).toHaveBeenCalledTimes(1);
-    // No outdated note suffix.
-    expect(result.content).not.toContain("outdated");
-  });
-
-  test("cached null result: second call does not reprobe", async () => {
-    execScripts.set("npm ls", { error: new Error("npm not installed") });
-    execScripts.set("npm view", { error: new Error("npm not installed") });
-
-    await executeAcpSpawn({ agent: "claude", task: "task 1" }, makeContext());
-    const firstCallCount = execFileMock.mock.calls.length;
-    expect(firstCallCount).toBeGreaterThan(0);
-
-    await executeAcpSpawn({ agent: "claude", task: "task 2" }, makeContext());
-    // No additional execFile calls — result was cached.
-    expect(execFileMock.mock.calls.length).toBe(firstCallCount);
-  });
-
-  test("cached outdated result: second call does not reprobe but still warns", async () => {
-    execScripts.set("npm ls", {
-      stdout: JSON.stringify({
-        dependencies: {
-          "@agentclientprotocol/claude-agent-acp": { version: "0.1.0" },
-        },
-      }),
-    });
-    execScripts.set("npm view", { stdout: "0.2.0\n" });
-
-    const first = await executeAcpSpawn(
-      { agent: "claude", task: "task 1" },
-      makeContext(),
-    );
-    expect(first.content).toContain("outdated");
-    const firstCallCount = execFileMock.mock.calls.length;
-
-    const second = await executeAcpSpawn(
-      { agent: "claude", task: "task 2" },
-      makeContext(),
-    );
-    expect(second.content).toContain("outdated");
-    // No additional execFile calls — outdated info was cached.
-    expect(execFileMock.mock.calls.length).toBe(firstCallCount);
+    const agentConfigArg = spawnMock.mock.calls[0][1] as { command: string };
+    expect(agentConfigArg.command).toBe("codex-acp");
   });
 });
 
@@ -350,9 +260,8 @@ describe("executeAcpSpawn — input validation", () => {
     expect(result.content).toContain("acp.enabled");
   });
 
-  test("missing binary returns install hint when auto-install fails", async () => {
-    which.setWhich({});
-    execScripts.set("npm i", { error: new Error("npm not installed") });
+  test("missing binary + bun absent returns install hint, no install attempted", async () => {
+    which.setWhich({}); // neither bun nor the adapter on PATH
     const result = await executeAcpSpawn(
       { agent: "claude", task: "do something" },
       makeContext(),
@@ -360,47 +269,29 @@ describe("executeAcpSpawn — input validation", () => {
     expect(result.isError).toBe(true);
     expect(result.content).toContain("claude-agent-acp is not on PATH");
     expect(result.content).toContain(
-      "npm i -g @agentclientprotocol/claude-agent-acp",
+      "bun add -g @agentclientprotocol/claude-agent-acp",
     );
+    expect(execFileMock).not.toHaveBeenCalled();
     expect(spawnMock).not.toHaveBeenCalled();
-  });
-
-  test("default-profile fallback when user config is empty", async () => {
-    // No user `agents.codex` entry, but `agent: "codex"` works via the bundled
-    // default profile (command: "codex-acp"). The resolver merges defaults
-    // automatically.
-    config.setConfig({ agents: {} });
-    execScripts.set("npm ls", { error: new Error("npm not installed") });
-    execScripts.set("npm view", { error: new Error("npm not installed") });
-
-    const result = await executeAcpSpawn(
-      { agent: "codex", task: "do something" },
-      makeContext(),
-    );
-
-    expect(result.isError).toBe(false);
-    expect(spawnMock).toHaveBeenCalledTimes(1);
-    // The agentConfig handed to spawn() should be the bundled default.
-    const agentConfigArg = spawnMock.mock.calls[0][1] as { command: string };
-    expect(agentConfigArg.command).toBe("codex-acp");
   });
 });
 
-describe("executeAcpSpawn: auto-install on missing binary", () => {
-  test("known command: installs the mapped package and spawn proceeds with a note", async () => {
-    // Binary appears on PATH only after `npm i -g` runs, simulating a
-    // successful global install.
+describe("executeAcpSpawn: sandboxed bun auto-install on missing binary", () => {
+  test("known command + bun present: installs via bun and spawn proceeds with a note", async () => {
+    // Only bun is on PATH until `bun add --global` runs, simulating a
+    // successful global install that links the adapter bin onto PATH.
     let binaryOnPath = false;
-    which.setWhich((cmd) => (binaryOnPath ? `/usr/local/bin/${cmd}` : null));
-    execScripts.set("npm i", {
+    which.setWhich((cmd) => {
+      if (cmd === "bun") return BUN_BIN;
+      if (binaryOnPath) return `/usr/local/bin/${cmd}`;
+      return null;
+    });
+    execScripts.set(BUN_ADD_KEY, {
       stdout: "",
       onCall: () => {
         binaryOnPath = true;
       },
     });
-    // Version probes after the install: best-effort, scripted to skip.
-    execScripts.set("npm ls", { error: new Error("skip") });
-    execScripts.set("npm view", { error: new Error("skip") });
 
     const result = await executeAcpSpawn(
       { agent: "claude", task: "do something" },
@@ -409,23 +300,67 @@ describe("executeAcpSpawn: auto-install on missing binary", () => {
 
     expect(result.isError).toBe(false);
     expect(spawnMock).toHaveBeenCalledTimes(1);
-    const [payloadJson] = result.content.split("\n\n");
-    const payload = JSON.parse(payloadJson);
+    const payload = JSON.parse(result.content);
     expect(payload.message).toContain(
       "Installed @agentclientprotocol/claude-agent-acp automatically.",
     );
-    const installCalls = execFileMock.mock.calls.filter(
-      (call) => (call[1] as string[])[0] === "i",
+    // The real binary was spawned with cwd = the project dir and token
+    // injected (trusted-binary config, no resolution at spawn).
+    const agentConfigArg = spawnMock.mock.calls[0][1] as {
+      command: string;
+      env?: Record<string, string>;
+    };
+    expect(agentConfigArg.command).toBe("claude-agent-acp");
+    expect(agentConfigArg.env?.CLAUDE_CODE_OAUTH_TOKEN).toBe(
+      "default-test-token",
     );
-    expect(installCalls).toHaveLength(1);
-    expect(installCalls[0][1]).toEqual([
-      "i",
-      "-g",
+    expect(spawnMock.mock.calls[0][3]).toBe("/tmp");
+
+    // Exactly one install, and it was `bun add --global` (never npm).
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+    const [command, args] = execFileMock.mock.calls[0];
+    expect(command).toBe(BUN_BIN);
+    expect(args).toEqual([
+      "add",
+      "--global",
       "@agentclientprotocol/claude-agent-acp",
     ]);
   });
 
-  test("unknown command: no install attempted, plain hint returned", async () => {
+  test("the installer cwd is a temp dir (not the project cwd) with secrets stripped", async () => {
+    let binaryOnPath = false;
+    which.setWhich((cmd) => {
+      if (cmd === "bun") return BUN_BIN;
+      if (binaryOnPath) return `/usr/local/bin/${cmd}`;
+      return null;
+    });
+    execScripts.set(BUN_ADD_KEY, {
+      stdout: "",
+      onCall: () => {
+        binaryOnPath = true;
+      },
+    });
+
+    await executeAcpSpawn(
+      { agent: "claude", task: "do something", cwd: "/untrusted/project" },
+      makeContext(),
+    );
+
+    const options = execFileMock.mock.calls[0][2] as {
+      cwd?: string;
+      env?: NodeJS.ProcessEnv;
+    };
+    expect(options.cwd).toBeDefined();
+    expect(options.cwd).not.toBe("/untrusted/project");
+    expect(options.cwd).toContain("vellum-acp-install-");
+    expect(options.env?.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+    expect(options.env?.GEMINI_API_KEY).toBeUndefined();
+    expect(options.env?.BUN_CONFIG_REGISTRY).toBe(
+      "https://registry.npmjs.org/",
+    );
+  });
+
+  test("unmapped command: no install attempted, plain hint returned", async () => {
     which.setWhich({});
 
     const result = await executeAcpSpawn(
@@ -444,9 +379,9 @@ describe("executeAcpSpawn: auto-install on missing binary", () => {
   test("no client connected: no install attempted even when the binary is missing", async () => {
     // The no-client guard is a pure precondition and must run BEFORE the
     // auto-install side effect: without a client the spawn fails anyway, so
-    // the host must not be mutated by `npm i -g` (which can also block for
-    // up to the install timeout).
-    which.setWhich({});
+    // the host must not be mutated by a global install (which can also block
+    // for up to the install timeout).
+    which.setWhich({ bun: BUN_BIN });
 
     const result = await executeAcpSpawn(
       { agent: "claude", task: "do something" },
@@ -459,9 +394,9 @@ describe("executeAcpSpawn: auto-install on missing binary", () => {
     expect(spawnMock).not.toHaveBeenCalled();
   });
 
-  test("npm failure: hint and install failure both surface", async () => {
-    which.setWhich({});
-    execScripts.set("npm i", {
+  test("install failure: hint and install failure both surface, never npm", async () => {
+    which.setWhich({ bun: BUN_BIN }); // bun present, adapter never appears
+    execScripts.set(BUN_ADD_KEY, {
       error: new Error("EACCES: permission denied"),
     });
 
@@ -473,75 +408,26 @@ describe("executeAcpSpawn: auto-install on missing binary", () => {
     expect(result.isError).toBe(true);
     expect(result.content).toContain("claude-agent-acp is not on PATH");
     expect(result.content).toContain(
-      "npm i -g @agentclientprotocol/claude-agent-acp",
+      "bun add -g @agentclientprotocol/claude-agent-acp",
     );
     expect(result.content).toContain("auto-install failed");
     expect(result.content).toContain("EACCES");
+    for (const call of execFileMock.mock.calls) {
+      expect(call[0]).not.toBe("npm");
+    }
     expect(spawnMock).not.toHaveBeenCalled();
   });
 });
 
-describe("executeAcpSpawn - bunx fallback when binary missing", () => {
-  test("binary missing + bun present: spawns via `bun x` with env injection and resume hint, no npm calls", async () => {
-    // Only bun is on PATH - the platform-hosted image (bun, no node/npm).
-    which.setWhich({ bun: "/usr/local/bin/bun" });
-
-    const result = await executeAcpSpawn(
-      { agent: "claude", task: "do something" },
-      makeContext(),
-    );
-
-    expect(result.isError).toBe(false);
-    // No npm install AND no npm version probe: bunx fetches the package on
-    // first use and there is no global install to compare.
-    expect(execFileMock).not.toHaveBeenCalled();
-    expect(result.content).not.toContain("outdated");
-
-    expect(spawnMock).toHaveBeenCalledTimes(1);
-    const agentConfigArg = spawnMock.mock.calls[0][1] as {
-      command: string;
-      args: string[];
-      adapterCommand?: string;
-      env?: Record<string, string>;
-    };
-    expect(agentConfigArg.command).toBe("bun");
-    expect(agentConfigArg.args).toEqual([
-      "x",
-      "--bun",
-      "@agentclientprotocol/claude-agent-acp",
-    ]);
-    expect(agentConfigArg.adapterCommand).toBe("claude-agent-acp");
-    // CLAUDE_CODE_OAUTH_TOKEN injection still applies to the bunx-resolved
-    // claude adapter (gated on adapterCommand, not the spawn command).
-    expect(agentConfigArg.env?.CLAUDE_CODE_OAUTH_TOKEN).toBe(
-      "default-test-token",
-    );
-
-    const [payloadJson] = result.content.split("\n\n");
-    const payload = JSON.parse(payloadJson);
-    // No auto-install happened; the claude resume hint still fires.
-    expect(payload.message).not.toContain("Installed");
-    expect(payload.message).toContain("claude --resume");
-  });
-
-  // The bun-absent npm fallback is covered by the existing auto-install
-  // suite below ("known command: installs the mapped package..."), whose
-  // which-stub leaves bun off PATH until the install completes.
-});
-
 describe("executeAcpSpawn — per-agent resume hint", () => {
   test("claude payload includes the `claude --resume` hint", async () => {
-    execScripts.set("npm ls", { error: new Error("npm not installed") });
-    execScripts.set("npm view", { error: new Error("npm not installed") });
-
     const result = await executeAcpSpawn(
       { agent: "claude", task: "do something" },
       makeContext(),
     );
 
     expect(result.isError).toBe(false);
-    const [payloadJson] = result.content.split("\n\n");
-    const payload = JSON.parse(payloadJson);
+    const payload = JSON.parse(result.content);
     expect(payload.message).toContain("claude --resume");
     expect(payload.message).toContain("To resume:");
   });
@@ -549,17 +435,13 @@ describe("executeAcpSpawn — per-agent resume hint", () => {
   test("non-claude payload omits the `claude --resume` hint", async () => {
     // `claude --resume <id>` is Claude Code-specific. Codex (and any other
     // adapter) should not have that command suggested back to the user.
-    execScripts.set("npm ls", { error: new Error("npm not installed") });
-    execScripts.set("npm view", { error: new Error("npm not installed") });
-
     const result = await executeAcpSpawn(
       { agent: "codex", task: "do something" },
       makeContext(),
     );
 
     expect(result.isError).toBe(false);
-    const [payloadJson] = result.content.split("\n\n");
-    const payload = JSON.parse(payloadJson);
+    const payload = JSON.parse(result.content);
     expect(payload.message).not.toContain("claude --resume");
     expect(payload.message).not.toContain("To resume:");
   });
@@ -585,8 +467,6 @@ describe("executeAcpSpawn — CLAUDE_CODE_OAUTH_TOKEN injection", () => {
     vaultStore.clear();
     metadataStore.clear();
     vaultStore.set("acp/claude_oauth_token", "tool-vault-token-abc");
-    execScripts.set("npm ls", { error: new Error("npm not installed") });
-    execScripts.set("npm view", { error: new Error("npm not installed") });
 
     const result = await executeAcpSpawn(
       { agent: "claude", task: "do something" },
@@ -617,8 +497,6 @@ describe("executeAcpSpawn — CLAUDE_CODE_OAUTH_TOKEN injection", () => {
         "unknown-agent": { command: "some-other-binary", args: [] },
       },
     });
-    execScripts.set("npm ls", { error: new Error("npm not installed") });
-    execScripts.set("npm view", { error: new Error("npm not installed") });
 
     const result = await executeAcpSpawn(
       { agent: "claude", task: "do something" },

--- a/assistant/src/tools/acp/spawn.ts
+++ b/assistant/src/tools/acp/spawn.ts
@@ -1,107 +1,12 @@
-import {
-  execFileWithTimeout,
-  resolveAgentWithAutoInstall,
-} from "../../acp/auto-install.js";
+import { basename } from "node:path";
+
+import { resolveAgentWithAutoInstall } from "../../acp/auto-install.js";
 import { getAcpSessionManager } from "../../acp/index.js";
 import { prepareAgentEnv } from "../../acp/prepare-agent-env.js";
-import {
-  adapterCommandOf,
-  formatResolveFailure,
-  runsViaBunx,
-} from "../../acp/resolve-agent.js";
+import { formatResolveFailure } from "../../acp/resolve-agent.js";
 import { claudeResumeHint } from "../../acp/resume-hint.js";
-import { DEFAULT_AGENT_NPM_PACKAGES } from "../../config/acp-defaults.js";
-import { getLogger } from "../../util/logger.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
 import { getSendToClient } from "./context.js";
-
-const log = getLogger("acp:spawn");
-
-/** Per-call timeout for `npm` probes. Best-effort: timeouts are non-fatal. */
-const NPM_PROBE_TIMEOUT_MS = 5_000;
-
-/**
- * Cache of resolved version-check outcomes — including `null` for "skipped" —
- * keyed by command. Lives for the process lifetime so retries don't reprobe.
- */
-const adapterVersionCache = new Map<string, AdapterVersionInfo | null>();
-
-interface AdapterVersionInfo {
-  outdated: true;
-  installed: string;
-  latest: string;
-  packageName: string;
-}
-
-/**
- * Checks if the globally-installed ACP adapter for `command` is outdated.
- * Best-effort: any error or timeout returns `null` (skipped). Unknown
- * commands also return `null`. Results are cached per-command for the
- * process lifetime.
- *
- * Note: `npm ls -g` doesn't see Homebrew/tarball installs, so a "not found"
- * here doesn't mean the binary is missing — it just means we can't compare
- * versions. The caller must NEVER block the spawn on this result.
- */
-async function checkAdapterVersion(
-  command: string,
-): Promise<AdapterVersionInfo | null> {
-  if (adapterVersionCache.has(command)) {
-    return adapterVersionCache.get(command) ?? null;
-  }
-
-  const packageName = DEFAULT_AGENT_NPM_PACKAGES[command];
-  if (!packageName) {
-    adapterVersionCache.set(command, null);
-    return null;
-  }
-
-  try {
-    const [installedRaw, latestRaw] = await Promise.all([
-      execFileWithTimeout(
-        "npm",
-        ["ls", "-g", "--json", packageName],
-        NPM_PROBE_TIMEOUT_MS,
-      ),
-      execFileWithTimeout(
-        "npm",
-        ["view", packageName, "version"],
-        NPM_PROBE_TIMEOUT_MS,
-      ),
-    ]);
-
-    const installed =
-      JSON.parse(installedRaw)?.dependencies?.[packageName]?.version;
-    const latest = latestRaw.trim();
-
-    if (!installed || !latest || installed === latest) {
-      adapterVersionCache.set(command, null);
-      return null;
-    }
-
-    log.info({ installed, latest, packageName }, "ACP adapter is outdated");
-    const info: AdapterVersionInfo = {
-      outdated: true,
-      installed,
-      latest,
-      packageName,
-    };
-    adapterVersionCache.set(command, info);
-    return info;
-  } catch (err) {
-    log.warn(
-      { err, packageName },
-      "Failed to check ACP adapter version (best-effort, skipping)",
-    );
-    adapterVersionCache.set(command, null);
-    return null;
-  }
-}
-
-/** @internal — exposed for tests only. */
-export function _resetAdapterVersionCacheForTests(): void {
-  adapterVersionCache.clear();
-}
 
 export async function executeAcpSpawn(
   input: Record<string, unknown>,
@@ -115,8 +20,9 @@ export async function executeAcpSpawn(
   }
 
   // Pure precondition: check for a connected client BEFORE any side effects
-  // (auto-install mutates the host via `npm i -g` and can block for up to
-  // the install timeout). Without a client the spawn cannot succeed anyway.
+  // (auto-install mutates the host via a `bun` global install and can block
+  // for up to the install timeout). Without a client the spawn cannot
+  // succeed anyway.
   const sendToClient = getSendToClient(context);
   if (!sendToClient) {
     return {
@@ -150,14 +56,6 @@ export async function executeAcpSpawn(
     return { content: msg, isError: true };
   }
 
-  // Best-effort version check — never blocks the spawn. If outdated, we
-  // append a non-blocking warning to the success payload. Skipped for
-  // bunx-resolved agents: there is no global npm install to compare (bun
-  // fetches the package on first use), and npm may not exist on the host.
-  const versionInfo = runsViaBunx(agentConfig)
-    ? null
-    : await checkAdapterVersion(adapterCommandOf(agentConfig));
-
   try {
     const manager = getAcpSessionManager();
     const cwd = (input.cwd as string) || context.workingDir;
@@ -171,10 +69,10 @@ export async function executeAcpSpawn(
     );
 
     // Claude Code-only resume hint; empty for other adapters. Keyed off the
-    // canonical adapter command so it survives the bunx rewrite. See
+    // resolved command basename (always the real adapter binary). See
     // acp/resume-hint.ts for the gating rationale.
     const hint = claudeResumeHint(
-      adapterCommandOf(agentConfig),
+      basename(agentConfig.command),
       cwd,
       protocolSessionId,
     );
@@ -194,15 +92,7 @@ export async function executeAcpSpawn(
         `${installNote}${resumeHint}`,
     });
 
-    let content = payload;
-    if (versionInfo) {
-      content +=
-        `\n\nNote: ${versionInfo.packageName} is outdated ` +
-        `(installed: ${versionInfo.installed}, latest: ${versionInfo.latest}). ` +
-        `To update, run: npm install -g ${versionInfo.packageName}@${versionInfo.latest}`;
-    }
-
-    return { content, isError: false };
+    return { content: payload, isError: false };
   } catch (err) {
     const msg =
       err instanceof Error


### PR DESCRIPTION
## Summary
- Security fix for ATL-808: stop running package resolution (bun x) in the untrusted task cwd with the Claude/Gemini token in env. A malicious repo could hijack resolution (local node_modules/.bin, cwd bunfig.toml/.npmrc registry redirect, lifecycle scripts) and run code as the assistant with the secret.
- Missing adapters are now installed once via a sandboxed bun global install: a fresh empty temp dir as cwd, the secrets stripped from the installer env, and BUN_CONFIG_REGISTRY forced to the public npm registry. The resolved REAL binary is then spawned the normal trusted way (project cwd, token injected only at spawn).
- Removes npm from the ACP path entirely (bun is the universal runtime; npm is absent on hosted): deletes the npm i -g fallback and the npm version probe, and the command==='bun' indirection from #33729.

## Original prompt
Codex flagged (ATL-808, high) that the bun x fallback added in #33729 resolves adapter packages in the untrusted task cwd while CLAUDE_CODE_OAUTH_TOKEN is injected, enabling code execution with the token via project-local package-manager state. We decided to fix the root cause (decouple resolution from the untrusted cwd, keep the secret out of resolution) by switching to a one-time sandboxed bun global install and then running the real installed binary, and to standardize fully on bun by removing npm from the ACP path.

## Reviewer note: bun global bin linking (please verify)
This change relies on `bun add --global <pkg>` installing AND linking each adapter's bin into bun's global bin dir (which is on PATH in our images), so the re-resolve via `Bun.which(command)` finds the real binary. I could not verify offline that this holds for all three:
- `@agentclientprotocol/claude-agent-acp` (bin: claude-agent-acp)
- `@google/gemini-cli` (bin: gemini)
- `@zed-industries/codex-acp` (ships a native binary; confirm bun links its bin and that the platform/arch artifact resolves under a global install)

If any package's bin is not linked onto PATH by `bun add --global`, the post-install re-resolve will still report binary_not_found. Please confirm on a hosted image (bun, no npm) before merge. The chosen subcommand is `bun add --global`; `bun install --global` is an alias.
