### PR TITLE
fix: keep getConfigReadOnly side-effect-free and treat null status as redundant override

### DIFF
--- a/assistant/src/__tests__/config-loader-corrupt.test.ts
+++ b/assistant/src/__tests__/config-loader-corrupt.test.ts
@@ -61,6 +61,11 @@ function listQuarantinedFiles(): string[] {
   );
 }
 
+/** Sorted recursive listing of every path under the workspace dir. */
+function snapshotWorkspaceTree(): string[] {
+  return readdirSync(WORKSPACE_DIR, { recursive: true }).map(String).sort();
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -297,6 +302,17 @@ describe("getConfigReadOnly corrupt-file recovery", () => {
     "returns defaults when config.json contains %s, without quarantining",
     (_label, jsonText) => {
       writeFileSync(CONFIG_PATH, jsonText);
+      // The contract also covers the logs dir: the shared `log` is a lazy
+      // proxy whose first call creates `data/logs/` and the day's log file,
+      // so this code path must not log at all. (Under BUN_TEST the logger
+      // routes to stderr, so the snapshot below can't observe a logger
+      // regression directly — it guards every other filesystem side effect
+      // and documents the contract.)
+      rmSync(join(WORKSPACE_DIR, "data", "logs"), {
+        recursive: true,
+        force: true,
+      });
+      const before = snapshotWorkspaceTree();
 
       // Must not throw — CLI program construction depends on this.
       const config = getConfigReadOnly();
@@ -305,6 +321,11 @@ describe("getConfigReadOnly corrupt-file recovery", () => {
       expect(config.memory).toBeDefined();
       expect(listQuarantinedFiles()).toHaveLength(0);
       expect(readFileSync(CONFIG_PATH, "utf-8")).toBe(jsonText);
+      // Side-effect-free: nothing anywhere in the workspace was created,
+      // removed, or renamed — no quarantine, no default-config write, no
+      // data/ or logs dirs.
+      expect(existsSync(join(WORKSPACE_DIR, "data", "logs"))).toBe(false);
+      expect(snapshotWorkspaceTree()).toEqual(before);
     },
   );
 

--- a/assistant/src/__tests__/managed-profile-guard.test.ts
+++ b/assistant/src/__tests__/managed-profile-guard.test.ts
@@ -147,10 +147,12 @@ describe("PUT /v1/config/llm/profiles/:name — managed profile guard", () => {
   // -------------------------------------------------------------------------
   // Built-in label/status edits persist as sparse `llm.profileOverrides`
   // entries; nothing is ever written under `llm.profiles` for a built-in
-  // name. Null is the "explicitly cleared" sentinel: it is stored as-is so
-  // the merge layer masks any stale label/status still carried by a
-  // transition-state materialized entry. An absent key leaves the existing
-  // override key untouched.
+  // name. Null is the "explicitly cleared" sentinel: it is stored when the
+  // merge layer needs it to mask a stale label/status still carried by a
+  // transition-state materialized entry, and otherwise just removes any
+  // stored override key (for `status`, an absent and an "active" baseline
+  // are both already equivalent to cleared). An absent key leaves the
+  // existing override key untouched.
   // -------------------------------------------------------------------------
 
   test("PUT { label: 'X' } lands in profileOverrides, leaving llm.profiles untouched", async () => {
@@ -204,7 +206,7 @@ describe("PUT /v1/config/llm/profiles/:name — managed profile guard", () => {
     });
   });
 
-  test("PUT { status: null } clears status, leaving other override keys untouched", async () => {
+  test("PUT { status: null } removes the stored status key, leaving other override keys untouched", async () => {
     savedRaw = null;
     rawConfig = {
       llm: {
@@ -222,11 +224,12 @@ describe("PUT /v1/config/llm/profiles/:name — managed profile guard", () => {
     });
     expect(result).toEqual({ ok: true });
     const saved = savedRaw as unknown as Record<string, any>;
-    // status cleared to the null sentinel; the absent label key left the
-    // existing label override alone.
+    // The materialized entry carries no status, so the no-override baseline
+    // is already active-by-absence: clearing removes the stored "disabled"
+    // key outright rather than storing a redundant null sentinel. The
+    // absent label key left the existing label override alone.
     expect(saved.llm.profileOverrides["quality-optimized"]).toEqual({
       label: "Keep Me",
-      status: null,
     });
   });
 
@@ -245,9 +248,11 @@ describe("PUT /v1/config/llm/profiles/:name — managed profile guard", () => {
     });
     expect(result).toEqual({ ok: true });
     const saved = savedRaw as unknown as Record<string, any>;
+    // label null masks the template default, so it persists as the
+    // sentinel; status null against an absent baseline just removes the
+    // stored "disabled" key.
     expect(saved.llm.profileOverrides["cost-optimized"]).toEqual({
       label: null,
-      status: null,
     });
   });
 

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -1122,13 +1122,11 @@ export function getConfigReadOnly(): AssistantConfig {
     if (!isPlainObject(parsed)) {
       // Same top-level-shape contract as `loadConfig`: a `null`, primitive,
       // or array would TypeError inside `validateWithBuiltinProfiles`
-      // (`ensurePlainObjectAt(raw, "llm")`). Fall back to defaults like the
-      // parse-error path above — but never quarantine here: this accessor
-      // must stay read-only and side-effect-free; `loadConfig` owns
-      // quarantining on the next full load.
-      log.warn(
-        `config.json must contain a JSON object at the top level; got ${describeJsonShape(parsed)} — using defaults`,
-      );
+      // (`ensurePlainObjectAt(raw, "llm")`). Fall back to defaults silently,
+      // like the parse-error path above — no logging here: the logger is a
+      // lazy proxy whose first call creates the logs directory and file,
+      // which would violate this accessor's side-effect-free contract.
+      // `loadConfig` owns warning and quarantining on the next full load.
       return cloneDefaultConfig();
     }
     fileConfig = parsed;

--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -916,6 +916,79 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
       expect(got.llm.profiles.balanced.label).toBeNull();
     });
 
+    test("macOS-style PUT { label, status: null } persists only the label when no status override exists", async () => {
+      // macOS `setManagedProfilePolicy` always sends both keys, with
+      // `status: null` for an active profile. With no stored status
+      // override and a baseline that resolves active, the null is
+      // redundant — persisting it would store a pointless sentinel on
+      // every label rename.
+      const result = await replaceProfileRoute.handler({
+        pathParams: { name: "balanced" },
+        body: { label: "My Balanced", status: null },
+      });
+
+      expect(result).toEqual({ ok: true });
+      const savedLlm = savedRawConfig?.llm as Record<
+        string,
+        Record<string, Record<string, unknown>>
+      >;
+      expect(savedLlm.profileOverrides.balanced).toEqual({
+        label: "My Balanced",
+      });
+    });
+
+    test("PUT { status: null } removes a stored disabled override instead of storing null", async () => {
+      await replaceProfileRoute.handler({
+        pathParams: { name: "balanced" },
+        body: { status: "disabled" },
+      });
+      const result = await replaceProfileRoute.handler({
+        pathParams: { name: "balanced" },
+        body: { status: null },
+      });
+
+      expect(result).toEqual({ ok: true });
+      // The cleared status was the entry's only key, so the entry (and the
+      // then-empty map) is pruned rather than left holding `status: null`.
+      const savedLlm = savedRawConfig?.llm as Record<string, unknown>;
+      expect(savedLlm.profileOverrides).toBeUndefined();
+
+      // Effective view: back to the no-override baseline (active).
+      const got = (await getConfigRoute.handler({})) as {
+        llm: { profiles: Record<string, Record<string, unknown>> };
+      };
+      expect(got.llm.profiles.balanced.status).toBe("active");
+    });
+
+    test("PUT { status: null } stores the null sentinel when it masks a materialized disabled lift", async () => {
+      // Transition-state install: the materialized entry on disk carries
+      // `status: "disabled"`, which lifts into the no-override baseline.
+      // Here null is NOT redundant — it must be stored to mask the lift.
+      (
+        rawConfigFixture.llm as {
+          profiles: Record<string, Record<string, unknown>>;
+        }
+      ).profiles.balanced.status = "disabled";
+
+      const result = await replaceProfileRoute.handler({
+        pathParams: { name: "balanced" },
+        body: { status: null },
+      });
+
+      expect(result).toEqual({ ok: true });
+      const savedLlm = savedRawConfig?.llm as Record<
+        string,
+        Record<string, Record<string, unknown>>
+      >;
+      expect(savedLlm.profileOverrides.balanced).toEqual({ status: null });
+
+      // Effective view: the sentinel wins over the lifted "disabled".
+      const got = (await getConfigRoute.handler({})) as {
+        llm: { profiles: Record<string, Record<string, unknown>> };
+      };
+      expect(got.llm.profiles.balanced.status).toBeNull();
+    });
+
     test("rejects provider edit on managed profile with disallowed-keys error", async () => {
       // The handler is `async`, so synchronous BadRequest throws still
       // surface as a rejected promise; assert via `.rejects.toThrow`.

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -1297,7 +1297,9 @@ async function handleReplaceInferenceProfile({
  * - Any other present key is stored. A key present with `null` therefore
  *   stores the null sentinel ("explicitly cleared" — it masks any stale
  *   label/status still carried by a transition-state materialized entry at
- *   merge time) whenever the no-override resolution differs from `null`.
+ *   merge time) whenever the no-override resolution isn't already equivalent
+ *   to the cleared state (for `status`, absent and "active" both are — see
+ *   `isRedundantBuiltinOverride`).
  * - An absent key leaves the existing override key untouched.
  * - An entry (or the whole map) left with no keys is deleted.
  *
@@ -1354,8 +1356,17 @@ function isRedundantBuiltinOverride(
   const resolved = baseline?.[key];
   if (value === resolved) return true;
   // `status` has no template default — absence means active — so writing
-  // "active" over an absent default is equally redundant.
-  return key === "status" && value === "active" && resolved === undefined;
+  // "active" over an absent default is equally redundant. The explicit-clear
+  // sentinel `null` also resolves to active behavior at merge time, so it is
+  // redundant against the same baselines (macOS always sends `status: null`
+  // for active profiles, e.g. on a plain label rename). When the baseline
+  // resolves a real lifted status (e.g. a transition-state materialized
+  // "disabled" entry), `null` is NOT redundant — storing it masks the lift.
+  return (
+    key === "status" &&
+    (value === "active" || value === null) &&
+    (resolved === undefined || resolved === "active")
+  );
 }
 
 function handleSearchConversations({ queryParams = {} }: RouteHandlerArgs) {

--- a/assistant/src/runtime/routes/inference-provider-connection-routes.ts
+++ b/assistant/src/runtime/routes/inference-provider-connection-routes.ts
@@ -234,7 +234,10 @@ async function handleCreateConnection({ body = {} }: RouteHandlerArgs) {
     );
   }
 
-  const customFields = await parseCustomProviderFields(body, providerResult.data);
+  const customFields = await parseCustomProviderFields(
+    body,
+    providerResult.data,
+  );
 
   const result = createConnection(getDb(), {
     name,
@@ -365,8 +368,10 @@ function handleDeleteConnection({ pathParams = {} }: RouteHandlerArgs) {
   // Managed connections are write-protected: `seedCanonicalConnections` would
   // re-upsert them on the next daemon boot anyway, so a successful delete here
   // produces a confusing delete → reappear loop. Reject outright. Mirrors
-  // `rejectManagedProfileDeletion` for managed profiles (which are similarly
-  // re-overlaid by `seed-inference-profiles.ts` on boot).
+  // `rejectManagedProfileDeletion` for managed profiles (which are
+  // code-defined and merged into the effective config by
+  // `applyBuiltinProfiles` on every config load, so a delete could never
+  // stick either).
   if (MANAGED_CONNECTION_NAMES.has(name)) {
     throw new BadRequestError(
       `Cannot delete managed connection "${name}". This is a Vellum-managed connection that is re-seeded on every startup.`,

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -3555,33 +3555,37 @@ public final class SettingsStore: ObservableObject {
 
     /// Persists the two policy-edit fields (`label`, `status`) for a
     /// managed profile via the `PUT /v1/config/llm/profiles/<name>` route.
-    /// Used by view-mode Save on managed profiles: the daemon's route
-    /// detects `MANAGED_PROFILE_NAMES` and applies a partial overlay (label/
-    /// status only, every other seed field preserved) instead of the full
-    /// UI-replace cycle that `replaceProfile` triggers. Sending any other
-    /// field for a managed name causes the daemon to reject the request
-    /// with a 400 — see `handleReplaceInferenceProfile` in
+    /// Used by view-mode Save on managed profiles: built-in profiles are
+    /// code-defined on the daemon side, so the route persists only the
+    /// user-ownable facets (`label`/`status`) as a sparse entry under
+    /// `llm.profileOverrides` — template fields (provider, model, advanced
+    /// params) are never written. Sending any other field for a managed
+    /// name causes the daemon to reject the request with a 400 — see
+    /// `handleReplaceInferenceProfile` / `writeBuiltinProfileOverride` in
     /// `assistant/src/runtime/routes/conversation-query-routes.ts`.
     ///
-    /// `label` and `status` use a nil-as-clear convention so the wire shape
-    /// matches the daemon's `patchManagedProfileFields` semantics. Both
-    /// `ProfileEntry.label` and `ProfileEntry.status` are now
-    /// `.nullable().optional()` in the daemon Zod schema (landed in #30387 —
-    /// see `assistant/src/config/schemas/llm.ts`), so `null` is the explicit
-    /// "clear this override" sentinel:
-    /// - `nil` / whitespace-only `label` → request body has `label: null`,
-    ///   daemon deletes the `label` key on disk and the profile renders
-    ///   without a custom label (local cache also mirrors `nil`).
-    /// - `nil` / empty `status` → request body has `status: null`, daemon
-    ///   deletes the `status` key on disk; the profile is then considered
+    /// `label` and `status` use a nil-as-clear convention: `null` on the
+    /// wire is the explicit "clear my override" sentinel (both fields are
+    /// `.nullable().optional()` in the daemon Zod schema — see
+    /// `assistant/src/config/schemas/llm.ts`):
+    /// - `nil` / whitespace-only `label` → request body has `label: null`;
+    ///   the daemon removes any stored label override (or stores `null` to
+    ///   mask a stale lifted label) and the profile renders without a
+    ///   custom label (local cache also mirrors `nil`).
+    /// - `nil` / empty `status` → request body has `status: null`; the
+    ///   daemon removes any stored status override, and skips persisting
+    ///   anything when no override exists — the profile is then considered
     ///   active by absence (matches `setProfileStatus`'s local convention).
-    /// - non-nil values are stored verbatim.
+    /// - non-nil values are stored verbatim in the override entry, unless
+    ///   they match the daemon's no-override baseline (redundant values are
+    ///   not persisted, so template relabels keep flowing through).
     ///
     /// On success the local `profiles` cache is patched in place so the UI
     /// reflects the new values without waiting for the next daemon config
     /// push. Only `label` and `status` are touched in the local entry —
     /// every other field on the cached profile (provider, model, advanced
-    /// params) is preserved, mirroring the daemon-side partial overlay.
+    /// params) is preserved, mirroring the daemon-side overrides-only
+    /// persistence.
     @discardableResult
     func setManagedProfilePolicy(
         name: String,

--- a/clients/macos/vellum-assistantTests/Features/Settings/SettingsStoreInferenceProfilesTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/SettingsStoreInferenceProfilesTests.swift
@@ -1078,11 +1078,13 @@ final class SettingsStoreInferenceProfilesTests: XCTestCase {
     }
 
     /// `nil` / whitespace-only `label` and `status` → wire serializes as
-    /// `NSNull` (= JSON null) so the daemon's `patchManagedProfileFields`
-    /// route applies the null-clear sentinel from #30362, deleting the
-    /// `label` / `status` key on disk. The daemon schema change in #30387
-    /// (`.nullable()` on both fields) is what makes this reachable
-    /// end-to-end.
+    /// `NSNull` (= JSON null), the explicit "clear my override" sentinel
+    /// for the PUT profile route. Built-in profiles are code-defined on the
+    /// daemon and only `label`/`status` deviations persist as sparse
+    /// `llm.profileOverrides` entries, so `null` removes the stored
+    /// override key (or is itself stored when it must mask a stale lifted
+    /// value) — see `writeBuiltinProfileOverride` in
+    /// `assistant/src/runtime/routes/conversation-query-routes.ts`.
     func testSetManagedProfilePolicySendsNullForClearedLabelAndStatus() async {
         store.loadInferenceProfiles(config: [
             "llm": [


### PR DESCRIPTION
## Summary
Round-2 review residuals for builtin-llm-profiles.md:
- Drop the log.warn from getConfigReadOnly's wrong-shape fallback (lazy logger init created the log file, violating the documented side-effect-free contract)
- PUT profile route: explicit null status with no stored/baseline status is no longer persisted as a pointless sentinel (macOS sends status:null on label renames); null-clear semantics preserved
- Stale comments updated (seeder re-overlay claim in inference-provider-connection-routes.ts; patchManagedProfileFields references in macOS SettingsStore + tests)