### PR TITLE
refactor(plugins): restore __vellumPluginRuntime bridge for external workspace plugins

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -230,6 +230,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "runtime/routes/platform-routes.ts", // CLI platform connect/disconnect/status routes (CLI-migrated to IPC)
       "ipc/skill-routes/providers.ts", // host.providers.secureKeys.getProviderKey IPC route (out-of-process SkillHost companion)
       "daemon/external-plugins-bootstrap.ts", // reads credentials at plugin init (manifest.requiresCredential) via the CES-mediated getSecureKeyAsync path
+      "plugins/external-api.ts", // globalThis runtime bridge that exposes getSecureKeyAsync to dynamically-imported workspace plugins (compiled-binary plugin loading)
       "inbound/platform-callback-registration.ts", // managed credential lookup for platform base URL, assistant ID, and API key
       "tts/providers/elevenlabs-provider.ts", // ElevenLabs TTS API key lookup
       "tts/providers/deepgram-provider.ts", // Deepgram TTS API key lookup

--- a/assistant/src/__tests__/plugin-external-api.test.ts
+++ b/assistant/src/__tests__/plugin-external-api.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Tests for the `globalThis.__vellumPluginRuntime` bridge.
+ *
+ * The bridge exists so workspace-local plugins (`<workspaceDir>/plugins/*`)
+ * can register with the daemon's bundled module instances even when the
+ * daemon is a `bun --compile` binary. Absolute-path imports against a
+ * compiled binary load fresh disk copies into a disjoint module graph; the
+ * bridge sidesteps that by attaching a stable handle to globalThis.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  getPluginRuntime,
+  installPluginRuntime,
+  uninstallPluginRuntimeForTests,
+} from "../plugins/external-api.js";
+import { registerPlugin } from "../plugins/registry.js";
+import { assistantEventHub } from "../runtime/assistant-event-hub.js";
+import { getSecureKeyAsync } from "../security/secure-keys.js";
+
+describe("plugin external-api bridge", () => {
+  beforeEach(() => {
+    uninstallPluginRuntimeForTests();
+  });
+
+  afterEach(() => {
+    uninstallPluginRuntimeForTests();
+  });
+
+  test("installs a runtime handle on globalThis", () => {
+    expect(getPluginRuntime()).toBeUndefined();
+    installPluginRuntime();
+    const runtime = getPluginRuntime();
+    expect(runtime).toBeDefined();
+    expect(runtime?.version).toBe(1);
+  });
+
+  test("exposes the canonical registerPlugin / hub / secrets references", () => {
+    installPluginRuntime();
+    const runtime = getPluginRuntime();
+    expect(runtime?.registerPlugin).toBe(registerPlugin);
+    expect(runtime?.assistantEventHub).toBe(assistantEventHub);
+    expect(runtime?.getSecureKeyAsync).toBe(getSecureKeyAsync);
+  });
+
+  test("plugins can read the runtime via the documented globalThis key", () => {
+    installPluginRuntime();
+    // Mirror the access pattern documented for plugin authors.
+    const runtime = (
+      globalThis as { __vellumPluginRuntime?: { version: number } }
+    ).__vellumPluginRuntime;
+    expect(runtime).toBeDefined();
+    expect(runtime?.version).toBe(1);
+  });
+
+  test("install is idempotent — repeat calls preserve the same handle", () => {
+    installPluginRuntime();
+    const first = getPluginRuntime();
+    installPluginRuntime();
+    installPluginRuntime();
+    expect(getPluginRuntime()).toBe(first);
+  });
+
+  test("getPluginRuntime returns undefined when the bridge is not installed", () => {
+    expect(getPluginRuntime()).toBeUndefined();
+  });
+});

--- a/assistant/src/daemon/external-plugins-bootstrap.ts
+++ b/assistant/src/daemon/external-plugins-bootstrap.ts
@@ -65,6 +65,7 @@ import { getConfig } from "../config/loader.js";
 import type { AssistantConfig } from "../config/schema.js";
 import { HOOKS } from "../plugin-api/constants.js";
 import { registerDefaultPlugins } from "../plugins/defaults/index.js";
+import { installPluginRuntime } from "../plugins/external-api.js";
 import { buildExternalPlugin } from "../plugins/external-plugin-loader.js";
 import {
   registerPluginSkills,
@@ -186,17 +187,21 @@ function getDisabledPluginFlag(
  * Bring the plugin layer up during daemon startup. Runs the full sequence in
  * the one order the rest of the system depends on:
  *
- * 1. Register the first-party defaults so their middleware composes innermost,
+ * 1. Install the `globalThis.__vellumPluginRuntime` bridge so plugins can touch
+ *    it from their module body (see `plugins/external-api.ts` — compiled-binary
+ *    module identity).
+ * 2. Register the first-party defaults so their middleware composes innermost,
  *    ahead of any user plugins.
- * 2. Load user plugins from `<workspaceDir>/plugins/*`. A failing user plugin is
+ * 3. Load user plugins from `<workspaceDir>/plugins/*`. A failing user plugin is
  *    logged and skipped; `loadUserPlugins()` closes the registration window
  *    when it returns, so the defaults must already be registered by then.
- * 3. Run every registered plugin's `init()` via {@link bootstrapPlugins}.
+ * 4. Run every registered plugin's `init()` via {@link bootstrapPlugins}.
  *
  * Plugin bootstrap is wrapped so a failing plugin cannot block daemon startup —
  * the daemon comes up with degraded plugin functionality instead.
  */
 export async function initializePlugins(): Promise<void> {
+  installPluginRuntime();
   registerDefaultPlugins();
   await loadUserPlugins();
   try {

--- a/assistant/src/plugins/external-api.ts
+++ b/assistant/src/plugins/external-api.ts
@@ -1,0 +1,114 @@
+/**
+ * External plugin runtime — `globalThis.__vellumPluginRuntime` bridge.
+ *
+ * ⚠️ DO NOT DELETE THIS AS "UNUSED". There is intentionally NO in-repo consumer:
+ * the consumers are out-of-repo, user-authored workspace plugins under
+ * `<workspaceDir>/plugins/*`, which a repo-wide reference search cannot see. On
+ * a `bun --compile` daemon (the shipped macOS app) this bridge is the ONLY way
+ * such a plugin can reach the daemon's real `assistantEventHub` /
+ * `getSecureKeyAsync` singletons — an absolute-path `import` re-loads a disjoint
+ * copy (see the module-identity note below). Removing it silently breaks every
+ * event-subscribing workspace plugin on the next app rebuild. This was already
+ * removed once on the false "unused" assumption (PR #33825) and restored here.
+ *
+ * Workspace-local plugins (`<workspaceDir>/plugins/*`) get dynamic-imported by
+ * {@link loadUserPlugins}. They need to call `registerPlugin()` from their
+ * module body and they typically also want to read secrets, subscribe to
+ * runtime events, etc.
+ *
+ * Importing those symbols by absolute path
+ * (`/abs/path/to/assistant/src/plugins/registry.js`) works when the daemon is
+ * running from source — both the daemon and the dynamic-imported plugin
+ * resolve the same on-disk file and share module identity. It DOES NOT work
+ * when the daemon is a `bun --compile` binary: the daemon's modules are baked
+ * into the executable, and any absolute-path import re-loads a fresh disk
+ * copy. `registerPlugin()` then writes into a disjoint registry instance and
+ * the daemon never sees the plugin.
+ *
+ * The fix is to expose a single, stable handle on `globalThis` that plugins
+ * read at module-load time. The daemon's bundled modules attach themselves
+ * here once at startup; plugins consume the same instance regardless of how
+ * the daemon was built.
+ *
+ * Plugins use the bridge like this:
+ *
+ *   const runtime = (globalThis as { __vellumPluginRuntime?: ... })
+ *     .__vellumPluginRuntime;
+ *   if (!runtime || runtime.version !== 1) throw new Error("...");
+ *   const { registerPlugin, assistantEventHub, getSecureKeyAsync } = runtime;
+ *
+ * Type-only imports (`import type { Plugin } from "..."`) remain free to use
+ * absolute paths or workspace-local copies — the TypeScript compiler erases
+ * them and they have no module-identity effect at runtime.
+ *
+ * See `experimental/plugins/README.md` for the full authoring contract and
+ * `assistant/examples/plugins/echo/` for a worked example.
+ */
+
+import { assistantEventHub } from "../runtime/assistant-event-hub.js";
+import { getSecureKeyAsync } from "../security/secure-keys.js";
+import { registerPlugin } from "./registry.js";
+
+/**
+ * The handle plugins read from `globalThis.__vellumPluginRuntime`.
+ *
+ * `version` is the contract version. Plugins should assert against the
+ * version they were authored against and refuse to register if they see a
+ * different one — bumping it is a breaking change to the plugin surface.
+ *
+ * The field set is intentionally small: the most-commonly-needed symbols
+ * across both static (module-load-time) and dynamic (init-time) plugin
+ * lifecycle. Plugins that need richer runtime state can still receive it
+ * through {@link PluginInitContext} during `init()`.
+ */
+export interface VellumPluginRuntime {
+  readonly version: 1;
+  readonly registerPlugin: typeof registerPlugin;
+  readonly assistantEventHub: typeof assistantEventHub;
+  readonly getSecureKeyAsync: typeof getSecureKeyAsync;
+}
+
+/** Stable globalThis key. Don't rename — plugins reference it by string. */
+const RUNTIME_GLOBAL_KEY = "__vellumPluginRuntime" as const;
+
+interface GlobalWithRuntime {
+  [RUNTIME_GLOBAL_KEY]?: VellumPluginRuntime;
+}
+
+/**
+ * Install the plugin runtime bridge on `globalThis`. Idempotent — repeat
+ * calls are no-ops, so it's safe to invoke from tests that also touch the
+ * lifecycle path.
+ *
+ * Must be called BEFORE {@link loadUserPlugins} runs, otherwise plugins that
+ * touch `globalThis.__vellumPluginRuntime` in their module body will throw.
+ */
+export function installPluginRuntime(): void {
+  const g = globalThis as GlobalWithRuntime;
+  if (g[RUNTIME_GLOBAL_KEY]) return;
+  g[RUNTIME_GLOBAL_KEY] = {
+    version: 1,
+    registerPlugin,
+    assistantEventHub,
+    getSecureKeyAsync,
+  };
+}
+
+/**
+ * Read the installed runtime. Returns `undefined` if {@link installPluginRuntime}
+ * hasn't been called yet — plugins should treat this as a fatal error.
+ *
+ * Exposed mainly for tests and for the rare in-process consumer that wants
+ * to read the bridge from the same module graph that installed it.
+ */
+export function getPluginRuntime(): VellumPluginRuntime | undefined {
+  return (globalThis as GlobalWithRuntime)[RUNTIME_GLOBAL_KEY];
+}
+
+/**
+ * Tear down the runtime handle. Test-only — production code never uninstalls
+ * because the runtime lifetime is the daemon lifetime.
+ */
+export function uninstallPluginRuntimeForTests(): void {
+  delete (globalThis as GlobalWithRuntime)[RUNTIME_GLOBAL_KEY];
+}


### PR DESCRIPTION
## What

Reverts #33825 (plus a retention note), which removed the `globalThis.__vellumPluginRuntime` bridge on the assumption it was unused.

## Why it was not unused

The consumers are **out-of-repo, user-authored workspace plugins** under `<workspaceDir>/plugins/*`. They read the bridge at module-load time to reach the daemon's real `assistantEventHub` / `getSecureKeyAsync` singletons. A repo-wide reference search can't see those consumers, so the bridge looks dead from inside the repo — but it isn't.

On a `bun --compile` daemon (the shipped desktop app) this bridge is the **only** way such a plugin can obtain the daemon's singletons: an absolute-path `import` re-loads a disjoint module copy, so a plugin that imports `assistantEventHub` directly subscribes to a dead hub that never receives the daemon's events. Removing the bridge silently breaks every event-subscribing workspace plugin on the next app rebuild (no error at build time — the plugin just fails to load).

## What this restores

- `assistant/src/plugins/external-api.ts` — the bridge + `installPluginRuntime()`.
- The `installPluginRuntime()` call at the top of `initializePlugins()` (must run before `loadUserPlugins()`).
- `plugin-external-api.test.ts` and the credential-invariants line.
- **A retention note** at the top of `external-api.ts` explaining there is intentionally no in-repo consumer, so a future "unused" sweep doesn't remove it a second time.

## Test

- `bun test src/__tests__/plugin-external-api.test.ts` → 5 pass
- `bun test src/__tests__/credential-security-invariants.test.ts` → 32 pass
- `bunx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)