### PR TITLE
fix(memory-v3): preserve authored links: frontmatter for the edge lane

### DIFF
--- a/assistant/src/memory/v2/__tests__/page-store.test.ts
+++ b/assistant/src/memory/v2/__tests__/page-store.test.ts
@@ -186,6 +186,28 @@ describe("writePage + readPage round-trip", () => {
     expect(read!.body).toBe(page.body);
   });
 
+  test("round-trips authored links: frontmatter (memory-v3 edge lane)", async () => {
+    const page = makePage({
+      frontmatter: {
+        edges: [],
+        ref_files: [],
+        ref_urls: [],
+        links: ["bob-handoff — the partner this hands off to"],
+      },
+    });
+    await writePage(workspaceDir, page);
+
+    // A page using the optional `links:` frontmatter must NOT be rejected by the
+    // strict schema (it would otherwise be dropped from memory-v3 entirely), and
+    // the curated links must survive the render → read round-trip so the edge
+    // graph can parse them back from the rendered frontmatter.
+    const read = await readPage(workspaceDir, page.slug);
+    expect(read).not.toBeNull();
+    expect(read!.frontmatter.links).toEqual([
+      "bob-handoff — the partner this hands off to",
+    ]);
+  });
+
   test("renders frontmatter at the top with --- delimiters", async () => {
     const page = makePage();
     await writePage(workspaceDir, page);

--- a/assistant/src/memory/v2/types.ts
+++ b/assistant/src/memory/v2/types.ts
@@ -41,6 +41,11 @@ export const ConceptPageFrontmatterSchema = z
     ref_urls: z.array(z.string().url()).default([]),
     summary: z.string().optional(),
     leaves: z.array(z.string()).optional(),
+    // Optional authored `"<target-slug> — <why>"` cross-links. Curated, first-class
+    // edges for the memory-v3 edge lane. Declared here so `.strict()` does not
+    // reject a page that uses `links:`, and so `renderPageContent` round-trips the
+    // field (the edge graph reads it back from the rendered frontmatter).
+    links: z.array(z.string()).optional(),
   })
   .strict();
 


### PR DESCRIPTION
## Summary
- Add the optional `links` field to `ConceptPageFrontmatterSchema`. Without it, the schema's `.strict()` parse REJECTED any real page using the new `links:` frontmatter, so `readPage` threw and the page was dropped from memory-v3 entirely (no sections, no edges) — and even if parsed, `renderPageContent` (schema-field serialization) stripped `links`, so `pageRaw` never carried it to `buildEdgeGraph`. Declaring `links` fixes both: strict-parse accepts it, and renderPageContent round-trips it so the curated edge lane works on real workspace pages. Additive optional field — backward-compatible, no migration.

Addresses Codex P2 on #33874. Follow-up to plan: memory-v3-section-lanes.md