### PR TITLE
fix: update teleport.ts hatchLocal() call for new flagEnvVars parameter

### DIFF
--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -891,6 +891,7 @@ export async function resolveOrHatchTarget(
       false,
       false,
       {},
+      {},
       {
         setupProviderCredentials: false,
       },


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for ff-env-var-overrides.md.

**Gap:** teleport.ts broken by hatchLocal() signature change
**What was expected:** All call sites updated when signature changes
**What was found:** teleport.ts passes options object where flagEnvVars param now is

## Changes
- Added empty `{}` for `flagEnvVars` parameter in teleport.ts `hatchLocal()` call, pushing the options object `{ setupProviderCredentials: false }` to the correct 7th position