### PR TITLE
feat(web): add env flag override reader and Window type declarations

### DIFF
--- a/apps/web/src/env.d.ts
+++ b/apps/web/src/env.d.ts
@@ -25,8 +25,16 @@ interface ImportMetaEnv {
    * Defaults to `velay.vellum.ai` when unset. See `domains/chat/voice/live-voice/connection.ts`.
    */
   readonly VITE_VELAY_HOST?: string;
+
+  /** Feature flag overrides via env vars: `VITE_VELLUM_FLAG_<UPPER_SNAKE_KEY>=true|false|string`. */
+  readonly [key: `VITE_VELLUM_FLAG_${string}`]: string | undefined;
 }
 
 interface ImportMeta {
   readonly env: ImportMetaEnv;
+}
+
+interface Window {
+  /** Feature flag overrides injected by Electron preload or CLI script. */
+  __VELLUM_FLAG_OVERRIDES__?: Record<string, boolean | string>;
 }

--- a/apps/web/src/lib/feature-flags/feature-flag-catalog.test.ts
+++ b/apps/web/src/lib/feature-flags/feature-flag-catalog.test.ts
@@ -3,6 +3,9 @@ import { describe, expect, test } from "bun:test";
 import {
   ASSISTANT_FLAG_DEFAULTS,
   CLIENT_FLAG_DEFAULTS,
+  getEnvFlagOverridesForScope,
+  readEnvFlagOverrides,
+  scopeIncludes,
 } from "@/lib/feature-flags/feature-flag-catalog";
 
 describe("feature flag catalog", () => {
@@ -21,5 +24,109 @@ describe("feature flag catalog", () => {
   test("exposes dynamic empty-state greetings as an assistant flag", () => {
     expect(ASSISTANT_FLAG_DEFAULTS.emptyStateDynamicGreetings).toBe(false);
     expect("emptyStateDynamicGreetings" in CLIENT_FLAG_DEFAULTS).toBe(false);
+  });
+});
+
+describe("readEnvFlagOverrides", () => {
+  test("returns empty object when neither window global nor Vite env vars are present", () => {
+    const overrides = readEnvFlagOverrides();
+    expect(overrides).toEqual({});
+  });
+
+  test("reads from window.__VELLUM_FLAG_OVERRIDES__ when set before module load", async () => {
+    // Set up the global before importing a fresh module instance
+    (globalThis as Record<string, unknown>).window = {
+      __VELLUM_FLAG_OVERRIDES__: {
+        "self-intro-greeting": true,
+        "home-tab": "variant-a",
+      },
+    };
+
+    try {
+      // Bust the module cache by appending a query parameter
+      const mod = await import(
+        "@/lib/feature-flags/feature-flag-catalog?t=window-test"
+      );
+      const overrides = mod.readEnvFlagOverrides();
+      expect(overrides).toEqual({
+        "self-intro-greeting": true,
+        "home-tab": "variant-a",
+      });
+    } finally {
+      delete (globalThis as Record<string, unknown>).window;
+    }
+  });
+});
+
+describe("getEnvFlagOverridesForScope", () => {
+  test("returns empty bool and str maps when no overrides are present", () => {
+    const result = getEnvFlagOverridesForScope("client");
+    expect(result).toEqual({ bool: {}, str: {} });
+  });
+
+  test("filters client-scoped flags and separates bool/str", async () => {
+    (globalThis as Record<string, unknown>).window = {
+      __VELLUM_FLAG_OVERRIDES__: {
+        // client-only flag (boolean)
+        "home-tab": true,
+        // assistant-only flag (boolean) — should be excluded from client scope
+        "auto-analyze": true,
+        // client-only flag (string)
+        "pre-chat-onboarding-experiment-2026-06-06": "variant-a",
+      },
+    };
+
+    try {
+      const mod = await import(
+        "@/lib/feature-flags/feature-flag-catalog?t=scope-client"
+      );
+      const result = mod.getEnvFlagOverridesForScope("client");
+      expect(result.bool).toEqual({ homeTab: true });
+      expect(result.str).toEqual({
+        preChatOnboardingExperiment20260606: "variant-a",
+      });
+      // assistant-only flag should not appear
+      expect(result.bool).not.toHaveProperty("autoAnalyze");
+    } finally {
+      delete (globalThis as Record<string, unknown>).window;
+    }
+  });
+
+  test("flags with scope 'both' appear for both client and assistant scopes", async () => {
+    (globalThis as Record<string, unknown>).window = {
+      __VELLUM_FLAG_OVERRIDES__: {
+        "self-intro-greeting": true,
+      },
+    };
+
+    try {
+      const mod = await import(
+        "@/lib/feature-flags/feature-flag-catalog?t=scope-both"
+      );
+      const clientResult = mod.getEnvFlagOverridesForScope("client");
+      const assistantResult = mod.getEnvFlagOverridesForScope("assistant");
+
+      expect(clientResult.bool).toEqual({ selfIntroGreeting: true });
+      expect(assistantResult.bool).toEqual({ selfIntroGreeting: true });
+    } finally {
+      delete (globalThis as Record<string, unknown>).window;
+    }
+  });
+});
+
+describe("scopeIncludes", () => {
+  test("'both' includes client and assistant", () => {
+    expect(scopeIncludes("both", "client")).toBe(true);
+    expect(scopeIncludes("both", "assistant")).toBe(true);
+  });
+
+  test("'client' only includes client", () => {
+    expect(scopeIncludes("client", "client")).toBe(true);
+    expect(scopeIncludes("client", "assistant")).toBe(false);
+  });
+
+  test("'assistant' only includes assistant", () => {
+    expect(scopeIncludes("assistant", "assistant")).toBe(true);
+    expect(scopeIncludes("assistant", "client")).toBe(false);
   });
 });

--- a/apps/web/src/lib/feature-flags/feature-flag-catalog.ts
+++ b/apps/web/src/lib/feature-flags/feature-flag-catalog.ts
@@ -92,3 +92,73 @@ export function getFlagDefinition(storeKey: string): FlagDefinition | undefined 
 }
 
 export { flags as ALL_FLAGS };
+
+// -- Env flag override helpers ------------------------------------------------
+
+const VITE_FLAG_PREFIX = "VITE_VELLUM_FLAG_";
+
+function upperSnakeToKebab(upper: string): string {
+  return upper.toLowerCase().replace(/_/g, "-");
+}
+
+function parseEnvValue(raw: string): boolean | string {
+  const lower = raw.toLowerCase();
+  if (lower === "true") return true;
+  if (lower === "false") return false;
+  return raw;
+}
+
+function computeEnvFlagOverrides(): Record<string, boolean | string> {
+  if (
+    typeof window !== "undefined" &&
+    window.__VELLUM_FLAG_OVERRIDES__ != null
+  ) {
+    return { ...window.__VELLUM_FLAG_OVERRIDES__ };
+  }
+
+  const overrides: Record<string, boolean | string> = {};
+  const env = import.meta.env;
+  for (const key of Object.keys(env)) {
+    if (key.startsWith(VITE_FLAG_PREFIX)) {
+      const flagKey = upperSnakeToKebab(key.slice(VITE_FLAG_PREFIX.length));
+      const raw = env[key as keyof ImportMetaEnv];
+      if (raw != null) {
+        overrides[flagKey] = parseEnvValue(raw);
+      }
+    }
+  }
+  return overrides;
+}
+
+const cachedOverrides = computeEnvFlagOverrides();
+
+export function readEnvFlagOverrides(): Record<string, boolean | string> {
+  return cachedOverrides;
+}
+
+const FLAG_KEY_TO_DEF = new Map<string, FlagDefinition>();
+for (const flag of flags) {
+  FLAG_KEY_TO_DEF.set(flag.key, flag);
+}
+
+export function getEnvFlagOverridesForScope(
+  scope: SingleScope,
+): { bool: Record<string, boolean>; str: Record<string, string> } {
+  const overrides = readEnvFlagOverrides();
+  const bool: Record<string, boolean> = {};
+  const str: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(overrides)) {
+    const def = FLAG_KEY_TO_DEF.get(key);
+    if (!def || !scopeIncludes(def.scope, scope)) continue;
+
+    const storeKey = flagKeyToStoreKey(key);
+    if (typeof value === "boolean") {
+      bool[storeKey] = value;
+    } else {
+      str[storeKey] = value;
+    }
+  }
+
+  return { bool, str };
+}


### PR DESCRIPTION
## Summary
- Add readEnvFlagOverrides() to read from window.__VELLUM_FLAG_OVERRIDES__ or VITE_VELLUM_FLAG_* env vars
- Add getEnvFlagOverridesForScope() to filter and separate overrides by scope and type
- Add Window.__VELLUM_FLAG_OVERRIDES__ type declaration to env.d.ts
- Add tests for both functions

Part of plan: ff-env-var-overrides.md (PR 6 of 8)