### PR TITLE
fix(web): gate platform API calls on organization ID readiness

### DIFF
--- a/apps/web/src/assistant/lifecycle-service.ts
+++ b/apps/web/src/assistant/lifecycle-service.ts
@@ -83,6 +83,12 @@ export interface LifecycleServiceInputs {
    * behavior. Optional so existing `setInputs` callers/tests need no change.
    */
   selectedPlatformAssistantId?: string | null;
+  /**
+   * Whether the organization store has resolved an active org ID.
+   * Platform API calls require the Vellum-Organization-Id header;
+   * `respondToInputs` defers `checkAssistant` until this is true.
+   */
+  hasOrganization?: boolean;
 }
 
 const NOOP_REDIRECT = (_: string) => {};
@@ -194,6 +200,7 @@ class AssistantLifecycleService {
     if (this.inputs.hasPlatformSession) {
       setSelfHostedConnection(null);
     }
+    if (!this.inputs.hasOrganization) return;
     await this.checkAssistant();
   }
 

--- a/apps/web/src/assistant/lifecycle-service.ts
+++ b/apps/web/src/assistant/lifecycle-service.ts
@@ -84,11 +84,12 @@ export interface LifecycleServiceInputs {
    */
   selectedPlatformAssistantId?: string | null;
   /**
-   * Whether the organization store has resolved an active org ID.
+   * Whether the org store has hydrated (or no platform session exists).
    * Platform API calls require the Vellum-Organization-Id header;
    * `respondToInputs` defers `checkAssistant` until this is true.
+   * Mirrors `useIsOrgReady()` from the React layer.
    */
-  hasOrganization?: boolean;
+  isOrgReady?: boolean;
 }
 
 const NOOP_REDIRECT = (_: string) => {};
@@ -200,7 +201,7 @@ class AssistantLifecycleService {
     if (this.inputs.hasPlatformSession) {
       setSelfHostedConnection(null);
     }
-    if (!this.inputs.hasOrganization) return;
+    if (!this.inputs.isOrgReady) return;
     await this.checkAssistant();
   }
 

--- a/apps/web/src/assistant/use-lifecycle.ts
+++ b/apps/web/src/assistant/use-lifecycle.ts
@@ -52,13 +52,19 @@ export function useAssistantLifecycle({
 }: UseAssistantLifecycleOptions): void {
   const queryClient = useQueryClient();
 
+  const currentOrganizationId =
+    useOrganizationStore.use.currentOrganizationId();
+
   // Whether to query the server-side status at all. Gateway-auth
   // mode and "local mode without platform session" short-circuit
   // to local states without ever calling /assistant/.
+  // Platform API calls require the Vellum-Organization-Id header;
+  // wait for the org store to resolve before firing them.
   const shouldQueryServer =
     isAuthenticated(sessionStatus) &&
     !isGatewayAuthMode() &&
-    (hasPlatformSession || !isLocalMode());
+    (hasPlatformSession || !isLocalMode()) &&
+    !!currentOrganizationId;
 
   // Which platform assistant the user has selected, gated by the
   // multi-platform-assistant flag. When the flag is off (or no
@@ -67,8 +73,6 @@ export function useAssistantLifecycle({
   // pre-multi-assistant behavior.
   const multiAssistantEnabled =
     useClientFeatureFlagStore.use.multiPlatformAssistant();
-  const currentOrganizationId =
-    useOrganizationStore.use.currentOrganizationId();
   const byOrg =
     useResolvedAssistantsStore.use.selectedPlatformAssistantByOrg();
   const selectedPlatformAssistantId =

--- a/apps/web/src/assistant/use-lifecycle.ts
+++ b/apps/web/src/assistant/use-lifecycle.ts
@@ -19,6 +19,7 @@ import { lifecycleService } from "@/assistant/lifecycle-service";
 import { useAssistantQuery } from "@/assistant/queries";
 import { isGatewayAuthMode } from "@/lib/auth/gateway-session";
 import { isLocalMode } from "@/lib/local-mode";
+import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import { isAuthenticated, type SessionStatus } from "@/stores/session-status";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
@@ -52,6 +53,7 @@ export function useAssistantLifecycle({
 }: UseAssistantLifecycleOptions): void {
   const queryClient = useQueryClient();
 
+  const isOrgReady = useIsOrgReady();
   const currentOrganizationId =
     useOrganizationStore.use.currentOrganizationId();
 
@@ -64,7 +66,7 @@ export function useAssistantLifecycle({
     isAuthenticated(sessionStatus) &&
     !isGatewayAuthMode() &&
     (hasPlatformSession || !isLocalMode()) &&
-    !!currentOrganizationId;
+    isOrgReady;
 
   // Which platform assistant the user has selected, gated by the
   // multi-platform-assistant flag. When the flag is off (or no
@@ -101,7 +103,7 @@ export function useAssistantLifecycle({
       resolveOnboardingRedirect,
       queryClient,
       selectedPlatformAssistantId,
-      hasOrganization: !!currentOrganizationId,
+      isOrgReady,
     });
     void lifecycleService.respondToInputs();
   }, [
@@ -113,7 +115,7 @@ export function useAssistantLifecycle({
     resolveOnboardingRedirect,
     queryClient,
     selectedPlatformAssistantId,
-    currentOrganizationId,
+    isOrgReady,
   ]);
 
   // Hand poll results to the service — it decides whether to

--- a/apps/web/src/assistant/use-lifecycle.ts
+++ b/apps/web/src/assistant/use-lifecycle.ts
@@ -101,6 +101,7 @@ export function useAssistantLifecycle({
       resolveOnboardingRedirect,
       queryClient,
       selectedPlatformAssistantId,
+      hasOrganization: !!currentOrganizationId,
     });
     void lifecycleService.respondToInputs();
   }, [
@@ -112,6 +113,7 @@ export function useAssistantLifecycle({
     resolveOnboardingRedirect,
     queryClient,
     selectedPlatformAssistantId,
+    currentOrganizationId,
   ]);
 
   // Hand poll results to the service — it decides whether to

--- a/apps/web/src/root-layout.tsx
+++ b/apps/web/src/root-layout.tsx
@@ -41,7 +41,7 @@ import { useElectronFeatureFlagBridge } from "@/runtime/electron-feature-flags";
 import { TimezoneSync } from "@/components/timezone-sync";
 import { retireAssistant } from "@/assistant/retire-service";
 import { selectPlatformAssistant } from "@/assistant/select-platform-assistant";
-import { useOrganizationStore } from "@/stores/organization-store";
+import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import { CreateAssistantDialog } from "@/components/create-assistant-dialog";
 import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
 import { toast } from "@vellumai/design-library/components/toast";
@@ -91,8 +91,8 @@ export function RootLayout() {
   const isSessionInitializing = useIsSessionInitializing();
   const hasPlatformSession = useHasPlatformSession();
   const isNonProduction = useEnvironmentStore.use.isNonProduction();
-  const hasOrganization = !!useOrganizationStore.use.currentOrganizationId();
-  useClientFeatureFlagSync(hasPlatformSession && !isSessionInitializing && hasOrganization);
+  const isOrgReady = useIsOrgReady();
+  useClientFeatureFlagSync(hasPlatformSession && !isSessionInitializing && isOrgReady);
   useAssistantLifecycle({
     sessionStatus,
     isRetired: false,

--- a/apps/web/src/root-layout.tsx
+++ b/apps/web/src/root-layout.tsx
@@ -41,6 +41,7 @@ import { useElectronFeatureFlagBridge } from "@/runtime/electron-feature-flags";
 import { TimezoneSync } from "@/components/timezone-sync";
 import { retireAssistant } from "@/assistant/retire-service";
 import { selectPlatformAssistant } from "@/assistant/select-platform-assistant";
+import { useOrganizationStore } from "@/stores/organization-store";
 import { CreateAssistantDialog } from "@/components/create-assistant-dialog";
 import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
 import { toast } from "@vellumai/design-library/components/toast";
@@ -90,7 +91,8 @@ export function RootLayout() {
   const isSessionInitializing = useIsSessionInitializing();
   const hasPlatformSession = useHasPlatformSession();
   const isNonProduction = useEnvironmentStore.use.isNonProduction();
-  useClientFeatureFlagSync(hasPlatformSession && !isSessionInitializing);
+  const hasOrganization = !!useOrganizationStore.use.currentOrganizationId();
+  useClientFeatureFlagSync(hasPlatformSession && !isSessionInitializing && hasOrganization);
   useAssistantLifecycle({
     sessionStatus,
     isRetired: false,


### PR DESCRIPTION
## Summary
- Platform API calls (`assistantsList`, `featureFlagsClientFlagValuesRetrieve`) require the `Vellum-Organization-Id` header, but could fire before the organization store finished loading — causing 400 errors and leaving the hatching screen stuck on "Setting up your assistant…" indefinitely.
- Gates the assistant lifecycle query (`shouldQueryServer`) and the client feature flag sync on `currentOrganizationId` being non-null before firing.

## Test plan
- [ ] Load the app on production/dev with a platform session — verify no 400 errors on `/v1/assistants` or `/v1/feature-flags/client-flag-values/` during startup
- [ ] Verify the hatching screen progresses past "Setting up your assistant…" without hanging
- [ ] Verify local mode (no platform session) still works — the org gate should be irrelevant since `shouldQueryServer` is already false

🤖 Generated with [Claude Code](https://claude.com/claude-code)