### PR TITLE
feat(memory-v3): cache-ordered selector input with stable-prefix breakpoint

### DIFF
--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/live-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/live-integration.test.ts
@@ -131,20 +131,39 @@ function toolUseResponse(input: Record<string, unknown>): ProviderResponse {
   };
 }
 
-/** Parse the numbered `<candidates>` block into an ordered slug list. */
+/**
+ * Parse the two-segment selector input into the globally-numbered pool slug
+ * list: stable-prefix cards (`<candidate_cards>`, identified by their
+ * `[i] # memory/concepts/<slug>.md` header line) then finder lines
+ * (`<candidates>`, `[i] slug — descriptor`).
+ */
 function candidateSlugs(messages: Message[]): Slug[] {
+  const entries: Array<{ id: number; slug: string }> = [];
   for (const msg of messages) {
     for (const block of msg.content) {
       if (block.type !== "text") continue;
-      const m = /<candidates>\n([\s\S]*?)\n<\/candidates>/.exec(block.text);
-      if (!m) continue;
-      return m[1]
-        .split("\n")
-        .map((line) => /^\[\d+\] (\S+) —/.exec(line)?.[1])
-        .filter((s): s is string => !!s);
+      const cards = /<candidate_cards>\n([\s\S]*?)\n<\/candidate_cards>/.exec(
+        block.text,
+      );
+      if (cards) {
+        for (const m of cards[1].matchAll(
+          /^\[(\d+)\] # memory\/concepts\/(.+)\.md$/gm,
+        )) {
+          entries.push({ id: Number(m[1]), slug: m[2]! });
+        }
+      }
+      const finder = /<candidates>\n([\s\S]*?)\n<\/candidates>/.exec(
+        block.text,
+      );
+      if (finder) {
+        for (const line of finder[1].split("\n")) {
+          const m = /^\[(\d+)\] (\S+)(?: — |$)/.exec(line);
+          if (m) entries.push({ id: Number(m[1]), slug: m[2]! });
+        }
+      }
     }
   }
-  return [];
+  return entries.sort((a, b) => a.id - b.id).map((e) => e.slug);
 }
 
 /** Provider that selects (and optionally pins) the pooled candidates in `keep`. */

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/orchestrate.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/orchestrate.test.ts
@@ -152,24 +152,51 @@ function toolUseResponse(input: Record<string, unknown>): ProviderResponse {
   };
 }
 
-/** Extract the raw numbered candidate lines from the rendered `<candidates>` block. */
-function candidateLines(messages: Message[]): string[] {
+/**
+ * Parse the two-segment selector input back into the globally-numbered pool:
+ * stable-prefix cards (`<candidate_cards>`, identified by their
+ * `[i] # memory/concepts/<slug>.md` header line) and finder lines
+ * (`<candidates>`, `[i] slug — descriptor`). Also captures the raw stable
+ * prefix block for byte-identity assertions.
+ */
+function parsePool(messages: Message[]): {
+  slugs: Slug[];
+  lines: string[];
+  prefixBlock: string | null;
+} {
+  const entries: Array<{ id: number; slug: string; line: string }> = [];
+  let prefixBlock: string | null = null;
   for (const msg of messages) {
     for (const block of msg.content) {
       if (block.type !== "text") continue;
-      const m = /<candidates>\n([\s\S]*?)\n<\/candidates>/.exec(block.text);
-      if (!m) continue;
-      return m[1].split("\n");
+      const cards = /<candidate_cards>\n([\s\S]*?)\n<\/candidate_cards>/.exec(
+        block.text,
+      );
+      if (cards) {
+        prefixBlock = cards[0];
+        for (const m of cards[1].matchAll(
+          /^\[(\d+)\] # memory\/concepts\/(.+)\.md$/gm,
+        )) {
+          entries.push({ id: Number(m[1]), slug: m[2]!, line: m[0] });
+        }
+      }
+      const finder = /<candidates>\n([\s\S]*?)\n<\/candidates>/.exec(
+        block.text,
+      );
+      if (finder) {
+        for (const line of finder[1].split("\n")) {
+          const m = /^\[(\d+)\] (\S+)(?: — |$)/.exec(line);
+          if (m) entries.push({ id: Number(m[1]), slug: m[2]!, line });
+        }
+      }
     }
   }
-  return [];
-}
-
-/** Parse the numbered `<candidates>` block back into an ordered slug list. */
-function candidateSlugs(messages: Message[]): Slug[] {
-  return candidateLines(messages)
-    .map((line) => /^\[\d+\] (\S+) —/.exec(line)?.[1])
-    .filter((s): s is string => !!s);
+  entries.sort((a, b) => a.id - b.id);
+  return {
+    slugs: entries.map((e) => e.slug),
+    lines: entries.map((e) => e.line),
+    prefixBlock,
+  };
 }
 
 /**
@@ -179,18 +206,20 @@ function candidateSlugs(messages: Message[]): Slug[] {
  */
 let lastPool: Slug[] = [];
 let lastPoolLines: string[] = [];
+let lastPrefixBlock: string | null = null;
 let selectCalls = 0;
 function selectProvider(keep: Slug[], pin: Slug[] = []): Provider {
   return {
     name: "stub",
     sendMessage: async (messages) => {
       selectCalls++;
-      const pool = candidateSlugs(messages);
-      lastPool = pool;
-      lastPoolLines = candidateLines(messages);
+      const parsed = parsePool(messages);
+      lastPool = parsed.slugs;
+      lastPoolLines = parsed.lines;
+      lastPrefixBlock = parsed.prefixBlock;
       const ids: number[] = [];
       const pinned_ids: number[] = [];
-      pool.forEach((slug, i) => {
+      parsed.slugs.forEach((slug, i) => {
         if (keep.includes(slug)) ids.push(i + 1);
         if (pin.includes(slug)) pinned_ids.push(i + 1);
       });
@@ -205,6 +234,7 @@ beforeEach(() => {
   denseHits = [];
   lastPool = [];
   lastPoolLines = [];
+  lastPrefixBlock = null;
   selectCalls = 0;
 });
 
@@ -336,21 +366,48 @@ describe("orchestrate — cache-ordered pool (core + hot + finders)", () => {
 
     providerStub = selectProvider([]);
     await orchestrate(makeTurn(1, "apple"), deps);
-    const prefix1 = lastPoolLines.slice(0, 2);
+    const prefix1 = lastPrefixBlock;
 
     await orchestrate(makeTurn(2, "grape"), deps);
-    const prefix2 = lastPoolLines.slice(0, 2);
+    const prefix2 = lastPrefixBlock;
 
-    // Stable-prefix descriptors are the pages' lead sections — query
-    // independent — so the rendered lines match byte-for-byte.
-    expect(prefix1).toEqual(prefix2);
-    expect(prefix1[0]).toContain("topic-c");
-    expect(prefix1[1]).toContain("topic-b");
+    // Stable-prefix cards are pre-rendered and query-independent, so the
+    // whole rendered cards block matches byte-for-byte across turns.
+    expect(prefix1).not.toBeNull();
+    expect(prefix2).toBe(prefix1!);
+    expect(prefix1).toContain("topic-c");
+    expect(prefix1).toContain("topic-b");
   });
 
-  test("a finder hit on a core page keeps its matched-section ref without duplicating the pool entry", async () => {
+  test("stable-prefix candidates render pre-rendered cards; a missing card degrades to header-only", async () => {
     const lanes = await buildLanes();
-    // topic-a is CORE and the needle also hits it on "apple".
+    providerStub = selectProvider([]);
+
+    await orchestrate(
+      makeTurn(1, "zzzz"),
+      depsOf(lanes, {
+        coreSlugs: ["topic-c"],
+        hotSlugs: ["topic-d"],
+        // Only topic-c has a pre-rendered card; topic-d falls back.
+        prefixCards: new Map([
+          [
+            "topic-c",
+            "# memory/concepts/topic-c.md\nlead for topic c\n\n[sections: §Notes]",
+          ],
+        ]),
+      }),
+    );
+
+    expect(lastPrefixBlock).toContain(
+      "[1] # memory/concepts/topic-c.md\nlead for topic c\n\n[sections: §Notes]",
+    );
+    expect(lastPrefixBlock).toContain("[2] # memory/concepts/topic-d.md");
+  });
+
+  test("a finder hit on a core page repeats as a finder line and dedupes on selection", async () => {
+    const lanes = await buildLanes();
+    // topic-a is CORE and the needle also hits it on "apple". The stub keeps
+    // BOTH occurrences (card id + finder-line id).
     providerStub = selectProvider(["topic-a"]);
 
     const result = await orchestrate(
@@ -358,11 +415,19 @@ describe("orchestrate — cache-ordered pool (core + hot + finders)", () => {
       depsOf(lanes, { coreSlugs: ["topic-a"] }),
     );
 
-    // The pool lists topic-a exactly once (in the stable prefix)…
-    expect(lastPool.filter((s) => s === "topic-a")).toHaveLength(1);
+    // The pool lists topic-a twice — once as the stable-prefix card, once as
+    // a finder line carrying its CURRENT matched section (the tail is not
+    // deduped against the prefix, by design: filtering would not change the
+    // prefix here, but the snippet line is the page's current relevance).
+    expect(lastPool.filter((s) => s === "topic-a")).toHaveLength(2);
     expect(lastPool[0]).toBe("topic-a");
-    // …but the finder lane still records the hit (current relevance) and the
-    // matched section survives for downstream injection/spotlight.
+    // The finder line shows the matched-section snippet.
+    expect(lastPoolLines.find((l) => /^\[2\] topic-a — /.test(l))).toContain(
+      "apple",
+    );
+    // Selecting both ids still yields ONE selection (slug dedup), the finder
+    // lane records the hit, and the matched section survives downstream.
+    expect(result.selections).toEqual([{ slug: "topic-a", pinned: false }]);
     expect(result.lanes.finder.map((c) => c.slug)).toContain("topic-a");
     expect(result.matchedSections.get("topic-a")?.text).toContain("apple");
   });
@@ -498,6 +563,18 @@ describe("orchestrate — dense liveness filter", () => {
     expect(lastPool).toContain("topic-b");
     expect(lastPool).not.toContain("gone-page");
     expect(result.lanes.finder.map((c) => c.slug)).not.toContain("gone-page");
+  });
+
+  test("a dense hit with an unresolvable ordinal falls back to the lead-section snippet", async () => {
+    const lanes = await buildLanes();
+    // Ordinal 99 resolves to no section, so the candidate carries no match
+    // text — its finder line falls back to the page's lead-section text.
+    denseHits = [{ article: "topic-b", section: 99 }];
+    providerStub = selectProvider([]);
+    await orchestrate(makeTurn(1, "zzzz"), depsOf(lanes));
+
+    const line = lastPoolLines.find((l) => / topic-b — /.test(l));
+    expect(line).toContain("lead for topic b");
   });
 });
 

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/pool-select.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/pool-select.test.ts
@@ -1,18 +1,25 @@
 /**
- * Tests for `pool-select.ts` — the single forced-tool selector over the unified
- * candidate pool.
+ * Tests for `pool-select.ts` — the single forced-tool selector over the
+ * two-segment candidate pool (stable-prefix cards + dynamic finder tail).
  *
  * Coverage matrix:
- *   - Numbered candidates render with their descriptors (truncated).
- *   - Returned IDs map to the right candidate slugs by 1-based index, with
- *     `pinned` driven by `pinned_ids`.
- *   - Omitted `ids` → keep ALL candidates (recall-safe).
+ *   - Segment ordering: the stable prefix (full cards, `[1]…[m]`) renders as
+ *     its own content block carrying the `cache_control` breakpoint; the
+ *     dynamic tail (finder lines `[m+1]…` + per-turn context) follows in an
+ *     un-cached block.
+ *   - Numbering stability: for identical stable lanes the rendered prefix
+ *     block is byte-identical across renders; only the tail varies.
+ *   - Returned IDs map over the CONCATENATED numbering, with `pinned` driven
+ *     by `pinned_ids`; out-of-range IDs dropped; selections deduped by slug
+ *     (a page can appear as both a card and a finder line; pinned flags OR).
+ *   - Omitted `ids` → keep ALL candidates (recall-safe, slug-deduped).
  *   - Explicit `ids: []` → keep none (deliberate abstention).
- *   - Out-of-range / duplicate IDs ignored without throwing.
+ *   - Finder snippets are whitespace-collapsed and truncated (~300 chars).
  *   - No provider / missing tool_use / schema mismatch / throw → keep none
  *     (degrade to deterministic lanes), the last three after a re-prompt retry.
- *   - One forced-tool `select_pages` call on the v3 L2 call site, with NO cache
- *     breakpoint (the pool is dynamic per turn).
+ *   - One forced-tool `select_pages` call on the v3 L2 call site with
+ *     `disableTurnStartCache` (the tail varies per turn — the provider's
+ *     auto-anchor would never hit).
  *
  * The provider is stubbed so no network calls fire; mirrors selector.test.ts.
  */
@@ -55,7 +62,7 @@ mock.module("../../../../util/logger.js", () => ({
 }));
 
 const { selectPool } = await import("../pool-select.js");
-type PoolCandidate = Parameters<typeof selectPool>[0][number];
+type SelectorPool = Parameters<typeof selectPool>[0];
 
 // ---------------------------------------------------------------------------
 // Helpers.
@@ -118,12 +125,23 @@ function makeThrowingProvider(): Provider {
   };
 }
 
-function makePool(): PoolCandidate[] {
-  return [
-    { slug: "page-a", descriptor: "section: the alpha rollout plan" },
-    { slug: "page-b", descriptor: "section: beta metrics dashboard" },
-    { slug: "topic-x", descriptor: "linked page about topic x" },
-  ];
+const CARD_A =
+  "# memory/concepts/page-a.md\nlead for page a\n\n[sections: §Alpha · §Beta]";
+const CARD_B = "# memory/concepts/page-b.md\nlead for page b";
+
+/** Two stable-prefix cards (`[1] page-a`, `[2] page-b`) and two finder lines
+ * (`[3] topic-x`, `[4] page-a` — a finder hit on a stable-prefix page). */
+function makePool(): SelectorPool {
+  return {
+    stable: [
+      { slug: "page-a", card: CARD_A },
+      { slug: "page-b", card: CARD_B },
+    ],
+    finder: [
+      { slug: "topic-x", descriptor: "section: about topic x" },
+      { slug: "page-a", descriptor: "section: the alpha rollout plan" },
+    ],
+  };
 }
 
 function makeTurn(currentMessage: string): MemoryRoutingTurn {
@@ -135,17 +153,28 @@ function makeTurn(currentMessage: string): MemoryRoutingTurn {
   };
 }
 
+interface RenderedBlock {
+  type: string;
+  text: string;
+  cache_control?: { type: string; ttl?: string };
+}
+
+function sentBlocks(callIndex = 0): RenderedBlock[] {
+  return providerCalls[callIndex]!.messages[0]!
+    .content as unknown as RenderedBlock[];
+}
+
 beforeEach(() => {
   providerStub = null;
   providerCalls.length = 0;
 });
 
 // ---------------------------------------------------------------------------
-// selectPool — id mapping.
+// selectPool — id mapping over the concatenated numbering.
 // ---------------------------------------------------------------------------
 
 describe("selectPool — id mapping", () => {
-  test("returned IDs map to candidate slugs, pinned driven by pinned_ids", async () => {
+  test("IDs map over cards then finder lines, pinned driven by pinned_ids", async () => {
     providerStub = makeProvider(
       toolUseResponse({ ids: [3, 1], pinned_ids: [1] }),
     );
@@ -156,7 +185,17 @@ describe("selectPool — id mapping", () => {
     ]);
   });
 
-  test("omitted ids keeps ALL candidates (recall-safe)", async () => {
+  test("a page selected as both card and finder line dedupes to one slug, pinned ORed", async () => {
+    // page-a is id 1 (card) AND id 4 (finder line); pinned only via the
+    // finder-line id.
+    providerStub = makeProvider(
+      toolUseResponse({ ids: [1, 4], pinned_ids: [4] }),
+    );
+    const result = await selectPool(makePool(), makeTurn("the alpha plan"));
+    expect(result).toEqual([{ slug: "page-a", pinned: true }]);
+  });
+
+  test("omitted ids keeps ALL candidates, deduped by slug (recall-safe)", async () => {
     providerStub = makeProvider(toolUseResponse({}));
     const result = await selectPool(makePool(), makeTurn("anything"));
     expect(result).toEqual([
@@ -180,7 +219,7 @@ describe("selectPool — id mapping", () => {
 
   test("empty pool returns no pages and never calls the provider", async () => {
     providerStub = makeProvider(toolUseResponse({ ids: [1] }));
-    const result = await selectPool([], makeTurn("hi"));
+    const result = await selectPool({ stable: [], finder: [] }, makeTurn("hi"));
     expect(result).toEqual([]);
     expect(providerCalls).toHaveLength(0);
   });
@@ -231,11 +270,12 @@ describe("selectPool — degradation on failure", () => {
 });
 
 // ---------------------------------------------------------------------------
-// selectPool — request shape (no cache breakpoint; pool is dynamic per turn).
+// selectPool — request shape: stable-prefix cards block with the cache
+// breakpoint, dynamic tail block without.
 // ---------------------------------------------------------------------------
 
 describe("selectPool — request shape", () => {
-  test("forces tool_choice to select_pages with the v3 L2 call site", async () => {
+  test("forces tool_choice to select_pages on the v3 L2 call site with disableTurnStartCache", async () => {
     providerStub = makeProvider(toolUseResponse({ ids: [1] }));
     await selectPool(makePool(), makeTurn("rollout?"));
 
@@ -244,63 +284,115 @@ describe("selectPool — request shape", () => {
     const cfg = call.options?.config as Record<string, unknown>;
     expect(cfg?.callSite).toBe("memoryV3SelectL2");
     expect(cfg?.tool_choice).toEqual({ type: "tool", name: "select_pages" });
+    expect(cfg?.disableTurnStartCache).toBe(true);
     expect(call.options?.tools?.[0]?.name).toBe("select_pages");
   });
 
-  test("renders numbered candidates with descriptors and NO cache breakpoint", async () => {
+  test("stable prefix renders full cards in its own block carrying cache_control", async () => {
     providerStub = makeProvider(toolUseResponse({ ids: [1] }));
     await selectPool(makePool(), makeTurn("rollout?"));
 
-    const content = providerCalls[0].messages[0].content as Array<{
-      type: string;
-      text: string;
-      cache_control?: unknown;
-    }>;
-    // A single text block — the dynamic pool has no static prefix to cache.
-    expect(content).toHaveLength(1);
-    const [block] = content;
-    expect(block.type).toBe("text");
-    expect(block.text).toContain(
-      "[1] page-a — section: the alpha rollout plan",
-    );
-    expect(block.text).toContain(
-      "[2] page-b — section: beta metrics dashboard",
-    );
-    expect(block.text).toContain("[3] topic-x — linked page about topic x");
-    expect(block.text).toContain("<current_message>rollout?</current_message>");
-    expect(block.text).toContain("<recent_context>");
-    expect(block.cache_control).toBeUndefined();
+    const blocks = sentBlocks();
+    expect(blocks).toHaveLength(2);
+
+    const [prefix, tail] = blocks;
+    expect(prefix.type).toBe("text");
+    // FULL cards, numbered in pool order, inside the cards segment.
+    expect(prefix.text).toContain(`[1] ${CARD_A}`);
+    expect(prefix.text).toContain(`[2] ${CARD_B}`);
+    expect(prefix.text.startsWith("<candidate_cards>\n")).toBe(true);
+    expect(prefix.text.endsWith("\n</candidate_cards>")).toBe(true);
+    // The breakpoint rides THIS block (preserved by toAnthropicBlockSafe).
+    expect(prefix.cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+
+    // The tail continues the numbering after the cards and is NOT cached.
+    expect(tail.type).toBe("text");
+    expect(tail.text).toContain("[3] topic-x — section: about topic x");
+    expect(tail.text).toContain("[4] page-a — section: the alpha rollout plan");
+    expect(tail.text).toContain("<current_message>rollout?</current_message>");
+    expect(tail.text).toContain("<recent_context>");
+    expect(tail.cache_control).toBeUndefined();
+    // No cards leak into the tail.
+    expect(tail.text).not.toContain("<candidate_cards>");
   });
 
-  test("long descriptors are truncated in the candidate list", async () => {
+  test("the rendered prefix is byte-identical across turns; only the tail varies", async () => {
     providerStub = makeProvider(toolUseResponse({ ids: [1] }));
-    const longDescriptor = "z".repeat(1000);
+    await selectPool(makePool(), makeTurn("first question"));
+
+    // Same stable lanes, different finder hits + message (a new turn).
+    const pool2 = makePool();
+    pool2.finder = [{ slug: "page-c", descriptor: "section: something else" }];
+    await selectPool(pool2, makeTurn("second question"));
+
+    const [prefix1, tail1] = sentBlocks(0);
+    const [prefix2, tail2] = sentBlocks(1);
+    expect(prefix2.text).toBe(prefix1.text);
+    expect(prefix2.cache_control).toEqual(prefix1.cache_control!);
+    expect(tail2.text).not.toBe(tail1.text);
+  });
+
+  test("an empty stable prefix renders a single un-cached block", async () => {
+    providerStub = makeProvider(toolUseResponse({ ids: [1] }));
     await selectPool(
-      [{ slug: "page-a", descriptor: longDescriptor }],
+      { stable: [], finder: [{ slug: "page-a", descriptor: "d" }] },
       makeTurn("x"),
     );
-    const text = (providerCalls[0].messages[0].content[0] as { text: string })
-      .text;
-    expect(text).toContain("...");
-    expect(text).not.toContain("z".repeat(1000));
+    const blocks = sentBlocks();
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].text).toContain("[1] page-a — d");
+    expect(blocks[0].cache_control).toBeUndefined();
   });
 
-  test("situational context renders in the user message when present", async () => {
+  test("long finder snippets are whitespace-collapsed and truncated (~300 chars)", async () => {
+    providerStub = makeProvider(toolUseResponse({ ids: [1] }));
+    const longDescriptor = `padded   ${"z".repeat(1000)}`;
+    await selectPool(
+      { stable: [], finder: [{ slug: "page-a", descriptor: longDescriptor }] },
+      makeTurn("x"),
+    );
+    const [block] = sentBlocks();
+    const line = block.text
+      .split("\n")
+      .find((l) => l.startsWith("[1] page-a — "))!;
+    expect(line).toContain("...");
+    expect(line).not.toContain("z".repeat(1000));
+    // snippet cap (300) + the `[1] page-a — ` prefix.
+    expect(line.length).toBeLessThanOrEqual(300 + "[1] page-a — ".length);
+  });
+
+  test("a finder candidate with an empty descriptor renders without a dangling dash", async () => {
+    providerStub = makeProvider(toolUseResponse({ ids: [1] }));
+    await selectPool(
+      { stable: [], finder: [{ slug: "page-a", descriptor: "   " }] },
+      makeTurn("x"),
+    );
+    const [block] = sentBlocks();
+    expect(block.text).toContain("[1] page-a\n");
+    expect(block.text).not.toContain("[1] page-a — ");
+  });
+
+  test("situational context renders in the tail when present", async () => {
     providerStub = makeProvider(toolUseResponse({ ids: [1] }));
     await selectPool(makePool(), {
       ...makeTurn("rollout?"),
       situationalContext: "Today is Saturday. The launch is today.",
     });
-    const text = (providerCalls[0].messages[0].content[0] as { text: string })
-      .text;
-    expect(text).toContain(
+    const blocks = sentBlocks();
+    expect(blocks[1].text).toContain(
       "<situation>Today is Saturday. The launch is today.</situation>",
     );
   });
 
-  test("system prompt mentions pinned (locks the pinning commitment)", async () => {
+  test("system prompt is carry-aware and generous (persistence + pinned + no limit)", async () => {
     providerStub = makeProvider(toolUseResponse({ ids: [1] }));
     await selectPool(makePool(), makeTurn("x"));
-    expect(providerCalls[0].options?.systemPrompt).toMatch(/pinned/);
+    const prompt = providerCalls[0].options?.systemPrompt ?? "";
+    // Carry-aware: previously selected pages persist automatically.
+    expect(prompt).toMatch(/persist/);
+    // Generous: explicitly no selection limit.
+    expect(prompt).toMatch(/no limit/i);
+    // Pinning commitment.
+    expect(prompt).toMatch(/pinned/);
   });
 });

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-integration.test.ts
@@ -210,20 +210,39 @@ function toolUseResponse(input: Record<string, unknown>): ProviderResponse {
   };
 }
 
-/** Parse the numbered `<candidates>` block back into an ordered slug list. */
+/**
+ * Parse the two-segment selector input back into the globally-numbered pool
+ * slug list: stable-prefix cards (`<candidate_cards>`, identified by their
+ * `[i] # memory/concepts/<slug>.md` header line) then finder lines
+ * (`<candidates>`, `[i] slug — descriptor`).
+ */
 function candidateSlugs(messages: Message[]): Slug[] {
+  const entries: Array<{ id: number; slug: string }> = [];
   for (const msg of messages) {
     for (const block of msg.content) {
       if (block.type !== "text") continue;
-      const m = /<candidates>\n([\s\S]*?)\n<\/candidates>/.exec(block.text);
-      if (!m) continue;
-      return m[1]
-        .split("\n")
-        .map((line) => /^\[\d+\] (\S+) —/.exec(line)?.[1])
-        .filter((s): s is string => !!s);
+      const cards = /<candidate_cards>\n([\s\S]*?)\n<\/candidate_cards>/.exec(
+        block.text,
+      );
+      if (cards) {
+        for (const m of cards[1].matchAll(
+          /^\[(\d+)\] # memory\/concepts\/(.+)\.md$/gm,
+        )) {
+          entries.push({ id: Number(m[1]), slug: m[2]! });
+        }
+      }
+      const finder = /<candidates>\n([\s\S]*?)\n<\/candidates>/.exec(
+        block.text,
+      );
+      if (finder) {
+        for (const line of finder[1].split("\n")) {
+          const m = /^\[(\d+)\] (\S+)(?: — |$)/.exec(line);
+          if (m) entries.push({ id: Number(m[1]), slug: m[2]! });
+        }
+      }
     }
   }
-  return [];
+  return entries.sort((a, b) => a.id - b.id).map((e) => e.slug);
 }
 
 /**
@@ -375,12 +394,14 @@ describe("memory-v3 shadow integration — core + hot stable prefix", () => {
   test("a finder hit on a core page logs core, not the finder lane", async () => {
     const lanes = await buildLanes();
     // "apple" hits page-a via the needle, but page-a is CORE — the pool lists
-    // it once (stable prefix) and the selection attributes to core.
+    // it twice (stable-prefix card + finder snippet line, by design), the
+    // selection dedupes to one slug, and the row attributes to core.
     const result = await runTurn(1, "apple", ["page-a"], [], {
       lanes,
       core: ["page-a"],
     });
-    expect(lastPool.filter((s) => s === "page-a")).toHaveLength(1);
+    expect(lastPool.filter((s) => s === "page-a")).toHaveLength(2);
+    expect(result.selections).toEqual([{ slug: "page-a", pinned: false }]);
     expect(result.lanes.finder.map((c) => c.slug)).toContain("page-a");
     expect(loggedSources(1)).toEqual([{ slug: "page-a", source: "core" }]);
   });

--- a/assistant/src/plugins/defaults/memory-v3-shadow/orchestrate.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/orchestrate.ts
@@ -14,21 +14,23 @@
  *      init — followed by the finder candidates (needle → dense → edge
  *      surfacing order). The stable prefix is identical across consecutive
  *      turns while the lanes are unchanged (lane invalidation at consolidation
- *      is the recompute cadence), so the selector input's leading segment can
- *      ride the provider KV cache.
+ *      is the recompute cadence), so the selector input's leading segment
+ *      rides the provider KV cache (the cache breakpoint itself lives in
+ *      `pool-select.ts`).
  *
- *      Finder hits are deduped against the stable prefix for the POOL list
- *      (a slug never appears twice in the numbered candidate list), but a
- *      finder hit on a core/hot page KEEPS its matched-section ref in
- *      `matchedSections` and its entry in `lanes.finder` — so the selector
- *      tail and the section spotlight can still surface that page's CURRENT
- *      relevance even though the page itself sits in the stable prefix.
+ *      Stable-prefix candidates render as FULL CARDS (`renderCard` — head
+ *      section + TOC), pre-rendered at lane init (`prefixCards`) so the
+ *      rendered prefix is byte-identical across turns. Finder candidates
+ *      render as compact snippet lines: the matched section's text (or the
+ *      curated `links` description for an edge hit), falling back to the
+ *      page's lead-section text when no match text exists.
  *
- *      Per-candidate descriptors: a finder candidate carries its matched
- *      section's text (or the curated `links` description for an edge hit); a
- *      stable-prefix candidate carries its LEAD section's text — deliberately
- *      query-independent so the rendered prefix stays byte-identical across
- *      turns.
+ *      The finder tail is NOT deduped against the stable prefix: a finder hit
+ *      on a core/hot page keeps its matched-section line (and its
+ *      `matchedSections` ref + `lanes.finder` entry), so the selector and the
+ *      section spotlight see that page's CURRENT relevance even though the
+ *      page itself sits in the stable prefix. The selector dedupes selections
+ *      by slug.
  *   3. A SINGLE forced-tool select (`selectPool`) over the whole pool. The
  *      result is this turn's selections — current turn only. There is no
  *      working-set union or eviction here anymore: cross-turn persistence is
@@ -37,10 +39,11 @@
  */
 
 import type { AssistantConfig } from "../../../config/schema.js";
+import { renderCard } from "./card.js";
 import { denseLane } from "./dense.js";
 import type { EdgeGraph } from "./edge.js";
 import { edgeExpand } from "./edge.js";
-import type { PoolCandidate } from "./pool-select.js";
+import type { PoolCandidate, StableCandidate } from "./pool-select.js";
 import { selectPool } from "./pool-select.js";
 import type { SectionNeedle } from "./section-needle.js";
 import type {
@@ -70,6 +73,11 @@ export interface OrchestrateDeps {
   /** The frecency hot set in score order (computed at lane init with the core
    *  set excluded). Follows core in the stable prefix. */
   hotSlugs: Slug[];
+  /** Pre-rendered FULL cards for the stable-prefix slugs, keyed by slug.
+   *  Rendered ONCE at lane init so the selector's stable prefix is
+   *  byte-identical across turns (the cache contract). A missing entry
+   *  degrades to a header-only card. */
+  prefixCards?: ReadonlyMap<Slug, string>;
   /** Number of BM25 needle articles. Defaults to {@link DEFAULT_NEEDLE_K}. */
   needleK?: number;
   /** Number of dense-lane articles. Defaults to {@link DEFAULT_DENSE_K}. */
@@ -109,8 +117,9 @@ export interface OrchestrateLanes {
 }
 
 export interface OrchestrateResult {
-  /** This turn's selections, deduped by slug (pinned flags ORed). Current turn
-   *  only — there is no carried-forward set unioned in. */
+  /** This turn's selections, deduped by slug (pinned flags ORed; the dedup is
+   *  `selectPool`'s contract). Current turn only — there is no
+   *  carried-forward set unioned in. */
   selections: SelectedPage[];
   /** The matched `Section` for each candidate slug that had one, keyed by slug.
    *  Populated from the finder-lane hits — including hits on core/hot pages —
@@ -237,34 +246,34 @@ export async function orchestrate(
     );
   }
 
-  // Step 2: assemble the pool in cache order — stable prefix (core then hot)
-  // first, then the finder tail deduped against the prefix. Stable-prefix
-  // descriptors are the page's LEAD section text: query-INDEPENDENT by design,
-  // so the rendered prefix is byte-identical across turns while the lanes are
-  // unchanged.
-  const pool: PoolCandidate[] = [
-    ...[...core, ...hot].map((slug) => ({
-      slug,
-      descriptor: leadSectionText(deps.sectionIndex, slug),
-    })),
-    ...finder
-      .filter((c) => !stablePrefix.has(c.slug))
-      .map((c) => ({ slug: c.slug, descriptor: c.descriptor })),
-  ];
+  // Step 2: assemble the selector pool in cache order — the stable prefix
+  // (core then hot) as FULL CARDS, then the finder tail. Cards are
+  // pre-rendered at lane init (`prefixCards`): query- AND
+  // conversation-state-INDEPENDENT by design, so the rendered prefix is
+  // byte-identical across turns while the lanes are unchanged. The tail is
+  // NOT deduped against the prefix — a finder hit on a core/hot page renders
+  // its own snippet line so its CURRENT relevance stays visible; `selectPool`
+  // dedupes selections by slug. Finder candidates with no match text fall
+  // back to the page's lead-section snippet.
+  const stable: StableCandidate[] = [...core, ...hot].map((slug) => ({
+    slug,
+    card: deps.prefixCards?.get(slug) ?? renderCard(slug, ""),
+  }));
+  const finderTail: PoolCandidate[] = finder.map((c) => ({
+    slug: c.slug,
+    descriptor:
+      c.descriptor.trim().length > 0
+        ? c.descriptor
+        : leadSectionText(deps.sectionIndex, c.slug),
+  }));
 
-  // Step 3: a SINGLE forced-tool select over the cache-ordered pool.
-  const selected = await selectPool(pool, turn);
-  const bySlug = new Map<Slug, SelectedPage>();
-  for (const page of selected) {
-    const existing = bySlug.get(page.slug);
-    bySlug.set(page.slug, {
-      slug: page.slug,
-      pinned: (existing?.pinned ?? false) || page.pinned,
-    });
-  }
+  // Step 3: a SINGLE forced-tool select over the cache-ordered pool. The
+  // selections come back slug-deduped (pinned flags ORed) — `selectPool`'s
+  // contract.
+  const selections = await selectPool({ stable, finder: finderTail }, turn);
 
   return {
-    selections: [...bySlug.values()],
+    selections,
     matchedSections,
     lanes: { core, hot, finder },
   };
@@ -293,9 +302,10 @@ function sectionByOrdinal(
 
 /**
  * The text of an article's LEAD (first) section, or `""` when the article has
- * no indexed sections. Used as the stable-prefix candidates' descriptor: it
- * depends only on the page content, never on the turn's query, so the rendered
- * prefix stays byte-identical across turns.
+ * no indexed sections. Used as the finder-line snippet fallback when a
+ * candidate carries no match text (e.g. an edge hit with neither a curated
+ * description nor a scoring section) — the lead is the closest free
+ * approximation of the card head.
  */
 function leadSectionText(index: SectionIndex, article: Slug): string {
   const first = index.byArticle.get(article)?.[0];

--- a/assistant/src/plugins/defaults/memory-v3-shadow/pool-select.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/pool-select.ts
@@ -1,17 +1,34 @@
 /**
  * Memory v3 — single pool selector.
  *
- * Runs a SINGLE forced-tool call over one unified candidate pool. Each candidate
- * is a page slug paired with a per-candidate `descriptor` the caller supplies —
- * the matched section text for a needle/dense hit, or a curated link description
- * for an edge page. The caller assembles the pool by unioning the section lanes;
- * the pool selector only decides which of those candidates the reply will draw
- * on.
+ * Runs a SINGLE forced-tool call over one unified candidate pool rendered in
+ * two segments that share one numbering:
  *
- * No cache breakpoint YET. The orchestrator now hands the pool over in cache
- * order — a stable core+hot prefix followed by the per-turn finder tail — but
- * this module still renders one flat block; the stable-prefix `cache_control`
- * breakpoint lands with the card-grain selector input rework.
+ *   1. STABLE PREFIX — the core+hot lane pages as FULL CARDS (head section +
+ *      section TOC, see `card.ts`), numbered `[1]…[m]` in pool order. The
+ *      cards are query- and conversation-state-independent, so the rendered
+ *      segment is byte-identical across turns while the lanes are unchanged
+ *      (lane invalidation at consolidation is the recompute cadence). It is
+ *      emitted as its OWN content block carrying a `cache_control`
+ *      breakpoint, so it rides the provider KV cache — block-level
+ *      `cache_control` is preserved through `toAnthropicBlockSafe` (PR
+ *      #33258; covered by the caller-stamped-block tests in
+ *      `anthropic-provider.test.ts`).
+ *   2. DYNAMIC TAIL — the per-turn finder candidates as compact numbered
+ *      lines (`[m+1] <slug> — <matched-section snippet>`), then the
+ *      situational/recent/current conversation context. Re-rendered every
+ *      turn; never cached. `disableTurnStartCache` suppresses the provider's
+ *      auto-applied 1h turn-start breakpoint, which would otherwise land on
+ *      this per-turn-varying block and pay cache_creation with no future hit
+ *      (same rationale as the v2 router).
+ *
+ * Candidate composition is deliberately conversation-state-independent:
+ * already-injected pages are NOT filtered out of the pool — that would change
+ * the stable prefix per conversation state and bust the cache. Re-selecting
+ * an injected page is harmless (injection dedup happens downstream) and feeds
+ * hot-set frecency + spotlight eligibility. A page may appear BOTH as a
+ * stable-prefix card and as a finder line (its current matched section);
+ * selections are deduped by slug.
  *
  * Failure handling is recall-safe by construction:
  *   - explicit `ids` → select exactly those candidates,
@@ -30,7 +47,11 @@ import {
   extractToolUse,
   getConfiguredProvider,
 } from "../../../providers/provider-send-message.js";
-import type { Message, ToolDefinition } from "../../../providers/types.js";
+import type {
+  ContentBlock,
+  Message,
+  ToolDefinition,
+} from "../../../providers/types.js";
 import { getLogger } from "../../../util/logger.js";
 import { truncate } from "../../../util/truncate.js";
 import { retryForResult } from "./llm-retry.js";
@@ -38,22 +59,40 @@ import type { MemoryRoutingTurn, SelectedPage, Slug } from "./types.js";
 
 const log = getLogger("memory-v3-pool-select");
 
-/** A candidate page in the unified pool, with the descriptor that justifies it. */
+/** A dynamic-tail (finder) candidate: the slug plus the descriptor that
+ *  justifies it — a matched section for a needle/dense hit, or a curated link
+ *  description for an edge page. Rendered as a one-line snippet. */
 export interface PoolCandidate {
   slug: Slug;
-  /**
-   * The text that justifies this candidate: a matched section for a
-   * needle/dense hit, or a curated link description for an edge page. Rendered
-   * (truncated) in the numbered candidate list the selector judges against.
-   */
   descriptor: string;
+}
+
+/** A stable-prefix candidate: the slug plus its pre-rendered FULL card
+ *  (`renderCard` output — head section + TOC). Cards must be byte-stable
+ *  across turns for the prefix to ride the provider KV cache, which is why
+ *  callers pre-render them at lane init rather than per turn. */
+export interface StableCandidate {
+  slug: Slug;
+  card: string;
+}
+
+/**
+ * The selector's unified candidate pool in cache order: the stable prefix
+ * (core+hot cards) then the dynamic finder tail. The two segments share one
+ * numbering — `[1]…[m]` cards, `[m+1]…` finder lines — and MAY repeat a slug
+ * (a finder hit on a core/hot page keeps its matched-section line so the
+ * page's CURRENT relevance stays visible); selections are deduped by slug.
+ */
+export interface SelectorPool {
+  stable: StableCandidate[];
+  finder: PoolCandidate[];
 }
 
 /** Tool name forced via `tool_choice`. Shared constant so tests can match it. */
 const SELECT_PAGES_TOOL_NAME = "select_pages";
 
-/** Descriptors are truncated to keep the candidate list compact. */
-const DESCRIPTOR_MAX_CHARS = 400;
+/** Finder-line snippets are truncated to keep the dynamic tail compact. */
+const SNIPPET_MAX_CHARS = 300;
 
 const SelectPagesSchema = z.object({
   // Optional: an omitted `ids` field is the recall-safe "keep everything"
@@ -65,8 +104,8 @@ const SelectPagesSchema = z.object({
 const SELECT_PAGES_TOOL: ToolDefinition = {
   name: SELECT_PAGES_TOOL_NAME,
   description:
-    "Select the candidate pages whose content the reply would directly draw " +
-    "on. Lean inclusive — when in doubt, keep a candidate; for a list or " +
+    "Select the candidate pages whose content the reply would draw on. Lean " +
+    "inclusive — when in doubt, keep a candidate; for a list or " +
     '"all of X" request keep every candidate that belongs. Pass `pinned_ids` ' +
     "for pages the conversation is centrally about. Omit `ids` only as a " +
     "recall-safe fallback when you cannot judge the pool (keeps every " +
@@ -87,34 +126,80 @@ const SELECT_PAGES_TOOL: ToolDefinition = {
   },
 };
 
-const SYSTEM_PROMPT = `You are given a pool of candidate memory pages, each surfaced because some part of it matched the conversation. Select every page whose specific content the reply to THIS message would directly draw on.
+const SYSTEM_PROMPT = `You are given the candidate memory pages for an assistant's next reply, in two segments that share one numbering: full page cards first (the curated core and recently-recurring pages, shown every turn), then this turn's search hits as one-line snippets.
 
-Lean inclusive: recall matters more than precision here, so when a candidate could plausibly inform the reply, keep it. For a list or an "all of X" request, keep EVERY candidate that belongs to X rather than guessing a representative subset.
+Select EVERY candidate whose content the upcoming reply would draw on. That includes facts the reply needs, but equally register, established framing, calibration rules, and relationship/person/project texture — pages that shape HOW to reply, not only what to say. There is no limit on how many you may select; recall matters more than precision, so when a candidate could plausibly inform the reply, keep it. For a list or an "all of X" request, keep EVERY candidate that belongs to X rather than guessing a representative subset.
+
+Pages you select persist in the conversation automatically, and re-selecting a page that is already in context is harmless (duplicates are removed downstream) — so never withhold a candidate because it might have been selected before. Judge each candidate only by whether the upcoming reply would draw on it.
 
 A page can be relevant because of the current situation — the date or the live scratchpad — not only the message: keep a page the situation makes pertinent (e.g. a person whose anniversary is today).
 
 If the conversation is centrally ABOUT a page (rather than only peripherally relevant to it), mark that page as pinned. Call \`select_pages\` with the chosen IDs. Omit \`ids\` only as a recall-safe fallback when you cannot judge the pool (keeps every candidate); return \`[]\` when candidates are present but none are relevant.`;
 
-/** Collapse a descriptor to one line and cap its length for the candidate list. */
-function renderDescriptor(descriptor: string): string {
-  return truncate(descriptor.replace(/\s+/g, " ").trim(), DESCRIPTOR_MAX_CHARS);
+/** Collapse a descriptor to one line and cap its length for a finder line. */
+function renderSnippet(descriptor: string): string {
+  return truncate(descriptor.replace(/\s+/g, " ").trim(), SNIPPET_MAX_CHARS);
 }
 
 /**
- * Render the numbered candidate list: one `[i] slug — descriptor` line per
- * candidate, descriptors collapsed to one line and length-capped. The pool is
- * dynamic per turn, so this block is NOT cached (see the module doc).
+ * Render the stable prefix: each core/hot card prefixed with its pool number.
+ * Pure concatenation of pre-rendered cards — byte-identical across turns for
+ * identical `stable` input, which is the cache contract.
  */
-function renderCandidateList(pool: PoolCandidate[]): string {
-  const lines = pool.map(
-    (c, i) => `[${i + 1}] ${c.slug} — ${renderDescriptor(c.descriptor)}`,
-  );
+function renderCardSegment(stable: StableCandidate[]): string {
+  const cards = stable.map((c, i) => `[${i + 1}] ${c.card}`);
+  return `<candidate_cards>\n${cards.join("\n\n")}\n</candidate_cards>`;
+}
+
+/**
+ * Render the finder tail: one `[m+i] slug — snippet` line per candidate,
+ * numbered continuing after the `offset` stable-prefix cards. A candidate
+ * with an empty descriptor renders without the dash.
+ */
+function renderFinderSegment(finder: PoolCandidate[], offset: number): string {
+  const lines = finder.map((c, i) => {
+    const snippet = renderSnippet(c.descriptor);
+    const id = offset + i + 1;
+    return snippet.length > 0
+      ? `[${id}] ${c.slug} — ${snippet}`
+      : `[${id}] ${c.slug}`;
+  });
   return `<candidates>\n${lines.join("\n")}\n</candidates>`;
 }
 
 /**
+ * Build a text content block carrying an ephemeral `cache_control` breakpoint
+ * with a 1h TTL. The internal `ContentBlock` type intentionally omits the
+ * field (only the Anthropic provider transforms it onto the wire), so reach
+ * through a `Record` cast — same pattern as the v2 router and `client.ts`.
+ * The 1h TTL matches the provider's auto-applied breakpoints; Haiku models
+ * have the `ttl` stripped provider-side.
+ */
+function cachedTextBlock(text: string): ContentBlock {
+  const block: ContentBlock = { type: "text", text };
+  (block as unknown as Record<string, unknown>).cache_control = {
+    type: "ephemeral",
+    ttl: "1h",
+  };
+  return block;
+}
+
+/** Dedupe selections by slug, preserving first-seen order and ORing pinned
+ *  flags (a page can be selected as both a card and a finder line). */
+function dedupeBySlug(
+  entries: Array<{ slug: Slug; pinned: boolean }>,
+): SelectedPage[] {
+  const bySlug = new Map<Slug, boolean>();
+  for (const entry of entries) {
+    bySlug.set(entry.slug, (bySlug.get(entry.slug) ?? false) || entry.pinned);
+  }
+  return [...bySlug].map(([slug, pinned]) => ({ slug, pinned }));
+}
+
+/**
  * Run the single forced-tool selector over the unified candidate pool. Returns
- * the pages to inject.
+ * the pages to inject, deduped by slug (a page that appeared as both a card
+ * and a finder line yields one entry, pinned flags ORed).
  *
  * An omitted `ids` keeps ALL candidates (the recall-safe "all of these are
  * relevant" signal); an explicit `[]` keeps none; an infrastructure failure
@@ -122,42 +207,48 @@ function renderCandidateList(pool: PoolCandidate[]): string {
  * recall lanes the orchestrator unions in.
  */
 export async function selectPool(
-  pool: PoolCandidate[],
+  pool: SelectorPool,
   turn: MemoryRoutingTurn,
 ): Promise<SelectedPage[]> {
-  if (pool.length === 0) return [];
+  // The concatenated numbering: ids 1…m are the stable-prefix cards, ids
+  // m+1… are the finder lines.
+  const ordered: Slug[] = [
+    ...pool.stable.map((c) => c.slug),
+    ...pool.finder.map((c) => c.slug),
+  ];
+  if (ordered.length === 0) return [];
 
   const keepAll = (): SelectedPage[] =>
-    pool.map((c) => ({ slug: c.slug, pinned: false }));
+    dedupeBySlug(ordered.map((slug) => ({ slug, pinned: false })));
 
   const provider = await getConfiguredProvider("memoryV3SelectL2");
   if (!provider) {
     log.warn(
-      { candidateCount: pool.length },
+      { candidateCount: ordered.length },
       "pool selector provider unavailable; degrading to deterministic lanes",
     );
     return [];
   }
 
-  // No cache breakpoint yet: the caller orders the pool stable-prefix-first,
-  // but the breakpoint lands with the card-grain selector input rework (see
-  // the module doc). The candidate list and the per-turn context go in a
-  // single plain text block.
-  const userMsg: Message = {
-    role: "user",
-    content: [
-      {
-        type: "text",
-        text:
-          `${renderCandidateList(pool)}\n` +
-          (turn.situationalContext
-            ? `<situation>${turn.situationalContext}</situation>\n`
-            : "") +
-          `<recent_context>${turn.recentContext}</recent_context>\n` +
-          `<current_message>${turn.currentMessage}</current_message>`,
-      },
-    ],
-  };
+  // Two content blocks: the stable prefix (cards) carries the cache
+  // breakpoint; the dynamic tail (finder lines + per-turn context) does not.
+  // See the module doc for the cache contract.
+  const content: ContentBlock[] = [];
+  if (pool.stable.length > 0) {
+    content.push(cachedTextBlock(renderCardSegment(pool.stable)));
+  }
+  const tailParts: string[] = [];
+  if (pool.finder.length > 0) {
+    tailParts.push(renderFinderSegment(pool.finder, pool.stable.length));
+  }
+  if (turn.situationalContext) {
+    tailParts.push(`<situation>${turn.situationalContext}</situation>`);
+  }
+  tailParts.push(`<recent_context>${turn.recentContext}</recent_context>`);
+  tailParts.push(`<current_message>${turn.currentMessage}</current_message>`);
+  content.push({ type: "text", text: tailParts.join("\n") });
+
+  const userMsg: Message = { role: "user", content };
 
   // One forced-tool call, retried a few times so a transient malformed response
   // (no usable tool_use, or tool input that fails the schema) re-prompts before
@@ -170,6 +261,11 @@ export async function selectPool(
       config: {
         callSite: "memoryV3SelectL2" as const,
         tool_choice: { type: "tool" as const, name: SELECT_PAGES_TOOL_NAME },
+        // The last block of this one-shot message varies every turn; the
+        // provider's auto-applied turn-start breakpoint would land on it and
+        // pay cache_creation with no future hit. The stable-prefix block
+        // above carries its own breakpoint instead.
+        disableTurnStartCache: true,
       },
     });
     const toolBlock = extractToolUse(response);
@@ -180,7 +276,7 @@ export async function selectPool(
 
   if (parsed === null) {
     log.warn(
-      { candidateCount: pool.length },
+      { candidateCount: ordered.length },
       "pool selector could not obtain a selection after retries; degrading to deterministic lanes",
     );
     return [];
@@ -191,14 +287,12 @@ export async function selectPool(
 
   const pinned = new Set(parsed.pinned_ids ?? []);
 
-  // Map 1-based IDs back to candidate slugs, dropping out-of-range IDs without
-  // throwing. De-duplicate while preserving model-returned order.
-  const seen = new Set<number>();
-  const selected: SelectedPage[] = [];
+  // Map 1-based IDs over the concatenated numbering, dropping out-of-range
+  // IDs without throwing, then dedupe by slug (pinned flags ORed).
+  const selected: Array<{ slug: Slug; pinned: boolean }> = [];
   for (const id of parsed.ids) {
-    if (id < 1 || id > pool.length || seen.has(id)) continue;
-    seen.add(id);
-    selected.push({ slug: pool[id - 1]!.slug, pinned: pinned.has(id) });
+    if (id < 1 || id > ordered.length) continue;
+    selected.push({ slug: ordered[id - 1]!, pinned: pinned.has(id) });
   }
-  return selected;
+  return dedupeBySlug(selected);
 }

--- a/assistant/src/plugins/defaults/memory-v3-shadow/shadow-plugin.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/shadow-plugin.ts
@@ -46,6 +46,7 @@ import {
 } from "../../../util/platform.js";
 import { stripCommentLines } from "../../../util/strip-comment-lines.js";
 import { capabilityOrDiskBody } from "./capabilities.js";
+import { renderCard } from "./card.js";
 import { loadCoreSet } from "./core-set.js";
 import type { EdgeGraph } from "./edge.js";
 import { buildEdgeGraph } from "./edge.js";
@@ -91,6 +92,10 @@ export interface ShadowLanes {
   /** Frecency hot set in score order: core excluded, filtered to pages in the
    *  section index. */
   hotSlugs: string[];
+  /** Pre-rendered FULL cards for the stable-prefix (core+hot) slugs, keyed by
+   *  slug. Frozen at lane build so the selector's stable prefix is
+   *  byte-identical across turns until the next invalidation. */
+  prefixCards: Map<Slug, string>;
 }
 
 /** Milliseconds per day — converts `hotSet.halfLifeDays` config to ms. */
@@ -184,6 +189,21 @@ async function initLanes(config: AssistantConfig): Promise<ShadowLanes> {
     .map((entry) => entry.slug)
     .filter((slug) => sectionIndex.byArticle.has(slug));
 
+  // Pre-render the stable-prefix cards ONCE per lane build: the selector's
+  // stable prefix must be byte-identical across turns to ride the provider KV
+  // cache, so the cards are frozen here (lane invalidation at consolidation is
+  // the recompute point) instead of being re-read per turn. Capability slugs
+  // render their capability content; disk pages render raw (frontmatter +
+  // body) so `kind: index` pages surface their `links:` map in the card TOC.
+  const prefixCards = new Map<Slug, string>();
+  for (const slug of [...coreSlugs, ...hotSlugs]) {
+    const raw = await capabilityOrDiskBody(
+      slug,
+      async (s) => (await loadPage(s))?.raw ?? "",
+    );
+    prefixCards.set(slug, renderCard(slug, raw));
+  }
+
   const edgeGraph = await buildEdgeGraph(pageIndex.entries, pageRaw, {
     hubDegree: config.memory.v3.edge.hubDegree,
   });
@@ -210,6 +230,7 @@ async function initLanes(config: AssistantConfig): Promise<ShadowLanes> {
     edgeGraph,
     coreSlugs,
     hotSlugs,
+    prefixCards,
   };
 }
 
@@ -374,6 +395,7 @@ export async function observeTurn(
       edgeGraph: lanes.edgeGraph,
       coreSlugs: lanes.coreSlugs,
       hotSlugs: lanes.hotSlugs,
+      prefixCards: lanes.prefixCards,
       needleK: v3.needleK,
       denseK: v3.denseK,
       edgeSeeds: v3.edge.seedCount,


### PR DESCRIPTION
## Summary
- Selector input renders in two segments: core+hot as full cards in a stable prefix (cache_control breakpoint), finder candidates as compact lines in the dynamic tail
- Candidates stay conversation-state-independent (no injected-page filtering — dedup happens at injection); numbered-id selection mapped over the concatenated numbering
- Carry-aware generous selector prompt (production v2 calibration: ~26 net-new/turn; no stinginess added)

Part of plan: memory-v3-cache-aware-carry.md (PR 6 of 11)