### PR TITLE
Collect billing address on the auto-top-up payment method (for tax)

### DIFF
--- a/apps/web/src/domains/settings/components/auto-top-up-payment-method-modal.test.tsx
+++ b/apps/web/src/domains/settings/components/auto-top-up-payment-method-modal.test.tsx
@@ -1,0 +1,201 @@
+/**
+ * Tests for the billing-address collection in `AutoTopUpPaymentMethodModal`
+ * (auto-topup-billing-address plan, PR 1): the saved PaymentMethod must carry
+ * `billing_details.address` so the Django webhook can seed `customer.address`
+ * for tax.
+ *
+ * Strategy: mock `@stripe/react-stripe-js` with prop-capturing stand-ins
+ * (real Stripe Elements need a live iframe) and mock the generated SDK's
+ * SetupIntent create so the modal mounts the form synchronously without
+ * network. `STRIPE_PK` is read from `import.meta.env` at module load, so the
+ * publishable key is set before the modal module is imported.
+ *
+ * Coverage:
+ *  - a billing-mode AddressElement renders alongside the PaymentElement once
+ *    the SetupIntent `client_secret` is loaded, and the PaymentElement's own
+ *    address fields are suppressed (no duplicate postal-code input),
+ *  - the Save button stays disabled until BOTH elements report `onReady`,
+ *  - submitting calls `stripe.confirmSetup` with `elements` and
+ *    `redirect: "if_required"` (no manual billing_details plumbing).
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+type ElementProps = {
+  onReady?: () => void;
+  options?: Record<string, unknown>;
+};
+
+let paymentElementProps: ElementProps | null = null;
+let addressElementProps: ElementProps | null = null;
+let confirmSetupCalls: Record<string, unknown>[] = [];
+
+const fakeElements = { __tag: "fake-elements" };
+const fakeStripe = {
+  confirmSetup: (opts: Record<string, unknown>) => {
+    confirmSetupCalls.push(opts);
+    return Promise.resolve({});
+  },
+};
+
+mock.module("@stripe/react-stripe-js", () => ({
+  Elements: ({ children }: { children: ReactNode }) => (
+    <div data-testid="stripe-elements">{children}</div>
+  ),
+  PaymentElement: (props: ElementProps) => {
+    paymentElementProps = props;
+    return <div data-testid="stripe-payment-element" />;
+  },
+  AddressElement: (props: ElementProps) => {
+    addressElementProps = props;
+    return <div data-testid="stripe-address-element" />;
+  },
+  useStripe: () => fakeStripe,
+  useElements: () => fakeElements,
+}));
+
+// Keep `loadStripe` from injecting Stripe.js script tags into happy-dom.
+mock.module("@stripe/stripe-js", () => ({
+  loadStripe: () => Promise.resolve(null),
+}));
+
+import * as sdkGen from "@/generated/api/sdk.gen";
+
+mock.module("@/generated/api/sdk.gen", () => ({
+  ...sdkGen,
+  organizationsBillingAutoTopUpSetupIntentCreate: () =>
+    Promise.resolve({
+      data: { client_secret: "seti_123_secret_456" },
+      response: { ok: true },
+    }),
+}));
+
+// The modal reads VITE_STRIPE_PUBLISHABLE_KEY into module-scope `STRIPE_PK`
+// at evaluation time (import.meta.env is process.env under Bun); without it
+// the modal renders only the missing-key notice. Static imports are hoisted
+// ahead of this assignment, so the component must be imported dynamically
+// after the env var is set.
+process.env.VITE_STRIPE_PUBLISHABLE_KEY = "pk_test_fake";
+const { AutoTopUpPaymentMethodModal } = await import(
+  "./auto-top-up-payment-method-modal"
+);
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+function renderModal(): ReturnType<typeof render> {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <AutoTopUpPaymentMethodModal
+        open
+        onClose={() => {}}
+        onSavedOptimistic={() => {}}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+/** Wait for the SetupIntent mutation to resolve and the card form to mount. */
+async function renderModalWithForm(): Promise<ReturnType<typeof render>> {
+  const result = renderModal();
+  await result.findByTestId("stripe-address-element");
+  return result;
+}
+
+function saveButton(): HTMLButtonElement {
+  const button = document.querySelector<HTMLButtonElement>(
+    '[data-testid="auto-top-up-pm-save-button"]',
+  );
+  if (!button) throw new Error("expected the Save button to be rendered");
+  return button;
+}
+
+function fireOnReady(props: ElementProps | null): void {
+  if (!props?.onReady) throw new Error("expected an onReady handler");
+  act(() => props.onReady!());
+}
+
+beforeEach(() => {
+  paymentElementProps = null;
+  addressElementProps = null;
+  confirmSetupCalls = [];
+});
+
+afterEach(cleanup);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("AutoTopUpPaymentMethodModal billing address", () => {
+  test("renders a billing-mode AddressElement alongside the PaymentElement once the client_secret loads", async () => {
+    await renderModalWithForm();
+
+    expect(
+      document.querySelector('[data-testid="stripe-payment-element"]'),
+    ).not.toBeNull();
+    expect(
+      document.querySelector('[data-testid="stripe-address-element"]'),
+    ).not.toBeNull();
+
+    // The Address Element collects the billing address...
+    expect(addressElementProps?.options?.mode).toBe("billing");
+    // ...and the Payment Element's own address fields are suppressed, so the
+    // user never sees two postal-code inputs.
+    expect(paymentElementProps?.options?.fields).toEqual({
+      billingDetails: { address: "never" },
+    });
+  });
+
+  test("keeps Save disabled until BOTH the PaymentElement and AddressElement report ready", async () => {
+    await renderModalWithForm();
+
+    // Neither element ready: disabled.
+    expect(saveButton().disabled).toBe(true);
+
+    // Payment Element ready alone is not enough.
+    fireOnReady(paymentElementProps);
+    expect(saveButton().disabled).toBe(true);
+
+    // Address Element ready too: enabled.
+    fireOnReady(addressElementProps);
+    expect(saveButton().disabled).toBe(false);
+  });
+
+  test("submitting calls stripe.confirmSetup with elements and redirect: 'if_required'", async () => {
+    await renderModalWithForm();
+    fireOnReady(paymentElementProps);
+    fireOnReady(addressElementProps);
+
+    fireEvent.submit(saveButton().closest("form")!);
+
+    await waitFor(() => {
+      if (confirmSetupCalls.length === 0) {
+        throw new Error("confirmSetup not called");
+      }
+    });
+    expect(confirmSetupCalls).toHaveLength(1);
+    const call = confirmSetupCalls[0]!;
+    // The Address Element's value flows through `elements` automatically —
+    // there must be no manual payment_method_data.billing_details plumbing.
+    expect(call.elements).toBe(fakeElements);
+    expect(call.redirect).toBe("if_required");
+    expect(
+      (call.confirmParams as Record<string, unknown>).return_url,
+    ).toBeDefined();
+    expect(
+      (call.confirmParams as Record<string, unknown>).payment_method_data,
+    ).toBeUndefined();
+  });
+});

--- a/apps/web/src/domains/settings/components/auto-top-up-payment-method-modal.tsx
+++ b/apps/web/src/domains/settings/components/auto-top-up-payment-method-modal.tsx
@@ -1,4 +1,5 @@
 import {
+    AddressElement,
     Elements,
     PaymentElement,
     useElements,
@@ -54,8 +55,9 @@ export interface AutoTopUpPaymentMethodModalProps {
 
 /**
  * Modal that bootstraps a Stripe SetupIntent (via the heyapi mutation) and
- * mounts `<PaymentElement />` inside `<Elements>` so the user can save a
- * card on the org's Stripe customer to use for auto-top-up off-session
+ * mounts `<PaymentElement />` plus a billing-mode `<AddressElement />`
+ * inside `<Elements>` so the user can save a card — with a billing address
+ * for tax — on the org's Stripe customer to use for auto-top-up off-session
  * charges. The card is tagged via SetupIntent metadata so the webhook can
  * persist it onto AutoTopUpConfig. There is no separate auto-top-up Stripe
  * customer — auto-top-up uses the org's single Stripe customer (the same
@@ -211,10 +213,12 @@ function SetupCardForm({
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [elementReady, setElementReady] = useState(false);
+  const [addressElementReady, setAddressElementReady] = useState(false);
+  const ready = elementReady && addressElementReady;
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
-    if (!stripe || !elements || !elementReady) return;
+    if (!stripe || !elements || !ready) return;
 
     setSubmitting(true);
     setError(null);
@@ -249,6 +253,28 @@ function SetupCardForm({
         options={{
           layout: { type: "tabs", defaultCollapsed: false },
           paymentMethodOrder: ["card", "us_bank_account"],
+          // The Address Element below owns the billing address (so the saved
+          // PM carries billing_details.address for tax); suppress the Payment
+          // Element's own address inputs to avoid a duplicate postal-code
+          // field. Name/email stay with the Payment Element where the chosen
+          // payment method needs them.
+          fields: { billingDetails: { address: "never" } },
+        }}
+      />
+      {/*
+        Billing address for tax: mounted in the same <Elements> group, the
+        Address Element's value is attached to the PaymentMethod's
+        billing_details automatically by `stripe.confirmSetup({ elements })` —
+        no manual plumbing. The Django webhook seeds `customer.address` from
+        it.
+      */}
+      <AddressElement
+        onReady={() => setAddressElementReady(true)}
+        options={{
+          mode: "billing",
+          // Full billing address is fine and more tax-complete, but country +
+          // postal code are the load-bearing fields the Django side requires.
+          fields: { phone: "never" },
         }}
       />
       {error && (
@@ -272,7 +298,8 @@ function SetupCardForm({
         <Button
           variant="primary"
           type="submit"
-          disabled={submitting || !stripe || !elements || !elementReady}
+          data-testid="auto-top-up-pm-save-button"
+          disabled={submitting || !stripe || !elements || !ready}
           leftIcon={submitting ? <Loader2 className="animate-spin" /> : undefined}
         >
           Save

--- a/apps/web/src/domains/settings/components/auto-top-up-payment-method-modal.tsx
+++ b/apps/web/src/domains/settings/components/auto-top-up-payment-method-modal.tsx
@@ -185,7 +185,7 @@ export function AutoTopUpPaymentMethodModal({
 function MissingStripeKeyNotice() {
   useEffect(() => {
     console.warn(
-      "[AutoTopUpPaymentMethodModal] NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY is not set; the payment-method modal cannot mount Stripe Elements.",
+      "[AutoTopUpPaymentMethodModal] VITE_STRIPE_PUBLISHABLE_KEY is not set; the payment-method modal cannot mount Stripe Elements.",
     );
   }, []);
   return (


### PR DESCRIPTION
## Summary
- Add a billing-mode AddressElement to the auto-top-up payment method modal so saved PaymentMethods carry billing_details.address (country + postal code) for tax
- Suppress the PaymentElement's own address fields to avoid a duplicate postal-code prompt
- Gate submit on both PaymentElement and AddressElement readiness

Part of plan: auto-topup-billing-address.md (PR 1 of 1)