### PR TITLE
feat: add host_browser executor to Electron host proxy bridge

### DIFF
--- a/apps/macos/src/main/executors/host-browser-executor.test.ts
+++ b/apps/macos/src/main/executors/host-browser-executor.test.ts
@@ -1,0 +1,510 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Stubs — must precede the executor import
+// ---------------------------------------------------------------------------
+
+const MOCK_DEVICE_ID = "test-device-00000000-0000-0000-0000-000000000000";
+mock.module("../device-id", () => ({
+  getDeviceId: () => MOCK_DEVICE_ID,
+  resetDeviceIdCache: () => {},
+}));
+
+mock.module("electron-log/main", () => {
+  const noop = () => {};
+  return {
+    default: {
+      info: noop,
+      warn: noop,
+      error: noop,
+      debug: noop,
+      initialize: noop,
+      transports: {
+        file: {
+          maxSize: 0,
+          fileName: "",
+          format: "",
+          getFile: () => ({ path: "" }),
+        },
+      },
+    },
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Mock fetch at the global level
+// ---------------------------------------------------------------------------
+
+let mockFetchImpl: typeof globalThis.fetch = async () => new Response("[]");
+
+// We need to intercept fetch calls for target discovery
+globalThis.fetch = async (...args: Parameters<typeof globalThis.fetch>) => {
+  return mockFetchImpl(...args);
+};
+
+// ---------------------------------------------------------------------------
+// Mock WebSocket
+// ---------------------------------------------------------------------------
+
+class MockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  readyState = MockWebSocket.CONNECTING;
+  url: string;
+
+  private listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+
+  constructor(url: string) {
+    this.url = url;
+    // Simulate async connection
+    setTimeout(() => {
+      if (this.readyState === MockWebSocket.CONNECTING) {
+        this.readyState = MockWebSocket.OPEN;
+        this.emit("open");
+      }
+    }, 5);
+  }
+
+  addEventListener(event: string, listener: (...args: unknown[]) => void, opts?: { once?: boolean }) {
+    if (!this.listeners.has(event)) {
+      this.listeners.set(event, new Set());
+    }
+    if (opts?.once) {
+      const wrapped = (...args: unknown[]) => {
+        this.listeners.get(event)?.delete(wrapped);
+        listener(...args);
+      };
+      this.listeners.get(event)!.add(wrapped);
+    } else {
+      this.listeners.get(event)!.add(listener);
+    }
+  }
+
+  removeEventListener(event: string, listener: (...args: unknown[]) => void) {
+    this.listeners.get(event)?.delete(listener);
+  }
+
+  emit(event: string, data?: unknown) {
+    const handlers = this.listeners.get(event);
+    if (!handlers) return;
+    for (const handler of [...handlers]) {
+      handler(data);
+    }
+  }
+
+  send = mock((_data: string) => {});
+  close = mock(() => {
+    this.readyState = MockWebSocket.CLOSED;
+  });
+}
+
+// Store created WebSocket instances for test manipulation
+let createdWebSockets: MockWebSocket[] = [];
+
+// @ts-expect-error -- mock WebSocket
+globalThis.WebSocket = class extends MockWebSocket {
+  constructor(url: string) {
+    super(url);
+    createdWebSockets.push(this);
+  }
+} as unknown as typeof WebSocket;
+
+// Static constants on the class
+Object.assign(globalThis.WebSocket, {
+  CONNECTING: 0,
+  OPEN: 1,
+  CLOSING: 2,
+  CLOSED: 3,
+});
+
+const { HostBrowserExecutor, __testing } = await import("./host-browser-executor");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function flush(ms = 30): Promise<void> {
+  await new Promise((r) => setTimeout(r, ms));
+}
+
+/** Build a page target entry as returned by /json/list. */
+function pageTarget(
+  id: string,
+  wsUrl = `ws://localhost:9222/devtools/page/${id}`,
+): Record<string, unknown> {
+  return {
+    id,
+    type: "page",
+    title: `Page ${id}`,
+    url: `http://example.com/${id}`,
+    webSocketDebuggerUrl: wsUrl,
+  };
+}
+
+/** Create a capturing poster that records all postBrowserResult calls. */
+function capturingPoster() {
+  const results: Array<{ requestId: string; content?: string; isError?: boolean }> = [];
+  return {
+    results,
+    poster: {
+      postBrowserResult: async (payload: { requestId: string; content?: string; isError?: boolean }) => {
+        results.push(payload);
+        return true;
+      },
+    } as unknown as import("../host-proxy-poster").HostProxyPoster,
+  };
+}
+
+/** Set fetch to return the given target list for /json/list. */
+function setTargets(targets: Record<string, unknown>[]) {
+  mockFetchImpl = async () => new Response(JSON.stringify(targets), { status: 200 });
+}
+
+/** Set fetch to fail. */
+function setFetchError(msg = "Connection refused") {
+  mockFetchImpl = async () => { throw new Error(msg); };
+}
+
+/**
+ * After flush, find the most recently created mock WebSocket and simulate
+ * a CDP response.
+ */
+function replyToCDP(
+  ws: MockWebSocket,
+  commandId: number,
+  result: unknown,
+) {
+  ws.emit("message", { data: JSON.stringify({ id: commandId, result }) });
+}
+
+function replyWithCDPError(
+  ws: MockWebSocket,
+  commandId: number,
+  code: number,
+  message: string,
+) {
+  ws.emit("message", { data: JSON.stringify({ id: commandId, error: { code, message } }) });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("HostBrowserExecutor", () => {
+  let executor: InstanceType<typeof HostBrowserExecutor>;
+
+  beforeEach(() => {
+    createdWebSockets = [];
+    executor = new HostBrowserExecutor();
+  });
+
+  afterEach(() => {
+    executor.destroy();
+    mockFetchImpl = async () => new Response("[]");
+  });
+
+  // -- Test seams -----------------------------------------------------------
+
+  describe("test seams", () => {
+    test("isLoopback accepts localhost, 127.0.0.1, ::1", () => {
+      expect(__testing.isLoopback("localhost")).toBe(true);
+      expect(__testing.isLoopback("127.0.0.1")).toBe(true);
+      expect(__testing.isLoopback("::1")).toBe(true);
+      expect(__testing.isLoopback("LOCALHOST")).toBe(true);
+    });
+
+    test("isLoopback rejects non-loopback hosts", () => {
+      expect(__testing.isLoopback("192.168.1.1")).toBe(false);
+      expect(__testing.isLoopback("evil.com")).toBe(false);
+      expect(__testing.isLoopback("10.0.0.1")).toBe(false);
+    });
+
+    test("transportError returns structured error payload", () => {
+      const err = __testing.transportError("req-1", "unreachable", "cannot connect");
+      expect(err.requestId).toBe("req-1");
+      expect(err.isError).toBe(true);
+      const parsed = JSON.parse(err.content);
+      expect(parsed.code).toBe("unreachable");
+      expect(parsed.message).toBe("cannot connect");
+    });
+  });
+
+  // -- Target discovery -----------------------------------------------------
+
+  describe("target discovery", () => {
+    test("filters to page targets only", async () => {
+      const targets = [
+        pageTarget("page-1"),
+        { id: "worker-1", type: "service_worker", title: "SW" },
+        pageTarget("page-2"),
+        { id: "bg-1", type: "background_page", title: "BG" },
+      ];
+      setTargets(targets);
+
+      const { poster, results } = capturingPoster();
+      executor.handleRequest(
+        { type: "host_browser_request", requestId: "r1", cdpMethod: "Runtime.evaluate", cdpParams: { expression: "1+1" } },
+        poster,
+      );
+
+      await flush(50);
+      // Should have created a WebSocket to the first page target
+      expect(createdWebSockets.length).toBeGreaterThanOrEqual(1);
+      expect(createdWebSockets[0].url).toContain("page-1");
+    });
+
+    test("returns unreachable error when Chrome is not running", async () => {
+      setFetchError("Connection refused");
+
+      const { poster, results } = capturingPoster();
+      executor.handleRequest(
+        { type: "host_browser_request", requestId: "r1", cdpMethod: "Page.navigate" },
+        poster,
+      );
+
+      await flush(50);
+      expect(results.length).toBe(1);
+      expect(results[0].isError).toBe(true);
+      const parsed = JSON.parse(results[0].content!);
+      expect(parsed.code).toBe("unreachable");
+    });
+
+    test("returns unreachable when no page targets exist", async () => {
+      setTargets([
+        { id: "sw-1", type: "service_worker", title: "SW" },
+      ]);
+
+      const { poster, results } = capturingPoster();
+      executor.handleRequest(
+        { type: "host_browser_request", requestId: "r1", cdpMethod: "Page.navigate" },
+        poster,
+      );
+
+      await flush(50);
+      expect(results.length).toBe(1);
+      const parsed = JSON.parse(results[0].content!);
+      expect(parsed.code).toBe("unreachable");
+    });
+  });
+
+  // -- Session matching -----------------------------------------------------
+
+  describe("session matching", () => {
+    test("matches target by cdpSessionId", async () => {
+      setTargets([pageTarget("target-A"), pageTarget("target-B")]);
+
+      const { poster, results } = capturingPoster();
+      executor.handleRequest(
+        {
+          type: "host_browser_request",
+          requestId: "r1",
+          cdpMethod: "Runtime.evaluate",
+          cdpSessionId: "target-B",
+        },
+        poster,
+      );
+
+      await flush(50);
+      expect(createdWebSockets.length).toBeGreaterThanOrEqual(1);
+      expect(createdWebSockets[0].url).toContain("target-B");
+    });
+
+    test("fails closed when cdpSessionId does not match any target", async () => {
+      setTargets([pageTarget("target-A")]);
+
+      const { poster, results } = capturingPoster();
+      executor.handleRequest(
+        {
+          type: "host_browser_request",
+          requestId: "r1",
+          cdpMethod: "Runtime.evaluate",
+          cdpSessionId: "nonexistent",
+        },
+        poster,
+      );
+
+      await flush(50);
+      expect(results.length).toBe(1);
+      expect(results[0].isError).toBe(true);
+      const parsed = JSON.parse(results[0].content!);
+      expect(parsed.code).toBe("cdp_session_not_found");
+    });
+  });
+
+  // -- Loopback validation --------------------------------------------------
+
+  describe("loopback validation", () => {
+    test("rejects non-loopback WebSocket URL from target", async () => {
+      setTargets([
+        pageTarget("page-1", "ws://evil.com:9222/devtools/page/page-1"),
+      ]);
+
+      const { poster, results } = capturingPoster();
+      executor.handleRequest(
+        { type: "host_browser_request", requestId: "r1", cdpMethod: "Page.navigate" },
+        poster,
+      );
+
+      await flush(50);
+      expect(results.length).toBe(1);
+      expect(results[0].isError).toBe(true);
+      const parsed = JSON.parse(results[0].content!);
+      expect(parsed.code).toBe("non_loopback");
+    });
+  });
+
+  // -- CDP command send/receive ---------------------------------------------
+
+  describe("CDP command", () => {
+    test("sends method and params, returns result", async () => {
+      setTargets([pageTarget("page-1")]);
+
+      const { poster, results } = capturingPoster();
+      executor.handleRequest(
+        {
+          type: "host_browser_request",
+          requestId: "r1",
+          cdpMethod: "Runtime.evaluate",
+          cdpParams: { expression: "document.title" },
+        },
+        poster,
+      );
+
+      await flush(50);
+      const ws = createdWebSockets[0];
+      expect(ws).toBeDefined();
+      expect(ws.send).toHaveBeenCalled();
+
+      // Parse the sent message to find command id
+      const sentData = JSON.parse((ws.send as ReturnType<typeof mock>).mock.calls[0][0] as string);
+      expect(sentData.method).toBe("Runtime.evaluate");
+      expect(sentData.params.expression).toBe("document.title");
+
+      // Reply
+      replyToCDP(ws, sentData.id, { result: { type: "string", value: "Test Page" } });
+      await flush(50);
+
+      expect(results.length).toBe(1);
+      expect(results[0].isError).toBe(false);
+      const parsed = JSON.parse(results[0].content!);
+      expect(parsed.result.value).toBe("Test Page");
+    });
+
+    test("returns CDP protocol error with isError true", async () => {
+      setTargets([pageTarget("page-1")]);
+
+      const { poster, results } = capturingPoster();
+      executor.handleRequest(
+        {
+          type: "host_browser_request",
+          requestId: "r1",
+          cdpMethod: "DOM.getDocument",
+        },
+        poster,
+      );
+
+      await flush(50);
+      const ws = createdWebSockets[0];
+      const sentData = JSON.parse((ws.send as ReturnType<typeof mock>).mock.calls[0][0] as string);
+
+      replyWithCDPError(ws, sentData.id, -32000, "Cannot find context");
+      await flush(50);
+
+      expect(results.length).toBe(1);
+      expect(results[0].isError).toBe(true);
+      const parsed = JSON.parse(results[0].content!);
+      expect(parsed.code).toBe(-32000);
+      expect(parsed.message).toBe("Cannot find context");
+    });
+  });
+
+  // -- Timeout --------------------------------------------------------------
+
+  describe("timeout", () => {
+    test("times out after configured seconds", async () => {
+      setTargets([pageTarget("page-1")]);
+
+      const { poster, results } = capturingPoster();
+      // Use a very short timeout for testing
+      executor.handleRequest(
+        {
+          type: "host_browser_request",
+          requestId: "r1",
+          cdpMethod: "Page.navigate",
+          timeout_seconds: 0.05,
+        },
+        poster,
+      );
+
+      // Wait longer than the timeout
+      await flush(200);
+
+      expect(results.length).toBe(1);
+      expect(results[0].isError).toBe(true);
+      const parsed = JSON.parse(results[0].content!);
+      expect(parsed.code).toBe("timeout");
+    });
+  });
+
+  // -- Cancellation ---------------------------------------------------------
+
+  describe("cancellation", () => {
+    test("pre-flight cancellation suppresses execution", async () => {
+      setTargets([pageTarget("page-1")]);
+
+      // Cancel before the request even starts executing
+      executor.handleCancel(
+        { type: "host_browser_cancel", requestId: "r1" },
+        {} as import("../host-proxy-poster").HostProxyPoster,
+      );
+
+      const { poster, results } = capturingPoster();
+      executor.handleRequest(
+        { type: "host_browser_request", requestId: "r1", cdpMethod: "Page.navigate" },
+        poster,
+      );
+
+      await flush(100);
+      // No result should be posted
+      expect(results.length).toBe(0);
+    });
+
+    test("in-flight cancellation aborts pending request", async () => {
+      setTargets([pageTarget("page-1")]);
+
+      const { poster, results } = capturingPoster();
+      executor.handleRequest(
+        { type: "host_browser_request", requestId: "r1", cdpMethod: "Page.navigate" },
+        poster,
+      );
+
+      await flush(50);
+      // Cancel while in flight
+      executor.handleCancel(
+        { type: "host_browser_cancel", requestId: "r1" },
+        poster,
+      );
+
+      await flush(100);
+      // No successful result should be posted (timeout/cancel errors may or may not appear)
+      const nonError = results.filter((r) => !r.isError);
+      expect(nonError.length).toBe(0);
+    });
+  });
+
+  // -- Missing requestId ---------------------------------------------------
+
+  describe("edge cases", () => {
+    test("ignores messages without requestId", () => {
+      const { poster, results } = capturingPoster();
+      executor.handleRequest(
+        { type: "host_browser_request" },
+        poster,
+      );
+      expect(results.length).toBe(0);
+    });
+  });
+});

--- a/apps/macos/src/main/executors/host-browser-executor.ts
+++ b/apps/macos/src/main/executors/host-browser-executor.ts
@@ -1,0 +1,493 @@
+/**
+ * Host browser executor — sends CDP commands to a local Chrome instance and
+ * returns results to the daemon via the host proxy poster.
+ *
+ * Mirrors the Swift HostBrowserExecutor: target discovery via /json/list,
+ * loopback-only security validation, WebSocket CDP JSON-RPC, session
+ * matching by target id, connection pooling with idle timeout, and
+ * cooperative cancellation.
+ */
+
+import type { HostProxyExecutor } from "../host-proxy-router";
+import type { HostProxySseMessage } from "../host-proxy-sse";
+import type { HostProxyPoster } from "../host-proxy-poster";
+import log from "../logger";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEFAULT_CDP_PORT = 9222;
+const DEFAULT_TIMEOUT_SECONDS = 30;
+const IDLE_CLOSE_MS = 30_000;
+const ALLOWED_LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
+
+// ---------------------------------------------------------------------------
+// CDP Error type
+// ---------------------------------------------------------------------------
+
+class CDPError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "CDPError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Connection pool entry
+// ---------------------------------------------------------------------------
+
+interface PoolEntry {
+  ws: WebSocket;
+  idleTimer: ReturnType<typeof setTimeout>;
+}
+
+// ---------------------------------------------------------------------------
+// In-flight request tracking
+// ---------------------------------------------------------------------------
+
+interface InFlightRequest {
+  abortController: AbortController;
+  timeoutTimer: ReturnType<typeof setTimeout>;
+  ws: WebSocket | null;
+  settled: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Transport error helper
+// ---------------------------------------------------------------------------
+
+function transportError(
+  requestId: string,
+  code: string,
+  message: string,
+): { requestId: string; content: string; isError: true } {
+  const payload = JSON.stringify({ code, message });
+  log.error(`[host-browser] transport error: ${code} — ${message}`, { requestId });
+  return { requestId, content: payload, isError: true };
+}
+
+// ---------------------------------------------------------------------------
+// Loopback validation
+// ---------------------------------------------------------------------------
+
+function isLoopback(host: string): boolean {
+  return ALLOWED_LOOPBACK_HOSTS.has(host.toLowerCase());
+}
+
+// ---------------------------------------------------------------------------
+// HostBrowserExecutor
+// ---------------------------------------------------------------------------
+
+export class HostBrowserExecutor implements HostProxyExecutor {
+  private readonly pool = new Map<string, PoolEntry>();
+  private readonly inFlight = new Map<string, InFlightRequest>();
+  private readonly cancelledIds = new Map<string, number>();
+  private nextCommandId = 1;
+
+  // -- HostProxyExecutor interface ------------------------------------------
+
+  handleRequest(message: HostProxySseMessage, poster: HostProxyPoster): void {
+    const requestId = message.requestId as string | undefined;
+    if (!requestId) {
+      log.warn("[host-browser] message missing requestId");
+      return;
+    }
+
+    // Pre-flight cancellation check
+    if (this.consumeCancelled(requestId)) {
+      log.debug("[host-browser] skipped (pre-cancelled)", { requestId });
+      return;
+    }
+
+    void this.execute(message, poster).catch((err) => {
+      log.error("[host-browser] unexpected top-level error", { requestId, err });
+    });
+  }
+
+  handleCancel(message: HostProxySseMessage, poster: HostProxyPoster): void {
+    const requestId = message.requestId as string | undefined;
+    if (!requestId) return;
+
+    this.markCancelled(requestId);
+    const pending = this.inFlight.get(requestId);
+    if (pending) {
+      pending.abortController.abort();
+      clearTimeout(pending.timeoutTimer);
+      if (pending.ws && pending.ws.readyState === WebSocket.OPEN) {
+        pending.ws.close();
+      }
+      pending.settled = true;
+      this.inFlight.delete(requestId);
+    }
+    log.info("[host-browser] cancelled", { requestId });
+  }
+
+  // -- Teardown -------------------------------------------------------------
+
+  destroy(): void {
+    for (const [id, entry] of this.pool) {
+      clearTimeout(entry.idleTimer);
+      if (entry.ws.readyState === WebSocket.OPEN) {
+        entry.ws.close();
+      }
+      this.pool.delete(id);
+    }
+    for (const [id, req] of this.inFlight) {
+      req.abortController.abort();
+      clearTimeout(req.timeoutTimer);
+      req.settled = true;
+      this.inFlight.delete(id);
+    }
+  }
+
+  // -- Main execution flow --------------------------------------------------
+
+  private async execute(
+    message: HostProxySseMessage,
+    poster: HostProxyPoster,
+  ): Promise<void> {
+    const requestId = message.requestId as string;
+    const cdpMethod = (message.cdpMethod as string) ?? "";
+    const cdpParams = message.cdpParams as Record<string, unknown> | undefined;
+    const cdpSessionId = message.cdpSessionId as string | undefined;
+    const rawTimeout = (message.timeout_seconds as number) ?? DEFAULT_TIMEOUT_SECONDS;
+    const timeoutSeconds =
+      typeof rawTimeout === "number" && isFinite(rawTimeout) && rawTimeout >= 0 && rawTimeout <= 18_000_000_000
+        ? rawTimeout
+        : DEFAULT_TIMEOUT_SECONDS;
+    const host = "localhost";
+    const port = DEFAULT_CDP_PORT;
+
+    // Set up abort / timeout tracking
+    const abortController = new AbortController();
+    const timeoutTimer = setTimeout(() => {
+      abortController.abort();
+      const pending = this.inFlight.get(requestId);
+      if (pending && !pending.settled) {
+        pending.settled = true;
+        this.inFlight.delete(requestId);
+        void poster.postBrowserResult(
+          transportError(requestId, "timeout", `CDP command '${cdpMethod}' timed out after ${timeoutSeconds}s`),
+        );
+      }
+    }, timeoutSeconds * 1000);
+
+    const flight: InFlightRequest = {
+      abortController,
+      timeoutTimer,
+      ws: null,
+      settled: false,
+    };
+    this.inFlight.set(requestId, flight);
+
+    try {
+      // Step 1: Target discovery
+      const targets = await this.fetchTargets(host, port, abortController.signal, timeoutSeconds);
+
+      // Step 2: Select a page target
+      const pageTargets = targets.filter(
+        (t: Record<string, unknown>) => t.type === "page",
+      );
+
+      let selectedTarget: Record<string, unknown> | undefined;
+      if (cdpSessionId) {
+        selectedTarget = pageTargets.find(
+          (t: Record<string, unknown>) => t.id === cdpSessionId,
+        );
+        if (!selectedTarget) {
+          this.settle(requestId);
+          void poster.postBrowserResult(
+            transportError(
+              requestId,
+              "cdp_session_not_found",
+              `cdpSessionId '${cdpSessionId}' did not match any page target in /json/list. The target may have been closed or navigated.`,
+            ),
+          );
+          return;
+        }
+      } else {
+        selectedTarget = pageTargets[0];
+      }
+
+      if (!selectedTarget || typeof selectedTarget.webSocketDebuggerUrl !== "string") {
+        this.settle(requestId);
+        void poster.postBrowserResult(
+          transportError(
+            requestId,
+            "unreachable",
+            `No debuggable page target found at ${host}:${port}. Ensure Chrome is running with --remote-debugging-port=${port}.`,
+          ),
+        );
+        return;
+      }
+
+      const wsUrl = selectedTarget.webSocketDebuggerUrl as string;
+
+      // Validate WebSocket URL is loopback
+      let wsHost: string;
+      try {
+        const parsed = new URL(wsUrl);
+        wsHost = parsed.hostname;
+      } catch {
+        this.settle(requestId);
+        void poster.postBrowserResult(
+          transportError(requestId, "transport_error", `Chrome returned an invalid WebSocket URL: ${wsUrl}`),
+        );
+        return;
+      }
+
+      if (!isLoopback(wsHost)) {
+        this.settle(requestId);
+        void poster.postBrowserResult(
+          transportError(
+            requestId,
+            "non_loopback",
+            `WebSocket URL host '${wsHost}' is not a loopback address. Only localhost, 127.0.0.1, and ::1 are permitted.`,
+          ),
+        );
+        return;
+      }
+
+      // Step 3: Send CDP command via WebSocket
+      const targetId = selectedTarget.id as string;
+      const result = await this.sendCDPCommand(wsUrl, targetId, cdpMethod, cdpParams, flight);
+
+      if (this.consumeCancelled(requestId)) {
+        log.debug("[host-browser] result suppressed (cancelled)", { requestId });
+        this.settle(requestId);
+        return;
+      }
+
+      this.settle(requestId);
+      void poster.postBrowserResult({ requestId, content: result, isError: false });
+    } catch (err) {
+      if (flight.settled) return;
+      this.settle(requestId);
+
+      if (this.consumeCancelled(requestId)) {
+        log.debug("[host-browser] error suppressed (cancelled)", { requestId });
+        return;
+      }
+
+      if (err instanceof CDPError) {
+        if (err.code === "protocol_error") {
+          // Protocol errors carry the CDP error code in the message as "code:message"
+          void poster.postBrowserResult({ requestId, content: err.message, isError: true });
+        } else {
+          void poster.postBrowserResult(transportError(requestId, err.code, err.message));
+        }
+      } else if (abortController.signal.aborted) {
+        // Timeout or cancellation already handled
+      } else {
+        void poster.postBrowserResult(
+          transportError(
+            requestId,
+            "transport_error",
+            `Unexpected error executing CDP command: ${err instanceof Error ? err.message : String(err)}`,
+          ),
+        );
+      }
+    }
+  }
+
+  // -- Target discovery -----------------------------------------------------
+
+  private async fetchTargets(
+    host: string,
+    port: number,
+    signal: AbortSignal,
+    timeoutSeconds: number,
+  ): Promise<Record<string, unknown>[]> {
+    const url = `http://${host}:${port}/json/list`;
+    const controller = new AbortController();
+
+    // Link outer abort to our fetch
+    const onAbort = () => controller.abort();
+    signal.addEventListener("abort", onAbort, { once: true });
+
+    const timer = setTimeout(() => controller.abort(), timeoutSeconds * 1000);
+    try {
+      const response = await fetch(url, { signal: controller.signal });
+      if (!response.ok) {
+        throw new CDPError(
+          "unreachable",
+          `HTTP ${response.status} from ${url}`,
+        );
+      }
+      const json = await response.json();
+      if (!Array.isArray(json)) {
+        throw new CDPError("unreachable", `Invalid JSON response from ${url}`);
+      }
+      return json as Record<string, unknown>[];
+    } catch (err) {
+      if (err instanceof CDPError) throw err;
+      throw new CDPError(
+        "unreachable",
+        `Failed to connect to Chrome DevTools at ${host}:${port}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", onAbort);
+    }
+  }
+
+  // -- CDP command over WebSocket -------------------------------------------
+
+  private sendCDPCommand(
+    wsUrl: string,
+    targetId: string,
+    method: string,
+    params: Record<string, unknown> | undefined,
+    flight: InFlightRequest,
+  ): Promise<string> {
+    const commandId = this.nextCommandId++;
+
+    return new Promise<string>((resolve, reject) => {
+      if (flight.abortController.signal.aborted) {
+        reject(new CDPError("cancelled", "CDP command cancelled"));
+        return;
+      }
+
+      // Use pooled connection or create a new one
+      let ws: WebSocket;
+      const pooled = this.pool.get(targetId);
+      if (pooled && pooled.ws.readyState === WebSocket.OPEN) {
+        clearTimeout(pooled.idleTimer);
+        ws = pooled.ws;
+      } else {
+        // Clean up stale pool entry if any
+        if (pooled) {
+          clearTimeout(pooled.idleTimer);
+          this.pool.delete(targetId);
+        }
+        ws = new WebSocket(wsUrl);
+      }
+
+      flight.ws = ws;
+
+      const message: Record<string, unknown> = { id: commandId, method };
+      if (params) {
+        message.params = params;
+      }
+
+      const onAbort = () => {
+        cleanup();
+        reject(new CDPError("cancelled", "CDP command cancelled"));
+      };
+
+      const onMessage = (event: MessageEvent) => {
+        try {
+          const data = JSON.parse(typeof event.data === "string" ? event.data : String(event.data));
+          if (data.id !== commandId) return; // Not our response, keep listening
+
+          cleanup();
+
+          if (data.error) {
+            const code = data.error.code ?? -1;
+            const msg = data.error.message ?? "Unknown CDP error";
+            const errorPayload = JSON.stringify({ code, message: msg });
+            reject(new CDPError("protocol_error", errorPayload));
+            return;
+          }
+
+          const result = data.result !== undefined ? JSON.stringify(data.result) : "{}";
+          resolve(result);
+        } catch {
+          // Malformed JSON, keep listening
+        }
+      };
+
+      const onError = () => {
+        cleanup();
+        this.pool.delete(targetId);
+        reject(new CDPError("transport_error", "WebSocket connection to Chrome DevTools failed"));
+      };
+
+      const onClose = () => {
+        cleanup();
+        this.pool.delete(targetId);
+        // Only reject if not already settled
+        reject(new CDPError("transport_error", "WebSocket closed before receiving response"));
+      };
+
+      const cleanup = () => {
+        flight.abortController.signal.removeEventListener("abort", onAbort);
+        ws.removeEventListener("message", onMessage);
+        ws.removeEventListener("error", onError);
+        ws.removeEventListener("close", onClose);
+
+        // Return to pool with idle timeout
+        if (ws.readyState === WebSocket.OPEN) {
+          const idleTimer = setTimeout(() => {
+            this.pool.delete(targetId);
+            if (ws.readyState === WebSocket.OPEN) ws.close();
+          }, IDLE_CLOSE_MS);
+          this.pool.set(targetId, { ws, idleTimer });
+        }
+      };
+
+      flight.abortController.signal.addEventListener("abort", onAbort, { once: true });
+      ws.addEventListener("message", onMessage);
+      ws.addEventListener("error", onError);
+      ws.addEventListener("close", onClose);
+
+      const sendCommand = () => {
+        ws.send(JSON.stringify(message));
+      };
+
+      if (ws.readyState === WebSocket.OPEN) {
+        sendCommand();
+      } else if (ws.readyState === WebSocket.CONNECTING) {
+        ws.addEventListener("open", sendCommand, { once: true });
+      } else {
+        cleanup();
+        this.pool.delete(targetId);
+        reject(new CDPError("transport_error", "WebSocket is not in a connectable state"));
+      }
+    });
+  }
+
+  // -- Cancellation tracking ------------------------------------------------
+
+  private markCancelled(requestId: string): void {
+    const now = Date.now();
+    this.cancelledIds.set(requestId, now);
+    // Sweep entries older than 30s
+    for (const [id, ts] of this.cancelledIds) {
+      if (now - ts >= 30_000) this.cancelledIds.delete(id);
+    }
+  }
+
+  private consumeCancelled(requestId: string): boolean {
+    return this.cancelledIds.delete(requestId);
+  }
+
+  // -- Helpers --------------------------------------------------------------
+
+  private settle(requestId: string): void {
+    const pending = this.inFlight.get(requestId);
+    if (pending) {
+      clearTimeout(pending.timeoutTimer);
+      pending.settled = true;
+      this.inFlight.delete(requestId);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test seams
+// ---------------------------------------------------------------------------
+
+export const __testing = {
+  CDPError,
+  transportError,
+  isLoopback,
+  DEFAULT_CDP_PORT,
+  DEFAULT_TIMEOUT_SECONDS,
+  IDLE_CLOSE_MS,
+  ALLOWED_LOOPBACK_HOSTS,
+};

--- a/apps/macos/src/main/host-proxy-router.ts
+++ b/apps/macos/src/main/host-proxy-router.ts
@@ -18,10 +18,11 @@ import type { Lockfile } from "@vellumai/local-mode/contract";
 import { HostProxySseClient, type HostProxySseMessage } from "./host-proxy-sse";
 import { HostProxyPoster } from "./host-proxy-poster";
 import { onLockfileChange } from "./lockfile-watcher";
+import { HostBrowserExecutor } from "./executors/host-browser-executor";
 import log from "./logger";
 
 // ---------------------------------------------------------------------------
-// Executor interface — PRs 5-8 plug in via setExecutor()
+// Executor interface
 // ---------------------------------------------------------------------------
 
 export interface HostProxyExecutor {
@@ -240,12 +241,18 @@ export function installHostProxyBridge(
   resolveCliInvocation = cliResolver;
   unsubscribe = onLockfileChange(handleLockfileChange);
 
+  // Register built-in executors
+  const browserExecutor = new HostBrowserExecutor();
+  setExecutor("host_browser", browserExecutor);
+
   return () => {
     unsubscribe?.();
     unsubscribe = null;
     for (const assistantId of [...connections.keys()]) {
       disconnectAssistant(assistantId);
     }
+    browserExecutor.destroy();
+    removeExecutor("host_browser");
     resolveCliInvocation = null;
   };
 }


### PR DESCRIPTION
## Summary
- Implement host_browser executor with CDP target discovery and WebSocket client
- Connection pooling with idle timeout, loopback security validation
- Wire into host proxy router via setExecutor

Part of plan: electron-host-proxy-parity.md (PR 8 of 8)