### PR TITLE
fix: consolidate duplicated tool-telemetry test helpers and redundant tests

### DIFF
--- a/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
+++ b/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
@@ -531,45 +531,6 @@ describe("ToolExecutor lifecycle events", () => {
     }
   });
 
-  test("stamps context.skillId on error events", async () => {
-    toolThrow = new Error("boom");
-
-    const events: ToolLifecycleEvent[] = [];
-    const executor = new ToolExecutor(makePrompter());
-
-    await executor.execute(
-      "skill_sandbox_tool",
-      { query: "test" },
-      makeContext(events, { skillId: "test-skill" }),
-    );
-
-    const errorEvent = events.find((event) => event.type === "error");
-    expect(errorEvent?.skillId).toBe("test-skill");
-  });
-
-  test("stamps context.skillId on permission_denied events", async () => {
-    checkerDecision = "prompt";
-    checkerRisk = "medium";
-    promptDecision = "deny";
-
-    const events: ToolLifecycleEvent[] = [];
-    const executor = new ToolExecutor(makePrompter());
-
-    await executor.execute(
-      "bash",
-      { command: "ls -la" },
-      makeContext(events, {
-        skillId: "test-skill",
-        forcePromptSideEffects: true,
-      }),
-    );
-
-    const deniedEvent = events.find(
-      (event) => event.type === "permission_denied",
-    );
-    expect(deniedEvent?.skillId).toBe("test-skill");
-  });
-
   test("leaves skillId unset on lifecycle events for direct tool calls", async () => {
     const events: ToolLifecycleEvent[] = [];
     const executor = new ToolExecutor(makePrompter());

--- a/assistant/src/memory/__tests__/tool-invocation-test-helpers.ts
+++ b/assistant/src/memory/__tests__/tool-invocation-test-helpers.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared seeding helper for tests that exercise the tool_invocations →
+ * telemetry projection chain. Inserts raw audit rows (with PII-sentinel
+ * input/result payloads) plus the FK-required conversation row.
+ */
+import { getDb } from "../db-connection.js";
+import { conversations, toolInvocations } from "../schema.js";
+
+/**
+ * Sentinel embedded in the seeded raw input/result payloads. Assert it
+ * never appears in any telemetry projection or wire payload.
+ */
+export const TOOL_INVOCATION_PII_SENTINEL = "must never leave the device";
+
+export interface SeedToolInvocationSpec {
+  id: string;
+  createdAt: number;
+  conversationId: string;
+  toolName?: string;
+  skillId?: string | null;
+  decision?: string;
+  riskLevel?: string;
+  durationMs?: number;
+}
+
+export function seedToolInvocation(spec: SeedToolInvocationSpec): void {
+  const db = getDb();
+  // tool_invocations has an enforced FK to conversations.
+  db.insert(conversations)
+    .values({
+      id: spec.conversationId,
+      title: "test",
+      createdAt: 1000,
+      updatedAt: 1000,
+    })
+    .onConflictDoNothing()
+    .run();
+  db.insert(toolInvocations)
+    .values({
+      id: spec.id,
+      conversationId: spec.conversationId,
+      toolName: spec.toolName ?? "calendar_list_events",
+      input: `{"secret":"raw tool args — ${TOOL_INVOCATION_PII_SENTINEL}"}`,
+      result: `{"secret":"raw tool output — ${TOOL_INVOCATION_PII_SENTINEL}"}`,
+      decision: spec.decision ?? "allow",
+      riskLevel: spec.riskLevel ?? "low",
+      skillId: spec.skillId ?? null,
+      durationMs: spec.durationMs ?? 12,
+      createdAt: spec.createdAt,
+    })
+    .run();
+}

--- a/assistant/src/memory/tool-execution-events-store.test.ts
+++ b/assistant/src/memory/tool-execution-events-store.test.ts
@@ -8,6 +8,10 @@ mock.module("../util/logger.js", () => ({
 }));
 
 import { createToolAuditListener } from "../events/tool-audit-listener.js";
+import {
+  seedToolInvocation,
+  type SeedToolInvocationSpec,
+} from "./__tests__/tool-invocation-test-helpers.js";
 import { getDb } from "./db-connection.js";
 import { initializeDb } from "./db-init.js";
 import { conversations, toolInvocations } from "./schema.js";
@@ -17,32 +21,10 @@ initializeDb();
 
 const CONVERSATION_ID = "conv-tool-exec-store-test";
 
-interface InsertSpec {
-  id: string;
-  createdAt: number;
-  toolName?: string;
-  skillId?: string | null;
-  decision?: string;
-  riskLevel?: string;
-  durationMs?: number;
-}
-
-function insertInvocation(spec: InsertSpec): void {
-  getDb()
-    .insert(toolInvocations)
-    .values({
-      id: spec.id,
-      conversationId: CONVERSATION_ID,
-      toolName: spec.toolName ?? "calendar_list_events",
-      input: '{"secret":"raw tool args — must never leave the device"}',
-      result: '{"secret":"raw tool output — must never leave the device"}',
-      decision: spec.decision ?? "allow",
-      riskLevel: spec.riskLevel ?? "low",
-      skillId: spec.skillId ?? null,
-      durationMs: spec.durationMs ?? 12,
-      createdAt: spec.createdAt,
-    })
-    .run();
+function insertInvocation(
+  spec: Omit<SeedToolInvocationSpec, "conversationId">,
+): void {
+  seedToolInvocation({ ...spec, conversationId: CONVERSATION_ID });
 }
 
 describe("tool-execution-events-store", () => {

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -153,14 +153,15 @@ mock.module("../memory/onboarding-events-store.js", () => ({
 // Production import (after mocks)
 // ---------------------------------------------------------------------------
 
+import {
+  seedToolInvocation as seedToolInvocationRow,
+  type SeedToolInvocationSpec,
+  TOOL_INVOCATION_PII_SENTINEL,
+} from "../memory/__tests__/tool-invocation-test-helpers.js";
 import { recordAuthFallbackCounts } from "../memory/auth-fallback-events-store.js";
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
-import {
-  authFallbackEvents,
-  conversations,
-  toolInvocations,
-} from "../memory/schema.js";
+import { authFallbackEvents, toolInvocations } from "../memory/schema.js";
 import type { UsageEvent } from "../usage/types.js";
 import {
   ACTIVATION_FUNNEL_VERSION,
@@ -245,40 +246,13 @@ function makeOnboardingEvent(
 
 const TOOL_EXEC_CONVERSATION_ID = "conv-tool-exec-reporter-test";
 
-function seedToolInvocation(overrides: {
-  id: string;
-  createdAt: number;
-  toolName?: string;
-  skillId?: string | null;
-  decision?: string;
-  riskLevel?: string;
-  durationMs?: number;
-}): void {
-  const db = getDb();
-  // tool_invocations has an enforced FK to conversations.
-  db.insert(conversations)
-    .values({
-      id: TOOL_EXEC_CONVERSATION_ID,
-      title: "test",
-      createdAt: 1000,
-      updatedAt: 1000,
-    })
-    .onConflictDoNothing()
-    .run();
-  db.insert(toolInvocations)
-    .values({
-      id: overrides.id,
-      conversationId: TOOL_EXEC_CONVERSATION_ID,
-      toolName: overrides.toolName ?? "web_search",
-      input: '{"secret":"raw tool args — must never leave the device"}',
-      result: '{"secret":"raw tool output — must never leave the device"}',
-      decision: overrides.decision ?? "allow",
-      riskLevel: overrides.riskLevel ?? "low",
-      skillId: overrides.skillId ?? null,
-      durationMs: overrides.durationMs ?? 42,
-      createdAt: overrides.createdAt,
-    })
-    .run();
+function seedToolInvocation(
+  spec: Omit<SeedToolInvocationSpec, "conversationId">,
+): void {
+  seedToolInvocationRow({
+    ...spec,
+    conversationId: TOOL_EXEC_CONVERSATION_ID,
+  });
 }
 
 const originalFetch = globalThis.fetch;
@@ -1275,15 +1249,21 @@ describe("UsageTelemetryReporter", () => {
   test("tool_invocations rows flush as tool_execution events with mapped fields and no raw input/result", async () => {
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
     seedToolInvocation({
-      id: "ti-flush-1",
+      id: "ti-flush-direct",
       createdAt: 1700000900000,
       toolName: "calendar_list_events",
       decision: "denied",
       riskLevel: "high",
       durationMs: 137,
     });
+    seedToolInvocation({
+      id: "ti-flush-skill",
+      createdAt: 1700000950000,
+      toolName: "task_create",
+      skillId: "tasks-skill",
+    });
     mockFetch.mockImplementation(() =>
-      Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
+      Promise.resolve(new Response('{"accepted":2}', { status: 200 })),
     );
 
     const reporter = new UsageTelemetryReporter();
@@ -1293,10 +1273,15 @@ describe("UsageTelemetryReporter", () => {
     const body = JSON.parse(
       (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
     );
-    expect(body.events.length).toBe(1);
-    expect(body.events[0]).toMatchObject({
+    expect(body.events.length).toBe(2);
+
+    const direct = body.events.find(
+      (e: { daemon_event_id: string }) =>
+        e.daemon_event_id === "ti-flush-direct",
+    );
+    expect(direct).toMatchObject({
       type: "tool_execution",
-      daemon_event_id: "ti-flush-1",
+      daemon_event_id: "ti-flush-direct",
       recorded_at: 1700000900000,
       tool_name: "calendar_list_events",
       // Direct (non-skill) tool call — skill_id stays null on the wire.
@@ -1307,40 +1292,22 @@ describe("UsageTelemetryReporter", () => {
       conversation_id: TOOL_EXEC_CONVERSATION_ID,
       assistant_version: "1.2.3-test",
     });
-    // The raw tool args/outputs persisted in the audit row are potentially
-    // PII and must NEVER appear anywhere in the payload.
-    expect(JSON.stringify(body)).not.toContain("must never leave the device");
-    expect(body.events[0].input).toBeUndefined();
-    expect(body.events[0].result).toBeUndefined();
-  });
 
-  test("skill-routed tool_invocations flush with a non-null skill_id", async () => {
-    mockQueryUnreportedUsageEvents.mockReturnValue([]);
-    seedToolInvocation({
-      id: "ti-skill-1",
-      createdAt: 1700000950000,
-      toolName: "task_create",
-      skillId: "tasks-skill",
-    });
-    mockFetch.mockImplementation(() =>
-      Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
+    const skillRouted = body.events.find(
+      (e: { daemon_event_id: string }) =>
+        e.daemon_event_id === "ti-flush-skill",
     );
-
-    const reporter = new UsageTelemetryReporter();
-    await reporter.flush();
-
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-    const body = JSON.parse(
-      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
-    );
-    expect(body.events.length).toBe(1);
-    expect(body.events[0]).toMatchObject({
+    expect(skillRouted).toMatchObject({
       type: "tool_execution",
       tool_name: "task_create",
       skill_id: "tasks-skill",
     });
-    // Only the skill id ships — never raw skill arguments or outputs.
-    expect(JSON.stringify(body)).not.toContain("must never leave the device");
+
+    // The raw tool args/outputs persisted in the audit rows are potentially
+    // PII and must NEVER appear anywhere in the payload.
+    expect(JSON.stringify(body)).not.toContain(TOOL_INVOCATION_PII_SENTINEL);
+    expect(direct.input).toBeUndefined();
+    expect(direct.result).toBeUndefined();
   });
 
   test("tool_execution watermark advances to the last reported row on success", async () => {


### PR DESCRIPTION
## Summary
Fixes test-quality gaps identified during plan review for tool-telemetry-daemon.md: shared tool-invocation seeding helper, redundant executor lifecycle skillId tests, merged near-duplicate reporter flush tests.