### PR TITLE
feat: add host proxy SSE client to Electron main process

### DIFF
--- a/apps/macos/src/main/host-proxy-sse.test.ts
+++ b/apps/macos/src/main/host-proxy-sse.test.ts
@@ -1,0 +1,362 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+// Stub device-id so we don't touch the filesystem.
+const MOCK_DEVICE_ID = "test-device-00000000-0000-0000-0000-000000000000";
+mock.module("./device-id", () => ({
+  getDeviceId: () => MOCK_DEVICE_ID,
+}));
+
+const { HostProxySseClient } = await import("./host-proxy-sse");
+type HostProxySseMessage = import("./host-proxy-sse").HostProxySseMessage;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a ReadableStream that pushes encoded SSE chunks then closes. */
+function sseStream(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+}
+
+/** Build a ReadableStream that yields chunks on demand via a push function. */
+function controllableStream(): {
+  stream: ReadableStream<Uint8Array>;
+  push: (text: string) => void;
+  close: () => void;
+} {
+  const encoder = new TextEncoder();
+  let ctrl: ReadableStreamDefaultController<Uint8Array>;
+  const stream = new ReadableStream<Uint8Array>({
+    start(c) {
+      ctrl = c;
+    },
+  });
+  return {
+    stream,
+    push: (text: string) => ctrl.enqueue(encoder.encode(text)),
+    close: () => ctrl.close(),
+  };
+}
+
+/** Create a mock fetch that returns a streaming SSE response. */
+function mockFetch(
+  body: ReadableStream<Uint8Array>,
+  status = 200,
+): typeof globalThis.fetch {
+  return (async () =>
+    new Response(body, {
+      status,
+      headers: { "Content-Type": "text/event-stream" },
+    })) as unknown as typeof globalThis.fetch;
+}
+
+/** Flush pending microtasks / timers so stream processing can complete. */
+async function flush(ms = 10): Promise<void> {
+  await new Promise((r) => setTimeout(r, ms));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("HostProxySseClient", () => {
+  let client: InstanceType<typeof HostProxySseClient>;
+
+  afterEach(() => {
+    client?.disconnect();
+  });
+
+  // -- Basic SSE parsing --------------------------------------------------
+
+  test("parses data frames and delivers messages via callback", async () => {
+    const messages: HostProxySseMessage[] = [];
+    const body = sseStream([
+      'data: {"type":"ping"}\n\n',
+      'data: {"type":"host_bash_request","conversationId":"c1"}\n\n',
+    ]);
+
+    client = new HostProxySseClient({
+      gatewayPort: 9999,
+      authToken: "tok",
+      fetch: mockFetch(body),
+    });
+    client.setMessageCallback((m) => messages.push(m));
+    client.connect();
+
+    await flush(50);
+
+    expect(messages).toHaveLength(2);
+    expect(messages[0]!.type).toBe("ping");
+    expect(messages[1]!.type).toBe("host_bash_request");
+  });
+
+  test("ignores heartbeat comments", async () => {
+    const messages: HostProxySseMessage[] = [];
+    const body = sseStream([
+      ": heartbeat\n",
+      'data: {"type":"ping"}\n\n',
+      ": another heartbeat\n",
+    ]);
+
+    client = new HostProxySseClient({
+      gatewayPort: 9999,
+      authToken: "tok",
+      fetch: mockFetch(body),
+    });
+    client.setMessageCallback((m) => messages.push(m));
+    client.connect();
+
+    await flush(50);
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]!.type).toBe("ping");
+  });
+
+  test("skips malformed JSON data lines", async () => {
+    const messages: HostProxySseMessage[] = [];
+    const body = sseStream([
+      "data: not json\n\n",
+      'data: {"type":"ok"}\n\n',
+    ]);
+
+    client = new HostProxySseClient({
+      gatewayPort: 9999,
+      authToken: "tok",
+      fetch: mockFetch(body),
+    });
+    client.setMessageCallback((m) => messages.push(m));
+    client.connect();
+
+    await flush(50);
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]!.type).toBe("ok");
+  });
+
+  // -- Connection state ---------------------------------------------------
+
+  test("isConnected reflects stream state", async () => {
+    const { stream, close } = controllableStream();
+    client = new HostProxySseClient({
+      gatewayPort: 9999,
+      authToken: "tok",
+      fetch: mockFetch(stream),
+    });
+
+    expect(client.isConnected).toBe(false);
+    client.connect();
+
+    // Wait for the fetch response to resolve
+    await flush(50);
+    expect(client.isConnected).toBe(true);
+
+    close();
+    await flush(50);
+    // After stream closes, connected should be false (reconnect may be scheduled
+    // but the stream itself is down).
+    expect(client.isConnected).toBe(false);
+  });
+
+  // -- Reconnection on error ---------------------------------------------
+
+  test("reconnects with backoff on fetch failure", async () => {
+    let fetchCount = 0;
+    const messages: HostProxySseMessage[] = [];
+
+    const fakeFetch: typeof globalThis.fetch = (async () => {
+      fetchCount++;
+      if (fetchCount < 3) {
+        throw new Error("network error");
+      }
+      // Third attempt succeeds
+      return new Response(sseStream(['data: {"type":"recovered"}\n\n']), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      });
+    }) as unknown as typeof globalThis.fetch;
+
+    client = new HostProxySseClient({
+      gatewayPort: 9999,
+      authToken: "tok",
+      fetch: fakeFetch,
+    });
+    client.setMessageCallback((m) => messages.push(m));
+    client.connect();
+
+    // Wait for reconnect attempts (1s + 2s backoff)
+    await flush(4_000);
+
+    expect(fetchCount).toBeGreaterThanOrEqual(3);
+    expect(messages.some((m) => m.type === "recovered")).toBe(true);
+  });
+
+  test("reconnects on non-200 response", async () => {
+    let fetchCount = 0;
+    const fakeFetch: typeof globalThis.fetch = (async () => {
+      fetchCount++;
+      if (fetchCount === 1) {
+        return new Response("Unauthorized", { status: 401 });
+      }
+      return new Response(sseStream(['data: {"type":"ok"}\n\n']), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      });
+    }) as unknown as typeof globalThis.fetch;
+
+    const messages: HostProxySseMessage[] = [];
+    client = new HostProxySseClient({
+      gatewayPort: 9999,
+      authToken: "tok",
+      fetch: fakeFetch,
+    });
+    client.setMessageCallback((m) => messages.push(m));
+    client.connect();
+
+    await flush(2_000);
+
+    expect(fetchCount).toBeGreaterThanOrEqual(2);
+    expect(messages.some((m) => m.type === "ok")).toBe(true);
+  });
+
+  // -- Idle watchdog ------------------------------------------------------
+
+  test("idle watchdog triggers reconnect when no traffic arrives", async () => {
+    let fetchCount = 0;
+    const { stream, push } = controllableStream();
+
+    const fakeFetch: typeof globalThis.fetch = (async () => {
+      fetchCount++;
+      if (fetchCount === 1) {
+        return new Response(stream, {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        });
+      }
+      // Second connect: return a fresh stream that closes immediately
+      return new Response(sseStream(['data: {"type":"reconnected"}\n\n']), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      });
+    }) as unknown as typeof globalThis.fetch;
+
+    const messages: HostProxySseMessage[] = [];
+    client = new HostProxySseClient({
+      gatewayPort: 9999,
+      authToken: "tok",
+      fetch: fakeFetch,
+    });
+    client.setMessageCallback((m) => messages.push(m));
+    client.connect();
+
+    // Push initial data so stream is established
+    await flush(50);
+    push('data: {"type":"initial"}\n\n');
+    await flush(50);
+
+    // Wait for idle timeout (30s) + watchdog check interval (10s) + reconnect
+    await flush(42_000);
+
+    expect(fetchCount).toBeGreaterThanOrEqual(2);
+    expect(messages.some((m) => m.type === "reconnected")).toBe(true);
+  });
+
+  // -- Disconnect ---------------------------------------------------------
+
+  test("disconnect cancels timers and stream", async () => {
+    const { stream } = controllableStream();
+    let fetchCount = 0;
+
+    const fakeFetch: typeof globalThis.fetch = (async () => {
+      fetchCount++;
+      return new Response(stream, {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      });
+    }) as unknown as typeof globalThis.fetch;
+
+    client = new HostProxySseClient({
+      gatewayPort: 9999,
+      authToken: "tok",
+      fetch: fakeFetch,
+    });
+    client.connect();
+    await flush(50);
+    expect(client.isConnected).toBe(true);
+
+    client.disconnect();
+    expect(client.isConnected).toBe(false);
+
+    // Wait to confirm no reconnect happens
+    await flush(3_000);
+    expect(fetchCount).toBe(1);
+  });
+
+  // -- Request headers ----------------------------------------------------
+
+  test("sends correct headers", async () => {
+    let capturedUrl = "";
+    let capturedHeaders: Record<string, string> = {};
+
+    const fakeFetch: typeof globalThis.fetch = (async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      capturedUrl = String(input);
+      const h = init?.headers as Record<string, string> | undefined;
+      if (h) capturedHeaders = { ...h };
+      return new Response(sseStream([]), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      });
+    }) as unknown as typeof globalThis.fetch;
+
+    client = new HostProxySseClient({
+      gatewayPort: 8080,
+      authToken: "my-token",
+      fetch: fakeFetch,
+    });
+    client.connect();
+    await flush(50);
+
+    expect(capturedUrl).toBe("http://127.0.0.1:8080/v1/events");
+    expect(capturedHeaders["Authorization"]).toBe("Bearer my-token");
+    expect(capturedHeaders["Accept"]).toBe(
+      "text/event-stream, application/json",
+    );
+    expect(capturedHeaders["X-Vellum-Client-Id"]).toBe(MOCK_DEVICE_ID);
+    expect(capturedHeaders["X-Vellum-Interface-Id"]).toBe("macos");
+    expect(capturedHeaders["X-Vellum-Machine-Name"]).toBeTruthy();
+  });
+
+  // -- Chunked data handling ----------------------------------------------
+
+  test("handles data split across multiple chunks", async () => {
+    const messages: HostProxySseMessage[] = [];
+    // JSON payload split across two chunks
+    const body = sseStream([
+      'data: {"type":"sp',
+      'lit_msg","val":1}\n\n',
+    ]);
+
+    client = new HostProxySseClient({
+      gatewayPort: 9999,
+      authToken: "tok",
+      fetch: mockFetch(body),
+    });
+    client.setMessageCallback((m) => messages.push(m));
+    client.connect();
+
+    await flush(50);
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]!.type).toBe("split_msg");
+  });
+});

--- a/apps/macos/src/main/host-proxy-sse.ts
+++ b/apps/macos/src/main/host-proxy-sse.ts
@@ -1,0 +1,243 @@
+/**
+ * SSE client for the host proxy subsystem in the Electron main process.
+ *
+ * Connects to the daemon's `/v1/events` endpoint, parses SSE frames
+ * (`data: <json>\n\n` for messages, `: <comment>\n` for heartbeats),
+ * and emits parsed JSON payloads via a callback. Reconnects automatically
+ * with exponential backoff and detects stale connections via an idle
+ * watchdog.
+ */
+
+import { hostname } from "node:os";
+
+import { getDeviceId } from "./device-id";
+
+export interface HostProxySseOptions {
+  gatewayPort: number;
+  gatewayHost?: string;
+  authToken: string;
+  /** Injectable fetch for testing. Defaults to globalThis.fetch. */
+  fetch?: typeof globalThis.fetch;
+}
+
+export interface HostProxySseMessage {
+  type: string;
+  [key: string]: unknown;
+}
+
+export type MessageCallback = (message: HostProxySseMessage) => void;
+
+const INITIAL_RECONNECT_DELAY_MS = 1_000;
+const MAX_RECONNECT_DELAY_MS = 30_000;
+const IDLE_TIMEOUT_MS = 30_000;
+const IDLE_CHECK_INTERVAL_MS = 10_000;
+
+export class HostProxySseClient {
+  private readonly gatewayPort: number;
+  private readonly gatewayHost: string;
+  private authToken: string;
+  private readonly fetchFn: typeof globalThis.fetch;
+  private onMessage: MessageCallback | null = null;
+
+  private abortController: AbortController | null = null;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private idleWatchdogTimer: ReturnType<typeof setInterval> | null = null;
+  private reconnectDelay = INITIAL_RECONNECT_DELAY_MS;
+  private lastTrafficAt = 0;
+  private _connected = false;
+  private shouldReconnect = false;
+
+  constructor(options: HostProxySseOptions) {
+    this.gatewayPort = options.gatewayPort;
+    this.gatewayHost = options.gatewayHost ?? "127.0.0.1";
+    this.authToken = options.authToken;
+    this.fetchFn = options.fetch ?? globalThis.fetch;
+  }
+
+  /** Register a callback for parsed SSE messages. */
+  setMessageCallback(cb: MessageCallback): void {
+    this.onMessage = cb;
+  }
+
+  /** Whether the client currently has an active SSE stream. */
+  get isConnected(): boolean {
+    return this._connected;
+  }
+
+  /** Open the SSE connection. Safe to call multiple times. */
+  connect(): void {
+    if (this.abortController) return;
+    this.shouldReconnect = true;
+    this.startStream();
+  }
+
+  /** Close the SSE connection and cancel all pending timers. */
+  disconnect(): void {
+    this.shouldReconnect = false;
+    this.clearReconnectTimer();
+    this.clearIdleWatchdog();
+    if (this.abortController) {
+      this.abortController.abort();
+      this.abortController = null;
+    }
+    this._connected = false;
+  }
+
+  /** Replace the auth token (e.g. after token rotation). */
+  updateAuthToken(token: string): void {
+    this.authToken = token;
+  }
+
+  // -- Stream lifecycle ---------------------------------------------------
+
+  private startStream(): void {
+    this.abortController?.abort();
+    const controller = new AbortController();
+    this.abortController = controller;
+
+    const url = `http://${this.gatewayHost}:${this.gatewayPort}/v1/events`;
+    const headers: Record<string, string> = {
+      Accept: "text/event-stream, application/json",
+      "X-Vellum-Client-Id": getDeviceId(),
+      "X-Vellum-Interface-Id": "macos",
+      "X-Vellum-Machine-Name": hostname(),
+      Authorization: `Bearer ${this.authToken}`,
+    };
+
+    this.fetchFn(url, { headers, signal: controller.signal })
+      .then((response) => this.handleResponse(response))
+      .catch((err: unknown) => {
+        if (isAbortError(err)) return;
+        this._connected = false;
+        this.scheduleReconnect();
+      });
+  }
+
+  private async handleResponse(response: Response): Promise<void> {
+    if (!response.ok || !response.body) {
+      this._connected = false;
+      this.scheduleReconnect();
+      return;
+    }
+
+    this._connected = true;
+    this.reconnectDelay = INITIAL_RECONNECT_DELAY_MS;
+    this.lastTrafficAt = Date.now();
+    this.startIdleWatchdog();
+
+    try {
+      await this.readStream(response.body);
+    } catch (err: unknown) {
+      if (isAbortError(err)) return;
+    }
+
+    this._connected = false;
+    if (this.shouldReconnect) {
+      this.scheduleReconnect();
+    }
+  }
+
+  private async readStream(body: ReadableStream<Uint8Array>): Promise<void> {
+    const reader = body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        this.lastTrafficAt = Date.now();
+        buffer += decoder.decode(value, { stream: true });
+
+        const lines = buffer.split("\n");
+        // Keep the last (possibly incomplete) line in the buffer
+        buffer = lines.pop() ?? "";
+
+        for (const line of lines) {
+          this.processLine(line);
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
+  private processLine(line: string): void {
+    // Heartbeat comment — no payload; liveness already tracked by readStream
+    if (line.startsWith(":")) return;
+
+    if (!line.startsWith("data: ")) return;
+
+    const payload = line.slice(6);
+    if (!payload) return;
+
+    try {
+      const parsed = JSON.parse(payload) as HostProxySseMessage;
+      this.onMessage?.(parsed);
+    } catch {
+      // Malformed JSON — skip
+    }
+  }
+
+  // -- Reconnect ----------------------------------------------------------
+
+  private scheduleReconnect(): void {
+    if (!this.shouldReconnect) return;
+    this.clearReconnectTimer();
+    this.clearIdleWatchdog();
+
+    const delay = this.reconnectDelay;
+    this.reconnectDelay = Math.min(
+      this.reconnectDelay * 2,
+      MAX_RECONNECT_DELAY_MS,
+    );
+
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      if (this.shouldReconnect) {
+        this.startStream();
+      }
+    }, delay);
+  }
+
+  private clearReconnectTimer(): void {
+    if (this.reconnectTimer !== null) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+  }
+
+  // -- Idle watchdog ------------------------------------------------------
+
+  private startIdleWatchdog(): void {
+    this.clearIdleWatchdog();
+    this.lastTrafficAt = Date.now();
+
+    this.idleWatchdogTimer = setInterval(() => {
+      const elapsed = Date.now() - this.lastTrafficAt;
+      if (elapsed >= IDLE_TIMEOUT_MS) {
+        this.clearIdleWatchdog();
+        // Force-close the current stream so reconnect kicks in
+        if (this.abortController) {
+          this.abortController.abort();
+          this.abortController = null;
+        }
+        this._connected = false;
+        this.reconnectDelay = INITIAL_RECONNECT_DELAY_MS;
+        this.scheduleReconnect();
+      }
+    }, IDLE_CHECK_INTERVAL_MS);
+  }
+
+  private clearIdleWatchdog(): void {
+    if (this.idleWatchdogTimer !== null) {
+      clearInterval(this.idleWatchdogTimer);
+      this.idleWatchdogTimer = null;
+    }
+  }
+}
+
+function isAbortError(err: unknown): boolean {
+  return err instanceof DOMException && err.name === "AbortError";
+}


### PR DESCRIPTION
## Summary
- Add HostProxySseClient class for connecting to daemon SSE endpoint
- Handles SSE parsing, reconnection with exponential backoff, and idle watchdog
- Injectable fetch function for testability

Part of plan: electron-host-proxy-parity.md (PR 2 of 8)