### PR TITLE
chore: remove platform-features-in-local-mode from feature flag registry

### DIFF
--- a/apps/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/apps/web/src/lib/feature-flags/feature-flag-registry.json
@@ -444,14 +444,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "platform-features-in-local-mode",
-      "scope": "assistant",
-      "key": "platform-features-in-local-mode",
-      "label": "Platform Features in Local Mode",
-      "description": "When enabled, the assistant can call the Vellum platform API from local mode. When disabled, all platform API clients in the daemon, gateway, CES, and web UI no-op with a debug log instead of making outbound requests.",
-      "defaultEnabled": true
-    },
-    {
       "id": "memory-v3-shadow",
       "scope": "assistant",
       "key": "memory-v3-shadow",

--- a/apps/web/src/stores/assistant-feature-flag-store.ts
+++ b/apps/web/src/stores/assistant-feature-flag-store.ts
@@ -113,9 +113,6 @@ const useAssistantFeatureFlagStoreBase = create<AssistantFeatureFlagStore>()(
         }),
 
       setFlag: (key: string, value: boolean, assistantId: string | null) => {
-        // Fire the PATCH before updating local state: the platform-features
-        // interceptor reads this store synchronously, so toggling
-        // platformFeaturesInLocalMode OFF would block its own request.
         const requestId = ++nextFlagRequestId;
         const revertIfLatestRejectedRequest = () => {
           if (pendingFlagRequestIds[key] !== requestId) {

--- a/gateway/src/__tests__/remote-feature-flag-sync.test.ts
+++ b/gateway/src/__tests__/remote-feature-flag-sync.test.ts
@@ -65,14 +65,6 @@ const TEST_REGISTRY = {
       description: "A2A channel integration",
       defaultEnabled: false,
     },
-    {
-      id: "platform-features-in-local-mode",
-      scope: "assistant",
-      key: "platform-features-in-local-mode",
-      label: "Platform Features in Local Mode",
-      description: "Gate platform API calls in local mode",
-      defaultEnabled: true,
-    },
   ],
 };
 
@@ -128,15 +120,14 @@ function defaultCredentials(): Record<string, string> {
 // ---------------------------------------------------------------------------
 const savedVellumPlatformUrl = process.env.VELLUM_PLATFORM_URL;
 const savedAssistantCredential = process.env.ASSISTANT_API_KEY;
-const savedPlatformFeaturesFlag =
-  process.env.VELLUM_FLAG_PLATFORM_FEATURES_IN_LOCAL_MODE;
+const savedDisablePlatform = process.env.VELLUM_DISABLE_PLATFORM;
 
 beforeEach(() => {
   // Clear env vars that the production code falls back to, so tests remain
   // deterministic unless they explicitly set them.
   delete process.env.VELLUM_PLATFORM_URL;
   delete process.env.ASSISTANT_API_KEY;
-  delete process.env.VELLUM_FLAG_PLATFORM_FEATURES_IN_LOCAL_MODE;
+  delete process.env.VELLUM_DISABLE_PLATFORM;
   mkdirSync(protectedDir, { recursive: true });
   // Write the test registry and point resolution at it
   writeFileSync(testRegistryPath, JSON.stringify(TEST_REGISTRY, null, 2));
@@ -158,10 +149,7 @@ afterEach(() => {
   };
   restoreEnv("VELLUM_PLATFORM_URL", savedVellumPlatformUrl);
   restoreEnv("ASSISTANT_API_KEY", savedAssistantCredential);
-  restoreEnv(
-    "VELLUM_FLAG_PLATFORM_FEATURES_IN_LOCAL_MODE",
-    savedPlatformFeaturesFlag,
-  );
+  restoreEnv("VELLUM_DISABLE_PLATFORM", savedDisablePlatform);
   try {
     rmSync(protectedDir, { recursive: true, force: true });
     mkdirSync(protectedDir, { recursive: true });
@@ -180,8 +168,7 @@ afterEach(() => {
 describe("RemoteFeatureFlagSync", () => {
   test("skips sync when platform features are disabled", async () => {
     fetchMock = mock(async () => Response.json({ flags: { ff1: true } }));
-    process.env.VELLUM_FLAG_PLATFORM_FEATURES_IN_LOCAL_MODE = "false";
-    resetEnvOverridesCache();
+    process.env.VELLUM_DISABLE_PLATFORM = "true";
 
     const sync = new RemoteFeatureFlagSync({
       credentials: fakeCredentialCache(defaultCredentials()),

--- a/gateway/src/auth/guardian-bootstrap.ts
+++ b/gateway/src/auth/guardian-bootstrap.ts
@@ -598,7 +598,7 @@ export function mintAndRecordDeviceBoundTokenPair(params: {
 async function fetchPlatformOwnerDisplayName(): Promise<string | null> {
   if (!arePlatformFeaturesEnabled()) {
     log.debug(
-      "platform-features-in-local-mode is disabled — skipping platform owner display name fetch",
+      "Platform features disabled — skipping platform owner display name fetch",
     );
     return null;
   }

--- a/gateway/src/email/register-callback.ts
+++ b/gateway/src/email/register-callback.ts
@@ -40,7 +40,7 @@ export async function registerEmailCallbackRoute(caches?: {
 }): Promise<string | undefined> {
   if (!arePlatformFeaturesEnabled()) {
     log.debug(
-      "platform-features-in-local-mode is disabled — skipping email callback registration",
+      "Platform features disabled — skipping email callback registration",
     );
     return undefined;
   }

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1854,7 +1854,7 @@ async function main() {
   async function notifyRecordActivity(): Promise<void> {
     if (!arePlatformFeaturesEnabled()) {
       log.debug(
-        "platform-features-in-local-mode is disabled — skipping record-activity",
+        "Platform features disabled — skipping record-activity",
       );
       return;
     }

--- a/gateway/src/telegram/webhook-manager.ts
+++ b/gateway/src/telegram/webhook-manager.ts
@@ -34,7 +34,7 @@ async function registerManagedTelegramCallbackRoute(
 ): Promise<string | undefined> {
   if (!arePlatformFeaturesEnabled()) {
     log.debug(
-      "platform-features-in-local-mode is disabled — skipping managed Telegram callback registration",
+      "Platform features disabled — skipping managed Telegram callback registration",
     );
     return undefined;
   }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -444,14 +444,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "platform-features-in-local-mode",
-      "scope": "assistant",
-      "key": "platform-features-in-local-mode",
-      "label": "Platform Features in Local Mode",
-      "description": "When enabled, the assistant can call the Vellum platform API from local mode. When disabled, all platform API clients in the daemon, gateway, CES, and web UI no-op with a debug log instead of making outbound requests.",
-      "defaultEnabled": true
-    },
-    {
       "id": "memory-v3-shadow",
       "scope": "assistant",
       "key": "memory-v3-shadow",


### PR DESCRIPTION
## Summary
- Remove `platform-features-in-local-mode` from the canonical registry and all synced copies
- Clean up test fixtures and store comments that referenced the removed flag
- All consumers already migrated to `VELLUM_DISABLE_PLATFORM` env var in PRs 1-4

Part of plan: disable-platform-env-var.md (PR 5 of 5)