### PR TITLE
refactor(web): move welcome, select-assistant, review-terms out of /onboarding/ prefix

### DIFF
--- a/apps/web/src/assistant/retire-service.test.ts
+++ b/apps/web/src/assistant/retire-service.test.ts
@@ -41,10 +41,10 @@ mock.module("@/lib/navigation/navigation-resolver", () => ({
     query: { kind: string },
   ) => {
     if (query.kind !== "post-retire") return { action: "allow" };
-    if (state.hasAssistants) return { action: "redirect", to: state.isLocalMode ? "/assistant/onboarding/select-assistant" : "/assistant" };
+    if (state.hasAssistants) return { action: "redirect", to: state.isLocalMode ? "/assistant/select-assistant" : "/assistant" };
     if (!state.isLocalMode) return { action: "redirect", to: "/assistant/onboarding/privacy" };
     if (state.platformSession === "present") return { action: "redirect", to: "/assistant/onboarding/hosting" };
-    return { action: "redirect", to: "/assistant/onboarding/welcome" };
+    return { action: "redirect", to: "/assistant/welcome" };
   },
 }));
 mock.module("@/lib/navigation/build-state", () => ({
@@ -68,9 +68,9 @@ mock.module("@/stores/resolved-assistants-store", () => ({
 mock.module("@/utils/routes", () => ({
   routes: {
     assistant: "/assistant",
+    welcome: "/assistant/welcome",
+    selectAssistant: "/assistant/select-assistant",
     onboarding: {
-      welcome: "/assistant/onboarding/welcome",
-      selectAssistant: "/assistant/onboarding/select-assistant",
       hosting: "/assistant/onboarding/hosting",
       prechat: "/assistant/onboarding/prechat",
       privacy: "/assistant/onboarding/privacy",
@@ -181,7 +181,7 @@ describe("retireAssistant", () => {
 
     expect(outcome.ok).toBe(true);
     if (outcome.ok) {
-      expect(outcome.nextRoute).toBe("/assistant/onboarding/select-assistant");
+      expect(outcome.nextRoute).toBe("/assistant/select-assistant");
     }
   });
 
@@ -194,7 +194,7 @@ describe("retireAssistant", () => {
 
     expect(outcome.ok).toBe(true);
     if (outcome.ok) {
-      expect(outcome.nextRoute).toBe("/assistant/onboarding/welcome");
+      expect(outcome.nextRoute).toBe("/assistant/welcome");
     }
   });
 });

--- a/apps/web/src/assistant/retire-service.ts
+++ b/apps/web/src/assistant/retire-service.ts
@@ -31,7 +31,7 @@ function getPostRetireRoute(): string {
   });
   return decision.action === "redirect"
     ? decision.to
-    : routes.onboarding.welcome;
+    : routes.welcome;
 }
 
 /**

--- a/apps/web/src/domains/account/pages/platform-loopback-page.tsx
+++ b/apps/web/src/domains/account/pages/platform-loopback-page.tsx
@@ -83,7 +83,7 @@ export function PlatformLoopbackPage() {
           <button
             type="button"
             className="mt-4 rounded-lg border border-[var(--border-disabled)] px-4 py-2 text-sm hover:bg-[var(--surface-lift)]"
-            onClick={() => void navigate(routes.onboarding.welcome)}
+            onClick={() => void navigate(routes.welcome)}
           >
             Back to Welcome
           </button>

--- a/apps/web/src/domains/onboarding/gate.ts
+++ b/apps/web/src/domains/onboarding/gate.ts
@@ -16,5 +16,5 @@ export function resolveOnboardingRedirect({
 }
 
 export function getOnboardingEntrypoint(): string {
-  return isLocalMode() ? routes.onboarding.welcome : routes.onboarding.privacy;
+  return isLocalMode() ? routes.welcome : routes.onboarding.privacy;
 }

--- a/apps/web/src/domains/onboarding/pages/hosting-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hosting-screen.tsx
@@ -111,8 +111,8 @@ export function HostingScreen() {
   const onBack = () => {
     void navigate(
       fromSelectAssistant
-        ? routes.onboarding.selectAssistant
-        : routes.onboarding.welcome,
+        ? routes.selectAssistant
+        : routes.welcome,
     );
   };
 

--- a/apps/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -92,7 +92,7 @@ export function SelectAssistantScreen() {
   };
 
   const onBack = () => {
-    void navigate(routes.onboarding.welcome);
+    void navigate(routes.welcome);
   };
 
   const displayError = loginError ?? error;

--- a/apps/web/src/domains/onboarding/pages/welcome-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/welcome-screen.tsx
@@ -13,7 +13,7 @@ export function WelcomeScreen() {
   const handleContinueWithoutAccount = () => {
     if (loading) cancel();
     if (hasAssistants()) {
-      void navigate(routes.onboarding.selectAssistant);
+      void navigate(routes.selectAssistant);
     } else {
       void navigate(routes.onboarding.hosting);
     }

--- a/apps/web/src/hooks/use-onboarding-window-size.test.tsx
+++ b/apps/web/src/hooks/use-onboarding-window-size.test.tsx
@@ -31,7 +31,7 @@ afterEach(() => {
 
 describe("useOnboardingWindowSize", () => {
   test("requests the small onboarding window on an onboarding route", () => {
-    currentPath = "/assistant/onboarding/welcome";
+    currentPath = "/assistant/welcome";
     renderHook(() => useOnboardingWindowSize());
     expect(setOnboardingWindowMock).toHaveBeenLastCalledWith(true);
   });
@@ -60,7 +60,9 @@ describe("useOnboardingWindowSize", () => {
 
   test("covers every onboarding step under the shared prefix", () => {
     for (const step of [
-      "/assistant/onboarding/welcome",
+      "/assistant/welcome",
+      "/assistant/select-assistant",
+      "/assistant/review-terms",
       "/assistant/onboarding/hosting",
       "/assistant/onboarding/api-key",
       "/assistant/onboarding/privacy",

--- a/apps/web/src/hooks/use-onboarding-window-size.ts
+++ b/apps/web/src/hooks/use-onboarding-window-size.ts
@@ -20,7 +20,13 @@ import { setOnboardingWindow } from "@/runtime/main-window";
  * targets the main window, so signalling from any non-main window would
  * resize the wrong window.
  */
-const COMPACT_PATH_PREFIXES = ["/assistant/onboarding/", "/account"];
+const COMPACT_PATH_PREFIXES = [
+  "/assistant/onboarding/",
+  "/assistant/welcome",
+  "/assistant/select-assistant",
+  "/assistant/review-terms",
+  "/account",
+];
 
 function isCompactRoute(pathname: string): boolean {
   return COMPACT_PATH_PREFIXES.some((prefix) => pathname.startsWith(prefix));

--- a/apps/web/src/lib/auth/auth-middleware.test.ts
+++ b/apps/web/src/lib/auth/auth-middleware.test.ts
@@ -82,7 +82,7 @@ describe("authMiddleware — local-mode onboarding fork", () => {
 
     const res = await runMiddleware(routes.home);
     expect(res.status).toBe(302);
-    expect(res.headers.get("Location")).toBe(routes.onboarding.welcome);
+    expect(res.headers.get("Location")).toBe(routes.welcome);
   });
 
   test("routes to hosting when a resolved platform session exists", async () => {

--- a/apps/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/apps/web/src/lib/navigation/navigation-resolver.test.ts
@@ -62,7 +62,7 @@ describe("resolveNavigation", () => {
       expect(
         guard(
           s({ isAuthenticated: false, isLocalMode: true, hasAssistants: false }),
-          "/assistant/onboarding/welcome",
+          "/assistant/welcome",
         ),
       ).toEqual(ALLOW);
     });
@@ -71,7 +71,7 @@ describe("resolveNavigation", () => {
       expect(
         guard(
           s({ isAuthenticated: false, isLocalMode: true, hasAssistants: true }),
-          "/assistant/onboarding/select-assistant",
+          "/assistant/select-assistant",
         ),
       ).toEqual(ALLOW);
     });
@@ -80,7 +80,7 @@ describe("resolveNavigation", () => {
       expect(
         guard(
           s({ isAuthenticated: false, isLocalMode: true, hasAssistants: false }),
-          "/assistant/onboarding/select-assistant",
+          "/assistant/select-assistant",
         ),
       ).toEqual({ action: "redirect", to: "/assistant/onboarding/hosting" });
     });
@@ -88,13 +88,13 @@ describe("resolveNavigation", () => {
     test("redirects unauthenticated local-mode fresh user to welcome", () => {
       expect(
         guard(s({ isAuthenticated: false, isLocalMode: true, hasAssistants: false })),
-      ).toEqual({ action: "redirect", to: "/assistant/onboarding/welcome" });
+      ).toEqual({ action: "redirect", to: "/assistant/welcome" });
     });
 
     test("redirects unauthenticated local-mode returning user (has assistants) to select-assistant", () => {
       expect(
         guard(s({ isAuthenticated: false, isLocalMode: true, hasAssistants: true })),
-      ).toEqual({ action: "redirect", to: "/assistant/onboarding/select-assistant" });
+      ).toEqual({ action: "redirect", to: "/assistant/select-assistant" });
     });
 
     // -- authenticated, onboarding routes ---------------------------------
@@ -113,7 +113,7 @@ describe("resolveNavigation", () => {
 
     test("allows authenticated user on review-terms route", () => {
       expect(
-        guard(s({}), "/assistant/onboarding/review-terms"),
+        guard(s({}), "/assistant/review-terms"),
       ).toEqual(ALLOW);
     });
 
@@ -133,17 +133,17 @@ describe("resolveNavigation", () => {
       expect(
         guard(
           s({ isLocalMode: true, hasAssistants: false }),
-          "/assistant/onboarding/select-assistant",
+          "/assistant/select-assistant",
         ),
       ).toEqual({ action: "redirect", to: "/assistant/onboarding/hosting" });
     });
 
     test("redirects non-local user from local-only onboarding screen", () => {
       expect(
-        guard(s({ isLocalMode: false }), "/assistant/onboarding/welcome"),
+        guard(s({ isLocalMode: false }), "/assistant/welcome"),
       ).toEqual({ action: "redirect", to: "/assistant" });
       expect(
-        guard(s({ isLocalMode: false }), "/assistant/onboarding/select-assistant"),
+        guard(s({ isLocalMode: false }), "/assistant/select-assistant"),
       ).toEqual({ action: "redirect", to: "/assistant" });
       expect(
         guard(s({ isLocalMode: false }), "/assistant/onboarding/hosting"),
@@ -177,7 +177,7 @@ describe("resolveNavigation", () => {
           s({ tosAccepted: false, aiDataConsent: false }),
           "/assistant/onboarding/hatching",
         ),
-      ).toEqual({ action: "redirect", to: "/assistant/onboarding/review-terms?returnTo=%2Fassistant%2Fonboarding%2Fhatching" });
+      ).toEqual({ action: "redirect", to: "/assistant/review-terms?returnTo=%2Fassistant%2Fonboarding%2Fhatching" });
     });
 
     test("redirects user with assistants from hatching to /assistant when consent present", () => {
@@ -195,7 +195,7 @@ describe("resolveNavigation", () => {
           s({ tosAccepted: true, aiDataConsent: false }),
           "/assistant/onboarding/hatching",
         ),
-      ).toEqual({ action: "redirect", to: "/assistant/onboarding/review-terms?returnTo=%2Fassistant%2Fonboarding%2Fhatching" });
+      ).toEqual({ action: "redirect", to: "/assistant/review-terms?returnTo=%2Fassistant%2Fonboarding%2Fhatching" });
     });
 
     test("redirects from hatching without consent to privacy when no assistants", () => {
@@ -213,7 +213,7 @@ describe("resolveNavigation", () => {
           s({ isLocalMode: true, tosAccepted: false, aiDataConsent: false }),
           "/assistant/onboarding/hatching",
         ),
-      ).toEqual({ action: "redirect", to: "/assistant/onboarding/welcome" });
+      ).toEqual({ action: "redirect", to: "/assistant/welcome" });
     });
 
     test("allows hatching with consent when no assistants", () => {
@@ -242,7 +242,7 @@ describe("resolveNavigation", () => {
     test("redirects to welcome when local mode + no platform session", () => {
       expect(
         guard(s({ isLocalMode: true, hasAssistants: false, platformSession: "absent" })),
-      ).toEqual({ action: "redirect", to: "/assistant/onboarding/welcome" });
+      ).toEqual({ action: "redirect", to: "/assistant/welcome" });
     });
 
     test("allows local mode with assistants", () => {
@@ -254,13 +254,13 @@ describe("resolveNavigation", () => {
     test("redirects platform-mode user without consent to review-terms with returnTo", () => {
       expect(
         guard(s({ isLocalMode: false, tosAccepted: false, aiDataConsent: false })),
-      ).toEqual({ action: "redirect", to: "/assistant/onboarding/review-terms?returnTo=%2Fassistant" });
+      ).toEqual({ action: "redirect", to: "/assistant/review-terms?returnTo=%2Fassistant" });
     });
 
     test("redirects platform-mode user with partial consent to review-terms with returnTo", () => {
       expect(
         guard(s({ isLocalMode: false, tosAccepted: true, aiDataConsent: false })),
-      ).toEqual({ action: "redirect", to: "/assistant/onboarding/review-terms?returnTo=%2Fassistant" });
+      ).toEqual({ action: "redirect", to: "/assistant/review-terms?returnTo=%2Fassistant" });
     });
 
     test("redirects platform-mode user without consent and no assistants to privacy without returnTo", () => {
@@ -314,7 +314,7 @@ describe("resolveNavigation", () => {
     test("redirects to welcome in local mode", () => {
       expect(
         intercept(s({ isLocalMode: true, hasAssistants: false, tosAccepted: false, aiDataConsent: false }), "/assistant"),
-      ).toEqual({ action: "redirect", to: "/assistant/onboarding/welcome" });
+      ).toEqual({ action: "redirect", to: "/assistant/welcome" });
     });
 
     test("redirects to privacy in platform mode", () => {
@@ -364,7 +364,7 @@ describe("resolveNavigation", () => {
     test("redirects unauthenticated local-mode user without consent to welcome", () => {
       expect(hatch(s({ isAuthenticated: false, isLocalMode: true, tosAccepted: false, aiDataConsent: false }))).toEqual({
         action: "redirect",
-        to: "/assistant/onboarding/welcome",
+        to: "/assistant/welcome",
       });
     });
 
@@ -385,7 +385,7 @@ describe("resolveNavigation", () => {
     test("redirects to welcome in local mode when missing consent", () => {
       expect(
         hatch(s({ isLocalMode: true, tosAccepted: false, aiDataConsent: false })),
-      ).toEqual({ action: "redirect", to: "/assistant/onboarding/welcome" });
+      ).toEqual({ action: "redirect", to: "/assistant/welcome" });
     });
 
     test("allows with full consent", () => {
@@ -403,7 +403,7 @@ describe("resolveNavigation", () => {
     test("redirects to select-assistant in local mode when other assistants remain", () => {
       expect(postRetire(s({ hasAssistants: true, isLocalMode: true }))).toEqual({
         action: "redirect",
-        to: "/assistant/onboarding/select-assistant",
+        to: "/assistant/select-assistant",
       });
     });
 
@@ -435,7 +435,7 @@ describe("resolveNavigation", () => {
         postRetire(s({ hasAssistants: false, isLocalMode: true, platformSession: "absent" })),
       ).toEqual({
         action: "redirect",
-        to: "/assistant/onboarding/welcome",
+        to: "/assistant/welcome",
       });
     });
   });
@@ -489,8 +489,8 @@ describe("resolveNavigation", () => {
   describe("resolveLoginReturnTo", () => {
     test("returns select-assistant from welcome when assistants exist", () => {
       expect(
-        resolveLoginReturnTo(s({ hasAssistants: true }), "/assistant/onboarding/welcome"),
-      ).toBe("/assistant/onboarding/select-assistant");
+        resolveLoginReturnTo(s({ hasAssistants: true }), "/assistant/welcome"),
+      ).toBe("/assistant/select-assistant");
     });
 
     test("returns hosting from welcome when no assistants", () => {
@@ -501,8 +501,8 @@ describe("resolveNavigation", () => {
 
     test("appends fromLogin param when logging in from select-assistant", () => {
       expect(
-        resolveLoginReturnTo(s({}), "/assistant/onboarding/select-assistant"),
-      ).toBe("/assistant/onboarding/select-assistant?fromLogin=1");
+        resolveLoginReturnTo(s({}), "/assistant/select-assistant"),
+      ).toBe("/assistant/select-assistant?fromLogin=1");
     });
 
     test("returns the same path for other non-welcome pages", () => {

--- a/apps/web/src/lib/navigation/navigation-resolver.ts
+++ b/apps/web/src/lib/navigation/navigation-resolver.ts
@@ -49,10 +49,13 @@ export type NavigationDecision =
 const ONBOARDING_PREFIX = `${routes.assistant}/onboarding`;
 
 const LOCAL_ONLY_ONBOARDING_PATHS: Set<string> = new Set([
-  routes.onboarding.welcome,
-  routes.onboarding.selectAssistant,
   routes.onboarding.hosting,
   routes.onboarding.apiKey,
+]);
+
+const LOCAL_ONLY_STANDALONE_PATHS: Set<string> = new Set([
+  routes.welcome,
+  routes.selectAssistant,
 ]);
 
 function isOnboardingPath(pathname: string): boolean {
@@ -60,7 +63,7 @@ function isOnboardingPath(pathname: string): boolean {
 }
 
 function onboardingEntrypoint(isLocalMode: boolean): string {
-  return isLocalMode ? routes.onboarding.welcome : routes.onboarding.privacy;
+  return isLocalMode ? routes.welcome : routes.onboarding.privacy;
 }
 
 function extractPathname(destination: string): string {
@@ -86,12 +89,12 @@ export function resolveLoginReturnTo(
   state: NavigationState,
   fromPath: string,
 ): string {
-  if (fromPath === routes.onboarding.welcome) {
+  if (fromPath === routes.welcome) {
     return state.hasAssistants
-      ? routes.onboarding.selectAssistant
+      ? routes.selectAssistant
       : routes.onboarding.hosting;
   }
-  if (fromPath === routes.onboarding.selectAssistant) {
+  if (fromPath === routes.selectAssistant) {
     return `${fromPath}?fromLogin=1`;
   }
   return fromPath;
@@ -140,17 +143,17 @@ function resolveRouteGuard(
 
   // 3. Unauthenticated
   if (!state.isAuthenticated) {
-    if (state.isLocalMode && isOnboardingPath(path)) {
-      if (path === routes.onboarding.selectAssistant && !state.hasAssistants) {
+    if (state.isLocalMode && (isOnboardingPath(path) || LOCAL_ONLY_STANDALONE_PATHS.has(path))) {
+      if (path === routes.selectAssistant && !state.hasAssistants) {
         return { action: "redirect", to: routes.onboarding.hosting };
       }
       return { action: "allow" };
     }
     if (state.isLocalMode && !state.hasAssistants) {
-      return { action: "redirect", to: routes.onboarding.welcome };
+      return { action: "redirect", to: routes.welcome };
     }
     if (state.isLocalMode) {
-      return { action: "redirect", to: routes.onboarding.selectAssistant };
+      return { action: "redirect", to: routes.selectAssistant };
     }
     return {
       action: "redirect",
@@ -158,18 +161,29 @@ function resolveRouteGuard(
     };
   }
 
-  // 4. Authenticated, on an onboarding route
+  // 4a. Authenticated, local-only standalone paths (welcome, select-assistant)
+  if (LOCAL_ONLY_STANDALONE_PATHS.has(path)) {
+    if (!state.isLocalMode) {
+      return { action: "redirect", to: routes.assistant };
+    }
+    if (path === routes.selectAssistant && !state.hasAssistants) {
+      return { action: "redirect", to: routes.onboarding.hosting };
+    }
+    return { action: "allow" };
+  }
+
+  // 4b. Authenticated, review-terms (consent gate for existing users)
+  if (path === routes.reviewTerms) return { action: "allow" };
+
+  // 4c. Authenticated, on an onboarding route
   if (isOnboardingPath(path)) {
     if (LOCAL_ONLY_ONBOARDING_PATHS.has(path) && !state.isLocalMode) {
       return { action: "redirect", to: routes.assistant };
     }
-    if (path === routes.onboarding.selectAssistant && !state.hasAssistants) {
-      return { action: "redirect", to: routes.onboarding.hosting };
-    }
-    if (state.hasAssistants && !state.isLocalMode && path !== routes.onboarding.reviewTerms) {
+    if (state.hasAssistants && !state.isLocalMode) {
       if (!(state.tosAccepted && state.aiDataConsent)) {
         const returnTo = encodeURIComponent(pathnameWithSearch);
-        return { action: "redirect", to: `${routes.onboarding.reviewTerms}?returnTo=${returnTo}` };
+        return { action: "redirect", to: `${routes.reviewTerms}?returnTo=${returnTo}` };
       }
       return { action: "redirect", to: routes.assistant };
     }
@@ -185,14 +199,14 @@ function resolveRouteGuard(
     if (state.platformSession === "present") {
       return { action: "redirect", to: routes.onboarding.hosting };
     }
-    return { action: "redirect", to: routes.onboarding.welcome };
+    return { action: "redirect", to: routes.welcome };
   }
 
   // 6. Authenticated, platform mode, onboarding not completed
   if (!state.isLocalMode && !(state.tosAccepted && state.aiDataConsent)) {
     if (state.hasAssistants) {
       const returnTo = encodeURIComponent(pathnameWithSearch);
-      return { action: "redirect", to: `${routes.onboarding.reviewTerms}?returnTo=${returnTo}` };
+      return { action: "redirect", to: `${routes.reviewTerms}?returnTo=${returnTo}` };
     }
     return { action: "redirect", to: routes.onboarding.privacy };
   }
@@ -215,6 +229,7 @@ function resolveOnboardingIntercept(
   const path = extractPathname(intendedDestination);
   if (!path.startsWith(routes.assistant)) return { action: "allow" };
   if (path.startsWith(`${routes.assistant}/onboarding`)) return { action: "allow" };
+  if (path === routes.reviewTerms) return { action: "allow" };
 
   return {
     action: "redirect",
@@ -262,7 +277,7 @@ function resolvePostRetire(state: NavigationState): NavigationDecision {
     // where the app picks up the next available assistant.
     return {
       action: "redirect",
-      to: state.isLocalMode ? routes.onboarding.selectAssistant : routes.assistant,
+      to: state.isLocalMode ? routes.selectAssistant : routes.assistant,
     };
   }
   if (!state.isLocalMode) {
@@ -271,6 +286,6 @@ function resolvePostRetire(state: NavigationState): NavigationDecision {
   if (state.platformSession === "present") {
     return { action: "redirect", to: routes.onboarding.hosting };
   }
-  return { action: "redirect", to: routes.onboarding.welcome };
+  return { action: "redirect", to: routes.welcome };
 }
 

--- a/apps/web/src/lib/onboarding-middleware.ts
+++ b/apps/web/src/lib/onboarding-middleware.ts
@@ -10,7 +10,7 @@ export const localModeOnlyMiddleware: MiddlewareFunction = async (
   // Auth has already been verified by the parent auth middleware.
   const decision = resolveNavigation(
     buildNavigationState({ sessionSettled: true, isAuthenticated: true }),
-    { kind: "route-guard", pathname: "/assistant/onboarding/welcome" },
+    { kind: "route-guard", pathname: "/assistant/onboarding/hosting" },
   );
   if (decision.action === "redirect") throw redirect(decision.to);
   return next();

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -140,23 +140,27 @@ export const routeTree = [
         {
           ErrorBoundary: RouteErrorBoundary,
           children: [
-        // Onboarding routes — redirect to /assistant when onboarding is
-        // already completed (unless ?replay is present).
+        // Standalone pre-app routes (not part of the new-user onboarding funnel).
+        {
+          path: "welcome",
+          lazy: { Component: () => import("@/domains/onboarding/pages/welcome-screen").then((m) => m.WelcomeScreen) },
+        },
+        {
+          path: "select-assistant",
+          lazy: { Component: () => import("@/domains/onboarding/pages/select-assistant-screen").then((m) => m.SelectAssistantScreen) },
+        },
+        {
+          path: "review-terms",
+          lazy: { Component: () => import("@/domains/onboarding/pages/review-terms-screen").then((m) => m.ReviewTermsScreen) },
+        },
+
+        // Onboarding funnel — new-user setup flow (privacy → prechat → hatching).
         {
           middleware: [onboardingCompletedMiddleware],
           children: [
-            // Local-mode-only: redirect to /assistant when not in local mode.
             {
               middleware: [localModeOnlyMiddleware],
               children: [
-                {
-                  path: "onboarding/welcome",
-                  lazy: { Component: () => import("@/domains/onboarding/pages/welcome-screen").then((m) => m.WelcomeScreen) },
-                },
-                {
-                  path: "onboarding/select-assistant",
-                  lazy: { Component: () => import("@/domains/onboarding/pages/select-assistant-screen").then((m) => m.SelectAssistantScreen) },
-                },
                 {
                   path: "onboarding/hosting",
                   lazy: { Component: () => import("@/domains/onboarding/pages/hosting-screen").then((m) => m.HostingScreen) },
@@ -170,10 +174,6 @@ export const routeTree = [
             {
               path: "onboarding/privacy",
               lazy: { Component: () => import("@/domains/onboarding/pages/privacy-screen").then((m) => m.PrivacyScreen) },
-            },
-            {
-              path: "onboarding/review-terms",
-              lazy: { Component: () => import("@/domains/onboarding/pages/review-terms-screen").then((m) => m.ReviewTermsScreen) },
             },
             {
               path: "onboarding/prechat",

--- a/apps/web/src/utils/routes.ts
+++ b/apps/web/src/utils/routes.ts
@@ -76,13 +76,14 @@ export const routes = {
     },
   },
 
+  welcome: r("/assistant/welcome"),
+  selectAssistant: r("/assistant/select-assistant"),
+  reviewTerms: r("/assistant/review-terms"),
+
   onboarding: {
-    welcome: r("/assistant/onboarding/welcome"),
-    selectAssistant: r("/assistant/onboarding/select-assistant"),
     hosting: r("/assistant/onboarding/hosting"),
     apiKey: r("/assistant/onboarding/api-key"),
     privacy: r("/assistant/onboarding/privacy"),
-    reviewTerms: r("/assistant/onboarding/review-terms"),
     prechat: r("/assistant/onboarding/prechat"),
     hatching: r("/assistant/onboarding/hatching"),
   },


### PR DESCRIPTION
## Summary

- Moves `/assistant/onboarding/welcome` → `/assistant/welcome`, `/assistant/onboarding/select-assistant` → `/assistant/select-assistant`, `/assistant/onboarding/review-terms` → `/assistant/review-terms`
- Restructures the route guard into sub-steps (4a/4b/4c) so standalone paths, review-terms, and the true onboarding funnel are handled independently
- Updates route tree, middleware, window sizing hook, component navigation, and all test references

## Original prompt

After merging a route guard fix that prevents users with existing assistants from re-entering the new-user onboarding funnel, we identified that welcome, select-assistant, and review-terms don't semantically belong under `/onboarding/` — they serve broader purposes (local-mode entry, assistant switching, terms re-acceptance). Moving them out makes the `/onboarding/` prefix exclusively the new-user funnel, so the route guard can block existing-user access to that prefix without needing per-path exceptions.

## Test plan

- [x] All 63 navigation-resolver tests pass
- [x] All 8 retire-service tests pass
- [x] All 4 window-sizing tests pass
- [ ] Verify local-mode welcome → select-assistant → hosting flow works at new URLs
- [ ] Verify review-terms consent gate works at `/assistant/review-terms`
- [ ] Verify new-user onboarding funnel (privacy → prechat → hatching) is unaffected


🤖 Generated with [Claude Code](https://claude.com/claude-code)