### PR TITLE
fix(memory-v3): prune capability-card robustness + header consolidation (review round 1)

### DIFF
--- a/assistant/src/memory/v2/__tests__/injected-block-slugs.test.ts
+++ b/assistant/src/memory/v2/__tests__/injected-block-slugs.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
-import { extractInjectedConceptSlugs } from "../injected-block-slugs.js";
+import {
+  extractInjectedConceptSlugs,
+  injectedConceptHeader,
+  readInjectedBlock,
+} from "../injected-block-slugs.js";
 
 describe("extractInjectedConceptSlugs", () => {
   test("extracts nested concept slugs from page headers", () => {
@@ -47,5 +51,40 @@ describe("extractInjectedConceptSlugs", () => {
       "# memory/concepts/topics/page-a.md\nA.\n\n# memory/concepts/topics/page-a.md\nA again.";
     expect(extractInjectedConceptSlugs(block)).toEqual(["topics/page-a"]);
     expect(extractInjectedConceptSlugs("no headers here")).toEqual([]);
+  });
+});
+
+describe("injectedConceptHeader", () => {
+  test("builds the header the extractor recovers (builder/parser round-trip)", () => {
+    const header = injectedConceptHeader("topics/page-a");
+    expect(header).toBe("# memory/concepts/topics/page-a.md");
+    expect(extractInjectedConceptSlugs(`${header}\nBody.`)).toEqual([
+      "topics/page-a",
+    ]);
+  });
+});
+
+describe("readInjectedBlock", () => {
+  test("reads the requested key off valid metadata JSON", () => {
+    const metadata = JSON.stringify({
+      memoryInjectedBlock: "v2 block",
+      memoryV3InjectedBlock: "v3 block",
+    });
+    expect(readInjectedBlock(metadata, "memoryInjectedBlock")).toBe("v2 block");
+    expect(readInjectedBlock(metadata, "memoryV3InjectedBlock")).toBe(
+      "v3 block",
+    );
+  });
+
+  test("returns null for absent, non-string, malformed, or non-object metadata", () => {
+    expect(readInjectedBlock(null, "memoryInjectedBlock")).toBeNull();
+    expect(readInjectedBlock(undefined, "memoryInjectedBlock")).toBeNull();
+    expect(readInjectedBlock("", "memoryInjectedBlock")).toBeNull();
+    expect(readInjectedBlock("not json", "memoryInjectedBlock")).toBeNull();
+    expect(readInjectedBlock('["array"]', "memoryInjectedBlock")).toBeNull();
+    expect(
+      readInjectedBlock('{"memoryInjectedBlock": 42}', "memoryInjectedBlock"),
+    ).toBeNull();
+    expect(readInjectedBlock("{}", "memoryInjectedBlock")).toBeNull();
   });
 });

--- a/assistant/src/memory/v2/injected-block-slugs.ts
+++ b/assistant/src/memory/v2/injected-block-slugs.ts
@@ -1,30 +1,79 @@
 /**
- * Slug extraction for persisted memory-injection blocks.
+ * The `# memory/concepts/<slug>.md` header convention for persisted
+ * memory-injection blocks — builder, matcher, and slug extraction.
  *
- * `renderInjectionBlock` (injection.ts) renders each concept page under a
- * `# memory/concepts/<slug>.md` header inside the block that is persisted on
- * the user message as `metadata.memoryInjectedBlock` and re-attached at
- * request build. This module is the read-side inverse of that header
- * convention: given a persisted block, recover the concept slugs it contains.
+ * Both the v2 injection renderer (`injection.ts`) and the v3 card renderers
+ * (`plugins/defaults/memory-v3-shadow/card.ts` / `page-content.ts`) emit each
+ * concept page under this exact header inside the block that is persisted on
+ * the user message (`metadata.memoryInjectedBlock` /
+ * `metadata.memoryV3InjectedBlock`) and re-attached at request build. The
+ * v3 prune valve's card-section parser keys on the same header. Keeping the
+ * builder and the matcher in one place is what guarantees the writers and the
+ * read-side parsers never drift apart.
  *
- * Skill (`skills/<id>`) and CLI-command sections render as plain description
- * lines without a recoverable slug, so they are intentionally not extracted.
- * The one consumer (truncated-fork everInjected seeding) tolerates that:
- * re-attaching a few synthetic capability lines once is harmless, unlike
- * re-attaching every inherited concept summary.
+ * Skill (`skills/<id>`) and CLI-command sections render under their own
+ * `# Skill:` / `# CLI command:` headers without a recoverable slug, so they
+ * are intentionally not extracted.
  *
  * Kept as a dependency-free leaf (like `memory-marker.ts`) so the
  * conversation-fork path can import it without pulling in the heavyweight
  * injection module.
  */
+
+/** Render the concept-page path header that opens a page's section inside an
+ *  injected memory block. The read-side inverse is
+ *  {@link INJECTED_CONCEPT_HEADER_REGEX}. */
+export function injectedConceptHeader(slug: string): string {
+  return `# memory/concepts/${slug}.md`;
+}
+
+/**
+ * Matches a {@link injectedConceptHeader} line inside an injected block;
+ * capture group 1 is the page slug.
+ *
+ * Flagged `gm` for `String.prototype.matchAll`, which clones the regex per
+ * spec and so never mutates this shared instance's `lastIndex`. Do NOT call
+ * `exec`/`test` on it directly — a `g`-flagged regex is stateful under those.
+ */
+export const INJECTED_CONCEPT_HEADER_REGEX = /^# memory\/concepts\/(.+)\.md$/gm;
+
+/** Recover the (deduplicated, in-order) concept slugs a persisted injection
+ *  block contains. */
 export function extractInjectedConceptSlugs(block: string): string[] {
   const slugs: string[] = [];
   const seen = new Set<string>();
-  for (const match of block.matchAll(/^# memory\/concepts\/(.+)\.md$/gm)) {
+  for (const match of block.matchAll(INJECTED_CONCEPT_HEADER_REGEX)) {
     const slug = match[1]!;
     if (seen.has(slug)) continue;
     seen.add(slug);
     slugs.push(slug);
   }
   return slugs;
+}
+
+/**
+ * Read a persisted memory-injection block off a message's metadata JSON, or
+ * `null` when absent/malformed. `key` selects the injection layer: v2's
+ * `memoryInjectedBlock` or memory-v3's card block
+ * (`MEMORY_V3_INJECTED_BLOCK_METADATA_KEY`).
+ *
+ * NOTE: `memory/conversation-crud.ts` carries a private copy of this exact
+ * helper (its fork-seeding scan predates this export); consolidating it onto
+ * this one is a pending cleanup tracked alongside the prune-valve work.
+ */
+export function readInjectedBlock(
+  metadata: string | null | undefined,
+  key: string,
+): string | null {
+  if (!metadata) return null;
+  try {
+    const parsed: unknown = JSON.parse(metadata);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      const block = (parsed as Record<string, unknown>)[key];
+      if (typeof block === "string") return block;
+    }
+  } catch {
+    // Malformed metadata — treat as no block.
+  }
+  return null;
 }

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/injection.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/injection.test.ts
@@ -25,6 +25,7 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
+import { unwrapMemoryBlock } from "../../../../memory/memory-marker.js";
 import { migrateAddMemoryV3Selections } from "../../../../memory/migrations/268-add-memory-v3-selections.js";
 import { migrateAddMemoryV3EverInjected } from "../../../../memory/migrations/275-add-memory-v3-ever-injected.js";
 import * as schema from "../../../../memory/schema.js";
@@ -81,6 +82,19 @@ function makeDb() {
   migrateAddMemoryV3EverInjected(db);
   // The prune valve's recency ranking reads `memory_v3_selections`.
   migrateAddMemoryV3Selections(db);
+  // The prune valve plans only against slugs whose card sections are
+  // locatable in persisted `memoryV3InjectedBlock` rows
+  // (`collectPersistedV3Cards`) — minimal `messages` shape it reads.
+  testSqlite.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS messages (
+      id TEXT PRIMARY KEY,
+      conversation_id TEXT NOT NULL,
+      role TEXT NOT NULL,
+      content TEXT NOT NULL,
+      metadata TEXT,
+      created_at INTEGER NOT NULL
+    )
+  `);
   return db;
 }
 
@@ -207,6 +221,28 @@ function produceCards(conversationId: string, turnIndex: number) {
   });
 }
 
+/** Persist a produced card block to message metadata, as the conversation
+ *  assembly does in production (unwrapped, under `memoryV3InjectedBlock`) —
+ *  the prune valve's plan only counts slugs locatable in persisted rows. */
+let persistedMessageSeq = 0;
+function persistCardBlockMetadata(
+  conversationId: string,
+  blockText: string,
+): void {
+  testSqlite
+    .query(
+      /*sql*/ `
+      INSERT INTO messages (id, conversation_id, role, content, metadata, created_at)
+      VALUES (?, ?, 'user', '[]', ?, 0)
+    `,
+    )
+    .run(
+      `m-${persistedMessageSeq++}`,
+      conversationId,
+      JSON.stringify({ memoryV3InjectedBlock: unwrapMemoryBlock(blockText) }),
+    );
+}
+
 function produceSpotlight(conversationId: string, turnIndex: number) {
   return memoryV3SpotlightInjector.produce({
     requestId: "req-1",
@@ -315,12 +351,14 @@ describe("memoryV3Injector — frozen net-new cards", () => {
     turnResults.set(0, t0);
     turnResults.set(1, result(["page-b"])); // …but not on turn 1's lanes.
 
-    await produceCards("conv-1", 0);
+    const b0 = await produceCards("conv-1", 0);
+    persistCardBlockMetadata("conv-1", b0!.text);
     await flushPruneValveForTests();
     // Turn 0 is within the cap — nothing pruned.
     expect(getPrunedSlugs("conv-1").size).toBe(0);
 
-    await produceCards("conv-1", 1);
+    const b1 = await produceCards("conv-1", 1);
+    persistCardBlockMetadata("conv-1", b1!.text);
     // The valve is DEFERRED: nothing pruned synchronously at produce time.
     expect(getPrunedSlugs("conv-1").size).toBe(0);
     await flushPruneValveForTests();

--- a/assistant/src/plugins/defaults/memory-v3-shadow/card.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/card.ts
@@ -1,3 +1,4 @@
+import { injectedConceptHeader } from "../../../memory/v2/injected-block-slugs.js";
 import {
   FRONTMATTER_REGEX,
   parseFrontmatterFields,
@@ -11,9 +12,10 @@ import type { Slug } from "./types.js";
  * enough signal to act on (or `file_read` the full page) at a fraction of the
  * full-page byte cost.
  *
- * The `# memory/concepts/<slug>.md` header matches the v2 memory-block page
- * convention, so the existing `file_read` affordance instruction applies to
- * cards unchanged.
+ * The `# memory/concepts/<slug>.md` header (shared builder:
+ * `injectedConceptHeader` in `memory/v2/injected-block-slugs.ts`) matches the
+ * v2 memory-block page convention, so the existing `file_read` affordance
+ * instruction applies to cards unchanged.
  *
  * Pure text → text: no I/O, no LLM calls. Callers load the raw page text via
  * the existing page-store helpers (see `page-content.ts`).
@@ -98,7 +100,7 @@ export function renderCard(slug: Slug, rawPageText: string): string {
   const firstHeading = SECTION_HEADING_REGEX.exec(body);
   const head = (firstHeading ? body.slice(0, firstHeading.index) : body).trim();
 
-  let card = `# memory/concepts/${slug}.md`;
+  let card = injectedConceptHeader(slug);
   if (head.length > 0) card += `\n${head}`;
 
   const toc = renderTocLine(body, fields);

--- a/assistant/src/plugins/defaults/memory-v3-shadow/page-content.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/page-content.ts
@@ -1,3 +1,4 @@
+import { injectedConceptHeader } from "../../../memory/v2/injected-block-slugs.js";
 import { readPage, renderPageContent } from "../../../memory/v2/page-store.js";
 import { getWorkspaceDir } from "../../../util/platform.js";
 import { renderCapabilityContent } from "./capabilities.js";
@@ -6,12 +7,12 @@ import type { Section, Slug } from "./types.js";
 
 /**
  * Prefix `body` with the `# memory/concepts/<slug>.md` header marker the v3
- * `<memory>` block uses. Both the full-page and matched-section renderers emit
- * this exact marker, and the v2 stripper recognizes pages by it — so the two
- * call sites MUST stay byte-identical, which is why this lives in one place.
+ * `<memory>` block uses (shared builder: `injectedConceptHeader`, so the
+ * renderers, the card renderer, and the read-side parsers all agree on the
+ * exact bytes).
  */
 function withConceptHeader(slug: Slug, body: string): string {
-  return `# memory/concepts/${slug}.md\n${body}`;
+  return `${injectedConceptHeader(slug)}\n${body}`;
 }
 
 /**
@@ -26,9 +27,11 @@ function withConceptHeader(slug: Slug, body: string): string {
  * `readPage`. A non-null result (including "") means the slug was a capability
  * slug and was handled here.
  *
- * Shared by the live injector (`shadow-plugin.ts`) and the inspector
- * selection-log store (`selection-log-store.ts`) so the inspector's rendered
- * block is byte-identical to what live injection produces.
+ * INSPECTOR-ONLY (as the `renderV3SectionContent` fallback): live injection
+ * freezes compact CARDS into history via {@link renderV3CardContent} — it no
+ * longer renders full pages, so this output is an APPROXIMATE reconstruction
+ * for the inspector selection log (`selection-log-store.ts`), not what the
+ * model saw.
  */
 export async function renderV3PageContent(slug: Slug): Promise<string> {
   const capability = renderCapabilityContent(slug);
@@ -70,11 +73,13 @@ export async function renderV3CardContent(slug: Slug): Promise<string> {
 }
 
 /**
- * Render a slug's matched section for the v3 `<memory>` block (progressive
- * disclosure: inject only the section the lanes matched, not the full page).
- * Uses the same `# memory/concepts/<slug>.md` header marker as
- * {@link renderV3PageContent} so the block reads like v2's and the v2 stripper
- * recognizes it.
+ * Render a slug's matched section under the `# memory/concepts/<slug>.md`
+ * header marker, the same marker as {@link renderV3PageContent}.
+ *
+ * INSPECTOR-ONLY: live injection freezes cards ({@link renderV3CardContent})
+ * and re-renders the ephemeral spotlight separately; this per-section render
+ * remains for the inspector selection log (`selection-log-store.ts`), which
+ * reconstructs an approximate view of a turn's selection after the fact.
  *
  * - Capability slugs (skills, `assistant` CLI commands) have no on-disk
  *   section, so they always render their capability content via

--- a/assistant/src/plugins/defaults/memory-v3-shadow/prune.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/prune.test.ts
@@ -1,10 +1,14 @@
 /**
  * Tests for `prune.ts` — the memory-v3 resident-footprint prune valve:
  *   - `filterPrunedCardSections`: card-boundary parsing, byte-identical
- *     remainders, all-pruned → `""`, no-op → same reference;
+ *     remainders, all-pruned → `""`, no-op → same reference, capability
+ *     chunks (`# Skill:` / `# CLI command:` headers) terminating a card and
+ *     surviving its prune;
  *   - `planPrune`: no-op below the cap, oldest-first selection-recency
  *     ranking down to the target, core/hot exemption, `injected_at` fallback,
- *     zero-byte (fork-seed) rows skipped, idempotence below the cap;
+ *     zero-byte (fork-seed) rows skipped, unlocatable slugs excluded from
+ *     candidacy AND the freeable measure (no loop-fire), idempotence below
+ *     the cap;
  *   - `runPruneValve` + the live strip: v3-owned blocks stripped in place,
  *     v2-lookalike blocks untouched, all-pruned blocks removed, and the
  *     rehydration filter (the same `filterPrunedCardSections` over persisted
@@ -46,7 +50,7 @@ function makeDb() {
   const db = drizzle(testSqlite, { schema });
   migrateAddMemoryV3EverInjected(db);
   migrateAddMemoryV3Selections(db);
-  // Minimal `messages` shape — `collectPersistedV3CardSections` reads only
+  // Minimal `messages` shape — `collectPersistedV3Cards` reads only
   // `conversation_id` and `metadata`.
   testSqlite.run(/*sql*/ `
     CREATE TABLE IF NOT EXISTS messages (
@@ -79,7 +83,7 @@ mock.module("../../../config/loader.js", () => ({
 }));
 
 const {
-  collectPersistedV3CardSections,
+  collectPersistedV3Cards,
   filterPrunedCardSections,
   flushPruneValveForTests,
   parseCardSections,
@@ -99,6 +103,10 @@ const { V3_CARDS_INJECTION_HEADER, renderCardsBlockInner } =
 function card(slug: string): string {
   return `# memory/concepts/${slug}.md\nlead for ${slug}\n\n[sections: §One · §Two]`;
 }
+
+/** A capability chunk exactly as `renderCapabilityContent` shapes it: its own
+ *  non-concept top-level header plus the capability content. */
+const CAPABILITY_CHUNK = "# Skill: meet-join\nJoin a video meeting on request.";
 
 function insertSelection(
   conversationId: string,
@@ -194,6 +202,43 @@ describe("parseCardSections / filterPrunedCardSections", () => {
     const plain = "remember: user prefers tea";
     expect(filterPrunedCardSections(plain, new Set(["page-a"]))).toBe(plain);
   });
+
+  test("a capability chunk terminates the preceding card's section", () => {
+    const mixed = renderCardsBlockInner([
+      card("page-a"),
+      CAPABILITY_CHUNK,
+      card("page-b"),
+    ]);
+    const parsed = parseCardSections(mixed);
+    expect(parsed.sections.map((s) => s.slug)).toEqual(["page-a", "page-b"]);
+    // page-a's section stops AT the capability header — it must not absorb it.
+    expect(parsed.sections[0]!.text).toBe(card("page-a"));
+    expect(parsed.pieces.map((p) => p.kind)).toEqual(["card", "other", "card"]);
+    expect(parsed.pieces[1]!.text).toBe(CAPABILITY_CHUNK);
+  });
+
+  test("pruning a concept card never swallows a trailing capability chunk", () => {
+    const mixed = renderCardsBlockInner([
+      card("page-a"),
+      CAPABILITY_CHUNK,
+      card("page-b"),
+    ]);
+    expect(filterPrunedCardSections(mixed, new Set(["page-a"]))).toBe(
+      renderCardsBlockInner([CAPABILITY_CHUNK, card("page-b")]),
+    );
+    // Capability chunk at the block END survives the prune of the last card.
+    const trailing = renderCardsBlockInner([card("page-a"), CAPABILITY_CHUNK]);
+    expect(filterPrunedCardSections(trailing, new Set(["page-a"]))).toBe(
+      renderCardsBlockInner([CAPABILITY_CHUNK]),
+    );
+  });
+
+  test("all cards pruned keeps the preamble + capability chunks", () => {
+    const mixed = renderCardsBlockInner([card("page-a"), CAPABILITY_CHUNK]);
+    expect(
+      filterPrunedCardSections(mixed, new Set(["page-a", "page-b", "page-c"])),
+    ).toBe(renderCardsBlockInner([CAPABILITY_CHUNK]));
+  });
 });
 
 // ─── planPrune ───────────────────────────────────────────────────────────────
@@ -203,6 +248,18 @@ describe("planPrune", () => {
     maxResidentBytes: 300,
     targetResidentBytes: 200,
     exemptSlugs: new Set<string>(),
+    // Every concept slug these tests record, locatable by default; the
+    // unlocatable-exclusion tests override this per-case.
+    locatableSlugs: new Set([
+      "page-a",
+      "page-b",
+      "page-c",
+      "page-d",
+      "page-old",
+      "page-new",
+      "core-page",
+      "seeded",
+    ]),
   };
 
   test("no-op below (or at) the cap", () => {
@@ -300,6 +357,43 @@ describe("planPrune", () => {
       planPrune({ ...deps, exemptSlugs: new Set(["core-page"]) }, "conv-1"),
     ).toBeNull();
   });
+
+  test("unlocatable slugs (capability rows, drift) are invisible: no loop-fire against unfreeable bytes", () => {
+    // A capability row's bytes can never be stripped from context, so they
+    // must not count toward the freeable footprint — even when they alone
+    // push the raw store total over the cap.
+    recordInjected(
+      "conv-1",
+      [
+        { slug: "skills/meet-join", bytes: 500 }, // not locatable
+        { slug: "page-a", bytes: 100 },
+      ],
+      1_000,
+    );
+    expect(planPrune(deps, "conv-1")).toBeNull();
+    expect(getPrunedSlugs("conv-1").size).toBe(0);
+  });
+
+  test("plans down to the target over freeable bytes only, never tombstoning unlocatable slugs", () => {
+    recordInjected(
+      "conv-1",
+      [
+        { slug: "skills/meet-join", bytes: 500 }, // not locatable
+        { slug: "page-a", bytes: 200 },
+        { slug: "page-b", bytes: 200 },
+      ],
+      1_000,
+    );
+    insertSelection("conv-1", 0, "page-a", 1_000);
+    insertSelection("conv-1", 0, "page-b", 2_000);
+
+    // Freeable resident = 400 > max 300; pruning page-a reaches the 200
+    // target. The 500 unfreeable bytes neither inflate the measure (which
+    // would over-tombstone real cards chasing an unreachable target) nor
+    // enter candidacy.
+    const plan = planPrune(deps, "conv-1");
+    expect(plan).toEqual({ slugs: ["page-a"], bytesFreed: 200 });
+  });
 });
 
 // ─── live strip & v3-block identification ────────────────────────────────────
@@ -365,6 +459,31 @@ describe("stripPrunedCardsFromMessages", () => {
     ]);
   });
 
+  test("stripping a card from a capability-bearing v3 block keeps the capability chunk", () => {
+    const mixedInner = renderCardsBlockInner([
+      card("page-a"),
+      CAPABILITY_CHUNK,
+      card("page-b"),
+    ]);
+    const message = userMessage(wrapMemoryBlock(mixedInner), "hello");
+
+    // Ownership is judged on the card sections only — the capability chunk
+    // (a non-card piece on both the persisted and live side) doesn't break it.
+    const stripped = stripPrunedCardsFromMessages(
+      [message],
+      new Set(["page-a"]),
+      knownSections,
+    );
+
+    expect(stripped).toBe(1);
+    expect(message.content[0]).toEqual({
+      type: "text",
+      text: wrapMemoryBlock(
+        renderCardsBlockInner([CAPABILITY_CHUNK, card("page-b")]),
+      ),
+    });
+  });
+
   test("ignores assistant messages, non-memory blocks, and unpruned v3 blocks", () => {
     const assistant: Message = {
       role: "assistant",
@@ -389,8 +508,8 @@ describe("stripPrunedCardsFromMessages", () => {
   });
 });
 
-describe("collectPersistedV3CardSections", () => {
-  test("collects card sections from persisted v3 metadata, skipping malformed rows", () => {
+describe("collectPersistedV3Cards", () => {
+  test("collects card sections AND locatable slugs from persisted v3 metadata, skipping malformed rows", () => {
     insertUserRowWithV3Block(
       "conv-1",
       "m1",
@@ -410,9 +529,24 @@ describe("collectPersistedV3CardSections", () => {
       )
       .run();
 
-    const sections = collectPersistedV3CardSections("conv-1");
-    expect(sections).toEqual(new Set([card("page-a"), card("page-b")]));
-    expect(collectPersistedV3CardSections("conv-other").size).toBe(0);
+    const collected = collectPersistedV3Cards("conv-1");
+    expect(collected.sections).toEqual(
+      new Set([card("page-a"), card("page-b")]),
+    );
+    expect(collected.slugs).toEqual(new Set(["page-a", "page-b"]));
+    expect(collectPersistedV3Cards("conv-other").sections.size).toBe(0);
+  });
+
+  test("capability chunks contribute neither a section nor a locatable slug", () => {
+    insertUserRowWithV3Block(
+      "conv-1",
+      "m1",
+      renderCardsBlockInner([card("page-a"), CAPABILITY_CHUNK]),
+    );
+
+    const collected = collectPersistedV3Cards("conv-1");
+    expect(collected.sections).toEqual(new Set([card("page-a")]));
+    expect(collected.slugs).toEqual(new Set(["page-a"]));
   });
 });
 
@@ -438,6 +572,34 @@ describe("runPruneValve", () => {
     expect(
       await runPruneValve("conv-1", { exemptSlugs: new Set() }),
     ).toBeNull();
+  });
+
+  test("unfreeable capability bytes over the raw cap: no-op, nothing tombstoned", async () => {
+    // The capability row inflates the store total past the cap, but its
+    // content has no locatable card section — the valve must not loop-fire
+    // (tombstoning real cards turn after turn against an unreachable target).
+    insertUserRowWithV3Block(
+      "conv-1",
+      "m1",
+      renderCardsBlockInner([card("page-a"), CAPABILITY_CHUNK]),
+    );
+    recordInjected(
+      "conv-1",
+      [
+        { slug: "page-a", bytes: 100 },
+        { slug: "skills/meet-join", bytes: 500 },
+      ],
+      1_000,
+    );
+
+    pruneConfig = { maxResidentBytes: 300, targetResidentBytes: 200 };
+    expect(
+      await runPruneValve("conv-1", { exemptSlugs: new Set() }),
+    ).toBeNull();
+    expect(
+      await runPruneValve("conv-1", { exemptSlugs: new Set() }),
+    ).toBeNull();
+    expect(getPrunedSlugs("conv-1").size).toBe(0);
   });
 
   test("over the cap: marks pruned, strips the live history, and converges with rehydration", async () => {
@@ -568,6 +730,11 @@ describe("schedulePruneValve", () => {
 
   test("valve failures are swallowed (never affect the turn)", async () => {
     pruneConfig = { maxResidentBytes: 0, targetResidentBytes: 0 };
+    insertUserRowWithV3Block(
+      "conv-1",
+      "m1",
+      renderCardsBlockInner([card("page-a")]),
+    );
     recordInjected("conv-1", [{ slug: "page-a", bytes: 100 }], 1_000);
     schedulePruneValve("conv-1", {
       exemptSlugs: new Set(),

--- a/assistant/src/plugins/defaults/memory-v3-shadow/prune.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/prune.ts
@@ -18,9 +18,11 @@
  *   (a) a one-time strip of the pruned cards' sections from the `<memory>`
  *       blocks riding the LIVE in-memory history
  *       ({@link stripPrunedCardsFromMessages} — per-card boundaries are the
- *       `# memory/concepts/<slug>.md` headers within a block). The strip
- *       mutates the shared message objects in place so the agent loop's
- *       end-of-turn history fold-back keeps the stripped content;
+ *       `# memory/concepts/<slug>.md` headers within a block, terminated at
+ *       any other top-level header chunk such as capability content; see
+ *       {@link parseCardSections}). The strip mutates the shared message
+ *       objects in place so the agent loop's end-of-turn history fold-back
+ *       keeps the stripped content;
  *   (b) the `loadFromDb` rehydration splice in `daemon/conversation.ts`
  *       re-applies {@link filterPrunedCardSections} on every load, so prunes
  *       persist across daemon restarts without touching the metadata.
@@ -34,10 +36,18 @@
  * cannot tell layers apart syntactically. A block is treated as v3-owned only
  * when EVERY card section in it byte-matches a section of some persisted
  * `memoryV3InjectedBlock` for the conversation
- * ({@link collectPersistedV3CardSections}) — v2 sections render the page
- * SUMMARY (or full page) rather than the card head+TOC, so pre-flip v2 blocks
- * never qualify and are left untouched, keeping their unfiltered rehydration
+ * ({@link collectPersistedV3Cards}) — v2 sections render the page SUMMARY
+ * (or full page) rather than the card head+TOC, so pre-flip v2 blocks never
+ * qualify and are left untouched, keeping their unfiltered rehydration
  * byte-identical.
+ *
+ * Capability note: skill / CLI-command content renders under its own
+ * `# Skill:` / `# CLI command:` header — not a card section — so it can never
+ * be located (and therefore never stripped) by slug. The plan only counts and
+ * prunes slugs with a locatable persisted card section
+ * ({@link PruneDeps.locatableSlugs}); capability content riding a card block
+ * survives the prune of its neighboring cards as a non-card chunk. (The
+ * injector complements this by recording capability slugs at `bytes: 0`.)
  */
 
 import { getConfig } from "../../../config/loader.js";
@@ -46,6 +56,10 @@ import {
   unwrapMemoryBlock,
   wrapMemoryBlock,
 } from "../../../memory/memory-marker.js";
+import {
+  INJECTED_CONCEPT_HEADER_REGEX,
+  readInjectedBlock,
+} from "../../../memory/v2/injected-block-slugs.js";
 import type { ContentBlock, Message } from "../../../providers/types.js";
 import { getLogger } from "../../../util/logger.js";
 import {
@@ -60,11 +74,12 @@ const log = getLogger("memory-v3-shadow");
 
 // ─── card-section parsing & filtering ────────────────────────────────────────
 
-/** Matches a card's path-header line; capture group 1 is the page slug. */
-const CARD_HEADER_REGEX = /^# memory\/concepts\/(.+)\.md$/gm;
+/** Matches any top-level `# ` header line — concept card headers AND foreign
+ *  headers like a capability chunk's `# Skill:` / `# CLI command:` line. */
+const TOP_LEVEL_HEADER_REGEX = /^# /gm;
 
 /** One parsed card section: the header line plus everything up to the next
- *  card header (or end of block), trailing whitespace removed. */
+ *  chunk boundary (or end of block), trailing whitespace removed. */
 export interface CardSection {
   slug: string;
   /** The section text INCLUDING its `# memory/concepts/<slug>.md` header
@@ -73,24 +88,66 @@ export interface CardSection {
   text: string;
 }
 
+/** One ordered chunk of a parsed card block: a concept card (prunable, owned
+ *  by `slug`) or any other `\n\n`-joined chunk (e.g. capability content under
+ *  its own `# Skill:` / `# CLI command:` header — never prunable). */
+export type CardBlockPiece =
+  | { kind: "card"; slug: string; text: string }
+  | { kind: "other"; text: string };
+
 /**
  * Split an UNWRAPPED card-block body into its preamble (the instruction
- * header — everything before the first card header) and per-card sections.
- * Returns zero sections when the text carries no card headers.
+ * header — everything before the first boundary), the ordered chunk pieces,
+ * and the card sections (the `kind: "card"` pieces, kept as a convenience
+ * view). Returns zero sections/pieces when the text carries no concept card
+ * headers.
+ *
+ * A card's section ends at the next concept header OR at any other top-level
+ * `# ` header that starts its own `\n\n`-joined chunk — so a capability chunk
+ * trailing a concept card (`renderCardsBlockInner` joins them with `\n\n`) is
+ * parsed as a separate non-card piece instead of being absorbed into the
+ * card, and pruning the card never deletes it. The blank-line requirement
+ * keeps a card head's own `# Title` line (which follows the path header with
+ * a single `\n`) from splitting the card, and guarantees splits land on the
+ * renderer's `\n\n` seams so re-joins stay byte-identical.
  */
 export function parseCardSections(inner: string): {
   preamble: string;
   sections: CardSection[];
+  pieces: CardBlockPiece[];
 } {
-  const matches = [...inner.matchAll(CARD_HEADER_REGEX)];
-  if (matches.length === 0) return { preamble: inner, sections: [] };
+  const cardMatches = [...inner.matchAll(INJECTED_CONCEPT_HEADER_REGEX)];
+  if (cardMatches.length === 0) {
+    return { preamble: inner, sections: [], pieces: [] };
+  }
 
-  const preamble = inner.slice(0, matches[0]!.index).trimEnd();
-  const sections = matches.map((match, i) => {
-    const end = i + 1 < matches.length ? matches[i + 1]!.index : inner.length;
-    return { slug: match[1]!, text: inner.slice(match.index, end).trimEnd() };
+  const cardStarts = new Set(cardMatches.map((match) => match.index!));
+  const boundaries: Array<{ index: number; slug: string | null }> =
+    cardMatches.map((match) => ({ index: match.index!, slug: match[1]! }));
+  for (const match of inner.matchAll(TOP_LEVEL_HEADER_REGEX)) {
+    const i = match.index!;
+    if (cardStarts.has(i)) continue;
+    // Foreign header on a `\n\n` seam → starts its own chunk.
+    if (i >= 2 && inner[i - 1] === "\n" && inner[i - 2] === "\n") {
+      boundaries.push({ index: i, slug: null });
+    }
+  }
+  boundaries.sort((a, b) => a.index - b.index);
+
+  const preamble = inner.slice(0, boundaries[0]!.index).trimEnd();
+  const pieces = boundaries.map((boundary, i): CardBlockPiece => {
+    const end =
+      i + 1 < boundaries.length ? boundaries[i + 1]!.index : undefined;
+    const text = inner.slice(boundary.index, end).trimEnd();
+    return boundary.slug === null
+      ? { kind: "other", text }
+      : { kind: "card", slug: boundary.slug, text };
   });
-  return { preamble, sections };
+  const sections = pieces.filter(
+    (piece): piece is Extract<CardBlockPiece, { kind: "card" }> =>
+      piece.kind === "card",
+  );
+  return { preamble, sections, pieces };
 }
 
 /**
@@ -98,26 +155,30 @@ export function parseCardSections(inner: string): {
  *
  * Returns the input string UNCHANGED (same reference) when nothing is
  * removed — callers use identity to detect a no-op — and `""` when every
- * card section is pruned (the caller drops/skips the whole block; a bare
- * instruction header with no cards carries no content). Kept sections are
- * re-joined exactly as the renderer joined them (`\n\n`), so an unpruned
- * remainder stays byte-identical to what a fresh render of those cards would
- * produce.
+ * chunk is pruned (the caller drops/skips the whole block; a bare
+ * instruction header with no cards carries no content). Non-card chunks
+ * (capability content) are always kept, so a block whose concept cards are
+ * all pruned but which carries capability content keeps its preamble and
+ * that content. Kept chunks are re-joined exactly as the renderer joined
+ * them (`\n\n`), so an unpruned remainder stays byte-identical to what a
+ * fresh render of those chunks would produce.
  */
 export function filterPrunedCardSections(
   inner: string,
   prunedSlugs: ReadonlySet<string>,
 ): string {
-  const { preamble, sections } = parseCardSections(inner);
+  const { preamble, sections, pieces } = parseCardSections(inner);
   if (sections.length === 0) return inner;
 
-  const kept = sections.filter((section) => !prunedSlugs.has(section.slug));
-  if (kept.length === sections.length) return inner;
+  const kept = pieces.filter(
+    (piece) => piece.kind !== "card" || !prunedSlugs.has(piece.slug),
+  );
+  if (kept.length === pieces.length) return inner;
   if (kept.length === 0) return "";
 
-  const pieces = kept.map((section) => section.text);
-  if (preamble.length > 0) pieces.unshift(preamble);
-  return pieces.join("\n\n");
+  const texts = kept.map((piece) => piece.text);
+  if (preamble.length > 0) texts.unshift(preamble);
+  return texts.join("\n\n");
 }
 
 // ─── prune planning ──────────────────────────────────────────────────────────
@@ -135,25 +196,41 @@ export interface PruneDeps {
   /** Core + hot lane members — the selector's stable prefix must never be
    *  pruned out from under it. */
   exemptSlugs: ReadonlySet<string>;
+  /** Slugs whose card section is locatable in the conversation's persisted
+   *  card blocks ({@link collectPersistedV3Cards}'s `slugs`). Only these
+   *  bytes are freeable: a slug with no locatable section — a capability slug
+   *  rendered under its own `# Skill:` / `# CLI command:` header, or
+   *  accounting drift — could be tombstoned, but the strip/rehydration filter
+   *  could never remove its content, so its bytes would "free" on paper while
+   *  staying in context. Such slugs are excluded from candidacy AND from the
+   *  resident measure the plan works down, so the valve never loop-fires
+   *  against a target it cannot actually reach. */
+  locatableSlugs: ReadonlySet<string>;
 }
 
 /**
- * Plan a prune for the conversation, or `null` when the resident footprint is
- * within `maxResidentBytes` (or nothing is prunable).
+ * Plan a prune for the conversation, or `null` when the freeable resident
+ * footprint is within `maxResidentBytes` (or nothing is prunable).
  *
- * Candidates are the ACTIVE injected slugs ranked by last selection recency —
- * `MAX(created_at)` per slug from `memory_v3_selections`, falling back to the
- * store's `injected_at` for slugs with no selection rows (e.g. rows copied by
- * a full fork) — taken oldest-first until the resident footprint is at
- * `targetResidentBytes`. Core/hot lane members are exempt, and zero-byte rows
- * (truncated-fork seeds: dedup-only, no byte accounting) are skipped — pruning
- * them frees nothing while discarding inherited context.
+ * The footprint and the candidates both range over the ACTIVE injected slugs
+ * whose sections are locatable (`deps.locatableSlugs`) — bytes a prune cannot
+ * free are invisible to the plan. Candidates are ranked by last selection
+ * recency — `MAX(created_at)` per slug from `memory_v3_selections`, falling
+ * back to the store's `injected_at` for slugs with no selection rows (e.g.
+ * rows copied by a full fork) — taken oldest-first until the freeable
+ * footprint is at `targetResidentBytes`. Core/hot lane members are exempt,
+ * and zero-byte rows (truncated-fork seeds: dedup-only, no byte accounting)
+ * are skipped — pruning them frees nothing while discarding inherited
+ * context.
  */
 export function planPrune(
   deps: PruneDeps,
   conversationId: string,
 ): PrunePlan | null {
-  const resident = residentBytes(conversationId);
+  const locatableEntries = getActiveEntries(conversationId).filter((entry) =>
+    deps.locatableSlugs.has(entry.slug),
+  );
+  const resident = locatableEntries.reduce((sum, e) => sum + e.bytes, 0);
   if (resident <= deps.maxResidentBytes) return null;
 
   const selectionRows = getSqliteFrom(getDb())
@@ -169,7 +246,7 @@ export function planPrune(
     selectionRows.map((row) => [row.slug, row.lastSelectedAt]),
   );
 
-  const candidates = getActiveEntries(conversationId)
+  const candidates = locatableEntries
     .filter((entry) => entry.bytes > 0 && !deps.exemptSlugs.has(entry.slug))
     .map((entry) => ({
       ...entry,
@@ -190,17 +267,31 @@ export function planPrune(
 
 // ─── live-history strip ──────────────────────────────────────────────────────
 
+/** The conversation's persisted v3 card record (see
+ *  {@link collectPersistedV3Cards}). */
+export interface PersistedV3Cards {
+  /** Card section texts — the live strip's v3-ownership test: a live
+   *  `<memory>` block is v3-owned iff all of its card sections appear here
+   *  (see the module doc's v2-coexistence note). */
+  sections: Set<string>;
+  /** Slugs with a locatable persisted card section — `planPrune`'s freeable
+   *  set ({@link PruneDeps.locatableSlugs}). Capability slugs never appear:
+   *  their content renders under `# Skill:` / `# CLI command:` headers, which
+   *  parse as non-card chunks. */
+  slugs: Set<string>;
+}
+
 /**
- * The conversation's known v3 card sections, collected from every persisted
- * `metadata.memoryV3InjectedBlock` row. The live strip's v3-ownership test:
- * a live `<memory>` block is v3-owned iff all of its card sections appear in
- * this set (see the module doc's v2-coexistence note).
+ * Collect the conversation's known v3 cards from every persisted
+ * `metadata.memoryV3InjectedBlock` row: the section texts (live-strip
+ * ownership test) and the slugs whose sections are locatable (prune-plan
+ * candidacy).
  */
-export function collectPersistedV3CardSections(
+export function collectPersistedV3Cards(
   conversationId: string,
-): Set<string> {
+): PersistedV3Cards {
   // Substring prefilter (indexable LIKE) mirrors the Slack metadata scan;
-  // rows are validated by the JSON parse below.
+  // rows are validated by `readInjectedBlock`'s JSON parse.
   const rows = getSqliteFrom(getDb())
     .query(
       /*sql*/ `
@@ -213,21 +304,20 @@ export function collectPersistedV3CardSections(
   }>;
 
   const sections = new Set<string>();
+  const slugs = new Set<string>();
   for (const row of rows) {
-    if (!row.metadata) continue;
-    try {
-      const meta = JSON.parse(row.metadata) as Record<string, unknown>;
-      const block = meta[MEMORY_V3_INJECTED_BLOCK_METADATA_KEY];
-      if (typeof block !== "string") continue;
-      for (const section of parseCardSections(unwrapMemoryBlock(block))
-        .sections) {
-        sections.add(section.text);
-      }
-    } catch {
-      /* malformed metadata rows are skipped */
+    const block = readInjectedBlock(
+      row.metadata,
+      MEMORY_V3_INJECTED_BLOCK_METADATA_KEY,
+    );
+    if (block === null) continue;
+    for (const section of parseCardSections(unwrapMemoryBlock(block))
+      .sections) {
+      sections.add(section.text);
+      slugs.add(section.slug);
     }
   }
-  return sections;
+  return { sections, slugs };
 }
 
 /**
@@ -253,15 +343,17 @@ export function stripPrunedCardsFromMessages(
     let changed = false;
     const nextContent: ContentBlock[] = [];
     for (const block of message.content) {
-      if (
-        block.type !== "text" ||
-        !block.text.startsWith("<memory>\n") ||
-        !block.text.endsWith("\n</memory>")
-      ) {
+      if (block.type !== "text") {
         nextContent.push(block);
         continue;
       }
       const inner = unwrapMemoryBlock(block.text);
+      if (inner === block.text) {
+        // Not a wrapped `<memory>` block (unwrap is identity on anything
+        // without the full wrapper pair).
+        nextContent.push(block);
+        continue;
+      }
       const { sections } = parseCardSections(inner);
       const isV3Block =
         sections.length > 0 &&
@@ -328,11 +420,20 @@ export async function runPruneValve(
   const pruneConfig = getConfig().memory?.v3?.prune;
   if (!pruneConfig) return null;
 
+  // Fast path: the store's TOTAL resident bytes upper-bound the freeable
+  // (locatable-only) measure `planPrune` works with, so a conversation within
+  // the cap skips the persisted-metadata scan entirely (the common case).
+  if (residentBytes(conversationId) <= pruneConfig.maxResidentBytes) {
+    return null;
+  }
+
+  const persistedCards = collectPersistedV3Cards(conversationId);
   const plan = planPrune(
     {
       maxResidentBytes: pruneConfig.maxResidentBytes,
       targetResidentBytes: pruneConfig.targetResidentBytes,
       exemptSlugs: options.exemptSlugs,
+      locatableSlugs: persistedCards.slugs,
     },
     conversationId,
   );
@@ -348,7 +449,7 @@ export async function runPruneValve(
     strippedBlocks = stripPrunedCardsFromMessages(
       liveMessages,
       getPrunedSlugs(conversationId),
-      collectPersistedV3CardSections(conversationId),
+      persistedCards.sections,
     );
   }
 

--- a/assistant/src/plugins/defaults/memory-v3-shadow/selection-log-store.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/selection-log-store.ts
@@ -1,10 +1,17 @@
 /**
  * Read-side store for the inspector's Memory V3 section. Reads the persisted
- * `memory_v3_selections` rows for a turn and re-renders the `<memory>` block
- * v3 selected, so the inspector can show what v3 chose (and, in live mode,
- * what it actually injected) without re-running orchestration — which would be
- * wrong anyway, since the hot lane is frecency-stateful and can't be
- * reproduced after the fact.
+ * `memory_v3_selections` rows for a turn and re-renders an APPROXIMATE
+ * `<memory>` block for what v3 selected, so the inspector can show the turn's
+ * selection without re-running orchestration — which would be wrong anyway,
+ * since the hot lane is frecency-stateful and can't be reproduced after the
+ * fact.
+ *
+ * The rendered text is inspector-only and NOT byte-identical to live
+ * injection: the live injector freezes net-new compact CARDS into history
+ * (`renderV3CardContent`) plus an ephemeral spotlight, while this store
+ * re-renders the whole selection set as full/lead pages
+ * (`renderV3SectionContent` with no persisted section identity — see the
+ * inline note at `injectedText`).
  */
 
 import type { MemoryV3SelectionLog } from "../../../api/responses/memory-v3-selection-log.js";


### PR DESCRIPTION
## Summary
Fixes self-review gaps in memory-v3-cache-aware-carry.md:
- planPrune excludes unlocatable (capability) sections from candidacy and freeable-bytes accounting — no loop-fire against unfreeable bytes; section parsing terminates at any top-level header so pruning a concept never swallows a trailing capability card
- The # memory/concepts/ header convention now has one shared source (injected-block-slugs.ts) for builders and parsers
- Inspector-only renderer docstrings corrected