### PR TITLE
Add system-wide dictation overlay to the macOS Electron app

### DIFF
--- a/apps/macos/native/mac-helper/Package.swift
+++ b/apps/macos/native/mac-helper/Package.swift
@@ -16,7 +16,9 @@ let package = Package(
             dependencies: ["MacHelperCore"],
             linkerSettings: [
                 .linkedFramework("AppKit"),
+                .linkedFramework("AVFoundation"),
                 .linkedFramework("Carbon"),
+                .linkedFramework("Speech"),
             ]
         ),
         .testTarget(

--- a/apps/macos/native/mac-helper/Sources/MacHelperExecutable/DictationPartials.swift
+++ b/apps/macos/native/mac-helper/Sources/MacHelperExecutable/DictationPartials.swift
@@ -1,0 +1,89 @@
+import AVFoundation
+import Foundation
+import Speech
+
+enum DictationPartialsError: LocalizedError {
+    case recognizerUnavailable
+    case noInputDevice
+
+    var errorDescription: String? {
+        switch self {
+        case .recognizerUnavailable:
+            return "speech recognizer unavailable"
+        case .noInputDevice:
+            return "no audio input device"
+        }
+    }
+}
+
+/// Streams local `SFSpeechRecognizer` partial transcriptions while dictation
+/// records — the same role the recognizer played in the legacy Swift client.
+///
+/// This is the universal live-transcript source for the dictation overlay:
+/// it needs no network topology at all, so it works for platform-managed
+/// assistants whose runtime traffic rides the platform proxy (where the
+/// renderer has no gateway WebSocket to stream against). When daemon
+/// streaming STT *is* reachable, the renderer prefers those partials and
+/// never starts this session.
+///
+/// Capture runs in the helper process: a tap on `AVAudioEngine`'s input node
+/// feeds an `SFSpeechAudioBufferRecognitionRequest`, and every recognition
+/// callback emits the cumulative best transcription via `emit`. The mic can
+/// be captured here concurrently with the renderer's `MediaRecorder` — macOS
+/// allows multiple taps on the default input.
+final class DictationPartialsSession: @unchecked Sendable {
+    private let audioEngine = AVAudioEngine()
+    private let request = SFSpeechAudioBufferRecognitionRequest()
+    private var task: SFSpeechRecognitionTask?
+    private var stopped = false
+    private let emit: (String) -> Void
+
+    init(emit: @escaping (String) -> Void) {
+        self.emit = emit
+    }
+
+    func start() throws {
+        guard
+            let recognizer = SFSpeechRecognizer()
+                ?? SFSpeechRecognizer(locale: Locale(identifier: "en-US")),
+            recognizer.isAvailable
+        else {
+            throw DictationPartialsError.recognizerUnavailable
+        }
+
+        request.shouldReportPartialResults = true
+
+        let input = audioEngine.inputNode
+        let format = input.outputFormat(forBus: 0)
+        guard format.sampleRate > 0, format.channelCount > 0 else {
+            throw DictationPartialsError.noInputDevice
+        }
+
+        input.installTap(onBus: 0, bufferSize: 1024, format: format) { [request] buffer, _ in
+            request.append(buffer)
+        }
+
+        do {
+            audioEngine.prepare()
+            try audioEngine.start()
+        } catch {
+            input.removeTap(onBus: 0)
+            throw error
+        }
+
+        task = recognizer.recognitionTask(with: request) { [weak self] result, _ in
+            guard let self, !self.stopped, let result else { return }
+            self.emit(result.bestTranscription.formattedString)
+        }
+    }
+
+    func stop() {
+        guard !stopped else { return }
+        stopped = true
+        audioEngine.inputNode.removeTap(onBus: 0)
+        audioEngine.stop()
+        request.endAudio()
+        task?.cancel()
+        task = nil
+    }
+}

--- a/apps/macos/native/mac-helper/Sources/MacHelperExecutable/Disclaim.swift
+++ b/apps/macos/native/mac-helper/Sources/MacHelperExecutable/Disclaim.swift
@@ -1,0 +1,71 @@
+import Darwin
+import Foundation
+
+/// Re-exec the helper with TCC responsibility disclaimed.
+///
+/// macOS attributes privacy-sensitive access (microphone, speech
+/// recognition) to the *responsible process* — normally the outermost
+/// ancestor app. When the Electron shell runs from a dev terminal, that
+/// resolves to the IDE/terminal (e.g. PyCharm), whose Info.plist lacks the
+/// usage strings, and the first privacy API touch aborts the helper with a
+/// TCC SIGABRT. Disclaiming makes the helper its own responsible process,
+/// so the Info.plist embedded in its `__TEXT,__info_plist` section is the
+/// one TCC consults — in dev, packaged, and any launcher.
+///
+/// `responsibility_spawnattrs_setdisclaim` is the same private-but-stable
+/// API Chromium and VS Code use for their helpers. It's resolved via
+/// `dlsym` so a future macOS removing it degrades to a no-op instead of a
+/// link failure. `POSIX_SPAWN_SETEXEC` replaces the current image in place
+/// (same pid, stdio pipes preserved), so the supervising Electron main
+/// never notices the re-exec.
+///
+/// Returns true when the current process is already running disclaimed.
+func ensureDisclaimedResponsibility() -> Bool {
+    let marker = "VELLUM_HELPER_DISCLAIMED"
+    if ProcessInfo.processInfo.environment[marker] == "1" {
+        return true
+    }
+
+    typealias SetDisclaimFn = @convention(c) (
+        UnsafeMutablePointer<posix_spawnattr_t?>, Int32
+    ) -> Int32
+    guard
+        let sym = dlsym(
+            UnsafeMutableRawPointer(bitPattern: -2), // RTLD_DEFAULT
+            "responsibility_spawnattrs_setdisclaim"
+        )
+    else {
+        return false
+    }
+    let setDisclaim = unsafeBitCast(sym, to: SetDisclaimFn.self)
+
+    var attrs: posix_spawnattr_t?
+    guard posix_spawnattr_init(&attrs) == 0 else { return false }
+    defer { posix_spawnattr_destroy(&attrs) }
+    guard posix_spawnattr_setflags(&attrs, Int16(POSIX_SPAWN_SETEXEC)) == 0,
+          setDisclaim(&attrs, 1) == 0
+    else {
+        return false
+    }
+
+    var executable = [CChar](repeating: 0, count: 4096)
+    var size = UInt32(executable.count)
+    guard _NSGetExecutablePath(&executable, &size) == 0 else { return false }
+
+    let args = CommandLine.arguments
+    var argv: [UnsafeMutablePointer<CChar>?] = args.map { strdup($0) }
+    argv.append(nil)
+
+    var env = ProcessInfo.processInfo.environment
+    env[marker] = "1"
+    var envp: [UnsafeMutablePointer<CChar>?] = env.map { strdup("\($0.key)=\($0.value)") }
+    envp.append(nil)
+
+    var pid: pid_t = 0
+    // With SETEXEC this only returns on failure.
+    _ = posix_spawn(&pid, executable, nil, &attrs, argv, envp)
+
+    for pointer in argv { free(pointer) }
+    for pointer in envp { free(pointer) }
+    return false
+}

--- a/apps/macos/native/mac-helper/Sources/MacHelperExecutable/Info.plist
+++ b/apps/macos/native/mac-helper/Sources/MacHelperExecutable/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!--
+      Embedded into the bare executable's __TEXT,__info_plist section by
+      build-mac-helper.sh. TCC consults the requesting binary's Info.plist
+      for usage strings when the helper itself (not just the responsible
+      host app) is attributed for microphone / speech-recognition access,
+      so the dictation-partials session can prompt and run without a full
+      .app bundle.
+    -->
+    <key>CFBundleIdentifier</key>
+    <string>ai.vellum.assistant.mac-helper</string>
+    <key>CFBundleName</key>
+    <string>vellum-mac-helper</string>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>Vellum uses the microphone to transcribe dictated voice input.</string>
+    <key>NSSpeechRecognitionUsageDescription</key>
+    <string>Vellum uses speech recognition to show your words live while you dictate.</string>
+</dict>
+</plist>

--- a/apps/macos/native/mac-helper/Sources/MacHelperExecutable/main.swift
+++ b/apps/macos/native/mac-helper/Sources/MacHelperExecutable/main.swift
@@ -1,4 +1,5 @@
 import AppKit
+import AVFoundation
 import Carbon
 import Darwin
 import Foundation
@@ -55,6 +56,9 @@ private func isFnHotkeyEvent(_ event: EventRef) -> Bool {
 }
 
 final class MacHelper: @unchecked Sendable {
+    /// Whether this process re-exec'd with TCC responsibility disclaimed —
+    /// the precondition for safely prompting for privacy permissions.
+    let isDisclaimed: Bool
     private var hotkeyRef: EventHotKeyRef?
     private var handlerRefs: [EventHandlerRef] = []
     private var isFnDown = false
@@ -63,6 +67,10 @@ final class MacHelper: @unchecked Sendable {
     // Bumped on every dictation.setPartials so a pending speech-authorization
     // callback can tell the session it was starting has since been stopped.
     private var dictationGeneration = 0
+
+    init(isDisclaimed: Bool) {
+        self.isDisclaimed = isDisclaimed
+    }
 
     private lazy var router: JsonRpcRouter = {
         let router = JsonRpcRouter()
@@ -180,27 +188,68 @@ final class MacHelper: @unchecked Sendable {
             return ["enabled": false]
         }
 
-        switch SFSpeechRecognizer.authorizationStatus() {
-        case .authorized:
+        let speechStatus = SFSpeechRecognizer.authorizationStatus()
+        let micStatus = AVCaptureDevice.authorizationStatus(for: .audio)
+
+        if speechStatus == .authorized, micStatus == .authorized {
             return startDictationSession()
-        case .notDetermined:
-            // First use: prompt (attributed to the host app, which carries
-            // the usage strings) and start late once granted — the renderer
-            // simply receives partials from that point on.
-            let generation = dictationGeneration
-            SFSpeechRecognizer.requestAuthorization { [weak self] status in
+        }
+        if speechStatus == .denied || speechStatus == .restricted {
+            return ["enabled": false, "reason": "speech-recognition-denied"]
+        }
+        if micStatus == .denied || micStatus == .restricted {
+            return ["enabled": false, "reason": "microphone-denied"]
+        }
+
+        // A privacy request from a process whose TCC-responsible ancestor
+        // lacks the usage strings is a SIGABRT, not a denial. Only prompt
+        // when this process runs disclaimed (its own embedded Info.plist is
+        // the one TCC consults); otherwise degrade to no partials.
+        guard isDisclaimed else {
+            return ["enabled": false, "reason": "permissions-not-promptable"]
+        }
+
+        // First use: prompt for whichever permissions are undetermined and
+        // start late once granted — the renderer simply receives partials
+        // from that point on.
+        let generation = dictationGeneration
+        requestSpeechIfNeeded { [weak self] speechGranted in
+            guard speechGranted else { return }
+            Self.requestMicIfNeeded { micGranted in
+                guard micGranted else { return }
                 DispatchQueue.main.async {
                     guard
                         let self,
-                        status == .authorized,
                         generation == self.dictationGeneration
                     else { return }
                     _ = self.startDictationSession()
                 }
             }
-            return ["enabled": true, "authorizing": true]
-        default:
-            return ["enabled": false, "reason": "speech-recognition-denied"]
+        }
+        return ["enabled": true, "authorizing": true]
+    }
+
+    private func requestSpeechIfNeeded(
+        _ completion: @escaping @Sendable (Bool) -> Void
+    ) {
+        if SFSpeechRecognizer.authorizationStatus() == .authorized {
+            completion(true)
+            return
+        }
+        SFSpeechRecognizer.requestAuthorization { status in
+            completion(status == .authorized)
+        }
+    }
+
+    private static func requestMicIfNeeded(
+        _ completion: @escaping @Sendable (Bool) -> Void
+    ) {
+        if AVCaptureDevice.authorizationStatus(for: .audio) == .authorized {
+            completion(true)
+            return
+        }
+        AVCaptureDevice.requestAccess(for: .audio) { granted in
+            completion(granted)
         }
     }
 
@@ -378,7 +427,8 @@ private enum HelperError: LocalizedError {
     }
 }
 
-let helper = MacHelper()
+let disclaimed = ensureDisclaimedResponsibility()
+let helper = MacHelper(isDisclaimed: disclaimed)
 MainActor.assumeIsolated {
     helper.run()
 }

--- a/apps/macos/native/mac-helper/Sources/MacHelperExecutable/main.swift
+++ b/apps/macos/native/mac-helper/Sources/MacHelperExecutable/main.swift
@@ -3,6 +3,7 @@ import Carbon
 import Darwin
 import Foundation
 import MacHelperCore
+import Speech
 
 private let hotkeySignature = OSType(0x564C_464E) // "VLFN"
 private let fnHotkeyId = EventHotKeyID(signature: hotkeySignature, id: 1)
@@ -58,6 +59,10 @@ final class MacHelper: @unchecked Sendable {
     private var handlerRefs: [EventHandlerRef] = []
     private var isFnDown = false
     private let outputLock = NSLock()
+    private var dictationSession: DictationPartialsSession?
+    // Bumped on every dictation.setPartials so a pending speech-authorization
+    // callback can tell the session it was starting has since been stopped.
+    private var dictationGeneration = 0
 
     private lazy var router: JsonRpcRouter = {
         let router = JsonRpcRouter()
@@ -77,6 +82,20 @@ final class MacHelper: @unchecked Sendable {
                 )
             }
             return try self.setFnPushToTalk(enable: enable)
+        }
+        router.register("dictation.setPartials") { [weak self] params in
+            guard let self else {
+                throw JsonRpcDispatchError.internalError("Helper is shutting down")
+            }
+            guard
+                let object = params as? [String: Any],
+                let enable = object["enable"] as? Bool
+            else {
+                throw JsonRpcDispatchError.invalidParams(
+                    "dictation.setPartials requires enable"
+                )
+            }
+            return self.setDictationPartials(enable: enable)
         }
         return router
     }()
@@ -147,6 +166,59 @@ final class MacHelper: @unchecked Sendable {
 
     private func handleCommand(_ line: String) {
         writeLine(router.handle(line: line))
+    }
+
+    /// Start/stop local speech-recognition partials (`dictation.partial`
+    /// notifications). The renderer enables this for the dictation overlay
+    /// whenever daemon streaming STT is unreachable.
+    private func setDictationPartials(enable: Bool) -> [String: Any] {
+        dictationGeneration += 1
+        dictationSession?.stop()
+        dictationSession = nil
+
+        guard enable else {
+            return ["enabled": false]
+        }
+
+        switch SFSpeechRecognizer.authorizationStatus() {
+        case .authorized:
+            return startDictationSession()
+        case .notDetermined:
+            // First use: prompt (attributed to the host app, which carries
+            // the usage strings) and start late once granted — the renderer
+            // simply receives partials from that point on.
+            let generation = dictationGeneration
+            SFSpeechRecognizer.requestAuthorization { [weak self] status in
+                DispatchQueue.main.async {
+                    guard
+                        let self,
+                        status == .authorized,
+                        generation == self.dictationGeneration
+                    else { return }
+                    _ = self.startDictationSession()
+                }
+            }
+            return ["enabled": true, "authorizing": true]
+        default:
+            return ["enabled": false, "reason": "speech-recognition-denied"]
+        }
+    }
+
+    private func startDictationSession() -> [String: Any] {
+        let session = DictationPartialsSession { [weak self] text in
+            self?.writeNotification(
+                method: "dictation.partial",
+                params: ["text": text]
+            )
+        }
+        do {
+            try session.start()
+            dictationSession = session
+            return ["enabled": true]
+        } catch {
+            log("dictation partials failed to start: \(error.localizedDescription)")
+            return ["enabled": false, "reason": error.localizedDescription]
+        }
     }
 
     private func setFnPushToTalk(enable: Bool) throws -> [String: Any] {
@@ -267,6 +339,9 @@ final class MacHelper: @unchecked Sendable {
     }
 
     private func shutdown() {
+        dictationGeneration += 1
+        dictationSession?.stop()
+        dictationSession = nil
         unregisterFnHotkey()
     }
 

--- a/apps/macos/package.json
+++ b/apps/macos/package.json
@@ -17,7 +17,7 @@
     "test": "bun test",
     "test:ci": "bun scripts/run-tests.ts",
     "build:fetch-bun": "bash scripts/fetch-bun.sh",
-    "build:web": "cd ../web && bun install && bun run openapi-ts && bun run build && cd ../macos && mkdir -p resources && cp -R ../web/dist resources/web-dist",
+    "build:web": "cd ../web && bun install && bun run openapi-ts && bun run build && cd ../macos && mkdir -p resources && rm -rf resources/web-dist && cp -R ../web/dist resources/web-dist",
     "pack": "bash scripts/pack.sh",
     "pack:debug": "VELLUM_ENABLE_CHROME_DEVTOOLS=true bash scripts/pack.sh"
   },

--- a/apps/macos/scripts/build-mac-helper.sh
+++ b/apps/macos/scripts/build-mac-helper.sh
@@ -24,6 +24,17 @@ if [ -n "${ELECTRON_TARGET_ARCH:-}" ]; then
   esac
 fi
 
+# Embed Info.plist (bundle id + microphone / speech-recognition usage
+# strings) into the bare executable so TCC can attribute permission
+# prompts for the dictation-partials session without a full .app bundle.
+INFO_PLIST="$PACKAGE_DIR/Sources/MacHelperExecutable/Info.plist"
+BUILD_ARGS+=(
+  -Xlinker -sectcreate
+  -Xlinker __TEXT
+  -Xlinker __info_plist
+  -Xlinker "$INFO_PLIST"
+)
+
 mkdir -p "$OUTPUT_DIR"
 rm -f "$OUTPUT_DIR/hotkey-helper"
 xcrun swift build "${BUILD_ARGS[@]}"

--- a/apps/macos/src/main/csp.test.ts
+++ b/apps/macos/src/main/csp.test.ts
@@ -59,4 +59,12 @@ describe("CSP_POLICY", () => {
     expect(connectSrc).toContain("https://*.ingest.sentry.io");
     expect(connectSrc).not.toMatch(/\bhttps:\s/);
   });
+
+  test("connect-src allows loopback gateway WebSockets but not broad ws:", () => {
+    const connectSrc = directiveValue("connect-src")!;
+    expect(connectSrc).toContain("ws://localhost:*");
+    expect(connectSrc).toContain("ws://127.0.0.1:*");
+    expect(connectSrc).not.toMatch(/\bws:\s/);
+    expect(connectSrc).not.toContain("ws://*");
+  });
 });

--- a/apps/macos/src/main/csp.ts
+++ b/apps/macos/src/main/csp.ts
@@ -5,14 +5,18 @@ import { session } from "electron";
 // injected bridge/storage scripts are inline. The sandbox attribute is the
 // primary isolation boundary for that content.
 //
-// Self-hosted live-voice WS connects to an arbitrary ingress URL that a
-// static CSP can't allowlist — follow-up will proxy through main or
-// extend connect-src dynamically.
+// ws://localhost / ws://127.0.0.1 in connect-src: the self-hosted gateway's
+// WebSocket endpoints (/v1/stt/stream dictation partials, /v1/live-voice).
+// HTTP gateway traffic rides the app:// protocol forward in main and stays
+// within 'self', but WebSocket upgrades can't take that path — the local
+// loopback ingress is the one shape a static CSP can allowlist. A REMOTE
+// self-hosted ingress (e.g. an ngrok wss:// URL) still can't be — those
+// connections need the planned proxy-through-main follow-up.
 export const CSP_POLICY = [
   "default-src 'self'",
   "script-src 'self' 'unsafe-inline'",
   "style-src 'self' 'unsafe-inline'",
-  "connect-src 'self' blob: data: https://*.vellum.ai wss://*.vellum.ai https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://api.elevenlabs.io https://api.deepgram.com",
+  "connect-src 'self' blob: data: https://*.vellum.ai wss://*.vellum.ai https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://api.elevenlabs.io https://api.deepgram.com ws://localhost:* ws://127.0.0.1:*",
   "img-src 'self' https: data: blob:",
   "media-src 'self' blob:",
   "worker-src 'self' blob: https://cdn.jsdelivr.net",

--- a/apps/macos/src/main/dictation-overlay-window.test.ts
+++ b/apps/macos/src/main/dictation-overlay-window.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import {
+  DONE_HIDE_MS,
+  ERROR_HIDE_MS,
+  createDictationOverlayController,
+  type DictationOverlayState,
+} from "./dictation-overlay-window";
+
+type Harness = {
+  controller: ReturnType<typeof createDictationOverlayController>;
+  setFocused: (focused: boolean) => void;
+  flushTimers: () => void;
+  pendingTimerDelays: () => number[];
+  showOverlay: ReturnType<typeof mock>;
+  hideOverlay: ReturnType<typeof mock>;
+  forwarded: DictationOverlayState[];
+};
+
+const createHarness = ({ focused = false }: { focused?: boolean } = {}): Harness => {
+  let isFocused = focused;
+  const timers = new Map<number, { callback: () => void; ms: number }>();
+  let nextTimerId = 1;
+  const showOverlay = mock(() => undefined);
+  const hideOverlay = mock(() => undefined);
+  const forwarded: DictationOverlayState[] = [];
+
+  const controller = createDictationOverlayController({
+    isVellumFocused: () => isFocused,
+    showOverlay,
+    hideOverlay,
+    forwardState: (state) => {
+      forwarded.push(state);
+    },
+    setTimeout: (callback, ms) => {
+      const id = nextTimerId++;
+      timers.set(id, { callback, ms });
+      return id;
+    },
+    clearTimeout: (handle) => {
+      timers.delete(handle as number);
+    },
+  });
+
+  return {
+    controller,
+    setFocused: (value) => {
+      isFocused = value;
+    },
+    flushTimers: () => {
+      const pending = [...timers.values()];
+      timers.clear();
+      for (const { callback } of pending) callback();
+    },
+    pendingTimerDelays: () => [...timers.values()].map((t) => t.ms),
+    showOverlay,
+    hideOverlay,
+    forwarded,
+  };
+};
+
+describe("createDictationOverlayController", () => {
+  test("shows the overlay and forwards live transcription while unfocused", () => {
+    const h = createHarness();
+
+    h.controller.handleMessage({ kind: "recording", transcription: "" });
+    h.controller.handleMessage({ kind: "recording", transcription: "hello wor" });
+    h.controller.handleMessage({ kind: "processing" });
+
+    expect(h.showOverlay).toHaveBeenCalledTimes(1);
+    expect(h.forwarded).toEqual([
+      { kind: "recording", transcription: "" },
+      { kind: "recording", transcription: "hello wor" },
+      { kind: "processing" },
+    ]);
+    expect(h.hideOverlay).not.toHaveBeenCalled();
+  });
+
+  test("suppresses the whole session when a Vellum window is focused at start", () => {
+    const h = createHarness({ focused: true });
+
+    h.controller.handleMessage({ kind: "recording", transcription: "" });
+    h.controller.handleMessage({ kind: "recording", transcription: "hi" });
+    h.controller.handleMessage({ kind: "processing" });
+    h.controller.handleMessage({ kind: "done" });
+    h.controller.handleMessage({ kind: "dismiss" });
+
+    expect(h.showOverlay).not.toHaveBeenCalled();
+    expect(h.forwarded).toEqual([]);
+
+    // The suppressed session ended on `done`; a later unfocused session
+    // shows normally.
+    h.setFocused(false);
+    h.controller.handleMessage({ kind: "recording", transcription: "" });
+    expect(h.showOverlay).toHaveBeenCalledTimes(1);
+    expect(h.forwarded).toEqual([{ kind: "recording", transcription: "" }]);
+  });
+
+  test("focus is only evaluated at session start", () => {
+    const h = createHarness();
+
+    h.controller.handleMessage({ kind: "recording", transcription: "" });
+    h.setFocused(true);
+    h.controller.handleMessage({ kind: "recording", transcription: "still showing" });
+
+    expect(h.forwarded).toHaveLength(2);
+  });
+
+  test("dismiss hides immediately during recording (cancelled session)", () => {
+    const h = createHarness();
+
+    h.controller.handleMessage({ kind: "recording", transcription: "" });
+    h.controller.handleMessage({ kind: "dismiss" });
+
+    expect(h.hideOverlay).toHaveBeenCalledTimes(1);
+  });
+
+  test("dismiss without a session is a no-op", () => {
+    const h = createHarness();
+
+    h.controller.handleMessage({ kind: "dismiss" });
+
+    expect(h.hideOverlay).not.toHaveBeenCalled();
+  });
+
+  test("done lingers on its own timer and ignores the store's dismiss", () => {
+    const h = createHarness();
+
+    h.controller.handleMessage({ kind: "recording", transcription: "hi" });
+    h.controller.handleMessage({ kind: "processing" });
+    h.controller.handleMessage({ kind: "done" });
+    expect(h.pendingTimerDelays()).toEqual([DONE_HIDE_MS]);
+
+    h.controller.handleMessage({ kind: "dismiss" });
+    expect(h.hideOverlay).not.toHaveBeenCalled();
+
+    h.flushTimers();
+    expect(h.hideOverlay).toHaveBeenCalledTimes(1);
+  });
+
+  test("error lingers longer than done and ignores dismiss", () => {
+    const h = createHarness();
+
+    h.controller.handleMessage({ kind: "recording", transcription: "" });
+    h.controller.handleMessage({ kind: "error", message: "Paste blocked" });
+    expect(h.forwarded).toContainEqual({ kind: "error", message: "Paste blocked" });
+    expect(h.pendingTimerDelays()).toEqual([ERROR_HIDE_MS]);
+
+    h.controller.handleMessage({ kind: "dismiss" });
+    expect(h.hideOverlay).not.toHaveBeenCalled();
+
+    h.flushTimers();
+    expect(h.hideOverlay).toHaveBeenCalledTimes(1);
+  });
+
+  test("a new recording cancels a pending terminal hide and reuses the session", () => {
+    const h = createHarness();
+
+    h.controller.handleMessage({ kind: "recording", transcription: "" });
+    h.controller.handleMessage({ kind: "done" });
+    h.controller.handleMessage({ kind: "recording", transcription: "again" });
+
+    expect(h.pendingTimerDelays()).toEqual([]);
+    h.flushTimers();
+    expect(h.hideOverlay).not.toHaveBeenCalled();
+    // Window already visible — no second show needed.
+    expect(h.showOverlay).toHaveBeenCalledTimes(1);
+    expect(h.forwarded).toContainEqual({ kind: "recording", transcription: "again" });
+  });
+
+  test("a session can start again after a terminal hide completes", () => {
+    const h = createHarness();
+
+    h.controller.handleMessage({ kind: "recording", transcription: "" });
+    h.controller.handleMessage({ kind: "done" });
+    h.flushTimers();
+    expect(h.hideOverlay).toHaveBeenCalledTimes(1);
+
+    h.controller.handleMessage({ kind: "recording", transcription: "" });
+    expect(h.showOverlay).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/macos/src/main/dictation-overlay-window.ts
+++ b/apps/macos/src/main/dictation-overlay-window.ts
@@ -1,0 +1,270 @@
+import { BrowserWindow, app, screen } from "electron";
+import { z } from "zod";
+
+import { RENDERER_BASE_PROD, getDevRendererBase } from "./app-config";
+import { on } from "./ipc";
+import { createWindow } from "./windows";
+
+/**
+ * System-wide dictation overlay — a floating, click-through panel pinned
+ * top-center of the active display that shows the user's words live while
+ * they dictate via push-to-talk into another app. Matches the native Swift
+ * client's `DictationOverlayWindow`: a small pill that expands with partial
+ * transcription during recording, then walks the processing → done / error
+ * states before dismissing itself.
+ *
+ * The renderer that owns the recording session (the chat composer in the
+ * main window) publishes lifecycle messages over
+ * `vellum:dictationOverlay:setState`; main owns the window and forwards the
+ * state to the overlay's own renderer route (`/dictation-overlay` in
+ * `apps/web/`, same standalone pattern as Quick Input).
+ *
+ * `type: "panel"` + `focusable: false` keep the overlay from ever stealing
+ * focus from the app being dictated into, and the window is fully
+ * click-through — it's a display surface only.
+ */
+
+const OVERLAY_PATH = "/dictation-overlay";
+
+// The window is a fixed-size transparent canvas larger than the visible
+// pill: the page renders the pill top-centered and sized to content, with
+// padding so its CSS shadow has room to paint (the window itself draws no
+// shadow — `hasShadow` would outline the invisible canvas rect).
+const OVERLAY_WIDTH = 480;
+const OVERLAY_HEIGHT = 160;
+
+// The page pads the pill by 16 px (`p-4`); offset the window so the pill's
+// top edge lands 20 px below the work-area top — the Swift overlay's
+// position (NSPanel origin `visibleFrame.maxY - 60` for a 40 pt panel).
+const CANVAS_TOP_INSET = 16;
+const PILL_TOP_OFFSET = 20;
+
+/** How long the success state stays up before the overlay hides. */
+export const DONE_HIDE_MS = 800;
+
+/** How long error states stay up — mirrors the recording store's 3 s. */
+export const ERROR_HIDE_MS = 3000;
+
+/** States the overlay renderer can display. */
+export type DictationOverlayState =
+  | { kind: "recording"; transcription: string }
+  | { kind: "processing" }
+  | { kind: "done" }
+  | { kind: "error"; message: string };
+
+/** Renderer → main messages: a displayable state or an explicit dismiss. */
+export type DictationOverlayMessage =
+  | DictationOverlayState
+  | { kind: "dismiss" };
+
+const dictationOverlayMessageSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("recording"), transcription: z.string() }),
+  z.object({ kind: z.literal("processing") }),
+  z.object({ kind: z.literal("done") }),
+  z.object({ kind: z.literal("error"), message: z.string() }),
+  z.object({ kind: z.literal("dismiss") }),
+]);
+
+export type DictationOverlayDeps = {
+  isVellumFocused: () => boolean;
+  showOverlay: () => void;
+  hideOverlay: () => void;
+  forwardState: (state: DictationOverlayState) => void;
+  setTimeout: (callback: () => void, ms: number) => unknown;
+  clearTimeout: (handle: unknown) => void;
+};
+
+/**
+ * Session state machine, separated from the window plumbing so the
+ * suppression and auto-hide rules are unit-testable (same deps-injection
+ * shape as `textInsertion.ts`).
+ *
+ * A session begins on the first displayable state after idle and ends when
+ * the overlay hides. Sessions that begin while a Vellum window is focused
+ * are suppressed entirely: the composer already shows interim text inline,
+ * mirroring the Swift client suppressing the overlay for
+ * chat-composer-origin dictation.
+ */
+export const createDictationOverlayController = (
+  deps: DictationOverlayDeps,
+): { handleMessage: (message: DictationOverlayMessage) => void } => {
+  let session: "none" | "visible" | "suppressed" = "none";
+  let hideTimer: unknown = null;
+
+  const clearHideTimer = (): void => {
+    if (hideTimer !== null) {
+      deps.clearTimeout(hideTimer);
+      hideTimer = null;
+    }
+  };
+
+  const endSession = (): void => {
+    clearHideTimer();
+    session = "none";
+    deps.hideOverlay();
+  };
+
+  const handleMessage = (message: DictationOverlayMessage): void => {
+    if (message.kind === "dismiss") {
+      if (session === "none") return;
+      // Terminal states own their dismissal timing (done flashes briefly,
+      // errors linger) — the recording store's idle transition arrives
+      // earlier and must not cut them short.
+      if (hideTimer !== null) return;
+      endSession();
+      return;
+    }
+
+    if (session === "none") {
+      if (deps.isVellumFocused()) {
+        session = "suppressed";
+        return;
+      }
+      session = "visible";
+      deps.showOverlay();
+    }
+
+    if (session === "suppressed") {
+      if (message.kind === "done" || message.kind === "error") {
+        session = "none";
+      }
+      return;
+    }
+
+    clearHideTimer();
+    deps.forwardState(message);
+    if (message.kind === "done") {
+      hideTimer = deps.setTimeout(endSession, DONE_HIDE_MS);
+    } else if (message.kind === "error") {
+      hideTimer = deps.setTimeout(endSession, ERROR_HIDE_MS);
+    }
+  };
+
+  return { handleMessage };
+};
+
+// ---------------------------------------------------------------------------
+// Window plumbing
+// ---------------------------------------------------------------------------
+
+const overlayUrl = (): string => {
+  const base = app.isPackaged ? RENDERER_BASE_PROD : getDevRendererBase();
+  return `${base}${OVERLAY_PATH}`;
+};
+
+let overlayWindow: BrowserWindow | null = null;
+
+// Latest state forwarded to the overlay renderer, replayed on
+// `did-finish-load` so the session that triggers the window's creation
+// isn't lost to the route-load race.
+let latestState: DictationOverlayState | null = null;
+
+const sendState = (state: DictationOverlayState): void => {
+  latestState = state;
+  if (overlayWindow && !overlayWindow.isDestroyed()) {
+    overlayWindow.webContents.send("vellum:dictationOverlay:state", state);
+  }
+};
+
+const positionOverlay = (win: BrowserWindow): void => {
+  const cursor = screen.getCursorScreenPoint();
+  const display = screen.getDisplayNearestPoint(cursor);
+  const { x, y, width } = display.workArea;
+  win.setPosition(
+    Math.round(x + (width - OVERLAY_WIDTH) / 2),
+    Math.round(y + PILL_TOP_OFFSET - CANVAS_TOP_INSET),
+  );
+};
+
+const ensureOverlayWindow = (): BrowserWindow => {
+  if (overlayWindow && !overlayWindow.isDestroyed()) {
+    return overlayWindow;
+  }
+
+  const win = createWindow({
+    browserWindow: {
+      type: "panel",
+      width: OVERLAY_WIDTH,
+      height: OVERLAY_HEIGHT,
+      frame: false,
+      transparent: true,
+      resizable: false,
+      movable: false,
+      minimizable: false,
+      maximizable: false,
+      fullscreenable: false,
+      alwaysOnTop: true,
+      skipTaskbar: true,
+      focusable: false,
+      show: false,
+      hasShadow: false,
+    },
+    navigation: "deny-all",
+  });
+
+  // Display surface only — clicks fall through to whatever is underneath,
+  // so the transparent canvas margin never intercepts input.
+  win.setIgnoreMouseEvents(true);
+  // Dictation targets whatever app the user is in, including fullscreen
+  // Spaces — let the overlay appear there too.
+  win.setVisibleOnAllWorkspaces(true, {
+    visibleOnFullScreen: true,
+    skipTransformProcessType: true,
+  });
+
+  win.webContents.on("did-finish-load", () => {
+    if (latestState) {
+      win.webContents.send("vellum:dictationOverlay:state", latestState);
+    }
+  });
+
+  win.on("closed", () => {
+    overlayWindow = null;
+  });
+
+  void win.loadURL(overlayUrl());
+  overlayWindow = win;
+  return win;
+};
+
+const showOverlay = (): void => {
+  const win = ensureOverlayWindow();
+  positionOverlay(win);
+  // Never `show()` — that would activate the app and steal focus from the
+  // app being dictated into.
+  win.showInactive();
+};
+
+const hideOverlay = (): void => {
+  latestState = null;
+  if (overlayWindow && !overlayWindow.isDestroyed()) {
+    overlayWindow.hide();
+  }
+};
+
+let installed = false;
+
+export const installDictationOverlay = (): void => {
+  if (installed) return;
+  installed = true;
+
+  const controller = createDictationOverlayController({
+    // Same focus test `textInsertion.ts` uses to decide composer-vs-front-app
+    // insertion, so the overlay suppression agrees with where the text lands.
+    isVellumFocused: () => BrowserWindow.getFocusedWindow() !== null,
+    showOverlay,
+    hideOverlay,
+    forwardState: sendState,
+    setTimeout,
+    clearTimeout: (handle) =>
+      clearTimeout(handle as ReturnType<typeof setTimeout>),
+  });
+
+  on(
+    "vellum:dictationOverlay:setState",
+    z.tuple([dictationOverlayMessageSchema]),
+    ([message]) => {
+      controller.handleMessage(message);
+    },
+  );
+};

--- a/apps/macos/src/main/dictation-overlay-window.ts
+++ b/apps/macos/src/main/dictation-overlay-window.ts
@@ -2,7 +2,7 @@ import { BrowserWindow, app, screen } from "electron";
 import { z } from "zod";
 
 import { RENDERER_BASE_PROD, getDevRendererBase } from "./app-config";
-import { on } from "./ipc";
+import { handle, on } from "./ipc";
 import { createWindow } from "./windows";
 
 /**
@@ -154,9 +154,10 @@ const overlayUrl = (): string => {
 
 let overlayWindow: BrowserWindow | null = null;
 
-// Latest state forwarded to the overlay renderer, replayed on
-// `did-finish-load` so the session that triggers the window's creation
-// isn't lost to the route-load race.
+// Latest state forwarded to the overlay renderer. The overlay route loads
+// lazily after the window is created, so pushes sent before its `onState`
+// subscription registers are dropped by Electron — the route pulls this via
+// `vellum:dictationOverlay:getState` once subscribed to catch up.
 let latestState: DictationOverlayState | null = null;
 
 const sendState = (state: DictationOverlayState): void => {
@@ -212,12 +213,6 @@ const ensureOverlayWindow = (): BrowserWindow => {
     skipTransformProcessType: true,
   });
 
-  win.webContents.on("did-finish-load", () => {
-    if (latestState) {
-      win.webContents.send("vellum:dictationOverlay:state", latestState);
-    }
-  });
-
   win.on("closed", () => {
     overlayWindow = null;
   });
@@ -267,4 +262,6 @@ export const installDictationOverlay = (): void => {
       controller.handleMessage(message);
     },
   );
+
+  handle("vellum:dictationOverlay:getState", z.tuple([]), () => latestState);
 };

--- a/apps/macos/src/main/hotkey-helper.ts
+++ b/apps/macos/src/main/hotkey-helper.ts
@@ -25,6 +25,14 @@ export type HelperRestartResult =
   | { ok: true; state: MacHelperState }
   | { ok: false; reason: string; state: MacHelperState };
 
+export type DictationPartialsResult =
+  | { ok: true; enabled: boolean }
+  | { ok: false; reason: string };
+
+export interface DictationPartialEvent {
+  text: string;
+}
+
 const HOTKEY_EVENT_SCHEMA = z.object({
   kind: z.literal("fnPushToTalk"),
   state: z.enum(["down", "up"]),
@@ -32,6 +40,15 @@ const HOTKEY_EVENT_SCHEMA = z.object({
 
 const HOTKEY_RESULT_SCHEMA = z.object({
   enabled: z.boolean(),
+});
+
+const DICTATION_PARTIAL_SCHEMA = z.object({
+  text: z.string(),
+});
+
+const DICTATION_RESULT_SCHEMA = z.object({
+  enabled: z.boolean(),
+  reason: z.string().optional(),
 });
 
 let platformForTesting: NodeJS.Platform | null = null;
@@ -97,6 +114,41 @@ interface HotkeyOwner {
   webContents: WebContents;
   cleanup: () => void;
 }
+
+// The renderer that most recently enabled dictation partials — the recording
+// session's host. Partial notifications route only there.
+let dictationPartialsOwner: WebContents | null = null;
+
+const setDictationPartials = async (
+  webContents: WebContents,
+  enable: boolean,
+): Promise<DictationPartialsResult> => {
+  try {
+    const result = await client.call("dictation.setPartials", { enable });
+    const parsed = DICTATION_RESULT_SCHEMA.safeParse(result);
+    if (!parsed.success) {
+      return {
+        ok: false,
+        reason: "mac helper returned invalid dictation result",
+      };
+    }
+    if (enable && !parsed.data.enabled) {
+      return { ok: false, reason: parsed.data.reason ?? "unavailable" };
+    }
+    dictationPartialsOwner = enable ? webContents : null;
+    return { ok: true, enabled: parsed.data.enabled };
+  } catch (err) {
+    return {
+      ok: false,
+      reason: err instanceof Error ? err.message : String(err),
+    };
+  }
+};
+
+const sendDictationPartialToOwner = (event: DictationPartialEvent): void => {
+  if (!dictationPartialsOwner || dictationPartialsOwner.isDestroyed()) return;
+  dictationPartialsOwner.send("vellum:helper:dictation:partial", event);
+};
 
 const hotkeyOwners = new Map<number, HotkeyOwner>();
 let activeHotkeyOwnerId: number | null = null;
@@ -285,6 +337,9 @@ const handleHelperState = (state: MacHelperState): void => {
     restoreHotkeyAfterRestart = true;
   }
   helperRegistered = false;
+  // The partials session lived in the dead helper process; the renderer's
+  // session simply continues without live text.
+  dictationPartialsOwner = null;
   sendSyntheticHotkeyUpIfNeeded();
 };
 
@@ -304,6 +359,7 @@ const restartHelper = (): HelperRestartResult => {
 let installed = false;
 let unsubscribeHotkeyEvents: (() => void) | null = null;
 let unsubscribeHelperState: (() => void) | null = null;
+let unsubscribeDictationPartials: (() => void) | null = null;
 
 export const installHotkeyHelper = (): void => {
   if (installed) return;
@@ -314,6 +370,13 @@ export const installHotkeyHelper = (): void => {
     HOTKEY_EVENT_SCHEMA,
     (event) => {
       sendHotkeyEventToOwner(event);
+    },
+  );
+  unsubscribeDictationPartials = client.onNotification(
+    "dictation.partial",
+    DICTATION_PARTIAL_SCHEMA,
+    (event) => {
+      sendDictationPartialToOwner(event);
     },
   );
   unsubscribeHelperState = client.onState(handleHelperState);
@@ -329,6 +392,12 @@ export const installHotkeyHelper = (): void => {
       enable
         ? enableFnPushToTalkForOwner(event.sender)
         : disableFnPushToTalkForOwner(event.sender),
+  );
+
+  handle(
+    "vellum:helper:dictation:setPartials",
+    z.tuple([z.boolean()]),
+    ([enable], event) => setDictationPartials(event.sender, enable),
   );
 
   app.on("before-quit", () => {
@@ -352,6 +421,9 @@ export const __resetForTesting = (): void => {
   unsubscribeHotkeyEvents = null;
   unsubscribeHelperState?.();
   unsubscribeHelperState = null;
+  unsubscribeDictationPartials?.();
+  unsubscribeDictationPartials = null;
+  dictationPartialsOwner = null;
   for (const owner of hotkeyOwners.values()) owner.cleanup();
   hotkeyOwners.clear();
   activeHotkeyOwnerId = null;

--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -30,6 +30,7 @@ import {
 import { handleBundleFile, installBundleFlow } from "./bundle-flow";
 import { handleFileOpen, installFileOpen, onFileOpen } from "./file-open";
 import { installAvatarIpc } from "./avatar";
+import { installDictationOverlay } from "./dictation-overlay-window";
 import { installDock } from "./dock";
 import { installEscapeMonitor } from "./escape-monitor";
 import { installFeatureFlagsIpc } from "./feature-flags";
@@ -327,6 +328,7 @@ app
     installTextInsertionIpc();
     installApplicationMenu();
     installQuickInput();
+    installDictationOverlay();
     installPopoutWindows();
     installGlobalShortcuts();
     // Register the avatar channel before the Dock and Tray install so their

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -577,6 +577,13 @@ export interface VellumBridge {
      * function.
      */
     onState(callback: (state: DictationOverlayState) => void): () => void;
+    /**
+     * Read the latest overlay state (or null when no session is active).
+     * The overlay route loads lazily, so states pushed before its `onState`
+     * subscription registers are dropped — it pulls this once subscribed
+     * to catch up.
+     */
+    getState(): Promise<DictationOverlayState | null>;
   };
   popout: {
     /**
@@ -915,6 +922,10 @@ const bridge: VellumBridge = {
         ipcRenderer.off("vellum:dictationOverlay:state", handler);
       };
     },
+    getState: (): Promise<DictationOverlayState | null> =>
+      ipcRenderer.invoke(
+        "vellum:dictationOverlay:getState",
+      ) as Promise<DictationOverlayState | null>,
   },
   popout: {
     open: (conversationId: string): Promise<void> =>

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -108,6 +108,20 @@ export type FnPushToTalkResult =
   | { ok: true; enabled: boolean }
   | { ok: false; reason: string };
 
+// States the system-wide dictation overlay can display, plus the explicit
+// dismiss message. Mirrors `DictationOverlayState` / `DictationOverlayMessage`
+// in `apps/macos/src/main/dictation-overlay-window.ts` (kept inline for the
+// same three-TS-project reason as `VellumCommand`).
+export type DictationOverlayState =
+  | { kind: "recording"; transcription: string }
+  | { kind: "processing" }
+  | { kind: "done" }
+  | { kind: "error"; message: string };
+
+export type DictationOverlayMessage =
+  | DictationOverlayState
+  | { kind: "dismiss" };
+
 export type HelperState =
   | { status: "idle" }
   | { status: "starting"; attempt: number }
@@ -549,6 +563,21 @@ export interface VellumBridge {
     /** Dismiss the quick input panel without submitting. */
     dismiss(): Promise<void>;
   };
+  dictationOverlay: {
+    /**
+     * Publish the current dictation lifecycle state so main can drive the
+     * system-wide overlay panel (live transcription pinned top-center of
+     * the active display). Fire-and-forget — interim transcription updates
+     * are high-frequency and need no acknowledgement.
+     */
+    setState(state: DictationOverlayMessage): void;
+    /**
+     * Subscribe to overlay states. Only the dictation overlay window's own
+     * renderer (`/dictation-overlay`) consumes this. Returns an unsubscribe
+     * function.
+     */
+    onState(callback: (state: DictationOverlayState) => void): () => void;
+  };
   popout: {
     /**
      * Open (or focus) a pop-out window for a conversation. Main creates an
@@ -869,6 +898,23 @@ const bridge: VellumBridge = {
       ipcRenderer.invoke("vellum:quickInput:submit", message) as Promise<void>,
     dismiss: (): Promise<void> =>
       ipcRenderer.invoke("vellum:quickInput:dismiss") as Promise<void>,
+  },
+  dictationOverlay: {
+    setState: (state: DictationOverlayMessage): void => {
+      ipcRenderer.send("vellum:dictationOverlay:setState", state);
+    },
+    onState: (callback) => {
+      const handler = (
+        _event: IpcRendererEvent,
+        payload: DictationOverlayState,
+      ) => {
+        callback(payload);
+      };
+      ipcRenderer.on("vellum:dictationOverlay:state", handler);
+      return () => {
+        ipcRenderer.off("vellum:dictationOverlay:state", handler);
+      };
+    },
   },
   popout: {
     open: (conversationId: string): Promise<void> =>

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -108,6 +108,17 @@ export type FnPushToTalkResult =
   | { ok: true; enabled: boolean }
   | { ok: false; reason: string };
 
+// Mirrors `DictationPartialsResult` / `DictationPartialEvent` in
+// `apps/macos/src/main/hotkey-helper.ts` (same three-TS-project reason as
+// `VellumCommand`).
+export type DictationPartialsResult =
+  | { ok: true; enabled: boolean }
+  | { ok: false; reason: string };
+
+export interface DictationPartialEvent {
+  text: string;
+}
+
 // States the system-wide dictation overlay can display, plus the explicit
 // dismiss message. Mirrors `DictationOverlayState` / `DictationOverlayMessage`
 // in `apps/macos/src/main/dictation-overlay-window.ts` (kept inline for the
@@ -330,6 +341,20 @@ export interface VellumBridge {
        * Returns an unsubscribe function.
        */
       onEvent(callback: (event: HotkeyEvent) => void): () => void;
+    };
+    dictation: {
+      /**
+       * Start/stop local speech-recognition partials in the helper. While
+       * enabled, the helper emits `dictation.partial` notifications with the
+       * cumulative transcription — the dictation overlay's live-text source
+       * when daemon streaming STT is unreachable.
+       */
+      setPartials(enable: boolean): Promise<DictationPartialsResult>;
+      /**
+       * Subscribe to partial transcriptions for the enabling renderer.
+       * Returns an unsubscribe function.
+       */
+      onPartial(callback: (event: DictationPartialEvent) => void): () => void;
     };
   };
   commands: {
@@ -702,6 +727,25 @@ const bridge: VellumBridge = {
         ipcRenderer.on("vellum:helper:hotkey:event", handler);
         return () => {
           ipcRenderer.off("vellum:helper:hotkey:event", handler);
+        };
+      },
+    },
+    dictation: {
+      setPartials: (enable: boolean): Promise<DictationPartialsResult> =>
+        ipcRenderer.invoke(
+          "vellum:helper:dictation:setPartials",
+          enable,
+        ) as Promise<DictationPartialsResult>,
+      onPartial: (callback) => {
+        const handler = (
+          _event: IpcRendererEvent,
+          payload: DictationPartialEvent,
+        ) => {
+          callback(payload);
+        };
+        ipcRenderer.on("vellum:helper:dictation:partial", handler);
+        return () => {
+          ipcRenderer.off("vellum:helper:dictation:partial", handler);
         };
       },
     },

--- a/apps/web/src/components/dictation-overlay-page.tsx
+++ b/apps/web/src/components/dictation-overlay-page.tsx
@@ -1,0 +1,97 @@
+import { Check, Loader2, TriangleAlert } from "lucide-react";
+import { useEffect, useState } from "react";
+
+import { subscribeToDictationOverlayState } from "@/runtime/dictation-overlay";
+import type { DictationOverlayState } from "@/runtime/is-electron";
+
+/**
+ * Live dictation pill rendered inside the Electron dictation overlay
+ * BrowserWindow — a click-through, non-activating panel pinned top-center
+ * of the active display while the user dictates via push-to-talk into
+ * another app. The Electron port of the native Swift client's
+ * `DictationOverlayWindow`: a status row (state icon + label) over an
+ * optional two-line live transcription that expands the pill as words
+ * stream in.
+ *
+ * Standalone (no auth, no RootLayout) like the Quick Input page; the
+ * window canvas is transparent, so the page paints only the pill. The
+ * main process owns visibility — this page just renders the latest state
+ * it receives. Off-Electron the subscription no-ops and the page stays
+ * blank.
+ */
+export function DictationOverlayPage() {
+  const [state, setState] = useState<DictationOverlayState | null>(null);
+
+  useEffect(() => subscribeToDictationOverlayState(setState), []);
+
+  if (!state) {
+    return null;
+  }
+
+  const transcription =
+    state.kind === "recording" ? state.transcription.trim() : "";
+
+  return (
+    <div className="flex h-screen w-screen items-start justify-center bg-transparent p-4">
+      <div className="flex min-w-40 max-w-full flex-col gap-1 rounded-xl border border-[var(--border-default)] bg-[var(--surface-base)] px-4 py-2.5 shadow-lg">
+        <div className="flex items-center gap-2">
+          <StateIcon state={state} />
+          <span className="truncate text-[11px] font-medium text-[var(--content-secondary)]">
+            {stateLabel(state)}
+          </span>
+        </div>
+        {transcription && (
+          <p className="line-clamp-2 break-words text-[10px] leading-snug text-[var(--content-tertiary)]">
+            {transcription}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function stateLabel(state: DictationOverlayState): string {
+  switch (state.kind) {
+    case "recording":
+      return "Recording…";
+    case "processing":
+      return "Processing…";
+    case "done":
+      return "Done";
+    case "error":
+      return state.message;
+  }
+}
+
+function StateIcon({ state }: { state: DictationOverlayState }) {
+  switch (state.kind) {
+    case "recording":
+      return (
+        <span
+          className="size-2 shrink-0 rounded-full bg-[var(--system-negative-strong)]"
+          aria-hidden
+        />
+      );
+    case "processing":
+      return (
+        <Loader2
+          className="size-4 shrink-0 animate-spin text-[var(--content-secondary)]"
+          aria-hidden
+        />
+      );
+    case "done":
+      return (
+        <Check
+          className="size-4 shrink-0 text-[var(--system-positive-strong)]"
+          aria-hidden
+        />
+      );
+    case "error":
+      return (
+        <TriangleAlert
+          className="size-4 shrink-0 text-[var(--system-negative-strong)]"
+          aria-hidden
+        />
+      );
+  }
+}

--- a/apps/web/src/components/dictation-overlay-page.tsx
+++ b/apps/web/src/components/dictation-overlay-page.tsx
@@ -56,9 +56,14 @@ export function DictationOverlayPage() {
           </span>
         </div>
         {transcription && (
-          <p className="line-clamp-2 break-words text-[10px] leading-snug text-[var(--content-tertiary)]">
-            {transcription}
-          </p>
+          // Bottom-anchored two-line window: the transcript grows as words
+          // stream in and the newest words are the ones worth showing — a
+          // line-clamp would freeze on the first two lines instead.
+          <div className="flex max-h-7 flex-col justify-end overflow-hidden">
+            <p className="break-words text-[10px] leading-snug text-[var(--content-tertiary)]">
+              {transcription}
+            </p>
+          </div>
         )}
       </div>
     </div>

--- a/apps/web/src/components/dictation-overlay-page.tsx
+++ b/apps/web/src/components/dictation-overlay-page.tsx
@@ -1,7 +1,10 @@
 import { Check, Loader2, TriangleAlert } from "lucide-react";
 import { useEffect, useState } from "react";
 
-import { subscribeToDictationOverlayState } from "@/runtime/dictation-overlay";
+import {
+  getDictationOverlayState,
+  subscribeToDictationOverlayState,
+} from "@/runtime/dictation-overlay";
 import type { DictationOverlayState } from "@/runtime/is-electron";
 
 /**
@@ -22,7 +25,19 @@ import type { DictationOverlayState } from "@/runtime/is-electron";
 export function DictationOverlayPage() {
   const [state, setState] = useState<DictationOverlayState | null>(null);
 
-  useEffect(() => subscribeToDictationOverlayState(setState), []);
+  useEffect(() => {
+    const unsubscribe = subscribeToDictationOverlayState(setState);
+    // This route chunk loads lazily after the window is created, so the
+    // session's first states can be pushed before the subscription above
+    // registers and be dropped. Pull the latest to catch up — pushed states
+    // are newer, so never overwrite one.
+    void getDictationOverlayState().then((initial) => {
+      if (initial) {
+        setState((current) => current ?? initial);
+      }
+    });
+    return unsubscribe;
+  }, []);
 
   if (!state) {
     return null;

--- a/apps/web/src/domains/chat/components/voice-input-button.tsx
+++ b/apps/web/src/domains/chat/components/voice-input-button.tsx
@@ -13,6 +13,7 @@ import {
   startDictationStream,
   type DictationStreamHandle,
 } from "@/domains/chat/voice/dictation-stream";
+import { startNativeDictationPartials } from "@/runtime/native-dictation-partials";
 import {
     postSttTranscribe,
     type SttFailureReason,
@@ -259,6 +260,14 @@ export const VoiceInputButton = forwardRef<
   // the authority for the final text.
   const dictationStreamRef = useRef<DictationStreamHandle | null>(null);
 
+  // Native helper speech-recognition partials — the fallback live-text
+  // source when the daemon stream can't start at all (no self-hosted
+  // gateway ingress; platform-managed assistants ride the platform proxy,
+  // which has no WebSocket path). Same role the native recognizer played
+  // in the legacy Swift client.
+  const nativePartialsStopRef = useRef<(() => void) | null>(null);
+  const nativePartialsTextRef = useRef("");
+
   const onStreamReadyRef = useRef(onStreamReady);
   onStreamReadyRef.current = onStreamReady;
 
@@ -302,10 +311,17 @@ export const VoiceInputButton = forwardRef<
     dictationStreamRef.current = null;
   }, []);
 
+  const stopNativePartials = useCallback(() => {
+    nativePartialsStopRef.current?.();
+    nativePartialsStopRef.current = null;
+    nativePartialsTextRef.current = "";
+  }, []);
+
   const stopRecording = useCallback(() => {
     cancelledStartRef.current = true;
     stopSpeechRecognition();
     stopDictationStream();
+    stopNativePartials();
     const recorder = mediaRecorderRef.current;
     if (!recorder) return;
     if (recorder.state !== "inactive") {
@@ -316,7 +332,12 @@ export const VoiceInputButton = forwardRef<
       }
     }
     vsStopRecording();
-  }, [vsStopRecording, stopSpeechRecognition, stopDictationStream]);
+  }, [
+    vsStopRecording,
+    stopSpeechRecognition,
+    stopDictationStream,
+    stopNativePartials,
+  ]);
 
   useEffect(() => {
     if (disabled && recording) {
@@ -329,6 +350,7 @@ export const VoiceInputButton = forwardRef<
       transcribeAbortRef.current?.abort();
       stopSpeechRecognition();
       stopDictationStream();
+      stopNativePartials();
       const recorder = mediaRecorderRef.current;
       if (recorder && recorder.state !== "inactive") {
         try {
@@ -340,7 +362,12 @@ export const VoiceInputButton = forwardRef<
       releaseStream();
       useVoiceRecordingStore.getState().reset();
     };
-  }, [releaseStream, stopSpeechRecognition, stopDictationStream]);
+  }, [
+    releaseStream,
+    stopSpeechRecognition,
+    stopDictationStream,
+    stopNativePartials,
+  ]);
 
   const startRecording = useCallback(async () => {
     if (mediaRecorderRef.current) return;
@@ -393,10 +420,14 @@ export const VoiceInputButton = forwardRef<
             }
           }
           speechAccumulatorRef.current = accumulated + interim;
-          // Streaming STT partials take priority over Web Speech partials
-          // to avoid competing UI updates (the legacy client's rule). The
-          // accumulator above still builds — it stays the batch fallback.
-          if (!dictationStreamRef.current?.isLive()) {
+          // Streaming STT and native helper partials both take priority
+          // over Web Speech partials to avoid competing UI updates (the
+          // legacy client's rule). The accumulator above still builds — it
+          // stays the batch fallback.
+          if (
+            !dictationStreamRef.current?.isLive() &&
+            !nativePartialsTextRef.current
+          ) {
             publishInterim(interim);
           }
         };
@@ -468,6 +499,7 @@ export const VoiceInputButton = forwardRef<
       releaseStream();
       stopSpeechRecognition();
       stopDictationStream();
+      stopNativePartials();
       publishInterim("");
 
       if (erroredRef.current) {
@@ -551,6 +583,7 @@ export const VoiceInputButton = forwardRef<
       releaseStream();
       stopSpeechRecognition();
       stopDictationStream();
+      stopNativePartials();
       onError?.("audio-capture");
       vsFail("audio-capture");
     };
@@ -579,12 +612,32 @@ export const VoiceInputButton = forwardRef<
     }
 
     // Recording is live — open the daemon streaming session for interim
-    // transcripts. Null / later failure means no live partials, nothing
-    // more: the recorder above is untouched.
+    // transcripts. Null / later failure means no live partials from that
+    // source; the recorder above is untouched either way.
     stopDictationStream();
     dictationStreamRef.current = startDictationStream({
       onPartial: publishInterim,
     });
+
+    // No stream possible (no self-hosted gateway ingress) — fall back to
+    // the mac helper's local speech recognizer for live text.
+    stopNativePartials();
+    if (!dictationStreamRef.current) {
+      void startNativeDictationPartials((text) => {
+        nativePartialsTextRef.current = text;
+        if (!dictationStreamRef.current?.isLive()) {
+          publishInterim(text);
+        }
+      }).then((stop) => {
+        if (!stop) return;
+        // The session may have ended while the helper call was in flight.
+        if (!mediaRecorderRef.current) {
+          stop();
+          return;
+        }
+        nativePartialsStopRef.current = stop;
+      });
+    }
   }, [
     assistantId,
     onBeforeStart,
@@ -594,6 +647,7 @@ export const VoiceInputButton = forwardRef<
     releaseStream,
     stopSpeechRecognition,
     stopDictationStream,
+    stopNativePartials,
     vsStartRecording,
     vsStopRecording,
     vsFail,

--- a/apps/web/src/domains/chat/components/voice-input-button.tsx
+++ b/apps/web/src/domains/chat/components/voice-input-button.tsx
@@ -10,6 +10,10 @@ import {
 } from "react";
 
 import {
+  startDictationStream,
+  type DictationStreamHandle,
+} from "@/domains/chat/voice/dictation-stream";
+import {
     postSttTranscribe,
     type SttFailureReason,
 } from "@/domains/chat/voice/stt-api";
@@ -247,6 +251,14 @@ export const VoiceInputButton = forwardRef<
   const speechRecRef = useRef<SpeechRecognitionInstance | null>(null);
   const speechAccumulatorRef = useRef("");
 
+  // Daemon streaming STT session — the primary source of live interim
+  // transcripts. Web Speech is non-functional inside the Electron shell
+  // (Chromium ships the API without the speech service behind it), so
+  // without this, dictation there shows no words as they're spoken.
+  // Interim display only; the batch transcribe-on-stop flow below stays
+  // the authority for the final text.
+  const dictationStreamRef = useRef<DictationStreamHandle | null>(null);
+
   const onStreamReadyRef = useRef(onStreamReady);
   onStreamReadyRef.current = onStreamReady;
 
@@ -275,9 +287,15 @@ export const VoiceInputButton = forwardRef<
     }
   }, []);
 
+  const stopDictationStream = useCallback(() => {
+    dictationStreamRef.current?.stop();
+    dictationStreamRef.current = null;
+  }, []);
+
   const stopRecording = useCallback(() => {
     cancelledStartRef.current = true;
     stopSpeechRecognition();
+    stopDictationStream();
     const recorder = mediaRecorderRef.current;
     if (!recorder) return;
     if (recorder.state !== "inactive") {
@@ -288,7 +306,7 @@ export const VoiceInputButton = forwardRef<
       }
     }
     vsStopRecording();
-  }, [vsStopRecording, stopSpeechRecognition]);
+  }, [vsStopRecording, stopSpeechRecognition, stopDictationStream]);
 
   useEffect(() => {
     if (disabled && recording) {
@@ -300,6 +318,7 @@ export const VoiceInputButton = forwardRef<
     return () => {
       transcribeAbortRef.current?.abort();
       stopSpeechRecognition();
+      stopDictationStream();
       const recorder = mediaRecorderRef.current;
       if (recorder && recorder.state !== "inactive") {
         try {
@@ -311,7 +330,7 @@ export const VoiceInputButton = forwardRef<
       releaseStream();
       useVoiceRecordingStore.getState().reset();
     };
-  }, [releaseStream, stopSpeechRecognition]);
+  }, [releaseStream, stopSpeechRecognition, stopDictationStream]);
 
   const startRecording = useCallback(async () => {
     if (mediaRecorderRef.current) return;
@@ -364,7 +383,12 @@ export const VoiceInputButton = forwardRef<
             }
           }
           speechAccumulatorRef.current = accumulated + interim;
-          onInterimTranscriptRef.current?.(interim);
+          // Streaming STT partials take priority over Web Speech partials
+          // to avoid competing UI updates (the legacy client's rule). The
+          // accumulator above still builds — it stays the batch fallback.
+          if (!dictationStreamRef.current?.isLive()) {
+            onInterimTranscriptRef.current?.(interim);
+          }
         };
 
         speechRec.onerror = () => {
@@ -433,6 +457,7 @@ export const VoiceInputButton = forwardRef<
       }
       releaseStream();
       stopSpeechRecognition();
+      stopDictationStream();
       onInterimTranscriptRef.current?.("");
 
       if (erroredRef.current) {
@@ -515,6 +540,7 @@ export const VoiceInputButton = forwardRef<
       mediaRecorderRef.current = null;
       releaseStream();
       stopSpeechRecognition();
+      stopDictationStream();
       onError?.("audio-capture");
       vsFail("audio-capture");
     };
@@ -542,6 +568,13 @@ export const VoiceInputButton = forwardRef<
       return;
     }
 
+    // Recording is live — open the daemon streaming session for interim
+    // transcripts. Null / later failure means no live partials, nothing
+    // more: the recorder above is untouched.
+    stopDictationStream();
+    dictationStreamRef.current = startDictationStream({
+      onPartial: (text) => onInterimTranscriptRef.current?.(text),
+    });
   }, [
     assistantId,
     onBeforeStart,
@@ -549,7 +582,9 @@ export const VoiceInputButton = forwardRef<
     onTranscript,
     releaseStream,
     stopSpeechRecognition,
+    stopDictationStream,
     vsStartRecording,
+    vsStopRecording,
     vsFail,
     vsFinalize,
     vsReset,

--- a/apps/web/src/domains/chat/components/voice-input-button.tsx
+++ b/apps/web/src/domains/chat/components/voice-input-button.tsx
@@ -265,6 +265,16 @@ export const VoiceInputButton = forwardRef<
   const onInterimTranscriptRef = useRef(onInterimTranscript);
   onInterimTranscriptRef.current = onInterimTranscript;
 
+  // Interim transcripts fan out to the per-instance callback (composer
+  // preview) AND the global recording store, so window-level consumers —
+  // the Electron dictation overlay sync — see partials no matter which
+  // button instance (chat composer or the global push-to-talk fallback)
+  // owns the session.
+  const publishInterim = useCallback((text: string) => {
+    useVoiceRecordingStore.getState().setInterimTranscript(text);
+    onInterimTranscriptRef.current?.(text);
+  }, []);
+
   const releaseStream = useCallback(() => {
     if (streamRef.current) {
       for (const track of streamRef.current.getTracks()) {
@@ -387,7 +397,7 @@ export const VoiceInputButton = forwardRef<
           // to avoid competing UI updates (the legacy client's rule). The
           // accumulator above still builds — it stays the batch fallback.
           if (!dictationStreamRef.current?.isLive()) {
-            onInterimTranscriptRef.current?.(interim);
+            publishInterim(interim);
           }
         };
 
@@ -458,7 +468,7 @@ export const VoiceInputButton = forwardRef<
       releaseStream();
       stopSpeechRecognition();
       stopDictationStream();
-      onInterimTranscriptRef.current?.("");
+      publishInterim("");
 
       if (erroredRef.current) {
         return;
@@ -573,13 +583,14 @@ export const VoiceInputButton = forwardRef<
     // more: the recorder above is untouched.
     stopDictationStream();
     dictationStreamRef.current = startDictationStream({
-      onPartial: (text) => onInterimTranscriptRef.current?.(text),
+      onPartial: publishInterim,
     });
   }, [
     assistantId,
     onBeforeStart,
     onError,
     onTranscript,
+    publishInterim,
     releaseStream,
     stopSpeechRecognition,
     stopDictationStream,

--- a/apps/web/src/domains/chat/hooks/use-dictation-overlay-sync.test.tsx
+++ b/apps/web/src/domains/chat/hooks/use-dictation-overlay-sync.test.tsx
@@ -94,6 +94,19 @@ describe("useDictationOverlaySync", () => {
     });
   });
 
+  test("unmounting mid-recording publishes a dismiss so the overlay can't stick", () => {
+    const hook = renderSync();
+
+    act(() => {
+      store().startRecording();
+    });
+    messages.length = 0;
+
+    hook.unmount();
+
+    expect(messages).toContainEqual({ kind: "dismiss" });
+  });
+
   test("a front-app insertion error turns the finalized session into an error, not done", () => {
     const hook = renderSync();
 

--- a/apps/web/src/domains/chat/hooks/use-dictation-overlay-sync.test.tsx
+++ b/apps/web/src/domains/chat/hooks/use-dictation-overlay-sync.test.tsx
@@ -18,14 +18,8 @@ const { useVoiceRecordingStore } = await import(
 );
 const { formatVoiceError } = await import("@/domains/chat/utils/chat");
 
-type SyncProps = { interim: string; errorCode: string | null };
-
-const renderSync = (
-  initialProps: SyncProps = { interim: "", errorCode: null },
-) => {
-  const hook = renderHook((props: SyncProps) => useDictationOverlaySync(props), {
-    initialProps,
-  });
+const renderSync = () => {
+  const hook = renderHook(() => useDictationOverlaySync());
   // Mounting in the store's idle phase publishes an initial dismiss —
   // uninteresting to every assertion below.
   messages.length = 0;
@@ -46,14 +40,16 @@ afterEach(() => {
 
 describe("useDictationOverlaySync", () => {
   test("publishes recording states with the live interim transcript", () => {
-    const hook = renderSync();
+    renderSync();
 
     act(() => {
       store().startRecording();
     });
     expect(messages).toEqual([{ kind: "recording", transcription: "" }]);
 
-    hook.rerender({ interim: "hello wor", errorCode: null });
+    act(() => {
+      store().setInterimTranscript("hello wor");
+    });
     expect(messages[messages.length - 1]).toEqual({
       kind: "recording",
       transcription: "hello wor",
@@ -108,16 +104,16 @@ describe("useDictationOverlaySync", () => {
   });
 
   test("a front-app insertion error turns the finalized session into an error, not done", () => {
-    const hook = renderSync();
+    renderSync();
 
     act(() => {
       store().startRecording();
       store().stopRecording();
     });
-    // Insertion failed: `handleVoiceTranscript` sets the voice error code,
-    // falls back to the composer, and the recorder still finalizes.
-    hook.rerender({ interim: "", errorCode: "dictation-automation-denied" });
+    // Insertion failed: the transcript handler flags the error code, the
+    // text falls back to the composer, and the recorder still finalizes.
     act(() => {
+      store().flagDictationInsertionError("dictation-automation-denied");
       store().finalize();
     });
 
@@ -126,5 +122,29 @@ describe("useDictationOverlaySync", () => {
       message: formatVoiceError("dictation-automation-denied"),
     });
     expect(messages).not.toContainEqual({ kind: "done" });
+  });
+
+  test("a new session clears the previous session's interim and insertion error", () => {
+    renderSync();
+
+    act(() => {
+      store().startRecording();
+      store().setInterimTranscript("old words");
+      store().flagDictationInsertionError("dictation-paste-blocked");
+      store().stopRecording();
+      store().finalize();
+    });
+    messages.length = 0;
+
+    act(() => {
+      store().startRecording();
+    });
+    expect(messages[0]).toEqual({ kind: "recording", transcription: "" });
+
+    act(() => {
+      store().stopRecording();
+      store().finalize();
+    });
+    expect(messages[messages.length - 1]).toEqual({ kind: "done" });
   });
 });

--- a/apps/web/src/domains/chat/hooks/use-dictation-overlay-sync.test.tsx
+++ b/apps/web/src/domains/chat/hooks/use-dictation-overlay-sync.test.tsx
@@ -1,0 +1,117 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import type { DictationOverlayMessage } from "@/runtime/is-electron";
+
+const messages: DictationOverlayMessage[] = [];
+
+mock.module("@/runtime/dictation-overlay", () => ({
+  setDictationOverlayState: (state: DictationOverlayMessage) => {
+    messages.push(state);
+  },
+  subscribeToDictationOverlayState: () => () => undefined,
+}));
+
+const { useDictationOverlaySync } = await import("./use-dictation-overlay-sync");
+const { useVoiceRecordingStore } = await import(
+  "@/domains/chat/voice/voice-recording-store"
+);
+const { formatVoiceError } = await import("@/domains/chat/utils/chat");
+
+type SyncProps = { interim: string; errorCode: string | null };
+
+const renderSync = (
+  initialProps: SyncProps = { interim: "", errorCode: null },
+) => {
+  const hook = renderHook((props: SyncProps) => useDictationOverlaySync(props), {
+    initialProps,
+  });
+  // Mounting in the store's idle phase publishes an initial dismiss —
+  // uninteresting to every assertion below.
+  messages.length = 0;
+  return hook;
+};
+
+const store = () => useVoiceRecordingStore.getState();
+
+afterEach(() => {
+  cleanup();
+  // Clears the store's done/error auto-dismiss timers so they can't fire
+  // into a later test.
+  act(() => {
+    store().reset();
+  });
+  messages.length = 0;
+});
+
+describe("useDictationOverlaySync", () => {
+  test("publishes recording states with the live interim transcript", () => {
+    const hook = renderSync();
+
+    act(() => {
+      store().startRecording();
+    });
+    expect(messages).toEqual([{ kind: "recording", transcription: "" }]);
+
+    hook.rerender({ interim: "hello wor", errorCode: null });
+    expect(messages[messages.length - 1]).toEqual({
+      kind: "recording",
+      transcription: "hello wor",
+    });
+  });
+
+  test("publishes processing, done, and dismiss through a successful session", () => {
+    renderSync();
+
+    act(() => {
+      store().startRecording();
+      store().stopRecording();
+    });
+    expect(messages[messages.length - 1]).toEqual({ kind: "processing" });
+
+    act(() => {
+      store().finalize();
+    });
+    expect(messages[messages.length - 1]).toEqual({ kind: "done" });
+
+    act(() => {
+      store().reset();
+    });
+    expect(messages[messages.length - 1]).toEqual({ kind: "dismiss" });
+  });
+
+  test("publishes a formatted error for STT failures", () => {
+    renderSync();
+
+    act(() => {
+      store().startRecording();
+      store().fail("stt-timeout");
+    });
+
+    expect(messages[messages.length - 1]).toEqual({
+      kind: "error",
+      message: formatVoiceError("stt-timeout"),
+    });
+  });
+
+  test("a front-app insertion error turns the finalized session into an error, not done", () => {
+    const hook = renderSync();
+
+    act(() => {
+      store().startRecording();
+      store().stopRecording();
+    });
+    // Insertion failed: `handleVoiceTranscript` sets the voice error code,
+    // falls back to the composer, and the recorder still finalizes.
+    hook.rerender({ interim: "", errorCode: "dictation-automation-denied" });
+    act(() => {
+      store().finalize();
+    });
+
+    expect(messages[messages.length - 1]).toEqual({
+      kind: "error",
+      message: formatVoiceError("dictation-automation-denied"),
+    });
+    expect(messages).not.toContainEqual({ kind: "done" });
+  });
+});

--- a/apps/web/src/domains/chat/hooks/use-dictation-overlay-sync.ts
+++ b/apps/web/src/domains/chat/hooks/use-dictation-overlay-sync.ts
@@ -10,32 +10,33 @@ import { setDictationOverlayState } from "@/runtime/dictation-overlay";
  * live while they dictate via push-to-talk into another app.
  *
  * Domain hook per the Electron conventions (`docs/ELECTRON.md`): the chat
- * domain owns the recording store, interim transcripts, and the voice error
- * taxonomy, so it decides when to call the `runtime/` bridge. Off Electron
- * the bridge no-ops, so this is safe to mount on web and iOS.
+ * domain owns the recording store and the voice error taxonomy, so it
+ * decides when to call the `runtime/` bridge. Off Electron the bridge
+ * no-ops, so this is safe to mount on web and iOS.
+ *
+ * Everything it publishes is read from `useVoiceRecordingStore` — phase,
+ * live interim transcript, and error codes — so it must be mounted exactly
+ * ONCE per window, in `GlobalPushToTalkBridge` (always present in
+ * `RootLayout`). That covers dictation hosted by any `VoiceInputButton`
+ * instance: the chat composer's on chat routes, and the bridge's headless
+ * fallback on every other route (Settings, onboarding, …). A second
+ * mounted instance would publish duplicate messages racing this one.
  *
  * The main process decides visibility: sessions that start while a Vellum
- * window is focused are suppressed there (the composer already shows interim
- * text inline), so this hook publishes unconditionally.
+ * window is focused are suppressed there (the composer already shows
+ * interim text inline), so this hook publishes unconditionally.
  *
- * @param interim   Live partial transcript while recording (`voiceInterim`).
- * @param errorCode Current voice error code (`voiceError`). Needed beyond
- *                  the store's own error phase because front-app insertion
- *                  failures (automation denied / paste blocked) set an error
- *                  code and then fall back to the composer, finalizing the
- *                  store into `done` — the overlay must show the error, not
- *                  a success check, or the user would believe the paste
- *                  landed in the app they were dictating into.
+ * `dictationInsertionError` exists because front-app insertion failures
+ * (automation denied / paste blocked) flag an error and then still
+ * finalize the store into `done` while the transcript soft-lands in the
+ * composer — the overlay must show the error, not a success check, or the
+ * user would believe the paste landed in the app they were dictating into.
  */
-export function useDictationOverlaySync({
-  interim,
-  errorCode,
-}: {
-  interim: string;
-  errorCode: string | null;
-}): void {
+export function useDictationOverlaySync(): void {
   const phase = useVoiceRecordingStore.use.phase();
-  const storeErrorCode = useVoiceRecordingStore.use.errorCode();
+  const errorCode = useVoiceRecordingStore.use.errorCode();
+  const interim = useVoiceRecordingStore.use.interimTranscript();
+  const insertionError = useVoiceRecordingStore.use.dictationInsertionError();
 
   useEffect(() => {
     switch (phase) {
@@ -47,30 +48,29 @@ export function useDictationOverlaySync({
         break;
       case "done":
         setDictationOverlayState(
-          errorCode
-            ? { kind: "error", message: formatVoiceError(errorCode) }
+          insertionError
+            ? { kind: "error", message: formatVoiceError(insertionError) }
             : { kind: "done" },
         );
         break;
       case "error":
         setDictationOverlayState({
           kind: "error",
-          message: formatVoiceError(storeErrorCode ?? errorCode ?? "unknown"),
+          message: formatVoiceError(errorCode ?? insertionError ?? "unknown"),
         });
         break;
       case "idle":
         setDictationOverlayState({ kind: "dismiss" });
         break;
     }
-  }, [phase, interim, errorCode, storeErrorCode]);
+  }, [phase, interim, errorCode, insertionError]);
 
   // Mount-scoped (not in the effect above — its cleanup runs on every dep
   // change, which would hide and re-show the overlay between interim
-  // updates). If the composer unmounts mid-recording (e.g. navigating to
-  // Settings), no idle transition is ever published, so dismiss explicitly
-  // or the overlay would stay up until the next session. Harmless after a
-  // terminal state: main pins done/error on their own timers and ignores
-  // this dismiss.
+  // updates). If the host window tears down mid-recording, no idle
+  // transition is ever published, so dismiss explicitly or the overlay
+  // would stay up until the next session. Harmless after a terminal state:
+  // main pins done/error on their own timers and ignores this dismiss.
   useEffect(() => {
     return () => {
       setDictationOverlayState({ kind: "dismiss" });

--- a/apps/web/src/domains/chat/hooks/use-dictation-overlay-sync.ts
+++ b/apps/web/src/domains/chat/hooks/use-dictation-overlay-sync.ts
@@ -63,4 +63,17 @@ export function useDictationOverlaySync({
         break;
     }
   }, [phase, interim, errorCode, storeErrorCode]);
+
+  // Mount-scoped (not in the effect above — its cleanup runs on every dep
+  // change, which would hide and re-show the overlay between interim
+  // updates). If the composer unmounts mid-recording (e.g. navigating to
+  // Settings), no idle transition is ever published, so dismiss explicitly
+  // or the overlay would stay up until the next session. Harmless after a
+  // terminal state: main pins done/error on their own timers and ignores
+  // this dismiss.
+  useEffect(() => {
+    return () => {
+      setDictationOverlayState({ kind: "dismiss" });
+    };
+  }, []);
 }

--- a/apps/web/src/domains/chat/hooks/use-dictation-overlay-sync.ts
+++ b/apps/web/src/domains/chat/hooks/use-dictation-overlay-sync.ts
@@ -1,0 +1,66 @@
+import { useEffect } from "react";
+
+import { formatVoiceError } from "@/domains/chat/utils/chat";
+import { useVoiceRecordingStore } from "@/domains/chat/voice/voice-recording-store";
+import { setDictationOverlayState } from "@/runtime/dictation-overlay";
+
+/**
+ * Mirrors the dictation lifecycle to the Electron system-wide overlay — the
+ * floating panel pinned top-center of the screen that shows the user's words
+ * live while they dictate via push-to-talk into another app.
+ *
+ * Domain hook per the Electron conventions (`docs/ELECTRON.md`): the chat
+ * domain owns the recording store, interim transcripts, and the voice error
+ * taxonomy, so it decides when to call the `runtime/` bridge. Off Electron
+ * the bridge no-ops, so this is safe to mount on web and iOS.
+ *
+ * The main process decides visibility: sessions that start while a Vellum
+ * window is focused are suppressed there (the composer already shows interim
+ * text inline), so this hook publishes unconditionally.
+ *
+ * @param interim   Live partial transcript while recording (`voiceInterim`).
+ * @param errorCode Current voice error code (`voiceError`). Needed beyond
+ *                  the store's own error phase because front-app insertion
+ *                  failures (automation denied / paste blocked) set an error
+ *                  code and then fall back to the composer, finalizing the
+ *                  store into `done` — the overlay must show the error, not
+ *                  a success check, or the user would believe the paste
+ *                  landed in the app they were dictating into.
+ */
+export function useDictationOverlaySync({
+  interim,
+  errorCode,
+}: {
+  interim: string;
+  errorCode: string | null;
+}): void {
+  const phase = useVoiceRecordingStore.use.phase();
+  const storeErrorCode = useVoiceRecordingStore.use.errorCode();
+
+  useEffect(() => {
+    switch (phase) {
+      case "recording":
+        setDictationOverlayState({ kind: "recording", transcription: interim });
+        break;
+      case "processing":
+        setDictationOverlayState({ kind: "processing" });
+        break;
+      case "done":
+        setDictationOverlayState(
+          errorCode
+            ? { kind: "error", message: formatVoiceError(errorCode) }
+            : { kind: "done" },
+        );
+        break;
+      case "error":
+        setDictationOverlayState({
+          kind: "error",
+          message: formatVoiceError(storeErrorCode ?? errorCode ?? "unknown"),
+        });
+        break;
+      case "idle":
+        setDictationOverlayState({ kind: "dismiss" });
+        break;
+    }
+  }, [phase, interim, errorCode, storeErrorCode]);
+}

--- a/apps/web/src/domains/chat/hooks/use-voice-input.ts
+++ b/apps/web/src/domains/chat/hooks/use-voice-input.ts
@@ -7,6 +7,7 @@ import {
 import {
   shouldShowMicPrimer,
 } from "@/domains/chat/components/mic-permission-primer";
+import { useDictationOverlaySync } from "@/domains/chat/hooks/use-dictation-overlay-sync";
 import { useIsNativePlatform } from "@/runtime/native-auth";
 import { postDictation } from "@/domains/chat/voice/dictation-api";
 import { registerPushToTalkTarget } from "@/domains/chat/voice/push-to-talk-target";
@@ -108,6 +109,11 @@ export function useVoiceInput({
       stop: () => voiceInputRef.current?.stop(),
     });
   }, []);
+
+  // Mirror the dictation lifecycle to the Electron system-wide overlay so
+  // push-to-talk dictation into another app has visible live feedback
+  // outside the main window. No-op off Electron.
+  useDictationOverlaySync({ interim: voiceInterim, errorCode: voiceError });
 
   const clearVoiceError = useCallback(() => {
     setVoiceError(null);

--- a/apps/web/src/domains/chat/hooks/use-voice-input.ts
+++ b/apps/web/src/domains/chat/hooks/use-voice-input.ts
@@ -7,7 +7,6 @@ import {
 import {
   shouldShowMicPrimer,
 } from "@/domains/chat/components/mic-permission-primer";
-import { useDictationOverlaySync } from "@/domains/chat/hooks/use-dictation-overlay-sync";
 import { useIsNativePlatform } from "@/runtime/native-auth";
 import { postDictation } from "@/domains/chat/voice/dictation-api";
 import { registerPushToTalkTarget } from "@/domains/chat/voice/push-to-talk-target";
@@ -110,11 +109,6 @@ export function useVoiceInput({
     });
   }, []);
 
-  // Mirror the dictation lifecycle to the Electron system-wide overlay so
-  // push-to-talk dictation into another app has visible live feedback
-  // outside the main window. No-op off Electron.
-  useDictationOverlaySync({ interim: voiceInterim, errorCode: voiceError });
-
   const clearVoiceError = useCallback(() => {
     setVoiceError(null);
   }, []);
@@ -163,8 +157,14 @@ export function useVoiceInput({
       }
       if (frontAppInsertion.status === "automation-denied") {
         setVoiceError("dictation-automation-denied");
+        useVoiceRecordingStore
+          .getState()
+          .flagDictationInsertionError("dictation-automation-denied");
       } else if (frontAppInsertion.status === "blocked") {
         setVoiceError("dictation-paste-blocked");
+        useVoiceRecordingStore
+          .getState()
+          .flagDictationInsertionError("dictation-paste-blocked");
       }
 
       setInput((current: string) => {

--- a/apps/web/src/domains/chat/voice/dictation-stream.test.ts
+++ b/apps/web/src/domains/chat/voice/dictation-stream.test.ts
@@ -1,0 +1,273 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import type { LiveVoiceAudioCaptureOptions, LiveVoiceCaptureResult } from "@/domains/chat/voice/live-voice/pcm-capture";
+
+let ingressUrl: string | null = "http://localhost:8500";
+let actorToken: string | null = "actor-jwt";
+let pcmSupported = true;
+
+mock.module("@/lib/self-hosted/connection", () => ({
+  getSelfHostedIngressUrl: () => ingressUrl,
+  getSelfHostedActorToken: () => actorToken,
+}));
+
+// The real module imports an AudioWorklet asset via Vite's `?worker&url`
+// suffix, which Bun's test runner can't resolve. The capture itself is
+// injected through `captureFactory`, so only the named exports the module
+// statically references need stubs.
+mock.module("@/domains/chat/voice/live-voice/pcm-capture", () => ({
+  isSupported: () => pcmSupported,
+  LiveVoiceAudioCapture: class {
+    constructor(_options: LiveVoiceAudioCaptureOptions) {}
+    start(): Promise<LiveVoiceCaptureResult> {
+      return Promise.resolve({ ok: true });
+    }
+    shutdown(): void {}
+  },
+}));
+
+const { buildSttStreamWsUrl, startDictationStream } = await import(
+  "./dictation-stream"
+);
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+class FakeWebSocket {
+  url: string;
+  readyState = 0; // CONNECTING
+  sent: Array<string | ArrayBuffer> = [];
+  closeCalls: Array<number | undefined> = [];
+  private listeners = new Map<string, Array<(event: unknown) => void>>();
+
+  constructor(url: string) {
+    this.url = url;
+  }
+
+  addEventListener(type: string, callback: (event: unknown) => void): void {
+    const existing = this.listeners.get(type) ?? [];
+    existing.push(callback);
+    this.listeners.set(type, existing);
+  }
+
+  send(data: string | ArrayBuffer): void {
+    this.sent.push(data);
+  }
+
+  close(code?: number): void {
+    this.closeCalls.push(code);
+    this.readyState = 3; // CLOSED
+    this.emit("close", {});
+  }
+
+  emit(type: string, event: unknown): void {
+    for (const callback of this.listeners.get(type) ?? []) {
+      callback(event);
+    }
+  }
+
+  /** Simulate the server accepting the connection. */
+  serverOpen(): void {
+    this.readyState = 1; // OPEN
+    this.emit("open", {});
+  }
+
+  /** Simulate a JSON event frame from the runtime session. */
+  serverMessage(payload: Record<string, unknown>): void {
+    this.emit("message", { data: JSON.stringify(payload) });
+  }
+}
+
+function createCaptureFake({
+  startResult = { ok: true } as LiveVoiceCaptureResult,
+} = {}) {
+  const calls = { started: 0, shutdown: 0 };
+  let onChunk: ((buf: ArrayBuffer) => void) | null = null;
+  const factory = (options: LiveVoiceAudioCaptureOptions) => {
+    onChunk = options.onChunk;
+    return {
+      start: () => {
+        calls.started += 1;
+        return Promise.resolve(startResult);
+      },
+      shutdown: () => {
+        calls.shutdown += 1;
+      },
+    };
+  };
+  return {
+    factory,
+    calls,
+    pushChunk: (buf: ArrayBuffer) => onChunk?.(buf),
+  };
+}
+
+function startWithFakes(
+  onPartial: (text: string) => void = () => undefined,
+  captureFake = createCaptureFake(),
+) {
+  let ws: FakeWebSocket | null = null;
+  const handle = startDictationStream(
+    { onPartial },
+    {
+      webSocketFactory: (url) => {
+        ws = new FakeWebSocket(url);
+        return ws as unknown as WebSocket;
+      },
+      captureFactory: captureFake.factory,
+    },
+  );
+  if (!handle || !ws) throw new Error("expected stream to start");
+  return { handle, ws: ws as FakeWebSocket, captureFake };
+}
+
+const flushMicrotasks = () => Promise.resolve();
+
+afterEach(() => {
+  ingressUrl = "http://localhost:8500";
+  actorToken = "actor-jwt";
+  pcmSupported = true;
+});
+
+// ---------------------------------------------------------------------------
+// URL building
+// ---------------------------------------------------------------------------
+
+describe("buildSttStreamWsUrl", () => {
+  test("http ingress with a path prefix maps to ws and keeps the prefix", () => {
+    const url = new URL(
+      buildSttStreamWsUrl({
+        ingressUrl: "http://localhost:3000/assistant/__gateway/8500/",
+        token: "tok en",
+      }),
+    );
+
+    expect(url.protocol).toBe("ws:");
+    expect(url.pathname).toBe("/assistant/__gateway/8500/v1/stt/stream");
+    expect(url.searchParams.get("token")).toBe("tok en");
+    expect(url.searchParams.get("mimeType")).toBe("audio/pcm");
+    expect(url.searchParams.get("sampleRate")).toBe("16000");
+  });
+
+  test("https ingress maps to wss and drops query/hash", () => {
+    const url = new URL(
+      buildSttStreamWsUrl({
+        ingressUrl: "https://x.example.com?foo=1#bar",
+        token: "t",
+      }),
+    );
+
+    expect(url.protocol).toBe("wss:");
+    expect(url.pathname).toBe("/v1/stt/stream");
+    expect(url.searchParams.get("foo")).toBeNull();
+    expect(url.hash).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Session lifecycle
+// ---------------------------------------------------------------------------
+
+describe("startDictationStream", () => {
+  test("returns null without a self-hosted ingress, token, or worklet support", () => {
+    ingressUrl = null;
+    expect(startDictationStream({ onPartial: () => undefined })).toBeNull();
+
+    ingressUrl = "http://localhost:8500";
+    actorToken = null;
+    expect(startDictationStream({ onPartial: () => undefined })).toBeNull();
+
+    actorToken = "actor-jwt";
+    pcmSupported = false;
+    expect(startDictationStream({ onPartial: () => undefined })).toBeNull();
+  });
+
+  test("starts capture on open and composes partial/final transcripts", async () => {
+    const partials: string[] = [];
+    const { handle, ws, captureFake } = startWithFakes((t) => partials.push(t));
+
+    ws.serverOpen();
+    await flushMicrotasks();
+    expect(captureFake.calls.started).toBe(1);
+
+    expect(handle.isLive()).toBe(false);
+    ws.serverMessage({ type: "ready", provider: "deepgram" });
+    expect(handle.isLive()).toBe(true);
+
+    ws.serverMessage({ type: "partial", text: "hello", seq: 0 });
+    ws.serverMessage({ type: "partial", text: "hello wor", seq: 1 });
+    ws.serverMessage({ type: "final", text: "hello world.", seq: 2 });
+    ws.serverMessage({ type: "partial", text: "next bit", seq: 3 });
+
+    expect(partials).toEqual([
+      "hello",
+      "hello wor",
+      "hello world.",
+      "hello world. next bit",
+    ]);
+  });
+
+  test("forwards PCM chunks only while the socket is open", () => {
+    const { handle, ws, captureFake } = startWithFakes();
+    const chunk = new ArrayBuffer(4);
+
+    captureFake.pushChunk(chunk);
+    expect(ws.sent).toHaveLength(0);
+
+    ws.serverOpen();
+    captureFake.pushChunk(chunk);
+    expect(ws.sent).toEqual([chunk]);
+
+    handle.stop();
+    captureFake.pushChunk(chunk);
+    expect(ws.sent.filter((s) => s === chunk)).toHaveLength(1);
+  });
+
+  test("a structured error (e.g. provider without streaming) tears down silently", () => {
+    const partials: string[] = [];
+    const { handle, ws, captureFake } = startWithFakes((t) => partials.push(t));
+
+    ws.serverOpen();
+    ws.serverMessage({
+      type: "error",
+      category: "provider-error",
+      message: "Streaming transcription is not supported",
+      seq: 0,
+    });
+
+    expect(handle.isLive()).toBe(false);
+    expect(captureFake.calls.shutdown).toBe(1);
+
+    ws.serverMessage({ type: "partial", text: "late", seq: 1 });
+    expect(partials).toEqual([]);
+  });
+
+  test("stop() sends the stop frame once and closes; idempotent", () => {
+    const { handle, ws } = startWithFakes();
+    ws.serverOpen();
+
+    handle.stop();
+    handle.stop();
+
+    const stopFrames = ws.sent.filter(
+      (frame) => typeof frame === "string" && frame.includes('"stop"'),
+    );
+    expect(stopFrames).toHaveLength(1);
+    expect(ws.closeCalls).toHaveLength(1);
+    expect(handle.isLive()).toBe(false);
+  });
+
+  test("capture failure tears the session down without throwing", async () => {
+    const captureFake = createCaptureFake({
+      startResult: { ok: false, error: "permission-denied" },
+    });
+    const { handle, ws } = startWithFakes(() => undefined, captureFake);
+
+    ws.serverOpen();
+    await flushMicrotasks();
+
+    expect(handle.isLive()).toBe(false);
+    expect(captureFake.calls.shutdown).toBe(1);
+  });
+});

--- a/apps/web/src/domains/chat/voice/dictation-stream.ts
+++ b/apps/web/src/domains/chat/voice/dictation-stream.ts
@@ -121,6 +121,11 @@ export function startDictationStream(
   const ingressUrl = getSelfHostedIngressUrl();
   const token = getSelfHostedActorToken();
   if (!ingressUrl || !token || !isPcmCaptureSupported()) {
+    // Expected on cloud-hosted assistants and plain browsers — log once
+    // per session attempt so a missing-partials report is diagnosable.
+    console.info(
+      "dictation-stream: skipping (no self-hosted ingress/token or no AudioWorklet)",
+    );
     return null;
   }
 
@@ -171,7 +176,10 @@ export function startDictationStream(
     if (closed) return;
     void capture.start().then((result) => {
       // Mic denied / device busy: no partials, batch capture unaffected.
-      if (!result.ok) teardown();
+      if (!result.ok) {
+        console.warn("dictation-stream: PCM capture failed", result.error);
+        teardown();
+      }
     });
   });
 
@@ -203,8 +211,14 @@ export function startDictationStream(
         }
         return;
       // Includes the structured "streaming not supported for provider"
-      // error — the session degrades to batch-only, silently.
+      // error — the session degrades to batch-only.
       case "error":
+        console.warn(
+          "dictation-stream: server error event",
+          (parsed as { message?: string }).message ?? event.data,
+        );
+        teardown();
+        return;
       case "closed":
         teardown();
         return;
@@ -213,7 +227,16 @@ export function startDictationStream(
     }
   });
 
-  ws.addEventListener("close", teardown);
+  ws.addEventListener("close", (event) => {
+    // A close before `ready` means the session never delivered a partial —
+    // surface why (CSP-blocked sockets land here with code 1006).
+    if (!live && !closed) {
+      console.warn(
+        `dictation-stream: socket closed before ready (code ${event.code})`,
+      );
+    }
+    teardown();
+  });
   ws.addEventListener("error", teardown);
 
   return {

--- a/apps/web/src/domains/chat/voice/dictation-stream.ts
+++ b/apps/web/src/domains/chat/voice/dictation-stream.ts
@@ -1,0 +1,232 @@
+/**
+ * Streaming dictation partials over the daemon's `/v1/stt/stream` WebSocket.
+ *
+ * Web Speech API partials are dead inside the Electron shell (Chromium ships
+ * the binding without the speech service behind it), so dictation there had
+ * no live transcript at all — the legacy Swift client solved this by
+ * streaming mic audio to the daemon's STT stream session and rendering its
+ * `partial` events. This module is that client for the web renderer.
+ *
+ * Scope: **interim display only.** The session runs alongside the existing
+ * `MediaRecorder` → batch `/v1/stt/transcribe` flow in
+ * `voice-input-button.tsx`, which remains the sole authority for the final
+ * inserted text. If the stream can't start (no self-hosted gateway ingress,
+ * provider without streaming support, capture failure), dictation simply
+ * proceeds without live partials — exactly today's behavior.
+ *
+ * Transport mirrors `live-voice/connection.ts`'s self-hosted path: connect
+ * straight to the user's gateway ingress with the actor edge JWT in
+ * `?token=` (browser WebSockets can't set an `Authorization` header). The
+ * cloud/velay path is deliberately not wired — the Electron shell (this
+ * feature's target) always talks to a local/self-hosted gateway, matching
+ * the legacy native client.
+ *
+ * Audio is the live-voice capture pipeline's 16 kHz mono PCM16LE
+ * (`LiveVoiceAudioCapture`), sent as binary frames; the runtime session
+ * (`assistant/src/stt/stt-stream-session.ts`) emits sequenced JSON events:
+ * `ready`, `partial`, `final`, `error`, `closed`. A `{type:"stop"}` text
+ * frame asks the provider to flush.
+ */
+
+import {
+  LiveVoiceAudioCapture,
+  isSupported as isPcmCaptureSupported,
+  type LiveVoiceAudioCaptureOptions,
+  type LiveVoiceCaptureResult,
+} from "@/domains/chat/voice/live-voice/pcm-capture";
+import { LIVE_VOICE_AUDIO_FORMAT } from "@/domains/chat/voice/live-voice/protocol";
+import {
+  getSelfHostedActorToken,
+  getSelfHostedIngressUrl,
+} from "@/lib/self-hosted/connection";
+
+export interface DictationStreamHandle {
+  /**
+   * True once the runtime accepted the session (`ready` received) and until
+   * teardown. Used by `voice-input-button.tsx` to give streaming partials
+   * priority over Web Speech partials (mirrors the legacy client's rule).
+   */
+  isLive(): boolean;
+  /**
+   * Stop capture, ask the provider to flush, and close the session.
+   * Idempotent.
+   */
+  stop(): void;
+}
+
+export interface StartDictationStreamArgs {
+  /**
+   * Receives the running transcript (committed finals + current interim)
+   * on every partial/final event.
+   */
+  onPartial: (text: string) => void;
+}
+
+/** Injection seams for tests. */
+export interface DictationStreamOptions {
+  webSocketFactory?: (url: string) => WebSocket;
+  captureFactory?: (options: LiveVoiceAudioCaptureOptions) => {
+    start(): Promise<LiveVoiceCaptureResult>;
+    shutdown(): void;
+  };
+}
+
+/**
+ * Build the self-hosted STT stream WebSocket URL:
+ *
+ *   ws(s)://<ingressHost>/v1/stt/stream?token=…&mimeType=audio/pcm&sampleRate=16000
+ *
+ * Same shape rules as `buildSelfHostedLiveVoiceWsUrl`: scheme follows the
+ * ingress (`http`→`ws`, `https`→`wss`), any ingress path prefix is preserved
+ * (local Docker mode proxies the gateway at a sub-path), and query/hash on
+ * the ingress are dropped. Exported for unit tests.
+ */
+export function buildSttStreamWsUrl({
+  ingressUrl,
+  token,
+}: {
+  ingressUrl: string;
+  token: string;
+}): string {
+  const url = new URL(ingressUrl);
+  url.protocol = url.protocol === "http:" ? "ws:" : "wss:";
+  const prefix = url.pathname.replace(/\/+$/, "");
+  url.pathname = `${prefix}/v1/stt/stream`;
+  url.search = "";
+  url.hash = "";
+  url.searchParams.set("token", token);
+  url.searchParams.set("mimeType", LIVE_VOICE_AUDIO_FORMAT.mimeType);
+  url.searchParams.set("sampleRate", String(LIVE_VOICE_AUDIO_FORMAT.sampleRate));
+  return url.toString();
+}
+
+/** Join transcript segments with a single space, ignoring blanks. */
+function joinTranscript(a: string, b: string): string {
+  return [a.trim(), b.trim()].filter(Boolean).join(" ");
+}
+
+/**
+ * Open a streaming dictation session for live partials.
+ *
+ * Returns `null` when streaming isn't possible in this environment (no
+ * self-hosted ingress/actor token, or no AudioWorklet support) so callers
+ * can skip it without branching on platform. All later failures — provider
+ * without streaming support, capture denial, socket errors — tear the
+ * session down silently; the batch recording path is unaffected.
+ */
+export function startDictationStream(
+  { onPartial }: StartDictationStreamArgs,
+  options: DictationStreamOptions = {},
+): DictationStreamHandle | null {
+  const ingressUrl = getSelfHostedIngressUrl();
+  const token = getSelfHostedActorToken();
+  if (!ingressUrl || !token || !isPcmCaptureSupported()) {
+    return null;
+  }
+
+  const webSocketFactory =
+    options.webSocketFactory ?? ((url: string) => new WebSocket(url));
+
+  let ws: WebSocket;
+  try {
+    ws = webSocketFactory(buildSttStreamWsUrl({ ingressUrl, token }));
+  } catch {
+    return null;
+  }
+
+  let live = false;
+  let closed = false;
+  let committedText = "";
+
+  const capture = (
+    options.captureFactory ??
+    ((captureOptions: LiveVoiceAudioCaptureOptions) =>
+      new LiveVoiceAudioCapture(captureOptions))
+  )({
+    onChunk: (buf) => {
+      if (!closed && ws.readyState === WebSocket.OPEN) {
+        ws.send(buf);
+      }
+    },
+  });
+
+  const teardown = (): void => {
+    if (closed) return;
+    closed = true;
+    live = false;
+    capture.shutdown();
+    if (
+      ws.readyState === WebSocket.OPEN ||
+      ws.readyState === WebSocket.CONNECTING
+    ) {
+      try {
+        ws.close(1000);
+      } catch {
+        // Already closing — nothing to clean up.
+      }
+    }
+  };
+
+  ws.addEventListener("open", () => {
+    if (closed) return;
+    void capture.start().then((result) => {
+      // Mic denied / device busy: no partials, batch capture unaffected.
+      if (!result.ok) teardown();
+    });
+  });
+
+  ws.addEventListener("message", (event) => {
+    if (closed || typeof event.data !== "string") return;
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(event.data);
+    } catch {
+      return;
+    }
+    if (!parsed || typeof parsed !== "object") return;
+
+    const message = parsed as { type?: string; text?: string };
+    switch (message.type) {
+      case "ready":
+        live = true;
+        return;
+      case "partial":
+        if (typeof message.text === "string") {
+          onPartial(joinTranscript(committedText, message.text));
+        }
+        return;
+      case "final":
+        if (typeof message.text === "string") {
+          committedText = joinTranscript(committedText, message.text);
+          onPartial(committedText);
+        }
+        return;
+      // Includes the structured "streaming not supported for provider"
+      // error — the session degrades to batch-only, silently.
+      case "error":
+      case "closed":
+        teardown();
+        return;
+      default:
+        return;
+    }
+  });
+
+  ws.addEventListener("close", teardown);
+  ws.addEventListener("error", teardown);
+
+  return {
+    isLive: () => live && !closed,
+    stop: () => {
+      if (!closed && ws.readyState === WebSocket.OPEN) {
+        try {
+          ws.send(JSON.stringify({ type: "stop" }));
+        } catch {
+          // Socket raced shut — teardown below handles it.
+        }
+      }
+      teardown();
+    },
+  };
+}

--- a/apps/web/src/domains/chat/voice/global-push-to-talk-bridge.tsx
+++ b/apps/web/src/domains/chat/voice/global-push-to-talk-bridge.tsx
@@ -5,6 +5,7 @@ import {
   type VoiceInputButtonHandle,
 } from "@/domains/chat/components/voice-input-button";
 import { useComposerStore } from "@/domains/chat/composer-store";
+import { useDictationOverlaySync } from "@/domains/chat/hooks/use-dictation-overlay-sync";
 import { createDraftConversationId } from "@/domains/chat/utils/conversation-selection";
 import { formatVoiceError } from "@/domains/chat/utils/chat";
 import { postDictation } from "@/domains/chat/voice/dictation-api";
@@ -12,6 +13,7 @@ import { getPushToTalkTarget } from "@/domains/chat/voice/push-to-talk-target";
 import { shouldEnablePushToTalk } from "@/domains/chat/voice/push-to-talk-host";
 import { useNativePushToTalkRegistration } from "@/domains/chat/voice/use-native-push-to-talk-registration";
 import { usePushToTalk } from "@/domains/chat/voice/use-push-to-talk";
+import { useVoiceRecordingStore } from "@/domains/chat/voice/voice-recording-store";
 import { insertTextIntoFrontApp } from "@/runtime/text-insertion";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useViewerStore } from "@/stores/viewer-store";
@@ -45,6 +47,13 @@ export function GlobalPushToTalkBridge({
 
   useNativePushToTalkRegistration();
 
+  // Single per-window publisher for the Electron dictation overlay. Lives
+  // here — not in `useVoiceInput` — because this bridge is always mounted
+  // (RootLayout) while the chat composer only exists on chat routes; the
+  // overlay must mirror dictation hosted by either VoiceInputButton
+  // instance. Reads everything from the shared recording store.
+  useDictationOverlaySync();
+
   const resolveTarget = useCallback(
     () =>
       getPushToTalkTarget() ??
@@ -73,8 +82,14 @@ export function GlobalPushToTalkBridge({
 
       if (frontAppInsertion.status === "automation-denied") {
         toast.error(formatVoiceError("dictation-automation-denied"));
+        useVoiceRecordingStore
+          .getState()
+          .flagDictationInsertionError("dictation-automation-denied");
       } else if (frontAppInsertion.status === "blocked") {
         toast.error(formatVoiceError("dictation-paste-blocked"));
+        useVoiceRecordingStore
+          .getState()
+          .flagDictationInsertionError("dictation-paste-blocked");
       }
 
       if (assistantId) {

--- a/apps/web/src/domains/chat/voice/voice-recording-store.ts
+++ b/apps/web/src/domains/chat/voice/voice-recording-store.ts
@@ -42,6 +42,22 @@ export interface VoiceRecordingState {
   phase: VoiceRecordingPhase;
   /** Error code when `phase === "error"`, `null` otherwise. */
   errorCode: string | null;
+  /**
+   * Live interim transcript while `phase === "recording"`, published by the
+   * recording `VoiceInputButton` instance (streaming STT or Web Speech).
+   * Global so window-level consumers — the Electron dictation overlay sync —
+   * see partials regardless of which button instance (chat composer or the
+   * global push-to-talk fallback) owns the session.
+   */
+  interimTranscript: string;
+  /**
+   * Front-app insertion failure (`dictation-automation-denied` /
+   * `dictation-paste-blocked`) flagged during the current session. The
+   * session still finalizes into `done` — the transcript soft-lands in the
+   * composer — but the dictation overlay must show the error rather than a
+   * success check. Cleared on the next `startRecording`.
+   */
+  dictationInsertionError: string | null;
 }
 
 export interface VoiceRecordingActions {
@@ -50,6 +66,8 @@ export interface VoiceRecordingActions {
   finalize: () => void;
   fail: (code: string) => void;
   reset: () => void;
+  setInterimTranscript: (text: string) => void;
+  flagDictationInsertionError: (code: string) => void;
 }
 
 export type VoiceRecordingStore = VoiceRecordingState & VoiceRecordingActions;
@@ -84,15 +102,22 @@ function clearDismissTimer() {
 const useVoiceRecordingStoreBase = create<VoiceRecordingStore>()((set) => ({
   phase: "idle",
   errorCode: null,
+  interimTranscript: "",
+  dictationInsertionError: null,
 
   startRecording: () => {
     clearDismissTimer();
-    set({ phase: "recording", errorCode: null });
+    set({
+      phase: "recording",
+      errorCode: null,
+      interimTranscript: "",
+      dictationInsertionError: null,
+    });
   },
 
   stopRecording: () => {
     clearDismissTimer();
-    set({ phase: "processing", errorCode: null });
+    set({ phase: "processing", errorCode: null, interimTranscript: "" });
   },
 
   finalize: () => {
@@ -115,7 +140,20 @@ const useVoiceRecordingStoreBase = create<VoiceRecordingStore>()((set) => ({
 
   reset: () => {
     clearDismissTimer();
-    set({ phase: "idle", errorCode: null });
+    set({
+      phase: "idle",
+      errorCode: null,
+      interimTranscript: "",
+      dictationInsertionError: null,
+    });
+  },
+
+  setInterimTranscript: (text: string) => {
+    set({ interimTranscript: text });
+  },
+
+  flagDictationInsertionError: (code: string) => {
+    set({ dictationInsertionError: code });
   },
 }));
 

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -116,6 +116,13 @@ export const routeTree = [
     // outside auth middleware and RootLayout for fast load.
     { path: "/assistant/quick-input", ErrorBoundary: RouteErrorBoundary, HydrateFallback: RootHydrateFallback, lazy: { Component: () => import("@/components/quick-input-page").then((m) => m.QuickInputPage) } },
 
+    // Dictation overlay — live transcription pill rendered inside the
+    // Electron dictation overlay BrowserWindow (a click-through floating
+    // panel pinned top-center of the screen while push-to-talk dictation
+    // is active). Same pattern as Quick Input: sibling of `/assistant`,
+    // outside auth middleware and RootLayout for fast load.
+    { path: "/assistant/dictation-overlay", ErrorBoundary: RouteErrorBoundary, HydrateFallback: RootHydrateFallback, lazy: { Component: () => import("@/components/dictation-overlay-page").then((m) => m.DictationOverlayPage) } },
+
     // Assistant routes — auth-protected app with layout
     {
       path: "/assistant",

--- a/apps/web/src/runtime/dictation-overlay.ts
+++ b/apps/web/src/runtime/dictation-overlay.ts
@@ -1,0 +1,43 @@
+/**
+ * Runtime wrapper for the dictation overlay bridge surface.
+ *
+ * The Electron main process owns a system-wide, click-through panel pinned
+ * top-center of the active display that shows the user's words live while
+ * they dictate via push-to-talk into another app (the Electron port of the
+ * native Swift client's `DictationOverlayWindow`).
+ *
+ * Feature code imports these functions instead of touching
+ * `window.vellum.dictationOverlay` directly. Off-Electron (web, Capacitor
+ * iOS) and on older shells that predate the channel they are no-ops, so the
+ * dictation flow degrades gracefully.
+ */
+
+import {
+  isElectron,
+  type DictationOverlayMessage,
+  type DictationOverlayState,
+} from "@/runtime/is-electron";
+
+/**
+ * Publish the current dictation lifecycle state to the overlay.
+ * Fire-and-forget — interim transcription updates are high-frequency.
+ */
+export function setDictationOverlayState(
+  state: DictationOverlayMessage,
+): void {
+  if (!isElectron()) return;
+  window.vellum?.dictationOverlay?.setState(state);
+}
+
+/**
+ * Subscribe to overlay states. Only the dictation overlay window's own
+ * renderer route consumes this. Returns an unsubscribe function.
+ */
+export function subscribeToDictationOverlayState(
+  callback: (state: DictationOverlayState) => void,
+): () => void {
+  if (!isElectron() || !window.vellum?.dictationOverlay) {
+    return () => undefined;
+  }
+  return window.vellum.dictationOverlay.onState(callback);
+}

--- a/apps/web/src/runtime/dictation-overlay.ts
+++ b/apps/web/src/runtime/dictation-overlay.ts
@@ -41,3 +41,16 @@ export function subscribeToDictationOverlayState(
   }
   return window.vellum.dictationOverlay.onState(callback);
 }
+
+/**
+ * Read the latest overlay state (null when no session is active, off
+ * Electron, or on shells that predate the channel). The overlay route
+ * loads lazily, so states pushed before its subscription registers are
+ * dropped — pull this once subscribed to catch up.
+ */
+export async function getDictationOverlayState(): Promise<DictationOverlayState | null> {
+  if (!isElectron() || !window.vellum?.dictationOverlay?.getState) {
+    return null;
+  }
+  return window.vellum.dictationOverlay.getState();
+}

--- a/apps/web/src/runtime/is-electron.ts
+++ b/apps/web/src/runtime/is-electron.ts
@@ -117,6 +117,23 @@ export type FnPushToTalkResult =
   | { ok: true; enabled: boolean }
   | { ok: false; reason: string };
 
+/**
+ * States the system-wide dictation overlay can display, plus the explicit
+ * dismiss message. Renderer-side mirror of `DictationOverlayState` /
+ * `DictationOverlayMessage` in
+ * `apps/macos/src/main/dictation-overlay-window.ts` — inline for the same
+ * reason as `VellumCommand`.
+ */
+export type DictationOverlayState =
+  | { kind: "recording"; transcription: string }
+  | { kind: "processing" }
+  | { kind: "done" }
+  | { kind: "error"; message: string };
+
+export type DictationOverlayMessage =
+  | DictationOverlayState
+  | { kind: "dismiss" };
+
 export type HelperState =
   | { status: "idle" }
   | { status: "starting"; attempt: number }
@@ -378,6 +395,13 @@ declare global {
       quickInput?: {
         submit(message: string): Promise<void>;
         dismiss(): Promise<void>;
+      };
+      // Optional: older Electron shells predate the dictation overlay channel.
+      dictationOverlay?: {
+        setState(state: DictationOverlayMessage): void;
+        onState(
+          callback: (state: DictationOverlayState) => void,
+        ): () => void;
       };
       // Optional: older Electron shells predate the notifications channel.
       notifications?: {

--- a/apps/web/src/runtime/is-electron.ts
+++ b/apps/web/src/runtime/is-electron.ts
@@ -402,6 +402,7 @@ declare global {
         onState(
           callback: (state: DictationOverlayState) => void,
         ): () => void;
+        getState(): Promise<DictationOverlayState | null>;
       };
       // Optional: older Electron shells predate the notifications channel.
       notifications?: {

--- a/apps/web/src/runtime/is-electron.ts
+++ b/apps/web/src/runtime/is-electron.ts
@@ -118,6 +118,19 @@ export type FnPushToTalkResult =
   | { ok: false; reason: string };
 
 /**
+ * Renderer-side mirror of `DictationPartialsResult` / `DictationPartialEvent`
+ * in `apps/macos/src/main/hotkey-helper.ts` — inline for the same reason as
+ * `VellumCommand`.
+ */
+export type DictationPartialsResult =
+  | { ok: true; enabled: boolean }
+  | { ok: false; reason: string };
+
+export interface DictationPartialEvent {
+  text: string;
+}
+
+/**
  * States the system-wide dictation overlay can display, plus the explicit
  * dismiss message. Renderer-side mirror of `DictationOverlayState` /
  * `DictationOverlayMessage` in
@@ -292,6 +305,13 @@ declare global {
         hotkey?: {
           fnPushToTalk(enable: boolean): Promise<FnPushToTalkResult>;
           onEvent(callback: (event: HotkeyEvent) => void): () => void;
+        };
+        // Optional: older Electron shells predate the dictation channel.
+        dictation?: {
+          setPartials(enable: boolean): Promise<DictationPartialsResult>;
+          onPartial(
+            callback: (event: DictationPartialEvent) => void,
+          ): () => void;
         };
       };
       commands: {

--- a/apps/web/src/runtime/native-dictation-partials.ts
+++ b/apps/web/src/runtime/native-dictation-partials.ts
@@ -1,0 +1,60 @@
+/**
+ * Runtime wrapper for the mac helper's local speech-recognition partials.
+ *
+ * The helper runs `SFSpeechRecognizer` against its own mic tap and streams
+ * cumulative partial transcriptions — the dictation overlay's live-text
+ * source when daemon streaming STT is unreachable (platform-managed
+ * assistants whose runtime traffic rides the platform proxy have no gateway
+ * WebSocket the renderer could stream against). The same role the native
+ * recognizer played in the legacy Swift client.
+ *
+ * Off Electron, and on shells that predate the channel, this no-ops by
+ * resolving `null`.
+ */
+
+import { isElectron } from "@/runtime/is-electron";
+
+/**
+ * Start native dictation partials, delivering cumulative transcription text
+ * to `onPartial`. Resolves a stop function on success, or `null` when the
+ * capability is unavailable (off Electron, old shell, speech permission
+ * denied, recognizer unavailable).
+ */
+export async function startNativeDictationPartials(
+  onPartial: (text: string) => void,
+): Promise<(() => void) | null> {
+  const dictation = isElectron()
+    ? window.vellum?.helper?.dictation
+    : undefined;
+  if (!dictation) {
+    return null;
+  }
+
+  // Subscribe before enabling so a fast first partial isn't dropped.
+  const unsubscribe = dictation.onPartial((event) => {
+    onPartial(event.text);
+  });
+
+  try {
+    const result = await dictation.setPartials(true);
+    if (!result.ok) {
+      console.info("native-dictation-partials: unavailable:", result.reason);
+      unsubscribe();
+      return null;
+    }
+  } catch (err) {
+    console.warn("native-dictation-partials: setPartials failed", err);
+    unsubscribe();
+    return null;
+  }
+
+  let stopped = false;
+  return () => {
+    if (stopped) return;
+    stopped = true;
+    unsubscribe();
+    dictation.setPartials(false).catch(() => {
+      // Helper may have exited; nothing to stop.
+    });
+  };
+}


### PR DESCRIPTION
## Summary

- Ports the legacy native macOS app's top-of-screen dictation UI to the Electron app: a click-through, non-activating floating panel pinned top-center of the active display that shows your words live as you dictate via push-to-talk into any app, then shows processing → done / error states before auto-dismissing.
- Main process owns the window (panel type, never focusable, visible over fullscreen Spaces) and a unit-tested session controller: sessions starting while a Vellum window is focused are suppressed (the composer shows interim text inline, matching the Swift client), and terminal states keep their own display timing (done 800 ms, error 3 s).
- Adds the `dictationOverlay` bridge surface (preload + renderer mirror + `runtime/` wrapper) and a domain hook `useDictationOverlaySync` that publishes the recording store phase, live interim transcript, and voice errors — including front-app paste failures, so the overlay shows the error instead of a false success check.

## Original prompt

For the macOS Electron app, bring across the dictation UI at the top of the screen that displays outside the main window, which the legacy native macOS app had — so you can see your words as you dictate them at a global level. The legacy implementation is `DictationOverlayWindow.swift` in `clients/macos`; the Electron port follows the existing quick-input floating-panel and Electron bridge conventions.