### PR TITLE
fix: add (created_at, id) index for tool_invocations telemetry cursor

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -201,6 +201,7 @@ import {
   migrateStripIntegrationPrefixFromProviderKeys,
   migrateStripPlaceholderSentinelsFromMessages,
   migrateStripThinkingFromConsolidated,
+  migrateToolInvocationsCreatedAtIdIndex,
   migrateToolInvocationsMatchedRuleId,
   migrateToolInvocationsSkillId,
   migrateTraceEventsCreatedAtIndex,
@@ -486,6 +487,7 @@ export function initializeDb(): void {
     migrateOnboardingEventsFunnelColumns,
     createActivationSessionsTable,
     migrateToolInvocationsSkillId,
+    migrateToolInvocationsCreatedAtIdIndex,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/276-tool-invocations-created-at-id-index.test.ts
+++ b/assistant/src/memory/migrations/276-tool-invocations-created-at-id-index.test.ts
@@ -1,0 +1,68 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import * as schema from "../schema.js";
+import { migrateToolInvocationsCreatedAtIdIndex } from "./276-tool-invocations-created-at-id-index.js";
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  // Pre-276 shape: no (created_at, id) index.
+  sqlite.exec(/*sql*/ `
+    CREATE TABLE tool_invocations (
+      id TEXT PRIMARY KEY,
+      conversation_id TEXT NOT NULL,
+      tool_name TEXT NOT NULL,
+      input TEXT NOT NULL,
+      result TEXT NOT NULL,
+      decision TEXT NOT NULL,
+      risk_level TEXT NOT NULL,
+      matched_trust_rule_id TEXT,
+      skill_id TEXT,
+      duration_ms INTEGER NOT NULL,
+      created_at INTEGER NOT NULL
+    )
+  `);
+  return { sqlite, db: drizzle(sqlite, { schema }) };
+}
+
+function indexNames(sqlite: Database): string[] {
+  return (
+    sqlite.query("PRAGMA index_list(tool_invocations)").all() as Array<{
+      name: string;
+    }>
+  ).map((i) => i.name);
+}
+
+describe("migration 276: tool_invocations (created_at, id) index", () => {
+  test("creates the index on (created_at, id)", () => {
+    const { sqlite, db } = createTestDb();
+    expect(indexNames(sqlite)).not.toContain(
+      "idx_tool_invocations_created_at_id",
+    );
+
+    migrateToolInvocationsCreatedAtIdIndex(db);
+
+    expect(indexNames(sqlite)).toContain("idx_tool_invocations_created_at_id");
+    const columns = (
+      sqlite
+        .query("PRAGMA index_info(idx_tool_invocations_created_at_id)")
+        .all() as Array<{ name: string }>
+    ).map((c) => c.name);
+    expect(columns).toEqual(["created_at", "id"]);
+  });
+
+  test("is idempotent — re-run is a no-op", () => {
+    const { sqlite, db } = createTestDb();
+
+    migrateToolInvocationsCreatedAtIdIndex(db);
+    expect(() => migrateToolInvocationsCreatedAtIdIndex(db)).not.toThrow();
+
+    expect(
+      indexNames(sqlite).filter(
+        (name) => name === "idx_tool_invocations_created_at_id",
+      ),
+    ).toHaveLength(1);
+  });
+});

--- a/assistant/src/memory/migrations/276-tool-invocations-created-at-id-index.ts
+++ b/assistant/src/memory/migrations/276-tool-invocations-created-at-id-index.ts
@@ -1,0 +1,20 @@
+import type { DrizzleDb } from "../db-connection.js";
+
+/**
+ * Indexes `tool_invocations(created_at, id)` so the tool_execution telemetry
+ * cursor can seek to the next unreported batch instead of scanning the table.
+ *
+ * `queryUnreportedToolExecutionEvents` filters and orders by `(created_at, id)`
+ * every telemetry flush (~5 min); without this index each flush scans and
+ * sorts the whole audit table, which grows unboundedly by default and carries
+ * large `input`/`result` text blobs.
+ *
+ * Idempotent — `CREATE INDEX IF NOT EXISTS` is a no-op once the index exists.
+ */
+export function migrateToolInvocationsCreatedAtIdIndex(
+  database: DrizzleDb,
+): void {
+  database.run(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_tool_invocations_created_at_id ON tool_invocations (created_at, id)`,
+  );
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -263,6 +263,7 @@ export { migrateAcpSessionHistoryCwd } from "./272-acp-session-history-cwd.js";
 export { migrateOnboardingEventsFunnelColumns } from "./273-onboarding-events-funnel-columns.js";
 export { createActivationSessionsTable } from "./274-create-activation-sessions.js";
 export { migrateToolInvocationsSkillId } from "./275-tool-invocations-add-skill-id.js";
+export { migrateToolInvocationsCreatedAtIdIndex } from "./276-tool-invocations-created-at-id-index.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/conversations.ts
+++ b/assistant/src/memory/schema/conversations.ts
@@ -98,6 +98,7 @@ export const toolInvocations = sqliteTable(
   },
   (table) => [
     index("idx_tool_invocations_conversation_id").on(table.conversationId),
+    index("idx_tool_invocations_created_at_id").on(table.createdAt, table.id),
   ],
 );
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for tool-telemetry-daemon.md.

**Gap:** the tool_execution telemetry cursor query scans tool_invocations by (created_at, id) every flush with no supporting index (Codex P2 on #34124).
**Fix:** schema index + idempotent CREATE INDEX IF NOT EXISTS migration following the 275 convention.