### PR TITLE
feat(assistant): migrate materialized built-in profiles to profileOverrides

### DIFF
--- a/assistant/src/__tests__/workspace-migration-098-collapse-builtin-profiles.test.ts
+++ b/assistant/src/__tests__/workspace-migration-098-collapse-builtin-profiles.test.ts
@@ -1,0 +1,355 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { collapseBuiltinProfilesToOverridesMigration } from "../workspace/migrations/098-collapse-builtin-profiles-to-overrides.js";
+
+let workspaceDir: string;
+
+function freshWorkspace(): void {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-098-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+}
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(data, null, 2) + "\n",
+  );
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(workspaceDir, "config.json"), "utf-8"));
+}
+
+function readLlm(): Record<string, unknown> {
+  return readConfig().llm as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  freshWorkspace();
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+describe("098-collapse-builtin-profiles-to-overrides migration", () => {
+  test("has correct migration id", () => {
+    expect(collapseBuiltinProfilesToOverridesMigration.id).toBe(
+      "098-collapse-builtin-profiles-to-overrides",
+    );
+  });
+
+  test("drifted entry: custom label + disabled status lift into overrides, entry deleted, drifted model dropped", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          balanced: {
+            provider: "anthropic",
+            provider_connection: "anthropic-managed",
+            model: "claude-assistant-modified-model",
+            maxTokens: 999,
+            effort: "high",
+            thinking: { enabled: true, streamThinking: true },
+            source: "managed",
+            label: "My Balanced",
+            status: "disabled",
+          },
+        },
+        activeProfile: "balanced",
+      },
+    });
+
+    collapseBuiltinProfilesToOverridesMigration.run(workspaceDir);
+
+    const llm = readLlm();
+    const profiles = llm.profiles as Record<string, unknown>;
+    const overrides = llm.profileOverrides as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect("balanced" in profiles).toBe(false);
+    expect(overrides.balanced).toEqual({
+      label: "My Balanced",
+      status: "disabled",
+    });
+    // Drift is dropped, not preserved anywhere.
+    expect(JSON.stringify(readConfig())).not.toContain(
+      "claude-assistant-modified-model",
+    );
+  });
+
+  test("collapses every built-in name, including auto and balanced-economy", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          auto: { source: "managed", label: "Auto" },
+          balanced: { source: "managed", label: "Balanced" },
+          "quality-optimized": { source: "managed", label: "Quality" },
+          "cost-optimized": { source: "managed", label: "Speed" },
+          "balanced-economy": {
+            source: "managed",
+            label: "Balanced Economy",
+          },
+        },
+      },
+    });
+
+    collapseBuiltinProfilesToOverridesMigration.run(workspaceDir);
+
+    const llm = readLlm();
+    expect(llm.profiles).toEqual({});
+    // All labels were seed defaults — nothing to lift, no override store.
+    expect(llm.profileOverrides).toBeUndefined();
+  });
+
+  test("seed-default bare labels are NOT lifted", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          balanced: { source: "managed", label: "Balanced" },
+          "cost-optimized": {
+            source: "managed",
+            label: "Speed",
+            status: "disabled",
+          },
+        },
+      },
+    });
+
+    collapseBuiltinProfilesToOverridesMigration.run(workspaceDir);
+
+    const llm = readLlm();
+    const overrides = llm.profileOverrides as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect(llm.profiles).toEqual({});
+    // balanced had only a seed-default label — no override entry at all.
+    expect(overrides.balanced).toBeUndefined();
+    // cost-optimized lifts only the status; the seed-default label is dropped.
+    expect(overrides["cost-optimized"]).toEqual({ status: "disabled" });
+  });
+
+  test("BYOK-suffixed seed-default labels are NOT lifted", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          balanced: { source: "managed", label: "Balanced (Managed)" },
+          "quality-optimized": {
+            source: "managed",
+            label: "Quality (Managed)",
+          },
+          "cost-optimized": { source: "managed", label: "Speed (Managed)" },
+          "balanced-economy": {
+            source: "managed",
+            label: "Balanced Economy (Managed)",
+          },
+        },
+      },
+    });
+
+    collapseBuiltinProfilesToOverridesMigration.run(workspaceDir);
+
+    const llm = readLlm();
+    expect(llm.profiles).toEqual({});
+    expect(llm.profileOverrides).toBeUndefined();
+  });
+
+  test("explicit label: null lifts as null", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          balanced: { source: "managed", label: null },
+        },
+      },
+    });
+
+    collapseBuiltinProfilesToOverridesMigration.run(workspaceDir);
+
+    const overrides = readLlm().profileOverrides as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect("label" in overrides.balanced!).toBe(true);
+    expect(overrides.balanced!.label).toBeNull();
+  });
+
+  test("explicit status: null lifts as null", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          balanced: { source: "managed", status: null },
+        },
+      },
+    });
+
+    collapseBuiltinProfilesToOverridesMigration.run(workspaceDir);
+
+    const overrides = readLlm().profileOverrides as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect("status" in overrides.balanced!).toBe(true);
+    expect(overrides.balanced!.status).toBeNull();
+  });
+
+  test("never clobbers a pre-existing profileOverrides key", () => {
+    // The PUT route may have written overrides before the migration ran.
+    writeConfig({
+      llm: {
+        profiles: {
+          balanced: {
+            source: "managed",
+            label: "Stale Rename",
+            status: "disabled",
+          },
+          "quality-optimized": {
+            source: "managed",
+            label: "Stale Quality Rename",
+          },
+        },
+        profileOverrides: {
+          balanced: { label: "Route Rename" },
+        },
+      },
+    });
+
+    collapseBuiltinProfilesToOverridesMigration.run(workspaceDir);
+
+    const overrides = readLlm().profileOverrides as Record<
+      string,
+      Record<string, unknown>
+    >;
+    // Existing label key survives; the stale status still lifts alongside it.
+    expect(overrides.balanced).toEqual({
+      label: "Route Rename",
+      status: "disabled",
+    });
+    // Profiles without a pre-existing override lift normally.
+    expect(overrides["quality-optimized"]).toEqual({
+      label: "Stale Quality Rename",
+    });
+  });
+
+  test("is idempotent — second run produces no further changes", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          balanced: {
+            source: "managed",
+            label: "My Balanced",
+            status: "disabled",
+          },
+        },
+      },
+    });
+
+    collapseBuiltinProfilesToOverridesMigration.run(workspaceDir);
+    const afterFirst = readFileSync(join(workspaceDir, "config.json"), "utf-8");
+
+    collapseBuiltinProfilesToOverridesMigration.run(workspaceDir);
+    const afterSecond = readFileSync(
+      join(workspaceDir, "config.json"),
+      "utf-8",
+    );
+
+    expect(afterSecond).toBe(afterFirst);
+  });
+
+  test("config with no built-in entries is untouched — no spurious write", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          "my-custom": { provider: "anthropic", model: "claude-opus-4-8" },
+        },
+        activeProfile: "my-custom",
+      },
+    });
+    const before = readFileSync(join(workspaceDir, "config.json"), "utf-8");
+
+    collapseBuiltinProfilesToOverridesMigration.run(workspaceDir);
+
+    const after = readFileSync(join(workspaceDir, "config.json"), "utf-8");
+    expect(after).toBe(before);
+  });
+
+  test("custom (non-built-in) profiles are untouched while built-ins collapse", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          balanced: { source: "managed", label: "Renamed" },
+          "my-custom": {
+            provider: "openai",
+            model: "gpt-5.4",
+            label: "Mine",
+            source: "user",
+          },
+        },
+      },
+    });
+
+    collapseBuiltinProfilesToOverridesMigration.run(workspaceDir);
+
+    const llm = readLlm();
+    const profiles = llm.profiles as Record<string, unknown>;
+    expect(profiles["my-custom"]).toEqual({
+      provider: "openai",
+      model: "gpt-5.4",
+      label: "Mine",
+      source: "user",
+    });
+    expect("balanced" in profiles).toBe(false);
+  });
+
+  test("profileOrder is left untouched", () => {
+    const order = ["auto", "balanced", "balanced-economy", "my-custom"];
+    writeConfig({
+      llm: {
+        profiles: {
+          balanced: { source: "managed" },
+        },
+        profileOrder: order,
+      },
+    });
+
+    collapseBuiltinProfilesToOverridesMigration.run(workspaceDir);
+
+    expect(readLlm().profileOrder).toEqual(order);
+  });
+
+  test("no-op when config.json does not exist", () => {
+    collapseBuiltinProfilesToOverridesMigration.run(workspaceDir);
+    expect(existsSync(join(workspaceDir, "config.json"))).toBe(false);
+  });
+
+  test("no-op when llm.profiles is absent", () => {
+    writeConfig({ llm: { default: { provider: "anthropic" } } });
+    const before = readFileSync(join(workspaceDir, "config.json"), "utf-8");
+
+    collapseBuiltinProfilesToOverridesMigration.run(workspaceDir);
+
+    const after = readFileSync(join(workspaceDir, "config.json"), "utf-8");
+    expect(after).toBe(before);
+  });
+
+  test("ignores malformed config.json without throwing", () => {
+    writeFileSync(join(workspaceDir, "config.json"), "{ not valid json");
+    expect(() =>
+      collapseBuiltinProfilesToOverridesMigration.run(workspaceDir),
+    ).not.toThrow();
+  });
+});

--- a/assistant/src/workspace/migrations/098-collapse-builtin-profiles-to-overrides.ts
+++ b/assistant/src/workspace/migrations/098-collapse-builtin-profiles-to-overrides.ts
@@ -1,0 +1,188 @@
+/**
+ * Workspace migration `098-collapse-builtin-profiles-to-overrides`.
+ *
+ * Built-in inference profiles (`auto`, `balanced`, `quality-optimized`,
+ * `cost-optimized`, `balanced-economy`) are now code-defined and merged into
+ * the effective config at load time. The legacy seeder (and migrations
+ * 052/082/097) materialized full entries for them under `llm.profiles`; the
+ * config loader keeps a transition-compat path that treats label/status on
+ * those stale entries as low-precedence overrides.
+ *
+ * This migration collapses the stale materialized entries so the
+ * transition-compat path becomes a no-op for migrated installs:
+ *
+ *   - `status`: lifted into `llm.profileOverrides[name].status` whenever the
+ *     key is present on the entry (an explicit `null` lifts as `null`).
+ *   - `label`: lifted only when the key is present AND the value is not a
+ *     seed-default label for that profile (bare or `" (Managed)"`-suffixed).
+ *     Seed-default-equal labels are seed artifacts — dropped so future
+ *     template relabels propagate. An explicit `null` lifts as `null`.
+ *   - Pre-existing `llm.profileOverrides[name]` fields are never overwritten
+ *     (write routes may have landed overrides before this migration runs).
+ *   - The entry is deleted from `llm.profiles`. Drifted config fields
+ *     (provider/model/maxTokens/thinking/...) are NOT preserved — only
+ *     relabel + enablement survive (product decision). A structured warning
+ *     lists the dropped keys per profile so drifted installs are diagnosable.
+ *
+ * `llm.profileOrder` is left untouched — built-in names there remain valid.
+ * Idempotent: a second run finds no built-in entries and does not write.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { getLogger } from "../../util/logger.js";
+import type { WorkspaceMigration } from "./types.js";
+
+const log = getLogger(
+  "workspace-migration-098-collapse-builtin-profiles-to-overrides",
+);
+
+/**
+ * Built-in profile names and their seed-default labels (bare template label
+ * plus the `" (Managed)"`-suffixed form the BYOK-era seeder wrote; `auto`
+ * never had a suffixed variant). Duplicated from
+ * `config/builtin-inference-profiles.ts` intentionally — migrations are
+ * forward-only and self-contained per the workspace migrations AGENTS
+ * contract; future template relabels must NOT retroactively change what this
+ * migration treats as a seed artifact.
+ */
+const SEED_DEFAULT_LABELS: Record<string, readonly string[]> = {
+  auto: ["Auto"],
+  balanced: ["Balanced", "Balanced (Managed)"],
+  "quality-optimized": ["Quality", "Quality (Managed)"],
+  "cost-optimized": ["Speed", "Speed (Managed)"],
+  "balanced-economy": ["Balanced Economy", "Balanced Economy (Managed)"],
+};
+
+const BUILTIN_PROFILE_NAMES = Object.keys(SEED_DEFAULT_LABELS);
+
+/**
+ * Entry keys that are either lifted (label/status) or pure seeder metadata
+ * (source/description). Anything else on a materialized entry is config
+ * drift and gets dropped with a warning.
+ */
+const NON_DRIFT_KEYS = new Set(["label", "status", "source", "description"]);
+
+/** Valid `ProfileOverrideEntry.status` values (schema: active|disabled|null). */
+const VALID_STATUSES = new Set<unknown>(["active", "disabled", null]);
+
+export const collapseBuiltinProfilesToOverridesMigration: WorkspaceMigration = {
+  id: "098-collapse-builtin-profiles-to-overrides",
+  description:
+    "Collapse materialized built-in inference profiles into llm.profileOverrides",
+
+  run(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) {
+      return;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(readFileSync(configPath, "utf-8"));
+    } catch (err) {
+      log.warn(
+        { err, path: configPath },
+        "Failed to read or parse config.json; skipping migration",
+      );
+      return;
+    }
+
+    const config = readObject(parsed);
+    if (!config) return;
+
+    const llm = readObject(config.llm);
+    if (!llm) return;
+
+    const profiles = readObject(llm.profiles);
+    if (!profiles) return;
+
+    const overrides = readObject(llm.profileOverrides) ?? {};
+
+    let changed = false;
+
+    for (const name of BUILTIN_PROFILE_NAMES) {
+      if (!(name in profiles)) continue;
+
+      const entry = readObject(profiles[name]);
+      if (entry) {
+        const existing = readObject(overrides[name]);
+        const override = existing ?? {};
+
+        if (
+          "status" in entry &&
+          !("status" in override) &&
+          VALID_STATUSES.has(entry.status)
+        ) {
+          override.status = entry.status;
+        }
+
+        if ("label" in entry && !("label" in override)) {
+          const label = entry.label;
+          if (label === null) {
+            override.label = null;
+          } else if (
+            typeof label === "string" &&
+            label.length > 0 &&
+            !SEED_DEFAULT_LABELS[name]!.includes(label)
+          ) {
+            override.label = label;
+          }
+        }
+
+        if (!existing && Object.keys(override).length > 0) {
+          overrides[name] = override;
+        }
+
+        const droppedKeys = Object.keys(entry).filter(
+          (key) => !NON_DRIFT_KEYS.has(key),
+        );
+        if (droppedKeys.length > 0) {
+          log.warn(
+            { profile: name, droppedKeys },
+            "Dropped config fields from materialized built-in profile while collapsing to profileOverrides; built-in templates are now authoritative",
+          );
+        }
+      }
+
+      delete profiles[name];
+      changed = true;
+    }
+
+    if (!changed) return;
+
+    if (Object.keys(overrides).length > 0) {
+      llm.profileOverrides = overrides;
+    }
+
+    try {
+      writeFileSync(
+        configPath,
+        JSON.stringify(config, null, 2) + "\n",
+        "utf-8",
+      );
+      log.info(
+        { path: configPath },
+        "Collapsed materialized built-in profiles into llm.profileOverrides",
+      );
+    } catch (err) {
+      log.warn(
+        { err, path: configPath },
+        "Failed to write collapsed config.json; leaving prior file in place",
+      );
+    }
+  },
+
+  down(_workspaceDir: string): void {
+    // Forward-only: re-materializing built-in entries would resurrect the
+    // transition-compat ambiguity this migration exists to remove.
+  },
+};
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -95,6 +95,7 @@ import { seedAvatarManifestMigration } from "./094-seed-avatar-manifest.js";
 import { bumpHeartbeatInterval30mTo60mMigration } from "./095-bump-heartbeat-interval-30m-to-60m.js";
 import { reduceQualityProfileEffortMigration } from "./096-reduce-quality-profile-effort.js";
 import { enableAdaptiveThinkingManagedProfilesMigration } from "./097-enable-adaptive-thinking-managed-profiles.js";
+import { collapseBuiltinProfilesToOverridesMigration } from "./098-collapse-builtin-profiles-to-overrides.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -201,4 +202,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   bumpHeartbeatInterval30mTo60mMigration,
   reduceQualityProfileEffortMigration,
   enableAdaptiveThinkingManagedProfilesMigration,
+  collapseBuiltinProfilesToOverridesMigration,
 ];


### PR DESCRIPTION
## Summary
- Workspace migration 098 collapses legacy materialized built-in profile entries in config.json into sparse llm.profileOverrides
- User relabels (non-seed-default) and status toggles survive; drifted fields (model/provider/etc.) are dropped with a structured warning
- Idempotent, forward-only; profileOrder untouched; pre-existing overrides never clobbered

Part of plan: builtin-llm-profiles.md (PR 7 of 8)