### PR TITLE
fix: report raw payload download failures and tidy invoices test

### DIFF
--- a/apps/web/src/domains/chat/inspector/components/tabs/raw-tab.tsx
+++ b/apps/web/src/domains/chat/inspector/components/tabs/raw-tab.tsx
@@ -2,8 +2,10 @@ import { AlertCircle, Copy, Download, RefreshCw } from "lucide-react";
 import { useState, type ReactNode } from "react";
 
 import { useLlmLogPayload } from "@/domains/chat/inspector/inspector-payload-api";
+import { captureError } from "@/lib/sentry/capture-error";
 import type { LLMRequestLogEntry } from "@vellumai/assistant-api";
 import { Button, Card } from "@vellumai/design-library";
+import { toast } from "@vellumai/design-library/components/toast";
 
 type RawPane = "request" | "response";
 
@@ -125,9 +127,14 @@ async function downloadRawPayload(
   text: string,
   filename: string,
 ): Promise<void> {
-  const blob = new Blob([text], { type: "application/json;charset=utf-8" });
-  const { saveFile } = await import("@/runtime/native-file");
-  await saveFile(blob, filename);
+  try {
+    const blob = new Blob([text], { type: "application/json;charset=utf-8" });
+    const { saveFile } = await import("@/runtime/native-file");
+    await saveFile(blob, filename);
+  } catch (error) {
+    captureError(error, { context: "download_raw_payload" });
+    toast.error("Failed to download the payload.");
+  }
 }
 
 function LoadingState(): ReactNode {

--- a/apps/web/src/domains/settings/components/invoices-modal.test.tsx
+++ b/apps/web/src/domains/settings/components/invoices-modal.test.tsx
@@ -19,8 +19,7 @@ function okDownloadResult(): DownloadResult {
 }
 
 let downloadRetrieveCalls = 0;
-let downloadRetrieveResult: () => Promise<DownloadResult> = async () =>
-  okDownloadResult();
+let downloadRetrieveResult: () => Promise<DownloadResult>;
 
 mock.module("@/generated/api/sdk.gen", () => ({
   ...sdkGen,
@@ -92,7 +91,9 @@ function renderModal(): ReturnType<typeof render> {
 function getDownloadAllButton(
   result: ReturnType<typeof render>,
 ): HTMLButtonElement {
-  return result.getByText("Download all").closest("button")!;
+  return result.getByRole("button", {
+    name: "Download all",
+  }) as HTMLButtonElement;
 }
 
 beforeEach(() => {

--- a/apps/web/src/domains/settings/components/invoices-modal.tsx
+++ b/apps/web/src/domains/settings/components/invoices-modal.tsx
@@ -112,12 +112,6 @@ export function InvoicesModal({ open, onOpenChange }: InvoicesModalProps) {
     (invoice) => invoice.invoice_pdf != null,
   );
 
-  /**
-   * Download every invoice PDF as a single server-assembled zip. Stripe's
-   * `invoice_pdf` URLs don't serve CORS headers, so the archive must be built
-   * server-side; the SDK call routes through the platform client so the
-   * interceptor attaches the org/session headers.
-   */
   async function downloadAllInvoices(): Promise<void> {
     setIsDownloadingAll(true);
     try {


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for invoices-zip-download.md.

**Gap:** downloadRawPayload's saveFile migration left rejections unhandled (no toast/Sentry) — wrapped in try/catch with captureError + toast.error per CONVENTIONS.md.
**Also:** removed narrating JSDoc on downloadAllInvoices; deduplicated a test mock default; switched the test's button query to the getByRole idiom.