### PR TITLE
fix(memory-v3): injection/assembly correctness (review round 1)

### DIFF
--- a/assistant/src/__tests__/injector-v3-suppression.test.ts
+++ b/assistant/src/__tests__/injector-v3-suppression.test.ts
@@ -25,6 +25,8 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { wrapMemorySpotlightBlock } from "../memory/memory-marker.js";
+import { V3_CARDS_INJECTION_HEADER } from "../plugins/defaults/memory-v3-shadow/render-injection.js";
+import { MEMORY_V3_COMMIT_META_KEY } from "../plugins/defaults/memory-v3-shadow/types.js";
 import type {
   InjectionBlock,
   Injector,
@@ -60,7 +62,7 @@ function makeTurnContext(): TurnContext {
  * (error/empty selection); `inner === ""` mirrors an all-repeat turn (block
  * produced, empty text — nothing attached, but v2 is still suppressed).
  */
-function v3Injector(inner: string | null): Injector {
+function v3Injector(inner: string | null, commit?: () => void): Injector {
   return {
     name: "memory-v3-shadow",
     order: 1000,
@@ -70,6 +72,7 @@ function v3Injector(inner: string | null): Injector {
         id: "memory-v3",
         text: inner === "" ? "" : `<memory>\n${inner}\n</memory>`,
         placement: "after-memory-prefix",
+        ...(commit ? { meta: { [MEMORY_V3_COMMIT_META_KEY]: commit } } : {}),
       };
     },
   };
@@ -213,6 +216,103 @@ describe("memory-v3-live v2 suppression", () => {
     expect(texts).toEqual([
       "current question",
       wrapMemorySpotlightBlock("fresh sections"),
+    ]);
+  });
+
+  test("convergence re-entry: a tail leading with this turn's frozen v3 cards (and <info>) is NOT stripped", async () => {
+    setOverridesForTesting({ "memory-v3-live": true });
+    // Re-entry shape: the memo returns the same selections, every slug is now
+    // in the everInjected store, so the injector produces an EMPTY block —
+    // while the tail still carries the v3 card block frozen on first entry
+    // (leading the content because no workspace / <turn_context> prepend
+    // fired this turn) plus the <info> static block.
+    injectorChainSlot.push(v3Injector(""));
+
+    const frozenV3Block = `<memory>\n${V3_CARDS_INJECTION_HEADER}\n\n# memory/concepts/page-a.md\nhead\n</memory>`;
+    const infoBlock = "<info>\nstatic memory\n</info>";
+    const runMessages: Message[] = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: infoBlock },
+          { type: "text", text: frozenV3Block },
+          { type: "text", text: "current question" },
+        ],
+      },
+    ];
+
+    const result = await applyRuntimeInjections(runMessages, {
+      ...makeTurnContext(),
+    });
+
+    // The just-frozen cards and the static block survive re-entry — only
+    // v2's fresh dynamic prefix (absent here; stripped on first entry) is
+    // ever removed.
+    expect(tailTexts(result.messages)).toEqual([
+      infoBlock,
+      frozenV3Block,
+      "current question",
+    ]);
+  });
+
+  test("first entry with a v2 prefix AND a frozen v3 block strips ONLY the v2 block", async () => {
+    setOverridesForTesting({ "memory-v3-live": true });
+    injectorChainSlot.push(v3Injector(""));
+
+    const frozenV3Block = `<memory>\n${V3_CARDS_INJECTION_HEADER}\n\n# memory/concepts/page-a.md\nhead\n</memory>`;
+    const runMessages: Message[] = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "<memory>\nfresh recalled fact\n</memory>" },
+          { type: "text", text: frozenV3Block },
+          { type: "text", text: "current question" },
+        ],
+      },
+    ];
+
+    const result = await applyRuntimeInjections(runMessages, {
+      ...makeTurnContext(),
+    });
+
+    expect(tailTexts(result.messages)).toEqual([
+      frozenV3Block,
+      "current question",
+    ]);
+  });
+
+  test("the v3 block's attachment-commit callback fires on a user tail", async () => {
+    setOverridesForTesting({ "memory-v3-live": true });
+    const commit = mock(() => {});
+    injectorChainSlot.push(v3Injector("net-new cards", commit));
+
+    const runMessages: Message[] = [
+      userMsgWithV2Memory("fresh recalled fact", "current question"),
+    ];
+    await applyRuntimeInjections(runMessages, { ...makeTurnContext() });
+
+    expect(commit).toHaveBeenCalledTimes(1);
+  });
+
+  test("the commit callback is SKIPPED when the tail is not a user message (block never attaches)", async () => {
+    setOverridesForTesting({ "memory-v3-live": true });
+    const commit = mock(() => {});
+    injectorChainSlot.push(v3Injector("net-new cards", commit));
+
+    const runMessages: Message[] = [
+      { role: "user", content: [{ type: "text", text: "question" }] },
+      { role: "assistant", content: [{ type: "text", text: "answer" }] },
+    ];
+    const result = await applyRuntimeInjections(runMessages, {
+      ...makeTurnContext(),
+    });
+
+    // Neither attached nor captured nor committed: the store must not claim
+    // cards that never reached history.
+    expect(commit).not.toHaveBeenCalled();
+    expect(result.blocks.memoryV3InjectedBlock).toBeUndefined();
+    expect(result.messages[1].content).toEqual([
+      { type: "text", text: "answer" },
     ]);
   });
 

--- a/assistant/src/__tests__/memory-retrieval-hook.test.ts
+++ b/assistant/src/__tests__/memory-retrieval-hook.test.ts
@@ -341,10 +341,13 @@ describe("user-prompt-submit hook (memory retrieval)", () => {
     expect(emitted.type).toBe("memory_recalled");
   });
 
-  test("memory-v3 active → skips v2's memoryInjectedBlock and persists the v3 card block", async () => {
-    // Assembly reports memoryV3Active when v3 superseded (stripped) v2's tail
-    // block this turn — persisting v2's bytes would rehydrate a block that is
-    // not in the live history.
+  test("memory-v3 active → v2 persists immediately, then the combined update removes it and persists the v3 card block", async () => {
+    // The v2 block is persisted RIGHT AFTER retrieval (no loss window: a
+    // crash between retrieval and assembly must not leave v2's activation
+    // store claiming pages whose block never reached metadata). Assembly then
+    // reports memoryV3Active (v3 superseded/stripped v2's tail block), so the
+    // post-assembly combined update REMOVES the v2 key — persisting it would
+    // rehydrate a block that is not in the live history.
     const { memory } = makeFakeGraphMemory({
       injectedBlockText: "v2-block-superseded",
       metrics: makeMetrics(),
@@ -363,12 +366,21 @@ describe("user-prompt-submit hook (memory retrieval)", () => {
 
     await userPromptSubmitMemoryRetrieval(ctx);
 
-    expect(updateMessageMetadataMock).toHaveBeenCalledWith("msg-43", {
-      memoryV3InjectedBlock: "header\n\n# memory/concepts/page-a.md\nhead",
-    });
+    expect(updateMessageMetadataMock.mock.calls).toEqual([
+      ["msg-43", { memoryInjectedBlock: "v2-block-superseded" }],
+      [
+        "msg-43",
+        {
+          // `undefined` deletes the key (JSON.stringify drops it) — the turn
+          // ends with the two memory layers mutually exclusive per row.
+          memoryInjectedBlock: undefined,
+          memoryV3InjectedBlock: "header\n\n# memory/concepts/page-a.md\nhead",
+        },
+      ],
+    ]);
   });
 
-  test("memory-v3 active with EMPTY net-new → no memory metadata persisted at all", async () => {
+  test("memory-v3 active with EMPTY net-new → the immediate v2 persist is removed again", async () => {
     // All-repeat turn: v2 was stripped (superseded) and v3 attached nothing
     // new — the row must rehydrate with no memory block, matching live state.
     const { memory } = makeFakeGraphMemory({
@@ -382,11 +394,39 @@ describe("user-prompt-submit hook (memory retrieval)", () => {
         blocks: { memoryV3Active: true },
       }),
     );
-    const ctx = makeHookCtx();
+    const ctx = makeHookCtx({ userMessageId: "msg-44" });
 
     await userPromptSubmitMemoryRetrieval(ctx);
 
-    expect(updateMessageMetadataMock).not.toHaveBeenCalled();
+    expect(updateMessageMetadataMock.mock.calls).toEqual([
+      ["msg-44", { memoryInjectedBlock: "v2-block-superseded" }],
+      ["msg-44", { memoryInjectedBlock: undefined }],
+    ]);
+  });
+
+  test("v2 block is already persisted when runtime assembly throws (no loss window)", async () => {
+    // Regression guard for the v2 path: with the v3 shadow flag on, assembly
+    // includes a seconds-long selector LLM call. If the process dies or the
+    // turn aborts in that window, the v2 block must already be in metadata —
+    // v2's activation store claimed its pages during retrieval, and a
+    // claimed-but-never-persisted block is absent from history on reload AND
+    // suppressed until compaction.
+    const { memory } = makeFakeGraphMemory({
+      injectedBlockText: "v2-block",
+      metrics: makeMetrics(),
+    });
+    installConversation(memory, { trusted: true });
+    applyRuntimeInjectionsMock.mockImplementationOnce(async () => {
+      throw new Error("assembly failed");
+    });
+    const ctx = makeHookCtx({ userMessageId: "msg-45" });
+
+    await expect(userPromptSubmitMemoryRetrieval(ctx)).rejects.toThrow(
+      "assembly failed",
+    );
+    expect(updateMessageMetadataMock).toHaveBeenCalledWith("msg-45", {
+      memoryInjectedBlock: "v2-block",
+    });
   });
 
   test("skips metadata persist when no block text is injected", async () => {

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -32,7 +32,6 @@ import { isBackgroundConversationType } from "../memory/conversation-types.js";
 import {
   countMemoryPrefixBlocks,
   extractMemoryPrefixBlocks,
-  stripExistingMemoryInjections,
 } from "../memory/graph/conversation-graph-memory.js";
 import { unwrapMemoryBlock } from "../memory/memory-marker.js";
 import {
@@ -49,7 +48,11 @@ import {
 } from "../messaging/providers/slack/render-transcript.js";
 import { createContextSummaryMessage } from "../plugins/defaults/compaction/window-manager.js";
 import { getInjectorChain } from "../plugins/defaults/memory-retrieval/injector-chain.js";
-import { MEMORY_V3_BLOCK_ID } from "../plugins/defaults/memory-v3-shadow/types.js";
+import { V3_CARDS_INJECTION_HEADER } from "../plugins/defaults/memory-v3-shadow/render-injection.js";
+import {
+  MEMORY_V3_BLOCK_ID,
+  MEMORY_V3_COMMIT_META_KEY,
+} from "../plugins/defaults/memory-v3-shadow/types.js";
 import type {
   InjectionBlock,
   InjectionPlacement,
@@ -1698,6 +1701,50 @@ function applyInjectionBlock(
 }
 
 /**
+ * Byte prefix of a memory-v3 frozen card block: the `<memory>` wrapper opening
+ * followed by the v3 cards instruction header. v2's dynamic block carries
+ * recalled facts (no such header), so this prefix discriminates the two
+ * layers' otherwise-identical wrappers.
+ */
+const V3_CARDS_BLOCK_PREFIX = `<memory>\n${V3_CARDS_INJECTION_HEADER}`;
+
+/**
+ * Strip v2's freshly-prepended DYNAMIC memory prefix — the `<memory>` /
+ * legacy `<memory __injected>` text block plus any memory-image groups — from
+ * the tail user message, preserving every other leading memory-prefix block:
+ *
+ *  - memory-v3's frozen card block (recognized by
+ *    {@link V3_CARDS_BLOCK_PREFIX}): a same-turn re-entry assembly (overflow
+ *    convergence) sees the tail it assembled on first entry, whose leading
+ *    block may be this turn's just-frozen v3 cards when no workspace /
+ *    `<turn_context>` prepend fired. Stripping it would drop the cards from
+ *    live history while the everInjected store and metadata still claim them.
+ *  - the `<info>` static block: it counts toward the memory prefix for
+ *    splice positioning but is never prepended by `prepareMemory`, so the v2
+ *    suppression strip has no business removing it.
+ *
+ * Only v2's dynamic block is re-prepended fresh each first-entry assembly
+ * (by `prepareMemory`, before this runs), so it is the only thing this strip
+ * exists to remove.
+ */
+function stripTailV2DynamicMemoryPrefix(messages: Message[]): Message[] {
+  const last = messages[messages.length - 1];
+  if (!last || last.role !== "user") return messages;
+  const prefixCount = countMemoryPrefixBlocksOnContent(last.content);
+  if (prefixCount === 0) return messages;
+  const content = last.content.filter((block, i) => {
+    if (i >= prefixCount) return true;
+    return (
+      block.type === "text" &&
+      (block.text.startsWith(V3_CARDS_BLOCK_PREFIX) ||
+        block.text.startsWith("<info>\n"))
+    );
+  });
+  if (content.length === last.content.length) return messages;
+  return [...messages.slice(0, -1), { ...last, content }];
+}
+
+/**
  * Per-turn options accepted by {@link applyRuntimeInjections}.
  *
  * Most fields are layered onto the {@link TurnContext} the caller provides
@@ -2074,7 +2121,7 @@ export async function applyRuntimeInjections(
         case "memory-v2-static":
           memoryV2StaticCaptured = block.text;
           break;
-        case MEMORY_V3_BLOCK_ID:
+        case MEMORY_V3_BLOCK_ID: {
           // The v3 frozen card block is persisted UNWRAPPED (the v2
           // `memoryInjectedBlock` contract — rehydration re-wraps on use).
           // An empty-text block (all-repeat turn) attaches no content, so
@@ -2082,7 +2129,18 @@ export async function applyRuntimeInjections(
           if (block.text.length > 0) {
             memoryV3Captured = unwrapMemoryBlock(block.text);
           }
+          // Attachment is guaranteed from here (user tail — the gate this
+          // capture loop runs under), so commit the injector's deferred
+          // everInjected-store write. On a non-user tail the block silently
+          // no-ops in `applyInjectionBlock`, and skipping the commit keeps
+          // the store from claiming cards that never attached (which would
+          // suppress them until compaction).
+          const commit = block.meta?.[MEMORY_V3_COMMIT_META_KEY];
+          if (typeof commit === "function") {
+            (commit as () => void)();
+          }
           break;
+        }
       }
     }
   }
@@ -2113,12 +2171,17 @@ export async function applyRuntimeInjections(
   // v2 suppression: when the `memory-v3-live` flag is on AND the v3 injector
   // produced a block this turn (possibly empty-text on an all-repeat turn), v3
   // owns the `<memory>` layer. v2's `prepareMemory` already prepended its own
-  // fresh `<memory>` block to the tail user message — strip the TAIL's memory
-  // prefix only, so the v3 `after-memory-prefix` block (Step 2) lands at the
-  // top of the tail with no v2 prefix ahead of it. Historical user messages
-  // keep their memory blocks byte-identical: frozen v3 card blocks from prior
-  // turns AND pre-cutover v2 blocks both ride the cached prefix (the old
-  // whole-layer `stripAllMemoryInjections` replace is gone).
+  // fresh `<memory>` block to the tail user message — strip the TAIL's v2
+  // dynamic prefix only, so the v3 `after-memory-prefix` block (Step 2) lands
+  // at the top of the tail with no v2 prefix ahead of it. Historical user
+  // messages keep their memory blocks byte-identical: frozen v3 card blocks
+  // from prior turns AND pre-cutover v2 blocks both ride the cached prefix
+  // (the old whole-layer `stripAllMemoryInjections` replace is gone). The
+  // strip is SCOPED to v2's dynamic blocks ({@link
+  // stripTailV2DynamicMemoryPrefix}): a same-turn re-entry assembly's tail
+  // may lead with this turn's just-frozen v3 card block (and the `<info>`
+  // static block) when no other prepends fired, and those must survive — the
+  // v2 prefix this strip exists to remove was already stripped on first entry.
   // Keyed off the v3 block being present (not the flag alone) so a v3 failure
   // (`produce()` → null) leaves v2's block intact — fallback rather than a
   // memory-less turn. Idempotent: re-injection sites that already stripped
@@ -2130,7 +2193,7 @@ export async function applyRuntimeInjections(
   const v3ProducedBlock = afterMemory.some((b) => b.id === MEMORY_V3_BLOCK_ID);
   const memoryV3Active = suppressV2MemoryForV3 && v3ProducedBlock;
   if (memoryV3Active) {
-    runMessagesForAssembly = stripExistingMemoryInjections(
+    runMessagesForAssembly = stripTailV2DynamicMemoryPrefix(
       runMessagesForAssembly,
     );
   }

--- a/assistant/src/plugins/defaults/memory-retrieval/hooks/user-prompt-submit.ts
+++ b/assistant/src/plugins/defaults/memory-retrieval/hooks/user-prompt-submit.ts
@@ -49,17 +49,38 @@ import type { GraphMemoryResult } from "../../../types.js";
 import { MEMORY_V3_INJECTED_BLOCK_METADATA_KEY } from "../../memory-v3-shadow/ever-injected-store.js";
 
 /**
- * Record and broadcast the retrieval's observability side effects: a
- * recall-log row and the `memory_recalled` debug event. Both are best-effort —
- * a failure must not abort the turn. The injected-block METADATA persist moved
- * to {@link persistInjectionBlocks}: it runs after runtime assembly, which is
- * the first point where it is known whether memory-v3 superseded (stripped)
- * v2's block this turn.
+ * Persist and broadcast the retrieval's side effects: the injected block on
+ * the user message's metadata (so it survives reloads), a recall-log row, and
+ * the `memory_recalled` debug event. All three are best-effort — a failure
+ * must not abort the turn.
+ *
+ * The injected-block persist runs HERE, immediately after retrieval — not
+ * after runtime assembly. v2's activation store marks the block's pages
+ * `everInjected` during retrieval, so deferring the metadata write would open
+ * a window (which includes memory-v3's selector LLM call when the shadow flag
+ * is on) where a crash/abort leaves pages claimed-but-never-persisted: absent
+ * from history on reload AND suppressed until compaction. When memory-v3
+ * supersedes (strips) the block later this turn, {@link
+ * persistInjectionBlocks} REMOVES this key again in its combined update — a
+ * transient both-keys state mid-turn is acceptable; a v2 loss window is not.
  */
 function recordRecallSideEffects(
   graphResult: GraphMemoryResult,
   ctx: UserPromptSubmitContext,
 ): void {
+  if (graphResult.injectedBlockText) {
+    try {
+      updateMessageMetadata(ctx.userMessageId, {
+        memoryInjectedBlock: graphResult.injectedBlockText,
+      });
+    } catch (err) {
+      ctx.logger.warn(
+        { err },
+        "Failed to persist memory injection to metadata (non-fatal)",
+      );
+    }
+  }
+
   const m = graphResult.metrics;
 
   try {
@@ -130,12 +151,14 @@ function recordRecallSideEffects(
  * update to avoid doubling SQLite SELECT+UPDATE work each turn. Best-effort — a
  * persistence failure must not abort the turn.
  *
- * The two `<memory>` layers are mutually exclusive per row:
- *  - `v2InjectedBlockText` (the graph retrieval's block) persists as
- *    `memoryInjectedBlock` ONLY when memory-v3 did not supersede it this turn
- *    (`blocks.memoryV3Active`) — assembly stripped a superseded v2 block from
- *    the tail, so persisting it would rehydrate a block that is not in the
- *    live history (a reload cache-bust and duplicated memory).
+ * The two `<memory>` layers end the turn mutually exclusive per row:
+ *  - v2's block (`memoryInjectedBlock`) was already persisted right after
+ *    retrieval (see {@link recordRecallSideEffects} — no loss window). When
+ *    memory-v3 superseded it this turn (`blocks.memoryV3Active`), assembly
+ *    stripped the v2 block from the tail, so this combined update REMOVES the
+ *    key again (persisting it would rehydrate a block that is not in the live
+ *    history — a reload cache-bust and duplicated memory). `v2BlockPersisted`
+ *    tells this function whether there is anything to remove.
  *  - `blocks.memoryV3InjectedBlock` (the frozen net-new card block, unwrapped)
  *    persists under `MEMORY_V3_INJECTED_BLOCK_METADATA_KEY`; `loadFromDb`
  *    re-wraps and splices it on load, freezing the cards into history.
@@ -143,9 +166,9 @@ function recordRecallSideEffects(
 function persistInjectionBlocks(
   blocks: RuntimeInjectionResult["blocks"],
   ctx: UserPromptSubmitContext,
-  v2InjectedBlockText: string | null,
+  v2BlockPersisted: boolean,
 ): void {
-  const v2BlockToPersist = blocks.memoryV3Active ? null : v2InjectedBlockText;
+  const removeV2Block = Boolean(blocks.memoryV3Active) && v2BlockPersisted;
   if (
     !blocks.unifiedTurnContext &&
     !blocks.pkbSystemReminder &&
@@ -154,14 +177,18 @@ function persistInjectionBlocks(
     !blocks.pkbContextBlock &&
     !blocks.memoryV2StaticBlock &&
     !blocks.memoryV3InjectedBlock &&
-    !v2BlockToPersist
+    !removeV2Block
   ) {
     return;
   }
   try {
     const metadataUpdates: Record<string, unknown> = {};
-    if (v2BlockToPersist) {
-      metadataUpdates.memoryInjectedBlock = v2BlockToPersist;
+    if (removeV2Block) {
+      // An explicit `undefined` overrides the value persisted after retrieval
+      // and is dropped by `updateMessageMetadata`'s JSON.stringify, deleting
+      // the key — the metadata schema types the field `string | absent`, so
+      // removal must drop the key rather than write null.
+      metadataUpdates.memoryInjectedBlock = undefined;
     }
     if (blocks.memoryV3InjectedBlock) {
       metadataUpdates[MEMORY_V3_INJECTED_BLOCK_METADATA_KEY] =
@@ -223,7 +250,7 @@ const userPromptSubmitMemoryRetrieval: PluginHookFn<
     conversation?.assistantId,
   );
 
-  let v2InjectedBlockText: string | null = null;
+  let v2BlockPersisted = false;
   if (conversation && isTrustedActor && abortSignal) {
     // Retrieval progress (`memory_status`) and the `memory_recalled` summary
     // publish to the shared `broadcastMessage` hub — the sink every turn
@@ -237,10 +264,10 @@ const userPromptSubmitMemoryRetrieval: PluginHookFn<
     );
 
     recordRecallSideEffects(graphResult, ctx);
-    // Held until after runtime assembly: whether this block persists to
-    // metadata depends on whether memory-v3 supersedes it this turn (see
-    // `persistInjectionBlocks`).
-    v2InjectedBlockText = graphResult.injectedBlockText;
+    // The v2 block is persisted inside `recordRecallSideEffects`. If
+    // memory-v3 supersedes it later this turn, `persistInjectionBlocks`
+    // removes the key in its combined post-assembly update.
+    v2BlockPersisted = Boolean(graphResult.injectedBlockText);
 
     ctx.latestMessages = graphResult.runMessages;
     // Select dense+sparse as a matched pair so RRF fusion combines two signals
@@ -296,7 +323,7 @@ const userPromptSubmitMemoryRetrieval: PluginHookFn<
     conversationId: ctx.conversationId,
   });
   ctx.latestMessages = injection.messages;
-  persistInjectionBlocks(injection.blocks, ctx, v2InjectedBlockText);
+  persistInjectionBlocks(injection.blocks, ctx, v2BlockPersisted);
 };
 
 export default userPromptSubmitMemoryRetrieval;

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/carry-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/carry-integration.test.ts
@@ -71,7 +71,11 @@ import type { EdgeGraph } from "../edge.js";
 import { buildEdgeGraph } from "../edge.js";
 import { buildSectionNeedle } from "../section-needle.js";
 import { buildSectionIndex } from "../sections.js";
-import type { SectionIndex, Slug } from "../types.js";
+import {
+  MEMORY_V3_COMMIT_META_KEY,
+  type SectionIndex,
+  type Slug,
+} from "../types.js";
 
 // ---------------------------------------------------------------------------
 // Module stubs (installed before the dynamic imports below; each delegates to
@@ -593,6 +597,11 @@ async function runTurn(
   const cards = await memoryV3Injector.produce(ctx);
   if (!cards)
     throw new Error(`turn ${turnIndex}: cards injector returned null`);
+  // Runtime assembly invokes the block's attachment-commit callback at its
+  // user-tail commit point — this is where the everInjected store records
+  // the turn's cards (and the prune valve is scheduled).
+  const commit = cards.meta?.[MEMORY_V3_COMMIT_META_KEY];
+  if (typeof commit === "function") (commit as () => void)();
   const netNewSlugs = [...getActiveSlugs(convId)].filter(
     (slug) => !activeBefore.has(slug),
   );

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/injection.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/injection.test.ts
@@ -4,6 +4,11 @@
  *
  *   - net-new dedup: a turn re-selecting already-injected pages renders zero
  *     new cards (empty-text block — still produced, so v2 suppression holds);
+ *   - commit deferral: the everInjected-store write happens in the block's
+ *     attachment-commit callback (invoked by assembly on user-tail turns),
+ *     never in `produce()` itself;
+ *   - trust gate: an untrusted remote actor's turn produces nothing and
+ *     records nothing (the v2 personal-memory gate);
  *   - fork dedup: a conversation whose everInjected record was seeded from
  *     inherited blocks does not re-render those slugs;
  *   - prune round-trip: a pruned slug that is re-selected re-injects;
@@ -28,8 +33,13 @@ import { drizzle } from "drizzle-orm/bun-sqlite";
 import { migrateAddMemoryV3Selections } from "../../../../memory/migrations/268-add-memory-v3-selections.js";
 import { migrateAddMemoryV3EverInjected } from "../../../../memory/migrations/275-add-memory-v3-ever-injected.js";
 import * as schema from "../../../../memory/schema.js";
+import type { InjectionBlock } from "../../../types.js";
 import type { OrchestrateResult } from "../orchestrate.js";
-import type { Section, Slug } from "../types.js";
+import {
+  MEMORY_V3_COMMIT_META_KEY,
+  type Section,
+  type Slug,
+} from "../types.js";
 
 const realConfigLoader = { ...(await import("../../../../config/loader.js")) };
 const realFlags = {
@@ -198,21 +208,51 @@ function result(
   };
 }
 
-function produceCards(conversationId: string, turnIndex: number) {
+const GUARDIAN_TRUST = {
+  sourceChannel: "vellum",
+  trustClass: "guardian",
+} as const;
+
+/** Invoke the block's attachment-commit callback — simulating runtime
+ *  assembly's user-tail commit point, where the everInjected-store write
+ *  (and the prune-valve schedule) now happens. */
+function commitCardsBlock(block: InjectionBlock | null): void {
+  const commit = block?.meta?.[MEMORY_V3_COMMIT_META_KEY];
+  if (typeof commit === "function") (commit as () => void)();
+}
+
+/** Produce the cards block WITHOUT committing — what assembly observes on a
+ *  turn whose tail is not a user message (the block never attaches). */
+function produceCardsWithoutCommit(
+  conversationId: string,
+  turnIndex: number,
+  trust: { sourceChannel: string; trustClass: string } = GUARDIAN_TRUST,
+) {
   return memoryV3Injector.produce({
     requestId: "req-1",
     conversationId,
     turnIndex,
-    trust: { sourceChannel: "vellum", trustClass: "guardian" },
+    trust: trust as never,
   });
 }
 
-function produceSpotlight(conversationId: string, turnIndex: number) {
+/** Produce the cards block and commit it (the normal user-tail turn). */
+async function produceCards(conversationId: string, turnIndex: number) {
+  const block = await produceCardsWithoutCommit(conversationId, turnIndex);
+  commitCardsBlock(block);
+  return block;
+}
+
+function produceSpotlight(
+  conversationId: string,
+  turnIndex: number,
+  trust: { sourceChannel: string; trustClass: string } = GUARDIAN_TRUST,
+) {
   return memoryV3SpotlightInjector.produce({
     requestId: "req-1",
     conversationId,
     turnIndex,
-    trust: { sourceChannel: "vellum", trustClass: "guardian" },
+    trust: trust as never,
   });
 }
 
@@ -337,6 +377,86 @@ describe("memoryV3Injector — frozen net-new cards", () => {
     expect(block!.text).toContain("# memory/concepts/page-a.md");
     expect(block!.text).not.toContain("missing-page");
     expect(getActiveSlugs("conv-1")).toEqual(new Set(["page-a"]));
+  });
+
+  test("EVERY net-new card rendering empty → null (v2 fallback), not an empty block", async () => {
+    liveEnabled = true;
+    turnResults.set(0, result(["missing-page"]));
+
+    // An empty-text block would suppress v2 with nothing to show — a
+    // memory-less turn. Distinct from the all-repeat case (empty netNew),
+    // where the empty block correctly keeps v2 suppressed.
+    expect(await produceCards("conv-1", 0)).toBeNull();
+    expect(getActiveSlugs("conv-1")).toEqual(new Set());
+  });
+
+  test("produce() defers the store write to the commit callback — a never-attached block records nothing", async () => {
+    liveEnabled = true;
+    turnResults.set(0, result(["page-a"]));
+
+    // A turn whose tail is not a user message: assembly never invokes the
+    // commit, so the store must not claim the cards (which would suppress
+    // them until compaction despite never reaching history).
+    const block = await produceCardsWithoutCommit("conv-1", 0);
+    expect(block).not.toBeNull();
+    expect(getActiveSlugs("conv-1")).toEqual(new Set());
+
+    // Assembly's user-tail commit point records them.
+    commitCardsBlock(block);
+    expect(getActiveSlugs("conv-1")).toEqual(new Set(["page-a"]));
+  });
+
+  test("untrusted remote actor → both injectors produce null, no orchestration, nothing recorded", async () => {
+    liveEnabled = true;
+    turnResults.set(0, result(["page-a"]));
+    const untrusted = { sourceChannel: "telegram", trustClass: "unknown" };
+
+    expect(await produceCardsWithoutCommit("conv-1", 0, untrusted)).toBeNull();
+    expect(await produceSpotlight("conv-1", 0, untrusted)).toBeNull();
+    // The gate runs before orchestration: nothing selected, nothing recorded.
+    expect(observeTurnSpy).not.toHaveBeenCalled();
+    expect(getActiveSlugs("conv-1")).toEqual(new Set());
+  });
+
+  test("capability cards (skills / CLI commands) record ZERO bytes", async () => {
+    liveEnabled = true;
+    turnResults.set(0, result(["skills/test-skill", "page-a"]));
+
+    const block = await produceCards("conv-1", 0);
+    // Both cards attach…
+    expect(block!.text).toContain("skills/test-skill");
+    expect(block!.text).toContain("# memory/concepts/page-a.md");
+    // …but the capability card's bytes are recorded as 0: its `# Skill:`
+    // header is invisible to the prune valve's `# memory/concepts/<slug>.md`
+    // section grammar, so non-zero bytes could never be freed and would
+    // loop-fire the valve.
+    const injected = getInjected("conv-1");
+    expect(injected.get("skills/test-skill")!.bytes).toBe(0);
+    expect(injected.get("page-a")!.bytes).toBeGreaterThan(0);
+  });
+
+  test("per-conversation memo LRU: a key refresh evicts nothing; new-key eviction prefers stale entries", async () => {
+    liveEnabled = true;
+    turnResults.set(0, result(["page-a"]));
+    turnResults.set(1, result(["page-a"]));
+    // Fill the memo to its 256-entry cap.
+    for (let i = 0; i < 256; i++) {
+      await produceCards(`conv-${i}`, 0);
+    }
+    // A new turn for a tracked conversation is a key REFRESH — nothing may be
+    // evicted for it (the pre-fix code evicted the oldest entry here).
+    await produceCards("conv-5", 1);
+    observeTurnSpy.mockClear();
+    await produceCards("conv-0", 0);
+    expect(observeTurnSpy).toHaveBeenCalledTimes(0); // still memoized
+    // A genuinely NEW key at the cap evicts the least-recently-set entry
+    // (conv-0); the refreshed conv-5 survives.
+    await produceCards("conv-new", 0);
+    observeTurnSpy.mockClear();
+    await produceCards("conv-5", 1);
+    expect(observeTurnSpy).toHaveBeenCalledTimes(0); // refreshed → survived
+    await produceCards("conv-0", 0);
+    expect(observeTurnSpy).toHaveBeenCalledTimes(1); // evicted → re-observed
   });
 
   test("empty selection → null (fallback to v2), nothing recorded", async () => {

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-plugin.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-plugin.test.ts
@@ -32,7 +32,11 @@ import { migrateAddMemoryV3EverInjected } from "../../../../memory/migrations/27
 import * as schema from "../../../../memory/schema.js";
 import type { HotSetEntry, HotSetOptions } from "../hot-set.js";
 import type { OrchestrateResult } from "../orchestrate.js";
-import type { SectionIndex, SelectionSource } from "../types.js";
+import {
+  MEMORY_V3_COMMIT_META_KEY,
+  type SectionIndex,
+  type SelectionSource,
+} from "../types.js";
 
 // `mock.module` is process-global and, in Bun, neither `mock.restore()` nor a
 // re-mock in `afterAll` reverts it for files that load LATER in the same
@@ -402,14 +406,20 @@ beforeEach(() => {
   resetMemoryV3InjectorStateForTests();
 });
 
-/** Invoke the memory-v3 injector's `produce()` for a turn. */
-function produce(conversationId: string, turnIndex: number) {
-  return memoryV3Injector.produce({
+/** Invoke the memory-v3 injector's `produce()` for a turn and, when a block
+ *  is produced, invoke its attachment-commit callback — simulating runtime
+ *  assembly's user-tail commit point, where the everInjected-store write now
+ *  happens. */
+async function produce(conversationId: string, turnIndex: number) {
+  const block = await memoryV3Injector.produce({
     requestId: "r1",
     conversationId,
     turnIndex,
     trust: {} as never,
   });
+  const commit = block?.meta?.[MEMORY_V3_COMMIT_META_KEY];
+  if (typeof commit === "function") (commit as () => void)();
+  return block;
 }
 
 describe("memory-v3 shadow plugin", () => {

--- a/assistant/src/plugins/defaults/memory-v3-shadow/injector.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/injector.ts
@@ -9,17 +9,23 @@
  *  - {@link memoryV3Injector} (id `memory-v3`, `after-memory-prefix`): the
  *    PERSISTENT layer. Renders only this turn's NET-NEW selections — selections
  *    not already in the everInjected store — as compact cards inside one
- *    `<memory>` block, records them (`recordInjected`), and returns the block.
- *    Runtime assembly splices it onto the current user message and the
- *    user-prompt-submit hook persists the unwrapped inner text under
- *    `metadata.memoryV3InjectedBlock`; `conversation.ts` rehydrates it on
- *    load. The block is FROZEN thereafter: prior turns' card blocks stay
+ *    `<memory>` block and returns the block. The everInjected store write
+ *    (`recordInjected`) and the prune-valve schedule are DEFERRED to a commit
+ *    callback the block carries (`meta[MEMORY_V3_COMMIT_META_KEY]`): runtime
+ *    assembly invokes it only when the turn's tail is a user message — the
+ *    same gate as metadata capture — so a turn whose block silently fails to
+ *    attach never claims its cards in the store (which would suppress them
+ *    until compaction). Runtime assembly splices the block onto the current
+ *    user message and the user-prompt-submit hook persists the unwrapped inner
+ *    text under `metadata.memoryV3InjectedBlock`; `conversation.ts` rehydrates
+ *    it on load. The block is FROZEN thereafter: prior turns' card blocks stay
  *    byte-identical in history, so they ride the provider's cached prefix and
  *    survive restarts — mirroring v2's `memoryInjectedBlock` mechanism. An
  *    all-repeat turn returns an EMPTY-TEXT block: assembly attaches nothing,
  *    but the block's presence still keys v2 suppression (v3 ran and owns the
- *    `<memory>` layer this turn). A `null` return (failure / empty selection)
- *    leaves v2's block intact — fallback to v2 rather than a memory-less turn.
+ *    `<memory>` layer this turn). A `null` return (failure / empty selection /
+ *    every net-new card rendered empty) leaves v2's block intact — fallback to
+ *    v2 rather than a memory-less turn.
  *
  *  - {@link memoryV3SpotlightInjector} (id `memory-v3-spotlight`,
  *    `append-user-tail`): the EPHEMERAL layer. Renders the top `spotlight.n`
@@ -34,6 +40,11 @@
  * (live off) logs what WOULD inject (net-new slugs + bytes + spotlight refs)
  * and attaches nothing; both off → no orchestration.
  *
+ * Both injectors apply the same personal-memory trust gate as v2
+ * ({@link isMemoryV3InjectionAllowed}): an untrusted remote actor's turn
+ * produces nothing — no orchestration, no cards, no spotlight, and nothing
+ * recorded or persisted.
+ *
  * Known mirror-of-v2 limitation: cards attached by mid-turn re-entry
  * assemblies (post-compaction re-injection) live only in memory — metadata is
  * persisted at the first-call site only — so a restart drops them while the
@@ -43,16 +54,19 @@
 
 import { isAssistantFeatureFlagEnabled } from "../../../config/assistant-feature-flags.js";
 import { getConfig } from "../../../config/loader.js";
+import { resolveTrustClass } from "../../../daemon/trust-context.js";
 import {
   wrapMemoryBlock,
   wrapMemorySpotlightBlock,
 } from "../../../memory/memory-marker.js";
+import { shouldExposePersonalMemory } from "../../../memory/v2/static-context.js";
 import { getLogger } from "../../../util/logger.js";
 import {
   type InjectionBlock,
   type Injector,
   type TurnContext,
 } from "../../types.js";
+import { isCapabilitySlug } from "./capabilities.js";
 import { cardBytes } from "./card.js";
 import { getActiveSlugs, recordInjected } from "./ever-injected-store.js";
 import type { OrchestrateResult } from "./orchestrate.js";
@@ -70,6 +84,7 @@ import {
 } from "./shadow-plugin.js";
 import {
   MEMORY_V3_BLOCK_ID,
+  MEMORY_V3_COMMIT_META_KEY,
   MEMORY_V3_SPOTLIGHT_BLOCK_ID,
   type Slug,
 } from "./types.js";
@@ -77,16 +92,27 @@ import {
 const log = getLogger("memory-v3-shadow");
 
 /**
- * Cap on the per-conversation maps below. Oldest-inserted entries are evicted
- * first; an evicted conversation simply re-warms (spotlight) or re-runs
- * orchestration (memo) on its next turn.
+ * Cap on the per-conversation maps below. Least-recently-touched entries are
+ * evicted first; an evicted conversation simply re-warms (spotlight) or
+ * re-runs orchestration (memo) on its next turn.
  */
 const MAX_TRACKED_CONVERSATIONS = 256;
 
-function evictOldest(map: Map<string, unknown>): void {
-  if (map.size < MAX_TRACKED_CONVERSATIONS) return;
-  const oldest = map.keys().next().value;
-  if (oldest !== undefined) map.delete(oldest);
+/**
+ * LRU-set `key` on `map`: delete-then-set so a re-touched key moves to the
+ * back of the Map's insertion order (a plain `set` on an existing key keeps
+ * its original position, which would evict the most long-lived ACTIVE
+ * conversation first). Eviction only fires when inserting a genuinely new
+ * key at the cap.
+ */
+function lruSet<V>(map: Map<string, V>, key: string, value: V): void {
+  if (map.has(key)) {
+    map.delete(key);
+  } else if (map.size >= MAX_TRACKED_CONVERSATIONS) {
+    const oldest = map.keys().next().value;
+    if (oldest !== undefined) map.delete(oldest);
+  }
+  map.set(key, value);
 }
 
 // ─── shared per-turn orchestration memo ─────────────────────────────────────
@@ -114,9 +140,8 @@ function observeTurnOnce(
 ): Promise<OrchestrateResult | null> {
   const cached = observedTurns.get(conversationId);
   if (cached && cached.turnIndex === turnIndex) return cached.result;
-  evictOldest(observedTurns);
   const result = observeTurn(conversationId, turnIndex);
-  observedTurns.set(conversationId, { turnIndex, result });
+  lruSet(observedTurns, conversationId, { turnIndex, result });
   return result;
 }
 
@@ -173,8 +198,7 @@ function updateSpotlightWindow(
   const prior = (spotlightRings.get(conversationId) ?? []).filter(
     (t) => t.turnIndex < turnIndex && t.turnIndex >= turnIndex - windowTurns,
   );
-  if (!spotlightRings.has(conversationId)) evictOldest(spotlightRings);
-  spotlightRings.set(conversationId, [...prior, { turnIndex, entries }]);
+  lruSet(spotlightRings, conversationId, [...prior, { turnIndex, entries }]);
 
   const window: SpotlightEntry[] = [];
   const seen = new Set<string>();
@@ -196,6 +220,25 @@ export function resetMemoryV3InjectorStateForTests(): void {
   spotlightRings.clear();
 }
 
+// ─── trust gate ──────────────────────────────────────────────────────────────
+
+/**
+ * Personal-memory trust gate — the same class v2 applies to its dynamic and
+ * static `<memory>` layers ({@link shouldExposePersonalMemory} with the
+ * guardian trust class, mirroring `isPersonalMemoryAllowed` in the
+ * memory-retrieval injectors). Memory pages, skill/CLI capability cards, and
+ * matched-section spotlights all surface private user content, so an
+ * untrusted remote actor's turn must produce NOTHING — and, because v3 cards
+ * are persisted to message metadata and rehydrated forever, must also record
+ * and persist nothing.
+ */
+function isMemoryV3InjectionAllowed(trust: TurnContext["trust"]): boolean {
+  return shouldExposePersonalMemory({
+    sourceChannel: trust.sourceChannel,
+    isTrustedActor: resolveTrustClass(trust) === "guardian",
+  });
+}
+
 // ─── injectors ───────────────────────────────────────────────────────────────
 
 export const memoryV3Injector: Injector = {
@@ -209,6 +252,7 @@ export const memoryV3Injector: Injector = {
     const live = isAssistantFeatureFlagEnabled(MEMORY_V3_LIVE, config);
     const shadow = isAssistantFeatureFlagEnabled(MEMORY_V3_SHADOW, config);
     if (!live && !shadow) return null;
+    if (!isMemoryV3InjectionAllowed(ctx.trust)) return null;
 
     const result = await observeTurnOnce(ctx.conversationId, ctx.turnIndex);
     // Empty selection falls back to v2 (return null): v2 suppression keys off
@@ -230,9 +274,21 @@ export const memoryV3Injector: Injector = {
         const card = await renderV3CardContent(slug);
         if (card.trim().length > 0) cards.push({ slug, card });
       }
+      // Every net-new card rendered empty: return null (fall back to v2)
+      // rather than an empty-text block — suppressing v2 with nothing to show
+      // would ship a memory-less turn. Distinct from the all-repeat case
+      // (empty `netNew`), where the empty block correctly keeps v2 suppressed
+      // because the cards already ride history.
+      if (netNew.length > 0 && cards.length === 0) return null;
       const entries = cards.map(({ slug, card }) => ({
         slug,
-        bytes: cardBytes(card),
+        // Capability cards (skills / CLI commands) render with their own
+        // `# Skill:` / `# CLI command:` headers, which the prune valve's
+        // `# memory/concepts/<slug>.md` section grammar can never locate to
+        // free. Record them at zero bytes so they never inflate the freeable
+        // resident accounting (the valve would otherwise loop-fire on bytes
+        // it cannot free).
+        bytes: isCapabilitySlug(slug) ? 0 : cardBytes(card),
       }));
 
       if (!live) {
@@ -254,15 +310,24 @@ export const memoryV3Injector: Injector = {
         return null;
       }
 
-      recordInjected(ctx.conversationId, entries);
-
-      // Prune valve: deferred (never delays this turn's assembly) and fired
-      // after `recordInjected` so the resident accounting includes this
-      // turn's cards. Core/hot lane members are exempt — the selector's
+      // The everInjected store write and the prune-valve schedule are
+      // DEFERRED to this commit callback, invoked by runtime assembly at the
+      // point where attachment is guaranteed (the turn's tail is a user
+      // message — the same gate as metadata capture). Recording here in
+      // `produce()` would let a never-attached turn (non-user tail) claim
+      // cards in the store, suppressing them until compaction. The valve is
+      // scheduled after `recordInjected` so the resident accounting includes
+      // this turn's cards; core/hot lane members are exempt — the selector's
       // stable prefix must never be pruned out from under it.
-      schedulePruneValve(ctx.conversationId, {
-        exemptSlugs: new Set<Slug>([...result.lanes.core, ...result.lanes.hot]),
-      });
+      const commit = (): void => {
+        recordInjected(ctx.conversationId, entries);
+        schedulePruneValve(ctx.conversationId, {
+          exemptSlugs: new Set<Slug>([
+            ...result.lanes.core,
+            ...result.lanes.hot,
+          ]),
+        });
+      };
 
       // Empty net-new → empty-text block: assembly attaches no content
       // (`applyInjectionBlock` no-ops empty text) but the block's presence
@@ -273,6 +338,7 @@ export const memoryV3Injector: Injector = {
         text: inner.length === 0 ? "" : wrapMemoryBlock(inner),
         // Mirror v2's dynamic `<memory>` block placement.
         placement: "after-memory-prefix",
+        meta: { [MEMORY_V3_COMMIT_META_KEY]: commit },
       };
     } catch (err) {
       log.warn(
@@ -297,6 +363,7 @@ export const memoryV3SpotlightInjector: Injector = {
     // must keep the turn untouched (no ring state either, so a later
     // live-flag flip starts from a clean window).
     if (!isAssistantFeatureFlagEnabled(MEMORY_V3_LIVE, config)) return null;
+    if (!isMemoryV3InjectionAllowed(ctx.trust)) return null;
 
     try {
       const result = await observeTurnOnce(ctx.conversationId, ctx.turnIndex);

--- a/assistant/src/plugins/defaults/memory-v3-shadow/types.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/types.ts
@@ -11,6 +11,18 @@ export type Slug = string;
 export const MEMORY_V3_BLOCK_ID = "memory-v3" as const;
 
 /**
+ * `meta` key under which the v3 cards block carries its attachment-commit
+ * callback. The injector defers its everInjected-store write (and the
+ * prune-valve schedule) into this callback; runtime assembly invokes it only
+ * when the turn's tail is a user message — the same gate as metadata capture
+ * — so a block that silently fails to attach never claims its cards in the
+ * dedup store. Shared between the producer (`injector.ts`) and the consumer
+ * (`conversation-runtime-assembly.ts`) so a rename is a compile error on both
+ * sides instead of a silent never-commit.
+ */
+export const MEMORY_V3_COMMIT_META_KEY = "memoryV3Commit" as const;
+
+/**
  * Injection-block id for the v3 ephemeral `<memory_spotlight>` block (the
  * current window's matched sections, re-rendered at the user tail each turn).
  * Distinct from {@link MEMORY_V3_BLOCK_ID}: the spotlight never participates


### PR DESCRIPTION
## Summary
Fixes gaps from the plan self-review for memory-v3-cache-aware-carry.md:
- v2 metadata persistence restored to immediately-after-retrieval (no loss window for v3-OFF users); v3 mutual exclusion now removes the v2 key in the post-assembly update
- everInjected store writes moved to the attachment-commit point (non-user-tail turns no longer dedup never-attached cards); all-empty-render turns no longer suppress v2
- v3 injectors gated on the same personal-memory trust class as v2
- convergence re-entry no longer strips just-frozen cards; LRU maps refresh recency properly; capability cards record zero bytes (prune accounting)