### PR TITLE
fix(auth): close login races in the Electron OAuth handoff

### DIFF
--- a/apps/web/src/domains/settings/ai/email-service-card.tsx
+++ b/apps/web/src/domains/settings/ai/email-service-card.tsx
@@ -12,6 +12,7 @@ import {
     assistantsListOptions,
 } from "@/generated/api/@tanstack/react-query.gen";
 import { credentialsInspectPost } from "@/generated/daemon/sdk.gen";
+import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import { usePlatformGate } from "@/hooks/use-platform-gate";
 import { captureError } from "@/lib/sentry/capture-error";
 import { useEnvironmentStore } from "@/stores/environment-store";
@@ -34,7 +35,11 @@ export function EmailServiceCard() {
   const assistantId = useActiveAssistantId();
 
   // assistantHandle is platform-only; used to pre-fill the email subdomain.
-  const { data: assistantList } = useQuery(assistantsListOptions());
+  const isOrgReady = useIsOrgReady();
+  const { data: assistantList } = useQuery({
+    ...assistantsListOptions(),
+    enabled: isOrgReady,
+  });
   const assistantHandle = assistantList?.results?.[0]?.handle;
 
   const emailRootDomain = useEnvironmentStore.use.emailRootDomain();

--- a/apps/web/src/domains/settings/components/panels/assistant-lifecycle-panel.tsx
+++ b/apps/web/src/domains/settings/components/panels/assistant-lifecycle-panel.tsx
@@ -10,6 +10,7 @@ import {
     assistantsListOptions,
 } from "@/generated/api/@tanstack/react-query.gen";
 import type { Assistant } from "@/generated/api/types.gen";
+import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import { Button } from "@vellumai/design-library/components/button";
 import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
 import { Tag } from "@vellumai/design-library/components/tag";
@@ -19,14 +20,17 @@ export function AssistantLifecyclePanel() {
   const queryClient = useQueryClient();
   const [hatching, setHatching] = useState(false);
   const [hatchConfirmOpen, setHatchConfirmOpen] = useState(false);
+  const isOrgReady = useIsOrgReady();
 
-  const { data: assistant, isLoading: assistantLoading } = useQuery(
-    assistantsActiveRetrieveOptions(),
-  );
+  const { data: assistant, isLoading: assistantLoading } = useQuery({
+    ...assistantsActiveRetrieveOptions(),
+    enabled: isOrgReady,
+  });
 
-  const { data: assistantsList, isLoading: listLoading } = useQuery(
-    assistantsListOptions({ query: { hosting: "all" } }),
-  );
+  const { data: assistantsList, isLoading: listLoading } = useQuery({
+    ...assistantsListOptions({ query: { hosting: "all" } }),
+    enabled: isOrgReady,
+  });
 
   const loading = assistantLoading || listLoading;
   const allAssistants = assistantsList?.results ?? [];

--- a/apps/web/src/runtime/native-auth.ts
+++ b/apps/web/src/runtime/native-auth.ts
@@ -11,6 +11,7 @@ import { isPlatformLocal, startLoopbackAuth } from "@/lib/auth/loopback-auth";
 import { isLocalMode } from "@/lib/local-mode";
 import { isElectron } from "@/runtime/is-electron";
 import { setMenuPlatformSession } from "@/runtime/menu";
+import { primeElectronSessionToken } from "@/runtime/session-token";
 import { isBiometricEnabled, storeBiometricToken } from "@/runtime/native-biometric";
 import { routes } from "@/utils/routes";
 
@@ -46,6 +47,15 @@ const NativeAuth = registerPlugin<NativeAuthPlugin>("NativeAuth");
 
 /** Fallback destination after a successful native login. */
 const DEFAULT_POST_AUTH_DESTINATION = routes.assistant;
+
+// True while the Electron OAuth flow awaits its deep-link callback. The
+// redirect refocuses the window before the code exchange finishes, so the
+// auth store skips app-resume session probes while this is set.
+let oauthFlowInFlight = false;
+
+export function isOAuthFlowInFlight(): boolean {
+  return oauthFlowInFlight;
+}
 
 /**
  * Origin to present to the native OAuth flow. The Capacitor shell's
@@ -257,20 +267,26 @@ export async function startAuthFlow(
   // install) and returns the session token. Falls through to the web
   // form-POST path when the bridge method is absent (older preload).
   if (isElectron() && window.vellum?.auth?.startOAuth) {
-    const result = await window.vellum.auth.startOAuth({
-      providerHint: options.providerHint,
-      loginHint: options.loginHint,
-      intent: options.intent,
-    });
-    if (result?.sessionToken) {
-      await setMenuPlatformSession(true);
-      const destination = sanitizeReturnTo(
-        options.intent === "signup"
-          ? routes.onboarding.privacy
-          : options.returnTo ?? null,
-        DEFAULT_POST_AUTH_DESTINATION,
-      );
-      window.location.href = destination;
+    oauthFlowInFlight = true;
+    try {
+      const result = await window.vellum.auth.startOAuth({
+        providerHint: options.providerHint,
+        loginHint: options.loginHint,
+        intent: options.intent,
+      });
+      if (result?.sessionToken) {
+        primeElectronSessionToken(result.sessionToken);
+        await setMenuPlatformSession(true);
+        const destination = sanitizeReturnTo(
+          options.intent === "signup"
+            ? routes.onboarding.privacy
+            : options.returnTo ?? null,
+          DEFAULT_POST_AUTH_DESTINATION,
+        );
+        window.location.href = destination;
+      }
+    } finally {
+      oauthFlowInFlight = false;
     }
     return;
   }

--- a/apps/web/src/runtime/session-token.test.ts
+++ b/apps/web/src/runtime/session-token.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import {
   __resetForTesting,
   getElectronSessionToken,
+  primeElectronSessionToken,
 } from "@/runtime/session-token";
 
 function setBridge(token: string | null, calls?: { count: number }): void {
@@ -42,5 +43,22 @@ describe("getElectronSessionToken", () => {
   test("returns null when the bridge reports no token", () => {
     setBridge(null);
     expect(getElectronSessionToken()).toBeNull();
+  });
+
+  test("caches a null seed without re-reading the bridge", () => {
+    const calls = { count: 0 };
+    setBridge(null, calls);
+
+    expect(getElectronSessionToken()).toBeNull();
+    expect(getElectronSessionToken()).toBeNull();
+    expect(calls.count).toBe(1);
+  });
+
+  test("priming replaces a stale signed-out seed", () => {
+    setBridge(null);
+    expect(getElectronSessionToken()).toBeNull();
+
+    primeElectronSessionToken("tok");
+    expect(getElectronSessionToken()).toBe("tok");
   });
 });

--- a/apps/web/src/runtime/session-token.ts
+++ b/apps/web/src/runtime/session-token.ts
@@ -1,9 +1,10 @@
 import { isElectron } from "@/runtime/is-electron";
 
 // Seeded once per page load from the main process, which owns the token.
-// Auth transitions (login / logout / re-auth) hard-navigate, reloading the
-// renderer and re-seeding, so a per-load cache stays correct without any
-// per-request IPC. `undefined` = not yet seeded; `null` = signed out.
+// Auth transitions hard-navigate, reloading the renderer and re-seeding,
+// so a per-load cache stays correct without per-request IPC. `undefined` =
+// not yet seeded; `null` = signed out. Login acquiring a token mid-page is
+// the one exception, handled by `primeElectronSessionToken`.
 let cached: string | null | undefined;
 
 /** The session token in Electron, or `null` on web / when signed out. */
@@ -13,6 +14,11 @@ export function getElectronSessionToken(): string | null {
     cached = window.vellum?.auth?.getSessionToken?.() ?? null;
   }
   return cached;
+}
+
+/** Update the cache when login acquires a token mid-page, before the post-login navigation. */
+export function primeElectronSessionToken(token: string): void {
+  cached = token;
 }
 
 export function __resetForTesting(): void {

--- a/apps/web/src/stores/auth-store.test.ts
+++ b/apps/web/src/stores/auth-store.test.ts
@@ -99,6 +99,7 @@ mock.module("@/lib/local-mode", () => ({
 
 mock.module("@/runtime/native-auth", () => ({
   isNativePlatform: () => mockIsNativePlatform,
+  isOAuthFlowInFlight: () => false,
   installSessionCookies: installSessionCookiesMock,
   waitForNativeSessionCookie: async () => {},
 }));

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -618,6 +618,8 @@ export function setupAuthListeners(): () => void {
     );
 
   const unsubResume = subscribe("app.resume", () => {
+    // Mid-OAuth refocus — an unauthenticated probe would tear down state.
+    if (isOAuthFlowInFlight()) return;
     void safeRefresh();
   });
   cleanups.push(unsubResume);

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -54,7 +54,7 @@ import { clearOrganization, useOrganizationStore } from "@/stores/organization-s
 import { clearUserScopedStorage } from "@/lib/auth/session-cleanup";
 import { subscribe } from "@/lib/event-bus";
 import { isElectron } from "@/runtime/is-electron";
-import { isNativePlatform, installSessionCookies, waitForNativeSessionCookie } from "@/runtime/native-auth";
+import { isNativePlatform, isOAuthFlowInFlight, installSessionCookies, waitForNativeSessionCookie } from "@/runtime/native-auth";
 import { isBiometricEnabled, retrieveBiometricToken } from "@/runtime/native-biometric";
 
 export interface AuthUser {
@@ -493,6 +493,8 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
     }
     const user = toAuthUser(result.data.user);
     await syncUserScopedState(user?.id ?? null);
+    // Hydrate the organizations to avoid race conditions from lazy fetch.
+    await useOrganizationStore.getState().fetchOrganizations();
     set(authenticatedPlatformUser(user));
   },
 


### PR DESCRIPTION
ref LUM-2315

The OAuth browser redirect refocuses the window before the code exchange finishes, so the app-resume session probe fired unauthenticated, 401'd, and cleared org state mid-login.

- Skip the resume refresh while the OAuth flow is in flight.
- Prime the renderer's token cache from the `startOAuth` result instead of waiting for the post-login reload.
- Hydrate the org store before flipping auth state, and gate org-scoped assistant queries on `useIsOrgReady`.

Known follow-up: `useIsOrgReady` treats the boot-time `"unknown"` platform session as ready, so one `/v1/assistants` query can still escape without the org header at startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)