### PR TITLE
feat(assistant): add app_update tool; make app_create name optional (JARVIS-1104)

### DIFF
--- a/assistant/src/__tests__/app-builder-tool-scripts.test.ts
+++ b/assistant/src/__tests__/app-builder-tool-scripts.test.ts
@@ -81,6 +81,7 @@ mock.module("../bundler/app-compiler.js", () => ({
 import * as appCreateScript from "../config/bundled-skills/app-builder/tools/app-create.js";
 import * as appDeleteScript from "../config/bundled-skills/app-builder/tools/app-delete.js";
 import * as appRefreshScript from "../config/bundled-skills/app-builder/tools/app-refresh.js";
+import * as appUpdateScript from "../config/bundled-skills/app-builder/tools/app-update.js";
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -169,6 +170,26 @@ describe("app-builder skill tool scripts", () => {
       const parsed = JSON.parse(result.content);
       expect(parsed.refreshed).toBe(true);
       expect(parsed.appId).toBe("app-1");
+    });
+  });
+
+  // ---- app-update --------------------------------------------------------
+
+  describe("app-update", () => {
+    test("exports a run function", () => {
+      expect(typeof appUpdateScript.run).toBe("function");
+    });
+
+    test("delegates to executeAppUpdate and returns result", async () => {
+      const result = await appUpdateScript.run(
+        { app_id: "app-1", name: "Renamed" },
+        makeContext(),
+      );
+      expect(result.isError).toBe(false);
+      const parsed = JSON.parse(result.content);
+      expect(parsed.updated).toBe(true);
+      expect(parsed.appId).toBe("app-1");
+      expect(parsed.name).toBe("Renamed");
     });
   });
 });

--- a/assistant/src/__tests__/app-executors.test.ts
+++ b/assistant/src/__tests__/app-executors.test.ts
@@ -90,9 +90,9 @@ function mockStore(
 // ---------------------------------------------------------------------------
 
 describe("executeAppCreate", () => {
-  test("defaults the name to 'Untitled app' when omitted or blank", async () => {
+  test("falls back to the preview title when the name is omitted or blank", async () => {
     let createdParams: Record<string, unknown> | undefined;
-    const app = makeMultifileApp({ name: "Untitled app" });
+    const app = makeMultifileApp({ name: "Coffee Tracker" });
     const store: AppStore = {
       ...mockStore(app, {}),
       createApp: (params) => {
@@ -101,10 +101,33 @@ describe("executeAppCreate", () => {
       },
     };
 
-    const result = await executeAppCreate({ name: "   " }, store);
+    const result = await executeAppCreate(
+      { name: "   ", preview: { title: "Coffee Tracker" } },
+      store,
+    );
 
     expect(result.isError).toBe(false);
-    expect(createdParams?.name).toBe("Untitled app");
+    expect(createdParams?.name).toBe("Coffee Tracker");
+  });
+
+  test("defaults the name to 'New App' when neither name nor preview title is given", async () => {
+    let createdParams: Record<string, unknown> | undefined;
+    const app = makeMultifileApp({ name: "New App" });
+    const store: AppStore = {
+      ...mockStore(app, {}),
+      createApp: (params) => {
+        createdParams = params as unknown as Record<string, unknown>;
+        return app;
+      },
+    };
+
+    const result = await executeAppCreate(
+      {} as unknown as Parameters<typeof executeAppCreate>[0],
+      store,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(createdParams?.name).toBe("New App");
   });
 
   test("creates multifile app with src/ scaffold", async () => {

--- a/assistant/src/__tests__/app-executors.test.ts
+++ b/assistant/src/__tests__/app-executors.test.ts
@@ -32,6 +32,7 @@ import type { AppStore } from "../tools/apps/executors.js";
 import {
   executeAppCreate,
   executeAppRefresh,
+  executeAppUpdate,
 } from "../tools/apps/executors.js";
 
 // ---------------------------------------------------------------------------
@@ -89,6 +90,23 @@ function mockStore(
 // ---------------------------------------------------------------------------
 
 describe("executeAppCreate", () => {
+  test("defaults the name to 'Untitled app' when omitted or blank", async () => {
+    let createdParams: Record<string, unknown> | undefined;
+    const app = makeMultifileApp({ name: "Untitled app" });
+    const store: AppStore = {
+      ...mockStore(app, {}),
+      createApp: (params) => {
+        createdParams = params as unknown as Record<string, unknown>;
+        return app;
+      },
+    };
+
+    const result = await executeAppCreate({ name: "   " }, store);
+
+    expect(result.isError).toBe(false);
+    expect(createdParams?.name).toBe("Untitled app");
+  });
+
   test("creates multifile app with src/ scaffold", async () => {
     const files: Record<string, string> = {};
     let createdParams: Record<string, unknown> | undefined;
@@ -406,5 +424,96 @@ describe("executeAppRefresh", () => {
     expect(result.isError).toBe(true);
     const parsed = JSON.parse(result.content);
     expect(parsed.error).toContain("not found");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// executeAppUpdate
+// ---------------------------------------------------------------------------
+
+describe("executeAppUpdate", () => {
+  test("updates metadata and recompiles a multifile app", async () => {
+    const app = makeMultifileApp({ name: "Old", description: "old desc" });
+    let updateArgs: unknown;
+    const store: AppStore = {
+      ...mockStore(app),
+      updateApp: (_id, updates) => {
+        updateArgs = updates;
+        return { ...app, ...updates };
+      },
+    };
+
+    const result = await executeAppUpdate(
+      { app_id: app.id, name: "New Name", description: "new desc" },
+      store,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(updateArgs).toEqual({ name: "New Name", description: "new desc" });
+    const parsed = JSON.parse(result.content);
+    expect(parsed.updated).toBe(true);
+    expect(parsed.name).toBe("New Name");
+    expect(parsed.description).toBe("new desc");
+    expect(parsed.compiled).toBe(true);
+  });
+
+  test("writes source_files before recompiling", async () => {
+    const files: Record<string, string> = {};
+    const app = makeMultifileApp();
+    const store: AppStore = {
+      ...mockStore(app, files),
+      updateApp: (_id, updates) => ({ ...app, ...updates }),
+    };
+
+    const result = await executeAppUpdate(
+      { app_id: app.id, source_files: { "src/App.tsx": "// new code" } },
+      store,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(files["src/App.tsx"]).toBe("// new code");
+    expect(JSON.parse(result.content).compiled).toBe(true);
+  });
+
+  test("legacy app: updates without compiling", async () => {
+    const app = makeLegacyApp({ name: "Legacy" });
+    const store: AppStore = {
+      ...mockStore(app),
+      updateApp: (_id, updates) => ({ ...app, ...updates }),
+    };
+
+    const result = await executeAppUpdate(
+      { app_id: app.id, name: "Renamed" },
+      store,
+    );
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.updated).toBe(true);
+    expect(parsed.name).toBe("Renamed");
+    expect(parsed.compiled).toBeUndefined();
+  });
+
+  test("returns error for unknown app", async () => {
+    const store = mockStore(makeMultifileApp());
+    const result = await executeAppUpdate({ app_id: "nope" }, store);
+
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content).error).toContain("not found");
+  });
+
+  test("rejects invalid source_files", async () => {
+    const app = makeMultifileApp();
+    const store = mockStore(app);
+    const result = await executeAppUpdate(
+      {
+        app_id: app.id,
+        source_files: { "src/App.tsx": 123 as unknown as string },
+      },
+      store,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content).error).toContain("must be a string");
   });
 });

--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -203,7 +203,7 @@ render(<App />, document.getElementById("app")!);
 
 #### `app_create` accepts EXACTLY these 7 keys — nothing else
 
-`name` (optional — defaults to "Untitled app"), `description`, `schema_json`, `source_files`, `preview`, `auto_open`, `change_summary`.
+`name` (optional — defaults to the `preview` title, else "New App"), `description`, `schema_json`, `source_files`, `preview`, `auto_open`, `change_summary`.
 
 Anything else fails with `Invalid input for tool "app_create": Unknown parameter "X"`. The retired keys models still reach for:
 

--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -203,7 +203,7 @@ render(<App />, document.getElementById("app")!);
 
 #### `app_create` accepts EXACTLY these 7 keys — nothing else
 
-`name` (required), `description`, `schema_json`, `source_files`, `preview`, `auto_open`, `change_summary`.
+`name` (optional — defaults to "Untitled app"), `description`, `schema_json`, `source_files`, `preview`, `auto_open`, `change_summary`.
 
 Anything else fails with `Invalid input for tool "app_create": Unknown parameter "X"`. The retired keys models still reach for:
 
@@ -251,10 +251,10 @@ Editing an existing app means reusing its `app_id` — never `app_create`. Resol
 
 - **`file_edit`** — targeted changes (styles, fixes, small features), full path `/workspace/data/apps/<slug>/src/...`
 - **`file_write`** — new files or full rewrites
-- **Rename / metadata** — edit `/workspace/data/apps/<slug>.json` directly. Not a new app.
+- **`app_update`** — rename or change description/schema, and/or rewrite files via `source_files`, in one call. It recompiles for you, so no separate `app_refresh` is needed. Use this instead of editing `<slug>.json` by hand.
 - **Full rebrand** — still iteration, edit the existing files.
 
-Then `app_refresh(app_id)` ONCE. If the change is substantial, `app_open(app_id, open_mode: "preview")` for a fresh card; for small tweaks the existing card stays valid.
+Then `app_refresh(app_id)` ONCE (unless you used `app_update`, which already recompiled). If the change is substantial, `app_open(app_id, open_mode: "preview")` for a fresh card; for small tweaks the existing card stays valid.
 
 > ⚠️ **`skill_load("app-builder")` is required before every `app_*` call** (including the first `app_create`). The skill can auto-unload between turns; without the reload, `app_refresh` / `app_open` error with "not currently active." It's idempotent — call it every time.
 

--- a/assistant/src/config/bundled-skills/app-builder/TOOLS.json
+++ b/assistant/src/config/bundled-skills/app-builder/TOOLS.json
@@ -11,7 +11,7 @@
         "properties": {
           "name": {
             "type": "string",
-            "description": "Optional name of the app. Defaults to \"Untitled app\" when omitted; rename later via app_update."
+            "description": "Optional name of the app. When omitted, defaults to the preview card title (or \"New App\" if there is none); rename later via app_update."
           },
           "description": {
             "type": "string",

--- a/assistant/src/config/bundled-skills/app-builder/TOOLS.json
+++ b/assistant/src/config/bundled-skills/app-builder/TOOLS.json
@@ -11,7 +11,7 @@
         "properties": {
           "name": {
             "type": "string",
-            "description": "Name of the app"
+            "description": "Optional name of the app. Defaults to \"Untitled app\" when omitted; rename later via app_update."
           },
           "description": {
             "type": "string",
@@ -87,9 +87,50 @@
             "description": "Retired. Multi-page apps route inside the Preact app under src/components/. Passing this returns a guidance error."
           }
         },
-        "required": ["name"]
+        "required": []
       },
       "executor": "tools/app-create.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "app_update",
+      "description": "Update an existing app: change its name, description, or schema, and/or rewrite source files, then recompile. Use this to iterate on an app you already created instead of calling app_create again (which would make a duplicate). Resolve the app_id with app_list first if you don't have it.",
+      "category": "apps",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "app_id": {
+            "type": "string",
+            "description": "The ID of the app to update"
+          },
+          "name": {
+            "type": "string",
+            "description": "New name for the app. Omit to leave the name unchanged."
+          },
+          "description": {
+            "type": "string",
+            "description": "New description for the app. Omit to leave the description unchanged."
+          },
+          "schema_json": {
+            "type": "string",
+            "description": "New JSON schema for the app data structure. Omit to leave the schema unchanged."
+          },
+          "source_files": {
+            "type": "object",
+            "description": "Map of relative file paths to file contents to write under the app directory (e.g. 'src/main.tsx', 'src/components/App.tsx', 'src/styles.css'). Supply changed source here instead of separate file_write calls. The app is recompiled after writing.",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "change_summary": {
+            "type": "string",
+            "description": "Short summary of what changed, using git conventional commit format (e.g. 'fix: correct totals', 'feat: add dark mode'). Used as the version history entry."
+          }
+        },
+        "required": ["app_id"]
+      },
+      "executor": "tools/app-update.ts",
       "execution_target": "host"
     },
     {

--- a/assistant/src/config/bundled-skills/app-builder/tools/app-update.ts
+++ b/assistant/src/config/bundled-skills/app-builder/tools/app-update.ts
@@ -1,0 +1,18 @@
+import { setAppCommitMessage } from "../../../../memory/app-git-service.js";
+import * as appStore from "../../../../memory/app-store.js";
+import type { AppUpdateInput } from "../../../../tools/apps/executors.js";
+import { executeAppUpdate } from "../../../../tools/apps/executors.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  if (typeof input.change_summary === "string" && input.change_summary.trim()) {
+    setAppCommitMessage(context.conversationId, input.change_summary.trim());
+  }
+  return executeAppUpdate(input as unknown as AppUpdateInput, appStore);
+}

--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -25,6 +25,7 @@ import * as appDelete from "./bundled-skills/app-builder/tools/app-delete.js";
 import * as appGenerateIcon from "./bundled-skills/app-builder/tools/app-generate-icon.js";
 import * as appList from "./bundled-skills/app-builder/tools/app-list.js";
 import * as appRefresh from "./bundled-skills/app-builder/tools/app-refresh.js";
+import * as appUpdate from "./bundled-skills/app-builder/tools/app-update.js";
 // ── app-control ────────────────────────────────────────────────────────────────
 import * as appControlClick from "./bundled-skills/app-control/tools/app-control-click.js";
 import * as appControlCombo from "./bundled-skills/app-control/tools/app-control-combo.js";
@@ -140,6 +141,7 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
 
   // app-builder
   ["app-builder:tools/app-create.ts", appCreate],
+  ["app-builder:tools/app-update.ts", appUpdate],
   ["app-builder:tools/app-delete.ts", appDelete],
   ["app-builder:tools/app-refresh.ts", appRefresh],
   ["app-builder:tools/app-generate-icon.ts", appGenerateIcon],

--- a/assistant/src/tools/apps/executors.ts
+++ b/assistant/src/tools/apps/executors.ts
@@ -68,6 +68,55 @@ export type ProxyResolver = (
   input: Record<string, unknown>,
 ) => Promise<ExecutorResult>;
 
+/**
+ * Validate a `source_files` map (LLM input is not type-checked at runtime).
+ * Returns an error ExecutorResult when invalid, or null when absent/valid.
+ */
+function validateSourceFiles(sourceFiles: unknown): ExecutorResult | null {
+  if (sourceFiles == null) {
+    return null;
+  }
+  if (typeof sourceFiles !== "object" || Array.isArray(sourceFiles)) {
+    return {
+      content: JSON.stringify({
+        error:
+          "source_files must be an object mapping relative file paths to string contents",
+      }),
+      isError: true,
+    };
+  }
+  for (const [key, val] of Object.entries(sourceFiles)) {
+    if (typeof val !== "string") {
+      return {
+        content: JSON.stringify({
+          error: `source_files["${key}"] must be a string, got ${typeof val}`,
+        }),
+        isError: true,
+      };
+    }
+  }
+  return null;
+}
+
+/**
+ * Compile-result fields shared by the app_refresh and app_update responses.
+ * On failure the errors/warnings are surfaced so the agent can fix them.
+ */
+function compileResultPayload(
+  compileResult: Awaited<ReturnType<typeof compileApp>>,
+): Record<string, unknown> {
+  return {
+    compiled: compileResult.ok,
+    ...(compileResult.ok
+      ? { compile_duration_ms: compileResult.durationMs }
+      : {
+          compile_errors: compileResult.errors,
+          compile_warnings: compileResult.warnings,
+          compile_duration_ms: compileResult.durationMs,
+        }),
+  };
+}
+
 // ---------------------------------------------------------------------------
 // app_create
 // ---------------------------------------------------------------------------
@@ -92,7 +141,12 @@ export async function executeAppCreate(
   store: AppStore,
   proxyToolResolver?: ProxyResolver,
 ): Promise<ExecutorResult> {
-  const name = input.name;
+  // The model sometimes omits a name; default rather than erroring out so the
+  // build still succeeds. Users can rename later via app_update.
+  const name =
+    typeof input.name === "string" && input.name.trim() !== ""
+      ? input.name.trim()
+      : "Untitled app";
   const description = input.description;
   const schemaJson = input.schema_json ?? "{}";
 
@@ -121,39 +175,9 @@ export async function executeAppCreate(
   const autoOpen = input.auto_open !== false; // default true
   const preview = input.preview;
 
-  // Validate required fields - LLM input is not type-checked at runtime
-  if (typeof name !== "string" || name.trim() === "") {
-    return {
-      content: JSON.stringify({
-        error: "name is required and must be a non-empty string",
-      }),
-      isError: true,
-    };
-  }
-
-  if (input.source_files != null) {
-    if (
-      typeof input.source_files !== "object" ||
-      Array.isArray(input.source_files)
-    ) {
-      return {
-        content: JSON.stringify({
-          error:
-            "source_files must be an object mapping relative file paths to string contents",
-        }),
-        isError: true,
-      };
-    }
-    for (const [key, val] of Object.entries(input.source_files)) {
-      if (typeof val !== "string") {
-        return {
-          content: JSON.stringify({
-            error: `source_files["${key}"] must be a string, got ${typeof val}`,
-          }),
-          isError: true,
-        };
-      }
-    }
+  const sourceFilesError = validateSourceFiles(input.source_files);
+  if (sourceFilesError) {
+    return sourceFilesError;
   }
 
   // Extract icon from preview if provided - only persist emoji-like values,
@@ -356,14 +380,7 @@ export async function executeAppRefresh(
         refreshed: true,
         appId: updated.id,
         name: updated.name,
-        compiled: compileResult.ok,
-        ...(compileResult.ok
-          ? { compile_duration_ms: compileResult.durationMs }
-          : {
-              compile_errors: compileResult.errors,
-              compile_warnings: compileResult.warnings,
-              compile_duration_ms: compileResult.durationMs,
-            }),
+        ...compileResultPayload(compileResult),
       }),
       isError: false,
     };
@@ -374,6 +391,85 @@ export async function executeAppRefresh(
       refreshed: true,
       appId: updated.id,
       name: updated.name,
+    }),
+    isError: false,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// app_update
+// ---------------------------------------------------------------------------
+
+export interface AppUpdateInput {
+  app_id: string;
+  name?: string;
+  description?: string;
+  schema_json?: string;
+  source_files?: Record<string, string>;
+}
+
+export async function executeAppUpdate(
+  input: AppUpdateInput,
+  store: AppStore,
+): Promise<ExecutorResult> {
+  const app = store.getApp(input.app_id);
+  if (!app) {
+    return {
+      content: JSON.stringify({ error: `App '${input.app_id}' not found` }),
+      isError: true,
+    };
+  }
+
+  const sourceFilesError = validateSourceFiles(input.source_files);
+  if (sourceFilesError) {
+    return sourceFilesError;
+  }
+
+  if (input.source_files) {
+    for (const [filePath, content] of Object.entries(input.source_files)) {
+      store.writeAppFile(input.app_id, filePath, content);
+    }
+  }
+
+  const updates: Partial<
+    Pick<AppDefinition, "name" | "description" | "schemaJson">
+  > = {};
+  if (typeof input.name === "string" && input.name.trim() !== "") {
+    updates.name = input.name.trim();
+  }
+  if (typeof input.description === "string") {
+    updates.description = input.description;
+  }
+  if (typeof input.schema_json === "string") {
+    updates.schemaJson = input.schema_json;
+  }
+
+  // An empty update still bumps updatedAt, triggering a client surface refresh.
+  const updated = store.updateApp(input.app_id, updates);
+
+  // Multifile apps recompile so the agent sees any errors from the edited
+  // source instead of serving a stale dist (mirrors app_refresh).
+  if (app.formatVersion === 2) {
+    const appDir = getAppDirPath(input.app_id);
+    const compileResult = await compileApp(appDir);
+    return {
+      content: JSON.stringify({
+        updated: true,
+        appId: updated.id,
+        name: updated.name,
+        description: updated.description,
+        ...compileResultPayload(compileResult),
+      }),
+      isError: false,
+    };
+  }
+
+  return {
+    content: JSON.stringify({
+      updated: true,
+      appId: updated.id,
+      name: updated.name,
+      description: updated.description,
     }),
     isError: false,
   };

--- a/assistant/src/tools/apps/executors.ts
+++ b/assistant/src/tools/apps/executors.ts
@@ -99,6 +99,24 @@ function validateSourceFiles(sourceFiles: unknown): ExecutorResult | null {
 }
 
 /**
+ * Resolve an app name when the model omits it. The preview card's title is
+ * "always include" guidance and almost always present, so it's the best
+ * fallback — a real, meaningful name — before a generic placeholder.
+ */
+function resolveAppName(input: AppCreateInput): string {
+  const previewTitle =
+    input.preview && typeof input.preview.title === "string"
+      ? input.preview.title
+      : undefined;
+  for (const candidate of [input.name, previewTitle]) {
+    if (typeof candidate === "string" && candidate.trim() !== "") {
+      return candidate.trim();
+    }
+  }
+  return "New App";
+}
+
+/**
  * Compile-result fields shared by the app_refresh and app_update responses.
  * On failure the errors/warnings are surfaced so the agent can fix them.
  */
@@ -141,12 +159,9 @@ export async function executeAppCreate(
   store: AppStore,
   proxyToolResolver?: ProxyResolver,
 ): Promise<ExecutorResult> {
-  // The model sometimes omits a name; default rather than erroring out so the
-  // build still succeeds. Users can rename later via app_update.
-  const name =
-    typeof input.name === "string" && input.name.trim() !== ""
-      ? input.name.trim()
-      : "Untitled app";
+  // The model sometimes omits a name; resolve a sensible one rather than
+  // erroring out so the build still succeeds. Users can rename via app_update.
+  const name = resolveAppName(input);
   const description = input.description;
   const schemaJson = input.schema_json ?? "{}";
 


### PR DESCRIPTION
## Summary
- **app_create name is now optional** — when the model omits or blanks the name, it falls back to the **preview card title** (which the skill guidance says to always include, so it's almost always present and meaningful), and only then to a generic `"New App"`. Previously a missing name aborted the whole build with an error.
- **New `app_update` tool** — update an existing app's name/description/schema and/or rewrite `source_files`, then recompile. This is the natural way to iterate on an app instead of calling `app_create` again (which makes a duplicate), and directly serves the 'update my existing app' path.
- Refactor: shared `validateSourceFiles`, `resolveAppName`, and `compileResultPayload` helpers reused across `app_create`/`app_refresh`/`app_update`. Updated SKILL.md + TOOLS.json; regenerated `bundled-tool-registry.ts` via the repo script.

## Original prompt
Triaging an app-builder bug cluster in Linear. JARVIS-1104 (Akash's feedback) asked to add an `app_update` tool and make `name` non-required for `app_create` — the model sometimes forgets the name and the tool errors out. Rather than a static 'Untitled app' placeholder, an unnamed app now inherits the preview card's title (real signal the model already supplied), falling back to 'New App' only when nothing is available.