### PR TITLE
fix: remove chatgpt-subscription-auth feature flag gating (GA'ed)

### DIFF
--- a/assistant/src/cli/commands/inference-providers.ts
+++ b/assistant/src/cli/commands/inference-providers.ts
@@ -16,8 +16,6 @@
 
 import type { Command } from "commander";
 
-import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
-import { getConfig } from "../../config/loader.js";
 import { cliIpcCall } from "../../ipc/cli-client.js";
 import type { OAuth2Config } from "../../security/oauth2.js";
 import { startOAuth2Flow } from "../../security/oauth2.js";
@@ -343,12 +341,6 @@ function attachLoginChatgptSubcommand(providers: Command): void {
     .description("Authenticate with ChatGPT via browser OAuth flow")
     .option("--json", "Output as JSON")
     .action(async (opts: { json?: boolean }) => {
-      const config = getConfig();
-      if (!isAssistantFeatureFlagEnabled("chatgpt-subscription-auth", config)) {
-        writeCliError("This feature is not yet available", opts.json);
-        return;
-      }
-
       try {
         // Step 1: Run browser-based PKCE OAuth flow
         process.stdout.write("Opening browser for ChatGPT authentication...\n");

--- a/assistant/src/runtime/routes/chatgpt-subscription-auth-routes.ts
+++ b/assistant/src/runtime/routes/chatgpt-subscription-auth-routes.ts
@@ -11,8 +11,6 @@
 
 import { z } from "zod";
 
-import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
-import { getConfigReadOnly } from "../../config/loader.js";
 import { getDb } from "../../memory/db-connection.js";
 import {
   createConnection,
@@ -29,17 +27,7 @@ import {
 import { setSecureKeyAsync } from "../../security/secure-keys.js";
 import { getLogger } from "../../util/logger.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
-import { BadRequestError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
-
-function requireFeatureFlag() {
-  const config = getConfigReadOnly();
-  if (!isAssistantFeatureFlagEnabled("chatgpt-subscription-auth", config)) {
-    throw new BadRequestError(
-      "ChatGPT subscription auth is not enabled for this assistant.",
-    );
-  }
-}
 
 const log = getLogger("chatgpt-subscription-auth");
 
@@ -87,7 +75,6 @@ function cleanupExpiredEntries(): void {
 // ---------------------------------------------------------------------------
 
 async function handleStartAuth(_args: RouteHandlerArgs) {
-  requireFeatureFlag();
   cleanupExpiredEntries();
 
   const codeVerifier = generateCodeVerifier();
@@ -115,7 +102,6 @@ async function handleStartAuth(_args: RouteHandlerArgs) {
 }
 
 async function handleExchange(args: RouteHandlerArgs) {
-  requireFeatureFlag();
   const { code, state } = args.body as { code: string; state: string };
 
   const pending = pendingAuths.get(state);

--- a/clients/macos/vellum-assistant/Features/Settings/ProvidersSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ProvidersSheet.swift
@@ -59,9 +59,7 @@ struct ProvidersSheet: View {
     /// mode (new connection) or editing an existing oauth_subscription
     /// connection (so the user can re-authenticate if needed).
     private var isChatgptSubscriptionVisible: Bool {
-        guard let flagStore = assistantFeatureFlagStore,
-              flagStore.isEnabled("chatgpt-subscription-auth"),
-              editorDraft.provider == "openai" else {
+        guard editorDraft.provider == "openai" else {
             return false
         }
         switch editorState {
@@ -558,13 +556,7 @@ struct ProvidersSheet: View {
         if store.isPlatformCapable(provider) {
             options.append((label: "Platform (managed by Vellum)", value: "platform"))
         }
-        // Offer ChatGPT Subscription when the feature flag is on and
-        // the provider is OpenAI. In create mode this lets the user
-        // pick the OAuth flow; in edit mode the fallback below handles
-        // connections that already carry this auth type.
-        if provider == "openai",
-           let flagStore = assistantFeatureFlagStore,
-           flagStore.isEnabled("chatgpt-subscription-auth") {
+        if provider == "openai" {
             options.append((label: "ChatGPT Subscription", value: "oauth_subscription"))
         }
         // Preserve the current auth type in edit mode so existing connections


### PR DESCRIPTION
## Summary
- Remove requireFeatureFlag() from chatgpt-subscription-auth-routes.ts — routes serve unconditionally
- Remove flag check from login-chatgpt CLI command
- Remove flag checks from ProvidersSheet.swift — ChatGPT Subscription always available for OpenAI

Part of plan: rm-gaed-flags-wave2.md (PR 1 of 5)