### PR TITLE
feat: add host proxy parity to Electron macOS app

### DIFF
--- a/apps/macos/src/main/device-id.test.ts
+++ b/apps/macos/src/main/device-id.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DIR = path.join(os.tmpdir(), `device-id-test-${process.pid}`);
+const DEVICE_FILE = path.join(TEST_DIR, "device.json");
+
+// Stub @vellumai/local-mode so we control the resolved paths.
+let mockEnvironment = "dev";
+mock.module("@vellumai/local-mode", () => ({
+  resolveConfigDir: () => TEST_DIR,
+  resolveEnvironmentName: () => mockEnvironment,
+}));
+
+const { getDeviceId, resetDeviceIdCache } = await import("./device-id");
+
+const cleanup = (): void => {
+  resetDeviceIdCache();
+  try {
+    fs.rmSync(TEST_DIR, { recursive: true, force: true });
+  } catch {
+    // already gone
+  }
+};
+
+beforeEach(() => {
+  cleanup();
+  fs.mkdirSync(TEST_DIR, { recursive: true });
+});
+
+afterEach(cleanup);
+
+describe("device-id", () => {
+  test("reads existing device.json and returns the deviceId", () => {
+    /**
+     * Tests that when device.json already exists with a valid deviceId,
+     * getDeviceId returns that value without overwriting it.
+     */
+
+    // GIVEN a device.json with a known UUID
+    const existingId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+    fs.writeFileSync(
+      DEVICE_FILE,
+      JSON.stringify({ deviceId: existingId }, null, 2) + "\n",
+    );
+
+    // WHEN getDeviceId is called
+    const result = getDeviceId();
+
+    // THEN it returns the existing ID
+    expect(result).toBe(existingId);
+  });
+
+  test("creates device.json when the file does not exist", () => {
+    /**
+     * Tests that when no device.json exists, getDeviceId generates a new
+     * UUID, writes it to disk, and returns it.
+     */
+
+    // GIVEN no device.json on disk
+    expect(fs.existsSync(DEVICE_FILE)).toBe(false);
+
+    // WHEN getDeviceId is called
+    const result = getDeviceId();
+
+    // THEN it returns a valid UUID
+    expect(result).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+
+    // AND the file is created on disk with the same ID
+    const onDisk = JSON.parse(fs.readFileSync(DEVICE_FILE, "utf-8"));
+    expect(onDisk.deviceId).toBe(result);
+  });
+
+  test("caches the result after the first call", () => {
+    /**
+     * Tests that subsequent calls return the same value without re-reading
+     * disk. Verified by changing the file between calls.
+     */
+
+    // GIVEN getDeviceId has been called once
+    const firstResult = getDeviceId();
+
+    // WHEN the on-disk file is changed
+    fs.writeFileSync(
+      DEVICE_FILE,
+      JSON.stringify({ deviceId: "changed-id" }, null, 2) + "\n",
+    );
+
+    // THEN the second call still returns the cached value
+    expect(getDeviceId()).toBe(firstResult);
+  });
+
+  test("handles malformed JSON gracefully", () => {
+    /**
+     * Tests that a corrupted device.json doesn't crash the process — the
+     * function generates a new UUID and overwrites the file.
+     */
+
+    // GIVEN a device.json with invalid JSON
+    fs.writeFileSync(DEVICE_FILE, "not valid json {{{");
+
+    // WHEN getDeviceId is called
+    const result = getDeviceId();
+
+    // THEN it returns a valid UUID
+    expect(result).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+
+    // AND the file is overwritten with valid JSON
+    const onDisk = JSON.parse(fs.readFileSync(DEVICE_FILE, "utf-8"));
+    expect(onDisk.deviceId).toBe(result);
+  });
+
+  test("handles device.json with missing deviceId field", () => {
+    /**
+     * Tests that a device.json without a deviceId field is treated the same
+     * as a missing file — a new UUID is generated and the field is added
+     * while preserving other content.
+     */
+
+    // GIVEN a device.json with other fields but no deviceId
+    fs.writeFileSync(
+      DEVICE_FILE,
+      JSON.stringify({ otherField: "preserved" }, null, 2) + "\n",
+    );
+
+    // WHEN getDeviceId is called
+    const result = getDeviceId();
+
+    // THEN it returns a valid UUID
+    expect(result).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+
+    // AND the existing field is preserved alongside the new deviceId
+    const onDisk = JSON.parse(fs.readFileSync(DEVICE_FILE, "utf-8"));
+    expect(onDisk.deviceId).toBe(result);
+    expect(onDisk.otherField).toBe("preserved");
+  });
+
+  test("resetDeviceIdCache forces re-read on next call", () => {
+    /**
+     * Tests that resetDeviceIdCache clears the in-memory cache so the next
+     * getDeviceId call reads from disk again.
+     */
+
+    // GIVEN getDeviceId has been called and cached
+    const firstResult = getDeviceId();
+
+    // WHEN the cache is reset and the file is updated
+    resetDeviceIdCache();
+    const newId = "11111111-2222-3333-4444-555555555555";
+    fs.writeFileSync(
+      DEVICE_FILE,
+      JSON.stringify({ deviceId: newId }, null, 2) + "\n",
+    );
+
+    // THEN the next call reads the new value from disk
+    const secondResult = getDeviceId();
+    expect(secondResult).toBe(newId);
+    expect(secondResult).not.toBe(firstResult);
+  });
+
+  test("creates parent directories when they do not exist", () => {
+    /**
+     * Tests that getDeviceId creates the config directory tree if it
+     * doesn't exist yet (first-run scenario).
+     */
+
+    // GIVEN the entire test directory has been removed
+    fs.rmSync(TEST_DIR, { recursive: true, force: true });
+
+    // WHEN getDeviceId is called
+    const result = getDeviceId();
+
+    // THEN it returns a valid UUID and the directory + file were created
+    expect(result).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+    expect(fs.existsSync(DEVICE_FILE)).toBe(true);
+  });
+});

--- a/apps/macos/src/main/device-id.ts
+++ b/apps/macos/src/main/device-id.ts
@@ -1,0 +1,94 @@
+/**
+ * Device ID resolver for the Electron main process.
+ *
+ * Reads or creates a stable per-device UUID stored in device.json. The file
+ * is shared with the daemon (TypeScript) and Swift client so all three
+ * runtimes use the same identifier for X-Vellum-Client-Id headers.
+ *
+ * Path resolution mirrors VellumPaths.deviceIdFile (Swift) and
+ * assistant/src/util/device-id.ts (daemon):
+ *   - Production:     ~/.vellum/device.json  (legacy shared path)
+ *   - Non-production: <configDir>/device.json where configDir is
+ *                     $XDG_CONFIG_HOME/vellum-<env>
+ */
+
+import { randomUUID } from "node:crypto";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { resolveConfigDir, resolveEnvironmentName } from "@vellumai/local-mode";
+
+let cached: string | undefined;
+
+/**
+ * Resolve the directory containing device.json. Production uses the legacy
+ * ~/.vellum path (shared with the Swift client and daemon); non-production
+ * uses resolveConfigDir from @vellumai/local-mode.
+ */
+function resolveDeviceDir(): string {
+  const env = resolveEnvironmentName(process.env);
+  if (env === "production") {
+    return join(homedir(), ".vellum");
+  }
+  return resolveConfigDir(process.env);
+}
+
+/**
+ * Get the stable device ID for this machine.
+ *
+ * Resolution order:
+ *   1. Cached in-memory value (populated on first call)
+ *   2. deviceId field from device.json
+ *   3. Generate a new UUID, persist it to device.json, and return it
+ *
+ * On any read/write error the generated UUID is still cached so the
+ * process uses a consistent ID for the remainder of its lifetime.
+ */
+export function getDeviceId(): string {
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const dir = resolveDeviceDir();
+  const filePath = join(dir, "device.json");
+
+  // Try to read an existing device.json, keeping the parsed object for
+  // field preservation if we need to write back.
+  let existing: Record<string, unknown> = {};
+  try {
+    const raw = JSON.parse(readFileSync(filePath, "utf-8"));
+    if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+      existing = raw as Record<string, unknown>;
+      if (typeof existing.deviceId === "string" && existing.deviceId.length > 0) {
+        cached = existing.deviceId as string;
+        return cached;
+      }
+    }
+  } catch {
+    // Missing or malformed — fall through to generate
+  }
+
+  // Generate a new UUID and persist it.
+  const generated = randomUUID();
+  try {
+    mkdirSync(dir, { recursive: true });
+    existing.deviceId = generated;
+    writeFileSync(filePath, JSON.stringify(existing, null, 2) + "\n", {
+      mode: 0o644,
+    });
+  } catch {
+    // Write failed — use generated ID in-memory only
+  }
+
+  cached = generated;
+  return cached;
+}
+
+/**
+ * Reset the cached device ID. Used by tests to force
+ * re-resolution on the next call.
+ */
+export function resetDeviceIdCache(): void {
+  cached = undefined;
+}

--- a/apps/macos/src/main/executors/host-bash-executor.test.ts
+++ b/apps/macos/src/main/executors/host-bash-executor.test.ts
@@ -1,0 +1,226 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Stubs — must precede executor import
+// ---------------------------------------------------------------------------
+
+const MOCK_DEVICE_ID = "test-device-00000000-0000-0000-0000-000000000000";
+mock.module("../device-id", () => ({
+  getDeviceId: () => MOCK_DEVICE_ID,
+  resetDeviceIdCache: () => {},
+}));
+
+// Stub electron-log
+mock.module("electron-log/main", () => {
+  const noop = () => {};
+  return {
+    default: {
+      info: noop,
+      warn: noop,
+      error: noop,
+      debug: noop,
+      initialize: noop,
+      transports: { file: { maxSize: 0, fileName: "", format: "", getFile: () => ({ path: "" }) } },
+    },
+  };
+});
+
+// Stub lockfile-watcher (required by host-proxy-router)
+mock.module("../lockfile-watcher", () => ({
+  onLockfileChange: () => () => {},
+}));
+
+// Stub @vellumai/local-mode (required by host-proxy-router)
+mock.module("@vellumai/local-mode", () => ({
+  getGuardianAccessToken: async () => ({ ok: true, accessToken: "test-token" }),
+  resolveConfigDir: () => "/tmp/test-config",
+}));
+
+const { HostProxyPoster } = await import("../host-proxy-poster");
+const { hostBashExecutor, __testing: executorTesting } = await import("./host-bash-executor");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function flush(ms = 50): Promise<void> {
+  await new Promise((r) => setTimeout(r, ms));
+}
+
+interface CapturedPost {
+  url: string;
+  body: Record<string, unknown>;
+}
+
+function capturingPoster(): { poster: InstanceType<typeof HostProxyPoster>; posts: () => CapturedPost[] } {
+  const captured: CapturedPost[] = [];
+  const fakeFetch = async (url: unknown, init?: RequestInit) => {
+    captured.push({ url: String(url), body: JSON.parse(init?.body as string) });
+    return new Response("ok");
+  };
+  const poster = new HostProxyPoster({
+    gatewayPort: 9000,
+    authToken: "t",
+    fetch: fakeFetch as typeof globalThis.fetch,
+  });
+  return { poster, posts: () => captured };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("host-bash-executor", () => {
+  afterEach(() => {
+    // Clean up any lingering processes
+    for (const [, entry] of executorTesting.runningProcesses) {
+      try { entry.child.kill("SIGKILL"); } catch { /* already exited */ }
+    }
+    executorTesting.runningProcesses.clear();
+  });
+
+  test("executes a command and posts result", async () => {
+    const { poster, posts } = capturingPoster();
+
+    hostBashExecutor.handleRequest(
+      { type: "host_bash_request", requestId: "r1", command: "echo hello" },
+      poster,
+    );
+
+    // Wait for process to complete
+    await flush(500);
+
+    expect(posts().length).toBe(1);
+    const result = posts()[0].body;
+    expect(result.requestId).toBe("r1");
+    expect((result.stdout as string).trim()).toBe("hello");
+    expect(result.exitCode).toBe(0);
+    expect(result.timedOut).toBe(false);
+  });
+
+  test("captures stderr output", async () => {
+    const { poster, posts } = capturingPoster();
+
+    hostBashExecutor.handleRequest(
+      { type: "host_bash_request", requestId: "r2", command: "echo err >&2" },
+      poster,
+    );
+
+    await flush(500);
+
+    expect(posts().length).toBe(1);
+    expect((posts()[0].body.stderr as string).trim()).toBe("err");
+  });
+
+  test("reports non-zero exit code", async () => {
+    const { poster, posts } = capturingPoster();
+
+    hostBashExecutor.handleRequest(
+      { type: "host_bash_request", requestId: "r3", command: "exit 42" },
+      poster,
+    );
+
+    await flush(500);
+
+    expect(posts().length).toBe(1);
+    expect(posts()[0].body.exitCode).toBe(42);
+  });
+
+  test("times out and sends SIGTERM then SIGKILL", async () => {
+    const { poster, posts } = capturingPoster();
+
+    hostBashExecutor.handleRequest(
+      {
+        type: "host_bash_request",
+        requestId: "r4",
+        command: "sleep 60",
+        timeout_seconds: 1,
+      },
+      poster,
+    );
+
+    // Wait for timeout + SIGKILL grace period + buffer
+    await flush(4_000);
+
+    expect(posts().length).toBe(1);
+    expect(posts()[0].body.timedOut).toBe(true);
+    expect(posts()[0].body.requestId).toBe("r4");
+  });
+
+  test("cancellation terminates process and suppresses result", async () => {
+    const { poster, posts } = capturingPoster();
+
+    hostBashExecutor.handleRequest(
+      { type: "host_bash_request", requestId: "r5", command: "sleep 60" },
+      poster,
+    );
+
+    await flush(100);
+    expect(executorTesting.runningProcesses.has("r5")).toBe(true);
+
+    hostBashExecutor.handleCancel(
+      { type: "host_bash_cancel", requestId: "r5" },
+      poster,
+    );
+
+    await flush(3_000);
+
+    // Result should be suppressed
+    expect(posts().length).toBe(0);
+    expect(executorTesting.runningProcesses.has("r5")).toBe(false);
+  });
+
+  test("merges environment variables", async () => {
+    const { poster, posts } = capturingPoster();
+
+    hostBashExecutor.handleRequest(
+      {
+        type: "host_bash_request",
+        requestId: "r6",
+        command: 'echo "$TEST_BASH_VAR"',
+        env: { TEST_BASH_VAR: "custom_value" },
+      },
+      poster,
+    );
+
+    await flush(500);
+
+    expect(posts().length).toBe(1);
+    expect((posts()[0].body.stdout as string).trim()).toBe("custom_value");
+  });
+
+  test("uses specified working directory", async () => {
+    const { poster, posts } = capturingPoster();
+
+    hostBashExecutor.handleRequest(
+      {
+        type: "host_bash_request",
+        requestId: "r7",
+        command: "pwd",
+        working_dir: "/tmp",
+      },
+      poster,
+    );
+
+    await flush(500);
+
+    expect(posts().length).toBe(1);
+    // On macOS /tmp is a symlink to /private/tmp
+    expect((posts()[0].body.stdout as string).trim()).toMatch(/\/tmp$/);
+  });
+
+  test("returns error for missing command", async () => {
+    const { poster, posts } = capturingPoster();
+
+    hostBashExecutor.handleRequest(
+      { type: "host_bash_request", requestId: "r8" },
+      poster,
+    );
+
+    await flush(100);
+
+    expect(posts().length).toBe(1);
+    expect(posts()[0].body.stderr).toBe("Missing command");
+    expect(posts()[0].body.exitCode).toBe(1);
+  });
+});

--- a/apps/macos/src/main/executors/host-bash-executor.ts
+++ b/apps/macos/src/main/executors/host-bash-executor.ts
@@ -1,0 +1,133 @@
+/**
+ * Host bash executor — runs shell commands on the host machine and posts
+ * results back to the daemon via the host proxy poster.
+ *
+ * Supports timeout (SIGTERM → SIGKILL cascade) and cancellation.
+ */
+
+import { spawn, type ChildProcess } from "node:child_process";
+import { homedir } from "node:os";
+
+import type { HostProxyExecutor } from "../host-proxy-router";
+import type { HostProxySseMessage } from "../host-proxy-sse";
+import type { HostProxyPoster } from "../host-proxy-poster";
+import { setExecutor } from "../host-proxy-router";
+import log from "../logger";
+
+const DEFAULT_TIMEOUT_SECONDS = 120;
+const SIGKILL_GRACE_MS = 2_000;
+
+interface RunningProcess {
+  child: ChildProcess;
+  cancelled: boolean;
+  killTimer: ReturnType<typeof setTimeout> | null;
+}
+
+const runningProcesses = new Map<string, RunningProcess>();
+
+function handleRequest(message: HostProxySseMessage, poster: HostProxyPoster): void {
+  const requestId = message.requestId as string | undefined;
+  if (!requestId) {
+    log.warn("[host-bash-executor] message missing requestId");
+    return;
+  }
+
+  const command = message.command as string | undefined;
+  if (!command) {
+    void poster.postBashResult({ requestId, stdout: "", stderr: "Missing command", exitCode: 1, timedOut: false });
+    return;
+  }
+
+  const workingDir = (message.working_dir as string | undefined) || homedir();
+  const timeoutSeconds = (message.timeout_seconds as number | undefined) ?? DEFAULT_TIMEOUT_SECONDS;
+  const extraEnv = (message.env as Record<string, string> | undefined) ?? {};
+
+  const env = { ...process.env, ...extraEnv };
+
+  let stdout = "";
+  let stderr = "";
+  let timedOut = false;
+
+  const child = spawn("/bin/bash", ["-c", "--", command], {
+    cwd: workingDir,
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  const entry: RunningProcess = { child, cancelled: false, killTimer: null };
+  runningProcesses.set(requestId, entry);
+
+  child.stdout!.on("data", (chunk: Buffer) => { stdout += chunk.toString(); });
+  child.stderr!.on("data", (chunk: Buffer) => { stderr += chunk.toString(); });
+
+  // Timeout cascade: SIGTERM, then SIGKILL after grace period
+  const timeoutTimer = setTimeout(() => {
+    timedOut = true;
+    child.kill("SIGTERM");
+
+    entry.killTimer = setTimeout(() => {
+      if (!child.killed) {
+        child.kill("SIGKILL");
+      }
+    }, SIGKILL_GRACE_MS);
+  }, timeoutSeconds * 1_000);
+
+  child.on("close", (exitCode) => {
+    clearTimeout(timeoutTimer);
+    if (entry.killTimer) clearTimeout(entry.killTimer);
+    runningProcesses.delete(requestId);
+
+    if (entry.cancelled) return;
+
+    void poster.postBashResult({
+      requestId,
+      stdout,
+      stderr,
+      exitCode,
+      timedOut,
+    });
+  });
+
+  child.on("error", (err) => {
+    clearTimeout(timeoutTimer);
+    if (entry.killTimer) clearTimeout(entry.killTimer);
+    runningProcesses.delete(requestId);
+
+    if (entry.cancelled) return;
+
+    void poster.postBashResult({
+      requestId,
+      stdout,
+      stderr: stderr || err.message,
+      exitCode: 1,
+      timedOut: false,
+    });
+  });
+}
+
+function handleCancel(message: HostProxySseMessage, _poster: HostProxyPoster): void {
+  const requestId = message.requestId as string | undefined;
+  if (!requestId) return;
+
+  const entry = runningProcesses.get(requestId);
+  if (!entry) return;
+
+  entry.cancelled = true;
+  entry.child.kill("SIGTERM");
+
+  entry.killTimer = setTimeout(() => {
+    if (!entry.child.killed) {
+      entry.child.kill("SIGKILL");
+    }
+  }, SIGKILL_GRACE_MS);
+}
+
+export const hostBashExecutor: HostProxyExecutor = { handleRequest, handleCancel };
+
+// Register with the router
+setExecutor("host_bash", hostBashExecutor);
+
+// Test seam
+export const __testing = {
+  get runningProcesses() { return runningProcesses; },
+};

--- a/apps/macos/src/main/executors/host-bash-executor.ts
+++ b/apps/macos/src/main/executors/host-bash-executor.ts
@@ -20,6 +20,7 @@ const SIGKILL_GRACE_MS = 2_000;
 interface RunningProcess {
   child: ChildProcess;
   cancelled: boolean;
+  hasExited: boolean;
   killTimer: ReturnType<typeof setTimeout> | null;
 }
 
@@ -54,7 +55,7 @@ function handleRequest(message: HostProxySseMessage, poster: HostProxyPoster): v
     stdio: ["ignore", "pipe", "pipe"],
   });
 
-  const entry: RunningProcess = { child, cancelled: false, killTimer: null };
+  const entry: RunningProcess = { child, cancelled: false, hasExited: false, killTimer: null };
   runningProcesses.set(requestId, entry);
 
   child.stdout!.on("data", (chunk: Buffer) => { stdout += chunk.toString(); });
@@ -66,13 +67,14 @@ function handleRequest(message: HostProxySseMessage, poster: HostProxyPoster): v
     child.kill("SIGTERM");
 
     entry.killTimer = setTimeout(() => {
-      if (!child.killed) {
+      if (!entry.hasExited) {
         child.kill("SIGKILL");
       }
     }, SIGKILL_GRACE_MS);
   }, timeoutSeconds * 1_000);
 
   child.on("close", (exitCode) => {
+    entry.hasExited = true;
     clearTimeout(timeoutTimer);
     if (entry.killTimer) clearTimeout(entry.killTimer);
     runningProcesses.delete(requestId);
@@ -116,7 +118,7 @@ function handleCancel(message: HostProxySseMessage, _poster: HostProxyPoster): v
   entry.child.kill("SIGTERM");
 
   entry.killTimer = setTimeout(() => {
-    if (!entry.child.killed) {
+    if (!entry.hasExited) {
       entry.child.kill("SIGKILL");
     }
   }, SIGKILL_GRACE_MS);

--- a/apps/macos/src/main/executors/host-bash-executor.ts
+++ b/apps/macos/src/main/executors/host-bash-executor.ts
@@ -11,7 +11,6 @@ import { homedir } from "node:os";
 import type { HostProxyExecutor } from "../host-proxy-router";
 import type { HostProxySseMessage } from "../host-proxy-sse";
 import type { HostProxyPoster } from "../host-proxy-poster";
-import { setExecutor } from "../host-proxy-router";
 import log from "../logger";
 
 const DEFAULT_TIMEOUT_SECONDS = 120;
@@ -125,9 +124,6 @@ function handleCancel(message: HostProxySseMessage, _poster: HostProxyPoster): v
 }
 
 export const hostBashExecutor: HostProxyExecutor = { handleRequest, handleCancel };
-
-// Register with the router
-setExecutor("host_bash", hostBashExecutor);
 
 // Test seam
 export const __testing = {

--- a/apps/macos/src/main/executors/host-browser-executor.test.ts
+++ b/apps/macos/src/main/executors/host-browser-executor.test.ts
@@ -1,0 +1,510 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Stubs — must precede the executor import
+// ---------------------------------------------------------------------------
+
+const MOCK_DEVICE_ID = "test-device-00000000-0000-0000-0000-000000000000";
+mock.module("../device-id", () => ({
+  getDeviceId: () => MOCK_DEVICE_ID,
+  resetDeviceIdCache: () => {},
+}));
+
+mock.module("electron-log/main", () => {
+  const noop = () => {};
+  return {
+    default: {
+      info: noop,
+      warn: noop,
+      error: noop,
+      debug: noop,
+      initialize: noop,
+      transports: {
+        file: {
+          maxSize: 0,
+          fileName: "",
+          format: "",
+          getFile: () => ({ path: "" }),
+        },
+      },
+    },
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Mock fetch at the global level
+// ---------------------------------------------------------------------------
+
+let mockFetchImpl: typeof globalThis.fetch = async () => new Response("[]");
+
+// We need to intercept fetch calls for target discovery
+globalThis.fetch = async (...args: Parameters<typeof globalThis.fetch>) => {
+  return mockFetchImpl(...args);
+};
+
+// ---------------------------------------------------------------------------
+// Mock WebSocket
+// ---------------------------------------------------------------------------
+
+class MockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  readyState = MockWebSocket.CONNECTING;
+  url: string;
+
+  private listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+
+  constructor(url: string) {
+    this.url = url;
+    // Simulate async connection
+    setTimeout(() => {
+      if (this.readyState === MockWebSocket.CONNECTING) {
+        this.readyState = MockWebSocket.OPEN;
+        this.emit("open");
+      }
+    }, 5);
+  }
+
+  addEventListener(event: string, listener: (...args: unknown[]) => void, opts?: { once?: boolean }) {
+    if (!this.listeners.has(event)) {
+      this.listeners.set(event, new Set());
+    }
+    if (opts?.once) {
+      const wrapped = (...args: unknown[]) => {
+        this.listeners.get(event)?.delete(wrapped);
+        listener(...args);
+      };
+      this.listeners.get(event)!.add(wrapped);
+    } else {
+      this.listeners.get(event)!.add(listener);
+    }
+  }
+
+  removeEventListener(event: string, listener: (...args: unknown[]) => void) {
+    this.listeners.get(event)?.delete(listener);
+  }
+
+  emit(event: string, data?: unknown) {
+    const handlers = this.listeners.get(event);
+    if (!handlers) return;
+    for (const handler of [...handlers]) {
+      handler(data);
+    }
+  }
+
+  send = mock((_data: string) => {});
+  close = mock(() => {
+    this.readyState = MockWebSocket.CLOSED;
+  });
+}
+
+// Store created WebSocket instances for test manipulation
+let createdWebSockets: MockWebSocket[] = [];
+
+// @ts-expect-error -- mock WebSocket
+globalThis.WebSocket = class extends MockWebSocket {
+  constructor(url: string) {
+    super(url);
+    createdWebSockets.push(this);
+  }
+} as unknown as typeof WebSocket;
+
+// Static constants on the class
+Object.assign(globalThis.WebSocket, {
+  CONNECTING: 0,
+  OPEN: 1,
+  CLOSING: 2,
+  CLOSED: 3,
+});
+
+const { HostBrowserExecutor, __testing } = await import("./host-browser-executor");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function flush(ms = 30): Promise<void> {
+  await new Promise((r) => setTimeout(r, ms));
+}
+
+/** Build a page target entry as returned by /json/list. */
+function pageTarget(
+  id: string,
+  wsUrl = `ws://localhost:9222/devtools/page/${id}`,
+): Record<string, unknown> {
+  return {
+    id,
+    type: "page",
+    title: `Page ${id}`,
+    url: `http://example.com/${id}`,
+    webSocketDebuggerUrl: wsUrl,
+  };
+}
+
+/** Create a capturing poster that records all postBrowserResult calls. */
+function capturingPoster() {
+  const results: Array<{ requestId: string; content?: string; isError?: boolean }> = [];
+  return {
+    results,
+    poster: {
+      postBrowserResult: async (payload: { requestId: string; content?: string; isError?: boolean }) => {
+        results.push(payload);
+        return true;
+      },
+    } as unknown as import("../host-proxy-poster").HostProxyPoster,
+  };
+}
+
+/** Set fetch to return the given target list for /json/list. */
+function setTargets(targets: Record<string, unknown>[]) {
+  mockFetchImpl = async () => new Response(JSON.stringify(targets), { status: 200 });
+}
+
+/** Set fetch to fail. */
+function setFetchError(msg = "Connection refused") {
+  mockFetchImpl = async () => { throw new Error(msg); };
+}
+
+/**
+ * After flush, find the most recently created mock WebSocket and simulate
+ * a CDP response.
+ */
+function replyToCDP(
+  ws: MockWebSocket,
+  commandId: number,
+  result: unknown,
+) {
+  ws.emit("message", { data: JSON.stringify({ id: commandId, result }) });
+}
+
+function replyWithCDPError(
+  ws: MockWebSocket,
+  commandId: number,
+  code: number,
+  message: string,
+) {
+  ws.emit("message", { data: JSON.stringify({ id: commandId, error: { code, message } }) });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("HostBrowserExecutor", () => {
+  let executor: InstanceType<typeof HostBrowserExecutor>;
+
+  beforeEach(() => {
+    createdWebSockets = [];
+    executor = new HostBrowserExecutor();
+  });
+
+  afterEach(() => {
+    executor.destroy();
+    mockFetchImpl = async () => new Response("[]");
+  });
+
+  // -- Test seams -----------------------------------------------------------
+
+  describe("test seams", () => {
+    test("isLoopback accepts localhost, 127.0.0.1, ::1", () => {
+      expect(__testing.isLoopback("localhost")).toBe(true);
+      expect(__testing.isLoopback("127.0.0.1")).toBe(true);
+      expect(__testing.isLoopback("::1")).toBe(true);
+      expect(__testing.isLoopback("LOCALHOST")).toBe(true);
+    });
+
+    test("isLoopback rejects non-loopback hosts", () => {
+      expect(__testing.isLoopback("192.168.1.1")).toBe(false);
+      expect(__testing.isLoopback("evil.com")).toBe(false);
+      expect(__testing.isLoopback("10.0.0.1")).toBe(false);
+    });
+
+    test("transportError returns structured error payload", () => {
+      const err = __testing.transportError("req-1", "unreachable", "cannot connect");
+      expect(err.requestId).toBe("req-1");
+      expect(err.isError).toBe(true);
+      const parsed = JSON.parse(err.content);
+      expect(parsed.code).toBe("unreachable");
+      expect(parsed.message).toBe("cannot connect");
+    });
+  });
+
+  // -- Target discovery -----------------------------------------------------
+
+  describe("target discovery", () => {
+    test("filters to page targets only", async () => {
+      const targets = [
+        pageTarget("page-1"),
+        { id: "worker-1", type: "service_worker", title: "SW" },
+        pageTarget("page-2"),
+        { id: "bg-1", type: "background_page", title: "BG" },
+      ];
+      setTargets(targets);
+
+      const { poster, results } = capturingPoster();
+      executor.handleRequest(
+        { type: "host_browser_request", requestId: "r1", cdpMethod: "Runtime.evaluate", cdpParams: { expression: "1+1" } },
+        poster,
+      );
+
+      await flush(50);
+      // Should have created a WebSocket to the first page target
+      expect(createdWebSockets.length).toBeGreaterThanOrEqual(1);
+      expect(createdWebSockets[0].url).toContain("page-1");
+    });
+
+    test("returns unreachable error when Chrome is not running", async () => {
+      setFetchError("Connection refused");
+
+      const { poster, results } = capturingPoster();
+      executor.handleRequest(
+        { type: "host_browser_request", requestId: "r1", cdpMethod: "Page.navigate" },
+        poster,
+      );
+
+      await flush(50);
+      expect(results.length).toBe(1);
+      expect(results[0].isError).toBe(true);
+      const parsed = JSON.parse(results[0].content!);
+      expect(parsed.code).toBe("unreachable");
+    });
+
+    test("returns unreachable when no page targets exist", async () => {
+      setTargets([
+        { id: "sw-1", type: "service_worker", title: "SW" },
+      ]);
+
+      const { poster, results } = capturingPoster();
+      executor.handleRequest(
+        { type: "host_browser_request", requestId: "r1", cdpMethod: "Page.navigate" },
+        poster,
+      );
+
+      await flush(50);
+      expect(results.length).toBe(1);
+      const parsed = JSON.parse(results[0].content!);
+      expect(parsed.code).toBe("unreachable");
+    });
+  });
+
+  // -- Session matching -----------------------------------------------------
+
+  describe("session matching", () => {
+    test("matches target by cdpSessionId", async () => {
+      setTargets([pageTarget("target-A"), pageTarget("target-B")]);
+
+      const { poster, results } = capturingPoster();
+      executor.handleRequest(
+        {
+          type: "host_browser_request",
+          requestId: "r1",
+          cdpMethod: "Runtime.evaluate",
+          cdpSessionId: "target-B",
+        },
+        poster,
+      );
+
+      await flush(50);
+      expect(createdWebSockets.length).toBeGreaterThanOrEqual(1);
+      expect(createdWebSockets[0].url).toContain("target-B");
+    });
+
+    test("fails closed when cdpSessionId does not match any target", async () => {
+      setTargets([pageTarget("target-A")]);
+
+      const { poster, results } = capturingPoster();
+      executor.handleRequest(
+        {
+          type: "host_browser_request",
+          requestId: "r1",
+          cdpMethod: "Runtime.evaluate",
+          cdpSessionId: "nonexistent",
+        },
+        poster,
+      );
+
+      await flush(50);
+      expect(results.length).toBe(1);
+      expect(results[0].isError).toBe(true);
+      const parsed = JSON.parse(results[0].content!);
+      expect(parsed.code).toBe("cdp_session_not_found");
+    });
+  });
+
+  // -- Loopback validation --------------------------------------------------
+
+  describe("loopback validation", () => {
+    test("rejects non-loopback WebSocket URL from target", async () => {
+      setTargets([
+        pageTarget("page-1", "ws://evil.com:9222/devtools/page/page-1"),
+      ]);
+
+      const { poster, results } = capturingPoster();
+      executor.handleRequest(
+        { type: "host_browser_request", requestId: "r1", cdpMethod: "Page.navigate" },
+        poster,
+      );
+
+      await flush(50);
+      expect(results.length).toBe(1);
+      expect(results[0].isError).toBe(true);
+      const parsed = JSON.parse(results[0].content!);
+      expect(parsed.code).toBe("non_loopback");
+    });
+  });
+
+  // -- CDP command send/receive ---------------------------------------------
+
+  describe("CDP command", () => {
+    test("sends method and params, returns result", async () => {
+      setTargets([pageTarget("page-1")]);
+
+      const { poster, results } = capturingPoster();
+      executor.handleRequest(
+        {
+          type: "host_browser_request",
+          requestId: "r1",
+          cdpMethod: "Runtime.evaluate",
+          cdpParams: { expression: "document.title" },
+        },
+        poster,
+      );
+
+      await flush(50);
+      const ws = createdWebSockets[0];
+      expect(ws).toBeDefined();
+      expect(ws.send).toHaveBeenCalled();
+
+      // Parse the sent message to find command id
+      const sentData = JSON.parse((ws.send as ReturnType<typeof mock>).mock.calls[0][0] as string);
+      expect(sentData.method).toBe("Runtime.evaluate");
+      expect(sentData.params.expression).toBe("document.title");
+
+      // Reply
+      replyToCDP(ws, sentData.id, { result: { type: "string", value: "Test Page" } });
+      await flush(50);
+
+      expect(results.length).toBe(1);
+      expect(results[0].isError).toBe(false);
+      const parsed = JSON.parse(results[0].content!);
+      expect(parsed.result.value).toBe("Test Page");
+    });
+
+    test("returns CDP protocol error with isError true", async () => {
+      setTargets([pageTarget("page-1")]);
+
+      const { poster, results } = capturingPoster();
+      executor.handleRequest(
+        {
+          type: "host_browser_request",
+          requestId: "r1",
+          cdpMethod: "DOM.getDocument",
+        },
+        poster,
+      );
+
+      await flush(50);
+      const ws = createdWebSockets[0];
+      const sentData = JSON.parse((ws.send as ReturnType<typeof mock>).mock.calls[0][0] as string);
+
+      replyWithCDPError(ws, sentData.id, -32000, "Cannot find context");
+      await flush(50);
+
+      expect(results.length).toBe(1);
+      expect(results[0].isError).toBe(true);
+      const parsed = JSON.parse(results[0].content!);
+      expect(parsed.code).toBe(-32000);
+      expect(parsed.message).toBe("Cannot find context");
+    });
+  });
+
+  // -- Timeout --------------------------------------------------------------
+
+  describe("timeout", () => {
+    test("times out after configured seconds", async () => {
+      setTargets([pageTarget("page-1")]);
+
+      const { poster, results } = capturingPoster();
+      // Use a very short timeout for testing
+      executor.handleRequest(
+        {
+          type: "host_browser_request",
+          requestId: "r1",
+          cdpMethod: "Page.navigate",
+          timeout_seconds: 0.05,
+        },
+        poster,
+      );
+
+      // Wait longer than the timeout
+      await flush(200);
+
+      expect(results.length).toBe(1);
+      expect(results[0].isError).toBe(true);
+      const parsed = JSON.parse(results[0].content!);
+      expect(parsed.code).toBe("timeout");
+    });
+  });
+
+  // -- Cancellation ---------------------------------------------------------
+
+  describe("cancellation", () => {
+    test("pre-flight cancellation suppresses execution", async () => {
+      setTargets([pageTarget("page-1")]);
+
+      // Cancel before the request even starts executing
+      executor.handleCancel(
+        { type: "host_browser_cancel", requestId: "r1" },
+        {} as import("../host-proxy-poster").HostProxyPoster,
+      );
+
+      const { poster, results } = capturingPoster();
+      executor.handleRequest(
+        { type: "host_browser_request", requestId: "r1", cdpMethod: "Page.navigate" },
+        poster,
+      );
+
+      await flush(100);
+      // No result should be posted
+      expect(results.length).toBe(0);
+    });
+
+    test("in-flight cancellation aborts pending request", async () => {
+      setTargets([pageTarget("page-1")]);
+
+      const { poster, results } = capturingPoster();
+      executor.handleRequest(
+        { type: "host_browser_request", requestId: "r1", cdpMethod: "Page.navigate" },
+        poster,
+      );
+
+      await flush(50);
+      // Cancel while in flight
+      executor.handleCancel(
+        { type: "host_browser_cancel", requestId: "r1" },
+        poster,
+      );
+
+      await flush(100);
+      // No successful result should be posted (timeout/cancel errors may or may not appear)
+      const nonError = results.filter((r) => !r.isError);
+      expect(nonError.length).toBe(0);
+    });
+  });
+
+  // -- Missing requestId ---------------------------------------------------
+
+  describe("edge cases", () => {
+    test("ignores messages without requestId", () => {
+      const { poster, results } = capturingPoster();
+      executor.handleRequest(
+        { type: "host_browser_request" },
+        poster,
+      );
+      expect(results.length).toBe(0);
+    });
+  });
+});

--- a/apps/macos/src/main/executors/host-browser-executor.test.ts
+++ b/apps/macos/src/main/executors/host-browser-executor.test.ts
@@ -35,12 +35,12 @@ mock.module("electron-log/main", () => {
 // Mock fetch at the global level
 // ---------------------------------------------------------------------------
 
-let mockFetchImpl: typeof globalThis.fetch = async () => new Response("[]");
+let mockFetchImpl: typeof globalThis.fetch = (async () => new Response("[]")) as unknown as typeof globalThis.fetch;
 
 // We need to intercept fetch calls for target discovery
-globalThis.fetch = async (...args: Parameters<typeof globalThis.fetch>) => {
+globalThis.fetch = (async (...args: Parameters<typeof globalThis.fetch>) => {
   return mockFetchImpl(...args);
-};
+}) as unknown as typeof globalThis.fetch;
 
 // ---------------------------------------------------------------------------
 // Mock WebSocket
@@ -104,7 +104,6 @@ class MockWebSocket {
 // Store created WebSocket instances for test manipulation
 let createdWebSockets: MockWebSocket[] = [];
 
-// @ts-expect-error -- mock WebSocket
 globalThis.WebSocket = class extends MockWebSocket {
   constructor(url: string) {
     super(url);
@@ -160,12 +159,12 @@ function capturingPoster() {
 
 /** Set fetch to return the given target list for /json/list. */
 function setTargets(targets: Record<string, unknown>[]) {
-  mockFetchImpl = async () => new Response(JSON.stringify(targets), { status: 200 });
+  mockFetchImpl = (async () => new Response(JSON.stringify(targets), { status: 200 })) as unknown as typeof globalThis.fetch;
 }
 
 /** Set fetch to fail. */
 function setFetchError(msg = "Connection refused") {
-  mockFetchImpl = async () => { throw new Error(msg); };
+  mockFetchImpl = (async () => { throw new Error(msg); }) as unknown as typeof globalThis.fetch;
 }
 
 /**
@@ -203,7 +202,7 @@ describe("HostBrowserExecutor", () => {
 
   afterEach(() => {
     executor.destroy();
-    mockFetchImpl = async () => new Response("[]");
+    mockFetchImpl = (async () => new Response("[]")) as unknown as typeof globalThis.fetch;
   });
 
   // -- Test seams -----------------------------------------------------------

--- a/apps/macos/src/main/executors/host-browser-executor.ts
+++ b/apps/macos/src/main/executors/host-browser-executor.ts
@@ -117,7 +117,7 @@ export class HostBrowserExecutor implements HostProxyExecutor {
     if (pending) {
       pending.abortController.abort();
       clearTimeout(pending.timeoutTimer);
-      if (pending.ws && pending.ws.readyState === WebSocket.OPEN) {
+      if (pending.ws && (pending.ws.readyState === WebSocket.OPEN || pending.ws.readyState === WebSocket.CONNECTING)) {
         pending.ws.close();
       }
       pending.settled = true;
@@ -436,6 +436,7 @@ export class HostBrowserExecutor implements HostProxyExecutor {
       ws.addEventListener("close", onClose);
 
       const sendCommand = () => {
+        if (flight.settled || flight.abortController.signal.aborted) return;
         ws.send(JSON.stringify(message));
       };
 

--- a/apps/macos/src/main/executors/host-browser-executor.ts
+++ b/apps/macos/src/main/executors/host-browser-executor.ts
@@ -1,0 +1,493 @@
+/**
+ * Host browser executor — sends CDP commands to a local Chrome instance and
+ * returns results to the daemon via the host proxy poster.
+ *
+ * Mirrors the Swift HostBrowserExecutor: target discovery via /json/list,
+ * loopback-only security validation, WebSocket CDP JSON-RPC, session
+ * matching by target id, connection pooling with idle timeout, and
+ * cooperative cancellation.
+ */
+
+import type { HostProxyExecutor } from "../host-proxy-router";
+import type { HostProxySseMessage } from "../host-proxy-sse";
+import type { HostProxyPoster } from "../host-proxy-poster";
+import log from "../logger";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEFAULT_CDP_PORT = 9222;
+const DEFAULT_TIMEOUT_SECONDS = 30;
+const IDLE_CLOSE_MS = 30_000;
+const ALLOWED_LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
+
+// ---------------------------------------------------------------------------
+// CDP Error type
+// ---------------------------------------------------------------------------
+
+class CDPError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "CDPError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Connection pool entry
+// ---------------------------------------------------------------------------
+
+interface PoolEntry {
+  ws: WebSocket;
+  idleTimer: ReturnType<typeof setTimeout>;
+}
+
+// ---------------------------------------------------------------------------
+// In-flight request tracking
+// ---------------------------------------------------------------------------
+
+interface InFlightRequest {
+  abortController: AbortController;
+  timeoutTimer: ReturnType<typeof setTimeout>;
+  ws: WebSocket | null;
+  settled: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Transport error helper
+// ---------------------------------------------------------------------------
+
+function transportError(
+  requestId: string,
+  code: string,
+  message: string,
+): { requestId: string; content: string; isError: true } {
+  const payload = JSON.stringify({ code, message });
+  log.error(`[host-browser] transport error: ${code} — ${message}`, { requestId });
+  return { requestId, content: payload, isError: true };
+}
+
+// ---------------------------------------------------------------------------
+// Loopback validation
+// ---------------------------------------------------------------------------
+
+function isLoopback(host: string): boolean {
+  return ALLOWED_LOOPBACK_HOSTS.has(host.toLowerCase());
+}
+
+// ---------------------------------------------------------------------------
+// HostBrowserExecutor
+// ---------------------------------------------------------------------------
+
+export class HostBrowserExecutor implements HostProxyExecutor {
+  private readonly pool = new Map<string, PoolEntry>();
+  private readonly inFlight = new Map<string, InFlightRequest>();
+  private readonly cancelledIds = new Map<string, number>();
+  private nextCommandId = 1;
+
+  // -- HostProxyExecutor interface ------------------------------------------
+
+  handleRequest(message: HostProxySseMessage, poster: HostProxyPoster): void {
+    const requestId = message.requestId as string | undefined;
+    if (!requestId) {
+      log.warn("[host-browser] message missing requestId");
+      return;
+    }
+
+    // Pre-flight cancellation check
+    if (this.consumeCancelled(requestId)) {
+      log.debug("[host-browser] skipped (pre-cancelled)", { requestId });
+      return;
+    }
+
+    void this.execute(message, poster).catch((err) => {
+      log.error("[host-browser] unexpected top-level error", { requestId, err });
+    });
+  }
+
+  handleCancel(message: HostProxySseMessage, poster: HostProxyPoster): void {
+    const requestId = message.requestId as string | undefined;
+    if (!requestId) return;
+
+    this.markCancelled(requestId);
+    const pending = this.inFlight.get(requestId);
+    if (pending) {
+      pending.abortController.abort();
+      clearTimeout(pending.timeoutTimer);
+      if (pending.ws && pending.ws.readyState === WebSocket.OPEN) {
+        pending.ws.close();
+      }
+      pending.settled = true;
+      this.inFlight.delete(requestId);
+    }
+    log.info("[host-browser] cancelled", { requestId });
+  }
+
+  // -- Teardown -------------------------------------------------------------
+
+  destroy(): void {
+    for (const [id, entry] of this.pool) {
+      clearTimeout(entry.idleTimer);
+      if (entry.ws.readyState === WebSocket.OPEN) {
+        entry.ws.close();
+      }
+      this.pool.delete(id);
+    }
+    for (const [id, req] of this.inFlight) {
+      req.abortController.abort();
+      clearTimeout(req.timeoutTimer);
+      req.settled = true;
+      this.inFlight.delete(id);
+    }
+  }
+
+  // -- Main execution flow --------------------------------------------------
+
+  private async execute(
+    message: HostProxySseMessage,
+    poster: HostProxyPoster,
+  ): Promise<void> {
+    const requestId = message.requestId as string;
+    const cdpMethod = (message.cdpMethod as string) ?? "";
+    const cdpParams = message.cdpParams as Record<string, unknown> | undefined;
+    const cdpSessionId = message.cdpSessionId as string | undefined;
+    const rawTimeout = (message.timeout_seconds as number) ?? DEFAULT_TIMEOUT_SECONDS;
+    const timeoutSeconds =
+      typeof rawTimeout === "number" && isFinite(rawTimeout) && rawTimeout >= 0 && rawTimeout <= 18_000_000_000
+        ? rawTimeout
+        : DEFAULT_TIMEOUT_SECONDS;
+    const host = "localhost";
+    const port = DEFAULT_CDP_PORT;
+
+    // Set up abort / timeout tracking
+    const abortController = new AbortController();
+    const timeoutTimer = setTimeout(() => {
+      abortController.abort();
+      const pending = this.inFlight.get(requestId);
+      if (pending && !pending.settled) {
+        pending.settled = true;
+        this.inFlight.delete(requestId);
+        void poster.postBrowserResult(
+          transportError(requestId, "timeout", `CDP command '${cdpMethod}' timed out after ${timeoutSeconds}s`),
+        );
+      }
+    }, timeoutSeconds * 1000);
+
+    const flight: InFlightRequest = {
+      abortController,
+      timeoutTimer,
+      ws: null,
+      settled: false,
+    };
+    this.inFlight.set(requestId, flight);
+
+    try {
+      // Step 1: Target discovery
+      const targets = await this.fetchTargets(host, port, abortController.signal, timeoutSeconds);
+
+      // Step 2: Select a page target
+      const pageTargets = targets.filter(
+        (t: Record<string, unknown>) => t.type === "page",
+      );
+
+      let selectedTarget: Record<string, unknown> | undefined;
+      if (cdpSessionId) {
+        selectedTarget = pageTargets.find(
+          (t: Record<string, unknown>) => t.id === cdpSessionId,
+        );
+        if (!selectedTarget) {
+          this.settle(requestId);
+          void poster.postBrowserResult(
+            transportError(
+              requestId,
+              "cdp_session_not_found",
+              `cdpSessionId '${cdpSessionId}' did not match any page target in /json/list. The target may have been closed or navigated.`,
+            ),
+          );
+          return;
+        }
+      } else {
+        selectedTarget = pageTargets[0];
+      }
+
+      if (!selectedTarget || typeof selectedTarget.webSocketDebuggerUrl !== "string") {
+        this.settle(requestId);
+        void poster.postBrowserResult(
+          transportError(
+            requestId,
+            "unreachable",
+            `No debuggable page target found at ${host}:${port}. Ensure Chrome is running with --remote-debugging-port=${port}.`,
+          ),
+        );
+        return;
+      }
+
+      const wsUrl = selectedTarget.webSocketDebuggerUrl as string;
+
+      // Validate WebSocket URL is loopback
+      let wsHost: string;
+      try {
+        const parsed = new URL(wsUrl);
+        wsHost = parsed.hostname;
+      } catch {
+        this.settle(requestId);
+        void poster.postBrowserResult(
+          transportError(requestId, "transport_error", `Chrome returned an invalid WebSocket URL: ${wsUrl}`),
+        );
+        return;
+      }
+
+      if (!isLoopback(wsHost)) {
+        this.settle(requestId);
+        void poster.postBrowserResult(
+          transportError(
+            requestId,
+            "non_loopback",
+            `WebSocket URL host '${wsHost}' is not a loopback address. Only localhost, 127.0.0.1, and ::1 are permitted.`,
+          ),
+        );
+        return;
+      }
+
+      // Step 3: Send CDP command via WebSocket
+      const targetId = selectedTarget.id as string;
+      const result = await this.sendCDPCommand(wsUrl, targetId, cdpMethod, cdpParams, flight);
+
+      if (this.consumeCancelled(requestId)) {
+        log.debug("[host-browser] result suppressed (cancelled)", { requestId });
+        this.settle(requestId);
+        return;
+      }
+
+      this.settle(requestId);
+      void poster.postBrowserResult({ requestId, content: result, isError: false });
+    } catch (err) {
+      if (flight.settled) return;
+      this.settle(requestId);
+
+      if (this.consumeCancelled(requestId)) {
+        log.debug("[host-browser] error suppressed (cancelled)", { requestId });
+        return;
+      }
+
+      if (err instanceof CDPError) {
+        if (err.code === "protocol_error") {
+          // Protocol errors carry the CDP error code in the message as "code:message"
+          void poster.postBrowserResult({ requestId, content: err.message, isError: true });
+        } else {
+          void poster.postBrowserResult(transportError(requestId, err.code, err.message));
+        }
+      } else if (abortController.signal.aborted) {
+        // Timeout or cancellation already handled
+      } else {
+        void poster.postBrowserResult(
+          transportError(
+            requestId,
+            "transport_error",
+            `Unexpected error executing CDP command: ${err instanceof Error ? err.message : String(err)}`,
+          ),
+        );
+      }
+    }
+  }
+
+  // -- Target discovery -----------------------------------------------------
+
+  private async fetchTargets(
+    host: string,
+    port: number,
+    signal: AbortSignal,
+    timeoutSeconds: number,
+  ): Promise<Record<string, unknown>[]> {
+    const url = `http://${host}:${port}/json/list`;
+    const controller = new AbortController();
+
+    // Link outer abort to our fetch
+    const onAbort = () => controller.abort();
+    signal.addEventListener("abort", onAbort, { once: true });
+
+    const timer = setTimeout(() => controller.abort(), timeoutSeconds * 1000);
+    try {
+      const response = await fetch(url, { signal: controller.signal });
+      if (!response.ok) {
+        throw new CDPError(
+          "unreachable",
+          `HTTP ${response.status} from ${url}`,
+        );
+      }
+      const json = await response.json();
+      if (!Array.isArray(json)) {
+        throw new CDPError("unreachable", `Invalid JSON response from ${url}`);
+      }
+      return json as Record<string, unknown>[];
+    } catch (err) {
+      if (err instanceof CDPError) throw err;
+      throw new CDPError(
+        "unreachable",
+        `Failed to connect to Chrome DevTools at ${host}:${port}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", onAbort);
+    }
+  }
+
+  // -- CDP command over WebSocket -------------------------------------------
+
+  private sendCDPCommand(
+    wsUrl: string,
+    targetId: string,
+    method: string,
+    params: Record<string, unknown> | undefined,
+    flight: InFlightRequest,
+  ): Promise<string> {
+    const commandId = this.nextCommandId++;
+
+    return new Promise<string>((resolve, reject) => {
+      if (flight.abortController.signal.aborted) {
+        reject(new CDPError("cancelled", "CDP command cancelled"));
+        return;
+      }
+
+      // Use pooled connection or create a new one
+      let ws: WebSocket;
+      const pooled = this.pool.get(targetId);
+      if (pooled && pooled.ws.readyState === WebSocket.OPEN) {
+        clearTimeout(pooled.idleTimer);
+        ws = pooled.ws;
+      } else {
+        // Clean up stale pool entry if any
+        if (pooled) {
+          clearTimeout(pooled.idleTimer);
+          this.pool.delete(targetId);
+        }
+        ws = new WebSocket(wsUrl);
+      }
+
+      flight.ws = ws;
+
+      const message: Record<string, unknown> = { id: commandId, method };
+      if (params) {
+        message.params = params;
+      }
+
+      const onAbort = () => {
+        cleanup();
+        reject(new CDPError("cancelled", "CDP command cancelled"));
+      };
+
+      const onMessage = (event: MessageEvent) => {
+        try {
+          const data = JSON.parse(typeof event.data === "string" ? event.data : String(event.data));
+          if (data.id !== commandId) return; // Not our response, keep listening
+
+          cleanup();
+
+          if (data.error) {
+            const code = data.error.code ?? -1;
+            const msg = data.error.message ?? "Unknown CDP error";
+            const errorPayload = JSON.stringify({ code, message: msg });
+            reject(new CDPError("protocol_error", errorPayload));
+            return;
+          }
+
+          const result = data.result !== undefined ? JSON.stringify(data.result) : "{}";
+          resolve(result);
+        } catch {
+          // Malformed JSON, keep listening
+        }
+      };
+
+      const onError = () => {
+        cleanup();
+        this.pool.delete(targetId);
+        reject(new CDPError("transport_error", "WebSocket connection to Chrome DevTools failed"));
+      };
+
+      const onClose = () => {
+        cleanup();
+        this.pool.delete(targetId);
+        // Only reject if not already settled
+        reject(new CDPError("transport_error", "WebSocket closed before receiving response"));
+      };
+
+      const cleanup = () => {
+        flight.abortController.signal.removeEventListener("abort", onAbort);
+        ws.removeEventListener("message", onMessage);
+        ws.removeEventListener("error", onError);
+        ws.removeEventListener("close", onClose);
+
+        // Return to pool with idle timeout
+        if (ws.readyState === WebSocket.OPEN) {
+          const idleTimer = setTimeout(() => {
+            this.pool.delete(targetId);
+            if (ws.readyState === WebSocket.OPEN) ws.close();
+          }, IDLE_CLOSE_MS);
+          this.pool.set(targetId, { ws, idleTimer });
+        }
+      };
+
+      flight.abortController.signal.addEventListener("abort", onAbort, { once: true });
+      ws.addEventListener("message", onMessage);
+      ws.addEventListener("error", onError);
+      ws.addEventListener("close", onClose);
+
+      const sendCommand = () => {
+        ws.send(JSON.stringify(message));
+      };
+
+      if (ws.readyState === WebSocket.OPEN) {
+        sendCommand();
+      } else if (ws.readyState === WebSocket.CONNECTING) {
+        ws.addEventListener("open", sendCommand, { once: true });
+      } else {
+        cleanup();
+        this.pool.delete(targetId);
+        reject(new CDPError("transport_error", "WebSocket is not in a connectable state"));
+      }
+    });
+  }
+
+  // -- Cancellation tracking ------------------------------------------------
+
+  private markCancelled(requestId: string): void {
+    const now = Date.now();
+    this.cancelledIds.set(requestId, now);
+    // Sweep entries older than 30s
+    for (const [id, ts] of this.cancelledIds) {
+      if (now - ts >= 30_000) this.cancelledIds.delete(id);
+    }
+  }
+
+  private consumeCancelled(requestId: string): boolean {
+    return this.cancelledIds.delete(requestId);
+  }
+
+  // -- Helpers --------------------------------------------------------------
+
+  private settle(requestId: string): void {
+    const pending = this.inFlight.get(requestId);
+    if (pending) {
+      clearTimeout(pending.timeoutTimer);
+      pending.settled = true;
+      this.inFlight.delete(requestId);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test seams
+// ---------------------------------------------------------------------------
+
+export const __testing = {
+  CDPError,
+  transportError,
+  isLoopback,
+  DEFAULT_CDP_PORT,
+  DEFAULT_TIMEOUT_SECONDS,
+  IDLE_CLOSE_MS,
+  ALLOWED_LOOPBACK_HOSTS,
+};

--- a/apps/macos/src/main/executors/host-file-executor.test.ts
+++ b/apps/macos/src/main/executors/host-file-executor.test.ts
@@ -168,7 +168,7 @@ describe("host-file-executor", () => {
       const filePath = path.join(dir, "lines.txt");
       fs.writeFileSync(filePath, "a\nb\nc\nd\ne");
 
-      const result = __testing.executeRead({ path: filePath, offset: 1, limit: 2 });
+      const result = __testing.executeRead({ path: filePath, offset: 2, limit: 2 });
       expect(result.content).toBe("b\nc");
     });
 

--- a/apps/macos/src/main/executors/host-file-executor.test.ts
+++ b/apps/macos/src/main/executors/host-file-executor.test.ts
@@ -1,0 +1,339 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+// ---------------------------------------------------------------------------
+// Stubs
+// ---------------------------------------------------------------------------
+
+const MOCK_DEVICE_ID = "test-device-00000000-0000-0000-0000-000000000000";
+mock.module("../device-id", () => ({
+  getDeviceId: () => MOCK_DEVICE_ID,
+  resetDeviceIdCache: () => {},
+}));
+
+mock.module("electron-log/main", () => {
+  const noop = () => {};
+  return {
+    default: {
+      info: noop,
+      warn: noop,
+      error: noop,
+      debug: noop,
+      initialize: noop,
+      transports: { file: { maxSize: 0, fileName: "", format: "", getFile: () => ({ path: "" }) } },
+    },
+  };
+});
+
+const { HostProxyPoster } = await import("../host-proxy-poster");
+const { hostFileExecutor, __testing } = await import("./host-file-executor");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+
+function freshTmpDir(): string {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "host-file-exec-"));
+  return tmpDir;
+}
+
+function capturingPoster(): {
+  poster: InstanceType<typeof HostProxyPoster>;
+  body: () => Record<string, unknown> | null;
+} {
+  let postedBody: Record<string, unknown> | null = null;
+  const fakeFetch = async (_url: unknown, init?: RequestInit) => {
+    postedBody = JSON.parse(init?.body as string);
+    return new Response("ok");
+  };
+  const poster = new HostProxyPoster({
+    gatewayPort: 9000,
+    authToken: "t",
+    fetch: fakeFetch as typeof globalThis.fetch,
+  });
+  return { poster, body: () => postedBody };
+}
+
+async function flush(ms = 20): Promise<void> {
+  await new Promise((r) => setTimeout(r, ms));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("host-file-executor", () => {
+  afterEach(() => {
+    __testing.pendingRequests.clear();
+    if (tmpDir) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  // -- Magic byte detection -------------------------------------------------
+
+  describe("isImageByMagicBytes", () => {
+    test("detects PNG", () => {
+      const buf = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a]);
+      expect(__testing.isImageByMagicBytes(buf)).toBe(true);
+    });
+
+    test("detects JPEG", () => {
+      const buf = Buffer.from([0xff, 0xd8, 0xff, 0xe0]);
+      expect(__testing.isImageByMagicBytes(buf)).toBe(true);
+    });
+
+    test("detects GIF", () => {
+      const buf = Buffer.from([0x47, 0x49, 0x46, 0x38]);
+      expect(__testing.isImageByMagicBytes(buf)).toBe(true);
+    });
+
+    test("detects BMP", () => {
+      const buf = Buffer.from([0x42, 0x4d, 0x00, 0x00]);
+      expect(__testing.isImageByMagicBytes(buf)).toBe(true);
+    });
+
+    test("detects WebP", () => {
+      const buf = Buffer.alloc(12);
+      buf.write("RIFF", 0);
+      buf.write("WEBP", 8);
+      expect(__testing.isImageByMagicBytes(buf)).toBe(true);
+    });
+
+    test("returns false for text", () => {
+      const buf = Buffer.from("hello world", "utf-8");
+      expect(__testing.isImageByMagicBytes(buf)).toBe(false);
+    });
+  });
+
+  describe("detectAudioByMagicBytes", () => {
+    test("detects MP3 with ID3 tag", () => {
+      const buf = Buffer.from([0x49, 0x44, 0x33, 0x00]);
+      expect(__testing.detectAudioByMagicBytes(buf)).toEqual({ mimeType: "audio/mpeg" });
+    });
+
+    test("detects MP3 sync word", () => {
+      const buf = Buffer.from([0xff, 0xfb, 0x90, 0x00]);
+      expect(__testing.detectAudioByMagicBytes(buf)).toEqual({ mimeType: "audio/mpeg" });
+    });
+
+    test("detects OGG", () => {
+      const buf = Buffer.from([0x4f, 0x67, 0x67, 0x53]);
+      expect(__testing.detectAudioByMagicBytes(buf)).toEqual({ mimeType: "audio/ogg" });
+    });
+
+    test("detects FLAC", () => {
+      const buf = Buffer.from([0x66, 0x4c, 0x61, 0x43]);
+      expect(__testing.detectAudioByMagicBytes(buf)).toEqual({ mimeType: "audio/flac" });
+    });
+
+    test("detects WAV", () => {
+      const buf = Buffer.alloc(12);
+      buf.write("RIFF", 0);
+      buf.write("WAVE", 8);
+      expect(__testing.detectAudioByMagicBytes(buf)).toEqual({ mimeType: "audio/wav" });
+    });
+
+    test("detects M4A", () => {
+      const buf = Buffer.alloc(8);
+      buf.write("ftyp", 4);
+      expect(__testing.detectAudioByMagicBytes(buf)).toEqual({ mimeType: "audio/mp4" });
+    });
+
+    test("returns null for text", () => {
+      const buf = Buffer.from("hello world", "utf-8");
+      expect(__testing.detectAudioByMagicBytes(buf)).toBeNull();
+    });
+  });
+
+  // -- Read -----------------------------------------------------------------
+
+  describe("read", () => {
+    test("reads text file and returns content", () => {
+      const dir = freshTmpDir();
+      const filePath = path.join(dir, "hello.txt");
+      fs.writeFileSync(filePath, "line1\nline2\nline3\n");
+
+      const result = __testing.executeRead({ path: filePath });
+      expect(result.content).toBe("line1\nline2\nline3\n");
+      expect(result.imageData).toBeUndefined();
+    });
+
+    test("respects offset and limit", () => {
+      const dir = freshTmpDir();
+      const filePath = path.join(dir, "lines.txt");
+      fs.writeFileSync(filePath, "a\nb\nc\nd\ne");
+
+      const result = __testing.executeRead({ path: filePath, offset: 1, limit: 2 });
+      expect(result.content).toBe("b\nc");
+    });
+
+    test("returns base64 imageData for PNG file", () => {
+      const dir = freshTmpDir();
+      const filePath = path.join(dir, "img.png");
+      const pngHeader = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+      fs.writeFileSync(filePath, pngHeader);
+
+      const result = __testing.executeRead({ path: filePath });
+      expect(result.imageData).toBe(pngHeader.toString("base64"));
+      expect(result.content).toBeUndefined();
+    });
+
+    test("returns base64 audioData for WAV file", () => {
+      const dir = freshTmpDir();
+      const filePath = path.join(dir, "sound.wav");
+      const wavBuf = Buffer.alloc(16);
+      wavBuf.write("RIFF", 0);
+      wavBuf.writeUInt32LE(8, 4);
+      wavBuf.write("WAVE", 8);
+      fs.writeFileSync(filePath, wavBuf);
+
+      const result = __testing.executeRead({ path: filePath });
+      expect(result.audioData).toBe(wavBuf.toString("base64"));
+      expect(result.audioMimeType).toBe("audio/wav");
+      expect(result.content).toBeUndefined();
+    });
+  });
+
+  // -- Write ----------------------------------------------------------------
+
+  describe("write", () => {
+    test("writes content to file", () => {
+      const dir = freshTmpDir();
+      const filePath = path.join(dir, "out.txt");
+
+      const result = __testing.executeWrite({ path: filePath, content: "hello" });
+      expect(result.isError).toBeUndefined();
+      expect(fs.readFileSync(filePath, "utf-8")).toBe("hello");
+    });
+
+    test("creates parent directories", () => {
+      const dir = freshTmpDir();
+      const filePath = path.join(dir, "a", "b", "c", "deep.txt");
+
+      __testing.executeWrite({ path: filePath, content: "deep" });
+      expect(fs.readFileSync(filePath, "utf-8")).toBe("deep");
+    });
+  });
+
+  // -- Edit -----------------------------------------------------------------
+
+  describe("edit", () => {
+    test("replaces unique string", () => {
+      const dir = freshTmpDir();
+      const filePath = path.join(dir, "edit.txt");
+      fs.writeFileSync(filePath, "foo bar baz");
+
+      const result = __testing.executeEdit({
+        path: filePath,
+        old_string: "bar",
+        new_string: "qux",
+      });
+      expect(result.isError).toBeUndefined();
+      expect(fs.readFileSync(filePath, "utf-8")).toBe("foo qux baz");
+    });
+
+    test("errors when old_string not found", () => {
+      const dir = freshTmpDir();
+      const filePath = path.join(dir, "edit.txt");
+      fs.writeFileSync(filePath, "foo bar baz");
+
+      const result = __testing.executeEdit({
+        path: filePath,
+        old_string: "missing",
+        new_string: "x",
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("not found");
+    });
+
+    test("errors when old_string is not unique and replace_all is false", () => {
+      const dir = freshTmpDir();
+      const filePath = path.join(dir, "edit.txt");
+      fs.writeFileSync(filePath, "foo foo bar");
+
+      const result = __testing.executeEdit({
+        path: filePath,
+        old_string: "foo",
+        new_string: "x",
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("not unique");
+    });
+
+    test("replaces all occurrences when replace_all is true", () => {
+      const dir = freshTmpDir();
+      const filePath = path.join(dir, "edit.txt");
+      fs.writeFileSync(filePath, "foo foo bar");
+
+      const result = __testing.executeEdit({
+        path: filePath,
+        old_string: "foo",
+        new_string: "x",
+        replace_all: true,
+      });
+      expect(result.isError).toBeUndefined();
+      expect(fs.readFileSync(filePath, "utf-8")).toBe("x x bar");
+    });
+  });
+
+  // -- handleRequest integration --------------------------------------------
+
+  describe("handleRequest", () => {
+    test("posts read result to poster", async () => {
+      const dir = freshTmpDir();
+      const filePath = path.join(dir, "test.txt");
+      fs.writeFileSync(filePath, "content here");
+
+      const { poster, body } = capturingPoster();
+      hostFileExecutor.handleRequest(
+        { type: "host_file_request", requestId: "r1", operation: "read", path: filePath },
+        poster,
+      );
+      await flush();
+
+      expect(body()!.requestId).toBe("r1");
+      expect(body()!.content).toBe("content here");
+    });
+
+    test("posts error for missing operation", async () => {
+      const { poster, body } = capturingPoster();
+      hostFileExecutor.handleRequest(
+        { type: "host_file_request", requestId: "r2", path: "/tmp/x" },
+        poster,
+      );
+      await flush();
+
+      expect(body()!.isError).toBe(true);
+      expect(body()!.content).toContain("Missing operation");
+    });
+
+    test("posts error for fs failure", async () => {
+      const { poster, body } = capturingPoster();
+      hostFileExecutor.handleRequest(
+        { type: "host_file_request", requestId: "r3", operation: "read", path: "/nonexistent/path/file.txt" },
+        poster,
+      );
+      await flush();
+
+      expect(body()!.isError).toBe(true);
+    });
+  });
+
+  // -- Cancellation ---------------------------------------------------------
+
+  describe("cancellation", () => {
+    test("handleCancel removes requestId from pending set", () => {
+      __testing.pendingRequests.add("c1");
+      hostFileExecutor.handleCancel(
+        { type: "host_file_cancel", requestId: "c1" },
+        {} as InstanceType<typeof HostProxyPoster>,
+      );
+      expect(__testing.pendingRequests.has("c1")).toBe(false);
+    });
+  });
+});

--- a/apps/macos/src/main/executors/host-file-executor.ts
+++ b/apps/macos/src/main/executors/host-file-executor.ts
@@ -1,0 +1,252 @@
+/**
+ * Host file executor — handles read/write/edit operations on the local
+ * filesystem via the host proxy bridge.
+ *
+ * Plugs into the host-proxy-router via setExecutor("host_file", ...).
+ * Results are posted back to the daemon through HostProxyPoster.postFileResult.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import type { HostProxyExecutor } from "../host-proxy-router";
+import type { HostProxyPoster } from "../host-proxy-poster";
+import type { HostProxySseMessage } from "../host-proxy-sse";
+import log from "../logger";
+
+// ---------------------------------------------------------------------------
+// Magic-byte detection helpers
+// ---------------------------------------------------------------------------
+
+/** Check leading bytes against known image signatures. */
+function isImageByMagicBytes(buf: Buffer): boolean {
+  if (buf.length < 4) return false;
+  // PNG
+  if (buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47) return true;
+  // JPEG
+  if (buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff) return true;
+  // GIF
+  if (buf[0] === 0x47 && buf[1] === 0x49 && buf[2] === 0x46) return true;
+  // BMP
+  if (buf[0] === 0x42 && buf[1] === 0x4d) return true;
+  // WebP: RIFF....WEBP
+  if (
+    buf.length >= 12 &&
+    buf[0] === 0x52 && buf[1] === 0x49 && buf[2] === 0x46 && buf[3] === 0x46 &&
+    buf[8] === 0x57 && buf[9] === 0x45 && buf[10] === 0x42 && buf[11] === 0x50
+  ) return true;
+  return false;
+}
+
+interface AudioDetection {
+  mimeType: string;
+}
+
+/** Check leading bytes against known audio signatures. Returns mime type or null. */
+function detectAudioByMagicBytes(buf: Buffer): AudioDetection | null {
+  if (buf.length < 4) return null;
+  // MP3 — ID3 tag
+  if (buf[0] === 0x49 && buf[1] === 0x44 && buf[2] === 0x33) return { mimeType: "audio/mpeg" };
+  // MP3 — sync word 0xFF 0xFB (or 0xFF 0xEx)
+  if (buf[0] === 0xff && (buf[1] & 0xe0) === 0xe0) return { mimeType: "audio/mpeg" };
+  // OGG
+  if (buf[0] === 0x4f && buf[1] === 0x67 && buf[2] === 0x67 && buf[3] === 0x53) return { mimeType: "audio/ogg" };
+  // FLAC
+  if (buf[0] === 0x66 && buf[1] === 0x4c && buf[2] === 0x61 && buf[3] === 0x43) return { mimeType: "audio/flac" };
+  // WAV: RIFF....WAVE
+  if (
+    buf.length >= 12 &&
+    buf[0] === 0x52 && buf[1] === 0x49 && buf[2] === 0x46 && buf[3] === 0x46 &&
+    buf[8] === 0x57 && buf[9] === 0x41 && buf[10] === 0x56 && buf[11] === 0x45
+  ) return { mimeType: "audio/wav" };
+  // M4A: bytes 4-7 contain "ftyp"
+  if (
+    buf.length >= 8 &&
+    buf[4] === 0x66 && buf[5] === 0x74 && buf[6] === 0x79 && buf[7] === 0x70
+  ) return { mimeType: "audio/mp4" };
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Read operation
+// ---------------------------------------------------------------------------
+
+interface ReadFields {
+  path: string;
+  offset?: number;
+  limit?: number;
+}
+
+function executeRead(fields: ReadFields): {
+  content?: string;
+  imageData?: string;
+  audioData?: string;
+  audioMimeType?: string;
+  isError?: boolean;
+} {
+  const filePath = fields.path;
+  const raw = fs.readFileSync(filePath);
+
+  // Check for image
+  if (isImageByMagicBytes(raw)) {
+    return { imageData: raw.toString("base64") };
+  }
+
+  // Check for audio
+  const audio = detectAudioByMagicBytes(raw);
+  if (audio) {
+    return { audioData: raw.toString("base64"), audioMimeType: audio.mimeType };
+  }
+
+  // Text file — apply line-based offset/limit
+  const text = raw.toString("utf-8");
+  const lines = text.split("\n");
+  const offset = fields.offset ?? 0;
+  const limit = fields.limit ?? lines.length;
+  const sliced = lines.slice(offset, offset + limit);
+  return { content: sliced.join("\n") };
+}
+
+// ---------------------------------------------------------------------------
+// Write operation
+// ---------------------------------------------------------------------------
+
+interface WriteFields {
+  path: string;
+  content: string;
+}
+
+function executeWrite(fields: WriteFields): { content?: string; isError?: boolean } {
+  const filePath = fields.path;
+  const dir = path.dirname(filePath);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(filePath, fields.content, "utf-8");
+  return { content: `Wrote ${Buffer.byteLength(fields.content, "utf-8")} bytes to ${filePath}` };
+}
+
+// ---------------------------------------------------------------------------
+// Edit operation
+// ---------------------------------------------------------------------------
+
+interface EditFields {
+  path: string;
+  old_string: string;
+  new_string: string;
+  replace_all?: boolean;
+}
+
+function executeEdit(fields: EditFields): { content?: string; isError?: boolean } {
+  const filePath = fields.path;
+  const existing = fs.readFileSync(filePath, "utf-8");
+  const { old_string, new_string, replace_all } = fields;
+
+  const firstIdx = existing.indexOf(old_string);
+  if (firstIdx === -1) {
+    return { content: `old_string not found in ${filePath}`, isError: true };
+  }
+
+  if (!replace_all) {
+    const secondIdx = existing.indexOf(old_string, firstIdx + 1);
+    if (secondIdx !== -1) {
+      return { content: `old_string is not unique in ${filePath} (use replace_all to replace all occurrences)`, isError: true };
+    }
+    const updated = existing.slice(0, firstIdx) + new_string + existing.slice(firstIdx + old_string.length);
+    fs.writeFileSync(filePath, updated, "utf-8");
+  } else {
+    const updated = existing.split(old_string).join(new_string);
+    fs.writeFileSync(filePath, updated, "utf-8");
+  }
+
+  return { content: `Edited ${filePath}` };
+}
+
+// ---------------------------------------------------------------------------
+// Executor
+// ---------------------------------------------------------------------------
+
+const pendingRequests = new Set<string>();
+
+function handleRequest(message: HostProxySseMessage, poster: HostProxyPoster): void {
+  const requestId = message.requestId as string | undefined;
+  if (!requestId) {
+    log.warn("[host-file-executor] message missing requestId");
+    return;
+  }
+
+  const operation = message.operation as string | undefined;
+  const filePath = message.path as string | undefined;
+
+  if (!operation || !filePath) {
+    void poster.postFileResult({ requestId, content: "Missing operation or path", isError: true });
+    return;
+  }
+
+  pendingRequests.add(requestId);
+
+  try {
+    let result: { content?: string; imageData?: string; audioData?: string; audioMimeType?: string; isError?: boolean };
+
+    switch (operation) {
+      case "read":
+        result = executeRead({
+          path: filePath,
+          offset: message.offset as number | undefined,
+          limit: message.limit as number | undefined,
+        });
+        break;
+      case "write":
+        result = executeWrite({
+          path: filePath,
+          content: message.content as string ?? "",
+        });
+        break;
+      case "edit":
+        result = executeEdit({
+          path: filePath,
+          old_string: message.old_string as string ?? "",
+          new_string: message.new_string as string ?? "",
+          replace_all: message.replace_all as boolean | undefined,
+        });
+        break;
+      default:
+        result = { content: `Unknown operation: ${operation}`, isError: true };
+    }
+
+    if (!pendingRequests.has(requestId)) return;
+
+    void poster.postFileResult({ requestId, ...result });
+  } catch (err: unknown) {
+    if (!pendingRequests.has(requestId)) return;
+    const errMsg = err instanceof Error ? err.message : String(err);
+    void poster.postFileResult({ requestId, content: errMsg, isError: true });
+  } finally {
+    pendingRequests.delete(requestId);
+  }
+}
+
+function handleCancel(message: HostProxySseMessage): void {
+  const requestId = message.requestId as string | undefined;
+  if (requestId) {
+    pendingRequests.delete(requestId);
+  }
+}
+
+export const hostFileExecutor: HostProxyExecutor = {
+  handleRequest,
+  handleCancel,
+};
+
+// ---------------------------------------------------------------------------
+// Test seams
+// ---------------------------------------------------------------------------
+
+export const __testing = {
+  isImageByMagicBytes,
+  detectAudioByMagicBytes,
+  executeRead,
+  executeWrite,
+  executeEdit,
+  get pendingRequests() {
+    return pendingRequests;
+  },
+};

--- a/apps/macos/src/main/executors/host-file-executor.ts
+++ b/apps/macos/src/main/executors/host-file-executor.ts
@@ -101,7 +101,7 @@ function executeRead(fields: ReadFields): {
   // Text file — apply line-based offset/limit
   const text = raw.toString("utf-8");
   const lines = text.split("\n");
-  const offset = fields.offset ?? 0;
+  const offset = (fields.offset ?? 1) - 1;
   const limit = fields.limit ?? lines.length;
   const sliced = lines.slice(offset, offset + limit);
   return { content: sliced.join("\n") };

--- a/apps/macos/src/main/executors/host-transfer-executor.test.ts
+++ b/apps/macos/src/main/executors/host-transfer-executor.test.ts
@@ -1,0 +1,511 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// ---------------------------------------------------------------------------
+// Stubs — must precede the executor import
+// ---------------------------------------------------------------------------
+
+mock.module("electron-log/main", () => {
+  const noop = () => {};
+  return {
+    default: {
+      info: noop,
+      warn: noop,
+      error: noop,
+      debug: noop,
+      initialize: noop,
+      transports: {
+        file: {
+          maxSize: 0,
+          fileName: "",
+          format: "",
+          getFile: () => ({ path: "" }),
+        },
+      },
+    },
+  };
+});
+
+const MOCK_DEVICE_ID = "test-device-00000000-0000-0000-0000-000000000000";
+mock.module("../device-id", () => ({
+  getDeviceId: () => MOCK_DEVICE_ID,
+  resetDeviceIdCache: () => {},
+}));
+
+const { HostProxyPoster } = await import("../host-proxy-poster");
+const { hostTransferExecutor, __testing } = await import(
+  "./host-transfer-executor"
+);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const TEST_DIR = path.join(
+  os.tmpdir(),
+  `host-transfer-test-${process.pid}`,
+);
+
+function sha256hex(data: Buffer): string {
+  return createHash("sha256").update(data).digest("hex");
+}
+
+interface PosterCapture {
+  poster: InstanceType<typeof HostProxyPoster>;
+  transferResult: () => Record<string, unknown> | null;
+  pullData: Buffer;
+  pushCalls: Array<{ transferId: string; data: Buffer; sha256: string }>;
+  pushReturn: boolean;
+}
+
+/**
+ * Build a poster with injectable pull/push behavior and result capture.
+ */
+function capturingPoster(opts: {
+  pullData?: Buffer;
+  pushReturn?: boolean;
+}): PosterCapture {
+  const pullData = opts.pullData ?? Buffer.alloc(0);
+  const pushReturn = opts.pushReturn ?? true;
+  let transferResult: Record<string, unknown> | null = null;
+  const pushCalls: PosterCapture["pushCalls"] = [];
+
+  const fakeFetch = async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url = typeof input === "string" ? input : input.toString();
+
+    // POST to host-transfer-result
+    if (url.includes("/v1/host-transfer-result") && init?.method === "POST") {
+      transferResult = JSON.parse(init.body as string);
+      return new Response("ok");
+    }
+
+    // GET transfer content (pull)
+    if (url.includes("/v1/transfers/") && init?.method === "GET") {
+      if (pullData.length === 0) {
+        return new Response(null, { status: 404 });
+      }
+      return new Response(pullData, { status: 200 });
+    }
+
+    // PUT transfer content (push)
+    if (url.includes("/v1/transfers/") && init?.method === "PUT") {
+      const idMatch = url.match(/\/v1\/transfers\/([^/]+)\/content/);
+      const transferId = idMatch ? decodeURIComponent(idMatch[1]) : "";
+      const headers = init.headers as Record<string, string>;
+      let body: Buffer;
+      if (Buffer.isBuffer(init.body)) {
+        body = init.body;
+      } else if (init.body instanceof Uint8Array) {
+        body = Buffer.from(init.body);
+      } else {
+        body = Buffer.from(init.body as string);
+      }
+      pushCalls.push({
+        transferId,
+        data: body,
+        sha256: headers["X-Transfer-SHA256"],
+      });
+      return new Response("ok", { status: pushReturn ? 200 : 500 });
+    }
+
+    return new Response("not found", { status: 404 });
+  };
+
+  const poster = new HostProxyPoster({
+    gatewayPort: 9000,
+    authToken: "test-token",
+    fetch: fakeFetch as typeof globalThis.fetch,
+  });
+
+  return {
+    poster,
+    transferResult: () => transferResult,
+    pullData,
+    pushCalls,
+    pushReturn,
+  };
+}
+
+async function flush(ms = 50): Promise<void> {
+  await new Promise((r) => setTimeout(r, ms));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("host-transfer-executor", () => {
+  beforeEach(() => {
+    fs.mkdirSync(TEST_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    __testing.reset();
+    fs.rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  // -- to_host --------------------------------------------------------------
+
+  describe("to_host", () => {
+    test("writes file with SHA-256 verification", async () => {
+      const fileContent = Buffer.from("hello, host filesystem!");
+      const hash = sha256hex(fileContent);
+      const destPath = path.join(TEST_DIR, "subdir", "received.txt");
+
+      const cap = capturingPoster({ pullData: fileContent });
+
+      hostTransferExecutor.handleRequest(
+        {
+          type: "host_transfer_request",
+          requestId: "r1",
+          direction: "to_host",
+          transferId: "xfer-1",
+          destPath,
+          sha256: hash,
+          overwrite: false,
+        },
+        cap.poster,
+      );
+      await flush();
+
+      expect(cap.transferResult()).not.toBeNull();
+      expect(cap.transferResult()!.requestId).toBe("r1");
+      expect(cap.transferResult()!.isError).toBe(false);
+      expect(cap.transferResult()!.bytesWritten).toBe(fileContent.length);
+
+      const written = fs.readFileSync(destPath);
+      expect(written.toString()).toBe("hello, host filesystem!");
+    });
+
+    test("fails on SHA-256 mismatch", async () => {
+      const fileContent = Buffer.from("correct data");
+      const destPath = path.join(TEST_DIR, "bad-sha.txt");
+
+      const cap = capturingPoster({ pullData: fileContent });
+
+      hostTransferExecutor.handleRequest(
+        {
+          type: "host_transfer_request",
+          requestId: "r2",
+          direction: "to_host",
+          transferId: "xfer-2",
+          destPath,
+          sha256: "0000000000000000000000000000000000000000000000000000000000000000",
+          overwrite: false,
+        },
+        cap.poster,
+      );
+      await flush();
+
+      expect(cap.transferResult()!.isError).toBe(true);
+      expect(cap.transferResult()!.errorMessage).toContain("SHA-256 mismatch");
+      expect(fs.existsSync(destPath)).toBe(false);
+    });
+
+    test("respects overwrite=false when file exists", async () => {
+      const destPath = path.join(TEST_DIR, "existing.txt");
+      fs.writeFileSync(destPath, "original");
+
+      const fileContent = Buffer.from("replacement");
+      const hash = sha256hex(fileContent);
+      const cap = capturingPoster({ pullData: fileContent });
+
+      hostTransferExecutor.handleRequest(
+        {
+          type: "host_transfer_request",
+          requestId: "r3",
+          direction: "to_host",
+          transferId: "xfer-3",
+          destPath,
+          sha256: hash,
+          overwrite: false,
+        },
+        cap.poster,
+      );
+      await flush();
+
+      expect(cap.transferResult()!.isError).toBe(true);
+      expect(cap.transferResult()!.errorMessage).toContain("already exists");
+      expect(fs.readFileSync(destPath, "utf-8")).toBe("original");
+    });
+
+    test("overwrites when overwrite=true", async () => {
+      const destPath = path.join(TEST_DIR, "overwrite-me.txt");
+      fs.writeFileSync(destPath, "original");
+
+      const fileContent = Buffer.from("replacement");
+      const hash = sha256hex(fileContent);
+      const cap = capturingPoster({ pullData: fileContent });
+
+      hostTransferExecutor.handleRequest(
+        {
+          type: "host_transfer_request",
+          requestId: "r4",
+          direction: "to_host",
+          transferId: "xfer-4",
+          destPath,
+          sha256: hash,
+          overwrite: true,
+        },
+        cap.poster,
+      );
+      await flush();
+
+      expect(cap.transferResult()!.isError).toBe(false);
+      expect(fs.readFileSync(destPath, "utf-8")).toBe("replacement");
+    });
+
+    test("reports error when pull returns empty data", async () => {
+      const cap = capturingPoster({ pullData: Buffer.alloc(0) });
+
+      hostTransferExecutor.handleRequest(
+        {
+          type: "host_transfer_request",
+          requestId: "r5",
+          direction: "to_host",
+          transferId: "xfer-5",
+          destPath: path.join(TEST_DIR, "nope.txt"),
+          sha256: "abc",
+        },
+        cap.poster,
+      );
+      await flush();
+
+      expect(cap.transferResult()!.isError).toBe(true);
+      expect(cap.transferResult()!.errorMessage).toContain(
+        "Failed to pull transfer content",
+      );
+    });
+  });
+
+  // -- to_sandbox -----------------------------------------------------------
+
+  describe("to_sandbox", () => {
+    test("reads file and pushes with SHA-256", async () => {
+      const sourcePath = path.join(TEST_DIR, "upload.txt");
+      const content = Buffer.from("push me to sandbox");
+      fs.writeFileSync(sourcePath, content);
+
+      const cap = capturingPoster({ pushReturn: true });
+
+      hostTransferExecutor.handleRequest(
+        {
+          type: "host_transfer_request",
+          requestId: "r6",
+          direction: "to_sandbox",
+          transferId: "xfer-6",
+          sourcePath,
+        },
+        cap.poster,
+      );
+      await flush();
+
+      expect(cap.transferResult()!.isError).toBe(false);
+      expect(cap.transferResult()!.bytesWritten).toBe(content.length);
+
+      expect(cap.pushCalls).toHaveLength(1);
+      expect(cap.pushCalls[0].transferId).toBe("xfer-6");
+      expect(cap.pushCalls[0].data.toString()).toBe("push me to sandbox");
+      expect(cap.pushCalls[0].sha256).toBe(sha256hex(content));
+    });
+
+    test("reports error when source file does not exist", async () => {
+      const cap = capturingPoster({ pushReturn: true });
+
+      hostTransferExecutor.handleRequest(
+        {
+          type: "host_transfer_request",
+          requestId: "r7",
+          direction: "to_sandbox",
+          transferId: "xfer-7",
+          sourcePath: path.join(TEST_DIR, "nonexistent.txt"),
+        },
+        cap.poster,
+      );
+      await flush();
+
+      expect(cap.transferResult()!.isError).toBe(true);
+      expect(cap.transferResult()!.errorMessage).toContain(
+        "Failed to read source file",
+      );
+    });
+
+    test("reports error when push fails", async () => {
+      const sourcePath = path.join(TEST_DIR, "push-fail.txt");
+      fs.writeFileSync(sourcePath, "data");
+
+      const cap = capturingPoster({ pushReturn: false });
+
+      hostTransferExecutor.handleRequest(
+        {
+          type: "host_transfer_request",
+          requestId: "r8",
+          direction: "to_sandbox",
+          transferId: "xfer-8",
+          sourcePath,
+        },
+        cap.poster,
+      );
+      await flush();
+
+      expect(cap.transferResult()!.isError).toBe(true);
+      expect(cap.transferResult()!.errorMessage).toContain(
+        "Failed to push transfer content",
+      );
+    });
+  });
+
+  // -- Cancellation ---------------------------------------------------------
+
+  describe("cancellation", () => {
+    test("cancelling suppresses the result for to_host", async () => {
+      const fileContent = Buffer.from("cancelled transfer");
+      const hash = sha256hex(fileContent);
+      const destPath = path.join(TEST_DIR, "cancelled.txt");
+
+      // Use a slow pull to give us time to cancel
+      let pullResolve: ((value: Response) => void) | null = null;
+      const slowFetch = async (
+        input: string | URL | Request,
+        init?: RequestInit,
+      ): Promise<Response> => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("/v1/transfers/") && init?.method === "GET") {
+          return new Promise<Response>((resolve) => {
+            pullResolve = resolve;
+          });
+        }
+        if (url.includes("/v1/host-transfer-result")) {
+          return new Response("ok");
+        }
+        return new Response("not found", { status: 404 });
+      };
+
+      const poster = new HostProxyPoster({
+        gatewayPort: 9000,
+        authToken: "t",
+        fetch: slowFetch as typeof globalThis.fetch,
+      });
+
+      hostTransferExecutor.handleRequest(
+        {
+          type: "host_transfer_request",
+          requestId: "cancel-1",
+          direction: "to_host",
+          transferId: "xfer-cancel",
+          destPath,
+          sha256: hash,
+        },
+        poster,
+      );
+
+      // Cancel before pull resolves
+      hostTransferExecutor.handleCancel(
+        { type: "host_transfer_cancel", requestId: "cancel-1" },
+        poster,
+      );
+
+      // Now resolve the pull
+      pullResolve!(new Response(fileContent, { status: 200 }));
+      await flush();
+
+      // File should not be written because the request was cancelled
+      expect(fs.existsSync(destPath)).toBe(false);
+    });
+
+    test("cancelling a to_sandbox suppresses the result", async () => {
+      const sourcePath = path.join(TEST_DIR, "cancel-upload.txt");
+      fs.writeFileSync(sourcePath, "data");
+
+      let transferResult: Record<string, unknown> | null = null;
+      let pushResolve: ((value: Response) => void) | null = null;
+
+      const slowFetch = async (
+        input: string | URL | Request,
+        init?: RequestInit,
+      ): Promise<Response> => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("/v1/transfers/") && init?.method === "PUT") {
+          return new Promise<Response>((resolve) => {
+            pushResolve = resolve;
+          });
+        }
+        if (url.includes("/v1/host-transfer-result") && init?.method === "POST") {
+          transferResult = JSON.parse(init.body as string);
+          return new Response("ok");
+        }
+        return new Response("not found", { status: 404 });
+      };
+
+      const poster = new HostProxyPoster({
+        gatewayPort: 9000,
+        authToken: "t",
+        fetch: slowFetch as typeof globalThis.fetch,
+      });
+
+      hostTransferExecutor.handleRequest(
+        {
+          type: "host_transfer_request",
+          requestId: "cancel-2",
+          direction: "to_sandbox",
+          transferId: "xfer-cancel-2",
+          sourcePath,
+        },
+        poster,
+      );
+
+      // Cancel before push resolves
+      hostTransferExecutor.handleCancel(
+        { type: "host_transfer_cancel", requestId: "cancel-2" },
+        poster,
+      );
+
+      // Resolve the push
+      pushResolve!(new Response("ok", { status: 200 }));
+      await flush();
+
+      // No result should have been posted
+      expect(transferResult).toBeNull();
+    });
+  });
+
+  // -- Edge cases -----------------------------------------------------------
+
+  describe("edge cases", () => {
+    test("unknown direction posts error", async () => {
+      const cap = capturingPoster({});
+
+      hostTransferExecutor.handleRequest(
+        {
+          type: "host_transfer_request",
+          requestId: "r-bad",
+          direction: "sideways",
+          transferId: "xfer-bad",
+        },
+        cap.poster,
+      );
+      await flush();
+
+      expect(cap.transferResult()!.isError).toBe(true);
+      expect(cap.transferResult()!.errorMessage).toContain("Unknown transfer direction");
+    });
+
+    test("missing requestId is a no-op", () => {
+      const cap = capturingPoster({});
+
+      // Should not throw
+      hostTransferExecutor.handleRequest(
+        { type: "host_transfer_request", direction: "to_host" },
+        cap.poster,
+      );
+
+      expect(cap.transferResult()).toBeNull();
+    });
+  });
+});

--- a/apps/macos/src/main/executors/host-transfer-executor.ts
+++ b/apps/macos/src/main/executors/host-transfer-executor.ts
@@ -1,0 +1,199 @@
+/**
+ * Host transfer executor — handles bidirectional file transfers between
+ * the daemon sandbox and the host filesystem.
+ *
+ * Two directions:
+ *  - to_host: pull file bytes from the daemon, verify SHA-256, write to disk.
+ *  - to_sandbox: read file from disk, compute SHA-256, push bytes to daemon.
+ *
+ * Tracks in-flight transfers so cancellation can suppress late results.
+ */
+
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+import type { HostProxyExecutor } from "../host-proxy-router";
+import type { HostProxyPoster } from "../host-proxy-poster";
+import type { HostProxySseMessage } from "../host-proxy-sse";
+import log from "../logger";
+
+// ---------------------------------------------------------------------------
+// Cancellation tracking
+// ---------------------------------------------------------------------------
+
+const cancelledRequests = new Set<string>();
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function sha256(data: Buffer): string {
+  return createHash("sha256").update(data).digest("hex");
+}
+
+// ---------------------------------------------------------------------------
+// Direction handlers
+// ---------------------------------------------------------------------------
+
+async function handleToHost(
+  message: HostProxySseMessage,
+  poster: HostProxyPoster,
+): Promise<void> {
+  const requestId = message.requestId as string;
+  const transferId = message.transferId as string;
+  const destPath = message.destPath as string;
+  const expectedSha = message.sha256 as string;
+  const overwrite = message.overwrite as boolean | undefined;
+
+  const data = await poster.pullTransferContent(transferId);
+
+  if (cancelledRequests.has(requestId)) {
+    cancelledRequests.delete(requestId);
+    return;
+  }
+
+  if (data.length === 0) {
+    void poster.postTransferResult({
+      requestId,
+      isError: true,
+      errorMessage: "Failed to pull transfer content from daemon",
+    });
+    return;
+  }
+
+  const actualSha = sha256(data);
+  if (actualSha !== expectedSha) {
+    void poster.postTransferResult({
+      requestId,
+      isError: true,
+      errorMessage: `SHA-256 mismatch: expected ${expectedSha}, got ${actualSha}`,
+    });
+    return;
+  }
+
+  if (existsSync(destPath) && !overwrite) {
+    void poster.postTransferResult({
+      requestId,
+      isError: true,
+      errorMessage: `File already exists and overwrite is not set: ${destPath}`,
+    });
+    return;
+  }
+
+  try {
+    mkdirSync(dirname(destPath), { recursive: true });
+    writeFileSync(destPath, data);
+  } catch (err) {
+    void poster.postTransferResult({
+      requestId,
+      isError: true,
+      errorMessage: `Failed to write file: ${err}`,
+    });
+    return;
+  }
+
+  void poster.postTransferResult({
+    requestId,
+    isError: false,
+    bytesWritten: data.length,
+  });
+}
+
+async function handleToSandbox(
+  message: HostProxySseMessage,
+  poster: HostProxyPoster,
+): Promise<void> {
+  const requestId = message.requestId as string;
+  const transferId = message.transferId as string;
+  const sourcePath = message.sourcePath as string;
+
+  let data: Buffer;
+  try {
+    data = readFileSync(sourcePath);
+  } catch (err) {
+    void poster.postTransferResult({
+      requestId,
+      isError: true,
+      errorMessage: `Failed to read source file: ${err}`,
+    });
+    return;
+  }
+
+  if (cancelledRequests.has(requestId)) {
+    cancelledRequests.delete(requestId);
+    return;
+  }
+
+  const hash = sha256(data);
+  const pushed = await poster.pushTransferContent(transferId, data, hash);
+
+  if (cancelledRequests.has(requestId)) {
+    cancelledRequests.delete(requestId);
+    return;
+  }
+
+  if (!pushed) {
+    void poster.postTransferResult({
+      requestId,
+      isError: true,
+      errorMessage: "Failed to push transfer content to daemon",
+    });
+    return;
+  }
+
+  void poster.postTransferResult({
+    requestId,
+    isError: false,
+    bytesWritten: data.length,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Executor
+// ---------------------------------------------------------------------------
+
+export const hostTransferExecutor: HostProxyExecutor = {
+  handleRequest(message: HostProxySseMessage, poster: HostProxyPoster): void {
+    const direction = message.direction as string | undefined;
+    const requestId = message.requestId as string | undefined;
+
+    if (!requestId) {
+      log.warn("[host-transfer] message missing requestId");
+      return;
+    }
+
+    if (direction === "to_host") {
+      void handleToHost(message, poster);
+    } else if (direction === "to_sandbox") {
+      void handleToSandbox(message, poster);
+    } else {
+      log.warn("[host-transfer] unknown direction", { direction, requestId });
+      void poster.postTransferResult({
+        requestId,
+        isError: true,
+        errorMessage: `Unknown transfer direction: ${direction}`,
+      });
+    }
+  },
+
+  handleCancel(message: HostProxySseMessage, _poster: HostProxyPoster): void {
+    const requestId = message.requestId as string | undefined;
+    if (requestId) {
+      cancelledRequests.add(requestId);
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Test seam
+// ---------------------------------------------------------------------------
+
+export const __testing = {
+  get cancelledRequests() {
+    return cancelledRequests;
+  },
+  reset() {
+    cancelledRequests.clear();
+  },
+};

--- a/apps/macos/src/main/executors/host-transfer-executor.ts
+++ b/apps/macos/src/main/executors/host-transfer-executor.ts
@@ -53,7 +53,7 @@ async function handleToHost(
     return;
   }
 
-  if (data.length === 0) {
+  if (data === null) {
     void poster.postTransferResult({
       requestId,
       isError: true,

--- a/apps/macos/src/main/host-proxy-poster.test.ts
+++ b/apps/macos/src/main/host-proxy-poster.test.ts
@@ -1,0 +1,455 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// ---------------------------------------------------------------------------
+// Stub device-id so we get a deterministic client ID without touching disk.
+// ---------------------------------------------------------------------------
+
+const TEST_DIR = path.join(os.tmpdir(), `host-proxy-poster-test-${process.pid}`);
+const DEVICE_FILE = path.join(TEST_DIR, "device.json");
+const FAKE_DEVICE_ID = "test-device-00000000-0000-0000-0000-000000000000";
+
+let mockEnvironment = "dev";
+mock.module("@vellumai/local-mode", () => ({
+  resolveConfigDir: () => TEST_DIR,
+  resolveEnvironmentName: () => mockEnvironment,
+}));
+
+// Write a device.json so getDeviceId returns our deterministic value.
+fs.mkdirSync(TEST_DIR, { recursive: true });
+fs.writeFileSync(
+  DEVICE_FILE,
+  JSON.stringify({ deviceId: FAKE_DEVICE_ID }, null, 2) + "\n",
+);
+
+// Import device-id first so the cache is seeded, then import the poster.
+const { resetDeviceIdCache } = await import("./device-id");
+resetDeviceIdCache();
+const { getDeviceId } = await import("./device-id");
+// Prime the cache with our fake ID
+getDeviceId();
+
+const { HostProxyPoster } = await import("./host-proxy-poster");
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+interface CapturedRequest {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: string | null;
+  rawBody: Buffer | null;
+}
+
+function createMockFetch(
+  status = 200,
+  responseBody: unknown = { accepted: true },
+) {
+  const captured: CapturedRequest[] = [];
+  const fetchFn = async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url = typeof input === "string" ? input : input.toString();
+    const method = init?.method ?? "GET";
+    const headers: Record<string, string> = {};
+    if (init?.headers) {
+      const h = init.headers as Record<string, string>;
+      for (const [k, v] of Object.entries(h)) {
+        headers[k] = v;
+      }
+    }
+
+    let body: string | null = null;
+    let rawBody: Buffer | null = null;
+    if (init?.body != null) {
+      if (typeof init.body === "string") {
+        body = init.body;
+      } else if (Buffer.isBuffer(init.body)) {
+        rawBody = init.body;
+      } else if (init.body instanceof Uint8Array) {
+        rawBody = Buffer.from(init.body);
+      }
+    }
+
+    captured.push({ url, method, headers, body, rawBody });
+
+    const resBody =
+      typeof responseBody === "string"
+        ? responseBody
+        : JSON.stringify(responseBody);
+    return new Response(resBody, {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+  return { fetchFn: fetchFn as typeof globalThis.fetch, captured };
+}
+
+function createBinaryMockFetch(status: number, data: Buffer) {
+  const captured: CapturedRequest[] = [];
+  const fetchFn = async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url = typeof input === "string" ? input : input.toString();
+    const method = init?.method ?? "GET";
+    const headers: Record<string, string> = {};
+    if (init?.headers) {
+      const h = init.headers as Record<string, string>;
+      for (const [k, v] of Object.entries(h)) {
+        headers[k] = v;
+      }
+    }
+    captured.push({ url, method, headers, body: null, rawBody: null });
+    return new Response(data, {
+      status,
+      headers: { "Content-Type": "application/octet-stream" },
+    });
+  };
+  return { fetchFn: fetchFn as typeof globalThis.fetch, captured };
+}
+
+function makePoster(
+  fetchFn: typeof globalThis.fetch,
+  overrides?: { gatewayPort?: number; gatewayHost?: string; authToken?: string },
+) {
+  return new HostProxyPoster({
+    gatewayPort: overrides?.gatewayPort ?? 9000,
+    gatewayHost: overrides?.gatewayHost,
+    authToken: overrides?.authToken ?? "test-token",
+    fetch: fetchFn,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Cleanup
+// ---------------------------------------------------------------------------
+
+afterEach(() => {
+  resetDeviceIdCache();
+  // Re-prime the cache for the next test
+  getDeviceId();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("HostProxyPoster", () => {
+  describe("postBashResult", () => {
+    test("sends correct URL, method, headers, and body", async () => {
+      const { fetchFn, captured } = createMockFetch();
+      const poster = makePoster(fetchFn);
+
+      const result = await poster.postBashResult({
+        requestId: "req-1",
+        stdout: "hello",
+        stderr: "",
+        exitCode: 0,
+        timedOut: false,
+      });
+
+      expect(result).toBe(true);
+      expect(captured).toHaveLength(1);
+
+      const req = captured[0];
+      expect(req.url).toBe("http://127.0.0.1:9000/v1/host-bash-result");
+      expect(req.method).toBe("POST");
+      expect(req.headers["Content-Type"]).toBe("application/json");
+      expect(req.headers["Authorization"]).toBe("Bearer test-token");
+      expect(req.headers["X-Vellum-Client-Id"]).toBe(FAKE_DEVICE_ID);
+
+      const body = JSON.parse(req.body!);
+      expect(body.requestId).toBe("req-1");
+      expect(body.stdout).toBe("hello");
+      expect(body.exitCode).toBe(0);
+    });
+  });
+
+  describe("postFileResult", () => {
+    test("sends correct URL and body fields", async () => {
+      const { fetchFn, captured } = createMockFetch();
+      const poster = makePoster(fetchFn);
+
+      const result = await poster.postFileResult({
+        requestId: "req-2",
+        content: "file-content",
+        isError: false,
+        imageData: "base64img",
+      });
+
+      expect(result).toBe(true);
+      const req = captured[0];
+      expect(req.url).toBe("http://127.0.0.1:9000/v1/host-file-result");
+
+      const body = JSON.parse(req.body!);
+      expect(body.requestId).toBe("req-2");
+      expect(body.content).toBe("file-content");
+      expect(body.imageData).toBe("base64img");
+    });
+  });
+
+  describe("postTransferResult", () => {
+    test("sends correct URL and body fields", async () => {
+      const { fetchFn, captured } = createMockFetch();
+      const poster = makePoster(fetchFn);
+
+      const result = await poster.postTransferResult({
+        requestId: "req-3",
+        isError: false,
+        bytesWritten: 1024,
+      });
+
+      expect(result).toBe(true);
+      const req = captured[0];
+      expect(req.url).toBe("http://127.0.0.1:9000/v1/host-transfer-result");
+
+      const body = JSON.parse(req.body!);
+      expect(body.requestId).toBe("req-3");
+      expect(body.bytesWritten).toBe(1024);
+    });
+  });
+
+  describe("postBrowserResult", () => {
+    test("sends correct URL and body fields", async () => {
+      const { fetchFn, captured } = createMockFetch();
+      const poster = makePoster(fetchFn);
+
+      const result = await poster.postBrowserResult({
+        requestId: "req-4",
+        content: '{"result": true}',
+        isError: false,
+      });
+
+      expect(result).toBe(true);
+      const req = captured[0];
+      expect(req.url).toBe("http://127.0.0.1:9000/v1/host-browser-result");
+
+      const body = JSON.parse(req.body!);
+      expect(body.requestId).toBe("req-4");
+      expect(body.content).toBe('{"result": true}');
+    });
+  });
+
+  describe("postCuResult", () => {
+    test("sends correct URL and body fields", async () => {
+      const { fetchFn, captured } = createMockFetch();
+      const poster = makePoster(fetchFn);
+
+      const result = await poster.postCuResult({
+        requestId: "req-5",
+        screenshot: "base64screenshot",
+        screenshotWidthPx: 1920,
+        screenshotHeightPx: 1080,
+        screenWidthPt: 1920,
+        screenHeightPt: 1080,
+        executionResult: "done",
+      });
+
+      expect(result).toBe(true);
+      const req = captured[0];
+      expect(req.url).toBe("http://127.0.0.1:9000/v1/host-cu-result");
+
+      const body = JSON.parse(req.body!);
+      expect(body.requestId).toBe("req-5");
+      expect(body.screenshot).toBe("base64screenshot");
+      expect(body.screenshotWidthPx).toBe(1920);
+    });
+  });
+
+  describe("postAppControlResult", () => {
+    test("sends correct URL and body fields", async () => {
+      const { fetchFn, captured } = createMockFetch();
+      const poster = makePoster(fetchFn);
+
+      const result = await poster.postAppControlResult({
+        requestId: "req-6",
+        state: "running",
+        pngBase64: "base64png",
+        windowBounds: { x: 0, y: 0, width: 800, height: 600 },
+        executionResult: "ok",
+      });
+
+      expect(result).toBe(true);
+      const req = captured[0];
+      expect(req.url).toBe(
+        "http://127.0.0.1:9000/v1/host-app-control-result",
+      );
+
+      const body = JSON.parse(req.body!);
+      expect(body.requestId).toBe("req-6");
+      expect(body.state).toBe("running");
+      expect(body.windowBounds).toEqual({
+        x: 0,
+        y: 0,
+        width: 800,
+        height: 600,
+      });
+    });
+  });
+
+  describe("pullTransferContent", () => {
+    test("returns buffer on success", async () => {
+      const payload = Buffer.from("file-bytes-here");
+      const { fetchFn, captured } = createBinaryMockFetch(200, payload);
+      const poster = makePoster(fetchFn);
+
+      const buf = await poster.pullTransferContent("xfer-1");
+
+      expect(Buffer.isBuffer(buf)).toBe(true);
+      expect(buf.toString()).toBe("file-bytes-here");
+
+      const req = captured[0];
+      expect(req.url).toBe(
+        "http://127.0.0.1:9000/v1/transfers/xfer-1/content",
+      );
+      expect(req.method).toBe("GET");
+      expect(req.headers["Authorization"]).toBe("Bearer test-token");
+      expect(req.headers["X-Vellum-Client-Id"]).toBe(FAKE_DEVICE_ID);
+    });
+
+    test("returns empty buffer on non-2xx", async () => {
+      const { fetchFn } = createBinaryMockFetch(404, Buffer.alloc(0));
+      const poster = makePoster(fetchFn);
+
+      const buf = await poster.pullTransferContent("xfer-missing");
+
+      expect(buf.length).toBe(0);
+    });
+
+    test("URL-encodes the transfer ID", async () => {
+      const { fetchFn, captured } = createBinaryMockFetch(
+        200,
+        Buffer.from("ok"),
+      );
+      const poster = makePoster(fetchFn);
+
+      await poster.pullTransferContent("id/with special&chars");
+
+      expect(captured[0].url).toBe(
+        "http://127.0.0.1:9000/v1/transfers/id%2Fwith%20special%26chars/content",
+      );
+    });
+  });
+
+  describe("pushTransferContent", () => {
+    test("sends binary data with correct headers", async () => {
+      const { fetchFn, captured } = createMockFetch();
+      const poster = makePoster(fetchFn);
+      const data = Buffer.from("binary-payload");
+
+      const result = await poster.pushTransferContent(
+        "xfer-2",
+        data,
+        "abc123sha256",
+      );
+
+      expect(result).toBe(true);
+      const req = captured[0];
+      expect(req.url).toBe(
+        "http://127.0.0.1:9000/v1/transfers/xfer-2/content",
+      );
+      expect(req.method).toBe("PUT");
+      expect(req.headers["Content-Type"]).toBe("application/octet-stream");
+      expect(req.headers["X-Transfer-SHA256"]).toBe("abc123sha256");
+      expect(req.headers["Authorization"]).toBe("Bearer test-token");
+    });
+
+    test("returns false on non-2xx", async () => {
+      const { fetchFn } = createMockFetch(500);
+      const poster = makePoster(fetchFn);
+
+      const result = await poster.pushTransferContent(
+        "xfer-3",
+        Buffer.from("x"),
+        "sha",
+      );
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("error handling", () => {
+    test("returns false on non-2xx status", async () => {
+      const { fetchFn } = createMockFetch(500);
+      const poster = makePoster(fetchFn);
+
+      const result = await poster.postBashResult({
+        requestId: "req-err",
+        stdout: "",
+      });
+
+      expect(result).toBe(false);
+    });
+
+    test("returns false when fetch throws", async () => {
+      const throwingFetch = (async () => {
+        throw new Error("network failure");
+      }) as unknown as typeof globalThis.fetch;
+      const poster = makePoster(throwingFetch);
+
+      const result = await poster.postBashResult({
+        requestId: "req-throw",
+        stdout: "",
+      });
+
+      expect(result).toBe(false);
+    });
+
+    test("pullTransferContent returns empty buffer when fetch throws", async () => {
+      const throwingFetch = (async () => {
+        throw new Error("network failure");
+      }) as unknown as typeof globalThis.fetch;
+      const poster = makePoster(throwingFetch);
+
+      const buf = await poster.pullTransferContent("xfer-throw");
+
+      expect(buf.length).toBe(0);
+    });
+
+    test("pushTransferContent returns false when fetch throws", async () => {
+      const throwingFetch = (async () => {
+        throw new Error("network failure");
+      }) as unknown as typeof globalThis.fetch;
+      const poster = makePoster(throwingFetch);
+
+      const result = await poster.pushTransferContent(
+        "xfer-throw",
+        Buffer.from("x"),
+        "sha",
+      );
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("configuration", () => {
+    test("uses custom gatewayHost when provided", async () => {
+      const { fetchFn, captured } = createMockFetch();
+      const poster = makePoster(fetchFn, {
+        gatewayHost: "192.168.1.100",
+        gatewayPort: 8080,
+      });
+
+      await poster.postBashResult({ requestId: "req-host", stdout: "" });
+
+      expect(captured[0].url).toBe(
+        "http://192.168.1.100:8080/v1/host-bash-result",
+      );
+    });
+
+    test("defaults gatewayHost to 127.0.0.1", async () => {
+      const { fetchFn, captured } = createMockFetch();
+      const poster = makePoster(fetchFn);
+
+      await poster.postBashResult({ requestId: "req-default", stdout: "" });
+
+      expect(captured[0].url).toStartWith("http://127.0.0.1:9000/");
+    });
+  });
+});

--- a/apps/macos/src/main/host-proxy-poster.test.ts
+++ b/apps/macos/src/main/host-proxy-poster.test.ts
@@ -301,8 +301,9 @@ describe("HostProxyPoster", () => {
 
       const buf = await poster.pullTransferContent("xfer-1");
 
+      expect(buf).not.toBeNull();
       expect(Buffer.isBuffer(buf)).toBe(true);
-      expect(buf.toString()).toBe("file-bytes-here");
+      expect(buf!.toString()).toBe("file-bytes-here");
 
       const req = captured[0];
       expect(req.url).toBe(
@@ -313,13 +314,13 @@ describe("HostProxyPoster", () => {
       expect(req.headers["X-Vellum-Client-Id"]).toBe(FAKE_DEVICE_ID);
     });
 
-    test("returns empty buffer on non-2xx", async () => {
+    test("returns null on non-2xx", async () => {
       const { fetchFn } = createBinaryMockFetch(404, Buffer.alloc(0));
       const poster = makePoster(fetchFn);
 
       const buf = await poster.pullTransferContent("xfer-missing");
 
-      expect(buf.length).toBe(0);
+      expect(buf).toBeNull();
     });
 
     test("URL-encodes the transfer ID", async () => {
@@ -401,7 +402,7 @@ describe("HostProxyPoster", () => {
       expect(result).toBe(false);
     });
 
-    test("pullTransferContent returns empty buffer when fetch throws", async () => {
+    test("pullTransferContent returns null when fetch throws", async () => {
       const throwingFetch = (async () => {
         throw new Error("network failure");
       }) as unknown as typeof globalThis.fetch;
@@ -409,7 +410,7 @@ describe("HostProxyPoster", () => {
 
       const buf = await poster.pullTransferContent("xfer-throw");
 
-      expect(buf.length).toBe(0);
+      expect(buf).toBeNull();
     });
 
     test("pushTransferContent returns false when fetch throws", async () => {

--- a/apps/macos/src/main/host-proxy-poster.ts
+++ b/apps/macos/src/main/host-proxy-poster.ts
@@ -104,7 +104,7 @@ function computeTimeout(bodyBytes: number): number {
 
 export class HostProxyPoster {
   private readonly baseUrl: string;
-  private readonly authToken: string;
+  private authToken: string;
   private readonly fetchFn: FetchFn;
 
   constructor(opts: HostProxyPosterOptions) {
@@ -112,6 +112,10 @@ export class HostProxyPoster {
     this.baseUrl = `http://${host}:${opts.gatewayPort}`;
     this.authToken = opts.authToken;
     this.fetchFn = opts.fetch ?? globalThis.fetch;
+  }
+
+  updateAuthToken(token: string): void {
+    this.authToken = token;
   }
 
   // -----------------------------------------------------------------------

--- a/apps/macos/src/main/host-proxy-poster.ts
+++ b/apps/macos/src/main/host-proxy-poster.ts
@@ -152,7 +152,7 @@ export class HostProxyPoster {
   // Transfer content methods
   // -----------------------------------------------------------------------
 
-  async pullTransferContent(transferId: string): Promise<Buffer> {
+  async pullTransferContent(transferId: string): Promise<Buffer | null> {
     try {
       const url = `${this.baseUrl}/v1/transfers/${encodeURIComponent(transferId)}/content`;
       const controller = new AbortController();
@@ -166,14 +166,14 @@ export class HostProxyPoster {
           headers: this.commonHeaders(),
           signal: controller.signal,
         });
-        if (!res.ok) return Buffer.alloc(0);
+        if (!res.ok) return null;
         const arrayBuf = await res.arrayBuffer();
         return Buffer.from(arrayBuf);
       } finally {
         clearTimeout(timer);
       }
     } catch {
-      return Buffer.alloc(0);
+      return null;
     }
   }
 
@@ -219,7 +219,7 @@ export class HostProxyPoster {
 
   private async postJson(
     path: string,
-    payload: Record<string, unknown>,
+    payload: object,
   ): Promise<boolean> {
     try {
       const body = JSON.stringify(payload);

--- a/apps/macos/src/main/host-proxy-poster.ts
+++ b/apps/macos/src/main/host-proxy-poster.ts
@@ -1,0 +1,246 @@
+/**
+ * HTTP client for posting host proxy results back to the daemon.
+ *
+ * Each typed POST method sends a JSON body to the corresponding daemon
+ * endpoint with the required auth and client-id headers. Transfer content
+ * methods handle binary GET/PUT for file transfers.
+ *
+ * Injectable fetch function for testability (mirrors the SSE client pattern).
+ * Returns boolean success/failure without throwing.
+ */
+
+import { getDeviceId } from "./device-id";
+
+// ---------------------------------------------------------------------------
+// Payload interfaces — match the daemon route request bodies
+// ---------------------------------------------------------------------------
+
+export interface HostBashResultPayload {
+  requestId: string;
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number | null;
+  timedOut?: boolean;
+}
+
+export interface HostFileResultPayload {
+  requestId: string;
+  content?: string;
+  isError?: boolean;
+  imageData?: string;
+  audioData?: string;
+  audioMimeType?: string;
+}
+
+export interface HostTransferResultPayload {
+  requestId: string;
+  isError?: boolean;
+  bytesWritten?: number;
+  errorMessage?: string;
+}
+
+export interface HostBrowserResultPayload {
+  requestId: string;
+  content?: string;
+  isError?: boolean;
+}
+
+export interface HostCuResultPayload {
+  requestId: string;
+  axTree?: string;
+  axDiff?: string;
+  screenshot?: string;
+  screenshotWidthPx?: number;
+  screenshotHeightPx?: number;
+  screenWidthPt?: number;
+  screenHeightPt?: number;
+  executionResult?: string;
+  executionError?: string;
+  secondaryWindows?: string;
+  userGuidance?: string;
+}
+
+export type HostAppControlState = "running" | "missing" | "minimized";
+
+export interface HostAppControlResultPayload {
+  requestId: string;
+  state: HostAppControlState;
+  pngBase64?: string;
+  windowBounds?: { x: number; y: number; width: number; height: number };
+  executionResult?: string;
+  executionError?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Fetch type — matches the subset of globalThis.fetch we use
+// ---------------------------------------------------------------------------
+
+type FetchFn = typeof globalThis.fetch;
+
+// ---------------------------------------------------------------------------
+// HostProxyPoster
+// ---------------------------------------------------------------------------
+
+export interface HostProxyPosterOptions {
+  gatewayPort: number;
+  gatewayHost?: string;
+  authToken: string;
+  /** Override fetch for testing. Defaults to globalThis.fetch. */
+  fetch?: FetchFn;
+}
+
+/** Minimum timeout in milliseconds. */
+const MIN_TIMEOUT_MS = 30_000;
+/** Extra timeout per megabyte of payload. */
+const TIMEOUT_PER_MB_MS = 5_000;
+
+/**
+ * Compute a timeout that scales with payload size: 30s floor + 5s per MB.
+ */
+function computeTimeout(bodyBytes: number): number {
+  const mbPortion = Math.ceil(bodyBytes / (1024 * 1024)) * TIMEOUT_PER_MB_MS;
+  return MIN_TIMEOUT_MS + mbPortion;
+}
+
+export class HostProxyPoster {
+  private readonly baseUrl: string;
+  private readonly authToken: string;
+  private readonly fetchFn: FetchFn;
+
+  constructor(opts: HostProxyPosterOptions) {
+    const host = opts.gatewayHost ?? "127.0.0.1";
+    this.baseUrl = `http://${host}:${opts.gatewayPort}`;
+    this.authToken = opts.authToken;
+    this.fetchFn = opts.fetch ?? globalThis.fetch;
+  }
+
+  // -----------------------------------------------------------------------
+  // Result POST methods
+  // -----------------------------------------------------------------------
+
+  async postBashResult(result: HostBashResultPayload): Promise<boolean> {
+    return this.postJson("/v1/host-bash-result", result);
+  }
+
+  async postFileResult(result: HostFileResultPayload): Promise<boolean> {
+    return this.postJson("/v1/host-file-result", result);
+  }
+
+  async postTransferResult(
+    result: HostTransferResultPayload,
+  ): Promise<boolean> {
+    return this.postJson("/v1/host-transfer-result", result);
+  }
+
+  async postBrowserResult(
+    result: HostBrowserResultPayload,
+  ): Promise<boolean> {
+    return this.postJson("/v1/host-browser-result", result);
+  }
+
+  async postCuResult(result: HostCuResultPayload): Promise<boolean> {
+    return this.postJson("/v1/host-cu-result", result);
+  }
+
+  async postAppControlResult(
+    result: HostAppControlResultPayload,
+  ): Promise<boolean> {
+    return this.postJson("/v1/host-app-control-result", result);
+  }
+
+  // -----------------------------------------------------------------------
+  // Transfer content methods
+  // -----------------------------------------------------------------------
+
+  async pullTransferContent(transferId: string): Promise<Buffer> {
+    try {
+      const url = `${this.baseUrl}/v1/transfers/${encodeURIComponent(transferId)}/content`;
+      const controller = new AbortController();
+      const timer = setTimeout(
+        () => controller.abort(),
+        MIN_TIMEOUT_MS,
+      );
+      try {
+        const res = await this.fetchFn(url, {
+          method: "GET",
+          headers: this.commonHeaders(),
+          signal: controller.signal,
+        });
+        if (!res.ok) return Buffer.alloc(0);
+        const arrayBuf = await res.arrayBuffer();
+        return Buffer.from(arrayBuf);
+      } finally {
+        clearTimeout(timer);
+      }
+    } catch {
+      return Buffer.alloc(0);
+    }
+  }
+
+  async pushTransferContent(
+    transferId: string,
+    data: Buffer,
+    sha256: string,
+  ): Promise<boolean> {
+    try {
+      const url = `${this.baseUrl}/v1/transfers/${encodeURIComponent(transferId)}/content`;
+      const timeout = computeTimeout(data.length);
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), timeout);
+      try {
+        const headers = this.commonHeaders();
+        headers["Content-Type"] = "application/octet-stream";
+        headers["X-Transfer-SHA256"] = sha256;
+        const res = await this.fetchFn(url, {
+          method: "PUT",
+          headers,
+          body: data,
+          signal: controller.signal,
+        });
+        return res.ok;
+      } finally {
+        clearTimeout(timer);
+      }
+    } catch {
+      return false;
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Internal helpers
+  // -----------------------------------------------------------------------
+
+  private commonHeaders(): Record<string, string> {
+    return {
+      Authorization: `Bearer ${this.authToken}`,
+      "X-Vellum-Client-Id": getDeviceId(),
+    };
+  }
+
+  private async postJson(
+    path: string,
+    payload: Record<string, unknown>,
+  ): Promise<boolean> {
+    try {
+      const body = JSON.stringify(payload);
+      const timeout = computeTimeout(Buffer.byteLength(body, "utf-8"));
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), timeout);
+      try {
+        const headers = this.commonHeaders();
+        headers["Content-Type"] = "application/json";
+        const res = await this.fetchFn(`${this.baseUrl}${path}`, {
+          method: "POST",
+          headers,
+          body,
+          signal: controller.signal,
+        });
+        return res.ok;
+      } finally {
+        clearTimeout(timer);
+      }
+    } catch {
+      return false;
+    }
+  }
+}

--- a/apps/macos/src/main/host-proxy-router.test.ts
+++ b/apps/macos/src/main/host-proxy-router.test.ts
@@ -1,0 +1,326 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Stubs — must precede the router import
+// ---------------------------------------------------------------------------
+
+const MOCK_DEVICE_ID = "test-device-00000000-0000-0000-0000-000000000000";
+mock.module("./device-id", () => ({
+  getDeviceId: () => MOCK_DEVICE_ID,
+  resetDeviceIdCache: () => {},
+}));
+
+const mockGetGuardianAccessToken = mock(
+  async () => ({ ok: true, accessToken: "test-token" }) as const,
+);
+mock.module("@vellumai/local-mode", () => ({
+  getGuardianAccessToken: mockGetGuardianAccessToken,
+  resolveConfigDir: () => "/tmp/test-config",
+}));
+
+// Minimal lockfile-watcher stub — capture the listener
+let lockfileListener: ((lockfile: import("@vellumai/local-mode/contract").Lockfile) => void) | null = null;
+mock.module("./lockfile-watcher", () => ({
+  onLockfileChange: (listener: typeof lockfileListener) => {
+    lockfileListener = listener;
+    return () => { lockfileListener = null; };
+  },
+}));
+
+// Stub electron-log
+mock.module("electron-log/main", () => {
+  const noop = () => {};
+  return {
+    default: {
+      info: noop,
+      warn: noop,
+      error: noop,
+      debug: noop,
+      initialize: noop,
+      transports: { file: { maxSize: 0, fileName: "", format: "", getFile: () => ({ path: "" }) } },
+    },
+  };
+});
+
+const { HostProxySseClient } = await import("./host-proxy-sse");
+const { HostProxyPoster } = await import("./host-proxy-poster");
+const {
+  installHostProxyBridge,
+  setExecutor,
+  removeExecutor,
+  __testing,
+} = await import("./host-proxy-router");
+
+type Lockfile = import("@vellumai/local-mode/contract").Lockfile;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const fakeCliResolver = async () => ({ command: "echo", baseArgs: [] });
+
+async function flush(ms = 20): Promise<void> {
+  await new Promise((r) => setTimeout(r, ms));
+}
+
+/** Create a poster that captures the first POST body for assertions. */
+function capturingPoster(): { poster: InstanceType<typeof HostProxyPoster>; body: () => Record<string, unknown> | null } {
+  let postedBody: Record<string, unknown> | null = null;
+  const fakeFetch = async (_url: unknown, init?: RequestInit) => {
+    postedBody = JSON.parse(init?.body as string);
+    return new Response("ok");
+  };
+  const poster = new HostProxyPoster({
+    gatewayPort: 9000,
+    authToken: "t",
+    fetch: fakeFetch as typeof globalThis.fetch,
+  });
+  return { poster, body: () => postedBody };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("host-proxy-router", () => {
+  afterEach(() => {
+    __testing.reset();
+    lockfileListener = null;
+    mockGetGuardianAccessToken.mockReset();
+    mockGetGuardianAccessToken.mockImplementation(
+      async () => ({ ok: true, accessToken: "test-token" }) as const,
+    );
+  });
+
+  // -- Lifecycle -----------------------------------------------------------
+
+  describe("lifecycle", () => {
+    test("connects when an assistant with a gatewayPort appears", async () => {
+      installHostProxyBridge(fakeCliResolver);
+
+      const lockfile: Lockfile = {
+        assistants: [
+          {
+            assistantId: "a1",
+            resources: { gatewayPort: 9001, daemonPort: 9002 },
+          },
+        ],
+        activeAssistant: "a1",
+      };
+      lockfileListener?.(lockfile);
+      await flush();
+
+      expect(__testing.connections.has("a1")).toBe(true);
+      const conn = __testing.connections.get("a1")!;
+      expect(conn.sse).toBeInstanceOf(HostProxySseClient);
+      expect(conn.poster).toBeInstanceOf(HostProxyPoster);
+    });
+
+    test("disconnects when an assistant is retired", async () => {
+      installHostProxyBridge(fakeCliResolver);
+
+      // Appear
+      lockfileListener?.({
+        assistants: [
+          { assistantId: "a1", resources: { gatewayPort: 9001, daemonPort: 9002 } },
+        ],
+        activeAssistant: "a1",
+      });
+      await flush();
+      expect(__testing.connections.has("a1")).toBe(true);
+
+      // Retire
+      lockfileListener?.({ assistants: [], activeAssistant: null });
+      await flush();
+      expect(__testing.connections.has("a1")).toBe(false);
+    });
+
+    test("ignores assistants without resources", async () => {
+      installHostProxyBridge(fakeCliResolver);
+
+      lockfileListener?.({
+        assistants: [{ assistantId: "no-resources" }],
+        activeAssistant: null,
+      });
+      await flush();
+
+      expect(__testing.connections.has("no-resources")).toBe(false);
+    });
+
+    test("does not duplicate connections on repeated lockfile updates", async () => {
+      installHostProxyBridge(fakeCliResolver);
+
+      const lockfile: Lockfile = {
+        assistants: [
+          { assistantId: "a1", resources: { gatewayPort: 9001, daemonPort: 9002 } },
+        ],
+        activeAssistant: "a1",
+      };
+
+      lockfileListener?.(lockfile);
+      await flush();
+      const firstSse = __testing.connections.get("a1")!.sse;
+
+      lockfileListener?.(lockfile);
+      await flush();
+      // Same instance — no duplicate connection
+      expect(__testing.connections.get("a1")!.sse).toBe(firstSse);
+    });
+
+    test("teardown disconnects all and clears listener", async () => {
+      const teardown = installHostProxyBridge(fakeCliResolver);
+
+      lockfileListener?.({
+        assistants: [
+          { assistantId: "a1", resources: { gatewayPort: 9001, daemonPort: 9002 } },
+        ],
+        activeAssistant: "a1",
+      });
+      await flush();
+      expect(__testing.connections.size).toBe(1);
+
+      teardown();
+      expect(__testing.connections.size).toBe(0);
+      expect(lockfileListener).toBeNull();
+    });
+
+    test("does not connect when guardian token fetch fails", async () => {
+      mockGetGuardianAccessToken.mockImplementation(
+        async () => ({ ok: false, status: 401, error: "expired" }) as const,
+      );
+      installHostProxyBridge(fakeCliResolver);
+
+      lockfileListener?.({
+        assistants: [
+          { assistantId: "a1", resources: { gatewayPort: 9001, daemonPort: 9002 } },
+        ],
+        activeAssistant: "a1",
+      });
+      await flush();
+
+      expect(__testing.connections.has("a1")).toBe(false);
+    });
+  });
+
+  // -- Message dispatch ----------------------------------------------------
+
+  describe("message dispatch", () => {
+    test("routes request to registered executor", () => {
+      const handled: string[] = [];
+      setExecutor("host_bash", {
+        handleRequest: (msg) => { handled.push(`req:${msg.requestId}`); },
+        handleCancel: (msg) => { handled.push(`cancel:${msg.requestId}`); },
+      });
+
+      const poster = new HostProxyPoster({
+        gatewayPort: 9000,
+        authToken: "t",
+        fetch: (async () => new Response("ok")) as typeof globalThis.fetch,
+      });
+
+      __testing.dispatchMessage(
+        { type: "host_bash_request", requestId: "r1" },
+        poster,
+      );
+      __testing.dispatchMessage(
+        { type: "host_bash_cancel", requestId: "r2" },
+        poster,
+      );
+
+      expect(handled).toEqual(["req:r1", "cancel:r2"]);
+      removeExecutor("host_bash");
+    });
+
+    test("routes file messages to file executor", () => {
+      const handled: string[] = [];
+      setExecutor("host_file", {
+        handleRequest: (msg) => { handled.push(`req:${msg.requestId}`); },
+        handleCancel: (msg) => { handled.push(`cancel:${msg.requestId}`); },
+      });
+
+      const poster = new HostProxyPoster({
+        gatewayPort: 9000,
+        authToken: "t",
+        fetch: (async () => new Response("ok")) as typeof globalThis.fetch,
+      });
+
+      __testing.dispatchMessage(
+        { type: "host_file_request", requestId: "f1" },
+        poster,
+      );
+
+      expect(handled).toEqual(["req:f1"]);
+      removeExecutor("host_file");
+    });
+
+    test("posts stub error for unimplemented bash executor", async () => {
+      const { poster, body } = capturingPoster();
+      __testing.dispatchMessage({ type: "host_bash_request", requestId: "r1" }, poster);
+      await flush();
+
+      expect(body()).not.toBeNull();
+      expect(body()!.requestId).toBe("r1");
+      expect(body()!.stderr).toBe("Executor not yet implemented");
+      expect(body()!.exitCode).toBe(1);
+    });
+
+    test("posts stub error for unimplemented file executor", async () => {
+      const { poster, body } = capturingPoster();
+      __testing.dispatchMessage({ type: "host_file_request", requestId: "f1" }, poster);
+      await flush();
+
+      expect(body()!.requestId).toBe("f1");
+      expect(body()!.isError).toBe(true);
+    });
+
+    test("posts stub error for unimplemented transfer executor", async () => {
+      const { poster, body } = capturingPoster();
+      __testing.dispatchMessage({ type: "host_transfer_request", requestId: "t1" }, poster);
+      await flush();
+
+      expect(body()!.requestId).toBe("t1");
+      expect(body()!.isError).toBe(true);
+      expect(body()!.errorMessage).toBe("Executor not yet implemented");
+    });
+
+    test("posts stub error for unimplemented browser executor", async () => {
+      const { poster, body } = capturingPoster();
+      __testing.dispatchMessage({ type: "host_browser_request", requestId: "b1" }, poster);
+      await flush();
+
+      expect(body()!.requestId).toBe("b1");
+      expect(body()!.isError).toBe(true);
+    });
+
+    test("ignores unknown message types without crashing", () => {
+      const poster = new HostProxyPoster({
+        gatewayPort: 9000,
+        authToken: "t",
+        fetch: (async () => new Response("ok")) as typeof globalThis.fetch,
+      });
+
+      // Should not throw
+      __testing.dispatchMessage(
+        { type: "host_unknown_request", requestId: "u1" },
+        poster,
+      );
+    });
+  });
+
+  // -- Executor registry ---------------------------------------------------
+
+  describe("executor registry", () => {
+    test("setExecutor and removeExecutor manage the registry", () => {
+      const executor = {
+        handleRequest: () => {},
+        handleCancel: () => {},
+      };
+
+      setExecutor("host_bash", executor);
+      expect(__testing.executors.has("host_bash")).toBe(true);
+
+      removeExecutor("host_bash");
+      expect(__testing.executors.has("host_bash")).toBe(false);
+    });
+  });
+});

--- a/apps/macos/src/main/host-proxy-router.test.ts
+++ b/apps/macos/src/main/host-proxy-router.test.ts
@@ -11,7 +11,8 @@ mock.module("./device-id", () => ({
 }));
 
 const mockGetGuardianAccessToken = mock(
-  async () => ({ ok: true, accessToken: "test-token" }) as const,
+  async (): Promise<{ ok: true; accessToken: string } | { ok: false; status: number; error: string }> =>
+    ({ ok: true, accessToken: "test-token" }),
 );
 mock.module("@vellumai/local-mode", () => ({
   getGuardianAccessToken: mockGetGuardianAccessToken,
@@ -25,6 +26,7 @@ mock.module("./lockfile-watcher", () => ({
     lockfileListener = listener;
     return () => { lockfileListener = null; };
   },
+  getWatchedLockfile: () => ({ assistants: [], activeAssistant: null }),
 }));
 
 // Stub electron-log
@@ -88,7 +90,7 @@ describe("host-proxy-router", () => {
     lockfileListener = null;
     mockGetGuardianAccessToken.mockReset();
     mockGetGuardianAccessToken.mockImplementation(
-      async () => ({ ok: true, accessToken: "test-token" }) as const,
+      async () => ({ ok: true, accessToken: "test-token" }),
     );
   });
 
@@ -186,7 +188,7 @@ describe("host-proxy-router", () => {
 
     test("does not connect when guardian token fetch fails", async () => {
       mockGetGuardianAccessToken.mockImplementation(
-        async () => ({ ok: false, status: 401, error: "expired" }) as const,
+        async () => ({ ok: false, status: 401, error: "expired" }),
       );
       installHostProxyBridge(fakeCliResolver);
 
@@ -215,7 +217,7 @@ describe("host-proxy-router", () => {
       const poster = new HostProxyPoster({
         gatewayPort: 9000,
         authToken: "t",
-        fetch: (async () => new Response("ok")) as typeof globalThis.fetch,
+        fetch: (async () => new Response("ok")) as unknown as typeof globalThis.fetch,
       });
 
       __testing.dispatchMessage(
@@ -241,7 +243,7 @@ describe("host-proxy-router", () => {
       const poster = new HostProxyPoster({
         gatewayPort: 9000,
         authToken: "t",
-        fetch: (async () => new Response("ok")) as typeof globalThis.fetch,
+        fetch: (async () => new Response("ok")) as unknown as typeof globalThis.fetch,
       });
 
       __testing.dispatchMessage(
@@ -296,7 +298,7 @@ describe("host-proxy-router", () => {
       const poster = new HostProxyPoster({
         gatewayPort: 9000,
         authToken: "t",
-        fetch: (async () => new Response("ok")) as typeof globalThis.fetch,
+        fetch: (async () => new Response("ok")) as unknown as typeof globalThis.fetch,
       });
 
       // Should not throw

--- a/apps/macos/src/main/host-proxy-router.ts
+++ b/apps/macos/src/main/host-proxy-router.ts
@@ -1,0 +1,277 @@
+/**
+ * Host proxy message router and daemon connection lifecycle.
+ *
+ * Listens for lockfile changes and maintains an SSE + poster pair for each
+ * local assistant that has a gatewayPort. When an assistant appears, the
+ * router obtains a guardian token and connects; when it disappears, it
+ * disconnects. Incoming SSE messages are dispatched to pluggable executors;
+ * unimplemented executors post error results so daemon requests don't hang.
+ */
+
+import {
+  getGuardianAccessToken,
+  resolveConfigDir,
+  type CliInvocation,
+} from "@vellumai/local-mode";
+import type { Lockfile } from "@vellumai/local-mode/contract";
+
+import { HostProxySseClient, type HostProxySseMessage } from "./host-proxy-sse";
+import { HostProxyPoster } from "./host-proxy-poster";
+import { onLockfileChange } from "./lockfile-watcher";
+import log from "./logger";
+
+// ---------------------------------------------------------------------------
+// Executor interface — PRs 5-8 plug in via setExecutor()
+// ---------------------------------------------------------------------------
+
+export interface HostProxyExecutor {
+  handleRequest(message: HostProxySseMessage, poster: HostProxyPoster): void;
+  handleCancel(message: HostProxySseMessage, poster: HostProxyPoster): void;
+}
+
+// ---------------------------------------------------------------------------
+// Connection entry
+// ---------------------------------------------------------------------------
+
+interface AssistantConnection {
+  sse: HostProxySseClient;
+  poster: HostProxyPoster;
+}
+
+// ---------------------------------------------------------------------------
+// Module state
+// ---------------------------------------------------------------------------
+
+const connections = new Map<string, AssistantConnection>();
+const executors = new Map<string, HostProxyExecutor>();
+
+// Injected by installHostProxyBridge; kept at module scope so the
+// lockfile-change listener (which cannot be async) can reference it.
+let resolveCliInvocation: (() => Promise<CliInvocation>) | null = null;
+
+// ---------------------------------------------------------------------------
+// Executor registry
+// ---------------------------------------------------------------------------
+
+export function setExecutor(kind: string, executor: HostProxyExecutor): void {
+  executors.set(kind, executor);
+}
+
+export function removeExecutor(kind: string): void {
+  executors.delete(kind);
+}
+
+// ---------------------------------------------------------------------------
+// Message dispatch
+// ---------------------------------------------------------------------------
+
+const EXECUTOR_KINDS = ["host_bash", "host_file", "host_transfer", "host_browser"] as const;
+
+/** Route type → executor kind. Returns null for unknown types. */
+function executorKindForType(type: string): { kind: string; action: "request" | "cancel" } | null {
+  for (const kind of EXECUTOR_KINDS) {
+    if (type === `${kind}_request`) return { kind, action: "request" };
+    if (type === `${kind}_cancel`) return { kind, action: "cancel" };
+  }
+  return null;
+}
+
+function dispatchMessage(message: HostProxySseMessage, poster: HostProxyPoster): void {
+  const { type } = message;
+  const route = executorKindForType(type);
+  if (!route) {
+    log.warn("[host-proxy-router] unknown message type, ignoring", { type });
+    return;
+  }
+
+  const executor = executors.get(route.kind);
+
+  if (executor) {
+    if (route.action === "request") {
+      executor.handleRequest(message, poster);
+    } else {
+      executor.handleCancel(message, poster);
+    }
+    return;
+  }
+
+  // No executor registered — post an error result so the daemon doesn't hang.
+  const requestId = message.requestId as string | undefined;
+  if (!requestId) {
+    log.warn("[host-proxy-router] message missing requestId, cannot post stub error", { type });
+    return;
+  }
+
+  log.warn("[host-proxy-router] executor not yet implemented", { type });
+
+  switch (route.kind) {
+    case "host_bash":
+      void poster.postBashResult({
+        requestId,
+        stdout: "",
+        stderr: "Executor not yet implemented",
+        exitCode: 1,
+        timedOut: false,
+      });
+      break;
+    case "host_file":
+      void poster.postFileResult({
+        requestId,
+        content: "Executor not yet implemented",
+        isError: true,
+      });
+      break;
+    case "host_transfer":
+      void poster.postTransferResult({
+        requestId,
+        isError: true,
+        errorMessage: "Executor not yet implemented",
+      });
+      break;
+    case "host_browser":
+      void poster.postBrowserResult({
+        requestId,
+        content: "Executor not yet implemented",
+        isError: true,
+      });
+      break;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle — connect / disconnect per assistant
+// ---------------------------------------------------------------------------
+
+async function connectAssistant(
+  assistantId: string,
+  gatewayPort: number,
+): Promise<void> {
+  if (connections.has(assistantId)) return;
+
+  if (!resolveCliInvocation) {
+    log.error("[host-proxy-router] CLI invocation resolver not set");
+    return;
+  }
+
+  const configDir = resolveConfigDir(process.env);
+
+  let invocation: CliInvocation;
+  try {
+    invocation = await resolveCliInvocation();
+  } catch (err) {
+    log.error("[host-proxy-router] failed to resolve CLI invocation", { assistantId, err });
+    return;
+  }
+
+  const tokenResult = await getGuardianAccessToken(
+    assistantId,
+    configDir,
+    invocation,
+    true,
+  );
+
+  if (!tokenResult.ok) {
+    log.warn("[host-proxy-router] failed to obtain guardian token", {
+      assistantId,
+      error: tokenResult.error,
+    });
+    return;
+  }
+
+  const authToken = tokenResult.accessToken;
+
+  const sse = new HostProxySseClient({ gatewayPort, authToken });
+  const poster = new HostProxyPoster({ gatewayPort, authToken });
+
+  sse.setMessageCallback((msg) => dispatchMessage(msg, poster));
+  sse.connect();
+
+  connections.set(assistantId, { sse, poster });
+  log.info("[host-proxy-router] connected to assistant", { assistantId, gatewayPort });
+}
+
+function disconnectAssistant(assistantId: string): void {
+  const conn = connections.get(assistantId);
+  if (!conn) return;
+  conn.sse.disconnect();
+  connections.delete(assistantId);
+  log.info("[host-proxy-router] disconnected from assistant", { assistantId });
+}
+
+// ---------------------------------------------------------------------------
+// Lockfile change handler
+// ---------------------------------------------------------------------------
+
+function handleLockfileChange(lockfile: Lockfile): void {
+  const activeIds = new Set<string>();
+
+  for (const assistant of lockfile.assistants) {
+    const port = assistant.resources?.gatewayPort;
+    if (!port) continue;
+    activeIds.add(assistant.assistantId);
+
+    if (!connections.has(assistant.assistantId)) {
+      void connectAssistant(assistant.assistantId, port);
+    }
+  }
+
+  // Disconnect assistants that are no longer in the lockfile
+  for (const assistantId of connections.keys()) {
+    if (!activeIds.has(assistantId)) {
+      disconnectAssistant(assistantId);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public install / teardown
+// ---------------------------------------------------------------------------
+
+let unsubscribe: (() => void) | null = null;
+
+/**
+ * Wire the host proxy bridge into the app lifecycle. Call once from
+ * `app.whenReady()` after `installLockfileWatcher()`. Returns a teardown
+ * function for `before-quit`.
+ */
+export function installHostProxyBridge(
+  cliResolver: () => Promise<CliInvocation>,
+): () => void {
+  resolveCliInvocation = cliResolver;
+  unsubscribe = onLockfileChange(handleLockfileChange);
+
+  return () => {
+    unsubscribe?.();
+    unsubscribe = null;
+    for (const assistantId of [...connections.keys()]) {
+      disconnectAssistant(assistantId);
+    }
+    resolveCliInvocation = null;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Test seams
+// ---------------------------------------------------------------------------
+
+export const __testing = {
+  get connections() {
+    return connections;
+  },
+  get executors() {
+    return executors;
+  },
+  dispatchMessage,
+  connectAssistant,
+  disconnectAssistant,
+  handleLockfileChange,
+  reset() {
+    for (const assistantId of [...connections.keys()]) {
+      disconnectAssistant(assistantId);
+    }
+    executors.clear();
+    resolveCliInvocation = null;
+    unsubscribe?.();
+    unsubscribe = null;
+  },
+};

--- a/apps/macos/src/main/host-proxy-router.ts
+++ b/apps/macos/src/main/host-proxy-router.ts
@@ -17,6 +17,7 @@ import type { Lockfile } from "@vellumai/local-mode/contract";
 
 import { HostProxySseClient, type HostProxySseMessage } from "./host-proxy-sse";
 import { HostProxyPoster } from "./host-proxy-poster";
+import { hostBashExecutor } from "./executors/host-bash-executor";
 import { hostFileExecutor } from "./executors/host-file-executor";
 import { hostTransferExecutor } from "./executors/host-transfer-executor";
 import { onLockfileChange, getWatchedLockfile } from "./lockfile-watcher";
@@ -254,6 +255,7 @@ export function installHostProxyBridge(
   cliResolver: () => Promise<CliInvocation>,
 ): () => void {
   resolveCliInvocation = cliResolver;
+  setExecutor("host_bash", hostBashExecutor);
   setExecutor("host_file", hostFileExecutor);
   setExecutor("host_transfer", hostTransferExecutor);
   unsubscribe = onLockfileChange(handleLockfileChange);

--- a/apps/macos/src/main/host-proxy-router.ts
+++ b/apps/macos/src/main/host-proxy-router.ts
@@ -17,6 +17,7 @@ import type { Lockfile } from "@vellumai/local-mode/contract";
 
 import { HostProxySseClient, type HostProxySseMessage } from "./host-proxy-sse";
 import { HostProxyPoster } from "./host-proxy-poster";
+import { hostFileExecutor } from "./executors/host-file-executor";
 import { hostTransferExecutor } from "./executors/host-transfer-executor";
 import { onLockfileChange } from "./lockfile-watcher";
 import log from "./logger";
@@ -239,6 +240,7 @@ export function installHostProxyBridge(
   cliResolver: () => Promise<CliInvocation>,
 ): () => void {
   resolveCliInvocation = cliResolver;
+  setExecutor("host_file", hostFileExecutor);
   setExecutor("host_transfer", hostTransferExecutor);
   unsubscribe = onLockfileChange(handleLockfileChange);
 

--- a/apps/macos/src/main/host-proxy-router.ts
+++ b/apps/macos/src/main/host-proxy-router.ts
@@ -20,10 +20,11 @@ import { HostProxyPoster } from "./host-proxy-poster";
 import { hostFileExecutor } from "./executors/host-file-executor";
 import { hostTransferExecutor } from "./executors/host-transfer-executor";
 import { onLockfileChange } from "./lockfile-watcher";
+import { HostBrowserExecutor } from "./executors/host-browser-executor";
 import log from "./logger";
 
 // ---------------------------------------------------------------------------
-// Executor interface — PRs 5-8 plug in via setExecutor()
+// Executor interface
 // ---------------------------------------------------------------------------
 
 export interface HostProxyExecutor {
@@ -244,12 +245,18 @@ export function installHostProxyBridge(
   setExecutor("host_transfer", hostTransferExecutor);
   unsubscribe = onLockfileChange(handleLockfileChange);
 
+  // Register built-in executors
+  const browserExecutor = new HostBrowserExecutor();
+  setExecutor("host_browser", browserExecutor);
+
   return () => {
     unsubscribe?.();
     unsubscribe = null;
     for (const assistantId of [...connections.keys()]) {
       disconnectAssistant(assistantId);
     }
+    browserExecutor.destroy();
+    removeExecutor("host_browser");
     resolveCliInvocation = null;
   };
 }

--- a/apps/macos/src/main/host-proxy-router.ts
+++ b/apps/macos/src/main/host-proxy-router.ts
@@ -19,7 +19,7 @@ import { HostProxySseClient, type HostProxySseMessage } from "./host-proxy-sse";
 import { HostProxyPoster } from "./host-proxy-poster";
 import { hostFileExecutor } from "./executors/host-file-executor";
 import { hostTransferExecutor } from "./executors/host-transfer-executor";
-import { onLockfileChange } from "./lockfile-watcher";
+import { onLockfileChange, getWatchedLockfile } from "./lockfile-watcher";
 import { HostBrowserExecutor } from "./executors/host-browser-executor";
 import log from "./logger";
 
@@ -68,7 +68,7 @@ export function removeExecutor(kind: string): void {
 // Message dispatch
 // ---------------------------------------------------------------------------
 
-const EXECUTOR_KINDS = ["host_bash", "host_file", "host_transfer", "host_browser"] as const;
+const EXECUTOR_KINDS = ["host_bash", "host_file", "host_transfer", "host_browser", "host_cu", "host_app_control"] as const;
 
 /** Route type → executor kind. Returns null for unknown types. */
 function executorKindForType(type: string): { kind: string; action: "request" | "cancel" } | null {
@@ -136,6 +136,19 @@ function dispatchMessage(message: HostProxySseMessage, poster: HostProxyPoster):
         requestId,
         content: "Executor not yet implemented",
         isError: true,
+      });
+      break;
+    case "host_cu":
+      void poster.postCuResult({
+        requestId,
+        executionError: "Executor not yet implemented",
+      });
+      break;
+    case "host_app_control":
+      void poster.postAppControlResult({
+        requestId,
+        state: "missing",
+        executionError: "Executor not yet implemented",
       });
       break;
   }
@@ -244,6 +257,12 @@ export function installHostProxyBridge(
   setExecutor("host_file", hostFileExecutor);
   setExecutor("host_transfer", hostTransferExecutor);
   unsubscribe = onLockfileChange(handleLockfileChange);
+
+  // Seed from any assistants already present in the lockfile
+  const currentLockfile = getWatchedLockfile();
+  if (currentLockfile.assistants.length > 0) {
+    handleLockfileChange(currentLockfile);
+  }
 
   // Register built-in executors
   const browserExecutor = new HostBrowserExecutor();

--- a/apps/macos/src/main/host-proxy-router.ts
+++ b/apps/macos/src/main/host-proxy-router.ts
@@ -17,6 +17,7 @@ import type { Lockfile } from "@vellumai/local-mode/contract";
 
 import { HostProxySseClient, type HostProxySseMessage } from "./host-proxy-sse";
 import { HostProxyPoster } from "./host-proxy-poster";
+import { hostTransferExecutor } from "./executors/host-transfer-executor";
 import { onLockfileChange } from "./lockfile-watcher";
 import log from "./logger";
 
@@ -238,6 +239,7 @@ export function installHostProxyBridge(
   cliResolver: () => Promise<CliInvocation>,
 ): () => void {
   resolveCliInvocation = cliResolver;
+  setExecutor("host_transfer", hostTransferExecutor);
   unsubscribe = onLockfileChange(handleLockfileChange);
 
   return () => {

--- a/apps/macos/src/main/host-proxy-router.ts
+++ b/apps/macos/src/main/host-proxy-router.ts
@@ -40,6 +40,7 @@ export interface HostProxyExecutor {
 interface AssistantConnection {
   sse: HostProxySseClient;
   poster: HostProxyPoster;
+  gatewayPort: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -197,13 +198,26 @@ async function connectAssistant(
 
   const authToken = tokenResult.accessToken;
 
-  const sse = new HostProxySseClient({ gatewayPort, authToken });
+  const refreshToken = async (): Promise<string | null> => {
+    if (!resolveCliInvocation) return null;
+    try {
+      const inv = await resolveCliInvocation();
+      const result = await getGuardianAccessToken(assistantId, configDir, inv, true);
+      if (result.ok) {
+        poster.updateAuthToken(result.accessToken);
+        return result.accessToken;
+      }
+    } catch { /* keep existing token */ }
+    return null;
+  };
+
+  const sse = new HostProxySseClient({ gatewayPort, authToken, onRefreshToken: refreshToken });
   const poster = new HostProxyPoster({ gatewayPort, authToken });
 
   sse.setMessageCallback((msg) => dispatchMessage(msg, poster));
   sse.connect();
 
-  connections.set(assistantId, { sse, poster });
+  connections.set(assistantId, { sse, poster, gatewayPort });
   log.info("[host-proxy-router] connected to assistant", { assistantId, gatewayPort });
 }
 
@@ -227,7 +241,16 @@ function handleLockfileChange(lockfile: Lockfile): void {
     if (!port) continue;
     activeIds.add(assistant.assistantId);
 
-    if (!connections.has(assistant.assistantId)) {
+    const existing = connections.get(assistant.assistantId);
+    if (!existing) {
+      void connectAssistant(assistant.assistantId, port);
+    } else if (existing.gatewayPort !== port) {
+      log.info("[host-proxy-router] gateway port changed, reconnecting", {
+        assistantId: assistant.assistantId,
+        oldPort: existing.gatewayPort,
+        newPort: port,
+      });
+      disconnectAssistant(assistant.assistantId);
       void connectAssistant(assistant.assistantId, port);
     }
   }

--- a/apps/macos/src/main/host-proxy-sse.test.ts
+++ b/apps/macos/src/main/host-proxy-sse.test.ts
@@ -306,7 +306,7 @@ describe("HostProxySseClient", () => {
     let capturedHeaders: Record<string, string> = {};
 
     const fakeFetch: typeof globalThis.fetch = (async (
-      input: RequestInfo | URL,
+      input: string | URL | Request,
       init?: RequestInit,
     ) => {
       capturedUrl = String(input);

--- a/apps/macos/src/main/host-proxy-sse.test.ts
+++ b/apps/macos/src/main/host-proxy-sse.test.ts
@@ -1,0 +1,362 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+// Stub device-id so we don't touch the filesystem.
+const MOCK_DEVICE_ID = "test-device-00000000-0000-0000-0000-000000000000";
+mock.module("./device-id", () => ({
+  getDeviceId: () => MOCK_DEVICE_ID,
+}));
+
+const { HostProxySseClient } = await import("./host-proxy-sse");
+type HostProxySseMessage = import("./host-proxy-sse").HostProxySseMessage;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a ReadableStream that pushes encoded SSE chunks then closes. */
+function sseStream(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+}
+
+/** Build a ReadableStream that yields chunks on demand via a push function. */
+function controllableStream(): {
+  stream: ReadableStream<Uint8Array>;
+  push: (text: string) => void;
+  close: () => void;
+} {
+  const encoder = new TextEncoder();
+  let ctrl: ReadableStreamDefaultController<Uint8Array>;
+  const stream = new ReadableStream<Uint8Array>({
+    start(c) {
+      ctrl = c;
+    },
+  });
+  return {
+    stream,
+    push: (text: string) => ctrl.enqueue(encoder.encode(text)),
+    close: () => ctrl.close(),
+  };
+}
+
+/** Create a mock fetch that returns a streaming SSE response. */
+function mockFetch(
+  body: ReadableStream<Uint8Array>,
+  status = 200,
+): typeof globalThis.fetch {
+  return (async () =>
+    new Response(body, {
+      status,
+      headers: { "Content-Type": "text/event-stream" },
+    })) as unknown as typeof globalThis.fetch;
+}
+
+/** Flush pending microtasks / timers so stream processing can complete. */
+async function flush(ms = 10): Promise<void> {
+  await new Promise((r) => setTimeout(r, ms));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("HostProxySseClient", () => {
+  let client: InstanceType<typeof HostProxySseClient>;
+
+  afterEach(() => {
+    client?.disconnect();
+  });
+
+  // -- Basic SSE parsing --------------------------------------------------
+
+  test("parses data frames and delivers messages via callback", async () => {
+    const messages: HostProxySseMessage[] = [];
+    const body = sseStream([
+      'data: {"type":"ping"}\n\n',
+      'data: {"type":"host_bash_request","conversationId":"c1"}\n\n',
+    ]);
+
+    client = new HostProxySseClient({
+      gatewayPort: 9999,
+      authToken: "tok",
+      fetch: mockFetch(body),
+    });
+    client.setMessageCallback((m) => messages.push(m));
+    client.connect();
+
+    await flush(50);
+
+    expect(messages).toHaveLength(2);
+    expect(messages[0]!.type).toBe("ping");
+    expect(messages[1]!.type).toBe("host_bash_request");
+  });
+
+  test("ignores heartbeat comments", async () => {
+    const messages: HostProxySseMessage[] = [];
+    const body = sseStream([
+      ": heartbeat\n",
+      'data: {"type":"ping"}\n\n',
+      ": another heartbeat\n",
+    ]);
+
+    client = new HostProxySseClient({
+      gatewayPort: 9999,
+      authToken: "tok",
+      fetch: mockFetch(body),
+    });
+    client.setMessageCallback((m) => messages.push(m));
+    client.connect();
+
+    await flush(50);
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]!.type).toBe("ping");
+  });
+
+  test("skips malformed JSON data lines", async () => {
+    const messages: HostProxySseMessage[] = [];
+    const body = sseStream([
+      "data: not json\n\n",
+      'data: {"type":"ok"}\n\n',
+    ]);
+
+    client = new HostProxySseClient({
+      gatewayPort: 9999,
+      authToken: "tok",
+      fetch: mockFetch(body),
+    });
+    client.setMessageCallback((m) => messages.push(m));
+    client.connect();
+
+    await flush(50);
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]!.type).toBe("ok");
+  });
+
+  // -- Connection state ---------------------------------------------------
+
+  test("isConnected reflects stream state", async () => {
+    const { stream, close } = controllableStream();
+    client = new HostProxySseClient({
+      gatewayPort: 9999,
+      authToken: "tok",
+      fetch: mockFetch(stream),
+    });
+
+    expect(client.isConnected).toBe(false);
+    client.connect();
+
+    // Wait for the fetch response to resolve
+    await flush(50);
+    expect(client.isConnected).toBe(true);
+
+    close();
+    await flush(50);
+    // After stream closes, connected should be false (reconnect may be scheduled
+    // but the stream itself is down).
+    expect(client.isConnected).toBe(false);
+  });
+
+  // -- Reconnection on error ---------------------------------------------
+
+  test("reconnects with backoff on fetch failure", async () => {
+    let fetchCount = 0;
+    const messages: HostProxySseMessage[] = [];
+
+    const fakeFetch: typeof globalThis.fetch = (async () => {
+      fetchCount++;
+      if (fetchCount < 3) {
+        throw new Error("network error");
+      }
+      // Third attempt succeeds
+      return new Response(sseStream(['data: {"type":"recovered"}\n\n']), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      });
+    }) as unknown as typeof globalThis.fetch;
+
+    client = new HostProxySseClient({
+      gatewayPort: 9999,
+      authToken: "tok",
+      fetch: fakeFetch,
+    });
+    client.setMessageCallback((m) => messages.push(m));
+    client.connect();
+
+    // Wait for reconnect attempts (1s + 2s backoff)
+    await flush(4_000);
+
+    expect(fetchCount).toBeGreaterThanOrEqual(3);
+    expect(messages.some((m) => m.type === "recovered")).toBe(true);
+  });
+
+  test("reconnects on non-200 response", async () => {
+    let fetchCount = 0;
+    const fakeFetch: typeof globalThis.fetch = (async () => {
+      fetchCount++;
+      if (fetchCount === 1) {
+        return new Response("Unauthorized", { status: 401 });
+      }
+      return new Response(sseStream(['data: {"type":"ok"}\n\n']), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      });
+    }) as unknown as typeof globalThis.fetch;
+
+    const messages: HostProxySseMessage[] = [];
+    client = new HostProxySseClient({
+      gatewayPort: 9999,
+      authToken: "tok",
+      fetch: fakeFetch,
+    });
+    client.setMessageCallback((m) => messages.push(m));
+    client.connect();
+
+    await flush(2_000);
+
+    expect(fetchCount).toBeGreaterThanOrEqual(2);
+    expect(messages.some((m) => m.type === "ok")).toBe(true);
+  });
+
+  // -- Idle watchdog ------------------------------------------------------
+
+  test("idle watchdog triggers reconnect when no traffic arrives", async () => {
+    let fetchCount = 0;
+    const { stream, push } = controllableStream();
+
+    const fakeFetch: typeof globalThis.fetch = (async () => {
+      fetchCount++;
+      if (fetchCount === 1) {
+        return new Response(stream, {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        });
+      }
+      // Second connect: return a fresh stream that closes immediately
+      return new Response(sseStream(['data: {"type":"reconnected"}\n\n']), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      });
+    }) as unknown as typeof globalThis.fetch;
+
+    const messages: HostProxySseMessage[] = [];
+    client = new HostProxySseClient({
+      gatewayPort: 9999,
+      authToken: "tok",
+      fetch: fakeFetch,
+    });
+    client.setMessageCallback((m) => messages.push(m));
+    client.connect();
+
+    // Push initial data so stream is established
+    await flush(50);
+    push('data: {"type":"initial"}\n\n');
+    await flush(50);
+
+    // Wait for idle timeout (30s) + watchdog check interval (10s) + reconnect
+    await flush(42_000);
+
+    expect(fetchCount).toBeGreaterThanOrEqual(2);
+    expect(messages.some((m) => m.type === "reconnected")).toBe(true);
+  });
+
+  // -- Disconnect ---------------------------------------------------------
+
+  test("disconnect cancels timers and stream", async () => {
+    const { stream } = controllableStream();
+    let fetchCount = 0;
+
+    const fakeFetch: typeof globalThis.fetch = (async () => {
+      fetchCount++;
+      return new Response(stream, {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      });
+    }) as unknown as typeof globalThis.fetch;
+
+    client = new HostProxySseClient({
+      gatewayPort: 9999,
+      authToken: "tok",
+      fetch: fakeFetch,
+    });
+    client.connect();
+    await flush(50);
+    expect(client.isConnected).toBe(true);
+
+    client.disconnect();
+    expect(client.isConnected).toBe(false);
+
+    // Wait to confirm no reconnect happens
+    await flush(3_000);
+    expect(fetchCount).toBe(1);
+  });
+
+  // -- Request headers ----------------------------------------------------
+
+  test("sends correct headers", async () => {
+    let capturedUrl = "";
+    let capturedHeaders: Record<string, string> = {};
+
+    const fakeFetch: typeof globalThis.fetch = (async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      capturedUrl = String(input);
+      const h = init?.headers as Record<string, string> | undefined;
+      if (h) capturedHeaders = { ...h };
+      return new Response(sseStream([]), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      });
+    }) as unknown as typeof globalThis.fetch;
+
+    client = new HostProxySseClient({
+      gatewayPort: 8080,
+      authToken: "my-token",
+      fetch: fakeFetch,
+    });
+    client.connect();
+    await flush(50);
+
+    expect(capturedUrl).toBe("http://127.0.0.1:8080/v1/events");
+    expect(capturedHeaders["Authorization"]).toBe("Bearer my-token");
+    expect(capturedHeaders["Accept"]).toBe(
+      "text/event-stream, application/json",
+    );
+    expect(capturedHeaders["X-Vellum-Client-Id"]).toBe(MOCK_DEVICE_ID);
+    expect(capturedHeaders["X-Vellum-Interface-Id"]).toBe("macos");
+    expect(capturedHeaders["X-Vellum-Machine-Name"]).toBeTruthy();
+  });
+
+  // -- Chunked data handling ----------------------------------------------
+
+  test("handles data split across multiple chunks", async () => {
+    const messages: HostProxySseMessage[] = [];
+    // JSON payload split across two chunks
+    const body = sseStream([
+      'data: {"type":"sp',
+      'lit_msg","val":1}\n\n',
+    ]);
+
+    client = new HostProxySseClient({
+      gatewayPort: 9999,
+      authToken: "tok",
+      fetch: mockFetch(body),
+    });
+    client.setMessageCallback((m) => messages.push(m));
+    client.connect();
+
+    await flush(50);
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]!.type).toBe("split_msg");
+  });
+});

--- a/apps/macos/src/main/host-proxy-sse.test.ts
+++ b/apps/macos/src/main/host-proxy-sse.test.ts
@@ -252,6 +252,8 @@ describe("HostProxySseClient", () => {
       gatewayPort: 9999,
       authToken: "tok",
       fetch: fakeFetch,
+      idleTimeoutMs: 200,
+      idleCheckIntervalMs: 100,
     });
     client.setMessageCallback((m) => messages.push(m));
     client.connect();
@@ -261,8 +263,8 @@ describe("HostProxySseClient", () => {
     push('data: {"type":"initial"}\n\n');
     await flush(50);
 
-    // Wait for idle timeout (30s) + watchdog check interval (10s) + reconnect
-    await flush(42_000);
+    // Wait for idle timeout (200ms) + check interval (100ms) + reconnect buffer
+    await flush(1_500);
 
     expect(fetchCount).toBeGreaterThanOrEqual(2);
     expect(messages.some((m) => m.type === "reconnected")).toBe(true);

--- a/apps/macos/src/main/host-proxy-sse.ts
+++ b/apps/macos/src/main/host-proxy-sse.ts
@@ -22,6 +22,8 @@ export interface HostProxySseOptions {
   idleTimeoutMs?: number;
   /** Override idle check interval for testing. */
   idleCheckIntervalMs?: number;
+  /** Called before each reconnect — return a fresh token or null to keep the current one. */
+  onRefreshToken?: () => Promise<string | null>;
 }
 
 export interface HostProxySseMessage {
@@ -43,6 +45,7 @@ export class HostProxySseClient {
   private readonly fetchFn: typeof globalThis.fetch;
   private readonly idleTimeoutMs: number;
   private readonly idleCheckIntervalMs: number;
+  private readonly onRefreshToken: (() => Promise<string | null>) | null;
   private onMessage: MessageCallback | null = null;
 
   private abortController: AbortController | null = null;
@@ -60,6 +63,7 @@ export class HostProxySseClient {
     this.fetchFn = options.fetch ?? globalThis.fetch;
     this.idleTimeoutMs = options.idleTimeoutMs ?? IDLE_TIMEOUT_MS;
     this.idleCheckIntervalMs = options.idleCheckIntervalMs ?? IDLE_CHECK_INTERVAL_MS;
+    this.onRefreshToken = options.onRefreshToken ?? null;
   }
 
   /** Register a callback for parsed SSE messages. */
@@ -107,6 +111,10 @@ export class HostProxySseClient {
     const headers: Record<string, string> = {
       Accept: "text/event-stream, application/json",
       "X-Vellum-Client-Id": getDeviceId(),
+      // "macos" advertises all 5 host capabilities (including host_cu and
+      // host_app_control which aren't implemented yet). Unimplemented
+      // capabilities return stub errors via the router so the daemon doesn't
+      // hang. A selective capability mechanism requires daemon-side changes.
       "X-Vellum-Interface-Id": "macos",
       "X-Vellum-Machine-Name": hostname(),
       Authorization: `Bearer ${this.authToken}`,
@@ -209,11 +217,18 @@ export class HostProxySseClient {
       MAX_RECONNECT_DELAY_MS,
     );
 
-    this.reconnectTimer = setTimeout(() => {
+    this.reconnectTimer = setTimeout(async () => {
       this.reconnectTimer = null;
-      if (this.shouldReconnect) {
-        this.startStream();
+      if (!this.shouldReconnect) return;
+      if (this.onRefreshToken) {
+        try {
+          const freshToken = await this.onRefreshToken();
+          if (freshToken) this.authToken = freshToken;
+        } catch {
+          // Token refresh failed — reconnect with existing token
+        }
       }
+      this.startStream();
     }, delay);
   }
 

--- a/apps/macos/src/main/host-proxy-sse.ts
+++ b/apps/macos/src/main/host-proxy-sse.ts
@@ -173,8 +173,16 @@ export class HostProxySseClient {
     if (!payload) return;
 
     try {
-      const parsed = JSON.parse(payload) as HostProxySseMessage;
-      this.onMessage?.(parsed);
+      const parsed = JSON.parse(payload);
+      // The daemon's /v1/events endpoint wraps messages in an AssistantEvent
+      // envelope: { id, ..., message: { type, ... } }. Unwrap if present.
+      const msg: HostProxySseMessage =
+        parsed.message != null &&
+        typeof parsed.message === "object" &&
+        typeof parsed.message.type === "string"
+          ? parsed.message
+          : parsed;
+      this.onMessage?.(msg);
     } catch {
       // Malformed JSON — skip
     }

--- a/apps/macos/src/main/host-proxy-sse.ts
+++ b/apps/macos/src/main/host-proxy-sse.ts
@@ -18,6 +18,10 @@ export interface HostProxySseOptions {
   authToken: string;
   /** Injectable fetch for testing. Defaults to globalThis.fetch. */
   fetch?: typeof globalThis.fetch;
+  /** Override idle timeout for testing. */
+  idleTimeoutMs?: number;
+  /** Override idle check interval for testing. */
+  idleCheckIntervalMs?: number;
 }
 
 export interface HostProxySseMessage {
@@ -37,6 +41,8 @@ export class HostProxySseClient {
   private readonly gatewayHost: string;
   private authToken: string;
   private readonly fetchFn: typeof globalThis.fetch;
+  private readonly idleTimeoutMs: number;
+  private readonly idleCheckIntervalMs: number;
   private onMessage: MessageCallback | null = null;
 
   private abortController: AbortController | null = null;
@@ -52,6 +58,8 @@ export class HostProxySseClient {
     this.gatewayHost = options.gatewayHost ?? "127.0.0.1";
     this.authToken = options.authToken;
     this.fetchFn = options.fetch ?? globalThis.fetch;
+    this.idleTimeoutMs = options.idleTimeoutMs ?? IDLE_TIMEOUT_MS;
+    this.idleCheckIntervalMs = options.idleCheckIntervalMs ?? IDLE_CHECK_INTERVAL_MS;
   }
 
   /** Register a callback for parsed SSE messages. */
@@ -224,7 +232,7 @@ export class HostProxySseClient {
 
     this.idleWatchdogTimer = setInterval(() => {
       const elapsed = Date.now() - this.lastTrafficAt;
-      if (elapsed >= IDLE_TIMEOUT_MS) {
+      if (elapsed >= this.idleTimeoutMs) {
         this.clearIdleWatchdog();
         // Force-close the current stream so reconnect kicks in
         if (this.abortController) {
@@ -235,7 +243,7 @@ export class HostProxySseClient {
         this.reconnectDelay = INITIAL_RECONNECT_DELAY_MS;
         this.scheduleReconnect();
       }
-    }, IDLE_CHECK_INTERVAL_MS);
+    }, this.idleCheckIntervalMs);
   }
 
   private clearIdleWatchdog(): void {

--- a/apps/macos/src/main/host-proxy-sse.ts
+++ b/apps/macos/src/main/host-proxy-sse.ts
@@ -1,0 +1,243 @@
+/**
+ * SSE client for the host proxy subsystem in the Electron main process.
+ *
+ * Connects to the daemon's `/v1/events` endpoint, parses SSE frames
+ * (`data: <json>\n\n` for messages, `: <comment>\n` for heartbeats),
+ * and emits parsed JSON payloads via a callback. Reconnects automatically
+ * with exponential backoff and detects stale connections via an idle
+ * watchdog.
+ */
+
+import { hostname } from "node:os";
+
+import { getDeviceId } from "./device-id";
+
+export interface HostProxySseOptions {
+  gatewayPort: number;
+  gatewayHost?: string;
+  authToken: string;
+  /** Injectable fetch for testing. Defaults to globalThis.fetch. */
+  fetch?: typeof globalThis.fetch;
+}
+
+export interface HostProxySseMessage {
+  type: string;
+  [key: string]: unknown;
+}
+
+export type MessageCallback = (message: HostProxySseMessage) => void;
+
+const INITIAL_RECONNECT_DELAY_MS = 1_000;
+const MAX_RECONNECT_DELAY_MS = 30_000;
+const IDLE_TIMEOUT_MS = 30_000;
+const IDLE_CHECK_INTERVAL_MS = 10_000;
+
+export class HostProxySseClient {
+  private readonly gatewayPort: number;
+  private readonly gatewayHost: string;
+  private authToken: string;
+  private readonly fetchFn: typeof globalThis.fetch;
+  private onMessage: MessageCallback | null = null;
+
+  private abortController: AbortController | null = null;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private idleWatchdogTimer: ReturnType<typeof setInterval> | null = null;
+  private reconnectDelay = INITIAL_RECONNECT_DELAY_MS;
+  private lastTrafficAt = 0;
+  private _connected = false;
+  private shouldReconnect = false;
+
+  constructor(options: HostProxySseOptions) {
+    this.gatewayPort = options.gatewayPort;
+    this.gatewayHost = options.gatewayHost ?? "127.0.0.1";
+    this.authToken = options.authToken;
+    this.fetchFn = options.fetch ?? globalThis.fetch;
+  }
+
+  /** Register a callback for parsed SSE messages. */
+  setMessageCallback(cb: MessageCallback): void {
+    this.onMessage = cb;
+  }
+
+  /** Whether the client currently has an active SSE stream. */
+  get isConnected(): boolean {
+    return this._connected;
+  }
+
+  /** Open the SSE connection. Safe to call multiple times. */
+  connect(): void {
+    if (this.abortController) return;
+    this.shouldReconnect = true;
+    this.startStream();
+  }
+
+  /** Close the SSE connection and cancel all pending timers. */
+  disconnect(): void {
+    this.shouldReconnect = false;
+    this.clearReconnectTimer();
+    this.clearIdleWatchdog();
+    if (this.abortController) {
+      this.abortController.abort();
+      this.abortController = null;
+    }
+    this._connected = false;
+  }
+
+  /** Replace the auth token (e.g. after token rotation). */
+  updateAuthToken(token: string): void {
+    this.authToken = token;
+  }
+
+  // -- Stream lifecycle ---------------------------------------------------
+
+  private startStream(): void {
+    this.abortController?.abort();
+    const controller = new AbortController();
+    this.abortController = controller;
+
+    const url = `http://${this.gatewayHost}:${this.gatewayPort}/v1/events`;
+    const headers: Record<string, string> = {
+      Accept: "text/event-stream, application/json",
+      "X-Vellum-Client-Id": getDeviceId(),
+      "X-Vellum-Interface-Id": "macos",
+      "X-Vellum-Machine-Name": hostname(),
+      Authorization: `Bearer ${this.authToken}`,
+    };
+
+    this.fetchFn(url, { headers, signal: controller.signal })
+      .then((response) => this.handleResponse(response))
+      .catch((err: unknown) => {
+        if (isAbortError(err)) return;
+        this._connected = false;
+        this.scheduleReconnect();
+      });
+  }
+
+  private async handleResponse(response: Response): Promise<void> {
+    if (!response.ok || !response.body) {
+      this._connected = false;
+      this.scheduleReconnect();
+      return;
+    }
+
+    this._connected = true;
+    this.reconnectDelay = INITIAL_RECONNECT_DELAY_MS;
+    this.lastTrafficAt = Date.now();
+    this.startIdleWatchdog();
+
+    try {
+      await this.readStream(response.body);
+    } catch (err: unknown) {
+      if (isAbortError(err)) return;
+    }
+
+    this._connected = false;
+    if (this.shouldReconnect) {
+      this.scheduleReconnect();
+    }
+  }
+
+  private async readStream(body: ReadableStream<Uint8Array>): Promise<void> {
+    const reader = body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        this.lastTrafficAt = Date.now();
+        buffer += decoder.decode(value, { stream: true });
+
+        const lines = buffer.split("\n");
+        // Keep the last (possibly incomplete) line in the buffer
+        buffer = lines.pop() ?? "";
+
+        for (const line of lines) {
+          this.processLine(line);
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
+  private processLine(line: string): void {
+    // Heartbeat comment — no payload; liveness already tracked by readStream
+    if (line.startsWith(":")) return;
+
+    if (!line.startsWith("data: ")) return;
+
+    const payload = line.slice(6);
+    if (!payload) return;
+
+    try {
+      const parsed = JSON.parse(payload) as HostProxySseMessage;
+      this.onMessage?.(parsed);
+    } catch {
+      // Malformed JSON — skip
+    }
+  }
+
+  // -- Reconnect ----------------------------------------------------------
+
+  private scheduleReconnect(): void {
+    if (!this.shouldReconnect) return;
+    this.clearReconnectTimer();
+    this.clearIdleWatchdog();
+
+    const delay = this.reconnectDelay;
+    this.reconnectDelay = Math.min(
+      this.reconnectDelay * 2,
+      MAX_RECONNECT_DELAY_MS,
+    );
+
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      if (this.shouldReconnect) {
+        this.startStream();
+      }
+    }, delay);
+  }
+
+  private clearReconnectTimer(): void {
+    if (this.reconnectTimer !== null) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+  }
+
+  // -- Idle watchdog ------------------------------------------------------
+
+  private startIdleWatchdog(): void {
+    this.clearIdleWatchdog();
+    this.lastTrafficAt = Date.now();
+
+    this.idleWatchdogTimer = setInterval(() => {
+      const elapsed = Date.now() - this.lastTrafficAt;
+      if (elapsed >= IDLE_TIMEOUT_MS) {
+        this.clearIdleWatchdog();
+        // Force-close the current stream so reconnect kicks in
+        if (this.abortController) {
+          this.abortController.abort();
+          this.abortController = null;
+        }
+        this._connected = false;
+        this.reconnectDelay = INITIAL_RECONNECT_DELAY_MS;
+        this.scheduleReconnect();
+      }
+    }, IDLE_CHECK_INTERVAL_MS);
+  }
+
+  private clearIdleWatchdog(): void {
+    if (this.idleWatchdogTimer !== null) {
+      clearInterval(this.idleWatchdogTimer);
+      this.idleWatchdogTimer = null;
+    }
+  }
+}
+
+function isAbortError(err: unknown): boolean {
+  return err instanceof DOMException && err.name === "AbortError";
+}

--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -39,6 +39,7 @@ import { installQuickInput } from "./quick-input-window";
 import { installLocalMode, resolveCliInvocation } from "./local-mode";
 import { installLockfileWatcher } from "./lockfile-watcher";
 import { installHostProxyBridge } from "./host-proxy-router";
+import "./executors/host-bash-executor"; // side-effect: registers host_bash executor
 import log from "./logger";
 import {
   ensureVisible as ensureMainWindowVisible,

--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -36,8 +36,9 @@ import { installHotkeyHelper } from "./hotkey-helper";
 import { installHotkeysIpc } from "./hotkeys";
 import { installPopoutWindows } from "./popout-window";
 import { installQuickInput } from "./quick-input-window";
-import { installLocalMode } from "./local-mode";
+import { installLocalMode, resolveCliInvocation } from "./local-mode";
 import { installLockfileWatcher } from "./lockfile-watcher";
+import { installHostProxyBridge } from "./host-proxy-router";
 import log from "./logger";
 import {
   ensureVisible as ensureMainWindowVisible,
@@ -360,6 +361,8 @@ app
     // switcher submenu has data on its first right-click.
     const teardownLockfileWatcher = installLockfileWatcher();
     app.on("before-quit", teardownLockfileWatcher);
+    const teardownHostProxy = installHostProxyBridge(resolveCliInvocation);
+    app.on("before-quit", teardownHostProxy);
     installTray({
       toggleMainWindow: toggleMainWindowVisibility,
       ensureMainWindow: ensureMainWindowVisible,

--- a/apps/macos/src/main/local-mode.ts
+++ b/apps/macos/src/main/local-mode.ts
@@ -69,7 +69,7 @@ interface WakeResult {
  *
  * Throws when no CLI path can be resolved (e.g. install fails).
  */
-async function resolveCliInvocation(): Promise<CliInvocation> {
+export async function resolveCliInvocation(): Promise<CliInvocation> {
   const envPath = process.env.VELLUM_CLI_PATH;
   if (envPath) {
     return { command: "bun", baseArgs: ["run", envPath] };


### PR DESCRIPTION
## Summary
Add feature parity for four host proxy capabilities (host_bash, host_file, host_transfer, host_browser) to the Electron-based macOS app. The Swift app executes host commands via an SSE-request → local-execute → HTTP-POST-result protocol; the Electron main process now does the same.

## Architecture
- **SSE client** connects to the daemon's `/v1/events` endpoint as a `"macos"` interface, receiving host proxy requests
- **Result poster** sends execution results back via typed HTTP POST methods
- **Message router** dispatches SSE messages to pluggable executors, managing daemon connection lifecycle via lockfile watcher
- **Four executors**: bash (child_process.spawn), file (fs read/write/edit with media detection), transfer (bidirectional with SHA-256 verification), browser (CDP over WebSocket with connection pooling)

No daemon-side changes required — the daemon already supports the `"macos"` interface with all capabilities.

## PRs merged into feature branch
- #33996: Device ID reader
- #34000: Host proxy SSE client
- #34001: Host proxy result poster
- #34004: Message router and lifecycle
- #34007: Host bash executor
- #34008: Host transfer executor
- #34009: Host file executor
- #34010: Host browser executor

## Out of scope
- Computer use (host_cu) and app control (host_app_control) — these require native macOS APIs (ScreenCaptureKit, AXUIElement, CGEvent) via a Swift helper binary, deferred to a follow-up

Part of plan: electron-host-proxy-parity.md