### PR TITLE
Polish one-time schedule row affordance

### DIFF
--- a/apps/web/src/domains/settings/components/schedule-row.tsx
+++ b/apps/web/src/domains/settings/components/schedule-row.tsx
@@ -28,11 +28,11 @@ export function ScheduleRow({
   onOpenUsage: () => void;
 }) {
   return (
-    <div className="flex flex-wrap items-center gap-3 py-3 first:pt-0 last:pb-0 [&+&]:border-t [&+&]:border-[var(--border-base)]">
+    <div className="flex flex-wrap items-center gap-3 rounded-md px-2 py-3 transition-colors hover:bg-[var(--surface-hover)] [&+&]:border-t [&+&]:border-[var(--border-base)]">
       <button
         type="button"
         onClick={onClick}
-        className="min-w-0 flex-1 text-left"
+        className="min-w-0 flex-1 cursor-pointer text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
       >
         <div className="flex items-center gap-2">
           <span className="truncate text-body-medium-default text-[var(--content-default)]">

--- a/apps/web/src/domains/settings/pages/schedules-page.test.ts
+++ b/apps/web/src/domains/settings/pages/schedules-page.test.ts
@@ -433,6 +433,39 @@ describe("ScheduleRow", () => {
     expect(detailClicks).toBe(0);
   });
 
+  test("one-time rows use the shared clickable row affordance", () => {
+    const { container } = render(
+      createElement(ScheduleRow, {
+        schedule: rowSchedule({
+          description: "One-time",
+          isOneShot: true,
+        }),
+        usage: {
+          status: "ready",
+          summary: {
+            scheduleId: "schedule-123",
+            runCount: 0,
+            totalEstimatedCostUsd: 0,
+            eventCount: 0,
+          },
+        },
+        onClick: () => {},
+        onToggle: () => {},
+        onOpenUsage: () => {},
+      }),
+    );
+
+    const row = container.firstElementChild;
+    expect(row?.className).toContain("rounded-md");
+    expect(row?.className).toContain("hover:bg-[var(--surface-hover)]");
+
+    const detailButton = screen.getByText("Daily summary").closest("button");
+    expect(detailButton?.className).toContain("cursor-pointer");
+    expect(detailButton?.className).toContain(
+      "focus-visible:ring-[var(--ring)]",
+    );
+  });
+
   test("renders loading placeholders and unavailable error stats", () => {
     const { rerender } = render(
       createElement(ScheduleRow, {


### PR DESCRIPTION
## Summary
- Apply the same rounded hover surface and pointer/focus treatment to regular schedule rows that System rows already use
- Cover the missed one-time row case with a focused ScheduleRow regression test

## Verification
- `cd apps/web && bun test src/domains/settings/pages/schedules-page.test.ts`
- `cd apps/web && bun run lint src/domains/settings/components/schedule-row.tsx src/domains/settings/pages/schedules-page.test.ts`
- `cd apps/web && bun run typecheck`
- `git diff --check`