### PR TITLE
fix(web): lock pro-onboarding welcome card against accidental dismissal

### DIFF
--- a/apps/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/apps/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -113,9 +113,22 @@ export function BillingOnboardingModal({
     }
   }, [domainSetupAvailable]);
 
+  // The welcome card is the user's first real touchpoint with the flow; we lock
+  // it so an accidental backdrop click or Esc can't bail them out of setup. The
+  // explicit X (shown only here) is the deliberate exit, and the card's copy
+  // tells them they can opt into these features later from Settings.
+  const isFirstCard = step === "welcome";
+
   return (
     <Modal.Root open={open} onOpenChange={(o) => { if (!o) onClose(); }}>
-      <Modal.Content size="md" hideCloseButton className="overflow-hidden">
+      <Modal.Content
+        size="md"
+        hideCloseButton={!isFirstCard}
+        dismissOnOverlayClick={!isFirstCard}
+        onEscapeKeyDown={isFirstCard ? (e) => e.preventDefault() : undefined}
+        onInteractOutside={isFirstCard ? (e) => e.preventDefault() : undefined}
+        className="overflow-hidden"
+      >
         {renderStep()}
       </Modal.Content>
     </Modal.Root>

--- a/apps/web/src/domains/settings/billing/pro-onboarding/welcome-state.tsx
+++ b/apps/web/src/domains/settings/billing/pro-onboarding/welcome-state.tsx
@@ -80,6 +80,14 @@ export function WelcomeState({
           Get started
         </Button>
       </div>
+
+      <p
+        className="relative mt-6 max-w-[320px] text-body-small-default text-[var(--content-tertiary)]"
+        style={{ animation: "welcome-reveal 600ms ease-out 600ms both" }}
+      >
+        This quick setup gets your Pro features ready to go. You can close it
+        anytime and turn these features on later from Settings.
+      </p>
     </div>
   );
 }

--- a/packages/design-library/src/components/modal.tsx
+++ b/packages/design-library/src/components/modal.tsx
@@ -63,6 +63,12 @@ interface ModalContentProps extends ComponentProps<typeof Dialog.Content> {
   size?: ModalSize;
   hideCloseButton?: boolean;
   overlayClassName?: string;
+  /**
+   * When `false`, clicking the overlay backdrop no longer dismisses the modal.
+   * Pair with Radix's `onInteractOutside`/`onEscapeKeyDown` (passed through to
+   * `Dialog.Content`) to make a modal fully non-dismissible. Defaults to `true`.
+   */
+  dismissOnOverlayClick?: boolean;
   children?: ReactNode;
 }
 
@@ -70,6 +76,7 @@ function Content({
   size = "md",
   hideCloseButton = false,
   overlayClassName,
+  dismissOnOverlayClick = true,
   className,
   children,
   ref,
@@ -86,6 +93,7 @@ function Content({
           overlayClassName,
         )}
         onClick={(e) => {
+          if (!dismissOnOverlayClick) return;
           if (e.target === e.currentTarget) onOpenChange?.(false);
         }}
       >


### PR DESCRIPTION
## Summary
- On the pro onboarding flow's first card (`welcome`), block accidental dismissal via backdrop click, Esc, and pointer-outside — the only exit is now an explicit close (X) button, which previously was hidden on every step.
- Add always-visible helper copy on the welcome card explaining the user is starting setup and can close anytime and turn these features on later from Settings (verified the General settings page exposes the same storage/compute `ResizeCard` used in onboarding).
- Add an additive, backwards-compatible `dismissOnOverlayClick` prop to the shared `Modal` primitive to gate the hardcoded overlay backdrop-click dismiss; all other steps and existing modal usages are unchanged.

## Original prompt
Change the first card of the pro plan onboarding flow so the user cannot click out of the modal on that card only. Add text making clear they're about to go through onboarding and that if they quit they can opt into those features later from the general settings page. Add a close button on that first card if one doesn't exist (it didn't — the X was hidden on all steps). Decisions confirmed: block both backdrop and Esc, copy always visible on the card, and the X shown on the first card only.