### PR TITLE
fix(security): use requester principal for queued host proxy dispatch

### DIFF
--- a/assistant/src/__tests__/conversation-process-app-control-preactivation.test.ts
+++ b/assistant/src/__tests__/conversation-process-app-control-preactivation.test.ts
@@ -185,6 +185,7 @@ function makeQueuedMessage(opts: {
   requestId: string;
   content?: string;
   turnInterfaceContext?: TurnInterfaceContext;
+  sourceActorPrincipalId?: string;
 }): QueuedMessage {
   return {
     content: opts.content ?? "follow up",
@@ -194,6 +195,10 @@ function makeQueuedMessage(opts: {
     metadata: {},
     sentAt: Date.now(),
     turnInterfaceContext: opts.turnInterfaceContext,
+    sourceActorPrincipalId: opts.sourceActorPrincipalId,
+    authContext: opts.sourceActorPrincipalId
+      ? ({ actorPrincipalId: opts.sourceActorPrincipalId } as never)
+      : undefined,
   };
 }
 
@@ -332,6 +337,7 @@ describe("drainQueue preactivation re-add for host-proxy interfaces", () => {
       makeQueuedMessage({
         requestId: "req-web-1",
         turnInterfaceContext: ifCtx,
+        sourceActorPrincipalId: "user-1",
       }),
     );
     const ctx = makeFakeContext({ queue, turnInterfaceContext: ifCtx });
@@ -344,6 +350,39 @@ describe("drainQueue preactivation re-add for host-proxy interfaces", () => {
     expect(ctx.preactivatedSkillIdCalls).toContain("app-control");
     expect(ctx.preactivatedSkillIds).toContain("app-control");
     expect(ctx.preactivatedSkillIdCalls).toContain("computer-use");
+  });
+
+  test("drainSingleMessage filters cross-client preactivation by the queued requester, not guardian owner", async () => {
+    mockCapabilityClients = [
+      { clientId: "owner-macos-client", actorPrincipalId: "owner-user" },
+    ];
+    const queue = new MessageQueue();
+    const ifCtx: TurnInterfaceContext = {
+      userMessageInterface: "web",
+      assistantMessageInterface: "web",
+    };
+    queue.push(
+      makeQueuedMessage({
+        requestId: "req-web-attacker",
+        turnInterfaceContext: ifCtx,
+        sourceActorPrincipalId: "trusted-contact-user",
+      }),
+    );
+    const ctx = makeFakeContext({ queue, turnInterfaceContext: ifCtx });
+    ctx.trustContext = {
+      trustClass: "trusted_contact",
+      guardianPrincipalId: "owner-user",
+      sourceChannel: "vellum",
+    };
+
+    await drainQueue(ctx);
+
+    expect(ctx.preactivatedSkillIdCalls).not.toContain("computer-use");
+    expect(ctx.preactivatedSkillIdCalls).not.toContain("app-control");
+    expect(ctx.currentTurnAuthContext?.actorPrincipalId).toBe(
+      "trusted-contact-user",
+    );
+    expect(ctx.currentTurnSourceActorPrincipalId).toBe("trusted-contact-user");
   });
 
   test("drainSingleMessage does NOT re-add 'app-control' for web-sourced message when no capable client is connected", async () => {
@@ -380,6 +419,7 @@ describe("drainQueue preactivation re-add for host-proxy interfaces", () => {
       makeQueuedMessage({
         requestId: "req-web-3",
         turnInterfaceContext: ifCtx,
+        sourceActorPrincipalId: "user-1",
       }),
     );
     const ctx = makeFakeContext({ queue, turnInterfaceContext: ifCtx });

--- a/assistant/src/__tests__/conversation-surfaces-app-control.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-app-control.test.ts
@@ -73,6 +73,7 @@ function buildMockContext(
     proxy: InstanceType<typeof HostAppControlProxy> | undefined,
   ) => void,
   trustGuardianPrincipalId: string | null = DEFAULT_PRINCIPAL,
+  actorPrincipalId: string | null = trustGuardianPrincipalId,
 ): SurfaceConversationContext {
   return {
     conversationId,
@@ -83,6 +84,16 @@ function buildMockContext(
             trustClass: "guardian",
             guardianPrincipalId: trustGuardianPrincipalId,
           }
+        : undefined,
+    authContext:
+      actorPrincipalId != null
+        ? ({ actorPrincipalId } as SurfaceConversationContext["authContext"])
+        : undefined,
+    currentTurnAuthContext:
+      actorPrincipalId != null
+        ? ({
+            actorPrincipalId,
+          } as SurfaceConversationContext["currentTurnAuthContext"])
         : undefined,
     traceEmitter: { emit: () => {} },
     sendToClient: () => {},
@@ -213,6 +224,39 @@ describe("surfaceProxyResolver — app-control tool routing", () => {
       expect(result.isError).toBe(false);
       expect(result.content).toContain("State: running");
       expect(result.content).toContain("Window observed");
+
+      proxy.dispose();
+    });
+
+    test("app_control_observe rejects owner client when current requester is a trusted contact", async () => {
+      mockHubClients = [
+        {
+          clientId: "owner-client",
+          capabilities: ["host_app_control"],
+          actorPrincipalId: "owner-user",
+        },
+      ];
+      const proxy = new HostAppControlProxy("conv-1");
+      const ctx = buildMockContext(
+        proxy,
+        "conv-1",
+        undefined,
+        "owner-user",
+        "trusted-contact-user",
+      );
+      _setActiveAppControlSession({
+        conversationId: "conv-1",
+        app: "com.example.editor",
+      });
+
+      const result = await surfaceProxyResolver(ctx, "app_control_observe", {
+        tool: "observe",
+        app: "com.example.editor",
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("current actor");
+      expect(sentMessages).toHaveLength(0);
 
       proxy.dispose();
     });

--- a/assistant/src/__tests__/cu-unified-flow.test.ts
+++ b/assistant/src/__tests__/cu-unified-flow.test.ts
@@ -69,6 +69,7 @@ type SurfaceConversationContext =
 function buildMockContext(
   hostCuProxy?: InstanceType<typeof HostCuProxy>,
   trustGuardianPrincipalId: string | null = DEFAULT_PRINCIPAL,
+  actorPrincipalId: string | null = trustGuardianPrincipalId,
 ): SurfaceConversationContext {
   return {
     conversationId: "test-session",
@@ -79,6 +80,16 @@ function buildMockContext(
             trustClass: "guardian",
             guardianPrincipalId: trustGuardianPrincipalId,
           }
+        : undefined,
+    authContext:
+      actorPrincipalId != null
+        ? ({ actorPrincipalId } as SurfaceConversationContext["authContext"])
+        : undefined,
+    currentTurnAuthContext:
+      actorPrincipalId != null
+        ? ({
+            actorPrincipalId,
+          } as SurfaceConversationContext["currentTurnAuthContext"])
         : undefined,
     traceEmitter: { emit: () => {} },
     sendToClient: () => {},
@@ -662,6 +673,31 @@ describe("surfaceProxyResolver — CU tool routing", () => {
       expect(result.content).toContain(
         "Submitting actor does not match the target client's actor",
       );
+      expect(sentMessages).toHaveLength(0);
+    });
+
+    test("rejects untargeted CU dispatch to owner client when current requester is a trusted contact", async () => {
+      sentMessages.length = 0;
+      mockHasClient = true;
+      mockCuClients = [
+        {
+          clientId: "owner-cu-client",
+          capabilities: ["host_cu"],
+          actorPrincipalId: "owner-user",
+        },
+      ];
+      proxy = new HostCuProxy();
+      const ctx = buildMockContext(proxy, "owner-user", "trusted-contact-user");
+
+      const result = await surfaceProxyResolver(ctx, "computer_use_click", {
+        element_id: 1,
+        reasoning: "click",
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("current actor");
+      expect(proxy.stepCount).toBe(0);
+      expect(proxy.actionHistory).toHaveLength(0);
       expect(sentMessages).toHaveLength(0);
     });
 

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -43,6 +43,7 @@ import {
 } from "../messaging/providers/slack/message-metadata.js";
 import type { SecretPrompter } from "../permissions/secret-prompter.js";
 import type { Message } from "../providers/types.js";
+import type { AuthContext } from "../runtime/auth/types.js";
 import { getLogger } from "../util/logger.js";
 import type { MessageQueue } from "./conversation-queue-manager.js";
 import type { SlackInboundMessageMetadata } from "./handlers/shared.js";
@@ -193,6 +194,9 @@ export interface MessagingConversationContext {
   currentRequestId?: string;
   readonly queue: MessageQueue;
   trustContext?: TrustContext;
+  authContext?: AuthContext;
+  currentTurnAuthContext?: AuthContext;
+  currentTurnSourceActorPrincipalId?: string;
   getTurnChannelContext(): TurnChannelContext | null;
   getTurnInterfaceContext(): TurnInterfaceContext | null;
 }
@@ -302,6 +306,10 @@ export interface EnqueueMessageOptions {
   displayContent?: string;
   transport?: ConversationTransportMetadata;
   clientMessageId?: string;
+  /** JWT-verified requester principal captured for queued host-proxy routing. */
+  sourceActorPrincipalId?: string;
+  /** Auth context snapshot captured for queued turn-scoped authorization. */
+  authContext?: AuthContext;
 }
 
 // ── enqueueMessage ───────────────────────────────────────────────────
@@ -322,7 +330,14 @@ export function enqueueMessage(
     displayContent,
     transport,
     clientMessageId,
+    authContext,
   } = options;
+  const queuedAuthContext =
+    authContext ?? ctx.currentTurnAuthContext ?? ctx.authContext;
+  const sourceActorPrincipalId =
+    options.sourceActorPrincipalId ??
+    ctx.currentTurnSourceActorPrincipalId ??
+    queuedAuthContext?.actorPrincipalId;
 
   if (!ctx.isProcessing()) {
     return { queued: false, requestId };
@@ -347,6 +362,8 @@ export function enqueueMessage(
     turnChannelContext,
     turnInterfaceContext,
     isInteractive,
+    sourceActorPrincipalId,
+    authContext: queuedAuthContext,
     transport,
     displayContent,
     sentAt: Date.now(),

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -28,7 +28,6 @@ import {
 } from "../memory/conversation-crud.js";
 import { extractPreferences } from "../notifications/preference-extractor.js";
 import { createPreference } from "../notifications/preferences-store.js";
-import type { AuthContext } from "../runtime/auth/types.js";
 import { routeGuardianReply } from "../runtime/guardian-reply-router.js";
 import { publishConversationMessagesChanged } from "../runtime/sync/resource-sync-events.js";
 import { getLogger } from "../util/logger.js";

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -28,6 +28,7 @@ import {
 } from "../memory/conversation-crud.js";
 import { extractPreferences } from "../notifications/preference-extractor.js";
 import { createPreference } from "../notifications/preferences-store.js";
+import type { AuthContext } from "../runtime/auth/types.js";
 import { routeGuardianReply } from "../runtime/guardian-reply-router.js";
 import { publishConversationMessagesChanged } from "../runtime/sync/resource-sync-events.js";
 import { getLogger } from "../util/logger.js";
@@ -422,6 +423,9 @@ async function drainSingleMessage(
     conversation.applyClientTimezoneFromTransport(next.transport);
   }
 
+  conversation.currentTurnAuthContext = next.authContext;
+  conversation.currentTurnSourceActorPrincipalId = next.sourceActorPrincipalId;
+
   // Re-attach and re-preactivate host-proxy skills for interactive turns.
   // The dequeue path reset `preactivatedSkillIds` above; without these
   // re-adds the relevant skill tools won't be projected to the LLM for
@@ -433,8 +437,7 @@ async function drainSingleMessage(
     const interfaceCtx =
       queuedInterfaceCtx ?? conversation.getTurnInterfaceContext();
     const sourceInterface = interfaceCtx?.userMessageInterface;
-    const sourceActorPrincipalId =
-      conversation.trustContext?.guardianPrincipalId;
+    const sourceActorPrincipalId = next.sourceActorPrincipalId;
     conversation.ensureHostProxiesForTurn(
       sourceInterface,
       sourceActorPrincipalId,
@@ -979,14 +982,16 @@ async function drainBatch(
     conversation.applyClientTimezoneFromTransport(head.transport);
   }
 
+  conversation.currentTurnAuthContext = head.authContext;
+  conversation.currentTurnSourceActorPrincipalId = head.sourceActorPrincipalId;
+
   // Re-attach and re-preactivate host-proxy skills for interactive turns.
   // Mirrors the single-message path exactly — sourced from `head`.
   if (head.isInteractive !== false) {
     const interfaceCtx =
       queuedInterfaceCtx ?? conversation.getTurnInterfaceContext();
     const sourceInterface = interfaceCtx?.userMessageInterface;
-    const sourceActorPrincipalId =
-      conversation.trustContext?.guardianPrincipalId;
+    const sourceActorPrincipalId = head.sourceActorPrincipalId;
     conversation.ensureHostProxiesForTurn(
       sourceInterface,
       sourceActorPrincipalId,
@@ -1380,6 +1385,9 @@ export async function processMessage(
   // Snapshot persona context at turn start so later tool turns can't pick up
   // a different actor's context if a concurrent request mutates the live fields.
   conversation.currentTurnTrustContext = conversation.trustContext;
+  conversation.currentTurnAuthContext = conversation.authContext;
+  conversation.currentTurnSourceActorPrincipalId =
+    conversation.authContext?.actorPrincipalId;
   conversation.currentTurnChannelCapabilities =
     conversation.channelCapabilities;
   conversation.currentActiveSurfaceId = activeSurfaceId;

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -222,6 +222,8 @@ async function buildPassthroughBatch(
     // otherwise diverge.
     if (candIf?.userMessageInterface !== headInterface?.userMessageInterface)
       break;
+    if (candidate.sourceActorPrincipalId !== head.sourceActorPrincipalId)
+      break;
     if (classifySlash(candidate.content) !== "passthrough") break;
     if (
       resolveVerificationSessionIntent(candidate.content).kind ===

--- a/assistant/src/daemon/conversation-queue-manager.ts
+++ b/assistant/src/daemon/conversation-queue-manager.ts
@@ -9,6 +9,7 @@ import type {
   TurnChannelContext,
   TurnInterfaceContext,
 } from "../channels/types.js";
+import type { AuthContext } from "../runtime/auth/types.js";
 import { getLogger } from "../util/logger.js";
 import type {
   ServerMessage,
@@ -30,6 +31,10 @@ export interface QueuedMessage {
   turnInterfaceContext?: TurnInterfaceContext;
   /** When false, the turn has no interactive user and should skip clarification prompts. */
   isInteractive?: boolean;
+  /** Requester identity captured from the verified auth context at enqueue time. */
+  sourceActorPrincipalId?: string;
+  /** Full auth snapshot captured at enqueue time for turn-scoped authorization decisions. */
+  authContext?: AuthContext;
   /** Transport metadata snapshot captured at enqueue time, applied when this message becomes active. */
   transport?: ConversationTransportMetadata;
   /** Original user message text to persist to DB when recording intent stripping produced a different `content`. */
@@ -203,6 +208,9 @@ function estimateItemBytes(item: QueuedMessage): number {
   // payloads (e.g. hostHomeDir, hostUsername) count against the budget.
   if (item.transport) {
     bytes += JSON.stringify(item.transport).length * 2;
+  }
+  if (item.sourceActorPrincipalId) {
+    bytes += item.sourceActorPrincipalId.length * 2;
   }
   // Small fixed overhead for metadata, pointers, etc. (not worth
   // measuring precisely — the content/attachment data dominates).

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -25,6 +25,7 @@ import {
   enforceSameActorOrErrorResult,
   pickSameUserAutoResolve,
 } from "../runtime/auth/same-actor.js";
+import type { AuthContext } from "../runtime/auth/types.js";
 import type {
   InteractiveUiRequest,
   InteractiveUiResult,
@@ -552,6 +553,12 @@ export interface SurfaceConversationContext {
   readonly assistantId?: string;
   /** Inherited to spawned conversations in the `launch_conversation` action path. */
   readonly trustContext?: TrustContext;
+  /** Verified requester auth context for the active turn. */
+  readonly authContext?: AuthContext;
+  /** Per-turn auth snapshot, preferred for tool dispatch authorization. */
+  readonly currentTurnAuthContext?: AuthContext;
+  /** JWT-verified requester principal for the active turn. */
+  readonly currentTurnSourceActorPrincipalId?: string;
   readonly channelCapabilities?: {
     channel: string;
     supportsDynamicUi: boolean;
@@ -2314,7 +2321,10 @@ export async function surfaceProxyResolver(
     // validate at the tool-resolution layer for the same reason. The proxy
     // re-checks same-user (single authoritative gate); using the shared
     // helper keeps log payload and error wording identical at both layers.
-    const sourceActorPrincipalId = ctx.trustContext?.guardianPrincipalId;
+    const sourceActorPrincipalId =
+      ctx.currentTurnSourceActorPrincipalId ??
+      ctx.currentTurnAuthContext?.actorPrincipalId ??
+      ctx.authContext?.actorPrincipalId;
     if (targetClientId != null) {
       const client = assistantEventHub.getClientById(targetClientId);
       if (!client) {
@@ -2420,7 +2430,10 @@ export async function surfaceProxyResolver(
         ? input.target_client_id
         : undefined;
 
-    const sourceActorPrincipalId = ctx.trustContext?.guardianPrincipalId;
+    const sourceActorPrincipalId =
+      ctx.currentTurnSourceActorPrincipalId ??
+      ctx.currentTurnAuthContext?.actorPrincipalId ??
+      ctx.authContext?.actorPrincipalId;
     if (targetClientId != null) {
       const client = assistantEventHub.getClientById(targetClientId);
       if (!client) {

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -273,6 +273,8 @@ export class Conversation {
   /** @internal */ currentTurnOverrideProfile?: string;
   /** @internal */ toolRoutedProfile?: string;
   /** @internal */ authContext?: AuthContext;
+  /** @internal */ currentTurnAuthContext?: AuthContext;
+  /** @internal */ currentTurnSourceActorPrincipalId?: string;
   /** @internal */ loadedHistoryTrustClass?: TrustClass;
   /** @internal */ loadedHistoryPersonalMemoryAllowed?: boolean;
   /** @internal */ voiceCallControlPrompt?: string;
@@ -1361,7 +1363,9 @@ export class Conversation {
 
   ensureHostProxiesForTurn(
     sourceInterface: import("../channels/types.js").InterfaceId | undefined,
-    sourceActorPrincipalId = this.trustContext?.guardianPrincipalId,
+    sourceActorPrincipalId = this.currentTurnSourceActorPrincipalId ??
+      this.currentTurnAuthContext?.actorPrincipalId ??
+      this.authContext?.actorPrincipalId,
   ): void {
     if (
       shouldAttachHostProxyForCapability(

--- a/assistant/src/daemon/process-message.ts
+++ b/assistant/src/daemon/process-message.ts
@@ -195,7 +195,7 @@ async function prepareConversationForMessage(
         "wiring in conversation-routes.ts into a shared helper.",
     );
   }
-  const sourceActorPrincipalId = conversation.trustContext?.guardianPrincipalId;
+  const sourceActorPrincipalId = conversation.authContext?.actorPrincipalId;
   // CU is per-conversation (owns step count, AX tree history, loop detection).
   if (
     shouldAttachHostProxyForCapability(

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1741,6 +1741,7 @@ export async function handleSendMessage(
         ...(body.automated === true ? { automated: true } : {}),
       },
       isInteractive,
+      sourceActorPrincipalId,
       transport,
       clientMessageId,
     });
@@ -1842,6 +1843,7 @@ export async function handleSendMessage(
     userMessageInterface: sourceInterface,
     assistantMessageInterface: sourceInterface,
   });
+  conversation.currentTurnSourceActorPrincipalId = sourceActorPrincipalId;
 
   await conversation.ensureActorScopedHistory();
 


### PR DESCRIPTION
## Summary
- **Captures the JWT-verified requester principal** (`actorPrincipalId`) at message enqueue time and stores it on `QueuedMessage`, so the queue drain paths use the actual requester identity instead of `guardianPrincipalId` (the workspace owner)
- **Fixes tool dispatch** in `conversation-surfaces.ts` (host_cu + host_app_control) and `process-message.ts` to derive `sourceActorPrincipalId` from `currentTurnAuthContext`/`authContext` instead of `trustContext.guardianPrincipalId`
- **Adds per-turn auth snapshots** (`currentTurnAuthContext`, `currentTurnSourceActorPrincipalId`) to the Conversation class, mirroring the existing `currentTurnTrustContext` pattern

Codex finding: https://chatgpt.com/codex/cloud/security/findings/32a59cb493f88191b6f600c8ac959261?q=API+keys+can+trigger+paid+Pro+tier+changes&sev=

## Original prompt
A Codex security scan identified that the same-actor enforcement for host proxy dispatch (added in #32804) used `guardianPrincipalId` instead of the JWT requester principal in several code paths: queued message drain, batch drain, process-message, and tool dispatch. This allowed a trusted contact to trigger host_cu/host_app_control actions on the owner's macOS client by bypassing same-actor checks. The fix aligns all paths with the correct pattern already used in the idle HTTP `/messages` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)