### PR TITLE
fix(permissions): re-read threshold before prompting so Full access never asks from a stale cache

### DIFF
--- a/assistant/src/__tests__/require-fresh-approval.test.ts
+++ b/assistant/src/__tests__/require-fresh-approval.test.ts
@@ -125,6 +125,9 @@ mock.module("../tools/registry.js", () => ({
 
 mock.module("../permissions/gateway-threshold-reader.js", () => ({
   getAutoApproveThreshold: async () => "medium",
+  // Refresh failure ("null") keeps the original decision — these tests
+  // exercise the cached-threshold paths only.
+  refreshAutoApproveThreshold: async () => null,
   _clearGlobalCacheForTesting: () => {},
 }));
 

--- a/assistant/src/__tests__/tool-execution-pipeline.benchmark.test.ts
+++ b/assistant/src/__tests__/tool-execution-pipeline.benchmark.test.ts
@@ -75,6 +75,7 @@ mock.module("../util/platform.js", () => ({
 
 mock.module("../permissions/gateway-threshold-reader.js", () => ({
   getAutoApproveThreshold: async () => undefined,
+  refreshAutoApproveThreshold: async () => null,
 }));
 
 mock.module("../permissions/workspace-policy.js", () => ({

--- a/assistant/src/permissions/checker.test.ts
+++ b/assistant/src/permissions/checker.test.ts
@@ -76,8 +76,13 @@ mock.module("../util/platform.js", () => ({
 }));
 
 // Mock gateway threshold reader — return "low" by default (conversation context default).
+// `mockRefreshedThreshold` simulates the cache-bypassing refresh performed
+// before a prompt is surfaced; `null` means "refresh failed, keep decision".
+let mockCachedThreshold = "low";
+let mockRefreshedThreshold: string | null = null;
 mock.module("./gateway-threshold-reader.js", () => ({
-  getAutoApproveThreshold: async () => "low",
+  getAutoApproveThreshold: async () => mockCachedThreshold,
+  refreshAutoApproveThreshold: async () => mockRefreshedThreshold,
   _clearGlobalCacheForTesting: () => {},
 }));
 
@@ -136,6 +141,8 @@ describe("Permission Checker (gateway IPC)", () => {
     testConfig.skills = { load: { extraDirs: [] } };
     mockIsContainerized = false;
     mockIpcClassifyRiskResult = undefined;
+    mockCachedThreshold = "low";
+    mockRefreshedThreshold = null;
   });
 
   // ── classifyRisk ──────────────────────────────────────────────────────────
@@ -472,6 +479,81 @@ describe("Permission Checker (gateway IPC)", () => {
           "/home/user/project",
         ),
       ).rejects.toThrow(/Gateway IPC classify_risk failed/);
+    });
+
+    // ── Stale-threshold refresh before prompting ────────────────────────────
+    // The threshold reader caches values (5s conversation / 30s global TTL)
+    // and no write path invalidates them, so a user who just switched to
+    // Full access could still be prompted from the stale snapshot. check()
+    // must re-read the threshold fresh before surfacing a prompt.
+
+    test("re-evaluates with refreshed threshold instead of prompting (stale cache after Full access)", async () => {
+      mockIpcClassifyRiskResult = {
+        risk: "high",
+        reason: "Recursive force delete",
+        matchType: "registry",
+        scopeOptions: [],
+      };
+      mockCachedThreshold = "low"; // stale cached value
+      mockRefreshedThreshold = "high"; // user just selected Full access
+      const result = await check(
+        "bash",
+        { command: "rm -rf /tmp/stale-cache-test" },
+        "/home/user/project",
+      );
+      expect(result.decision).toBe("allow");
+      expect(result.reason).toContain("within auto-approve threshold");
+    });
+
+    test("keeps the prompt when the threshold refresh fails", async () => {
+      mockIpcClassifyRiskResult = {
+        risk: "high",
+        reason: "Recursive force delete",
+        matchType: "registry",
+        scopeOptions: [],
+      };
+      mockCachedThreshold = "low";
+      mockRefreshedThreshold = null; // gateway unreachable during refresh
+      const result = await check(
+        "bash",
+        { command: "rm -rf /tmp/refresh-failed-test" },
+        "/home/user/project",
+      );
+      expect(result.decision).toBe("prompt");
+    });
+
+    test("keeps the prompt when the refreshed threshold matches the cached one", async () => {
+      mockIpcClassifyRiskResult = {
+        risk: "high",
+        reason: "Recursive force delete",
+        matchType: "registry",
+        scopeOptions: [],
+      };
+      mockCachedThreshold = "low";
+      mockRefreshedThreshold = "low"; // no change — still below the risk
+      const result = await check(
+        "bash",
+        { command: "rm -rf /tmp/refresh-unchanged-test" },
+        "/home/user/project",
+      );
+      expect(result.decision).toBe("prompt");
+    });
+
+    test("keeps the prompt when the refreshed threshold is stricter", async () => {
+      mockIpcClassifyRiskResult = {
+        risk: "medium",
+        reason: "Network request (default)",
+        matchType: "registry",
+        scopeOptions: [],
+      };
+      mockCachedThreshold = "low";
+      mockRefreshedThreshold = "none"; // user tightened to Strict mid-flight
+      const result = await check(
+        "network_request",
+        { url: "https://api.example.com/refresh-stricter-test" },
+        "/home/user/project",
+      );
+      expect(result.decision).toBe("prompt");
     });
   });
 

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -28,7 +28,10 @@ import {
   type ApprovalContext,
   DefaultApprovalPolicy,
 } from "./approval-policy.js";
-import { getAutoApproveThreshold } from "./gateway-threshold-reader.js";
+import {
+  getAutoApproveThreshold,
+  refreshAutoApproveThreshold,
+} from "./gateway-threshold-reader.js";
 import type { RiskAssessment } from "./risk-types.js";
 import {
   type AllowlistOption,
@@ -555,7 +558,27 @@ export async function check(
   };
 
   // Delegate the allow/prompt/deny decision to the approval policy
-  const approvalDecision = defaultApprovalPolicy.evaluate(approvalContext);
+  let approvalDecision = defaultApprovalPolicy.evaluate(approvalContext);
+
+  // A "prompt" computed from a cached threshold may contradict a setting
+  // the user just changed: the reader caches thresholds (5s conversation /
+  // 30s global TTL) and no threshold write path invalidates this process's
+  // caches. Re-read the threshold fresh before interrupting the user; when
+  // the current value differs, re-evaluate so e.g. Full access never
+  // prompts. A failed refresh returns null and keeps the prompt — fail
+  // toward asking, never toward silent approval.
+  if (approvalDecision.decision === "prompt") {
+    const freshThreshold = await refreshAutoApproveThreshold(
+      policyContext?.conversationId,
+      policyContext?.executionContext,
+    );
+    if (freshThreshold !== null && freshThreshold !== threshold) {
+      approvalDecision = defaultApprovalPolicy.evaluate({
+        ...approvalContext,
+        autoApproveUpTo: freshThreshold,
+      });
+    }
+  }
 
   // Enrich the reason with the classifier's explanation when available.
   // For risk-based fallback decisions (prompt/deny from High/Medium risk),

--- a/assistant/src/permissions/gateway-threshold-reader.test.ts
+++ b/assistant/src/permissions/gateway-threshold-reader.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests for the gateway-backed threshold reader, focused on
+ * refreshAutoApproveThreshold(): the cache-bypassing re-read performed
+ * before a permission prompt is surfaced. The reader's caches (5s
+ * conversation TTL with negative caching, 30s global TTL) are never
+ * invalidated by threshold writes, so without the refresh a user who just
+ * switched to Full access could still be prompted from a stale snapshot.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Silence logger output during tests.
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// ── Controllable IPC mock ────────────────────────────────────────────────────
+
+type IpcHandler = (params?: Record<string, unknown>) => unknown;
+
+const ipcHandlers = new Map<string, IpcHandler>();
+const ipcCallLog: Array<{ method: string; params?: Record<string, unknown> }> =
+  [];
+
+mock.module("../ipc/gateway-client.js", () => ({
+  ipcCall: async (method: string, params?: Record<string, unknown>) => {
+    ipcCallLog.push({ method, params });
+    const handler = ipcHandlers.get(method);
+    return handler ? handler(params) : undefined;
+  },
+  ipcCallPersistent: async () => undefined,
+  resetPersistentClient: () => {},
+}));
+
+import {
+  _clearGlobalCacheForTesting,
+  _resetFailureCoalesceForTesting,
+  getAutoApproveThreshold,
+  refreshAutoApproveThreshold,
+} from "./gateway-threshold-reader.js";
+
+function countCalls(method: string): number {
+  return ipcCallLog.filter((c) => c.method === method).length;
+}
+
+describe("refreshAutoApproveThreshold", () => {
+  beforeEach(() => {
+    _clearGlobalCacheForTesting();
+    _resetFailureCoalesceForTesting();
+    ipcHandlers.clear();
+    ipcCallLog.length = 0;
+  });
+
+  test("bypasses a stale conversation cache and returns the fresh override", async () => {
+    // Seed the cache with "low" via the normal read path.
+    ipcHandlers.set("get_conversation_threshold", () => ({
+      threshold: "low",
+    }));
+    expect(await getAutoApproveThreshold("conv-1", "conversation")).toBe("low");
+
+    // The user switches the conversation to Full access — the gateway now
+    // returns "high", but the reader's 5s cache still holds "low".
+    ipcHandlers.set("get_conversation_threshold", () => ({
+      threshold: "high",
+    }));
+    expect(await getAutoApproveThreshold("conv-1", "conversation")).toBe("low");
+
+    // The refresh bypasses the cache and sees the new value.
+    expect(await refreshAutoApproveThreshold("conv-1", "conversation")).toBe(
+      "high",
+    );
+  });
+
+  test("primes the conversation cache so subsequent reads skip IPC", async () => {
+    ipcHandlers.set("get_conversation_threshold", () => ({
+      threshold: "high",
+    }));
+
+    expect(await refreshAutoApproveThreshold("conv-2", "conversation")).toBe(
+      "high",
+    );
+    const callsAfterRefresh = countCalls("get_conversation_threshold");
+
+    expect(await getAutoApproveThreshold("conv-2", "conversation")).toBe(
+      "high",
+    );
+    // Cache hit — no additional IPC round-trip.
+    expect(countCalls("get_conversation_threshold")).toBe(callsAfterRefresh);
+  });
+
+  test("returns null when the conversation override read fails", async () => {
+    // No handler registered → ipcCall returns undefined (transport failure).
+    expect(
+      await refreshAutoApproveThreshold("conv-3", "conversation"),
+    ).toBeNull();
+    // Must not fall through to the global read: without the override we
+    // cannot know whether the conversation is stricter than the global.
+    expect(countCalls("get_global_thresholds")).toBe(0);
+  });
+
+  test("falls through to a fresh global read when no override exists", async () => {
+    ipcHandlers.set("get_conversation_threshold", () => null);
+    ipcHandlers.set("get_global_thresholds", () => ({
+      interactive: "high",
+      autonomous: "low",
+      headless: "none",
+    }));
+
+    expect(await refreshAutoApproveThreshold("conv-4", "conversation")).toBe(
+      "high",
+    );
+  });
+
+  test("bypasses a stale global cache", async () => {
+    ipcHandlers.set("get_global_thresholds", () => ({
+      interactive: "medium",
+      autonomous: "low",
+      headless: "none",
+    }));
+    expect(await getAutoApproveThreshold(undefined, "conversation")).toBe(
+      "medium",
+    );
+
+    // The user switches the global interactive threshold to Full access —
+    // the reader's 30s global cache still holds "medium".
+    ipcHandlers.set("get_global_thresholds", () => ({
+      interactive: "high",
+      autonomous: "low",
+      headless: "none",
+    }));
+    expect(await getAutoApproveThreshold(undefined, "conversation")).toBe(
+      "medium",
+    );
+
+    expect(await refreshAutoApproveThreshold(undefined, "conversation")).toBe(
+      "high",
+    );
+
+    // The refresh primed the global cache with the fresh values.
+    expect(await getAutoApproveThreshold(undefined, "conversation")).toBe(
+      "high",
+    );
+  });
+
+  test("resolves the context-appropriate global field", async () => {
+    ipcHandlers.set("get_global_thresholds", () => ({
+      interactive: "high",
+      autonomous: "medium",
+      headless: "none",
+    }));
+
+    expect(await refreshAutoApproveThreshold("conv-5", "background")).toBe(
+      "medium",
+    );
+    expect(await refreshAutoApproveThreshold("conv-5", "headless")).toBe(
+      "none",
+    );
+    // Background/headless contexts never consult the per-conversation
+    // override, mirroring getAutoApproveThreshold.
+    expect(countCalls("get_conversation_threshold")).toBe(0);
+  });
+
+  test("returns null when the global read fails", async () => {
+    expect(
+      await refreshAutoApproveThreshold(undefined, "conversation"),
+    ).toBeNull();
+  });
+
+  test("returns null for an invalid global value", async () => {
+    ipcHandlers.set("get_global_thresholds", () => ({
+      interactive: "bogus",
+      autonomous: "low",
+      headless: "none",
+    }));
+    expect(
+      await refreshAutoApproveThreshold(undefined, "conversation"),
+    ).toBeNull();
+  });
+});

--- a/assistant/src/permissions/gateway-threshold-reader.ts
+++ b/assistant/src/permissions/gateway-threshold-reader.ts
@@ -288,3 +288,83 @@ async function fetchGlobalThresholds(): Promise<GlobalThresholds> {
   cachedGlobalTimestamp = Date.now();
   return result;
 }
+
+/**
+ * Re-read the auto-approve threshold from the gateway, bypassing both
+ * caches, and prime them with the fresh values.
+ *
+ * Used by the permission checker immediately before surfacing an
+ * interactive prompt: the cached snapshot (5s conversation TTL with
+ * negative caching, 30s global TTL) may predate a threshold change the
+ * user just made — e.g. switching to Full access — because no threshold
+ * write path invalidates these in-process caches (the web picker writes
+ * through the gateway HTTP route, the desktop picker through the
+ * `set_conversation_threshold` IPC). Prompting from a stale threshold
+ * directly contradicts the user's visible setting. A prompt is already a
+ * rare, user-visible interruption, so the extra IPC round-trip is cheap
+ * relative to a wrong prompt.
+ *
+ * Returns the freshly-resolved threshold, or `null` when the gateway
+ * could not be reached. Callers must keep their original decision on
+ * `null` — fail toward prompting, never toward silent approval. The
+ * conversation-override read failing is also treated as `null` (rather
+ * than falling through to the global threshold) because without the
+ * override we cannot know whether the conversation is configured more
+ * strictly than the global default.
+ */
+export async function refreshAutoApproveThreshold(
+  conversationId: string | undefined,
+  executionContext?: ExecutionContext,
+): Promise<Threshold | null> {
+  const ctx: ExecutionContext = executionContext ?? "conversation";
+
+  if (ctx === "conversation" && conversationId) {
+    const result = (await ipcCall("get_conversation_threshold", {
+      conversationId,
+    })) as ConversationThreshold | null | undefined;
+
+    if (result === undefined) {
+      noteFailure(
+        "conversation_threshold",
+        { conversationId },
+        "IPC call failed for conversation threshold refresh, keeping cached decision",
+      );
+      return null;
+    }
+    noteSuccess("conversation_threshold");
+    if (result && isValidThreshold(result.threshold)) {
+      conversationThresholdCache.set(conversationId, {
+        threshold: result.threshold,
+        timestamp: Date.now(),
+      });
+      return result.threshold;
+    }
+    // No override (or unexpected shape) — prime the negative cache and
+    // fall through to a fresh global read.
+    conversationThresholdCache.set(conversationId, {
+      threshold: null,
+      timestamp: Date.now(),
+    });
+  }
+
+  try {
+    const result = (await ipcCall(
+      "get_global_thresholds",
+    )) as GlobalThresholds | null;
+    if (!result) {
+      throw new Error("Gateway IPC returned no result for global thresholds");
+    }
+    noteSuccess("global_thresholds");
+    cachedGlobalThresholds = result;
+    cachedGlobalTimestamp = Date.now();
+    const value = result[mapExecutionContextToField(ctx)];
+    return isValidThreshold(value) ? value : null;
+  } catch (err) {
+    noteFailure(
+      "global_thresholds",
+      { error: String(err) },
+      "Failed to refresh global thresholds, keeping cached decision",
+    );
+    return null;
+  }
+}


### PR DESCRIPTION
Fixes JARVIS-1099 — [Asking for permission when in full access mode](https://linear.app/vellum/issue/JARVIS-1099/asking-for-permission-when-in-full-access-mode)

## Symptom

A user in Full access mode (auto-approve threshold `high` — "Your assistant will never ask for permission") still receives permission prompts. Reported on Platform · production · client 0.8.4.

## Root cause

The daemon resolves the auto-approve threshold through `getAutoApproveThreshold()` in `assistant/src/permissions/gateway-threshold-reader.ts`, which serves cached values:

- per-conversation override: **5s TTL with negative caching** (`conversationThresholdCache`)
- global thresholds: **30s TTL** (`cachedGlobalThresholds`)

No threshold write path invalidates these in-process caches:

- the web composer picker and Settings page write through the gateway HTTP routes (`gateway/src/http/routes/auto-approve-thresholds.ts`) — a different process;
- the desktop picker writes through `set_conversation_threshold` IPC from `messages_post` (`assistant/src/runtime/routes/conversation-routes.ts:1305`), which goes daemon → gateway DB and never touches the reader's cache.

So the natural flow — assistant prompts → user switches to Full access → user retries / lets the turn continue — re-evaluates tool calls against the **stale stricter snapshot** for up to 5s (conversation, including a stale "no override" negative entry) or 30s (global), and `check()` (`assistant/src/permissions/checker.ts`) surfaces another prompt that directly contradicts the user's visible setting.

## Fix

When the approval policy resolves to `prompt`, re-read the threshold from the gateway **bypassing both caches** (new `refreshAutoApproveThreshold()`), prime the caches with the fresh values, and re-evaluate the policy if the threshold changed. Properties:

- **No behavior change for allow/deny decisions** — the refresh runs only on the prompt path, which is already a rare, user-visible interruption, so the extra IPC round-trip is negligible.
- **Fail toward asking, never toward silent approval** — any refresh failure (gateway unreachable, invalid value) returns `null` and the original prompt stands. A failed conversation-override read is also treated as a failed refresh rather than falling through to the global threshold, because without the override we can't know whether the conversation is configured more strictly than the global default.
- **No new approval modes** — this respects the existing risk-threshold model (permission-controls-v2 rule); deny rules and the `skill_load_dynamic` always-prompt exception are unaffected because the re-evaluation goes through the same `DefaultApprovalPolicy`.

## Testing

- New `assistant/src/permissions/gateway-threshold-reader.test.ts` — 8 tests covering cache bypass, cache priming, fail-closed null returns, context-field resolution.
- `assistant/src/permissions/checker.test.ts` — 4 new `check()` tests: stale-cache → refreshed `high` allows instead of prompting; refresh failure keeps prompt; unchanged refresh keeps prompt; stricter refresh keeps prompt.
- All affected test files pass in isolation (matching CI's per-file process isolation): `gateway-threshold-reader.test.ts`, `permissions/checker.test.ts`, `approval-policy.test.ts`, `__tests__/checker.test.ts`, `__tests__/require-fresh-approval.test.ts`, `__tests__/inline-skill-load-permissions.test.ts`, `__tests__/tool-execution-pipeline.benchmark.test.ts`.
- `bunx tsc --noEmit` clean; eslint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)