### PR TITLE
feat: activation flow as multivariate control/variant-a cohort (JARVIS-1033)

### DIFF
--- a/apps/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
+++ b/apps/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
@@ -1,20 +1,20 @@
 import {
-    cleanup,
-    fireEvent,
-    render,
-    screen,
-    waitFor,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { useEffect, useState, type ReactNode } from "react";
 
 import {
-    DEFAULT_PRECHAT_INITIAL_MESSAGE,
-    STORAGE_KEY,
+  DEFAULT_PRECHAT_INITIAL_MESSAGE,
+  STORAGE_KEY,
 } from "@/domains/onboarding/prechat";
 import {
-    ACTIVATION_FLOW_COHORT,
-    ACTIVATION_RAIL_BOOTSTRAP_TEMPLATE,
+  ACTIVATION_FLOW_COHORT,
+  ACTIVATION_RAIL_BOOTSTRAP_TEMPLATE,
 } from "@/domains/onboarding/prechat-context";
 import type { PlatformSessionStatus } from "@/stores/session-status";
 import { routes } from "@/utils/routes";
@@ -62,7 +62,7 @@ type TestOnboardingRecipe = {
 };
 
 let preChatOnboardingExperiment = "variant-a";
-let activationFlowExperiment = false;
+let activationFlowExperiment = "control";
 let selfIntroGreeting = true;
 let isIOSWeb = false;
 let isMacOSWeb = false;
@@ -208,8 +208,8 @@ mock.module("@/stores/client-feature-flag-store", () => ({
     use: {
       stringFlags: () => ({
         preChatOnboardingExperiment20260606: preChatOnboardingExperiment,
+        experimentActivationFlow20260603: activationFlowExperiment,
       }),
-      experimentActivationFlow20260603: () => activationFlowExperiment,
       selfIntroGreeting: () => selfIntroGreeting,
     },
   },
@@ -326,17 +326,20 @@ mock.module("@/domains/onboarding/screens/tool-selection-screen", () => ({
   ),
 }));
 
-mock.module("@/domains/onboarding/screens/prior-assistant-selection-screen", () => ({
-  PriorAssistantSelectionScreen: ({
-    onContinue,
-  }: {
-    onContinue: () => void;
-  }) => (
-    <button type="button" data-testid="prior-continue" onClick={onContinue}>
-      prior assistants
-    </button>
-  ),
-}));
+mock.module(
+  "@/domains/onboarding/screens/prior-assistant-selection-screen",
+  () => ({
+    PriorAssistantSelectionScreen: ({
+      onContinue,
+    }: {
+      onContinue: () => void;
+    }) => (
+      <button type="button" data-testid="prior-continue" onClick={onContinue}>
+        prior assistants
+      </button>
+    ),
+  }),
+);
 
 mock.module("@/domains/onboarding/screens/get-ios-app-screen", () => ({
   GetIOSAppScreen: ({ onComplete }: { onComplete: () => void }) => (
@@ -346,18 +349,16 @@ mock.module("@/domains/onboarding/screens/get-ios-app-screen", () => ({
   ),
 }));
 
-const { HatchingScreen } = await import(
-  "@/domains/onboarding/pages/hatching-screen"
-);
-const { PreChatFlow } = await import(
-  "@/domains/onboarding/pages/pre-chat-flow"
-);
+const { HatchingScreen } =
+  await import("@/domains/onboarding/pages/hatching-screen");
+const { PreChatFlow } =
+  await import("@/domains/onboarding/pages/pre-chat-flow");
 
 beforeEach(() => {
   searchParams = new URLSearchParams();
   checkAssistantImpl = async () => {};
   preChatOnboardingExperiment = "variant-a";
-  activationFlowExperiment = false;
+  activationFlowExperiment = "control";
   selfIntroGreeting = true;
   isIOSWeb = false;
   isMacOSWeb = false;
@@ -465,7 +466,7 @@ describe("onboarding lifecycle sync", () => {
   });
 
   test("activation flow flag selects the activation bootstrap after pre-chat", async () => {
-    activationFlowExperiment = true;
+    activationFlowExperiment = "variant-a";
 
     render(<PreChatFlow />);
 

--- a/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
+++ b/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
@@ -1,10 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useState,
-} from "react";
+import { useCallback, useEffect, useLayoutEffect, useState } from "react";
 import { useNavigate } from "react-router";
 
 import { useIsIOSWeb } from "@/runtime/platform-detection";
@@ -48,10 +43,7 @@ import {
   sampleSuggestionNames,
 } from "@/domains/onboarding/prechat-names";
 import { GOOGLE_TOOL_IDS } from "@/domains/onboarding/prechat-tools";
-import {
-  readAiDataConsent,
-  readTosAccepted,
-} from "@/domains/onboarding/prefs";
+import { readAiDataConsent, readTosAccepted } from "@/domains/onboarding/prefs";
 import {
   getPlatformAssistants,
   getSelectedAssistant,
@@ -88,15 +80,17 @@ export function PreChatFlow() {
   const firstName = user?.firstName ?? "";
   const lastName = user?.lastName ?? "";
   const isNative = useIsNativePlatform();
-  const activeAssistantId =
-    useResolvedAssistantsStore.use.activeAssistantId();
+  const activeAssistantId = useResolvedAssistantsStore.use.activeAssistantId();
   const localMode = isLocalMode();
   const isIOSWeb = useIsIOSWeb();
   const showIOSAppStep = isIOSWeb && !readIOSAppDownloaded();
   const preChatExperimentArm =
-    useClientFeatureFlagStore.use.stringFlags().preChatOnboardingExperiment20260606 ?? "control";
-  const activationFlowEnabled =
-    useClientFeatureFlagStore.use.experimentActivationFlow20260603();
+    useClientFeatureFlagStore.use.stringFlags()
+      .preChatOnboardingExperiment20260606 ?? "control";
+  const activationFlowArm =
+    useClientFeatureFlagStore.use.stringFlags()
+      .experimentActivationFlow20260603 ?? "control";
+  const activationFlowEnabled = activationFlowArm === "variant-a";
   const selfIntroGreetingEnabled =
     useClientFeatureFlagStore.use.selfIntroGreeting();
   const preferredFunnelVariant =
@@ -138,7 +132,9 @@ export function PreChatFlow() {
   useLayoutEffect(() => {
     if (!screenStorageKey) return;
     try {
-      const restored = restoreNativeStep(sessionStorage.getItem(screenStorageKey));
+      const restored = restoreNativeStep(
+        sessionStorage.getItem(screenStorageKey),
+      );
       if (restored) setCurrentStep(restored);
     } catch {
       // sessionStorage can throw under privacy modes — ignore.
@@ -170,8 +166,8 @@ export function PreChatFlow() {
     localMode && !hasPlatformSession ? "" : firstName || lastName,
   );
   const [selectedGroupId, setSelectedGroupId] = useState<string | null>(null);
-  const [displayedAssistantNames] = useState<string[]>(
-    () => sampleSuggestionNames(),
+  const [displayedAssistantNames] = useState<string[]>(() =>
+    sampleSuggestionNames(),
   );
   const [assistantName, setAssistantName] = useState<string>("");
   const [googleConnected, setGoogleConnected] = useState(false);
@@ -180,7 +176,9 @@ export function PreChatFlow() {
   const { data: activeAssistant } = useQuery({
     ...assistantsActiveRetrieveOptions(),
     enabled:
-      !isAuthInitializing && isAuthenticated && (!localMode || hasPlatformSession),
+      !isAuthInitializing &&
+      isAuthenticated &&
+      (!localMode || hasPlatformSession),
   });
   // The onboarding recipe is platform-only marketing-funnel data, resolved on
   // the platform from a UTM attribution cookie. Native and local runtimes have
@@ -226,8 +224,7 @@ export function PreChatFlow() {
     }
     return {
       userId,
-      decision:
-        readTosAccepted() && readAiDataConsent() ? "ok" : "missing",
+      decision: readTosAccepted() && readAiDataConsent() ? "ok" : "missing",
     };
   });
   const consentDecision = consent.decision;
@@ -236,8 +233,7 @@ export function PreChatFlow() {
     if (consent.userId === userId && consent.decision !== "pending") return;
     setConsent({
       userId,
-      decision:
-        readTosAccepted() && readAiDataConsent() ? "ok" : "missing",
+      decision: readTosAccepted() && readAiDataConsent() ? "ok" : "missing",
     });
   }, [consent, isAuthInitializing, isAuthenticated, userId]);
 
@@ -265,10 +261,7 @@ export function PreChatFlow() {
   const consentReady = isNative || consentDecision === "ok";
   const recipeReady = !recipeLoading;
   const shouldHidePrechat =
-    isAuthInitializing ||
-    !isAuthenticated ||
-    !consentReady ||
-    !recipeReady;
+    isAuthInitializing || !isAuthenticated || !consentReady || !recipeReady;
 
   function emitWebFunnelStep(
     step: (typeof ONBOARDING_FUNNEL_STEPS)[keyof typeof ONBOARDING_FUNNEL_STEPS],

--- a/apps/web/src/lib/feature-flags/feature-flag-catalog.test.ts
+++ b/apps/web/src/lib/feature-flags/feature-flag-catalog.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   ASSISTANT_FLAG_DEFAULTS,
   CLIENT_FLAG_DEFAULTS,
+  CLIENT_STRING_FLAG_DEFAULTS,
 } from "@/lib/feature-flags/feature-flag-catalog";
 
 describe("feature flag catalog", () => {
@@ -11,10 +12,15 @@ describe("feature flag catalog", () => {
     expect(ASSISTANT_FLAG_DEFAULTS.selfIntroGreeting).toBe(false);
   });
 
-  test("exposes the activation flow experiment as a client flag", () => {
-    expect(CLIENT_FLAG_DEFAULTS.experimentActivationFlow20260603).toBe(false);
+  test("exposes the activation flow experiment as a client string flag", () => {
+    expect(CLIENT_STRING_FLAG_DEFAULTS.experimentActivationFlow20260603).toBe(
+      "control",
+    );
+    expect("experimentActivationFlow20260603" in CLIENT_FLAG_DEFAULTS).toBe(
+      false,
+    );
     expect("experimentActivationFlow20260603" in ASSISTANT_FLAG_DEFAULTS).toBe(
-      false
+      false,
     );
   });
 

--- a/apps/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/apps/web/src/lib/feature-flags/feature-flag-registry.json
@@ -39,8 +39,9 @@
       "scope": "client",
       "key": "experiment-activation-flow-2026-06-03",
       "label": "Activation Flow Experiment 2026-06-03",
-      "description": "Route allowlisted users to the activation-rail bootstrap template after pre-chat. Off by default and targeted through LaunchDarkly.",
-      "defaultEnabled": false
+      "description": "Multivariate activation-flow experiment. control = standard flow; variant-a = activation rail. Targeted via LaunchDarkly.",
+      "defaultEnabled": "control",
+      "values": ["control", "variant-a"]
     },
     {
       "id": "local-docker-enabled",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -39,8 +39,9 @@
       "scope": "client",
       "key": "experiment-activation-flow-2026-06-03",
       "label": "Activation Flow Experiment 2026-06-03",
-      "description": "Route allowlisted users to the activation-rail bootstrap template after pre-chat. Off by default and targeted through LaunchDarkly.",
-      "defaultEnabled": false
+      "description": "Multivariate activation-flow experiment. control = standard flow; variant-a = activation rail. Targeted via LaunchDarkly.",
+      "defaultEnabled": "control",
+      "values": ["control", "variant-a"]
     },
     {
       "id": "local-docker-enabled",


### PR DESCRIPTION
## Summary
Converts `experiment-activation-flow-2026-06-03` from a boolean gate to a multivariate `control`/`variant-a` cohort flag (mirrors `pre-chat-onboarding-experiment-2026-06-06`). Registry → defaultEnabled "control" + values; pre-chat-flow reads the string arm (`activationFlowEnabled = arm === "variant-a"`); tests updated.

JARVIS-1033.

## ⚠️ MERGE ORDERING (important)
Do NOT merge until the LaunchDarkly flag is actually multivariate (the companion vellum-assistant-platform terraform PR is applied / the LD flag is recreated with string variations). If the client reads this as a string flag while LD still serves a boolean `false`, the value routes to boolFlags, `stringFlags()` is undefined, and it falls to `control` → the rail turns off for everyone. Land the LD flag conversion first.