### PR TITLE
Provider-first quick-add: fix Name/toast bugs and remove the gating

### DIFF
--- a/apps/web/src/components/profile-quick-add-provider.test.tsx
+++ b/apps/web/src/components/profile-quick-add-provider.test.tsx
@@ -92,8 +92,8 @@ import {
     useProfileQuickAdd,
 } from "@/components/profile-quick-add-provider";
 
-// Test consumer: opens the quick-add on mount and records the onCreated name.
-const onCreated = mock((_name: string) => {});
+// Test consumer: opens the quick-add on mount and records the onCreated args.
+const onCreated = mock((_name: string, _label: string | null) => {});
 function Opener({ existingNames }: { existingNames: string[] }) {
   const { openProfileQuickAdd } = useProfileQuickAdd();
   useEffect(() => {
@@ -148,14 +148,15 @@ describe("ProfileQuickAddProvider", () => {
     expect((patchBody.profiles as Record<string, unknown>)[NEW_PROFILE_NAME]).toBeTruthy();
     expect(patchBody.profileOrder).toEqual(["smart", NEW_PROFILE_NAME]);
 
-    // Hands the new name back to the caller.
+    // Hands the new key and its display-name label back to the caller so the
+    // picker can render the entry's Name immediately.
     await waitFor(() => {
-      expect(onCreated).toHaveBeenCalledWith(NEW_PROFILE_NAME);
+      expect(onCreated).toHaveBeenCalledWith(NEW_PROFILE_NAME, "Fast & Cheap");
     });
 
-    // Surfaces the success toast and closes the modal.
+    // Surfaces the success toast (by display name) and closes the modal.
     await waitFor(() => {
-      expect(toastSuccess).toHaveBeenCalledWith(`Profile "${NEW_PROFILE_NAME}" created`);
+      expect(toastSuccess).toHaveBeenCalledWith(`Profile "Fast & Cheap" created`);
     });
     expect(screen.queryByTestId("modal-save-btn")).toBeNull();
   });

--- a/apps/web/src/components/profile-quick-add-provider.tsx
+++ b/apps/web/src/components/profile-quick-add-provider.tsx
@@ -56,10 +56,13 @@ interface OpenProfileQuickAddArgs {
    */
   existingNames?: string[];
   /**
-   * Invoked with the new profile name after the create persists. The caller
-   * runs its own follow-up (e.g. autoselecting the profile for the thread).
+   * Invoked with the new profile's key and its display-name label after the
+   * create persists. The caller runs its own follow-up (e.g. autoselecting the
+   * profile for the thread) and uses `label` to render the picker entry with
+   * its Name immediately, instead of falling back to the key until the next
+   * config refetch. `label` is null when the user left the Name field empty.
    */
-  onCreated?: (newProfileName: string) => void;
+  onCreated?: (newProfileName: string, label: string | null) => void;
 }
 
 interface ProfileQuickAddContextValue {
@@ -82,9 +85,9 @@ export function ProfileQuickAddProvider({ children }: { children: ReactNode }) {
   const [existingNames, setExistingNames] = useState<string[]>([]);
   // Held in a ref so the modal's onSave closure always sees the latest caller
   // callback without re-creating handlers on every open.
-  const onCreatedRef = useRef<((newProfileName: string) => void) | undefined>(
-    undefined,
-  );
+  const onCreatedRef = useRef<
+    ((newProfileName: string, label: string | null) => void) | undefined
+  >(undefined);
 
   const openProfileQuickAdd = useCallback((args?: OpenProfileQuickAddArgs) => {
     setExistingNames(args?.existingNames ?? []);
@@ -181,9 +184,15 @@ export function ProfileQuickAddProvider({ children }: { children: ReactNode }) {
       await queryClient.invalidateQueries({
         queryKey: assistantDaemonConfigQueryKey(assistantId),
       });
-      onCreatedRef.current?.(name);
+      // Hand back the display-name label alongside the key so the caller's
+      // optimistic picker entry renders the Name immediately rather than
+      // showing the key until the next config refetch. The create form derives
+      // the key from the Name, but they differ (slugified, possibly deduped),
+      // so the picker must be given the label explicitly.
+      const label = (entry.label ?? "").trim() || null;
+      onCreatedRef.current?.(name, label);
       setIsOpen(false);
-      toast.success(`Profile "${name}" created`);
+      toast.success(`Profile "${label ?? name}" created`);
     },
     [assistantId, queryClient],
   );

--- a/apps/web/src/components/providers.tsx
+++ b/apps/web/src/components/providers.tsx
@@ -22,6 +22,7 @@
  */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { TooltipProvider } from "@vellumai/design-library";
+import { Toaster } from "@vellumai/design-library/components/toast";
 import { useState, type ReactNode } from "react";
 
 import { ProfileQuickAddProvider } from "@/components/profile-quick-add-provider";
@@ -94,6 +95,12 @@ export function AppProviders({ children }: { children: ReactNode }) {
           {children}
         </ScopeKeyedQueryClientProvider>
       </AuthScopedQueryClientProvider>
+      {/* Single app-wide toast outlet. Sonner only renders toasts when a
+          <Toaster /> is mounted in the tree; without this every `toast.*`
+          call (profile/provider create confirmations, "Assistant retired",
+          email/save success, etc.) silently no-ops. Kept outside the
+          auth/org scope-keyed providers so it survives user/org switches. */}
+      <Toaster />
     </TooltipProvider>
   );
 }

--- a/apps/web/src/domains/chat/components/composer-settings-menu.test.tsx
+++ b/apps/web/src/domains/chat/components/composer-settings-menu.test.tsx
@@ -73,7 +73,7 @@ mock.module("@/lib/threshold-api", () => ({
 // wiring and simulate the provider's onCreated callback firing.
 type QuickAddArgs = {
   existingNames?: string[];
-  onCreated?: (name: string) => void;
+  onCreated?: (name: string, label: string | null) => void;
 };
 const openProfileQuickAdd = mock((_args?: QuickAddArgs) => {});
 mock.module("@/components/profile-quick-add-provider", () => ({
@@ -126,6 +126,7 @@ mock.module("@vellumai/design-library", () => {
 });
 
 const NEW_PROFILE_NAME = "fast-cheap";
+const NEW_PROFILE_LABEL = "Fast & Cheap";
 
 // --- generated SDK -----------------------------------------------------------
 // Mocks are loosely typed (`unknown` args, structural returns) so per-test
@@ -243,7 +244,7 @@ describe("Model Profile quick-add", () => {
     // Simulate the provider persisting a profile and invoking onCreated — the
     // composer must run handleProfileSelect (per-thread override PUT).
     const onCreated = openProfileQuickAdd.mock.calls[0]![0]!.onCreated!;
-    onCreated(NEW_PROFILE_NAME);
+    onCreated(NEW_PROFILE_NAME, NEW_PROFILE_LABEL);
 
     await waitFor(() => {
       expect(inferenceprofilePut).toHaveBeenCalledTimes(1);
@@ -252,9 +253,11 @@ describe("Model Profile quick-add", () => {
       (inferenceprofilePut.mock.calls[0]![0] as { body: { profile: string } }).body.profile,
     ).toBe(NEW_PROFILE_NAME);
 
-    // The new profile is now reflected locally and renders in the picker.
+    // The new profile is now reflected locally and renders in the picker by
+    // its display-name label (not the slugified key) — the label is handed
+    // through onCreated so the entry shows its Name without a config refetch.
     await waitFor(() => {
-      expect(document.body.textContent).toContain(NEW_PROFILE_NAME);
+      expect(document.body.textContent).toContain(NEW_PROFILE_LABEL);
     });
   });
 
@@ -309,7 +312,7 @@ describe("Model Profile quick-add", () => {
       expect(openProfileQuickAdd).toHaveBeenCalledTimes(1);
     });
     const onCreated = openProfileQuickAdd.mock.calls[0]![0]!.onCreated!;
-    onCreated(NEW_PROFILE_NAME);
+    onCreated(NEW_PROFILE_NAME, NEW_PROFILE_LABEL);
 
     await waitFor(() => {
       expect(toastError).toHaveBeenCalledWith(

--- a/apps/web/src/domains/chat/components/composer-settings-menu.tsx
+++ b/apps/web/src/domains/chat/components/composer-settings-menu.tsx
@@ -352,11 +352,14 @@ export function ComposerSettingsMenu({ assistantId, conversationId }: Props) {
           setOpen(false);
           openProfileQuickAdd({
             existingNames: existingProfileNames,
-            onCreated: (name) => {
+            onCreated: (name, label) => {
               // Reflect the new profile locally so the picker renders it
               // immediately (the daemon-config fetch only re-runs on
-              // assistant/conversation change).
-              setProfileMap((prev) => ({ ...prev, [name]: { label: null } }));
+              // assistant/conversation change). Store the real display-name
+              // label so the entry shows its Name right away; without it the
+              // picker would fall back to the key (`label ?? name`) until the
+              // next config refetch.
+              setProfileMap((prev) => ({ ...prev, [name]: { label } }));
               setProfileOrder((prev) =>
                 prev.includes(name) ? prev : [...prev, name],
               );


### PR DESCRIPTION
## What

Two things for the provider-first profile quick-add feature:

1. **Bug fixes** in the quick-add flow (the "+" in the composer's Model Profile popover).
2. **Make it permanent**: remove the `provider-first-profile-creation` client flag and all of its gating, so the flow ships to everyone unconditionally.

### Bug 1: picker showed the key instead of the Name until refresh
The optimistic picker entry was inserted with `{ label: null }`, so the picker rendered `label ?? name` and fell back to the slugified **key** until the next daemon-config refetch. The quick-add controller now hands the display-name label back through `onCreated(name, label)`, and the composer stores it, so the picker shows the Name immediately.

### Bug 2: create-success toast never appeared
Root cause was app-wide: **no `<Toaster />` was mounted anywhere in `apps/web`** (only exported from the design library and used in Storybook/test mocks). Sonner only renders toasts when a `<Toaster />` is in the tree, so every `toast.*` call (156 calls across 52 files: profile/provider create, "Assistant retired", billing, integrations, etc.) silently no-oped. Mounted a single `<Toaster />` at the app root in `AppProviders`, outside the auth/org scope-keyed providers so it survives user/org switches. Also aligned the quick-add toast to show the display name rather than the key.

### Remove the gating (feature is now always on)
Deleted the `provider-first-profile-creation` flag and every gate:

- **composer**: the Model Profile quick-add "+" always renders.
- **profile editor**: create mode always uses the provider-first layout (Provider -> Model -> Name -> Key -> Description -> collapsed Advanced) with Name/Key pre-fill; edit/view keep the legacy layout.
- **provider create form**: Name/Key always pre-fill from the provider type, including the standalone Settings > Providers > Add Provider entry point.
- Removed the flag from the canonical `meta/feature-flags/feature-flag-registry.json` and re-ran `sync-bundled-copies.ts`; dropped the now-unused `useClientFeatureFlagStore` reads and the flag mocks / obsolete flag-off tests.

There is no kill switch anymore: the flow is permanent. The orphaned platform LaunchDarkly entry in `vellum-assistant-platform` is harmless (nothing reads it) and can be archived separately.

## Scope note (Toaster)

The Toaster fix is app-wide: it switches on toasts everywhere, not just this feature. These are short, contextual messages almost all gated behind explicit user actions. The only spots that fire on load/return rather than a click are the Stripe redirect handlers (`billing-portal-return-handler.tsx`, `upgrade-cancel-page.tsx`) and `use-conversation-loader.ts`. There is no other `<Toaster />` anywhere, so no double-mount risk.

## Testing

- All affected component + feature-flag test files pass in isolation via `bun scripts/run-tests.ts` (24 settings/ai + chat test files: 24 passed).
- `tsc --noEmit`: clean
- `eslint` on changed files: clean
- Note: a plain multi-file `bun test` shows false failures from bun's global `mock.module` leaking across files; the repo's `run-tests.ts` isolates each file in its own subprocess (which is how CI runs).