### PR TITLE
chore: remove stale platform-hosted-enabled flag comments

### DIFF
--- a/apps/web/src/assistant/lifecycle-service.ts
+++ b/apps/web/src/assistant/lifecycle-service.ts
@@ -504,11 +504,11 @@ class AssistantLifecycleService {
             attempt: this.hatchRetryCount,
           },
         });
-        // Capacity / kill-switch from the backend
-        // (platform-hosted-enabled flag is off). Surface the
-        // tailored message instead of treating this as a
-        // recoverable 5xx — retrying just burns the
-        // MAX_HATCH_RETRIES budget and ends in a generic error.
+        // Capacity kill-switch: when platform hosting is unavailable
+        // the backend returns 503. Surface the tailored message
+        // instead of treating this as a recoverable 5xx — retrying
+        // just burns the MAX_HATCH_RETRIES budget and ends in a
+        // generic error.
         if (isPlatformHostedDisabled(result.status, result.error)) {
           this.transition({
             kind: "error",

--- a/apps/web/src/assistant/lifecycle.ts
+++ b/apps/web/src/assistant/lifecycle.ts
@@ -52,9 +52,9 @@ export function shouldRecoverFromHatchFailure(status?: number): boolean {
 
 /**
  * The Django hatch endpoint returns 503 + `{ code: "platform_hosted_disabled" }`
- * when the `platform-hosted-enabled` feature flag is off (global capacity
- * kill-switch). The onboarding flow surfaces this as a user-friendly message
- * instead of recovering / retrying.
+ * when platform hosting is unavailable (global capacity kill-switch). The
+ * onboarding flow surfaces this as a user-friendly message instead of
+ * recovering / retrying.
  */
 export const PLATFORM_HOSTED_DISABLED_CODE = "platform_hosted_disabled";
 


### PR DESCRIPTION
## Summary
- Rewrite comments in lifecycle-service.ts and lifecycle.ts that referenced the platform-hosted-enabled flag
- Comments now describe the behavior in non-flag terms

Part of plan: rm-gaed-feature-flags.md (PR 7 of 7)