### PR TITLE
fix(web): route assistant flag fetches through gateway

### DIFF
--- a/apps/web/src/hooks/use-assistant-feature-flag-sync.ts
+++ b/apps/web/src/hooks/use-assistant-feature-flag-sync.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from "react";
 import { useQuery } from "@tanstack/react-query";
 
-import { client } from "@/generated/api/client.gen";
+import { client } from "@/generated/daemon/client.gen";
 import { assertHasResponse } from "@/utils/api-errors";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import {

--- a/apps/web/src/root-layout.tsx
+++ b/apps/web/src/root-layout.tsx
@@ -41,7 +41,6 @@ import { useElectronFeatureFlagBridge } from "@/runtime/electron-feature-flags";
 import { TimezoneSync } from "@/components/timezone-sync";
 import { retireAssistant } from "@/assistant/retire-service";
 import { selectPlatformAssistant } from "@/assistant/select-platform-assistant";
-import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import { CreateAssistantDialog } from "@/components/create-assistant-dialog";
 import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
 import { toast } from "@vellumai/design-library/components/toast";
@@ -91,8 +90,7 @@ export function RootLayout() {
   const isSessionInitializing = useIsSessionInitializing();
   const hasPlatformSession = useHasPlatformSession();
   const isNonProduction = useEnvironmentStore.use.isNonProduction();
-  const isOrgReady = useIsOrgReady();
-  useClientFeatureFlagSync(hasPlatformSession && !isSessionInitializing && isOrgReady);
+  useClientFeatureFlagSync(!isSessionInitializing);
   useAssistantLifecycle({
     sessionStatus,
     isRetired: false,
@@ -109,7 +107,7 @@ export function RootLayout() {
     (s) => s.assistantState.kind,
   );
   const isAssistantActive = assistantStateKind === "active";
-  useAssistantFeatureFlagSync(hasPlatformSession ? assistantId : null);
+  useAssistantFeatureFlagSync(assistantId);
   useAssistantResourceSync(assistantId, isAssistantActive);
   useConversationSync(assistantId, isAssistantActive);
   useFeatureFlagBusSync(assistantId, isAssistantActive);


### PR DESCRIPTION
## Summary
- **Assistant flag fetches** now use the daemon client (`@/generated/daemon/client.gen`) instead of the platform client, so they route through the gateway where the endpoint is actually served.
- **Client flag fetches** no longer require a platform session — the platform API accepts unauthenticated requests, so flags are fetched as soon as the session finishes initializing (regardless of login state).
- Removed the now-unused `useIsOrgReady` import from root-layout.

## Test plan
- [ ] Verify assistant flags load in local mode (gateway serves `/v1/assistants/{id}/feature-flags`)
- [ ] Verify client flags load before login (unauthenticated fetch to platform)
- [ ] Verify client flags still load after login
- [ ] Verify `platformFeaturesGate` still blocks client flag fetches when platform features are disabled in local mode
- [ ] Type check passes (`npx tsc --noEmit` — confirmed clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)