### PR TITLE
fix(memory-v3): ensure article payload index on every ensureSectionCollection path

### DIFF
--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/section-dense-store.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/section-dense-store.test.ts
@@ -183,13 +183,18 @@ describe("memory v3 section-dense-store — collection lifecycle", () => {
     expect(params.vectors.size).toBe(1536);
   });
 
-  test("is a no-op when the collection already exists", async () => {
+  test("ensures the article payload index when the collection already exists", async () => {
     state.collectionExists = true;
 
     await ensureSectionCollection(CONFIG);
 
+    // No collection create, but the article payload index is ensured idempotently
+    // so a collection left without it (e.g. an earlier crash between create and
+    // index, under strict-mode Qdrant) self-heals on the next start.
     expect(state.createCollectionCalls).toBe(0);
-    expect(state.createIndexCalls).toEqual([]);
+    expect(state.createIndexCalls).toEqual([
+      { field_name: "article", field_schema: "keyword" },
+    ]);
   });
 
   test("re-running ensure latches readiness (single existence probe)", async () => {
@@ -202,7 +207,7 @@ describe("memory v3 section-dense-store — collection lifecycle", () => {
     expect(state.createCollectionCalls).toBe(1);
   });
 
-  test("treats a 409-on-create as success", async () => {
+  test("treats a 409-on-create as success and still ensures the index", async () => {
     state.collectionExists = false;
     state.createCollectionThrows = Object.assign(new Error("Conflict"), {
       status: 409,
@@ -210,9 +215,12 @@ describe("memory v3 section-dense-store — collection lifecycle", () => {
 
     await ensureSectionCollection(CONFIG);
 
-    // No throw; index creation is skipped because the racing peer created it.
+    // No throw; after the racing-peer 409 we fall through and still ensure the
+    // article payload index (idempotent) rather than returning early.
     expect(state.createCollectionCalls).toBe(1);
-    expect(state.createIndexCalls).toEqual([]);
+    expect(state.createIndexCalls).toEqual([
+      { field_name: "article", field_schema: "keyword" },
+    ]);
   });
 });
 

--- a/assistant/src/plugins/defaults/memory-v3-shadow/section-dense-store.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/section-dense-store.ts
@@ -86,48 +86,45 @@ export async function ensureSectionCollection(
   const onDisk = config.memory.qdrant.onDisk;
 
   const exists = await client.collectionExists(SECTION_COLLECTION);
-  if (exists.exists) {
-    _collectionReady = true;
-    return;
-  }
-
-  log.info(
-    { collection: SECTION_COLLECTION, vectorSize },
-    "Creating Qdrant collection for memory v3 sections",
-  );
-
-  try {
-    await client.createCollection(SECTION_COLLECTION, {
-      vectors: {
-        size: vectorSize,
-        distance: "Cosine",
-        on_disk: onDisk,
-      },
-      hnsw_config: {
-        on_disk: onDisk,
-        m: 16,
-        ef_construct: 100,
-      },
-      optimizers_config: {
-        default_segment_number: 2,
-      },
-      on_disk_payload: onDisk,
-    });
-  } catch (err) {
-    // 409 = a concurrent caller created the collection — that's fine.
-    if (
-      err instanceof Error &&
-      "status" in err &&
-      (err as { status: number }).status === 409
-    ) {
-      _collectionReady = true;
-      return;
+  if (!exists.exists) {
+    log.info(
+      { collection: SECTION_COLLECTION, vectorSize },
+      "Creating Qdrant collection for memory v3 sections",
+    );
+    try {
+      await client.createCollection(SECTION_COLLECTION, {
+        vectors: {
+          size: vectorSize,
+          distance: "Cosine",
+          on_disk: onDisk,
+        },
+        hnsw_config: {
+          on_disk: onDisk,
+          m: 16,
+          ef_construct: 100,
+        },
+        optimizers_config: {
+          default_segment_number: 2,
+        },
+        on_disk_payload: onDisk,
+      });
+    } catch (err) {
+      // 409 = a concurrent caller created the collection — fall through to
+      // ensure the payload index below rather than returning early.
+      const status =
+        err instanceof Error && "status" in err
+          ? (err as { status: number }).status
+          : undefined;
+      if (status !== 409) throw err;
     }
-    throw err;
   }
 
-  // Index the `article` payload so `deleteSectionsForArticle` can filter on it
-  // under strict-mode Qdrant (which rejects filters on unindexed fields).
+  // Always ensure the `article` payload index — on EVERY path (fresh create,
+  // concurrent 409, and a pre-existing collection whose index creation was
+  // interrupted by an earlier crash). `deleteSectionsForArticle`/pruning filter
+  // on `article`, and strict-mode Qdrant rejects filters on unindexed fields, so
+  // a missing index would make them fail until manual repair. createPayloadIndex
+  // is idempotent, so re-running it against an existing index is a no-op.
   await client.createPayloadIndex(SECTION_COLLECTION, {
     field_name: "article",
     field_schema: "keyword",


### PR DESCRIPTION
## Summary
- `ensureSectionCollection` created the `article` payload index only on the fresh-create path; the collection-exists and concurrent-409 early returns skipped it. If a prior start crashed between `createCollection` and `createPayloadIndex`, the index stayed missing and `deleteSectionsForArticle`/pruning (which filter on `article`) failed forever under strict-mode Qdrant. Now the idempotent index-ensure runs on every path, so such a collection self-heals on the next start.

Addresses Codex P2 on #33874. Follow-up to plan: memory-v3-section-lanes.md