### PR TITLE
Remove unreferenced provider-zai feature flag from registry

### DIFF
--- a/apps/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/apps/web/src/lib/feature-flags/feature-flag-registry.json
@@ -284,14 +284,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "provider-zai",
-      "scope": "assistant",
-      "key": "provider-zai",
-      "label": "z.ai Provider",
-      "description": "Enable the z.ai (Zhipu AI) provider and its GLM models in the provider picker and model selection UI",
-      "defaultEnabled": false
-    },
-    {
       "id": "velvet-theme",
       "scope": "client",
       "key": "velvet-theme",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -284,14 +284,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "provider-zai",
-      "scope": "assistant",
-      "key": "provider-zai",
-      "label": "z.ai Provider",
-      "description": "Enable the z.ai (Zhipu AI) provider and its GLM models in the provider picker and model selection UI",
-      "defaultEnabled": false
-    },
-    {
       "id": "velvet-theme",
       "scope": "client",
       "key": "velvet-theme",


### PR DESCRIPTION
## Summary
- Remove the `provider-zai` feature flag entry from both `meta/feature-flags/feature-flag-registry.json` and `apps/web/src/lib/feature-flags/feature-flag-registry.json`
- This flag has zero source code references anywhere in the repo — no gating code, no web selectors, no catalog mapping — and is off in LD production

## Original prompt
During a feature flag audit, we identified 7 registry entries with no source code references. Six of them turned out to have dynamically-generated web Zustand store selectors that would break at render time if removed. `provider-zai` is the only one with truly no references anywhere, so it's safe to remove from the registry alone.