### PR TITLE
feat: cut the Electron client over to X-Session-Token header auth

### DIFF
--- a/apps/macos/src/main/native-auth.test.ts
+++ b/apps/macos/src/main/native-auth.test.ts
@@ -22,6 +22,9 @@ mock.module("./ipc", () => ({
 // Capture the OAuth start URL so tests can read back the generated `state`.
 let lastOpenedUrl = "";
 
+// Capture legacy-cookie eviction calls.
+const cookieRemoveCalls: Array<{ url: string; name: string }> = [];
+
 mock.module("electron", () => ({
   app: { getVersion: () => "9.9.9", getPath: () => "/tmp" },
   net: {
@@ -33,7 +36,14 @@ mock.module("electron", () => ({
       ),
   },
   session: {
-    defaultSession: { cookies: { set: () => Promise.resolve() } },
+    defaultSession: {
+      cookies: {
+        remove: (url: string, name: string) => {
+          cookieRemoveCalls.push({ url, name });
+          return Promise.resolve();
+        },
+      },
+    },
   },
   shell: {
     openExternal: (url: string) => {
@@ -79,6 +89,7 @@ afterEach(() => {
   store.saved.length = 0;
   store.clearCalls = 0;
   lastOpenedUrl = "";
+  cookieRemoveCalls.length = 0;
   for (const key of Object.keys(ipcHandlers)) delete ipcHandlers[key];
   for (const key of Object.keys(ipcSyncHandlers)) delete ipcSyncHandlers[key];
 });
@@ -146,6 +157,17 @@ describe("installNativeAuth — session-token wiring", () => {
 
     expect(result.sessionToken).toBe("sess-tok-123");
     expect(store.saved).toContain("sess-tok-123");
+  });
+
+  test("evicts both legacy session cookies on install", () => {
+    installNativeAuth();
+    // Eviction fires synchronously (Promise.all over the cookie names).
+    const names = cookieRemoveCalls.map((c) => c.name);
+    expect(names).toContain("sessionid");
+    expect(names).toContain("__Secure-sessionid");
+    expect(cookieRemoveCalls.every((c) => c.url === "https://platform.example")).toBe(
+      true,
+    );
   });
 
   test("signOut clears the persisted token", async () => {

--- a/apps/macos/src/main/native-auth.ts
+++ b/apps/macos/src/main/native-auth.ts
@@ -60,42 +60,16 @@ async function exchangeCode(
   return data.session_token;
 }
 
-async function installSessionCookie(
-  platformUrl: string,
-  sessionToken: string,
-): Promise<void> {
-  const target = new URL(platformUrl);
-  const domain = target.hostname.includes("vellum.ai")
-    ? ".vellum.ai"
-    : target.hostname;
-  const isSecure = target.protocol === "https:";
-  const expirationDate = Math.floor(Date.now() / 1000) + 14 * 24 * 3600;
-
-  await session.defaultSession.cookies.set({
-    url: platformUrl,
-    name: "sessionid",
-    value: sessionToken,
-    domain,
-    path: "/",
-    secure: isSecure,
-    httpOnly: true,
-    sameSite: "lax",
-    expirationDate,
-  });
-
-  if (isSecure) {
-    await session.defaultSession.cookies.set({
-      url: platformUrl,
-      name: "__Secure-sessionid",
-      value: sessionToken,
-      domain,
-      path: "/",
-      secure: true,
-      httpOnly: true,
-      sameSite: "lax",
-      expirationDate,
-    });
-  }
+// Evict the session cookies installed by prior builds, so that
+// header auth takes precedence.
+async function clearLegacySessionCookies(): Promise<void> {
+  const url = resolveProxyPlatformUrl();
+  await Promise.all(
+    ["sessionid", "__Secure-sessionid"].map((name) =>
+      // Best-effort — a missing cookie is the common case.
+      session.defaultSession.cookies.remove(url, name).catch(() => undefined),
+    ),
+  );
 }
 
 function cancelPendingFlows(): void {
@@ -115,8 +89,7 @@ function resolveAuthPlatformUrl(): string {
   return resolveLocalConfigFromEnv(process.env).webUrl;
 }
 
-// The cookie must be installed against the platform URL the renderer's
-// proxy actually talks to (which may be localhost in dev).
+// The platform URL the renderer's proxy talks to.
 function resolveProxyPlatformUrl(): string {
   return resolveLocalConfigFromEnv(process.env).platformUrl;
 }
@@ -148,9 +121,7 @@ async function startOAuth(options: {
     void shell.openExternal(url);
   });
 
-  // The session cookie is here for backwards compatibility. We'll remove shortly.
   saveSessionToken(sessionToken);
-  await installSessionCookie(resolveProxyPlatformUrl(), sessionToken);
   return { sessionToken };
 }
 
@@ -196,6 +167,8 @@ let installed = false;
 export const installNativeAuth = (): void => {
   if (installed) return;
   installed = true;
+
+  void clearLegacySessionCookies();
 
   handle(
     "vellum:auth:startOAuth",

--- a/apps/web/src/lib/api-interceptors.test.ts
+++ b/apps/web/src/lib/api-interceptors.test.ts
@@ -139,10 +139,10 @@ describe("api-interceptors / Electron session-token header", () => {
     expect(headers.get("X-Session-Token")).toBe("electron-sess-tok");
   });
 
-  test("rides alongside CSRF on mutations (additive)", async () => {
+  test("drops CSRF on mutations — header auth, not cookie auth", async () => {
     const headers = await intercept("POST");
     expect(headers.get("X-Session-Token")).toBe("electron-sess-tok");
-    expect(headers.get("X-CSRFToken")).toBe("test-csrf-token");
+    expect(headers.get("X-CSRFToken")).toBeNull();
   });
 });
 

--- a/apps/web/src/lib/api-interceptors.ts
+++ b/apps/web/src/lib/api-interceptors.ts
@@ -35,6 +35,7 @@ import {
     getSelfHostedIngressUrl,
 } from "@/lib/self-hosted/connection";
 import { getClientRegistrationHeaders } from "@/lib/telemetry/client-identity";
+import { isElectron } from "@/runtime/is-electron";
 import { getElectronSessionToken } from "@/runtime/session-token";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { getActiveOrganizationIdForRequests } from "@/stores/organization-store";
@@ -200,7 +201,9 @@ function createInterceptor({ skipSegmentAllowlist = false } = {}) {
       newRequest.headers.set("X-Session-Token", sessionToken);
     }
 
-    if (MUTATING_METHODS.has(request.method)) {
+    // Clients authenticating via session cookie need to pass CSRF checks.
+    // Electron authenticates via a session token header.
+    if (!isElectron() && MUTATING_METHODS.has(request.method)) {
       await ensureCsrfCookie();
       const csrfToken = getCsrfToken();
       if (csrfToken) {

--- a/apps/web/src/lib/auth/allauth-client.test.ts
+++ b/apps/web/src/lib/auth/allauth-client.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @jest-environment happy-dom
+ */
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+// Capture the `client` path param each allauth SDK call receives.
+const calls: Array<{ fn: string; client: string }> = [];
+
+function sdkStub(fn: string) {
+  return (opts: { path: { client: string } }) => {
+    calls.push({ fn, client: opts.path.client });
+    return Promise.resolve({
+      data: { data: {} },
+      error: undefined,
+      response: { status: 200 },
+    });
+  };
+}
+
+mock.module("@/generated/auth/sdk.gen", () => ({
+  getAllauthByClientV1AuthSession: sdkStub("getSession"),
+  deleteAllauthByClientV1AuthSession: sdkStub("logout"),
+  getAllauthByClientV1AuthProviderSignup: sdkStub("getProviderSignup"),
+  postAllauthByClientV1AuthProviderSignup: sdkStub("submitProviderSignup"),
+}));
+
+const { getSession, logout } = await import("@/lib/auth/allauth-client");
+
+function setElectron(): void {
+  (window as unknown as { vellum?: unknown }).vellum = { platform: "electron" };
+}
+
+afterEach(() => {
+  delete (window as unknown as { vellum?: unknown }).vellum;
+  calls.length = 0;
+});
+
+describe("allauth-client — client selection", () => {
+  test("uses the browser client on web", async () => {
+    await getSession();
+    expect(calls.at(-1)?.client).toBe("browser");
+  });
+
+  test("uses the app client in Electron", async () => {
+    setElectron();
+    await getSession();
+    await logout();
+    expect(calls.map((c) => c.client)).toEqual(["app", "app"]);
+  });
+});

--- a/apps/web/src/lib/auth/allauth-client.ts
+++ b/apps/web/src/lib/auth/allauth-client.ts
@@ -18,6 +18,12 @@ import {
   getAllauthByClientV1AuthProviderSignup,
   postAllauthByClientV1AuthProviderSignup,
 } from "@/generated/auth/sdk.gen";
+import { isElectron } from "@/runtime/is-electron";
+
+// Electron authenticates via the session-token header → allauth's "app" client.
+// Web/iOS use cookie sessions → the "browser" client.
+const allauthClient = (): "app" | "browser" =>
+  isElectron() ? "app" : "browser";
 
 export type AllauthResult<T = unknown> =
   | { ok: true; data: T }
@@ -49,7 +55,7 @@ function errorResult(
 
 export async function getSession(): Promise<AllauthResult<Authenticated>> {
   const { data, error, response } = await getAllauthByClientV1AuthSession({
-    path: { client: "browser" },
+    path: { client: allauthClient() },
   });
 
   if (data) {
@@ -62,7 +68,7 @@ export async function getSession(): Promise<AllauthResult<Authenticated>> {
 export async function logout(): Promise<AllauthResult> {
   const { data, error, response } =
     await deleteAllauthByClientV1AuthSession({
-      path: { client: "browser" },
+      path: { client: allauthClient() },
     });
 
   if (data) {
@@ -87,7 +93,7 @@ export async function getProviderSignup(): Promise<
 > {
   const { data, error, response } =
     await getAllauthByClientV1AuthProviderSignup({
-      path: { client: "browser" },
+      path: { client: allauthClient() },
     });
 
   if (data) {
@@ -106,7 +112,7 @@ export async function submitProviderSignup({
 }): Promise<AllauthResult<Authenticated>> {
   const { data, error, response } =
     await postAllauthByClientV1AuthProviderSignup({
-      path: { client: "browser" },
+      path: { client: allauthClient() },
       body: { email, username },
     });
 

--- a/apps/web/src/lib/auth/csrf.ts
+++ b/apps/web/src/lib/auth/csrf.ts
@@ -10,6 +10,7 @@
  */
 import { getAllauthByClientV1AuthSession } from "@/generated/auth/sdk.gen";
 import { isGatewayAuthMode } from "@/lib/auth/gateway-session";
+import { isElectron } from "@/runtime/is-electron";
 
 const CSRF_COOKIE_NAME = import.meta.env.PROD
   ? "__Secure-csrftoken"
@@ -47,6 +48,8 @@ function clearDuplicateCsrfCookies(): void {
 let csrfBootstrap: Promise<void> | null = null;
 
 export async function ensureCsrfCookie(): Promise<void> {
+  // Electron authenticates via a token header - no CSRF needed.
+  if (isElectron()) return;
   if (isGatewayAuthMode()) return;
 
   clearDuplicateCsrfCookies();

--- a/apps/web/src/lib/auth/request-headers.ts
+++ b/apps/web/src/lib/auth/request-headers.ts
@@ -23,6 +23,7 @@
  */
 import { ensureCsrfCookie, getCsrfToken } from "@/lib/auth/csrf";
 import { getSelfHostedActorToken } from "@/lib/self-hosted/connection";
+import { isElectron } from "@/runtime/is-electron";
 import { getElectronSessionToken } from "@/runtime/session-token";
 import { getActiveOrganizationIdForRequests } from "@/stores/organization-store";
 
@@ -62,6 +63,8 @@ export async function buildVellumMutatingHeaders(
 ): Promise<Record<string, string>> {
   const headers = buildVellumHeaders(extra);
   if (headers["Authorization"]) return headers;
+  // Electron authenticates via a token header - no CSRF needed.
+  if (isElectron()) return headers;
   await ensureCsrfCookie();
   const csrfToken = getCsrfToken();
   if (csrfToken) {

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -53,6 +53,7 @@ import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
 import { clearOrganization } from "@/stores/organization-store";
 import { clearUserScopedStorage } from "@/lib/auth/session-cleanup";
 import { subscribe } from "@/lib/event-bus";
+import { isElectron } from "@/runtime/is-electron";
 import { isNativePlatform, installSessionCookies, waitForNativeSessionCookie } from "@/runtime/native-auth";
 import { isBiometricEnabled, retrieveBiometricToken } from "@/runtime/native-biometric";
 
@@ -556,6 +557,8 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
     try {
       await allauthLogout();
     } finally {
+      // Clean up session token in the main process.
+      if (isElectron()) await window.vellum?.auth?.signOut?.();
       if (isLocalMode()) {
         document.cookie = "sessionid=; path=/; samesite=lax; expires=Thu, 01 Jan 1970 00:00:00 UTC";
       }


### PR DESCRIPTION
ref: ATL-816

Part 3/n: Cuts the Electron client over to header auth (builds on #34022, #34025):
- allauth `browser` → `app` client
- drop the renderer CSRF attach
- stop installing the session cookie + evict stale on launch
- clear the token on logout

Tested locally and inspect network calls -- requests carry session-token header with no session cookie.

Follow-ups:
- more CSRF cleanup
- splitting up the client / keeping session token out of renderer, as discussed here: https://github.com/vellum-ai/vellum-assistant/pull/34025