### PR TITLE
fix(macos): trust source-less POST requests in Electron platform proxy

### DIFF
--- a/apps/macos/src/main/platform-forward.test.ts
+++ b/apps/macos/src/main/platform-forward.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import { planPlatformForward } from "./platform-forward";
 
 const PLATFORM = "https://platform.vellum.ai";
+const ELECTRON_RENDERER_ORIGIN_HEADER = "X-Vellum-Electron-Renderer-Origin";
 
 const request = (
   pathname: string,
@@ -136,9 +137,66 @@ describe("planPlatformForward", () => {
     expect(plan.kind).toBe("reject");
   });
 
-  test("rejects source-less unsafe platform requests", () => {
+  test("trusts source-less unsafe requests with renderer-origin marker", () => {
+    const plan = planPlatformForward(
+      request("/v1/assistants", {
+        method: "POST",
+        headers: { [ELECTRON_RENDERER_ORIGIN_HEADER]: "app://vellum.ai" },
+      }),
+      PLATFORM,
+      { allowedOrigin: { protocol: "app:", host: "vellum.ai" } },
+    );
+
+    if (plan.kind !== "forward") throw new Error("expected forward");
+    expect(plan.headers.get("origin")).toBe("https://platform.vellum.ai");
+    expect(plan.headers.get(ELECTRON_RENDERER_ORIGIN_HEADER)).toBeNull();
+  });
+
+  test("trusts source-less unsafe requests with Sec-Fetch-Site same-origin", () => {
+    const plan = planPlatformForward(
+      request("/v1/assistants", {
+        method: "POST",
+        headers: { "sec-fetch-site": "same-origin" },
+      }),
+      PLATFORM,
+      { allowedOrigin: { protocol: "app:", host: "vellum.ai" } },
+    );
+
+    if (plan.kind !== "forward") throw new Error("expected forward");
+  });
+
+  test("rejects source-less unsafe requests with cross-site fetch metadata", () => {
+    const plan = planPlatformForward(
+      request("/v1/assistants", {
+        method: "POST",
+        headers: { "sec-fetch-site": "cross-site" },
+      }),
+      PLATFORM,
+      { allowedOrigin: { protocol: "app:", host: "vellum.ai" } },
+    );
+
+    expect(plan.kind).toBe("reject");
+  });
+
+  test("rejects source-less unsafe requests without any trust signal", () => {
     const plan = planPlatformForward(
       request("/v1/assistants", { method: "POST" }),
+      PLATFORM,
+      { allowedOrigin: { protocol: "app:", host: "vellum.ai" } },
+    );
+
+    expect(plan.kind).toBe("reject");
+  });
+
+  test("rejects source-less unsafe requests from a foreign request URL", () => {
+    const plan = planPlatformForward(
+      {
+        url: "app://evil.example/v1/assistants",
+        method: "POST",
+        headers: new Headers({
+          [ELECTRON_RENDERER_ORIGIN_HEADER]: "app://vellum.ai",
+        }),
+      },
       PLATFORM,
       { allowedOrigin: { protocol: "app:", host: "vellum.ai" } },
     );

--- a/apps/macos/src/main/platform-forward.ts
+++ b/apps/macos/src/main/platform-forward.ts
@@ -34,6 +34,7 @@ export interface PlatformForwardOptions {
 }
 
 const PLATFORM_PREFIXES = ["/v1", "/_allauth", "/accounts"] as const;
+const ELECTRON_RENDERER_ORIGIN_HEADER = "X-Vellum-Electron-Renderer-Origin";
 
 function isPlatformPath(pathname: string): boolean {
   return PLATFORM_PREFIXES.some(
@@ -58,7 +59,48 @@ function isUnsafeMethod(method: string): boolean {
   return !["GET", "HEAD", "OPTIONS"].includes(method.toUpperCase());
 }
 
+function expectedRendererOrigin(allowed: PlatformForwardAllowedOrigin): string {
+  return `${allowed.protocol}//${allowed.host}`;
+}
+
+/**
+ * Chromium omits the `Origin` header on requests to Electron custom protocol
+ * handlers (`app://`), so standard origin-checking cannot trust them. Fall
+ * back to two signals that ARE present:
+ *
+ *   1. `X-Vellum-Electron-Renderer-Origin` — set by the renderer's API
+ *      interceptor on mutating requests, stripped before forwarding.
+ *   2. `Sec-Fetch-Site: same-origin` — browser-controlled Fetch Metadata
+ *      header that page JS cannot forge.
+ *
+ * Both checks additionally verify the request URL itself targets the
+ * expected app origin, preventing a hypothetical cross-origin sub-resource
+ * from satisfying the check.
+ */
+function hasTrustedSourceLessRendererSignal(
+  requestUrl: URL,
+  headers: Headers,
+  allowed: PlatformForwardAllowedOrigin,
+): boolean {
+  if (
+    requestUrl.protocol !== allowed.protocol ||
+    requestUrl.host !== allowed.host
+  ) {
+    return false;
+  }
+
+  if (
+    headers.get(ELECTRON_RENDERER_ORIGIN_HEADER) ===
+    expectedRendererOrigin(allowed)
+  ) {
+    return true;
+  }
+
+  return headers.get("sec-fetch-site") === "same-origin";
+}
+
 function getInitiatorTrust(
+  requestUrl: URL,
   headers: Headers,
   allowed?: PlatformForwardAllowedOrigin,
 ): { trusted: boolean; rejected: boolean } {
@@ -71,7 +113,16 @@ function getInitiatorTrust(
   }
 
   const referer = headers.get("referer");
-  if (!referer) return { trusted: false, rejected: false };
+  if (!referer) {
+    return {
+      trusted: hasTrustedSourceLessRendererSignal(
+        requestUrl,
+        headers,
+        allowed,
+      ),
+      rejected: false,
+    };
+  }
 
   const trusted = isAllowedSource(referer, allowed);
   return { trusted, rejected: !trusted };
@@ -96,7 +147,11 @@ export function planPlatformForward(
     return { kind: "pass" };
   }
 
-  const initiator = getInitiatorTrust(request.headers, options.allowedOrigin);
+  const initiator = getInitiatorTrust(
+    url,
+    request.headers,
+    options.allowedOrigin,
+  );
   const unsafeUntrustedRequest =
     options.allowedOrigin &&
     isUnsafeMethod(request.method) &&
@@ -111,6 +166,7 @@ export function planPlatformForward(
 
   const target = new URL(platformUrl);
   const headers = new Headers(request.headers);
+  headers.delete(ELECTRON_RENDERER_ORIGIN_HEADER);
   headers.set("origin", target.origin);
 
   return {

--- a/apps/web/src/lib/api-interceptors.test.ts
+++ b/apps/web/src/lib/api-interceptors.test.ts
@@ -36,6 +36,7 @@ import { useOrganizationStore } from "@/stores/organization-store";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 
 const TEST_ORG_ID = "org-test-1234";
+const ELECTRON_RENDERER_ORIGIN_HEADER = "X-Vellum-Electron-Renderer-Origin";
 
 function setCsrfCookie(token: string): void {
   document.cookie = `csrftoken=${token}; path=/`;
@@ -101,6 +102,11 @@ describe("api-interceptors / requestInterceptor", () => {
     expect(headers.get("X-Session-Token")).toBeNull();
   });
 
+  test("does not attach renderer-origin marker outside Electron", async () => {
+    const headers = await intercept("POST");
+    expect(headers.get(ELECTRON_RENDERER_ORIGIN_HEADER)).toBeNull();
+  });
+
   test("returns a new Request, leaving the input headers untouched", async () => {
     const input = new Request("https://example.test/v1/probe", { method: "POST" });
     expect(input.headers.get("X-Vellum-Client-Id")).toBeNull();
@@ -143,6 +149,18 @@ describe("api-interceptors / Electron session-token header", () => {
     const headers = await intercept("POST");
     expect(headers.get("X-Session-Token")).toBe("electron-sess-tok");
     expect(headers.get("X-CSRFToken")).toBeNull();
+  });
+
+  test("attaches renderer-origin marker on Electron mutating requests", async () => {
+    const headers = await intercept("POST");
+    expect(headers.get(ELECTRON_RENDERER_ORIGIN_HEADER)).toBe(
+      `${window.location.protocol}//${window.location.host}`,
+    );
+  });
+
+  test("does not attach renderer-origin marker on Electron safe requests", async () => {
+    const headers = await intercept("GET");
+    expect(headers.get(ELECTRON_RENDERER_ORIGIN_HEADER)).toBeNull();
   });
 });
 

--- a/apps/web/src/lib/api-interceptors.ts
+++ b/apps/web/src/lib/api-interceptors.ts
@@ -41,6 +41,11 @@ import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-st
 import { getActiveOrganizationIdForRequests } from "@/stores/organization-store";
 
 const MUTATING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+const ELECTRON_RENDERER_ORIGIN_HEADER = "X-Vellum-Electron-Renderer-Origin";
+
+function getRendererTupleOrigin(): string {
+  return `${window.location.protocol}//${window.location.host}`;
+}
 
 /**
  * Allowlist of `/v1/assistants/{id}/<segment>/...` first segments that
@@ -190,6 +195,13 @@ function createInterceptor({ skipSegmentAllowlist = false } = {}) {
     }
 
     // Platform path — Django session auth.
+    if (isElectron() && MUTATING_METHODS.has(request.method)) {
+      newRequest.headers.set(
+        ELECTRON_RENDERER_ORIGIN_HEADER,
+        getRendererTupleOrigin(),
+      );
+    }
+
     const organizationId = getActiveOrganizationIdForRequests();
     if (organizationId) {
       newRequest.headers.set("Vellum-Organization-Id", organizationId);


### PR DESCRIPTION
## Summary

- Chromium omits the `Origin` header on requests to Electron custom protocol handlers (`app://`), so the platform proxy's trust check rejected **all** POST/PUT/PATCH/DELETE requests in packaged builds with `403 Forbidden platform proxy request`
- Adds two fallback trust signals when both `Origin` and `Referer` are absent:
  - `X-Vellum-Electron-Renderer-Origin` header — set by the renderer's API interceptor on mutating requests, validated and stripped before forwarding to the platform
  - `Sec-Fetch-Site: same-origin` — browser-controlled Fetch Metadata header that page JS cannot forge
- Both checks also verify the request URL targets the expected `app://vellum.ai` origin to prevent cross-origin sub-resources from satisfying the check

## Context

All POST requests from packaged Electron builds (dev, staging, prod DMGs) were returning 403. `bun run dev` was unaffected because dev mode uses Vite's proxy instead of the `app://` protocol handler. Inspired by #34030.

## Test plan

- [x] `platform-forward.test.ts` — 23 tests pass (5 new: renderer-origin marker, Sec-Fetch-Site same-origin, cross-site rejection, bare rejection, foreign URL rejection)
- [x] `api-interceptors.test.ts` — 32 tests pass (3 new: marker attached on Electron POST, absent on Electron GET, absent on web POST)
- [ ] Build DMG with `bun run pack:debug` and verify POST requests succeed (login, send message)
- [ ] Verify `bun run dev` still works (no regression in Vite proxy path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)