### PR TITLE
fix(assistant): refresh surfaces + redeploy after app_update (JARVIS-1139)

### DIFF
--- a/assistant/src/__tests__/conversation-tool-setup-app-refresh.test.ts
+++ b/assistant/src/__tests__/conversation-tool-setup-app-refresh.test.ts
@@ -2,9 +2,9 @@
  * Regression tests for app surface refresh and eventing side effects in
  * createToolExecutor (conversation-tool-setup.ts).
  *
- * Tests verify that app_refresh, app_create, and app_delete hooks fire
- * correctly, and that removed hooks (app_update, app_file_edit,
- * app_file_write) no longer trigger side effects.
+ * Tests verify that app_refresh, app_update, app_create, and app_delete hooks
+ * fire correctly, and that non-hooked tools (app_file_edit, app_file_write) do
+ * not trigger side effects.
  *
  * File-change detection for file_write/file_edit is handled by
  * AppSourceWatcher (see app-source-watcher.test.ts).
@@ -242,6 +242,76 @@ describe("session-tool-setup app refresh side effects", () => {
       );
 
       await toolFn("app_refresh", {});
+
+      expect(refreshSpy).not.toHaveBeenCalled();
+      expect(broadcastSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── app_update ──────────────────────────────────────────────────────
+
+  describe("app_update", () => {
+    test("triggers refreshSurfacesForApp and broadcast on success", async () => {
+      const ctx = makeCtx();
+      const executor = makeFakeExecutor({
+        content: '{"updated":true,"appId":"app-7"}',
+        isError: false,
+      });
+
+      const toolFn = createToolExecutor(
+        executor as unknown as ToolExecutor,
+        noopPrompter,
+        noopSecretPrompter,
+        ctx,
+        noopLifecycleHandler,
+      );
+
+      await toolFn("app_update", { app_id: "app-7" });
+
+      expect(refreshSpy).toHaveBeenCalledTimes(1);
+      expect((refreshSpy.mock.calls as unknown[][])[0][1]).toBe("app-7");
+      expectAppChangeBroadcast("app-7");
+      expect(updatePublishedSpy).toHaveBeenCalledTimes(1);
+      expect((updatePublishedSpy.mock.calls as unknown[][])[0][0]).toBe(
+        "app-7",
+      );
+    });
+
+    test("skips side effects when result is an error", async () => {
+      const ctx = makeCtx();
+      const executor = makeFakeExecutor({
+        content: "Error: not found",
+        isError: true,
+      });
+
+      const toolFn = createToolExecutor(
+        executor as unknown as ToolExecutor,
+        noopPrompter,
+        noopSecretPrompter,
+        ctx,
+        noopLifecycleHandler,
+      );
+
+      await toolFn("app_update", { app_id: "app-err" });
+
+      expect(refreshSpy).not.toHaveBeenCalled();
+      expect(broadcastSpy).not.toHaveBeenCalled();
+      expect(updatePublishedSpy).not.toHaveBeenCalled();
+    });
+
+    test("skips side effects when app_id is missing", async () => {
+      const ctx = makeCtx();
+      const executor = makeFakeExecutor({ content: "{}", isError: false });
+
+      const toolFn = createToolExecutor(
+        executor as unknown as ToolExecutor,
+        noopPrompter,
+        noopSecretPrompter,
+        ctx,
+        noopLifecycleHandler,
+      );
+
+      await toolFn("app_update", {});
 
       expect(refreshSpy).not.toHaveBeenCalled();
       expect(broadcastSpy).not.toHaveBeenCalled();
@@ -518,7 +588,6 @@ describe("session-tool-setup app refresh side effects", () => {
         "write_file",
         "shell",
         "app_list",
-        "app_update",
         "app_file_edit",
         "app_file_write",
       ]) {

--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -155,6 +155,21 @@ registerHook("app_refresh", (_name, input, _result, { ctx }) => {
   notifyAppChanged(ctx, appId, { fileChange: true });
 });
 
+// app_update compiles internally (like app_refresh) but emits no events of its
+// own, so without this hook an updated app leaves open surfaces rendering the
+// stale dist and never re-deploys or invalidates the Library. The executor owns
+// the compile; notifyAppChanged only refreshes surfaces and broadcasts.
+registerHook("app_update", (_name, input, _result, { ctx }) => {
+  const appId = input.app_id as string | undefined;
+  if (!appId) return;
+  try {
+    addAppConversationId(appId, ctx.conversationId);
+  } catch (err) {
+    log.warn({ err, appId }, "Failed to track conversation ID on app_update");
+  }
+  notifyAppChanged(ctx, appId, { fileChange: true });
+});
+
 registerHook("voice_config_update", (_name, input) => {
   const setting = input.setting as string | undefined;
   if (!setting) return;


### PR DESCRIPTION
## Summary
- Adds a post-execution hook for `app_update` in `tool-side-effects.ts`, mirroring `app_refresh`: it associates the conversation and calls `notifyAppChanged(...)` (refresh open surfaces, broadcast `app_files_changed`, trigger Library invalidation + re-deploy). The executor already owns the compile, so the hook does **not** recompile.
- Fixes JARVIS-1139: after `app_update`, open app surfaces kept rendering the stale `dist/` (often the Hello-world scaffold placeholder) — the "still shows a plain text hello" report — because nothing refreshed the surface or invalidated the Library.
- Root cause is structural: `app_update` had no hook (only `app_create`/`app_refresh`/`app_delete` did). That was fine when iteration went through `file_write` + `app_refresh`, but `app_update` became a first-class model-callable tool in #33919, so the gap is now actively hit.
- Tests: new `app_update` side-effect cases (fires on success, skips on error / missing app_id) and removed `app_update` from the "non-app tools" no-op list.

## Original prompt
Investigation of a foreground app-builder bug cluster (JARVIS-1139/1138/1005) found that `app_update` was missing a post-execution side-effect hook, so updates compiled but never refreshed the rendered surface or the Library — the "update shows plain-text hello" symptom. Fix is to add the hook mirroring `app_refresh`, now that `app_update` is a real tool the model uses.