### PR TITLE
chore: remove 3 GA'ed flags from feature flag registry

### DIFF
--- a/apps/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/apps/web/src/lib/feature-flags/feature-flag-registry.json
@@ -116,14 +116,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "chatgpt-subscription-auth",
-      "scope": "assistant",
-      "key": "chatgpt-subscription-auth",
-      "label": "ChatGPT Subscription Auth",
-      "description": "Enable ChatGPT subscription OAuth as a provider auth type for OpenAI models, using the Codex device-code flow.",
-      "defaultEnabled": false
-    },
-    {
       "id": "settings-embedding-provider",
       "scope": "assistant",
       "key": "settings-embedding-provider",
@@ -161,14 +153,6 @@
       "key": "message-tts",
       "label": "Message Text-to-Speech",
       "description": "Show a speaker button on assistant messages to generate and play the message as audio via Fish Audio TTS",
-      "defaultEnabled": false
-    },
-    {
-      "id": "openai-compatible-endpoints",
-      "scope": "assistant",
-      "key": "openai-compatible-endpoints",
-      "label": "OpenAI-Compatible Endpoints",
-      "description": "Enable user-configured OpenAI-compatible inference endpoints with custom base URLs and model identifiers",
       "defaultEnabled": false
     },
     {
@@ -337,14 +321,6 @@
       "key": "chat-pull-to-refresh-enabled",
       "label": "Chat Pull to Refresh",
       "description": "Enable pull-to-refresh gesture in the chat view.",
-      "defaultEnabled": false
-    },
-    {
-      "id": "home-page",
-      "scope": "client",
-      "key": "home-page",
-      "label": "Home Page",
-      "description": "Enable the Home page as the default landing view.",
       "defaultEnabled": false
     },
     {

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -116,14 +116,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "chatgpt-subscription-auth",
-      "scope": "assistant",
-      "key": "chatgpt-subscription-auth",
-      "label": "ChatGPT Subscription Auth",
-      "description": "Enable ChatGPT subscription OAuth as a provider auth type for OpenAI models, using the Codex device-code flow.",
-      "defaultEnabled": false
-    },
-    {
       "id": "settings-embedding-provider",
       "scope": "assistant",
       "key": "settings-embedding-provider",
@@ -161,14 +153,6 @@
       "key": "message-tts",
       "label": "Message Text-to-Speech",
       "description": "Show a speaker button on assistant messages to generate and play the message as audio via Fish Audio TTS",
-      "defaultEnabled": false
-    },
-    {
-      "id": "openai-compatible-endpoints",
-      "scope": "assistant",
-      "key": "openai-compatible-endpoints",
-      "label": "OpenAI-Compatible Endpoints",
-      "description": "Enable user-configured OpenAI-compatible inference endpoints with custom base URLs and model identifiers",
       "defaultEnabled": false
     },
     {
@@ -337,14 +321,6 @@
       "key": "chat-pull-to-refresh-enabled",
       "label": "Chat Pull to Refresh",
       "description": "Enable pull-to-refresh gesture in the chat view.",
-      "defaultEnabled": false
-    },
-    {
-      "id": "home-page",
-      "scope": "client",
-      "key": "home-page",
-      "label": "Home Page",
-      "description": "Enable the Home page as the default landing view.",
       "defaultEnabled": false
     },
     {


### PR DESCRIPTION
## Summary
- Remove chatgpt-subscription-auth, openai-compatible-endpoints, home-page entries from both registry JSON files
- All flag-checking code was already removed in PRs 1-4

Part of plan: rm-gaed-flags-wave2.md (PR 5 of 5)