### PR TITLE
fix(gateway): add memory v3 commands to the risk registry

### DIFF
--- a/gateway/src/risk/command-registry/commands/assistant.ts
+++ b/gateway/src/risk/command-registry/commands/assistant.ts
@@ -163,6 +163,9 @@ const ASSISTANT_SUPPORTED_COMMAND_PATHS = [
   "memory v2 reembed-skills",
   "memory v2 activation",
   "memory v2 validate",
+  "memory v3",
+  "memory v3 rebuild-index",
+  "memory v3 backfill-sections",
   "notifications",
   "notifications send",
   "notifications list",
@@ -493,6 +496,18 @@ const riskOverrides: AssistantRiskOverride[] = [
     path: "memory v2 validate",
     risk: "low",
     reason: "Read-only diagnostic walk over concept pages and edges",
+  },
+  {
+    path: "memory v3 backfill-sections",
+    risk: "medium",
+    reason:
+      "Embeds every page's sections into the v3 dense store and advances the maintain checkpoint",
+  },
+  {
+    path: "memory v3 rebuild-index",
+    risk: "low",
+    reason:
+      "Invalidates the in-memory v3 section lanes so they rebuild on the next turn",
   },
   { path: "notifications send", risk: "low" },
   {


### PR DESCRIPTION
## Summary
- Register the `memory v3 backfill-sections` (medium — embeds the whole corpus into the dense store + advances the maintain checkpoint) and `memory v3 rebuild-index` (low — invalidates in-memory lanes) CLI commands in the gateway bash risk registry (coverage list + risk overrides). Without these, host/shell approval contexts resolve only the top-level `assistant` spec and under-classify the mutating backfill at default low risk. Required by assistant/src/cli/AGENTS.md when CLI subcommands change.

Addresses Codex P2 on #33874. Follow-up to plan: memory-v3-section-lanes.md