### PR TITLE
refactor(web): convert navigation resolver route guard to pipeline

### DIFF
--- a/apps/web/src/lib/navigation/navigation-resolver.ts
+++ b/apps/web/src/lib/navigation/navigation-resolver.ts
@@ -43,8 +43,12 @@ export type NavigationDecision =
   | { action: "wait" };
 
 // ---------------------------------------------------------------------------
-// Helpers
+// Shared predicates & helpers
 // ---------------------------------------------------------------------------
+
+function hasCompletedOnboarding(state: NavigationState): boolean {
+  return state.tosAccepted && state.aiDataConsent;
+}
 
 const ONBOARDING_PREFIX = `${routes.assistant}/onboarding`;
 
@@ -57,7 +61,6 @@ const LOCAL_ONLY_STANDALONE_PATHS: Set<string> = new Set([
   routes.welcome,
   routes.selectAssistant,
 ]);
-
 
 function isOnboardingPath(pathname: string): boolean {
   return pathname.startsWith(`${ONBOARDING_PREFIX}/`) || pathname === ONBOARDING_PREFIX;
@@ -124,47 +127,88 @@ export function resolveNavigation(
 }
 
 // ---------------------------------------------------------------------------
-// route-guard
+// Route guard — pipeline of steps
 // ---------------------------------------------------------------------------
+//
+// Each step returns a NavigationDecision to short-circuit, or null to
+// pass through to the next step. The pipeline terminates with "allow".
+//
+// Conceptual layers:
+//   1. Readiness          — is the session ready?
+//   2. Bypass             — gateway auth skips everything
+//   3. Identity           — is the user authenticated?
+//   4. Mode boundary      — is this path valid for the user's mode?
+//   5. Setup exemptions   — onboarding/consent paths are always reachable
+//   6. Assistant required  — user needs at least one assistant
+//   7. Consent required   — platform users must accept TOS
+
+type RouteGuardStep = (
+  state: NavigationState,
+  path: string,
+  pathnameWithSearch: string,
+) => NavigationDecision | null;
+
+const ROUTE_GUARD_PIPELINE: RouteGuardStep[] = [
+  waitForSession,
+  allowGatewayAuth,
+  requireAuth,
+  enforceModeBoundary,
+  allowSetupRoutes,
+  requireAssistant,
+  requireConsent,
+];
 
 function resolveRouteGuard(
   state: NavigationState,
   pathnameWithSearch: string,
 ): NavigationDecision {
-  // Split off the query string so path-matching uses the bare path,
-  // but returnTo encoding preserves the full URL for post-login return.
   const qIdx = pathnameWithSearch.indexOf("?");
   const path = qIdx >= 0 ? pathnameWithSearch.slice(0, qIdx) : pathnameWithSearch;
 
-  // 1. Wait for session to settle
-  if (!state.sessionSettled) return { action: "wait" };
-
-  // 2. Gateway auth bypasses all guards
-  if (state.isGatewayAuth) return { action: "allow" };
-
-  // 3. Unauthenticated
-  if (!state.isAuthenticated) {
-    if (state.isLocalMode && (isOnboardingPath(path) || LOCAL_ONLY_STANDALONE_PATHS.has(path))) {
-      if (path === routes.selectAssistant && !state.hasAssistants) {
-        return { action: "redirect", to: routes.onboarding.hosting };
-      }
-      return { action: "allow" };
-    }
-    if (state.isLocalMode && !state.hasAssistants) {
-      return { action: "redirect", to: routes.welcome };
-    }
-    if (state.isLocalMode) {
-      return { action: "redirect", to: routes.selectAssistant };
-    }
-    return {
-      action: "redirect",
-      to: `${routes.account.login}?returnTo=${encodeURIComponent(pathnameWithSearch)}`,
-    };
+  for (const step of ROUTE_GUARD_PIPELINE) {
+    const decision = step(state, path, pathnameWithSearch);
+    if (decision) return decision;
   }
+  return { action: "allow" };
+}
 
-  // 4. Authenticated — special-purpose routes
+function waitForSession(state: NavigationState): NavigationDecision | null {
+  return state.sessionSettled ? null : { action: "wait" };
+}
 
-  // 4a. Local-only standalone paths (welcome, select-assistant)
+function allowGatewayAuth(state: NavigationState): NavigationDecision | null {
+  return state.isGatewayAuth ? { action: "allow" } : null;
+}
+
+function requireAuth(
+  state: NavigationState,
+  path: string,
+  pathnameWithSearch: string,
+): NavigationDecision | null {
+  if (state.isAuthenticated) return null;
+
+  if (state.isLocalMode && (isOnboardingPath(path) || LOCAL_ONLY_STANDALONE_PATHS.has(path))) {
+    if (path === routes.selectAssistant && !state.hasAssistants) {
+      return { action: "redirect", to: routes.onboarding.hosting };
+    }
+    return { action: "allow" };
+  }
+  if (state.isLocalMode && !state.hasAssistants) {
+    return { action: "redirect", to: routes.welcome };
+  }
+  if (state.isLocalMode) {
+    return { action: "redirect", to: routes.selectAssistant };
+  }
+  return {
+    action: "redirect",
+    to: `${routes.account.login}?returnTo=${encodeURIComponent(pathnameWithSearch)}`,
+  };
+}
+
+function enforceModeBoundary(
+  state: NavigationState,
+  path: string,
+): NavigationDecision | null {
   if (LOCAL_ONLY_STANDALONE_PATHS.has(path)) {
     if (!state.isLocalMode) {
       return { action: "redirect", to: routes.assistant };
@@ -175,24 +219,33 @@ function resolveRouteGuard(
     return { action: "allow" };
   }
 
-  // 4b. Review-terms (consent gate for existing users)
+  if (LOCAL_ONLY_ONBOARDING_PATHS.has(path) && !state.isLocalMode) {
+    return { action: "redirect", to: routes.assistant };
+  }
+
+  return null;
+}
+
+function allowSetupRoutes(
+  state: NavigationState,
+  path: string,
+): NavigationDecision | null {
   if (path === routes.reviewTerms) return { action: "allow" };
 
-  // 4c. Onboarding routes
   if (isOnboardingPath(path)) {
-    if (LOCAL_ONLY_ONBOARDING_PATHS.has(path) && !state.isLocalMode) {
-      return { action: "redirect", to: routes.assistant };
-    }
-    if (path === routes.onboarding.hatching && !(state.tosAccepted && state.aiDataConsent)) {
+    if (path === routes.onboarding.hatching && !hasCompletedOnboarding(state)) {
       return { action: "redirect", to: onboardingEntrypoint(state.isLocalMode) };
     }
     return { action: "allow" };
   }
 
-  // 5. Authenticated, no assistants — onboarding / hatching
+  return null;
+}
 
-  // 5a. Local mode: check platform session to choose entry point
-  if (state.isLocalMode && !state.hasAssistants) {
+function requireAssistant(state: NavigationState): NavigationDecision | null {
+  if (state.hasAssistants) return null;
+
+  if (state.isLocalMode) {
     if (state.platformSession === "unknown") return { action: "wait" };
     if (state.platformSession === "present") {
       return { action: "redirect", to: routes.onboarding.hosting };
@@ -200,24 +253,21 @@ function resolveRouteGuard(
     return { action: "redirect", to: routes.welcome };
   }
 
-  // 5b. Platform mode, onboarding not completed
-  if (!state.isLocalMode && !state.hasAssistants && !(state.tosAccepted && state.aiDataConsent)) {
+  if (!hasCompletedOnboarding(state)) {
     return { action: "redirect", to: routes.onboarding.privacy };
   }
+  return { action: "redirect", to: routes.onboarding.hatching };
+}
 
-  // 5c. Platform mode, onboarded — show hatching UX
-  if (!state.isLocalMode && !state.hasAssistants) {
-    return { action: "redirect", to: routes.onboarding.hatching };
-  }
+function requireConsent(
+  state: NavigationState,
+  _path: string,
+  pathnameWithSearch: string,
+): NavigationDecision | null {
+  if (state.isLocalMode || hasCompletedOnboarding(state)) return null;
 
-  // 6. Authenticated, has assistants, onboarding not completed
-  if (!state.isLocalMode && !(state.tosAccepted && state.aiDataConsent)) {
-    const returnTo = encodeURIComponent(pathnameWithSearch);
-    return { action: "redirect", to: `${routes.reviewTerms}?returnTo=${returnTo}` };
-  }
-
-  // 7. All clear
-  return { action: "allow" };
+  const returnTo = encodeURIComponent(pathnameWithSearch);
+  return { action: "redirect", to: `${routes.reviewTerms}?returnTo=${returnTo}` };
 }
 
 // ---------------------------------------------------------------------------
@@ -229,7 +279,7 @@ function resolveOnboardingIntercept(
   intendedDestination: string,
 ): NavigationDecision {
   if (state.isLocalMode && state.hasAssistants) return { action: "allow" };
-  if (state.tosAccepted && state.aiDataConsent) return { action: "allow" };
+  if (hasCompletedOnboarding(state)) return { action: "allow" };
 
   const path = extractPathname(intendedDestination);
   if (!path.startsWith(routes.assistant)) return { action: "allow" };
@@ -251,7 +301,7 @@ function resolveHatchGate(state: NavigationState): NavigationDecision {
   if (!state.isAuthenticated && !state.isLocalMode) {
     return { action: "redirect", to: routes.account.login };
   }
-  if (!(state.tosAccepted && state.aiDataConsent)) {
+  if (!hasCompletedOnboarding(state)) {
     return { action: "redirect", to: onboardingEntrypoint(state.isLocalMode) };
   }
   return { action: "allow" };
@@ -279,7 +329,6 @@ function resolvePostAuth(
 function resolvePostRetire(state: NavigationState): NavigationDecision {
   if (state.hasAssistants) {
     // select-assistant is local-only; platform users go straight to /assistant
-    // where the app picks up the next available assistant.
     return {
       action: "redirect",
       to: state.isLocalMode ? routes.selectAssistant : routes.assistant,
@@ -293,4 +342,3 @@ function resolvePostRetire(state: NavigationState): NavigationDecision {
   }
   return { action: "redirect", to: routes.welcome };
 }
-


### PR DESCRIPTION
## Summary

- Refactored `resolveRouteGuard` from a monolithic 90-line function with numbered comments into a pipeline of 7 focused steps: `waitForSession` → `allowGatewayAuth` → `requireAuth` → `enforceModeBoundary` → `allowSetupRoutes` → `requireAssistant` → `requireConsent`
- Each step returns a `NavigationDecision` to short-circuit or `null` to pass through — the pipeline terminates with "allow"
- Extracted `hasCompletedOnboarding(state)` predicate to replace the repeated `state.tosAccepted && state.aiDataConsent` pattern (used 5 times across the file)

## Original prompt

The navigation resolver file had grown unwieldy, with `resolveRouteGuard` being the main offender — a single function with 7 interleaved numbered steps mixing path-matching with state checks. The user asked to refactor it into a pipeline pattern, rethinking the conceptual layers from first principles rather than mechanically splitting the existing sequence. Each pipeline step now maps to a clear concern: readiness, auth bypass, identity, mode boundary, setup path exemptions, assistant availability, and consent.