### PR TITLE
fix: remove openai-compatible-endpoints flag gating from web app (GA'ed)

### DIFF
--- a/apps/web/src/components/profile-quick-add-provider.test.tsx
+++ b/apps/web/src/components/profile-quick-add-provider.test.tsx
@@ -29,7 +29,6 @@ mock.module("@/stores/resolved-assistants-store", () => {
 mock.module("@/stores/assistant-feature-flag-store", () => {
   const store = () => null;
   store.use = {
-    openAICompatibleEndpoints: () => false,
     chatgptSubscriptionAuth: () => false,
   };
   return { useAssistantFeatureFlagStore: store };

--- a/apps/web/src/components/profile-quick-add-provider.tsx
+++ b/apps/web/src/components/profile-quick-add-provider.tsx
@@ -40,7 +40,6 @@ import {
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import type { ProfileEntry } from "@/domains/settings/ai/ai-types";
 import { ProfileEditorModal } from "@/domains/settings/ai/profile-editor-modal";
-import { filterFlaggedConnections } from "@/domains/settings/ai/provider-connections-client";
 import { client } from "@/generated/api/client.gen";
 import { inferenceProviderconnectionsGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
 import { assistantDaemonConfigQueryKey } from "@/lib/sync/query-tags";
@@ -75,8 +74,6 @@ const ProfileQuickAddContext = createContext<ProfileQuickAddContextValue | null>
 
 export function ProfileQuickAddProvider({ children }: { children: ReactNode }) {
   const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
-  const openAICompatibleEndpoints =
-    useAssistantFeatureFlagStore.use.openAICompatibleEndpoints();
   const chatgptSubscriptionAuth =
     useAssistantFeatureFlagStore.use.chatgptSubscriptionAuth();
 
@@ -104,16 +101,7 @@ export function ProfileQuickAddProvider({ children }: { children: ReactNode }) {
     }),
     enabled: isOpen && !!assistantId,
   });
-  const connections = useMemo(
-    () =>
-      connectionsData
-        ? filterFlaggedConnections(
-            connectionsData.connections,
-            openAICompatibleEndpoints,
-          )
-        : undefined,
-    [connectionsData, openAICompatibleEndpoints],
-  );
+  const connections = connectionsData?.connections;
 
   // Persist a freshly-created profile, then hand the name back to the caller.
   // Writes `llm.profiles[name]` plus an appended `profileOrder` in a single
@@ -211,7 +199,6 @@ export function ProfileQuickAddProvider({ children }: { children: ReactNode }) {
           mode="create"
           existingNames={existingNames}
           connections={connections}
-          openAICompatibleEndpointsEnabled={openAICompatibleEndpoints}
           assistantId={assistantId}
           chatgptSubscriptionEnabled={chatgptSubscriptionAuth}
           onSave={handleSave}

--- a/apps/web/src/domains/chat/components/composer-settings-menu.test.tsx
+++ b/apps/web/src/domains/chat/components/composer-settings-menu.test.tsx
@@ -40,7 +40,6 @@ mock.module("@/stores/assistant-feature-flag-store", () => {
   const store = () => null;
   store.use = {
     queryComplexityRouting: () => false,
-    openAICompatibleEndpoints: () => false,
     chatgptSubscriptionAuth: () => false,
   };
   return { useAssistantFeatureFlagStore: store };

--- a/apps/web/src/domains/settings/ai/manage-profiles-modal.test.tsx
+++ b/apps/web/src/domains/settings/ai/manage-profiles-modal.test.tsx
@@ -63,7 +63,6 @@ mock.module("@/domains/settings/ai/use-daemon-config", () => ({
 mock.module("@/stores/assistant-feature-flag-store", () => {
   const store = () => null;
   store.use = {
-    openAICompatibleEndpoints: () => false,
     chatgptSubscriptionAuth: () => false,
     queryComplexityRouting: () => false,
   };

--- a/apps/web/src/domains/settings/ai/manage-profiles-modal.tsx
+++ b/apps/web/src/domains/settings/ai/manage-profiles-modal.tsx
@@ -14,7 +14,6 @@ import { BlockedDeleteModal } from "@/domains/settings/ai/manage-profiles-blocke
 import { ProfileListItem } from "@/domains/settings/ai/manage-profiles-list-item";
 import { ProfileEditorModal } from "@/domains/settings/ai/profile-editor-modal";
 import { gateAutoProfile } from "@/domains/settings/ai/profile-pickers";
-import { filterFlaggedConnections } from "@/domains/settings/ai/provider-connections-client";
 import { useDaemonConfigMutation, useDaemonConfigQuery } from "@/domains/settings/ai/use-daemon-config";
 import { inferenceProviderconnectionsGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
 
@@ -46,7 +45,6 @@ export function ManageProfilesModal({
   } = useDaemonConfigQuery();
   const configMutation = useDaemonConfigMutation();
 
-  const openAICompatibleEndpoints = useAssistantFeatureFlagStore.use.openAICompatibleEndpoints();
   const chatgptSubscriptionAuth = useAssistantFeatureFlagStore.use.chatgptSubscriptionAuth();
   const [editorOpen, setEditorOpen] = useState(false);
   const [editingProfile, setEditingProfile] = useState<ProfileWithName | null>(null);
@@ -58,13 +56,7 @@ export function ManageProfilesModal({
     }),
     enabled: isOpen,
   });
-  const connections = useMemo(
-    () =>
-      connectionsData
-        ? filterFlaggedConnections(connectionsData.connections, openAICompatibleEndpoints)
-        : undefined,
-    [connectionsData, openAICompatibleEndpoints],
-  );
+  const connections = connectionsData?.connections;
 
   const existingNames = Object.keys(profiles);
 
@@ -173,7 +165,6 @@ export function ManageProfilesModal({
         initialValues={editingProfile ?? undefined}
         existingNames={existingNames}
         connections={connections}
-        openAICompatibleEndpointsEnabled={openAICompatibleEndpoints}
         assistantId={assistantId}
         chatgptSubscriptionEnabled={chatgptSubscriptionAuth}
         onSave={handleEditorSave}

--- a/apps/web/src/domains/settings/ai/manage-providers-modal.tsx
+++ b/apps/web/src/domains/settings/ai/manage-providers-modal.tsx
@@ -14,7 +14,6 @@ import {
 import { inferenceProviderconnectionsByNameDelete } from "@/generated/daemon/sdk.gen";
 
 import {
-    filterFlaggedConnections,
     PROVIDER_DISPLAY_NAMES,
     type ProviderConnection,
 } from "@/domains/settings/ai/provider-connections-client";
@@ -55,7 +54,6 @@ export function ManageProvidersModal({
   assistantId,
   onClose,
 }: ManageProvidersModalProps) {
-  const openAICompatibleEndpoints = useAssistantFeatureFlagStore.use.openAICompatibleEndpoints();
   const chatgptSubscriptionAuth = useAssistantFeatureFlagStore.use.chatgptSubscriptionAuth();
   const [editorOpen, setEditorOpen] = useState(false);
   const [editingConnection, setEditingConnection] = useState<ProviderConnection | null>(null);
@@ -70,8 +68,8 @@ export function ManageProvidersModal({
   });
 
   const connections = useMemo(
-    () => filterFlaggedConnections(data?.connections ?? [], openAICompatibleEndpoints),
-    [data, openAICompatibleEndpoints],
+    () => data?.connections ?? [],
+    [data],
   );
 
   function handleEditorSave(_saved: ProviderConnection) {
@@ -124,7 +122,6 @@ export function ManageProvidersModal({
             connection={editingConnection ?? undefined}
             assistantId={assistantId}
             existingNames={existingNames}
-            openAICompatibleEndpointsEnabled={openAICompatibleEndpoints}
             chatgptSubscriptionEnabled={chatgptSubscriptionAuth}
             onSave={handleEditorSave}
             onCancel={cancelEditor}

--- a/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -14,7 +14,7 @@ import { getModelsForProvider } from "@/assistant/llm-model-catalog";
 import { inferenceProviderconnectionsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
 
 import type { ProfileEntry, ProfileStatus, ProfileWithName } from "@/domains/settings/ai/ai-types";
-import { INFERENCE_PROVIDER_DISPLAY_NAMES, OPENAI_COMPATIBLE_PROVIDER } from "@/domains/settings/ai/ai-types";
+import { INFERENCE_PROVIDER_DISPLAY_NAMES } from "@/domains/settings/ai/ai-types";
 import {
     ProfileAdvancedParams,
     THINKING_LEVEL_INHERIT,
@@ -54,7 +54,6 @@ export interface ProfileEditorModalProps {
    *   the daemon can't dispatch through.
    */
   connections?: ProviderConnection[];
-  openAICompatibleEndpointsEnabled?: boolean;
   /**
    * Assistant whose provider connections the inline "+ Create new provider"
    * sub-form writes to. Required for the create-mode quick-add flow.
@@ -93,7 +92,6 @@ export function ProfileEditorModal({
   initialValues,
   existingNames,
   connections,
-  openAICompatibleEndpointsEnabled = false,
   assistantId,
   chatgptSubscriptionEnabled = false,
   onSave,
@@ -113,7 +111,6 @@ export function ProfileEditorModal({
           initialValues={initialValues}
           existingNames={existingNames}
           connections={connections}
-          openAICompatibleEndpointsEnabled={openAICompatibleEndpointsEnabled}
           assistantId={assistantId}
           chatgptSubscriptionEnabled={chatgptSubscriptionEnabled}
           onSave={onSave}
@@ -135,7 +132,6 @@ interface ProfileEditorModalInnerProps {
   existingNames: string[];
   // See `ProfileEditorModalProps.connections` for nil-vs-empty semantics.
   connections: ProviderConnection[] | undefined;
-  openAICompatibleEndpointsEnabled: boolean;
   assistantId: string;
   chatgptSubscriptionEnabled: boolean;
   onSave: (
@@ -152,7 +148,6 @@ function ProfileEditorModalInner({
   initialValues,
   existingNames,
   connections,
-  openAICompatibleEndpointsEnabled,
   assistantId,
   chatgptSubscriptionEnabled,
   onSave,
@@ -272,14 +267,9 @@ function ProfileEditorModalInner({
   const availableConnectionsForProvider = useMemo(
     () =>
       provider
-        ? effectiveConnections.filter(
-            (c) =>
-              c.provider === provider &&
-              (openAICompatibleEndpointsEnabled ||
-                c.provider !== OPENAI_COMPATIBLE_PROVIDER),
-          )
+        ? effectiveConnections.filter((c) => c.provider === provider)
         : [],
-    [provider, effectiveConnections, openAICompatibleEndpointsEnabled],
+    [provider, effectiveConnections],
   );
 
   // Saved binding no longer points at any known connection. The save handler
@@ -678,12 +668,6 @@ function ProfileEditorModalInner({
     const seen = new Set<string>();
     const opts: { value: string; label: string }[] = [];
     for (const c of effectiveConnections) {
-      if (
-        !openAICompatibleEndpointsEnabled &&
-        c.provider === OPENAI_COMPATIBLE_PROVIDER
-      ) {
-        continue;
-      }
       if (!seen.has(c.provider)) {
         seen.add(c.provider);
         opts.push({
@@ -697,7 +681,7 @@ function ProfileEditorModalInner({
       label: "+ Create new provider",
     });
     return opts;
-  }, [effectiveConnections, openAICompatibleEndpointsEnabled]);
+  }, [effectiveConnections]);
 
   const createProviderSection = (
     <div className="space-y-4">
@@ -746,7 +730,6 @@ function ProfileEditorModalInner({
           variant="inline"
           assistantId={assistantId}
           existingNames={effectiveConnections.map((c) => c.name)}
-          openAICompatibleEndpointsEnabled={openAICompatibleEndpointsEnabled}
           chatgptSubscriptionEnabled={chatgptSubscriptionEnabled}
           defaultProviderType={
             (provider || undefined) as ConnectionProvider | undefined
@@ -763,7 +746,6 @@ function ProfileEditorModalInner({
           onModelChange={handleModelChange}
           onConnectionChange={handleConnectionChange}
           connections={effectiveConnections}
-          openAICompatibleEndpointsEnabled={openAICompatibleEndpointsEnabled}
           isReadOnly={isReadOnly}
           availableConnectionsForProvider={availableConnectionsForProvider}
           connectionNotFound={connectionNotFound}
@@ -868,7 +850,6 @@ function ProfileEditorModalInner({
                 onModelChange={handleModelChange}
                 onConnectionChange={handleConnectionChange}
                 connections={connections}
-                openAICompatibleEndpointsEnabled={openAICompatibleEndpointsEnabled}
                 isReadOnly={isReadOnly}
                 availableConnectionsForProvider={availableConnectionsForProvider}
                 connectionNotFound={connectionNotFound}

--- a/apps/web/src/domains/settings/ai/profile-editor-provider-section.tsx
+++ b/apps/web/src/domains/settings/ai/profile-editor-provider-section.tsx
@@ -40,7 +40,6 @@ interface ProfileEditorProviderSectionProps {
   onModelChange: (newModel: string) => void;
   onConnectionChange: (newConnection: string) => void;
   connections: ProviderConnection[] | undefined;
-  openAICompatibleEndpointsEnabled: boolean;
   isReadOnly: boolean;
   /** Connections matching the current provider, computed by the parent
    *  (the save handler also needs this for binding resolution). */
@@ -76,7 +75,6 @@ export function ProfileEditorProviderSection({
   onModelChange,
   onConnectionChange,
   connections,
-  openAICompatibleEndpointsEnabled,
   isReadOnly,
   availableConnectionsForProvider,
   connectionNotFound,
@@ -85,13 +83,7 @@ export function ProfileEditorProviderSection({
   const providerMissing = provider.length === 0;
   const providerWithoutModel = provider.length > 0 && model.length === 0;
 
-  const allProvidersForPicker = useMemo(
-    () =>
-      openAICompatibleEndpointsEnabled
-        ? ALL_PROVIDERS
-        : ALL_PROVIDERS.filter((p) => p !== OPENAI_COMPATIBLE_PROVIDER),
-    [openAICompatibleEndpointsEnabled],
-  );
+  const allProvidersForPicker = ALL_PROVIDERS;
 
   // Filter to providers with at least one connection — picking a provider
   // with zero connections binds a profile to a route the daemon can't
@@ -100,25 +92,15 @@ export function ProfileEditorProviderSection({
   const visibleProviders = useMemo(() => {
     const providerSet = new Set<string>();
     for (const c of connections ?? []) {
-      if (
-        openAICompatibleEndpointsEnabled ||
-        c.provider !== OPENAI_COMPATIBLE_PROVIDER
-      ) {
-        providerSet.add(c.provider);
-      }
+      providerSet.add(c.provider);
     }
-    if (
-      provider &&
-      (openAICompatibleEndpointsEnabled ||
-        provider !== OPENAI_COMPATIBLE_PROVIDER)
-    ) {
+    if (provider) {
       providerSet.add(provider);
     }
     return allProvidersForPicker.filter((p) => providerSet.has(p));
   }, [
     allProvidersForPicker,
     connections,
-    openAICompatibleEndpointsEnabled,
     provider,
   ]);
 
@@ -144,12 +126,6 @@ export function ProfileEditorProviderSection({
   // selected, merge models from all available openai-compatible connections.
   const availableModels: readonly { id: string; displayName: string }[] = useMemo(() => {
     if (!provider) return [];
-    if (
-      provider === OPENAI_COMPATIBLE_PROVIDER &&
-      !openAICompatibleEndpointsEnabled
-    ) {
-      return [];
-    }
     const catalogModels = getModelsForProvider(provider);
     if (catalogModels.length > 0) {
       const selectedConn = providerConnection
@@ -187,7 +163,6 @@ export function ProfileEditorProviderSection({
     return merged;
   }, [
     provider,
-    openAICompatibleEndpointsEnabled,
     providerConnection,
     availableConnectionsForProvider,
   ]);

--- a/apps/web/src/domains/settings/ai/provider-connections-client.ts
+++ b/apps/web/src/domains/settings/ai/provider-connections-client.ts
@@ -78,15 +78,13 @@ function buildConnectionProviderDisplayNames(): Record<
 }
 
 // ---------------------------------------------------------------------------
-// Feature-flag filter
+// Feature-flag filter (retained for call-site compatibility)
 // ---------------------------------------------------------------------------
 
 export function filterFlaggedConnections(
   connections: ProviderConnection[],
-  openAICompatibleEndpointsEnabled: boolean,
 ): ProviderConnection[] {
-  if (openAICompatibleEndpointsEnabled) return connections;
-  return connections.filter((c) => c.provider !== "openai-compatible");
+  return connections;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/domains/settings/ai/provider-create-form.tsx
+++ b/apps/web/src/domains/settings/ai/provider-create-form.tsx
@@ -53,7 +53,6 @@ import { useProviderCredentialsList } from "@/domains/settings/ai/use-provider-c
 export interface ProviderCreateFormProps {
   assistantId: string;
   existingNames: string[];
-  openAICompatibleEndpointsEnabled?: boolean;
   chatgptSubscriptionEnabled?: boolean;
   /** Pre-selected provider type (e.g. when cloning a managed connection). */
   defaultProviderType?: ConnectionProvider;
@@ -73,7 +72,6 @@ export interface ProviderCreateFormProps {
 export function ProviderCreateForm({
   assistantId,
   existingNames,
-  openAICompatibleEndpointsEnabled = false,
   chatgptSubscriptionEnabled = false,
   defaultProviderType,
   defaultAuthType,
@@ -112,14 +110,11 @@ export function ProviderCreateForm({
 
   const isOpenAICompatible = provider === "openai-compatible";
   const connectionProviderOptions = useMemo(() => {
-    const options = openAICompatibleEndpointsEnabled
-      ? CONNECTION_PROVIDERS
-      : CONNECTION_PROVIDERS.filter((p) => p !== "openai-compatible");
-    if (provider && !options.includes(provider)) {
-      return [...options, provider];
+    if (provider && !CONNECTION_PROVIDERS.includes(provider)) {
+      return [...CONNECTION_PROVIDERS, provider];
     }
-    return options;
-  }, [openAICompatibleEndpointsEnabled, provider]);
+    return CONNECTION_PROVIDERS;
+  }, [provider]);
 
   const { handleLabelChange, handleKeyChange: handleNameChange, getDirty } =
     useLabelKeySync("create", setLabel, setName);

--- a/apps/web/src/domains/settings/ai/provider-editor-modal.tsx
+++ b/apps/web/src/domains/settings/ai/provider-editor-modal.tsx
@@ -60,7 +60,6 @@ export interface ProviderEditorContentProps {
   connection?: ProviderConnection;
   assistantId: string;
   existingNames: string[];
-  openAICompatibleEndpointsEnabled?: boolean;
   chatgptSubscriptionEnabled?: boolean;
   onSave: (connection: ProviderConnection) => void;
   onCancel: () => void;
@@ -71,7 +70,6 @@ export function ProviderEditorContent({
   connection,
   assistantId,
   existingNames,
-  openAICompatibleEndpointsEnabled = false,
   chatgptSubscriptionEnabled = false,
   onSave,
   onCancel,
@@ -123,14 +121,11 @@ export function ProviderEditorContent({
 
   const isOpenAICompatible = provider === "openai-compatible";
   const connectionProviderOptions = useMemo(() => {
-    const options = openAICompatibleEndpointsEnabled
-      ? CONNECTION_PROVIDERS
-      : CONNECTION_PROVIDERS.filter((p) => p !== "openai-compatible");
-    if (provider && !options.includes(provider)) {
-      return [...options, provider];
+    if (provider && !CONNECTION_PROVIDERS.includes(provider)) {
+      return [...CONNECTION_PROVIDERS, provider];
     }
-    return options;
-  }, [openAICompatibleEndpointsEnabled, provider]);
+    return CONNECTION_PROVIDERS;
+  }, [provider]);
 
   const { handleLabelChange, resetDirty } =
     useLabelKeySync(effectiveMode, setLabel, setName);
@@ -360,7 +355,6 @@ export function ProviderEditorContent({
         variant="modal"
         assistantId={assistantId}
         existingNames={existingNames}
-        openAICompatibleEndpointsEnabled={openAICompatibleEndpointsEnabled}
         chatgptSubscriptionEnabled={chatgptSubscriptionEnabled}
         defaultProviderType={provider}
         defaultAuthType={createAuthTypeSeed}

--- a/apps/web/src/lib/feature-flags/feature-flag-catalog.ts
+++ b/apps/web/src/lib/feature-flags/feature-flag-catalog.ts
@@ -22,9 +22,7 @@ export interface FlagDefinition {
 
 const flags = registry.flags as FlagDefinition[];
 
-const STORE_KEY_OVERRIDES: Record<string, string> = {
-  "openai-compatible-endpoints": "openAICompatibleEndpoints",
-};
+const STORE_KEY_OVERRIDES: Record<string, string> = {};
 
 function kebabToStoreKey(kebabKey: string): string {
   const override = STORE_KEY_OVERRIDES[kebabKey];


### PR DESCRIPTION
## Summary
- Remove openAICompatibleEndpoints store selector from 3 top-level consumers
- Unwind openAICompatibleEndpointsEnabled prop from 5 intermediate components
- Simplify filterFlaggedConnections to always return all connections
- Remove feature-flag-catalog mapping entry
- Update 3 test files to remove flag mocks

Part of plan: rm-gaed-flags-wave2.md (PR 3 of 5)