### PR TITLE
fix(memory-v3): v2-block strip discrimination + trust-gate consolidation (review round 2)

### DIFF
--- a/assistant/src/__tests__/injector-v3-suppression.test.ts
+++ b/assistant/src/__tests__/injector-v3-suppression.test.ts
@@ -20,11 +20,20 @@
  * (fallback-to-v2). The flag-off path must be byte-for-byte identical to
  * today — that is the load-bearing regression guard. `applyRuntimeInjections`
  * reads the flag itself, so these tests drive it through the override cache.
+ *
+ * The strip discriminates v2's dynamic block by IDENTITY, not by prefix: v2's
+ * `INJECTION_HEADER` and v3's `V3_CARDS_INJECTION_HEADER` are deliberately
+ * byte-identical, and v2's router block leads with that header whenever any
+ * summary section is present, so no prefix can tell the layers apart. The
+ * identity — the exact text v2 prepended this turn — is read off the live
+ * graph-memory handle, which these tests register and seed per test.
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { ConversationGraphMemory } from "../memory/graph/conversation-graph-memory.js";
 import { wrapMemorySpotlightBlock } from "../memory/memory-marker.js";
+import { INJECTION_HEADER } from "../memory/v2/injection.js";
 import { V3_CARDS_INJECTION_HEADER } from "../plugins/defaults/memory-v3-shadow/render-injection.js";
 import { MEMORY_V3_COMMIT_META_KEY } from "../plugins/defaults/memory-v3-shadow/types.js";
 import type {
@@ -53,6 +62,23 @@ function makeTurnContext(): TurnContext {
     turnIndex: 0,
     trust: { sourceChannel: "vellum", trustClass: "guardian" },
   };
+}
+
+/** Live graph handles registered by the current test (disposed afterwards). */
+const seededGraphs: ConversationGraphMemory[] = [];
+
+/**
+ * Register a live graph-memory handle for `conv-test-1` whose last retrieval
+ * injected `text` — the identity the suppression strip resolves via
+ * `getLiveGraphMemory(conversationId)?.lastInjectedBlockText`. The production
+ * setter is `prepareMemory` (which needs a live DB), so the cached block is
+ * seeded directly through the private field.
+ */
+function seedV2Identity(text: string | null): void {
+  const graph = new ConversationGraphMemory("conv-test-1");
+  (graph as unknown as { lastInjectedBlock: string | null }).lastInjectedBlock =
+    text;
+  seededGraphs.push(graph);
 }
 
 /**
@@ -120,9 +146,15 @@ describe("memory-v3-live v2 suppression", () => {
     setOverridesForTesting({});
   });
 
+  afterEach(() => {
+    for (const graph of seededGraphs) graph.dispose();
+    seededGraphs.length = 0;
+  });
+
   test("flag ON + v3 produced a block → TAIL v2 stripped, historical memory blocks frozen in place", async () => {
     setOverridesForTesting({ "memory-v3-live": true });
     injectorChainSlot.push(v3Injector("net-new cards"));
+    seedV2Identity("fresh recalled fact");
 
     // History: a prior user turn carrying a frozen memory block (a v3 card
     // block or a pre-cutover v2 block — same wrapper), plus the current tail
@@ -164,6 +196,7 @@ describe("memory-v3-live v2 suppression", () => {
   test("flag ON + EMPTY-TEXT v3 block (all-repeat turn) → tail v2 stripped, nothing attached", async () => {
     setOverridesForTesting({ "memory-v3-live": true });
     injectorChainSlot.push(v3Injector(""));
+    seedV2Identity("fresh recalled fact");
 
     const runMessages: Message[] = [
       userMsgWithV2Memory("fresh recalled fact", "current question"),
@@ -225,8 +258,11 @@ describe("memory-v3-live v2 suppression", () => {
     // in the everInjected store, so the injector produces an EMPTY block —
     // while the tail still carries the v3 card block frozen on first entry
     // (leading the content because no workspace / <turn_context> prepend
-    // fired this turn) plus the <info> static block.
+    // fired this turn) plus the <info> static block. The graph handle still
+    // holds this turn's v2 identity (stripped on first entry, so absent from
+    // the tail) — it must not match the frozen cards.
     injectorChainSlot.push(v3Injector(""));
+    seedV2Identity("fresh recalled fact");
 
     const frozenV3Block = `<memory>\n${V3_CARDS_INJECTION_HEADER}\n\n# memory/concepts/page-a.md\nhead\n</memory>`;
     const infoBlock = "<info>\nstatic memory\n</info>";
@@ -258,6 +294,7 @@ describe("memory-v3-live v2 suppression", () => {
   test("first entry with a v2 prefix AND a frozen v3 block strips ONLY the v2 block", async () => {
     setOverridesForTesting({ "memory-v3-live": true });
     injectorChainSlot.push(v3Injector(""));
+    seedV2Identity("fresh recalled fact");
 
     const frozenV3Block = `<memory>\n${V3_CARDS_INJECTION_HEADER}\n\n# memory/concepts/page-a.md\nhead\n</memory>`;
     const runMessages: Message[] = [
@@ -279,6 +316,117 @@ describe("memory-v3-live v2 suppression", () => {
       frozenV3Block,
       "current question",
     ]);
+  });
+
+  test("REGRESSION: a v2 block leading with the REAL summary header (byte-identical to v3's) is stripped; v3 cards and <info> survive (first entry)", async () => {
+    setOverridesForTesting({ "memory-v3-live": true });
+    injectorChainSlot.push(v3Injector(""));
+
+    // The collision this guards: v2's router block leads with
+    // INJECTION_HEADER whenever any summary section is present — the dominant
+    // production case — and v3's card header is deliberately the same bytes.
+    expect(INJECTION_HEADER).toBe(V3_CARDS_INJECTION_HEADER);
+
+    const v2Inner = `${INJECTION_HEADER}\n\n## memory/concepts/page-b.md\nsummary of page b`;
+    seedV2Identity(v2Inner);
+
+    const frozenV3Block = `<memory>\n${V3_CARDS_INJECTION_HEADER}\n\n# memory/concepts/page-a.md\nhead\n</memory>`;
+    const infoBlock = "<info>\nstatic memory\n</info>";
+    const runMessages: Message[] = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: `<memory>\n${v2Inner}\n</memory>` },
+          { type: "text", text: frozenV3Block },
+          { type: "text", text: infoBlock },
+          { type: "text", text: "current question" },
+        ],
+      },
+    ];
+
+    const result = await applyRuntimeInjections(runMessages, {
+      ...makeTurnContext(),
+    });
+
+    // Despite sharing v3's header prefix, v2's block is gone (identity
+    // match); the v3 cards and <info> blocks are byte-identical in place.
+    expect(tailTexts(result.messages)).toEqual([
+      frozenV3Block,
+      infoBlock,
+      "current question",
+    ]);
+  });
+
+  test("REGRESSION: re-entry with a header-bearing v2 identity keeps the first entry's frozen v3 cards", async () => {
+    setOverridesForTesting({ "memory-v3-live": true });
+    // Re-entry: produce() returns the EMPTY block (cards already claimed by
+    // the store) while the tail carries the FIRST entry's v3 block — and the
+    // graph handle still holds the summary-bearing v2 identity from this
+    // turn's retrieval. Identity must be matched against the v2 block, never
+    // against "whatever leads with the shared header".
+    injectorChainSlot.push(v3Injector(""));
+
+    const v2Inner = `${INJECTION_HEADER}\n\n## memory/concepts/page-b.md\nsummary of page b`;
+    seedV2Identity(v2Inner);
+
+    const frozenV3Block = `<memory>\n${V3_CARDS_INJECTION_HEADER}\n\n# memory/concepts/page-a.md\nhead\n</memory>`;
+    const runMessages: Message[] = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: frozenV3Block },
+          { type: "text", text: "current question" },
+        ],
+      },
+    ];
+
+    const result = await applyRuntimeInjections(runMessages, {
+      ...makeTurnContext(),
+    });
+
+    expect(tailTexts(result.messages)).toEqual([
+      frozenV3Block,
+      "current question",
+    ]);
+  });
+
+  test("v2 memory-image groups and legacy <memory __injected> blocks are stripped even without an identity", async () => {
+    setOverridesForTesting({ "memory-v3-live": true });
+    injectorChainSlot.push(v3Injector("net-new cards"));
+    // No live graph handle: identity unknown (null). Image groups and legacy
+    // blocks are unambiguously v2's and are stripped regardless; the shared
+    // `<memory>` wrapper is left alone without an identity to match.
+    const runMessages: Message[] = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "<memory_image __injected>\na chart" },
+          {
+            type: "image",
+            source: { type: "base64", media_type: "image/png", data: "aGk=" },
+          },
+          { type: "text", text: "</memory_image>" },
+          { type: "text", text: "<memory __injected>\nlegacy recalled fact" },
+          { type: "text", text: "current question" },
+        ],
+      },
+    ];
+
+    const result = await applyRuntimeInjections(runMessages, {
+      ...makeTurnContext(),
+    });
+
+    const texts = tailTexts(result.messages);
+    expect(texts).toEqual([
+      "<memory>\nnet-new cards\n</memory>",
+      "current question",
+    ]);
+    // The injected image is gone too (the 3-block group strips as a unit).
+    expect(
+      result.messages[result.messages.length - 1].content.some(
+        (b) => b.type === "image",
+      ),
+    ).toBe(false);
   });
 
   test("the v3 block's attachment-commit callback fires on a user tail", async () => {

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -32,8 +32,9 @@ import { isBackgroundConversationType } from "../memory/conversation-types.js";
 import {
   countMemoryPrefixBlocks,
   extractMemoryPrefixBlocks,
+  getLiveGraphMemory,
 } from "../memory/graph/conversation-graph-memory.js";
-import { unwrapMemoryBlock } from "../memory/memory-marker.js";
+import { unwrapMemoryBlock, wrapMemoryBlock } from "../memory/memory-marker.js";
 import {
   readSlackMetadata,
   readSlackMetadataFromMessageMetadata,
@@ -48,7 +49,6 @@ import {
 } from "../messaging/providers/slack/render-transcript.js";
 import { createContextSummaryMessage } from "../plugins/defaults/compaction/window-manager.js";
 import { getInjectorChain } from "../plugins/defaults/memory-retrieval/injector-chain.js";
-import { V3_CARDS_INJECTION_HEADER } from "../plugins/defaults/memory-v3-shadow/render-injection.js";
 import {
   MEMORY_V3_BLOCK_ID,
   MEMORY_V3_COMMIT_META_KEY,
@@ -1701,44 +1701,57 @@ function applyInjectionBlock(
 }
 
 /**
- * Byte prefix of a memory-v3 frozen card block: the `<memory>` wrapper opening
- * followed by the v3 cards instruction header. v2's dynamic block carries
- * recalled facts (no such header), so this prefix discriminates the two
- * layers' otherwise-identical wrappers.
- */
-const V3_CARDS_BLOCK_PREFIX = `<memory>\n${V3_CARDS_INJECTION_HEADER}`;
-
-/**
- * Strip v2's freshly-prepended DYNAMIC memory prefix — the `<memory>` /
- * legacy `<memory __injected>` text block plus any memory-image groups — from
- * the tail user message, preserving every other leading memory-prefix block:
+ * Strip v2's freshly-prepended DYNAMIC memory prefix from the tail user
+ * message, preserving every other leading memory-prefix block. Exactly three
+ * shapes are v2's to remove:
  *
- *  - memory-v3's frozen card block (recognized by
- *    {@link V3_CARDS_BLOCK_PREFIX}): a same-turn re-entry assembly (overflow
+ *  - `v2WrappedBlock` — the wrapped (`wrapMemoryBlock`) form of the text the
+ *    graph-memory wiring prepended this turn, matched by full-block IDENTITY.
+ *    A prefix match cannot work here: v3's card-block instruction header is
+ *    deliberately byte-identical to v2's `INJECTION_HEADER`
+ *    (`memory/v2/injection.ts`), and v2's router block leads with that same
+ *    header whenever any summary section is present — the dominant case — so
+ *    the two layers' blocks are indistinguishable by any shared prefix.
+ *  - legacy `<memory __injected>` text blocks — only v2 ever produced them.
+ *  - memory-image groups (`<memory_image …>` opener text, the image block,
+ *    the `</memory_image>` closer) — only v2 injects images; v3 card blocks
+ *    are text-only.
+ *
+ * Everything else in the leading memory prefix survives:
+ *
+ *  - memory-v3's frozen card blocks: a same-turn re-entry assembly (overflow
  *    convergence) sees the tail it assembled on first entry, whose leading
- *    block may be this turn's just-frozen v3 cards when no workspace /
- *    `<turn_context>` prepend fired. Stripping it would drop the cards from
- *    live history while the everInjected store and metadata still claim them.
+ *    block may be this turn's just-frozen v3 cards (while this re-entry's
+ *    injector run produces an EMPTY block — the cards are already claimed by
+ *    the everInjected store). Their bytes never equal the v2 identity, so
+ *    they are kept without needing to be recognized as v3.
  *  - the `<info>` static block: it counts toward the memory prefix for
  *    splice positioning but is never prepended by `prepareMemory`, so the v2
  *    suppression strip has no business removing it.
  *
- * Only v2's dynamic block is re-prepended fresh each first-entry assembly
- * (by `prepareMemory`, before this runs), so it is the only thing this strip
- * exists to remove.
+ * `v2WrappedBlock === null` (nothing injected this turn, or no live graph
+ * handle) still strips the image groups and legacy blocks — both are
+ * unambiguously v2's — but leaves every `<memory>` text block in place.
  */
-function stripTailV2DynamicMemoryPrefix(messages: Message[]): Message[] {
+function stripTailV2DynamicMemoryPrefix(
+  messages: Message[],
+  v2WrappedBlock: string | null,
+): Message[] {
   const last = messages[messages.length - 1];
   if (!last || last.role !== "user") return messages;
   const prefixCount = countMemoryPrefixBlocksOnContent(last.content);
   if (prefixCount === 0) return messages;
   const content = last.content.filter((block, i) => {
     if (i >= prefixCount) return true;
-    return (
-      block.type === "text" &&
-      (block.text.startsWith(V3_CARDS_BLOCK_PREFIX) ||
-        block.text.startsWith("<info>\n"))
-    );
+    // v2's memory-image groups: opener text, injected image, closer text.
+    if (block.type === "image") return false;
+    if (block.type !== "text") return true;
+    if (block.text.startsWith("<memory_image")) return false;
+    if (block.text === "</memory_image>") return false;
+    // v2's legacy dynamic wrapper.
+    if (block.text.startsWith("<memory __injected>\n")) return false;
+    // v2's current dynamic block — identity match only (see doc comment).
+    return v2WrappedBlock === null || block.text !== v2WrappedBlock;
   });
   if (content.length === last.content.length) return messages;
   return [...messages.slice(0, -1), { ...last, content }];
@@ -2177,11 +2190,12 @@ export async function applyRuntimeInjections(
   // messages keep their memory blocks byte-identical: frozen v3 card blocks
   // from prior turns AND pre-cutover v2 blocks both ride the cached prefix
   // (the old whole-layer `stripAllMemoryInjections` replace is gone). The
-  // strip is SCOPED to v2's dynamic blocks ({@link
-  // stripTailV2DynamicMemoryPrefix}): a same-turn re-entry assembly's tail
-  // may lead with this turn's just-frozen v3 card block (and the `<info>`
-  // static block) when no other prepends fired, and those must survive — the
-  // v2 prefix this strip exists to remove was already stripped on first entry.
+  // strip discriminates v2's dynamic block by IDENTITY ({@link
+  // stripTailV2DynamicMemoryPrefix}): the live graph handle holds the exact
+  // text the wiring layer prepended this turn, so a re-entry tail's
+  // just-frozen v3 card block (and the `<info>` static block) survive even
+  // though v2 and v3 blocks share identical wrapper + header bytes — the v2
+  // prefix this strip exists to remove was already stripped on first entry.
   // Keyed off the v3 block being present (not the flag alone) so a v3 failure
   // (`produce()` → null) leaves v2's block intact — fallback rather than a
   // memory-less turn. Idempotent: re-injection sites that already stripped
@@ -2193,8 +2207,11 @@ export async function applyRuntimeInjections(
   const v3ProducedBlock = afterMemory.some((b) => b.id === MEMORY_V3_BLOCK_ID);
   const memoryV3Active = suppressV2MemoryForV3 && v3ProducedBlock;
   if (memoryV3Active) {
+    const v2DynamicText =
+      getLiveGraphMemory(conversationId)?.lastInjectedBlockText ?? null;
     runMessagesForAssembly = stripTailV2DynamicMemoryPrefix(
       runMessagesForAssembly,
+      v2DynamicText === null ? null : wrapMemoryBlock(v2DynamicText),
     );
   }
 

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -54,7 +54,6 @@ import {
 } from "../memory/conversation-crud.js";
 import { ConversationGraphMemory } from "../memory/graph/conversation-graph-memory.js";
 import { unwrapMemoryBlock, wrapMemoryBlock } from "../memory/memory-marker.js";
-import { shouldExposePersonalMemory } from "../memory/v2/static-context.js";
 import { PermissionPrompter } from "../permissions/prompter.js";
 import { SecretPrompter } from "../permissions/secret-prompter.js";
 import type { UserDecision } from "../permissions/types.js";
@@ -182,7 +181,7 @@ export type {
   QueueDrainReason,
   QueuePolicy,
 } from "./conversation-queue-manager.js";
-import { resolveTrustClass, type TrustContext } from "./trust-context.js";
+import { isPersonalMemoryAllowed, type TrustContext } from "./trust-context.js";
 
 export interface ConversationConstructorOptions {
   maxTokens?: number;
@@ -808,16 +807,12 @@ export class Conversation {
       preStrippedCount = boundary === -1 ? slicedDbMessages.length : boundary;
     }
 
-    // Mirror the injection-time gate (`shouldExposePersonalMemory` in
-    // `conversation-agent-loop.ts`) so background/local conversations
-    // (sourceChannel `undefined` or `"vellum"`) can rehydrate the persisted
-    // v2 static memory block. Use `resolveTrustClass` for parity with the
-    // agent loop — it folds in the HTTP-auth-disabled dev bypass so
-    // rehydration and injection agree on the effective trust class.
-    const personalMemoryAllowed = shouldExposePersonalMemory({
-      sourceChannel: this.trustContext?.sourceChannel,
-      isTrustedActor: resolveTrustClass(this.trustContext) === "guardian",
-    });
+    // The injection-time personal-memory gate, so background/local
+    // conversations (sourceChannel `undefined` or `"vellum"`) can rehydrate
+    // the persisted v2 static memory block. The shared helper folds in the
+    // HTTP-auth-disabled dev bypass so rehydration and injection agree on the
+    // effective trust class.
+    const personalMemoryAllowed = isPersonalMemoryAllowed(this.trustContext);
     // Pruned v3 card slugs, read lazily on the first row that carries a v3
     // block (most conversations carry none, so most loads never query). The
     // prune valve marks cards pruned in the everInjected store instead of
@@ -937,7 +932,7 @@ export class Conversation {
           // The v2 static memory block (essentials/threads/recent/buffer
           // wrapped in either `<info>…</info>` or `<memory>…</memory>`)
           // carries personal user memory. Trust-gated to mirror
-          // `shouldExposePersonalMemory` at injection time — untrusted-actor
+          // `isPersonalMemoryAllowed` at injection time — untrusted-actor
           // views must not read persisted personal memory back through
           // metadata. Skipped on the tail row because the next turn
           // re-injects fresh content on full-mode turns.
@@ -1100,14 +1095,13 @@ export class Conversation {
   async ensureActorScopedHistory(): Promise<void> {
     const currentTrustClass = this.trustContext?.trustClass;
     // `loadFromDb` gates personal-memory rehydration on `sourceChannel` too
-    // (via `shouldExposePersonalMemory`), so a same-trust-class reuse from a
+    // (via `isPersonalMemoryAllowed`), so a same-trust-class reuse from a
     // different channel (e.g. internal `vellum` → remote channel) must also
     // trigger a reload. Otherwise stale personal-memory blocks can leak to
     // an untrusted remote turn, or be hidden when they should be present.
-    const currentPersonalMemoryAllowed = shouldExposePersonalMemory({
-      sourceChannel: this.trustContext?.sourceChannel,
-      isTrustedActor: resolveTrustClass(this.trustContext) === "guardian",
-    });
+    const currentPersonalMemoryAllowed = isPersonalMemoryAllowed(
+      this.trustContext,
+    );
     if (
       this.loadedHistoryTrustClass === currentTrustClass &&
       this.loadedHistoryPersonalMemoryAllowed === currentPersonalMemoryAllowed

--- a/assistant/src/daemon/trust-context.ts
+++ b/assistant/src/daemon/trust-context.ts
@@ -6,6 +6,7 @@
  */
 import type { ChannelId } from "../channels/types.js";
 import { isHttpAuthDisabled } from "../config/env.js";
+import { shouldExposePersonalMemory } from "../memory/v2/static-context.js";
 import type { TrustClass } from "../runtime/actor-trust-resolver.js";
 
 export interface TrustContext {
@@ -80,4 +81,26 @@ export function resolveTrustClass(
 ): TrustClass {
   if (isHttpAuthDisabled()) return "guardian";
   return trustContext?.trustClass ?? "unknown";
+}
+
+/**
+ * Whether personal-memory content may be surfaced for the actor described by
+ * `trustContext`: the gate admits guardian-class actors and internal/local
+ * flows (including turns with no trust context), and blocks remote untrusted
+ * actors — see {@link shouldExposePersonalMemory} for the rationale.
+ *
+ * This is THE personal-memory trust gate. Every surface that exposes private
+ * user content — the v2 dynamic/static `<memory>` layers, PKB context, NOW.md,
+ * memory-v3 cards/spotlight, and the `loadFromDb` rehydration of persisted
+ * memory blocks — must call this one helper so the exposure rule cannot drift
+ * between copies. It folds in {@link resolveTrustClass} so the dev-bypass
+ * (HTTP auth disabled → guardian) applies uniformly at every call site.
+ */
+export function isPersonalMemoryAllowed(
+  trustContext: TrustContext | undefined,
+): boolean {
+  return shouldExposePersonalMemory({
+    sourceChannel: trustContext?.sourceChannel,
+    isTrustedActor: resolveTrustClass(trustContext) === "guardian",
+  });
 }

--- a/assistant/src/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/memory/graph/conversation-graph-memory.ts
@@ -385,6 +385,22 @@ export class ConversationGraphMemory {
   }
 
   /**
+   * The unwrapped text of the dynamic memory block the last retrieval
+   * injected (the v2 router block, or the v1 context block on legacy
+   * configs), or `null` when the last retrieval injected nothing.
+   *
+   * Runtime assembly reads this as the IDENTITY of the v2 dynamic `<memory>`
+   * block when memory-v3 supersedes the v2 layer: v2's block and v3's frozen
+   * card blocks deliberately share the same wrapper AND leading instruction
+   * header bytes, so the tail strip must match the exact block this handle
+   * prepended (`prepareMemory` → `injectTextBlock`, or a convergence
+   * re-injection of the same cached text) rather than any shared prefix.
+   */
+  get lastInjectedBlockText(): string | null {
+    return this.lastInjectedBlock;
+  }
+
+  /**
    * Main entry point — called on every turn before the LLM sees the messages.
    *
    * Dispatches to the appropriate retrieval mode:

--- a/assistant/src/memory/v2/injection.ts
+++ b/assistant/src/memory/v2/injection.ts
@@ -727,8 +727,13 @@ interface RenderInjectionBlockResult {
  * if relevant. Suppressed when every section is a full-page fallback —
  * claiming "these are summaries" over already-complete content would mislead
  * the agent into wasted reads.
+ *
+ * Exported for the v2-suppression regression tests: memory-v3's
+ * `V3_CARDS_INJECTION_HEADER` is deliberately byte-identical to this header,
+ * which is exactly why the v3-era tail strip must discriminate the two
+ * `<memory>` layers by block identity rather than by this shared prefix.
  */
-const INJECTION_HEADER =
+export const INJECTION_HEADER =
   'Use `file_read("memory/concepts/path/to/file.md")` to read the full pages for any of the injected memory summaries you want more information on.';
 
 /**

--- a/assistant/src/plugins/defaults/memory-retrieval/injectors.ts
+++ b/assistant/src/plugins/defaults/memory-retrieval/injectors.ts
@@ -53,7 +53,7 @@ import { readNowScratchpad } from "../../../daemon/now-scratchpad.js";
 import { getInContextPkbPaths } from "../../../daemon/pkb-context-tracker.js";
 import { buildPkbReminder } from "../../../daemon/pkb-reminder-builder.js";
 import {
-  resolveTrustClass,
+  isPersonalMemoryAllowed,
   type TrustContext,
 } from "../../../daemon/trust-context.js";
 import { listComments } from "../../../documents/document-comments-store.js";
@@ -62,10 +62,7 @@ import { getPkbAutoInjectList } from "../../../memory/pkb/autoinject.js";
 import { readPkbContext } from "../../../memory/pkb/context.js";
 import { searchPkbFiles } from "../../../memory/pkb/pkb-search.js";
 import { getPkbRoot, PKB_WORKSPACE_SCOPE } from "../../../memory/pkb/types.js";
-import {
-  readMemoryV2StaticContent,
-  shouldExposePersonalMemory,
-} from "../../../memory/v2/static-context.js";
+import { readMemoryV2StaticContent } from "../../../memory/v2/static-context.js";
 import type { Message } from "../../../providers/types.js";
 import { getLogger } from "../../../util/logger.js";
 import { getSandboxWorkingDir } from "../../../util/platform.js";
@@ -359,19 +356,6 @@ const pkbReminderInjector: Injector = {
     };
   },
 };
-
-/**
- * Whether personal-memory content (PKB, NOW.md) may be surfaced this turn: the
- * trust gate admits the actor (guardian-class, or an internal/local flow). All
- * memory-domain injectors share this gate so they apply identical exposure
- * rules without it being threaded in from the agent loop.
- */
-function isPersonalMemoryAllowed(trust: TrustContext): boolean {
-  return shouldExposePersonalMemory({
-    sourceChannel: trust.sourceChannel,
-    isTrustedActor: resolveTrustClass(trust) === "guardian",
-  });
-}
 
 /**
  * Read the auto-injected PKB content for the turn, gated behind the

--- a/assistant/src/plugins/defaults/memory-v3-shadow/injector.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/injector.ts
@@ -41,9 +41,12 @@
  * and attaches nothing; both off → no orchestration.
  *
  * Both injectors apply the same personal-memory trust gate as v2
- * ({@link isMemoryV3InjectionAllowed}): an untrusted remote actor's turn
+ * ({@link isPersonalMemoryAllowed}): an untrusted remote actor's turn
  * produces nothing — no orchestration, no cards, no spotlight, and nothing
- * recorded or persisted.
+ * recorded or persisted. Memory pages, skill/CLI capability cards, and
+ * matched-section spotlights all surface private user content — and because
+ * v3 cards are persisted to message metadata and rehydrated forever, the gate
+ * must also keep an untrusted turn from recording or persisting anything.
  *
  * Known mirror-of-v2 limitation: cards attached by mid-turn re-entry
  * assemblies (post-compaction re-injection) live only in memory — metadata is
@@ -54,12 +57,11 @@
 
 import { isAssistantFeatureFlagEnabled } from "../../../config/assistant-feature-flags.js";
 import { getConfig } from "../../../config/loader.js";
-import { resolveTrustClass } from "../../../daemon/trust-context.js";
+import { isPersonalMemoryAllowed } from "../../../daemon/trust-context.js";
 import {
   wrapMemoryBlock,
   wrapMemorySpotlightBlock,
 } from "../../../memory/memory-marker.js";
-import { shouldExposePersonalMemory } from "../../../memory/v2/static-context.js";
 import { getLogger } from "../../../util/logger.js";
 import {
   type InjectionBlock,
@@ -220,25 +222,6 @@ export function resetMemoryV3InjectorStateForTests(): void {
   spotlightRings.clear();
 }
 
-// ─── trust gate ──────────────────────────────────────────────────────────────
-
-/**
- * Personal-memory trust gate — the same class v2 applies to its dynamic and
- * static `<memory>` layers ({@link shouldExposePersonalMemory} with the
- * guardian trust class, mirroring `isPersonalMemoryAllowed` in the
- * memory-retrieval injectors). Memory pages, skill/CLI capability cards, and
- * matched-section spotlights all surface private user content, so an
- * untrusted remote actor's turn must produce NOTHING — and, because v3 cards
- * are persisted to message metadata and rehydrated forever, must also record
- * and persist nothing.
- */
-function isMemoryV3InjectionAllowed(trust: TurnContext["trust"]): boolean {
-  return shouldExposePersonalMemory({
-    sourceChannel: trust.sourceChannel,
-    isTrustedActor: resolveTrustClass(trust) === "guardian",
-  });
-}
-
 // ─── injectors ───────────────────────────────────────────────────────────────
 
 export const memoryV3Injector: Injector = {
@@ -252,7 +235,7 @@ export const memoryV3Injector: Injector = {
     const live = isAssistantFeatureFlagEnabled(MEMORY_V3_LIVE, config);
     const shadow = isAssistantFeatureFlagEnabled(MEMORY_V3_SHADOW, config);
     if (!live && !shadow) return null;
-    if (!isMemoryV3InjectionAllowed(ctx.trust)) return null;
+    if (!isPersonalMemoryAllowed(ctx.trust)) return null;
 
     const result = await observeTurnOnce(ctx.conversationId, ctx.turnIndex);
     // Empty selection falls back to v2 (return null): v2 suppression keys off
@@ -363,7 +346,7 @@ export const memoryV3SpotlightInjector: Injector = {
     // must keep the turn untouched (no ring state either, so a later
     // live-flag flip starts from a clean window).
     if (!isAssistantFeatureFlagEnabled(MEMORY_V3_LIVE, config)) return null;
-    if (!isMemoryV3InjectionAllowed(ctx.trust)) return null;
+    if (!isPersonalMemoryAllowed(ctx.trust)) return null;
 
     try {
       const result = await observeTurnOnce(ctx.conversationId, ctx.turnIndex);

--- a/assistant/src/plugins/defaults/memory-v3-shadow/prune.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/prune.test.ts
@@ -6,15 +6,17 @@
  *     surviving its prune;
  *   - `planPrune`: no-op below the cap, oldest-first selection-recency
  *     ranking down to the target, core/hot exemption, `injected_at` fallback,
- *     zero-byte (fork-seed) rows skipped, unlocatable slugs excluded from
- *     candidacy AND the freeable measure (no loop-fire), idempotence below
- *     the cap;
+ *     zero-byte (capability / fork-seed) rows skipped, idempotence below the
+ *     cap;
  *   - `runPruneValve` + the live strip: v3-owned blocks stripped in place,
  *     v2-lookalike blocks untouched, all-pruned blocks removed, and the
  *     rehydration filter (the same `filterPrunedCardSections` over persisted
  *     metadata) converging to the same bytes;
  *   - re-injection round-trip: `recordInjected` clears `pruned_at`, after
  *     which the filter keeps the slug again;
+ *   - accounting-drift regression: a slug with recorded bytes but no
+ *     locatable persisted card section is tombstoned in ONE pass and the
+ *     valve does not loop-fire afterwards;
  *   - `schedulePruneValve` deferred execution via `flushPruneValveForTests`.
  *
  * `mock.module` is process-global and leaks into sibling files in a directory
@@ -248,18 +250,6 @@ describe("planPrune", () => {
     maxResidentBytes: 300,
     targetResidentBytes: 200,
     exemptSlugs: new Set<string>(),
-    // Every concept slug these tests record, locatable by default; the
-    // unlocatable-exclusion tests override this per-case.
-    locatableSlugs: new Set([
-      "page-a",
-      "page-b",
-      "page-c",
-      "page-d",
-      "page-old",
-      "page-new",
-      "core-page",
-      "seeded",
-    ]),
   };
 
   test("no-op below (or at) the cap", () => {
@@ -337,11 +327,12 @@ describe("planPrune", () => {
     expect(plan!.slugs).toEqual(["page-b", "page-c"]);
   });
 
-  test("zero-byte fork-seed rows are skipped (pruning them frees nothing)", () => {
+  test("zero-byte rows (capability slugs, fork seeds) are skipped (pruning them frees nothing)", () => {
     recordInjected(
       "conv-1",
       [
         { slug: "seeded", bytes: 0 },
+        { slug: "skills/meet-join", bytes: 0 },
         { slug: "page-b", bytes: 400 },
       ],
       1_000,
@@ -356,43 +347,6 @@ describe("planPrune", () => {
     expect(
       planPrune({ ...deps, exemptSlugs: new Set(["core-page"]) }, "conv-1"),
     ).toBeNull();
-  });
-
-  test("unlocatable slugs (capability rows, drift) are invisible: no loop-fire against unfreeable bytes", () => {
-    // A capability row's bytes can never be stripped from context, so they
-    // must not count toward the freeable footprint — even when they alone
-    // push the raw store total over the cap.
-    recordInjected(
-      "conv-1",
-      [
-        { slug: "skills/meet-join", bytes: 500 }, // not locatable
-        { slug: "page-a", bytes: 100 },
-      ],
-      1_000,
-    );
-    expect(planPrune(deps, "conv-1")).toBeNull();
-    expect(getPrunedSlugs("conv-1").size).toBe(0);
-  });
-
-  test("plans down to the target over freeable bytes only, never tombstoning unlocatable slugs", () => {
-    recordInjected(
-      "conv-1",
-      [
-        { slug: "skills/meet-join", bytes: 500 }, // not locatable
-        { slug: "page-a", bytes: 200 },
-        { slug: "page-b", bytes: 200 },
-      ],
-      1_000,
-    );
-    insertSelection("conv-1", 0, "page-a", 1_000);
-    insertSelection("conv-1", 0, "page-b", 2_000);
-
-    // Freeable resident = 400 > max 300; pruning page-a reaches the 200
-    // target. The 500 unfreeable bytes neither inflate the measure (which
-    // would over-tombstone real cards chasing an unreachable target) nor
-    // enter candidacy.
-    const plan = planPrune(deps, "conv-1");
-    expect(plan).toEqual({ slugs: ["page-a"], bytesFreed: 200 });
   });
 });
 
@@ -509,7 +463,7 @@ describe("stripPrunedCardsFromMessages", () => {
 });
 
 describe("collectPersistedV3Cards", () => {
-  test("collects card sections AND locatable slugs from persisted v3 metadata, skipping malformed rows", () => {
+  test("collects card sections from persisted v3 metadata, skipping malformed rows", () => {
     insertUserRowWithV3Block(
       "conv-1",
       "m1",
@@ -529,24 +483,22 @@ describe("collectPersistedV3Cards", () => {
       )
       .run();
 
-    const collected = collectPersistedV3Cards("conv-1");
-    expect(collected.sections).toEqual(
+    expect(collectPersistedV3Cards("conv-1")).toEqual(
       new Set([card("page-a"), card("page-b")]),
     );
-    expect(collected.slugs).toEqual(new Set(["page-a", "page-b"]));
-    expect(collectPersistedV3Cards("conv-other").sections.size).toBe(0);
+    expect(collectPersistedV3Cards("conv-other").size).toBe(0);
   });
 
-  test("capability chunks contribute neither a section nor a locatable slug", () => {
+  test("capability chunks contribute no section (they are non-card chunks)", () => {
     insertUserRowWithV3Block(
       "conv-1",
       "m1",
       renderCardsBlockInner([card("page-a"), CAPABILITY_CHUNK]),
     );
 
-    const collected = collectPersistedV3Cards("conv-1");
-    expect(collected.sections).toEqual(new Set([card("page-a")]));
-    expect(collected.slugs).toEqual(new Set(["page-a"]));
+    expect(collectPersistedV3Cards("conv-1")).toEqual(
+      new Set([card("page-a")]),
+    );
   });
 });
 
@@ -574,10 +526,10 @@ describe("runPruneValve", () => {
     ).toBeNull();
   });
 
-  test("unfreeable capability bytes over the raw cap: no-op, nothing tombstoned", async () => {
-    // The capability row inflates the store total past the cap, but its
-    // content has no locatable card section — the valve must not loop-fire
-    // (tombstoning real cards turn after turn against an unreachable target).
+  test("zero-byte capability rows never trigger the valve (the injector's bytes:0 contract)", async () => {
+    // Capability content can never be located/stripped by slug, so the
+    // injector records capability slugs at zero bytes — they contribute
+    // nothing to the resident measure and are never candidates.
     insertUserRowWithV3Block(
       "conv-1",
       "m1",
@@ -587,7 +539,7 @@ describe("runPruneValve", () => {
       "conv-1",
       [
         { slug: "page-a", bytes: 100 },
-        { slug: "skills/meet-join", bytes: 500 },
+        { slug: "skills/meet-join", bytes: 0 },
       ],
       1_000,
     );
@@ -596,10 +548,66 @@ describe("runPruneValve", () => {
     expect(
       await runPruneValve("conv-1", { exemptSlugs: new Set() }),
     ).toBeNull();
-    expect(
-      await runPruneValve("conv-1", { exemptSlugs: new Set() }),
-    ).toBeNull();
     expect(getPrunedSlugs("conv-1").size).toBe(0);
+  });
+
+  test("accounting drift (bytes recorded, no locatable section) is tombstoned in ONE pass — no loop-fire", async () => {
+    // Regression: a slug whose recorded bytes have no locatable persisted
+    // card section (e.g. its metadata row was lost) pushes the store total
+    // over the cap. The valve tombstones it like any candidate — the strip
+    // finds nothing to remove, but the tombstone removes its bytes from the
+    // resident accounting, so the very next pass is a no-op rather than the
+    // valve loop-firing against bytes it cannot free.
+    const inner = renderCardsBlockInner([card("page-a")]);
+    insertUserRowWithV3Block("conv-1", "m1", inner);
+    recordInjected(
+      "conv-1",
+      [
+        { slug: "page-drifted", bytes: 500 }, // no persisted section anywhere
+        { slug: "page-a", bytes: 100 },
+      ],
+      1_000,
+    );
+    insertSelection("conv-1", 0, "page-drifted", 1_000);
+    insertSelection("conv-1", 0, "page-a", 2_000);
+
+    const liveMessages: Message[] = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: wrapMemoryBlock(inner) },
+          { type: "text", text: "turn 1" },
+        ],
+      },
+    ];
+
+    // Resident 600 > max 300; tombstoning the drifted slug's 500 bytes
+    // reaches the 200 target in one pass without touching page-a.
+    pruneConfig = { maxResidentBytes: 300, targetResidentBytes: 200 };
+    const plan = await runPruneValve("conv-1", {
+      exemptSlugs: new Set(),
+      liveMessages: () => liveMessages,
+      now: 9_000,
+    });
+    expect(plan).toEqual({ slugs: ["page-drifted"], bytesFreed: 500 });
+    expect(getActiveSlugs("conv-1")).toEqual(new Set(["page-a"]));
+
+    // The live history is untouched — the drifted slug had no card section
+    // to strip, and page-a was not pruned.
+    expect(liveMessages[0]!.content).toEqual([
+      { type: "text", text: wrapMemoryBlock(inner) },
+      { type: "text", text: "turn 1" },
+    ]);
+
+    // One pass self-heals the accounting: the next run is a no-op (no
+    // loop-fire), with nothing further tombstoned.
+    expect(
+      await runPruneValve("conv-1", {
+        exemptSlugs: new Set(),
+        liveMessages: () => liveMessages,
+      }),
+    ).toBeNull();
+    expect(getPrunedSlugs("conv-1")).toEqual(new Set(["page-drifted"]));
   });
 
   test("over the cap: marks pruned, strips the live history, and converges with rehydration", async () => {

--- a/assistant/src/plugins/defaults/memory-v3-shadow/prune.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/prune.ts
@@ -43,11 +43,19 @@
  *
  * Capability note: skill / CLI-command content renders under its own
  * `# Skill:` / `# CLI command:` header — not a card section — so it can never
- * be located (and therefore never stripped) by slug. The plan only counts and
- * prunes slugs with a locatable persisted card section
- * ({@link PruneDeps.locatableSlugs}); capability content riding a card block
- * survives the prune of its neighboring cards as a non-card chunk. (The
- * injector complements this by recording capability slugs at `bytes: 0`.)
+ * be located (and therefore never stripped) by slug. The injector records
+ * capability slugs at `bytes: 0`, which keeps them out of the resident
+ * measure AND out of candidacy (zero-byte rows are skipped — pruning them
+ * frees nothing); capability content riding a card block survives the prune
+ * of its neighboring cards as a non-card chunk.
+ *
+ * Accounting-drift note: a slug whose recorded bytes have no locatable
+ * persisted card section (e.g. its metadata row was lost) can be planned and
+ * tombstoned — the strip/rehydration filter simply finds nothing to remove,
+ * its content (if any) stays in context, and its bytes leave the resident
+ * accounting with the tombstone. That self-heals in ONE pass: the next valve
+ * run measures the corrected footprint, so the valve never loop-fires against
+ * bytes it cannot free.
  */
 
 import { getConfig } from "../../../config/loader.js";
@@ -196,41 +204,27 @@ export interface PruneDeps {
   /** Core + hot lane members — the selector's stable prefix must never be
    *  pruned out from under it. */
   exemptSlugs: ReadonlySet<string>;
-  /** Slugs whose card section is locatable in the conversation's persisted
-   *  card blocks ({@link collectPersistedV3Cards}'s `slugs`). Only these
-   *  bytes are freeable: a slug with no locatable section — a capability slug
-   *  rendered under its own `# Skill:` / `# CLI command:` header, or
-   *  accounting drift — could be tombstoned, but the strip/rehydration filter
-   *  could never remove its content, so its bytes would "free" on paper while
-   *  staying in context. Such slugs are excluded from candidacy AND from the
-   *  resident measure the plan works down, so the valve never loop-fires
-   *  against a target it cannot actually reach. */
-  locatableSlugs: ReadonlySet<string>;
 }
 
 /**
- * Plan a prune for the conversation, or `null` when the freeable resident
- * footprint is within `maxResidentBytes` (or nothing is prunable).
+ * Plan a prune for the conversation, or `null` when the resident footprint is
+ * within `maxResidentBytes` (or nothing is prunable).
  *
- * The footprint and the candidates both range over the ACTIVE injected slugs
- * whose sections are locatable (`deps.locatableSlugs`) — bytes a prune cannot
- * free are invisible to the plan. Candidates are ranked by last selection
- * recency — `MAX(created_at)` per slug from `memory_v3_selections`, falling
- * back to the store's `injected_at` for slugs with no selection rows (e.g.
- * rows copied by a full fork) — taken oldest-first until the freeable
- * footprint is at `targetResidentBytes`. Core/hot lane members are exempt,
- * and zero-byte rows (truncated-fork seeds: dedup-only, no byte accounting)
- * are skipped — pruning them frees nothing while discarding inherited
- * context.
+ * The footprint and the candidates both range over the ACTIVE injected slugs.
+ * Candidates are ranked by last selection recency — `MAX(created_at)` per
+ * slug from `memory_v3_selections`, falling back to the store's `injected_at`
+ * for slugs with no selection rows (e.g. rows copied by a full fork) — taken
+ * oldest-first until the footprint is at `targetResidentBytes`. Core/hot lane
+ * members are exempt, and zero-byte rows (capability slugs, truncated-fork
+ * seeds: dedup-only, no byte accounting) are skipped — pruning them frees
+ * nothing while discarding inherited context.
  */
 export function planPrune(
   deps: PruneDeps,
   conversationId: string,
 ): PrunePlan | null {
-  const locatableEntries = getActiveEntries(conversationId).filter((entry) =>
-    deps.locatableSlugs.has(entry.slug),
-  );
-  const resident = locatableEntries.reduce((sum, e) => sum + e.bytes, 0);
+  const activeEntries = getActiveEntries(conversationId);
+  const resident = activeEntries.reduce((sum, e) => sum + e.bytes, 0);
   if (resident <= deps.maxResidentBytes) return null;
 
   const selectionRows = getSqliteFrom(getDb())
@@ -246,7 +240,7 @@ export function planPrune(
     selectionRows.map((row) => [row.slug, row.lastSelectedAt]),
   );
 
-  const candidates = locatableEntries
+  const candidates = activeEntries
     .filter((entry) => entry.bytes > 0 && !deps.exemptSlugs.has(entry.slug))
     .map((entry) => ({
       ...entry,
@@ -267,29 +261,15 @@ export function planPrune(
 
 // ─── live-history strip ──────────────────────────────────────────────────────
 
-/** The conversation's persisted v3 card record (see
- *  {@link collectPersistedV3Cards}). */
-export interface PersistedV3Cards {
-  /** Card section texts — the live strip's v3-ownership test: a live
-   *  `<memory>` block is v3-owned iff all of its card sections appear here
-   *  (see the module doc's v2-coexistence note). */
-  sections: Set<string>;
-  /** Slugs with a locatable persisted card section — `planPrune`'s freeable
-   *  set ({@link PruneDeps.locatableSlugs}). Capability slugs never appear:
-   *  their content renders under `# Skill:` / `# CLI command:` headers, which
-   *  parse as non-card chunks. */
-  slugs: Set<string>;
-}
-
 /**
- * Collect the conversation's known v3 cards from every persisted
- * `metadata.memoryV3InjectedBlock` row: the section texts (live-strip
- * ownership test) and the slugs whose sections are locatable (prune-plan
- * candidacy).
+ * Collect the conversation's known v3 card SECTION TEXTS from every persisted
+ * `metadata.memoryV3InjectedBlock` row — the live strip's v3-ownership test:
+ * a live `<memory>` block is v3-owned iff all of its card sections appear
+ * here (see the module doc's v2-coexistence note). Capability chunks never
+ * contribute: their content renders under `# Skill:` / `# CLI command:`
+ * headers, which parse as non-card chunks.
  */
-export function collectPersistedV3Cards(
-  conversationId: string,
-): PersistedV3Cards {
+export function collectPersistedV3Cards(conversationId: string): Set<string> {
   // Substring prefilter (indexable LIKE) mirrors the Slack metadata scan;
   // rows are validated by `readInjectedBlock`'s JSON parse.
   const rows = getSqliteFrom(getDb())
@@ -304,7 +284,6 @@ export function collectPersistedV3Cards(
   }>;
 
   const sections = new Set<string>();
-  const slugs = new Set<string>();
   for (const row of rows) {
     const block = readInjectedBlock(
       row.metadata,
@@ -314,10 +293,9 @@ export function collectPersistedV3Cards(
     for (const section of parseCardSections(unwrapMemoryBlock(block))
       .sections) {
       sections.add(section.text);
-      slugs.add(section.slug);
     }
   }
-  return { sections, slugs };
+  return sections;
 }
 
 /**
@@ -420,20 +398,14 @@ export async function runPruneValve(
   const pruneConfig = getConfig().memory?.v3?.prune;
   if (!pruneConfig) return null;
 
-  // Fast path: the store's TOTAL resident bytes upper-bound the freeable
-  // (locatable-only) measure `planPrune` works with, so a conversation within
-  // the cap skips the persisted-metadata scan entirely (the common case).
-  if (residentBytes(conversationId) <= pruneConfig.maxResidentBytes) {
-    return null;
-  }
-
-  const persistedCards = collectPersistedV3Cards(conversationId);
+  // Planning needs only the store (cheap); the persisted-metadata scan for
+  // the live strip's ownership test runs only once a plan exists — a
+  // conversation within the cap never pays it (the common case).
   const plan = planPrune(
     {
       maxResidentBytes: pruneConfig.maxResidentBytes,
       targetResidentBytes: pruneConfig.targetResidentBytes,
       exemptSlugs: options.exemptSlugs,
-      locatableSlugs: persistedCards.slugs,
     },
     conversationId,
   );
@@ -449,7 +421,7 @@ export async function runPruneValve(
     strippedBlocks = stripPrunedCardsFromMessages(
       liveMessages,
       getPrunedSlugs(conversationId),
-      persistedCards.sections,
+      collectPersistedV3Cards(conversationId),
     );
   }
 


### PR DESCRIPTION
## Summary
Fixes review-round-2 gaps in memory-v3-cache-aware-carry.md:
- v2-suppression strip now discriminates by block identity instead of a header prefix that is deliberately byte-identical between v2 and v3 — summary-bearing v2 blocks no longer survive the strip (which also de-risks the metadata-removal divergence)
- Personal-memory trust gate consolidated to one helper used by all four call sites
- Prune accounting simplified: bytes:0 capability recording makes the locatableSlugs re-basing redundant; drift self-heals via tombstone in one pass (regression-tested)