### PR TITLE
feat(memory-v3): add compact card renderer (head section + TOC)

### DIFF
--- a/assistant/src/plugins/defaults/memory-v3-shadow/card.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/card.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, test } from "bun:test";
+
+import { cardBytes, renderCard } from "./card.js";
+
+describe("renderCard", () => {
+  test("standard article renders head section + section TOC", () => {
+    const raw = [
+      "---",
+      "summary: A page about topic A.",
+      "---",
+      "# Topic A",
+      "",
+      "Lead paragraph one about topic A.",
+      "",
+      "Lead paragraph two with more detail.",
+      "",
+      "## History",
+      "history body",
+      "",
+      "## Design",
+      "design body",
+      "",
+      "## Open Questions",
+      "open questions body",
+    ].join("\n");
+
+    expect(renderCard("page-a", raw)).toBe(
+      [
+        "# memory/concepts/page-a.md",
+        "# Topic A",
+        "",
+        "Lead paragraph one about topic A.",
+        "",
+        "Lead paragraph two with more detail.",
+        "",
+        "[sections: §History · §Design · §Open Questions]",
+      ].join("\n"),
+    );
+  });
+
+  test("kind: index page renders its links: map instead of section names", () => {
+    const longNote = "x".repeat(100);
+    const raw = [
+      "---",
+      "kind: index",
+      "links:",
+      "  - page-a — short note about page a",
+      `  - page-b — ${longNote}`,
+      "  - page-c",
+      "---",
+      "# Index of Topics",
+      "",
+      "Lead line.",
+      "",
+      "## Pages",
+      "generic section body",
+    ].join("\n");
+
+    const card = renderCard("topics-index", raw);
+    expect(card).toBe(
+      [
+        "# memory/concepts/topics-index.md",
+        "# Index of Topics",
+        "",
+        "Lead line.",
+        "",
+        `[linked: page-a — short note about page a · page-b — ${"x".repeat(80)}… · page-c]`,
+      ].join("\n"),
+    );
+    // Section names never appear on an index card.
+    expect(card).not.toContain("§Pages");
+  });
+
+  test("kind: index without usable links falls back to section names", () => {
+    const raw = [
+      "---",
+      "kind: index",
+      "---",
+      "# Bare Index",
+      "",
+      "## Pages",
+      "body",
+    ].join("\n");
+
+    expect(renderCard("bare-index", raw)).toBe(
+      [
+        "# memory/concepts/bare-index.md",
+        "# Bare Index",
+        "",
+        "[sections: §Pages]",
+      ].join("\n"),
+    );
+  });
+
+  test("sectionless page omits the TOC line", () => {
+    const raw = [
+      "---",
+      "summary: s",
+      "---",
+      "# Sectionless",
+      "",
+      "Just a lead.",
+    ].join("\n");
+
+    expect(renderCard("page-b", raw)).toBe(
+      ["# memory/concepts/page-b.md", "# Sectionless", "", "Just a lead."].join(
+        "\n",
+      ),
+    );
+  });
+
+  test("frontmatter-less text renders head + TOC", () => {
+    const raw = [
+      "# No Frontmatter",
+      "",
+      "Lead.",
+      "",
+      "## Only Section",
+      "body",
+    ].join("\n");
+
+    expect(renderCard("page-c", raw)).toBe(
+      [
+        "# memory/concepts/page-c.md",
+        "# No Frontmatter",
+        "",
+        "Lead.",
+        "",
+        "[sections: §Only Section]",
+      ].join("\n"),
+    );
+  });
+
+  test("body starting at a ## heading renders header + TOC with no head block", () => {
+    const raw = ["## First", "body", "", "## Second", "body"].join("\n");
+
+    expect(renderCard("page-d", raw)).toBe(
+      ["# memory/concepts/page-d.md", "", "[sections: §First · §Second]"].join(
+        "\n",
+      ),
+    );
+  });
+
+  test("long lead injects whole (no length cap)", () => {
+    const longLead = `Long lead. ${"y".repeat(10_000)}`;
+    const raw = ["# Long", "", longLead, "", "## Section", "body"].join("\n");
+
+    expect(renderCard("page-e", raw)).toContain(longLead);
+  });
+
+  test("deterministic for the same input", () => {
+    const raw = ["# T", "", "Lead.", "", "## S", "b"].join("\n");
+    expect(renderCard("page-f", raw)).toBe(renderCard("page-f", raw));
+  });
+});
+
+describe("cardBytes", () => {
+  test("counts UTF-8 bytes, not characters", () => {
+    expect(cardBytes("abc")).toBe(3);
+    expect(cardBytes("§")).toBe(2); // U+00A7 is 2 bytes in UTF-8
+  });
+
+  test("accounts for a rendered card's full byte footprint", () => {
+    const card = renderCard(
+      "page-a",
+      ["# T", "", "Lead.", "", "## S", "b"].join("\n"),
+    );
+    // The card contains exactly one multibyte char (the TOC's "§"), so its
+    // byte footprint is one over its character length.
+    expect(card.match(/§/g)).toHaveLength(1);
+    expect(cardBytes(card)).toBe(card.length + 1);
+  });
+});

--- a/assistant/src/plugins/defaults/memory-v3-shadow/card.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/card.ts
@@ -1,0 +1,114 @@
+import {
+  FRONTMATTER_REGEX,
+  parseFrontmatterFields,
+} from "../../../skills/frontmatter.js";
+import type { Slug } from "./types.js";
+
+/**
+ * Compact card renderer for memory-v3: a page's head section (the `# Title`
+ * line plus lead paragraphs, everything before the first `## ` heading) plus a
+ * one-line section TOC. Cards are the compact injection unit — they carry
+ * enough signal to act on (or `file_read` the full page) at a fraction of the
+ * full-page byte cost.
+ *
+ * The `# memory/concepts/<slug>.md` header matches the v2 memory-block page
+ * convention, so the existing `file_read` affordance instruction applies to
+ * cards unchanged.
+ *
+ * Pure text → text: no I/O, no LLM calls. Callers load the raw page text via
+ * the existing page-store helpers (see `page-content.ts`).
+ */
+
+/** Max characters of a `links:` entry note carried into the `[linked: …]`
+ * line. Notes longer than this are truncated with an ellipsis. */
+const LINK_NOTE_MAX_CHARS = 80;
+
+/** Matches a `## ` section heading line; capture group is the heading text. */
+const SECTION_HEADING_REGEX = /^## (.*)$/m;
+
+/**
+ * Render one `links:` frontmatter entry (`"<target-slug> — <note>"`) for the
+ * `[linked: …]` TOC line, truncating the note at {@link LINK_NOTE_MAX_CHARS}.
+ * Entries with no ` — ` separator are bare target slugs and pass through.
+ */
+function renderLinkEntry(entry: string): string {
+  const sep = entry.indexOf(" — ");
+  if (sep === -1) return entry.trim();
+  const target = entry.slice(0, sep).trim();
+  let note = entry.slice(sep + " — ".length).trim();
+  if (note.length > LINK_NOTE_MAX_CHARS) {
+    note = `${note.slice(0, LINK_NOTE_MAX_CHARS).trimEnd()}…`;
+  }
+  return note.length > 0 ? `${target} — ${note}` : target;
+}
+
+/**
+ * Build the one-line TOC for a card.
+ *
+ * Index pages (`kind: index` frontmatter) render their `links:` map instead of
+ * section names — index sections have generic names ("Pages", "See also");
+ * the link map is the real signal. All other pages (including an index with no
+ * usable `links:`) render their `## ` heading names. Returns `null` when there
+ * is nothing to list (the TOC line is omitted).
+ */
+function renderTocLine(
+  body: string,
+  fields: Record<string, unknown>,
+): string | null {
+  if (fields.kind === "index" && Array.isArray(fields.links)) {
+    const entries = fields.links
+      .filter((entry): entry is string => typeof entry === "string")
+      .map(renderLinkEntry)
+      .filter((entry) => entry.length > 0);
+    if (entries.length > 0) return `[linked: ${entries.join(" · ")}]`;
+  }
+
+  const headings = [...body.matchAll(new RegExp(SECTION_HEADING_REGEX, "gm"))]
+    .map((match) => match[1]!.trim())
+    .filter((heading) => heading.length > 0);
+  if (headings.length === 0) return null;
+  return `[sections: ${headings.map((h) => `§${h}`).join(" · ")}]`;
+}
+
+/**
+ * Render a page's compact card: header marker, head section (uncapped — the
+ * corpus's rare long leads inject whole; a length cap is a deliberate
+ * non-feature), and one-line TOC.
+ *
+ * ```
+ * # memory/concepts/<slug>.md
+ * <head section verbatim>
+ *
+ * [sections: §… · §…]
+ * ```
+ *
+ * The TOC line is omitted when the page has no `## ` sections and no usable
+ * `links:`. Deterministic for a given (slug, rawPageText).
+ */
+export function renderCard(slug: Slug, rawPageText: string): string {
+  const parsed = parseFrontmatterFields(rawPageText);
+  // `parseFrontmatterFields` returns null both for "no frontmatter block" and
+  // "block present but YAML failed to parse" — strip the block either way so a
+  // malformed page never leaks raw frontmatter into the card head.
+  const body = parsed
+    ? parsed.body
+    : rawPageText.replace(FRONTMATTER_REGEX, "");
+  const fields = parsed?.fields ?? {};
+
+  const firstHeading = SECTION_HEADING_REGEX.exec(body);
+  const head = (firstHeading ? body.slice(0, firstHeading.index) : body).trim();
+
+  let card = `# memory/concepts/${slug}.md`;
+  if (head.length > 0) card += `\n${head}`;
+
+  const toc = renderTocLine(body, fields);
+  if (toc !== null) card += `\n\n${toc}`;
+
+  return card;
+}
+
+/** UTF-8 byte length of a rendered card (prune-valve and footprint
+ * accounting both budget in bytes, not characters). */
+export function cardBytes(card: string): number {
+  return Buffer.byteLength(card, "utf8");
+}


### PR DESCRIPTION
## Summary
- Adds renderCard: page head section (uncapped) + one-line section TOC, under the v2 memory-block header convention
- Index pages render their links: map instead of generic section names; cardBytes helper for footprint accounting

Part of plan: memory-v3-cache-aware-carry.md (PR 3 of 11)