### PR TITLE
fix(web): persist consent in versioned per-user device keys

### DIFF
--- a/apps/web/src/assistant/retire-service.test.ts
+++ b/apps/web/src/assistant/retire-service.test.ts
@@ -65,9 +65,15 @@ mock.module("@/stores/resolved-assistants-store", () => ({
   },
 }));
 
-const clearOnboardingFlagsMock = mock(() => {});
+const clearConsentForUserMock = mock((_userId: string | null) => {});
 mock.module("@/utils/onboarding-cleanup", () => ({
-  clearOnboardingFlags: clearOnboardingFlagsMock,
+  clearConsentForUser: clearConsentForUserMock,
+}));
+
+mock.module("@/stores/auth-store", () => ({
+  useAuthStore: {
+    getState: () => ({ user: { id: "test-user" } }),
+  },
 }));
 
 mock.module("@/utils/routes", () => ({
@@ -95,7 +101,7 @@ beforeEach(() => {
   listAssistantsMock.mockClear();
   retireLocalAssistantMock.mockClear();
   syncPlatformAssistantsToLockfileMock.mockClear();
-  clearOnboardingFlagsMock.mockClear();
+  clearConsentForUserMock.mockClear();
   removeMock.mockClear();
 });
 
@@ -119,7 +125,7 @@ describe("retireAssistant", () => {
     if (outcome.ok) {
       expect(outcome.nextRoute).toBe("/assistant/onboarding/privacy");
     }
-    expect(clearOnboardingFlagsMock).toHaveBeenCalled();
+    expect(clearConsentForUserMock).toHaveBeenCalledWith("test-user");
   });
 
   test("local assistant in local mode routes through the local retire", async () => {
@@ -161,7 +167,7 @@ describe("retireAssistant", () => {
     const outcome = await retireAssistant("p1");
 
     expect(outcome.ok).toBe(true);
-    expect(clearOnboardingFlagsMock).toHaveBeenCalled();
+    expect(clearConsentForUserMock).toHaveBeenCalledWith("test-user");
   });
 
   test("a non-404 platform failure surfaces the error detail", async () => {
@@ -175,7 +181,7 @@ describe("retireAssistant", () => {
     if (!outcome.ok) {
       expect(outcome.error).toBe("boom");
     }
-    expect(clearOnboardingFlagsMock).not.toHaveBeenCalled();
+    expect(clearConsentForUserMock).not.toHaveBeenCalled();
   });
 
   test("post-retire redirects to select-assistant when other assistants remain", async () => {

--- a/apps/web/src/assistant/retire-service.test.ts
+++ b/apps/web/src/assistant/retire-service.test.ts
@@ -65,17 +65,6 @@ mock.module("@/stores/resolved-assistants-store", () => ({
   },
 }));
 
-const clearConsentForUserMock = mock((_userId: string | null) => {});
-mock.module("@/utils/onboarding-cleanup", () => ({
-  clearConsentForUser: clearConsentForUserMock,
-}));
-
-mock.module("@/stores/auth-store", () => ({
-  useAuthStore: {
-    getState: () => ({ user: { id: "test-user" } }),
-  },
-}));
-
 mock.module("@/utils/routes", () => ({
   routes: {
     assistant: "/assistant",
@@ -101,7 +90,6 @@ beforeEach(() => {
   listAssistantsMock.mockClear();
   retireLocalAssistantMock.mockClear();
   syncPlatformAssistantsToLockfileMock.mockClear();
-  clearConsentForUserMock.mockClear();
   removeMock.mockClear();
 });
 
@@ -125,7 +113,6 @@ describe("retireAssistant", () => {
     if (outcome.ok) {
       expect(outcome.nextRoute).toBe("/assistant/onboarding/privacy");
     }
-    expect(clearConsentForUserMock).toHaveBeenCalledWith("test-user");
   });
 
   test("local assistant in local mode routes through the local retire", async () => {
@@ -167,7 +154,6 @@ describe("retireAssistant", () => {
     const outcome = await retireAssistant("p1");
 
     expect(outcome.ok).toBe(true);
-    expect(clearConsentForUserMock).toHaveBeenCalledWith("test-user");
   });
 
   test("a non-404 platform failure surfaces the error detail", async () => {
@@ -181,7 +167,6 @@ describe("retireAssistant", () => {
     if (!outcome.ok) {
       expect(outcome.error).toBe("boom");
     }
-    expect(clearConsentForUserMock).not.toHaveBeenCalled();
   });
 
   test("post-retire redirects to select-assistant when other assistants remain", async () => {

--- a/apps/web/src/assistant/retire-service.ts
+++ b/apps/web/src/assistant/retire-service.ts
@@ -9,7 +9,8 @@ import {
 import { resolveNavigation } from "@/lib/navigation/navigation-resolver";
 import { buildNavigationState } from "@/lib/navigation/build-state";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
-import { clearOnboardingFlags } from "@/utils/onboarding-cleanup";
+import { clearConsentForUser } from "@/utils/onboarding-cleanup";
+import { useAuthStore } from "@/stores/auth-store";
 import { routes } from "@/utils/routes";
 
 /**
@@ -90,7 +91,7 @@ export async function retireAssistant(
     }
 
     useResolvedAssistantsStore.getState().remove(assistantId);
-    clearOnboardingFlags();
+    clearConsentForUser(useAuthStore.getState().user?.id ?? null);
     return { ok: true, nextRoute: getPostRetireRoute() };
   } catch {
     return { ok: false, error: "Failed to retire assistant." };

--- a/apps/web/src/assistant/retire-service.ts
+++ b/apps/web/src/assistant/retire-service.ts
@@ -9,8 +9,6 @@ import {
 import { resolveNavigation } from "@/lib/navigation/navigation-resolver";
 import { buildNavigationState } from "@/lib/navigation/build-state";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
-import { clearConsentForUser } from "@/utils/onboarding-cleanup";
-import { useAuthStore } from "@/stores/auth-store";
 import { routes } from "@/utils/routes";
 
 /**
@@ -91,7 +89,6 @@ export async function retireAssistant(
     }
 
     useResolvedAssistantsStore.getState().remove(assistantId);
-    clearConsentForUser(useAuthStore.getState().user?.id ?? null);
     return { ok: true, nextRoute: getPostRetireRoute() };
   } catch {
     return { ok: false, error: "Failed to retire assistant." };

--- a/apps/web/src/domains/onboarding/onboarding-store.ts
+++ b/apps/web/src/domains/onboarding/onboarding-store.ts
@@ -1,46 +1,14 @@
 /**
  * Zustand store for onboarding boolean preferences.
  *
- * Owns the four onboarding/privacy flags consumed by the privacy page,
- * the onboarding pages, and Sentry. `prefs.ts` exposes thin hooks
- * (`useShareAnalytics`, `useShareDiagnostics`, `useTosAccepted`,
- * `useAiDataConsent`) that wrap `.use.field()` selectors and setter
- * actions on this store.
+ * **Device-persisted fields** (`shareAnalytics`, `shareDiagnostics`) are
+ * written to `device:` localStorage keys on every setter call and synced
+ * across tabs via `watchSetting`. They survive logout.
  *
- * **Storage model — strict per-key, with absence semantics preserved:**
- *
- * Each field maps 1:1 to its own localStorage key:
- *
- * | Field             | localStorage key              | Read by                |
- * |-------------------|-------------------------------|------------------------|
- * | `shareAnalytics`  | `device:share_analytics`      | privacy page (direct)  |
- * | `shareDiagnostics`| `device:share_diagnostics`    | privacy page + Sentry  |
- * | `tosAccepted`     | `vellum:onboarding:tosAccepted`  | onboarding pages       |
- * | `aiDataConsent`   | `vellum:onboarding:aiDataConsent`| onboarding pages       |
- *
- * We deliberately do **not** use Zustand's `persist` middleware here.
- * `persist` writes the full state envelope on every update, which would
- * write `device:share_diagnostics = "true"` to localStorage whenever any
- * unrelated flag (e.g. `tosAccepted`) changed — silently flipping Sentry
- * consent from "absent / opt-out" to "true / explicit consent" without
- * the user ever toggling the Share Diagnostics control. The Sentry gate
- * (`apps/web/src/lib/sentry/sentry-control.ts`) treats absence as the
- * privacy-safe default and ANY explicit `"true"` as opt-in.
- *
- * Instead, each setter writes only its own key via `setLocalBool`,
- * so a field that was never explicitly set stays absent in localStorage
- * — keeping the privacy-safe default intact. Initial state is read once
- * on module load via `computeInitialFromLS()`.
- *
- * **Cross-tab + cross-surface sync:**
- *
- * - `setLocalBool` fires a native `storage` event in other tabs and
- *   a same-tab `vellum:pref-changed` CustomEvent. The store registers
- *   `watchSetting` listeners for each tracked key and updates its state
- *   from localStorage whenever any of the five keys changes elsewhere.
- * - That way a write from the privacy page (same tab, different
- *   surface) and a write from another tab both flow back into the
- *   store and re-render subscribed components.
+ * **In-memory-only fields** (`tosAccepted`, `aiDataConsent`) start `false`
+ * and are populated by `restoreConsentForUser` (called from the auth store
+ * once the user id is known). Persistence to durable per-user device keys
+ * is handled by `persistConsentForUser` in `onboarding-cleanup.ts`.
  *
  * Reference: {@link https://zustand.docs.pmnd.rs/}
  */
@@ -54,44 +22,22 @@ import {
   watchSetting,
 } from "@/utils/local-settings";
 import { deviceKey } from "@/utils/device-settings";
-import {
-  KEY_TOS_ACCEPTED,
-  KEY_AI_DATA_CONSENT,
-} from "@/utils/onboarding-cleanup";
 
 // ---------------------------------------------------------------------------
-// Storage keys — shared with other surfaces
+// Storage keys — device-persisted fields only
 // ---------------------------------------------------------------------------
 
-/** Shared with `/settings/privacy`. */
 const KEY_SHARE_ANALYTICS = deviceKey("shareAnalytics");
-/** Shared with `/settings/privacy` and the Sentry consent gate. */
 const KEY_SHARE_DIAGNOSTICS = deviceKey("shareDiagnostics");
-
-/**
- * Lookup table from localStorage key → which state field to refresh.
- * Used by the cross-tab / cross-surface listeners to map an external
- * write back into the store.
- */
-const KEY_TO_FIELD: ReadonlyMap<string, keyof OnboardingState> = new Map([
-  [KEY_SHARE_ANALYTICS, "shareAnalytics" as const],
-  [KEY_SHARE_DIAGNOSTICS, "shareDiagnostics" as const],
-  [KEY_TOS_ACCEPTED, "tosAccepted" as const],
-  [KEY_AI_DATA_CONSENT, "aiDataConsent" as const],
-]);
 
 // ---------------------------------------------------------------------------
 // State + Actions
 // ---------------------------------------------------------------------------
 
 export interface OnboardingState {
-  /** Share anonymous product analytics. Default `true`. */
   shareAnalytics: boolean;
-  /** Share crash reports + diagnostics (Sentry consent). Default `true` UI-wise; **absent in LS means OFF** per the Sentry gate. */
   shareDiagnostics: boolean;
-  /** User accepted Terms of Service. Default `false`. */
   tosAccepted: boolean;
-  /** Explicit AI-data-sharing consent. Default `false`. */
   aiDataConsent: boolean;
 }
 
@@ -105,31 +51,14 @@ export interface OnboardingActions {
 export type OnboardingStore = OnboardingState & OnboardingActions;
 
 // ---------------------------------------------------------------------------
-// LS helpers
-// ---------------------------------------------------------------------------
-
-const FIELD_DEFAULTS: Record<keyof OnboardingState, boolean> = {
-  shareAnalytics: true,
-  shareDiagnostics: true,
-  tosAccepted: false,
-  aiDataConsent: false,
-};
-
-function computeInitialFromLS(): OnboardingState {
-  return {
-    shareAnalytics: getLocalBool(KEY_SHARE_ANALYTICS, true),
-    shareDiagnostics: getLocalBool(KEY_SHARE_DIAGNOSTICS, true),
-    tosAccepted: getLocalBool(KEY_TOS_ACCEPTED, false),
-    aiDataConsent: getLocalBool(KEY_AI_DATA_CONSENT, false),
-  };
-}
-
-// ---------------------------------------------------------------------------
 // Store
 // ---------------------------------------------------------------------------
 
 const useOnboardingStoreBase = create<OnboardingStore>()((set) => ({
-  ...computeInitialFromLS(),
+  shareAnalytics: getLocalBool(KEY_SHARE_ANALYTICS, true),
+  shareDiagnostics: getLocalBool(KEY_SHARE_DIAGNOSTICS, true),
+  tosAccepted: false,
+  aiDataConsent: false,
 
   setShareAnalytics: (value) => {
     set({ shareAnalytics: value });
@@ -141,27 +70,31 @@ const useOnboardingStoreBase = create<OnboardingStore>()((set) => ({
   },
   setTosAccepted: (value) => {
     set({ tosAccepted: value });
-    setLocalBool(KEY_TOS_ACCEPTED, value);
   },
   setAiDataConsent: (value) => {
     set({ aiDataConsent: value });
-    setLocalBool(KEY_AI_DATA_CONSENT, value);
   },
 }));
 
 export const useOnboardingStore = createSelectors(useOnboardingStoreBase);
 
 // ---------------------------------------------------------------------------
-// Cross-tab + cross-surface sync
+// Cross-tab sync — device-persisted fields only
 // ---------------------------------------------------------------------------
 
-function syncFieldFromLS(key: string): void {
-  const field = KEY_TO_FIELD.get(key);
-  if (!field) return;
-  const next = getLocalBool(key, FIELD_DEFAULTS[field]);
-  useOnboardingStoreBase.setState({ [field]: next } as Partial<OnboardingState>);
-}
+const SYNCED_KEYS: ReadonlyMap<string, keyof OnboardingState> = new Map([
+  [KEY_SHARE_ANALYTICS, "shareAnalytics"],
+  [KEY_SHARE_DIAGNOSTICS, "shareDiagnostics"],
+]);
 
-for (const key of KEY_TO_FIELD.keys()) {
-  watchSetting(key, () => syncFieldFromLS(key));
+const SYNCED_DEFAULTS: Record<string, boolean> = {
+  shareAnalytics: true,
+  shareDiagnostics: true,
+};
+
+for (const [key, field] of SYNCED_KEYS) {
+  watchSetting(key, () => {
+    const next = getLocalBool(key, SYNCED_DEFAULTS[field] ?? false);
+    useOnboardingStoreBase.setState({ [field]: next } as Partial<OnboardingState>);
+  });
 }

--- a/apps/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -21,6 +21,7 @@ import {
 import { useIsNativePlatform } from "@/runtime/native-auth";
 import { useAuthStore } from "@/stores/auth-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
+import { persistConsentForUser } from "@/utils/onboarding-cleanup";
 import { legalUrl, routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
 import { Card } from "@vellumai/design-library/components/card";
@@ -93,6 +94,7 @@ export function PrivacyScreen() {
     } catch (err) {
       captureError(err, { context: "onboarding_persist_share_prefs" });
     }
+    persistConsentForUser(userId, tosAccepted, aiDataConsent);
     if (!isNative) {
       const variant = resolveOnboardingFunnelVariant(preferredFunnelVariant);
       emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.privacyTos, {
@@ -117,6 +119,7 @@ export function PrivacyScreen() {
     const qs = params.toString();
     void navigate(`${routes.onboarding.hatching}${qs ? `?${qs}` : ""}`);
   }, [
+    aiDataConsent,
     isNative,
     navigate,
     preferredFunnelVariant,
@@ -125,8 +128,11 @@ export function PrivacyScreen() {
     setShareDiagnostics,
     shareAnalytics,
     shareDiagnostics,
+    tosAccepted,
     userId,
   ]);
+
+  const isReturningUser = !!searchParams.get("returnTo");
 
   const tosLabel: ReactNode = (
     <span className="text-body-medium-lighter text-[var(--content-default)]">
@@ -237,7 +243,7 @@ export function PrivacyScreen() {
             onClick={onStart}
             className="h-11 text-base"
           >
-            Start
+            {isReturningUser ? "Continue" : "Start"}
           </Button>
           <Button
             variant="outlined"

--- a/apps/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -184,7 +184,7 @@ export function PrivacyScreen() {
         )}
         {/* typography: off-scale — hero onboarding h1 (30px) larger than text-title-large (24px) to match macOS visual weight */}
         <h1 className="text-3xl font-semibold tracking-tight">
-          Before You Start
+          {isReturningUser ? "Review Terms" : "Before You Start"}
         </h1>
         <p className="mt-4 text-center text-body-medium-lighter text-[var(--content-tertiary)]">
           Choose your privacy preferences. You can update these anytime in the

--- a/apps/web/src/domains/onboarding/prefs.ts
+++ b/apps/web/src/domains/onboarding/prefs.ts
@@ -20,11 +20,7 @@ import {
   removeLocalSetting,
   setLocalSetting,
 } from "@/utils/local-settings";
-import { getDeviceBool, getDeviceSetting } from "@/utils/device-settings";
-import {
-  KEY_TOS_ACCEPTED,
-  KEY_AI_DATA_CONSENT,
-} from "@/utils/onboarding-cleanup";
+import { getDeviceBool } from "@/utils/device-settings";
 import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
 
 // ---------------------------------------------------------------------------
@@ -133,22 +129,6 @@ export function readShareAnalytics(): boolean {
 }
 
 /**
- * SSR-safe, non-hook check for a returning user signal.
- * Returns `true` when `onboarding.lastUserId` exists in localStorage,
- * indicating this browser has previously had a signed-in user. The key
- * persists through logout (by design), so a user who signs out and
- * revisits is still detected as "returning".
- */
-export function hasReturningUserSignal(): boolean {
-  if (typeof window === "undefined") return false;
-  try {
-    return getDeviceSetting("lastUserId", "") !== "";
-  } catch {
-    return false;
-  }
-}
-
-/**
  * Read the pinned release version the user picked on the privacy screen's
  * nonprod version selector. Empty string means "latest" / no pin. SSR-safe
  * and tolerant of disabled storage.
@@ -181,11 +161,3 @@ export function writeSelectedVersion(version: string): void {
 }
 
 
-// ---------------------------------------------------------------------------
-// Internals exported for tests only. Not part of the public API.
-// ---------------------------------------------------------------------------
-
-export const __testing = {
-  KEY_TOS_ACCEPTED,
-  KEY_AI_DATA_CONSENT,
-};

--- a/apps/web/src/domains/settings/components/delete-account-section.tsx
+++ b/apps/web/src/domains/settings/components/delete-account-section.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/hooks/use-platform-gate";
 import { hardNavigate } from "@/lib/auth/hard-navigate";
 import { useAuthStore } from "@/stores/auth-store";
+import { clearConsentForUser } from "@/utils/onboarding-cleanup";
 import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
 import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
@@ -33,6 +34,7 @@ export function DeleteAccountSection() {
   // (`retired`, `error`) should NOT block account deletion, since the
   // user's platform account exists independently of any assistant.
   const isLifecycleLoading = useActiveAssistantLifecycleIsLoading();
+  const userId = useAuthStore.use.user()?.id ?? null;
   const logout = useAuthStore.use.logout();
   const [confirmOpen, setConfirmOpen] = useState(false);
 
@@ -42,6 +44,7 @@ export function DeleteAccountSection() {
       toast.success(
         "Account deletion requested. You will be logged out shortly.",
       );
+      clearConsentForUser(userId);
       await logout();
       hardNavigate(routes.account.login);
     },

--- a/apps/web/src/domains/settings/components/panels/debug-controls-panel.tsx
+++ b/apps/web/src/domains/settings/components/panels/debug-controls-panel.tsx
@@ -9,7 +9,7 @@ import { RestartAssistant } from "@/domains/settings/components/restart-assistan
 import { usePlatformGate } from "@/hooks/use-platform-gate";
 import { captureError } from "@/lib/sentry/capture-error";
 import { useAuthStore } from "@/stores/auth-store";
-import { clearOnboardingFlags } from "@/utils/onboarding-cleanup";
+import { clearConsentForUser } from "@/utils/onboarding-cleanup";
 import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
 import { Notice } from "@vellumai/design-library/components/notice";
@@ -31,10 +31,10 @@ export function DebugControlsPanel() {
   const fetchedRef = useRef(false);
 
   const handleReplayOnboarding = useCallback(() => {
-    clearOnboardingFlags();
+    clearConsentForUser(user?.id ?? null);
     toast.success("Onboarding flags cleared.");
     navigate(routes.onboarding.privacy);
-  }, [navigate]);
+  }, [navigate, user?.id]);
 
   const fetchAssistant = useCallback(async (force?: boolean) => {
     if (!force && fetchedRef.current) {

--- a/apps/web/src/stores/auth-store.test.ts
+++ b/apps/web/src/stores/auth-store.test.ts
@@ -25,8 +25,7 @@ const primeLocalGatewayConnectionMock = mock(async () => {
 const primeLocalGatewayConnectionWithRepairMock = mock(async () => {
   if (mockPrimeError) throw mockPrimeError;
 });
-const syncOnboardingUserMock = mock((_userId: string | null) => {});
-const clearOnboardingFlagsMock = mock(() => {});
+const restoreConsentForUserMock = mock((_userId: string | null) => ({ tos: false, ai: false }));
 const clearOrganizationMock = mock(() => {});
 const logoutMock = mock(async () => {});
 const deleteBiometricTokenMock = mock(async () => {});
@@ -101,8 +100,16 @@ mock.module("@/runtime/native-biometric", () => ({
 const clearUserScopedStorageMock = mock(() => {});
 
 mock.module("@/utils/onboarding-cleanup", () => ({
-  syncOnboardingUser: syncOnboardingUserMock,
-  clearOnboardingFlags: clearOnboardingFlagsMock,
+  restoreConsentForUser: restoreConsentForUserMock,
+}));
+
+mock.module("@/domains/onboarding/onboarding-store", () => ({
+  useOnboardingStore: {
+    getState: () => ({
+      setTosAccepted: () => {},
+      setAiDataConsent: () => {},
+    }),
+  },
 }));
 
 mock.module("@/lib/auth/session-cleanup", () => ({
@@ -160,8 +167,7 @@ beforeEach(() => {
   setSelectedAssistantIdMock.mockClear();
   primeLocalGatewayConnectionMock.mockClear();
   primeLocalGatewayConnectionWithRepairMock.mockClear();
-  syncOnboardingUserMock.mockClear();
-  clearOnboardingFlagsMock.mockClear();
+  restoreConsentForUserMock.mockClear();
   clearOrganizationMock.mockClear();
   clearUserScopedStorageMock.mockClear();
   logoutMock.mockClear();
@@ -176,21 +182,21 @@ beforeEach(() => {
 });
 
 describe("auth store onboarding flag reconciliation", () => {
-  test("initSession reconciles onboarding flags for the signed-in user", async () => {
+  test("initSession restores consent for the signed-in user", async () => {
     sessionUser = { id: "user-1", email: "user@example.com" };
 
     await useAuthStore.getState().initSession();
 
-    expect(syncOnboardingUserMock).toHaveBeenCalledWith("user-1");
+    expect(restoreConsentForUserMock).toHaveBeenCalledWith("user-1");
     expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
   });
 
-  test("refreshSession reconciles onboarding flags for a changed user", async () => {
+  test("refreshSession restores consent for a changed user", async () => {
     sessionUser = { id: "user-2", email: "user@example.com" };
 
     await expect(useAuthStore.getState().refreshSession()).resolves.toBe(true);
 
-    expect(syncOnboardingUserMock).toHaveBeenCalledWith("user-2");
+    expect(restoreConsentForUserMock).toHaveBeenCalledWith("user-2");
     expect(useAuthStore.getState().user?.id).toBe("user-2");
   });
 
@@ -230,11 +236,10 @@ describe("auth store onboarding flag reconciliation", () => {
     expect(syncPlatformAssistantsToLockfileMock).not.toHaveBeenCalled();
   });
 
-  test("logout clears onboarding flags directly", async () => {
+  test("logout does not clear consent flags (durable device keys survive)", async () => {
     await useAuthStore.getState().logout();
 
     expect(logoutMock).toHaveBeenCalled();
-    expect(clearOnboardingFlagsMock).toHaveBeenCalled();
     expect(useAuthStore.getState().sessionStatus).toBe("unauthenticated");
   });
 });

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -47,7 +47,8 @@ import {
 import { listAssistants } from "@/assistant/api";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { deleteBiometricToken } from "@/runtime/native-biometric";
-import { syncOnboardingUser, clearOnboardingFlags } from "@/utils/onboarding-cleanup";
+import { restoreConsentForUser } from "@/utils/onboarding-cleanup";
+import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
 import { clearOrganization } from "@/stores/organization-store";
 import { clearUserScopedStorage } from "@/lib/auth/session-cleanup";
 import { subscribe } from "@/lib/event-bus";
@@ -162,7 +163,10 @@ function broadcastAuthChange(): void {
 }
 
 function syncUserScopedState(nextUserId: string | null): void {
-  syncOnboardingUser(nextUserId);
+  const consent = restoreConsentForUser(nextUserId);
+  const store = useOnboardingStore.getState();
+  store.setTosAccepted(consent.tos);
+  store.setAiDataConsent(consent.ai);
   syncOrganizationState(nextUserId);
 }
 
@@ -488,7 +492,6 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
     if (isGatewayAuthMode()) {
       clearSelectedAssistant();
       clearGatewayToken();
-      clearOnboardingFlags();
       clearOrganization();
       clearUserScopedStorage();
       // Clear lifecycle state BEFORE `sessionStatus` leaves `authenticated`
@@ -509,7 +512,6 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
         document.cookie = "sessionid=; path=/; samesite=lax; expires=Thu, 01 Jan 1970 00:00:00 UTC";
       }
       void deleteBiometricToken();
-      clearOnboardingFlags();
       clearOrganization();
       clearUserScopedStorage();
       lifecycleService.resetForLogout();

--- a/apps/web/src/utils/onboarding-cleanup.ts
+++ b/apps/web/src/utils/onboarding-cleanup.ts
@@ -23,10 +23,21 @@ function consentKey(field: string, userId: string): string {
 export function restoreConsentForUser(userId: string | null): { tos: boolean; ai: boolean } {
   if (typeof window === "undefined" || !userId) return { tos: false, ai: false };
   try {
-    return {
-      tos: getLocalBool(consentKey("tos", userId), false),
-      ai: getLocalBool(consentKey("ai", userId), false),
-    };
+    const tos = getLocalBool(consentKey("tos", userId), false);
+    const ai = getLocalBool(consentKey("ai", userId), false);
+    if (tos || ai) return { tos, ai };
+
+    // One-time migration: users who accepted before the per-user device
+    // key change still have consent in the legacy vellum: active keys.
+    // Promote to the new keys so they aren't re-prompted.
+    const legacyTos = getLocalBool("vellum:onboarding:tosAccepted", false);
+    const legacyAi = getLocalBool("vellum:onboarding:aiDataConsent", false);
+    if (legacyTos || legacyAi) {
+      persistConsentForUser(userId, legacyTos, legacyAi);
+      return { tos: legacyTos, ai: legacyAi };
+    }
+
+    return { tos: false, ai: false };
   } catch {
     return { tos: false, ai: false };
   }

--- a/apps/web/src/utils/onboarding-cleanup.ts
+++ b/apps/web/src/utils/onboarding-cleanup.ts
@@ -1,67 +1,60 @@
 /**
- * Cross-domain onboarding cleanup utilities.
+ * Versioned, per-user consent persistence.
  *
- * These functions are consumed by the auth store (logout), settings
- * (retire assistant, debug controls), and are extracted here so domain
- * code doesn't reach into `domains/onboarding/` directly.
+ * Consent flags live in `device:consent:{tos,ai}:v<VERSION>:<userId>`.
+ * The `device:` prefix survives logout; the userId makes them per-user;
+ * the version lets us force re-consent by bumping CONSENT_VERSION.
  *
- * Clears localStorage keys directly rather than going through the Zustand
- * store — all callers (logout, retire) navigate away immediately, so the
- * in-memory store state is irrelevant and reinitializes from localStorage
- * on the next page load.
+ * The onboarding Zustand store holds the in-memory state (`tosAccepted`,
+ * `aiDataConsent`). This module handles the durable device-key layer:
+ *
+ * - `restoreConsentForUser` — read device keys, return {tos, ai}
+ * - `persistConsentForUser` — write device keys
+ * - `clearConsentForUser`   — delete device keys + legacy active keys
  */
-import { removeLocalSetting } from "@/utils/local-settings";
-import { getDeviceSetting, setDeviceSetting } from "@/utils/device-settings";
+import { removeLocalSetting, getLocalBool, setLocalBool } from "@/utils/local-settings";
 
-/** Source of truth for onboarding key constants. Also imported by
- * `onboarding-store.ts`, `prefs.ts`, and `storage-migration.ts`. */
-export const KEY_TOS_ACCEPTED = "vellum:onboarding:tosAccepted";
-export const KEY_AI_DATA_CONSENT = "vellum:onboarding:aiDataConsent";
-const KEY_SELECTED_VERSION = "vellum:onboarding:selectedVersion";
+export const CONSENT_VERSION = "2026-06-08";
 
-/**
- * Remove per-user onboarding flags so a different account signing in on the
- * same browser isn't treated as already onboarded. Call this on logout.
- *
- * Intentionally leaves the `vellum_share_*` keys alone — those are framed as
- * device-level privacy preferences (shared with `/settings/privacy`) rather
- * than per-user state, and resetting them on every logout would clobber a
- * user's deliberate opt-out for the next user on a shared machine.
- *
- * Safe to call during SSR (no-op) and safe to call when keys are absent.
- */
-export function clearOnboardingFlags(): void {
-  removeLocalSetting(KEY_TOS_ACCEPTED);
-  removeLocalSetting(KEY_AI_DATA_CONSENT);
-  removeLocalSetting(KEY_SELECTED_VERSION);
+function consentKey(field: string, userId: string): string {
+  return `device:consent:${field}:v${CONSENT_VERSION}:${userId}`;
 }
 
-/**
- * Reconcile onboarding flags against the currently signed-in user.
- *
- * Clears stale `onboarding.*` flags whenever the active user id doesn't
- * match the one we last observed on this browser. That covers:
- *   - A different user signing in after session expiry / cookie clearing
- *     (the previous user never went through `logout()`, so the flags
- *     survived).
- *   - A different user signing in on the same browser after a fresh load
- *     (there was no previous in-memory user to compare against).
- *
- * When the new user id matches the stored one (same user signing back in),
- * this is a no-op so the user isn't forced through onboarding again.
- *
- * `userId === null` (signed-out) is also a no-op — we preserve the last
- * observed id across signed-out gaps so a same-user re-login is recognized.
- */
-export function syncOnboardingUser(userId: string | null): void {
-  if (typeof window === "undefined") return;
-  if (userId === null) return;
+export function restoreConsentForUser(userId: string | null): { tos: boolean; ai: boolean } {
+  if (typeof window === "undefined" || !userId) return { tos: false, ai: false };
   try {
-    const stored = getDeviceSetting("lastUserId", "");
-    if (stored === userId) return;
-    clearOnboardingFlags();
-    setDeviceSetting("lastUserId", userId);
+    return {
+      tos: getLocalBool(consentKey("tos", userId), false),
+      ai: getLocalBool(consentKey("ai", userId), false),
+    };
   } catch {
-    // Storage unavailable — nothing to reconcile.
+    return { tos: false, ai: false };
+  }
+}
+
+export function persistConsentForUser(
+  userId: string | null,
+  tos: boolean,
+  ai: boolean,
+): void {
+  if (typeof window === "undefined" || !userId) return;
+  try {
+    setLocalBool(consentKey("tos", userId), tos);
+    setLocalBool(consentKey("ai", userId), ai);
+  } catch {
+    // Storage unavailable.
+  }
+}
+
+export function clearConsentForUser(userId: string | null): void {
+  removeLocalSetting("vellum:onboarding:tosAccepted");
+  removeLocalSetting("vellum:onboarding:aiDataConsent");
+  removeLocalSetting("vellum:onboarding:selectedVersion");
+  if (typeof window === "undefined" || !userId) return;
+  try {
+    removeLocalSetting(consentKey("tos", userId));
+    removeLocalSetting(consentKey("ai", userId));
+  } catch {
+    // Storage unavailable.
   }
 }


### PR DESCRIPTION
## Summary
- On logout, `clearUserScopedStorage()` sweeps all `vellum:` localStorage keys — including `tosAccepted` and `aiDataConsent`. Returning users who log back in are incorrectly redirected to the "Before You Start" privacy screen.
- Consent is now stored in versioned, per-user device keys: `device:consent:{tos,ai}:v2026-06-08:<userId>`. These survive logout (`device:` prefix), are per-user (userId in key), and support forced re-consent by bumping `CONSENT_VERSION`.
- The onboarding store holds consent as **in-memory-only state** (no more `vellum:onboarding:tosAccepted` localStorage writes). On login, `restoreConsentForUser` reads device keys and populates the store. On consent submit, `persistConsentForUser` writes to device keys.
- Removes `syncOnboardingUser`, `clearOnboardingFlags`, `hasReturningUserSignal` (dead code), the `lastUserId` device-setting tracking, and the `__testing` export from prefs.
- Moves `clearConsentForUser` from the retire-assistant flow (no reason to re-prompt TOS after retiring) to the delete-account flow (new account on same browser should start fresh).
- Privacy screen button now says "Continue" for returning users (has `returnTo` param) and "Start" for new users.

## Test plan
- [x] `auth-store.test.ts` — 17 pass
- [x] `retire-service.test.ts` — 7 pass
- [x] `session-cleanup.test.ts` — 10 pass (unchanged)
- [x] `navigation-resolver.test.ts` — 57 pass (unchanged)
- [ ] Manual: log in → accept TOS → log out → log back in → no privacy redirect
- [ ] Manual: log out → log in as different user → privacy screen shown
- [ ] Manual: delete account → create new account on same browser → privacy screen shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)