### PR TITLE
Fix oversized tool-result images wedging conversations (JARVIS-1041)

### DIFF
--- a/assistant/src/__tests__/conversation-error.test.ts
+++ b/assistant/src/__tests__/conversation-error.test.ts
@@ -319,7 +319,6 @@ describe("classifyConversationError", () => {
       expect(result.errorCategory).toBe("image_dimensions_too_large");
       expect(result.retryable).toBe(false);
       expect(result.userMessage).toContain("image");
-      expect(result.userMessage).toContain("8000");
     });
 
     it("matches the singular 'image dimension exceeds' phrasing as well", () => {
@@ -329,6 +328,21 @@ describe("classifyConversationError", () => {
         400,
       );
       const result = classifyConversationError(err, baseCtx);
+      expect(result.errorCategory).toBe("image_dimensions_too_large");
+      expect(result.retryable).toBe(false);
+    });
+
+    it("classifies the base64 payload 'exceeds 5 MB maximum' variant as IMAGE_TOO_LARGE (JARVIS-1041)", () => {
+      // This is the exact shape that wedged the reporting user: an oversized
+      // image nested in a tool_result. It must route to IMAGE_TOO_LARGE so the
+      // recovery path fires, not to a retryable PROVIDER_API loop.
+      const err = new ProviderError(
+        'Anthropic API error (400): 400 {"type":"error","error":{"type":"invalid_request_error","message":"messages.28.content.1.tool_result.content.1.image.source.base64: image exceeds 5 MB maximum: 7465044 bytes > 5242880 bytes"},"request_id":"req_011CbbFqvxBmDQdhVlqxtAfW"}',
+        "anthropic",
+        400,
+      );
+      const result = classifyConversationError(err, baseCtx);
+      expect(result.code).toBe("IMAGE_TOO_LARGE");
       expect(result.errorCategory).toBe("image_dimensions_too_large");
       expect(result.retryable).toBe(false);
     });

--- a/assistant/src/__tests__/conversation-history-web-search.test.ts
+++ b/assistant/src/__tests__/conversation-history-web-search.test.ts
@@ -809,6 +809,11 @@ describe("web_search_tool_result structural guard", () => {
     // contentBlocks property, so it cannot contain nested media.
     "plugins/defaults/compaction/context-overflow-reducer.ts",
 
+    // Downgrades permanently-unsendable images nested in tool_result.contentBlocks
+    // (e.g. an oversized browser screenshot). web_search_tool_result has opaque
+    // content with no contentBlocks property, so it cannot hold such an image.
+    "daemon/persist-unsendable-image.ts",
+
     // Final orphan-pair safety pass in the Slack transcript renderer.
     // Server-side block types (`server_tool_use`, `web_search_tool_result`)
     // are stripped earlier by `buildMessageContentBlocks` and cannot reach

--- a/assistant/src/__tests__/persist-unsendable-image-downscale.test.ts
+++ b/assistant/src/__tests__/persist-unsendable-image-downscale.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Regression test for the durable-downscale path of the image-too-large
+ * recovery (JARVIS-1041 review follow-up).
+ *
+ * When an oversized stored image *can* be shrunk on this host (the common macOS
+ * path where `sips` is available), `persistUnsendableImageDowngrades` must write
+ * the downscaled bytes back to the DB — not leave the original in place. The
+ * latest tool-result media is intentionally kept in context, so leaving the
+ * full-size block would rehydrate and re-reject on every later turn instead of
+ * durably self-healing the conversation.
+ *
+ * `optimizeImageForTransport` needs `sips` and a decodable image to actually
+ * downscale, which is not portable to CI, so it is mocked here to simulate a
+ * successful shrink. The mock is process-global, so this case lives in its own
+ * file (the test runner isolates each file in its own process) to avoid
+ * disturbing the no-op-resize cases in persist-unsendable-image.test.ts.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Module mock (must precede the import of the module under test) ────
+// Simulate a host where resizing succeeds: any oversized image is shrunk to a
+// small, distinct JPEG payload. durableImageReplacement checks the provider
+// caps before calling this, so in-limit images never reach the mock.
+const SHRUNK_DATA = "c2hydW5r"; // base64 for "shrunk"
+mock.module("../agent/image-optimize.js", () => ({
+  optimizeImageForTransport: () => ({
+    data: SHRUNK_DATA,
+    mediaType: "image/jpeg",
+  }),
+}));
+
+import { persistUnsendableImageDowngrades } from "../daemon/persist-unsendable-image.js";
+import {
+  addMessage,
+  createConversation,
+  getMessages,
+} from "../memory/conversation-crud.js";
+import { getDb } from "../memory/db-connection.js";
+import { initializeDb } from "../memory/db-init.js";
+import type { ContentBlock } from "../providers/types.js";
+
+initializeDb();
+
+function resetTables(): void {
+  const db = getDb();
+  db.run("DELETE FROM message_attachments");
+  db.run("DELETE FROM attachments");
+  db.run("DELETE FROM memory_segments");
+  db.run("DELETE FROM memory_embeddings");
+  db.run("DELETE FROM messages");
+  db.run("DELETE FROM conversations");
+}
+
+/** Minimal PNG whose IHDR declares dimensions past the 8000px provider cap. */
+function oversizedPngBase64(): string {
+  const width = 12000;
+  const height = 9000;
+  return Buffer.from(
+    Uint8Array.from([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, // PNG signature
+      0x00, 0x00, 0x00, 0x0d, // IHDR length (13)
+      0x49, 0x48, 0x44, 0x52, // "IHDR"
+      (width >>> 24) & 0xff,
+      (width >>> 16) & 0xff,
+      (width >>> 8) & 0xff,
+      width & 0xff,
+      (height >>> 24) & 0xff,
+      (height >>> 16) & 0xff,
+      (height >>> 8) & 0xff,
+      height & 0xff,
+      0x08, 0x06, 0x00, 0x00, 0x00,
+    ]),
+  ).toString("base64");
+}
+
+function toolResultWithImage(data: string): ContentBlock {
+  return {
+    type: "tool_result",
+    tool_use_id: "toolu_123",
+    content: "Screenshot captured",
+    contentBlocks: [
+      { type: "image", source: { type: "base64", media_type: "image/png", data } },
+    ],
+  };
+}
+
+function storedContent(conversationId: string): ContentBlock[][] {
+  return getMessages(conversationId).map(
+    (row) => JSON.parse(row.content) as ContentBlock[],
+  );
+}
+
+describe("persistUnsendableImageDowngrades (downscalable host)", () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  /** JARVIS-1041: an oversized screenshot that CAN be shrunk must persist the
+   *  downscaled bytes, not the note and not the original. */
+  test("persists the downscaled image for a shrinkable tool_result screenshot", async () => {
+    // GIVEN a tool_result holding an oversized but shrinkable screenshot
+    const conv = createConversation();
+    await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([toolResultWithImage(oversizedPngBase64())]),
+      { skipIndexing: true },
+    );
+
+    // WHEN the downgrade is persisted
+    const rewritten = persistUnsendableImageDowngrades(conv.id);
+
+    // THEN the nested block stays an image, rewritten to the downscaled payload
+    expect(rewritten).toBe(1);
+    const [content] = storedContent(conv.id);
+    const toolResult = content.find((b) => b.type === "tool_result") as {
+      contentBlocks?: ContentBlock[];
+    };
+    const nested = toolResult.contentBlocks?.[0];
+    expect(nested?.type).toBe("image");
+    expect((nested as Extract<ContentBlock, { type: "image" }>).source.data).toBe(
+      SHRUNK_DATA,
+    );
+  });
+
+  /** Re-running is a no-op: the downscaled payload is within limits. */
+  test("is idempotent after a downscale rewrite", async () => {
+    // GIVEN a conversation whose oversized screenshot was already downscaled
+    const conv = createConversation();
+    await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([toolResultWithImage(oversizedPngBase64())]),
+      { skipIndexing: true },
+    );
+    expect(persistUnsendableImageDowngrades(conv.id)).toBe(1);
+
+    // WHEN the downgrade runs again
+    const secondRun = persistUnsendableImageDowngrades(conv.id);
+
+    // THEN nothing further is rewritten
+    expect(secondRun).toBe(0);
+  });
+});

--- a/assistant/src/__tests__/persist-unsendable-image.test.ts
+++ b/assistant/src/__tests__/persist-unsendable-image.test.ts
@@ -14,7 +14,10 @@
 
 import { beforeEach, describe, expect, test } from "bun:test";
 
-import { persistUnsendableImageDowngrades } from "../daemon/persist-unsendable-image.js";
+import {
+  oversizedImageReplacement,
+  persistUnsendableImageDowngrades,
+} from "../daemon/persist-unsendable-image.js";
 import {
   addMessage,
   createConversation,
@@ -280,5 +283,29 @@ describe("persistUnsendableImageDowngrades", () => {
 
     // THEN nothing further is rewritten
     expect(secondRun).toBe(0);
+  });
+});
+
+describe("oversizedImageReplacement", () => {
+  /** A still-sendable image must be left alone — never replaced with a note.
+   *  This is the gate that keeps the in-memory recovery from discarding valid
+   *  screenshots when only one image in the turn was actually oversized. */
+  test("returns null for an image within the provider caps", () => {
+    const sendable = imageBlock(makePngBase64(1024, 768)) as Extract<
+      ContentBlock,
+      { type: "image" }
+    >;
+    expect(oversizedImageReplacement(sendable)).toBeNull();
+  });
+
+  /** An image past the provider caps that cannot be shrunk on this host (fake
+   *  PNG that sips cannot decode) collapses to the unsendable note. */
+  test("returns the unsendable note when an oversized image cannot be shrunk", () => {
+    const oversized = imageBlock(makePngBase64(12000, 9000)) as Extract<
+      ContentBlock,
+      { type: "image" }
+    >;
+    const replacement = oversizedImageReplacement(oversized);
+    expect(replacement?.type).toBe("text");
   });
 });

--- a/assistant/src/__tests__/persist-unsendable-image.test.ts
+++ b/assistant/src/__tests__/persist-unsendable-image.test.ts
@@ -87,6 +87,20 @@ function imageBlock(data: string): ContentBlock {
   };
 }
 
+/**
+ * A tool_result carrying a nested image in its contentBlocks, mirroring what a
+ * browser screenshot produces. This is the JARVIS-1041 shape: the oversized
+ * image lives at tool_result.contentBlocks, never as a top-level block.
+ */
+function toolResultWithImage(data: string): ContentBlock {
+  return {
+    type: "tool_result",
+    tool_use_id: "toolu_123",
+    content: "Screenshot captured",
+    contentBlocks: [imageBlock(data)],
+  };
+}
+
 function storedContent(conversationId: string): ContentBlock[][] {
   return getMessages(conversationId).map(
     (row) => JSON.parse(row.content) as ContentBlock[],
@@ -192,6 +206,61 @@ describe("persistUnsendableImageDowngrades", () => {
     expect(rewritten).toBe(1);
     const [content] = storedContent(conv.id);
     expect(content.some((b) => b.type === "image")).toBe(false);
+  });
+
+  /** JARVIS-1041: the oversized image is nested inside a tool_result (e.g. a
+   *  browser screenshot), not a top-level block. The downgrade must descend
+   *  into tool_result.contentBlocks and swap the nested image for a note, while
+   *  keeping the tool_result itself intact so tool_use/tool_result pairing
+   *  survives. */
+  test("downgrades an oversized image nested in tool_result.contentBlocks", async () => {
+    // GIVEN an assistant turn whose tool_result holds an oversized screenshot
+    const conv = createConversation();
+    await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([toolResultWithImage(makePngBase64(12000, 9000))]),
+      { skipIndexing: true },
+    );
+
+    // WHEN the downgrade is persisted
+    const rewritten = persistUnsendableImageDowngrades(conv.id);
+
+    // THEN the message is rewritten with the nested image swapped for a note
+    expect(rewritten).toBe(1);
+    const [content] = storedContent(conv.id);
+    const toolResult = content.find((b) => b.type === "tool_result");
+    expect(toolResult).toBeDefined();
+    // AND the tool_result is preserved (pairing intact) with no image left
+    const nested = (toolResult as { contentBlocks?: ContentBlock[] })
+      .contentBlocks;
+    expect(nested?.some((b) => b.type === "image")).toBe(false);
+    expect(nested?.some((b) => b.type === "text")).toBe(true);
+  });
+
+  /** A sendable nested screenshot is never disturbed. */
+  test("leaves a normally-sized tool_result image untouched", async () => {
+    // GIVEN a tool_result with an image well within provider limits
+    const conv = createConversation();
+    await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([toolResultWithImage(makePngBase64(1024, 768))]),
+      { skipIndexing: true },
+    );
+
+    // WHEN the downgrade is persisted
+    const rewritten = persistUnsendableImageDowngrades(conv.id);
+
+    // THEN nothing is rewritten and the nested image remains
+    expect(rewritten).toBe(0);
+    const [content] = storedContent(conv.id);
+    const toolResult = content.find((b) => b.type === "tool_result") as {
+      contentBlocks?: ContentBlock[];
+    };
+    expect(toolResult.contentBlocks?.some((b) => b.type === "image")).toBe(
+      true,
+    );
   });
 
   /** Re-running after a rewrite is a safe no-op (no image blocks remain). */

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -170,6 +170,48 @@ function formatDiskPressureBlockedMessage(): string {
   return "Storage is critically low, so background processes are paused and remote messages are ignored until the guardian frees enough space. Remote senders should try again later.";
 }
 
+// ── Image-recovery helpers ───────────────────────────────────────────
+
+/**
+ * True when a message's content holds an image the provider may have rejected
+ * for being oversized — either a top-level image block (user upload) or one
+ * nested inside a tool_result's contentBlocks (e.g. a browser screenshot).
+ */
+function messageHasImageBlock(content: ContentBlock[]): boolean {
+  return content.some(
+    (b) =>
+      b.type === "image" ||
+      (b.type === "tool_result" &&
+        (b.contentBlocks?.some((cb) => cb.type === "image") ?? false)),
+  );
+}
+
+/**
+ * Downscale an oversized image block to fit the provider's limits. When sips
+ * manages to shrink it, the smaller version is returned; when it can't (e.g.
+ * sips is unavailable off macOS), the image is replaced with a text note so the
+ * model can explain the situation instead of the turn hard-failing.
+ */
+function downgradeOversizedImage(
+  block: Extract<ContentBlock, { type: "image" }>,
+): ContentBlock {
+  const resized = optimizeImageForTransport(
+    block.source.data,
+    block.source.media_type,
+  );
+  if (resized.data !== block.source.data) {
+    return {
+      ...block,
+      source: {
+        type: "base64" as const,
+        media_type: resized.mediaType,
+        data: resized.data,
+      },
+    };
+  }
+  return { type: "text" as const, text: UNSENDABLE_IMAGE_NOTE };
+}
+
 // ── Plugin pipeline helpers ──────────────────────────────────────────
 
 /**
@@ -1052,7 +1094,10 @@ export async function runAgentLoopImpl(
 
     // ── Image-dimension overflow recovery ──────────────────────────
     // When the provider rejects because an image block exceeds its pixel
-    // cap, strip every image block from ctx.messages and retry once.
+    // or payload cap, downscale or strip every image from ctx.messages and
+    // retry once. This covers both top-level image blocks (user uploads)
+    // and images nested inside a tool_result's contentBlocks (e.g. a
+    // browser screenshot), which is where the rejected block usually lives.
     // optimizeImageForTransport already ran at upload time; if sips was
     // unavailable (non-macOS) it returns the same bytes unchanged.  In
     // that case we swap the block for a text note so the model can tell
@@ -1065,31 +1110,26 @@ export async function runAgentLoopImpl(
       );
       ctx.messages = ctx.messages.map((msg) => {
         if (!Array.isArray(msg.content)) return msg;
-        if (!msg.content.some((b) => b.type === "image")) return msg;
+        if (!messageHasImageBlock(msg.content)) return msg;
         return {
           ...msg,
           content: msg.content.flatMap((b): ContentBlock[] => {
-            if (b.type !== "image") return [b];
-            const resized = optimizeImageForTransport(
-              b.source.data,
-              b.source.media_type,
-            );
-            if (resized.data !== b.source.data) {
-              // sips managed to downscale — use the smaller version
+            if (b.type === "image") return [downgradeOversizedImage(b)];
+            // Images returned by a tool (e.g. browser_screenshot) live in
+            // the tool_result's contentBlocks, not as top-level blocks.
+            // Downgrade them in place so the tool_use/tool_result pairing
+            // stays intact rather than dropping the whole tool_result.
+            if (b.type === "tool_result" && b.contentBlocks?.length) {
               return [
                 {
                   ...b,
-                  source: {
-                    type: "base64" as const,
-                    media_type: resized.mediaType,
-                    data: resized.data,
-                  },
+                  contentBlocks: b.contentBlocks.map((cb) =>
+                    cb.type === "image" ? downgradeOversizedImage(cb) : cb,
+                  ),
                 },
               ];
             }
-            // Can't resize — replace with a text annotation so the model
-            // can explain the situation rather than silently dropping context
-            return [{ type: "text" as const, text: UNSENDABLE_IMAGE_NOTE }];
+            return [b];
           }),
         };
       });

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -9,7 +9,6 @@
 
 import { v4 as uuid } from "uuid";
 
-import { optimizeImageForTransport } from "../agent/image-optimize.js";
 import type {
   AgentEvent,
   AgentLoopExitReason,
@@ -142,8 +141,8 @@ import type {
 } from "./message-protocol.js";
 import { parseActualTokensFromError } from "./parse-actual-tokens-from-error.js";
 import {
+  oversizedImageReplacement,
   persistUnsendableImageDowngrades,
-  UNSENDABLE_IMAGE_NOTE,
 } from "./persist-unsendable-image.js";
 import { resolveTrustClass, type TrustContext } from "./trust-context.js";
 
@@ -187,29 +186,15 @@ function messageHasImageBlock(content: ContentBlock[]): boolean {
 }
 
 /**
- * Downscale an oversized image block to fit the provider's limits. When sips
- * manages to shrink it, the smaller version is returned; when it can't (e.g.
- * sips is unavailable off macOS), the image is replaced with a text note so the
- * model can explain the situation instead of the turn hard-failing.
+ * Replace an oversized image with its downscaled form or an unsendable note,
+ * leaving still-sendable images untouched. Delegates to the shared
+ * {@link oversizedImageReplacement} so the in-memory recovery and the durable
+ * persist pass apply the identical provider-cap gate.
  */
-function downgradeOversizedImage(
+function recoverImageBlock(
   block: Extract<ContentBlock, { type: "image" }>,
 ): ContentBlock {
-  const resized = optimizeImageForTransport(
-    block.source.data,
-    block.source.media_type,
-  );
-  if (resized.data !== block.source.data) {
-    return {
-      ...block,
-      source: {
-        type: "base64" as const,
-        media_type: resized.mediaType,
-        data: resized.data,
-      },
-    };
-  }
-  return { type: "text" as const, text: UNSENDABLE_IMAGE_NOTE };
+  return oversizedImageReplacement(block) ?? block;
 }
 
 // ── Plugin pipeline helpers ──────────────────────────────────────────
@@ -1094,19 +1079,18 @@ export async function runAgentLoopImpl(
 
     // ── Image-dimension overflow recovery ──────────────────────────
     // When the provider rejects because an image block exceeds its pixel
-    // or payload cap, downscale or strip every image from ctx.messages and
-    // retry once. This covers both top-level image blocks (user uploads)
-    // and images nested inside a tool_result's contentBlocks (e.g. a
-    // browser screenshot), which is where the rejected block usually lives.
-    // optimizeImageForTransport already ran at upload time; if sips was
-    // unavailable (non-macOS) it returns the same bytes unchanged.  In
-    // that case we swap the block for a text note so the model can tell
-    // the user what happened instead of hard-failing with a red banner.
+    // or payload cap, recover every oversized image in ctx.messages and
+    // retry once. recoverImageBlock downscales an oversized image, or swaps
+    // it for a text note when resize is a no-op (e.g. sips unavailable
+    // off macOS), while leaving still-sendable images untouched. This covers
+    // both top-level image blocks (user uploads) and images nested inside a
+    // tool_result's contentBlocks (e.g. a browser screenshot), which is where
+    // the rejected block usually lives.
     if (state.imageTooLargeDetected) {
       state.imageTooLargeDetected = false;
       rlog.warn(
         { phase: "image-recovery" },
-        "Image too large — stripping oversized image blocks and retrying",
+        "Image too large — recovering oversized image blocks and retrying",
       );
       ctx.messages = ctx.messages.map((msg) => {
         if (!Array.isArray(msg.content)) return msg;
@@ -1114,17 +1098,17 @@ export async function runAgentLoopImpl(
         return {
           ...msg,
           content: msg.content.flatMap((b): ContentBlock[] => {
-            if (b.type === "image") return [downgradeOversizedImage(b)];
+            if (b.type === "image") return [recoverImageBlock(b)];
             // Images returned by a tool (e.g. browser_screenshot) live in
             // the tool_result's contentBlocks, not as top-level blocks.
-            // Downgrade them in place so the tool_use/tool_result pairing
+            // Recover them in place so the tool_use/tool_result pairing
             // stays intact rather than dropping the whole tool_result.
             if (b.type === "tool_result" && b.contentBlocks?.length) {
               return [
                 {
                   ...b,
                   contentBlocks: b.contentBlocks.map((cb) =>
-                    cb.type === "image" ? downgradeOversizedImage(cb) : cb,
+                    cb.type === "image" ? recoverImageBlock(cb) : cb,
                   ),
                 },
               ];

--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -150,11 +150,15 @@ const STREAMING_ERROR_PATTERNS = [
 ];
 
 // User-initiated cancellation patterns — these should NOT produce conversation_error
-// Image-input validation patterns — Anthropic 400s with this message when an image
-// block exceeds the per-side pixel cap. Distinct classification matters because
-// retrying with the same oversized image is futile; the user needs to resize.
+// Image-input validation patterns — Anthropic 400s with one of these messages
+// when an image block violates a hard limit. The first matches the per-side
+// pixel cap ("image dimensions exceed max allowed size"); the second matches the
+// base64 payload cap ("image exceeds 5 MB maximum: 7465044 bytes > 5242880
+// bytes"). Distinct classification matters because retrying with the same
+// oversized image is futile — the recovery path must strip or downscale it.
 const IMAGE_DIMENSIONS_TOO_LARGE_PATTERNS = [
   /image dimensions? exceeds? max allowed size/i,
+  /image exceeds \d+\s*MB maximum/i,
 ];
 
 const CANCEL_PATTERNS = [/abort/i, /cancel/i];
@@ -447,7 +451,7 @@ function classifyCore(
         return {
           code: "IMAGE_TOO_LARGE",
           userMessage:
-            "An attached image is too large for the AI provider — image dimensions must be under 8000 pixels per side. Resize the image and try again.",
+            "An image in this conversation was too large for the AI provider and was automatically reduced. Send your message again to continue.",
           retryable: false,
           errorCategory: "image_dimensions_too_large",
         };

--- a/assistant/src/daemon/persist-unsendable-image.ts
+++ b/assistant/src/daemon/persist-unsendable-image.ts
@@ -70,6 +70,18 @@ function isImagePermanentlyUnsendable(
 }
 
 /**
+ * Replacement note for a permanently unsendable image, or null when the image
+ * is fine and should be left untouched. Shared by the top-level and nested
+ * (tool_result.contentBlocks) downgrade paths.
+ */
+function unsendableImageNote(
+  block: Extract<ContentBlock, { type: "image" }>,
+): ContentBlock | null {
+  if (!isImagePermanentlyUnsendable(block)) return null;
+  return { type: "text", text: UNSENDABLE_IMAGE_NOTE };
+}
+
+/**
  * Rewrite every stored message in a conversation that holds a permanently
  * unsendable image, replacing those image blocks with {@link
  * UNSENDABLE_IMAGE_NOTE}. Reads stored content directly (not the in-memory,
@@ -99,10 +111,29 @@ export function persistUnsendableImageDowngrades(
 
     let changed = false;
     const next = (parsed as ContentBlock[]).map((block): ContentBlock => {
-      if (block.type !== "image") return block;
-      if (!isImagePermanentlyUnsendable(block)) return block;
-      changed = true;
-      return { type: "text", text: UNSENDABLE_IMAGE_NOTE };
+      if (block.type === "image") {
+        const note = unsendableImageNote(block);
+        if (!note) return block;
+        changed = true;
+        return note;
+      }
+      // Images returned by a tool (e.g. browser_screenshot) live inside the
+      // tool_result's contentBlocks, not as top-level blocks. Downgrade them
+      // in place so the tool_use/tool_result pairing stays intact.
+      if (block.type === "tool_result" && block.contentBlocks?.length) {
+        let nestedChanged = false;
+        const contentBlocks = block.contentBlocks.map((cb): ContentBlock => {
+          if (cb.type !== "image") return cb;
+          const note = unsendableImageNote(cb);
+          if (!note) return cb;
+          nestedChanged = true;
+          return note;
+        });
+        if (!nestedChanged) return block;
+        changed = true;
+        return { ...block, contentBlocks };
+      }
+      return block;
     });
     if (!changed) continue;
 

--- a/assistant/src/daemon/persist-unsendable-image.ts
+++ b/assistant/src/daemon/persist-unsendable-image.ts
@@ -41,20 +41,23 @@ export const UNSENDABLE_IMAGE_NOTE =
   "(An image was attached but could not be sent — its dimensions exceed the provider limit and automatic resize was not available. Please resize the image and try again.)";
 
 /**
- * Durable replacement for a stored image that violates a provider hard limit
- * (per-side pixel cap or payload size), or null when the image is within limits
- * and should be left untouched.
+ * Replacement for an image that violates a provider hard limit (per-side pixel
+ * cap or payload size), or null when the image is within limits and should be
+ * left untouched. Gating on the provider hard caps is what keeps still-sendable
+ * images intact: a normally sized image is left alone rather than being noted or
+ * needlessly rewritten.
  *
- * Mirrors the in-memory recovery transform so the persisted history matches what
- * the model is sent: an oversized image that can be shrunk is rewritten to its
- * downscaled form; one that cannot be shrunk on this host (resize is a no-op,
- * e.g. `sips` is absent off macOS or the format is unsupported) is replaced with
- * a text note. Persisting the downscaled form is what lets a poisoned
- * conversation durably self-heal — the latest tool-result media is kept in
- * context, so without it the original oversized block rehydrates and re-rejects
- * on every later turn.
+ * An oversized image that can be shrunk is rewritten to its downscaled form; one
+ * that cannot be shrunk on this host (resize is a no-op, e.g. `sips` is absent
+ * off macOS or the format is unsupported) is replaced with a text note.
+ *
+ * Shared by the in-memory recovery transform and this durable persist pass so
+ * both apply the identical rule. Persisting the downscaled form is what lets a
+ * poisoned conversation durably self-heal — the latest tool-result media is kept
+ * in context, so without it the original oversized block rehydrates and
+ * re-rejects on every later turn.
  */
-function durableImageReplacement(
+export function oversizedImageReplacement(
   block: Extract<ContentBlock, { type: "image" }>,
 ): ContentBlock | null {
   const payloadBytes = block.source.data.length;
@@ -115,7 +118,7 @@ export function persistUnsendableImageDowngrades(
     let changed = false;
     const next = (parsed as ContentBlock[]).map((block): ContentBlock => {
       if (block.type === "image") {
-        const replacement = durableImageReplacement(block);
+        const replacement = oversizedImageReplacement(block);
         if (!replacement) return block;
         changed = true;
         return replacement;
@@ -127,7 +130,7 @@ export function persistUnsendableImageDowngrades(
         let nestedChanged = false;
         const contentBlocks = block.contentBlocks.map((cb): ContentBlock => {
           if (cb.type !== "image") return cb;
-          const replacement = durableImageReplacement(cb);
+          const replacement = oversizedImageReplacement(cb);
           if (!replacement) return cb;
           nestedChanged = true;
           return replacement;

--- a/assistant/src/daemon/persist-unsendable-image.ts
+++ b/assistant/src/daemon/persist-unsendable-image.ts
@@ -6,8 +6,9 @@
  * retries. That transformation is transient — the stored message row keeps the
  * full-size image block, so the rejected image is rehydrated on every later
  * turn and keeps re-entering the model's context. This module makes the
- * downgrade durable for images that can *never* be transmitted, so a rejected
- * upload cannot resurface after the user re-uploads a smaller version.
+ * downgrade durable: the oversized block is rewritten to its downscaled form,
+ * or to a text note when it cannot be shrunk on this host, so a rejected image
+ * cannot resurface and re-reject on every later turn.
  */
 
 import { optimizeImageForTransport } from "../agent/image-optimize.js";
@@ -40,19 +41,22 @@ export const UNSENDABLE_IMAGE_NOTE =
   "(An image was attached but could not be sent — its dimensions exceed the provider limit and automatic resize was not available. Please resize the image and try again.)";
 
 /**
- * True when a stored image block can never be transmitted to the provider: it
- * violates a provider hard limit (per-side pixel cap or payload size) and
- * cannot be shrunk to fit (re-optimization is a no-op).
+ * Durable replacement for a stored image that violates a provider hard limit
+ * (per-side pixel cap or payload size), or null when the image is within limits
+ * and should be left untouched.
  *
- * Stored blocks are already post-optimization, so a block that is still
- * oversized here only stays oversized because resizing is unavailable on this
- * host (e.g. `sips` is absent off macOS, or the format is unsupported). A
- * downscalable image would have been reduced at upload time and would not reach
- * this predicate, so it is left untouched.
+ * Mirrors the in-memory recovery transform so the persisted history matches what
+ * the model is sent: an oversized image that can be shrunk is rewritten to its
+ * downscaled form; one that cannot be shrunk on this host (resize is a no-op,
+ * e.g. `sips` is absent off macOS or the format is unsupported) is replaced with
+ * a text note. Persisting the downscaled form is what lets a poisoned
+ * conversation durably self-heal — the latest tool-result media is kept in
+ * context, so without it the original oversized block rehydrates and re-rejects
+ * on every later turn.
  */
-function isImagePermanentlyUnsendable(
+function durableImageReplacement(
   block: Extract<ContentBlock, { type: "image" }>,
-): boolean {
+): ContentBlock | null {
   const payloadBytes = block.source.data.length;
   const dims = parseImageDimensions(block.source.data, block.source.media_type);
   const exceedsDimensionCap =
@@ -60,36 +64,35 @@ function isImagePermanentlyUnsendable(
     (dims.width > PROVIDER_MAX_IMAGE_DIMENSION ||
       dims.height > PROVIDER_MAX_IMAGE_DIMENSION);
   const exceedsPayloadCap = payloadBytes > PROVIDER_MAX_IMAGE_PAYLOAD_BYTES;
-  if (!exceedsDimensionCap && !exceedsPayloadCap) return false;
+  if (!exceedsDimensionCap && !exceedsPayloadCap) return null;
 
   const optimized = optimizeImageForTransport(
     block.source.data,
     block.source.media_type,
   );
-  return optimized.data === block.source.data;
-}
-
-/**
- * Replacement note for a permanently unsendable image, or null when the image
- * is fine and should be left untouched. Shared by the top-level and nested
- * (tool_result.contentBlocks) downgrade paths.
- */
-function unsendableImageNote(
-  block: Extract<ContentBlock, { type: "image" }>,
-): ContentBlock | null {
-  if (!isImagePermanentlyUnsendable(block)) return null;
+  if (optimized.data !== block.source.data) {
+    return {
+      type: "image",
+      source: {
+        type: "base64",
+        media_type: optimized.mediaType,
+        data: optimized.data,
+      },
+    };
+  }
   return { type: "text", text: UNSENDABLE_IMAGE_NOTE };
 }
 
 /**
- * Rewrite every stored message in a conversation that holds a permanently
- * unsendable image, replacing those image blocks with {@link
- * UNSENDABLE_IMAGE_NOTE}. Reads stored content directly (not the in-memory,
- * injection-enriched copy) so injected prefixes and hydrated source paths are
- * never written back.
+ * Rewrite every stored message in a conversation that holds an oversized image
+ * the provider rejects — whether a top-level block or one nested in a
+ * tool_result's contentBlocks — replacing it with its downscaled form, or with
+ * {@link UNSENDABLE_IMAGE_NOTE} when it cannot be shrunk on this host. Reads
+ * stored content directly (not the in-memory, injection-enriched copy) so
+ * injected prefixes and hydrated source paths are never written back.
  *
- * Idempotent: once an image is replaced by the note there is no image block
- * left to match, so re-running is a no-op. Returns the number of rewritten
+ * Idempotent: a downscaled image is within limits and a note is no longer an
+ * image, so neither matches on a second run. Returns the number of rewritten
  * messages.
  */
 export function persistUnsendableImageDowngrades(
@@ -112,10 +115,10 @@ export function persistUnsendableImageDowngrades(
     let changed = false;
     const next = (parsed as ContentBlock[]).map((block): ContentBlock => {
       if (block.type === "image") {
-        const note = unsendableImageNote(block);
-        if (!note) return block;
+        const replacement = durableImageReplacement(block);
+        if (!replacement) return block;
         changed = true;
-        return note;
+        return replacement;
       }
       // Images returned by a tool (e.g. browser_screenshot) live inside the
       // tool_result's contentBlocks, not as top-level blocks. Downgrade them
@@ -124,10 +127,10 @@ export function persistUnsendableImageDowngrades(
         let nestedChanged = false;
         const contentBlocks = block.contentBlocks.map((cb): ContentBlock => {
           if (cb.type !== "image") return cb;
-          const note = unsendableImageNote(cb);
-          if (!note) return cb;
+          const replacement = durableImageReplacement(cb);
+          if (!replacement) return cb;
           nestedChanged = true;
-          return note;
+          return replacement;
         });
         if (!nestedChanged) return block;
         changed = true;

--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -1,3 +1,4 @@
+import { optimizeImageForTransport } from "../../agent/image-optimize.js";
 import { getConfig } from "../../config/loader.js";
 import { HostBrowserProxy } from "../../daemon/host-browser-proxy.js";
 import type { ImageContent } from "../../providers/types.js";
@@ -1206,13 +1207,22 @@ export async function executeBrowserScreenshot(
       { quality: 80, fullPage },
       context.signal,
     );
-    const base64Data = buffer.toString("base64");
+    const rawBase64 = buffer.toString("base64");
+
+    // Downscale before handing the screenshot to the model. A full-page
+    // capture of a tall or high-DPI page can exceed Anthropic's 5 MB
+    // per-image cap, which would otherwise persist into the conversation
+    // history inside this tool_result and reject every subsequent turn.
+    const { data: base64Data, mediaType } = optimizeImageForTransport(
+      rawBase64,
+      "image/jpeg",
+    );
 
     const imageBlock: ImageContent = {
       type: "image" as const,
       source: {
         type: "base64" as const,
-        media_type: "image/jpeg",
+        media_type: mediaType,
         data: base64Data,
       },
     };


### PR DESCRIPTION
## Summary
- An oversized image returned by a tool (e.g. a full-page browser screenshot) was persisted into conversation history inside a `tool_result`, and every subsequent turn re-sent it and got the same HTTP 400 `image exceeds 5 MB maximum`, permanently wedging the conversation. The user reported every message failing despite healthy billing.
- Fixes three compounding gaps: (1) browser screenshots now run through `optimizeImageForTransport` at capture time so oversized captures are downscaled before they persist; (2) the byte-size error variant is now classified as `IMAGE_TOO_LARGE` so the recovery path fires instead of an infinite retryable `PROVIDER_API` loop; (3) both the in-memory recovery transform and the durable `persistUnsendableImageDowngrades` now recurse into `tool_result.contentBlocks`, downscaling or replacing the nested image while keeping tool_use/tool_result pairing intact, so already-poisoned conversations self-heal.
- Reworded the `IMAGE_TOO_LARGE` user message, which wrongly told users to resize an image they never attached, and added unit tests for the byte-size classification and the nested-tool_result downgrade.

## Original prompt
Triage of Linear JARVIS-1041, where a user reported every message to their assistant failing with an API error despite confirmed billing and no Anthropic outage. The attached client logs revealed the real cause: a 7.46 MB image wedged inside a `tool_result` at message 28 of the history, rejected by Anthropic's 5 MB per-image cap on every turn. The ask was to diagnose and fix the root cause across the prevention, classification, and recovery layers so the conversation can recover and the failure stops recurring.