### PR TITLE
fix(web): wait for lifecycle to resolve before route guard redirects

### DIFF
--- a/apps/web/src/lib/auth/auth-middleware.ts
+++ b/apps/web/src/lib/auth/auth-middleware.ts
@@ -4,6 +4,7 @@ import {
   type MiddlewareFunction,
 } from "react-router";
 
+import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
 import { useAuthStore, type AuthUser } from "@/stores/auth-store";
 import { isSessionSettled } from "@/stores/session-status";
 import { isLocalMode, hasAssistants } from "@/lib/local-mode";
@@ -14,6 +15,7 @@ import { whenStoreState } from "@/utils/when-store-state";
 export const authUserContext = createRouterContext<AuthUser | null>(null);
 
 const PLATFORM_SESSION_PROBE_TIMEOUT_MS = 5_000;
+const ASSISTANT_CHECK_TIMEOUT_MS = 10_000;
 
 export const authMiddleware: MiddlewareFunction = async ({ request, context }, next) => {
   const url = new URL(request.url);
@@ -34,6 +36,11 @@ export const authMiddleware: MiddlewareFunction = async ({ request, context }, n
         { timeoutMs: PLATFORM_SESSION_PROBE_TIMEOUT_MS },
       );
     }
+    await whenStoreState(
+      useAssistantLifecycleStore,
+      (s) => s.assistantState.kind !== "loading",
+      { timeoutMs: ASSISTANT_CHECK_TIMEOUT_MS },
+    );
     return authMiddleware({ request, context } as Parameters<MiddlewareFunction>[0], next);
   }
 

--- a/apps/web/src/lib/navigation/build-state.ts
+++ b/apps/web/src/lib/navigation/build-state.ts
@@ -6,6 +6,7 @@ import {
   readTosAccepted,
   readAiDataConsent,
 } from "@/domains/onboarding/prefs";
+import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import type { NavigationState } from "./navigation-resolver";
 
@@ -17,6 +18,7 @@ export function buildNavigationState(
     isLocalMode: isLocalMode(),
     isGatewayAuth: isGatewayAuthMode(),
     hasAssistants: useResolvedAssistantsStore.getState().assistants.length > 0,
+    assistantCheckPending: useAssistantLifecycleStore.getState().assistantState.kind === "loading",
     sessionSettled: isSessionSettled(sessionStatus),
     isAuthenticated: isAuthenticated(sessionStatus),
     platformSession,

--- a/apps/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/apps/web/src/lib/navigation/navigation-resolver.test.ts
@@ -11,6 +11,7 @@ const base: NavigationState = {
   isLocalMode: false,
   isGatewayAuth: false,
   hasAssistants: true,
+  assistantCheckPending: false,
   sessionSettled: true,
   isAuthenticated: true,
   platformSession: "present",

--- a/apps/web/src/lib/navigation/navigation-resolver.ts
+++ b/apps/web/src/lib/navigation/navigation-resolver.ts
@@ -10,6 +10,7 @@ export interface NavigationState {
   isLocalMode: boolean;
   isGatewayAuth: boolean;
   hasAssistants: boolean;
+  assistantCheckPending: boolean;
   sessionSettled: boolean;
   isAuthenticated: boolean;
   platformSession: PlatformSessionStatus;
@@ -244,6 +245,7 @@ function allowSetupRoutes(
 
 function requireAssistant(state: NavigationState): NavigationDecision | null {
   if (state.hasAssistants) return null;
+  if (state.assistantCheckPending) return { action: "wait" };
 
   if (state.isLocalMode) {
     if (state.platformSession === "unknown") return { action: "wait" };


### PR DESCRIPTION
## Summary
- Add `assistantCheckPending` to `NavigationState` — true while the lifecycle service is still in `loading` state
- `requireAssistant` returns `wait` instead of redirecting when the assistant check is pending, preventing premature redirects to `/onboarding/privacy` for platform users whose `listAssistants()` call fails because the `Vellum-Organization-Id` header isn't available yet
- Auth middleware waits for the lifecycle service to leave `loading` (10s timeout) before retrying the route guard

## Original prompt
Platform users with active cloud assistants were being incorrectly redirected to `/onboarding/privacy` on navigation to `/assistant`. The root cause: `initSession` calls `listAssistants()` before the org store hydrates, so the `Vellum-Organization-Id` header is missing → 400 → silent catch → resolved-assistants store stays empty → route guard sees `hasAssistants: false` and redirects. The same timing issue affected the feature flags endpoint. The fix defers the route guard's redirect decision until the lifecycle service has had a chance to resolve the assistant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)