### PR TITLE
feat: universal binary (arm64 + x64) for Electron packaged builds

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -1813,7 +1813,7 @@ jobs:
     needs: [compute-version, publish-meta-dev]
     runs-on: macos-26
     timeout-minutes: 30
-    continue-on-error: true
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
@@ -1821,9 +1821,11 @@ jobs:
           - arch: arm64
             dmg_name: vellum-assistant-electron-dev.dmg
             artifact_name: dev-electron-dmg
+            experimental: false
           - arch: x64
             dmg_name: vellum-assistant-electron-dev-x64.dmg
             artifact_name: dev-electron-dmg-x64
+            experimental: true
     defaults:
       run:
         working-directory: apps/macos

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -1813,12 +1813,24 @@ jobs:
     needs: [compute-version, publish-meta-dev]
     runs-on: macos-26
     timeout-minutes: 30
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: arm64
+            dmg_name: vellum-assistant-electron-dev.dmg
+            artifact_name: dev-electron-dmg
+          - arch: x64
+            dmg_name: vellum-assistant-electron-dev-x64.dmg
+            artifact_name: dev-electron-dmg-x64
     defaults:
       run:
         working-directory: apps/macos
     env:
       KEYCHAIN_NAME: build-electron.keychain
       KEYCHAIN_PASSWORD: temporary-ci-password
+      ELECTRON_TARGET_ARCH: ${{ matrix.arch }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -1915,7 +1927,7 @@ jobs:
             exit 1
           fi
           echo "Found DMG: $ELECTRON_DMG"
-          FINAL_DMG="dist/vellum-assistant-electron-dev.dmg"
+          FINAL_DMG="dist/${{ matrix.dmg_name }}"
           mv "$ELECTRON_DMG" "$FINAL_DMG"
           echo "dmg_path=$FINAL_DMG" >> "$GITHUB_OUTPUT"
 
@@ -1988,8 +2000,8 @@ jobs:
       - name: Upload Electron DMG artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: dev-electron-dmg
-          path: apps/macos/dist/vellum-assistant-electron-dev.dmg
+          name: ${{ matrix.artifact_name }}
+          path: apps/macos/dist/${{ matrix.dmg_name }}
           if-no-files-found: error
           retention-days: 30
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2349,9 +2349,9 @@ jobs:
           security delete-keychain "$KEYCHAIN_PATH" 2>/dev/null || true
           rm -rf ~/.private_keys 2>/dev/null || true
 
-  # ── Electron macOS build (arm64) ──────────────────────────────────────
-  # Builds the Electron-wrapped macOS app, code-signs it, notarizes the
-  # DMG, and uploads it as a release asset. Non-blocking (continue-on-error)
+  # ── Electron macOS build (arm64 + x64) ────────────────────────────────
+  # Builds the Electron-wrapped macOS app for each architecture, code-signs,
+  # notarizes, and uploads as release assets. Non-blocking (continue-on-error)
   # while the Electron client is WIP.
   build-electron:
     needs: [extract-version, publish-meta-prod, publish-meta-staging]
@@ -2359,12 +2359,23 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 30
     continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: arm64
+            dmg_name: vellum-assistant-electron.dmg
+            artifact_name: macos-build-electron
+          - arch: x64
+            dmg_name: vellum-assistant-electron-x64.dmg
+            artifact_name: macos-build-electron-x64
     defaults:
       run:
         working-directory: apps/macos
     env:
       KEYCHAIN_NAME: build-electron.keychain
       KEYCHAIN_PASSWORD: temporary-ci-password
+      ELECTRON_TARGET_ARCH: ${{ matrix.arch }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -2461,7 +2472,7 @@ jobs:
             exit 1
           fi
           echo "Found DMG: $ELECTRON_DMG"
-          FINAL_DMG="dist/vellum-assistant-electron.dmg"
+          FINAL_DMG="dist/${{ matrix.dmg_name }}"
           mv "$ELECTRON_DMG" "$FINAL_DMG"
           echo "dmg_path=$FINAL_DMG" >> "$GITHUB_OUTPUT"
 
@@ -2538,8 +2549,8 @@ jobs:
       - name: Upload Electron DMG artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: macos-build-electron
-          path: apps/macos/dist/vellum-assistant-electron.dmg
+          name: ${{ matrix.artifact_name }}
+          path: apps/macos/dist/${{ matrix.dmg_name }}
           if-no-files-found: error
           retention-days: 7
 
@@ -2617,12 +2628,19 @@ jobs:
           name: chrome-extension-crx-zip
           path: chrome-extension-artifacts
 
-      - name: Download Electron DMG artifact
+      - name: Download Electron DMG artifact (arm64)
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         continue-on-error: true
         with:
           name: macos-build-electron
           path: electron-artifacts
+
+      - name: Download Electron DMG artifact (x64)
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        continue-on-error: true
+        with:
+          name: macos-build-electron-x64
+          path: electron-artifacts-x64
 
       - name: Create GitHub Releases
         env:
@@ -2648,10 +2666,14 @@ jobs:
             [ -n "$X64_DMG" ] && ASSETS+=("$X64_DMG#vellum-assistant-x64.dmg")
           fi
 
-          # Add Electron DMG if available (non-blocking — may not exist if Electron build failed)
+          # Add Electron DMGs if available (non-blocking — may not exist if Electron build failed)
           if [ -d "electron-artifacts" ]; then
             ELECTRON_DMG=$(find electron-artifacts -name "vellum-assistant-electron.dmg" -type f | grep -m1 .)
             [ -n "$ELECTRON_DMG" ] && ASSETS+=("$ELECTRON_DMG#vellum-assistant-electron.dmg")
+          fi
+          if [ -d "electron-artifacts-x64" ]; then
+            ELECTRON_X64_DMG=$(find electron-artifacts-x64 -name "vellum-assistant-electron-x64.dmg" -type f | grep -m1 .)
+            [ -n "$ELECTRON_X64_DMG" ] && ASSETS+=("$ELECTRON_X64_DMG#vellum-assistant-electron-x64.dmg")
           fi
 
           INSTALL_SH="cli/src/adapters/install.sh"

--- a/apps/macos/electron-builder.config.cjs
+++ b/apps/macos/electron-builder.config.cjs
@@ -1,6 +1,7 @@
 // @ts-check
 
 const env = process.env.VELLUM_ENVIRONMENT || "production";
+const targetArch = process.env.ELECTRON_TARGET_ARCH || "arm64";
 
 const productName =
   env === "production"
@@ -72,7 +73,7 @@ module.exports = {
     target: [
       {
         target: "dmg",
-        arch: ["arm64"],
+        arch: [targetArch],
       },
     ],
   },

--- a/apps/macos/package.json
+++ b/apps/macos/package.json
@@ -18,7 +18,7 @@
     "test:ci": "bun scripts/run-tests.ts",
     "build:fetch-bun": "bash scripts/fetch-bun.sh",
     "build:web": "cd ../web && bun install && bun run openapi-ts && bun run build && cd ../macos && mkdir -p resources && cp -R ../web/dist resources/web-dist",
-    "pack": "bash scripts/fetch-bun.sh --arch aarch64 && bash scripts/generate-icon.sh && bash scripts/build-hotkey-helper.sh && bun run build:web && bash scripts/generate-cli-lockfile.sh && electron-vite build && electron-builder --config electron-builder.config.cjs"
+    "pack": "bash scripts/pack.sh"
   },
   "devDependencies": {
     "@types/bun": "1.3.14",

--- a/apps/macos/scripts/afterPack.js
+++ b/apps/macos/scripts/afterPack.js
@@ -30,6 +30,9 @@ const QL_EXTENSIONS = [
   },
 ];
 
+// electron-builder Arch enum → swiftc -target triple prefix
+const SWIFTC_TARGETS = { 1: "x86_64-apple-macosx15.0", 3: "arm64-apple-macosx15.0" };
+
 /**
  * Build a Quick Look .appex bundle from Swift source.
  *
@@ -42,9 +45,10 @@ const QL_EXTENSIONS = [
  * @param {string} appBundleId - The containing app's CFBundleIdentifier.
  * @param {string} identity - Code signing identity.
  * @param {string} timestampFlag - Timestamp flag for codesign ("" or " --timestamp").
+ * @param {string} swiftTarget - The swiftc -target triple (e.g. "arm64-apple-macosx15.0").
  * @returns {boolean} true if the extension was built successfully.
  */
-function buildQLExtension(ext, plugInsDir, appBundleId, identity, timestampFlag) {
+function buildQLExtension(ext, plugInsDir, appBundleId, identity, timestampFlag, swiftTarget) {
   // Resolve source directory relative to the repo root (two levels up from apps/macos/scripts/).
   const repoRoot = path.resolve(__dirname, "..", "..", "..");
   const sourceDir = path.join(repoRoot, "clients", "macos", ext.name);
@@ -72,7 +76,7 @@ function buildQLExtension(ext, plugInsDir, appBundleId, identity, timestampFlag)
         "xcrun swiftc",
         `-module-name ${ext.name}`,
         "-emit-executable",
-        `-target arm64-apple-macosx15.0`,
+        `-target ${swiftTarget}`,
         `-sdk "$(xcrun --show-sdk-path)"`,
         frameworkFlags,
         "-Xlinker -e -Xlinker _NSExtensionMain",
@@ -168,8 +172,9 @@ exports.default = async function afterPack(context) {
   // 2. Build and embed Quick Look extensions (.appex).
   const plugInsDir = path.join(contentsDir, "PlugIns");
   const appBundleId = packager.config.appId;
+  const swiftTarget = SWIFTC_TARGETS[context.arch] || "arm64-apple-macosx15.0";
 
   for (const ext of QL_EXTENSIONS) {
-    buildQLExtension(ext, plugInsDir, appBundleId, identity, timestampFlag);
+    buildQLExtension(ext, plugInsDir, appBundleId, identity, timestampFlag, swiftTarget);
   }
 };

--- a/apps/macos/scripts/build-hotkey-helper.sh
+++ b/apps/macos/scripts/build-hotkey-helper.sh
@@ -16,6 +16,14 @@ if ! command -v xcrun >/dev/null 2>&1; then
   exit 1
 fi
 
+TARGET_FLAGS=""
+if [ -n "${ELECTRON_TARGET_ARCH:-}" ]; then
+  case "$ELECTRON_TARGET_ARCH" in
+    arm64) TARGET_FLAGS="-target arm64-apple-macosx15.0" ;;
+    x64)   TARGET_FLAGS="-target x86_64-apple-macosx15.0" ;;
+  esac
+fi
+
 mkdir -p "$OUTPUT_DIR"
-xcrun swiftc "$SOURCE" -framework AppKit -framework Carbon -o "$OUTPUT"
+xcrun swiftc $TARGET_FLAGS "$SOURCE" -framework AppKit -framework Carbon -o "$OUTPUT"
 chmod 755 "$OUTPUT"

--- a/apps/macos/scripts/pack.sh
+++ b/apps/macos/scripts/pack.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# pack.sh — Build and package the Electron app for the target architecture.
+#
+# Reads ELECTRON_TARGET_ARCH (arm64 | x64, default arm64) and maps it to
+# the correct --arch value for fetch-bun.sh.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+ARCH="${ELECTRON_TARGET_ARCH:-arm64}"
+case "$ARCH" in
+  arm64) BUN_ARCH=aarch64 ;;
+  x64)   BUN_ARCH=x64 ;;
+  *)
+    echo "ERROR: unsupported ELECTRON_TARGET_ARCH: $ARCH (use arm64 or x64)" >&2
+    exit 1
+    ;;
+esac
+
+cd "$APP_DIR"
+
+bash scripts/fetch-bun.sh --arch "$BUN_ARCH"
+bash scripts/generate-icon.sh
+bash scripts/build-hotkey-helper.sh
+bun run build:web
+bash scripts/generate-cli-lockfile.sh
+electron-vite build
+electron-builder --config electron-builder.config.cjs


### PR DESCRIPTION
## Summary
- Add x64 to Electron build matrix in both `dev-release.yaml` and `release.yml`, producing separate per-arch DMGs (Option A from LUM-2292)
- Extract `apps/macos/scripts/pack.sh` as an arch-aware build orchestrator controlled by a single env var (`ELECTRON_TARGET_ARCH`)
- Make `afterPack.js` and `build-hotkey-helper.sh` arch-aware for correct cross-compilation of Swift binaries

## Original prompt
LUM-2292 requested adding x64 (Intel Mac) support to the Electron packaged builds, which currently only target arm64. The plan chose Option A (two separate DMGs per arch) over a universal binary for simplicity and smaller download sizes. A single `ELECTRON_TARGET_ARCH` env var controls the entire build pipeline — electron-builder config, bun binary fetch, Swift compilation targets. CI uses a matrix strategy so both architectures build in parallel, each independently signed and notarized. The x64 build is non-blocking (`continue-on-error`) in both workflows.