### PR TITLE
fix(web): don't overwrite device consent when server has no record

### DIFF
--- a/apps/web/src/stores/auth-store.test.ts
+++ b/apps/web/src/stores/auth-store.test.ts
@@ -111,14 +111,18 @@ mock.module("@/runtime/native-biometric", () => ({
 
 const clearUserScopedStorageMock = mock(() => {});
 
+const patchConsentMock = mock(async (_consent: unknown) => {});
+
 mock.module("@/domains/account/profile", () => ({
   fetchMe: fetchMeMock,
+  patchConsent: patchConsentMock,
 }));
 
 mock.module("@/utils/onboarding-cleanup", () => ({
   restoreConsentForUser: restoreConsentForUserMock,
   persistConsentForUser: persistConsentForUserMock,
   resolveServerConsent: resolveServerConsentMock,
+  CONSENT_VERSION: "2026-06-08",
 }));
 
 mock.module("@/domains/onboarding/onboarding-store", () => ({
@@ -191,6 +195,7 @@ beforeEach(() => {
   persistConsentForUserMock.mockClear();
   resolveServerConsentMock.mockClear();
   fetchMeMock.mockClear();
+  patchConsentMock.mockClear();
   mockFetchMeResult = { id: "user-1", username: "test", email: "test@example.com", first_name: "", last_name: "", consent: null };
   mockFetchMeError = null;
   clearOrganizationMock.mockClear();
@@ -207,8 +212,13 @@ beforeEach(() => {
 });
 
 describe("auth store onboarding flag reconciliation", () => {
-  test("initSession fetches consent from server for platform users", async () => {
+  test("initSession uses server consent when server has a consent record", async () => {
     sessionUser = { id: "user-1", email: "user@example.com" };
+    mockFetchMeResult = {
+      id: "user-1", username: "test", email: "test@example.com",
+      first_name: "", last_name: "",
+      consent: { tos_accepted_version: "2026-06-08", privacy_policy_accepted_version: "2026-06-08", ai_data_sharing_accepted_version: "2026-06-08", share_analytics: true, share_diagnostics: true },
+    };
 
     await useAuthStore.getState().initSession();
 
@@ -216,6 +226,26 @@ describe("auth store onboarding flag reconciliation", () => {
     expect(resolveServerConsentMock).toHaveBeenCalled();
     expect(restoreConsentForUserMock).not.toHaveBeenCalled();
     expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
+  });
+
+  test("initSession falls through to device keys when server consent is null", async () => {
+    sessionUser = { id: "user-1", email: "user@example.com" };
+
+    await useAuthStore.getState().initSession();
+
+    expect(fetchMeMock).toHaveBeenCalled();
+    expect(resolveServerConsentMock).not.toHaveBeenCalled();
+    expect(restoreConsentForUserMock).toHaveBeenCalledWith("user-1");
+    expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
+  });
+
+  test("initSession backfills server when device keys show prior consent and server has no record", async () => {
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    restoreConsentForUserMock.mockReturnValueOnce({ tos: true, ai: true });
+
+    await useAuthStore.getState().initSession();
+
+    expect(patchConsentMock).toHaveBeenCalled();
   });
 
   test("initSession falls back to device keys when fetchMe fails", async () => {
@@ -233,6 +263,11 @@ describe("auth store onboarding flag reconciliation", () => {
     mockIsLocalMode = true;
     sessionUser = { id: "user-1", email: "user@example.com" };
     mockPlatformAssistants = [{ assistantId: "p1", cloud: "vellum" }];
+    mockFetchMeResult = {
+      id: "user-1", username: "test", email: "test@example.com",
+      first_name: "", last_name: "",
+      consent: { tos_accepted_version: "2026-06-08", privacy_policy_accepted_version: "2026-06-08", ai_data_sharing_accepted_version: "2026-06-08", share_analytics: true, share_diagnostics: true },
+    };
 
     await useAuthStore.getState().initSession();
 
@@ -243,6 +278,11 @@ describe("auth store onboarding flag reconciliation", () => {
 
   test("refreshSession fetches consent from server for platform users", async () => {
     sessionUser = { id: "user-2", email: "user@example.com" };
+    mockFetchMeResult = {
+      id: "user-2", username: "test", email: "user@example.com",
+      first_name: "", last_name: "",
+      consent: { tos_accepted_version: "2026-06-08", privacy_policy_accepted_version: "2026-06-08", ai_data_sharing_accepted_version: "2026-06-08", share_analytics: true, share_diagnostics: true },
+    };
 
     await expect(useAuthStore.getState().refreshSession()).resolves.toBe(true);
 

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -47,8 +47,8 @@ import {
 import { listAssistants } from "@/assistant/api";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { deleteBiometricToken } from "@/runtime/native-biometric";
-import { fetchMe } from "@/domains/account/profile";
-import { restoreConsentForUser, persistConsentForUser, resolveServerConsent } from "@/utils/onboarding-cleanup";
+import { fetchMe, patchConsent } from "@/domains/account/profile";
+import { restoreConsentForUser, persistConsentForUser, resolveServerConsent, CONSENT_VERSION } from "@/utils/onboarding-cleanup";
 import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
 import { clearOrganization } from "@/stores/organization-store";
 import { clearUserScopedStorage } from "@/lib/auth/session-cleanup";
@@ -168,13 +168,30 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
   if (nextUserId) {
     try {
       const me = await fetchMe();
-      const resolved = resolveServerConsent(me.consent);
+      if (me.consent) {
+        const resolved = resolveServerConsent(me.consent);
+        const store = useOnboardingStore.getState();
+        store.setTosAccepted(resolved.tos);
+        store.setAiDataConsent(resolved.ai);
+        if (resolved.shareAnalytics !== null) store.setShareAnalytics(resolved.shareAnalytics);
+        if (resolved.shareDiagnostics !== null) store.setShareDiagnostics(resolved.shareDiagnostics);
+        persistConsentForUser(nextUserId, resolved.tos, resolved.ai);
+        syncOrganizationState(nextUserId);
+        return;
+      }
+      // Server has no consent record — fall through to device keys.
+      // If device keys show prior acceptance, backfill the server.
+      const deviceConsent = restoreConsentForUser(nextUserId);
       const store = useOnboardingStore.getState();
-      store.setTosAccepted(resolved.tos);
-      store.setAiDataConsent(resolved.ai);
-      if (resolved.shareAnalytics !== null) store.setShareAnalytics(resolved.shareAnalytics);
-      if (resolved.shareDiagnostics !== null) store.setShareDiagnostics(resolved.shareDiagnostics);
-      persistConsentForUser(nextUserId, resolved.tos, resolved.ai);
+      store.setTosAccepted(deviceConsent.tos);
+      store.setAiDataConsent(deviceConsent.ai);
+      if (deviceConsent.tos && deviceConsent.ai) {
+        void patchConsent({
+          tos_accepted_version: CONSENT_VERSION,
+          privacy_policy_accepted_version: CONSENT_VERSION,
+          ai_data_sharing_accepted_version: CONSENT_VERSION,
+        }).catch(() => {});
+      }
       syncOrganizationState(nextUserId);
       return;
     } catch {


### PR DESCRIPTION
## Summary
- When `me.consent` is `null` (no server record), `syncUserScopedState` now falls through to device keys instead of treating it as "not consented"
- If device keys show prior acceptance, the server is backfilled via fire-and-forget `patchConsent` so future sessions use the server path
- Fixes a regression from #33988 where every authenticated user was redirected to `/assistant/onboarding/privacy` on session init

## Original prompt
User reported a regression since merging #33988 (server-side UserConsent API) where users are incorrectly redirected to `/assistant/onboarding/privacy`. The root cause was that `syncUserScopedState` treated `me.consent === null` as "no consent" rather than "no server record yet", overwriting device-key consent with `false` for all existing users.