### PR TITLE
Remove 7 GA'ed feature flag gating code

### DIFF
--- a/apps/web/src/assistant/lifecycle-service.ts
+++ b/apps/web/src/assistant/lifecycle-service.ts
@@ -504,11 +504,11 @@ class AssistantLifecycleService {
             attempt: this.hatchRetryCount,
           },
         });
-        // Capacity / kill-switch from the backend
-        // (platform-hosted-enabled flag is off). Surface the
-        // tailored message instead of treating this as a
-        // recoverable 5xx — retrying just burns the
-        // MAX_HATCH_RETRIES budget and ends in a generic error.
+        // Capacity kill-switch: when platform hosting is unavailable
+        // the backend returns 503. Surface the tailored message
+        // instead of treating this as a recoverable 5xx — retrying
+        // just burns the MAX_HATCH_RETRIES budget and ends in a
+        // generic error.
         if (isPlatformHostedDisabled(result.status, result.error)) {
           this.transition({
             kind: "error",

--- a/apps/web/src/assistant/lifecycle.ts
+++ b/apps/web/src/assistant/lifecycle.ts
@@ -52,9 +52,9 @@ export function shouldRecoverFromHatchFailure(status?: number): boolean {
 
 /**
  * The Django hatch endpoint returns 503 + `{ code: "platform_hosted_disabled" }`
- * when the `platform-hosted-enabled` feature flag is off (global capacity
- * kill-switch). The onboarding flow surfaces this as a user-friendly message
- * instead of recovering / retrying.
+ * when platform hosting is unavailable (global capacity kill-switch). The
+ * onboarding flow surfaces this as a user-friendly message instead of
+ * recovering / retrying.
  */
 export const PLATFORM_HOSTED_DISABLED_CODE = "platform_hosted_disabled";
 

--- a/apps/web/src/domains/chat/components/chat-content-layout.tsx
+++ b/apps/web/src/domains/chat/components/chat-content-layout.tsx
@@ -20,7 +20,6 @@ import { AppViewerContainer } from "@/components/app-viewer-container";
 import { DocumentViewerContainer } from "@/domains/chat/components/document-viewer-container";
 import { ChatMainPanel, type ChatMainPanelProps } from "@/domains/chat/components/chat-route-content";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
-import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useDeployStore } from "@/stores/deploy-store";
 import { useViewerStore } from "@/stores/viewer-store";
@@ -56,7 +55,6 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
 
   const isSharing = useDeployStore.use.isSharing();
   const isDeploying = useDeployStore.use.isDeploying();
-  const deployToVercel = useAssistantFeatureFlagStore.use.deployToVercel();
   const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
 
   const isMobile = useIsMobile();
@@ -136,7 +134,7 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
             onEdit={handleCloseEditPanel}
             onShare={handleShareApp}
             isSharing={isSharing}
-            onDeploy={deployToVercel ? handleDeployApp : undefined}
+            onDeploy={handleDeployApp}
             isDeploying={isDeploying}
             isEditing
           />
@@ -165,7 +163,7 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
         onEdit={handleEditApp}
         onShare={handleShareApp}
         isSharing={isSharing}
-        onDeploy={deployToVercel ? handleDeployApp : undefined}
+        onDeploy={handleDeployApp}
         isDeploying={isDeploying}
       />
     );

--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -200,7 +200,6 @@ export function ChatMainPanel({
   const assistantState = useAssistantLifecycleStore.use.assistantState();
   const assistantName = useAssistantIdentityStore.use.name();
   const chatPullToRefreshEnabled = useClientFeatureFlagStore.use.chatPullToRefreshEnabled();
-  const doctorEnabled = useClientFeatureFlagStore.use.doctor();
 
   // -------------------------------------------------------------------------
   // Store reads — per-conversation state
@@ -437,13 +436,13 @@ export function ChatMainPanel({
   const genericChatError = shouldShowGenericChatErrorNotice(error) && error
     ? {
         message: error.message,
-        actions: doctorEnabled ? (
+        actions: (
           <Button asChild variant="outlined" size="compact">
             <Link to={`${routes.settings.debug}?tab=doctor`}>
               Go to Doctor
             </Link>
           </Button>
-        ) : undefined,
+        ),
       }
     : null;
 

--- a/apps/web/src/domains/chat/components/connecting-to-assistant.tsx
+++ b/apps/web/src/domains/chat/components/connecting-to-assistant.tsx
@@ -8,7 +8,6 @@ import type {
     ReachabilityState,
 } from "@/assistant/use-assistant-reachability";
 import { MAX_ATTEMPTS } from "@/assistant/use-assistant-reachability";
-import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { VELLUM_COMMUNITY_URL } from "@/utils/external-urls";
 import { routes } from "@/utils/routes";
 import { Button, Modal, Typography } from "@vellumai/design-library";
@@ -112,19 +111,14 @@ const FailureBody: FC<FailureBodyProps> = ({
   lastServerState,
   onRetry,
 }) => {
-  const doctorEnabled = useClientFeatureFlagStore.use.doctor();
   const isCrashLoop = lastServerState === "crash_loop";
 
   const title = isCrashLoop
     ? "Your assistant hit an error"
     : "Couldn't connect to your assistant";
   const description = isCrashLoop
-    ? doctorEnabled
-      ? "Your assistant reported an error while starting. Try running Vellum Doctor to diagnose the issue, or ask the community for help."
-      : "Your assistant reported an error while starting. Ask the community for help if the problem persists."
-    : doctorEnabled
-      ? `We tried ${MAX_ATTEMPTS} times over 60 seconds and still can't reach your assistant. Try running Vellum Doctor to diagnose the issue, or ask the community for help.`
-      : `We tried ${MAX_ATTEMPTS} times over 60 seconds and still can't reach your assistant. Ask the community for help if the problem persists.`;
+    ? "Your assistant reported an error while starting. Try running Vellum Doctor to diagnose the issue, or ask the community for help."
+    : `We tried ${MAX_ATTEMPTS} times over 60 seconds and still can't reach your assistant. Try running Vellum Doctor to diagnose the issue, or ask the community for help.`;
 
   return (
     <StatusLayout
@@ -145,17 +139,15 @@ const FailureBody: FC<FailureBodyProps> = ({
           >
             Try again
           </Button>
-          {doctorEnabled && (
-            <Button
-              asChild
-              variant="outlined"
-              data-testid="connection-go-to-doctor-button"
-            >
-              <Link to={`${routes.settings.debug}?tab=doctor`}>
-                Vellum Doctor
-              </Link>
-            </Button>
-          )}
+          <Button
+            asChild
+            variant="outlined"
+            data-testid="connection-go-to-doctor-button"
+          >
+            <Link to={`${routes.settings.debug}?tab=doctor`}>
+              Vellum Doctor
+            </Link>
+          </Button>
           <Button
             asChild
             variant="outlined"

--- a/apps/web/src/domains/chat/components/mobile-chat-overlays.tsx
+++ b/apps/web/src/domains/chat/components/mobile-chat-overlays.tsx
@@ -11,7 +11,6 @@ import { createPortal } from "react-dom";
 import { useNavigate } from "react-router";
 
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
-import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useDeployStore } from "@/stores/deploy-store";
 import { useSubagentStore } from "@/domains/chat/subagent-store";
@@ -38,8 +37,6 @@ export function MobileChatOverlays() {
   const subagentById = useSubagentStore.use.byId();
   const isSharing = useDeployStore.use.isSharing();
   const isDeploying = useDeployStore.use.isDeploying();
-  const deployToVercel = useAssistantFeatureFlagStore.use.deployToVercel();
-
   const handleCloseApp = useCallback(() => {
     useViewerStore.getState().closeApp();
     useConversationStore.getState().setEditingConversationId(null);
@@ -107,7 +104,7 @@ export function MobileChatOverlays() {
         onClose={handleCloseApp}
         onShare={handleShareApp}
         isSharing={isSharing}
-        onDeploy={deployToVercel ? handleDeployApp : undefined}
+        onDeploy={handleDeployApp}
         isDeploying={isDeploying}
       />
       <MobileDocumentOverlay

--- a/apps/web/src/domains/library/library-view.tsx
+++ b/apps/web/src/domains/library/library-view.tsx
@@ -20,7 +20,6 @@ import { LibraryGridSection } from "@/domains/library/components/library-grid-se
 import { useLibraryData } from "@/domains/library/use-library-data";
 import { appsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
 import { appsByIdDeletePost } from "@/generated/daemon/sdk.gen";
-import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { useDeployStore } from "@/stores/deploy-store";
 import { usePinnedAppsStore } from "@/stores/pinned-apps-store";
 import type { AppSummary } from "@/types/app-types";
@@ -46,7 +45,6 @@ export function LibraryView({
   onOpenApp,
 }: LibraryViewProps) {
   const queryClient = useQueryClient();
-  const deployToVercel = useAssistantFeatureFlagStore.use.deployToVercel();
   const togglePin = usePinnedAppsStore.use.togglePin();
   const pinnedAppIds = usePinnedAppsStore.use.pinnedAppIds();
   const isDeploying = useDeployStore.use.isDeploying();
@@ -244,7 +242,7 @@ export function LibraryView({
               onOpen={onOpenApp}
               onPin={handlePinToggle}
               onDelete={setAppPendingDelete}
-              onDeploy={deployToVercel ? handleDeploy : undefined}
+              onDeploy={handleDeploy}
             />
             <LibraryGridSection
               title="Recents"
@@ -254,7 +252,7 @@ export function LibraryView({
               onOpen={onOpenApp}
               onPin={handlePinToggle}
               onDelete={setAppPendingDelete}
-              onDeploy={deployToVercel ? handleDeploy : undefined}
+              onDeploy={handleDeploy}
             />
             {filteredDocuments.length > 0 ? (
               <section>

--- a/apps/web/src/domains/settings/pages/debug-page.tsx
+++ b/apps/web/src/domains/settings/pages/debug-page.tsx
@@ -5,7 +5,6 @@ import { AssistantTerminalPanel } from "@/domains/settings/components/panels/ass
 import { DebugControlsPanel } from "@/domains/settings/components/panels/debug-controls-panel";
 import { DoctorPanel } from "@/domains/settings/components/panels/doctor-panel";
 import { usePlatformGate } from "@/hooks/use-platform-gate";
-import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { cn } from "@/utils/misc";
 
 const ALL_TABS = [
@@ -18,7 +17,6 @@ type DebugTabId = (typeof ALL_TABS)[number]["id"];
 
 export function DebugPage() {
   const [searchParams, setSearchParams] = useSearchParams();
-  const doctorEnabled = useClientFeatureFlagStore.use.doctor();
   // Terminal tab is platform-routed and should be hidden when the active
   // assistant is self-hosted — `platformHostedOnly: true` is the correct
   // variant. The standard gate would still resolve to "full" on a
@@ -29,13 +27,12 @@ export function DebugPage() {
   const tabs = useMemo(
     () =>
       ALL_TABS.filter((tab) => {
-        if (tab.id === "doctor" && !doctorEnabled) return false;
         // Terminal is platform-routed — hide the tab entirely on self-hosted
         // assistants so users don't land on an empty panel.
         if (tab.id === "terminal" && platformGate === "gated") return false;
         return true;
       }),
-    [doctorEnabled, platformGate],
+    [platformGate],
   );
 
   const activeTab: DebugTabId = useMemo(() => {
@@ -93,7 +90,7 @@ export function DebugPage() {
       >
         {activeTab === "general" && <DebugControlsPanel />}
         {activeTab === "terminal" && <AssistantTerminalPanel />}
-        {activeTab === "doctor" && doctorEnabled && <DoctorPanel />}
+        {activeTab === "doctor" && <DoctorPanel />}
       </div>
     </div>
   );

--- a/apps/web/src/domains/settings/pages/general-page.tsx
+++ b/apps/web/src/domains/settings/pages/general-page.tsx
@@ -217,7 +217,6 @@ export function GeneralPage() {
     refetch,
     refetchUntilResized,
   } = useAssistantWithHealthz();
-  const accountDeletion = useAssistantFeatureFlagStore.use.accountDeletion();
   const multiPlatformAssistant = useClientFeatureFlagStore.use.multiPlatformAssistant();
   const settingsSleepPolicy = useAssistantFeatureFlagStore.use.settingsSleepPolicy();
   const isAuthenticated = useIsAuthenticated();
@@ -377,7 +376,7 @@ export function GeneralPage() {
         </DetailCard>
       )}
 
-      {accountDeletion && <DeleteAccountSection />}
+      <DeleteAccountSection />
     </div>
   );
 }

--- a/apps/web/src/domains/settings/settings-layout.tsx
+++ b/apps/web/src/domains/settings/settings-layout.tsx
@@ -30,7 +30,6 @@ export function SettingsLayout() {
   );
   const settingsDeveloperNav = useAssistantFeatureFlagStore.use.settingsDeveloperNav();
   const platformNotifications = useClientFeatureFlagStore.use.platformNotifications();
-  const sounds = useAssistantFeatureFlagStore.use.sounds();
   const platformGate = usePlatformGate({ platformHostedOnly: true });
   const billingGate = usePlatformGate();
   const { pathname } = useLocation();
@@ -50,9 +49,6 @@ export function SettingsLayout() {
         if (item.id === "devices" && platformGate === "gated") {
           return false;
         }
-        if (item.id === "sounds" && !sounds) {
-          return false;
-        }
         // Hotkey rebinding drives Electron globalShortcut + menu accelerators,
         // which have no web/iOS analogue. Hide the entry off the desktop app;
         // the page itself also redirects as defense in depth.
@@ -64,7 +60,7 @@ export function SettingsLayout() {
         }
         return true;
       }),
-    [platformNotifications, sounds, platformGate, billingGate],
+    [platformNotifications, platformGate, billingGate],
   );
 
   const bottomItems = useMemo(

--- a/apps/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/apps/web/src/lib/feature-flags/feature-flag-registry.json
@@ -124,14 +124,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "deploy-to-vercel",
-      "scope": "assistant",
-      "key": "deploy-to-vercel",
-      "label": "Deploy to Vercel",
-      "description": "Enable the Deploy to Vercel / Publish option in the app workspace header share menu",
-      "defaultEnabled": false
-    },
-    {
       "id": "settings-embedding-provider",
       "scope": "assistant",
       "key": "settings-embedding-provider",
@@ -161,14 +153,6 @@
       "key": "expand-completed-steps",
       "label": "Expand Completed Steps",
       "description": "Auto-expand completed tool call step groups instead of showing them collapsed",
-      "defaultEnabled": false
-    },
-    {
-      "id": "sounds",
-      "scope": "assistant",
-      "key": "sounds",
-      "label": "Sounds",
-      "description": "Enable the Sounds tab in Settings and all app sound playback (event sounds, random ambient sounds)",
       "defaultEnabled": false
     },
     {
@@ -236,14 +220,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "managed-gemini-embeddings-enabled",
-      "scope": "assistant",
-      "key": "managed-gemini-embeddings-enabled",
-      "label": "Managed Gemini Embeddings Enabled",
-      "description": "Route embedding requests through the platform runtime proxy using Vellum-managed Gemini credentials when available",
-      "defaultEnabled": false
-    },
-    {
       "id": "bookmarks",
       "scope": "client",
       "key": "bookmarks",
@@ -298,14 +274,6 @@
       "label": "Compaction Playground",
       "description": "Expose the developer-only Compaction Playground tab in macOS Settings and enable the /playground/* HTTP endpoints for exercising compaction conditions. Dev-only; default off.",
       "defaultEnabled": false
-    },
-    {
-      "id": "account-deletion",
-      "scope": "assistant",
-      "key": "account-deletion",
-      "label": "Account Deletion",
-      "description": "Surfaces the user-initiated account deletion flow in client settings.",
-      "defaultEnabled": true
     },
     {
       "id": "app-control",
@@ -369,14 +337,6 @@
       "key": "chat-pull-to-refresh-enabled",
       "label": "Chat Pull to Refresh",
       "description": "Enable pull-to-refresh gesture in the chat view.",
-      "defaultEnabled": false
-    },
-    {
-      "id": "doctor",
-      "scope": "client",
-      "key": "doctor",
-      "label": "Doctor",
-      "description": "Enable the Doctor diagnostic tab in Debug settings.",
       "defaultEnabled": false
     },
     {

--- a/assistant/src/__tests__/config-managed-gemini-defaults.test.ts
+++ b/assistant/src/__tests__/config-managed-gemini-defaults.test.ts
@@ -57,17 +57,8 @@ mock.module("../util/logger.js", () => ({
   getLogger: () => makeLoggerStub(),
 }));
 
-// ---------------------------------------------------------------------------
-// Feature flag mock — controls whether managed-gemini-embeddings-enabled is on
-// ---------------------------------------------------------------------------
-
-let featureFlagEnabled = false;
-
 mock.module("../config/assistant-feature-flags.js", () => ({
-  isAssistantFeatureFlagEnabled: (key: string) => {
-    if (key === "managed-gemini-embeddings-enabled") return featureFlagEnabled;
-    return true;
-  },
+  isAssistantFeatureFlagEnabled: () => true,
   clearFeatureFlagOverridesCache: () => {},
   initFeatureFlagOverrides: async () => {},
   getAssistantFeatureFlagDefaults: () => ({}),
@@ -119,8 +110,6 @@ describe("managed Gemini embedding defaults (via loadConfig)", () => {
     setStorePathForTesting(join(WORKSPACE_DIR, "keys.enc"));
     invalidateConfigCache();
 
-    // Reset mock state
-    featureFlagEnabled = false;
     originalIsPlatform = process.env.IS_PLATFORM;
     delete process.env.IS_PLATFORM;
   });
@@ -137,10 +126,9 @@ describe("managed Gemini embedding defaults (via loadConfig)", () => {
     }
   });
 
-  test("applies managed Gemini defaults when FF on + IS_PLATFORM + provider auto", () => {
+  test("applies managed Gemini defaults when IS_PLATFORM + provider auto", () => {
     writeConfig({});
 
-    featureFlagEnabled = true;
     process.env.IS_PLATFORM = "true";
 
     const config = loadConfig();
@@ -162,22 +150,9 @@ describe("managed Gemini embedding defaults (via loadConfig)", () => {
     expect(qdrantRaw.vectorSize).toBe(3072);
   });
 
-  test("does NOT apply when feature flag is OFF", () => {
-    writeConfig({});
-
-    featureFlagEnabled = false;
-    process.env.IS_PLATFORM = "true";
-
-    const config = loadConfig();
-
-    expect(config.memory.embeddings.provider).toBe("auto");
-    expect(config.memory.qdrant.vectorSize).toBe(384);
-  });
-
   test("does NOT apply when IS_PLATFORM is not set", () => {
     writeConfig({});
 
-    featureFlagEnabled = true;
     delete process.env.IS_PLATFORM;
 
     const config = loadConfig();
@@ -191,7 +166,6 @@ describe("managed Gemini embedding defaults (via loadConfig)", () => {
       memory: { embeddings: { provider: "local" } },
     });
 
-    featureFlagEnabled = true;
     process.env.IS_PLATFORM = "true";
 
     const config = loadConfig();
@@ -204,7 +178,6 @@ describe("managed Gemini embedding defaults (via loadConfig)", () => {
       memory: { embeddings: { provider: "openai" } },
     });
 
-    featureFlagEnabled = true;
     process.env.IS_PLATFORM = "true";
 
     const config = loadConfig();
@@ -219,7 +192,6 @@ describe("managed Gemini embedding defaults (via loadConfig)", () => {
       },
     });
 
-    featureFlagEnabled = true;
     process.env.IS_PLATFORM = "true";
 
     const config = loadConfig();
@@ -235,7 +207,6 @@ describe("managed Gemini embedding defaults (via loadConfig)", () => {
       memory: { embeddings: { provider: "ollama" } },
     });
 
-    featureFlagEnabled = true;
     process.env.IS_PLATFORM = "true";
 
     const config = loadConfig();
@@ -245,7 +216,6 @@ describe("managed Gemini embedding defaults (via loadConfig)", () => {
   test("is idempotent — second loadConfig is a no-op after migration", () => {
     writeConfig({});
 
-    featureFlagEnabled = true;
     process.env.IS_PLATFORM = "true";
 
     const config = loadConfig();
@@ -274,7 +244,6 @@ describe("managed Gemini embedding defaults (via loadConfig)", () => {
       },
     });
 
-    featureFlagEnabled = true;
     process.env.IS_PLATFORM = "true";
 
     const config = loadConfig();
@@ -295,22 +264,9 @@ describe("managed Gemini embedding defaults (via loadConfig)", () => {
     expect(qdrantRaw.onDisk).toBe(false);
   });
 
-  test("does NOT apply when both FF off and IS_PLATFORM not set", () => {
-    writeConfig({});
-
-    featureFlagEnabled = false;
-    delete process.env.IS_PLATFORM;
-
-    const config = loadConfig();
-
-    expect(config.memory.embeddings.provider).toBe("auto");
-    expect(config.memory.qdrant.vectorSize).toBe(384);
-  });
-
   test("applies when IS_PLATFORM is '1'", () => {
     writeConfig({});
 
-    featureFlagEnabled = true;
     process.env.IS_PLATFORM = "1";
 
     const config = loadConfig();

--- a/assistant/src/__tests__/credential-execution-feature-gates.test.ts
+++ b/assistant/src/__tests__/credential-execution-feature-gates.test.ts
@@ -165,10 +165,11 @@ describe("CES flags do not affect unrelated flags", () => {
     setOverridesForTesting(overrides);
     const config = makeConfig();
 
-    // account-deletion defaults to true in the registry and should stay true.
-    expect(isAssistantFeatureFlagEnabled("account-deletion", config)).toBe(
-      true,
-    );
+    // Flags with defaultEnabled: true in the registry should stay true
+    // regardless of CES overrides.
+    expect(
+      isAssistantFeatureFlagEnabled("platform-features-in-local-mode", config),
+    ).toBe(true);
   });
 
   test("enabling all CES flags does not change unrelated fail-closed flags", () => {

--- a/assistant/src/__tests__/embedding-managed-proxy-selection.test.ts
+++ b/assistant/src/__tests__/embedding-managed-proxy-selection.test.ts
@@ -2,8 +2,7 @@
  * Tests for managed proxy Gemini embedding backend selection.
  *
  * Verifies that selectEmbeddingBackend correctly routes through the
- * managed proxy when the feature flag is enabled and managed proxy
- * prerequisites are satisfied.
+ * managed proxy when managed proxy prerequisites are satisfied.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -42,13 +41,9 @@ mock.module("../security/secure-keys.js", () => ({
   },
 }));
 
-// Feature flag mock
-const mockFeatureFlags: Record<string, boolean> = {};
-
+// Feature flag mock — always returns true (flag is GA'ed)
 mock.module("../config/assistant-feature-flags.js", () => ({
-  isAssistantFeatureFlagEnabled: (key: string, _config: unknown) => {
-    return mockFeatureFlags[key] ?? false;
-  },
+  isAssistantFeatureFlagEnabled: () => true,
 }));
 
 import type { AssistantConfig } from "../config/types.js";
@@ -73,14 +68,6 @@ function enableManagedProxy() {
 function disableManagedProxy() {
   mockPlatformBaseUrl = "";
   mockAssistantApiKey = null;
-}
-
-function enableFlag() {
-  mockFeatureFlags["managed-gemini-embeddings-enabled"] = true;
-}
-
-function disableFlag() {
-  mockFeatureFlags["managed-gemini-embeddings-enabled"] = false;
 }
 
 function makeConfig(
@@ -116,7 +103,6 @@ function makeConfig(
 
 beforeEach(() => {
   disableManagedProxy();
-  disableFlag();
   mockProviderKeys = {};
   clearEmbeddingBackendCache();
 });
@@ -126,9 +112,8 @@ afterEach(() => {
 });
 
 describe("managed proxy Gemini embedding selection", () => {
-  test("selects managed proxy Gemini when flag enabled and proxy context available", async () => {
+  test("selects managed proxy Gemini when proxy context available", async () => {
     enableManagedProxy();
-    enableFlag();
     const config = makeConfig();
 
     const { backend, reason } = await selectEmbeddingBackend(config);
@@ -141,7 +126,6 @@ describe("managed proxy Gemini embedding selection", () => {
 
   test("managed proxy backend uses default 3072 dimensions when geminiDimensions not set", async () => {
     enableManagedProxy();
-    enableFlag();
     const config = makeConfig();
 
     const { backend } = await selectEmbeddingBackend(config);
@@ -155,7 +139,6 @@ describe("managed proxy Gemini embedding selection", () => {
 
   test("managed proxy backend uses explicit geminiDimensions when set", async () => {
     enableManagedProxy();
-    enableFlag();
     const config = makeConfig({ geminiDimensions: 768 });
 
     const { backend } = await selectEmbeddingBackend(config);
@@ -168,7 +151,6 @@ describe("managed proxy Gemini embedding selection", () => {
 
   test("managed proxy backend uses managedBaseUrl (not direct Google API)", async () => {
     enableManagedProxy();
-    enableFlag();
     const config = makeConfig();
 
     const { backend } = await selectEmbeddingBackend(config);
@@ -179,32 +161,19 @@ describe("managed proxy Gemini embedding selection", () => {
     expect(managedBaseUrl).toBe(`${PLATFORM_BASE}/v1/runtime-proxy/gemini`);
   });
 
-  test("falls back to local when flag is disabled (no managed proxy)", async () => {
-    enableManagedProxy();
-    disableFlag();
-    const config = makeConfig();
-
-    const { backend } = await selectEmbeddingBackend(config);
-
-    // With auto and no provider keys, falls through to local
-    expect(backend).not.toBeNull();
-    expect(backend!.provider).toBe("local");
-  });
-
   test("falls back to local when managed proxy context unavailable", async () => {
     disableManagedProxy();
-    enableFlag();
     const config = makeConfig();
 
     const { backend } = await selectEmbeddingBackend(config);
 
+    // With auto and no provider keys or proxy, falls through to local
     expect(backend).not.toBeNull();
     expect(backend!.provider).toBe("local");
   });
 
   test("selects managed proxy when provider is explicitly gemini", async () => {
     enableManagedProxy();
-    enableFlag();
     const config = makeConfig({ provider: "gemini" });
 
     const { backend } = await selectEmbeddingBackend(config);
@@ -217,7 +186,6 @@ describe("managed proxy Gemini embedding selection", () => {
 
   test("does not use managed proxy when provider is explicitly local", async () => {
     enableManagedProxy();
-    enableFlag();
     const config = makeConfig({ provider: "local" });
 
     const { backend } = await selectEmbeddingBackend(config);
@@ -228,7 +196,6 @@ describe("managed proxy Gemini embedding selection", () => {
 
   test("does not use managed proxy when provider is explicitly openai", async () => {
     enableManagedProxy();
-    enableFlag();
     mockProviderKeys[credentialKey("openai", "api_key")] = "user-openai-key";
     const config = makeConfig({ provider: "openai" });
 
@@ -238,9 +205,8 @@ describe("managed proxy Gemini embedding selection", () => {
     expect(backend!.provider).toBe("openai");
   });
 
-  test("direct Gemini key still works when flag is off", async () => {
+  test("direct Gemini key still works without managed proxy", async () => {
     disableManagedProxy();
-    disableFlag();
     mockProviderKeys[credentialKey("gemini", "api_key")] = "user-gemini-key";
     const config = makeConfig({ provider: "gemini" });
 

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -14,7 +14,6 @@ import {
   getWorkspaceConfigPath,
   getWorkspaceDir,
 } from "../util/platform.js";
-import { isAssistantFeatureFlagEnabled } from "./assistant-feature-flags.js";
 import { AssistantConfigSchema } from "./schema.js";
 import type { AssistantConfig } from "./types.js";
 
@@ -692,16 +691,15 @@ export function loadConfig(): AssistantConfig {
 
     if (suppressConfigDiskWritesDepth === 0) {
       // Managed Gemini embedding defaults migration.
-      // When on a managed platform (IS_PLATFORM=true) with the feature flag
-      // enabled and no explicit embedding provider chosen (provider=auto),
-      // persist Gemini embedding defaults into the raw config file.
+      // When on a managed platform (IS_PLATFORM=true) and no explicit embedding
+      // provider chosen (provider=auto), persist Gemini embedding defaults into
+      // the raw config file.
       // Idempotent: once provider=gemini is written, subsequent loads skip this.
       if (config.memory.embeddings.provider === "auto") {
         try {
           if (
-            (process.env.IS_PLATFORM === "true" ||
-              process.env.IS_PLATFORM === "1") &&
-            isManagedGeminiFFEnabled(config)
+            process.env.IS_PLATFORM === "true" ||
+            process.env.IS_PLATFORM === "1"
           ) {
             setNestedValue(fileConfig, "memory.embeddings.provider", "gemini");
             setNestedValue(
@@ -794,21 +792,6 @@ export function loadConfig(): AssistantConfig {
     cachedFileSignature = null;
     loading = false;
     throw err;
-  }
-}
-
-/**
- * Check whether the managed-gemini-embeddings-enabled feature flag is on.
- * Wrapped in a try/catch so a flag-resolver failure never breaks config loading.
- */
-function isManagedGeminiFFEnabled(config: AssistantConfig): boolean {
-  try {
-    return isAssistantFeatureFlagEnabled(
-      "managed-gemini-embeddings-enabled",
-      config,
-    );
-  } catch {
-    return false;
   }
 }
 

--- a/assistant/src/memory/embedding-backend.ts
+++ b/assistant/src/memory/embedding-backend.ts
@@ -1,6 +1,5 @@
 import { createHash } from "node:crypto";
 
-import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getOllamaBaseUrlEnv } from "../config/env.js";
 import { resolveCallSiteConfig } from "../config/llm-resolver.js";
 import type { AssistantConfig } from "../config/types.js";
@@ -302,13 +301,10 @@ export async function selectEmbeddingBackend(
     };
   }
 
-  // When the managed-gemini-embeddings-enabled flag is on AND managed proxy
-  // prerequisites are satisfied, insert managed-proxy Gemini at the front of
-  // the auto chain so platform assistants use Vellum-managed Gemini embeddings.
-  if (
-    (requested === "auto" || requested === "gemini") &&
-    isAssistantFeatureFlagEnabled("managed-gemini-embeddings-enabled", config)
-  ) {
+  // When managed proxy prerequisites are satisfied, insert managed-proxy Gemini
+  // at the front of the auto chain so platform assistants use Vellum-managed
+  // Gemini embeddings.
+  if (requested === "auto" || requested === "gemini") {
     const proxyCtx = await resolveManagedProxyContext();
     if (proxyCtx.enabled) {
       const meta = PLATFORM_PROVIDER_META["gemini"];
@@ -677,12 +673,7 @@ async function selectFallbackBackends(
               geminiCacheExtras(config),
             ),
           );
-        } else if (
-          isAssistantFeatureFlagEnabled(
-            "managed-gemini-embeddings-enabled",
-            config,
-          )
-        ) {
+        } else {
           // Try managed proxy Gemini as fallback when no direct key exists.
           const proxyCtx = await resolveManagedProxyContext();
           const meta = PLATFORM_PROVIDER_META["gemini"];
@@ -724,14 +715,6 @@ async function selectFallbackBackends(
               );
             if (cached) backends.push(cached);
           }
-        } else {
-          // Preserve cached backend on transient credential-store failures.
-          const cached = getCached(
-            "gemini",
-            config.memory.embeddings.geminiModel,
-            geminiCacheExtras(config),
-          );
-          if (cached) backends.push(cached);
         }
         break;
       }

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -660,7 +660,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         setupNotifications()
         setupAutoUpdate()
 
-        SoundManager.shared.start(featureFlagStore: featureFlagStore)
+        SoundManager.shared.start()
         RandomSoundTimer.shared.start()
         if !hasPlayedAppOpenSound {
             hasPlayedAppOpenSound = true

--- a/clients/macos/vellum-assistant/Features/MainWindow/DynamicWorkspaceWrapper.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DynamicWorkspaceWrapper.swift
@@ -18,16 +18,11 @@ struct DynamicWorkspaceWrapper: View {
     let isChatDockOpen: Bool
     let onToggleChatDock: () -> Void
     let onMicrophoneToggle: () -> Void
-    var featureFlagClient: FeatureFlagClientProtocol = FeatureFlagClient()
 
     @State private var showVersionHistory = false
     @State private var publishUrlCopied = false
     @State private var showShareDrawer = false
     @State private var shareButtonFrame: CGRect = .zero
-    @State private var isDeployToVercelEnabled = false
-
-    private static let deployToVercelFlagKey = "deploy-to-vercel"
-
     /// Corner radius for the WKWebView clipping container — no rounding needed since the
     /// outer page container handles corner rounding.
     private var webViewCornerRadius: CGFloat { 0 }
@@ -81,11 +76,7 @@ struct DynamicWorkspaceWrapper: View {
                                     .frame(height: 32)
                             } else {
                                 VButton(label: "Share", iconOnly: VIcon.share.rawValue, style: .outlined, iconSize: 32, tooltip: "Share") {
-                                    if isDeployToVercelEnabled {
-                                        showShareDrawer.toggle()
-                                    } else if let appId = data.appId {
-                                        onBundleAndShare(appId)
-                                    }
+                                    showShareDrawer.toggle()
                                 }
                                 .onGeometryChange(for: CGRect.self) { proxy in
                                     proxy.frame(in: .named("appPageContainer"))
@@ -111,7 +102,7 @@ struct DynamicWorkspaceWrapper: View {
                             ProgressView()
                                 .controlSize(.small)
                                 .frame(height: 32)
-                        } else if sharing.publishedUrl == nil && isDeployToVercelEnabled {
+                        } else if sharing.publishedUrl == nil {
                             VButton(label: "Publish", iconOnly: VIcon.arrowUpRight.rawValue, style: .outlined, iconSize: 32, tooltip: "Publish to Vercel") {
                                 onPublishPage(data.html, data.preview?.title, data.appId)
                             }
@@ -234,8 +225,7 @@ struct DynamicWorkspaceWrapper: View {
                     onPublish: {
                         showShareDrawer = false
                         onPublishPage(data.html, data.preview?.title, data.appId)
-                    },
-                    isDeployToVercelEnabled: isDeployToVercelEnabled
+                    }
                 )
                 .offset(
                     x: shareButtonFrame.maxX - 180,
@@ -243,23 +233,6 @@ struct DynamicWorkspaceWrapper: View {
                 )
                 .zIndex(10)
                 .transition(.opacity)
-            }
-        }
-        .task {
-            do {
-                let flags = try await featureFlagClient.getFeatureFlags()
-                if let flag = flags.first(where: { $0.key == Self.deployToVercelFlagKey }) {
-                    isDeployToVercelEnabled = flag.enabled
-                }
-            } catch {
-                // Flag stays disabled on error
-            }
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .assistantFeatureFlagDidChange)) { notification in
-            if let key = notification.userInfo?["key"] as? String,
-               let enabled = notification.userInfo?["enabled"] as? Bool,
-               key == Self.deployToVercelFlagKey {
-                isDeployToVercelEnabled = enabled
             }
         }
     }
@@ -323,21 +296,18 @@ private struct PublishedButton: View {
 
 // MARK: - Share Drawer
 
-/// Popover menu with "Share" and optionally "Publish to Vercel" options.
+/// Popover menu with "Share" and "Publish to Vercel" options.
 /// Styled to match ConversationSwitcherDrawer / DrawerMenuView.
 private struct ShareDrawer: View {
     let onShare: () -> Void
     let onPublish: () -> Void
-    let isDeployToVercelEnabled: Bool
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             VNavItem(icon: VIcon.share.rawValue, label: "Share") { onShare() }
-            if isDeployToVercelEnabled {
-                VColor.borderBase.frame(height: 1)
-                    .padding(.horizontal, VSpacing.xs)
-                VNavItem(icon: VIcon.arrowUpRight.rawValue, label: "Publish to Vercel") { onPublish() }
-            }
+            VColor.borderBase.frame(height: 1)
+                .padding(.horizontal, VSpacing.xs)
+            VNavItem(icon: VIcon.arrowUpRight.rawValue, label: "Publish to Vercel") { onPublish() }
         }
         .padding(.vertical, VSpacing.xs)
         .frame(width: 180)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -39,7 +39,6 @@ enum SettingsTab: String {
     }
 
     static func sidebarTopTabs(
-        soundsEnabled: Bool = true,
         debugEnabled: Bool = false,
         includeCompactionPlayground: Bool = false,
         includeMemoryRouterPlayground: Bool = false,
@@ -54,7 +53,7 @@ enum SettingsTab: String {
         }
         tabs.append(contentsOf: [.general, .modelsAndServices, .integrations])
         tabs.append(.voice)
-        if soundsEnabled { tabs.append(.sounds) }
+        tabs.append(.sounds)
         tabs.append(.billing)
         tabs.append(.community)
         tabs.append(.permissionsAndPrivacy)
@@ -113,9 +112,6 @@ struct SettingsPanel: View {
         let developerEnabled = MacOSClientFeatureFlagManager.shared.isEnabled(Self.developerFeatureFlagKey)
         _isDeveloperEnabled = State(initialValue: developerEnabled)
 
-        let soundsEnabled = assistantFeatureFlagStore.isEnabled(Self.soundsFeatureFlagKey)
-        _isSoundsEnabled = State(initialValue: soundsEnabled)
-
         let bookmarksEnabled = MacOSClientFeatureFlagManager.shared.isEnabled(Self.bookmarksFeatureFlagKey)
         _isBookmarksEnabled = State(initialValue: bookmarksEnabled)
 
@@ -138,7 +134,6 @@ struct SettingsPanel: View {
             // in `ConnectionSetup` before the settings view is presented.
             let debugEnabled = AppDelegate.shared?.isCurrentAssistantManaged ?? false
             var visibleTabs = SettingsTab.sidebarTopTabs(
-                soundsEnabled: soundsEnabled,
                 debugEnabled: debugEnabled,
                 includeCompactionPlayground: false,
                 includeMemoryRouterPlayground: false,
@@ -177,7 +172,6 @@ struct SettingsPanel: View {
     @State private var isDeveloperEnabled: Bool = false
     @State private var isCompactionPlaygroundEnabled: Bool = false
     @State private var isMemoryRouterPlaygroundEnabled: Bool = false
-    @State private var isSoundsEnabled: Bool = true
     @State private var isBookmarksEnabled: Bool = false
     @State private var isEmbeddingProviderEnabled: Bool = false
     @State private var showingDevUnlock: Bool = false
@@ -188,7 +182,6 @@ struct SettingsPanel: View {
     private static let compactionPlaygroundFeatureFlagKey = "compaction-playground"
     private static let memoryRouterPlaygroundFeatureFlagKey = "memory-router-playground"
     private static let embeddingProviderFeatureFlagKey = "settings-embedding-provider"
-    private static let soundsFeatureFlagKey = "sounds"
     private static let bookmarksFeatureFlagKey = "bookmarks"
     private static let deferredDeepLinkTabs: Set<SettingsTab> = [
         .compactionPlayground,
@@ -260,7 +253,6 @@ struct SettingsPanel: View {
         }
         .onAppear {
             isDeveloperEnabled = MacOSClientFeatureFlagManager.shared.isEnabled(Self.developerFeatureFlagKey)
-            isSoundsEnabled = assistantFeatureFlagStore.isEnabled(Self.soundsFeatureFlagKey)
             isBookmarksEnabled = MacOSClientFeatureFlagManager.shared.isEnabled(Self.bookmarksFeatureFlagKey)
             // The init already consumed pendingSettingsTab into selectedTab.
             // Clear the store value so it doesn't leak into future navigations.
@@ -292,9 +284,6 @@ struct SettingsPanel: View {
         .onChange(of: isDebugVisible) { _, _ in
             handleSidebarVisibilityChanged()
         }
-        .onChange(of: isSoundsEnabled) { _, _ in
-            handleSidebarVisibilityChanged()
-        }
         .onChange(of: isDeveloperEnabled) { _, _ in
             handleSidebarVisibilityChanged()
         }
@@ -313,8 +302,6 @@ struct SettingsPanel: View {
                     isCompactionPlaygroundEnabled = enabled
                 } else if key == Self.embeddingProviderFeatureFlagKey {
                     isEmbeddingProviderEnabled = enabled
-                } else if key == Self.soundsFeatureFlagKey {
-                    isSoundsEnabled = enabled
                 } else if key == Self.bookmarksFeatureFlagKey {
                     isBookmarksEnabled = enabled
                 }
@@ -410,7 +397,6 @@ struct SettingsPanel: View {
 
     private var visibleSidebarTopTabs: [SettingsTab] {
         SettingsTab.sidebarTopTabs(
-            soundsEnabled: isSoundsEnabled,
             debugEnabled: isDebugVisible,
             includeCompactionPlayground: isCompactionPlaygroundVisible,
             includeMemoryRouterPlayground: isMemoryRouterPlaygroundVisible,
@@ -765,9 +751,6 @@ struct SettingsPanel: View {
                 if let embeddingProviderFlag = flags.first(where: { $0.key == Self.embeddingProviderFeatureFlagKey }) {
                     isEmbeddingProviderEnabled = embeddingProviderFlag.enabled
                 }
-                if let soundsFlag = flags.first(where: { $0.key == Self.soundsFeatureFlagKey }) {
-                    isSoundsEnabled = soundsFlag.enabled
-                }
                 handleSidebarVisibilityChanged(clearDeferredIfHidden: true)
                 hasLoadedFeatureFlags = true
                 return
@@ -785,9 +768,6 @@ struct SettingsPanel: View {
         }
         if let embeddingProviderEnabled = resolved[Self.embeddingProviderFeatureFlagKey] {
             isEmbeddingProviderEnabled = embeddingProviderEnabled
-        }
-        if let soundsEnabled = resolved[Self.soundsFeatureFlagKey] {
-            isSoundsEnabled = soundsEnabled
         }
         handleSidebarVisibilityChanged(clearDeferredIfHidden: true)
         hasLoadedFeatureFlags = true

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -498,16 +498,13 @@ struct SettingsGeneralTab: View {
 
     // MARK: - Danger Zone
 
-    /// Whether to render the Danger Zone (account deletion) section. Gated on
-    /// both the client-side `account-deletion` feature flag (mirroring the
-    /// server-side LaunchDarkly flag in `vellum-assistant-platform`) and a
+    /// Whether to render the Danger Zone (account deletion) section. Requires a
     /// signed-in session — without a `currentUser`, the POST would fail with
     /// notAuthenticated, so we don't expose the destructive button.
     nonisolated static func shouldShowDangerZone(
-        flagManager: MacOSClientFeatureFlagManager = .shared,
         isAuthenticated: Bool
     ) -> Bool {
-        flagManager.isEnabled("account-deletion") && isAuthenticated
+        isAuthenticated
     }
 
     private var dangerZoneSection: some View {

--- a/clients/macos/vellum-assistant/Features/Sounds/SoundManager.swift
+++ b/clients/macos/vellum-assistant/Features/Sounds/SoundManager.swift
@@ -18,12 +18,6 @@ final class SoundManager {
     /// Current sound configuration, fetched from the gateway.
     private(set) var config: SoundsConfig = .defaultConfig
 
-    /// Cached feature flag store used to check the "sounds" flag without disk I/O.
-    /// Set via `start(featureFlagStore:)` so `play(_:)` reads from memory instead
-    /// of calling `AssistantFeatureFlagResolver.isEnabled()` (which performs
-    /// synchronous file reads on the main thread).
-    @ObservationIgnored private var featureFlagStore: AssistantFeatureFlagStore?
-
     /// Serial background queue for audio playback. `NSSound.play()` can block the
     /// calling thread for 2000ms+ during audio subsystem initialization
     /// (`AudioQueueXPC_Bridge::Start` → XPC sync dispatch → mutex lock). Routing all
@@ -112,9 +106,7 @@ final class SoundManager {
 
     // MARK: - Lifecycle
 
-    func start(featureFlagStore: AssistantFeatureFlagStore? = nil) {
-        self.featureFlagStore = featureFlagStore
-
+    func start() {
         // Reload sounds config on every daemon (re)connect. The daemon
         // only broadcasts sounds_config_updated on file mutations, so
         // without this hook the config would stay at `.defaultConfig`
@@ -350,11 +342,6 @@ final class SoundManager {
 
     /// Plays the sound associated with the given event, respecting global and per-event toggles.
     func play(_ event: SoundEvent) {
-        // Use the cached store when available (zero disk I/O); fall back to
-        // the static resolver only if start() was called without a store.
-        let soundsEnabled = featureFlagStore?.isEnabled("sounds")
-            ?? AssistantFeatureFlagResolver.isEnabled("sounds")
-        guard soundsEnabled else { return }
         guard config.globalEnabled else { return }
 
         let eventConfig = config.config(for: event)

--- a/clients/macos/vellum-assistantTests/DeleteAccountTests.swift
+++ b/clients/macos/vellum-assistantTests/DeleteAccountTests.swift
@@ -3,12 +3,11 @@ import SwiftUI
 @testable import VellumAssistantLib
 @testable import VellumAssistantShared
 
-/// Tests for the `account-deletion` feature-flag-gated Danger Zone section in
-/// `SettingsGeneralTab`, and for the `DeleteAccountConfirmView` confirmation
-/// modal. The modal calls `AuthService.requestAccountDeletion()`, which posts
-/// directly to platform at `/v1/user/deletion-request/` and returns
-/// `.requested` (HTTP 201) when the server-side `account-deletion` flag is on
-/// or `.unavailable` (HTTP 404) when off.
+/// Tests for the Danger Zone section in `SettingsGeneralTab` and the
+/// `DeleteAccountConfirmView` confirmation modal. The modal calls
+/// `AuthService.requestAccountDeletion()`, which posts directly to platform
+/// at `/v1/user/deletion-request/` and returns `.requested` (HTTP 201) on
+/// success or `.unavailable` (HTTP 404) when the endpoint is unreachable.
 @MainActor
 final class DeleteAccountTests: XCTestCase {
 
@@ -34,8 +33,8 @@ final class DeleteAccountTests: XCTestCase {
         }
     }
 
-    /// On an `.unavailable` result (server-side flag off), the modal surfaces
-    /// an inline error and does not report `.deleted` to the parent.
+    /// On an `.unavailable` result (HTTP 404), the modal surfaces an inline
+    /// error and does not report `.deleted` to the parent.
     func testConfirmModalShowsErrorOnUnavailable() async {
         let view = DeleteAccountConfirmView(
             onDeleted: { _ in XCTFail("onDeleted should not fire on unavailable") },

--- a/clients/shared/App/Auth/AuthService.swift
+++ b/clients/shared/App/Auth/AuthService.swift
@@ -733,8 +733,7 @@ public final class AuthService {
         /// Server accepted the request (HTTP 201). The session should be torn
         /// down on the client side.
         case requested
-        /// Server-side `account-deletion` flag is off (HTTP 404). The feature
-        /// is unavailable for this account; the caller should surface the
+        /// The endpoint returned HTTP 404. The caller should surface the
         /// inline "not available" copy rather than a generic error.
         case unavailable
     }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -124,14 +124,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "deploy-to-vercel",
-      "scope": "assistant",
-      "key": "deploy-to-vercel",
-      "label": "Deploy to Vercel",
-      "description": "Enable the Deploy to Vercel / Publish option in the app workspace header share menu",
-      "defaultEnabled": false
-    },
-    {
       "id": "settings-embedding-provider",
       "scope": "assistant",
       "key": "settings-embedding-provider",
@@ -161,14 +153,6 @@
       "key": "expand-completed-steps",
       "label": "Expand Completed Steps",
       "description": "Auto-expand completed tool call step groups instead of showing them collapsed",
-      "defaultEnabled": false
-    },
-    {
-      "id": "sounds",
-      "scope": "assistant",
-      "key": "sounds",
-      "label": "Sounds",
-      "description": "Enable the Sounds tab in Settings and all app sound playback (event sounds, random ambient sounds)",
       "defaultEnabled": false
     },
     {
@@ -236,14 +220,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "managed-gemini-embeddings-enabled",
-      "scope": "assistant",
-      "key": "managed-gemini-embeddings-enabled",
-      "label": "Managed Gemini Embeddings Enabled",
-      "description": "Route embedding requests through the platform runtime proxy using Vellum-managed Gemini credentials when available",
-      "defaultEnabled": false
-    },
-    {
       "id": "bookmarks",
       "scope": "client",
       "key": "bookmarks",
@@ -298,14 +274,6 @@
       "label": "Compaction Playground",
       "description": "Expose the developer-only Compaction Playground tab in macOS Settings and enable the /playground/* HTTP endpoints for exercising compaction conditions. Dev-only; default off.",
       "defaultEnabled": false
-    },
-    {
-      "id": "account-deletion",
-      "scope": "assistant",
-      "key": "account-deletion",
-      "label": "Account Deletion",
-      "description": "Surfaces the user-initiated account deletion flow in client settings.",
-      "defaultEnabled": true
     },
     {
       "id": "app-control",
@@ -369,14 +337,6 @@
       "key": "chat-pull-to-refresh-enabled",
       "label": "Chat Pull to Refresh",
       "description": "Enable pull-to-refresh gesture in the chat view.",
-      "defaultEnabled": false
-    },
-    {
-      "id": "doctor",
-      "scope": "client",
-      "key": "doctor",
-      "label": "Doctor",
-      "description": "Enable the Doctor diagnostic tab in Debug settings.",
       "defaultEnabled": false
     },
     {


### PR DESCRIPTION
## Summary
Remove feature flag gating code for 7 flags confirmed GA'ed in LaunchDarkly production (fallthrough → `true`, no restrictive rules). Each feature is now unconditionally enabled.

**Flags removed:**
- `account-deletion` — Danger Zone section now shows whenever authenticated
- `deploy-to-vercel` — Publish to Vercel always available in share menu
- `sounds` — Sound playback governed by config only, no flag check
- `managed-gemini-embeddings-enabled` — Managed Gemini proxy path unconditional when IS_PLATFORM is set
- `doctor` — Doctor tab and links always visible
- `platform-hosted-enabled` — Stale comments cleaned up (no code gating existed)
- `email-channel` — Registry entry removed (no code gating existed; skill ID references preserved)

## PRs merged into feature branch
- #34089: fix: remove account-deletion feature flag gating (GA'ed)
- #34088: fix: remove deploy-to-vercel feature flag gating (GA'ed)
- #34091: fix: remove sounds feature flag gating (GA'ed)
- #34092: fix: remove managed-gemini-embeddings-enabled feature flag gating (GA'ed)
- #34090: fix: remove doctor feature flag gating (GA'ed)
- #34097: chore: remove 7 GA'ed flags from feature flag registry
- #34087: chore: remove stale platform-hosted-enabled flag comments

Part of plan: rm-gaed-feature-flags.md