### PR TITLE
feat: add host_file executor to Electron host proxy bridge

### DIFF
--- a/apps/macos/src/main/executors/host-file-executor.test.ts
+++ b/apps/macos/src/main/executors/host-file-executor.test.ts
@@ -1,0 +1,339 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+// ---------------------------------------------------------------------------
+// Stubs
+// ---------------------------------------------------------------------------
+
+const MOCK_DEVICE_ID = "test-device-00000000-0000-0000-0000-000000000000";
+mock.module("../device-id", () => ({
+  getDeviceId: () => MOCK_DEVICE_ID,
+  resetDeviceIdCache: () => {},
+}));
+
+mock.module("electron-log/main", () => {
+  const noop = () => {};
+  return {
+    default: {
+      info: noop,
+      warn: noop,
+      error: noop,
+      debug: noop,
+      initialize: noop,
+      transports: { file: { maxSize: 0, fileName: "", format: "", getFile: () => ({ path: "" }) } },
+    },
+  };
+});
+
+const { HostProxyPoster } = await import("../host-proxy-poster");
+const { hostFileExecutor, __testing } = await import("./host-file-executor");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+
+function freshTmpDir(): string {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "host-file-exec-"));
+  return tmpDir;
+}
+
+function capturingPoster(): {
+  poster: InstanceType<typeof HostProxyPoster>;
+  body: () => Record<string, unknown> | null;
+} {
+  let postedBody: Record<string, unknown> | null = null;
+  const fakeFetch = async (_url: unknown, init?: RequestInit) => {
+    postedBody = JSON.parse(init?.body as string);
+    return new Response("ok");
+  };
+  const poster = new HostProxyPoster({
+    gatewayPort: 9000,
+    authToken: "t",
+    fetch: fakeFetch as typeof globalThis.fetch,
+  });
+  return { poster, body: () => postedBody };
+}
+
+async function flush(ms = 20): Promise<void> {
+  await new Promise((r) => setTimeout(r, ms));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("host-file-executor", () => {
+  afterEach(() => {
+    __testing.pendingRequests.clear();
+    if (tmpDir) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  // -- Magic byte detection -------------------------------------------------
+
+  describe("isImageByMagicBytes", () => {
+    test("detects PNG", () => {
+      const buf = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a]);
+      expect(__testing.isImageByMagicBytes(buf)).toBe(true);
+    });
+
+    test("detects JPEG", () => {
+      const buf = Buffer.from([0xff, 0xd8, 0xff, 0xe0]);
+      expect(__testing.isImageByMagicBytes(buf)).toBe(true);
+    });
+
+    test("detects GIF", () => {
+      const buf = Buffer.from([0x47, 0x49, 0x46, 0x38]);
+      expect(__testing.isImageByMagicBytes(buf)).toBe(true);
+    });
+
+    test("detects BMP", () => {
+      const buf = Buffer.from([0x42, 0x4d, 0x00, 0x00]);
+      expect(__testing.isImageByMagicBytes(buf)).toBe(true);
+    });
+
+    test("detects WebP", () => {
+      const buf = Buffer.alloc(12);
+      buf.write("RIFF", 0);
+      buf.write("WEBP", 8);
+      expect(__testing.isImageByMagicBytes(buf)).toBe(true);
+    });
+
+    test("returns false for text", () => {
+      const buf = Buffer.from("hello world", "utf-8");
+      expect(__testing.isImageByMagicBytes(buf)).toBe(false);
+    });
+  });
+
+  describe("detectAudioByMagicBytes", () => {
+    test("detects MP3 with ID3 tag", () => {
+      const buf = Buffer.from([0x49, 0x44, 0x33, 0x00]);
+      expect(__testing.detectAudioByMagicBytes(buf)).toEqual({ mimeType: "audio/mpeg" });
+    });
+
+    test("detects MP3 sync word", () => {
+      const buf = Buffer.from([0xff, 0xfb, 0x90, 0x00]);
+      expect(__testing.detectAudioByMagicBytes(buf)).toEqual({ mimeType: "audio/mpeg" });
+    });
+
+    test("detects OGG", () => {
+      const buf = Buffer.from([0x4f, 0x67, 0x67, 0x53]);
+      expect(__testing.detectAudioByMagicBytes(buf)).toEqual({ mimeType: "audio/ogg" });
+    });
+
+    test("detects FLAC", () => {
+      const buf = Buffer.from([0x66, 0x4c, 0x61, 0x43]);
+      expect(__testing.detectAudioByMagicBytes(buf)).toEqual({ mimeType: "audio/flac" });
+    });
+
+    test("detects WAV", () => {
+      const buf = Buffer.alloc(12);
+      buf.write("RIFF", 0);
+      buf.write("WAVE", 8);
+      expect(__testing.detectAudioByMagicBytes(buf)).toEqual({ mimeType: "audio/wav" });
+    });
+
+    test("detects M4A", () => {
+      const buf = Buffer.alloc(8);
+      buf.write("ftyp", 4);
+      expect(__testing.detectAudioByMagicBytes(buf)).toEqual({ mimeType: "audio/mp4" });
+    });
+
+    test("returns null for text", () => {
+      const buf = Buffer.from("hello world", "utf-8");
+      expect(__testing.detectAudioByMagicBytes(buf)).toBeNull();
+    });
+  });
+
+  // -- Read -----------------------------------------------------------------
+
+  describe("read", () => {
+    test("reads text file and returns content", () => {
+      const dir = freshTmpDir();
+      const filePath = path.join(dir, "hello.txt");
+      fs.writeFileSync(filePath, "line1\nline2\nline3\n");
+
+      const result = __testing.executeRead({ path: filePath });
+      expect(result.content).toBe("line1\nline2\nline3\n");
+      expect(result.imageData).toBeUndefined();
+    });
+
+    test("respects offset and limit", () => {
+      const dir = freshTmpDir();
+      const filePath = path.join(dir, "lines.txt");
+      fs.writeFileSync(filePath, "a\nb\nc\nd\ne");
+
+      const result = __testing.executeRead({ path: filePath, offset: 1, limit: 2 });
+      expect(result.content).toBe("b\nc");
+    });
+
+    test("returns base64 imageData for PNG file", () => {
+      const dir = freshTmpDir();
+      const filePath = path.join(dir, "img.png");
+      const pngHeader = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+      fs.writeFileSync(filePath, pngHeader);
+
+      const result = __testing.executeRead({ path: filePath });
+      expect(result.imageData).toBe(pngHeader.toString("base64"));
+      expect(result.content).toBeUndefined();
+    });
+
+    test("returns base64 audioData for WAV file", () => {
+      const dir = freshTmpDir();
+      const filePath = path.join(dir, "sound.wav");
+      const wavBuf = Buffer.alloc(16);
+      wavBuf.write("RIFF", 0);
+      wavBuf.writeUInt32LE(8, 4);
+      wavBuf.write("WAVE", 8);
+      fs.writeFileSync(filePath, wavBuf);
+
+      const result = __testing.executeRead({ path: filePath });
+      expect(result.audioData).toBe(wavBuf.toString("base64"));
+      expect(result.audioMimeType).toBe("audio/wav");
+      expect(result.content).toBeUndefined();
+    });
+  });
+
+  // -- Write ----------------------------------------------------------------
+
+  describe("write", () => {
+    test("writes content to file", () => {
+      const dir = freshTmpDir();
+      const filePath = path.join(dir, "out.txt");
+
+      const result = __testing.executeWrite({ path: filePath, content: "hello" });
+      expect(result.isError).toBeUndefined();
+      expect(fs.readFileSync(filePath, "utf-8")).toBe("hello");
+    });
+
+    test("creates parent directories", () => {
+      const dir = freshTmpDir();
+      const filePath = path.join(dir, "a", "b", "c", "deep.txt");
+
+      __testing.executeWrite({ path: filePath, content: "deep" });
+      expect(fs.readFileSync(filePath, "utf-8")).toBe("deep");
+    });
+  });
+
+  // -- Edit -----------------------------------------------------------------
+
+  describe("edit", () => {
+    test("replaces unique string", () => {
+      const dir = freshTmpDir();
+      const filePath = path.join(dir, "edit.txt");
+      fs.writeFileSync(filePath, "foo bar baz");
+
+      const result = __testing.executeEdit({
+        path: filePath,
+        old_string: "bar",
+        new_string: "qux",
+      });
+      expect(result.isError).toBeUndefined();
+      expect(fs.readFileSync(filePath, "utf-8")).toBe("foo qux baz");
+    });
+
+    test("errors when old_string not found", () => {
+      const dir = freshTmpDir();
+      const filePath = path.join(dir, "edit.txt");
+      fs.writeFileSync(filePath, "foo bar baz");
+
+      const result = __testing.executeEdit({
+        path: filePath,
+        old_string: "missing",
+        new_string: "x",
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("not found");
+    });
+
+    test("errors when old_string is not unique and replace_all is false", () => {
+      const dir = freshTmpDir();
+      const filePath = path.join(dir, "edit.txt");
+      fs.writeFileSync(filePath, "foo foo bar");
+
+      const result = __testing.executeEdit({
+        path: filePath,
+        old_string: "foo",
+        new_string: "x",
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("not unique");
+    });
+
+    test("replaces all occurrences when replace_all is true", () => {
+      const dir = freshTmpDir();
+      const filePath = path.join(dir, "edit.txt");
+      fs.writeFileSync(filePath, "foo foo bar");
+
+      const result = __testing.executeEdit({
+        path: filePath,
+        old_string: "foo",
+        new_string: "x",
+        replace_all: true,
+      });
+      expect(result.isError).toBeUndefined();
+      expect(fs.readFileSync(filePath, "utf-8")).toBe("x x bar");
+    });
+  });
+
+  // -- handleRequest integration --------------------------------------------
+
+  describe("handleRequest", () => {
+    test("posts read result to poster", async () => {
+      const dir = freshTmpDir();
+      const filePath = path.join(dir, "test.txt");
+      fs.writeFileSync(filePath, "content here");
+
+      const { poster, body } = capturingPoster();
+      hostFileExecutor.handleRequest(
+        { type: "host_file_request", requestId: "r1", operation: "read", path: filePath },
+        poster,
+      );
+      await flush();
+
+      expect(body()!.requestId).toBe("r1");
+      expect(body()!.content).toBe("content here");
+    });
+
+    test("posts error for missing operation", async () => {
+      const { poster, body } = capturingPoster();
+      hostFileExecutor.handleRequest(
+        { type: "host_file_request", requestId: "r2", path: "/tmp/x" },
+        poster,
+      );
+      await flush();
+
+      expect(body()!.isError).toBe(true);
+      expect(body()!.content).toContain("Missing operation");
+    });
+
+    test("posts error for fs failure", async () => {
+      const { poster, body } = capturingPoster();
+      hostFileExecutor.handleRequest(
+        { type: "host_file_request", requestId: "r3", operation: "read", path: "/nonexistent/path/file.txt" },
+        poster,
+      );
+      await flush();
+
+      expect(body()!.isError).toBe(true);
+    });
+  });
+
+  // -- Cancellation ---------------------------------------------------------
+
+  describe("cancellation", () => {
+    test("handleCancel removes requestId from pending set", () => {
+      __testing.pendingRequests.add("c1");
+      hostFileExecutor.handleCancel(
+        { type: "host_file_cancel", requestId: "c1" },
+        {} as InstanceType<typeof HostProxyPoster>,
+      );
+      expect(__testing.pendingRequests.has("c1")).toBe(false);
+    });
+  });
+});

--- a/apps/macos/src/main/executors/host-file-executor.ts
+++ b/apps/macos/src/main/executors/host-file-executor.ts
@@ -1,0 +1,252 @@
+/**
+ * Host file executor — handles read/write/edit operations on the local
+ * filesystem via the host proxy bridge.
+ *
+ * Plugs into the host-proxy-router via setExecutor("host_file", ...).
+ * Results are posted back to the daemon through HostProxyPoster.postFileResult.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import type { HostProxyExecutor } from "../host-proxy-router";
+import type { HostProxyPoster } from "../host-proxy-poster";
+import type { HostProxySseMessage } from "../host-proxy-sse";
+import log from "../logger";
+
+// ---------------------------------------------------------------------------
+// Magic-byte detection helpers
+// ---------------------------------------------------------------------------
+
+/** Check leading bytes against known image signatures. */
+function isImageByMagicBytes(buf: Buffer): boolean {
+  if (buf.length < 4) return false;
+  // PNG
+  if (buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47) return true;
+  // JPEG
+  if (buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff) return true;
+  // GIF
+  if (buf[0] === 0x47 && buf[1] === 0x49 && buf[2] === 0x46) return true;
+  // BMP
+  if (buf[0] === 0x42 && buf[1] === 0x4d) return true;
+  // WebP: RIFF....WEBP
+  if (
+    buf.length >= 12 &&
+    buf[0] === 0x52 && buf[1] === 0x49 && buf[2] === 0x46 && buf[3] === 0x46 &&
+    buf[8] === 0x57 && buf[9] === 0x45 && buf[10] === 0x42 && buf[11] === 0x50
+  ) return true;
+  return false;
+}
+
+interface AudioDetection {
+  mimeType: string;
+}
+
+/** Check leading bytes against known audio signatures. Returns mime type or null. */
+function detectAudioByMagicBytes(buf: Buffer): AudioDetection | null {
+  if (buf.length < 4) return null;
+  // MP3 — ID3 tag
+  if (buf[0] === 0x49 && buf[1] === 0x44 && buf[2] === 0x33) return { mimeType: "audio/mpeg" };
+  // MP3 — sync word 0xFF 0xFB (or 0xFF 0xEx)
+  if (buf[0] === 0xff && (buf[1] & 0xe0) === 0xe0) return { mimeType: "audio/mpeg" };
+  // OGG
+  if (buf[0] === 0x4f && buf[1] === 0x67 && buf[2] === 0x67 && buf[3] === 0x53) return { mimeType: "audio/ogg" };
+  // FLAC
+  if (buf[0] === 0x66 && buf[1] === 0x4c && buf[2] === 0x61 && buf[3] === 0x43) return { mimeType: "audio/flac" };
+  // WAV: RIFF....WAVE
+  if (
+    buf.length >= 12 &&
+    buf[0] === 0x52 && buf[1] === 0x49 && buf[2] === 0x46 && buf[3] === 0x46 &&
+    buf[8] === 0x57 && buf[9] === 0x41 && buf[10] === 0x56 && buf[11] === 0x45
+  ) return { mimeType: "audio/wav" };
+  // M4A: bytes 4-7 contain "ftyp"
+  if (
+    buf.length >= 8 &&
+    buf[4] === 0x66 && buf[5] === 0x74 && buf[6] === 0x79 && buf[7] === 0x70
+  ) return { mimeType: "audio/mp4" };
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Read operation
+// ---------------------------------------------------------------------------
+
+interface ReadFields {
+  path: string;
+  offset?: number;
+  limit?: number;
+}
+
+function executeRead(fields: ReadFields): {
+  content?: string;
+  imageData?: string;
+  audioData?: string;
+  audioMimeType?: string;
+  isError?: boolean;
+} {
+  const filePath = fields.path;
+  const raw = fs.readFileSync(filePath);
+
+  // Check for image
+  if (isImageByMagicBytes(raw)) {
+    return { imageData: raw.toString("base64") };
+  }
+
+  // Check for audio
+  const audio = detectAudioByMagicBytes(raw);
+  if (audio) {
+    return { audioData: raw.toString("base64"), audioMimeType: audio.mimeType };
+  }
+
+  // Text file — apply line-based offset/limit
+  const text = raw.toString("utf-8");
+  const lines = text.split("\n");
+  const offset = fields.offset ?? 0;
+  const limit = fields.limit ?? lines.length;
+  const sliced = lines.slice(offset, offset + limit);
+  return { content: sliced.join("\n") };
+}
+
+// ---------------------------------------------------------------------------
+// Write operation
+// ---------------------------------------------------------------------------
+
+interface WriteFields {
+  path: string;
+  content: string;
+}
+
+function executeWrite(fields: WriteFields): { content?: string; isError?: boolean } {
+  const filePath = fields.path;
+  const dir = path.dirname(filePath);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(filePath, fields.content, "utf-8");
+  return { content: `Wrote ${Buffer.byteLength(fields.content, "utf-8")} bytes to ${filePath}` };
+}
+
+// ---------------------------------------------------------------------------
+// Edit operation
+// ---------------------------------------------------------------------------
+
+interface EditFields {
+  path: string;
+  old_string: string;
+  new_string: string;
+  replace_all?: boolean;
+}
+
+function executeEdit(fields: EditFields): { content?: string; isError?: boolean } {
+  const filePath = fields.path;
+  const existing = fs.readFileSync(filePath, "utf-8");
+  const { old_string, new_string, replace_all } = fields;
+
+  const firstIdx = existing.indexOf(old_string);
+  if (firstIdx === -1) {
+    return { content: `old_string not found in ${filePath}`, isError: true };
+  }
+
+  if (!replace_all) {
+    const secondIdx = existing.indexOf(old_string, firstIdx + 1);
+    if (secondIdx !== -1) {
+      return { content: `old_string is not unique in ${filePath} (use replace_all to replace all occurrences)`, isError: true };
+    }
+    const updated = existing.slice(0, firstIdx) + new_string + existing.slice(firstIdx + old_string.length);
+    fs.writeFileSync(filePath, updated, "utf-8");
+  } else {
+    const updated = existing.split(old_string).join(new_string);
+    fs.writeFileSync(filePath, updated, "utf-8");
+  }
+
+  return { content: `Edited ${filePath}` };
+}
+
+// ---------------------------------------------------------------------------
+// Executor
+// ---------------------------------------------------------------------------
+
+const pendingRequests = new Set<string>();
+
+function handleRequest(message: HostProxySseMessage, poster: HostProxyPoster): void {
+  const requestId = message.requestId as string | undefined;
+  if (!requestId) {
+    log.warn("[host-file-executor] message missing requestId");
+    return;
+  }
+
+  const operation = message.operation as string | undefined;
+  const filePath = message.path as string | undefined;
+
+  if (!operation || !filePath) {
+    void poster.postFileResult({ requestId, content: "Missing operation or path", isError: true });
+    return;
+  }
+
+  pendingRequests.add(requestId);
+
+  try {
+    let result: { content?: string; imageData?: string; audioData?: string; audioMimeType?: string; isError?: boolean };
+
+    switch (operation) {
+      case "read":
+        result = executeRead({
+          path: filePath,
+          offset: message.offset as number | undefined,
+          limit: message.limit as number | undefined,
+        });
+        break;
+      case "write":
+        result = executeWrite({
+          path: filePath,
+          content: message.content as string ?? "",
+        });
+        break;
+      case "edit":
+        result = executeEdit({
+          path: filePath,
+          old_string: message.old_string as string ?? "",
+          new_string: message.new_string as string ?? "",
+          replace_all: message.replace_all as boolean | undefined,
+        });
+        break;
+      default:
+        result = { content: `Unknown operation: ${operation}`, isError: true };
+    }
+
+    if (!pendingRequests.has(requestId)) return;
+
+    void poster.postFileResult({ requestId, ...result });
+  } catch (err: unknown) {
+    if (!pendingRequests.has(requestId)) return;
+    const errMsg = err instanceof Error ? err.message : String(err);
+    void poster.postFileResult({ requestId, content: errMsg, isError: true });
+  } finally {
+    pendingRequests.delete(requestId);
+  }
+}
+
+function handleCancel(message: HostProxySseMessage): void {
+  const requestId = message.requestId as string | undefined;
+  if (requestId) {
+    pendingRequests.delete(requestId);
+  }
+}
+
+export const hostFileExecutor: HostProxyExecutor = {
+  handleRequest,
+  handleCancel,
+};
+
+// ---------------------------------------------------------------------------
+// Test seams
+// ---------------------------------------------------------------------------
+
+export const __testing = {
+  isImageByMagicBytes,
+  detectAudioByMagicBytes,
+  executeRead,
+  executeWrite,
+  executeEdit,
+  get pendingRequests() {
+    return pendingRequests;
+  },
+};

--- a/apps/macos/src/main/host-proxy-router.ts
+++ b/apps/macos/src/main/host-proxy-router.ts
@@ -17,6 +17,7 @@ import type { Lockfile } from "@vellumai/local-mode/contract";
 
 import { HostProxySseClient, type HostProxySseMessage } from "./host-proxy-sse";
 import { HostProxyPoster } from "./host-proxy-poster";
+import { hostFileExecutor } from "./executors/host-file-executor";
 import { onLockfileChange } from "./lockfile-watcher";
 import log from "./logger";
 
@@ -238,6 +239,7 @@ export function installHostProxyBridge(
   cliResolver: () => Promise<CliInvocation>,
 ): () => void {
   resolveCliInvocation = cliResolver;
+  setExecutor("host_file", hostFileExecutor);
   unsubscribe = onLockfileChange(handleLockfileChange);
 
   return () => {


### PR DESCRIPTION
## Summary
- Implement host_file executor with read/write/edit operations
- Detect image and audio files by magic bytes, return base64
- Wire into host proxy router via setExecutor

Part of plan: electron-host-proxy-parity.md (PR 6 of 8)