### PR TITLE
feat(web): download all invoices as a single zip instead of one tab per PDF

### DIFF
--- a/apps/web/src/domains/chat/inspector/inspect-page.tsx
+++ b/apps/web/src/domains/chat/inspector/inspect-page.tsx
@@ -12,7 +12,6 @@ import {
 import {
     buildInspectorExportFilename,
     buildInspectorExportZipBlob,
-    downloadBlob,
 } from "@/domains/chat/inspector/inspector-export";
 import {
     llmLogPayloadQueryOptions,
@@ -20,6 +19,7 @@ import {
 } from "@/domains/chat/inspector/inspector-payload-api";
 import { normalizeContentBlocks } from "@/domains/chat/api/messages";
 import { useAuthStore, useIsSessionInitializing } from "@/stores/auth-store";
+import { downloadBlob } from "@/utils/download-blob";
 import { routes } from "@/utils/routes";
 import type {
   ConversationContentBlock,

--- a/apps/web/src/domains/chat/inspector/inspector-export.ts
+++ b/apps/web/src/domains/chat/inspector/inspector-export.ts
@@ -122,17 +122,6 @@ export async function buildInspectorExportZipBlob(
   return zip.generateAsync({ type: "blob", mimeType: "application/zip" });
 }
 
-export function downloadBlob(blob: Blob, filename: string): void {
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement("a");
-  a.href = url;
-  a.download = filename;
-  document.body.appendChild(a);
-  a.click();
-  a.remove();
-  URL.revokeObjectURL(url);
-}
-
 function extractActualUserMessages(
   logs: LLMRequestLogEntry[],
 ): ActualUserMessageExport[] {

--- a/apps/web/src/domains/settings/components/invoices-modal.test.tsx
+++ b/apps/web/src/domains/settings/components/invoices-modal.test.tsx
@@ -1,0 +1,205 @@
+/**
+ * Tests for the InvoicesModal "Download all" zip flow.
+ *
+ * Strategy: pre-seed the invoice list into the React Query cache so the modal
+ * renders synchronously, and mock the generated SDK's zip download plus the
+ * shared `downloadBlob` helper and the toast module. Covers: one SDK call →
+ * one saved `invoices.zip` (never one download per invoice), the error toast
+ * on a non-OK response, and the disabled button while the request is in
+ * flight.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+
+import * as sdkGen from "@/generated/api/sdk.gen";
+import { organizationsBillingInvoicesRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
+import type { Invoice } from "@/generated/api/types.gen";
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+type DownloadResult = {
+  data?: Blob;
+  response: { ok: boolean; status: number };
+};
+
+function okDownloadResult(): DownloadResult {
+  return {
+    data: new Blob(["zip"], { type: "application/zip" }),
+    response: { ok: true, status: 200 },
+  };
+}
+
+let downloadRetrieveCalls = 0;
+let downloadRetrieveResult: () => Promise<DownloadResult> = async () =>
+  okDownloadResult();
+
+mock.module("@/generated/api/sdk.gen", () => ({
+  ...sdkGen,
+  organizationsBillingInvoicesDownloadRetrieve: () => {
+    downloadRetrieveCalls += 1;
+    return downloadRetrieveResult();
+  },
+}));
+
+let downloadBlobCalls: { blob: Blob; filename: string }[] = [];
+
+mock.module("@/utils/download-blob", () => ({
+  downloadBlob: (blob: Blob, filename: string) => {
+    downloadBlobCalls.push({ blob, filename });
+  },
+}));
+
+let toastErrorCalls: string[] = [];
+
+mock.module("@vellumai/design-library/components/toast", () => ({
+  toast: {
+    success: () => {},
+    error: (message: string) => {
+      toastErrorCalls.push(message);
+    },
+  },
+  Toaster: () => null,
+  ToastContent: () => null,
+}));
+
+import { InvoicesModal } from "./invoices-modal";
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+function makeInvoice(id: string): Invoice {
+  return {
+    id,
+    number: `INV-${id}`,
+    status: "paid",
+    currency: "usd",
+    amount_due: 1000,
+    amount_paid: 1000,
+    amount_remaining: 0,
+    created: 1735689600,
+    hosted_invoice_url: `https://invoice.example.com/${id}`,
+    invoice_pdf: `https://invoice.example.com/${id}.pdf`,
+  };
+}
+
+function renderModal(): ReturnType<typeof render> {
+  // staleTime: Infinity keeps the pre-seeded list from refetching on mount,
+  // so the test never touches the network.
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
+  client.setQueryData(organizationsBillingInvoicesRetrieveQueryKey(), {
+    invoices: [makeInvoice("1"), makeInvoice("2"), makeInvoice("3")],
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <InvoicesModal open onOpenChange={() => {}} />
+    </QueryClientProvider>,
+  );
+}
+
+function getDownloadAllButton(
+  result: ReturnType<typeof render>,
+): HTMLButtonElement {
+  return result.getByText("Download all").closest("button")!;
+}
+
+beforeEach(() => {
+  downloadRetrieveCalls = 0;
+  downloadRetrieveResult = async () => okDownloadResult();
+  downloadBlobCalls = [];
+  toastErrorCalls = [];
+});
+
+afterEach(cleanup);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("InvoicesModal download all", () => {
+  test("clicking Download all fetches the zip once and saves a single invoices.zip", async () => {
+    const result = renderModal();
+
+    fireEvent.click(getDownloadAllButton(result));
+
+    await waitFor(() => {
+      if (downloadBlobCalls.length === 0) {
+        throw new Error("downloadBlob not called");
+      }
+    });
+
+    // One SDK call and one saved file — never one download per invoice.
+    expect(downloadRetrieveCalls).toBe(1);
+    expect(downloadBlobCalls).toHaveLength(1);
+    expect(downloadBlobCalls[0]!.filename).toBe("invoices.zip");
+    expect(toastErrorCalls).toHaveLength(0);
+  });
+
+  test("a non-OK response shows the error toast and saves nothing", async () => {
+    downloadRetrieveResult = () =>
+      Promise.resolve({ response: { ok: false, status: 404 } });
+    const result = renderModal();
+
+    fireEvent.click(getDownloadAllButton(result));
+
+    await waitFor(() => {
+      if (toastErrorCalls.length === 0) {
+        throw new Error("toast.error not called");
+      }
+    });
+
+    expect(toastErrorCalls).toEqual(["Failed to download invoices."]);
+    expect(downloadBlobCalls).toHaveLength(0);
+  });
+
+  test("a thrown network error shows the error toast and saves nothing", async () => {
+    downloadRetrieveResult = () => Promise.reject(new Error("network down"));
+    const result = renderModal();
+
+    fireEvent.click(getDownloadAllButton(result));
+
+    await waitFor(() => {
+      if (toastErrorCalls.length === 0) {
+        throw new Error("toast.error not called");
+      }
+    });
+
+    expect(toastErrorCalls).toEqual(["Failed to download invoices."]);
+    expect(downloadBlobCalls).toHaveLength(0);
+  });
+
+  test("the button is disabled while the request is in flight and re-enabled after", async () => {
+    let resolveDownload: (value: DownloadResult) => void;
+    downloadRetrieveResult = () =>
+      new Promise<DownloadResult>((resolve) => {
+        resolveDownload = resolve;
+      });
+    const result = renderModal();
+    const button = getDownloadAllButton(result);
+
+    expect(button.disabled).toBe(false);
+
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      if (!getDownloadAllButton(result).disabled) {
+        throw new Error("button not disabled while in flight");
+      }
+    });
+
+    resolveDownload!(okDownloadResult());
+
+    await waitFor(() => {
+      if (getDownloadAllButton(result).disabled) {
+        throw new Error("button still disabled after resolution");
+      }
+    });
+    expect(downloadBlobCalls).toHaveLength(1);
+  });
+});

--- a/apps/web/src/domains/settings/components/invoices-modal.test.tsx
+++ b/apps/web/src/domains/settings/components/invoices-modal.test.tsx
@@ -53,6 +53,14 @@ mock.module("@/utils/download-blob", () => ({
   },
 }));
 
+let captureErrorCalls: { error: unknown; context: string }[] = [];
+
+mock.module("@/lib/sentry/capture-error", () => ({
+  captureError: (error: unknown, opts: { context: string }) => {
+    captureErrorCalls.push({ error, context: opts.context });
+  },
+}));
+
 let toastErrorCalls: string[] = [];
 
 mock.module("@vellumai/design-library/components/toast", () => ({
@@ -113,6 +121,7 @@ beforeEach(() => {
   downloadRetrieveCalls = 0;
   downloadRetrieveResult = async () => okDownloadResult();
   downloadBlobCalls = [];
+  captureErrorCalls = [];
   toastErrorCalls = [];
 });
 
@@ -156,6 +165,8 @@ describe("InvoicesModal download all", () => {
 
     expect(toastErrorCalls).toEqual(["Failed to download invoices."]);
     expect(downloadBlobCalls).toHaveLength(0);
+    expect(captureErrorCalls).toHaveLength(1);
+    expect(captureErrorCalls[0]!.context).toBe("download_all_invoices");
   });
 
   test("a thrown network error shows the error toast and saves nothing", async () => {
@@ -172,6 +183,8 @@ describe("InvoicesModal download all", () => {
 
     expect(toastErrorCalls).toEqual(["Failed to download invoices."]);
     expect(downloadBlobCalls).toHaveLength(0);
+    expect(captureErrorCalls).toHaveLength(1);
+    expect(captureErrorCalls[0]!.context).toBe("download_all_invoices");
   });
 
   test("the button is disabled while the request is in flight and re-enabled after", async () => {

--- a/apps/web/src/domains/settings/components/invoices-modal.tsx
+++ b/apps/web/src/domains/settings/components/invoices-modal.tsx
@@ -1,15 +1,21 @@
 import { Download, ExternalLink, FileText, Loader2 } from "lucide-react";
+import { useState } from "react";
 
 import { useQuery } from "@tanstack/react-query";
 
 import { organizationsBillingInvoicesRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
-import { organizationsBillingInvoicesRetrieve } from "@/generated/api/sdk.gen";
+import {
+  organizationsBillingInvoicesDownloadRetrieve,
+  organizationsBillingInvoicesRetrieve,
+} from "@/generated/api/sdk.gen";
 import type { Invoice, InvoiceListResponse } from "@/generated/api/types.gen";
+import { downloadBlob } from "@/utils/download-blob";
 import { formatFriendlyDate } from "@/utils/format-date";
 import { Button } from "@vellumai/design-library/components/button";
 import { Modal } from "@vellumai/design-library/components/modal";
 import { Notice } from "@vellumai/design-library/components/notice";
 import { Tag, type TagTone } from "@vellumai/design-library/components/tag";
+import { toast } from "@vellumai/design-library/components/toast";
 import { Typography } from "@vellumai/design-library/components/typography";
 
 const EMPTY_RESPONSE: InvoiceListResponse = { invoices: [] };
@@ -77,6 +83,8 @@ interface InvoicesModalProps {
 }
 
 export function InvoicesModal({ open, onOpenChange }: InvoicesModalProps) {
+  const [isDownloadingAll, setIsDownloadingAll] = useState(false);
+
   const invoicesQuery = useQuery({
     queryKey: organizationsBillingInvoicesRetrieveQueryKey(),
     enabled: open,
@@ -104,6 +112,32 @@ export function InvoicesModal({ open, onOpenChange }: InvoicesModalProps) {
     (invoice): invoice is Invoice & { invoice_pdf: string } =>
       invoice.invoice_pdf != null,
   );
+
+  /**
+   * Download every invoice PDF as a single server-assembled zip. Stripe's
+   * `invoice_pdf` URLs don't serve CORS headers, so the archive must be built
+   * server-side; the SDK call routes through the platform client so the
+   * interceptor attaches the org/session headers.
+   */
+  async function downloadAllInvoices(): Promise<void> {
+    setIsDownloadingAll(true);
+    try {
+      const { data, response } =
+        await organizationsBillingInvoicesDownloadRetrieve({
+          throwOnError: false,
+        });
+      if (!response?.ok || !(data instanceof Blob)) {
+        throw new Error(
+          `Failed to download invoices (${response?.status ?? "network error"})`,
+        );
+      }
+      downloadBlob(data, "invoices.zip");
+    } catch {
+      toast.error("Failed to download invoices.");
+    } finally {
+      setIsDownloadingAll(false);
+    }
+  }
 
   return (
     <Modal.Root open={open} onOpenChange={onOpenChange}>
@@ -202,12 +236,15 @@ export function InvoicesModal({ open, onOpenChange }: InvoicesModalProps) {
           {downloadable.length > 0 && (
             <Button
               variant="outlined"
-              leftIcon={<Download />}
-              onClick={() => {
-                for (const invoice of downloadable) {
-                  downloadPdf(invoice.invoice_pdf);
-                }
-              }}
+              leftIcon={
+                isDownloadingAll ? (
+                  <Loader2 className="animate-spin" />
+                ) : (
+                  <Download />
+                )
+              }
+              disabled={isDownloadingAll}
+              onClick={downloadAllInvoices}
             >
               Download all
             </Button>

--- a/apps/web/src/domains/settings/components/invoices-modal.tsx
+++ b/apps/web/src/domains/settings/components/invoices-modal.tsx
@@ -9,6 +9,7 @@ import {
   organizationsBillingInvoicesRetrieve,
 } from "@/generated/api/sdk.gen";
 import type { Invoice, InvoiceListResponse } from "@/generated/api/types.gen";
+import { captureError } from "@/lib/sentry/capture-error";
 import { downloadBlob } from "@/utils/download-blob";
 import { formatFriendlyDate } from "@/utils/format-date";
 import { Button } from "@vellumai/design-library/components/button";
@@ -132,7 +133,8 @@ export function InvoicesModal({ open, onOpenChange }: InvoicesModalProps) {
         );
       }
       downloadBlob(data, "invoices.zip");
-    } catch {
+    } catch (error) {
+      captureError(error, { context: "download_all_invoices" });
       toast.error("Failed to download invoices.");
     } finally {
       setIsDownloadingAll(false);

--- a/apps/web/src/utils/download-blob.ts
+++ b/apps/web/src/utils/download-blob.ts
@@ -1,0 +1,14 @@
+/**
+ * Save a Blob as a browser download via a temporary object URL and a
+ * synthetic `<a download>` click.
+ */
+export function downloadBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary
- Replace the per-invoice tab-opening loop behind the invoices modal's Download all button with a single authenticated zip download via the new platform endpoint
- Extract downloadBlob into shared src/utils/download-blob.ts
- Add invoices-modal.test.tsx covering success, failure-toast, and in-flight disabled states

Part of plan: invoices-zip-download.md (PR 1 of 1)