### PR TITLE
fix(memory): seed truncated-fork everInjected from inherited memory attachments

### DIFF
--- a/assistant/src/__tests__/conversation-fork-crud.test.ts
+++ b/assistant/src/__tests__/conversation-fork-crud.test.ts
@@ -922,6 +922,116 @@ describe("forkConversation", () => {
     expect(loadGraphMemoryState(fork.id)).toBeNull();
   });
 
+  test("truncated fork seeds everInjected from inherited memory attachments", async () => {
+    const source = createConversation("Truncated seed thread");
+    await addMessage(source.id, "user", "first turn", {
+      metadata: {
+        memoryInjectedBlock:
+          "# memory/concepts/topics/page-a.md\nSummary A\n\n# memory/concepts/topics/page-b.md\nSummary B",
+      },
+      skipIndexing: true,
+    });
+    await addMessage(source.id, "assistant", "first reply", {
+      skipIndexing: true,
+    });
+    const boundaryMessage = await addMessage(source.id, "user", "second turn", {
+      metadata: {
+        memoryInjectedBlock: "# memory/concepts/topics/page-c.md\nSummary C",
+      },
+      skipIndexing: true,
+    });
+    await addMessage(source.id, "assistant", "second reply", {
+      skipIndexing: true,
+    });
+    // Past the fork boundary — its attachment must NOT be claimed.
+    await addMessage(source.id, "user", "third turn", {
+      metadata: {
+        memoryInjectedBlock: "# memory/concepts/topics/page-d.md\nSummary D",
+      },
+      skipIndexing: true,
+    });
+
+    const db = getDb();
+    db.insert(activationState)
+      .values({
+        conversationId: source.id,
+        messageId: "parent-msg",
+        stateJson: JSON.stringify({ "topics/page-d": 0.9 }),
+        everInjectedJson: JSON.stringify([
+          { slug: "topics/page-a", turn: 1 },
+          { slug: "topics/page-b", turn: 1 },
+          { slug: "topics/page-c", turn: 2 },
+          { slug: "topics/page-d", turn: 3 },
+        ]),
+        currentTurn: 3,
+        updatedAt: 1_700_000_000_000,
+      })
+      .run();
+
+    const fork = forkConversation({
+      conversationId: source.id,
+      throughMessageId: boundaryMessage.id,
+    });
+
+    const childState = await hydrateActivationState(db, fork.id);
+    expect(childState).not.toBeNull();
+    // Exactly the slugs whose attachments live in the copied history —
+    // page-d (injected past the boundary) stays re-injectable.
+    expect(childState?.everInjected.map((e) => e.slug).sort()).toEqual([
+      "topics/page-a",
+      "topics/page-b",
+      "topics/page-c",
+    ]);
+    expect(childState?.everInjected.every((e) => e.turn === 0)).toBe(true);
+    // Activation scores and the turn counter start fresh, matching the
+    // graph tracker (also not copied for truncated forks).
+    expect(childState?.state).toEqual({});
+    expect(childState?.currentTurn).toBe(0);
+  });
+
+  test("truncated fork ignores attachments behind an inherited compaction boundary", async () => {
+    const source = createConversation("Compacted truncated thread");
+    await addMessage(source.id, "user", "compacted turn", {
+      metadata: {
+        memoryInjectedBlock:
+          "# memory/concepts/topics/page-compacted.md\nOld summary",
+      },
+      skipIndexing: true,
+    });
+    await addMessage(source.id, "assistant", "compacted reply", {
+      skipIndexing: true,
+    });
+    const boundaryMessage = await addMessage(source.id, "user", "live turn", {
+      metadata: {
+        memoryInjectedBlock: "# memory/concepts/topics/page-live.md\nSummary",
+      },
+      skipIndexing: true,
+    });
+    await addMessage(source.id, "assistant", "live reply", {
+      skipIndexing: true,
+    });
+    await addMessage(source.id, "user", "past boundary", {
+      skipIndexing: true,
+    });
+    // First two messages sit behind the compaction boundary: their
+    // attachments are not rendered, so the fork must not claim them.
+    getDb()
+      .update(conversations)
+      .set({ contextCompactedMessageCount: 2 })
+      .where(eq(conversations.id, source.id))
+      .run();
+
+    const fork = forkConversation({
+      conversationId: source.id,
+      throughMessageId: boundaryMessage.id,
+    });
+
+    const childState = await hydrateActivationState(getDb(), fork.id);
+    expect(childState?.everInjected.map((e) => e.slug)).toEqual([
+      "topics/page-live",
+    ]);
+  });
+
   test("defaults conversationType to standard and inherits the parent's group", async () => {
     const source = createConversation("Default inheritance thread");
     await addMessage(source.id, "user", "first message", {

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -70,7 +70,11 @@ import {
   toolInvocations,
 } from "./schema.js";
 import { cancelPendingJobsForConversation } from "./task-memory-cleanup.js";
-import { forkActivationState } from "./v2/activation-store.js";
+import {
+  forkActivationState,
+  seedForkActivationState,
+} from "./v2/activation-store.js";
+import { extractInjectedConceptSlugs } from "./v2/injected-block-slugs.js";
 
 const log = getLogger("conversation-store");
 
@@ -164,6 +168,25 @@ function cloneForkMessageMetadata(
   }
 
   return JSON.stringify({ forkSourceMessageId: sourceMessageId });
+}
+
+/**
+ * Read the persisted `memoryInjectedBlock` off a message's metadata JSON, or
+ * `null` when absent/malformed. The block is what the request builder
+ * re-attaches as the message's `<memory>` content each turn.
+ */
+function readMemoryInjectedBlock(metadata: string | null): string | null {
+  if (!metadata) return null;
+  try {
+    const parsed: unknown = JSON.parse(metadata);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      const block = (parsed as Record<string, unknown>).memoryInjectedBlock;
+      if (typeof block === "string") return block;
+    }
+  } catch {
+    // Malformed metadata — treat as no block.
+  }
+  return null;
 }
 
 /**
@@ -1034,6 +1057,26 @@ export function forkConversation(params: {
     if (isFullHistoryFork) {
       forkActivationState(db, sourceConversation.id, fc.id);
       forkGraphMemoryState(sourceConversation.id, fc.id);
+    } else {
+      // Truncated fork: the wholesale copy above would over-claim, but
+      // seeding nothing makes the child re-select and re-attach every page
+      // whose `<memory>` attachment it already inherited (observed in
+      // production: 89 duplicate page injections on one fork). Derive
+      // `everInjected` from the inherited attachments themselves — scoped to
+      // the child's visible window, since attachments behind an inherited
+      // compaction boundary are not rendered and must stay re-injectable.
+      const visibleStartIndex = preserveSourceCompactionState
+        ? visibleWindowStartIndex
+        : 0;
+      const inheritedSlugs = new Set<string>();
+      for (const message of messagesToCopy.slice(visibleStartIndex)) {
+        const block = readMemoryInjectedBlock(message.metadata);
+        if (!block) continue;
+        for (const slug of extractInjectedConceptSlugs(block)) {
+          inheritedSlugs.add(slug);
+        }
+      }
+      seedForkActivationState(db, fc.id, [...inheritedSlugs]);
     }
     forkRetrospectiveState({
       database: db,

--- a/assistant/src/memory/v2/__tests__/injected-block-slugs.test.ts
+++ b/assistant/src/memory/v2/__tests__/injected-block-slugs.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+
+import { extractInjectedConceptSlugs } from "../injected-block-slugs.js";
+
+describe("extractInjectedConceptSlugs", () => {
+  test("extracts nested concept slugs from page headers", () => {
+    const block = [
+      'Use `file_read("memory/concepts/path/to/file.md")` to read the full pages for any of the injected memory summaries you want more information on.',
+      "",
+      "# memory/concepts/topics/page-a.md",
+      "Summary of page a.",
+      "",
+      "# memory/concepts/arcs/deep/nested/page-b.md",
+      "Summary of page b.",
+    ].join("\n");
+
+    expect(extractInjectedConceptSlugs(block)).toEqual([
+      "topics/page-a",
+      "arcs/deep/nested/page-b",
+    ]);
+  });
+
+  test("handles a <memory>-wrapped block the same as an unwrapped one", () => {
+    const wrapped =
+      "<memory>\n# memory/concepts/topics/page-a.md\nSummary.\n</memory>";
+    expect(extractInjectedConceptSlugs(wrapped)).toEqual(["topics/page-a"]);
+  });
+
+  test("ignores skill and CLI sections and non-header lines", () => {
+    const block = [
+      "# memory/concepts/topics/page-a.md",
+      "Summary mentioning memory/concepts/topics/page-x.md inline.",
+      "",
+      "### Skills You Can Use",
+      "- Meeting joiner skill → use skill_load to activate",
+      "",
+      "### CLI Commands You Can Use",
+      "Run `assistant <command> --help` for full usage.",
+      "- `assistant export`: export a conversation",
+    ].join("\n");
+
+    expect(extractInjectedConceptSlugs(block)).toEqual(["topics/page-a"]);
+  });
+
+  test("dedupes repeated headers and returns [] when none match", () => {
+    const block =
+      "# memory/concepts/topics/page-a.md\nA.\n\n# memory/concepts/topics/page-a.md\nA again.";
+    expect(extractInjectedConceptSlugs(block)).toEqual(["topics/page-a"]);
+    expect(extractInjectedConceptSlugs("no headers here")).toEqual([]);
+  });
+});

--- a/assistant/src/memory/v2/activation-store.ts
+++ b/assistant/src/memory/v2/activation-store.ts
@@ -11,7 +11,11 @@ import { eq } from "drizzle-orm";
 
 import type { DrizzleDb } from "../db-connection.js";
 import { activationState } from "../schema.js";
-import { type ActivationState, ActivationStateSchema } from "./types.js";
+import {
+  type ActivationState,
+  ActivationStateSchema,
+  type EverInjectedEntry,
+} from "./types.js";
 
 /**
  * Load the activation state for a conversation, or `null` if no row exists.
@@ -114,6 +118,51 @@ export function forkActivationState(
         currentTurn: row.currentTurn,
         updatedAt: row.updatedAt,
       },
+    })
+    .run();
+}
+
+/**
+ * Seed a truncated fork's activation row from the concept slugs whose
+ * `<memory>` attachments the child actually inherited.
+ *
+ * Truncated forks cannot take the wholesale `forkActivationState` copy: the
+ * parent row marks slugs injected on turns the child does not contain, so
+ * copying it would suppress those pages in the child forever (silent recall
+ * holes). Seeding nothing has the opposite failure — every attachment already
+ * present in the copied history gets re-selected and re-attached on the
+ * child's next turns as a duplicate. Deriving `everInjected` from the
+ * inherited attachments themselves is exact by construction.
+ *
+ * Activation scores and the turn counter intentionally start fresh: the turn
+ * counter is supplied by the graph tracker, which is also not copied for
+ * truncated forks, so both counters restart together. Inherited entries are
+ * stamped `turn: 0` — dedup is slug-set membership (`turn` is bookkeeping
+ * only) and compaction clears the list wholesale.
+ *
+ * No-op when the child inherited no memory attachments. Synchronous so it can
+ * run inside the transaction that wraps `forkConversation()`.
+ */
+export function seedForkActivationState(
+  database: DrizzleDb,
+  newConversationId: string,
+  inheritedSlugs: string[],
+): void {
+  if (inheritedSlugs.length === 0) return;
+
+  const everInjected: EverInjectedEntry[] = inheritedSlugs.map((slug) => ({
+    slug,
+    turn: 0,
+  }));
+  database
+    .insert(activationState)
+    .values({
+      conversationId: newConversationId,
+      messageId: `${newConversationId}:turn:0`,
+      stateJson: "{}",
+      everInjectedJson: JSON.stringify(everInjected),
+      currentTurn: 0,
+      updatedAt: Date.now(),
     })
     .run();
 }

--- a/assistant/src/memory/v2/injected-block-slugs.ts
+++ b/assistant/src/memory/v2/injected-block-slugs.ts
@@ -1,0 +1,30 @@
+/**
+ * Slug extraction for persisted memory-injection blocks.
+ *
+ * `renderInjectionBlock` (injection.ts) renders each concept page under a
+ * `# memory/concepts/<slug>.md` header inside the block that is persisted on
+ * the user message as `metadata.memoryInjectedBlock` and re-attached at
+ * request build. This module is the read-side inverse of that header
+ * convention: given a persisted block, recover the concept slugs it contains.
+ *
+ * Skill (`skills/<id>`) and CLI-command sections render as plain description
+ * lines without a recoverable slug, so they are intentionally not extracted.
+ * The one consumer (truncated-fork everInjected seeding) tolerates that:
+ * re-attaching a few synthetic capability lines once is harmless, unlike
+ * re-attaching every inherited concept summary.
+ *
+ * Kept as a dependency-free leaf (like `memory-marker.ts`) so the
+ * conversation-fork path can import it without pulling in the heavyweight
+ * injection module.
+ */
+export function extractInjectedConceptSlugs(block: string): string[] {
+  const slugs: string[] = [];
+  const seen = new Set<string>();
+  for (const match of block.matchAll(/^# memory\/concepts\/(.+)\.md$/gm)) {
+    const slug = match[1]!;
+    if (seen.has(slug)) continue;
+    seen.add(slug);
+    slugs.push(slug);
+  }
+  return slugs;
+}


### PR DESCRIPTION
## Summary
- Truncated conversation forks started with an empty v2 `everInjected` set even though the copied history already carried the parent's `<memory>` attachments (persisted per-message as `metadata.memoryInjectedBlock`), so the child re-selected and re-attached the same page summaries — measured on a production fork as **89 duplicate page injections (~45KB)** of the 165 pages it attached across its post-fork turns.
- `forkConversation` now seeds the truncated child's `everInjected` by extracting `# memory/concepts/<slug>.md` headers from the inherited blocks (new dependency-free `injected-block-slugs.ts`, the read-side inverse of `renderInjectionBlock`'s header convention), scoped to the child's visible window so attachments behind an inherited compaction boundary remain re-injectable. Activation scores and `currentTurn` start fresh, consistent with the graph tracker which also restarts for truncated forks. Full-history forks keep the existing wholesale row copy (richer: scores + real turns + synthetic skill/CLI slugs).
- Skill/CLI synthetic entries render as description lines without a recoverable slug and are intentionally not seeded — re-attaching those few lines once is harmless. Known sibling gap (unchanged): the graph-memory InContextTracker is still not carried for truncated forks.

## Original prompt
While analyzing memory-v2 injection behavior on a real forked conversation (for the memory-v3 carry rework), we found the fork's final request contained 518 distinct injected pages but its own activation row only knew 165 — and 89 of those 165 were re-injections of pages already frozen in the inherited history, because the truncated-fork path skips the activation-state copy. The user asked to fix this v2 fork bug so forked conversations stop re-attaching summaries they already inherited.