### PR TITLE
fix: suppress auto-skip on select-assistant screen after login

### DIFF
--- a/apps/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -1,6 +1,6 @@
 import { Cloud, Laptop } from "lucide-react";
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router";
+import { useNavigate, useSearchParams } from "react-router";
 
 import { selectPlatformAssistant } from "@/assistant/select-platform-assistant";
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
@@ -26,6 +26,8 @@ function assistantSubtitle(a: ResolvedAssistant): string {
 
 export function SelectAssistantScreen() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const fromLogin = searchParams.get("fromLogin") === "1";
   const hasPlatformSession = useHasPlatformSession();
   const assistants = useResolvedAssistantsStore.use.assistants();
   const {
@@ -72,8 +74,9 @@ export function SelectAssistantScreen() {
   };
 
   // Auto-skip when there's exactly one assistant and it's accessible.
-  // Don't skip when inaccessible assistants exist — the user may want to log in.
+  // Don't skip when the user just logged in — let them see the now-enabled option.
   useEffect(() => {
+    if (fromLogin) return;
     if (assistants.length === 0) return;
     if (assistants.length === 1 && accessibleAssistants.length === 1) {
       setAutoSkipping(true);

--- a/apps/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/apps/web/src/lib/navigation/navigation-resolver.test.ts
@@ -460,10 +460,13 @@ describe("resolveNavigation", () => {
       ).toBe("/assistant/onboarding/hosting");
     });
 
-    test("returns the same path for non-welcome pages", () => {
+    test("appends fromLogin param when logging in from select-assistant", () => {
       expect(
         resolveLoginReturnTo(s({}), "/assistant/onboarding/select-assistant"),
-      ).toBe("/assistant/onboarding/select-assistant");
+      ).toBe("/assistant/onboarding/select-assistant?fromLogin=1");
+    });
+
+    test("returns the same path for other non-welcome pages", () => {
       expect(
         resolveLoginReturnTo(s({}), "/assistant/onboarding/hosting"),
       ).toBe("/assistant/onboarding/hosting");

--- a/apps/web/src/lib/navigation/navigation-resolver.ts
+++ b/apps/web/src/lib/navigation/navigation-resolver.ts
@@ -91,6 +91,9 @@ export function resolveLoginReturnTo(
       ? routes.onboarding.selectAssistant
       : routes.onboarding.hosting;
   }
+  if (fromPath === routes.onboarding.selectAssistant) {
+    return `${fromPath}?fromLogin=1`;
+  }
   return fromPath;
 }
 


### PR DESCRIPTION
## Summary
- After logging in from the "Choose an Assistant" screen, the auto-skip logic was immediately connecting to the now-accessible Cloud Assistant, bypassing the selection screen entirely
- Added a `fromLogin=1` query parameter to the post-login `returnTo` URL (mirroring the existing `from=select-assistant` pattern) so the select-assistant screen can suppress auto-skip when the user just authenticated
- Updated `resolveLoginReturnTo` and its tests to encode this context

## Original prompt
After clicking "Log In" on the "Choose an Assistant" screen in the web app, the user expected to return to the same screen with the Cloud Assistant option now enabled and selectable. Instead, the auto-skip `useEffect` detected exactly one accessible assistant on re-mount and immediately navigated into the conversation view. The fix follows the existing `from=` query parameter convention used elsewhere in onboarding to signal navigation context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)