### PR TITLE
fix: extract shared scaffolding for conversation-tool-setup tests

### DIFF
--- a/assistant/src/__tests__/conversation-tool-setup-app-refresh.test.ts
+++ b/assistant/src/__tests__/conversation-tool-setup-app-refresh.test.ts
@@ -12,55 +12,20 @@
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import type { ToolSetupContext } from "../daemon/conversation-tool-setup.js";
-import type { SurfaceData, SurfaceType } from "../daemon/message-protocol.js";
 import { SYNC_TAGS } from "../daemon/message-types/sync.js";
 import type { PermissionPrompter } from "../permissions/prompter.js";
 import type { SecretPrompter } from "../permissions/secret-prompter.js";
 import type { ToolExecutor } from "../tools/executor.js";
 import type { ToolExecutionResult } from "../tools/types.js";
+import {
+  broadcastMessageSpy as broadcastSpy,
+  installConversationToolSetupMocks,
+  makeToolSetupContext as makeCtx,
+  refreshSurfacesForAppSpy as refreshSpy,
+  updatePublishedAppDeploymentSpy as updatePublishedSpy,
+} from "./conversation-tool-setup-test-helpers.js";
 
-// ---------------------------------------------------------------------------
-// Spies for side-effect verification
-// ---------------------------------------------------------------------------
-
-const refreshSpy = mock(() => {});
-const updatePublishedSpy = mock(() => Promise.resolve());
-const broadcastSpy = mock(() => {});
-
-mock.module("../runtime/assistant-event-hub.js", () => ({
-  broadcastMessage: broadcastSpy,
-}));
-
-// Mock session-surfaces so refreshSurfacesForApp is captured
-mock.module("../daemon/conversation-surfaces.js", () => ({
-  refreshSurfacesForApp: refreshSpy,
-  surfaceProxyResolver: mock(() =>
-    Promise.resolve({ content: "", isError: false }),
-  ),
-}));
-
-// Mock published-app-updater to prevent real deployment calls
-mock.module("../services/published-app-updater.js", () => ({
-  updatePublishedAppDeployment: updatePublishedSpy,
-}));
-
-// Mock browser-screencast registration (no-op)
-mock.module("../tools/browser/browser-screencast.js", () => ({
-  registerConversationSender: mock(() => {}),
-}));
-
-// Stub app-store functions used by other modules (e.g. app-source-watcher,
-// conversation-surfaces) so tool-side-effects' hooks can run without touching
-// the real app store during tests.
-mock.module("../memory/app-store.js", () => ({
-  getApp: mock(() => null),
-  getAppDirPath: mock(() => "/tmp/test-apps/dummy"),
-  isMultifileApp: mock(() => false),
-  getAppsDir: mock(() => "/tmp/test-apps"),
-  resolveAppIdByDirName: mock(() => null),
-  resolveAppIdFromPath: mock(() => null),
-}));
+installConversationToolSetupMocks();
 
 // ---------------------------------------------------------------------------
 // Import createToolExecutor after mocks are in place
@@ -83,34 +48,6 @@ function expectAppChangeBroadcast(appId: string): void {
       { type: "sync_changed", tags: [SYNC_TAGS.appsList] },
     ]) as never,
   );
-}
-
-/** Build a minimal ToolSetupContext stub. */
-function makeCtx(overrides: Partial<ToolSetupContext> = {}): ToolSetupContext {
-  return {
-    conversationId: "conv-test",
-    currentRequestId: "req-1",
-    workingDir: "/tmp/test",
-    abortController: null,
-    traceEmitter: { emit: () => {} },
-    sendToClient: mock(() => {}),
-    pendingSurfaceActions: new Map(),
-    lastSurfaceAction: new Map(),
-    surfaceState: new Map<
-      string,
-      { surfaceType: SurfaceType; data: SurfaceData; title?: string }
-    >(),
-    surfaceUndoStacks: new Map(),
-    accumulatedSurfaceState: new Map(),
-    surfaceActionRequestIds: new Set<string>(),
-    currentTurnSurfaces: [],
-    isProcessing: () => false,
-    enqueueMessage: () => ({ queued: false, requestId: "r" }),
-    getQueueDepth: () => 0,
-    processMessage: async () => "",
-    withSurface: async <T>(_id: string, fn: () => T | Promise<T>) => fn(),
-    ...overrides,
-  };
 }
 
 /** Fake ToolExecutor whose execute() returns a controlled result. */

--- a/assistant/src/__tests__/conversation-tool-setup-skill-attribution.test.ts
+++ b/assistant/src/__tests__/conversation-tool-setup-skill-attribution.test.ts
@@ -7,41 +7,17 @@
 
 import { afterAll, describe, expect, mock, test } from "bun:test";
 
-import type { ToolSetupContext } from "../daemon/conversation-tool-setup.js";
-import type { SurfaceData, SurfaceType } from "../daemon/message-protocol.js";
 import type { PermissionPrompter } from "../permissions/prompter.js";
 import type { SecretPrompter } from "../permissions/secret-prompter.js";
 import { RiskLevel } from "../permissions/types.js";
 import type { ToolExecutor } from "../tools/executor.js";
 import type { Tool, ToolContext, ToolExecutionResult } from "../tools/types.js";
+import {
+  installConversationToolSetupMocks,
+  makeToolSetupContext,
+} from "./conversation-tool-setup-test-helpers.js";
 
-mock.module("../runtime/assistant-event-hub.js", () => ({
-  broadcastMessage: mock(() => {}),
-}));
-
-mock.module("../daemon/conversation-surfaces.js", () => ({
-  refreshSurfacesForApp: mock(() => {}),
-  surfaceProxyResolver: mock(() =>
-    Promise.resolve({ content: "", isError: false }),
-  ),
-}));
-
-mock.module("../services/published-app-updater.js", () => ({
-  updatePublishedAppDeployment: mock(() => Promise.resolve()),
-}));
-
-mock.module("../tools/browser/browser-screencast.js", () => ({
-  registerConversationSender: mock(() => {}),
-}));
-
-mock.module("../memory/app-store.js", () => ({
-  getApp: mock(() => null),
-  getAppDirPath: mock(() => "/tmp/test-apps/dummy"),
-  isMultifileApp: mock(() => false),
-  getAppsDir: mock(() => "/tmp/test-apps"),
-  resolveAppIdByDirName: mock(() => null),
-  resolveAppIdFromPath: mock(() => null),
-}));
+installConversationToolSetupMocks();
 
 import { createToolExecutor } from "../daemon/conversation-tool-setup.js";
 import { registerSkillTools, unregisterSkillTools } from "../tools/registry.js";
@@ -61,32 +37,6 @@ const skillTool: Tool = {
 
 registerSkillTools(SKILL_ID, [skillTool]);
 afterAll(() => unregisterSkillTools(SKILL_ID));
-
-function makeCtx(): ToolSetupContext {
-  return {
-    conversationId: "conv-test",
-    currentRequestId: "req-1",
-    workingDir: "/tmp/test",
-    abortController: null,
-    traceEmitter: { emit: () => {} },
-    sendToClient: mock(() => {}),
-    pendingSurfaceActions: new Map(),
-    lastSurfaceAction: new Map(),
-    surfaceState: new Map<
-      string,
-      { surfaceType: SurfaceType; data: SurfaceData; title?: string }
-    >(),
-    surfaceUndoStacks: new Map(),
-    accumulatedSurfaceState: new Map(),
-    surfaceActionRequestIds: new Set<string>(),
-    currentTurnSurfaces: [],
-    isProcessing: () => false,
-    enqueueMessage: () => ({ queued: false, requestId: "r" }),
-    getQueueDepth: () => 0,
-    processMessage: async () => "",
-    withSurface: async <T>(_id: string, fn: () => T | Promise<T>) => fn(),
-  };
-}
 
 /** Fake ToolExecutor that captures the context of each execute() call. */
 function makeCapturingExecutor() {
@@ -116,7 +66,7 @@ function makeToolFn(executor: ToolExecutor) {
     executor,
     noopPrompter,
     noopSecretPrompter,
-    makeCtx(),
+    makeToolSetupContext(),
     () => {},
   );
 }

--- a/assistant/src/__tests__/conversation-tool-setup-test-helpers.ts
+++ b/assistant/src/__tests__/conversation-tool-setup-test-helpers.ts
@@ -1,0 +1,98 @@
+/**
+ * Shared scaffolding for conversation-tool-setup (createToolExecutor) tests.
+ *
+ * `installConversationToolSetupMocks()` mocks the side-effect modules that
+ * conversation-tool-setup.ts pulls in at import time. `mock.module` is
+ * process-global and order-sensitive: call it BEFORE the import statement for
+ * `../daemon/conversation-tool-setup.js`, mirroring how the test files
+ * sequence statements and imports.
+ *
+ * Test-machinery isolation (assistant/AGENTS.md): this helper's only runtime
+ * import is `bun:test`, and the mock factories return plain stub objects.
+ * Production types are referenced via `import type` only — a value import
+ * would pull those modules' import-time side effects into this helper.
+ */
+
+import { mock } from "bun:test";
+
+import type { ToolSetupContext } from "../daemon/conversation-tool-setup.js";
+import type { SurfaceData, SurfaceType } from "../daemon/message-protocol.js";
+
+/**
+ * Spies installed by {@link installConversationToolSetupMocks}. Shared across
+ * test files in the same process — clear them in `beforeEach` when asserting
+ * on call counts.
+ */
+export const refreshSurfacesForAppSpy = mock(() => {});
+export const broadcastMessageSpy = mock(() => {});
+export const updatePublishedAppDeploymentSpy = mock(() => Promise.resolve());
+
+/**
+ * Mock the modules whose import-time / call-time side effects must not run
+ * during conversation-tool-setup tests.
+ */
+export function installConversationToolSetupMocks(): void {
+  mock.module("../runtime/assistant-event-hub.js", () => ({
+    broadcastMessage: broadcastMessageSpy,
+  }));
+
+  // Mock conversation-surfaces so refreshSurfacesForApp is captured.
+  mock.module("../daemon/conversation-surfaces.js", () => ({
+    refreshSurfacesForApp: refreshSurfacesForAppSpy,
+    surfaceProxyResolver: mock(() =>
+      Promise.resolve({ content: "", isError: false }),
+    ),
+  }));
+
+  // Mock published-app-updater to prevent real deployment calls.
+  mock.module("../services/published-app-updater.js", () => ({
+    updatePublishedAppDeployment: updatePublishedAppDeploymentSpy,
+  }));
+
+  // Mock browser-screencast registration (no-op).
+  mock.module("../tools/browser/browser-screencast.js", () => ({
+    registerConversationSender: mock(() => {}),
+  }));
+
+  // Stub app-store functions used by other modules (e.g. app-source-watcher,
+  // conversation-surfaces) so tool-side-effects' hooks can run without
+  // touching the real app store during tests.
+  mock.module("../memory/app-store.js", () => ({
+    getApp: mock(() => null),
+    getAppDirPath: mock(() => "/tmp/test-apps/dummy"),
+    isMultifileApp: mock(() => false),
+    getAppsDir: mock(() => "/tmp/test-apps"),
+    resolveAppIdByDirName: mock(() => null),
+    resolveAppIdFromPath: mock(() => null),
+  }));
+}
+
+/** Build a minimal ToolSetupContext stub. */
+export function makeToolSetupContext(
+  overrides: Partial<ToolSetupContext> = {},
+): ToolSetupContext {
+  return {
+    conversationId: "conv-test",
+    currentRequestId: "req-1",
+    workingDir: "/tmp/test",
+    abortController: null,
+    traceEmitter: { emit: () => {} },
+    sendToClient: mock(() => {}),
+    pendingSurfaceActions: new Map(),
+    lastSurfaceAction: new Map(),
+    surfaceState: new Map<
+      string,
+      { surfaceType: SurfaceType; data: SurfaceData; title?: string }
+    >(),
+    surfaceUndoStacks: new Map(),
+    accumulatedSurfaceState: new Map(),
+    surfaceActionRequestIds: new Set<string>(),
+    currentTurnSurfaces: [],
+    isProcessing: () => false,
+    enqueueMessage: () => ({ queued: false, requestId: "r" }),
+    getQueueDepth: () => 0,
+    processMessage: async () => "",
+    withSurface: async <T>(_id: string, fn: () => T | Promise<T>) => fn(),
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## Summary
Fixes a round-2 review gap for tool-telemetry-daemon.md: the new skill-attribution test duplicated ~70 lines of mock.module + ToolSetupContext scaffolding from the app-refresh test; extracted a shared helper compliant with the AGENTS.md test-machinery isolation rule.