### PR TITLE
docs(memory-v3): clarify injectedText is full-page-approximate in the API contract

### DIFF
--- a/assistant/src/api/responses/memory-v3-selection-log.ts
+++ b/assistant/src/api/responses/memory-v3-selection-log.ts
@@ -12,10 +12,17 @@
  * `live` / `shadow` reflect the CURRENT `memory-v3-live` / `memory-v3-shadow`
  * flag state, not the per-turn history (the selection rows don't record which
  * mode was active when they were written). When `live` is true the rendered
- * `injectedText` block was actually injected into the turn; when only `shadow`
- * is true it is the block that WOULD have been injected. For stable-flag
- * shadow validation these coincide; recording per-turn `injected` is a
- * documented follow-up.
+ * `injectedText` reflects the live selection; when only `shadow` is true it is
+ * the block that WOULD have been injected.
+ *
+ * `injectedText` is APPROXIMATE, not a verbatim record. It is re-rendered from
+ * the persisted selection rows, which store slug/source/pinned but NOT the
+ * matched-section identity. A page that live injection sent as a single matched
+ * section is re-rendered here as its FULL page (the section ordinal isn't
+ * persisted), so the text can differ from what was actually sent to the model.
+ * The selected slug set is exact — only the rendered text is full-page
+ * approximate. Persisting the per-turn injected section is a documented
+ * follow-up.
  */
 
 import { z } from "zod";
@@ -37,8 +44,9 @@ export type MemoryV3SelectionRow = z.infer<typeof MemoryV3SelectionRowSchema>;
 
 /**
  * Memory v3 selection log shape. `injectedText` is the rendered
- * `<memory>…</memory>` block for the selection (actual when `live`, would-be
- * when `shadow`-only).
+ * `<memory>…</memory>` block for the selection — APPROXIMATE: re-rendered from
+ * the persisted rows, with full pages where live injection used a matched
+ * section (the section identity isn't persisted). See the file header.
  */
 export const MemoryV3SelectionLogSchema = z.object({
   turn: z.number(),


### PR DESCRIPTION
## Summary
- The `MemoryV3SelectionLog.injectedText` contract said the block was "actually injected into the turn" when live. It's actually re-rendered from persisted rows that don't store the matched-section identity, so a page injected as a section is re-rendered as its full page. Updated the response-schema docs to state injectedText is approximate (full-page where live used a matched section); the selected slug set stays exact. Per the earlier decision to defer persisting the section identity and document the approximation instead.

Addresses Codex P2 on #33874 (the deferred inspector-fidelity item). Follow-up to plan: memory-v3-section-lanes.md