### PR TITLE
fix: remove chatgptSubscriptionAuth web selectors and prop drilling (GA'ed)

### DIFF
--- a/apps/web/src/components/profile-quick-add-provider.test.tsx
+++ b/apps/web/src/components/profile-quick-add-provider.test.tsx
@@ -29,7 +29,6 @@ mock.module("@/stores/resolved-assistants-store", () => {
 mock.module("@/stores/assistant-feature-flag-store", () => {
   const store = () => null;
   store.use = {
-    openAICompatibleEndpoints: () => false,
     chatgptSubscriptionAuth: () => false,
   };
   return { useAssistantFeatureFlagStore: store };

--- a/apps/web/src/components/profile-quick-add-provider.test.tsx
+++ b/apps/web/src/components/profile-quick-add-provider.test.tsx
@@ -25,15 +25,6 @@ mock.module("@/stores/resolved-assistants-store", () => {
   return { useResolvedAssistantsStore: store };
 });
 
-// --- feature flag store ------------------------------------------------------
-mock.module("@/stores/assistant-feature-flag-store", () => {
-  const store = () => null;
-  store.use = {
-    chatgptSubscriptionAuth: () => false,
-  };
-  return { useAssistantFeatureFlagStore: store };
-});
-
 // --- toast -------------------------------------------------------------------
 const toastSuccess = mock((_msg: string) => {});
 mock.module("@vellumai/design-library/components/toast", () => ({

--- a/apps/web/src/components/profile-quick-add-provider.tsx
+++ b/apps/web/src/components/profile-quick-add-provider.tsx
@@ -43,7 +43,6 @@ import { ProfileEditorModal } from "@/domains/settings/ai/profile-editor-modal";
 import { client } from "@/generated/api/client.gen";
 import { inferenceProviderconnectionsGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
 import { assistantDaemonConfigQueryKey } from "@/lib/sync/query-tags";
-import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { toast } from "@vellumai/design-library/components/toast";
 
 interface OpenProfileQuickAddArgs {
@@ -74,8 +73,6 @@ const ProfileQuickAddContext = createContext<ProfileQuickAddContextValue | null>
 
 export function ProfileQuickAddProvider({ children }: { children: ReactNode }) {
   const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
-  const chatgptSubscriptionAuth =
-    useAssistantFeatureFlagStore.use.chatgptSubscriptionAuth();
 
   const queryClient = useQueryClient();
   const [isOpen, setIsOpen] = useState(false);
@@ -200,7 +197,6 @@ export function ProfileQuickAddProvider({ children }: { children: ReactNode }) {
           existingNames={existingNames}
           connections={connections}
           assistantId={assistantId}
-          chatgptSubscriptionEnabled={chatgptSubscriptionAuth}
           onSave={handleSave}
           onCancel={() => setIsOpen(false)}
         />

--- a/apps/web/src/components/profile-quick-add-provider.tsx
+++ b/apps/web/src/components/profile-quick-add-provider.tsx
@@ -40,7 +40,6 @@ import {
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import type { ProfileEntry } from "@/domains/settings/ai/ai-types";
 import { ProfileEditorModal } from "@/domains/settings/ai/profile-editor-modal";
-import { filterFlaggedConnections } from "@/domains/settings/ai/provider-connections-client";
 import { client } from "@/generated/api/client.gen";
 import { inferenceProviderconnectionsGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
 import { assistantDaemonConfigQueryKey } from "@/lib/sync/query-tags";
@@ -75,8 +74,6 @@ const ProfileQuickAddContext = createContext<ProfileQuickAddContextValue | null>
 
 export function ProfileQuickAddProvider({ children }: { children: ReactNode }) {
   const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
-  const openAICompatibleEndpoints =
-    useAssistantFeatureFlagStore.use.openAICompatibleEndpoints();
   const chatgptSubscriptionAuth =
     useAssistantFeatureFlagStore.use.chatgptSubscriptionAuth();
 
@@ -104,16 +101,7 @@ export function ProfileQuickAddProvider({ children }: { children: ReactNode }) {
     }),
     enabled: isOpen && !!assistantId,
   });
-  const connections = useMemo(
-    () =>
-      connectionsData
-        ? filterFlaggedConnections(
-            connectionsData.connections,
-            openAICompatibleEndpoints,
-          )
-        : undefined,
-    [connectionsData, openAICompatibleEndpoints],
-  );
+  const connections = connectionsData?.connections;
 
   // Persist a freshly-created profile, then hand the name back to the caller.
   // Writes `llm.profiles[name]` plus an appended `profileOrder` in a single
@@ -211,7 +199,6 @@ export function ProfileQuickAddProvider({ children }: { children: ReactNode }) {
           mode="create"
           existingNames={existingNames}
           connections={connections}
-          openAICompatibleEndpointsEnabled={openAICompatibleEndpoints}
           assistantId={assistantId}
           chatgptSubscriptionEnabled={chatgptSubscriptionAuth}
           onSave={handleSave}

--- a/apps/web/src/domains/chat/chat-layout.tsx
+++ b/apps/web/src/domains/chat/chat-layout.tsx
@@ -45,7 +45,6 @@ import { openPopoutWindow } from "@/runtime/popout-window";
 import { useVellumCommands } from "@/runtime/vellum-commands";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { useAuthStore } from "@/stores/auth-store";
-import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useViewerStore } from "@/stores/viewer-store";
 import type { Conversation } from "@/types/conversation-types";
@@ -127,7 +126,6 @@ export function ChatLayout() {
   // inherits a populated sidebar on direct navigation — not just /assistant.
   // TanStack Query handles dedup with any other consumer using the same key.
   const conversationGroupsUI = useAssistantFeatureFlagStore.use.conversationGroupsUI();
-  const homePageEnabled = useClientFeatureFlagStore.use.homePage();
   const { conversations } = useConversationListQuery(
     assistantId,
     isAssistantActive,
@@ -168,11 +166,8 @@ export function ChatLayout() {
 
 
   // Home page unread indicator — drives the red dot on the Home button in
-  // the layout header. Gated on the homePage feature flag so the hook
-  // doesn't fire its query when the home route is disabled.
-  const { hasUnreadHome } = useHomeUnreadBadge(
-    homePageEnabled ? assistantId : null,
-  );
+  // the layout header.
+  const { hasUnreadHome } = useHomeUnreadBadge(assistantId);
 
   // Mirror the unread count + signed-in flag into the Electron Dock
   // (no-op off Electron). Uses the conversation list this layout

--- a/apps/web/src/domains/chat/components/composer-settings-menu.test.tsx
+++ b/apps/web/src/domains/chat/components/composer-settings-menu.test.tsx
@@ -40,7 +40,6 @@ mock.module("@/stores/assistant-feature-flag-store", () => {
   const store = () => null;
   store.use = {
     queryComplexityRouting: () => false,
-    openAICompatibleEndpoints: () => false,
     chatgptSubscriptionAuth: () => false,
   };
   return { useAssistantFeatureFlagStore: store };

--- a/apps/web/src/domains/chat/components/composer-settings-menu.test.tsx
+++ b/apps/web/src/domains/chat/components/composer-settings-menu.test.tsx
@@ -40,7 +40,6 @@ mock.module("@/stores/assistant-feature-flag-store", () => {
   const store = () => null;
   store.use = {
     queryComplexityRouting: () => false,
-    chatgptSubscriptionAuth: () => false,
   };
   return { useAssistantFeatureFlagStore: store };
 });

--- a/apps/web/src/domains/settings/ai/manage-profiles-modal.test.tsx
+++ b/apps/web/src/domains/settings/ai/manage-profiles-modal.test.tsx
@@ -63,7 +63,6 @@ mock.module("@/domains/settings/ai/use-daemon-config", () => ({
 mock.module("@/stores/assistant-feature-flag-store", () => {
   const store = () => null;
   store.use = {
-    chatgptSubscriptionAuth: () => false,
     queryComplexityRouting: () => false,
   };
   return { useAssistantFeatureFlagStore: store };

--- a/apps/web/src/domains/settings/ai/manage-profiles-modal.test.tsx
+++ b/apps/web/src/domains/settings/ai/manage-profiles-modal.test.tsx
@@ -63,7 +63,6 @@ mock.module("@/domains/settings/ai/use-daemon-config", () => ({
 mock.module("@/stores/assistant-feature-flag-store", () => {
   const store = () => null;
   store.use = {
-    openAICompatibleEndpoints: () => false,
     chatgptSubscriptionAuth: () => false,
     queryComplexityRouting: () => false,
   };

--- a/apps/web/src/domains/settings/ai/manage-profiles-modal.tsx
+++ b/apps/web/src/domains/settings/ai/manage-profiles-modal.tsx
@@ -45,7 +45,6 @@ export function ManageProfilesModal({
   } = useDaemonConfigQuery();
   const configMutation = useDaemonConfigMutation();
 
-  const chatgptSubscriptionAuth = useAssistantFeatureFlagStore.use.chatgptSubscriptionAuth();
   const [editorOpen, setEditorOpen] = useState(false);
   const [editingProfile, setEditingProfile] = useState<ProfileWithName | null>(null);
 
@@ -166,7 +165,6 @@ export function ManageProfilesModal({
         existingNames={existingNames}
         connections={connections}
         assistantId={assistantId}
-        chatgptSubscriptionEnabled={chatgptSubscriptionAuth}
         onSave={handleEditorSave}
         onCancel={() => {
           setEditorOpen(false);

--- a/apps/web/src/domains/settings/ai/manage-profiles-modal.tsx
+++ b/apps/web/src/domains/settings/ai/manage-profiles-modal.tsx
@@ -14,7 +14,6 @@ import { BlockedDeleteModal } from "@/domains/settings/ai/manage-profiles-blocke
 import { ProfileListItem } from "@/domains/settings/ai/manage-profiles-list-item";
 import { ProfileEditorModal } from "@/domains/settings/ai/profile-editor-modal";
 import { gateAutoProfile } from "@/domains/settings/ai/profile-pickers";
-import { filterFlaggedConnections } from "@/domains/settings/ai/provider-connections-client";
 import { useDaemonConfigMutation, useDaemonConfigQuery } from "@/domains/settings/ai/use-daemon-config";
 import { inferenceProviderconnectionsGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
 
@@ -46,7 +45,6 @@ export function ManageProfilesModal({
   } = useDaemonConfigQuery();
   const configMutation = useDaemonConfigMutation();
 
-  const openAICompatibleEndpoints = useAssistantFeatureFlagStore.use.openAICompatibleEndpoints();
   const chatgptSubscriptionAuth = useAssistantFeatureFlagStore.use.chatgptSubscriptionAuth();
   const [editorOpen, setEditorOpen] = useState(false);
   const [editingProfile, setEditingProfile] = useState<ProfileWithName | null>(null);
@@ -58,13 +56,7 @@ export function ManageProfilesModal({
     }),
     enabled: isOpen,
   });
-  const connections = useMemo(
-    () =>
-      connectionsData
-        ? filterFlaggedConnections(connectionsData.connections, openAICompatibleEndpoints)
-        : undefined,
-    [connectionsData, openAICompatibleEndpoints],
-  );
+  const connections = connectionsData?.connections;
 
   const existingNames = Object.keys(profiles);
 
@@ -173,7 +165,6 @@ export function ManageProfilesModal({
         initialValues={editingProfile ?? undefined}
         existingNames={existingNames}
         connections={connections}
-        openAICompatibleEndpointsEnabled={openAICompatibleEndpoints}
         assistantId={assistantId}
         chatgptSubscriptionEnabled={chatgptSubscriptionAuth}
         onSave={handleEditorSave}

--- a/apps/web/src/domains/settings/ai/manage-providers-modal.tsx
+++ b/apps/web/src/domains/settings/ai/manage-providers-modal.tsx
@@ -14,7 +14,6 @@ import {
 import { inferenceProviderconnectionsByNameDelete } from "@/generated/daemon/sdk.gen";
 
 import {
-    filterFlaggedConnections,
     PROVIDER_DISPLAY_NAMES,
     type ProviderConnection,
 } from "@/domains/settings/ai/provider-connections-client";
@@ -55,7 +54,6 @@ export function ManageProvidersModal({
   assistantId,
   onClose,
 }: ManageProvidersModalProps) {
-  const openAICompatibleEndpoints = useAssistantFeatureFlagStore.use.openAICompatibleEndpoints();
   const chatgptSubscriptionAuth = useAssistantFeatureFlagStore.use.chatgptSubscriptionAuth();
   const [editorOpen, setEditorOpen] = useState(false);
   const [editingConnection, setEditingConnection] = useState<ProviderConnection | null>(null);
@@ -70,8 +68,8 @@ export function ManageProvidersModal({
   });
 
   const connections = useMemo(
-    () => filterFlaggedConnections(data?.connections ?? [], openAICompatibleEndpoints),
-    [data, openAICompatibleEndpoints],
+    () => data?.connections ?? [],
+    [data],
   );
 
   function handleEditorSave(_saved: ProviderConnection) {
@@ -124,7 +122,6 @@ export function ManageProvidersModal({
             connection={editingConnection ?? undefined}
             assistantId={assistantId}
             existingNames={existingNames}
-            openAICompatibleEndpointsEnabled={openAICompatibleEndpoints}
             chatgptSubscriptionEnabled={chatgptSubscriptionAuth}
             onSave={handleEditorSave}
             onCancel={cancelEditor}

--- a/apps/web/src/domains/settings/ai/manage-providers-modal.tsx
+++ b/apps/web/src/domains/settings/ai/manage-providers-modal.tsx
@@ -18,8 +18,6 @@ import {
     type ProviderConnection,
 } from "@/domains/settings/ai/provider-connections-client";
 import { ProviderEditorContent } from "@/domains/settings/ai/provider-editor-modal";
-import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
-
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -54,7 +52,6 @@ export function ManageProvidersModal({
   assistantId,
   onClose,
 }: ManageProvidersModalProps) {
-  const chatgptSubscriptionAuth = useAssistantFeatureFlagStore.use.chatgptSubscriptionAuth();
   const [editorOpen, setEditorOpen] = useState(false);
   const [editingConnection, setEditingConnection] = useState<ProviderConnection | null>(null);
 
@@ -122,7 +119,6 @@ export function ManageProvidersModal({
             connection={editingConnection ?? undefined}
             assistantId={assistantId}
             existingNames={existingNames}
-            chatgptSubscriptionEnabled={chatgptSubscriptionAuth}
             onSave={handleEditorSave}
             onCancel={cancelEditor}
           />

--- a/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -14,7 +14,7 @@ import { getModelsForProvider } from "@/assistant/llm-model-catalog";
 import { inferenceProviderconnectionsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
 
 import type { ProfileEntry, ProfileStatus, ProfileWithName } from "@/domains/settings/ai/ai-types";
-import { INFERENCE_PROVIDER_DISPLAY_NAMES, OPENAI_COMPATIBLE_PROVIDER } from "@/domains/settings/ai/ai-types";
+import { INFERENCE_PROVIDER_DISPLAY_NAMES } from "@/domains/settings/ai/ai-types";
 import {
     ProfileAdvancedParams,
     THINKING_LEVEL_INHERIT,
@@ -54,7 +54,6 @@ export interface ProfileEditorModalProps {
    *   the daemon can't dispatch through.
    */
   connections?: ProviderConnection[];
-  openAICompatibleEndpointsEnabled?: boolean;
   /**
    * Assistant whose provider connections the inline "+ Create new provider"
    * sub-form writes to. Required for the create-mode quick-add flow.
@@ -93,7 +92,6 @@ export function ProfileEditorModal({
   initialValues,
   existingNames,
   connections,
-  openAICompatibleEndpointsEnabled = false,
   assistantId,
   chatgptSubscriptionEnabled = false,
   onSave,
@@ -113,7 +111,6 @@ export function ProfileEditorModal({
           initialValues={initialValues}
           existingNames={existingNames}
           connections={connections}
-          openAICompatibleEndpointsEnabled={openAICompatibleEndpointsEnabled}
           assistantId={assistantId}
           chatgptSubscriptionEnabled={chatgptSubscriptionEnabled}
           onSave={onSave}
@@ -135,7 +132,6 @@ interface ProfileEditorModalInnerProps {
   existingNames: string[];
   // See `ProfileEditorModalProps.connections` for nil-vs-empty semantics.
   connections: ProviderConnection[] | undefined;
-  openAICompatibleEndpointsEnabled: boolean;
   assistantId: string;
   chatgptSubscriptionEnabled: boolean;
   onSave: (
@@ -152,7 +148,6 @@ function ProfileEditorModalInner({
   initialValues,
   existingNames,
   connections,
-  openAICompatibleEndpointsEnabled,
   assistantId,
   chatgptSubscriptionEnabled,
   onSave,
@@ -272,14 +267,9 @@ function ProfileEditorModalInner({
   const availableConnectionsForProvider = useMemo(
     () =>
       provider
-        ? effectiveConnections.filter(
-            (c) =>
-              c.provider === provider &&
-              (openAICompatibleEndpointsEnabled ||
-                c.provider !== OPENAI_COMPATIBLE_PROVIDER),
-          )
+        ? effectiveConnections.filter((c) => c.provider === provider)
         : [],
-    [provider, effectiveConnections, openAICompatibleEndpointsEnabled],
+    [provider, effectiveConnections],
   );
 
   // Saved binding no longer points at any known connection. The save handler
@@ -678,12 +668,6 @@ function ProfileEditorModalInner({
     const seen = new Set<string>();
     const opts: { value: string; label: string }[] = [];
     for (const c of effectiveConnections) {
-      if (
-        !openAICompatibleEndpointsEnabled &&
-        c.provider === OPENAI_COMPATIBLE_PROVIDER
-      ) {
-        continue;
-      }
       if (!seen.has(c.provider)) {
         seen.add(c.provider);
         opts.push({
@@ -697,7 +681,7 @@ function ProfileEditorModalInner({
       label: "+ Create new provider",
     });
     return opts;
-  }, [effectiveConnections, openAICompatibleEndpointsEnabled]);
+  }, [effectiveConnections]);
 
   const createProviderSection = (
     <div className="space-y-4">
@@ -746,7 +730,6 @@ function ProfileEditorModalInner({
           variant="inline"
           assistantId={assistantId}
           existingNames={effectiveConnections.map((c) => c.name)}
-          openAICompatibleEndpointsEnabled={openAICompatibleEndpointsEnabled}
           chatgptSubscriptionEnabled={chatgptSubscriptionEnabled}
           defaultProviderType={
             (provider || undefined) as ConnectionProvider | undefined
@@ -763,7 +746,6 @@ function ProfileEditorModalInner({
           onModelChange={handleModelChange}
           onConnectionChange={handleConnectionChange}
           connections={effectiveConnections}
-          openAICompatibleEndpointsEnabled={openAICompatibleEndpointsEnabled}
           isReadOnly={isReadOnly}
           availableConnectionsForProvider={availableConnectionsForProvider}
           connectionNotFound={connectionNotFound}
@@ -868,7 +850,6 @@ function ProfileEditorModalInner({
                 onModelChange={handleModelChange}
                 onConnectionChange={handleConnectionChange}
                 connections={connections}
-                openAICompatibleEndpointsEnabled={openAICompatibleEndpointsEnabled}
                 isReadOnly={isReadOnly}
                 availableConnectionsForProvider={availableConnectionsForProvider}
                 connectionNotFound={connectionNotFound}

--- a/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -59,9 +59,6 @@ export interface ProfileEditorModalProps {
    * sub-form writes to. Required for the create-mode quick-add flow.
    */
   assistantId: string;
-  /** Surfaces the "Sign in with ChatGPT" subscription path in the inline
-   *  provider create sub-form when enabled. */
-  chatgptSubscriptionEnabled?: boolean;
   /**
    * Persist a profile entry. The optional `options.mode` argument tells the
    * parent how to combine `entry` with the existing on-disk record:
@@ -93,7 +90,6 @@ export function ProfileEditorModal({
   existingNames,
   connections,
   assistantId,
-  chatgptSubscriptionEnabled = false,
   onSave,
   onCancel,
 }: ProfileEditorModalProps) {
@@ -112,7 +108,6 @@ export function ProfileEditorModal({
           existingNames={existingNames}
           connections={connections}
           assistantId={assistantId}
-          chatgptSubscriptionEnabled={chatgptSubscriptionEnabled}
           onSave={onSave}
           onCancel={onCancel}
         />
@@ -133,7 +128,6 @@ interface ProfileEditorModalInnerProps {
   // See `ProfileEditorModalProps.connections` for nil-vs-empty semantics.
   connections: ProviderConnection[] | undefined;
   assistantId: string;
-  chatgptSubscriptionEnabled: boolean;
   onSave: (
     name: string,
     entry: ProfileEntry,
@@ -149,7 +143,6 @@ function ProfileEditorModalInner({
   existingNames,
   connections,
   assistantId,
-  chatgptSubscriptionEnabled,
   onSave,
   onCancel,
 }: ProfileEditorModalInnerProps) {
@@ -730,7 +723,6 @@ function ProfileEditorModalInner({
           variant="inline"
           assistantId={assistantId}
           existingNames={effectiveConnections.map((c) => c.name)}
-          chatgptSubscriptionEnabled={chatgptSubscriptionEnabled}
           defaultProviderType={
             (provider || undefined) as ConnectionProvider | undefined
           }

--- a/apps/web/src/domains/settings/ai/profile-editor-provider-section.tsx
+++ b/apps/web/src/domains/settings/ai/profile-editor-provider-section.tsx
@@ -40,7 +40,6 @@ interface ProfileEditorProviderSectionProps {
   onModelChange: (newModel: string) => void;
   onConnectionChange: (newConnection: string) => void;
   connections: ProviderConnection[] | undefined;
-  openAICompatibleEndpointsEnabled: boolean;
   isReadOnly: boolean;
   /** Connections matching the current provider, computed by the parent
    *  (the save handler also needs this for binding resolution). */
@@ -76,7 +75,6 @@ export function ProfileEditorProviderSection({
   onModelChange,
   onConnectionChange,
   connections,
-  openAICompatibleEndpointsEnabled,
   isReadOnly,
   availableConnectionsForProvider,
   connectionNotFound,
@@ -85,13 +83,7 @@ export function ProfileEditorProviderSection({
   const providerMissing = provider.length === 0;
   const providerWithoutModel = provider.length > 0 && model.length === 0;
 
-  const allProvidersForPicker = useMemo(
-    () =>
-      openAICompatibleEndpointsEnabled
-        ? ALL_PROVIDERS
-        : ALL_PROVIDERS.filter((p) => p !== OPENAI_COMPATIBLE_PROVIDER),
-    [openAICompatibleEndpointsEnabled],
-  );
+  const allProvidersForPicker = ALL_PROVIDERS;
 
   // Filter to providers with at least one connection — picking a provider
   // with zero connections binds a profile to a route the daemon can't
@@ -100,25 +92,15 @@ export function ProfileEditorProviderSection({
   const visibleProviders = useMemo(() => {
     const providerSet = new Set<string>();
     for (const c of connections ?? []) {
-      if (
-        openAICompatibleEndpointsEnabled ||
-        c.provider !== OPENAI_COMPATIBLE_PROVIDER
-      ) {
-        providerSet.add(c.provider);
-      }
+      providerSet.add(c.provider);
     }
-    if (
-      provider &&
-      (openAICompatibleEndpointsEnabled ||
-        provider !== OPENAI_COMPATIBLE_PROVIDER)
-    ) {
+    if (provider) {
       providerSet.add(provider);
     }
     return allProvidersForPicker.filter((p) => providerSet.has(p));
   }, [
     allProvidersForPicker,
     connections,
-    openAICompatibleEndpointsEnabled,
     provider,
   ]);
 
@@ -144,12 +126,6 @@ export function ProfileEditorProviderSection({
   // selected, merge models from all available openai-compatible connections.
   const availableModels: readonly { id: string; displayName: string }[] = useMemo(() => {
     if (!provider) return [];
-    if (
-      provider === OPENAI_COMPATIBLE_PROVIDER &&
-      !openAICompatibleEndpointsEnabled
-    ) {
-      return [];
-    }
     const catalogModels = getModelsForProvider(provider);
     if (catalogModels.length > 0) {
       const selectedConn = providerConnection
@@ -187,7 +163,6 @@ export function ProfileEditorProviderSection({
     return merged;
   }, [
     provider,
-    openAICompatibleEndpointsEnabled,
     providerConnection,
     availableConnectionsForProvider,
   ]);

--- a/apps/web/src/domains/settings/ai/provider-connections-client.ts
+++ b/apps/web/src/domains/settings/ai/provider-connections-client.ts
@@ -78,15 +78,13 @@ function buildConnectionProviderDisplayNames(): Record<
 }
 
 // ---------------------------------------------------------------------------
-// Feature-flag filter
+// Feature-flag filter (retained for call-site compatibility)
 // ---------------------------------------------------------------------------
 
 export function filterFlaggedConnections(
   connections: ProviderConnection[],
-  openAICompatibleEndpointsEnabled: boolean,
 ): ProviderConnection[] {
-  if (openAICompatibleEndpointsEnabled) return connections;
-  return connections.filter((c) => c.provider !== "openai-compatible");
+  return connections;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/domains/settings/ai/provider-create-form.tsx
+++ b/apps/web/src/domains/settings/ai/provider-create-form.tsx
@@ -53,7 +53,6 @@ import { useProviderCredentialsList } from "@/domains/settings/ai/use-provider-c
 export interface ProviderCreateFormProps {
   assistantId: string;
   existingNames: string[];
-  chatgptSubscriptionEnabled?: boolean;
   /** Pre-selected provider type (e.g. when cloning a managed connection). */
   defaultProviderType?: ConnectionProvider;
   /**
@@ -72,7 +71,6 @@ export interface ProviderCreateFormProps {
 export function ProviderCreateForm({
   assistantId,
   existingNames,
-  chatgptSubscriptionEnabled = false,
   defaultProviderType,
   defaultAuthType,
   onCreated,
@@ -428,7 +426,7 @@ export function ProviderCreateForm({
               types = ["api_key"];
             }
             // Add oauth_subscription when ChatGPT flag is enabled for OpenAI.
-            if (chatgptSubscriptionEnabled && provider === "openai") {
+            if (provider === "openai") {
               types.push("oauth_subscription");
             }
             if (authType && !types.includes(authType)) {

--- a/apps/web/src/domains/settings/ai/provider-create-form.tsx
+++ b/apps/web/src/domains/settings/ai/provider-create-form.tsx
@@ -53,7 +53,6 @@ import { useProviderCredentialsList } from "@/domains/settings/ai/use-provider-c
 export interface ProviderCreateFormProps {
   assistantId: string;
   existingNames: string[];
-  openAICompatibleEndpointsEnabled?: boolean;
   chatgptSubscriptionEnabled?: boolean;
   /** Pre-selected provider type (e.g. when cloning a managed connection). */
   defaultProviderType?: ConnectionProvider;
@@ -73,7 +72,6 @@ export interface ProviderCreateFormProps {
 export function ProviderCreateForm({
   assistantId,
   existingNames,
-  openAICompatibleEndpointsEnabled = false,
   chatgptSubscriptionEnabled = false,
   defaultProviderType,
   defaultAuthType,
@@ -112,14 +110,11 @@ export function ProviderCreateForm({
 
   const isOpenAICompatible = provider === "openai-compatible";
   const connectionProviderOptions = useMemo(() => {
-    const options = openAICompatibleEndpointsEnabled
-      ? CONNECTION_PROVIDERS
-      : CONNECTION_PROVIDERS.filter((p) => p !== "openai-compatible");
-    if (provider && !options.includes(provider)) {
-      return [...options, provider];
+    if (provider && !CONNECTION_PROVIDERS.includes(provider)) {
+      return [...CONNECTION_PROVIDERS, provider];
     }
-    return options;
-  }, [openAICompatibleEndpointsEnabled, provider]);
+    return CONNECTION_PROVIDERS;
+  }, [provider]);
 
   const { handleLabelChange, handleKeyChange: handleNameChange, getDirty } =
     useLabelKeySync("create", setLabel, setName);

--- a/apps/web/src/domains/settings/ai/provider-editor-modal.tsx
+++ b/apps/web/src/domains/settings/ai/provider-editor-modal.tsx
@@ -60,7 +60,6 @@ export interface ProviderEditorContentProps {
   connection?: ProviderConnection;
   assistantId: string;
   existingNames: string[];
-  openAICompatibleEndpointsEnabled?: boolean;
   chatgptSubscriptionEnabled?: boolean;
   onSave: (connection: ProviderConnection) => void;
   onCancel: () => void;
@@ -71,7 +70,6 @@ export function ProviderEditorContent({
   connection,
   assistantId,
   existingNames,
-  openAICompatibleEndpointsEnabled = false,
   chatgptSubscriptionEnabled = false,
   onSave,
   onCancel,
@@ -123,14 +121,11 @@ export function ProviderEditorContent({
 
   const isOpenAICompatible = provider === "openai-compatible";
   const connectionProviderOptions = useMemo(() => {
-    const options = openAICompatibleEndpointsEnabled
-      ? CONNECTION_PROVIDERS
-      : CONNECTION_PROVIDERS.filter((p) => p !== "openai-compatible");
-    if (provider && !options.includes(provider)) {
-      return [...options, provider];
+    if (provider && !CONNECTION_PROVIDERS.includes(provider)) {
+      return [...CONNECTION_PROVIDERS, provider];
     }
-    return options;
-  }, [openAICompatibleEndpointsEnabled, provider]);
+    return CONNECTION_PROVIDERS;
+  }, [provider]);
 
   const { handleLabelChange, resetDirty } =
     useLabelKeySync(effectiveMode, setLabel, setName);
@@ -360,7 +355,6 @@ export function ProviderEditorContent({
         variant="modal"
         assistantId={assistantId}
         existingNames={existingNames}
-        openAICompatibleEndpointsEnabled={openAICompatibleEndpointsEnabled}
         chatgptSubscriptionEnabled={chatgptSubscriptionEnabled}
         defaultProviderType={provider}
         defaultAuthType={createAuthTypeSeed}

--- a/apps/web/src/domains/settings/ai/provider-editor-modal.tsx
+++ b/apps/web/src/domains/settings/ai/provider-editor-modal.tsx
@@ -60,7 +60,6 @@ export interface ProviderEditorContentProps {
   connection?: ProviderConnection;
   assistantId: string;
   existingNames: string[];
-  chatgptSubscriptionEnabled?: boolean;
   onSave: (connection: ProviderConnection) => void;
   onCancel: () => void;
 }
@@ -70,7 +69,6 @@ export function ProviderEditorContent({
   connection,
   assistantId,
   existingNames,
-  chatgptSubscriptionEnabled = false,
   onSave,
   onCancel,
 }: ProviderEditorContentProps) {
@@ -355,7 +353,6 @@ export function ProviderEditorContent({
         variant="modal"
         assistantId={assistantId}
         existingNames={existingNames}
-        chatgptSubscriptionEnabled={chatgptSubscriptionEnabled}
         defaultProviderType={provider}
         defaultAuthType={createAuthTypeSeed}
         onCreated={onSave}

--- a/apps/web/src/lib/feature-flags/feature-flag-catalog.ts
+++ b/apps/web/src/lib/feature-flags/feature-flag-catalog.ts
@@ -22,9 +22,7 @@ export interface FlagDefinition {
 
 const flags = registry.flags as FlagDefinition[];
 
-const STORE_KEY_OVERRIDES: Record<string, string> = {
-  "openai-compatible-endpoints": "openAICompatibleEndpoints",
-};
+const STORE_KEY_OVERRIDES: Record<string, string> = {};
 
 function kebabToStoreKey(kebabKey: string): string {
   const override = STORE_KEY_OVERRIDES[kebabKey];

--- a/apps/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/apps/web/src/lib/feature-flags/feature-flag-registry.json
@@ -116,14 +116,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "chatgpt-subscription-auth",
-      "scope": "assistant",
-      "key": "chatgpt-subscription-auth",
-      "label": "ChatGPT Subscription Auth",
-      "description": "Enable ChatGPT subscription OAuth as a provider auth type for OpenAI models, using the Codex device-code flow.",
-      "defaultEnabled": false
-    },
-    {
       "id": "settings-embedding-provider",
       "scope": "assistant",
       "key": "settings-embedding-provider",
@@ -161,14 +153,6 @@
       "key": "message-tts",
       "label": "Message Text-to-Speech",
       "description": "Show a speaker button on assistant messages to generate and play the message as audio via Fish Audio TTS",
-      "defaultEnabled": false
-    },
-    {
-      "id": "openai-compatible-endpoints",
-      "scope": "assistant",
-      "key": "openai-compatible-endpoints",
-      "label": "OpenAI-Compatible Endpoints",
-      "description": "Enable user-configured OpenAI-compatible inference endpoints with custom base URLs and model identifiers",
       "defaultEnabled": false
     },
     {
@@ -337,14 +321,6 @@
       "key": "chat-pull-to-refresh-enabled",
       "label": "Chat Pull to Refresh",
       "description": "Enable pull-to-refresh gesture in the chat view.",
-      "defaultEnabled": false
-    },
-    {
-      "id": "home-page",
-      "scope": "client",
-      "key": "home-page",
-      "label": "Home Page",
-      "description": "Enable the Home page as the default landing view.",
       "defaultEnabled": false
     },
     {

--- a/assistant/src/__tests__/provider-catalog-visibility.test.ts
+++ b/assistant/src/__tests__/provider-catalog-visibility.test.ts
@@ -19,16 +19,8 @@ function makeConfig(): AssistantConfig {
 }
 
 describe("getVisibleProviderCatalog", () => {
-  test("hides openai-compatible endpoints by default", () => {
+  test("shows openai-compatible endpoints unconditionally (GA'ed)", () => {
     setOverridesForTesting({});
-
-    const visible = getVisibleProviderCatalog(makeConfig());
-
-    expect(visible.find((p) => p.id === "openai-compatible")).toBeUndefined();
-  });
-
-  test("shows openai-compatible endpoints when its flag is enabled", () => {
-    setOverridesForTesting({ "openai-compatible-endpoints": true });
 
     const visible = getVisibleProviderCatalog(makeConfig());
 

--- a/assistant/src/cli/commands/inference-providers.ts
+++ b/assistant/src/cli/commands/inference-providers.ts
@@ -16,8 +16,6 @@
 
 import type { Command } from "commander";
 
-import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
-import { getConfig } from "../../config/loader.js";
 import { cliIpcCall } from "../../ipc/cli-client.js";
 import type { OAuth2Config } from "../../security/oauth2.js";
 import { startOAuth2Flow } from "../../security/oauth2.js";
@@ -343,12 +341,6 @@ function attachLoginChatgptSubcommand(providers: Command): void {
     .description("Authenticate with ChatGPT via browser OAuth flow")
     .option("--json", "Output as JSON")
     .action(async (opts: { json?: boolean }) => {
-      const config = getConfig();
-      if (!isAssistantFeatureFlagEnabled("chatgpt-subscription-auth", config)) {
-        writeCliError("This feature is not yet available", opts.json);
-        return;
-      }
-
       try {
         // Step 1: Run browser-based PKCE OAuth flow
         process.stdout.write("Opening browser for ChatGPT authentication...\n");

--- a/assistant/src/providers/inference/__tests__/base-url-route-validation.test.ts
+++ b/assistant/src/providers/inference/__tests__/base-url-route-validation.test.ts
@@ -37,8 +37,7 @@ mock.module("../../../memory/db-connection.js", () => ({
 }));
 
 mock.module("../../../config/assistant-feature-flags.js", () => ({
-  isAssistantFeatureFlagEnabled: (flag: string) =>
-    flag === "openai-compatible-endpoints",
+  isAssistantFeatureFlagEnabled: () => false,
 }));
 
 mock.module("../../../config/loader.js", () => ({

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -1212,7 +1212,6 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
     setupHint:
       "Enter the base URL of your endpoint and at least one model identifier.",
     apiKeyPlaceholder: "Your provider's API key",
-    featureFlag: "openai-compatible-endpoints",
     models: [],
     defaultModel: "",
   },

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -28,7 +28,6 @@ const log = getLogger("provider-registry");
 
 const providers = new Map<string, Provider>();
 const routingSources = new Map<string, "user-key" | "managed-proxy">();
-const OPENAI_COMPATIBLE_ENDPOINTS_FLAG = "openai-compatible-endpoints";
 const NATIVE_WEB_SEARCH_PROVIDER_IDS = new Set(["anthropic", "openai"]);
 
 /** Per-connection provider cache, keyed by connection name and model. */
@@ -258,13 +257,6 @@ export async function resolveProviderFromConnection(
   config: ProvidersConfig,
   opts: { model?: string } = {},
 ): Promise<Provider | null> {
-  if (
-    connection.provider === "openai-compatible" &&
-    !isProviderFeatureFlagEnabled(OPENAI_COMPATIBLE_ENDPOINTS_FLAG, config)
-  ) {
-    return null;
-  }
-
   const model = opts.model ?? resolveModel(config, connection.provider);
   const cacheKey = getConnectionProviderCacheKey(connection, model);
   const cached = connectionProviders.get(cacheKey);

--- a/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
@@ -29,7 +29,6 @@ mock.module("../../../util/logger.js", () => ({
 
 // ── Real imports (after mocks) ────────────────────────────────────────────────
 
-import { setOverridesForTesting } from "../../../__tests__/feature-flag-test-helpers.js";
 import { getDb } from "../../../memory/db-connection.js";
 import { initializeDb } from "../../../memory/db-init.js";
 import { providerConnections } from "../../../memory/schema/inference.js";
@@ -91,7 +90,6 @@ function seedConnection(opts: {
 beforeEach(() => {
   clearConnections();
   fakeConfig = {};
-  setOverridesForTesting({ "openai-compatible-endpoints": true });
 });
 
 // ── GET list ─────────────────────────────────────────────────────────────────
@@ -160,36 +158,6 @@ describe("GET inference/provider-connections (list)", () => {
     expect(result.connections).toEqual([]);
   });
 
-  test("hides openai-compatible rows when the feature flag is disabled", async () => {
-    setOverridesForTesting({ "openai-compatible-endpoints": false });
-    seedConnection({
-      name: "my-openai",
-      provider: "openai",
-      auth: { type: "platform" },
-    });
-    seedConnection({
-      name: "my-compatible",
-      provider: "openai-compatible",
-      auth: { type: "api_key", credential: "ref/k" },
-    });
-
-    const result = (await call(
-      findHandler("inference_provider_connections_list"),
-      {},
-    )) as { connections: Array<{ name: string }> };
-
-    expect(result.connections.map((c) => c.name)).toEqual(["my-openai"]);
-  });
-
-  test("rejects openai-compatible provider filter when the feature flag is disabled", async () => {
-    setOverridesForTesting({ "openai-compatible-endpoints": false });
-
-    await expect(
-      call(findHandler("inference_provider_connections_list"), {
-        queryParams: { provider: "openai-compatible" },
-      }),
-    ).rejects.toBeInstanceOf(BadRequestError);
-  });
 });
 
 // ── GET single ────────────────────────────────────────────────────────────────
@@ -219,20 +187,6 @@ describe("GET inference/provider-connections/:name (single)", () => {
     ).rejects.toBeInstanceOf(NotFoundError);
   });
 
-  test("throws 404 for openai-compatible row when the feature flag is disabled", async () => {
-    setOverridesForTesting({ "openai-compatible-endpoints": false });
-    seedConnection({
-      name: "my-compatible",
-      provider: "openai-compatible",
-      auth: { type: "api_key", credential: "ref/k" },
-    });
-
-    await expect(
-      call(findHandler("inference_provider_connections_get"), {
-        pathParams: { name: "my-compatible" },
-      }),
-    ).rejects.toBeInstanceOf(NotFoundError);
-  });
 });
 
 // ── POST create ───────────────────────────────────────────────────────────────
@@ -312,22 +266,6 @@ describe("POST inference/provider-connections (create)", () => {
           name: "test",
           provider: "bogus-provider",
           auth: { type: "platform" },
-        },
-      }),
-    ).rejects.toBeInstanceOf(BadRequestError);
-  });
-
-  test("rejects openai-compatible creation when the feature flag is disabled", async () => {
-    setOverridesForTesting({ "openai-compatible-endpoints": false });
-
-    await expect(
-      call(findHandler("inference_provider_connections_create"), {
-        body: {
-          name: "my-compatible",
-          provider: "openai-compatible",
-          auth: { type: "api_key", credential: "ref/k" },
-          base_url: "http://localhost:8080/v1",
-          models: [{ id: "local-model" }],
         },
       }),
     ).rejects.toBeInstanceOf(BadRequestError);

--- a/assistant/src/runtime/routes/chatgpt-subscription-auth-routes.ts
+++ b/assistant/src/runtime/routes/chatgpt-subscription-auth-routes.ts
@@ -11,8 +11,6 @@
 
 import { z } from "zod";
 
-import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
-import { getConfigReadOnly } from "../../config/loader.js";
 import { getDb } from "../../memory/db-connection.js";
 import {
   createConnection,
@@ -29,17 +27,7 @@ import {
 import { setSecureKeyAsync } from "../../security/secure-keys.js";
 import { getLogger } from "../../util/logger.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
-import { BadRequestError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
-
-function requireFeatureFlag() {
-  const config = getConfigReadOnly();
-  if (!isAssistantFeatureFlagEnabled("chatgpt-subscription-auth", config)) {
-    throw new BadRequestError(
-      "ChatGPT subscription auth is not enabled for this assistant.",
-    );
-  }
-}
 
 const log = getLogger("chatgpt-subscription-auth");
 
@@ -87,7 +75,6 @@ function cleanupExpiredEntries(): void {
 // ---------------------------------------------------------------------------
 
 async function handleStartAuth(_args: RouteHandlerArgs) {
-  requireFeatureFlag();
   cleanupExpiredEntries();
 
   const codeVerifier = generateCodeVerifier();
@@ -115,7 +102,6 @@ async function handleStartAuth(_args: RouteHandlerArgs) {
 }
 
 async function handleExchange(args: RouteHandlerArgs) {
-  requireFeatureFlag();
   const { code, state } = args.body as { code: string; state: string };
 
   const pending = pendingAuths.get(state);

--- a/assistant/src/runtime/routes/inference-provider-connection-routes.ts
+++ b/assistant/src/runtime/routes/inference-provider-connection-routes.ts
@@ -10,7 +10,6 @@
 
 import { z } from "zod";
 
-import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import { getConfigReadOnly } from "../../config/loader.js";
 import { getDb } from "../../memory/db-connection.js";
 import {
@@ -44,22 +43,6 @@ import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 // ---------------------------------------------------------------------------
 
 const providerConnectionResponseSchema = ProviderConnectionSchema;
-const OPENAI_COMPATIBLE_ENDPOINTS_FLAG = "openai-compatible-endpoints";
-
-function openAICompatibleEndpointsEnabled(): boolean {
-  return isAssistantFeatureFlagEnabled(
-    OPENAI_COMPATIBLE_ENDPOINTS_FLAG,
-    getConfigReadOnly(),
-  );
-}
-
-function rejectDisabledOpenAICompatibleProvider(provider: string): void {
-  if (provider !== "openai-compatible") return;
-  if (openAICompatibleEndpointsEnabled()) return;
-  throw new BadRequestError(
-    "OpenAI-compatible endpoints are disabled. Enable the openai-compatible-endpoints feature flag to configure this provider.",
-  );
-}
 
 // ---------------------------------------------------------------------------
 // Custom provider field parsing (openai-compatible base_url + models)
@@ -170,18 +153,10 @@ async function parseCustomProviderFields(
 
 function handleListConnections({ queryParams = {} }: RouteHandlerArgs) {
   const provider = queryParams.provider;
-  if (provider) rejectDisabledOpenAICompatibleProvider(provider);
   const connections = listConnections(
     getDb(),
     provider ? { provider } : undefined,
   );
-  if (!openAICompatibleEndpointsEnabled()) {
-    return {
-      connections: connections.filter(
-        (conn) => conn.provider !== "openai-compatible",
-      ),
-    };
-  }
   return { connections };
 }
 
@@ -191,12 +166,6 @@ function handleGetConnection({ pathParams = {} }: RouteHandlerArgs) {
 
   const conn = getConnection(getDb(), name);
   if (!conn) throw new NotFoundError(`Connection "${name}" not found.`);
-  if (
-    conn.provider === "openai-compatible" &&
-    !openAICompatibleEndpointsEnabled()
-  ) {
-    throw new NotFoundError(`Connection "${name}" not found.`);
-  }
 
   return conn;
 }
@@ -216,8 +185,6 @@ async function handleCreateConnection({ body = {} }: RouteHandlerArgs) {
       `Invalid provider "${String(provider)}". Valid: ${VALID_CONNECTION_PROVIDERS.join(", ")}`,
     );
   }
-  rejectDisabledOpenAICompatibleProvider(providerResult.data);
-
   const authResult = AuthSchema.safeParse(auth);
   if (!authResult.success) {
     throw new BadRequestError(`Invalid auth: ${authResult.error.message}`);
@@ -280,12 +247,6 @@ async function handleUpdateConnection({
 
   const existing = getConnection(getDb(), name);
   if (!existing) throw new NotFoundError(`Connection "${name}" not found.`);
-  if (
-    existing.provider === "openai-compatible" &&
-    !openAICompatibleEndpointsEnabled()
-  ) {
-    throw new NotFoundError(`Connection "${name}" not found.`);
-  }
 
   const auth = body.auth;
   const authResult = AuthSchema.safeParse(auth);
@@ -353,12 +314,6 @@ function handleDeleteConnection({ pathParams = {} }: RouteHandlerArgs) {
   // reference to a missing connection returns 404 (not 409).
   const existing = getConnection(getDb(), name);
   if (!existing) {
-    throw new NotFoundError(`Connection "${name}" not found.`);
-  }
-  if (
-    existing.provider === "openai-compatible" &&
-    !openAICompatibleEndpointsEnabled()
-  ) {
     throw new NotFoundError(`Connection "${name}" not found.`);
   }
 

--- a/clients/macos/vellum-assistant/Features/Settings/ProvidersSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ProvidersSheet.swift
@@ -59,9 +59,7 @@ struct ProvidersSheet: View {
     /// mode (new connection) or editing an existing oauth_subscription
     /// connection (so the user can re-authenticate if needed).
     private var isChatgptSubscriptionVisible: Bool {
-        guard let flagStore = assistantFeatureFlagStore,
-              flagStore.isEnabled("chatgpt-subscription-auth"),
-              editorDraft.provider == "openai" else {
+        guard editorDraft.provider == "openai" else {
             return false
         }
         switch editorState {
@@ -558,13 +556,7 @@ struct ProvidersSheet: View {
         if store.isPlatformCapable(provider) {
             options.append((label: "Platform (managed by Vellum)", value: "platform"))
         }
-        // Offer ChatGPT Subscription when the feature flag is on and
-        // the provider is OpenAI. In create mode this lets the user
-        // pick the OAuth flow; in edit mode the fallback below handles
-        // connections that already carry this auth type.
-        if provider == "openai",
-           let flagStore = assistantFeatureFlagStore,
-           flagStore.isEnabled("chatgpt-subscription-auth") {
+        if provider == "openai" {
             options.append((label: "ChatGPT Subscription", value: "oauth_subscription"))
         }
         // Preserve the current auth type in edit mode so existing connections

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -116,14 +116,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "chatgpt-subscription-auth",
-      "scope": "assistant",
-      "key": "chatgpt-subscription-auth",
-      "label": "ChatGPT Subscription Auth",
-      "description": "Enable ChatGPT subscription OAuth as a provider auth type for OpenAI models, using the Codex device-code flow.",
-      "defaultEnabled": false
-    },
-    {
       "id": "settings-embedding-provider",
       "scope": "assistant",
       "key": "settings-embedding-provider",
@@ -161,14 +153,6 @@
       "key": "message-tts",
       "label": "Message Text-to-Speech",
       "description": "Show a speaker button on assistant messages to generate and play the message as audio via Fish Audio TTS",
-      "defaultEnabled": false
-    },
-    {
-      "id": "openai-compatible-endpoints",
-      "scope": "assistant",
-      "key": "openai-compatible-endpoints",
-      "label": "OpenAI-Compatible Endpoints",
-      "description": "Enable user-configured OpenAI-compatible inference endpoints with custom base URLs and model identifiers",
       "defaultEnabled": false
     },
     {
@@ -337,14 +321,6 @@
       "key": "chat-pull-to-refresh-enabled",
       "label": "Chat Pull to Refresh",
       "description": "Enable pull-to-refresh gesture in the chat view.",
-      "defaultEnabled": false
-    },
-    {
-      "id": "home-page",
-      "scope": "client",
-      "key": "home-page",
-      "label": "Home Page",
-      "description": "Enable the Home page as the default landing view.",
       "defaultEnabled": false
     },
     {


### PR DESCRIPTION
## Summary
- Remove chatgptSubscriptionAuth store selector from 3 top-level consumers
- Unwind chatgptSubscriptionEnabled prop from 3 intermediate components
- ChatGPT Subscription auth option always appears for OpenAI provider
- Update 3 test files to remove flag mocks

Fixes Codex review feedback on PR #34139.