### PR TITLE
Remove the now-unread acp.enabled config field

### DIFF
--- a/assistant/src/config/acp-defaults.ts
+++ b/assistant/src/config/acp-defaults.ts
@@ -9,9 +9,9 @@ const FROZEN_EMPTY_ARGS = Object.freeze([] as string[]) as unknown as string[];
 /**
  * Default ACP agent profiles that ship with the assistant.
  *
- * When `acp.enabled: true` and the user has not provided a config entry for an
- * agent id, the resolver falls back to this map so common agents like `claude`
- * and `codex` Just Work without requiring per-user config.
+ * When the user has not provided a config entry for an agent id, the resolver
+ * falls back to this map so common agents like `claude` and `codex` Just Work
+ * without requiring per-user config.
  *
  * Keyed by agent id. Deeply frozen — the outer object, each profile, and the
  * `args` arrays — so mutation throws in strict mode rather than silently

--- a/assistant/src/config/acp-schema.ts
+++ b/assistant/src/config/acp-schema.ts
@@ -20,12 +20,6 @@ const AcpAgentConfigSchema = z
 
 export const AcpConfigSchema = z
   .object({
-    enabled: z
-      .boolean()
-      .default(false)
-      .describe(
-        "Whether the Agent Communication Protocol (ACP) system is enabled",
-      ),
     maxConcurrentSessions: z
       .number()
       .int()
@@ -40,7 +34,7 @@ export const AcpConfigSchema = z
       .describe("Map of agent names to their configurations"),
   })
   .describe(
-    "Agent Communication Protocol (ACP) — enables inter-agent communication and delegation",
+    "Agent Communication Protocol (ACP) — inter-agent communication and delegation",
   );
 
 export type AcpConfig = z.infer<typeof AcpConfigSchema>;

--- a/assistant/src/config/bundled-skills/acp/SKILL.md
+++ b/assistant/src/config/bundled-skills/acp/SKILL.md
@@ -26,24 +26,11 @@ Users can refer to agents by natural names: "claude code", "codex cli", "openai 
 
 ## First-time setup
 
-When the user first tries to use ACP and it's not enabled, set it up automatically:
+ACP is always available - default profiles for `claude`, `codex`, and `gemini` ship out-of-box, so no config edit is needed to start. First-time setup is just making the adapter binary available, then spawning:
 
-1. **Enable the `acp` feature flag** (the primary enablement path). Either PATCH it via the gateway feature-flags endpoint or direct the user to toggle "ACP Coding Agents" in the client's feature flags UI. Flag changes are hot-refreshed in the assistant - no restart needed.
+1. Install the adapter binary if it's missing. This happens automatically: when `acp_spawn` finds the agent's binary missing from PATH, the assistant installs it once via a sandboxed bun global install and proceeds in the same call (see "Automatic adapter availability" below).
 
-   As a supported alternative, edit the workspace config file to add the `acp` section. Default profiles for `claude`, `codex`, and `gemini` ship out-of-box, so the minimal config is just:
-   ```json
-   {
-     "acp": {
-       "enabled": true,
-       "maxConcurrentSessions": 4
-     }
-   }
-   ```
-   If you go the config route, **wait a few seconds** for the config watcher to pick up the change (it hot-reloads automatically - no restart needed).
-
-2. Then retry the `acp_spawn` call. Do NOT run `vellum sleep && vellum wake` - that kills the conversation.
-
-No manual binary installation is needed first: missing adapter binaries are installed automatically (see below).
+2. Call `acp_spawn`. Do NOT run `vellum sleep && vellum wake` - that kills the conversation.
 
 ## Automatic adapter availability
 
@@ -140,7 +127,7 @@ Then retry the `acp_spawn` call.
 
 ## Discoverability
 
-Use `acp_list_agents` to see what's set up and what's missing. It returns each available agent profile, whether ACP is enabled, whether the agent's binary is on PATH (missing binaries are installed automatically on first spawn), and an install hint if not. This is the right tool to call when deciding between `claude`, `codex`, and `gemini`, or when the user asks "what coding agents do I have?"
+Use `acp_list_agents` to see what's set up and what's missing. It returns each available agent profile, whether the agent's binary is on PATH (missing binaries are installed automatically on first spawn), and an install hint if not. This is the right tool to call when deciding between `claude`, `codex`, and `gemini`, or when the user asks "what coding agents do I have?"
 
 ## Working directory
 

--- a/assistant/src/config/bundled-skills/acp/TOOLS.json
+++ b/assistant/src/config/bundled-skills/acp/TOOLS.json
@@ -3,7 +3,7 @@
   "tools": [
     {
       "name": "acp_spawn",
-      "description": "Spawn an external coding agent (e.g. Claude Code, Codex, Gemini) via ACP to work on a task. Default profiles ship for `claude` (`claude-agent-acp`), `codex` (`codex-acp`), and `gemini` (`gemini --acp`); the assistant resolves the agent id to the right binary. The agent runs as a subprocess and streams results back. Use this when you want to delegate a coding task to an external agent that has its own tools, file editing, and terminal access. If a default agent's binary is missing, the assistant installs it once via a sandboxed bun global install and proceeds in the same call; if that fails (e.g. bun unavailable), an actionable install hint is returned - do NOT alter `agents.<id>.command` to swap binaries. If ACP is disabled, follow the setup instructions in SKILL.md.",
+      "description": "Spawn an external coding agent (e.g. Claude Code, Codex, Gemini) via ACP to work on a task. Default profiles ship for `claude` (`claude-agent-acp`), `codex` (`codex-acp`), and `gemini` (`gemini --acp`); the assistant resolves the agent id to the right binary. The agent runs as a subprocess and streams results back. Use this when you want to delegate a coding task to an external agent that has its own tools, file editing, and terminal access. If a default agent's binary is missing, the assistant installs it once via a sandboxed bun global install and proceeds in the same call; if that fails (e.g. bun unavailable), an actionable install hint is returned - do NOT alter `agents.<id>.command` to swap binaries.",
       "category": "orchestration",
       "risk": "high",
       "input_schema": {
@@ -87,7 +87,7 @@
     },
     {
       "name": "acp_list_agents",
-      "description": "Lists ACP coding agents available to spawn. Each entry includes whether ACP is enabled, whether the agent's binary is on PATH (missing binaries are installed automatically on first spawn), and an install command if not. Use this to decide between 'claude', 'codex', and 'gemini' or to surface setup steps to the user.",
+      "description": "Lists ACP coding agents available to spawn. Each entry includes whether the agent's binary is on PATH (missing binaries are installed automatically on first spawn), and an install command if not. Use this to decide between 'claude', 'codex', and 'gemini' or to surface setup steps to the user.",
       "category": "orchestration",
       "risk": "low",
       "input_schema": {


### PR DESCRIPTION
## Summary
- Drop the vestigial acp.enabled field from AcpConfigSchema (no migration needed; Zod strips the leftover key).
- Update acp-defaults.ts comment and the bundled ACP SKILL.md / TOOLS.json so first-time setup is install-binary-then-spawn, with no instruction to enable ACP in config.

Part of plan: acp-native.md (PR 2 of 2)