### PR TITLE
Add supervised mac helper IPC client

### DIFF
--- a/apps/macos/src/main/hotkey-helper.test.ts
+++ b/apps/macos/src/main/hotkey-helper.test.ts
@@ -102,6 +102,7 @@ Object.defineProperty(process, "resourcesPath", {
 const {
   __resetForTesting,
   __setPlatformForTesting,
+  __setSupervisorOptionsForTesting,
   getHotkeyHelperPath,
   installHotkeyHelper,
 } = await import("./hotkey-helper");
@@ -120,6 +121,15 @@ const invokeFnPushToTalkFrom = (enable: boolean, sender: FakeWebContents) =>
 
 const invokePing = () =>
   handlers["vellum:helper:ping"]({ sender: defaultSender }) as Promise<unknown>;
+
+const invokeGetState = () =>
+  handlers["vellum:helper:state:get"]({ sender: defaultSender }) as unknown;
+
+const invokeRestart = () =>
+  handlers["vellum:helper:restart"]({ sender: defaultSender }) as unknown;
+
+const wait = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
 
 beforeEach(() => {
   __resetForTesting();
@@ -156,6 +166,8 @@ describe("installHotkeyHelper", () => {
   test("registers the fnPushToTalk IPC handler", () => {
     installHotkeyHelper();
     expect(handlers["vellum:helper:ping"]).toBeDefined();
+    expect(handlers["vellum:helper:state:get"]).toBeDefined();
+    expect(handlers["vellum:helper:restart"]).toBeDefined();
     expect(handlers["vellum:helper:hotkey:fnPushToTalk"]).toBeDefined();
   });
 
@@ -172,6 +184,20 @@ describe("installHotkeyHelper", () => {
     );
 
     expect(await pending).toBe("pong");
+  });
+
+  test("exposes helper state and user-initiated restart", () => {
+    installHotkeyHelper();
+
+    expect(invokeGetState()).toEqual({ status: "idle" });
+
+    expect(invokeRestart()).toEqual({
+      ok: true,
+      state: { status: "running" },
+    });
+    expect(spawnCalls[0]?.[0]).toBe(
+      "/repo/apps/macos/resources/hotkey-helper",
+    );
   });
 
   test("sends hotkey.fnPushToTalk to the helper process", async () => {
@@ -195,6 +221,56 @@ describe("installHotkeyHelper", () => {
     );
 
     expect(await pending).toEqual({ ok: true, enabled: true });
+  });
+
+  test("restarts the helper after a crash", async () => {
+    __setSupervisorOptionsForTesting({
+      initialBackoffMs: 1,
+      maxBackoffMs: 1,
+    });
+    installHotkeyHelper();
+
+    const pending = invokePing();
+    lastChild?.stdout.emit(
+      "data",
+      Buffer.from("{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":\"pong\"}\n"),
+    );
+    expect(await pending).toBe("pong");
+
+    const crashed = lastChild;
+    crashed?.emit("close", 1, null);
+    await wait(5);
+
+    expect(spawnCalls).toHaveLength(2);
+    expect(lastChild).not.toBe(crashed);
+  });
+
+  test("restores Fn push-to-talk after a helper crash", async () => {
+    __setSupervisorOptionsForTesting({
+      initialBackoffMs: 1,
+      maxBackoffMs: 1,
+    });
+    installHotkeyHelper();
+
+    const pending = invokeFnPushToTalk(true);
+    lastChild?.stdout.emit(
+      "data",
+      Buffer.from(
+        "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"enabled\":true}}\n",
+      ),
+    );
+    expect(await pending).toEqual({ ok: true, enabled: true });
+
+    const crashed = lastChild;
+    crashed?.emit("close", 1, null);
+    await wait(5);
+
+    expect(spawnCalls).toHaveLength(2);
+    expect(lastChild).not.toBe(crashed);
+    expect(lastChild?.stdin.writes[0]).toContain(
+      "\"method\":\"hotkey.fnPushToTalk\"",
+    );
+    expect(lastChild?.stdin.writes[0]).toContain("\"enable\":true");
   });
 
   test("maps JSON-RPC helper errors to hotkey results", async () => {
@@ -308,7 +384,7 @@ describe("installHotkeyHelper", () => {
     );
     await pending;
 
-    appListeners.get("will-quit")?.();
+    appListeners.get("before-quit")?.();
 
     expect(lastChild?.stdin.writes.at(-1)).toContain("\"enable\":false");
     expect(lastChild?.stdin.ended).toBe(true);

--- a/apps/macos/src/main/hotkey-helper.test.ts
+++ b/apps/macos/src/main/hotkey-helper.test.ts
@@ -200,6 +200,27 @@ describe("installHotkeyHelper", () => {
     );
   });
 
+  test("user-initiated restart replaces an already-running helper", async () => {
+    installHotkeyHelper();
+
+    const pending = invokePing();
+    lastChild?.stdout.emit(
+      "data",
+      Buffer.from("{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":\"pong\"}\n"),
+    );
+    expect(await pending).toBe("pong");
+
+    const original = lastChild;
+    expect(invokeRestart()).toEqual({
+      ok: true,
+      state: { status: "running" },
+    });
+
+    expect(original?.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(spawnCalls).toHaveLength(2);
+    expect(lastChild).not.toBe(original);
+  });
+
   test("sends hotkey.fnPushToTalk to the helper process", async () => {
     installHotkeyHelper();
     const pending = invokeFnPushToTalk(true);
@@ -388,5 +409,24 @@ describe("installHotkeyHelper", () => {
 
     expect(lastChild?.stdin.writes.at(-1)).toContain("\"enable\":false");
     expect(lastChild?.stdin.ended).toBe(true);
+  });
+
+  test("does not respawn the helper after deliberate shutdown", async () => {
+    installHotkeyHelper();
+    const pending = invokePing();
+    lastChild?.stdout.emit(
+      "data",
+      Buffer.from("{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":\"pong\"}\n"),
+    );
+    await pending;
+
+    const shuttingDown = lastChild;
+    appListeners.get("before-quit")?.();
+    shuttingDown?.emit("close", 0, null);
+
+    await expect(invokePing()).rejects.toThrow(
+      "hotkey helper is not available",
+    );
+    expect(spawnCalls).toHaveLength(1);
   });
 });

--- a/apps/macos/src/main/hotkey-helper.test.ts
+++ b/apps/macos/src/main/hotkey-helper.test.ts
@@ -221,6 +221,39 @@ describe("installHotkeyHelper", () => {
     expect(lastChild).not.toBe(original);
   });
 
+  test("user-initiated restart reopens a circuit-open helper", async () => {
+    __setSupervisorOptionsForTesting({
+      initialBackoffMs: 1,
+      maxBackoffMs: 1,
+      circuitCrashCount: 2,
+      circuitWindowMs: 1_000,
+    });
+    installHotkeyHelper();
+
+    expect(invokeRestart()).toEqual({
+      ok: true,
+      state: { status: "running" },
+    });
+
+    const first = lastChild;
+    first?.emit("close", 1, null);
+    await wait(5);
+    expect(spawnCalls).toHaveLength(2);
+
+    const second = lastChild;
+    second?.emit("close", 1, null);
+    await wait(0);
+    expect(invokeGetState()).toEqual(
+      expect.objectContaining({ status: "circuit-open" }),
+    );
+
+    expect(invokeRestart()).toEqual({
+      ok: true,
+      state: { status: "running" },
+    });
+    expect(spawnCalls).toHaveLength(3);
+  });
+
   test("sends hotkey.fnPushToTalk to the helper process", async () => {
     installHotkeyHelper();
     const pending = invokeFnPushToTalk(true);

--- a/apps/macos/src/main/hotkey-helper.ts
+++ b/apps/macos/src/main/hotkey-helper.ts
@@ -1,11 +1,14 @@
 import { BrowserWindow, app, type WebContents } from "electron";
-import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
-import { existsSync } from "node:fs";
 import path from "node:path";
 import { z } from "zod";
 
 import { handle } from "./ipc";
 import log from "./logger";
+import {
+  MacHelperClient,
+  type MacHelperClientOptions,
+  type MacHelperState,
+} from "./sidecar/mac-helper";
 
 export type HotkeyEventState = "down" | "up";
 
@@ -18,14 +21,9 @@ export type FnPushToTalkResult =
   | { ok: true; enabled: boolean }
   | { ok: false; reason: string };
 
-type PendingCall = {
-  resolve: (result: unknown) => void;
-  reject: (err: Error) => void;
-  timeout: ReturnType<typeof setTimeout>;
-};
-
-const RESPONSE_TIMEOUT_MS = 2_000;
-const SHUTDOWN_KILL_DELAY_MS = 500;
+export type HelperRestartResult =
+  | { ok: true; state: MacHelperState }
+  | { ok: false; reason: string; state: MacHelperState };
 
 const HOTKEY_EVENT_SCHEMA = z.object({
   kind: z.literal("fnPushToTalk"),
@@ -36,31 +34,17 @@ const HOTKEY_RESULT_SCHEMA = z.object({
   enabled: z.boolean(),
 });
 
-const JSON_RPC_ID_SCHEMA = z.union([z.string(), z.number(), z.null()]);
-
-const HELPER_ENVELOPE_SCHEMA = z.union([
-  z.object({
-    jsonrpc: z.literal("2.0"),
-    method: z.literal("hotkey.event"),
-    params: HOTKEY_EVENT_SCHEMA,
-  }).strict(),
-  z.object({
-    jsonrpc: z.literal("2.0"),
-    id: JSON_RPC_ID_SCHEMA,
-    error: z.object({
-      code: z.number(),
-      message: z.string(),
-      data: z.unknown().optional(),
-    }),
-  }).strict(),
-  z.object({
-    jsonrpc: z.literal("2.0"),
-    id: JSON_RPC_ID_SCHEMA,
-    result: z.unknown().optional(),
-  }).strict(),
-]);
-
 let platformForTesting: NodeJS.Platform | null = null;
+let supervisorOptionsForTesting: Partial<
+  Pick<
+    MacHelperClientOptions,
+    | "initialBackoffMs"
+    | "maxBackoffMs"
+    | "stableResetMs"
+    | "circuitCrashCount"
+    | "circuitWindowMs"
+  >
+> = {};
 
 const getPlatform = (): NodeJS.Platform =>
   platformForTesting ?? process.platform;
@@ -72,288 +56,42 @@ export const getHotkeyHelperPath = (): string => {
   return path.join(app.getAppPath(), "resources", "hotkey-helper");
 };
 
-class JsonRpcHelperError extends Error {
-  readonly code: number;
-  readonly data?: unknown;
+const makeClient = (): MacHelperClient =>
+  new MacHelperClient({
+    name: "hotkey helper",
+    resolveExecutablePath: getHotkeyHelperPath,
+    logger: log,
+    platform: getPlatform(),
+    ...supervisorOptionsForTesting,
+  });
 
-  constructor(error: { code: number; message: string; data?: unknown }) {
-    super(error.message);
-    this.name = "JsonRpcHelperError";
-    this.code = error.code;
-    if (error.data !== undefined) this.data = error.data;
-  }
-}
+let client = makeClient();
 
-class HotkeyHelperClient {
-  private child: ChildProcessWithoutNullStreams | null = null;
-  private nextId = 1;
-  private stdoutBuffer = "";
-  private readonly pending = new Map<string, PendingCall>();
-  private readonly listeners = new Set<(event: HotkeyEvent) => void>();
-  private readonly exitListeners = new Set<() => void>();
-  private pttIsDown = false;
-
-  onEvent(listener: (event: HotkeyEvent) => void): () => void {
-    this.listeners.add(listener);
-    return () => {
-      this.listeners.delete(listener);
+const fnPushToTalk = async (
+  enable: boolean,
+): Promise<FnPushToTalkResult> => {
+  try {
+    const result = await client.call("hotkey.fnPushToTalk", { enable });
+    const parsed = HOTKEY_RESULT_SCHEMA.safeParse(result);
+    if (!parsed.success) {
+      return { ok: false, reason: "hotkey helper returned invalid result" };
+    }
+    return { ok: true, enabled: parsed.data.enabled };
+  } catch (err) {
+    return {
+      ok: false,
+      reason: err instanceof Error ? err.message : String(err),
     };
   }
+};
 
-  onExit(listener: () => void): () => void {
-    this.exitListeners.add(listener);
-    return () => {
-      this.exitListeners.delete(listener);
-    };
+const ping = async (): Promise<"pong"> => {
+  const result = await client.call("ping");
+  if (result !== "pong") {
+    throw new Error("hotkey helper returned invalid ping result");
   }
-
-  async fnPushToTalk(enable: boolean): Promise<FnPushToTalkResult> {
-    if (getPlatform() !== "darwin") {
-      return {
-        ok: false,
-        reason: "Fn push-to-talk is only available on macOS",
-      };
-    }
-
-    try {
-      const result = await this.call("hotkey.fnPushToTalk", { enable });
-      const parsed = HOTKEY_RESULT_SCHEMA.safeParse(result);
-      if (!parsed.success) {
-        return { ok: false, reason: "hotkey helper returned invalid result" };
-      }
-      return { ok: true, enabled: parsed.data.enabled };
-    } catch (err) {
-      return {
-        ok: false,
-        reason: err instanceof Error ? err.message : String(err),
-      };
-    }
-  }
-
-  async ping(): Promise<"pong"> {
-    if (getPlatform() !== "darwin") {
-      throw new Error("helper.ping is only available on macOS");
-    }
-
-    const result = await this.call("ping");
-    if (result !== "pong") {
-      throw new Error("hotkey helper returned invalid ping result");
-    }
-    return "pong";
-  }
-
-  shutdown(): void {
-    if (!this.child) return;
-
-    try {
-      this.writeFrame(this.child, {
-        jsonrpc: "2.0",
-        id: this.nextId++,
-        method: "hotkey.fnPushToTalk",
-        params: { enable: false },
-      });
-      this.child.stdin.end();
-    } catch {
-      // The process may already be gone. The exit handler resolves cleanup.
-    }
-
-    const child = this.child;
-    const killTimer = setTimeout(() => {
-      if (this.child === child) {
-        child.kill();
-      }
-    }, SHUTDOWN_KILL_DELAY_MS);
-    killTimer.unref?.();
-  }
-
-  __resetForTesting(): void {
-    this.shutdown();
-    this.child = null;
-    this.nextId = 1;
-    this.stdoutBuffer = "";
-    this.pttIsDown = false;
-    this.listeners.clear();
-    this.exitListeners.clear();
-    for (const [id, pending] of this.pending) {
-      clearTimeout(pending.timeout);
-      pending.reject(new Error(`hotkey helper reset (${id})`));
-    }
-    this.pending.clear();
-  }
-
-  private ensureChild(): ChildProcessWithoutNullStreams | null {
-    if (this.child) return this.child;
-
-    const helperPath = getHotkeyHelperPath();
-    if (!existsSync(helperPath)) {
-      log.warn(`[hotkey-helper] executable not found at ${helperPath}`);
-      return null;
-    }
-
-    try {
-      const child = spawn(helperPath, [], { stdio: "pipe" });
-      this.child = child;
-      child.stdout.on("data", (chunk: Buffer) => this.handleStdout(chunk));
-      child.stderr.on("data", (chunk: Buffer) => {
-        const line = chunk.toString("utf8").trim();
-        if (line) log.warn(`[hotkey-helper] ${line}`);
-      });
-      child.on("error", (err: Error) => {
-        log.warn(`[hotkey-helper] failed to spawn: ${err.message}`);
-        this.handleExit();
-      });
-      child.on("close", () => this.handleExit());
-      return child;
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      log.warn(`[hotkey-helper] failed to spawn: ${message}`);
-      return null;
-    }
-  }
-
-  private call(
-    method: string,
-    params?: Record<string, unknown>,
-  ): Promise<unknown> {
-    const child = this.ensureChild();
-    if (!child) {
-      throw new Error("hotkey helper is not available");
-    }
-
-    const id = this.nextId++;
-    return new Promise<unknown>((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        this.pending.delete(String(id));
-        reject(new Error("hotkey helper did not respond"));
-      }, RESPONSE_TIMEOUT_MS);
-      timeout.unref?.();
-
-      this.pending.set(String(id), { resolve, reject, timeout });
-      try {
-        this.writeFrame(
-          child,
-          {
-            jsonrpc: "2.0",
-            id,
-            method,
-            ...(params === undefined ? {} : { params }),
-          },
-          (err) => {
-            if (!err) return;
-            this.rejectPending(
-              id,
-              new Error(`hotkey helper write failed: ${err.message}`),
-            );
-          },
-        );
-      } catch (err) {
-        this.rejectPending(
-          id,
-          err instanceof Error ? err : new Error(String(err)),
-        );
-      }
-    });
-  }
-
-  private writeFrame(
-    child: ChildProcessWithoutNullStreams,
-    frame: Record<string, unknown>,
-    callback?: (err?: Error | null) => void,
-  ): void {
-    const line = JSON.stringify(frame);
-    if (line.includes("\n") || line.includes("\r")) {
-      throw new Error("hotkey helper frame contained raw newline");
-    }
-    child.stdin.write(`${line}\n`, callback);
-  }
-
-  private handleStdout(chunk: Buffer): void {
-    this.stdoutBuffer += chunk.toString("utf8");
-    let newline = this.stdoutBuffer.indexOf("\n");
-    while (newline >= 0) {
-      const line = this.stdoutBuffer.slice(0, newline).trim();
-      this.stdoutBuffer = this.stdoutBuffer.slice(newline + 1);
-      if (line.length > 0) this.handleLine(line);
-      newline = this.stdoutBuffer.indexOf("\n");
-    }
-  }
-
-  private handleLine(line: string): void {
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(line);
-    } catch {
-      log.warn(`[hotkey-helper] ignored invalid JSON: ${line}`);
-      return;
-    }
-
-    const envelope = HELPER_ENVELOPE_SCHEMA.safeParse(parsed);
-    if (!envelope.success) {
-      log.warn(`[hotkey-helper] ignored invalid envelope: ${line}`);
-      return;
-    }
-
-    const message = envelope.data;
-    if ("method" in message) {
-      this.emitEvent(message.params);
-      return;
-    }
-
-    if ("error" in message) {
-      this.rejectPending(message.id, new JsonRpcHelperError(message.error));
-    } else {
-      this.resolvePending(message.id, message.result);
-    }
-  }
-
-  private resolvePending(id: string | number | null, result: unknown): void {
-    if (id === null) return;
-    const pending = this.pending.get(String(id));
-    if (!pending) return;
-    clearTimeout(pending.timeout);
-    this.pending.delete(String(id));
-    pending.resolve(result);
-  }
-
-  private rejectPending(id: string | number | null, error: Error): void {
-    if (id === null) return;
-    const pending = this.pending.get(String(id));
-    if (!pending) return;
-    clearTimeout(pending.timeout);
-    this.pending.delete(String(id));
-    pending.reject(error);
-  }
-
-  private emitEvent(event: HotkeyEvent): void {
-    this.pttIsDown = event.state === "down";
-    for (const listener of this.listeners) listener(event);
-  }
-
-  private handleExit(): void {
-    const hadChild = this.child !== null;
-    this.child = null;
-    this.stdoutBuffer = "";
-
-    for (const [id, pending] of this.pending) {
-      clearTimeout(pending.timeout);
-      pending.reject(new Error(`hotkey helper exited before response ${id}`));
-    }
-    this.pending.clear();
-
-    if (this.pttIsDown) {
-      this.pttIsDown = false;
-      for (const listener of this.listeners) {
-        listener({ kind: "fnPushToTalk", state: "up" });
-      }
-    }
-
-    if (hadChild) {
-      for (const listener of this.exitListeners) listener();
-    }
-  }
-}
-
-const client = new HotkeyHelperClient();
+  return "pong";
+};
 
 interface HotkeyOwner {
   webContents: WebContents;
@@ -363,6 +101,9 @@ interface HotkeyOwner {
 const hotkeyOwners = new Map<number, HotkeyOwner>();
 let activeHotkeyOwnerId: number | null = null;
 let helperRegistered = false;
+let restoreHotkeyAfterRestart = false;
+let restoreHotkeyInFlight = false;
+let pttIsDown = false;
 
 const newestOwnerId = (): number | null => {
   let id: number | null = null;
@@ -390,11 +131,12 @@ const disableFnPushToTalkForOwner = async (
   if (hotkeyOwners.size > 0) {
     return { ok: true, enabled: true };
   }
+  restoreHotkeyAfterRestart = false;
   if (!helperRegistered) {
     return { ok: true, enabled: false };
   }
 
-  const result = await client.fnPushToTalk(false);
+  const result = await fnPushToTalk(false);
   if (result.ok) {
     helperRegistered = false;
     log.info("[hotkey-helper] disabled Fn push-to-talk");
@@ -439,7 +181,7 @@ const enableFnPushToTalkForOwner = async (
     return { ok: true, enabled: true };
   }
 
-  const result = await client.fnPushToTalk(true);
+  const result = await fnPushToTalk(true);
   if (result.ok) {
     helperRegistered = result.enabled;
     log.info("[hotkey-helper] enabled Fn push-to-talk");
@@ -453,6 +195,7 @@ const enableFnPushToTalkForOwner = async (
 };
 
 const sendHotkeyEventToOwner = (event: HotkeyEvent): void => {
+  pttIsDown = event.state === "down";
   const ownerId = activeHotkeyOwnerId ?? newestOwnerId();
   const activeOwner = ownerId !== null ? hotkeyOwners.get(ownerId) : null;
   const owner =
@@ -463,17 +206,92 @@ const sendHotkeyEventToOwner = (event: HotkeyEvent): void => {
   owner.webContents.send("vellum:helper:hotkey:event", event);
 };
 
+const sendSyntheticHotkeyUpIfNeeded = (): void => {
+  if (!pttIsDown) return;
+  pttIsDown = false;
+  sendHotkeyEventToOwner({ kind: "fnPushToTalk", state: "up" });
+};
+
+const sendHelperStateToRenderers = (state: MacHelperState): void => {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (win.webContents.isDestroyed()) continue;
+    win.webContents.send("vellum:helper:state", state);
+  }
+};
+
+const restoreHotkeyRegistrationIfNeeded = async (): Promise<void> => {
+  if (
+    !restoreHotkeyAfterRestart ||
+    restoreHotkeyInFlight ||
+    helperRegistered ||
+    hotkeyOwners.size === 0
+  ) {
+    return;
+  }
+
+  restoreHotkeyInFlight = true;
+  const result = await fnPushToTalk(true);
+  restoreHotkeyInFlight = false;
+  if (result.ok) {
+    helperRegistered = result.enabled;
+    restoreHotkeyAfterRestart = !result.enabled;
+    if (result.enabled) {
+      log.info("[hotkey-helper] restored Fn push-to-talk after helper restart");
+    }
+  } else {
+    log.warn(
+      `[hotkey-helper] failed to restore Fn push-to-talk: ${result.reason}`,
+    );
+  }
+};
+
+const handleHelperState = (state: MacHelperState): void => {
+  sendHelperStateToRenderers(state);
+  if (state.status === "running") {
+    void restoreHotkeyRegistrationIfNeeded();
+    return;
+  }
+
+  if (helperRegistered && hotkeyOwners.size > 0) {
+    restoreHotkeyAfterRestart = true;
+  }
+  helperRegistered = false;
+  sendSyntheticHotkeyUpIfNeeded();
+};
+
+const restartHelper = (): HelperRestartResult => {
+  try {
+    const state = client.retry();
+    return { ok: true, state };
+  } catch (err) {
+    return {
+      ok: false,
+      reason: err instanceof Error ? err.message : String(err),
+      state: client.getState(),
+    };
+  }
+};
+
 let installed = false;
+let unsubscribeHotkeyEvents: (() => void) | null = null;
+let unsubscribeHelperState: (() => void) | null = null;
+
 export const installHotkeyHelper = (): void => {
   if (installed) return;
   installed = true;
 
-  client.onEvent(sendHotkeyEventToOwner);
-  client.onExit(() => {
-    helperRegistered = false;
-  });
+  unsubscribeHotkeyEvents = client.onNotification(
+    "hotkey.event",
+    HOTKEY_EVENT_SCHEMA,
+    (event) => {
+      sendHotkeyEventToOwner(event);
+    },
+  );
+  unsubscribeHelperState = client.onState(handleHelperState);
 
-  handle("vellum:helper:ping", z.tuple([]), () => client.ping());
+  handle("vellum:helper:ping", z.tuple([]), () => ping());
+  handle("vellum:helper:state:get", z.tuple([]), () => client.getState());
+  handle("vellum:helper:restart", z.tuple([]), () => restartHelper());
 
   handle(
     "vellum:helper:hotkey:fnPushToTalk",
@@ -484,23 +302,54 @@ export const installHotkeyHelper = (): void => {
         : disableFnPushToTalkForOwner(event.sender),
   );
 
-  app.on("will-quit", () => {
-    client.shutdown();
+  app.on("before-quit", () => {
+    client.shutdown({
+      method: "hotkey.fnPushToTalk",
+      params: { enable: false },
+    });
   });
 };
 
 export const __resetForTesting = (): void => {
   installed = false;
   platformForTesting = null;
+  supervisorOptionsForTesting = {};
   helperRegistered = false;
+  restoreHotkeyAfterRestart = false;
+  restoreHotkeyInFlight = false;
+  pttIsDown = false;
+  unsubscribeHotkeyEvents?.();
+  unsubscribeHotkeyEvents = null;
+  unsubscribeHelperState?.();
+  unsubscribeHelperState = null;
   for (const owner of hotkeyOwners.values()) owner.cleanup();
   hotkeyOwners.clear();
   activeHotkeyOwnerId = null;
-  client.__resetForTesting();
+  client.resetForTesting();
+  client = makeClient();
 };
 
 export const __setPlatformForTesting = (
   platform: NodeJS.Platform | null,
 ): void => {
   platformForTesting = platform;
+  client.resetForTesting();
+  client = makeClient();
+};
+
+export const __setSupervisorOptionsForTesting = (
+  options: Partial<
+    Pick<
+      MacHelperClientOptions,
+      | "initialBackoffMs"
+      | "maxBackoffMs"
+      | "stableResetMs"
+      | "circuitCrashCount"
+      | "circuitWindowMs"
+    >
+  >,
+): void => {
+  supervisorOptionsForTesting = options;
+  client.resetForTesting();
+  client = makeClient();
 };

--- a/apps/macos/src/main/sidecar/mac-helper.ts
+++ b/apps/macos/src/main/sidecar/mac-helper.ts
@@ -1,0 +1,536 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { existsSync } from "node:fs";
+import { z } from "zod";
+
+import {
+  SidecarSupervisor,
+  type SidecarState,
+} from "./supervisor";
+
+export type MacHelperState = SidecarState;
+
+export const JSON_RPC_PARSE_ERROR = -32700;
+export const JSON_RPC_INVALID_REQUEST = -32600;
+export const JSON_RPC_METHOD_NOT_FOUND = -32601;
+export const JSON_RPC_INVALID_PARAMS = -32602;
+export const JSON_RPC_INTERNAL_ERROR = -32603;
+
+const JSON_RPC_ID_SCHEMA = z.union([z.string(), z.number(), z.null()]);
+
+const JSON_RPC_ERROR_SCHEMA = z.object({
+  code: z.number(),
+  message: z.string(),
+  data: z.unknown().optional(),
+});
+
+const JSON_RPC_NOTIFICATION_SCHEMA = z
+  .object({
+    jsonrpc: z.literal("2.0"),
+    method: z.string().min(1),
+    params: z.unknown().optional(),
+  })
+  .strict();
+
+const JSON_RPC_SUCCESS_RESPONSE_SCHEMA = z
+  .object({
+    jsonrpc: z.literal("2.0"),
+    id: JSON_RPC_ID_SCHEMA,
+    result: z.unknown().optional(),
+  })
+  .strict();
+
+const JSON_RPC_ERROR_RESPONSE_SCHEMA = z
+  .object({
+    jsonrpc: z.literal("2.0"),
+    id: JSON_RPC_ID_SCHEMA,
+    error: JSON_RPC_ERROR_SCHEMA,
+  })
+  .strict();
+
+const JSON_RPC_FRAME_SCHEMA = z.union([
+  JSON_RPC_NOTIFICATION_SCHEMA,
+  JSON_RPC_SUCCESS_RESPONSE_SCHEMA,
+  JSON_RPC_ERROR_RESPONSE_SCHEMA,
+]);
+
+export type JsonRpcId = z.infer<typeof JSON_RPC_ID_SCHEMA>;
+export type JsonRpcNotification = z.infer<
+  typeof JSON_RPC_NOTIFICATION_SCHEMA
+>;
+export type JsonRpcErrorPayload = z.infer<typeof JSON_RPC_ERROR_SCHEMA>;
+
+type PendingCall = {
+  resolve: (result: unknown) => void;
+  reject: (err: Error) => void;
+  timeout: ReturnType<typeof setTimeout>;
+};
+
+type PendingStream = {
+  queue: AsyncQueue<unknown>;
+  timeout: ReturnType<typeof setTimeout>;
+};
+
+type NotificationSubscription = {
+  schema: z.ZodType;
+  listener: (params: unknown) => void;
+};
+
+type StreamSubscription = {
+  method: string;
+  schema: z.ZodType;
+  matches?: (notification: JsonRpcNotification) => boolean;
+  queue: AsyncQueue<unknown>;
+};
+
+export interface MacHelperClientOptions {
+  name: string;
+  resolveExecutablePath: () => string;
+  logger: {
+    info: (...args: unknown[]) => void;
+    warn: (...args: unknown[]) => void;
+  };
+  responseTimeoutMs?: number;
+  spawnArgs?: string[];
+  platform?: NodeJS.Platform;
+  initialBackoffMs?: number;
+  maxBackoffMs?: number;
+  stableResetMs?: number;
+  circuitCrashCount?: number;
+  circuitWindowMs?: number;
+}
+
+export interface MacHelperStreamOptions<T> {
+  notificationMethod: string;
+  notificationSchema: z.ZodType<T>;
+  matches?: (notification: JsonRpcNotification) => boolean;
+}
+
+export class JsonRpcHelperError extends Error {
+  readonly code: number;
+  readonly data?: unknown;
+
+  constructor(error: JsonRpcErrorPayload) {
+    super(error.message);
+    this.name = "JsonRpcHelperError";
+    this.code = error.code;
+    if (error.data !== undefined) this.data = error.data;
+  }
+}
+
+const DEFAULT_RESPONSE_TIMEOUT_MS = 2_000;
+
+export class MacHelperClient {
+  private readonly name: string;
+  private readonly resolveExecutablePath: () => string;
+  private readonly logger: MacHelperClientOptions["logger"];
+  private readonly responseTimeoutMs: number;
+  private readonly spawnArgs: string[];
+  private readonly platform: NodeJS.Platform;
+  private readonly supervisor: SidecarSupervisor;
+  private stdoutBuffer = "";
+  private nextId = 1;
+  private readonly pendingCalls = new Map<string, PendingCall>();
+  private readonly pendingStreams = new Map<string, PendingStream>();
+  private readonly notificationSubscriptions = new Map<
+    string,
+    Set<NotificationSubscription>
+  >();
+  private readonly streamSubscriptions = new Set<StreamSubscription>();
+
+  constructor(options: MacHelperClientOptions) {
+    this.name = options.name;
+    this.resolveExecutablePath = options.resolveExecutablePath;
+    this.logger = options.logger;
+    this.responseTimeoutMs =
+      options.responseTimeoutMs ?? DEFAULT_RESPONSE_TIMEOUT_MS;
+    this.spawnArgs = options.spawnArgs ?? [];
+    this.platform = options.platform ?? process.platform;
+    this.supervisor = new SidecarSupervisor({
+      name: this.name,
+      logger: this.logger,
+      spawn: () => this.spawnChild(),
+      onStart: (child) => this.attachChild(child),
+      onExit: (reason) => this.handleExit(reason),
+      initialBackoffMs: options.initialBackoffMs,
+      maxBackoffMs: options.maxBackoffMs,
+      stableResetMs: options.stableResetMs,
+      circuitCrashCount: options.circuitCrashCount,
+      circuitWindowMs: options.circuitWindowMs,
+    });
+  }
+
+  getState(): MacHelperState {
+    return this.supervisor.getState();
+  }
+
+  onState(listener: (state: MacHelperState) => void): () => void {
+    return this.supervisor.onState(listener);
+  }
+
+  onNotification<T>(
+    method: string,
+    schema: z.ZodType<T>,
+    listener: (params: T) => void,
+  ): () => void {
+    const subscription: NotificationSubscription = {
+      schema,
+      listener: (params) => listener(params as T),
+    };
+    const subscriptions =
+      this.notificationSubscriptions.get(method) ??
+      new Set<NotificationSubscription>();
+    subscriptions.add(subscription);
+    this.notificationSubscriptions.set(method, subscriptions);
+
+    return () => {
+      subscriptions.delete(subscription);
+      if (subscriptions.size === 0) {
+        this.notificationSubscriptions.delete(method);
+      }
+    };
+  }
+
+  call(method: string, params?: unknown): Promise<unknown> {
+    const child = this.ensureChild();
+    const id = this.nextId++;
+
+    return new Promise<unknown>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pendingCalls.delete(String(id));
+        reject(new Error(`${this.name} did not respond`));
+      }, this.responseTimeoutMs);
+      timeout.unref?.();
+
+      this.pendingCalls.set(String(id), { resolve, reject, timeout });
+      try {
+        this.writeFrame(
+          child,
+          {
+            jsonrpc: "2.0",
+            id,
+            method,
+            ...(params === undefined ? {} : { params }),
+          },
+          (err) => {
+            if (!err) return;
+            this.rejectPendingCall(
+              id,
+              new Error(`${this.name} write failed: ${err.message}`),
+            );
+          },
+        );
+      } catch (err) {
+        this.rejectPendingCall(
+          id,
+          err instanceof Error ? err : new Error(String(err)),
+        );
+      }
+    });
+  }
+
+  async *stream<T>(
+    method: string,
+    params: unknown,
+    options: MacHelperStreamOptions<T>,
+  ): AsyncIterable<T> {
+    const child = this.ensureChild();
+    const id = this.nextId++;
+    const queue = new AsyncQueue<unknown>();
+    const streamSubscription: StreamSubscription = {
+      method: options.notificationMethod,
+      schema: options.notificationSchema,
+      matches: options.matches,
+      queue,
+    };
+    this.streamSubscriptions.add(streamSubscription);
+
+    const timeout = setTimeout(() => {
+      this.pendingStreams.delete(String(id));
+      this.streamSubscriptions.delete(streamSubscription);
+      queue.fail(new Error(`${this.name} did not finish ${method}`));
+    }, this.responseTimeoutMs);
+    timeout.unref?.();
+    this.pendingStreams.set(String(id), { queue, timeout });
+
+    try {
+      this.writeFrame(child, {
+        jsonrpc: "2.0",
+        id,
+        method,
+        params,
+      });
+
+      for await (const frame of queue) {
+        yield frame as T;
+      }
+    } finally {
+      clearTimeout(timeout);
+      this.pendingStreams.delete(String(id));
+      this.streamSubscriptions.delete(streamSubscription);
+    }
+  }
+
+  retry(): MacHelperState {
+    return this.supervisor.retry();
+  }
+
+  shutdown(gracefulRequest?: { method: string; params?: unknown }): void {
+    const child = this.supervisor.currentChild();
+    if (child) {
+      try {
+        if (gracefulRequest) {
+          this.writeFrame(child, {
+            jsonrpc: "2.0",
+            id: this.nextId++,
+            method: gracefulRequest.method,
+            ...(gracefulRequest.params === undefined
+              ? {}
+              : { params: gracefulRequest.params }),
+          });
+        }
+        child.stdin.end();
+      } catch {
+        // The process may already be gone. The supervisor owns final cleanup.
+      }
+    }
+    this.supervisor.stop({ reason: "app quit" });
+  }
+
+  resetForTesting(): void {
+    this.stdoutBuffer = "";
+    this.nextId = 1;
+    this.clearPending(new Error(`${this.name} reset`));
+    this.notificationSubscriptions.clear();
+    this.streamSubscriptions.clear();
+    this.supervisor.resetForTesting();
+  }
+
+  private ensureChild(): ChildProcessWithoutNullStreams {
+    if (this.platform !== "darwin") {
+      throw new Error(`${this.name} is only available on macOS`);
+    }
+
+    const child = this.supervisor.ensureRunning();
+    if (!child) {
+      throw new Error(`${this.name} is not available`);
+    }
+    return child;
+  }
+
+  private spawnChild(): ChildProcessWithoutNullStreams {
+    const helperPath = this.resolveExecutablePath();
+    if (!existsSync(helperPath)) {
+      throw new Error(`executable not found at ${helperPath}`);
+    }
+    return spawn(helperPath, this.spawnArgs, {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+  }
+
+  private attachChild(child: ChildProcessWithoutNullStreams): void {
+    child.stdout.on("data", (chunk: Buffer) => this.handleStdout(chunk));
+    child.stderr.on("data", (chunk: Buffer) => {
+      const line = chunk.toString("utf8").trim();
+      if (line) this.logger.warn(`[${this.name}] ${line}`);
+    });
+  }
+
+  private handleStdout(chunk: Buffer): void {
+    this.stdoutBuffer += chunk.toString("utf8");
+    let newline = this.stdoutBuffer.indexOf("\n");
+    while (newline >= 0) {
+      const line = this.stdoutBuffer.slice(0, newline).trim();
+      this.stdoutBuffer = this.stdoutBuffer.slice(newline + 1);
+      if (line.length > 0) this.handleLine(line);
+      newline = this.stdoutBuffer.indexOf("\n");
+    }
+  }
+
+  private handleLine(line: string): void {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      this.logger.warn(`[${this.name}] ignored invalid JSON: ${line}`);
+      return;
+    }
+
+    const envelope = JSON_RPC_FRAME_SCHEMA.safeParse(parsed);
+    if (!envelope.success) {
+      this.logger.warn(`[${this.name}] ignored invalid envelope: ${line}`);
+      return;
+    }
+
+    const message = envelope.data;
+    if ("method" in message) {
+      this.handleNotification(message);
+      return;
+    }
+
+    if ("error" in message) {
+      const error = new JsonRpcHelperError(message.error);
+      this.rejectPendingCall(message.id, error);
+      this.failPendingStream(message.id, error);
+    } else {
+      this.resolvePendingCall(message.id, message.result);
+      this.finishPendingStream(message.id);
+    }
+  }
+
+  private handleNotification(notification: JsonRpcNotification): void {
+    const subscriptions = this.notificationSubscriptions.get(
+      notification.method,
+    );
+    if (subscriptions) {
+      for (const subscription of subscriptions) {
+        const parsed = subscription.schema.safeParse(notification.params);
+        if (parsed.success) {
+          subscription.listener(parsed.data);
+        } else {
+          this.logger.warn(
+            `[${this.name}] ignored invalid ${notification.method} params`,
+          );
+        }
+      }
+    }
+
+    for (const stream of this.streamSubscriptions) {
+      if (stream.method !== notification.method) continue;
+      if (stream.matches && !stream.matches(notification)) continue;
+      const parsed = stream.schema.safeParse(notification.params);
+      if (parsed.success) {
+        stream.queue.push(parsed.data);
+      } else {
+        stream.queue.fail(
+          new Error(`${this.name} returned invalid ${notification.method}`),
+        );
+      }
+    }
+  }
+
+  private writeFrame(
+    child: ChildProcessWithoutNullStreams,
+    frame: Record<string, unknown>,
+    callback?: (err?: Error | null) => void,
+  ): void {
+    const line = JSON.stringify(frame);
+    if (line.includes("\n") || line.includes("\r")) {
+      throw new Error(`${this.name} frame contained raw newline`);
+    }
+    child.stdin.write(`${line}\n`, callback);
+  }
+
+  private resolvePendingCall(id: JsonRpcId, result: unknown): void {
+    if (id === null) return;
+    const pending = this.pendingCalls.get(String(id));
+    if (!pending) return;
+    clearTimeout(pending.timeout);
+    this.pendingCalls.delete(String(id));
+    pending.resolve(result);
+  }
+
+  private rejectPendingCall(id: JsonRpcId, error: Error): void {
+    if (id === null) return;
+    const pending = this.pendingCalls.get(String(id));
+    if (!pending) return;
+    clearTimeout(pending.timeout);
+    this.pendingCalls.delete(String(id));
+    pending.reject(error);
+  }
+
+  private finishPendingStream(id: JsonRpcId): void {
+    if (id === null) return;
+    const pending = this.pendingStreams.get(String(id));
+    if (!pending) return;
+    clearTimeout(pending.timeout);
+    this.pendingStreams.delete(String(id));
+    pending.queue.end();
+  }
+
+  private failPendingStream(id: JsonRpcId, error: Error): void {
+    if (id === null) return;
+    const pending = this.pendingStreams.get(String(id));
+    if (!pending) return;
+    clearTimeout(pending.timeout);
+    this.pendingStreams.delete(String(id));
+    pending.queue.fail(error);
+  }
+
+  private handleExit(reason: string): void {
+    this.stdoutBuffer = "";
+    this.clearPending(
+      new Error(`${this.name} exited before response (${reason})`),
+    );
+  }
+
+  private clearPending(error: Error): void {
+    for (const pending of this.pendingCalls.values()) {
+      clearTimeout(pending.timeout);
+      pending.reject(error);
+    }
+    this.pendingCalls.clear();
+
+    for (const pending of this.pendingStreams.values()) {
+      clearTimeout(pending.timeout);
+      pending.queue.fail(error);
+    }
+    this.pendingStreams.clear();
+    this.streamSubscriptions.clear();
+  }
+}
+
+class AsyncQueue<T> implements AsyncIterable<T> {
+  private readonly values: T[] = [];
+  private readonly waiters: Array<{
+    resolve: (result: IteratorResult<T>) => void;
+    reject: (err: Error) => void;
+  }> = [];
+  private closed = false;
+  private failure: Error | null = null;
+
+  push(value: T): void {
+    if (this.closed || this.failure) return;
+    const waiter = this.waiters.shift();
+    if (waiter) {
+      waiter.resolve({ value, done: false });
+      return;
+    }
+    this.values.push(value);
+  }
+
+  end(): void {
+    if (this.closed) return;
+    this.closed = true;
+    for (const waiter of this.waiters.splice(0)) {
+      waiter.resolve({ value: undefined as T, done: true });
+    }
+  }
+
+  fail(error: Error): void {
+    if (this.failure) return;
+    this.failure = error;
+    for (const waiter of this.waiters.splice(0)) {
+      waiter.reject(error);
+    }
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<T> {
+    return {
+      next: () => {
+        if (this.failure) return Promise.reject(this.failure);
+        if (this.values.length > 0) {
+          return Promise.resolve({
+            value: this.values.shift() as T,
+            done: false,
+          });
+        }
+        if (this.closed) {
+          return Promise.resolve({ value: undefined as T, done: true });
+        }
+        return new Promise<IteratorResult<T>>((resolve, reject) => {
+          this.waiters.push({ resolve, reject });
+        });
+      },
+    };
+  }
+}

--- a/apps/macos/src/main/sidecar/mac-helper.ts
+++ b/apps/macos/src/main/sidecar/mac-helper.ts
@@ -271,6 +271,7 @@ export class MacHelperClient {
   }
 
   retry(): MacHelperState {
+    this.clearPending(new Error(`${this.name} restarted`));
     return this.supervisor.retry();
   }
 

--- a/apps/macos/src/main/sidecar/supervisor.ts
+++ b/apps/macos/src/main/sidecar/supervisor.ts
@@ -89,7 +89,9 @@ export class SidecarSupervisor {
   }
 
   ensureRunning(): ChildProcessWithoutNullStreams | null {
+    if (this.stopping) return null;
     if (this.child) return this.child;
+    if (this.state.status === "stopped") return null;
     if (this.state.status === "circuit-open") return null;
     if (this.restartTimer) return null;
     return this.startNow();
@@ -101,14 +103,32 @@ export class SidecarSupervisor {
     this.attempt = 0;
     this.stopping = false;
     if (this.child) {
-      this.setState({
-        status: "running",
-        ...(this.child.pid === undefined ? {} : { pid: this.child.pid }),
-      });
-      return this.state;
+      this.replaceChild();
     }
     this.startNow();
     return this.state;
+  }
+
+  private replaceChild(): void {
+    const child = this.child;
+    if (!child) return;
+
+    this.child = null;
+    this.clearStableTimer();
+    try {
+      child.kill("SIGTERM");
+    } catch {
+      // The child may already have exited.
+    }
+
+    const killTimer = setTimeout(() => {
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        // The child may already have exited.
+      }
+    }, DEFAULT_SHUTDOWN_GRACE_MS);
+    killTimer.unref?.();
   }
 
   stop(options?: { graceMs?: number; reason?: string }): void {

--- a/apps/macos/src/main/sidecar/supervisor.ts
+++ b/apps/macos/src/main/sidecar/supervisor.ts
@@ -102,6 +102,9 @@ export class SidecarSupervisor {
     this.crashTimestamps = [];
     this.attempt = 0;
     this.stopping = false;
+    if (this.state.status === "circuit-open") {
+      this.setState({ status: "idle" });
+    }
     if (this.child) {
       this.replaceChild();
     }

--- a/apps/macos/src/main/sidecar/supervisor.ts
+++ b/apps/macos/src/main/sidecar/supervisor.ts
@@ -1,0 +1,306 @@
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+
+export type SidecarState =
+  | { status: "idle" }
+  | { status: "starting"; attempt: number }
+  | { status: "running"; pid?: number }
+  | {
+      status: "backing-off";
+      attempt: number;
+      retryAt: number;
+      reason: string;
+    }
+  | { status: "circuit-open"; reason: string }
+  | { status: "stopped"; reason?: string };
+
+export interface SidecarSupervisorOptions {
+  name: string;
+  spawn: () => ChildProcessWithoutNullStreams;
+  logger: {
+    info: (...args: unknown[]) => void;
+    warn: (...args: unknown[]) => void;
+  };
+  onStart?: (child: ChildProcessWithoutNullStreams) => void;
+  onExit?: (reason: string) => void;
+  initialBackoffMs?: number;
+  maxBackoffMs?: number;
+  stableResetMs?: number;
+  circuitCrashCount?: number;
+  circuitWindowMs?: number;
+}
+
+const DEFAULT_INITIAL_BACKOFF_MS = 1_000;
+const DEFAULT_MAX_BACKOFF_MS = 30_000;
+const DEFAULT_STABLE_RESET_MS = 60_000;
+const DEFAULT_CIRCUIT_CRASH_COUNT = 5;
+const DEFAULT_CIRCUIT_WINDOW_MS = 60_000;
+const DEFAULT_SHUTDOWN_GRACE_MS = 2_000;
+
+export class SidecarSupervisor {
+  private readonly name: string;
+  private readonly spawnChild: () => ChildProcessWithoutNullStreams;
+  private readonly logger: SidecarSupervisorOptions["logger"];
+  private readonly onStart?: (child: ChildProcessWithoutNullStreams) => void;
+  private readonly onExit?: (reason: string) => void;
+  private readonly initialBackoffMs: number;
+  private readonly maxBackoffMs: number;
+  private readonly stableResetMs: number;
+  private readonly circuitCrashCount: number;
+  private readonly circuitWindowMs: number;
+  private readonly listeners = new Set<(state: SidecarState) => void>();
+
+  private child: ChildProcessWithoutNullStreams | null = null;
+  private restartTimer: ReturnType<typeof setTimeout> | null = null;
+  private stableTimer: ReturnType<typeof setTimeout> | null = null;
+  private crashTimestamps: number[] = [];
+  private attempt = 0;
+  private stopping = false;
+  private state: SidecarState = { status: "idle" };
+
+  constructor(options: SidecarSupervisorOptions) {
+    this.name = options.name;
+    this.spawnChild = options.spawn;
+    this.logger = options.logger;
+    this.onStart = options.onStart;
+    this.onExit = options.onExit;
+    this.initialBackoffMs =
+      options.initialBackoffMs ?? DEFAULT_INITIAL_BACKOFF_MS;
+    this.maxBackoffMs = options.maxBackoffMs ?? DEFAULT_MAX_BACKOFF_MS;
+    this.stableResetMs = options.stableResetMs ?? DEFAULT_STABLE_RESET_MS;
+    this.circuitCrashCount =
+      options.circuitCrashCount ?? DEFAULT_CIRCUIT_CRASH_COUNT;
+    this.circuitWindowMs = options.circuitWindowMs ?? DEFAULT_CIRCUIT_WINDOW_MS;
+  }
+
+  getState(): SidecarState {
+    return this.state;
+  }
+
+  currentChild(): ChildProcessWithoutNullStreams | null {
+    return this.child;
+  }
+
+  onState(listener: (state: SidecarState) => void): () => void {
+    this.listeners.add(listener);
+    listener(this.state);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  ensureRunning(): ChildProcessWithoutNullStreams | null {
+    if (this.child) return this.child;
+    if (this.state.status === "circuit-open") return null;
+    if (this.restartTimer) return null;
+    return this.startNow();
+  }
+
+  retry(): SidecarState {
+    this.clearRestartTimer();
+    this.crashTimestamps = [];
+    this.attempt = 0;
+    this.stopping = false;
+    if (this.child) {
+      this.setState({
+        status: "running",
+        ...(this.child.pid === undefined ? {} : { pid: this.child.pid }),
+      });
+      return this.state;
+    }
+    this.startNow();
+    return this.state;
+  }
+
+  stop(options?: { graceMs?: number; reason?: string }): void {
+    this.stopping = true;
+    this.clearRestartTimer();
+    this.clearStableTimer();
+
+    const child = this.child;
+    if (!child) {
+      this.setState({ status: "stopped", reason: options?.reason });
+      return;
+    }
+
+    try {
+      child.kill("SIGTERM");
+    } catch {
+      // The child may already have exited.
+    }
+
+    const killTimer = setTimeout(() => {
+      if (this.child === child) {
+        try {
+          child.kill("SIGKILL");
+        } catch {
+          // The child may already have exited.
+        }
+      }
+    }, options?.graceMs ?? DEFAULT_SHUTDOWN_GRACE_MS);
+    killTimer.unref?.();
+  }
+
+  resetForTesting(): void {
+    this.clearRestartTimer();
+    this.clearStableTimer();
+    this.child = null;
+    this.crashTimestamps = [];
+    this.attempt = 0;
+    this.stopping = false;
+    this.setState({ status: "idle" });
+    this.listeners.clear();
+  }
+
+  private startNow(): ChildProcessWithoutNullStreams | null {
+    if (this.state.status === "circuit-open") return null;
+
+    this.stopping = false;
+    this.setState({ status: "starting", attempt: this.attempt + 1 });
+
+    let child: ChildProcessWithoutNullStreams;
+    try {
+      child = this.spawnChild();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.warn(`[${this.name}] failed to spawn: ${message}`);
+      this.handleUnexpectedExit(`spawn failed: ${message}`);
+      return null;
+    }
+
+    this.child = child;
+    let handledExit = false;
+    const handleExit = (reason: string) => {
+      if (handledExit) return;
+      handledExit = true;
+      if (this.child !== child) return;
+      this.handleChildExit(reason);
+    };
+
+    child.once("error", (err: Error) => {
+      this.logger.warn(`[${this.name}] process error: ${err.message}`);
+      handleExit(err.message);
+    });
+    child.once("close", (code: number | null, signal: NodeJS.Signals | null) => {
+      const suffix =
+        signal !== null
+          ? `signal ${signal}`
+          : code !== null
+            ? `exit ${code}`
+            : "closed";
+      handleExit(suffix);
+    });
+
+    this.onStart?.(child);
+    this.setState({
+      status: "running",
+      ...(child.pid === undefined ? {} : { pid: child.pid }),
+    });
+    this.armStableReset();
+    return child;
+  }
+
+  private handleChildExit(reason: string): void {
+    this.child = null;
+    this.clearStableTimer();
+    this.onExit?.(reason);
+
+    if (this.stopping) {
+      this.setState({ status: "stopped", reason });
+      return;
+    }
+
+    this.handleUnexpectedExit(reason);
+  }
+
+  private handleUnexpectedExit(reason: string): void {
+    const now = Date.now();
+    const windowStart = now - this.circuitWindowMs;
+    this.crashTimestamps = [
+      ...this.crashTimestamps.filter((timestamp) => timestamp >= windowStart),
+      now,
+    ];
+
+    if (this.crashTimestamps.length >= this.circuitCrashCount) {
+      const circuitReason = `${this.name} crashed ${this.crashTimestamps.length} times in ${Math.round(
+        this.circuitWindowMs / 1_000,
+      )}s`;
+      this.logger.warn(`[${this.name}] ${circuitReason}; circuit open`);
+      this.setState({ status: "circuit-open", reason: circuitReason });
+      return;
+    }
+
+    const delay = Math.min(
+      this.initialBackoffMs * 2 ** this.attempt,
+      this.maxBackoffMs,
+    );
+    this.attempt += 1;
+    const retryAt = now + delay;
+    this.logger.warn(
+      `[${this.name}] exited (${reason}); restarting in ${delay}ms`,
+    );
+    this.setState({
+      status: "backing-off",
+      attempt: this.attempt,
+      retryAt,
+      reason,
+    });
+
+    this.restartTimer = setTimeout(() => {
+      this.restartTimer = null;
+      this.startNow();
+    }, delay);
+    this.restartTimer.unref?.();
+  }
+
+  private armStableReset(): void {
+    this.clearStableTimer();
+    this.stableTimer = setTimeout(() => {
+      this.attempt = 0;
+      this.crashTimestamps = [];
+    }, this.stableResetMs);
+    this.stableTimer.unref?.();
+  }
+
+  private clearRestartTimer(): void {
+    if (this.restartTimer) {
+      clearTimeout(this.restartTimer);
+      this.restartTimer = null;
+    }
+  }
+
+  private clearStableTimer(): void {
+    if (this.stableTimer) {
+      clearTimeout(this.stableTimer);
+      this.stableTimer = null;
+    }
+  }
+
+  private setState(state: SidecarState): void {
+    if (sidecarStatesEqual(this.state, state)) return;
+    this.state = state;
+    for (const listener of this.listeners) listener(state);
+  }
+}
+
+const sidecarStatesEqual = (a: SidecarState, b: SidecarState): boolean => {
+  if (a.status !== b.status) return false;
+  switch (a.status) {
+    case "idle":
+      return true;
+    case "starting":
+      return b.status === "starting" && a.attempt === b.attempt;
+    case "running":
+      return b.status === "running" && a.pid === b.pid;
+    case "backing-off":
+      return (
+        b.status === "backing-off" &&
+        a.attempt === b.attempt &&
+        a.retryAt === b.retryAt &&
+        a.reason === b.reason
+      );
+    case "circuit-open":
+      return b.status === "circuit-open" && a.reason === b.reason;
+    case "stopped":
+      return b.status === "stopped" && a.reason === b.reason;
+  }
+};

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -44,9 +44,9 @@ export interface ResolvedHotkey {
   accelerator: string;
 }
 
-// Surface exposed to the renderer as `window.vellum`. `platform`, `hotkeys`,
-// and `commands` are wired through IPC; `auth` and `helper` are typed stubs
-// that reject with "not implemented yet" until their feature tickets land.
+// Surface exposed to the renderer as `window.vellum`. Each privileged
+// capability is routed through a narrow IPC method; the renderer never gets a
+// raw main-process or native-helper RPC passthrough.
 // When adding new bridge methods, see the "When to extend the bridge with
 // new methods" section in `apps/macos/README.md` for the convention
 // (generic KV for non-sensitive prefs; dedicated `<capability>.<verb>()`
@@ -107,6 +107,23 @@ export interface HotkeyEvent {
 export type FnPushToTalkResult =
   | { ok: true; enabled: boolean }
   | { ok: false; reason: string };
+
+export type HelperState =
+  | { status: "idle" }
+  | { status: "starting"; attempt: number }
+  | { status: "running"; pid?: number }
+  | {
+      status: "backing-off";
+      attempt: number;
+      retryAt: number;
+      reason: string;
+    }
+  | { status: "circuit-open"; reason: string }
+  | { status: "stopped"; reason?: string };
+
+export type HelperRestartResult =
+  | { ok: true; state: HelperState }
+  | { ok: false; reason: string; state: HelperState };
 
 /**
  * Mirror of `AssistantStatus` in `apps/macos/src/main/status.ts`. Inlined for
@@ -274,6 +291,9 @@ export interface VellumBridge {
   };
   helper: {
     ping(): Promise<"pong">;
+    getState(): Promise<HelperState>;
+    restart(): Promise<HelperRestartResult>;
+    onState(callback: (state: HelperState) => void): () => void;
     hotkey: {
       /**
        * Enable or disable the native Fn push-to-talk registration.
@@ -596,6 +616,21 @@ const bridge: VellumBridge = {
   helper: {
     ping: () =>
       ipcRenderer.invoke("vellum:helper:ping") as Promise<"pong">,
+    getState: () =>
+      ipcRenderer.invoke("vellum:helper:state:get") as Promise<HelperState>,
+    restart: () =>
+      ipcRenderer.invoke(
+        "vellum:helper:restart",
+      ) as Promise<HelperRestartResult>,
+    onState: (callback) => {
+      const handler = (_event: IpcRendererEvent, payload: HelperState) => {
+        callback(payload);
+      };
+      ipcRenderer.on("vellum:helper:state", handler);
+      return () => {
+        ipcRenderer.off("vellum:helper:state", handler);
+      };
+    },
     hotkey: {
       fnPushToTalk: (enable: boolean): Promise<FnPushToTalkResult> =>
         ipcRenderer.invoke(

--- a/apps/web/src/runtime/is-electron.ts
+++ b/apps/web/src/runtime/is-electron.ts
@@ -116,6 +116,23 @@ export type FnPushToTalkResult =
   | { ok: true; enabled: boolean }
   | { ok: false; reason: string };
 
+export type HelperState =
+  | { status: "idle" }
+  | { status: "starting"; attempt: number }
+  | { status: "running"; pid?: number }
+  | {
+      status: "backing-off";
+      attempt: number;
+      retryAt: number;
+      reason: string;
+    }
+  | { status: "circuit-open"; reason: string }
+  | { status: "stopped"; reason?: string };
+
+export type HelperRestartResult =
+  | { ok: true; state: HelperState }
+  | { ok: false; reason: string; state: HelperState };
+
 /**
  * Renderer-side mirror of `NotificationCategory` in
  * `apps/macos/src/main/notifications.ts`. Each variant maps to a set of
@@ -241,6 +258,10 @@ declare global {
         set(flags: Record<string, boolean>): void;
       };
       helper?: {
+        ping?(): Promise<"pong">;
+        getState?(): Promise<HelperState>;
+        restart?(): Promise<HelperRestartResult>;
+        onState?(callback: (state: HelperState) => void): () => void;
         hotkey?: {
           fnPushToTalk(enable: boolean): Promise<FnPushToTalkResult>;
           onEvent(callback: (event: HotkeyEvent) => void): () => void;


### PR DESCRIPTION
## Summary
- Add a reusable Electron main-process mac helper client for JSON-RPC 2.0 over NDJSON stdio, with request IDs, typed notifications, stream support, supervised restarts, backoff, circuit breaking, and graceful shutdown.
- Refactor the existing Fn push-to-talk helper bridge onto that sidecar client while preserving the narrow renderer API and adding helper state/restart IPC.
- Mirror the new helper state surface through preload/web ambient types and cover ping, crash restart, and PTT re-registration behavior in the existing hotkey-helper tests.

## Original prompt
The request was to implement LUM-1851 using the `$do` workflow. The ticket had been reconciled since it was written, so the implementation needed to avoid stale assumptions: there is no old bundled assistant supervisor to reuse, the helper should use JSON-RPC over line-delimited stdio, helper distribution/signing remains a separate design question, and the sidecar supervisor should be built fresh for native helpers.