### PR TITLE
feat(web): attach the session token header on Electron platform requests

### DIFF
--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -104,12 +104,12 @@ const universalAuthRules = [
  * Path-scoped via the override block below.
  */
 const headerLiteralRules = [
-  // No new literal `X-Session-Token` strings. This header is a legacy
-  // native-bridge artifact and is being retired.
+  // No literal `X-Session-Token` strings outside the auth/interceptor
+  // surface. It is the native-client session auth header; keep it centralized.
   {
     selector: "Literal[value='X-Session-Token']",
     message:
-      "Do not introduce new uses of the X-Session-Token header. It is a legacy native-bridge artifact that is being retired in favor of cookie-based session auth issued by the gateway.",
+      "Do not set the X-Session-Token header outside src/lib/auth/ or src/lib/api-interceptors.ts. It is the native-client session auth header and is centralized in the auth interceptor.",
   },
 
   // No new literal `X-CSRFToken` strings outside the auth/interceptor

--- a/apps/web/src/lib/api-interceptors.test.ts
+++ b/apps/web/src/lib/api-interceptors.test.ts
@@ -14,7 +14,15 @@
  * @jest-environment happy-dom
  */
 
-import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
 
 import {
   daemonRequestInterceptor,
@@ -23,6 +31,7 @@ import {
 } from "@/lib/api-interceptors";
 import { setSelfHostedConnection } from "@/lib/self-hosted/connection";
 import { getClientId } from "@/lib/telemetry/client-identity";
+import { __resetForTesting as resetSessionToken } from "@/runtime/session-token";
 import { useOrganizationStore } from "@/stores/organization-store";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 
@@ -87,6 +96,11 @@ describe("api-interceptors / requestInterceptor", () => {
     expect(headers.get("X-CSRFToken")).toBeNull();
   });
 
+  test("does not attach the session-token header on web (no Electron bridge)", async () => {
+    const headers = await intercept("GET");
+    expect(headers.get("X-Session-Token")).toBeNull();
+  });
+
   test("returns a new Request, leaving the input headers untouched", async () => {
     const input = new Request("https://example.test/v1/probe", { method: "POST" });
     expect(input.headers.get("X-Vellum-Client-Id")).toBeNull();
@@ -95,6 +109,40 @@ describe("api-interceptors / requestInterceptor", () => {
     expect(output).not.toBe(input);
     expect(input.headers.get("X-Vellum-Client-Id")).toBeNull();
     expect(output.headers.get("X-Vellum-Client-Id")).toBe(getClientId());
+  });
+});
+
+describe("api-interceptors / Electron session-token header", () => {
+  beforeAll(() => {
+    useOrganizationStore.setState({ currentOrganizationId: TEST_ORG_ID });
+    setCsrfCookie("test-csrf-token");
+  });
+
+  beforeEach(() => {
+    (window as unknown as { vellum?: unknown }).vellum = {
+      platform: "electron",
+      auth: { getSessionToken: () => "electron-sess-tok" },
+    };
+  });
+
+  afterEach(() => {
+    delete (window as unknown as { vellum?: unknown }).vellum;
+    resetSessionToken();
+  });
+
+  afterAll(() => {
+    clearCsrfCookie();
+  });
+
+  test("attaches the session-token header on platform requests", async () => {
+    const headers = await intercept("GET");
+    expect(headers.get("X-Session-Token")).toBe("electron-sess-tok");
+  });
+
+  test("rides alongside CSRF on mutations (additive)", async () => {
+    const headers = await intercept("POST");
+    expect(headers.get("X-Session-Token")).toBe("electron-sess-tok");
+    expect(headers.get("X-CSRFToken")).toBe("test-csrf-token");
   });
 });
 

--- a/apps/web/src/lib/api-interceptors.ts
+++ b/apps/web/src/lib/api-interceptors.ts
@@ -25,17 +25,18 @@
  *
  * Reference: https://heyapi.dev/openapi-ts/clients/fetch#interceptors
  */
+import { client as platformClient } from "@/generated/api/client.gen";
 import { client as authClient } from "@/generated/auth/client.gen";
 import { client as daemonClient } from "@/generated/daemon/client.gen";
-import { client as platformClient } from "@/generated/api/client.gen";
 import { ensureCsrfCookie, getCsrfToken } from "@/lib/auth/csrf";
-import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
-import {
-  getSelfHostedActorToken,
-  getSelfHostedIngressUrl,
-} from "@/lib/self-hosted/connection";
 import { isLocalMode } from "@/lib/local-mode";
+import {
+    getSelfHostedActorToken,
+    getSelfHostedIngressUrl,
+} from "@/lib/self-hosted/connection";
 import { getClientRegistrationHeaders } from "@/lib/telemetry/client-identity";
+import { getElectronSessionToken } from "@/runtime/session-token";
+import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { getActiveOrganizationIdForRequests } from "@/stores/organization-store";
 
 const MUTATING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
@@ -191,6 +192,12 @@ function createInterceptor({ skipSegmentAllowlist = false } = {}) {
     const organizationId = getActiveOrganizationIdForRequests();
     if (organizationId) {
       newRequest.headers.set("Vellum-Organization-Id", organizationId);
+    }
+
+    // Electron app provides a session token header. This is no-ops on web.
+    const sessionToken = getElectronSessionToken();
+    if (sessionToken) {
+      newRequest.headers.set("X-Session-Token", sessionToken);
     }
 
     if (MUTATING_METHODS.has(request.method)) {

--- a/apps/web/src/lib/auth/request-headers.ts
+++ b/apps/web/src/lib/auth/request-headers.ts
@@ -23,6 +23,7 @@
  */
 import { ensureCsrfCookie, getCsrfToken } from "@/lib/auth/csrf";
 import { getSelfHostedActorToken } from "@/lib/self-hosted/connection";
+import { getElectronSessionToken } from "@/runtime/session-token";
 import { getActiveOrganizationIdForRequests } from "@/stores/organization-store";
 
 /**
@@ -42,6 +43,11 @@ export function buildVellumHeaders(
   const organizationId = getActiveOrganizationIdForRequests();
   if (organizationId) {
     headers["Vellum-Organization-Id"] = organizationId;
+  }
+  // Electron app provides a session token header. This is no-ops on web.
+  const sessionToken = getElectronSessionToken();
+  if (sessionToken) {
+    headers["X-Session-Token"] = sessionToken;
   }
   return headers;
 }

--- a/apps/web/src/runtime/session-token.test.ts
+++ b/apps/web/src/runtime/session-token.test.ts
@@ -1,0 +1,46 @@
+/**
+ * @jest-environment happy-dom
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  __resetForTesting,
+  getElectronSessionToken,
+} from "@/runtime/session-token";
+
+function setBridge(token: string | null, calls?: { count: number }): void {
+  (window as unknown as { vellum?: unknown }).vellum = {
+    platform: "electron",
+    auth: {
+      getSessionToken: () => {
+        if (calls) calls.count += 1;
+        return token;
+      },
+    },
+  };
+}
+
+afterEach(() => {
+  delete (window as unknown as { vellum?: unknown }).vellum;
+  __resetForTesting();
+});
+
+describe("getElectronSessionToken", () => {
+  test("returns null on web (no Electron bridge)", () => {
+    expect(getElectronSessionToken()).toBeNull();
+  });
+
+  test("seeds from the bridge once and caches the value", () => {
+    const calls = { count: 0 };
+    setBridge("tok", calls);
+
+    expect(getElectronSessionToken()).toBe("tok");
+    expect(getElectronSessionToken()).toBe("tok");
+    expect(calls.count).toBe(1);
+  });
+
+  test("returns null when the bridge reports no token", () => {
+    setBridge(null);
+    expect(getElectronSessionToken()).toBeNull();
+  });
+});

--- a/apps/web/src/runtime/session-token.ts
+++ b/apps/web/src/runtime/session-token.ts
@@ -1,0 +1,20 @@
+import { isElectron } from "@/runtime/is-electron";
+
+// Seeded once per page load from the main process, which owns the token.
+// Auth transitions (login / logout / re-auth) hard-navigate, reloading the
+// renderer and re-seeding, so a per-load cache stays correct without any
+// per-request IPC. `undefined` = not yet seeded; `null` = signed out.
+let cached: string | null | undefined;
+
+/** The session token in Electron, or `null` on web / when signed out. */
+export function getElectronSessionToken(): string | null {
+  if (!isElectron()) return null;
+  if (cached === undefined) {
+    cached = window.vellum?.auth?.getSessionToken?.() ?? null;
+  }
+  return cached;
+}
+
+export function __resetForTesting(): void {
+  cached = undefined;
+}


### PR DESCRIPTION
ref ATL-816

Part 2/n: Attach `X-Session-Token` header to platform requests. Note that we still inject the session cookie, which likely takes precedence, so we still need CSRF protections. There should be no behavioral changes to electron -- we'll perform the cutover in the next PR.

All of this no-ops on web.