### PR TITLE
fix: enforce env overrides in individual flag toggle and clear methods

### DIFF
--- a/apps/web/src/stores/assistant-feature-flag-store.ts
+++ b/apps/web/src/stores/assistant-feature-flag-store.ts
@@ -155,7 +155,7 @@ const useAssistantFeatureFlagStoreBase = create<AssistantFeatureFlagStore>()(
           confirmedAssistantFlagValues[key] = value;
         }
 
-        set({ [key]: value });
+        set({ [key]: envOverrides.bool[key] ?? value });
       },
 
       markHydrated: () => set({ hasHydrated: true }),
@@ -218,7 +218,7 @@ const useAssistantFeatureFlagStoreBase = create<AssistantFeatureFlagStore>()(
         }
 
         setStr((prev) => ({
-          stringFlags: { ...prev.stringFlags, [key]: value },
+          stringFlags: { ...prev.stringFlags, [key]: envOverrides.str[key] ?? value },
         }));
       },
     }) as AssistantFeatureFlagStore;

--- a/apps/web/src/stores/client-feature-flag-store.ts
+++ b/apps/web/src/stores/client-feature-flag-store.ts
@@ -94,7 +94,7 @@ const useClientFeatureFlagStoreBase = create<ClientFeatureFlagStore>()(
         } catch {
           // localStorage unavailable
         }
-        set({ [key]: value });
+        set({ [key]: envOverrides.bool[key] ?? value });
       },
 
       clearOverride: (key: string) => {
@@ -103,7 +103,7 @@ const useClientFeatureFlagStoreBase = create<ClientFeatureFlagStore>()(
         } catch {
           // localStorage unavailable
         }
-        const defaultValue = CLIENT_FLAG_DEFAULTS[key];
+        const defaultValue = envOverrides.bool[key] ?? CLIENT_FLAG_DEFAULTS[key];
         if (defaultValue !== undefined) {
           set({ [key]: defaultValue });
         }
@@ -127,7 +127,7 @@ const useClientFeatureFlagStoreBase = create<ClientFeatureFlagStore>()(
           // localStorage unavailable
         }
         setStr((prev) => ({
-          stringFlags: { ...prev.stringFlags, [key]: value },
+          stringFlags: { ...prev.stringFlags, [key]: envOverrides.str[key] ?? value },
         }));
       },
 
@@ -137,7 +137,7 @@ const useClientFeatureFlagStoreBase = create<ClientFeatureFlagStore>()(
         } catch {
           // localStorage unavailable
         }
-        const defaultValue = CLIENT_STRING_FLAG_DEFAULTS[key];
+        const defaultValue = envOverrides.str[key] ?? CLIENT_STRING_FLAG_DEFAULTS[key];
         setStr((prev) => ({
           stringFlags: {
             ...prev.stringFlags,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for ff-env-var-overrides.md.

**Gap:** Individual toggle methods bypass env override enforcement
**What was expected:** Toggling in UI has no effect while env var is set
**What was found:** setFlag/clearOverride write directly without checking env overrides