### PR TITLE
feat(gateway): wire env var overrides into flag resolver, IPC, and HTTP

### DIFF
--- a/gateway/src/__tests__/feature-flag-resolver.test.ts
+++ b/gateway/src/__tests__/feature-flag-resolver.test.ts
@@ -64,6 +64,10 @@ afterEach(() => {
   resetFeatureFlagDefaultsCache();
   clearFeatureFlagStoreCache();
   clearRemoteFeatureFlagStoreCache();
+  resetEnvOverridesCache();
+  delete process.env.VELLUM_FLAG_BROWSER;
+  delete process.env.VELLUM_FLAG_A2A_CHANNEL;
+  delete process.env.VELLUM_FLAG_DEFAULT_MODEL;
 });
 
 const { isFeatureFlagEnabled, getFeatureFlagValue } = await import("../feature-flag-resolver.js");
@@ -73,6 +77,8 @@ const { clearFeatureFlagStoreCache, writeFeatureFlag } =
   await import("../feature-flag-store.js");
 const { clearRemoteFeatureFlagStoreCache, writeRemoteFeatureFlags } =
   await import("../feature-flag-remote-store.js");
+const { resetEnvOverridesCache } =
+  await import("../feature-flag-env-overrides.js");
 
 describe("isFeatureFlagEnabled", () => {
   test("uses registry defaults when no override exists", () => {
@@ -148,5 +154,25 @@ describe("getFeatureFlagValue", () => {
     writeRemoteFeatureFlags({ "default-model": "remote-model" });
     writeFeatureFlag("default-model", "persisted-model");
     expect(getFeatureFlagValue("default-model")).toBe("persisted-model");
+  });
+
+  test("env override wins over persisted, remote, and default values", () => {
+    writeRemoteFeatureFlags({ browser: false });
+    writeFeatureFlag("browser", false);
+
+    process.env.VELLUM_FLAG_BROWSER = "true";
+    resetEnvOverridesCache();
+
+    expect(getFeatureFlagValue("browser")).toBe(true);
+  });
+
+  test("env override wins for string flags", () => {
+    writeRemoteFeatureFlags({ "default-model": "remote-model" });
+    writeFeatureFlag("default-model", "persisted-model");
+
+    process.env.VELLUM_FLAG_DEFAULT_MODEL = "env-model";
+    resetEnvOverridesCache();
+
+    expect(getFeatureFlagValue("default-model")).toBe("env-model");
   });
 });

--- a/gateway/src/__tests__/feature-flags-route.test.ts
+++ b/gateway/src/__tests__/feature-flags-route.test.ts
@@ -80,6 +80,8 @@ afterEach(() => {
   resetFeatureFlagDefaultsCache();
   clearFeatureFlagStoreCache();
   clearRemoteFeatureFlagStoreCache();
+  resetEnvOverridesCache();
+  delete process.env.VELLUM_FLAG_A2A_CHANNEL;
 });
 
 const { createFeatureFlagsGetHandler, createFeatureFlagsPatchHandler } =
@@ -93,6 +95,8 @@ const { clearFeatureFlagStoreCache, readPersistedFeatureFlags } =
   await import("../feature-flag-store.js");
 const { clearRemoteFeatureFlagStoreCache, writeRemoteFeatureFlags } =
   await import("../feature-flag-remote-store.js");
+const { resetEnvOverridesCache } =
+  await import("../feature-flag-env-overrides.js");
 
 describe("GET /v1/feature-flags handler", () => {
   test("returns all declared assistant-scope flags with defaults when no persisted file exists", async () => {
@@ -509,6 +513,36 @@ describe("GET /v1/feature-flags handler", () => {
     );
     expect(modelFlag).toBeDefined();
     expect(modelFlag.enabled).toBe("gpt-4");
+  });
+
+  test("env override takes precedence over persisted and default values", async () => {
+    // Persisted value sets a2a-channel to false
+    writeFileSync(
+      featureFlagStorePath,
+      JSON.stringify({
+        version: 1,
+        values: { "a2a-channel": false },
+      }),
+    );
+    clearFeatureFlagStoreCache();
+
+    // Env override sets it to true
+    process.env.VELLUM_FLAG_A2A_CHANNEL = "true";
+    resetEnvOverridesCache();
+
+    const handler = createFeatureFlagsGetHandler();
+    const res = await handler(
+      new Request("http://gateway.test/v1/feature-flags"),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    const a2aFlag = body.flags.find(
+      (f: { key: string }) => f.key === "a2a-channel",
+    );
+    expect(a2aFlag).toBeDefined();
+    expect(a2aFlag.enabled).toBe(true);
   });
 
   test("returns flags when invoked via assistants path without trailing slash", async () => {

--- a/gateway/src/__tests__/ipc-feature-flag-routes.test.ts
+++ b/gateway/src/__tests__/ipc-feature-flag-routes.test.ts
@@ -76,6 +76,8 @@ afterEach(() => {
   resetFeatureFlagDefaultsCache();
   clearFeatureFlagStoreCache();
   clearRemoteFeatureFlagStoreCache();
+  resetEnvOverridesCache();
+  delete process.env.VELLUM_FLAG_A2A_CHANNEL;
 });
 
 const { resetFeatureFlagDefaultsCache, _setRegistryCandidateOverrides } =
@@ -83,6 +85,8 @@ const { resetFeatureFlagDefaultsCache, _setRegistryCandidateOverrides } =
 const { clearFeatureFlagStoreCache } = await import("../feature-flag-store.js");
 const { clearRemoteFeatureFlagStoreCache } =
   await import("../feature-flag-remote-store.js");
+const { resetEnvOverridesCache } =
+  await import("../feature-flag-env-overrides.js");
 const { GatewayIpcServer } = await import("../ipc/server.js");
 const { featureFlagRoutes } = await import("../ipc/feature-flag-handlers.js");
 
@@ -306,6 +310,22 @@ describe("IPC feature flag routes", () => {
 
     expect(res.error).toBeDefined();
     expect(res.error).toContain("Invalid params");
+  });
+
+  test("get_feature_flags includes env override values", async () => {
+    process.env.VELLUM_FLAG_A2A_CHANNEL = "true";
+    resetEnvOverridesCache();
+
+    if (existsSync(featureFlagStorePath)) rmSync(featureFlagStorePath);
+    clearFeatureFlagStoreCache();
+
+    await startServerAndConnect();
+    const res = await sendRequest(client, "get_feature_flags");
+
+    expect(res.error).toBeUndefined();
+    const flags = res.result as Record<string, boolean | string>;
+    // a2a-channel defaults to false, but env override sets it to true
+    expect(flags["a2a-channel"]).toBe(true);
   });
 
   test("unknown method returns error", async () => {

--- a/gateway/src/feature-flag-resolver.ts
+++ b/gateway/src/feature-flag-resolver.ts
@@ -1,11 +1,12 @@
 import { loadFeatureFlagDefaults } from "./feature-flag-defaults.js";
+import { readEnvFeatureFlagOverrides } from "./feature-flag-env-overrides.js";
 import { readRemoteFeatureFlags } from "./feature-flag-remote-store.js";
 import { readPersistedFeatureFlags } from "./feature-flag-store.js";
 
 /**
  * Resolve the raw value for a feature flag.
  *
- * Priority: persisted (user-toggled) > remote (platform-pushed) > registry default.
+ * Priority: env override > persisted (user-toggled) > remote (platform-pushed) > registry default.
  * Undeclared keys return `false` (fail closed), even if stale local/remote
  * state contains a value for them.
  */
@@ -13,6 +14,9 @@ export function getFeatureFlagValue(key: string): boolean | string {
   const defaults = loadFeatureFlagDefaults();
   const defaultDef = defaults[key];
   if (defaultDef === undefined) return false;
+
+  const envOverrides = readEnvFeatureFlagOverrides();
+  if (key in envOverrides) return envOverrides[key];
 
   const persisted = readPersistedFeatureFlags();
   const persistedValue = persisted[key];

--- a/gateway/src/http/routes/feature-flags.ts
+++ b/gateway/src/http/routes/feature-flags.ts
@@ -2,6 +2,7 @@ import {
   loadFeatureFlagDefaults,
   isFlagDeclared,
 } from "../../feature-flag-defaults.js";
+import { readEnvFeatureFlagOverrides } from "../../feature-flag-env-overrides.js";
 import { readRemoteFeatureFlags } from "../../feature-flag-remote-store.js";
 import {
   readPersistedFeatureFlags,
@@ -30,20 +31,23 @@ export function createFeatureFlagsGetHandler() {
       const defaults = loadFeatureFlagDefaults();
       const persisted = readPersistedFeatureFlags();
       const remote = readRemoteFeatureFlags();
+      const envOverrides = readEnvFeatureFlagOverrides();
 
       const entries: FeatureFlagEntry[] = [];
       for (const [key, def] of Object.entries(defaults)) {
         const persistedValue = persisted[key];
         const remoteValue = remote[key];
+        const base =
+          persistedValue !== undefined
+            ? persistedValue
+            : remoteValue !== undefined
+              ? remoteValue
+              : def.defaultEnabled;
+        const envValue = envOverrides[key];
         entries.push({
           key,
           label: def.label,
-          enabled:
-            persistedValue !== undefined
-              ? persistedValue
-              : remoteValue !== undefined
-                ? remoteValue
-                : def.defaultEnabled,
+          enabled: envValue !== undefined ? envValue : base,
           defaultEnabled: def.defaultEnabled,
           description: def.description,
         });

--- a/gateway/src/ipc/feature-flag-handlers.ts
+++ b/gateway/src/ipc/feature-flag-handlers.ts
@@ -9,6 +9,7 @@
 import { z } from "zod";
 
 import { loadFeatureFlagDefaults } from "../feature-flag-defaults.js";
+import { readEnvFeatureFlagOverrides } from "../feature-flag-env-overrides.js";
 import { readRemoteFeatureFlags } from "../feature-flag-remote-store.js";
 import { readPersistedFeatureFlags } from "../feature-flag-store.js";
 import type { IpcRoute } from "./server.js";
@@ -37,6 +38,12 @@ export function getMergedFeatureFlags(): Record<string, boolean | string> {
           ? remoteValue
           : def.defaultEnabled;
   }
+
+  const envOverrides = readEnvFeatureFlagOverrides();
+  for (const [key, value] of Object.entries(envOverrides)) {
+    if (key in result) result[key] = value;
+  }
+
   return result;
 }
 


### PR DESCRIPTION
## Summary
- Wire readEnvFeatureFlagOverrides() into getFeatureFlagValue() as highest priority source
- Wire env overrides into getMergedFeatureFlags() IPC handler
- Wire env overrides into HTTP GET /v1/feature-flags route
- Add tests for all three integration points

Part of plan: ff-env-var-overrides.md (PR 2 of 8)