### PR TITLE
Add macOS debug pack target for DevTools

### DIFF
--- a/apps/macos/electron.vite.config.ts
+++ b/apps/macos/electron.vite.config.ts
@@ -48,6 +48,10 @@ const BUILD_DEFINES = {
   __VELLUM_ENVIRONMENT__: JSON.stringify(
     process.env.VELLUM_ENVIRONMENT || "production",
   ),
+  __VELLUM_ENABLE_CHROME_DEVTOOLS__: JSON.stringify(
+    process.env.VELLUM_ENABLE_CHROME_DEVTOOLS === "true" ||
+      process.env.VELLUM_ENABLE_CHROME_DEVTOOLS === "1",
+  ),
 };
 
 export default defineConfig({

--- a/apps/macos/package.json
+++ b/apps/macos/package.json
@@ -18,7 +18,8 @@
     "test:ci": "bun scripts/run-tests.ts",
     "build:fetch-bun": "bash scripts/fetch-bun.sh",
     "build:web": "cd ../web && bun install && bun run openapi-ts && bun run build && cd ../macos && mkdir -p resources && cp -R ../web/dist resources/web-dist",
-    "pack": "bash scripts/pack.sh"
+    "pack": "bash scripts/pack.sh",
+    "pack:debug": "VELLUM_ENABLE_CHROME_DEVTOOLS=true bash scripts/pack.sh"
   },
   "devDependencies": {
     "@types/bun": "1.3.14",

--- a/apps/macos/src/main/devtools.ts
+++ b/apps/macos/src/main/devtools.ts
@@ -1,0 +1,10 @@
+import { app } from "electron";
+
+declare const __VELLUM_ENABLE_CHROME_DEVTOOLS__: boolean | undefined;
+
+const isChromeDevToolsBuild = (): boolean =>
+  typeof __VELLUM_ENABLE_CHROME_DEVTOOLS__ === "boolean" &&
+  __VELLUM_ENABLE_CHROME_DEVTOOLS__;
+
+export const areChromeDevToolsEnabled = (): boolean =>
+  !app.isPackaged || isChromeDevToolsBuild();

--- a/apps/macos/src/main/menu.ts
+++ b/apps/macos/src/main/menu.ts
@@ -8,6 +8,7 @@ import {
   dispatchToFocused,
   type VellumCommand,
 } from "./commands";
+import { areChromeDevToolsEnabled } from "./devtools";
 import { handle } from "./ipc";
 import { onSettingChange } from "./settings";
 import { readOnboardingActive } from "./window-state";
@@ -22,6 +23,7 @@ const state: MenuState = {
 
 const buildTemplate = (): MenuItemConstructorOptions[] => {
   const isDev = !app.isPackaged;
+  const chromeDevToolsEnabled = areChromeDevToolsEnabled();
 
   const fileItem = (
     label: string,
@@ -114,7 +116,9 @@ const buildTemplate = (): MenuItemConstructorOptions[] => {
         { type: "separator" },
         { role: "reload" },
         { role: "forceReload" },
-        ...(isDev ? [{ role: "toggleDevTools" as const }] : []),
+        ...(chromeDevToolsEnabled
+          ? [{ role: "toggleDevTools" as const }]
+          : []),
         { type: "separator" },
         { role: "resetZoom" },
         { role: "zoomIn" },
@@ -163,8 +167,8 @@ const applyMenu = (): void => {
  * Toggle Developer Tools at the top level) and lacks the standard macOS
  * shape end users expect.
  *
- * The `View > Toggle Developer Tools` item is gated to dev only so the
- * packaged build doesn't expose devtools to end users.
+ * The `View > Toggle Developer Tools` item is gated to dev/debug builds so a
+ * normal packaged build doesn't expose devtools to end users.
  *
  * Registers an IPC handler so the renderer can publish platform session
  * state, which gates the "Log Out" item in the app menu.

--- a/apps/macos/src/main/windows.test.ts
+++ b/apps/macos/src/main/windows.test.ts
@@ -15,6 +15,7 @@ let constructed: CapturedWindow[] = [];
 // the `devTools` gate, mirroring how the real `app.isPackaged` differs between
 // a dev run and a shipped build.
 const appState = { isPackaged: false };
+const DEBUG_DEVTOOLS_DEFINE = "__VELLUM_ENABLE_CHROME_DEVTOOLS__";
 
 mock.module("electron", () => ({
   app: appState,
@@ -49,6 +50,7 @@ const { createWindow, hardenedWebPreferences } = await import("./windows");
 beforeEach(() => {
   constructed = [];
   appState.isPackaged = false;
+  delete (globalThis as Record<string, unknown>)[DEBUG_DEVTOOLS_DEFINE];
 });
 
 describe("hardenedWebPreferences", () => {
@@ -72,6 +74,12 @@ describe("hardenedWebPreferences", () => {
     expect(hardenedWebPreferences().devTools).toBe(true);
     appState.isPackaged = true;
     expect(hardenedWebPreferences().devTools).toBe(false);
+  });
+
+  test("enables devTools in a packaged debug build", () => {
+    appState.isPackaged = true;
+    (globalThis as Record<string, unknown>)[DEBUG_DEVTOOLS_DEFINE] = true;
+    expect(hardenedWebPreferences().devTools).toBe(true);
   });
 });
 

--- a/apps/macos/src/main/windows.ts
+++ b/apps/macos/src/main/windows.ts
@@ -6,6 +6,8 @@ import {
 } from "electron";
 import path from "node:path";
 
+import { areChromeDevToolsEnabled } from "./devtools";
+
 const preloadPath = (): string => path.join(__dirname, "../preload/index.js");
 
 /**
@@ -19,8 +21,9 @@ const preloadPath = (): string => path.join(__dirname, "../preload/index.js");
  * - `webSecurity` + `allowRunningInsecureContent:false` keep the same-origin
  *   policy enforced and block mixed (http-in-https) content.
  * - `experimentalFeatures:false` keeps unstable web-platform features off.
- * - `devTools` is enabled only in development; a packaged build ships with it
- *   disabled so the renderer can't be inspected on an end user's machine.
+ * - `devTools` is enabled only in development and explicit debug packages; a
+ *   normal packaged build ships with it disabled so the renderer can't be
+ *   inspected on an end user's machine.
  *
  * `preload` is deliberately excluded: it is role-specific (app windows load the
  * Vellum bridge, OAuth popups intentionally run without it), so each caller
@@ -34,7 +37,7 @@ export const hardenedWebPreferences = (): WebPreferences => ({
   webSecurity: true,
   allowRunningInsecureContent: false,
   experimentalFeatures: false,
-  devTools: !app.isPackaged,
+  devTools: areChromeDevToolsEnabled(),
 });
 
 /**


### PR DESCRIPTION
## Summary
- Add an `apps/macos` `pack:debug` script that builds the packaged app with Chrome DevTools enabled.
- Embed the debug DevTools flag at Electron build time so Finder-launched debug DMGs keep the setting.
- Use the same flag for hardened window preferences and the View menu DevTools toggle.

## Original prompt
Maddie needed a production-like macOS DMG that can still be inspected with Chrome DevTools while debugging the packaged app's speech-to-text request flow. The normal production DMG hides DevTools, so this PR adds a dedicated debug packaging target instead of changing default production behavior.