### PR TITLE
feat: add device ID reader to Electron main process

### DIFF
--- a/apps/macos/src/main/device-id.test.ts
+++ b/apps/macos/src/main/device-id.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DIR = path.join(os.tmpdir(), `device-id-test-${process.pid}`);
+const DEVICE_FILE = path.join(TEST_DIR, "device.json");
+
+// Stub @vellumai/local-mode so we control the resolved paths.
+let mockEnvironment = "dev";
+mock.module("@vellumai/local-mode", () => ({
+  resolveConfigDir: () => TEST_DIR,
+  resolveEnvironmentName: () => mockEnvironment,
+}));
+
+const { getDeviceId, resetDeviceIdCache } = await import("./device-id");
+
+const cleanup = (): void => {
+  resetDeviceIdCache();
+  try {
+    fs.rmSync(TEST_DIR, { recursive: true, force: true });
+  } catch {
+    // already gone
+  }
+};
+
+beforeEach(() => {
+  cleanup();
+  fs.mkdirSync(TEST_DIR, { recursive: true });
+});
+
+afterEach(cleanup);
+
+describe("device-id", () => {
+  test("reads existing device.json and returns the deviceId", () => {
+    /**
+     * Tests that when device.json already exists with a valid deviceId,
+     * getDeviceId returns that value without overwriting it.
+     */
+
+    // GIVEN a device.json with a known UUID
+    const existingId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+    fs.writeFileSync(
+      DEVICE_FILE,
+      JSON.stringify({ deviceId: existingId }, null, 2) + "\n",
+    );
+
+    // WHEN getDeviceId is called
+    const result = getDeviceId();
+
+    // THEN it returns the existing ID
+    expect(result).toBe(existingId);
+  });
+
+  test("creates device.json when the file does not exist", () => {
+    /**
+     * Tests that when no device.json exists, getDeviceId generates a new
+     * UUID, writes it to disk, and returns it.
+     */
+
+    // GIVEN no device.json on disk
+    expect(fs.existsSync(DEVICE_FILE)).toBe(false);
+
+    // WHEN getDeviceId is called
+    const result = getDeviceId();
+
+    // THEN it returns a valid UUID
+    expect(result).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+
+    // AND the file is created on disk with the same ID
+    const onDisk = JSON.parse(fs.readFileSync(DEVICE_FILE, "utf-8"));
+    expect(onDisk.deviceId).toBe(result);
+  });
+
+  test("caches the result after the first call", () => {
+    /**
+     * Tests that subsequent calls return the same value without re-reading
+     * disk. Verified by changing the file between calls.
+     */
+
+    // GIVEN getDeviceId has been called once
+    const firstResult = getDeviceId();
+
+    // WHEN the on-disk file is changed
+    fs.writeFileSync(
+      DEVICE_FILE,
+      JSON.stringify({ deviceId: "changed-id" }, null, 2) + "\n",
+    );
+
+    // THEN the second call still returns the cached value
+    expect(getDeviceId()).toBe(firstResult);
+  });
+
+  test("handles malformed JSON gracefully", () => {
+    /**
+     * Tests that a corrupted device.json doesn't crash the process — the
+     * function generates a new UUID and overwrites the file.
+     */
+
+    // GIVEN a device.json with invalid JSON
+    fs.writeFileSync(DEVICE_FILE, "not valid json {{{");
+
+    // WHEN getDeviceId is called
+    const result = getDeviceId();
+
+    // THEN it returns a valid UUID
+    expect(result).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+
+    // AND the file is overwritten with valid JSON
+    const onDisk = JSON.parse(fs.readFileSync(DEVICE_FILE, "utf-8"));
+    expect(onDisk.deviceId).toBe(result);
+  });
+
+  test("handles device.json with missing deviceId field", () => {
+    /**
+     * Tests that a device.json without a deviceId field is treated the same
+     * as a missing file — a new UUID is generated and the field is added
+     * while preserving other content.
+     */
+
+    // GIVEN a device.json with other fields but no deviceId
+    fs.writeFileSync(
+      DEVICE_FILE,
+      JSON.stringify({ otherField: "preserved" }, null, 2) + "\n",
+    );
+
+    // WHEN getDeviceId is called
+    const result = getDeviceId();
+
+    // THEN it returns a valid UUID
+    expect(result).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+
+    // AND the existing field is preserved alongside the new deviceId
+    const onDisk = JSON.parse(fs.readFileSync(DEVICE_FILE, "utf-8"));
+    expect(onDisk.deviceId).toBe(result);
+    expect(onDisk.otherField).toBe("preserved");
+  });
+
+  test("resetDeviceIdCache forces re-read on next call", () => {
+    /**
+     * Tests that resetDeviceIdCache clears the in-memory cache so the next
+     * getDeviceId call reads from disk again.
+     */
+
+    // GIVEN getDeviceId has been called and cached
+    const firstResult = getDeviceId();
+
+    // WHEN the cache is reset and the file is updated
+    resetDeviceIdCache();
+    const newId = "11111111-2222-3333-4444-555555555555";
+    fs.writeFileSync(
+      DEVICE_FILE,
+      JSON.stringify({ deviceId: newId }, null, 2) + "\n",
+    );
+
+    // THEN the next call reads the new value from disk
+    const secondResult = getDeviceId();
+    expect(secondResult).toBe(newId);
+    expect(secondResult).not.toBe(firstResult);
+  });
+
+  test("creates parent directories when they do not exist", () => {
+    /**
+     * Tests that getDeviceId creates the config directory tree if it
+     * doesn't exist yet (first-run scenario).
+     */
+
+    // GIVEN the entire test directory has been removed
+    fs.rmSync(TEST_DIR, { recursive: true, force: true });
+
+    // WHEN getDeviceId is called
+    const result = getDeviceId();
+
+    // THEN it returns a valid UUID and the directory + file were created
+    expect(result).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+    expect(fs.existsSync(DEVICE_FILE)).toBe(true);
+  });
+});

--- a/apps/macos/src/main/device-id.ts
+++ b/apps/macos/src/main/device-id.ts
@@ -1,0 +1,94 @@
+/**
+ * Device ID resolver for the Electron main process.
+ *
+ * Reads or creates a stable per-device UUID stored in device.json. The file
+ * is shared with the daemon (TypeScript) and Swift client so all three
+ * runtimes use the same identifier for X-Vellum-Client-Id headers.
+ *
+ * Path resolution mirrors VellumPaths.deviceIdFile (Swift) and
+ * assistant/src/util/device-id.ts (daemon):
+ *   - Production:     ~/.vellum/device.json  (legacy shared path)
+ *   - Non-production: <configDir>/device.json where configDir is
+ *                     $XDG_CONFIG_HOME/vellum-<env>
+ */
+
+import { randomUUID } from "node:crypto";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { resolveConfigDir, resolveEnvironmentName } from "@vellumai/local-mode";
+
+let cached: string | undefined;
+
+/**
+ * Resolve the directory containing device.json. Production uses the legacy
+ * ~/.vellum path (shared with the Swift client and daemon); non-production
+ * uses resolveConfigDir from @vellumai/local-mode.
+ */
+function resolveDeviceDir(): string {
+  const env = resolveEnvironmentName(process.env);
+  if (env === "production") {
+    return join(homedir(), ".vellum");
+  }
+  return resolveConfigDir(process.env);
+}
+
+/**
+ * Get the stable device ID for this machine.
+ *
+ * Resolution order:
+ *   1. Cached in-memory value (populated on first call)
+ *   2. deviceId field from device.json
+ *   3. Generate a new UUID, persist it to device.json, and return it
+ *
+ * On any read/write error the generated UUID is still cached so the
+ * process uses a consistent ID for the remainder of its lifetime.
+ */
+export function getDeviceId(): string {
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const dir = resolveDeviceDir();
+  const filePath = join(dir, "device.json");
+
+  // Try to read an existing device.json, keeping the parsed object for
+  // field preservation if we need to write back.
+  let existing: Record<string, unknown> = {};
+  try {
+    const raw = JSON.parse(readFileSync(filePath, "utf-8"));
+    if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+      existing = raw as Record<string, unknown>;
+      if (typeof existing.deviceId === "string" && existing.deviceId.length > 0) {
+        cached = existing.deviceId as string;
+        return cached;
+      }
+    }
+  } catch {
+    // Missing or malformed — fall through to generate
+  }
+
+  // Generate a new UUID and persist it.
+  const generated = randomUUID();
+  try {
+    mkdirSync(dir, { recursive: true });
+    existing.deviceId = generated;
+    writeFileSync(filePath, JSON.stringify(existing, null, 2) + "\n", {
+      mode: 0o644,
+    });
+  } catch {
+    // Write failed — use generated ID in-memory only
+  }
+
+  cached = generated;
+  return cached;
+}
+
+/**
+ * Reset the cached device ID. Used by tests to force
+ * re-resolution on the next call.
+ */
+export function resetDeviceIdCache(): void {
+  cached = undefined;
+}


### PR DESCRIPTION
## Summary
- Add device-id.ts to Electron main process that reads/creates a stable UUID from device.json
- Follows the same resolution logic as the daemon's device-id.ts and Swift's DeviceIdStore
- Uses resolveConfigDir from @vellumai/local-mode for path consistency

Part of plan: electron-host-proxy-parity.md (PR 1 of 11)