### PR TITLE
fix: propagate VELLUM_DISABLE_PLATFORM through Electron IPC config bridge

### DIFF
--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -257,6 +257,10 @@ const resolvedConfig = resolveLocalConfigFromEnv(process.env);
 handleSync("vellum:config:get", () => ({
   webUrl: resolvedConfig.webUrl,
   platformUrl: resolvedConfig.platformUrl,
+  disablePlatform:
+    ["true", "1"].includes(
+      (process.env.VELLUM_DISABLE_PLATFORM ?? "").toLowerCase(),
+    ) || undefined,
 }));
 
 /**

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -898,6 +898,7 @@ contextBridge.exposeInMainWorld("vellum", bridge);
 const vellumConfig = ipcRenderer.sendSync("vellum:config:get") as {
   webUrl: string;
   platformUrl: string;
+  disablePlatform?: boolean;
 } | null;
 if (vellumConfig) {
   contextBridge.exposeInMainWorld("__VELLUM_CONFIG__", vellumConfig);


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for disable-platform-env-var.md.

**Gap:** Electron app does not propagate disablePlatform through IPC config bridge
**What was expected:** macOS desktop renderer should see disablePlatform via __VELLUM_CONFIG__
**What was found:** The vellum:config:get handler only sent webUrl and platformUrl