### PR TITLE
fix(notifications): stop Telegram token-not-configured Sentry noise (JARVIS-991)

### DIFF
--- a/assistant/src/messaging/providers/telegram-bot/api.ts
+++ b/assistant/src/messaging/providers/telegram-bot/api.ts
@@ -8,7 +8,8 @@
  */
 
 import { credentialKey } from "../../../security/credential-key.js";
-import { getSecureKeyAsync } from "../../../security/secure-keys.js";
+import { getSecureKeyResultAsync } from "../../../security/secure-keys.js";
+import { BackendUnavailableError, ConfigError } from "../../../util/errors.js";
 import { getLogger } from "../../../util/logger.js";
 
 const log = getLogger("telegram-api");
@@ -197,13 +198,21 @@ async function retryableFetch<T>(
 // ---------------------------------------------------------------------------
 
 async function resolveBotToken(): Promise<string> {
-  const botToken = await getSecureKeyAsync(
+  const result = await getSecureKeyResultAsync(
     credentialKey("telegram", "bot_token"),
   );
-  if (!botToken) {
-    throw new Error("Telegram bot token not configured");
+  if (result.value) {
+    return result.value;
   }
-  return botToken;
+  // Distinguish a transient credential-store outage from a token that was
+  // genuinely never set. Both surface as an absent value, but only the
+  // latter is an operator misconfiguration; the former is retryable
+  // infrastructure unavailability that callers should not treat as
+  // "not configured".
+  if (result.unreachable) {
+    throw new BackendUnavailableError("Telegram credential store unreachable");
+  }
+  throw new ConfigError("Telegram bot token not configured");
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/notifications/adapters/telegram.ts
+++ b/assistant/src/notifications/adapters/telegram.ts
@@ -10,6 +10,7 @@
 
 import { sendTelegramReply } from "../../messaging/providers/telegram-bot/send.js";
 import type { ApprovalUIMetadata } from "../../runtime/channel-approval-types.js";
+import { ConfigError } from "../../util/errors.js";
 import { getLogger } from "../../util/logger.js";
 import { isConversationSeedSane } from "../conversation-seed-composer.js";
 import { buildAccessRequestContractText, nonEmpty } from "../copy-composer.js";
@@ -136,7 +137,12 @@ export class TelegramAdapter implements ChannelAdapter {
       return { success: true };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      log.error(
+      // A missing bot token means the operator simply hasn't configured
+      // Telegram; it is not a code fault, so log it at warn to keep it out
+      // of Sentry. Genuine and transient failures (e.g. an unreachable
+      // credential store) stay at error so they remain visible.
+      const logFn = err instanceof ConfigError ? log.warn : log.error;
+      logFn(
         { err, sourceEventName: payload.sourceEventName, chatId },
         "Failed to deliver Telegram notification",
       );


### PR DESCRIPTION
## Summary
- `resolveBotToken` (telegram-bot/api.ts) now uses `getSecureKeyResultAsync` and branches on the `unreachable` flag: a genuinely-absent token throws `ConfigError` ("Telegram bot token not configured"), while a transient credential-store outage throws `BackendUnavailableError` ("Telegram credential store unreachable"). Previously both collapsed into a single bare `Error`, so a momentary CES blip was indistinguishable from real misconfiguration.
- The `TelegramAdapter.send` catch now logs the `ConfigError` (not-configured) case at `warn` instead of `error`, so an operator who simply hasn't set up a Telegram bot token no longer generates a Sentry error. Genuine and transient failures (including the unreachable-store case) stay at `error` so they remain visible.

This is the minimal scope chosen for JARVIS-991: stop the Sentry noise. Note that the dispatch-side gate (`getConnectedChannels` in emit-signal.ts) still selects the telegram channel based only on `externalChatId`, not token presence, and the Slack provider has the identical `resolveBotToken` pattern; both are out of scope here and left as potential follow-ups.

## Original prompt
Diagnosing Linear issue JARVIS-991 ("Error: Telegram bot token not configured", Jarvis team), a Sentry error fired from `resolveBotToken`. The root cause: `getSecureKeyAsync` discards the credential backend's `unreachable` flag, so a transient outage looks identical to a never-set token, and the Telegram adapter logged the handled delivery failure via `log.error`, forwarding it to Sentry as an error. The user asked for the minimal fix to stop the noise: distinguish unreachable-from-unconfigured at the source and downgrade the expected not-configured case to a warn.