### PR TITLE
fix(electron): scope URL scheme registration to the build's environment (LUM-2272)

### DIFF
--- a/apps/macos/electron-builder.config.cjs
+++ b/apps/macos/electron-builder.config.cjs
@@ -13,10 +13,10 @@ const appId =
     ? "com.vellum.vellum-assistant-electron"
     : `com.vellum.vellum-assistant-electron-${env}`;
 
-const schemes = ["vellum", "vellum-assistant"];
-if (env !== "production") {
-  schemes.push(`vellum-assistant-${env}`);
-}
+const schemes =
+  env === "production"
+    ? ["vellum", "vellum-assistant"]
+    : [`vellum-assistant-${env}`];
 
 const channel =
   env === "staging" ? "beta" : env === "dev" ? "alpha" : "latest";

--- a/apps/macos/src/main/deep-links.test.ts
+++ b/apps/macos/src/main/deep-links.test.ts
@@ -577,8 +577,8 @@ describe("resolveRegisteredSchemes", () => {
     ]);
   });
 
-  test("unknown env falls back to production callback scheme without claiming vellum://", () => {
-    expect(resolveRegisteredSchemes("unknown")).toEqual(["vellum-assistant"]);
+  test("unknown env derives scheme from env name", () => {
+    expect(resolveRegisteredSchemes("test")).toEqual(["vellum-assistant-test"]);
   });
 });
 

--- a/apps/macos/src/main/deep-links.test.ts
+++ b/apps/macos/src/main/deep-links.test.ts
@@ -79,8 +79,11 @@ const {
   handleDeepLink,
   installDeepLinks,
   parseVellumUrl,
+  resolveAcceptedSchemes,
+  resolveRegisteredSchemes,
 } = await import("./deep-links");
 const { resolveAllowedOrigin } = await import("./app-origin");
+const { resolveEnvironmentName } = await import("@vellumai/local-mode");
 
 // The IPC wrappers reject any sender whose frame origin isn't the
 // build's renderer origin. These tests drive the registered handlers
@@ -243,24 +246,12 @@ describe("parseVellumUrl", () => {
     });
   });
 
-  test("auth callback works with environment-specific scheme (e.g. vellum-assistant-dev)", () => {
-    // The dev scheme is registered when VELLUM_ENVIRONMENT=dev (or persisted default is dev).
-    // On this dev machine the scheme is in ACCEPTED_SCHEMES; on production it isn't,
-    // but the server would use the production scheme there. Verify the parser accepts it.
-    const devUrl = "vellum-assistant-dev://auth/callback?code=abc&state=xyz";
-    const result = parseVellumUrl(devUrl);
-    // If the dev scheme is registered (dev environment), we get authCallback;
-    // if not (production CI), it falls through to unknown — both are correct.
-    if (result.kind === "authCallback") {
-      expect(result).toEqual({
-        kind: "authCallback",
-        state: "xyz",
-        code: "abc",
-        error: undefined,
-      });
-    } else {
-      expect(result.kind).toBe("unknown");
-    }
+  test("env-specific scheme for a foreign environment is rejected as unknown", () => {
+    // A scheme that doesn't match any known environment is always
+    // rejected, regardless of which env this test suite runs under.
+    const url =
+      "vellum-assistant-nonexistent://auth/callback?code=abc&state=xyz";
+    expect(parseVellumUrl(url)).toEqual({ kind: "unknown", url });
   });
 });
 
@@ -288,7 +279,7 @@ describe("extractDeepLinkFromArgv", () => {
 });
 
 describe("installDeepLinks", () => {
-  test("registers schemes with Launch Services and is idempotent across repeated calls", () => {
+  test("registers only the env-appropriate schemes and is idempotent across repeated calls", () => {
     installDeepLinks();
     const firstCallCount = setAsDefaultProtocolClientMock.mock.calls.length;
 
@@ -296,8 +287,8 @@ describe("installDeepLinks", () => {
     installDeepLinks();
 
     const schemes = setAsDefaultProtocolClientMock.mock.calls.map((c) => c[0]);
-    expect(schemes).toContain("vellum");
-    expect(schemes).toContain("vellum-assistant");
+    const expected = resolveRegisteredSchemes(resolveEnvironmentName(process.env));
+    expect(schemes).toEqual(expected);
     // Idempotent — repeated calls don't register again.
     expect(setAsDefaultProtocolClientMock).toHaveBeenCalledTimes(firstCallCount);
   });
@@ -559,6 +550,68 @@ describe("handleDeepLink — window activation", () => {
     expect(drain(allowedEvent)).toEqual([
       { kind: "send", message: "delivered" },
     ]);
+  });
+});
+
+describe("resolveRegisteredSchemes", () => {
+  test("production registers vellum and vellum-assistant", () => {
+    expect(resolveRegisteredSchemes("production")).toEqual([
+      "vellum",
+      "vellum-assistant",
+    ]);
+  });
+
+  test("dev registers only vellum-assistant-dev", () => {
+    expect(resolveRegisteredSchemes("dev")).toEqual(["vellum-assistant-dev"]);
+  });
+
+  test("staging registers only vellum-assistant-staging", () => {
+    expect(resolveRegisteredSchemes("staging")).toEqual([
+      "vellum-assistant-staging",
+    ]);
+  });
+
+  test("local registers only vellum-assistant-local", () => {
+    expect(resolveRegisteredSchemes("local")).toEqual([
+      "vellum-assistant-local",
+    ]);
+  });
+
+  test("unknown env falls back to production callback scheme without claiming vellum://", () => {
+    expect(resolveRegisteredSchemes("unknown")).toEqual(["vellum-assistant"]);
+  });
+});
+
+describe("resolveAcceptedSchemes", () => {
+  test("production accepts vellum: and vellum-assistant:", () => {
+    const accepted = resolveAcceptedSchemes("production");
+    expect(accepted).toContain("vellum:");
+    expect(accepted).toContain("vellum-assistant:");
+    expect(accepted).toHaveLength(2);
+  });
+
+  test("dev accepts vellum:, vellum-assistant:, and vellum-assistant-dev:", () => {
+    const accepted = resolveAcceptedSchemes("dev");
+    expect(accepted).toContain("vellum:");
+    expect(accepted).toContain("vellum-assistant:");
+    expect(accepted).toContain("vellum-assistant-dev:");
+    expect(accepted).toHaveLength(3);
+  });
+
+  test("staging accepts vellum:, vellum-assistant:, and vellum-assistant-staging:", () => {
+    const accepted = resolveAcceptedSchemes("staging");
+    expect(accepted).toContain("vellum:");
+    expect(accepted).toContain("vellum-assistant:");
+    expect(accepted).toContain("vellum-assistant-staging:");
+    expect(accepted).toHaveLength(3);
+  });
+
+  test("local accepts vellum:, vellum-assistant:, and vellum-assistant-local:", () => {
+    const accepted = resolveAcceptedSchemes("local");
+    expect(accepted).toContain("vellum:");
+    expect(accepted).toContain("vellum-assistant:");
+    expect(accepted).toContain("vellum-assistant-local:");
+    expect(accepted).toHaveLength(3);
   });
 });
 

--- a/apps/macos/src/main/deep-links.ts
+++ b/apps/macos/src/main/deep-links.ts
@@ -55,29 +55,26 @@ export type DeepLink =
   | { kind: "authCallback"; state: string; code?: string; error?: string }
   | { kind: "unknown"; url: string };
 
-const SCHEME_BY_ENV: Record<string, string> = {
-  production: "vellum-assistant",
-  staging: "vellum-assistant-staging",
-  dev: "vellum-assistant-dev",
-  local: "vellum-assistant-local",
-};
+const PRODUCTION_SCHEME = "vellum-assistant";
+
+function schemeForEnv(env: string): string {
+  return env === "production" ? PRODUCTION_SCHEME : `${PRODUCTION_SCHEME}-${env}`;
+}
 
 // Schemes to REGISTER with the OS via `app.setAsDefaultProtocolClient`.
 // Production claims both `vellum` and `vellum-assistant`; non-production
 // claims only the env-specific scheme to avoid hijacking production.
 export function resolveRegisteredSchemes(env: string): string[] {
-  const envScheme = SCHEME_BY_ENV[env] ?? SCHEME_BY_ENV.production;
-  if (env === "production") return ["vellum", envScheme];
-  return [envScheme];
+  if (env === "production") return ["vellum", PRODUCTION_SCHEME];
+  return [schemeForEnv(env)];
 }
 
 // Schemes to ACCEPT when parsing inbound URLs. Superset of registered
 // schemes — always includes `vellum:` and `vellum-assistant:` so URLs
 // routed to this build still parse correctly.
 export function resolveAcceptedSchemes(env: string): string[] {
-  const envScheme = SCHEME_BY_ENV[env];
-  const accepted = new Set(["vellum:", "vellum-assistant:"]);
-  if (envScheme) accepted.add(`${envScheme}:`);
+  const accepted = new Set(["vellum:", `${PRODUCTION_SCHEME}:`]);
+  if (env !== "production") accepted.add(`${schemeForEnv(env)}:`);
   return [...accepted];
 }
 

--- a/apps/macos/src/main/deep-links.ts
+++ b/apps/macos/src/main/deep-links.ts
@@ -55,8 +55,6 @@ export type DeepLink =
   | { kind: "authCallback"; state: string; code?: string; error?: string }
   | { kind: "unknown"; url: string };
 
-const BASE_SCHEMES = ["vellum:", "vellum-assistant:"] as const;
-
 const SCHEME_BY_ENV: Record<string, string> = {
   production: "vellum-assistant",
   staging: "vellum-assistant-staging",
@@ -64,28 +62,39 @@ const SCHEME_BY_ENV: Record<string, string> = {
   local: "vellum-assistant-local",
 };
 
-function resolveAcceptedSchemes(): string[] {
-  const schemes = [...BASE_SCHEMES] as string[];
-  const env = resolveEnvironmentName(process.env);
-  const envScheme = SCHEME_BY_ENV[env];
-  if (envScheme) {
-    const withColon = `${envScheme}:`;
-    if (!schemes.includes(withColon)) schemes.push(withColon);
-  }
-  return schemes;
+// Schemes to REGISTER with the OS via `app.setAsDefaultProtocolClient`.
+// Production claims both `vellum` and `vellum-assistant`; non-production
+// claims only the env-specific scheme to avoid hijacking production.
+export function resolveRegisteredSchemes(env: string): string[] {
+  const envScheme = SCHEME_BY_ENV[env] ?? SCHEME_BY_ENV.production;
+  if (env === "production") return ["vellum", envScheme];
+  return [envScheme];
 }
 
-const ACCEPTED_SCHEMES = resolveAcceptedSchemes();
+// Schemes to ACCEPT when parsing inbound URLs. Superset of registered
+// schemes — always includes `vellum:` and `vellum-assistant:` so URLs
+// routed to this build still parse correctly.
+export function resolveAcceptedSchemes(env: string): string[] {
+  const envScheme = SCHEME_BY_ENV[env];
+  const accepted = new Set(["vellum:", "vellum-assistant:"]);
+  if (envScheme) accepted.add(`${envScheme}:`);
+  return [...accepted];
+}
+
+const currentEnv = resolveEnvironmentName(process.env);
+const REGISTERED_SCHEMES = resolveRegisteredSchemes(currentEnv);
+const ACCEPTED_SCHEMES = resolveAcceptedSchemes(currentEnv);
 
 /**
  * Pure parser: URL string → typed `DeepLink`. Exported for unit tests.
  *
  * Rules:
  *
- *   - Scheme MUST be `vellum:` or `vellum-assistant:`. Anything else
- *     (`javascript:`, `data:`, `file:`, foreign customs) is rejected
- *     as `kind: "unknown"` — the renderer additionally defensively
- *     validates before dispatching.
+ *   - Scheme MUST be in the accepted set (`vellum:`, `vellum-assistant:`,
+ *     plus the env-specific scheme like `vellum-assistant-dev:`).
+ *     Anything else (`javascript:`, `data:`, `file:`, foreign customs)
+ *     is rejected as `kind: "unknown"` — the renderer additionally
+ *     defensively validates before dispatching.
  *   - `vellum://send?message=…` → `{ kind: "send", message }`. Empty
  *     `message` is preserved (renderer can decide to open an empty
  *     composer).
@@ -224,14 +233,12 @@ export const installDeepLinks = (): void => {
   if (installed) return;
   installed = true;
 
-  // Dynamic registration. Packaged builds also declare these in
-  // `electron-builder.yml`'s `protocols` (so `Info.plist` carries
-  // `CFBundleURLTypes`); the dynamic call is required for dev and
-  // defensive for prod. Includes the environment-specific callback
-  // scheme (e.g. `vellum-assistant-dev`) so the OS routes OAuth
-  // callbacks from the system browser back to this instance.
-  for (const scheme of ACCEPTED_SCHEMES) {
-    app.setAsDefaultProtocolClient(scheme.replace(/:$/, ""));
+  // Dynamic registration — only claim the schemes this build owns.
+  // Non-production builds register only their env-specific scheme
+  // (e.g. `vellum-assistant-dev`) to avoid hijacking production
+  // callbacks when both apps coexist.
+  for (const scheme of REGISTERED_SCHEMES) {
+    app.setAsDefaultProtocolClient(scheme);
   }
 
   app.on("will-finish-launching", () => {


### PR DESCRIPTION
## Summary
- Non-production Electron builds no longer register the production `vellum-assistant://` or `vellum://` URL schemes — they only claim their env-specific scheme (e.g. `vellum-assistant-dev`)
- Split `ACCEPTED_SCHEMES` into `REGISTERED_SCHEMES` (for `app.setAsDefaultProtocolClient`) and `ACCEPTED_SCHEMES` (for URL parsing), so non-production builds parse liberally but register conservatively
- Updated `electron-builder.config.cjs` to only include the env-specific scheme in `Info.plist` for non-production builds

## Original prompt
This addresses LUM-2272, which was surfaced during review of PR #33782 (environment-aware bundle IDs). That PR gave non-production builds distinct bundle IDs so they can coexist alongside production, but didn't scope the URL scheme registration — so a dev build could claim ownership of `vellum-assistant://` from Launch Services and steal production OAuth callbacks. The fix scopes both the static `Info.plist` registration and the dynamic `app.setAsDefaultProtocolClient` call to only register the env-specific scheme for non-production builds, while keeping the URL parser accepting all known schemes so inbound URLs still work if routed to the wrong build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)