### PR TITLE
refactor: retire builtin-profile re-exports, dedupe types, fix stale comments

### DIFF
--- a/apps/web/src/assistant/profile-pickers.ts
+++ b/apps/web/src/assistant/profile-pickers.ts
@@ -26,7 +26,7 @@ export interface ProfilePickerEntry {
  * Manage Profiles modal, and the per-call-site override picker.
  *
  * Mirrors `AUTO_PROFILE_KEY` in
- * `assistant/src/config/seed-inference-profiles.ts`.
+ * `assistant/src/config/builtin-inference-profiles.ts`.
  */
 export const AUTO_PROFILE_NAME = "auto";
 

--- a/apps/web/src/domains/settings/ai/manage-profiles-modal.test.tsx
+++ b/apps/web/src/domains/settings/ai/manage-profiles-modal.test.tsx
@@ -57,6 +57,7 @@ mock.module("@/domains/settings/ai/use-daemon-config", () => ({
       return Promise.resolve({ data: undefined, resolvedId: "asst-1" });
     },
   }),
+  invalidateDaemonConfig: () => {},
 }));
 
 // Feature-flag store: `.use.<flag>()` accessors return booleans.

--- a/apps/web/src/domains/settings/ai/manage-profiles-modal.tsx
+++ b/apps/web/src/domains/settings/ai/manage-profiles-modal.tsx
@@ -15,10 +15,9 @@ import { ProfileListItem } from "@/domains/settings/ai/manage-profiles-list-item
 import { ProfileEditorModal } from "@/domains/settings/ai/profile-editor-modal";
 import { gateAutoProfile } from "@/domains/settings/ai/profile-pickers";
 import { filterFlaggedConnections } from "@/domains/settings/ai/provider-connections-client";
-import { useDaemonConfigMutation, useDaemonConfigQuery } from "@/domains/settings/ai/use-daemon-config";
+import { invalidateDaemonConfig, useDaemonConfigMutation, useDaemonConfigQuery } from "@/domains/settings/ai/use-daemon-config";
 import { inferenceProviderconnectionsGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
 import { configLlmProfilesByNamePut } from "@/generated/daemon/sdk.gen";
-import { assistantDaemonConfigQueryKey } from "@/lib/sync/query-tags";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -94,11 +93,7 @@ export function ManageProfilesModal({
         body: override,
         throwOnError: true,
       });
-      // Replicate `useDaemonConfigMutation`'s settle-time invalidation so
-      // every consumer of the config query refetches the updated profile.
-      void queryClient.invalidateQueries({
-        queryKey: assistantDaemonConfigQueryKey(assistantId),
-      });
+      invalidateDaemonConfig(queryClient, assistantId);
       setEditorOpen(false);
       setEditingProfile(null);
       return;

--- a/apps/web/src/domains/settings/ai/profile-pickers.ts
+++ b/apps/web/src/domains/settings/ai/profile-pickers.ts
@@ -17,7 +17,7 @@ export interface ProfilePickerEntry {
 
 /**
  * Name of the meta-"auto" profile seeded by the daemon. Mirrors
- * `AUTO_PROFILE_KEY` in `assistant/src/config/seed-inference-profiles.ts`
+ * `AUTO_PROFILE_KEY` in `assistant/src/config/builtin-inference-profiles.ts`
  * and `AUTO_PROFILE_NAME` in `@/assistant/profile-pickers`.
  */
 export const AUTO_PROFILE_NAME = "auto";

--- a/apps/web/src/domains/settings/ai/use-daemon-config.ts
+++ b/apps/web/src/domains/settings/ai/use-daemon-config.ts
@@ -14,7 +14,7 @@
 
 import { useCallback, useMemo } from "react";
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { type QueryClient, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import type { CallSiteOverrideDraft, DaemonConfig, DaemonConfigPatch, ProfileEntry } from "@/domains/settings/ai/ai-types";
 import { applyConfigPatch, assertProvisionSuccess, buildOrderedProfiles, snapshotPatchedFields } from "@/domains/settings/ai/ai-utils";
@@ -116,6 +116,21 @@ export function useDaemonConfigQuery() {
 // ---------------------------------------------------------------------------
 
 /**
+ * Invalidate the daemon config query so every consumer refetches the
+ * server's authoritative state. Used by `useDaemonConfigMutation` on settle
+ * and by callers that write config through other endpoints (e.g. the PUT
+ * profile route in ManageProfilesModal).
+ */
+export function invalidateDaemonConfig(
+  queryClient: QueryClient,
+  assistantId: string,
+): void {
+  void queryClient.invalidateQueries({
+    queryKey: assistantDaemonConfigQueryKey(assistantId),
+  });
+}
+
+/**
  * Mutation hook for daemon config patches.
  *
  * Wraps `configPatch` with optimistic cache updates and auto-invalidation:
@@ -164,10 +179,7 @@ export function useDaemonConfigMutation() {
       }
     },
     onSettled: (result) => {
-      const idToInvalidate = result?.resolvedId ?? assistantId;
-      void queryClient.invalidateQueries({
-        queryKey: assistantDaemonConfigQueryKey(idToInvalidate),
-      });
+      invalidateDaemonConfig(queryClient, result?.resolvedId ?? assistantId);
     },
   });
 }

--- a/assistant/src/__tests__/config-loader-builtin-profiles.test.ts
+++ b/assistant/src/__tests__/config-loader-builtin-profiles.test.ts
@@ -129,12 +129,7 @@ function readConfigFromDisk(): Record<string, unknown> {
 }
 
 function templateEntry(name: string): ProfileEntry {
-  const template = MANAGED_PROFILE_TEMPLATES[name]!;
-  return materializeProfile(
-    template,
-    template.provider,
-    template.connectionName,
-  );
+  return materializeProfile(MANAGED_PROFILE_TEMPLATES[name]!);
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/config/builtin-inference-profiles.ts
+++ b/assistant/src/config/builtin-inference-profiles.ts
@@ -3,7 +3,7 @@ import type { ModelIntent } from "../providers/types.js";
 import {
   DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS,
   type ProfileEntry,
-  type ProfileStatus,
+  type ProfileOverrideEntry,
 } from "./schemas/llm.js";
 
 /**
@@ -28,9 +28,10 @@ export type BuiltinProfileDefinition = Omit<
 };
 
 /**
- * Managed profiles. Overwritten on every daemon boot so Vellum can push
- * model/config updates to customers in new releases. Platform overlays
- * (`preserveProfileNames`) take precedence when present.
+ * Managed profiles. Resolved into the effective config at load time
+ * (`applyBuiltinProfiles` in `loader.ts`) and never persisted to disk, so
+ * Vellum can push model/config updates to customers in new releases. User
+ * label/status overrides come from the sparse `llm.profileOverrides` store.
  */
 export const MANAGED_PROFILE_TEMPLATES: Record<
   string,
@@ -126,7 +127,7 @@ export function isSeedDefaultBuiltinLabel(
   label: string,
 ): boolean {
   if (name === AUTO_PROFILE_KEY) {
-    return label === createAutoProfileEntry().label;
+    return label === AUTO_PROFILE_LABEL;
   }
   const base = MANAGED_PROFILE_TEMPLATES[name]?.label;
   return (
@@ -137,8 +138,8 @@ export function isSeedDefaultBuiltinLabel(
 
 export function materializeProfile(
   template: BuiltinProfileDefinition,
-  provider: NonNullable<ProfileEntry["provider"]>,
-  connectionName: string,
+  provider: NonNullable<ProfileEntry["provider"]> = template.provider,
+  connectionName: string = template.connectionName,
 ): ProfileEntry {
   const {
     intent,
@@ -155,28 +156,22 @@ export function materializeProfile(
   };
 }
 
+const AUTO_PROFILE_LABEL = "Auto";
+
+const AUTO_PROFILE_DESCRIPTION =
+  "Automatically routes each query to the best profile — fast for simple questions, capable for complex ones";
+
 /**
  * The `auto` profile entry is metadata-only: no provider/model — the resolver
  * falls through to the call-site default when it is active.
  */
-export function createAutoProfileEntry(): ProfileEntry {
+function createAutoProfileEntry(): ProfileEntry {
   return {
     source: "managed",
-    label: "Auto",
-    description:
-      "Automatically routes each query to the best profile — fast for simple questions, capable for complex ones",
+    label: AUTO_PROFILE_LABEL,
+    description: AUTO_PROFILE_DESCRIPTION,
   };
 }
-
-/**
- * Sparse user override for a built-in profile. Only `label` and `status` are
- * user-ownable on built-ins; `null` means "explicitly cleared" and is applied
- * as-is (key-presence semantics — an absent key leaves the default in place).
- */
-export type BuiltinProfileOverride = {
-  label?: string | null;
-  status?: ProfileStatus | null;
-};
 
 /**
  * Resolve the effective built-in profile set. Pure: reads only its arguments
@@ -194,7 +189,7 @@ export type BuiltinProfileOverride = {
 export function resolveBuiltinProfiles(opts: {
   isPlatform: boolean;
   isFlagEnabled: (key: string) => boolean;
-  overrides: Record<string, BuiltinProfileOverride>;
+  overrides: Record<string, ProfileOverrideEntry>;
 }): { profiles: Record<string, ProfileEntry>; order: string[] } {
   const profiles: Record<string, ProfileEntry> = {};
   const order: string[] = [AUTO_PROFILE_KEY];
@@ -210,11 +205,7 @@ export function resolveBuiltinProfiles(opts: {
     const effective: BuiltinProfileDefinition = opts.isPlatform
       ? definition
       : { ...definition, label: `${definition.label}${MANAGED_LABEL_SUFFIX}` };
-    const entry = materializeProfile(
-      effective,
-      definition.provider,
-      definition.connectionName,
-    );
+    const entry = materializeProfile(effective);
     applyOverride(entry, opts.overrides[name]);
     profiles[name] = entry;
     order.push(name);
@@ -225,7 +216,7 @@ export function resolveBuiltinProfiles(opts: {
 
 function applyOverride(
   entry: ProfileEntry,
-  override: BuiltinProfileOverride | undefined,
+  override: ProfileOverrideEntry | undefined,
 ): void {
   if (!override) return;
   if ("label" in override) entry.label = override.label;

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -20,12 +20,12 @@ import {
 } from "./assistant-feature-flags.js";
 import {
   AUTO_PROFILE_KEY,
-  type BuiltinProfileOverride,
   isSeedDefaultBuiltinLabel,
   MANAGED_PROFILE_NAMES,
   resolveBuiltinProfiles,
 } from "./builtin-inference-profiles.js";
 import { AssistantConfigSchema } from "./schema.js";
+import type { ProfileOverrideEntry } from "./schemas/llm.js";
 import type { AssistantConfig } from "./types.js";
 
 export { API_KEY_PROVIDERS } from "../providers/provider-secret-catalog.js";
@@ -122,7 +122,7 @@ function cloneDefaultConfig(): AssistantConfig {
  * IS_PLATFORM is set by the Vellum platform launcher; local, Docker, and
  * bare-metal assistants are unaffected.
  */
-function isPlatformDeployment(): boolean {
+export function isPlatformDeployment(): boolean {
   return process.env.IS_PLATFORM === "true" || process.env.IS_PLATFORM === "1";
 }
 
@@ -394,9 +394,9 @@ export function applyBuiltinProfiles(raw: Record<string, unknown>): void {
   const profiles = ensurePlainObjectAt(llm, "profiles");
   const profileOverrides = readPlainObject(llm.profileOverrides) ?? {};
 
-  const overrides: Record<string, BuiltinProfileOverride> = {};
+  const overrides: Record<string, ProfileOverrideEntry> = {};
   for (const name of MANAGED_PROFILE_NAMES) {
-    const entry: BuiltinProfileOverride = {};
+    const entry: ProfileOverrideEntry = {};
     // Lower precedence: label/status carried on a still-materialized entry.
     collectBuiltinOverrideFields(profiles[name], entry);
     // A stale label equal to a seed default is a seeder artifact, not user
@@ -468,7 +468,7 @@ export function applyBuiltinProfiles(raw: Record<string, unknown>): void {
  */
 function collectBuiltinOverrideFields(
   value: unknown,
-  into: BuiltinProfileOverride,
+  into: ProfileOverrideEntry,
 ): void {
   const obj = readPlainObject(value);
   if (!obj) return;
@@ -801,7 +801,7 @@ export function mergeDefaultWorkspaceConfig(): DefaultWorkspaceConfigMergeResult
       delete providedProfiles[name];
       if (!entry) continue;
 
-      const override: BuiltinProfileOverride = {};
+      const override: ProfileOverrideEntry = {};
       collectBuiltinOverrideFields(entry, override);
       const droppedKeys = Object.keys(entry).filter(
         (key) => !(key in override),

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -278,8 +278,10 @@ const OpenRouterDeepPartialSchema = z.object({
 // ---------------------------------------------------------------------------
 
 /**
- * Distinguishes daemon-managed profiles (overwritten on every startup) from
- * user-created ones (never touched by the daemon).
+ * Distinguishes daemon-managed profiles (resolved at config load time from
+ * the code definitions in `config/builtin-inference-profiles.ts`, never
+ * persisted) from user-created ones (stored in `llm.profiles` and never
+ * touched by the daemon).
  */
 const ProfileSource = z.enum(["managed", "user"]);
 type ProfileSource = z.infer<typeof ProfileSource>;
@@ -390,11 +392,11 @@ export const ProfileEntry = LLMConfigFragment.extend({
   /**
    * `.nullable()` is intentional: the PUT `/v1/config/llm/profiles/:name`
    * route uses `null` as the "clear this override" sentinel for managed
-   * profiles (see `patchManagedProfileFields` in
+   * profiles (see `writeBuiltinProfileOverride` in
    * `runtime/routes/conversation-query-routes.ts`). Without `.nullable()`,
    * Zod rejects `{ label: null }` at parse time before the route handler
-   * ever sees it, and the clear-back-to-seed path is unreachable from any
-   * client. `.min(1)` still applies to string values so empty strings
+   * ever sees it, and the clear-back-to-default path is unreachable from
+   * any client. `.min(1)` still applies to string values so empty strings
    * remain rejected — `null` is the only non-string-non-undefined input
    * accepted.
    */
@@ -410,8 +412,8 @@ export const ProfileEntry = LLMConfigFragment.extend({
   /**
    * Absent means active. `.nullable()` matches `label` so the PUT route's
    * "send `null` to clear" sentinel works for status edits too — see
-   * `patchManagedProfileFields`, which has handled `status === null` since
-   * #30362 even though the schema didn't accept it until now.
+   * `writeBuiltinProfileOverride` in
+   * `runtime/routes/conversation-query-routes.ts`.
    */
   status: ProfileStatusSchema.nullable().optional(),
   /**
@@ -438,7 +440,8 @@ export type ProfileEntry = z.infer<typeof ProfileEntry>;
  * (`model`, `provider`, `maxTokens`, ...) through the override store — that
  * drift vector is exactly what built-in profiles exist to close. `.nullable()`
  * on both fields mirrors `ProfileEntry`: `null` is the "clear this override"
- * sentinel used by the PUT profile route (see `patchManagedProfileFields`).
+ * sentinel used by the PUT profile route (see `writeBuiltinProfileOverride`
+ * in `runtime/routes/conversation-query-routes.ts`).
  */
 export const ProfileOverrideEntry = z
   .object({

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -9,21 +9,20 @@ import { PROVIDER_CATALOG } from "../providers/model-catalog.js";
 import { credentialKey } from "../security/credential-key.js";
 import { getLogger } from "../util/logger.js";
 import {
-  AUTO_PROFILE_KEY,
   type BuiltinProfileDefinition,
   MANAGED_PROFILE_NAMES,
   MANAGED_PROFILE_TEMPLATES,
   materializeProfile,
 } from "./builtin-inference-profiles.js";
-import { loadRawConfig, saveRawConfig } from "./loader.js";
+import {
+  isPlatformDeployment,
+  loadRawConfig,
+  saveRawConfig,
+} from "./loader.js";
 import {
   DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS,
   type ProfileEntry,
 } from "./schemas/llm.js";
-
-// Re-exported so existing importers of the seeder keep working; the canonical
-// home for built-in profile definitions is `builtin-inference-profiles.ts`.
-export { AUTO_PROFILE_KEY, MANAGED_PROFILE_NAMES };
 
 const log = getLogger("seed-inference-profiles");
 
@@ -135,12 +134,9 @@ export function seedInferenceProfiles(
   }
   const profiles = llm.profiles as Record<string, Record<string, unknown>>;
 
-  const isPlatform =
-    process.env.IS_PLATFORM === "true" || process.env.IS_PLATFORM === "1";
-
   // BYOK mode = off-platform installs (the user brings their own provider
   // API key).
-  const isByokMode = !isPlatform;
+  const isByokMode = !isPlatformDeployment();
 
   // The personal connection a BYOK hatch will create (step 2), determined up
   // front because the status-override and activeProfile steps both depend on

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -51,7 +51,7 @@ import { resolveTrustClass } from "./trust-context.js";
 const log = getLogger("conversation-tool-setup");
 
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
-import { AUTO_PROFILE_KEY } from "../config/seed-inference-profiles.js";
+import { AUTO_PROFILE_KEY } from "../config/builtin-inference-profiles.js";
 import {
   buildSwitchInferenceProfileToolDef,
   SWITCH_INFERENCE_PROFILE_TOOL_NAME,

--- a/assistant/src/daemon/switch-inference-profile-tool.ts
+++ b/assistant/src/daemon/switch-inference-profile-tool.ts
@@ -1,5 +1,5 @@
+import { AUTO_PROFILE_KEY } from "../config/builtin-inference-profiles.js";
 import type { ProfileEntry } from "../config/schemas/llm.js";
-import { AUTO_PROFILE_KEY } from "../config/seed-inference-profiles.js";
 import type { ToolDefinition } from "../providers/types.js";
 
 export const SWITCH_INFERENCE_PROFILE_TOOL_NAME = "switch_inference_profile";

--- a/assistant/src/providers/inference/connections.ts
+++ b/assistant/src/providers/inference/connections.ts
@@ -361,7 +361,7 @@ const CANONICAL_CONNECTIONS: Array<{
  *     null on subsequent boots so pre-seed installs pick up the default; a non-null
  *     user-customized label is preserved (see `seedCanonicalConnections`).
  *
- * Mirrors `MANAGED_PROFILE_NAMES` (config/seed-inference-profiles.ts).
+ * Mirrors `MANAGED_PROFILE_NAMES` (config/builtin-inference-profiles.ts).
  */
 export const MANAGED_CONNECTION_NAMES: ReadonlySet<string> = new Set(
   CANONICAL_CONNECTIONS.map((c) => c.name),
@@ -415,4 +415,3 @@ export function seedCanonicalConnections(db: DrizzleDb): void {
       .run();
   }
 }
-

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -112,7 +112,7 @@ type LlmContextRouteResult = Omit<LlmContextNormalizationResult, "summary"> & {
   summary?: LlmContextSummaryResponse;
 };
 
-import { MANAGED_PROFILE_NAMES } from "../../config/seed-inference-profiles.js";
+import { MANAGED_PROFILE_NAMES } from "../../config/builtin-inference-profiles.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 
 const RESERVED_PROFILE_NAMES = new Set([

--- a/assistant/src/workspace/migrations/097-enable-adaptive-thinking-managed-profiles.ts
+++ b/assistant/src/workspace/migrations/097-enable-adaptive-thinking-managed-profiles.ts
@@ -28,19 +28,11 @@ const ADAPTIVE_THINKING = { enabled: true, streamThinking: true } as const;
 const TARGET_PROFILES = ["balanced", "quality-optimized"] as const;
 
 /**
- * Patch managed Anthropic profiles that are missing adaptive thinking.
- *
- * Exported so lifecycle.ts can re-run the repair after mergeDefaultWorkspaceConfig()
- * and seedInferenceProfiles(). On-platform instances with a config overlay have their
- * profiles overwritten by the overlay merge (which runs after workspace migrations),
- * so the migration alone is insufficient — the post-overlay call ensures the repair
- * sticks even when the overlay supplies profiles without thinking enabled.
- *
- * The function is idempotent: profiles that already have thinking enabled are skipped.
+ * Patch managed Anthropic profiles in the on-disk config that are missing
+ * adaptive thinking. Idempotent: profiles that already have thinking enabled
+ * are skipped.
  */
-export function repairAdaptiveThinkingOnManagedProfiles(
-  workspaceDir: string,
-): void {
+function repairAdaptiveThinkingOnManagedProfiles(workspaceDir: string): void {
   const configPath = join(workspaceDir, "config.json");
   if (!existsSync(configPath)) return;
 


### PR DESCRIPTION
## Summary
Cleanup gaps from the builtin-llm-profiles.md plan review (slop audit):
- Importers moved to the canonical builtin-inference-profiles module; back-compat re-exports deleted
- BuiltinProfileOverride deduped into ProfileOverrideEntry; materializeProfile params default to template values; createAutoProfileEntry un-exported with label hoisted to a constant
- Stale comments fixed (patchManagedProfileFields references, seeder-era docstrings, migration 097 orphaned export)
- isPlatformDeployment shared with the seeder; web daemon-config invalidation consolidated into a helper