### PR TITLE
fix: drop stale acp.enabled references from ACP test fixtures

### DIFF
--- a/assistant/src/__tests__/skill-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/skill-feature-flags-integration.test.ts
@@ -247,8 +247,8 @@ describe("bundled acp skill discoverability", () => {
     expect(skillFlagKey(skill!)).toBeUndefined();
 
     const config = makeConfig({
-      acp: { enabled: true, maxConcurrentSessions: 4, agents: {} },
-    } as Partial<AssistantConfig>);
+      acp: { maxConcurrentSessions: 4, agents: {} },
+    });
 
     const resolved = resolveSkillStates([skill!], config);
     expect(resolved.length).toBe(1);

--- a/assistant/src/acp/__tests__/helpers/acp-config-stub.ts
+++ b/assistant/src/acp/__tests__/helpers/acp-config-stub.ts
@@ -20,13 +20,11 @@ import { mock } from "bun:test";
 import type { AcpAgentConfig } from "../../../config/acp-schema.js";
 
 export interface MockAcpConfig {
-  enabled: boolean;
   maxConcurrentSessions: number;
   agents: Record<string, AcpAgentConfig>;
 }
 
 const DEFAULT_CONFIG: MockAcpConfig = {
-  enabled: true,
   maxConcurrentSessions: 4,
   agents: {},
 };


### PR DESCRIPTION
## Summary
Post-removal cleanup for the acp-native plan: the ACP config no longer has an `enabled` field, but two test fixtures still carried it.

- acp-config-stub.ts: drop `MockAcpConfig.enabled` and its default.
- skill-feature-flags-integration.test.ts: drop the stale `acp.enabled: true` override key.