### PR TITLE
fix(assistant): clarify bundled skills are always installed in skill_load description (JARVIS-1100)

### DIFF
--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -128,7 +128,7 @@ export const skillLoadTool = {
   name: "skill_load",
 
   description:
-    'Load full instructions for a skill. Works for both bundled skills (listed in the catalog) and custom workspace skills. Bundled/first-party skills (like `app-builder`) are ALWAYS installed and available — loading only brings their instructions into the current conversation, since skills unload between turns. Never tell a user a bundled skill is "not installed" or offer to install it; just load it. For app, website, dashboard, game, calculator, tracker, visualization, or interactive tool requests, load `app-builder` with `skill: "app-builder"`.',
+    'Load full instructions for a skill. Works for both bundled skills (listed in the catalog) and custom workspace skills. Bundled/first-party skills (like `app-builder`) are already installed — loading only activates their instructions for the current conversation, since skills unload between turns; treat "load" as activation, not installation, and don\'t tell users a bundled skill needs installing. Loading can still fail (e.g. a feature-gated skill returns "currently unavailable", or the load errors) — if it does, relay that specific error rather than claiming the skill is not installed or offering to install it. For app, website, dashboard, game, calculator, tracker, visualization, or interactive tool requests, load `app-builder` with `skill: "app-builder"`.',
 
   category: "skills",
 

--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -128,7 +128,7 @@ export const skillLoadTool = {
   name: "skill_load",
 
   description:
-    'Load full instructions for a skill. Works for both bundled skills (listed in the catalog) and custom workspace skills. For app, website, dashboard, game, calculator, tracker, visualization, or interactive tool requests, load `app-builder` with `skill: "app-builder"`.',
+    'Load full instructions for a skill. Works for both bundled skills (listed in the catalog) and custom workspace skills. Bundled/first-party skills (like `app-builder`) are ALWAYS installed and available — loading only brings their instructions into the current conversation, since skills unload between turns. Never tell a user a bundled skill is "not installed" or offer to install it; just load it. For app, website, dashboard, game, calculator, tracker, visualization, or interactive tool requests, load `app-builder` with `skill: "app-builder"`.',
 
   category: "skills",
 


### PR DESCRIPTION
## Summary
- Ava told a user the bundled `app-builder` skill was "not installed" and offered to install it, then corrected itself. Root cause is **not** a data/logic bug — bundled skills are correctly treated as installed everywhere (`loadSkillCatalog` includes them, `listSkillsWithCatalog` classifies them as installed, capability seeding skips them). The model conflated "not currently **loaded** this turn" (bundled skills unload between turns and need `skill_load`) with "not **installed**."
- Fix is model-facing wording only: the `skill_load` tool description now states bundled/first-party skills are always installed and available, that loading just pulls their instructions into the current conversation, and that the assistant must never tell a user a bundled skill is "not installed" or offer to install it.

## Original prompt
While triaging an app-builder bug cluster, JARVIS-1100 reported Ava misclassifying the bundled app-builder skill as uninstalled. Investigation confirmed the install/catalog/capability data is all correct, so the issue is the model conflating load-vs-install — fixed by tightening the `skill_load` tool description. Scope kept to wording; no changes to skill install/load logic, catalog, or capability seeding.