### PR TITLE
fix(ci): scope NODE_AUTH_TOKEN to npm publish step only

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -2024,14 +2024,17 @@ jobs:
         run: bun run meta/feature-flags/sync-bundled-copies.ts
       - name: Stamp dev version
         run: jq --arg v "${{ needs.compute-version.outputs.version }}" '.version = $v' ${{ matrix.package }}/package.json > ${{ matrix.package }}/package.json.tmp && mv ${{ matrix.package }}/package.json.tmp ${{ matrix.package }}/package.json
-      - name: Install and publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Install package dependencies
         run: |
           cd "${{ matrix.package }}"
           if ! bun install --frozen-lockfile; then
             rm -f bun.lock && rm -rf node_modules && bun install
           fi
+      - name: Publish package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          cd "${{ matrix.package }}"
           PKG_NAME=$(node -p "require('./package.json').name")
           PKG_VERSION=$(node -p "require('./package.json').version")
           if npm view "$PKG_NAME@$PKG_VERSION" version >/dev/null 2>&1; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1289,10 +1289,7 @@ jobs:
       - name: Sync feature flag registry for publish
         run: bun run meta/feature-flags/sync-bundled-copies.ts
 
-      - name: Install and publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          E2E_BLOCKS_RELEASE: ${{ inputs.playwright_blocks_release }}
+      - name: Install package dependencies
         run: |
           PACKAGE="${{ matrix.package }}"
           cd "$PACKAGE"
@@ -1302,6 +1299,13 @@ jobs:
             rm -rf node_modules
             bun install
           fi
+      - name: Publish package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          E2E_BLOCKS_RELEASE: ${{ inputs.playwright_blocks_release }}
+        run: |
+          PACKAGE="${{ matrix.package }}"
+          cd "$PACKAGE"
           PKG_NAME=$(node -p "require('./package.json').name")
           PKG_VERSION=$(node -p "require('./package.json').version")
           if npm view "$PKG_NAME@$PKG_VERSION" version >/dev/null 2>&1; then
@@ -1397,14 +1401,17 @@ jobs:
         run: bun run meta/feature-flags/sync-bundled-copies.ts
       - name: Stamp staging version
         run: jq --arg v "${{ needs.extract-version.outputs.version }}" '.version = $v' ${{ matrix.package }}/package.json > ${{ matrix.package }}/package.json.tmp && mv ${{ matrix.package }}/package.json.tmp ${{ matrix.package }}/package.json
-      - name: Install and publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Install package dependencies
         run: |
           cd "${{ matrix.package }}"
           if ! bun install --frozen-lockfile; then
             rm -f bun.lock && rm -rf node_modules && bun install
           fi
+      - name: Publish package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          cd "${{ matrix.package }}"
           PKG_NAME=$(node -p "require('./package.json').name")
           PKG_VERSION=$(node -p "require('./package.json').version")
           if npm view "$PKG_NAME@$PKG_VERSION" version >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

- Split "Install and publish" workflow steps into separate "Install package dependencies" and "Publish package" steps across all three npm publish jobs (`publish-npm-dev`, `publish-npm-prod`, `publish-npm-staging`)
- `NODE_AUTH_TOKEN` is now only present in the environment during `npm publish`, not during `bun install` where lifecycle scripts could read it
- Addresses supply-chain risk where a compromised dependency's install script could exfiltrate the npm publish token

Codex finding: https://chatgpt.com/codex/cloud/security/findings/7fd13b42d5088191b45c3e31a7a0282b?q=API+keys+can+trigger+paid+Pro+tier+changes&sev=

## Original prompt

A Codex security finding flagged that the npm publish jobs in `dev-release.yaml` and `release.yml` set `NODE_AUTH_TOKEN` for the entire "Install and publish" step, meaning `bun install` lifecycle scripts inherit the publish-capable npm token. The fix splits each combined step into two: dependency installation without credentials, then publishing with credentials — ensuring the token is only available when actually needed for `npm publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)