### PR TITLE
feat(memory-v3): add maintainer-curated core-set loader

### DIFF
--- a/assistant/src/plugins/defaults/memory-v3-shadow/core-set.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/core-set.test.ts
@@ -1,0 +1,80 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { loadCoreSet } from "./core-set.js";
+
+let workspaceDir: string;
+
+function writeCorePages(content: string): void {
+  mkdirSync(join(workspaceDir, "memory"), { recursive: true });
+  writeFileSync(join(workspaceDir, "memory", "core-pages.md"), content);
+}
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "core-set-test-"));
+});
+
+afterEach(() => {
+  rmSync(workspaceDir, { recursive: true, force: true });
+});
+
+describe("loadCoreSet", () => {
+  test("missing file yields []", () => {
+    expect(loadCoreSet(workspaceDir)).toEqual([]);
+  });
+
+  test("accepts both wikilink and bare-slug list forms", () => {
+    writeCorePages(["- [[page-a]]", "- page-b"].join("\n"));
+    expect(loadCoreSet(workspaceDir)).toEqual(["page-a", "page-b"]);
+  });
+
+  test("ignores headings, blank lines, and prose annotations", () => {
+    writeCorePages(
+      [
+        "# Core pages",
+        "",
+        "Curated during consolidation; keep this list short.",
+        "- [[page-a]]",
+        "",
+        "## Identity frames",
+        "These never match lexically but should always be candidates.",
+        "- page-b",
+      ].join("\n"),
+    );
+    expect(loadCoreSet(workspaceDir)).toEqual(["page-a", "page-b"]);
+  });
+
+  test("dedupes while preserving first-seen order", () => {
+    writeCorePages(
+      ["- page-b", "- [[page-a]]", "- [[page-b]]", "- page-a", "- page-c"].join(
+        "\n",
+      ),
+    );
+    expect(loadCoreSet(workspaceDir)).toEqual(["page-b", "page-a", "page-c"]);
+  });
+
+  test("skips entries outside the slug-safe charset", () => {
+    writeCorePages(
+      [
+        "- [[Page A]]",
+        "- page_b",
+        "- [[topics/page-a]]",
+        "- UPPER-CASE",
+        "- page-b",
+        "- [[]]",
+      ].join("\n"),
+    );
+    expect(loadCoreSet(workspaceDir)).toEqual(["topics/page-a", "page-b"]);
+  });
+
+  test("malformed list lines are skipped, not fatal", () => {
+    writeCorePages(
+      ["-", "-no-space", "- [[unclosed", "- two words here", "- page-a"].join(
+        "\n",
+      ),
+    );
+    expect(loadCoreSet(workspaceDir)).toEqual(["page-a"]);
+  });
+});

--- a/assistant/src/plugins/defaults/memory-v3-shadow/core-set.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/core-set.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { Slug } from "./types.js";
+
+/**
+ * Workspace-relative path of the maintainer-curated core-set file. Edited
+ * during memory consolidation — the loader never creates or modifies it.
+ */
+const CORE_PAGES_RELATIVE_PATH = join("memory", "core-pages.md");
+
+/**
+ * A list line is `- <item>`; the item may be a bare slug or a `[[slug]]`
+ * wikilink. Anything else on the line (headings, prose, annotations) is the
+ * maintainer's notes and is ignored.
+ */
+const LIST_LINE = /^-\s+(?:\[\[([^\]]+)\]\]|(\S+))\s*$/;
+
+/** Slug-safe charset; existence against the page store is checked at lane init. */
+const SLUG_SHAPE = /^[a-z0-9-/]+$/;
+
+/**
+ * Load the maintainer-curated core set from `<workspaceDir>/memory/core-pages.md`.
+ *
+ * The core lane answers the associative-texture gap (pages with no
+ * lexical/semantic match to the message), so its membership is curated, not
+ * computed. Parsing is tolerant: list lines in `- [[some-slug]]` or
+ * `- some-slug` form are accepted; headings, blank lines, and prose are
+ * skipped so the maintainer can annotate the file; malformed or
+ * non-slug-shaped entries are dropped, never fatal.
+ *
+ * Returns slugs deduped in first-seen file order — that order is the stable
+ * sort the selector uses for the core prefix. A missing file yields `[]`.
+ */
+export function loadCoreSet(workspaceDir: string): Slug[] {
+  let raw: string;
+  try {
+    raw = readFileSync(join(workspaceDir, CORE_PAGES_RELATIVE_PATH), "utf8");
+  } catch {
+    return [];
+  }
+
+  const seen = new Set<Slug>();
+  const slugs: Slug[] = [];
+  for (const line of raw.split("\n")) {
+    const match = LIST_LINE.exec(line.trim());
+    if (!match) continue;
+    const slug = (match[1] ?? match[2] ?? "").trim();
+    if (!SLUG_SHAPE.test(slug) || seen.has(slug)) continue;
+    seen.add(slug);
+    slugs.push(slug);
+  }
+  return slugs;
+}


### PR DESCRIPTION
## Summary
- Adds loadCoreSet: tolerant parser for the maintainer-curated memory/core-pages.md workspace file
- Missing file yields an empty lane; order preserved as the selector's stable sort

Part of plan: memory-v3-cache-aware-carry.md (PR 2 of 11)