### PR TITLE
refactor(web): remove unused lifecycle service inputs (onRedirect, resolveOnboardingRedirect, isRetired)

### DIFF
--- a/apps/web/src/assistant/lifecycle-service.test.ts
+++ b/apps/web/src/assistant/lifecycle-service.test.ts
@@ -83,10 +83,7 @@ function makeQueryClient(): QueryClient {
 
 const baseInputs = {
   sessionStatus: "authenticated" as const,
-  isRetired: false,
   hasPlatformSession: true,
-  onRedirect: () => {},
-  resolveOnboardingRedirect: () => null,
 };
 
 beforeEach(() => {
@@ -290,21 +287,18 @@ describe("lifecycleService — bootstrap branches", () => {
 });
 
 describe("lifecycleService — 404 (no assistant)", () => {
-  test("404 is a no-op — no redirect, no state transition", async () => {
+  test("404 is a no-op — no state transition", async () => {
     getAssistantMock.mockImplementationOnce(async () => ({
       ok: false,
       status: 404,
     }));
 
-    const onRedirect = mock(() => {});
     lifecycleService.setInputs({
       ...baseInputs,
-      onRedirect,
       queryClient: makeQueryClient(),
     });
     await lifecycleService.checkAssistant();
 
-    expect(onRedirect).not.toHaveBeenCalled();
     expect(useAssistantLifecycleStore.getState().assistantState.kind).toBe(
       "loading",
     );

--- a/apps/web/src/assistant/lifecycle-service.ts
+++ b/apps/web/src/assistant/lifecycle-service.ts
@@ -7,11 +7,11 @@
  * (`useAssistantLifecycleStore`, `useResolvedAssistantsStore`),
  * which is how the React tree reads it. Also owns the generation
  * counter that drops stale async responses on timeout escalations,
- * the 5-minute stuck-initializing watchdog, the gateway-auth
- * short-circuit, and the onboarding-redirect coordination.
+ * the 5-minute stuck-initializing watchdog, and the gateway-auth
+ * short-circuit.
  *
- * Inputs from React (auth, env, the navigate callback, the
- * TanStack Query client) flow in through `setInputs()`;
+ * Inputs from React (auth, env, the TanStack Query client) flow
+ * in through `setInputs()`;
  * `useAssistantLifecycle` is the thin wiring layer that pushes
  * them.
  *
@@ -44,26 +44,13 @@ import { isGatewayAuthMode, getGatewayToken } from "@/lib/auth/gateway-session";
 import {
   getSelectedAssistant,
   getLocalGatewayUrl,
-  isLocalMode,
 } from "@/lib/local-mode";
 import { setSelfHostedConnection } from "@/lib/self-hosted/connection";
 import { isAuthenticated, type SessionStatus } from "@/stores/session-status";
 
 export interface LifecycleServiceInputs {
   sessionStatus: SessionStatus;
-  isRetired: boolean;
   hasPlatformSession: boolean;
-  /** Framework-agnostic redirect — called instead of router.replace(). */
-  onRedirect: (url: string) => void;
-  /**
-   * Returns the path to redirect to when onboarding should intercept,
-   * or `null` if the intended destination is fine as-is. Injected so
-   * `assistant/` stays free of the onboarding domain (the
-   * `shared → domains` direction).
-   */
-  resolveOnboardingRedirect: (input: {
-    intendedDestination: string;
-  }) => string | null;
   /** The TanStack Query client owned by `RootLayout`'s provider. */
   queryClient: QueryClient;
   /**
@@ -80,10 +67,6 @@ export interface LifecycleServiceInputs {
    */
   isOrgReady?: boolean;
 }
-
-const NOOP_REDIRECT = (_: string) => {};
-const NOOP_RESOLVE: LifecycleServiceInputs["resolveOnboardingRedirect"] =
-  () => null;
 
 class AssistantLifecycleService {
   private state: AssistantState = { kind: "loading" };
@@ -107,10 +90,7 @@ class AssistantLifecycleService {
   private ready = false;
   private inputs: LifecycleServiceInputs = {
     sessionStatus: "initializing",
-    isRetired: false,
     hasPlatformSession: false,
-    onRedirect: NOOP_REDIRECT,
-    resolveOnboardingRedirect: NOOP_RESOLVE,
     queryClient: null as unknown as QueryClient,
     selectedPlatformAssistantId: null,
   };
@@ -168,17 +148,6 @@ class AssistantLifecycleService {
 
     if (isGatewayAuthMode()) {
       this.applyGatewayAuthShortCircuit();
-      return;
-    }
-    if (
-      isLocalMode() &&
-      !isGatewayAuthMode() &&
-      !this.inputs.hasPlatformSession
-    ) {
-      const redirect = this.inputs.resolveOnboardingRedirect({
-        intendedDestination: window.location.pathname,
-      });
-      if (redirect) this.inputs.onRedirect(redirect);
       return;
     }
     if (this.inputs.hasPlatformSession) {
@@ -445,10 +414,7 @@ class AssistantLifecycleService {
     useAssistantLifecycleStore.setState({ expectingFirstMessage: false });
     this.inputs = {
       sessionStatus: "initializing",
-      isRetired: false,
       hasPlatformSession: false,
-      onRedirect: NOOP_REDIRECT,
-      resolveOnboardingRedirect: NOOP_RESOLVE,
       queryClient: null as unknown as QueryClient,
     };
     useAssistantLifecycleStore.setState({ assistantState: this.state });

--- a/apps/web/src/assistant/use-lifecycle.ts
+++ b/apps/web/src/assistant/use-lifecycle.ts
@@ -27,27 +27,12 @@ import { useOrganizationStore } from "@/stores/organization-store";
 
 interface UseAssistantLifecycleOptions {
   sessionStatus: SessionStatus;
-  isRetired: boolean;
   hasPlatformSession: boolean;
-  /** Framework-agnostic redirect — called instead of router.replace(). */
-  onRedirect: (url: string) => void;
-  /**
-   * Returns the path to redirect to when onboarding should intercept,
-   * or `null` if the intended destination is fine as-is. Injected so
-   * `assistant/` stays free of the onboarding domain (the
-   * `shared → domains` direction).
-   */
-  resolveOnboardingRedirect: (input: {
-    intendedDestination: string;
-  }) => string | null;
 }
 
 export function useAssistantLifecycle({
   sessionStatus,
-  isRetired,
   hasPlatformSession,
-  onRedirect,
-  resolveOnboardingRedirect,
 }: UseAssistantLifecycleOptions): void {
   const queryClient = useQueryClient();
 
@@ -94,10 +79,7 @@ export function useAssistantLifecycle({
   useEffect(() => {
     lifecycleService.setInputs({
       sessionStatus,
-      isRetired,
       hasPlatformSession,
-      onRedirect,
-      resolveOnboardingRedirect,
       queryClient,
       selectedPlatformAssistantId,
       isOrgReady,
@@ -105,10 +87,7 @@ export function useAssistantLifecycle({
     void lifecycleService.respondToInputs();
   }, [
     sessionStatus,
-    isRetired,
     hasPlatformSession,
-    onRedirect,
-    resolveOnboardingRedirect,
     queryClient,
     selectedPlatformAssistantId,
     isOrgReady,

--- a/apps/web/src/lib/auth/auth-middleware.test.ts
+++ b/apps/web/src/lib/auth/auth-middleware.test.ts
@@ -9,6 +9,7 @@ mock.module("@/lib/local-mode", () => ({
 }));
 
 import { authMiddleware } from "./auth-middleware";
+import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
 import { useAuthStore, type AuthUser } from "@/stores/auth-store";
 import { routes } from "@/utils/routes";
 
@@ -40,6 +41,7 @@ beforeEach(() => {
   isLocalModeMock.mockImplementation(() => true);
   hasAssistantsMock.mockImplementation(() => false);
   useAuthStore.setState(initialAuthState, true);
+  useAssistantLifecycleStore.setState({ assistantState: { kind: "error", message: "no assistant" } });
 });
 
 afterEach(() => {

--- a/apps/web/src/root-layout.tsx
+++ b/apps/web/src/root-layout.tsx
@@ -23,7 +23,6 @@ import { useDocumentEditorSync } from "@/hooks/use-document-editor-sync";
 import { useNotificationIntentSync } from "@/hooks/use-notification-intent-sync";
 import { useOnboardingWindowSize } from "@/hooks/use-onboarding-window-size";
 import { useConversationSync } from "@/hooks/use-conversation-sync";
-import { resolveOnboardingRedirect } from "@/domains/onboarding/gate";
 import { useFeatureFlagBusSync } from "@/hooks/use-feature-flag-bus-sync";
 import { useClientFeatureFlagSync } from "@/hooks/use-client-feature-flag-sync";
 import { useAssistantFeatureFlagSync } from "@/hooks/use-assistant-feature-flag-sync";
@@ -93,10 +92,7 @@ export function RootLayout() {
   useClientFeatureFlagSync(!isSessionInitializing);
   useAssistantLifecycle({
     sessionStatus,
-    isRetired: false,
     hasPlatformSession,
-    onRedirect: navigate,
-    resolveOnboardingRedirect,
   });
 
   const assistantId = useResolvedAssistantsStore.use.activeAssistantId();


### PR DESCRIPTION
## Summary
- Remove `onRedirect`, `resolveOnboardingRedirect`, and `isRetired` from `LifecycleServiceInputs`
- Remove the local-mode-without-platform-session redirect branch from `respondToInputs()` — the route guard handles this
- Clean up `use-lifecycle.ts` and `root-layout.tsx` to stop passing these inputs

Part of plan: lifecycle-service-refactor.md (PR 1 of 5)