### PR TITLE
chore: remove 7 GA'ed flags from feature flag registry

### DIFF
--- a/apps/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/apps/web/src/lib/feature-flags/feature-flag-registry.json
@@ -124,14 +124,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "deploy-to-vercel",
-      "scope": "assistant",
-      "key": "deploy-to-vercel",
-      "label": "Deploy to Vercel",
-      "description": "Enable the Deploy to Vercel / Publish option in the app workspace header share menu",
-      "defaultEnabled": false
-    },
-    {
       "id": "settings-embedding-provider",
       "scope": "assistant",
       "key": "settings-embedding-provider",
@@ -161,14 +153,6 @@
       "key": "expand-completed-steps",
       "label": "Expand Completed Steps",
       "description": "Auto-expand completed tool call step groups instead of showing them collapsed",
-      "defaultEnabled": false
-    },
-    {
-      "id": "sounds",
-      "scope": "assistant",
-      "key": "sounds",
-      "label": "Sounds",
-      "description": "Enable the Sounds tab in Settings and all app sound playback (event sounds, random ambient sounds)",
       "defaultEnabled": false
     },
     {
@@ -236,14 +220,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "managed-gemini-embeddings-enabled",
-      "scope": "assistant",
-      "key": "managed-gemini-embeddings-enabled",
-      "label": "Managed Gemini Embeddings Enabled",
-      "description": "Route embedding requests through the platform runtime proxy using Vellum-managed Gemini credentials when available",
-      "defaultEnabled": false
-    },
-    {
       "id": "bookmarks",
       "scope": "client",
       "key": "bookmarks",
@@ -298,14 +274,6 @@
       "label": "Compaction Playground",
       "description": "Expose the developer-only Compaction Playground tab in macOS Settings and enable the /playground/* HTTP endpoints for exercising compaction conditions. Dev-only; default off.",
       "defaultEnabled": false
-    },
-    {
-      "id": "account-deletion",
-      "scope": "assistant",
-      "key": "account-deletion",
-      "label": "Account Deletion",
-      "description": "Surfaces the user-initiated account deletion flow in client settings.",
-      "defaultEnabled": true
     },
     {
       "id": "app-control",
@@ -369,14 +337,6 @@
       "key": "chat-pull-to-refresh-enabled",
       "label": "Chat Pull to Refresh",
       "description": "Enable pull-to-refresh gesture in the chat view.",
-      "defaultEnabled": false
-    },
-    {
-      "id": "doctor",
-      "scope": "client",
-      "key": "doctor",
-      "label": "Doctor",
-      "description": "Enable the Doctor diagnostic tab in Debug settings.",
       "defaultEnabled": false
     },
     {

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -124,14 +124,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "deploy-to-vercel",
-      "scope": "assistant",
-      "key": "deploy-to-vercel",
-      "label": "Deploy to Vercel",
-      "description": "Enable the Deploy to Vercel / Publish option in the app workspace header share menu",
-      "defaultEnabled": false
-    },
-    {
       "id": "settings-embedding-provider",
       "scope": "assistant",
       "key": "settings-embedding-provider",
@@ -161,14 +153,6 @@
       "key": "expand-completed-steps",
       "label": "Expand Completed Steps",
       "description": "Auto-expand completed tool call step groups instead of showing them collapsed",
-      "defaultEnabled": false
-    },
-    {
-      "id": "sounds",
-      "scope": "assistant",
-      "key": "sounds",
-      "label": "Sounds",
-      "description": "Enable the Sounds tab in Settings and all app sound playback (event sounds, random ambient sounds)",
       "defaultEnabled": false
     },
     {
@@ -236,14 +220,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "managed-gemini-embeddings-enabled",
-      "scope": "assistant",
-      "key": "managed-gemini-embeddings-enabled",
-      "label": "Managed Gemini Embeddings Enabled",
-      "description": "Route embedding requests through the platform runtime proxy using Vellum-managed Gemini credentials when available",
-      "defaultEnabled": false
-    },
-    {
       "id": "bookmarks",
       "scope": "client",
       "key": "bookmarks",
@@ -298,14 +274,6 @@
       "label": "Compaction Playground",
       "description": "Expose the developer-only Compaction Playground tab in macOS Settings and enable the /playground/* HTTP endpoints for exercising compaction conditions. Dev-only; default off.",
       "defaultEnabled": false
-    },
-    {
-      "id": "account-deletion",
-      "scope": "assistant",
-      "key": "account-deletion",
-      "label": "Account Deletion",
-      "description": "Surfaces the user-initiated account deletion flow in client settings.",
-      "defaultEnabled": true
     },
     {
       "id": "app-control",
@@ -369,14 +337,6 @@
       "key": "chat-pull-to-refresh-enabled",
       "label": "Chat Pull to Refresh",
       "description": "Enable pull-to-refresh gesture in the chat view.",
-      "defaultEnabled": false
-    },
-    {
-      "id": "doctor",
-      "scope": "client",
-      "key": "doctor",
-      "label": "Doctor",
-      "description": "Enable the Doctor diagnostic tab in Debug settings.",
       "defaultEnabled": false
     },
     {


### PR DESCRIPTION
## Summary
- Remove 7 GA'ed feature flag entries from all 4 registry JSON files
- Flags removed: account-deletion, deploy-to-vercel, sounds, managed-gemini-embeddings-enabled, email-channel, platform-hosted-enabled, doctor
- All flag-checking code was already removed in PRs 1-5

Part of plan: rm-gaed-feature-flags.md (PR 6 of 7)