### PR TITLE
ci: skip Playwright browser download in macOS Build install step

### DIFF
--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -248,6 +248,10 @@ jobs:
           chmod 600 ~/.netrc
 
       - name: Install nested package dependencies
+        env:
+          # Build-only job: skip @playwright/browser-chromium's postinstall
+          # download from cdn.playwright.dev (flaky DNS on macOS runners).
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
         run: |
           pids=()
           for dir in packages/*/ skills/*/; do


### PR DESCRIPTION
## Summary
- Set `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` on the `Install nested package dependencies` step of the `macOS Build` job in `ci-main-macos.yaml`.
- The job's blanket `bun install` over `packages/*/` triggers `@playwright/browser-chromium`'s postinstall (transitive via `packages/design-library`), which downloads ~150MB of Chrome for Testing from `cdn.playwright.dev`. The build-only job never runs browser tests, and the download failed with DNS `ENOTFOUND` across all 5 internal retries in [run 27246264128](https://github.com/vellum-ai/vellum-assistant/actions/runs/27246264128/job/80460889970), failing the job.
- Scoped to this job only per the request. The same inline install step exists in `pr-macos.yaml`, `release.yml`, and `dev-release.yaml` (macOS jobs) and carries the same latent flake — left untouched here as a possible follow-up.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/27246264128/job/80460889970