### PR TITLE
feat: publish electron-updater artifacts to GCS in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2543,12 +2543,64 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+      - name: Upload Electron update artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: macos-electron-update
+          path: |
+            apps/macos/dist/latest-mac.yml
+            apps/macos/dist/*.zip
+            apps/macos/dist/*.zip.blockmap
+          if-no-files-found: warn
+          retention-days: 7
+
       - name: Cleanup keychain and keys
         if: always()
         run: |
           KEYCHAIN_PATH="$HOME/Library/Keychains/$KEYCHAIN_NAME-db"
           security delete-keychain "$KEYCHAIN_PATH" 2>/dev/null || true
           rm -rf ~/.private_keys 2>/dev/null || true
+
+  # ── Upload Electron update artifacts to GCS ────────────────────────────
+  # Push latest-mac.yml, ZIP, and blockmap to the public GCS bucket so
+  # electron-updater can pull delta updates. Production goes to
+  # electron/latest/, staging to electron/beta/.
+
+  upload-electron-updates:
+    needs: [extract-version, build-electron]
+    if: ${{ needs.build-electron.result == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment: ${{ needs.extract-version.outputs.is_staging == 'true' && 'staging' || 'production' }}
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download Electron update artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: macos-electron-update
+          path: electron-artifacts
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+
+      - name: Upload Electron update artifacts to GCS
+        run: |
+          CHANNEL=${{ needs.extract-version.outputs.is_staging == 'true' && 'beta' || 'latest' }}
+          BUCKET="vellum-desktop-releases"
+          PREFIX="electron/${CHANNEL}"
+
+          LATEST_YML=$(find electron-artifacts -name "latest-mac.yml" -type f | grep -m1 .)
+          ZIP=$(find electron-artifacts -name "*.zip" -type f | grep -v blockmap | grep -m1 .)
+          BLOCKMAP=$(find electron-artifacts -name "*.zip.blockmap" -type f | grep -m1 .)
+
+          gcloud storage cp "$LATEST_YML" "gs://${BUCKET}/${PREFIX}/latest-mac.yml"
+          gcloud storage cp "$ZIP" "gs://${BUCKET}/${PREFIX}/$(basename "$ZIP")"
+          [ -n "$BLOCKMAP" ] && gcloud storage cp "$BLOCKMAP" "gs://${BUCKET}/${PREFIX}/$(basename "$BLOCKMAP")"
 
   release:
     needs: [extract-version, publish-npm-prod, publish-web-prod, publish-meta-prod, build-macos-arm64, build-macos-x64, build-electron, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image, ci-playwright, build-chrome-extension]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2598,7 +2598,8 @@ jobs:
           ZIP=$(find electron-artifacts -name "*.zip" -type f | grep -v blockmap | grep -m1 .)
           BLOCKMAP=$(find electron-artifacts -name "*.zip.blockmap" -type f | grep -m1 .)
 
-          gcloud storage cp "$LATEST_YML" "gs://${BUCKET}/${PREFIX}/latest-mac.yml"
+          MANIFEST_NAME="${CHANNEL}-mac.yml"
+          gcloud storage cp "$LATEST_YML" "gs://${BUCKET}/${PREFIX}/${MANIFEST_NAME}"
           gcloud storage cp "$ZIP" "gs://${BUCKET}/${PREFIX}/$(basename "$ZIP")"
           [ -n "$BLOCKMAP" ] && gcloud storage cp "$BLOCKMAP" "gs://${BUCKET}/${PREFIX}/$(basename "$BLOCKMAP")"
 


### PR DESCRIPTION
## Summary
- Add upload-artifact step in build-electron job for update files (latest-mac.yml, zip, blockmap)
- Add upload-electron-updates job to publish update artifacts to GCS bucket
- Production releases go to electron/latest/, staging to electron/beta/

Part of plan: electron-auto-update.md (PR 4 of 5)