### PR TITLE
fix(design-library): make katex a peer dependency

### DIFF
--- a/packages/design-library/bun.lock
+++ b/packages/design-library/bun.lock
@@ -4,9 +4,6 @@
   "workspaces": {
     "": {
       "name": "@vellumai/design-library",
-      "dependencies": {
-        "katex": "0.17.0",
-      },
       "devDependencies": {
         "@playwright/browser-chromium": "1.60.0",
         "@radix-ui/react-accordion": "1.2.12",
@@ -36,6 +33,7 @@
         "@vitest/runner": "4.1.6",
         "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",
+        "katex": "0.16.47",
         "lucide-react": "1.16.0",
         "playwright": "1.60.0",
         "react": "19.2.6",
@@ -67,6 +65,7 @@
         "@radix-ui/react-tooltip": ">=1.2.0",
         "class-variance-authority": ">=0.7.0",
         "clsx": ">=2.1.0",
+        "katex": ">=0.16.0",
         "lucide-react": ">=1.16.0",
         "react": ">=19.0.0",
         "react-dom": ">=19.0.0",
@@ -744,7 +743,7 @@
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
-    "katex": ["katex@0.17.0", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-Vdw0ATsQ9V+LuegM/BTwQqV/6cTl5lbGcIrU+BCgLxyf6bo38ybOr372tuSIxir3CN720flu1meYR6XzNMwQnw=="],
+    "katex": ["katex@0.16.47", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg=="],
 
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
@@ -1162,13 +1161,9 @@
 
     "ast-v8-to-istanbul/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
-    "micromark-extension-math/katex": ["katex@0.16.47", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg=="],
-
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "redent/strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
-
-    "rehype-katex/katex": ["katex@0.16.47", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg=="],
 
     "rolldown/@oxc-project/types": ["@oxc-project/types@0.128.0", "", {}, "sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ=="],
 

--- a/packages/design-library/bun.lock
+++ b/packages/design-library/bun.lock
@@ -65,7 +65,7 @@
         "@radix-ui/react-tooltip": ">=1.2.0",
         "class-variance-authority": ">=0.7.0",
         "clsx": ">=2.1.0",
-        "katex": ">=0.16.0",
+        "katex": "^0.16.0",
         "lucide-react": ">=1.16.0",
         "react": ">=19.0.0",
         "react-dom": ">=19.0.0",

--- a/packages/design-library/package.json
+++ b/packages/design-library/package.json
@@ -36,6 +36,7 @@
     "@radix-ui/react-tooltip": ">=1.2.0",
     "class-variance-authority": ">=0.7.0",
     "clsx": ">=2.1.0",
+    "katex": ">=0.16.0",
     "lucide-react": ">=1.16.0",
     "react": ">=19.0.0",
     "react-dom": ">=19.0.0",
@@ -78,6 +79,7 @@
     "@vitest/runner": "4.1.6",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
+    "katex": "0.16.47",
     "lucide-react": "1.16.0",
     "playwright": "1.60.0",
     "react": "19.2.6",
@@ -94,8 +96,5 @@
     "unified": "11.0.5",
     "vite": "8.0.11",
     "vitest": "4.1.6"
-  },
-  "dependencies": {
-    "katex": "0.17.0"
   }
 }

--- a/packages/design-library/package.json
+++ b/packages/design-library/package.json
@@ -36,7 +36,7 @@
     "@radix-ui/react-tooltip": ">=1.2.0",
     "class-variance-authority": ">=0.7.0",
     "clsx": ">=2.1.0",
-    "katex": ">=0.16.0",
+    "katex": "^0.16.0",
     "lucide-react": ">=1.16.0",
     "react": ">=19.0.0",
     "react-dom": ">=19.0.0",


### PR DESCRIPTION
ref ATL-789

We have *grand* ambitions to publish `design-library` as an actual package some day, so we should keep things as peerdeps where possible.

Our installation of `design-library` has two distinct katex versions. We import a stylesheet from katex `0.17.0` but render math using `rehype-katex` which depends on `katex@^0.16`.

Note that `web` itself has *additional* katex deps that we might be able to remove. I don't think we're actually using/resolving peer deps correctly with the `file:` install approach, which is a separate issue. This change is more about cleanup for publishing this package.