### PR TITLE
feat(web): integrate server-side UserConsent API for platform users

### DIFF
--- a/apps/web/src/domains/account/profile.ts
+++ b/apps/web/src/domains/account/profile.ts
@@ -6,12 +6,28 @@ import {
 } from "@/utils/api-errors";
 import { parseDrfFieldError } from "@/domains/account/parse-drf-field-error";
 
+export interface UserConsent {
+  tos_accepted_version: string;
+  tos_accepted_at: string | null;
+  privacy_policy_accepted_version: string;
+  privacy_policy_accepted_at: string | null;
+  ai_data_sharing_accepted_version: string;
+  ai_data_sharing_accepted_at: string | null;
+  share_analytics: boolean;
+  share_diagnostics: boolean;
+}
+
+export type ConsentPatch = Partial<
+  Omit<UserConsent, "tos_accepted_at" | "privacy_policy_accepted_at" | "ai_data_sharing_accepted_at">
+>;
+
 export interface UserMe {
   id: string;
   username: string;
   email: string;
   first_name: string;
   last_name: string;
+  consent: UserConsent | null;
 }
 
 export type UsernameErrorCode =
@@ -115,6 +131,14 @@ export async function updateMe(patch: UpdateMePatch): Promise<UpdateMeResult> {
     kind: "error",
     message: extractErrorMessage(error, response, "Failed to save profile."),
   };
+}
+
+export async function patchConsent(consent: ConsentPatch): Promise<void> {
+  await client.patch({
+    url: "/v1/user/me/",
+    body: { consent },
+    throwOnError: true,
+  });
 }
 
 export async function checkUsernameAvailable(

--- a/apps/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -1,4 +1,3 @@
-import { captureError } from "@/lib/sentry/capture-error";
 import { EyeOff } from "lucide-react";
 import { useCallback, useEffect, useId, type ReactNode } from "react";
 import { useNavigate, useSearchParams } from "react-router";
@@ -20,9 +19,9 @@ import {
 } from "@/domains/onboarding/prefs";
 import { isElectron } from "@/runtime/is-electron";
 import { useIsNativePlatform } from "@/runtime/native-auth";
-import { useAuthStore } from "@/stores/auth-store";
+import { useAuthStore, useHasPlatformSession } from "@/stores/auth-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
-import { persistConsentForUser } from "@/utils/onboarding-cleanup";
+import { saveConsent } from "@/utils/onboarding-cleanup";
 import { legalUrl, routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
 import { Card } from "@vellumai/design-library/components/card";
@@ -82,6 +81,7 @@ export function PrivacyScreen() {
   const [shareDiagnostics, setShareDiagnostics] = useShareDiagnostics();
   const [tosAccepted, setTosAccepted] = useTosAccepted();
   const [aiDataConsent, setAiDataConsent] = useAiDataConsent();
+  const hasPlatformSession = useHasPlatformSession();
 
   useEffect(() => {
     if (!isNative) {
@@ -90,13 +90,7 @@ export function PrivacyScreen() {
   }, [isNative]);
 
   const onStart = useCallback(() => {
-    try {
-      setShareAnalytics(shareAnalytics);
-      setShareDiagnostics(shareDiagnostics);
-    } catch (err) {
-      captureError(err, { context: "onboarding_persist_share_prefs" });
-    }
-    persistConsentForUser(userId, tosAccepted, aiDataConsent);
+    saveConsent({ userId, tos: tosAccepted, ai: aiDataConsent, shareAnalytics, shareDiagnostics, hasPlatformSession });
     if (!isNative) {
       const variant = resolveOnboardingFunnelVariant(preferredFunnelVariant);
       emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.privacyTos, {
@@ -122,12 +116,11 @@ export function PrivacyScreen() {
     void navigate(`${routes.onboarding.hatching}${qs ? `?${qs}` : ""}`);
   }, [
     aiDataConsent,
+    hasPlatformSession,
     isNative,
     navigate,
     preferredFunnelVariant,
     searchParams,
-    setShareAnalytics,
-    setShareDiagnostics,
     shareAnalytics,
     shareDiagnostics,
     tosAccepted,

--- a/apps/web/src/domains/settings/pages/privacy-page.tsx
+++ b/apps/web/src/domains/settings/pages/privacy-page.tsx
@@ -6,12 +6,13 @@ import { BiometricSettingsCard } from "@/domains/settings/components/biometric-s
 import { RiskToleranceSettings } from "@/domains/settings/components/risk-tolerance-settings";
 import { TrustRules } from "@/domains/settings/components/trust-rules/trust-rules";
 import { usePlatformGate } from "@/hooks/use-platform-gate";
+import { useHasPlatformSession } from "@/stores/auth-store";
 import {
     getDeviceBool,
     getDeviceSetting,
-    setDeviceBool,
     setDeviceSetting,
 } from "@/utils/device-settings";
+import { savePreferenceToggle } from "@/utils/onboarding-cleanup";
 import { Dropdown } from "@vellumai/design-library/components/dropdown";
 import { Toggle } from "@vellumai/design-library/components/toggle";
 
@@ -63,6 +64,7 @@ export function PrivacyPage() {
   // platformHostedOnly so the divider visibility matches the gate inside
   // `AccessConsentSetting` exactly.
   const platformGate = usePlatformGate({ platformHostedOnly: true });
+  const hasPlatformSession = useHasPlatformSession();
   const [shareAnalytics, setShareAnalytics] = useState(
     () => getDeviceBool("shareAnalytics", true),
   );
@@ -76,13 +78,13 @@ export function PrivacyPage() {
   const handleAnalyticsToggle = () => {
     const next = !shareAnalytics;
     setShareAnalytics(next);
-    setDeviceBool("shareAnalytics", next);
+    savePreferenceToggle("share_analytics", next, hasPlatformSession);
   };
 
   const handleDiagnosticsToggle = () => {
     const next = !shareDiagnostics;
     setShareDiagnostics(next);
-    setDeviceBool("shareDiagnostics", next);
+    savePreferenceToggle("share_diagnostics", next, hasPlatformSession);
   };
 
   const handleRetentionChange = (value: string) => {

--- a/apps/web/src/stores/auth-store.test.ts
+++ b/apps/web/src/stores/auth-store.test.ts
@@ -229,14 +229,15 @@ describe("auth store onboarding flag reconciliation", () => {
     expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
   });
 
-  test("initSession skips server fetch in local mode", async () => {
+  test("initSession fetches server consent for local-mode platform sessions", async () => {
     mockIsLocalMode = true;
     sessionUser = { id: "user-1", email: "user@example.com" };
     mockPlatformAssistants = [{ assistantId: "p1", cloud: "vellum" }];
 
     await useAuthStore.getState().initSession();
 
-    expect(restoreConsentForUserMock).toHaveBeenCalledWith("user-1");
+    expect(fetchMeMock).toHaveBeenCalled();
+    expect(resolveServerConsentMock).toHaveBeenCalled();
     expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
   });
 

--- a/apps/web/src/stores/auth-store.test.ts
+++ b/apps/web/src/stores/auth-store.test.ts
@@ -28,7 +28,7 @@ const primeLocalGatewayConnectionWithRepairMock = mock(async () => {
 const restoreConsentForUserMock = mock((_userId: string | null) => ({ tos: false, ai: false }));
 const persistConsentForUserMock = mock((_userId: string | null, _tos: boolean, _ai: boolean) => {});
 const resolveServerConsentMock = mock((_consent: unknown) => ({
-  tos: false, ai: false, shareAnalytics: true, shareDiagnostics: true,
+  tos: false, ai: false, shareAnalytics: null, shareDiagnostics: null,
 }));
 
 let mockFetchMeResult: unknown = { id: "user-1", username: "test", email: "test@example.com", first_name: "", last_name: "", consent: null };

--- a/apps/web/src/stores/auth-store.test.ts
+++ b/apps/web/src/stores/auth-store.test.ts
@@ -26,6 +26,17 @@ const primeLocalGatewayConnectionWithRepairMock = mock(async () => {
   if (mockPrimeError) throw mockPrimeError;
 });
 const restoreConsentForUserMock = mock((_userId: string | null) => ({ tos: false, ai: false }));
+const persistConsentForUserMock = mock((_userId: string | null, _tos: boolean, _ai: boolean) => {});
+const resolveServerConsentMock = mock((_consent: unknown) => ({
+  tos: false, ai: false, shareAnalytics: true, shareDiagnostics: true,
+}));
+
+let mockFetchMeResult: unknown = { id: "user-1", username: "test", email: "test@example.com", first_name: "", last_name: "", consent: null };
+let mockFetchMeError: Error | null = null;
+const fetchMeMock = mock(async () => {
+  if (mockFetchMeError) throw mockFetchMeError;
+  return mockFetchMeResult;
+});
 const clearOrganizationMock = mock(() => {});
 const logoutMock = mock(async () => {});
 const deleteBiometricTokenMock = mock(async () => {});
@@ -100,8 +111,14 @@ mock.module("@/runtime/native-biometric", () => ({
 
 const clearUserScopedStorageMock = mock(() => {});
 
+mock.module("@/domains/account/profile", () => ({
+  fetchMe: fetchMeMock,
+}));
+
 mock.module("@/utils/onboarding-cleanup", () => ({
   restoreConsentForUser: restoreConsentForUserMock,
+  persistConsentForUser: persistConsentForUserMock,
+  resolveServerConsent: resolveServerConsentMock,
 }));
 
 mock.module("@/domains/onboarding/onboarding-store", () => ({
@@ -109,6 +126,8 @@ mock.module("@/domains/onboarding/onboarding-store", () => ({
     getState: () => ({
       setTosAccepted: () => {},
       setAiDataConsent: () => {},
+      setShareAnalytics: () => {},
+      setShareDiagnostics: () => {},
     }),
   },
 }));
@@ -169,6 +188,11 @@ beforeEach(() => {
   primeLocalGatewayConnectionMock.mockClear();
   primeLocalGatewayConnectionWithRepairMock.mockClear();
   restoreConsentForUserMock.mockClear();
+  persistConsentForUserMock.mockClear();
+  resolveServerConsentMock.mockClear();
+  fetchMeMock.mockClear();
+  mockFetchMeResult = { id: "user-1", username: "test", email: "test@example.com", first_name: "", last_name: "", consent: null };
+  mockFetchMeError = null;
   clearOrganizationMock.mockClear();
   clearUserScopedStorageMock.mockClear();
   logoutMock.mockClear();
@@ -183,8 +207,32 @@ beforeEach(() => {
 });
 
 describe("auth store onboarding flag reconciliation", () => {
-  test("initSession restores consent for the signed-in user", async () => {
+  test("initSession fetches consent from server for platform users", async () => {
     sessionUser = { id: "user-1", email: "user@example.com" };
+
+    await useAuthStore.getState().initSession();
+
+    expect(fetchMeMock).toHaveBeenCalled();
+    expect(resolveServerConsentMock).toHaveBeenCalled();
+    expect(restoreConsentForUserMock).not.toHaveBeenCalled();
+    expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
+  });
+
+  test("initSession falls back to device keys when fetchMe fails", async () => {
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    mockFetchMeError = new Error("Network error");
+
+    await useAuthStore.getState().initSession();
+
+    expect(fetchMeMock).toHaveBeenCalled();
+    expect(restoreConsentForUserMock).toHaveBeenCalledWith("user-1");
+    expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
+  });
+
+  test("initSession skips server fetch in local mode", async () => {
+    mockIsLocalMode = true;
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    mockPlatformAssistants = [{ assistantId: "p1", cloud: "vellum" }];
 
     await useAuthStore.getState().initSession();
 
@@ -192,12 +240,13 @@ describe("auth store onboarding flag reconciliation", () => {
     expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
   });
 
-  test("refreshSession restores consent for a changed user", async () => {
+  test("refreshSession fetches consent from server for platform users", async () => {
     sessionUser = { id: "user-2", email: "user@example.com" };
 
     await expect(useAuthStore.getState().refreshSession()).resolves.toBe(true);
 
-    expect(restoreConsentForUserMock).toHaveBeenCalledWith("user-2");
+    expect(fetchMeMock).toHaveBeenCalled();
+    expect(resolveServerConsentMock).toHaveBeenCalled();
     expect(useAuthStore.getState().user?.id).toBe("user-2");
   });
 

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -172,8 +172,8 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
       const store = useOnboardingStore.getState();
       store.setTosAccepted(resolved.tos);
       store.setAiDataConsent(resolved.ai);
-      store.setShareAnalytics(resolved.shareAnalytics);
-      store.setShareDiagnostics(resolved.shareDiagnostics);
+      if (resolved.shareAnalytics !== null) store.setShareAnalytics(resolved.shareAnalytics);
+      if (resolved.shareDiagnostics !== null) store.setShareDiagnostics(resolved.shareDiagnostics);
       persistConsentForUser(nextUserId, resolved.tos, resolved.ai);
       syncOrganizationState(nextUserId);
       return;

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -47,7 +47,8 @@ import {
 import { listAssistants } from "@/assistant/api";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { deleteBiometricToken } from "@/runtime/native-biometric";
-import { restoreConsentForUser } from "@/utils/onboarding-cleanup";
+import { fetchMe } from "@/domains/account/profile";
+import { restoreConsentForUser, persistConsentForUser, resolveServerConsent } from "@/utils/onboarding-cleanup";
 import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
 import { clearOrganization } from "@/stores/organization-store";
 import { clearUserScopedStorage } from "@/lib/auth/session-cleanup";
@@ -163,7 +164,24 @@ function broadcastAuthChange(): void {
   broadcastChannel?.postMessage("auth-changed");
 }
 
-function syncUserScopedState(nextUserId: string | null): void {
+async function syncUserScopedState(nextUserId: string | null): Promise<void> {
+  if (nextUserId && !isLocalMode()) {
+    try {
+      const me = await fetchMe();
+      const resolved = resolveServerConsent(me.consent);
+      const store = useOnboardingStore.getState();
+      store.setTosAccepted(resolved.tos);
+      store.setAiDataConsent(resolved.ai);
+      store.setShareAnalytics(resolved.shareAnalytics);
+      store.setShareDiagnostics(resolved.shareDiagnostics);
+      persistConsentForUser(nextUserId, resolved.tos, resolved.ai);
+      syncOrganizationState(nextUserId);
+      return;
+    } catch {
+      // Server fetch failed — fall through to device keys
+    }
+  }
+
   const consent = restoreConsentForUser(nextUserId);
   const store = useOnboardingStore.getState();
   store.setTosAccepted(consent.tos);
@@ -342,6 +360,7 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
           const result = await getSession();
           if (result.ok && result.data.user) {
             const user = toAuthUser(result.data.user);
+            await syncUserScopedState(user?.id ?? null);
             // Re-sync platform assistants to remove stale lockfile entries.
             try {
               const apiAssistants = await listAssistants();
@@ -378,7 +397,7 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
       const result = await getSession();
       if (result.ok && result.data.user) {
         const user = toAuthUser(result.data.user);
-        syncUserScopedState(user?.id ?? null);
+        await syncUserScopedState(user?.id ?? null);
         try {
           const apiAssistants = await listAssistants();
           if (apiAssistants.ok) {
@@ -403,7 +422,7 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
           const retryResult = await getSession();
           if (retryResult.ok && retryResult.data.user) {
             const user = toAuthUser(retryResult.data.user);
-            syncUserScopedState(user?.id ?? null);
+            await syncUserScopedState(user?.id ?? null);
             try {
               const apiAssistants = await listAssistants();
               if (apiAssistants.ok) {
@@ -419,7 +438,7 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
       }
     }
 
-    syncUserScopedState(null);
+    await syncUserScopedState(null);
     set(sessionEnded());
   },
 
@@ -451,7 +470,7 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
       throw new Error("Platform authentication required");
     }
     const user = toAuthUser(result.data.user);
-    syncUserScopedState(user?.id ?? null);
+    await syncUserScopedState(user?.id ?? null);
     set(authenticatedPlatformUser(user));
   },
 
@@ -472,7 +491,7 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
       const result = await getSession();
       if (result.ok && result.data.user) {
         const user = toAuthUser(result.data.user);
-        syncUserScopedState(user?.id ?? null);
+        await syncUserScopedState(user?.id ?? null);
         // Reconcile the lockfile mirror on refresh too — not just cold
         // `initSession`. App resume, profile save, and the provider callback
         // all route through here; without this the macOS tray and CLI keep a
@@ -495,7 +514,7 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
     } catch (err) {
       console.warn("auth.refreshSession failed", err);
     }
-    syncUserScopedState(null);
+    await syncUserScopedState(null);
     set(sessionEnded());
     return false;
   },

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -165,7 +165,7 @@ function broadcastAuthChange(): void {
 }
 
 async function syncUserScopedState(nextUserId: string | null): Promise<void> {
-  if (nextUserId && !isLocalMode()) {
+  if (nextUserId) {
     try {
       const me = await fetchMe();
       const resolved = resolveServerConsent(me.consent);

--- a/apps/web/src/utils/onboarding-cleanup.ts
+++ b/apps/web/src/utils/onboarding-cleanup.ts
@@ -6,13 +6,20 @@
  * the version lets us force re-consent by bumping CONSENT_VERSION.
  *
  * The onboarding Zustand store holds the in-memory state (`tosAccepted`,
- * `aiDataConsent`). This module handles the durable device-key layer:
+ * `aiDataConsent`). This module handles the durable device-key layer
+ * and the unified read/write API for all consent state:
  *
+ * - `resolveServerConsent` — compare server consent versions against CONSENT_VERSION
+ * - `saveConsent`          — unified write: store + device keys + server sync
+ * - `savePreferenceToggle` — single-field write for settings page toggles
  * - `restoreConsentForUser` — read device keys, return {tos, ai}
  * - `persistConsentForUser` — write device keys
  * - `clearConsentForUser`   — delete device keys + legacy active keys
  */
 import { removeLocalSetting, getLocalBool, setLocalBool } from "@/utils/local-settings";
+import { setDeviceBool } from "@/utils/device-settings";
+import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
+import { patchConsent, type UserConsent } from "@/domains/account/profile";
 
 export const CONSENT_VERSION = "2026-06-08";
 
@@ -67,5 +74,71 @@ export function clearConsentForUser(userId: string | null): void {
     removeLocalSetting(consentKey("ai", userId));
   } catch {
     // Storage unavailable.
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Server consent resolution
+// ---------------------------------------------------------------------------
+
+export function resolveServerConsent(
+  consent: UserConsent | null | undefined,
+): { tos: boolean; ai: boolean; shareAnalytics: boolean; shareDiagnostics: boolean } {
+  if (!consent) return { tos: false, ai: false, shareAnalytics: true, shareDiagnostics: true };
+  return {
+    tos: consent.tos_accepted_version === CONSENT_VERSION,
+    ai: consent.ai_data_sharing_accepted_version === CONSENT_VERSION,
+    shareAnalytics: consent.share_analytics,
+    shareDiagnostics: consent.share_diagnostics,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Unified write API
+// ---------------------------------------------------------------------------
+
+export function saveConsent(opts: {
+  userId: string | null;
+  tos: boolean;
+  ai: boolean;
+  shareAnalytics: boolean;
+  shareDiagnostics: boolean;
+  hasPlatformSession: boolean;
+}): void {
+  const store = useOnboardingStore.getState();
+  store.setTosAccepted(opts.tos);
+  store.setAiDataConsent(opts.ai);
+  store.setShareAnalytics(opts.shareAnalytics);
+  store.setShareDiagnostics(opts.shareDiagnostics);
+
+  persistConsentForUser(opts.userId, opts.tos, opts.ai);
+
+  if (opts.hasPlatformSession) {
+    void patchConsent({
+      tos_accepted_version: opts.tos ? CONSENT_VERSION : "",
+      privacy_policy_accepted_version: opts.tos ? CONSENT_VERSION : "",
+      ai_data_sharing_accepted_version: opts.ai ? CONSENT_VERSION : "",
+      share_analytics: opts.shareAnalytics,
+      share_diagnostics: opts.shareDiagnostics,
+    }).catch(() => {});
+  }
+}
+
+export function savePreferenceToggle(
+  field: "share_analytics" | "share_diagnostics",
+  value: boolean,
+  hasPlatformSession: boolean,
+): void {
+  const store = useOnboardingStore.getState();
+  if (field === "share_analytics") {
+    store.setShareAnalytics(value);
+    setDeviceBool("shareAnalytics", value);
+  } else {
+    store.setShareDiagnostics(value);
+    setDeviceBool("shareDiagnostics", value);
+  }
+
+  if (hasPlatformSession) {
+    void patchConsent({ [field]: value }).catch(() => {});
   }
 }

--- a/apps/web/src/utils/onboarding-cleanup.ts
+++ b/apps/web/src/utils/onboarding-cleanup.ts
@@ -83,8 +83,8 @@ export function clearConsentForUser(userId: string | null): void {
 
 export function resolveServerConsent(
   consent: UserConsent | null | undefined,
-): { tos: boolean; ai: boolean; shareAnalytics: boolean; shareDiagnostics: boolean } {
-  if (!consent) return { tos: false, ai: false, shareAnalytics: true, shareDiagnostics: true };
+): { tos: boolean; ai: boolean; shareAnalytics: boolean | null; shareDiagnostics: boolean | null } {
+  if (!consent) return { tos: false, ai: false, shareAnalytics: null, shareDiagnostics: null };
   return {
     tos: consent.tos_accepted_version === CONSENT_VERSION
       && consent.privacy_policy_accepted_version === CONSENT_VERSION,

--- a/apps/web/src/utils/onboarding-cleanup.ts
+++ b/apps/web/src/utils/onboarding-cleanup.ts
@@ -86,7 +86,8 @@ export function resolveServerConsent(
 ): { tos: boolean; ai: boolean; shareAnalytics: boolean; shareDiagnostics: boolean } {
   if (!consent) return { tos: false, ai: false, shareAnalytics: true, shareDiagnostics: true };
   return {
-    tos: consent.tos_accepted_version === CONSENT_VERSION,
+    tos: consent.tos_accepted_version === CONSENT_VERSION
+      && consent.privacy_policy_accepted_version === CONSENT_VERSION,
     ai: consent.ai_data_sharing_accepted_version === CONSENT_VERSION,
     shareAnalytics: consent.share_analytics,
     shareDiagnostics: consent.share_diagnostics,


### PR DESCRIPTION
## Summary

- **Unified consent read/write API**: `saveConsent()` and `savePreferenceToggle()` handle Zustand store updates, device key persistence, and server PATCH in a single call — consumers never choose between local and server paths
- **Server-first consent on login**: `syncUserScopedState()` in the auth store now fetches `/v1/user/me/` for platform users and resolves consent versions against `CONSENT_VERSION`, falling back to device keys on failure
- **Privacy screen & settings page**: both now route through the unified write API, syncing consent to the server for platform users via fire-and-forget PATCH

## Original prompt

The backend now exposes consent fields (TOS, privacy policy, AI data sharing versions + timestamps, analytics/diagnostics preferences) on `GET/PATCH /v1/user/me/`. The goal was to make the server the source of truth for authenticated platform users while keeping device-local keys as a fallback for local-only mode. The user wanted a unified read/write API so consumers never need to distinguish between local and server paths — the onboarding Zustand store remains the single read surface, and `saveConsent()`/`savePreferenceToggle()` are the single write surface.

## Test plan

- [ ] Platform user login: returning user with accepted consent should NOT see privacy screen
- [ ] New platform user: first login → privacy screen → accept → verify PATCH to `/v1/user/me/` in Network tab
- [ ] Local-only user: works exactly as before — device keys only, no server calls
- [ ] Version bump: change `CONSENT_VERSION` → returning user re-prompted → new version stored on server
- [ ] Offline resilience: if `/v1/user/me/` fails, falls back to device keys silently
- [ ] Settings page: toggle analytics/diagnostics → verify PATCH to `/v1/user/me/`
- [ ] `bun test src/stores/auth-store.test.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)