### PR TITLE
fix(macos): gate platform proxy CSRF injection on trusted renderer origin

### DIFF
--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -13,6 +13,7 @@ import {
 
 import { installAbout, openAboutWindow } from "./about";
 import { APP_HOST, APP_PROTOCOL, BUNDLES_DIR_NAME, VELLUMAPP_PROTOCOL } from "./app-config";
+import { resolveAllowedOrigin } from "./app-origin";
 import { installCsp } from "./csp";
 import { handleSync } from "./ipc";
 import { resolveAppProtocolPath } from "./app-protocol";
@@ -279,10 +280,19 @@ const forwardPlatformRequest = async (
   request: GlobalRequest,
   platformUrl: string,
 ): Promise<Response | null> => {
-  const plan = planPlatformForward(request, platformUrl);
+  const plan = planPlatformForward(request, platformUrl, {
+    allowedOrigin: resolveAllowedOrigin(),
+  });
   if (plan.kind === "pass") return null;
+  if (plan.kind === "reject") {
+    return new Response(plan.message, { status: plan.status });
+  }
 
-  if (cachedCsrfToken && !plan.headers.has("X-CSRFToken")) {
+  if (
+    plan.shouldInjectCsrfToken &&
+    cachedCsrfToken &&
+    !plan.headers.has("X-CSRFToken")
+  ) {
     plan.headers.set("X-CSRFToken", cachedCsrfToken);
   }
 

--- a/apps/macos/src/main/platform-forward.test.ts
+++ b/apps/macos/src/main/platform-forward.test.ts
@@ -93,6 +93,71 @@ describe("planPlatformForward", () => {
     expect(plan.headers.get("origin")).toBe("https://platform.vellum.ai");
   });
 
+  test("marks app-origin platform requests as eligible for CSRF injection", () => {
+    const plan = planPlatformForward(
+      request("/_allauth/browser/v1/auth/session", {
+        method: "POST",
+        origin: "app://vellum.ai",
+      }),
+      PLATFORM,
+      { allowedOrigin: { protocol: "app:", host: "vellum.ai" } },
+    );
+    if (plan.kind !== "forward") throw new Error("expected forward");
+    expect(plan.shouldInjectCsrfToken).toBe(true);
+    expect(plan.headers.get("origin")).toBe("https://platform.vellum.ai");
+  });
+
+  test("rejects platform requests with a foreign Origin before CSRF injection", () => {
+    const plan = planPlatformForward(
+      request("/_allauth/browser/v1/auth/session", {
+        method: "POST",
+        origin: "https://evil.example",
+      }),
+      PLATFORM,
+      { allowedOrigin: { protocol: "app:", host: "vellum.ai" } },
+    );
+
+    expect(plan).toEqual({
+      kind: "reject",
+      status: 403,
+      message: "Forbidden platform proxy request",
+    });
+  });
+
+  test("rejects platform requests with a foreign Referer when Origin is absent", () => {
+    const plan = planPlatformForward(
+      request("/_allauth/browser/v1/auth/session", {
+        method: "POST",
+        headers: { referer: "https://evil.example/form" },
+      }),
+      PLATFORM,
+      { allowedOrigin: { protocol: "app:", host: "vellum.ai" } },
+    );
+
+    expect(plan.kind).toBe("reject");
+  });
+
+  test("rejects source-less unsafe platform requests", () => {
+    const plan = planPlatformForward(
+      request("/v1/assistants", { method: "POST" }),
+      PLATFORM,
+      { allowedOrigin: { protocol: "app:", host: "vellum.ai" } },
+    );
+
+    expect(plan.kind).toBe("reject");
+  });
+
+  test("does not auto-inject CSRF for source-less safe platform requests", () => {
+    const plan = planPlatformForward(
+      request("/v1/assistants", { method: "GET" }),
+      PLATFORM,
+      { allowedOrigin: { protocol: "app:", host: "vellum.ai" } },
+    );
+
+    if (plan.kind !== "forward") throw new Error("expected forward");
+    expect(plan.shouldInjectCsrfToken).toBe(false);
+  });
+
   test("preserves non-Origin headers", () => {
     const plan = planPlatformForward(
       request("/_allauth/browser/v1/auth/session", {

--- a/apps/macos/src/main/platform-forward.ts
+++ b/apps/macos/src/main/platform-forward.ts
@@ -9,18 +9,29 @@
 
 export type PlatformForwardPlan =
   | { kind: "pass" }
+  | { kind: "reject"; status: number; message: string }
   | {
       kind: "forward";
       url: string;
       method: string;
       headers: Headers;
       hasBody: boolean;
+      shouldInjectCsrfToken: boolean;
     };
 
 export interface PlatformForwardRequest {
   url: string;
   method: string;
   headers: Headers;
+}
+
+export interface PlatformForwardAllowedOrigin {
+  protocol: string;
+  host: string;
+}
+
+export interface PlatformForwardOptions {
+  allowedOrigin?: PlatformForwardAllowedOrigin;
 }
 
 const PLATFORM_PREFIXES = ["/v1", "/_allauth", "/accounts"] as const;
@@ -31,21 +42,74 @@ function isPlatformPath(pathname: string): boolean {
   );
 }
 
+function isAllowedSource(
+  value: string | null,
+  allowed: PlatformForwardAllowedOrigin,
+): boolean {
+  if (!value) return false;
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === allowed.protocol && parsed.host === allowed.host;
+  } catch {
+    return false;
+  }
+}
+
+function isUnsafeMethod(method: string): boolean {
+  return !["GET", "HEAD", "OPTIONS"].includes(method.toUpperCase());
+}
+
+function getInitiatorTrust(
+  headers: Headers,
+  allowed?: PlatformForwardAllowedOrigin,
+): { trusted: boolean; rejected: boolean } {
+  if (!allowed) return { trusted: false, rejected: false };
+
+  const origin = headers.get("origin");
+  if (origin) {
+    const trusted = isAllowedSource(origin, allowed);
+    return { trusted, rejected: !trusted };
+  }
+
+  const referer = headers.get("referer");
+  if (!referer) return { trusted: false, rejected: false };
+
+  const trusted = isAllowedSource(referer, allowed);
+  return { trusted, rejected: !trusted };
+}
+
 /**
  * Resolve a renderer request to a platform-proxy plan.
  *
  * On `forward`, the request's `Origin` is rewritten to the platform's own
  * origin. The renderer issues this request from `app://vellum.ai` but the
- * platform expects its own origin for CORS/CSRF purposes. All other headers
- * (Authorization, X-CSRFToken, Content-Type, etc.) pass through unchanged.
+ * platform expects its own origin for CORS/CSRF purposes. Unsafe requests are
+ * only forwarded when their browser-controlled `Origin` or `Referer` matches
+ * the trusted renderer origin, and only those trusted requests are eligible for
+ * main-process CSRF token injection. All other headers (Authorization,
+ * X-CSRFToken, Content-Type, etc.) pass through unchanged.
  */
 export function planPlatformForward(
   request: PlatformForwardRequest,
   platformUrl: string,
+  options: PlatformForwardOptions = {},
 ): PlatformForwardPlan {
   const url = new URL(request.url);
   if (!isPlatformPath(url.pathname)) {
     return { kind: "pass" };
+  }
+
+  const initiator = getInitiatorTrust(request.headers, options.allowedOrigin);
+  const unsafeUntrustedRequest =
+    options.allowedOrigin &&
+    isUnsafeMethod(request.method) &&
+    !initiator.trusted;
+  if (initiator.rejected || unsafeUntrustedRequest) {
+    return {
+      kind: "reject",
+      status: 403,
+      message: "Forbidden platform proxy request",
+    };
   }
 
   const target = new URL(platformUrl);
@@ -58,5 +122,6 @@ export function planPlatformForward(
     method: request.method,
     headers,
     hasBody: request.method !== "GET" && request.method !== "HEAD",
+    shouldInjectCsrfToken: initiator.trusted,
   };
 }


### PR DESCRIPTION
## Summary

- Add initiator origin verification to the platform API proxy (`planPlatformForward`) — requests with a foreign `Origin`/`Referer` or source-less unsafe methods are now rejected with 403 instead of being forwarded with the victim's CSRF token and session cookies
- Gate main-process CSRF token injection (`X-CSRFToken`) behind a `shouldInjectCsrfToken` flag that is only set when the request's initiator matches the trusted renderer origin (`app://vellum.ai` in prod, the Vite dev URL in dev)
- Add 5 new test cases covering the trust matrix: trusted origin, foreign origin, foreign referer, source-less unsafe, and source-less safe requests

Codex finding: https://chatgpt.com/codex/cloud/security/findings/fb7e8ab2bf0c8191b571be950c43046f?q=API+keys+can+trigger+paid+Pro+tier+changes&sev=

## Original prompt

A Codex security scan identified a high-severity CSRF injection vulnerability in the Electron macOS app's platform proxy. The `app://` protocol handler forwards `/v1/*`, `/_allauth/*`, and `/accounts/*` requests to the cloud platform without checking which webContents initiated the request, and unconditionally injects a cached CSRF token. This allows untrusted external pages opened in Electron (via allowed popups or auth-flow navigation) to trigger authenticated platform mutations as the victim. The fix adds origin verification to the proxy planning layer, consistent with the existing IPC sender-origin checks elsewhere in the app.

## Test plan

- [x] All 19 platform-forward tests pass (including 5 new origin trust tests)
- [ ] Verify the packaged Electron app still authenticates and makes platform API calls normally
- [ ] Verify that in-app popups (e.g. OAuth flows) work correctly with the new origin check


🤖 Generated with [Claude Code](https://claude.com/claude-code)