### PR TITLE
fix(security): add Host/Origin validation to local endpoints against DNS rebinding

### DIFF
--- a/apps/web/vite-plugin-local-mode.ts
+++ b/apps/web/vite-plugin-local-mode.ts
@@ -7,9 +7,12 @@ import {
   resolveLocalConfigFromEnv,
   resolveDevCliInvocation,
   isLoopbackAddr,
+  headerHostIsLoopback,
+  originIsAllowed,
   getLockfileData,
   upsertLockfileAssistant,
   replacePlatformAssistants,
+  isActiveAssistant,
   runHatch,
   runRetire,
   runWake,
@@ -46,7 +49,7 @@ export function localModePlugin(env: Record<string, string>): Plugin {
       );
       server.middlewares.use(lockfileMiddleware(config.lockfilePaths));
       server.middlewares.use(hatchMiddleware(baseDir));
-      server.middlewares.use(retireMiddleware(baseDir));
+      server.middlewares.use(retireMiddleware(baseDir, config.lockfilePaths));
       server.middlewares.use(wakeMiddleware(baseDir));
       server.middlewares.use(
         guardianTokenMiddleware(config.configDir, baseDir, env),
@@ -57,15 +60,20 @@ export function localModePlugin(env: Record<string, string>): Plugin {
   };
 }
 
-function rejectUnlessLoopback(
+function rejectUnlessLocalEndpointRequest(
   req: http.IncomingMessage,
   res: http.ServerResponse,
 ): boolean {
-  if (isLoopbackAddr(req.socket.remoteAddress ?? "")) return false;
-  res.statusCode = 403;
-  res.setHeader("Content-Type", "application/json");
-  res.end(JSON.stringify({ error: "Forbidden" }));
-  return true;
+  const peer = req.socket.remoteAddress ?? "";
+  const host = Array.isArray(req.headers.host) ? req.headers.host[0] : req.headers.host;
+  const origin = Array.isArray(req.headers.origin) ? req.headers.origin[0] : req.headers.origin;
+  if (!isLoopbackAddr(peer) || !headerHostIsLoopback(host) || !originIsAllowed(origin)) {
+    res.statusCode = 403;
+    res.setHeader("Content-Type", "application/json");
+    res.end(JSON.stringify({ error: "Forbidden" }));
+    return true;
+  }
+  return false;
 }
 
 function loopbackCallbackMiddleware(): Connect.NextHandleFunction {
@@ -127,7 +135,7 @@ function lockfileMiddleware(
     )
       return next();
 
-    if (rejectUnlessLoopback(req, res)) return;
+    if (rejectUnlessLocalEndpointRequest(req, res)) return;
 
     if (req.method === "GET") {
       const result = getLockfileData(lockfilePaths);
@@ -184,7 +192,7 @@ function hatchMiddleware(baseDir: string): Connect.NextHandleFunction {
     if (req.url !== "/assistant/__local/hatch" && req.url !== "/__local/hatch")
       return next();
 
-    if (rejectUnlessLoopback(req, res)) return;
+    if (rejectUnlessLocalEndpointRequest(req, res)) return;
 
     if (req.method !== "POST") {
       res.statusCode = 405;
@@ -243,7 +251,7 @@ function hatchMiddleware(baseDir: string): Connect.NextHandleFunction {
   };
 }
 
-function retireMiddleware(baseDir: string): Connect.NextHandleFunction {
+function retireMiddleware(baseDir: string, lockfilePaths: string[]): Connect.NextHandleFunction {
   return (req, res, next) => {
     if (
       req.url !== "/assistant/__local/retire" &&
@@ -251,7 +259,7 @@ function retireMiddleware(baseDir: string): Connect.NextHandleFunction {
     )
       return next();
 
-    if (rejectUnlessLoopback(req, res)) return;
+    if (rejectUnlessLocalEndpointRequest(req, res)) return;
 
     if (req.method !== "POST") {
       res.statusCode = 405;
@@ -281,6 +289,13 @@ function retireMiddleware(baseDir: string): Connect.NextHandleFunction {
         res.statusCode = 400;
         res.setHeader("Content-Type", "application/json");
         res.end(JSON.stringify({ ok: false, error: "Missing assistantId" }));
+        return;
+      }
+
+      if (!isActiveAssistant(lockfilePaths, assistantId)) {
+        res.statusCode = 403;
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify({ ok: false, error: "Can only retire the active local assistant" }));
         return;
       }
 
@@ -317,7 +332,7 @@ function wakeMiddleware(baseDir: string): Connect.NextHandleFunction {
     if (req.url !== "/assistant/__local/wake" && req.url !== "/__local/wake")
       return next();
 
-    if (rejectUnlessLoopback(req, res)) return;
+    if (rejectUnlessLocalEndpointRequest(req, res)) return;
 
     if (req.method !== "POST") {
       res.statusCode = 405;
@@ -393,7 +408,7 @@ function guardianTokenMiddleware(
       return;
     }
 
-    if (rejectUnlessLoopback(req, res)) return;
+    if (rejectUnlessLocalEndpointRequest(req, res)) return;
 
     const assistantId = decodeURIComponent(match[1]!);
 
@@ -435,7 +450,7 @@ function gatewayProxyMiddleware(
     );
     if (decision.kind === "pass") return next();
 
-    if (rejectUnlessLoopback(req, res)) return;
+    if (rejectUnlessLocalEndpointRequest(req, res)) return;
 
     if (decision.kind === "invalid-port") {
       res.statusCode = 400;

--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -27,6 +27,7 @@ import {
   getLockfileData,
   upsertLockfileAssistant,
   replacePlatformAssistants,
+  isActiveAssistant,
   runHatch,
   runRetire,
   getGuardianAccessToken,
@@ -34,6 +35,8 @@ import {
   resolveGatewayProxyTarget,
   readAllowedGatewayPorts,
   isLoopbackAddr,
+  headerHostIsLoopback,
+  originIsAllowed,
   resolveDevCliInvocation,
   resolveLockfilePaths,
   resolveConfigDir,
@@ -384,6 +387,13 @@ async function handleLocalEndpoints(
     return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 
+  if (
+    !headerHostIsLoopback(req.headers.get("host") ?? undefined) ||
+    !originIsAllowed(req.headers.get("origin") ?? undefined)
+  ) {
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+
   // Lockfile
   if (LOCKFILE_PATTERN.test(pathname)) {
     if (req.method === "GET") {
@@ -487,6 +497,13 @@ async function handleLocalEndpoints(
       return Response.json(
         { ok: false, error: "Missing assistantId" },
         { status: 400 },
+      );
+    }
+
+    if (!isActiveAssistant(lockfilePaths, assistantId)) {
+      return Response.json(
+        { ok: false, error: "Can only retire the active local assistant" },
+        { status: 403 },
       );
     }
 

--- a/packages/local-mode/src/__tests__/loopback-auth.test.ts
+++ b/packages/local-mode/src/__tests__/loopback-auth.test.ts
@@ -1,0 +1,88 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { headerHostIsLoopback, originIsAllowed } from "../util";
+import { isActiveAssistant } from "../lockfile";
+
+describe("headerHostIsLoopback", () => {
+  test("rejects DNS-rebound hosts", () => {
+    expect(headerHostIsLoopback("attacker.example")).toBe(false);
+    expect(headerHostIsLoopback("evil.com:3000")).toBe(false);
+  });
+
+  test("accepts loopback hosts", () => {
+    expect(headerHostIsLoopback("127.0.0.1:3000")).toBe(true);
+    expect(headerHostIsLoopback("localhost:3000")).toBe(true);
+    expect(headerHostIsLoopback("localhost")).toBe(true);
+    expect(headerHostIsLoopback("[::1]:3000")).toBe(true);
+  });
+
+  test("rejects undefined/empty", () => {
+    expect(headerHostIsLoopback(undefined)).toBe(false);
+    expect(headerHostIsLoopback("")).toBe(false);
+  });
+});
+
+describe("originIsAllowed", () => {
+  test("rejects cross-origin requests", () => {
+    expect(originIsAllowed("https://attacker.example")).toBe(false);
+    expect(originIsAllowed("http://evil.com")).toBe(false);
+  });
+
+  test("accepts localhost origins", () => {
+    expect(originIsAllowed("http://localhost:3000")).toBe(true);
+    expect(originIsAllowed("http://127.0.0.1:3000")).toBe(true);
+  });
+
+  test("allows absent origin (non-browser clients)", () => {
+    expect(originIsAllowed(undefined)).toBe(true);
+  });
+});
+
+describe("isActiveAssistant", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function makeTempDir(): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "vellum-local-mode-test-"));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  test("returns true for the active assistant", () => {
+    const dir = makeTempDir();
+    const lockfilePath = path.join(dir, "lockfile.json");
+    fs.writeFileSync(
+      lockfilePath,
+      JSON.stringify({
+        assistants: [{ assistantId: "active" }, { assistantId: "inactive" }],
+        activeAssistant: "active",
+      }),
+    );
+    expect(isActiveAssistant([lockfilePath], "active")).toBe(true);
+  });
+
+  test("returns false for a non-active assistant", () => {
+    const dir = makeTempDir();
+    const lockfilePath = path.join(dir, "lockfile.json");
+    fs.writeFileSync(
+      lockfilePath,
+      JSON.stringify({
+        assistants: [{ assistantId: "active" }, { assistantId: "inactive" }],
+        activeAssistant: "active",
+      }),
+    );
+    expect(isActiveAssistant([lockfilePath], "inactive")).toBe(false);
+  });
+
+  test("returns false when lockfile does not exist", () => {
+    expect(isActiveAssistant(["/nonexistent/lockfile.json"], "any")).toBe(false);
+  });
+});

--- a/packages/local-mode/src/index.ts
+++ b/packages/local-mode/src/index.ts
@@ -9,6 +9,8 @@
 export {
   stripSensitiveFields,
   isLoopbackAddr,
+  headerHostIsLoopback,
+  originIsAllowed,
   resolveDevCliInvocation,
 } from "./util";
 export type { CliInvocation } from "./util";
@@ -19,6 +21,7 @@ export {
   getLockfileData,
   upsertLockfileAssistant,
   replacePlatformAssistants,
+  isActiveAssistant,
 } from "./lockfile";
 export type { LockfileResult, WriteResult } from "./lockfile";
 export { parseLockfile } from "./lockfile-contract";

--- a/packages/local-mode/src/lockfile.ts
+++ b/packages/local-mode/src/lockfile.ts
@@ -88,6 +88,21 @@ export function upsertLockfileAssistant(
   return { ok: true, lockfile: parseLockfile(stripped) };
 }
 
+export function isActiveAssistant(
+  lockfilePaths: string[],
+  assistantId: string,
+): boolean {
+  for (const candidate of lockfilePaths) {
+    try {
+      const data = JSON.parse(fs.readFileSync(candidate, "utf-8")) as Record<string, unknown>;
+      return data.activeAssistant === assistantId;
+    } catch {
+      continue;
+    }
+  }
+  return false;
+}
+
 export function replacePlatformAssistants(
   lockfilePaths: string[],
   platformAssistants: Array<Record<string, unknown>>,

--- a/packages/local-mode/src/util.ts
+++ b/packages/local-mode/src/util.ts
@@ -42,6 +42,39 @@ export function stripSensitiveFields(data: Record<string, unknown>): void {
   }
 }
 
+function isLoopbackHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  return (
+    normalized === "localhost" ||
+    normalized === "[::1]" ||
+    normalized === "::1" ||
+    normalized === "0:0:0:0:0:0:0:1" ||
+    /^127(?:\.\d{1,3}){3}$/.test(normalized)
+  );
+}
+
+export function headerHostIsLoopback(hostHeader: string | undefined): boolean {
+  if (!hostHeader) return false;
+  try {
+    return isLoopbackHostname(new URL(`http://${hostHeader}`).hostname);
+  } catch {
+    return false;
+  }
+}
+
+export function originIsAllowed(originHeader: string | undefined): boolean {
+  if (!originHeader) return true;
+  try {
+    const origin = new URL(originHeader);
+    return (
+      (origin.protocol === "http:" || origin.protocol === "https:") &&
+      isLoopbackHostname(origin.hostname)
+    );
+  } catch {
+    return false;
+  }
+}
+
 export function isLoopbackAddr(addr: string): boolean {
   const v4Mapped = addr.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i);
   const normalized = v4Mapped ? v4Mapped[1]! : addr;


### PR DESCRIPTION
## Summary
- Add `headerHostIsLoopback()` and `originIsAllowed()` validators to the shared `@vellumai/local-mode` package and apply them to all `__local`/`__gateway` endpoints on both the Bun (`cli/src/commands/client.ts`) and Vite (`apps/web/vite-plugin-local-mode.ts`) hosts, blocking DNS rebinding and cross-origin browser attacks
- Add `isActiveAssistant()` check to the retire endpoint on both hosts, restoring the active-assistant restriction that was removed during the shared-module extraction — prevents retiring arbitrary assistants via a browser-originated request
- Add unit tests for the new Host, Origin, and active-assistant validation helpers

Codex finding: https://chatgpt.com/codex/cloud/security/findings/4cad2bb45dbc819184b8c0dd3779df23

## Original prompt
A Codex security scan identified that `__local` and `__gateway` endpoints on both the Bun and Vite local web servers authorize requests solely by checking that the TCP peer IP is loopback, without validating Host, Origin, or CSRF tokens. This allows DNS rebinding attacks from malicious web pages to steal guardian access tokens, read lockfile metadata, proxy gateway requests, and retire assistants. The proposed Codex patch was outdated (pre-extraction into `@vellumai/local-mode`) and only covered the Vite side, so we re-implemented the fix against the current codebase covering both hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)