### PR TITLE
Remove provider-first profile creation gating (always on)

### DIFF
--- a/apps/web/src/domains/chat/components/composer-settings-menu.test.tsx
+++ b/apps/web/src/domains/chat/components/composer-settings-menu.test.tsx
@@ -46,18 +46,6 @@ mock.module("@/stores/assistant-feature-flag-store", () => {
   return { useAssistantFeatureFlagStore: store };
 });
 
-// --- client feature flag store ----------------------------------------------
-// The quick-add "+" is gated by the provider-first-profile-creation client
-// flag. A mutable ref lets individual tests flip the flag; default ON so the
-// existing "+" tests exercise the enabled path.
-const providerFirstEnabledRef = { value: true };
-mock.module("@/stores/client-feature-flag-store", () => {
-  const store = () => null;
-  store.use = {
-    providerFirstProfileCreation: () => providerFirstEnabledRef.value,
-  };
-  return { useClientFeatureFlagStore: store };
-});
 
 // --- threshold-api (mount-time access-level fetches) -------------------------
 mock.module("@/lib/threshold-api", () => ({
@@ -175,7 +163,6 @@ function renderMenu() {
 
 beforeEach(() => {
   isMobileRef.value = false;
-  providerFirstEnabledRef.value = true;
   openProfileQuickAdd.mockClear();
   inferenceprofilePut.mockClear();
   clientPatch.mockClear();
@@ -284,16 +271,6 @@ describe("Model Profile quick-add", () => {
       const plus = screen.getByLabelText("New Profile") as HTMLButtonElement;
       expect(plus.disabled).toBe(false);
     });
-  });
-
-  test('"+" New Profile is NOT rendered when the provider-first flag is off', async () => {
-    providerFirstEnabledRef.value = false;
-    renderMenu();
-    // The Model Profile section still renders, but without the quick-add "+".
-    await waitFor(() => {
-      expect(document.body.textContent).toContain("Model Profile");
-    });
-    expect(screen.queryByLabelText("New Profile")).toBeNull();
   });
 
   test("a failed autoselect surfaces an error toast (without claiming creation failed)", async () => {

--- a/apps/web/src/domains/chat/components/composer-settings-menu.tsx
+++ b/apps/web/src/domains/chat/components/composer-settings-menu.tsx
@@ -25,7 +25,6 @@ import {
     setGlobalThresholds,
 } from "@/lib/threshold-api";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
-import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import {
     THRESHOLD_PRESETS,
     overrideAction,
@@ -304,11 +303,6 @@ export function ComposerSettingsMenu({ assistantId, conversationId }: Props) {
 
   const queryComplexityRoutingEnabled =
     useAssistantFeatureFlagStore.use.queryComplexityRouting();
-  // Quick-add "+" is part of the provider-first profile-creation UX and is
-  // gated by the same client flag. When off, the Model Profile header renders
-  // no "+" and the quick-add modal is unreachable from chat.
-  const providerFirstEnabled =
-    useClientFeatureFlagStore.use.providerFirstProfileCreation();
 
   const visibleProfileEntries = useMemo(
     () =>
@@ -333,9 +327,8 @@ export function ComposerSettingsMenu({ assistantId, conversationId }: Props) {
 
   // The "+" quick-add affordance rendered in both the desktop Menu.Label and
   // the mobile SectionLabel. Closes the popover/sheet, then opens the modal.
-  // Disabled until `profilesLoaded` (see its declaration for why). Gated to
-  // `null` when the provider-first flag is off, so neither header shows a "+".
-  const quickAddButton = !providerFirstEnabled ? null : (
+  // Disabled until `profilesLoaded` (see its declaration for why).
+  const quickAddButton = (
     <Tooltip
       content={profilesLoaded ? "New Profile" : "Loading profiles…"}
       side="top"

--- a/apps/web/src/domains/settings/ai/profile-editor-modal.test.tsx
+++ b/apps/web/src/domains/settings/ai/profile-editor-modal.test.tsx
@@ -59,17 +59,6 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
     }),
 }));
 
-// The provider-first create layout + pre-fill is gated by the
-// provider-first-profile-creation client flag. A mutable ref lets individual
-// tests flip it; default ON so the existing provider-first tests pass.
-const providerFirstEnabledRef = { value: true };
-mock.module("@/stores/client-feature-flag-store", () => {
-  const store = () => null;
-  store.use = {
-    providerFirstProfileCreation: () => providerFirstEnabledRef.value,
-  };
-  return { useClientFeatureFlagStore: store };
-});
 
 // Stub the credential hooks so the inline ProviderCreateForm renders without
 // issuing real daemon queries.
@@ -237,7 +226,6 @@ function fillCreateForm(): void {
 beforeEach(() => {
   createdConnection = makeConnection("anthropic-personal");
   toastSuccessCalls = [];
-  providerFirstEnabledRef.value = true;
 });
 
 afterEach(() => {
@@ -451,28 +439,6 @@ describe("ProfileEditorModal create mode — provider-first", () => {
     });
     // ...and the modal stays open (the Save button is still rendered).
     expect(getSaveBtn()).toBeDefined();
-  });
-
-  test("flag OFF: legacy create layout — Display Name first, no '+ Create new provider'", () => {
-    providerFirstEnabledRef.value = false;
-    renderCreate([makeConnection("anthropic-personal")]);
-
-    // Legacy create renders the edit/view field order: the first labelled field
-    // is "Display Name" and it appears BEFORE the Provider section (i.e.
-    // provider is not first).
-    const text = document.body.textContent ?? "";
-    expect(text).toContain("Display Name");
-    const displayNameIdx = text.indexOf("Display Name");
-    const providerIdx = text.indexOf("Provider");
-    expect(displayNameIdx).toBeGreaterThanOrEqual(0);
-    expect(providerIdx).toBeGreaterThan(displayNameIdx);
-
-    // The legacy Provider dropdown has NO inline "+ Create new provider" option.
-    fireEvent.click(providerTrigger());
-    const optionLabels = Array.from(
-      document.querySelectorAll<HTMLElement>('[role="option"]'),
-    ).map((o) => o.textContent?.trim());
-    expect(optionLabels).not.toContain("+ Create new provider");
   });
 
   test("the modal itself does NOT fire a profile-create success toast", async () => {

--- a/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -12,7 +12,6 @@ import { ChevronRight } from "lucide-react";
 
 import { getModelsForProvider } from "@/assistant/llm-model-catalog";
 import { inferenceProviderconnectionsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
-import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 
 import type { ProfileEntry, ProfileStatus, ProfileWithName } from "@/domains/settings/ai/ai-types";
 import { INFERENCE_PROVIDER_DISPLAY_NAMES, OPENAI_COMPATIBLE_PROVIDER } from "@/domains/settings/ai/ai-types";
@@ -162,8 +161,6 @@ function ProfileEditorModalInner({
   const [effectiveMode, setEffectiveMode] = useState<"create" | "edit" | "view">(mode);
   const isReadOnly = effectiveMode === "view";
   const isAutoProfile = profileName === AUTO_PROFILE_NAME;
-  const providerFirstEnabled =
-    useClientFeatureFlagStore.use.providerFirstProfileCreation();
 
   // Managed profiles open the editor in view mode (mode === "view") so they
   // can't be reshaped (provider, model, advanced params) — those are
@@ -383,7 +380,7 @@ function ProfileEditorModalInner({
     // but only while the user hasn't manually edited either field (dirty
     // tracking lives in useLabelKeySync). Clearing the model leaves the
     // current values untouched.
-    if (effectiveMode === "create" && providerFirstEnabled && newModel && !getDirty()) {
+    if (effectiveMode === "create" && newModel && !getDirty()) {
       const { name, key: derivedKey } = deriveProfileDefaults(
         resolveModelDisplayName(newModel),
         existingNames,
@@ -561,10 +558,10 @@ function ProfileEditorModalInner({
         ? "Edit Profile"
         : (initialValues?.label ?? profileName ?? "Profile");
 
-  // The provider-first create layout + pre-fill is behind a client flag. When
-  // off, create mode falls back to the legacy edit/view-style layout (legacy
-  // create), which renders the previous field order with an editable Key.
-  const useProviderFirst = effectiveMode === "create" && providerFirstEnabled;
+  // Create mode uses the provider-first layout (Provider -> Model -> Name ->
+  // Key -> Description -> collapsed Advanced) with pre-fill. Edit and view
+  // modes use the legacy layout below.
+  const useProviderFirst = effectiveMode === "create";
 
   // ---- Reusable field nodes (shared by create + edit/view bodies) ----
 
@@ -841,12 +838,9 @@ function ProfileEditorModalInner({
             {saveErrorNode}
           </div>
         ) : (
-          // Edit / view modes — and flag-off (legacy) create — keep the
-          // original field order and locking:
+          // Edit / view modes keep the original field order and locking:
           // Display Name -> Description -> Key -> Active -> Provider -> Model
-          // -> always-visible Advanced. The Key field stays editable in create
-          // mode and the footer renders Cancel/Save (both keyed off
-          // `effectiveMode`), so this branch is a correct legacy-create layout.
+          // -> always-visible Advanced.
           <div className="space-y-4">
             {displayNameField}
             {descriptionField}

--- a/apps/web/src/domains/settings/ai/provider-create-form.test.tsx
+++ b/apps/web/src/domains/settings/ai/provider-create-form.test.tsx
@@ -91,16 +91,6 @@ mock.module("@/domains/settings/ai/use-provider-credentials-list", () => ({
   }),
 }));
 
-// Provider Name/Key pre-fill is gated by the provider-first client flag.
-// Default it ON so the seeding tests below exercise the new behavior; an
-// individual test flips it to false to assert the legacy (no pre-fill) path.
-const providerFirstFlag = { value: true };
-mock.module("@/stores/client-feature-flag-store", () => ({
-  useClientFeatureFlagStore: {
-    use: { providerFirstProfileCreation: () => providerFirstFlag.value },
-  },
-}));
-
 const { ProviderCreateForm } = await import(
   "@/domains/settings/ai/provider-create-form"
 );
@@ -203,7 +193,6 @@ beforeEach(() => {
   createResponseOk = true;
   createResponseStatus = 200;
   toastSuccessCalls = [];
-  providerFirstFlag.value = true;
 });
 
 afterEach(() => {
@@ -453,26 +442,6 @@ describe("ProviderCreateForm submit sequence", () => {
     expect(getInputByPlaceholder("e.g. anthropic-personal").value).toBe(
       "anthropic",
     );
-  });
-
-  test("with the provider-first flag OFF, Name/Key are NOT pre-filled (legacy Add Provider)", () => {
-    providerFirstFlag.value = false;
-    render(
-      <ModalWrapper>
-        <ProviderCreateForm
-          assistantId={ASSISTANT_ID}
-          existingNames={[]}
-          defaultProviderType="anthropic"
-          onCreated={() => {}}
-          onCancel={() => {}}
-        />
-      </ModalWrapper>,
-    );
-
-    // Standalone Settings → Providers → Add Provider must behave as before the
-    // rollout: empty Name/Key, no provider-type seeding.
-    expect(getInputByPlaceholder("e.g. My Anthropic Key").value).toBe("");
-    expect(getInputByPlaceholder("e.g. anthropic-personal").value).toBe("");
   });
 
   test("dedupes the seeded Key against existingNames", () => {

--- a/apps/web/src/domains/settings/ai/provider-create-form.tsx
+++ b/apps/web/src/domains/settings/ai/provider-create-form.tsx
@@ -35,7 +35,6 @@ import {
 import { secretPlaceholder } from "@/domains/settings/ai/secret-placeholder";
 import { useLabelKeySync } from "@/domains/settings/ai/use-label-key-sync";
 import { useProviderCredentialsList } from "@/domains/settings/ai/use-provider-credentials-list";
-import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 
 // ---------------------------------------------------------------------------
 // ProviderCreateForm
@@ -84,21 +83,12 @@ export function ProviderCreateForm({
 }: ProviderCreateFormProps) {
   const initialProvider: ConnectionProvider = defaultProviderType ?? "anthropic";
 
-  // Provider Name/Key pre-fill is part of the provider-first rollout, so it is
-  // gated by the same client flag. When off, this form — including the
-  // standalone Settings → Providers → Add Provider entry point — behaves as
-  // before: empty Name/Key and no provider-type re-seed.
-  const providerFirstEnabled =
-    useClientFeatureFlagStore.use.providerFirstProfileCreation();
-
   // Seed Display Name (label) + Key (name) from the initial provider type so
   // the form opens pre-filled (e.g. Anthropic → "Anthropic" / "anthropic"),
   // deduped against existing connection names. The user can override both, and
   // a provider-type change re-seeds only while they haven't edited the fields
   // (see the dirty guard in the Provider dropdown's onChange below).
-  const initialDefaults = providerFirstEnabled
-    ? deriveProviderDefaults(initialProvider, existingNames)
-    : { name: "", key: "" };
+  const initialDefaults = deriveProviderDefaults(initialProvider, existingNames);
 
   const [label, setLabel] = useState(initialDefaults.name);
   const [name, setName] = useState(initialDefaults.key);
@@ -343,7 +333,7 @@ export function ProviderCreateForm({
             // only while the user hasn't manually edited either field (dirty
             // tracking lives in useLabelKeySync). Seeding writes state
             // directly so it doesn't itself flip the dirty flag.
-            if (providerFirstEnabled && !getDirty()) {
+            if (!getDirty()) {
               const { name: seedName, key: seedKey } = deriveProviderDefaults(
                 newProvider,
                 existingNames,

--- a/apps/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/apps/web/src/lib/feature-flags/feature-flag-registry.json
@@ -483,14 +483,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "provider-first-profile-creation",
-      "scope": "client",
-      "key": "provider-first-profile-creation",
-      "label": "Provider-First Profile Creation",
-      "description": "New profile creation flow: pick (or inline-create) a provider first, then a model, with pre-filled provider and profile name/key, plus a quick-add \"+\" in the chat composer's Model Profile menu. When off, profile creation uses the previous field order and there is no composer quick-add.",
-      "defaultEnabled": false
-    },
-    {
       "id": "acp",
       "scope": "assistant",
       "key": "acp",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -483,14 +483,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "provider-first-profile-creation",
-      "scope": "client",
-      "key": "provider-first-profile-creation",
-      "label": "Provider-First Profile Creation",
-      "description": "New profile creation flow: pick (or inline-create) a provider first, then a model, with pre-filled provider and profile name/key, plus a quick-add \"+\" in the chat composer's Model Profile menu. When off, profile creation uses the previous field order and there is no composer quick-add.",
-      "defaultEnabled": false
-    },
-    {
       "id": "acp",
       "scope": "assistant",
       "key": "acp",


### PR DESCRIPTION
## What

Makes the provider-first profile creation flow permanent by removing the `provider-first-profile-creation` client flag and all of its gating. Follow-up to #33925 (the bug fixes + Toaster), which has merged.

The flow is now always on:

- **composer**: the Model Profile quick-add "+" always renders.
- **profile editor**: create mode always uses the provider-first layout (Provider -> Model -> Name -> Key -> Description -> collapsed Advanced) with Name/Key pre-fill; edit/view keep the legacy layout.
- **provider create form**: Name/Key always pre-fill from the provider type, including the standalone Settings > Providers > Add Provider entry point.

Also:

- Removed the flag from the canonical `meta/feature-flags/feature-flag-registry.json` and re-ran `sync-bundled-copies.ts` (the tracked apps/web copy + gitignored assistant/gateway copies all match).
- Dropped the now-unused `useClientFeatureFlagStore` reads from all three components.
- Deleted the flag mocks and the obsolete flag-off test cases.

Net -127 lines.

## Platform / LaunchDarkly

No companion platform change is needed. The flag was never provisioned in `vellum-assistant-platform`: it is absent from the Terraform `flags` map in `terraform/gcp/env/prod/vellum-assistant/main.tf` (the sole source of LaunchDarkly flags), so there is nothing to delete in LaunchDarkly.

## Testing

- Affected component + feature-flag test files pass in isolation via `bun scripts/run-tests.ts` (6 passed). Note: a plain multi-file `bun test` shows false failures from bun's global `mock.module` leaking across files; CI isolates each file in its own subprocess.
- `tsc --noEmit`: clean
- `eslint` on changed files: clean