### PR TITLE
feat: install electron-updater and wire main-process update lifecycle

### DIFF
--- a/apps/macos/bun.lock
+++ b/apps/macos/bun.lock
@@ -9,6 +9,7 @@
         "@vellumai/local-mode": "file:../../packages/local-mode",
         "electron-log": "5.4.4",
         "electron-store": "11.0.2",
+        "electron-updater": "6.8.9",
         "jszip": "3.10.1",
         "zod": "4.3.6",
       },
@@ -402,6 +403,8 @@
 
     "electron-to-chromium": ["electron-to-chromium@1.5.361", "", {}, "sha512-Q6Hts7N9FnJc5LeGRINFvLhCI9xZmNtTDe5ZbcVezQz7cU4a8Aua3GH1b8J2XY8Al9PF+OCwYqhgsOOheMdvkA=="],
 
+    "electron-updater": ["electron-updater@6.8.9", "", { "dependencies": { "builder-util-runtime": "9.7.0", "fs-extra": "^10.1.0", "js-yaml": "^4.1.0", "lazy-val": "^1.0.5", "lodash.escaperegexp": "^4.1.2", "lodash.isequal": "^4.5.0", "semver": "~7.7.3", "tiny-typed-emitter": "^2.1.0" } }, "sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig=="],
+
     "electron-vite": ["electron-vite@5.0.0", "", { "dependencies": { "@babel/core": "^7.28.4", "@babel/plugin-transform-arrow-functions": "^7.27.1", "cac": "^6.7.14", "esbuild": "^0.25.11", "magic-string": "^0.30.19", "picocolors": "^1.1.1" }, "peerDependencies": { "@swc/core": "^1.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0" }, "optionalPeers": ["@swc/core"], "bin": { "electron-vite": "bin/electron-vite.js" } }, "sha512-OHp/vjdlubNlhNkPkL/+3JD34ii5ov7M0GpuXEVdQeqdQ3ulvVR7Dg/rNBLfS5XPIFwgoBLDf9sjjrL+CuDyRQ=="],
 
     "electron-winstaller": ["electron-winstaller@5.4.0", "", { "dependencies": { "@electron/asar": "^3.2.1", "debug": "^4.1.1", "fs-extra": "^7.0.1", "lodash": "^4.17.21", "temp": "^0.9.0" }, "optionalDependencies": { "@electron/windows-sign": "^1.1.2" } }, "sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg=="],
@@ -555,6 +558,10 @@
     "lie": ["lie@3.3.0", "", { "dependencies": { "immediate": "~3.0.5" } }, "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ=="],
 
     "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
+
+    "lodash.escaperegexp": ["lodash.escaperegexp@4.1.2", "", {}, "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw=="],
+
+    "lodash.isequal": ["lodash.isequal@4.5.0", "", {}, "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="],
 
     "lowercase-keys": ["lowercase-keys@2.0.0", "", {}, "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="],
 
@@ -738,6 +745,8 @@
 
     "tiny-async-pool": ["tiny-async-pool@1.3.0", "", { "dependencies": { "semver": "^5.5.0" } }, "sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA=="],
 
+    "tiny-typed-emitter": ["tiny-typed-emitter@2.1.0", "", {}, "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA=="],
+
     "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
     "tmp": ["tmp@0.2.6", "", {}, "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA=="],
@@ -865,6 +874,8 @@
     "dmg-license/ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
 
     "electron/@types/node": ["@types/node@24.12.4", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA=="],
+
+    "electron-updater/builder-util-runtime": ["builder-util-runtime@9.7.0", "", { "dependencies": { "debug": "^4.3.4", "sax": "^1.2.4" } }, "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw=="],
 
     "electron-winstaller/fs-extra": ["fs-extra@7.0.1", "", { "dependencies": { "graceful-fs": "^4.1.2", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw=="],
 

--- a/apps/macos/electron.vite.config.ts
+++ b/apps/macos/electron.vite.config.ts
@@ -24,6 +24,7 @@ import { defineConfig, externalizeDepsPlugin } from "electron-vite";
 const DEPS_TO_INLINE = [
   "electron-log",
   "electron-store",
+  "electron-updater",
   "conf",
   "@vellumai/local-mode",
   "@vellumai/environments",

--- a/apps/macos/package.json
+++ b/apps/macos/package.json
@@ -35,6 +35,7 @@
     "@vellumai/environments": "file:../../packages/environments",
     "@vellumai/local-mode": "file:../../packages/local-mode",
     "electron-log": "5.4.4",
+    "electron-updater": "6.8.9",
     "electron-store": "11.0.2",
     "jszip": "3.10.1",
     "zod": "4.3.6"

--- a/apps/macos/src/main/auto-update.ts
+++ b/apps/macos/src/main/auto-update.ts
@@ -1,0 +1,111 @@
+import { autoUpdater } from "electron-updater";
+import { app, BrowserWindow } from "electron";
+import { z } from "zod";
+
+import { handle } from "./ipc";
+import log from "./logger";
+
+declare const __VELLUM_ENVIRONMENT__: string;
+
+const resolveChannel = (): string => {
+  const env =
+    typeof __VELLUM_ENVIRONMENT__ === "string"
+      ? __VELLUM_ENVIRONMENT__
+      : "production";
+  switch (env) {
+    case "staging":
+      return "beta";
+    case "dev":
+      return "alpha";
+    default:
+      return "latest";
+  }
+};
+
+type UpdateStatus =
+  | "idle"
+  | "checking"
+  | "available"
+  | "downloading"
+  | "downloaded"
+  | "error";
+
+interface UpdateState {
+  status: UpdateStatus;
+  version?: string;
+  progress?: { percent: number; transferred: number; total: number };
+  error?: string;
+}
+
+let currentState: UpdateState = { status: "idle" };
+
+const setState = (next: UpdateState): void => {
+  currentState = next;
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.isDestroyed()) {
+      win.webContents.send("vellum:update:state", currentState);
+    }
+  }
+};
+
+export const checkForUpdates = (): void => {
+  autoUpdater.checkForUpdates().catch((err: unknown) => {
+    log.error("[auto-update] checkForUpdates failed:", err);
+  });
+};
+
+export const installAutoUpdate = (): void => {
+  if (!app.isPackaged) return;
+
+  const channel = resolveChannel();
+
+  autoUpdater.logger = log;
+  autoUpdater.autoDownload = true;
+  autoUpdater.autoInstallOnAppQuit = true;
+  autoUpdater.channel = channel;
+  autoUpdater.setFeedURL({
+    provider: "generic",
+    url: `https://storage.googleapis.com/vellum-desktop-releases/electron/${channel}/`,
+  });
+
+  autoUpdater.on("checking-for-update", () => {
+    setState({ status: "checking" });
+  });
+
+  autoUpdater.on("update-available", (info) => {
+    setState({ status: "available", version: info.version });
+  });
+
+  autoUpdater.on("download-progress", (progressObj) => {
+    setState({
+      status: "downloading",
+      progress: {
+        percent: progressObj.percent,
+        transferred: progressObj.transferred,
+        total: progressObj.total,
+      },
+    });
+  });
+
+  autoUpdater.on("update-downloaded", (info) => {
+    setState({ status: "downloaded", version: info.version });
+  });
+
+  autoUpdater.on("error", (err) => {
+    log.error("[auto-update] error:", err);
+    setState({ status: "error", error: err.message });
+  });
+
+  autoUpdater.on("update-not-available", () => {
+    setState({ status: "idle" });
+  });
+
+  handle("vellum:update:getState", z.tuple([]), () => currentState);
+  handle("vellum:update:check", z.tuple([]), () => checkForUpdates());
+  handle("vellum:update:install", z.tuple([]), () =>
+    autoUpdater.quitAndInstall(),
+  );
+
+  checkForUpdates();
+  setInterval(checkForUpdates, 4 * 60 * 60 * 1000);
+};

--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -12,6 +12,7 @@ import {
 } from "@vellumai/local-mode";
 
 import { installAbout, openAboutWindow } from "./about";
+import { installAutoUpdate } from "./auto-update";
 import { APP_HOST, APP_PROTOCOL, BUNDLES_DIR_NAME, VELLUMAPP_PROTOCOL } from "./app-config";
 import { resolveAllowedOrigin } from "./app-origin";
 import { installCsp } from "./csp";
@@ -337,6 +338,7 @@ app
     installLocalMode();
     installHotkeyHelper();
     installAbout();
+    installAutoUpdate();
     installFeedbackIpc();
     installApplicationMenu();
     installQuickInput();

--- a/apps/macos/src/main/menu.ts
+++ b/apps/macos/src/main/menu.ts
@@ -2,6 +2,7 @@ import { Menu, type MenuItemConstructorOptions, app, shell } from "electron";
 import { z } from "zod";
 
 import { openAboutWindow } from "./about";
+import { checkForUpdates } from "./auto-update";
 import {
   acceleratorOption,
   dispatchToFocused,
@@ -41,6 +42,16 @@ const buildTemplate = (): MenuItemConstructorOptions[] => {
             openAboutWindow();
           },
         },
+        ...(!isDev
+          ? [
+              {
+                label: "Check for Updates\u2026",
+                click: () => {
+                  checkForUpdates();
+                },
+              },
+            ]
+          : []),
         { type: "separator" },
         {
           label: "Settings\u2026",


### PR DESCRIPTION
## Summary
- Install electron-updater as a dependency and add it to DEPS_TO_INLINE in electron.vite.config.ts
- Create auto-update.ts module with full update lifecycle: check on launch, every 4h, per-env channels, event handling, IPC surface
- Add Check for Updates menu item in app submenu (packaged builds only)
- Wire installAutoUpdate() in main process whenReady()

Part of plan: electron-auto-update.md (PR 2 of 5)