### PR TITLE
Finish LUM-1973 configurable macOS push-to-talk

### DIFF
--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -188,9 +188,13 @@ The preload script exposes a typed `window.vellum` API to the renderer:
   transport seam is [`apps/web/src/runtime/local-mode-host.ts`](../web/src/runtime/local-mode-host.ts),
   which selects this bridge on Electron and the dev-server `/assistant/__local/*`
   middleware on web/dev so both hosts honor the same contract.
-- `helper.hotkey.fnPushToTalk(enable)` — starts or stops the native helper
-  that captures the Fn key globally for Push to Talk, with
-  `helper.hotkey.onEvent(callback)` streaming `down` / `up` notifications.
+- `ptt.getConfig()` / `ptt.setConfig(config)` / `ptt.configure(config)` —
+  reads, writes, and activates the structured Push to Talk trigger stored in
+  `settings.hotkeys.ptt` (`none`, modifier-only, key, modifier+key, or mouse
+  button). `ptt.on(callback)` streams native `down` / `up` notifications from
+  the helper while the app is in the background.
+- `helper.hotkey.fnPushToTalk(enable)` — legacy Fn-only Push to Talk bridge,
+  retained for older renderer callers during the generic PTT rollout.
 - `helper.ping()` — health-checks the native helper over JSON-RPC stdio.
 - `auth.*` — typed stubs that reject with "not implemented yet" until the
   corresponding feature tickets land.

--- a/apps/macos/electron-builder.config.cjs
+++ b/apps/macos/electron-builder.config.cjs
@@ -64,6 +64,8 @@ module.exports = {
       CFBundleIconName: "AppIcon",
       NSMicrophoneUsageDescription:
         "Vellum uses the microphone to record voice input for chat.",
+      NSInputMonitoringUsageDescription:
+        "Vellum monitors your configured push-to-talk key or mouse button while you use other apps.",
       NSAppleEventsUsageDescription:
         "Vellum uses Automation to paste dictated voice input into the app you are using.",
       NSUserNotificationAlertStyle: "alert",

--- a/apps/macos/native/mac-helper/Package.swift
+++ b/apps/macos/native/mac-helper/Package.swift
@@ -18,6 +18,7 @@ let package = Package(
                 .linkedFramework("AppKit"),
                 .linkedFramework("AVFoundation"),
                 .linkedFramework("Carbon"),
+                .linkedFramework("CoreGraphics"),
                 .linkedFramework("Speech"),
             ]
         ),

--- a/apps/macos/native/mac-helper/Sources/MacHelperExecutable/Info.plist
+++ b/apps/macos/native/mac-helper/Sources/MacHelperExecutable/Info.plist
@@ -18,5 +18,7 @@
     <string>Vellum uses the microphone to transcribe dictated voice input.</string>
     <key>NSSpeechRecognitionUsageDescription</key>
     <string>Vellum uses speech recognition to show your words live while you dictate.</string>
+    <key>NSInputMonitoringUsageDescription</key>
+    <string>Vellum monitors your configured push-to-talk key or mouse button while you use other apps.</string>
 </dict>
 </plist>

--- a/apps/macos/native/mac-helper/Sources/MacHelperExecutable/PttMonitor.swift
+++ b/apps/macos/native/mac-helper/Sources/MacHelperExecutable/PttMonitor.swift
@@ -36,14 +36,14 @@ final class PttMonitor {
     private var runLoopSource: CFRunLoopSource?
     private var pressedModifiers = Set<PttModifier>()
     private var isDown = false
-    private var pendingModifierTimer: Timer?
+    private var pendingActivationTimer: Timer?
 
     init(emitState: @escaping (String) -> Void) {
         self.emitState = emitState
     }
 
     func setConfig(_ nextConfig: PttConfig) throws -> Bool {
-        cancelPendingModifierActivation()
+        cancelPendingActivation()
         if isDown {
             emitUp()
         }
@@ -59,7 +59,7 @@ final class PttMonitor {
     }
 
     func stop() {
-        cancelPendingModifierActivation()
+        cancelPendingActivation()
         if isDown {
             emitUp()
         }
@@ -153,19 +153,27 @@ final class PttMonitor {
         switch config {
         case let .modifierOnly(required):
             if modifierRequirementIsSatisfied(required) {
-                scheduleModifierActivation(required: required)
+                scheduleActivation { monitor in
+                    monitor.modifierRequirementIsSatisfied(required)
+                }
             } else {
-                cancelPendingModifierActivation()
+                cancelPendingActivation()
                 if isDown {
                     emitUp()
                 }
             }
         case .key:
-            if isDown && !pressedModifiers.isEmpty {
+            if !pressedModifiers.isEmpty {
+                cancelPendingActivation()
+            }
+            if isDown, !pressedModifiers.isEmpty {
                 emitUp()
             }
         case let .modifierKey(required, _):
-            if isDown && !modifierRequirementIsSatisfied(required) {
+            if !modifierRequirementIsSatisfied(required) {
+                cancelPendingActivation()
+            }
+            if isDown, !modifierRequirementIsSatisfied(required) {
                 emitUp()
             }
         default:
@@ -174,22 +182,30 @@ final class PttMonitor {
     }
 
     private func handleKeyDown(_ event: CGEvent) {
+        if event.getIntegerValueField(.keyboardEventAutorepeat) != 0 {
+            return
+        }
+
         let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
         if modifierForKeyCode(keyCode) == nil {
-            cancelPendingModifierActivation()
+            cancelPendingActivation()
         }
 
         switch config {
         case let .key(requiredKeyCode):
             if keyCode == requiredKeyCode, pressedModifiers.isEmpty, !isDown {
-                emitDown()
+                scheduleActivation { monitor in
+                    monitor.pressedModifiers.isEmpty
+                }
             }
         case let .modifierKey(required, requiredKeyCode):
             if keyCode == requiredKeyCode,
                modifierRequirementIsSatisfied(required),
                !isDown
             {
-                emitDown()
+                scheduleActivation { monitor in
+                    monitor.modifierRequirementIsSatisfied(required)
+                }
             }
         default:
             break
@@ -200,11 +216,17 @@ final class PttMonitor {
         let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
         switch config {
         case let .key(requiredKeyCode):
-            if keyCode == requiredKeyCode && isDown {
+            if keyCode == requiredKeyCode {
+                cancelPendingActivation()
+            }
+            if keyCode == requiredKeyCode, isDown {
                 emitUp()
             }
         case let .modifierKey(_, requiredKeyCode):
-            if keyCode == requiredKeyCode && isDown {
+            if keyCode == requiredKeyCode {
+                cancelPendingActivation()
+            }
+            if keyCode == requiredKeyCode, isDown {
                 emitUp()
             }
         default:
@@ -230,27 +252,27 @@ final class PttMonitor {
         }
     }
 
-    private func scheduleModifierActivation(required: Set<PttModifier>) {
-        if isDown || pendingModifierTimer != nil {
+    private func scheduleActivation(when condition: @escaping (PttMonitor) -> Bool) {
+        if isDown || pendingActivationTimer != nil {
             return
         }
-        pendingModifierTimer = Timer.scheduledTimer(
+        pendingActivationTimer = Timer.scheduledTimer(
             withTimeInterval: Self.holdDelaySeconds,
             repeats: false
         ) { [weak self] _ in
             guard let self else {
                 return
             }
-            self.pendingModifierTimer = nil
-            if self.modifierRequirementIsSatisfied(required), !self.isDown {
+            self.pendingActivationTimer = nil
+            if condition(self), !self.isDown {
                 self.emitDown()
             }
         }
     }
 
-    private func cancelPendingModifierActivation() {
-        pendingModifierTimer?.invalidate()
-        pendingModifierTimer = nil
+    private func cancelPendingActivation() {
+        pendingActivationTimer?.invalidate()
+        pendingActivationTimer = nil
     }
 
     private func emitDown() {

--- a/apps/macos/native/mac-helper/Sources/MacHelperExecutable/PttMonitor.swift
+++ b/apps/macos/native/mac-helper/Sources/MacHelperExecutable/PttMonitor.swift
@@ -34,6 +34,7 @@ final class PttMonitor {
     private var config: PttConfig = .none
     private var eventTap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
+    private var pressedModifierKeyCodes = Set<Int64>()
     private var pressedModifiers = Set<PttModifier>()
     private var isDown = false
     private var pendingActivationTimer: Timer?
@@ -72,6 +73,7 @@ final class PttMonitor {
             eventTap = nil
         }
         pressedModifiers.removeAll()
+        pressedModifierKeyCodes.removeAll()
     }
 
     fileprivate func handle(type: CGEventType, event: CGEvent) {
@@ -141,14 +143,10 @@ final class PttMonitor {
     }
 
     private func handleFlagsChanged(_ event: CGEvent) {
-        let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
-        if let modifier = modifierForKeyCode(keyCode) {
-            if modifierIsDown(modifier, flags: event.flags) {
-                pressedModifiers.insert(modifier)
-            } else {
-                pressedModifiers.remove(modifier)
-            }
-        }
+        updatePressedModifiers(
+            changedKeyCode: event.getIntegerValueField(.keyboardEventKeycode),
+            flags: event.flags
+        )
 
         switch config {
         case let .modifierOnly(required):
@@ -170,15 +168,39 @@ final class PttMonitor {
                 emitUp()
             }
         case let .modifierKey(required, _):
-            if !modifierRequirementIsSatisfied(required) {
+            let satisfied = modifierRequirementIsSatisfied(required)
+            if !satisfied {
                 cancelPendingActivation()
             }
-            if isDown, !modifierRequirementIsSatisfied(required) {
+            if isDown, !satisfied {
                 emitUp()
             }
         default:
             break
         }
+    }
+
+    private func updatePressedModifiers(
+        changedKeyCode: Int64,
+        flags: CGEventFlags
+    ) {
+        if let modifier = modifierForKeyCode(changedKeyCode) {
+            if pressedModifierKeyCodes.contains(changedKeyCode) {
+                pressedModifierKeyCodes.remove(changedKeyCode)
+            } else if modifierIsDown(modifier, flags: flags) {
+                pressedModifierKeyCodes.insert(changedKeyCode)
+            }
+        } else {
+            pressedModifierKeyCodes = pressedModifierKeyCodes.filter { code in
+                guard let modifier = modifierForKeyCode(code) else {
+                    return false
+                }
+                return modifierIsDown(modifier, flags: flags)
+            }
+        }
+        pressedModifiers = Set(
+            pressedModifierKeyCodes.compactMap { modifierForKeyCode($0) }
+        )
     }
 
     private func handleKeyDown(_ event: CGEvent) {

--- a/apps/macos/native/mac-helper/Sources/MacHelperExecutable/PttMonitor.swift
+++ b/apps/macos/native/mac-helper/Sources/MacHelperExecutable/PttMonitor.swift
@@ -1,0 +1,415 @@
+import CoreGraphics
+import Foundation
+import MacHelperCore
+
+enum PttModifier: String, Hashable {
+    case function
+    case control
+    case shift
+    case option
+    case command
+    case rightCommand
+    case rightOption
+}
+
+enum PttConfig: Equatable {
+    case none
+    case modifierOnly(Set<PttModifier>)
+    case key(keyCode: Int64)
+    case modifierKey(modifiers: Set<PttModifier>, keyCode: Int64)
+    case mouseButton(button: Int64)
+
+    var isEnabled: Bool {
+        if case .none = self {
+            return false
+        }
+        return true
+    }
+}
+
+final class PttMonitor {
+    private static let holdDelaySeconds: TimeInterval = 0.3
+
+    private let emitState: (String) -> Void
+    private var config: PttConfig = .none
+    private var eventTap: CFMachPort?
+    private var runLoopSource: CFRunLoopSource?
+    private var pressedModifiers = Set<PttModifier>()
+    private var isDown = false
+    private var pendingModifierTimer: Timer?
+
+    init(emitState: @escaping (String) -> Void) {
+        self.emitState = emitState
+    }
+
+    func setConfig(_ nextConfig: PttConfig) throws -> Bool {
+        cancelPendingModifierActivation()
+        if isDown {
+            emitUp()
+        }
+
+        config = nextConfig
+        guard nextConfig.isEnabled else {
+            stop()
+            return false
+        }
+
+        try start()
+        return true
+    }
+
+    func stop() {
+        cancelPendingModifierActivation()
+        if isDown {
+            emitUp()
+        }
+        if let source = runLoopSource {
+            CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
+            runLoopSource = nil
+        }
+        if let tap = eventTap {
+            CGEvent.tapEnable(tap: tap, enable: false)
+            eventTap = nil
+        }
+        pressedModifiers.removeAll()
+    }
+
+    fileprivate func handle(type: CGEventType, event: CGEvent) {
+        if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+            if let eventTap {
+                CGEvent.tapEnable(tap: eventTap, enable: true)
+            }
+            return
+        }
+
+        switch type {
+        case .flagsChanged:
+            handleFlagsChanged(event)
+        case .keyDown:
+            handleKeyDown(event)
+        case .keyUp:
+            handleKeyUp(event)
+        case .leftMouseDown, .rightMouseDown, .otherMouseDown:
+            handleMouseDown(type: type, event: event)
+        case .leftMouseUp, .rightMouseUp, .otherMouseUp:
+            handleMouseUp(type: type, event: event)
+        default:
+            return
+        }
+    }
+
+    private func start() throws {
+        if eventTap != nil {
+            return
+        }
+
+        let mask = Self.eventMask([
+            .flagsChanged,
+            .keyDown,
+            .keyUp,
+            .leftMouseDown,
+            .leftMouseUp,
+            .rightMouseDown,
+            .rightMouseUp,
+            .otherMouseDown,
+            .otherMouseUp,
+        ])
+        let userInfo = Unmanaged.passUnretained(self).toOpaque()
+        guard
+            let tap = CGEvent.tapCreate(
+                tap: .cgSessionEventTap,
+                place: .headInsertEventTap,
+                options: .listenOnly,
+                eventsOfInterest: mask,
+                callback: pttEventTapCallback,
+                userInfo: userInfo
+            )
+        else {
+            throw PttMonitorError.eventTapUnavailable
+        }
+        guard
+            let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
+        else {
+            CFMachPortInvalidate(tap)
+            throw PttMonitorError.runLoopSourceUnavailable
+        }
+
+        eventTap = tap
+        runLoopSource = source
+        CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
+        CGEvent.tapEnable(tap: tap, enable: true)
+    }
+
+    private func handleFlagsChanged(_ event: CGEvent) {
+        let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
+        if let modifier = modifierForKeyCode(keyCode) {
+            if modifierIsDown(modifier, flags: event.flags) {
+                pressedModifiers.insert(modifier)
+            } else {
+                pressedModifiers.remove(modifier)
+            }
+        }
+
+        switch config {
+        case let .modifierOnly(required):
+            if pressedModifiers == required {
+                scheduleModifierActivation(required: required)
+            } else {
+                cancelPendingModifierActivation()
+                if isDown {
+                    emitUp()
+                }
+            }
+        case .key:
+            if isDown && !pressedModifiers.isEmpty {
+                emitUp()
+            }
+        case let .modifierKey(required, _):
+            if isDown && pressedModifiers != required {
+                emitUp()
+            }
+        default:
+            break
+        }
+    }
+
+    private func handleKeyDown(_ event: CGEvent) {
+        let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
+        if modifierForKeyCode(keyCode) == nil {
+            cancelPendingModifierActivation()
+        }
+
+        switch config {
+        case let .key(requiredKeyCode):
+            if keyCode == requiredKeyCode, pressedModifiers.isEmpty, !isDown {
+                emitDown()
+            }
+        case let .modifierKey(required, requiredKeyCode):
+            if keyCode == requiredKeyCode,
+               pressedModifiers == required,
+               !isDown
+            {
+                emitDown()
+            }
+        default:
+            break
+        }
+    }
+
+    private func handleKeyUp(_ event: CGEvent) {
+        let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
+        switch config {
+        case let .key(requiredKeyCode):
+            if keyCode == requiredKeyCode && isDown {
+                emitUp()
+            }
+        case let .modifierKey(_, requiredKeyCode):
+            if keyCode == requiredKeyCode && isDown {
+                emitUp()
+            }
+        default:
+            break
+        }
+    }
+
+    private func handleMouseDown(type: CGEventType, event: CGEvent) {
+        guard case let .mouseButton(button) = config else {
+            return
+        }
+        if mouseButtonNumber(type: type, event: event) == button && !isDown {
+            emitDown()
+        }
+    }
+
+    private func handleMouseUp(type: CGEventType, event: CGEvent) {
+        guard case let .mouseButton(button) = config else {
+            return
+        }
+        if mouseButtonNumber(type: type, event: event) == button && isDown {
+            emitUp()
+        }
+    }
+
+    private func scheduleModifierActivation(required: Set<PttModifier>) {
+        if isDown || pendingModifierTimer != nil {
+            return
+        }
+        pendingModifierTimer = Timer.scheduledTimer(
+            withTimeInterval: Self.holdDelaySeconds,
+            repeats: false
+        ) { [weak self] _ in
+            guard let self else {
+                return
+            }
+            self.pendingModifierTimer = nil
+            if self.pressedModifiers == required, !self.isDown {
+                self.emitDown()
+            }
+        }
+    }
+
+    private func cancelPendingModifierActivation() {
+        pendingModifierTimer?.invalidate()
+        pendingModifierTimer = nil
+    }
+
+    private func emitDown() {
+        guard !isDown else {
+            return
+        }
+        isDown = true
+        emitState("down")
+    }
+
+    private func emitUp() {
+        guard isDown else {
+            return
+        }
+        isDown = false
+        emitState("up")
+    }
+
+    private func modifierForKeyCode(_ keyCode: Int64) -> PttModifier? {
+        switch keyCode {
+        case 54:
+            return .rightCommand
+        case 55:
+            return .command
+        case 56, 60:
+            return .shift
+        case 58:
+            return .option
+        case 59, 62:
+            return .control
+        case 61:
+            return .rightOption
+        case 63:
+            return .function
+        default:
+            return nil
+        }
+    }
+
+    private func modifierIsDown(_ modifier: PttModifier, flags: CGEventFlags) -> Bool {
+        switch modifier {
+        case .function:
+            return flags.contains(.maskSecondaryFn)
+        case .control:
+            return flags.contains(.maskControl)
+        case .shift:
+            return flags.contains(.maskShift)
+        case .option, .rightOption:
+            return flags.contains(.maskAlternate)
+        case .command, .rightCommand:
+            return flags.contains(.maskCommand)
+        }
+    }
+
+    private func mouseButtonNumber(type: CGEventType, event: CGEvent) -> Int64 {
+        switch type {
+        case .leftMouseDown, .leftMouseUp:
+            return 0
+        case .rightMouseDown, .rightMouseUp:
+            return 1
+        default:
+            return event.getIntegerValueField(.mouseEventButtonNumber)
+        }
+    }
+
+    private static func eventMask(_ types: [CGEventType]) -> CGEventMask {
+        types.reduce(CGEventMask(0)) { mask, type in
+            mask | (CGEventMask(1) << CGEventMask(type.rawValue))
+        }
+    }
+}
+
+private func pttEventTapCallback(
+    proxy _: CGEventTapProxy,
+    type: CGEventType,
+    event: CGEvent,
+    userInfo: UnsafeMutableRawPointer?
+) -> Unmanaged<CGEvent>? {
+    guard let userInfo else {
+        return Unmanaged.passUnretained(event)
+    }
+
+    let monitor = Unmanaged<PttMonitor>.fromOpaque(userInfo).takeUnretainedValue()
+    monitor.handle(type: type, event: event)
+    return Unmanaged.passUnretained(event)
+}
+
+enum PttMonitorError: LocalizedError {
+    case eventTapUnavailable
+    case runLoopSourceUnavailable
+
+    var errorDescription: String? {
+        switch self {
+        case .eventTapUnavailable:
+            return "CGEvent tap is unavailable"
+        case .runLoopSourceUnavailable:
+            return "CGEvent tap run loop source is unavailable"
+        }
+    }
+}
+
+func parsePttConfig(_ params: Any?) throws -> PttConfig {
+    guard
+        let object = params as? [String: Any],
+        let rawConfig = object["config"] as? [String: Any],
+        let kind = rawConfig["kind"] as? String
+    else {
+        throw JsonRpcDispatchError.invalidParams("ptt.setConfig requires config")
+    }
+
+    switch kind {
+    case "none":
+        return .none
+    case "modifierOnly":
+        return .modifierOnly(try parseModifiers(rawConfig["modifiers"]))
+    case "key":
+        return .key(keyCode: try parseInt(rawConfig["keyCode"], name: "keyCode"))
+    case "modifierKey":
+        return .modifierKey(
+            modifiers: try parseModifiers(rawConfig["modifiers"]),
+            keyCode: try parseInt(rawConfig["keyCode"], name: "keyCode")
+        )
+    case "mouseButton":
+        return .mouseButton(button: try parseInt(rawConfig["button"], name: "button"))
+    default:
+        throw JsonRpcDispatchError.invalidParams("Unknown PTT config kind")
+    }
+}
+
+private func parseModifiers(_ value: Any?) throws -> Set<PttModifier> {
+    guard let values = value as? [Any], !values.isEmpty else {
+        throw JsonRpcDispatchError.invalidParams("PTT modifiers must be non-empty")
+    }
+    var modifiers = Set<PttModifier>()
+    for value in values {
+        guard
+            let raw = value as? String,
+            let modifier = PttModifier(rawValue: raw)
+        else {
+            throw JsonRpcDispatchError.invalidParams("Unknown PTT modifier")
+        }
+        modifiers.insert(modifier)
+    }
+    return modifiers
+}
+
+private func parseInt(_ value: Any?, name: String) throws -> Int64 {
+    let parsed: Int64
+    if value is Bool {
+        throw JsonRpcDispatchError.invalidParams("PTT \(name) must be a number")
+    } else if let number = value as? NSNumber {
+        parsed = number.int64Value
+    } else if let int = value as? Int {
+        parsed = Int64(int)
+    } else {
+        throw JsonRpcDispatchError.invalidParams("PTT \(name) must be a number")
+    }
+    if parsed < 0 {
+        throw JsonRpcDispatchError.invalidParams("PTT \(name) must be non-negative")
+    }
+    return parsed
+}

--- a/apps/macos/native/mac-helper/Sources/MacHelperExecutable/PttMonitor.swift
+++ b/apps/macos/native/mac-helper/Sources/MacHelperExecutable/PttMonitor.swift
@@ -152,7 +152,7 @@ final class PttMonitor {
 
         switch config {
         case let .modifierOnly(required):
-            if pressedModifiers == required {
+            if modifierRequirementIsSatisfied(required) {
                 scheduleModifierActivation(required: required)
             } else {
                 cancelPendingModifierActivation()
@@ -165,7 +165,7 @@ final class PttMonitor {
                 emitUp()
             }
         case let .modifierKey(required, _):
-            if isDown && pressedModifiers != required {
+            if isDown && !modifierRequirementIsSatisfied(required) {
                 emitUp()
             }
         default:
@@ -186,7 +186,7 @@ final class PttMonitor {
             }
         case let .modifierKey(required, requiredKeyCode):
             if keyCode == requiredKeyCode,
-               pressedModifiers == required,
+               modifierRequirementIsSatisfied(required),
                !isDown
             {
                 emitDown()
@@ -242,7 +242,7 @@ final class PttMonitor {
                 return
             }
             self.pendingModifierTimer = nil
-            if self.pressedModifiers == required, !self.isDown {
+            if self.modifierRequirementIsSatisfied(required), !self.isDown {
                 self.emitDown()
             }
         }
@@ -303,6 +303,21 @@ final class PttMonitor {
         case .command, .rightCommand:
             return flags.contains(.maskCommand)
         }
+    }
+
+    private func modifierRequirementIsSatisfied(_ required: Set<PttModifier>) -> Bool {
+        var pressed = pressedModifiers
+        if required.contains(.option), !required.contains(.rightOption) {
+            if pressed.remove(.rightOption) != nil {
+                pressed.insert(.option)
+            }
+        }
+        if required.contains(.command), !required.contains(.rightCommand) {
+            if pressed.remove(.rightCommand) != nil {
+                pressed.insert(.command)
+            }
+        }
+        return pressed == required
     }
 
     private func mouseButtonNumber(type: CGEventType, event: CGEvent) -> Int64 {

--- a/apps/macos/native/mac-helper/Sources/MacHelperExecutable/main.swift
+++ b/apps/macos/native/mac-helper/Sources/MacHelperExecutable/main.swift
@@ -67,6 +67,9 @@ final class MacHelper: @unchecked Sendable {
     // Bumped on every dictation.setPartials so a pending speech-authorization
     // callback can tell the session it was starting has since been stopped.
     private var dictationGeneration = 0
+    private lazy var pttMonitor = PttMonitor { [weak self] state in
+        self?.writeNotification(method: "ptt.event", params: ["state": state])
+    }
 
     init(isDisclaimed: Bool) {
         self.isDisclaimed = isDisclaimed
@@ -90,6 +93,13 @@ final class MacHelper: @unchecked Sendable {
                 )
             }
             return try self.setFnPushToTalk(enable: enable)
+        }
+        router.register("ptt.setConfig") { [weak self] params in
+            guard let self else {
+                throw JsonRpcDispatchError.internalError("Helper is shutting down")
+            }
+            let config = try parsePttConfig(params)
+            return try self.setPttConfig(config)
         }
         router.register("dictation.setPartials") { [weak self] params in
             guard let self else {
@@ -280,6 +290,10 @@ final class MacHelper: @unchecked Sendable {
         }
     }
 
+    private func setPttConfig(_ config: PttConfig) throws -> [String: Any] {
+        ["enabled": try pttMonitor.setConfig(config)]
+    }
+
     private func registerFnHotkey() throws {
         if !handlerRefs.isEmpty {
             return
@@ -391,6 +405,7 @@ final class MacHelper: @unchecked Sendable {
         dictationGeneration += 1
         dictationSession?.stop()
         dictationSession = nil
+        pttMonitor.stop()
         unregisterFnHotkey()
     }
 

--- a/apps/macos/src/main/hotkey-helper.test.ts
+++ b/apps/macos/src/main/hotkey-helper.test.ts
@@ -151,6 +151,9 @@ const invokeFnPushToTalkFrom = (enable: boolean, sender: FakeWebContents) =>
 const invokePttGetConfig = () =>
   handlers["vellum:ptt:getConfig"]({ sender: defaultSender }) as unknown;
 
+const invokePttGetConfigState = () =>
+  handlers["vellum:ptt:getConfigState"]({ sender: defaultSender }) as unknown;
+
 const invokePttSetConfig = (config: unknown) =>
   handlers["vellum:ptt:setConfig"](
     { sender: defaultSender },
@@ -220,6 +223,7 @@ describe("installHotkeyHelper", () => {
     expect(handlers["vellum:helper:state:get"]).toBeDefined();
     expect(handlers["vellum:helper:restart"]).toBeDefined();
     expect(handlers["vellum:ptt:getConfig"]).toBeDefined();
+    expect(handlers["vellum:ptt:getConfigState"]).toBeDefined();
     expect(handlers["vellum:ptt:setConfig"]).toBeDefined();
     expect(handlers["vellum:ptt:configure"]).toBeDefined();
     expect(handlers["vellum:helper:hotkey:fnPushToTalk"]).toBeDefined();
@@ -338,6 +342,10 @@ describe("installHotkeyHelper", () => {
       kind: "modifierOnly",
       modifiers: ["function"],
     });
+    expect(invokePttGetConfigState()).toEqual({
+      config: { kind: "modifierOnly", modifiers: ["function"] },
+      isStored: false,
+    });
 
     expect(invokePttSetConfig({ kind: "mouseButton", button: 4 })).toEqual({
       kind: "mouseButton",
@@ -345,6 +353,10 @@ describe("installHotkeyHelper", () => {
     });
     expect(hotkeysSetting.ptt).toEqual({ kind: "mouseButton", button: 4 });
     expect(invokePttGetConfig()).toEqual({ kind: "mouseButton", button: 4 });
+    expect(invokePttGetConfigState()).toEqual({
+      config: { kind: "mouseButton", button: 4 },
+      isStored: true,
+    });
   });
 
   test("configures generic push-to-talk through the helper process", async () => {

--- a/apps/macos/src/main/hotkey-helper.test.ts
+++ b/apps/macos/src/main/hotkey-helper.test.ts
@@ -94,6 +94,35 @@ mock.module("./app-origin", () => ({
   resolveAllowedOrigin: () => ({ protocol: "app:", host: "vellum.ai" }),
 }));
 
+type HotkeysSetting = Record<string, string | Record<string, unknown>>;
+
+let hotkeysSetting: HotkeysSetting = {};
+const settingsListeners = new Set<
+  (newValue: HotkeysSetting, oldValue: HotkeysSetting) => void
+>();
+
+mock.module("./settings", () => ({
+  readSetting: (key: string) => (key === "hotkeys" ? hotkeysSetting : null),
+  writeSetting: (key: string, value: unknown) => {
+    if (key !== "hotkeys") return;
+    const oldValue = hotkeysSetting;
+    hotkeysSetting = value as HotkeysSetting;
+    for (const listener of settingsListeners) {
+      listener(hotkeysSetting, oldValue);
+    }
+  },
+  onSettingChange: (
+    key: string,
+    callback: (newValue: HotkeysSetting, oldValue: HotkeysSetting) => void,
+  ) => {
+    if (key !== "hotkeys") return () => undefined;
+    settingsListeners.add(callback);
+    return () => {
+      settingsListeners.delete(callback);
+    };
+  },
+}));
+
 Object.defineProperty(process, "resourcesPath", {
   value: "/mock/resources",
   writable: true,
@@ -119,6 +148,24 @@ const invokeFnPushToTalkFrom = (enable: boolean, sender: FakeWebContents) =>
     enable,
   ) as Promise<unknown>;
 
+const invokePttGetConfig = () =>
+  handlers["vellum:ptt:getConfig"]({ sender: defaultSender }) as unknown;
+
+const invokePttSetConfig = (config: unknown) =>
+  handlers["vellum:ptt:setConfig"](
+    { sender: defaultSender },
+    config,
+  ) as unknown;
+
+const invokePttConfigure = (
+  config: unknown,
+  sender: FakeWebContents = defaultSender,
+) =>
+  handlers["vellum:ptt:configure"](
+    { sender },
+    config,
+  ) as Promise<unknown>;
+
 const invokePing = () =>
   handlers["vellum:helper:ping"]({ sender: defaultSender }) as Promise<unknown>;
 
@@ -141,6 +188,8 @@ beforeEach(() => {
   exists = true;
   appState.isPackaged = false;
   appState.appPath = "/repo/apps/macos";
+  hotkeysSetting = {};
+  settingsListeners.clear();
   nextWebContentsId = 1;
   defaultSender = makeWebContents();
 });
@@ -170,6 +219,9 @@ describe("installHotkeyHelper", () => {
     expect(handlers["vellum:helper:ping"]).toBeDefined();
     expect(handlers["vellum:helper:state:get"]).toBeDefined();
     expect(handlers["vellum:helper:restart"]).toBeDefined();
+    expect(handlers["vellum:ptt:getConfig"]).toBeDefined();
+    expect(handlers["vellum:ptt:setConfig"]).toBeDefined();
+    expect(handlers["vellum:ptt:configure"]).toBeDefined();
     expect(handlers["vellum:helper:hotkey:fnPushToTalk"]).toBeDefined();
   });
 
@@ -279,6 +331,74 @@ describe("installHotkeyHelper", () => {
     expect(await pending).toEqual({ ok: true, enabled: true });
   });
 
+  test("reads and writes structured push-to-talk config", () => {
+    installHotkeyHelper();
+
+    expect(invokePttGetConfig()).toEqual({
+      kind: "modifierOnly",
+      modifiers: ["function"],
+    });
+
+    expect(invokePttSetConfig({ kind: "mouseButton", button: 4 })).toEqual({
+      kind: "mouseButton",
+      button: 4,
+    });
+    expect(hotkeysSetting.ptt).toEqual({ kind: "mouseButton", button: 4 });
+    expect(invokePttGetConfig()).toEqual({ kind: "mouseButton", button: 4 });
+  });
+
+  test("configures generic push-to-talk through the helper process", async () => {
+    installHotkeyHelper();
+    const pending = invokePttConfigure({ kind: "mouseButton", button: 4 });
+
+    expect(spawnCalls[0]?.[0]).toBe(
+      "/repo/apps/macos/resources/vellum-mac-helper",
+    );
+    expect(lastChild?.stdin.writes[0]).toContain("\"jsonrpc\":\"2.0\"");
+    expect(lastChild?.stdin.writes[0]).toContain("\"method\":\"ptt.setConfig\"");
+    expect(lastChild?.stdin.writes[0]).toContain("\"kind\":\"mouseButton\"");
+    expect(lastChild?.stdin.writes[0]).toContain("\"button\":4");
+
+    lastChild?.stdout.emit(
+      "data",
+      Buffer.from(
+        "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"enabled\":true}}\n",
+      ),
+    );
+
+    expect(await pending).toEqual({
+      ok: true,
+      enabled: true,
+      config: { kind: "mouseButton", button: 4 },
+    });
+
+    lastChild?.stdout.emit(
+      "data",
+      Buffer.from(
+        "{\"jsonrpc\":\"2.0\",\"method\":\"ptt.event\",\"params\":{\"state\":\"down\"}}\n",
+      ),
+    );
+
+    expect(defaultSender.send).toHaveBeenCalledWith("vellum:ptt:state", {
+      state: "down",
+    });
+
+    const disabled = invokePttConfigure({ kind: "none" });
+    expect(lastChild?.stdin.writes.at(-1)).toContain("\"kind\":\"none\"");
+    lastChild?.stdout.emit(
+      "data",
+      Buffer.from(
+        "{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"enabled\":false}}\n",
+      ),
+    );
+
+    expect(await disabled).toEqual({
+      ok: true,
+      enabled: false,
+      config: { kind: "none" },
+    });
+  });
+
   test("restarts the helper after a crash", async () => {
     __setSupervisorOptionsForTesting({
       initialBackoffMs: 1,
@@ -327,6 +447,37 @@ describe("installHotkeyHelper", () => {
       "\"method\":\"hotkey.fnPushToTalk\"",
     );
     expect(lastChild?.stdin.writes[0]).toContain("\"enable\":true");
+  });
+
+  test("restores generic push-to-talk after a helper crash", async () => {
+    __setSupervisorOptionsForTesting({
+      initialBackoffMs: 1,
+      maxBackoffMs: 1,
+    });
+    installHotkeyHelper();
+
+    const pending = invokePttConfigure({ kind: "mouseButton", button: 4 });
+    lastChild?.stdout.emit(
+      "data",
+      Buffer.from(
+        "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"enabled\":true}}\n",
+      ),
+    );
+    expect(await pending).toEqual({
+      ok: true,
+      enabled: true,
+      config: { kind: "mouseButton", button: 4 },
+    });
+
+    const crashed = lastChild;
+    crashed?.emit("close", 1, null);
+    await wait(5);
+
+    expect(spawnCalls).toHaveLength(2);
+    expect(lastChild).not.toBe(crashed);
+    expect(lastChild?.stdin.writes[0]).toContain("\"method\":\"ptt.setConfig\"");
+    expect(lastChild?.stdin.writes[0]).toContain("\"kind\":\"mouseButton\"");
+    expect(lastChild?.stdin.writes[0]).toContain("\"button\":4");
   });
 
   test("maps JSON-RPC helper errors to hotkey results", async () => {

--- a/apps/macos/src/main/hotkey-helper.test.ts
+++ b/apps/macos/src/main/hotkey-helper.test.ts
@@ -411,6 +411,63 @@ describe("installHotkeyHelper", () => {
     });
   });
 
+  test("configures default Fn push-to-talk through the legacy Fn helper path", async () => {
+    installHotkeyHelper();
+    const fnConfig = { kind: "modifierOnly", modifiers: ["function"] };
+    const pending = invokePttConfigure(fnConfig);
+
+    expect(spawnCalls[0]?.[0]).toBe(
+      "/repo/apps/macos/resources/vellum-mac-helper",
+    );
+    expect(lastChild?.stdin.writes[0]).toContain("\"jsonrpc\":\"2.0\"");
+    expect(lastChild?.stdin.writes[0]).toContain(
+      "\"method\":\"hotkey.fnPushToTalk\"",
+    );
+    expect(lastChild?.stdin.writes[0]).toContain("\"enable\":true");
+
+    lastChild?.stdout.emit(
+      "data",
+      Buffer.from(
+        "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"enabled\":true}}\n",
+      ),
+    );
+
+    expect(await pending).toEqual({
+      ok: true,
+      enabled: true,
+      config: fnConfig,
+    });
+
+    lastChild?.stdout.emit(
+      "data",
+      Buffer.from(
+        "{\"jsonrpc\":\"2.0\",\"method\":\"hotkey.event\",\"params\":{\"kind\":\"fnPushToTalk\",\"state\":\"down\"}}\n",
+      ),
+    );
+
+    expect(defaultSender.send).toHaveBeenCalledWith("vellum:ptt:state", {
+      state: "down",
+    });
+
+    const disabled = invokePttConfigure({ kind: "none" });
+    expect(lastChild?.stdin.writes.at(-1)).toContain(
+      "\"method\":\"hotkey.fnPushToTalk\"",
+    );
+    expect(lastChild?.stdin.writes.at(-1)).toContain("\"enable\":false");
+    lastChild?.stdout.emit(
+      "data",
+      Buffer.from(
+        "{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"enabled\":false}}\n",
+      ),
+    );
+
+    expect(await disabled).toEqual({
+      ok: true,
+      enabled: false,
+      config: { kind: "none" },
+    });
+  });
+
   test("restarts the helper after a crash", async () => {
     __setSupervisorOptionsForTesting({
       initialBackoffMs: 1,
@@ -490,6 +547,41 @@ describe("installHotkeyHelper", () => {
     expect(lastChild?.stdin.writes[0]).toContain("\"method\":\"ptt.setConfig\"");
     expect(lastChild?.stdin.writes[0]).toContain("\"kind\":\"mouseButton\"");
     expect(lastChild?.stdin.writes[0]).toContain("\"button\":4");
+  });
+
+  test("restores default Fn push-to-talk through the legacy path after a helper crash", async () => {
+    __setSupervisorOptionsForTesting({
+      initialBackoffMs: 1,
+      maxBackoffMs: 1,
+    });
+    installHotkeyHelper();
+
+    const pending = invokePttConfigure({
+      kind: "modifierOnly",
+      modifiers: ["function"],
+    });
+    lastChild?.stdout.emit(
+      "data",
+      Buffer.from(
+        "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"enabled\":true}}\n",
+      ),
+    );
+    expect(await pending).toEqual({
+      ok: true,
+      enabled: true,
+      config: { kind: "modifierOnly", modifiers: ["function"] },
+    });
+
+    const crashed = lastChild;
+    crashed?.emit("close", 1, null);
+    await wait(5);
+
+    expect(spawnCalls).toHaveLength(2);
+    expect(lastChild).not.toBe(crashed);
+    expect(lastChild?.stdin.writes[0]).toContain(
+      "\"method\":\"hotkey.fnPushToTalk\"",
+    );
+    expect(lastChild?.stdin.writes[0]).toContain("\"enable\":true");
   });
 
   test("maps JSON-RPC helper errors to hotkey results", async () => {

--- a/apps/macos/src/main/hotkey-helper.ts
+++ b/apps/macos/src/main/hotkey-helper.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 
 import { handle } from "./ipc";
 import log from "./logger";
+import { onSettingChange, readSetting, writeSetting } from "./settings";
 import {
   MacHelperClient,
   type MacHelperClientOptions,
@@ -17,8 +18,38 @@ export interface HotkeyEvent {
   state: HotkeyEventState;
 }
 
+export type PttModifier =
+  | "function"
+  | "control"
+  | "shift"
+  | "option"
+  | "command"
+  | "rightCommand"
+  | "rightOption";
+
+export type PttConfig =
+  | { kind: "none" }
+  | { kind: "modifierOnly"; modifiers: PttModifier[] }
+  | { kind: "key"; keyCode: number; code?: string; label?: string }
+  | {
+      kind: "modifierKey";
+      modifiers: PttModifier[];
+      keyCode: number;
+      code?: string;
+      label?: string;
+    }
+  | { kind: "mouseButton"; button: number };
+
+export interface PttEvent {
+  state: HotkeyEventState;
+}
+
 export type FnPushToTalkResult =
   | { ok: true; enabled: boolean }
+  | { ok: false; reason: string };
+
+export type PttRegistrationResult =
+  | { ok: true; enabled: boolean; config: PttConfig }
   | { ok: false; reason: string };
 
 export type HelperRestartResult =
@@ -38,7 +69,50 @@ const HOTKEY_EVENT_SCHEMA = z.object({
   state: z.enum(["down", "up"]),
 });
 
+const PTT_MODIFIER_SCHEMA = z.enum([
+  "function",
+  "control",
+  "shift",
+  "option",
+  "command",
+  "rightCommand",
+  "rightOption",
+]);
+
+const PTT_CONFIG_SCHEMA = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("none") }),
+  z.object({
+    kind: z.literal("modifierOnly"),
+    modifiers: z.array(PTT_MODIFIER_SCHEMA).min(1),
+  }),
+  z.object({
+    kind: z.literal("key"),
+    keyCode: z.number().int().nonnegative(),
+    code: z.string().optional(),
+    label: z.string().optional(),
+  }),
+  z.object({
+    kind: z.literal("modifierKey"),
+    modifiers: z.array(PTT_MODIFIER_SCHEMA).min(1),
+    keyCode: z.number().int().nonnegative(),
+    code: z.string().optional(),
+    label: z.string().optional(),
+  }),
+  z.object({
+    kind: z.literal("mouseButton"),
+    button: z.number().int().nonnegative(),
+  }),
+]) satisfies z.ZodType<PttConfig>;
+
+const PTT_EVENT_SCHEMA = z.object({
+  state: z.enum(["down", "up"]),
+});
+
 const HOTKEY_RESULT_SCHEMA = z.object({
+  enabled: z.boolean(),
+});
+
+const PTT_RESULT_SCHEMA = z.object({
   enabled: z.boolean(),
 });
 
@@ -66,6 +140,13 @@ let supervisorOptionsForTesting: Partial<
 const getPlatform = (): NodeJS.Platform =>
   platformForTesting ?? process.platform;
 
+const NONE_PTT_CONFIG: PttConfig = { kind: "none" };
+const DEFAULT_PTT_CONFIG: PttConfig = {
+  kind: "modifierOnly",
+  modifiers: ["function"],
+};
+const PTT_HOTKEY_SETTING_KEY = "ptt";
+
 export const getMacHelperPath = (): string => {
   if (app.isPackaged) {
     return path.join(process.resourcesPath, "bin", "vellum-mac-helper");
@@ -83,6 +164,51 @@ const makeClient = (): MacHelperClient =>
   });
 
 let client = makeClient();
+
+const normalizePttConfig = (config: PttConfig): PttConfig => {
+  switch (config.kind) {
+    case "modifierOnly":
+      return {
+        kind: "modifierOnly",
+        modifiers: Array.from(new Set(config.modifiers)).sort(),
+      };
+    case "modifierKey":
+      return {
+        ...config,
+        modifiers: Array.from(new Set(config.modifiers)).sort(),
+      };
+    default:
+      return config;
+  }
+};
+
+const pttConfigsEqual = (a: PttConfig, b: PttConfig): boolean =>
+  JSON.stringify(normalizePttConfig(a)) ===
+  JSON.stringify(normalizePttConfig(b));
+
+const parseStoredPttConfig = (raw: unknown): PttConfig => {
+  const parsed = PTT_CONFIG_SCHEMA.safeParse(raw);
+  return parsed.success ? normalizePttConfig(parsed.data) : DEFAULT_PTT_CONFIG;
+};
+
+const readPttConfig = (): PttConfig =>
+  parseStoredPttConfig(readSetting("hotkeys")?.[PTT_HOTKEY_SETTING_KEY]);
+
+const writePttConfig = (config: PttConfig): PttConfig => {
+  const normalized = normalizePttConfig(config);
+  const next = { ...(readSetting("hotkeys") ?? {}) };
+  next[PTT_HOTKEY_SETTING_KEY] = normalized;
+  writeSetting("hotkeys", next);
+  return normalized;
+};
+
+const broadcastPttConfig = (): void => {
+  const config = readPttConfig();
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (win.webContents.isDestroyed()) continue;
+    win.webContents.send("vellum:ptt:configChanged", config);
+  }
+};
 
 const fnPushToTalk = async (
   enable: boolean,
@@ -102,6 +228,34 @@ const fnPushToTalk = async (
   }
 };
 
+const setNativePttConfig = async (
+  config: PttConfig,
+): Promise<PttRegistrationResult> => {
+  const normalized = normalizePttConfig(config);
+  try {
+    const result = await client.call("ptt.setConfig", { config: normalized });
+    const parsed = PTT_RESULT_SCHEMA.safeParse(result);
+    if (!parsed.success) {
+      return { ok: false, reason: "mac helper returned invalid PTT result" };
+    }
+    const expectedEnabled = normalized.kind !== "none";
+    if (parsed.data.enabled !== expectedEnabled) {
+      return {
+        ok: false,
+        reason: expectedEnabled
+          ? "mac helper did not enable push-to-talk"
+          : "mac helper did not disable push-to-talk",
+      };
+    }
+    return { ok: true, enabled: parsed.data.enabled, config: normalized };
+  } catch (err) {
+    return {
+      ok: false,
+      reason: err instanceof Error ? err.message : String(err),
+    };
+  }
+};
+
 const ping = async (): Promise<"pong"> => {
   const result = await client.call("ping");
   if (result !== "pong") {
@@ -113,6 +267,10 @@ const ping = async (): Promise<"pong"> => {
 interface HotkeyOwner {
   webContents: WebContents;
   cleanup: () => void;
+}
+
+interface PttOwner extends HotkeyOwner {
+  config: PttConfig;
 }
 
 // The renderer that most recently enabled dictation partials — the recording
@@ -157,6 +315,14 @@ let helperRegistrationSync: Promise<FnPushToTalkResult> | null = null;
 let restoreHotkeyAfterRestart = false;
 let restoreHotkeyInFlight = false;
 let pttIsDown = false;
+
+const pttOwners = new Map<number, PttOwner>();
+let activePttOwnerId: number | null = null;
+let helperPttConfig: PttConfig = NONE_PTT_CONFIG;
+let helperPttSync: Promise<PttRegistrationResult> | null = null;
+let restorePttAfterRestart = false;
+let restorePttInFlight = false;
+let nativePttIsDown = false;
 
 const shouldRegisterHelper = (): boolean => hotkeyOwners.size > 0;
 
@@ -294,6 +460,142 @@ const sendSyntheticHotkeyUpIfNeeded = (): void => {
   sendHotkeyEventToOwner({ kind: "fnPushToTalk", state: "up" });
 };
 
+const newestPttOwnerId = (): number | null => {
+  let id: number | null = null;
+  for (const [ownerId, owner] of pttOwners) {
+    if (!owner.webContents.isDestroyed()) id = ownerId;
+  }
+  return id;
+};
+
+const desiredPttConfig = (): PttConfig => {
+  const ownerId = activePttOwnerId ?? newestPttOwnerId();
+  const owner = ownerId !== null ? pttOwners.get(ownerId) : null;
+  return owner && !owner.webContents.isDestroyed()
+    ? owner.config
+    : NONE_PTT_CONFIG;
+};
+
+const removePttOwner = (webContentsId: number): void => {
+  const owner = pttOwners.get(webContentsId);
+  if (!owner) return;
+  owner.cleanup();
+  pttOwners.delete(webContentsId);
+  if (activePttOwnerId === webContentsId) {
+    activePttOwnerId = newestPttOwnerId();
+  }
+};
+
+const addOrUpdatePttOwner = (
+  webContents: WebContents,
+  config: PttConfig,
+): void => {
+  const id = webContents.id;
+  const existing = pttOwners.get(id);
+  if (existing) {
+    existing.config = config;
+    activePttOwnerId = id;
+    return;
+  }
+
+  const win = BrowserWindow.fromWebContents(webContents);
+  const markActive = () => {
+    if (pttOwners.has(id)) activePttOwnerId = id;
+  };
+  const handleDestroyed = () => {
+    removePttOwner(id);
+    void syncPttRegistration();
+  };
+
+  webContents.once("destroyed", handleDestroyed);
+  win?.on("focus", markActive);
+
+  pttOwners.set(id, {
+    webContents,
+    config,
+    cleanup: () => {
+      webContents.off("destroyed", handleDestroyed);
+      win?.off("focus", markActive);
+    },
+  });
+  activePttOwnerId = id;
+};
+
+const setHelperPttConfig = async (
+  config: PttConfig,
+): Promise<PttRegistrationResult> => {
+  const result = await setNativePttConfig(config);
+  if (!result.ok) return result;
+
+  helperPttConfig = result.config;
+  log.info(
+    result.enabled
+      ? `[mac-helper] enabled push-to-talk (${result.config.kind})`
+      : "[mac-helper] disabled push-to-talk",
+  );
+  return result;
+};
+
+const syncPttRegistration = (): Promise<PttRegistrationResult> => {
+  if (helperPttSync) return helperPttSync;
+
+  const sync = (async (): Promise<PttRegistrationResult> => {
+    let desired = desiredPttConfig();
+    while (!pttConfigsEqual(helperPttConfig, desired)) {
+      const result = await setHelperPttConfig(desired);
+      if (!result.ok) return result;
+      desired = desiredPttConfig();
+    }
+    return {
+      ok: true,
+      enabled: helperPttConfig.kind !== "none",
+      config: helperPttConfig,
+    };
+  })();
+  helperPttSync = sync;
+  void sync.finally(() => {
+    if (helperPttSync === sync) helperPttSync = null;
+  });
+  return sync;
+};
+
+const configurePttForOwner = async (
+  webContents: WebContents,
+  config: PttConfig,
+): Promise<PttRegistrationResult> => {
+  const normalized = normalizePttConfig(config);
+  if (normalized.kind === "none") {
+    removePttOwner(webContents.id);
+  } else {
+    addOrUpdatePttOwner(webContents, normalized);
+  }
+  const result = await syncPttRegistration();
+  if (!result.ok && normalized.kind !== "none") {
+    log.warn(`[mac-helper] failed to configure push-to-talk: ${result.reason}`);
+    removePttOwner(webContents.id);
+    void syncPttRegistration();
+  }
+  return result;
+};
+
+const sendPttEventToOwner = (event: PttEvent): void => {
+  nativePttIsDown = event.state === "down";
+  const ownerId = activePttOwnerId ?? newestPttOwnerId();
+  const activeOwner = ownerId !== null ? pttOwners.get(ownerId) : null;
+  const owner =
+    activeOwner && !activeOwner.webContents.isDestroyed()
+      ? activeOwner
+      : pttOwners.get(newestPttOwnerId() ?? -1);
+  if (!owner || owner.webContents.isDestroyed()) return;
+  owner.webContents.send("vellum:ptt:state", event);
+};
+
+const sendSyntheticPttUpIfNeeded = (): void => {
+  if (!nativePttIsDown) return;
+  nativePttIsDown = false;
+  sendPttEventToOwner({ state: "up" });
+};
+
 const sendHelperStateToRenderers = (state: MacHelperState): void => {
   for (const win of BrowserWindow.getAllWindows()) {
     if (win.webContents.isDestroyed()) continue;
@@ -326,21 +628,50 @@ const restoreHotkeyRegistrationIfNeeded = async (): Promise<void> => {
   }
 };
 
+const restorePttRegistrationIfNeeded = async (): Promise<void> => {
+  if (
+    !restorePttAfterRestart ||
+    restorePttInFlight ||
+    helperPttConfig.kind !== "none" ||
+    pttOwners.size === 0
+  ) {
+    return;
+  }
+
+  restorePttInFlight = true;
+  const result = await syncPttRegistration();
+  restorePttInFlight = false;
+  if (result.ok) {
+    restorePttAfterRestart = !result.enabled;
+    if (result.enabled) {
+      log.info("[mac-helper] restored push-to-talk after helper restart");
+    }
+  } else {
+    log.warn(`[mac-helper] failed to restore push-to-talk: ${result.reason}`);
+  }
+};
+
 const handleHelperState = (state: MacHelperState): void => {
   sendHelperStateToRenderers(state);
   if (state.status === "running") {
     void restoreHotkeyRegistrationIfNeeded();
+    void restorePttRegistrationIfNeeded();
     return;
   }
 
   if (helperRegistered && hotkeyOwners.size > 0) {
     restoreHotkeyAfterRestart = true;
   }
+  if (helperPttConfig.kind !== "none" && pttOwners.size > 0) {
+    restorePttAfterRestart = true;
+  }
   helperRegistered = false;
+  helperPttConfig = NONE_PTT_CONFIG;
   // The partials session lived in the dead helper process; the renderer's
   // session simply continues without live text.
   dictationPartialsOwner = null;
   sendSyntheticHotkeyUpIfNeeded();
+  sendSyntheticPttUpIfNeeded();
 };
 
 const restartHelper = (): HelperRestartResult => {
@@ -358,8 +689,10 @@ const restartHelper = (): HelperRestartResult => {
 
 let installed = false;
 let unsubscribeHotkeyEvents: (() => void) | null = null;
+let unsubscribePttEvents: (() => void) | null = null;
 let unsubscribeHelperState: (() => void) | null = null;
 let unsubscribeDictationPartials: (() => void) | null = null;
+let unsubscribePttConfigChanges: (() => void) | null = null;
 
 export const installHotkeyHelper = (): void => {
   if (installed) return;
@@ -370,6 +703,13 @@ export const installHotkeyHelper = (): void => {
     HOTKEY_EVENT_SCHEMA,
     (event) => {
       sendHotkeyEventToOwner(event);
+    },
+  );
+  unsubscribePttEvents = client.onNotification(
+    "ptt.event",
+    PTT_EVENT_SCHEMA,
+    (event) => {
+      sendPttEventToOwner(event);
     },
   );
   unsubscribeDictationPartials = client.onNotification(
@@ -384,6 +724,18 @@ export const installHotkeyHelper = (): void => {
   handle("vellum:helper:ping", z.tuple([]), () => ping());
   handle("vellum:helper:state:get", z.tuple([]), () => client.getState());
   handle("vellum:helper:restart", z.tuple([]), () => restartHelper());
+
+  handle("vellum:ptt:getConfig", z.tuple([]), () => readPttConfig());
+  handle(
+    "vellum:ptt:setConfig",
+    z.tuple([PTT_CONFIG_SCHEMA]),
+    ([config]) => writePttConfig(config),
+  );
+  handle(
+    "vellum:ptt:configure",
+    z.tuple([PTT_CONFIG_SCHEMA]),
+    ([config], event) => configurePttForOwner(event.sender, config),
+  );
 
   handle(
     "vellum:helper:hotkey:fnPushToTalk",
@@ -406,6 +758,15 @@ export const installHotkeyHelper = (): void => {
       params: { enable: false },
     });
   });
+
+  unsubscribePttConfigChanges = onSettingChange("hotkeys", (next, previous) => {
+    const nextConfig = parseStoredPttConfig(next?.[PTT_HOTKEY_SETTING_KEY]);
+    const previousConfig = parseStoredPttConfig(
+      previous?.[PTT_HOTKEY_SETTING_KEY],
+    );
+    if (pttConfigsEqual(nextConfig, previousConfig)) return;
+    broadcastPttConfig();
+  });
 };
 
 export const __resetForTesting = (): void => {
@@ -417,16 +778,28 @@ export const __resetForTesting = (): void => {
   restoreHotkeyAfterRestart = false;
   restoreHotkeyInFlight = false;
   pttIsDown = false;
+  helperPttConfig = NONE_PTT_CONFIG;
+  helperPttSync = null;
+  restorePttAfterRestart = false;
+  restorePttInFlight = false;
+  nativePttIsDown = false;
   unsubscribeHotkeyEvents?.();
   unsubscribeHotkeyEvents = null;
+  unsubscribePttEvents?.();
+  unsubscribePttEvents = null;
   unsubscribeHelperState?.();
   unsubscribeHelperState = null;
   unsubscribeDictationPartials?.();
   unsubscribeDictationPartials = null;
+  unsubscribePttConfigChanges?.();
+  unsubscribePttConfigChanges = null;
   dictationPartialsOwner = null;
   for (const owner of hotkeyOwners.values()) owner.cleanup();
   hotkeyOwners.clear();
   activeHotkeyOwnerId = null;
+  for (const owner of pttOwners.values()) owner.cleanup();
+  pttOwners.clear();
+  activePttOwnerId = null;
   client.resetForTesting();
   client = makeClient();
 };

--- a/apps/macos/src/main/hotkey-helper.ts
+++ b/apps/macos/src/main/hotkey-helper.ts
@@ -44,6 +44,11 @@ export interface PttEvent {
   state: HotkeyEventState;
 }
 
+export interface PttConfigState {
+  config: PttConfig;
+  isStored: boolean;
+}
+
 export type FnPushToTalkResult =
   | { ok: true; enabled: boolean }
   | { ok: false; reason: string };
@@ -191,8 +196,19 @@ const parseStoredPttConfig = (raw: unknown): PttConfig => {
   return parsed.success ? normalizePttConfig(parsed.data) : DEFAULT_PTT_CONFIG;
 };
 
+const readPttConfigState = (): PttConfigState => {
+  const raw = readSetting("hotkeys")?.[PTT_HOTKEY_SETTING_KEY];
+  const parsed = PTT_CONFIG_SCHEMA.safeParse(raw);
+  return {
+    config: parsed.success
+      ? normalizePttConfig(parsed.data)
+      : DEFAULT_PTT_CONFIG,
+    isStored: parsed.success,
+  };
+};
+
 const readPttConfig = (): PttConfig =>
-  parseStoredPttConfig(readSetting("hotkeys")?.[PTT_HOTKEY_SETTING_KEY]);
+  readPttConfigState().config;
 
 const writePttConfig = (config: PttConfig): PttConfig => {
   const normalized = normalizePttConfig(config);
@@ -726,6 +742,7 @@ export const installHotkeyHelper = (): void => {
   handle("vellum:helper:restart", z.tuple([]), () => restartHelper());
 
   handle("vellum:ptt:getConfig", z.tuple([]), () => readPttConfig());
+  handle("vellum:ptt:getConfigState", z.tuple([]), () => readPttConfigState());
   handle(
     "vellum:ptt:setConfig",
     z.tuple([PTT_CONFIG_SCHEMA]),

--- a/apps/macos/src/main/hotkey-helper.ts
+++ b/apps/macos/src/main/hotkey-helper.ts
@@ -191,6 +191,11 @@ const pttConfigsEqual = (a: PttConfig, b: PttConfig): boolean =>
   JSON.stringify(normalizePttConfig(a)) ===
   JSON.stringify(normalizePttConfig(b));
 
+const isFnOnlyPttConfig = (config: PttConfig): boolean =>
+  config.kind === "modifierOnly" &&
+  config.modifiers.length === 1 &&
+  config.modifiers[0] === "function";
+
 const parseStoredPttConfig = (raw: unknown): PttConfig => {
   const parsed = PTT_CONFIG_SCHEMA.safeParse(raw);
   return parsed.success ? normalizePttConfig(parsed.data) : DEFAULT_PTT_CONFIG;
@@ -244,7 +249,7 @@ const fnPushToTalk = async (
   }
 };
 
-const setNativePttConfig = async (
+const setNativeGenericPttConfig = async (
   config: PttConfig,
 ): Promise<PttRegistrationResult> => {
   const normalized = normalizePttConfig(config);
@@ -270,6 +275,39 @@ const setNativePttConfig = async (
       reason: err instanceof Error ? err.message : String(err),
     };
   }
+};
+
+const setNativePttConfig = async (
+  config: PttConfig,
+): Promise<PttRegistrationResult> => {
+  const normalized = normalizePttConfig(config);
+  const wasFnOnly = isFnOnlyPttConfig(helperPttConfig);
+  const nextIsFnOnly = isFnOnlyPttConfig(normalized);
+
+  if (wasFnOnly && !nextIsFnOnly) {
+    const disabled = await fnPushToTalk(false);
+    if (!disabled.ok) return disabled;
+    if (normalized.kind === "none") {
+      return { ok: true, enabled: false, config: normalized };
+    }
+  } else if (!wasFnOnly && nextIsFnOnly && helperPttConfig.kind !== "none") {
+    const disabled = await setNativeGenericPttConfig(NONE_PTT_CONFIG);
+    if (!disabled.ok) return disabled;
+  }
+
+  if (nextIsFnOnly) {
+    const result = await fnPushToTalk(true);
+    if (!result.ok) return result;
+    if (!result.enabled) {
+      return {
+        ok: false,
+        reason: "mac helper did not enable Fn push-to-talk",
+      };
+    }
+    return { ok: true, enabled: true, config: normalized };
+  }
+
+  return setNativeGenericPttConfig(normalized);
 };
 
 const ping = async (): Promise<"pong"> => {
@@ -466,8 +504,12 @@ const sendHotkeyEventToOwner = (event: HotkeyEvent): void => {
     activeOwner && !activeOwner.webContents.isDestroyed()
       ? activeOwner
       : hotkeyOwners.get(newestOwnerId() ?? -1);
-  if (!owner || owner.webContents.isDestroyed()) return;
-  owner.webContents.send("vellum:helper:hotkey:event", event);
+  if (owner && !owner.webContents.isDestroyed()) {
+    owner.webContents.send("vellum:helper:hotkey:event", event);
+  }
+  if (isFnOnlyPttConfig(helperPttConfig)) {
+    sendPttEventToOwner({ state: event.state });
+  }
 };
 
 const sendSyntheticHotkeyUpIfNeeded = (): void => {

--- a/apps/macos/src/main/settings.ts
+++ b/apps/macos/src/main/settings.ts
@@ -15,7 +15,7 @@ import Store, { type Schema } from "electron-store";
  * to share this file's strict schema.
  */
 export interface AppSettings {
-  hotkeys: Record<string, string>;
+  hotkeys: Record<string, string | Record<string, unknown>>;
   theme: "light" | "dark" | "system";
   featureFlags: Record<string, boolean>;
 }
@@ -23,7 +23,12 @@ export interface AppSettings {
 const schema: Schema<AppSettings> = {
   hotkeys: {
     type: "object",
-    additionalProperties: { type: "string" },
+    additionalProperties: {
+      anyOf: [
+        { type: "string" },
+        { type: "object", additionalProperties: true },
+      ],
+    },
     default: {},
   },
   theme: {

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -130,6 +130,11 @@ export interface PttEvent {
   state: HotkeyEventState;
 }
 
+export interface PttConfigState {
+  config: PttConfig;
+  isStored: boolean;
+}
+
 export type FnPushToTalkResult =
   | { ok: true; enabled: boolean }
   | { ok: false; reason: string };
@@ -358,6 +363,8 @@ export interface VellumBridge {
   ptt: {
     /** Read the structured push-to-talk activator from settings.hotkeys.ptt. */
     getConfig(): Promise<PttConfig>;
+    /** Read the PTT activator plus whether it is explicitly stored. */
+    getConfigState(): Promise<PttConfigState>;
     /** Persist the structured push-to-talk activator to settings.hotkeys.ptt. */
     setConfig(config: PttConfig): Promise<PttConfig>;
     /**
@@ -744,6 +751,10 @@ const bridge: VellumBridge = {
   ptt: {
     getConfig: (): Promise<PttConfig> =>
       ipcRenderer.invoke("vellum:ptt:getConfig") as Promise<PttConfig>,
+    getConfigState: (): Promise<PttConfigState> =>
+      ipcRenderer.invoke(
+        "vellum:ptt:getConfigState",
+      ) as Promise<PttConfigState>,
     setConfig: (config: PttConfig): Promise<PttConfig> =>
       ipcRenderer.invoke("vellum:ptt:setConfig", config) as Promise<PttConfig>,
     configure: (config: PttConfig): Promise<PttRegistrationResult> =>

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -104,8 +104,38 @@ export interface HotkeyEvent {
   state: HotkeyEventState;
 }
 
+export type PttModifier =
+  | "function"
+  | "control"
+  | "shift"
+  | "option"
+  | "command"
+  | "rightCommand"
+  | "rightOption";
+
+export type PttConfig =
+  | { kind: "none" }
+  | { kind: "modifierOnly"; modifiers: PttModifier[] }
+  | { kind: "key"; keyCode: number; code?: string; label?: string }
+  | {
+      kind: "modifierKey";
+      modifiers: PttModifier[];
+      keyCode: number;
+      code?: string;
+      label?: string;
+    }
+  | { kind: "mouseButton"; button: number };
+
+export interface PttEvent {
+  state: HotkeyEventState;
+}
+
 export type FnPushToTalkResult =
   | { ok: true; enabled: boolean }
+  | { ok: false; reason: string };
+
+export type PttRegistrationResult =
+  | { ok: true; enabled: boolean; config: PttConfig }
   | { ok: false; reason: string };
 
 // Mirrors `DictationPartialsResult` / `DictationPartialEvent` in
@@ -324,6 +354,21 @@ export interface VellumBridge {
   featureFlags: {
     /** Publish the renderer's feature-flag map to main (fire-and-forget). */
     set(flags: Record<string, boolean>): void;
+  };
+  ptt: {
+    /** Read the structured push-to-talk activator from settings.hotkeys.ptt. */
+    getConfig(): Promise<PttConfig>;
+    /** Persist the structured push-to-talk activator to settings.hotkeys.ptt. */
+    setConfig(config: PttConfig): Promise<PttConfig>;
+    /**
+     * Arm or disarm native monitoring for this renderer. Main routes native
+     * PTT events to the active renderer owner.
+     */
+    configure(config: PttConfig): Promise<PttRegistrationResult>;
+    /** Subscribe to native PTT down/up states. */
+    on(callback: (event: PttEvent) => void): () => void;
+    /** Subscribe to settings changes for the persisted PTT config. */
+    onConfigChange(callback: (config: PttConfig) => void): () => void;
   };
   helper: {
     ping(): Promise<"pong">;
@@ -694,6 +739,35 @@ const bridge: VellumBridge = {
   featureFlags: {
     set: (flags: Record<string, boolean>): void => {
       ipcRenderer.send("vellum:featureFlags:set", flags);
+    },
+  },
+  ptt: {
+    getConfig: (): Promise<PttConfig> =>
+      ipcRenderer.invoke("vellum:ptt:getConfig") as Promise<PttConfig>,
+    setConfig: (config: PttConfig): Promise<PttConfig> =>
+      ipcRenderer.invoke("vellum:ptt:setConfig", config) as Promise<PttConfig>,
+    configure: (config: PttConfig): Promise<PttRegistrationResult> =>
+      ipcRenderer.invoke(
+        "vellum:ptt:configure",
+        config,
+      ) as Promise<PttRegistrationResult>,
+    on: (callback) => {
+      const handler = (_event: IpcRendererEvent, payload: PttEvent) => {
+        callback(payload);
+      };
+      ipcRenderer.on("vellum:ptt:state", handler);
+      return () => {
+        ipcRenderer.off("vellum:ptt:state", handler);
+      };
+    },
+    onConfigChange: (callback) => {
+      const handler = (_event: IpcRendererEvent, payload: PttConfig) => {
+        callback(payload);
+      };
+      ipcRenderer.on("vellum:ptt:configChanged", handler);
+      return () => {
+        ipcRenderer.off("vellum:ptt:configChanged", handler);
+      };
     },
   },
   helper: {

--- a/apps/web/src/domains/chat/voice/use-native-push-to-talk-registration.ts
+++ b/apps/web/src/domains/chat/voice/use-native-push-to-talk-registration.ts
@@ -8,12 +8,15 @@ import {
   supportsNativePushToTalk,
 } from "@/runtime/hotkey";
 
+let registrationGeneration = 0;
+
 export function useNativePushToTalkRegistration(): void {
   useEffect(() => {
     if (typeof window === "undefined" || !supportsNativePushToTalk()) {
       return;
     }
 
+    const generation = ++registrationGeneration;
     let disposed = false;
     let syncInFlight: Promise<void> | null = null;
     let syncAgain = false;
@@ -28,10 +31,14 @@ export function useNativePushToTalkRegistration(): void {
         do {
           syncAgain = false;
           const config = await getPushToTalkConfig();
-          if (!disposed) {
+          if (!disposed && registrationGeneration === generation) {
             await configureNativePushToTalk(config);
           }
-        } while (!disposed && syncAgain);
+        } while (
+          !disposed &&
+          registrationGeneration === generation &&
+          syncAgain
+        );
       })().finally(() => {
         syncInFlight = null;
       });
@@ -43,7 +50,11 @@ export function useNativePushToTalkRegistration(): void {
     return () => {
       disposed = true;
       unsubscribeSetting();
-      void configureNativePushToTalk(NONE_PTT_ACTIVATOR);
+      window.setTimeout(() => {
+        if (registrationGeneration === generation) {
+          void configureNativePushToTalk(NONE_PTT_ACTIVATOR);
+        }
+      }, 0);
     };
   }, []);
 }

--- a/apps/web/src/domains/chat/voice/use-native-push-to-talk-registration.ts
+++ b/apps/web/src/domains/chat/voice/use-native-push-to-talk-registration.ts
@@ -1,71 +1,49 @@
 import { useEffect } from "react";
 
+import { NONE_PTT_ACTIVATOR } from "@/utils/ptt-activator";
 import {
-  FN_PTT_ACTIVATOR,
-  LS_PTT_ACTIVATION_KEY,
-  isFnPushToTalkActivator,
-  parseActivator,
-} from "@/utils/ptt-activator";
-import { getLocalSetting, watchSetting } from "@/utils/local-settings";
-import {
-  setFnPushToTalkEnabled,
-  supportsFnPushToTalk,
+  configureNativePushToTalk,
+  getPushToTalkConfig,
+  onPushToTalkConfigChange,
+  supportsNativePushToTalk,
 } from "@/runtime/hotkey";
-
-function shouldRegisterFnPushToTalk(): boolean {
-  const raw = getLocalSetting(LS_PTT_ACTIVATION_KEY, "");
-  const activator = raw
-    ? parseActivator(raw, { preserveFunction: true })
-    : FN_PTT_ACTIVATOR;
-  return isFnPushToTalkActivator(activator);
-}
 
 export function useNativePushToTalkRegistration(): void {
   useEffect(() => {
-    if (typeof window === "undefined" || !supportsFnPushToTalk()) {
+    if (typeof window === "undefined" || !supportsNativePushToTalk()) {
       return;
     }
 
     let disposed = false;
-    let desired = shouldRegisterFnPushToTalk();
-    let applied = false;
     let syncInFlight: Promise<void> | null = null;
+    let syncAgain = false;
 
     const sync = () => {
-      if (syncInFlight) return;
+      if (syncInFlight) {
+        syncAgain = true;
+        return;
+      }
 
       syncInFlight = (async () => {
-        while (!disposed && applied !== desired) {
-          const next = desired;
-          const ok = await setFnPushToTalkEnabled(next);
-          if (!ok) {
-            if (next) applied = false;
-            return;
+        do {
+          syncAgain = false;
+          const config = await getPushToTalkConfig();
+          if (!disposed) {
+            await configureNativePushToTalk(config);
           }
-          applied = next;
-        }
+        } while (!disposed && syncAgain);
       })().finally(() => {
         syncInFlight = null;
       });
     };
 
-    const updateDesiredRegistration = () => {
-      desired = shouldRegisterFnPushToTalk();
-      sync();
-    };
-
-    updateDesiredRegistration();
-    const unsubscribeSetting = watchSetting(
-      LS_PTT_ACTIVATION_KEY,
-      updateDesiredRegistration,
-    );
+    sync();
+    const unsubscribeSetting = onPushToTalkConfigChange(() => sync());
 
     return () => {
       disposed = true;
       unsubscribeSetting();
-      if (applied || desired) {
-        void setFnPushToTalkEnabled(false);
-      }
+      void configureNativePushToTalk(NONE_PTT_ACTIVATOR);
     };
   }, []);
 }

--- a/apps/web/src/domains/chat/voice/use-push-to-talk.test.tsx
+++ b/apps/web/src/domains/chat/voice/use-push-to-talk.test.tsx
@@ -5,6 +5,7 @@ import { type RefObject } from "react";
 import {
   CTRL_PTT_ACTIVATOR,
   LS_PTT_ACTIVATION_KEY,
+  parseActivator,
   serializeActivator,
 } from "@/utils/ptt-activator";
 import {
@@ -43,6 +44,24 @@ afterEach(() => {
 });
 
 describe("usePushToTalk", () => {
+  test("migrates legacy label-only key activators", () => {
+    expect(
+      parseActivator(
+        JSON.stringify({
+          kind: "key",
+          label: "K",
+          modifiers: ["control"],
+        }),
+      ),
+    ).toEqual({
+      kind: "modifierKey",
+      modifiers: ["control"],
+      keyCode: 40,
+      code: "KeyK",
+      label: "K",
+    });
+  });
+
   test("starts modifier-only PTT from a focused editable target", async () => {
     localStorage.setItem(
       LS_PTT_ACTIVATION_KEY,
@@ -68,13 +87,18 @@ describe("usePushToTalk", () => {
   test("keeps key activators disabled inside editable targets", async () => {
     localStorage.setItem(
       LS_PTT_ACTIVATION_KEY,
-      serializeActivator({ kind: "key", label: "K", modifiers: [] }),
+      serializeActivator({
+        kind: "key",
+        keyCode: 40,
+        code: "KeyK",
+        label: "K",
+      }),
     );
     const target = { start: mock(() => {}), stop: mock(() => {}) };
     renderPushToTalk(target);
     const textarea = focusedTextarea();
 
-    fireEvent.keyDown(textarea, { key: "k" });
+    fireEvent.keyDown(textarea, { key: "k", code: "KeyK" });
 
     await act(async () => {
       await wait(PTT_HOLD_DELAY_MS + 25);

--- a/apps/web/src/domains/chat/voice/use-push-to-talk.ts
+++ b/apps/web/src/domains/chat/voice/use-push-to-talk.ts
@@ -216,6 +216,10 @@ export function usePushToTalk(
           holdingRef.current = false;
           return;
         }
+        if (activeRef.current) {
+          holdingRef.current = false;
+          return;
+        }
         holdingRef.current = false;
         startActiveTarget("dom");
       }, PTT_HOLD_DELAY_MS);

--- a/apps/web/src/domains/chat/voice/use-push-to-talk.ts
+++ b/apps/web/src/domains/chat/voice/use-push-to-talk.ts
@@ -1,20 +1,20 @@
-
 import { useEffect, useRef, type RefObject } from "react";
 
 import {
-  FN_PTT_ACTIVATOR,
-  LS_PTT_ACTIVATION_KEY,
   eventActivatesPTT,
   eventDeactivatesPTT,
-  isFnPushToTalkActivator,
+  isDisabledPttActivator,
+  mouseEventActivatesPTT,
   parseActivator,
   type PTTActivator,
 } from "@/utils/ptt-activator";
-import { getLocalSetting, watchSetting } from "@/utils/local-settings";
 import {
-  subscribeToHotkeyEvents,
-  supportsFnPushToTalk,
-  type HotkeyEvent,
+  getLocalPushToTalkConfig,
+  getPushToTalkConfig,
+  onPushToTalkConfigChange,
+  subscribeToNativePushToTalkEvents,
+  supportsNativePushToTalk,
+  type PttEvent,
 } from "@/runtime/hotkey";
 
 /**
@@ -106,7 +106,7 @@ function playActivationBlip(): void {
  * Listens for the saved PTT activator on `window` keydown/keyup and drives
  * the provided voice-input handle. Hold-to-talk: key-down starts recording
  * after a 300 ms hold delay, key-up stops it. Only fires while the Vellum
- * tab has focus. Electron's app-level native Fn bridge bypasses this DOM path
+ * tab has focus. Electron's app-level native PTT bridge bypasses this DOM path
  * so the desktop app can keep PTT active while it is in the background.
  *
  * The 300 ms hold delay prevents accidental activation from quick taps and
@@ -114,16 +114,15 @@ function playActivationBlip(): void {
  * another non-modifier key is pressed during the hold window, activation
  * is cancelled (the user is likely typing a shortcut like Ctrl+C).
  *
- * Storage lives in `localStorage` under `LS_PTT_ACTIVATION_KEY`; the hook
- * re-reads on `storage` events so PTT picks up changes made in the settings
- * UI without a reload.
+ * Storage lives in Electron `settings.hotkeys.ptt` when the native bridge is
+ * available, with localStorage fallback for browser/iOS surfaces.
  */
 export function usePushToTalk(
   targetSource: PushToTalkTargetSource,
   options: { enabled?: boolean } = {},
 ): void {
   const { enabled = true } = options;
-  const activatorRef = useRef<PTTActivator>({ kind: "off" });
+  const activatorRef = useRef<PTTActivator>({ kind: "none" });
   const activeRef = useRef(false);
   const activeOriginRef = useRef<"dom" | "native" | null>(null);
   const activeTargetRef = useRef<PushToTalkTarget | null>(null);
@@ -138,14 +137,12 @@ export function usePushToTalk(
       return;
     }
 
-    const nativeFnAvailable = supportsFnPushToTalk();
+    const nativePttAvailable = supportsNativePushToTalk();
     const readActivator = () => {
-      const raw = getLocalSetting(LS_PTT_ACTIVATION_KEY, "");
-      activatorRef.current = raw
-        ? parseActivator(raw, { preserveFunction: nativeFnAvailable })
-        : nativeFnAvailable
-          ? FN_PTT_ACTIVATOR
-          : { kind: "off" };
+      activatorRef.current = getLocalPushToTalkConfig();
+      void getPushToTalkConfig().then((config) => {
+        activatorRef.current = config;
+      });
     };
     readActivator();
 
@@ -183,7 +180,7 @@ export function usePushToTalk(
         return;
       }
       const activator = activatorRef.current;
-      if (activator.kind === "off") {
+      if (isDisabledPttActivator(activator)) {
         return;
       }
 
@@ -194,7 +191,10 @@ export function usePushToTalk(
         return;
       }
 
-      if (activator.kind === "key" && isEditableTarget(event.target)) {
+      if (
+        (activator.kind === "key" || activator.kind === "modifierKey") &&
+        isEditableTarget(event.target)
+      ) {
         return;
       }
 
@@ -212,7 +212,7 @@ export function usePushToTalk(
           return;
         }
         // Re-check activator in case it changed during the hold window.
-        if (activatorRef.current.kind === "off") {
+        if (isDisabledPttActivator(activatorRef.current)) {
           holdingRef.current = false;
           return;
         }
@@ -223,7 +223,7 @@ export function usePushToTalk(
 
     const handleKeyUp = (event: KeyboardEvent) => {
       const activator = activatorRef.current;
-      if (activator.kind === "off") {
+      if (isDisabledPttActivator(activator)) {
         return;
       }
 
@@ -232,7 +232,7 @@ export function usePushToTalk(
       // eventDeactivatesPTT only matches the trigger key, not modifiers.
       if (
         holdingRef.current &&
-        activator.kind === "key" &&
+        activator.kind === "modifierKey" &&
         activator.modifiers.length > 0
       ) {
         const k = event.key;
@@ -263,11 +263,8 @@ export function usePushToTalk(
       stopActiveTarget();
     };
 
-    const handleNativeHotkey = (event: HotkeyEvent) => {
-      if (
-        !nativeFnAvailable ||
-        !isFnPushToTalkActivator(activatorRef.current)
-      ) {
+    const handleNativeHotkey = (event: PttEvent) => {
+      if (!nativePttAvailable || isDisabledPttActivator(activatorRef.current)) {
         return;
       }
       if (event.state === "down") {
@@ -285,11 +282,31 @@ export function usePushToTalk(
       stopActiveTarget();
     };
 
+    const handleMouseDown = (event: MouseEvent) => {
+      const activator = activatorRef.current;
+      if (!mouseEventActivatesPTT(event, activator)) {
+        return;
+      }
+      if (activeRef.current || holdingRef.current) {
+        return;
+      }
+      startActiveTarget("dom");
+    };
+
+    const handleMouseUp = (event: MouseEvent) => {
+      if (!activeRef.current || activeOriginRef.current !== "dom") {
+        return;
+      }
+      if (mouseEventActivatesPTT(event, activatorRef.current)) {
+        stopActiveTarget();
+      }
+    };
+
     const handleBlur = () => {
       // Dropping focus while in the hold window — cancel.
       cancelHold();
 
-      // DOM keyup can be lost when the page blurs. Native Fn events are
+      // DOM keyup can be lost when the page blurs. Native events are
       // delivered by the host helper while the app is in the background, so
       // leave those sessions running until the helper sends the up event.
       if (activeRef.current && activeOriginRef.current !== "native") {
@@ -297,16 +314,26 @@ export function usePushToTalk(
       }
     };
 
-    const unsubscribeSetting = watchSetting(LS_PTT_ACTIVATION_KEY, readActivator);
-    const unsubscribeNative = subscribeToHotkeyEvents(handleNativeHotkey);
+    const unsubscribeSetting = onPushToTalkConfigChange((config) => {
+      activatorRef.current = parseActivator(config, {
+        preserveFunction: nativePttAvailable,
+      });
+    });
+    const unsubscribeNative = subscribeToNativePushToTalkEvents(
+      handleNativeHotkey,
+    );
 
     window.addEventListener("keydown", handleKeyDown);
     window.addEventListener("keyup", handleKeyUp);
+    window.addEventListener("mousedown", handleMouseDown);
+    window.addEventListener("mouseup", handleMouseUp);
     window.addEventListener("blur", handleBlur);
 
     return () => {
       window.removeEventListener("keydown", handleKeyDown);
       window.removeEventListener("keyup", handleKeyUp);
+      window.removeEventListener("mousedown", handleMouseDown);
+      window.removeEventListener("mouseup", handleMouseUp);
       window.removeEventListener("blur", handleBlur);
       unsubscribeSetting();
       unsubscribeNative();

--- a/apps/web/src/domains/settings/pages/voice-page.tsx
+++ b/apps/web/src/domains/settings/pages/voice-page.tsx
@@ -1,43 +1,50 @@
 import { ArrowUpRight, Info } from "lucide-react";
 import {
-    useCallback,
-    useEffect,
-    useMemo,
-    useRef,
-    useState,
-    type KeyboardEvent as ReactKeyboardEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
 } from "react";
 import { Link } from "react-router";
 
 import { Button } from "@vellumai/design-library/components/button";
 import { Dropdown } from "@vellumai/design-library/components/dropdown";
+import { Input } from "@vellumai/design-library/components/input";
 import { Toggle } from "@vellumai/design-library/components/toggle";
 
 import { DetailCard } from "@/components/detail-card";
 import {
-    getLocalSetting,
-    removeLocalSetting,
-    setLocalSetting,
+  getLocalSetting,
+  removeLocalSetting,
+  setLocalSetting,
 } from "@/utils/local-settings";
 import {
-    CTRL_PTT_ACTIVATOR,
-    FN_PTT_ACTIVATOR,
-    LS_PTT_ACTIVATION_KEY,
-    activatorDisplayName,
-    activatorsEqual,
-    modifierLabel,
-    parseActivator,
-    serializeActivator,
-    sortModifiers,
-    type PTTActivator,
-    type PTTModifier,
+  CTRL_PTT_ACTIVATOR,
+  FN_PTT_ACTIVATOR,
+  NONE_PTT_ACTIVATOR,
+  activatorDisplayName,
+  activatorsEqual,
+  isDisabledPttActivator,
+  keyActivatorFromEvent,
+  modifierLabel,
+  sortModifiers,
+  type PTTActivator,
+  type PTTModifier,
 } from "@/utils/ptt-activator";
 import { routes } from "@/utils/routes";
 import {
-    LS_VOICE_INPUT_DEVICE,
-    getPreferredInputDeviceId,
+  LS_VOICE_INPUT_DEVICE,
+  getPreferredInputDeviceId,
 } from "@/utils/voice-input-device";
-import { canConfigureFnPushToTalk } from "@/runtime/hotkey";
+import {
+  getLocalPushToTalkConfig,
+  getPushToTalkConfig,
+  onPushToTalkConfigChange,
+  setPushToTalkConfig,
+  supportsNativePushToTalk,
+} from "@/runtime/hotkey";
 
 const LS_CONVERSATION_TIMEOUT = "vellum:voice:conversationTimeoutSeconds";
 
@@ -60,6 +67,26 @@ const FN_PTT_PRESET: { label: string; activator: PTTActivator } = {
   label: "Fn",
   activator: FN_PTT_ACTIVATOR,
 };
+
+const RIGHT_CMD_PTT_PRESET: { label: string; activator: PTTActivator } = {
+  label: "Right Cmd",
+  activator: { kind: "modifierOnly", modifiers: ["rightCommand"] },
+};
+
+const MOUSE_4_PTT_PRESET: { label: string; activator: PTTActivator } = {
+  label: "Mouse 4",
+  activator: { kind: "mouseButton", button: 4 },
+};
+
+type PttKind = PTTActivator["kind"];
+
+const PTT_KIND_OPTIONS: ReadonlyArray<{ label: string; value: PttKind }> = [
+  { label: "None", value: "none" },
+  { label: "Modifier only", value: "modifierOnly" },
+  { label: "Key", value: "key" },
+  { label: "Modifier + Key", value: "modifierKey" },
+  { label: "Mouse button", value: "mouseButton" },
+];
 
 const CONVERSATION_TIMEOUT_OPTIONS = [
   { label: "5 seconds", value: "5" },
@@ -221,34 +248,80 @@ function MicrophoneCard() {
   );
 }
 
+function defaultActivatorForKind(
+  kind: PttKind,
+  nativePttConfigurable: boolean,
+): PTTActivator {
+  switch (kind) {
+    case "none":
+      return NONE_PTT_ACTIVATOR;
+    case "modifierOnly":
+      return nativePttConfigurable ? FN_PTT_ACTIVATOR : CTRL_PTT_ACTIVATOR;
+    case "key":
+      return { kind: "key", keyCode: 49, code: "Space", label: "Space" };
+    case "modifierKey":
+      return {
+        kind: "modifierKey",
+        modifiers: ["control"],
+        keyCode: 49,
+        code: "Space",
+        label: "Space",
+      };
+    case "mouseButton":
+      return { kind: "mouseButton", button: 4 };
+  }
+}
+
 function PushToTalkCard() {
-  const fnPushToTalkConfigurable = canConfigureFnPushToTalk();
-  const [activator, setActivator] = useState<PTTActivator>(() => {
-    const raw = getLocalSetting(LS_PTT_ACTIVATION_KEY, "");
-    return raw
-      ? parseActivator(raw, { preserveFunction: fnPushToTalkConfigurable })
-      : fnPushToTalkConfigurable
-        ? FN_PTT_PRESET.activator
-        : { kind: "off" };
-  });
+  const nativePttConfigurable = supportsNativePushToTalk();
+  const [activator, setActivator] = useState<PTTActivator>(() =>
+    getLocalPushToTalkConfig(),
+  );
   const [isRecording, setIsRecording] = useState(false);
   const [pendingModifiers, setPendingModifiers] = useState<PTTModifier[]>([]);
   const recordingZoneRef = useRef<HTMLDivElement | null>(null);
   const nonModifierPressedRef = useRef(false);
+  const saveSequenceRef = useRef(0);
+  const selectedKind = activator.kind;
   const pttPresets = useMemo(
     () =>
-      fnPushToTalkConfigurable ? [FN_PTT_PRESET, ...PTT_PRESETS] : PTT_PRESETS,
-    [fnPushToTalkConfigurable],
+      nativePttConfigurable
+        ? [
+            FN_PTT_PRESET,
+            RIGHT_CMD_PTT_PRESET,
+            MOUSE_4_PTT_PRESET,
+            ...PTT_PRESETS,
+          ]
+        : PTT_PRESETS,
+    [nativePttConfigurable],
   );
 
-  const pttEnabled = activator.kind !== "off";
-  const showFocusedTabNote = pttEnabled && !fnPushToTalkConfigurable;
+  const pttEnabled = !isDisabledPttActivator(activator);
+  const showFocusedTabNote = pttEnabled && !nativePttConfigurable;
 
   const selectActivator = useCallback((next: PTTActivator) => {
+    const sequence = saveSequenceRef.current + 1;
+    saveSequenceRef.current = sequence;
     setActivator(next);
-    setLocalSetting(LS_PTT_ACTIVATION_KEY, serializeActivator(next));
+    void setPushToTalkConfig(next).then((saved) => {
+      if (saveSequenceRef.current === sequence) setActivator(saved);
+    });
     setIsRecording(false);
     setPendingModifiers([]);
+  }, []);
+
+  useEffect(() => {
+    let disposed = false;
+    void getPushToTalkConfig().then((config) => {
+      if (!disposed) setActivator(config);
+    });
+    const unsubscribe = onPushToTalkConfigChange((config) => {
+      setActivator(config);
+    });
+    return () => {
+      disposed = true;
+      unsubscribe();
+    };
   }, []);
 
   const beginRecording = useCallback(() => {
@@ -269,16 +342,28 @@ function PushToTalkCard() {
   const collectModifiers = useCallback(
     (event: ReactKeyboardEvent<HTMLDivElement>): PTTModifier[] => {
       const modifiers: PTTModifier[] = [];
-      if (fnPushToTalkConfigurable && event.getModifierState("Fn")) {
+      if (nativePttConfigurable && event.getModifierState("Fn")) {
         modifiers.push("function");
       }
       if (event.ctrlKey) modifiers.push("control");
-      if (event.altKey) modifiers.push("option");
+      if (event.altKey) {
+        modifiers.push(
+          event.key === "Alt" && event.location === 2
+            ? "rightOption"
+            : "option",
+        );
+      }
       if (event.shiftKey) modifiers.push("shift");
-      if (event.metaKey) modifiers.push("command");
+      if (event.metaKey) {
+        modifiers.push(
+          event.key === "Meta" && event.location === 2
+            ? "rightCommand"
+            : "command",
+        );
+      }
       return modifiers;
     },
-    [fnPushToTalkConfigurable],
+    [nativePttConfigurable],
   );
 
   const handleCaptureKeyDown = useCallback(
@@ -299,7 +384,7 @@ function PushToTalkCard() {
         key === "Shift" ||
         key === "Meta" ||
         key === "Fn";
-      if (isModifierOnly) {
+      if (selectedKind === "modifierOnly" && isModifierOnly) {
         setPendingModifiers(
           modifiers.includes("function")
             ? FN_PTT_ACTIVATOR.modifiers
@@ -308,16 +393,27 @@ function PushToTalkCard() {
         return;
       }
 
-      if (modifiers.includes("function")) {
-        selectActivator(FN_PTT_ACTIVATOR);
+      if (isModifierOnly) {
         return;
       }
 
       nonModifierPressedRef.current = true;
-      const label = key.length === 1 ? key.toUpperCase() : key;
-      selectActivator({ kind: "key", label, modifiers });
+      if (selectedKind === "key") {
+        const keyActivator = keyActivatorFromEvent(event.nativeEvent, []);
+        if (keyActivator) selectActivator(keyActivator);
+        return;
+      }
+      if (selectedKind === "modifierKey") {
+        const keyActivator = keyActivatorFromEvent(
+          event.nativeEvent,
+          modifiers,
+        );
+        if (keyActivator?.kind === "modifierKey") {
+          selectActivator(keyActivator);
+        }
+      }
     },
-    [cancelRecording, collectModifiers, selectActivator],
+    [cancelRecording, collectModifiers, selectActivator, selectedKind],
   );
 
   const handleCaptureKeyUp = useCallback(
@@ -342,14 +438,24 @@ function PushToTalkCard() {
       }
 
       const remaining = collectModifiers(event);
-      if (remaining.length === 0 && pendingModifiers.length > 0) {
+      if (
+        selectedKind === "modifierOnly" &&
+        remaining.length === 0 &&
+        pendingModifiers.length > 0
+      ) {
         selectActivator({
           kind: "modifierOnly",
           modifiers: pendingModifiers,
         });
       }
     },
-    [collectModifiers, isRecording, pendingModifiers, selectActivator],
+    [
+      collectModifiers,
+      isRecording,
+      pendingModifiers,
+      selectActivator,
+      selectedKind,
+    ],
   );
 
   useEffect(() => {
@@ -366,6 +472,23 @@ function PushToTalkCard() {
     return () => window.removeEventListener("mousedown", handler);
   }, [cancelRecording, isRecording]);
 
+  const setKind = useCallback(
+    (kind: PttKind) => {
+      if (kind === activator.kind) return;
+      selectActivator(defaultActivatorForKind(kind, nativePttConfigurable));
+    },
+    [activator.kind, nativePttConfigurable, selectActivator],
+  );
+
+  const updateMouseButton = useCallback(
+    (raw: string) => {
+      const button = Number(raw);
+      if (!Number.isInteger(button) || button < 0) return;
+      selectActivator({ kind: "mouseButton", button });
+    },
+    [selectActivator],
+  );
+
   const isCustom =
     pttEnabled &&
     !pttPresets.some((p) => activatorsEqual(p.activator, activator));
@@ -380,23 +503,33 @@ function PushToTalkCard() {
           checked={pttEnabled}
           onChange={(next: boolean) => {
             if (next) {
-              if (activator.kind === "off") {
+              if (isDisabledPttActivator(activator)) {
                 selectActivator(
-                  fnPushToTalkConfigurable
-                    ? FN_PTT_PRESET.activator
-                    : CTRL_PTT_ACTIVATOR,
+                  defaultActivatorForKind(
+                    "modifierOnly",
+                    nativePttConfigurable,
+                  ),
                 );
               }
             } else {
-              selectActivator({ kind: "off" });
+              selectActivator(NONE_PTT_ACTIVATOR);
             }
           }}
           label="Enable Push to Talk"
         />
 
+        <div className="max-w-xs">
+          <Dropdown<PttKind>
+            options={PTT_KIND_OPTIONS}
+            value={selectedKind}
+            onChange={setKind}
+            aria-label="Push to Talk activation type"
+          />
+        </div>
+
         {pttEnabled && (
-          <div className="flex flex-col gap-2">
-            <span className={labelClasses}>Activation Key:</span>
+          <div className="flex flex-col gap-3">
+            <span className={labelClasses}>Activator:</span>
             <div
               ref={recordingZoneRef}
               tabIndex={isRecording ? 0 : -1}
@@ -415,25 +548,41 @@ function PushToTalkCard() {
                   />
                 );
               })}
-              {isRecording ? (
-                <ActivationKeyOption
-                  label={
-                    pendingModifiers.length > 0
-                      ? modifierLabel(pendingModifiers)
-                      : "Press any key…"
-                  }
-                  selected
-                  recording
-                  onClick={cancelRecording}
-                />
-              ) : (
-                <ActivationKeyOption
-                  label={isCustom ? activatorDisplayName(activator) : "Custom"}
-                  selected={isCustom}
-                  onClick={beginRecording}
-                />
+              {selectedKind !== "mouseButton" && (
+                isRecording ? (
+                  <ActivationKeyOption
+                    label={
+                      pendingModifiers.length > 0
+                        ? modifierLabel(pendingModifiers)
+                        : selectedKind === "modifierOnly"
+                          ? "Press modifier..."
+                          : "Press key..."
+                    }
+                    selected
+                    recording
+                    onClick={cancelRecording}
+                  />
+                ) : (
+                  <ActivationKeyOption
+                    label={isCustom ? activatorDisplayName(activator) : "Custom"}
+                    selected={isCustom}
+                    onClick={beginRecording}
+                  />
+                )
               )}
             </div>
+
+            {selectedKind === "mouseButton" && (
+              <Input
+                type="number"
+                min={0}
+                step={1}
+                value={activator.kind === "mouseButton" ? activator.button : 4}
+                onChange={(event) => updateMouseButton(event.target.value)}
+                label="Mouse button"
+                wrapperClassName="max-w-[180px]"
+              />
+            )}
 
             {showFocusedTabNote && (
               <div className="flex items-start gap-1 pt-1 text-body-small-default text-[var(--content-quiet)]">

--- a/apps/web/src/runtime/hotkey.ts
+++ b/apps/web/src/runtime/hotkey.ts
@@ -1,34 +1,130 @@
-import { isElectron, type HotkeyEvent } from "@/runtime/is-electron";
+import {
+  FN_PTT_ACTIVATOR,
+  LS_PTT_ACTIVATION_KEY,
+  NONE_PTT_ACTIVATOR,
+  parseActivator,
+  serializeActivator,
+  type PTTActivator,
+} from "@/utils/ptt-activator";
+import {
+  getLocalSetting,
+  setLocalSetting,
+  watchSetting,
+} from "@/utils/local-settings";
+import {
+  isElectron,
+  type HotkeyEvent,
+  type PttConfig,
+  type PttEvent,
+  type PttRegistrationResult,
+} from "@/runtime/is-electron";
 
-export type { HotkeyEvent };
+export type { HotkeyEvent, PttEvent, PttRegistrationResult };
 
-export function canConfigureFnPushToTalk(): boolean {
-  return isElectron();
+function pttBridge() {
+  return isElectron() ? window.vellum?.ptt : undefined;
 }
 
-export function supportsFnPushToTalk(): boolean {
+export function supportsNativePushToTalk(): boolean {
+  const bridge = pttBridge();
   return (
-    isElectron() &&
-    typeof window.vellum?.helper?.hotkey?.fnPushToTalk === "function" &&
-    typeof window.vellum?.helper?.hotkey?.onEvent === "function"
+    !!bridge &&
+    typeof bridge.getConfig === "function" &&
+    typeof bridge.setConfig === "function" &&
+    typeof bridge.configure === "function" &&
+    typeof bridge.on === "function"
   );
 }
 
-export async function setFnPushToTalkEnabled(
-  enable: boolean,
+export function canConfigureFnPushToTalk(): boolean {
+  return supportsNativePushToTalk();
+}
+
+export function getDefaultPushToTalkConfig(): PTTActivator {
+  return supportsNativePushToTalk() ? FN_PTT_ACTIVATOR : NONE_PTT_ACTIVATOR;
+}
+
+export function getLocalPushToTalkConfig(): PTTActivator {
+  const raw = getLocalSetting(LS_PTT_ACTIVATION_KEY, "");
+  return raw
+    ? parseActivator(raw, { preserveFunction: supportsNativePushToTalk() })
+    : getDefaultPushToTalkConfig();
+}
+
+export async function getPushToTalkConfig(): Promise<PTTActivator> {
+  const bridge = pttBridge();
+  if (supportsNativePushToTalk() && bridge) {
+    return parseActivator(await bridge.getConfig(), { preserveFunction: true });
+  }
+  return getLocalPushToTalkConfig();
+}
+
+export async function setPushToTalkConfig(
+  config: PTTActivator,
+): Promise<PTTActivator> {
+  const bridge = pttBridge();
+  if (supportsNativePushToTalk() && bridge) {
+    return parseActivator(await bridge.setConfig(config as PttConfig), {
+      preserveFunction: true,
+    });
+  }
+  setLocalSetting(LS_PTT_ACTIVATION_KEY, serializeActivator(config));
+  return config;
+}
+
+export async function configureNativePushToTalk(
+  config: PTTActivator,
 ): Promise<boolean> {
-  if (!supportsFnPushToTalk()) return false;
+  const bridge = pttBridge();
+  if (!supportsNativePushToTalk() || !bridge) return false;
   try {
-    const result = await window.vellum!.helper!.hotkey!.fnPushToTalk(enable);
+    const result = await bridge.configure(config as PttConfig);
     return result.ok;
   } catch {
     return false;
   }
 }
 
+export function onPushToTalkConfigChange(
+  callback: (config: PTTActivator) => void,
+): () => void {
+  const bridge = pttBridge();
+  if (supportsNativePushToTalk() && bridge?.onConfigChange) {
+    return bridge.onConfigChange((config) => {
+      callback(parseActivator(config, { preserveFunction: true }));
+    });
+  }
+  return watchSetting(LS_PTT_ACTIVATION_KEY, () => {
+    callback(getLocalPushToTalkConfig());
+  });
+}
+
+export function subscribeToNativePushToTalkEvents(
+  callback: (event: PttEvent) => void,
+): () => void {
+  const bridge = pttBridge();
+  if (!supportsNativePushToTalk() || !bridge) return () => undefined;
+  return bridge.on(callback);
+}
+
+// Legacy Fn-only wrapper names kept for older callers/tests while the app
+// migrates to the generic PTT bridge.
+export function supportsFnPushToTalk(): boolean {
+  return supportsNativePushToTalk();
+}
+
+export async function setFnPushToTalkEnabled(
+  enable: boolean,
+): Promise<boolean> {
+  return configureNativePushToTalk(
+    enable ? FN_PTT_ACTIVATOR : NONE_PTT_ACTIVATOR,
+  );
+}
+
 export function subscribeToHotkeyEvents(
   callback: (event: HotkeyEvent) => void,
 ): () => void {
-  if (!supportsFnPushToTalk()) return () => undefined;
-  return window.vellum!.helper!.hotkey!.onEvent(callback);
+  return subscribeToNativePushToTalkEvents((event) => {
+    callback({ kind: "fnPushToTalk", state: event.state });
+  });
 }

--- a/apps/web/src/runtime/hotkey.ts
+++ b/apps/web/src/runtime/hotkey.ts
@@ -44,17 +44,49 @@ export function getDefaultPushToTalkConfig(): PTTActivator {
   return supportsNativePushToTalk() ? FN_PTT_ACTIVATOR : NONE_PTT_ACTIVATOR;
 }
 
-export function getLocalPushToTalkConfig(): PTTActivator {
+function getStoredLocalPushToTalkConfig(
+  preserveFunction: boolean,
+): PTTActivator | null {
   const raw = getLocalSetting(LS_PTT_ACTIVATION_KEY, "");
-  return raw
-    ? parseActivator(raw, { preserveFunction: supportsNativePushToTalk() })
-    : getDefaultPushToTalkConfig();
+  return raw ? parseActivator(raw, { preserveFunction }) : null;
+}
+
+function cacheLocalPushToTalkConfig(config: PTTActivator): void {
+  setLocalSetting(LS_PTT_ACTIVATION_KEY, serializeActivator(config));
+}
+
+export function getLocalPushToTalkConfig(): PTTActivator {
+  return (
+    getStoredLocalPushToTalkConfig(supportsNativePushToTalk()) ??
+    getDefaultPushToTalkConfig()
+  );
 }
 
 export async function getPushToTalkConfig(): Promise<PTTActivator> {
   const bridge = pttBridge();
   if (supportsNativePushToTalk() && bridge) {
-    return parseActivator(await bridge.getConfig(), { preserveFunction: true });
+    if (bridge.getConfigState) {
+      const state = await bridge.getConfigState();
+      if (!state.isStored) {
+        const legacy = getStoredLocalPushToTalkConfig(true);
+        if (legacy) {
+          const migrated = parseActivator(
+            await bridge.setConfig(legacy as PttConfig),
+            { preserveFunction: true },
+          );
+          cacheLocalPushToTalkConfig(migrated);
+          return migrated;
+        }
+      }
+      const config = parseActivator(state.config, { preserveFunction: true });
+      cacheLocalPushToTalkConfig(config);
+      return config;
+    }
+    const config = parseActivator(await bridge.getConfig(), {
+      preserveFunction: true,
+    });
+    cacheLocalPushToTalkConfig(config);
+    return config;
   }
   return getLocalPushToTalkConfig();
 }
@@ -64,9 +96,11 @@ export async function setPushToTalkConfig(
 ): Promise<PTTActivator> {
   const bridge = pttBridge();
   if (supportsNativePushToTalk() && bridge) {
-    return parseActivator(await bridge.setConfig(config as PttConfig), {
+    const saved = parseActivator(await bridge.setConfig(config as PttConfig), {
       preserveFunction: true,
     });
+    cacheLocalPushToTalkConfig(saved);
+    return saved;
   }
   setLocalSetting(LS_PTT_ACTIVATION_KEY, serializeActivator(config));
   return config;

--- a/apps/web/src/runtime/is-electron.ts
+++ b/apps/web/src/runtime/is-electron.ts
@@ -142,6 +142,11 @@ export interface PttEvent {
   state: HotkeyEventState;
 }
 
+export interface PttConfigState {
+  config: PttConfig;
+  isStored: boolean;
+}
+
 export type FnPushToTalkResult =
   | { ok: true; enabled: boolean }
   | { ok: false; reason: string };
@@ -332,6 +337,7 @@ declare global {
       };
       ptt?: {
         getConfig(): Promise<PttConfig>;
+        getConfigState?(): Promise<PttConfigState>;
         setConfig(config: PttConfig): Promise<PttConfig>;
         configure(config: PttConfig): Promise<PttRegistrationResult>;
         on(callback: (event: PttEvent) => void): () => void;

--- a/apps/web/src/runtime/is-electron.ts
+++ b/apps/web/src/runtime/is-electron.ts
@@ -116,8 +116,38 @@ export interface HotkeyEvent {
   state: HotkeyEventState;
 }
 
+export type PttModifier =
+  | "function"
+  | "control"
+  | "shift"
+  | "option"
+  | "command"
+  | "rightCommand"
+  | "rightOption";
+
+export type PttConfig =
+  | { kind: "none" }
+  | { kind: "modifierOnly"; modifiers: PttModifier[] }
+  | { kind: "key"; keyCode: number; code?: string; label?: string }
+  | {
+      kind: "modifierKey";
+      modifiers: PttModifier[];
+      keyCode: number;
+      code?: string;
+      label?: string;
+    }
+  | { kind: "mouseButton"; button: number };
+
+export interface PttEvent {
+  state: HotkeyEventState;
+}
+
 export type FnPushToTalkResult =
   | { ok: true; enabled: boolean }
+  | { ok: false; reason: string };
+
+export type PttRegistrationResult =
+  | { ok: true; enabled: boolean; config: PttConfig }
   | { ok: false; reason: string };
 
 /**
@@ -299,6 +329,13 @@ declare global {
       };
       featureFlags?: {
         set(flags: Record<string, boolean>): void;
+      };
+      ptt?: {
+        getConfig(): Promise<PttConfig>;
+        setConfig(config: PttConfig): Promise<PttConfig>;
+        configure(config: PttConfig): Promise<PttRegistrationResult>;
+        on(callback: (event: PttEvent) => void): () => void;
+        onConfigChange(callback: (config: PttConfig) => void): () => void;
       };
       helper?: {
         ping?(): Promise<"pong">;

--- a/apps/web/src/utils/ptt-activator.ts
+++ b/apps/web/src/utils/ptt-activator.ts
@@ -1,10 +1,11 @@
 /**
- * Push-to-Talk (PTT) activator types and helpers.
+ * Push-to-talk (PTT) activator types and helpers.
  *
- * Mirrors the macOS `PTTActivator` model so the web port can (de)serialize
- * values already stored in `localStorage` by the settings UI. Browsers cannot
- * observe the Fn key, so stored Fn preferences fall back to Ctrl on read
- * unless the Electron host bridge asks to preserve the native Fn binding.
+ * Electron stores the structured config in `settings.hotkeys.ptt` and sends it
+ * to the native macOS helper, which matches hardware key codes and mouse
+ * button numbers from a CGEvent tap. Browser/iOS surfaces still use the same
+ * model with a localStorage fallback, but only focused-window DOM events are
+ * observable there.
  */
 
 export type PTTModifier =
@@ -12,10 +13,12 @@ export type PTTModifier =
   | "control"
   | "shift"
   | "option"
-  | "command";
+  | "command"
+  | "rightCommand"
+  | "rightOption";
 
-export interface PTTOff {
-  kind: "off";
+export interface PTTNone {
+  kind: "none";
 }
 
 export interface PTTModifierOnly {
@@ -25,15 +28,37 @@ export interface PTTModifierOnly {
 
 export interface PTTKey {
   kind: "key";
+  /** macOS virtual key code, used by the native helper. */
+  keyCode: number;
+  /** DOM KeyboardEvent.code, retained for display/migration/debugging. */
+  code: string;
   /** Display label for the captured key (e.g. "A", "Space"). */
   label: string;
-  /** Modifiers held alongside the key, if any. */
-  modifiers: PTTModifier[];
 }
 
-export type PTTActivator = PTTOff | PTTModifierOnly | PTTKey;
+export interface PTTModifierKey {
+  kind: "modifierKey";
+  modifiers: PTTModifier[];
+  keyCode: number;
+  code: string;
+  label: string;
+}
+
+export interface PTTMouseButton {
+  kind: "mouseButton";
+  /** macOS / DOM button number. Back/forward are commonly 3 and 4. */
+  button: number;
+}
+
+export type PTTActivator =
+  | PTTNone
+  | PTTModifierOnly
+  | PTTKey
+  | PTTModifierKey
+  | PTTMouseButton;
 
 export const LS_PTT_ACTIVATION_KEY = "vellum:voice:activationKey";
+export const NONE_PTT_ACTIVATOR: PTTNone = { kind: "none" };
 export const CTRL_PTT_ACTIVATOR: PTTModifierOnly = {
   kind: "modifierOnly",
   modifiers: ["control"],
@@ -53,6 +78,8 @@ const MODIFIER_ORDER: PTTModifier[] = [
   "option",
   "shift",
   "command",
+  "rightOption",
+  "rightCommand",
 ];
 
 const MODIFIER_LABELS: Record<PTTModifier, string> = {
@@ -61,6 +88,149 @@ const MODIFIER_LABELS: Record<PTTModifier, string> = {
   option: "Alt",
   shift: "Shift",
   command: "Cmd",
+  rightOption: "Right Alt",
+  rightCommand: "Right Cmd",
+};
+
+const MODIFIER_ALIASES: Record<string, PTTModifier> = {
+  fn: "function",
+  function: "function",
+  ctrl: "control",
+  control: "control",
+  shift: "shift",
+  alt: "option",
+  option: "option",
+  cmd: "command",
+  command: "command",
+  meta: "command",
+  rightcmd: "rightCommand",
+  rightcommand: "rightCommand",
+  rightoption: "rightOption",
+  rightalt: "rightOption",
+};
+
+const MAC_KEY_CODES: Record<string, number> = {
+  KeyA: 0,
+  KeyS: 1,
+  KeyD: 2,
+  KeyF: 3,
+  KeyH: 4,
+  KeyG: 5,
+  KeyZ: 6,
+  KeyX: 7,
+  KeyC: 8,
+  KeyV: 9,
+  KeyB: 11,
+  KeyQ: 12,
+  KeyW: 13,
+  KeyE: 14,
+  KeyR: 15,
+  KeyY: 16,
+  KeyT: 17,
+  Digit1: 18,
+  Digit2: 19,
+  Digit3: 20,
+  Digit4: 21,
+  Digit6: 22,
+  Digit5: 23,
+  Equal: 24,
+  Digit9: 25,
+  Digit7: 26,
+  Minus: 27,
+  Digit8: 28,
+  Digit0: 29,
+  BracketRight: 30,
+  KeyO: 31,
+  KeyU: 32,
+  BracketLeft: 33,
+  KeyI: 34,
+  KeyP: 35,
+  Enter: 36,
+  KeyL: 37,
+  KeyJ: 38,
+  Quote: 39,
+  KeyK: 40,
+  Semicolon: 41,
+  Backslash: 42,
+  Comma: 43,
+  Slash: 44,
+  KeyN: 45,
+  KeyM: 46,
+  Period: 47,
+  Tab: 48,
+  Space: 49,
+  Backquote: 50,
+  Backspace: 51,
+  Escape: 53,
+  NumpadDecimal: 65,
+  NumpadMultiply: 67,
+  NumpadAdd: 69,
+  NumLock: 71,
+  NumpadDivide: 75,
+  NumpadEnter: 76,
+  NumpadSubtract: 78,
+  NumpadEqual: 81,
+  Numpad0: 82,
+  Numpad1: 83,
+  Numpad2: 84,
+  Numpad3: 85,
+  Numpad4: 86,
+  Numpad5: 87,
+  Numpad6: 88,
+  Numpad7: 89,
+  F5: 96,
+  F6: 97,
+  F7: 98,
+  F3: 99,
+  F8: 100,
+  F9: 101,
+  F11: 103,
+  F13: 105,
+  F16: 106,
+  F14: 107,
+  F10: 109,
+  F12: 111,
+  F15: 113,
+  Help: 114,
+  Home: 115,
+  PageUp: 116,
+  Delete: 117,
+  F4: 118,
+  End: 119,
+  F2: 120,
+  PageDown: 121,
+  F1: 122,
+  ArrowLeft: 123,
+  ArrowRight: 124,
+  ArrowDown: 125,
+  ArrowUp: 126,
+};
+
+const CODE_LABELS: Record<string, string> = {
+  Space: "Space",
+  Enter: "Return",
+  Backspace: "Delete",
+  Escape: "Esc",
+  ArrowLeft: "Left",
+  ArrowRight: "Right",
+  ArrowDown: "Down",
+  ArrowUp: "Up",
+};
+
+const LABEL_CODES: Record<string, string> = {
+  " ": "Space",
+  Space: "Space",
+  Return: "Enter",
+  Enter: "Enter",
+  Delete: "Backspace",
+  Backspace: "Backspace",
+  Esc: "Escape",
+  Escape: "Escape",
+  Tab: "Tab",
+  Left: "ArrowLeft",
+  Right: "ArrowRight",
+  Down: "ArrowDown",
+  Up: "ArrowUp",
 };
 
 export function sortModifiers(
@@ -79,39 +249,62 @@ export function modifierLabel(modifiers: readonly PTTModifier[]): string {
 }
 
 export function activatorDisplayName(activator: PTTActivator): string {
-  if (activator.kind === "off") {
-    return "Off";
+  switch (activator.kind) {
+    case "none":
+      return "None";
+    case "modifierOnly":
+      return modifierLabel(activator.modifiers);
+    case "key":
+      return activator.label;
+    case "modifierKey": {
+      const mods = modifierLabel(activator.modifiers);
+      return mods ? `${mods}+${activator.label}` : activator.label;
+    }
+    case "mouseButton":
+      return `Mouse ${activator.button}`;
   }
-  if (activator.kind === "modifierOnly") {
-    return modifierLabel(activator.modifiers);
-  }
-  const mods = modifierLabel(activator.modifiers);
-  return mods ? `${mods}+${activator.label}` : activator.label;
 }
 
 export function activatorsEqual(a: PTTActivator, b: PTTActivator): boolean {
   if (a.kind !== b.kind) {
     return false;
   }
-  if (a.kind === "off" || b.kind === "off") {
-    return true;
+  switch (a.kind) {
+    case "none":
+      return true;
+    case "modifierOnly":
+      return sameModifierSet(a.modifiers, (b as PTTModifierOnly).modifiers);
+    case "key":
+      return a.keyCode === (b as PTTKey).keyCode;
+    case "modifierKey":
+      return (
+        a.keyCode === (b as PTTModifierKey).keyCode &&
+        sameModifierSet(a.modifiers, (b as PTTModifierKey).modifiers)
+      );
+    case "mouseButton":
+      return a.button === (b as PTTMouseButton).button;
   }
-  const aMods = sortModifiers(a.modifiers);
-  const bMods = sortModifiers(b.modifiers);
-  if (aMods.length !== bMods.length) {
-    return false;
-  }
-  if (aMods.some((m, i) => m !== bMods[i])) {
-    return false;
-  }
-  if (a.kind === "key" && b.kind === "key") {
-    return a.label === b.label;
-  }
-  return true;
 }
 
 export function serializeActivator(activator: PTTActivator): string {
   return JSON.stringify(activator);
+}
+
+export function isDisabledPttActivator(activator: PTTActivator): boolean {
+  return activator.kind === "none";
+}
+
+export function isNativeOnlyPttActivator(activator: PTTActivator): boolean {
+  return (
+    (activator.kind === "modifierOnly" ||
+      activator.kind === "modifierKey") &&
+    activator.modifiers.some(
+      (modifier) =>
+        modifier === "function" ||
+        modifier === "rightCommand" ||
+        modifier === "rightOption",
+    )
+  );
 }
 
 export function isFnPushToTalkActivator(activator: PTTActivator): boolean {
@@ -122,18 +315,18 @@ export function isFnPushToTalkActivator(activator: PTTActivator): boolean {
   );
 }
 
-function isPTTModifier(value: unknown): value is PTTModifier {
-  return (
-    typeof value === "string" &&
-    (MODIFIER_ORDER as readonly string[]).includes(value)
-  );
+function normalizeModifier(value: unknown): PTTModifier | null {
+  if (typeof value !== "string") return null;
+  return MODIFIER_ALIASES[value.replace(/[-_\s]/g, "").toLowerCase()] ?? null;
 }
 
 function normalizeModifiers(
   raw: readonly unknown[],
   options: ParseActivatorOptions,
 ): PTTModifier[] {
-  const modifiers = raw.filter(isPTTModifier);
+  const modifiers = raw
+    .map(normalizeModifier)
+    .filter((value): value is PTTModifier => value !== null);
   if (options.preserveFunction && modifiers.includes("function")) {
     return FN_PTT_ACTIVATOR.modifiers;
   }
@@ -143,15 +336,56 @@ function normalizeModifiers(
   return sortModifiers(filtered);
 }
 
+function parseKeyFields(raw: Record<string, unknown>): {
+  keyCode: number;
+  code: string;
+  label: string;
+} | null {
+  const rawLabel = typeof raw.label === "string" ? raw.label : "";
+  const code =
+    typeof raw.code === "string"
+      ? raw.code
+      : rawLabel
+        ? domCodeForLegacyLabel(rawLabel) ?? ""
+        : "";
+  const keyCode =
+    typeof raw.keyCode === "number"
+      ? raw.keyCode
+      : typeof raw.code === "number"
+        ? raw.code
+        : code
+          ? macKeyCodeForDomCode(code)
+          : null;
+  if (keyCode === null || !Number.isInteger(keyCode) || keyCode < 0) {
+    return null;
+  }
+  const label =
+    rawLabel.length > 0
+      ? rawLabel
+      : code
+        ? labelForDomCode(code)
+        : `Key ${keyCode}`;
+  return { keyCode, code, label };
+}
+
+function domCodeForLegacyLabel(label: string): string | null {
+  if (LABEL_CODES[label]) return LABEL_CODES[label];
+  if (/^[A-Z]$/i.test(label)) return `Key${label.toUpperCase()}`;
+  if (/^[0-9]$/.test(label)) return `Digit${label}`;
+  return null;
+}
+
 export function parseActivator(
-  raw: string | null,
+  raw: unknown,
   options: ParseActivatorOptions = {},
 ): PTTActivator {
-  if (!raw) {
+  if (raw === null || raw === "") {
     return CTRL_PTT_ACTIVATOR;
   }
-  // Back-compat with the macOS legacy string values. Browsers cannot detect
-  // the Fn key, so any stored "fn" preference falls back to Ctrl.
+  if (typeof raw !== "string") {
+    return normalizeParsedActivator(raw, options);
+  }
+  // Back-compat with legacy string values and pre-Electron localStorage.
   if (raw === "fn") {
     return {
       kind: "modifierOnly",
@@ -171,56 +405,105 @@ export function parseActivator(
         : ["shift"],
     };
   }
-  if (raw === "off") {
-    return { kind: "off" };
+  if (raw === "off" || raw === "none") {
+    return NONE_PTT_ACTIVATOR;
   }
   try {
-    const parsed = JSON.parse(raw) as PTTActivator;
-    if (parsed.kind === "off") {
-      return { kind: "off" };
-    }
-    if (parsed.kind === "modifierOnly" && Array.isArray(parsed.modifiers)) {
-      const modifiers = normalizeModifiers(parsed.modifiers, options);
-      if (modifiers.length === 0) {
-        return CTRL_PTT_ACTIVATOR;
-      }
-      return { kind: "modifierOnly", modifiers };
-    }
-    if (
-      parsed.kind === "key" &&
-      typeof parsed.label === "string" &&
-      Array.isArray(parsed.modifiers)
-    ) {
-      return {
-        kind: "key",
-        label: parsed.label,
-        modifiers: normalizeModifiers(parsed.modifiers, options),
-      };
-    }
+    return normalizeParsedActivator(JSON.parse(raw) as PTTActivator, options);
   } catch {
-    // fall through
+    return CTRL_PTT_ACTIVATOR;
+  }
+}
+
+function normalizeParsedActivator(
+  parsed: unknown,
+  options: ParseActivatorOptions,
+): PTTActivator {
+  if (!parsed || typeof parsed !== "object") {
+    return CTRL_PTT_ACTIVATOR;
+  }
+  const obj = parsed as Record<string, unknown>;
+  if (obj.kind === "none" || obj.kind === "off") {
+    return NONE_PTT_ACTIVATOR;
+  }
+  if (obj.kind === "modifierOnly" && Array.isArray(obj.modifiers)) {
+    const modifiers = normalizeModifiers(obj.modifiers, options);
+    return modifiers.length === 0
+      ? CTRL_PTT_ACTIVATOR
+      : { kind: "modifierOnly", modifiers };
+  }
+  if (obj.kind === "key") {
+    const key = parseKeyFields(obj);
+    if (!key) return CTRL_PTT_ACTIVATOR;
+    const modifiers = Array.isArray(obj.modifiers)
+      ? normalizeModifiers(obj.modifiers, options)
+      : [];
+    if (modifiers.length > 0) {
+      return { kind: "modifierKey", modifiers, ...key };
+    }
+    return { kind: "key", ...key };
+  }
+  if (obj.kind === "modifierKey") {
+    const key = parseKeyFields(obj);
+    if (!key) return CTRL_PTT_ACTIVATOR;
+    const rawModifiers = Array.isArray(obj.modifiers)
+      ? obj.modifiers
+      : obj.modifier !== undefined
+        ? [obj.modifier]
+        : [];
+    const modifiers = normalizeModifiers(rawModifiers, options);
+    return modifiers.length === 0
+      ? { kind: "key", ...key }
+      : { kind: "modifierKey", modifiers, ...key };
+  }
+  if (obj.kind === "mouseButton") {
+    const button = Number(obj.button);
+    if (Number.isInteger(button) && button >= 0) {
+      return { kind: "mouseButton", button };
+    }
   }
   return CTRL_PTT_ACTIVATOR;
 }
 
+export function macKeyCodeForDomCode(code: string): number | null {
+  return MAC_KEY_CODES[code] ?? null;
+}
+
+export function labelForDomCode(code: string): string {
+  if (CODE_LABELS[code]) return CODE_LABELS[code];
+  if (code.startsWith("Key") && code.length === 4) return code.slice(3);
+  if (code.startsWith("Digit") && code.length === 6) return code.slice(5);
+  if (code.startsWith("Numpad")) return code.replace("Numpad", "Num ");
+  return code;
+}
+
+export function keyActivatorFromEvent(
+  event: KeyboardEvent,
+  modifiers: readonly PTTModifier[] = [],
+): PTTKey | PTTModifierKey | null {
+  const keyCode = macKeyCodeForDomCode(event.code);
+  if (keyCode === null) return null;
+  const key = {
+    keyCode,
+    code: event.code,
+    label: labelForDomCode(event.code),
+  };
+  const normalizedModifiers = sortModifiers(modifiers);
+  return normalizedModifiers.length > 0
+    ? { kind: "modifierKey", modifiers: normalizedModifiers, ...key }
+    : { kind: "key", ...key };
+}
+
 // ---------------------------------------------------------------------------
-// Keyboard event matching (runtime PTT listener)
+// Keyboard and mouse event matching (runtime PTT listener)
 // ---------------------------------------------------------------------------
 
 function eventModifiers(event: KeyboardEvent): PTTModifier[] {
   const mods: PTTModifier[] = [];
-  if (event.ctrlKey) {
-    mods.push("control");
-  }
-  if (event.altKey) {
-    mods.push("option");
-  }
-  if (event.shiftKey) {
-    mods.push("shift");
-  }
-  if (event.metaKey) {
-    mods.push("command");
-  }
+  if (event.ctrlKey) mods.push("control");
+  if (event.altKey) mods.push("option");
+  if (event.shiftKey) mods.push("shift");
+  if (event.metaKey) mods.push("command");
   return mods;
 }
 
@@ -238,91 +521,63 @@ function sameModifierSet(
   a: readonly PTTModifier[],
   b: readonly PTTModifier[],
 ): boolean {
-  if (a.length !== b.length) {
-    return false;
-  }
   const sortedA = sortModifiers(a);
   const sortedB = sortModifiers(b);
+  if (sortedA.length !== sortedB.length) return false;
   return sortedA.every((m, i) => m === sortedB[i]);
 }
 
-/**
- * Returns `true` if the given keyboard event fully satisfies the configured
- * activator (used to trigger start-recording on keydown).
- *
- * - For `modifierOnly` activators, returns `true` when *all* required
- *   modifiers are held and the event key is one of those modifiers (so
- *   pressing Ctrl alone fires Ctrl-only, and pressing Ctrl+Shift in sequence
- *   fires on the second keydown).
- * - For `key` activators, returns `true` when the key matches and all
- *   required modifiers are held.
- */
 export function eventActivatesPTT(
   event: KeyboardEvent,
   activator: PTTActivator,
 ): boolean {
-  if (activator.kind === "off") {
-    return false;
-  }
-  if (activator.modifiers.includes("function")) {
+  if (
+    activator.kind === "none" ||
+    activator.kind === "mouseButton" ||
+    isNativeOnlyPttActivator(activator)
+  ) {
     return false;
   }
   const held = eventModifiers(event);
-  const requiredMods = activator.modifiers.filter((m) => m !== "function");
 
   if (activator.kind === "modifierOnly") {
-    if (!keyIsModifier(event.key)) {
-      return false;
-    }
-    return sameModifierSet(held, requiredMods);
+    if (!keyIsModifier(event.key)) return false;
+    return sameModifierSet(held, activator.modifiers);
   }
 
-  const eventKeyLabel =
-    event.key.length === 1 ? event.key.toUpperCase() : event.key;
-  if (eventKeyLabel !== activator.label) {
-    return false;
-  }
-  return sameModifierSet(held, requiredMods);
+  const eventKeyCode = macKeyCodeForDomCode(event.code);
+  if (eventKeyCode !== activator.keyCode) return false;
+  if (activator.kind === "key") return held.length === 0;
+  return sameModifierSet(held, activator.modifiers);
 }
 
-/**
- * Returns `true` if releasing this key should deactivate PTT (stop recording).
- *
- * This is called on every `keyup` while PTT is active. We stop on the first
- * key-release that would break the activator — either the non-modifier key
- * itself (for `key` activators) or *any* of the required modifiers (for
- * `modifierOnly` activators). That mirrors the "hold to talk, release to
- * submit" behaviour of a physical PTT button.
- */
 export function eventDeactivatesPTT(
   event: KeyboardEvent,
   activator: PTTActivator,
 ): boolean {
-  if (activator.kind === "off") {
+  if (
+    activator.kind === "none" ||
+    activator.kind === "mouseButton" ||
+    isNativeOnlyPttActivator(activator)
+  ) {
     return false;
   }
-  if (activator.modifiers.includes("function")) {
-    return false;
-  }
-  const requiredMods = activator.modifiers.filter((m) => m !== "function");
 
   if (activator.kind === "modifierOnly") {
-    if (event.key === "Control" && requiredMods.includes("control")) {
-      return true;
-    }
-    if (event.key === "Alt" && requiredMods.includes("option")) {
-      return true;
-    }
-    if (event.key === "Shift" && requiredMods.includes("shift")) {
-      return true;
-    }
-    if (event.key === "Meta" && requiredMods.includes("command")) {
-      return true;
-    }
-    return false;
+    const released = normalizeModifier(event.key);
+    return released !== null && activator.modifiers.includes(released);
   }
 
-  const eventKeyLabel =
-    event.key.length === 1 ? event.key.toUpperCase() : event.key;
-  return eventKeyLabel === activator.label;
+  const eventKeyCode = macKeyCodeForDomCode(event.code);
+  if (eventKeyCode === activator.keyCode) return true;
+  if (activator.kind !== "modifierKey") return false;
+  const released = normalizeModifier(event.key);
+  return released !== null && activator.modifiers.includes(released);
+}
+
+export function mouseEventActivatesPTT(
+  event: MouseEvent,
+  activator: PTTActivator,
+): boolean {
+  return activator.kind === "mouseButton" && event.button === activator.button;
 }


### PR DESCRIPTION
## Summary
- Add structured Push to Talk activators for the Electron macOS app, including none, modifier-only, key, modifier+key, and mouse-button modes backed by settings.hotkeys.ptt.
- Add a native macOS CGEvent tap path in the helper and expose it through the main/preload/renderer bridge so PTT works globally while the app is in the background.
- Update the Voice settings UI and PTT runtime to support the new activator types, preserve legacy config migration, and cover the new bridge behavior in focused tests.

## Original prompt
The user asked whether Linear ticket LUM-1973 had been fully implemented for the Electron macOS app. After finding that only the old Fn-only native bridge and focused-window browser fallback existed, they asked to use /do to finish the ticket. This PR completes the configurable Push to Talk activator work described in LUM-1973.

Fixes LUM-1973