### PR TITLE
fix: remove doctor feature flag gating (GA'ed)

### DIFF
--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -200,7 +200,6 @@ export function ChatMainPanel({
   const assistantState = useAssistantLifecycleStore.use.assistantState();
   const assistantName = useAssistantIdentityStore.use.name();
   const chatPullToRefreshEnabled = useClientFeatureFlagStore.use.chatPullToRefreshEnabled();
-  const doctorEnabled = useClientFeatureFlagStore.use.doctor();
 
   // -------------------------------------------------------------------------
   // Store reads — per-conversation state
@@ -437,13 +436,13 @@ export function ChatMainPanel({
   const genericChatError = shouldShowGenericChatErrorNotice(error) && error
     ? {
         message: error.message,
-        actions: doctorEnabled ? (
+        actions: (
           <Button asChild variant="outlined" size="compact">
             <Link to={`${routes.settings.debug}?tab=doctor`}>
               Go to Doctor
             </Link>
           </Button>
-        ) : undefined,
+        ),
       }
     : null;
 

--- a/apps/web/src/domains/chat/components/connecting-to-assistant.tsx
+++ b/apps/web/src/domains/chat/components/connecting-to-assistant.tsx
@@ -8,7 +8,6 @@ import type {
     ReachabilityState,
 } from "@/assistant/use-assistant-reachability";
 import { MAX_ATTEMPTS } from "@/assistant/use-assistant-reachability";
-import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { VELLUM_COMMUNITY_URL } from "@/utils/external-urls";
 import { routes } from "@/utils/routes";
 import { Button, Modal, Typography } from "@vellumai/design-library";
@@ -112,19 +111,14 @@ const FailureBody: FC<FailureBodyProps> = ({
   lastServerState,
   onRetry,
 }) => {
-  const doctorEnabled = useClientFeatureFlagStore.use.doctor();
   const isCrashLoop = lastServerState === "crash_loop";
 
   const title = isCrashLoop
     ? "Your assistant hit an error"
     : "Couldn't connect to your assistant";
   const description = isCrashLoop
-    ? doctorEnabled
-      ? "Your assistant reported an error while starting. Try running Vellum Doctor to diagnose the issue, or ask the community for help."
-      : "Your assistant reported an error while starting. Ask the community for help if the problem persists."
-    : doctorEnabled
-      ? `We tried ${MAX_ATTEMPTS} times over 60 seconds and still can't reach your assistant. Try running Vellum Doctor to diagnose the issue, or ask the community for help.`
-      : `We tried ${MAX_ATTEMPTS} times over 60 seconds and still can't reach your assistant. Ask the community for help if the problem persists.`;
+    ? "Your assistant reported an error while starting. Try running Vellum Doctor to diagnose the issue, or ask the community for help."
+    : `We tried ${MAX_ATTEMPTS} times over 60 seconds and still can't reach your assistant. Try running Vellum Doctor to diagnose the issue, or ask the community for help.`;
 
   return (
     <StatusLayout
@@ -145,17 +139,15 @@ const FailureBody: FC<FailureBodyProps> = ({
           >
             Try again
           </Button>
-          {doctorEnabled && (
-            <Button
-              asChild
-              variant="outlined"
-              data-testid="connection-go-to-doctor-button"
-            >
-              <Link to={`${routes.settings.debug}?tab=doctor`}>
-                Vellum Doctor
-              </Link>
-            </Button>
-          )}
+          <Button
+            asChild
+            variant="outlined"
+            data-testid="connection-go-to-doctor-button"
+          >
+            <Link to={`${routes.settings.debug}?tab=doctor`}>
+              Vellum Doctor
+            </Link>
+          </Button>
           <Button
             asChild
             variant="outlined"

--- a/apps/web/src/domains/settings/pages/debug-page.tsx
+++ b/apps/web/src/domains/settings/pages/debug-page.tsx
@@ -5,7 +5,6 @@ import { AssistantTerminalPanel } from "@/domains/settings/components/panels/ass
 import { DebugControlsPanel } from "@/domains/settings/components/panels/debug-controls-panel";
 import { DoctorPanel } from "@/domains/settings/components/panels/doctor-panel";
 import { usePlatformGate } from "@/hooks/use-platform-gate";
-import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { cn } from "@/utils/misc";
 
 const ALL_TABS = [
@@ -18,7 +17,6 @@ type DebugTabId = (typeof ALL_TABS)[number]["id"];
 
 export function DebugPage() {
   const [searchParams, setSearchParams] = useSearchParams();
-  const doctorEnabled = useClientFeatureFlagStore.use.doctor();
   // Terminal tab is platform-routed and should be hidden when the active
   // assistant is self-hosted — `platformHostedOnly: true` is the correct
   // variant. The standard gate would still resolve to "full" on a
@@ -29,13 +27,12 @@ export function DebugPage() {
   const tabs = useMemo(
     () =>
       ALL_TABS.filter((tab) => {
-        if (tab.id === "doctor" && !doctorEnabled) return false;
         // Terminal is platform-routed — hide the tab entirely on self-hosted
         // assistants so users don't land on an empty panel.
         if (tab.id === "terminal" && platformGate === "gated") return false;
         return true;
       }),
-    [doctorEnabled, platformGate],
+    [platformGate],
   );
 
   const activeTab: DebugTabId = useMemo(() => {
@@ -93,7 +90,7 @@ export function DebugPage() {
       >
         {activeTab === "general" && <DebugControlsPanel />}
         {activeTab === "terminal" && <AssistantTerminalPanel />}
-        {activeTab === "doctor" && doctorEnabled && <DoctorPanel />}
+        {activeTab === "doctor" && <DoctorPanel />}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Remove doctor feature flag checks from debug-page.tsx, connecting-to-assistant.tsx, and chat-route-content.tsx
- Doctor tab and links now always visible without flag gating
- Check assistant-backups.tsx and api-interceptors.test.ts for any flag references

Part of plan: rm-gaed-feature-flags.md (PR 5 of 7)