### PR TITLE
feat(web): add Delete file action to workspace file editor

### DIFF
--- a/apps/web/src/domains/workspace/components/workspace-browser.tsx
+++ b/apps/web/src/domains/workspace/components/workspace-browser.tsx
@@ -103,6 +103,7 @@ export function WorkspaceBrowser({ assistantId }: { assistantId: string }) {
             viewMode={viewMode}
             onChangeViewMode={setViewMode}
             onBrowse={() => setDrawerOpen(true)}
+            onDeleted={() => setSelectedPath(null)}
           />
         </div>
       </div>

--- a/apps/web/src/domains/workspace/components/workspace-file-viewer.tsx
+++ b/apps/web/src/domains/workspace/components/workspace-file-viewer.tsx
@@ -35,12 +35,15 @@ import { FileMarkdown, isMarkdown } from "@/components/file-markdown";
 import { isJson, prettifyJson } from "@/domains/workspace/utils/file-json";
 import { formatFileSize } from "@/domains/workspace/utils/format-file-size";
 import {
+    workspaceDeletePost,
     workspaceFileContentGet,
     workspaceFileGet,
     workspaceWritePost,
 } from "@/generated/daemon/sdk.gen";
 import type { WorkspaceFileGetResponse } from "@/generated/daemon/types.gen";
 import { Button } from "@vellumai/design-library/components/button";
+import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
+import { toast } from "@vellumai/design-library/components/toast";
 
 import type { WorkspaceViewMode } from "@/domains/workspace/components/workspace-browser";
 
@@ -265,41 +268,55 @@ function isHiddenPath(path: string): boolean {
 function EditFooter({
   isDirty,
   isSaving,
+  isDeleting,
   onSave,
   onDiscard,
+  onDelete,
 }: {
   isDirty: boolean;
   isSaving: boolean;
+  isDeleting: boolean;
   onSave: () => void;
   onDiscard: () => void;
+  onDelete: () => void;
 }) {
   return (
     <div
-      className="flex items-center justify-end gap-2 border-t px-3 py-2"
+      className="flex items-center justify-between gap-2 border-t px-3 py-2"
       style={{ borderColor: "var(--border-element)" }}
     >
       <Button
-        variant="ghost"
+        variant="danger"
         size="compact"
-        disabled={isSaving}
-        onClick={onDiscard}
+        disabled={isSaving || isDeleting}
+        onClick={onDelete}
       >
-        Discard
+        Delete file
       </Button>
-      {isSaving && (
-        <Loader2
-          className="h-4 w-4 animate-spin"
-          style={{ color: "var(--content-tertiary)" }}
-        />
-      )}
-      <Button
-        variant="primary"
-        size="compact"
-        disabled={!isDirty || isSaving}
-        onClick={onSave}
-      >
-        Save
-      </Button>
+      <div className="flex items-center gap-2">
+        <Button
+          variant="ghost"
+          size="compact"
+          disabled={isSaving || isDeleting}
+          onClick={onDiscard}
+        >
+          Discard changes
+        </Button>
+        {isSaving && (
+          <Loader2
+            className="h-4 w-4 animate-spin"
+            style={{ color: "var(--content-tertiary)" }}
+          />
+        )}
+        <Button
+          variant="primary"
+          size="compact"
+          disabled={!isDirty || isSaving || isDeleting}
+          onClick={onSave}
+        >
+          Save
+        </Button>
+      </div>
     </div>
   );
 }
@@ -459,6 +476,7 @@ export function WorkspaceFileViewer({
   viewMode,
   onChangeViewMode,
   onBrowse,
+  onDeleted,
 }: {
   assistantId: string;
   selectedPath: string | null;
@@ -466,6 +484,7 @@ export function WorkspaceFileViewer({
   viewMode: WorkspaceViewMode;
   onChangeViewMode: (mode: WorkspaceViewMode) => void;
   onBrowse?: () => void;
+  onDeleted?: () => void;
 }) {
   const queryClient = useQueryClient();
   const { data, isLoading } = useQuery({
@@ -481,6 +500,7 @@ export function WorkspaceFileViewer({
     path: string;
     content: string;
   } | null>(null);
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
 
   const isEditing = editingPath != null && editingPath === selectedPath;
   const originalContent = data?.content ?? "";
@@ -521,6 +541,34 @@ export function WorkspaceFileViewer({
       void queryClient.invalidateQueries({
         queryKey: ["assistantsWorkspaceFileRetrieve"],
       });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async (path: string) => {
+      const { error, response } = await workspaceDeletePost({
+        path: { assistant_id: assistantId },
+        body: { path },
+        throwOnError: false,
+      });
+      if (!response?.ok || error) {
+        throw new Error("Failed to delete file");
+      }
+    },
+    onSuccess: () => {
+      setConfirmDeleteOpen(false);
+      stopEditing();
+      void queryClient.invalidateQueries({
+        queryKey: ["assistantsWorkspaceTreeRetrieve"],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ["assistantsWorkspaceFileRetrieve"],
+      });
+      onDeleted?.();
+    },
+    onError: () => {
+      setConfirmDeleteOpen(false);
+      toast.error("Failed to delete file.");
     },
   });
 
@@ -595,12 +643,30 @@ export function WorkspaceFileViewer({
   const readOnly = selectedPath ? isHiddenPath(selectedPath) : true;
 
   const editFooter = isEditing && (
-    <EditFooter
-      isDirty={isDirty}
-      isSaving={saveMutation.isPending}
-      onSave={handleSave}
-      onDiscard={stopEditing}
-    />
+    <>
+      <EditFooter
+        isDirty={isDirty}
+        isSaving={saveMutation.isPending}
+        isDeleting={deleteMutation.isPending}
+        onSave={handleSave}
+        onDiscard={stopEditing}
+        onDelete={() => setConfirmDeleteOpen(true)}
+      />
+      <ConfirmDialog
+        open={confirmDeleteOpen}
+        title="Delete file"
+        message={`Are you sure you want to delete "${name}"? This cannot be undone.`}
+        confirmLabel="Delete"
+        destructive
+        isPending={deleteMutation.isPending}
+        onConfirm={() => {
+          if (selectedPath && !deleteMutation.isPending) {
+            deleteMutation.mutate(selectedPath);
+          }
+        }}
+        onCancel={() => setConfirmDeleteOpen(false)}
+      />
+    </>
   );
 
   // Markdown: Preview/Source toggle


### PR DESCRIPTION
## Summary

In settings → workspace, when editing a file:

- Renames the **Discard** button to **Discard changes**.
- Adds a red **Delete file** button (design library `danger` variant) aligned left in the same footer row as Discard changes/Save.

Deleting follows the codebase's standard destructive-action pattern: clicking the button opens a `ConfirmDialog` in destructive mode. On confirm it calls the daemon's existing `POST /v1/workspace/delete` endpoint (`workspaceDeletePost` from the generated SDK), invalidates the workspace tree and file queries, clears the viewer selection via a new `onDeleted` prop wired in `workspace-browser.tsx`, and shows an error toast on failure. All footer buttons are disabled while a save or delete is in flight.

## Test plan

- `bun run typecheck` and `eslint` pass in `apps/web` (also enforced by the pre-commit hook).
- For manual testing: local stack via `vellum hatch --remote local` + `vellum client -i web`, then settings → workspace → open a file → pencil icon. Delete file should prompt for confirmation, remove the file, refresh the tree, and return the viewer to the empty state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)