### PR TITLE
fix: allow unauthenticated remote feature flag fetches

### DIFF
--- a/gateway/src/__tests__/remote-feature-flag-sync.test.ts
+++ b/gateway/src/__tests__/remote-feature-flag-sync.test.ts
@@ -35,6 +35,9 @@ const { readRemoteFeatureFlags, clearRemoteFeatureFlagStoreCache } =
   await import("../feature-flag-remote-store.js");
 const { resetFeatureFlagDefaultsCache, _setRegistryCandidateOverrides } =
   await import("../feature-flag-defaults.js");
+const { resetEnvOverridesCache } = await import(
+  "../feature-flag-env-overrides.js"
+);
 
 // ---------------------------------------------------------------------------
 // Test-local registry with a GA flag (defaultEnabled: true) for the
@@ -125,17 +128,21 @@ function defaultCredentials(): Record<string, string> {
 // ---------------------------------------------------------------------------
 const savedVellumPlatformUrl = process.env.VELLUM_PLATFORM_URL;
 const savedAssistantCredential = process.env.ASSISTANT_API_KEY;
+const savedPlatformFeaturesFlag =
+  process.env.VELLUM_FLAG_PLATFORM_FEATURES_IN_LOCAL_MODE;
 
 beforeEach(() => {
   // Clear env vars that the production code falls back to, so tests remain
   // deterministic unless they explicitly set them.
   delete process.env.VELLUM_PLATFORM_URL;
   delete process.env.ASSISTANT_API_KEY;
+  delete process.env.VELLUM_FLAG_PLATFORM_FEATURES_IN_LOCAL_MODE;
   mkdirSync(protectedDir, { recursive: true });
   // Write the test registry and point resolution at it
   writeFileSync(testRegistryPath, JSON.stringify(TEST_REGISTRY, null, 2));
   _setRegistryCandidateOverrides([testRegistryPath]);
   resetFeatureFlagDefaultsCache();
+  resetEnvOverridesCache();
   clearRemoteFeatureFlagStoreCache();
   fetchMock = mock(async () => new Response());
 });
@@ -151,6 +158,10 @@ afterEach(() => {
   };
   restoreEnv("VELLUM_PLATFORM_URL", savedVellumPlatformUrl);
   restoreEnv("ASSISTANT_API_KEY", savedAssistantCredential);
+  restoreEnv(
+    "VELLUM_FLAG_PLATFORM_FEATURES_IN_LOCAL_MODE",
+    savedPlatformFeaturesFlag,
+  );
   try {
     rmSync(protectedDir, { recursive: true, force: true });
     mkdirSync(protectedDir, { recursive: true });
@@ -159,6 +170,7 @@ afterEach(() => {
   }
   _setRegistryCandidateOverrides(null);
   resetFeatureFlagDefaultsCache();
+  resetEnvOverridesCache();
   clearRemoteFeatureFlagStoreCache();
 });
 
@@ -166,6 +178,20 @@ afterEach(() => {
 // Tests
 // ---------------------------------------------------------------------------
 describe("RemoteFeatureFlagSync", () => {
+  test("skips sync when platform features are disabled", async () => {
+    fetchMock = mock(async () => Response.json({ flags: { ff1: true } }));
+    process.env.VELLUM_FLAG_PLATFORM_FEATURES_IN_LOCAL_MODE = "false";
+    resetEnvOverridesCache();
+
+    const sync = new RemoteFeatureFlagSync({
+      credentials: fakeCredentialCache(defaultCredentials()),
+    });
+    await sync.start();
+    sync.stop();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   test("skips sync when no platform URL is available from cache or env", async () => {
     fetchMock = mock(async () => Response.json({ flags: { ff1: true } }));
 
@@ -203,7 +229,9 @@ describe("RemoteFeatureFlagSync", () => {
     );
   });
 
-  test("skips sync when assistant_api_key is missing", async () => {
+  test("fetches without auth header when assistant_api_key is missing", async () => {
+    fetchMock = mock(async () => Response.json({ flags: { ff1: true } }));
+
     const creds = defaultCredentials();
     delete creds["credential/vellum/assistant_api_key"];
 
@@ -213,7 +241,11 @@ describe("RemoteFeatureFlagSync", () => {
     await sync.start();
     sync.stop();
 
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0];
+    const headers = init?.headers as Record<string, string>;
+    expect(headers.Authorization).toBeUndefined();
+    expect(headers.Accept).toBe("application/json");
   });
 
   test("syncs when only platformUrl and assistantApiKey are present", async () => {
@@ -873,14 +905,13 @@ describe("RemoteFeatureFlagSync", () => {
     sync.stop();
   });
 
-  test("pauses polling when credentials are missing and resumes on invalidation", async () => {
+  test("pauses polling when platform URL is missing and resumes on invalidation", async () => {
     fetchMock = mock(async () =>
       Response.json({ flags: { "resumed-flag": true } }),
     );
 
     const creds = fakeCredentialCache({
-      ...defaultCredentials(),
-      "credential/vellum/assistant_api_key": undefined,
+      "credential/vellum/assistant_api_key": "test-api-key",
     });
 
     const sync = new RemoteFeatureFlagSync({
@@ -889,14 +920,14 @@ describe("RemoteFeatureFlagSync", () => {
     });
     await sync.start();
 
-    // No fetch calls — missing creds, polling should be paused
+    // No fetch calls — missing platform URL, polling should be paused
     expect(fetchMock).not.toHaveBeenCalled();
 
     // Wait well past the initial poll interval — should still not poll
     await new Promise((r) => setTimeout(r, 200));
     expect(fetchMock).not.toHaveBeenCalled();
 
-    // Simulate user logging in — credentials now available
+    // Simulate platform URL becoming available
     creds._setValues(defaultCredentials());
     creds._invalidate();
 

--- a/gateway/src/__tests__/remote-feature-flag-sync.test.ts
+++ b/gateway/src/__tests__/remote-feature-flag-sync.test.ts
@@ -942,4 +942,43 @@ describe("RemoteFeatureFlagSync", () => {
 
     sync.stop();
   });
+
+  test("does not downgrade to anonymous fetch when API key is transiently lost", async () => {
+    const cache = fakeCredentialCache(defaultCredentials());
+
+    // Initial authenticated fetch succeeds
+    fetchMock = mock(async () =>
+      Response.json({ flags: { "per-assistant-flag": true } }),
+    );
+
+    const sync = new RemoteFeatureFlagSync({
+      credentials: cache,
+      initialPollIntervalMs: 50,
+    });
+    await sync.start();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    clearRemoteFeatureFlagStoreCache();
+    expect(readRemoteFeatureFlags()).toEqual({ "per-assistant-flag": true });
+
+    // Simulate transient API key loss (CES hiccup) — platform URL still present
+    cache._setValues({
+      "credential/vellum/platform_base_url": "https://platform.vellum.ai",
+    });
+    fetchMock = mock(async () =>
+      Response.json({ flags: { "per-assistant-flag": false } }),
+    );
+
+    await sync.syncNow();
+
+    // Should NOT have fetched — transient key loss triggers error/backoff,
+    // not an anonymous fetch that would overwrite per-assistant values.
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    // Cached values from the previous authenticated fetch are preserved.
+    clearRemoteFeatureFlagStoreCache();
+    expect(readRemoteFeatureFlags()).toEqual({ "per-assistant-flag": true });
+
+    sync.stop();
+  });
 });

--- a/gateway/src/remote-feature-flag-sync.ts
+++ b/gateway/src/remote-feature-flag-sync.ts
@@ -70,6 +70,7 @@ export class RemoteFeatureFlagSync {
    * change that lands mid-fetch is never dropped (see `syncNow`).
    */
   private pendingResync = false;
+  private hasAuthedSuccessfully = false;
   private waitingForCredentials = false;
   private unsubscribeCredentials: (() => void) | null = null;
   private currentIntervalMs: number;
@@ -363,6 +364,17 @@ export class RemoteFeatureFlagSync {
       return { status: "missing_credentials" };
     }
 
+    // If we previously fetched with auth and the API key is now missing,
+    // treat it as a transient error (backoff + retry) rather than
+    // downgrading to an anonymous fetch that would overwrite per-assistant
+    // flag values with anonymous defaults.
+    if (!assistantCredential && this.hasAuthedSuccessfully) {
+      log.warn(
+        "API key previously available but now missing — treating as transient error",
+      );
+      return { status: "error" };
+    }
+
     const url = `${platformUrl}/v1/feature-flags/assistant-flag-values/`;
     const headers: Record<string, string> = { Accept: "application/json" };
     if (assistantCredential) {
@@ -414,6 +426,10 @@ export class RemoteFeatureFlagSync {
         continue;
       }
       values[key] = value;
+    }
+
+    if (assistantCredential) {
+      this.hasAuthedSuccessfully = true;
     }
 
     return { status: "success", values };

--- a/gateway/src/remote-feature-flag-sync.ts
+++ b/gateway/src/remote-feature-flag-sync.ts
@@ -3,6 +3,7 @@ import { credentialKey } from "./credential-key.js";
 import { fetchImpl } from "./fetch.js";
 import { loadFeatureFlagDefaults } from "./feature-flag-defaults.js";
 import { writeRemoteFeatureFlags } from "./feature-flag-remote-store.js";
+import { arePlatformFeaturesEnabled } from "./feature-flag-resolver.js";
 import { getLogger } from "./logger.js";
 
 const log = getLogger("remote-feature-flag-sync");
@@ -325,6 +326,11 @@ export class RemoteFeatureFlagSync {
   }
 
   private async fetchRemoteFeatureFlags(): Promise<RemoteFetchResult> {
+    if (!arePlatformFeaturesEnabled()) {
+      log.debug("Remote feature flag sync skipped: platform features disabled");
+      return { status: "missing_credentials" };
+    }
+
     // Wrap credential reads so transient failures (CES unreachable, keychain
     // errors) are treated as retriable errors with backoff, not as "missing
     // credentials" which would pause polling indefinitely.
@@ -347,33 +353,29 @@ export class RemoteFeatureFlagSync {
       ""
     ).replace(/\/+$/, "");
 
-    // Feature flag sync hits the public platform API and requires assistant
-    // API key auth.
     const assistantCredential =
       assistantApiKeyRaw?.trim() ||
       process.env.ASSISTANT_API_KEY?.trim() ||
       undefined;
 
-    if (!platformUrl || !assistantCredential) {
-      log.debug(
-        {
-          hasPlatformUrl: !!platformUrl,
-          hasApiKey: !!assistantCredential,
-        },
-        "Remote feature flag sync skipped: missing credentials",
-      );
+    if (!platformUrl) {
+      log.debug("Remote feature flag sync skipped: no platform URL configured");
       return { status: "missing_credentials" };
     }
 
     const url = `${platformUrl}/v1/feature-flags/assistant-flag-values/`;
-    log.debug({ url }, "Fetching remote feature flags from platform");
+    const headers: Record<string, string> = { Accept: "application/json" };
+    if (assistantCredential) {
+      headers["Authorization"] = `Api-Key ${assistantCredential}`;
+    }
+    log.debug(
+      { url, authenticated: !!assistantCredential },
+      "Fetching remote feature flags from platform",
+    );
 
     const response = await fetchImpl(url, {
       method: "GET",
-      headers: {
-        Authorization: `Api-Key ${assistantCredential}`,
-        Accept: "application/json",
-      },
+      headers,
       signal: AbortSignal.timeout(10_000),
     });
 


### PR DESCRIPTION
## Summary
- The platform's `/v1/feature-flags/assistant-flag-values/` endpoint no longer requires authentication ([platform#8284](https://github.com/vellum-ai/vellum-assistant-platform/pull/8284)). Updated the gateway's remote flag sync to fetch without the `Authorization` header when no API key is available, instead of pausing polling entirely. This means pre-login users get real platform flag values (anonymous context) rather than only local registry defaults.
- Added an `arePlatformFeaturesEnabled()` gate so we don't hit the platform API when the `platform-features-in-local-mode` flag is explicitly disabled.
- Only a missing platform URL now pauses polling — a missing API key no longer blocks fetches.

## Test plan
- [x] Existing test updated: "fetches without auth header when assistant_api_key is missing" — verifies request fires without `Authorization` header
- [x] Existing test updated: "pauses polling when platform URL is missing and resumes on invalidation" — confirms pause only triggers on missing URL
- [x] New test: "skips sync when platform features are disabled" — verifies the FF gate
- [x] All 27 tests in `remote-feature-flag-sync.test.ts` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)