### PR TITLE
feat: add zip target to electron-builder for auto-update support

### DIFF
--- a/apps/macos/electron-builder.config.cjs
+++ b/apps/macos/electron-builder.config.cjs
@@ -70,10 +70,8 @@ module.exports = {
       ],
     },
     target: [
-      {
-        target: "dmg",
-        arch: ["arm64"],
-      },
+      { target: "dmg", arch: ["arm64"] },
+      { target: "zip", arch: ["arm64"] },
     ],
   },
 };


### PR DESCRIPTION
## Summary
- Add zip target alongside dmg in electron-builder config for arm64
- This enables electron-updater support by generating latest-mac.yml and blockmap files during builds

Part of plan: electron-auto-update.md (PR 1 of 5)