### PR TITLE
feat: add host_bash executor to Electron host proxy bridge

### DIFF
--- a/apps/macos/src/main/executors/host-bash-executor.test.ts
+++ b/apps/macos/src/main/executors/host-bash-executor.test.ts
@@ -1,0 +1,226 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Stubs — must precede executor import
+// ---------------------------------------------------------------------------
+
+const MOCK_DEVICE_ID = "test-device-00000000-0000-0000-0000-000000000000";
+mock.module("../device-id", () => ({
+  getDeviceId: () => MOCK_DEVICE_ID,
+  resetDeviceIdCache: () => {},
+}));
+
+// Stub electron-log
+mock.module("electron-log/main", () => {
+  const noop = () => {};
+  return {
+    default: {
+      info: noop,
+      warn: noop,
+      error: noop,
+      debug: noop,
+      initialize: noop,
+      transports: { file: { maxSize: 0, fileName: "", format: "", getFile: () => ({ path: "" }) } },
+    },
+  };
+});
+
+// Stub lockfile-watcher (required by host-proxy-router)
+mock.module("../lockfile-watcher", () => ({
+  onLockfileChange: () => () => {},
+}));
+
+// Stub @vellumai/local-mode (required by host-proxy-router)
+mock.module("@vellumai/local-mode", () => ({
+  getGuardianAccessToken: async () => ({ ok: true, accessToken: "test-token" }),
+  resolveConfigDir: () => "/tmp/test-config",
+}));
+
+const { HostProxyPoster } = await import("../host-proxy-poster");
+const { hostBashExecutor, __testing: executorTesting } = await import("./host-bash-executor");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function flush(ms = 50): Promise<void> {
+  await new Promise((r) => setTimeout(r, ms));
+}
+
+interface CapturedPost {
+  url: string;
+  body: Record<string, unknown>;
+}
+
+function capturingPoster(): { poster: InstanceType<typeof HostProxyPoster>; posts: () => CapturedPost[] } {
+  const captured: CapturedPost[] = [];
+  const fakeFetch = async (url: unknown, init?: RequestInit) => {
+    captured.push({ url: String(url), body: JSON.parse(init?.body as string) });
+    return new Response("ok");
+  };
+  const poster = new HostProxyPoster({
+    gatewayPort: 9000,
+    authToken: "t",
+    fetch: fakeFetch as typeof globalThis.fetch,
+  });
+  return { poster, posts: () => captured };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("host-bash-executor", () => {
+  afterEach(() => {
+    // Clean up any lingering processes
+    for (const [, entry] of executorTesting.runningProcesses) {
+      try { entry.child.kill("SIGKILL"); } catch { /* already exited */ }
+    }
+    executorTesting.runningProcesses.clear();
+  });
+
+  test("executes a command and posts result", async () => {
+    const { poster, posts } = capturingPoster();
+
+    hostBashExecutor.handleRequest(
+      { type: "host_bash_request", requestId: "r1", command: "echo hello" },
+      poster,
+    );
+
+    // Wait for process to complete
+    await flush(500);
+
+    expect(posts().length).toBe(1);
+    const result = posts()[0].body;
+    expect(result.requestId).toBe("r1");
+    expect((result.stdout as string).trim()).toBe("hello");
+    expect(result.exitCode).toBe(0);
+    expect(result.timedOut).toBe(false);
+  });
+
+  test("captures stderr output", async () => {
+    const { poster, posts } = capturingPoster();
+
+    hostBashExecutor.handleRequest(
+      { type: "host_bash_request", requestId: "r2", command: "echo err >&2" },
+      poster,
+    );
+
+    await flush(500);
+
+    expect(posts().length).toBe(1);
+    expect((posts()[0].body.stderr as string).trim()).toBe("err");
+  });
+
+  test("reports non-zero exit code", async () => {
+    const { poster, posts } = capturingPoster();
+
+    hostBashExecutor.handleRequest(
+      { type: "host_bash_request", requestId: "r3", command: "exit 42" },
+      poster,
+    );
+
+    await flush(500);
+
+    expect(posts().length).toBe(1);
+    expect(posts()[0].body.exitCode).toBe(42);
+  });
+
+  test("times out and sends SIGTERM then SIGKILL", async () => {
+    const { poster, posts } = capturingPoster();
+
+    hostBashExecutor.handleRequest(
+      {
+        type: "host_bash_request",
+        requestId: "r4",
+        command: "sleep 60",
+        timeout_seconds: 1,
+      },
+      poster,
+    );
+
+    // Wait for timeout + SIGKILL grace period + buffer
+    await flush(4_000);
+
+    expect(posts().length).toBe(1);
+    expect(posts()[0].body.timedOut).toBe(true);
+    expect(posts()[0].body.requestId).toBe("r4");
+  });
+
+  test("cancellation terminates process and suppresses result", async () => {
+    const { poster, posts } = capturingPoster();
+
+    hostBashExecutor.handleRequest(
+      { type: "host_bash_request", requestId: "r5", command: "sleep 60" },
+      poster,
+    );
+
+    await flush(100);
+    expect(executorTesting.runningProcesses.has("r5")).toBe(true);
+
+    hostBashExecutor.handleCancel(
+      { type: "host_bash_cancel", requestId: "r5" },
+      poster,
+    );
+
+    await flush(3_000);
+
+    // Result should be suppressed
+    expect(posts().length).toBe(0);
+    expect(executorTesting.runningProcesses.has("r5")).toBe(false);
+  });
+
+  test("merges environment variables", async () => {
+    const { poster, posts } = capturingPoster();
+
+    hostBashExecutor.handleRequest(
+      {
+        type: "host_bash_request",
+        requestId: "r6",
+        command: 'echo "$TEST_BASH_VAR"',
+        env: { TEST_BASH_VAR: "custom_value" },
+      },
+      poster,
+    );
+
+    await flush(500);
+
+    expect(posts().length).toBe(1);
+    expect((posts()[0].body.stdout as string).trim()).toBe("custom_value");
+  });
+
+  test("uses specified working directory", async () => {
+    const { poster, posts } = capturingPoster();
+
+    hostBashExecutor.handleRequest(
+      {
+        type: "host_bash_request",
+        requestId: "r7",
+        command: "pwd",
+        working_dir: "/tmp",
+      },
+      poster,
+    );
+
+    await flush(500);
+
+    expect(posts().length).toBe(1);
+    // On macOS /tmp is a symlink to /private/tmp
+    expect((posts()[0].body.stdout as string).trim()).toMatch(/\/tmp$/);
+  });
+
+  test("returns error for missing command", async () => {
+    const { poster, posts } = capturingPoster();
+
+    hostBashExecutor.handleRequest(
+      { type: "host_bash_request", requestId: "r8" },
+      poster,
+    );
+
+    await flush(100);
+
+    expect(posts().length).toBe(1);
+    expect(posts()[0].body.stderr).toBe("Missing command");
+    expect(posts()[0].body.exitCode).toBe(1);
+  });
+});

--- a/apps/macos/src/main/executors/host-bash-executor.ts
+++ b/apps/macos/src/main/executors/host-bash-executor.ts
@@ -1,0 +1,133 @@
+/**
+ * Host bash executor — runs shell commands on the host machine and posts
+ * results back to the daemon via the host proxy poster.
+ *
+ * Supports timeout (SIGTERM → SIGKILL cascade) and cancellation.
+ */
+
+import { spawn, type ChildProcess } from "node:child_process";
+import { homedir } from "node:os";
+
+import type { HostProxyExecutor } from "../host-proxy-router";
+import type { HostProxySseMessage } from "../host-proxy-sse";
+import type { HostProxyPoster } from "../host-proxy-poster";
+import { setExecutor } from "../host-proxy-router";
+import log from "../logger";
+
+const DEFAULT_TIMEOUT_SECONDS = 120;
+const SIGKILL_GRACE_MS = 2_000;
+
+interface RunningProcess {
+  child: ChildProcess;
+  cancelled: boolean;
+  killTimer: ReturnType<typeof setTimeout> | null;
+}
+
+const runningProcesses = new Map<string, RunningProcess>();
+
+function handleRequest(message: HostProxySseMessage, poster: HostProxyPoster): void {
+  const requestId = message.requestId as string | undefined;
+  if (!requestId) {
+    log.warn("[host-bash-executor] message missing requestId");
+    return;
+  }
+
+  const command = message.command as string | undefined;
+  if (!command) {
+    void poster.postBashResult({ requestId, stdout: "", stderr: "Missing command", exitCode: 1, timedOut: false });
+    return;
+  }
+
+  const workingDir = (message.working_dir as string | undefined) || homedir();
+  const timeoutSeconds = (message.timeout_seconds as number | undefined) ?? DEFAULT_TIMEOUT_SECONDS;
+  const extraEnv = (message.env as Record<string, string> | undefined) ?? {};
+
+  const env = { ...process.env, ...extraEnv };
+
+  let stdout = "";
+  let stderr = "";
+  let timedOut = false;
+
+  const child = spawn("/bin/bash", ["-c", "--", command], {
+    cwd: workingDir,
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  const entry: RunningProcess = { child, cancelled: false, killTimer: null };
+  runningProcesses.set(requestId, entry);
+
+  child.stdout!.on("data", (chunk: Buffer) => { stdout += chunk.toString(); });
+  child.stderr!.on("data", (chunk: Buffer) => { stderr += chunk.toString(); });
+
+  // Timeout cascade: SIGTERM, then SIGKILL after grace period
+  const timeoutTimer = setTimeout(() => {
+    timedOut = true;
+    child.kill("SIGTERM");
+
+    entry.killTimer = setTimeout(() => {
+      if (!child.killed) {
+        child.kill("SIGKILL");
+      }
+    }, SIGKILL_GRACE_MS);
+  }, timeoutSeconds * 1_000);
+
+  child.on("close", (exitCode) => {
+    clearTimeout(timeoutTimer);
+    if (entry.killTimer) clearTimeout(entry.killTimer);
+    runningProcesses.delete(requestId);
+
+    if (entry.cancelled) return;
+
+    void poster.postBashResult({
+      requestId,
+      stdout,
+      stderr,
+      exitCode,
+      timedOut,
+    });
+  });
+
+  child.on("error", (err) => {
+    clearTimeout(timeoutTimer);
+    if (entry.killTimer) clearTimeout(entry.killTimer);
+    runningProcesses.delete(requestId);
+
+    if (entry.cancelled) return;
+
+    void poster.postBashResult({
+      requestId,
+      stdout,
+      stderr: stderr || err.message,
+      exitCode: 1,
+      timedOut: false,
+    });
+  });
+}
+
+function handleCancel(message: HostProxySseMessage, _poster: HostProxyPoster): void {
+  const requestId = message.requestId as string | undefined;
+  if (!requestId) return;
+
+  const entry = runningProcesses.get(requestId);
+  if (!entry) return;
+
+  entry.cancelled = true;
+  entry.child.kill("SIGTERM");
+
+  entry.killTimer = setTimeout(() => {
+    if (!entry.child.killed) {
+      entry.child.kill("SIGKILL");
+    }
+  }, SIGKILL_GRACE_MS);
+}
+
+export const hostBashExecutor: HostProxyExecutor = { handleRequest, handleCancel };
+
+// Register with the router
+setExecutor("host_bash", hostBashExecutor);
+
+// Test seam
+export const __testing = {
+  get runningProcesses() { return runningProcesses; },
+};

--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -39,6 +39,7 @@ import { installQuickInput } from "./quick-input-window";
 import { installLocalMode, resolveCliInvocation } from "./local-mode";
 import { installLockfileWatcher } from "./lockfile-watcher";
 import { installHostProxyBridge } from "./host-proxy-router";
+import "./executors/host-bash-executor"; // side-effect: registers host_bash executor
 import log from "./logger";
 import {
   ensureVisible as ensureMainWindowVisible,


### PR DESCRIPTION
## Summary
- Implement host_bash executor using child_process.spawn
- Timeout with SIGTERM→SIGKILL cascade, cancellation support
- Wire into host proxy router via setExecutor

Part of plan: electron-host-proxy-parity.md (PR 5 of 8)