### PR TITLE
refactor(assistant): stop materializing built-in profiles into config.json

### DIFF
--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -97,6 +97,8 @@ function mergeDefaultConfigAndSeedInferenceProfiles(db?: DrizzleDb): void {
   seedInferenceProfiles({
     preserveProfileNames: defaultConfigMerge.providedLlmProfileNames,
     preserveActiveProfile: defaultConfigMerge.providedLlmActiveProfile,
+    builtinProfilesWithDroppedProviderConfig:
+      defaultConfigMerge.builtinProfilesWithDroppedProviderConfig,
     isHatch: defaultConfigMerge.hadOverlay,
     db,
   });
@@ -1102,7 +1104,10 @@ describe("seedInferenceProfiles BYOK-mode built-in profile handling", () => {
     // An overlay supplying a full `balanced` entry must not produce a shadow
     // entry in llm.profiles: label/status are lifted into profileOverrides
     // and everything else (provider/connection/model) is dropped — the code
-    // template is authoritative for built-in profile config.
+    // template is authoritative for built-in profile config. Because the
+    // dropped fields carried provider routing, the activeProfile naming the
+    // built-in did not select the managed route: it remaps to the personal
+    // custom profile backed by the hatch connection.
     const overlayPath = join(WORKSPACE_DIR, "hatch-overlay.json");
     writeFileSync(
       overlayPath,
@@ -1132,10 +1137,13 @@ describe("seedInferenceProfiles BYOK-mode built-in profile handling", () => {
     mergeDefaultConfigAndSeedInferenceProfiles(db);
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
 
-    expect(raw.llm.activeProfile).toBe("balanced");
+    expect(raw.llm.activeProfile).toBe("custom-balanced");
     expect(raw.llm.profiles.balanced).toBeUndefined();
+    // No managed connection was genuinely selected, so the managed built-in
+    // gets the hatch-disable status alongside the lifted overlay label.
     expect(raw.llm.profileOverrides.balanced).toEqual({
       label: "Hatch Balanced",
+      status: "disabled",
     });
 
     // Connection routing comes from the template, not the dropped overlay
@@ -1145,7 +1153,154 @@ describe("seedInferenceProfiles BYOK-mode built-in profile handling", () => {
       "anthropic-managed",
     );
     expect(config.llm.profiles.balanced?.label).toBe("Hatch Balanced");
+    expect(config.llm.profiles["custom-balanced"]?.provider_connection).toBe(
+      "anthropic-personal",
+    );
     expect(getConnection(db, "anthropic-managed")).not.toBeNull();
+    expect(getConnection(db, "anthropic-personal")).not.toBeNull();
+  });
+
+  test("hatch overlay activeProfile naming a built-in with dropped provider routing remaps to the matching custom profile", () => {
+    // Pre-PR semantics let a hatch overlay back `balanced` with openai; that
+    // representation no longer exists. The hatch collected an openai BYOK
+    // key (CLI seeds llm.default.provider from the active profile body), so
+    // booting active on the code-defined managed Anthropic `balanced` would
+    // break first-run routing/auth. The nearest equivalent is the personal
+    // custom profile with the same intent.
+    const overlayPath = join(WORKSPACE_DIR, "hatch-overlay.json");
+    writeFileSync(
+      overlayPath,
+      JSON.stringify(
+        {
+          llm: {
+            default: { provider: "openai" },
+            profiles: {
+              balanced: { provider: "openai", label: "My Balanced" },
+            },
+            activeProfile: "balanced",
+          },
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+    process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH = overlayPath;
+    const db = createProviderConnectionsDb();
+
+    mergeDefaultConfigAndSeedInferenceProfiles(db);
+    const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+
+    expect(raw.llm.activeProfile).toBe("custom-balanced");
+    // No built-in entries are materialized into llm.profiles.
+    expect(Object.keys(raw.llm.profiles).sort()).toEqual([
+      "custom-balanced",
+      "custom-cost-optimized",
+      "custom-quality-optimized",
+    ]);
+    // No managed connection was genuinely selected, so every managed
+    // profile gets the hatch-disable override; the overlay label is still
+    // lifted into the override store.
+    expect(raw.llm.profileOverrides.balanced).toEqual({
+      label: "My Balanced",
+      status: "disabled",
+    });
+    expect(raw.llm.profileOverrides["quality-optimized"]).toEqual({
+      status: "disabled",
+    });
+    expect(raw.llm.profileOverrides["cost-optimized"]).toEqual({
+      status: "disabled",
+    });
+    expect(raw.llm.profileOverrides["balanced-economy"]).toEqual({
+      status: "disabled",
+    });
+
+    const config = loadConfig();
+    expect(config.llm.profiles["custom-balanced"]?.provider).toBe("openai");
+    expect(config.llm.profiles["custom-balanced"]?.provider_connection).toBe(
+      "openai-personal",
+    );
+    expect(getConnection(db, "openai-personal")).not.toBeNull();
+  });
+
+  test("hatch overlay activeProfile=quality-optimized with dropped gemini routing remaps by intent", () => {
+    const overlayPath = join(WORKSPACE_DIR, "hatch-overlay.json");
+    writeFileSync(
+      overlayPath,
+      JSON.stringify(
+        {
+          llm: {
+            default: { provider: "gemini" },
+            profiles: {
+              "quality-optimized": { provider: "gemini" },
+            },
+            activeProfile: "quality-optimized",
+          },
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+    process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH = overlayPath;
+    const db = createProviderConnectionsDb();
+
+    mergeDefaultConfigAndSeedInferenceProfiles(db);
+    const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+
+    expect(raw.llm.activeProfile).toBe("custom-quality-optimized");
+    expect(raw.llm.profileOverrides["quality-optimized"]).toEqual({
+      status: "disabled",
+    });
+
+    const config = loadConfig();
+    expect(
+      config.llm.profiles["custom-quality-optimized"]?.provider_connection,
+    ).toBe("gemini-personal");
+    expect(getConnection(db, "gemini-personal")).not.toBeNull();
+  });
+
+  test("hatch overlay activeProfile naming a built-in with a label-only body stays preserved", () => {
+    // A label-only fragment carries no provider routing, so the overlay
+    // genuinely selected the managed route: the built-in name is preserved
+    // as active and its managed connection's profiles stay enabled.
+    const overlayPath = join(WORKSPACE_DIR, "hatch-overlay.json");
+    writeFileSync(
+      overlayPath,
+      JSON.stringify(
+        {
+          llm: {
+            default: { provider: "anthropic" },
+            profiles: {
+              balanced: { label: "Renamed Balanced" },
+            },
+            activeProfile: "balanced",
+          },
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+    process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH = overlayPath;
+    const db = createProviderConnectionsDb();
+
+    mergeDefaultConfigAndSeedInferenceProfiles(db);
+    const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+
+    expect(raw.llm.activeProfile).toBe("balanced");
+    expect(raw.llm.profiles.balanced).toBeUndefined();
+    // Profiles sharing the hatch-selected anthropic-managed connection stay
+    // enabled; only built-ins on other managed connections are disabled.
+    expect(raw.llm.profileOverrides.balanced).toEqual({
+      label: "Renamed Balanced",
+    });
+    expect(raw.llm.profileOverrides["quality-optimized"]).toBeUndefined();
+    expect(raw.llm.profileOverrides["cost-optimized"]).toBeUndefined();
+    expect(raw.llm.profileOverrides["balanced-economy"]).toEqual({
+      status: "disabled",
+    });
+
+    const config = loadConfig();
+    expect(config.llm.profiles.balanced?.label).toBe("Renamed Balanced");
+    expect(config.llm.profiles.balanced?.status).toBeUndefined();
   });
 
   test("non-hatch off-platform boot does NOT auto-disable built-in profiles", () => {

--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -429,7 +429,7 @@ describe("loadConfig startup behavior", () => {
     expect(raw.dataDir).toBeUndefined();
   });
 
-  test("off-platform hatch seeds both managed and user anthropic profiles", () => {
+  test("off-platform hatch seeds user profiles; built-ins stay code-resolved", () => {
     const overlayPath = join(WORKSPACE_DIR, "hatch-overlay.json");
     writeFileSync(
       overlayPath,
@@ -459,7 +459,7 @@ describe("loadConfig startup behavior", () => {
     expect(config.llm.profiles["custom-balanced"]?.provider_connection).toBe(
       "anthropic-personal",
     );
-    // Managed profiles exist as well.
+    // Managed profiles exist as well (code-resolved at load time).
     expect(config.llm.profiles.balanced?.model).toBe("claude-sonnet-4-6");
     expect(config.llm.profiles.balanced?.provider_connection).toBe(
       "anthropic-managed",
@@ -471,7 +471,10 @@ describe("loadConfig startup behavior", () => {
       model: "claude-opus-4-7",
     });
     expect(raw.llm.activeProfile).toBe("custom-balanced");
-    expect(raw.llm.profiles.balanced.model).toBe("claude-sonnet-4-6");
+    // Built-ins are never materialized to disk; the BYOK hatch disable is
+    // persisted as sparse status overrides instead.
+    expect(raw.llm.profiles.balanced).toBeUndefined();
+    expect(raw.llm.profileOverrides.balanced).toEqual({ status: "disabled" });
   });
 
   test("on-platform hatch seeds only managed profiles", () => {
@@ -543,9 +546,11 @@ describe("loadConfig startup behavior", () => {
     expect(raw.llm.profiles["custom-balanced"].provider_connection).toBe(
       "anthropic-personal",
     );
-    // Managed balanced profile is seeded for anthropic-managed.
-    expect(raw.llm.profiles.balanced.provider).toBe("anthropic");
-    expect(raw.llm.profiles.balanced.provider_connection).toBe(
+    // The managed balanced profile is code-resolved, not written to disk.
+    expect(raw.llm.profiles.balanced).toBeUndefined();
+    const config = loadConfig();
+    expect(config.llm.profiles.balanced?.provider).toBe("anthropic");
+    expect(config.llm.profiles.balanced?.provider_connection).toBe(
       "anthropic-managed",
     );
   });
@@ -580,8 +585,11 @@ describe("loadConfig startup behavior", () => {
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
     // On-platform: no user profiles created, active resets to managed balanced.
     expect(raw.llm.activeProfile).toBe("balanced");
-    expect(raw.llm.profiles.balanced.provider).toBe("anthropic");
-    expect(raw.llm.profiles.balanced.provider_connection).toBe(
+    // The managed balanced profile is code-resolved, not written to disk.
+    expect(raw.llm.profiles.balanced).toBeUndefined();
+    const config = loadConfig();
+    expect(config.llm.profiles.balanced?.provider).toBe("anthropic");
+    expect(config.llm.profiles.balanced?.provider_connection).toBe(
       "anthropic-managed",
     );
     // The old custom-balanced is preserved on disk but no longer active.
@@ -605,7 +613,7 @@ describe("loadConfig startup behavior", () => {
     expect(raw.llm.default.model).toBe("codellama");
   });
 
-  test("off-platform hatch with openai seeds user profiles and managed anthropic profiles", () => {
+  test("off-platform hatch with openai seeds user profiles; built-in anthropic profiles stay code-resolved", () => {
     const overlayPath = join(WORKSPACE_DIR, "hatch-overlay.json");
     writeFileSync(
       overlayPath,
@@ -634,18 +642,29 @@ describe("loadConfig startup behavior", () => {
       "gpt-5.4-nano",
     );
 
-    // Managed profiles are also seeded (balanced uses Anthropic).
-    expect(raw.llm.profiles.balanced.provider).toBe("anthropic");
-    expect(raw.llm.profiles.balanced.provider_connection).toBe(
+    // Built-in profiles are not written to disk; they are still exposed by
+    // the loader (balanced uses Anthropic).
+    expect(raw.llm.profiles.balanced).toBeUndefined();
+    expect(raw.llm.profiles["quality-optimized"]).toBeUndefined();
+    expect(raw.llm.profiles["cost-optimized"]).toBeUndefined();
+    const config = loadConfig();
+    expect(config.llm.profiles.balanced?.provider).toBe("anthropic");
+    expect(config.llm.profiles.balanced?.provider_connection).toBe(
       "anthropic-managed",
     );
-    expect(raw.llm.profiles.balanced.source).toBe("managed");
-    expect(raw.llm.profiles["quality-optimized"].provider).toBe("anthropic");
-    expect(raw.llm.profiles["cost-optimized"].provider).toBe("anthropic");
+    expect(config.llm.profiles.balanced?.source).toBe("managed");
+    expect(config.llm.profiles["quality-optimized"]?.provider).toBe(
+      "anthropic",
+    );
+    expect(config.llm.profiles["cost-optimized"]?.provider).toBe("anthropic");
   });
 
-  test("off-platform managed profiles are overwritten on every boot", () => {
-    // Simulate a previous boot that left managed profiles on disk.
+  test("stale materialized built-in entries are left on disk; template wins in the effective config", () => {
+    // Simulate a pre-migration install whose previous boots materialized
+    // managed profiles into config.json. The seeder no longer touches them;
+    // the loader treats the entry as transition state (template fields
+    // authoritative, label/status honored) until workspace migration 098
+    // collapses it into profileOverrides.
     writeConfig({
       llm: {
         profiles: {
@@ -660,21 +679,25 @@ describe("loadConfig startup behavior", () => {
       },
     });
 
-    // Non-hatch boot (no overlay). Managed profiles should be overwritten
-    // with the latest templates.
+    // Non-hatch boot (no overlay).
     mergeDefaultConfigAndSeedInferenceProfiles();
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
 
-    expect(raw.llm.profiles.balanced.model).toBe("claude-sonnet-4-6");
-    expect(raw.llm.profiles.balanced.provider_connection).toBe(
-      "anthropic-managed",
+    expect(raw.llm.profiles.balanced.model).toBe(
+      "old-model-from-previous-release",
     );
     expect(raw.llm.activeProfile).toBe("balanced");
+
+    const config = loadConfig();
+    expect(config.llm.profiles.balanced?.model).toBe("claude-sonnet-4-6");
+    expect(config.llm.profiles.balanced?.provider_connection).toBe(
+      "anthropic-managed",
+    );
   });
 
-  test("off-platform reseed preserves user-edited label on managed profiles (Codex P1 on PR #30362)", () => {
-    // Simulate a user who renamed the managed "balanced" profile via
-    // PUT /v1/config/llm/profiles/balanced { label: "My Default" }.
+  test("user-edited label on a stale materialized entry survives into the effective config", () => {
+    // Simulate a pre-migration user who renamed the managed "balanced"
+    // profile while it was still materialized on disk.
     writeConfig({
       llm: {
         profiles: {
@@ -691,17 +714,15 @@ describe("loadConfig startup behavior", () => {
     });
 
     mergeDefaultConfigAndSeedInferenceProfiles();
-    const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+    const config = loadConfig();
 
-    // Model still gets the new template value (provider-controlled).
-    expect(raw.llm.profiles.balanced.model).toBe("claude-sonnet-4-6");
-    // But the user's label override is preserved across the reseed.
-    expect(raw.llm.profiles.balanced.label).toBe("My Default");
+    // The template model is authoritative (provider-controlled)…
+    expect(config.llm.profiles.balanced?.model).toBe("claude-sonnet-4-6");
+    // …while the user's label carries through as a transition override.
+    expect(config.llm.profiles.balanced?.label).toBe("My Default");
   });
 
-  test("off-platform reseed preserves user-toggled status on managed profiles", () => {
-    // Simulate a user who disabled the managed "balanced" profile via
-    // PUT /v1/config/llm/profiles/balanced { status: "disabled" }.
+  test("user-toggled status on a stale materialized entry survives into the effective config", () => {
     writeConfig({
       llm: {
         profiles: {
@@ -718,17 +739,17 @@ describe("loadConfig startup behavior", () => {
     });
 
     mergeDefaultConfigAndSeedInferenceProfiles();
-    const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+    const config = loadConfig();
 
-    expect(raw.llm.profiles.balanced.status).toBe("disabled");
-    // Model still refreshes — only label/status are user-owned.
-    expect(raw.llm.profiles.balanced.model).toBe("claude-sonnet-4-6");
+    expect(config.llm.profiles.balanced?.status).toBe("disabled");
+    // Model still resolves from the template — only label/status are
+    // user-owned.
+    expect(config.llm.profiles.balanced?.model).toBe("claude-sonnet-4-6");
   });
 
-  test("off-platform reseed preserves an explicit null label (user cleared it)", () => {
-    // Setting label to null is the "clear" intent — must survive too,
-    // otherwise the next boot would re-stamp the template's default
-    // label and ignore the user's clear action.
+  test("boot leaves an explicit null label on a stale materialized entry untouched", () => {
+    // Setting label to null is the "clear" intent — the seeder must not
+    // rewrite or remove the stale entry on boot.
     writeConfig({
       llm: {
         profiles: {
@@ -750,25 +771,27 @@ describe("loadConfig startup behavior", () => {
     expect(raw.llm.profiles.balanced.label).toBeNull();
   });
 
-  test("off-platform reseed materializes template defaults with the BYOK label suffix when no user overrides exist", () => {
-    // First boot, no prior config — template defaults must materialize
-    // exactly. Off-platform installs get the " (Managed)" suffix so the
-    // managed profile is distinguishable from the personal "custom-*"
-    // sibling that shares the base label. Guards against accidentally
-    // clobbering template values with `undefined` from a `"label" in
-    // previous` check when previous is an empty shell.
+  test("first boot writes no built-in entries; BYOK label suffix comes from the loader", () => {
+    // First boot, no prior config — nothing is materialized. Off-platform
+    // installs get the " (Managed)" suffix on the code-resolved entries so
+    // the managed profile is distinguishable from the personal "custom-*"
+    // sibling that shares the base label.
     writeConfig({});
 
     mergeDefaultConfigAndSeedInferenceProfiles();
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
 
-    expect(raw.llm.profiles.balanced.label).toBe("Balanced (Managed)");
-    expect(raw.llm.profiles.balanced.model).toBe("claude-sonnet-4-6");
-    // Status is unset by default — must not appear as `undefined`.
-    expect("status" in raw.llm.profiles.balanced).toBe(false);
+    expect(raw.llm.profiles).toEqual({});
+    expect(raw.llm.profileOverrides).toBeUndefined();
+
+    const config = loadConfig();
+    expect(config.llm.profiles.balanced?.label).toBe("Balanced (Managed)");
+    expect(config.llm.profiles.balanced?.model).toBe("claude-sonnet-4-6");
+    // Status is unset by default (non-hatch boot writes no overrides).
+    expect(config.llm.profiles.balanced?.status).toBeUndefined();
   });
 
-  test("platform-provided profile fragments are not polluted by managed seeds", () => {
+  test("platform overlay built-in fragments convert to profileOverrides", () => {
     process.env.IS_PLATFORM = "true";
 
     writeConfig({
@@ -825,10 +848,8 @@ describe("loadConfig startup behavior", () => {
     expect(config.llm.activeProfile).toBe("balanced");
     // Built-in profiles are code-resolved at load time: the template's
     // config fields are authoritative in the *effective* config, while the
-    // overlay-materialized entry contributes only its user-ownable facets
-    // (label/status). The overlay fragment itself stays untouched on disk
-    // (asserted below) — PR 6 of the builtin-llm-profiles plan converts
-    // overlay built-in entries to profileOverrides at merge time.
+    // overlay fragment contributes only its user-ownable facets, lifted into
+    // `llm.profileOverrides` at merge time (non-override fields dropped).
     expect(config.llm.profiles.balanced!.label).toBe("Platform Balanced");
     expect(config.llm.profiles.balanced!.provider).toBe("anthropic");
     expect(config.llm.profiles.balanced!.model).toBe("claude-sonnet-4-6");
@@ -836,23 +857,19 @@ describe("loadConfig startup behavior", () => {
     expect(mainAgentConfig.model).toBe("claude-sonnet-4-6");
 
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
-    expect(raw.llm.profiles.balanced).toEqual({
-      source: "managed",
-      provider: "openai",
-      model: "gpt-5.4",
+    // The overlay entry never lands in llm.profiles — and the pre-existing
+    // materialized entry was removed rather than left behind as a shadow.
+    expect(raw.llm.profiles.balanced).toBeUndefined();
+    expect(raw.llm.profileOverrides.balanced).toEqual({
       label: "Platform Balanced",
     });
-    expect(raw.llm.profiles.balanced.maxTokens).toBeUndefined();
-    expect(raw.llm.profiles.balanced.thinking).toBeUndefined();
 
     mergeDefaultConfigAndSeedInferenceProfiles();
 
     const afterRestart = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
     expect(afterRestart.llm.activeProfile).toBe("balanced");
-    expect(afterRestart.llm.profiles.balanced).toEqual({
-      source: "managed",
-      provider: "openai",
-      model: "gpt-5.4",
+    expect(afterRestart.llm.profiles.balanced).toBeUndefined();
+    expect(afterRestart.llm.profileOverrides.balanced).toEqual({
       label: "Platform Balanced",
     });
   });
@@ -890,10 +907,12 @@ describe("loadConfig startup behavior", () => {
       provider: "anthropic",
       model: "claude-opus-4-7",
     });
-    // Off-platform hatch: user profiles are active.
+    // Off-platform hatch: user profiles are active; built-ins are not
+    // materialized.
     expect(raw.llm.activeProfile).toBe("custom-balanced");
     expect(raw.llm.profiles["custom-balanced"].provider).toBe("anthropic");
-    expect(raw.llm.profiles.balanced.model).toBe("claude-sonnet-4-6");
+    expect(raw.llm.profiles.balanced).toBeUndefined();
+    expect(loadConfig().llm.profiles.balanced?.model).toBe("claude-sonnet-4-6");
   });
 
   test("still quarantines corrupt JSON", () => {
@@ -918,18 +937,18 @@ describe("loadConfig startup behavior", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Tests: BYOK-mode seed behavior (issues #2/#3/#4 of the May 12 provider UX
-// queue). Off-platform managed profiles share base labels with the personal
-// "custom-*" profiles (Balanced / Quality / Speed), so the seed function
-// suffixes managed labels with " (Managed)" to disambiguate. Status is
-// initialized to "disabled" ONLY at hatch on first materialization — a fresh
-// BYOK user has no platform auth, so we don't want managed entries surfacing
-// as enabled in the picker on day one. Post-hatch user toggles persist
-// through every subsequent boot — the "never auto-disable BYOK connections"
-// rule applies to RESTART, not to hatch. On-platform behavior is unchanged.
+// Tests: BYOK-mode behavior. Off-platform built-in profiles share base labels
+// with the personal "custom-*" profiles (Balanced / Quality / Speed), so the
+// loader's code-resolved entries carry a " (Managed)" suffix to disambiguate.
+// Status is set to "disabled" via sparse `llm.profileOverrides` entries ONLY
+// at hatch — a fresh BYOK user has no platform auth, so built-ins must not
+// surface as enabled in the picker on day one. Post-hatch user toggles
+// persist through every subsequent boot — the "never auto-disable BYOK
+// connections" rule applies to RESTART, not to hatch. On-platform behavior
+// is unchanged.
 // ---------------------------------------------------------------------------
 
-describe("seedInferenceProfiles BYOK-mode managed profile labels", () => {
+describe("seedInferenceProfiles BYOK-mode built-in profile handling", () => {
   beforeEach(() => {
     ensureTestDir();
     const resetPaths = [
@@ -992,12 +1011,13 @@ describe("seedInferenceProfiles BYOK-mode managed profile labels", () => {
     expect(config.llm.profiles["custom-balanced"]?.label).toBe("Balanced");
   });
 
-  test("off-platform hatch initializes managed profile status to 'disabled'", () => {
-    // On a fresh BYOK hatch the user has no platform auth, so managed
-    // profiles must not surface as enabled in the picker on day one. We
-    // flip the three canonical managed profiles to status="disabled"
-    // ONCE at hatch time. (The complementary "user re-enable persists
-    // across restarts" guarantee is covered by the test further down.)
+  test("off-platform hatch initializes built-in profile status to 'disabled' via profileOverrides", () => {
+    // On a fresh BYOK hatch the user has no platform auth, so built-in
+    // profiles must not surface as enabled in the picker on day one. The
+    // disable is persisted ONCE at hatch time as sparse status overrides —
+    // never as materialized profile entries. (The complementary "user
+    // re-enable persists across restarts" guarantee is covered by the test
+    // further down.)
     const overlayPath = join(WORKSPACE_DIR, "hatch-overlay.json");
     writeFileSync(
       overlayPath,
@@ -1012,6 +1032,26 @@ describe("seedInferenceProfiles BYOK-mode managed profile labels", () => {
     expect(config.llm.profiles.balanced?.status).toBe("disabled");
     expect(config.llm.profiles["quality-optimized"]?.status).toBe("disabled");
     expect(config.llm.profiles["cost-optimized"]?.status).toBe("disabled");
+
+    const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+    // Only the hatch-time custom profiles are materialized on disk.
+    expect(Object.keys(raw.llm.profiles).sort()).toEqual([
+      "custom-balanced",
+      "custom-cost-optimized",
+      "custom-quality-optimized",
+    ]);
+    expect(raw.llm.profileOverrides.balanced).toEqual({ status: "disabled" });
+    expect(raw.llm.profileOverrides["quality-optimized"]).toEqual({
+      status: "disabled",
+    });
+    expect(raw.llm.profileOverrides["cost-optimized"]).toEqual({
+      status: "disabled",
+    });
+    // Flag-gated built-ins get the override too, regardless of flag state —
+    // harmless while the flag is off, correct if it later enables.
+    expect(raw.llm.profileOverrides["balanced-economy"]).toEqual({
+      status: "disabled",
+    });
   });
 
   test("off-platform managed-inference hatch keeps selected managed connection active", () => {
@@ -1036,17 +1076,33 @@ describe("seedInferenceProfiles BYOK-mode managed profile labels", () => {
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
 
     expect(raw.llm.activeProfile).toBe("balanced");
-    expect(raw.llm.profiles.balanced.provider_connection).toBe(
+    expect(raw.llm.profiles.balanced).toBeUndefined();
+    // The hatch-selected connection (anthropic-managed, resolved from the
+    // balanced template) keeps the profiles sharing it enabled; only the
+    // built-ins on other managed connections get a status override.
+    expect(raw.llm.profileOverrides?.balanced).toBeUndefined();
+    expect(raw.llm.profileOverrides?.["quality-optimized"]).toBeUndefined();
+    expect(raw.llm.profileOverrides?.["cost-optimized"]).toBeUndefined();
+    expect(raw.llm.profileOverrides?.["balanced-economy"]).toEqual({
+      status: "disabled",
+    });
+
+    const config = loadConfig();
+    expect(config.llm.profiles.balanced?.provider_connection).toBe(
       "anthropic-managed",
     );
-    expect("status" in raw.llm.profiles.balanced).toBe(false);
+    expect(config.llm.profiles.balanced?.status).toBeUndefined();
     // Connections exist (status is no longer a connection-level concept).
     expect(getConnection(db, "anthropic-managed")).not.toBeNull();
     expect(getConnection(db, "openai-managed")).not.toBeNull();
     expect(getConnection(db, "gemini-managed")).not.toBeNull();
   });
 
-  test("off-platform managed-inference hatch respects explicit non-managed active connection", () => {
+  test("hatch overlay built-in entry converts to profileOverrides, dropping non-override fields", () => {
+    // An overlay supplying a full `balanced` entry must not produce a shadow
+    // entry in llm.profiles: label/status are lifted into profileOverrides
+    // and everything else (provider/connection/model) is dropped — the code
+    // template is authoritative for built-in profile config.
     const overlayPath = join(WORKSPACE_DIR, "hatch-overlay.json");
     writeFileSync(
       overlayPath,
@@ -1060,6 +1116,7 @@ describe("seedInferenceProfiles BYOK-mode managed profile labels", () => {
                 provider: "anthropic",
                 provider_connection: "anthropic-personal",
                 model: "claude-sonnet-4-6",
+                label: "Hatch Balanced",
               },
             },
             activeProfile: "balanced",
@@ -1076,29 +1133,30 @@ describe("seedInferenceProfiles BYOK-mode managed profile labels", () => {
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
 
     expect(raw.llm.activeProfile).toBe("balanced");
-    expect(raw.llm.profiles.balanced.provider_connection).toBe(
-      "anthropic-personal",
+    expect(raw.llm.profiles.balanced).toBeUndefined();
+    expect(raw.llm.profileOverrides.balanced).toEqual({
+      label: "Hatch Balanced",
+    });
+
+    // Connection routing comes from the template, not the dropped overlay
+    // field.
+    const config = loadConfig();
+    expect(config.llm.profiles.balanced?.provider_connection).toBe(
+      "anthropic-managed",
     );
-    // Connections exist (status is no longer a connection-level concept).
+    expect(config.llm.profiles.balanced?.label).toBe("Hatch Balanced");
     expect(getConnection(db, "anthropic-managed")).not.toBeNull();
-    expect(getConnection(db, "openai-managed")).not.toBeNull();
-    expect(getConnection(db, "gemini-managed")).not.toBeNull();
   });
 
-  test("non-hatch off-platform boot does NOT auto-disable freshly-materialized managed profiles", () => {
-    // Existing installs that upgrade to a version where the managed
-    // profile didn't previously exist (e.g. a new template added later)
-    // must not be auto-disabled on a normal boot. The hatch-time disable
-    // is gated on `isHatch && !previous`; without an overlay there's no
-    // hatch signal, so the seeder leaves status unset (schema default
-    // = "active"). This is the "we never want to auto-disable BYOK
-    // connections on restart" guarantee.
+  test("non-hatch off-platform boot does NOT auto-disable built-in profiles", () => {
+    // Existing installs that upgrade must not have built-ins auto-disabled
+    // on a normal boot. The hatch-time disable is gated on `isHatch`;
+    // without an overlay there's no hatch signal, so no status overrides
+    // are written (schema default = "active"). This is the "we never want
+    // to auto-disable BYOK connections on restart" guarantee.
     writeConfig({
       llm: {
         default: { provider: "anthropic", model: "claude-opus-4-7" },
-        // Note: no `profiles` key — the managed profiles will be freshly
-        // materialized by seedInferenceProfiles. !previous is true for all
-        // three, but isHatch is false, so disable does NOT fire.
       },
     });
 
@@ -1106,9 +1164,12 @@ describe("seedInferenceProfiles BYOK-mode managed profile labels", () => {
     mergeDefaultConfigAndSeedInferenceProfiles();
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
 
-    expect("status" in raw.llm.profiles.balanced).toBe(false);
-    expect("status" in raw.llm.profiles["quality-optimized"]).toBe(false);
-    expect("status" in raw.llm.profiles["cost-optimized"]).toBe(false);
+    expect(raw.llm.profileOverrides).toBeUndefined();
+
+    const config = loadConfig();
+    expect(config.llm.profiles.balanced?.status).toBeUndefined();
+    expect(config.llm.profiles["quality-optimized"]?.status).toBeUndefined();
+    expect(config.llm.profiles["cost-optimized"]?.status).toBeUndefined();
   });
 
   test("on-platform hatch leaves managed labels untouched", () => {
@@ -1132,13 +1193,12 @@ describe("seedInferenceProfiles BYOK-mode managed profile labels", () => {
     expect(config.llm.profiles["cost-optimized"]?.label).toBe("Speed");
   });
 
-  test("upgrade boot rewrites legacy bare labels to suffixed form on off-platform", () => {
-    // Existing off-platform install (pre-suffix-PR) has `label: "Balanced"`
-    // on disk. The "label" in previous preservation would normally keep
-    // the bare label and the picker would stay ambiguous forever — so the
-    // seeder runs a one-shot upgrade migration when previous.label exactly
-    // equals the bare template default. User-customized labels and
-    // explicit nulls are NOT rewritten.
+  test("stale bare labels on materialized entries are honored as transition overrides on off-platform", () => {
+    // Existing off-platform install (pre-suffix era) has `label: "Balanced"`
+    // on disk. The loader honors label keys on stale materialized entries by
+    // key presence, so the bare label carries through unsuffixed until
+    // workspace migration 098 collapses seed-default labels (letting the
+    // loader's " (Managed)" suffix default apply again).
     writeConfig({
       llm: {
         default: { provider: "anthropic", model: "claude-opus-4-7" },
@@ -1167,17 +1227,13 @@ describe("seedInferenceProfiles BYOK-mode managed profile labels", () => {
       },
     });
 
-    // No overlay → not a hatch. Still upgrades labels.
+    // No overlay → not a hatch. The seeder leaves the stale entries alone.
     mergeDefaultConfigAndSeedInferenceProfiles();
     const config = loadConfig();
 
-    expect(config.llm.profiles.balanced?.label).toBe("Balanced (Managed)");
-    expect(config.llm.profiles["quality-optimized"]?.label).toBe(
-      "Quality (Managed)",
-    );
-    expect(config.llm.profiles["cost-optimized"]?.label).toBe(
-      "Speed (Managed)",
-    );
+    expect(config.llm.profiles.balanced?.label).toBe("Balanced");
+    expect(config.llm.profiles["quality-optimized"]?.label).toBe("Quality");
+    expect(config.llm.profiles["cost-optimized"]?.label).toBe("Speed");
   });
 
   test("upgrade boot preserves user-customized labels and explicit null on off-platform", () => {

--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -1160,6 +1160,41 @@ describe("seedInferenceProfiles BYOK-mode built-in profile handling", () => {
     expect(getConnection(db, "anthropic-personal")).not.toBeNull();
   });
 
+  test("explicit overlay profileOverrides win over lifted legacy fragment fields", () => {
+    // When an overlay carries both representations for a built-in — a legacy
+    // `llm.profiles` fragment and an explicit `llm.profileOverrides` entry —
+    // the explicit override is canonical: lifted legacy fields only fill
+    // keys the explicit entry does not set.
+    const overlayPath = join(WORKSPACE_DIR, "hatch-overlay.json");
+    writeFileSync(
+      overlayPath,
+      JSON.stringify(
+        {
+          llm: {
+            profiles: {
+              balanced: { label: "Legacy Label", status: "disabled" },
+            },
+            profileOverrides: {
+              balanced: { label: "Explicit Label" },
+            },
+          },
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+    process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH = overlayPath;
+
+    mergeDefaultConfigAndSeedInferenceProfiles();
+
+    const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+    expect(raw.llm.profiles?.balanced).toBeUndefined();
+    expect(raw.llm.profileOverrides.balanced).toEqual({
+      label: "Explicit Label",
+      status: "disabled",
+    });
+  });
+
   test("hatch overlay activeProfile naming a built-in with dropped provider routing remaps to the matching custom profile", () => {
     // Pre-PR semantics let a hatch overlay back `balanced` with openai; that
     // representation no longer exists. The hatch collected an openai BYOK

--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -1348,12 +1348,12 @@ describe("seedInferenceProfiles BYOK-mode built-in profile handling", () => {
     expect(config.llm.profiles["cost-optimized"]?.label).toBe("Speed");
   });
 
-  test("stale bare labels on materialized entries are honored as transition overrides on off-platform", () => {
+  test("stale bare labels on materialized entries are seed artifacts: the BYOK suffix default applies", () => {
     // Existing off-platform install (pre-suffix era) has `label: "Balanced"`
-    // on disk. The loader honors label keys on stale materialized entries by
-    // key presence, so the bare label carries through unsuffixed until
-    // workspace migration 098 collapses seed-default labels (letting the
-    // loader's " (Managed)" suffix default apply again).
+    // on disk. A seed-default label is not user intent, so the loader skips
+    // it when lifting transition overrides — the resolve-time " (Managed)"
+    // suffix applies and the managed profile stays distinguishable from the
+    // personal `custom-*` sibling sharing the bare label.
     writeConfig({
       llm: {
         default: { provider: "anthropic", model: "claude-opus-4-7" },
@@ -1386,15 +1386,20 @@ describe("seedInferenceProfiles BYOK-mode built-in profile handling", () => {
     mergeDefaultConfigAndSeedInferenceProfiles();
     const config = loadConfig();
 
-    expect(config.llm.profiles.balanced?.label).toBe("Balanced");
-    expect(config.llm.profiles["quality-optimized"]?.label).toBe("Quality");
-    expect(config.llm.profiles["cost-optimized"]?.label).toBe("Speed");
+    expect(config.llm.profiles.balanced?.label).toBe("Balanced (Managed)");
+    expect(config.llm.profiles["quality-optimized"]?.label).toBe(
+      "Quality (Managed)",
+    );
+    expect(config.llm.profiles["cost-optimized"]?.label).toBe(
+      "Speed (Managed)",
+    );
   });
 
   test("upgrade boot preserves user-customized labels and explicit null on off-platform", () => {
-    // A user-set string that differs from the bare default must survive;
-    // an explicit null (user cleared the label) must also survive. Only
-    // exact matches against the bare template label trigger the upgrade.
+    // The seeder never rewrites stale materialized entries: a user-set
+    // string and an explicit null (user cleared the label) stay on disk
+    // verbatim. Seed-default labels stay on disk too — the loader skips
+    // them at read time instead of migrating them here.
     writeConfig({
       llm: {
         default: { provider: "anthropic", model: "claude-opus-4-7" },
@@ -1412,7 +1417,8 @@ describe("seedInferenceProfiles BYOK-mode built-in profile handling", () => {
             provider_connection: "anthropic-managed",
             label: null,
           },
-          // Already-suffixed labels are also preserved (idempotency).
+          // Seed-default suffixed labels stay on disk; the loader treats
+          // them as seed artifacts at read time.
           "cost-optimized": {
             source: "managed",
             provider: "anthropic",
@@ -1432,9 +1438,10 @@ describe("seedInferenceProfiles BYOK-mode built-in profile handling", () => {
     expect(raw.llm.profiles["cost-optimized"].label).toBe("Speed (Managed)");
   });
 
-  test("upgrade boot does NOT rewrite bare labels on platform", () => {
-    // The migration is gated on isByokMode, so an on-platform install with
-    // a bare "Balanced" label preserves it (no suffix on platform).
+  test("upgrade boot keeps the bare label on platform", () => {
+    // A stale bare "Balanced" label is a seed artifact and is skipped as an
+    // override; on platform the resolve-time default is the bare label, so
+    // the effective label is unchanged (no suffix on platform).
     process.env.IS_PLATFORM = "true";
     writeConfig({
       llm: {

--- a/assistant/src/__tests__/config-loader-builtin-profiles.test.ts
+++ b/assistant/src/__tests__/config-loader-builtin-profiles.test.ts
@@ -290,6 +290,112 @@ describe("config loader — built-in inference profile merge", () => {
     expect(config.llm.profiles.balanced!.label).toBe("Override Label");
   });
 
+  test("stale seed-default labels are not lifted as overrides: BYOK gets the suffixed default", () => {
+    process.env.IS_PLATFORM = "false";
+    // Pre-suffix-era seeder wrote the bare template label; the suffix-era
+    // seeder wrote the " (Managed)" form. Both are seed artifacts — neither
+    // carries user intent, so the resolve-time BYOK default applies.
+    writeConfig({
+      llm: {
+        profiles: {
+          balanced: {
+            source: "managed",
+            provider: "anthropic",
+            provider_connection: "anthropic-managed",
+            model: "claude-sonnet-4-6",
+            label: "Balanced",
+          },
+          "quality-optimized": {
+            source: "managed",
+            provider: "anthropic",
+            provider_connection: "anthropic-managed",
+            label: "Quality (Managed)",
+          },
+        },
+        activeProfile: "balanced",
+      },
+    });
+
+    const config = getConfig();
+
+    expect(config.llm.profiles.balanced!.label).toBe("Balanced (Managed)");
+    expect(config.llm.profiles["quality-optimized"]!.label).toBe(
+      "Quality (Managed)",
+    );
+  });
+
+  test("stale seed-default suffixed label resolves to the bare default on platform", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          balanced: {
+            source: "managed",
+            provider: "anthropic",
+            provider_connection: "anthropic-managed",
+            label: "Balanced (Managed)",
+          },
+        },
+        activeProfile: "balanced",
+      },
+    });
+
+    const config = getConfig();
+
+    expect(config.llm.profiles.balanced!.label).toBe("Balanced");
+  });
+
+  test("non-seed stale labels and explicit null are honored as overrides on BYOK", () => {
+    process.env.IS_PLATFORM = "false";
+    writeConfig({
+      llm: {
+        profiles: {
+          balanced: {
+            source: "managed",
+            provider: "anthropic",
+            provider_connection: "anthropic-managed",
+            label: "My Custom Name",
+          },
+          "quality-optimized": {
+            source: "managed",
+            provider: "anthropic",
+            provider_connection: "anthropic-managed",
+            label: null,
+          },
+        },
+        activeProfile: "balanced",
+      },
+    });
+
+    const config = getConfig();
+
+    expect(config.llm.profiles.balanced!.label).toBe("My Custom Name");
+    expect(config.llm.profiles["quality-optimized"]!.label).toBeNull();
+  });
+
+  test("llm.profileOverrides label wins over a stale seed-default label", () => {
+    process.env.IS_PLATFORM = "false";
+    writeConfig({
+      llm: {
+        profiles: {
+          balanced: {
+            source: "managed",
+            provider: "anthropic",
+            provider_connection: "anthropic-managed",
+            label: "Balanced",
+          },
+        },
+        profileOverrides: {
+          balanced: { label: "Override Label" },
+        },
+        activeProfile: "balanced",
+      },
+    });
+
+    const config = getConfig();
+
+    expect(config.llm.profiles.balanced!.label).toBe("Override Label");
+  });
+
   test("the balanced-economy definition is gated by the registry flag", () => {
     expect(MANAGED_PROFILE_TEMPLATES["balanced-economy"]!.featureFlag).toBe(
       BALANCED_ECONOMY_FLAG,

--- a/assistant/src/__tests__/conversation-slash-commands.test.ts
+++ b/assistant/src/__tests__/conversation-slash-commands.test.ts
@@ -261,8 +261,10 @@ describe("resolveSlash /model — inference profile switcher", () => {
     expect(result.kind).toBe("unknown");
     if (result.kind !== "unknown") throw new Error("expected unknown kind");
     expect(result.message).toContain("Inference profiles:");
+    // The stale entry's "Balanced" label is a seed artifact, not an
+    // override, so the BYOK " (Managed)" default applies.
     expect(result.message).toContain(
-      "`balanced` (Balanced) **[current]** — Good balance of quality, cost, and speed",
+      "`balanced` (Balanced (Managed)) **[current]** — Good balance of quality, cost, and speed",
     );
     expect(result.message).toContain(
       "`cost-optimized` (Cost-optimized) — Fastest responses at lower cost",
@@ -321,7 +323,9 @@ describe("resolveSlash /model — inference profile switcher", () => {
     const result = await resolveSlash("/model balanced");
     expect(result.kind).toBe("unknown");
     if (result.kind !== "unknown") throw new Error("expected unknown kind");
-    expect(result.message).toBe("Already using profile `balanced` (Balanced).");
+    expect(result.message).toBe(
+      "Already using profile `balanced` (Balanced (Managed)).",
+    );
   });
 
   test("`/model` with no profiles in raw config still lists the built-ins", async () => {

--- a/assistant/src/config/builtin-inference-profiles.ts
+++ b/assistant/src/config/builtin-inference-profiles.ts
@@ -106,6 +106,35 @@ export const MANAGED_PROFILE_NAMES = new Set([
   AUTO_PROFILE_KEY,
 ]);
 
+/**
+ * Label suffix applied to managed built-ins on off-platform (BYOK) installs,
+ * disambiguating them from the personal `custom-*` profiles that share the
+ * bare base labels.
+ */
+const MANAGED_LABEL_SUFFIX = " (Managed)";
+
+/**
+ * Whether `label` is a seed-default label for the built-in profile `name`:
+ * the bare template label (e.g. `"Balanced"`) or its BYOK-suffixed form
+ * (`"Balanced (Managed)"`), both of which the legacy seeder materialized to
+ * disk. A seed-default label carries no user intent — callers skip it as an
+ * override so the resolve-time default supplies the platform-appropriate
+ * form. The `auto` entry only ever had the bare label.
+ */
+export function isSeedDefaultBuiltinLabel(
+  name: string,
+  label: string,
+): boolean {
+  if (name === AUTO_PROFILE_KEY) {
+    return label === createAutoProfileEntry().label;
+  }
+  const base = MANAGED_PROFILE_TEMPLATES[name]?.label;
+  return (
+    base !== undefined &&
+    (label === base || label === `${base}${MANAGED_LABEL_SUFFIX}`)
+  );
+}
+
 export function materializeProfile(
   template: BuiltinProfileDefinition,
   provider: NonNullable<ProfileEntry["provider"]>,
@@ -180,7 +209,7 @@ export function resolveBuiltinProfiles(opts: {
     }
     const effective: BuiltinProfileDefinition = opts.isPlatform
       ? definition
-      : { ...definition, label: `${definition.label} (Managed)` };
+      : { ...definition, label: `${definition.label}${MANAGED_LABEL_SUFFIX}` };
     const entry = materializeProfile(
       effective,
       definition.provider,

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -370,11 +370,10 @@ function deleteNestedKey(
  * - Template fields (provider/model/maxTokens/…) are always authoritative;
  *   user-ownable facets are `label` and `status` only.
  * - `llm.profileOverrides[name]` is the canonical override store.
- * - **Transition-state compatibility**: while the boot seeder still
- *   materializes full built-in entries into `config.json` (and for
- *   pre-migration installs that already carry them, including drifted
- *   shadow entries the assistant wrote on-platform), the materialized
- *   entry's `label`/`status` are honored as *lower*-precedence overrides
+ * - **Transition-state compatibility**: pre-migration installs still carry
+ *   full materialized built-in entries in `config.json` (including drifted
+ *   shadow entries the assistant wrote on-platform). Such an entry's
+ *   `label`/`status` are honored as *lower*-precedence overrides
  *   (key-presence semantics) and every other field is discarded.
  * - Built-in names are spliced into `llm.profileOrder` exactly as the
  *   seeder does (auto prepended if missing, managed names appended if
@@ -748,6 +747,45 @@ export function mergeDefaultWorkspaceConfig(): DefaultWorkspaceConfigMergeResult
     (defaults as Record<string, unknown>).llm,
   );
   const providedProfiles = readPlainObject(llmDefaults?.profiles);
+
+  // Overlay entries for built-in profile names are converted to sparse
+  // `llm.profileOverrides` entries (label/status only) — built-in profile
+  // config is code-defined and never materialized into `llm.profiles` on
+  // disk. Non-override fields are dropped with a warning. The converted
+  // names are excluded from `providedLlmProfileNames` so the seeder treats
+  // only custom overlay names as overlay-owned.
+  const convertedBuiltinNames = new Set<string>();
+  if (llmDefaults && providedProfiles) {
+    for (const name of Object.keys(providedProfiles)) {
+      if (!MANAGED_PROFILE_NAMES.has(name)) continue;
+      convertedBuiltinNames.add(name);
+      const entry = readPlainObject(providedProfiles[name]);
+      delete providedProfiles[name];
+      if (!entry) continue;
+
+      const override: BuiltinProfileOverride = {};
+      collectBuiltinOverrideFields(entry, override);
+      const droppedKeys = Object.keys(entry).filter(
+        (key) => !(key in override),
+      );
+      if (droppedKeys.length > 0) {
+        log.warn(
+          { profile: name, droppedKeys },
+          "Default workspace config supplied non-override fields for built-in profile %s; dropping them (built-in profile config is code-defined)",
+          name,
+        );
+      }
+      if (Object.keys(override).length > 0) {
+        const overridesStore = ensurePlainObjectAt(
+          llmDefaults,
+          "profileOverrides",
+        );
+        const existing = readPlainObject(overridesStore[name]);
+        overridesStore[name] = { ...existing, ...override };
+      }
+    }
+  }
+
   const mergeResult: DefaultWorkspaceConfigMergeResult = {
     hadOverlay: true,
     providedLlmProfileNames: new Set(
@@ -770,14 +808,21 @@ export function mergeDefaultWorkspaceConfig(): DefaultWorkspaceConfigMergeResult
     }
   }
 
-  if (mergeResult.providedLlmProfileNames.size > 0) {
+  const overlayProfileNames = new Set([
+    ...mergeResult.providedLlmProfileNames,
+    ...convertedBuiltinNames,
+  ]);
+  if (overlayProfileNames.size > 0) {
     // Default-config profile entries are authoritative fragments. Remove any
     // old same-name profile first so recursive merge does not leave stale
-    // provider-specific leaves behind.
+    // provider-specific leaves behind. Converted built-in names are removed
+    // too: the overlay owns the profile, and its entry now lives in
+    // `llm.profileOverrides` rather than `llm.profiles`, so a stale
+    // materialized entry must not survive as a shadow.
     const existingLlm = readPlainObject(existing.llm);
     const existingProfiles = readPlainObject(existingLlm?.profiles);
     if (existingProfiles) {
-      for (const name of mergeResult.providedLlmProfileNames) {
+      for (const name of overlayProfileNames) {
         delete existingProfiles[name];
       }
     }

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -21,6 +21,7 @@ import {
 import {
   AUTO_PROFILE_KEY,
   type BuiltinProfileOverride,
+  isSeedDefaultBuiltinLabel,
   MANAGED_PROFILE_NAMES,
   resolveBuiltinProfiles,
 } from "./builtin-inference-profiles.js";
@@ -374,7 +375,11 @@ function deleteNestedKey(
  *   full materialized built-in entries in `config.json` (including drifted
  *   shadow entries the assistant wrote on-platform). Such an entry's
  *   `label`/`status` are honored as *lower*-precedence overrides
- *   (key-presence semantics) and every other field is discarded.
+ *   (key-presence semantics) and every other field is discarded. A stale
+ *   label equal to a seed default (the bare template label or its BYOK
+ *   `" (Managed)"` form) is a seeder artifact, not user intent, and is not
+ *   lifted — the resolve-time default supplies the platform-appropriate
+ *   label instead.
  * - Built-in names are spliced into `llm.profileOrder` exactly as the
  *   seeder does (auto prepended if missing, managed names appended if
  *   missing); flag-disabled built-ins are removed from the in-memory order
@@ -394,6 +399,16 @@ export function applyBuiltinProfiles(raw: Record<string, unknown>): void {
     const entry: BuiltinProfileOverride = {};
     // Lower precedence: label/status carried on a still-materialized entry.
     collectBuiltinOverrideFields(profiles[name], entry);
+    // A stale label equal to a seed default is a seeder artifact, not user
+    // intent — drop it so the resolve-time default supplies the
+    // platform-appropriate label. Explicit `null` (cleared) and any other
+    // string remain honored.
+    if (
+      typeof entry.label === "string" &&
+      isSeedDefaultBuiltinLabel(name, entry.label)
+    ) {
+      delete entry.label;
+    }
     // Higher precedence: the sparse override store.
     collectBuiltinOverrideFields(profileOverrides[name], entry);
     if ("label" in entry || "status" in entry) overrides[name] = entry;

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -821,8 +821,12 @@ export function mergeDefaultWorkspaceConfig(): DefaultWorkspaceConfigMergeResult
           llmDefaults,
           "profileOverrides",
         );
+        // An explicit `llm.profileOverrides.<name>` entry in the overlay is
+        // the canonical representation and wins over fields lifted from the
+        // legacy `llm.profiles.<name>` fragment; lifted fields only fill
+        // keys the explicit override does not set.
         const existing = readPlainObject(overridesStore[name]);
-        overridesStore[name] = { ...existing, ...override };
+        overridesStore[name] = { ...override, ...existing };
       }
     }
   }

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -698,13 +698,35 @@ export type DefaultWorkspaceConfigMergeResult = {
   hadOverlay: boolean;
   providedLlmProfileNames: Set<string>;
   providedLlmActiveProfile: boolean;
+  /**
+   * Built-in profile names whose overlay entry carried provider-routing
+   * fields (`provider`, `model`, `provider_connection`, `mix`) that the
+   * conversion to `llm.profileOverrides` dropped. The overlay intended these
+   * names to route somewhere other than the code-defined template, so the
+   * seeder must not treat an `activeProfile` naming one of them as a genuine
+   * selection of the managed built-in.
+   */
+  builtinProfilesWithDroppedProviderConfig: Set<string>;
 };
+
+/**
+ * Provider-routing fields on an overlay profile entry. When one of these is
+ * dropped from a built-in-name entry, the overlay's routing intent for that
+ * profile is lost — tracked via `builtinProfilesWithDroppedProviderConfig`.
+ */
+const PROVIDER_ROUTING_PROFILE_KEYS = new Set([
+  "provider",
+  "model",
+  "provider_connection",
+  "mix",
+]);
 
 function emptyDefaultWorkspaceConfigMergeResult(): DefaultWorkspaceConfigMergeResult {
   return {
     hadOverlay: false,
     providedLlmProfileNames: new Set(),
     providedLlmActiveProfile: false,
+    builtinProfilesWithDroppedProviderConfig: new Set(),
   };
 }
 
@@ -755,6 +777,7 @@ export function mergeDefaultWorkspaceConfig(): DefaultWorkspaceConfigMergeResult
   // names are excluded from `providedLlmProfileNames` so the seeder treats
   // only custom overlay names as overlay-owned.
   const convertedBuiltinNames = new Set<string>();
+  const builtinProfilesWithDroppedProviderConfig = new Set<string>();
   if (llmDefaults && providedProfiles) {
     for (const name of Object.keys(providedProfiles)) {
       if (!MANAGED_PROFILE_NAMES.has(name)) continue;
@@ -774,6 +797,9 @@ export function mergeDefaultWorkspaceConfig(): DefaultWorkspaceConfigMergeResult
           "Default workspace config supplied non-override fields for built-in profile %s; dropping them (built-in profile config is code-defined)",
           name,
         );
+        if (droppedKeys.some((key) => PROVIDER_ROUTING_PROFILE_KEYS.has(key))) {
+          builtinProfilesWithDroppedProviderConfig.add(name);
+        }
       }
       if (Object.keys(override).length > 0) {
         const overridesStore = ensurePlainObjectAt(
@@ -794,6 +820,7 @@ export function mergeDefaultWorkspaceConfig(): DefaultWorkspaceConfigMergeResult
     providedLlmActiveProfile:
       llmDefaults != null &&
       Object.prototype.hasOwnProperty.call(llmDefaults, "activeProfile"),
+    builtinProfilesWithDroppedProviderConfig,
   };
 
   const configPath = getConfigPath();

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -11,7 +11,6 @@ import { getLogger } from "../util/logger.js";
 import {
   AUTO_PROFILE_KEY,
   type BuiltinProfileDefinition,
-  createAutoProfileEntry,
   MANAGED_PROFILE_NAMES,
   MANAGED_PROFILE_TEMPLATES,
   materializeProfile,
@@ -76,8 +75,11 @@ const USER_PROFILE_TEMPLATES: Record<string, BuiltinProfileDefinition> = {
 
 export type SeedInferenceProfilesOptions = {
   /**
-   * Profile names supplied by the platform/default overlay for this startup.
-   * Those entries are already on disk and should remain authoritative.
+   * Custom profile names supplied by the platform/default overlay for this
+   * startup. Those entries are already on disk and should remain
+   * authoritative. Built-in names never appear here —
+   * `mergeDefaultWorkspaceConfig` converts overlay built-in entries to
+   * `llm.profileOverrides` before seeding runs.
    */
   preserveProfileNames?: Iterable<string>;
   preserveActiveProfile?: boolean;
@@ -90,18 +92,23 @@ export type SeedInferenceProfilesOptions = {
 /**
  * Seed inference profiles into the workspace config.
  *
- * Runs on every daemon startup. Two responsibilities:
+ * Runs on every daemon startup. Built-in (managed + auto) profiles are
+ * code-resolved at config load time (`applyBuiltinProfiles` in `loader.ts`)
+ * and never written to `config.json` — the only persisted built-in state is
+ * the sparse `llm.profileOverrides` store. The seeder's responsibilities:
  *
- * 1. **Managed profiles** (`balanced`, `quality-optimized`, `cost-optimized`):
- *    overwritten on every boot so Vellum can push model/config updates to
- *    customers. Each carries `provider_connection: "anthropic-managed"`.
- *    Platform overlays (`preserveProfileNames`) take precedence.
- *
- * 2. **User profiles** (`custom-balanced`, `custom-quality-optimized`,
+ * 1. **User profiles** (`custom-balanced`, `custom-quality-optimized`,
  *    `custom-cost-optimized`): materialized once at hatch time for
  *    off-platform installations. Each points at a personal provider
  *    connection backed by the user's API key in CES. Subsequent boots
  *    leave these untouched — the user owns them.
+ *
+ * 2. **BYOK hatch status overrides**: a fresh off-platform hatch writes
+ *    `status: "disabled"` overrides for built-ins whose managed connection
+ *    isn't the hatch-selected one, so the picker doesn't offer unusable
+ *    platform-auth options on day one.
+ *
+ * 3. **activeProfile defaults** and source-tagging of custom profiles.
  */
 export function seedInferenceProfiles(
   options: SeedInferenceProfilesOptions = {},
@@ -122,106 +129,35 @@ export function seedInferenceProfiles(
   const isPlatform =
     process.env.IS_PLATFORM === "true" || process.env.IS_PLATFORM === "1";
 
-  // BYOK mode = off-platform installs. The user is bringing their own provider
-  // API key; managed profile labels get a " (Managed)" suffix to disambiguate
-  // from the personal "custom-*" profiles that share base labels. Managed
-  // profile + connection status is initially "disabled" for true BYOK hatches
-  // so the picker doesn't offer an unusable platform-auth option on day one.
-  // When the hatch overlay explicitly selects a managed profile, the matching
-  // managed connection stays active so the first post-onboarding message can
-  // use the user's chosen managed route. Post-hatch user toggles survive every
-  // subsequent boot.
+  // BYOK mode = off-platform installs (the user brings their own provider
+  // API key).
   const isByokMode = !isPlatform;
 
-  // 1. Managed profiles. Off-platform: overwrite on every boot so Vellum can
-  //    push model/config updates in new releases. On-platform: insert only if
-  //    absent — the platform controls profiles through overlays, and the
-  //    overlay fragment is authoritative even when it omits fields the local
-  //    template carries (e.g. an overlay supplying only provider/model/label
-  //    must not get its maxTokens/thinking polluted from the template). The
-  //    legacy migration-052 backfill that seeds label-less Anthropic
-  //    defaults is healed by workspace migration 082
-  //    (`backfill-managed-profile-labels`) rather than the seeder, so
-  //    this skip path stays simple.
-  //
-  //    Two user-editable fields survive the overwrite: `label` (display
-  //    rename) and `status` (active/disabled toggle). The PUT route
-  //    `/v1/config/llm/profiles/:name` lets users patch these on managed
-  //    profiles without duplicating; we have to honor those edits across
-  //    reseeds or they'd silently revert on every boot. Carry by
-  //    key-presence rather than truthiness so an explicit `null` (user
-  //    cleared the label) survives too. Codex P1 finding on PR #30362.
-  //
-  //    BYOK seed defaults (off-platform only):
-  //      • label: " (Managed)" suffix disambiguates managed profile labels
-  //        from personal "custom-*" profiles that share base labels.
-  //        Upgrade migration: existing installs that already have the bare
-  //        template label ("Balanced" / "Quality" / "Speed") on disk get
-  //        rewritten to the suffixed form. Any other previous label value
-  //        (user-set custom string, explicit null, already-suffixed) is
-  //        preserved as-is.
-  //      • status: "disabled" on fresh materialization at BYOK hatch only —
-  //        gated on (isHatch && !previous) and skipped for any managed
-  //        connection explicitly selected by the hatch overlay. Post-hatch
-  //        boots and existing installs are never auto-disabled. A user
-  //        re-enable persists across boots via the key-presence preservation
-  //        below.
-  const hatchSelectedManagedConnection = getHatchSelectedManagedConnection(
-    llm,
-    profiles,
-    options,
-  );
-
-  for (const [name, template] of Object.entries(MANAGED_PROFILE_TEMPLATES)) {
-    if (preservedProfileNames.has(name)) continue;
-    if (isPlatform && readObject(profiles[name]) !== null) continue;
-
-    const previous = readObject(profiles[name]);
-    const effectiveTemplate: BuiltinProfileDefinition = isByokMode
-      ? { ...template, label: `${template.label} (Managed)` }
-      : template;
-    const next = materializeProfile(
-      effectiveTemplate,
-      template.provider,
-      template.connectionName,
-    ) as Record<string, unknown>;
-    if (
-      isByokMode &&
-      options.isHatch &&
-      !previous &&
-      template.connectionName !== hatchSelectedManagedConnection
-    ) {
-      next.status = "disabled";
+  // 1. BYOK hatch status overrides. A fresh BYOK hatch has no platform auth,
+  //    so built-ins whose managed connection isn't the hatch-selected one
+  //    must not surface as enabled in the picker on day one. The disable is
+  //    persisted as a sparse `llm.profileOverrides` status entry; a
+  //    pre-existing status override key (e.g. from a prior hatch or a user
+  //    toggle) is never clobbered. Applied to every definition regardless of
+  //    feature-flag state — an override for a flag-off profile is harmless
+  //    and correct if the flag later enables.
+  if (options.isHatch && isByokMode) {
+    const hatchSelectedManagedConnection = getHatchSelectedManagedConnection(
+      llm,
+      profiles,
+      options,
+    );
+    let profileOverrides = readObject(llm.profileOverrides);
+    if (!profileOverrides) {
+      profileOverrides = {};
+      llm.profileOverrides = profileOverrides;
     }
-    if (previous) {
-      // Preserve user overrides on these whitelisted fields. The label path
-      // also runs the BYOK upgrade migration described above: if the on-disk
-      // label exactly equals the bare template default and we're in BYOK
-      // mode, rewrite to the suffixed effective label so existing installs
-      // get the disambiguation, not just fresh hatches.
-      if ("label" in previous) {
-        next.label =
-          isByokMode && previous.label === template.label
-            ? effectiveTemplate.label
-            : previous.label;
-      }
-      if ("status" in previous) next.status = previous.status;
+    for (const [name, template] of Object.entries(MANAGED_PROFILE_TEMPLATES)) {
+      if (template.connectionName === hatchSelectedManagedConnection) continue;
+      const existing = readObject(profileOverrides[name]);
+      if (existing && "status" in existing) continue;
+      profileOverrides[name] = { ...existing, status: "disabled" };
     }
-    profiles[name] = next as ProfileEntry;
-  }
-
-  // 1b. Auto profile — a metadata-only profile with no provider/model. When
-  //     the user selects "Auto", the resolver falls through to the call-site
-  //     default (balanced or custom-balanced), and the agent loop injects the
-  //     switch_inference_profile tool so the model can self-select per query.
-  if (!preservedProfileNames.has(AUTO_PROFILE_KEY)) {
-    const previousAuto = readObject(profiles[AUTO_PROFILE_KEY]);
-    const autoEntry = createAutoProfileEntry() as Record<string, unknown>;
-    if (previousAuto) {
-      if ("label" in previousAuto) autoEntry.label = previousAuto.label;
-      if ("status" in previousAuto) autoEntry.status = previousAuto.status;
-    }
-    profiles[AUTO_PROFILE_KEY] = autoEntry as ProfileEntry;
   }
 
   // 2. User profiles — only at hatch time for off-platform installations.
@@ -265,13 +201,14 @@ export function seedInferenceProfiles(
     }
   }
 
-  // Active profile resolution.
+  // Active profile resolution. Built-in names count as present even though
+  // they are never materialized into `profiles` — the loader resolves them
+  // from code at every read.
   const requestedActiveProfile = readString(llm.activeProfile);
-  const requestedActiveEntry =
-    requestedActiveProfile !== undefined
-      ? readObject(profiles[requestedActiveProfile])
-      : null;
-  const requestedActiveExists = requestedActiveEntry !== null;
+  const requestedActiveExists =
+    requestedActiveProfile !== undefined &&
+    (MANAGED_PROFILE_NAMES.has(requestedActiveProfile) ||
+      readObject(profiles[requestedActiveProfile]) !== null);
   const shouldPreserveActiveProfile =
     options.preserveActiveProfile === true && requestedActiveExists;
 
@@ -284,31 +221,22 @@ export function seedInferenceProfiles(
     }
   }
 
-  // Profile ordering — ensure all seeded profiles appear in the order array.
-  // "auto" is prepended so it appears first in the picker.
-  const profileOrder = Array.isArray(llm.profileOrder)
-    ? (llm.profileOrder as string[])
-    : [];
-  const orderSet = new Set(profileOrder);
-  if (!orderSet.has(AUTO_PROFILE_KEY)) {
-    profileOrder.unshift(AUTO_PROFILE_KEY);
-    orderSet.add(AUTO_PROFILE_KEY);
-  }
-  for (const name of Object.keys(MANAGED_PROFILE_TEMPLATES)) {
-    if (!orderSet.has(name)) {
-      profileOrder.push(name);
-      orderSet.add(name);
-    }
-  }
+  // Profile ordering — ensure hatch-seeded custom profiles appear in the
+  // order array. Built-in names are spliced into the in-memory order by the
+  // config loader, never persisted here.
   if (userConnectionName) {
+    const profileOrder = Array.isArray(llm.profileOrder)
+      ? (llm.profileOrder as string[])
+      : [];
+    const orderSet = new Set(profileOrder);
     for (const name of Object.keys(USER_PROFILE_TEMPLATES)) {
       if (!orderSet.has(name)) {
         profileOrder.push(name);
         orderSet.add(name);
       }
     }
+    llm.profileOrder = profileOrder;
   }
-  llm.profileOrder = profileOrder;
 
   // Tag any remaining profiles without a source as user-created.
   for (const [name, profile] of Object.entries(profiles)) {
@@ -347,27 +275,23 @@ function getHatchSelectedManagedConnection(
   const activeProfile = readString(llm.activeProfile);
   if (!activeProfile) return undefined;
 
-  const activeProfileEntry = readObject(profiles[activeProfile]);
-  if (
-    activeProfileEntry &&
-    Object.prototype.hasOwnProperty.call(
-      activeProfileEntry,
-      "provider_connection",
-    )
-  ) {
-    const explicitConnection = readString(
-      activeProfileEntry.provider_connection,
-    );
-    return explicitConnection &&
-      MANAGED_CONNECTION_NAMES.has(explicitConnection)
-      ? explicitConnection
+  // Built-in active profiles resolve their connection from the code
+  // template — built-ins are never materialized into `profiles`, and the
+  // template is authoritative for connection routing.
+  const templateConnection =
+    MANAGED_PROFILE_TEMPLATES[activeProfile]?.connectionName;
+  if (templateConnection) {
+    return MANAGED_CONNECTION_NAMES.has(templateConnection)
+      ? templateConnection
       : undefined;
   }
 
-  const templateConnection =
-    MANAGED_PROFILE_TEMPLATES[activeProfile]?.connectionName;
-  return templateConnection && MANAGED_CONNECTION_NAMES.has(templateConnection)
-    ? templateConnection
+  const activeProfileEntry = readObject(profiles[activeProfile]);
+  const explicitConnection = activeProfileEntry
+    ? readString(activeProfileEntry.provider_connection)
+    : undefined;
+  return explicitConnection && MANAGED_CONNECTION_NAMES.has(explicitConnection)
+    ? explicitConnection
     : undefined;
 }
 

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -83,6 +83,15 @@ export type SeedInferenceProfilesOptions = {
    */
   preserveProfileNames?: Iterable<string>;
   preserveActiveProfile?: boolean;
+  /**
+   * Built-in profile names whose overlay entry carried provider-routing
+   * fields that `mergeDefaultWorkspaceConfig` dropped during the conversion
+   * to `llm.profileOverrides`. An `activeProfile` naming one of these meant
+   * "this name, routed to my own provider" — not the code-defined managed
+   * built-in — so the seeder remaps it to the equivalent personal `custom-*`
+   * profile instead of preserving it.
+   */
+  builtinProfilesWithDroppedProviderConfig?: Iterable<string>;
   /** True when a hatch overlay was consumed this startup. */
   isHatch?: boolean;
   /** DB handle for creating user provider connections at hatch time. */
@@ -133,6 +142,36 @@ export function seedInferenceProfiles(
   // API key).
   const isByokMode = !isPlatform;
 
+  // The personal connection a BYOK hatch will create (step 2), determined up
+  // front because the status-override and activeProfile steps both depend on
+  // whether one exists.
+  const hatchProvider =
+    options.isHatch && isByokMode
+      ? readString(readObject(llm.default)?.provider)
+      : undefined;
+  const userConnectionName =
+    hatchProvider &&
+    hatchProvider !== "ollama" &&
+    !PROVIDERS_REQUIRING_BASE_URL_AND_MODELS.has(hatchProvider)
+      ? `${hatchProvider}-personal`
+      : undefined;
+
+  // A hatch overlay activeProfile naming a built-in whose provider-routing
+  // fields were dropped by `mergeDefaultWorkspaceConfig` did not select the
+  // code-defined managed built-in — it asked for that name routed through
+  // the user's own provider. With a personal connection available, the
+  // nearest equivalent is the matching `custom-*` profile; the built-in name
+  // is remapped rather than preserved.
+  const droppedProviderConfigNames = new Set(
+    options.builtinProfilesWithDroppedProviderConfig ?? [],
+  );
+  const requestedActiveProfile = readString(llm.activeProfile);
+  const remapActiveToCustomProfile =
+    options.isHatch === true &&
+    userConnectionName !== undefined &&
+    requestedActiveProfile !== undefined &&
+    droppedProviderConfigNames.has(requestedActiveProfile);
+
   // 1. BYOK hatch status overrides. A fresh BYOK hatch has no platform auth,
   //    so built-ins whose managed connection isn't the hatch-selected one
   //    must not surface as enabled in the picker on day one. The disable is
@@ -142,11 +181,12 @@ export function seedInferenceProfiles(
   //    feature-flag state — an override for a flag-off profile is harmless
   //    and correct if the flag later enables.
   if (options.isHatch && isByokMode) {
-    const hatchSelectedManagedConnection = getHatchSelectedManagedConnection(
-      llm,
-      profiles,
-      options,
-    );
+    // A remapped activeProfile is not a genuine managed-connection selection
+    // — the hatch routes through the personal connection, so every managed
+    // profile gets the disable override.
+    const hatchSelectedManagedConnection = remapActiveToCustomProfile
+      ? undefined
+      : getHatchSelectedManagedConnection(llm, profiles, options);
     let profileOverrides = readObject(llm.profileOverrides);
     if (!profileOverrides) {
       profileOverrides = {};
@@ -161,51 +201,43 @@ export function seedInferenceProfiles(
   }
 
   // 2. User profiles — only at hatch time for off-platform installations.
-  let userConnectionName: string | undefined;
-  if (options.isHatch && !isPlatform) {
-    const hatchProvider = readString(readObject(llm.default)?.provider);
-    if (
-      hatchProvider &&
-      hatchProvider !== "ollama" &&
-      !PROVIDERS_REQUIRING_BASE_URL_AND_MODELS.has(hatchProvider)
-    ) {
-      userConnectionName = `${hatchProvider}-personal`;
-
-      if (options.db) {
-        if (!getConnection(options.db, userConnectionName)) {
-          const credName = credentialKey(hatchProvider, "api_key");
-          const result = createConnection(options.db, {
-            name: userConnectionName,
-            provider: hatchProvider,
-            auth: { type: "api_key", credential: credName },
-            label: personalConnectionLabel(hatchProvider),
-          });
-          if (!result.ok) {
-            log.warn(
-              { provider: hatchProvider, error: result.error },
-              "Failed to create personal connection during hatch seeding",
-            );
-          }
+  if (hatchProvider && userConnectionName) {
+    if (options.db) {
+      if (!getConnection(options.db, userConnectionName)) {
+        const credName = credentialKey(hatchProvider, "api_key");
+        const result = createConnection(options.db, {
+          name: userConnectionName,
+          provider: hatchProvider,
+          auth: { type: "api_key", credential: credName },
+          label: personalConnectionLabel(hatchProvider),
+        });
+        if (!result.ok) {
+          log.warn(
+            { provider: hatchProvider, error: result.error },
+            "Failed to create personal connection during hatch seeding",
+          );
         }
       }
+    }
 
-      const provider = hatchProvider as NonNullable<ProfileEntry["provider"]>;
-      for (const [name, template] of Object.entries(USER_PROFILE_TEMPLATES)) {
-        if (preservedProfileNames.has(name)) continue;
-        profiles[name] = materializeProfile(
-          template,
-          provider,
-          userConnectionName,
-        );
-      }
+    const provider = hatchProvider as NonNullable<ProfileEntry["provider"]>;
+    for (const [name, template] of Object.entries(USER_PROFILE_TEMPLATES)) {
+      if (preservedProfileNames.has(name)) continue;
+      profiles[name] = materializeProfile(
+        template,
+        provider,
+        userConnectionName,
+      );
     }
   }
 
   // Active profile resolution. Built-in names count as present even though
   // they are never materialized into `profiles` — the loader resolves them
-  // from code at every read.
-  const requestedActiveProfile = readString(llm.activeProfile);
+  // from code at every read. A remapped built-in name is deliberately
+  // treated as absent so preservation can't keep the hatch on a managed
+  // profile its BYOK credential can't use.
   const requestedActiveExists =
+    !remapActiveToCustomProfile &&
     requestedActiveProfile !== undefined &&
     (MANAGED_PROFILE_NAMES.has(requestedActiveProfile) ||
       readObject(profiles[requestedActiveProfile]) !== null);
@@ -214,8 +246,13 @@ export function seedInferenceProfiles(
 
   if (!shouldPreserveActiveProfile) {
     if (options.isHatch) {
-      // Hatch = fresh setup. Pick the right default based on platform mode.
-      llm.activeProfile = userConnectionName ? "custom-balanced" : "balanced";
+      // Hatch = fresh setup. Pick the right default based on platform mode;
+      // a remapped built-in lands on the custom profile with the same intent.
+      llm.activeProfile = userConnectionName
+        ? customProfileForBuiltin(
+            remapActiveToCustomProfile ? requestedActiveProfile : undefined,
+          )
+        : "balanced";
     } else if (!requestedActiveExists) {
       llm.activeProfile = "balanced";
     }
@@ -251,6 +288,24 @@ export function seedInferenceProfiles(
   }
 
   saveRawConfig(config);
+}
+
+/**
+ * The personal `custom-*` profile that matches a built-in's model intent —
+ * the landing spot for a hatch whose overlay built-in activeProfile had its
+ * provider routing dropped. Unknown or absent names (and intents without a
+ * user template, e.g. `auto`) fall back to `custom-balanced`.
+ */
+function customProfileForBuiltin(builtinName: string | undefined): string {
+  const intent = builtinName
+    ? MANAGED_PROFILE_TEMPLATES[builtinName]?.intent
+    : undefined;
+  if (intent) {
+    for (const [name, template] of Object.entries(USER_PROFILE_TEMPLATES)) {
+      if (template.intent === intent) return name;
+    }
+  }
+  return "custom-balanced";
 }
 
 function readObject(value: unknown): Record<string, unknown> | null {

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -580,6 +580,8 @@ export async function runDaemon(): Promise<void> {
       seedInferenceProfiles({
         preserveProfileNames: defaultConfigMerge.providedLlmProfileNames,
         preserveActiveProfile: defaultConfigMerge.providedLlmActiveProfile,
+        builtinProfilesWithDroppedProviderConfig:
+          defaultConfigMerge.builtinProfilesWithDroppedProviderConfig,
         isHatch: defaultConfigMerge.hadOverlay,
         db: dbReady ? getDb() : undefined,
       });

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -97,7 +97,6 @@ import {
   updateWorkItem,
 } from "../work-items/work-item-store.js";
 import { WorkspaceHeartbeatService } from "../workspace/heartbeat-service.js";
-import { repairAdaptiveThinkingOnManagedProfiles } from "../workspace/migrations/097-enable-adaptive-thinking-managed-profiles.js";
 import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
 import { runWorkspaceMigrations } from "../workspace/migrations/runner.js";
 import {
@@ -570,10 +569,13 @@ export async function runDaemon(): Promise<void> {
     // seeder and persisted alongside schema defaults.
     const defaultConfigMerge = mergeDefaultWorkspaceConfig();
 
-    // Seed inference profiles into the workspace config. Managed Anthropic
-    // profiles are overwritten on every boot so Vellum can push updates.
-    // Off-platform hatches additionally create user profiles + a personal
-    // provider connection for the hatch provider.
+    // Seed inference profiles into the workspace config. Built-in (managed)
+    // profiles are code-resolved at config load time and never written to
+    // disk; the seeder handles hatch-time user (`custom-*`) profiles + the
+    // personal provider connection, BYOK hatch status overrides, and the
+    // activeProfile default. `preserveProfileNames` carries only custom
+    // overlay names — built-in overlay entries were converted to
+    // `llm.profileOverrides` by mergeDefaultWorkspaceConfig above.
     try {
       seedInferenceProfiles({
         preserveProfileNames: defaultConfigMerge.providedLlmProfileNames,
@@ -587,26 +589,6 @@ export async function runDaemon(): Promise<void> {
         { err },
         "Inference profile seeding failed — continuing startup",
       );
-    }
-
-    // Re-run the adaptive thinking repair after overlay merge + profile seeding.
-    // Workspace migration 097 enables adaptive thinking on managed profiles, but
-    // it runs before mergeDefaultWorkspaceConfig() which can overwrite the fix
-    // with overlay profiles that have thinking disabled or absent. On-platform
-    // instances where the overlay supplies "balanced" / "quality-optimized"
-    // profiles without thinking enabled would be stuck permanently because the
-    // migration is already checkpointed as completed. This idempotent repair
-    // ensures thinking is enabled regardless of overlay ordering.
-    if (defaultConfigMerge.hadOverlay) {
-      try {
-        repairAdaptiveThinkingOnManagedProfiles(getWorkspaceDir());
-        log.info("Post-overlay adaptive thinking repair complete");
-      } catch (err) {
-        log.warn(
-          { err },
-          "Post-overlay adaptive thinking repair failed — continuing startup",
-        );
-      }
     }
 
     log.info("Daemon startup: loading config");


### PR DESCRIPTION
## Summary
- seedInferenceProfiles no longer writes managed/auto profile entries to config.json (custom-* hatch materialization unchanged)
- BYOK hatch-disable now persists status overrides in llm.profileOverrides; overlay-supplied built-in entries convert to overrides with dropped fields logged
- Post-overlay repairAdaptiveThinkingOnManagedProfiles call removed — templates are authoritative at load time

Part of plan: builtin-llm-profiles.md (PR 6 of 8)