### PR TITLE
feat: gate the balanced-economy built-in profile behind a feature flag

### DIFF
--- a/apps/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/apps/web/src/lib/feature-flags/feature-flag-registry.json
@@ -476,6 +476,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "balanced-economy-profile",
+      "scope": "assistant",
+      "key": "balanced-economy-profile",
+      "label": "Balanced Economy Profile",
+      "description": "Controls availability of the built-in Balanced Economy (Kimi K2.6 via Fireworks) inference profile. When disabled, the profile is removed from the effective profile set and profile pickers, and an active selection falls back to Balanced. Enabled by default; acts as a remote kill switch.",
+      "defaultEnabled": true
+    },
+    {
       "id": "self-intro-greeting",
       "scope": "both",
       "key": "self-intro-greeting",

--- a/assistant/src/__tests__/config-loader-builtin-profiles.test.ts
+++ b/assistant/src/__tests__/config-loader-builtin-profiles.test.ts
@@ -95,9 +95,9 @@ const BUILTIN_NAMES = [
   ...Object.keys(MANAGED_PROFILE_TEMPLATES),
 ];
 
-/** Flag key used by the gating tests. Undeclared in the registry on purpose
- * — resolution comes entirely from the (test-seeded) override cache. */
-const TEST_FLAG = "test-builtin-profile-flag";
+/** Registry flag gating the `balanced-economy` built-in
+ * (`defaultEnabled: true` — a remote kill switch). */
+const BALANCED_ECONOMY_FLAG = "balanced-economy-profile";
 
 function ensureTestDir(): void {
   const dirs = [
@@ -156,8 +156,6 @@ describe("config loader — built-in inference profile merge", () => {
   });
 
   afterEach(() => {
-    // Safety net: gating tests patch the shared template object.
-    delete MANAGED_PROFILE_TEMPLATES["balanced-economy"]!.featureFlag;
     setStorePathForTesting(null);
     invalidateConfigCache();
     clearFeatureFlagOverridesCache();
@@ -292,9 +290,14 @@ describe("config loader — built-in inference profile merge", () => {
     expect(config.llm.profiles.balanced!.label).toBe("Override Label");
   });
 
+  test("the balanced-economy definition is gated by the registry flag", () => {
+    expect(MANAGED_PROFILE_TEMPLATES["balanced-economy"]!.featureFlag).toBe(
+      BALANCED_ECONOMY_FLAG,
+    );
+  });
+
   test("flag-disabled built-in is absent from profiles and profileOrder; activeProfile falls back to balanced", () => {
-    MANAGED_PROFILE_TEMPLATES["balanced-economy"]!.featureFlag = TEST_FLAG;
-    setOverridesForTesting({ [TEST_FLAG]: false });
+    setOverridesForTesting({ [BALANCED_ECONOMY_FLAG]: false });
     writeConfig({
       llm: {
         profiles: {
@@ -320,8 +323,7 @@ describe("config loader — built-in inference profile merge", () => {
   });
 
   test("flag flip via refreshOverridesFromGateway changes the visible profile set without restart", async () => {
-    MANAGED_PROFILE_TEMPLATES["balanced-economy"]!.featureFlag = TEST_FLAG;
-    setOverridesForTesting({ [TEST_FLAG]: true });
+    setOverridesForTesting({ [BALANCED_ECONOMY_FLAG]: true });
     writeConfig({ llm: { activeProfile: "balanced" } });
 
     expect(getConfig().llm.profiles["balanced-economy"]).toBeDefined();
@@ -329,10 +331,51 @@ describe("config loader — built-in inference profile merge", () => {
     // The gateway pushes a flag flip; the refresh must invalidate the
     // parsed-config cache (config.json itself is unchanged, so the file
     // signature alone would keep serving the stale merged set).
-    mockGatewayIpc({ [TEST_FLAG]: false });
+    mockGatewayIpc({ [BALANCED_ECONOMY_FLAG]: false });
     await refreshOverridesFromGateway();
 
     expect(getConfig().llm.profiles["balanced-economy"]).toBeUndefined();
+  });
+
+  test("balanced-economy is present by default (registry defaultEnabled: true)", () => {
+    // setOverridesForTesting({}) in beforeEach pins "no remote overrides" —
+    // resolution falls back to the registry default.
+    const config = getConfig();
+
+    expect(config.llm.profiles["balanced-economy"]).toBeDefined();
+    expect(config.llm.profileOrder).toContain("balanced-economy");
+  });
+
+  test("a profileOverrides entry for a flag-disabled built-in is retained on disk and re-applies on re-enable", () => {
+    setOverridesForTesting({ [BALANCED_ECONOMY_FLAG]: false });
+    writeConfig({
+      llm: {
+        profileOverrides: {
+          "balanced-economy": { label: "My Economy", status: "disabled" },
+        },
+        activeProfile: "balanced",
+      },
+    });
+
+    expect(getConfig().llm.profiles["balanced-economy"]).toBeUndefined();
+
+    // The override store on disk is untouched while the flag is off.
+    const onDisk = readConfigFromDisk() as {
+      llm: { profileOverrides: Record<string, unknown> };
+    };
+    expect(onDisk.llm.profileOverrides["balanced-economy"]).toEqual({
+      label: "My Economy",
+      status: "disabled",
+    });
+
+    // Flag re-enables → the profile reappears with the override applied.
+    setOverridesForTesting({ [BALANCED_ECONOMY_FLAG]: true });
+    invalidateConfigCache();
+    const config = getConfig();
+
+    expect(config.llm.profiles["balanced-economy"]).toBeDefined();
+    expect(config.llm.profiles["balanced-economy"]!.label).toBe("My Economy");
+    expect(config.llm.profiles["balanced-economy"]!.status).toBe("disabled");
   });
 
   test("activeProfile naming a custom user profile is NOT reset", () => {

--- a/assistant/src/config/builtin-inference-profiles.ts
+++ b/assistant/src/config/builtin-inference-profiles.ts
@@ -89,6 +89,7 @@ export const MANAGED_PROFILE_TEMPLATES: Record<
     thinking: { enabled: true, streamThinking: true },
     contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
     logitBias: "suppress-cjk",
+    featureFlag: "balanced-economy-profile",
   },
 };
 

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -476,6 +476,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "balanced-economy-profile",
+      "scope": "assistant",
+      "key": "balanced-economy-profile",
+      "label": "Balanced Economy Profile",
+      "description": "Controls availability of the built-in Balanced Economy (Kimi K2.6 via Fireworks) inference profile. When disabled, the profile is removed from the effective profile set and profile pickers, and an active selection falls back to Balanced. Enabled by default; acts as a remote kill switch.",
+      "defaultEnabled": true
+    },
+    {
       "id": "self-intro-greeting",
       "scope": "both",
       "key": "self-intro-greeting",


### PR DESCRIPTION
## Summary
- New assistant-scope flag balanced-economy-profile (defaultEnabled: true) — remote kill switch for the built-in Kimi K2.6/Fireworks profile
- balanced-economy definition now carries featureFlag; flag off removes it from effective profiles/order with activeProfile fallback
- Bundled registry copies regenerated via sync-bundled-copies.ts

## Out-of-repo follow-up
- Create the balanced-economy-profile flag via Terraform in vellum-assistant-platform so the remote override path can target it.

Part of plan: builtin-llm-profiles.md (PR 8 of 8)