### PR TITLE
Add microphone input device picker to Voice settings

### DIFF
--- a/apps/web/src/domains/chat/components/voice-input-button.tsx
+++ b/apps/web/src/domains/chat/components/voice-input-button.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/domains/chat/voice/stt-api";
 import { useVoiceRecordingStore } from "@/domains/chat/voice/voice-recording-store";
 import { useIsNativePlatform } from "@/runtime/native-auth";
+import { voiceInputAudioConstraints } from "@/utils/voice-input-device";
 import { Button, cn } from "@vellumai/design-library";
 
 // ---------------------------------------------------------------------------
@@ -384,7 +385,9 @@ export const VoiceInputButton = forwardRef<
 
     let stream: MediaStream;
     try {
-      stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      stream = await navigator.mediaDevices.getUserMedia({
+        audio: voiceInputAudioConstraints(),
+      });
     } catch (err) {
       stopSpeechRecognition();
       const code =

--- a/apps/web/src/domains/chat/voice/live-voice/pcm-capture.ts
+++ b/apps/web/src/domains/chat/voice/live-voice/pcm-capture.ts
@@ -33,6 +33,7 @@ import WORKLET_MODULE_URL from "./pcm-downsample-worklet.ts?worker&url";
 
 import { createAudioContext, getAudioContextCtor } from "@/domains/chat/voice/audio-context";
 import { LIVE_VOICE_AUDIO_FORMAT } from "@/domains/chat/voice/live-voice/protocol";
+import { voiceInputAudioConstraints } from "@/utils/voice-input-device";
 
 // Re-exported for capture consumers (e.g. use-live-voice.ts) so they don't need
 // to reach into the protocol module. Canonical definition lives in protocol.ts.
@@ -148,7 +149,9 @@ export class LiveVoiceAudioCapture {
 
     let stream: MediaStream;
     try {
-      stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      stream = await navigator.mediaDevices.getUserMedia({
+        audio: voiceInputAudioConstraints(),
+      });
     } catch (cause) {
       return { ok: false, error: classifyError(cause), cause };
     }

--- a/apps/web/src/domains/chat/voice/use-audio-amplitude.ts
+++ b/apps/web/src/domains/chat/voice/use-audio-amplitude.ts
@@ -1,6 +1,8 @@
 
 import { useEffect, useRef, useState } from "react";
 
+import { voiceInputAudioConstraints } from "@/utils/voice-input-device";
+
 /**
  * Real-time microphone amplitude via Web Audio API.
  *
@@ -88,7 +90,7 @@ export function useAudioAmplitude({
     } else {
       // Open our own stream; we own its lifecycle.
       navigator.mediaDevices
-        .getUserMedia({ audio: true })
+        .getUserMedia({ audio: voiceInputAudioConstraints() })
         .then((stream) => {
           if (cancelled) {
             for (const track of stream.getTracks()) {

--- a/apps/web/src/domains/settings/pages/voice-page.tsx
+++ b/apps/web/src/domains/settings/pages/voice-page.tsx
@@ -9,6 +9,7 @@ import {
 } from "react";
 import { Link } from "react-router";
 
+import { Button } from "@vellumai/design-library/components/button";
 import { Dropdown } from "@vellumai/design-library/components/dropdown";
 import { Toggle } from "@vellumai/design-library/components/toggle";
 
@@ -109,6 +110,7 @@ const SYSTEM_DEFAULT_DEVICE = "";
 
 function MicrophoneCard() {
   const [devices, setDevices] = useState<MediaDeviceInfo[]>([]);
+  const [needsPermission, setNeedsPermission] = useState(false);
   const [deviceId, setDeviceId] = useState<string>(() =>
     getPreferredInputDeviceId(),
   );
@@ -117,13 +119,19 @@ function MicrophoneCard() {
     if (!navigator.mediaDevices?.enumerateDevices) return;
     try {
       const all = await navigator.mediaDevices.enumerateDevices();
+      const inputs = all.filter((device) => device.kind === "audioinput");
+      // Until mic permission is granted, browsers redact device ids and
+      // labels, so inputs exist but none are selectable — offer a
+      // permission prompt instead of a picker with only System Default.
+      setNeedsPermission(
+        inputs.length > 0 && inputs.every((device) => !device.label),
+      );
       // Chromium lists "default"/"communications" pseudo-devices that mirror
       // a physical device already in the list; our own System Default option
       // covers that case without the duplicate rows.
       setDevices(
-        all.filter(
+        inputs.filter(
           (device) =>
-            device.kind === "audioinput" &&
             device.deviceId !== "" &&
             device.deviceId !== "default" &&
             device.deviceId !== "communications",
@@ -131,8 +139,21 @@ function MicrophoneCard() {
       );
     } catch {
       setDevices([]);
+      setNeedsPermission(false);
     }
   }, []);
+
+  const requestMicAccess = useCallback(async () => {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({
+        audio: true,
+      });
+      for (const track of stream.getTracks()) track.stop();
+    } catch {
+      // Denied or no device — the picker keeps showing System Default.
+    }
+    void refreshDevices();
+  }, [refreshDevices]);
 
   useEffect(() => {
     void refreshDevices();
@@ -176,13 +197,25 @@ function MicrophoneCard() {
       title="Microphone"
       subtitle="Which input device is used for dictation and voice conversations."
     >
-      <div className="max-w-xs">
-        <Dropdown<string>
-          options={options}
-          value={selectedValue}
-          onChange={handleChange}
-          aria-label="Microphone"
-        />
+      <div className="flex flex-col gap-3">
+        <div className="max-w-xs">
+          <Dropdown<string>
+            options={options}
+            value={selectedValue}
+            onChange={handleChange}
+            aria-label="Microphone"
+          />
+        </div>
+        {needsPermission && (
+          <div className="flex flex-wrap items-center gap-2">
+            <Button variant="outlined" onClick={requestMicAccess}>
+              Allow Microphone Access
+            </Button>
+            <span className={labelClasses}>
+              Grant microphone access to list your available input devices.
+            </span>
+          </div>
+        )}
       </div>
     </DetailCard>
   );

--- a/apps/web/src/domains/settings/pages/voice-page.tsx
+++ b/apps/web/src/domains/settings/pages/voice-page.tsx
@@ -15,6 +15,7 @@ import { Toggle } from "@vellumai/design-library/components/toggle";
 import { DetailCard } from "@/components/detail-card";
 import {
     getLocalSetting,
+    removeLocalSetting,
     setLocalSetting,
 } from "@/utils/local-settings";
 import {
@@ -31,6 +32,10 @@ import {
     type PTTModifier,
 } from "@/utils/ptt-activator";
 import { routes } from "@/utils/routes";
+import {
+    LS_VOICE_INPUT_DEVICE,
+    getPreferredInputDeviceId,
+} from "@/utils/voice-input-device";
 import { canConfigureFnPushToTalk } from "@/runtime/hotkey";
 
 const LS_CONVERSATION_TIMEOUT = "vellum:voice:conversationTimeoutSeconds";
@@ -75,6 +80,7 @@ export function VoicePage() {
   return (
     <div className="flex flex-col gap-6">
       <SpeechServicesBanner />
+      <MicrophoneCard />
       <PushToTalkCard />
       <ConversationTimeoutCard />
     </div>
@@ -96,6 +102,89 @@ function SpeechServicesBanner() {
         <ArrowUpRight className="h-3 w-3" />
       </Link>
     </div>
+  );
+}
+
+const SYSTEM_DEFAULT_DEVICE = "";
+
+function MicrophoneCard() {
+  const [devices, setDevices] = useState<MediaDeviceInfo[]>([]);
+  const [deviceId, setDeviceId] = useState<string>(() =>
+    getPreferredInputDeviceId(),
+  );
+
+  const refreshDevices = useCallback(async () => {
+    if (!navigator.mediaDevices?.enumerateDevices) return;
+    try {
+      const all = await navigator.mediaDevices.enumerateDevices();
+      // Chromium lists "default"/"communications" pseudo-devices that mirror
+      // a physical device already in the list; our own System Default option
+      // covers that case without the duplicate rows.
+      setDevices(
+        all.filter(
+          (device) =>
+            device.kind === "audioinput" &&
+            device.deviceId !== "" &&
+            device.deviceId !== "default" &&
+            device.deviceId !== "communications",
+        ),
+      );
+    } catch {
+      setDevices([]);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refreshDevices();
+    const mediaDevices = navigator.mediaDevices;
+    if (!mediaDevices?.addEventListener) return;
+    const onDeviceChange = () => void refreshDevices();
+    mediaDevices.addEventListener("devicechange", onDeviceChange);
+    return () =>
+      mediaDevices.removeEventListener("devicechange", onDeviceChange);
+  }, [refreshDevices]);
+
+  const options = useMemo(
+    () => [
+      { value: SYSTEM_DEFAULT_DEVICE, label: "System Default" },
+      ...devices.map((device, index) => ({
+        value: device.deviceId,
+        label: device.label || `Microphone ${index + 1}`,
+      })),
+    ],
+    [devices],
+  );
+
+  const handleChange = useCallback((next: string) => {
+    setDeviceId(next);
+    if (next === SYSTEM_DEFAULT_DEVICE) {
+      removeLocalSetting(LS_VOICE_INPUT_DEVICE);
+    } else {
+      setLocalSetting(LS_VOICE_INPUT_DEVICE, next);
+    }
+  }, []);
+
+  // A saved device that's currently unplugged won't be in the list; show
+  // System Default (capture falls back to it) without clearing the saved
+  // preference, so reconnecting the device picks it back up.
+  const selectedValue = options.some((option) => option.value === deviceId)
+    ? deviceId
+    : SYSTEM_DEFAULT_DEVICE;
+
+  return (
+    <DetailCard
+      title="Microphone"
+      subtitle="Which input device is used for dictation and voice conversations."
+    >
+      <div className="max-w-xs">
+        <Dropdown<string>
+          options={options}
+          value={selectedValue}
+          onChange={handleChange}
+          aria-label="Microphone"
+        />
+      </div>
+    </DetailCard>
   );
 }
 

--- a/apps/web/src/utils/voice-input-device.ts
+++ b/apps/web/src/utils/voice-input-device.ts
@@ -1,0 +1,22 @@
+import { getLocalSetting } from "@/utils/local-settings";
+
+/**
+ * Microphone chosen on the Voice settings page, stored as a
+ * `MediaDeviceInfo.deviceId`. Empty/absent means "follow the system default".
+ */
+export const LS_VOICE_INPUT_DEVICE = "vellum:voice:inputDeviceId";
+
+export function getPreferredInputDeviceId(): string {
+  return getLocalSetting(LS_VOICE_INPUT_DEVICE, "");
+}
+
+/**
+ * Audio constraints for voice capture, honoring the microphone chosen on the
+ * Voice settings page. The `deviceId` is a preference rather than `exact` so
+ * capture falls back to the system default when the saved device is
+ * unplugged instead of failing with an `OverconstrainedError`.
+ */
+export function voiceInputAudioConstraints(): MediaTrackConstraints | true {
+  const deviceId = getPreferredInputDeviceId();
+  return deviceId ? { deviceId } : true;
+}


### PR DESCRIPTION
## Summary
- Adds a **Microphone** card to Settings → Voice with a dropdown to choose the audio input device, built from the existing `DetailCard` + design-library `Dropdown` components and styled to match the other cards on the page. Devices are enumerated via `navigator.mediaDevices.enumerateDevices()` and the list refreshes on `devicechange`; Chromium's `default`/`communications` pseudo-devices are collapsed into a single **System Default** option.
- The selection persists in local settings (`vellum:voice:inputDeviceId`) via the same `local-settings` helpers the rest of the page uses, and a new `@/utils/voice-input-device` helper exposes it as a `getUserMedia` audio constraint.
- All three voice capture sites — dictation (`voice-input-button.tsx`), live-voice PCM capture (`pcm-capture.ts`), and amplitude analysis (`use-audio-amplitude.ts`) — now honor the chosen device, using a non-exact `deviceId` so capture falls back to the system default when the saved device is unplugged.

## Original prompt
For the mac electron app add the ability to choose the input device on the voice tab in settings. Use all standard UI components and do not use one off components and match the existing styling of the page.