### PR TITLE
feat(assistant): persist built-in profile edits as profileOverrides and sanitize config writes

### DIFF
--- a/assistant/src/__tests__/managed-profile-guard.test.ts
+++ b/assistant/src/__tests__/managed-profile-guard.test.ts
@@ -1,7 +1,15 @@
 /**
- * Tests that managed inference profiles ("quality-optimized", "balanced",
- * "cost-optimized") cannot be edited via the PUT profile route or deleted
- * via the PATCH config route.
+ * Tests that built-in (managed) inference profiles ("quality-optimized",
+ * "balanced", "cost-optimized", ...) cannot be reshaped or deleted via the
+ * config write routes:
+ *
+ * - PUT /v1/config/llm/profiles/:name allows only label/status, persisted as
+ *   sparse `llm.profileOverrides` entries (never under `llm.profiles`).
+ * - PATCH /v1/config re-routes built-in label/status edits into
+ *   `llm.profileOverrides` and drops every other built-in field, so clients
+ *   that round-trip `GET /v1/config` output (which contains the merged
+ *   built-in entries) keep working without materializing built-ins on disk.
+ * - POST /v1/config/set gets the same treatment with path-aware handling.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -98,6 +106,10 @@ const replaceRoute = ROUTES.find(
 
 const patchRoute = ROUTES.find((r) => r.operationId === "config_patch")!;
 
+const setRoute = ROUTES.find((r) => r.operationId === "config_set")!;
+
+const getRoute = ROUTES.find((r) => r.operationId === "config_get")!;
+
 beforeEach(() => {
   rawConfig = makeDefaultRawConfig();
   savedRaw = null;
@@ -159,14 +171,33 @@ describe("PUT /v1/config/llm/profiles/:name — managed profile guard", () => {
   });
 
   // -------------------------------------------------------------------------
-  // Null-as-clear sentinel: clients send `{ label: null }` or
-  // `{ status: null }` to clear a managed profile's overrides back to the
-  // seed defaults. The Zod `ProfileEntry` schema accepts null for both
-  // fields, and the managed-profile guard / `patchManagedProfileFields`
-  // propagate the clear through to disk. These tests lock the round-trip.
+  // Built-in label/status edits persist as sparse `llm.profileOverrides`
+  // entries; nothing is ever written under `llm.profiles` for a built-in
+  // name. Null is the "explicitly cleared" sentinel: it is stored as-is so
+  // the merge layer masks any stale label/status still carried by a
+  // transition-state materialized entry. An absent key leaves the existing
+  // override key untouched.
   // -------------------------------------------------------------------------
 
-  test("PUT { label: null } on managed profile clears the label on disk", async () => {
+  test("PUT { label: 'X' } lands in profileOverrides, leaving llm.profiles untouched", async () => {
+    savedRaw = null;
+    const result = await replaceRoute.handler({
+      pathParams: { name: "balanced" },
+      body: { label: "My Balanced" },
+    });
+    expect(result).toEqual({ ok: true });
+    const saved = savedRaw as unknown as Record<string, any>;
+    expect(saved.llm.profileOverrides.balanced).toEqual({
+      label: "My Balanced",
+    });
+    // The transition-state materialized entry is not the write target.
+    expect(saved.llm.profiles.balanced).toEqual({
+      provider: "anthropic",
+      model: "claude-sonnet",
+    });
+  });
+
+  test("PUT { label: null } stores the null sentinel in profileOverrides", async () => {
     savedRaw = null;
     rawConfig = {
       llm: {
@@ -178,6 +209,7 @@ describe("PUT /v1/config/llm/profiles/:name — managed profile guard", () => {
             source: "managed",
           },
         },
+        profileOverrides: { balanced: { label: "My Custom Name" } },
       },
     };
     const result = await replaceRoute.handler({
@@ -185,26 +217,28 @@ describe("PUT /v1/config/llm/profiles/:name — managed profile guard", () => {
       body: { label: null },
     });
     expect(result).toEqual({ ok: true });
-    const profile = (savedRaw as unknown as Record<string, any>)?.llm?.profiles
-      ?.balanced as Record<string, unknown>;
-    // Label key removed; seed fields preserved.
-    expect("label" in profile).toBe(false);
-    expect(profile.provider).toBe("anthropic");
-    expect(profile.model).toBe("claude-sonnet");
-    expect(profile.source).toBe("managed");
+    const saved = savedRaw as unknown as Record<string, any>;
+    // Key present with null — masks the stale materialized label at merge
+    // time instead of letting it resurface.
+    expect(saved.llm.profileOverrides.balanced).toEqual({ label: null });
+    // The materialized entry's fields are untouched by the PUT.
+    expect(saved.llm.profiles.balanced).toEqual({
+      provider: "anthropic",
+      model: "claude-sonnet",
+      label: "My Custom Name",
+      source: "managed",
+    });
   });
 
-  test("PUT { status: null } on managed profile clears status (back to active-by-absence)", async () => {
+  test("PUT { status: null } clears status, leaving other override keys untouched", async () => {
     savedRaw = null;
     rawConfig = {
       llm: {
         profiles: {
-          "quality-optimized": {
-            provider: "anthropic",
-            model: "claude-opus",
-            status: "disabled",
-            source: "managed",
-          },
+          "quality-optimized": { provider: "anthropic", model: "claude-opus" },
+        },
+        profileOverrides: {
+          "quality-optimized": { label: "Keep Me", status: "disabled" },
         },
       },
     };
@@ -213,25 +247,21 @@ describe("PUT /v1/config/llm/profiles/:name — managed profile guard", () => {
       body: { status: null },
     });
     expect(result).toEqual({ ok: true });
-    const profile = (savedRaw as unknown as Record<string, any>)?.llm
-      ?.profiles?.["quality-optimized"] as Record<string, unknown>;
-    expect("status" in profile).toBe(false);
-    expect(profile.provider).toBe("anthropic");
-    expect(profile.model).toBe("claude-opus");
+    const saved = savedRaw as unknown as Record<string, any>;
+    // status cleared to the null sentinel; the absent label key left the
+    // existing label override alone.
+    expect(saved.llm.profileOverrides["quality-optimized"]).toEqual({
+      label: "Keep Me",
+      status: null,
+    });
   });
 
   test("PUT { label: null, status: null } clears both in a single request", async () => {
     savedRaw = null;
     rawConfig = {
       llm: {
-        profiles: {
-          "cost-optimized": {
-            provider: "anthropic",
-            model: "claude-haiku",
-            label: "Speed (Custom)",
-            status: "disabled",
-            source: "managed",
-          },
+        profileOverrides: {
+          "cost-optimized": { label: "Speed (Custom)", status: "disabled" },
         },
       },
     };
@@ -240,26 +270,18 @@ describe("PUT /v1/config/llm/profiles/:name — managed profile guard", () => {
       body: { label: null, status: null },
     });
     expect(result).toEqual({ ok: true });
-    const profile = (savedRaw as unknown as Record<string, any>)?.llm
-      ?.profiles?.["cost-optimized"] as Record<string, unknown>;
-    expect("label" in profile).toBe(false);
-    expect(profile.status).toBeUndefined();
-    expect(profile.provider).toBe("anthropic");
-    expect(profile.model).toBe("claude-haiku");
+    const saved = savedRaw as unknown as Record<string, any>;
+    expect(saved.llm.profileOverrides["cost-optimized"]).toEqual({
+      label: null,
+      status: null,
+    });
   });
 
   test("PUT { label: null, status: 'disabled' } mixes clear + set in one call", async () => {
     savedRaw = null;
     rawConfig = {
       llm: {
-        profiles: {
-          balanced: {
-            provider: "anthropic",
-            model: "claude-sonnet",
-            label: "Custom Label",
-            source: "managed",
-          },
-        },
+        profileOverrides: { balanced: { label: "Custom Label" } },
       },
     };
     const result = await replaceRoute.handler({
@@ -267,10 +289,11 @@ describe("PUT /v1/config/llm/profiles/:name — managed profile guard", () => {
       body: { label: null, status: "disabled" },
     });
     expect(result).toEqual({ ok: true });
-    const profile = (savedRaw as unknown as Record<string, any>)?.llm?.profiles
-      ?.balanced as Record<string, unknown>;
-    expect("label" in profile).toBe(false);
-    expect(profile.status).toBe("disabled");
+    const saved = savedRaw as unknown as Record<string, any>;
+    expect(saved.llm.profileOverrides.balanced).toEqual({
+      label: null,
+      status: "disabled",
+    });
   });
 
   test("PUT { label: '' } on managed profile still rejected by `.min(1)`", async () => {
@@ -362,16 +385,24 @@ describe("PATCH /v1/config — managed profile deletion guard", () => {
     });
   });
 
-  test("allows patches that modify a managed profile (non-null)", async () => {
+  test("drops non-overridable fields from a managed profile patch instead of persisting them", async () => {
     savedRaw = null;
     const result = await patchRoute.handler({
       body: {
         llm: {
-          profiles: { "quality-optimized": { provider: "anthropic" } },
+          profiles: { "quality-optimized": { provider: "openai" } },
         },
       },
     });
     expect(result).toEqual({ ok: true });
+    const saved = savedRaw as unknown as Record<string, any>;
+    // The on-disk entry is exactly what the fixture had — the patched
+    // provider never landed, and no override store was created.
+    expect(saved.llm.profiles["quality-optimized"]).toEqual({
+      provider: "anthropic",
+      model: "claude-sonnet",
+    });
+    expect(saved.llm.profileOverrides).toBeUndefined();
   });
 
   test("rejects nulling the entire profiles map", async () => {
@@ -380,5 +411,226 @@ describe("PATCH /v1/config — managed profile deletion guard", () => {
         body: { llm: { profiles: null } },
       }),
     ).rejects.toThrow("Cannot null llm.profiles");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PATCH /v1/config — built-in profile writes are re-routed to profileOverrides
+// ---------------------------------------------------------------------------
+
+describe("PATCH /v1/config — built-in profile sanitization", () => {
+  test("built-in label/status edits land in profileOverrides, not llm.profiles", async () => {
+    rawConfig = {
+      llm: {
+        profiles: { "my-custom": { provider: "openai", model: "gpt-4o" } },
+      },
+    };
+    const result = await patchRoute.handler({
+      body: {
+        llm: { profiles: { balanced: { label: "X", status: "disabled" } } },
+      },
+    });
+    expect(result).toEqual({ ok: true });
+    const saved = savedRaw as unknown as Record<string, any>;
+    expect(saved.llm.profiles.balanced).toBeUndefined();
+    expect(saved.llm.profileOverrides.balanced).toEqual({
+      label: "X",
+      status: "disabled",
+    });
+    // Custom profiles are untouched by the sanitizer.
+    expect(saved.llm.profiles["my-custom"]).toEqual({
+      provider: "openai",
+      model: "gpt-4o",
+    });
+  });
+
+  test("PATCH with { model: 'foo' } on a built-in drops the field from the write", async () => {
+    rawConfig = {
+      llm: {
+        profiles: { "my-custom": { provider: "openai", model: "gpt-4o" } },
+      },
+    };
+    const result = await patchRoute.handler({
+      body: { llm: { profiles: { balanced: { model: "foo" } } } },
+    });
+    expect(result).toEqual({ ok: true });
+    const saved = savedRaw as unknown as Record<string, any>;
+    // Nothing of the built-in write survives: no materialized entry, no
+    // override entry.
+    expect(saved.llm.profiles.balanced).toBeUndefined();
+    expect(saved.llm.profileOverrides).toBeUndefined();
+  });
+
+  test("explicit body profileOverrides win over values lifted from a merged profiles entry", async () => {
+    rawConfig = { llm: { profiles: {} } };
+    const result = await patchRoute.handler({
+      body: {
+        llm: {
+          profiles: { balanced: { label: "Lifted" } },
+          profileOverrides: { balanced: { label: "Explicit" } },
+        },
+      },
+    });
+    expect(result).toEqual({ ok: true });
+    const saved = savedRaw as unknown as Record<string, any>;
+    expect(saved.llm.profileOverrides.balanced).toEqual({ label: "Explicit" });
+    expect(saved.llm.profiles.balanced).toBeUndefined();
+  });
+
+  test("an unmodified GET → PATCH round trip creates no overrides and leaves raw profiles unchanged", async () => {
+    const got = (await getRoute.handler({})) as Record<string, any>;
+    const result = await patchRoute.handler({
+      body: { llm: { profiles: got.llm.profiles } },
+    });
+    expect(result).toEqual({ ok: true });
+    const saved = savedRaw as unknown as Record<string, any>;
+    // No override materialized from round-tripping the merged template
+    // values, and the on-disk (transition-state) entry is exactly what was
+    // there before.
+    expect(saved.llm.profileOverrides).toBeUndefined();
+    expect(saved.llm.profiles.balanced).toEqual({
+      provider: "anthropic",
+      model: "claude-sonnet",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /v1/config/set — built-in profile writes are re-routed to
+// profileOverrides with path-aware replace semantics
+// ---------------------------------------------------------------------------
+
+describe("POST /v1/config/set — built-in profile sanitization", () => {
+  test("single-field set on a built-in routes to profileOverrides and leaves the materialized entry untouched", async () => {
+    const result = await setRoute.handler({
+      body: { path: "llm.profiles.balanced.label", value: "Renamed" },
+    });
+    expect(result).toEqual({ ok: true });
+    const saved = savedRaw as unknown as Record<string, any>;
+    expect(saved.llm.profileOverrides.balanced).toEqual({ label: "Renamed" });
+    expect(saved.llm.profiles.balanced).toEqual({
+      provider: "anthropic",
+      model: "claude-sonnet",
+    });
+  });
+
+  test("set of a non-overridable built-in field is dropped", async () => {
+    const result = await setRoute.handler({
+      body: { path: "llm.profiles.balanced.maxTokens", value: 999 },
+    });
+    expect(result).toEqual({ ok: true });
+    const saved = savedRaw as unknown as Record<string, any>;
+    expect(saved.llm.profiles.balanced).toEqual({
+      provider: "anthropic",
+      model: "claude-sonnet",
+    });
+    expect(saved.llm.profileOverrides).toBeUndefined();
+  });
+
+  test("whole-entry set on a built-in lifts label/status and strips the entry from disk", async () => {
+    const result = await setRoute.handler({
+      body: {
+        path: "llm.profiles.balanced",
+        value: { label: "Mine", status: "disabled", model: "smuggled" },
+      },
+    });
+    expect(result).toEqual({ ok: true });
+    const saved = savedRaw as unknown as Record<string, any>;
+    expect(saved.llm.profiles.balanced).toBeUndefined();
+    expect(saved.llm.profileOverrides.balanced).toEqual({
+      label: "Mine",
+      status: "disabled",
+    });
+  });
+
+  test("set llm.profiles replaces customs and converts built-ins to overrides", async () => {
+    const result = await setRoute.handler({
+      body: {
+        path: "llm.profiles",
+        value: {
+          balanced: { label: "B", model: "smuggled" },
+          "new-custom": { provider: "openai", model: "gpt-4o" },
+        },
+      },
+    });
+    expect(result).toEqual({ ok: true });
+    const saved = savedRaw as unknown as Record<string, any>;
+    expect(saved.llm.profiles).toEqual({
+      "new-custom": { provider: "openai", model: "gpt-4o" },
+    });
+    expect(saved.llm.profileOverrides.balanced).toEqual({ label: "B" });
+  });
+
+  test("an unmodified GET → set llm round trip persists no built-ins and creates no overrides", async () => {
+    const got = (await getRoute.handler({})) as Record<string, any>;
+    const result = await setRoute.handler({
+      body: { path: "llm", value: got.llm },
+    });
+    expect(result).toEqual({ ok: true });
+    const saved = savedRaw as unknown as Record<string, any>;
+    for (const name of [
+      "auto",
+      "balanced",
+      "quality-optimized",
+      "cost-optimized",
+      "balanced-economy",
+    ]) {
+      expect(saved.llm.profiles[name]).toBeUndefined();
+    }
+    expect(saved.llm.profileOverrides).toBeUndefined();
+    expect(saved.llm.profiles["my-custom"]).toMatchObject({
+      provider: "openai",
+      model: "gpt-4o",
+    });
+  });
+
+  test("a round-tripped GET body lifts a transition-state seeder status instead of losing it", async () => {
+    rawConfig = {
+      llm: {
+        profiles: {
+          balanced: {
+            provider: "anthropic",
+            model: "claude-drifted",
+            status: "disabled",
+            source: "managed",
+          },
+          "my-custom": { provider: "openai", model: "gpt-4o" },
+        },
+      },
+    };
+    const got = (await getRoute.handler({})) as Record<string, any>;
+    const result = await setRoute.handler({
+      body: { path: "llm", value: got.llm },
+    });
+    expect(result).toEqual({ ok: true });
+    const saved = savedRaw as unknown as Record<string, any>;
+    expect(saved.llm.profiles.balanced).toBeUndefined();
+    // The materialized entry's status survived the strip as an override; the
+    // unmodified template label did not become one.
+    expect(saved.llm.profileOverrides.balanced).toEqual({
+      status: "disabled",
+    });
+    expect(saved.llm.profileOverrides["quality-optimized"]).toBeUndefined();
+  });
+
+  test("set llm.profiles.<builtin> to null is still rejected", async () => {
+    await expect(
+      setRoute.handler({
+        body: { path: "llm.profiles.balanced", value: null },
+      }),
+    ).rejects.toThrow('Cannot delete managed profile "balanced".');
+  });
+
+  test("set of an unrelated path leaves materialized built-in entries alone", async () => {
+    const result = await setRoute.handler({
+      body: { path: "heartbeat.enabled", value: true },
+    });
+    expect(result).toEqual({ ok: true });
+    const saved = savedRaw as unknown as Record<string, any>;
+    expect(saved.heartbeat).toEqual({ enabled: true });
+    expect(saved.llm.profiles.balanced).toEqual({
+      provider: "anthropic",
+      model: "claude-sonnet",
+    });
   });
 });

--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -25,6 +25,9 @@ mock.module("../../../config/loader.js", () => ({
   loadRawConfig: () => structuredClone(rawConfigFixture),
   saveRawConfig: (raw: Record<string, unknown>) => {
     savedRawConfig = raw;
+    // Round-trip support: subsequent loadRawConfig() calls (e.g. a GET
+    // /v1/config issued after a write) see the persisted state.
+    rawConfigFixture = structuredClone(raw);
   },
   deepMergeOverwrite: (
     target: Record<string, unknown>,
@@ -97,6 +100,8 @@ const conversationLlmContextRoute = ROUTES.find(
 const replaceProfileRoute = ROUTES.find(
   (r) => r.operationId === "config_llm_profiles_replace",
 )!;
+
+const getConfigRoute = ROUTES.find((r) => r.operationId === "config_get")!;
 
 function dispatchLlmContext(messageId: string) {
   return llmContextRoute.handler({ pathParams: { id: messageId } });
@@ -820,41 +825,50 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
       };
     });
 
-    test("allows label edit on managed profile, preserving seed fields", async () => {
+    test("label edit lands in profileOverrides and round-trips through GET /v1/config", async () => {
       const result = await replaceProfileRoute.handler({
         pathParams: { name: "balanced" },
         body: { label: "My Balanced" },
       });
 
       expect(result).toEqual({ ok: true });
-      const savedProfile = (
-        savedRawConfig?.llm as {
-          profiles: Record<string, Record<string, unknown>>;
-        }
-      ).profiles.balanced;
+      const savedLlm = savedRawConfig?.llm as Record<
+        string,
+        Record<string, Record<string, unknown>>
+      >;
+      expect(savedLlm.profileOverrides.balanced).toEqual({
+        label: "My Balanced",
+      });
+      // The seeded transition-state entry under llm.profiles is untouched.
+      expect(savedLlm.profiles.balanced.label).toBe("Balanced");
 
-      expect(savedProfile.label).toBe("My Balanced");
-      // Seed fields preserved.
-      expect(savedProfile.provider).toBe("anthropic");
-      expect(savedProfile.model).toBe("claude-sonnet-4-6");
-      expect(savedProfile.source).toBe("managed");
+      // The effective config exposes the override on the merged entry.
+      const got = (await getConfigRoute.handler({})) as {
+        llm: { profiles: Record<string, Record<string, unknown>> };
+      };
+      expect(got.llm.profiles.balanced.label).toBe("My Balanced");
     });
 
-    test("allows status edit on managed profile", async () => {
+    test("status edit lands in profileOverrides and round-trips through GET /v1/config", async () => {
       const result = await replaceProfileRoute.handler({
         pathParams: { name: "balanced" },
         body: { status: "disabled" },
       });
 
       expect(result).toEqual({ ok: true });
-      const savedProfile = (
-        savedRawConfig?.llm as {
-          profiles: Record<string, Record<string, unknown>>;
-        }
-      ).profiles.balanced;
+      const savedLlm = savedRawConfig?.llm as Record<
+        string,
+        Record<string, Record<string, unknown>>
+      >;
+      expect(savedLlm.profileOverrides.balanced).toEqual({
+        status: "disabled",
+      });
+      expect(savedLlm.profiles.balanced.status).toBe("active");
 
-      expect(savedProfile.status).toBe("disabled");
-      expect(savedProfile.provider).toBe("anthropic");
+      const got = (await getConfigRoute.handler({})) as {
+        llm: { profiles: Record<string, Record<string, unknown>> };
+      };
+      expect(got.llm.profiles.balanced.status).toBe("disabled");
     });
 
     test("allows label+status edit together", async () => {
@@ -864,14 +878,42 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
       });
 
       expect(result).toEqual({ ok: true });
-      const savedProfile = (
-        savedRawConfig?.llm as {
-          profiles: Record<string, Record<string, unknown>>;
-        }
-      ).profiles.balanced;
+      const savedLlm = savedRawConfig?.llm as Record<
+        string,
+        Record<string, Record<string, unknown>>
+      >;
+      expect(savedLlm.profileOverrides.balanced).toEqual({
+        label: "Renamed",
+        status: "disabled",
+      });
+    });
 
-      expect(savedProfile.label).toBe("Renamed");
-      expect(savedProfile.status).toBe("disabled");
+    test("PUT { label: null } stores the null sentinel and clears the user label", async () => {
+      await replaceProfileRoute.handler({
+        pathParams: { name: "balanced" },
+        body: { label: "My Balanced" },
+      });
+      const result = await replaceProfileRoute.handler({
+        pathParams: { name: "balanced" },
+        body: { label: null },
+      });
+
+      expect(result).toEqual({ ok: true });
+      const savedLlm = savedRawConfig?.llm as Record<
+        string,
+        Record<string, Record<string, unknown>>
+      >;
+      expect(savedLlm.profileOverrides.balanced).toEqual({ label: null });
+
+      // Effective view: the null sentinel masks both the previous override
+      // and the stale materialized label ("Balanced" on the seeded fixture
+      // entry), so the user-visible custom label is gone. Per the loader's
+      // null-as-cleared semantics the merged entry carries `label: null`;
+      // clients fall back to their default presentation for the profile.
+      const got = (await getConfigRoute.handler({})) as {
+        llm: { profiles: Record<string, Record<string, unknown>> };
+      };
+      expect(got.llm.profiles.balanced.label).toBeNull();
     });
 
     test("rejects provider edit on managed profile with disallowed-keys error", async () => {
@@ -904,6 +946,49 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
       expect(initializeProvidersCalls).toBe(0);
       expect(invalidateConfigCacheCalls).toBe(0);
       expect(clearEmbeddingBackendCacheCalls).toBe(0);
+    });
+  });
+
+  describe("mix profile validation", () => {
+    test("a mix referencing a built-in validates against the effective profile set", async () => {
+      // The fixture has no "balanced" entry on disk — the arm can only
+      // resolve through the code-defined built-ins merged at load time.
+      const result = await replaceProfileRoute.handler({
+        pathParams: { name: "my-mix" },
+        body: {
+          mix: [
+            { profile: "balanced", weight: 1 },
+            { profile: "custom", weight: 1 },
+          ],
+        },
+      });
+
+      expect(result).toEqual({ ok: true });
+      const savedProfile = (
+        savedRawConfig?.llm as {
+          profiles: Record<string, Record<string, unknown>>;
+        }
+      ).profiles["my-mix"];
+      expect(savedProfile.mix).toEqual([
+        { profile: "balanced", weight: 1 },
+        { profile: "custom", weight: 1 },
+      ]);
+    });
+
+    test("a mix referencing an undefined profile is rejected", async () => {
+      await expect(
+        replaceProfileRoute.handler({
+          pathParams: { name: "my-mix" },
+          body: {
+            mix: [
+              { profile: "balanced", weight: 1 },
+              { profile: "no-such-profile", weight: 1 },
+            ],
+          },
+        }),
+      ).rejects.toThrow(
+        'references profile "no-such-profile" which is not defined',
+      );
     });
   });
 

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -36,7 +36,10 @@ import {
 } from "../../config/loader.js";
 import { AssistantConfigSchema } from "../../config/schema.js";
 import { getSchemaAtPath } from "../../config/schema-utils.js";
-import { ProfileEntry } from "../../config/schemas/llm.js";
+import {
+  ProfileEntry,
+  ProfileOverrideEntry,
+} from "../../config/schemas/llm.js";
 import { VALID_MEMORY_EMBEDDING_PROVIDERS } from "../../config/schemas/memory-storage.js";
 import { getConfigWatcher } from "../../daemon/config-watcher.js";
 import {
@@ -172,13 +175,8 @@ function replaceInferenceProfileConfig(
   name: string,
   fragment: Record<string, unknown>,
 ): void {
-  const existingLlm = asMutablePlainObject(raw.llm);
-  const llm = existingLlm ?? {};
-  if (!existingLlm) raw.llm = llm;
-
-  const existingProfiles = asMutablePlainObject(llm.profiles);
-  const profiles = existingProfiles ?? {};
-  if (!existingProfiles) llm.profiles = profiles;
+  const llm = ensureObjectAt(raw, "llm");
+  const profiles = ensureObjectAt(llm, "profiles");
 
   const existingProfile = asMutablePlainObject(profiles[name]) ?? {};
   const nextProfile: Record<string, unknown> = { ...existingProfile };
@@ -538,6 +536,292 @@ function rejectManagedProfileDeletion(body: Record<string, unknown>): void {
 }
 
 /**
+ * Read `parent[key]` as a plain object, creating (and assigning) an empty one
+ * when the current value is absent or not a plain object.
+ */
+function ensureObjectAt(
+  parent: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> {
+  const existing = asMutablePlainObject(parent[key]);
+  if (existing) return existing;
+  const created: Record<string, unknown> = {};
+  parent[key] = created;
+  return created;
+}
+
+/**
+ * Effective (built-ins merged) view of the given raw config's `llm.profiles`.
+ * Works on a clone — `applyBuiltinProfiles` mutates its argument and `raw`
+ * may be destined for disk, where built-in entries must never land.
+ */
+function effectiveLlmProfiles(
+  raw: Record<string, unknown>,
+): Record<string, unknown> {
+  const merged = structuredClone(raw);
+  applyBuiltinProfiles(merged);
+  const llm = asMutablePlainObject(merged.llm);
+  return (llm && asMutablePlainObject(llm.profiles)) ?? {};
+}
+
+/**
+ * Whether `value` is persistable under `llm.profileOverrides[*][key]`. Defers
+ * to the `ProfileOverrideEntry` schema so the legality rule has one source of
+ * truth (the explicit `undefined` check exists because Zod treats it as
+ * "absent", which would otherwise lift a key that JSON can't round-trip).
+ */
+function isLegalBuiltinOverrideValue(
+  key: "label" | "status",
+  value: unknown,
+): boolean {
+  if (value === undefined) return false;
+  return ProfileOverrideEntry.safeParse({ [key]: value }).success;
+}
+
+/**
+ * Split a built-in profile entry arriving on a generic config write into the
+ * override fragment to persist and the keys to drop.
+ *
+ * - Only `label`/`status` are user-ownable on built-ins; everything else is
+ *   dropped (callers warn) rather than rejected, because clients round-trip
+ *   `GET /v1/config` output, which contains the fully merged built-in
+ *   entries.
+ * - A key equal to the current effective value is skipped: an unmodified
+ *   GET → write round trip must not materialize overrides that would pin the
+ *   template's label/status forever.
+ * - Values outside the override shape (empty label, unknown status) are
+ *   dropped too — persisting them would fail `ProfileOverrideEntry`'s strict
+ *   parse and poison the next full config load.
+ */
+function extractBuiltinProfileOverride(
+  entry: Record<string, unknown>,
+  effectiveEntry: Record<string, unknown> | null,
+): { lifted: Record<string, unknown>; dropped: string[] } {
+  const lifted: Record<string, unknown> = {};
+  const dropped: string[] = [];
+  for (const [key, value] of Object.entries(entry)) {
+    if (key !== "label" && key !== "status") {
+      dropped.push(key);
+      continue;
+    }
+    if (!isLegalBuiltinOverrideValue(key, value)) {
+      dropped.push(key);
+      continue;
+    }
+    if (value === effectiveEntry?.[key]) continue;
+    lifted[key] = value;
+  }
+  return { lifted, dropped };
+}
+
+function warnDroppedBuiltinProfileFields(
+  name: string,
+  dropped: string[],
+): void {
+  if (dropped.length === 0) return;
+  log.warn(
+    { profile: name, droppedKeys: dropped },
+    `Dropped non-overridable fields [${dropped.join(", ")}] from built-in profile "${name}" config write — only label and status are user-editable`,
+  );
+}
+
+/**
+ * Merge a lifted `{label?, status?}` fragment into the raw config's
+ * `llm.profileOverrides[name]`. With `explicitWins`, keys already present on
+ * the stored override entry are kept (used when that entry was itself part
+ * of the incoming write — the override store is the canonical write surface
+ * for built-ins, so an explicit override beats a value lifted from a merged
+ * `llm.profiles` entry in the same write).
+ */
+function liftIntoRawProfileOverrides(
+  raw: Record<string, unknown>,
+  name: string,
+  lifted: Record<string, unknown>,
+  opts: { explicitWins?: boolean } = {},
+): void {
+  if (Object.keys(lifted).length === 0) return;
+  const llm = ensureObjectAt(raw, "llm");
+  const overrides = ensureObjectAt(llm, "profileOverrides");
+  const existing = asMutablePlainObject(overrides[name]);
+  if (!existing) {
+    overrides[name] = lifted;
+    return;
+  }
+  overrides[name] = opts.explicitWins
+    ? { ...lifted, ...existing }
+    : { ...existing, ...lifted };
+}
+
+/**
+ * Re-route built-in profile edits arriving on the generic `PATCH /v1/config`
+ * body into `llm.profileOverrides`, and drop everything else.
+ *
+ * Built-in profiles are code-defined and merged into reads at load time, so
+ * clients legitimately round-trip `GET /v1/config` bodies that contain fully
+ * materialized built-in entries (the web manage-profiles modal's managed
+ * edit does exactly this). Rejecting would break those clients; instead:
+ *
+ * - `label`/`status` keys (including the `null` clear sentinel) move into
+ *   the write's `llm.profileOverrides[name]`, but only when they differ from
+ *   the current effective merged value — an unmodified round trip persists
+ *   no override.
+ * - When the body also carries an explicit `llm.profileOverrides[name]`
+ *   value for the same key, the explicit override wins.
+ * - All other fields are dropped with a warning; the templates in
+ *   `builtin-inference-profiles.ts` are authoritative.
+ *
+ * `currentRaw` is only read (effective-value comparisons); `body` is mutated
+ * in place. `rejectManagedProfileDeletion` runs before this, so built-in
+ * entries here are never `null`.
+ */
+function sanitizeBuiltinProfileWrites(
+  body: Record<string, unknown>,
+  currentRaw: Record<string, unknown>,
+): void {
+  const llm = asMutablePlainObject(body.llm);
+  const profiles = llm ? asMutablePlainObject(llm.profiles) : null;
+  if (!llm || !profiles) return;
+  const builtinNames = Object.keys(profiles).filter((name) =>
+    MANAGED_PROFILE_NAMES.has(name),
+  );
+  if (builtinNames.length === 0) return;
+
+  const effective = effectiveLlmProfiles(currentRaw);
+  for (const name of builtinNames) {
+    const entry = asMutablePlainObject(profiles[name]);
+    delete profiles[name];
+    if (!entry) {
+      warnDroppedBuiltinProfileFields(name, ["<non-object entry>"]);
+      continue;
+    }
+    const { lifted, dropped } = extractBuiltinProfileOverride(
+      entry,
+      asMutablePlainObject(effective[name]),
+    );
+    warnDroppedBuiltinProfileFields(name, dropped);
+    // The body is root-shaped, so the raw-config lift applies directly.
+    liftIntoRawProfileOverrides(body, name, lifted, { explicitWins: true });
+  }
+}
+
+/**
+ * `setNestedValue` with built-in-profile sanitization for the direct-path
+ * config set (`assistant config set <key> <value>`). The same contract as
+ * PATCH applies — built-in profile edits land in `llm.profileOverrides`,
+ * never as materialized `llm.profiles` entries — but the replace-at-path
+ * semantics need path-aware handling:
+ *
+ * - `llm` / `llm.profiles`: the written profiles map replaces the old one.
+ *   Built-in entries are stripped from what lands on disk; their
+ *   label/status lift into `llm.profileOverrides` when they differ from
+ *   what the template + remaining override store resolve to, so a
+ *   round-tripped `GET /v1/config` body neither re-materializes built-ins
+ *   on disk nor creates redundant overrides. For `set llm`, an explicit
+ *   `profileOverrides` carried by the written value wins over lifted values.
+ * - `llm.profiles.<builtin>`: replace semantics for the entry — any
+ *   materialized entry is removed from disk and the written label/status
+ *   lift into the override store.
+ * - `llm.profiles.<builtin>.label|status`: single-field set routes straight
+ *   to the override store (when it differs from the current effective
+ *   value). A still-materialized transition-state entry is left untouched —
+ *   cleaning those up is the collapse migration's job.
+ * - Any other/deeper field under a built-in entry is dropped with a warning
+ *   (only label and status are user-editable on built-ins).
+ */
+function setConfigValueWithBuiltinSanitizer(
+  raw: Record<string, unknown>,
+  path: string,
+  value: unknown,
+): void {
+  const segments = path.split(".");
+  const touchesProfiles =
+    segments[0] === "llm" &&
+    (segments.length === 1 || segments[1] === "profiles");
+  if (!touchesProfiles) {
+    setNestedValue(raw, path, value);
+    return;
+  }
+
+  if (segments.length <= 2) {
+    // Whole-map (`llm.profiles`) or whole-subtree (`llm`) replacement.
+    setNestedValue(raw, path, value);
+    const llm = asMutablePlainObject(raw.llm);
+    const profiles = llm ? asMutablePlainObject(llm.profiles) : null;
+    if (!llm || !profiles) return;
+    const builtinEntries = new Map<string, Record<string, unknown> | null>();
+    for (const name of Object.keys(profiles)) {
+      if (!MANAGED_PROFILE_NAMES.has(name)) continue;
+      builtinEntries.set(name, asMutablePlainObject(profiles[name]));
+      delete profiles[name];
+    }
+    if (builtinEntries.size === 0) return;
+    // Baseline AFTER stripping: what each built-in resolves to from the
+    // template plus the override store this write leaves in place. A
+    // transition-state seeder entry's label/status that the round-tripped
+    // body carries differs from this baseline and is lifted instead of lost.
+    const effective = effectiveLlmProfiles(raw);
+    for (const [name, entry] of builtinEntries) {
+      if (!entry) {
+        warnDroppedBuiltinProfileFields(name, ["<non-object entry>"]);
+        continue;
+      }
+      const { lifted, dropped } = extractBuiltinProfileOverride(
+        entry,
+        asMutablePlainObject(effective[name]),
+      );
+      warnDroppedBuiltinProfileFields(name, dropped);
+      liftIntoRawProfileOverrides(raw, name, lifted, {
+        // For `set llm`, raw.llm.profileOverrides is the write's own payload.
+        explicitWins: segments.length === 1,
+      });
+    }
+    return;
+  }
+
+  const name = segments[2];
+  if (!MANAGED_PROFILE_NAMES.has(name)) {
+    setNestedValue(raw, path, value);
+    return;
+  }
+
+  if (segments.length === 3) {
+    // Replace a single built-in entry: nothing lands under `llm.profiles`,
+    // and any previous materialized entry is removed per replace semantics.
+    const llm = asMutablePlainObject(raw.llm);
+    const profiles = llm ? asMutablePlainObject(llm.profiles) : null;
+    if (profiles) delete profiles[name];
+    const entry = asMutablePlainObject(value);
+    if (!entry) {
+      warnDroppedBuiltinProfileFields(name, ["<non-object entry>"]);
+      return;
+    }
+    const { lifted, dropped } = extractBuiltinProfileOverride(
+      entry,
+      asMutablePlainObject(effectiveLlmProfiles(raw)[name]),
+    );
+    warnDroppedBuiltinProfileFields(name, dropped);
+    liftIntoRawProfileOverrides(raw, name, lifted);
+    return;
+  }
+
+  // Single-field set inside a built-in entry.
+  const key = segments[3];
+  if (
+    segments.length === 4 &&
+    (key === "label" || key === "status") &&
+    isLegalBuiltinOverrideValue(key, value)
+  ) {
+    const effectiveEntry = asMutablePlainObject(
+      effectiveLlmProfiles(raw)[name],
+    );
+    if (value === effectiveEntry?.[key]) return;
+    liftIntoRawProfileOverrides(raw, name, { [key]: value });
+    return;
+  }
+  warnDroppedBuiltinProfileFields(name, [segments.slice(3).join(".")]);
+}
+
+/**
  * Persist a mutated raw config object to disk and synchronize the running
  * daemon (file-watcher, embedding cache, provider registry).
  *
@@ -602,6 +886,7 @@ async function handlePatchConfig({ body }: RouteHandlerArgs) {
 
   const raw = loadRawConfig();
   const patch = body as Record<string, unknown>;
+  sanitizeBuiltinProfileWrites(patch, raw);
   deepMergeOverwrite(raw, patch);
 
   await commitConfigWrite(raw, "patch");
@@ -650,7 +935,7 @@ async function handleSetConfig({ body }: RouteHandlerArgs) {
   rejectManagedProfileDeletion(patchShape);
 
   const raw = loadRawConfig();
-  setNestedValue(raw, path, value);
+  setConfigValueWithBuiltinSanitizer(raw, path, value);
 
   await commitConfigWrite(raw, "set");
   return { ok: true };
@@ -703,11 +988,12 @@ async function handleReplaceInferenceProfile({
   }
   const isManaged = MANAGED_PROFILE_NAMES.has(name);
   if (isManaged) {
-    // Managed profiles are daemon-seeded — provider, model, advanced params,
-    // and the connection binding all belong to the seed contract and can't
-    // be reshaped by the user. The two fields that ARE user policy (display
-    // label and enabled status) are allowed through so users can rename a
-    // managed profile or temporarily disable it without duplicating it.
+    // Built-in profiles are code-defined — provider, model, advanced params,
+    // and the connection binding all belong to the template contract and
+    // can't be reshaped by the user. The two fields that ARE user policy
+    // (display label and enabled status) are allowed through so users can
+    // rename a built-in profile or temporarily disable it without
+    // duplicating it.
     const requestedKeys = Object.keys(parsed.data);
     const disallowed = requestedKeys.filter(
       (k) => k !== "label" && k !== "status",
@@ -719,12 +1005,15 @@ async function handleReplaceInferenceProfile({
       );
     }
   }
+  const raw = loadRawConfig();
   // Mix profiles reference other profiles by name. `ProfileEntry.safeParse`
   // above validates the fragment in isolation, so the cross-profile integrity
   // rules `LLMSchema.superRefine` enforces on full-config load (every arm
   // exists, no nesting, no self-reference, no config fields) must be checked
   // here against the live profile set — otherwise an invalid mix would persist
-  // and break the next full config reparse.
+  // and break the next full config reparse. Validation runs against the
+  // EFFECTIVE profile set (built-ins merged), not the raw one: mixes may
+  // reference built-in profiles, which no longer live in config.json.
   if (parsed.data.mix != null) {
     const MIX_ALLOWED_KEYS = new Set([
       "mix",
@@ -741,14 +1030,14 @@ async function handleReplaceInferenceProfile({
         `Mix profile "${name}" cannot also set [${extraneous.join(", ")}] — a mix only references other profiles plus metadata (label, description, status).`,
       );
     }
-    const existingProfiles = getConfig().llm.profiles ?? {};
+    const existingProfiles = effectiveLlmProfiles(raw);
     parsed.data.mix.forEach((arm, index) => {
       if (arm.profile === name) {
         throw new BadRequestError(
           `Mix profile "${name}" cannot reference itself (arm ${index}).`,
         );
       }
-      const target = existingProfiles[arm.profile];
+      const target = asMutablePlainObject(existingProfiles[arm.profile]);
       if (target == null) {
         throw new BadRequestError(
           `Mix profile "${name}" references profile "${arm.profile}" which is not defined.`,
@@ -791,14 +1080,11 @@ async function handleReplaceInferenceProfile({
     }
   }
 
-  const raw = loadRawConfig();
   if (isManaged) {
-    // Partial overlay: keep every existing key intact, only update label
-    // and/or status from the fragment. Using `replaceInferenceProfileConfig`
-    // here would wipe the UI-owned seed fields (provider, model, advanced
-    // params) because that function assumes the body carries the full UI
-    // surface.
-    patchManagedProfileFields(raw, name, fragment);
+    // Built-in profile edits live in the sparse `llm.profileOverrides`
+    // store — nothing is written under `llm.profiles`, whose built-in
+    // entries are code-defined and merged at load time.
+    writeBuiltinProfileOverride(raw, name, fragment);
   } else {
     replaceInferenceProfileConfig(raw, name, fragment);
   }
@@ -816,42 +1102,23 @@ async function handleReplaceInferenceProfile({
 }
 
 /**
- * Apply a `{label?, status?}` patch to a managed profile entry, preserving
- * every other field already on disk (provider, model, advanced params, etc).
+ * Persist a `{label?, status?}` edit for a built-in profile into the sparse
+ * `llm.profileOverrides` store. Key-presence semantics: a key present with
+ * `null` stores the null sentinel ("explicitly cleared" — it masks any
+ * stale label/status still carried by a transition-state materialized entry
+ * at merge time); an absent key leaves the existing override key untouched.
  * Caller is responsible for having already restricted the fragment to the
- * managed-allowed keys.
+ * override-allowed keys.
  */
-function patchManagedProfileFields(
+function writeBuiltinProfileOverride(
   raw: Record<string, unknown>,
   name: string,
   fragment: Record<string, unknown>,
 ): void {
-  const existingLlm = asMutablePlainObject(raw.llm);
-  const llm = existingLlm ?? {};
-  if (!existingLlm) raw.llm = llm;
-
-  const existingProfiles = asMutablePlainObject(llm.profiles);
-  const profiles = existingProfiles ?? {};
-  if (!existingProfiles) llm.profiles = profiles;
-
-  const existingProfile = asMutablePlainObject(profiles[name]) ?? {};
-  const nextProfile: Record<string, unknown> = { ...existingProfile };
-  // Send `null` to clear; omit to leave untouched.
-  if ("label" in fragment) {
-    if (fragment.label === null) {
-      delete nextProfile.label;
-    } else {
-      nextProfile.label = fragment.label;
-    }
-  }
-  if ("status" in fragment) {
-    if (fragment.status === null) {
-      delete nextProfile.status;
-    } else {
-      nextProfile.status = fragment.status;
-    }
-  }
-  profiles[name] = nextProfile;
+  const next: Record<string, unknown> = {};
+  if ("label" in fragment) next.label = fragment.label;
+  if ("status" in fragment) next.status = fragment.status;
+  liftIntoRawProfileOverrides(raw, name, next);
 }
 
 function handleSearchConversations({ queryParams = {} }: RouteHandlerArgs) {


### PR DESCRIPTION
## Summary
- PUT /v1/config/llm/profiles/:name now writes built-in label/status edits to llm.profileOverrides (nullable sentinels preserved)
- Generic PATCH/SET config writes re-route built-in label/status into overrides and drop other built-in fields with a warning (round-trip safe)
- Mix-arm validation runs against the effective (merged) profile set

Part of plan: builtin-llm-profiles.md (PR 4 of 8)