### PR TITLE
feat(memory-v3): add frecency hot-set lane module

### DIFF
--- a/assistant/src/config/schemas/__tests__/memory-v3.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v3.test.ts
@@ -7,6 +7,7 @@ describe("MemoryV3ConfigSchema", () => {
     const parsed = MemoryV3ConfigSchema.parse({});
     expect(parsed).toEqual({
       workingSet: { maxPages: 150, evictWindow: 5 },
+      hotSet: { k: 40, halfLifeDays: 14 },
       needleK: 100,
       denseK: 100,
       edge: { hubDegree: 30, seedCount: 18, perSeed: 6, cap: 45 },

--- a/assistant/src/config/schemas/memory-v3.ts
+++ b/assistant/src/config/schemas/memory-v3.ts
@@ -67,11 +67,36 @@ export const MemoryV3EdgeSchema = z
   })
   .describe("Memory v3 edge-lane (link-graph expansion) tuning.");
 
+/**
+ * Hot-set lane tuning: the top-K pages by exponentially-decayed selection
+ * frequency (frecency) folded into the candidate pool as a stable lane.
+ */
+export const MemoryV3HotSetSchema = z
+  .object({
+    k: z
+      .number({ error: "memory.v3.hotSet.k must be a number" })
+      .int("memory.v3.hotSet.k must be an integer")
+      .positive("memory.v3.hotSet.k must be a positive integer")
+      .default(40)
+      .describe(
+        "Number of top frecency-scored pages included in the hot-set lane.",
+      ),
+    halfLifeDays: z
+      .number({ error: "memory.v3.hotSet.halfLifeDays must be a number" })
+      .positive("memory.v3.hotSet.halfLifeDays must be a positive number")
+      .default(14)
+      .describe(
+        "Frecency decay half-life in days: a selection this old contributes half the weight of one made now.",
+      ),
+  })
+  .describe("Memory v3 hot-set lane (decayed selection frequency) tuning.");
+
 export const MemoryV3ConfigSchema = z
   .object({
     workingSet: MemoryV3WorkingSetSchema.default(
       MemoryV3WorkingSetSchema.parse({}),
     ),
+    hotSet: MemoryV3HotSetSchema.default(MemoryV3HotSetSchema.parse({})),
     needleK: z
       .number({ error: "memory.v3.needleK must be a number" })
       .int("memory.v3.needleK must be an integer")

--- a/assistant/src/plugins/defaults/memory-v3-shadow/hot-set.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/hot-set.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests for the frecency hot-set lane (`hot-set.ts`) and its config schema.
+ *
+ * `computeHotSet` takes the db handle directly (no module mocks needed):
+ * each test seeds an in-memory SQLite db with `memory_v3_selections` rows
+ * (via the real migration) and asserts the decayed-frequency ranking.
+ */
+
+import { Database } from "bun:sqlite";
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import { MemoryV3ConfigSchema } from "../../../config/schemas/memory-v3.js";
+import { migrateAddMemoryV3Selections } from "../../../memory/migrations/268-add-memory-v3-selections.js";
+import * as schema from "../../../memory/schema.js";
+import { computeHotSet, type HotSetOptions } from "./hot-set.js";
+
+const HALF_LIFE_MS = 1000;
+const NOW = 100_000;
+
+let sqlite: Database;
+let db: ReturnType<typeof drizzle<typeof schema>>;
+
+beforeEach(() => {
+  sqlite = new Database(":memory:");
+  db = drizzle(sqlite, { schema });
+  migrateAddMemoryV3Selections(db);
+});
+
+let nextTurn = 0;
+/** Insert one selection row per createdAt (distinct turns keep the PK unique). */
+function seed(slug: string, createdAts: number[]): void {
+  const stmt = sqlite.query(
+    `INSERT INTO memory_v3_selections (conversation_id, turn, slug, source, pinned, created_at) VALUES (?, ?, ?, ?, ?, ?)`,
+  );
+  for (const createdAt of createdAts) {
+    stmt.run("conv-1", nextTurn++, slug, "needle", 0, createdAt);
+  }
+}
+
+function hotSet(overrides: Partial<HotSetOptions> = {}) {
+  return computeHotSet(
+    { db },
+    {
+      k: 10,
+      halfLifeMs: HALF_LIFE_MS,
+      now: NOW,
+      excludeSlugs: new Set<string>(),
+      ...overrides,
+    },
+  );
+}
+
+describe("computeHotSet", () => {
+  test("empty table yields empty result", () => {
+    expect(hotSet()).toEqual([]);
+  });
+
+  test("newer selections outweigh older ones at the same count", () => {
+    seed("page-old", [NOW - 10 * HALF_LIFE_MS, NOW - 10 * HALF_LIFE_MS]);
+    seed("page-new", [NOW, NOW]);
+    const result = hotSet();
+    expect(result.map((e) => e.slug)).toEqual(["page-new", "page-old"]);
+    expect(result[0]!.score).toBeGreaterThan(result[1]!.score);
+  });
+
+  test("decay halves at exactly one half-life", () => {
+    seed("page-a", [NOW]);
+    seed("page-b", [NOW - HALF_LIFE_MS]);
+    const result = hotSet();
+    const bySlug = new Map(result.map((e) => [e.slug, e.score]));
+    expect(bySlug.get("page-a")).toBeCloseTo(1, 10);
+    expect(bySlug.get("page-b")).toBeCloseTo(0.5, 10);
+  });
+
+  test("scores sum across a slug's selections", () => {
+    seed("page-a", [NOW, NOW - HALF_LIFE_MS]);
+    expect(hotSet()[0]!.score).toBeCloseTo(1.5, 10);
+  });
+
+  test("k cut keeps only the top-k", () => {
+    seed("page-a", [NOW, NOW, NOW]);
+    seed("page-b", [NOW, NOW]);
+    seed("page-c", [NOW]);
+    expect(hotSet({ k: 2 }).map((e) => e.slug)).toEqual(["page-a", "page-b"]);
+  });
+
+  test("excludeSlugs filters before the k cut", () => {
+    seed("page-a", [NOW, NOW, NOW]);
+    seed("page-b", [NOW, NOW]);
+    seed("page-c", [NOW]);
+    const result = hotSet({ k: 2, excludeSlugs: new Set(["page-a"]) });
+    expect(result.map((e) => e.slug)).toEqual(["page-b", "page-c"]);
+  });
+
+  test("ties break deterministically by slug ascending", () => {
+    seed("page-b", [NOW]);
+    seed("page-a", [NOW]);
+    seed("page-c", [NOW]);
+    expect(hotSet().map((e) => e.slug)).toEqual(["page-a", "page-b", "page-c"]);
+  });
+
+  test("deterministic for fixed inputs", () => {
+    seed("page-a", [NOW, NOW - 3 * HALF_LIFE_MS]);
+    seed("page-b", [NOW - HALF_LIFE_MS]);
+    expect(hotSet()).toEqual(hotSet());
+  });
+
+  test("future-dated rows are clamped to weight 1", () => {
+    seed("page-a", [NOW + 50 * HALF_LIFE_MS]);
+    expect(hotSet()[0]!.score).toBeCloseTo(1, 10);
+  });
+});
+
+describe("MemoryV3ConfigSchema hotSet", () => {
+  test("defaults apply when omitted", () => {
+    const config = MemoryV3ConfigSchema.parse({});
+    expect(config.hotSet).toEqual({ k: 40, halfLifeDays: 14 });
+  });
+
+  test("explicit values parse", () => {
+    const config = MemoryV3ConfigSchema.parse({
+      hotSet: { k: 5, halfLifeDays: 7 },
+    });
+    expect(config.hotSet).toEqual({ k: 5, halfLifeDays: 7 });
+  });
+
+  test("rejects negative k", () => {
+    expect(() => MemoryV3ConfigSchema.parse({ hotSet: { k: -1 } })).toThrow();
+  });
+
+  test("rejects negative halfLifeDays", () => {
+    expect(() =>
+      MemoryV3ConfigSchema.parse({ hotSet: { halfLifeDays: -1 } }),
+    ).toThrow();
+  });
+});

--- a/assistant/src/plugins/defaults/memory-v3-shadow/hot-set.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/hot-set.ts
@@ -1,0 +1,85 @@
+/**
+ * Frecency hot-set lane.
+ *
+ * Scores every page slug in `memory_v3_selections` (all conversations) by its
+ * exponentially-decayed selection count and returns the top-K. The hot set is
+ * the lane that keeps *seasonally recurrent* pages in the candidate pool even
+ * when the current message gives the finder lanes nothing to match on; the
+ * curated core set (a separate lane) covers the associative-texture class
+ * frecency cannot discriminate.
+ *
+ * Each selection row contributes `2^(−age / halfLifeMs)` to its slug's score,
+ * so a selection exactly one half-life old counts half as much as one made
+ * now. Slugs in `excludeSlugs` (the core set) are dropped before the K cut —
+ * the hot lane never duplicates core.
+ */
+
+import {
+  type DrizzleDb,
+  getSqliteFrom,
+} from "../../../memory/db-connection.js";
+import type { Slug } from "./types.js";
+
+export interface HotSetDeps {
+  /** Handle to the database containing `memory_v3_selections`. */
+  db: DrizzleDb;
+}
+
+export interface HotSetOptions {
+  /** Maximum number of slugs returned. */
+  k: number;
+  /** Decay half-life in milliseconds: a selection this old scores 0.5. */
+  halfLifeMs: number;
+  /** Reference timestamp (ms epoch) ages are measured against. */
+  now: number;
+  /** Slugs excluded from the result (the core set — hot never duplicates core). */
+  excludeSlugs: Set<string>;
+}
+
+export interface HotSetEntry {
+  slug: Slug;
+  score: number;
+}
+
+interface SelectionAgeRow {
+  slug: string;
+  created_at: number;
+}
+
+/**
+ * Compute the top-`k` hot slugs by exponentially-decayed selection frequency.
+ *
+ * Deterministic for fixed inputs: ties break score desc, then slug asc. The
+ * decay sum runs in TS over `(slug, created_at)` pairs — the selections table
+ * is small enough that reading it directly beats pushing the math into SQL.
+ */
+export function computeHotSet(
+  deps: HotSetDeps,
+  opts: HotSetOptions,
+): HotSetEntry[] {
+  const { k, halfLifeMs, now, excludeSlugs } = opts;
+  if (k <= 0) return [];
+
+  const rows = getSqliteFrom(deps.db)
+    .query(
+      /*sql*/ `
+      SELECT slug, created_at FROM memory_v3_selections
+    `,
+    )
+    .all() as SelectionAgeRow[];
+
+  const scores = new Map<Slug, number>();
+  for (const row of rows) {
+    if (excludeSlugs.has(row.slug)) continue;
+    // Clamp future-dated rows (clock skew) to "now" rather than letting them
+    // score above 1 per selection.
+    const age = Math.max(0, now - row.created_at);
+    const weight = 2 ** (-age / halfLifeMs);
+    scores.set(row.slug, (scores.get(row.slug) ?? 0) + weight);
+  }
+
+  return [...scores.entries()]
+    .map(([slug, score]) => ({ slug, score }))
+    .sort((a, b) => b.score - a.score || (a.slug < b.slug ? -1 : 1))
+    .slice(0, k);
+}


### PR DESCRIPTION
## Summary
- Adds computeHotSet: top-K pages by exponentially-decayed selection frequency from memory_v3_selections, excluding the core set
- Adds memory.v3.hotSet config (k=40, halfLifeDays=14)

Part of plan: memory-v3-cache-aware-carry.md (PR 1 of 11)