### PR TITLE
refactor(gateway): switch platform feature check from flag to VELLUM_DISABLE_PLATFORM env var

### DIFF
--- a/gateway/src/feature-flag-resolver.ts
+++ b/gateway/src/feature-flag-resolver.ts
@@ -47,5 +47,6 @@ function isPlatformMode(): boolean {
 
 export function arePlatformFeaturesEnabled(): boolean {
   if (isPlatformMode()) return true;
-  return isFeatureFlagEnabled("platform-features-in-local-mode");
+  const v = process.env.VELLUM_DISABLE_PLATFORM?.trim().toLowerCase();
+  return !(v === "true" || v === "1");
 }


### PR DESCRIPTION
## Summary
- Replace `arePlatformFeaturesEnabled()` in gateway to read `VELLUM_DISABLE_PLATFORM` env var instead of the feature flag
- Follows same parsing pattern as existing `isPlatformMode()`

Part of plan: disable-platform-env-var.md (PR 2 of 5)