### PR TITLE
fix: remove managed-gemini-embeddings-enabled feature flag gating (GA'ed)

### DIFF
--- a/assistant/src/__tests__/config-managed-gemini-defaults.test.ts
+++ b/assistant/src/__tests__/config-managed-gemini-defaults.test.ts
@@ -57,17 +57,8 @@ mock.module("../util/logger.js", () => ({
   getLogger: () => makeLoggerStub(),
 }));
 
-// ---------------------------------------------------------------------------
-// Feature flag mock — controls whether managed-gemini-embeddings-enabled is on
-// ---------------------------------------------------------------------------
-
-let featureFlagEnabled = false;
-
 mock.module("../config/assistant-feature-flags.js", () => ({
-  isAssistantFeatureFlagEnabled: (key: string) => {
-    if (key === "managed-gemini-embeddings-enabled") return featureFlagEnabled;
-    return true;
-  },
+  isAssistantFeatureFlagEnabled: () => true,
   clearFeatureFlagOverridesCache: () => {},
   initFeatureFlagOverrides: async () => {},
   getAssistantFeatureFlagDefaults: () => ({}),
@@ -119,8 +110,6 @@ describe("managed Gemini embedding defaults (via loadConfig)", () => {
     setStorePathForTesting(join(WORKSPACE_DIR, "keys.enc"));
     invalidateConfigCache();
 
-    // Reset mock state
-    featureFlagEnabled = false;
     originalIsPlatform = process.env.IS_PLATFORM;
     delete process.env.IS_PLATFORM;
   });
@@ -137,10 +126,9 @@ describe("managed Gemini embedding defaults (via loadConfig)", () => {
     }
   });
 
-  test("applies managed Gemini defaults when FF on + IS_PLATFORM + provider auto", () => {
+  test("applies managed Gemini defaults when IS_PLATFORM + provider auto", () => {
     writeConfig({});
 
-    featureFlagEnabled = true;
     process.env.IS_PLATFORM = "true";
 
     const config = loadConfig();
@@ -162,22 +150,9 @@ describe("managed Gemini embedding defaults (via loadConfig)", () => {
     expect(qdrantRaw.vectorSize).toBe(3072);
   });
 
-  test("does NOT apply when feature flag is OFF", () => {
-    writeConfig({});
-
-    featureFlagEnabled = false;
-    process.env.IS_PLATFORM = "true";
-
-    const config = loadConfig();
-
-    expect(config.memory.embeddings.provider).toBe("auto");
-    expect(config.memory.qdrant.vectorSize).toBe(384);
-  });
-
   test("does NOT apply when IS_PLATFORM is not set", () => {
     writeConfig({});
 
-    featureFlagEnabled = true;
     delete process.env.IS_PLATFORM;
 
     const config = loadConfig();
@@ -191,7 +166,6 @@ describe("managed Gemini embedding defaults (via loadConfig)", () => {
       memory: { embeddings: { provider: "local" } },
     });
 
-    featureFlagEnabled = true;
     process.env.IS_PLATFORM = "true";
 
     const config = loadConfig();
@@ -204,7 +178,6 @@ describe("managed Gemini embedding defaults (via loadConfig)", () => {
       memory: { embeddings: { provider: "openai" } },
     });
 
-    featureFlagEnabled = true;
     process.env.IS_PLATFORM = "true";
 
     const config = loadConfig();
@@ -219,7 +192,6 @@ describe("managed Gemini embedding defaults (via loadConfig)", () => {
       },
     });
 
-    featureFlagEnabled = true;
     process.env.IS_PLATFORM = "true";
 
     const config = loadConfig();
@@ -235,7 +207,6 @@ describe("managed Gemini embedding defaults (via loadConfig)", () => {
       memory: { embeddings: { provider: "ollama" } },
     });
 
-    featureFlagEnabled = true;
     process.env.IS_PLATFORM = "true";
 
     const config = loadConfig();
@@ -245,7 +216,6 @@ describe("managed Gemini embedding defaults (via loadConfig)", () => {
   test("is idempotent — second loadConfig is a no-op after migration", () => {
     writeConfig({});
 
-    featureFlagEnabled = true;
     process.env.IS_PLATFORM = "true";
 
     const config = loadConfig();
@@ -274,7 +244,6 @@ describe("managed Gemini embedding defaults (via loadConfig)", () => {
       },
     });
 
-    featureFlagEnabled = true;
     process.env.IS_PLATFORM = "true";
 
     const config = loadConfig();
@@ -295,22 +264,9 @@ describe("managed Gemini embedding defaults (via loadConfig)", () => {
     expect(qdrantRaw.onDisk).toBe(false);
   });
 
-  test("does NOT apply when both FF off and IS_PLATFORM not set", () => {
-    writeConfig({});
-
-    featureFlagEnabled = false;
-    delete process.env.IS_PLATFORM;
-
-    const config = loadConfig();
-
-    expect(config.memory.embeddings.provider).toBe("auto");
-    expect(config.memory.qdrant.vectorSize).toBe(384);
-  });
-
   test("applies when IS_PLATFORM is '1'", () => {
     writeConfig({});
 
-    featureFlagEnabled = true;
     process.env.IS_PLATFORM = "1";
 
     const config = loadConfig();

--- a/assistant/src/__tests__/embedding-managed-proxy-selection.test.ts
+++ b/assistant/src/__tests__/embedding-managed-proxy-selection.test.ts
@@ -2,8 +2,7 @@
  * Tests for managed proxy Gemini embedding backend selection.
  *
  * Verifies that selectEmbeddingBackend correctly routes through the
- * managed proxy when the feature flag is enabled and managed proxy
- * prerequisites are satisfied.
+ * managed proxy when managed proxy prerequisites are satisfied.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -42,13 +41,9 @@ mock.module("../security/secure-keys.js", () => ({
   },
 }));
 
-// Feature flag mock
-const mockFeatureFlags: Record<string, boolean> = {};
-
+// Feature flag mock — always returns true (flag is GA'ed)
 mock.module("../config/assistant-feature-flags.js", () => ({
-  isAssistantFeatureFlagEnabled: (key: string, _config: unknown) => {
-    return mockFeatureFlags[key] ?? false;
-  },
+  isAssistantFeatureFlagEnabled: () => true,
 }));
 
 import type { AssistantConfig } from "../config/types.js";
@@ -73,14 +68,6 @@ function enableManagedProxy() {
 function disableManagedProxy() {
   mockPlatformBaseUrl = "";
   mockAssistantApiKey = null;
-}
-
-function enableFlag() {
-  mockFeatureFlags["managed-gemini-embeddings-enabled"] = true;
-}
-
-function disableFlag() {
-  mockFeatureFlags["managed-gemini-embeddings-enabled"] = false;
 }
 
 function makeConfig(
@@ -116,7 +103,6 @@ function makeConfig(
 
 beforeEach(() => {
   disableManagedProxy();
-  disableFlag();
   mockProviderKeys = {};
   clearEmbeddingBackendCache();
 });
@@ -126,9 +112,8 @@ afterEach(() => {
 });
 
 describe("managed proxy Gemini embedding selection", () => {
-  test("selects managed proxy Gemini when flag enabled and proxy context available", async () => {
+  test("selects managed proxy Gemini when proxy context available", async () => {
     enableManagedProxy();
-    enableFlag();
     const config = makeConfig();
 
     const { backend, reason } = await selectEmbeddingBackend(config);
@@ -141,7 +126,6 @@ describe("managed proxy Gemini embedding selection", () => {
 
   test("managed proxy backend uses default 3072 dimensions when geminiDimensions not set", async () => {
     enableManagedProxy();
-    enableFlag();
     const config = makeConfig();
 
     const { backend } = await selectEmbeddingBackend(config);
@@ -155,7 +139,6 @@ describe("managed proxy Gemini embedding selection", () => {
 
   test("managed proxy backend uses explicit geminiDimensions when set", async () => {
     enableManagedProxy();
-    enableFlag();
     const config = makeConfig({ geminiDimensions: 768 });
 
     const { backend } = await selectEmbeddingBackend(config);
@@ -168,7 +151,6 @@ describe("managed proxy Gemini embedding selection", () => {
 
   test("managed proxy backend uses managedBaseUrl (not direct Google API)", async () => {
     enableManagedProxy();
-    enableFlag();
     const config = makeConfig();
 
     const { backend } = await selectEmbeddingBackend(config);
@@ -179,32 +161,19 @@ describe("managed proxy Gemini embedding selection", () => {
     expect(managedBaseUrl).toBe(`${PLATFORM_BASE}/v1/runtime-proxy/gemini`);
   });
 
-  test("falls back to local when flag is disabled (no managed proxy)", async () => {
-    enableManagedProxy();
-    disableFlag();
-    const config = makeConfig();
-
-    const { backend } = await selectEmbeddingBackend(config);
-
-    // With auto and no provider keys, falls through to local
-    expect(backend).not.toBeNull();
-    expect(backend!.provider).toBe("local");
-  });
-
   test("falls back to local when managed proxy context unavailable", async () => {
     disableManagedProxy();
-    enableFlag();
     const config = makeConfig();
 
     const { backend } = await selectEmbeddingBackend(config);
 
+    // With auto and no provider keys or proxy, falls through to local
     expect(backend).not.toBeNull();
     expect(backend!.provider).toBe("local");
   });
 
   test("selects managed proxy when provider is explicitly gemini", async () => {
     enableManagedProxy();
-    enableFlag();
     const config = makeConfig({ provider: "gemini" });
 
     const { backend } = await selectEmbeddingBackend(config);
@@ -217,7 +186,6 @@ describe("managed proxy Gemini embedding selection", () => {
 
   test("does not use managed proxy when provider is explicitly local", async () => {
     enableManagedProxy();
-    enableFlag();
     const config = makeConfig({ provider: "local" });
 
     const { backend } = await selectEmbeddingBackend(config);
@@ -228,7 +196,6 @@ describe("managed proxy Gemini embedding selection", () => {
 
   test("does not use managed proxy when provider is explicitly openai", async () => {
     enableManagedProxy();
-    enableFlag();
     mockProviderKeys[credentialKey("openai", "api_key")] = "user-openai-key";
     const config = makeConfig({ provider: "openai" });
 
@@ -238,9 +205,8 @@ describe("managed proxy Gemini embedding selection", () => {
     expect(backend!.provider).toBe("openai");
   });
 
-  test("direct Gemini key still works when flag is off", async () => {
+  test("direct Gemini key still works without managed proxy", async () => {
     disableManagedProxy();
-    disableFlag();
     mockProviderKeys[credentialKey("gemini", "api_key")] = "user-gemini-key";
     const config = makeConfig({ provider: "gemini" });
 

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -14,7 +14,6 @@ import {
   getWorkspaceConfigPath,
   getWorkspaceDir,
 } from "../util/platform.js";
-import { isAssistantFeatureFlagEnabled } from "./assistant-feature-flags.js";
 import { AssistantConfigSchema } from "./schema.js";
 import type { AssistantConfig } from "./types.js";
 
@@ -692,16 +691,15 @@ export function loadConfig(): AssistantConfig {
 
     if (suppressConfigDiskWritesDepth === 0) {
       // Managed Gemini embedding defaults migration.
-      // When on a managed platform (IS_PLATFORM=true) with the feature flag
-      // enabled and no explicit embedding provider chosen (provider=auto),
-      // persist Gemini embedding defaults into the raw config file.
+      // When on a managed platform (IS_PLATFORM=true) and no explicit embedding
+      // provider chosen (provider=auto), persist Gemini embedding defaults into
+      // the raw config file.
       // Idempotent: once provider=gemini is written, subsequent loads skip this.
       if (config.memory.embeddings.provider === "auto") {
         try {
           if (
-            (process.env.IS_PLATFORM === "true" ||
-              process.env.IS_PLATFORM === "1") &&
-            isManagedGeminiFFEnabled(config)
+            process.env.IS_PLATFORM === "true" ||
+            process.env.IS_PLATFORM === "1"
           ) {
             setNestedValue(fileConfig, "memory.embeddings.provider", "gemini");
             setNestedValue(
@@ -794,21 +792,6 @@ export function loadConfig(): AssistantConfig {
     cachedFileSignature = null;
     loading = false;
     throw err;
-  }
-}
-
-/**
- * Check whether the managed-gemini-embeddings-enabled feature flag is on.
- * Wrapped in a try/catch so a flag-resolver failure never breaks config loading.
- */
-function isManagedGeminiFFEnabled(config: AssistantConfig): boolean {
-  try {
-    return isAssistantFeatureFlagEnabled(
-      "managed-gemini-embeddings-enabled",
-      config,
-    );
-  } catch {
-    return false;
   }
 }
 

--- a/assistant/src/memory/embedding-backend.ts
+++ b/assistant/src/memory/embedding-backend.ts
@@ -1,6 +1,5 @@
 import { createHash } from "node:crypto";
 
-import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getOllamaBaseUrlEnv } from "../config/env.js";
 import { resolveCallSiteConfig } from "../config/llm-resolver.js";
 import type { AssistantConfig } from "../config/types.js";
@@ -302,13 +301,10 @@ export async function selectEmbeddingBackend(
     };
   }
 
-  // When the managed-gemini-embeddings-enabled flag is on AND managed proxy
-  // prerequisites are satisfied, insert managed-proxy Gemini at the front of
-  // the auto chain so platform assistants use Vellum-managed Gemini embeddings.
-  if (
-    (requested === "auto" || requested === "gemini") &&
-    isAssistantFeatureFlagEnabled("managed-gemini-embeddings-enabled", config)
-  ) {
+  // When managed proxy prerequisites are satisfied, insert managed-proxy Gemini
+  // at the front of the auto chain so platform assistants use Vellum-managed
+  // Gemini embeddings.
+  if (requested === "auto" || requested === "gemini") {
     const proxyCtx = await resolveManagedProxyContext();
     if (proxyCtx.enabled) {
       const meta = PLATFORM_PROVIDER_META["gemini"];
@@ -677,12 +673,7 @@ async function selectFallbackBackends(
               geminiCacheExtras(config),
             ),
           );
-        } else if (
-          isAssistantFeatureFlagEnabled(
-            "managed-gemini-embeddings-enabled",
-            config,
-          )
-        ) {
+        } else {
           // Try managed proxy Gemini as fallback when no direct key exists.
           const proxyCtx = await resolveManagedProxyContext();
           const meta = PLATFORM_PROVIDER_META["gemini"];
@@ -724,14 +715,6 @@ async function selectFallbackBackends(
               );
             if (cached) backends.push(cached);
           }
-        } else {
-          // Preserve cached backend on transient credential-store failures.
-          const cached = getCached(
-            "gemini",
-            config.memory.embeddings.geminiModel,
-            geminiCacheExtras(config),
-          );
-          if (cached) backends.push(cached);
         }
         break;
       }


### PR DESCRIPTION
## Summary
- Remove managed-gemini-embeddings-enabled flag checks from embedding-backend.ts — managed proxy path now unconditional
- Delete isManagedGeminiFFEnabled wrapper from loader.ts, keep only IS_PLATFORM gate
- Update tests to remove flag mocking and adjust expectations

Part of plan: rm-gaed-feature-flags.md (PR 4 of 7)