### PR TITLE
mcp-setup: rework per skill-writing guide, support web app, prefer native OAuth

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -442,7 +442,7 @@
     {
       "id": "mcp-setup",
       "name": "mcp-setup",
-      "description": "Add, authenticate, list, and remove MCP (Model Context Protocol) servers",
+      "description": "Add, authenticate, list, and remove MCP (Model Context Protocol) servers — connect any external tool or service that publishes an MCP endpoint to the assistant",
       "metadata": {
         "emoji": "🔌",
         "vellum": {
@@ -450,8 +450,8 @@
           "display-name": "MCP Setup"
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "compatibility": "Works on both the Vellum desktop app (local daemon) and the Vellum web app (platform-hosted). Auth flow differs by environment.",
+      "updatedAt": "2026-06-08T20:46:51.000Z"
     },
     {
       "id": "meet-join",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -325,7 +325,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-05T22:44:27.000Z"
+      "updatedAt": "2026-06-05T23:44:29.000Z"
     },
     {
       "id": "inbox-management",
@@ -451,7 +451,7 @@
         }
       },
       "compatibility": "Works on both the Vellum desktop app (local daemon) and the Vellum web app (platform-hosted). Auth flow differs by environment.",
-      "updatedAt": "2026-06-08T20:46:51.000Z"
+      "updatedAt": "2026-06-08T20:48:43.000Z"
     },
     {
       "id": "meet-join",

--- a/skills/mcp-setup/SKILL.md
+++ b/skills/mcp-setup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: mcp-setup
-description: Add, authenticate, list, and remove MCP (Model Context Protocol) servers
-compatibility: "Designed for Vellum personal assistants"
+description: Add, authenticate, list, and remove MCP (Model Context Protocol) servers — connect any external tool or service to the assistant. Works with Figma, Linear, GitHub, Notion, Slack, Jira, Sentry, Stripe, Postgres, Google Drive, Vercel, GitLab, Cloudflare, Brave Search, and any other service that publishes an MCP endpoint
+compatibility: "Requires the Vellum desktop app (local daemon). Does not work with platform-hosted assistants."
 metadata:
   emoji: "🔌"
   vellum:
@@ -9,34 +9,87 @@ metadata:
     display-name: "MCP Setup"
 ---
 
-Help users configure MCP servers so external tools (e.g. Linear, GitHub, Notion) become available in conversations.
+Configure MCP servers to give the assistant access to any external tool or service that publishes an MCP endpoint.
 
-## CLI Commands
+**DO NOT** run exploratory commands. Do not check available CLI commands, look up documentation, search for bun/npx/node, or investigate transport types. Follow the steps below exactly and stop when done.
 
-All commands use `assistant mcp`. Run `list`, `add`, and `remove` via the `bash` tool — they just read/write config and don't need host access. Run `auth` via `host_bash` because it binds a localhost OAuth callback server that the user's host browser must redirect back to.
+## When to Use
+
+USE THIS SKILL WHEN:
+
+- User asks to connect any external tool or service via MCP
+- User asks "what MCP servers / integrations do I have?"
+- An MCP tool returns an auth error → run `assistant mcp auth <name>`
+- User wants to disconnect an integration
+
+## Step 1 — Verify desktop app is running
+
+**Before doing anything else**, run this via `host_bash`:
+
+```
+echo "desktop ok"
+```
+
+- If it succeeds → proceed.
+- If `host_bash` is unavailable or denied → stop and tell the user:
+
+> This skill requires the **Vellum desktop app**. Please download and launch it from [vellum.ai](https://vellum.ai), then start a new conversation.
+
+Do not attempt any `assistant mcp` commands without `host_bash` access — they will silently fail or error.
+
+## Step 2 — Check the recipe table
+
+**Check this table before doing anything else.** If the service is listed, run the command shown and do nothing else — no exploration, no checking available commands, no looking up documentation.
+
+| Service | Command | After? |
+|---------|---------|--------|
+| Context7 (docs) | `assistant mcp add context7 -t streamable-http -u https://mcp.context7.com/mcp -r low` | Done — no auth needed |
+| Linear | `assistant mcp add linear -t streamable-http -u https://mcp.linear.app/mcp` | Run `assistant mcp auth linear` |
+
+If the service is not in this table, go to Step 3.
+
+## Step 3 — Unknown service
+
+Find the MCP endpoint URL in the service's documentation, then run:
+
+```
+assistant mcp add <name> -t streamable-http -u <url>
+```
+
+Then run `assistant mcp list`. If it shows `! Needs authentication`, run `assistant mcp auth <name>` via `host_bash`.
+
+---
+
+## Reference: All Commands
+
+Run `list`, `add`, `remove`, and `reload` via the `bash` tool. Run `auth` via `host_bash` (it opens a browser).
 
 ### List servers
 
 ```
 assistant mcp list
+assistant mcp list --json   # machine-readable output
 ```
 
-Shows all configured servers with connection status, transport type, and URL.
+Shows each server's connection status, transport, URL/command, and risk level. Status indicators:
+- `✓` Connected
+- `✗` Error or disabled
+- `!` Needs authentication
 
 ### Add a server
 
 ```
-assistant mcp add <name> -t <transport-type> -u <url> [-r <risk>] [--disabled]
+assistant mcp add <name> -t <transport> -u <url> [-r low|medium|high] [--disabled]
 ```
 
-- `<name>` - unique identifier (e.g. `linear`, `github`)
-- `-t` - transport type: `stdio`, `sse`, or `streamable-http`
-- `-u` - server URL (required for `sse`/`streamable-http`)
-- `-c` - command (required for `stdio`), `-a` for args
-- `-r` - risk level: `low`, `medium`, or `high` (default: `high`)
+Transport types:
+- `streamable-http` — most modern remote servers (use this by default)
+- `sse` — legacy remote servers
+- `stdio` — local process: use `-c <command>` and `-a <args...>` instead of `-u`
+
+Risk level (`-r`) controls approval prompts per tool call — `low` auto-approves, `high` always prompts (default: `high`).
 
 Examples:
-
 ```
 assistant mcp add linear -t streamable-http -u https://mcp.linear.app/mcp
 assistant mcp add context7 -t streamable-http -u https://mcp.context7.com/mcp -r low
@@ -49,11 +102,8 @@ assistant mcp add local-db -t stdio -c npx -a -y @my/mcp-server
 assistant mcp auth <name>
 ```
 
-Opens the user's browser for OAuth authorization. Only works for `sse`/`streamable-http` servers that require authentication. After the user completes login in the browser, tokens are saved automatically.
-
-Use this when:
-
-- A server shows `! Needs authentication` in `assistant mcp list`
+Run via `host_bash`. Opens the user's browser for OAuth login. Tokens are saved automatically. Use when:
+- `assistant mcp list` shows `! Needs authentication`
 - An MCP tool call fails with an auth/token error
 - Setting up a new OAuth-protected server for the first time
 
@@ -63,17 +113,26 @@ Use this when:
 assistant mcp remove <name>
 ```
 
-Removes the server config and cleans up any stored OAuth credentials.
+Removes config and cleans up stored OAuth credentials.
 
-## After Changes
+### Reload
 
-After adding, removing, or authenticating a server, the user must **quit and relaunch the Vellum app** for changes to take effect. The app runs its own assistant process - `assistant daemon restart` only restarts the CLI assistant, which is a separate process.
+```
+assistant mcp reload
+```
 
-Tell the user: "Please quit and relaunch the Vellum app, then start a new conversation."
+Manually signals the assistant to reconnect all MCP servers from disk. Normally not needed — the assistant detects changes automatically after `add`, `remove`, and `auth`. Use this only if a server's tools aren't appearing after ~10 seconds.
 
-## When to Use
+## Advanced Configuration
 
-- User asks to connect/set up an external service via MCP
-- User asks "what MCP servers do I have?"
-- An MCP tool returns an auth error - offer to run `assistant mcp auth <name>`
-- User wants to remove an MCP integration
+`mcp add` covers the common cases. For advanced options, edit `~/.vellum/workspace/config.json` directly under `mcp.servers.<name>`:
+
+- `env` — environment variables for stdio servers
+- `headers` — custom HTTP headers for remote servers
+- `maxTools` — per-server tool cap (default: 20)
+- `allowedTools` / `blockedTools` — tool name filters
+- `globalMaxTools` — total cap across all servers (default: 50)
+
+## SKILL COMPLETE WHEN
+
+The MCP server appears in `assistant mcp list` with status `✓ Connected` and the user confirms tools from that server are available in the conversation.

--- a/skills/mcp-setup/SKILL.md
+++ b/skills/mcp-setup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: mcp-setup
 description: Add, authenticate, list, and remove MCP (Model Context Protocol) servers — connect any external tool or service to the assistant. Works with Figma, Linear, GitHub, Notion, Slack, Jira, Sentry, Stripe, Postgres, Google Drive, Vercel, GitLab, Cloudflare, Brave Search, and any other service that publishes an MCP endpoint
-compatibility: "Requires the Vellum desktop app (local daemon). Does not work with platform-hosted assistants."
+compatibility: "Works on both the Vellum desktop app (local daemon) and the Vellum web app (platform-hosted). Auth flow differs by environment."
 metadata:
   emoji: "🔌"
   vellum:
@@ -22,17 +22,7 @@ USE THIS SKILL WHEN:
 - An MCP tool returns an auth error → run `assistant mcp auth <name>`
 - User wants to disconnect an integration
 
-## Step 1 — Verify you are on the desktop app (HARD GATE)
-
-⚠️ **This is a hard gate. Do not run any `assistant mcp` command until it passes.**
-
-MCP servers only work on the local desktop daemon. A cloud / platform-hosted
-session **has `bash`**, so `mcp add` and `mcp list` will appear to succeed — but
-the config is written to the cloud daemon, not the user's machine, and the
-`auth` step can never complete because there is no browser on the host. The
-result is a zombie config: half set up, impossible to authenticate. **`bash`
-succeeding proves nothing. Only `host_bash` confirms you are on the machine that
-can finish the flow.**
+## Step 1 — Detect your environment
 
 **Before doing anything else**, run this via `host_bash` (not `bash`):
 
@@ -40,16 +30,10 @@ can finish the flow.**
 echo "desktop ok"
 ```
 
-- If it succeeds → you are on the desktop. Proceed.
-- If `host_bash` is unavailable, denied, or you only have `bash` → **STOP NOW.**
-  Do not run `mcp add`. Do not run `mcp list`. Tell the user:
+- If it succeeds → you are on the **desktop app**. `mcp auth` must run via `host_bash` because it opens a local browser.
+- If `host_bash` is unavailable or denied → you are on the **web app** (or a cloud-hosted session). `mcp auth` still works — the platform handles the browser redirect. Use `bash` for all commands, including `auth`.
 
-> This skill needs the **Vellum desktop app** — MCP setup can't run from a
-> cloud session because the OAuth step needs a browser on your machine. Please
-> open the desktop app from [vellum.ai](https://vellum.ai) and ask me there.
-
-Writing an MCP config from a cloud session creates a broken server the user
-cannot authenticate. Refuse to start rather than leave a half-configured mess.
+Both environments fully support MCP. The only difference is which tool runs the `auth` command.
 
 ## Step 2 — Check the recipe table
 
@@ -71,13 +55,16 @@ Find the MCP endpoint URL in the service's documentation, then run:
 assistant mcp add <name> -t streamable-http -u <url>
 ```
 
-Then run `assistant mcp list`. If it shows `! Needs authentication`, run `assistant mcp auth <name>` via `host_bash`.
+Then run `assistant mcp list`. If it shows `! Needs authentication`, run `assistant mcp auth <name>`.
+
+- On **desktop** → run via `host_bash` (opens the local browser).
+- On **web app** → run via `bash` (the platform handles the browser redirect).
 
 ---
 
 ## Reference: All Commands
 
-Run `list`, `add`, `remove`, and `reload` via the `bash` tool. Run `auth` via `host_bash` (it opens a browser).
+Run `list`, `add`, `remove`, and `reload` via `bash` on both environments. Run `auth` via `host_bash` on desktop, or via `bash` on the web app.
 
 ### List servers
 
@@ -117,7 +104,10 @@ assistant mcp add local-db -t stdio -c npx -a -y @my/mcp-server
 assistant mcp auth <name>
 ```
 
-Run via `host_bash`. Opens the user's browser for OAuth login. Tokens are saved automatically. Use when:
+- On **desktop** → run via `host_bash` (opens the user's local browser for OAuth login).
+- On **web app** → run via `bash` (the platform handles the browser redirect and saves tokens).
+
+Tokens are saved automatically. Use when:
 - `assistant mcp list` shows `! Needs authentication`
 - An MCP tool call fails with an auth/token error
 - Setting up a new OAuth-protected server for the first time

--- a/skills/mcp-setup/SKILL.md
+++ b/skills/mcp-setup/SKILL.md
@@ -37,6 +37,7 @@ assistant oauth connect <provider>
 ```
 
 **Only use MCP when:**
+
 - The service is not in `assistant oauth providers list`
 - The user explicitly asks to use MCP for a specific service
 - The native OAuth integration fails or lacks features the user needs
@@ -60,11 +61,11 @@ Both environments fully support MCP. The only difference is which tool runs the 
 
 **Check this table before doing anything else.** If the service is listed, run the command shown and do nothing else — no exploration, no checking available commands, no looking up documentation.
 
-| Service | Command | After? |
-|---------|---------|--------|
-| Context7 (docs) | `assistant mcp add context7 -t streamable-http -u https://mcp.context7.com/mcp -r low` | Done — no auth needed |
-| Linear | `assistant mcp add linear -t streamable-http -u https://mcp.linear.app/mcp` | Run `assistant mcp auth linear` |
-| Figma | `assistant mcp add figma -t streamable-http -u https://mcp.figma.com/mcp` | Run `assistant mcp auth figma` |
+| Service         | Command                                                                                | After?                          |
+| --------------- | -------------------------------------------------------------------------------------- | ------------------------------- |
+| Context7 (docs) | `assistant mcp add context7 -t streamable-http -u https://mcp.context7.com/mcp -r low` | Done — no auth needed           |
+| Linear          | `assistant mcp add linear -t streamable-http -u https://mcp.linear.app/mcp`            | Run `assistant mcp auth linear` |
+| Figma           | `assistant mcp add figma -t streamable-http -u https://mcp.figma.com/mcp`              | Run `assistant mcp auth figma`  |
 
 If the service is not in this table, go to Step 3.
 
@@ -95,6 +96,7 @@ assistant mcp list --json   # machine-readable output
 ```
 
 Shows each server's connection status, transport, URL/command, and risk level. Status indicators:
+
 - `✓` Connected
 - `✗` Error or disabled
 - `!` Needs authentication
@@ -106,6 +108,7 @@ assistant mcp add <name> -t <transport> -u <url> [-r low|medium|high] [--disable
 ```
 
 Transport types:
+
 - `streamable-http` — most modern remote servers (use this by default)
 - `sse` — legacy remote servers
 - `stdio` — local process: use `-c <command>` and `-a <args...>` instead of `-u`
@@ -113,6 +116,7 @@ Transport types:
 Risk level (`-r`) controls approval prompts per tool call — `low` auto-approves, `high` always prompts (default: `high`).
 
 Examples:
+
 ```
 assistant mcp add linear -t streamable-http -u https://mcp.linear.app/mcp
 assistant mcp add context7 -t streamable-http -u https://mcp.context7.com/mcp -r low
@@ -129,6 +133,7 @@ assistant mcp auth <name>
 - On **web app** → run via `bash` (the platform handles the browser redirect and saves tokens).
 
 Tokens are saved automatically. Use when:
+
 - `assistant mcp list` shows `! Needs authentication`
 - An MCP tool call fails with an auth/token error
 - Setting up a new OAuth-protected server for the first time

--- a/skills/mcp-setup/SKILL.md
+++ b/skills/mcp-setup/SKILL.md
@@ -22,20 +22,34 @@ USE THIS SKILL WHEN:
 - An MCP tool returns an auth error → run `assistant mcp auth <name>`
 - User wants to disconnect an integration
 
-## Step 1 — Verify desktop app is running
+## Step 1 — Verify you are on the desktop app (HARD GATE)
 
-**Before doing anything else**, run this via `host_bash`:
+⚠️ **This is a hard gate. Do not run any `assistant mcp` command until it passes.**
+
+MCP servers only work on the local desktop daemon. A cloud / platform-hosted
+session **has `bash`**, so `mcp add` and `mcp list` will appear to succeed — but
+the config is written to the cloud daemon, not the user's machine, and the
+`auth` step can never complete because there is no browser on the host. The
+result is a zombie config: half set up, impossible to authenticate. **`bash`
+succeeding proves nothing. Only `host_bash` confirms you are on the machine that
+can finish the flow.**
+
+**Before doing anything else**, run this via `host_bash` (not `bash`):
 
 ```
 echo "desktop ok"
 ```
 
-- If it succeeds → proceed.
-- If `host_bash` is unavailable or denied → stop and tell the user:
+- If it succeeds → you are on the desktop. Proceed.
+- If `host_bash` is unavailable, denied, or you only have `bash` → **STOP NOW.**
+  Do not run `mcp add`. Do not run `mcp list`. Tell the user:
 
-> This skill requires the **Vellum desktop app**. Please download and launch it from [vellum.ai](https://vellum.ai), then start a new conversation.
+> This skill needs the **Vellum desktop app** — MCP setup can't run from a
+> cloud session because the OAuth step needs a browser on your machine. Please
+> open the desktop app from [vellum.ai](https://vellum.ai) and ask me there.
 
-Do not attempt any `assistant mcp` commands without `host_bash` access — they will silently fail or error.
+Writing an MCP config from a cloud session creates a broken server the user
+cannot authenticate. Refuse to start rather than leave a half-configured mess.
 
 ## Step 2 — Check the recipe table
 
@@ -45,6 +59,7 @@ Do not attempt any `assistant mcp` commands without `host_bash` access — they 
 |---------|---------|--------|
 | Context7 (docs) | `assistant mcp add context7 -t streamable-http -u https://mcp.context7.com/mcp -r low` | Done — no auth needed |
 | Linear | `assistant mcp add linear -t streamable-http -u https://mcp.linear.app/mcp` | Run `assistant mcp auth linear` |
+| Figma | `assistant mcp add figma -t streamable-http -u https://mcp.figma.com/mcp` | Run `assistant mcp auth figma` |
 
 If the service is not in this table, go to Step 3.
 

--- a/skills/mcp-setup/SKILL.md
+++ b/skills/mcp-setup/SKILL.md
@@ -11,7 +11,7 @@ metadata:
 
 Configure MCP servers to give the assistant access to any external tool or service that publishes an MCP endpoint.
 
-**DO NOT** run exploratory commands. Do not check available CLI commands, look up documentation, search for bun/npx/node, or investigate transport types. Follow the steps below exactly and stop when done.
+**DO NOT** run exploratory commands. Do not check available CLI commands, search for bun/npx/node, or investigate transport types. Follow the steps below exactly and stop when done. (Looking up a service's MCP endpoint URL in its own documentation is allowed when the service is not in the recipe table, per Step 3.)
 
 ## When to Use
 
@@ -161,4 +161,8 @@ Manually signals the assistant to reconnect all MCP servers from disk. Normally 
 
 ## SKILL COMPLETE WHEN
 
-The MCP server appears in `assistant mcp list` with status `✓ Connected` and the user confirms tools from that server are available in the conversation.
+Match the completion condition to the task:
+
+- **Add / authenticate:** the server appears in `assistant mcp list` with status `✓ Connected` and the user confirms its tools are available in the conversation.
+- **List:** the current servers (or the fact that none are configured) have been reported to the user.
+- **Remove / disconnect:** `assistant mcp remove <name>` succeeds and the server no longer appears in `assistant mcp list`.

--- a/skills/mcp-setup/SKILL.md
+++ b/skills/mcp-setup/SKILL.md
@@ -22,6 +22,30 @@ USE THIS SKILL WHEN:
 - An MCP tool returns an auth error → run `assistant mcp auth <name>`
 - User wants to disconnect an integration
 
+## Prefer Native OAuth Integration (check this first)
+
+Many services have built-in OAuth integrations that are simpler and more reliable than MCP. Before using MCP, check if the service has a native OAuth option.
+
+**Native OAuth integrations available:** GitHub, Google, Linear, Notion, Discord, Twitter, Asana, Todoist, HubSpot, Outlook/Microsoft.
+
+If the service is in that list, use the native OAuth command instead:
+
+```
+assistant oauth connect <service>
+```
+
+Examples:
+```
+assistant oauth connect linear
+assistant oauth connect notion
+assistant oauth connect github
+```
+
+**Only use MCP when:**
+- The service has no native OAuth integration (e.g., Figma, Slack, Jira, Sentry, Stripe, Context7, Vercel, Cloudflare, Brave Search)
+- The user explicitly asks to use MCP for a specific service
+- The native OAuth integration fails or lacks features the user needs
+
 ## Step 1 — Detect your environment
 
 **Before doing anything else**, determine which environment you are in.

--- a/skills/mcp-setup/SKILL.md
+++ b/skills/mcp-setup/SKILL.md
@@ -24,16 +24,18 @@ USE THIS SKILL WHEN:
 
 ## Step 1 — Detect your environment
 
-**Before doing anything else**, run this via `host_bash` (not `bash`):
+**Before doing anything else**, determine which environment you are in.
+
+Try `host_bash`:
 
 ```
 echo "desktop ok"
 ```
 
-- If it succeeds → you are on the **desktop app**. `mcp auth` must run via `host_bash` because it opens a local browser.
-- If `host_bash` is unavailable or denied → you are on the **web app** (or a cloud-hosted session). `mcp auth` still works — the platform handles the browser redirect. Use `bash` for all commands, including `auth`.
+- If it succeeds → you are on the **desktop app**. Use `host_bash` for all commands, including `auth` (opens a local browser).
+- If it is unavailable → you are on the **web app** (or a cloud-hosted session). Use `bash` for all commands, including `auth` (the platform handles the browser redirect).
 
-Both environments fully support MCP. The only difference is which tool runs the `auth` command.
+Both environments fully support MCP. The only difference is which tool runs the commands.
 
 ## Step 2 — Check the recipe table
 

--- a/skills/mcp-setup/SKILL.md
+++ b/skills/mcp-setup/SKILL.md
@@ -24,25 +24,20 @@ USE THIS SKILL WHEN:
 
 ## Prefer Native OAuth Integration (check this first)
 
-Many services have built-in OAuth integrations that are simpler and more reliable than MCP. Before using MCP, check if the service has a native OAuth option.
-
-**Native OAuth integrations available:** GitHub, Google, Linear, Notion, Discord, Twitter, Asana, Todoist, HubSpot, Outlook/Microsoft.
-
-If the service is in that list, use the native OAuth command instead:
+Many services have built-in OAuth integrations that are simpler and more reliable than MCP. Before setting up MCP, check whether the service already has a native OAuth provider:
 
 ```
-assistant oauth connect <service>
+assistant oauth providers list
 ```
 
-Examples:
+If the service appears in that list, connect it natively instead of using MCP:
+
 ```
-assistant oauth connect linear
-assistant oauth connect notion
-assistant oauth connect github
+assistant oauth connect <provider>
 ```
 
 **Only use MCP when:**
-- The service has no native OAuth integration (e.g., Figma, Slack, Jira, Sentry, Stripe, Context7, Vercel, Cloudflare, Brave Search)
+- The service is not in `assistant oauth providers list`
 - The user explicitly asks to use MCP for a specific service
 - The native OAuth integration fails or lacks features the user needs
 

--- a/skills/mcp-setup/SKILL.md
+++ b/skills/mcp-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mcp-setup
-description: Add, authenticate, list, and remove MCP (Model Context Protocol) servers — connect any external tool or service to the assistant. Works with Figma, Linear, GitHub, Notion, Slack, Jira, Sentry, Stripe, Postgres, Google Drive, Vercel, GitLab, Cloudflare, Brave Search, and any other service that publishes an MCP endpoint
+description: Add, authenticate, list, and remove MCP (Model Context Protocol) servers — connect any external tool or service that publishes an MCP endpoint to the assistant
 compatibility: "Works on both the Vellum desktop app (local daemon) and the Vellum web app (platform-hosted). Auth flow differs by environment."
 metadata:
   emoji: "🔌"


### PR DESCRIPTION
## What

Reworks the `mcp-setup` skill per the skill-writing guide and fixes correctness issues found while connecting Figma.

## Changes

- **Activation block at top.** Moved "When to Use" up so weaker models recognize when to invoke the skill.
- **Explicit termination.** Added "SKILL COMPLETE WHEN" so the model stops cleanly.
- **Works on web app too.** Previous version claimed desktop-only. Both desktop and web app support MCP. The only difference is which tool runs `auth` (host_bash on desktop, bash on web, where the platform handles the browser redirect).
- **Neutral environment detection.** Step 1 no longer frames desktop as the default and web as a fallback.
- **Prefer native OAuth.** When a service already has a native OAuth provider, suggest `assistant oauth connect <provider>` instead of MCP. Checks `assistant oauth providers list` dynamically rather than carrying a hardcoded service list that rots.
- **Figma recipe.** Added to the recipe table.
- **Description cleanup.** Dropped the hardcoded service list from the description.

## Testing

Verified locally against the dev stack: skill loads with all sections present and correct.
