### PR TITLE
fix(cli): refuse to send the guardian refresh token over insecure URLs

### DIFF
--- a/cli/src/__tests__/assistant-client-refresh.test.ts
+++ b/cli/src/__tests__/assistant-client-refresh.test.ts
@@ -25,7 +25,7 @@ import { AssistantClient } from "../lib/assistant-client.js";
 import { saveAssistantEntry } from "../lib/assistant-config.js";
 import { loadGuardianToken, saveGuardianToken } from "../lib/guardian-token.js";
 
-const RUNTIME = "http://10.0.0.9:7830";
+const RUNTIME = "https://gw.example.com";
 const FUTURE = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString();
 
 function seedPaired(refreshToken: string): void {

--- a/cli/src/__tests__/client-tui-refresh.test.ts
+++ b/cli/src/__tests__/client-tui-refresh.test.ts
@@ -17,7 +17,7 @@ import { resolveFreshBearerToken } from "../commands/client.js";
 import { saveAssistantEntry } from "../lib/assistant-config.js";
 import { saveGuardianToken } from "../lib/guardian-token.js";
 
-const RUNTIME = "http://10.0.0.9:7830";
+const RUNTIME = "https://gw.example.com";
 const past = () => new Date(Date.now() - 60_000).toISOString();
 const future = () => new Date(Date.now() + 60 * 60 * 1000).toISOString();
 

--- a/cli/src/__tests__/guardian-token.test.ts
+++ b/cli/src/__tests__/guardian-token.test.ts
@@ -293,7 +293,7 @@ describe("refreshGuardianToken", () => {
       );
     }) as typeof fetch;
 
-    const result = await refreshGuardianToken("http://10.0.0.9:7830", "px");
+    const result = await refreshGuardianToken("https://gw.example.com", "px");
 
     expect(result?.accessToken).toBe("new-acc");
     expect(loadGuardianToken("px")?.accessToken).toBe("new-acc");
@@ -309,7 +309,9 @@ describe("refreshGuardianToken", () => {
       return new Response("", { status: 200 });
     }) as typeof fetch;
 
-    expect(await refreshGuardianToken("http://10.0.0.9:7830", "px")).toBeNull();
+    expect(
+      await refreshGuardianToken("https://gw.example.com", "px"),
+    ).toBeNull();
     expect(called).toBe(false);
   });
 
@@ -321,7 +323,7 @@ describe("refreshGuardianToken", () => {
     }) as typeof fetch;
 
     expect(
-      await refreshGuardianToken("http://10.0.0.9:7830", "missing"),
+      await refreshGuardianToken("https://gw.example.com", "missing"),
     ).toBeNull();
     expect(called).toBe(false);
   });
@@ -342,8 +344,75 @@ describe("refreshGuardianToken", () => {
         headers: { "content-type": "application/json" },
       })) as typeof fetch;
 
-    const result = await refreshGuardianToken("http://10.0.0.9:7830", "px");
+    const result = await refreshGuardianToken("https://gw.example.com", "px");
     expect(result?.accessToken).toBe("new-acc");
     expect(existsSync(lp)).toBe(false); // stolen lock cleaned up after release
+  });
+
+  // The refresh token is long-lived and replayable, so it must only travel over
+  // a confidential channel: https, or a loopback host. These guard the
+  // plaintext-interception vector flagged in the security review.
+
+  test("sends the refresh token over loopback http (127.0.0.1 / localhost / [::1])", async () => {
+    for (const url of [
+      "http://127.0.0.1:7830",
+      "http://localhost:7830",
+      "http://[::1]:7830",
+    ]) {
+      seed(future());
+      let called = false;
+      globalThis.fetch = (async (_url: unknown, _init?: RequestInit) => {
+        called = true;
+        return new Response(JSON.stringify({ accessToken: "new-acc" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }) as typeof fetch;
+
+      expect(await refreshGuardianToken(url, "px")).not.toBeNull();
+      expect(called).toBe(true); // loopback http is allowed
+    }
+  });
+
+  test("refuses a non-loopback plaintext http URL: no fetch, returns null, warns", async () => {
+    seed(future());
+    let called = false;
+    globalThis.fetch = (async (_url: unknown, _init?: RequestInit) => {
+      called = true;
+      return new Response("", { status: 200 });
+    }) as typeof fetch;
+
+    const origWarn = console.warn;
+    let warned = false;
+    console.warn = () => {
+      warned = true;
+    };
+    try {
+      expect(
+        await refreshGuardianToken("http://10.0.0.5:7830", "px"),
+      ).toBeNull();
+    } finally {
+      console.warn = origWarn;
+    }
+    expect(called).toBe(false); // the refresh token is never sent
+    expect(warned).toBe(true);
+  });
+
+  test("refuses a malformed gateway URL: no fetch, returns null", async () => {
+    seed(future());
+    let called = false;
+    globalThis.fetch = (async (_url: unknown, _init?: RequestInit) => {
+      called = true;
+      return new Response("", { status: 200 });
+    }) as typeof fetch;
+
+    const origWarn = console.warn;
+    console.warn = () => {};
+    try {
+      expect(await refreshGuardianToken("not-a-url", "px")).toBeNull();
+    } finally {
+      console.warn = origWarn;
+    }
+    expect(called).toBe(false);
   });
 });

--- a/cli/src/__tests__/tui-midsession-refresh.test.ts
+++ b/cli/src/__tests__/tui-midsession-refresh.test.ts
@@ -18,7 +18,7 @@ import { maybeRefreshAuthHeaders } from "../components/DefaultMainScreen";
 import { saveAssistantEntry } from "../lib/assistant-config";
 import { saveGuardianToken } from "../lib/guardian-token";
 
-const RUNTIME = "http://10.0.0.9:7830";
+const RUNTIME = "https://gw.example.com";
 const future = () => new Date(Date.now() + 60 * 60 * 1000).toISOString();
 
 function seedEntry(cloud: string, localUrl?: string): void {

--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -250,12 +250,14 @@ ${ANSI.bold}DEFAULTS:${ANSI.reset}
 ${ANSI.bold}EXAMPLES:${ANSI.reset}
     vellum client
     vellum client vellum-assistant-foo
-    vellum client --url http://34.56.78.90:${GATEWAY_PORT}
+    # Remote assistants must be reached over https (e.g. a tunnel) — the
+    # guardian refresh token is only sent over https or a loopback address:
+    vellum client --url https://your-tunnel.example
     vellum client vellum-assistant-foo --url http://localhost:${GATEWAY_PORT}
 
     # Ephemeral: connect to another machine's assistant with a paired token
     # (no lockfile entry, nothing persisted):
-    vellum client --url http://10.0.0.196:${GATEWAY_PORT} --token <jwt>
+    vellum client --url https://your-tunnel.example --token <jwt>
 `);
 }
 

--- a/cli/src/lib/guardian-token.ts
+++ b/cli/src/lib/guardian-token.ts
@@ -254,10 +254,51 @@ function releaseRefreshLock(lockPath: string): void {
  * process already rotated it while we waited, we return that fresh token
  * instead of replaying our now-stale refresh token.
  */
+/**
+ * The guardian refresh token is long-lived and replayable, so we only transmit
+ * it over a confidential channel: HTTPS, or a loopback host (local dev, or a
+ * same-host reverse proxy / tunnel agent). Refreshing against a non-loopback
+ * plaintext `http://` URL is refused — an on-path attacker could otherwise
+ * capture the refresh token and rotate it into fresh credentials.
+ *
+ * A user-chosen malicious `https://` destination is intentionally out of scope:
+ * HTTPS protects the channel, and the access token already goes wherever the
+ * configured URL points. This guard targets the plaintext-interception vector.
+ */
+function isLoopbackHostname(hostname: string): boolean {
+  const h = hostname.toLowerCase();
+  return (
+    h === "localhost" ||
+    h === "::1" ||
+    h === "[::1]" ||
+    h === "0:0:0:0:0:0:0:1" ||
+    /^127(?:\.\d{1,3}){3}$/.test(h)
+  );
+}
+
+function isConfidentialRefreshUrl(gatewayUrl: string): boolean {
+  try {
+    const url = new URL(gatewayUrl);
+    return url.protocol === "https:" || isLoopbackHostname(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
 export async function refreshGuardianToken(
   gatewayUrl: string,
   assistantId: string,
 ): Promise<GuardianTokenData | null> {
+  // Never send the long-lived refresh token over a non-loopback plaintext URL.
+  if (!isConfidentialRefreshUrl(gatewayUrl)) {
+    console.warn(
+      `Refusing to refresh the guardian token over an insecure URL (${gatewayUrl}). ` +
+        "The refresh token is only sent over https or a loopback address — " +
+        "use an https URL (e.g. a tunnel) or connect over loopback.",
+    );
+    return null;
+  }
+
   const before = loadGuardianToken(assistantId);
   if (!before) return null;
 


### PR DESCRIPTION
## Summary
- Add an HTTPS-or-loopback guard at the start of `refreshGuardianToken` (`cli/src/lib/guardian-token.ts`): the long-lived guardian **refresh token** is only transmitted when the destination is `https://` or a loopback host (`127.0.0.0/8`, `localhost`, `::1`/`[::1]`). Otherwise it warns and returns `null` (the existing "refresh not possible" fallback — the session still starts / surfaces the original 401).
- One chokepoint covers **all** callers: startup refresh, the on-401 retry, the TUI, backup, setup, and gateway-token.
- Intentionally scoped: loopback `http://` stays allowed (local dev); `https://` to any host is allowed (a user-chosen malicious https destination is a separate, inherent vector — the access token already goes wherever the URL points). The guard targets the plaintext-interception vector only.
- Tests: loopback http (127.0.0.1 / localhost / [::1]) and https still refresh; non-loopback http is refused (no fetch, returns null, warns); malformed URL is refused. Existing refresh tests updated to use a confidential URL.

## Original prompt
A High security finding (commit 00f9811 / #33497) flagged that the CLI's proactive startup refresh — part of the remote-pairing/M1 foundation — sends the guardian refresh token to a user/lockfile-controlled `runtimeUrl` with no HTTPS or origin validation, so an on-path attacker on a plaintext HTTP connection could capture it. The underlying gap actually predates that commit and lives in the shared `refreshGuardianToken` helper. This change makes the code enforce the secure-channel assumption the remote (tunnel) flow already relies on, rather than depending on the operator's deployment choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)