### PR TITLE
fix(macos): deny permissions on per-bundle Electron sessions

### DIFF
--- a/apps/macos/src/main/bundle-window.test.ts
+++ b/apps/macos/src/main/bundle-window.test.ts
@@ -77,9 +77,17 @@ const makeWindow = (options: Record<string, unknown>): StubWindow => {
 const sessionProtocolHandleMock = mock(
   (_scheme: string, _handler: unknown) => undefined,
 );
+const setPermissionRequestHandlerMock = mock(
+  (_handler: unknown) => undefined,
+);
+const setPermissionCheckHandlerMock = mock(
+  (_handler: unknown) => undefined,
+);
 const fromPartitionMock = mock(
   (_partition: string, _opts?: { cache: boolean }) => ({
     protocol: { handle: sessionProtocolHandleMock },
+    setPermissionRequestHandler: setPermissionRequestHandlerMock,
+    setPermissionCheckHandler: setPermissionCheckHandlerMock,
   }),
 );
 
@@ -120,6 +128,8 @@ beforeEach(() => {
   loadURLMock.mockClear();
   fromPartitionMock.mockClear();
   sessionProtocolHandleMock.mockClear();
+  setPermissionRequestHandlerMock.mockClear();
+  setPermissionCheckHandlerMock.mockClear();
   createVellumAppHandlerMock.mockClear();
 });
 
@@ -156,6 +166,27 @@ describe("openBundleWindow", () => {
     expect(prefs.sandbox).toBe(true);
     expect(prefs.nodeIntegration).toBe(false);
     expect(prefs.preload).toBeUndefined();
+  });
+
+  test("denies all permission requests and checks on the bundle session", () => {
+    openBundleWindow(UUID, "index.html", "Test Bundle");
+
+    expect(setPermissionRequestHandlerMock).toHaveBeenCalledTimes(1);
+    expect(setPermissionCheckHandlerMock).toHaveBeenCalledTimes(1);
+
+    const requestHandler = setPermissionRequestHandlerMock.mock.calls[0]![0] as (
+      wc: unknown,
+      perm: string,
+      cb: (allowed: boolean) => void,
+    ) => void;
+    let granted = true;
+    requestHandler({}, "media", (allowed) => { granted = allowed; });
+    expect(granted).toBe(false);
+
+    const checkHandler = setPermissionCheckHandlerMock.mock.calls[0]![0] as (
+      ...args: unknown[]
+    ) => boolean;
+    expect(checkHandler({}, "clipboard-read", "vellumapp://example")).toBe(false);
   });
 
   test("registers the vellumapp:// handler on the bundle session", () => {

--- a/apps/macos/src/main/bundle-window.ts
+++ b/apps/macos/src/main/bundle-window.ts
@@ -16,6 +16,7 @@ import path from "node:path";
 
 import { BUNDLES_DIR_NAME, VELLUMAPP_PROTOCOL } from "./app-config";
 import { createVellumAppHandler } from "./vellumapp-protocol";
+import { denyAllPermissions } from "./permissions";
 import { hardenedWebPreferences } from "./windows";
 
 const openBundleWindows = new Map<string, BrowserWindow>();
@@ -34,6 +35,7 @@ export const openBundleWindow = (
   const bundleSession = session.fromPartition(`persist:bundle-${uuid}`, {
     cache: true,
   });
+  denyAllPermissions(bundleSession);
 
   const bundlesRoot = path.join(app.getPath("userData"), BUNDLES_DIR_NAME);
   bundleSession.protocol.handle(

--- a/apps/macos/src/main/permissions.test.ts
+++ b/apps/macos/src/main/permissions.test.ts
@@ -32,6 +32,7 @@ mock.module("electron", () => ({
 }));
 
 const {
+  denyAllPermissions,
   installPermissionHandler,
   shouldGrantPermissionCheck,
   shouldGrantPermissionRequest,
@@ -129,5 +130,32 @@ describe("permission policy", () => {
     );
 
     expect(granted).toBe(true);
+  });
+});
+
+describe("denyAllPermissions", () => {
+  test("installs blanket deny handlers on the target session", () => {
+    let requestHandler: ((...args: unknown[]) => void) | null = null;
+    let checkHandler: ((...args: unknown[]) => boolean) | null = null;
+
+    const targetSession = {
+      setPermissionRequestHandler: mock((h: typeof requestHandler) => {
+        requestHandler = h;
+      }),
+      setPermissionCheckHandler: mock((h: typeof checkHandler) => {
+        checkHandler = h;
+      }),
+    };
+
+    denyAllPermissions(targetSession as never);
+
+    expect(targetSession.setPermissionRequestHandler).toHaveBeenCalledTimes(1);
+    expect(targetSession.setPermissionCheckHandler).toHaveBeenCalledTimes(1);
+
+    let granted = true;
+    requestHandler!({}, "media", (allowed: boolean) => { granted = allowed; });
+    expect(granted).toBe(false);
+
+    expect(checkHandler!({}, "clipboard-read", "vellumapp://bundle")).toBe(false);
   });
 });

--- a/apps/macos/src/main/permissions.ts
+++ b/apps/macos/src/main/permissions.ts
@@ -2,6 +2,7 @@ import {
   session,
   type MediaAccessPermissionRequest,
   type PermissionCheckHandlerHandlerDetails,
+  type Session,
 } from "electron";
 
 import { isAllowedOrigin, resolveAllowedOrigin } from "./app-origin";
@@ -61,6 +62,15 @@ export const shouldGrantPermissionCheck = (
   (isTrustedRendererOrigin(details.securityOrigin) ||
     isTrustedRendererOrigin(requestingOrigin) ||
     isTrustedRendererOrigin(details.requestingUrl));
+
+export const denyAllPermissions = (targetSession: Session): void => {
+  targetSession.setPermissionRequestHandler(
+    (_webContents, _permission, callback) => {
+      callback(false);
+    },
+  );
+  targetSession.setPermissionCheckHandler(() => false);
+};
 
 export const installPermissionHandler = (): void => {
   session.defaultSession.setPermissionCheckHandler(


### PR DESCRIPTION
## Summary
- Add `denyAllPermissions()` to `permissions.ts` that installs blanket deny handlers (both `setPermissionRequestHandler` and `setPermissionCheckHandler`) on any Electron session
- Call `denyAllPermissions(bundleSession)` in `bundle-window.ts` immediately after creating the per-bundle session partition
- Add tests verifying permission denial on bundle sessions and for the new `denyAllPermissions` helper

## Original prompt
A Codex security finding identified that untrusted `.vellum` bundle windows were created with dedicated Electron sessions (`persist:bundle-{uuid}`) but without permission handlers. The app's deny-by-default permission policy only covered `session.defaultSession`, so bundle pages served over the secure `vellumapp://` scheme could access permission-gated web APIs like microphone, geolocation, and clipboard. The fix installs blanket deny handlers on every new bundle session.

Codex finding: https://chatgpt.com/codex/cloud/security/findings/c6c8cb4914908191af91d0c1a12a3b26

🤖 Generated with [Claude Code](https://claude.com/claude-code)