### PR TITLE
feat(memory-v3): resident-footprint prune valve

### DIFF
--- a/assistant/src/__tests__/conversation-lifecycle.test.ts
+++ b/assistant/src/__tests__/conversation-lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 // Stub out heavy dependencies before importing Conversation
 mock.module("../util/logger.js", () => ({
@@ -110,7 +110,37 @@ mock.module("../memory/conversation-queries.js", () => ({
   listConversations: () => [],
 }));
 
+// `loadFromDb` reads the conversation's pruned v3 card slugs (prune valve)
+// when a row carries a `memoryV3InjectedBlock`. Stub the store read so these
+// tests never touch a real DB; the stub DELEGATES to the real implementation
+// unless this file is actively running (`mock.module` is process-global and
+// would otherwise leak into sibling files that use the real store).
+const realEverInjectedStore = {
+  ...(await import("../plugins/defaults/memory-v3-shadow/ever-injected-store.js")),
+};
+let lifecycleStoreMockActive = false;
+let mockPrunedSlugs = new Set<string>();
+mock.module(
+  "../plugins/defaults/memory-v3-shadow/ever-injected-store.js",
+  () => ({
+    ...realEverInjectedStore,
+    getPrunedSlugs: (conversationId: string) =>
+      lifecycleStoreMockActive
+        ? mockPrunedSlugs
+        : realEverInjectedStore.getPrunedSlugs(conversationId),
+  }),
+);
+
 import { Conversation } from "../daemon/conversation.js";
+
+beforeEach(() => {
+  lifecycleStoreMockActive = true;
+  mockPrunedSlugs = new Set();
+});
+
+afterAll(() => {
+  lifecycleStoreMockActive = false;
+});
 
 function makeConversation(): Conversation {
   const provider = {
@@ -397,6 +427,71 @@ describe("loadFromDb metadata injection rehydration", () => {
       },
       { type: "text", text: "Tail turn" },
     ]);
+  });
+
+  test("pruned slugs' card sections are skipped at v3 rehydration (prune valve persistence)", async () => {
+    // The prune valve marks cards pruned in the everInjected store instead of
+    // rewriting the persisted metadata; the rehydration splice re-filters on
+    // every load, which is what makes a prune survive restarts.
+    mockConversation = defaultConv();
+    mockPrunedSlugs = new Set(["page-a"]);
+    mockDbMessages = [
+      {
+        id: "m1",
+        role: "user",
+        content: JSON.stringify([{ type: "text", text: "First turn" }]),
+        metadata: JSON.stringify({
+          memoryV3InjectedBlock:
+            "header line\n\n# memory/concepts/page-a.md\nhead a\n\n# memory/concepts/page-b.md\nhead b",
+        }),
+      },
+      {
+        id: "m2",
+        role: "assistant",
+        content: JSON.stringify([{ type: "text", text: "Reply" }]),
+      },
+    ];
+
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+    const messages = conversation.getMessages();
+
+    expect(messages[0].content).toEqual([
+      {
+        type: "text",
+        text: "<memory>\nheader line\n\n# memory/concepts/page-b.md\nhead b\n</memory>",
+      },
+      { type: "text", text: "First turn" },
+    ]);
+  });
+
+  test("a fully-pruned memoryV3InjectedBlock is skipped entirely at rehydration", async () => {
+    mockConversation = defaultConv();
+    mockPrunedSlugs = new Set(["page-a"]);
+    mockDbMessages = [
+      {
+        id: "m1",
+        role: "user",
+        content: JSON.stringify([{ type: "text", text: "First turn" }]),
+        metadata: JSON.stringify({
+          memoryV3InjectedBlock:
+            "header line\n\n# memory/concepts/page-a.md\nhead a",
+        }),
+      },
+      {
+        id: "m2",
+        role: "assistant",
+        content: JSON.stringify([{ type: "text", text: "Reply" }]),
+      },
+    ];
+
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+    const messages = conversation.getMessages();
+
+    // No memory block at all — an instruction header with zero cards carries
+    // no content (matches the live strip, which removes the emptied block).
+    expect(messages[0].content).toEqual([{ type: "text", text: "First turn" }]);
   });
 
   test("defensively-wrapped memoryV3InjectedBlock rehydrates singly-wrapped", async () => {

--- a/assistant/src/config/schemas/__tests__/memory-v3.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v3.test.ts
@@ -7,12 +7,44 @@ describe("MemoryV3ConfigSchema", () => {
     const parsed = MemoryV3ConfigSchema.parse({});
     expect(parsed).toEqual({
       workingSet: { maxPages: 150, evictWindow: 5 },
+      prune: { maxResidentBytes: 393216, targetResidentBytes: 262144 },
       hotSet: { k: 40, halfLifeDays: 14 },
       spotlight: { n: 6, windowTurns: 2 },
       needleK: 100,
       denseK: 100,
       edge: { hubDegree: 30, seedCount: 18, perSeed: 6, cap: 45 },
     });
+  });
+
+  test("prune: accepts partial overrides and enforces target < max", () => {
+    const parsed = MemoryV3ConfigSchema.parse({
+      prune: { maxResidentBytes: 500000 },
+    });
+    expect(parsed.prune).toEqual({
+      maxResidentBytes: 500000,
+      targetResidentBytes: 262144,
+    });
+    // target must be strictly below max (defaults included in the check).
+    expect(() =>
+      MemoryV3ConfigSchema.parse({
+        prune: { maxResidentBytes: 100000 },
+      }),
+    ).toThrow();
+    expect(() =>
+      MemoryV3ConfigSchema.parse({
+        prune: { maxResidentBytes: 1000, targetResidentBytes: 1000 },
+      }),
+    ).toThrow();
+    expect(() =>
+      MemoryV3ConfigSchema.parse({
+        prune: { maxResidentBytes: 0 },
+      }),
+    ).toThrow();
+    expect(() =>
+      MemoryV3ConfigSchema.parse({
+        prune: { targetResidentBytes: 1.5 },
+      }),
+    ).toThrow();
   });
 
   test("accepts a partial spotlight override and rejects invalid knobs", () => {

--- a/assistant/src/config/schemas/memory-v3.ts
+++ b/assistant/src/config/schemas/memory-v3.ts
@@ -121,11 +121,53 @@ export const MemoryV3SpotlightSchema = z
   })
   .describe("Memory v3 ephemeral section-spotlight tuning.");
 
+/**
+ * Prune-valve bounds on the resident (non-pruned) frozen-card footprint.
+ *
+ * Frozen cards accumulate in history with no per-turn bound, so the valve is
+ * the structural backstop: once resident card bytes exceed
+ * `maxResidentBytes`, the least-recently-selected non-core/non-hot cards are
+ * pruned until the footprint is back at `targetResidentBytes`.
+ *
+ * Defaults rationale: production v2 ran 303KB of accumulated memory unpruned
+ * on the widest observed conversation — 384KB max / 256KB target make the
+ * valve insurance for growth beyond that, not routine behavior.
+ */
+export const MemoryV3PruneSchema = z
+  .object({
+    maxResidentBytes: z
+      .number({ error: "memory.v3.prune.maxResidentBytes must be a number" })
+      .int("memory.v3.prune.maxResidentBytes must be an integer")
+      .positive("memory.v3.prune.maxResidentBytes must be a positive integer")
+      .default(393216 /* 384KB */)
+      .describe(
+        "Resident (non-pruned) card bytes above which the prune valve fires.",
+      ),
+    targetResidentBytes: z
+      .number({
+        error: "memory.v3.prune.targetResidentBytes must be a number",
+      })
+      .int("memory.v3.prune.targetResidentBytes must be an integer")
+      .positive(
+        "memory.v3.prune.targetResidentBytes must be a positive integer",
+      )
+      .default(262144 /* 256KB */)
+      .describe(
+        "Resident card bytes a fired prune reduces the footprint to (must be below maxResidentBytes).",
+      ),
+  })
+  .refine((value) => value.targetResidentBytes < value.maxResidentBytes, {
+    error:
+      "memory.v3.prune.targetResidentBytes must be less than memory.v3.prune.maxResidentBytes",
+  })
+  .describe("Memory v3 prune-valve (resident card footprint) bounds.");
+
 export const MemoryV3ConfigSchema = z
   .object({
     workingSet: MemoryV3WorkingSetSchema.default(
       MemoryV3WorkingSetSchema.parse({}),
     ),
+    prune: MemoryV3PruneSchema.default(MemoryV3PruneSchema.parse({})),
     hotSet: MemoryV3HotSetSchema.default(MemoryV3HotSetSchema.parse({})),
     spotlight: MemoryV3SpotlightSchema.default(
       MemoryV3SpotlightSchema.parse({}),

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -68,7 +68,11 @@ import {
   createContextSummaryMessage,
 } from "../plugins/defaults/compaction/window-manager.js";
 import { repairHistory } from "../plugins/defaults/history-repair/terminal.js";
-import { MEMORY_V3_INJECTED_BLOCK_METADATA_KEY } from "../plugins/defaults/memory-v3-shadow/ever-injected-store.js";
+import {
+  getPrunedSlugs,
+  MEMORY_V3_INJECTED_BLOCK_METADATA_KEY,
+} from "../plugins/defaults/memory-v3-shadow/ever-injected-store.js";
+import { filterPrunedCardSections } from "../plugins/defaults/memory-v3-shadow/prune.js";
 import {
   applyBootstrapTemplate,
   buildSystemPrompt,
@@ -813,6 +817,24 @@ export class Conversation {
       sourceChannel: this.trustContext?.sourceChannel,
       isTrustedActor: resolveTrustClass(this.trustContext) === "guardian",
     });
+    // Pruned v3 card slugs, read lazily on the first row that carries a v3
+    // block (most conversations carry none, so most loads never query). The
+    // prune valve marks cards pruned in the everInjected store instead of
+    // rewriting the persisted metadata, so the v3 rehydration splice below
+    // re-applies the filter on every load — that is what makes a prune
+    // survive daemon restarts. Defensive catch: a store failure degrades to
+    // an unfiltered (pre-prune) rehydration rather than a failed load.
+    let v3PrunedSlugsMemo: Set<string> | null = null;
+    const v3PrunedSlugs = (): Set<string> => {
+      if (v3PrunedSlugsMemo === null) {
+        try {
+          v3PrunedSlugsMemo = getPrunedSlugs(this.conversationId);
+        } catch {
+          v3PrunedSlugsMemo = new Set();
+        }
+      }
+      return v3PrunedSlugsMemo;
+    };
     const parsedMessages: Message[] = slicedDbMessages.map((m, index, arr) => {
       const isPreStripped = index < preStrippedCount;
       const role = m.role as "user" | "assistant";
@@ -924,6 +946,10 @@ export class Conversation {
           // be back in history byte-identical for the dedup (and the provider
           // prefix cache) to hold. A row carries at most one of the two keys
           // (the user-prompt-submit hook persists them mutually exclusively).
+          // Pruned slugs' card sections are filtered out here (the metadata
+          // itself is never rewritten — auditable and reversible); an
+          // all-pruned block is skipped entirely, matching the live strip in
+          // `memory-v3-shadow/prune.ts`.
           if (typeof meta[MEMORY_V3_INJECTED_BLOCK_METADATA_KEY] === "string") {
             const v3Block = meta[
               MEMORY_V3_INJECTED_BLOCK_METADATA_KEY
@@ -933,13 +959,19 @@ export class Conversation {
               v3Block.endsWith("\n</memory>")
                 ? v3Block.slice("<memory>\n".length, -"\n</memory>".length)
                 : v3Block;
-            content = [
-              {
-                type: "text" as const,
-                text: `<memory>\n${v3Inner}\n</memory>`,
-              },
-              ...content,
-            ];
+            const v3Resident = filterPrunedCardSections(
+              v3Inner,
+              v3PrunedSlugs(),
+            );
+            if (v3Resident.length > 0) {
+              content = [
+                {
+                  type: "text" as const,
+                  text: `<memory>\n${v3Resident}\n</memory>`,
+                },
+                ...content,
+              ];
+            }
           }
 
           if (!isTail && typeof meta.turnContextBlock === "string") {

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/injection.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/injection.test.ts
@@ -25,6 +25,7 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
+import { migrateAddMemoryV3Selections } from "../../../../memory/migrations/268-add-memory-v3-selections.js";
 import { migrateAddMemoryV3EverInjected } from "../../../../memory/migrations/275-add-memory-v3-ever-injected.js";
 import * as schema from "../../../../memory/schema.js";
 import type { OrchestrateResult } from "../orchestrate.js";
@@ -47,6 +48,12 @@ let injectionMockActive = false;
 let liveEnabled = false;
 let shadowEnabled = false;
 let spotlightConfig = { n: 6, windowTurns: 2 };
+/** `null` disables the prune valve (the default for tests not exercising it —
+ *  `runPruneValve` bails when the config block is absent). */
+let pruneConfig: {
+  maxResidentBytes: number;
+  targetResidentBytes: number;
+} | null = null;
 /** Canned orchestrate result per turnIndex; `null` simulates a failed turn. */
 let turnResults = new Map<number, OrchestrateResult | null>();
 const observeTurnSpy = mock(
@@ -72,6 +79,8 @@ function makeDb() {
   testSqlite = new Database(":memory:");
   const db = drizzle(testSqlite, { schema });
   migrateAddMemoryV3EverInjected(db);
+  // The prune valve's recency ranking reads `memory_v3_selections`.
+  migrateAddMemoryV3Selections(db);
   return db;
 }
 
@@ -90,8 +99,23 @@ mock.module("../../../../config/loader.js", () => ({
   ...realConfigLoader,
   getConfig: () =>
     injectionMockActive
-      ? { memory: { v3: { spotlight: spotlightConfig } } }
+      ? {
+          memory: {
+            v3: {
+              spotlight: spotlightConfig,
+              prune: pruneConfig ?? undefined,
+            },
+          },
+        }
       : realConfigLoader.getConfig(),
+}));
+
+// The prune valve resolves the live conversation through the daemon registry
+// (dynamically imported). Stub it so the deferred valve never drags the heavy
+// daemon module graph into this test process; `undefined` = "conversation not
+// live" (the valve skips the live strip).
+mock.module("../../../../daemon/conversation-registry.js", () => ({
+  findConversationOrSubagent: () => undefined,
 }));
 
 mock.module("../../../../config/assistant-feature-flags.js", () => ({
@@ -137,9 +161,15 @@ const {
   memoryV3SpotlightInjector,
   resetMemoryV3InjectorStateForTests,
 } = await import("../injector.js");
-const { getActiveSlugs, getInjected, markPruned, recordInjected } =
-  await import("../ever-injected-store.js");
+const {
+  getActiveSlugs,
+  getInjected,
+  getPrunedSlugs,
+  markPruned,
+  recordInjected,
+} = await import("../ever-injected-store.js");
 const { V3_CARDS_INJECTION_HEADER } = await import("../render-injection.js");
+const { flushPruneValveForTests } = await import("../prune.js");
 
 // ─── helpers ────────────────────────────────────────────────────────────────
 
@@ -186,11 +216,15 @@ function produceSpotlight(conversationId: string, turnIndex: number) {
   });
 }
 
-beforeEach(() => {
+beforeEach(async () => {
+  // Drain any prune-valve work the previous test's live injection deferred,
+  // so it lands against that test's DB instead of bleeding into this one.
+  await flushPruneValveForTests();
   injectionMockActive = true;
   liveEnabled = false;
   shadowEnabled = false;
   spotlightConfig = { n: 6, windowTurns: 2 };
+  pruneConfig = null;
   turnResults = new Map();
   observeTurnSpy.mockClear();
   logCalls.length = 0;
@@ -198,7 +232,9 @@ beforeEach(() => {
   resetMemoryV3InjectorStateForTests();
 });
 
-afterAll(() => {
+afterAll(async () => {
+  // Deferred valve work must finish while the mocks are still active.
+  await flushPruneValveForTests();
   injectionMockActive = false;
 });
 
@@ -267,6 +303,30 @@ describe("memoryV3Injector — frozen net-new cards", () => {
     const t2 = await produceCards("conv-1", 1);
     expect(t2!.text).toContain("# memory/concepts/page-a.md");
     expect(getActiveSlugs("conv-1")).toEqual(new Set(["page-a"]));
+  });
+
+  test("end-of-turn prune valve: fires deferred after live injection, exempting core/hot lanes", async () => {
+    liveEnabled = true;
+    // Each stubbed card is ~47 bytes; cap so the second turn tips over and
+    // one prune reaches the target.
+    pruneConfig = { maxResidentBytes: 60, targetResidentBytes: 50 };
+    const t0 = result(["page-a"]);
+    t0.lanes.core = ["page-a"]; // page-a is a core-lane member this turn…
+    turnResults.set(0, t0);
+    turnResults.set(1, result(["page-b"])); // …but not on turn 1's lanes.
+
+    await produceCards("conv-1", 0);
+    await flushPruneValveForTests();
+    // Turn 0 is within the cap — nothing pruned.
+    expect(getPrunedSlugs("conv-1").size).toBe(0);
+
+    await produceCards("conv-1", 1);
+    // The valve is DEFERRED: nothing pruned synchronously at produce time.
+    expect(getPrunedSlugs("conv-1").size).toBe(0);
+    await flushPruneValveForTests();
+    // Over the cap, page-a (oldest, and no longer lane-exempt) is pruned.
+    expect(getPrunedSlugs("conv-1")).toEqual(new Set(["page-a"]));
+    expect(getActiveSlugs("conv-1")).toEqual(new Set(["page-b"]));
   });
 
   test("slugs whose card renders empty are neither attached nor recorded", async () => {

--- a/assistant/src/plugins/defaults/memory-v3-shadow/ever-injected-store.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/ever-injected-store.ts
@@ -78,6 +78,49 @@ export function getActiveSlugs(conversationId: string): Set<string> {
   return new Set(rows.map((row) => row.slug));
 }
 
+/** One active (resident) row of the prune valve's candidate set. */
+export interface ActiveInjectedEntry {
+  slug: string;
+  bytes: number;
+  /** Epoch ms the card was (last) injected — the recency fallback for slugs
+   *  with no selection rows (e.g. rows copied by a full fork). */
+  injectedAt: number;
+}
+
+/**
+ * Active (non-pruned) rows with byte and injection-time accounting — the
+ * prune valve's candidate set ({@link ActiveInjectedEntry}).
+ */
+export function getActiveEntries(
+  conversationId: string,
+): ActiveInjectedEntry[] {
+  return getSqliteFrom(getDb())
+    .query(
+      /*sql*/ `
+      SELECT slug, bytes, injected_at AS injectedAt FROM memory_v3_ever_injected
+      WHERE conversation_id = ? AND pruned_at IS NULL
+    `,
+    )
+    .all(conversationId) as ActiveInjectedEntry[];
+}
+
+/**
+ * Slugs currently marked pruned — the card-section skip set shared by the
+ * live-history strip and the `loadFromDb` rehydration filter (see
+ * `prune.ts` / `daemon/conversation.ts`).
+ */
+export function getPrunedSlugs(conversationId: string): Set<string> {
+  const rows = getSqliteFrom(getDb())
+    .query(
+      /*sql*/ `
+      SELECT slug FROM memory_v3_ever_injected
+      WHERE conversation_id = ? AND pruned_at IS NOT NULL
+    `,
+    )
+    .all(conversationId) as Array<{ slug: string }>;
+  return new Set(rows.map((row) => row.slug));
+}
+
 /**
  * Upsert this turn's injected cards. Re-recording an existing slug clears
  * `pruned_at` and refreshes `bytes`/`injected_at` — a pruned page that is

--- a/assistant/src/plugins/defaults/memory-v3-shadow/injector.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/injector.ts
@@ -57,6 +57,7 @@ import { cardBytes } from "./card.js";
 import { getActiveSlugs, recordInjected } from "./ever-injected-store.js";
 import type { OrchestrateResult } from "./orchestrate.js";
 import { renderV3CardContent } from "./page-content.js";
+import { schedulePruneValve } from "./prune.js";
 import {
   renderCardsBlockInner,
   renderSpotlightInner,
@@ -254,6 +255,14 @@ export const memoryV3Injector: Injector = {
       }
 
       recordInjected(ctx.conversationId, entries);
+
+      // Prune valve: deferred (never delays this turn's assembly) and fired
+      // after `recordInjected` so the resident accounting includes this
+      // turn's cards. Core/hot lane members are exempt — the selector's
+      // stable prefix must never be pruned out from under it.
+      schedulePruneValve(ctx.conversationId, {
+        exemptSlugs: new Set<Slug>([...result.lanes.core, ...result.lanes.hot]),
+      });
 
       // Empty net-new → empty-text block: assembly attaches no content
       // (`applyInjectionBlock` no-ops empty text) but the block's presence

--- a/assistant/src/plugins/defaults/memory-v3-shadow/prune.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/prune.test.ts
@@ -1,0 +1,583 @@
+/**
+ * Tests for `prune.ts` — the memory-v3 resident-footprint prune valve:
+ *   - `filterPrunedCardSections`: card-boundary parsing, byte-identical
+ *     remainders, all-pruned → `""`, no-op → same reference;
+ *   - `planPrune`: no-op below the cap, oldest-first selection-recency
+ *     ranking down to the target, core/hot exemption, `injected_at` fallback,
+ *     zero-byte (fork-seed) rows skipped, idempotence below the cap;
+ *   - `runPruneValve` + the live strip: v3-owned blocks stripped in place,
+ *     v2-lookalike blocks untouched, all-pruned blocks removed, and the
+ *     rehydration filter (the same `filterPrunedCardSections` over persisted
+ *     metadata) converging to the same bytes;
+ *   - re-injection round-trip: `recordInjected` clears `pruned_at`, after
+ *     which the filter keeps the slug again;
+ *   - `schedulePruneValve` deferred execution via `flushPruneValveForTests`.
+ *
+ * `mock.module` is process-global and leaks into sibling files in a directory
+ * run, so the db-connection / config stubs DELEGATE to the real implementation
+ * unless this test is actively running (`pruneMockActive`) — mirrors
+ * `ever-injected-store.test.ts`.
+ */
+
+import { Database } from "bun:sqlite";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import { wrapMemoryBlock } from "../../../memory/memory-marker.js";
+import { migrateAddMemoryV3Selections } from "../../../memory/migrations/268-add-memory-v3-selections.js";
+import { migrateAddMemoryV3EverInjected } from "../../../memory/migrations/275-add-memory-v3-ever-injected.js";
+import * as schema from "../../../memory/schema.js";
+import type { Message } from "../../../providers/types.js";
+
+const realDb = { ...(await import("../../../memory/db-connection.js")) };
+const realConfigLoader = { ...(await import("../../../config/loader.js")) };
+
+let pruneMockActive = false;
+let pruneConfig: {
+  maxResidentBytes: number;
+  targetResidentBytes: number;
+} | null = null;
+
+let testSqlite: Database;
+let testDb = makeDb();
+function makeDb() {
+  testSqlite = new Database(":memory:");
+  const db = drizzle(testSqlite, { schema });
+  migrateAddMemoryV3EverInjected(db);
+  migrateAddMemoryV3Selections(db);
+  // Minimal `messages` shape — `collectPersistedV3CardSections` reads only
+  // `conversation_id` and `metadata`.
+  testSqlite.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS messages (
+      id TEXT PRIMARY KEY,
+      conversation_id TEXT NOT NULL,
+      role TEXT NOT NULL,
+      content TEXT NOT NULL,
+      metadata TEXT,
+      created_at INTEGER NOT NULL
+    )
+  `);
+  return db;
+}
+
+mock.module("../../../memory/db-connection.js", () => ({
+  ...realDb,
+  getDb: () => (pruneMockActive ? testDb : realDb.getDb()),
+  getSqliteFrom: (db: unknown) =>
+    pruneMockActive
+      ? testSqlite
+      : realDb.getSqliteFrom(db as Parameters<typeof realDb.getSqliteFrom>[0]),
+}));
+
+mock.module("../../../config/loader.js", () => ({
+  ...realConfigLoader,
+  getConfig: () =>
+    pruneMockActive
+      ? { memory: { v3: { prune: pruneConfig ?? undefined } } }
+      : realConfigLoader.getConfig(),
+}));
+
+const {
+  collectPersistedV3CardSections,
+  filterPrunedCardSections,
+  flushPruneValveForTests,
+  parseCardSections,
+  planPrune,
+  runPruneValve,
+  schedulePruneValve,
+  stripPrunedCardsFromMessages,
+} = await import("./prune.js");
+const { getActiveSlugs, getInjected, getPrunedSlugs, recordInjected } =
+  await import("./ever-injected-store.js");
+const { V3_CARDS_INJECTION_HEADER, renderCardsBlockInner } =
+  await import("./render-injection.js");
+
+// ─── fixtures ────────────────────────────────────────────────────────────────
+
+/** A card exactly as `renderCard` shapes it: path header, head, TOC line. */
+function card(slug: string): string {
+  return `# memory/concepts/${slug}.md\nlead for ${slug}\n\n[sections: §One · §Two]`;
+}
+
+function insertSelection(
+  conversationId: string,
+  turn: number,
+  slug: string,
+  createdAt: number,
+): void {
+  testSqlite
+    .query(
+      /*sql*/ `
+      INSERT OR REPLACE INTO memory_v3_selections
+        (conversation_id, turn, slug, source, pinned, created_at)
+      VALUES (?, ?, ?, 'needle', 0, ?)
+    `,
+    )
+    .run(conversationId, turn, slug, createdAt);
+}
+
+function insertUserRowWithV3Block(
+  conversationId: string,
+  id: string,
+  blockInner: string,
+): void {
+  testSqlite
+    .query(
+      /*sql*/ `
+      INSERT INTO messages (id, conversation_id, role, content, metadata, created_at)
+      VALUES (?, ?, 'user', '[]', ?, 0)
+    `,
+    )
+    .run(
+      id,
+      conversationId,
+      JSON.stringify({ memoryV3InjectedBlock: blockInner }),
+    );
+}
+
+beforeEach(() => {
+  pruneMockActive = true;
+  pruneConfig = null;
+  testDb = makeDb();
+});
+
+afterAll(async () => {
+  await flushPruneValveForTests();
+  pruneMockActive = false;
+});
+
+// ─── filterPrunedCardSections ────────────────────────────────────────────────
+
+describe("parseCardSections / filterPrunedCardSections", () => {
+  const inner = renderCardsBlockInner([
+    card("page-a"),
+    card("page-b"),
+    card("page-c"),
+  ]);
+
+  test("parses preamble and per-card sections at the path headers", () => {
+    const parsed = parseCardSections(inner);
+    expect(parsed.preamble).toBe(V3_CARDS_INJECTION_HEADER);
+    expect(parsed.sections.map((s) => s.slug)).toEqual([
+      "page-a",
+      "page-b",
+      "page-c",
+    ]);
+    expect(parsed.sections[1]!.text).toBe(card("page-b"));
+  });
+
+  test("no pruned slug present → returns the SAME reference (no-op)", () => {
+    expect(filterPrunedCardSections(inner, new Set(["page-z"]))).toBe(inner);
+    expect(filterPrunedCardSections(inner, new Set())).toBe(inner);
+  });
+
+  test("strips pruned cards, leaving the remainder byte-identical to a fresh render", () => {
+    const filtered = filterPrunedCardSections(inner, new Set(["page-b"]));
+    expect(filtered).toBe(
+      renderCardsBlockInner([card("page-a"), card("page-c")]),
+    );
+    // A `# Title` line inside a card head is NOT a card boundary.
+    const headerInHead = `${V3_CARDS_INJECTION_HEADER}\n\n# memory/concepts/page-a.md\n# A Title Line\nlead\n\n# memory/concepts/page-b.md\nlead b`;
+    expect(filterPrunedCardSections(headerInHead, new Set(["page-b"]))).toBe(
+      `${V3_CARDS_INJECTION_HEADER}\n\n# memory/concepts/page-a.md\n# A Title Line\nlead`,
+    );
+  });
+
+  test("all cards pruned → empty string (caller drops the block)", () => {
+    expect(
+      filterPrunedCardSections(inner, new Set(["page-a", "page-b", "page-c"])),
+    ).toBe("");
+  });
+
+  test("text with no card headers passes through unchanged", () => {
+    const plain = "remember: user prefers tea";
+    expect(filterPrunedCardSections(plain, new Set(["page-a"]))).toBe(plain);
+  });
+});
+
+// ─── planPrune ───────────────────────────────────────────────────────────────
+
+describe("planPrune", () => {
+  const deps = {
+    maxResidentBytes: 300,
+    targetResidentBytes: 200,
+    exemptSlugs: new Set<string>(),
+  };
+
+  test("no-op below (or at) the cap", () => {
+    recordInjected("conv-1", [{ slug: "page-a", bytes: 300 }], 1_000);
+    expect(planPrune(deps, "conv-1")).toBeNull();
+  });
+
+  test("over the cap: prunes oldest-first by last selection recency down to the target", () => {
+    recordInjected(
+      "conv-1",
+      [
+        { slug: "page-a", bytes: 100 },
+        { slug: "page-b", bytes: 100 },
+        { slug: "page-c", bytes: 100 },
+        { slug: "page-d", bytes: 100 },
+      ],
+      1_000,
+    );
+    insertSelection("conv-1", 0, "page-a", 1_000);
+    insertSelection("conv-1", 0, "page-b", 2_000);
+    insertSelection("conv-1", 0, "page-c", 3_000);
+    insertSelection("conv-1", 0, "page-d", 4_000);
+
+    const plan = planPrune(deps, "conv-1");
+    expect(plan).toEqual({ slugs: ["page-a", "page-b"], bytesFreed: 200 });
+  });
+
+  test("re-selection recency outranks injection order", () => {
+    recordInjected(
+      "conv-1",
+      [
+        { slug: "page-old", bytes: 200 },
+        { slug: "page-new", bytes: 200 },
+      ],
+      1_000,
+    );
+    // page-old was injected first but re-selected most recently; page-new was
+    // selected only at injection time.
+    insertSelection("conv-1", 0, "page-old", 1_000);
+    insertSelection("conv-1", 1, "page-new", 2_000);
+    insertSelection("conv-1", 5, "page-old", 9_000);
+
+    const plan = planPrune(deps, "conv-1");
+    expect(plan!.slugs).toEqual(["page-new"]);
+  });
+
+  test("never-selected slugs fall back to injected_at for recency", () => {
+    recordInjected("conv-1", [{ slug: "page-a", bytes: 200 }], 5_000);
+    recordInjected("conv-1", [{ slug: "page-b", bytes: 200 }], 1_000);
+
+    const plan = planPrune(deps, "conv-1");
+    expect(plan!.slugs).toEqual(["page-b"]);
+  });
+
+  test("core/hot exempt slugs are never pruned, even when oldest", () => {
+    recordInjected(
+      "conv-1",
+      [
+        { slug: "core-page", bytes: 150 },
+        { slug: "page-b", bytes: 150 },
+        { slug: "page-c", bytes: 150 },
+      ],
+      1_000,
+    );
+    insertSelection("conv-1", 0, "core-page", 1_000);
+    insertSelection("conv-1", 0, "page-b", 2_000);
+    insertSelection("conv-1", 0, "page-c", 3_000);
+
+    // Resident 450 > max 300: reaching the 200 target needs both non-exempt
+    // pages — the exempt core page is skipped over even though it is oldest.
+    const plan = planPrune(
+      { ...deps, exemptSlugs: new Set(["core-page"]) },
+      "conv-1",
+    );
+    expect(plan!.slugs).toEqual(["page-b", "page-c"]);
+  });
+
+  test("zero-byte fork-seed rows are skipped (pruning them frees nothing)", () => {
+    recordInjected(
+      "conv-1",
+      [
+        { slug: "seeded", bytes: 0 },
+        { slug: "page-b", bytes: 400 },
+      ],
+      1_000,
+    );
+
+    const plan = planPrune(deps, "conv-1");
+    expect(plan!.slugs).toEqual(["page-b"]);
+  });
+
+  test("returns null when only exempt/zero-byte candidates remain over the cap", () => {
+    recordInjected("conv-1", [{ slug: "core-page", bytes: 400 }], 1_000);
+    expect(
+      planPrune({ ...deps, exemptSlugs: new Set(["core-page"]) }, "conv-1"),
+    ).toBeNull();
+  });
+});
+
+// ─── live strip & v3-block identification ────────────────────────────────────
+
+describe("stripPrunedCardsFromMessages", () => {
+  const innerAB = renderCardsBlockInner([card("page-a"), card("page-b")]);
+  const knownSections = new Set([card("page-a"), card("page-b")]);
+
+  function userMessage(...texts: string[]): Message {
+    return {
+      role: "user",
+      content: texts.map((text) => ({ type: "text" as const, text })),
+    };
+  }
+
+  test("strips pruned cards from v3-owned blocks in place", () => {
+    const message = userMessage(wrapMemoryBlock(innerAB), "hello");
+    const messages = [message];
+
+    const stripped = stripPrunedCardsFromMessages(
+      messages,
+      new Set(["page-a"]),
+      knownSections,
+    );
+
+    expect(stripped).toBe(1);
+    expect(message.content).toEqual([
+      {
+        type: "text",
+        text: wrapMemoryBlock(renderCardsBlockInner([card("page-b")])),
+      },
+      { type: "text", text: "hello" },
+    ]);
+  });
+
+  test("removes a block whose cards are ALL pruned (matching rehydration's skip)", () => {
+    const message = userMessage(wrapMemoryBlock(innerAB), "hello");
+
+    stripPrunedCardsFromMessages(
+      [message],
+      new Set(["page-a", "page-b"]),
+      knownSections,
+    );
+
+    expect(message.content).toEqual([{ type: "text", text: "hello" }]);
+  });
+
+  test("leaves v2-lookalike blocks untouched even when they name a pruned slug", () => {
+    // Same wrapper + header convention, but the section body is a v2 SUMMARY,
+    // not a card — so it fails the known-sections ownership test.
+    const v2Inner = `${V3_CARDS_INJECTION_HEADER}\n\n# memory/concepts/page-a.md\nv2 summary of page a`;
+    const message = userMessage(wrapMemoryBlock(v2Inner));
+
+    const stripped = stripPrunedCardsFromMessages(
+      [message],
+      new Set(["page-a"]),
+      knownSections,
+    );
+
+    expect(stripped).toBe(0);
+    expect(message.content).toEqual([
+      { type: "text", text: wrapMemoryBlock(v2Inner) },
+    ]);
+  });
+
+  test("ignores assistant messages, non-memory blocks, and unpruned v3 blocks", () => {
+    const assistant: Message = {
+      role: "assistant",
+      content: [{ type: "text", text: wrapMemoryBlock(innerAB) }],
+    };
+    const untouched = userMessage(wrapMemoryBlock(innerAB), "tail");
+    const before = untouched.content;
+
+    const stripped = stripPrunedCardsFromMessages(
+      [assistant, untouched],
+      new Set(["page-z"]),
+      knownSections,
+    );
+
+    expect(stripped).toBe(0);
+    // No-op leaves the original content array reference in place.
+    expect(untouched.content).toBe(before);
+    expect(assistant.content[0]).toEqual({
+      type: "text",
+      text: wrapMemoryBlock(innerAB),
+    });
+  });
+});
+
+describe("collectPersistedV3CardSections", () => {
+  test("collects card sections from persisted v3 metadata, skipping malformed rows", () => {
+    insertUserRowWithV3Block(
+      "conv-1",
+      "m1",
+      renderCardsBlockInner([card("page-a")]),
+    );
+    insertUserRowWithV3Block(
+      "conv-1",
+      "m2",
+      renderCardsBlockInner([card("page-b")]),
+    );
+    testSqlite
+      .query(
+        /*sql*/ `
+        INSERT INTO messages (id, conversation_id, role, content, metadata, created_at)
+        VALUES ('m3', 'conv-1', 'user', '[]', 'not json memoryV3InjectedBlock', 0)
+      `,
+      )
+      .run();
+
+    const sections = collectPersistedV3CardSections("conv-1");
+    expect(sections).toEqual(new Set([card("page-a"), card("page-b")]));
+    expect(collectPersistedV3CardSections("conv-other").size).toBe(0);
+  });
+});
+
+// ─── runPruneValve (end-to-end against the temp DB) ──────────────────────────
+
+describe("runPruneValve", () => {
+  test("below the cap: no-op, nothing marked pruned (idempotent)", async () => {
+    pruneConfig = { maxResidentBytes: 1_000, targetResidentBytes: 500 };
+    recordInjected("conv-1", [{ slug: "page-a", bytes: 100 }], 1_000);
+
+    expect(
+      await runPruneValve("conv-1", { exemptSlugs: new Set() }),
+    ).toBeNull();
+    expect(
+      await runPruneValve("conv-1", { exemptSlugs: new Set() }),
+    ).toBeNull();
+    expect(getPrunedSlugs("conv-1").size).toBe(0);
+  });
+
+  test("missing prune config: bails before touching the store", async () => {
+    pruneConfig = null;
+    recordInjected("conv-1", [{ slug: "page-a", bytes: 100 }], 1_000);
+    expect(
+      await runPruneValve("conv-1", { exemptSlugs: new Set() }),
+    ).toBeNull();
+  });
+
+  test("over the cap: marks pruned, strips the live history, and converges with rehydration", async () => {
+    const innerTurn1 = renderCardsBlockInner([card("page-a"), card("page-b")]);
+    const innerTurn2 = renderCardsBlockInner([card("page-c")]);
+    insertUserRowWithV3Block("conv-1", "m1", innerTurn1);
+    insertUserRowWithV3Block("conv-1", "m2", innerTurn2);
+
+    recordInjected(
+      "conv-1",
+      [
+        { slug: "page-a", bytes: 100 },
+        { slug: "page-b", bytes: 100 },
+        { slug: "page-c", bytes: 100 },
+      ],
+      1_000,
+    );
+    insertSelection("conv-1", 0, "page-a", 1_000);
+    insertSelection("conv-1", 0, "page-b", 2_000);
+    insertSelection("conv-1", 1, "page-c", 3_000);
+
+    // Live history as rehydration would build it, plus a v2-lookalike block
+    // that must survive untouched.
+    const v2Inner = `${V3_CARDS_INJECTION_HEADER}\n\n# memory/concepts/page-a.md\nv2 summary of page a`;
+    const liveMessages: Message[] = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: wrapMemoryBlock(v2Inner) },
+          { type: "text", text: wrapMemoryBlock(innerTurn1) },
+          { type: "text", text: "turn 1" },
+        ],
+      },
+      { role: "assistant", content: [{ type: "text", text: "reply" }] },
+      {
+        role: "user",
+        content: [
+          { type: "text", text: wrapMemoryBlock(innerTurn2) },
+          { type: "text", text: "turn 2" },
+        ],
+      },
+    ];
+
+    pruneConfig = { maxResidentBytes: 250, targetResidentBytes: 100 };
+    const plan = await runPruneValve("conv-1", {
+      exemptSlugs: new Set(),
+      liveMessages: () => liveMessages,
+      now: 9_000,
+    });
+
+    expect(plan).toEqual({ slugs: ["page-a", "page-b"], bytesFreed: 200 });
+    expect(getActiveSlugs("conv-1")).toEqual(new Set(["page-c"]));
+    expect(getInjected("conv-1").get("page-a")!.prunedAt).toBe(9_000);
+
+    // Turn-1's v3 block lost BOTH pruned cards → removed outright; the
+    // v2-lookalike and turn-2's block are byte-identical.
+    expect(liveMessages[0]!.content).toEqual([
+      { type: "text", text: wrapMemoryBlock(v2Inner) },
+      { type: "text", text: "turn 1" },
+    ]);
+    expect(liveMessages[2]!.content).toEqual([
+      { type: "text", text: wrapMemoryBlock(innerTurn2) },
+      { type: "text", text: "turn 2" },
+    ]);
+
+    // Rehydration converges: the same filter over the persisted metadata
+    // produces exactly what the live strip left in place.
+    const pruned = getPrunedSlugs("conv-1");
+    expect(filterPrunedCardSections(innerTurn1, pruned)).toBe("");
+    expect(filterPrunedCardSections(innerTurn2, pruned)).toBe(innerTurn2);
+
+    // Idempotent: resident is at 100 ≤ target → next pass is a no-op.
+    expect(
+      await runPruneValve("conv-1", { exemptSlugs: new Set() }),
+    ).toBeNull();
+  });
+
+  test("a pruned page later re-selected re-injects and is kept by the filter again", async () => {
+    const inner = renderCardsBlockInner([card("page-a")]);
+    insertUserRowWithV3Block("conv-1", "m1", inner);
+    recordInjected("conv-1", [{ slug: "page-a", bytes: 300 }], 1_000);
+
+    pruneConfig = { maxResidentBytes: 200, targetResidentBytes: 100 };
+    const plan = await runPruneValve("conv-1", {
+      exemptSlugs: new Set(),
+      liveMessages: () => null,
+      now: 2_000,
+    });
+    expect(plan!.slugs).toEqual(["page-a"]);
+    expect(filterPrunedCardSections(inner, getPrunedSlugs("conv-1"))).toBe("");
+
+    // Re-selection re-injects (PR 4 contract: recordInjected clears
+    // pruned_at) — the slug is active again and the filter keeps its card.
+    recordInjected("conv-1", [{ slug: "page-a", bytes: 50 }], 3_000);
+    expect(getActiveSlugs("conv-1")).toEqual(new Set(["page-a"]));
+    expect(filterPrunedCardSections(inner, getPrunedSlugs("conv-1"))).toBe(
+      inner,
+    );
+  });
+});
+
+describe("schedulePruneValve", () => {
+  test("defers the valve run; flush awaits completion", async () => {
+    const inner = renderCardsBlockInner([card("page-a"), card("page-b")]);
+    insertUserRowWithV3Block("conv-1", "m1", inner);
+    recordInjected(
+      "conv-1",
+      [
+        { slug: "page-a", bytes: 200 },
+        { slug: "page-b", bytes: 200 },
+      ],
+      1_000,
+    );
+    insertSelection("conv-1", 0, "page-a", 1_000);
+    insertSelection("conv-1", 0, "page-b", 2_000);
+
+    pruneConfig = { maxResidentBytes: 300, targetResidentBytes: 200 };
+    schedulePruneValve("conv-1", {
+      exemptSlugs: new Set(),
+      liveMessages: () => null,
+    });
+    // Synchronously after scheduling, nothing has been pruned yet.
+    expect(getPrunedSlugs("conv-1").size).toBe(0);
+
+    await flushPruneValveForTests();
+    expect(getPrunedSlugs("conv-1")).toEqual(new Set(["page-a"]));
+  });
+
+  test("valve failures are swallowed (never affect the turn)", async () => {
+    pruneConfig = { maxResidentBytes: 0, targetResidentBytes: 0 };
+    recordInjected("conv-1", [{ slug: "page-a", bytes: 100 }], 1_000);
+    schedulePruneValve("conv-1", {
+      exemptSlugs: new Set(),
+      liveMessages: () => {
+        throw new Error("boom");
+      },
+    });
+    await flushPruneValveForTests();
+    // The markPruned preceding the failing strip still landed; the error
+    // itself did not propagate.
+    expect(getPrunedSlugs("conv-1")).toEqual(new Set(["page-a"]));
+  });
+});

--- a/assistant/src/plugins/defaults/memory-v3-shadow/prune.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/prune.ts
@@ -1,0 +1,398 @@
+/**
+ * Memory-v3 prune valve: a structural bound on the resident frozen-card
+ * footprint.
+ *
+ * Frozen cards accumulate in history with no per-turn bound (the injector
+ * renders net-new only and never strips prior blocks — the cache contract).
+ * The valve is the backstop: when the resident (non-pruned) card bytes exceed
+ * `memory.v3.prune.maxResidentBytes`, the least-recently-selected
+ * non-core/non-hot cards are pruned, oldest first, until the footprint is at
+ * `targetResidentBytes`.
+ *
+ * Pruning is `markPruned` (the store's audit-preserving tombstone) plus two
+ * FILTER points — never a metadata rewrite, so the persisted
+ * `metadata.memoryV3InjectedBlock` rows stay intact (auditable, and a
+ * re-selected slug re-injects as a fresh card because `recordInjected` clears
+ * `pruned_at`):
+ *
+ *   (a) a one-time strip of the pruned cards' sections from the `<memory>`
+ *       blocks riding the LIVE in-memory history
+ *       ({@link stripPrunedCardsFromMessages} — per-card boundaries are the
+ *       `# memory/concepts/<slug>.md` headers within a block). The strip
+ *       mutates the shared message objects in place so the agent loop's
+ *       end-of-turn history fold-back keeps the stripped content;
+ *   (b) the `loadFromDb` rehydration splice in `daemon/conversation.ts`
+ *       re-applies {@link filterPrunedCardSections} on every load, so prunes
+ *       persist across daemon restarts without touching the metadata.
+ *
+ * The first post-prune request loses the provider prefix cache from the
+ * earliest affected message — ONE amortized bust per prune, logged with
+ * `prunedSlugs` / `bytesFreed`.
+ *
+ * v2-coexistence note: v2's dynamic `<memory>` blocks share the exact wrapper
+ * and `# memory/concepts/<slug>.md` header convention, so the live strip
+ * cannot tell layers apart syntactically. A block is treated as v3-owned only
+ * when EVERY card section in it byte-matches a section of some persisted
+ * `memoryV3InjectedBlock` for the conversation
+ * ({@link collectPersistedV3CardSections}) — v2 sections render the page
+ * SUMMARY (or full page) rather than the card head+TOC, so pre-flip v2 blocks
+ * never qualify and are left untouched, keeping their unfiltered rehydration
+ * byte-identical.
+ */
+
+import { getConfig } from "../../../config/loader.js";
+import { getDb, getSqliteFrom } from "../../../memory/db-connection.js";
+import {
+  unwrapMemoryBlock,
+  wrapMemoryBlock,
+} from "../../../memory/memory-marker.js";
+import type { ContentBlock, Message } from "../../../providers/types.js";
+import { getLogger } from "../../../util/logger.js";
+import {
+  getActiveEntries,
+  getPrunedSlugs,
+  markPruned,
+  MEMORY_V3_INJECTED_BLOCK_METADATA_KEY,
+  residentBytes,
+} from "./ever-injected-store.js";
+
+const log = getLogger("memory-v3-shadow");
+
+// ─── card-section parsing & filtering ────────────────────────────────────────
+
+/** Matches a card's path-header line; capture group 1 is the page slug. */
+const CARD_HEADER_REGEX = /^# memory\/concepts\/(.+)\.md$/gm;
+
+/** One parsed card section: the header line plus everything up to the next
+ *  card header (or end of block), trailing whitespace removed. */
+export interface CardSection {
+  slug: string;
+  /** The section text INCLUDING its `# memory/concepts/<slug>.md` header
+   *  line, `trimEnd()`ed so re-joining with `\n\n` reproduces the renderer's
+   *  exact bytes. */
+  text: string;
+}
+
+/**
+ * Split an UNWRAPPED card-block body into its preamble (the instruction
+ * header — everything before the first card header) and per-card sections.
+ * Returns zero sections when the text carries no card headers.
+ */
+export function parseCardSections(inner: string): {
+  preamble: string;
+  sections: CardSection[];
+} {
+  const matches = [...inner.matchAll(CARD_HEADER_REGEX)];
+  if (matches.length === 0) return { preamble: inner, sections: [] };
+
+  const preamble = inner.slice(0, matches[0]!.index).trimEnd();
+  const sections = matches.map((match, i) => {
+    const end = i + 1 < matches.length ? matches[i + 1]!.index : inner.length;
+    return { slug: match[1]!, text: inner.slice(match.index, end).trimEnd() };
+  });
+  return { preamble, sections };
+}
+
+/**
+ * Remove pruned slugs' card sections from an unwrapped block body.
+ *
+ * Returns the input string UNCHANGED (same reference) when nothing is
+ * removed — callers use identity to detect a no-op — and `""` when every
+ * card section is pruned (the caller drops/skips the whole block; a bare
+ * instruction header with no cards carries no content). Kept sections are
+ * re-joined exactly as the renderer joined them (`\n\n`), so an unpruned
+ * remainder stays byte-identical to what a fresh render of those cards would
+ * produce.
+ */
+export function filterPrunedCardSections(
+  inner: string,
+  prunedSlugs: ReadonlySet<string>,
+): string {
+  const { preamble, sections } = parseCardSections(inner);
+  if (sections.length === 0) return inner;
+
+  const kept = sections.filter((section) => !prunedSlugs.has(section.slug));
+  if (kept.length === sections.length) return inner;
+  if (kept.length === 0) return "";
+
+  const pieces = kept.map((section) => section.text);
+  if (preamble.length > 0) pieces.unshift(preamble);
+  return pieces.join("\n\n");
+}
+
+// ─── prune planning ──────────────────────────────────────────────────────────
+
+export interface PrunePlan {
+  /** Slugs to prune, least-recently-selected first. */
+  slugs: string[];
+  /** Resident bytes the plan frees once executed. */
+  bytesFreed: number;
+}
+
+export interface PruneDeps {
+  maxResidentBytes: number;
+  targetResidentBytes: number;
+  /** Core + hot lane members — the selector's stable prefix must never be
+   *  pruned out from under it. */
+  exemptSlugs: ReadonlySet<string>;
+}
+
+/**
+ * Plan a prune for the conversation, or `null` when the resident footprint is
+ * within `maxResidentBytes` (or nothing is prunable).
+ *
+ * Candidates are the ACTIVE injected slugs ranked by last selection recency —
+ * `MAX(created_at)` per slug from `memory_v3_selections`, falling back to the
+ * store's `injected_at` for slugs with no selection rows (e.g. rows copied by
+ * a full fork) — taken oldest-first until the resident footprint is at
+ * `targetResidentBytes`. Core/hot lane members are exempt, and zero-byte rows
+ * (truncated-fork seeds: dedup-only, no byte accounting) are skipped — pruning
+ * them frees nothing while discarding inherited context.
+ */
+export function planPrune(
+  deps: PruneDeps,
+  conversationId: string,
+): PrunePlan | null {
+  const resident = residentBytes(conversationId);
+  if (resident <= deps.maxResidentBytes) return null;
+
+  const selectionRows = getSqliteFrom(getDb())
+    .query(
+      /*sql*/ `
+      SELECT slug, MAX(created_at) AS lastSelectedAt FROM memory_v3_selections
+      WHERE conversation_id = ?
+      GROUP BY slug
+    `,
+    )
+    .all(conversationId) as Array<{ slug: string; lastSelectedAt: number }>;
+  const lastSelectedAt = new Map(
+    selectionRows.map((row) => [row.slug, row.lastSelectedAt]),
+  );
+
+  const candidates = getActiveEntries(conversationId)
+    .filter((entry) => entry.bytes > 0 && !deps.exemptSlugs.has(entry.slug))
+    .map((entry) => ({
+      ...entry,
+      recency: lastSelectedAt.get(entry.slug) ?? entry.injectedAt,
+    }))
+    // Oldest first; slug ascending as the deterministic tiebreak.
+    .sort((a, b) => a.recency - b.recency || (a.slug < b.slug ? -1 : 1));
+
+  const slugs: string[] = [];
+  let bytesFreed = 0;
+  for (const candidate of candidates) {
+    if (resident - bytesFreed <= deps.targetResidentBytes) break;
+    slugs.push(candidate.slug);
+    bytesFreed += candidate.bytes;
+  }
+  return slugs.length === 0 ? null : { slugs, bytesFreed };
+}
+
+// ─── live-history strip ──────────────────────────────────────────────────────
+
+/**
+ * The conversation's known v3 card sections, collected from every persisted
+ * `metadata.memoryV3InjectedBlock` row. The live strip's v3-ownership test:
+ * a live `<memory>` block is v3-owned iff all of its card sections appear in
+ * this set (see the module doc's v2-coexistence note).
+ */
+export function collectPersistedV3CardSections(
+  conversationId: string,
+): Set<string> {
+  // Substring prefilter (indexable LIKE) mirrors the Slack metadata scan;
+  // rows are validated by the JSON parse below.
+  const rows = getSqliteFrom(getDb())
+    .query(
+      /*sql*/ `
+      SELECT metadata FROM messages
+      WHERE conversation_id = ? AND metadata LIKE '%' || ? || '%'
+    `,
+    )
+    .all(conversationId, MEMORY_V3_INJECTED_BLOCK_METADATA_KEY) as Array<{
+    metadata: string | null;
+  }>;
+
+  const sections = new Set<string>();
+  for (const row of rows) {
+    if (!row.metadata) continue;
+    try {
+      const meta = JSON.parse(row.metadata) as Record<string, unknown>;
+      const block = meta[MEMORY_V3_INJECTED_BLOCK_METADATA_KEY];
+      if (typeof block !== "string") continue;
+      for (const section of parseCardSections(unwrapMemoryBlock(block))
+        .sections) {
+        sections.add(section.text);
+      }
+    } catch {
+      /* malformed metadata rows are skipped */
+    }
+  }
+  return sections;
+}
+
+/**
+ * One-time strip of pruned cards from the live in-memory history: for every
+ * v3-owned `<memory>` text block (ownership per `knownV3Sections` — see the
+ * module doc), drop the pruned slugs' card sections; a block whose cards are
+ * all pruned is removed outright (matching the rehydration splice, which
+ * skips an all-pruned block).
+ *
+ * Mutates the affected `Message` objects IN PLACE (`message.content`
+ * reassignment): the agent loop's working arrays share these object
+ * references, so its end-of-turn history fold-back keeps the strip. Returns
+ * the number of blocks changed.
+ */
+export function stripPrunedCardsFromMessages(
+  messages: Message[],
+  prunedSlugs: ReadonlySet<string>,
+  knownV3Sections: ReadonlySet<string>,
+): number {
+  let strippedBlocks = 0;
+  for (const message of messages) {
+    if (message.role !== "user") continue;
+    let changed = false;
+    const nextContent: ContentBlock[] = [];
+    for (const block of message.content) {
+      if (
+        block.type !== "text" ||
+        !block.text.startsWith("<memory>\n") ||
+        !block.text.endsWith("\n</memory>")
+      ) {
+        nextContent.push(block);
+        continue;
+      }
+      const inner = unwrapMemoryBlock(block.text);
+      const { sections } = parseCardSections(inner);
+      const isV3Block =
+        sections.length > 0 &&
+        sections.every((section) => knownV3Sections.has(section.text));
+      if (!isV3Block) {
+        nextContent.push(block);
+        continue;
+      }
+      const filtered = filterPrunedCardSections(inner, prunedSlugs);
+      if (filtered === inner) {
+        nextContent.push(block);
+        continue;
+      }
+      strippedBlocks += 1;
+      changed = true;
+      if (filtered.length > 0) {
+        nextContent.push({ type: "text", text: wrapMemoryBlock(filtered) });
+      }
+    }
+    if (changed) message.content = nextContent;
+  }
+  return strippedBlocks;
+}
+
+// ─── valve execution & trigger ───────────────────────────────────────────────
+
+export interface PruneValveOptions {
+  /** Core + hot lane members (never pruned). */
+  exemptSlugs: ReadonlySet<string>;
+  /** Test seam: resolve the conversation's LIVE in-memory message array.
+   *  Defaults to the daemon conversation registry (dynamically imported — a
+   *  static import would cycle with `daemon/conversation.ts`, which imports
+   *  this module for the rehydration filter). `null` skips the live strip
+   *  (the rehydration filter still applies the prune on next load). */
+  liveMessages?: (conversationId: string) => Message[] | null;
+  /** Test seam for the `pruned_at` timestamp. */
+  now?: number;
+}
+
+async function defaultLiveMessages(
+  conversationId: string,
+): Promise<Message[] | null> {
+  const { findConversationOrSubagent } =
+    await import("../../../daemon/conversation-registry.js");
+  return findConversationOrSubagent(conversationId)?.messages ?? null;
+}
+
+/**
+ * Run the prune valve once: plan against `memory.v3.prune` config, mark the
+ * planned slugs pruned, and strip their cards from the live in-memory
+ * history. Returns the executed plan, or `null` when the footprint is within
+ * bounds (the common case — repeated invocations below the cap are no-ops).
+ *
+ * The live strip filters with the conversation's FULL pruned set (not just
+ * this plan's slugs), so a card an earlier strip could not reach — e.g. a
+ * block not yet folded back into the live history when that prune ran —
+ * self-heals on the next prune.
+ */
+export async function runPruneValve(
+  conversationId: string,
+  options: PruneValveOptions,
+): Promise<PrunePlan | null> {
+  // Defensive read: test configs may omit the prune block entirely.
+  const pruneConfig = getConfig().memory?.v3?.prune;
+  if (!pruneConfig) return null;
+
+  const plan = planPrune(
+    {
+      maxResidentBytes: pruneConfig.maxResidentBytes,
+      targetResidentBytes: pruneConfig.targetResidentBytes,
+      exemptSlugs: options.exemptSlugs,
+    },
+    conversationId,
+  );
+  if (!plan) return null;
+
+  markPruned(conversationId, plan.slugs, options.now ?? Date.now());
+
+  const liveMessages = options.liveMessages
+    ? options.liveMessages(conversationId)
+    : await defaultLiveMessages(conversationId);
+  let strippedBlocks = 0;
+  if (liveMessages) {
+    strippedBlocks = stripPrunedCardsFromMessages(
+      liveMessages,
+      getPrunedSlugs(conversationId),
+      collectPersistedV3CardSections(conversationId),
+    );
+  }
+
+  log.info(
+    {
+      conversationId,
+      prunedSlugs: plan.slugs.length,
+      bytesFreed: plan.bytesFreed,
+      strippedBlocks,
+      residentBytes: residentBytes(conversationId),
+    },
+    "memory-v3 prune valve: pruned least-recently-selected cards (one amortized prefix-cache bust)",
+  );
+  return plan;
+}
+
+/** Pending valve work, chained so runs serialize per process and tests can
+ *  await completion ({@link flushPruneValveForTests}). */
+let pendingPrune: Promise<unknown> = Promise.resolve();
+
+/**
+ * End-of-turn trigger: defer a {@link runPruneValve} pass so prune work never
+ * delays the in-flight turn's assembly. Failures are logged and swallowed —
+ * the valve must never affect the live turn.
+ */
+export function schedulePruneValve(
+  conversationId: string,
+  options: PruneValveOptions,
+): void {
+  pendingPrune = pendingPrune
+    .then(() => new Promise((resolve) => setTimeout(resolve, 0)))
+    .then(() => runPruneValve(conversationId, options))
+    .catch((err) => {
+      log.warn(
+        {
+          err: err instanceof Error ? err.message : String(err),
+          conversationId,
+        },
+        "memory-v3 prune valve failed (non-fatal)",
+      );
+    });
+}
+
+/** Await all scheduled valve work (deterministic teardown for tests). */
+export function flushPruneValveForTests(): Promise<void> {
+  return pendingPrune.then(() => undefined);
+}


### PR DESCRIPTION
## Summary
- Adds the prune valve: when resident card bytes exceed maxResidentBytes (384KB default), least-recently-selected non-core/hot cards are pruned to targetResidentBytes (256KB default)
- Prune = pruned_at + live-history section strip + rehydration skip — persisted metadata never mutated (auditable, reversible); one amortized cache bust per prune
- Pruned pages re-inject as fresh cards on re-selection

Part of plan: memory-v3-cache-aware-carry.md (PR 9 of 11)