### PR TITLE
feat(memory-v3): add everInjected store with v2-style fork inheritance

### DIFF
--- a/assistant/src/__tests__/conversation-fork-crud.test.ts
+++ b/assistant/src/__tests__/conversation-fork-crud.test.ts
@@ -63,6 +63,12 @@ import {
   toolInvocations,
 } from "../memory/schema.js";
 import { hydrate as hydrateActivationState } from "../memory/v2/activation-store.js";
+import {
+  getInjected as getV3Injected,
+  markPruned as markV3Pruned,
+  MEMORY_V3_INJECTED_BLOCK_METADATA_KEY,
+  recordInjected as recordV3Injected,
+} from "../plugins/defaults/memory-v3-shadow/ever-injected-store.js";
 
 initializeDb();
 
@@ -77,6 +83,7 @@ function resetTables(): void {
   db.delete(llmRequestLogs).run();
   db.delete(toolInvocations).run();
   db.delete(memoryJobs).run();
+  db.run("DELETE FROM memory_v3_ever_injected");
   db.run("DELETE FROM message_attachments");
   db.run("DELETE FROM attachments");
   db.run("DELETE FROM messages");
@@ -1029,6 +1036,103 @@ describe("forkConversation", () => {
     const childState = await hydrateActivationState(getDb(), fork.id);
     expect(childState?.everInjected.map((e) => e.slug)).toEqual([
       "topics/page-live",
+    ]);
+  });
+
+  test("copies the parent's memory-v3 everInjected record into a full fork", async () => {
+    const source = createConversation("V3 carry thread");
+    await addMessage(source.id, "user", "first turn", { skipIndexing: true });
+
+    recordV3Injected(
+      source.id,
+      [
+        { slug: "topics/page-a", bytes: 120 },
+        { slug: "topics/page-b", bytes: 340 },
+      ],
+      1_700_000_000_000,
+    );
+    markV3Pruned(source.id, ["topics/page-b"], 1_700_000_001_000);
+
+    const fork = forkConversation({ conversationId: source.id });
+
+    // Full-row copy, pruned state included.
+    expect(getV3Injected(fork.id)).toEqual(
+      new Map([
+        ["topics/page-a", { bytes: 120, prunedAt: null }],
+        ["topics/page-b", { bytes: 340, prunedAt: 1_700_000_001_000 }],
+      ]),
+    );
+    // Parent record is untouched.
+    expect(getV3Injected(source.id).size).toBe(2);
+  });
+
+  test("leaves the fork's memory-v3 record empty when the parent has none", async () => {
+    const source = createConversation("V3 pristine thread");
+    await addMessage(source.id, "user", "first message", {
+      skipIndexing: true,
+    });
+
+    const fork = forkConversation({ conversationId: source.id });
+
+    expect(getV3Injected(fork.id).size).toBe(0);
+  });
+
+  test("truncated fork seeds the memory-v3 record from inherited v3 card blocks", async () => {
+    const source = createConversation("V3 truncated seed thread");
+    await addMessage(source.id, "user", "first turn", {
+      metadata: {
+        [MEMORY_V3_INJECTED_BLOCK_METADATA_KEY]:
+          "# memory/concepts/topics/page-a.md\nCard A\n\n# memory/concepts/topics/page-b.md\nCard B",
+        // A v2 block on the same message must seed only the v2 record.
+        memoryInjectedBlock: "# memory/concepts/topics/page-v2.md\nSummary",
+      },
+      skipIndexing: true,
+    });
+    await addMessage(source.id, "assistant", "first reply", {
+      skipIndexing: true,
+    });
+    const boundaryMessage = await addMessage(source.id, "user", "second turn", {
+      skipIndexing: true,
+    });
+    await addMessage(source.id, "assistant", "second reply", {
+      skipIndexing: true,
+    });
+    // Past the fork boundary — its card must NOT be claimed.
+    await addMessage(source.id, "user", "third turn", {
+      metadata: {
+        [MEMORY_V3_INJECTED_BLOCK_METADATA_KEY]:
+          "# memory/concepts/topics/page-c.md\nCard C",
+      },
+      skipIndexing: true,
+    });
+
+    recordV3Injected(
+      source.id,
+      [
+        { slug: "topics/page-a", bytes: 120 },
+        { slug: "topics/page-b", bytes: 340 },
+        { slug: "topics/page-c", bytes: 90 },
+      ],
+      1_700_000_000_000,
+    );
+
+    const fork = forkConversation({
+      conversationId: source.id,
+      throughMessageId: boundaryMessage.id,
+    });
+
+    // Exactly the slugs whose card blocks live in the copied history,
+    // dedup-only (`bytes = 0` — resident accounting restarts on the child).
+    expect(getV3Injected(fork.id)).toEqual(
+      new Map([
+        ["topics/page-a", { bytes: 0, prunedAt: null }],
+        ["topics/page-b", { bytes: 0, prunedAt: null }],
+      ]),
+    );
+    // The v2 seed picked up only the v2 block, not the v3 cards.
+    const childState = await hydrateActivationState(getDb(), fork.id);
+    expect(childState?.everInjected.map((e) => e.slug)).toEqual([
+      "topics/page-v2",
     ]);
   });
 

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -28,6 +28,11 @@ import { findDisplayTurnEndIndex } from "../conversations/message-consolidation.
 import { conversationMetadataSyncTag } from "../daemon/message-types/sync.js";
 import type { TrustContext } from "../daemon/trust-context.js";
 import { clearAllConversationIds } from "../home/feed-writer.js";
+import {
+  forkEverInjected,
+  MEMORY_V3_INJECTED_BLOCK_METADATA_KEY,
+  seedEverInjectedFromSlugs,
+} from "../plugins/defaults/memory-v3-shadow/ever-injected-store.js";
 import { publishSyncInvalidation } from "../runtime/sync/sync-publisher.js";
 import { UserError } from "../util/errors.js";
 import { safeParseRecord } from "../util/json.js";
@@ -171,16 +176,21 @@ function cloneForkMessageMetadata(
 }
 
 /**
- * Read the persisted `memoryInjectedBlock` off a message's metadata JSON, or
- * `null` when absent/malformed. The block is what the request builder
- * re-attaches as the message's `<memory>` content each turn.
+ * Read a persisted memory-injection block off a message's metadata JSON, or
+ * `null` when absent/malformed. `key` selects the injection layer: v2's
+ * `memoryInjectedBlock` or memory-v3's card block
+ * (`MEMORY_V3_INJECTED_BLOCK_METADATA_KEY`). The block is what the request
+ * builder re-attaches as the message's `<memory>` content each turn.
  */
-function readMemoryInjectedBlock(metadata: string | null): string | null {
+function readInjectedBlock(
+  metadata: string | null,
+  key: string,
+): string | null {
   if (!metadata) return null;
   try {
     const parsed: unknown = JSON.parse(metadata);
     if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-      const block = (parsed as Record<string, unknown>).memoryInjectedBlock;
+      const block = (parsed as Record<string, unknown>)[key];
       if (typeof block === "string") return block;
     }
   } catch {
@@ -1056,6 +1066,7 @@ export function forkConversation(params: {
     const isFullHistoryFork = copyBoundaryIndex === sourceMessages.length - 1;
     if (isFullHistoryFork) {
       forkActivationState(db, sourceConversation.id, fc.id);
+      forkEverInjected(db, sourceConversation.id, fc.id);
       forkGraphMemoryState(sourceConversation.id, fc.id);
     } else {
       // Truncated fork: the wholesale copy above would over-claim, but
@@ -1065,18 +1076,36 @@ export function forkConversation(params: {
       // `everInjected` from the inherited attachments themselves — scoped to
       // the child's visible window, since attachments behind an inherited
       // compaction boundary are not rendered and must stay re-injectable.
+      // The v2 and v3 layers persist under separate metadata keys with the
+      // same `# memory/concepts/<slug>.md` header convention, so each seeds
+      // its own dedup record from its own blocks.
       const visibleStartIndex = preserveSourceCompactionState
         ? visibleWindowStartIndex
         : 0;
       const inheritedSlugs = new Set<string>();
+      const inheritedV3Slugs = new Set<string>();
       for (const message of messagesToCopy.slice(visibleStartIndex)) {
-        const block = readMemoryInjectedBlock(message.metadata);
-        if (!block) continue;
-        for (const slug of extractInjectedConceptSlugs(block)) {
-          inheritedSlugs.add(slug);
+        const block = readInjectedBlock(
+          message.metadata,
+          "memoryInjectedBlock",
+        );
+        if (block) {
+          for (const slug of extractInjectedConceptSlugs(block)) {
+            inheritedSlugs.add(slug);
+          }
+        }
+        const v3Block = readInjectedBlock(
+          message.metadata,
+          MEMORY_V3_INJECTED_BLOCK_METADATA_KEY,
+        );
+        if (v3Block) {
+          for (const slug of extractInjectedConceptSlugs(v3Block)) {
+            inheritedV3Slugs.add(slug);
+          }
         }
       }
       seedForkActivationState(db, fc.id, [...inheritedSlugs]);
+      seedEverInjectedFromSlugs(db, fc.id, [...inheritedV3Slugs], Date.now());
     }
     forkRetrospectiveState({
       database: db,

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -46,6 +46,7 @@ import {
   migrateActivationState,
   migrateActivationStateFkCascade,
   migrateAddConversationInferenceProfile,
+  migrateAddMemoryV3EverInjected,
   migrateAddMemoryV3Selections,
   migrateAddSourceTypeColumns,
   migrateAssistantContactMetadata,
@@ -484,6 +485,7 @@ export function initializeDb(): void {
     migrateAcpSessionHistoryCwd,
     migrateOnboardingEventsFunnelColumns,
     createActivationSessionsTable,
+    migrateAddMemoryV3EverInjected,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/275-add-memory-v3-ever-injected.ts
+++ b/assistant/src/memory/migrations/275-add-memory-v3-ever-injected.ts
@@ -1,0 +1,29 @@
+import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+
+/**
+ * Adds `memory_v3_ever_injected` for memory-v3's frozen-card carry: one row
+ * per (conversation, page-slug) the v3 injector ever attached as a card.
+ * `bytes` is the rendered card size used for resident-footprint accounting;
+ * `pruned_at` marks rows the prune valve removed from the live context (rows
+ * are never deleted — the record stays auditable, and a pruned page that is
+ * re-selected re-injects by clearing `pruned_at`).
+ *
+ * Idempotent — re-running is a no-op once the table and index exist.
+ */
+export function migrateAddMemoryV3EverInjected(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  raw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS memory_v3_ever_injected (
+      conversation_id TEXT NOT NULL,
+      slug TEXT NOT NULL,
+      injected_at INTEGER NOT NULL,
+      bytes INTEGER NOT NULL DEFAULT 0,
+      pruned_at INTEGER,
+      PRIMARY KEY (conversation_id, slug)
+    )
+  `);
+  raw.exec(/*sql*/ `
+    CREATE INDEX IF NOT EXISTS idx_memory_v3_ever_injected_conv
+      ON memory_v3_ever_injected (conversation_id)
+  `);
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -262,6 +262,7 @@ export { createAuthFallbackEventsTable } from "./271-create-auth-fallback-events
 export { migrateAcpSessionHistoryCwd } from "./272-acp-session-history-cwd.js";
 export { migrateOnboardingEventsFunnelColumns } from "./273-onboarding-events-funnel-columns.js";
 export { createActivationSessionsTable } from "./274-create-activation-sessions.js";
+export { migrateAddMemoryV3EverInjected } from "./275-add-memory-v3-ever-injected.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/plugins/defaults/memory-v3-shadow/ever-injected-store.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/ever-injected-store.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Tests for `ever-injected-store.ts` — memory-v3's per-conversation
+ * everInjected record:
+ *   - record/get/active-set round-trip and re-record clearing `pruned_at`;
+ *   - `markPruned` excluding rows from the active set and `residentBytes`;
+ *   - `clearConversation` (compaction reset);
+ *   - fork hooks: full-row copy (pruned state included) and truncated-fork
+ *     seeding (`bytes = 0`, dedup-only);
+ *   - migration idempotence (run twice).
+ *
+ * `mock.module` is process-global and leaks into sibling files in a directory
+ * run, so the db-connection stub DELEGATES to the real implementation unless
+ * this test is actively running (`storeMockActive`, toggled in
+ * beforeEach/afterAll). Mirrors `__tests__/selection-log-store.test.ts`.
+ */
+
+import { Database } from "bun:sqlite";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import { migrateAddMemoryV3EverInjected } from "../../../memory/migrations/275-add-memory-v3-ever-injected.js";
+import * as schema from "../../../memory/schema.js";
+
+const realDb = { ...(await import("../../../memory/db-connection.js")) };
+
+let storeMockActive = false;
+
+let testSqlite: Database;
+let testDb = makeDb();
+function makeDb() {
+  testSqlite = new Database(":memory:");
+  const db = drizzle(testSqlite, { schema });
+  migrateAddMemoryV3EverInjected(db);
+  return db;
+}
+
+mock.module("../../../memory/db-connection.js", () => ({
+  ...realDb,
+  getDb: () => (storeMockActive ? testDb : realDb.getDb()),
+  getSqliteFrom: (db: unknown) =>
+    storeMockActive
+      ? testSqlite
+      : realDb.getSqliteFrom(db as Parameters<typeof realDb.getSqliteFrom>[0]),
+}));
+
+const {
+  clearConversation,
+  forkEverInjected,
+  getActiveSlugs,
+  getInjected,
+  markPruned,
+  MEMORY_V3_INJECTED_BLOCK_METADATA_KEY,
+  recordInjected,
+  residentBytes,
+  seedEverInjectedFromSlugs,
+} = await import("./ever-injected-store.js");
+
+beforeEach(() => {
+  storeMockActive = true;
+  testDb = makeDb();
+});
+
+afterAll(() => {
+  storeMockActive = false;
+});
+
+describe("metadata key constant", () => {
+  test("exports the v3 injected-block metadata key", () => {
+    expect(MEMORY_V3_INJECTED_BLOCK_METADATA_KEY).toBe("memoryV3InjectedBlock");
+  });
+});
+
+describe("recordInjected / getInjected / getActiveSlugs", () => {
+  test("round-trips the recorded entries", () => {
+    recordInjected(
+      "conv-1",
+      [
+        { slug: "topics/page-a", bytes: 100 },
+        { slug: "topics/page-b", bytes: 250 },
+      ],
+      1_000,
+    );
+
+    expect(getInjected("conv-1")).toEqual(
+      new Map([
+        ["topics/page-a", { bytes: 100, prunedAt: null }],
+        ["topics/page-b", { bytes: 250, prunedAt: null }],
+      ]),
+    );
+    expect(getActiveSlugs("conv-1")).toEqual(
+      new Set(["topics/page-a", "topics/page-b"]),
+    );
+    // Other conversations see nothing.
+    expect(getInjected("conv-other").size).toBe(0);
+    expect(getActiveSlugs("conv-other").size).toBe(0);
+  });
+
+  test("re-recording a pruned slug clears pruned_at and refreshes bytes", () => {
+    recordInjected("conv-1", [{ slug: "topics/page-a", bytes: 100 }], 1_000);
+    markPruned("conv-1", ["topics/page-a"], 2_000);
+    expect(getInjected("conv-1").get("topics/page-a")).toEqual({
+      bytes: 100,
+      prunedAt: 2_000,
+    });
+
+    recordInjected("conv-1", [{ slug: "topics/page-a", bytes: 140 }], 3_000);
+
+    expect(getInjected("conv-1").get("topics/page-a")).toEqual({
+      bytes: 140,
+      prunedAt: null,
+    });
+    expect(getActiveSlugs("conv-1")).toEqual(new Set(["topics/page-a"]));
+    const row = testSqlite
+      .query(
+        "SELECT injected_at FROM memory_v3_ever_injected WHERE conversation_id = ? AND slug = ?",
+      )
+      .get("conv-1", "topics/page-a") as { injected_at: number };
+    expect(row.injected_at).toBe(3_000);
+  });
+
+  test("empty entries are a no-op", () => {
+    recordInjected("conv-1", []);
+    expect(getInjected("conv-1").size).toBe(0);
+  });
+});
+
+describe("markPruned / residentBytes", () => {
+  test("pruned rows leave the active set and resident bytes but stay on record", () => {
+    recordInjected(
+      "conv-1",
+      [
+        { slug: "topics/page-a", bytes: 100 },
+        { slug: "topics/page-b", bytes: 250 },
+        { slug: "topics/page-c", bytes: 50 },
+      ],
+      1_000,
+    );
+    expect(residentBytes("conv-1")).toBe(400);
+
+    markPruned("conv-1", ["topics/page-a", "topics/page-c"], 2_000);
+
+    expect(getActiveSlugs("conv-1")).toEqual(new Set(["topics/page-b"]));
+    expect(residentBytes("conv-1")).toBe(250);
+    // Rows are never deleted — the record stays auditable.
+    expect([...getInjected("conv-1").keys()].sort()).toEqual([
+      "topics/page-a",
+      "topics/page-b",
+      "topics/page-c",
+    ]);
+  });
+
+  test("empty slug list is a no-op and residentBytes is 0 for unknown conversations", () => {
+    recordInjected("conv-1", [{ slug: "topics/page-a", bytes: 100 }], 1_000);
+    markPruned("conv-1", [], 2_000);
+    expect(residentBytes("conv-1")).toBe(100);
+    expect(residentBytes("conv-unknown")).toBe(0);
+  });
+});
+
+describe("clearConversation", () => {
+  test("deletes all rows for the conversation only", () => {
+    recordInjected("conv-1", [{ slug: "topics/page-a", bytes: 100 }], 1_000);
+    recordInjected("conv-2", [{ slug: "topics/page-b", bytes: 200 }], 1_000);
+
+    clearConversation("conv-1");
+
+    expect(getInjected("conv-1").size).toBe(0);
+    expect(getInjected("conv-2").size).toBe(1);
+  });
+});
+
+describe("forkEverInjected", () => {
+  test("copies the parent's full record, pruned state included", () => {
+    recordInjected(
+      "conv-parent",
+      [
+        { slug: "topics/page-a", bytes: 100 },
+        { slug: "topics/page-b", bytes: 250 },
+      ],
+      1_000,
+    );
+    markPruned("conv-parent", ["topics/page-b"], 2_000);
+
+    forkEverInjected(testDb, "conv-parent", "conv-child");
+
+    expect(getInjected("conv-child")).toEqual(
+      new Map([
+        ["topics/page-a", { bytes: 100, prunedAt: null }],
+        ["topics/page-b", { bytes: 250, prunedAt: 2_000 }],
+      ]),
+    );
+    expect(residentBytes("conv-child")).toBe(100);
+    // Parent record is untouched.
+    expect(getInjected("conv-parent").size).toBe(2);
+  });
+
+  test("is a no-op when the parent has no rows", () => {
+    forkEverInjected(testDb, "conv-empty", "conv-child");
+    expect(getInjected("conv-child").size).toBe(0);
+  });
+});
+
+describe("seedEverInjectedFromSlugs", () => {
+  test("seeds dedup-only rows with bytes = 0 stamped at the given time", () => {
+    seedEverInjectedFromSlugs(
+      testDb,
+      "conv-child",
+      ["topics/page-a", "topics/page-b"],
+      5_000,
+    );
+
+    expect(getInjected("conv-child")).toEqual(
+      new Map([
+        ["topics/page-a", { bytes: 0, prunedAt: null }],
+        ["topics/page-b", { bytes: 0, prunedAt: null }],
+      ]),
+    );
+    expect(getActiveSlugs("conv-child")).toEqual(
+      new Set(["topics/page-a", "topics/page-b"]),
+    );
+    // Inherited cards carry no byte accounting — resident accounting
+    // restarts from the fork's own injections.
+    expect(residentBytes("conv-child")).toBe(0);
+    const row = testSqlite
+      .query(
+        "SELECT injected_at FROM memory_v3_ever_injected WHERE conversation_id = ? AND slug = ?",
+      )
+      .get("conv-child", "topics/page-a") as { injected_at: number };
+    expect(row.injected_at).toBe(5_000);
+  });
+
+  test("is a no-op for an empty slug list and never overwrites existing rows", () => {
+    seedEverInjectedFromSlugs(testDb, "conv-child", [], 5_000);
+    expect(getInjected("conv-child").size).toBe(0);
+
+    recordInjected(
+      "conv-child",
+      [{ slug: "topics/page-a", bytes: 100 }],
+      1_000,
+    );
+    seedEverInjectedFromSlugs(testDb, "conv-child", ["topics/page-a"], 5_000);
+    expect(getInjected("conv-child").get("topics/page-a")).toEqual({
+      bytes: 100,
+      prunedAt: null,
+    });
+  });
+});
+
+describe("migration", () => {
+  test("is idempotent — running twice leaves a usable table", () => {
+    // makeDb() already ran the migration once; run it again.
+    migrateAddMemoryV3EverInjected(testDb);
+
+    recordInjected("conv-1", [{ slug: "topics/page-a", bytes: 100 }], 1_000);
+    expect(getActiveSlugs("conv-1")).toEqual(new Set(["topics/page-a"]));
+  });
+});

--- a/assistant/src/plugins/defaults/memory-v3-shadow/ever-injected-store.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/ever-injected-store.ts
@@ -1,0 +1,208 @@
+/**
+ * Per-conversation everInjected record for memory-v3's frozen-card carry.
+ *
+ * Backed by `memory_v3_ever_injected` (migration 275): one row per
+ * (conversation, page-slug) the v3 injector ever attached as a card. The
+ * active (non-pruned) slug set is the injection dedup record — a slug present
+ * here rides the cached message prefix and must not be re-rendered — and
+ * `bytes` sums into the resident footprint the prune valve bounds. Rows are
+ * never deleted by pruning (`pruned_at` is set instead) so the record stays
+ * auditable; a pruned page that is re-selected re-injects by clearing
+ * `pruned_at` on upsert. `clearConversation` is the compaction reset: the
+ * cached blocks those slugs lived on are gone, so future turns are free to
+ * re-inject them.
+ *
+ * Fork semantics mirror v2's activation-store hooks (both run synchronously
+ * inside the `forkConversation()` transaction — see
+ * `assistant/src/memory/conversation-crud.ts`):
+ *   - full-history forks copy the parent's rows wholesale
+ *     (`forkEverInjected`), pruned state included;
+ *   - truncated forks seed from the slugs scanned out of the inherited
+ *     messages' persisted card blocks (`seedEverInjectedFromSlugs`) — a
+ *     wholesale copy would over-claim slugs injected on turns the child does
+ *     not contain, suppressing their re-injection forever.
+ */
+
+import {
+  type DrizzleDb,
+  getDb,
+  getSqliteFrom,
+} from "../../../memory/db-connection.js";
+
+/**
+ * Message-metadata key the v3 injector persists each turn's card block under
+ * (the v3 counterpart of v2's `memoryInjectedBlock`). Shared by the writer,
+ * the conversation-load rehydration splice, and the truncated-fork seed scan
+ * in `conversation-crud.ts` so all three agree on the key.
+ */
+export const MEMORY_V3_INJECTED_BLOCK_METADATA_KEY = "memoryV3InjectedBlock";
+
+export interface EverInjectedEntry {
+  bytes: number;
+  /** Epoch ms the prune valve removed the card, or `null` while resident. */
+  prunedAt: number | null;
+}
+
+/** The full per-conversation record, pruned rows included. */
+export function getInjected(
+  conversationId: string,
+): Map<string, EverInjectedEntry> {
+  const rows = getSqliteFrom(getDb())
+    .query(
+      /*sql*/ `
+      SELECT slug, bytes, pruned_at AS prunedAt FROM memory_v3_ever_injected
+      WHERE conversation_id = ?
+    `,
+    )
+    .all(conversationId) as Array<{
+    slug: string;
+    bytes: number;
+    prunedAt: number | null;
+  }>;
+
+  return new Map(
+    rows.map((row) => [row.slug, { bytes: row.bytes, prunedAt: row.prunedAt }]),
+  );
+}
+
+/** The injection dedup set: slugs whose cards are currently resident. */
+export function getActiveSlugs(conversationId: string): Set<string> {
+  const rows = getSqliteFrom(getDb())
+    .query(
+      /*sql*/ `
+      SELECT slug FROM memory_v3_ever_injected
+      WHERE conversation_id = ? AND pruned_at IS NULL
+    `,
+    )
+    .all(conversationId) as Array<{ slug: string }>;
+  return new Set(rows.map((row) => row.slug));
+}
+
+/**
+ * Upsert this turn's injected cards. Re-recording an existing slug clears
+ * `pruned_at` and refreshes `bytes`/`injected_at` — a pruned page that is
+ * re-selected re-injects as a fresh card.
+ */
+export function recordInjected(
+  conversationId: string,
+  entries: Array<{ slug: string; bytes: number }>,
+  at: number = Date.now(),
+): void {
+  if (entries.length === 0) return;
+  const stmt = getSqliteFrom(getDb()).query(/*sql*/ `
+    INSERT INTO memory_v3_ever_injected (conversation_id, slug, injected_at, bytes, pruned_at)
+    VALUES (?, ?, ?, ?, NULL)
+    ON CONFLICT (conversation_id, slug) DO UPDATE SET
+      injected_at = excluded.injected_at,
+      bytes = excluded.bytes,
+      pruned_at = NULL
+  `);
+  for (const entry of entries) {
+    stmt.run(conversationId, entry.slug, at, entry.bytes);
+  }
+}
+
+/**
+ * Mark cards pruned from the live context. Rows are never deleted — the
+ * record stays auditable and the slugs stay eligible for re-injection.
+ */
+export function markPruned(
+  conversationId: string,
+  slugs: string[],
+  at: number,
+): void {
+  if (slugs.length === 0) return;
+  const placeholders = slugs.map(() => "?").join(", ");
+  getSqliteFrom(getDb())
+    .query(
+      /*sql*/ `
+      UPDATE memory_v3_ever_injected SET pruned_at = ?
+      WHERE conversation_id = ? AND slug IN (${placeholders})
+    `,
+    )
+    .run(at, conversationId, ...slugs);
+}
+
+/**
+ * Delete the conversation's entire record. Compaction reset: the cached
+ * blocks are gone from history, so every slug must become re-injectable.
+ */
+export function clearConversation(conversationId: string): void {
+  getSqliteFrom(getDb())
+    .query(
+      /*sql*/ `
+      DELETE FROM memory_v3_ever_injected WHERE conversation_id = ?
+    `,
+    )
+    .run(conversationId);
+}
+
+/** Total bytes of resident (non-pruned) cards — the prune-valve input. */
+export function residentBytes(conversationId: string): number {
+  const row = getSqliteFrom(getDb())
+    .query(
+      /*sql*/ `
+      SELECT COALESCE(SUM(bytes), 0) AS total FROM memory_v3_ever_injected
+      WHERE conversation_id = ? AND pruned_at IS NULL
+    `,
+    )
+    .get(conversationId) as { total: number };
+  return row.total;
+}
+
+/**
+ * Copy the parent conversation's rows to a new conversation id, pruned state
+ * included. No-op if the parent has no rows. Mirrors `forkActivationState`:
+ * synchronous so it can run inside the bun:sqlite transaction that wraps
+ * `forkConversation()`, keeping the copy atomic with the message copies.
+ * Full-history forks only — truncated forks must use
+ * `seedEverInjectedFromSlugs` instead.
+ */
+export function forkEverInjected(
+  db: DrizzleDb,
+  parentConversationId: string,
+  newConversationId: string,
+): void {
+  getSqliteFrom(db)
+    .query(
+      /*sql*/ `
+      INSERT INTO memory_v3_ever_injected (conversation_id, slug, injected_at, bytes, pruned_at)
+      SELECT ?, slug, injected_at, bytes, pruned_at FROM memory_v3_ever_injected
+      WHERE conversation_id = ?
+      ON CONFLICT (conversation_id, slug) DO UPDATE SET
+        injected_at = excluded.injected_at,
+        bytes = excluded.bytes,
+        pruned_at = excluded.pruned_at
+    `,
+    )
+    .run(newConversationId, parentConversationId);
+}
+
+/**
+ * Seed a truncated fork's record from the slugs whose card blocks the child
+ * actually inherited (scanned out of the copied messages'
+ * `MEMORY_V3_INJECTED_BLOCK_METADATA_KEY` metadata). Mirrors
+ * `seedForkActivationState`: a wholesale copy would over-claim, while seeding
+ * nothing would re-attach every inherited card as a duplicate.
+ *
+ * Rows are stamped `injected_at = at` and `bytes = 0` — the rendered size of
+ * inherited cards is unknown, so `residentBytes` accounting restarts from the
+ * fork's own injections. No-op when the child inherited no card blocks.
+ * Synchronous so it can run inside the `forkConversation()` transaction.
+ */
+export function seedEverInjectedFromSlugs(
+  db: DrizzleDb,
+  newConversationId: string,
+  slugs: string[],
+  at: number,
+): void {
+  if (slugs.length === 0) return;
+  const stmt = getSqliteFrom(db).query(/*sql*/ `
+    INSERT INTO memory_v3_ever_injected (conversation_id, slug, injected_at, bytes, pruned_at)
+    VALUES (?, ?, ?, 0, NULL)
+    ON CONFLICT (conversation_id, slug) DO NOTHING
+  `);
+  for (const slug of slugs) {
+    stmt.run(newConversationId, slug, at);
+  }
+}


### PR DESCRIPTION
## Summary
- Adds memory_v3_ever_injected table (slug-grain dedup + bytes/pruned accounting) with append-only idempotent migration
- Store API: recordInjected / getActiveSlugs / markPruned / clearConversation / residentBytes
- Fork inheritance mirrors v2's two hooks inside the forkConversation transaction (full copy + truncated-fork seed from inherited metadata blocks)

Part of plan: memory-v3-cache-aware-carry.md (PR 4 of 11)