### PR TITLE
feat(cli): add --flag to vellum hatch

### DIFF
--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -16,6 +16,7 @@ import {
 import type { RemoteHost, Species } from "../lib/constants";
 import { buildNestedConfig } from "../lib/config-utils";
 import { hatchDocker } from "../lib/docker";
+import { parseFeatureFlagArgs } from "../lib/flag-args";
 import type { PollResult, WatchHatchingResult } from "../lib/gcp";
 import { hatchLocal } from "../lib/hatch-local";
 import {
@@ -178,11 +179,14 @@ interface HatchArgs {
   watch: boolean;
   sourcePath: string | null;
   configValues: Record<string, string>;
+  flagEnvVars: Record<string, string>;
   analyze: boolean;
 }
 
 function parseArgs(): HatchArgs {
-  const args = process.argv.slice(3);
+  const { envVars: flagEnvVars, remaining: args } = parseFeatureFlagArgs(
+    process.argv.slice(3),
+  );
   let species: Species = DEFAULT_SPECIES;
   let detached = false;
   let keepAlive = false;
@@ -221,6 +225,9 @@ function parseArgs(): HatchArgs {
       );
       console.log(
         "  --config <key=value>      Set a workspace config value (repeatable)",
+      );
+      console.log(
+        "  --flag <key=value>        Set a feature flag override as VELLUM_FLAG_<KEY> env var (repeatable)",
       );
       console.log(
         "  --analyze                 Emit a structured hatch-timing log line on stdout",
@@ -289,7 +296,7 @@ function parseArgs(): HatchArgs {
       species = arg as Species;
     } else {
       console.error(
-        `Error: Unknown argument '${arg}'. Valid options: ${VALID_SPECIES.join(", ")}, -d, --watch, --source <path>, --keep-alive, --name <name>, --remote <${VALID_REMOTE_HOSTS.join("|")}>, --config <key=value>, --analyze`,
+        `Error: Unknown argument '${arg}'. Valid options: ${VALID_SPECIES.join(", ")}, -d, --watch, --source <path>, --keep-alive, --name <name>, --remote <${VALID_REMOTE_HOSTS.join("|")}>, --config <key=value>, --flag <key=value>, --analyze`,
       );
       process.exit(1);
     }
@@ -304,6 +311,7 @@ function parseArgs(): HatchArgs {
     watch,
     sourcePath,
     configValues,
+    flagEnvVars,
     analyze,
   };
 }
@@ -538,6 +546,7 @@ export async function hatch(): Promise<void> {
     watch,
     sourcePath,
     configValues,
+    flagEnvVars,
     analyze,
   } = parseArgs();
 
@@ -566,7 +575,7 @@ export async function hatch(): Promise<void> {
   }
 
   if (remote === "local") {
-    await hatchLocal(species, name, watch, keepAlive, configValues);
+    await hatchLocal(species, name, watch, keepAlive, configValues, flagEnvVars);
     return;
   }
 

--- a/cli/src/lib/hatch-local.ts
+++ b/cli/src/lib/hatch-local.ts
@@ -164,6 +164,7 @@ export async function hatchLocal(
   watch: boolean = false,
   keepAlive: boolean = false,
   configValues: Record<string, string> = {},
+  flagEnvVars: Record<string, string> = {},
   options: HatchLocalOptions = {},
 ): Promise<HatchLocalResult> {
   const reporter = options.reporter ?? consoleLifecycleReporter;
@@ -234,6 +235,7 @@ export async function hatchLocal(
     runtimeUrl = await startGateway(watch, resources, {
       signingKey,
       bootstrapSecret,
+      envOverrides: flagEnvVars,
     });
   } catch (error) {
     // Gateway failed — stop the daemon we just started so we don't leave

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -1057,7 +1057,11 @@ export async function startLocalDaemon(
 export async function startGateway(
   watch: boolean = false,
   resources?: LocalInstanceResources,
-  options?: { signingKey?: string; bootstrapSecret?: string },
+  options?: {
+    signingKey?: string;
+    bootstrapSecret?: string;
+    envOverrides?: Record<string, string>;
+  },
 ): Promise<string> {
   const effectiveGatewayPort = resources?.gatewayPort ?? GATEWAY_PORT;
 
@@ -1083,6 +1087,7 @@ export async function startGateway(
 
   const gatewayEnv: Record<string, string> = {
     ...(process.env as Record<string, string>),
+    ...options?.envOverrides,
     RUNTIME_HTTP_PORT: String(effectiveDaemonPort),
     GATEWAY_PORT: String(effectiveGatewayPort),
     // Pass gateway operational settings via env vars so the CLI does not


### PR DESCRIPTION
## Summary
- Add --flag key=value to vellum hatch arg parsing via parseFeatureFlagArgs
- Thread flagEnvVars through hatchLocal() to startGateway()
- Spread flag env vars into gateway child process environment
- Add --flag to help text

Part of plan: ff-env-var-overrides.md (PR 4 of 8)