### PR TITLE
feat: show creation timestamp on assistant picker cards

### DIFF
--- a/apps/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useSearchParams } from "react-router";
 
 import { selectPlatformAssistant } from "@/assistant/select-platform-assistant";
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
+import { formatRelativeDate } from "@/utils/format-date";
 import { useOnboardingLogin } from "@/hooks/use-onboarding-login";
 import { useAuthStore, useHasPlatformSession } from "@/stores/auth-store";
 import {
@@ -20,8 +21,9 @@ function assistantLabel(a: ResolvedAssistant): string {
   return a.isLocal ? "Local Assistant" : "Cloud Assistant";
 }
 
-function assistantSubtitle(a: ResolvedAssistant): string {
-  return a.isLocal ? "Running locally on this device" : "Hosted on Vellum Cloud";
+function assistantSubtitle(a: ResolvedAssistant): string | undefined {
+  if (!a.hatchedAt) return undefined;
+  return `Created ${formatRelativeDate(a.hatchedAt)}`;
 }
 
 export function SelectAssistantScreen() {
@@ -253,9 +255,11 @@ function AssistantCard({
             </span>
           )}
         </div>
-        <span className="mt-0.5 line-clamp-2 text-body-small-default text-[var(--content-tertiary)]">
-          {assistantSubtitle(assistant)}
-        </span>
+        {assistantSubtitle(assistant) && (
+          <span className="mt-0.5 block text-body-small-default text-[var(--content-tertiary)]">
+            {assistantSubtitle(assistant)}
+          </span>
+        )}
       </div>
       {!disabled && (
         <div

--- a/apps/web/src/stores/resolved-assistants-store.ts
+++ b/apps/web/src/stores/resolved-assistants-store.ts
@@ -32,6 +32,7 @@ import type { Assistant } from "@/generated/api/types.gen";
 export interface ResolvedAssistant {
   id: string;
   name?: string;
+  hatchedAt?: string;
   isLocal: boolean;
   isPlatformHosted: boolean;
 }
@@ -121,6 +122,7 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
         assistants: lockfile.assistants.map((a) => ({
           id: a.assistantId,
           name: a.name,
+          hatchedAt: a.hatchedAt,
           isLocal: isLocalAssistant(a),
           isPlatformHosted: isPlatformAssistant(a),
         })),
@@ -131,6 +133,7 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
         assistants: assistants.map((a) => ({
           id: a.id,
           name: a.name,
+          hatchedAt: a.created,
           isLocal: a.is_local,
           isPlatformHosted: !a.is_local,
         })),


### PR DESCRIPTION
## Summary
- Added `hatchedAt` field to `ResolvedAssistant` interface, populated from `LockfileAssistant.hatchedAt` (local) and `Assistant.created` (platform API)
- Updated assistant picker cards to show a relative timestamp subtitle (e.g. "Created 3h ago") using the existing `formatRelativeDate` helper
- Removed redundant "Running locally" / "Hosted on Vellum Cloud" subtitle text — the Laptop/Cloud icons already communicate this

## Original prompt
The user wanted to make the assistant picker cards more informative. We investigated the upstream data sources and found that both the lockfile and platform API already carry metadata (name, timestamps, description, etc.) that was being discarded during resolution. The user decided to carry through `hatchedAt` and display a relative creation timestamp on each card, relying on icons for the local/cloud distinction.