### PR TITLE
fix(web): poll daemon healthz before leaving hatching screen

### DIFF
--- a/apps/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
+++ b/apps/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
@@ -89,6 +89,7 @@ mock.module("@/assistant/lifecycle-service", () => ({
 mock.module("@/assistant/api", () => ({
   hatchAssistant: hatchAssistantMock,
   getAssistant: getAssistantMock,
+  getAssistantHealthz: async () => ({ ok: true, status: 200, data: { status: "ok" } }),
 }));
 
 mock.module("@/assistant/avatar-api", () => ({

--- a/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -3,7 +3,7 @@ import * as Sentry from "@sentry/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 
-import { getAssistant, hatchAssistant, type Assistant } from "@/assistant/api";
+import { getAssistant, getAssistantHealthz, hatchAssistant, type Assistant } from "@/assistant/api";
 import { fetchCharacterTraits, saveCharacterTraits } from "@/assistant/avatar-api";
 import {
     isPlatformHostedDisabled,
@@ -396,6 +396,28 @@ export function HatchingScreen() {
                 hatchedAt: new Date().toISOString(),
               });
             }
+
+            // Wait for the daemon to be reachable before navigating.
+            // The platform may report "active" before the pod is
+            // fully ready to serve requests.
+            transitionPhase("connecting");
+            while (!cancelled) {
+              try {
+                const health = await getAssistantHealthz(assistantId);
+                if (health.ok) break;
+              } catch {
+                // Daemon not reachable yet
+              }
+              if (Date.now() - pollStartMs >= MAX_HATCH_WAIT_MS) {
+                setError("Your assistant is taking longer than expected. Please try again.");
+                return;
+              }
+              await new Promise<void>(resolve => {
+                pollTimer = setTimeout(resolve, POLL_INTERVAL_MS);
+              });
+              pollTimer = null;
+            }
+            if (cancelled) return;
           }
 
           handleHatchReady();


### PR DESCRIPTION
## Summary
- After the platform reports a cloud assistant as `active`, poll `getAssistantHealthz(assistantId)` until the daemon responds before navigating away from the hatching screen
- Mirrors the local hatch path's existing `/readyz` poll, ensuring the daemon is actually reachable before the user lands on the chat page
- Adds `getAssistantHealthz` mock to onboarding lifecycle sync test

## Original prompt
The local hosting onboarding path polls `/readyz` on the gateway before leaving the hatching screen, but the Vellum Cloud path only waits for the platform to report the assistant as `active` — it never verifies the daemon is reachable. This caused users to land on the chat page before the daemon was ready, resulting in failed auto-send wake messages and an empty conversation. The fix adds an analogous healthz poll for cloud assistants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)