### PR TITLE
feat(web): apply env flag overrides in client and assistant stores

### DIFF
--- a/apps/web/src/stores/assistant-feature-flag-store.ts
+++ b/apps/web/src/stores/assistant-feature-flag-store.ts
@@ -5,6 +5,7 @@ import { client } from "@/generated/api/client.gen";
 import {
   ASSISTANT_FLAG_DEFAULTS,
   ASSISTANT_STRING_FLAG_DEFAULTS,
+  getEnvFlagOverridesForScope,
   storeKeyToFlagKey,
 } from "@/lib/feature-flags/feature-flag-catalog";
 
@@ -73,6 +74,8 @@ function resetAllConfirmed() {
   resetConfirmedStringFlags();
 }
 
+const envOverrides = getEnvFlagOverridesForScope("assistant");
+
 function latestConfirmedValue(key: string): boolean {
   return confirmedAssistantFlagValues[key] ?? ASSISTANT_FLAG_DEFAULTS[key] ?? false;
 }
@@ -95,16 +98,18 @@ const useAssistantFeatureFlagStoreBase = create<AssistantFeatureFlagStore>()(
 
     return ({
       ...ASSISTANT_FLAG_DEFAULTS,
+      ...envOverrides.bool,
       hasHydrated: false,
-      stringFlags: { ...ASSISTANT_STRING_FLAG_DEFAULTS },
+      stringFlags: { ...ASSISTANT_STRING_FLAG_DEFAULTS, ...envOverrides.str },
 
       setFlags: (flags: Record<string, boolean>) =>
         set((prev) => {
           resetConfirmedFlags(flags);
-          const changed = Object.keys(flags).some(
-            (k) => flags[k] !== prev[k],
+          const merged = { ...flags, ...envOverrides.bool };
+          const changed = Object.keys(merged).some(
+            (k) => merged[k] !== prev[k],
           );
-          return changed ? flags : prev;
+          return changed ? merged : prev;
         }),
 
       setFlag: (key: string, value: boolean, assistantId: string | null) => {
@@ -157,18 +162,19 @@ const useAssistantFeatureFlagStoreBase = create<AssistantFeatureFlagStore>()(
 
       resetForAssistantSwitch: () => {
         resetAllConfirmed();
-        set({ ...ASSISTANT_FLAG_DEFAULTS, hasHydrated: false });
-        setStr({ stringFlags: { ...ASSISTANT_STRING_FLAG_DEFAULTS } });
+        set({ ...ASSISTANT_FLAG_DEFAULTS, ...envOverrides.bool, hasHydrated: false });
+        setStr({ stringFlags: { ...ASSISTANT_STRING_FLAG_DEFAULTS, ...envOverrides.str } });
       },
 
       setStringFlags: (flags: Record<string, string>) =>
         setStr((prev) => {
           resetConfirmedStringFlags(flags);
+          const merged = { ...flags, ...envOverrides.str };
           const prevStr = prev.stringFlags;
-          const changed = Object.keys(flags).some(
-            (k) => flags[k] !== prevStr[k],
+          const changed = Object.keys(merged).some(
+            (k) => merged[k] !== prevStr[k],
           );
-          return changed ? { stringFlags: flags } : prev;
+          return changed ? { stringFlags: merged } : prev;
         }),
 
       setStringFlag: (key: string, value: string, assistantId: string | null) => {

--- a/apps/web/src/stores/client-feature-flag-store.ts
+++ b/apps/web/src/stores/client-feature-flag-store.ts
@@ -4,6 +4,7 @@ import { createSelectors } from "@/utils/create-selectors";
 import {
   CLIENT_FLAG_DEFAULTS,
   CLIENT_STRING_FLAG_DEFAULTS,
+  getEnvFlagOverridesForScope,
 } from "@/lib/feature-flags/feature-flag-catalog";
 
 const LS_PREFIX = "vellum:ff:";
@@ -43,6 +44,7 @@ function readStringOverrides(): Record<string, string> {
 
 const localOverrides = readOverrides();
 const localStringOverrides = readStringOverrides();
+const envOverrides = getEnvFlagOverridesForScope("client");
 
 interface ClientFeatureFlagMeta {
   stringFlags: Record<string, string>;
@@ -73,12 +75,13 @@ const useClientFeatureFlagStoreBase = create<ClientFeatureFlagStore>()(
     return ({
       ...CLIENT_FLAG_DEFAULTS,
       ...localOverrides,
-      stringFlags: { ...CLIENT_STRING_FLAG_DEFAULTS, ...localStringOverrides },
+      ...envOverrides.bool,
+      stringFlags: { ...CLIENT_STRING_FLAG_DEFAULTS, ...localStringOverrides, ...envOverrides.str },
 
       setFlags: (flags: Record<string, boolean>) =>
         set((prev) => {
           const overrides = readOverrides();
-          const merged = { ...flags, ...overrides };
+          const merged = { ...flags, ...overrides, ...envOverrides.bool };
           const changed = Object.keys(merged).some(
             (k) => merged[k] !== prev[k],
           );
@@ -109,7 +112,7 @@ const useClientFeatureFlagStoreBase = create<ClientFeatureFlagStore>()(
       setStringFlags: (flags: Record<string, string>) =>
         setStr((prev) => {
           const overrides = readStringOverrides();
-          const merged = { ...flags, ...overrides };
+          const merged = { ...flags, ...overrides, ...envOverrides.str };
           const prevStr = prev.stringFlags;
           const changed = Object.keys(merged).some(
             (k) => merged[k] !== prevStr[k],


### PR DESCRIPTION
## Summary
- Wire getEnvFlagOverridesForScope into client-feature-flag-store (init, setFlags, setStringFlags)
- Wire getEnvFlagOverridesForScope into assistant-feature-flag-store (init, setFlags, resetForAssistantSwitch, setStringFlags)
- Env overrides always win over server sync and localStorage

Part of plan: ff-env-var-overrides.md (PR 8 of 8)