### PR TITLE
fix: remove home-page feature flag gating (GA'ed)

### DIFF
--- a/apps/web/src/domains/chat/chat-layout.tsx
+++ b/apps/web/src/domains/chat/chat-layout.tsx
@@ -45,7 +45,6 @@ import { openPopoutWindow } from "@/runtime/popout-window";
 import { useVellumCommands } from "@/runtime/vellum-commands";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { useAuthStore } from "@/stores/auth-store";
-import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useViewerStore } from "@/stores/viewer-store";
 import type { Conversation } from "@/types/conversation-types";
@@ -127,7 +126,6 @@ export function ChatLayout() {
   // inherits a populated sidebar on direct navigation — not just /assistant.
   // TanStack Query handles dedup with any other consumer using the same key.
   const conversationGroupsUI = useAssistantFeatureFlagStore.use.conversationGroupsUI();
-  const homePageEnabled = useClientFeatureFlagStore.use.homePage();
   const { conversations } = useConversationListQuery(
     assistantId,
     isAssistantActive,
@@ -168,11 +166,8 @@ export function ChatLayout() {
 
 
   // Home page unread indicator — drives the red dot on the Home button in
-  // the layout header. Gated on the homePage feature flag so the hook
-  // doesn't fire its query when the home route is disabled.
-  const { hasUnreadHome } = useHomeUnreadBadge(
-    homePageEnabled ? assistantId : null,
-  );
+  // the layout header.
+  const { hasUnreadHome } = useHomeUnreadBadge(assistantId);
 
   // Mirror the unread count + signed-in flag into the Electron Dock
   // (no-op off Electron). Uses the conversation list this layout


### PR DESCRIPTION
## Summary
- Remove homePage feature flag selector from chat-layout.tsx
- Home unread badge hook now always fires unconditionally

Part of plan: rm-gaed-flags-wave2.md (PR 4 of 5)