### PR TITLE
fix(macos): harden runtime CLI install — lockfile pinning + suppress lifecycle scripts (ATL-771)

### DIFF
--- a/apps/macos/.gitignore
+++ b/apps/macos/.gitignore
@@ -4,3 +4,4 @@ dist/
 build/
 resources/bun
 resources/web-dist
+resources/cli-lockfile

--- a/apps/macos/electron-builder.config.cjs
+++ b/apps/macos/electron-builder.config.cjs
@@ -27,6 +27,7 @@ module.exports = {
   extraResources: [
     { from: "resources/bun", to: "bun" },
     { from: "resources/web-dist", to: "web-dist" },
+    { from: "resources/cli-lockfile", to: "cli-lockfile" },
     { from: "build/icon.icns", to: "icon.icns" },
   ],
   afterPack: "./scripts/afterPack.js",

--- a/apps/macos/package.json
+++ b/apps/macos/package.json
@@ -18,7 +18,7 @@
     "test:ci": "bun scripts/run-tests.ts",
     "build:fetch-bun": "bash scripts/fetch-bun.sh",
     "build:web": "cd ../web && bun install && bun run openapi-ts && bun run build && cd ../macos && mkdir -p resources && cp -R ../web/dist resources/web-dist",
-    "pack": "bash scripts/fetch-bun.sh --arch aarch64 && bash scripts/generate-icon.sh && bun run build:web && electron-vite build && electron-builder --config electron-builder.config.cjs"
+    "pack": "bash scripts/fetch-bun.sh --arch aarch64 && bash scripts/generate-icon.sh && bun run build:web && bash scripts/generate-cli-lockfile.sh && electron-vite build && electron-builder --config electron-builder.config.cjs"
   },
   "devDependencies": {
     "@types/bun": "1.3.14",

--- a/apps/macos/scripts/generate-cli-lockfile.sh
+++ b/apps/macos/scripts/generate-cli-lockfile.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# generate-cli-lockfile.sh — Resolve the CLI dependency graph at build time
+# and ship it as an app resource so the runtime install uses
+# `bun install --frozen-lockfile` instead of resolving from the live registry.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_DIR="$SCRIPT_DIR/.."
+SEED_DIR="$APP_DIR/resources/cli-lockfile"
+
+VERSION=$(grep -o 'PINNED_CLI_VERSION = "[^"]*"' "$APP_DIR/src/main/cli-installer.ts" \
+  | sed 's/PINNED_CLI_VERSION = "//;s/"//')
+
+if [ -z "$VERSION" ]; then
+  echo "ERROR: could not read PINNED_CLI_VERSION from cli-installer.ts" >&2
+  exit 1
+fi
+
+echo "Generating CLI lockfile for vellum@$VERSION ..."
+
+rm -rf "$SEED_DIR"
+mkdir -p "$SEED_DIR"
+
+cat > "$SEED_DIR/package.json" <<EOF
+{"dependencies":{"vellum":"$VERSION"}}
+EOF
+
+(cd "$SEED_DIR" && bun install --ignore-scripts)
+
+if [ ! -f "$SEED_DIR/bun.lock" ]; then
+  echo "ERROR: bun.lock was not generated" >&2
+  exit 1
+fi
+
+# Only ship the seed files; node_modules is discarded.
+rm -rf "$SEED_DIR/node_modules"
+
+echo "CLI lockfile generated at $SEED_DIR"

--- a/apps/macos/src/main/cli-installer.test.ts
+++ b/apps/macos/src/main/cli-installer.test.ts
@@ -32,8 +32,12 @@ let readdirSyncReturn: Array<{ name: string; isDirectory: () => boolean }> = [];
 let readdirSyncError: Error | null = null;
 const mkdirSyncCalls: Array<[string, object]> = [];
 const rmSyncCalls: Array<[string, object]> = [];
+const copyFileSyncCalls: Array<[string, string]> = [];
 
 mock.module("node:fs", () => ({
+  copyFileSync: (src: string, dst: string) => {
+    copyFileSyncCalls.push([src, dst]);
+  },
   existsSync: (p: string) =>
     p in existsSyncByPath ? existsSyncByPath[p] : existsSyncDefault,
   mkdirSync: (p: string, opts: object) => {
@@ -74,6 +78,9 @@ const {
   _resetInstallLock,
 } = await import("./cli-installer");
 
+const seedPkgPath = `${mockResourcesPath}/cli-lockfile/package.json`;
+const seedLockPath = `${mockResourcesPath}/cli-lockfile/bun.lock`;
+
 afterEach(() => {
   existsSyncDefault = false;
   for (const key of Object.keys(existsSyncByPath)) delete existsSyncByPath[key];
@@ -81,6 +88,7 @@ afterEach(() => {
   readdirSyncError = null;
   mkdirSyncCalls.length = 0;
   rmSyncCalls.length = 0;
+  copyFileSyncCalls.length = 0;
   spawnCalls.length = 0;
   _resetInstallLock();
 });
@@ -132,19 +140,18 @@ describe("ensureCliInstalled", () => {
     expect(spawnCalls).toHaveLength(0);
   });
 
-  test("spawns bun add with correct args, cwd, and augmented env", async () => {
+  test("falls back to bun add --ignore-scripts when no seed lockfile exists", async () => {
     existsSyncDefault = false;
 
     const promise = ensureCliInstalled();
 
-    // Let the spawn resolve successfully.
     lastChild.emit("close", 0);
     await promise;
 
     expect(spawnCalls).toHaveLength(1);
     const [cmd, args, opts] = spawnCalls[0];
     expect(cmd).toBe(`${mockResourcesPath}/bun`);
-    expect(args).toEqual(["add", `vellum@${PINNED_CLI_VERSION}`]);
+    expect(args).toEqual(["add", `vellum@${PINNED_CLI_VERSION}`, "--ignore-scripts"]);
     expect((opts as { cwd: string }).cwd).toBe(
       `${userDataPath}/cli/${PINNED_CLI_VERSION}`,
     );
@@ -152,6 +159,26 @@ describe("ensureCliInstalled", () => {
     expect(env).toBeDefined();
     expect(env!.PATH).toContain("/opt/homebrew/bin");
     expect(env!.PATH).toContain("/usr/local/bin");
+  });
+
+  test("uses bun install --frozen-lockfile --ignore-scripts when seed lockfile exists", async () => {
+    existsSyncDefault = false;
+    existsSyncByPath[seedPkgPath] = true;
+    existsSyncByPath[seedLockPath] = true;
+
+    const promise = ensureCliInstalled();
+
+    lastChild.emit("close", 0);
+    await promise;
+
+    expect(copyFileSyncCalls).toHaveLength(2);
+    expect(copyFileSyncCalls[0][0]).toBe(seedPkgPath);
+    expect(copyFileSyncCalls[1][0]).toBe(seedLockPath);
+
+    expect(spawnCalls).toHaveLength(1);
+    const [cmd, args] = spawnCalls[0];
+    expect(cmd).toBe(`${mockResourcesPath}/bun`);
+    expect(args).toEqual(["install", "--frozen-lockfile", "--ignore-scripts"]);
   });
 
   test("creates the install directory before spawning", async () => {

--- a/apps/macos/src/main/cli-installer.ts
+++ b/apps/macos/src/main/cli-installer.ts
@@ -1,6 +1,7 @@
 import { app } from "electron";
 import { spawn } from "node:child_process";
 import {
+  copyFileSync,
   existsSync,
   mkdirSync,
   readdirSync,
@@ -67,14 +68,37 @@ export function buildInstallEnv(): NodeJS.ProcessEnv {
   };
 }
 
-function bunAdd(pkg: string): Promise<void> {
+/**
+ * Seed the install directory with the package.json and bun.lock shipped in
+ * the signed app bundle.  When present, the subsequent `bun install
+ * --frozen-lockfile` uses the exact dependency graph that was resolved at
+ * build time rather than resolving from the live registry.
+ */
+function seedCliLockfile(installDir: string): boolean {
+  const seedDir = path.join(process.resourcesPath, "cli-lockfile");
+  const seedPkg = path.join(seedDir, "package.json");
+  const seedLock = path.join(seedDir, "bun.lock");
+
+  if (!existsSync(seedPkg) || !existsSync(seedLock)) return false;
+
+  copyFileSync(seedPkg, path.join(installDir, "package.json"));
+  copyFileSync(seedLock, path.join(installDir, "bun.lock"));
+  return true;
+}
+
+function bunInstallCli(): Promise<void> {
   const installDir = getCliInstallDir();
   mkdirSync(installDir, { recursive: true });
 
   const bunPath = getBundledBunPath();
+  const seeded = seedCliLockfile(installDir);
+
+  const args = seeded
+    ? ["install", "--frozen-lockfile", "--ignore-scripts"]
+    : ["add", `vellum@${PINNED_CLI_VERSION}`, "--ignore-scripts"];
 
   return new Promise<void>((resolve, reject) => {
-    const child = spawn(bunPath, ["add", `${pkg}@${PINNED_CLI_VERSION}`], {
+    const child = spawn(bunPath, args, {
       cwd: installDir,
       env: buildInstallEnv(),
     });
@@ -124,10 +148,9 @@ export function _resetInstallLock(): void {
 /**
  * Install the pinned vellum meta-package if it isn't already present.
  *
- * Uses the bundled bun runtime to `bun add vellum@<version>` into the
- * per-version install directory. The meta-package brings the full local
- * stack (daemon, gateway, credential-executor, web). After a successful
- * install, stale versions are cleaned up.
+ * Packaged builds ship a pre-resolved lockfile so `bun install
+ * --frozen-lockfile` pins the exact dependency graph from build time;
+ * lifecycle scripts are always suppressed via `--ignore-scripts`.
  */
 export async function ensureCliInstalled(): Promise<void> {
   if (isCliInstalled()) return;
@@ -135,7 +158,7 @@ export async function ensureCliInstalled(): Promise<void> {
   if (cliInstallPromise) return cliInstallPromise;
 
   cliInstallPromise = (async () => {
-    await bunAdd("vellum");
+    await bunInstallCli();
     cleanupOldVersions();
   })();
 


### PR DESCRIPTION
## Summary
- **Suppress lifecycle scripts**: all runtime CLI installs now pass `--ignore-scripts` to bun, preventing postinstall/preinstall scripts from executing with user privileges during package installation.
- **Ship a pre-resolved lockfile**: a new build step (`generate-cli-lockfile.sh`) resolves the CLI dependency graph at build time and bundles the `package.json` + `bun.lock` into the signed app resources. At runtime, these seed files are copied into the install directory and `bun install --frozen-lockfile` pins the exact dependency graph from build time.
- **Graceful fallback**: if the seed lockfile is absent (e.g., dev builds), falls back to `bun add vellum@<version> --ignore-scripts` so the install still works with script suppression.

Closes ATL-771.

Codex finding: https://chatgpt.com/codex/cloud/security/findings/99b67dbb45e88191a0e75158fd8a2a8f

## Original prompt
A Codex security finding (ATL-771) flagged that the packaged Electron app's runtime CLI install via `bun add vellum@<version>` lacked two mitigations: (1) no lockfile/integrity manifest was shipped, so the transitive dependency graph was resolved from the live npm registry at first use rather than pinned at build time, and (2) install-time lifecycle scripts were not suppressed, allowing postinstall code from any dependency to execute with user privileges. This PR addresses both.

## Test plan
- [x] `bun test ./src/main/cli-installer.test.ts` — 21 tests pass
- [ ] Verify `bun run pack` succeeds and `resources/cli-lockfile/` contains `package.json` + `bun.lock`
- [ ] Verify packaged app installs CLI via `bun install --frozen-lockfile --ignore-scripts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)