### PR TITLE
refactor(web): remove auto-hatch from lifecycle service

### DIFF
--- a/apps/web/src/assistant/lifecycle-service.test.ts
+++ b/apps/web/src/assistant/lifecycle-service.test.ts
@@ -313,74 +313,29 @@ describe("lifecycleService — bootstrap branches", () => {
   });
 });
 
-describe("lifecycleService — auto-hatch cascade", () => {
-  test("404 → auto_hatch path issues hatchAssistant and lands the seeded id", async () => {
-    // checkAssistant fetches the cache, gets a 404, which
-    // resolves to `auto_hatch`. With no onboarding redirect, the
-    // service then issues hatchAssistant,
-    // which succeeds and seeds the cache.
-    getAssistantMock.mockImplementationOnce(async () => ({
-      ok: false,
-      status: 404,
-    }));
-    hatchAssistantMock.mockImplementationOnce(async () => ({
-      ok: true,
-      status: 201,
-      data: { id: "asst-hatched-1", status: "initializing" },
-    }));
-
-    lifecycleService.setInputs({
-      ...baseInputs,
-      queryClient: makeQueryClient(),
-    });
-    await lifecycleService.checkAssistant();
-
-    expect(hatchAssistantMock).toHaveBeenCalledTimes(1);
-    expect(useAssistantLifecycleStore.getState().assistantState.kind).toBe(
-      "initializing",
-    );
-  });
-
-  test("auto_hatch + isRetired transitions to retired (no hatch)", async () => {
+describe("lifecycleService — 404 (no assistant)", () => {
+  test("404 is a no-op — no hatch, no redirect, no state transition", async () => {
     getAssistantMock.mockImplementationOnce(async () => ({
       ok: false,
       status: 404,
     }));
 
+    const onRedirect = mock(() => {});
     lifecycleService.setInputs({
       ...baseInputs,
-      isRetired: true,
+      onRedirect,
       queryClient: makeQueryClient(),
     });
     await lifecycleService.checkAssistant();
 
     expect(hatchAssistantMock).not.toHaveBeenCalled();
+    expect(onRedirect).not.toHaveBeenCalled();
     expect(useAssistantLifecycleStore.getState().assistantState.kind).toBe(
-      "retired",
+      "loading",
     );
   });
 
-  test("vanilla auto_hatch marks expecting-first-message — chat-page consumes it on mount", async () => {
-    getAssistantMock.mockImplementationOnce(async () => ({
-      ok: false,
-      status: 404,
-    }));
-    hatchAssistantMock.mockImplementationOnce(async () => ({
-      ok: true,
-      status: 201,
-      data: { id: "asst-fresh", status: "initializing" },
-    }));
-
-    lifecycleService.setInputs({
-      ...baseInputs,
-      queryClient: makeQueryClient(),
-    });
-    await lifecycleService.checkAssistant();
-
-    expect(useAssistantLifecycleStore.getState().expectingFirstMessage).toBe(true);
-  });
-
-  test("auto_hatch + isRetired does NOT mark expecting-first-message", async () => {
+  test("404 does not mark expecting-first-message", async () => {
     getAssistantMock.mockImplementationOnce(async () => ({
       ok: false,
       status: 404,
@@ -388,7 +343,6 @@ describe("lifecycleService — auto-hatch cascade", () => {
 
     lifecycleService.setInputs({
       ...baseInputs,
-      isRetired: true,
       queryClient: makeQueryClient(),
     });
     await lifecycleService.checkAssistant();
@@ -481,20 +435,10 @@ describe("lifecycleService — stuck-initializing watchdog", () => {
 });
 
 describe("lifecycleService — retry budget exhaustion", () => {
-  test("3 recoverable hatch failures in the auto-hatch poll loop surface as error", async () => {
-    // Server says 404 (no assistant) → service hits the auto_hatch
-    // branch → calls hatchAssistant. The mock returns a recoverable
-    // 5xx, so each pass increments `hatchRetryCount` without ever
-    // succeeding. Three failed `checkAssistant`s reach the budget;
-    // the fourth surfaces the terminal error state.
+  test("repeated 404s are no-ops — no hatch retries, no state change", async () => {
     getAssistantMock.mockImplementation(async () => ({
       ok: false,
       status: 404,
-    }));
-    hatchAssistantMock.mockImplementation(async () => ({
-      ok: false,
-      status: 502,
-      error: { message: "bad gateway" },
     }));
 
     lifecycleService.setInputs({
@@ -505,13 +449,10 @@ describe("lifecycleService — retry budget exhaustion", () => {
     await lifecycleService.checkAssistant();
     await lifecycleService.checkAssistant();
     await lifecycleService.checkAssistant();
-    expect(useAssistantLifecycleStore.getState().assistantState.kind).toBe(
-      "initializing",
-    );
 
-    await lifecycleService.checkAssistant();
+    expect(hatchAssistantMock).not.toHaveBeenCalled();
     expect(useAssistantLifecycleStore.getState().assistantState.kind).toBe(
-      "error",
+      "loading",
     );
   });
 });

--- a/apps/web/src/assistant/lifecycle-service.ts
+++ b/apps/web/src/assistant/lifecycle-service.ts
@@ -240,12 +240,30 @@ class AssistantLifecycleService {
       // doesn't silently replay. Poll-driven projections go through
       // `applyServerResult` to avoid the read-back loop.
       const selectedId = this.inputs.selectedPlatformAssistantId ?? null;
-      const result = await this.inputs.queryClient.fetchQuery({
+      let result = await this.inputs.queryClient.fetchQuery({
         queryKey: assistantQueryKey(selectedId),
         queryFn: () => getAssistant(selectedId ?? undefined),
         staleTime: 0,
       });
       if (generation !== this.generation) return;
+      // If the selected assistant 404s (retired/deleted), clear the
+      // stale selection and retry without an ID so the lifecycle
+      // falls back to the default first-listed assistant.
+      if (selectedId && !result.ok && result.status === 404) {
+        const store = useResolvedAssistantsStore.getState();
+        const byOrg = store.selectedPlatformAssistantByOrg;
+        for (const orgId of Object.keys(byOrg)) {
+          if (byOrg[orgId] === selectedId) {
+            store.setSelectedPlatformAssistant(orgId, null);
+          }
+        }
+        result = await this.inputs.queryClient.fetchQuery({
+          queryKey: ASSISTANT_QUERY_KEY,
+          queryFn: () => getAssistant(),
+          staleTime: 0,
+        });
+        if (generation !== this.generation) return;
+      }
       await this.applyServerStateUpdate(result);
     } catch (err) {
       console.error("Error checking assistant status:", err);

--- a/apps/web/src/assistant/lifecycle-service.ts
+++ b/apps/web/src/assistant/lifecycle-service.ts
@@ -412,26 +412,9 @@ class AssistantLifecycleService {
     }
 
     if (nextState.kind === "auto_hatch") {
-      // If we just retired, show the retired screen instead of auto-hatching.
-      if (this.inputs.isRetired) {
-        this.transition({ kind: "retired" });
-        return;
-      }
-      // New signups without completed onboarding land on
-      // `/onboarding/privacy` before we hatch an assistant for them.
-      const onboardingRedirect = this.inputs.resolveOnboardingRedirect({
-        intendedDestination: window.location.pathname,
-      });
-      if (onboardingRedirect) {
-        this.inputs.onRedirect(onboardingRedirect);
-        return;
-      }
-      // Auto-hatch: a new signup with no assistant lands here.
-      // Mark the auto-greet one-shot so the next `ChatPage` mount
-      // shows the loading gate until the server's greeting SSE
-      // arrives.
-      this.markExpectingFirstMessage();
-      await this.hatchAndCheck();
+      // No assistant found. Don't hatch or redirect — the navigation
+      // resolver's requireAssistant step handles routing to the
+      // correct onboarding screen. Just leave the current state as-is.
       return;
     }
 

--- a/apps/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
+++ b/apps/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
@@ -194,6 +194,7 @@ mock.module("@/lib/local-mode", () => ({
   getSelectedAssistant: () => undefined,
   loadLockfile: async () => ({ assistants: [], activeAssistant: null }),
   setSelectedAssistantId: () => {},
+  setActiveLockfileAssistant: async () => {},
   saveLockfileAssistant: async () => {},
   primeLocalGatewayConnection: async () => {},
   getLocalGatewayUrl: () => undefined,
@@ -201,6 +202,26 @@ mock.module("@/lib/local-mode", () => ({
 
 mock.module("@/runtime/local-mode-host", () => ({
   hatchLocalAssistant: async () => ({ ok: true, assistantId: "local-1" }),
+}));
+
+mock.module("@/assistant/select-platform-assistant", () => ({
+  selectPlatformAssistant: async () => {},
+}));
+
+mock.module("@/stores/resolved-assistants-store", () => ({
+  useResolvedAssistantsStore: {
+    getState: () => ({
+      assistants: [],
+      activeAssistantId: null,
+      upsertFromApi: () => {},
+      setActiveAssistantId: () => {},
+    }),
+    use: {
+      assistants: () => [],
+      activeAssistantId: () => null,
+      selectedPlatformAssistantByOrg: () => ({}),
+    },
+  },
 }));
 
 mock.module("@/stores/client-feature-flag-store", () => ({

--- a/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -286,6 +286,13 @@ export function HatchingScreen() {
             } catch (err) {
               captureError(err, { context: "onboarding_apply_provider_key" });
             }
+            useResolvedAssistantsStore.getState().upsertFromApi({
+              id: result.assistantId,
+              name: result.assistantId,
+              status: "active",
+              is_local: true,
+              created: new Date().toISOString(),
+            } as import("@/assistant/api").Assistant);
             void selectPlatformAssistant(result.assistantId);
           }
 

--- a/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -286,6 +286,7 @@ export function HatchingScreen() {
             } catch (err) {
               captureError(err, { context: "onboarding_apply_provider_key" });
             }
+            void selectPlatformAssistant(result.assistantId);
           }
 
           handleHatchReady();

--- a/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -24,7 +24,9 @@ import { resolveNavigation } from "@/lib/navigation/navigation-resolver";
 import { buildNavigationState } from "@/lib/navigation/build-state";
 import { hatchLocalAssistant } from "@/runtime/local-mode-host";
 import { isNativePlatform } from "@/runtime/native-auth";
+import { selectPlatformAssistant } from "@/assistant/select-platform-assistant";
 import { useAuthStore } from "@/stores/auth-store";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import type { CharacterTraits } from "@/types/avatar";
 import { extractErrorMessage } from "@/utils/api-errors";
 import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
@@ -142,6 +144,7 @@ export function HatchingScreen() {
     let navigateTimer: ReturnType<typeof setTimeout> | null = null;
     let readyPollTimer: ReturnType<typeof setTimeout> | null = null;
     const pollStartMs = Date.now();
+    let hatchedAssistantId: string | undefined;
 
     const pinnedVersion = readSelectedVersion();
 
@@ -303,6 +306,9 @@ export function HatchingScreen() {
         const result = await platformHatchPromise;
         platformHatchPromise = null;
         if (cancelled) return;
+        if (result.ok) {
+          hatchedAssistantId = result.data.id;
+        }
         if (!result.ok) {
           Sentry.captureMessage("Onboarding hatch request failed", {
             level: "warning",
@@ -353,12 +359,21 @@ export function HatchingScreen() {
         return;
       }
       try {
-        const result = await getAssistant();
+        let result = await getAssistant(hatchedAssistantId);
         if (cancelled) return;
+        // If the hatched ID 404s (e.g. stale after refresh, or backend
+        // assigned a different ID), fall back to list-based discovery.
+        if (hatchedAssistantId && !result.ok && result.status === 404) {
+          hatchedAssistantId = undefined;
+          result = await getAssistant();
+          if (cancelled) return;
+        }
         const next = resolveAssistantLifecycleState(result);
         if (next.kind === "active") {
           if (result.ok) {
             const assistantId = result.data.id;
+            useResolvedAssistantsStore.getState().upsertFromApi(result.data);
+            void selectPlatformAssistant(assistantId);
             fetchCharacterTraits(assistantId).then((existing) => {
               if (existing) return;
               return saveCharacterTraits(assistantId, hatchTraits);

--- a/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -3,7 +3,7 @@ import * as Sentry from "@sentry/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 
-import { getAssistant, hatchAssistant } from "@/assistant/api";
+import { getAssistant, hatchAssistant, type Assistant } from "@/assistant/api";
 import { fetchCharacterTraits, saveCharacterTraits } from "@/assistant/avatar-api";
 import {
     isPlatformHostedDisabled,
@@ -292,7 +292,7 @@ export function HatchingScreen() {
               status: "active",
               is_local: true,
               created: new Date().toISOString(),
-            } as import("@/assistant/api").Assistant);
+            } as Assistant);
             void selectPlatformAssistant(result.assistantId);
           }
 

--- a/apps/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -76,15 +76,17 @@ export function SelectAssistantScreen() {
 
   // Auto-skip when there's exactly one assistant and it's accessible.
   // Don't skip when the user just logged in — let them see the now-enabled option.
+  // Reactive to assistants so it fires when the store populates after mount.
   useEffect(() => {
     if (fromLogin) return;
+    if (connecting || autoSkipping) return;
     if (assistants.length === 0) return;
     if (assistants.length === 1 && accessibleAssistants.length === 1) {
       setAutoSkipping(true);
       void handleConnect(accessibleAssistants[0]);
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [assistants.length, accessibleAssistants.length]);
 
   const onContinue = () => {
     const assistant = assistants.find((a) => a.id === selected);


### PR DESCRIPTION
## Summary
- Remove auto-hatch logic from `AssistantLifecycleService` — a 404 (no assistant) is now a no-op instead of triggering hatch, redirect, or expecting-first-message
- Move hatch responsibility fully into the onboarding hatching screen: track the hatched assistant ID, fall back to list-based discovery on 404, and seed the resolved-assistants store + platform selection after hatch
- Make the select-assistant auto-skip effect reactive to store population so it fires when assistants load after mount

## Original prompt
Ship changes that decouple hatching from the lifecycle service's poll loop. The lifecycle service was auto-hatching on 404, handling onboarding redirects, and marking expecting-first-message — all of which belong in the onboarding flow. The navigation resolver's `requireAssistant` step now handles routing, and the hatching screen owns the full hatch lifecycle including store seeding and platform selection.