### PR TITLE
feat(memory-v3): consolidation-time core-set validation and curation guidance

### DIFF
--- a/assistant/src/memory/v2/prompts/consolidation.ts
+++ b/assistant/src/memory/v2/prompts/consolidation.ts
@@ -384,6 +384,16 @@ Scan namespace sizes. If any namespace has crossed ~12-15 articles with visible 
 - Rewrite to contain ONLY entries with timestamp ≥ \`${CUTOFF_PLACEHOLDER}\`.
 - Smart removal — never wholesale-clear.
 
+## 10. Review \`memory/core-pages.md\` — the curated core set
+
+\`memory/core-pages.md\` lists the pages retrieval keeps in reach EVERY turn, regardless of topic. It exists for one class of page: associative texture — registers, identity frames, calibration rules — pages with no lexical or semantic match to the message that neither search nor usage frequency can surface on their own. You are the only editor of this file; review it each pass.
+
+- **Format:** one page per list line — \`- [[slug]]\` or \`- slug\`. Headings, prose, and annotations are ignored, so annotate freely.
+- **Keep it small** — on the order of a few dozen entries (~30–50). Every entry costs context budget every single turn.
+- **Add** a page only when its content should always be in reach with no topical cue. If a search query would find it, it doesn't belong here.
+- **Remove** entries made redundant by frequent use — recently-used pages stay warm automatically (the hot set), so a page that comes up all the time doesn't need a core slot.
+- **Fix** entries whose page you renamed or deleted this pass (maintenance reports dangling entries, but never edits the file).
+
 ---
 
 # What NOT to do

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/maintain-job.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/maintain-job.test.ts
@@ -84,6 +84,9 @@ describe("maintainJob", () => {
       // dedicated prune tests below override both collaborators.
       listSectionArticles: async () => [],
       listIndexedSlugs: async () => [],
+      // Core-validation stage off by default: empty core set ⇒ nothing to
+      // check. The dedicated core tests below override this.
+      loadCoreSet: () => [],
       invalidateLanes: () => {
         calls.invalidate += 1;
       },
@@ -269,6 +272,68 @@ describe("maintainJob", () => {
     // were still invalidated.
     expect(outcome.failures).not.toContain("prune");
     expect(calls.invalidate).toBe(1);
+  });
+
+  test("reports dangling core entries without mutating anything", async () => {
+    setOverridesForTesting({ [FLAG_SHADOW]: true });
+    // The core file lists a live page, a renamed/deleted page, and a synthetic
+    // capability slug; only the missing page is reported. The stage is
+    // report-only: no deletes, no upserts, and the maintainer-owned file is
+    // untouched (the injected loader is read-only by construction).
+    const { deps: d, calls } = deps({
+      loadCoreSet: () => ["page-live", "page-gone", "skills/example"],
+      listIndexedSlugs: async () => ["page-live", "skills/example"],
+    });
+    const outcome = await maintainJob(JOB, CONFIG, d);
+
+    expect(outcome.danglingCoreSlugs).toEqual(["page-gone"]);
+    expect(outcome.failures).toEqual([]);
+    // Report-only: the dangling entry triggered no dense-store mutation.
+    expect(calls.deleted).toEqual([]);
+    expect(calls.upserted).toEqual([]);
+    // The pass still invalidates the lanes.
+    expect(calls.invalidate).toBe(1);
+  });
+
+  test("reports nothing when every core entry is still in the index", async () => {
+    setOverridesForTesting({ [FLAG_SHADOW]: true });
+    const { deps: d } = deps({
+      loadCoreSet: () => ["page-a", "page-b"],
+      listIndexedSlugs: async () => ["page-a", "page-b", "page-c"],
+    });
+    const outcome = await maintainJob(JOB, CONFIG, d);
+    expect(outcome.danglingCoreSlugs).toEqual([]);
+  });
+
+  test("an empty core set skips validation entirely", async () => {
+    setOverridesForTesting({ [FLAG_SHADOW]: true });
+    let indexReads = 0;
+    const { deps: d } = deps({
+      loadCoreSet: () => [],
+      listIndexedSlugs: async () => {
+        indexReads += 1;
+        return [];
+      },
+    });
+    const outcome = await maintainJob(JOB, CONFIG, d);
+    expect(outcome.danglingCoreSlugs).toEqual([]);
+    // The prune stage reads the index once; the core stage adds no second read.
+    expect(indexReads).toBe(1);
+  });
+
+  test("a thrown core-validation stage is contained and does not abort lane invalidation", async () => {
+    setOverridesForTesting({ [FLAG_SHADOW]: true });
+    const { deps: d, calls } = deps({
+      loadCoreSet: () => {
+        throw new Error("core boom");
+      },
+    });
+    const outcome = await maintainJob(JOB, CONFIG, d);
+
+    expect(outcome.failures).toContain("core-validate");
+    expect(outcome.danglingCoreSlugs).toEqual([]);
+    expect(calls.invalidate).toBe(1);
+    expect(outcome.invalidated).toBe(true);
   });
 
   test("a thrown prune stage is contained and does not abort lane invalidation", async () => {

--- a/assistant/src/plugins/defaults/memory-v3-shadow/maintain-job.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/maintain-job.ts
@@ -2,7 +2,7 @@
  * Memory v3 — `memory_v3_maintain` job handler.
  *
  * A flag-gated, best-effort self-maintenance pass over the v3 section dense
- * store and the in-memory lanes. It runs three independent stages, in order:
+ * store and the in-memory lanes. It runs four independent stages, in order:
  *
  *   1. **Section re-embed** — diff the page index by `modifiedAt` against the
  *      last successful pass (the high-water mark below), and for every page that
@@ -22,7 +22,12 @@
  *      (it only names live pages), so without this its section points would
  *      linger in Qdrant and the dense lane could still surface the deleted page.
  *      Synthetic capability rows are in the page index, so they are never pruned.
- *   3. **Lane invalidation** — `invalidateLanes()` so the next turn rebuilds the
+ *   3. **Core-set validation** — load the maintainer-curated core set
+ *      (`memory/core-pages.md`) and report entries whose page no longer exists
+ *      in the page index (dangling slugs) via the log + outcome. The file is
+ *      maintainer-owned, so this stage NEVER edits it — the maintainer fixes
+ *      dangling entries at the next consolidation pass.
+ *   4. **Lane invalidation** — `invalidateLanes()` so the next turn rebuilds the
  *      in-memory section index, needle, and edge graph from the freshly-updated
  *      pages.
  *
@@ -35,8 +40,8 @@
  *
  * Dependency-injectable: `deps` lets tests substitute the page-index reader,
  * section builder, dense-store ops (including the prune-stage
- * `listSectionArticles`/`listIndexedSlugs` collaborators), and `invalidateLanes`
- * without process-global module mocks.
+ * `listSectionArticles`/`listIndexedSlugs` collaborators), the core-set loader,
+ * and `invalidateLanes` without process-global module mocks.
  */
 
 import { isAssistantFeatureFlagEnabled } from "../../../config/assistant-feature-flags.js";
@@ -51,6 +56,7 @@ import { readPage } from "../../../memory/v2/page-store.js";
 import { getLogger } from "../../../util/logger.js";
 import { getWorkspaceDir } from "../../../util/platform.js";
 import { capabilityOrDiskBody } from "./capabilities.js";
+import { loadCoreSet as realLoadCoreSet } from "./core-set.js";
 import {
   deleteSectionsForArticle as realDeleteSectionsForArticle,
   ensureSectionCollection as realEnsureSectionCollection,
@@ -126,6 +132,12 @@ export interface MaintainJobDeps {
    * from this set. Includes synthetic capability rows so they are never pruned.
    */
   listIndexedSlugs: () => Promise<Slug[]>;
+  /**
+   * The maintainer-curated core set from `memory/core-pages.md`. The validation
+   * stage diffs it against the live page-index slugs and REPORTS dangling
+   * entries only — the file is maintainer-owned and is never edited here.
+   */
+  loadCoreSet: () => Slug[];
   /** Drop the memoized v3 lanes so the next turn rebuilds them. */
   invalidateLanes: () => void;
   /** Active assistant config (for the dense-store/embedding calls). */
@@ -188,6 +200,12 @@ export interface MaintainOutcome {
   pruned: number;
   /** Prune deletes that threw (and were contained). */
   pruneFailures: number;
+  /**
+   * Core-set entries (`memory/core-pages.md`) whose page no longer exists in
+   * the page index. Reported for the maintainer to fix at the next
+   * consolidation pass — the file itself is never mutated.
+   */
+  danglingCoreSlugs: Slug[];
   /** Whether the in-memory lanes were invalidated. */
   invalidated: boolean;
   /** Stages that threw (and were contained). */
@@ -284,6 +302,7 @@ function defaultDeps(config: AssistantConfig): MaintainJobDeps {
     commitEmbedHighWater,
     listSectionArticles: () => realListSectionArticles(config),
     listIndexedSlugs: () => selectAllPagesFromWorkspace(workspaceDir),
+    loadCoreSet: () => realLoadCoreSet(workspaceDir),
     invalidateLanes: realInvalidateLanes,
     config,
   };
@@ -463,6 +482,7 @@ export async function maintainJob(
     reembedFailures: 0,
     pruned: 0,
     pruneFailures: 0,
+    danglingCoreSlugs: [],
     invalidated: false,
     failures: [],
   };
@@ -527,7 +547,35 @@ export async function maintainJob(
     );
   }
 
-  // Stage 3: rebuild section index + needle + edge graph on the next turn.
+  // Stage 3: validate the maintainer-curated core set. Diff `core-pages.md`
+  // entries against the live page-index slugs and REPORT dangling entries
+  // (pages that were renamed or deleted) through the log + outcome — the file
+  // is maintainer-owned, so it is never auto-edited; the maintainer fixes it at
+  // the next consolidation pass. No hot/core recompute is needed in this job:
+  // the lanes (including the core and hot prefixes) are computed at lane init,
+  // and the invalidateLanes() stage below already forces a next-turn rebuild —
+  // that rebuild IS the consolidation-cadence refresh.
+  try {
+    const coreSlugs = deps.loadCoreSet();
+    if (coreSlugs.length > 0) {
+      const live = new Set(await deps.listIndexedSlugs());
+      outcome.danglingCoreSlugs = coreSlugs.filter((slug) => !live.has(slug));
+      if (outcome.danglingCoreSlugs.length > 0) {
+        log.warn(
+          { dangling: outcome.danglingCoreSlugs },
+          "memory-v3 maintain: core-pages.md lists pages missing from the index — review the file at the next consolidation",
+        );
+      }
+    }
+  } catch (err) {
+    outcome.failures.push("core-validate");
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "memory-v3 maintain: core-set validation failed (non-fatal)",
+    );
+  }
+
+  // Stage 4: rebuild section index + needle + edge graph on the next turn.
   try {
     deps.invalidateLanes();
     outcome.invalidated = true;
@@ -545,6 +593,7 @@ export async function maintainJob(
       reembedFailures: outcome.reembedFailures,
       pruned: outcome.pruned,
       pruneFailures: outcome.pruneFailures,
+      danglingCoreSlugs: outcome.danglingCoreSlugs,
       invalidated: outcome.invalidated,
       failures: outcome.failures,
     },


### PR DESCRIPTION
## Summary
- memory_v3_maintain gains a core-set validation stage: reports dangling core-pages entries without mutating the maintainer-owned file
- Repo-default consolidation prompt now documents core-pages curation (keep ~30-50 always-relevant pages; the associative-texture class finders/frecency can't surface)

Operator follow-up: workspaces with customized consolidation prompts should receive this section as a reviewed copy (dual-update rule) — not a live edit.

Part of plan: memory-v3-cache-aware-carry.md (PR 8 of 11)