### PR TITLE
fix(macos): add disable-library-validation entitlement for hardened runtime

### DIFF
--- a/apps/macos/scripts/entitlements/app.plist
+++ b/apps/macos/scripts/entitlements/app.plist
@@ -6,6 +6,8 @@
     <true/>
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
     <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
     <key>com.apple.security.network.client</key>
     <true/>
     <key>com.apple.security.network.server</key>

--- a/apps/macos/scripts/entitlements/bun.plist
+++ b/apps/macos/scripts/entitlements/bun.plist
@@ -6,6 +6,8 @@
     <true/>
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
     <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
     <key>com.apple.security.network.client</key>
     <true/>
     <key>com.apple.security.network.server</key>

--- a/apps/macos/scripts/entitlements/inherit.plist
+++ b/apps/macos/scripts/entitlements/inherit.plist
@@ -6,5 +6,7 @@
     <true/>
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
     <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Problem

Launching the packaged macOS app crashes immediately with a DYLD error:

```
Library not loaded: @rpath/Electron Framework.framework/Electron Framework
Reason: ... not valid for use in process:
mapping process and mapped file (non-platform) have different Team IDs
```

This is **code-signing / Library Validation**, not a missing file. The app is signed with `hardenedRuntime: true`, which enables Library Validation — every library loaded into a process must share the app's Team ID or be Apple-signed. The entitlement files were missing `com.apple.security.cs.disable-library-validation` (which Electron ships by default), breaking two things:

1. **Launch crash (dev builds).** Local self-signed builds use a cert with *no* Team ID, so the Electron Framework and helper processes fail Library Validation and dyld aborts at launch. `codesign --verify` passes statically because it doesn't evaluate the library-validation policy — only the runtime loader does.

2. **Latent production failure.** The bundled `bun` runtime installs the `vellum` daemon at runtime via `bun add`, pulling **ad-hoc-signed native addons** (`fsevents`, `@resvg/resvg-js`, `tree-sitter-bash` — confirmed `flags=0x20002(adhoc,linker-signed)`, `TeamIdentifier=not set`). In a production build signed with a real Developer ID, Library Validation in the hardened `bun` process would block these — a failure that only surfaces once properly signed.

## Fix

Add `com.apple.security.cs.disable-library-validation` to all three entitlement files:

| File | Process | Fixes |
|---|---|---|
| `app.plist` | main Vellum process | Electron Framework load crash |
| `inherit.plist` | Helper (Renderer/GPU/Plugin) | follow-on helper crashes |
| `bun.plist` | bundled `bun` runtime | daemon's ad-hoc native addons |

The entitlement is permitted under hardened runtime and does not affect notarization. This matches Electron's default `entitlements.mac.plist`.

## Verification

Clean `electron-builder` rebuild (no manual re-sign), signed with `Vellum Local Development`:
- Entitlement embedded in main binary, `bun`, and helpers ✅
- App + all helper processes (`Vellum Helper`, `… (Renderer)`, `bun`) launch with **zero DYLD/Team-ID errors** ✅
- `codesign --verify --deep --strict` → exit 0, "valid on disk" ✅
- App reached normal startup; stable after 30s ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)