### PR TITLE
Exempt skill_load results from post-turn tool-result truncation (JARVIS-1000)

### DIFF
--- a/assistant/src/__tests__/post-turn-tool-result-truncation.test.ts
+++ b/assistant/src/__tests__/post-turn-tool-result-truncation.test.ts
@@ -12,6 +12,7 @@ import {
   TARGET_CHARS,
   THRESHOLD_CHARS,
   TOOL_RESULT_DIR,
+  TRUNCATION_EXEMPT_TOOLS,
   TRUNCATION_MARKER,
 } from "../context/post-turn-tool-result-truncation.js";
 import type { ContentBlock, Message } from "../providers/types.js";
@@ -149,6 +150,74 @@ describe("postTurnTruncateToolResults", () => {
     expect(stub.endsWith(expectedSuffix)).toBe(true);
     expect(stub).toContain(TRUNCATION_MARKER);
     expect(stub).toContain(filePath);
+  });
+
+  test("skill_load result above threshold is NOT truncated (durable instructions exempt)", () => {
+    // Regression for JARVIS-1000: a hosted assistant lost its app-builder skill
+    // workflow when the large skill_load result was middle-truncated between the
+    // turn that loaded the skill and the turn that used it, then fell back to a
+    // local-dev (vite/localhost) build path.
+    const toolUseId = "tool_skill_load";
+    const skillBody = "S".repeat(THRESHOLD_CHARS + 5_000);
+    const messages: Message[] = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use" as const,
+            id: toolUseId,
+            name: "skill_load",
+            input: { skill: "app-builder" },
+          },
+        ],
+      },
+      { role: "user", content: [makeToolResult(skillBody, toolUseId)] },
+    ];
+
+    const { messages: result, truncatedCount } =
+      postTurnTruncateToolResults(messages, { conversationDir: convDir });
+
+    expect(truncatedCount).toBe(0);
+    expect(result).toBe(messages); // same reference — no copy
+    expect(existsSync(join(convDir, TOOL_RESULT_DIR))).toBe(false);
+
+    const block = result[1].content[0] as {
+      type: "tool_result";
+      content: string;
+    };
+    expect(block.content).toBe(skillBody);
+    expect(TRUNCATION_EXEMPT_TOOLS.has("skill_load")).toBe(true);
+  });
+
+  test("non-exempt tool result above threshold is still truncated when paired with a tool_use", () => {
+    // Control for the exemption: same shape as the skill_load case, but a tool
+    // that is NOT exempt must still be truncated.
+    const toolUseId = "tool_bash_1";
+    const longContent = "B".repeat(THRESHOLD_CHARS + 5_000);
+    const messages: Message[] = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use" as const,
+            id: toolUseId,
+            name: "bash",
+            input: { command: "cat big.log" },
+          },
+        ],
+      },
+      { role: "user", content: [makeToolResult(longContent, toolUseId)] },
+    ];
+
+    const { messages: result, truncatedCount } =
+      postTurnTruncateToolResults(messages, { conversationDir: convDir });
+
+    expect(truncatedCount).toBe(1);
+    const block = result[1].content[0] as {
+      type: "tool_result";
+      content: string;
+    };
+    expect(block.content).toContain(TRUNCATION_MARKER);
   });
 
   test("file path is deterministic for the same toolUseId", () => {

--- a/assistant/src/context/post-turn-tool-result-truncation.ts
+++ b/assistant/src/context/post-turn-tool-result-truncation.ts
@@ -23,6 +23,34 @@ export const TOOL_RESULT_DIR = ".tool-results";
 export const TRUNCATION_MARKER = "\u2014 full result:";
 
 /**
+ * Tools whose results carry durable operating instructions the model relies on
+ * across later turns rather than one-off data it only needs in the moment.
+ * Their results must never be middle-truncated: paging out the middle silently
+ * strips the workflow (e.g. a `skill_load` body losing its "## Available Tools"
+ * section), leaving the model to fall back to generic priors. Skill bodies are
+ * bounded and authored to live in context, so exempting them is safe.
+ */
+export const TRUNCATION_EXEMPT_TOOLS = new Set<string>(["skill_load"]);
+
+/**
+ * Build a map of tool_use_id -> originating tool name by walking the tool_use
+ * blocks in assistant messages. A tool_result only carries `tool_use_id`, so
+ * this is the only way to recover which tool produced a given result.
+ */
+function buildToolNameById(messages: Message[]): Map<string, string> {
+  const byId = new Map<string, string>();
+  for (const msg of messages) {
+    if (msg.role !== "assistant") continue;
+    for (const block of msg.content) {
+      if (block.type !== "tool_use") continue;
+      const tu = block as ToolUseContent;
+      byId.set(tu.id, tu.name);
+    }
+  }
+  return byId;
+}
+
+/**
  * Deterministic file path for a tool result's full content on disk.
  * Uses the first 12 hex chars of the SHA-256 of the tool_use_id.
  */
@@ -59,7 +87,8 @@ export function buildTruncatedContent(
  * - The in-context content is replaced with a prefix/suffix stub.
  *
  * Results are skipped if they are below threshold, are error results,
- * or have already been truncated (contain `TRUNCATION_MARKER`).
+ * have already been truncated (contain `TRUNCATION_MARKER`), or were produced
+ * by a tool in `TRUNCATION_EXEMPT_TOOLS` (durable instructions like skill bodies).
  *
  * Returns a shallow-copied messages array (only modified messages are cloned)
  * and the count of results that were truncated.
@@ -69,6 +98,8 @@ export function postTurnTruncateToolResults(
   options: { conversationDir: string },
 ): { messages: Message[]; truncatedCount: number } {
   let truncatedCount = 0;
+
+  const toolNameById = buildToolNameById(messages);
 
   const mapped = messages.map((msg) => {
     let changed = false;
@@ -81,6 +112,13 @@ export function postTurnTruncateToolResults(
 
       // Skip error results.
       if (tr.is_error) return block;
+
+      // Skip results from tools whose output is durable operating instructions
+      // (e.g. skill_load); middle-truncating them strips the workflow.
+      const toolName = toolNameById.get(tr.tool_use_id);
+      if (toolName !== undefined && TRUNCATION_EXEMPT_TOOLS.has(toolName)) {
+        return block;
+      }
 
       // Skip already-truncated results (idempotency).
       if (tr.content.includes(TRUNCATION_MARKER)) return block;


### PR DESCRIPTION
## Summary

Fixes JARVIS-1000: a platform-hosted assistant misidentified its deployment mode and built an app the way a local install would (raw Vite project, `bunx vite`, "open http://localhost:5174"), instead of producing an app in the user's hosted library.

## Root cause

The model did the right thing at first: it classified "build me a dashboard", called `skill_load("app-builder")`, and received the full skill. Skill tools are not first-class LLM tools; the model is meant to invoke them via `skill_execute` (e.g. `app_create`), as documented in the skill body's "## Available Tools" section.

But `postTurnTruncateToolResults` (`assistant/src/context/post-turn-tool-result-truncation.ts`) treats every large tool result identically. It middle-truncates anything over `THRESHOLD_CHARS` (8000) down to a ~1200-char head+tail stub and pages the full content out to disk. It could not tell `skill_load` apart from a giant `bash`/`file_read` dump because a `tool_result` only carries `tool_use_id`, not the tool name.

The reproduction timeline (from the attached feedback logs):

| Requests | State |
|---|---|
| 4-6 | Full app-builder workflow in context (skill just loaded) |
| 6 | Model paused with `yield_to_user` ("switch to quality mode?") instead of building |
| 7+ | skill_load result now truncated, workflow gone |
| 10, 23, 27 | App actually built here, with no workflow in context |

Because the model loaded the skill in one turn but only built in a later turn (after the quality-mode confirmation), post-turn truncation ran in the gap and stripped the middle of the skill_load result, including the build workflow and the "Use `skill_execute` to call these tools" section. Left with only the "you are an expert designer, build immediately" preamble, the model fell back to its generic training: scaffold a Vite project with `file_write`, run `bunx --bun vite`, and tell the hosted user to `bun install` / open `localhost`. It then guessed at `app_open` with a path-like id (`apps/demo-dashboard`) and failed validation. The user never got a library app.

## Fix

Skill bodies are durable operating instructions the model relies on across later turns, not one-off data, and they are bounded in size. This change builds a `tool_use_id -> tool_name` map (the same walk `derefToolResultReReads` already does) and skips truncation for tools in `TRUNCATION_EXEMPT_TOOLS` (`skill_load`). Other tools are unaffected and still truncate as before.

## Tests

- New: `skill_load` result above threshold is not truncated and no file is paged to disk.
- New control: a non-exempt tool (`bash`) with the same shape still truncates.
- All 15 tests in the suite pass; typecheck clean.

## Follow-ups (not in this PR)

Defense-in-depth gaps noted during diagnosis, worth separate tickets:
- The base system prompt never surfaces `getIsPlatform()`/`getIsContainerized()`, so nothing counteracts the local-dev fallback if skill instructions are ever lost.
- `app_open` accepts a free-form `app_id` and only fails deep in `validateId`; it could steer toward `app_create` on an unknown id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)