### PR TITLE
feat(memory-v3): frozen net-new card injection + ephemeral section spotlight

### DIFF
--- a/assistant/src/__tests__/conversation-lifecycle.test.ts
+++ b/assistant/src/__tests__/conversation-lifecycle.test.ts
@@ -346,6 +346,91 @@ describe("loadFromDb metadata injection rehydration", () => {
     expect(firstBlock.text.match(/<memory>/g)?.length).toBe(1);
   });
 
+  test("memoryV3InjectedBlock rehydrates wrapped on ALL rows (tail included)", async () => {
+    // The memory-v3 frozen card block persists UNWRAPPED under its own key and
+    // must come back wrapped on every row — including the tail, since the next
+    // turn injects only NET-NEW cards (deduped via the v3 store) and never
+    // re-renders this row's cards.
+    mockConversation = defaultConv();
+    mockDbMessages = [
+      {
+        id: "m1",
+        role: "user",
+        content: JSON.stringify([{ type: "text", text: "First turn" }]),
+        metadata: JSON.stringify({
+          memoryV3InjectedBlock:
+            "header line\n\n# memory/concepts/page-a.md\nhead a",
+        }),
+      },
+      {
+        id: "m2",
+        role: "assistant",
+        content: JSON.stringify([{ type: "text", text: "Reply" }]),
+      },
+      {
+        id: "m3",
+        role: "user",
+        content: JSON.stringify([{ type: "text", text: "Tail turn" }]),
+        metadata: JSON.stringify({
+          memoryV3InjectedBlock: "# memory/concepts/page-b.md\nhead b",
+        }),
+      },
+    ];
+
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+    const messages = conversation.getMessages();
+
+    expect(messages).toHaveLength(3);
+    expect(messages[0].content).toEqual([
+      {
+        type: "text",
+        text: "<memory>\nheader line\n\n# memory/concepts/page-a.md\nhead a\n</memory>",
+      },
+      { type: "text", text: "First turn" },
+    ]);
+    // Tail row rehydrates too (unlike turn_context / system_reminder).
+    expect(messages[2].content).toEqual([
+      {
+        type: "text",
+        text: "<memory>\n# memory/concepts/page-b.md\nhead b\n</memory>",
+      },
+      { type: "text", text: "Tail turn" },
+    ]);
+  });
+
+  test("defensively-wrapped memoryV3InjectedBlock rehydrates singly-wrapped", async () => {
+    mockConversation = defaultConv();
+    mockDbMessages = [
+      {
+        id: "m1",
+        role: "user",
+        content: JSON.stringify([{ type: "text", text: "Hi" }]),
+        metadata: JSON.stringify({
+          memoryV3InjectedBlock:
+            "<memory>\n# memory/concepts/page-a.md\nhead a\n</memory>",
+        }),
+      },
+      {
+        id: "m2",
+        role: "assistant",
+        content: JSON.stringify([{ type: "text", text: "Hello" }]),
+      },
+    ];
+
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+    const messages = conversation.getMessages();
+
+    const firstBlock = messages[0].content[0];
+    expect(firstBlock).toEqual({
+      type: "text",
+      text: "<memory>\n# memory/concepts/page-a.md\nhead a\n</memory>",
+    });
+    if (firstBlock.type !== "text") throw new Error("unexpected block type");
+    expect(firstBlock.text.match(/<memory>/g)?.length).toBe(1);
+  });
+
   test("malformed metadata is tolerated: load does not throw, content unchanged", async () => {
     mockConversation = defaultConv();
     mockDbMessages = [

--- a/assistant/src/__tests__/injector-chain.test.ts
+++ b/assistant/src/__tests__/injector-chain.test.ts
@@ -342,16 +342,17 @@ describe("injector chain", () => {
     expect(byName.get("thread-focus")).toBe(DEFAULT_INJECTOR_ORDER.threadFocus);
   });
 
-  test("the injector chain sorts the defaults plus memory-v3 by ascending order", () => {
-    // The assembled chain merges the defaults with the memory-v3 injector and
-    // sorts by `order`, so memory-v3 (order 1000) sits last.
+  test("the injector chain sorts the defaults plus the memory-v3 injectors by ascending order", () => {
+    // The assembled chain merges the defaults with the two memory-v3
+    // injectors and sorts by `order`, so the cards injector (order 1000) and
+    // the spotlight injector (order 1001) sit last, in that order.
     const chain = getInjectorChain();
     const orders = chain.map((i) => i.order);
     expect(orders).toEqual([...orders].sort((a, b) => a - b));
-    expect(chain[chain.length - 1]?.name).toBe("memory-v3-shadow");
     expect(chain.map((i) => i.name)).toEqual([
       ...defaultInjectors.map((i) => i.name),
       "memory-v3-shadow",
+      "memory-v3-spotlight",
     ]);
   });
 

--- a/assistant/src/__tests__/injector-v3-suppression.test.ts
+++ b/assistant/src/__tests__/injector-v3-suppression.test.ts
@@ -1,23 +1,30 @@
 /**
- * Tests for the memory-v3-live v2-suppression branch in
- * `applyRuntimeInjections`.
+ * Tests for the memory-v3 step-0 branch in `applyRuntimeInjections`:
+ * spotlight strip + v2 tail suppression.
  *
  * When the `memory-v3-live` flag is on AND the v3 injector (id `memory-v3`,
- * placement `after-memory-prefix`) actually produces a block, runtime
- * assembly strips the v2 `<memory>` prefix from EVERY user message before
- * splicing the v3 block — so v3 becomes the sole `<memory>` source and history
- * is byte-stable for prompt caching.
+ * placement `after-memory-prefix`) produces a block — possibly EMPTY-TEXT on
+ * an all-repeat turn — runtime assembly strips the v2 `<memory>` prefix from
+ * the TAIL user message only before splicing the v3 block. Historical user
+ * messages keep their memory blocks byte-identical (frozen v3 cards and
+ * pre-cutover v2 blocks both ride the cached prefix); the old whole-layer
+ * strip is gone.
  *
- * Keyed off whether v3 produced a block, NOT off the flag alone: a v3
- * failure (`produce()` → null) leaves v2's block intact (fallback-to-v2).
+ * The ephemeral `<memory_spotlight>` block is strip-and-replaced every turn:
+ * stale spotlights are removed from every user message unconditionally (a
+ * scoped, single-id strip), and the spotlight injector's `append-user-tail`
+ * block lands at the tail.
  *
- * The flag-off path must be byte-for-byte identical to today — that is the
- * load-bearing regression guard. `applyRuntimeInjections` reads the flag
- * itself, so these tests drive it through the override cache.
+ * v2 suppression stays keyed off whether v3 produced a block, NOT off the
+ * flag alone: a v3 failure (`produce()` → null) leaves v2's block intact
+ * (fallback-to-v2). The flag-off path must be byte-for-byte identical to
+ * today — that is the load-bearing regression guard. `applyRuntimeInjections`
+ * reads the flag itself, so these tests drive it through the override cache.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { wrapMemorySpotlightBlock } from "../memory/memory-marker.js";
 import type {
   InjectionBlock,
   Injector,
@@ -28,7 +35,7 @@ import { setOverridesForTesting } from "./feature-flag-test-helpers.js";
 
 // Drive the suppression branch by controlling the static injector chain that
 // `applyRuntimeInjections` walks. The slot is mutated per-test to stand in for
-// the memory-v3 injector producing (or not producing) a block.
+// the memory-v3 injectors producing (or not producing) blocks.
 const injectorChainSlot: Injector[] = [];
 mock.module("../plugins/defaults/memory-retrieval/injector-chain.js", () => ({
   getInjectorChain: () => injectorChainSlot,
@@ -47,10 +54,11 @@ function makeTurnContext(): TurnContext {
 }
 
 /**
- * A fake v3 injector that mirrors the real one's id + placement. The real
- * injector's `renderMemoryBlock` already wraps its content in
- * `<memory>\n…\n</memory>`, so the fake does too — `inner === null` means the
- * injector produced nothing this turn (error/empty selection).
+ * A fake v3 cards injector that mirrors the real one's id + placement. The
+ * real injector wraps its content in `<memory>\n…\n</memory>`, so the fake
+ * does too. `inner === null` means the injector produced nothing this turn
+ * (error/empty selection); `inner === ""` mirrors an all-repeat turn (block
+ * produced, empty text — nothing attached, but v2 is still suppressed).
  */
 function v3Injector(inner: string | null): Injector {
   return {
@@ -60,8 +68,23 @@ function v3Injector(inner: string | null): Injector {
       if (inner === null) return null;
       return {
         id: "memory-v3",
-        text: `<memory>\n${inner}\n</memory>`,
+        text: inner === "" ? "" : `<memory>\n${inner}\n</memory>`,
         placement: "after-memory-prefix",
+      };
+    },
+  };
+}
+
+/** A fake v3 spotlight injector mirroring the real id + tail placement. */
+function spotlightInjector(inner: string): Injector {
+  return {
+    name: "memory-v3-spotlight",
+    order: 1001,
+    async produce(): Promise<InjectionBlock | null> {
+      return {
+        id: "memory-v3-spotlight",
+        text: wrapMemorySpotlightBlock(inner),
+        placement: "append-user-tail",
       };
     },
   };
@@ -94,14 +117,19 @@ describe("memory-v3-live v2 suppression", () => {
     setOverridesForTesting({});
   });
 
-  test("flag ON + v3 produced a block → v2 stripped from all turns, exactly one <memory> (the v3 block)", async () => {
+  test("flag ON + v3 produced a block → TAIL v2 stripped, historical memory blocks frozen in place", async () => {
     setOverridesForTesting({ "memory-v3-live": true });
-    injectorChainSlot.push(v3Injector("v3 working set"));
+    injectorChainSlot.push(v3Injector("net-new cards"));
 
-    // History: a prior user turn that still carries a v2 block (rehydrated),
-    // plus the current tail user turn with its own v2 block.
+    // History: a prior user turn carrying a frozen memory block (a v3 card
+    // block or a pre-cutover v2 block — same wrapper), plus the current tail
+    // user turn with v2's freshly-prepended block.
+    const historicalUser = userMsgWithV2Memory(
+      "frozen card from turn 1",
+      "earlier question",
+    );
     const runMessages: Message[] = [
-      userMsgWithV2Memory("old recalled fact", "earlier question"),
+      historicalUser,
       {
         role: "assistant",
         content: [{ type: "text", text: "earlier answer" }],
@@ -113,31 +141,79 @@ describe("memory-v3-live v2 suppression", () => {
       ...makeTurnContext(),
     });
 
-    // Exactly one <memory> source across the WHOLE assembled context.
-    const allTexts = result.messages.flatMap((m) =>
-      m.content
-        .filter((b): b is { type: "text"; text: string } => b.type === "text")
-        .map((b) => b.text),
-    );
-    const memoryBlocks = allTexts.filter((t) => t.startsWith("<memory>"));
-    expect(memoryBlocks).toHaveLength(1);
-    // And it is the v3 block, not a v2 one.
-    expect(memoryBlocks[0]).toBe("<memory>\nv3 working set\n</memory>");
+    // The HISTORICAL user turn keeps its memory block byte-identical — the
+    // frozen-card cache contract (no whole-layer strip).
+    expect(result.messages[0].content).toEqual(historicalUser.content);
 
-    // The historical user turn no longer carries its v2 block (all-turns strip).
-    const firstUser = result.messages[0];
-    expect(
-      firstUser.content.every(
-        (b) => !(b.type === "text" && b.text.startsWith("<memory>")),
-      ),
-    ).toBe(true);
-
-    // The v3 block lands at the head of the tail user message; original user
+    // The tail's fresh v2 block is replaced by the v3 block; original user
     // text is preserved right after it.
     const texts = tailTexts(result.messages);
-    expect(texts[0]).toBe("<memory>\nv3 working set\n</memory>");
+    expect(texts[0]).toBe("<memory>\nnet-new cards\n</memory>");
     expect(texts[1]).toBe("current question");
     expect(texts).toHaveLength(2);
+
+    // The v3 block is captured for metadata persistence (UNWRAPPED) and the
+    // turn is marked v3-active so the hook skips v2's metadata write.
+    expect(result.blocks.memoryV3InjectedBlock).toBe("net-new cards");
+    expect(result.blocks.memoryV3Active).toBe(true);
+  });
+
+  test("flag ON + EMPTY-TEXT v3 block (all-repeat turn) → tail v2 stripped, nothing attached", async () => {
+    setOverridesForTesting({ "memory-v3-live": true });
+    injectorChainSlot.push(v3Injector(""));
+
+    const runMessages: Message[] = [
+      userMsgWithV2Memory("fresh recalled fact", "current question"),
+    ];
+
+    const result = await applyRuntimeInjections(runMessages, {
+      ...makeTurnContext(),
+    });
+
+    // v2's fresh block is gone and NO v3 content replaced it — the frozen
+    // cards from prior turns already carry the memory.
+    const texts = tailTexts(result.messages);
+    expect(texts).toEqual(["current question"]);
+    // No bytes to persist, but the turn is still v3-active (gates v2's
+    // metadata write so the stripped block is not rehydrated on reload).
+    expect(result.blocks.memoryV3InjectedBlock).toBeUndefined();
+    expect(result.blocks.memoryV3Active).toBe(true);
+  });
+
+  test("stale spotlight blocks are stripped from EVERY user message; the new spotlight lands at the tail", async () => {
+    setOverridesForTesting({ "memory-v3-live": true });
+    injectorChainSlot.push(v3Injector(""), spotlightInjector("fresh sections"));
+
+    const staleSpotlight = {
+      type: "text" as const,
+      text: wrapMemorySpotlightBlock("stale sections"),
+    };
+    const runMessages: Message[] = [
+      {
+        role: "user",
+        content: [{ type: "text", text: "earlier question" }, staleSpotlight],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "earlier answer" }],
+      },
+      { role: "user", content: [{ type: "text", text: "current question" }] },
+    ];
+
+    const result = await applyRuntimeInjections(runMessages, {
+      ...makeTurnContext(),
+    });
+
+    // The stale spotlight is gone from the historical turn…
+    expect(result.messages[0].content).toEqual([
+      { type: "text", text: "earlier question" },
+    ]);
+    // …and exactly one fresh spotlight sits at the tail.
+    const texts = tailTexts(result.messages);
+    expect(texts).toEqual([
+      "current question",
+      wrapMemorySpotlightBlock("fresh sections"),
+    ]);
   });
 
   test("flag ON but v3 produced NOTHING → v2 block left intact (fallback-to-v2)", async () => {
@@ -158,10 +234,11 @@ describe("memory-v3-live v2 suppression", () => {
     expect(texts[1]).toBe("current question");
     // No v3 block was added.
     expect(texts).toHaveLength(2);
+    expect(result.blocks.memoryV3Active).toBe(false);
   });
 
   test("flag OFF → byte-for-byte identical to today even when v3 would have produced a block", async () => {
-    injectorChainSlot.push(v3Injector("v3 working set"));
+    injectorChainSlot.push(v3Injector("v3 cards"));
 
     const runMessages: Message[] = [
       userMsgWithV2Memory("old recalled fact", "earlier question"),
@@ -185,14 +262,15 @@ describe("memory-v3-live v2 suppression", () => {
     // behavior change and it is fully gated off here.
     const texts = tailTexts(offResult.messages);
     expect(texts[0]).toBe("<memory>\nfresh recalled fact\n</memory>");
-    expect(texts[1]).toBe("<memory>\nv3 working set\n</memory>");
+    expect(texts[1]).toBe("<memory>\nv3 cards\n</memory>");
     expect(texts[2]).toBe("current question");
 
-    // Historical user turn keeps its v2 block (no all-turns strip when off).
+    // Historical user turn keeps its v2 block.
     const firstUserTexts = offResult.messages[0].content
       .filter((b): b is { type: "text"; text: string } => b.type === "text")
       .map((b) => b.text);
     expect(firstUserTexts[0]).toBe("<memory>\nold recalled fact\n</memory>");
+    expect(offResult.blocks.memoryV3Active).toBe(false);
   });
 
   test("no v3 injector registered + flag ON → no stripping, messages untouched", async () => {

--- a/assistant/src/__tests__/memory-retrieval-hook.test.ts
+++ b/assistant/src/__tests__/memory-retrieval-hook.test.ts
@@ -341,6 +341,54 @@ describe("user-prompt-submit hook (memory retrieval)", () => {
     expect(emitted.type).toBe("memory_recalled");
   });
 
+  test("memory-v3 active → skips v2's memoryInjectedBlock and persists the v3 card block", async () => {
+    // Assembly reports memoryV3Active when v3 superseded (stripped) v2's tail
+    // block this turn — persisting v2's bytes would rehydrate a block that is
+    // not in the live history.
+    const { memory } = makeFakeGraphMemory({
+      injectedBlockText: "v2-block-superseded",
+      metrics: makeMetrics(),
+    });
+    installConversation(memory, { trusted: true });
+    applyRuntimeInjectionsMock.mockImplementationOnce(
+      async (messages: unknown) => ({
+        messages,
+        blocks: {
+          memoryV3Active: true,
+          memoryV3InjectedBlock: "header\n\n# memory/concepts/page-a.md\nhead",
+        },
+      }),
+    );
+    const ctx = makeHookCtx({ userMessageId: "msg-43" });
+
+    await userPromptSubmitMemoryRetrieval(ctx);
+
+    expect(updateMessageMetadataMock).toHaveBeenCalledWith("msg-43", {
+      memoryV3InjectedBlock: "header\n\n# memory/concepts/page-a.md\nhead",
+    });
+  });
+
+  test("memory-v3 active with EMPTY net-new → no memory metadata persisted at all", async () => {
+    // All-repeat turn: v2 was stripped (superseded) and v3 attached nothing
+    // new — the row must rehydrate with no memory block, matching live state.
+    const { memory } = makeFakeGraphMemory({
+      injectedBlockText: "v2-block-superseded",
+      metrics: makeMetrics(),
+    });
+    installConversation(memory, { trusted: true });
+    applyRuntimeInjectionsMock.mockImplementationOnce(
+      async (messages: unknown) => ({
+        messages,
+        blocks: { memoryV3Active: true },
+      }),
+    );
+    const ctx = makeHookCtx();
+
+    await userPromptSubmitMemoryRetrieval(ctx);
+
+    expect(updateMessageMetadataMock).not.toHaveBeenCalled();
+  });
+
   test("skips metadata persist when no block text is injected", async () => {
     const { memory } = makeFakeGraphMemory({ injectedBlockText: null });
     installConversation(memory, { trusted: true });

--- a/assistant/src/__tests__/strip-memory-injections.test.ts
+++ b/assistant/src/__tests__/strip-memory-injections.test.ts
@@ -1,9 +1,8 @@
 import { describe, expect, test } from "bun:test";
 
-import {
-  stripAllMemoryInjections,
-  stripExistingMemoryInjections,
-} from "../memory/graph/conversation-graph-memory.js";
+import { stripSpotlightInjections } from "../context/strip-injections.js";
+import { stripExistingMemoryInjections } from "../memory/graph/conversation-graph-memory.js";
+import { wrapMemorySpotlightBlock } from "../memory/memory-marker.js";
 import type { ContentBlock, Message } from "../providers/types.js";
 
 // ---------------------------------------------------------------------------
@@ -204,8 +203,8 @@ describe("stripExistingMemoryInjections", () => {
     expect(result[0].content).toEqual([textBlock("hello")]);
   });
 
-  // Regression guard: the v2 helper must remain last-message-only even after
-  // the shared per-message strip is extracted for stripAllMemoryInjections.
+  // Regression guard: the helper must remain last-message-only — memory-v3's
+  // frozen-card carry depends on historical `<memory>` blocks staying intact.
   test("strips ONLY the last user message, leaving earlier ones injected", () => {
     const messages = [
       userMsg(memoryTextBlock, textBlock("first")),
@@ -221,55 +220,50 @@ describe("stripExistingMemoryInjections", () => {
 });
 
 // ---------------------------------------------------------------------------
-// stripAllMemoryInjections — removes memory-injected blocks from EVERY user
-// message (memory-v3 live mode). Reuses the same per-message strip logic.
+// stripSpotlightInjections — the memory-v3 ephemeral spotlight is the ONLY
+// block strip-and-replaced across every user message each turn. Frozen
+// `<memory>` card blocks must never be touched by it (the cache contract);
+// the old whole-layer stripAllMemoryInjections replace is gone.
 // ---------------------------------------------------------------------------
 
-describe("stripAllMemoryInjections", () => {
-  test("strips memory blocks from multiple historical user messages", () => {
+const spotlightBlock = (inner: string): ContentBlock => ({
+  type: "text",
+  text: wrapMemorySpotlightBlock(inner),
+});
+
+describe("stripSpotlightInjections", () => {
+  test("strips spotlight blocks from every user message, leaving <memory> blocks intact", () => {
     const messages = [
-      userMsg(memoryTextBlock, textBlock("first")),
+      userMsg(memoryTextBlock, textBlock("first"), spotlightBlock("s1")),
       assistantMsg("ok"),
-      userMsg(
-        memoryImageMarker,
-        memoryImage,
-        memoryImageClose,
-        memoryTextBlock,
-        textBlock("second"),
-      ),
-      assistantMsg("sure"),
-      userMsg(memoryTextBlock, textBlock("third")),
+      userMsg(memoryTextBlock, textBlock("second"), spotlightBlock("s2")),
     ];
-    const result = stripAllMemoryInjections(messages);
-    expect(result[0].content).toEqual([textBlock("first")]);
+    const result = stripSpotlightInjections(messages);
+    expect(result[0].content).toEqual([memoryTextBlock, textBlock("first")]);
     expect(result[1]).toBe(messages[1]); // assistant message untouched
-    expect(result[2].content).toEqual([textBlock("second")]);
-    expect(result[3]).toBe(messages[3]);
-    expect(result[4].content).toEqual([textBlock("third")]);
+    expect(result[2].content).toEqual([memoryTextBlock, textBlock("second")]);
   });
 
-  test("preserves non-memory content and user-attached images", () => {
-    const messages = [
-      userMsg(memoryTextBlock, imageBlock, textBlock("what is this?")),
-      userMsg(textBlock("plain message")),
-    ];
-    const result = stripAllMemoryInjections(messages);
-    expect(result[0].content).toEqual([imageBlock, textBlock("what is this?")]);
-    expect(result[1].content).toEqual([textBlock("plain message")]);
+  test("requires the full wrapper: user text merely starting with the tag survives", () => {
+    const lookalike = textBlock("<memory_spotlight>\nnot really a block");
+    const messages = [userMsg(lookalike, textBlock("hello"))];
+    const result = stripSpotlightInjections(messages);
+    expect(result[0].content).toEqual([lookalike, textBlock("hello")]);
   });
 
-  test("no-op (same reference) when no user message carries a memory block", () => {
+  test("content no-op when no spotlight blocks exist", () => {
     const messages = [
-      userMsg(textBlock("hello")),
+      userMsg(memoryTextBlock, textBlock("hello")),
       assistantMsg("hi"),
       userMsg(imageBlock),
     ];
-    const result = stripAllMemoryInjections(messages);
-    expect(result).toBe(messages);
+    const result = stripSpotlightInjections(messages);
+    expect(result).toEqual(messages);
+    // Untouched messages keep their identity (cheap no-op detection upstream).
+    expect(result[0]).toBe(messages[0]);
   });
 
   test("no-op for empty messages array", () => {
-    const result = stripAllMemoryInjections([]);
-    expect(result).toEqual([]);
+    expect(stripSpotlightInjections([])).toEqual([]);
   });
 });

--- a/assistant/src/config/schemas/__tests__/memory-v3.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v3.test.ts
@@ -8,10 +8,27 @@ describe("MemoryV3ConfigSchema", () => {
     expect(parsed).toEqual({
       workingSet: { maxPages: 150, evictWindow: 5 },
       hotSet: { k: 40, halfLifeDays: 14 },
+      spotlight: { n: 6, windowTurns: 2 },
       needleK: 100,
       denseK: 100,
       edge: { hubDegree: 30, seedCount: 18, perSeed: 6, cap: 45 },
     });
+  });
+
+  test("accepts a partial spotlight override and rejects invalid knobs", () => {
+    const parsed = MemoryV3ConfigSchema.parse({ spotlight: { n: 3 } });
+    expect(parsed.spotlight).toEqual({ n: 3, windowTurns: 2 });
+    // windowTurns: 0 is valid — current turn only, no carried window.
+    expect(
+      MemoryV3ConfigSchema.parse({ spotlight: { windowTurns: 0 } }).spotlight,
+    ).toEqual({ n: 6, windowTurns: 0 });
+    expect(() => MemoryV3ConfigSchema.parse({ spotlight: { n: 0 } })).toThrow();
+    expect(() =>
+      MemoryV3ConfigSchema.parse({ spotlight: { windowTurns: -1 } }),
+    ).toThrow();
+    expect(() =>
+      MemoryV3ConfigSchema.parse({ spotlight: { n: 1.5 } }),
+    ).toThrow();
   });
 
   test("accepts explicit lane-K overrides", () => {

--- a/assistant/src/config/schemas/memory-v3.ts
+++ b/assistant/src/config/schemas/memory-v3.ts
@@ -91,12 +91,45 @@ export const MemoryV3HotSetSchema = z
   })
   .describe("Memory v3 hot-set lane (decayed selection frequency) tuning.");
 
+/**
+ * Ephemeral section-spotlight tuning: how many of the current turn's selected
+ * finder hits render their matched section into the `<memory_spotlight>`
+ * block, and how many previous turns' spotlight entries are carried along
+ * before they age out. The block is strip-and-replaced every turn, so its
+ * size is bounded by `n × (windowTurns + 1)` entries.
+ */
+export const MemoryV3SpotlightSchema = z
+  .object({
+    n: z
+      .number({ error: "memory.v3.spotlight.n must be a number" })
+      .int("memory.v3.spotlight.n must be an integer")
+      .positive("memory.v3.spotlight.n must be a positive integer")
+      .default(6)
+      .describe(
+        "Number of the current turn's selected finder hits whose matched sections render into the spotlight block.",
+      ),
+    windowTurns: z
+      .number({ error: "memory.v3.spotlight.windowTurns must be a number" })
+      .int("memory.v3.spotlight.windowTurns must be an integer")
+      .nonnegative(
+        "memory.v3.spotlight.windowTurns must be a non-negative integer",
+      )
+      .default(2)
+      .describe(
+        "Number of previous turns whose spotlight entries are carried into the current block before aging out (0 = current turn only).",
+      ),
+  })
+  .describe("Memory v3 ephemeral section-spotlight tuning.");
+
 export const MemoryV3ConfigSchema = z
   .object({
     workingSet: MemoryV3WorkingSetSchema.default(
       MemoryV3WorkingSetSchema.parse({}),
     ),
     hotSet: MemoryV3HotSetSchema.default(MemoryV3HotSetSchema.parse({})),
+    spotlight: MemoryV3SpotlightSchema.default(
+      MemoryV3SpotlightSchema.parse({}),
+    ),
     needleK: z
       .number({ error: "memory.v3.needleK must be a number" })
       .int("memory.v3.needleK must be an integer")

--- a/assistant/src/context/strip-injections.ts
+++ b/assistant/src/context/strip-injections.ts
@@ -11,6 +11,10 @@
  * loop (which drives the compaction pipeline) and the compactor can call it
  * without reaching up into the daemon orchestrator.
  */
+import {
+  MEMORY_SPOTLIGHT_PREFIX,
+  MEMORY_SPOTLIGHT_SUFFIX,
+} from "../memory/memory-marker.js";
 import type { Message } from "../providers/types.js";
 
 /**
@@ -56,6 +60,28 @@ export function stripUserTextBlocksByPrefix(
     );
 }
 
+/**
+ * Full-wrapper matcher for the memory-v3 ephemeral `<memory_spotlight>` block.
+ * Shared by the per-turn scoped strip ({@link stripSpotlightInjections}) and
+ * the compaction pipeline below so both recognize exactly the same wrapper.
+ */
+const MEMORY_SPOTLIGHT_MATCHER: InjectionMatcher = {
+  prefix: MEMORY_SPOTLIGHT_PREFIX,
+  suffix: MEMORY_SPOTLIGHT_SUFFIX,
+};
+
+/**
+ * Remove memory-v3 `<memory_spotlight>` blocks from every user message — and
+ * ONLY those blocks. The spotlight is ephemeral by contract: runtime assembly
+ * strip-and-replaces it each turn (the previous turn's spotlight is stale),
+ * while the frozen `<memory>` card blocks stay byte-identical in history for
+ * prompt caching. This is deliberately a scoped, single-id strip — the old
+ * whole-layer `stripAllMemoryInjections` replace is gone.
+ */
+export function stripSpotlightInjections(messages: Message[]): Message[] {
+  return stripUserTextBlocksByPrefix(messages, [MEMORY_SPOTLIGHT_MATCHER]);
+}
+
 /** Matchers stripped by the pipeline (order doesn't matter — single pass). */
 const RUNTIME_INJECTION_PREFIXES: InjectionMatcher[] = [
   "<channel_capabilities>",
@@ -85,6 +111,11 @@ const RUNTIME_INJECTION_PREFIXES: InjectionMatcher[] = [
   // matches the full-wrapper requirement in `countMemoryPrefixBlocks`.
   { prefix: "<memory>\n", suffix: "\n</memory>" },
   { prefix: "<info>\n", suffix: "\n</info>" },
+  // The memory-v3 ephemeral spotlight block. Normally strip-and-replaced every
+  // turn by `stripSpotlightInjections`, but registered here too so compaction
+  // and overflow recovery remove a stale spotlight along with the rest of the
+  // runtime injections. Full-wrapper shape for the same reason as `<memory>`.
+  MEMORY_SPOTLIGHT_MATCHER,
   "<voice_call_control>",
   "<workspace_top_level>", // backward-compat: strip legacy workspace blocks
   // The `<workspace>` top-level block is stripped so each compaction re-injects

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -13,7 +13,10 @@ import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags
 import { resolveCallSiteConfig } from "../config/llm-resolver.js";
 import { getConfig } from "../config/loader.js";
 import type { LLMCallSite, LLMConfig } from "../config/schemas/llm.js";
-import { stripUserTextBlocksByPrefix } from "../context/strip-injections.js";
+import {
+  stripSpotlightInjections,
+  stripUserTextBlocksByPrefix,
+} from "../context/strip-injections.js";
 import { getDocumentsForConversation } from "../documents/document-store.js";
 import {
   getApp,
@@ -29,8 +32,9 @@ import { isBackgroundConversationType } from "../memory/conversation-types.js";
 import {
   countMemoryPrefixBlocks,
   extractMemoryPrefixBlocks,
-  stripAllMemoryInjections,
+  stripExistingMemoryInjections,
 } from "../memory/graph/conversation-graph-memory.js";
+import { unwrapMemoryBlock } from "../memory/memory-marker.js";
 import {
   readSlackMetadata,
   readSlackMetadataFromMessageMetadata,
@@ -1524,6 +1528,24 @@ export interface RuntimeInjectionBlocks {
   pkbContextBlock?: string;
   memoryV2StaticBlock?: string;
   /**
+   * UNWRAPPED inner text of the memory-v3 frozen net-new card block the v3
+   * injector attached this turn, mirroring v2's unwrapped `memoryInjectedBlock`
+   * contract (rehydration re-wraps on use). Undefined when v3 attached no new
+   * cards (all-repeat turn, v3 off, or v3 failure). Persisted by the
+   * user-prompt-submit hook under `metadata.memoryV3InjectedBlock`
+   * (`MEMORY_V3_INJECTED_BLOCK_METADATA_KEY`).
+   */
+  memoryV3InjectedBlock?: string;
+  /**
+   * True when memory-v3 superseded v2 as this turn's `<memory>` source — the
+   * `memory-v3-live` flag is on AND the v3 injector produced a block (possibly
+   * empty-text on an all-repeat turn), i.e. exactly when assembly stripped
+   * v2's fresh tail block. The user-prompt-submit hook keys v2's
+   * `memoryInjectedBlock` metadata persist off this so a stripped v2 block is
+   * never rehydrated back into history on reload.
+   */
+  memoryV3Active?: boolean;
+  /**
    * Composed output of every plugin-registered {@link Injector}, concatenated
    * in ascending `order`. Empty string when every injector opted out (returned
    * `null`). Today the default injectors (`default-injectors` plugin)
@@ -2028,6 +2050,7 @@ export async function applyRuntimeInjections(
   let pkbContextCaptured: string | undefined;
   let pkbSystemReminderCaptured: string | undefined;
   let memoryV2StaticCaptured: string | undefined;
+  let memoryV3Captured: string | undefined;
   const initialTail = runMessages[runMessages.length - 1];
   const initialTailIsUser = !!initialTail && initialTail.role === "user";
   if (initialTailIsUser) {
@@ -2051,6 +2074,15 @@ export async function applyRuntimeInjections(
         case "memory-v2-static":
           memoryV2StaticCaptured = block.text;
           break;
+        case MEMORY_V3_BLOCK_ID:
+          // The v3 frozen card block is persisted UNWRAPPED (the v2
+          // `memoryInjectedBlock` contract — rehydration re-wraps on use).
+          // An empty-text block (all-repeat turn) attaches no content, so
+          // nothing is captured for persistence either.
+          if (block.text.length > 0) {
+            memoryV3Captured = unwrapMemoryBlock(block.text);
+          }
+          break;
       }
     }
   }
@@ -2067,15 +2099,26 @@ export async function applyRuntimeInjections(
       ? injectorChainPieces.join("\n\n")
       : undefined;
 
-  // ── Step 0: memory-v3-live v2 suppression ──
-  // When the `memory-v3-live` flag is on AND the v3 injector actually produced
-  // a block this turn, v3 is the sole `<memory>` source. v2's `prepareMemory`
-  // already prepended its own `<memory>` block to the tail user message (and
-  // historical turns may carry v2 blocks from earlier turns). Strip every user
-  // message's memory prefix here so:
-  //   1. The v3 `after-memory-prefix` block (Step 2) lands at the top of the
-  //      tail with no v2 prefix ahead of it — exactly one `<memory>` block.
-  //   2. History is byte-stable across turns for prompt caching.
+  // ── Step 0: memory-v3 ephemeral-spotlight strip + v2 tail suppression ──
+  //
+  // Spotlight strip (unconditional): the `<memory_spotlight>` block is
+  // ephemeral by contract — re-rendered at the current tail each turn — so any
+  // spotlight riding history from a previous turn is stale and is removed
+  // here. This is a SCOPED strip of only that block id: the frozen `<memory>`
+  // card blocks on historical messages are untouched (the cache contract).
+  // With the v3 flag off no spotlight blocks exist and this is a content
+  // no-op, keeping the v2 path bit-for-bit identical.
+  let runMessagesForAssembly = stripSpotlightInjections(runMessages);
+
+  // v2 suppression: when the `memory-v3-live` flag is on AND the v3 injector
+  // produced a block this turn (possibly empty-text on an all-repeat turn), v3
+  // owns the `<memory>` layer. v2's `prepareMemory` already prepended its own
+  // fresh `<memory>` block to the tail user message — strip the TAIL's memory
+  // prefix only, so the v3 `after-memory-prefix` block (Step 2) lands at the
+  // top of the tail with no v2 prefix ahead of it. Historical user messages
+  // keep their memory blocks byte-identical: frozen v3 card blocks from prior
+  // turns AND pre-cutover v2 blocks both ride the cached prefix (the old
+  // whole-layer `stripAllMemoryInjections` replace is gone).
   // Keyed off the v3 block being present (not the flag alone) so a v3 failure
   // (`produce()` → null) leaves v2's block intact — fallback rather than a
   // memory-less turn. Idempotent: re-injection sites that already stripped
@@ -2085,9 +2128,11 @@ export async function applyRuntimeInjections(
     getConfig(),
   );
   const v3ProducedBlock = afterMemory.some((b) => b.id === MEMORY_V3_BLOCK_ID);
-  let runMessagesForAssembly = runMessages;
-  if (suppressV2MemoryForV3 && v3ProducedBlock) {
-    runMessagesForAssembly = stripAllMemoryInjections(runMessages);
+  const memoryV3Active = suppressV2MemoryForV3 && v3ProducedBlock;
+  if (memoryV3Active) {
+    runMessagesForAssembly = stripExistingMemoryInjections(
+      runMessagesForAssembly,
+    );
   }
 
   let result = runMessagesForAssembly;
@@ -2252,6 +2297,8 @@ export async function applyRuntimeInjections(
       nowScratchpadBlock: nowScratchpadCaptured,
       pkbContextBlock: pkbContextCaptured,
       memoryV2StaticBlock: memoryV2StaticCaptured,
+      memoryV3InjectedBlock: memoryV3Captured,
+      memoryV3Active,
       injectorChainBlock,
     },
   };

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -68,6 +68,7 @@ import {
   createContextSummaryMessage,
 } from "../plugins/defaults/compaction/window-manager.js";
 import { repairHistory } from "../plugins/defaults/history-repair/terminal.js";
+import { MEMORY_V3_INJECTED_BLOCK_METADATA_KEY } from "../plugins/defaults/memory-v3-shadow/ever-injected-store.js";
 import {
   applyBootstrapTemplate,
   buildSystemPrompt,
@@ -911,6 +912,31 @@ export class Conversation {
               {
                 type: "text" as const,
                 text: `<memory>\n${inner}\n</memory>`,
+              },
+              ...content,
+            ];
+          }
+
+          // The memory-v3 frozen card block (net-new compact cards) persists
+          // under its own key, stored UNWRAPPED like v2's above. Rehydrated on
+          // ALL rows (tail included): the next turn injects only net-new cards
+          // — deduped via the v3 everInjected store — so this row's block must
+          // be back in history byte-identical for the dedup (and the provider
+          // prefix cache) to hold. A row carries at most one of the two keys
+          // (the user-prompt-submit hook persists them mutually exclusively).
+          if (typeof meta[MEMORY_V3_INJECTED_BLOCK_METADATA_KEY] === "string") {
+            const v3Block = meta[
+              MEMORY_V3_INJECTED_BLOCK_METADATA_KEY
+            ] as string;
+            const v3Inner =
+              v3Block.startsWith("<memory>\n") &&
+              v3Block.endsWith("\n</memory>")
+                ? v3Block.slice("<memory>\n".length, -"\n</memory>".length)
+                : v3Block;
+            content = [
+              {
+                type: "text" as const,
+                text: `<memory>\n${v3Inner}\n</memory>`,
               },
               ...content,
             ];

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -138,6 +138,9 @@ export const messageMetadataSchema = z
     /** Image source paths from desktop attachments, keyed by filename. */
     imageSourcePaths: z.record(z.string(), z.string()).optional(),
     memoryInjectedBlock: z.string().optional(),
+    /** Memory-v3 frozen net-new card block (unwrapped) — the v3 counterpart
+     *  of `memoryInjectedBlock`. A row carries at most one of the two. */
+    [MEMORY_V3_INJECTED_BLOCK_METADATA_KEY]: z.string().optional(),
     turnContextBlock: z.string().optional(),
     pkbSystemReminderBlock: z.string().optional(),
     workspaceBlock: z.string().optional(),

--- a/assistant/src/memory/graph/__tests__/conversation-graph-memory-v2-routing.test.ts
+++ b/assistant/src/memory/graph/__tests__/conversation-graph-memory-v2-routing.test.ts
@@ -173,6 +173,10 @@ const { applyNestedDefaults } = await import("../../../config/loader.js");
 const { getSqliteFrom } = await import("../../db-connection.js");
 const { migrateActivationState } =
   await import("../../migrations/232-activation-state.js");
+const { migrateAddMemoryV3EverInjected } =
+  await import("../../migrations/275-add-memory-v3-ever-injected.js");
+const { getActiveSlugs: getV3ActiveSlugs, recordInjected: recordV3Injected } =
+  await import("../../../plugins/defaults/memory-v3-shadow/ever-injected-store.js");
 const schema = await import("../../schema.js");
 const { _resetMemoryV2QdrantForTests } = await import("../../v2/qdrant.js");
 const { hydrate: hydrateActivationState, save: saveActivationState } =
@@ -210,6 +214,8 @@ function createTestDb(): DrizzleDb {
     )
   `);
   migrateActivationState(db);
+  // `onCompacted` also clears memory-v3's everInjected record.
+  migrateAddMemoryV3EverInjected(db);
   return db;
 }
 
@@ -589,10 +595,16 @@ describe("ConversationGraphMemory.onCompacted — v2 activation eviction", () =>
     const before = await hydrateActivationState(testDbHandle!, conversationId);
     expect(before?.everInjected.map((e) => e.slug)).toContain("alice-vscode");
 
+    // Seed a memory-v3 everInjected record too: the same trigger clears it
+    // (the frozen card blocks those slugs rode were just compacted away).
+    recordV3Injected(conversationId, [{ slug: "alice-vscode", bytes: 100 }]);
+    expect(getV3ActiveSlugs(conversationId)).toEqual(new Set(["alice-vscode"]));
+
     await memory.onCompacted(1);
 
     const after = await hydrateActivationState(testDbHandle!, conversationId);
     expect(after?.everInjected).toEqual([]);
+    expect(getV3ActiveSlugs(conversationId)).toEqual(new Set());
 
     // Turn 2 — same Qdrant relevance. With everInjected cleared the slug
     // should appear again in the injection block (re-attached on the new

--- a/assistant/src/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/memory/graph/conversation-graph-memory.ts
@@ -12,6 +12,7 @@ import { z } from "zod";
 import type { AssistantConfig } from "../../config/types.js";
 import { estimateTextTokens } from "../../context/token-estimator.js";
 import type { ServerMessage } from "../../daemon/message-protocol.js";
+import { clearConversation as clearV3EverInjected } from "../../plugins/defaults/memory-v3-shadow/ever-injected-store.js";
 import type {
   ContentBlock,
   ImageContent,
@@ -281,6 +282,19 @@ export class ConversationGraphMemory {
       log.warn(
         { err: err instanceof Error ? err.message : String(err) },
         "Failed to evict v2 activation state on compaction (non-fatal)",
+      );
+    }
+
+    // Memory-v3's frozen-card dedup record resets at the same trigger: the
+    // cached card blocks those slugs rode were just stripped by compaction, so
+    // every slug must become re-injectable. Cleared unconditionally for the
+    // same crash-drift reason as v2's `everInjected` above.
+    try {
+      clearV3EverInjected(this.conversationId);
+    } catch (err) {
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        "Failed to clear memory-v3 everInjected on compaction (non-fatal)",
       );
     }
 
@@ -970,36 +984,17 @@ export function stripExistingMemoryInjections(messages: Message[]): Message[] {
 /**
  * Strip the memory-injected prefix from a single user message. Returns the
  * same message reference unchanged when it is not a user message or carries no
- * injected prefix, so callers can cheaply detect no-ops. Shared by
- * `stripExistingMemoryInjections` (last message only) and
- * `stripAllMemoryInjections` (every user message).
+ * injected prefix, so callers can cheaply detect no-ops. Used by
+ * `stripExistingMemoryInjections` (last message only) — memory-v3's frozen
+ * card carry means historical `<memory>` blocks are never bulk-stripped
+ * anymore (the old whole-layer `stripAllMemoryInjections` is gone): runtime
+ * assembly strips only the TAIL's fresh v2 prefix when v3 supersedes it.
  */
 function stripMemoryPrefixFromUserMessage(message: Message): Message {
   if (message.role !== "user") return message;
   const firstNonMemory = countMemoryPrefixBlocks(message.content);
   if (firstNonMemory === 0) return message;
   return { ...message, content: message.content.slice(firstNonMemory) };
-}
-
-/**
- * Remove memory-injected blocks from EVERY user message, not just the last.
- *
- * memory-v3 live mode strips the injected `<memory>` block from all historical
- * user messages each turn: it keeps the prompt lean and makes history
- * byte-stable for prompt caching (v2 strips only the last user message — see
- * `stripExistingMemoryInjections`). Reuses the same per-message block
- * recognition as the last-message strip. Wired into the runtime-assembly
- * suppression step (`conversation-runtime-assembly.ts`), which calls it when
- * `memory-v3-live` is on and the v3 injector produced a block this turn.
- */
-export function stripAllMemoryInjections(messages: Message[]): Message[] {
-  let changed = false;
-  const result = messages.map((message) => {
-    const stripped = stripMemoryPrefixFromUserMessage(message);
-    if (stripped !== message) changed = true;
-    return stripped;
-  });
-  return changed ? result : messages;
 }
 
 /**

--- a/assistant/src/memory/memory-marker.ts
+++ b/assistant/src/memory/memory-marker.ts
@@ -15,3 +15,32 @@
 export function wrapMemoryBlock(text: string): string {
   return `<memory>\n${text}\n</memory>`;
 }
+
+/**
+ * Inverse of {@link wrapMemoryBlock}: recover the inner text from a wrapped
+ * block. Only unwraps when the full `<memory>\n…\n</memory>` pair is present,
+ * so payloads that merely start with the opening tag pass through unchanged —
+ * the same defensive guard the metadata rehydration in
+ * `daemon/conversation.ts` applies.
+ */
+export function unwrapMemoryBlock(block: string): string {
+  return block.startsWith("<memory>\n") && block.endsWith("\n</memory>")
+    ? block.slice("<memory>\n".length, -"\n</memory>".length)
+    : block;
+}
+
+/**
+ * The memory-v3 ephemeral spotlight wrapper. Unlike `<memory>` card blocks
+ * (frozen into history), the spotlight block is re-rendered onto the current
+ * user tail every turn: the per-turn scoped strip in
+ * `context/strip-injections.ts` (`stripSpotlightInjections`) and the
+ * compaction matcher in `RUNTIME_INJECTION_PREFIXES` both key off this exact
+ * prefix/suffix pair, so the producer wrapper lives here beside the `<memory>`
+ * marker it parallels.
+ */
+export const MEMORY_SPOTLIGHT_PREFIX = "<memory_spotlight>\n";
+export const MEMORY_SPOTLIGHT_SUFFIX = "\n</memory_spotlight>";
+
+export function wrapMemorySpotlightBlock(text: string): string {
+  return `${MEMORY_SPOTLIGHT_PREFIX}${text}${MEMORY_SPOTLIGHT_SUFFIX}`;
+}

--- a/assistant/src/plugins/defaults/memory-retrieval/hooks/user-prompt-submit.ts
+++ b/assistant/src/plugins/defaults/memory-retrieval/hooks/user-prompt-submit.ts
@@ -46,33 +46,20 @@ import { updateMessageMetadata } from "../../../../memory/conversation-crud.js";
 import { recordMemoryRecallLog } from "../../../../memory/memory-recall-log-store.js";
 import { broadcastMessage } from "../../../../runtime/assistant-event-hub.js";
 import type { GraphMemoryResult } from "../../../types.js";
+import { MEMORY_V3_INJECTED_BLOCK_METADATA_KEY } from "../../memory-v3-shadow/ever-injected-store.js";
 
 /**
- * Persist and broadcast the retrieval's side effects: the injected block on
- * the user message's metadata (so it survives reloads), a recall-log row, and
- * the `memory_recalled` debug event. All three are best-effort — a failure to
- * persist must not abort the turn.
+ * Record and broadcast the retrieval's observability side effects: a
+ * recall-log row and the `memory_recalled` debug event. Both are best-effort —
+ * a failure must not abort the turn. The injected-block METADATA persist moved
+ * to {@link persistInjectionBlocks}: it runs after runtime assembly, which is
+ * the first point where it is known whether memory-v3 superseded (stripped)
+ * v2's block this turn.
  */
 function recordRecallSideEffects(
   graphResult: GraphMemoryResult,
   ctx: UserPromptSubmitContext,
 ): void {
-  // Persist the injected block text in message metadata so it survives
-  // conversation reloads (eviction, restart, fork). loadFromDb re-injects
-  // from metadata.
-  if (graphResult.injectedBlockText) {
-    try {
-      updateMessageMetadata(ctx.userMessageId, {
-        memoryInjectedBlock: graphResult.injectedBlockText,
-      });
-    } catch (err) {
-      ctx.logger.warn(
-        { err },
-        "Failed to persist memory injection to metadata (non-fatal)",
-      );
-    }
-  }
-
   const m = graphResult.metrics;
 
   try {
@@ -142,23 +129,44 @@ function recordRecallSideEffects(
  * correspond to `userMessageId`. All present blocks are written in a single
  * update to avoid doubling SQLite SELECT+UPDATE work each turn. Best-effort — a
  * persistence failure must not abort the turn.
+ *
+ * The two `<memory>` layers are mutually exclusive per row:
+ *  - `v2InjectedBlockText` (the graph retrieval's block) persists as
+ *    `memoryInjectedBlock` ONLY when memory-v3 did not supersede it this turn
+ *    (`blocks.memoryV3Active`) — assembly stripped a superseded v2 block from
+ *    the tail, so persisting it would rehydrate a block that is not in the
+ *    live history (a reload cache-bust and duplicated memory).
+ *  - `blocks.memoryV3InjectedBlock` (the frozen net-new card block, unwrapped)
+ *    persists under `MEMORY_V3_INJECTED_BLOCK_METADATA_KEY`; `loadFromDb`
+ *    re-wraps and splices it on load, freezing the cards into history.
  */
 function persistInjectionBlocks(
   blocks: RuntimeInjectionResult["blocks"],
   ctx: UserPromptSubmitContext,
+  v2InjectedBlockText: string | null,
 ): void {
+  const v2BlockToPersist = blocks.memoryV3Active ? null : v2InjectedBlockText;
   if (
     !blocks.unifiedTurnContext &&
     !blocks.pkbSystemReminder &&
     !blocks.workspaceBlock &&
     !blocks.nowScratchpadBlock &&
     !blocks.pkbContextBlock &&
-    !blocks.memoryV2StaticBlock
+    !blocks.memoryV2StaticBlock &&
+    !blocks.memoryV3InjectedBlock &&
+    !v2BlockToPersist
   ) {
     return;
   }
   try {
     const metadataUpdates: Record<string, unknown> = {};
+    if (v2BlockToPersist) {
+      metadataUpdates.memoryInjectedBlock = v2BlockToPersist;
+    }
+    if (blocks.memoryV3InjectedBlock) {
+      metadataUpdates[MEMORY_V3_INJECTED_BLOCK_METADATA_KEY] =
+        blocks.memoryV3InjectedBlock;
+    }
     if (blocks.unifiedTurnContext) {
       metadataUpdates.turnContextBlock = blocks.unifiedTurnContext;
     }
@@ -215,6 +223,7 @@ const userPromptSubmitMemoryRetrieval: PluginHookFn<
     conversation?.assistantId,
   );
 
+  let v2InjectedBlockText: string | null = null;
   if (conversation && isTrustedActor && abortSignal) {
     // Retrieval progress (`memory_status`) and the `memory_recalled` summary
     // publish to the shared `broadcastMessage` hub — the sink every turn
@@ -228,6 +237,10 @@ const userPromptSubmitMemoryRetrieval: PluginHookFn<
     );
 
     recordRecallSideEffects(graphResult, ctx);
+    // Held until after runtime assembly: whether this block persists to
+    // metadata depends on whether memory-v3 supersedes it this turn (see
+    // `persistInjectionBlocks`).
+    v2InjectedBlockText = graphResult.injectedBlockText;
 
     ctx.latestMessages = graphResult.runMessages;
     // Select dense+sparse as a matched pair so RRF fusion combines two signals
@@ -283,7 +296,7 @@ const userPromptSubmitMemoryRetrieval: PluginHookFn<
     conversationId: ctx.conversationId,
   });
   ctx.latestMessages = injection.messages;
-  persistInjectionBlocks(injection.blocks, ctx);
+  persistInjectionBlocks(injection.blocks, ctx, v2InjectedBlockText);
 };
 
 export default userPromptSubmitMemoryRetrieval;

--- a/assistant/src/plugins/defaults/memory-retrieval/injector-chain.ts
+++ b/assistant/src/plugins/defaults/memory-retrieval/injector-chain.ts
@@ -8,10 +8,11 @@
  * injectors out of the plugin registry.
  *
  * The chain combines the default injectors ({@link defaultInjectors}) with the
- * memory-v3 injector ({@link memoryV3Injector}). The sort mirrors the previous
- * registry aggregation (`Array.prototype.sort` is stable, so injectors sharing
- * an `order` keep their listed order), so the produced sequence — and therefore
- * the injected content — is identical.
+ * memory-v3 injectors ({@link memoryV3Injector} — frozen net-new cards — and
+ * {@link memoryV3SpotlightInjector} — the ephemeral section spotlight). The
+ * sort mirrors the previous registry aggregation (`Array.prototype.sort` is
+ * stable, so injectors sharing an `order` keep their listed order), so the
+ * produced sequence — and therefore the injected content — is identical.
  *
  * The chain is assembled lazily on first access and memoized, so the sort runs
  * once per process rather than per turn and module evaluation stays free of any
@@ -19,7 +20,10 @@
  */
 
 import type { Injector } from "../../types.js";
-import { memoryV3Injector } from "../memory-v3-shadow/injector.js";
+import {
+  memoryV3Injector,
+  memoryV3SpotlightInjector,
+} from "../memory-v3-shadow/injector.js";
 import { defaultInjectors } from "./injectors.js";
 
 let cachedChain: Injector[] | null = null;
@@ -27,9 +31,11 @@ let cachedChain: Injector[] | null = null;
 /** The order-sorted runtime injector chain, assembled once and memoized. */
 export function getInjectorChain(): Injector[] {
   if (cachedChain === null) {
-    cachedChain = [...defaultInjectors, memoryV3Injector].sort(
-      (a, b) => a.order - b.order,
-    );
+    cachedChain = [
+      ...defaultInjectors,
+      memoryV3Injector,
+      memoryV3SpotlightInjector,
+    ].sort((a, b) => a.order - b.order);
   }
   return cachedChain;
 }

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/injection.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/injection.test.ts
@@ -1,0 +1,451 @@
+/**
+ * Tests for the memory-v3 injection layer (`injector.ts`): frozen net-new
+ * cards + ephemeral spotlight.
+ *
+ *   - net-new dedup: a turn re-selecting already-injected pages renders zero
+ *     new cards (empty-text block — still produced, so v2 suppression holds);
+ *   - fork dedup: a conversation whose everInjected record was seeded from
+ *     inherited blocks does not re-render those slugs;
+ *   - prune round-trip: a pruned slug that is re-selected re-injects;
+ *   - shadow mode: attaches nothing and records nothing, but logs the
+ *     would-inject set;
+ *   - spotlight: current-window entries only, re-rendered (never accumulated),
+ *     bounded by `n × (windowTurns + 1)`, live-only, absent from the
+ *     persistent card layer.
+ *
+ * Orchestration is stubbed at the `observeTurn` seam (the injectors' shared
+ * input); the everInjected store runs REAL against an in-memory SQLite DB so
+ * the dedup contract is exercised end-to-end. `mock.module` is process-global,
+ * so every stub delegates to the real implementation unless this file's tests
+ * are running (`injectionMockActive`) — mirrors the sibling test files.
+ */
+
+import { Database } from "bun:sqlite";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import { migrateAddMemoryV3EverInjected } from "../../../../memory/migrations/275-add-memory-v3-ever-injected.js";
+import * as schema from "../../../../memory/schema.js";
+import type { OrchestrateResult } from "../orchestrate.js";
+import type { Section, Slug } from "../types.js";
+
+const realConfigLoader = { ...(await import("../../../../config/loader.js")) };
+const realFlags = {
+  ...(await import("../../../../config/assistant-feature-flags.js")),
+};
+const realDbConnection = {
+  ...(await import("../../../../memory/db-connection.js")),
+};
+const realPageContent = { ...(await import("../page-content.js")) };
+const realShadowPlugin = { ...(await import("../shadow-plugin.js")) };
+
+let injectionMockActive = false;
+
+// ─── mutable test state ──────────────────────────────────────────────────────
+
+let liveEnabled = false;
+let shadowEnabled = false;
+let spotlightConfig = { n: 6, windowTurns: 2 };
+/** Canned orchestrate result per turnIndex; `null` simulates a failed turn. */
+let turnResults = new Map<number, OrchestrateResult | null>();
+const observeTurnSpy = mock(
+  async (
+    _conversationId: string,
+    turnIndex: number,
+  ): Promise<OrchestrateResult | null> => turnResults.get(turnIndex) ?? null,
+);
+
+const logCalls: Array<{ data: unknown; msg: string }> = [];
+mock.module("../../../../util/logger.js", () => ({
+  getLogger: () => ({
+    info: (data: unknown, msg: string) => logCalls.push({ data, msg }),
+    warn: (data: unknown, msg: string) => logCalls.push({ data, msg }),
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+let testSqlite: Database;
+let testDb = makeDb();
+function makeDb() {
+  testSqlite = new Database(":memory:");
+  const db = drizzle(testSqlite, { schema });
+  migrateAddMemoryV3EverInjected(db);
+  return db;
+}
+
+mock.module("../../../../memory/db-connection.js", () => ({
+  ...realDbConnection,
+  getDb: () => (injectionMockActive ? testDb : realDbConnection.getDb()),
+  getSqliteFrom: (db: unknown) =>
+    injectionMockActive
+      ? testSqlite
+      : realDbConnection.getSqliteFrom(
+          db as Parameters<typeof realDbConnection.getSqliteFrom>[0],
+        ),
+}));
+
+mock.module("../../../../config/loader.js", () => ({
+  ...realConfigLoader,
+  getConfig: () =>
+    injectionMockActive
+      ? { memory: { v3: { spotlight: spotlightConfig } } }
+      : realConfigLoader.getConfig(),
+}));
+
+mock.module("../../../../config/assistant-feature-flags.js", () => ({
+  ...realFlags,
+  isAssistantFeatureFlagEnabled: (
+    key: string,
+    config: Parameters<typeof realFlags.isAssistantFeatureFlagEnabled>[1],
+  ) => {
+    if (!injectionMockActive) {
+      return realFlags.isAssistantFeatureFlagEnabled(
+        key as Parameters<typeof realFlags.isAssistantFeatureFlagEnabled>[0],
+        config,
+      );
+    }
+    return key === "memory-v3-live"
+      ? liveEnabled
+      : key === "memory-v3-shadow"
+        ? shadowEnabled
+        : false;
+  },
+}));
+
+mock.module("../page-content.js", () => ({
+  ...realPageContent,
+  renderV3CardContent: async (slug: Slug) =>
+    injectionMockActive
+      ? slug === "missing-page"
+        ? ""
+        : `# memory/concepts/${slug}.md\ncard body for ${slug}`
+      : realPageContent.renderV3CardContent(slug),
+}));
+
+mock.module("../shadow-plugin.js", () => ({
+  ...realShadowPlugin,
+  observeTurn: (conversationId: string, turnIndex: number) =>
+    injectionMockActive
+      ? observeTurnSpy(conversationId, turnIndex)
+      : realShadowPlugin.observeTurn(conversationId, turnIndex),
+}));
+
+const {
+  memoryV3Injector,
+  memoryV3SpotlightInjector,
+  resetMemoryV3InjectorStateForTests,
+} = await import("../injector.js");
+const { getActiveSlugs, getInjected, markPruned, recordInjected } =
+  await import("../ever-injected-store.js");
+const { V3_CARDS_INJECTION_HEADER } = await import("../render-injection.js");
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+function section(slug: Slug, title: string, text: string): Section {
+  return { article: slug, title, text, ordinal: 1 };
+}
+
+/** An orchestrate result selecting `slugs`, with optional finder-matched
+ *  sections (slug → section) feeding the spotlight. */
+function result(
+  slugs: Slug[],
+  matched: Array<[Slug, Section]> = [],
+): OrchestrateResult {
+  return {
+    selections: slugs.map((slug) => ({ slug, pinned: false })),
+    matchedSections: new Map(matched),
+    lanes: {
+      core: [],
+      hot: [],
+      finder: matched.map(([slug]) => ({
+        slug,
+        descriptor: "",
+        lane: "needle" as const,
+      })),
+    },
+  };
+}
+
+function produceCards(conversationId: string, turnIndex: number) {
+  return memoryV3Injector.produce({
+    requestId: "req-1",
+    conversationId,
+    turnIndex,
+    trust: { sourceChannel: "vellum", trustClass: "guardian" },
+  });
+}
+
+function produceSpotlight(conversationId: string, turnIndex: number) {
+  return memoryV3SpotlightInjector.produce({
+    requestId: "req-1",
+    conversationId,
+    turnIndex,
+    trust: { sourceChannel: "vellum", trustClass: "guardian" },
+  });
+}
+
+beforeEach(() => {
+  injectionMockActive = true;
+  liveEnabled = false;
+  shadowEnabled = false;
+  spotlightConfig = { n: 6, windowTurns: 2 };
+  turnResults = new Map();
+  observeTurnSpy.mockClear();
+  logCalls.length = 0;
+  testDb = makeDb();
+  resetMemoryV3InjectorStateForTests();
+});
+
+afterAll(() => {
+  injectionMockActive = false;
+});
+
+// ─── frozen net-new cards ───────────────────────────────────────────────────
+
+describe("memoryV3Injector — frozen net-new cards", () => {
+  test("turn 1 renders cards; turn 2 re-selecting the same pages renders ZERO new cards", async () => {
+    liveEnabled = true;
+    turnResults.set(0, result(["page-a", "page-b"]));
+    turnResults.set(1, result(["page-a", "page-b"]));
+
+    const t1 = await produceCards("conv-1", 0);
+    expect(t1).not.toBeNull();
+    expect(t1!.placement).toBe("after-memory-prefix");
+    expect(t1!.text.startsWith("<memory>\n")).toBe(true);
+    expect(t1!.text).toContain(V3_CARDS_INJECTION_HEADER);
+    expect(t1!.text).toContain("# memory/concepts/page-a.md");
+    expect(t1!.text).toContain("# memory/concepts/page-b.md");
+    expect(getActiveSlugs("conv-1")).toEqual(new Set(["page-a", "page-b"]));
+    // Recorded bytes match the rendered card sizes (non-zero).
+    for (const entry of getInjected("conv-1").values()) {
+      expect(entry.bytes).toBeGreaterThan(0);
+      expect(entry.prunedAt).toBeNull();
+    }
+
+    // All-repeat turn: the block is still PRODUCED (its presence keys v2
+    // suppression) but carries no text — no new persistent bytes.
+    const t2 = await produceCards("conv-1", 1);
+    expect(t2).not.toBeNull();
+    expect(t2!.text).toBe("");
+  });
+
+  test("a partially-new turn renders only the net-new cards", async () => {
+    liveEnabled = true;
+    turnResults.set(0, result(["page-a"]));
+    turnResults.set(1, result(["page-a", "page-c"]));
+
+    await produceCards("conv-1", 0);
+    const t2 = await produceCards("conv-1", 1);
+    expect(t2!.text).toContain("# memory/concepts/page-c.md");
+    expect(t2!.text).not.toContain("# memory/concepts/page-a.md");
+    expect(getActiveSlugs("conv-1")).toEqual(new Set(["page-a", "page-c"]));
+  });
+
+  test("fork-seeded dedup record suppresses re-rendering inherited slugs", async () => {
+    liveEnabled = true;
+    // PR 4's fork hooks seed the child's record from inherited metadata
+    // blocks; from the injector's perspective that is just pre-existing rows.
+    recordInjected("conv-fork", [{ slug: "page-a", bytes: 0 }]);
+    turnResults.set(0, result(["page-a", "page-b"]));
+
+    const block = await produceCards("conv-fork", 0);
+    expect(block!.text).toContain("# memory/concepts/page-b.md");
+    expect(block!.text).not.toContain("# memory/concepts/page-a.md");
+  });
+
+  test("a pruned slug that is re-selected re-injects as a fresh card", async () => {
+    liveEnabled = true;
+    turnResults.set(0, result(["page-a"]));
+    turnResults.set(1, result(["page-a"]));
+
+    await produceCards("conv-1", 0);
+    markPruned("conv-1", ["page-a"], Date.now());
+    expect(getActiveSlugs("conv-1")).toEqual(new Set());
+
+    const t2 = await produceCards("conv-1", 1);
+    expect(t2!.text).toContain("# memory/concepts/page-a.md");
+    expect(getActiveSlugs("conv-1")).toEqual(new Set(["page-a"]));
+  });
+
+  test("slugs whose card renders empty are neither attached nor recorded", async () => {
+    liveEnabled = true;
+    turnResults.set(0, result(["missing-page", "page-a"]));
+
+    const block = await produceCards("conv-1", 0);
+    expect(block!.text).toContain("# memory/concepts/page-a.md");
+    expect(block!.text).not.toContain("missing-page");
+    expect(getActiveSlugs("conv-1")).toEqual(new Set(["page-a"]));
+  });
+
+  test("empty selection → null (fallback to v2), nothing recorded", async () => {
+    liveEnabled = true;
+    turnResults.set(0, result([]));
+    expect(await produceCards("conv-1", 0)).toBeNull();
+    expect(getActiveSlugs("conv-1")).toEqual(new Set());
+  });
+
+  test("shadow mode (live off) attaches nothing, records nothing, logs the would-inject set", async () => {
+    shadowEnabled = true;
+    turnResults.set(
+      0,
+      result(
+        ["page-a"],
+        [["page-a", section("page-a", "Heading", "section text")]],
+      ),
+    );
+
+    expect(await produceCards("conv-1", 0)).toBeNull();
+    expect(await produceSpotlight("conv-1", 0)).toBeNull();
+    expect(getActiveSlugs("conv-1")).toEqual(new Set());
+    const shadowLog = logCalls.find((c) =>
+      c.msg.includes("memory-v3 shadow: would inject"),
+    );
+    expect(shadowLog).toBeDefined();
+    const data = shadowLog!.data as {
+      netNew: Array<{ slug: string; bytes: number }>;
+      spotlightRefs: string[];
+    };
+    expect(data.netNew.map((e) => e.slug)).toEqual(["page-a"]);
+    expect(data.spotlightRefs).toEqual(["page-a§Heading"]);
+  });
+
+  test("the persistent card block never contains the spotlight wrapper", async () => {
+    liveEnabled = true;
+    turnResults.set(
+      0,
+      result(
+        ["page-a"],
+        [["page-a", section("page-a", "Heading", "section text")]],
+      ),
+    );
+    const block = await produceCards("conv-1", 0);
+    expect(block!.text).not.toContain("<memory_spotlight>");
+  });
+
+  test("both injectors share ONE orchestration per turn (memoized)", async () => {
+    liveEnabled = true;
+    turnResults.set(0, result(["page-a"]));
+    await produceCards("conv-1", 0);
+    await produceSpotlight("conv-1", 0);
+    expect(observeTurnSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─── ephemeral spotlight ────────────────────────────────────────────────────
+
+describe("memoryV3SpotlightInjector — ephemeral section spotlight", () => {
+  const sectionA = section("page-a", "Alpha", "alpha section text");
+  const sectionB = section("page-b", "Beta", "beta section text");
+  const sectionC = section("page-c", "Gamma", "gamma section text");
+
+  test("renders selected finder hits' matched sections at the user tail", async () => {
+    liveEnabled = true;
+    turnResults.set(0, result(["page-a", "page-b"], [["page-a", sectionA]]));
+
+    const block = await produceSpotlight("conv-1", 0);
+    expect(block).not.toBeNull();
+    expect(block!.placement).toBe("append-user-tail");
+    expect(block!.text.startsWith("<memory_spotlight>\n")).toBe(true);
+    expect(block!.text.endsWith("\n</memory_spotlight>")).toBe(true);
+    expect(block!.text).toContain(
+      "## memory/concepts/page-a.md § Alpha\nalpha section text",
+    );
+  });
+
+  test("unselected finder hits do not spotlight; top-n bound applies", async () => {
+    liveEnabled = true;
+    spotlightConfig = { n: 1, windowTurns: 0 };
+    turnResults.set(
+      0,
+      result(
+        ["page-a", "page-b"],
+        [
+          ["page-c", sectionC], // finder hit, NOT selected
+          ["page-a", sectionA],
+          ["page-b", sectionB], // selected but over the n=1 cut
+        ],
+      ),
+    );
+    const block = await produceSpotlight("conv-1", 0);
+    expect(block!.text).toContain("page-a.md § Alpha");
+    expect(block!.text).not.toContain("page-b.md");
+    expect(block!.text).not.toContain("page-c.md");
+  });
+
+  test("carries the previous windowTurns turns' entries, ages older ones out, never accumulates", async () => {
+    liveEnabled = true;
+    spotlightConfig = { n: 6, windowTurns: 1 };
+    turnResults.set(0, result(["page-a"], [["page-a", sectionA]]));
+    turnResults.set(1, result(["page-b"], [["page-b", sectionB]]));
+    turnResults.set(2, result(["page-c"], [["page-c", sectionC]]));
+
+    const t1 = await produceSpotlight("conv-1", 0);
+    expect(t1!.text).toContain("Alpha");
+
+    // Turn 1: current (Beta) + previous turn (Alpha).
+    const t2 = await produceSpotlight("conv-1", 1);
+    expect(t2!.text).toContain("Beta");
+    expect(t2!.text).toContain("Alpha");
+
+    // Turn 2: current (Gamma) + turn 1 (Beta); turn 0 (Alpha) aged out.
+    const t3 = await produceSpotlight("conv-1", 2);
+    expect(t3!.text).toContain("Gamma");
+    expect(t3!.text).toContain("Beta");
+    expect(t3!.text).not.toContain("Alpha");
+  });
+
+  test("re-producing the SAME turn replaces its window entry (no duplication)", async () => {
+    liveEnabled = true;
+    spotlightConfig = { n: 6, windowTurns: 2 };
+    turnResults.set(0, result(["page-a"], [["page-a", sectionA]]));
+
+    await produceSpotlight("conv-1", 0);
+    const again = await produceSpotlight("conv-1", 0);
+    const occurrences = again!.text.split("page-a.md § Alpha").length - 1;
+    expect(occurrences).toBe(1);
+  });
+
+  test("window is bounded by n × (windowTurns + 1) entries", async () => {
+    liveEnabled = true;
+    spotlightConfig = { n: 2, windowTurns: 1 };
+    const sections = (turn: number): Array<[Slug, Section]> =>
+      ["w", "x", "y", "z"].map((s) => {
+        const slug = `page-${s}${turn}`;
+        return [slug, section(slug, `T${turn}${s}`, "text")] as [Slug, Section];
+      });
+    turnResults.set(
+      0,
+      result(
+        sections(0).map(([s]) => s),
+        sections(0),
+      ),
+    );
+    turnResults.set(
+      1,
+      result(
+        sections(1).map(([s]) => s),
+        sections(1),
+      ),
+    );
+
+    await produceSpotlight("conv-1", 0);
+    const block = await produceSpotlight("conv-1", 1);
+    const entryCount = (block!.text.match(/^## memory\/concepts\//gm) ?? [])
+      .length;
+    expect(entryCount).toBeLessThanOrEqual(2 * (1 + 1));
+  });
+
+  test("no matched sections in the window → no block", async () => {
+    liveEnabled = true;
+    turnResults.set(0, result(["page-a"]));
+    expect(await produceSpotlight("conv-1", 0)).toBeNull();
+  });
+
+  test("live off → null even when shadow is on", async () => {
+    shadowEnabled = true;
+    turnResults.set(0, result(["page-a"], [["page-a", sectionA]]));
+    expect(await produceSpotlight("conv-1", 0)).toBeNull();
+  });
+});

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/live-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/live-integration.test.ts
@@ -4,25 +4,30 @@
  * SCOPE / ALTITUDE. A full daemon-assembly integration (plugin registry → flag
  * read → runtime assembly → provider call) is too heavy and too mock-fragile
  * for a unit test. Instead this composes the REAL v3 live-path units with a
- * mocked select provider + stubbed dense lane and synthetic fixtures:
+ * mocked select provider + stubbed dense lane, synthetic fixtures, and a real
+ * in-memory everInjected store:
  *
  *   orchestrate (cache-ordered pool → ONE selectPool call → this turn's
  *     selections)
- *     → renderMemoryBlock (the rendered `<memory>` selections block)
- *     → stripAllMemoryInjections (all-turns history strip)
+ *     → net-new filter against the everInjected store (`getActiveSlugs`)
+ *     → renderCard + renderCardsBlockInner (the frozen card block)
+ *     → recordInjected
  *
- * That is exactly the behavioral contract the live path wires together: the
- * plugin's `produce()` renders this turn's `orchestrate(...).selections` via
- * `renderMemoryBlock`, and assembly strips `<memory>` from every historical
- * user message so exactly one block exists. INTERIM SHAPE: the block reflects
- * current-turn selections only — the working-set carry was removed from
- * orchestration; cross-turn persistence (net-new blocks frozen into history)
- * replaces it in a follow-up. The provider is stubbed (no network).
+ * That is the behavioral contract the live path wires together: the injector
+ * renders only the turn's NET-NEW selections as cards, records them, and the
+ * resulting block is FROZEN into history — prior turns' blocks are never
+ * re-rendered or stripped (the cache contract; the old `stripAllMemoryInjections`
+ * whole-layer replace is gone). The provider is stubbed (no network).
  */
 
+import { Database } from "bun:sqlite";
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
-import { stripAllMemoryInjections } from "../../../../memory/graph/conversation-graph-memory.js";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import { wrapMemoryBlock } from "../../../../memory/memory-marker.js";
+import { migrateAddMemoryV3EverInjected } from "../../../../memory/migrations/275-add-memory-v3-ever-injected.js";
+import * as schema from "../../../../memory/schema.js";
 import type { PageIndexEntry } from "../../../../memory/v2/page-index.js";
 import type {
   ContentBlock,
@@ -30,6 +35,7 @@ import type {
   Provider,
   ProviderResponse,
 } from "../../../../providers/types.js";
+import { cardBytes, renderCard } from "../card.js";
 import type { EdgeGraph } from "../edge.js";
 import { buildEdgeGraph } from "../edge.js";
 import { buildSectionNeedle } from "../section-needle.js";
@@ -67,8 +73,35 @@ mock.module("../dense.js", () => ({
     denseMockActive ? [] : realDense.denseLane(...args),
 }));
 
+// In-memory everInjected store backing the net-new dedup, swapped in only
+// while this file's tests run.
+const realDbConnection = {
+  ...(await import("../../../../memory/db-connection.js")),
+};
+let testSqlite: Database;
+let testDb = makeDb();
+function makeDb() {
+  testSqlite = new Database(":memory:");
+  const db = drizzle(testSqlite, { schema });
+  migrateAddMemoryV3EverInjected(db);
+  return db;
+}
+mock.module("../../../../memory/db-connection.js", () => ({
+  ...realDbConnection,
+  getDb: () => (denseMockActive ? testDb : realDbConnection.getDb()),
+  getSqliteFrom: (db: unknown) =>
+    denseMockActive
+      ? testSqlite
+      : realDbConnection.getSqliteFrom(
+          db as Parameters<typeof realDbConnection.getSqliteFrom>[0],
+        ),
+}));
+
 const { orchestrate } = await import("../orchestrate.js");
-const { renderMemoryBlock } = await import("../render-injection.js");
+const { renderCardsBlockInner, V3_CARDS_INJECTION_HEADER } =
+  await import("../render-injection.js");
+const { getActiveSlugs, recordInjected, residentBytes } =
+  await import("../ever-injected-store.js");
 
 // ---------------------------------------------------------------------------
 // Fixtures: a tiny corpus whose section text contains a distinctive term per
@@ -94,7 +127,6 @@ function makeEntries(): PageIndexEntry[] {
 }
 
 const config = {} as never;
-const contentOf = async (slug: Slug): Promise<string> => `body for ${slug}`;
 
 async function buildLanes(): Promise<{
   sectionIndex: SectionIndex;
@@ -164,43 +196,44 @@ function selectProvider(keep: Slug[], pin: Slug[] = []): Provider {
   };
 }
 
-/** Run one turn through orchestrate + render this turn's selections. */
+/**
+ * Run one turn through the live composition: orchestrate → net-new filter
+ * against the store → card render → record. Returns the wrapped block ("" when
+ * the turn had no net-new cards) — the same shape the injector attaches.
+ */
 async function runTurn(
+  conversationId: string,
   turnNumber: number,
   query: string,
   keep: Slug[],
-  pin: Slug[],
-  deps: {
-    lanes: Awaited<ReturnType<typeof buildLanes>>;
-    core?: Slug[];
-    hot?: Slug[];
-  },
-) {
-  providerStub = selectProvider(keep, pin);
+  deps: { lanes: Awaited<ReturnType<typeof buildLanes>> },
+): Promise<{ block: string; netNew: Slug[] }> {
+  providerStub = selectProvider(keep);
   const result = await orchestrate(makeTurn(turnNumber, query), {
     sectionIndex: deps.lanes.sectionIndex,
     needle: deps.lanes.needle,
     denseConfig: config,
     edgeGraph: deps.lanes.edgeGraph,
-    coreSlugs: deps.core ?? [],
-    hotSlugs: deps.hot ?? [],
+    coreSlugs: [],
+    hotSlugs: [],
   });
-  const block = await renderMemoryBlock(
-    result.selections.map((s) => s.slug),
-    result.matchedSections,
-    contentOf,
+  const active = getActiveSlugs(conversationId);
+  const netNew = result.selections
+    .map((s) => s.slug)
+    .filter((slug) => !active.has(slug));
+  const cards = netNew.map((slug) => renderCard(slug, PAGES[slug]!));
+  recordInjected(
+    conversationId,
+    cards.map((card, i) => ({ slug: netNew[i]!, bytes: cardBytes(card) })),
   );
-  return { result, block };
-}
-
-/** Count `<memory>\n…\n</memory>` blocks in a rendered string. */
-function countMemoryBlocks(text: string): number {
-  return (text.match(/<memory>\n/g) ?? []).length;
+  const inner = renderCardsBlockInner(cards);
+  return { block: inner.length === 0 ? "" : wrapMemoryBlock(inner), netNew };
 }
 
 beforeEach(() => {
   denseMockActive = true;
   providerStub = null;
+  testDb = makeDb();
 });
 
 afterAll(() => {
@@ -208,100 +241,104 @@ afterAll(() => {
 });
 
 // ---------------------------------------------------------------------------
-// Selections-only block (interim shape): the rendered block reflects THIS
-// turn's selections; a page selected on an earlier turn and not re-selected
-// does not reappear — cross-turn persistence moves to the injector (net-new
-// blocks frozen into history) in a follow-up.
+// Net-new accumulation: each turn renders ONLY pages not already frozen into
+// history; an all-repeat turn renders nothing new.
 // ---------------------------------------------------------------------------
 
-describe("memory-v3 live — selections-only block", () => {
-  test("a page selected in turn 1 is absent from turn 2's block unless re-selected", async () => {
+describe("memory-v3 live — net-new card accumulation", () => {
+  test("turn 2 re-selecting turn 1's page renders zero new cards", async () => {
     const lanes = await buildLanes();
 
-    const t1 = await runTurn(1, "apple", ["page-a"], ["page-a"], { lanes });
-    expect(t1.result.selections.map((s) => s.slug)).toContain("page-a");
-    expect(t1.block).toContain("body for page-a");
+    const t1 = await runTurn("conv-1", 1, "apple", ["page-a"], { lanes });
+    expect(t1.netNew).toEqual(["page-a"]);
+    expect(t1.block).toContain("# memory/concepts/page-a.md");
+    expect(t1.block).toContain("lead a");
 
-    const t2 = await runTurn(2, "cherry", ["page-c"], [], { lanes });
-    expect(t2.result.selections.map((s) => s.slug)).toEqual(["page-c"]);
-    expect(t2.block).toContain("body for page-c");
-    expect(t2.block).not.toContain("body for page-a");
+    // All-repeat turn: no new persistent bytes.
+    const t2 = await runTurn("conv-1", 2, "apple", ["page-a"], { lanes });
+    expect(t2.netNew).toEqual([]);
+    expect(t2.block).toBe("");
+    expect(residentBytes("conv-1")).toBeGreaterThan(0);
   });
 
-  test("a selected stable-prefix page renders in the block", async () => {
+  test("a topic shift renders only the newly-selected page's card", async () => {
     const lanes = await buildLanes();
-    // page-b is HOT; the query never matches it, but the selector keeps it
-    // from the stable prefix and it renders like any other selection.
-    const t1 = await runTurn(1, "apple", ["page-a", "page-b"], [], {
+
+    await runTurn("conv-1", 1, "apple", ["page-a"], { lanes });
+    const t2 = await runTurn("conv-1", 2, "cherry", ["page-a", "page-c"], {
       lanes,
-      hot: ["page-b"],
     });
-    expect(t1.result.selections.map((s) => s.slug)).toEqual([
-      "page-b",
-      "page-a",
-    ]);
-    expect(t1.block).toContain("body for page-b");
-    expect(t1.block).toContain("body for page-a");
+    expect(t2.netNew).toEqual(["page-c"]);
+    expect(t2.block).toContain("# memory/concepts/page-c.md");
+    expect(t2.block).not.toContain("# memory/concepts/page-a.md");
   });
-});
 
-// ---------------------------------------------------------------------------
-// Single source: orchestrate → render produces exactly one coherent `<memory>`
-// block per turn.
-// ---------------------------------------------------------------------------
-
-describe("memory-v3 live — single memory source", () => {
-  test("each turn renders exactly one <memory> block", async () => {
+  test("each non-empty turn block is one <memory> block with the read-affordance header", async () => {
     const lanes = await buildLanes();
-
     const queries = ["apple", "banana", "cherry"];
     for (const [i, query] of queries.entries()) {
-      const { block } = await runTurn(i + 1, query, [SLUGS[i]!], [], {
+      const { block } = await runTurn("conv-1", i + 1, query, [SLUGS[i]!], {
         lanes,
       });
-      expect(countMemoryBlocks(block)).toBe(1);
+      expect((block.match(/<memory>\n/g) ?? []).length).toBe(1);
       expect(block.startsWith("<memory>\n")).toBe(true);
       expect(block.endsWith("\n</memory>")).toBe(true);
+      expect(block).toContain(V3_CARDS_INJECTION_HEADER);
     }
   });
 });
 
 // ---------------------------------------------------------------------------
-// Strip-all: the rendered block injected into historical user messages is
-// stripped each turn, leaving byte-stable history (only the live block differs).
+// Frozen history: blocks splice onto their own turn's user message and are
+// NEVER touched on later turns — prior messages stay byte-identical (the
+// cache contract that replaced the old all-turns strip).
 // ---------------------------------------------------------------------------
 
-describe("memory-v3 live — all-turns history strip", () => {
-  test("historical <memory> blocks strip back to byte-stable user history", async () => {
+describe("memory-v3 live — frozen card blocks in history", () => {
+  test("prior turns' messages stay byte-identical as new turns inject", async () => {
     const lanes = await buildLanes();
-
-    const baseHistory: Message[] = [
-      { role: "user", content: [{ type: "text", text: "first user message" }] },
-      { role: "assistant", content: [{ type: "text", text: "ok" }] },
-      {
-        role: "user",
-        content: [{ type: "text", text: "second user message" }],
-      },
-      { role: "assistant", content: [{ type: "text", text: "sure" }] },
-      { role: "user", content: [{ type: "text", text: "third user message" }] },
-    ];
-
     const memBlock = (text: string): ContentBlock => ({ type: "text", text });
+
+    const history: Message[] = [];
+    const snapshots: string[] = [];
     const queries = ["apple", "banana", "cherry"];
-    let injected: Message[] = baseHistory;
     for (const [i, query] of queries.entries()) {
-      const { block } = await runTurn(i + 1, query, [SLUGS[i]!], [], {
+      history.push({
+        role: "user",
+        content: [{ type: "text", text: `user message ${i + 1}` }],
+      });
+      const { block } = await runTurn("conv-1", i + 1, query, [SLUGS[i]!], {
         lanes,
       });
-      const stripped = stripAllMemoryInjections(injected);
-      injected = stripped.map((m) =>
-        m.role === "user"
-          ? { ...m, content: [memBlock(block), ...m.content] }
-          : m,
-      );
+      // The injector splices the block onto the CURRENT tail only; prior
+      // messages are never revisited.
+      if (block.length > 0) {
+        const tail = history[history.length - 1]!;
+        tail.content = [memBlock(block), ...tail.content];
+      }
+      snapshots.push(JSON.stringify(history.slice(0, -1)));
+      history.push({
+        role: "assistant",
+        content: [{ type: "text", text: "ok" }],
+      });
     }
 
-    const finalStripped = stripAllMemoryInjections(injected);
-    expect(finalStripped).toEqual(baseHistory);
+    // Every snapshot of the pre-tail history is a byte-prefix of the final
+    // history: nothing a later turn did rewrote an earlier message.
+    const finalJson = JSON.stringify(history);
+    for (const snapshot of snapshots) {
+      expect(finalJson.startsWith(snapshot.slice(0, -1))).toBe(true);
+    }
+
+    // Accumulation: all three turns' cards are present, one block per turn.
+    const allText = history
+      .flatMap((m) => m.content)
+      .filter((b): b is { type: "text"; text: string } => b.type === "text")
+      .map((b) => b.text)
+      .join("\n");
+    expect((allText.match(/<memory>\n/g) ?? []).length).toBe(3);
+    for (const slug of SLUGS) {
+      expect(allText).toContain(`# memory/concepts/${slug}.md`);
+    }
   });
 });

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/render-injection.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/render-injection.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from "bun:test";
 
 import { wrapMemoryBlock } from "../../../../memory/memory-marker.js";
-import { renderMemoryBlock } from "../render-injection.js";
+import {
+  renderCardsBlockInner,
+  renderMemoryBlock,
+  renderSpotlightInner,
+  V3_CARDS_INJECTION_HEADER,
+} from "../render-injection.js";
 import type { Section, Slug } from "../types.js";
 
 function section(article: Slug, text: string): Section {
@@ -16,6 +21,38 @@ const resolver =
   (fullBodies: Record<Slug, string>) =>
   async (slug: Slug, sec: Section | undefined): Promise<string> =>
     sec ? sec.text : (fullBodies[slug] ?? "");
+
+describe("renderCardsBlockInner", () => {
+  test("prefixes the v2 read-affordance header and joins cards with blank lines", () => {
+    const inner = renderCardsBlockInner([
+      "# memory/concepts/page-a.md\nhead a",
+      "# memory/concepts/page-b.md\nhead b",
+    ]);
+    expect(inner).toBe(
+      `${V3_CARDS_INJECTION_HEADER}\n\n# memory/concepts/page-a.md\nhead a\n\n# memory/concepts/page-b.md\nhead b`,
+    );
+  });
+
+  test("empty card list renders the empty string (no header-only block)", () => {
+    expect(renderCardsBlockInner([])).toBe("");
+  });
+});
+
+describe("renderSpotlightInner", () => {
+  test("renders each entry as a § header plus section text", () => {
+    const inner = renderSpotlightInner([
+      { slug: "page-a", title: "Alpha", text: "alpha text" },
+      { slug: "page-b", title: "Beta", text: "beta text" },
+    ]);
+    expect(inner).toBe(
+      "## memory/concepts/page-a.md § Alpha\nalpha text\n\n## memory/concepts/page-b.md § Beta\nbeta text",
+    );
+  });
+
+  test("empty window renders the empty string", () => {
+    expect(renderSpotlightInner([])).toBe("");
+  });
+});
 
 describe("renderMemoryBlock", () => {
   test("renders the matched section (not the full body) for each slug", async () => {

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-plugin.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-plugin.test.ts
@@ -28,6 +28,7 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
 import { migrateAddMemoryV3Selections } from "../../../../memory/migrations/268-add-memory-v3-selections.js";
+import { migrateAddMemoryV3EverInjected } from "../../../../memory/migrations/275-add-memory-v3-ever-injected.js";
 import * as schema from "../../../../memory/schema.js";
 import type { HotSetEntry, HotSetOptions } from "../hot-set.js";
 import type { OrchestrateResult } from "../orchestrate.js";
@@ -140,6 +141,8 @@ function makeDb() {
   testSqlite.exec("PRAGMA journal_mode=WAL");
   const db = drizzle(testSqlite, { schema });
   migrateAddMemoryV3Selections(db);
+  // The live injector's net-new dedup reads/writes the everInjected store.
+  migrateAddMemoryV3EverInjected(db);
   return db;
 }
 
@@ -171,6 +174,7 @@ mock.module("../../../../config/loader.js", () => ({
     memory: {
       v3: {
         hotSet: { k: 40, halfLifeDays: 14 },
+        spotlight: { n: 6, windowTurns: 2 },
         needleK: 100,
         denseK: 100,
         edge: { hubDegree: 30, seedCount: 18, perSeed: 6, cap: 45 },
@@ -356,7 +360,8 @@ const {
   invalidateLanes,
   attributeSelections,
 } = await import("../shadow-plugin.js");
-const { memoryV3Injector } = await import("../injector.js");
+const { memoryV3Injector, resetMemoryV3InjectorStateForTests } =
+  await import("../injector.js");
 
 afterAll(() => {
   shadowMockActive = false;
@@ -392,6 +397,9 @@ beforeEach(() => {
   hotSetOpts = null;
   testDb = makeDb();
   resetShadowLanesForTests();
+  // The injector memoizes one orchestration per (conversation, turn); clear it
+  // so tests reusing the same ids observe fresh orchestrations.
+  resetMemoryV3InjectorStateForTests();
 });
 
 /** Invoke the memory-v3 injector's `produce()` for a turn. */
@@ -527,7 +535,7 @@ describe("memory-v3 shadow plugin", () => {
     expect(readRows().length).toBeGreaterThan(0);
   });
 
-  test("live on → produce returns the rendered <memory> block and logs", async () => {
+  test("live on → produce returns the net-new CARD block and logs", async () => {
     liveEnabled = true;
     shadowEnabled = false;
     const block = await produce("conv-1", 0);
@@ -535,15 +543,28 @@ describe("memory-v3 shadow plugin", () => {
     expect(block!.placement).toBe("after-memory-prefix");
     expect(block!.text.startsWith("<memory>\n")).toBe(true);
     expect(block!.text.endsWith("\n</memory>")).toBe(true);
-    // Progressive disclosure: a slug with a matched section renders that
-    // section's text (page-1 → "x"), NOT the full page body.
-    expect(block!.text).toContain("# memory/concepts/page-1.md\nx");
-    expect(block!.text).not.toContain("body for page-1");
-    // A selected slug with no matched section (edge-surfaced page-3) falls
-    // back to the full body.
-    expect(block!.text).toContain("body for page-3");
+    // Turn 1: every selection is net-new and renders as a compact card —
+    // the page header plus the page's head section (the fixture body has no
+    // `## ` headings, so the whole body is the head and no TOC line renders).
+    for (const slug of ["page-core", "page-hot", "page-1", "page-2"]) {
+      expect(block!.text).toContain(
+        `# memory/concepts/${slug}.md\nbody for ${slug}`,
+      );
+    }
     // Selections are still logged in live mode.
     expect(readRows().length).toBeGreaterThan(0);
+  });
+
+  test("live on → a later turn re-selecting the same pages renders an EMPTY block (net-new dedup)", async () => {
+    liveEnabled = true;
+    shadowEnabled = false;
+    const first = await produce("conv-1", 0);
+    expect(first!.text.length).toBeGreaterThan(0);
+    // Same orchestrate fixture on the next turn → zero net-new cards. The
+    // block is still produced (its presence keys v2 suppression downstream).
+    const repeat = await produce("conv-1", 1);
+    expect(repeat).not.toBeNull();
+    expect(repeat!.text).toBe("");
   });
 
   test("live on but empty selection → produce returns null", async () => {

--- a/assistant/src/plugins/defaults/memory-v3-shadow/injector.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/injector.ts
@@ -1,40 +1,201 @@
 /**
- * The memory-v3 {@link Injector}. Reads both v3 flags:
- *   - `memory-v3-live` on → orchestrate, log, render THIS TURN's selections
- *     into a `<memory>` block, and return it at v2's dynamic-memory placement.
- *     (Interim shape: cross-turn persistence — net-new blocks frozen into
- *     history — replaces this whole-selection render in a follow-up; until
- *     then live/shadow output reflects current-turn selections only.)
- *   - `memory-v3-shadow` on (live off) → orchestrate + log only, return `null`.
- *   - both off → return `null` (no orchestration).
+ * The memory-v3 {@link Injector}s: frozen net-new cards + ephemeral spotlight.
  *
- * Empty selection and any failure return `null` (no v3 injection). v2
- * suppression keys off BOTH the flag AND this return value, so a `null` here
- * (failure or empty selection) falls back to v2 memory rather than dropping all
- * memory.
+ * Two injectors share one orchestration result per turn (memoized via
+ * {@link observeTurnOnce} so re-entry assemblies — overflow convergence,
+ * post-compaction re-injection — reuse the turn's selections instead of
+ * re-running the selector):
  *
- * Orchestration and telemetry live in {@link observeTurn}; this module is the
- * thin injector wrapper that renders the result for live injection.
+ *  - {@link memoryV3Injector} (id `memory-v3`, `after-memory-prefix`): the
+ *    PERSISTENT layer. Renders only this turn's NET-NEW selections — selections
+ *    not already in the everInjected store — as compact cards inside one
+ *    `<memory>` block, records them (`recordInjected`), and returns the block.
+ *    Runtime assembly splices it onto the current user message and the
+ *    user-prompt-submit hook persists the unwrapped inner text under
+ *    `metadata.memoryV3InjectedBlock`; `conversation.ts` rehydrates it on
+ *    load. The block is FROZEN thereafter: prior turns' card blocks stay
+ *    byte-identical in history, so they ride the provider's cached prefix and
+ *    survive restarts — mirroring v2's `memoryInjectedBlock` mechanism. An
+ *    all-repeat turn returns an EMPTY-TEXT block: assembly attaches nothing,
+ *    but the block's presence still keys v2 suppression (v3 ran and owns the
+ *    `<memory>` layer this turn). A `null` return (failure / empty selection)
+ *    leaves v2's block intact — fallback to v2 rather than a memory-less turn.
+ *
+ *  - {@link memoryV3SpotlightInjector} (id `memory-v3-spotlight`,
+ *    `append-user-tail`): the EPHEMERAL layer. Renders the top `spotlight.n`
+ *    selected finder hits' matched sections, plus the previous
+ *    `spotlight.windowTurns` turns' entries from an in-memory per-conversation
+ *    ring (a daemon restart simply re-warms it), as a `<memory_spotlight>`
+ *    block at the current-message tail. Assembly strip-and-replaces this block
+ *    every turn (scoped to this block id only); it is never persisted to
+ *    metadata.
+ *
+ * Flag gating is unchanged: `memory-v3-live` attaches blocks; `memory-v3-shadow`
+ * (live off) logs what WOULD inject (net-new slugs + bytes + spotlight refs)
+ * and attaches nothing; both off → no orchestration.
+ *
+ * Known mirror-of-v2 limitation: cards attached by mid-turn re-entry
+ * assemblies (post-compaction re-injection) live only in memory — metadata is
+ * persisted at the first-call site only — so a restart drops them while the
+ * store still claims them, exactly as v2's `lastInjectedBlock` reinject does.
+ * The next compaction clears the store and resets both layers.
  */
 
 import { isAssistantFeatureFlagEnabled } from "../../../config/assistant-feature-flags.js";
 import { getConfig } from "../../../config/loader.js";
+import {
+  wrapMemoryBlock,
+  wrapMemorySpotlightBlock,
+} from "../../../memory/memory-marker.js";
 import { getLogger } from "../../../util/logger.js";
 import {
   type InjectionBlock,
   type Injector,
   type TurnContext,
 } from "../../types.js";
-import { renderV3SectionContent } from "./page-content.js";
-import { renderMemoryBlock } from "./render-injection.js";
+import { cardBytes } from "./card.js";
+import { getActiveSlugs, recordInjected } from "./ever-injected-store.js";
+import type { OrchestrateResult } from "./orchestrate.js";
+import { renderV3CardContent } from "./page-content.js";
+import {
+  renderCardsBlockInner,
+  renderSpotlightInner,
+  type SpotlightEntry,
+} from "./render-injection.js";
 import {
   MEMORY_V3_LIVE,
   MEMORY_V3_SHADOW,
   observeTurn,
 } from "./shadow-plugin.js";
-import { MEMORY_V3_BLOCK_ID } from "./types.js";
+import {
+  MEMORY_V3_BLOCK_ID,
+  MEMORY_V3_SPOTLIGHT_BLOCK_ID,
+  type Slug,
+} from "./types.js";
 
 const log = getLogger("memory-v3-shadow");
+
+/**
+ * Cap on the per-conversation maps below. Oldest-inserted entries are evicted
+ * first; an evicted conversation simply re-warms (spotlight) or re-runs
+ * orchestration (memo) on its next turn.
+ */
+const MAX_TRACKED_CONVERSATIONS = 256;
+
+function evictOldest(map: Map<string, unknown>): void {
+  if (map.size < MAX_TRACKED_CONVERSATIONS) return;
+  const oldest = map.keys().next().value;
+  if (oldest !== undefined) map.delete(oldest);
+}
+
+// ─── shared per-turn orchestration memo ─────────────────────────────────────
+
+interface ObservedTurn {
+  turnIndex: number;
+  result: Promise<OrchestrateResult | null>;
+}
+
+/** Latest observed turn per conversation (both injectors + re-entry sites
+ *  share one orchestration per turn). */
+const observedTurns = new Map<string, ObservedTurn>();
+
+/**
+ * Run {@link observeTurn} once per (conversation, turn) and memoize the
+ * promise. The cards and spotlight injectors both consume the result, and
+ * re-entry assemblies within the same turn (overflow convergence,
+ * post-compaction re-injection) reuse the turn's selections rather than
+ * paying a second selector call. A new `turnIndex` replaces the entry, so the
+ * memo never holds more than one turn per conversation.
+ */
+function observeTurnOnce(
+  conversationId: string,
+  turnIndex: number,
+): Promise<OrchestrateResult | null> {
+  const cached = observedTurns.get(conversationId);
+  if (cached && cached.turnIndex === turnIndex) return cached.result;
+  evictOldest(observedTurns);
+  const result = observeTurn(conversationId, turnIndex);
+  observedTurns.set(conversationId, { turnIndex, result });
+  return result;
+}
+
+// ─── ephemeral spotlight ring ────────────────────────────────────────────────
+
+interface SpotlightTurn {
+  turnIndex: number;
+  entries: SpotlightEntry[];
+}
+
+/** Recent turns' spotlight entries per conversation, oldest → newest. */
+const spotlightRings = new Map<string, SpotlightTurn[]>();
+
+/**
+ * Compute this turn's spotlight entries: the top `n` SELECTED finder hits'
+ * matched sections, in finder surfacing order (needle → dense → edge
+ * precedence). A finder hit on a stable-prefix page keeps its matched-section
+ * ref in the orchestrate result, so core/hot pages with current relevance
+ * spotlight too.
+ */
+function computeSpotlightEntries(
+  result: OrchestrateResult,
+  n: number,
+): SpotlightEntry[] {
+  const selected = new Set<Slug>(result.selections.map((s) => s.slug));
+  const entries: SpotlightEntry[] = [];
+  for (const candidate of result.lanes.finder) {
+    if (entries.length >= n) break;
+    if (!selected.has(candidate.slug)) continue;
+    const section = result.matchedSections.get(candidate.slug);
+    if (!section) continue;
+    entries.push({
+      slug: candidate.slug,
+      title: section.title,
+      text: section.text,
+    });
+  }
+  return entries;
+}
+
+/**
+ * Fold this turn's entries into the conversation's ring and return the
+ * rendered window: current turn first, then previous turns newest-first,
+ * deduped by slug § heading, bounded by `n × (windowTurns + 1)` entries by
+ * construction. Re-observing the SAME turn (re-entry assembly) replaces that
+ * turn's entry rather than accumulating.
+ */
+function updateSpotlightWindow(
+  conversationId: string,
+  turnIndex: number,
+  entries: SpotlightEntry[],
+  windowTurns: number,
+): SpotlightEntry[] {
+  const prior = (spotlightRings.get(conversationId) ?? []).filter(
+    (t) => t.turnIndex < turnIndex && t.turnIndex >= turnIndex - windowTurns,
+  );
+  if (!spotlightRings.has(conversationId)) evictOldest(spotlightRings);
+  spotlightRings.set(conversationId, [...prior, { turnIndex, entries }]);
+
+  const window: SpotlightEntry[] = [];
+  const seen = new Set<string>();
+  // Newest first: this turn's entries, then prior turns newest → oldest.
+  for (const turn of [{ turnIndex, entries }, ...prior.reverse()]) {
+    for (const entry of turn.entries) {
+      const key = `${entry.slug}§${entry.title}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      window.push(entry);
+    }
+  }
+  return window;
+}
+
+/** Test-only reset for the per-turn memo and the spotlight rings. */
+export function resetMemoryV3InjectorStateForTests(): void {
+  observedTurns.clear();
+  spotlightRings.clear();
+}
+
+// ─── injectors ───────────────────────────────────────────────────────────────
 
 export const memoryV3Injector: Injector = {
   name: "memory-v3-shadow",
@@ -48,20 +209,59 @@ export const memoryV3Injector: Injector = {
     const shadow = isAssistantFeatureFlagEnabled(MEMORY_V3_SHADOW, config);
     if (!live && !shadow) return null;
 
-    const result = await observeTurn(ctx.conversationId, ctx.turnIndex);
-    if (!live || !result) return null;
+    const result = await observeTurnOnce(ctx.conversationId, ctx.turnIndex);
+    // Empty selection falls back to v2 (return null): v2 suppression keys off
+    // BOTH the flag AND a produced block, so a selector failure or a turn with
+    // nothing selected ships v2 memory rather than no memory.
+    if (!result || result.selections.length === 0) return null;
 
     try {
-      // `renderMemoryBlock` returns "" for an empty selection; inject nothing.
-      const text = await renderMemoryBlock(
-        result.selections.map((s) => s.slug),
-        result.matchedSections,
-        renderV3SectionContent,
-      );
-      if (text.length === 0) return null;
+      const active = getActiveSlugs(ctx.conversationId);
+      const netNew = result.selections
+        .map((s) => s.slug)
+        .filter((slug) => !active.has(slug));
+
+      // Render net-new cards, skipping slugs that resolve to no content
+      // (deleted pages, unresolvable capabilities) — nothing is attached for
+      // them, so nothing is recorded either.
+      const cards: Array<{ slug: Slug; card: string }> = [];
+      for (const slug of netNew) {
+        const card = await renderV3CardContent(slug);
+        if (card.trim().length > 0) cards.push({ slug, card });
+      }
+      const entries = cards.map(({ slug, card }) => ({
+        slug,
+        bytes: cardBytes(card),
+      }));
+
+      if (!live) {
+        // Shadow mode: log what WOULD inject, attach and record nothing.
+        const spotlightRefs = computeSpotlightEntries(
+          result,
+          config.memory.v3.spotlight.n,
+        ).map((e) => `${e.slug}§${e.title}`);
+        log.info(
+          {
+            conversationId: ctx.conversationId,
+            turnIndex: ctx.turnIndex,
+            netNew: entries,
+            netNewBytes: entries.reduce((sum, e) => sum + e.bytes, 0),
+            spotlightRefs,
+          },
+          "memory-v3 shadow: would inject net-new cards + spotlight",
+        );
+        return null;
+      }
+
+      recordInjected(ctx.conversationId, entries);
+
+      // Empty net-new → empty-text block: assembly attaches no content
+      // (`applyInjectionBlock` no-ops empty text) but the block's presence
+      // still marks v3 as this turn's `<memory>` source for v2 suppression.
+      const inner = renderCardsBlockInner(cards.map((c) => c.card));
       return {
         id: MEMORY_V3_BLOCK_ID,
-        text,
+        text: inner.length === 0 ? "" : wrapMemoryBlock(inner),
         // Mirror v2's dynamic `<memory>` block placement.
         placement: "after-memory-prefix",
       };
@@ -72,6 +272,49 @@ export const memoryV3Injector: Injector = {
           conversationId: ctx.conversationId,
         },
         "memory-v3 live render failed (non-fatal) — falling back to v2",
+      );
+      return null;
+    }
+  },
+};
+
+export const memoryV3SpotlightInjector: Injector = {
+  name: "memory-v3-spotlight",
+  // After the cards injector so the shared memo is (usually) already primed.
+  order: 1001,
+  async produce(ctx: TurnContext): Promise<InjectionBlock | null> {
+    const config = getConfig();
+    // Live-only: shadow mode logs spotlight refs from the cards injector and
+    // must keep the turn untouched (no ring state either, so a later
+    // live-flag flip starts from a clean window).
+    if (!isAssistantFeatureFlagEnabled(MEMORY_V3_LIVE, config)) return null;
+
+    try {
+      const result = await observeTurnOnce(ctx.conversationId, ctx.turnIndex);
+      if (!result || result.selections.length === 0) return null;
+
+      const { n, windowTurns } = config.memory.v3.spotlight;
+      const current = computeSpotlightEntries(result, n);
+      const window = updateSpotlightWindow(
+        ctx.conversationId,
+        ctx.turnIndex,
+        current,
+        windowTurns,
+      );
+      if (window.length === 0) return null;
+
+      return {
+        id: MEMORY_V3_SPOTLIGHT_BLOCK_ID,
+        text: wrapMemorySpotlightBlock(renderSpotlightInner(window)),
+        placement: "append-user-tail",
+      };
+    } catch (err) {
+      log.warn(
+        {
+          err: err instanceof Error ? err.message : String(err),
+          conversationId: ctx.conversationId,
+        },
+        "memory-v3 spotlight render failed (non-fatal) — skipping spotlight",
       );
       return null;
     }

--- a/assistant/src/plugins/defaults/memory-v3-shadow/page-content.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/page-content.ts
@@ -1,6 +1,7 @@
 import { readPage, renderPageContent } from "../../../memory/v2/page-store.js";
 import { getWorkspaceDir } from "../../../util/platform.js";
 import { renderCapabilityContent } from "./capabilities.js";
+import { renderCard } from "./card.js";
 import type { Section, Slug } from "./types.js";
 
 /**
@@ -38,6 +39,31 @@ export async function renderV3PageContent(slug: Slug): Promise<string> {
     const content = renderPageContent(page).trim();
     if (content.length === 0) return "";
     return withConceptHeader(slug, content);
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Render a selected page's compact CARD for the v3 frozen-injection layer:
+ * the `# memory/concepts/<slug>.md` header, the page's head section, and a
+ * one-line section TOC (see `card.ts`). Cards are the persistent injection
+ * unit — frozen into history once and deduped by the everInjected store.
+ *
+ * - Capability slugs (skills, `assistant` CLI commands) have no on-disk page
+ *   and no meaningful head/TOC split, so they render their full capability
+ *   content via {@link renderCapabilityContent} (its own `# Skill:` /
+ *   `# CLI command:` header) instead of a card.
+ * - A missing page or any read failure degrades to "" — the injector skips
+ *   empty cards rather than throwing into the turn.
+ */
+export async function renderV3CardContent(slug: Slug): Promise<string> {
+  const capability = renderCapabilityContent(slug);
+  if (capability !== null) return capability;
+  try {
+    const page = await readPage(getWorkspaceDir(), slug);
+    if (!page) return "";
+    return renderCard(slug, renderPageContent(page));
   } catch {
     return "";
   }

--- a/assistant/src/plugins/defaults/memory-v3-shadow/render-injection.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/render-injection.ts
@@ -2,17 +2,68 @@ import { wrapMemoryBlock } from "../../../memory/memory-marker.js";
 import { Section, Slug } from "./types.js";
 
 /**
- * Render a v3 selection into a single `<memory>…</memory>` text block,
+ * Leading instruction line of the frozen card block — byte-identical to v2's
+ * `INJECTION_HEADER` (`memory/v2/injection.ts`) so the read affordance the
+ * model already knows applies to cards unchanged: every card carries a
+ * `# memory/concepts/<slug>.md` path header it can `file_read`.
+ */
+export const V3_CARDS_INJECTION_HEADER =
+  'Use `file_read("memory/concepts/path/to/file.md")` to read the full pages for any of the injected memory summaries you want more information on.';
+
+/**
+ * Render the UNWRAPPED inner text of a frozen net-new card block: the v2-style
+ * instruction header followed by the rendered cards, blank-line separated.
+ * Returns `""` for an empty card list (the injector attaches no block and the
+ * caller persists nothing). The caller wraps the result via
+ * {@link wrapMemoryBlock} exactly once at injection time and persists the
+ * unwrapped form to message metadata — the same wrap-on-use contract as v2's
+ * `memoryInjectedBlock`.
+ */
+export function renderCardsBlockInner(cards: string[]): string {
+  if (cards.length === 0) return "";
+  return [V3_CARDS_INJECTION_HEADER, ...cards].join("\n\n");
+}
+
+/**
+ * One ephemeral spotlight entry: a selected finder hit's matched section.
+ * `title` is the matched section's heading; `text` its indexed section text.
+ */
+export interface SpotlightEntry {
+  slug: Slug;
+  title: string;
+  text: string;
+}
+
+/**
+ * Render the UNWRAPPED inner text of the ephemeral `<memory_spotlight>` block:
+ * one `## memory/concepts/<slug>.md § <section heading>` header plus section
+ * text per entry, blank-line separated. Returns `""` for an empty window (the
+ * injector attaches no block). The caller wraps via
+ * `wrapMemorySpotlightBlock`.
+ */
+export function renderSpotlightInner(entries: SpotlightEntry[]): string {
+  return entries
+    .map(
+      (entry) =>
+        `## memory/concepts/${entry.slug}.md § ${entry.title}\n${entry.text}`,
+    )
+    .join("\n\n");
+}
+
+/**
+ * Render a v3 selection set into a single `<memory>…</memory>` text block,
  * injecting each slug's matched section (progressive disclosure) rather than
  * its full page body.
+ *
+ * INSPECTOR-ONLY: live injection no longer renders the whole selection set —
+ * the injector freezes net-new CARDS into history ({@link renderCardsBlockInner})
+ * and re-renders the ephemeral spotlight separately. This whole-set render
+ * remains for the inspector's selection log (`selection-log-store.ts`), which
+ * reconstructs an approximate view of a turn's selection after the fact.
  *
  * Pure and side-effect-free: all I/O is delegated to the injected
  * `pageContent` resolver, which is awaited once per slug in input order with
  * that slug's matched section (`sectionBySlug.get(slug)`, possibly undefined).
- * The resulting block uses the shared {@link wrapMemoryBlock} marker — the same
- * wrapper the v2 graph-memory path emits — so the existing strip machinery in
- * `conversation-graph-memory.ts` already recognizes (and evicts) it.
- *
  * Resolution is concurrent; the rendered block preserves `slugs` order
  * regardless of which fetch settles first.
  *
@@ -24,7 +75,7 @@ import { Section, Slug } from "./types.js";
  * @param pageContent - Resolver returning a slug's rendered content given its
  *   matched section (or undefined).
  * @returns The wrapped `<memory>` block, or `""` for an empty selection (the
- *   caller injects nothing).
+ *   caller renders nothing).
  */
 export async function renderMemoryBlock(
   slugs: Slug[],

--- a/assistant/src/plugins/defaults/memory-v3-shadow/types.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/types.ts
@@ -11,6 +11,14 @@ export type Slug = string;
 export const MEMORY_V3_BLOCK_ID = "memory-v3" as const;
 
 /**
+ * Injection-block id for the v3 ephemeral `<memory_spotlight>` block (the
+ * current window's matched sections, re-rendered at the user tail each turn).
+ * Distinct from {@link MEMORY_V3_BLOCK_ID}: the spotlight never participates
+ * in v2 suppression and is never persisted to message metadata.
+ */
+export const MEMORY_V3_SPOTLIGHT_BLOCK_ID = "memory-v3-spotlight" as const;
+
+/**
  * A single section of a page: the lead (text before the first `## heading`,
  * ordinal 0) or a heading-delimited block. Over-long sections are split into
  * multiple ordered `Section`s, each with its own consecutive `ordinal`, so each


### PR DESCRIPTION
## Summary
- Persistent layer: net-new cards frozen per-message via the v3 metadata key + conversation.ts rehydration (mirrors v2's memoryInjectedBlock mechanism — cached prefix, survives restarts)
- Ephemeral spotlight: current-window matched sections in a tail block, strip-replaced each turn, never accumulated; registered for compaction stripping
- Compaction clears the v3 dedup store at the same trigger as v2; old whole-set strip-and-replace render deleted

Flag this PR for careful review: assembly semantics.

Part of plan: memory-v3-cache-aware-carry.md (PR 7 of 11)