### PR TITLE
fix: remove account-deletion feature flag gating (GA'ed)

### DIFF
--- a/assistant/src/__tests__/credential-execution-feature-gates.test.ts
+++ b/assistant/src/__tests__/credential-execution-feature-gates.test.ts
@@ -165,10 +165,11 @@ describe("CES flags do not affect unrelated flags", () => {
     setOverridesForTesting(overrides);
     const config = makeConfig();
 
-    // account-deletion defaults to true in the registry and should stay true.
-    expect(isAssistantFeatureFlagEnabled("account-deletion", config)).toBe(
-      true,
-    );
+    // Flags with defaultEnabled: true in the registry should stay true
+    // regardless of CES overrides.
+    expect(
+      isAssistantFeatureFlagEnabled("platform-features-in-local-mode", config),
+    ).toBe(true);
   });
 
   test("enabling all CES flags does not change unrelated fail-closed flags", () => {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -498,16 +498,13 @@ struct SettingsGeneralTab: View {
 
     // MARK: - Danger Zone
 
-    /// Whether to render the Danger Zone (account deletion) section. Gated on
-    /// both the client-side `account-deletion` feature flag (mirroring the
-    /// server-side LaunchDarkly flag in `vellum-assistant-platform`) and a
+    /// Whether to render the Danger Zone (account deletion) section. Requires a
     /// signed-in session — without a `currentUser`, the POST would fail with
     /// notAuthenticated, so we don't expose the destructive button.
     nonisolated static func shouldShowDangerZone(
-        flagManager: MacOSClientFeatureFlagManager = .shared,
         isAuthenticated: Bool
     ) -> Bool {
-        flagManager.isEnabled("account-deletion") && isAuthenticated
+        isAuthenticated
     }
 
     private var dangerZoneSection: some View {

--- a/clients/macos/vellum-assistantTests/DeleteAccountTests.swift
+++ b/clients/macos/vellum-assistantTests/DeleteAccountTests.swift
@@ -3,12 +3,11 @@ import SwiftUI
 @testable import VellumAssistantLib
 @testable import VellumAssistantShared
 
-/// Tests for the `account-deletion` feature-flag-gated Danger Zone section in
-/// `SettingsGeneralTab`, and for the `DeleteAccountConfirmView` confirmation
-/// modal. The modal calls `AuthService.requestAccountDeletion()`, which posts
-/// directly to platform at `/v1/user/deletion-request/` and returns
-/// `.requested` (HTTP 201) when the server-side `account-deletion` flag is on
-/// or `.unavailable` (HTTP 404) when off.
+/// Tests for the Danger Zone section in `SettingsGeneralTab` and the
+/// `DeleteAccountConfirmView` confirmation modal. The modal calls
+/// `AuthService.requestAccountDeletion()`, which posts directly to platform
+/// at `/v1/user/deletion-request/` and returns `.requested` (HTTP 201) on
+/// success or `.unavailable` (HTTP 404) when the endpoint is unreachable.
 @MainActor
 final class DeleteAccountTests: XCTestCase {
 
@@ -34,8 +33,8 @@ final class DeleteAccountTests: XCTestCase {
         }
     }
 
-    /// On an `.unavailable` result (server-side flag off), the modal surfaces
-    /// an inline error and does not report `.deleted` to the parent.
+    /// On an `.unavailable` result (HTTP 404), the modal surfaces an inline
+    /// error and does not report `.deleted` to the parent.
     func testConfirmModalShowsErrorOnUnavailable() async {
         let view = DeleteAccountConfirmView(
             onDeleted: { _ in XCTFail("onDeleted should not fire on unavailable") },

--- a/clients/shared/App/Auth/AuthService.swift
+++ b/clients/shared/App/Auth/AuthService.swift
@@ -733,8 +733,7 @@ public final class AuthService {
         /// Server accepted the request (HTTP 201). The session should be torn
         /// down on the client side.
         case requested
-        /// Server-side `account-deletion` flag is off (HTTP 404). The feature
-        /// is unavailable for this account; the caller should surface the
+        /// The endpoint returned HTTP 404. The caller should surface the
         /// inline "not available" copy rather than a generic error.
         case unavailable
     }


### PR DESCRIPTION
## Summary
- Remove account-deletion feature flag check from SettingsGeneralTab.swift — Danger Zone now shows whenever authenticated
- Update DeleteAccountTests.swift to remove flag references
- Remove flag comment from AuthService.swift and flag assertion from credential-execution-feature-gates.test.ts

Part of plan: rm-gaed-feature-flags.md (PR 1 of 7)