### PR TITLE
fix(assistant): auto-redeploy published apps with effective HTML, not empty htmlDefinition (JARVIS-1138)

### DIFF
--- a/assistant/src/__tests__/published-app-updater.test.ts
+++ b/assistant/src/__tests__/published-app-updater.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests that the auto-redeploy path deploys the app's *effective* HTML
+ * (dist/index.html for multifile apps) rather than the empty `htmlDefinition`.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { AppDefinition } from "../memory/app-store.js";
+
+// ── Mocks ───────────────────────────────────────────────────────────────
+
+let mockApp: AppDefinition | null = null;
+let mockIsMultifile = false;
+let mockEffectiveHtml = "";
+// A directory that does not exist on disk, so the multifile dist-existence
+// guard reads `false` from the real fs without mocking node:fs (which would
+// leak across test files).
+let mockAppDir = "/tmp/__vellum_test_nonexistent__/app-1";
+
+mock.module("../memory/app-store.js", () => ({
+  getApp: () => mockApp,
+  getAppDirPath: () => mockAppDir,
+  isMultifileApp: () => mockIsMultifile,
+  resolveEffectiveAppHtml: () => mockEffectiveHtml,
+}));
+
+let mockPublishedPage: {
+  id: string;
+  projectSlug?: string;
+  htmlHash: string;
+} | null = null;
+const updatePublishedPageSpy = mock(() => {});
+
+mock.module("../memory/published-pages-store.js", () => ({
+  getActivePublishedPageByAppId: () => mockPublishedPage,
+  updatePublishedPage: updatePublishedPageSpy,
+}));
+
+const deploySpy = mock(async (_args: { html: string; name: string }) => ({
+  deploymentId: "dep-1",
+  url: "https://example.vercel.app",
+}));
+
+mock.module("../services/vercel-deploy.js", () => ({
+  deployHtmlToVercel: deploySpy,
+}));
+
+// credentialBroker.serverUse invokes execute(token) and reports success.
+mock.module("../tools/credentials/broker.js", () => ({
+  credentialBroker: {
+    serverUse: async ({
+      execute,
+    }: {
+      execute: (token: string) => Promise<unknown>;
+    }) => {
+      await execute("test-token");
+      return { success: true };
+    },
+  },
+}));
+
+const { updatePublishedAppDeployment } =
+  await import("../services/published-app-updater.js");
+
+function makeApp(overrides: Partial<AppDefinition> = {}): AppDefinition {
+  return {
+    id: "app-1",
+    name: "App",
+    schemaJson: "{}",
+    htmlDefinition: "",
+    createdAt: 1,
+    updatedAt: 2,
+    ...overrides,
+  };
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+describe("updatePublishedAppDeployment", () => {
+  beforeEach(() => {
+    mockApp = makeApp();
+    mockIsMultifile = false;
+    mockEffectiveHtml = "";
+    mockPublishedPage = { id: "pp-1", projectSlug: "slug", htmlHash: "old" };
+    mockAppDir = "/tmp/__vellum_test_nonexistent__/app-1";
+    deploySpy.mockClear();
+    updatePublishedPageSpy.mockClear();
+  });
+
+  test("deploys the resolved effective HTML, not the empty htmlDefinition", async () => {
+    // htmlDefinition is "" (as it is for every multifile app); the real
+    // content comes from resolveEffectiveAppHtml. isMultifile=false here keeps
+    // the dist guard out of the way so the assertion targets the html source.
+    mockApp = makeApp({ htmlDefinition: "" });
+    mockEffectiveHtml = "<html><body>real app</body></html>";
+
+    await updatePublishedAppDeployment("app-1");
+
+    expect(deploySpy).toHaveBeenCalledTimes(1);
+    expect(deploySpy.mock.calls[0][0].html).toBe(
+      "<html><body>real app</body></html>",
+    );
+  });
+
+  test("skips deploy when a multifile app has no compiled output", async () => {
+    mockIsMultifile = true;
+    mockApp = makeApp({ formatVersion: 2 });
+    mockEffectiveHtml = "<p>App compilation failed.</p>";
+    // mockAppDir does not exist → dist/index.html is absent.
+
+    await updatePublishedAppDeployment("app-1");
+
+    expect(deploySpy).not.toHaveBeenCalled();
+  });
+
+  test("skips deploy when content hash is unchanged", async () => {
+    const html = "<html>same</html>";
+    mockEffectiveHtml = html;
+    const { createHash } = await import("node:crypto");
+    mockPublishedPage = {
+      id: "pp-1",
+      htmlHash: createHash("sha256").update(html).digest("hex"),
+    };
+
+    await updatePublishedAppDeployment("app-1");
+
+    expect(deploySpy).not.toHaveBeenCalled();
+  });
+
+  test("skips deploy when the app has no active published page", async () => {
+    mockPublishedPage = null;
+    mockEffectiveHtml = "<html>x</html>";
+
+    await updatePublishedAppDeployment("app-1");
+
+    expect(deploySpy).not.toHaveBeenCalled();
+  });
+});

--- a/assistant/src/services/published-app-updater.ts
+++ b/assistant/src/services/published-app-updater.ts
@@ -3,8 +3,15 @@
  */
 
 import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
 
-import { getApp } from "../memory/app-store.js";
+import {
+  getApp,
+  getAppDirPath,
+  isMultifileApp,
+  resolveEffectiveAppHtml,
+} from "../memory/app-store.js";
 import {
   getActivePublishedPageByAppId,
   updatePublishedPage,
@@ -23,17 +30,32 @@ export async function updatePublishedAppDeployment(
     const publishedPage = getActivePublishedPageByAppId(appId);
     if (!publishedPage) return;
 
-    // 2. Load the app to get current HTML
+    // 2. Load the app and resolve its deployable HTML. For multifile apps the
+    // real content lives in dist/index.html (compiled from src/), not in
+    // htmlDefinition (which is "" for them) — using htmlDefinition directly
+    // would deploy a blank page.
     const app = getApp(appId);
-    if (!app || !app.htmlDefinition) {
-      log.warn({ appId }, "Published app not found or has no HTML");
+    if (!app) {
+      log.warn({ appId }, "Published app not found");
       return;
     }
 
+    // Skip rather than deploy the compile-failure fallback when a multifile
+    // app has no compiled output (e.g. a concurrent compile failed); a later
+    // successful compile re-triggers this path.
+    if (
+      isMultifileApp(app) &&
+      !existsSync(join(getAppDirPath(app.id), "dist", "index.html"))
+    ) {
+      log.warn({ appId }, "Skipping auto-redeploy: compiled output missing");
+      return;
+    }
+
+    const html = resolveEffectiveAppHtml(app);
+    if (!html) return;
+
     // 3. Hash the current HTML and check if it changed
-    const newHash = createHash("sha256")
-      .update(app.htmlDefinition)
-      .digest("hex");
+    const newHash = createHash("sha256").update(html).digest("hex");
     if (newHash === publishedPage.htmlHash) return; // No change
 
     // 4. Get Vercel token — don't prompt, just skip if unavailable
@@ -46,7 +68,7 @@ export async function updatePublishedAppDeployment(
       execute: async (token) => {
         // 5. Deploy updated HTML using the same project slug
         const result = await deployHtmlToVercel({
-          html: app.htmlDefinition,
+          html,
           name: slug,
           token,
         });


### PR DESCRIPTION
## Summary
- The background auto-redeploy service (published-app-updater.ts) hashed and deployed app.htmlDefinition directly. For multifile (formatVersion 2) apps that field is empty — the real content lives in compiled dist/index.html — so auto-redeploys shipped a blank page, and the guard bailed for all multifile apps. This is the JARVIS-1138 'can't deploy my app to library' symptom.
- Now resolves the deployable HTML via resolveEffectiveAppHtml(app) and deploys/hashes that. Skips the redeploy when a multifile app has no compiled output, so a failed compile never overwrites a working deployment with the compile-failure placeholder.
- Adds published-app-updater.test.ts (deploys resolved HTML not empty htmlDefinition; skips when dist missing / hash unchanged / no active published page).

## Original prompt
Part of the foreground app-builder cluster (JARVIS-1139/1138/1005). The auto-redeploy path deployed app.htmlDefinition, empty for multifile apps, so published apps redeployed blank. Fix deploys resolveEffectiveAppHtml(app) instead.