### PR TITLE
Feature Flag Env Var Overrides

### DIFF
--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -799,8 +799,26 @@ if (vellumConfig) {
   contextBridge.exposeInMainWorld("__VELLUM_CONFIG__", vellumConfig);
 }
 
+const flagOverrides: Record<string, boolean | string> = {};
+for (const [key, value] of Object.entries(process.env)) {
+  if (!key.startsWith("VELLUM_FLAG_") || value === undefined) continue;
+  const flagKey = key
+    .slice("VELLUM_FLAG_".length)
+    .toLowerCase()
+    .replace(/_/g, "-");
+  const lower = value.trim().toLowerCase();
+  if (["true", "1", "yes", "on"].includes(lower)) flagOverrides[flagKey] = true;
+  else if (["false", "0", "no", "off"].includes(lower))
+    flagOverrides[flagKey] = false;
+  else flagOverrides[flagKey] = value.trim();
+}
+if (Object.keys(flagOverrides).length > 0) {
+  contextBridge.exposeInMainWorld("__VELLUM_FLAG_OVERRIDES__", flagOverrides);
+}
+
 declare global {
   interface Window {
     vellum: VellumBridge;
+    __VELLUM_FLAG_OVERRIDES__?: Record<string, boolean | string>;
   }
 }

--- a/apps/web/src/env.d.ts
+++ b/apps/web/src/env.d.ts
@@ -25,8 +25,16 @@ interface ImportMetaEnv {
    * Defaults to `velay.vellum.ai` when unset. See `domains/chat/voice/live-voice/connection.ts`.
    */
   readonly VITE_VELAY_HOST?: string;
+
+  /** Feature flag overrides via env vars: `VITE_VELLUM_FLAG_<UPPER_SNAKE_KEY>=true|false|string`. */
+  readonly [key: `VITE_VELLUM_FLAG_${string}`]: string | undefined;
 }
 
 interface ImportMeta {
   readonly env: ImportMetaEnv;
+}
+
+interface Window {
+  /** Feature flag overrides injected by Electron preload or CLI script. */
+  __VELLUM_FLAG_OVERRIDES__?: Record<string, boolean | string>;
 }

--- a/apps/web/src/lib/feature-flags/feature-flag-catalog.test.ts
+++ b/apps/web/src/lib/feature-flags/feature-flag-catalog.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 
 import {
   ASSISTANT_FLAG_DEFAULTS,
@@ -6,8 +6,14 @@ import {
   CLIENT_STRING_FLAG_DEFAULTS,
   getEnvFlagOverridesForScope,
   readEnvFlagOverrides,
+  resetEnvOverridesCache,
   scopeIncludes,
 } from "@/lib/feature-flags/feature-flag-catalog";
+
+afterEach(() => {
+  resetEnvOverridesCache();
+  delete (globalThis as Record<string, unknown>).window;
+});
 
 describe("feature flag catalog", () => {
   test("exposes self-intro greeting to client and assistant flag stores", () => {
@@ -39,28 +45,20 @@ describe("readEnvFlagOverrides", () => {
     expect(overrides).toEqual({});
   });
 
-  test("reads from window.__VELLUM_FLAG_OVERRIDES__ when set before module load", async () => {
-    // Set up the global before importing a fresh module instance
+  test("reads from window.__VELLUM_FLAG_OVERRIDES__ when set", () => {
     (globalThis as Record<string, unknown>).window = {
       __VELLUM_FLAG_OVERRIDES__: {
         "self-intro-greeting": true,
         "home-tab": "variant-a",
       },
     };
+    resetEnvOverridesCache();
 
-    try {
-      // Bust the module cache by appending a query parameter
-      const mod = await import(
-        "@/lib/feature-flags/feature-flag-catalog?t=window-test"
-      );
-      const overrides = mod.readEnvFlagOverrides();
-      expect(overrides).toEqual({
-        "self-intro-greeting": true,
-        "home-tab": "variant-a",
-      });
-    } finally {
-      delete (globalThis as Record<string, unknown>).window;
-    }
+    const overrides = readEnvFlagOverrides();
+    expect(overrides).toEqual({
+      "self-intro-greeting": true,
+      "home-tab": "variant-a",
+    });
   });
 });
 
@@ -70,7 +68,7 @@ describe("getEnvFlagOverridesForScope", () => {
     expect(result).toEqual({ bool: {}, str: {} });
   });
 
-  test("filters client-scoped flags and separates bool/str", async () => {
+  test("filters client-scoped flags and separates bool/str", () => {
     (globalThis as Record<string, unknown>).window = {
       __VELLUM_FLAG_OVERRIDES__: {
         // client-only flag (boolean)
@@ -81,42 +79,29 @@ describe("getEnvFlagOverridesForScope", () => {
         "pre-chat-onboarding-experiment-2026-06-06": "variant-a",
       },
     };
+    resetEnvOverridesCache();
 
-    try {
-      const mod = await import(
-        "@/lib/feature-flags/feature-flag-catalog?t=scope-client"
-      );
-      const result = mod.getEnvFlagOverridesForScope("client");
-      expect(result.bool).toEqual({ homeTab: true });
-      expect(result.str).toEqual({
-        preChatOnboardingExperiment20260606: "variant-a",
-      });
-      // assistant-only flag should not appear
-      expect(result.bool).not.toHaveProperty("autoAnalyze");
-    } finally {
-      delete (globalThis as Record<string, unknown>).window;
-    }
+    const result = getEnvFlagOverridesForScope("client");
+    expect(result.bool).toEqual({ homeTab: true });
+    expect(result.str).toEqual({
+      preChatOnboardingExperiment20260606: "variant-a",
+    });
+    expect(result.bool).not.toHaveProperty("autoAnalyze");
   });
 
-  test("flags with scope 'both' appear for both client and assistant scopes", async () => {
+  test("flags with scope 'both' appear for both client and assistant scopes", () => {
     (globalThis as Record<string, unknown>).window = {
       __VELLUM_FLAG_OVERRIDES__: {
         "self-intro-greeting": true,
       },
     };
+    resetEnvOverridesCache();
 
-    try {
-      const mod = await import(
-        "@/lib/feature-flags/feature-flag-catalog?t=scope-both"
-      );
-      const clientResult = mod.getEnvFlagOverridesForScope("client");
-      const assistantResult = mod.getEnvFlagOverridesForScope("assistant");
+    const clientResult = getEnvFlagOverridesForScope("client");
+    const assistantResult = getEnvFlagOverridesForScope("assistant");
 
-      expect(clientResult.bool).toEqual({ selfIntroGreeting: true });
-      expect(assistantResult.bool).toEqual({ selfIntroGreeting: true });
-    } finally {
-      delete (globalThis as Record<string, unknown>).window;
-    }
+    expect(clientResult.bool).toEqual({ selfIntroGreeting: true });
+    expect(assistantResult.bool).toEqual({ selfIntroGreeting: true });
   });
 });
 

--- a/apps/web/src/lib/feature-flags/feature-flag-catalog.test.ts
+++ b/apps/web/src/lib/feature-flags/feature-flag-catalog.test.ts
@@ -4,6 +4,9 @@ import {
   ASSISTANT_FLAG_DEFAULTS,
   CLIENT_FLAG_DEFAULTS,
   CLIENT_STRING_FLAG_DEFAULTS,
+  getEnvFlagOverridesForScope,
+  readEnvFlagOverrides,
+  scopeIncludes,
 } from "@/lib/feature-flags/feature-flag-catalog";
 
 describe("feature flag catalog", () => {
@@ -27,5 +30,109 @@ describe("feature flag catalog", () => {
   test("exposes dynamic empty-state greetings as an assistant flag", () => {
     expect(ASSISTANT_FLAG_DEFAULTS.emptyStateDynamicGreetings).toBe(false);
     expect("emptyStateDynamicGreetings" in CLIENT_FLAG_DEFAULTS).toBe(false);
+  });
+});
+
+describe("readEnvFlagOverrides", () => {
+  test("returns empty object when neither window global nor Vite env vars are present", () => {
+    const overrides = readEnvFlagOverrides();
+    expect(overrides).toEqual({});
+  });
+
+  test("reads from window.__VELLUM_FLAG_OVERRIDES__ when set before module load", async () => {
+    // Set up the global before importing a fresh module instance
+    (globalThis as Record<string, unknown>).window = {
+      __VELLUM_FLAG_OVERRIDES__: {
+        "self-intro-greeting": true,
+        "home-tab": "variant-a",
+      },
+    };
+
+    try {
+      // Bust the module cache by appending a query parameter
+      const mod = await import(
+        "@/lib/feature-flags/feature-flag-catalog?t=window-test"
+      );
+      const overrides = mod.readEnvFlagOverrides();
+      expect(overrides).toEqual({
+        "self-intro-greeting": true,
+        "home-tab": "variant-a",
+      });
+    } finally {
+      delete (globalThis as Record<string, unknown>).window;
+    }
+  });
+});
+
+describe("getEnvFlagOverridesForScope", () => {
+  test("returns empty bool and str maps when no overrides are present", () => {
+    const result = getEnvFlagOverridesForScope("client");
+    expect(result).toEqual({ bool: {}, str: {} });
+  });
+
+  test("filters client-scoped flags and separates bool/str", async () => {
+    (globalThis as Record<string, unknown>).window = {
+      __VELLUM_FLAG_OVERRIDES__: {
+        // client-only flag (boolean)
+        "home-tab": true,
+        // assistant-only flag (boolean) — should be excluded from client scope
+        "auto-analyze": true,
+        // client-only flag (string)
+        "pre-chat-onboarding-experiment-2026-06-06": "variant-a",
+      },
+    };
+
+    try {
+      const mod = await import(
+        "@/lib/feature-flags/feature-flag-catalog?t=scope-client"
+      );
+      const result = mod.getEnvFlagOverridesForScope("client");
+      expect(result.bool).toEqual({ homeTab: true });
+      expect(result.str).toEqual({
+        preChatOnboardingExperiment20260606: "variant-a",
+      });
+      // assistant-only flag should not appear
+      expect(result.bool).not.toHaveProperty("autoAnalyze");
+    } finally {
+      delete (globalThis as Record<string, unknown>).window;
+    }
+  });
+
+  test("flags with scope 'both' appear for both client and assistant scopes", async () => {
+    (globalThis as Record<string, unknown>).window = {
+      __VELLUM_FLAG_OVERRIDES__: {
+        "self-intro-greeting": true,
+      },
+    };
+
+    try {
+      const mod = await import(
+        "@/lib/feature-flags/feature-flag-catalog?t=scope-both"
+      );
+      const clientResult = mod.getEnvFlagOverridesForScope("client");
+      const assistantResult = mod.getEnvFlagOverridesForScope("assistant");
+
+      expect(clientResult.bool).toEqual({ selfIntroGreeting: true });
+      expect(assistantResult.bool).toEqual({ selfIntroGreeting: true });
+    } finally {
+      delete (globalThis as Record<string, unknown>).window;
+    }
+  });
+});
+
+describe("scopeIncludes", () => {
+  test("'both' includes client and assistant", () => {
+    expect(scopeIncludes("both", "client")).toBe(true);
+    expect(scopeIncludes("both", "assistant")).toBe(true);
+  });
+
+  test("'client' only includes client", () => {
+    expect(scopeIncludes("client", "client")).toBe(true);
+    expect(scopeIncludes("client", "assistant")).toBe(false);
+  });
+
+  test("'assistant' only includes assistant", () => {
+    expect(scopeIncludes("assistant", "assistant")).toBe(true);
+    expect(scopeIncludes("assistant", "client")).toBe(false);
   });
 });

--- a/apps/web/src/lib/feature-flags/feature-flag-catalog.ts
+++ b/apps/web/src/lib/feature-flags/feature-flag-catalog.ts
@@ -133,10 +133,17 @@ function computeEnvFlagOverrides(): Record<string, boolean | string> {
   return overrides;
 }
 
-const cachedOverrides = computeEnvFlagOverrides();
+let cachedOverrides: Record<string, boolean | string> | null = null;
 
 export function readEnvFlagOverrides(): Record<string, boolean | string> {
+  if (cachedOverrides === null) {
+    cachedOverrides = computeEnvFlagOverrides();
+  }
   return cachedOverrides;
+}
+
+export function resetEnvOverridesCache(): void {
+  cachedOverrides = null;
 }
 
 const FLAG_KEY_TO_DEF = new Map<string, FlagDefinition>();

--- a/apps/web/src/lib/feature-flags/feature-flag-catalog.ts
+++ b/apps/web/src/lib/feature-flags/feature-flag-catalog.ts
@@ -101,10 +101,13 @@ function upperSnakeToKebab(upper: string): string {
   return upper.toLowerCase().replace(/_/g, "-");
 }
 
+const TRUTHY = new Set(["true", "1", "yes", "on"]);
+const FALSY = new Set(["false", "0", "no", "off"]);
+
 function parseEnvValue(raw: string): boolean | string {
   const lower = raw.toLowerCase();
-  if (lower === "true") return true;
-  if (lower === "false") return false;
+  if (TRUTHY.has(lower)) return true;
+  if (FALSY.has(lower)) return false;
   return raw;
 }
 

--- a/apps/web/src/lib/feature-flags/feature-flag-catalog.ts
+++ b/apps/web/src/lib/feature-flags/feature-flag-catalog.ts
@@ -92,3 +92,73 @@ export function getFlagDefinition(storeKey: string): FlagDefinition | undefined 
 }
 
 export { flags as ALL_FLAGS };
+
+// -- Env flag override helpers ------------------------------------------------
+
+const VITE_FLAG_PREFIX = "VITE_VELLUM_FLAG_";
+
+function upperSnakeToKebab(upper: string): string {
+  return upper.toLowerCase().replace(/_/g, "-");
+}
+
+function parseEnvValue(raw: string): boolean | string {
+  const lower = raw.toLowerCase();
+  if (lower === "true") return true;
+  if (lower === "false") return false;
+  return raw;
+}
+
+function computeEnvFlagOverrides(): Record<string, boolean | string> {
+  if (
+    typeof window !== "undefined" &&
+    window.__VELLUM_FLAG_OVERRIDES__ != null
+  ) {
+    return { ...window.__VELLUM_FLAG_OVERRIDES__ };
+  }
+
+  const overrides: Record<string, boolean | string> = {};
+  const env = import.meta.env;
+  for (const key of Object.keys(env)) {
+    if (key.startsWith(VITE_FLAG_PREFIX)) {
+      const flagKey = upperSnakeToKebab(key.slice(VITE_FLAG_PREFIX.length));
+      const raw = env[key as keyof ImportMetaEnv];
+      if (raw != null) {
+        overrides[flagKey] = parseEnvValue(raw);
+      }
+    }
+  }
+  return overrides;
+}
+
+const cachedOverrides = computeEnvFlagOverrides();
+
+export function readEnvFlagOverrides(): Record<string, boolean | string> {
+  return cachedOverrides;
+}
+
+const FLAG_KEY_TO_DEF = new Map<string, FlagDefinition>();
+for (const flag of flags) {
+  FLAG_KEY_TO_DEF.set(flag.key, flag);
+}
+
+export function getEnvFlagOverridesForScope(
+  scope: SingleScope,
+): { bool: Record<string, boolean>; str: Record<string, string> } {
+  const overrides = readEnvFlagOverrides();
+  const bool: Record<string, boolean> = {};
+  const str: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(overrides)) {
+    const def = FLAG_KEY_TO_DEF.get(key);
+    if (!def || !scopeIncludes(def.scope, scope)) continue;
+
+    const storeKey = flagKeyToStoreKey(key);
+    if (typeof value === "boolean") {
+      bool[storeKey] = value;
+    } else {
+      str[storeKey] = value;
+    }
+  }
+
+  return { bool, str };
+}

--- a/apps/web/src/stores/assistant-feature-flag-store.ts
+++ b/apps/web/src/stores/assistant-feature-flag-store.ts
@@ -5,6 +5,7 @@ import { client } from "@/generated/api/client.gen";
 import {
   ASSISTANT_FLAG_DEFAULTS,
   ASSISTANT_STRING_FLAG_DEFAULTS,
+  getEnvFlagOverridesForScope,
   storeKeyToFlagKey,
 } from "@/lib/feature-flags/feature-flag-catalog";
 
@@ -73,6 +74,8 @@ function resetAllConfirmed() {
   resetConfirmedStringFlags();
 }
 
+const envOverrides = getEnvFlagOverridesForScope("assistant");
+
 function latestConfirmedValue(key: string): boolean {
   return confirmedAssistantFlagValues[key] ?? ASSISTANT_FLAG_DEFAULTS[key] ?? false;
 }
@@ -95,16 +98,18 @@ const useAssistantFeatureFlagStoreBase = create<AssistantFeatureFlagStore>()(
 
     return ({
       ...ASSISTANT_FLAG_DEFAULTS,
+      ...envOverrides.bool,
       hasHydrated: false,
-      stringFlags: { ...ASSISTANT_STRING_FLAG_DEFAULTS },
+      stringFlags: { ...ASSISTANT_STRING_FLAG_DEFAULTS, ...envOverrides.str },
 
       setFlags: (flags: Record<string, boolean>) =>
         set((prev) => {
           resetConfirmedFlags(flags);
-          const changed = Object.keys(flags).some(
-            (k) => flags[k] !== prev[k],
+          const merged = { ...flags, ...envOverrides.bool };
+          const changed = Object.keys(merged).some(
+            (k) => merged[k] !== prev[k],
           );
-          return changed ? flags : prev;
+          return changed ? merged : prev;
         }),
 
       setFlag: (key: string, value: boolean, assistantId: string | null) => {
@@ -157,18 +162,19 @@ const useAssistantFeatureFlagStoreBase = create<AssistantFeatureFlagStore>()(
 
       resetForAssistantSwitch: () => {
         resetAllConfirmed();
-        set({ ...ASSISTANT_FLAG_DEFAULTS, hasHydrated: false });
-        setStr({ stringFlags: { ...ASSISTANT_STRING_FLAG_DEFAULTS } });
+        set({ ...ASSISTANT_FLAG_DEFAULTS, ...envOverrides.bool, hasHydrated: false });
+        setStr({ stringFlags: { ...ASSISTANT_STRING_FLAG_DEFAULTS, ...envOverrides.str } });
       },
 
       setStringFlags: (flags: Record<string, string>) =>
         setStr((prev) => {
           resetConfirmedStringFlags(flags);
+          const merged = { ...flags, ...envOverrides.str };
           const prevStr = prev.stringFlags;
-          const changed = Object.keys(flags).some(
-            (k) => flags[k] !== prevStr[k],
+          const changed = Object.keys(merged).some(
+            (k) => merged[k] !== prevStr[k],
           );
-          return changed ? { stringFlags: flags } : prev;
+          return changed ? { stringFlags: merged } : prev;
         }),
 
       setStringFlag: (key: string, value: string, assistantId: string | null) => {

--- a/apps/web/src/stores/assistant-feature-flag-store.ts
+++ b/apps/web/src/stores/assistant-feature-flag-store.ts
@@ -155,7 +155,7 @@ const useAssistantFeatureFlagStoreBase = create<AssistantFeatureFlagStore>()(
           confirmedAssistantFlagValues[key] = value;
         }
 
-        set({ [key]: value });
+        set({ [key]: envOverrides.bool[key] ?? value });
       },
 
       markHydrated: () => set({ hasHydrated: true }),
@@ -218,7 +218,7 @@ const useAssistantFeatureFlagStoreBase = create<AssistantFeatureFlagStore>()(
         }
 
         setStr((prev) => ({
-          stringFlags: { ...prev.stringFlags, [key]: value },
+          stringFlags: { ...prev.stringFlags, [key]: envOverrides.str[key] ?? value },
         }));
       },
     }) as AssistantFeatureFlagStore;

--- a/apps/web/src/stores/client-feature-flag-store.ts
+++ b/apps/web/src/stores/client-feature-flag-store.ts
@@ -4,6 +4,7 @@ import { createSelectors } from "@/utils/create-selectors";
 import {
   CLIENT_FLAG_DEFAULTS,
   CLIENT_STRING_FLAG_DEFAULTS,
+  getEnvFlagOverridesForScope,
 } from "@/lib/feature-flags/feature-flag-catalog";
 
 const LS_PREFIX = "vellum:ff:";
@@ -43,6 +44,7 @@ function readStringOverrides(): Record<string, string> {
 
 const localOverrides = readOverrides();
 const localStringOverrides = readStringOverrides();
+const envOverrides = getEnvFlagOverridesForScope("client");
 
 interface ClientFeatureFlagMeta {
   stringFlags: Record<string, string>;
@@ -73,12 +75,13 @@ const useClientFeatureFlagStoreBase = create<ClientFeatureFlagStore>()(
     return ({
       ...CLIENT_FLAG_DEFAULTS,
       ...localOverrides,
-      stringFlags: { ...CLIENT_STRING_FLAG_DEFAULTS, ...localStringOverrides },
+      ...envOverrides.bool,
+      stringFlags: { ...CLIENT_STRING_FLAG_DEFAULTS, ...localStringOverrides, ...envOverrides.str },
 
       setFlags: (flags: Record<string, boolean>) =>
         set((prev) => {
           const overrides = readOverrides();
-          const merged = { ...flags, ...overrides };
+          const merged = { ...flags, ...overrides, ...envOverrides.bool };
           const changed = Object.keys(merged).some(
             (k) => merged[k] !== prev[k],
           );
@@ -109,7 +112,7 @@ const useClientFeatureFlagStoreBase = create<ClientFeatureFlagStore>()(
       setStringFlags: (flags: Record<string, string>) =>
         setStr((prev) => {
           const overrides = readStringOverrides();
-          const merged = { ...flags, ...overrides };
+          const merged = { ...flags, ...overrides, ...envOverrides.str };
           const prevStr = prev.stringFlags;
           const changed = Object.keys(merged).some(
             (k) => merged[k] !== prevStr[k],

--- a/apps/web/src/stores/client-feature-flag-store.ts
+++ b/apps/web/src/stores/client-feature-flag-store.ts
@@ -94,7 +94,7 @@ const useClientFeatureFlagStoreBase = create<ClientFeatureFlagStore>()(
         } catch {
           // localStorage unavailable
         }
-        set({ [key]: value });
+        set({ [key]: envOverrides.bool[key] ?? value });
       },
 
       clearOverride: (key: string) => {
@@ -103,7 +103,7 @@ const useClientFeatureFlagStoreBase = create<ClientFeatureFlagStore>()(
         } catch {
           // localStorage unavailable
         }
-        const defaultValue = CLIENT_FLAG_DEFAULTS[key];
+        const defaultValue = envOverrides.bool[key] ?? CLIENT_FLAG_DEFAULTS[key];
         if (defaultValue !== undefined) {
           set({ [key]: defaultValue });
         }
@@ -127,7 +127,7 @@ const useClientFeatureFlagStoreBase = create<ClientFeatureFlagStore>()(
           // localStorage unavailable
         }
         setStr((prev) => ({
-          stringFlags: { ...prev.stringFlags, [key]: value },
+          stringFlags: { ...prev.stringFlags, [key]: envOverrides.str[key] ?? value },
         }));
       },
 
@@ -137,7 +137,7 @@ const useClientFeatureFlagStoreBase = create<ClientFeatureFlagStore>()(
         } catch {
           // localStorage unavailable
         }
-        const defaultValue = CLIENT_STRING_FLAG_DEFAULTS[key];
+        const defaultValue = envOverrides.str[key] ?? CLIENT_STRING_FLAG_DEFAULTS[key];
         setStr((prev) => ({
           stringFlags: {
             ...prev.stringFlags,

--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -779,6 +779,7 @@ describe("resolveOrHatchTarget", () => {
       "new-one",
       false,
       {},
+      {},
       { setupProviderCredentials: false },
     );
     expect(result).toBe(newEntry);

--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -43,7 +43,7 @@ import {
   type CliInvocation,
 } from "@vellumai/local-mode";
 import { parseAssistantTargetArg } from "../lib/assistant-target-args.js";
-import { parseFeatureFlagArgs } from "../lib/flag-args";
+import { parseFeatureFlagArgs, readAmbientFlagEnvVars } from "../lib/flag-args";
 import {
   fetchOrganizationId,
   fetchPlatformAssistants,
@@ -92,8 +92,9 @@ function readAssistantName(entry: AssistantEntry | null): string | undefined {
 
 // Exported for unit testing the arg/auth resolution without launching the TUI.
 export function parseArgs(): ParsedArgs {
-  const { envVars: flagEnvVars, remaining: argsWithoutFlags } =
+  const { envVars: cliFlagVars, remaining: argsWithoutFlags } =
     parseFeatureFlagArgs(process.argv.slice(3));
+  const flagEnvVars = { ...readAmbientFlagEnvVars(), ...cliFlagVars };
   const args = argsWithoutFlags;
 
   // Build parsedFlagOverrides from the extracted env vars:

--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -43,6 +43,7 @@ import {
   type CliInvocation,
 } from "@vellumai/local-mode";
 import { parseAssistantTargetArg } from "../lib/assistant-target-args.js";
+import { parseFeatureFlagArgs } from "../lib/flag-args";
 import {
   fetchOrganizationId,
   fetchPlatformAssistants,
@@ -76,6 +77,10 @@ interface ParsedArgs {
   bearerToken?: string;
   /** Interface identifier sent as X-Vellum-Interface-Id on all requests. */
   interfaceId: SupportedInterface;
+  /** VELLUM_FLAG_* env vars for the gateway (process.env propagation). */
+  flagEnvVars: Record<string, string>;
+  /** Parsed --flag overrides: kebab-case key -> typed value (for web injection). */
+  parsedFlagOverrides: Record<string, boolean | string>;
 }
 
 function readAssistantName(entry: AssistantEntry | null): string | undefined {
@@ -87,7 +92,25 @@ function readAssistantName(entry: AssistantEntry | null): string | undefined {
 
 // Exported for unit testing the arg/auth resolution without launching the TUI.
 export function parseArgs(): ParsedArgs {
-  const args = process.argv.slice(3);
+  const { envVars: flagEnvVars, remaining: argsWithoutFlags } =
+    parseFeatureFlagArgs(process.argv.slice(3));
+  const args = argsWithoutFlags;
+
+  // Build parsedFlagOverrides from the extracted env vars:
+  // VELLUM_FLAG_UPPER_SNAKE -> kebab-case key with typed value.
+  const parsedFlagOverrides: Record<string, boolean | string> = {};
+  for (const [envName, rawValue] of Object.entries(flagEnvVars)) {
+    const snake = envName.replace(/^VELLUM_FLAG_/, "");
+    const kebab = snake.toLowerCase().replace(/_/g, "-");
+    const lower = rawValue.toLowerCase();
+    if (["true", "1", "yes", "on"].includes(lower)) {
+      parsedFlagOverrides[kebab] = true;
+    } else if (["false", "0", "no", "off"].includes(lower)) {
+      parsedFlagOverrides[kebab] = false;
+    } else {
+      parsedFlagOverrides[kebab] = rawValue;
+    }
+  }
 
   const positionalName = parseAssistantTargetArg(args, [
     "--url",
@@ -222,6 +245,8 @@ export function parseArgs(): ParsedArgs {
     platformToken,
     bearerToken,
     interfaceId,
+    flagEnvVars,
+    parsedFlagOverrides,
   };
 }
 
@@ -241,6 +266,7 @@ ${ANSI.bold}OPTIONS:${ANSI.reset}
                               not persisted.
     -a, --assistant-id <id>    Assistant ID
     -i, --interface <id>       Interface identifier: cli (default) or web
+    --flag <key=value>         Feature flag override (repeatable, kebab-case key)
     -h, --help                 Show this help message
 
 ${ANSI.bold}DEFAULTS:${ANSI.reset}
@@ -616,12 +642,18 @@ function getBaseDir(): string {
   return path.resolve(import.meta.dir, "..", "..", "..");
 }
 
-async function runWebInterface(): Promise<void> {
+async function runWebInterface(
+  flagEnvVars: Record<string, string>,
+  parsedFlagOverrides: Record<string, boolean | string>,
+): Promise<void> {
+  // Propagate flag env vars so child processes (e.g. hatch from the web UI) inherit them.
+  Object.assign(process.env, flagEnvVars);
+
   // Prefer Vite dev server in source checkouts for full local-mode support
   // (HMR, __local endpoints, gateway proxy).
   const webSourceDir = findWebSourceDir();
   if (webSourceDir) {
-    return runViteDevServer(webSourceDir);
+    return runViteDevServer(webSourceDir, flagEnvVars);
   }
 
   const distDir = findWebDistDir();
@@ -639,9 +671,13 @@ async function runWebInterface(): Promise<void> {
   const platformUrl = getPlatformUrl();
   const webUrl = getWebUrl();
   const configJson = JSON.stringify({ webUrl, platformUrl });
+  const hasOverrides = Object.keys(parsedFlagOverrides).length > 0;
+  const flagOverridesSnippet = hasOverrides
+    ? `;window.__VELLUM_FLAG_OVERRIDES__=${JSON.stringify(parsedFlagOverrides)}`
+    : "";
   const indexHtml = rawIndexHtml.replace(
     "</head>",
-    `<script>window.__VELLUM_CONFIG__=${configJson}</script></head>`,
+    `<script>window.__VELLUM_CONFIG__=${configJson}${flagOverridesSnippet}</script></head>`,
   );
 
   const server = Bun.serve({
@@ -766,14 +802,25 @@ async function runWebInterface(): Promise<void> {
   await new Promise(() => {});
 }
 
-async function runViteDevServer(webSourceDir: string): Promise<void> {
+async function runViteDevServer(
+  webSourceDir: string,
+  flagEnvVars: Record<string, string>,
+): Promise<void> {
   const platformUrl = getPlatformUrl();
+
+  // Build VITE_VELLUM_FLAG_* vars so Vite exposes them to the browser bundle.
+  const viteFlagVars: Record<string, string> = {};
+  for (const [envName, value] of Object.entries(flagEnvVars)) {
+    viteFlagVars[`VITE_${envName}`] = value;
+  }
 
   const child = spawn("bun", ["run", "dev"], {
     cwd: webSourceDir,
     stdio: "inherit",
     env: {
       ...process.env,
+      ...flagEnvVars,
+      ...viteFlagVars,
       VITE_PLATFORM_MODE: "false",
       API_PROXY_TARGET: platformUrl,
       VELLUM_WEB_URL: getWebUrl(),
@@ -854,10 +901,12 @@ export async function client(): Promise<void> {
     platformToken,
     bearerToken,
     interfaceId,
+    flagEnvVars,
+    parsedFlagOverrides,
   } = parseArgs();
 
   if (interfaceId === WEB_INTERFACE_ID) {
-    await runWebInterface();
+    await runWebInterface(flagEnvVars, parsedFlagOverrides);
     return;
   }
 

--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -671,10 +671,12 @@ async function runWebInterface(
   const rawIndexHtml = await Bun.file(path.join(distDir, "index.html")).text();
   const platformUrl = getPlatformUrl();
   const webUrl = getWebUrl();
-  const configJson = JSON.stringify({ webUrl, platformUrl });
+  const safeJson = (v: unknown) =>
+    JSON.stringify(v).replace(/</g, "\\u003c").replace(/>/g, "\\u003e");
+  const configJson = safeJson({ webUrl, platformUrl });
   const hasOverrides = Object.keys(parsedFlagOverrides).length > 0;
   const flagOverridesSnippet = hasOverrides
-    ? `;window.__VELLUM_FLAG_OVERRIDES__=${JSON.stringify(parsedFlagOverrides)}`
+    ? `;window.__VELLUM_FLAG_OVERRIDES__=${safeJson(parsedFlagOverrides)}`
     : "";
   const indexHtml = rawIndexHtml.replace(
     "</head>",

--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -16,7 +16,7 @@ import {
 import type { RemoteHost, Species } from "../lib/constants";
 import { buildNestedConfig } from "../lib/config-utils";
 import { hatchDocker } from "../lib/docker";
-import { parseFeatureFlagArgs } from "../lib/flag-args";
+import { parseFeatureFlagArgs, readAmbientFlagEnvVars } from "../lib/flag-args";
 import type { PollResult, WatchHatchingResult } from "../lib/gcp";
 import { hatchLocal } from "../lib/hatch-local";
 import {
@@ -184,9 +184,10 @@ interface HatchArgs {
 }
 
 function parseArgs(): HatchArgs {
-  const { envVars: flagEnvVars, remaining: args } = parseFeatureFlagArgs(
+  const { envVars: cliFlagVars, remaining: args } = parseFeatureFlagArgs(
     process.argv.slice(3),
   );
+  const flagEnvVars = { ...readAmbientFlagEnvVars(), ...cliFlagVars };
   let species: Species = DEFAULT_SPECIES;
   let detached = false;
   let keepAlive = false;

--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -16,6 +16,7 @@ import {
 import type { RemoteHost, Species } from "../lib/constants";
 import { buildNestedConfig } from "../lib/config-utils";
 import { hatchDocker } from "../lib/docker";
+import { parseFeatureFlagArgs } from "../lib/flag-args";
 import type { PollResult, WatchHatchingResult } from "../lib/gcp";
 import { hatchLocal } from "../lib/hatch-local";
 import {
@@ -178,11 +179,14 @@ interface HatchArgs {
   watch: boolean;
   sourcePath: string | null;
   configValues: Record<string, string>;
+  flagEnvVars: Record<string, string>;
   analyze: boolean;
 }
 
 function parseArgs(): HatchArgs {
-  const args = process.argv.slice(3);
+  const { envVars: flagEnvVars, remaining: args } = parseFeatureFlagArgs(
+    process.argv.slice(3),
+  );
   let species: Species = DEFAULT_SPECIES;
   let detached = false;
   let keepAlive = false;
@@ -221,6 +225,9 @@ function parseArgs(): HatchArgs {
       );
       console.log(
         "  --config <key=value>      Set a workspace config value (repeatable)",
+      );
+      console.log(
+        "  --flag <key=value>        Set a feature flag override as VELLUM_FLAG_<KEY> env var (repeatable)",
       );
       console.log(
         "  --analyze                 Emit a structured hatch-timing log line on stdout",
@@ -289,7 +296,7 @@ function parseArgs(): HatchArgs {
       species = arg as Species;
     } else {
       console.error(
-        `Error: Unknown argument '${arg}'. Valid options: ${VALID_SPECIES.join(", ")}, -d, --watch, --source <path>, --keep-alive, --name <name>, --remote <${VALID_REMOTE_HOSTS.join("|")}>, --config <key=value>, --analyze`,
+        `Error: Unknown argument '${arg}'. Valid options: ${VALID_SPECIES.join(", ")}, -d, --watch, --source <path>, --keep-alive, --name <name>, --remote <${VALID_REMOTE_HOSTS.join("|")}>, --config <key=value>, --flag <key=value>, --analyze`,
       );
       process.exit(1);
     }
@@ -304,6 +311,7 @@ function parseArgs(): HatchArgs {
     watch,
     sourcePath,
     configValues,
+    flagEnvVars,
     analyze,
   };
 }
@@ -538,6 +546,7 @@ export async function hatch(): Promise<void> {
     watch,
     sourcePath,
     configValues,
+    flagEnvVars,
     analyze,
   } = parseArgs();
 
@@ -566,7 +575,7 @@ export async function hatch(): Promise<void> {
   }
 
   if (remote === "local") {
-    await hatchLocal(species, name, watch, keepAlive, configValues);
+    await hatchLocal(species, name, watch, keepAlive, configValues, flagEnvVars);
     return;
   }
 

--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -580,7 +580,7 @@ export async function hatch(): Promise<void> {
   }
 
   if (remote === "docker") {
-    await hatchDocker(species, detached, name, watch, configValues, {
+    await hatchDocker(species, detached, name, watch, configValues, flagEnvVars, {
       sourcePath,
       analyze,
     });

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -891,6 +891,7 @@ export async function resolveOrHatchTarget(
       false,
       false,
       {},
+      {},
       {
         setupProviderCredentials: false,
       },

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -916,6 +916,7 @@ export async function resolveOrHatchTarget(
       targetName ?? null,
       false,
       {},
+      {},
       {
         setupProviderCredentials: false,
       },

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -662,6 +662,7 @@ export async function startContainers(
     bootstrapSecret?: string;
     cesServiceToken?: string;
     extraAssistantEnv?: Record<string, string>;
+    extraGatewayEnv?: Record<string, string>;
     gatewayPort: number;
     imageTags: Record<ServiceName, string>;
     instanceName: string;
@@ -1042,6 +1043,7 @@ export async function hatchDocker(
   name: string | null,
   watch: boolean = false,
   configValues: Record<string, string> = {},
+  flagEnvVars: Record<string, string> = {},
   options: HatchDockerOptions = {},
 ): Promise<void> {
   resetLogFile("hatch.log");
@@ -1321,12 +1323,15 @@ export async function hatchDocker(
       : ownSecret;
 
     emitProgress(4, 6, "Starting containers...");
+    const extraGatewayEnv =
+      Object.keys(flagEnvVars).length > 0 ? flagEnvVars : undefined;
     await startContainers(
       {
         signingKey,
         bootstrapSecret,
         cesServiceToken,
         extraAssistantEnv,
+        extraGatewayEnv,
         gatewayPort,
         imageTags,
         instanceName,

--- a/cli/src/lib/flag-args.test.ts
+++ b/cli/src/lib/flag-args.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test, spyOn } from "bun:test";
+
+import { parseFeatureFlagArgs } from "./flag-args";
+
+describe("parseFeatureFlagArgs", () => {
+  test("single flag produces env var and empty remaining", () => {
+    const result = parseFeatureFlagArgs(["--flag", "voice-mode=true"]);
+    expect(result).toEqual({
+      envVars: { VELLUM_FLAG_VOICE_MODE: "true" },
+      remaining: [],
+    });
+  });
+
+  test("multiple flags produce multiple env vars", () => {
+    const result = parseFeatureFlagArgs([
+      "--flag",
+      "a=1",
+      "--flag",
+      "b=0",
+    ]);
+    expect(result).toEqual({
+      envVars: { VELLUM_FLAG_A: "1", VELLUM_FLAG_B: "0" },
+      remaining: [],
+    });
+  });
+
+  test("flags mixed with other args preserves remaining", () => {
+    const result = parseFeatureFlagArgs([
+      "--watch",
+      "--flag",
+      "x=y",
+      "--name",
+      "foo",
+    ]);
+    expect(result).toEqual({
+      envVars: { VELLUM_FLAG_X: "y" },
+      remaining: ["--watch", "--name", "foo"],
+    });
+  });
+
+  test("exits with error when --flag has no following argument", () => {
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+
+    expect(() => parseFeatureFlagArgs(["--flag"])).toThrow("process.exit");
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Error: --flag requires a key=value argument",
+    );
+
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  test("exits with error when value has no equals sign", () => {
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+
+    expect(() => parseFeatureFlagArgs(["--flag", "noequals"])).toThrow(
+      "process.exit",
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Error: --flag value must be in key=value format, got "noequals"',
+    );
+
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  test("exits with error when key is not kebab-case", () => {
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+
+    expect(() => parseFeatureFlagArgs(["--flag", "UPPER=true"])).toThrow(
+      "process.exit",
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Error: invalid flag key "UPPER". Keys must be kebab-case (e.g. "voice-mode")',
+    );
+
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+});

--- a/cli/src/lib/flag-args.ts
+++ b/cli/src/lib/flag-args.ts
@@ -1,0 +1,56 @@
+/** Only allow simple kebab-case keys (e.g. "voice-mode", "ces-tools"). */
+const ALLOWED_KEY_RE = /^[a-z0-9][a-z0-9-]*$/;
+
+/**
+ * Extract repeatable `--flag key=value` pairs from a CLI arg list.
+ *
+ * Each `--flag` consumes the next argument as `key=value`. Keys are validated
+ * against a kebab-case pattern, then converted to env var names of the form
+ * `VELLUM_FLAG_<UPPER_SNAKE>`. All `--flag` pairs are stripped from the
+ * returned `remaining` array so downstream parsers never see them.
+ */
+export function parseFeatureFlagArgs(args: string[]): {
+  envVars: Record<string, string>;
+  remaining: string[];
+} {
+  const envVars: Record<string, string> = {};
+  const remaining: string[] = [];
+
+  let i = 0;
+  while (i < args.length) {
+    if (args[i] === "--flag") {
+      if (i + 1 >= args.length) {
+        console.error("Error: --flag requires a key=value argument");
+        process.exit(1);
+      }
+
+      const pair = args[i + 1]!;
+      const eqIdx = pair.indexOf("=");
+      if (eqIdx === -1) {
+        console.error(
+          `Error: --flag value must be in key=value format, got "${pair}"`,
+        );
+        process.exit(1);
+      }
+
+      const key = pair.slice(0, eqIdx);
+      const value = pair.slice(eqIdx + 1);
+
+      if (!ALLOWED_KEY_RE.test(key)) {
+        console.error(
+          `Error: invalid flag key "${key}". Keys must be kebab-case (e.g. "voice-mode")`,
+        );
+        process.exit(1);
+      }
+
+      const envName = `VELLUM_FLAG_${key.toUpperCase().replace(/-/g, "_")}`;
+      envVars[envName] = value;
+      i += 2;
+    } else {
+      remaining.push(args[i]!);
+      i += 1;
+    }
+  }
+
+  return { envVars, remaining };
+}

--- a/cli/src/lib/flag-args.ts
+++ b/cli/src/lib/flag-args.ts
@@ -54,3 +54,21 @@ export function parseFeatureFlagArgs(args: string[]): {
 
   return { envVars, remaining };
 }
+
+const ENV_FLAG_PREFIX = "VELLUM_FLAG_";
+
+/**
+ * Scan `process.env` for ambient `VELLUM_FLAG_*` entries.
+ * Returns them as-is (same `Record<string, string>` shape as
+ * `parseFeatureFlagArgs().envVars`) so callers can merge both
+ * sources with `--flag` args winning over ambient env vars.
+ */
+export function readAmbientFlagEnvVars(): Record<string, string> {
+  const vars: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (key.startsWith(ENV_FLAG_PREFIX) && value !== undefined) {
+      vars[key] = value;
+    }
+  }
+  return vars;
+}

--- a/cli/src/lib/hatch-local.ts
+++ b/cli/src/lib/hatch-local.ts
@@ -164,6 +164,7 @@ export async function hatchLocal(
   watch: boolean = false,
   keepAlive: boolean = false,
   configValues: Record<string, string> = {},
+  flagEnvVars: Record<string, string> = {},
   options: HatchLocalOptions = {},
 ): Promise<HatchLocalResult> {
   const reporter = options.reporter ?? consoleLifecycleReporter;
@@ -234,6 +235,7 @@ export async function hatchLocal(
     runtimeUrl = await startGateway(watch, resources, {
       signingKey,
       bootstrapSecret,
+      envOverrides: flagEnvVars,
     });
   } catch (error) {
     // Gateway failed — stop the daemon we just started so we don't leave

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -1057,7 +1057,11 @@ export async function startLocalDaemon(
 export async function startGateway(
   watch: boolean = false,
   resources?: LocalInstanceResources,
-  options?: { signingKey?: string; bootstrapSecret?: string },
+  options?: {
+    signingKey?: string;
+    bootstrapSecret?: string;
+    envOverrides?: Record<string, string>;
+  },
 ): Promise<string> {
   const effectiveGatewayPort = resources?.gatewayPort ?? GATEWAY_PORT;
 
@@ -1083,6 +1087,7 @@ export async function startGateway(
 
   const gatewayEnv: Record<string, string> = {
     ...(process.env as Record<string, string>),
+    ...options?.envOverrides,
     RUNTIME_HTTP_PORT: String(effectiveDaemonPort),
     GATEWAY_PORT: String(effectiveGatewayPort),
     // Pass gateway operational settings via env vars so the CLI does not

--- a/cli/src/lib/statefulset.ts
+++ b/cli/src/lib/statefulset.ts
@@ -257,6 +257,7 @@ export interface BuildServiceRunArgsOpts extends DockerRunSecrets {
   instanceName: string;
   res: DockerResourceNames;
   extraAssistantEnv?: Record<string, string>;
+  extraGatewayEnv?: Record<string, string>;
   /** Avatar device path, if available. Injected by `docker.ts` after resolving. */
   avatarDevicePath?: string;
 }
@@ -285,6 +286,7 @@ export function buildServiceRunArgs(
     instanceName,
     res,
     extraAssistantEnv,
+    extraGatewayEnv,
     avatarDevicePath,
   } = opts;
 
@@ -343,6 +345,13 @@ export function buildServiceRunArgs(
           const hostVar = entry.hostVar ?? entry.name;
           const val = process.env[hostVar];
           if (val) args.push("-e", `${entry.name}=${val}`);
+        }
+      }
+
+      // Gateway-only additions (e.g. feature flag env overrides)
+      if (svc === "gateway" && extraGatewayEnv) {
+        for (const [k, v] of Object.entries(extraGatewayEnv)) {
+          args.push("-e", `${k}=${v}`);
         }
       }
 

--- a/gateway/src/__tests__/feature-flag-resolver.test.ts
+++ b/gateway/src/__tests__/feature-flag-resolver.test.ts
@@ -64,6 +64,10 @@ afterEach(() => {
   resetFeatureFlagDefaultsCache();
   clearFeatureFlagStoreCache();
   clearRemoteFeatureFlagStoreCache();
+  resetEnvOverridesCache();
+  delete process.env.VELLUM_FLAG_BROWSER;
+  delete process.env.VELLUM_FLAG_A2A_CHANNEL;
+  delete process.env.VELLUM_FLAG_DEFAULT_MODEL;
 });
 
 const { isFeatureFlagEnabled, getFeatureFlagValue } = await import("../feature-flag-resolver.js");
@@ -73,6 +77,8 @@ const { clearFeatureFlagStoreCache, writeFeatureFlag } =
   await import("../feature-flag-store.js");
 const { clearRemoteFeatureFlagStoreCache, writeRemoteFeatureFlags } =
   await import("../feature-flag-remote-store.js");
+const { resetEnvOverridesCache } =
+  await import("../feature-flag-env-overrides.js");
 
 describe("isFeatureFlagEnabled", () => {
   test("uses registry defaults when no override exists", () => {
@@ -148,5 +154,25 @@ describe("getFeatureFlagValue", () => {
     writeRemoteFeatureFlags({ "default-model": "remote-model" });
     writeFeatureFlag("default-model", "persisted-model");
     expect(getFeatureFlagValue("default-model")).toBe("persisted-model");
+  });
+
+  test("env override wins over persisted, remote, and default values", () => {
+    writeRemoteFeatureFlags({ browser: false });
+    writeFeatureFlag("browser", false);
+
+    process.env.VELLUM_FLAG_BROWSER = "true";
+    resetEnvOverridesCache();
+
+    expect(getFeatureFlagValue("browser")).toBe(true);
+  });
+
+  test("env override wins for string flags", () => {
+    writeRemoteFeatureFlags({ "default-model": "remote-model" });
+    writeFeatureFlag("default-model", "persisted-model");
+
+    process.env.VELLUM_FLAG_DEFAULT_MODEL = "env-model";
+    resetEnvOverridesCache();
+
+    expect(getFeatureFlagValue("default-model")).toBe("env-model");
   });
 });

--- a/gateway/src/__tests__/feature-flags-route.test.ts
+++ b/gateway/src/__tests__/feature-flags-route.test.ts
@@ -80,6 +80,8 @@ afterEach(() => {
   resetFeatureFlagDefaultsCache();
   clearFeatureFlagStoreCache();
   clearRemoteFeatureFlagStoreCache();
+  resetEnvOverridesCache();
+  delete process.env.VELLUM_FLAG_A2A_CHANNEL;
 });
 
 const { createFeatureFlagsGetHandler, createFeatureFlagsPatchHandler } =
@@ -93,6 +95,8 @@ const { clearFeatureFlagStoreCache, readPersistedFeatureFlags } =
   await import("../feature-flag-store.js");
 const { clearRemoteFeatureFlagStoreCache, writeRemoteFeatureFlags } =
   await import("../feature-flag-remote-store.js");
+const { resetEnvOverridesCache } =
+  await import("../feature-flag-env-overrides.js");
 
 describe("GET /v1/feature-flags handler", () => {
   test("returns all declared assistant-scope flags with defaults when no persisted file exists", async () => {
@@ -509,6 +513,36 @@ describe("GET /v1/feature-flags handler", () => {
     );
     expect(modelFlag).toBeDefined();
     expect(modelFlag.enabled).toBe("gpt-4");
+  });
+
+  test("env override takes precedence over persisted and default values", async () => {
+    // Persisted value sets a2a-channel to false
+    writeFileSync(
+      featureFlagStorePath,
+      JSON.stringify({
+        version: 1,
+        values: { "a2a-channel": false },
+      }),
+    );
+    clearFeatureFlagStoreCache();
+
+    // Env override sets it to true
+    process.env.VELLUM_FLAG_A2A_CHANNEL = "true";
+    resetEnvOverridesCache();
+
+    const handler = createFeatureFlagsGetHandler();
+    const res = await handler(
+      new Request("http://gateway.test/v1/feature-flags"),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    const a2aFlag = body.flags.find(
+      (f: { key: string }) => f.key === "a2a-channel",
+    );
+    expect(a2aFlag).toBeDefined();
+    expect(a2aFlag.enabled).toBe(true);
   });
 
   test("returns flags when invoked via assistants path without trailing slash", async () => {

--- a/gateway/src/__tests__/ipc-feature-flag-routes.test.ts
+++ b/gateway/src/__tests__/ipc-feature-flag-routes.test.ts
@@ -76,6 +76,8 @@ afterEach(() => {
   resetFeatureFlagDefaultsCache();
   clearFeatureFlagStoreCache();
   clearRemoteFeatureFlagStoreCache();
+  resetEnvOverridesCache();
+  delete process.env.VELLUM_FLAG_A2A_CHANNEL;
 });
 
 const { resetFeatureFlagDefaultsCache, _setRegistryCandidateOverrides } =
@@ -83,6 +85,8 @@ const { resetFeatureFlagDefaultsCache, _setRegistryCandidateOverrides } =
 const { clearFeatureFlagStoreCache } = await import("../feature-flag-store.js");
 const { clearRemoteFeatureFlagStoreCache } =
   await import("../feature-flag-remote-store.js");
+const { resetEnvOverridesCache } =
+  await import("../feature-flag-env-overrides.js");
 const { GatewayIpcServer } = await import("../ipc/server.js");
 const { featureFlagRoutes } = await import("../ipc/feature-flag-handlers.js");
 
@@ -306,6 +310,22 @@ describe("IPC feature flag routes", () => {
 
     expect(res.error).toBeDefined();
     expect(res.error).toContain("Invalid params");
+  });
+
+  test("get_feature_flags includes env override values", async () => {
+    process.env.VELLUM_FLAG_A2A_CHANNEL = "true";
+    resetEnvOverridesCache();
+
+    if (existsSync(featureFlagStorePath)) rmSync(featureFlagStorePath);
+    clearFeatureFlagStoreCache();
+
+    await startServerAndConnect();
+    const res = await sendRequest(client, "get_feature_flags");
+
+    expect(res.error).toBeUndefined();
+    const flags = res.result as Record<string, boolean | string>;
+    // a2a-channel defaults to false, but env override sets it to true
+    expect(flags["a2a-channel"]).toBe(true);
   });
 
   test("unknown method returns error", async () => {

--- a/gateway/src/feature-flag-env-overrides.test.ts
+++ b/gateway/src/feature-flag-env-overrides.test.ts
@@ -1,0 +1,166 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { testSecurityDir } from "./__tests__/test-preload.js";
+
+const protectedDir = testSecurityDir;
+const defaultsPath = join(protectedDir, "feature-flag-registry.json");
+
+const TEST_REGISTRY = {
+  version: 1,
+  flags: [
+    {
+      id: "auto-analyze",
+      scope: "assistant",
+      key: "auto-analyze",
+      label: "Auto Analyze",
+      description: "Automatic analysis",
+      defaultEnabled: false,
+    },
+    {
+      id: "cool-feature",
+      scope: "assistant",
+      key: "cool-feature",
+      label: "Cool Feature",
+      description: "A cool feature",
+      defaultEnabled: false,
+    },
+  ],
+};
+
+const { readEnvFeatureFlagOverrides, resetEnvOverridesCache } = await import(
+  "./feature-flag-env-overrides.js"
+);
+const { resetFeatureFlagDefaultsCache, _setRegistryCandidateOverrides } =
+  await import("./feature-flag-defaults.js");
+
+/** Keys set by tests, cleaned up automatically. */
+const injectedKeys: string[] = [];
+
+function setEnv(key: string, value: string): void {
+  process.env[key] = value;
+  injectedKeys.push(key);
+}
+
+beforeEach(() => {
+  mkdirSync(protectedDir, { recursive: true });
+  writeFileSync(defaultsPath, JSON.stringify(TEST_REGISTRY, null, 2));
+  _setRegistryCandidateOverrides([defaultsPath]);
+  resetFeatureFlagDefaultsCache();
+  resetEnvOverridesCache();
+});
+
+afterEach(() => {
+  for (const key of injectedKeys) {
+    delete process.env[key];
+  }
+  injectedKeys.length = 0;
+
+  try {
+    rmSync(protectedDir, { recursive: true, force: true });
+    mkdirSync(protectedDir, { recursive: true });
+  } catch {
+    // best-effort cleanup
+  }
+  _setRegistryCandidateOverrides(null);
+  resetFeatureFlagDefaultsCache();
+  resetEnvOverridesCache();
+});
+
+describe("readEnvFeatureFlagOverrides", () => {
+  test("maps VELLUM_FLAG_AUTO_ANALYZE=true to { 'auto-analyze': true }", () => {
+    setEnv("VELLUM_FLAG_AUTO_ANALYZE", "true");
+    expect(readEnvFeatureFlagOverrides()).toEqual({ "auto-analyze": true });
+  });
+
+  test("parses truthy values: 1, yes, on -> true", () => {
+    setEnv("VELLUM_FLAG_AUTO_ANALYZE", "1");
+    expect(readEnvFeatureFlagOverrides()).toEqual({ "auto-analyze": true });
+
+    resetEnvOverridesCache();
+    delete process.env.VELLUM_FLAG_AUTO_ANALYZE;
+
+    setEnv("VELLUM_FLAG_AUTO_ANALYZE", "yes");
+    expect(readEnvFeatureFlagOverrides()).toEqual({ "auto-analyze": true });
+
+    resetEnvOverridesCache();
+    delete process.env.VELLUM_FLAG_AUTO_ANALYZE;
+
+    setEnv("VELLUM_FLAG_AUTO_ANALYZE", "on");
+    expect(readEnvFeatureFlagOverrides()).toEqual({ "auto-analyze": true });
+  });
+
+  test("parses falsy values: false, 0, no, off -> false", () => {
+    setEnv("VELLUM_FLAG_AUTO_ANALYZE", "false");
+    expect(readEnvFeatureFlagOverrides()).toEqual({ "auto-analyze": false });
+
+    resetEnvOverridesCache();
+    delete process.env.VELLUM_FLAG_AUTO_ANALYZE;
+
+    setEnv("VELLUM_FLAG_AUTO_ANALYZE", "0");
+    expect(readEnvFeatureFlagOverrides()).toEqual({ "auto-analyze": false });
+
+    resetEnvOverridesCache();
+    delete process.env.VELLUM_FLAG_AUTO_ANALYZE;
+
+    setEnv("VELLUM_FLAG_AUTO_ANALYZE", "no");
+    expect(readEnvFeatureFlagOverrides()).toEqual({ "auto-analyze": false });
+
+    resetEnvOverridesCache();
+    delete process.env.VELLUM_FLAG_AUTO_ANALYZE;
+
+    setEnv("VELLUM_FLAG_AUTO_ANALYZE", "off");
+    expect(readEnvFeatureFlagOverrides()).toEqual({ "auto-analyze": false });
+  });
+
+  test("preserves arbitrary string values", () => {
+    setEnv("VELLUM_FLAG_AUTO_ANALYZE", "some-custom-value");
+    expect(readEnvFeatureFlagOverrides()).toEqual({
+      "auto-analyze": "some-custom-value",
+    });
+  });
+
+  test("discards unknown keys not in registry", () => {
+    setEnv("VELLUM_FLAG_NONEXISTENT_FLAG", "true");
+    expect(readEnvFeatureFlagOverrides()).toEqual({});
+  });
+
+  test("caches result across calls", () => {
+    setEnv("VELLUM_FLAG_AUTO_ANALYZE", "true");
+    const first = readEnvFeatureFlagOverrides();
+    expect(first).toEqual({ "auto-analyze": true });
+
+    // Mutate env after first call
+    setEnv("VELLUM_FLAG_COOL_FEATURE", "true");
+    const second = readEnvFeatureFlagOverrides();
+    expect(second).toEqual({ "auto-analyze": true });
+    expect(second).toBe(first);
+  });
+
+  test("resetEnvOverridesCache allows re-read", () => {
+    setEnv("VELLUM_FLAG_AUTO_ANALYZE", "true");
+    expect(readEnvFeatureFlagOverrides()).toEqual({ "auto-analyze": true });
+
+    setEnv("VELLUM_FLAG_COOL_FEATURE", "true");
+    resetEnvOverridesCache();
+    expect(readEnvFeatureFlagOverrides()).toEqual({
+      "auto-analyze": true,
+      "cool-feature": true,
+    });
+  });
+
+  test("returns empty object when no VELLUM_FLAG_* keys exist", () => {
+    expect(readEnvFeatureFlagOverrides()).toEqual({});
+  });
+
+  test("value parsing is case-insensitive", () => {
+    setEnv("VELLUM_FLAG_AUTO_ANALYZE", "TRUE");
+    expect(readEnvFeatureFlagOverrides()).toEqual({ "auto-analyze": true });
+
+    resetEnvOverridesCache();
+    delete process.env.VELLUM_FLAG_AUTO_ANALYZE;
+
+    setEnv("VELLUM_FLAG_AUTO_ANALYZE", "False");
+    expect(readEnvFeatureFlagOverrides()).toEqual({ "auto-analyze": false });
+  });
+});

--- a/gateway/src/feature-flag-env-overrides.ts
+++ b/gateway/src/feature-flag-env-overrides.ts
@@ -1,0 +1,58 @@
+import { getLogger } from "./logger.js";
+import { isFlagDeclared } from "./feature-flag-defaults.js";
+
+const log = getLogger("feature-flag-env-overrides");
+
+const ENV_PREFIX = "VELLUM_FLAG_";
+
+const TRUTHY = new Set(["true", "1", "yes", "on"]);
+const FALSY = new Set(["false", "0", "no", "off"]);
+
+let cache: Record<string, boolean | string> | null = null;
+
+function envKeyToFlagKey(envKey: string): string {
+  return envKey.slice(ENV_PREFIX.length).toLowerCase().replace(/_/g, "-");
+}
+
+function parseValue(raw: string): boolean | string {
+  const lower = raw.toLowerCase();
+  if (TRUTHY.has(lower)) return true;
+  if (FALSY.has(lower)) return false;
+  return raw;
+}
+
+/**
+ * Scan `process.env` for keys starting with `VELLUM_FLAG_`, convert each to a
+ * kebab-case flag key, parse the value, and validate against the registry.
+ *
+ * The result is cached for the process lifetime. Unknown keys (not declared in
+ * the registry) are logged at warn level and discarded.
+ */
+export function readEnvFeatureFlagOverrides(): Record<string, boolean | string> {
+  if (cache !== null) return cache;
+
+  const result: Record<string, boolean | string> = {};
+
+  for (const envKey of Object.keys(process.env)) {
+    if (!envKey.startsWith(ENV_PREFIX)) continue;
+
+    const flagKey = envKeyToFlagKey(envKey);
+    const raw = process.env[envKey];
+    if (raw === undefined) continue;
+
+    if (!isFlagDeclared(flagKey)) {
+      log.warn({ envKey, flagKey }, "Ignoring unknown env feature flag override");
+      continue;
+    }
+
+    result[flagKey] = parseValue(raw);
+  }
+
+  cache = result;
+  return cache;
+}
+
+/** Reset the cache so the next call re-scans `process.env`. For tests. */
+export function resetEnvOverridesCache(): void {
+  cache = null;
+}

--- a/gateway/src/feature-flag-resolver.ts
+++ b/gateway/src/feature-flag-resolver.ts
@@ -1,11 +1,12 @@
 import { loadFeatureFlagDefaults } from "./feature-flag-defaults.js";
+import { readEnvFeatureFlagOverrides } from "./feature-flag-env-overrides.js";
 import { readRemoteFeatureFlags } from "./feature-flag-remote-store.js";
 import { readPersistedFeatureFlags } from "./feature-flag-store.js";
 
 /**
  * Resolve the raw value for a feature flag.
  *
- * Priority: persisted (user-toggled) > remote (platform-pushed) > registry default.
+ * Priority: env override > persisted (user-toggled) > remote (platform-pushed) > registry default.
  * Undeclared keys return `false` (fail closed), even if stale local/remote
  * state contains a value for them.
  */
@@ -13,6 +14,9 @@ export function getFeatureFlagValue(key: string): boolean | string {
   const defaults = loadFeatureFlagDefaults();
   const defaultDef = defaults[key];
   if (defaultDef === undefined) return false;
+
+  const envOverrides = readEnvFeatureFlagOverrides();
+  if (key in envOverrides) return envOverrides[key];
 
   const persisted = readPersistedFeatureFlags();
   const persistedValue = persisted[key];

--- a/gateway/src/http/routes/feature-flags.ts
+++ b/gateway/src/http/routes/feature-flags.ts
@@ -2,6 +2,7 @@ import {
   loadFeatureFlagDefaults,
   isFlagDeclared,
 } from "../../feature-flag-defaults.js";
+import { readEnvFeatureFlagOverrides } from "../../feature-flag-env-overrides.js";
 import { readRemoteFeatureFlags } from "../../feature-flag-remote-store.js";
 import {
   readPersistedFeatureFlags,
@@ -30,20 +31,23 @@ export function createFeatureFlagsGetHandler() {
       const defaults = loadFeatureFlagDefaults();
       const persisted = readPersistedFeatureFlags();
       const remote = readRemoteFeatureFlags();
+      const envOverrides = readEnvFeatureFlagOverrides();
 
       const entries: FeatureFlagEntry[] = [];
       for (const [key, def] of Object.entries(defaults)) {
         const persistedValue = persisted[key];
         const remoteValue = remote[key];
+        const base =
+          persistedValue !== undefined
+            ? persistedValue
+            : remoteValue !== undefined
+              ? remoteValue
+              : def.defaultEnabled;
+        const envValue = envOverrides[key];
         entries.push({
           key,
           label: def.label,
-          enabled:
-            persistedValue !== undefined
-              ? persistedValue
-              : remoteValue !== undefined
-                ? remoteValue
-                : def.defaultEnabled,
+          enabled: envValue !== undefined ? envValue : base,
           defaultEnabled: def.defaultEnabled,
           description: def.description,
         });

--- a/gateway/src/ipc/feature-flag-handlers.ts
+++ b/gateway/src/ipc/feature-flag-handlers.ts
@@ -9,6 +9,7 @@
 import { z } from "zod";
 
 import { loadFeatureFlagDefaults } from "../feature-flag-defaults.js";
+import { readEnvFeatureFlagOverrides } from "../feature-flag-env-overrides.js";
 import { readRemoteFeatureFlags } from "../feature-flag-remote-store.js";
 import { readPersistedFeatureFlags } from "../feature-flag-store.js";
 import type { IpcRoute } from "./server.js";
@@ -37,6 +38,12 @@ export function getMergedFeatureFlags(): Record<string, boolean | string> {
           ? remoteValue
           : def.defaultEnabled;
   }
+
+  const envOverrides = readEnvFeatureFlagOverrides();
+  for (const [key, value] of Object.entries(envOverrides)) {
+    if (key in result) result[key] = value;
+  }
+
   return result;
 }
 


### PR DESCRIPTION
## Summary
Add `VELLUM_FLAG_*` environment variable support across the gateway, CLI, Electron client, and web client — giving developers and operators a fast, session-scoped way to override feature flags without touching the settings UI or platform. Also add repeatable `--flag key=value` arguments to `vellum hatch` and `vellum client --interface web`.

## Self-review result
3 gaps found and fixed in 1 round:
- `teleport.ts` broken by `hatchLocal()` signature change (blocking)
- Web `parseEnvValue` only handled "true"/"false" (not full set)
- Individual toggle/clear methods bypassed env override enforcement

## PRs merged into feature branch
- #33940: feat(gateway): add VELLUM_FLAG_* env var reader module
- #33941: feat(cli): add shared --flag key=value parser
- #33942: feat(macos): bridge VELLUM_FLAG_* env vars to renderer via contextBridge
- #33943: feat(web): add env flag override reader and Window type declarations
- #33945: feat(cli): add --flag to vellum hatch
- #33946: feat(gateway): wire env var overrides into flag resolver, IPC, and HTTP
- #33947: feat(cli): add --flag to vellum client --interface web
- #33948: feat(web): apply env flag overrides in client and assistant stores

### Fix PRs
- #33951: fix teleport.ts hatchLocal() call for new flagEnvVars parameter
- #33952: fix web parseEnvValue with full truthy/falsy convention
- #33954: fix individual flag toggle/clear methods to enforce env overrides

Part of plan: ff-env-var-overrides.md