### PR TITLE
feat(web): add daemon reachability tracking to lifecycle service via healthz probe

### DIFF
--- a/apps/web/src/assistant/lifecycle-service.test.ts
+++ b/apps/web/src/assistant/lifecycle-service.test.ts
@@ -25,9 +25,11 @@ const TEST_INITIALIZING_TIMEOUT_MS = 30;
 // --- module mocks --- //
 
 const getAssistantMock = mock(async () => ({ ok: false, status: 404 }));
+const getAssistantHealthzMock = mock(async () => ({ ok: true }));
 
 mock.module("@/assistant/api", () => ({
   getAssistant: getAssistantMock,
+  getAssistantHealthz: getAssistantHealthzMock,
 }));
 
 const setSelfHostedConnectionMock = mock((_args: unknown) => {});
@@ -56,6 +58,17 @@ mock.module("@sentry/react", () => ({
   captureException: () => {},
   captureMessage: () => {},
   addBreadcrumb: () => {},
+}));
+
+// Capture the unreachable-bus listener so tests can trigger it.
+let capturedUnreachableListener: (() => void) | null = null;
+mock.module("@/assistant/unreachable-bus", () => ({
+  subscribeAssistantUnreachable: (listener: () => void) => {
+    capturedUnreachableListener = listener;
+    return () => {
+      capturedUnreachableListener = null;
+    };
+  },
 }));
 
 mock.module("@/assistant/lifecycle", () => ({
@@ -88,6 +101,7 @@ const baseInputs = {
 
 beforeEach(() => {
   getAssistantMock.mockClear();
+  getAssistantHealthzMock.mockClear();
   setSelfHostedConnectionMock.mockClear();
   // Re-baseline implementations every test so a `mockImplementationOnce`
   // or `mockImplementation` from a prior test doesn't leak.
@@ -97,6 +111,7 @@ beforeEach(() => {
   isGatewayAuthModeMock.mockImplementation(() => false);
   isLocalModeMock.mockImplementation(() => false);
   getAssistantMock.mockImplementation(async () => ({ ok: false, status: 404 }));
+  getAssistantHealthzMock.mockImplementation(async () => ({ ok: true }));
   lifecycleService.__resetForTesting();
 });
 
@@ -490,6 +505,156 @@ describe("lifecycleService — watchdog timeout", () => {
     if (state.kind === "error") {
       expect(state.message).toEqual(buildInitializingTimeoutError().message);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reachability probe
+// ---------------------------------------------------------------------------
+
+describe("lifecycleService — reachability probe", () => {
+  test("after projectActive, reachable becomes true when healthz succeeds", async () => {
+    getAssistantHealthzMock.mockImplementation(async () => ({ ok: true }));
+    getAssistantMock.mockImplementationOnce(async () => ({
+      ok: true,
+      status: 200,
+      data: {
+        id: "asst-reach-1",
+        status: "active",
+        is_local: false,
+        maintenance_mode: { enabled: false },
+      },
+    }));
+    lifecycleService.setInputs({
+      ...baseInputs,
+      queryClient: makeQueryClient(),
+    });
+
+    await lifecycleService.checkAssistant();
+
+    await waitFor(() => {
+      const s = useAssistantLifecycleStore.getState().assistantState;
+      return s.kind === "active" && s.reachable === true;
+    });
+
+    const state = useAssistantLifecycleStore.getState().assistantState;
+    expect(state.kind).toBe("active");
+    if (state.kind === "active") {
+      expect(state.reachable).toBe(true);
+    }
+  });
+
+  test("after projectActive, reachable becomes false when healthz fails", async () => {
+    getAssistantHealthzMock.mockImplementation(async () => ({ ok: false, status: 503 }));
+    getAssistantMock.mockImplementationOnce(async () => ({
+      ok: true,
+      status: 200,
+      data: {
+        id: "asst-reach-2",
+        status: "active",
+        is_local: false,
+        maintenance_mode: { enabled: false },
+      },
+    }));
+    lifecycleService.setInputs({
+      ...baseInputs,
+      queryClient: makeQueryClient(),
+    });
+
+    await lifecycleService.checkAssistant();
+
+    await waitFor(() => {
+      const s = useAssistantLifecycleStore.getState().assistantState;
+      return s.kind === "active" && s.reachable === false;
+    });
+
+    const state = useAssistantLifecycleStore.getState().assistantState;
+    expect(state.kind).toBe("active");
+    if (state.kind === "active") {
+      expect(state.reachable).toBe(false);
+    }
+  });
+
+  test("after projectActive, reachable becomes false when healthz throws", async () => {
+    getAssistantHealthzMock.mockImplementation(async () => {
+      throw new Error("network error");
+    });
+    getAssistantMock.mockImplementationOnce(async () => ({
+      ok: true,
+      status: 200,
+      data: {
+        id: "asst-reach-3",
+        status: "active",
+        is_local: false,
+        maintenance_mode: { enabled: false },
+      },
+    }));
+    lifecycleService.setInputs({
+      ...baseInputs,
+      queryClient: makeQueryClient(),
+    });
+
+    await lifecycleService.checkAssistant();
+
+    await waitFor(() => {
+      const s = useAssistantLifecycleStore.getState().assistantState;
+      return s.kind === "active" && s.reachable === false;
+    });
+
+    const state = useAssistantLifecycleStore.getState().assistantState;
+    expect(state.kind).toBe("active");
+    if (state.kind === "active") {
+      expect(state.reachable).toBe(false);
+    }
+  });
+
+  test("unreachable bus sets reachable to false", async () => {
+    getAssistantHealthzMock.mockImplementation(async () => ({ ok: true }));
+    getAssistantMock.mockImplementationOnce(async () => ({
+      ok: true,
+      status: 200,
+      data: {
+        id: "asst-unreach-1",
+        status: "active",
+        is_local: false,
+        maintenance_mode: { enabled: false },
+      },
+    }));
+    lifecycleService.setInputs({
+      ...baseInputs,
+      queryClient: makeQueryClient(),
+    });
+
+    await lifecycleService.checkAssistant();
+
+    // Wait for the initial probe to complete with reachable=true
+    await waitFor(() => {
+      const s = useAssistantLifecycleStore.getState().assistantState;
+      return s.kind === "active" && s.reachable === true;
+    });
+
+    // Now make the healthz fail so the retry probe doesn't flip it back
+    getAssistantHealthzMock.mockImplementation(async () => ({ ok: false, status: 503 }));
+
+    // Fire the unreachable bus listener
+    expect(capturedUnreachableListener).not.toBeNull();
+    capturedUnreachableListener!();
+
+    const state = useAssistantLifecycleStore.getState().assistantState;
+    expect(state.kind).toBe("active");
+    if (state.kind === "active") {
+      expect(state.reachable).toBe(false);
+    }
+  });
+
+  test("unreachable bus is a no-op when not in active state", () => {
+    // Service is in loading state (never driven to active)
+    expect(capturedUnreachableListener).not.toBeNull();
+    capturedUnreachableListener!();
+
+    expect(useAssistantLifecycleStore.getState().assistantState.kind).toBe(
+      "loading",
+    );
   });
 });
 

--- a/apps/web/src/assistant/lifecycle-service.test.ts
+++ b/apps/web/src/assistant/lifecycle-service.test.ts
@@ -141,7 +141,7 @@ describe("lifecycleService — server state projection", () => {
     expect(
       useResolvedAssistantsStore.getState().activeAssistantId,
     ).toBe("asst-1");
-    expect(useAssistantLifecycleStore.getState().assistantState).toEqual({
+    expect(useAssistantLifecycleStore.getState().assistantState).toMatchObject({
       kind: "active",
       isLocal: false,
       maintenanceMode: { enabled: false },

--- a/apps/web/src/assistant/lifecycle-service.ts
+++ b/apps/web/src/assistant/lifecycle-service.ts
@@ -27,8 +27,10 @@ import type { QueryClient } from "@tanstack/react-query";
 import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
 import {
   getAssistant,
+  getAssistantHealthz,
   type GetAssistantResult,
 } from "@/assistant/api";
+import { subscribeAssistantUnreachable } from "@/assistant/unreachable-bus";
 import {
   buildInitializingTimeoutError,
   INITIALIZING_TIMEOUT_MS,
@@ -47,6 +49,9 @@ import {
 } from "@/lib/local-mode";
 import { setSelfHostedConnection } from "@/lib/self-hosted/connection";
 import { isAuthenticated, type SessionStatus } from "@/stores/session-status";
+
+const PROBE_RETRY_DELAY_MS = 4_000;
+const PROBE_RETRY_LIMIT_MS = 30_000;
 
 export interface LifecycleServiceInputs {
   sessionStatus: SessionStatus;
@@ -94,6 +99,11 @@ class AssistantLifecycleService {
     queryClient: null as unknown as QueryClient,
     selectedPlatformAssistantId: null,
   };
+  private probeTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor() {
+    subscribeAssistantUnreachable(() => this.onUnreachable());
+  }
 
   // ---------------------------------------------------------------------------
   // React-facing API
@@ -320,6 +330,7 @@ class AssistantLifecycleService {
       isLocal: result.data.is_local ?? false,
       maintenanceMode: { enabled: mm?.enabled },
     });
+    void this.probeReachability(result.data.id);
   }
 
   /**
@@ -398,6 +409,57 @@ class AssistantLifecycleService {
     }
   }
 
+  // ---------------------------------------------------------------------------
+  // Reachability probe
+  // ---------------------------------------------------------------------------
+
+  private async probeReachability(assistantId: string): Promise<void> {
+    const generation = this.generation;
+    try {
+      const result = await getAssistantHealthz(assistantId);
+      if (generation !== this.generation) return;
+      if (this.state.kind !== "active") return;
+      this.transition({ ...this.state, reachable: result.ok });
+    } catch {
+      if (generation !== this.generation) return;
+      if (this.state.kind !== "active") return;
+      this.transition({ ...this.state, reachable: false });
+    }
+  }
+
+  private cancelProbeTimer(): void {
+    if (this.probeTimer) {
+      clearTimeout(this.probeTimer);
+      this.probeTimer = null;
+    }
+  }
+
+  private startProbeLoop(assistantId: string): void {
+    this.cancelProbeTimer();
+    const startedAt = Date.now();
+    const tick = async () => {
+      if (this.state.kind !== "active") return;
+      if (this.state.reachable === true) return;
+      if (Date.now() - startedAt > PROBE_RETRY_LIMIT_MS) return;
+      await this.probeReachability(assistantId);
+      if (this.state.kind !== "active") return;
+      if (this.state.reachable === true) return;
+      if (Date.now() - startedAt > PROBE_RETRY_LIMIT_MS) return;
+      this.probeTimer = setTimeout(() => void tick(), PROBE_RETRY_DELAY_MS);
+    };
+    this.probeTimer = setTimeout(() => void tick(), PROBE_RETRY_DELAY_MS);
+  }
+
+  private onUnreachable(): void {
+    if (this.state.kind !== "active") return;
+    this.transition({ ...this.state, reachable: false });
+    const assistantId =
+      useResolvedAssistantsStore.getState().activeAssistantId;
+    if (assistantId) {
+      this.startProbeLoop(assistantId);
+    }
+  }
+
   /**
    * Reset all state to the post-import default. For tests only —
    * production code should never call this. (Use `respondToInputs`
@@ -408,6 +470,7 @@ class AssistantLifecycleService {
       clearTimeout(this.initializingTimeout);
       this.initializingTimeout = null;
     }
+    this.cancelProbeTimer();
     this.state = { kind: "loading" };
     this.generation = 0;
     this.ready = false;

--- a/apps/web/src/assistant/lifecycle-service.ts
+++ b/apps/web/src/assistant/lifecycle-service.ts
@@ -438,12 +438,11 @@ class AssistantLifecycleService {
     this.cancelProbeTimer();
     const startedAt = Date.now();
     const tick = async () => {
-      if (this.state.kind !== "active") return;
-      if (this.state.reachable === true) return;
+      if (this.state.kind !== "active" || this.state.reachable === true) return;
       if (Date.now() - startedAt > PROBE_RETRY_LIMIT_MS) return;
       await this.probeReachability(assistantId);
-      if (this.state.kind !== "active") return;
-      if (this.state.reachable === true) return;
+      const s = this.state;
+      if (s.kind !== "active" || s.reachable === true) return;
       if (Date.now() - startedAt > PROBE_RETRY_LIMIT_MS) return;
       this.probeTimer = setTimeout(() => void tick(), PROBE_RETRY_DELAY_MS);
     };

--- a/apps/web/src/assistant/types.ts
+++ b/apps/web/src/assistant/types.ts
@@ -17,5 +17,5 @@ export type AssistantState =
   | { kind: "initializing" }
   | { kind: "cleaning_up" }
   | { kind: "self_hosted" }
-  | { kind: "active"; isLocal: boolean; maintenanceMode?: MaintenanceModeInfo }
+  | { kind: "active"; isLocal: boolean; maintenanceMode?: MaintenanceModeInfo; reachable?: boolean }
   | { kind: "error"; message: string };


### PR DESCRIPTION
## Summary
- Add optional `reachable?: boolean` field to the `active` AssistantState variant
- After projecting an active assistant, schedule a background healthz probe that updates `reachable`
- Subscribe to the unreachable bus so 502/503/504 errors trigger a reachability re-check

Part of plan: lifecycle-service-refactor.md (PR 3 of 5)