### PR TITLE
chore: remove the dead cookie/CSRF machinery from the Electron client

### DIFF
--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -252,29 +252,11 @@ const forwardGatewayRequest = async (
   }
 };
 
-const CSRF_COOKIE_RE = /(?:__Secure-)?csrftoken=([^;]+)/;
-
-// `app://` is not a cookieable scheme, so the renderer can't read the CSRF
-// token via `document.cookie`. Main caches it here and injects it into
-// forwarded requests; `net.fetch`'s own cookie jar supplies the cookie side.
-let cachedCsrfToken: string | null = null;
-handleSync("vellum:csrf:getToken", () => cachedCsrfToken);
-
 const resolvedConfig = resolveLocalConfigFromEnv(process.env);
 handleSync("vellum:config:get", () => ({
   webUrl: resolvedConfig.webUrl,
   platformUrl: resolvedConfig.platformUrl,
 }));
-
-const captureCsrfToken = (response: Response): void => {
-  const setCookies = response.headers.getSetCookie?.() ?? [];
-  for (const raw of setCookies) {
-    const match = CSRF_COOKIE_RE.exec(raw);
-    if (match?.[1]) {
-      cachedCsrfToken = match[1];
-    }
-  }
-};
 
 /**
  * Forward a platform API request (`/v1/*`, `/_allauth/*`, `/accounts/*`) to
@@ -293,17 +275,8 @@ const forwardPlatformRequest = async (
     return new Response(plan.message, { status: plan.status });
   }
 
-  if (
-    plan.shouldInjectCsrfToken &&
-    cachedCsrfToken &&
-    !plan.headers.has("X-CSRFToken")
-  ) {
-    plan.headers.set("X-CSRFToken", cachedCsrfToken);
-  }
-
-  let response: Response;
   try {
-    response = await net.fetch(plan.url, {
+    return await net.fetch(plan.url, {
       method: plan.method,
       headers: plan.headers,
       body: plan.hasBody ? request.body : undefined,
@@ -314,9 +287,6 @@ const forwardPlatformRequest = async (
     const message = err instanceof Error ? err.message : "Platform unreachable";
     return new Response(message, { status: 502 });
   }
-
-  captureCsrfToken(response);
-  return response;
 };
 
 // ---------------------------------------------------------------------------

--- a/apps/macos/src/main/platform-forward.test.ts
+++ b/apps/macos/src/main/platform-forward.test.ts
@@ -93,7 +93,7 @@ describe("planPlatformForward", () => {
     expect(plan.headers.get("origin")).toBe("https://platform.vellum.ai");
   });
 
-  test("marks app-origin platform requests as eligible for CSRF injection", () => {
+  test("forwards unsafe requests from the trusted app origin", () => {
     const plan = planPlatformForward(
       request("/_allauth/browser/v1/auth/session", {
         method: "POST",
@@ -103,11 +103,10 @@ describe("planPlatformForward", () => {
       { allowedOrigin: { protocol: "app:", host: "vellum.ai" } },
     );
     if (plan.kind !== "forward") throw new Error("expected forward");
-    expect(plan.shouldInjectCsrfToken).toBe(true);
     expect(plan.headers.get("origin")).toBe("https://platform.vellum.ai");
   });
 
-  test("rejects platform requests with a foreign Origin before CSRF injection", () => {
+  test("rejects platform requests with a foreign Origin", () => {
     const plan = planPlatformForward(
       request("/_allauth/browser/v1/auth/session", {
         method: "POST",
@@ -147,15 +146,14 @@ describe("planPlatformForward", () => {
     expect(plan.kind).toBe("reject");
   });
 
-  test("does not auto-inject CSRF for source-less safe platform requests", () => {
+  test("forwards source-less safe platform requests", () => {
     const plan = planPlatformForward(
       request("/v1/assistants", { method: "GET" }),
       PLATFORM,
       { allowedOrigin: { protocol: "app:", host: "vellum.ai" } },
     );
 
-    if (plan.kind !== "forward") throw new Error("expected forward");
-    expect(plan.shouldInjectCsrfToken).toBe(false);
+    expect(plan.kind).toBe("forward");
   });
 
   test("preserves non-Origin headers", () => {

--- a/apps/macos/src/main/platform-forward.ts
+++ b/apps/macos/src/main/platform-forward.ts
@@ -16,7 +16,6 @@ export type PlatformForwardPlan =
       method: string;
       headers: Headers;
       hasBody: boolean;
-      shouldInjectCsrfToken: boolean;
     };
 
 export interface PlatformForwardRequest {
@@ -83,11 +82,9 @@ function getInitiatorTrust(
  *
  * On `forward`, the request's `Origin` is rewritten to the platform's own
  * origin. The renderer issues this request from `app://vellum.ai` but the
- * platform expects its own origin for CORS/CSRF purposes. Unsafe requests are
- * only forwarded when their browser-controlled `Origin` or `Referer` matches
- * the trusted renderer origin, and only those trusted requests are eligible for
- * main-process CSRF token injection. All other headers (Authorization,
- * X-CSRFToken, Content-Type, etc.) pass through unchanged.
+ * platform expects its own origin for CORS purposes. Unsafe requests are only
+ * forwarded when their browser-controlled `Origin` or `Referer` matches the
+ * trusted renderer origin. All other headers pass through unchanged.
  */
 export function planPlatformForward(
   request: PlatformForwardRequest,
@@ -122,6 +119,5 @@ export function planPlatformForward(
     method: request.method,
     headers,
     hasBody: request.method !== "GET" && request.method !== "HEAD",
-    shouldInjectCsrfToken: initiator.trusted,
   };
 }

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -267,9 +267,6 @@ export interface VellumBridge {
     insertIntoFrontApp(text: string): Promise<TextInsertionResult>;
     openAutomationSettings(): Promise<void>;
   };
-  csrf: {
-    getToken(): string | null;
-  };
   auth: {
     startOAuth(options: {
       providerHint?: string;
@@ -594,10 +591,6 @@ const bridge: VellumBridge = {
       ipcRenderer.invoke(
         "vellum:text:openAutomationSettings",
       ) as Promise<void>,
-  },
-  csrf: {
-    getToken: (): string | null =>
-      ipcRenderer.sendSync("vellum:csrf:getToken") as string | null,
   },
   auth: {
     startOAuth: (options: {

--- a/apps/web/src/lib/auth/csrf.ts
+++ b/apps/web/src/lib/auth/csrf.ts
@@ -24,12 +24,6 @@ const CSRF_COOKIE_NAME = import.meta.env.PROD
  * last-wins semantics.
  */
 export function getCsrfToken(): string | undefined {
-  // In Electron the `app://` scheme doesn't support cookies, so
-  // `document.cookie` is always empty. Read from the preload bridge
-  // which pulls the token from main's cache via sync IPC.
-  const bridgeToken = window.vellum?.csrf?.getToken();
-  if (bridgeToken) return bridgeToken;
-
   const match = document.cookie
     .split("; ")
     .findLast((row) => row.startsWith(`${CSRF_COOKIE_NAME}=`));

--- a/apps/web/src/runtime/is-electron.ts
+++ b/apps/web/src/runtime/is-electron.ts
@@ -254,9 +254,6 @@ declare global {
         insertIntoFrontApp(text: string): Promise<ElectronTextInsertionResult>;
         openAutomationSettings(): Promise<void>;
       };
-      csrf?: {
-        getToken(): string | null;
-      };
       // Optional: an older preload predates the hotkeys/featureFlags channels.
       // The macOS app and web bundle don't release together, so a newer
       // renderer can run against an older preload; callers must guard on


### PR DESCRIPTION
ref ATL-816

Removes the cookie/CSRF machinery left dead by the header-auth cutover (#34034):
- the platform proxy no longer caches/injects `X-CSRFToken` (`forwardPlatformRequest` is now plan → fetch → return; trust gating kept)
- `shouldInjectCsrfToken` dropped from the proxy plan
- the `vellum:csrf:getToken` bridge removed (preload + renderer type + renderer read)

No behavior change — all of it was a no-op after the cutover. Web/iOS cookie + CSRF auth is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)