### PR TITLE
fix(assistant): categorize STT file-transcription provider failures (JARVIS-994)

### DIFF
--- a/assistant/src/runtime/routes/__tests__/stt-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/stt-routes.test.ts
@@ -1,9 +1,9 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { randomUUID } from "node:crypto";
 import { writeFileSync } from "node:fs";
 import { unlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 // ---------------------------------------------------------------------------
 // Module mocks — must appear before any imports of the modules under test

--- a/assistant/src/runtime/routes/__tests__/stt-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/stt-routes.test.ts
@@ -460,10 +460,13 @@ describe("stt-routes", () => {
     });
   });
 
-  test("transcribe-file maps ffmpeg failures to 502", async () => {
+  test("transcribe-file maps ffmpeg failures to 502 even when stderr contains a status-like number", async () => {
+    // Guards against ffmpeg stderr (or a user-supplied path) deciding the HTTP
+    // category: a conversion failure whose message contains "403" must stay a
+    // 502 conversion error, not become a misleading 401 auth error.
     spawnOverride = (args) =>
       args[0] === "ffmpeg"
-        ? { exitCode: 1, stdout: "", stderr: "ffmpeg boom" }
+        ? { exitCode: 1, stdout: "", stderr: "Error opening /tmp/403/clip.wav" }
         : { exitCode: 0, stdout: "1.0", stderr: "" };
 
     await withTempAudioFile(async (filePath) => {

--- a/assistant/src/runtime/routes/__tests__/stt-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/stt-routes.test.ts
@@ -1,4 +1,9 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { writeFileSync } from "node:fs";
+import { unlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 // ---------------------------------------------------------------------------
 // Module mocks — must appear before any imports of the modules under test
@@ -24,6 +29,35 @@ mock.module("../../../providers/speech-to-text/resolve.js", () => ({
     if (mockResolveError) throw mockResolveError;
     return mockTranscriber;
   },
+}));
+
+// -- Spawn mock (ffmpeg/ffprobe) for the file-transcription path ------------
+
+type SpawnResult = { exitCode: number; stdout: string; stderr: string };
+let spawnOverride: ((args: string[]) => SpawnResult) | null = null;
+
+/**
+ * Default spawn behavior: ffmpeg writes the requested output file so the
+ * downstream readFile succeeds, ffprobe reports a short duration.
+ */
+function defaultSpawn(args: string[]): SpawnResult {
+  if (args[0] === "ffmpeg") {
+    const outputPath = args[args.length - 1];
+    writeFileSync(outputPath, Buffer.from("fake-wav-bytes"));
+    return { exitCode: 0, stdout: "", stderr: "" };
+  }
+  if (args[0] === "ffprobe") {
+    return { exitCode: 0, stdout: "1.0", stderr: "" };
+  }
+  return { exitCode: 0, stdout: "", stderr: "" };
+}
+
+mock.module("../../../util/spawn.js", () => ({
+  FFMPEG_TRANSCODE_TIMEOUT_MS: 60_000,
+  FFPROBE_TIMEOUT_MS: 10_000,
+  STT_REQUEST_TIMEOUT_MS: 300_000,
+  spawnWithTimeout: async (args: string[]) =>
+    (spawnOverride ?? defaultSpawn)(args),
 }));
 
 // ---------------------------------------------------------------------------
@@ -86,6 +120,7 @@ const fakeTranscriber: BatchTranscriber = {
 beforeEach(() => {
   mockTranscriber = fakeTranscriber;
   mockResolveError = null;
+  spawnOverride = null;
 });
 
 afterEach(() => {
@@ -365,5 +400,79 @@ describe("stt-routes", () => {
       502,
       "BAD_GATEWAY",
     );
+  });
+
+  // -- File transcription: provider error categorization --------------------
+
+  async function withTempAudioFile(
+    run: (filePath: string) => Promise<void>,
+  ): Promise<void> {
+    const filePath = join(tmpdir(), `vellum-stt-test-${randomUUID()}.wav`);
+    await writeFile(filePath, Buffer.from("fake-audio"));
+    try {
+      await run(filePath);
+    } finally {
+      await unlink(filePath).catch(() => {});
+    }
+  }
+
+  test("transcribe-file maps provider auth failures (403) to 401", async () => {
+    // Reproduces JARVIS-994: a raw Gemini 403 denial must surface as an
+    // actionable 401, not a generic 502, and must not be treated as a
+    // daemon-level error.
+    mockTranscriber = {
+      providerId: "google-gemini",
+      boundaryId: "daemon-batch",
+      transcribe: async () => {
+        throw new Error(
+          'Google Gemini API error (403): {"error":{"code":403,"message":"Your project has been denied access. Please contact support.","status":"PERMISSION_DENIED"}}',
+        );
+      },
+    };
+
+    await withTempAudioFile(async (filePath) => {
+      const { handler } = getRoute("stt/transcribe-file");
+      const err = await expectRouteError(
+        () => handler(makeArgs({ filePath })),
+        401,
+        "UNAUTHORIZED",
+      );
+      expect(err.message).toContain("credentials");
+    });
+  });
+
+  test("transcribe-file maps generic provider failures to 502", async () => {
+    mockTranscriber = {
+      providerId: "openai-whisper",
+      boundaryId: "daemon-batch",
+      transcribe: async () => {
+        throw new Error("upstream kaboom");
+      },
+    };
+
+    await withTempAudioFile(async (filePath) => {
+      const { handler } = getRoute("stt/transcribe-file");
+      await expectRouteError(
+        () => handler(makeArgs({ filePath })),
+        502,
+        "BAD_GATEWAY",
+      );
+    });
+  });
+
+  test("transcribe-file maps ffmpeg failures to 502", async () => {
+    spawnOverride = (args) =>
+      args[0] === "ffmpeg"
+        ? { exitCode: 1, stdout: "", stderr: "ffmpeg boom" }
+        : { exitCode: 0, stdout: "1.0", stderr: "" };
+
+    await withTempAudioFile(async (filePath) => {
+      const { handler } = getRoute("stt/transcribe-file");
+      await expectRouteError(
+        () => handler(makeArgs({ filePath })),
+        502,
+        "BAD_GATEWAY",
+      );
+    });
   });
 });

--- a/assistant/src/runtime/routes/stt-routes.ts
+++ b/assistant/src/runtime/routes/stt-routes.ts
@@ -363,10 +363,20 @@ async function handleTranscribeFile({ body }: RouteHandlerArgs) {
       durationSeconds,
     };
   } catch (err) {
-    log.error({ err, filePath }, "File transcription failed");
-    throw new BadGatewayError(
-      err instanceof Error ? err.message : "Transcription failed",
-    );
+    const sttErr = normalizeSttError(err);
+    // Auth/rate-limit/timeout/invalid-audio are user-config or transient
+    // conditions, not daemon defects, so log them at warn to keep them out of
+    // error telemetry. Reserve error level (with the raw err for a Sentry
+    // stack) for genuine provider/unexpected failures (e.g. ffmpeg, network).
+    if (sttErr.category === "provider-error") {
+      log.error({ err, filePath }, "File transcription failed");
+    } else {
+      log.warn(
+        { category: sttErr.category, message: sttErr.message, filePath },
+        "File transcription failed",
+      );
+    }
+    throw STT_ERROR_MAP[sttErr.category]();
   } finally {
     if (wavPath) {
       await unlink(wavPath).catch(() => {});

--- a/assistant/src/runtime/routes/stt-routes.ts
+++ b/assistant/src/runtime/routes/stt-routes.ts
@@ -17,6 +17,7 @@ import { listProviderEntries } from "../../providers/speech-to-text/provider-cat
 import { resolveBatchTranscriber } from "../../providers/speech-to-text/resolve.js";
 import { normalizeSttError } from "../../stt/daemon-batch-transcriber.js";
 import type { BatchTranscriber, SttErrorCategory } from "../../stt/types.js";
+import { SttError } from "../../stt/types.js";
 import { getLogger } from "../../util/logger.js";
 import {
   FFMPEG_TRANSCODE_TIMEOUT_MS,
@@ -141,6 +142,27 @@ async function toWav(inputPath: string, isVideo: boolean): Promise<string> {
   return wavPath;
 }
 
+/**
+ * Call the provider and tag any failure as an {@link SttError} so callers can
+ * distinguish provider failures (categorized HTTP statuses) from local
+ * preprocessing failures (ffmpeg/ffprobe), which stay on the bad-gateway path.
+ */
+async function transcribeChunk(
+  transcriber: BatchTranscriber,
+  audioBuffer: Buffer,
+): Promise<string> {
+  try {
+    const result = await transcriber.transcribe({
+      audio: audioBuffer,
+      mimeType: "audio/wav",
+      signal: AbortSignal.timeout(STT_REQUEST_TIMEOUT_MS),
+    });
+    return result.text;
+  } catch (err) {
+    throw normalizeSttError(err);
+  }
+}
+
 async function transcribeWithProvider(
   audioPath: string,
   transcriber: BatchTranscriber,
@@ -151,12 +173,7 @@ async function transcribeWithProvider(
   // If small enough, send directly
   if (fileSize <= STT_CHUNK_MAX_BYTES) {
     const audioBuffer = await readFile(audioPath);
-    const result = await transcriber.transcribe({
-      audio: audioBuffer,
-      mimeType: "audio/wav",
-      signal: AbortSignal.timeout(STT_REQUEST_TIMEOUT_MS),
-    });
-    return result.text;
+    return transcribeChunk(transcriber, audioBuffer);
   }
 
   // Split into chunks for large files
@@ -175,12 +192,8 @@ async function transcribeWithProvider(
         `  Transcribing chunk ${i + 1}/${chunks.length}...\n`,
       );
       const audioBuffer = await readFile(chunks[i]);
-      const result = await transcriber.transcribe({
-        audio: audioBuffer,
-        mimeType: "audio/wav",
-        signal: AbortSignal.timeout(STT_REQUEST_TIMEOUT_MS),
-      });
-      if (result.text) parts.push(result.text);
+      const text = await transcribeChunk(transcriber, audioBuffer);
+      if (text) parts.push(text);
     }
 
     return parts.join(" ");
@@ -363,20 +376,30 @@ async function handleTranscribeFile({ body }: RouteHandlerArgs) {
       durationSeconds,
     };
   } catch (err) {
-    const sttErr = normalizeSttError(err);
-    // Auth/rate-limit/timeout/invalid-audio are user-config or transient
-    // conditions, not daemon defects, so log them at warn to keep them out of
-    // error telemetry. Reserve error level (with the raw err for a Sentry
-    // stack) for genuine provider/unexpected failures (e.g. ffmpeg, network).
-    if (sttErr.category === "provider-error") {
-      log.error({ err, filePath }, "File transcription failed");
-    } else {
-      log.warn(
-        { category: sttErr.category, message: sttErr.message, filePath },
-        "File transcription failed",
-      );
+    // Only provider failures (tagged as SttError by transcribeChunk) are
+    // categorized into HTTP statuses. Local preprocessing failures (ffmpeg/
+    // ffprobe) stay on the bad-gateway path so their stderr never decides the
+    // category (e.g. a path under a dir named "403" must not become a 401).
+    if (err instanceof SttError) {
+      // Auth/rate-limit/timeout/invalid-audio are user-config or transient
+      // conditions, not daemon defects, so log them at warn to keep them out
+      // of error telemetry. Reserve error level (with the raw err for a Sentry
+      // stack) for genuine provider/unexpected failures.
+      if (err.category === "provider-error") {
+        log.error({ err, filePath }, "File transcription failed");
+      } else {
+        log.warn(
+          { category: err.category, message: err.message, filePath },
+          "File transcription failed",
+        );
+      }
+      throw STT_ERROR_MAP[err.category]();
     }
-    throw STT_ERROR_MAP[sttErr.category]();
+
+    log.error({ err, filePath }, "File transcription failed");
+    throw new BadGatewayError(
+      err instanceof Error ? err.message : "Transcription failed",
+    );
   } finally {
     if (wavPath) {
       await unlink(wavPath).catch(() => {});


### PR DESCRIPTION
## Summary
- `handleTranscribeFile` now normalizes provider errors via `normalizeSttError` and maps them through `STT_ERROR_MAP`, matching `handleTranscribe`. A denied or invalid STT credential (e.g. Google Gemini `403 PERMISSION_DENIED` "Your project has been denied access") now surfaces as an actionable 401 instead of a generic 502.
- Auth, rate-limit, timeout, and invalid-audio failures log at `warn` so they stay out of error telemetry (this is the Sentry noise JARVIS-994 was reporting). Only genuine provider or unexpected failures (ffmpeg, network) log at `error`, retaining the raw `err` for a usable Sentry stack.
- Adds regression tests for the file-transcription path: the 403 to 401 mapping (the JARVIS-994 repro), generic provider failures mapping to 502, and ffmpeg failures mapping to 502.

## Original prompt
Triage of Linear JARVIS-994: a Sentry error reported a Google Gemini `403 PERMISSION_DENIED` ("Your project has been denied access") thrown from the STT `transcribe` path. The 403 itself is an external, account-side condition on the user's Gemini project, not a code defect. The actionable finding was that `handleTranscribeFile` was the only one of the three STT entry points that ignored the shared error-normalization machinery, logging every failure at error level and returning a generic 502. The fix makes it consistent with `handleTranscribe` so credential failures are logged at warn and returned as 401, removing the Sentry noise without changing the Gemini provider or adding provider fallback.