### PR TITLE
feat: add unobtrusive auto-update UI in renderer

### DIFF
--- a/apps/web/src/components/update-banner.tsx
+++ b/apps/web/src/components/update-banner.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useState } from "react";
+
+import { isElectron } from "@/runtime/is-electron";
+import {
+  getUpdateState,
+  installUpdate,
+  onUpdateState,
+  type UpdateState,
+} from "@/runtime/auto-update";
+
+/**
+ * Compact, non-blocking banner that surfaces auto-update progress to
+ * the user. Only renders inside the Electron host — on web / iOS the
+ * component returns null.
+ *
+ * States:
+ *  - idle / checking / error: render nothing.
+ *  - available: "Update available" (auto-download is enabled, no action needed).
+ *  - downloading: progress bar with percentage.
+ *  - downloaded: "Vellum X.Y.Z is ready — Restart to install" with a button.
+ */
+export function UpdateBanner() {
+  const [state, setState] = useState<UpdateState>({ status: "idle" });
+
+  useEffect(() => {
+    if (!isElectron()) return;
+
+    // Seed with current state, then subscribe for live updates.
+    void getUpdateState().then(setState);
+    return onUpdateState(setState);
+  }, []);
+
+  if (!isElectron()) return null;
+
+  if (
+    state.status === "idle" ||
+    state.status === "checking" ||
+    state.status === "error"
+  ) {
+    return null;
+  }
+
+  const percent = Math.round(state.progress?.percent ?? 0);
+
+  return (
+    <div
+      data-testid="update-banner"
+      className="flex items-center gap-3 px-4 py-1.5"
+      style={{
+        background: "var(--surface-active)",
+        borderBottom: "1px solid var(--border-default)",
+        fontSize: "13px",
+        color: "var(--text-secondary)",
+      }}
+    >
+      {state.status === "available" && (
+        <span>Update available — downloading will begin shortly.</span>
+      )}
+
+      {state.status === "downloading" && (
+        <>
+          <span className="shrink-0">Downloading update…</span>
+          <div
+            className="h-1.5 flex-1 overflow-hidden rounded-full"
+            style={{ background: "var(--surface-hover)" }}
+          >
+            <div
+              className="h-full rounded-full transition-[width] duration-300"
+              style={{
+                width: `${percent}%`,
+                background: "var(--brand-default)",
+              }}
+            />
+          </div>
+          <span className="shrink-0 tabular-nums">{percent}%</span>
+        </>
+      )}
+
+      {state.status === "downloaded" && (
+        <>
+          <span>
+            Vellum {state.version ?? "update"} is ready.
+          </span>
+          <button
+            type="button"
+            onClick={() => void installUpdate()}
+            className="cursor-pointer underline"
+            style={{
+              background: "none",
+              border: "none",
+              padding: 0,
+              font: "inherit",
+              color: "var(--brand-default)",
+            }}
+          >
+            Restart to install
+          </button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/root-layout.tsx
+++ b/apps/web/src/root-layout.tsx
@@ -39,6 +39,7 @@ import { useElectronIconSync } from "@/hooks/use-electron-icon-sync";
 import { useElectronStatusSync } from "@/hooks/use-electron-status-sync";
 import { useElectronFeatureFlagBridge } from "@/runtime/electron-feature-flags";
 import { TimezoneSync } from "@/components/timezone-sync";
+import { UpdateBanner } from "@/components/update-banner";
 import { retireAssistant } from "@/assistant/retire-service";
 import { selectPlatformAssistant } from "@/assistant/select-platform-assistant";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
@@ -249,6 +250,7 @@ export function RootLayout() {
         isolation: "isolate",
       }}
     >
+      <UpdateBanner />
       <div className="flex min-w-0 flex-col overflow-hidden h-full w-full">
         <Outlet />
       </div>

--- a/apps/web/src/root-layout.tsx
+++ b/apps/web/src/root-layout.tsx
@@ -248,10 +248,12 @@ export function RootLayout() {
         paddingRight:
           "var(--safe-area-inset-right, env(safe-area-inset-right, 0px))",
         isolation: "isolate",
+        display: "flex",
+        flexDirection: "column",
       }}
     >
       <UpdateBanner />
-      <div className="flex min-w-0 flex-col overflow-hidden h-full w-full">
+      <div className="flex min-w-0 flex-col overflow-hidden w-full" style={{ flex: "1 1 0%", minHeight: 0 }}>
         <Outlet />
       </div>
 

--- a/apps/web/src/runtime/auto-update.ts
+++ b/apps/web/src/runtime/auto-update.ts
@@ -1,0 +1,44 @@
+import {
+  isElectron,
+  type UpdateState,
+  type UpdateStatus,
+} from "@/runtime/is-electron";
+
+export type { UpdateState, UpdateStatus };
+
+/**
+ * Per-capability wrapper for the Electron host's auto-update bridge.
+ * Matches the established shape (`app-info.ts`, `power-events.ts`,
+ * `connectivity.ts`): feature code never touches `window.vellum.*`
+ * directly, and the cross-platform branch lives here.
+ *
+ * Off Electron (web build, Capacitor iOS): all functions are safe
+ * no-ops — `getUpdateState` returns idle, subscriptions return
+ * unsubscribe-noops, and imperative triggers are swallowed.
+ */
+
+/** Snapshot the current update state. Returns idle off Electron. */
+export async function getUpdateState(): Promise<UpdateState> {
+  if (!isElectron()) return { status: "idle" };
+  return (await window.vellum?.update?.getState()) ?? { status: "idle" };
+}
+
+/** Trigger a manual check for updates. No-op off Electron. */
+export async function checkForUpdates(): Promise<void> {
+  if (!isElectron()) return;
+  await window.vellum?.update?.check();
+}
+
+/** Quit and install the downloaded update. No-op off Electron. */
+export async function installUpdate(): Promise<void> {
+  if (!isElectron()) return;
+  await window.vellum?.update?.install();
+}
+
+/** Subscribe to update state changes. Returns an unsubscribe function. */
+export function onUpdateState(
+  callback: (state: UpdateState) => void,
+): () => void {
+  if (!isElectron()) return () => undefined;
+  return window.vellum?.update?.onState(callback) ?? (() => undefined);
+}


### PR DESCRIPTION
## Summary
- Create runtime/auto-update.ts wrapper module gated behind isElectron()
- Add UpdateBanner component showing download progress and restart prompt
- Render UpdateBanner in root-layout.tsx, only visible in Electron builds

Part of plan: electron-auto-update.md (PR 5 of 5)