### PR TITLE
fix: align web parseEnvValue with full truthy/falsy convention

### DIFF
--- a/apps/web/src/lib/feature-flags/feature-flag-catalog.ts
+++ b/apps/web/src/lib/feature-flags/feature-flag-catalog.ts
@@ -101,10 +101,13 @@ function upperSnakeToKebab(upper: string): string {
   return upper.toLowerCase().replace(/_/g, "-");
 }
 
+const TRUTHY = new Set(["true", "1", "yes", "on"]);
+const FALSY = new Set(["false", "0", "no", "off"]);
+
 function parseEnvValue(raw: string): boolean | string {
   const lower = raw.toLowerCase();
-  if (lower === "true") return true;
-  if (lower === "false") return false;
+  if (TRUTHY.has(lower)) return true;
+  if (FALSY.has(lower)) return false;
   return raw;
 }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for ff-env-var-overrides.md.

**Gap:** Web parseEnvValue only handles true/false
**What was expected:** Same convention as gateway (true/1/yes/on, false/0/no/off)
**What was found:** Only literal true/false recognized