### PR TITLE
feat: add host proxy message router and daemon connection lifecycle

### DIFF
--- a/apps/macos/src/main/host-proxy-router.test.ts
+++ b/apps/macos/src/main/host-proxy-router.test.ts
@@ -1,0 +1,326 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Stubs — must precede the router import
+// ---------------------------------------------------------------------------
+
+const MOCK_DEVICE_ID = "test-device-00000000-0000-0000-0000-000000000000";
+mock.module("./device-id", () => ({
+  getDeviceId: () => MOCK_DEVICE_ID,
+  resetDeviceIdCache: () => {},
+}));
+
+const mockGetGuardianAccessToken = mock(
+  async () => ({ ok: true, accessToken: "test-token" }) as const,
+);
+mock.module("@vellumai/local-mode", () => ({
+  getGuardianAccessToken: mockGetGuardianAccessToken,
+  resolveConfigDir: () => "/tmp/test-config",
+}));
+
+// Minimal lockfile-watcher stub — capture the listener
+let lockfileListener: ((lockfile: import("@vellumai/local-mode/contract").Lockfile) => void) | null = null;
+mock.module("./lockfile-watcher", () => ({
+  onLockfileChange: (listener: typeof lockfileListener) => {
+    lockfileListener = listener;
+    return () => { lockfileListener = null; };
+  },
+}));
+
+// Stub electron-log
+mock.module("electron-log/main", () => {
+  const noop = () => {};
+  return {
+    default: {
+      info: noop,
+      warn: noop,
+      error: noop,
+      debug: noop,
+      initialize: noop,
+      transports: { file: { maxSize: 0, fileName: "", format: "", getFile: () => ({ path: "" }) } },
+    },
+  };
+});
+
+const { HostProxySseClient } = await import("./host-proxy-sse");
+const { HostProxyPoster } = await import("./host-proxy-poster");
+const {
+  installHostProxyBridge,
+  setExecutor,
+  removeExecutor,
+  __testing,
+} = await import("./host-proxy-router");
+
+type Lockfile = import("@vellumai/local-mode/contract").Lockfile;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const fakeCliResolver = async () => ({ command: "echo", baseArgs: [] });
+
+async function flush(ms = 20): Promise<void> {
+  await new Promise((r) => setTimeout(r, ms));
+}
+
+/** Create a poster that captures the first POST body for assertions. */
+function capturingPoster(): { poster: InstanceType<typeof HostProxyPoster>; body: () => Record<string, unknown> | null } {
+  let postedBody: Record<string, unknown> | null = null;
+  const fakeFetch = async (_url: unknown, init?: RequestInit) => {
+    postedBody = JSON.parse(init?.body as string);
+    return new Response("ok");
+  };
+  const poster = new HostProxyPoster({
+    gatewayPort: 9000,
+    authToken: "t",
+    fetch: fakeFetch as typeof globalThis.fetch,
+  });
+  return { poster, body: () => postedBody };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("host-proxy-router", () => {
+  afterEach(() => {
+    __testing.reset();
+    lockfileListener = null;
+    mockGetGuardianAccessToken.mockReset();
+    mockGetGuardianAccessToken.mockImplementation(
+      async () => ({ ok: true, accessToken: "test-token" }) as const,
+    );
+  });
+
+  // -- Lifecycle -----------------------------------------------------------
+
+  describe("lifecycle", () => {
+    test("connects when an assistant with a gatewayPort appears", async () => {
+      installHostProxyBridge(fakeCliResolver);
+
+      const lockfile: Lockfile = {
+        assistants: [
+          {
+            assistantId: "a1",
+            resources: { gatewayPort: 9001, daemonPort: 9002 },
+          },
+        ],
+        activeAssistant: "a1",
+      };
+      lockfileListener?.(lockfile);
+      await flush();
+
+      expect(__testing.connections.has("a1")).toBe(true);
+      const conn = __testing.connections.get("a1")!;
+      expect(conn.sse).toBeInstanceOf(HostProxySseClient);
+      expect(conn.poster).toBeInstanceOf(HostProxyPoster);
+    });
+
+    test("disconnects when an assistant is retired", async () => {
+      installHostProxyBridge(fakeCliResolver);
+
+      // Appear
+      lockfileListener?.({
+        assistants: [
+          { assistantId: "a1", resources: { gatewayPort: 9001, daemonPort: 9002 } },
+        ],
+        activeAssistant: "a1",
+      });
+      await flush();
+      expect(__testing.connections.has("a1")).toBe(true);
+
+      // Retire
+      lockfileListener?.({ assistants: [], activeAssistant: null });
+      await flush();
+      expect(__testing.connections.has("a1")).toBe(false);
+    });
+
+    test("ignores assistants without resources", async () => {
+      installHostProxyBridge(fakeCliResolver);
+
+      lockfileListener?.({
+        assistants: [{ assistantId: "no-resources" }],
+        activeAssistant: null,
+      });
+      await flush();
+
+      expect(__testing.connections.has("no-resources")).toBe(false);
+    });
+
+    test("does not duplicate connections on repeated lockfile updates", async () => {
+      installHostProxyBridge(fakeCliResolver);
+
+      const lockfile: Lockfile = {
+        assistants: [
+          { assistantId: "a1", resources: { gatewayPort: 9001, daemonPort: 9002 } },
+        ],
+        activeAssistant: "a1",
+      };
+
+      lockfileListener?.(lockfile);
+      await flush();
+      const firstSse = __testing.connections.get("a1")!.sse;
+
+      lockfileListener?.(lockfile);
+      await flush();
+      // Same instance — no duplicate connection
+      expect(__testing.connections.get("a1")!.sse).toBe(firstSse);
+    });
+
+    test("teardown disconnects all and clears listener", async () => {
+      const teardown = installHostProxyBridge(fakeCliResolver);
+
+      lockfileListener?.({
+        assistants: [
+          { assistantId: "a1", resources: { gatewayPort: 9001, daemonPort: 9002 } },
+        ],
+        activeAssistant: "a1",
+      });
+      await flush();
+      expect(__testing.connections.size).toBe(1);
+
+      teardown();
+      expect(__testing.connections.size).toBe(0);
+      expect(lockfileListener).toBeNull();
+    });
+
+    test("does not connect when guardian token fetch fails", async () => {
+      mockGetGuardianAccessToken.mockImplementation(
+        async () => ({ ok: false, status: 401, error: "expired" }) as const,
+      );
+      installHostProxyBridge(fakeCliResolver);
+
+      lockfileListener?.({
+        assistants: [
+          { assistantId: "a1", resources: { gatewayPort: 9001, daemonPort: 9002 } },
+        ],
+        activeAssistant: "a1",
+      });
+      await flush();
+
+      expect(__testing.connections.has("a1")).toBe(false);
+    });
+  });
+
+  // -- Message dispatch ----------------------------------------------------
+
+  describe("message dispatch", () => {
+    test("routes request to registered executor", () => {
+      const handled: string[] = [];
+      setExecutor("host_bash", {
+        handleRequest: (msg) => { handled.push(`req:${msg.requestId}`); },
+        handleCancel: (msg) => { handled.push(`cancel:${msg.requestId}`); },
+      });
+
+      const poster = new HostProxyPoster({
+        gatewayPort: 9000,
+        authToken: "t",
+        fetch: (async () => new Response("ok")) as typeof globalThis.fetch,
+      });
+
+      __testing.dispatchMessage(
+        { type: "host_bash_request", requestId: "r1" },
+        poster,
+      );
+      __testing.dispatchMessage(
+        { type: "host_bash_cancel", requestId: "r2" },
+        poster,
+      );
+
+      expect(handled).toEqual(["req:r1", "cancel:r2"]);
+      removeExecutor("host_bash");
+    });
+
+    test("routes file messages to file executor", () => {
+      const handled: string[] = [];
+      setExecutor("host_file", {
+        handleRequest: (msg) => { handled.push(`req:${msg.requestId}`); },
+        handleCancel: (msg) => { handled.push(`cancel:${msg.requestId}`); },
+      });
+
+      const poster = new HostProxyPoster({
+        gatewayPort: 9000,
+        authToken: "t",
+        fetch: (async () => new Response("ok")) as typeof globalThis.fetch,
+      });
+
+      __testing.dispatchMessage(
+        { type: "host_file_request", requestId: "f1" },
+        poster,
+      );
+
+      expect(handled).toEqual(["req:f1"]);
+      removeExecutor("host_file");
+    });
+
+    test("posts stub error for unimplemented bash executor", async () => {
+      const { poster, body } = capturingPoster();
+      __testing.dispatchMessage({ type: "host_bash_request", requestId: "r1" }, poster);
+      await flush();
+
+      expect(body()).not.toBeNull();
+      expect(body()!.requestId).toBe("r1");
+      expect(body()!.stderr).toBe("Executor not yet implemented");
+      expect(body()!.exitCode).toBe(1);
+    });
+
+    test("posts stub error for unimplemented file executor", async () => {
+      const { poster, body } = capturingPoster();
+      __testing.dispatchMessage({ type: "host_file_request", requestId: "f1" }, poster);
+      await flush();
+
+      expect(body()!.requestId).toBe("f1");
+      expect(body()!.isError).toBe(true);
+    });
+
+    test("posts stub error for unimplemented transfer executor", async () => {
+      const { poster, body } = capturingPoster();
+      __testing.dispatchMessage({ type: "host_transfer_request", requestId: "t1" }, poster);
+      await flush();
+
+      expect(body()!.requestId).toBe("t1");
+      expect(body()!.isError).toBe(true);
+      expect(body()!.errorMessage).toBe("Executor not yet implemented");
+    });
+
+    test("posts stub error for unimplemented browser executor", async () => {
+      const { poster, body } = capturingPoster();
+      __testing.dispatchMessage({ type: "host_browser_request", requestId: "b1" }, poster);
+      await flush();
+
+      expect(body()!.requestId).toBe("b1");
+      expect(body()!.isError).toBe(true);
+    });
+
+    test("ignores unknown message types without crashing", () => {
+      const poster = new HostProxyPoster({
+        gatewayPort: 9000,
+        authToken: "t",
+        fetch: (async () => new Response("ok")) as typeof globalThis.fetch,
+      });
+
+      // Should not throw
+      __testing.dispatchMessage(
+        { type: "host_unknown_request", requestId: "u1" },
+        poster,
+      );
+    });
+  });
+
+  // -- Executor registry ---------------------------------------------------
+
+  describe("executor registry", () => {
+    test("setExecutor and removeExecutor manage the registry", () => {
+      const executor = {
+        handleRequest: () => {},
+        handleCancel: () => {},
+      };
+
+      setExecutor("host_bash", executor);
+      expect(__testing.executors.has("host_bash")).toBe(true);
+
+      removeExecutor("host_bash");
+      expect(__testing.executors.has("host_bash")).toBe(false);
+    });
+  });
+});

--- a/apps/macos/src/main/host-proxy-router.ts
+++ b/apps/macos/src/main/host-proxy-router.ts
@@ -1,0 +1,277 @@
+/**
+ * Host proxy message router and daemon connection lifecycle.
+ *
+ * Listens for lockfile changes and maintains an SSE + poster pair for each
+ * local assistant that has a gatewayPort. When an assistant appears, the
+ * router obtains a guardian token and connects; when it disappears, it
+ * disconnects. Incoming SSE messages are dispatched to pluggable executors;
+ * unimplemented executors post error results so daemon requests don't hang.
+ */
+
+import {
+  getGuardianAccessToken,
+  resolveConfigDir,
+  type CliInvocation,
+} from "@vellumai/local-mode";
+import type { Lockfile } from "@vellumai/local-mode/contract";
+
+import { HostProxySseClient, type HostProxySseMessage } from "./host-proxy-sse";
+import { HostProxyPoster } from "./host-proxy-poster";
+import { onLockfileChange } from "./lockfile-watcher";
+import log from "./logger";
+
+// ---------------------------------------------------------------------------
+// Executor interface — PRs 5-8 plug in via setExecutor()
+// ---------------------------------------------------------------------------
+
+export interface HostProxyExecutor {
+  handleRequest(message: HostProxySseMessage, poster: HostProxyPoster): void;
+  handleCancel(message: HostProxySseMessage, poster: HostProxyPoster): void;
+}
+
+// ---------------------------------------------------------------------------
+// Connection entry
+// ---------------------------------------------------------------------------
+
+interface AssistantConnection {
+  sse: HostProxySseClient;
+  poster: HostProxyPoster;
+}
+
+// ---------------------------------------------------------------------------
+// Module state
+// ---------------------------------------------------------------------------
+
+const connections = new Map<string, AssistantConnection>();
+const executors = new Map<string, HostProxyExecutor>();
+
+// Injected by installHostProxyBridge; kept at module scope so the
+// lockfile-change listener (which cannot be async) can reference it.
+let resolveCliInvocation: (() => Promise<CliInvocation>) | null = null;
+
+// ---------------------------------------------------------------------------
+// Executor registry
+// ---------------------------------------------------------------------------
+
+export function setExecutor(kind: string, executor: HostProxyExecutor): void {
+  executors.set(kind, executor);
+}
+
+export function removeExecutor(kind: string): void {
+  executors.delete(kind);
+}
+
+// ---------------------------------------------------------------------------
+// Message dispatch
+// ---------------------------------------------------------------------------
+
+const EXECUTOR_KINDS = ["host_bash", "host_file", "host_transfer", "host_browser"] as const;
+
+/** Route type → executor kind. Returns null for unknown types. */
+function executorKindForType(type: string): { kind: string; action: "request" | "cancel" } | null {
+  for (const kind of EXECUTOR_KINDS) {
+    if (type === `${kind}_request`) return { kind, action: "request" };
+    if (type === `${kind}_cancel`) return { kind, action: "cancel" };
+  }
+  return null;
+}
+
+function dispatchMessage(message: HostProxySseMessage, poster: HostProxyPoster): void {
+  const { type } = message;
+  const route = executorKindForType(type);
+  if (!route) {
+    log.warn("[host-proxy-router] unknown message type, ignoring", { type });
+    return;
+  }
+
+  const executor = executors.get(route.kind);
+
+  if (executor) {
+    if (route.action === "request") {
+      executor.handleRequest(message, poster);
+    } else {
+      executor.handleCancel(message, poster);
+    }
+    return;
+  }
+
+  // No executor registered — post an error result so the daemon doesn't hang.
+  const requestId = message.requestId as string | undefined;
+  if (!requestId) {
+    log.warn("[host-proxy-router] message missing requestId, cannot post stub error", { type });
+    return;
+  }
+
+  log.warn("[host-proxy-router] executor not yet implemented", { type });
+
+  switch (route.kind) {
+    case "host_bash":
+      void poster.postBashResult({
+        requestId,
+        stdout: "",
+        stderr: "Executor not yet implemented",
+        exitCode: 1,
+        timedOut: false,
+      });
+      break;
+    case "host_file":
+      void poster.postFileResult({
+        requestId,
+        content: "Executor not yet implemented",
+        isError: true,
+      });
+      break;
+    case "host_transfer":
+      void poster.postTransferResult({
+        requestId,
+        isError: true,
+        errorMessage: "Executor not yet implemented",
+      });
+      break;
+    case "host_browser":
+      void poster.postBrowserResult({
+        requestId,
+        content: "Executor not yet implemented",
+        isError: true,
+      });
+      break;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle — connect / disconnect per assistant
+// ---------------------------------------------------------------------------
+
+async function connectAssistant(
+  assistantId: string,
+  gatewayPort: number,
+): Promise<void> {
+  if (connections.has(assistantId)) return;
+
+  if (!resolveCliInvocation) {
+    log.error("[host-proxy-router] CLI invocation resolver not set");
+    return;
+  }
+
+  const configDir = resolveConfigDir(process.env);
+
+  let invocation: CliInvocation;
+  try {
+    invocation = await resolveCliInvocation();
+  } catch (err) {
+    log.error("[host-proxy-router] failed to resolve CLI invocation", { assistantId, err });
+    return;
+  }
+
+  const tokenResult = await getGuardianAccessToken(
+    assistantId,
+    configDir,
+    invocation,
+    true,
+  );
+
+  if (!tokenResult.ok) {
+    log.warn("[host-proxy-router] failed to obtain guardian token", {
+      assistantId,
+      error: tokenResult.error,
+    });
+    return;
+  }
+
+  const authToken = tokenResult.accessToken;
+
+  const sse = new HostProxySseClient({ gatewayPort, authToken });
+  const poster = new HostProxyPoster({ gatewayPort, authToken });
+
+  sse.setMessageCallback((msg) => dispatchMessage(msg, poster));
+  sse.connect();
+
+  connections.set(assistantId, { sse, poster });
+  log.info("[host-proxy-router] connected to assistant", { assistantId, gatewayPort });
+}
+
+function disconnectAssistant(assistantId: string): void {
+  const conn = connections.get(assistantId);
+  if (!conn) return;
+  conn.sse.disconnect();
+  connections.delete(assistantId);
+  log.info("[host-proxy-router] disconnected from assistant", { assistantId });
+}
+
+// ---------------------------------------------------------------------------
+// Lockfile change handler
+// ---------------------------------------------------------------------------
+
+function handleLockfileChange(lockfile: Lockfile): void {
+  const activeIds = new Set<string>();
+
+  for (const assistant of lockfile.assistants) {
+    const port = assistant.resources?.gatewayPort;
+    if (!port) continue;
+    activeIds.add(assistant.assistantId);
+
+    if (!connections.has(assistant.assistantId)) {
+      void connectAssistant(assistant.assistantId, port);
+    }
+  }
+
+  // Disconnect assistants that are no longer in the lockfile
+  for (const assistantId of connections.keys()) {
+    if (!activeIds.has(assistantId)) {
+      disconnectAssistant(assistantId);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public install / teardown
+// ---------------------------------------------------------------------------
+
+let unsubscribe: (() => void) | null = null;
+
+/**
+ * Wire the host proxy bridge into the app lifecycle. Call once from
+ * `app.whenReady()` after `installLockfileWatcher()`. Returns a teardown
+ * function for `before-quit`.
+ */
+export function installHostProxyBridge(
+  cliResolver: () => Promise<CliInvocation>,
+): () => void {
+  resolveCliInvocation = cliResolver;
+  unsubscribe = onLockfileChange(handleLockfileChange);
+
+  return () => {
+    unsubscribe?.();
+    unsubscribe = null;
+    for (const assistantId of [...connections.keys()]) {
+      disconnectAssistant(assistantId);
+    }
+    resolveCliInvocation = null;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Test seams
+// ---------------------------------------------------------------------------
+
+export const __testing = {
+  get connections() {
+    return connections;
+  },
+  get executors() {
+    return executors;
+  },
+  dispatchMessage,
+  connectAssistant,
+  disconnectAssistant,
+  handleLockfileChange,
+  reset() {
+    for (const assistantId of [...connections.keys()]) {
+      disconnectAssistant(assistantId);
+    }
+    executors.clear();
+    resolveCliInvocation = null;
+    unsubscribe?.();
+    unsubscribe = null;
+  },
+};

--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -36,8 +36,9 @@ import { installHotkeyHelper } from "./hotkey-helper";
 import { installHotkeysIpc } from "./hotkeys";
 import { installPopoutWindows } from "./popout-window";
 import { installQuickInput } from "./quick-input-window";
-import { installLocalMode } from "./local-mode";
+import { installLocalMode, resolveCliInvocation } from "./local-mode";
 import { installLockfileWatcher } from "./lockfile-watcher";
+import { installHostProxyBridge } from "./host-proxy-router";
 import log from "./logger";
 import {
   ensureVisible as ensureMainWindowVisible,
@@ -360,6 +361,8 @@ app
     // switcher submenu has data on its first right-click.
     const teardownLockfileWatcher = installLockfileWatcher();
     app.on("before-quit", teardownLockfileWatcher);
+    const teardownHostProxy = installHostProxyBridge(resolveCliInvocation);
+    app.on("before-quit", teardownHostProxy);
     installTray({
       toggleMainWindow: toggleMainWindowVisibility,
       ensureMainWindow: ensureMainWindowVisible,

--- a/apps/macos/src/main/local-mode.ts
+++ b/apps/macos/src/main/local-mode.ts
@@ -69,7 +69,7 @@ interface WakeResult {
  *
  * Throws when no CLI path can be resolved (e.g. install fails).
  */
-async function resolveCliInvocation(): Promise<CliInvocation> {
+export async function resolveCliInvocation(): Promise<CliInvocation> {
   const envPath = process.env.VELLUM_CLI_PATH;
   if (envPath) {
     return { command: "bun", baseArgs: ["run", envPath] };


### PR DESCRIPTION
## Summary
- Add host-proxy-router.ts that connects to each local assistant's daemon SSE
- Dispatch messages to pluggable executors via setExecutor() registry
- Unimplemented executors post error results so daemon requests don't hang
- Wire into Electron app lifecycle via index.ts

Part of plan: electron-host-proxy-parity.md (PR 4 of 8)