### PR TITLE
fix: getConfigReadOnly falls back to defaults on non-object config.json

### DIFF
--- a/assistant/src/__tests__/config-loader-corrupt.test.ts
+++ b/assistant/src/__tests__/config-loader-corrupt.test.ts
@@ -3,8 +3,10 @@
  * hand-edited to invalid JSON) is quarantined by the loader, which
  * logs an error with a remediation hint and falls through to the
  * default-config path so startup proceeds. These tests verify that
- * loadConfig() / loadRawConfig() never throw on corrupt input, and
- * that the corrupt file is preserved for debugging.
+ * loadConfig() / loadRawConfig() / getConfigReadOnly() never throw on
+ * corrupt input, and that the corrupt file is preserved for debugging
+ * (quarantined by the writing loaders; left in place by the read-only
+ * accessor).
  */
 
 import {
@@ -19,6 +21,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import {
+  getConfigReadOnly,
   invalidateConfigCache,
   loadConfig,
   loadRawConfig,
@@ -248,4 +251,69 @@ describe("loadRawConfig corrupt-file recovery", () => {
       );
     },
   );
+});
+
+describe("getConfigReadOnly corrupt-file recovery", () => {
+  beforeEach(() => {
+    resetWorkspace();
+    setStorePathForTesting(join(WORKSPACE_DIR, "keys.enc"));
+    invalidateConfigCache();
+  });
+
+  afterEach(() => {
+    setStorePathForTesting(null);
+    invalidateConfigCache();
+  });
+
+  test("returns defaults on unparseable config.json without side effects", () => {
+    writeFileSync(CONFIG_PATH, '{"provider": "anthropic", "mo');
+
+    // Must not throw — this runs during CLI program construction.
+    const config = getConfigReadOnly();
+
+    expect(config).toBeDefined();
+    expect(config.memory).toBeDefined();
+    expect(listQuarantinedFiles()).toHaveLength(0);
+    expect(readFileSync(CONFIG_PATH, "utf-8")).toBe(
+      '{"provider": "anthropic", "mo',
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Top-level shape guard — JSON.parse succeeds on `null`, primitives, and
+  // arrays, but `validateWithBuiltinProfiles` requires a plain-object root
+  // (its profile merge would TypeError otherwise). The read-only accessor
+  // must fall back to defaults like the parse-error path, and — unlike
+  // loadConfig() — must NOT quarantine: it stays side-effect-free.
+  // ---------------------------------------------------------------------------
+
+  test.each([
+    ["null at the top level", "null"],
+    ["a JSON number", "42"],
+    ["a JSON string", '"hello"'],
+    ["a JSON boolean", "true"],
+    ["a JSON array", '["provider", "anthropic"]'],
+  ])(
+    "returns defaults when config.json contains %s, without quarantining",
+    (_label, jsonText) => {
+      writeFileSync(CONFIG_PATH, jsonText);
+
+      // Must not throw — CLI program construction depends on this.
+      const config = getConfigReadOnly();
+
+      expect(config).toBeDefined();
+      expect(config.memory).toBeDefined();
+      expect(listQuarantinedFiles()).toHaveLength(0);
+      expect(readFileSync(CONFIG_PATH, "utf-8")).toBe(jsonText);
+    },
+  );
+
+  test("returns the parsed config when config.json is a valid object", () => {
+    const customDataDir = join(WORKSPACE_DIR, "custom-data");
+    writeFileSync(CONFIG_PATH, JSON.stringify({ dataDir: customDataDir }));
+
+    const config = getConfigReadOnly();
+    expect(config.dataDir).toBe(customDataDir);
+    expect(listQuarantinedFiles()).toHaveLength(0);
+  });
 });

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -1099,7 +1099,9 @@ export function getConfig(): AssistantConfig {
 /**
  * Read-only config accessor: returns the current config without creating
  * directories or writing files. Reads config.json if it exists on disk;
- * returns schema defaults otherwise. Unlike `getConfig()` / `loadConfig()`,
+ * returns schema defaults otherwise — and also when the file is unparseable
+ * or its top-level value is not a plain object (corrupt files are left in
+ * place, never quarantined). Unlike `getConfig()` / `loadConfig()`,
  * this never calls `ensureDataDir()` or writes a default config to disk,
  * making it safe to call during CLI program construction before the
  * workspace-existence check runs.
@@ -1111,11 +1113,25 @@ export function getConfigReadOnly(): AssistantConfig {
   const configPath = getConfigPath();
   let fileConfig: Record<string, unknown> = {};
   if (existsSync(configPath)) {
+    let parsed: unknown;
     try {
-      fileConfig = JSON.parse(readFileSync(configPath, "utf-8"));
+      parsed = JSON.parse(readFileSync(configPath, "utf-8"));
     } catch {
       return cloneDefaultConfig();
     }
+    if (!isPlainObject(parsed)) {
+      // Same top-level-shape contract as `loadConfig`: a `null`, primitive,
+      // or array would TypeError inside `validateWithBuiltinProfiles`
+      // (`ensurePlainObjectAt(raw, "llm")`). Fall back to defaults like the
+      // parse-error path above — but never quarantine here: this accessor
+      // must stay read-only and side-effect-free; `loadConfig` owns
+      // quarantining on the next full load.
+      log.warn(
+        `config.json must contain a JSON object at the top level; got ${describeJsonShape(parsed)} — using defaults`,
+      );
+      return cloneDefaultConfig();
+    }
+    fileConfig = parsed;
   }
 
   return validateWithBuiltinProfiles(fileConfig);


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for builtin-llm-profiles.md.

**Gap:** getConfigReadOnly only guarded JSON.parse throws; valid non-object JSON (null/number/string/array) reached applyBuiltinProfiles and crashed with a TypeError (regression vs the old safeParse fallback; hits CLI program construction). Now guards top-level shape and falls back to defaults, side-effect-free.