### PR TITLE
fix: type tool-invocation seed deps via import type and drop test import aliases

### DIFF
--- a/assistant/src/__tests__/conversation-tool-setup-app-refresh.test.ts
+++ b/assistant/src/__tests__/conversation-tool-setup-app-refresh.test.ts
@@ -18,11 +18,11 @@ import type { SecretPrompter } from "../permissions/secret-prompter.js";
 import type { ToolExecutor } from "../tools/executor.js";
 import type { ToolExecutionResult } from "../tools/types.js";
 import {
-  broadcastMessageSpy as broadcastSpy,
+  broadcastMessageSpy,
   installConversationToolSetupMocks,
-  makeToolSetupContext as makeCtx,
-  refreshSurfacesForAppSpy as refreshSpy,
-  updatePublishedAppDeploymentSpy as updatePublishedSpy,
+  makeToolSetupContext,
+  refreshSurfacesForAppSpy,
+  updatePublishedAppDeploymentSpy,
 } from "./conversation-tool-setup-test-helpers.js";
 
 installConversationToolSetupMocks();
@@ -38,7 +38,9 @@ import { createToolExecutor } from "../daemon/conversation-tool-setup.js";
 // ---------------------------------------------------------------------------
 
 function broadcastPayloads(): unknown[] {
-  return (broadcastSpy.mock.calls as unknown[][]).map(([payload]) => payload);
+  return (broadcastMessageSpy.mock.calls as unknown[][]).map(
+    ([payload]) => payload,
+  );
 }
 
 function expectAppChangeBroadcast(appId: string): void {
@@ -74,16 +76,16 @@ const noopLifecycleHandler = mock(() => {});
 
 describe("session-tool-setup app refresh side effects", () => {
   beforeEach(() => {
-    refreshSpy.mockClear();
-    broadcastSpy.mockClear();
-    updatePublishedSpy.mockClear();
+    refreshSurfacesForAppSpy.mockClear();
+    broadcastMessageSpy.mockClear();
+    updatePublishedAppDeploymentSpy.mockClear();
   });
 
   // ── app_refresh ─────────────────────────────────────────────────────
 
   describe("app_refresh", () => {
     test("triggers refreshSurfacesForApp when result is not an error", async () => {
-      const ctx = makeCtx();
+      const ctx = makeToolSetupContext();
       const executor = makeFakeExecutor({
         content: '{"id":"app-1"}',
         isError: false,
@@ -99,13 +101,17 @@ describe("session-tool-setup app refresh side effects", () => {
 
       await toolFn("app_refresh", { app_id: "app-1" });
 
-      expect(refreshSpy).toHaveBeenCalledTimes(1);
-      expect((refreshSpy.mock.calls as unknown[][])[0][0]).toBe(ctx);
-      expect((refreshSpy.mock.calls as unknown[][])[0][1]).toBe("app-1");
+      expect(refreshSurfacesForAppSpy).toHaveBeenCalledTimes(1);
+      expect((refreshSurfacesForAppSpy.mock.calls as unknown[][])[0][0]).toBe(
+        ctx,
+      );
+      expect((refreshSurfacesForAppSpy.mock.calls as unknown[][])[0][1]).toBe(
+        "app-1",
+      );
     });
 
     test("broadcasts app_files_changed with correct appId", async () => {
-      const ctx = makeCtx();
+      const ctx = makeToolSetupContext();
       const executor = makeFakeExecutor({ content: "{}", isError: false });
 
       const toolFn = createToolExecutor(
@@ -118,12 +124,12 @@ describe("session-tool-setup app refresh side effects", () => {
 
       await toolFn("app_refresh", { app_id: "app-42" });
 
-      expect(broadcastSpy).toHaveBeenCalledTimes(2);
+      expect(broadcastMessageSpy).toHaveBeenCalledTimes(2);
       expectAppChangeBroadcast("app-42");
     });
 
     test("calls updatePublishedAppDeployment", async () => {
-      const ctx = makeCtx();
+      const ctx = makeToolSetupContext();
       const executor = makeFakeExecutor({ content: "{}", isError: false });
 
       const toolFn = createToolExecutor(
@@ -138,14 +144,14 @@ describe("session-tool-setup app refresh side effects", () => {
 
       // updatePublishedAppDeployment is called with void (fire-and-forget),
       // so just verify it was invoked.
-      expect(updatePublishedSpy).toHaveBeenCalledTimes(1);
-      expect((updatePublishedSpy.mock.calls as unknown[][])[0][0]).toBe(
-        "app-publish",
-      );
+      expect(updatePublishedAppDeploymentSpy).toHaveBeenCalledTimes(1);
+      expect(
+        (updatePublishedAppDeploymentSpy.mock.calls as unknown[][])[0][0],
+      ).toBe("app-publish");
     });
 
     test("skips side effects when result is an error", async () => {
-      const ctx = makeCtx();
+      const ctx = makeToolSetupContext();
       const executor = makeFakeExecutor({
         content: "Error: not found",
         isError: true,
@@ -161,13 +167,13 @@ describe("session-tool-setup app refresh side effects", () => {
 
       await toolFn("app_refresh", { app_id: "app-err" });
 
-      expect(refreshSpy).not.toHaveBeenCalled();
-      expect(broadcastSpy).not.toHaveBeenCalled();
-      expect(updatePublishedSpy).not.toHaveBeenCalled();
+      expect(refreshSurfacesForAppSpy).not.toHaveBeenCalled();
+      expect(broadcastMessageSpy).not.toHaveBeenCalled();
+      expect(updatePublishedAppDeploymentSpy).not.toHaveBeenCalled();
     });
 
     test("skips side effects when app_id is missing", async () => {
-      const ctx = makeCtx();
+      const ctx = makeToolSetupContext();
       const executor = makeFakeExecutor({ content: "{}", isError: false });
 
       const toolFn = createToolExecutor(
@@ -180,8 +186,8 @@ describe("session-tool-setup app refresh side effects", () => {
 
       await toolFn("app_refresh", {});
 
-      expect(refreshSpy).not.toHaveBeenCalled();
-      expect(broadcastSpy).not.toHaveBeenCalled();
+      expect(refreshSurfacesForAppSpy).not.toHaveBeenCalled();
+      expect(broadcastMessageSpy).not.toHaveBeenCalled();
     });
   });
 
@@ -189,7 +195,7 @@ describe("session-tool-setup app refresh side effects", () => {
 
   describe("app_update", () => {
     test("triggers refreshSurfacesForApp and broadcast on success", async () => {
-      const ctx = makeCtx();
+      const ctx = makeToolSetupContext();
       const executor = makeFakeExecutor({
         content: '{"updated":true,"appId":"app-7"}',
         isError: false,
@@ -205,17 +211,19 @@ describe("session-tool-setup app refresh side effects", () => {
 
       await toolFn("app_update", { app_id: "app-7" });
 
-      expect(refreshSpy).toHaveBeenCalledTimes(1);
-      expect((refreshSpy.mock.calls as unknown[][])[0][1]).toBe("app-7");
-      expectAppChangeBroadcast("app-7");
-      expect(updatePublishedSpy).toHaveBeenCalledTimes(1);
-      expect((updatePublishedSpy.mock.calls as unknown[][])[0][0]).toBe(
+      expect(refreshSurfacesForAppSpy).toHaveBeenCalledTimes(1);
+      expect((refreshSurfacesForAppSpy.mock.calls as unknown[][])[0][1]).toBe(
         "app-7",
       );
+      expectAppChangeBroadcast("app-7");
+      expect(updatePublishedAppDeploymentSpy).toHaveBeenCalledTimes(1);
+      expect(
+        (updatePublishedAppDeploymentSpy.mock.calls as unknown[][])[0][0],
+      ).toBe("app-7");
     });
 
     test("skips side effects when result is an error", async () => {
-      const ctx = makeCtx();
+      const ctx = makeToolSetupContext();
       const executor = makeFakeExecutor({
         content: "Error: not found",
         isError: true,
@@ -231,13 +239,13 @@ describe("session-tool-setup app refresh side effects", () => {
 
       await toolFn("app_update", { app_id: "app-err" });
 
-      expect(refreshSpy).not.toHaveBeenCalled();
-      expect(broadcastSpy).not.toHaveBeenCalled();
-      expect(updatePublishedSpy).not.toHaveBeenCalled();
+      expect(refreshSurfacesForAppSpy).not.toHaveBeenCalled();
+      expect(broadcastMessageSpy).not.toHaveBeenCalled();
+      expect(updatePublishedAppDeploymentSpy).not.toHaveBeenCalled();
     });
 
     test("skips side effects when app_id is missing", async () => {
-      const ctx = makeCtx();
+      const ctx = makeToolSetupContext();
       const executor = makeFakeExecutor({ content: "{}", isError: false });
 
       const toolFn = createToolExecutor(
@@ -250,8 +258,8 @@ describe("session-tool-setup app refresh side effects", () => {
 
       await toolFn("app_update", {});
 
-      expect(refreshSpy).not.toHaveBeenCalled();
-      expect(broadcastSpy).not.toHaveBeenCalled();
+      expect(refreshSurfacesForAppSpy).not.toHaveBeenCalled();
+      expect(broadcastMessageSpy).not.toHaveBeenCalled();
     });
   });
 
@@ -259,7 +267,7 @@ describe("session-tool-setup app refresh side effects", () => {
 
   describe("app_create side effects", () => {
     test("broadcasts app_files_changed immediately after app_create", async () => {
-      const ctx = makeCtx();
+      const ctx = makeToolSetupContext();
       const executor = makeFakeExecutor({
         content: JSON.stringify({ id: "new-app-1", name: "My App" }),
         isError: false,
@@ -275,8 +283,8 @@ describe("session-tool-setup app refresh side effects", () => {
 
       await toolFn("app_create", { name: "My App", html: "<h1>hi</h1>" });
 
-      expect(broadcastSpy.mock.calls.length).toBeGreaterThanOrEqual(1);
-      expect((broadcastSpy.mock.calls as unknown[][])[0][0]).toEqual({
+      expect(broadcastMessageSpy.mock.calls.length).toBeGreaterThanOrEqual(1);
+      expect((broadcastMessageSpy.mock.calls as unknown[][])[0][0]).toEqual({
         type: "app_files_changed",
         appId: "new-app-1",
       });
@@ -284,7 +292,9 @@ describe("session-tool-setup app refresh side effects", () => {
     });
 
     test("canonicalizes create_app skill_execute alias before hooks run", async () => {
-      const ctx = makeCtx({ allowedToolNames: new Set(["app_create"]) });
+      const ctx = makeToolSetupContext({
+        allowedToolNames: new Set(["app_create"]),
+      });
       const executor = makeFakeExecutor({
         content: JSON.stringify({ id: "alias-app-1", name: "Alias App" }),
         isError: false,
@@ -307,8 +317,8 @@ describe("session-tool-setup app refresh side effects", () => {
       const calls = executor.execute.mock.calls as unknown[][];
       expect(calls[0][0]).toBe("app_create");
       expect(calls[0][1]).toEqual({ name: "Alias App" });
-      expect(broadcastSpy.mock.calls.length).toBeGreaterThanOrEqual(1);
-      expect((broadcastSpy.mock.calls as unknown[][])[0][0]).toEqual({
+      expect(broadcastMessageSpy.mock.calls.length).toBeGreaterThanOrEqual(1);
+      expect((broadcastMessageSpy.mock.calls as unknown[][])[0][0]).toEqual({
         type: "app_files_changed",
         appId: "alias-app-1",
       });
@@ -316,7 +326,9 @@ describe("session-tool-setup app refresh side effects", () => {
     });
 
     test("canonicalizes legacy computer_use_press_key skill_execute alias before dispatch", async () => {
-      const ctx = makeCtx({ allowedToolNames: new Set(["computer_use_key"]) });
+      const ctx = makeToolSetupContext({
+        allowedToolNames: new Set(["computer_use_key"]),
+      });
       const executor = makeFakeExecutor({ content: "ok", isError: false });
 
       const toolFn = createToolExecutor(
@@ -346,7 +358,7 @@ describe("session-tool-setup app refresh side effects", () => {
     });
 
     test("preserves exact active create_app skill tool when app_create is also active", async () => {
-      const ctx = makeCtx({
+      const ctx = makeToolSetupContext({
         allowedToolNames: new Set(["create_app", "app_create"]),
       });
       const executor = makeFakeExecutor({
@@ -370,11 +382,11 @@ describe("session-tool-setup app refresh side effects", () => {
 
       const calls = executor.execute.mock.calls as unknown[][];
       expect(calls[0][0]).toBe("create_app");
-      expect(broadcastSpy).not.toHaveBeenCalled();
+      expect(broadcastMessageSpy).not.toHaveBeenCalled();
     });
 
     test("skips side effects when app_create result is an error", async () => {
-      const ctx = makeCtx();
+      const ctx = makeToolSetupContext();
       const executor = makeFakeExecutor({ content: "Error", isError: true });
 
       const toolFn = createToolExecutor(
@@ -387,7 +399,7 @@ describe("session-tool-setup app refresh side effects", () => {
 
       await toolFn("app_create", { name: "Bad", html: "" });
 
-      expect(broadcastSpy).not.toHaveBeenCalled();
+      expect(broadcastMessageSpy).not.toHaveBeenCalled();
     });
 
     test("fires notify side effects regardless of compile outcome reported in payload", async () => {
@@ -396,7 +408,7 @@ describe("session-tool-setup app refresh side effects", () => {
       // compile or returns compile_errors, the hook still refreshes
       // surfaces and broadcasts — compile retries are the LLM's
       // responsibility via a follow-up tool call, not the hook's.
-      const ctx = makeCtx();
+      const ctx = makeToolSetupContext();
       const executor = makeFakeExecutor({
         content: JSON.stringify({
           id: "new-app-err",
@@ -417,14 +429,14 @@ describe("session-tool-setup app refresh side effects", () => {
 
       await toolFn("app_create", { name: "Busted", html: "" });
 
-      expect(refreshSpy).toHaveBeenCalledTimes(1);
-      expect(broadcastSpy.mock.calls.length).toBeGreaterThanOrEqual(1);
-      expect((broadcastSpy.mock.calls as unknown[][])[0][0]).toEqual({
+      expect(refreshSurfacesForAppSpy).toHaveBeenCalledTimes(1);
+      expect(broadcastMessageSpy.mock.calls.length).toBeGreaterThanOrEqual(1);
+      expect((broadcastMessageSpy.mock.calls as unknown[][])[0][0]).toEqual({
         type: "app_files_changed",
         appId: "new-app-err",
       });
       expectAppChangeBroadcast("new-app-err");
-      expect(updatePublishedSpy).toHaveBeenCalledTimes(1);
+      expect(updatePublishedAppDeploymentSpy).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -432,7 +444,7 @@ describe("session-tool-setup app refresh side effects", () => {
 
   describe("app_delete side effects", () => {
     test("broadcasts app_files_changed after app_delete", async () => {
-      const ctx = makeCtx();
+      const ctx = makeToolSetupContext();
       const executor = makeFakeExecutor({ content: "{}", isError: false });
 
       const toolFn = createToolExecutor(
@@ -445,12 +457,12 @@ describe("session-tool-setup app refresh side effects", () => {
 
       await toolFn("app_delete", { app_id: "del-app-1" });
 
-      expect(broadcastSpy).toHaveBeenCalledTimes(2);
+      expect(broadcastMessageSpy).toHaveBeenCalledTimes(2);
       expectAppChangeBroadcast("del-app-1");
     });
 
     test("skips side effects when app_delete result is an error", async () => {
-      const ctx = makeCtx();
+      const ctx = makeToolSetupContext();
       const executor = makeFakeExecutor({ content: "Error", isError: true });
 
       const toolFn = createToolExecutor(
@@ -463,7 +475,7 @@ describe("session-tool-setup app refresh side effects", () => {
 
       await toolFn("app_delete", { app_id: "del-err" });
 
-      expect(broadcastSpy).not.toHaveBeenCalled();
+      expect(broadcastMessageSpy).not.toHaveBeenCalled();
     });
   });
 
@@ -475,7 +487,7 @@ describe("session-tool-setup app refresh side effects", () => {
       // string comparison, not tool metadata or origin. This means skill-
       // projected tools with the same name trigger the same afterExecute
       // hooks as core tools.
-      const ctx = makeCtx();
+      const ctx = makeToolSetupContext();
       const executor = makeFakeExecutor({ content: "{}", isError: false });
 
       const toolFn = createToolExecutor(
@@ -488,19 +500,19 @@ describe("session-tool-setup app refresh side effects", () => {
 
       // Simulate calling app_refresh by name (as the agent loop does)
       for (const toolName of ["app_refresh"]) {
-        refreshSpy.mockClear();
-        broadcastSpy.mockClear();
-        broadcastSpy.mockClear();
-        updatePublishedSpy.mockClear();
+        refreshSurfacesForAppSpy.mockClear();
+        broadcastMessageSpy.mockClear();
+        broadcastMessageSpy.mockClear();
+        updatePublishedAppDeploymentSpy.mockClear();
 
         await toolFn(toolName, {
           app_id: "skill-app",
         });
 
-        expect(refreshSpy).toHaveBeenCalledTimes(1);
-        expect(broadcastSpy).toHaveBeenCalledTimes(2);
+        expect(refreshSurfacesForAppSpy).toHaveBeenCalledTimes(1);
+        expect(broadcastMessageSpy).toHaveBeenCalledTimes(2);
         expectAppChangeBroadcast("skill-app");
-        expect(updatePublishedSpy).toHaveBeenCalledTimes(1);
+        expect(updatePublishedAppDeploymentSpy).toHaveBeenCalledTimes(1);
       }
     });
   });
@@ -509,7 +521,7 @@ describe("session-tool-setup app refresh side effects", () => {
 
   describe("non-app tools", () => {
     test("other tool names do not trigger app refresh side effects", async () => {
-      const ctx = makeCtx();
+      const ctx = makeToolSetupContext();
       const executor = makeFakeExecutor({ content: "{}", isError: false });
 
       const toolFn = createToolExecutor(
@@ -528,16 +540,16 @@ describe("session-tool-setup app refresh side effects", () => {
         "app_file_edit",
         "app_file_write",
       ]) {
-        refreshSpy.mockClear();
-        broadcastSpy.mockClear();
-        broadcastSpy.mockClear();
-        updatePublishedSpy.mockClear();
+        refreshSurfacesForAppSpy.mockClear();
+        broadcastMessageSpy.mockClear();
+        broadcastMessageSpy.mockClear();
+        updatePublishedAppDeploymentSpy.mockClear();
 
         await toolFn(toolName, { app_id: "app-1" });
 
-        expect(refreshSpy).not.toHaveBeenCalled();
-        expect(broadcastSpy).not.toHaveBeenCalled();
-        expect(updatePublishedSpy).not.toHaveBeenCalled();
+        expect(refreshSurfacesForAppSpy).not.toHaveBeenCalled();
+        expect(broadcastMessageSpy).not.toHaveBeenCalled();
+        expect(updatePublishedAppDeploymentSpy).not.toHaveBeenCalled();
       }
     });
   });

--- a/assistant/src/memory/__tests__/tool-invocation-test-helpers.ts
+++ b/assistant/src/memory/__tests__/tool-invocation-test-helpers.ts
@@ -3,12 +3,15 @@
  * telemetry projection chain. Inserts raw audit rows (with PII-sentinel
  * input/result payloads) plus the FK-required conversation row.
  *
- * No source-module imports: per the test-machinery isolation rule
- * (`assistant/AGENTS.md`), shared test helpers must not reach into
- * `src/`. Callers pass in the real `getDb()` handle and schema table
- * refs; the structural types below describe only the slice this helper
- * uses.
+ * Zero runtime imports: per the test-machinery isolation rule
+ * (`assistant/AGENTS.md`), shared test helpers must not pull in source
+ * modules' import-time side effects. Production types are referenced via
+ * `import type` only (erased at compile time); callers pass in the real
+ * `getDb()` handle and schema table refs.
  */
+
+import type { DrizzleDb } from "../db-connection.js";
+import type { conversations, toolInvocations } from "../schema.js";
 
 /**
  * Sentinel embedded in the seeded raw input/result payloads. Assert it
@@ -16,20 +19,10 @@
  */
 export const TOOL_INVOCATION_PII_SENTINEL = "must never leave the device";
 
-interface SeedStatement {
-  run(): unknown;
-}
-
 export interface ToolInvocationSeedDeps {
-  db: {
-    insert(table: unknown): {
-      values(row: Record<string, unknown>): SeedStatement & {
-        onConflictDoNothing(): SeedStatement;
-      };
-    };
-  };
-  conversations: unknown;
-  toolInvocations: unknown;
+  db: DrizzleDb;
+  conversations: typeof conversations;
+  toolInvocations: typeof toolInvocations;
 }
 
 export interface SeedToolInvocationSpec {


### PR DESCRIPTION
## Summary
Fixes round-3 review gaps for tool-telemetry-daemon.md: replaces the hand-rolled untyped ToolInvocationSeedDeps structural mimic with real drizzle types via type-only imports (sanctioned by the test-machinery isolation rule), and drops the pre-refactor name aliases in the app-refresh test.