### PR TITLE
fix(web): hydrate org store before listAssistants to prevent missing header 400s

### DIFF
--- a/apps/web/src/lib/auth/auth-middleware.ts
+++ b/apps/web/src/lib/auth/auth-middleware.ts
@@ -4,7 +4,6 @@ import {
   type MiddlewareFunction,
 } from "react-router";
 
-import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
 import { useAuthStore, type AuthUser } from "@/stores/auth-store";
 import { isSessionSettled } from "@/stores/session-status";
 import { isLocalMode, hasAssistants } from "@/lib/local-mode";
@@ -15,7 +14,6 @@ import { whenStoreState } from "@/utils/when-store-state";
 export const authUserContext = createRouterContext<AuthUser | null>(null);
 
 const PLATFORM_SESSION_PROBE_TIMEOUT_MS = 5_000;
-const ASSISTANT_CHECK_TIMEOUT_MS = 10_000;
 
 export const authMiddleware: MiddlewareFunction = async ({ request, context }, next) => {
   const url = new URL(request.url);
@@ -36,11 +34,6 @@ export const authMiddleware: MiddlewareFunction = async ({ request, context }, n
         { timeoutMs: PLATFORM_SESSION_PROBE_TIMEOUT_MS },
       );
     }
-    await whenStoreState(
-      useAssistantLifecycleStore,
-      (s) => s.assistantState.kind !== "loading",
-      { timeoutMs: ASSISTANT_CHECK_TIMEOUT_MS },
-    );
     return authMiddleware({ request, context } as Parameters<MiddlewareFunction>[0], next);
   }
 

--- a/apps/web/src/lib/navigation/build-state.ts
+++ b/apps/web/src/lib/navigation/build-state.ts
@@ -6,7 +6,6 @@ import {
   readTosAccepted,
   readAiDataConsent,
 } from "@/domains/onboarding/prefs";
-import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import type { NavigationState } from "./navigation-resolver";
 
@@ -18,7 +17,6 @@ export function buildNavigationState(
     isLocalMode: isLocalMode(),
     isGatewayAuth: isGatewayAuthMode(),
     hasAssistants: useResolvedAssistantsStore.getState().assistants.length > 0,
-    assistantCheckPending: useAssistantLifecycleStore.getState().assistantState.kind === "loading",
     sessionSettled: isSessionSettled(sessionStatus),
     isAuthenticated: isAuthenticated(sessionStatus),
     platformSession,

--- a/apps/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/apps/web/src/lib/navigation/navigation-resolver.test.ts
@@ -11,7 +11,6 @@ const base: NavigationState = {
   isLocalMode: false,
   isGatewayAuth: false,
   hasAssistants: true,
-  assistantCheckPending: false,
   sessionSettled: true,
   isAuthenticated: true,
   platformSession: "present",

--- a/apps/web/src/lib/navigation/navigation-resolver.ts
+++ b/apps/web/src/lib/navigation/navigation-resolver.ts
@@ -10,7 +10,6 @@ export interface NavigationState {
   isLocalMode: boolean;
   isGatewayAuth: boolean;
   hasAssistants: boolean;
-  assistantCheckPending: boolean;
   sessionSettled: boolean;
   isAuthenticated: boolean;
   platformSession: PlatformSessionStatus;
@@ -245,7 +244,6 @@ function allowSetupRoutes(
 
 function requireAssistant(state: NavigationState): NavigationDecision | null {
   if (state.hasAssistants) return null;
-  if (state.assistantCheckPending) return { action: "wait" };
 
   if (state.isLocalMode) {
     if (state.platformSession === "unknown") return { action: "wait" };

--- a/apps/web/src/stores/auth-store.test.ts
+++ b/apps/web/src/stores/auth-store.test.ts
@@ -142,6 +142,11 @@ mock.module("@/lib/auth/session-cleanup", () => ({
 
 mock.module("@/stores/organization-store", () => ({
   clearOrganization: clearOrganizationMock,
+  useOrganizationStore: {
+    getState: () => ({
+      fetchOrganizations: async () => {},
+    }),
+  },
 }));
 
 // Don't mock `@/lib/event-bus` — bun's `mock.module` is process-

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -270,9 +270,8 @@ function probePlatformSession(
         // indefinitely otherwise.
         if (isLocalMode()) {
           try {
-            await useOrganizationStore.getState().fetchOrganizations();
             const apiAssistants = await Promise.race([
-              listAssistants(),
+              useOrganizationStore.getState().fetchOrganizations().then(() => listAssistants()),
               new Promise<never>((_, reject) =>
                 setTimeout(() => reject(new Error("sync timeout")), 3_000),
               ),

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -270,8 +270,9 @@ function probePlatformSession(
         // indefinitely otherwise.
         if (isLocalMode()) {
           try {
+            await useOrganizationStore.getState().fetchOrganizations();
             const apiAssistants = await Promise.race([
-              useOrganizationStore.getState().fetchOrganizations().then(() => listAssistants()),
+              listAssistants(),
               new Promise<never>((_, reject) =>
                 setTimeout(() => reject(new Error("sync timeout")), 3_000),
               ),

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -50,7 +50,7 @@ import { deleteBiometricToken } from "@/runtime/native-biometric";
 import { fetchMe, patchConsent } from "@/domains/account/profile";
 import { restoreConsentForUser, persistConsentForUser, resolveServerConsent, CONSENT_VERSION } from "@/utils/onboarding-cleanup";
 import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
-import { clearOrganization } from "@/stores/organization-store";
+import { clearOrganization, useOrganizationStore } from "@/stores/organization-store";
 import { clearUserScopedStorage } from "@/lib/auth/session-cleanup";
 import { subscribe } from "@/lib/event-bus";
 import { isElectron } from "@/runtime/is-electron";
@@ -270,6 +270,7 @@ function probePlatformSession(
         // indefinitely otherwise.
         if (isLocalMode()) {
           try {
+            await useOrganizationStore.getState().fetchOrganizations();
             const apiAssistants = await Promise.race([
               listAssistants(),
               new Promise<never>((_, reject) =>
@@ -381,6 +382,7 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
             await syncUserScopedState(user?.id ?? null);
             // Re-sync platform assistants to remove stale lockfile entries.
             try {
+              await useOrganizationStore.getState().fetchOrganizations();
               const apiAssistants = await listAssistants();
               if (apiAssistants.ok) {
                 await syncPlatformAssistantsToLockfile(apiAssistants.data);
@@ -417,6 +419,7 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
         const user = toAuthUser(result.data.user);
         await syncUserScopedState(user?.id ?? null);
         try {
+          await useOrganizationStore.getState().fetchOrganizations();
           const apiAssistants = await listAssistants();
           if (apiAssistants.ok) {
             useResolvedAssistantsStore.getState().setFromApi(apiAssistants.data);
@@ -442,6 +445,7 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
             const user = toAuthUser(retryResult.data.user);
             await syncUserScopedState(user?.id ?? null);
             try {
+              await useOrganizationStore.getState().fetchOrganizations();
               const apiAssistants = await listAssistants();
               if (apiAssistants.ok) {
                 useResolvedAssistantsStore.getState().setFromApi(apiAssistants.data);
@@ -518,6 +522,7 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
         // refresh has already succeeded regardless of the sync outcome.
         if (isLocalMode()) {
           try {
+            await useOrganizationStore.getState().fetchOrganizations();
             const apiAssistants = await listAssistants();
             if (apiAssistants.ok) {
               await syncPlatformAssistantsToLockfile(apiAssistants.data);


### PR DESCRIPTION
## Summary
- Add `await fetchOrganizations()` before every `listAssistants()` call in `initSession` and `refreshSession` so the `Vellum-Organization-Id` header is available — previously the org store hadn't hydrated yet, causing a 400 that silently left the assistants store empty
- Revert the `assistantCheckPending` approach from PR #34200 — the auth middleware waiting on the lifecycle store deadlocked because the middleware runs before `RootLayout` mounts (which is the only component that starts the lifecycle service)

## Original prompt
Platform users with active cloud assistants were redirected to `/onboarding/privacy` because `listAssistants()` in `initSession()` ran before the org store hydrated, so the `Vellum-Organization-Id` header was missing → 400 → empty store → route guard redirect. The same issue caused 400s on the feature flags endpoint. The prior fix (PR #34200) tried to wait on the lifecycle store from the middleware, but that deadlocked. The correct fix is to hydrate the org store imperatively before calling `listAssistants()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)