### PR TITLE
feat(web): Esc cancels dictation and per-session Sentry breadcrumbs

### DIFF
--- a/apps/macos/src/main/commands.ts
+++ b/apps/macos/src/main/commands.ts
@@ -30,6 +30,7 @@ export type VellumCommand =
   | { kind: "retireAssistant"; assistantId: string }
   | { kind: "quickInputSubmit"; message: string }
   | { kind: "cancelActiveAction" }
+  | { kind: "cancelDictation" }
   | { kind: "replayOnboarding" }
   | { kind: "previewPrechat" }
   | { kind: "openComponentGallery" };
@@ -66,6 +67,7 @@ export const DEFAULT_ACCELERATORS: Record<VellumCommandKind, string> = {
   retireAssistant: "",
   quickInputSubmit: "",
   cancelActiveAction: "",
+  cancelDictation: "",
   replayOnboarding: "",
   previewPrechat: "",
   openComponentGallery: "",

--- a/apps/macos/src/main/dictation-overlay-window.ts
+++ b/apps/macos/src/main/dictation-overlay-window.ts
@@ -239,7 +239,19 @@ const hideOverlay = (): void => {
 
 let installed = false;
 
-export const installDictationOverlay = (): void => {
+export const installDictationOverlay = (
+  options: {
+    /**
+     * Raw recording-lifecycle tap, true while the renderer reports an
+     * active recording. Feeds the escape monitor (injected from `index.ts`
+     * rather than imported — pulling `escape-monitor`'s module graph in
+     * here would drag `main-window` into this module's unit tests). Raw
+     * rather than suppression-aware on purpose: Esc must cancel a
+     * recording even when the overlay itself is suppressed.
+     */
+    onRecordingLifecycle?: (recording: boolean) => void;
+  } = {},
+): void => {
   if (installed) return;
   installed = true;
 
@@ -259,6 +271,7 @@ export const installDictationOverlay = (): void => {
     "vellum:dictationOverlay:setState",
     z.tuple([dictationOverlayMessageSchema]),
     ([message]) => {
+      options.onRecordingLifecycle?.(message.kind === "recording");
       controller.handleMessage(message);
     },
   );

--- a/apps/macos/src/main/escape-monitor.ts
+++ b/apps/macos/src/main/escape-monitor.ts
@@ -6,11 +6,17 @@ import { onStatusChange, type AssistantStatus } from "./status";
 
 /**
  * Hybrid Escape monitor: registers a system-wide Escape shortcut only
- * when the assistant is actively processing AND the app has no focused
- * window. When any BrowserWindow gains focus the shortcut is released
- * so normal in-app Escape handling (modals, popovers, inputs) is
- * unaffected — the renderer's own keydown listener handles the
+ * when there is something to cancel — the assistant is actively
+ * processing, or a dictation recording session is live — AND the app has
+ * no focused window. When any BrowserWindow gains focus the shortcut is
+ * released so normal in-app Escape handling (modals, popovers, inputs)
+ * is unaffected — the renderer's own keydown listeners handle the
  * focused case.
+ *
+ * A live dictation recording takes priority over a thinking assistant:
+ * the recording is the more immediate activity (the user is mid-hold on
+ * push-to-talk), and a second Escape can still cancel the assistant once
+ * the recording is gone.
  *
  * Electron's `globalShortcut` intercepts the keypress at the OS level
  * and swallows it (https://github.com/electron/electron/issues/13010),
@@ -24,14 +30,20 @@ import { onStatusChange, type AssistantStatus } from "./status";
 
 let armed = false;
 let thinking = false;
+let dictationRecording = false;
 let hasFocusedWindow = false;
 
-const shouldBeArmed = (): boolean => thinking && !hasFocusedWindow;
+const shouldBeArmed = (): boolean =>
+  (thinking || dictationRecording) && !hasFocusedWindow;
 
 const arm = (): void => {
   if (armed) return;
   const ok = globalShortcut.register("Escape", () => {
-    dispatchToMain({ kind: "cancelActiveAction" });
+    dispatchToMain(
+      dictationRecording
+        ? { kind: "cancelDictation" }
+        : { kind: "cancelActiveAction" },
+    );
   });
   if (ok) {
     armed = true;
@@ -56,6 +68,23 @@ const reconcile = (): void => {
   } else {
     disarm();
   }
+};
+
+/**
+ * Inform the monitor that a dictation recording session started or ended.
+ * Called from the dictation overlay's IPC handler — the renderer publishes
+ * its recording lifecycle there unconditionally, so it doubles as main's
+ * source of truth for "is a recording live".
+ */
+export const setDictationRecording = (recording: boolean): void => {
+  if (dictationRecording === recording) return;
+  dictationRecording = recording;
+  // Refresh rather than trust the cached flag: dictation state can arrive
+  // before installEscapeMonitor() subscribes to focus events, and arming
+  // while a Vellum window is actually focused would swallow Escape for
+  // every in-app affordance.
+  hasFocusedWindow = BrowserWindow.getFocusedWindow() != null;
+  reconcile();
 };
 
 let teardown: (() => void) | null = null;

--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -32,7 +32,10 @@ import { handleFileOpen, installFileOpen, onFileOpen } from "./file-open";
 import { installAvatarIpc } from "./avatar";
 import { installDictationOverlay } from "./dictation-overlay-window";
 import { installDock } from "./dock";
-import { installEscapeMonitor } from "./escape-monitor";
+import {
+  installEscapeMonitor,
+  setDictationRecording,
+} from "./escape-monitor";
 import { installFeatureFlagsIpc } from "./feature-flags";
 import { installFeedbackIpc } from "./feedback";
 import { installGlobalShortcuts } from "./global-shortcuts";
@@ -328,7 +331,7 @@ app
     installTextInsertionIpc();
     installApplicationMenu();
     installQuickInput();
-    installDictationOverlay();
+    installDictationOverlay({ onRecordingLifecycle: setDictationRecording });
     installPopoutWindows();
     installGlobalShortcuts();
     // Register the avatar channel before the Dock and Tray install so their

--- a/apps/web/src/domains/chat/components/voice-input-button.test.tsx
+++ b/apps/web/src/domains/chat/components/voice-input-button.test.tsx
@@ -13,7 +13,14 @@
  * transcribe branching is observable without timer games.
  */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 
 const addBreadcrumbSpy = mock((_breadcrumb: unknown) => {});
 mock.module("@sentry/react", () => ({
@@ -44,6 +51,19 @@ mock.module("@/runtime/native-auth", () => ({
 }));
 mock.module("@/utils/voice-input-device", () => ({
   voiceInputAudioConstraints: () => true,
+}));
+
+// Capture the command handler map the component registers so tests can
+// deliver the escape monitor's `cancelDictation` relay directly (the real
+// hook is an Electron IPC subscription and no-ops in this environment).
+const commandHandlers: Record<string, ((command: unknown) => void) | undefined> =
+  {};
+mock.module("@/runtime/vellum-commands", () => ({
+  useVellumCommands: (
+    handlers: Record<string, (command: unknown) => void>,
+  ) => {
+    Object.assign(commandHandlers, handlers);
+  },
 }));
 
 // ---------------------------------------------------------------------------
@@ -160,6 +180,22 @@ describe("VoiceInputButton — Esc cancellation", () => {
     expect(crumb.category).toBe("dictation");
     expect(crumb.data.outcome).toBe("cancelled");
     expect(crumb.data.finalLength).toBe(0);
+  });
+
+  test("cancelDictation command (escape monitor relay) discards like Escape", async () => {
+    const onTranscript = mock(async (_text: string) => {});
+    await startSession(onTranscript);
+
+    act(() => {
+      commandHandlers.cancelDictation?.({ kind: "cancelDictation" });
+    });
+
+    await waitFor(() => {
+      expect(useVoiceRecordingStore.getState().phase).toBe("idle");
+    });
+    expect(postSttTranscribeSpy).not.toHaveBeenCalled();
+    expect(onTranscript).not.toHaveBeenCalled();
+    expect(lastBreadcrumb().data.outcome).toBe("cancelled");
   });
 
   test("Escape while idle does nothing", () => {

--- a/apps/web/src/domains/chat/components/voice-input-button.test.tsx
+++ b/apps/web/src/domains/chat/components/voice-input-button.test.tsx
@@ -1,0 +1,212 @@
+/**
+ * Tests for `VoiceInputButton`'s session-termination behavior:
+ *
+ *   1. Esc during recording discards the session — the captured audio is
+ *      never transcribed and no transcript is delivered.
+ *   2. Each session emits exactly one Sentry breadcrumb with duration,
+ *      locale, and final transcript length (metrics only — never the
+ *      transcript text).
+ *
+ * The browser capture surface (`MediaRecorder` + `getUserMedia`) is faked at
+ * the global level since happy-dom provides neither; the fake recorder fires
+ * `ondataavailable` + `onstop` synchronously from `stop()` so the discard /
+ * transcribe branching is observable without timer games.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const addBreadcrumbSpy = mock((_breadcrumb: unknown) => {});
+mock.module("@sentry/react", () => ({
+  addBreadcrumb: addBreadcrumbSpy,
+}));
+
+const postSttTranscribeSpy = mock(
+  async (_blob: Blob, _assistantId: string, _signal?: AbortSignal) => ({
+    status: "ok" as const,
+    text: "hello world",
+  }),
+);
+mock.module("@/domains/chat/voice/stt-api", () => ({
+  postSttTranscribe: postSttTranscribeSpy,
+}));
+
+// No daemon stream and no native helper partials — live interim text is not
+// under test, and returning null from both exercises the default web path.
+mock.module("@/domains/chat/voice/dictation-stream", () => ({
+  startDictationStream: () => null,
+}));
+mock.module("@/runtime/native-dictation-partials", () => ({
+  startNativeDictationPartials: async () => null,
+}));
+
+mock.module("@/runtime/native-auth", () => ({
+  useIsNativePlatform: () => false,
+}));
+mock.module("@/utils/voice-input-device", () => ({
+  voiceInputAudioConstraints: () => true,
+}));
+
+// ---------------------------------------------------------------------------
+// Browser capture fakes
+// ---------------------------------------------------------------------------
+
+class FakeMediaRecorder {
+  static isTypeSupported = (_type: string) => true;
+  state: "inactive" | "recording" = "inactive";
+  ondataavailable: ((event: { data: Blob }) => void) | null = null;
+  onstop: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  constructor(
+    _stream: unknown,
+    _options?: unknown,
+  ) {}
+
+  start(): void {
+    this.state = "recording";
+  }
+
+  stop(): void {
+    if (this.state === "inactive") return;
+    this.state = "inactive";
+    this.ondataavailable?.({
+      data: new Blob(["audio"], { type: "audio/webm;codecs=opus" }),
+    });
+    this.onstop?.();
+  }
+}
+
+(globalThis as Record<string, unknown>).MediaRecorder = FakeMediaRecorder;
+
+const fakeStream = {
+  getTracks: () => [{ stop: () => {} }],
+} as unknown as MediaStream;
+Object.defineProperty(navigator, "mediaDevices", {
+  configurable: true,
+  value: {
+    getUserMedia: async () => fakeStream,
+  },
+});
+
+// Imported after the mocks so the component resolves against them. The
+// recording store is intentionally real — phase transitions are part of the
+// behavior under test.
+const { VoiceInputButton } = await import(
+  "@/domains/chat/components/voice-input-button"
+);
+const { useVoiceRecordingStore } = await import(
+  "@/domains/chat/voice/voice-recording-store"
+);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface RecordedBreadcrumb {
+  category: string;
+  data: {
+    outcome: string;
+    durationMs: number;
+    locale: string;
+    finalLength: number;
+  };
+}
+
+function lastBreadcrumb(): RecordedBreadcrumb {
+  const calls = addBreadcrumbSpy.mock.calls;
+  expect(calls.length).toBeGreaterThan(0);
+  return calls[calls.length - 1]![0] as RecordedBreadcrumb;
+}
+
+async function startSession(onTranscript: (text: string) => Promise<void>) {
+  render(
+    <VoiceInputButton assistantId="assistant-1" onTranscript={onTranscript} />,
+  );
+  fireEvent.click(screen.getByRole("button", { name: "Start voice input" }));
+  // The stop affordance appearing proves the recording render committed and
+  // the Escape listener effect has flushed.
+  await screen.findByRole("button", { name: "Stop recording" });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("VoiceInputButton — Esc cancellation", () => {
+  beforeEach(() => {
+    addBreadcrumbSpy.mockClear();
+    postSttTranscribeSpy.mockClear();
+    useVoiceRecordingStore.getState().reset();
+  });
+
+  afterEach(() => {
+    cleanup();
+    useVoiceRecordingStore.getState().reset();
+  });
+
+  test("Escape during recording discards the partial result", async () => {
+    const onTranscript = mock(async (_text: string) => {});
+    await startSession(onTranscript);
+
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(useVoiceRecordingStore.getState().phase).toBe("idle");
+    });
+    expect(postSttTranscribeSpy).not.toHaveBeenCalled();
+    expect(onTranscript).not.toHaveBeenCalled();
+
+    const crumb = lastBreadcrumb();
+    expect(crumb.category).toBe("dictation");
+    expect(crumb.data.outcome).toBe("cancelled");
+    expect(crumb.data.finalLength).toBe(0);
+  });
+
+  test("Escape while idle does nothing", () => {
+    const onTranscript = mock(async (_text: string) => {});
+    render(
+      <VoiceInputButton
+        assistantId="assistant-1"
+        onTranscript={onTranscript}
+      />,
+    );
+
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(useVoiceRecordingStore.getState().phase).toBe("idle");
+    expect(addBreadcrumbSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("VoiceInputButton — session breadcrumb", () => {
+  beforeEach(() => {
+    addBreadcrumbSpy.mockClear();
+    postSttTranscribeSpy.mockClear();
+    useVoiceRecordingStore.getState().reset();
+  });
+
+  afterEach(() => {
+    cleanup();
+    useVoiceRecordingStore.getState().reset();
+  });
+
+  test("completed session emits one breadcrumb with duration, locale, and final length", async () => {
+    const onTranscript = mock(async (_text: string) => {});
+    await startSession(onTranscript);
+
+    fireEvent.click(screen.getByRole("button", { name: "Stop recording" }));
+
+    await waitFor(() => {
+      expect(onTranscript).toHaveBeenCalledWith("hello world");
+    });
+    expect(postSttTranscribeSpy).toHaveBeenCalledTimes(1);
+    expect(addBreadcrumbSpy).toHaveBeenCalledTimes(1);
+
+    const crumb = lastBreadcrumb();
+    expect(crumb.category).toBe("dictation");
+    expect(crumb.data.outcome).toBe("completed");
+    expect(crumb.data.finalLength).toBe("hello world".length);
+    expect(crumb.data.durationMs).toBeGreaterThanOrEqual(0);
+    expect(typeof crumb.data.locale).toBe("string");
+  });
+});

--- a/apps/web/src/domains/chat/components/voice-input-button.tsx
+++ b/apps/web/src/domains/chat/components/voice-input-button.tsx
@@ -8,6 +8,7 @@ import {
     useRef,
     useSyncExternalStore,
 } from "react";
+import * as Sentry from "@sentry/react";
 
 import {
   startDictationStream,
@@ -179,6 +180,43 @@ export function errorCodeForReason(reason: SttFailureReason): string {
 }
 
 // ---------------------------------------------------------------------------
+// Session breadcrumbs
+// ---------------------------------------------------------------------------
+
+type DictationSessionOutcome =
+  | "completed"
+  | "empty"
+  | "error"
+  | "cancelled"
+  | "aborted";
+
+/**
+ * One breadcrumb per dictation session, emitted when the session reaches a
+ * terminal state. Carries only metrics (duration, locale, final transcript
+ * length) — never the transcript itself, which is user speech content and
+ * must not reach Sentry.
+ *
+ * @see https://docs.sentry.io/platforms/javascript/enriching-events/breadcrumbs/
+ */
+function addDictationSessionBreadcrumb(
+  outcome: DictationSessionOutcome,
+  durationMs: number,
+  finalLength: number,
+): void {
+  Sentry.addBreadcrumb({
+    category: "dictation",
+    level: "info",
+    message: `dictation session ${outcome}`,
+    data: {
+      outcome,
+      durationMs,
+      locale: typeof navigator !== "undefined" ? navigator.language : "unknown",
+      finalLength,
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
 
@@ -242,6 +280,12 @@ export const VoiceInputButton = forwardRef<
   // Guard so recorder.onstop (which always fires after onerror) doesn't
   // overwrite the error state with a vsReset/vsFinalize transition.
   const erroredRef = useRef(false);
+  // Set by cancelRecording (Esc) — recorder.onstop still fires for teardown
+  // but must discard the captured audio instead of transcribing it.
+  const discardedRef = useRef(false);
+  // Wall-clock start of the live recording, for the session breadcrumb's
+  // duration (recording time only, not the STT round trip).
+  const sessionStartedAtRef = useRef(0);
   // Monotonic session counter — incremented on each startRecording call.
   // The async STT completion captures the current value and skips state
   // mutations if a newer session has started since.
@@ -340,6 +384,53 @@ export const VoiceInputButton = forwardRef<
     stopNativePartials,
   ]);
 
+  /**
+   * Discard the in-flight recording session: stop capture without
+   * transcribing or inserting anything. `recorder.onstop` still fires and
+   * performs the usual teardown; `discardedRef` makes it skip the STT path.
+   */
+  const cancelRecording = useCallback(() => {
+    const recorder = mediaRecorderRef.current;
+    if (!recorder) return;
+    discardedRef.current = true;
+    stopSpeechRecognition();
+    stopDictationStream();
+    stopNativePartials();
+    if (recorder.state !== "inactive") {
+      try {
+        recorder.stop();
+      } catch {
+        // Already stopped.
+      }
+    }
+    vsReset();
+  }, [
+    stopSpeechRecognition,
+    stopDictationStream,
+    stopNativePartials,
+    vsReset,
+  ]);
+
+  // Esc during recording discards the partial result. Capture phase so it
+  // wins over composer/modal Escape handlers while a recording is live. Two
+  // instances can be mounted per window (chat composer + the global
+  // push-to-talk fallback) and both see the shared store phase; the
+  // recorder-ownership guard keeps the non-recording instance inert.
+  useEffect(() => {
+    if (!recording) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      if (!mediaRecorderRef.current) return;
+      event.preventDefault();
+      event.stopPropagation();
+      cancelRecording();
+    };
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown, true);
+    };
+  }, [recording, cancelRecording]);
+
   useEffect(() => {
     if (disabled && recording) {
       stopRecording();
@@ -373,6 +464,7 @@ export const VoiceInputButton = forwardRef<
   const startRecording = useCallback(async () => {
     if (mediaRecorderRef.current) return;
     cancelledStartRef.current = false;
+    discardedRef.current = false;
     const sessionId = ++sessionIdRef.current;
 
     if (onBeforeStart) {
@@ -495,6 +587,7 @@ export const VoiceInputButton = forwardRef<
     };
 
     recorder.onstop = () => {
+      const durationMs = Date.now() - sessionStartedAtRef.current;
       mediaRecorderRef.current = null;
       if (useVoiceRecordingStore.getState().phase === "recording") {
         vsStopRecording();
@@ -505,7 +598,20 @@ export const VoiceInputButton = forwardRef<
       stopNativePartials();
       publishInterim("");
 
+      if (discardedRef.current) {
+        discardedRef.current = false;
+        chunksRef.current = [];
+        speechAccumulatorRef.current = "";
+        // Re-assert idle: a stop() racing in between cancelRecording and
+        // this handler (e.g. the push-to-talk key-up after Esc) can have
+        // moved the store to "processing".
+        vsReset();
+        addDictationSessionBreadcrumb("cancelled", durationMs, 0);
+        return;
+      }
+
       if (erroredRef.current) {
+        addDictationSessionBreadcrumb("error", durationMs, 0);
         return;
       }
 
@@ -514,6 +620,7 @@ export const VoiceInputButton = forwardRef<
       const fallbackText = speechAccumulatorRef.current;
       speechAccumulatorRef.current = "";
       if (chunks.length === 0 && !fallbackText) {
+        addDictationSessionBreadcrumb("empty", durationMs, 0);
         vsReset();
         return;
       }
@@ -555,19 +662,23 @@ export const VoiceInputButton = forwardRef<
 
         try {
           if (text) {
+            addDictationSessionBreadcrumb("completed", durationMs, text.length);
             await onTranscript(text);
           } else if (daemonFailure) {
             // The user-cancelled `aborted` reason should not trigger a
             // visible error — it's the expected outcome of stop().
             if (daemonFailure === "aborted") {
+              addDictationSessionBreadcrumb("aborted", durationMs, 0);
               vsReset();
               return;
             }
+            addDictationSessionBreadcrumb("error", durationMs, 0);
             const code = errorCodeForReason(daemonFailure);
             onError?.(code);
             vsFail(code);
             return;
           } else {
+            addDictationSessionBreadcrumb("empty", durationMs, 0);
             vsReset();
             return;
           }
@@ -602,6 +713,7 @@ export const VoiceInputButton = forwardRef<
       // When a future change wires up the WS /v1/stt/stream consumer, the
       // timeslice should come back paired with that consumer.
       recorder.start();
+      sessionStartedAtRef.current = Date.now();
       vsStartRecording();
       onError?.(null);
     } catch (err) {

--- a/apps/web/src/domains/chat/components/voice-input-button.tsx
+++ b/apps/web/src/domains/chat/components/voice-input-button.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/domains/chat/voice/stt-api";
 import { useVoiceRecordingStore } from "@/domains/chat/voice/voice-recording-store";
 import { useIsNativePlatform } from "@/runtime/native-auth";
+import { useVellumCommands } from "@/runtime/vellum-commands";
 import { voiceInputAudioConstraints } from "@/utils/voice-input-device";
 import { Button, cn } from "@vellumai/design-library";
 
@@ -430,6 +431,17 @@ export const VoiceInputButton = forwardRef<
       window.removeEventListener("keydown", handleKeyDown, true);
     };
   }, [recording, cancelRecording]);
+
+  // The DOM listener above only sees Escape while a Vellum window has
+  // focus. During system-wide push-to-talk dictation into another app the
+  // Electron escape monitor owns Escape and relays it as a command; the
+  // same recorder-ownership guard applies.
+  useVellumCommands({
+    cancelDictation: () => {
+      if (!mediaRecorderRef.current) return;
+      cancelRecording();
+    },
+  });
 
   useEffect(() => {
     if (disabled && recording) {

--- a/apps/web/src/runtime/is-electron.ts
+++ b/apps/web/src/runtime/is-electron.ts
@@ -49,6 +49,7 @@ export type VellumCommand =
   | { kind: "retireAssistant"; assistantId: string }
   | { kind: "quickInputSubmit"; message: string }
   | { kind: "cancelActiveAction" }
+  | { kind: "cancelDictation" }
   | { kind: "replayOnboarding" }
   | { kind: "previewPrechat" }
   | { kind: "openComponentGallery" };


### PR DESCRIPTION
## Summary
- Pressing Escape during an active dictation recording now discards the session: capture stops, the recorded audio is never sent to STT, nothing is inserted, and the store snaps back to idle (which also dismisses the system-wide overlay). A capture-phase window listener in `VoiceInputButton` owns this, with a recorder-ownership guard so the always-mounted global push-to-talk fallback instance stays inert.
- Every dictation session now emits one Sentry breadcrumb at its terminal state (`completed` / `empty` / `error` / `cancelled` / `aborted`) carrying recording duration, locale, and final transcript length — metrics only, never the transcript text.
- Adds `voice-input-button.test.tsx` covering Esc discard (no STT call, no transcript delivery, cancelled breadcrumb) and the completed-session breadcrumb fields.

## Original prompt
Asked to verify whether the user-facing dictation flow ticket (renderer voice button + Fn-key activation, live partials in composer, insert-on-release, Esc cancellation, Sentry session breadcrumb) was fully implemented. Code review found the first three items shipped in the Electron app but no Esc cancellation path (stopping always transcribed and inserted) and no session telemetry anywhere in the dictation code. `/do` was invoked to implement the two missing items and close out the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)