### PR TITLE
fix: isolate tool-invocation test helper from production imports and clean up telemetry tests

### DIFF
--- a/assistant/src/memory/__tests__/tool-invocation-test-helpers.ts
+++ b/assistant/src/memory/__tests__/tool-invocation-test-helpers.ts
@@ -2,9 +2,13 @@
  * Shared seeding helper for tests that exercise the tool_invocations →
  * telemetry projection chain. Inserts raw audit rows (with PII-sentinel
  * input/result payloads) plus the FK-required conversation row.
+ *
+ * No source-module imports: per the test-machinery isolation rule
+ * (`assistant/AGENTS.md`), shared test helpers must not reach into
+ * `src/`. Callers pass in the real `getDb()` handle and schema table
+ * refs; the structural types below describe only the slice this helper
+ * uses.
  */
-import { getDb } from "../db-connection.js";
-import { conversations, toolInvocations } from "../schema.js";
 
 /**
  * Sentinel embedded in the seeded raw input/result payloads. Assert it
@@ -12,21 +16,40 @@ import { conversations, toolInvocations } from "../schema.js";
  */
 export const TOOL_INVOCATION_PII_SENTINEL = "must never leave the device";
 
+interface SeedStatement {
+  run(): unknown;
+}
+
+export interface ToolInvocationSeedDeps {
+  db: {
+    insert(table: unknown): {
+      values(row: Record<string, unknown>): SeedStatement & {
+        onConflictDoNothing(): SeedStatement;
+      };
+    };
+  };
+  conversations: unknown;
+  toolInvocations: unknown;
+}
+
 export interface SeedToolInvocationSpec {
   id: string;
   createdAt: number;
   conversationId: string;
   toolName?: string;
-  skillId?: string | null;
+  skillId?: string;
   decision?: string;
   riskLevel?: string;
   durationMs?: number;
 }
 
-export function seedToolInvocation(spec: SeedToolInvocationSpec): void {
-  const db = getDb();
+export function seedToolInvocation(
+  deps: ToolInvocationSeedDeps,
+  spec: SeedToolInvocationSpec,
+): void {
   // tool_invocations has an enforced FK to conversations.
-  db.insert(conversations)
+  deps.db
+    .insert(deps.conversations)
     .values({
       id: spec.conversationId,
       title: "test",
@@ -35,7 +58,8 @@ export function seedToolInvocation(spec: SeedToolInvocationSpec): void {
     })
     .onConflictDoNothing()
     .run();
-  db.insert(toolInvocations)
+  deps.db
+    .insert(deps.toolInvocations)
     .values({
       id: spec.id,
       conversationId: spec.conversationId,

--- a/assistant/src/memory/tool-execution-events-store.test.ts
+++ b/assistant/src/memory/tool-execution-events-store.test.ts
@@ -11,6 +11,7 @@ import { createToolAuditListener } from "../events/tool-audit-listener.js";
 import {
   seedToolInvocation,
   type SeedToolInvocationSpec,
+  TOOL_INVOCATION_PII_SENTINEL,
 } from "./__tests__/tool-invocation-test-helpers.js";
 import { getDb } from "./db-connection.js";
 import { initializeDb } from "./db-init.js";
@@ -24,23 +25,15 @@ const CONVERSATION_ID = "conv-tool-exec-store-test";
 function insertInvocation(
   spec: Omit<SeedToolInvocationSpec, "conversationId">,
 ): void {
-  seedToolInvocation({ ...spec, conversationId: CONVERSATION_ID });
+  seedToolInvocation(
+    { db: getDb(), conversations, toolInvocations },
+    { ...spec, conversationId: CONVERSATION_ID },
+  );
 }
 
 describe("tool-execution-events-store", () => {
   beforeEach(() => {
-    const db = getDb();
-    db.delete(toolInvocations).run();
-    // tool_invocations has an enforced FK to conversations.
-    db.insert(conversations)
-      .values({
-        id: CONVERSATION_ID,
-        title: "test",
-        createdAt: 1000,
-        updatedAt: 1000,
-      })
-      .onConflictDoNothing()
-      .run();
+    getDb().delete(toolInvocations).run();
   });
 
   test("returns rows in (createdAt, id) order with projected fields", () => {
@@ -76,10 +69,7 @@ describe("tool-execution-events-store", () => {
     });
     // Raw tool args/outputs are potentially PII — the projection must
     // never include them.
-    for (const row of rows) {
-      expect(Object.keys(row)).not.toContain("input");
-      expect(Object.keys(row)).not.toContain("result");
-    }
+    expect(JSON.stringify(rows)).not.toContain(TOOL_INVOCATION_PII_SENTINEL);
   });
 
   test("query advances past the compound (createdAt, id) cursor", () => {
@@ -112,6 +102,19 @@ describe("tool-execution-events-store", () => {
   });
 
   test("skill-routed lifecycle events persist skill_id end to end; direct calls stay null", () => {
+    // The audit listener writes through recordToolInvocation, which (unlike
+    // seedToolInvocation) does not seed the FK-required conversation row.
+    getDb()
+      .insert(conversations)
+      .values({
+        id: CONVERSATION_ID,
+        title: "test",
+        createdAt: 1000,
+        updatedAt: 1000,
+      })
+      .onConflictDoNothing()
+      .run();
+
     // Default recorder = recordToolInvocation, so this exercises the full
     // audit listener → tool_invocations → telemetry projection chain.
     const listener = createToolAuditListener();

--- a/assistant/src/memory/tool-usage-store.ts
+++ b/assistant/src/memory/tool-usage-store.ts
@@ -14,8 +14,8 @@ export interface ToolInvocationRecord {
   decision: string;
   riskLevel: string;
   matchedTrustRuleId?: string;
-  /** Id of the skill whose `skill_execute` dispatch triggered this tool call. Null for direct tool calls. */
-  skillId?: string | null;
+  /** Id of the skill whose `skill_execute` dispatch triggered this tool call. Absent for direct tool calls. */
+  skillId?: string;
   durationMs: number;
 }
 

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -154,14 +154,18 @@ mock.module("../memory/onboarding-events-store.js", () => ({
 // ---------------------------------------------------------------------------
 
 import {
-  seedToolInvocation as seedToolInvocationRow,
+  seedToolInvocation,
   type SeedToolInvocationSpec,
   TOOL_INVOCATION_PII_SENTINEL,
 } from "../memory/__tests__/tool-invocation-test-helpers.js";
 import { recordAuthFallbackCounts } from "../memory/auth-fallback-events-store.js";
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
-import { authFallbackEvents, toolInvocations } from "../memory/schema.js";
+import {
+  authFallbackEvents,
+  conversations,
+  toolInvocations,
+} from "../memory/schema.js";
 import type { UsageEvent } from "../usage/types.js";
 import {
   ACTIVATION_FUNNEL_VERSION,
@@ -246,13 +250,13 @@ function makeOnboardingEvent(
 
 const TOOL_EXEC_CONVERSATION_ID = "conv-tool-exec-reporter-test";
 
-function seedToolInvocation(
+function insertInvocation(
   spec: Omit<SeedToolInvocationSpec, "conversationId">,
 ): void {
-  seedToolInvocationRow({
-    ...spec,
-    conversationId: TOOL_EXEC_CONVERSATION_ID,
-  });
+  seedToolInvocation(
+    { db: getDb(), conversations, toolInvocations },
+    { ...spec, conversationId: TOOL_EXEC_CONVERSATION_ID },
+  );
 }
 
 const originalFetch = globalThis.fetch;
@@ -974,7 +978,7 @@ describe("UsageTelemetryReporter", () => {
     mockCollectUsageData = false;
     const events = [makeUsageEvent()];
     mockQueryUnreportedUsageEvents.mockReturnValue(events);
-    seedToolInvocation({ id: "ti-opt-out", createdAt: 1700000000000 });
+    insertInvocation({ id: "ti-opt-out", createdAt: 1700000000000 });
     mockFetch.mockImplementation(() =>
       Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
     );
@@ -1248,7 +1252,7 @@ describe("UsageTelemetryReporter", () => {
 
   test("tool_invocations rows flush as tool_execution events with mapped fields and no raw input/result", async () => {
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
-    seedToolInvocation({
+    insertInvocation({
       id: "ti-flush-direct",
       createdAt: 1700000900000,
       toolName: "calendar_list_events",
@@ -1256,7 +1260,7 @@ describe("UsageTelemetryReporter", () => {
       riskLevel: "high",
       durationMs: 137,
     });
-    seedToolInvocation({
+    insertInvocation({
       id: "ti-flush-skill",
       createdAt: 1700000950000,
       toolName: "task_create",
@@ -1312,8 +1316,8 @@ describe("UsageTelemetryReporter", () => {
 
   test("tool_execution watermark advances to the last reported row on success", async () => {
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
-    seedToolInvocation({ id: "ti-wm-1", createdAt: 1700001000000 });
-    seedToolInvocation({ id: "ti-wm-2", createdAt: 1700001001000 });
+    insertInvocation({ id: "ti-wm-1", createdAt: 1700001000000 });
+    insertInvocation({ id: "ti-wm-2", createdAt: 1700001001000 });
     mockFetch.mockImplementation(() =>
       Promise.resolve(new Response('{"accepted":2}', { status: 200 })),
     );
@@ -1338,7 +1342,7 @@ describe("UsageTelemetryReporter", () => {
 
   test("tool_execution watermark stays on failed upload", async () => {
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
-    seedToolInvocation({ id: "ti-fail-1", createdAt: 1700001100000 });
+    insertInvocation({ id: "ti-fail-1", createdAt: 1700001100000 });
     mockFetch.mockImplementation(() =>
       Promise.resolve(new Response("error", { status: 500 })),
     );


### PR DESCRIPTION
## Summary
Fixes round-2 review gaps for tool-telemetry-daemon.md: shared test helper now complies with the AGENTS.md test-machinery isolation rule (Codex P1 on #34147) by taking the db/table refs from callers; removes dead | null typing on ToolInvocationRecord.skillId; drops import-alias shadowing, duplicated FK seeding, and redundant projection assertions in favor of the PII sentinel.