### PR TITLE
fix: clean up tool_execution telemetry comments, types, and redundant coalescing

### DIFF
--- a/assistant/src/__tests__/tool-audit-listener.test.ts
+++ b/assistant/src/__tests__/tool-audit-listener.test.ts
@@ -28,7 +28,7 @@ describe("tool audit listener", () => {
     expect(records[0].decision).toBe("allow");
     expect(records[0].riskLevel).toBe("low");
     expect(records[0].durationMs).toBe(12);
-    expect(records[0].skillId).toBeNull();
+    expect(records[0].skillId).toBeUndefined();
   });
 
   test("records the triggering skill id on terminal events", () => {
@@ -202,6 +202,6 @@ describe("tool audit listener", () => {
     expect(records).toHaveLength(1);
     expect(records[0].result).toBe("error: boom");
     expect(records[0].decision).toBe("error");
-    expect(records[0].skillId).toBeNull();
+    expect(records[0].skillId).toBeUndefined();
   });
 });

--- a/assistant/src/events/tool-audit-listener.ts
+++ b/assistant/src/events/tool-audit-listener.ts
@@ -48,7 +48,7 @@ function toInvocationRecord(
         decision: event.decision,
         riskLevel: event.riskLevel,
         matchedTrustRuleId: event.matchedTrustRuleId,
-        skillId: event.skillId ?? null,
+        skillId: event.skillId,
         durationMs: event.durationMs,
       };
     case "error":
@@ -60,7 +60,7 @@ function toInvocationRecord(
         decision: "error",
         riskLevel: event.riskLevel,
         matchedTrustRuleId: event.matchedTrustRuleId,
-        skillId: event.skillId ?? null,
+        skillId: event.skillId,
         durationMs: event.durationMs,
       };
     case "permission_denied":
@@ -72,7 +72,7 @@ function toInvocationRecord(
         decision: "denied",
         riskLevel: event.riskLevel,
         matchedTrustRuleId: event.matchedTrustRuleId,
-        skillId: event.skillId ?? null,
+        skillId: event.skillId,
         durationMs: event.durationMs,
       };
     case "start":

--- a/assistant/src/memory/migrations/275-tool-invocations-add-skill-id.ts
+++ b/assistant/src/memory/migrations/275-tool-invocations-add-skill-id.ts
@@ -10,7 +10,7 @@ import { tableHasColumn } from "./schema-introspection.js";
  * persisted before this migration ran.
  *
  * Idempotent — re-running is a no-op once the column exists. Pure DDL with a
- * PRAGMA guard, no registry entry needed (matches the 236 / 273 pattern).
+ * PRAGMA guard, no registry entry needed (matches the 273 pattern).
  */
 export function migrateToolInvocationsSkillId(database: DrizzleDb): void {
   if (tableHasColumn(database, "tool_invocations", "skill_id")) {

--- a/assistant/src/memory/tool-execution-events-store.ts
+++ b/assistant/src/memory/tool-execution-events-store.ts
@@ -31,6 +31,12 @@ export interface UnreportedToolExecutionEvent {
  *
  * Rows are written by the tool audit listener
  * (`events/tool-audit-listener.ts`) — there is no record function here.
+ *
+ * Reporting is best-effort: `rotateToolInvocations` purges rows by
+ * `created_at` alone, so rows older than the configured
+ * `auditLog.retentionDays` window may be rotated away before they are
+ * reported (e.g. if the daemon is offline or failing for longer than
+ * the retention window).
  */
 export function queryUnreportedToolExecutionEvents(
   afterCreatedAt: number,
@@ -38,7 +44,7 @@ export function queryUnreportedToolExecutionEvents(
   limit: number,
 ): UnreportedToolExecutionEvent[] {
   const db = getDb();
-  const rows = db
+  return db
     .select({
       id: toolInvocations.id,
       toolName: toolInvocations.toolName,
@@ -64,5 +70,4 @@ export function queryUnreportedToolExecutionEvents(
     .orderBy(asc(toolInvocations.createdAt), asc(toolInvocations.id))
     .limit(limit)
     .all();
-  return rows;
 }

--- a/assistant/src/memory/tool-usage-store.ts
+++ b/assistant/src/memory/tool-usage-store.ts
@@ -31,7 +31,7 @@ export function recordToolInvocation(record: ToolInvocationRecord): void {
       decision: record.decision,
       riskLevel: record.riskLevel,
       matchedTrustRuleId: record.matchedTrustRuleId,
-      skillId: record.skillId ?? null,
+      skillId: record.skillId,
       durationMs: record.durationMs,
       createdAt: Date.now(),
     })

--- a/assistant/src/telemetry/types.ts
+++ b/assistant/src/telemetry/types.ts
@@ -228,22 +228,24 @@ export interface AuthFallbackTelemetryEvent extends TelemetryEventBase {
 /**
  * Tool execution event — one per tool invocation, sourced from the
  * `tool_invocations` audit table. Skill-routed calls appear under their
- * underlying tool name; `skill_id` identifies the triggering skill once the
- * daemon threads it through (null in the initial rollout and for direct tool
- * calls). Carries NO raw input/output — only tool identity, permission
+ * underlying tool name; `skill_id` identifies the triggering skill.
+ * Carries NO raw input/output — only tool identity, permission
  * outcome, risk class, duration, and parent conversation.
  */
 export interface ToolExecutionTelemetryEvent extends TelemetryEventBase {
   type: "tool_execution";
   tool_name: string;
-  /** Triggering skill id, or null for direct tool calls / pre-attribution daemons. */
+  /**
+   * Triggering skill id for skill-routed calls. Null for direct tool
+   * calls and for rows recorded before the `skill_id` column existed.
+   */
   skill_id: string | null;
   /** Permission outcome: "allow" | "error" | "denied". */
   decision: string;
   /** Executor risk classification. */
-  risk_level: string | null;
-  duration_ms: number | null;
-  conversation_id: string | null;
+  risk_level: string;
+  duration_ms: number;
+  conversation_id: string;
 }
 
 /** Discriminated union of all telemetry event types. */


### PR DESCRIPTION
## Summary
Fixes cleanup gaps identified during plan review for tool-telemetry-daemon.md: stale PR-1-era doc comments, vestigial variable, redundant ?? null coalescing, over-broad nullable typing, wrong migration-precedent citation, undocumented rotation-vs-telemetry interaction, and formatting churn.