### PR TITLE
fix(web): save managed profile edits via the dedicated profile replace endpoint

### DIFF
--- a/apps/web/src/domains/settings/ai/ai-types.ts
+++ b/apps/web/src/domains/settings/ai/ai-types.ts
@@ -60,6 +60,18 @@ export interface ProfileEntry {
 
 export type ProfileWithName = { name: string } & ProfileEntry;
 
+/**
+ * Body for the dedicated profile replace endpoint
+ * (`PUT /v1/config/llm/profiles/:name`, operation
+ * `config_llm_profiles_replace`) when editing a managed profile.
+ *
+ * Built-in profiles are code-defined on the daemon; only the user-policy
+ * leaves (display label, enabled status) may be edited. The daemon persists
+ * them as sparse `llm.profileOverrides` entries. `null` is a clear
+ * sentinel; an absent key leaves the stored override untouched.
+ */
+export type ProfileOverridePatch = Pick<ProfileEntry, "label" | "status">;
+
 export interface DaemonConfig {
   services?: {
     "web-search"?: { mode?: string; provider?: string };

--- a/apps/web/src/domains/settings/ai/manage-profiles-modal.tsx
+++ b/apps/web/src/domains/settings/ai/manage-profiles-modal.tsx
@@ -2,13 +2,13 @@ import { useMemo, useRef, useState } from "react";
 
 import { captureError } from "@/lib/sentry/capture-error";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Button } from "@vellumai/design-library/components/button";
 import { Modal } from "@vellumai/design-library/components/modal";
 import { toast } from "@vellumai/design-library/components/toast";
 import { Typography } from "@vellumai/design-library/components/typography";
 
-import type { CallSiteOverrideDraft, DaemonConfigPatch, ProfileEntry, ProfileStatus, ProfileWithName } from "@/domains/settings/ai/ai-types";
+import type { CallSiteOverrideDraft, DaemonConfigPatch, ProfileEntry, ProfileOverridePatch, ProfileStatus, ProfileWithName } from "@/domains/settings/ai/ai-types";
 import type { BlockedDeleteState } from "@/domains/settings/ai/manage-profiles-blocked-delete-modal";
 import { BlockedDeleteModal } from "@/domains/settings/ai/manage-profiles-blocked-delete-modal";
 import { ProfileListItem } from "@/domains/settings/ai/manage-profiles-list-item";
@@ -17,6 +17,8 @@ import { gateAutoProfile } from "@/domains/settings/ai/profile-pickers";
 import { filterFlaggedConnections } from "@/domains/settings/ai/provider-connections-client";
 import { useDaemonConfigMutation, useDaemonConfigQuery } from "@/domains/settings/ai/use-daemon-config";
 import { inferenceProviderconnectionsGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
+import { configLlmProfilesByNamePut } from "@/generated/daemon/sdk.gen";
+import { assistantDaemonConfigQueryKey } from "@/lib/sync/query-tags";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -45,6 +47,7 @@ export function ManageProfilesModal({
     callSites,
   } = useDaemonConfigQuery();
   const configMutation = useDaemonConfigMutation();
+  const queryClient = useQueryClient();
 
   const openAICompatibleEndpoints = useAssistantFeatureFlagStore.use.openAICompatibleEndpoints();
   const chatgptSubscriptionAuth = useAssistantFeatureFlagStore.use.chatgptSubscriptionAuth();
@@ -76,12 +79,26 @@ export function ManageProfilesModal({
     const mode = options?.mode ?? "replace";
     const isNew = !(name in profiles);
 
-    // Merge mode (view-mode managed-profile policy edits): send a single
-    // deep-merge PATCH so the caller's partial `entry` (typically just
-    // `{label, status}`) layers on top of the existing record without
-    // wiping seed-owned fields.
+    // Merge mode (view-mode managed-profile policy edits): managed profiles
+    // are code-defined on the daemon, so label/status edits go through the
+    // dedicated replace endpoint (`config_llm_profiles_replace`), which
+    // persists them as sparse `llm.profileOverrides` entries instead of
+    // writing into `llm.profiles`.
     if (mode === "merge" && !isNew) {
-      await configMutation.mutateAsync({ llm: { profiles: { [name]: entry } } });
+      const override: ProfileOverridePatch = {
+        label: entry.label,
+        status: entry.status,
+      };
+      await configLlmProfilesByNamePut({
+        path: { assistant_id: assistantId, name },
+        body: override,
+        throwOnError: true,
+      });
+      // Replicate `useDaemonConfigMutation`'s settle-time invalidation so
+      // every consumer of the config query refetches the updated profile.
+      void queryClient.invalidateQueries({
+        queryKey: assistantDaemonConfigQueryKey(assistantId),
+      });
       setEditorOpen(false);
       setEditingProfile(null);
       return;

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -4376,12 +4376,31 @@ paths:
       responses:
         "200":
           description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                required:
+                  - ok
+                additionalProperties: false
       parameters:
         - name: name
           in: path
           required: true
           schema:
             type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              propertyNames:
+                type: string
+              additionalProperties: {}
   /v1/config/platform:
     get:
       operationId: config_platform_get

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -1512,6 +1512,11 @@ export const ROUTES: RouteDefinition[] = [
     description:
       "Replace the settings-UI-managed leaves of a single llm.profiles entry while preserving non-UI leaves.",
     tags: ["config"],
+    // The handler validates against the full `ProfileEntry` Zod schema (with
+    // nullable clear-sentinels and managed-profile field restrictions), so
+    // the spec advertises an open object — same approach as `config_patch`.
+    requestBody: z.record(z.string(), z.unknown()),
+    responseBody: z.object({ ok: z.boolean() }),
     handler: handleReplaceInferenceProfile,
   },
   {


### PR DESCRIPTION
## Summary
- Managed-profile label/status edits in Settings → AI now use PUT /v1/config/llm/profiles/:name (config_llm_profiles_replace) instead of the generic config PATCH
- Edits persist to llm.profileOverrides on the daemon; modal refresh preserved (manual invalidation of the same config query the old mutation hook invalidated)
- The daemon route now declares its request/response body schemas (same open-object approach as config_patch), so the generated web SDK exposes a typed body instead of `body?: never`; regenerated assistant/openapi.yaml accordingly
- Custom-profile create/edit/delete flows are untouched
- Correctness/clarity change: the server-side sanitizer added in PR 4 keeps old clients working

Part of plan: builtin-llm-profiles.md (PR 5 of 8)