### PR TITLE
fix: forward VELLUM_DISABLE_PLATFORM to compiled daemon binary

### DIFF
--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -961,6 +961,7 @@ export async function startLocalDaemon(
         "VELLUM_DEBUG",
         "VELLUM_DEV",
         "VELLUM_DESKTOP_APP",
+        "VELLUM_DISABLE_PLATFORM",
         "VELLUM_WORKSPACE_DIR",
       ]) {
         if (process.env[key]) {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for disable-platform-env-var.md.

**Gap:** VELLUM_DISABLE_PLATFORM not forwarded to compiled daemon binary
**What was expected:** The daemon should respect the env var when launched via compiled binary
**What was found:** The curated daemon env in startLocalDaemon didn't include the new var