### PR TITLE
fix(web): show schedule costs with 2 decimal places in settings

### DIFF
--- a/apps/web/src/domains/settings/pages/schedules-page.test.ts
+++ b/apps/web/src/domains/settings/pages/schedules-page.test.ts
@@ -255,7 +255,7 @@ describe("SystemTaskDetailView", () => {
     );
 
     await waitFor(() =>
-      expect(document.body.textContent).toContain("$0.1234"),
+      expect(document.body.textContent).toContain("$0.12"),
     );
     expect(screen.getByRole("button", { name: /Run now/i })).toBeTruthy();
     expect(document.body.textContent).not.toContain(

--- a/apps/web/src/domains/settings/pages/schedules-page.test.ts
+++ b/apps/web/src/domains/settings/pages/schedules-page.test.ts
@@ -178,7 +178,7 @@ describe("formatScheduleCost", () => {
   test("formats zero, cents, and tiny nonzero costs", () => {
     expect(formatScheduleCost(0)).toBe("$0.00");
     expect(formatScheduleCost(0.42)).toBe("$0.42");
-    expect(formatScheduleCost(0.0034)).toBe("$0.0034");
+    expect(formatScheduleCost(0.0034)).toBe("$0.00");
   });
 
   test("falls back when cost is missing or invalid", () => {

--- a/apps/web/src/domains/settings/utils/schedule-formatters.ts
+++ b/apps/web/src/domains/settings/utils/schedule-formatters.ts
@@ -39,7 +39,7 @@ const costFormatter = new Intl.NumberFormat(undefined, {
   style: "currency",
   currency: "USD",
   minimumFractionDigits: 2,
-  maximumFractionDigits: 4,
+  maximumFractionDigits: 2,
 });
 
 export function formatScheduleCost(cost: number | null | undefined): string {


### PR DESCRIPTION
## Summary
- Cap `formatScheduleCost` at 2 decimal places (`maximumFractionDigits: 4` → `2`) in `apps/web/src/domains/settings/utils/schedule-formatters.ts`, matching the other cost displays in settings (billing panel, auto-top-up card)
- Update the test expectation for tiny nonzero costs (`$0.0034` → `$0.00`)

## Original prompt
In the schedules UI in settings we show the cost of schedules with 4 decimal places. We should change it to 2.