### PR TITLE
fix: drop restating coverage block and dead testid in auto-top-up modal test

### DIFF
--- a/apps/web/src/domains/settings/components/auto-top-up-payment-method-modal.test.tsx
+++ b/apps/web/src/domains/settings/components/auto-top-up-payment-method-modal.test.tsx
@@ -6,15 +6,6 @@
  * (real Stripe Elements need a live iframe) and mock the generated SDK's
  * SetupIntent create so the modal mounts the form synchronously without
  * network.
- *
- * Coverage:
- *  - a billing-mode AddressElement renders alongside the PaymentElement,
- *    with the PaymentElement's own name and address fields suppressed,
- *  - the Save button stays disabled until BOTH elements report `onReady`,
- *  - an element load failure surfaces an error instead of leaving Save
- *    silently disabled,
- *  - submitting calls `stripe.confirmSetup` with `elements` and
- *    `redirect: "if_required"`.
  */
 
 import {
@@ -56,7 +47,7 @@ mock.module("@stripe/react-stripe-js", () => ({
   Elements: ({ children }: { children: ReactNode }) => children,
   PaymentElement: (props: ElementProps) => {
     paymentElementProps = props;
-    return <div data-testid="stripe-payment-element" />;
+    return <div />;
   },
   AddressElement: (props: ElementProps) => {
     addressElementProps = props;


### PR DESCRIPTION
## Summary
Fixes round-3 review gaps for auto-topup-billing-address.md.

- Delete the header Coverage block that restated the four test names verbatim
- Drop the never-queried stripe-payment-element testid from the PaymentElement mock