### PR TITLE
fix(memory-v3): review-round-1 cleanups (core-set parsing, cache-block helper, orchestrate contract)

### DIFF
--- a/assistant/src/memory/v2/prompts/consolidation.ts
+++ b/assistant/src/memory/v2/prompts/consolidation.ts
@@ -388,7 +388,7 @@ Scan namespace sizes. If any namespace has crossed ~12-15 articles with visible 
 
 \`memory/core-pages.md\` lists the pages retrieval keeps in reach EVERY turn, regardless of topic. It exists for one class of page: associative texture — registers, identity frames, calibration rules — pages with no lexical or semantic match to the message that neither search nor usage frequency can surface on their own. You are the only editor of this file; review it each pass.
 
-- **Format:** one page per list line — \`- [[slug]]\` or \`- slug\`. Headings, prose, and annotations are ignored, so annotate freely.
+- **Format:** one page per list line — \`- [[slug]]\` or \`- slug\`, optionally followed by an inline note: after a wikilink the note is free-form (\`- [[slug]] — why it belongs\`); after a bare slug introduce it with a dash (\`- slug — why it belongs\`). Headings, blank lines, and standalone prose lines are ignored, so annotate freely.
 - **Keep it small** — on the order of a few dozen entries (~30–50). Every entry costs context budget every single turn.
 - **Add** a page only when its content should always be in reach with no topical cue. If a search query would find it, it doesn't belong here.
 - **Remove** entries made redundant by frequent use — recently-used pages stay warm automatically (the hot set), so a page that comes up all the time doesn't need a core slot.

--- a/assistant/src/memory/v2/router.ts
+++ b/assistant/src/memory/v2/router.ts
@@ -39,15 +39,12 @@ import {
   getAssistantName,
   resolveUserName,
 } from "../../daemon/identity-helpers.js";
+import { cachedTextBlock } from "../../providers/cache-control.js";
 import {
   extractToolUse,
   getConfiguredProvider,
 } from "../../providers/provider-send-message.js";
-import type {
-  ContentBlock,
-  Message,
-  ToolDefinition,
-} from "../../providers/types.js";
+import type { Message, ToolDefinition } from "../../providers/types.js";
 import { getLogger } from "../../util/logger.js";
 import type { DrizzleDb } from "../db-connection.js";
 import { computeInjectionScores } from "./injection-events.js";
@@ -601,27 +598,4 @@ export function applyHistoricalCharBudget(
     const slot = included.get(idx)!;
     return { assistantMessage: slot.assistant, userMessage: slot.user };
   });
-}
-
-/**
- * Build a text content block carrying an ephemeral `cache_control`
- * breakpoint with a 1h TTL. The Anthropic SDK accepts the field as an extra
- * property on text blocks, but our internal `TextContent` type intentionally
- * omits it (only the Anthropic provider transforms it onto the wire), so we
- * reach through a `Record` cast here for the same reason `client.ts` does —
- * it keeps the core types provider-agnostic. The 1h TTL matches the
- * provider's auto-applied breakpoints (see `cacheTtl` in
- * `providers/anthropic/client.ts`); the `<now>` block is stable across most
- * turns, so default 5m would force unnecessary re-creation. The
- * `extended-cache-ttl-2025-04-11` beta header is added unconditionally for
- * non-Haiku models in `client.ts`, so this works without any call-site
- * config.
- */
-function cachedTextBlock(text: string): ContentBlock {
-  const block: ContentBlock = { type: "text", text };
-  (block as unknown as Record<string, unknown>).cache_control = {
-    type: "ephemeral",
-    ttl: "1h",
-  };
-  return block;
 }

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/live-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/live-integration.test.ts
@@ -235,6 +235,7 @@ async function runTurn(
     edgeGraph: deps.lanes.edgeGraph,
     coreSlugs: [],
     hotSlugs: [],
+    prefixCards: new Map(),
   });
   const active = getActiveSlugs(conversationId);
   const netNew = result.selections

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/orchestrate.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/orchestrate.test.ts
@@ -23,6 +23,7 @@ import type {
   Provider,
   ProviderResponse,
 } from "../../../../providers/types.js";
+import { renderCard } from "../card.js";
 import type { EdgeGraph } from "../edge.js";
 import { buildEdgeGraph } from "../edge.js";
 import type { OrchestrateDeps } from "../orchestrate.js";
@@ -115,18 +116,31 @@ async function buildLanes(): Promise<Lanes> {
 
 const config = {} as never;
 
-/** Orchestrate deps with empty stable-prefix lanes unless overridden. */
+/**
+ * Orchestrate deps with empty stable-prefix lanes unless overridden. Mirrors
+ * lane init: every core/hot slug gets a pre-rendered card (from the RAW
+ * fixture when one exists) unless the test overrides `prefixCards` itself.
+ */
 function depsOf(
   lanes: Lanes,
   overrides: Partial<OrchestrateDeps> = {},
 ): OrchestrateDeps {
+  const coreSlugs = overrides.coreSlugs ?? [];
+  const hotSlugs = overrides.hotSlugs ?? [];
+  const prefixCards = new Map<Slug, string>(
+    [...coreSlugs, ...hotSlugs].map((slug) => [
+      slug,
+      renderCard(slug, RAW[slug] ?? ""),
+    ]),
+  );
   return {
     sectionIndex: lanes.sectionIndex,
     needle: lanes.needle,
     denseConfig: config,
     edgeGraph: lanes.edgeGraph,
-    coreSlugs: [],
-    hotSlugs: [],
+    coreSlugs,
+    hotSlugs,
+    prefixCards,
     ...overrides,
   };
 }
@@ -379,7 +393,7 @@ describe("orchestrate — cache-ordered pool (core + hot + finders)", () => {
     expect(prefix1).toContain("topic-b");
   });
 
-  test("stable-prefix candidates render pre-rendered cards; a missing card degrades to header-only", async () => {
+  test("stable-prefix candidates render their pre-rendered cards verbatim", async () => {
     const lanes = await buildLanes();
     providerStub = selectProvider([]);
 
@@ -388,12 +402,12 @@ describe("orchestrate — cache-ordered pool (core + hot + finders)", () => {
       depsOf(lanes, {
         coreSlugs: ["topic-c"],
         hotSlugs: ["topic-d"],
-        // Only topic-c has a pre-rendered card; topic-d falls back.
         prefixCards: new Map([
           [
             "topic-c",
             "# memory/concepts/topic-c.md\nlead for topic c\n\n[sections: §Notes]",
           ],
+          ["topic-d", "# memory/concepts/topic-d.md\nlead for topic d"],
         ]),
       }),
     );
@@ -401,7 +415,27 @@ describe("orchestrate — cache-ordered pool (core + hot + finders)", () => {
     expect(lastPrefixBlock).toContain(
       "[1] # memory/concepts/topic-c.md\nlead for topic c\n\n[sections: §Notes]",
     );
-    expect(lastPrefixBlock).toContain("[2] # memory/concepts/topic-d.md");
+    expect(lastPrefixBlock).toContain(
+      "[2] # memory/concepts/topic-d.md\nlead for topic d",
+    );
+  });
+
+  test("a stable-prefix slug with no pre-rendered card throws (never silently degrades)", async () => {
+    const lanes = await buildLanes();
+    providerStub = selectProvider([]);
+
+    await expect(
+      orchestrate(
+        makeTurn(1, "zzzz"),
+        depsOf(lanes, {
+          coreSlugs: ["topic-c"],
+          hotSlugs: ["topic-d"],
+          // topic-d is missing — a lane-init bug; a degraded card would break
+          // the byte-stable-prefix contract, so orchestrate must throw.
+          prefixCards: new Map([["topic-c", renderCard("topic-c", "")]]),
+        }),
+      ),
+    ).rejects.toThrow('no pre-rendered card for stable-prefix slug "topic-d"');
   });
 
   test("a finder hit on a core page repeats as a finder line and dedupes on selection", async () => {

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-integration.test.ts
@@ -41,6 +41,7 @@ import type {
   Provider,
   ProviderResponse,
 } from "../../../../providers/types.js";
+import { renderCard } from "../card.js";
 import type { EdgeGraph } from "../edge.js";
 import { buildEdgeGraph } from "../edge.js";
 import type { OrchestrateResult } from "../orchestrate.js";
@@ -301,6 +302,7 @@ async function runTurn(
   },
 ): Promise<OrchestrateResult> {
   providerStub = selectProvider(keep, pin);
+  const stableSlugs = [...(deps.core ?? []), ...(deps.hot ?? [])];
   const result = await orchestrate(makeTurn(turnNumber, query), {
     sectionIndex: deps.lanes.sectionIndex,
     needle: deps.lanes.needle,
@@ -308,6 +310,10 @@ async function runTurn(
     edgeGraph: deps.lanes.edgeGraph,
     coreSlugs: deps.core ?? [],
     hotSlugs: deps.hot ?? [],
+    // Mirrors lane init: every stable-prefix slug gets a pre-rendered card.
+    prefixCards: new Map(
+      stableSlugs.map((slug) => [slug, renderCard(slug, RAW[slug] ?? "")]),
+    ),
   });
   writeSelections(CONV, turnNumber, attributeSelections(result));
   return result;

--- a/assistant/src/plugins/defaults/memory-v3-shadow/core-set.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/core-set.test.ts
@@ -30,6 +30,25 @@ describe("loadCoreSet", () => {
     expect(loadCoreSet(workspaceDir)).toEqual(["page-a", "page-b"]);
   });
 
+  test("accepts inline annotations after the slug", () => {
+    writeCorePages(
+      [
+        "- [[page-a]] — register frame, never matches lexically",
+        "- [[page-b]] keep while the project is live",
+        "- page-c — calibration rules",
+        "- page-d – en-dash annotation",
+        "- page-e - hyphen annotation",
+      ].join("\n"),
+    );
+    expect(loadCoreSet(workspaceDir)).toEqual([
+      "page-a",
+      "page-b",
+      "page-c",
+      "page-d",
+      "page-e",
+    ]);
+  });
+
   test("ignores headings, blank lines, and prose annotations", () => {
     writeCorePages(
       [
@@ -71,9 +90,14 @@ describe("loadCoreSet", () => {
 
   test("malformed list lines are skipped, not fatal", () => {
     writeCorePages(
-      ["-", "-no-space", "- [[unclosed", "- two words here", "- page-a"].join(
-        "\n",
-      ),
+      [
+        "-",
+        "-no-space",
+        "- [[unclosed",
+        "- two words here",
+        "- prose that mentions — a dash mid-sentence",
+        "- page-a",
+      ].join("\n"),
     );
     expect(loadCoreSet(workspaceDir)).toEqual(["page-a"]);
   });

--- a/assistant/src/plugins/defaults/memory-v3-shadow/core-set.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/core-set.ts
@@ -11,10 +11,14 @@ const CORE_PAGES_RELATIVE_PATH = join("memory", "core-pages.md");
 
 /**
  * A list line is `- <item>`; the item may be a bare slug or a `[[slug]]`
- * wikilink. Anything else on the line (headings, prose, annotations) is the
- * maintainer's notes and is ignored.
+ * wikilink, optionally followed by an inline annotation. After a wikilink the
+ * annotation is free-form (`- [[some-slug]] — why this matters`); after a
+ * bare slug it must be introduced by a dash (`- some-slug — why this
+ * matters`), so a multi-word prose line (`- two words here`) is still read as
+ * the maintainer's notes, not a slug. Anything else on the line (headings,
+ * prose) is ignored.
  */
-const LIST_LINE = /^-\s+(?:\[\[([^\]]+)\]\]|(\S+))\s*$/;
+const LIST_LINE = /^-\s+(?:\[\[([^\]]+)\]\](?:\s+.*)?|(\S+)(?:\s+[—–-].*)?)$/;
 
 /** Slug-safe charset; existence against the page store is checked at lane init. */
 const SLUG_SHAPE = /^[a-z0-9-/]+$/;
@@ -25,9 +29,10 @@ const SLUG_SHAPE = /^[a-z0-9-/]+$/;
  * The core lane answers the associative-texture gap (pages with no
  * lexical/semantic match to the message), so its membership is curated, not
  * computed. Parsing is tolerant: list lines in `- [[some-slug]]` or
- * `- some-slug` form are accepted; headings, blank lines, and prose are
- * skipped so the maintainer can annotate the file; malformed or
- * non-slug-shaped entries are dropped, never fatal.
+ * `- some-slug` form are accepted, with optional inline annotations (see
+ * {@link LIST_LINE}); headings, blank lines, and prose are skipped so the
+ * maintainer can annotate the file; malformed or non-slug-shaped entries are
+ * dropped, never fatal.
  *
  * Returns slugs deduped in first-seen file order — that order is the stable
  * sort the selector uses for the core prefix. A missing file yields `[]`.

--- a/assistant/src/plugins/defaults/memory-v3-shadow/ever-injected-store.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/ever-injected-store.ts
@@ -43,7 +43,12 @@ export interface EverInjectedEntry {
   prunedAt: number | null;
 }
 
-/** The full per-conversation record, pruned rows included. */
+/**
+ * The full per-conversation record, pruned rows included. Test oracle only —
+ * no production code path reads it; production consumers use the narrower
+ * accessors ({@link getActiveSlugs}, {@link getActiveEntries},
+ * {@link getPrunedSlugs}, {@link residentBytes}).
+ */
 export function getInjected(
   conversationId: string,
 ): Map<string, EverInjectedEntry> {

--- a/assistant/src/plugins/defaults/memory-v3-shadow/orchestrate.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/orchestrate.ts
@@ -38,7 +38,6 @@
  */
 
 import type { AssistantConfig } from "../../../config/schema.js";
-import { renderCard } from "./card.js";
 import { denseLane } from "./dense.js";
 import type { EdgeGraph } from "./edge.js";
 import { edgeExpand } from "./edge.js";
@@ -74,9 +73,10 @@ export interface OrchestrateDeps {
   hotSlugs: Slug[];
   /** Pre-rendered FULL cards for the stable-prefix slugs, keyed by slug.
    *  Rendered ONCE at lane init so the selector's stable prefix is
-   *  byte-identical across turns (the cache contract). A missing entry
-   *  degrades to a header-only card. */
-  prefixCards?: ReadonlyMap<Slug, string>;
+   *  byte-identical across turns (the cache contract). Every core/hot slug
+   *  MUST have an entry — a missing card is a lane-init bug and throws
+   *  (silently degrading would violate the byte-stable-prefix contract). */
+  prefixCards: ReadonlyMap<Slug, string>;
   /** Number of BM25 needle articles. Defaults to {@link DEFAULT_NEEDLE_K}. */
   needleK?: number;
   /** Number of dense-lane articles. Defaults to {@link DEFAULT_DENSE_K}. */
@@ -254,10 +254,19 @@ export async function orchestrate(
   // its own snippet line so its CURRENT relevance stays visible; `selectPool`
   // dedupes selections by slug. Finder candidates with no match text fall
   // back to the page's lead-section snippet.
-  const stable: StableCandidate[] = [...core, ...hot].map((slug) => ({
-    slug,
-    card: deps.prefixCards?.get(slug) ?? renderCard(slug, ""),
-  }));
+  const stable: StableCandidate[] = [...core, ...hot].map((slug) => {
+    const card = deps.prefixCards.get(slug);
+    if (card === undefined) {
+      // Lane init renders a card for every core/hot slug; a hole here means
+      // the lanes and the card map are out of sync. Throw rather than render
+      // a degraded card — the caller (observeTurn) logs and skips the turn,
+      // which is better than silently breaking the byte-stable prefix.
+      throw new Error(
+        `memory-v3: no pre-rendered card for stable-prefix slug "${slug}"`,
+      );
+    }
+    return { slug, card };
+  });
   const finderTail: PoolCandidate[] = finder.map((c) => ({
     slug: c.slug,
     descriptor:

--- a/assistant/src/plugins/defaults/memory-v3-shadow/pool-select.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/pool-select.ts
@@ -43,6 +43,7 @@
 
 import { z } from "zod";
 
+import { cachedTextBlock } from "../../../providers/cache-control.js";
 import {
   extractToolUse,
   getConfiguredProvider,
@@ -165,23 +166,6 @@ function renderFinderSegment(finder: PoolCandidate[], offset: number): string {
       : `[${id}] ${c.slug}`;
   });
   return `<candidates>\n${lines.join("\n")}\n</candidates>`;
-}
-
-/**
- * Build a text content block carrying an ephemeral `cache_control` breakpoint
- * with a 1h TTL. The internal `ContentBlock` type intentionally omits the
- * field (only the Anthropic provider transforms it onto the wire), so reach
- * through a `Record` cast — same pattern as the v2 router and `client.ts`.
- * The 1h TTL matches the provider's auto-applied breakpoints; Haiku models
- * have the `ttl` stripped provider-side.
- */
-function cachedTextBlock(text: string): ContentBlock {
-  const block: ContentBlock = { type: "text", text };
-  (block as unknown as Record<string, unknown>).cache_control = {
-    type: "ephemeral",
-    ttl: "1h",
-  };
-  return block;
 }
 
 /** Dedupe selections by slug, preserving first-seen order and ORing pinned

--- a/assistant/src/providers/cache-control.ts
+++ b/assistant/src/providers/cache-control.ts
@@ -1,0 +1,26 @@
+import type { ContentBlock } from "./types.js";
+
+/**
+ * Build a text content block carrying an ephemeral `cache_control` breakpoint
+ * with a 1h TTL, marking a byte-stable prefix the provider KV cache should
+ * persist across calls.
+ *
+ * The Anthropic SDK accepts the field as an extra property on text blocks, but
+ * the internal `TextContent` type intentionally omits it (only the Anthropic
+ * provider transforms it onto the wire — block-level `cache_control` is
+ * preserved through `toAnthropicBlockSafe`), so we reach through a `Record`
+ * cast for the same reason `anthropic/client.ts` does — it keeps the core
+ * types provider-agnostic. The 1h TTL matches the provider's auto-applied
+ * breakpoints (see `cacheTtl` in `providers/anthropic/client.ts`); the
+ * `extended-cache-ttl-2025-04-11` beta header is added unconditionally for
+ * non-Haiku models in `client.ts` (Haiku models have the `ttl` stripped
+ * provider-side), so this works without any call-site config.
+ */
+export function cachedTextBlock(text: string): ContentBlock {
+  const block: ContentBlock = { type: "text", text };
+  (block as unknown as Record<string, unknown>).cache_control = {
+    type: "ephemeral",
+    ttl: "1h",
+  };
+  return block;
+}


### PR DESCRIPTION
## Summary
Fixes self-review gaps in memory-v3-cache-aware-carry.md:
- core-set parser accepts inline annotations after slugs (curation prompt aligned) — entries no longer silently dropped
- cachedTextBlock extracted to one shared helper (was duplicated between the v2 router and v3 pool-select)
- OrchestrateDeps.prefixCards now required (the optional fallback could silently violate the byte-stable prefix contract); getInjected marked test-oracle-only