### PR TITLE
fix(gateway): persist derived actor tokens so device revocation invalidates them

### DIFF
--- a/gateway/src/__tests__/actor-token-revocation.test.ts
+++ b/gateway/src/__tests__/actor-token-revocation.test.ts
@@ -8,6 +8,8 @@ import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { eq } from "drizzle-orm";
+
 import { initSigningKey, mintToken } from "../auth/token-service.js";
 import { CURRENT_POLICY_EPOCH } from "../auth/policy.js";
 import type { TokenClaims } from "../auth/types.js";
@@ -18,7 +20,7 @@ const { initGatewayDb, resetGatewayDb, getGatewayDb } =
   await import("../db/connection.js");
 const { actorTokenRecords } = await import("../db/schema.js");
 const { hashToken } = await import("../auth/guardian-bootstrap.js");
-const { isActorTokenRevoked } =
+const { isActorTokenRevoked, actorTokenRecordHash } =
   await import("../auth/actor-token-revocation.js");
 const { createRuntimeProxyHandler } =
   await import("../http/routes/runtime-proxy.js");
@@ -230,6 +232,47 @@ describe("/auth/token revocation", () => {
     );
 
     expect(res.status).toBe(401);
+  });
+
+  test("records a derived token so device revocation invalidates it", async () => {
+    const { handleCreateToken } = await import("../http/routes/auth-token.js");
+    const { revokeActorTokensByDevice } =
+      await import("../auth/guardian-bootstrap.js");
+    const sourceJwt = mintToken({
+      aud: "vellum-gateway",
+      sub: ACTOR_SUB,
+      scope_profile: "actor_client_v1",
+      policy_epoch: CURRENT_POLICY_EPOCH,
+      ttlSeconds: 3600,
+    });
+    insertTokenRecord(sourceJwt, "active");
+
+    const res = await handleCreateToken(
+      new Request("http://127.0.0.1:7830/auth/token", {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${sourceJwt}`,
+          origin: "http://localhost:3000",
+        },
+      }),
+      makeLoopbackServer(),
+    );
+
+    expect(res.status).toBe(200);
+    const { token: derivedJwt } = (await res.json()) as { token: string };
+    const derivedRecord = getGatewayDb()
+      .select({ status: actorTokenRecords.status })
+      .from(actorTokenRecords)
+      .where(eq(actorTokenRecords.tokenHash, actorTokenRecordHash(derivedJwt)))
+      .get();
+
+    expect(derivedRecord?.status).toBe("derived");
+    expect(isActorTokenRevoked(derivedJwt, actorClaims)).toBe(false);
+
+    revokeActorTokensByDevice("guardian-001", hashToken("device-A"));
+
+    expect(isActorTokenRevoked(sourceJwt, actorClaims)).toBe(true);
+    expect(isActorTokenRevoked(derivedJwt, actorClaims)).toBe(true);
   });
 });
 

--- a/gateway/src/auth/actor-token-revocation.ts
+++ b/gateway/src/auth/actor-token-revocation.ts
@@ -74,6 +74,17 @@ function canonicalizeTokenForHash(rawToken: string): string {
 }
 
 /**
+ * Hash a caller-supplied actor token exactly as revocation lookups do.
+ *
+ * Use this for DB writes/reads that need to line up with
+ * `isActorTokenRevoked`, including token-mint paths that persist derived
+ * actor tokens for later device revocation.
+ */
+export function actorTokenRecordHash(rawToken: string): string {
+  return hashToken(canonicalizeTokenForHash(rawToken));
+}
+
+/**
  * True only when `rawToken` is an actor token with an explicitly revoked record.
  * Fail-open in every other case (non-actor, no record, DB error).
  */
@@ -86,7 +97,7 @@ export function isActorTokenRevoked(
     return false;
   }
 
-  const tokenHash = hashToken(canonicalizeTokenForHash(rawToken));
+  const tokenHash = actorTokenRecordHash(rawToken);
 
   try {
     const record = getGatewayDb()

--- a/gateway/src/auth/guardian-bootstrap.ts
+++ b/gateway/src/auth/guardian-bootstrap.ts
@@ -8,7 +8,7 @@
 
 import { createHash, randomBytes } from "node:crypto";
 
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 
 import { getGatewayDb } from "../db/connection.js";
 import {
@@ -427,7 +427,7 @@ export function revokeActorTokensByDevice(
       and(
         eq(actorTokenRecords.guardianPrincipalId, guardianPrincipalId),
         eq(actorTokenRecords.hashedDeviceId, hashedDeviceId),
-        eq(actorTokenRecords.status, "active"),
+        inArray(actorTokenRecords.status, ["active", "derived"]),
       ),
     )
     .run();

--- a/gateway/src/auth/guardian-refresh.ts
+++ b/gateway/src/auth/guardian-refresh.ts
@@ -5,7 +5,7 @@
 
 import { randomBytes } from "node:crypto";
 
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 
 import { getGatewayDb } from "../db/connection.js";
 import { actorRefreshTokenRecords, actorTokenRecords } from "../db/schema.js";
@@ -81,7 +81,7 @@ function revokeFamily(familyId: string): void {
     .run();
 }
 
-function revokeActorTokensByDevice(
+function revokeActiveActorTokensByDevice(
   guardianPrincipalId: string,
   hashedDeviceId: string,
 ): void {
@@ -94,6 +94,24 @@ function revokeActorTokensByDevice(
         eq(actorTokenRecords.guardianPrincipalId, guardianPrincipalId),
         eq(actorTokenRecords.hashedDeviceId, hashedDeviceId),
         eq(actorTokenRecords.status, "active"),
+      ),
+    )
+    .run();
+}
+
+function revokeAllActorTokensByDevice(
+  guardianPrincipalId: string,
+  hashedDeviceId: string,
+): void {
+  const now = Date.now();
+  getGatewayDb()
+    .update(actorTokenRecords)
+    .set({ status: "revoked", updatedAt: now })
+    .where(
+      and(
+        eq(actorTokenRecords.guardianPrincipalId, guardianPrincipalId),
+        eq(actorTokenRecords.hashedDeviceId, hashedDeviceId),
+        inArray(actorTokenRecords.status, ["active", "derived"]),
       ),
     )
     .run();
@@ -232,7 +250,7 @@ export function rotateCredentials(params: {
       "Refresh token reuse detected — revoking entire family",
     );
     revokeFamily(record.familyId);
-    revokeActorTokensByDevice(
+    revokeAllActorTokensByDevice(
       record.guardianPrincipalId,
       record.hashedDeviceId,
     );
@@ -261,7 +279,7 @@ export function rotateCredentials(params: {
       return { ok: false as const, error: "refresh_reuse_detected" as const };
     }
 
-    revokeActorTokensByDevice(
+    revokeActiveActorTokensByDevice(
       record.guardianPrincipalId,
       record.hashedDeviceId,
     );

--- a/gateway/src/auth/guardian-refresh.ts
+++ b/gateway/src/auth/guardian-refresh.ts
@@ -5,7 +5,7 @@
 
 import { randomBytes } from "node:crypto";
 
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 
 import { getGatewayDb } from "../db/connection.js";
 import { actorRefreshTokenRecords, actorTokenRecords } from "../db/schema.js";
@@ -93,7 +93,7 @@ function revokeActorTokensByDevice(
       and(
         eq(actorTokenRecords.guardianPrincipalId, guardianPrincipalId),
         eq(actorTokenRecords.hashedDeviceId, hashedDeviceId),
-        inArray(actorTokenRecords.status, ["active", "derived"]),
+        eq(actorTokenRecords.status, "active"),
       ),
     )
     .run();

--- a/gateway/src/auth/guardian-refresh.ts
+++ b/gateway/src/auth/guardian-refresh.ts
@@ -5,7 +5,7 @@
 
 import { randomBytes } from "node:crypto";
 
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 
 import { getGatewayDb } from "../db/connection.js";
 import { actorRefreshTokenRecords, actorTokenRecords } from "../db/schema.js";
@@ -93,7 +93,7 @@ function revokeActorTokensByDevice(
       and(
         eq(actorTokenRecords.guardianPrincipalId, guardianPrincipalId),
         eq(actorTokenRecords.hashedDeviceId, hashedDeviceId),
-        eq(actorTokenRecords.status, "active"),
+        inArray(actorTokenRecords.status, ["active", "derived"]),
       ),
     )
     .run();

--- a/gateway/src/http/routes/auth-token.ts
+++ b/gateway/src/http/routes/auth-token.ts
@@ -1,9 +1,16 @@
 import type { Server } from "bun";
 
-import { isActorTokenRevoked } from "../../auth/actor-token-revocation.js";
+import { eq } from "drizzle-orm";
+
+import {
+  actorTokenRecordHash,
+  isActorTokenRevoked,
+} from "../../auth/actor-token-revocation.js";
 import { ensureVellumGuardianBinding } from "../../auth/guardian-bootstrap.js";
 import { CURRENT_POLICY_EPOCH } from "../../auth/policy.js";
 import { mintToken, verifyToken } from "../../auth/token-service.js";
+import { getGatewayDb } from "../../db/connection.js";
+import { actorTokenRecords } from "../../db/schema.js";
 import { getLogger } from "../../logger.js";
 import { isLoopbackPeer } from "../../util/is-loopback-address.js";
 
@@ -12,6 +19,69 @@ const log = getLogger("auth-token");
 const WEB_ORIGIN_RE = /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/;
 
 const TOKEN_TTL_SECONDS = 30 * 24 * 60 * 60;
+
+interface SourceActorTokenRecord {
+  guardianPrincipalId: string;
+  hashedDeviceId: string;
+  platform: string;
+}
+
+function findSourceActorTokenRecord(
+  sourceToken: string,
+): SourceActorTokenRecord | null {
+  try {
+    return (
+      getGatewayDb()
+        .select({
+          guardianPrincipalId: actorTokenRecords.guardianPrincipalId,
+          hashedDeviceId: actorTokenRecords.hashedDeviceId,
+          platform: actorTokenRecords.platform,
+        })
+        .from(actorTokenRecords)
+        .where(
+          eq(actorTokenRecords.tokenHash, actorTokenRecordHash(sourceToken)),
+        )
+        .get() ?? null
+    );
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "Source actor-token lookup failed — minting unrecorded compatibility token",
+    );
+    return null;
+  }
+}
+
+function recordDerivedActorToken(
+  sourceRecord: SourceActorTokenRecord | null,
+  derivedToken: string,
+): void {
+  if (!sourceRecord) return;
+
+  const now = Date.now();
+  try {
+    getGatewayDb()
+      .insert(actorTokenRecords)
+      .values({
+        id: crypto.randomUUID(),
+        tokenHash: actorTokenRecordHash(derivedToken),
+        guardianPrincipalId: sourceRecord.guardianPrincipalId,
+        hashedDeviceId: sourceRecord.hashedDeviceId,
+        platform: sourceRecord.platform,
+        status: "derived",
+        issuedAt: now,
+        expiresAt: now + TOKEN_TTL_SECONDS * 1000,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "Derived actor-token record insert failed — minted token remains compatible but unrecorded",
+    );
+  }
+}
 
 export async function handleCreateToken(
   req: Request,
@@ -64,7 +134,9 @@ export async function handleCreateToken(
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const guardianPrincipalId = await ensureVellumGuardianBinding();
+  const sourceRecord = findSourceActorTokenRecord(bearerToken);
+  const guardianPrincipalId =
+    sourceRecord?.guardianPrincipalId ?? (await ensureVellumGuardianBinding());
 
   const token = mintToken({
     aud: "vellum-gateway",
@@ -73,6 +145,8 @@ export async function handleCreateToken(
     policy_epoch: CURRENT_POLICY_EPOCH,
     ttlSeconds: TOKEN_TTL_SECONDS,
   });
+
+  recordDerivedActorToken(sourceRecord, token);
 
   const expiresAt = Math.floor(Date.now() / 1000) + TOKEN_TTL_SECONDS;
   log.info("Bearer token minted for web local mode");


### PR DESCRIPTION
## Summary

- **Security fix**: `POST /auth/token` now persists derived gateway JWTs into `actorTokenRecords` with `status="derived"`, inheriting the source token's device binding so device revocation also revokes derived tokens.
- **Revocation coverage**: Both `revokeActorTokensByDevice` copies (in `guardian-bootstrap.ts` and `guardian-refresh.ts`) updated to revoke `["active", "derived"]` tokens.
- **Backward compatibility**: Fail-open for legacy/unrecorded source tokens — if the source token has no DB record, the derived token is minted without a record (same behavior as before).

Codex finding: https://chatgpt.com/codex/cloud/security/findings/292bff73a17c819193ddda51efcdcb40

## Original prompt

A Codex security scan identified that the gateway's `/auth/token` endpoint mints 30-day `actor_client_v1` JWTs without persisting them to `actorTokenRecords`. Because the revocation check (`isActorTokenRevoked`) is fail-open for unrecorded tokens, these derived tokens survive device/source-token revocation indefinitely until JWT expiry. The fix persists derived tokens with a new `"derived"` status and extends device revocation to cover them.

## Test plan

- [x] Existing tests pass (12/12 in `actor-token-revocation.test.ts`)
- [x] New test "records a derived token so device revocation invalidates it" verifies the full flow: mint source → exchange for derived → verify derived is recorded with status="derived" → revoke device → verify both source and derived are revoked

🤖 Generated with [Claude Code](https://claude.com/claude-code)