### PR TITLE
refactor(macos): add reusable floating window factory for dictation overlay

### DIFF
--- a/apps/macos/src/main/dictation-overlay-window.ts
+++ b/apps/macos/src/main/dictation-overlay-window.ts
@@ -1,9 +1,8 @@
-import { BrowserWindow, app, screen } from "electron";
+import { BrowserWindow, screen } from "electron";
 import { z } from "zod";
 
-import { RENDERER_BASE_PROD, getDevRendererBase } from "./app-config";
+import { createFloatingWindow, getFloatingWindow } from "./floating-window";
 import { handle, on } from "./ipc";
-import { createWindow } from "./windows";
 
 /**
  * System-wide dictation overlay — a floating, click-through panel pinned
@@ -24,6 +23,7 @@ import { createWindow } from "./windows";
  * click-through — it's a display surface only.
  */
 
+const OVERLAY_KIND = "dictation-overlay";
 const OVERLAY_PATH = "/dictation-overlay";
 
 // The window is a fixed-size transparent canvas larger than the visible
@@ -147,13 +147,6 @@ export const createDictationOverlayController = (
 // Window plumbing
 // ---------------------------------------------------------------------------
 
-const overlayUrl = (): string => {
-  const base = app.isPackaged ? RENDERER_BASE_PROD : getDevRendererBase();
-  return `${base}${OVERLAY_PATH}`;
-};
-
-let overlayWindow: BrowserWindow | null = null;
-
 // Latest state forwarded to the overlay renderer. The overlay route loads
 // lazily after the window is created, so pushes sent before its `onState`
 // subscription registers are dropped by Electron — the route pulls this via
@@ -162,78 +155,56 @@ let latestState: DictationOverlayState | null = null;
 
 const sendState = (state: DictationOverlayState): void => {
   latestState = state;
-  if (overlayWindow && !overlayWindow.isDestroyed()) {
-    overlayWindow.webContents.send("vellum:dictationOverlay:state", state);
+  const win = getFloatingWindow(OVERLAY_KIND);
+  if (win) {
+    win.webContents.send("vellum:dictationOverlay:state", state);
   }
 };
 
-const positionOverlay = (win: BrowserWindow): void => {
+const overlayPosition = (): { x: number; y: number } => {
   const cursor = screen.getCursorScreenPoint();
   const display = screen.getDisplayNearestPoint(cursor);
   const { x, y, width } = display.workArea;
-  win.setPosition(
-    Math.round(x + (width - OVERLAY_WIDTH) / 2),
-    Math.round(y + PILL_TOP_OFFSET - CANVAS_TOP_INSET),
-  );
+  return {
+    x: Math.round(x + (width - OVERLAY_WIDTH) / 2),
+    y: Math.round(y + PILL_TOP_OFFSET - CANVAS_TOP_INSET),
+  };
 };
 
 const ensureOverlayWindow = (): BrowserWindow => {
-  if (overlayWindow && !overlayWindow.isDestroyed()) {
-    return overlayWindow;
-  }
-
-  const win = createWindow({
+  const win = createFloatingWindow({
+    kind: OVERLAY_KIND,
+    route: OVERLAY_PATH,
+    width: OVERLAY_WIDTH,
+    height: OVERLAY_HEIGHT,
+    focusOnShow: false,
+    position: overlayPosition,
     browserWindow: {
-      type: "panel",
-      width: OVERLAY_WIDTH,
-      height: OVERLAY_HEIGHT,
-      frame: false,
-      transparent: true,
-      resizable: false,
       movable: false,
       minimizable: false,
       maximizable: false,
-      fullscreenable: false,
-      alwaysOnTop: true,
-      skipTaskbar: true,
       focusable: false,
-      show: false,
       hasShadow: false,
     },
-    navigation: "deny-all",
   });
 
   // Display surface only — clicks fall through to whatever is underneath,
   // so the transparent canvas margin never intercepts input.
   win.setIgnoreMouseEvents(true);
-  // Dictation targets whatever app the user is in, including fullscreen
-  // Spaces — let the overlay appear there too.
-  win.setVisibleOnAllWorkspaces(true, {
-    visibleOnFullScreen: true,
-    skipTransformProcessType: true,
-  });
-
-  win.on("closed", () => {
-    overlayWindow = null;
-  });
-
-  void win.loadURL(overlayUrl());
-  overlayWindow = win;
   return win;
 };
 
 const showOverlay = (): void => {
-  const win = ensureOverlayWindow();
-  positionOverlay(win);
-  // Never `show()` — that would activate the app and steal focus from the
-  // app being dictated into.
-  win.showInactive();
+  // `createFloatingWindow` uses `showInactive()` when `focusOnShow` is false;
+  // never activate the app or steal focus from the dictation target.
+  ensureOverlayWindow();
 };
 
 const hideOverlay = (): void => {
   latestState = null;
-  if (overlayWindow && !overlayWindow.isDestroyed()) {
-    overlayWindow.hide();
+  const win = getFloatingWindow(OVERLAY_KIND);
+  if (win) {
+    win.hide();
   }
 };
 

--- a/apps/macos/src/main/dictation-overlay-window.ts
+++ b/apps/macos/src/main/dictation-overlay-window.ts
@@ -178,6 +178,7 @@ const ensureOverlayWindow = (): BrowserWindow => {
     width: OVERLAY_WIDTH,
     height: OVERLAY_HEIGHT,
     focusOnShow: false,
+    ignoreMouseEvents: true,
     position: overlayPosition,
     browserWindow: {
       movable: false,
@@ -188,9 +189,6 @@ const ensureOverlayWindow = (): BrowserWindow => {
     },
   });
 
-  // Display surface only — clicks fall through to whatever is underneath,
-  // so the transparent canvas margin never intercepts input.
-  win.setIgnoreMouseEvents(true);
   return win;
 };
 

--- a/apps/macos/src/main/floating-window.test.ts
+++ b/apps/macos/src/main/floating-window.test.ts
@@ -16,6 +16,7 @@ type StubWindow = {
   setPosition: ReturnType<typeof mock>;
   setAlwaysOnTop: ReturnType<typeof mock>;
   setVisibleOnAllWorkspaces: ReturnType<typeof mock>;
+  setIgnoreMouseEvents: ReturnType<typeof mock>;
   show: ReturnType<typeof mock>;
   focus: ReturnType<typeof mock>;
   showInactive: ReturnType<typeof mock>;
@@ -35,6 +36,7 @@ const makeWindow = (): StubWindow => {
   const webContentsListeners = new Map<string, Listener[]>();
   let destroyed = false;
   let webContentsDestroyed = false;
+  const calls: string[] = [];
 
   const webContents: StubWebContents = {
     on: (event, listener) => {
@@ -65,14 +67,22 @@ const makeWindow = (): StubWindow => {
     },
     setPosition: mock((_x: number, _y: number) => undefined),
     setAlwaysOnTop: mock((_flag: boolean, _level: string) => undefined),
+    setIgnoreMouseEvents: mock((_ignore: boolean) => {
+      calls.push("setIgnoreMouseEvents");
+    }),
     setVisibleOnAllWorkspaces: mock(
       (_visible: boolean, _opts: Record<string, boolean>) => undefined,
     ),
-    show: mock(() => undefined),
+    show: mock(() => {
+      calls.push("show");
+    }),
     focus: mock(() => undefined),
-    showInactive: mock(() => undefined),
+    showInactive: mock(() => {
+      calls.push("showInactive");
+    }),
     loadURL: mock((_url: string) => Promise.resolve()),
   };
+  Object.defineProperty(win, "__calls", { value: calls });
   return win;
 };
 
@@ -250,6 +260,19 @@ describe("createFloatingWindow", () => {
 
     expect(win.setAlwaysOnTop.mock.calls).toEqual([[true, "pop-up-menu"]]);
     expect(win.setVisibleOnAllWorkspaces).not.toHaveBeenCalled();
+  });
+
+  test("applies click-through behavior before showing the window", () => {
+    const win = createFloatingWindow({
+      kind: kind("click-through"),
+      route: "/overlay",
+      width: 100,
+      height: 100,
+      ignoreMouseEvents: true,
+    }) as unknown as StubWindow & { __calls: string[] };
+
+    expect(win.setIgnoreMouseEvents.mock.calls).toEqual([[true]]);
+    expect(win.__calls).toEqual(["setIgnoreMouseEvents", "showInactive"]);
   });
 
   test("drops the singleton reference when the window closes", () => {

--- a/apps/macos/src/main/floating-window.test.ts
+++ b/apps/macos/src/main/floating-window.test.ts
@@ -1,0 +1,298 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+type Listener = () => void;
+
+type StubWebContents = {
+  on: (event: string, listener: Listener) => StubWebContents;
+  isDestroyed: () => boolean;
+  emit: (event: string) => void;
+};
+
+type StubWindow = {
+  webContents: StubWebContents;
+  isDestroyed: () => boolean;
+  on: (event: string, listener: Listener) => StubWindow;
+  emit: (event: string) => void;
+  setPosition: ReturnType<typeof mock>;
+  setAlwaysOnTop: ReturnType<typeof mock>;
+  setVisibleOnAllWorkspaces: ReturnType<typeof mock>;
+  show: ReturnType<typeof mock>;
+  focus: ReturnType<typeof mock>;
+  showInactive: ReturnType<typeof mock>;
+  loadURL: ReturnType<typeof mock>;
+};
+
+type CreateWindowOptions = {
+  browserWindow: Record<string, unknown>;
+  navigation: unknown;
+};
+
+const appState = { isPackaged: false };
+const created: Array<{ opts: CreateWindowOptions; win: StubWindow }> = [];
+
+const makeWindow = (): StubWindow => {
+  const windowListeners = new Map<string, Listener[]>();
+  const webContentsListeners = new Map<string, Listener[]>();
+  let destroyed = false;
+  let webContentsDestroyed = false;
+
+  const webContents: StubWebContents = {
+    on: (event, listener) => {
+      const listeners = webContentsListeners.get(event) ?? [];
+      listeners.push(listener);
+      webContentsListeners.set(event, listeners);
+      return webContents;
+    },
+    isDestroyed: () => webContentsDestroyed,
+    emit: (event) => {
+      if (event === "destroyed") webContentsDestroyed = true;
+      for (const listener of webContentsListeners.get(event) ?? []) listener();
+    },
+  };
+
+  const win: StubWindow = {
+    webContents,
+    isDestroyed: () => destroyed,
+    on: (event, listener) => {
+      const listeners = windowListeners.get(event) ?? [];
+      listeners.push(listener);
+      windowListeners.set(event, listeners);
+      return win;
+    },
+    emit: (event) => {
+      if (event === "closed") destroyed = true;
+      for (const listener of windowListeners.get(event) ?? []) listener();
+    },
+    setPosition: mock((_x: number, _y: number) => undefined),
+    setAlwaysOnTop: mock((_flag: boolean, _level: string) => undefined),
+    setVisibleOnAllWorkspaces: mock(
+      (_visible: boolean, _opts: Record<string, boolean>) => undefined,
+    ),
+    show: mock(() => undefined),
+    focus: mock(() => undefined),
+    showInactive: mock(() => undefined),
+    loadURL: mock((_url: string) => Promise.resolve()),
+  };
+  return win;
+};
+
+const createWindowMock = mock((opts: CreateWindowOptions): StubWindow => {
+  const win = makeWindow();
+  created.push({ opts, win });
+  return win;
+});
+
+mock.module("electron", () => ({
+  app: appState,
+  BrowserWindow: class {
+    static getFocusedWindow() {
+      return null;
+    }
+  },
+  ipcMain: {
+    handle: mock(() => undefined),
+    on: mock(() => undefined),
+  },
+  screen: {
+    getCursorScreenPoint: () => ({ x: 0, y: 0 }),
+    getDisplayNearestPoint: () => ({
+      workArea: { x: 0, y: 0, width: 1440, height: 900 },
+    }),
+  },
+}));
+
+mock.module("./windows", () => ({
+  createWindow: createWindowMock,
+}));
+
+const { createFloatingWindow, getFloatingWindow } = await import(
+  "./floating-window"
+);
+
+let nextKind = 1;
+const kind = (name: string): string => `${name}-${nextKind++}`;
+
+beforeEach(() => {
+  created.length = 0;
+  createWindowMock.mockClear();
+  appState.isPackaged = false;
+  delete process.env.VELLUM_DEV_URL;
+});
+
+afterEach(() => {
+  for (const { win } of created) {
+    if (!win.isDestroyed()) win.emit("closed");
+  }
+});
+
+describe("createFloatingWindow", () => {
+  test("creates floating panels with the shared defaults and deny-all navigation", () => {
+    process.env.VELLUM_DEV_URL = "http://localhost:4242/assistant/";
+
+    const win = createFloatingWindow({
+      kind: kind("defaults"),
+      route: "dictation-overlay",
+      width: 480,
+      height: 160,
+    }) as unknown as StubWindow;
+
+    expect(createWindowMock).toHaveBeenCalledTimes(1);
+    expect(created[0]?.opts.navigation).toBe("deny-all");
+    expect(created[0]?.opts.browserWindow).toMatchObject({
+      type: "panel",
+      width: 480,
+      height: 160,
+      frame: false,
+      transparent: true,
+      resizable: false,
+      skipTaskbar: true,
+      fullscreenable: false,
+      show: false,
+    });
+    expect(win.setAlwaysOnTop.mock.calls).toEqual([[true, "floating"]]);
+    expect(win.setVisibleOnAllWorkspaces.mock.calls).toEqual([
+      [
+        true,
+        {
+          visibleOnFullScreen: true,
+          skipTransformProcessType: true,
+        },
+      ],
+    ]);
+    expect(win.loadURL.mock.calls[0]?.[0]).toBe(
+      "http://localhost:4242/assistant/dictation-overlay",
+    );
+  });
+
+  test("resolves packaged renderer routes under the assistant base", () => {
+    appState.isPackaged = true;
+
+    const win = createFloatingWindow({
+      kind: kind("packaged-url"),
+      route: "/command-palette",
+      width: 320,
+      height: 200,
+    }) as unknown as StubWindow;
+
+    expect(win.loadURL.mock.calls[0]?.[0]).toBe(
+      "app://vellum.ai/assistant/command-palette",
+    );
+  });
+
+  test("uses showInactive unless focus is explicitly requested", () => {
+    const passive = createFloatingWindow({
+      kind: kind("passive"),
+      route: "/passive",
+      width: 100,
+      height: 100,
+      focusOnShow: false,
+    }) as unknown as StubWindow;
+    expect(passive.showInactive).toHaveBeenCalledTimes(1);
+    expect(passive.show).not.toHaveBeenCalled();
+    expect(passive.focus).not.toHaveBeenCalled();
+
+    const focused = createFloatingWindow({
+      kind: kind("focused"),
+      route: "/focused",
+      width: 100,
+      height: 100,
+      focusOnShow: true,
+    }) as unknown as StubWindow;
+    expect(focused.showInactive).not.toHaveBeenCalled();
+    expect(focused.show).toHaveBeenCalledTimes(1);
+    expect(focused.focus).toHaveBeenCalledTimes(1);
+  });
+
+  test("reuses the existing window for a kind and repositions it before showing", () => {
+    let x = 10;
+    const singletonKind = kind("singleton");
+    const position = () => ({ x, y: x + 1 });
+
+    const first = createFloatingWindow({
+      kind: singletonKind,
+      route: "/singleton",
+      width: 100,
+      height: 100,
+      focusOnShow: true,
+      position,
+    }) as unknown as StubWindow;
+
+    x = 20;
+    const second = createFloatingWindow({
+      kind: singletonKind,
+      route: "/singleton",
+      width: 100,
+      height: 100,
+      focusOnShow: true,
+      position,
+    }) as unknown as StubWindow;
+
+    expect(second).toBe(first);
+    expect(createWindowMock).toHaveBeenCalledTimes(1);
+    expect(first.setPosition.mock.calls).toEqual([
+      [10, 11],
+      [20, 21],
+    ]);
+    expect(first.show).toHaveBeenCalledTimes(2);
+    expect(first.focus).toHaveBeenCalledTimes(2);
+    expect(first.loadURL).toHaveBeenCalledTimes(1);
+  });
+
+  test("allows callers to opt out of Spaces visibility and customize the top level", () => {
+    const win = createFloatingWindow({
+      kind: kind("spaces-opt-out"),
+      route: "/overlay",
+      width: 100,
+      height: 100,
+      visibleOnAllWorkspaces: false,
+      alwaysOnTopLevel: "pop-up-menu",
+    }) as unknown as StubWindow;
+
+    expect(win.setAlwaysOnTop.mock.calls).toEqual([[true, "pop-up-menu"]]);
+    expect(win.setVisibleOnAllWorkspaces).not.toHaveBeenCalled();
+  });
+
+  test("drops the singleton reference when the window closes", () => {
+    const cleanupKind = kind("closed");
+    const first = createFloatingWindow({
+      kind: cleanupKind,
+      route: "/cleanup",
+      width: 100,
+      height: 100,
+    }) as unknown as StubWindow;
+
+    first.emit("closed");
+
+    expect(getFloatingWindow(cleanupKind)).toBeNull();
+    const second = createFloatingWindow({
+      kind: cleanupKind,
+      route: "/cleanup",
+      width: 100,
+      height: 100,
+    });
+    expect(second).not.toBe(first);
+    expect(createWindowMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("drops the singleton reference when webContents is destroyed", () => {
+    const cleanupKind = kind("webcontents-destroyed");
+    const first = createFloatingWindow({
+      kind: cleanupKind,
+      route: "/cleanup",
+      width: 100,
+      height: 100,
+    }) as unknown as StubWindow;
+
+    first.webContents.emit("destroyed");
+
+    expect(getFloatingWindow(cleanupKind)).toBeNull();
+    const second = createFloatingWindow({
+      kind: cleanupKind,
+      route: "/cleanup",
+      width: 100,
+      height: 100,
+    });
+    expect(second).not.toBe(first);
+    expect(createWindowMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/macos/src/main/floating-window.ts
+++ b/apps/macos/src/main/floating-window.ts
@@ -1,0 +1,137 @@
+import {
+  app,
+  type BrowserWindow,
+  type BrowserWindowConstructorOptions,
+} from "electron";
+
+import { RENDERER_BASE_PROD, getDevRendererBase } from "./app-config";
+import { createWindow } from "./windows";
+
+type AlwaysOnTopLevel = NonNullable<
+  Parameters<BrowserWindow["setAlwaysOnTop"]>[1]
+>;
+
+export type FloatingWindowPosition =
+  | { x: number; y: number }
+  | ((win: BrowserWindow) => { x: number; y: number });
+
+export interface CreateFloatingWindowOptions {
+  kind: string;
+  route: string;
+  width: number;
+  height: number;
+  focusOnShow?: boolean;
+  alwaysOnTopLevel?: AlwaysOnTopLevel;
+  visibleOnAllWorkspaces?: boolean;
+  browserWindow?: Omit<
+    BrowserWindowConstructorOptions,
+    | "webPreferences"
+    | "type"
+    | "width"
+    | "height"
+    | "frame"
+    | "transparent"
+    | "resizable"
+    | "skipTaskbar"
+    | "fullscreenable"
+    | "show"
+  >;
+  position?: FloatingWindowPosition;
+}
+
+const floatingWindows = new Map<string, BrowserWindow>();
+
+const floatingWindowUrl = (route: string): string => {
+  const normalizedRoute = route.startsWith("/") ? route : `/${route}`;
+  const base = app.isPackaged ? RENDERER_BASE_PROD : getDevRendererBase();
+  return `${base}${normalizedRoute}`;
+};
+
+const isAlive = (win: BrowserWindow): boolean =>
+  !win.isDestroyed() && !win.webContents.isDestroyed();
+
+export const getFloatingWindow = (kind: string): BrowserWindow | null => {
+  const win = floatingWindows.get(kind);
+  if (!win) return null;
+  if (isAlive(win)) return win;
+  floatingWindows.delete(kind);
+  return null;
+};
+
+const applyPosition = (
+  win: BrowserWindow,
+  position: FloatingWindowPosition | undefined,
+): void => {
+  if (!position) return;
+  const { x, y } = typeof position === "function" ? position(win) : position;
+  win.setPosition(x, y);
+};
+
+const showFloatingWindow = (
+  win: BrowserWindow,
+  focusOnShow: boolean,
+): void => {
+  if (focusOnShow) {
+    win.show();
+    win.focus();
+    return;
+  }
+  win.showInactive();
+};
+
+export const createFloatingWindow = ({
+  kind,
+  route,
+  width,
+  height,
+  focusOnShow = false,
+  alwaysOnTopLevel = "floating",
+  visibleOnAllWorkspaces = true,
+  browserWindow,
+  position,
+}: CreateFloatingWindowOptions): BrowserWindow => {
+  const existing = getFloatingWindow(kind);
+  if (existing) {
+    applyPosition(existing, position);
+    showFloatingWindow(existing, focusOnShow);
+    return existing;
+  }
+
+  const win = createWindow({
+    browserWindow: {
+      ...browserWindow,
+      type: "panel",
+      width,
+      height,
+      frame: false,
+      transparent: true,
+      resizable: false,
+      skipTaskbar: true,
+      fullscreenable: false,
+      show: false,
+    },
+    navigation: "deny-all",
+  });
+
+  win.setAlwaysOnTop(true, alwaysOnTopLevel);
+  if (visibleOnAllWorkspaces) {
+    win.setVisibleOnAllWorkspaces(true, {
+      visibleOnFullScreen: true,
+      skipTransformProcessType: true,
+    });
+  }
+
+  const cleanup = (): void => {
+    if (floatingWindows.get(kind) === win) {
+      floatingWindows.delete(kind);
+    }
+  };
+  win.on("closed", cleanup);
+  win.webContents.on("destroyed", cleanup);
+
+  floatingWindows.set(kind, win);
+  applyPosition(win, position);
+  void win.loadURL(floatingWindowUrl(route));
+  showFloatingWindow(win, focusOnShow);
+  return win;
+};

--- a/apps/macos/src/main/floating-window.ts
+++ b/apps/macos/src/main/floating-window.ts
@@ -23,6 +23,7 @@ export interface CreateFloatingWindowOptions {
   focusOnShow?: boolean;
   alwaysOnTopLevel?: AlwaysOnTopLevel;
   visibleOnAllWorkspaces?: boolean;
+  ignoreMouseEvents?: boolean;
   browserWindow?: Omit<
     BrowserWindowConstructorOptions,
     | "webPreferences"
@@ -87,6 +88,7 @@ export const createFloatingWindow = ({
   focusOnShow = false,
   alwaysOnTopLevel = "floating",
   visibleOnAllWorkspaces = true,
+  ignoreMouseEvents = false,
   browserWindow,
   position,
 }: CreateFloatingWindowOptions): BrowserWindow => {
@@ -114,6 +116,9 @@ export const createFloatingWindow = ({
   });
 
   win.setAlwaysOnTop(true, alwaysOnTopLevel);
+  if (ignoreMouseEvents) {
+    win.setIgnoreMouseEvents(true);
+  }
   if (visibleOnAllWorkspaces) {
     win.setVisibleOnAllWorkspaces(true, {
       visibleOnFullScreen: true,


### PR DESCRIPTION
## Summary
- Adds a reusable Electron floating-window factory backed by the hardened window seam.
- Refactors the dictation overlay to use the shared factory while preserving current behavior.
- Adds focused unit coverage for the shared floating-window lifecycle.

## Validation
- `cd apps/macos && export PATH=\"$HOME/.bun/bin:$PATH\"; bun test src/main/floating-window.test.ts src/main/dictation-overlay-window.test.ts`

Part of plan: lum-1867-floating-windows.md (PR 1 of 5)