### PR TITLE
fix(web): accurate, human-readable activity-run-card timing + cleaner streaming header

### DIFF
--- a/apps/web/src/domains/chat/components/activity-run-card/activity-run-card.test.tsx
+++ b/apps/web/src/domains/chat/components/activity-run-card/activity-run-card.test.tsx
@@ -90,12 +90,12 @@ function renderCard(
 }
 
 describe("ActivityRunCard — non-web tool group", () => {
-  test("renders the unified shell with the bash carousel header collapsed by default", () => {
+  test("collapsed terminal card promotes the bash command into the carousel header", () => {
     const toolCalls = [
       makeToolCall({
         id: "tc-1",
         name: "bash",
-        status: "running",
+        status: "completed",
         input: { command: "git status" },
       }),
     ];
@@ -115,6 +115,26 @@ describe("ActivityRunCard — non-web tool group", () => {
     expect(queryByText("1 step")).toBeNull();
   });
 
+  test("shows a stable 'Working' summary header while streaming, not the step command", () => {
+    const toolCalls = [
+      makeToolCall({
+        id: "tc-1",
+        name: "bash",
+        status: "running",
+        input: { command: "git status" },
+      }),
+    ];
+    const { getByText, queryByText, queryByTestId } = renderCard(toolCalls);
+    // While the run is in flight the header is a single status summary — it
+    // does NOT carousel the live step (no "git status", no "Working (bash)").
+    // The latest step's loading indicator lives in the expanded timeline.
+    expect(getByText("Working")).toBeTruthy();
+    expect(queryByText("git status")).toBeNull();
+    expect(queryByText("Working (bash)")).toBeNull();
+    // Collapsed by default: no step rows on mount.
+    expect(queryByTestId("tool-step-pill")).toBeNull();
+  });
+
   test("keeps loading step rows hidden until the user expands the card", () => {
     const toolCalls = [
       makeToolCall({
@@ -128,6 +148,45 @@ describe("ActivityRunCard — non-web tool group", () => {
     expect(queryByTestId("tool-step-pill")).toBeNull();
     fireEvent.click(getByRole("button", { name: /expand steps/i }));
     expect(getByTestId("tool-step-pill")).toBeTruthy();
+  });
+
+  test("drops the header's loading dots once expanded — the timeline carries status", () => {
+    const toolCalls = [
+      makeToolCall({
+        id: "tc-1",
+        name: "bash",
+        status: "running",
+        input: { command: "git status" },
+      }),
+    ];
+    const { getByRole, getByTestId, queryByTestId } = renderCard(toolCalls);
+    // Collapsed: the header shows the loading dots (no timeline to carry them).
+    expect(getByTestId("tool-progress-card-status-indicator")).toBeTruthy();
+    fireEvent.click(getByRole("button", { name: /expand steps/i }));
+    // Expanded: the header's loading dots are gone; the running phase node in
+    // the timeline below carries the live indicator instead.
+    expect(queryByTestId("tool-progress-card-status-indicator")).toBeNull();
+    expect(
+      getByTestId("phase-header-status-icon").children.length,
+    ).toBe(3);
+  });
+
+  test("keeps the finished checkmark in the header when expanded and complete", () => {
+    const toolCalls = [
+      makeToolCall({
+        id: "tc-1",
+        name: "bash",
+        status: "completed",
+        input: { command: "git status" },
+      }),
+    ];
+    useChatSessionStore.setState({ expandedCardIds: new Map([["tc-1", true]]) });
+    const { getByTestId } = renderCard(toolCalls);
+    // Only the loading dots are dropped when expanded — the terminal checkmark
+    // still summarises the outcome in the header above the timeline.
+    const indicator = getByTestId("tool-progress-card-status-indicator");
+    expect(indicator.tagName.toLowerCase()).toBe("svg");
+    expect(indicator.getAttribute("data-state")).toBe("complete");
   });
 
   test("uses the loading indicator while any tool is running", () => {

--- a/apps/web/src/domains/chat/components/activity-run-card/activity-run-card.tsx
+++ b/apps/web/src/domains/chat/components/activity-run-card/activity-run-card.tsx
@@ -166,18 +166,25 @@ function deriveSummaryState(
  * this stays a short heading for the steps timeline rather than echoing the
  * latest step.
  *
- * Once the run is terminal and we have timing data, the summary reports how
- * long the agent worked ("Worked for 16s") regardless of outcome — the icon
- * still carries success / partial / failure. Without timing data it falls back
- * to an outcome label, and the `warning` fallback spells out how many tools
- * failed.
+ * Whenever we have timing data the summary reports how long the agent worked —
+ * a live, ticking "Working for 16s" while running and a final "Worked for 16s"
+ * once terminal, regardless of outcome (the icon still carries success /
+ * partial / failure). Without timing data it falls back to an outcome label,
+ * and the `warning` fallback spells out how many tools failed.
  */
 function expandedHeaderLabel(
   state: ToolProgressCardState,
   totalDurationLabel: string,
   failedCount: number,
 ): string {
-  if (state === "loading") return "Working";
+  // While running, surface the live, ticking total ("Working for 12s") once we
+  // have at least a full second of work — below that the `<1s` label reads
+  // awkwardly, so we keep the bare "Working".
+  if (state === "loading") {
+    return totalDurationLabel && totalDurationLabel !== "<1s"
+      ? `Working for ${totalDurationLabel}`
+      : "Working";
+  }
   if (totalDurationLabel) return `Worked for ${totalDurationLabel}`;
   switch (state) {
     case "warning":
@@ -381,12 +388,21 @@ function UnifiedActivityRunCard({
   // reads the raw call to build the tool-detail drawer payload.
   const toolCallById = new Map(toolCalls.map((tc) => [tc.id, tc]));
 
-  // Expanded, the full step timeline is visible below, so echoing the latest
-  // step's title + info in the header is pure repetition. Swap the live
-  // per-step title for a stable overall-status label ("Working" / "Completed" /
-  // "Failed") and drop the info entirely — the header then reads as a section
-  // heading for the expanded steps rather than a duplicate of the last row.
-  const headerTitle = expanded
+  // The header shows the stable overall-status summary ("Working for 8s" /
+  // "Worked for 8s" / "Failed") rather than the live per-step carousel in two
+  // cases:
+  //   - While the run is in flight: the only changing part is the ticking
+  //     duration — no step carousel, no truncated step text. The expanded
+  //     timeline's latest step carries the live loading indicator instead, so
+  //     the header needn't echo it (and a stable animation key below keeps the
+  //     number updating in place rather than re-sliding every second).
+  //   - When expanded: the full timeline is visible below, so echoing the
+  //     latest step in the header would be pure repetition.
+  // Otherwise (collapsed + terminal) the header carousels the latest step so a
+  // compact history card still summarises what ran.
+  const isLoading = shellState === "loading";
+  const showSummaryHeader = isLoading || expanded;
+  const headerTitle = showSummaryHeader
     ? expandedHeaderLabel(
         shellState,
         cardData.totalDurationLabel ?? "",
@@ -395,12 +411,13 @@ function UnifiedActivityRunCard({
     : cardData.currentStepTitle;
 
   // When the latest step is a thinking segment, the collapsed header pairs a
-  // brain glyph with the thinking text. Suppressed when expanded (the timeline
-  // below already shows every step). Memoized so the carousel (which compares
-  // the info node by reference via `Object.is`) doesn't re-animate on every
-  // parent render — only when the (expanded, kind, info) tuple actually changes.
+  // brain glyph with the thinking text. Suppressed for the summary header (the
+  // ticking duration / expanded timeline stand in). Memoized so the carousel
+  // (which compares the info node by reference via `Object.is`) doesn't
+  // re-animate on every parent render — only when the (summary, kind, info)
+  // tuple actually changes.
   const headerInfo = useMemo(() => {
-    if (expanded) return null;
+    if (showSummaryHeader) return null;
     if (cardData.currentStepKind === "thinking") {
       return (
         // Fill the carousel's flex slot (`flex w-full min-w-0`) so the inner
@@ -422,7 +439,7 @@ function UnifiedActivityRunCard({
       );
     }
     return cardData.currentStepInfo;
-  }, [expanded, cardData.currentStepKind, cardData.currentStepInfo]);
+  }, [showSummaryHeader, cardData.currentStepKind, cardData.currentStepInfo]);
 
   return (
     <ToolProgressCardShell
@@ -435,6 +452,18 @@ function UnifiedActivityRunCard({
       state={shellState}
       currentStepTitle={headerTitle}
       currentStepInfo={headerInfo}
+      // The summary header ("Working for Ns" / "Worked for Ns") is a single
+      // stable label whose only changing part is the duration, so a constant
+      // animation key keeps the carousel from re-sliding — the text updates in
+      // place. (Collapsed + terminal still carousels the latest step, hence the
+      // key only pins while the summary header is shown.)
+      headerAnimationKey={showSummaryHeader ? "summary" : undefined}
+      // Expanded + running: drop the header's animated loading dots — the
+      // timeline below already shows the live step's running indicator, so the
+      // dots are redundant noise. Terminal icons (the finished checkmark /
+      // failure alert) still render when expanded so the header keeps its
+      // outcome-at-a-glance summary; collapsed always keeps its indicator.
+      hideStatusIndicator={expanded && isLoading}
       stepCount={cardData.stepCount}
       expanded={expanded}
       onExpandChange={onCardExpandChange}

--- a/apps/web/src/domains/chat/components/tool-progress-card/header-step-carousel.tsx
+++ b/apps/web/src/domains/chat/components/tool-progress-card/header-step-carousel.tsx
@@ -115,6 +115,7 @@ export function HeaderStepCarousel({
   currentStepTitle,
   currentStepInfo,
   bypassDwell = false,
+  animationKey,
 }: {
   currentStepTitle: string;
   currentStepInfo: ReactNode;
@@ -129,6 +130,15 @@ export function HeaderStepCarousel({
    * metadata still coalesces into readable steps.
    */
   bypassDwell?: boolean;
+  /**
+   * Optional stable identity for the enter/exit transition. By default the
+   * animation re-keys on the `(title, info)` tuple, so any text change slides
+   * the old content out and the new content in. When the header's only
+   * changing part is a live value (e.g. a ticking "Working for 8s"), pass a
+   * constant key here so the same element stays mounted and the text updates
+   * in place — no per-tick slide.
+   */
+  animationKey?: string;
 }) {
   const reduce = useReducedMotion();
   const tuple = useMemo(
@@ -164,7 +174,10 @@ export function HeaderStepCarousel({
     : displayed.info == null
       ? ""
       : "node";
-  const key = `${displayed.title}::${infoKey}`;
+  // A caller-supplied `animationKey` pins the transition identity so in-place
+  // value updates (e.g. a ticking duration) don't trigger a slide; otherwise
+  // the key tracks the content tuple so each new step animates in.
+  const key = animationKey ?? `${displayed.title}::${infoKey}`;
 
   // Pipe separator only renders when there's info to follow it. Empty
   // string, null, and undefined all count as "no info".

--- a/apps/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.test.tsx
+++ b/apps/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.test.tsx
@@ -279,7 +279,7 @@ describe("PhaseGroupedStepList — timeline mode", () => {
     expect(icons[0]!.children.length).toBe(3);
   });
 
-  test("renders a gapped connector line for every non-last section (and a lead-in above the first), none for the last", () => {
+  test("renders a gapped connector line for every non-last section, none for the last (no header lead-in)", () => {
     const steps: ToolCallCardStep[] = [
       bash("ls", "completed", "1s", "tc-a"),
       thinking("Reasoning"),
@@ -295,19 +295,21 @@ describe("PhaseGroupedStepList — timeline mode", () => {
         section.querySelectorAll('div[aria-hidden][class*="w-px"]'),
       ) as HTMLElement[];
 
-    // First section: the inter-node segment (`top-6 bottom-0`) + the lead-in.
-    expect(connectorsIn(sections[0]!).length).toBe(2);
+    // First section: only the inter-node segment (`top-6 bottom-0`). The
+    // expanded card header omits its status icon, so there is no lead-in
+    // trailing up to it — the timeline starts cleanly at the first node.
+    expect(connectorsIn(sections[0]!).length).toBe(1);
     // Middle section: one inter-node segment.
     expect(connectorsIn(sections[1]!).length).toBe(1);
     // Last section: no line trails below the final circle.
     expect(connectorsIn(sections[2]!).length).toBe(0);
 
-    // First section carries the lead-in (`bottom-full`) up toward the header.
+    // No section renders a `bottom-full` lead-in any more.
     expect(
-      connectorsIn(sections[0]!).some((el) =>
-        el.className.includes("bottom-full"),
+      sections.some((s) =>
+        connectorsIn(s).some((el) => el.className.includes("bottom-full")),
       ),
-    ).toBe(true);
+    ).toBe(false);
 
     // The inter-node segment starts below its node (`top-6`) and runs to the
     // section bottom (`bottom-0`) — a small, even gap before the next node.

--- a/apps/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.tsx
+++ b/apps/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.tsx
@@ -89,15 +89,24 @@ export function phaseFromStep(step: ToolCallCardStep): string {
 
 /**
  * Best-effort parse of a `formatMs`-style duration label back into a raw ms
- * value so we can sum phase totals. Handles the two outputs the formatter
- * produces today (`"<1s"`, `"Ns"`) plus an empty / missing label.
+ * value so we can sum phase totals. Handles every output the formatter
+ * produces (`"<1s"`, `"Ns"`, `"Nm"`, `"Nh"`) plus an empty / missing label.
+ * Re-formatting the sum via `formatMs` collapses the coarse units back into a
+ * single readable label, so the per-unit rounding here is acceptable.
  */
 function parseDurationLabel(label: string): number {
-  if (!label) return 0;
-  if (label === "<1s") return 0;
-  const match = /^(\d+)s$/.exec(label);
+  if (!label || label === "<1s") return 0;
+  const match = /^(\d+)(s|m|h)$/.exec(label);
   if (!match) return 0;
-  return Number(match[1]) * 1000;
+  const value = Number(match[1]);
+  switch (match[2]) {
+    case "h":
+      return value * 3_600_000;
+    case "m":
+      return value * 60_000;
+    default:
+      return value * 1_000;
+  }
 }
 
 /**
@@ -300,7 +309,6 @@ export function PhaseGroupedStepList({
             key={`${section.label}-${sectionIdx}`}
             section={section}
             baseIndex={sectionOffsets[sectionIdx]!}
-            isFirst={sectionIdx === 0}
             isLast={sectionIdx === sections.length - 1}
             renderSectionSteps={renderSectionSteps}
           />
@@ -342,21 +350,8 @@ export function PhaseGroupedStepList({
 }
 
 /**
- * Height of the connector lead-in that rises from the FIRST timeline node up
- * toward the card header's status icon. Anchored `bottom-full` above the
- * section (so it keeps the same small gap above the first node as the
- * inter-node segments) and colinear with the main line (`left-[6.5px]`). It
- * spans the ActivityRunCard timeline body's top padding (`pt-4` = 16px) and
- * most of the gap up to the header icon, stopping a small gap short of it so
- * the connection reads consistently with the rest of the timeline. Nudge ±2-4px
- * to taste; if you change the body `pt`, re-tune this to match.
- */
-const TIMELINE_LEAD_IN_HEIGHT_PX = 24;
-
-/**
- * One phase section in the vertical timeline: the connector line (+ a lead-in
- * to the header on the first section), the circular status node, the phase
- * header row, and the indented step pills.
+ * One phase section in the vertical timeline: the connector line, the circular
+ * status node, the phase header row, and the indented step pills.
  *
  * Timeline mechanics:
  *  - A connector line per non-last section sits at the node's center x
@@ -365,20 +360,18 @@ const TIMELINE_LEAD_IN_HEIGHT_PX = 24;
  *    (`bottom-0`), leaving a small, even gap before the next node — so the
  *    timeline reads as evenly-spaced segments rather than one unbroken line.
  *  - The LAST section renders no line, so nothing trails below the final node.
- *  - The FIRST section additionally renders a `bottom-full` lead-in above the
- *    node so the timeline reads as flowing down from the card header icon, with
- *    the same small gap at each end.
+ *  - The FIRST section renders no lead-in: the expanded card header omits its
+ *    status icon, so the timeline starts cleanly at the first node rather than
+ *    trailing a connector up to empty space.
  */
 function TimelinePhaseSection({
   section,
   baseIndex,
-  isFirst,
   isLast,
   renderSectionSteps,
 }: {
   section: PhaseSection;
   baseIndex: number;
-  isFirst: boolean;
   isLast: boolean;
   renderSectionSteps: (section: PhaseSection, baseIndex: number) => ReactNode;
 }) {
@@ -407,17 +400,6 @@ function TimelinePhaseSection({
         <div
           aria-hidden
           className="absolute bottom-0 left-[6.5px] top-6 w-px bg-[var(--border-element)]"
-        />
-      )}
-      {/* Lead-in above the FIRST node, rising through the body's top padding
-          toward the card header's status icon. Anchored `bottom-full` so it
-          keeps the same small gap above the first node as the inter-node
-          segments; its height stops a matching gap short of the header icon. */}
-      {isFirst && (
-        <div
-          aria-hidden
-          className="absolute bottom-full left-[6.5px] w-px bg-[var(--border-element)]"
-          style={{ height: TIMELINE_LEAD_IN_HEIGHT_PX }}
         />
       )}
       {/* Header row: circular node + label share ONE items-center row so the

--- a/apps/web/src/domains/chat/components/tool-progress-card/three-dot-indicator.stories.tsx
+++ b/apps/web/src/domains/chat/components/tool-progress-card/three-dot-indicator.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ThreeDotIndicator } from "./three-dot-indicator";
+
+/**
+ * `ThreeDotIndicator` is the single, shared "loading dots" used everywhere the
+ * app shows in-flight tool/agent work: the tool-progress card header, each
+ * running phase node in the expanded timeline, the web-search card, and the
+ * `ThoughtProcessLink`. Three dots pulse in a staggered left-to-right wave and
+ * honour `prefers-reduced-motion`.
+ */
+const meta: Meta<typeof ThreeDotIndicator> = {
+  title: "Chat/ThreeDotIndicator",
+  component: ThreeDotIndicator,
+  parameters: {
+    layout: "centered",
+  },
+  argTypes: {
+    dotSize: {
+      control: { type: "number", min: 2, max: 24, step: 1 },
+      description: "Diameter of each dot in px.",
+    },
+    gap: {
+      control: { type: "number", min: 0, max: 16, step: 1 },
+      description: "Spacing between dots in px.",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ThreeDotIndicator>;
+
+/** Default transcript sizing — 8px dots with a 3px gap. */
+export const Default: Story = {};
+
+/** Tighter sizing used in cramped contexts like the avatar progress badge. */
+export const Small: Story = {
+  args: {
+    dotSize: 5,
+    gap: 2,
+  },
+};
+
+/** Larger sizing to inspect the pulse/scale animation closely. */
+export const Large: Story = {
+  args: {
+    dotSize: 14,
+    gap: 6,
+  },
+};
+
+/** Sat against a card-like surface, mirroring its in-app placement. */
+export const OnSurface: Story = {
+  decorators: [
+    (Story) => (
+      <div className="flex items-center gap-2 rounded-[var(--radius-lg)] bg-[var(--surface-overlay)] p-3">
+        <Story />
+        <span className="text-body-medium-default text-[var(--content-emphasised)]">
+          Working for 6s
+        </span>
+      </div>
+    ),
+  ],
+};

--- a/apps/web/src/domains/chat/components/tool-progress-card/tool-progress-card-shell.test.tsx
+++ b/apps/web/src/domains/chat/components/tool-progress-card/tool-progress-card-shell.test.tsx
@@ -84,6 +84,17 @@ describe("ToolProgressCardShell — collapsed render per state", () => {
     expect(getByText("3 steps")).toBeTruthy();
   });
 
+  test("hideStatusIndicator omits the leading status indicator", () => {
+    const { queryByTestId, getByText } = renderShell({
+      state: "loading",
+      hideStatusIndicator: true,
+    });
+    // No loading dots (or any status icon) in the header...
+    expect(queryByTestId("tool-progress-card-status-indicator")).toBeNull();
+    // ...but the header title still renders.
+    expect(getByText("Doing the thing")).toBeTruthy();
+  });
+
   test("does not render the children body when collapsed", () => {
     const { queryByTestId } = renderShell();
     expect(queryByTestId("shell-body")).toBeNull();

--- a/apps/web/src/domains/chat/components/tool-progress-card/tool-progress-card-shell.tsx
+++ b/apps/web/src/domains/chat/components/tool-progress-card/tool-progress-card-shell.tsx
@@ -54,6 +54,22 @@ export interface ToolProgressCardShellProps {
    * render.
    */
   currentStepInfo: ReactNode;
+  /**
+   * Optional stable identity for the header carousel's enter/exit animation.
+   * When supplied, the carousel keys its transition on this instead of the
+   * title text, so a header whose only changing part is a live value (e.g. a
+   * ticking "Working for 8s") updates in place rather than re-sliding on every
+   * change. See {@link HeaderStepCarousel}'s `animationKey`.
+   */
+  headerAnimationKey?: string;
+  /**
+   * When `true`, the leading status indicator is omitted from the header. Used
+   * by the expanded unified card: its timeline below carries per-phase status
+   * (including the running `ThreeDotIndicator`), so repeating a status icon —
+   * especially the animated loading dots — in the header is redundant noise.
+   * The collapsed header still shows it, since there's no timeline to carry it.
+   */
+  hideStatusIndicator?: boolean;
   /** Pre-formatted step count for the toggle pill, e.g. "2 steps". */
   stepCount: string;
   /** Whether the card starts expanded. Uncontrolled by default. */
@@ -192,6 +208,8 @@ export function ToolProgressCardShell({
   leadingIcon,
   currentStepTitle,
   currentStepInfo,
+  headerAnimationKey,
+  hideStatusIndicator = false,
   stepCount,
   defaultExpanded = false,
   expanded: controlledExpanded,
@@ -256,7 +274,9 @@ export function ToolProgressCardShell({
       {(() => {
         const titleCluster = (
           <span className="flex min-w-0 flex-1 items-center gap-1">
-            <StatusIndicator state={state} testId={statusIndicatorTestId} />
+            {hideStatusIndicator ? null : (
+              <StatusIndicator state={state} testId={statusIndicatorTestId} />
+            )}
             {leadingIcon ? (
               // `mx-1` adds 4px on each side on top of the parent's `gap-1`
               // (also 4px) so the icon sits with ~8px of breathing room on
@@ -269,6 +289,7 @@ export function ToolProgressCardShell({
             <HeaderStepCarousel
               currentStepTitle={currentStepTitle}
               currentStepInfo={currentStepInfo}
+              animationKey={headerAnimationKey}
               // Terminal states (complete / denied / error) flush the header
               // throttle so the final `(title, info)` lands in sync with the
               // status-icon swap. Without this, the 400ms min-dwell could

--- a/apps/web/src/domains/chat/hooks/use-tool-call-card-data.test.ts
+++ b/apps/web/src/domains/chat/hooks/use-tool-call-card-data.test.ts
@@ -454,6 +454,134 @@ describe("computeToolCallCardDataFromItems — interleaved ordering", () => {
   });
 });
 
+describe("computeToolCallCardDataFromItems — totalDurationLabel", () => {
+  test("sums BOTH thinking and tool time, not just tool calls", () => {
+    // GIVEN a run with 2s of thinking and 3s of tool work
+    const items: ToolCallCardItem[] = [
+      {
+        kind: "thinking",
+        text: "reasoning",
+        startedAt: 0,
+        completedAt: 2_000,
+      },
+      {
+        kind: "toolCall",
+        toolCall: makeToolCall({
+          id: "tc-1",
+          name: "bash",
+          status: "completed",
+          startedAt: 2_000,
+          completedAt: 5_000,
+          input: { command: "ls" },
+        }),
+      },
+    ];
+    // WHEN the card data is computed at rest (no `nowMs`)
+    const data = computeToolCallCardDataFromItems(items, {});
+    // THEN the header total is 2s + 3s = 5s — thinking is no longer excluded
+    expect(data.totalDurationLabel).toBe("5s");
+  });
+
+  test("excludes subagent_spawn time and returns '' when nothing is timed", () => {
+    const items: ToolCallCardItem[] = [
+      { kind: "thinking", text: "untimed reasoning" },
+      {
+        kind: "toolCall",
+        toolCall: makeToolCall({
+          id: "tc-spawn",
+          name: "subagent_spawn",
+          status: "completed",
+          startedAt: 0,
+          completedAt: 9_000,
+          input: { label: "Investigate" },
+        }),
+      },
+    ];
+    const data = computeToolCallCardDataFromItems(items, {});
+    expect(data.totalDurationLabel).toBe("");
+  });
+
+  test("ticks the running step's elapsed against nowMs during streaming", () => {
+    // GIVEN a completed 4s tool plus a still-running tool started at t=10s
+    const items: ToolCallCardItem[] = [
+      {
+        kind: "toolCall",
+        toolCall: makeToolCall({
+          id: "tc-1",
+          name: "bash",
+          status: "completed",
+          startedAt: 0,
+          completedAt: 4_000,
+          input: { command: "ls" },
+        }),
+      },
+      {
+        kind: "toolCall",
+        toolCall: makeToolCall({
+          id: "tc-2",
+          name: "bash",
+          status: "running",
+          startedAt: 10_000,
+          input: { command: "sleep 5" },
+        }),
+      },
+    ];
+    // WHEN the clock reads t=13s — the running tool has been live for 3s
+    const data = computeToolCallCardDataFromItems(items, {}, 13_000);
+    // THEN the header total ticks: 4s (done) + 3s (in flight) = 7s
+    expect(data.totalDurationLabel).toBe("7s");
+    expect(data.state).toBe("loading");
+  });
+
+  test("renders a long run in human-readable minutes, not raw seconds", () => {
+    // A 3-minute tool call should read "3m", not "180s".
+    const items: ToolCallCardItem[] = [
+      {
+        kind: "toolCall",
+        toolCall: makeToolCall({
+          id: "tc-long",
+          name: "bash",
+          status: "completed",
+          startedAt: 0,
+          completedAt: 180_000,
+          input: { command: "long-build" },
+        }),
+      },
+    ];
+    const data = computeToolCallCardDataFromItems(items, {});
+    expect(data.totalDurationLabel).toBe("3m");
+  });
+
+  test("a running step contributes nothing without a clock (at rest)", () => {
+    const items: ToolCallCardItem[] = [
+      {
+        kind: "toolCall",
+        toolCall: makeToolCall({
+          id: "tc-1",
+          name: "bash",
+          status: "completed",
+          startedAt: 0,
+          completedAt: 4_000,
+          input: { command: "ls" },
+        }),
+      },
+      {
+        kind: "toolCall",
+        toolCall: makeToolCall({
+          id: "tc-2",
+          name: "bash",
+          status: "running",
+          startedAt: 10_000,
+          input: { command: "sleep 5" },
+        }),
+      },
+    ];
+    // No `nowMs` → only the completed 4s counts.
+    const data = computeToolCallCardDataFromItems(items, {});
+    expect(data.totalDurationLabel).toBe("4s");
+  });
+});
+
 describe("computeToolCallCardDataFromItems — header reflects the latest step", () => {
   test("a run ending in a thinking step surfaces it in the header", () => {
     const items: ToolCallCardItem[] = [

--- a/apps/web/src/domains/chat/hooks/use-tool-call-card-data.ts
+++ b/apps/web/src/domains/chat/hooks/use-tool-call-card-data.ts
@@ -4,15 +4,37 @@
  *  Subscribes to the turn store's `liveWebActivity` map so the card data
  *  updates in lockstep with daemon-emitted metadata. */
 
+import { useEffect, useState } from "react";
+
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import { useTurnStore } from "@/domains/chat/turn-store";
 
 import {
   computeToolCallCardData,
   computeToolCallCardDataFromItems,
+  hasRunningItem,
   type ToolCallCardData,
   type ToolCallCardItem,
 } from "@/domains/chat/utils/tool-call-card-utils";
+
+/**
+ * Per-second clock that drives the card's "Working for Xs" header while a run
+ * is in flight. Returns the current epoch-ms, advancing once a second only
+ * while `active`; when inactive it stops the interval and holds its last
+ * value (completed steps measure against their own `completedAt`, so a stale
+ * `now` is harmless at rest). Returning `undefined` when inactive lets the
+ * projection fall back to `completedAt`-based durations.
+ */
+function useNow(active: boolean): number | undefined {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (!active) return;
+    setNow(Date.now());
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, [active]);
+  return active ? now : undefined;
+}
 
 /**
  * React hook flavour of {@link computeToolCallCardData}. Subscribes to the
@@ -23,7 +45,12 @@ export function useToolCallCardData(
   toolCalls: ChatMessageToolCall[],
 ): ToolCallCardData {
   const liveWebActivity = useTurnStore.use.liveWebActivity();
-  return computeToolCallCardData(toolCalls, liveWebActivity);
+  const now = useNow(
+    hasRunningItem(
+      toolCalls.map((tc) => ({ kind: "toolCall", toolCall: tc })),
+    ),
+  );
+  return computeToolCallCardData(toolCalls, liveWebActivity, now);
 }
 
 /**
@@ -35,5 +62,6 @@ export function useToolCallCardDataFromItems(
   items: ToolCallCardItem[],
 ): ToolCallCardData {
   const liveWebActivity = useTurnStore.use.liveWebActivity();
-  return computeToolCallCardDataFromItems(items, liveWebActivity);
+  const now = useNow(hasRunningItem(items));
+  return computeToolCallCardDataFromItems(items, liveWebActivity, now);
 }

--- a/apps/web/src/domains/chat/transcript/transcript-message-body.test.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.test.tsx
@@ -328,7 +328,7 @@ describe("TranscriptMessageBody", () => {
     expect(inspectedIds).toEqual(["message-1"]);
   });
 
-  test("auto-expands the latest interleaved tool-call group while a tool is running", () => {
+  test("renders the latest interleaved tool-call group collapsed while a tool is running", () => {
     const { getByTestId } = render(
       <TranscriptMessageBody
         message={{
@@ -351,9 +351,11 @@ describe("TranscriptMessageBody", () => {
       />,
     );
 
+    // Activity cards are collapsed by default — a running tool no longer forces
+    // the group open; the user opens it to see the live timeline.
     expect(
       getByTestId("tool-progress-card").getAttribute("data-auto-expand"),
-    ).toBe("true");
+    ).toBe("false");
   });
 
   test("does not auto-expand a latest interleaved tool-call group whose tools have all completed", () => {
@@ -386,7 +388,7 @@ describe("TranscriptMessageBody", () => {
     ).toBe("false");
   });
 
-  test("auto-expands the last tool-call group of a streaming message even after its tools complete", () => {
+  test("renders a streaming message's last tool-call group collapsed", () => {
     const { getByTestId } = render(
       <TranscriptMessageBody
         message={{
@@ -411,12 +413,13 @@ describe("TranscriptMessageBody", () => {
       />,
     );
 
+    // Streaming no longer forces the trailing group open — collapsed by default.
     expect(
       getByTestId("tool-progress-card").getAttribute("data-auto-expand"),
-    ).toBe("true");
+    ).toBe("false");
   });
 
-  test("only the last tool-call group of a streaming message auto-expands", () => {
+  test("renders every tool-call group of a streaming message collapsed", () => {
     const { getAllByTestId } = render(
       <TranscriptMessageBody
         message={{
@@ -455,7 +458,7 @@ describe("TranscriptMessageBody", () => {
       getAllByTestId("tool-progress-card").map((el) =>
         el.getAttribute("data-auto-expand"),
       ),
-    ).toEqual(["false", "true"]);
+    ).toEqual(["false", "false"]);
   });
 
   test("collapses a streaming message's tool-call group once answer text streams in below it", () => {
@@ -521,7 +524,7 @@ describe("TranscriptMessageBody", () => {
     ).toBe("false");
   });
 
-  test("moves auto-expansion to a later interleaved tool-call group", () => {
+  test("renders multiple interleaved tool-call groups collapsed", () => {
     const { getAllByTestId } = render(
       <TranscriptMessageBody
         message={{
@@ -558,7 +561,7 @@ describe("TranscriptMessageBody", () => {
       getAllByTestId("tool-progress-card").map((el) =>
         el.getAttribute("data-auto-expand"),
       ),
-    ).toEqual(["false", "true"]);
+    ).toEqual(["false", "false"]);
   });
 
   test("renders user text and an image attachment inside a single bubble", () => {
@@ -821,7 +824,7 @@ describe("TranscriptMessageBody", () => {
     ).not.toBeNull();
   });
 
-  test("auto-expands legacy tool-only messages while a tool runs, until content appears", () => {
+  test("renders legacy tool-only messages collapsed whether or not a tool is running", () => {
     const { getByTestId, rerender } = render(
       <TranscriptMessageBody
         message={{
@@ -839,9 +842,10 @@ describe("TranscriptMessageBody", () => {
         onSurfaceAction={noop}
       />,
     );
+    // Collapsed by default even while the tool runs.
     expect(
       getByTestId("tool-progress-card").getAttribute("data-auto-expand"),
-    ).toBe("true");
+    ).toBe("false");
 
     rerender(
       <TranscriptMessageBody

--- a/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -46,7 +46,6 @@ import {
 import type { ConfirmationDecision } from "@/types/event-types";
 import type { AllowlistOption, DirectoryScopeOption, ScopeOption } from "@/types/interaction-ui-types";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
-import { isToolCallRunning } from "@/domains/chat/utils/tool-call-status";
 
 export interface OpenRuleEditorContext {
   toolName: string;
@@ -206,31 +205,6 @@ function resolveSpawnedSubagentIds(
   }
 
   return ids;
-}
-
-function shouldAutoExpandToolCallGroup({
-  isCurrentGroup,
-  isStreaming,
-  toolCalls,
-}: {
-  isCurrentGroup: boolean;
-  isStreaming: boolean;
-  toolCalls: ChatMessageToolCall[];
-}): boolean {
-  if (!isCurrentGroup) {
-    return false;
-  }
-  // While the turn streams, the message's last content group stays open for the
-  // whole turn — so a trailing tool-call card is visible until the model starts
-  // writing the answer below it, at which point the text group becomes last and
-  // the card collapses. Outside a stream (history) it only expands while a tool
-  // is running, which keeps completed turns collapsed and compact.
-  if (isStreaming) {
-    return true;
-  }
-  return toolCalls.some(
-    (toolCall) => isToolCallRunning(toolCall),
-  );
 }
 
 function fallbackRoleLabel(
@@ -678,11 +652,6 @@ export function TranscriptMessageBody({
               <ActivityRunCard
                 toolCalls={groupToolCalls}
                 items={cardItems}
-                autoExpand={shouldAutoExpandToolCallGroup({
-                  isCurrentGroup: isLastGroup,
-                  isStreaming,
-                  toolCalls: renderableToolCalls,
-                })}
                 onOpenRuleEditor={onOpenRuleEditor}
                 onConfirmationSubmit={onConfirmationSubmit}
                 onAllowAndCreateRule={onAllowAndCreateRule}
@@ -876,11 +845,6 @@ export function TranscriptMessageBody({
               <div className="w-full">
                 <ActivityRunCard
                   toolCalls={legacyToolCalls}
-                  autoExpand={shouldAutoExpandToolCallGroup({
-                    isCurrentGroup: !hasVisibleLegacyContent,
-                    isStreaming,
-                    toolCalls: legacyToolCalls,
-                  })}
                   onOpenRuleEditor={onOpenRuleEditor}
                   onConfirmationSubmit={onConfirmationSubmit}
                   onAllowAndCreateRule={onAllowAndCreateRule}

--- a/apps/web/src/domains/chat/utils/tool-call-card-utils.ts
+++ b/apps/web/src/domains/chat/utils/tool-call-card-utils.ts
@@ -169,10 +169,20 @@ export interface ToolCallCardData {
 // Small pure helpers used by the unified card hook and its consumers.
 // ---------------------------------------------------------------------------
 
-/** Format a duration in ms for the row-meta cluster (e.g. `<1s`, `2s`). */
+/**
+ * Format a duration in ms for the row-meta cluster as a single, human-readable
+ * unit with low precision — seconds for short work, then minutes, then hours
+ * as the run gets longer (`<1s`, `2s`, `45s`, `3m`, `2h`). We round to the
+ * coarsest unit and drop the smaller one (a "long enough task" reads as `3m`,
+ * not `3m 12s`) so the label stays glanceable in the card header and chips.
+ */
 export function formatMs(ms: number): string {
   if (!Number.isFinite(ms) || ms < 1000) return "<1s";
-  return `${Math.round(ms / 1000)}s`;
+  const seconds = Math.round(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  return `${Math.round(minutes / 60)}h`;
 }
 
 /** True when `tc.name` is a web tool (`web_search` / `web_fetch`). */
@@ -358,18 +368,80 @@ function computeToolDurationLabel(tc: ChatMessageToolCall): string {
   return computeDurationLabel(tc.startedAt ?? undefined, tc.completedAt ?? undefined);
 }
 
+/** True for a tool call that is rendered as a step AND still in flight. */
+function isRenderableRunningCall(tc: ChatMessageToolCall): boolean {
+  return !isSubagentSpawnCall(tc) && isToolCallRunning(tc);
+}
+
 /**
- * Total active work time across a group's tool calls — the sum of each call's
- * raw duration — formatted via `formatMs` (so a sub-second total reads `<1s`,
- * matching the per-phase duration chips). Powers the expanded card's "Worked
- * for Xs" summary. Returns an empty string only when NO call carries timing
- * data, in which case the header falls back to its outcome label.
+ * Raw active-work duration in ms for a single ordered item — the building
+ * block of the header's "Worked for Xs" / "Working for Xs" total. Sums BOTH
+ * thinking and tool time so the header reflects everything the run grouped,
+ * not just its tool calls.
+ *
+ * For an in-flight step (a running tool call, or a thinking segment that has
+ * started but not yet finished) the elapsed is measured against `nowMs` when
+ * supplied, so the total ticks upward during streaming. Without `nowMs` an
+ * unfinished step contributes nothing (the caller is at rest). Returns `null`
+ * for items that carry no usable timing or aren't rendered as steps (empty
+ * thinking, `subagent_spawn`) so the caller can distinguish "no data".
  */
-function computeTotalDurationLabel(toolCalls: ChatMessageToolCall[]): string {
+function computeItemDurationMs(
+  item: ToolCallCardItem,
+  nowMs: number | undefined,
+): number | null {
+  if (item.kind === "thinking") {
+    if (!item.text) return null;
+    if (item.completedAt != null) {
+      return computeDurationMs(item.startedAt, item.completedAt);
+    }
+    if (item.startedAt != null && nowMs != null) {
+      return Math.max(0, nowMs - item.startedAt);
+    }
+    return null;
+  }
+  const tc = item.toolCall;
+  if (isSubagentSpawnCall(tc)) return null;
+  if (tc.completedAt != null) return computeToolDurationMs(tc);
+  if (isToolCallRunning(tc) && tc.startedAt != null && nowMs != null) {
+    return Math.max(0, nowMs - tc.startedAt);
+  }
+  return null;
+}
+
+/**
+ * True when any ordered item is still in flight — a running (non-spawn) tool
+ * call, or a thinking segment that has started but not completed. The card
+ * hook uses this to decide whether to drive the per-second clock that makes
+ * the header's "Working for Xs" total tick during streaming.
+ */
+export function hasRunningItem(items: ToolCallCardItem[]): boolean {
+  return items.some((item) =>
+    item.kind === "thinking"
+      ? Boolean(item.text) &&
+        item.startedAt != null &&
+        item.completedAt == null
+      : isRenderableRunningCall(item.toolCall),
+  );
+}
+
+/**
+ * Total active work time across a group's steps — the sum of each thinking and
+ * tool step's raw duration — formatted via `formatMs` (so a sub-second total
+ * reads `<1s`, matching the per-phase duration chips). Powers the expanded
+ * card's "Worked for Xs" / "Working for Xs" summary; when `nowMs` is supplied
+ * the still-running step's elapsed is included so the total ticks during
+ * streaming. Returns an empty string only when NO step carries timing data, in
+ * which case the header falls back to its outcome label.
+ */
+function computeTotalDurationLabel(
+  items: ToolCallCardItem[],
+  nowMs: number | undefined,
+): string {
   let total = 0;
   let anyTimed = false;
-  for (const tc of toolCalls) {
-    const ms = computeToolDurationMs(tc);
+  for (const item of items) {
+    const ms = computeItemDurationMs(item, nowMs);
     if (ms == null) continue;
     anyTimed = true;
     total += ms;
@@ -662,6 +734,7 @@ function buildStepForToolCall(
 export function computeToolCallCardDataFromItems(
   items: ToolCallCardItem[],
   liveWebActivity: Record<string, ToolActivityMetadata>,
+  nowMs?: number,
 ): ToolCallCardData {
   const toolCalls = items
     .filter((i): i is { kind: "toolCall"; toolCall: ChatMessageToolCall } =>
@@ -736,7 +809,7 @@ export function computeToolCallCardDataFromItems(
     liveWebActivity,
   );
   const stepCount = `${steps.length} step${steps.length === 1 ? "" : "s"}`;
-  const totalDurationLabel = computeTotalDurationLabel(renderableToolCalls);
+  const totalDurationLabel = computeTotalDurationLabel(items, nowMs);
 
   return {
     currentStepTitle,
@@ -766,10 +839,11 @@ export function computeToolCallCardDataFromItems(
 export function computeToolCallCardData(
   toolCalls: ChatMessageToolCall[],
   liveWebActivity: Record<string, ToolActivityMetadata>,
+  nowMs?: number,
 ): ToolCallCardData {
   const items: ToolCallCardItem[] = toolCalls.map((tc) => ({
     kind: "toolCall",
     toolCall: tc,
   }));
-  return computeToolCallCardDataFromItems(items, liveWebActivity);
+  return computeToolCallCardDataFromItems(items, liveWebActivity, nowMs);
 }


### PR DESCRIPTION
## Summary

Reworks the activity-run card's timing accuracy and streaming UX, driven by QA feedback.

### Timing
- **Header total now sums both thinking and tool durations** (was tool-only), so "Worked for Xs" reflects everything the run grouped — matching the sum of the per-phase chips.
- **Ticks live during streaming** — in-flight steps are measured against a 1s clock, so the header counts up ("Working for 8s") instead of staying static until completion.
- **Human-readable, low-precision durations** — seconds → minutes → hours (`<1s` / `45s` / `3m` / `2h`). `parseDurationLabel` updated to match so per-phase chip totals still sum correctly.

### Header & expansion
- **Collapsed by default** — removed the streaming/running auto-expand; the user opens cards on demand.
- **Stable streaming header** — while running, the header is a single "Working for Ns" summary: no per-step carousel, no truncated step text, and only the number updates in place (stable carousel animation key — no re-slide each second).
- **Cleaner expanded header** — when expanded, the header drops its animated loading dots (the timeline's running phase node carries them). The finished **checkmark** / failure alert still render so the header keeps its outcome-at-a-glance summary. Removed the now-orphaned timeline lead-in connector.

### Loading dots
- `ThreeDotIndicator` remains the single shared component for the loading dots (used by the card header, both phase-header layouts, web-search card, and thought-process link). Added a **Storybook story** for it.

## Testing
- Per-file test suites all green: activity-run-card (37), tool-progress-card-shell (27), phase-grouped-step-list (20), header-step-carousel (3), use-tool-call-card-data hook (36), transcript-message-body (33).
- New coverage: thinking+tool duration sum, streaming tick against the clock, human-readable minutes, collapsed-by-default contract, summary header during streaming, header drops loading dots when expanded but keeps the terminal checkmark, and the `hideStatusIndicator` shell prop.
- `tsc` clean for touched files, ESLint clean, `vite build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
