### PR TITLE
fix(memory-v3): a Qdrant outage degrades only the dense lane, not all of v3

### DIFF
--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-plugin.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-plugin.test.ts
@@ -106,6 +106,7 @@ let sectionBuilds = 0;
 let needleBuilds = 0;
 let edgeBuilds = 0;
 let ensureCollectionCalls = 0;
+let ensureCollectionThrows = false;
 
 // The `pageBody` resolver `initLanes` passes to `buildSectionIndex` (its second
 // arg), captured by the stub below so a test can drive it directly: a capability
@@ -291,6 +292,7 @@ mock.module("../section-dense-store.js", () => ({
       return realSectionDenseStore.ensureSectionCollection(...args);
     }
     ensureCollectionCalls++;
+    if (ensureCollectionThrows) throw new Error("qdrant unavailable");
   },
 }));
 
@@ -334,6 +336,7 @@ beforeEach(() => {
   needleBuilds = 0;
   edgeBuilds = 0;
   ensureCollectionCalls = 0;
+  ensureCollectionThrows = false;
   capturedPageBody = null;
   testDb = makeDb();
   resetShadowLanesForTests();
@@ -472,6 +475,19 @@ describe("memory-v3 shadow plugin", () => {
     expect(edgeBuilds).toBe(1);
     expect(ensureCollectionCalls).toBe(1);
     expect(orchestrateSpy).toHaveBeenCalledTimes(3);
+  });
+
+  test("a Qdrant section-collection failure does not disable the in-memory lanes", async () => {
+    shadowEnabled = true;
+    ensureCollectionThrows = true;
+    // initLanes still builds the needle + edge lanes and orchestrate runs — a
+    // Qdrant outage degrades only the dense lane, it does not take down all of v3
+    // (and does not poison the memoized lanes by rejecting init).
+    await runShadowObservation("conv-1", 0);
+    expect(needleBuilds).toBe(1);
+    expect(edgeBuilds).toBe(1);
+    expect(ensureCollectionCalls).toBe(1);
+    expect(orchestrateSpy).toHaveBeenCalledTimes(1);
   });
 
   test("invalidateLanes forces a one-time rebuild on the next turn", async () => {

--- a/assistant/src/plugins/defaults/memory-v3-shadow/shadow-plugin.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/shadow-plugin.ts
@@ -154,7 +154,21 @@ async function initLanes(config: AssistantConfig): Promise<ShadowLanes> {
   const edgeGraph = await buildEdgeGraph(pageIndex.entries, pageRaw, {
     hubDegree: config.memory.v3.edge.hubDegree,
   });
-  await ensureSectionCollection(config);
+  // Ensuring the dense collection is best-effort: the needle + edge lanes and
+  // carry-forward are in-memory and independent of Qdrant, so a Qdrant outage
+  // must NOT reject lane init (which would return `null` from observeTurn and
+  // disable ALL of v3, plus poison the memoized lanes until invalidation). On
+  // failure we log and continue with the dense lane degraded — denseLane already
+  // returns no hits on a Qdrant error, and maintain/backfill re-ensure the
+  // collection once Qdrant recovers.
+  try {
+    await ensureSectionCollection(config);
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "memory-v3: section collection ensure failed; continuing with the dense lane degraded",
+    );
+  }
 
   const workingSet = new WorkingSet(
     config.memory.v3.workingSet.maxPages,


### PR DESCRIPTION
## Summary
- `ensureSectionCollection` in `initLanes` is now best-effort (try/catch + log). Previously a Qdrant outage rejected lane init → `observeTurn` returned null → ALL of v3 (needle, edge, carry-forward, telemetry, live injection) went dark, and the rejected promise poisoned the memoized lanes until invalidation. The needle/edge lanes and carry-forward are in-memory and independent of Qdrant; the dense lane already degrades to no hits on a Qdrant error, and maintain/backfill re-ensure the collection on recovery. Matches the daemon 'degrade, don't block' philosophy.

Addresses Codex P2 on #33874. Follow-up to plan: memory-v3-section-lanes.md