### PR TITLE
refactor(assistant): extract built-in inference profile definitions into a dedicated module

### DIFF
--- a/assistant/src/__tests__/builtin-inference-profiles.test.ts
+++ b/assistant/src/__tests__/builtin-inference-profiles.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  AUTO_PROFILE_KEY,
+  type BuiltinProfileDefinition,
+  MANAGED_PROFILE_NAMES,
+  MANAGED_PROFILE_TEMPLATES,
+  resolveBuiltinProfiles,
+} from "../config/builtin-inference-profiles.js";
+import { resolveModelIntent } from "../providers/model-intents.js";
+
+const flagAlwaysEnabled = () => true;
+
+describe("resolveBuiltinProfiles", () => {
+  test("resolves all built-ins with no overrides", () => {
+    const { profiles, order } = resolveBuiltinProfiles({
+      isPlatform: true,
+      isFlagEnabled: flagAlwaysEnabled,
+      overrides: {},
+    });
+
+    const managedNames = Object.keys(MANAGED_PROFILE_TEMPLATES);
+    expect(new Set(Object.keys(profiles))).toEqual(MANAGED_PROFILE_NAMES);
+    expect(order).toEqual([AUTO_PROFILE_KEY, ...managedNames]);
+
+    for (const name of managedNames) {
+      const definition = MANAGED_PROFILE_TEMPLATES[name];
+      const entry = profiles[name];
+      expect(entry.provider).toBe(definition.provider);
+      expect(entry.provider_connection).toBe(definition.connectionName);
+      expect(entry.model).toBe(
+        resolveModelIntent(definition.provider, definition.intent),
+      );
+      expect(entry.source).toBe("managed");
+      expect(entry.maxTokens).toBe(definition.maxTokens);
+      // Template-internal fields must not leak onto the materialized entry.
+      expect(entry).not.toContainKeys([
+        "intent",
+        "connectionName",
+        "featureFlag",
+      ]);
+    }
+  });
+
+  test("auto entry is metadata-only (no provider/model)", () => {
+    const { profiles } = resolveBuiltinProfiles({
+      isPlatform: true,
+      isFlagEnabled: flagAlwaysEnabled,
+      overrides: {},
+    });
+
+    const auto = profiles[AUTO_PROFILE_KEY];
+    expect(auto.label).toBe("Auto");
+    expect(auto.source).toBe("managed");
+    expect(auto.description).toBeString();
+    expect(auto).not.toContainKeys([
+      "provider",
+      "model",
+      "provider_connection",
+    ]);
+  });
+
+  test("BYOK label suffix applied off-platform but not on-platform", () => {
+    const offPlatform = resolveBuiltinProfiles({
+      isPlatform: false,
+      isFlagEnabled: flagAlwaysEnabled,
+      overrides: {},
+    });
+    const onPlatform = resolveBuiltinProfiles({
+      isPlatform: true,
+      isFlagEnabled: flagAlwaysEnabled,
+      overrides: {},
+    });
+
+    expect(offPlatform.profiles.balanced.label).toBe("Balanced (Managed)");
+    expect(onPlatform.profiles.balanced.label).toBe("Balanced");
+    // The auto entry never gets the BYOK suffix.
+    expect(offPlatform.profiles[AUTO_PROFILE_KEY].label).toBe("Auto");
+  });
+
+  test("applies label and status overrides by key presence", () => {
+    const { profiles } = resolveBuiltinProfiles({
+      isPlatform: false,
+      isFlagEnabled: flagAlwaysEnabled,
+      overrides: {
+        balanced: { label: "My Daily Driver" },
+        "cost-optimized": { status: "disabled" },
+        [AUTO_PROFILE_KEY]: { status: "disabled" },
+      },
+    });
+
+    expect(profiles.balanced.label).toBe("My Daily Driver");
+    expect(profiles.balanced.status).toBeUndefined();
+    // Label key absent in the override → BYOK default label retained.
+    expect(profiles["cost-optimized"].label).toBe("Speed (Managed)");
+    expect(profiles["cost-optimized"].status).toBe("disabled");
+    expect(profiles[AUTO_PROFILE_KEY].status).toBe("disabled");
+  });
+
+  test("explicit null override values are applied as-is", () => {
+    const { profiles } = resolveBuiltinProfiles({
+      isPlatform: false,
+      isFlagEnabled: flagAlwaysEnabled,
+      overrides: {
+        balanced: { label: null, status: null },
+      },
+    });
+
+    expect(profiles.balanced.label).toBeNull();
+    expect(profiles.balanced.status).toBeNull();
+  });
+
+  test("flag-gated definition is omitted when the flag resolves disabled", () => {
+    const flaggedName = "test-flagged-profile";
+    const flaggedDefinition: BuiltinProfileDefinition = {
+      ...MANAGED_PROFILE_TEMPLATES.balanced,
+      label: "Flagged",
+      featureFlag: "test-only-flag",
+    };
+    MANAGED_PROFILE_TEMPLATES[flaggedName] = flaggedDefinition;
+    try {
+      const disabled = resolveBuiltinProfiles({
+        isPlatform: true,
+        isFlagEnabled: (key) => key !== "test-only-flag",
+        overrides: {},
+      });
+      expect(disabled.profiles).not.toContainKey(flaggedName);
+      expect(disabled.order).not.toContain(flaggedName);
+      // The other (flagless) built-ins are unaffected by the gate.
+      expect(disabled.profiles).toContainKey("balanced");
+
+      const enabled = resolveBuiltinProfiles({
+        isPlatform: true,
+        isFlagEnabled: flagAlwaysEnabled,
+        overrides: {},
+      });
+      expect(enabled.profiles).toContainKey(flaggedName);
+      expect(enabled.order).toContain(flaggedName);
+    } finally {
+      delete MANAGED_PROFILE_TEMPLATES[flaggedName];
+    }
+  });
+});

--- a/assistant/src/config/builtin-inference-profiles.ts
+++ b/assistant/src/config/builtin-inference-profiles.ts
@@ -1,0 +1,203 @@
+import { resolveModelIntent } from "../providers/model-intents.js";
+import type { ModelIntent } from "../providers/types.js";
+import {
+  DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS,
+  type ProfileEntry,
+  type ProfileStatus,
+} from "./schemas/llm.js";
+
+/**
+ * Definition of a built-in (daemon-managed) inference profile. The profile's
+ * model is resolved at materialization time from `PROVIDER_MODEL_INTENTS` so
+ * the catalog stays the single source of truth for "which model does this
+ * intent map to?".
+ */
+export type BuiltinProfileDefinition = Omit<
+  ProfileEntry,
+  "provider" | "model" | "provider_connection"
+> & {
+  intent: ModelIntent;
+  provider: NonNullable<ProfileEntry["provider"]>;
+  connectionName: string;
+  /**
+   * Optional feature-flag key gating this profile. When set and the flag
+   * resolves disabled, the profile is omitted from the effective profile set
+   * entirely (absent from both `profiles` and `order`).
+   */
+  featureFlag?: string;
+};
+
+/**
+ * Managed profiles. Overwritten on every daemon boot so Vellum can push
+ * model/config updates to customers in new releases. Platform overlays
+ * (`preserveProfileNames`) take precedence when present.
+ */
+export const MANAGED_PROFILE_TEMPLATES: Record<
+  string,
+  BuiltinProfileDefinition
+> = {
+  balanced: {
+    intent: "balanced",
+    provider: "anthropic",
+    connectionName: "anthropic-managed",
+    source: "managed",
+    label: "Balanced",
+    description: "Good balance of quality, cost, and speed",
+    maxTokens: 16000,
+    effort: "high",
+    thinking: { enabled: true, streamThinking: true },
+    contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
+  },
+  "quality-optimized": {
+    intent: "quality-optimized",
+    provider: "anthropic",
+    connectionName: "anthropic-managed",
+    source: "managed",
+    label: "Quality",
+    description: "Best results with the most capable model",
+    maxTokens: 32000,
+    effort: "high",
+    thinking: { enabled: true, streamThinking: true },
+    contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
+  },
+  "cost-optimized": {
+    intent: "latency-optimized",
+    provider: "anthropic",
+    connectionName: "anthropic-managed",
+    source: "managed",
+    label: "Speed",
+    description: "Fastest responses at lower cost",
+    maxTokens: 8192,
+    effort: "low",
+    thinking: { enabled: false, streamThinking: false },
+    contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
+  },
+  // Open-weight economy option: Kimi K2.6 served by Fireworks via managed
+  // platform inference. Carries the `suppress-cjk` logit-bias preset to
+  // discourage the model from spontaneously emitting Chinese in English
+  // output; the preset is profile-scoped and only forwarded on the Fireworks
+  // path (see `providers/inference/logit-bias.ts`).
+  "balanced-economy": {
+    intent: "balanced",
+    provider: "fireworks",
+    connectionName: "fireworks-managed",
+    source: "managed",
+    label: "Balanced Economy",
+    description: "Strong open model (Kimi K2.6) at a lower price point",
+    maxTokens: 16000,
+    effort: "high",
+    thinking: { enabled: true, streamThinking: true },
+    contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
+    logitBias: "suppress-cjk",
+  },
+};
+
+/**
+ * The "auto" profile key. When active, the daemon injects the
+ * `switch_inference_profile` tool and lets the model self-select a profile
+ * per query. No provider/model — the resolver falls through to the call-site
+ * default (balanced or custom-balanced for BYOK).
+ */
+export const AUTO_PROFILE_KEY = "auto";
+
+export const MANAGED_PROFILE_NAMES = new Set([
+  ...Object.keys(MANAGED_PROFILE_TEMPLATES),
+  AUTO_PROFILE_KEY,
+]);
+
+export function materializeProfile(
+  template: BuiltinProfileDefinition,
+  provider: NonNullable<ProfileEntry["provider"]>,
+  connectionName: string,
+): ProfileEntry {
+  const {
+    intent,
+    provider: _p,
+    connectionName: _c,
+    featureFlag: _f,
+    ...rest
+  } = template;
+  return {
+    ...rest,
+    provider,
+    provider_connection: connectionName,
+    model: resolveModelIntent(provider, intent),
+  };
+}
+
+/**
+ * The `auto` profile entry is metadata-only: no provider/model — the resolver
+ * falls through to the call-site default when it is active.
+ */
+export function createAutoProfileEntry(): ProfileEntry {
+  return {
+    source: "managed",
+    label: "Auto",
+    description:
+      "Automatically routes each query to the best profile — fast for simple questions, capable for complex ones",
+  };
+}
+
+/**
+ * Sparse user override for a built-in profile. Only `label` and `status` are
+ * user-ownable on built-ins; `null` means "explicitly cleared" and is applied
+ * as-is (key-presence semantics — an absent key leaves the default in place).
+ */
+export type BuiltinProfileOverride = {
+  label?: string | null;
+  status?: ProfileStatus | null;
+};
+
+/**
+ * Resolve the effective built-in profile set. Pure: reads only its arguments
+ * and the module-level definitions — no config, env, or filesystem access.
+ *
+ * - Definitions whose `featureFlag` resolves disabled are omitted entirely.
+ * - Off-platform (BYOK) installs get a `" (Managed)"` label suffix on managed
+ *   profiles to disambiguate from the personal `custom-*` profiles that share
+ *   base labels. The `auto` entry never gets the suffix.
+ * - `overrides` are applied by key presence, so an explicit `null` (user
+ *   cleared the value) is preserved.
+ * - `order` lists `auto` first, then the flag-enabled managed profiles in
+ *   definition order — matching the seeder's `profileOrder` maintenance.
+ */
+export function resolveBuiltinProfiles(opts: {
+  isPlatform: boolean;
+  isFlagEnabled: (key: string) => boolean;
+  overrides: Record<string, BuiltinProfileOverride>;
+}): { profiles: Record<string, ProfileEntry>; order: string[] } {
+  const profiles: Record<string, ProfileEntry> = {};
+  const order: string[] = [AUTO_PROFILE_KEY];
+
+  const autoEntry = createAutoProfileEntry();
+  applyOverride(autoEntry, opts.overrides[AUTO_PROFILE_KEY]);
+  profiles[AUTO_PROFILE_KEY] = autoEntry;
+
+  for (const [name, definition] of Object.entries(MANAGED_PROFILE_TEMPLATES)) {
+    if (definition.featureFlag && !opts.isFlagEnabled(definition.featureFlag)) {
+      continue;
+    }
+    const effective: BuiltinProfileDefinition = opts.isPlatform
+      ? definition
+      : { ...definition, label: `${definition.label} (Managed)` };
+    const entry = materializeProfile(
+      effective,
+      definition.provider,
+      definition.connectionName,
+    );
+    applyOverride(entry, opts.overrides[name]);
+    profiles[name] = entry;
+    order.push(name);
+  }
+
+  return { profiles, order };
+}
+
+function applyOverride(
+  entry: ProfileEntry,
+  override: BuiltinProfileOverride | undefined,
+): void {
+  if (!override) return;
+  if ("label" in override) entry.label = override.label;
+  if ("status" in override) entry.status = override.status;
+}

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -6,93 +6,27 @@ import {
   PROVIDERS_REQUIRING_BASE_URL_AND_MODELS,
 } from "../providers/inference/connections.js";
 import { PROVIDER_CATALOG } from "../providers/model-catalog.js";
-import { resolveModelIntent } from "../providers/model-intents.js";
-import type { ModelIntent } from "../providers/types.js";
 import { credentialKey } from "../security/credential-key.js";
 import { getLogger } from "../util/logger.js";
+import {
+  AUTO_PROFILE_KEY,
+  type BuiltinProfileDefinition,
+  createAutoProfileEntry,
+  MANAGED_PROFILE_NAMES,
+  MANAGED_PROFILE_TEMPLATES,
+  materializeProfile,
+} from "./builtin-inference-profiles.js";
 import { loadRawConfig, saveRawConfig } from "./loader.js";
 import {
   DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS,
   type ProfileEntry,
 } from "./schemas/llm.js";
 
+// Re-exported so existing importers of the seeder keep working; the canonical
+// home for built-in profile definitions is `builtin-inference-profiles.ts`.
+export { AUTO_PROFILE_KEY, MANAGED_PROFILE_NAMES };
+
 const log = getLogger("seed-inference-profiles");
-
-/**
- * Template for a daemon-managed inference profile. The profile's model is
- * resolved at seed time from `PROVIDER_MODEL_INTENTS` so the catalog stays the
- * single source of truth for "which model does this intent map to?".
- */
-type ManagedProfileTemplate = Omit<
-  ProfileEntry,
-  "provider" | "model" | "provider_connection"
-> & {
-  intent: ModelIntent;
-  provider: NonNullable<ProfileEntry["provider"]>;
-  connectionName: string;
-};
-
-/**
- * Managed profiles. Overwritten on every daemon boot so Vellum can push
- * model/config updates to customers in new releases. Platform overlays
- * (`preserveProfileNames`) take precedence when present.
- */
-const MANAGED_PROFILE_TEMPLATES: Record<string, ManagedProfileTemplate> = {
-  balanced: {
-    intent: "balanced",
-    provider: "anthropic",
-    connectionName: "anthropic-managed",
-    source: "managed",
-    label: "Balanced",
-    description: "Good balance of quality, cost, and speed",
-    maxTokens: 16000,
-    effort: "high",
-    thinking: { enabled: true, streamThinking: true },
-    contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
-  },
-  "quality-optimized": {
-    intent: "quality-optimized",
-    provider: "anthropic",
-    connectionName: "anthropic-managed",
-    source: "managed",
-    label: "Quality",
-    description: "Best results with the most capable model",
-    maxTokens: 32000,
-    effort: "high",
-    thinking: { enabled: true, streamThinking: true },
-    contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
-  },
-  "cost-optimized": {
-    intent: "latency-optimized",
-    provider: "anthropic",
-    connectionName: "anthropic-managed",
-    source: "managed",
-    label: "Speed",
-    description: "Fastest responses at lower cost",
-    maxTokens: 8192,
-    effort: "low",
-    thinking: { enabled: false, streamThinking: false },
-    contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
-  },
-  // Open-weight economy option: Kimi K2.6 served by Fireworks via managed
-  // platform inference. Carries the `suppress-cjk` logit-bias preset to
-  // discourage the model from spontaneously emitting Chinese in English
-  // output; the preset is profile-scoped and only forwarded on the Fireworks
-  // path (see `providers/inference/logit-bias.ts`).
-  "balanced-economy": {
-    intent: "balanced",
-    provider: "fireworks",
-    connectionName: "fireworks-managed",
-    source: "managed",
-    label: "Balanced Economy",
-    description: "Strong open model (Kimi K2.6) at a lower price point",
-    maxTokens: 16000,
-    effort: "high",
-    thinking: { enabled: true, streamThinking: true },
-    contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
-    logitBias: "suppress-cjk",
-  },
-};
 
 /**
  * User profile templates. Materialized at hatch time for off-platform
@@ -101,7 +35,7 @@ const MANAGED_PROFILE_TEMPLATES: Record<string, ManagedProfileTemplate> = {
  * fields are placeholders — they are overridden at hatch time with the
  * user's chosen provider and personal connection name.
  */
-const USER_PROFILE_TEMPLATES: Record<string, ManagedProfileTemplate> = {
+const USER_PROFILE_TEMPLATES: Record<string, BuiltinProfileDefinition> = {
   "custom-balanced": {
     intent: "balanced",
     provider: "anthropic",
@@ -139,19 +73,6 @@ const USER_PROFILE_TEMPLATES: Record<string, ManagedProfileTemplate> = {
     contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
   },
 };
-
-/**
- * The "auto" profile key. When active, the daemon injects the
- * `switch_inference_profile` tool and lets the model self-select a profile
- * per query. No provider/model — the resolver falls through to the call-site
- * default (balanced or custom-balanced for BYOK).
- */
-export const AUTO_PROFILE_KEY = "auto";
-
-export const MANAGED_PROFILE_NAMES = new Set([
-  ...Object.keys(MANAGED_PROFILE_TEMPLATES),
-  AUTO_PROFILE_KEY,
-]);
 
 export type SeedInferenceProfilesOptions = {
   /**
@@ -256,7 +177,7 @@ export function seedInferenceProfiles(
     if (isPlatform && readObject(profiles[name]) !== null) continue;
 
     const previous = readObject(profiles[name]);
-    const effectiveTemplate: ManagedProfileTemplate = isByokMode
+    const effectiveTemplate: BuiltinProfileDefinition = isByokMode
       ? { ...template, label: `${template.label} (Managed)` }
       : template;
     const next = materializeProfile(
@@ -295,12 +216,7 @@ export function seedInferenceProfiles(
   //     switch_inference_profile tool so the model can self-select per query.
   if (!preservedProfileNames.has(AUTO_PROFILE_KEY)) {
     const previousAuto = readObject(profiles[AUTO_PROFILE_KEY]);
-    const autoEntry: Record<string, unknown> = {
-      source: "managed",
-      label: "Auto",
-      description:
-        "Automatically routes each query to the best profile — fast for simple questions, capable for complex ones",
-    };
+    const autoEntry = createAutoProfileEntry() as Record<string, unknown>;
     if (previousAuto) {
       if ("label" in previousAuto) autoEntry.label = previousAuto.label;
       if ("status" in previousAuto) autoEntry.status = previousAuto.status;
@@ -407,20 +323,6 @@ export function seedInferenceProfiles(
   }
 
   saveRawConfig(config);
-}
-
-function materializeProfile(
-  template: ManagedProfileTemplate,
-  provider: NonNullable<ProfileEntry["provider"]>,
-  connectionName: string,
-): ProfileEntry {
-  const { intent, provider: _p, connectionName: _c, ...rest } = template;
-  return {
-    ...rest,
-    provider,
-    provider_connection: connectionName,
-    model: resolveModelIntent(provider, intent),
-  };
 }
 
 function readObject(value: unknown): Record<string, unknown> | null {


### PR DESCRIPTION
## Summary
- Move MANAGED_PROFILE_TEMPLATES, AUTO_PROFILE_KEY, MANAGED_PROFILE_NAMES, and materializeProfile into new assistant/src/config/builtin-inference-profiles.ts
- Add BuiltinProfileDefinition.featureFlag and pure resolveBuiltinProfiles() (flag gating + BYOK label suffix + key-presence label/status overrides)
- Pure refactor: seedInferenceProfiles behavior unchanged; symbols re-exported for existing importers

Part of plan: builtin-llm-profiles.md (PR 1 of 8)