### PR TITLE
feat(macos): inline chat title bar with the macOS traffic lights

### DIFF
--- a/apps/macos/src/main/main-window.test.ts
+++ b/apps/macos/src/main/main-window.test.ts
@@ -26,6 +26,7 @@ type StubWindow = {
   setBounds: ReturnType<typeof mock>;
   setPosition: ReturnType<typeof mock>;
   center: ReturnType<typeof mock>;
+  setWindowButtonPosition: ReturnType<typeof mock>;
   webContents: StubWebContents;
   // Test seam — emits a `closed` event so the production code's
   // module-scope `mainWindow = null` cleanup runs.
@@ -77,6 +78,7 @@ const makeWindow = (opts: Record<string, unknown> = {}): StubWindow => {
     setBounds: mock(() => undefined),
     setPosition: mock(() => undefined),
     center: mock(() => undefined),
+    setWindowButtonPosition: mock(() => undefined),
     show: mock(() => {
       state.visible = true;
     }),
@@ -531,6 +533,62 @@ describe("onboarding window sizing", () => {
 
     expect(writeOnboardingActiveMock).toHaveBeenCalledWith(true);
     expect(win.stub.setContentSize).toHaveBeenCalledWith(440, 630);
+  });
+
+  test("centres the macOS traffic lights for a main-app window on creation", () => {
+    onboardingActive = false;
+    ensureVisible();
+    const win = constructed[0];
+    if (!win) throw new Error("expected a window");
+
+    // Inline title-bar layout: cluster centred in the ~44px header.
+    expect(win.stub.setWindowButtonPosition).toHaveBeenCalledWith({ x: 19, y: 15 });
+  });
+
+  test("keeps the system-default traffic lights for a compact onboarding window", () => {
+    onboardingActive = true;
+    ensureVisible();
+    const win = constructed[0];
+    if (!win) throw new Error("expected a window");
+
+    // Compact / pre-app surfaces have no inline title bar → reset to default.
+    expect(win.stub.setWindowButtonPosition).toHaveBeenCalledWith(null);
+  });
+
+  test("setOnboarding(true) resets the traffic lights to the system default", () => {
+    onboardingActive = false;
+    ensureVisible();
+    const win = constructed[0];
+    if (!win) throw new Error("expected a window");
+    win.stub.setWindowButtonPosition.mockClear();
+
+    setOnboarding(true);
+
+    expect(win.stub.setWindowButtonPosition).toHaveBeenCalledWith(null);
+  });
+
+  test("setOnboarding(false) re-centres the traffic lights for the main app", () => {
+    onboardingActive = true;
+    ensureVisible();
+    const win = constructed[0];
+    if (!win) throw new Error("expected a window");
+    win.stub.setWindowButtonPosition.mockClear();
+
+    setOnboarding(false);
+
+    expect(win.stub.setWindowButtonPosition).toHaveBeenCalledWith({ x: 19, y: 15 });
+  });
+
+  test("re-asserting the current mode does not reposition the traffic lights", () => {
+    onboardingActive = false;
+    ensureVisible();
+    const win = constructed[0];
+    if (!win) throw new Error("expected a window");
+    win.stub.setWindowButtonPosition.mockClear();
+
+    setOnboarding(false);
+
+    expect(win.stub.setWindowButtonPosition).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/macos/src/main/main-window.ts
+++ b/apps/macos/src/main/main-window.ts
@@ -26,6 +26,35 @@ const ONBOARDING_CONTENT_SIZE = { width: 440, height: 630 } as const;
 // Default bounds for the main window once onboarding is done.
 const MAIN_DEFAULT_BOUNDS = { width: 1280, height: 800 } as const;
 
+// macOS traffic-light (window controls) position for the main-app layout.
+//
+// The renderer's chat header (`apps/web` `ChatLayoutHeader`) renders as a
+// unified ~44px title bar whose icon row sits *inline* with the window
+// controls. To line them up we vertically centre the ~14px-tall traffic
+// light cluster in that bar — `(44 − 14) / 2 ≈ 15` — and inset it ~19px from
+// the left edge (matching the macOS default), so the header's left padding
+// clears the cluster. See `ChatLayoutHeader`'s Electron branch in the
+// renderer for the matching toolbar height + left inset.
+//
+// Compact / pre-app surfaces (onboarding, the `/account/*` auth screens) have
+// no such title bar, so they keep the system-default position. Those surfaces
+// drive `setOnboarding(true)`; the main app drives `setOnboarding(false)`.
+const MAIN_TRAFFIC_LIGHT_POSITION = { x: 19, y: 15 } as const;
+
+// Align the macOS traffic lights with the active layout. The compact
+// onboarding / auth surfaces pass `compact: true` to reset the cluster to the
+// system default (`null`); the main app passes `compact: false` to centre it
+// in the inline title bar. macOS-only API — the desktop app only ships on
+// macOS — but `setWindowButtonPosition` is a harmless no-op shape elsewhere.
+const applyTrafficLightPosition = (
+  win: BrowserWindow,
+  compact: boolean,
+): void => {
+  win.setWindowButtonPosition(
+    compact ? null : { ...MAIN_TRAFFIC_LIGHT_POSITION },
+  );
+};
+
 /**
  * Main BrowserWindow lifecycle owner.
  *
@@ -160,6 +189,13 @@ const createMainWindow = (): BrowserWindow => {
     browserWindow: { ...sizing, titleBarStyle: "hidden", show: false },
     navigation: { installGuard: installSameOriginNavigationGuard },
   });
+
+  // Line the macOS traffic lights up with the renderer's inline title bar for
+  // the main app; the compact onboarding / auth window keeps the system
+  // default. Done before `show` (the window is created hidden) so there's no
+  // flicker of the cluster jumping into place. `setOnboarding` keeps this in
+  // sync as the user crosses between compact and main surfaces.
+  applyTrafficLightPosition(win, onboardingActive);
 
   // Persist bounds only when NOT in onboarding mode. Both layouts are
   // resizable, so resize events fire in either mode — but the small
@@ -320,6 +356,10 @@ export const setOnboarding = (active: boolean): void => {
   const win = mainWindow;
   if (!win || win.isDestroyed()) return;
   if (active === wasActive) return;
+
+  // Re-centre (or reset) the traffic lights to match the layout we're moving
+  // into — the inline title bar exists only on the main-app surface.
+  applyTrafficLightPosition(win, active);
 
   if (active) {
     win.setContentSize(

--- a/apps/web/src/components/sidebar-shell.tsx
+++ b/apps/web/src/components/sidebar-shell.tsx
@@ -2,6 +2,7 @@ import { ArrowLeft } from "lucide-react";
 import { type ReactNode } from "react";
 import { Link, useLocation, useNavigate } from "react-router";
 
+import { isElectron } from "@/runtime/is-electron";
 import { routes } from "@/utils/routes";
 import { Button, Typography } from "@vellumai/design-library";
 
@@ -32,6 +33,15 @@ export function SidebarShell({
   const { pathname } = useLocation();
   const navigate = useNavigate();
   const isMenuRoute = pathname === menuRoute;
+
+  // In the Electron shell the macOS window controls (traffic lights) sit in an
+  // inline title-bar zone at the top of the renderer (see `ChatLayoutHeader` /
+  // the desktop app's `MAIN_TRAFFIC_LIGHT_POSITION`). Unlike chat, this shell
+  // has no inline header row, so reserve top space to clear the controls AND
+  // match the chat layout, whose sidebar/content sits below the 44px title bar
+  // plus the 16px content inset (`p-4`) — i.e. 60px (3.75rem) from the top.
+  // Off Electron it stays at the standard 1rem inset.
+  const electron = isElectron();
 
   const mobileBackHref = isMenuRoute ? backHref : menuRoute;
   const mobileBackLabel = isMenuRoute
@@ -69,8 +79,9 @@ export function SidebarShell({
     <div
       className="flex h-full min-h-0 w-full flex-1 flex-col gap-4 p-4 sm:p-6 md:gap-0"
       style={{
-        paddingTop:
-          "calc(var(--safe-area-inset-top, env(safe-area-inset-top, 0px)) + 1rem)",
+        paddingTop: electron
+          ? "calc(var(--safe-area-inset-top, env(safe-area-inset-top, 0px)) + 3.75rem)"
+          : "calc(var(--safe-area-inset-top, env(safe-area-inset-top, 0px)) + 1rem)",
       }}
     >
       {/* Mobile header */}

--- a/apps/web/src/components/window-drag-region.test.tsx
+++ b/apps/web/src/components/window-drag-region.test.tsx
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+let isElectronMock = false;
+let inlineTitleBarActiveMock = false;
+
+mock.module("@/runtime/is-electron", () => ({
+  isElectron: () => isElectronMock,
+}));
+
+mock.module("@/stores/title-bar-store", () => ({
+  useTitleBarStore: {
+    use: { inlineTitleBarActive: () => inlineTitleBarActiveMock },
+  },
+}));
+
+import { WindowDragRegion } from "@/components/window-drag-region";
+
+beforeEach(() => {
+  isElectronMock = false;
+  inlineTitleBarActiveMock = false;
+});
+
+describe("WindowDragRegion", () => {
+  test("renders nothing off Electron", () => {
+    isElectronMock = false;
+    expect(renderToStaticMarkup(<WindowDragRegion />)).toBe("");
+  });
+
+  test("renders the drag strip on Electron when no inline title bar is active", () => {
+    isElectronMock = true;
+    const html = renderToStaticMarkup(<WindowDragRegion />);
+    expect(html).toContain("app-region:drag");
+  });
+
+  test("yields while an inline title bar (the chat header) owns dragging", () => {
+    // The chat header is the macOS title bar on the main app and provides its
+    // own drag region; the fallback strip must step aside so it doesn't
+    // out-stack and swallow the header's button clicks.
+    isElectronMock = true;
+    inlineTitleBarActiveMock = true;
+    expect(renderToStaticMarkup(<WindowDragRegion />)).toBe("");
+  });
+});

--- a/apps/web/src/components/window-drag-region.tsx
+++ b/apps/web/src/components/window-drag-region.tsx
@@ -1,4 +1,5 @@
 import { isElectron } from "@/runtime/is-electron";
+import { useTitleBarStore } from "@/stores/title-bar-store";
 
 /**
  * Electron-only window drag strip.
@@ -17,9 +18,16 @@ import { isElectron } from "@/runtime/is-electron";
  *   `[-webkit-app-region:no-drag]`) or it will be unclickable — a drag region
  *   swallows pointer events.
  * - No-ops off Electron (web / Capacitor iOS), so those layouts are untouched.
+ * - Yields on the main-app chat routes, where `ChatLayoutHeader` is the inline
+ *   title bar and owns dragging itself. This strip renders *outside*
+ *   `.app-shell` (an `isolation: isolate` stacking context), so leaving it up
+ *   would out-stack the header's buttons and swallow their clicks. See
+ *   {@link useTitleBarStore}.
  */
 export function WindowDragRegion() {
+  const inlineTitleBarActive = useTitleBarStore.use.inlineTitleBarActive();
   if (!isElectron()) return null;
+  if (inlineTitleBarActive) return null;
 
   return (
     <div

--- a/apps/web/src/domains/chat/chat-layout-header.tsx
+++ b/apps/web/src/domains/chat/chat-layout-header.tsx
@@ -17,9 +17,11 @@ import { useTitleBarStore } from "@/stores/title-bar-store";
 // the renderer. In the Electron shell the header renders as a unified title bar
 // sitting *inline* with those controls (the desktop app centres the cluster
 // vertically via `MAIN_TRAFFIC_LIGHT_POSITION`), so the left icon row is inset
-// to start clear of the ~71px-wide cluster. The header's own `px-4` supplies
-// the first 16px; this adds the remainder. Off Electron the inset is 0.
-const ELECTRON_TRAFFIC_LIGHT_CLEARANCE = 62;
+// to start clear of the ~71px-wide cluster with a comfortable gap after it.
+// The header's own `px-4` supplies the first 16px; this adds the remainder
+// (≈ button left edge at 96px, leaving a ~25px gap past the green control).
+// Off Electron the inset is 0.
+const ELECTRON_TRAFFIC_LIGHT_CLEARANCE = 80;
 
 export interface ChatLayoutHeaderProps {
   isMobile: boolean;

--- a/apps/web/src/domains/chat/chat-layout-header.tsx
+++ b/apps/web/src/domains/chat/chat-layout-header.tsx
@@ -7,9 +7,19 @@ import {
     PanelLeft,
     Search,
 } from "lucide-react";
-import { useCallback, type ReactNode } from "react";
+import { useCallback, useEffect, type ReactNode } from "react";
 
+import { isElectron } from "@/runtime/is-electron";
 import { useCommandPaletteStore } from "@/stores/command-palette-store";
+import { useTitleBarStore } from "@/stores/title-bar-store";
+
+// On macOS the native window controls (traffic lights) overlay the top-left of
+// the renderer. In the Electron shell the header renders as a unified title bar
+// sitting *inline* with those controls (the desktop app centres the cluster
+// vertically via `MAIN_TRAFFIC_LIGHT_POSITION`), so the left icon row is inset
+// to start clear of the ~71px-wide cluster. The header's own `px-4` supplies
+// the first 16px; this adds the remainder. Off Electron the inset is 0.
+const ELECTRON_TRAFFIC_LIGHT_CLEARANCE = 62;
 
 export interface ChatLayoutHeaderProps {
   isMobile: boolean;
@@ -47,21 +57,54 @@ export function ChatLayoutHeader({
   const toggleCommandPalette = useCommandPaletteStore.use.toggle();
   const handleSearchClick = useCallback(() => { toggleCommandPalette(); }, [toggleCommandPalette]);
 
+  // In the Electron shell the header doubles as the macOS title bar: it sits
+  // inline with the traffic lights and drives window dragging
+  // (`-webkit-app-region: drag`), with its interactive children opting back
+  // out via `no-drag`. While mounted it claims the title bar so the global
+  // `WindowDragRegion` fallback strip yields (see `useTitleBarStore`) —
+  // otherwise that strip, living outside `.app-shell`'s `isolation: isolate`
+  // context, would out-stack and swallow clicks on the header's buttons.
+  // Gated to Electron so the web/iOS layouts are byte-for-byte unchanged.
+  const electron = isElectron();
+
+  const setInlineTitleBarActive =
+    useTitleBarStore.use.setInlineTitleBarActive();
+  useEffect(() => {
+    if (!electron) return;
+    setInlineTitleBarActive(true);
+    return () => setInlineTitleBarActive(false);
+  }, [electron, setInlineTitleBarActive]);
+
   return (
     <header
       data-slot="chat-layout-header"
-      className={`flex w-full shrink-0 items-center gap-4 px-4 pt-4${isMobile ? " pb-4" : ""}`}
+      className={`flex w-full shrink-0 items-center gap-4 px-4 pt-4${isMobile ? " pb-4" : ""}${
+        electron
+          ? " select-none [-webkit-app-region:drag] [&_a]:[-webkit-app-region:no-drag] [&_button]:[-webkit-app-region:no-drag]"
+          : ""
+      }`}
       style={{
         background: "var(--surface-base)",
-        minHeight:
-          "calc(40px + var(--safe-area-inset-top, env(safe-area-inset-top, 0px)))",
-        paddingTop:
-          "calc(16px + var(--safe-area-inset-top, env(safe-area-inset-top, 0px)))",
+        minHeight: electron
+          ? "44px"
+          : "calc(40px + var(--safe-area-inset-top, env(safe-area-inset-top, 0px)))",
+        paddingTop: electron
+          ? 0
+          : "calc(16px + var(--safe-area-inset-top, env(safe-area-inset-top, 0px)))",
       }}
     >
       <div
         className="flex items-center gap-2 transition-[min-width] duration-150 ease-in-out max-md:min-w-0 max-md:flex-1"
-        style={!isMobile ? { minWidth: collapsed ? 48 : (sidebarWidth ?? 230) } : undefined}
+        style={
+          !isMobile
+            ? {
+                minWidth: collapsed ? 48 : (sidebarWidth ?? 230),
+                ...(electron
+                  ? { paddingLeft: ELECTRON_TRAFFIC_LIGHT_CLEARANCE }
+                  : {}),
+              }
+            : undefined
+        }
       >
         {isMobile ? (
           <Button

--- a/apps/web/src/domains/chat/chat-layout-header.tsx
+++ b/apps/web/src/domains/chat/chat-layout-header.tsx
@@ -97,21 +97,13 @@ export function ChatLayoutHeader({
     >
       <div
         className="flex items-center gap-2 transition-[min-width] duration-150 ease-in-out max-md:min-w-0 max-md:flex-1"
-        style={
-          !isMobile
-            ? {
-                minWidth: collapsed ? 48 : (sidebarWidth ?? 230),
-                ...(electron
-                  ? { paddingLeft: ELECTRON_TRAFFIC_LIGHT_CLEARANCE }
-                  : {}),
-              }
-            : // On Electron the traffic lights stay inline even when the window
-              // narrows below `md` (mobile layout), so the mobile menu row needs
-              // the same left clearance or it would overlap the controls.
-              electron
-              ? { paddingLeft: ELECTRON_TRAFFIC_LIGHT_CLEARANCE }
-              : undefined
-        }
+        style={{
+          // `minWidth` reserves the sidebar column on desktop only. The Electron
+          // inset clears the inline traffic lights regardless of `isMobile` —
+          // they stay put even in the narrow mobile layout.
+          ...(isMobile ? {} : { minWidth: collapsed ? 48 : (sidebarWidth ?? 230) }),
+          ...(electron ? { paddingLeft: ELECTRON_TRAFFIC_LIGHT_CLEARANCE } : {}),
+        }}
       >
         {isMobile ? (
           <Button

--- a/apps/web/src/domains/chat/chat-layout-header.tsx
+++ b/apps/web/src/domains/chat/chat-layout-header.tsx
@@ -105,7 +105,12 @@ export function ChatLayoutHeader({
                   ? { paddingLeft: ELECTRON_TRAFFIC_LIGHT_CLEARANCE }
                   : {}),
               }
-            : undefined
+            : // On Electron the traffic lights stay inline even when the window
+              // narrows below `md` (mobile layout), so the mobile menu row needs
+              // the same left clearance or it would overlap the controls.
+              electron
+              ? { paddingLeft: ELECTRON_TRAFFIC_LIGHT_CLEARANCE }
+              : undefined
         }
       >
         {isMobile ? (

--- a/apps/web/src/stores/title-bar-store.ts
+++ b/apps/web/src/stores/title-bar-store.ts
@@ -1,0 +1,41 @@
+/**
+ * Coordinates the Electron window-drag surface between the global fallback
+ * strip and a renderer-owned inline title bar.
+ *
+ * The macOS shell runs with `titleBarStyle: "hidden"`, so the renderer must
+ * declare its own `-webkit-app-region: drag` surface (see `WindowDragRegion`).
+ * On the main-app chat routes the chat header (`ChatLayoutHeader`) doubles as
+ * the macOS title bar — it sits inline with the traffic lights and provides
+ * that drag surface itself. The global `WindowDragRegion` strip must step
+ * aside there: it renders *outside* `.app-shell` (which is an `isolation:
+ * isolate` stacking context), so it would paint over — and out-stack — the
+ * header's buttons and swallow their clicks.
+ *
+ * `ChatLayoutHeader` sets `inlineTitleBarActive` while it's mounted on
+ * Electron; `WindowDragRegion` reads it and renders nothing while active. Off
+ * Electron nothing sets it and `WindowDragRegion` is already a no-op, so this
+ * is inert on web and iOS.
+ *
+ * @see {@link https://zustand.docs.pmnd.rs/}
+ */
+
+import { create } from "zustand";
+
+import { createSelectors } from "@/utils/create-selectors";
+
+interface TitleBarState {
+  inlineTitleBarActive: boolean;
+}
+
+interface TitleBarActions {
+  setInlineTitleBarActive: (active: boolean) => void;
+}
+
+type TitleBarStore = TitleBarState & TitleBarActions;
+
+const useTitleBarStoreBase = create<TitleBarStore>((set) => ({
+  inlineTitleBarActive: false,
+  setInlineTitleBarActive: (active) => set({ inlineTitleBarActive: active }),
+}));
+
+export const useTitleBarStore = createSelectors(useTitleBarStoreBase);


### PR DESCRIPTION
## Summary

Render the chat top navigation bar (sidebar / home / search / back / forward icons + centered conversation title) **inline with the macOS traffic-light window controls** — a unified title bar — instead of in a separate row below them. Electron-only; the web and iOS layouts are byte-for-byte unchanged.

Before → After:
- Icons sat in a row *below* the traffic lights → icons now sit *inline* with them, with the controls vertically centered in the bar.

## Changes

- **Inline chat title bar** (`feat(macos)`): the chat header becomes a ~44px unified title bar. The macOS window controls are vertically centered in it via `setWindowButtonPosition({ x: 19, y: 15 })`, the icon row is inset to clear the cluster, and the header itself is the window drag region (interactive children opt out with `-webkit-app-region: no-drag`). A small `title-bar-store` lets the header claim dragging so the global `WindowDragRegion` fallback yields instead of out-stacking the header's buttons (`.app-shell` is an `isolation: isolate` stacking context). Compact onboarding / auth surfaces keep the system-default control position.
- **Wider control ↔ icon gap** (`fix(web)`): bump the left clearance so the icon row sits a comfortable distance past the green control rather than hugging it.
- **Settings / Logs shell** (`fix(web)`): `SidebarShell` reserves the title-bar zone on Electron (60px = the chat layout's 44px bar + 16px content inset) so its container clears the repositioned controls and lines up with the chat sidebar.

## Test plan

- `apps/macos`: `bunx tsc --noEmit` ✓, `bun test src/main/main-window.test.ts` ✓ (incl. 5 new traffic-light positioning tests)
- `apps/web`: `bunx tsc --noEmit` ✓, `bun test src/components/window-drag-region.test.tsx` ✓ (3 new), eslint clean on changed files
- Manual (Electron dev): traffic lights centered in the bar; icons clear the cluster; window drags by the bar; icon buttons + the title dropdown stay clickable; Settings/Logs content clears the controls; web/iOS unaffected.

## Notes

- Fully Electron-gated via `isElectron()` — no behavior change on web or iOS.
- Branch is based on an older `main` (merge-base `f7bdc00`); none of the touched files changed on `main` since, so it merges cleanly. Rebase before merge if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
