### PR TITLE
feat(cli): add --disable-platform arg to hatch and client commands

### DIFF
--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -85,6 +85,7 @@ interface ParsedArgs {
   flagEnvVars: Record<string, string>;
   /** Parsed --flag overrides: kebab-case key -> typed value (for web injection). */
   parsedFlagOverrides: Record<string, boolean | string>;
+  disablePlatform: boolean;
 }
 
 function readAssistantName(entry: AssistantEntry | null): string | undefined {
@@ -99,6 +100,8 @@ export function parseArgs(): ParsedArgs {
   const { envVars: cliFlagVars, remaining: argsWithoutFlags } =
     parseFeatureFlagArgs(process.argv.slice(3));
   const flagEnvVars = { ...readAmbientFlagEnvVars(), ...cliFlagVars };
+  const disablePlatformAmbient = process.env.VELLUM_DISABLE_PLATFORM?.trim().toLowerCase();
+  let disablePlatform = disablePlatformAmbient === "true" || disablePlatformAmbient === "1";
   const args = argsWithoutFlags;
 
   // Build parsedFlagOverrides from the extracted env vars:
@@ -133,6 +136,8 @@ export function parseArgs(): ParsedArgs {
     if (arg === "--help" || arg === "-h") {
       printUsage();
       process.exit(0);
+    } else if (arg === "--disable-platform") {
+      disablePlatform = true;
     } else if (
       (arg === "--url" ||
         arg === "-u" ||
@@ -252,6 +257,7 @@ export function parseArgs(): ParsedArgs {
     interfaceId,
     flagEnvVars,
     parsedFlagOverrides,
+    disablePlatform,
   };
 }
 
@@ -272,6 +278,7 @@ ${ANSI.bold}OPTIONS:${ANSI.reset}
     -a, --assistant-id <id>    Assistant ID
     -i, --interface <id>       Interface identifier: cli (default) or web
     --flag <key=value>         Feature flag override (repeatable, kebab-case key)
+    --disable-platform         Suppress all outbound platform API calls
     -h, --help                 Show this help message
 
 ${ANSI.bold}DEFAULTS:${ANSI.reset}
@@ -652,6 +659,7 @@ function getBaseDir(): string {
 async function runWebInterface(
   flagEnvVars: Record<string, string>,
   parsedFlagOverrides: Record<string, boolean | string>,
+  disablePlatform: boolean,
 ): Promise<void> {
   // Propagate flag env vars so child processes (e.g. hatch from the web UI) inherit them.
   Object.assign(process.env, flagEnvVars);
@@ -660,7 +668,7 @@ async function runWebInterface(
   // (HMR, __local endpoints, gateway proxy).
   const webSourceDir = findWebSourceDir();
   if (webSourceDir) {
-    return runViteDevServer(webSourceDir, flagEnvVars);
+    return runViteDevServer(webSourceDir, flagEnvVars, disablePlatform);
   }
 
   const distDir = findWebDistDir();
@@ -679,7 +687,7 @@ async function runWebInterface(
   const webUrl = getWebUrl();
   const safeJson = (v: unknown) =>
     JSON.stringify(v).replace(/</g, "\\u003c").replace(/>/g, "\\u003e");
-  const configJson = safeJson({ webUrl, platformUrl });
+  const configJson = safeJson({ webUrl, platformUrl, disablePlatform });
   const hasOverrides = Object.keys(parsedFlagOverrides).length > 0;
   const flagOverridesSnippet = hasOverrides
     ? `;window.__VELLUM_FLAG_OVERRIDES__=${safeJson(parsedFlagOverrides)}`
@@ -814,6 +822,7 @@ async function runWebInterface(
 async function runViteDevServer(
   webSourceDir: string,
   flagEnvVars: Record<string, string>,
+  disablePlatform: boolean,
 ): Promise<void> {
   const platformUrl = getPlatformUrl();
 
@@ -830,6 +839,7 @@ async function runViteDevServer(
       ...process.env,
       ...flagEnvVars,
       ...viteFlagVars,
+      ...(disablePlatform ? { VITE_VELLUM_DISABLE_PLATFORM: "true" } : {}),
       VITE_PLATFORM_MODE: "false",
       API_PROXY_TARGET: platformUrl,
       VELLUM_WEB_URL: getWebUrl(),
@@ -909,10 +919,15 @@ export async function client(): Promise<void> {
     interfaceId,
     flagEnvVars,
     parsedFlagOverrides,
+    disablePlatform,
   } = parseArgs();
 
+  if (disablePlatform) {
+    process.env.VELLUM_DISABLE_PLATFORM = "true";
+  }
+
   if (interfaceId === WEB_INTERFACE_ID) {
-    await runWebInterface(flagEnvVars, parsedFlagOverrides);
+    await runWebInterface(flagEnvVars, parsedFlagOverrides, disablePlatform);
     return;
   }
 

--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -181,6 +181,7 @@ interface HatchArgs {
   configValues: Record<string, string>;
   flagEnvVars: Record<string, string>;
   analyze: boolean;
+  disablePlatform: boolean;
 }
 
 function parseArgs(): HatchArgs {
@@ -188,6 +189,8 @@ function parseArgs(): HatchArgs {
     process.argv.slice(3),
   );
   const flagEnvVars = { ...readAmbientFlagEnvVars(), ...cliFlagVars };
+  const disablePlatformAmbient = process.env.VELLUM_DISABLE_PLATFORM?.trim().toLowerCase();
+  let disablePlatform = disablePlatformAmbient === "true" || disablePlatformAmbient === "1";
   let species: Species = DEFAULT_SPECIES;
   let detached = false;
   let keepAlive = false;
@@ -232,6 +235,9 @@ function parseArgs(): HatchArgs {
       );
       console.log(
         "  --analyze                 Emit a structured hatch-timing log line on stdout",
+      );
+      console.log(
+        "  --disable-platform        Suppress all outbound platform API calls",
       );
       process.exit(0);
     } else if (arg === "-d") {
@@ -293,11 +299,13 @@ function parseArgs(): HatchArgs {
       const value = next.slice(eqIndex + 1);
       configValues[key] = value;
       i++;
+    } else if (arg === "--disable-platform") {
+      disablePlatform = true;
     } else if (VALID_SPECIES.includes(arg as Species)) {
       species = arg as Species;
     } else {
       console.error(
-        `Error: Unknown argument '${arg}'. Valid options: ${VALID_SPECIES.join(", ")}, -d, --watch, --source <path>, --keep-alive, --name <name>, --remote <${VALID_REMOTE_HOSTS.join("|")}>, --config <key=value>, --flag <key=value>, --analyze`,
+        `Error: Unknown argument '${arg}'. Valid options: ${VALID_SPECIES.join(", ")}, -d, --watch, --source <path>, --keep-alive, --name <name>, --remote <${VALID_REMOTE_HOSTS.join("|")}>, --config <key=value>, --flag <key=value>, --analyze, --disable-platform`,
       );
       process.exit(1);
     }
@@ -314,6 +322,7 @@ function parseArgs(): HatchArgs {
     configValues,
     flagEnvVars,
     analyze,
+    disablePlatform,
   };
 }
 
@@ -549,7 +558,13 @@ export async function hatch(): Promise<void> {
     configValues,
     flagEnvVars,
     analyze,
+    disablePlatform,
   } = parseArgs();
+
+  if (disablePlatform) {
+    process.env.VELLUM_DISABLE_PLATFORM = "true";
+    flagEnvVars.VELLUM_DISABLE_PLATFORM = "true";
+  }
 
   if (watch && remote !== "local" && remote !== "docker") {
     console.error(


### PR DESCRIPTION
## Summary
- Add `--disable-platform` boolean arg to `vellum hatch` and `vellum client` CLI commands
- Propagate `VELLUM_DISABLE_PLATFORM=true` to process.env, flagEnvVars (for Docker), and web UI config injection
- Support ambient `VELLUM_DISABLE_PLATFORM` env var as equivalent to the CLI arg

Part of plan: disable-platform-env-var.md (PR 3 of 5)