### PR TITLE
fix: align VELLUM_DISABLE_PLATFORM truthy parsing across all components

### DIFF
--- a/apps/web/src/lib/local-mode.ts
+++ b/apps/web/src/lib/local-mode.ts
@@ -96,7 +96,10 @@ export function isPlatformDisabled(): boolean {
   if (config?.disablePlatform != null) return !!config.disablePlatform;
 
   const raw = import.meta.env.VITE_VELLUM_DISABLE_PLATFORM;
-  if (raw) return PLATFORM_MODE_TRUTHY.has(raw.toLowerCase());
+  if (raw) {
+    const v = raw.toLowerCase();
+    return v === "true" || v === "1";
+  }
 
   return false;
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for disable-platform-env-var.md.

**Gap:** Truthy value inconsistency
**What was expected:** All components parse VELLUM_DISABLE_PLATFORM identically
**What was found:** Web UI accepted 'yes' via PLATFORM_MODE_TRUTHY but daemon/gateway only accept 'true'/'1'