### PR TITLE
feat(macos): persist the session token and expose it on the auth bridge

### DIFF
--- a/apps/macos/src/main/native-auth.test.ts
+++ b/apps/macos/src/main/native-auth.test.ts
@@ -1,6 +1,87 @@
-import { describe, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 
-import { buildStartUrl, generateState } from "./native-auth";
+// --- Mocks (installed before the `await import` of the module under test) ---
+
+// Capture IPC registrations so tests can invoke the handlers directly.
+const ipcHandlers: Record<string, (args: unknown[]) => unknown> = {};
+const ipcSyncHandlers: Record<string, () => unknown> = {};
+
+mock.module("./ipc", () => ({
+  handle: (
+    channel: string,
+    _schema: unknown,
+    fn: (args: unknown[]) => unknown,
+  ) => {
+    ipcHandlers[channel] = fn;
+  },
+  handleSync: (channel: string, fn: () => unknown) => {
+    ipcSyncHandlers[channel] = fn;
+  },
+}));
+
+// Capture the OAuth start URL so tests can read back the generated `state`.
+let lastOpenedUrl = "";
+
+mock.module("electron", () => ({
+  app: { getVersion: () => "9.9.9", getPath: () => "/tmp" },
+  net: {
+    fetch: () =>
+      Promise.resolve(
+        new Response(JSON.stringify({ session_token: "sess-tok-123" }), {
+          status: 200,
+        }),
+      ),
+  },
+  session: {
+    defaultSession: { cookies: { set: () => Promise.resolve() } },
+  },
+  shell: {
+    openExternal: (url: string) => {
+      lastOpenedUrl = url;
+      return Promise.resolve();
+    },
+  },
+}));
+
+mock.module("@vellumai/local-mode", () => ({
+  resolveLocalConfigFromEnv: () => ({
+    webUrl: "https://web.example",
+    platformUrl: "https://platform.example",
+  }),
+}));
+
+// Capture session-token-store interactions.
+const store = {
+  saved: [] as string[],
+  clearCalls: 0,
+};
+
+mock.module("./session-token-store", () => ({
+  saveSessionToken: (token: string) => {
+    store.saved.push(token);
+  },
+  clearSessionToken: () => {
+    store.clearCalls += 1;
+  },
+  getSessionToken: () => store.saved.at(-1) ?? null,
+}));
+
+const {
+  buildStartUrl,
+  generateState,
+  handleAuthCallback,
+  installNativeAuth,
+  __resetForTesting,
+} = await import("./native-auth");
+
+afterEach(() => {
+  __resetForTesting();
+  store.saved.length = 0;
+  store.clearCalls = 0;
+  lastOpenedUrl = "";
+  for (const key of Object.keys(ipcHandlers)) delete ipcHandlers[key];
+  for (const key of Object.keys(ipcSyncHandlers)) delete ipcSyncHandlers[key];
+});
 
 describe("generateState", () => {
   test("returns a base64url-encoded string of sufficient length", () => {
@@ -43,5 +124,46 @@ describe("buildStartUrl", () => {
     expect(parsed.searchParams.has("provider_hint")).toBe(false);
     expect(parsed.searchParams.has("login_hint")).toBe(false);
     expect(parsed.searchParams.has("client_version")).toBe(false);
+  });
+});
+
+describe("installNativeAuth — session-token wiring", () => {
+  test("persists the exchanged token on successful login", async () => {
+    installNativeAuth();
+
+    const startOAuth = ipcHandlers["vellum:auth:startOAuth"];
+    expect(startOAuth).toBeDefined();
+
+    const pending = startOAuth([{}]) as Promise<{ sessionToken: string }>;
+
+    // openExternal ran synchronously in the flow's executor, so the start URL
+    // (with the state) is already captured.
+    const state = new URL(lastOpenedUrl).searchParams.get("state");
+    expect(state).toBeTruthy();
+
+    await handleAuthCallback(state!, "auth-code-xyz");
+    const result = await pending;
+
+    expect(result.sessionToken).toBe("sess-tok-123");
+    expect(store.saved).toContain("sess-tok-123");
+  });
+
+  test("signOut clears the persisted token", async () => {
+    installNativeAuth();
+
+    const signOut = ipcHandlers["vellum:auth:signOut"];
+    expect(signOut).toBeDefined();
+
+    await signOut([]);
+    expect(store.clearCalls).toBe(1);
+  });
+
+  test("exposes the cached token over sync IPC", () => {
+    installNativeAuth();
+    store.saved.push("cached-tok");
+
+    const getToken = ipcSyncHandlers["vellum:auth:getSessionToken"];
+    expect(getToken).toBeDefined();
+    expect(getToken()).toBe("cached-tok");
   });
 });

--- a/apps/macos/src/main/native-auth.ts
+++ b/apps/macos/src/main/native-auth.ts
@@ -1,10 +1,15 @@
-import crypto from "node:crypto";
 import { app, net, session, shell } from "electron";
+import crypto from "node:crypto";
 import { z } from "zod";
 
 import { resolveLocalConfigFromEnv } from "@vellumai/local-mode";
 
-import { handle } from "./ipc";
+import { handle, handleSync } from "./ipc";
+import {
+    clearSessionToken,
+    getSessionToken,
+    saveSessionToken,
+} from "./session-token-store";
 
 const AUTH_FLOW_TIMEOUT_MS = 5 * 60_000;
 
@@ -143,6 +148,8 @@ async function startOAuth(options: {
     void shell.openExternal(url);
   });
 
+  // The session cookie is here for backwards compatibility. We'll remove shortly.
+  saveSessionToken(sessionToken);
   await installSessionCookie(resolveProxyPlatformUrl(), sessionToken);
   return { sessionToken };
 }
@@ -201,6 +208,12 @@ export const installNativeAuth = (): void => {
   handle("vellum:auth:cancelOAuth", z.tuple([]), () => {
     cancelPendingFlows();
   });
+
+  handle("vellum:auth:signOut", z.tuple([]), () => {
+    clearSessionToken();
+  });
+
+  handleSync("vellum:auth:getSessionToken", () => getSessionToken());
 };
 
 export const __resetForTesting = (): void => {

--- a/apps/macos/src/main/session-token-store.test.ts
+++ b/apps/macos/src/main/session-token-store.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// Only `electron` is stubbed (no Electron runtime / keychain in tests). The
+// store's fs calls run against a real per-test temp dir, so the file, its mode,
+// and real ENOENT/round-trip behavior are exercised for real.
+
+let userDataDir = "";
+let encryptionAvailable = true;
+
+mock.module("electron", () => ({
+  app: {
+    getPath: (name: string) => (name === "userData" ? userDataDir : "/tmp"),
+  },
+  safeStorage: {
+    isEncryptionAvailable: () => encryptionAvailable,
+    // Reversible tag so round-trips and bad blobs are checkable.
+    encryptString: (value: string) => Buffer.from(`enc:${value}`),
+    decryptString: (blob: Buffer) => {
+      const text = blob.toString();
+      if (!text.startsWith("enc:")) throw new Error("undecryptable blob");
+      return text.slice("enc:".length);
+    },
+  },
+}));
+
+mock.module("./logger", () => ({ default: { warn: () => {}, error: () => {} } }));
+
+const { getSessionToken, saveSessionToken, clearSessionToken } = await import(
+  "./session-token-store"
+);
+
+const tokenPath = (): string => path.join(userDataDir, "session.enc");
+
+beforeEach(() => {
+  userDataDir = mkdtempSync(path.join(os.tmpdir(), "vellum-session-token-"));
+  encryptionAvailable = true;
+});
+
+afterEach(() => {
+  rmSync(userDataDir, { recursive: true, force: true });
+});
+
+describe("saveSessionToken", () => {
+  test("writes an encrypted, 0600 file that getSessionToken round-trips", () => {
+    saveSessionToken("tok-abc");
+
+    expect(getSessionToken()).toBe("tok-abc");
+    expect(readFileSync(tokenPath()).toString()).toBe("enc:tok-abc");
+    expect(statSync(tokenPath()).mode & 0o777).toBe(0o600);
+  });
+
+  test("does not persist when encryption is unavailable", () => {
+    encryptionAvailable = false;
+
+    saveSessionToken("tok-abc");
+
+    expect(existsSync(tokenPath())).toBe(false);
+  });
+});
+
+describe("getSessionToken", () => {
+  test("returns null when no file exists (signed out)", () => {
+    expect(getSessionToken()).toBeNull();
+  });
+
+  test("returns null for an undecryptable blob without throwing", () => {
+    writeFileSync(tokenPath(), "garbage-not-encrypted");
+
+    expect(() => getSessionToken()).not.toThrow();
+    expect(getSessionToken()).toBeNull();
+  });
+
+  test("returns null when encryption is unavailable even if a file exists", () => {
+    writeFileSync(tokenPath(), "enc:persisted-tok");
+    encryptionAvailable = false;
+
+    expect(getSessionToken()).toBeNull();
+  });
+});
+
+describe("clearSessionToken", () => {
+  test("deletes the persisted file", () => {
+    saveSessionToken("tok-abc");
+
+    clearSessionToken();
+
+    expect(existsSync(tokenPath())).toBe(false);
+    expect(getSessionToken()).toBeNull();
+  });
+
+  test("tolerates a missing file", () => {
+    expect(() => clearSessionToken()).not.toThrow();
+  });
+});

--- a/apps/macos/src/main/session-token-store.ts
+++ b/apps/macos/src/main/session-token-store.ts
@@ -1,0 +1,48 @@
+import { app, safeStorage } from "electron";
+import { readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+import log from "./logger";
+
+const TOKEN_FILENAME = "session.enc";
+
+function tokenFilePath(): string {
+  return path.join(app.getPath("userData"), TOKEN_FILENAME);
+}
+
+/** The persisted token, or `null` when signed out or unreadable. */
+export function getSessionToken(): string | null {
+  try {
+    const encrypted = readFileSync(tokenFilePath());
+    if (!safeStorage.isEncryptionAvailable()) return null;
+    return safeStorage.decryptString(encrypted) || null;
+  } catch (err) {
+    // Missing or corrupt file
+    if ((err as NodeJS.ErrnoException)?.code !== "ENOENT") {
+      log.warn("[session-token] failed to read persisted token:", err);
+    }
+    return null;
+  }
+}
+
+/** Persist the token encrypted at rest. No-op (warns) when the OS keychain is unavailable. */
+export function saveSessionToken(token: string): void {
+  if (!safeStorage.isEncryptionAvailable()) {
+    log.warn("[session-token] OS encryption unavailable; token not persisted");
+    return;
+  }
+  writeFileSync(tokenFilePath(), safeStorage.encryptString(token), {
+    mode: 0o600,
+  });
+}
+
+/** Delete the persisted token. */
+export function clearSessionToken(): void {
+  try {
+    unlinkSync(tokenFilePath());
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code !== "ENOENT") {
+      log.warn("[session-token] failed to delete persisted token:", err);
+    }
+  }
+}

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -250,6 +250,10 @@ export interface VellumBridge {
       intent?: string;
     }): Promise<{ sessionToken: string }>;
     cancelOAuth(): Promise<void>;
+    /** Main's persisted session token, or null when signed out. */
+    getSessionToken(): string | null;
+    /** Clear main's persisted session token (used on logout). */
+    signOut(): Promise<void>;
   };
   hotkeys: {
     /** Resolved catalog of rebindable commands and their effective bindings. */
@@ -565,6 +569,10 @@ const bridge: VellumBridge = {
       }>,
     cancelOAuth: (): Promise<void> =>
       ipcRenderer.invoke("vellum:auth:cancelOAuth") as Promise<void>,
+    getSessionToken: (): string | null =>
+      ipcRenderer.sendSync("vellum:auth:getSessionToken") as string | null,
+    signOut: (): Promise<void> =>
+      ipcRenderer.invoke("vellum:auth:signOut") as Promise<void>,
   },
   hotkeys: {
     get: (): Promise<ResolvedHotkey[]> =>

--- a/apps/macos/test-setup.ts
+++ b/apps/macos/test-setup.ts
@@ -84,6 +84,13 @@ mock.module("electron", () => ({
     // `net.fetch` locally with their own fixture.
     fetch: () => Promise.resolve(new Response("")),
   },
+  safeStorage: {
+    // Use no-op shims by default instead of touching keychain.
+    // Re-mock `safeStorage` locally if needed for tests.
+    isEncryptionAvailable: () => false,
+    encryptString: (value: string) => Buffer.from(value),
+    decryptString: (blob: Buffer) => blob.toString(),
+  },
   screen: {
     getDisplayMatching: () => ({
       workArea: { x: 0, y: 0, width: 1920, height: 1080 },

--- a/apps/web/src/runtime/is-electron.ts
+++ b/apps/web/src/runtime/is-electron.ts
@@ -299,6 +299,9 @@ declare global {
           intent?: string;
         }): Promise<{ sessionToken: string }>;
         cancelOAuth(): Promise<void>;
+        // Optional: older shells predate the session-token bridge.
+        getSessionToken?(): string | null;
+        signOut?(): Promise<void>;
       };
       mainWindow: {
         ensureVisible(): Promise<void>;


### PR DESCRIPTION
ref ATL-816

PR 1/n: Migrate electron to use session token instead of cookies.

This handles lifecycle of stuff on electron shell side. Store it (encrypted), delete it on logout, and expose to web view.