### PR TITLE
fix(web): establish auth session when connecting to cloud assistant from onboarding

### DIFF
--- a/apps/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -63,6 +63,7 @@ export function SelectAssistantScreen() {
         await useAuthStore.getState().connectLocalAssistant(assistant.id);
       } else {
         await selectPlatformAssistant(assistant.id);
+        await useAuthStore.getState().connectPlatformAssistant(assistant.id);
       }
       void navigate(routes.assistant, { replace: true });
     } catch {

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -98,6 +98,7 @@ interface AuthState {
 interface AuthActions {
   initSession: () => Promise<void>;
   connectLocalAssistant: (assistantId: string) => Promise<void>;
+  connectPlatformAssistant: (assistantId: string) => Promise<void>;
   refreshSession: () => Promise<boolean>;
   logout: () => Promise<void>;
 }
@@ -441,6 +442,17 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
     await primeLocalGatewayConnectionWithRepair();
     set(authenticatedLocalUser());
     probePlatformSessionIfReachable(set);
+  },
+
+  connectPlatformAssistant: async (assistantId: string) => {
+    setSelectedAssistantId(assistantId);
+    const result = await getSession();
+    if (!result.ok || !result.data.user) {
+      throw new Error("Platform authentication required");
+    }
+    const user = toAuthUser(result.data.user);
+    syncUserScopedState(user?.id ?? null);
+    set(authenticatedPlatformUser(user));
   },
 
   refreshSession: async () => {


### PR DESCRIPTION
## Summary

- When a local assistant's guardian token is missing at boot, `initSession` settles to `"unauthenticated"`. Selecting a cloud assistant from the onboarding picker then fails because `selectPlatformAssistant` only updates the lockfile/org selection without fixing the auth state or the selected assistant ID in localStorage — the auth middleware sees the stale `"unauthenticated"` status and redirects back to select-assistant, trapping the user in a loop.
- Adds `connectPlatformAssistant` to the auth store (parallel to `connectLocalAssistant`) that updates the selected assistant ID via `setSelectedAssistantId` and establishes an authenticated session from the platform session via `getSession()`.
- The select-assistant screen now calls `connectPlatformAssistant` after `selectPlatformAssistant` for cloud assistants, so the auth middleware sees `isAuthenticated: true` and allows navigation to `/assistant`.

## Test plan

- [ ] Have both a local assistant (daemon not running / no guardian token) and a cloud assistant in the lockfile
- [ ] Navigate to the select-assistant onboarding screen
- [ ] Select "Cloud Assistant" and click Continue
- [ ] Verify navigation proceeds to `/assistant` instead of looping back to select-assistant
- [ ] Verify local assistant selection still works (daemon running with valid guardian token)

🤖 Generated with [Claude Code](https://claude.com/claude-code)