### PR TITLE
feat(telemetry): attribute skill-triggered tool calls with skill_id

### DIFF
--- a/assistant/src/__tests__/conversation-tool-setup-skill-attribution.test.ts
+++ b/assistant/src/__tests__/conversation-tool-setup-skill-attribution.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tests for skill attribution in the skill_execute interception of
+ * createToolExecutor (conversation-tool-setup.ts): skill-routed dispatches
+ * must carry the owning skill's id on the ToolContext handed to the
+ * executor, while direct tool calls must not.
+ */
+
+import { afterAll, describe, expect, mock, test } from "bun:test";
+
+import type { ToolSetupContext } from "../daemon/conversation-tool-setup.js";
+import type { SurfaceData, SurfaceType } from "../daemon/message-protocol.js";
+import type { PermissionPrompter } from "../permissions/prompter.js";
+import type { SecretPrompter } from "../permissions/secret-prompter.js";
+import { RiskLevel } from "../permissions/types.js";
+import type { ToolExecutor } from "../tools/executor.js";
+import type { Tool, ToolContext, ToolExecutionResult } from "../tools/types.js";
+
+mock.module("../runtime/assistant-event-hub.js", () => ({
+  broadcastMessage: mock(() => {}),
+}));
+
+mock.module("../daemon/conversation-surfaces.js", () => ({
+  refreshSurfacesForApp: mock(() => {}),
+  surfaceProxyResolver: mock(() =>
+    Promise.resolve({ content: "", isError: false }),
+  ),
+}));
+
+mock.module("../services/published-app-updater.js", () => ({
+  updatePublishedAppDeployment: mock(() => Promise.resolve()),
+}));
+
+mock.module("../tools/browser/browser-screencast.js", () => ({
+  registerConversationSender: mock(() => {}),
+}));
+
+mock.module("../memory/app-store.js", () => ({
+  getApp: mock(() => null),
+  getAppDirPath: mock(() => "/tmp/test-apps/dummy"),
+  isMultifileApp: mock(() => false),
+  getAppsDir: mock(() => "/tmp/test-apps"),
+  resolveAppIdByDirName: mock(() => null),
+  resolveAppIdFromPath: mock(() => null),
+}));
+
+import { createToolExecutor } from "../daemon/conversation-tool-setup.js";
+import { registerSkillTools, unregisterSkillTools } from "../tools/registry.js";
+
+const SKILL_ID = "attribution-test-skill";
+const SKILL_TOOL_NAME = "attribution_test_tool";
+
+const skillTool: Tool = {
+  name: SKILL_TOOL_NAME,
+  description: "skill tool for attribution tests",
+  category: "skill",
+  defaultRiskLevel: RiskLevel.Low,
+  executionTarget: "sandbox",
+  input_schema: { type: "object", properties: {} },
+  execute: async () => ({ content: "ok", isError: false }),
+};
+
+registerSkillTools(SKILL_ID, [skillTool]);
+afterAll(() => unregisterSkillTools(SKILL_ID));
+
+function makeCtx(): ToolSetupContext {
+  return {
+    conversationId: "conv-test",
+    currentRequestId: "req-1",
+    workingDir: "/tmp/test",
+    abortController: null,
+    traceEmitter: { emit: () => {} },
+    sendToClient: mock(() => {}),
+    pendingSurfaceActions: new Map(),
+    lastSurfaceAction: new Map(),
+    surfaceState: new Map<
+      string,
+      { surfaceType: SurfaceType; data: SurfaceData; title?: string }
+    >(),
+    surfaceUndoStacks: new Map(),
+    accumulatedSurfaceState: new Map(),
+    surfaceActionRequestIds: new Set<string>(),
+    currentTurnSurfaces: [],
+    isProcessing: () => false,
+    enqueueMessage: () => ({ queued: false, requestId: "r" }),
+    getQueueDepth: () => 0,
+    processMessage: async () => "",
+    withSurface: async <T>(_id: string, fn: () => T | Promise<T>) => fn(),
+  };
+}
+
+/** Fake ToolExecutor that captures the context of each execute() call. */
+function makeCapturingExecutor() {
+  const calls: Array<{ name: string; context: ToolContext }> = [];
+  const executor = {
+    execute: async (
+      name: string,
+      _input: Record<string, unknown>,
+      context: ToolContext,
+    ): Promise<ToolExecutionResult> => {
+      calls.push({ name, context });
+      return { content: "ok", isError: false };
+    },
+  };
+  return { executor: executor as unknown as ToolExecutor, calls };
+}
+
+const noopPrompter = {
+  prompt: mock(async () => ({ decision: "allow" as const })),
+} as unknown as PermissionPrompter;
+const noopSecretPrompter = {
+  prompt: mock(async () => ({ cancelled: true })),
+} as unknown as SecretPrompter;
+
+function makeToolFn(executor: ToolExecutor) {
+  return createToolExecutor(
+    executor,
+    noopPrompter,
+    noopSecretPrompter,
+    makeCtx(),
+    () => {},
+  );
+}
+
+describe("conversation-tool-setup skill attribution", () => {
+  test("skill_execute dispatch sets the owning skill id on the executor context", async () => {
+    const { executor, calls } = makeCapturingExecutor();
+    const toolFn = makeToolFn(executor);
+
+    const result = await toolFn("skill_execute", {
+      tool: SKILL_TOOL_NAME,
+      input: {},
+      activity: "testing",
+    });
+
+    expect(result).toMatchObject({ content: "ok", isError: false });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].name).toBe(SKILL_TOOL_NAME);
+    expect(calls[0].context.skillId).toBe(SKILL_ID);
+  });
+
+  test("skill_execute with a non-skill-owned tool leaves skillId unset", async () => {
+    const { executor, calls } = makeCapturingExecutor();
+    const toolFn = makeToolFn(executor);
+
+    await toolFn("skill_execute", {
+      tool: "file_read",
+      input: { path: "/tmp/a" },
+      activity: "testing",
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].name).toBe("file_read");
+    expect(calls[0].context.skillId).toBeUndefined();
+  });
+
+  test("direct tool calls leave skillId unset", async () => {
+    const { executor, calls } = makeCapturingExecutor();
+    const toolFn = makeToolFn(executor);
+
+    await toolFn("file_read", { path: "/tmp/a" });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].name).toBe("file_read");
+    expect(calls[0].context.skillId).toBeUndefined();
+  });
+});

--- a/assistant/src/__tests__/tool-audit-listener.test.ts
+++ b/assistant/src/__tests__/tool-audit-listener.test.ts
@@ -28,6 +28,56 @@ describe("tool audit listener", () => {
     expect(records[0].decision).toBe("allow");
     expect(records[0].riskLevel).toBe("low");
     expect(records[0].durationMs).toBe(12);
+    expect(records[0].skillId).toBeNull();
+  });
+
+  test("records the triggering skill id on terminal events", () => {
+    const records: ToolInvocationRecord[] = [];
+    const listener = createToolAuditListener((record) => records.push(record));
+
+    listener({
+      type: "executed",
+      toolName: "task_create",
+      input: { title: "t" },
+      workingDir: "/tmp",
+      conversationId: "conv-skill",
+      skillId: "tasks-skill",
+      riskLevel: "low",
+      decision: "allow",
+      durationMs: 4,
+      result: { content: "ok", isError: false },
+    });
+    listener({
+      type: "error",
+      toolName: "task_create",
+      input: { title: "t" },
+      workingDir: "/tmp",
+      conversationId: "conv-skill",
+      skillId: "tasks-skill",
+      riskLevel: "low",
+      decision: "error",
+      durationMs: 6,
+      errorMessage: "boom",
+      isExpected: false,
+      errorCategory: "tool_failure",
+    });
+    listener({
+      type: "permission_denied",
+      toolName: "task_create",
+      input: { title: "t" },
+      workingDir: "/tmp",
+      conversationId: "conv-skill",
+      skillId: "tasks-skill",
+      riskLevel: "high",
+      decision: "deny",
+      reason: "Permission denied by user",
+      durationMs: 8,
+    });
+
+    expect(records).toHaveLength(3);
+    for (const record of records) {
+      expect(record.skillId).toBe("tasks-skill");
+    }
   });
 
   test("records deny events with expected normalized results", () => {
@@ -152,5 +202,6 @@ describe("tool audit listener", () => {
     expect(records).toHaveLength(1);
     expect(records[0].result).toBe("error: boom");
     expect(records[0].decision).toBe("error");
+    expect(records[0].skillId).toBeNull();
   });
 });

--- a/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
+++ b/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
@@ -515,6 +515,77 @@ describe("ToolExecutor lifecycle events", () => {
     expect(executed.executionTarget).toBe("sandbox");
   });
 
+  test("stamps context.skillId on lifecycle events for skill-routed calls", async () => {
+    const events: ToolLifecycleEvent[] = [];
+    const executor = new ToolExecutor(makePrompter());
+
+    await executor.execute(
+      "skill_sandbox_tool",
+      { query: "test" },
+      makeContext(events, { skillId: "test-skill" }),
+    );
+
+    expect(events.map((event) => event.type)).toEqual(["start", "executed"]);
+    for (const event of events) {
+      expect(event.skillId).toBe("test-skill");
+    }
+  });
+
+  test("stamps context.skillId on error events", async () => {
+    toolThrow = new Error("boom");
+
+    const events: ToolLifecycleEvent[] = [];
+    const executor = new ToolExecutor(makePrompter());
+
+    await executor.execute(
+      "skill_sandbox_tool",
+      { query: "test" },
+      makeContext(events, { skillId: "test-skill" }),
+    );
+
+    const errorEvent = events.find((event) => event.type === "error");
+    expect(errorEvent?.skillId).toBe("test-skill");
+  });
+
+  test("stamps context.skillId on permission_denied events", async () => {
+    checkerDecision = "prompt";
+    checkerRisk = "medium";
+    promptDecision = "deny";
+
+    const events: ToolLifecycleEvent[] = [];
+    const executor = new ToolExecutor(makePrompter());
+
+    await executor.execute(
+      "bash",
+      { command: "ls -la" },
+      makeContext(events, {
+        skillId: "test-skill",
+        forcePromptSideEffects: true,
+      }),
+    );
+
+    const deniedEvent = events.find(
+      (event) => event.type === "permission_denied",
+    );
+    expect(deniedEvent?.skillId).toBe("test-skill");
+  });
+
+  test("leaves skillId unset on lifecycle events for direct tool calls", async () => {
+    const events: ToolLifecycleEvent[] = [];
+    const executor = new ToolExecutor(makePrompter());
+
+    await executor.execute(
+      "file_read",
+      { path: "README.md" },
+      makeContext(events),
+    );
+
+    expect(events.map((event) => event.type)).toEqual(["start", "executed"]);
+    for (const event of events) {
+      expect(event.skillId).toBeUndefined();
+    }
+  });
+
   test("skill tool with sandbox execution_target resolves to sandbox executionTarget", async () => {
     const events: ToolLifecycleEvent[] = [];
     const executor = new ToolExecutor(makePrompter());

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -20,7 +20,7 @@ import type { Message, ToolDefinition } from "../providers/types.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import { registerConversationSender } from "../tools/browser/browser-screencast.js";
 import type { ToolExecutor } from "../tools/executor.js";
-import { getMcpToolDefinitions } from "../tools/registry.js";
+import { getMcpToolDefinitions, getToolOwner } from "../tools/registry.js";
 import {
   ACTIVITY_SKIP_SET,
   injectActivityField,
@@ -234,6 +234,14 @@ export function createToolExecutor(
             'Error: skill_execute requires a "tool" parameter with the tool name',
           isError: true,
         };
+      }
+
+      // Attribute the invocation to the skill that owns the dispatched tool
+      // so lifecycle events (and the tool_invocations audit row) carry the
+      // triggering skill id.
+      const owner = getToolOwner(toolName);
+      if (owner?.kind === "skill") {
+        toolContext.skillId = owner.id;
       }
 
       const result = await executor.execute(toolName, toolInput, toolContext);

--- a/assistant/src/events/tool-audit-listener.ts
+++ b/assistant/src/events/tool-audit-listener.ts
@@ -41,10 +41,14 @@ function toInvocationRecord(
         conversationId: event.conversationId,
         toolName: event.toolName,
         input: stringifyInput(event.input),
-        result: redactSecrets(event.result.content).slice(0, RESULT_PREVIEW_LIMIT),
+        result: redactSecrets(event.result.content).slice(
+          0,
+          RESULT_PREVIEW_LIMIT,
+        ),
         decision: event.decision,
         riskLevel: event.riskLevel,
         matchedTrustRuleId: event.matchedTrustRuleId,
+        skillId: event.skillId ?? null,
         durationMs: event.durationMs,
       };
     case "error":
@@ -56,6 +60,7 @@ function toInvocationRecord(
         decision: "error",
         riskLevel: event.riskLevel,
         matchedTrustRuleId: event.matchedTrustRuleId,
+        skillId: event.skillId ?? null,
         durationMs: event.durationMs,
       };
     case "permission_denied":
@@ -67,6 +72,7 @@ function toInvocationRecord(
         decision: "denied",
         riskLevel: event.riskLevel,
         matchedTrustRuleId: event.matchedTrustRuleId,
+        skillId: event.skillId ?? null,
         durationMs: event.durationMs,
       };
     case "start":

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -202,6 +202,7 @@ import {
   migrateStripPlaceholderSentinelsFromMessages,
   migrateStripThinkingFromConsolidated,
   migrateToolInvocationsMatchedRuleId,
+  migrateToolInvocationsSkillId,
   migrateTraceEventsCreatedAtIndex,
   migrateUsageDashboardIndexes,
   migrateUsageLlmCallCount,
@@ -484,6 +485,7 @@ export function initializeDb(): void {
     migrateAcpSessionHistoryCwd,
     migrateOnboardingEventsFunnelColumns,
     createActivationSessionsTable,
+    migrateToolInvocationsSkillId,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/275-tool-invocations-add-skill-id.test.ts
+++ b/assistant/src/memory/migrations/275-tool-invocations-add-skill-id.test.ts
@@ -1,0 +1,81 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import * as schema from "../schema.js";
+import { migrateToolInvocationsSkillId } from "./275-tool-invocations-add-skill-id.js";
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  // Pre-275 shape: no skill_id column.
+  sqlite.exec(/*sql*/ `
+    CREATE TABLE tool_invocations (
+      id TEXT PRIMARY KEY,
+      conversation_id TEXT NOT NULL,
+      tool_name TEXT NOT NULL,
+      input TEXT NOT NULL,
+      result TEXT NOT NULL,
+      decision TEXT NOT NULL,
+      risk_level TEXT NOT NULL,
+      matched_trust_rule_id TEXT,
+      duration_ms INTEGER NOT NULL,
+      created_at INTEGER NOT NULL
+    )
+  `);
+  return { sqlite, db: drizzle(sqlite, { schema }) };
+}
+
+function columnNames(sqlite: Database): string[] {
+  return (
+    sqlite.query("PRAGMA table_info(tool_invocations)").all() as Array<{
+      name: string;
+    }>
+  ).map((c) => c.name);
+}
+
+describe("migration 275: tool_invocations skill_id", () => {
+  test("adds a nullable skill_id column", () => {
+    const { sqlite, db } = createTestDb();
+    expect(columnNames(sqlite)).not.toContain("skill_id");
+
+    migrateToolInvocationsSkillId(db);
+
+    const column = (
+      sqlite.query("PRAGMA table_info(tool_invocations)").all() as Array<{
+        name: string;
+        notnull: number;
+      }>
+    ).find((c) => c.name === "skill_id");
+    expect(column).toBeDefined();
+    expect(column?.notnull).toBe(0);
+  });
+
+  test("existing rows read back with skill_id null", () => {
+    const { sqlite, db } = createTestDb();
+    sqlite.exec(/*sql*/ `
+      INSERT INTO tool_invocations
+        (id, conversation_id, tool_name, input, result, decision, risk_level, duration_ms, created_at)
+      VALUES
+        ('ti-1', 'conv-1', 'bash', '{}', 'ok', 'allow', 'low', 5, 1000)
+    `);
+
+    migrateToolInvocationsSkillId(db);
+
+    const row = sqlite
+      .query("SELECT skill_id FROM tool_invocations WHERE id = 'ti-1'")
+      .get() as { skill_id: string | null };
+    expect(row.skill_id).toBeNull();
+  });
+
+  test("is idempotent — re-run is a no-op", () => {
+    const { sqlite, db } = createTestDb();
+
+    migrateToolInvocationsSkillId(db);
+    expect(() => migrateToolInvocationsSkillId(db)).not.toThrow();
+
+    expect(
+      columnNames(sqlite).filter((name) => name === "skill_id"),
+    ).toHaveLength(1);
+  });
+});

--- a/assistant/src/memory/migrations/275-tool-invocations-add-skill-id.ts
+++ b/assistant/src/memory/migrations/275-tool-invocations-add-skill-id.ts
@@ -1,0 +1,20 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { tableHasColumn } from "./schema-introspection.js";
+
+/**
+ * Add a nullable `skill_id` column to `tool_invocations`.
+ *
+ * Records which skill's `skill_execute` dispatch triggered the tool call so
+ * the `tool_execution` telemetry event can attribute skill-routed
+ * invocations. `NULL` for direct (non-skill) tool calls and for rows
+ * persisted before this migration ran.
+ *
+ * Idempotent — re-running is a no-op once the column exists. Pure DDL with a
+ * PRAGMA guard, no registry entry needed (matches the 236 / 273 pattern).
+ */
+export function migrateToolInvocationsSkillId(database: DrizzleDb): void {
+  if (tableHasColumn(database, "tool_invocations", "skill_id")) {
+    return;
+  }
+  database.run(`ALTER TABLE tool_invocations ADD COLUMN skill_id TEXT`);
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -262,6 +262,7 @@ export { createAuthFallbackEventsTable } from "./271-create-auth-fallback-events
 export { migrateAcpSessionHistoryCwd } from "./272-acp-session-history-cwd.js";
 export { migrateOnboardingEventsFunnelColumns } from "./273-onboarding-events-funnel-columns.js";
 export { createActivationSessionsTable } from "./274-create-activation-sessions.js";
+export { migrateToolInvocationsSkillId } from "./275-tool-invocations-add-skill-id.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/conversations.ts
+++ b/assistant/src/memory/schema/conversations.ts
@@ -91,6 +91,8 @@ export const toolInvocations = sqliteTable(
     decision: text("decision").notNull(),
     riskLevel: text("risk_level").notNull(),
     matchedTrustRuleId: text("matched_trust_rule_id"),
+    /** Id of the skill whose `skill_execute` dispatch triggered this tool call. Null for direct tool calls. */
+    skillId: text("skill_id"),
     durationMs: integer("duration_ms").notNull(),
     createdAt: integer("created_at").notNull(),
   },

--- a/assistant/src/memory/tool-execution-events-store.test.ts
+++ b/assistant/src/memory/tool-execution-events-store.test.ts
@@ -7,6 +7,7 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
+import { createToolAuditListener } from "../events/tool-audit-listener.js";
 import { getDb } from "./db-connection.js";
 import { initializeDb } from "./db-init.js";
 import { conversations, toolInvocations } from "./schema.js";
@@ -20,6 +21,7 @@ interface InsertSpec {
   id: string;
   createdAt: number;
   toolName?: string;
+  skillId?: string | null;
   decision?: string;
   riskLevel?: string;
   durationMs?: number;
@@ -36,6 +38,7 @@ function insertInvocation(spec: InsertSpec): void {
       result: '{"secret":"raw tool output — must never leave the device"}',
       decision: spec.decision ?? "allow",
       riskLevel: spec.riskLevel ?? "low",
+      skillId: spec.skillId ?? null,
       durationMs: spec.durationMs ?? 12,
       createdAt: spec.createdAt,
     })
@@ -58,11 +61,12 @@ describe("tool-execution-events-store", () => {
       .run();
   });
 
-  test("returns rows in (createdAt, id) order with projected fields and null skillId", () => {
+  test("returns rows in (createdAt, id) order with projected fields", () => {
     insertInvocation({
       id: "ti-b",
       createdAt: 2000,
       toolName: "web_search",
+      skillId: "research-skill",
       decision: "denied",
       riskLevel: "high",
       durationMs: 7,
@@ -83,7 +87,7 @@ describe("tool-execution-events-store", () => {
     });
     expect(rows[1]).toMatchObject({
       toolName: "web_search",
-      skillId: null,
+      skillId: "research-skill",
       decision: "denied",
       riskLevel: "high",
       durationMs: 7,
@@ -123,6 +127,43 @@ describe("tool-execution-events-store", () => {
     expect(
       queryUnreportedToolExecutionEvents(last.createdAt, last.id, 100).length,
     ).toBe(0);
+  });
+
+  test("skill-routed lifecycle events persist skill_id end to end; direct calls stay null", () => {
+    // Default recorder = recordToolInvocation, so this exercises the full
+    // audit listener → tool_invocations → telemetry projection chain.
+    const listener = createToolAuditListener();
+
+    listener({
+      type: "executed",
+      toolName: "task_create",
+      input: { title: "t" },
+      workingDir: "/tmp",
+      conversationId: CONVERSATION_ID,
+      skillId: "tasks-skill",
+      riskLevel: "low",
+      decision: "allow",
+      durationMs: 4,
+      result: { content: "ok", isError: false },
+    });
+    listener({
+      type: "executed",
+      toolName: "bash",
+      input: { command: "ls" },
+      workingDir: "/tmp",
+      conversationId: CONVERSATION_ID,
+      riskLevel: "low",
+      decision: "allow",
+      durationMs: 2,
+      result: { content: "ok", isError: false },
+    });
+
+    const rows = queryUnreportedToolExecutionEvents(0, undefined, 100);
+    expect(rows).toHaveLength(2);
+    expect(rows.find((r) => r.toolName === "task_create")?.skillId).toBe(
+      "tasks-skill",
+    );
+    expect(rows.find((r) => r.toolName === "bash")?.skillId).toBeNull();
   });
 
   test("honors the limit", () => {

--- a/assistant/src/memory/tool-execution-events-store.ts
+++ b/assistant/src/memory/tool-execution-events-store.ts
@@ -13,9 +13,9 @@ export interface UnreportedToolExecutionEvent {
   id: string;
   toolName: string;
   /**
-   * Triggering skill id. The `tool_invocations` table does not carry a
-   * skill column yet, so this is always null for now; the field exists so
-   * adding the column is a one-line change here.
+   * Id of the skill whose `skill_execute` dispatch triggered this tool
+   * call. Null for direct (non-skill) tool calls and for rows persisted
+   * before migration 275 added the column.
    */
   skillId: string | null;
   decision: string;
@@ -42,6 +42,7 @@ export function queryUnreportedToolExecutionEvents(
     .select({
       id: toolInvocations.id,
       toolName: toolInvocations.toolName,
+      skillId: toolInvocations.skillId,
       decision: toolInvocations.decision,
       riskLevel: toolInvocations.riskLevel,
       durationMs: toolInvocations.durationMs,
@@ -63,5 +64,5 @@ export function queryUnreportedToolExecutionEvents(
     .orderBy(asc(toolInvocations.createdAt), asc(toolInvocations.id))
     .limit(limit)
     .all();
-  return rows.map((r) => ({ ...r, skillId: null }));
+  return rows;
 }

--- a/assistant/src/memory/tool-usage-store.ts
+++ b/assistant/src/memory/tool-usage-store.ts
@@ -14,6 +14,8 @@ export interface ToolInvocationRecord {
   decision: string;
   riskLevel: string;
   matchedTrustRuleId?: string;
+  /** Id of the skill whose `skill_execute` dispatch triggered this tool call. Null for direct tool calls. */
+  skillId?: string | null;
   durationMs: number;
 }
 
@@ -29,6 +31,7 @@ export function recordToolInvocation(record: ToolInvocationRecord): void {
       decision: record.decision,
       riskLevel: record.riskLevel,
       matchedTrustRuleId: record.matchedTrustRuleId,
+      skillId: record.skillId ?? null,
       durationMs: record.durationMs,
       createdAt: Date.now(),
     })
@@ -65,9 +68,7 @@ export async function rotateToolInvocations(
 
   // Math.floor guarantees a plain integer literal in the inlined SQL
   // below; no decimal, no exponent, no surprise characters.
-  const cutoffMs = Math.floor(
-    Date.now() - retentionDays * 24 * 60 * 60 * 1000,
-  );
+  const cutoffMs = Math.floor(Date.now() - retentionDays * 24 * 60 * 60 * 1000);
   const db = getDb();
 
   // Count before delete so we can return + log the affected row count

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -249,6 +249,7 @@ function seedToolInvocation(overrides: {
   id: string;
   createdAt: number;
   toolName?: string;
+  skillId?: string | null;
   decision?: string;
   riskLevel?: string;
   durationMs?: number;
@@ -273,6 +274,7 @@ function seedToolInvocation(overrides: {
       result: '{"secret":"raw tool output — must never leave the device"}',
       decision: overrides.decision ?? "allow",
       riskLevel: overrides.riskLevel ?? "low",
+      skillId: overrides.skillId ?? null,
       durationMs: overrides.durationMs ?? 42,
       createdAt: overrides.createdAt,
     })
@@ -1297,7 +1299,7 @@ describe("UsageTelemetryReporter", () => {
       daemon_event_id: "ti-flush-1",
       recorded_at: 1700000900000,
       tool_name: "calendar_list_events",
-      // No skill column on tool_invocations yet — always null for now.
+      // Direct (non-skill) tool call — skill_id stays null on the wire.
       skill_id: null,
       decision: "denied",
       risk_level: "high",
@@ -1310,6 +1312,35 @@ describe("UsageTelemetryReporter", () => {
     expect(JSON.stringify(body)).not.toContain("must never leave the device");
     expect(body.events[0].input).toBeUndefined();
     expect(body.events[0].result).toBeUndefined();
+  });
+
+  test("skill-routed tool_invocations flush with a non-null skill_id", async () => {
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    seedToolInvocation({
+      id: "ti-skill-1",
+      createdAt: 1700000950000,
+      toolName: "task_create",
+      skillId: "tasks-skill",
+    });
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
+    );
+
+    const reporter = new UsageTelemetryReporter();
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect(body.events.length).toBe(1);
+    expect(body.events[0]).toMatchObject({
+      type: "tool_execution",
+      tool_name: "task_create",
+      skill_id: "tasks-skill",
+    });
+    // Only the skill id ships — never raw skill arguments or outputs.
+    expect(JSON.stringify(body)).not.toContain("must never leave the device");
   });
 
   test("tool_execution watermark advances to the last reported row on success", async () => {

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -485,9 +485,12 @@ function emitLifecycleEvent(
   const handler = context.onToolLifecycleEvent;
   if (!handler) return;
 
-  // Redact sensitive fields from tool inputs before they reach audit listeners
+  // Redact sensitive fields from tool inputs before they reach audit
+  // listeners, and stamp the triggering skill id (if any) so audit/telemetry
+  // consumers can attribute skill-routed calls.
   const sanitizedEvent = {
     ...event,
+    skillId: context.skillId,
     input: sanitizeToolInput(event.toolName, event.input),
   };
 

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -172,6 +172,8 @@ export interface ToolExecutedEvent {
   conversationId: string;
   requestId?: string;
   executionTarget?: ExecutionTarget;
+  /** Id of the skill whose `skill_execute` dispatch triggered this tool call. Absent for direct tool calls. */
+  skillId?: string;
   riskLevel: string;
   /** ID of the trust rule that matched this invocation (if any). */
   matchedTrustRuleId?: string;
@@ -210,6 +212,14 @@ export interface ToolContext {
   assistantId?: string;
   /** When set, the tool execution is part of a task run. Used to retrieve ephemeral permission rules. */
   taskRunId?: string;
+  /**
+   * Id of the skill whose `skill_execute` dispatch triggered this tool
+   * invocation. Set by the `skill_execute` interception in
+   * `daemon/conversation-tool-setup.ts`; the executor stamps it onto every
+   * lifecycle event so audit/telemetry consumers can attribute skill-routed
+   * calls. Absent for direct (non-skill) tool calls.
+   */
+  skillId?: string;
   /** Optional callback for tool lifecycle events (start/prompt/deny/execute/error). */
   onToolLifecycleEvent?: ToolLifecycleEventHandler;
   /** Optional resolver for proxy tools - delegates execution to an external client. */

--- a/packages/skill-host-contracts/src/tool-types.ts
+++ b/packages/skill-host-contracts/src/tool-types.ts
@@ -195,6 +195,8 @@ interface ToolLifecycleEventBase {
   conversationId: string;
   requestId?: string;
   executionTarget?: ExecutionTarget;
+  /** Id of the skill whose `skill_execute` dispatch triggered this tool call. Absent for direct tool calls. */
+  skillId?: string;
 }
 
 export interface AllowlistOption {


### PR DESCRIPTION
## Summary
- Add nullable skill_id column to tool_invocations with an idempotent PRAGMA-guarded migration
- Thread the triggering skill id from the skill_execute interception through ToolContext and executor lifecycle events into the audit listener
- Ship skill_id on tool_execution telemetry events; direct tool calls remain null

Part of plan: tool-telemetry-daemon.md (PR 2 of 2)