### PR TITLE
feat(assistant): add llm.profileOverrides schema for built-in profile user overrides

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -8,6 +8,8 @@ import {
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { z } from "zod";
+
 // ---------------------------------------------------------------------------
 // Mocks — declared before imports that depend on platform/logger
 // ---------------------------------------------------------------------------
@@ -289,6 +291,75 @@ describe("AssistantConfigSchema", () => {
       },
     };
     expect(() => AssistantConfigSchema.parse(input)).toThrow(/missing-profile/);
+  });
+
+  test("accepts llm.profileOverrides with label rename, status toggle, and explicit nulls", () => {
+    const input = {
+      llm: {
+        profileOverrides: {
+          balanced: { label: "My Balanced" },
+          "cost-optimized": { status: "disabled" as const },
+          turbo: { label: null, status: null },
+        },
+      },
+    };
+    const result = AssistantConfigSchema.parse(input);
+    expect(result.llm.profileOverrides).toEqual({
+      balanced: { label: "My Balanced" },
+      "cost-optimized": { status: "disabled" },
+      turbo: { label: null, status: null },
+    });
+  });
+
+  test("parses fine when llm.profileOverrides is absent", () => {
+    const result = AssistantConfigSchema.parse({ llm: {} });
+    expect(result.llm.profileOverrides).toBeUndefined();
+  });
+
+  test("rejects an llm.profileOverrides entry carrying non-override keys", () => {
+    for (const extra of [
+      { model: "claude-opus-4-8" },
+      { provider: "anthropic" },
+      { maxTokens: 1000 },
+      { description: "nope" },
+    ]) {
+      const input = {
+        llm: {
+          profileOverrides: {
+            balanced: { label: "My Balanced", ...extra },
+          },
+        },
+      };
+      expect(() => AssistantConfigSchema.parse(input)).toThrow(
+        /Unrecognized key/,
+      );
+    }
+  });
+
+  test("rejects an empty-string label in llm.profileOverrides", () => {
+    const input = {
+      llm: { profileOverrides: { balanced: { label: "" } } },
+    };
+    expect(() => AssistantConfigSchema.parse(input)).toThrow();
+  });
+
+  test("config schema endpoint output includes llm.profileOverrides", () => {
+    // Mirrors handleGetConfigSchema, which derives the GET /v1/config/schema
+    // payload from AssistantConfigSchema with these exact options.
+    const jsonSchema = z.toJSONSchema(AssistantConfigSchema, {
+      unrepresentable: "any",
+      io: "input",
+    }) as Record<string, unknown>;
+    const llm = (jsonSchema.properties as Record<string, unknown>)
+      .llm as Record<string, unknown>;
+    const llmProps = llm.properties as Record<string, unknown>;
+    expect(llmProps.profileOverrides).toBeDefined();
+    const overrides = llmProps.profileOverrides as Record<string, unknown>;
+    const entryProps = (
+      overrides.additionalProperties as Record<string, unknown>
+    ).properties as Record<string, unknown>;
+    expect(entryProps.label).toBeDefined();
+    expect(entryProps.status).toBeDefined();
   });
 
   test("legacy top-level inference keys are ignored after PR 19 cleanup", () => {

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -429,6 +429,26 @@ export const ProfileEntry = LLMConfigFragment.extend({
 export type ProfileEntry = z.infer<typeof ProfileEntry>;
 
 /**
+ * A sparse user override for a code-defined built-in profile. Built-in profile
+ * definitions live only in code and are merged into the parsed config at load
+ * time; the only user-editable facets are presentation (`label`) and
+ * enablement (`status`), persisted under `llm.profileOverrides`.
+ *
+ * `.strict()` is deliberate: it rejects attempts to smuggle config fields
+ * (`model`, `provider`, `maxTokens`, ...) through the override store — that
+ * drift vector is exactly what built-in profiles exist to close. `.nullable()`
+ * on both fields mirrors `ProfileEntry`: `null` is the "clear this override"
+ * sentinel used by the PUT profile route (see `patchManagedProfileFields`).
+ */
+export const ProfileOverrideEntry = z
+  .object({
+    label: z.string().min(1).nullable().optional(),
+    status: ProfileStatusSchema.nullable().optional(),
+  })
+  .strict();
+export type ProfileOverrideEntry = z.infer<typeof ProfileOverrideEntry>;
+
+/**
  * Per-call-site config: a fragment plus an optional `profile` reference.
  * The resolver merges in the named profile (if any) before applying
  * call-site-level overrides.
@@ -446,6 +466,11 @@ export const LLMSchema = z
   .object({
     default: LLMConfigBase.default(LLMConfigBase.parse({})),
     profiles: z.record(z.string().min(1), ProfileEntry).default({}),
+    // Sparse user overrides (label/status only) for code-defined built-in
+    // profiles, keyed by built-in profile id. See `ProfileOverrideEntry`.
+    profileOverrides: z
+      .record(z.string().min(1), ProfileOverrideEntry)
+      .optional(),
     // Presentation-only order for named profiles. The resolver ignores this;
     // clients use it to render profile pickers consistently.
     profileOrder: z.array(z.string().min(1)).default([]),


### PR DESCRIPTION
## Summary
- Add strict ProfileOverrideEntry ({label?, status?}, both nullable) to the LLM config schema
- Add llm.profileOverrides record for persisting user overrides on code-defined built-in profiles
- Schema tests: round-trip, null sentinels, rejection of non-override keys

Part of plan: builtin-llm-profiles.md (PR 2 of 8)