### PR TITLE
fix: remove openai-compatible-endpoints flag gating from daemon (GA'ed)

### DIFF
--- a/assistant/src/__tests__/provider-catalog-visibility.test.ts
+++ b/assistant/src/__tests__/provider-catalog-visibility.test.ts
@@ -19,16 +19,8 @@ function makeConfig(): AssistantConfig {
 }
 
 describe("getVisibleProviderCatalog", () => {
-  test("hides openai-compatible endpoints by default", () => {
+  test("shows openai-compatible endpoints unconditionally (GA'ed)", () => {
     setOverridesForTesting({});
-
-    const visible = getVisibleProviderCatalog(makeConfig());
-
-    expect(visible.find((p) => p.id === "openai-compatible")).toBeUndefined();
-  });
-
-  test("shows openai-compatible endpoints when its flag is enabled", () => {
-    setOverridesForTesting({ "openai-compatible-endpoints": true });
 
     const visible = getVisibleProviderCatalog(makeConfig());
 

--- a/assistant/src/providers/inference/__tests__/base-url-route-validation.test.ts
+++ b/assistant/src/providers/inference/__tests__/base-url-route-validation.test.ts
@@ -37,8 +37,7 @@ mock.module("../../../memory/db-connection.js", () => ({
 }));
 
 mock.module("../../../config/assistant-feature-flags.js", () => ({
-  isAssistantFeatureFlagEnabled: (flag: string) =>
-    flag === "openai-compatible-endpoints",
+  isAssistantFeatureFlagEnabled: () => false,
 }));
 
 mock.module("../../../config/loader.js", () => ({

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -1212,7 +1212,6 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
     setupHint:
       "Enter the base URL of your endpoint and at least one model identifier.",
     apiKeyPlaceholder: "Your provider's API key",
-    featureFlag: "openai-compatible-endpoints",
     models: [],
     defaultModel: "",
   },

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -28,7 +28,6 @@ const log = getLogger("provider-registry");
 
 const providers = new Map<string, Provider>();
 const routingSources = new Map<string, "user-key" | "managed-proxy">();
-const OPENAI_COMPATIBLE_ENDPOINTS_FLAG = "openai-compatible-endpoints";
 const NATIVE_WEB_SEARCH_PROVIDER_IDS = new Set(["anthropic", "openai"]);
 
 /** Per-connection provider cache, keyed by connection name and model. */
@@ -258,13 +257,6 @@ export async function resolveProviderFromConnection(
   config: ProvidersConfig,
   opts: { model?: string } = {},
 ): Promise<Provider | null> {
-  if (
-    connection.provider === "openai-compatible" &&
-    !isProviderFeatureFlagEnabled(OPENAI_COMPATIBLE_ENDPOINTS_FLAG, config)
-  ) {
-    return null;
-  }
-
   const model = opts.model ?? resolveModel(config, connection.provider);
   const cacheKey = getConnectionProviderCacheKey(connection, model);
   const cached = connectionProviders.get(cacheKey);

--- a/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
@@ -29,7 +29,6 @@ mock.module("../../../util/logger.js", () => ({
 
 // ── Real imports (after mocks) ────────────────────────────────────────────────
 
-import { setOverridesForTesting } from "../../../__tests__/feature-flag-test-helpers.js";
 import { getDb } from "../../../memory/db-connection.js";
 import { initializeDb } from "../../../memory/db-init.js";
 import { providerConnections } from "../../../memory/schema/inference.js";
@@ -91,7 +90,6 @@ function seedConnection(opts: {
 beforeEach(() => {
   clearConnections();
   fakeConfig = {};
-  setOverridesForTesting({ "openai-compatible-endpoints": true });
 });
 
 // ── GET list ─────────────────────────────────────────────────────────────────
@@ -160,36 +158,6 @@ describe("GET inference/provider-connections (list)", () => {
     expect(result.connections).toEqual([]);
   });
 
-  test("hides openai-compatible rows when the feature flag is disabled", async () => {
-    setOverridesForTesting({ "openai-compatible-endpoints": false });
-    seedConnection({
-      name: "my-openai",
-      provider: "openai",
-      auth: { type: "platform" },
-    });
-    seedConnection({
-      name: "my-compatible",
-      provider: "openai-compatible",
-      auth: { type: "api_key", credential: "ref/k" },
-    });
-
-    const result = (await call(
-      findHandler("inference_provider_connections_list"),
-      {},
-    )) as { connections: Array<{ name: string }> };
-
-    expect(result.connections.map((c) => c.name)).toEqual(["my-openai"]);
-  });
-
-  test("rejects openai-compatible provider filter when the feature flag is disabled", async () => {
-    setOverridesForTesting({ "openai-compatible-endpoints": false });
-
-    await expect(
-      call(findHandler("inference_provider_connections_list"), {
-        queryParams: { provider: "openai-compatible" },
-      }),
-    ).rejects.toBeInstanceOf(BadRequestError);
-  });
 });
 
 // ── GET single ────────────────────────────────────────────────────────────────
@@ -219,20 +187,6 @@ describe("GET inference/provider-connections/:name (single)", () => {
     ).rejects.toBeInstanceOf(NotFoundError);
   });
 
-  test("throws 404 for openai-compatible row when the feature flag is disabled", async () => {
-    setOverridesForTesting({ "openai-compatible-endpoints": false });
-    seedConnection({
-      name: "my-compatible",
-      provider: "openai-compatible",
-      auth: { type: "api_key", credential: "ref/k" },
-    });
-
-    await expect(
-      call(findHandler("inference_provider_connections_get"), {
-        pathParams: { name: "my-compatible" },
-      }),
-    ).rejects.toBeInstanceOf(NotFoundError);
-  });
 });
 
 // ── POST create ───────────────────────────────────────────────────────────────
@@ -312,22 +266,6 @@ describe("POST inference/provider-connections (create)", () => {
           name: "test",
           provider: "bogus-provider",
           auth: { type: "platform" },
-        },
-      }),
-    ).rejects.toBeInstanceOf(BadRequestError);
-  });
-
-  test("rejects openai-compatible creation when the feature flag is disabled", async () => {
-    setOverridesForTesting({ "openai-compatible-endpoints": false });
-
-    await expect(
-      call(findHandler("inference_provider_connections_create"), {
-        body: {
-          name: "my-compatible",
-          provider: "openai-compatible",
-          auth: { type: "api_key", credential: "ref/k" },
-          base_url: "http://localhost:8080/v1",
-          models: [{ id: "local-model" }],
         },
       }),
     ).rejects.toBeInstanceOf(BadRequestError);

--- a/assistant/src/runtime/routes/inference-provider-connection-routes.ts
+++ b/assistant/src/runtime/routes/inference-provider-connection-routes.ts
@@ -10,7 +10,6 @@
 
 import { z } from "zod";
 
-import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import { getConfigReadOnly } from "../../config/loader.js";
 import { getDb } from "../../memory/db-connection.js";
 import {
@@ -44,22 +43,6 @@ import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 // ---------------------------------------------------------------------------
 
 const providerConnectionResponseSchema = ProviderConnectionSchema;
-const OPENAI_COMPATIBLE_ENDPOINTS_FLAG = "openai-compatible-endpoints";
-
-function openAICompatibleEndpointsEnabled(): boolean {
-  return isAssistantFeatureFlagEnabled(
-    OPENAI_COMPATIBLE_ENDPOINTS_FLAG,
-    getConfigReadOnly(),
-  );
-}
-
-function rejectDisabledOpenAICompatibleProvider(provider: string): void {
-  if (provider !== "openai-compatible") return;
-  if (openAICompatibleEndpointsEnabled()) return;
-  throw new BadRequestError(
-    "OpenAI-compatible endpoints are disabled. Enable the openai-compatible-endpoints feature flag to configure this provider.",
-  );
-}
 
 // ---------------------------------------------------------------------------
 // Custom provider field parsing (openai-compatible base_url + models)
@@ -170,18 +153,10 @@ async function parseCustomProviderFields(
 
 function handleListConnections({ queryParams = {} }: RouteHandlerArgs) {
   const provider = queryParams.provider;
-  if (provider) rejectDisabledOpenAICompatibleProvider(provider);
   const connections = listConnections(
     getDb(),
     provider ? { provider } : undefined,
   );
-  if (!openAICompatibleEndpointsEnabled()) {
-    return {
-      connections: connections.filter(
-        (conn) => conn.provider !== "openai-compatible",
-      ),
-    };
-  }
   return { connections };
 }
 
@@ -191,12 +166,6 @@ function handleGetConnection({ pathParams = {} }: RouteHandlerArgs) {
 
   const conn = getConnection(getDb(), name);
   if (!conn) throw new NotFoundError(`Connection "${name}" not found.`);
-  if (
-    conn.provider === "openai-compatible" &&
-    !openAICompatibleEndpointsEnabled()
-  ) {
-    throw new NotFoundError(`Connection "${name}" not found.`);
-  }
 
   return conn;
 }
@@ -216,8 +185,6 @@ async function handleCreateConnection({ body = {} }: RouteHandlerArgs) {
       `Invalid provider "${String(provider)}". Valid: ${VALID_CONNECTION_PROVIDERS.join(", ")}`,
     );
   }
-  rejectDisabledOpenAICompatibleProvider(providerResult.data);
-
   const authResult = AuthSchema.safeParse(auth);
   if (!authResult.success) {
     throw new BadRequestError(`Invalid auth: ${authResult.error.message}`);
@@ -280,12 +247,6 @@ async function handleUpdateConnection({
 
   const existing = getConnection(getDb(), name);
   if (!existing) throw new NotFoundError(`Connection "${name}" not found.`);
-  if (
-    existing.provider === "openai-compatible" &&
-    !openAICompatibleEndpointsEnabled()
-  ) {
-    throw new NotFoundError(`Connection "${name}" not found.`);
-  }
 
   const auth = body.auth;
   const authResult = AuthSchema.safeParse(auth);
@@ -353,12 +314,6 @@ function handleDeleteConnection({ pathParams = {} }: RouteHandlerArgs) {
   // reference to a missing connection returns 404 (not 409).
   const existing = getConnection(getDb(), name);
   if (!existing) {
-    throw new NotFoundError(`Connection "${name}" not found.`);
-  }
-  if (
-    existing.provider === "openai-compatible" &&
-    !openAICompatibleEndpointsEnabled()
-  ) {
     throw new NotFoundError(`Connection "${name}" not found.`);
   }
 


### PR DESCRIPTION
## Summary
- Remove featureFlag field from openai-compatible model catalog entry
- Remove OPENAI_COMPATIBLE_ENDPOINTS_FLAG and guard functions from registry.ts and connection routes
- Update tests to remove flag mocking and flag-off test cases

Part of plan: rm-gaed-flags-wave2.md (PR 2 of 5)