### PR TITLE
refactor(web): read VELLUM_DISABLE_PLATFORM from config/env instead of feature flag store

### DIFF
--- a/apps/web/src/env.d.ts
+++ b/apps/web/src/env.d.ts
@@ -20,6 +20,8 @@ interface ImportMetaEnv {
   readonly VITE_APP_VERSION?: string;
   /** When set, the app runs in platform (cloud-hosted) mode. Unset = local mode. */
   readonly VITE_PLATFORM_MODE?: string;
+  /** When truthy ("1", "true", "yes"), disables platform connectivity in local mode. */
+  readonly VITE_VELLUM_DISABLE_PLATFORM?: string;
   /**
    * Override for the live-voice velay host (no scheme), e.g. `velay.dev.vellum.ai`.
    * Defaults to `velay.vellum.ai` when unset. See `domains/chat/voice/live-voice/connection.ts`.
@@ -37,4 +39,6 @@ interface ImportMeta {
 interface Window {
   /** Feature flag overrides injected by Electron preload or CLI script. */
   __VELLUM_FLAG_OVERRIDES__?: Record<string, boolean | string>;
+  /** Runtime config injected by the shell (Electron preload, CLI, etc.). */
+  __VELLUM_CONFIG__?: { disablePlatform?: boolean };
 }

--- a/apps/web/src/hooks/use-platform-gate.test.ts
+++ b/apps/web/src/hooks/use-platform-gate.test.ts
@@ -2,12 +2,13 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, renderHook } from "@testing-library/react";
 
 const isLocalModeMock = mock(() => false);
+const isPlatformDisabledMock = mock(() => false);
 mock.module("@/lib/local-mode", () => ({
   isLocalMode: isLocalModeMock,
+  isPlatformDisabled: isPlatformDisabledMock,
 }));
 
 import { useAuthStore } from "@/stores/auth-store";
-import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
 import type { AssistantState } from "@/assistant/types";
 import {
@@ -17,7 +18,6 @@ import {
 } from "@/hooks/use-platform-gate";
 
 const initialAuthState = useAuthStore.getState();
-const initialFlagState = useAssistantFeatureFlagStore.getState();
 const initialLifecycleState = useAssistantLifecycleStore.getState();
 
 function setLifecycle(assistantState: AssistantState) {
@@ -26,8 +26,8 @@ function setLifecycle(assistantState: AssistantState) {
 
 beforeEach(() => {
   isLocalModeMock.mockImplementation(() => false);
+  isPlatformDisabledMock.mockImplementation(() => false);
   useAuthStore.setState(initialAuthState, true);
-  useAssistantFeatureFlagStore.setState(initialFlagState, true);
   useAssistantLifecycleStore.setState(initialLifecycleState, true);
 });
 
@@ -48,32 +48,18 @@ describe("usePlatformGate — default (standard pattern)", () => {
     expect(result.current).toBe("disabled");
   });
 
-  test('returns "disabled" in local mode before flag hydration', () => {
+  test('returns "full" in local mode when logged in and platform not disabled', () => {
     isLocalModeMock.mockImplementation(() => true);
     useAuthStore.setState({ platformSession: "present" });
-    useAssistantFeatureFlagStore.setState({ hasHydrated: false });
-    const { result } = renderHook(() => usePlatformGate());
-    expect(result.current).toBe("disabled");
-  });
-
-  test('returns "full" in local mode when hydrated, logged in, and flag ON', () => {
-    isLocalModeMock.mockImplementation(() => true);
-    useAuthStore.setState({ platformSession: "present" });
-    useAssistantFeatureFlagStore.setState({
-      hasHydrated: true,
-      platformFeaturesInLocalMode: true,
-    } as Partial<ReturnType<typeof useAssistantFeatureFlagStore.getState>>);
+    isPlatformDisabledMock.mockImplementation(() => false);
     const { result } = renderHook(() => usePlatformGate());
     expect(result.current).toBe("full");
   });
 
-  test('returns "gated" in local mode when platform features flag is OFF', () => {
+  test('returns "gated" in local mode when VELLUM_DISABLE_PLATFORM is set', () => {
     isLocalModeMock.mockImplementation(() => true);
     useAuthStore.setState({ platformSession: "present" });
-    useAssistantFeatureFlagStore.setState({
-      hasHydrated: true,
-      platformFeaturesInLocalMode: false,
-    } as Partial<ReturnType<typeof useAssistantFeatureFlagStore.getState>>);
+    isPlatformDisabledMock.mockImplementation(() => true);
     const { result } = renderHook(() => usePlatformGate());
     expect(result.current).toBe("gated");
   });
@@ -135,31 +121,13 @@ describe("usePlatformGate — { platformHostedOnly: true }", () => {
     expect(result.current).toBe("full");
   });
 
-  test('ignores platformFeaturesInLocalMode flag when active assistant is platform-hosted', () => {
-    // The flag gates the daemon-side API interceptor in local mode —
+  test('ignores VELLUM_DISABLE_PLATFORM when active assistant is platform-hosted', () => {
+    // The env var gates the daemon-side API interceptor in local mode —
     // it has no bearing on UI that targets a platform-hosted assistant.
     isLocalModeMock.mockImplementation(() => true);
     setLifecycle({ kind: "active", isLocal: false });
     useAuthStore.setState({ platformSession: "present" });
-    useAssistantFeatureFlagStore.setState({
-      hasHydrated: true,
-      platformFeaturesInLocalMode: false,
-    } as Partial<ReturnType<typeof useAssistantFeatureFlagStore.getState>>);
-    const { result } = renderHook(() =>
-      usePlatformGate({ platformHostedOnly: true }),
-    );
-    expect(result.current).toBe("full");
-  });
-
-  test('does not gate on hydration state for platform-hosted-only branch', () => {
-    // Pre-hydration in local mode used to return "disabled" via the
-    // standard fall-through. The platform-hosted-only branch must
-    // bypass the hydration check entirely — the active assistant's
-    // hosting is the only signal that matters.
-    isLocalModeMock.mockImplementation(() => true);
-    setLifecycle({ kind: "active", isLocal: false });
-    useAuthStore.setState({ platformSession: "present" });
-    useAssistantFeatureFlagStore.setState({ hasHydrated: false });
+    isPlatformDisabledMock.mockImplementation(() => true);
     const { result } = renderHook(() =>
       usePlatformGate({ platformHostedOnly: true }),
     );

--- a/apps/web/src/hooks/use-platform-gate.ts
+++ b/apps/web/src/hooks/use-platform-gate.ts
@@ -1,7 +1,6 @@
 import { useHasPlatformSession } from "@/stores/auth-store";
-import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
-import { isLocalMode } from "@/lib/local-mode";
+import { isLocalMode, isPlatformDisabled } from "@/lib/local-mode";
 
 export type PlatformGateState = "full" | "disabled" | "gated";
 
@@ -40,14 +39,14 @@ export interface PlatformGateOptions {
    * | none resolved (loading etc) | yes              | `"full"`     |
    * | none resolved               | no               | `"disabled"` |
    *
-   * `platformFeaturesInLocalMode` and its hydration state do NOT apply
-   * to this branch — that flag gates daemon-side platform-API
-   * interception in local mode, which is orthogonal to whether the
-   * active assistant is platform-hosted.
+   * `VELLUM_DISABLE_PLATFORM` does NOT apply to this branch — that
+   * env var gates daemon-side platform-API interception in local mode,
+   * which is orthogonal to whether the active assistant is
+   * platform-hosted.
    *
    * Defaults to `false` — the standard `"full" / "disabled" / "gated"`
-   * behavior gated on `platformFeaturesInLocalMode`, hydration, and
-   * the platform session.
+   * behavior gated on `VELLUM_DISABLE_PLATFORM` and the platform
+   * session.
    */
   platformHostedOnly?: boolean;
 }
@@ -168,18 +167,14 @@ export function usePlatformGate(
   // keeps the last `"present"`/`"absent"` until the new result lands, so this
   // doesn't flicker to `"disabled"` on app resume.
   const hasPlatformSession = useHasPlatformSession();
-  const platformFeaturesOff = useAssistantFeatureFlagStore(
-    (s) =>
-      (s as Record<string, unknown>).platformFeaturesInLocalMode === false,
-  );
-  const hasHydrated = useAssistantFeatureFlagStore((s) => s.hasHydrated);
+  const platformDisabled = isPlatformDisabled();
   const activeIsSelfHosted = useActiveAssistantIsSelfHosted();
 
   // Platform-hosted-only branch is fully self-contained: it only depends
   // on the active assistant's hosting and the platform session. The
-  // local-mode feature flag and its hydration state DO NOT apply —
-  // that flag gates the daemon-side API interceptor in local mode, which
-  // is orthogonal to "is this UI's target assistant platform-hosted?"
+  // VELLUM_DISABLE_PLATFORM env var does NOT apply — it gates the
+  // daemon-side API interceptor in local mode, which is orthogonal to
+  // "is this UI's target assistant platform-hosted?"
   if (options.platformHostedOnly) {
     if (activeIsSelfHosted) return "gated";
     if (!hasPlatformSession) return "disabled";
@@ -187,8 +182,7 @@ export function usePlatformGate(
   }
 
   const local = isLocalMode();
-  if (local && platformFeaturesOff) return "gated";
-  if (local && !hasHydrated) return "disabled";
+  if (local && platformDisabled) return "gated";
   if (!hasPlatformSession) return "disabled";
   return "full";
 }

--- a/apps/web/src/lib/api-interceptors.test.ts
+++ b/apps/web/src/lib/api-interceptors.test.ts
@@ -21,8 +21,15 @@ import {
   beforeEach,
   describe,
   expect,
+  mock,
   test,
 } from "bun:test";
+
+const isPlatformDisabledMock = mock(() => false);
+mock.module("@/lib/local-mode", () => ({
+  isLocalMode: () => !process.env.VITE_PLATFORM_MODE,
+  isPlatformDisabled: isPlatformDisabledMock,
+}));
 
 import {
   daemonRequestInterceptor,
@@ -33,7 +40,6 @@ import { setSelfHostedConnection } from "@/lib/self-hosted/connection";
 import { getClientId } from "@/lib/telemetry/client-identity";
 import { __resetForTesting as resetSessionToken } from "@/runtime/session-token";
 import { useOrganizationStore } from "@/stores/organization-store";
-import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 
 const TEST_ORG_ID = "org-test-1234";
 const ELECTRON_RENDERER_ORIGIN_HEADER = "X-Vellum-Electron-Renderer-Origin";
@@ -458,18 +464,18 @@ describe("api-interceptors / platform features gate", () => {
 
   afterEach(() => {
     setSelfHostedConnection(null);
-    useAssistantFeatureFlagStore.setState({ platformFeaturesInLocalMode: true });
+    isPlatformDisabledMock.mockImplementation(() => false);
   });
 
-  test("aborts platform-bound requests when features are disabled", () => {
-    useAssistantFeatureFlagStore.setState({ platformFeaturesInLocalMode: false });
+  test("aborts platform-bound requests when platform is disabled", () => {
+    isPlatformDisabledMock.mockImplementation(() => true);
     const input = new Request("https://platform.test/v1/organizations/");
     const output = platformFeaturesGate(input);
     expect(output.signal.aborted).toBe(true);
   });
 
-  test("passes through gateway-rewritten requests when features are disabled", () => {
-    useAssistantFeatureFlagStore.setState({ platformFeaturesInLocalMode: false });
+  test("passes through gateway-rewritten requests when platform is disabled", () => {
+    isPlatformDisabledMock.mockImplementation(() => true);
     setSelfHostedConnection({ url: INGRESS, token: ACTOR_TOKEN });
     // Simulate a request already rewritten to the gateway by requestInterceptor
     const input = new Request(`${INGRESS}${DAEMON_SKILLS_PATH}`);
@@ -478,8 +484,8 @@ describe("api-interceptors / platform features gate", () => {
     expect(output.url).toBe(input.url);
   });
 
-  test("passes through all requests when features are enabled", () => {
-    useAssistantFeatureFlagStore.setState({ platformFeaturesInLocalMode: true });
+  test("passes through all requests when platform is not disabled", () => {
+    isPlatformDisabledMock.mockImplementation(() => false);
     const input = new Request("https://platform.test/v1/organizations/");
     const output = platformFeaturesGate(input);
     expect(output.signal.aborted).toBe(false);

--- a/apps/web/src/lib/api-interceptors.ts
+++ b/apps/web/src/lib/api-interceptors.ts
@@ -29,7 +29,7 @@ import { client as platformClient } from "@/generated/api/client.gen";
 import { client as authClient } from "@/generated/auth/client.gen";
 import { client as daemonClient } from "@/generated/daemon/client.gen";
 import { ensureCsrfCookie, getCsrfToken } from "@/lib/auth/csrf";
-import { isLocalMode } from "@/lib/local-mode";
+import { isLocalMode, isPlatformDisabled } from "@/lib/local-mode";
 import {
     getSelfHostedActorToken,
     getSelfHostedIngressUrl,
@@ -37,7 +37,6 @@ import {
 import { getClientRegistrationHeaders } from "@/lib/telemetry/client-identity";
 import { isElectron } from "@/runtime/is-electron";
 import { getElectronSessionToken } from "@/runtime/session-token";
-import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { getActiveOrganizationIdForRequests } from "@/stores/organization-store";
 
 const MUTATING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
@@ -242,10 +241,7 @@ for (const apiClient of [authClient, platformClient]) {
 }
 
 function arePlatformFeaturesEnabled(): boolean {
-  return (
-    (useAssistantFeatureFlagStore.getState() as Record<string, unknown>)
-      .platformFeaturesInLocalMode !== false
-  );
+  return !isPlatformDisabled();
 }
 
 /**
@@ -270,7 +266,7 @@ export function platformFeaturesGate(request: Request): Request {
   }
 
   console.debug(
-    "platform-features-in-local-mode is disabled — no-op platform request:",
+    "VELLUM_DISABLE_PLATFORM is set — no-op platform request:",
     new URL(request.url).pathname,
   );
   const aborted = new AbortController();

--- a/apps/web/src/lib/local-mode.ts
+++ b/apps/web/src/lib/local-mode.ts
@@ -87,6 +87,20 @@ export function isLocalMode(): boolean {
   return !PLATFORM_MODE_TRUTHY.has(raw.toLowerCase());
 }
 
+export function isPlatformDisabled(): boolean {
+  const config = (
+    window as unknown as {
+      __VELLUM_CONFIG__?: { disablePlatform?: boolean };
+    }
+  ).__VELLUM_CONFIG__;
+  if (config?.disablePlatform != null) return !!config.disablePlatform;
+
+  const raw = import.meta.env.VITE_VELLUM_DISABLE_PLATFORM;
+  if (raw) return PLATFORM_MODE_TRUTHY.has(raw.toLowerCase());
+
+  return false;
+}
+
 export async function loadLockfile(): Promise<Lockfile> {
   try {
     const data = await loadLockfileHost();


### PR DESCRIPTION
## Summary
- Add `isPlatformDisabled()` helper to local-mode.ts reading from `__VELLUM_CONFIG__` and `VITE_VELLUM_DISABLE_PLATFORM`
- Update `api-interceptors.ts` and `use-platform-gate.ts` to use the new helper instead of the feature flag store
- Update tests to mock `isPlatformDisabled()` instead of setting store state

Part of plan: disable-platform-env-var.md (PR 4 of 5)