### PR TITLE
fix: remove chatgptSubscriptionAuth web selectors and prop drilling (GA'ed)

### DIFF
--- a/apps/web/src/components/profile-quick-add-provider.test.tsx
+++ b/apps/web/src/components/profile-quick-add-provider.test.tsx
@@ -25,15 +25,6 @@ mock.module("@/stores/resolved-assistants-store", () => {
   return { useResolvedAssistantsStore: store };
 });
 
-// --- feature flag store ------------------------------------------------------
-mock.module("@/stores/assistant-feature-flag-store", () => {
-  const store = () => null;
-  store.use = {
-    chatgptSubscriptionAuth: () => false,
-  };
-  return { useAssistantFeatureFlagStore: store };
-});
-
 // --- toast -------------------------------------------------------------------
 const toastSuccess = mock((_msg: string) => {});
 mock.module("@vellumai/design-library/components/toast", () => ({

--- a/apps/web/src/components/profile-quick-add-provider.tsx
+++ b/apps/web/src/components/profile-quick-add-provider.tsx
@@ -43,7 +43,6 @@ import { ProfileEditorModal } from "@/domains/settings/ai/profile-editor-modal";
 import { client } from "@/generated/api/client.gen";
 import { inferenceProviderconnectionsGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
 import { assistantDaemonConfigQueryKey } from "@/lib/sync/query-tags";
-import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { toast } from "@vellumai/design-library/components/toast";
 
 interface OpenProfileQuickAddArgs {
@@ -74,8 +73,6 @@ const ProfileQuickAddContext = createContext<ProfileQuickAddContextValue | null>
 
 export function ProfileQuickAddProvider({ children }: { children: ReactNode }) {
   const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
-  const chatgptSubscriptionAuth =
-    useAssistantFeatureFlagStore.use.chatgptSubscriptionAuth();
 
   const queryClient = useQueryClient();
   const [isOpen, setIsOpen] = useState(false);
@@ -200,7 +197,6 @@ export function ProfileQuickAddProvider({ children }: { children: ReactNode }) {
           existingNames={existingNames}
           connections={connections}
           assistantId={assistantId}
-          chatgptSubscriptionEnabled={chatgptSubscriptionAuth}
           onSave={handleSave}
           onCancel={() => setIsOpen(false)}
         />

--- a/apps/web/src/domains/chat/components/composer-settings-menu.test.tsx
+++ b/apps/web/src/domains/chat/components/composer-settings-menu.test.tsx
@@ -40,7 +40,6 @@ mock.module("@/stores/assistant-feature-flag-store", () => {
   const store = () => null;
   store.use = {
     queryComplexityRouting: () => false,
-    chatgptSubscriptionAuth: () => false,
   };
   return { useAssistantFeatureFlagStore: store };
 });

--- a/apps/web/src/domains/settings/ai/manage-profiles-modal.test.tsx
+++ b/apps/web/src/domains/settings/ai/manage-profiles-modal.test.tsx
@@ -63,7 +63,6 @@ mock.module("@/domains/settings/ai/use-daemon-config", () => ({
 mock.module("@/stores/assistant-feature-flag-store", () => {
   const store = () => null;
   store.use = {
-    chatgptSubscriptionAuth: () => false,
     queryComplexityRouting: () => false,
   };
   return { useAssistantFeatureFlagStore: store };

--- a/apps/web/src/domains/settings/ai/manage-profiles-modal.tsx
+++ b/apps/web/src/domains/settings/ai/manage-profiles-modal.tsx
@@ -45,7 +45,6 @@ export function ManageProfilesModal({
   } = useDaemonConfigQuery();
   const configMutation = useDaemonConfigMutation();
 
-  const chatgptSubscriptionAuth = useAssistantFeatureFlagStore.use.chatgptSubscriptionAuth();
   const [editorOpen, setEditorOpen] = useState(false);
   const [editingProfile, setEditingProfile] = useState<ProfileWithName | null>(null);
 
@@ -166,7 +165,6 @@ export function ManageProfilesModal({
         existingNames={existingNames}
         connections={connections}
         assistantId={assistantId}
-        chatgptSubscriptionEnabled={chatgptSubscriptionAuth}
         onSave={handleEditorSave}
         onCancel={() => {
           setEditorOpen(false);

--- a/apps/web/src/domains/settings/ai/manage-providers-modal.tsx
+++ b/apps/web/src/domains/settings/ai/manage-providers-modal.tsx
@@ -18,8 +18,6 @@ import {
     type ProviderConnection,
 } from "@/domains/settings/ai/provider-connections-client";
 import { ProviderEditorContent } from "@/domains/settings/ai/provider-editor-modal";
-import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
-
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -54,7 +52,6 @@ export function ManageProvidersModal({
   assistantId,
   onClose,
 }: ManageProvidersModalProps) {
-  const chatgptSubscriptionAuth = useAssistantFeatureFlagStore.use.chatgptSubscriptionAuth();
   const [editorOpen, setEditorOpen] = useState(false);
   const [editingConnection, setEditingConnection] = useState<ProviderConnection | null>(null);
 
@@ -122,7 +119,6 @@ export function ManageProvidersModal({
             connection={editingConnection ?? undefined}
             assistantId={assistantId}
             existingNames={existingNames}
-            chatgptSubscriptionEnabled={chatgptSubscriptionAuth}
             onSave={handleEditorSave}
             onCancel={cancelEditor}
           />

--- a/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/apps/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -59,9 +59,6 @@ export interface ProfileEditorModalProps {
    * sub-form writes to. Required for the create-mode quick-add flow.
    */
   assistantId: string;
-  /** Surfaces the "Sign in with ChatGPT" subscription path in the inline
-   *  provider create sub-form when enabled. */
-  chatgptSubscriptionEnabled?: boolean;
   /**
    * Persist a profile entry. The optional `options.mode` argument tells the
    * parent how to combine `entry` with the existing on-disk record:
@@ -93,7 +90,6 @@ export function ProfileEditorModal({
   existingNames,
   connections,
   assistantId,
-  chatgptSubscriptionEnabled = false,
   onSave,
   onCancel,
 }: ProfileEditorModalProps) {
@@ -112,7 +108,6 @@ export function ProfileEditorModal({
           existingNames={existingNames}
           connections={connections}
           assistantId={assistantId}
-          chatgptSubscriptionEnabled={chatgptSubscriptionEnabled}
           onSave={onSave}
           onCancel={onCancel}
         />
@@ -133,7 +128,6 @@ interface ProfileEditorModalInnerProps {
   // See `ProfileEditorModalProps.connections` for nil-vs-empty semantics.
   connections: ProviderConnection[] | undefined;
   assistantId: string;
-  chatgptSubscriptionEnabled: boolean;
   onSave: (
     name: string,
     entry: ProfileEntry,
@@ -149,7 +143,6 @@ function ProfileEditorModalInner({
   existingNames,
   connections,
   assistantId,
-  chatgptSubscriptionEnabled,
   onSave,
   onCancel,
 }: ProfileEditorModalInnerProps) {
@@ -730,7 +723,6 @@ function ProfileEditorModalInner({
           variant="inline"
           assistantId={assistantId}
           existingNames={effectiveConnections.map((c) => c.name)}
-          chatgptSubscriptionEnabled={chatgptSubscriptionEnabled}
           defaultProviderType={
             (provider || undefined) as ConnectionProvider | undefined
           }

--- a/apps/web/src/domains/settings/ai/provider-create-form.tsx
+++ b/apps/web/src/domains/settings/ai/provider-create-form.tsx
@@ -53,7 +53,6 @@ import { useProviderCredentialsList } from "@/domains/settings/ai/use-provider-c
 export interface ProviderCreateFormProps {
   assistantId: string;
   existingNames: string[];
-  chatgptSubscriptionEnabled?: boolean;
   /** Pre-selected provider type (e.g. when cloning a managed connection). */
   defaultProviderType?: ConnectionProvider;
   /**
@@ -72,7 +71,6 @@ export interface ProviderCreateFormProps {
 export function ProviderCreateForm({
   assistantId,
   existingNames,
-  chatgptSubscriptionEnabled = false,
   defaultProviderType,
   defaultAuthType,
   onCreated,
@@ -428,7 +426,7 @@ export function ProviderCreateForm({
               types = ["api_key"];
             }
             // Add oauth_subscription when ChatGPT flag is enabled for OpenAI.
-            if (chatgptSubscriptionEnabled && provider === "openai") {
+            if (provider === "openai") {
               types.push("oauth_subscription");
             }
             if (authType && !types.includes(authType)) {

--- a/apps/web/src/domains/settings/ai/provider-editor-modal.tsx
+++ b/apps/web/src/domains/settings/ai/provider-editor-modal.tsx
@@ -60,7 +60,6 @@ export interface ProviderEditorContentProps {
   connection?: ProviderConnection;
   assistantId: string;
   existingNames: string[];
-  chatgptSubscriptionEnabled?: boolean;
   onSave: (connection: ProviderConnection) => void;
   onCancel: () => void;
 }
@@ -70,7 +69,6 @@ export function ProviderEditorContent({
   connection,
   assistantId,
   existingNames,
-  chatgptSubscriptionEnabled = false,
   onSave,
   onCancel,
 }: ProviderEditorContentProps) {
@@ -355,7 +353,6 @@ export function ProviderEditorContent({
         variant="modal"
         assistantId={assistantId}
         existingNames={existingNames}
-        chatgptSubscriptionEnabled={chatgptSubscriptionEnabled}
         defaultProviderType={provider}
         defaultAuthType={createAuthTypeSeed}
         onCreated={onSave}


### PR DESCRIPTION
## Summary
- Remove chatgptSubscriptionAuth store selector from 3 top-level consumers
- Unwind chatgptSubscriptionEnabled prop from 3 intermediate components
- ChatGPT Subscription auth option always appears for OpenAI provider
- Update 3 test files to remove flag mocks

Fixes Codex review feedback from PR #34139 (merged).