### PR TITLE
feat: send Vellum-Device-Id header on feature flag requests

### DIFF
--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -16,6 +16,7 @@ import { installAutoUpdate } from "./auto-update";
 import { APP_HOST, APP_PROTOCOL, BUNDLES_DIR_NAME, VELLUMAPP_PROTOCOL } from "./app-config";
 import { resolveAllowedOrigin } from "./app-origin";
 import { installCsp } from "./csp";
+import { getDeviceId } from "./device-id";
 import { handleSync } from "./ipc";
 import { resolveAppProtocolPath } from "./app-protocol";
 import { registerVellumAppProtocol } from "./vellumapp-protocol";
@@ -257,6 +258,7 @@ const resolvedConfig = resolveLocalConfigFromEnv(process.env);
 handleSync("vellum:config:get", () => ({
   webUrl: resolvedConfig.webUrl,
   platformUrl: resolvedConfig.platformUrl,
+  deviceId: getDeviceId(),
 }));
 
 /**

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -898,6 +898,7 @@ contextBridge.exposeInMainWorld("vellum", bridge);
 const vellumConfig = ipcRenderer.sendSync("vellum:config:get") as {
   webUrl: string;
   platformUrl: string;
+  deviceId: string | null;
 } | null;
 if (vellumConfig) {
   contextBridge.exposeInMainWorld("__VELLUM_CONFIG__", vellumConfig);

--- a/apps/web/src/lib/api-interceptors.ts
+++ b/apps/web/src/lib/api-interceptors.ts
@@ -35,6 +35,7 @@ import {
     getSelfHostedIngressUrl,
 } from "@/lib/self-hosted/connection";
 import { getClientRegistrationHeaders } from "@/lib/telemetry/client-identity";
+import { getDeviceId } from "@/runtime/device-id";
 import { isElectron } from "@/runtime/is-electron";
 import { getElectronSessionToken } from "@/runtime/session-token";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
@@ -205,6 +206,11 @@ function createInterceptor({ skipSegmentAllowlist = false } = {}) {
     const organizationId = getActiveOrganizationIdForRequests();
     if (organizationId) {
       newRequest.headers.set("Vellum-Organization-Id", organizationId);
+    }
+
+    const deviceId = getDeviceId();
+    if (deviceId) {
+      newRequest.headers.set("Vellum-Device-Id", deviceId);
     }
 
     // Electron app provides a session token header. This is no-ops on web.

--- a/apps/web/src/runtime/device-id.ts
+++ b/apps/web/src/runtime/device-id.ts
@@ -6,7 +6,7 @@ export function getDeviceId(): string | null {
   if (!isElectron()) return null;
   if (cached === undefined) {
     cached =
-      (window as Record<string, unknown> as { __VELLUM_CONFIG__?: { deviceId?: string } })
+      (window as unknown as { __VELLUM_CONFIG__?: { deviceId?: string } })
         .__VELLUM_CONFIG__?.deviceId ?? null;
   }
   return cached;

--- a/apps/web/src/runtime/device-id.ts
+++ b/apps/web/src/runtime/device-id.ts
@@ -1,0 +1,13 @@
+import { isElectron } from "@/runtime/is-electron";
+
+let cached: string | null | undefined;
+
+export function getDeviceId(): string | null {
+  if (!isElectron()) return null;
+  if (cached === undefined) {
+    cached =
+      (window as Record<string, unknown> as { __VELLUM_CONFIG__?: { deviceId?: string } })
+        .__VELLUM_CONFIG__?.deviceId ?? null;
+  }
+  return cached;
+}

--- a/gateway/src/device-id.ts
+++ b/gateway/src/device-id.ts
@@ -5,8 +5,21 @@ import { getLegacyRootDir } from "./paths.js";
 
 let cached: string | null = null;
 
+/**
+ * Read the persistent device ID from device.json or the VELLUM_DEVICE_ID
+ * env var. In containerized deployments, the gateway sidecar cannot access
+ * the assistant's home directory — the orchestration layer can set
+ * VELLUM_DEVICE_ID to thread the value through instead.
+ */
 export function getDeviceId(): string | null {
   if (cached !== null) return cached;
+
+  const envDeviceId = process.env.VELLUM_DEVICE_ID?.trim();
+  if (envDeviceId) {
+    cached = envDeviceId;
+    return cached;
+  }
+
   try {
     const raw = readFileSync(join(getLegacyRootDir(), "device.json"), "utf-8");
     const parsed = JSON.parse(raw);

--- a/gateway/src/device-id.ts
+++ b/gateway/src/device-id.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { getLegacyRootDir } from "./paths.js";
+
+let cached: string | null = null;
+
+export function getDeviceId(): string | null {
+  if (cached !== null) return cached;
+  try {
+    const raw = readFileSync(join(getLegacyRootDir(), "device.json"), "utf-8");
+    const parsed = JSON.parse(raw);
+    if (typeof parsed.deviceId === "string" && parsed.deviceId) {
+      cached = parsed.deviceId;
+      return cached;
+    }
+  } catch {}
+  return null;
+}

--- a/gateway/src/remote-feature-flag-sync.ts
+++ b/gateway/src/remote-feature-flag-sync.ts
@@ -1,5 +1,6 @@
 import type { CredentialCache } from "./credential-cache.js";
 import { credentialKey } from "./credential-key.js";
+import { getDeviceId } from "./device-id.js";
 import { fetchImpl } from "./fetch.js";
 import { loadFeatureFlagDefaults } from "./feature-flag-defaults.js";
 import { writeRemoteFeatureFlags } from "./feature-flag-remote-store.js";
@@ -379,6 +380,10 @@ export class RemoteFeatureFlagSync {
     const headers: Record<string, string> = { Accept: "application/json" };
     if (assistantCredential) {
       headers["Authorization"] = `Api-Key ${assistantCredential}`;
+    }
+    const deviceId = getDeviceId();
+    if (deviceId) {
+      headers["Vellum-Device-Id"] = deviceId;
     }
     log.debug(
       { url, authenticated: !!assistantCredential },


### PR DESCRIPTION
## Summary

- Add `Vellum-Device-Id` header to the gateway's remote feature flag sync (`remote-feature-flag-sync.ts`) using a new lightweight `device-id.ts` reader that reads from `~/.vellum/device.json`
- Expose the persistent device ID from the Electron main process to the renderer via the `__VELLUM_CONFIG__` IPC config object
- Add `Vellum-Device-Id` header in the web app's platform request interceptor (`api-interceptors.ts`), sourced from the config in Electron or absent in browser-only mode

## Original prompt

The platform repo is adding a `"device"` context kind to LaunchDarkly feature flag evaluation. When the platform receives a `Vellum-Device-Id` header, it includes a device context in the LD evaluation — enabling stable per-device flag targeting even for unauthenticated requests (replacing the current anonymous fallback where all unauthenticated requests are indistinguishable). This PR implements the client-side changes to send the header from the two callers that hit the platform's feature flag endpoints: the gateway (for assistant-scoped flags) and the Electron web app (for client-scoped flags).

🤖 Generated with [Claude Code](https://claude.com/claude-code)