### PR TITLE
feat(macos): bridge VELLUM_FLAG_* env vars to renderer via contextBridge

### DIFF
--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -760,8 +760,26 @@ if (vellumConfig) {
   contextBridge.exposeInMainWorld("__VELLUM_CONFIG__", vellumConfig);
 }
 
+const flagOverrides: Record<string, boolean | string> = {};
+for (const [key, value] of Object.entries(process.env)) {
+  if (!key.startsWith("VELLUM_FLAG_") || value === undefined) continue;
+  const flagKey = key
+    .slice("VELLUM_FLAG_".length)
+    .toLowerCase()
+    .replace(/_/g, "-");
+  const lower = value.trim().toLowerCase();
+  if (["true", "1", "yes", "on"].includes(lower)) flagOverrides[flagKey] = true;
+  else if (["false", "0", "no", "off"].includes(lower))
+    flagOverrides[flagKey] = false;
+  else flagOverrides[flagKey] = value.trim();
+}
+if (Object.keys(flagOverrides).length > 0) {
+  contextBridge.exposeInMainWorld("__VELLUM_FLAG_OVERRIDES__", flagOverrides);
+}
+
 declare global {
   interface Window {
     vellum: VellumBridge;
+    __VELLUM_FLAG_OVERRIDES__?: Record<string, boolean | string>;
   }
 }


### PR DESCRIPTION
## Summary
- Scan process.env for VELLUM_FLAG_* entries in the Electron preload
- Parse values (true/1/yes/on → true, false/0/no/off → false, else string)
- Expose as window.__VELLUM_FLAG_OVERRIDES__ via contextBridge when overrides exist
- Add Window type augmentation for __VELLUM_FLAG_OVERRIDES__

Part of plan: ff-env-var-overrides.md (PR 7 of 8)