### PR TITLE
Cherry-pick host proxy and actor token fixes into v0.8.9

### DIFF
--- a/apps/macos/src/main/executors/host-bash-executor.test.ts
+++ b/apps/macos/src/main/executors/host-bash-executor.test.ts
@@ -59,8 +59,8 @@ function capturingPoster(): { poster: InstanceType<typeof HostProxyPoster>; post
     return new Response("ok");
   };
   const poster = new HostProxyPoster({
-    gatewayPort: 9000,
-    authToken: "t",
+    endpointBase: "http://127.0.0.1:9000/v1",
+    authHeaders: () => ({ Authorization: "Bearer t" }),
     fetch: fakeFetch as typeof globalThis.fetch,
   });
   return { poster, posts: () => captured };

--- a/apps/macos/src/main/executors/host-file-executor.test.ts
+++ b/apps/macos/src/main/executors/host-file-executor.test.ts
@@ -51,8 +51,8 @@ function capturingPoster(): {
     return new Response("ok");
   };
   const poster = new HostProxyPoster({
-    gatewayPort: 9000,
-    authToken: "t",
+    endpointBase: "http://127.0.0.1:9000/v1",
+    authHeaders: () => ({ Authorization: "Bearer t" }),
     fetch: fakeFetch as typeof globalThis.fetch,
   });
   return { poster, body: () => postedBody };

--- a/apps/macos/src/main/executors/host-transfer-executor.test.ts
+++ b/apps/macos/src/main/executors/host-transfer-executor.test.ts
@@ -118,8 +118,8 @@ function capturingPoster(opts: {
   };
 
   const poster = new HostProxyPoster({
-    gatewayPort: 9000,
-    authToken: "test-token",
+    endpointBase: "http://127.0.0.1:9000/v1",
+    authHeaders: () => ({ Authorization: "Bearer test-token" }),
     fetch: fakeFetch as typeof globalThis.fetch,
   });
 
@@ -388,8 +388,8 @@ describe("host-transfer-executor", () => {
       };
 
       const poster = new HostProxyPoster({
-        gatewayPort: 9000,
-        authToken: "t",
+        endpointBase: "http://127.0.0.1:9000/v1",
+        authHeaders: () => ({ Authorization: "Bearer t" }),
         fetch: slowFetch as typeof globalThis.fetch,
       });
 
@@ -444,8 +444,8 @@ describe("host-transfer-executor", () => {
       };
 
       const poster = new HostProxyPoster({
-        gatewayPort: 9000,
-        authToken: "t",
+        endpointBase: "http://127.0.0.1:9000/v1",
+        authHeaders: () => ({ Authorization: "Bearer t" }),
         fetch: slowFetch as typeof globalThis.fetch,
       });
 

--- a/apps/macos/src/main/host-proxy-poster.test.ts
+++ b/apps/macos/src/main/host-proxy-poster.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -114,14 +114,18 @@ function createBinaryMockFetch(status: number, data: Buffer) {
   return { fetchFn: fetchFn as typeof globalThis.fetch, captured };
 }
 
-function makePoster(
-  fetchFn: typeof globalThis.fetch,
-  overrides?: { gatewayPort?: number; gatewayHost?: string; authToken?: string },
-) {
+function makeLocalPoster(fetchFn: typeof globalThis.fetch, port = 9000, token = "test-token") {
   return new HostProxyPoster({
-    gatewayPort: overrides?.gatewayPort ?? 9000,
-    gatewayHost: overrides?.gatewayHost,
-    authToken: overrides?.authToken ?? "test-token",
+    endpointBase: `http://127.0.0.1:${port}/v1`,
+    authHeaders: () => ({ Authorization: `Bearer ${token}` }),
+    fetch: fetchFn,
+  });
+}
+
+function makeCloudPoster(fetchFn: typeof globalThis.fetch, runtimeUrl = "https://platform.vellum.ai", assistantId = "asst-123", sessionToken = "session-tok") {
+  return new HostProxyPoster({
+    endpointBase: `${runtimeUrl}/v1/assistants/${assistantId}`,
+    authHeaders: () => ({ "X-Session-Token": sessionToken }),
     fetch: fetchFn,
   });
 }
@@ -144,7 +148,7 @@ describe("HostProxyPoster", () => {
   describe("postBashResult", () => {
     test("sends correct URL, method, headers, and body", async () => {
       const { fetchFn, captured } = createMockFetch();
-      const poster = makePoster(fetchFn);
+      const poster = makeLocalPoster(fetchFn);
 
       const result = await poster.postBashResult({
         requestId: "req-1",
@@ -174,7 +178,7 @@ describe("HostProxyPoster", () => {
   describe("postFileResult", () => {
     test("sends correct URL and body fields", async () => {
       const { fetchFn, captured } = createMockFetch();
-      const poster = makePoster(fetchFn);
+      const poster = makeLocalPoster(fetchFn);
 
       const result = await poster.postFileResult({
         requestId: "req-2",
@@ -197,7 +201,7 @@ describe("HostProxyPoster", () => {
   describe("postTransferResult", () => {
     test("sends correct URL and body fields", async () => {
       const { fetchFn, captured } = createMockFetch();
-      const poster = makePoster(fetchFn);
+      const poster = makeLocalPoster(fetchFn);
 
       const result = await poster.postTransferResult({
         requestId: "req-3",
@@ -218,7 +222,7 @@ describe("HostProxyPoster", () => {
   describe("postBrowserResult", () => {
     test("sends correct URL and body fields", async () => {
       const { fetchFn, captured } = createMockFetch();
-      const poster = makePoster(fetchFn);
+      const poster = makeLocalPoster(fetchFn);
 
       const result = await poster.postBrowserResult({
         requestId: "req-4",
@@ -239,7 +243,7 @@ describe("HostProxyPoster", () => {
   describe("postCuResult", () => {
     test("sends correct URL and body fields", async () => {
       const { fetchFn, captured } = createMockFetch();
-      const poster = makePoster(fetchFn);
+      const poster = makeLocalPoster(fetchFn);
 
       const result = await poster.postCuResult({
         requestId: "req-5",
@@ -265,7 +269,7 @@ describe("HostProxyPoster", () => {
   describe("postAppControlResult", () => {
     test("sends correct URL and body fields", async () => {
       const { fetchFn, captured } = createMockFetch();
-      const poster = makePoster(fetchFn);
+      const poster = makeLocalPoster(fetchFn);
 
       const result = await poster.postAppControlResult({
         requestId: "req-6",
@@ -297,7 +301,7 @@ describe("HostProxyPoster", () => {
     test("returns buffer on success", async () => {
       const payload = Buffer.from("file-bytes-here");
       const { fetchFn, captured } = createBinaryMockFetch(200, payload);
-      const poster = makePoster(fetchFn);
+      const poster = makeLocalPoster(fetchFn);
 
       const buf = await poster.pullTransferContent("xfer-1");
 
@@ -316,7 +320,7 @@ describe("HostProxyPoster", () => {
 
     test("returns null on non-2xx", async () => {
       const { fetchFn } = createBinaryMockFetch(404, Buffer.alloc(0));
-      const poster = makePoster(fetchFn);
+      const poster = makeLocalPoster(fetchFn);
 
       const buf = await poster.pullTransferContent("xfer-missing");
 
@@ -328,7 +332,7 @@ describe("HostProxyPoster", () => {
         200,
         Buffer.from("ok"),
       );
-      const poster = makePoster(fetchFn);
+      const poster = makeLocalPoster(fetchFn);
 
       await poster.pullTransferContent("id/with special&chars");
 
@@ -341,7 +345,7 @@ describe("HostProxyPoster", () => {
   describe("pushTransferContent", () => {
     test("sends binary data with correct headers", async () => {
       const { fetchFn, captured } = createMockFetch();
-      const poster = makePoster(fetchFn);
+      const poster = makeLocalPoster(fetchFn);
       const data = Buffer.from("binary-payload");
 
       const result = await poster.pushTransferContent(
@@ -363,7 +367,7 @@ describe("HostProxyPoster", () => {
 
     test("returns false on non-2xx", async () => {
       const { fetchFn } = createMockFetch(500);
-      const poster = makePoster(fetchFn);
+      const poster = makeLocalPoster(fetchFn);
 
       const result = await poster.pushTransferContent(
         "xfer-3",
@@ -378,7 +382,7 @@ describe("HostProxyPoster", () => {
   describe("error handling", () => {
     test("returns false on non-2xx status", async () => {
       const { fetchFn } = createMockFetch(500);
-      const poster = makePoster(fetchFn);
+      const poster = makeLocalPoster(fetchFn);
 
       const result = await poster.postBashResult({
         requestId: "req-err",
@@ -392,7 +396,7 @@ describe("HostProxyPoster", () => {
       const throwingFetch = (async () => {
         throw new Error("network failure");
       }) as unknown as typeof globalThis.fetch;
-      const poster = makePoster(throwingFetch);
+      const poster = makeLocalPoster(throwingFetch);
 
       const result = await poster.postBashResult({
         requestId: "req-throw",
@@ -406,7 +410,7 @@ describe("HostProxyPoster", () => {
       const throwingFetch = (async () => {
         throw new Error("network failure");
       }) as unknown as typeof globalThis.fetch;
-      const poster = makePoster(throwingFetch);
+      const poster = makeLocalPoster(throwingFetch);
 
       const buf = await poster.pullTransferContent("xfer-throw");
 
@@ -417,7 +421,7 @@ describe("HostProxyPoster", () => {
       const throwingFetch = (async () => {
         throw new Error("network failure");
       }) as unknown as typeof globalThis.fetch;
-      const poster = makePoster(throwingFetch);
+      const poster = makeLocalPoster(throwingFetch);
 
       const result = await poster.pushTransferContent(
         "xfer-throw",
@@ -429,28 +433,39 @@ describe("HostProxyPoster", () => {
     });
   });
 
-  describe("configuration", () => {
-    test("uses custom gatewayHost when provided", async () => {
-      const { fetchFn, captured } = createMockFetch();
-      const poster = makePoster(fetchFn, {
-        gatewayHost: "192.168.1.100",
-        gatewayPort: 8080,
-      });
+  // -- Cloud mode ---------------------------------------------------------
 
-      await poster.postBashResult({ requestId: "req-host", stdout: "" });
+  describe("cloud mode", () => {
+    test("uses assistant-scoped URLs for result POSTs", async () => {
+      const { fetchFn, captured } = createMockFetch();
+      const poster = makeCloudPoster(fetchFn);
+
+      await poster.postBashResult({ requestId: "r1", stdout: "" });
 
       expect(captured[0].url).toBe(
-        "http://192.168.1.100:8080/v1/host-bash-result",
+        "https://platform.vellum.ai/v1/assistants/asst-123/host-bash-result",
       );
     });
 
-    test("defaults gatewayHost to 127.0.0.1", async () => {
+    test("uses X-Session-Token header instead of Bearer token", async () => {
       const { fetchFn, captured } = createMockFetch();
-      const poster = makePoster(fetchFn);
+      const poster = makeCloudPoster(fetchFn);
 
-      await poster.postBashResult({ requestId: "req-default", stdout: "" });
+      await poster.postBashResult({ requestId: "r1", stdout: "" });
 
-      expect(captured[0].url).toStartWith("http://127.0.0.1:9000/");
+      expect(captured[0].headers["X-Session-Token"]).toBe("session-tok");
+      expect(captured[0].headers["Authorization"]).toBeUndefined();
+    });
+
+    test("uses assistant-scoped URLs for transfer content", async () => {
+      const { fetchFn, captured } = createBinaryMockFetch(200, Buffer.from("ok"));
+      const poster = makeCloudPoster(fetchFn);
+
+      await poster.pullTransferContent("xfer-1");
+
+      expect(captured[0].url).toBe(
+        "https://platform.vellum.ai/v1/assistants/asst-123/transfers/xfer-1/content",
+      );
     });
   });
 });

--- a/apps/macos/src/main/host-proxy-poster.ts
+++ b/apps/macos/src/main/host-proxy-poster.ts
@@ -1,9 +1,13 @@
 /**
  * HTTP client for posting host proxy results back to the daemon.
  *
- * Each typed POST method sends a JSON body to the corresponding daemon
- * endpoint with the required auth and client-id headers. Transfer content
- * methods handle binary GET/PUT for file transfers.
+ * Each typed POST method sends a JSON body to the corresponding endpoint
+ * with the required auth and client-id headers. Transfer content methods
+ * handle binary GET/PUT for file transfers.
+ *
+ * Supports both local gateway connections (loopback) and cloud/platform
+ * connections (assistant-scoped URLs) — the caller provides an endpoint
+ * base and an auth-headers builder.
  *
  * Injectable fetch function for testability (mirrors the SSE client pattern).
  * Returns boolean success/failure without throwing.
@@ -82,9 +86,14 @@ type FetchFn = typeof globalThis.fetch;
 // ---------------------------------------------------------------------------
 
 export interface HostProxyPosterOptions {
-  gatewayPort: number;
-  gatewayHost?: string;
-  authToken: string;
+  /**
+   * Base URL including the path prefix for result endpoints.
+   * Local: "http://127.0.0.1:{port}/v1"
+   * Cloud: "{runtimeUrl}/v1/assistants/{id}"
+   */
+  endpointBase: string;
+  /** Called on every request to build auth headers. */
+  authHeaders: () => Record<string, string>;
   /** Override fetch for testing. Defaults to globalThis.fetch. */
   fetch?: FetchFn;
 }
@@ -103,19 +112,14 @@ function computeTimeout(bodyBytes: number): number {
 }
 
 export class HostProxyPoster {
-  private readonly baseUrl: string;
-  private authToken: string;
+  private readonly endpointBase: string;
+  private readonly authHeaders: () => Record<string, string>;
   private readonly fetchFn: FetchFn;
 
   constructor(opts: HostProxyPosterOptions) {
-    const host = opts.gatewayHost ?? "127.0.0.1";
-    this.baseUrl = `http://${host}:${opts.gatewayPort}`;
-    this.authToken = opts.authToken;
+    this.endpointBase = opts.endpointBase;
+    this.authHeaders = opts.authHeaders;
     this.fetchFn = opts.fetch ?? globalThis.fetch;
-  }
-
-  updateAuthToken(token: string): void {
-    this.authToken = token;
   }
 
   // -----------------------------------------------------------------------
@@ -123,33 +127,33 @@ export class HostProxyPoster {
   // -----------------------------------------------------------------------
 
   async postBashResult(result: HostBashResultPayload): Promise<boolean> {
-    return this.postJson("/v1/host-bash-result", result);
+    return this.postJson("/host-bash-result", result);
   }
 
   async postFileResult(result: HostFileResultPayload): Promise<boolean> {
-    return this.postJson("/v1/host-file-result", result);
+    return this.postJson("/host-file-result", result);
   }
 
   async postTransferResult(
     result: HostTransferResultPayload,
   ): Promise<boolean> {
-    return this.postJson("/v1/host-transfer-result", result);
+    return this.postJson("/host-transfer-result", result);
   }
 
   async postBrowserResult(
     result: HostBrowserResultPayload,
   ): Promise<boolean> {
-    return this.postJson("/v1/host-browser-result", result);
+    return this.postJson("/host-browser-result", result);
   }
 
   async postCuResult(result: HostCuResultPayload): Promise<boolean> {
-    return this.postJson("/v1/host-cu-result", result);
+    return this.postJson("/host-cu-result", result);
   }
 
   async postAppControlResult(
     result: HostAppControlResultPayload,
   ): Promise<boolean> {
-    return this.postJson("/v1/host-app-control-result", result);
+    return this.postJson("/host-app-control-result", result);
   }
 
   // -----------------------------------------------------------------------
@@ -158,7 +162,7 @@ export class HostProxyPoster {
 
   async pullTransferContent(transferId: string): Promise<Buffer | null> {
     try {
-      const url = `${this.baseUrl}/v1/transfers/${encodeURIComponent(transferId)}/content`;
+      const url = `${this.endpointBase}/transfers/${encodeURIComponent(transferId)}/content`;
       const controller = new AbortController();
       const timer = setTimeout(
         () => controller.abort(),
@@ -187,7 +191,7 @@ export class HostProxyPoster {
     sha256: string,
   ): Promise<boolean> {
     try {
-      const url = `${this.baseUrl}/v1/transfers/${encodeURIComponent(transferId)}/content`;
+      const url = `${this.endpointBase}/transfers/${encodeURIComponent(transferId)}/content`;
       const timeout = computeTimeout(data.length);
       const controller = new AbortController();
       const timer = setTimeout(() => controller.abort(), timeout);
@@ -216,7 +220,7 @@ export class HostProxyPoster {
 
   private commonHeaders(): Record<string, string> {
     return {
-      Authorization: `Bearer ${this.authToken}`,
+      ...this.authHeaders(),
       "X-Vellum-Client-Id": getDeviceId(),
     };
   }
@@ -233,7 +237,7 @@ export class HostProxyPoster {
       try {
         const headers = this.commonHeaders();
         headers["Content-Type"] = "application/json";
-        const res = await this.fetchFn(`${this.baseUrl}${path}`, {
+        const res = await this.fetchFn(`${this.endpointBase}${path}`, {
           method: "POST",
           headers,
           body,

--- a/apps/macos/src/main/host-proxy-router.test.ts
+++ b/apps/macos/src/main/host-proxy-router.test.ts
@@ -44,6 +44,12 @@ mock.module("electron-log/main", () => {
   };
 });
 
+// Stub session-token-store
+let mockSessionToken: string | null = "test-session-token";
+mock.module("./session-token-store", () => ({
+  getSessionToken: () => mockSessionToken,
+}));
+
 const { HostProxySseClient } = await import("./host-proxy-sse");
 const { HostProxyPoster } = await import("./host-proxy-poster");
 const {
@@ -65,12 +71,18 @@ async function flush(ms = 20): Promise<void> {
   await new Promise((r) => setTimeout(r, ms));
 }
 
-// Mock globalThis.fetch for the /auth/token exchange used by connectAssistant.
+// Mock globalThis.fetch for /auth/token exchange (local) and /v1/organizations/ (cloud).
 const originalFetch = globalThis.fetch;
 const mockGatewayTokenFetch = async (input: string | URL | Request) => {
   const url = String(input);
   if (url.includes("/auth/token")) {
     return new Response(JSON.stringify({ token: "gateway-jwt", expiresAt: Date.now() + 60_000 }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+  if (url.includes("/v1/organizations/")) {
+    return new Response(JSON.stringify({ results: [{ id: "org-test-123" }] }), {
       status: 200,
       headers: { "Content-Type": "application/json" },
     });
@@ -87,8 +99,8 @@ function capturingPoster(): { poster: InstanceType<typeof HostProxyPoster>; body
     return new Response("ok");
   };
   const poster = new HostProxyPoster({
-    gatewayPort: 9000,
-    authToken: "t",
+    endpointBase: "http://127.0.0.1:9000/v1",
+    authHeaders: () => ({ Authorization: "Bearer t" }),
     fetch: fakeFetch as typeof globalThis.fetch,
   });
   return { poster, body: () => postedBody };
@@ -106,12 +118,13 @@ describe("host-proxy-router", () => {
     mockGetGuardianAccessToken.mockImplementation(
       async () => ({ ok: true, accessToken: "test-token" }),
     );
+    mockSessionToken = "test-session-token";
     globalThis.fetch = mockGatewayTokenFetch as typeof globalThis.fetch;
   });
 
-  // -- Lifecycle -----------------------------------------------------------
+  // -- Local lifecycle ----------------------------------------------------
 
-  describe("lifecycle", () => {
+  describe("local lifecycle", () => {
     test("connects when an assistant with a gatewayPort appears", async () => {
       installHostProxyBridge(fakeCliResolver);
 
@@ -131,6 +144,7 @@ describe("host-proxy-router", () => {
       const conn = __testing.connections.get("a1")!;
       expect(conn.sse).toBeInstanceOf(HostProxySseClient);
       expect(conn.poster).toBeInstanceOf(HostProxyPoster);
+      expect(conn.fingerprint).toBe("local:9001");
     });
 
     test("disconnects when an assistant is retired", async () => {
@@ -152,7 +166,7 @@ describe("host-proxy-router", () => {
       expect(__testing.connections.has("a1")).toBe(false);
     });
 
-    test("ignores assistants without resources", async () => {
+    test("ignores assistants without resources or runtimeUrl", async () => {
       installHostProxyBridge(fakeCliResolver);
 
       lockfileListener?.({
@@ -219,6 +233,148 @@ describe("host-proxy-router", () => {
     });
   });
 
+  // -- Cloud lifecycle ----------------------------------------------------
+
+  describe("cloud lifecycle", () => {
+    test("connects when a cloud assistant with runtimeUrl appears", async () => {
+      installHostProxyBridge(fakeCliResolver);
+
+      lockfileListener?.({
+        assistants: [
+          {
+            assistantId: "cloud-1",
+            cloud: "vellum",
+            runtimeUrl: "https://platform.vellum.ai",
+          },
+        ],
+        activeAssistant: "cloud-1",
+      });
+      await flush();
+
+      expect(__testing.connections.has("cloud-1")).toBe(true);
+      const conn = __testing.connections.get("cloud-1")!;
+      expect(conn.sse).toBeInstanceOf(HostProxySseClient);
+      expect(conn.poster).toBeInstanceOf(HostProxyPoster);
+      expect(conn.fingerprint).toBe("cloud:https://platform.vellum.ai");
+    });
+
+    test("skips cloud assistant when no session token is available", async () => {
+      mockSessionToken = null;
+      installHostProxyBridge(fakeCliResolver);
+
+      lockfileListener?.({
+        assistants: [
+          {
+            assistantId: "cloud-1",
+            cloud: "vellum",
+            runtimeUrl: "https://platform.vellum.ai",
+          },
+        ],
+        activeAssistant: "cloud-1",
+      });
+      await flush();
+
+      expect(__testing.connections.has("cloud-1")).toBe(false);
+    });
+
+    test("disconnects cloud assistant when removed from lockfile", async () => {
+      installHostProxyBridge(fakeCliResolver);
+
+      lockfileListener?.({
+        assistants: [
+          {
+            assistantId: "cloud-1",
+            cloud: "vellum",
+            runtimeUrl: "https://platform.vellum.ai",
+          },
+        ],
+        activeAssistant: "cloud-1",
+      });
+      await flush();
+      expect(__testing.connections.has("cloud-1")).toBe(true);
+
+      lockfileListener?.({ assistants: [], activeAssistant: null });
+      await flush();
+      expect(__testing.connections.has("cloud-1")).toBe(false);
+    });
+
+    test("handles mixed local and cloud assistants", async () => {
+      installHostProxyBridge(fakeCliResolver);
+
+      lockfileListener?.({
+        assistants: [
+          { assistantId: "local-1", resources: { gatewayPort: 9001, daemonPort: 9002 } },
+          { assistantId: "cloud-1", cloud: "vellum", runtimeUrl: "https://platform.vellum.ai" },
+        ],
+        activeAssistant: "local-1",
+      });
+      await flush();
+
+      expect(__testing.connections.has("local-1")).toBe(true);
+      expect(__testing.connections.has("cloud-1")).toBe(true);
+      expect(__testing.connections.get("local-1")!.fingerprint).toBe("local:9001");
+      expect(__testing.connections.get("cloud-1")!.fingerprint).toBe("cloud:https://platform.vellum.ai");
+    });
+
+    test("reconnects cloud assistant when runtimeUrl changes", async () => {
+      installHostProxyBridge(fakeCliResolver);
+
+      lockfileListener?.({
+        assistants: [
+          { assistantId: "cloud-1", cloud: "vellum", runtimeUrl: "https://old.vellum.ai" },
+        ],
+        activeAssistant: "cloud-1",
+      });
+      await flush();
+      const firstSse = __testing.connections.get("cloud-1")!.sse;
+
+      lockfileListener?.({
+        assistants: [
+          { assistantId: "cloud-1", cloud: "vellum", runtimeUrl: "https://new.vellum.ai" },
+        ],
+        activeAssistant: "cloud-1",
+      });
+      await flush();
+
+      expect(__testing.connections.has("cloud-1")).toBe(true);
+      expect(__testing.connections.get("cloud-1")!.sse).not.toBe(firstSse);
+      expect(__testing.connections.get("cloud-1")!.fingerprint).toBe("cloud:https://new.vellum.ai");
+    });
+
+    test("ignores non-vellum cloud assistants without resources", async () => {
+      installHostProxyBridge(fakeCliResolver);
+
+      lockfileListener?.({
+        assistants: [
+          { assistantId: "custom-1", cloud: "custom", runtimeUrl: "https://my-server.com" },
+        ],
+        activeAssistant: "custom-1",
+      });
+      await flush();
+
+      expect(__testing.connections.has("custom-1")).toBe(false);
+    });
+
+    test("does not duplicate cloud connections on repeated lockfile updates", async () => {
+      installHostProxyBridge(fakeCliResolver);
+
+      const lockfile: Lockfile = {
+        assistants: [
+          { assistantId: "cloud-1", cloud: "vellum", runtimeUrl: "https://platform.vellum.ai" },
+        ],
+        activeAssistant: "cloud-1",
+      };
+
+      lockfileListener?.(lockfile);
+      await flush();
+      const firstSse = __testing.connections.get("cloud-1")!.sse;
+
+      lockfileListener?.(lockfile);
+      await flush();
+      expect(__testing.connections.get("cloud-1")!.sse).toBe(firstSse);
+    });
+  });
+
   // -- Message dispatch ----------------------------------------------------
 
   describe("message dispatch", () => {
@@ -230,8 +386,8 @@ describe("host-proxy-router", () => {
       });
 
       const poster = new HostProxyPoster({
-        gatewayPort: 9000,
-        authToken: "t",
+        endpointBase: "http://127.0.0.1:9000/v1",
+        authHeaders: () => ({ Authorization: "Bearer t" }),
         fetch: (async () => new Response("ok")) as unknown as typeof globalThis.fetch,
       });
 
@@ -256,8 +412,8 @@ describe("host-proxy-router", () => {
       });
 
       const poster = new HostProxyPoster({
-        gatewayPort: 9000,
-        authToken: "t",
+        endpointBase: "http://127.0.0.1:9000/v1",
+        authHeaders: () => ({ Authorization: "Bearer t" }),
         fetch: (async () => new Response("ok")) as unknown as typeof globalThis.fetch,
       });
 
@@ -311,8 +467,8 @@ describe("host-proxy-router", () => {
 
     test("ignores unknown message types without crashing", () => {
       const poster = new HostProxyPoster({
-        gatewayPort: 9000,
-        authToken: "t",
+        endpointBase: "http://127.0.0.1:9000/v1",
+        authHeaders: () => ({ Authorization: "Bearer t" }),
         fetch: (async () => new Response("ok")) as unknown as typeof globalThis.fetch,
       });
 

--- a/apps/macos/src/main/host-proxy-router.ts
+++ b/apps/macos/src/main/host-proxy-router.ts
@@ -2,10 +2,12 @@
  * Host proxy message router and daemon connection lifecycle.
  *
  * Listens for lockfile changes and maintains an SSE + poster pair for each
- * local assistant that has a gatewayPort. When an assistant appears, the
- * router obtains a guardian token and connects; when it disappears, it
- * disconnects. Incoming SSE messages are dispatched to pluggable executors;
- * unimplemented executors post error results so daemon requests don't hang.
+ * assistant. Local assistants (with a gatewayPort) connect to the loopback
+ * gateway; cloud/managed assistants connect to the platform via
+ * assistant-scoped URLs with session-token auth.
+ *
+ * Incoming SSE messages are dispatched to pluggable executors; unimplemented
+ * executors post error results so daemon requests don't hang.
  */
 
 import {
@@ -22,6 +24,7 @@ import { hostFileExecutor } from "./executors/host-file-executor";
 import { hostTransferExecutor } from "./executors/host-transfer-executor";
 import { onLockfileChange, getWatchedLockfile } from "./lockfile-watcher";
 import { HostBrowserExecutor } from "./executors/host-browser-executor";
+import { getSessionToken } from "./session-token-store";
 import log from "./logger";
 
 // ---------------------------------------------------------------------------
@@ -40,7 +43,8 @@ export interface HostProxyExecutor {
 interface AssistantConnection {
   sse: HostProxySseClient;
   poster: HostProxyPoster;
-  gatewayPort: number;
+  /** Opaque string for detecting config changes that warrant a reconnect. */
+  fingerprint: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -162,9 +166,6 @@ function dispatchMessage(message: HostProxySseMessage, poster: HostProxyPoster):
 
 /**
  * Exchange a guardian access token for a gateway JWT via POST /auth/token.
- * The daemon requires a JWT with aud=vellum-daemon or aud=vellum-gateway;
- * the raw guardian token is an opaque string that cannot authenticate
- * directly against daemon endpoints.
  */
 async function exchangeForGatewayToken(
   gatewayPort: number,
@@ -228,7 +229,9 @@ async function acquireGatewayToken(
   return exchanged.token;
 }
 
-async function connectAssistant(
+// -- Local assistant connection ---------------------------------------------
+
+async function connectLocalAssistant(
   assistantId: string,
   gatewayPort: number,
 ): Promise<void> {
@@ -240,21 +243,87 @@ async function connectAssistant(
     return;
   }
 
-  const refreshToken = async (): Promise<string | null> => {
+  let currentToken = gatewayToken;
+  const authHeaders = () => ({ Authorization: `Bearer ${currentToken}` });
+
+  const onRefreshToken = async (): Promise<string | null> => {
     const fresh = await acquireGatewayToken(assistantId, gatewayPort);
-    if (fresh) poster.updateAuthToken(fresh);
+    if (fresh) currentToken = fresh;
     return fresh;
   };
 
-  const sse = new HostProxySseClient({ gatewayPort, authToken: gatewayToken, onRefreshToken: refreshToken });
-  const poster = new HostProxyPoster({ gatewayPort, authToken: gatewayToken });
+  const eventsUrl = `http://127.0.0.1:${gatewayPort}/v1/events`;
+  const endpointBase = `http://127.0.0.1:${gatewayPort}/v1`;
+
+  const sse = new HostProxySseClient({ eventsUrl, authHeaders, onRefreshToken });
+  const poster = new HostProxyPoster({ endpointBase, authHeaders });
 
   sse.setMessageCallback((msg) => dispatchMessage(msg, poster));
   sse.connect();
 
-  connections.set(assistantId, { sse, poster, gatewayPort });
-  log.info("[host-proxy-router] connected to assistant", { assistantId, gatewayPort });
+  connections.set(assistantId, { sse, poster, fingerprint: `local:${gatewayPort}` });
+  log.info("[host-proxy-router] connected to local assistant", { assistantId, gatewayPort });
 }
+
+// -- Cloud assistant connection ---------------------------------------------
+
+async function fetchOrganizationId(
+  runtimeUrl: string,
+  sessionToken: string,
+): Promise<string | null> {
+  try {
+    const res = await fetch(`${runtimeUrl}/v1/organizations/`, {
+      headers: { "X-Session-Token": sessionToken },
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { results?: Array<{ id: string }> };
+    return data.results?.[0]?.id ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function connectCloudAssistant(
+  assistantId: string,
+  runtimeUrl: string,
+): Promise<void> {
+  if (connections.has(assistantId)) return;
+
+  const sessionToken = getSessionToken();
+  if (!sessionToken) {
+    log.warn("[host-proxy-router] no session token, skipping cloud connection", { assistantId });
+    return;
+  }
+
+  const baseUrl = runtimeUrl.replace(/\/$/, "");
+
+  const organizationId = await fetchOrganizationId(baseUrl, sessionToken);
+  if (organizationId) {
+    log.info("[host-proxy-router] resolved organization for cloud assistant", { assistantId, organizationId });
+  }
+
+  const authHeaders = (): Record<string, string> => {
+    const token = getSessionToken();
+    if (!token) return {};
+    const headers: Record<string, string> = { "X-Session-Token": token };
+    if (organizationId) headers["Vellum-Organization-Id"] = organizationId;
+    return headers;
+  };
+
+  const eventsUrl = `${baseUrl}/v1/assistants/${encodeURIComponent(assistantId)}/events`;
+  const endpointBase = `${baseUrl}/v1/assistants/${encodeURIComponent(assistantId)}`;
+
+  const sse = new HostProxySseClient({ eventsUrl, authHeaders });
+  const poster = new HostProxyPoster({ endpointBase, authHeaders });
+
+  sse.setMessageCallback((msg) => dispatchMessage(msg, poster));
+  sse.connect();
+
+  connections.set(assistantId, { sse, poster, fingerprint: `cloud:${runtimeUrl}` });
+  log.info("[host-proxy-router] connected to cloud assistant", { assistantId, runtimeUrl });
+}
+
+// -- Disconnect -------------------------------------------------------------
 
 function disconnectAssistant(assistantId: string): void {
   const conn = connections.get(assistantId);
@@ -273,20 +342,27 @@ function handleLockfileChange(lockfile: Lockfile): void {
 
   for (const assistant of lockfile.assistants) {
     const port = assistant.resources?.gatewayPort;
-    if (!port) continue;
+    const isCloud = !port && assistant.cloud === "vellum" && assistant.runtimeUrl;
+    if (!port && !isCloud) continue;
+
     activeIds.add(assistant.assistantId);
+    const fp = port ? `local:${port}` : `cloud:${assistant.runtimeUrl}`;
 
     const existing = connections.get(assistant.assistantId);
-    if (!existing) {
-      void connectAssistant(assistant.assistantId, port);
-    } else if (existing.gatewayPort !== port) {
-      log.info("[host-proxy-router] gateway port changed, reconnecting", {
+    if (existing && existing.fingerprint !== fp) {
+      log.info("[host-proxy-router] connection config changed, reconnecting", {
         assistantId: assistant.assistantId,
-        oldPort: existing.gatewayPort,
-        newPort: port,
+        oldFingerprint: existing.fingerprint,
+        newFingerprint: fp,
       });
       disconnectAssistant(assistant.assistantId);
-      void connectAssistant(assistant.assistantId, port);
+    }
+    if (!connections.has(assistant.assistantId)) {
+      if (port) {
+        void connectLocalAssistant(assistant.assistantId, port);
+      } else {
+        void connectCloudAssistant(assistant.assistantId, assistant.runtimeUrl!);
+      }
     }
   }
 
@@ -352,7 +428,8 @@ export const __testing = {
     return executors;
   },
   dispatchMessage,
-  connectAssistant,
+  connectLocalAssistant,
+  connectCloudAssistant,
   disconnectAssistant,
   handleLockfileChange,
   reset() {

--- a/apps/macos/src/main/host-proxy-sse.test.ts
+++ b/apps/macos/src/main/host-proxy-sse.test.ts
@@ -84,8 +84,8 @@ describe("HostProxySseClient", () => {
     ]);
 
     client = new HostProxySseClient({
-      gatewayPort: 9999,
-      authToken: "tok",
+      eventsUrl: "http://127.0.0.1:9999/v1/events",
+      authHeaders: () => ({ Authorization: "Bearer tok" }),
       fetch: mockFetch(body),
     });
     client.setMessageCallback((m) => messages.push(m));
@@ -107,8 +107,8 @@ describe("HostProxySseClient", () => {
     ]);
 
     client = new HostProxySseClient({
-      gatewayPort: 9999,
-      authToken: "tok",
+      eventsUrl: "http://127.0.0.1:9999/v1/events",
+      authHeaders: () => ({ Authorization: "Bearer tok" }),
       fetch: mockFetch(body),
     });
     client.setMessageCallback((m) => messages.push(m));
@@ -128,8 +128,8 @@ describe("HostProxySseClient", () => {
     ]);
 
     client = new HostProxySseClient({
-      gatewayPort: 9999,
-      authToken: "tok",
+      eventsUrl: "http://127.0.0.1:9999/v1/events",
+      authHeaders: () => ({ Authorization: "Bearer tok" }),
       fetch: mockFetch(body),
     });
     client.setMessageCallback((m) => messages.push(m));
@@ -146,8 +146,8 @@ describe("HostProxySseClient", () => {
   test("isConnected reflects stream state", async () => {
     const { stream, close } = controllableStream();
     client = new HostProxySseClient({
-      gatewayPort: 9999,
-      authToken: "tok",
+      eventsUrl: "http://127.0.0.1:9999/v1/events",
+      authHeaders: () => ({ Authorization: "Bearer tok" }),
       fetch: mockFetch(stream),
     });
 
@@ -184,8 +184,8 @@ describe("HostProxySseClient", () => {
     }) as unknown as typeof globalThis.fetch;
 
     client = new HostProxySseClient({
-      gatewayPort: 9999,
-      authToken: "tok",
+      eventsUrl: "http://127.0.0.1:9999/v1/events",
+      authHeaders: () => ({ Authorization: "Bearer tok" }),
       fetch: fakeFetch,
     });
     client.setMessageCallback((m) => messages.push(m));
@@ -213,8 +213,8 @@ describe("HostProxySseClient", () => {
 
     const messages: HostProxySseMessage[] = [];
     client = new HostProxySseClient({
-      gatewayPort: 9999,
-      authToken: "tok",
+      eventsUrl: "http://127.0.0.1:9999/v1/events",
+      authHeaders: () => ({ Authorization: "Bearer tok" }),
       fetch: fakeFetch,
     });
     client.setMessageCallback((m) => messages.push(m));
@@ -249,8 +249,8 @@ describe("HostProxySseClient", () => {
 
     const messages: HostProxySseMessage[] = [];
     client = new HostProxySseClient({
-      gatewayPort: 9999,
-      authToken: "tok",
+      eventsUrl: "http://127.0.0.1:9999/v1/events",
+      authHeaders: () => ({ Authorization: "Bearer tok" }),
       fetch: fakeFetch,
       idleTimeoutMs: 200,
       idleCheckIntervalMs: 100,
@@ -285,8 +285,8 @@ describe("HostProxySseClient", () => {
     }) as unknown as typeof globalThis.fetch;
 
     client = new HostProxySseClient({
-      gatewayPort: 9999,
-      authToken: "tok",
+      eventsUrl: "http://127.0.0.1:9999/v1/events",
+      authHeaders: () => ({ Authorization: "Bearer tok" }),
       fetch: fakeFetch,
     });
     client.connect();
@@ -303,7 +303,7 @@ describe("HostProxySseClient", () => {
 
   // -- Request headers ----------------------------------------------------
 
-  test("sends correct headers", async () => {
+  test("sends correct headers for local connection", async () => {
     let capturedUrl = "";
     let capturedHeaders: Record<string, string> = {};
 
@@ -321,8 +321,8 @@ describe("HostProxySseClient", () => {
     }) as unknown as typeof globalThis.fetch;
 
     client = new HostProxySseClient({
-      gatewayPort: 8080,
-      authToken: "my-token",
+      eventsUrl: "http://127.0.0.1:8080/v1/events",
+      authHeaders: () => ({ Authorization: "Bearer my-token" }),
       fetch: fakeFetch,
     });
     client.connect();
@@ -338,6 +338,38 @@ describe("HostProxySseClient", () => {
     expect(capturedHeaders["X-Vellum-Machine-Name"]).toBeTruthy();
   });
 
+  test("sends correct headers for cloud connection", async () => {
+    let capturedUrl = "";
+    let capturedHeaders: Record<string, string> = {};
+
+    const fakeFetch: typeof globalThis.fetch = (async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      capturedUrl = String(input);
+      const h = init?.headers as Record<string, string> | undefined;
+      if (h) capturedHeaders = { ...h };
+      return new Response(sseStream([]), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      });
+    }) as unknown as typeof globalThis.fetch;
+
+    client = new HostProxySseClient({
+      eventsUrl: "https://platform.vellum.ai/v1/assistants/asst-123/events",
+      authHeaders: () => ({ "X-Session-Token": "session-tok-abc" }),
+      fetch: fakeFetch,
+    });
+    client.connect();
+    await flush(50);
+
+    expect(capturedUrl).toBe("https://platform.vellum.ai/v1/assistants/asst-123/events");
+    expect(capturedHeaders["X-Session-Token"]).toBe("session-tok-abc");
+    expect(capturedHeaders["Authorization"]).toBeUndefined();
+    expect(capturedHeaders["X-Vellum-Client-Id"]).toBe(MOCK_DEVICE_ID);
+    expect(capturedHeaders["X-Vellum-Interface-Id"]).toBe("macos");
+  });
+
   // -- Chunked data handling ----------------------------------------------
 
   test("handles data split across multiple chunks", async () => {
@@ -349,8 +381,8 @@ describe("HostProxySseClient", () => {
     ]);
 
     client = new HostProxySseClient({
-      gatewayPort: 9999,
-      authToken: "tok",
+      eventsUrl: "http://127.0.0.1:9999/v1/events",
+      authHeaders: () => ({ Authorization: "Bearer tok" }),
       fetch: mockFetch(body),
     });
     client.setMessageCallback((m) => messages.push(m));

--- a/apps/macos/src/main/host-proxy-sse.ts
+++ b/apps/macos/src/main/host-proxy-sse.ts
@@ -1,11 +1,13 @@
 /**
  * SSE client for the host proxy subsystem in the Electron main process.
  *
- * Connects to the daemon's `/v1/events` endpoint, parses SSE frames
- * (`data: <json>\n\n` for messages, `: <comment>\n` for heartbeats),
- * and emits parsed JSON payloads via a callback. Reconnects automatically
- * with exponential backoff and detects stale connections via an idle
- * watchdog.
+ * Connects to an events endpoint, parses SSE frames (`data: <json>\n\n`
+ * for messages, `: <comment>\n` for heartbeats), and emits parsed JSON
+ * payloads via a callback. Reconnects automatically with exponential
+ * backoff and detects stale connections via an idle watchdog.
+ *
+ * Supports both local gateway connections and cloud/platform connections
+ * — the caller provides the full events URL and an auth-headers builder.
  */
 
 import { hostname } from "node:os";
@@ -13,16 +15,17 @@ import { hostname } from "node:os";
 import { getDeviceId } from "./device-id";
 
 export interface HostProxySseOptions {
-  gatewayPort: number;
-  gatewayHost?: string;
-  authToken: string;
+  /** Full URL for the events endpoint. */
+  eventsUrl: string;
+  /** Called on every connect attempt to build auth headers. */
+  authHeaders: () => Record<string, string>;
   /** Injectable fetch for testing. Defaults to globalThis.fetch. */
   fetch?: typeof globalThis.fetch;
   /** Override idle timeout for testing. */
   idleTimeoutMs?: number;
   /** Override idle check interval for testing. */
   idleCheckIntervalMs?: number;
-  /** Called before each reconnect — return a fresh token or null to keep the current one. */
+  /** Called before each reconnect — return a fresh token or null. */
   onRefreshToken?: () => Promise<string | null>;
 }
 
@@ -39,9 +42,8 @@ const IDLE_TIMEOUT_MS = 30_000;
 const IDLE_CHECK_INTERVAL_MS = 10_000;
 
 export class HostProxySseClient {
-  private readonly gatewayPort: number;
-  private readonly gatewayHost: string;
-  private authToken: string;
+  private readonly eventsUrl: string;
+  private readonly authHeaders: () => Record<string, string>;
   private readonly fetchFn: typeof globalThis.fetch;
   private readonly idleTimeoutMs: number;
   private readonly idleCheckIntervalMs: number;
@@ -57,9 +59,8 @@ export class HostProxySseClient {
   private shouldReconnect = false;
 
   constructor(options: HostProxySseOptions) {
-    this.gatewayPort = options.gatewayPort;
-    this.gatewayHost = options.gatewayHost ?? "127.0.0.1";
-    this.authToken = options.authToken;
+    this.eventsUrl = options.eventsUrl;
+    this.authHeaders = options.authHeaders;
     this.fetchFn = options.fetch ?? globalThis.fetch;
     this.idleTimeoutMs = options.idleTimeoutMs ?? IDLE_TIMEOUT_MS;
     this.idleCheckIntervalMs = options.idleCheckIntervalMs ?? IDLE_CHECK_INTERVAL_MS;
@@ -95,11 +96,6 @@ export class HostProxySseClient {
     this._connected = false;
   }
 
-  /** Replace the auth token (e.g. after token rotation). */
-  updateAuthToken(token: string): void {
-    this.authToken = token;
-  }
-
   // -- Stream lifecycle ---------------------------------------------------
 
   private startStream(): void {
@@ -107,20 +103,15 @@ export class HostProxySseClient {
     const controller = new AbortController();
     this.abortController = controller;
 
-    const url = `http://${this.gatewayHost}:${this.gatewayPort}/v1/events`;
     const headers: Record<string, string> = {
       Accept: "text/event-stream, application/json",
       "X-Vellum-Client-Id": getDeviceId(),
-      // "macos" advertises all 5 host capabilities (including host_cu and
-      // host_app_control which aren't implemented yet). Unimplemented
-      // capabilities return stub errors via the router so the daemon doesn't
-      // hang. A selective capability mechanism requires daemon-side changes.
       "X-Vellum-Interface-Id": "macos",
       "X-Vellum-Machine-Name": hostname(),
-      Authorization: `Bearer ${this.authToken}`,
+      ...this.authHeaders(),
     };
 
-    this.fetchFn(url, { headers, signal: controller.signal })
+    this.fetchFn(this.eventsUrl, { headers, signal: controller.signal })
       .then((response) => this.handleResponse(response))
       .catch((err: unknown) => {
         if (isAbortError(err)) return;
@@ -222,10 +213,9 @@ export class HostProxySseClient {
       if (!this.shouldReconnect) return;
       if (this.onRefreshToken) {
         try {
-          const freshToken = await this.onRefreshToken();
-          if (freshToken) this.authToken = freshToken;
+          await this.onRefreshToken();
         } catch {
-          // Token refresh failed — reconnect with existing token
+          // Token refresh failed — reconnect with existing headers
         }
       }
       this.startStream();

--- a/gateway/src/__tests__/actor-token-revocation.test.ts
+++ b/gateway/src/__tests__/actor-token-revocation.test.ts
@@ -8,6 +8,8 @@ import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { eq } from "drizzle-orm";
+
 import { initSigningKey, mintToken } from "../auth/token-service.js";
 import { CURRENT_POLICY_EPOCH } from "../auth/policy.js";
 import type { TokenClaims } from "../auth/types.js";
@@ -18,7 +20,7 @@ const { initGatewayDb, resetGatewayDb, getGatewayDb } =
   await import("../db/connection.js");
 const { actorTokenRecords } = await import("../db/schema.js");
 const { hashToken } = await import("../auth/guardian-bootstrap.js");
-const { isActorTokenRevoked } =
+const { isActorTokenRevoked, actorTokenRecordHash } =
   await import("../auth/actor-token-revocation.js");
 const { createRuntimeProxyHandler } =
   await import("../http/routes/runtime-proxy.js");
@@ -230,6 +232,47 @@ describe("/auth/token revocation", () => {
     );
 
     expect(res.status).toBe(401);
+  });
+
+  test("records a derived token so device revocation invalidates it", async () => {
+    const { handleCreateToken } = await import("../http/routes/auth-token.js");
+    const { revokeActorTokensByDevice } =
+      await import("../auth/guardian-bootstrap.js");
+    const sourceJwt = mintToken({
+      aud: "vellum-gateway",
+      sub: ACTOR_SUB,
+      scope_profile: "actor_client_v1",
+      policy_epoch: CURRENT_POLICY_EPOCH,
+      ttlSeconds: 3600,
+    });
+    insertTokenRecord(sourceJwt, "active");
+
+    const res = await handleCreateToken(
+      new Request("http://127.0.0.1:7830/auth/token", {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${sourceJwt}`,
+          origin: "http://localhost:3000",
+        },
+      }),
+      makeLoopbackServer(),
+    );
+
+    expect(res.status).toBe(200);
+    const { token: derivedJwt } = (await res.json()) as { token: string };
+    const derivedRecord = getGatewayDb()
+      .select({ status: actorTokenRecords.status })
+      .from(actorTokenRecords)
+      .where(eq(actorTokenRecords.tokenHash, actorTokenRecordHash(derivedJwt)))
+      .get();
+
+    expect(derivedRecord?.status).toBe("derived");
+    expect(isActorTokenRevoked(derivedJwt, actorClaims)).toBe(false);
+
+    revokeActorTokensByDevice("guardian-001", hashToken("device-A"));
+
+    expect(isActorTokenRevoked(sourceJwt, actorClaims)).toBe(true);
+    expect(isActorTokenRevoked(derivedJwt, actorClaims)).toBe(true);
   });
 });
 

--- a/gateway/src/auth/actor-token-revocation.ts
+++ b/gateway/src/auth/actor-token-revocation.ts
@@ -74,6 +74,17 @@ function canonicalizeTokenForHash(rawToken: string): string {
 }
 
 /**
+ * Hash a caller-supplied actor token exactly as revocation lookups do.
+ *
+ * Use this for DB writes/reads that need to line up with
+ * `isActorTokenRevoked`, including token-mint paths that persist derived
+ * actor tokens for later device revocation.
+ */
+export function actorTokenRecordHash(rawToken: string): string {
+  return hashToken(canonicalizeTokenForHash(rawToken));
+}
+
+/**
  * True only when `rawToken` is an actor token with an explicitly revoked record.
  * Fail-open in every other case (non-actor, no record, DB error).
  */
@@ -86,7 +97,7 @@ export function isActorTokenRevoked(
     return false;
   }
 
-  const tokenHash = hashToken(canonicalizeTokenForHash(rawToken));
+  const tokenHash = actorTokenRecordHash(rawToken);
 
   try {
     const record = getGatewayDb()

--- a/gateway/src/auth/guardian-bootstrap.ts
+++ b/gateway/src/auth/guardian-bootstrap.ts
@@ -8,7 +8,7 @@
 
 import { createHash, randomBytes } from "node:crypto";
 
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 
 import { getGatewayDb } from "../db/connection.js";
 import {
@@ -427,7 +427,7 @@ export function revokeActorTokensByDevice(
       and(
         eq(actorTokenRecords.guardianPrincipalId, guardianPrincipalId),
         eq(actorTokenRecords.hashedDeviceId, hashedDeviceId),
-        eq(actorTokenRecords.status, "active"),
+        inArray(actorTokenRecords.status, ["active", "derived"]),
       ),
     )
     .run();

--- a/gateway/src/auth/guardian-refresh.ts
+++ b/gateway/src/auth/guardian-refresh.ts
@@ -5,7 +5,7 @@
 
 import { randomBytes } from "node:crypto";
 
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 
 import { getGatewayDb } from "../db/connection.js";
 import { actorRefreshTokenRecords, actorTokenRecords } from "../db/schema.js";
@@ -81,7 +81,7 @@ function revokeFamily(familyId: string): void {
     .run();
 }
 
-function revokeActorTokensByDevice(
+function revokeActiveActorTokensByDevice(
   guardianPrincipalId: string,
   hashedDeviceId: string,
 ): void {
@@ -94,6 +94,24 @@ function revokeActorTokensByDevice(
         eq(actorTokenRecords.guardianPrincipalId, guardianPrincipalId),
         eq(actorTokenRecords.hashedDeviceId, hashedDeviceId),
         eq(actorTokenRecords.status, "active"),
+      ),
+    )
+    .run();
+}
+
+function revokeAllActorTokensByDevice(
+  guardianPrincipalId: string,
+  hashedDeviceId: string,
+): void {
+  const now = Date.now();
+  getGatewayDb()
+    .update(actorTokenRecords)
+    .set({ status: "revoked", updatedAt: now })
+    .where(
+      and(
+        eq(actorTokenRecords.guardianPrincipalId, guardianPrincipalId),
+        eq(actorTokenRecords.hashedDeviceId, hashedDeviceId),
+        inArray(actorTokenRecords.status, ["active", "derived"]),
       ),
     )
     .run();
@@ -232,7 +250,7 @@ export function rotateCredentials(params: {
       "Refresh token reuse detected — revoking entire family",
     );
     revokeFamily(record.familyId);
-    revokeActorTokensByDevice(
+    revokeAllActorTokensByDevice(
       record.guardianPrincipalId,
       record.hashedDeviceId,
     );
@@ -261,7 +279,7 @@ export function rotateCredentials(params: {
       return { ok: false as const, error: "refresh_reuse_detected" as const };
     }
 
-    revokeActorTokensByDevice(
+    revokeActiveActorTokensByDevice(
       record.guardianPrincipalId,
       record.hashedDeviceId,
     );

--- a/gateway/src/http/routes/auth-token.ts
+++ b/gateway/src/http/routes/auth-token.ts
@@ -1,9 +1,16 @@
 import type { Server } from "bun";
 
-import { isActorTokenRevoked } from "../../auth/actor-token-revocation.js";
+import { eq } from "drizzle-orm";
+
+import {
+  actorTokenRecordHash,
+  isActorTokenRevoked,
+} from "../../auth/actor-token-revocation.js";
 import { ensureVellumGuardianBinding } from "../../auth/guardian-bootstrap.js";
 import { CURRENT_POLICY_EPOCH } from "../../auth/policy.js";
 import { mintToken, verifyToken } from "../../auth/token-service.js";
+import { getGatewayDb } from "../../db/connection.js";
+import { actorTokenRecords } from "../../db/schema.js";
 import { getLogger } from "../../logger.js";
 import { isLoopbackPeer } from "../../util/is-loopback-address.js";
 
@@ -12,6 +19,69 @@ const log = getLogger("auth-token");
 const WEB_ORIGIN_RE = /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/;
 
 const TOKEN_TTL_SECONDS = 30 * 24 * 60 * 60;
+
+interface SourceActorTokenRecord {
+  guardianPrincipalId: string;
+  hashedDeviceId: string;
+  platform: string;
+}
+
+function findSourceActorTokenRecord(
+  sourceToken: string,
+): SourceActorTokenRecord | null {
+  try {
+    return (
+      getGatewayDb()
+        .select({
+          guardianPrincipalId: actorTokenRecords.guardianPrincipalId,
+          hashedDeviceId: actorTokenRecords.hashedDeviceId,
+          platform: actorTokenRecords.platform,
+        })
+        .from(actorTokenRecords)
+        .where(
+          eq(actorTokenRecords.tokenHash, actorTokenRecordHash(sourceToken)),
+        )
+        .get() ?? null
+    );
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "Source actor-token lookup failed — minting unrecorded compatibility token",
+    );
+    return null;
+  }
+}
+
+function recordDerivedActorToken(
+  sourceRecord: SourceActorTokenRecord | null,
+  derivedToken: string,
+): void {
+  if (!sourceRecord) return;
+
+  const now = Date.now();
+  try {
+    getGatewayDb()
+      .insert(actorTokenRecords)
+      .values({
+        id: crypto.randomUUID(),
+        tokenHash: actorTokenRecordHash(derivedToken),
+        guardianPrincipalId: sourceRecord.guardianPrincipalId,
+        hashedDeviceId: sourceRecord.hashedDeviceId,
+        platform: sourceRecord.platform,
+        status: "derived",
+        issuedAt: now,
+        expiresAt: now + TOKEN_TTL_SECONDS * 1000,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "Derived actor-token record insert failed — minted token remains compatible but unrecorded",
+    );
+  }
+}
 
 export async function handleCreateToken(
   req: Request,
@@ -59,7 +129,9 @@ export async function handleCreateToken(
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const guardianPrincipalId = await ensureVellumGuardianBinding();
+  const sourceRecord = findSourceActorTokenRecord(bearerToken);
+  const guardianPrincipalId =
+    sourceRecord?.guardianPrincipalId ?? (await ensureVellumGuardianBinding());
 
   const token = mintToken({
     aud: "vellum-gateway",
@@ -68,6 +140,8 @@ export async function handleCreateToken(
     policy_epoch: CURRENT_POLICY_EPOCH,
     ttlSeconds: TOKEN_TTL_SECONDS,
   });
+
+  recordDerivedActorToken(sourceRecord, token);
 
   const expiresAt = Math.floor(Date.now() / 1000) + TOKEN_TTL_SECONDS;
   log.info("Bearer token minted for web local mode");


### PR DESCRIPTION
## Summary
- Cherry-picks **#34049** — `feat(macos): support host proxy for cloud/managed assistants`
- Cherry-picks **#34052** — `fix(gateway): persist derived actor tokens so device revocation invalidates them`

## Test plan
- [ ] Verify host proxy works for cloud/managed assistants
- [ ] Verify device revocation invalidates derived actor tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)