### PR TITLE
fix(web): prevent silent profile-switch failure after conversation change (LUM-2279)

### DIFF
--- a/apps/web/src/domains/chat/components/composer-settings-menu.test.tsx
+++ b/apps/web/src/domains/chat/components/composer-settings-menu.test.tsx
@@ -318,3 +318,27 @@ describe("Model Profile quick-add", () => {
     });
   });
 });
+
+describe("Profile selection after conversation change (LUM-2279)", () => {
+  test("selecting a profile works immediately after conversationId changes", async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const tree = (convId: string) =>
+      createElement(QueryClientProvider, { client: qc },
+        createElement(ComposerSettingsMenu, { assistantId: "assistant-1", conversationId: convId }));
+
+    const { rerender } = render(tree("conv-1"));
+    await waitFor(() => expect(screen.getByText("Smart")).toBeTruthy());
+
+    // Hang subsequent config fetches so the re-fetch from the conversationId
+    // change never completes — holds the race window open.
+    clientGet.mockImplementation(() => new Promise(() => {}));
+    rerender(tree("conv-2"));
+
+    // Click the profile — without the fix this is silently dropped.
+    const smart = screen.getAllByTestId("menu-item").find((b) => b.textContent?.includes("Smart"));
+    fireEvent.click(smart!);
+
+    await waitFor(() => expect(inferenceprofilePut).toHaveBeenCalledTimes(1));
+    expect((inferenceprofilePut.mock.calls[0]![0] as { body: { profile: string } }).body.profile).toBe("smart");
+  });
+});

--- a/apps/web/src/domains/chat/components/composer-settings-menu.tsx
+++ b/apps/web/src/domains/chat/components/composer-settings-menu.tsx
@@ -70,6 +70,9 @@ export function ComposerSettingsMenu({ assistantId, conversationId }: Props) {
   // values would let a duplicate name overwrite an existing profile and reset
   // the persisted profileOrder to just the new entry.
   const [profilesLoaded, setProfilesLoaded] = useState(false);
+  // Tracks the assistantId that profilesReadyRef was set for, so that
+  // conversationId changes alone don't reset the "ready" gate.
+  const profilesReadyForAssistantRef = useRef<string | null>(null);
 
   const conversationIdRef = useRef(conversationId);
   useLayoutEffect(() => {
@@ -112,12 +115,19 @@ export function ComposerSettingsMenu({ assistantId, conversationId }: Props) {
   // Fetch daemon config and conversation profile in parallel. Running both under
   // the same [assistantId, conversationId] dep set eliminates the two-effect
   // init race from prior cycles — state is always applied together after both
-  // fetches settle, and re-running on assistantId change resets profilesReadyRef
-  // before the async work starts (ref mutation, no extra render).
+  // fetches settle.
+  //
+  // Only reset the profile-selection gate when the assistant changes. The
+  // profile list doesn't change when conversationId changes, and resetting
+  // the gate on every conversationId transition creates a race window where
+  // profiles are visible but clicks are silently dropped (LUM-2279).
   useEffect(() => {
     if (!assistantId) return;
-    profilesReadyRef.current = false;
-    setProfilesLoaded(false);
+    if (profilesReadyForAssistantRef.current !== assistantId) {
+      profilesReadyRef.current = false;
+      setProfilesLoaded(false);
+      profilesReadyForAssistantRef.current = assistantId;
+    }
     let cancelled = false;
 
     (async () => {
@@ -281,6 +291,7 @@ export function ComposerSettingsMenu({ assistantId, conversationId }: Props) {
           // capture — avoids clobbering a later successful selection when two
           // requests race (select A → select B → A fails → should stay at B).
           setProfileActiveKey(lastConfirmedProfileRef.current);
+          toast.error("Failed to switch profile. Please try again.");
         }
         return false;
       }


### PR DESCRIPTION
## Summary

- Fix race condition in `ComposerSettingsMenu` where `profilesReadyRef` was reset on every `conversationId` change, silently dropping profile-switch clicks during the re-fetch window
- Only reset the profile-selection gate when `assistantId` changes — the profile list depends on the assistant, not the conversation
- Add error toast when the profile-switch API call fails (previously silent rollback)

## Root cause

When `conversationId` transitions (e.g. `undefined` → resolved ID on page load, or switching conversations), the `useEffect` unconditionally set `profilesReadyRef.current = false` and started a new config+conversation fetch. During that fetch, the profile list remained visible from the previous render's state, but `handleProfileSelect` silently returned `false` due to the guard — no toast, no error, menu closes, profile reverts.

On platform-hosted deployments the API latency widened this race window enough that users regularly hit it.

## Test plan

- [x] New regression test: renders with `conv-1`, waits for profiles, re-renders with `conv-2` while config fetch hangs, clicks a profile — asserts the PUT fires (fails without fix, passes with fix)
- [x] All 10 existing tests pass
- [x] `bunx tsc --noEmit` clean (no new type errors)
- [x] Verified manually on localhost:3000 via Chrome — profile switch works immediately after creating a new conversation

Closes LUM-2279

🤖 Generated with [Claude Code](https://claude.com/claude-code)