### PR TITLE
feat(assistant): resolve built-in inference profiles at config load time

### DIFF
--- a/assistant/src/__tests__/btw-routes.test.ts
+++ b/assistant/src/__tests__/btw-routes.test.ts
@@ -83,6 +83,7 @@ mock.module("../runtime/routes/identity-intro-cache.js", () => ({
 const assistantFeatureFlags: Record<string, boolean> = {};
 
 mock.module("../config/assistant-feature-flags.js", () => ({
+  setOnFeatureFlagOverridesRefreshed: () => {},
   isAssistantFeatureFlagEnabled: (key: string) =>
     assistantFeatureFlags[key] ?? false,
 }));

--- a/assistant/src/__tests__/compaction-events.test.ts
+++ b/assistant/src/__tests__/compaction-events.test.ts
@@ -95,6 +95,7 @@ mock.module("../config/loader.js", () => ({
 }));
 
 mock.module("../config/assistant-feature-flags.js", () => ({
+  setOnFeatureFlagOverridesRefreshed: () => {},
   isAssistantFeatureFlagEnabled: () => true,
 }));
 

--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -823,14 +823,17 @@ describe("loadConfig startup behavior", () => {
     const mainAgentConfig = resolveCallSiteConfig("mainAgent", config.llm);
 
     expect(config.llm.activeProfile).toBe("balanced");
-    expect(config.llm.profiles.balanced).toEqual({
-      source: "managed",
-      provider: "openai",
-      model: "gpt-5.4",
-      label: "Platform Balanced",
-    });
-    expect(mainAgentConfig.provider).toBe("openai");
-    expect(mainAgentConfig.model).toBe("gpt-5.4");
+    // Built-in profiles are code-resolved at load time: the template's
+    // config fields are authoritative in the *effective* config, while the
+    // overlay-materialized entry contributes only its user-ownable facets
+    // (label/status). The overlay fragment itself stays untouched on disk
+    // (asserted below) — PR 6 of the builtin-llm-profiles plan converts
+    // overlay built-in entries to profileOverrides at merge time.
+    expect(config.llm.profiles.balanced!.label).toBe("Platform Balanced");
+    expect(config.llm.profiles.balanced!.provider).toBe("anthropic");
+    expect(config.llm.profiles.balanced!.model).toBe("claude-sonnet-4-6");
+    expect(mainAgentConfig.provider).toBe("anthropic");
+    expect(mainAgentConfig.model).toBe("claude-sonnet-4-6");
 
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
     expect(raw.llm.profiles.balanced).toEqual({

--- a/assistant/src/__tests__/config-loader-builtin-profiles.test.ts
+++ b/assistant/src/__tests__/config-loader-builtin-profiles.test.ts
@@ -1,0 +1,399 @@
+/**
+ * Built-in inference profiles are code-defined and merged into the parsed
+ * config at load time (`applyBuiltinProfiles` in `config/loader.ts`):
+ *
+ * - `getConfig()` / `getConfigReadOnly()` expose all built-ins even when the
+ *   raw config has none materialized.
+ * - Template fields are authoritative; `llm.profileOverrides` (and, at lower
+ *   precedence, label/status on still-materialized transition-state entries)
+ *   control only label/status.
+ * - Feature-flag-gated built-ins disappear from the effective set when the
+ *   flag is off, with activeProfile falling back to `balanced`.
+ * - The merge is in-memory only: pure reads never write built-in entries
+ *   back to config.json.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mocks — declared before imports that depend on platform/logger
+// ---------------------------------------------------------------------------
+
+const WORKSPACE_DIR = process.env.VELLUM_WORKSPACE_DIR!;
+const CONFIG_PATH = join(WORKSPACE_DIR, "config.json");
+
+function makeLoggerStub(): Record<string, unknown> {
+  const stub: Record<string, unknown> = {};
+  for (const m of [
+    "info",
+    "warn",
+    "error",
+    "debug",
+    "trace",
+    "fatal",
+    "silent",
+    "child",
+  ]) {
+    stub[m] = m === "child" ? () => makeLoggerStub() : () => {};
+  }
+  return stub;
+}
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => makeLoggerStub(),
+}));
+
+afterAll(() => {
+  mock.restore();
+});
+
+import {
+  clearFeatureFlagOverridesCache,
+  refreshOverridesFromGateway,
+} from "../config/assistant-feature-flags.js";
+import {
+  AUTO_PROFILE_KEY,
+  MANAGED_PROFILE_TEMPLATES,
+  materializeProfile,
+} from "../config/builtin-inference-profiles.js";
+import {
+  getConfig,
+  getConfigReadOnly,
+  invalidateConfigCache,
+} from "../config/loader.js";
+import type { ProfileEntry } from "../config/schemas/llm.js";
+import { ROUTES as LLM_CALL_SITES_ROUTES } from "../runtime/routes/llm-call-sites-routes.js";
+import type { RouteHandlerArgs } from "../runtime/routes/types.js";
+import { setStorePathForTesting } from "./encrypted-store-test-helpers.js";
+import { setOverridesForTesting } from "./feature-flag-test-helpers.js";
+import { mockGatewayIpc, resetMockGatewayIpc } from "./mock-gateway-ipc.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const BUILTIN_NAMES = [
+  AUTO_PROFILE_KEY,
+  ...Object.keys(MANAGED_PROFILE_TEMPLATES),
+];
+
+/** Flag key used by the gating tests. Undeclared in the registry on purpose
+ * — resolution comes entirely from the (test-seeded) override cache. */
+const TEST_FLAG = "test-builtin-profile-flag";
+
+function ensureTestDir(): void {
+  const dirs = [
+    WORKSPACE_DIR,
+    join(WORKSPACE_DIR, "data"),
+    join(WORKSPACE_DIR, "data", "memory"),
+    join(WORKSPACE_DIR, "data", "logs"),
+  ];
+  for (const dir of dirs) {
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  }
+}
+
+function resetWorkspace(): void {
+  if (existsSync(WORKSPACE_DIR)) {
+    for (const name of readdirSync(WORKSPACE_DIR)) {
+      rmSync(join(WORKSPACE_DIR, name), { recursive: true, force: true });
+    }
+  }
+  ensureTestDir();
+}
+
+function writeConfig(config: Record<string, unknown>): void {
+  writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2) + "\n");
+}
+
+function readConfigFromDisk(): Record<string, unknown> {
+  return JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+}
+
+function templateEntry(name: string): ProfileEntry {
+  const template = MANAGED_PROFILE_TEMPLATES[name]!;
+  return materializeProfile(
+    template,
+    template.provider,
+    template.connectionName,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("config loader — built-in inference profile merge", () => {
+  const originalIsPlatform = process.env.IS_PLATFORM;
+
+  beforeEach(() => {
+    resetWorkspace();
+    setStorePathForTesting(join(WORKSPACE_DIR, "keys.enc"));
+    invalidateConfigCache();
+    resetMockGatewayIpc();
+    // Pin flag state: empty overrides → registry defaults apply, and the
+    // gateway IPC retry loop never runs.
+    setOverridesForTesting({});
+    process.env.IS_PLATFORM = "true";
+  });
+
+  afterEach(() => {
+    // Safety net: gating tests patch the shared template object.
+    delete MANAGED_PROFILE_TEMPLATES["balanced-economy"]!.featureFlag;
+    setStorePathForTesting(null);
+    invalidateConfigCache();
+    clearFeatureFlagOverridesCache();
+    resetMockGatewayIpc();
+    if (originalIsPlatform === undefined) {
+      delete process.env.IS_PLATFORM;
+    } else {
+      process.env.IS_PLATFORM = originalIsPlatform;
+    }
+  });
+
+  test("getConfig() exposes all built-ins on an empty raw config, without persisting them", () => {
+    const config = getConfig();
+
+    for (const name of BUILTIN_NAMES) {
+      expect(config.llm.profiles[name]).toBeDefined();
+    }
+    expect(config.llm.profiles[AUTO_PROFILE_KEY]!.provider).toBeUndefined();
+    expect(config.llm.profiles[AUTO_PROFILE_KEY]!.model).toBeUndefined();
+
+    const expectedBalanced = templateEntry("balanced");
+    expect(config.llm.profiles.balanced!.model).toBe(expectedBalanced.model!);
+    expect(config.llm.profiles.balanced!.label).toBe("Balanced");
+    expect(config.llm.profiles.balanced!.provider_connection).toBe(
+      "anthropic-managed",
+    );
+
+    expect(config.llm.profileOrder[0]).toBe(AUTO_PROFILE_KEY);
+    for (const name of BUILTIN_NAMES) {
+      expect(config.llm.profileOrder).toContain(name);
+    }
+    expect(config.llm.activeProfile).toBe("balanced");
+
+    // First-launch seed wrote schema defaults to disk — WITHOUT the merged
+    // built-in entries and without the in-memory activeProfile fallback.
+    const onDisk = readConfigFromDisk() as {
+      llm?: { profiles?: Record<string, unknown>; activeProfile?: string };
+    };
+    expect(onDisk.llm?.profiles).toEqual({});
+    expect(onDisk.llm?.activeProfile).toBeUndefined();
+  });
+
+  test("getConfigReadOnly() returns merged built-ins without creating config.json", () => {
+    const config = getConfigReadOnly();
+
+    for (const name of BUILTIN_NAMES) {
+      expect(config.llm.profiles[name]).toBeDefined();
+    }
+    expect(config.llm.activeProfile).toBe("balanced");
+    expect(existsSync(CONFIG_PATH)).toBe(false);
+  });
+
+  test("off-platform (BYOK) built-ins get the ' (Managed)' label suffix", () => {
+    process.env.IS_PLATFORM = "false";
+
+    const config = getConfig();
+
+    expect(config.llm.profiles.balanced!.label).toBe("Balanced (Managed)");
+    // `auto` never gets the suffix.
+    expect(config.llm.profiles[AUTO_PROFILE_KEY]!.label).toBe("Auto");
+  });
+
+  test("llm.profileOverrides label/status are reflected on the merged entry", () => {
+    writeConfig({
+      llm: {
+        profileOverrides: {
+          balanced: { label: "My Balanced", status: "disabled" },
+        },
+      },
+    });
+
+    const config = getConfig();
+
+    expect(config.llm.profiles.balanced!.label).toBe("My Balanced");
+    expect(config.llm.profiles.balanced!.status).toBe("disabled");
+    // Template config fields are untouched by the override.
+    expect(config.llm.profiles.balanced!.model).toBe(
+      templateEntry("balanced").model!,
+    );
+  });
+
+  test("stale materialized entry: template model/config win, its label/status are kept as low-precedence overrides", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          balanced: {
+            provider: "anthropic",
+            provider_connection: "anthropic-managed",
+            model: "claude-drifted-model",
+            maxTokens: 999,
+            temperature: 1.5,
+            label: "Renamed Balanced",
+            status: "disabled",
+            source: "managed",
+          },
+        },
+        activeProfile: "balanced",
+      },
+    });
+
+    const config = getConfig();
+    const balanced = config.llm.profiles.balanced!;
+    const expected = templateEntry("balanced");
+
+    // Drifted config fields are discarded — the template is authoritative.
+    expect(balanced.model).toBe(expected.model!);
+    expect(balanced.maxTokens).toBe(expected.maxTokens!);
+    expect(balanced.temperature).toBeUndefined();
+    // User-ownable facets carried on the stale entry survive.
+    expect(balanced.label).toBe("Renamed Balanced");
+    expect(balanced.status).toBe("disabled");
+  });
+
+  test("llm.profileOverrides beats a stale materialized entry's label", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          balanced: {
+            provider: "anthropic",
+            model: "claude-drifted-model",
+            label: "Stale Label",
+          },
+        },
+        profileOverrides: {
+          balanced: { label: "Override Label" },
+        },
+      },
+    });
+
+    const config = getConfig();
+
+    expect(config.llm.profiles.balanced!.label).toBe("Override Label");
+  });
+
+  test("flag-disabled built-in is absent from profiles and profileOrder; activeProfile falls back to balanced", () => {
+    MANAGED_PROFILE_TEMPLATES["balanced-economy"]!.featureFlag = TEST_FLAG;
+    setOverridesForTesting({ [TEST_FLAG]: false });
+    writeConfig({
+      llm: {
+        profiles: {
+          "balanced-economy": {
+            provider: "fireworks",
+            model: "kimi-k2p6",
+            source: "managed",
+          },
+        },
+        profileOrder: ["auto", "balanced", "balanced-economy"],
+        activeProfile: "balanced-economy",
+      },
+    });
+
+    const config = getConfig();
+
+    expect(config.llm.profiles["balanced-economy"]).toBeUndefined();
+    expect(config.llm.profileOrder).not.toContain("balanced-economy");
+    expect(config.llm.activeProfile).toBe("balanced");
+    // The other built-ins are unaffected.
+    expect(config.llm.profiles.balanced).toBeDefined();
+    expect(config.llm.profiles["quality-optimized"]).toBeDefined();
+  });
+
+  test("flag flip via refreshOverridesFromGateway changes the visible profile set without restart", async () => {
+    MANAGED_PROFILE_TEMPLATES["balanced-economy"]!.featureFlag = TEST_FLAG;
+    setOverridesForTesting({ [TEST_FLAG]: true });
+    writeConfig({ llm: { activeProfile: "balanced" } });
+
+    expect(getConfig().llm.profiles["balanced-economy"]).toBeDefined();
+
+    // The gateway pushes a flag flip; the refresh must invalidate the
+    // parsed-config cache (config.json itself is unchanged, so the file
+    // signature alone would keep serving the stale merged set).
+    mockGatewayIpc({ [TEST_FLAG]: false });
+    await refreshOverridesFromGateway();
+
+    expect(getConfig().llm.profiles["balanced-economy"]).toBeUndefined();
+  });
+
+  test("activeProfile naming a custom user profile is NOT reset", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          "my-custom": {
+            provider: "anthropic",
+            model: "claude-opus-4-8",
+            source: "user",
+          },
+        },
+        activeProfile: "my-custom",
+      },
+    });
+
+    const config = getConfig();
+
+    expect(config.llm.activeProfile).toBe("my-custom");
+    expect(config.llm.profiles["my-custom"]!.model).toBe("claude-opus-4-8");
+  });
+
+  test("a pure read writes nothing back to config.json", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          balanced: {
+            provider: "anthropic",
+            model: "claude-drifted-model",
+            label: "Renamed",
+          },
+          "my-custom": { provider: "anthropic", model: "claude-opus-4-8" },
+        },
+        activeProfile: "my-custom",
+      },
+    });
+    const before = readFileSync(CONFIG_PATH, "utf-8");
+    const mtimeBefore = statSync(CONFIG_PATH).mtimeMs;
+
+    getConfig();
+
+    expect(readFileSync(CONFIG_PATH, "utf-8")).toBe(before);
+    expect(statSync(CONFIG_PATH).mtimeMs).toBe(mtimeBefore);
+  });
+
+  test("handleListProfiles (GET /v1/config/llm/profiles) sees built-ins via getConfig() with no route change", async () => {
+    writeConfig({ llm: {} });
+
+    const route = LLM_CALL_SITES_ROUTES.find(
+      (r) => r.operationId === "llm_profiles_list",
+    )!;
+    expect(route).toBeDefined();
+
+    const result = (await route.handler({} as RouteHandlerArgs)) as {
+      profiles: string[];
+      activeProfile: string | null;
+    };
+
+    for (const name of BUILTIN_NAMES) {
+      expect(result.profiles).toContain(name);
+    }
+    expect(result.activeProfile).toBe("balanced");
+  });
+});

--- a/assistant/src/__tests__/config-managed-gemini-defaults.test.ts
+++ b/assistant/src/__tests__/config-managed-gemini-defaults.test.ts
@@ -64,6 +64,7 @@ mock.module("../util/logger.js", () => ({
 let featureFlagEnabled = false;
 
 mock.module("../config/assistant-feature-flags.js", () => ({
+  setOnFeatureFlagOverridesRefreshed: () => {},
   isAssistantFeatureFlagEnabled: (key: string) => {
     if (key === "managed-gemini-embeddings-enabled") return featureFlagEnabled;
     return true;

--- a/assistant/src/__tests__/config-watcher-cleanup-throttle.test.ts
+++ b/assistant/src/__tests__/config-watcher-cleanup-throttle.test.ts
@@ -183,6 +183,7 @@ mock.module("../config/loader.js", () => ({
 }));
 
 mock.module("../config/assistant-feature-flags.js", () => ({
+  setOnFeatureFlagOverridesRefreshed: () => {},
   clearFeatureFlagOverridesCache: () => {},
 }));
 

--- a/assistant/src/__tests__/conversation-app-control-instantiation.test.ts
+++ b/assistant/src/__tests__/conversation-app-control-instantiation.test.ts
@@ -50,6 +50,7 @@ mock.module("../util/logger.js", () => ({
 
 let appControlFlagEnabled = false;
 mock.module("../config/assistant-feature-flags.js", () => ({
+  setOnFeatureFlagOverridesRefreshed: () => {},
   isAssistantFeatureFlagEnabled: (key: string) => {
     if (key === "app-control") return appControlFlagEnabled;
     return true;

--- a/assistant/src/__tests__/conversation-skill-tools.test.ts
+++ b/assistant/src/__tests__/conversation-skill-tools.test.ts
@@ -218,6 +218,7 @@ mock.module("../config/loader.js", () => ({
 }));
 
 mock.module("../config/assistant-feature-flags.js", () => ({
+  setOnFeatureFlagOverridesRefreshed: () => {},
   isAssistantFeatureFlagEnabled: () => true,
   loadDefaultsRegistry: () => ({}),
 }));

--- a/assistant/src/__tests__/conversation-slash-commands.test.ts
+++ b/assistant/src/__tests__/conversation-slash-commands.test.ts
@@ -262,13 +262,20 @@ describe("resolveSlash /model — inference profile switcher", () => {
     if (result.kind !== "unknown") throw new Error("expected unknown kind");
     expect(result.message).toContain("Inference profiles:");
     expect(result.message).toContain(
-      "`balanced` (Balanced) **[current]** — Default mix of speed and quality",
+      "`balanced` (Balanced) **[current]** — Good balance of quality, cost, and speed",
     );
     expect(result.message).toContain(
-      "`cost-optimized` (Cost-optimized) — Cheaper models, slower",
+      "`cost-optimized` (Cost-optimized) — Fastest responses at lower cost",
     );
     expect(result.message).toContain(
       "`short-context` (Short context) *(disabled)*",
+    );
+    expect(result.message).toContain("`auto` (Auto)");
+    expect(result.message).toContain(
+      "`quality-optimized` (Quality (Managed)) — Best results with the most capable model",
+    );
+    expect(result.message).toContain(
+      "`balanced-economy` (Balanced Economy (Managed))",
     );
     expect(result.message).toContain("Switch with `/model <name>`.");
   });
@@ -317,16 +324,24 @@ describe("resolveSlash /model — inference profile switcher", () => {
     expect(result.message).toBe("Already using profile `balanced` (Balanced).");
   });
 
-  test("`/model` with no profiles defined points at Settings", async () => {
+  test("`/model` with no profiles in raw config still lists the built-ins", async () => {
     writeFixtureConfig({
       llm: { profiles: {}, profileOrder: [] },
     });
     const result = await resolveSlash("/model");
     expect(result.kind).toBe("unknown");
     if (result.kind !== "unknown") throw new Error("expected unknown kind");
-    expect(result.message).toBe(
-      "No inference profiles are defined. Use **Settings → Models & Services** to create one.",
+    expect(result.message).toContain("Inference profiles:");
+    expect(result.message).toContain("`auto` (Auto)");
+    expect(result.message).toContain(
+      "`balanced` (Balanced (Managed)) **[current]**",
     );
+    expect(result.message).toContain("`quality-optimized` (Quality (Managed))");
+    expect(result.message).toContain("`cost-optimized` (Speed (Managed))");
+    expect(result.message).toContain(
+      "`balanced-economy` (Balanced Economy (Managed))",
+    );
+    expect(result.message).toContain("Switch with `/model <name>`.");
   });
 
   test("`/model <name>` trims surrounding whitespace from the argument", async () => {

--- a/assistant/src/__tests__/conversation-speed-override.test.ts
+++ b/assistant/src/__tests__/conversation-speed-override.test.ts
@@ -93,6 +93,7 @@ mock.module("../config/loader.js", () => ({
 
 // Feature flag mock — fast-mode enabled for all tests in this file.
 mock.module("../config/assistant-feature-flags.js", () => ({
+  setOnFeatureFlagOverridesRefreshed: () => {},
   isAssistantFeatureFlagEnabled: (key: string) => {
     if (key === "fast-mode") return true;
     return true;

--- a/assistant/src/__tests__/embedding-managed-proxy-selection.test.ts
+++ b/assistant/src/__tests__/embedding-managed-proxy-selection.test.ts
@@ -46,6 +46,7 @@ mock.module("../security/secure-keys.js", () => ({
 const mockFeatureFlags: Record<string, boolean> = {};
 
 mock.module("../config/assistant-feature-flags.js", () => ({
+  setOnFeatureFlagOverridesRefreshed: () => {},
   isAssistantFeatureFlagEnabled: (key: string, _config: unknown) => {
     return mockFeatureFlags[key] ?? false;
   },

--- a/assistant/src/__tests__/gateway-flag-listener.test.ts
+++ b/assistant/src/__tests__/gateway-flag-listener.test.ts
@@ -2,7 +2,7 @@ import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { createServer, type Server, type Socket } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach,beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 // ---------------------------------------------------------------------------
 // Isolated temp directory for the IPC socket
@@ -27,6 +27,7 @@ mock.module("../ipc/socket-path.js", () => ({
 let refreshCallCount = 0;
 
 mock.module("../config/assistant-feature-flags.js", () => ({
+  setOnFeatureFlagOverridesRefreshed: () => {},
   refreshOverridesFromGateway: async () => {
     refreshCallCount++;
   },
@@ -51,9 +52,8 @@ mock.module("../runtime/sync/sync-publisher.js", () => ({
 // ---------------------------------------------------------------------------
 // Dynamic imports (after mock.module)
 // ---------------------------------------------------------------------------
-const { startGatewayFlagListener, stopGatewayFlagListener } = await import(
-  "../ipc/gateway-flag-listener.js"
-);
+const { startGatewayFlagListener, stopGatewayFlagListener } =
+  await import("../ipc/gateway-flag-listener.js");
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -207,8 +207,7 @@ describe("gateway-flag-listener", () => {
     const countAfterReconnect = refreshCallCount;
     expect(countAfterReconnect).toBeGreaterThan(0);
 
-    const payload =
-      JSON.stringify({ event: "feature_flags_changed" }) + "\n";
+    const payload = JSON.stringify({ event: "feature_flags_changed" }) + "\n";
     secondClient!.write(payload);
     await new Promise((r) => setTimeout(r, 200));
 

--- a/assistant/src/__tests__/get-skill-detail-audit.test.ts
+++ b/assistant/src/__tests__/get-skill-detail-audit.test.ts
@@ -65,6 +65,7 @@ mock.module("../config/skill-state.js", () => ({
 }));
 
 mock.module("../config/assistant-feature-flags.js", () => ({
+  setOnFeatureFlagOverridesRefreshed: () => {},
   isAssistantFeatureFlagEnabled: () => true,
 }));
 

--- a/assistant/src/__tests__/identity-routes.test.ts
+++ b/assistant/src/__tests__/identity-routes.test.ts
@@ -76,6 +76,7 @@ mock.module("../runtime/btw-sidechain.js", () => ({
 const assistantFeatureFlags: Record<string, boolean> = {};
 
 mock.module("../config/assistant-feature-flags.js", () => ({
+  setOnFeatureFlagOverridesRefreshed: () => {},
   isAssistantFeatureFlagEnabled: (key: string) =>
     assistantFeatureFlags[key] ?? false,
 }));

--- a/assistant/src/__tests__/install-skill-routing.test.ts
+++ b/assistant/src/__tests__/install-skill-routing.test.ts
@@ -94,6 +94,7 @@ mock.module("../skills/install-meta.js", () => ({
   readInstallMeta: () => null,
 }));
 mock.module("../config/assistant-feature-flags.js", () => ({
+  setOnFeatureFlagOverridesRefreshed: () => {},
   isAssistantFeatureFlagEnabled: () => true,
 }));
 mock.module("../config/loader.js", () => ({

--- a/assistant/src/__tests__/search-skills-unified.test.ts
+++ b/assistant/src/__tests__/search-skills-unified.test.ts
@@ -103,6 +103,7 @@ mock.module("../skills/install-meta.js", () => ({
 
 // Stub remaining imports pulled in by skills.ts
 mock.module("../config/assistant-feature-flags.js", () => ({
+  setOnFeatureFlagOverridesRefreshed: () => {},
   isAssistantFeatureFlagEnabled: () => true,
 }));
 mock.module("../config/loader.js", () => ({

--- a/assistant/src/__tests__/skill-projection-feature-flag.test.ts
+++ b/assistant/src/__tests__/skill-projection-feature-flag.test.ts
@@ -51,6 +51,7 @@ mock.module("../config/skill-state.js", () => ({
 // resolver module itself.
 let _mockOverrides: Record<string, boolean> = {};
 mock.module("../config/assistant-feature-flags.js", () => ({
+  setOnFeatureFlagOverridesRefreshed: () => {},
   isAssistantFeatureFlagEnabled: (key: string, _config: unknown): boolean => {
     const explicit = _mockOverrides[key];
     if (typeof explicit === "boolean") return explicit;

--- a/assistant/src/__tests__/skill-projection.benchmark.test.ts
+++ b/assistant/src/__tests__/skill-projection.benchmark.test.ts
@@ -37,6 +37,7 @@ mock.module("../config/loader.js", () => ({
 }));
 
 mock.module("../config/assistant-feature-flags.js", () => ({
+  setOnFeatureFlagOverridesRefreshed: () => {},
   isAssistantFeatureFlagEnabled: () => true,
   loadDefaultsRegistry: () => ({}),
   getFeatureFlagDefault: () => true,

--- a/assistant/src/__tests__/skills-file-content-endpoint.test.ts
+++ b/assistant/src/__tests__/skills-file-content-endpoint.test.ts
@@ -108,6 +108,7 @@ mock.module("../config/skill-state.js", () => ({
 }));
 
 mock.module("../config/assistant-feature-flags.js", () => ({
+  setOnFeatureFlagOverridesRefreshed: () => {},
   isAssistantFeatureFlagEnabled: () => true,
 }));
 

--- a/assistant/src/__tests__/skills-files-catalog-fallback.test.ts
+++ b/assistant/src/__tests__/skills-files-catalog-fallback.test.ts
@@ -109,6 +109,7 @@ mock.module("../config/skill-state.js", () => ({
 }));
 
 mock.module("../config/assistant-feature-flags.js", () => ({
+  setOnFeatureFlagOverridesRefreshed: () => {},
   isAssistantFeatureFlagEnabled: () => true,
 }));
 

--- a/assistant/src/__tests__/tool-execution-pipeline.benchmark.test.ts
+++ b/assistant/src/__tests__/tool-execution-pipeline.benchmark.test.ts
@@ -59,6 +59,7 @@ mock.module("../tools/registry.js", () => ({
 }));
 
 mock.module("../config/assistant-feature-flags.js", () => ({
+  setOnFeatureFlagOverridesRefreshed: () => {},
   isAssistantFeatureFlagEnabled: () => false,
 }));
 

--- a/assistant/src/config/assistant-feature-flags.ts
+++ b/assistant/src/config/assistant-feature-flags.ts
@@ -103,7 +103,11 @@ function parseRegistryToDefaults(parsed: unknown): FeatureFlagDefaultsRegistry {
     const entry = flag as Record<string, unknown>;
     if (entry.scope !== "assistant" && entry.scope !== "both") continue;
     if (typeof entry.key !== "string") continue;
-    if (typeof entry.defaultEnabled !== "boolean" && typeof entry.defaultEnabled !== "string") continue;
+    if (
+      typeof entry.defaultEnabled !== "boolean" &&
+      typeof entry.defaultEnabled !== "string"
+    )
+      continue;
 
     result[entry.key as string] = {
       defaultEnabled: entry.defaultEnabled,
@@ -139,6 +143,23 @@ async function fetchOverridesFromGateway(
   } catch {
     return {};
   }
+}
+
+/**
+ * Callback invoked whenever the override cache is (re)populated or refreshed.
+ *
+ * The config loader registers `invalidateConfigCache` here so a feature-flag
+ * flip recomputes flag-dependent config state (e.g. the merged built-in
+ * inference profile set) without a daemon restart. A registered callback —
+ * rather than importing from `loader.ts` — avoids an import cycle:
+ * `loader.ts` already imports this module.
+ */
+let onOverridesRefreshed: (() => void) | undefined;
+
+export function setOnFeatureFlagOverridesRefreshed(
+  callback: (() => void) | undefined,
+): void {
+  onOverridesRefreshed = callback;
 }
 
 /**
@@ -217,6 +238,7 @@ export async function initFeatureFlagOverrides(options?: {
           "Feature flag overrides loaded from gateway after retry",
         );
       }
+      onOverridesRefreshed?.();
       return;
     }
   }
@@ -266,6 +288,11 @@ export function clearFeatureFlagOverridesCache(): void {
 export async function refreshOverridesFromGateway(): Promise<void> {
   clearFeatureFlagOverridesCache();
   await initFeatureFlagOverrides({ retryBackoffsMs: [] });
+  // Notify even when the re-fetch failed/returned empty: the cache was
+  // cleared above, so flag resolution may now differ (registry defaults)
+  // and flag-dependent caches must recompute either way. Idempotent with
+  // the success-path notification inside `initFeatureFlagOverrides`.
+  onOverridesRefreshed?.();
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -14,7 +14,16 @@ import {
   getWorkspaceConfigPath,
   getWorkspaceDir,
 } from "../util/platform.js";
-import { isAssistantFeatureFlagEnabled } from "./assistant-feature-flags.js";
+import {
+  isAssistantFeatureFlagEnabled,
+  setOnFeatureFlagOverridesRefreshed,
+} from "./assistant-feature-flags.js";
+import {
+  AUTO_PROFILE_KEY,
+  type BuiltinProfileOverride,
+  MANAGED_PROFILE_NAMES,
+  resolveBuiltinProfiles,
+} from "./builtin-inference-profiles.js";
 import { AssistantConfigSchema } from "./schema.js";
 import type { AssistantConfig } from "./types.js";
 
@@ -108,18 +117,23 @@ function cloneDefaultConfig(): AssistantConfig {
 }
 
 /**
+ * True when running as a platform-managed (hosted) assistant deployment.
+ * IS_PLATFORM is set by the Vellum platform launcher; local, Docker, and
+ * bare-metal assistants are unaffected.
+ */
+function isPlatformDeployment(): boolean {
+  return process.env.IS_PLATFORM === "true" || process.env.IS_PLATFORM === "1";
+}
+
+/**
  * Returns deployment-context-aware config defaults that override schema
  * defaults for platform-managed assistants. Applied to every `loadConfig()`
  * call as a fill-only pass — they only fill keys that are absent from the
  * raw config on disk, so an explicit user choice (e.g. saving "your-own"
  * via the macOS Models & Services UI) always wins.
- *
- * IS_PLATFORM is set by the Vellum platform launcher for all hosted
- * assistant deployments. Local, Docker, and bare-metal assistants are
- * unaffected.
  */
 export function getDeploymentContextDefaults(): Record<string, unknown> {
-  if (process.env.IS_PLATFORM !== "true" && process.env.IS_PLATFORM !== "1") {
+  if (!isPlatformDeployment()) {
     return {};
   }
   // `web-search.mode = managed` enables platform-backed app-executed search
@@ -345,6 +359,169 @@ function deleteNestedKey(
   if (current != null && typeof current === "object") {
     delete (current as Record<string, unknown>)[String(path[path.length - 1])];
   }
+}
+
+/**
+ * Merge the code-defined built-in inference profiles into a raw config
+ * object. Mutates `raw` **in memory only** — the result must never be
+ * persisted back to `config.json` (built-in definitions live in code; only
+ * sparse `llm.profileOverrides` entries belong on disk).
+ *
+ * - Template fields (provider/model/maxTokens/…) are always authoritative;
+ *   user-ownable facets are `label` and `status` only.
+ * - `llm.profileOverrides[name]` is the canonical override store.
+ * - **Transition-state compatibility**: while the boot seeder still
+ *   materializes full built-in entries into `config.json` (and for
+ *   pre-migration installs that already carry them, including drifted
+ *   shadow entries the assistant wrote on-platform), the materialized
+ *   entry's `label`/`status` are honored as *lower*-precedence overrides
+ *   (key-presence semantics) and every other field is discarded.
+ * - Built-in names are spliced into `llm.profileOrder` exactly as the
+ *   seeder does (auto prepended if missing, managed names appended if
+ *   missing); flag-disabled built-ins are removed from the in-memory order
+ *   and profile set entirely.
+ * - `llm.activeProfile` falls back to `"balanced"` when unset or naming a
+ *   profile absent from the merged set (matching the seeder's fallback).
+ *   Custom user profiles count as present — an activeProfile naming one is
+ *   left untouched.
+ */
+export function applyBuiltinProfiles(raw: Record<string, unknown>): void {
+  const llm = ensurePlainObjectAt(raw, "llm");
+  const profiles = ensurePlainObjectAt(llm, "profiles");
+  const profileOverrides = readPlainObject(llm.profileOverrides) ?? {};
+
+  const overrides: Record<string, BuiltinProfileOverride> = {};
+  for (const name of MANAGED_PROFILE_NAMES) {
+    const entry: BuiltinProfileOverride = {};
+    // Lower precedence: label/status carried on a still-materialized entry.
+    collectBuiltinOverrideFields(profiles[name], entry);
+    // Higher precedence: the sparse override store.
+    collectBuiltinOverrideFields(profileOverrides[name], entry);
+    if ("label" in entry || "status" in entry) overrides[name] = entry;
+  }
+
+  const merged = resolveBuiltinProfiles({
+    isPlatform: isPlatformDeployment(),
+    isFlagEnabled: (key) => isBuiltinProfileFlagEnabled(key, raw),
+    overrides,
+  });
+
+  // Replace materialized/stale entries with the code-resolved ones; built-ins
+  // whose feature flag is disabled are removed from the profile set entirely.
+  for (const name of MANAGED_PROFILE_NAMES) {
+    const entry = merged.profiles[name];
+    if (entry) {
+      profiles[name] = entry;
+    } else {
+      delete profiles[name];
+    }
+  }
+
+  // Profile ordering, mirroring the seeder: drop flag-disabled built-in
+  // names, prepend `auto` if missing, then append the remaining built-ins
+  // that aren't already present.
+  const rawOrder = Array.isArray(llm.profileOrder) ? llm.profileOrder : [];
+  const order = rawOrder.filter(
+    (name) =>
+      typeof name !== "string" ||
+      !MANAGED_PROFILE_NAMES.has(name) ||
+      merged.profiles[name] !== undefined,
+  );
+  const present = new Set(order);
+  if (!present.has(AUTO_PROFILE_KEY)) order.unshift(AUTO_PROFILE_KEY);
+  for (const name of merged.order) {
+    if (name !== AUTO_PROFILE_KEY && !present.has(name)) order.push(name);
+  }
+  llm.profileOrder = order;
+
+  // Active-profile fallback. Custom user profiles already live in
+  // `profiles`, so an activeProfile naming one is left untouched.
+  const active = llm.activeProfile;
+  if (
+    typeof active !== "string" ||
+    readPlainObject(profiles[active]) === null
+  ) {
+    llm.activeProfile = "balanced";
+  }
+}
+
+/**
+ * Copy `label`/`status` from a raw (untrusted) profile or override entry
+ * into `into`, by key presence, keeping only values of the legal override
+ * shape (`string | null` label, `"active" | "disabled" | null` status).
+ * Malformed values are ignored so a corrupt config can't smuggle arbitrary
+ * data through the merge on the unvalidated `GET /v1/config` path.
+ */
+function collectBuiltinOverrideFields(
+  value: unknown,
+  into: BuiltinProfileOverride,
+): void {
+  const obj = readPlainObject(value);
+  if (!obj) return;
+  if ("label" in obj && (typeof obj.label === "string" || obj.label === null)) {
+    into.label = obj.label;
+  }
+  if (
+    "status" in obj &&
+    (obj.status === "active" ||
+      obj.status === "disabled" ||
+      obj.status === null)
+  ) {
+    into.status = obj.status;
+  }
+}
+
+/**
+ * Resolve a built-in profile's gating feature flag. Wrapped in try/catch so
+ * a flag-resolver failure never breaks config loading; fails *open* (profile
+ * stays visible) because hiding built-ins on a transient resolver error
+ * would be user-visible breakage, whereas the flag's purpose is an explicit
+ * remote kill switch.
+ *
+ * The resolver ignores its config argument (it reads gateway overrides and
+ * the bundled registry only); `raw` is passed for signature compatibility.
+ */
+function isBuiltinProfileFlagEnabled(
+  key: string,
+  raw: Record<string, unknown>,
+): boolean {
+  try {
+    return isAssistantFeatureFlagEnabled(
+      key,
+      raw as unknown as AssistantConfig,
+    );
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Read `parent[key]` as a plain object, creating (and assigning) an empty
+ * one when the current value is absent or not a plain object.
+ */
+function ensurePlainObjectAt(
+  parent: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> {
+  const existing = readPlainObject(parent[key]);
+  if (existing) return existing;
+  const created: Record<string, unknown> = {};
+  parent[key] = created;
+  return created;
+}
+
+/**
+ * Validate a raw config with the code-defined built-in profiles merged in.
+ * The merge happens on a clone so `fileConfig` — which the loader's
+ * disk-write paths (deprecated-field stripping, managed-Gemini migration,
+ * first-launch seed) persist — never carries the injected entries.
+ */
+function validateWithBuiltinProfiles(
+  fileConfig: Record<string, unknown>,
+): AssistantConfig {
+  const merged = structuredClone(fileConfig);
+  applyBuiltinProfiles(merged);
+  return validateWithSchema(merged);
 }
 
 /**
@@ -687,8 +864,12 @@ export function loadConfig(): AssistantConfig {
       warnAndStripDeprecatedFields(fileConfig, configPath);
     }
 
-    // Validate and apply defaults via Zod schema
-    let config = validateWithSchema(fileConfig);
+    // Validate and apply defaults via Zod schema, with the code-defined
+    // built-in inference profiles merged in (on a clone — `fileConfig`
+    // itself stays unmerged because the blocks below persist it to disk).
+    // Merging before the parse lets the schema's cross-checks (activeProfile
+    // and call-site profile references) see the full built-in entries.
+    let config = validateWithBuiltinProfiles(fileConfig);
 
     if (suppressConfigDiskWritesDepth === 0) {
       // Managed Gemini embedding defaults migration.
@@ -698,11 +879,7 @@ export function loadConfig(): AssistantConfig {
       // Idempotent: once provider=gemini is written, subsequent loads skip this.
       if (config.memory.embeddings.provider === "auto") {
         try {
-          if (
-            (process.env.IS_PLATFORM === "true" ||
-              process.env.IS_PLATFORM === "1") &&
-            isManagedGeminiFFEnabled(config)
-          ) {
+          if (isPlatformDeployment() && isManagedGeminiFFEnabled(config)) {
             setNestedValue(fileConfig, "memory.embeddings.provider", "gemini");
             setNestedValue(
               fileConfig,
@@ -723,7 +900,7 @@ export function loadConfig(): AssistantConfig {
               "Applied managed Gemini embedding defaults (provider=gemini, model=gemini-embedding-2, dimensions=3072, vectorSize=3072)",
             );
             // Re-validate so the returned config reflects the migration.
-            config = validateWithSchema(fileConfig);
+            config = validateWithBuiltinProfiles(fileConfig);
           }
         } catch (err) {
           log.warn(
@@ -774,8 +951,20 @@ export function loadConfig(): AssistantConfig {
         if (!existsSync(dir)) {
           mkdirSync(dir, { recursive: true });
         }
+        // Persist plain schema defaults (plus the deployment-context fills
+        // applied above), validated WITHOUT the built-in profile merge — the
+        // in-memory built-in entries are code-resolved on every load and
+        // must never leak into config.json.
+        const persistableConfig = validateWithSchema(fileConfig);
+        if (Object.keys(contextDefaults).length > 0) {
+          fillContextDefaultsForMissingKeys(
+            persistableConfig as unknown as Record<string, unknown>,
+            fileConfig,
+            contextDefaults,
+          );
+        }
         // Strip dataDir (runtime-derived) from the persisted config
-        const { dataDir: _, ...persistable } = config;
+        const { dataDir: _, ...persistable } = persistableConfig;
         writeFileSync(configPath, JSON.stringify(persistable, null, 2) + "\n");
         log.info("Wrote default config to %s", configPath);
       } catch (err) {
@@ -838,7 +1027,7 @@ export function getConfigReadOnly(): AssistantConfig {
     }
   }
 
-  return validateWithSchema(fileConfig);
+  return validateWithBuiltinProfiles(fileConfig);
 }
 
 export function invalidateConfigCache(): void {
@@ -846,6 +1035,13 @@ export function invalidateConfigCache(): void {
   cachedFileSignature = null;
   loading = false;
 }
+
+// The merged built-in profile set depends on feature-flag state, so a flag
+// override refresh must recompute the parsed-config cache without a daemon
+// restart. Registered as a callback (rather than the flags module importing
+// `invalidateConfigCache`) because this module already imports
+// `assistant-feature-flags.js` — a direct import back would form a cycle.
+setOnFeatureFlagOverridesRefreshed(invalidateConfigCache);
 
 export async function withSuppressedConfigDiskWrites<T>(
   fn: () => T | Promise<T>,

--- a/assistant/src/daemon/__tests__/daemon-skill-host.test.ts
+++ b/assistant/src/daemon/__tests__/daemon-skill-host.test.ts
@@ -44,6 +44,7 @@ mock.module("../../config/loader.js", () => ({
 }));
 
 mock.module("../../config/assistant-feature-flags.js", () => ({
+  setOnFeatureFlagOverridesRefreshed: () => {},
   isAssistantFeatureFlagEnabled: (key: string) => key === "enabled-flag",
 }));
 

--- a/assistant/src/ipc/skill-routes/__tests__/config.test.ts
+++ b/assistant/src/ipc/skill-routes/__tests__/config.test.ts
@@ -29,6 +29,7 @@ mock.module("../../../config/loader.js", () => ({
 }));
 
 mock.module("../../../config/assistant-feature-flags.js", () => ({
+  setOnFeatureFlagOverridesRefreshed: () => {},
   isAssistantFeatureFlagEnabled: (key: string) => {
     flagCalls.push(key);
     return mockFlagValues[key] ?? true;

--- a/assistant/src/memory/__tests__/auto-analysis-enqueue.test.ts
+++ b/assistant/src/memory/__tests__/auto-analysis-enqueue.test.ts
@@ -37,6 +37,7 @@ mock.module("../../config/loader.js", () => ({
 }));
 
 mock.module("../../config/assistant-feature-flags.js", () => ({
+  setOnFeatureFlagOverridesRefreshed: () => {},
   isAssistantFeatureFlagEnabled: (_key: string, _config: unknown) =>
     flagEnabled,
 }));

--- a/assistant/src/memory/__tests__/jobs-store-enqueue-gate.test.ts
+++ b/assistant/src/memory/__tests__/jobs-store-enqueue-gate.test.ts
@@ -45,6 +45,7 @@ mock.module("../../config/loader.js", () => ({
 
 // Stub feature flags so auto-analyze isn't gated by an unrelated flag.
 mock.module("../../config/assistant-feature-flags.js", () => ({
+  setOnFeatureFlagOverridesRefreshed: () => {},
   isAssistantFeatureFlagEnabled: () => true,
 }));
 
@@ -117,12 +118,10 @@ mock.module("../db-connection.js", () => ({
 
 // Now load the real modules under test.
 const { isMemoryEnabled } = await import("../jobs-store.js");
-const { enqueueAutoAnalysisIfEnabled } = await import(
-  "../auto-analysis-enqueue.js"
-);
-const { enqueueMemoryRetrospectiveIfEnabled } = await import(
-  "../memory-retrospective-enqueue.js"
-);
+const { enqueueAutoAnalysisIfEnabled } =
+  await import("../auto-analysis-enqueue.js");
+const { enqueueMemoryRetrospectiveIfEnabled } =
+  await import("../memory-retrospective-enqueue.js");
 
 beforeEach(() => {
   dbInserts.length = 0;

--- a/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
+++ b/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
@@ -148,6 +148,7 @@ mock.module("../conversation-crud.js", () => ({
 }));
 
 mock.module("../../config/assistant-feature-flags.js", () => ({
+  setOnFeatureFlagOverridesRefreshed: () => {},
   isAssistantFeatureFlagEnabled: (flag: string) =>
     flag === "memory-retrospective-fork" && forkFlagEnabled,
 }));

--- a/assistant/src/memory/v2/__tests__/consolidation-job.test.ts
+++ b/assistant/src/memory/v2/__tests__/consolidation-job.test.ts
@@ -111,6 +111,7 @@ mock.module("../../jobs-store.js", () => ({
 // follow-up fan-out. This mock lets each test toggle the flag.
 let v3FlagOn = false;
 mock.module("../../../config/assistant-feature-flags.js", () => ({
+  setOnFeatureFlagOverridesRefreshed: () => {},
   isAssistantFeatureFlagEnabled: () => v3FlagOn,
 }));
 

--- a/assistant/src/memory/v2/__tests__/skill-store.test.ts
+++ b/assistant/src/memory/v2/__tests__/skill-store.test.ts
@@ -136,6 +136,7 @@ mock.module("../../../config/skill-state.js", () => ({
 }));
 
 mock.module("../../../config/assistant-feature-flags.js", () => ({
+  setOnFeatureFlagOverridesRefreshed: () => {},
   isAssistantFeatureFlagEnabled: (key: string) =>
     state.flagsEnabled[key] ?? true,
 }));

--- a/assistant/src/permissions/checker.test.ts
+++ b/assistant/src/permissions/checker.test.ts
@@ -33,6 +33,7 @@ mock.module("../config/loader.js", () => ({
 
 // Mock feature flags to return false by default.
 mock.module("../config/assistant-feature-flags.js", () => ({
+  setOnFeatureFlagOverridesRefreshed: () => {},
   isAssistantFeatureFlagEnabled: () => false,
 }));
 

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-plugin.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-plugin.test.ts
@@ -133,6 +133,7 @@ const FAKE_SECTION_INDEX: SectionIndex = {
 // ─── module mocks (installed before the plugin import) ──────────────────────
 
 mock.module("../../../../config/assistant-feature-flags.js", () => ({
+  setOnFeatureFlagOverridesRefreshed: () => {},
   isAssistantFeatureFlagEnabled: (key: string) =>
     key === "memory-v3-live"
       ? liveEnabled

--- a/assistant/src/providers/inference/__tests__/base-url-route-validation.test.ts
+++ b/assistant/src/providers/inference/__tests__/base-url-route-validation.test.ts
@@ -37,6 +37,7 @@ mock.module("../../../memory/db-connection.js", () => ({
 }));
 
 mock.module("../../../config/assistant-feature-flags.js", () => ({
+  setOnFeatureFlagOverridesRefreshed: () => {},
   isAssistantFeatureFlagEnabled: (flag: string) =>
     flag === "openai-compatible-endpoints",
 }));
@@ -104,9 +105,8 @@ mock.module("../../../tools/network/url-safety.js", () => ({
   },
 }));
 
-const { ROUTES } = await import(
-  "../../../runtime/routes/inference-provider-connection-routes.js"
-);
+const { ROUTES } =
+  await import("../../../runtime/routes/inference-provider-connection-routes.js");
 
 const handleCreate = ROUTES.find(
   (r) => r.operationId === "inference_provider_connections_create",

--- a/assistant/src/runtime/routes/__tests__/tts-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/tts-routes.test.ts
@@ -16,6 +16,7 @@ mock.module("../../../util/logger.js", () => ({
 let mockFeatureFlagEnabled = true;
 
 mock.module("../../../config/assistant-feature-flags.js", () => ({
+  setOnFeatureFlagOverridesRefreshed: () => {},
   isAssistantFeatureFlagEnabled: () => mockFeatureFlagEnabled,
 }));
 

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -22,6 +22,7 @@ import { z } from "zod";
 
 import { LlmContextResponseSchema } from "../../api/responses/llm-context-response.js";
 import {
+  applyBuiltinProfiles,
   deepMergeOverwrite,
   fillContextDefaultsForMissingKeys,
   getConfig,
@@ -447,6 +448,11 @@ function readPlainObject(value: unknown): Record<string, unknown> | undefined {
 function handleGetConfig() {
   try {
     const config = applyContextDefaultsToRawConfig(loadRawConfig());
+    // Merge the code-defined built-in profiles into the wire payload (in
+    // memory only — never persisted) so clients reading the raw config
+    // (web manage-profiles modal, pickers) keep seeing the built-ins.
+    const root = readPlainObject(config);
+    if (root) applyBuiltinProfiles(root);
     enrichProfilesWithVisionFlag(config);
     return config;
   } catch (err) {

--- a/assistant/src/runtime/routes/playground/__tests__/force-compact.test.ts
+++ b/assistant/src/runtime/routes/playground/__tests__/force-compact.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, mock, test } from "bun:test";
 let _mockConversation: unknown = undefined;
 
 mock.module("../../../../config/assistant-feature-flags.js", () => ({
+  setOnFeatureFlagOverridesRefreshed: () => {},
   isAssistantFeatureFlagEnabled: () => true,
 }));
 

--- a/assistant/src/runtime/routes/playground/__tests__/guard.test.ts
+++ b/assistant/src/runtime/routes/playground/__tests__/guard.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, mock, test } from "bun:test";
 let _playgroundEnabled = true;
 
 mock.module("../../../../config/assistant-feature-flags.js", () => ({
+  setOnFeatureFlagOverridesRefreshed: () => {},
   isAssistantFeatureFlagEnabled: () => _playgroundEnabled,
 }));
 

--- a/assistant/src/runtime/routes/playground/__tests__/inject-failures.test.ts
+++ b/assistant/src/runtime/routes/playground/__tests__/inject-failures.test.ts
@@ -9,6 +9,7 @@ import type { ServerMessage } from "../../../../daemon/message-protocol.js";
 let _mockConversation: MockConversation | undefined;
 
 mock.module("../../../../config/assistant-feature-flags.js", () => ({
+  setOnFeatureFlagOverridesRefreshed: () => {},
   isAssistantFeatureFlagEnabled: () => true,
 }));
 

--- a/assistant/src/runtime/routes/playground/__tests__/reset-circuit.test.ts
+++ b/assistant/src/runtime/routes/playground/__tests__/reset-circuit.test.ts
@@ -8,6 +8,7 @@ mock.module("../../../../util/logger.js", () => ({
 }));
 
 mock.module("../../../../config/assistant-feature-flags.js", () => ({
+  setOnFeatureFlagOverridesRefreshed: () => {},
   isAssistantFeatureFlagEnabled: () => true,
 }));
 

--- a/assistant/src/runtime/routes/playground/__tests__/seed-conversation.test.ts
+++ b/assistant/src/runtime/routes/playground/__tests__/seed-conversation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, mock, test } from "bun:test";
 
 mock.module("../../../../config/assistant-feature-flags.js", () => ({
+  setOnFeatureFlagOverridesRefreshed: () => {},
   isAssistantFeatureFlagEnabled: () => true,
 }));
 

--- a/assistant/src/runtime/routes/playground/__tests__/seeded-conversations.test.ts
+++ b/assistant/src/runtime/routes/playground/__tests__/seeded-conversations.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, mock, test } from "bun:test";
 
 mock.module("../../../../config/assistant-feature-flags.js", () => ({
+  setOnFeatureFlagOverridesRefreshed: () => {},
   isAssistantFeatureFlagEnabled: () => true,
 }));
 
@@ -27,7 +28,9 @@ mock.module("../helpers.js", () => ({
   },
   deleteConversationById: (id: string) => {
     deleteCalls.push(id);
-    return typeof _deleteReturn === "function" ? _deleteReturn(id) : _deleteReturn;
+    return typeof _deleteReturn === "function"
+      ? _deleteReturn(id)
+      : _deleteReturn;
   },
   createPlaygroundConversation: () => ({ id: "conv-test" }),
   addPlaygroundMessage: async () => ({ id: "msg-test" }),
@@ -68,9 +71,9 @@ describe("GET playground/seeded-conversations", () => {
       },
     ];
 
-    const body = (await findRoute(
-      "playgroundListSeededConversations",
-    ).handler({})) as { conversations: typeof _listRows };
+    const body = (await findRoute("playgroundListSeededConversations").handler(
+      {},
+    )) as { conversations: typeof _listRows };
 
     expect(body.conversations).toEqual(_listRows);
     expect(listCalls).toEqual([PLAYGROUND_TITLE_PREFIX]);
@@ -113,11 +116,11 @@ describe("DELETE playground/seeded-conversations/:id", () => {
       },
     ];
 
-    const body = (await findRoute(
-      "playgroundDeleteSeededConversation",
-    ).handler({
-      pathParams: { id: "conv-seeded" },
-    })) as { deletedCount: number };
+    const body = (await findRoute("playgroundDeleteSeededConversation").handler(
+      {
+        pathParams: { id: "conv-seeded" },
+      },
+    )) as { deletedCount: number };
 
     expect(body.deletedCount).toBe(1);
     expect(deleteCalls).toEqual(["conv-seeded"]);
@@ -135,11 +138,11 @@ describe("DELETE playground/seeded-conversations/:id", () => {
     ];
     _deleteReturn = false;
 
-    const body = (await findRoute(
-      "playgroundDeleteSeededConversation",
-    ).handler({
-      pathParams: { id: "conv-seeded" },
-    })) as { deletedCount: number };
+    const body = (await findRoute("playgroundDeleteSeededConversation").handler(
+      {
+        pathParams: { id: "conv-seeded" },
+      },
+    )) as { deletedCount: number };
 
     expect(body.deletedCount).toBe(0);
     expect(deleteCalls).toEqual(["conv-seeded"]);

--- a/assistant/src/runtime/routes/playground/__tests__/state.test.ts
+++ b/assistant/src/runtime/routes/playground/__tests__/state.test.ts
@@ -15,6 +15,7 @@ mock.module("../../../../config/loader.js", () => ({
 }));
 
 mock.module("../../../../config/assistant-feature-flags.js", () => ({
+  setOnFeatureFlagOverridesRefreshed: () => {},
   isAssistantFeatureFlagEnabled: () => true,
 }));
 


### PR DESCRIPTION
## Summary
- getConfig()/GET /v1/config now merge code-defined built-in profiles into llm.profiles/profileOrder in memory (never persisted)
- Template fields are authoritative; label/status overrides come from llm.profileOverrides (and, lower-precedence, from stale materialized entries during transition)
- activeProfile falls back to balanced when unset/dangling; feature-flag override refresh invalidates the config cache

Part of plan: builtin-llm-profiles.md (PR 3 of 8)