### PR TITLE
feat(web): collapse Providers/Profiles/Overrides into Advanced Options

### DIFF
--- a/apps/web/src/domains/settings/ai/language-model-card.tsx
+++ b/apps/web/src/domains/settings/ai/language-model-card.tsx
@@ -141,6 +141,7 @@ export function LanguageModelCard() {
               <Button
                 variant="outlined"
                 size="regular"
+                className="h-9"
                 onClick={() => setManageProfilesOpen(true)}
               >
                 + Create

--- a/apps/web/src/domains/settings/ai/language-model-card.tsx
+++ b/apps/web/src/domains/settings/ai/language-model-card.tsx
@@ -40,6 +40,7 @@ export function LanguageModelCard() {
   const [manageProfilesOpen, setManageProfilesOpen] = useState(false);
   const [overridesOpen, setOverridesOpen] = useState(false);
   const [manageProvidersOpen, setManageProvidersOpen] = useState(false);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
 
   const queryComplexityRoutingEnabled =
     useAssistantFeatureFlagStore.use.queryComplexityRouting();
@@ -138,14 +139,16 @@ export function LanguageModelCard() {
                   }))}
                 />
               </div>
-              <Button
-                variant="outlined"
-                size="regular"
-                className="h-9"
-                onClick={() => setManageProfilesOpen(true)}
-              >
-                + Create
-              </Button>
+              {advancedOpen && (
+                <Button
+                  variant="outlined"
+                  size="regular"
+                  className="h-9"
+                  onClick={() => setManageProfilesOpen(true)}
+                >
+                  + Create
+                </Button>
+              )}
             </div>
             {queryComplexityRoutingEnabled && effectiveActiveProfile === AUTO_PROFILE_NAME && (
               <div className="flex items-center gap-2 rounded-lg bg-[var(--surface-warning-subtle)] px-3 py-2">
@@ -165,7 +168,11 @@ export function LanguageModelCard() {
             ) : null}
           </div>
 
-          <Collapsible.Root type="single" collapsible>
+          <Collapsible.Root
+            type="single"
+            collapsible
+            onValueChange={(val) => setAdvancedOpen(val === "advanced")}
+          >
             <Collapsible.Item value="advanced">
               <Collapsible.Trigger className="group gap-2 rounded-md py-2">
                 <Settings className="h-4 w-4 text-[var(--content-tertiary)]" />
@@ -174,10 +181,10 @@ export function LanguageModelCard() {
                 </span>
                 <ChevronRight className="h-3.5 w-3.5 text-[var(--content-tertiary)] transition-transform duration-200 group-data-[state=open]:rotate-90" />
               </Collapsible.Trigger>
+              <p className="mb-4 text-body-small-default text-[var(--content-disabled)]">
+                Define custom model APIs, create and edit Profiles and manage overrides.
+              </p>
               <Collapsible.Content>
-                <p className="mb-4 text-body-small-default text-[var(--content-disabled)]">
-                  Define custom model APIs, create and edit Profiles and manage overrides.
-                </p>
                 <div className="space-y-1">
                   <AdvancedRow
                     label="Provider Connections"

--- a/apps/web/src/domains/settings/ai/language-model-card.tsx
+++ b/apps/web/src/domains/settings/ai/language-model-card.tsx
@@ -121,20 +121,32 @@ export function LanguageModelCard() {
             <label className="block text-body-small-default text-[var(--content-tertiary)]">
               Default Profile
             </label>
-            <Dropdown
-              value={effectiveActiveProfile ?? ""}
-              onChange={(val) => {
-                setDraftActiveProfile(val === "" ? null : val);
-              }}
-              placeholder="Select a default profile…"
-              options={defaultProfilePickerEntries.map((p) => ({
-                value: p.name,
-                label:
-                  p.name === AUTO_PROFILE_NAME
-                    ? "Automatically switch between profiles"
-                    : profilePickerLabel(p),
-              }))}
-            />
+            <div className="flex items-center gap-2">
+              <div className="min-w-0 flex-1">
+                <Dropdown
+                  value={effectiveActiveProfile ?? ""}
+                  onChange={(val) => {
+                    setDraftActiveProfile(val === "" ? null : val);
+                  }}
+                  placeholder="Select a default profile…"
+                  options={defaultProfilePickerEntries.map((p) => ({
+                    value: p.name,
+                    label:
+                      p.name === AUTO_PROFILE_NAME
+                        ? "Automatically switch between profiles"
+                        : profilePickerLabel(p),
+                  }))}
+                />
+              </div>
+              <Button
+                variant="outlined"
+                size="compact"
+                onClick={() => setManageProfilesOpen(true)}
+              >
+                <Plus className="h-3.5 w-3.5" />
+                Create
+              </Button>
+            </div>
             {queryComplexityRoutingEnabled && effectiveActiveProfile === AUTO_PROFILE_NAME && (
               <div className="flex items-center gap-2 rounded-lg bg-[var(--surface-warning-subtle)] px-3 py-2">
                 <span className="text-body-small-default text-[var(--content-warning)]">

--- a/apps/web/src/domains/settings/ai/language-model-card.tsx
+++ b/apps/web/src/domains/settings/ai/language-model-card.tsx
@@ -24,7 +24,7 @@ import {
 import { filterFlaggedConnections } from "@/domains/settings/ai/provider-connections-client";
 import { useDaemonConfigMutation, useDaemonConfigQuery } from "@/domains/settings/ai/use-daemon-config";
 import { useDraftOverride } from "@/domains/settings/ai/use-draft-override";
-import { inferenceProviderconnectionsGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
+import { configLlmCallsitesGetOptions, inferenceProviderconnectionsGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
 
 export function LanguageModelCard() {
   const {
@@ -45,6 +45,8 @@ export function LanguageModelCard() {
     useAssistantFeatureFlagStore.use.queryComplexityRouting();
   const openAICompatibleEndpoints =
     useAssistantFeatureFlagStore.use.openAICompatibleEndpoints();
+  const analyzeConversationEnabled =
+    useAssistantFeatureFlagStore.use.analyzeConversation();
 
   const defaultProfilePickerEntries = useMemo(
     () =>
@@ -78,10 +80,23 @@ export function LanguageModelCard() {
     (p) => p.source !== "managed" && p.name !== AUTO_PROFILE_NAME,
   ).length;
 
+  // Call-site catalog — fetched for the true total count
+  const { data: catalogData } = useQuery({
+    ...configLlmCallsitesGetOptions({
+      path: { assistant_id: assistantId ?? "" },
+    }),
+    enabled: !!assistantId,
+    staleTime: 60_000,
+  });
+  const totalCallSiteCount = useMemo(() => {
+    const all = (catalogData?.callSites ?? []).filter((cs) => cs.id !== "mainAgent");
+    if (analyzeConversationEnabled) return all.length;
+    return all.filter((cs) => cs.id !== "analyzeConversation").length;
+  }, [catalogData, analyzeConversationEnabled]);
+
   const overrideCount = Object.entries(callSites).filter(
     ([id, s]) => id !== "mainAgent" && (s?.profile != null || s?.provider != null || s?.model != null),
   ).length;
-  const totalCallSiteCount = Object.keys(callSites).filter((id) => id !== "mainAgent").length;
 
   const isProfileDirty = effectiveActiveProfile !== activeProfile;
 

--- a/apps/web/src/domains/settings/ai/language-model-card.tsx
+++ b/apps/web/src/domains/settings/ai/language-model-card.tsx
@@ -140,11 +140,10 @@ export function LanguageModelCard() {
               </div>
               <Button
                 variant="outlined"
-                size="compact"
+                size="regular"
                 onClick={() => setManageProfilesOpen(true)}
               >
-                <Plus className="h-3.5 w-3.5" />
-                Create
+                + Create
               </Button>
             </div>
             {queryComplexityRoutingEnabled && effectiveActiveProfile === AUTO_PROFILE_NAME && (

--- a/apps/web/src/domains/settings/ai/language-model-card.tsx
+++ b/apps/web/src/domains/settings/ai/language-model-card.tsx
@@ -1,9 +1,12 @@
-import { Loader2 } from "lucide-react";
+import { ChevronRight, Loader2, Plus, Settings } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
+
+import { useQuery } from "@tanstack/react-query";
 
 import { captureError } from "@/lib/sentry/capture-error";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { Button } from "@vellumai/design-library/components/button";
+import { Collapsible } from "@vellumai/design-library/components/collapsible";
 import { Dropdown } from "@vellumai/design-library/components/dropdown";
 import { toast } from "@vellumai/design-library/components/toast";
 import { Typography } from "@vellumai/design-library/components/typography";
@@ -18,8 +21,10 @@ import {
     profilePickerLabel,
     visibleProfilesForPicker,
 } from "@/domains/settings/ai/profile-pickers";
+import { filterFlaggedConnections } from "@/domains/settings/ai/provider-connections-client";
 import { useDaemonConfigMutation, useDaemonConfigQuery } from "@/domains/settings/ai/use-daemon-config";
 import { useDraftOverride } from "@/domains/settings/ai/use-draft-override";
+import { inferenceProviderconnectionsGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
 
 export function LanguageModelCard() {
   const {
@@ -32,13 +37,14 @@ export function LanguageModelCard() {
 
   const [effectiveActiveProfile, setDraftActiveProfile] = useDraftOverride(activeProfile);
 
-  // Modal toggles — ephemeral UI state, correct as useState
   const [manageProfilesOpen, setManageProfilesOpen] = useState(false);
   const [overridesOpen, setOverridesOpen] = useState(false);
   const [manageProvidersOpen, setManageProvidersOpen] = useState(false);
 
   const queryComplexityRoutingEnabled =
     useAssistantFeatureFlagStore.use.queryComplexityRouting();
+  const openAICompatibleEndpoints =
+    useAssistantFeatureFlagStore.use.openAICompatibleEndpoints();
 
   const defaultProfilePickerEntries = useMemo(
     () =>
@@ -49,11 +55,34 @@ export function LanguageModelCard() {
     [orderedProfiles, effectiveActiveProfile, queryComplexityRoutingEnabled],
   );
 
+  // Provider connections — fetched inline for counts
+  const { data: connectionsData } = useQuery({
+    ...inferenceProviderconnectionsGetOptions({
+      path: { assistant_id: assistantId ?? "" },
+    }),
+    enabled: !!assistantId,
+    staleTime: 60_000,
+  });
+  const connections = useMemo(
+    () => filterFlaggedConnections(connectionsData?.connections ?? [], openAICompatibleEndpoints),
+    [connectionsData, openAICompatibleEndpoints],
+  );
+
+  const managedConnectionCount = connections.filter((c) => c.isManaged).length;
+  const ownConnectionCount = connections.filter((c) => !c.isManaged).length;
+
+  const managedProfileCount = orderedProfiles.filter(
+    (p) => p.source === "managed" && p.name !== AUTO_PROFILE_NAME,
+  ).length;
+  const ownProfileCount = orderedProfiles.filter(
+    (p) => p.source !== "managed" && p.name !== AUTO_PROFILE_NAME,
+  ).length;
+
   const overrideCount = Object.entries(callSites).filter(
     ([id, s]) => id !== "mainAgent" && (s?.profile != null || s?.provider != null || s?.model != null),
   ).length;
-  const overrideLabel =
-    overrideCount === 1 ? "1 Override" : overrideCount > 0 ? `${overrideCount} Overrides` : "Overrides";
+  const totalCallSiteCount = Object.keys(callSites).filter((id) => id !== "mainAgent").length;
+
   const isProfileDirty = effectiveActiveProfile !== activeProfile;
 
   const handleManagedProfileSave = useCallback(async () => {
@@ -69,8 +98,8 @@ export function LanguageModelCard() {
   return (
     <>
       <ByoServiceCard
-        title="Language Model"
-        subtitle="Configure the LLMs that power your assistant"
+        title="Model Profiles"
+        subtitle="Configure the base LLMs which power your assistants."
       >
         <div className="space-y-4">
           <div className="space-y-1">
@@ -104,34 +133,61 @@ export function LanguageModelCard() {
                 as="p"
                 className="mt-1 text-(--content-tertiary)"
               >
-                No profiles yet. Click Profiles below to create one.
+                No profiles yet. Open Advanced Options to create one.
               </Typography>
             ) : null}
           </div>
 
-          <div className="flex items-center gap-2">
-            <Button
-              variant="outlined"
-              size="compact"
-              onClick={() => setManageProvidersOpen(true)}
-            >
-              Providers
-            </Button>
-            <Button
-              variant="outlined"
-              size="compact"
-              onClick={() => setManageProfilesOpen(true)}
-            >
-              Profiles
-            </Button>
-            <Button
-              variant="outlined"
-              size="compact"
-              onClick={() => setOverridesOpen(true)}
-            >
-              {overrideLabel}
-            </Button>
-          </div>
+          <Collapsible.Root type="single" collapsible>
+            <Collapsible.Item value="advanced">
+              <Collapsible.Trigger className="group gap-2 rounded-md py-2">
+                <Settings className="h-4 w-4 text-[var(--content-tertiary)]" />
+                <span className="text-body-medium-default text-[var(--content-secondary)]">
+                  Advanced Options
+                </span>
+                <ChevronRight className="h-3.5 w-3.5 text-[var(--content-tertiary)] transition-transform duration-200 group-data-[state=open]:rotate-90" />
+              </Collapsible.Trigger>
+              <Collapsible.Content>
+                <p className="mb-4 text-body-small-default text-[var(--content-disabled)]">
+                  Define custom model APIs, create and edit Profiles and manage overrides.
+                </p>
+                <div className="space-y-1">
+                  <AdvancedRow
+                    label="Provider Connections"
+                    description="Configure your own API keys & view Vellum managed options"
+                    counts={
+                      connections.length > 0
+                        ? { managed: managedConnectionCount, own: ownConnectionCount }
+                        : undefined
+                    }
+                    onAdd={() => setManageProvidersOpen(true)}
+                    onManage={() => setManageProvidersOpen(true)}
+                  />
+                  <AdvancedRow
+                    label="Profiles"
+                    description="View and manage assistant usage profiles"
+                    counts={
+                      orderedProfiles.length > 0
+                        ? { managed: managedProfileCount, own: ownProfileCount }
+                        : undefined
+                    }
+                    onAdd={() => setManageProfilesOpen(true)}
+                    onManage={() => setManageProfilesOpen(true)}
+                  />
+                  <AdvancedRow
+                    label="Overrides"
+                    description="Assign specific profiles or provider/model combinations"
+                    overrideSummary={
+                      totalCallSiteCount > 0
+                        ? `${overrideCount}/${totalCallSiteCount} overrides`
+                        : undefined
+                    }
+                    onManage={() => setOverridesOpen(true)}
+                  />
+                </div>
+              </Collapsible.Content>
+            </Collapsible.Item>
+          </Collapsible.Root>
 
           {isProfileDirty && (
             <div className="flex items-center gap-2">
@@ -168,5 +224,74 @@ export function LanguageModelCard() {
         />
       )}
     </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// AdvancedRow — a single row inside the Advanced Options collapsible
+// ---------------------------------------------------------------------------
+
+interface AdvancedRowProps {
+  label: string;
+  description: string;
+  counts?: { managed: number; own: number };
+  overrideSummary?: string;
+  onAdd?: () => void;
+  onManage: () => void;
+}
+
+function AdvancedRow({ label, description, counts, overrideSummary, onAdd, onManage }: AdvancedRowProps) {
+  return (
+    <div className="flex items-center gap-3 rounded-lg px-1 py-2">
+      <div className="min-w-0 flex-1">
+        <div className="text-body-medium-default text-[var(--content-default)]">{label}</div>
+        <div className="text-body-small-default text-[var(--content-tertiary)]">{description}</div>
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        {counts && (
+          <div className="flex items-center gap-1.5 text-body-small-default">
+            {counts.managed > 0 && (
+              <span className="rounded bg-[var(--surface-active)] px-1.5 py-0.5 text-[var(--content-secondary)]">
+                {counts.managed} Managed
+              </span>
+            )}
+            {counts.own > 0 && (
+              <span className="rounded bg-[var(--system-positive-weak)] px-1.5 py-0.5 text-[var(--system-positive-strong)]">
+                {counts.own} Own
+              </span>
+            )}
+          </div>
+        )}
+        {overrideSummary && (
+          <span className="text-body-small-default text-[var(--content-tertiary)]">
+            {overrideSummary}
+          </span>
+        )}
+        {onAdd && (
+          <Button
+            variant="ghost"
+            size="compact"
+            onClick={(e) => {
+              e.stopPropagation();
+              onAdd();
+            }}
+            aria-label={`Add ${label.toLowerCase()}`}
+          >
+            <Plus className="h-3.5 w-3.5" />
+          </Button>
+        )}
+        <Button
+          variant="ghost"
+          size="compact"
+          onClick={(e) => {
+            e.stopPropagation();
+            onManage();
+          }}
+          aria-label={`Manage ${label.toLowerCase()}`}
+        >
+          <ChevronRight className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/domains/settings/ai/manage-profiles-modal.tsx
+++ b/apps/web/src/domains/settings/ai/manage-profiles-modal.tsx
@@ -90,12 +90,14 @@ export function ManageProfilesModal({
     const llmPatch: {
       profiles: Record<string, ProfileEntry>;
       profileOrder?: string[];
+      activeProfile?: string;
     } = { profiles: { [name]: entry } };
     if (isNew) {
       const newOrder = profileOrder.includes(name)
         ? profileOrder
         : [...profileOrder, name];
       llmPatch.profileOrder = newOrder;
+      llmPatch.activeProfile = name;
     }
 
     // For edits: delete the existing profile fragment first so the new entry

--- a/apps/web/src/domains/settings/ai/profile-advanced-params.tsx
+++ b/apps/web/src/domains/settings/ai/profile-advanced-params.tsx
@@ -121,7 +121,7 @@ export function ProfileAdvancedParams({
             <span className="text-body-small-default text-[var(--content-tertiary)]">
               {maxTokens !== null
                 ? formatCompactTokens(maxTokens)
-                : "Default"}
+                : "Inherit"}
             </span>
           </div>
           <div className="flex items-center gap-2">
@@ -161,7 +161,7 @@ export function ProfileAdvancedParams({
             <span className="text-body-small-default text-[var(--content-tertiary)]">
               {contextWindowMaxInputTokens !== null
                 ? formatCompactTokens(contextWindowMaxInputTokens)
-                : "Default"}
+                : "Inherit"}
             </span>
           </div>
           <div className="flex items-center gap-2">

--- a/apps/web/src/domains/settings/ai/profile-editor-modal.test.tsx
+++ b/apps/web/src/domains/settings/ai/profile-editor-modal.test.tsx
@@ -236,17 +236,17 @@ afterEach(() => {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("ProfileEditorModal create mode — provider-first", () => {
-  test("renders Provider before Name/Key in create mode", () => {
+describe("ProfileEditorModal create mode", () => {
+  test("renders Name/Key before Provider in create mode", () => {
     renderCreate([makeConnection("anthropic-personal")]);
 
     const text = document.body.textContent ?? "";
     const providerIdx = text.indexOf("Provider");
     const nameIdx = text.indexOf("Name");
     const keyIdx = text.indexOf("Key");
-    expect(providerIdx).toBeGreaterThanOrEqual(0);
-    expect(nameIdx).toBeGreaterThan(providerIdx);
-    expect(keyIdx).toBeGreaterThan(providerIdx);
+    expect(nameIdx).toBeGreaterThanOrEqual(0);
+    expect(providerIdx).toBeGreaterThan(nameIdx);
+    expect(providerIdx).toBeGreaterThan(keyIdx);
   });
 
   test("Advanced is hidden until a model is chosen, then collapsed by default", () => {
@@ -273,7 +273,7 @@ describe("ProfileEditorModal create mode — provider-first", () => {
     selectProvider("Anthropic");
     selectModel("Claude Opus 4.8");
 
-    expect(getInputByPlaceholder("e.g. Fast & Cheap").value).toBe(
+    expect(getInputByPlaceholder("Name your profile").value).toBe(
       "Claude Opus 4.8",
     );
     expect(getInputByPlaceholder("e.g. fast-cheap").value).toBe(
@@ -288,14 +288,14 @@ describe("ProfileEditorModal create mode — provider-first", () => {
     selectModel("Claude Opus 4.8");
 
     // User overrides the Name.
-    fireEvent.change(getInputByPlaceholder("e.g. Fast & Cheap"), {
+    fireEvent.change(getInputByPlaceholder("Name your profile"), {
       target: { value: "My Custom Profile" },
     });
 
     // Selecting a different model must NOT clobber the manual Name/Key.
     selectModel("Claude Opus 4.7");
 
-    expect(getInputByPlaceholder("e.g. Fast & Cheap").value).toBe(
+    expect(getInputByPlaceholder("Name your profile").value).toBe(
       "My Custom Profile",
     );
     expect(getInputByPlaceholder("e.g. fast-cheap").value).toBe(
@@ -317,12 +317,17 @@ describe("ProfileEditorModal create mode — provider-first", () => {
 
     selectProvider("+ New Connection");
 
-    // Inline ProviderCreateForm is mounted (its Key field placeholder).
+    // Inline ProviderCreateForm is mounted — starts with no provider selected.
+    // Select Anthropic in the inline form's Provider dropdown.
+    const inlineProviderTrigger = document.querySelector<HTMLButtonElement>(
+      'button[role="combobox"][aria-label="Provider"]',
+    );
+    expect(inlineProviderTrigger).toBeDefined();
+    pickOption(inlineProviderTrigger!, "Anthropic");
+
+    // Now the key field is seeded from the provider type.
     const inlineKey = getInputByPlaceholder("e.g. anthropic-personal");
     expect(inlineKey).toBeDefined();
-
-    // Fill the inline form and create (anthropic defaults to platform auth,
-    // so no API key entry is required).
     fireEvent.change(inlineKey, { target: { value: "anthropic-personal" } });
     fireEvent.click(getButton("Create"));
 
@@ -346,9 +351,6 @@ describe("ProfileEditorModal create mode — provider-first", () => {
   });
 
   test("inline-create then immediate save persists the new provider_connection (no race)", async () => {
-    // Regression: before the optimistic local-connection merge, saving in the
-    // window between inline create and the parent connections refetch left
-    // `connectionNotFound` true, so the save handler dropped the binding to "".
     createdConnection = makeConnection("anthropic-personal");
 
     const saveCalls: { name: string; entry: Record<string, unknown> }[] = [];
@@ -357,12 +359,16 @@ describe("ProfileEditorModal create mode — provider-first", () => {
       return Promise.resolve();
     };
 
-    // Start with zero connections so the only Provider option is "+ Create
-    // new provider" and the parent prop never refetches in this test (the
-    // binding must be valid purely from the optimistic local merge).
     renderCreate([], onSave);
 
     selectProvider("+ New Connection");
+
+    // Select Anthropic in the inline form's Provider dropdown.
+    const inlineProviderTrigger = document.querySelector<HTMLButtonElement>(
+      'button[role="combobox"][aria-label="Provider"]',
+    );
+    pickOption(inlineProviderTrigger!, "Anthropic");
+
     fireEvent.change(getInputByPlaceholder("e.g. anthropic-personal"), {
       target: { value: "anthropic-personal" },
     });

--- a/apps/web/src/domains/settings/ai/profile-editor-modal.test.tsx
+++ b/apps/web/src/domains/settings/ai/profile-editor-modal.test.tsx
@@ -12,7 +12,7 @@
  *  - field order is provider-first (Provider before Name/Key/Description),
  *  - selecting a model pre-fills Name + Key from the model display name,
  *  - editing Name then selecting another model does NOT clobber Name/Key,
- *  - "+ Create new provider" mounts the inline ProviderCreateForm, and a
+ *  - "+ New Connection" mounts the inline ProviderCreateForm, and a
  *    successful create selects that provider + enables Save once a model is
  *    chosen.
  */
@@ -309,13 +309,13 @@ describe("ProfileEditorModal create mode — provider-first", () => {
     const optionLabels = Array.from(
       document.querySelectorAll<HTMLElement>('[role="option"]'),
     ).map((o) => o.textContent?.trim());
-    expect(optionLabels).toEqual(["+ Create new provider"]);
+    expect(optionLabels).toEqual(["+ New Connection"]);
   });
 
-  test("+ Create new provider mounts ProviderCreateForm; successful create selects it and Save enables after a model", async () => {
+  test("+ New Connection mounts ProviderCreateForm; successful create selects it and Save enables after a model", async () => {
     renderCreate([]);
 
-    selectProvider("+ Create new provider");
+    selectProvider("+ New Connection");
 
     // Inline ProviderCreateForm is mounted (its Key field placeholder).
     const inlineKey = getInputByPlaceholder("e.g. anthropic-personal");
@@ -362,7 +362,7 @@ describe("ProfileEditorModal create mode — provider-first", () => {
     // binding must be valid purely from the optimistic local merge).
     renderCreate([], onSave);
 
-    selectProvider("+ Create new provider");
+    selectProvider("+ New Connection");
     fireEvent.change(getInputByPlaceholder("e.g. anthropic-personal"), {
       target: { value: "anthropic-personal" },
     });

--- a/apps/web/src/domains/settings/ai/profile-editor-modal.test.tsx
+++ b/apps/web/src/domains/settings/ai/profile-editor-modal.test.tsx
@@ -249,22 +249,17 @@ describe("ProfileEditorModal create mode", () => {
     expect(providerIdx).toBeGreaterThan(keyIdx);
   });
 
-  test("Advanced is hidden until a model is chosen, then collapsed by default", () => {
+  test("advanced params are hidden until a model is chosen, then shown inline", () => {
     renderCreate([makeConnection("anthropic-personal")]);
 
-    // No model selected yet → the Advanced disclosure is not rendered.
-    const hasAdvancedButton = () =>
-      Array.from(document.querySelectorAll("button")).some(
-        (b) => b.textContent?.trim() === "Advanced",
-      );
-    expect(hasAdvancedButton()).toBe(false);
+    // No model selected yet → advanced params not rendered.
+    expect(document.body.textContent).not.toContain("Max Output Tokens");
 
     selectProvider("Anthropic");
     selectModel("Claude Opus 4.8");
 
-    // Once a model is chosen the disclosure appears, collapsed.
-    expect(hasAdvancedButton()).toBe(true);
-    expect(getButton("Advanced").getAttribute("aria-expanded")).toBe("false");
+    // Once a model is chosen the params appear inline (no disclosure).
+    expect(document.body.textContent).toContain("Max Output Tokens");
   });
 
   test("selecting a model pre-fills Name and Key", () => {

--- a/apps/web/src/domains/settings/ai/profile-editor-modal.test.tsx
+++ b/apps/web/src/domains/settings/ai/profile-editor-modal.test.tsx
@@ -422,7 +422,7 @@ describe("ProfileEditorModal create mode", () => {
 
     resolveSave();
     await waitFor(() => {
-      expect(getSaveBtn().textContent?.trim()).toBe("Save");
+      expect(getSaveBtn().textContent?.trim()).toBe("Create");
     });
   });
 

--- a/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -27,7 +27,7 @@ import type { ConnectionProvider, ProviderConnection } from "@/domains/settings/
 import { ProviderCreateForm } from "@/domains/settings/ai/provider-create-form";
 import { useLabelKeySync } from "@/domains/settings/ai/use-label-key-sync";
 
-// Sentinel value for the "+ Create new provider" option in the create-mode
+// Sentinel value for the "+ New Connection" option in the create-mode
 // Provider dropdown. Picking it mounts the inline ProviderCreateForm instead
 // of selecting a provider.
 const CREATE_NEW_PROVIDER_SENTINEL = "__create_new_provider__";
@@ -56,7 +56,7 @@ export interface ProfileEditorModalProps {
   connections?: ProviderConnection[];
   openAICompatibleEndpointsEnabled?: boolean;
   /**
-   * Assistant whose provider connections the inline "+ Create new provider"
+   * Assistant whose provider connections the inline "+ New Connection"
    * sub-form writes to. Required for the create-mode quick-add flow.
    */
   assistantId: string;
@@ -293,7 +293,7 @@ function ProfileEditorModalInner({
 
   const queryClient = useQueryClient();
 
-  // Create-mode-only UI: whether the inline "+ Create new provider" sub-form
+  // Create-mode-only UI: whether the inline "+ New Connection" sub-form
   // is mounted, and whether the advanced-params disclosure is expanded.
   const [creatingProvider, setCreatingProvider] = useState(false);
   const [advancedExpanded, setAdvancedExpanded] = useState(false);
@@ -692,9 +692,9 @@ function ProfileEditorModalInner({
         });
       }
     }
-    opts.push({
+    opts.unshift({
       value: CREATE_NEW_PROVIDER_SENTINEL,
-      label: "+ Create new provider",
+      label: "+ New Connection",
     });
     return opts;
   }, [effectiveConnections, openAICompatibleEndpointsEnabled]);

--- a/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -673,11 +673,10 @@ function ProfileEditorModalInner({
   // new provider" sentinel. First-run empty state shows ONLY the sentinel.
   const createModeProviderOptions = useMemo(() => {
     const seen = new Set<string>();
-    const opts: { value: string; label: string; separated?: boolean | "above" | "below" }[] = [
+    const opts: { value: string; label: string }[] = [
       {
         value: CREATE_NEW_PROVIDER_SENTINEL,
         label: "+ New Connection",
-        separated: "below",
       },
     ];
     for (const c of effectiveConnections) {

--- a/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -558,23 +558,20 @@ function ProfileEditorModalInner({
         ? "Edit Profile"
         : (initialValues?.label ?? profileName ?? "Profile");
 
-  // Create mode uses the provider-first layout (Provider -> Model -> Name ->
-  // Key -> Description -> collapsed Advanced) with pre-fill. Edit and view
-  // modes use the legacy layout below.
-  const useProviderFirst = effectiveMode === "create";
+  const isCreateMode = effectiveMode === "create";
 
   // ---- Reusable field nodes (shared by create + edit/view bodies) ----
 
   const displayNameField = (
     <div className="space-y-1">
       <label className="block text-body-small-default text-[var(--content-tertiary)]">
-        {useProviderFirst ? "Name" : "Display Name"}
+        {isCreateMode ? "Name" : "Display Name"}
       </label>
       <Input
         type="text"
         value={label}
         onChange={(e) => handleLabelChange(e.target.value)}
-        placeholder="e.g. Fast & Cheap"
+        placeholder={isCreateMode ? "Name your profile" : "e.g. Fast & Cheap"}
         fullWidth
       />
     </div>
@@ -727,18 +724,21 @@ function ProfileEditorModalInner({
             setCreatingProvider(false);
             handleProviderChange(next);
           }}
-          placeholder="Select a provider…"
+          placeholder="Select a Provider"
           aria-labelledby="profile-editor-provider-label"
           options={createModeProviderOptions}
         />
         {newProviderNote ? (
-          <Typography
-            variant="body-small-default"
-            as="p"
-            className="text-[var(--content-tertiary)]"
-          >
-            New provider connection will show up in the Providers section.
-          </Typography>
+          <div className="flex items-center gap-2">
+            <Tag tone="positive">Own</Tag>
+            <Typography
+              variant="body-small-default"
+              as="span"
+              className="text-[var(--content-tertiary)]"
+            >
+              New provider connection will show up in the Providers section.
+            </Typography>
+          </div>
         ) : null}
       </div>
 
@@ -811,9 +811,7 @@ function ProfileEditorModalInner({
       </Modal.Header>
 
       <Modal.Body>
-        {useProviderFirst ? (
-          // Create mode is provider-first: Provider (with inline create) ->
-          // Model -> Name -> Key -> Description -> collapsed Advanced.
+        {isCreateMode ? (
           <div className="space-y-4">
             {isAutoProfile && (
               <div className="rounded-lg bg-[var(--surface-info-subtle)] p-3">
@@ -825,13 +823,12 @@ function ProfileEditorModalInner({
               </div>
             )}
 
+            {displayNameField}
+            {descriptionField}
+            {keyField}
+
             {/* Provider + Connection + Model — hidden for the auto profile. */}
             {!isAutoProfile && createProviderSection}
-
-            {displayNameField}
-            {keyField}
-            {descriptionField}
-            {activeToggle}
 
             {/* Advanced params — collapsed by default in create mode. */}
             {createAdvancedDisclosure}

--- a/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -8,7 +8,6 @@ import { Modal } from "@vellumai/design-library/components/modal";
 import { Tag } from "@vellumai/design-library/components/tag";
 import { Toggle } from "@vellumai/design-library/components/toggle";
 import { Typography } from "@vellumai/design-library/components/typography";
-import { ChevronRight } from "lucide-react";
 
 import { getModelsForProvider } from "@/assistant/llm-model-catalog";
 import { inferenceProviderconnectionsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
@@ -294,9 +293,8 @@ function ProfileEditorModalInner({
   const queryClient = useQueryClient();
 
   // Create-mode-only UI: whether the inline "+ New Connection" sub-form
-  // is mounted, and whether the advanced-params disclosure is expanded.
+  // is mounted.
   const [creatingProvider, setCreatingProvider] = useState(false);
-  const [advancedExpanded, setAdvancedExpanded] = useState(false);
   // One-time helper note shown after an inline provider create succeeds.
   const [newProviderNote, setNewProviderNote] = useState(false);
 
@@ -304,7 +302,6 @@ function ProfileEditorModalInner({
   useEffect(() => {
     resetDirty();
     setCreatingProvider(false);
-    setAdvancedExpanded(false);
     setNewProviderNote(false);
     setLocallyCreatedConnections([]);
   }, [profileName, mode, resetDirty]);
@@ -673,10 +670,11 @@ function ProfileEditorModalInner({
   // new provider" sentinel. First-run empty state shows ONLY the sentinel.
   const createModeProviderOptions = useMemo(() => {
     const seen = new Set<string>();
-    const opts: { value: string; label: string }[] = [
+    const opts: { value: string; label: string; separated?: boolean | "above" | "below" }[] = [
       {
         value: CREATE_NEW_PROVIDER_SENTINEL,
         label: "+ New Connection",
+        separated: "below",
       },
     ];
     for (const c of effectiveConnections) {
@@ -785,28 +783,11 @@ function ProfileEditorModalInner({
     </div>
   );
 
-  // Only surface Advanced once a model is chosen — the advanced params are
-  // model-dependent (effort/thinking/token ranges resolve from the selected
-  // model), so showing the disclosure before then is meaningless.
-  const createAdvancedDisclosure =
-    !isAutoProfile && model !== "" && advancedParamsNode ? (
-      <div>
-        <button
-          type="button"
-          aria-expanded={advancedExpanded}
-          onClick={() => setAdvancedExpanded((v) => !v)}
-          className="flex items-center gap-1 text-body-small-default text-[var(--content-secondary)] w-full text-left"
-        >
-          <ChevronRight
-            className={`h-4 w-4 transition-transform ${advancedExpanded ? "rotate-90" : ""}`}
-          />
-          <span>Advanced</span>
-        </button>
-        {advancedExpanded ? (
-          <div className="mt-4">{advancedParamsNode}</div>
-        ) : null}
-      </div>
-    ) : null;
+  // Show advanced params inline once a model is chosen (they're
+  // model-dependent — effort/thinking/token ranges resolve from the
+  // selected model).
+  const createAdvancedParams =
+    !isAutoProfile && model !== "" ? advancedParamsNode : null;
 
   return (
     <Modal.Content size="md">
@@ -841,8 +822,8 @@ function ProfileEditorModalInner({
             {/* Provider + Connection + Model — hidden for the auto profile. */}
             {!isAutoProfile && createProviderSection}
 
-            {/* Advanced params — collapsed by default in create mode. */}
-            {createAdvancedDisclosure}
+            {/* Advanced params — shown inline once a model is selected. */}
+            {createAdvancedParams}
 
             {saveErrorNode}
           </div>

--- a/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -673,7 +673,13 @@ function ProfileEditorModalInner({
   // new provider" sentinel. First-run empty state shows ONLY the sentinel.
   const createModeProviderOptions = useMemo(() => {
     const seen = new Set<string>();
-    const opts: { value: string; label: string; separated?: boolean | "above" | "below" }[] = [];
+    const opts: { value: string; label: string; separated?: boolean | "above" | "below" }[] = [
+      {
+        value: CREATE_NEW_PROVIDER_SENTINEL,
+        label: "+ New Connection",
+        separated: "below",
+      },
+    ];
     for (const c of effectiveConnections) {
       if (
         !openAICompatibleEndpointsEnabled &&
@@ -689,72 +695,78 @@ function ProfileEditorModalInner({
         });
       }
     }
-    opts.push({
-      value: CREATE_NEW_PROVIDER_SENTINEL,
-      label: "+ New Connection",
-      separated: "above",
-    });
     return opts;
   }, [effectiveConnections, openAICompatibleEndpointsEnabled]);
 
   const createProviderSection = (
     <div className="space-y-4">
-      <div className="space-y-1">
-        <div className="flex items-center justify-between gap-2">
-          <label
-            id="profile-editor-provider-label"
-            className="block text-body-small-default text-[var(--content-tertiary)]"
-          >
-            Provider
-          </label>
-          {providerMissing && !creatingProvider ? (
-            <span className="rounded-full bg-[var(--surface-warning-subtle)] px-2 py-0.5 text-body-small-default text-[var(--content-warning)]">
-              Pick a provider
-            </span>
+      {!creatingProvider && (
+        <div className="space-y-1">
+          <div className="flex items-center justify-between gap-2">
+            <label
+              id="profile-editor-provider-label"
+              className="block text-body-small-default text-[var(--content-tertiary)]"
+            >
+              Provider
+            </label>
+            {providerMissing ? (
+              <span className="rounded-full bg-[var(--surface-warning-subtle)] px-2 py-0.5 text-body-small-default text-[var(--content-warning)]">
+                Pick a provider
+              </span>
+            ) : null}
+          </div>
+          <Dropdown
+            value={provider}
+            onChange={(next) => {
+              if (next === CREATE_NEW_PROVIDER_SENTINEL) {
+                setCreatingProvider(true);
+                setNewProviderNote(false);
+                return;
+              }
+              handleProviderChange(next);
+            }}
+            placeholder="Select a Provider"
+            aria-labelledby="profile-editor-provider-label"
+            options={createModeProviderOptions}
+          />
+          {newProviderNote ? (
+            <div className="flex items-center gap-2">
+              <Tag tone="positive">Own</Tag>
+              <Typography
+                variant="body-small-default"
+                as="span"
+                className="text-[var(--content-tertiary)]"
+              >
+                New provider connection will show up in the Providers section.
+              </Typography>
+            </div>
           ) : null}
         </div>
-        <Dropdown
-          value={creatingProvider ? CREATE_NEW_PROVIDER_SENTINEL : provider}
-          onChange={(next) => {
-            if (next === CREATE_NEW_PROVIDER_SENTINEL) {
-              setCreatingProvider(true);
-              setNewProviderNote(false);
-              return;
-            }
-            setCreatingProvider(false);
-            handleProviderChange(next);
-          }}
-          placeholder="Select a Provider"
-          aria-labelledby="profile-editor-provider-label"
-          options={createModeProviderOptions}
-        />
-        {newProviderNote ? (
-          <div className="flex items-center gap-2">
-            <Tag tone="positive">Own</Tag>
-            <Typography
-              variant="body-small-default"
-              as="span"
-              className="text-[var(--content-tertiary)]"
-            >
+      )}
+
+      {creatingProvider ? (
+        <div className="rounded-lg border border-[var(--border-active)] p-4">
+          <div className="mb-4">
+            <Typography variant="body-medium-default" as="p" className="text-[var(--content-default)]">
+              Create New Provider
+            </Typography>
+            <Typography variant="body-small-default" as="p" className="text-[var(--content-tertiary)]">
               New provider connection will show up in the Providers section.
             </Typography>
           </div>
-        ) : null}
-      </div>
-
-      {creatingProvider ? (
-        <ProviderCreateForm
-          variant="inline"
-          assistantId={assistantId}
-          existingNames={effectiveConnections.map((c) => c.name)}
-          openAICompatibleEndpointsEnabled={openAICompatibleEndpointsEnabled}
-          chatgptSubscriptionEnabled={chatgptSubscriptionEnabled}
-          defaultProviderType={
-            (provider || undefined) as ConnectionProvider | undefined
-          }
-          onCreated={handleProviderCreated}
-          onCancel={() => setCreatingProvider(false)}
-        />
+          <ProviderCreateForm
+            variant="inline"
+            assistantId={assistantId}
+            existingNames={effectiveConnections.map((c) => c.name)}
+            openAICompatibleEndpointsEnabled={openAICompatibleEndpointsEnabled}
+            chatgptSubscriptionEnabled={chatgptSubscriptionEnabled}
+            defaultProviderType={
+              (provider || undefined) as ConnectionProvider | undefined
+            }
+            onCreated={handleProviderCreated}
+            onCancel={() => setCreatingProvider(false)}
+          />
+        </div>
       ) : (
         <ProfileEditorProviderSection
           provider={provider}

--- a/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -676,7 +676,7 @@ function ProfileEditorModalInner({
   // new provider" sentinel. First-run empty state shows ONLY the sentinel.
   const createModeProviderOptions = useMemo(() => {
     const seen = new Set<string>();
-    const opts: { value: string; label: string }[] = [];
+    const opts: { value: string; label: string; separated?: boolean }[] = [];
     for (const c of effectiveConnections) {
       if (
         !openAICompatibleEndpointsEnabled &&
@@ -695,6 +695,7 @@ function ProfileEditorModalInner({
     opts.unshift({
       value: CREATE_NEW_PROVIDER_SENTINEL,
       label: "+ New Connection",
+      separated: true,
     });
     return opts;
   }, [effectiveConnections, openAICompatibleEndpointsEnabled]);

--- a/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -744,7 +744,7 @@ function ProfileEditorModalInner({
       )}
 
       {creatingProvider ? (
-        <div className="rounded-lg border border-[var(--border-active)] p-4">
+        <div className="rounded-xl border border-[var(--border-base)] p-4">
           <div className="mb-4">
             <Typography variant="body-medium-default" as="p" className="text-[var(--content-default)]">
               Create New Provider

--- a/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -582,7 +582,7 @@ function ProfileEditorModalInner({
       label={
         <>
           Description{" "}
-          <span className="text-[var(--content-disabled)]">(optional)</span>
+          <span className="text-[var(--content-disabled)]">(Optional)</span>
         </>
       }
       value={description}
@@ -936,7 +936,7 @@ function ProfileEditorModalInner({
               disabled={isInvalid || saving}
               data-testid="modal-save-btn"
             >
-              {saving ? "Saving…" : "Save"}
+              {saving ? "Saving…" : isCreateMode ? "Create" : "Save"}
             </Button>
           </>
         )}

--- a/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -676,7 +676,7 @@ function ProfileEditorModalInner({
   // new provider" sentinel. First-run empty state shows ONLY the sentinel.
   const createModeProviderOptions = useMemo(() => {
     const seen = new Set<string>();
-    const opts: { value: string; label: string; separated?: boolean }[] = [];
+    const opts: { value: string; label: string; separated?: boolean | "above" | "below" }[] = [];
     for (const c of effectiveConnections) {
       if (
         !openAICompatibleEndpointsEnabled &&
@@ -692,10 +692,10 @@ function ProfileEditorModalInner({
         });
       }
     }
-    opts.unshift({
+    opts.push({
       value: CREATE_NEW_PROVIDER_SENTINEL,
       label: "+ New Connection",
-      separated: true,
+      separated: "above",
     });
     return opts;
   }, [effectiveConnections, openAICompatibleEndpointsEnabled]);

--- a/apps/web/src/domains/settings/ai/provider-create-form.test.tsx
+++ b/apps/web/src/domains/settings/ai/provider-create-form.test.tsx
@@ -227,7 +227,7 @@ describe("ProviderCreateForm submit sequence", () => {
     });
 
     // Select API Key auth so the API Key field renders.
-    selectDropdownOption("Auth type", "API Key");
+    selectDropdownOption("Authentication Type", "API Key");
 
     fireEvent.change(getInputByPlaceholder("Enter your API key"), {
       target: { value: "sk-test-123" },
@@ -311,7 +311,7 @@ describe("ProviderCreateForm submit sequence", () => {
       target: { value: "anthropic-personal" },
     });
 
-    selectDropdownOption("Auth type", "API Key");
+    selectDropdownOption("Authentication Type", "API Key");
     fireEvent.change(getInputByPlaceholder("Enter your API key"), {
       target: { value: "sk-test-123" },
     });
@@ -381,7 +381,7 @@ describe("ProviderCreateForm submit sequence", () => {
     fireEvent.change(getInputByPlaceholder("e.g. anthropic-personal"), {
       target: { value: "anthropic-personal" },
     });
-    selectDropdownOption("Auth type", "API Key");
+    selectDropdownOption("Authentication Type", "API Key");
     fireEvent.change(getInputByPlaceholder("Enter your API key"), {
       target: { value: "sk-test-123" },
     });
@@ -412,7 +412,7 @@ describe("ProviderCreateForm submit sequence", () => {
     fireEvent.change(getInputByPlaceholder("e.g. anthropic-personal"), {
       target: { value: "anthropic-personal" },
     });
-    selectDropdownOption("Auth type", "API Key");
+    selectDropdownOption("Authentication Type", "API Key");
     fireEvent.change(getInputByPlaceholder("Enter your API key"), {
       target: { value: "sk-test-123" },
     });

--- a/apps/web/src/domains/settings/ai/provider-create-form.test.tsx
+++ b/apps/web/src/domains/settings/ai/provider-create-form.test.tsx
@@ -211,6 +211,7 @@ describe("ProviderCreateForm submit sequence", () => {
         <ProviderCreateForm
           assistantId={ASSISTANT_ID}
           existingNames={[]}
+          defaultProviderType="anthropic"
           onCreated={(c) => {
             created = c;
           }}
@@ -269,6 +270,7 @@ describe("ProviderCreateForm submit sequence", () => {
         <ProviderCreateForm
           assistantId={ASSISTANT_ID}
           existingNames={["anthropic-personal"]}
+          defaultProviderType="anthropic"
           onCreated={() => {}}
           onCancel={() => {}}
         />
@@ -293,6 +295,7 @@ describe("ProviderCreateForm submit sequence", () => {
           variant="inline"
           assistantId={ASSISTANT_ID}
           existingNames={[]}
+          defaultProviderType="anthropic"
           onCreated={(c) => {
             created = c;
           }}
@@ -368,6 +371,7 @@ describe("ProviderCreateForm submit sequence", () => {
         <ProviderCreateForm
           assistantId={ASSISTANT_ID}
           existingNames={[]}
+          defaultProviderType="anthropic"
           onCreated={() => {}}
           onCancel={() => {}}
         />
@@ -398,6 +402,7 @@ describe("ProviderCreateForm submit sequence", () => {
         <ProviderCreateForm
           assistantId={ASSISTANT_ID}
           existingNames={[]}
+          defaultProviderType="anthropic"
           onCreated={() => {}}
           onCancel={() => {}}
         />

--- a/apps/web/src/domains/settings/ai/provider-create-form.tsx
+++ b/apps/web/src/domains/settings/ai/provider-create-form.tsx
@@ -276,11 +276,11 @@ export function ProviderCreateForm({
 
   const body = (
     <div className="space-y-4">
-      {/* Display Name */}
+      {/* Name */}
       <div className="space-y-1">
         <label className="block text-body-small-default text-[var(--content-tertiary)]">
-          Display Name{" "}
-          <span className="text-[var(--content-disabled)]">(optional)</span>
+          Name{" "}
+          <span className="text-[var(--content-disabled)]">(Optional)</span>
         </label>
         <Input
           value={label}
@@ -404,14 +404,14 @@ export function ProviderCreateForm({
         </>
       )}
 
-      {/* Auth type — hidden until a provider is selected */}
+      {/* Authentication Type — hidden until a provider is selected */}
       {provider !== "" && (
         <div className="space-y-1">
           <label className="block text-body-small-default text-[var(--content-tertiary)]">
-            Auth Type
+            Authentication Type
           </label>
           <Dropdown
-            aria-label="Auth type"
+            aria-label="Authentication Type"
             value={authType}
             onChange={(v) => {
               setAuthType(v as AuthType);

--- a/apps/web/src/domains/settings/ai/provider-create-form.tsx
+++ b/apps/web/src/domains/settings/ai/provider-create-form.tsx
@@ -499,7 +499,19 @@ export function ProviderCreateForm({
     return (
       <div className="space-y-4">
         {body}
-        <div className="flex justify-end gap-2">{footer}</div>
+        <div className="flex gap-2">
+          <Button
+            variant="primary"
+            size="compact"
+            disabled={!canSave || saving || isSavingKey}
+            onClick={() => void handleSave()}
+          >
+            {saving ? "Saving…" : "Create"}
+          </Button>
+          <Button variant="ghost" size="compact" onClick={onCancel}>
+            Cancel
+          </Button>
+        </div>
       </div>
     );
   }

--- a/apps/web/src/domains/settings/ai/provider-create-form.tsx
+++ b/apps/web/src/domains/settings/ai/provider-create-form.tsx
@@ -81,29 +81,26 @@ export function ProviderCreateForm({
   onCancel,
   variant = "modal",
 }: ProviderCreateFormProps) {
-  const initialProvider: ConnectionProvider = defaultProviderType ?? "anthropic";
+  const initialProvider: ConnectionProvider | "" = defaultProviderType ?? "";
 
-  // Seed Display Name (label) + Key (name) from the initial provider type so
-  // the form opens pre-filled (e.g. Anthropic → "Anthropic" / "anthropic"),
-  // deduped against existing connection names. The user can override both, and
-  // a provider-type change re-seeds only while they haven't edited the fields
-  // (see the dirty guard in the Provider dropdown's onChange below).
-  const initialDefaults = deriveProviderDefaults(initialProvider, existingNames);
+  const initialDefaults = initialProvider
+    ? deriveProviderDefaults(initialProvider, existingNames)
+    : { name: "", key: "" };
 
   const [label, setLabel] = useState(initialDefaults.name);
   const [name, setName] = useState(initialDefaults.key);
-  const [provider, setProvider] = useState<ConnectionProvider>(initialProvider);
+  const [provider, setProvider] = useState<ConnectionProvider | "">(initialProvider);
   const [authType, setAuthType] = useState<AuthType>(
     () =>
       defaultAuthType ??
       (initialProvider === "ollama"
         ? "none"
-        : providerSupportsPlatformAuth(initialProvider)
+        : initialProvider && providerSupportsPlatformAuth(initialProvider)
           ? "platform"
           : "api_key"),
   );
   const [credential, setCredential] = useState(() =>
-    initialProvider === "ollama" ? "" : `credential/${initialProvider}/api_key`,
+    !initialProvider || initialProvider === "ollama" ? "" : `credential/${initialProvider}/api_key`,
   );
   const [baseUrl, setBaseUrl] = useState("");
   const [connectionModels, setConnectionModels] = useState("");
@@ -115,8 +112,8 @@ export function ProviderCreateForm({
     const options = openAICompatibleEndpointsEnabled
       ? CONNECTION_PROVIDERS
       : CONNECTION_PROVIDERS.filter((p) => p !== "openai-compatible");
-    if (provider && !options.includes(provider)) {
-      return [...options, provider];
+    if (provider && !options.includes(provider as ConnectionProvider)) {
+      return [...options, provider as ConnectionProvider];
     }
     return options;
   }, [openAICompatibleEndpointsEnabled, provider]);
@@ -161,7 +158,7 @@ export function ProviderCreateForm({
     return null;
   })();
 
-  const canSave = name.trim().length > 0 && !nameError;
+  const canSave = name.trim().length > 0 && !nameError && provider !== "";
 
   async function handleSave() {
     if (!canSave) return;
@@ -225,7 +222,7 @@ export function ProviderCreateForm({
 
       const input: CreateConnectionInput = {
         name: name.trim(),
-        provider,
+        provider: provider as ConnectionProvider,
         auth,
         ...(labelValue !== null && { label: labelValue }),
         ...(isOpenAICompatible && {
@@ -326,13 +323,10 @@ export function ProviderCreateForm({
         <Dropdown
           aria-label="Provider"
           value={provider}
+          placeholder="Select a Provider"
           onChange={(v) => {
             const newProvider = v as ConnectionProvider;
             setProvider(newProvider);
-            // Re-seed Name + Key from the newly selected provider type, but
-            // only while the user hasn't manually edited either field (dirty
-            // tracking lives in useLabelKeySync). Seeding writes state
-            // directly so it doesn't itself flip the dirty flag.
             if (!getDirty()) {
               const { name: seedName, key: seedKey } = deriveProviderDefaults(
                 newProvider,
@@ -346,8 +340,10 @@ export function ProviderCreateForm({
               setCredential("");
             } else {
               setAuthType((prev) => {
-                if (prev === "none") {
-                  return "api_key";
+                if (prev === "none" || !provider) {
+                  return providerSupportsPlatformAuth(newProvider)
+                    ? "platform"
+                    : "api_key";
                 }
                 if (
                   prev === "oauth_subscription" &&
@@ -365,8 +361,6 @@ export function ProviderCreateForm({
               });
               setCredential(`credential/${newProvider}/api_key`);
             }
-            // Credential ref changes above trigger a new TQ query key,
-            // so the presence check auto-refetches for the new provider.
           }}
           options={connectionProviderOptions.map((p) => ({
             value: p,
@@ -410,45 +404,46 @@ export function ProviderCreateForm({
         </>
       )}
 
-      {/* Auth type */}
-      <div className="space-y-1">
-        <label className="block text-body-small-default text-[var(--content-tertiary)]">
-          Auth Type
-        </label>
-        <Dropdown
-          aria-label="Auth type"
-          value={authType}
-          onChange={(v) => {
-            setAuthType(v as AuthType);
-            setError(null);
-          }}
-          disabled={provider === "ollama"}
-          options={(() => {
-            let types: AuthType[];
-            if (provider === "ollama") {
-              types = ["none"];
-            } else if (providerSupportsPlatformAuth(provider)) {
-              types = ["api_key", "platform"];
-            } else {
-              types = ["api_key"];
-            }
-            // Add oauth_subscription when ChatGPT flag is enabled for OpenAI.
-            if (chatgptSubscriptionEnabled && provider === "openai") {
-              types.push("oauth_subscription");
-            }
-            if (authType && !types.includes(authType)) {
-              types.push(authType);
-            }
-            return types.map((t) => ({
-              value: t,
-              label: AUTH_TYPE_DISPLAY_NAMES[t],
-            }));
-          })()}
-        />
-      </div>
+      {/* Auth type — hidden until a provider is selected */}
+      {provider !== "" && (
+        <div className="space-y-1">
+          <label className="block text-body-small-default text-[var(--content-tertiary)]">
+            Auth Type
+          </label>
+          <Dropdown
+            aria-label="Auth type"
+            value={authType}
+            onChange={(v) => {
+              setAuthType(v as AuthType);
+              setError(null);
+            }}
+            disabled={provider === "ollama"}
+            options={(() => {
+              let types: AuthType[];
+              if (provider === "ollama") {
+                types = ["none"];
+              } else if (providerSupportsPlatformAuth(provider)) {
+                types = ["api_key", "platform"];
+              } else {
+                types = ["api_key"];
+              }
+              if (chatgptSubscriptionEnabled && provider === "openai") {
+                types.push("oauth_subscription");
+              }
+              if (authType && !types.includes(authType)) {
+                types.push(authType);
+              }
+              return types.map((t) => ({
+                value: t,
+                label: AUTH_TYPE_DISPLAY_NAMES[t],
+              }));
+            })()}
+          />
+        </div>
+      )}
 
       {/* API Key + Advanced disclosure — only shown for api_key auth */}
-      {authType === "api_key" && (
+      {provider !== "" && authType === "api_key" && (
         <ProviderEditorApiKeySection
           apiKeyValue={apiKeyValue}
           onApiKeyChange={setApiKeyValue}
@@ -457,7 +452,7 @@ export function ProviderCreateForm({
           isAuthLocked={false}
           isLoadingCredential={isLoadingCredential}
           apiKeyPlaceholder={apiKeyPlaceholder}
-          provider={provider}
+          provider={provider as ConnectionProvider}
           providerCredentials={providerCredentials}
           showAdvancedSection={shouldShowAdvancedSection}
           onError={setError}
@@ -465,7 +460,7 @@ export function ProviderCreateForm({
       )}
 
       {/* ChatGPT Subscription OAuth — shown when auth type is oauth_subscription */}
-      {authType === "oauth_subscription" && (
+      {provider !== "" && authType === "oauth_subscription" && (
         <ChatgptOAuthSection
           assistantId={assistantId}
           onConnected={onCreated}

--- a/packages/design-library/src/components/dropdown.tsx
+++ b/packages/design-library/src/components/dropdown.tsx
@@ -38,10 +38,11 @@ export interface DropdownOption<T extends string> {
    */
   readonly disabled?: boolean;
   /**
-   * When true, renders a bottom border below this option to visually
-   * separate it from the options that follow.
+   * When true, renders a border to visually separate this option.
+   * `"below"` (default when `true`) adds a bottom border;
+   * `"above"` adds a top border.
    */
-  readonly separated?: boolean;
+  readonly separated?: boolean | "above" | "below";
 }
 
 export interface DropdownProps<T extends string> {
@@ -336,7 +337,11 @@ export function Dropdown<T extends string>({
             className={cn(
               "flex items-center gap-2 px-3 py-2 text-body-medium-default transition-colors",
               isDisabled ? "cursor-not-allowed opacity-50" : "cursor-pointer",
-              option.separated && "border-b border-[var(--border-element)]",
+              option.separated === true || option.separated === "below"
+                ? "border-b border-[var(--border-element)]"
+                : option.separated === "above"
+                  ? "border-t border-[var(--border-element)]"
+                  : "",
             )}
             style={{
               background: isHighlighted

--- a/packages/design-library/src/components/dropdown.tsx
+++ b/packages/design-library/src/components/dropdown.tsx
@@ -336,7 +336,7 @@ export function Dropdown<T extends string>({
             className={cn(
               "flex items-center gap-2 px-3 py-2 text-body-medium-default transition-colors",
               isDisabled ? "cursor-not-allowed opacity-50" : "cursor-pointer",
-              option.separated && "border-b border-[var(--field-border)]",
+              option.separated && "border-b border-[var(--border-element)]",
             )}
             style={{
               background: isHighlighted

--- a/packages/design-library/src/components/dropdown.tsx
+++ b/packages/design-library/src/components/dropdown.tsx
@@ -37,6 +37,11 @@ export interface DropdownOption<T extends string> {
    * list reads consistently. Defaults to selectable.
    */
   readonly disabled?: boolean;
+  /**
+   * When true, renders a bottom border below this option to visually
+   * separate it from the options that follow.
+   */
+  readonly separated?: boolean;
 }
 
 export interface DropdownProps<T extends string> {
@@ -331,6 +336,7 @@ export function Dropdown<T extends string>({
             className={cn(
               "flex items-center gap-2 px-3 py-2 text-body-medium-default transition-colors",
               isDisabled ? "cursor-not-allowed opacity-50" : "cursor-pointer",
+              option.separated && "border-b border-[var(--field-border)]",
             )}
             style={{
               background: isHighlighted


### PR DESCRIPTION
## Summary

- Replaces the three flat buttons (Providers, Profiles, Overrides) on Settings > Models & Services with a collapsible **Advanced Options** accordion section
- Each row shows a label, description, managed/own count badges, and `+` (add) / `>` (manage) action buttons
- Provider connection counts are fetched inline to display "X Managed | Y Own" without opening the modal
- Profile counts exclude the Auto meta-profile and split by `source === "managed"` vs user-owned
- Overrides show `X/Y overrides` (active/total) format
- Uses the existing `Collapsible` design library component (Radix Accordion) with slide animation

Implements the "Advanced Options" collapsible from [Rok's Figma design](https://www.figma.com/design/cCGBcpVDbn22kj3OPU58W8/New-App?node-id=5419-40232) per the [Slack discussion](https://vellumai.slack.com/archives/C07J71ND4SU/p1780458682091549).

Part of JARVIS-1010

## Test plan

- [ ] Navigate to Settings > Models & Services — verify "Model Profiles" card shows Default Profile dropdown + collapsed "Advanced Options"
- [ ] Click Advanced Options — verify it expands with slide animation showing Provider Connections, Profiles, and Overrides rows
- [ ] Verify managed/own counts are accurate for Provider Connections and Profiles
- [ ] Click `>` on Provider Connections — verify Manage Providers modal opens
- [ ] Click `>` on Profiles — verify Manage Profiles modal opens
- [ ] Click `>` on Overrides — verify Call Site Overrides modal opens
- [ ] Click `+` on Provider Connections — verify Manage Providers modal opens
- [ ] Click `+` on Profiles — verify Manage Profiles modal opens
- [ ] Verify collapse/expand toggle works correctly (chevron rotates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)