### PR TITLE
fix(web): guard onboarding routes for users with existing assistants

### DIFF
--- a/apps/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/apps/web/src/lib/navigation/navigation-resolver.test.ts
@@ -99,9 +99,15 @@ describe("resolveNavigation", () => {
 
     // -- authenticated, onboarding routes ---------------------------------
 
-    test("allows authenticated user on onboarding route", () => {
+    test("redirects authenticated user with assistants away from new-user onboarding", () => {
       expect(
         guard(s({}), "/assistant/onboarding/privacy"),
+      ).toEqual({ action: "redirect", to: "/assistant" });
+    });
+
+    test("allows authenticated user without assistants on onboarding route", () => {
+      expect(
+        guard(s({ hasAssistants: false }), "/assistant/onboarding/privacy"),
       ).toEqual(ALLOW);
     });
 
@@ -113,11 +119,11 @@ describe("resolveNavigation", () => {
 
     test("query strings do not break onboarding path matching", () => {
       expect(
-        guard(s({}), "/assistant/onboarding/privacy?replay=1"),
+        guard(s({ hasAssistants: false }), "/assistant/onboarding/privacy?replay=1"),
       ).toEqual(ALLOW);
       expect(
         guard(
-          s({ tosAccepted: true, aiDataConsent: true }),
+          s({ hasAssistants: false, tosAccepted: true, aiDataConsent: true }),
           "/assistant/onboarding/hatching?hosting=local",
         ),
       ).toEqual(ALLOW);
@@ -147,19 +153,55 @@ describe("resolveNavigation", () => {
       ).toEqual({ action: "redirect", to: "/assistant" });
     });
 
-    test("allows non-local user on shared onboarding screens", () => {
+    test("redirects non-local user with assistants from shared onboarding screens", () => {
       expect(
         guard(s({ isLocalMode: false }), "/assistant/onboarding/privacy"),
-      ).toEqual(ALLOW);
+      ).toEqual({ action: "redirect", to: "/assistant" });
       expect(
         guard(s({ isLocalMode: false }), "/assistant/onboarding/prechat"),
+      ).toEqual({ action: "redirect", to: "/assistant" });
+    });
+
+    test("allows non-local user without assistants on shared onboarding screens", () => {
+      expect(
+        guard(s({ isLocalMode: false, hasAssistants: false }), "/assistant/onboarding/privacy"),
+      ).toEqual(ALLOW);
+      expect(
+        guard(s({ isLocalMode: false, hasAssistants: false }), "/assistant/onboarding/prechat"),
       ).toEqual(ALLOW);
     });
 
-    test("redirects from hatching without consent", () => {
+    test("redirects user with assistants from hatching to review-terms when consent missing", () => {
       expect(
         guard(
           s({ tosAccepted: false, aiDataConsent: false }),
+          "/assistant/onboarding/hatching",
+        ),
+      ).toEqual({ action: "redirect", to: "/assistant/onboarding/review-terms?returnTo=%2Fassistant%2Fonboarding%2Fhatching" });
+    });
+
+    test("redirects user with assistants from hatching to /assistant when consent present", () => {
+      expect(
+        guard(
+          s({ tosAccepted: true, aiDataConsent: true }),
+          "/assistant/onboarding/hatching",
+        ),
+      ).toEqual({ action: "redirect", to: "/assistant" });
+    });
+
+    test("redirects user with assistants from hatching to review-terms with partial consent", () => {
+      expect(
+        guard(
+          s({ tosAccepted: true, aiDataConsent: false }),
+          "/assistant/onboarding/hatching",
+        ),
+      ).toEqual({ action: "redirect", to: "/assistant/onboarding/review-terms?returnTo=%2Fassistant%2Fonboarding%2Fhatching" });
+    });
+
+    test("redirects from hatching without consent to privacy when no assistants", () => {
+      expect(
+        guard(
+          s({ hasAssistants: false, tosAccepted: false, aiDataConsent: false }),
           "/assistant/onboarding/hatching",
         ),
       ).toEqual({ action: "redirect", to: "/assistant/onboarding/privacy" });
@@ -174,22 +216,13 @@ describe("resolveNavigation", () => {
       ).toEqual({ action: "redirect", to: "/assistant/onboarding/welcome" });
     });
 
-    test("allows hatching with consent", () => {
+    test("allows hatching with consent when no assistants", () => {
       expect(
         guard(
-          s({ tosAccepted: true, aiDataConsent: true }),
+          s({ hasAssistants: false, tosAccepted: true, aiDataConsent: true }),
           "/assistant/onboarding/hatching",
         ),
       ).toEqual(ALLOW);
-    });
-
-    test("allows hatching with only tos (not ai data consent) — should redirect", () => {
-      expect(
-        guard(
-          s({ tosAccepted: true, aiDataConsent: false }),
-          "/assistant/onboarding/hatching",
-        ),
-      ).toEqual({ action: "redirect", to: "/assistant/onboarding/privacy" });
     });
 
     // -- authenticated, local mode, no assistants -------------------------

--- a/apps/web/src/lib/navigation/navigation-resolver.ts
+++ b/apps/web/src/lib/navigation/navigation-resolver.ts
@@ -166,6 +166,13 @@ function resolveRouteGuard(
     if (path === routes.onboarding.selectAssistant && !state.hasAssistants) {
       return { action: "redirect", to: routes.onboarding.hosting };
     }
+    if (state.hasAssistants && !state.isLocalMode && path !== routes.onboarding.reviewTerms) {
+      if (!(state.tosAccepted && state.aiDataConsent)) {
+        const returnTo = encodeURIComponent(pathnameWithSearch);
+        return { action: "redirect", to: `${routes.onboarding.reviewTerms}?returnTo=${returnTo}` };
+      }
+      return { action: "redirect", to: routes.assistant };
+    }
     if (path === routes.onboarding.hatching && !(state.tosAccepted && state.aiDataConsent)) {
       return { action: "redirect", to: onboardingEntrypoint(state.isLocalMode) };
     }


### PR DESCRIPTION
## Summary

- Platform-mode users with existing assistants could navigate directly to `/onboarding/privacy`, `/onboarding/prechat`, or `/onboarding/hatching` and get funneled into hatching a duplicate assistant
- Adds a new check in the route guard (step 4) that redirects these users to `/review-terms` (if consent is missing) or `/assistant` (if already consented)
- `/onboarding/review-terms` is exempt since it's designed for existing users re-accepting updated terms
- Local mode is unaffected (handled by separate existing logic)

## Test plan

- [x] All 63 navigation-resolver tests pass
- [ ] Verify a platform-mode user with an existing assistant cannot reach `/onboarding/privacy` directly
- [ ] Verify a platform-mode user with an existing assistant and missing consent is redirected to `/review-terms`
- [ ] Verify a new user without assistants can still complete the full onboarding funnel (privacy → prechat → hatching)
- [ ] Verify local-mode onboarding is unaffected


🤖 Generated with [Claude Code](https://claude.com/claude-code)