### PR TITLE
fix: remove remaining web app feature flag selectors for GA'ed flags

### DIFF
--- a/apps/web/src/domains/chat/components/chat-content-layout.tsx
+++ b/apps/web/src/domains/chat/components/chat-content-layout.tsx
@@ -20,7 +20,6 @@ import { AppViewerContainer } from "@/components/app-viewer-container";
 import { DocumentViewerContainer } from "@/domains/chat/components/document-viewer-container";
 import { ChatMainPanel, type ChatMainPanelProps } from "@/domains/chat/components/chat-route-content";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
-import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useDeployStore } from "@/stores/deploy-store";
 import { useViewerStore } from "@/stores/viewer-store";
@@ -56,7 +55,6 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
 
   const isSharing = useDeployStore.use.isSharing();
   const isDeploying = useDeployStore.use.isDeploying();
-  const deployToVercel = useAssistantFeatureFlagStore.use.deployToVercel();
   const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
 
   const isMobile = useIsMobile();
@@ -136,7 +134,7 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
             onEdit={handleCloseEditPanel}
             onShare={handleShareApp}
             isSharing={isSharing}
-            onDeploy={deployToVercel ? handleDeployApp : undefined}
+            onDeploy={handleDeployApp}
             isDeploying={isDeploying}
             isEditing
           />
@@ -165,7 +163,7 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
         onEdit={handleEditApp}
         onShare={handleShareApp}
         isSharing={isSharing}
-        onDeploy={deployToVercel ? handleDeployApp : undefined}
+        onDeploy={handleDeployApp}
         isDeploying={isDeploying}
       />
     );

--- a/apps/web/src/domains/chat/components/mobile-chat-overlays.tsx
+++ b/apps/web/src/domains/chat/components/mobile-chat-overlays.tsx
@@ -11,7 +11,6 @@ import { createPortal } from "react-dom";
 import { useNavigate } from "react-router";
 
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
-import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useDeployStore } from "@/stores/deploy-store";
 import { useSubagentStore } from "@/domains/chat/subagent-store";
@@ -38,8 +37,6 @@ export function MobileChatOverlays() {
   const subagentById = useSubagentStore.use.byId();
   const isSharing = useDeployStore.use.isSharing();
   const isDeploying = useDeployStore.use.isDeploying();
-  const deployToVercel = useAssistantFeatureFlagStore.use.deployToVercel();
-
   const handleCloseApp = useCallback(() => {
     useViewerStore.getState().closeApp();
     useConversationStore.getState().setEditingConversationId(null);
@@ -107,7 +104,7 @@ export function MobileChatOverlays() {
         onClose={handleCloseApp}
         onShare={handleShareApp}
         isSharing={isSharing}
-        onDeploy={deployToVercel ? handleDeployApp : undefined}
+        onDeploy={handleDeployApp}
         isDeploying={isDeploying}
       />
       <MobileDocumentOverlay

--- a/apps/web/src/domains/library/library-view.tsx
+++ b/apps/web/src/domains/library/library-view.tsx
@@ -20,7 +20,6 @@ import { LibraryGridSection } from "@/domains/library/components/library-grid-se
 import { useLibraryData } from "@/domains/library/use-library-data";
 import { appsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
 import { appsByIdDeletePost } from "@/generated/daemon/sdk.gen";
-import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { useDeployStore } from "@/stores/deploy-store";
 import { usePinnedAppsStore } from "@/stores/pinned-apps-store";
 import type { AppSummary } from "@/types/app-types";
@@ -46,7 +45,6 @@ export function LibraryView({
   onOpenApp,
 }: LibraryViewProps) {
   const queryClient = useQueryClient();
-  const deployToVercel = useAssistantFeatureFlagStore.use.deployToVercel();
   const togglePin = usePinnedAppsStore.use.togglePin();
   const pinnedAppIds = usePinnedAppsStore.use.pinnedAppIds();
   const isDeploying = useDeployStore.use.isDeploying();
@@ -244,7 +242,7 @@ export function LibraryView({
               onOpen={onOpenApp}
               onPin={handlePinToggle}
               onDelete={setAppPendingDelete}
-              onDeploy={deployToVercel ? handleDeploy : undefined}
+              onDeploy={handleDeploy}
             />
             <LibraryGridSection
               title="Recents"
@@ -254,7 +252,7 @@ export function LibraryView({
               onOpen={onOpenApp}
               onPin={handlePinToggle}
               onDelete={setAppPendingDelete}
-              onDeploy={deployToVercel ? handleDeploy : undefined}
+              onDeploy={handleDeploy}
             />
             {filteredDocuments.length > 0 ? (
               <section>

--- a/apps/web/src/domains/settings/pages/general-page.tsx
+++ b/apps/web/src/domains/settings/pages/general-page.tsx
@@ -217,7 +217,6 @@ export function GeneralPage() {
     refetch,
     refetchUntilResized,
   } = useAssistantWithHealthz();
-  const accountDeletion = useAssistantFeatureFlagStore.use.accountDeletion();
   const multiPlatformAssistant = useClientFeatureFlagStore.use.multiPlatformAssistant();
   const settingsSleepPolicy = useAssistantFeatureFlagStore.use.settingsSleepPolicy();
   const isAuthenticated = useIsAuthenticated();
@@ -377,7 +376,7 @@ export function GeneralPage() {
         </DetailCard>
       )}
 
-      {accountDeletion && <DeleteAccountSection />}
+      <DeleteAccountSection />
     </div>
   );
 }

--- a/apps/web/src/domains/settings/settings-layout.tsx
+++ b/apps/web/src/domains/settings/settings-layout.tsx
@@ -30,7 +30,6 @@ export function SettingsLayout() {
   );
   const settingsDeveloperNav = useAssistantFeatureFlagStore.use.settingsDeveloperNav();
   const platformNotifications = useClientFeatureFlagStore.use.platformNotifications();
-  const sounds = useAssistantFeatureFlagStore.use.sounds();
   const platformGate = usePlatformGate({ platformHostedOnly: true });
   const billingGate = usePlatformGate();
   const { pathname } = useLocation();
@@ -50,9 +49,6 @@ export function SettingsLayout() {
         if (item.id === "devices" && platformGate === "gated") {
           return false;
         }
-        if (item.id === "sounds" && !sounds) {
-          return false;
-        }
         // Hotkey rebinding drives Electron globalShortcut + menu accelerators,
         // which have no web/iOS analogue. Hide the entry off the desktop app;
         // the page itself also redirects as defense in depth.
@@ -64,7 +60,7 @@ export function SettingsLayout() {
         }
         return true;
       }),
-    [platformNotifications, sounds, platformGate, billingGate],
+    [platformNotifications, platformGate, billingGate],
   );
 
   const bottomItems = useMemo(


### PR DESCRIPTION
## Summary
- Remove deployToVercel selector from chat-content-layout, mobile-chat-overlays, library-view — deploy always available
- Remove sounds selector from settings-layout — Sounds tab always visible
- Remove accountDeletion selector from general-page — DeleteAccountSection always rendered
- Verify doctor selectors were already cleaned up

Fixes Codex review feedback on PR #34097 and #34099.

Part of plan: rm-gaed-feature-flags.md (fix PR)