### PR TITLE
feat(telemetry): ship tool_execution events for tool usage

### DIFF
--- a/assistant/src/memory/tool-execution-events-store.test.ts
+++ b/assistant/src/memory/tool-execution-events-store.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import { getDb } from "./db-connection.js";
+import { initializeDb } from "./db-init.js";
+import { conversations, toolInvocations } from "./schema.js";
+import { queryUnreportedToolExecutionEvents } from "./tool-execution-events-store.js";
+
+initializeDb();
+
+const CONVERSATION_ID = "conv-tool-exec-store-test";
+
+interface InsertSpec {
+  id: string;
+  createdAt: number;
+  toolName?: string;
+  decision?: string;
+  riskLevel?: string;
+  durationMs?: number;
+}
+
+function insertInvocation(spec: InsertSpec): void {
+  getDb()
+    .insert(toolInvocations)
+    .values({
+      id: spec.id,
+      conversationId: CONVERSATION_ID,
+      toolName: spec.toolName ?? "calendar_list_events",
+      input: '{"secret":"raw tool args — must never leave the device"}',
+      result: '{"secret":"raw tool output — must never leave the device"}',
+      decision: spec.decision ?? "allow",
+      riskLevel: spec.riskLevel ?? "low",
+      durationMs: spec.durationMs ?? 12,
+      createdAt: spec.createdAt,
+    })
+    .run();
+}
+
+describe("tool-execution-events-store", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.delete(toolInvocations).run();
+    // tool_invocations has an enforced FK to conversations.
+    db.insert(conversations)
+      .values({
+        id: CONVERSATION_ID,
+        title: "test",
+        createdAt: 1000,
+        updatedAt: 1000,
+      })
+      .onConflictDoNothing()
+      .run();
+  });
+
+  test("returns rows in (createdAt, id) order with projected fields and null skillId", () => {
+    insertInvocation({
+      id: "ti-b",
+      createdAt: 2000,
+      toolName: "web_search",
+      decision: "denied",
+      riskLevel: "high",
+      durationMs: 7,
+    });
+    insertInvocation({ id: "ti-a", createdAt: 1000 });
+
+    const rows = queryUnreportedToolExecutionEvents(0, undefined, 100);
+    expect(rows.map((r) => r.id)).toEqual(["ti-a", "ti-b"]);
+    expect(rows[0]).toEqual({
+      id: "ti-a",
+      toolName: "calendar_list_events",
+      skillId: null,
+      decision: "allow",
+      riskLevel: "low",
+      durationMs: 12,
+      conversationId: CONVERSATION_ID,
+      createdAt: 1000,
+    });
+    expect(rows[1]).toMatchObject({
+      toolName: "web_search",
+      skillId: null,
+      decision: "denied",
+      riskLevel: "high",
+      durationMs: 7,
+    });
+    // Raw tool args/outputs are potentially PII — the projection must
+    // never include them.
+    for (const row of rows) {
+      expect(Object.keys(row)).not.toContain("input");
+      expect(Object.keys(row)).not.toContain("result");
+    }
+  });
+
+  test("query advances past the compound (createdAt, id) cursor", () => {
+    // Two rows in the same millisecond: pagination must use the id
+    // tiebreaker to make forward progress, not loop.
+    insertInvocation({ id: "ti-1", createdAt: 5000 });
+    insertInvocation({ id: "ti-2", createdAt: 5000 });
+    insertInvocation({ id: "ti-3", createdAt: 6000 });
+
+    const first = queryUnreportedToolExecutionEvents(0, undefined, 1);
+    expect(first.map((r) => r.id)).toEqual(["ti-1"]);
+
+    const second = queryUnreportedToolExecutionEvents(
+      first[0].createdAt,
+      first[0].id,
+      100,
+    );
+    expect(second.map((r) => r.id)).toEqual(["ti-2", "ti-3"]);
+
+    // Without an id cursor the timestamp-only branch is used.
+    expect(
+      queryUnreportedToolExecutionEvents(5000, undefined, 100).map((r) => r.id),
+    ).toEqual(["ti-3"]);
+
+    // Cursor past the last row returns nothing.
+    const last = second[second.length - 1];
+    expect(
+      queryUnreportedToolExecutionEvents(last.createdAt, last.id, 100).length,
+    ).toBe(0);
+  });
+
+  test("honors the limit", () => {
+    insertInvocation({ id: "ti-l1", createdAt: 1000 });
+    insertInvocation({ id: "ti-l2", createdAt: 2000 });
+    insertInvocation({ id: "ti-l3", createdAt: 3000 });
+
+    const rows = queryUnreportedToolExecutionEvents(0, undefined, 2);
+    expect(rows.map((r) => r.id)).toEqual(["ti-l1", "ti-l2"]);
+  });
+});

--- a/assistant/src/memory/tool-execution-events-store.ts
+++ b/assistant/src/memory/tool-execution-events-store.ts
@@ -1,0 +1,67 @@
+import { and, asc, eq, gt, or } from "drizzle-orm";
+
+import { getDb } from "./db-connection.js";
+import { toolInvocations } from "./schema.js";
+
+/**
+ * A `tool_invocations` audit row projected for telemetry reporting.
+ *
+ * Deliberately excludes the `input` / `result` columns — raw tool
+ * args/outputs are potentially PII and must never leave the device.
+ */
+export interface UnreportedToolExecutionEvent {
+  id: string;
+  toolName: string;
+  /**
+   * Triggering skill id. The `tool_invocations` table does not carry a
+   * skill column yet, so this is always null for now; the field exists so
+   * adding the column is a one-line change here.
+   */
+  skillId: string | null;
+  decision: string;
+  riskLevel: string;
+  durationMs: number;
+  conversationId: string;
+  createdAt: number;
+}
+
+/**
+ * Query tool invocations that haven't been reported to telemetry yet.
+ * Uses a compound cursor (createdAt + id) for reliable watermarking.
+ *
+ * Rows are written by the tool audit listener
+ * (`events/tool-audit-listener.ts`) — there is no record function here.
+ */
+export function queryUnreportedToolExecutionEvents(
+  afterCreatedAt: number,
+  afterId: string | undefined,
+  limit: number,
+): UnreportedToolExecutionEvent[] {
+  const db = getDb();
+  const rows = db
+    .select({
+      id: toolInvocations.id,
+      toolName: toolInvocations.toolName,
+      decision: toolInvocations.decision,
+      riskLevel: toolInvocations.riskLevel,
+      durationMs: toolInvocations.durationMs,
+      conversationId: toolInvocations.conversationId,
+      createdAt: toolInvocations.createdAt,
+    })
+    .from(toolInvocations)
+    .where(
+      afterId
+        ? or(
+            gt(toolInvocations.createdAt, afterCreatedAt),
+            and(
+              eq(toolInvocations.createdAt, afterCreatedAt),
+              gt(toolInvocations.id, afterId),
+            ),
+          )
+        : gt(toolInvocations.createdAt, afterCreatedAt),
+    )
+    .orderBy(asc(toolInvocations.createdAt), asc(toolInvocations.id))
+    .limit(limit)
+    .all();
+  return rows.map((r) => ({ ...r, skillId: null }));
+}

--- a/assistant/src/telemetry/types.ts
+++ b/assistant/src/telemetry/types.ts
@@ -225,10 +225,32 @@ export interface AuthFallbackTelemetryEvent extends TelemetryEventBase {
   window_end: number;
 }
 
+/**
+ * Tool execution event — one per tool invocation, sourced from the
+ * `tool_invocations` audit table. Skill-routed calls appear under their
+ * underlying tool name; `skill_id` identifies the triggering skill once the
+ * daemon threads it through (null in the initial rollout and for direct tool
+ * calls). Carries NO raw input/output — only tool identity, permission
+ * outcome, risk class, duration, and parent conversation.
+ */
+export interface ToolExecutionTelemetryEvent extends TelemetryEventBase {
+  type: "tool_execution";
+  tool_name: string;
+  /** Triggering skill id, or null for direct tool calls / pre-attribution daemons. */
+  skill_id: string | null;
+  /** Permission outcome: "allow" | "error" | "denied". */
+  decision: string;
+  /** Executor risk classification. */
+  risk_level: string | null;
+  duration_ms: number | null;
+  conversation_id: string | null;
+}
+
 /** Discriminated union of all telemetry event types. */
 export type TelemetryEvent =
   | LlmUsageTelemetryEvent
   | TurnTelemetryEvent
   | LifecycleTelemetryEvent
   | OnboardingTelemetryEvent
-  | AuthFallbackTelemetryEvent;
+  | AuthFallbackTelemetryEvent
+  | ToolExecutionTelemetryEvent;

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -143,10 +143,11 @@ mock.module("../memory/onboarding-events-store.js", () => ({
   queryUnreportedOnboardingEvents: mockQueryUnreportedOnboardingEvents,
 }));
 
-// The auth-fallback store is intentionally NOT mocked — it has its own
-// DB-backed tests, and Bun's `mock.module` is process-global, so mocking it
-// here would leak into those tests when files share an invocation. We seed the
-// real DB instead so every auth-fallback test stays order-independent.
+// The auth-fallback and tool-execution stores are intentionally NOT mocked —
+// they have their own DB-backed tests, and Bun's `mock.module` is
+// process-global, so mocking them here would leak into those tests when files
+// share an invocation. We seed the real DB instead so every auth-fallback /
+// tool-execution test stays order-independent.
 
 // ---------------------------------------------------------------------------
 // Production import (after mocks)
@@ -155,7 +156,11 @@ mock.module("../memory/onboarding-events-store.js", () => ({
 import { recordAuthFallbackCounts } from "../memory/auth-fallback-events-store.js";
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
-import { authFallbackEvents } from "../memory/schema.js";
+import {
+  authFallbackEvents,
+  conversations,
+  toolInvocations,
+} from "../memory/schema.js";
 import type { UsageEvent } from "../usage/types.js";
 import {
   ACTIVATION_FUNNEL_VERSION,
@@ -238,6 +243,42 @@ function makeOnboardingEvent(
   };
 }
 
+const TOOL_EXEC_CONVERSATION_ID = "conv-tool-exec-reporter-test";
+
+function seedToolInvocation(overrides: {
+  id: string;
+  createdAt: number;
+  toolName?: string;
+  decision?: string;
+  riskLevel?: string;
+  durationMs?: number;
+}): void {
+  const db = getDb();
+  // tool_invocations has an enforced FK to conversations.
+  db.insert(conversations)
+    .values({
+      id: TOOL_EXEC_CONVERSATION_ID,
+      title: "test",
+      createdAt: 1000,
+      updatedAt: 1000,
+    })
+    .onConflictDoNothing()
+    .run();
+  db.insert(toolInvocations)
+    .values({
+      id: overrides.id,
+      conversationId: TOOL_EXEC_CONVERSATION_ID,
+      toolName: overrides.toolName ?? "web_search",
+      input: '{"secret":"raw tool args — must never leave the device"}',
+      result: '{"secret":"raw tool output — must never leave the device"}',
+      decision: overrides.decision ?? "allow",
+      riskLevel: overrides.riskLevel ?? "low",
+      durationMs: overrides.durationMs ?? 42,
+      createdAt: overrides.createdAt,
+    })
+    .run();
+}
+
 const originalFetch = globalThis.fetch;
 let mockFetch: ReturnType<typeof mock>;
 
@@ -258,6 +299,7 @@ beforeEach(() => {
   mockQueryUnreportedOnboardingEvents.mockReset();
   mockQueryUnreportedOnboardingEvents.mockReturnValue([]);
   getDb().delete(authFallbackEvents).run();
+  getDb().delete(toolInvocations).run();
   mockPlatformClient = null;
   mockGetPlatformBaseUrl.mockReset();
   mockGetDeviceId.mockReset();
@@ -956,6 +998,7 @@ describe("UsageTelemetryReporter", () => {
     mockCollectUsageData = false;
     const events = [makeUsageEvent()];
     mockQueryUnreportedUsageEvents.mockReturnValue(events);
+    seedToolInvocation({ id: "ti-opt-out", createdAt: 1700000000000 });
     mockFetch.mockImplementation(() =>
       Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
     );
@@ -966,9 +1009,9 @@ describe("UsageTelemetryReporter", () => {
     // No HTTP call should have been made
     expect(mockFetch).not.toHaveBeenCalled();
 
-    // All 5 timestamp watermarks should have been advanced (IDs left untouched
+    // All 6 timestamp watermarks should have been advanced (IDs left untouched
     // so the compound-cursor branch stays active)
-    expect(mockSetMemoryCheckpoint).toHaveBeenCalledTimes(5);
+    expect(mockSetMemoryCheckpoint).toHaveBeenCalledTimes(6);
 
     const calls = mockSetMemoryCheckpoint.mock.calls;
     const keys = calls.map((c) => c[0]);
@@ -977,6 +1020,7 @@ describe("UsageTelemetryReporter", () => {
     expect(keys).toContain("telemetry:lifecycle:last_reported_at");
     expect(keys).toContain("telemetry:onboarding:last_reported_at");
     expect(keys).toContain("telemetry:auth_fallback:last_reported_at");
+    expect(keys).toContain("telemetry:tool_execution:last_reported_at");
   });
 
   test("events sent normally after re-enabling collectUsageData", async () => {
@@ -1220,6 +1264,94 @@ describe("UsageTelemetryReporter", () => {
     );
     expect(idCalls.length).toBeGreaterThanOrEqual(1);
     expect(idCalls[idCalls.length - 1][1]).toBe(lastRow.id);
+  });
+
+  // -------------------------------------------------------------------------
+  // Tool-execution events
+  // -------------------------------------------------------------------------
+
+  test("tool_invocations rows flush as tool_execution events with mapped fields and no raw input/result", async () => {
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    seedToolInvocation({
+      id: "ti-flush-1",
+      createdAt: 1700000900000,
+      toolName: "calendar_list_events",
+      decision: "denied",
+      riskLevel: "high",
+      durationMs: 137,
+    });
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
+    );
+
+    const reporter = new UsageTelemetryReporter();
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect(body.events.length).toBe(1);
+    expect(body.events[0]).toMatchObject({
+      type: "tool_execution",
+      daemon_event_id: "ti-flush-1",
+      recorded_at: 1700000900000,
+      tool_name: "calendar_list_events",
+      // No skill column on tool_invocations yet — always null for now.
+      skill_id: null,
+      decision: "denied",
+      risk_level: "high",
+      duration_ms: 137,
+      conversation_id: TOOL_EXEC_CONVERSATION_ID,
+      assistant_version: "1.2.3-test",
+    });
+    // The raw tool args/outputs persisted in the audit row are potentially
+    // PII and must NEVER appear anywhere in the payload.
+    expect(JSON.stringify(body)).not.toContain("must never leave the device");
+    expect(body.events[0].input).toBeUndefined();
+    expect(body.events[0].result).toBeUndefined();
+  });
+
+  test("tool_execution watermark advances to the last reported row on success", async () => {
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    seedToolInvocation({ id: "ti-wm-1", createdAt: 1700001000000 });
+    seedToolInvocation({ id: "ti-wm-2", createdAt: 1700001001000 });
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response('{"accepted":2}', { status: 200 })),
+    );
+
+    const reporter = new UsageTelemetryReporter();
+    await reporter.flush();
+
+    const watermarkCalls = mockSetMemoryCheckpoint.mock.calls.filter(
+      (c) => c[0] === "telemetry:tool_execution:last_reported_at",
+    );
+    expect(watermarkCalls.length).toBeGreaterThanOrEqual(1);
+    expect(watermarkCalls[watermarkCalls.length - 1][1]).toBe(
+      String(1700001001000),
+    );
+
+    const idCalls = mockSetMemoryCheckpoint.mock.calls.filter(
+      (c) => c[0] === "telemetry:tool_execution:last_reported_id",
+    );
+    expect(idCalls.length).toBeGreaterThanOrEqual(1);
+    expect(idCalls[idCalls.length - 1][1]).toBe("ti-wm-2");
+  });
+
+  test("tool_execution watermark stays on failed upload", async () => {
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    seedToolInvocation({ id: "ti-fail-1", createdAt: 1700001100000 });
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response("error", { status: 500 })),
+    );
+
+    const reporter = new UsageTelemetryReporter();
+    await reporter.flush();
+
+    const watermarkCalls = mockSetMemoryCheckpoint.mock.calls.filter((c) =>
+      c[0].startsWith("telemetry:tool_execution:"),
+    );
+    expect(watermarkCalls.length).toBe(0);
   });
 
   // -------------------------------------------------------------------------

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -23,6 +23,7 @@ import {
 import { queryUnreportedLifecycleEvents } from "../memory/lifecycle-events-store.js";
 import { queryUnreportedUsageEvents } from "../memory/llm-usage-store.js";
 import { queryUnreportedOnboardingEvents } from "../memory/onboarding-events-store.js";
+import { queryUnreportedToolExecutionEvents } from "../memory/tool-execution-events-store.js";
 import { queryUnreportedTurnEvents } from "../memory/turn-events-store.js";
 import { VellumPlatformClient } from "../platform/client.js";
 import { getDeviceId } from "../util/device-id.js";
@@ -56,6 +57,10 @@ const CHECKPOINT_KEY_AUTH_FALLBACK_WATERMARK =
   "telemetry:auth_fallback:last_reported_at";
 const CHECKPOINT_KEY_AUTH_FALLBACK_WATERMARK_ID =
   "telemetry:auth_fallback:last_reported_id";
+const CHECKPOINT_KEY_TOOL_EXECUTION_WATERMARK =
+  "telemetry:tool_execution:last_reported_at";
+const CHECKPOINT_KEY_TOOL_EXECUTION_WATERMARK_ID =
+  "telemetry:tool_execution:last_reported_id";
 const REPORT_INTERVAL_MS = 5 * 60 * 1000;
 const INITIAL_FLUSH_DELAY_MS = 30_000; // Delay first flush to let CES handshake complete
 const BATCH_SIZE = 500;
@@ -149,6 +154,7 @@ export class UsageTelemetryReporter {
         setMemoryCheckpoint(CHECKPOINT_KEY_LIFECYCLE_WATERMARK, now);
         setMemoryCheckpoint(CHECKPOINT_KEY_ONBOARDING_WATERMARK, now);
         setMemoryCheckpoint(CHECKPOINT_KEY_AUTH_FALLBACK_WATERMARK, now);
+        setMemoryCheckpoint(CHECKPOINT_KEY_TOOL_EXECUTION_WATERMARK, now);
         return;
       }
 
@@ -189,6 +195,14 @@ export class UsageTelemetryReporter {
         getMemoryCheckpoint(CHECKPOINT_KEY_AUTH_FALLBACK_WATERMARK_ID) ??
         undefined;
 
+      // Read tool-execution watermark (compound cursor: createdAt + id)
+      const toolExecutionWatermark = Number(
+        getMemoryCheckpoint(CHECKPOINT_KEY_TOOL_EXECUTION_WATERMARK) ?? "0",
+      );
+      const toolExecutionWatermarkId =
+        getMemoryCheckpoint(CHECKPOINT_KEY_TOOL_EXECUTION_WATERMARK_ID) ??
+        undefined;
+
       // Query unreported events
       const events = queryUnreportedUsageEvents(
         watermark,
@@ -215,13 +229,19 @@ export class UsageTelemetryReporter {
         authFallbackWatermarkId,
         BATCH_SIZE,
       );
+      const toolExecutionEvents = queryUnreportedToolExecutionEvents(
+        toolExecutionWatermark,
+        toolExecutionWatermarkId,
+        BATCH_SIZE,
+      );
 
       if (
         events.length === 0 &&
         turnEvents.length === 0 &&
         lifecycleEvents.length === 0 &&
         onboardingEvents.length === 0 &&
-        authFallbackEvents.length === 0
+        authFallbackEvents.length === 0 &&
+        toolExecutionEvents.length === 0
       )
         return;
 
@@ -236,6 +256,7 @@ export class UsageTelemetryReporter {
           lifecycleCount: lifecycleEvents.length,
           onboardingCount: onboardingEvents.length,
           authFallbackCount: authFallbackEvents.length,
+          toolExecutionCount: toolExecutionEvents.length,
         },
         "Telemetry flush: resolved auth context",
       );
@@ -402,6 +423,26 @@ export class UsageTelemetryReporter {
             assistant_version: APP_VERSION,
           }),
         ),
+        ...toolExecutionEvents.map(
+          (e): TelemetryEvent => ({
+            type: "tool_execution",
+            daemon_event_id: e.id,
+            recorded_at: e.createdAt,
+            tool_name: e.toolName,
+            skill_id: e.skillId,
+            decision: e.decision,
+            risk_level: e.riskLevel,
+            duration_ms: e.durationMs,
+            conversation_id: e.conversationId,
+            // `tool_invocations` has no record-time version column — stamp
+            // the running binary's `APP_VERSION` so the wire value is
+            // concrete rather than an explicit null that would override the
+            // envelope under the platform's per-event-wins contract. Adding
+            // the record-time column is a separate follow-up that mirrors
+            // what migration 267 did for `llm_usage_events`.
+            assistant_version: APP_VERSION,
+          }),
+        ),
       ];
 
       const organizationId = getPlatformOrganizationId() || undefined;
@@ -501,13 +542,28 @@ export class UsageTelemetryReporter {
         );
       }
 
+      // Advance tool-execution watermark (compound cursor)
+      if (toolExecutionEvents.length > 0) {
+        const lastToolExecution =
+          toolExecutionEvents[toolExecutionEvents.length - 1];
+        setMemoryCheckpoint(
+          CHECKPOINT_KEY_TOOL_EXECUTION_WATERMARK,
+          String(lastToolExecution.createdAt),
+        );
+        setMemoryCheckpoint(
+          CHECKPOINT_KEY_TOOL_EXECUTION_WATERMARK_ID,
+          lastToolExecution.id,
+        );
+      }
+
       // If we got a full batch of any type, there may be more — recurse
       if (
         events.length === BATCH_SIZE ||
         turnEvents.length === BATCH_SIZE ||
         lifecycleEvents.length === BATCH_SIZE ||
         onboardingEvents.length === BATCH_SIZE ||
-        authFallbackEvents.length === BATCH_SIZE
+        authFallbackEvents.length === BATCH_SIZE ||
+        toolExecutionEvents.length === BATCH_SIZE
       ) {
         await this._doFlush(batchCount + 1);
       }


### PR DESCRIPTION
## Summary
- Add tool_execution telemetry event type sourced from the tool_invocations audit table
- Add compound-cursor store query and wire it through UsageTelemetryReporter batching/opt-out
- Ship tool identity, decision, risk level, duration, conversation id — never raw input/result

Part of plan: tool-telemetry-daemon.md (PR 1 of 2)