### PR TITLE
feat(macos): add final transcription floating overlay

### DIFF
--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -59,6 +59,7 @@ import { installPowerEvents } from "./power-events";
 import { installConnectivityIpc, installStatusIpc } from "./status";
 import { installTextInsertionIpc } from "./textInsertion";
 import { installTray } from "./tray";
+import { installTranscriptionOverlay } from "./transcription-overlay-window";
 import { hardenedWebPreferences } from "./windows";
 
 // Dev-only: override the workspace `name` (`@vellumai/macos`) so the
@@ -329,6 +330,7 @@ app
     installApplicationMenu();
     installQuickInput();
     installDictationOverlay();
+    installTranscriptionOverlay();
     installPopoutWindows();
     installGlobalShortcuts();
     // Register the avatar channel before the Dock and Tray install so their

--- a/apps/macos/src/main/transcription-overlay-window.test.ts
+++ b/apps/macos/src/main/transcription-overlay-window.test.ts
@@ -39,6 +39,17 @@ type HandlerFn = (args: unknown[]) => unknown;
 const appState = { isPackaged: false };
 const created: Array<{ opts: CreateWindowOptions; win: StubWindow }> = [];
 const ipcHandlers = new Map<string, HandlerFn>();
+const windowEvents: string[] = [];
+const globalShortcutHandlers = new Map<string, () => void>();
+const globalShortcutRegisterMock = mock(
+  (accelerator: string, handler: () => void) => {
+    globalShortcutHandlers.set(accelerator, handler);
+    return true;
+  },
+);
+const globalShortcutUnregisterMock = mock((accelerator: string) => {
+  globalShortcutHandlers.delete(accelerator);
+});
 let focusedWindow: { getBounds: () => Bounds; isDestroyed: () => boolean } | null =
   null;
 let displayWorkArea: Bounds = { x: 0, y: 0, width: 1440, height: 900 };
@@ -64,7 +75,11 @@ const makeWindow = (): StubWindow => {
         listener(...args);
       }
     },
-    send: mock((_channel: string, _payload: unknown) => undefined),
+    send: mock((_channel: string, payload: unknown) => {
+      windowEvents.push(
+        `send:${(payload as { transcript?: string }).transcript ?? ""}`,
+      );
+    }),
   };
 
   const win: StubWindow = {
@@ -96,7 +111,9 @@ const makeWindow = (): StubWindow => {
     ),
     show: mock(() => undefined),
     focus: mock(() => undefined),
-    showInactive: mock(() => undefined),
+    showInactive: mock(() => {
+      windowEvents.push("showInactive");
+    }),
     hide: mock(() => undefined),
     loadURL: mock((_url: string) => Promise.resolve()),
   };
@@ -125,6 +142,10 @@ mock.module("electron", () => ({
     getCursorScreenPoint: () => ({ x: 0, y: 0 }),
     getDisplayNearestPoint: () => ({ workArea: displayWorkArea }),
     getDisplayMatching: () => ({ workArea: displayWorkArea }),
+  },
+  globalShortcut: {
+    register: globalShortcutRegisterMock,
+    unregister: globalShortcutUnregisterMock,
   },
 }));
 
@@ -170,6 +191,10 @@ beforeEach(() => {
   }
   created.length = 0;
   createWindowMock.mockClear();
+  windowEvents.length = 0;
+  globalShortcutHandlers.clear();
+  globalShortcutRegisterMock.mockClear();
+  globalShortcutUnregisterMock.mockClear();
   appState.isPackaged = false;
   process.env.VELLUM_DEV_URL = "http://localhost:4242/assistant/";
   focusedWindow = null;
@@ -232,11 +257,15 @@ describe("installTranscriptionOverlay", () => {
     expect(first.win.showInactive).toHaveBeenCalledTimes(2);
     expect(first.win.loadURL).toHaveBeenCalledTimes(1);
     expect(first.win.webContents.send.mock.calls).toEqual([
-      ["vellum:transcriptionOverlay:state", state()],
       [
         "vellum:transcriptionOverlay:state",
         state({ transcript: "A newer transcript." }),
       ],
+    ]);
+    expect(windowEvents).toEqual([
+      "showInactive",
+      "send:A newer transcript.",
+      "showInactive",
     ]);
 
     first.win.emit("closed");
@@ -268,6 +297,27 @@ describe("installTranscriptionOverlay", () => {
 
     expect(preventDefault).toHaveBeenCalledTimes(1);
     expect(win.hide).toHaveBeenCalledTimes(2);
+    expect(invoke("vellum:transcriptionOverlay:getState")).toBeNull();
+  });
+
+  test("global Escape closes the inactive overlay and unregisters on dismiss", () => {
+    invoke("vellum:transcriptionOverlay:show", [state()]);
+    const win = created[0]!.win;
+    const escapeHandler = globalShortcutHandlers.get("Escape");
+
+    if (!escapeHandler) {
+      throw new Error("Expected overlay to register a global Escape handler");
+    }
+
+    expect(globalShortcutRegisterMock.mock.calls).toEqual([
+      ["Escape", escapeHandler],
+    ]);
+
+    escapeHandler();
+
+    expect(win.hide).toHaveBeenCalledTimes(1);
+    expect(globalShortcutUnregisterMock.mock.calls).toEqual([["Escape"]]);
+    expect(globalShortcutHandlers.has("Escape")).toBe(false);
     expect(invoke("vellum:transcriptionOverlay:getState")).toBeNull();
   });
 

--- a/apps/macos/src/main/transcription-overlay-window.test.ts
+++ b/apps/macos/src/main/transcription-overlay-window.test.ts
@@ -1,0 +1,317 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+type Listener = (...args: unknown[]) => void;
+
+type Bounds = { x: number; y: number; width: number; height: number };
+
+type StubWebContents = {
+  on: (event: string, listener: Listener) => StubWebContents;
+  isDestroyed: () => boolean;
+  emit: (event: string, ...args: unknown[]) => void;
+  send: ReturnType<typeof mock>;
+};
+
+type StubWindow = {
+  webContents: StubWebContents;
+  isDestroyed: () => boolean;
+  getBounds: () => Bounds;
+  setBounds: (bounds: Partial<Bounds>) => void;
+  on: (event: string, listener: Listener) => StubWindow;
+  emit: (event: string, ...args: unknown[]) => void;
+  setPosition: ReturnType<typeof mock>;
+  setAlwaysOnTop: ReturnType<typeof mock>;
+  setVisibleOnAllWorkspaces: ReturnType<typeof mock>;
+  setIgnoreMouseEvents: ReturnType<typeof mock>;
+  show: ReturnType<typeof mock>;
+  focus: ReturnType<typeof mock>;
+  showInactive: ReturnType<typeof mock>;
+  hide: ReturnType<typeof mock>;
+  loadURL: ReturnType<typeof mock>;
+};
+
+type CreateWindowOptions = {
+  browserWindow: Record<string, unknown>;
+  navigation: unknown;
+};
+
+type HandlerFn = (args: unknown[]) => unknown;
+
+const appState = { isPackaged: false };
+const created: Array<{ opts: CreateWindowOptions; win: StubWindow }> = [];
+const ipcHandlers = new Map<string, HandlerFn>();
+let focusedWindow: { getBounds: () => Bounds; isDestroyed: () => boolean } | null =
+  null;
+let displayWorkArea: Bounds = { x: 0, y: 0, width: 1440, height: 900 };
+
+const makeWindow = (): StubWindow => {
+  const windowListeners = new Map<string, Listener[]>();
+  const webContentsListeners = new Map<string, Listener[]>();
+  let destroyed = false;
+  let webContentsDestroyed = false;
+  let bounds: Bounds = { x: 0, y: 0, width: 0, height: 0 };
+
+  const webContents: StubWebContents = {
+    on: (event, listener) => {
+      const listeners = webContentsListeners.get(event) ?? [];
+      listeners.push(listener);
+      webContentsListeners.set(event, listeners);
+      return webContents;
+    },
+    isDestroyed: () => webContentsDestroyed,
+    emit: (event, ...args) => {
+      if (event === "destroyed") webContentsDestroyed = true;
+      for (const listener of webContentsListeners.get(event) ?? []) {
+        listener(...args);
+      }
+    },
+    send: mock((_channel: string, _payload: unknown) => undefined),
+  };
+
+  const win: StubWindow = {
+    webContents,
+    isDestroyed: () => destroyed,
+    getBounds: () => bounds,
+    setBounds: (next) => {
+      bounds = { ...bounds, ...next };
+    },
+    on: (event, listener) => {
+      const listeners = windowListeners.get(event) ?? [];
+      listeners.push(listener);
+      windowListeners.set(event, listeners);
+      return win;
+    },
+    emit: (event, ...args) => {
+      if (event === "closed") destroyed = true;
+      for (const listener of windowListeners.get(event) ?? []) {
+        listener(...args);
+      }
+    },
+    setPosition: mock((x: number, y: number) => {
+      bounds = { ...bounds, x, y };
+    }),
+    setAlwaysOnTop: mock((_flag: boolean, _level: string) => undefined),
+    setIgnoreMouseEvents: mock((_ignore: boolean) => undefined),
+    setVisibleOnAllWorkspaces: mock(
+      (_visible: boolean, _opts: Record<string, boolean>) => undefined,
+    ),
+    show: mock(() => undefined),
+    focus: mock(() => undefined),
+    showInactive: mock(() => undefined),
+    hide: mock(() => undefined),
+    loadURL: mock((_url: string) => Promise.resolve()),
+  };
+
+  return win;
+};
+
+const createWindowMock = mock((opts: CreateWindowOptions): StubWindow => {
+  const win = makeWindow();
+  win.setBounds({
+    width: opts.browserWindow.width as number,
+    height: opts.browserWindow.height as number,
+  });
+  created.push({ opts, win });
+  return win;
+});
+
+mock.module("electron", () => ({
+  app: appState,
+  BrowserWindow: class {
+    static getFocusedWindow() {
+      return focusedWindow;
+    }
+  },
+  screen: {
+    getCursorScreenPoint: () => ({ x: 0, y: 0 }),
+    getDisplayNearestPoint: () => ({ workArea: displayWorkArea }),
+    getDisplayMatching: () => ({ workArea: displayWorkArea }),
+  },
+}));
+
+mock.module("./windows", () => ({
+  createWindow: createWindowMock,
+}));
+
+mock.module("./ipc", () => ({
+  handle: mock((channel: string, _schema: unknown, fn: unknown) => {
+    ipcHandlers.set(channel, (args) => (fn as (args: unknown[]) => unknown)(args));
+  }),
+}));
+
+const invoke = (channel: string, args: unknown[] = []): unknown => {
+  const handler = ipcHandlers.get(channel);
+  if (!handler) throw new Error(`Missing IPC handler: ${channel}`);
+  return handler(args);
+};
+
+const state = (overrides: Partial<{
+  transcript: string;
+  createdAt: number;
+  autoDismissMs: number;
+}> = {}) => ({
+  transcript: "Hello from voice mode.",
+  createdAt: 1_725_000_000_000,
+  autoDismissMs: 0,
+  ...overrides,
+});
+
+const { installTranscriptionOverlay } = await import(
+  "./transcription-overlay-window"
+);
+
+installTranscriptionOverlay();
+
+beforeEach(() => {
+  invoke("vellum:transcriptionOverlay:dismiss");
+  for (const { win } of created) {
+    if (!win.isDestroyed()) {
+      win.emit("closed");
+    }
+  }
+  created.length = 0;
+  createWindowMock.mockClear();
+  appState.isPackaged = false;
+  process.env.VELLUM_DEV_URL = "http://localhost:4242/assistant/";
+  focusedWindow = null;
+  displayWorkArea = { x: 0, y: 0, width: 1440, height: 900 };
+});
+
+afterEach(() => {
+  invoke("vellum:transcriptionOverlay:dismiss");
+  for (const { win } of created) {
+    if (!win.isDestroyed()) {
+      win.emit("closed");
+    }
+  }
+});
+
+describe("installTranscriptionOverlay", () => {
+  test("creates a singleton floating transcription window on the standalone route", () => {
+    invoke("vellum:transcriptionOverlay:show", [state()]);
+
+    expect(createWindowMock).toHaveBeenCalledTimes(1);
+    const first = created[0]!;
+    expect(first.opts.navigation).toBe("deny-all");
+    expect(first.opts.browserWindow).toMatchObject({
+      type: "panel",
+      width: 520,
+      height: 176,
+      frame: false,
+      transparent: true,
+      resizable: false,
+      skipTaskbar: true,
+      fullscreenable: false,
+      show: false,
+      movable: true,
+      minimizable: false,
+      maximizable: false,
+      hasShadow: true,
+    });
+    expect(first.win.setAlwaysOnTop.mock.calls).toEqual([[true, "floating"]]);
+    expect(first.win.setVisibleOnAllWorkspaces.mock.calls).toEqual([
+      [
+        true,
+        {
+          visibleOnFullScreen: true,
+          skipTransformProcessType: true,
+        },
+      ],
+    ]);
+    expect(first.win.showInactive).toHaveBeenCalledTimes(1);
+    expect(first.win.show).not.toHaveBeenCalled();
+    expect(first.win.focus).not.toHaveBeenCalled();
+    expect(first.win.loadURL.mock.calls[0]?.[0]).toBe(
+      "http://localhost:4242/assistant/floating/transcription",
+    );
+
+    invoke("vellum:transcriptionOverlay:show", [
+      state({ transcript: "A newer transcript." }),
+    ]);
+
+    expect(createWindowMock).toHaveBeenCalledTimes(1);
+    expect(first.win.showInactive).toHaveBeenCalledTimes(2);
+    expect(first.win.loadURL).toHaveBeenCalledTimes(1);
+    expect(first.win.webContents.send.mock.calls).toEqual([
+      ["vellum:transcriptionOverlay:state", state()],
+      [
+        "vellum:transcriptionOverlay:state",
+        state({ transcript: "A newer transcript." }),
+      ],
+    ]);
+
+    first.win.emit("closed");
+    invoke("vellum:transcriptionOverlay:show", [
+      state({ transcript: "After close." }),
+    ]);
+    expect(createWindowMock).toHaveBeenCalledTimes(2);
+    expect(created[1]?.win).not.toBe(first.win);
+  });
+
+  test("dismiss IPC and Escape both hide the active overlay and clear state", () => {
+    invoke("vellum:transcriptionOverlay:show", [state()]);
+    const win = created[0]!.win;
+
+    expect(invoke("vellum:transcriptionOverlay:getState")).toEqual(state());
+
+    invoke("vellum:transcriptionOverlay:dismiss");
+    expect(win.hide).toHaveBeenCalledTimes(1);
+    expect(invoke("vellum:transcriptionOverlay:getState")).toBeNull();
+
+    invoke("vellum:transcriptionOverlay:show", [
+      state({ transcript: "Dismiss with Escape." }),
+    ]);
+    const preventDefault = mock(() => undefined);
+    win.webContents.emit("before-input-event", { preventDefault }, {
+      type: "keyDown",
+      key: "Escape",
+    });
+
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(win.hide).toHaveBeenCalledTimes(2);
+    expect(invoke("vellum:transcriptionOverlay:getState")).toBeNull();
+  });
+
+  test("blur closes the active overlay", () => {
+    invoke("vellum:transcriptionOverlay:show", [state()]);
+    const win = created[0]!.win;
+
+    win.emit("blur");
+
+    expect(win.hide).toHaveBeenCalledTimes(1);
+    expect(invoke("vellum:transcriptionOverlay:getState")).toBeNull();
+  });
+
+  test("auto-dismiss hides the overlay after the state timeout", async () => {
+    invoke("vellum:transcriptionOverlay:show", [
+      state({ autoDismissMs: 1, transcript: "Temporary." }),
+    ]);
+    const win = created[0]!.win;
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(win.hide).toHaveBeenCalledTimes(1);
+    expect(invoke("vellum:transcriptionOverlay:getState")).toBeNull();
+  });
+
+  test("positions bottom-center on the focused display, then reuses moved position", () => {
+    displayWorkArea = { x: 1920, y: 40, width: 1280, height: 860 };
+    focusedWindow = {
+      getBounds: () => ({ x: 2100, y: 120, width: 800, height: 600 }),
+      isDestroyed: () => false,
+    };
+
+    invoke("vellum:transcriptionOverlay:show", [state()]);
+    const win = created[0]!.win;
+
+    expect(win.setPosition.mock.calls[0]).toEqual([2300, 668]);
+
+    win.setBounds({ x: 2345, y: 456 });
+    win.emit("move");
+    invoke("vellum:transcriptionOverlay:dismiss");
+    invoke("vellum:transcriptionOverlay:show", [
+      state({ transcript: "Back where the user left it." }),
+    ]);
+
+    expect(win.setPosition.mock.calls.at(-1)).toEqual([2345, 456]);
+  });
+});

--- a/apps/macos/src/main/transcription-overlay-window.ts
+++ b/apps/macos/src/main/transcription-overlay-window.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, screen, type Rectangle } from "electron";
+import { BrowserWindow, globalShortcut, screen, type Rectangle } from "electron";
 import { z } from "zod";
 
 import { createFloatingWindow, getFloatingWindow } from "./floating-window";
@@ -14,6 +14,7 @@ import { handle } from "./ipc";
 
 const OVERLAY_KIND = "transcription";
 const OVERLAY_PATH = "/floating/transcription";
+const ESCAPE_ACCELERATOR = "Escape";
 
 const OVERLAY_WIDTH = 520;
 const OVERLAY_HEIGHT = 176;
@@ -67,8 +68,8 @@ export const createTranscriptionOverlayController = (
   const show = (state: TranscriptionOverlayState): void => {
     clearAutoDismissTimer();
     latestState = state;
-    deps.showOverlay();
     deps.forwardState(state);
+    deps.showOverlay();
 
     if (state.autoDismissMs > 0) {
       autoDismissTimer = deps.setTimeout(dismiss, state.autoDismissMs);
@@ -85,6 +86,7 @@ export const createTranscriptionOverlayController = (
 let lastMovedBounds: Rectangle | null = null;
 let trackedWindow: BrowserWindow | null = null;
 let controller: TranscriptionOverlayController | null = null;
+let globalEscapeRegistered = false;
 
 const displayPosition = (): { x: number; y: number } => {
   if (lastMovedBounds) {
@@ -113,6 +115,20 @@ const dismissOverlay = (): void => {
   controller?.dismiss();
 };
 
+const registerGlobalEscapeDismiss = (): void => {
+  if (globalEscapeRegistered) return;
+  globalEscapeRegistered = globalShortcut.register(
+    ESCAPE_ACCELERATOR,
+    dismissOverlay,
+  );
+};
+
+const unregisterGlobalEscapeDismiss = (): void => {
+  if (!globalEscapeRegistered) return;
+  globalShortcut.unregister(ESCAPE_ACCELERATOR);
+  globalEscapeRegistered = false;
+};
+
 const attachWindowLifecycle = (win: BrowserWindow): void => {
   if (trackedWindow === win) return;
   trackedWindow = win;
@@ -132,6 +148,7 @@ const attachWindowLifecycle = (win: BrowserWindow): void => {
     if (trackedWindow === win) {
       trackedWindow = null;
     }
+    unregisterGlobalEscapeDismiss();
     if (controller?.getState()) {
       controller.dismiss();
     }
@@ -163,9 +180,11 @@ const ensureOverlayWindow = (): BrowserWindow => {
 
 const showOverlay = (): void => {
   ensureOverlayWindow();
+  registerGlobalEscapeDismiss();
 };
 
 const hideOverlay = (): void => {
+  unregisterGlobalEscapeDismiss();
   const win = getFloatingWindow(OVERLAY_KIND);
   if (win) {
     win.hide();

--- a/apps/macos/src/main/transcription-overlay-window.ts
+++ b/apps/macos/src/main/transcription-overlay-window.ts
@@ -1,0 +1,212 @@
+import { BrowserWindow, screen, type Rectangle } from "electron";
+import { z } from "zod";
+
+import { createFloatingWindow, getFloatingWindow } from "./floating-window";
+import { handle } from "./ipc";
+
+/**
+ * Final transcript overlay shown after voice capture completes. This is a
+ * movable, non-focus-stealing floating window that can be dismissed explicitly,
+ * by Escape, by blur/click-outside, or by its caller-provided auto-dismiss
+ * timeout. Voice completion wiring lands in a follow-up PR; this module only
+ * owns the window and IPC surface.
+ */
+
+const OVERLAY_KIND = "transcription";
+const OVERLAY_PATH = "/floating/transcription";
+
+const OVERLAY_WIDTH = 520;
+const OVERLAY_HEIGHT = 176;
+const BOTTOM_MARGIN = 56;
+
+export type TranscriptionOverlayState = {
+  transcript: string;
+  createdAt: number;
+  autoDismissMs: number;
+};
+
+const transcriptionOverlayStateSchema = z.object({
+  transcript: z.string(),
+  createdAt: z.number(),
+  autoDismissMs: z.number().nonnegative(),
+});
+
+export type TranscriptionOverlayDeps = {
+  showOverlay: () => void;
+  hideOverlay: () => void;
+  forwardState: (state: TranscriptionOverlayState) => void;
+  setTimeout: (callback: () => void, ms: number) => unknown;
+  clearTimeout: (handle: unknown) => void;
+};
+
+export type TranscriptionOverlayController = {
+  show: (state: TranscriptionOverlayState) => void;
+  dismiss: () => void;
+  getState: () => TranscriptionOverlayState | null;
+};
+
+export const createTranscriptionOverlayController = (
+  deps: TranscriptionOverlayDeps,
+): TranscriptionOverlayController => {
+  let latestState: TranscriptionOverlayState | null = null;
+  let autoDismissTimer: unknown = null;
+
+  const clearAutoDismissTimer = (): void => {
+    if (autoDismissTimer !== null) {
+      deps.clearTimeout(autoDismissTimer);
+      autoDismissTimer = null;
+    }
+  };
+
+  const dismiss = (): void => {
+    clearAutoDismissTimer();
+    latestState = null;
+    deps.hideOverlay();
+  };
+
+  const show = (state: TranscriptionOverlayState): void => {
+    clearAutoDismissTimer();
+    latestState = state;
+    deps.showOverlay();
+    deps.forwardState(state);
+
+    if (state.autoDismissMs > 0) {
+      autoDismissTimer = deps.setTimeout(dismiss, state.autoDismissMs);
+    }
+  };
+
+  return {
+    show,
+    dismiss,
+    getState: () => latestState,
+  };
+};
+
+let lastMovedBounds: Rectangle | null = null;
+let trackedWindow: BrowserWindow | null = null;
+let controller: TranscriptionOverlayController | null = null;
+
+const displayPosition = (): { x: number; y: number } => {
+  if (lastMovedBounds) {
+    return { x: lastMovedBounds.x, y: lastMovedBounds.y };
+  }
+
+  const focusedWindow = BrowserWindow.getFocusedWindow();
+  const display =
+    focusedWindow && !focusedWindow.isDestroyed()
+      ? screen.getDisplayMatching(focusedWindow.getBounds())
+      : screen.getDisplayNearestPoint(screen.getCursorScreenPoint());
+  const { x, y, width, height } = display.workArea;
+
+  return {
+    x: Math.round(x + (width - OVERLAY_WIDTH) / 2),
+    y: Math.round(y + height - OVERLAY_HEIGHT - BOTTOM_MARGIN),
+  };
+};
+
+const rememberActivePosition = (win: BrowserWindow): void => {
+  if (!controller?.getState()) return;
+  lastMovedBounds = win.getBounds();
+};
+
+const dismissOverlay = (): void => {
+  controller?.dismiss();
+};
+
+const attachWindowLifecycle = (win: BrowserWindow): void => {
+  if (trackedWindow === win) return;
+  trackedWindow = win;
+
+  win.on("move", () => {
+    rememberActivePosition(win);
+  });
+  win.on("blur", dismissOverlay);
+  win.webContents.on("before-input-event", (event, input) => {
+    if (input.type === "keyDown" && input.key === "Escape") {
+      event.preventDefault();
+      dismissOverlay();
+    }
+  });
+
+  const cleanup = (): void => {
+    if (trackedWindow === win) {
+      trackedWindow = null;
+    }
+    if (controller?.getState()) {
+      controller.dismiss();
+    }
+  };
+  win.on("closed", cleanup);
+  win.webContents.on("destroyed", cleanup);
+};
+
+const ensureOverlayWindow = (): BrowserWindow => {
+  const win = createFloatingWindow({
+    kind: OVERLAY_KIND,
+    route: OVERLAY_PATH,
+    width: OVERLAY_WIDTH,
+    height: OVERLAY_HEIGHT,
+    focusOnShow: false,
+    visibleOnAllWorkspaces: true,
+    position: displayPosition,
+    browserWindow: {
+      movable: true,
+      minimizable: false,
+      maximizable: false,
+      hasShadow: true,
+    },
+  });
+
+  attachWindowLifecycle(win);
+  return win;
+};
+
+const showOverlay = (): void => {
+  ensureOverlayWindow();
+};
+
+const hideOverlay = (): void => {
+  const win = getFloatingWindow(OVERLAY_KIND);
+  if (win) {
+    win.hide();
+  }
+};
+
+const forwardState = (state: TranscriptionOverlayState): void => {
+  const win = getFloatingWindow(OVERLAY_KIND);
+  if (win) {
+    win.webContents.send("vellum:transcriptionOverlay:state", state);
+  }
+};
+
+let installed = false;
+
+export const installTranscriptionOverlay = (): void => {
+  if (installed) return;
+  installed = true;
+
+  controller = createTranscriptionOverlayController({
+    showOverlay,
+    hideOverlay,
+    forwardState,
+    setTimeout,
+    clearTimeout: (handle) =>
+      clearTimeout(handle as ReturnType<typeof setTimeout>),
+  });
+
+  handle(
+    "vellum:transcriptionOverlay:show",
+    z.tuple([transcriptionOverlayStateSchema]),
+    ([state]) => {
+      controller?.show(state);
+    },
+  );
+
+  handle("vellum:transcriptionOverlay:dismiss", z.tuple([]), () => {
+    controller?.dismiss();
+  });
+
+  handle("vellum:transcriptionOverlay:getState", z.tuple([]), () =>
+    controller?.getState() ?? null,
+  );
+};

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -133,6 +133,15 @@ export type DictationOverlayMessage =
   | DictationOverlayState
   | { kind: "dismiss" };
 
+// Mirrors `TranscriptionOverlayState` in
+// `apps/macos/src/main/transcription-overlay-window.ts` (kept inline for the
+// same three-TS-project reason as `VellumCommand`).
+export interface TranscriptionOverlayState {
+  transcript: string;
+  createdAt: number;
+  autoDismissMs: number;
+}
+
 export type HelperState =
   | { status: "idle" }
   | { status: "starting"; attempt: number }
@@ -610,6 +619,22 @@ export interface VellumBridge {
      */
     getState(): Promise<DictationOverlayState | null>;
   };
+  transcriptionOverlay: {
+    /** Show the final transcript overlay without focusing it. */
+    show(state: TranscriptionOverlayState): Promise<void>;
+    /** Dismiss the final transcript overlay if it is visible. */
+    dismiss(): Promise<void>;
+    /**
+     * Subscribe to final transcript overlay state. Only the standalone overlay
+     * renderer (`/floating/transcription`) consumes this.
+     */
+    onState(callback: (state: TranscriptionOverlayState) => void): () => void;
+    /**
+     * Read the latest final transcript overlay state, or null when no overlay
+     * session is active.
+     */
+    getState(): Promise<TranscriptionOverlayState | null>;
+  };
   popout: {
     /**
      * Open (or focus) a pop-out window for a conversation. Main creates an
@@ -970,6 +995,31 @@ const bridge: VellumBridge = {
       ipcRenderer.invoke(
         "vellum:dictationOverlay:getState",
       ) as Promise<DictationOverlayState | null>,
+  },
+  transcriptionOverlay: {
+    show: (state: TranscriptionOverlayState): Promise<void> =>
+      ipcRenderer.invoke(
+        "vellum:transcriptionOverlay:show",
+        state,
+      ) as Promise<void>,
+    dismiss: (): Promise<void> =>
+      ipcRenderer.invoke("vellum:transcriptionOverlay:dismiss") as Promise<void>,
+    onState: (callback) => {
+      const handler = (
+        _event: IpcRendererEvent,
+        payload: TranscriptionOverlayState,
+      ) => {
+        callback(payload);
+      };
+      ipcRenderer.on("vellum:transcriptionOverlay:state", handler);
+      return () => {
+        ipcRenderer.off("vellum:transcriptionOverlay:state", handler);
+      };
+    },
+    getState: (): Promise<TranscriptionOverlayState | null> =>
+      ipcRenderer.invoke(
+        "vellum:transcriptionOverlay:getState",
+      ) as Promise<TranscriptionOverlayState | null>,
   },
   popout: {
     open: (conversationId: string): Promise<void> =>

--- a/apps/web/src/components/transcription-overlay-page.tsx
+++ b/apps/web/src/components/transcription-overlay-page.tsx
@@ -1,0 +1,72 @@
+import { X } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+
+import {
+  dismissTranscriptionOverlay,
+  getTranscriptionOverlayState,
+  subscribeToTranscriptionOverlayState,
+} from "@/runtime/transcription-overlay";
+import type { TranscriptionOverlayState } from "@/runtime/is-electron";
+
+/**
+ * Transparent standalone page rendered inside the Electron transcription
+ * overlay BrowserWindow. Main owns placement and visibility; this page renders
+ * the latest transcript plus an explicit close affordance.
+ */
+export function TranscriptionOverlayPage() {
+  const [state, setState] = useState<TranscriptionOverlayState | null>(null);
+
+  useEffect(() => {
+    const unsubscribe = subscribeToTranscriptionOverlayState(setState);
+    void getTranscriptionOverlayState().then((initial) => {
+      if (initial) {
+        setState((current) => current ?? initial);
+      }
+    });
+    return unsubscribe;
+  }, []);
+
+  const dismiss = useCallback(() => {
+    void dismissTranscriptionOverlay();
+  }, []);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        dismiss();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, [dismiss]);
+
+  if (!state) {
+    return null;
+  }
+
+  return (
+    <div className="flex h-screen w-screen items-end justify-center bg-transparent p-3">
+      <section
+        aria-label="Transcription"
+        aria-live="polite"
+        className="flex max-h-full w-full max-w-[496px] items-start gap-3 overflow-hidden rounded-lg border border-[var(--border-default)] bg-[var(--surface-base)] px-4 py-3 shadow-lg [-webkit-app-region:drag]"
+      >
+        <p className="min-w-0 flex-1 whitespace-pre-wrap break-words text-sm leading-5 text-[var(--content-default)]">
+          {state.transcript}
+        </p>
+        <button
+          type="button"
+          aria-label="Close transcription"
+          title="Close"
+          onClick={dismiss}
+          className="flex size-7 shrink-0 items-center justify-center rounded-md text-[var(--content-secondary)] transition-colors hover:bg-[var(--surface-hover)] hover:text-[var(--content-default)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--border-focus)] [-webkit-app-region:no-drag]"
+        >
+          <X size={16} aria-hidden />
+        </button>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -123,6 +123,11 @@ export const routeTree = [
     // outside auth middleware and RootLayout for fast load.
     { path: "/assistant/dictation-overlay", ErrorBoundary: RouteErrorBoundary, HydrateFallback: RootHydrateFallback, lazy: { Component: () => import("@/components/dictation-overlay-page").then((m) => m.DictationOverlayPage) } },
 
+    // Transcription overlay — final transcript surface rendered inside the
+    // Electron transcription floating BrowserWindow. Standalone, outside
+    // auth middleware and RootLayout, so the transparent overlay loads fast.
+    { path: "/assistant/floating/transcription", ErrorBoundary: RouteErrorBoundary, HydrateFallback: RootHydrateFallback, lazy: { Component: () => import("@/components/transcription-overlay-page").then((m) => m.TranscriptionOverlayPage) } },
+
     // Assistant routes — auth-protected app with layout
     {
       path: "/assistant",

--- a/apps/web/src/runtime/is-electron.ts
+++ b/apps/web/src/runtime/is-electron.ts
@@ -150,6 +150,17 @@ export type DictationOverlayMessage =
   | DictationOverlayState
   | { kind: "dismiss" };
 
+/**
+ * Renderer-side mirror of `TranscriptionOverlayState` in
+ * `apps/macos/src/main/transcription-overlay-window.ts` — inline for the same
+ * reason as `VellumCommand`.
+ */
+export interface TranscriptionOverlayState {
+  transcript: string;
+  createdAt: number;
+  autoDismissMs: number;
+}
+
 export type HelperState =
   | { status: "idle" }
   | { status: "starting"; attempt: number }
@@ -426,6 +437,16 @@ declare global {
           callback: (state: DictationOverlayState) => void,
         ): () => void;
         getState(): Promise<DictationOverlayState | null>;
+      };
+      // Optional: older Electron shells predate the final transcription
+      // overlay channel.
+      transcriptionOverlay?: {
+        show(state: TranscriptionOverlayState): Promise<void>;
+        dismiss(): Promise<void>;
+        onState(
+          callback: (state: TranscriptionOverlayState) => void,
+        ): () => void;
+        getState(): Promise<TranscriptionOverlayState | null>;
       };
       // Optional: older Electron shells predate the notifications channel.
       notifications?: {

--- a/apps/web/src/runtime/transcription-overlay.ts
+++ b/apps/web/src/runtime/transcription-overlay.ts
@@ -1,0 +1,52 @@
+/**
+ * Runtime wrapper for the final transcription overlay bridge surface.
+ *
+ * Feature code imports these functions instead of touching
+ * `window.vellum.transcriptionOverlay` directly. Off-Electron and on older
+ * shells that predate the channel, calls degrade to no-ops.
+ */
+
+import {
+  isElectron,
+  type TranscriptionOverlayState,
+} from "@/runtime/is-electron";
+
+const DEFAULT_AUTO_DISMISS_MS = 6000;
+
+export async function showTranscriptionOverlay(
+  state:
+    | TranscriptionOverlayState
+    | {
+        transcript: string;
+        createdAt?: number;
+        autoDismissMs?: number;
+      },
+): Promise<void> {
+  if (!isElectron()) return;
+  await window.vellum?.transcriptionOverlay?.show?.({
+    transcript: state.transcript,
+    createdAt: state.createdAt ?? Date.now(),
+    autoDismissMs: state.autoDismissMs ?? DEFAULT_AUTO_DISMISS_MS,
+  });
+}
+
+export async function dismissTranscriptionOverlay(): Promise<void> {
+  if (!isElectron()) return;
+  await window.vellum?.transcriptionOverlay?.dismiss?.();
+}
+
+export function subscribeToTranscriptionOverlayState(
+  callback: (state: TranscriptionOverlayState) => void,
+): () => void {
+  if (!isElectron() || !window.vellum?.transcriptionOverlay?.onState) {
+    return () => undefined;
+  }
+  return window.vellum.transcriptionOverlay.onState(callback);
+}
+
+export async function getTranscriptionOverlayState(): Promise<TranscriptionOverlayState | null> {
+  if (!isElectron() || !window.vellum?.transcriptionOverlay?.getState) {
+    return null;
+  }
+  return window.vellum.transcriptionOverlay.getState();
+}


### PR DESCRIPTION
## Summary
- add a singleton final transcription floating BrowserWindow backed by the shared floating-window factory
- expose show/dismiss/getState/onState through Electron preload and a web runtime helper
- add the standalone /assistant/floating/transcription route and transparent overlay page

Part of LUM-1867.

## Tests
- cd apps/macos && export PATH="/Users/maddieabboud/.bun/bin:/Users/maddieabboud/Downloads/google-cloud-sdk/bin:/Users/maddieabboud/.pyenv/shims:/opt/homebrew/opt/gnu-getopt/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/opt/local/bin:/opt/local/sbin:/Users/maddieabboud/.nvm/versions/node/v22.22.2/bin:/Users/maddieabboud/.nvm/versions/node/v16.19.0/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Applications/VMware Fusion Tech Preview.app/Contents/Public:/Users/maddieabboud/.codex/tmp/arg0/codex-arg0Z4ZyPQ:/Users/maddieabboud/Downloads/google-cloud-sdk/bin:/Users/maddieabboud/.bun/bin:/Users/maddieabboud/.antigravity/antigravity/bin:/opt/homebrew/opt/postgresql@16/bin:/Users/maddieabboud/Library/pnpm:/opt/homebrew/opt/gnu-getopt/bin:/Users/maddieabboud/.cargo/bin:/Users/maddieabboud/Library/Application Support/JetBrains/Toolbox/scripts:/Users/maddieabboud/.local/bin:/Applications/Codex.app/Contents/Resources:/Users/maddieabboud/Library/Application Support/JetBrains/Toolbox/scripts:/Users/maddieabboud/.local/bin"; bun test src/main/transcription-overlay-window.test.ts
- cd apps/macos && export PATH="/Users/maddieabboud/.bun/bin:/Users/maddieabboud/Downloads/google-cloud-sdk/bin:/Users/maddieabboud/.pyenv/shims:/opt/homebrew/opt/gnu-getopt/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/opt/local/bin:/opt/local/sbin:/Users/maddieabboud/.nvm/versions/node/v22.22.2/bin:/Users/maddieabboud/.nvm/versions/node/v16.19.0/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Applications/VMware Fusion Tech Preview.app/Contents/Public:/Users/maddieabboud/.codex/tmp/arg0/codex-arg0Z4ZyPQ:/Users/maddieabboud/Downloads/google-cloud-sdk/bin:/Users/maddieabboud/.bun/bin:/Users/maddieabboud/.antigravity/antigravity/bin:/opt/homebrew/opt/postgresql@16/bin:/Users/maddieabboud/Library/pnpm:/opt/homebrew/opt/gnu-getopt/bin:/Users/maddieabboud/.cargo/bin:/Users/maddieabboud/Library/Application Support/JetBrains/Toolbox/scripts:/Users/maddieabboud/.local/bin:/Applications/Codex.app/Contents/Resources:/Users/maddieabboud/Library/Application Support/JetBrains/Toolbox/scripts:/Users/maddieabboud/.local/bin"; bunx tsc --noEmit
- cd apps/web && export PATH="/Users/maddieabboud/.bun/bin:/Users/maddieabboud/Downloads/google-cloud-sdk/bin:/Users/maddieabboud/.pyenv/shims:/opt/homebrew/opt/gnu-getopt/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/opt/local/bin:/opt/local/sbin:/Users/maddieabboud/.nvm/versions/node/v22.22.2/bin:/Users/maddieabboud/.nvm/versions/node/v16.19.0/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Applications/VMware Fusion Tech Preview.app/Contents/Public:/Users/maddieabboud/.codex/tmp/arg0/codex-arg0Z4ZyPQ:/Users/maddieabboud/Downloads/google-cloud-sdk/bin:/Users/maddieabboud/.bun/bin:/Users/maddieabboud/.antigravity/antigravity/bin:/opt/homebrew/opt/postgresql@16/bin:/Users/maddieabboud/Library/pnpm:/opt/homebrew/opt/gnu-getopt/bin:/Users/maddieabboud/.cargo/bin:/Users/maddieabboud/Library/Application Support/JetBrains/Toolbox/scripts:/Users/maddieabboud/.local/bin:/Applications/Codex.app/Contents/Resources:/Users/maddieabboud/Library/Application Support/JetBrains/Toolbox/scripts:/Users/maddieabboud/.local/bin"; bunx tsc --noEmit
- cd apps/web && export PATH="/Users/maddieabboud/.bun/bin:/Users/maddieabboud/Downloads/google-cloud-sdk/bin:/Users/maddieabboud/.pyenv/shims:/opt/homebrew/opt/gnu-getopt/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/opt/local/bin:/opt/local/sbin:/Users/maddieabboud/.nvm/versions/node/v22.22.2/bin:/Users/maddieabboud/.nvm/versions/node/v16.19.0/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Applications/VMware Fusion Tech Preview.app/Contents/Public:/Users/maddieabboud/.codex/tmp/arg0/codex-arg0Z4ZyPQ:/Users/maddieabboud/Downloads/google-cloud-sdk/bin:/Users/maddieabboud/.bun/bin:/Users/maddieabboud/.antigravity/antigravity/bin:/opt/homebrew/opt/postgresql@16/bin:/Users/maddieabboud/Library/pnpm:/opt/homebrew/opt/gnu-getopt/bin:/Users/maddieabboud/.cargo/bin:/Users/maddieabboud/Library/Application Support/JetBrains/Toolbox/scripts:/Users/maddieabboud/.local/bin:/Applications/Codex.app/Contents/Resources:/Users/maddieabboud/Library/Application Support/JetBrains/Toolbox/scripts:/Users/maddieabboud/.local/bin"; bun test src/routes.test.ts