### PR TITLE
feat(macos): align dictation overlay with floating spec

### DIFF
--- a/apps/macos/src/main/dictation-overlay-window.test.ts
+++ b/apps/macos/src/main/dictation-overlay-window.test.ts
@@ -4,6 +4,7 @@ import {
   DONE_HIDE_MS,
   ERROR_HIDE_MS,
   createDictationOverlayController,
+  positionDictationOverlayInWorkArea,
   type DictationOverlayState,
 } from "./dictation-overlay-window";
 
@@ -63,14 +64,22 @@ describe("createDictationOverlayController", () => {
   test("shows the overlay and forwards live transcription while unfocused", () => {
     const h = createHarness();
 
-    h.controller.handleMessage({ kind: "recording", transcription: "" });
-    h.controller.handleMessage({ kind: "recording", transcription: "hello wor" });
+    h.controller.handleMessage({
+      kind: "recording",
+      transcription: "",
+      audioLevel: 0,
+    });
+    h.controller.handleMessage({
+      kind: "recording",
+      transcription: "hello wor",
+      audioLevel: 0.6,
+    });
     h.controller.handleMessage({ kind: "processing" });
 
     expect(h.showOverlay).toHaveBeenCalledTimes(1);
     expect(h.forwarded).toEqual([
-      { kind: "recording", transcription: "" },
-      { kind: "recording", transcription: "hello wor" },
+      { kind: "recording", transcription: "", audioLevel: 0 },
+      { kind: "recording", transcription: "hello wor", audioLevel: 0.6 },
       { kind: "processing" },
     ]);
     expect(h.hideOverlay).not.toHaveBeenCalled();
@@ -178,5 +187,21 @@ describe("createDictationOverlayController", () => {
 
     h.controller.handleMessage({ kind: "recording", transcription: "" });
     expect(h.showOverlay).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("positionDictationOverlayInWorkArea", () => {
+  test("positions the transparent overlay canvas bottom-center of the display work area", () => {
+    expect(
+      positionDictationOverlayInWorkArea({
+        x: 100,
+        y: 50,
+        width: 1440,
+        height: 900,
+      }),
+    ).toEqual({
+      x: 580,
+      y: 778,
+    });
   });
 });

--- a/apps/macos/src/main/dictation-overlay-window.ts
+++ b/apps/macos/src/main/dictation-overlay-window.ts
@@ -6,7 +6,7 @@ import { handle, on } from "./ipc";
 
 /**
  * System-wide dictation overlay — a floating, click-through panel pinned
- * top-center of the active display that shows the user's words live while
+ * bottom-center of the active display that shows the user's words live while
  * they dictate via push-to-talk into another app. Matches the native Swift
  * client's `DictationOverlayWindow`: a small pill that expands with partial
  * transcription during recording, then walks the processing → done / error
@@ -24,20 +24,19 @@ import { handle, on } from "./ipc";
  */
 
 const OVERLAY_KIND = "dictation-overlay";
-const OVERLAY_PATH = "/dictation-overlay";
+const OVERLAY_PATH = "/floating/dictation-overlay";
 
 // The window is a fixed-size transparent canvas larger than the visible
-// pill: the page renders the pill top-centered and sized to content, with
+// pill: the page renders the pill bottom-centered and sized to content, with
 // padding so its CSS shadow has room to paint (the window itself draws no
 // shadow — `hasShadow` would outline the invisible canvas rect).
 const OVERLAY_WIDTH = 480;
 const OVERLAY_HEIGHT = 160;
 
 // The page pads the pill by 16 px (`p-4`); offset the window so the pill's
-// top edge lands 20 px below the work-area top — the Swift overlay's
-// position (NSPanel origin `visibleFrame.maxY - 60` for a 40 pt panel).
-const CANVAS_TOP_INSET = 16;
-const PILL_TOP_OFFSET = 20;
+// bottom edge lands 28 px above the work-area bottom.
+const CANVAS_BOTTOM_INSET = 16;
+const PILL_BOTTOM_OFFSET = 28;
 
 /** How long the success state stays up before the overlay hides. */
 export const DONE_HIDE_MS = 800;
@@ -47,7 +46,7 @@ export const ERROR_HIDE_MS = 3000;
 
 /** States the overlay renderer can display. */
 export type DictationOverlayState =
-  | { kind: "recording"; transcription: string }
+  | { kind: "recording"; transcription: string; audioLevel?: number }
   | { kind: "processing" }
   | { kind: "done" }
   | { kind: "error"; message: string };
@@ -58,7 +57,11 @@ export type DictationOverlayMessage =
   | { kind: "dismiss" };
 
 const dictationOverlayMessageSchema = z.discriminatedUnion("kind", [
-  z.object({ kind: z.literal("recording"), transcription: z.string() }),
+  z.object({
+    kind: z.literal("recording"),
+    transcription: z.string(),
+    audioLevel: z.number().min(0).max(1).optional(),
+  }),
   z.object({ kind: z.literal("processing") }),
   z.object({ kind: z.literal("done") }),
   z.object({ kind: z.literal("error"), message: z.string() }),
@@ -161,14 +164,26 @@ const sendState = (state: DictationOverlayState): void => {
   }
 };
 
+export const positionDictationOverlayInWorkArea = (workArea: {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}): { x: number; y: number } => ({
+  x: Math.round(workArea.x + (workArea.width - OVERLAY_WIDTH) / 2),
+  y: Math.round(
+    workArea.y +
+      workArea.height -
+      OVERLAY_HEIGHT -
+      PILL_BOTTOM_OFFSET +
+      CANVAS_BOTTOM_INSET,
+  ),
+});
+
 const overlayPosition = (): { x: number; y: number } => {
   const cursor = screen.getCursorScreenPoint();
   const display = screen.getDisplayNearestPoint(cursor);
-  const { x, y, width } = display.workArea;
-  return {
-    x: Math.round(x + (width - OVERLAY_WIDTH) / 2),
-    y: Math.round(y + PILL_TOP_OFFSET - CANVAS_TOP_INSET),
-  };
+  return positionDictationOverlayInWorkArea(display.workArea);
 };
 
 const ensureOverlayWindow = (): BrowserWindow => {

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -124,7 +124,7 @@ export interface DictationPartialEvent {
 // in `apps/macos/src/main/dictation-overlay-window.ts` (kept inline for the
 // same three-TS-project reason as `VellumCommand`).
 export type DictationOverlayState =
-  | { kind: "recording"; transcription: string }
+  | { kind: "recording"; transcription: string; audioLevel?: number }
   | { kind: "processing" }
   | { kind: "done" }
   | { kind: "error"; message: string };
@@ -591,14 +591,14 @@ export interface VellumBridge {
   dictationOverlay: {
     /**
      * Publish the current dictation lifecycle state so main can drive the
-     * system-wide overlay panel (live transcription pinned top-center of
+     * system-wide overlay panel (live transcription pinned bottom-center of
      * the active display). Fire-and-forget — interim transcription updates
      * are high-frequency and need no acknowledgement.
      */
     setState(state: DictationOverlayMessage): void;
     /**
      * Subscribe to overlay states. Only the dictation overlay window's own
-     * renderer (`/dictation-overlay`) consumes this. Returns an unsubscribe
+     * renderer (`/floating/dictation-overlay`) consumes this. Returns an unsubscribe
      * function.
      */
     onState(callback: (state: DictationOverlayState) => void): () => void;

--- a/apps/web/src/components/dictation-overlay-page.tsx
+++ b/apps/web/src/components/dictation-overlay-page.tsx
@@ -9,12 +9,11 @@ import type { DictationOverlayState } from "@/runtime/is-electron";
 
 /**
  * Live dictation pill rendered inside the Electron dictation overlay
- * BrowserWindow — a click-through, non-activating panel pinned top-center
+ * BrowserWindow — a click-through, non-activating panel pinned bottom-center
  * of the active display while the user dictates via push-to-talk into
  * another app. The Electron port of the native Swift client's
- * `DictationOverlayWindow`: a status row (state icon + label) over an
- * optional two-line live transcription that expands the pill as words
- * stream in.
+ * `DictationOverlayWindow`: a status row (state icon + label), compact
+ * audio meter, and optional two-line live transcription.
  *
  * Standalone (no auth, no RootLayout) like the Quick Input page; the
  * window canvas is transparent, so the page paints only the pill. The
@@ -45,15 +44,19 @@ export function DictationOverlayPage() {
 
   const transcription =
     state.kind === "recording" ? state.transcription.trim() : "";
+  const audioLevel = state.kind === "recording" ? (state.audioLevel ?? 0) : 0;
 
   return (
-    <div className="flex h-screen w-screen items-start justify-center bg-transparent p-4">
-      <div className="flex min-w-40 max-w-full flex-col gap-1 rounded-xl border border-[var(--border-default)] bg-[var(--surface-base)] px-4 py-2.5 shadow-lg">
-        <div className="flex items-center gap-2">
+    <div className="flex h-screen w-screen items-end justify-center bg-transparent p-4">
+      <div className="flex w-[min(28rem,calc(100vw-2rem))] flex-col gap-1 rounded-xl border border-[var(--border-default)] bg-[var(--surface-base)] px-4 py-2.5 shadow-lg">
+        <div className="flex min-w-0 items-center gap-2">
           <StateIcon state={state} />
           <span className="truncate text-[11px] font-medium text-[var(--content-secondary)]">
             {stateLabel(state)}
           </span>
+          {state.kind === "recording" && (
+            <AudioMeter level={audioLevel} />
+          )}
         </div>
         {transcription && (
           // Bottom-anchored two-line window: the transcript grows as words
@@ -66,6 +69,28 @@ export function DictationOverlayPage() {
           </div>
         )}
       </div>
+    </div>
+  );
+}
+
+function AudioMeter({ level }: { level: number }) {
+  const clamped = Math.max(0, Math.min(1, level));
+
+  return (
+    <div
+      className="ml-auto flex h-4 w-16 shrink-0 items-end gap-0.5"
+      aria-hidden
+    >
+      {[0.16, 0.32, 0.48, 0.64, 0.8, 0.96].map((threshold, index) => (
+        <span
+          key={threshold}
+          className="w-1 rounded-full bg-[var(--system-negative-strong)] transition-[height,opacity] duration-75"
+          style={{
+            height: `${6 + index * 1.5}px`,
+            opacity: clamped >= threshold ? 1 : 0.22,
+          }}
+        />
+      ))}
     </div>
   );
 }

--- a/apps/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/apps/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -108,12 +108,15 @@ mock.module("@/domains/chat/components/voice-input-button", () => ({
 // (cross-domain `voice` store) to derive its `isVoiceActive` signal. Mock it
 // via `mock.module` (rather than importing the store) so the `chat` test stays
 // free of cross-domain coupling, matching the live-voice mocks above. Only the
-// `.use.phase()` selector is consumed by the composer.
+// `.use.phase()` and `.use.setAudioLevel()` selectors are consumed by the
+// composer.
 let mockVoicePhase = "idle";
+const setAudioLevelSpy = mock((_level: number) => undefined);
 mock.module("@/domains/chat/voice/voice-recording-store", () => ({
   useVoiceRecordingStore: {
     use: {
       phase: () => mockVoicePhase,
+      setAudioLevel: () => setAudioLevelSpy,
     },
   },
 }));
@@ -125,6 +128,7 @@ function resetLiveVoiceMocks() {
   mockLiveFinal = "";
   mockLiveAssistant = "";
   mockVoicePhase = "idle";
+  setAudioLevelSpy.mockClear();
   liveStartSpy.mockClear();
   liveStopSpy.mockClear();
 }

--- a/apps/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/apps/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -199,13 +199,14 @@ export function ChatComposer({
   const voiceStreamRef = useRef<MediaStream | null>(null);
   const [voiceStream, setVoiceStream] = useState<MediaStream | null>(null);
   const { amplitude } = useAudioAmplitude({
-    active: voicePhase === "recording",
+    active: voicePhase === "recording" && voiceStream !== null,
     stream: voiceStream,
   });
   const setVoiceAudioLevel = useVoiceRecordingStore.use.setAudioLevel();
   useEffect(() => {
+    if (!voiceStream) return;
     setVoiceAudioLevel(amplitude);
-  }, [amplitude, setVoiceAudioLevel]);
+  }, [amplitude, voiceStream, setVoiceAudioLevel]);
   const showVoiceInput =
     voiceInputRef !== undefined && onVoiceTranscript !== undefined;
 

--- a/apps/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/apps/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -6,6 +6,7 @@ import {
     type RefObject,
     type SetStateAction,
     useCallback,
+    useEffect,
     useLayoutEffect,
     useMemo,
     useRef,
@@ -201,6 +202,9 @@ export function ChatComposer({
     active: voicePhase === "recording",
     stream: voiceStream,
   });
+  useEffect(() => {
+    useVoiceRecordingStore.getState().setAudioLevel(amplitude);
+  }, [amplitude]);
   const showVoiceInput =
     voiceInputRef !== undefined && onVoiceTranscript !== undefined;
 

--- a/apps/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/apps/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -202,9 +202,10 @@ export function ChatComposer({
     active: voicePhase === "recording",
     stream: voiceStream,
   });
+  const setVoiceAudioLevel = useVoiceRecordingStore.use.setAudioLevel();
   useEffect(() => {
-    useVoiceRecordingStore.getState().setAudioLevel(amplitude);
-  }, [amplitude]);
+    setVoiceAudioLevel(amplitude);
+  }, [amplitude, setVoiceAudioLevel]);
   const showVoiceInput =
     voiceInputRef !== undefined && onVoiceTranscript !== undefined;
 

--- a/apps/web/src/domains/chat/hooks/use-dictation-overlay-sync.test.tsx
+++ b/apps/web/src/domains/chat/hooks/use-dictation-overlay-sync.test.tsx
@@ -45,14 +45,18 @@ describe("useDictationOverlaySync", () => {
     act(() => {
       store().startRecording();
     });
-    expect(messages).toEqual([{ kind: "recording", transcription: "" }]);
+    expect(messages).toEqual([
+      { kind: "recording", transcription: "", audioLevel: 0 },
+    ]);
 
     act(() => {
+      store().setAudioLevel(0.42);
       store().setInterimTranscript("hello wor");
     });
     expect(messages[messages.length - 1]).toEqual({
       kind: "recording",
       transcription: "hello wor",
+      audioLevel: 0.42,
     });
   });
 
@@ -139,7 +143,11 @@ describe("useDictationOverlaySync", () => {
     act(() => {
       store().startRecording();
     });
-    expect(messages[0]).toEqual({ kind: "recording", transcription: "" });
+    expect(messages[0]).toEqual({
+      kind: "recording",
+      transcription: "",
+      audioLevel: 0,
+    });
 
     act(() => {
       store().stopRecording();

--- a/apps/web/src/domains/chat/hooks/use-dictation-overlay-sync.ts
+++ b/apps/web/src/domains/chat/hooks/use-dictation-overlay-sync.ts
@@ -6,7 +6,7 @@ import { setDictationOverlayState } from "@/runtime/dictation-overlay";
 
 /**
  * Mirrors the dictation lifecycle to the Electron system-wide overlay — the
- * floating panel pinned top-center of the screen that shows the user's words
+ * floating panel pinned bottom-center of the screen that shows the user's words
  * live while they dictate via push-to-talk into another app.
  *
  * Domain hook per the Electron conventions (`docs/ELECTRON.md`): the chat
@@ -15,7 +15,7 @@ import { setDictationOverlayState } from "@/runtime/dictation-overlay";
  * no-ops, so this is safe to mount on web and iOS.
  *
  * Everything it publishes is read from `useVoiceRecordingStore` — phase,
- * live interim transcript, and error codes — so it must be mounted exactly
+ * live interim transcript, audio level, and error codes — so it must be mounted exactly
  * ONCE per window, in `GlobalPushToTalkBridge` (always present in
  * `RootLayout`). That covers dictation hosted by any `VoiceInputButton`
  * instance: the chat composer's on chat routes, and the bridge's headless
@@ -36,12 +36,17 @@ export function useDictationOverlaySync(): void {
   const phase = useVoiceRecordingStore.use.phase();
   const errorCode = useVoiceRecordingStore.use.errorCode();
   const interim = useVoiceRecordingStore.use.interimTranscript();
+  const audioLevel = useVoiceRecordingStore.use.audioLevel();
   const insertionError = useVoiceRecordingStore.use.dictationInsertionError();
 
   useEffect(() => {
     switch (phase) {
       case "recording":
-        setDictationOverlayState({ kind: "recording", transcription: interim });
+        setDictationOverlayState({
+          kind: "recording",
+          transcription: interim,
+          audioLevel,
+        });
         break;
       case "processing":
         setDictationOverlayState({ kind: "processing" });
@@ -63,7 +68,7 @@ export function useDictationOverlaySync(): void {
         setDictationOverlayState({ kind: "dismiss" });
         break;
     }
-  }, [phase, interim, errorCode, insertionError]);
+  }, [phase, interim, audioLevel, errorCode, insertionError]);
 
   // Mount-scoped (not in the effect above — its cleanup runs on every dep
   // change, which would hide and re-show the overlay between interim

--- a/apps/web/src/domains/chat/voice/global-push-to-talk-bridge.tsx
+++ b/apps/web/src/domains/chat/voice/global-push-to-talk-bridge.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import {
   VoiceInputButton,
@@ -12,6 +12,7 @@ import { postDictation } from "@/domains/chat/voice/dictation-api";
 import { getPushToTalkTarget } from "@/domains/chat/voice/push-to-talk-target";
 import { shouldEnablePushToTalk } from "@/domains/chat/voice/push-to-talk-host";
 import { useNativePushToTalkRegistration } from "@/domains/chat/voice/use-native-push-to-talk-registration";
+import { useAudioAmplitude } from "@/domains/chat/voice/use-audio-amplitude";
 import { usePushToTalk } from "@/domains/chat/voice/use-push-to-talk";
 import { useVoiceRecordingStore } from "@/domains/chat/voice/voice-recording-store";
 import { insertTextIntoFrontApp } from "@/runtime/text-insertion";
@@ -44,6 +45,17 @@ export function GlobalPushToTalkBridge({
   assistantId,
 }: GlobalPushToTalkBridgeProps) {
   const fallbackVoiceInputRef = useRef<VoiceInputButtonHandle | null>(null);
+  const voicePhase = useVoiceRecordingStore.use.phase();
+  const [voiceStream, setVoiceStream] = useState<MediaStream | null>(null);
+  const { amplitude } = useAudioAmplitude({
+    active: voicePhase === "recording" && voiceStream !== null,
+    stream: voiceStream,
+  });
+
+  useEffect(() => {
+    if (!voiceStream) return;
+    useVoiceRecordingStore.getState().setAudioLevel(amplitude);
+  }, [amplitude, voiceStream]);
 
   useNativePushToTalkRegistration();
 
@@ -124,6 +136,7 @@ export function GlobalPushToTalkBridge({
       assistantId={assistantId}
       onTranscript={handleTranscript}
       onError={handleError}
+      onStreamReady={setVoiceStream}
       onBeforeStart={allowVoiceStart}
       renderButton={false}
     />

--- a/apps/web/src/domains/chat/voice/global-push-to-talk-bridge.tsx
+++ b/apps/web/src/domains/chat/voice/global-push-to-talk-bridge.tsx
@@ -51,11 +51,12 @@ export function GlobalPushToTalkBridge({
     active: voicePhase === "recording" && voiceStream !== null,
     stream: voiceStream,
   });
+  const setVoiceAudioLevel = useVoiceRecordingStore.use.setAudioLevel();
 
   useEffect(() => {
     if (!voiceStream) return;
-    useVoiceRecordingStore.getState().setAudioLevel(amplitude);
-  }, [amplitude, voiceStream]);
+    setVoiceAudioLevel(amplitude);
+  }, [amplitude, voiceStream, setVoiceAudioLevel]);
 
   useNativePushToTalkRegistration();
 

--- a/apps/web/src/domains/chat/voice/voice-recording-store.ts
+++ b/apps/web/src/domains/chat/voice/voice-recording-store.ts
@@ -51,6 +51,12 @@ export interface VoiceRecordingState {
    */
   interimTranscript: string;
   /**
+   * Smoothed live mic level in the range 0..1 while recording. Published
+   * globally so the Electron dictation overlay can mirror the composer
+   * waveform without opening a second capture graph.
+   */
+  audioLevel: number;
+  /**
    * Front-app insertion failure (`dictation-automation-denied` /
    * `dictation-paste-blocked`) flagged during the current session. The
    * session still finalizes into `done` — the transcript soft-lands in the
@@ -67,6 +73,7 @@ export interface VoiceRecordingActions {
   fail: (code: string) => void;
   reset: () => void;
   setInterimTranscript: (text: string) => void;
+  setAudioLevel: (level: number) => void;
   flagDictationInsertionError: (code: string) => void;
 }
 
@@ -103,6 +110,7 @@ const useVoiceRecordingStoreBase = create<VoiceRecordingStore>()((set) => ({
   phase: "idle",
   errorCode: null,
   interimTranscript: "",
+  audioLevel: 0,
   dictationInsertionError: null,
 
   startRecording: () => {
@@ -111,13 +119,19 @@ const useVoiceRecordingStoreBase = create<VoiceRecordingStore>()((set) => ({
       phase: "recording",
       errorCode: null,
       interimTranscript: "",
+      audioLevel: 0,
       dictationInsertionError: null,
     });
   },
 
   stopRecording: () => {
     clearDismissTimer();
-    set({ phase: "processing", errorCode: null, interimTranscript: "" });
+    set({
+      phase: "processing",
+      errorCode: null,
+      interimTranscript: "",
+      audioLevel: 0,
+    });
   },
 
   finalize: () => {
@@ -144,12 +158,18 @@ const useVoiceRecordingStoreBase = create<VoiceRecordingStore>()((set) => ({
       phase: "idle",
       errorCode: null,
       interimTranscript: "",
+      audioLevel: 0,
       dictationInsertionError: null,
     });
   },
 
   setInterimTranscript: (text: string) => {
     set({ interimTranscript: text });
+  },
+
+  setAudioLevel: (level: number) => {
+    const clamped = Math.max(0, Math.min(1, level));
+    set({ audioLevel: clamped });
   },
 
   flagDictationInsertionError: (code: string) => {

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -118,9 +118,12 @@ export const routeTree = [
 
     // Dictation overlay — live transcription pill rendered inside the
     // Electron dictation overlay BrowserWindow (a click-through floating
-    // panel pinned top-center of the screen while push-to-talk dictation
+    // panel pinned bottom-center of the screen while push-to-talk dictation
     // is active). Same pattern as Quick Input: sibling of `/assistant`,
     // outside auth middleware and RootLayout for fast load.
+    { path: "/assistant/floating/dictation-overlay", ErrorBoundary: RouteErrorBoundary, HydrateFallback: RootHydrateFallback, lazy: { Component: () => import("@/components/dictation-overlay-page").then((m) => m.DictationOverlayPage) } },
+    // Legacy direct path retained so old dev windows do not blank during
+    // rolling Electron/web updates.
     { path: "/assistant/dictation-overlay", ErrorBoundary: RouteErrorBoundary, HydrateFallback: RootHydrateFallback, lazy: { Component: () => import("@/components/dictation-overlay-page").then((m) => m.DictationOverlayPage) } },
 
     // Assistant routes — auth-protected app with layout

--- a/apps/web/src/runtime/dictation-overlay.ts
+++ b/apps/web/src/runtime/dictation-overlay.ts
@@ -2,7 +2,7 @@
  * Runtime wrapper for the dictation overlay bridge surface.
  *
  * The Electron main process owns a system-wide, click-through panel pinned
- * top-center of the active display that shows the user's words live while
+ * bottom-center of the active display that shows the user's words live while
  * they dictate via push-to-talk into another app (the Electron port of the
  * native Swift client's `DictationOverlayWindow`).
  *

--- a/apps/web/src/runtime/is-electron.ts
+++ b/apps/web/src/runtime/is-electron.ts
@@ -141,7 +141,7 @@ export interface DictationPartialEvent {
  * reason as `VellumCommand`.
  */
 export type DictationOverlayState =
-  | { kind: "recording"; transcription: string }
+  | { kind: "recording"; transcription: string; audioLevel?: number }
   | { kind: "processing" }
   | { kind: "done" }
   | { kind: "error"; message: string };


### PR DESCRIPTION
## Summary
- move the dictation overlay to the shared floating route family and bottom-center display placement
- thread live mic audio levels through the recording store into the overlay bridge
- render a stable-width dictation pill with a compact audio meter and constrained transcript text

Part of LUM-1867.

## Tests
- cd apps/macos && export PATH="/Users/maddieabboud/.bun/bin:/Users/maddieabboud/Downloads/google-cloud-sdk/bin:/Users/maddieabboud/.pyenv/shims:/opt/homebrew/opt/gnu-getopt/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/opt/local/bin:/opt/local/sbin:/Users/maddieabboud/.nvm/versions/node/v22.22.2/bin:/Users/maddieabboud/.nvm/versions/node/v16.19.0/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Applications/VMware Fusion Tech Preview.app/Contents/Public:/Users/maddieabboud/.codex/tmp/arg0/codex-arg0Z4ZyPQ:/Users/maddieabboud/Downloads/google-cloud-sdk/bin:/Users/maddieabboud/.bun/bin:/Users/maddieabboud/.antigravity/antigravity/bin:/opt/homebrew/opt/postgresql@16/bin:/Users/maddieabboud/Library/pnpm:/opt/homebrew/opt/gnu-getopt/bin:/Users/maddieabboud/.cargo/bin:/Users/maddieabboud/Library/Application Support/JetBrains/Toolbox/scripts:/Users/maddieabboud/.local/bin:/Applications/Codex.app/Contents/Resources:/Users/maddieabboud/Library/Application Support/JetBrains/Toolbox/scripts:/Users/maddieabboud/.local/bin"; bun test src/main/dictation-overlay-window.test.ts src/main/floating-window.test.ts
- cd apps/web && export PATH="/Users/maddieabboud/.bun/bin:/Users/maddieabboud/Downloads/google-cloud-sdk/bin:/Users/maddieabboud/.pyenv/shims:/opt/homebrew/opt/gnu-getopt/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/opt/local/bin:/opt/local/sbin:/Users/maddieabboud/.nvm/versions/node/v22.22.2/bin:/Users/maddieabboud/.nvm/versions/node/v16.19.0/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Applications/VMware Fusion Tech Preview.app/Contents/Public:/Users/maddieabboud/.codex/tmp/arg0/codex-arg0Z4ZyPQ:/Users/maddieabboud/Downloads/google-cloud-sdk/bin:/Users/maddieabboud/.bun/bin:/Users/maddieabboud/.antigravity/antigravity/bin:/opt/homebrew/opt/postgresql@16/bin:/Users/maddieabboud/Library/pnpm:/opt/homebrew/opt/gnu-getopt/bin:/Users/maddieabboud/.cargo/bin:/Users/maddieabboud/Library/Application Support/JetBrains/Toolbox/scripts:/Users/maddieabboud/.local/bin:/Applications/Codex.app/Contents/Resources:/Users/maddieabboud/Library/Application Support/JetBrains/Toolbox/scripts:/Users/maddieabboud/.local/bin"; bun test src/domains/chat/hooks/use-dictation-overlay-sync.test.tsx
- cd apps/macos && export PATH="/Users/maddieabboud/.bun/bin:/Users/maddieabboud/Downloads/google-cloud-sdk/bin:/Users/maddieabboud/.pyenv/shims:/opt/homebrew/opt/gnu-getopt/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/opt/local/bin:/opt/local/sbin:/Users/maddieabboud/.nvm/versions/node/v22.22.2/bin:/Users/maddieabboud/.nvm/versions/node/v16.19.0/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Applications/VMware Fusion Tech Preview.app/Contents/Public:/Users/maddieabboud/.codex/tmp/arg0/codex-arg0Z4ZyPQ:/Users/maddieabboud/Downloads/google-cloud-sdk/bin:/Users/maddieabboud/.bun/bin:/Users/maddieabboud/.antigravity/antigravity/bin:/opt/homebrew/opt/postgresql@16/bin:/Users/maddieabboud/Library/pnpm:/opt/homebrew/opt/gnu-getopt/bin:/Users/maddieabboud/.cargo/bin:/Users/maddieabboud/Library/Application Support/JetBrains/Toolbox/scripts:/Users/maddieabboud/.local/bin:/Applications/Codex.app/Contents/Resources:/Users/maddieabboud/Library/Application Support/JetBrains/Toolbox/scripts:/Users/maddieabboud/.local/bin"; bunx tsc --noEmit
- cd apps/web && export PATH="/Users/maddieabboud/.bun/bin:/Users/maddieabboud/Downloads/google-cloud-sdk/bin:/Users/maddieabboud/.pyenv/shims:/opt/homebrew/opt/gnu-getopt/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/opt/local/bin:/opt/local/sbin:/Users/maddieabboud/.nvm/versions/node/v22.22.2/bin:/Users/maddieabboud/.nvm/versions/node/v16.19.0/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Applications/VMware Fusion Tech Preview.app/Contents/Public:/Users/maddieabboud/.codex/tmp/arg0/codex-arg0Z4ZyPQ:/Users/maddieabboud/Downloads/google-cloud-sdk/bin:/Users/maddieabboud/.bun/bin:/Users/maddieabboud/.antigravity/antigravity/bin:/opt/homebrew/opt/postgresql@16/bin:/Users/maddieabboud/Library/pnpm:/opt/homebrew/opt/gnu-getopt/bin:/Users/maddieabboud/.cargo/bin:/Users/maddieabboud/Library/Application Support/JetBrains/Toolbox/scripts:/Users/maddieabboud/.local/bin:/Applications/Codex.app/Contents/Resources:/Users/maddieabboud/Library/Application Support/JetBrains/Toolbox/scripts:/Users/maddieabboud/.local/bin"; bunx tsc --noEmit
- cd apps/web && export PATH="/Users/maddieabboud/.bun/bin:/Users/maddieabboud/Downloads/google-cloud-sdk/bin:/Users/maddieabboud/.pyenv/shims:/opt/homebrew/opt/gnu-getopt/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/opt/local/bin:/opt/local/sbin:/Users/maddieabboud/.nvm/versions/node/v22.22.2/bin:/Users/maddieabboud/.nvm/versions/node/v16.19.0/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Applications/VMware Fusion Tech Preview.app/Contents/Public:/Users/maddieabboud/.codex/tmp/arg0/codex-arg0Z4ZyPQ:/Users/maddieabboud/Downloads/google-cloud-sdk/bin:/Users/maddieabboud/.bun/bin:/Users/maddieabboud/.antigravity/antigravity/bin:/opt/homebrew/opt/postgresql@16/bin:/Users/maddieabboud/Library/pnpm:/opt/homebrew/opt/gnu-getopt/bin:/Users/maddieabboud/.cargo/bin:/Users/maddieabboud/Library/Application Support/JetBrains/Toolbox/scripts:/Users/maddieabboud/.local/bin:/Applications/Codex.app/Contents/Resources:/Users/maddieabboud/Library/Application Support/JetBrains/Toolbox/scripts:/Users/maddieabboud/.local/bin"; bun run lint -- src/components/dictation-overlay-page.tsx src/domains/chat/components/chat-composer/chat-composer.tsx src/domains/chat/hooks/use-dictation-overlay-sync.ts src/domains/chat/hooks/use-dictation-overlay-sync.test.tsx src/domains/chat/voice/global-push-to-talk-bridge.tsx src/domains/chat/voice/voice-recording-store.ts src/routes.tsx src/runtime/dictation-overlay.ts src/runtime/is-electron.ts (passes with existing exhaustive-deps warning in chat-composer.tsx)