### PR TITLE
fix(security): bind app-control session to target client

### DIFF
--- a/assistant/src/__tests__/conversation-surfaces-app-control.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-app-control.test.ts
@@ -511,6 +511,7 @@ describe("surfaceProxyResolver — app-control tool routing", () => {
       _setActiveAppControlSession({
         conversationId: "conv-1",
         app: "com.example.editor",
+        targetClientId: "client-b",
       });
 
       const resultPromise = surfaceProxyResolver(ctx, "app_control_observe", {
@@ -595,6 +596,7 @@ describe("surfaceProxyResolver — app-control tool routing", () => {
       _setActiveAppControlSession({
         conversationId: "conv-1",
         app: "com.example.editor",
+        targetClientId: "client-mine",
       });
 
       const resultPromise = surfaceProxyResolver(ctx, "app_control_observe", {
@@ -617,7 +619,7 @@ describe("surfaceProxyResolver — app-control tool routing", () => {
       proxy.dispose();
     });
 
-    test("single same-user client with no target proceeds without forcing targetClientId", async () => {
+    test("single same-user client with no target resolves to that client", async () => {
       mockHubClients = [
         {
           clientId: "only-client",
@@ -630,6 +632,7 @@ describe("surfaceProxyResolver — app-control tool routing", () => {
       _setActiveAppControlSession({
         conversationId: "conv-1",
         app: "com.example.editor",
+        targetClientId: "only-client",
       });
 
       const resultPromise = surfaceProxyResolver(ctx, "app_control_observe", {

--- a/assistant/src/__tests__/host-app-control-proxy.test.ts
+++ b/assistant/src/__tests__/host-app-control-proxy.test.ts
@@ -372,6 +372,49 @@ describe("HostAppControlProxy", () => {
       proxy.dispose();
     });
 
+    test("non-start tool with mismatched target client is rejected", async () => {
+      mockActorMap.set("client-A", "user-1");
+      mockActorMap.set("client-B", "user-1");
+      const proxy = new HostAppControlProxy("conv-1");
+      const startCtrl = new AbortController();
+
+      const pStart = proxy.request(
+        "app_control_start",
+        { tool: "start", app: "com.example.editor" },
+        "conv-1",
+        startCtrl.signal,
+        "user-1",
+        "client-A",
+      );
+      proxy.resolve(
+        (sentMessages[0] as Record<string, unknown>).requestId as string,
+        payload({ pngBase64: PNG_A }),
+      );
+      await pStart;
+      sentMessages.length = 0;
+
+      const result = await proxy.request(
+        "app_control_type",
+        {
+          tool: "type",
+          app: "com.example.editor",
+          text: "hello",
+        },
+        "conv-1",
+        new AbortController().signal,
+        "user-1",
+        "client-B",
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("client-A");
+      expect(result.content).toContain("client-B");
+      expect(result.content).toContain("app_control_start");
+      expect(sentMessages).toHaveLength(0);
+
+      proxy.dispose();
+    });
+
     test("non-start tool with case-different but otherwise matching app is allowed", async () => {
       const proxy = new HostAppControlProxy("conv-1");
       const startCtrl = new AbortController();
@@ -1297,6 +1340,7 @@ describe("HostAppControlProxy", () => {
       _setActiveAppControlSession({
         conversationId: "conv-1",
         app: "com.example.app",
+        targetClientId: "client-A",
       });
 
       const resultPromise = proxy.request(
@@ -1332,6 +1376,7 @@ describe("HostAppControlProxy", () => {
       _setActiveAppControlSession({
         conversationId: "conv-1",
         app: "com.example.app",
+        targetClientId: "client-A",
       });
 
       const resultPromise = proxy.request(

--- a/assistant/src/daemon/host-app-control-proxy.ts
+++ b/assistant/src/daemon/host-app-control-proxy.ts
@@ -12,11 +12,12 @@
  * translation on top.
  *
  * **Session lock.** Only one conversation may hold an active app-control
- * session at a time, and that session is bound to a specific target app.
+ * session at a time, and that session is bound to a specific target app
+ * on a specific client.
  * The lock is module-level (`activeAppControlSession`) because the session
  * targets the user's actual desktop application, which is a host-wide
  * resource. It is acquired optimistically when `app_control_start` is
- * dispatched (storing `(conversationId, app)`) so that the synchronous
+ * dispatched (storing `(conversationId, app, targetClientId)`) so that the synchronous
  * guard and the asynchronous host round-trip cannot race. A separate
  * `confirmedAppControlSession` tracks the last session the host reported
  * `running`; the rollback path on a failed `start` restores from the
@@ -32,7 +33,7 @@
  * user's medium-risk approval at start time is the consent boundary. All
  * other tools (observe / press / combo / sequence / type / click / drag)
  * require the calling conversation to own an active session targeting the
- * same `app`; otherwise the call is rejected before any host dispatch.
+ * same `app` and client; otherwise the call is rejected before any host dispatch.
  * This prevents prompt-injected tool calls from sending raw input to
  * arbitrary apps without the user having approved control of that
  * specific app.
@@ -78,9 +79,9 @@ const STUCK_REPEAT_THRESHOLD = 4;
 // ---------------------------------------------------------------------------
 
 /**
- * Active app-control session: the conversation that owns the lock and the
- * `app` it was approved against. Set on a successful `app_control_start`;
- * cleared by the owning proxy's `dispose()`.
+ * Active app-control session: the conversation that owns the lock, the
+ * `app` and client it was approved against. Set on a successful
+ * `app_control_start`; cleared by the owning proxy's `dispose()`.
  */
 export interface ActiveAppControlSession {
   conversationId: string;
@@ -90,6 +91,11 @@ export interface ActiveAppControlSession {
    * the `app` of subsequent non-start tool calls.
    */
   app: string;
+  /**
+   * The client selected for `app_control_start`. Undefined when the start
+   * was untargeted; subsequent calls must match the same value.
+   */
+  targetClientId?: string;
   /**
    * Strictly monotonic counter assigned when the session is created (in
    * `request()` for a `start`). Used by {@link promoteStartIfCurrent} to
@@ -153,11 +159,13 @@ export function _resetActiveAppControlSession(): void {
 export function _setActiveAppControlSession(session: {
   conversationId: string;
   app: string;
+  targetClientId?: string;
   dispatchedAt?: number;
 }): void {
   const full: ActiveAppControlSession = {
     conversationId: session.conversationId,
     app: session.app,
+    targetClientId: session.targetClientId,
     dispatchedAt: session.dispatchedAt ?? nextDispatchedAt++,
   };
   activeAppControlSession = full;
@@ -177,6 +185,7 @@ export function _setActiveAppControlSession(session: {
 function checkNonStartAuthorization(
   input: HostAppControlInput,
   conversationId: string,
+  targetClientId: string | undefined,
 ): ToolExecutionResult | null {
   if (activeAppControlSession == null) {
     return {
@@ -216,6 +225,16 @@ function checkNonStartAuthorization(
         `Active app-control session targets ${activeAppControlSession.app}; ` +
         `cannot send actions to ${requestedApp}. Call app_control_stop and ` +
         `app_control_start to switch apps.`,
+      isError: true,
+    };
+  }
+  if (activeAppControlSession.targetClientId !== targetClientId) {
+    return {
+      content:
+        `Active app-control session targets client ` +
+        `${activeAppControlSession.targetClientId ?? "<default>"}; cannot ` +
+        `send actions to client ${targetClientId ?? "<default>"}. Call ` +
+        `app_control_stop and app_control_start to switch clients.`,
       isError: true,
     };
   }
@@ -284,11 +303,53 @@ export class HostAppControlProxy extends HostProxyBase<
       return { content: "Aborted", isError: true };
     }
 
+    // Resolve target client and enforce same-actor BEFORE acquiring the
+    // session lock. This way early-exit errors don't need rollback, and
+    // the resolved client id can be stored in the session.
+    let resolvedTargetClientId = targetClientId;
+    if (resolvedTargetClientId == null) {
+      const resolved = pickSameUserAutoResolve({
+        hub: assistantEventHub,
+        capability: "host_app_control",
+        sourceActorPrincipalId,
+      });
+      if (resolved.kind === "ambiguous") {
+        return {
+          content:
+            "Multiple host_app_control clients are connected for this user. Specify target_client_id to disambiguate.",
+          isError: true,
+        };
+      }
+      if (resolved.kind === "match") {
+        resolvedTargetClientId = resolved.clientId;
+      } else if (
+        assistantEventHub.listClientsByCapability("host_app_control").length > 0
+      ) {
+        return {
+          content:
+            "App control is not available for the current actor. Connect a host_app_control-capable client as the same user.",
+          isError: true,
+        };
+      }
+    }
+
+    if (resolvedTargetClientId != null) {
+      const rejection = enforceSameActorOrErrorResult({
+        hub: assistantEventHub,
+        sourceActorPrincipalId,
+        targetClientId: resolvedTargetClientId,
+        op: "host_app_control",
+      });
+      if (rejection) {
+        return rejection;
+      }
+    }
+
     // Authorization gate. `start` acquires the session lock (the user's
     // medium-risk approval is the consent boundary); all other tools must
-    // belong to the active session and target the same `app`. Without this
-    // gate, prompt-injected calls would bypass the start-time approval and
-    // send raw input to arbitrary apps.
+    // belong to the active session and target the same `app` and client.
+    // Without this gate, prompt-injected calls would bypass the start-time
+    // approval and send raw input to arbitrary apps or clients.
     let attemptedSession: ActiveAppControlSession | undefined;
     if (input.tool === "start") {
       if (
@@ -314,6 +375,7 @@ export class HostAppControlProxy extends HostProxyBase<
       attemptedSession = {
         conversationId: this.conversationId,
         app: input.app,
+        targetClientId: resolvedTargetClientId,
         dispatchedAt: nextDispatchedAt++,
       };
       activeAppControlSession = attemptedSession;
@@ -321,57 +383,10 @@ export class HostAppControlProxy extends HostProxyBase<
       const sessionError = checkNonStartAuthorization(
         input,
         this.conversationId,
+        resolvedTargetClientId,
       );
       if (sessionError != null) {
         return sessionError;
-      }
-    }
-
-    let resolvedTargetClientId = targetClientId;
-    if (resolvedTargetClientId == null) {
-      const resolved = pickSameUserAutoResolve({
-        hub: assistantEventHub,
-        capability: "host_app_control",
-        sourceActorPrincipalId,
-      });
-      if (resolved.kind === "ambiguous") {
-        if (input.tool === "start") {
-          this.rollbackStartIfCurrent(attemptedSession);
-        }
-        return {
-          content:
-            "Multiple host_app_control clients are connected for this user. Specify target_client_id to disambiguate.",
-          isError: true,
-        };
-      }
-      if (resolved.kind === "match") {
-        resolvedTargetClientId = resolved.clientId;
-      } else if (
-        assistantEventHub.listClientsByCapability("host_app_control").length > 0
-      ) {
-        if (input.tool === "start") {
-          this.rollbackStartIfCurrent(attemptedSession);
-        }
-        return {
-          content:
-            "App control is not available for the current actor. Connect a host_app_control-capable client as the same user.",
-          isError: true,
-        };
-      }
-    }
-
-    if (resolvedTargetClientId != null) {
-      const rejection = enforceSameActorOrErrorResult({
-        hub: assistantEventHub,
-        sourceActorPrincipalId,
-        targetClientId: resolvedTargetClientId,
-        op: "host_app_control",
-      });
-      if (rejection) {
-        if (input.tool === "start") {
-          this.rollbackStartIfCurrent(attemptedSession);
-        }
-        return rejection;
       }
     }
 


### PR DESCRIPTION
## Summary
- Add `targetClientId` to `ActiveAppControlSession` so the session lock records which client received `app_control_start` approval
- Reorder `request()` to resolve the target client before session acquisition, eliminating rollback code in error paths and ensuring the resolved client is stored in the session
- Enforce `targetClientId` match in `checkNonStartAuthorization` — non-start actions targeting a different client are now rejected with an actionable error

## Original prompt
A Codex security finding identified that the app-control session lock only recorded `conversationId` and `app`, not the target client. After `app_control_start` was approved for client A, subsequent low-risk actions could switch `targetClientId` to client B without new approval — a permission-boundary bypass for host app automation in multi-client same-user setups.

Codex finding: https://chatgpt.com/codex/cloud/security/findings/b254639eba788191ae2fa48b4b730770?q=API+keys+can+trigger+paid+Pro+tier+changes&sev=

🤖 Generated with [Claude Code](https://claude.com/claude-code)