### PR TITLE
fix(web): drop redundant "Working (bash)" label from collapsed tool-card header

### DIFF
--- a/apps/web/src/domains/chat/components/activity-run-card/activity-run-card.test.tsx
+++ b/apps/web/src/domains/chat/components/activity-run-card/activity-run-card.test.tsx
@@ -102,10 +102,11 @@ describe("ActivityRunCard — non-web tool group", () => {
     const { getByRole, getByText, getByTestId, queryByTestId, queryByText } = renderCard(toolCalls);
     // The unified card mounts the shared shell wrapper.
     expect(getByTestId("tool-progress-card-shell")).toBeTruthy();
-    // Title comes from `deriveStepLabel("bash")`, info from the `command`
-    // input. The expanded body is hidden by default, so only the header
-    // content is present on mount.
-    expect(getByText("Working (bash)")).toBeTruthy();
+    // The redundant "Working (bash)" label is suppressed in the collapsed
+    // header; the `command` input is promoted to the header's primary slot.
+    // The expanded body is hidden by default, so only the header content is
+    // present on mount.
+    expect(queryByText("Working (bash)")).toBeNull();
     expect(getByText("git status")).toBeTruthy();
     expect(getByRole("button", { name: /expand steps/i })).toBeTruthy();
     expect(queryByTestId("tool-step-pill")).toBeNull();
@@ -806,7 +807,9 @@ describe("ActivityRunCard — header reflects the latest step", () => {
       { kind: "toolCall", toolCall: toolCalls[0]! },
     ];
     const { getByText, queryByText } = renderCard(toolCalls, { items });
-    expect(getByText("Working (bash)")).toBeTruthy();
+    // Bash label suppressed in the collapsed header; command promoted to the
+    // primary slot.
+    expect(queryByText("Working (bash)")).toBeNull();
     expect(getByText("echo hi")).toBeTruthy();
     // The leading thinking text is NOT promoted into the header (it's a body
     // step only).

--- a/apps/web/src/domains/chat/components/tool-progress-card/header-step-carousel.test.tsx
+++ b/apps/web/src/domains/chat/components/tool-progress-card/header-step-carousel.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * Tests for `HeaderStepCarousel` — the animated (title, info) tuple rendered
+ * inside a `ToolProgressCardShell`'s collapsed header.
+ *
+ * Focus: the title-less rendering path. Some tools (e.g. bash) intentionally
+ * carry no collapsed-header title; the carousel must then drop both the title
+ * element and the leading pipe separator and promote the info subtext into the
+ * primary (emphasised) slot. The component seeds its throttle state with the
+ * initial value, so the first render shows the supplied tuple synchronously.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { cleanup, render } from "@testing-library/react";
+
+import { HeaderStepCarousel } from "@/domains/chat/components/tool-progress-card/header-step-carousel";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("HeaderStepCarousel — empty title", () => {
+  test("drops the title element and the leading pipe, promoting info to the primary slot", () => {
+    const { getByText, container } = render(
+      <HeaderStepCarousel currentStepTitle="" currentStepInfo="git status" />,
+    );
+
+    // Info still renders…
+    const info = getByText("git status");
+    expect(info).toBeTruthy();
+    // …but with no leading pipe separator to its left.
+    expect(container.textContent).not.toContain("|");
+    // Promoted to the emphasised (primary) colour rather than tertiary subtext.
+    expect(info.className).toContain("content-emphasised");
+    expect(info.className).not.toContain("content-tertiary");
+  });
+
+  test("renders nothing visible when both title and info are empty", () => {
+    const { container } = render(
+      <HeaderStepCarousel currentStepTitle="" currentStepInfo="" />,
+    );
+    expect(container.textContent).toBe("");
+  });
+});
+
+describe("HeaderStepCarousel — with title", () => {
+  test("renders the title, a pipe separator, and the info as tertiary subtext", () => {
+    const { getByText, container } = render(
+      <HeaderStepCarousel currentStepTitle="Reading" currentStepInfo="foo.ts" />,
+    );
+
+    expect(getByText("Reading")).toBeTruthy();
+    const info = getByText("foo.ts");
+    expect(info).toBeTruthy();
+    // The pipe separator sits between title and info.
+    expect(container.textContent).toContain("|");
+    // Info stays de-emphasised subtext when a title is present.
+    expect(info.className).toContain("content-tertiary");
+    expect(info.className).not.toContain("content-emphasised");
+  });
+});

--- a/apps/web/src/domains/chat/components/tool-progress-card/header-step-carousel.tsx
+++ b/apps/web/src/domains/chat/components/tool-progress-card/header-step-carousel.tsx
@@ -170,6 +170,12 @@ export function HeaderStepCarousel({
   // string, null, and undefined all count as "no info".
   const hasInfo = isTextInfo ? displayed.info !== "" : displayed.info != null;
 
+  // Some tools (e.g. bash) intentionally carry no collapsed-header title —
+  // the info subtext alone is the label. When the title is empty we drop both
+  // the title element and the leading pipe, and promote the info into the
+  // primary (emphasised) slot so it doesn't read as de-emphasised subtext.
+  const hasTitle = displayed.title.trim() !== "";
+
   return (
     <AnimatePresence initial={false} mode="popLayout">
       <motion.span
@@ -182,31 +188,43 @@ export function HeaderStepCarousel({
         // truncates inside the remaining space.
         className="flex min-w-0 flex-1 items-center gap-1"
       >
-        <Typography
-          variant="body-medium-default"
-          className="ml-1 shrink-0 whitespace-nowrap text-[var(--content-emphasised)]"
-        >
-          {displayed.title}
-        </Typography>
+        {hasTitle ? (
+          <Typography
+            variant="body-medium-default"
+            className="ml-1 shrink-0 whitespace-nowrap text-[var(--content-emphasised)]"
+          >
+            {displayed.title}
+          </Typography>
+        ) : null}
         {hasInfo ? (
           <>
-            <span
-              aria-hidden="true"
-              className="shrink-0 text-[var(--border-element)]"
-            >
-              |
-            </span>
+            {hasTitle ? (
+              <span
+                aria-hidden="true"
+                className="shrink-0 text-[var(--border-element)]"
+              >
+                |
+              </span>
+            ) : null}
             {isTextInfo ? (
               <Typography
-                variant="body-small-default"
+                // With a title present, the info is subtext (small, tertiary).
+                // With no title it IS the header label, so it takes the
+                // title's emphasis (medium, emphasised) instead.
+                variant={hasTitle ? "body-small-default" : "body-medium-default"}
                 // `body-small-default` ships line-height: 1, which clips
                 // descenders (e.g. the "g" in "subagent") once `truncate`
                 // adds overflow:hidden. Bump to 16px — the same ~1.3 ratio
                 // the title's `body-medium-default` (18/14) uses — so the
                 // glyphs get vertical breathing room while staying centered.
                 // `ml-1` adds 4px on top of the row's `gap-1` (also 4px) so
-                // the descriptor sits ~8px clear of the `|` separator.
-                className="ml-1 block min-w-0 flex-1 truncate text-left leading-[16px] text-[var(--content-tertiary)]"
+                // the descriptor sits ~8px clear of the `|` separator (or, when
+                // title-less, aligns where the title would have sat).
+                className={`ml-1 block min-w-0 flex-1 truncate text-left leading-[16px] ${
+                  hasTitle
+                    ? "text-[var(--content-tertiary)]"
+                    : "text-[var(--content-emphasised)]"
+                }`}
               >
                 {displayed.info}
               </Typography>

--- a/apps/web/src/domains/chat/hooks/use-tool-call-card-data.test.ts
+++ b/apps/web/src/domains/chat/hooks/use-tool-call-card-data.test.ts
@@ -87,8 +87,10 @@ describe("computeToolCallCardData — step kinds", () => {
       status: "completed",
     });
     expect(data.state).toBe("complete");
-    // `currentStepTitle` / `currentStepInfo` mirror the tool step.
-    expect(data.currentStepTitle).toBe("Working (bash)");
+    // The collapsed header suppresses the redundant "Working (bash)" label,
+    // promoting the command into the (otherwise subtext) info slot. The
+    // underlying step keeps its "Working (bash)" title for phase grouping.
+    expect(data.currentStepTitle).toBe("");
     expect(data.currentStepInfo).toBe("echo hello");
   });
 
@@ -349,8 +351,8 @@ describe("computeToolCallCardData — subagent_spawn filtering", () => {
     expect(data.steps).toHaveLength(1);
     expect(data.steps[0]!.kind).toBe("tool");
     // Header derivation also ignores the filtered spawn so the carousel
-    // reflects only the bash call.
-    expect(data.currentStepTitle).toBe("Working (bash)");
+    // reflects only the bash call — whose title is suppressed in the header.
+    expect(data.currentStepTitle).toBe("");
   });
 });
 
@@ -450,7 +452,8 @@ describe("computeToolCallCardDataFromItems — header reflects the latest step",
     ];
     const data = computeToolCallCardDataFromItems(items, {});
     expect(data.currentStepKind).toBe("tool");
-    expect(data.currentStepTitle).toBe("Working (bash)");
+    // Bash title suppressed in the collapsed header; command promoted to info.
+    expect(data.currentStepTitle).toBe("");
     expect(data.currentStepInfo).toBe("echo hi");
   });
 });
@@ -557,8 +560,9 @@ describe("computeToolCallCardData — mixed web + non-web groups", () => {
     expect(data.steps).toHaveLength(2);
     expect(data.steps[0]!.kind).toBe("web_search");
     expect(data.steps[1]!.kind).toBe("tool");
-    // currentStepTitle reflects the latest call (the bash tool).
-    expect(data.currentStepTitle).toBe("Working (bash)");
+    // currentStepTitle reflects the latest call (the bash tool), whose
+    // redundant label is suppressed in the collapsed header.
+    expect(data.currentStepTitle).toBe("");
     expect(data.currentStepInfo).toBe("ls");
   });
 });

--- a/apps/web/src/domains/chat/utils/tool-call-card-utils.ts
+++ b/apps/web/src/domains/chat/utils/tool-call-card-utils.ts
@@ -402,6 +402,15 @@ function buildToolStep(tc: ChatMessageToolCall): ToolCallCardStep {
  * the calls in reverse so the latest one wins, mirroring the legacy
  * web-search hook's selector logic for the web-tool branch and adding a
  * non-web `deriveStepLabel().title` branch alongside it.
+ *
+ * The bash label ("Working (bash)") is redundant chrome in the collapsed
+ * header — the command/activity subtext already conveys what's running — so
+ * we suppress it here, letting `HeaderStepCarousel` promote the info to the
+ * primary slot. We intentionally key off the derived title rather than
+ * `tc.name` so the `skill_execute → bash` wrapper (which also derives to
+ * "Working (bash)") is covered too. `deriveStepLabel` and `phaseFromStep`
+ * stay untouched, so the EXPANDED list still groups bash steps under a
+ * distinct "Working (bash)" section.
  */
 function deriveCurrentStepTitle(
   toolCalls: ChatMessageToolCall[],
@@ -425,7 +434,8 @@ function deriveCurrentStepTitle(
         return "Thinking";
       }
     } else {
-      return deriveStepLabel(tc).title;
+      const title = deriveStepLabel(tc).title;
+      return title === "Working (bash)" ? "" : title;
     }
   }
   return "";


### PR DESCRIPTION
## Summary
- Suppress the hardcoded `"Working (bash)"` title in the **collapsed** tool-progress-card header and promote the command/activity text into the primary slot (no leading `|`). `HeaderStepCarousel` now handles an empty title gracefully.
- Keyed the suppression on the derived title rather than the tool name, so the `skill_execute → bash` wrapper is covered too.
- The **expanded** step list intentionally still groups bash steps under a distinct `"Working (bash)"` phase section (`deriveStepLabel`/`phaseFromStep` unchanged).

## Original prompt
Noticed that "Working (bash)" renders to the left of tool calls in the web chat view and felt it was unnecessary chrome. Asked to investigate where it comes from (it's frontend-derived, not sent by the daemon), what data the backend provides, and how it's rendered — then produce a concise plan to remove it. Decision: drop the title in the collapsed header but keep the command/activity text, and leave the expanded-list phase grouping intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)