### PR TITLE
fix(assistant): enforce path policy and size guards in Electron host-file executor

### DIFF
--- a/apps/macos/src/main/executors/host-file-executor.test.ts
+++ b/apps/macos/src/main/executors/host-file-executor.test.ts
@@ -276,6 +276,19 @@ describe("host-file-executor", () => {
       expect(fs.readFileSync(target, "utf-8")).toBe("original");
     });
 
+    test("rejects writing through dangling symlink to denied basename", () => {
+      const dir = freshTmpDir();
+      const target = path.join(dir, "backup.key");
+      const link = path.join(dir, "harmless.txt");
+      // Target doesn't exist — symlink is dangling
+      fs.symlinkSync(target, link);
+
+      const result = __testing.executeWrite({ path: link, content: "secret" });
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain('Access to "backup.key" is denied');
+      expect(fs.existsSync(target)).toBe(false);
+    });
+
     test("rejects writing to existing non-regular file", () => {
       const result = __testing.executeWrite({ path: "/dev/null", content: "data" });
       expect(result.isError).toBe(true);

--- a/apps/macos/src/main/executors/host-file-executor.test.ts
+++ b/apps/macos/src/main/executors/host-file-executor.test.ts
@@ -263,6 +263,25 @@ describe("host-file-executor", () => {
       }
     });
 
+    test("rejects writing through symlink to denied basename", () => {
+      const dir = freshTmpDir();
+      const target = path.join(dir, ".backup.key");
+      const link = path.join(dir, "innocent.txt");
+      fs.writeFileSync(target, "original");
+      fs.symlinkSync(target, link);
+
+      const result = __testing.executeWrite({ path: link, content: "overwritten" });
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain('Access to ".backup.key" is denied');
+      expect(fs.readFileSync(target, "utf-8")).toBe("original");
+    });
+
+    test("rejects writing to existing non-regular file", () => {
+      const result = __testing.executeWrite({ path: "/dev/null", content: "data" });
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("Not a regular file");
+    });
+
     test("writes content to file", () => {
       const dir = freshTmpDir();
       const filePath = path.join(dir, "out.txt");

--- a/apps/macos/src/main/executors/host-file-executor.test.ts
+++ b/apps/macos/src/main/executors/host-file-executor.test.ts
@@ -163,6 +163,18 @@ describe("host-file-executor", () => {
       expect(result.content).toContain('Access to ".backup.key" is denied');
     });
 
+    test("rejects symlinks pointing to denied basenames", () => {
+      const dir = freshTmpDir();
+      const target = path.join(dir, ".backup.key");
+      const link = path.join(dir, "innocent.txt");
+      fs.writeFileSync(target, "secret");
+      fs.symlinkSync(target, link);
+
+      const result = __testing.executeRead({ path: link });
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain('Access to ".backup.key" is denied');
+    });
+
     test("rejects non-regular files before reading", () => {
       const result = __testing.executeRead({ path: "/dev/null" });
       expect(result.isError).toBe(true);
@@ -300,6 +312,22 @@ describe("host-file-executor", () => {
       });
       expect(result.isError).toBe(true);
       expect(result.content).toContain("exceeds the 100.0 MB limit");
+    });
+
+    test("rejects edits that would produce oversized output", () => {
+      const dir = freshTmpDir();
+      const filePath = path.join(dir, "small.txt");
+      fs.writeFileSync(filePath, "REPLACE_ME");
+
+      const bigString = "x".repeat(100 * 1024 * 1024 + 1);
+      const result = __testing.executeEdit({
+        path: filePath,
+        old_string: "REPLACE_ME",
+        new_string: bigString,
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("exceeds the 100.0 MB limit");
+      expect(fs.readFileSync(filePath, "utf-8")).toBe("REPLACE_ME");
     });
 
     test("replaces unique string", () => {

--- a/apps/macos/src/main/executors/host-file-executor.test.ts
+++ b/apps/macos/src/main/executors/host-file-executor.test.ts
@@ -153,6 +153,33 @@ describe("host-file-executor", () => {
   // -- Read -----------------------------------------------------------------
 
   describe("read", () => {
+    test("rejects denied backup key basenames before reading", () => {
+      const dir = freshTmpDir();
+      const filePath = path.join(dir, ".backup.key");
+      fs.writeFileSync(filePath, "secret");
+
+      const result = __testing.executeRead({ path: filePath });
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain('Access to ".backup.key" is denied');
+    });
+
+    test("rejects non-regular files before reading", () => {
+      const result = __testing.executeRead({ path: "/dev/null" });
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("Not a regular file");
+    });
+
+    test("rejects oversized files before reading", () => {
+      const dir = freshTmpDir();
+      const filePath = path.join(dir, "large.txt");
+      fs.closeSync(fs.openSync(filePath, "w"));
+      fs.truncateSync(filePath, 100 * 1024 * 1024 + 1);
+
+      const result = __testing.executeRead({ path: filePath });
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("exceeds the 100.0 MB limit");
+    });
+
     test("reads text file and returns content", () => {
       const dir = freshTmpDir();
       const filePath = path.join(dir, "hello.txt");
@@ -202,6 +229,28 @@ describe("host-file-executor", () => {
   // -- Write ----------------------------------------------------------------
 
   describe("write", () => {
+    test("rejects denied backup key basenames before writing", () => {
+      const dir = freshTmpDir();
+      const filePath = path.join(dir, "backup.key");
+
+      const result = __testing.executeWrite({ path: filePath, content: "secret" });
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain('Access to "backup.key" is denied');
+      expect(fs.existsSync(filePath)).toBe(false);
+    });
+
+    test("rejects oversized content before writing", () => {
+      const dir = freshTmpDir();
+      const filePath = path.join(dir, "large.txt");
+      const result = __testing.validateContentSize("x".repeat(100 * 1024 * 1024 + 1), filePath);
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.isError).toBe(true);
+        expect(result.content).toContain("exceeds the 100.0 MB limit");
+      }
+    });
+
     test("writes content to file", () => {
       const dir = freshTmpDir();
       const filePath = path.join(dir, "out.txt");
@@ -223,6 +272,36 @@ describe("host-file-executor", () => {
   // -- Edit -----------------------------------------------------------------
 
   describe("edit", () => {
+    test("rejects denied backup key basenames before editing", () => {
+      const dir = freshTmpDir();
+      const filePath = path.join(dir, ".backup.key");
+      fs.writeFileSync(filePath, "old secret");
+
+      const result = __testing.executeEdit({
+        path: filePath,
+        old_string: "old",
+        new_string: "new",
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain('Access to ".backup.key" is denied');
+      expect(fs.readFileSync(filePath, "utf-8")).toBe("old secret");
+    });
+
+    test("rejects oversized files before editing", () => {
+      const dir = freshTmpDir();
+      const filePath = path.join(dir, "large.txt");
+      fs.closeSync(fs.openSync(filePath, "w"));
+      fs.truncateSync(filePath, 100 * 1024 * 1024 + 1);
+
+      const result = __testing.executeEdit({
+        path: filePath,
+        old_string: "old",
+        new_string: "new",
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("exceeds the 100.0 MB limit");
+    });
+
     test("replaces unique string", () => {
       const dir = freshTmpDir();
       const filePath = path.join(dir, "edit.txt");

--- a/apps/macos/src/main/executors/host-file-executor.test.ts
+++ b/apps/macos/src/main/executors/host-file-executor.test.ts
@@ -289,6 +289,21 @@ describe("host-file-executor", () => {
       expect(fs.existsSync(target)).toBe(false);
     });
 
+    test("rejects writing through multi-level symlink chain to denied basename", () => {
+      const dir = freshTmpDir();
+      const target = path.join(dir, ".backup.key");
+      const mid = path.join(dir, "intermediate");
+      const link = path.join(dir, "harmless.txt");
+      fs.writeFileSync(target, "original");
+      fs.symlinkSync(target, mid);
+      fs.symlinkSync(mid, link);
+
+      const result = __testing.executeWrite({ path: link, content: "overwritten" });
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain('Access to ".backup.key" is denied');
+      expect(fs.readFileSync(target, "utf-8")).toBe("original");
+    });
+
     test("rejects writing to existing non-regular file", () => {
       const result = __testing.executeWrite({ path: "/dev/null", content: "data" });
       expect(result.isError).toBe(true);

--- a/apps/macos/src/main/executors/host-file-executor.ts
+++ b/apps/macos/src/main/executors/host-file-executor.ts
@@ -8,11 +8,69 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
+import type { Stats } from "node:fs";
 
 import type { HostProxyExecutor } from "../host-proxy-router";
 import type { HostProxyPoster } from "../host-proxy-poster";
 import type { HostProxySseMessage } from "../host-proxy-sse";
 import log from "../logger";
+
+// ---------------------------------------------------------------------------
+// Host filesystem safety checks
+// ---------------------------------------------------------------------------
+
+const MAX_FILE_SIZE_BYTES = 100 * 1024 * 1024;
+const DENIED_BASENAMES = new Set([".backup.key", "backup.key"]);
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function validateHostPath(rawPath: string): { ok: true; path: string } | { ok: false; content: string; isError: true } {
+  if (!path.isAbsolute(rawPath)) {
+    return { content: `path must be absolute for host file access: ${rawPath}`, isError: true, ok: false };
+  }
+
+  const basename = path.basename(rawPath);
+  if (DENIED_BASENAMES.has(basename)) {
+    return { content: `Access to "${basename}" is denied`, isError: true, ok: false };
+  }
+
+  return { ok: true, path: rawPath };
+}
+
+function validateRegularFile(filePath: string): { ok: true; stat: Stats } | { ok: false; content: string; isError: true } {
+  const stat = fs.statSync(filePath);
+  if (!stat.isFile()) {
+    return { content: `Not a regular file: ${filePath}`, isError: true, ok: false };
+  }
+  return { ok: true, stat };
+}
+
+function validateFileSize(filePath: string, size: number): { ok: true } | { ok: false; content: string; isError: true } {
+  if (size > MAX_FILE_SIZE_BYTES) {
+    return {
+      content: `File size (${formatBytes(size)}) exceeds the ${formatBytes(MAX_FILE_SIZE_BYTES)} limit: ${filePath}`,
+      isError: true,
+      ok: false,
+    };
+  }
+  return { ok: true };
+}
+
+function validateContentSize(content: string, filePath: string): { ok: true } | { ok: false; content: string; isError: true } {
+  const size = Buffer.byteLength(content, "utf-8");
+  if (size > MAX_FILE_SIZE_BYTES) {
+    return {
+      content: `Content size (${formatBytes(size)}) exceeds the ${formatBytes(MAX_FILE_SIZE_BYTES)} limit for: ${filePath}`,
+      isError: true,
+      ok: false,
+    };
+  }
+  return { ok: true };
+}
 
 // ---------------------------------------------------------------------------
 // Magic-byte detection helpers
@@ -84,7 +142,16 @@ function executeRead(fields: ReadFields): {
   audioMimeType?: string;
   isError?: boolean;
 } {
-  const filePath = fields.path;
+  const pathCheck = validateHostPath(fields.path);
+  if (!pathCheck.ok) return pathCheck;
+
+  const filePath = pathCheck.path;
+  const fileCheck = validateRegularFile(filePath);
+  if (!fileCheck.ok) return fileCheck;
+
+  const sizeCheck = validateFileSize(filePath, fileCheck.stat.size);
+  if (!sizeCheck.ok) return sizeCheck;
+
   const raw = fs.readFileSync(filePath);
 
   // Check for image
@@ -117,7 +184,13 @@ interface WriteFields {
 }
 
 function executeWrite(fields: WriteFields): { content?: string; isError?: boolean } {
-  const filePath = fields.path;
+  const pathCheck = validateHostPath(fields.path);
+  if (!pathCheck.ok) return pathCheck;
+
+  const filePath = pathCheck.path;
+  const sizeCheck = validateContentSize(fields.content, filePath);
+  if (!sizeCheck.ok) return sizeCheck;
+
   const dir = path.dirname(filePath);
   fs.mkdirSync(dir, { recursive: true });
   fs.writeFileSync(filePath, fields.content, "utf-8");
@@ -136,7 +209,16 @@ interface EditFields {
 }
 
 function executeEdit(fields: EditFields): { content?: string; isError?: boolean } {
-  const filePath = fields.path;
+  const pathCheck = validateHostPath(fields.path);
+  if (!pathCheck.ok) return pathCheck;
+
+  const filePath = pathCheck.path;
+  const fileCheck = validateRegularFile(filePath);
+  if (!fileCheck.ok) return fileCheck;
+
+  const sizeCheck = validateFileSize(filePath, fileCheck.stat.size);
+  if (!sizeCheck.ok) return sizeCheck;
+
   const existing = fs.readFileSync(filePath, "utf-8");
   const { old_string, new_string, replace_all } = fields;
 
@@ -246,6 +328,10 @@ export const __testing = {
   executeRead,
   executeWrite,
   executeEdit,
+  validateHostPath,
+  validateRegularFile,
+  validateFileSize,
+  validateContentSize,
   get pendingRequests() {
     return pendingRequests;
   },

--- a/apps/macos/src/main/executors/host-file-executor.ts
+++ b/apps/macos/src/main/executors/host-file-executor.ts
@@ -78,6 +78,35 @@ function validateContentSize(content: string, filePath: string): { ok: true } | 
   return { ok: true };
 }
 
+function validateWriteTarget(filePath: string): { ok: true } | { ok: false; content: string; isError: true } {
+  let lstat: Stats;
+  try {
+    lstat = fs.lstatSync(filePath);
+  } catch {
+    return { ok: true };
+  }
+
+  if (lstat.isSymbolicLink()) {
+    const target = fs.readlinkSync(filePath);
+    const resolved = path.isAbsolute(target) ? target : path.resolve(path.dirname(filePath), target);
+    if (DENIED_BASENAMES.has(path.basename(resolved))) {
+      return { content: `Access to "${path.basename(resolved)}" is denied`, isError: true, ok: false };
+    }
+    try {
+      const targetStat = fs.statSync(filePath);
+      if (!targetStat.isFile()) {
+        return { content: `Not a regular file: ${filePath}`, isError: true, ok: false };
+      }
+    } catch {
+      // Dangling symlink with allowed target basename — write will create regular file
+    }
+  } else if (!lstat.isFile()) {
+    return { content: `Not a regular file: ${filePath}`, isError: true, ok: false };
+  }
+
+  return { ok: true };
+}
+
 // ---------------------------------------------------------------------------
 // Magic-byte detection helpers
 // ---------------------------------------------------------------------------
@@ -197,10 +226,8 @@ function executeWrite(fields: WriteFields): { content?: string; isError?: boolea
   const sizeCheck = validateContentSize(fields.content, filePath);
   if (!sizeCheck.ok) return sizeCheck;
 
-  if (fs.existsSync(filePath)) {
-    const fileCheck = validateRegularFile(filePath);
-    if (!fileCheck.ok) return fileCheck;
-  }
+  const targetCheck = validateWriteTarget(filePath);
+  if (!targetCheck.ok) return targetCheck;
 
   const dir = path.dirname(filePath);
   fs.mkdirSync(dir, { recursive: true });
@@ -347,6 +374,7 @@ export const __testing = {
   validateRegularFile,
   validateFileSize,
   validateContentSize,
+  validateWriteTarget,
   get pendingRequests() {
     return pendingRequests;
   },

--- a/apps/macos/src/main/executors/host-file-executor.ts
+++ b/apps/macos/src/main/executors/host-file-executor.ts
@@ -42,6 +42,12 @@ function validateHostPath(rawPath: string): { ok: true; path: string } | { ok: f
 }
 
 function validateRegularFile(filePath: string): { ok: true; stat: Stats } | { ok: false; content: string; isError: true } {
+  const resolved = fs.realpathSync(filePath);
+  const resolvedBasename = path.basename(resolved);
+  if (DENIED_BASENAMES.has(resolvedBasename)) {
+    return { content: `Access to "${resolvedBasename}" is denied`, isError: true, ok: false };
+  }
+
   const stat = fs.statSync(filePath);
   if (!stat.isFile()) {
     return { content: `Not a regular file: ${filePath}`, isError: true, ok: false };
@@ -227,17 +233,21 @@ function executeEdit(fields: EditFields): { content?: string; isError?: boolean 
     return { content: `old_string not found in ${filePath}`, isError: true };
   }
 
+  let updated: string;
   if (!replace_all) {
     const secondIdx = existing.indexOf(old_string, firstIdx + 1);
     if (secondIdx !== -1) {
       return { content: `old_string is not unique in ${filePath} (use replace_all to replace all occurrences)`, isError: true };
     }
-    const updated = existing.slice(0, firstIdx) + new_string + existing.slice(firstIdx + old_string.length);
-    fs.writeFileSync(filePath, updated, "utf-8");
+    updated = existing.slice(0, firstIdx) + new_string + existing.slice(firstIdx + old_string.length);
   } else {
-    const updated = existing.split(old_string).join(new_string);
-    fs.writeFileSync(filePath, updated, "utf-8");
+    updated = existing.split(old_string).join(new_string);
   }
+
+  const outputSizeCheck = validateContentSize(updated, filePath);
+  if (!outputSizeCheck.ok) return outputSizeCheck;
+
+  fs.writeFileSync(filePath, updated, "utf-8");
 
   return { content: `Edited ${filePath}` };
 }

--- a/apps/macos/src/main/executors/host-file-executor.ts
+++ b/apps/macos/src/main/executors/host-file-executor.ts
@@ -78,6 +78,24 @@ function validateContentSize(content: string, filePath: string): { ok: true } | 
   return { ok: true };
 }
 
+function resolveSymlinkChain(startPath: string): string {
+  let current = startPath;
+  const seen = new Set<string>();
+  for (;;) {
+    if (seen.has(current)) return current;
+    seen.add(current);
+    let st: Stats;
+    try {
+      st = fs.lstatSync(current);
+    } catch {
+      return current;
+    }
+    if (!st.isSymbolicLink()) return current;
+    const target = fs.readlinkSync(current);
+    current = path.isAbsolute(target) ? target : path.resolve(path.dirname(current), target);
+  }
+}
+
 function validateWriteTarget(filePath: string): { ok: true } | { ok: false; content: string; isError: true } {
   let lstat: Stats;
   try {
@@ -87,8 +105,7 @@ function validateWriteTarget(filePath: string): { ok: true } | { ok: false; cont
   }
 
   if (lstat.isSymbolicLink()) {
-    const target = fs.readlinkSync(filePath);
-    const resolved = path.isAbsolute(target) ? target : path.resolve(path.dirname(filePath), target);
+    const resolved = resolveSymlinkChain(filePath);
     if (DENIED_BASENAMES.has(path.basename(resolved))) {
       return { content: `Access to "${path.basename(resolved)}" is denied`, isError: true, ok: false };
     }

--- a/apps/macos/src/main/executors/host-file-executor.ts
+++ b/apps/macos/src/main/executors/host-file-executor.ts
@@ -197,6 +197,11 @@ function executeWrite(fields: WriteFields): { content?: string; isError?: boolea
   const sizeCheck = validateContentSize(fields.content, filePath);
   if (!sizeCheck.ok) return sizeCheck;
 
+  if (fs.existsSync(filePath)) {
+    const fileCheck = validateRegularFile(filePath);
+    if (!fileCheck.ok) return fileCheck;
+  }
+
   const dir = path.dirname(filePath);
   fs.mkdirSync(dir, { recursive: true });
   fs.writeFileSync(filePath, fields.content, "utf-8");


### PR DESCRIPTION
## Summary

- Add path validation (denied basenames, absolute path check), regular-file check, and 100 MB size limit to the Electron host-file executor's read/write/edit operations, matching the daemon-side hostPolicy/FileSystemOps guards
- Add 7 new tests covering all three operations for denied paths, non-regular files, and oversized files

Codex finding: https://chatgpt.com/codex/cloud/security/findings/da102b7c6c108191aab92ed52e3e2ca8

## Original prompt

A Codex security scan identified that the Electron host-file executor (`host-file-executor.ts`) bypasses the daemon-side `hostPolicy` denylist for `.backup.key`/`backup.key` basenames, regular-file checks, and 100 MB file size limits. The executor directly calls `fs.readFileSync`/`writeFileSync` on untrusted SSE message paths. The fix adds equivalent validation functions before all filesystem operations to close this policy bypass.

## Test plan

- [x] All 34 tests pass (27 existing + 7 new validation tests)
- [ ] Verify denied basenames are rejected for read/write/edit
- [ ] Verify non-regular files (e.g. /dev/null) are rejected for read/edit
- [ ] Verify oversized files are rejected for read/edit and oversized content is rejected for write

🤖 Generated with [Claude Code](https://claude.com/claude-code)