### PR TITLE
fix(assistant+web): order Library by updatedAt so updated apps resurface (JARVIS-1005)

### DIFF
--- a/apps/web/src/domains/chat/components/surfaces/dynamic-page-surface.tsx
+++ b/apps/web/src/domains/chat/components/surfaces/dynamic-page-surface.tsx
@@ -169,6 +169,7 @@ export function DynamicPageSurface({
             name: cardName,
             icon: data.preview?.icon,
             createdAt: 0,
+            updatedAt: 0,
             version: "",
             contentId: "",
           })

--- a/apps/web/src/domains/library/use-library-data.ts
+++ b/apps/web/src/domains/library/use-library-data.ts
@@ -14,6 +14,17 @@ import {
 } from "@/generated/daemon/@tanstack/react-query.gen";
 import { usePinnedAppsStore } from "@/stores/pinned-apps-store";
 
+/**
+ * Order apps most-recently-touched first. Sorting by `updatedAt` (not
+ * `createdAt`) keeps a freshly edited app at the top and matches the daemon's
+ * own ordering, so updated apps resurface in the Library instead of staying
+ * buried by creation order. `createdAt` breaks ties.
+ */
+const byMostRecentlyUpdated = (
+  a: { updatedAt: number; createdAt: number },
+  b: { updatedAt: number; createdAt: number },
+) => b.updatedAt - a.updatedAt || b.createdAt - a.createdAt;
+
 export function useLibraryData(assistantId: string) {
   const pinnedAppIds = usePinnedAppsStore.use.pinnedAppIds();
 
@@ -45,12 +56,12 @@ export function useLibraryData(assistantId: string) {
   }, [apps, searchText]);
 
   const pinnedApps = useMemo(
-    () => filteredApps.filter((a) => pinnedAppIds.has(a.id)).sort((a, b) => b.createdAt - a.createdAt),
+    () => filteredApps.filter((a) => pinnedAppIds.has(a.id)).sort(byMostRecentlyUpdated),
     [filteredApps, pinnedAppIds],
   );
 
   const recentApps = useMemo(
-    () => filteredApps.filter((a) => !pinnedAppIds.has(a.id)).sort((a, b) => b.createdAt - a.createdAt),
+    () => filteredApps.filter((a) => !pinnedAppIds.has(a.id)).sort(byMostRecentlyUpdated),
     [filteredApps, pinnedAppIds],
   );
 

--- a/apps/web/src/utils/app-pin-storage.test.ts
+++ b/apps/web/src/utils/app-pin-storage.test.ts
@@ -18,6 +18,7 @@ function makeApp(overrides: Partial<AppSummary> & { id: string }): AppSummary {
   return {
     name: `App ${overrides.id}`,
     createdAt: Date.now(),
+    updatedAt: Date.now(),
     version: "1.0.0",
     contentId: `content_${overrides.id}`,
     ...overrides,

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -480,6 +480,8 @@ paths:
                           type: string
                         createdAt:
                           type: number
+                        updatedAt:
+                          type: number
                         version:
                           type: string
                         contentId:
@@ -488,6 +490,7 @@ paths:
                         - id
                         - name
                         - createdAt
+                        - updatedAt
                         - version
                         - contentId
                       additionalProperties: false

--- a/assistant/src/runtime/routes/app-management-routes.ts
+++ b/assistant/src/runtime/routes/app-management-routes.ts
@@ -89,6 +89,7 @@ function listAppsFiltered(apps?: AppDefinition[]): Array<{
   description?: string;
   icon?: string;
   createdAt: number;
+  updatedAt: number;
   version: string;
   contentId: string;
 }> {
@@ -101,6 +102,7 @@ function listAppsFiltered(apps?: AppDefinition[]): Array<{
       description: a.description,
       icon: a.icon,
       createdAt: a.createdAt,
+      updatedAt: a.updatedAt,
       version,
       contentId,
     };
@@ -751,6 +753,7 @@ export const ROUTES: RouteDefinition[] = [
           description: z.string().optional(),
           icon: z.string().optional(),
           createdAt: z.number(),
+          updatedAt: z.number(),
           version: z.string(),
           contentId: z.string(),
         }),


### PR DESCRIPTION
## Summary
- The apps list endpoint exposed createdAt but not updatedAt, and the web Library (use-library-data.ts) re-sorted by createdAt — discarding the daemon's updatedAt ordering. So a freshly created or recently updated app could stay buried, the JARVIS-1005 'sometimes doesn't show up in library' report.
- Daemon: add updatedAt to the apps list response (listAppsFiltered mapping + responseBody zod schema; openapi.yaml regenerated).
- Web: sort pinned and recent app lists by updatedAt with createdAt as a tiebreak (shared byMostRecentlyUpdated comparator), matching the daemon order; add updatedAt to the two app-summary construction sites the new required field surfaced.

## Original prompt
Part of the foreground app-builder cluster (JARVIS-1139/1138/1005). Investigation found updatedAt was missing from the apps list response and the web sorted by createdAt only, so updated apps didn't resurface in the Library. Fix threads updatedAt through and sorts by it.