### PR TITLE
feat(macos): open command palette in a floating window

### DIFF
--- a/apps/macos/src/main/command-palette-window.test.ts
+++ b/apps/macos/src/main/command-palette-window.test.ts
@@ -372,6 +372,14 @@ describe("installCommandPaletteWindow", () => {
       { kind: "home" },
     ]);
     expect(dispatchToMainMock).toHaveBeenCalledWith({ kind: "home" });
+
+    await ipcHandlers.get("vellum:commandPalette:select")?.([
+      { kind: "openConversation", conversationId: "conv-123" },
+    ]);
+    expect(dispatchToMainMock).toHaveBeenCalledWith({
+      kind: "openConversation",
+      conversationId: "conv-123",
+    });
   });
 });
 
@@ -419,5 +427,18 @@ describe("dispatchMenuCommand", () => {
     expect(source.webContents.send).toHaveBeenCalledWith("vellum:command", {
       kind: "newConversation",
     });
+  });
+
+  test("routes non-palette menu commands to the main window while the palette is focused", () => {
+    openCommandPaletteWindow();
+    const palette = created[0]!.win;
+
+    dispatchMenuCommand({ kind: "openSettings" });
+
+    expect(palette.webContents.send).not.toHaveBeenCalledWith(
+      "vellum:command",
+      { kind: "openSettings" },
+    );
+    expect(dispatchToMainMock).toHaveBeenCalledWith({ kind: "openSettings" });
   });
 });

--- a/apps/macos/src/main/command-palette-window.test.ts
+++ b/apps/macos/src/main/command-palette-window.test.ts
@@ -1,0 +1,423 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+type Listener = (...args: unknown[]) => void;
+
+type StubWebContents = {
+  on: (event: string, listener: Listener) => StubWebContents;
+  isDestroyed: () => boolean;
+  emit: (event: string, ...args: unknown[]) => void;
+  send: ReturnType<typeof mock>;
+};
+
+type StubWindow = {
+  webContents: StubWebContents;
+  isDestroyed: () => boolean;
+  isVisible: () => boolean;
+  isMinimized: () => boolean;
+  getBounds: () => Electron.Rectangle;
+  on: (event: string, listener: Listener) => StubWindow;
+  emit: (event: string, ...args: unknown[]) => void;
+  close: ReturnType<typeof mock>;
+  setPosition: ReturnType<typeof mock>;
+  setAlwaysOnTop: ReturnType<typeof mock>;
+  setVisibleOnAllWorkspaces: ReturnType<typeof mock>;
+  setIgnoreMouseEvents: ReturnType<typeof mock>;
+  show: ReturnType<typeof mock>;
+  focus: ReturnType<typeof mock>;
+  showInactive: ReturnType<typeof mock>;
+  loadURL: ReturnType<typeof mock>;
+};
+
+type FocusedSource = {
+  webContents: { send: ReturnType<typeof mock> };
+  isDestroyed: () => boolean;
+  getBounds: () => Electron.Rectangle;
+};
+
+type CreateWindowOptions = {
+  browserWindow: Record<string, unknown>;
+  navigation: unknown;
+};
+
+const appState = { isPackaged: false, name: "Vellum" };
+const created: Array<{ opts: CreateWindowOptions; win: StubWindow }> = [];
+const ipcHandlers = new Map<string, (...args: unknown[]) => unknown>();
+
+let focusedWindow: StubWindow | FocusedSource | null = null;
+let activeWorkArea: Electron.Rectangle = {
+  x: 1440,
+  y: 100,
+  width: 1600,
+  height: 900,
+};
+let currentMainWindow: {
+  isDestroyed: () => boolean;
+  isVisible: () => boolean;
+  isMinimized: () => boolean;
+} | null = null;
+
+const makeWindow = (): StubWindow => {
+  const windowListeners = new Map<string, Listener[]>();
+  const webContentsListeners = new Map<string, Listener[]>();
+  let destroyed = false;
+  let webContentsDestroyed = false;
+  let visible = false;
+  let minimized = false;
+  const bounds: Electron.Rectangle = {
+    x: 0,
+    y: 0,
+    width: 800,
+    height: 520,
+  };
+
+  const webContents: StubWebContents = {
+    on: (event, listener) => {
+      const listeners = webContentsListeners.get(event) ?? [];
+      listeners.push(listener);
+      webContentsListeners.set(event, listeners);
+      return webContents;
+    },
+    isDestroyed: () => webContentsDestroyed,
+    emit: (event, ...args) => {
+      if (event === "destroyed") webContentsDestroyed = true;
+      for (const listener of webContentsListeners.get(event) ?? []) {
+        listener(...args);
+      }
+    },
+    send: mock(() => undefined),
+  };
+
+  const win: StubWindow = {
+    webContents,
+    isDestroyed: () => destroyed,
+    isVisible: () => visible,
+    isMinimized: () => minimized,
+    getBounds: () => ({ ...bounds }),
+    on: (event, listener) => {
+      const listeners = windowListeners.get(event) ?? [];
+      listeners.push(listener);
+      windowListeners.set(event, listeners);
+      return win;
+    },
+    emit: (event, ...args) => {
+      if (event === "closed") {
+        destroyed = true;
+        visible = false;
+      }
+      if (event === "hide") visible = false;
+      if (event === "show") visible = true;
+      for (const listener of windowListeners.get(event) ?? []) {
+        listener(...args);
+      }
+    },
+    close: mock(() => {
+      win.emit("closed");
+    }),
+    setPosition: mock((x: number, y: number) => {
+      bounds.x = x;
+      bounds.y = y;
+    }),
+    setAlwaysOnTop: mock((_flag: boolean, _level: string) => undefined),
+    setIgnoreMouseEvents: mock((_ignore: boolean) => undefined),
+    setVisibleOnAllWorkspaces: mock(
+      (_visible: boolean, _opts: Record<string, boolean>) => undefined,
+    ),
+    show: mock(() => {
+      visible = true;
+    }),
+    focus: mock(() => {
+      focusedWindow = win;
+    }),
+    showInactive: mock(() => {
+      visible = true;
+    }),
+    loadURL: mock((_url: string) => Promise.resolve()),
+  };
+  Object.defineProperty(win, "__setMinimized", {
+    value: (value: boolean) => {
+      minimized = value;
+    },
+  });
+  return win;
+};
+
+const makeFocusedSource = (
+  bounds: Electron.Rectangle = { x: 1500, y: 200, width: 900, height: 700 },
+): FocusedSource => ({
+  webContents: { send: mock(() => undefined) },
+  isDestroyed: () => false,
+  getBounds: () => bounds,
+});
+
+const makeMainWindow = ({
+  visible = true,
+  minimized = false,
+  destroyed = false,
+}: {
+  visible?: boolean;
+  minimized?: boolean;
+  destroyed?: boolean;
+}) => ({
+  isDestroyed: () => destroyed,
+  isVisible: () => visible,
+  isMinimized: () => minimized,
+});
+
+const createWindowMock = mock((opts: CreateWindowOptions): StubWindow => {
+  const win = makeWindow();
+  created.push({ opts, win });
+  return win;
+});
+
+const handleMock = mock(
+  (
+    channel: string,
+    _schema: unknown,
+    fn: (...args: unknown[]) => unknown,
+  ) => {
+    ipcHandlers.set(channel, fn);
+  },
+);
+
+const ensureVisibleMock = mock(async () => undefined);
+const dispatchToMainMock = mock((_command: unknown) => undefined);
+
+mock.module("electron", () => ({
+  app: appState,
+  BrowserWindow: class {
+    static getFocusedWindow() {
+      return focusedWindow;
+    }
+
+    static getAllWindows() {
+      return focusedWindow ? [focusedWindow] : [];
+    }
+  },
+  Menu: {
+    buildFromTemplate: mock((template: unknown) => template),
+    setApplicationMenu: mock((_menu: unknown) => undefined),
+  },
+  ipcMain: {
+    handle: mock(() => undefined),
+    on: mock(() => undefined),
+  },
+  screen: {
+    getCursorScreenPoint: () => ({ x: 0, y: 0 }),
+    getDisplayNearestPoint: () => ({ workArea: activeWorkArea }),
+    getDisplayMatching: mock((_bounds: Electron.Rectangle) => ({
+      workArea: activeWorkArea,
+    })),
+  },
+  shell: {
+    openExternal: mock(() => Promise.resolve()),
+  },
+}));
+
+mock.module("./windows", () => ({
+  createWindow: createWindowMock,
+}));
+
+mock.module("./ipc", () => ({
+  handle: handleMock,
+}));
+
+mock.module("./main-window", () => ({
+  current: () => currentMainWindow,
+  ensureVisible: ensureVisibleMock,
+  dispatchToMain: dispatchToMainMock,
+}));
+
+mock.module("./settings", () => ({
+  readHotkeyOverride: () => null,
+  readSetting: () => null,
+  writeSetting: () => {},
+  onSettingChange: () => () => {},
+}));
+
+mock.module("./about", () => ({
+  openAboutWindow: mock(() => undefined),
+}));
+
+mock.module("./auto-update", () => ({
+  checkForUpdates: mock(() => undefined),
+}));
+
+mock.module("./devtools", () => ({
+  areChromeDevToolsEnabled: () => false,
+}));
+
+mock.module("./window-state", () => ({
+  readOnboardingActive: () => false,
+}));
+
+const {
+  __resetForTesting,
+  installCommandPaletteWindow,
+  openCommandPaletteWindow,
+  selectCommandPaletteCommand,
+} = await import("./command-palette-window");
+const { dispatchMenuCommand } = await import("./menu");
+
+beforeEach(() => {
+  for (const { win } of created) {
+    if (!win.isDestroyed()) win.close();
+  }
+  created.length = 0;
+  ipcHandlers.clear();
+  createWindowMock.mockClear();
+  handleMock.mockClear();
+  ensureVisibleMock.mockClear();
+  dispatchToMainMock.mockClear();
+  appState.isPackaged = false;
+  process.env.VELLUM_DEV_URL = "http://localhost:4242/assistant/";
+  activeWorkArea = { x: 1440, y: 100, width: 1600, height: 900 };
+  focusedWindow = makeFocusedSource();
+  currentMainWindow = null;
+  __resetForTesting();
+});
+
+afterEach(() => {
+  for (const { win } of created) {
+    if (!win.isDestroyed()) win.close();
+  }
+  delete process.env.VELLUM_DEV_URL;
+});
+
+describe("openCommandPaletteWindow", () => {
+  test("opens a focused singleton floating window centered in the focused display work area", () => {
+    const first = openCommandPaletteWindow();
+    expect(first).toBeUndefined();
+
+    expect(createWindowMock).toHaveBeenCalledTimes(1);
+    const { opts, win } = created[0]!;
+    expect(opts.navigation).toBe("deny-all");
+    expect(opts.browserWindow).toMatchObject({
+      type: "panel",
+      width: 800,
+      height: 520,
+      frame: false,
+      transparent: true,
+      resizable: false,
+      skipTaskbar: true,
+      fullscreenable: false,
+      show: false,
+      minimizable: false,
+      maximizable: false,
+      hasShadow: true,
+      vibrancy: "popover",
+    });
+    expect(win.setPosition.mock.calls).toEqual([[1840, 290]]);
+    expect(win.show).toHaveBeenCalledTimes(1);
+    expect(win.focus).toHaveBeenCalledTimes(1);
+    expect(win.loadURL.mock.calls[0]?.[0]).toBe(
+      "http://localhost:4242/assistant/floating/command-palette",
+    );
+
+    openCommandPaletteWindow();
+
+    expect(createWindowMock).toHaveBeenCalledTimes(1);
+    expect(win.show).toHaveBeenCalledTimes(2);
+    expect(win.focus).toHaveBeenCalledTimes(2);
+    expect(win.loadURL).toHaveBeenCalledTimes(1);
+  });
+
+  test("closes when the floating window blurs", () => {
+    openCommandPaletteWindow();
+    const win = created[0]!.win;
+
+    win.emit("blur");
+
+    expect(win.close).toHaveBeenCalledTimes(1);
+    expect(win.isDestroyed()).toBe(true);
+  });
+
+  test("closes on Escape before-input events", () => {
+    openCommandPaletteWindow();
+    const win = created[0]!.win;
+    const preventDefault = mock(() => undefined);
+
+    win.webContents.emit(
+      "before-input-event",
+      { preventDefault },
+      {
+        type: "keyDown",
+        key: "Escape",
+      },
+    );
+
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(win.close).toHaveBeenCalledTimes(1);
+    expect(win.isDestroyed()).toBe(true);
+  });
+});
+
+describe("installCommandPaletteWindow", () => {
+  test("registers open, dismiss, and select IPC handlers", async () => {
+    installCommandPaletteWindow();
+
+    expect(handleMock.mock.calls.map((call) => call[0])).toEqual([
+      "vellum:commandPalette:open",
+      "vellum:commandPalette:dismiss",
+      "vellum:commandPalette:select",
+    ]);
+
+    ipcHandlers.get("vellum:commandPalette:open")?.([]);
+    expect(created).toHaveLength(1);
+
+    ipcHandlers.get("vellum:commandPalette:dismiss")?.([]);
+    expect(created[0]!.win.close).toHaveBeenCalledTimes(1);
+
+    currentMainWindow = makeMainWindow({ visible: true });
+    await ipcHandlers.get("vellum:commandPalette:select")?.([
+      { kind: "home" },
+    ]);
+    expect(dispatchToMainMock).toHaveBeenCalledWith({ kind: "home" });
+  });
+});
+
+describe("selectCommandPaletteCommand", () => {
+  test("closes the palette and dispatches to a visible main window without refocusing it", async () => {
+    openCommandPaletteWindow();
+    const win = created[0]!.win;
+    currentMainWindow = makeMainWindow({ visible: true });
+
+    await selectCommandPaletteCommand({ kind: "openSettings" });
+
+    expect(win.close).toHaveBeenCalledTimes(1);
+    expect(ensureVisibleMock).not.toHaveBeenCalled();
+    expect(dispatchToMainMock).toHaveBeenCalledWith({ kind: "openSettings" });
+  });
+
+  test("ensures the main window before dispatch when it is hidden", async () => {
+    currentMainWindow = makeMainWindow({ visible: false });
+
+    await selectCommandPaletteCommand({ kind: "shareFeedback" });
+
+    expect(ensureVisibleMock).toHaveBeenCalledTimes(1);
+    expect(dispatchToMainMock).toHaveBeenCalledWith({ kind: "shareFeedback" });
+  });
+});
+
+describe("dispatchMenuCommand", () => {
+  test("routes the Command Palette menu command to the floating window", () => {
+    const source = makeFocusedSource();
+    focusedWindow = source;
+
+    dispatchMenuCommand({ kind: "commandPalette" });
+
+    expect(created).toHaveLength(1);
+    expect(source.webContents.send).not.toHaveBeenCalled();
+  });
+
+  test("keeps other menu commands on the focused renderer command stream", () => {
+    const source = makeFocusedSource();
+    focusedWindow = source;
+
+    dispatchMenuCommand({ kind: "newConversation" });
+
+    expect(created).toHaveLength(0);
+    expect(source.webContents.send).toHaveBeenCalledWith("vellum:command", {
+      kind: "newConversation",
+    });
+  });
+});

--- a/apps/macos/src/main/command-palette-window.test.ts
+++ b/apps/macos/src/main/command-palette-window.test.ts
@@ -417,6 +417,16 @@ describe("dispatchMenuCommand", () => {
     expect(source.webContents.send).not.toHaveBeenCalled();
   });
 
+  test("closes the focused palette when the Command Palette accelerator is pressed again", () => {
+    openCommandPaletteWindow();
+    const palette = created[0]!.win;
+
+    dispatchMenuCommand({ kind: "commandPalette" });
+
+    expect(palette.close).toHaveBeenCalledTimes(1);
+    expect(palette.isDestroyed()).toBe(true);
+  });
+
   test("keeps other menu commands on the focused renderer command stream", () => {
     const source = makeFocusedSource();
     focusedWindow = source;

--- a/apps/macos/src/main/command-palette-window.ts
+++ b/apps/macos/src/main/command-palette-window.ts
@@ -43,6 +43,13 @@ const payloadlessCommandKindSchema = z.enum([
   "popOut",
   "previousConversation",
   "nextConversation",
+  "openLibrary",
+  "openIdentity",
+  "navigateBack",
+  "navigateForward",
+  "zoomIn",
+  "zoomOut",
+  "actualSize",
   "createAssistant",
   "cancelActiveAction",
   "replayOnboarding",
@@ -53,10 +60,11 @@ const payloadlessCommandKindSchema = z.enum([
 const commandPaletteDispatchCommandSchema: z.ZodType<CommandPaletteDispatchCommand> =
   z.union([
     z.object({ kind: payloadlessCommandKindSchema }),
+    z.object({ kind: z.literal("openConversation"), conversationId: z.string() }),
     z.object({ kind: z.literal("selectAssistant"), assistantId: z.string() }),
     z.object({ kind: z.literal("retireAssistant"), assistantId: z.string() }),
     z.object({ kind: z.literal("quickInputSubmit"), message: z.string() }),
-  ]);
+  ]) as z.ZodType<CommandPaletteDispatchCommand>;
 
 const focusedDisplayWorkArea = (): Electron.Rectangle => {
   const focused = BrowserWindow.getFocusedWindow();
@@ -114,6 +122,12 @@ export const openCommandPaletteWindow = (): void => {
   if (!existing) {
     wireCloseHandlers(win);
   }
+};
+
+export const isCommandPaletteWindowFocused = (): boolean => {
+  const focused = BrowserWindow.getFocusedWindow();
+  const palette = getFloatingWindow(COMMAND_PALETTE_KIND);
+  return Boolean(focused && palette && focused === palette);
 };
 
 export const selectCommandPaletteCommand = async (

--- a/apps/macos/src/main/command-palette-window.ts
+++ b/apps/macos/src/main/command-palette-window.ts
@@ -1,0 +1,157 @@
+import { BrowserWindow, screen } from "electron";
+import { z } from "zod";
+
+import { createFloatingWindow, getFloatingWindow } from "./floating-window";
+import { handle } from "./ipc";
+import {
+  current as currentMainWindow,
+  dispatchToMain,
+  ensureVisible as ensureMainWindowVisible,
+} from "./main-window";
+import type { VellumCommand } from "./commands";
+
+const COMMAND_PALETTE_KIND = "commandPalette";
+const COMMAND_PALETTE_PATH = "/floating/command-palette";
+
+const PANEL_WIDTH = 800;
+const PANEL_HEIGHT = 520;
+
+type PayloadCommandKind = Extract<
+  VellumCommand,
+  { kind: "selectAssistant" | "retireAssistant" | "quickInputSubmit" }
+>["kind"];
+
+type CommandPaletteDispatchCommand =
+  | Exclude<
+      VellumCommand,
+      { kind: "commandPalette" } | { kind: PayloadCommandKind }
+    >
+  | Extract<VellumCommand, { kind: PayloadCommandKind }>;
+
+const payloadlessCommandKindSchema = z.enum([
+  "newConversation",
+  "currentConversation",
+  "markCurrentUnread",
+  "openSettings",
+  "shareFeedback",
+  "find",
+  "markAllRead",
+  "logout",
+  "rePair",
+  "sidebarToggle",
+  "home",
+  "popOut",
+  "previousConversation",
+  "nextConversation",
+  "createAssistant",
+  "cancelActiveAction",
+  "replayOnboarding",
+  "previewPrechat",
+  "openComponentGallery",
+]);
+
+const commandPaletteDispatchCommandSchema: z.ZodType<CommandPaletteDispatchCommand> =
+  z.union([
+    z.object({ kind: payloadlessCommandKindSchema }),
+    z.object({ kind: z.literal("selectAssistant"), assistantId: z.string() }),
+    z.object({ kind: z.literal("retireAssistant"), assistantId: z.string() }),
+    z.object({ kind: z.literal("quickInputSubmit"), message: z.string() }),
+  ]);
+
+const focusedDisplayWorkArea = (): Electron.Rectangle => {
+  const focused = BrowserWindow.getFocusedWindow();
+  if (focused && !focused.isDestroyed()) {
+    return screen.getDisplayMatching(focused.getBounds()).workArea;
+  }
+  const cursor = screen.getCursorScreenPoint();
+  return screen.getDisplayNearestPoint(cursor).workArea;
+};
+
+const commandPalettePosition = (): { x: number; y: number } => {
+  const { x, y, width, height } = focusedDisplayWorkArea();
+  return {
+    x: Math.round(x + (width - PANEL_WIDTH) / 2),
+    y: Math.round(y + (height - PANEL_HEIGHT) / 2),
+  };
+};
+
+const closeCommandPaletteWindow = (): void => {
+  const win = getFloatingWindow(COMMAND_PALETTE_KIND);
+  if (win && !win.isDestroyed()) {
+    win.close();
+  }
+};
+
+const wireCloseHandlers = (win: BrowserWindow): void => {
+  win.on("blur", () => {
+    closeCommandPaletteWindow();
+  });
+  win.webContents.on("before-input-event", (event, input) => {
+    if (input.type === "keyDown" && input.key === "Escape") {
+      event.preventDefault();
+      closeCommandPaletteWindow();
+    }
+  });
+};
+
+export const openCommandPaletteWindow = (): void => {
+  const existing = getFloatingWindow(COMMAND_PALETTE_KIND);
+  const win = createFloatingWindow({
+    kind: COMMAND_PALETTE_KIND,
+    route: COMMAND_PALETTE_PATH,
+    width: PANEL_WIDTH,
+    height: PANEL_HEIGHT,
+    focusOnShow: true,
+    position: commandPalettePosition,
+    browserWindow: {
+      minimizable: false,
+      maximizable: false,
+      hasShadow: true,
+      vibrancy: "popover",
+    },
+  });
+
+  if (!existing) {
+    wireCloseHandlers(win);
+  }
+};
+
+export const selectCommandPaletteCommand = async (
+  command: CommandPaletteDispatchCommand,
+): Promise<void> => {
+  closeCommandPaletteWindow();
+
+  const main = currentMainWindow();
+  if (!main || main.isDestroyed() || !main.isVisible() || main.isMinimized()) {
+    await ensureMainWindowVisible();
+  }
+
+  dispatchToMain(command);
+};
+
+let installed = false;
+
+export const installCommandPaletteWindow = (): void => {
+  if (installed) return;
+  installed = true;
+
+  handle("vellum:commandPalette:open", z.tuple([]), () => {
+    openCommandPaletteWindow();
+  });
+
+  handle("vellum:commandPalette:dismiss", z.tuple([]), () => {
+    closeCommandPaletteWindow();
+  });
+
+  handle(
+    "vellum:commandPalette:select",
+    z.tuple([commandPaletteDispatchCommandSchema]),
+    async ([command]) => {
+      await selectCommandPaletteCommand(command);
+    },
+  );
+};
+
+export const __resetForTesting = (): void => {
+  installed = false;
+};

--- a/apps/macos/src/main/command-palette-window.ts
+++ b/apps/macos/src/main/command-palette-window.ts
@@ -83,7 +83,7 @@ const commandPalettePosition = (): { x: number; y: number } => {
   };
 };
 
-const closeCommandPaletteWindow = (): void => {
+export const closeCommandPaletteWindow = (): void => {
   const win = getFloatingWindow(COMMAND_PALETTE_KIND);
   if (win && !win.isDestroyed()) {
     win.close();

--- a/apps/macos/src/main/commands.ts
+++ b/apps/macos/src/main/commands.ts
@@ -25,6 +25,14 @@ export type VellumCommand =
   | { kind: "previousConversation" }
   | { kind: "nextConversation" }
   | { kind: "commandPalette" }
+  | { kind: "openConversation"; conversationId: string }
+  | { kind: "openLibrary" }
+  | { kind: "openIdentity" }
+  | { kind: "navigateBack" }
+  | { kind: "navigateForward" }
+  | { kind: "zoomIn" }
+  | { kind: "zoomOut" }
+  | { kind: "actualSize" }
   | { kind: "selectAssistant"; assistantId: string }
   | { kind: "createAssistant" }
   | { kind: "retireAssistant"; assistantId: string }
@@ -61,6 +69,14 @@ export const DEFAULT_ACCELERATORS: Record<VellumCommandKind, string> = {
   previousConversation: "CmdOrCtrl+Up",
   nextConversation: "CmdOrCtrl+Down",
   commandPalette: "CmdOrCtrl+K",
+  openConversation: "",
+  openLibrary: "",
+  openIdentity: "",
+  navigateBack: "",
+  navigateForward: "",
+  zoomIn: "",
+  zoomOut: "",
+  actualSize: "",
   selectAssistant: "",
   createAssistant: "",
   retireAssistant: "",

--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -30,6 +30,7 @@ import {
 import { handleBundleFile, installBundleFlow } from "./bundle-flow";
 import { handleFileOpen, installFileOpen, onFileOpen } from "./file-open";
 import { installAvatarIpc } from "./avatar";
+import { installCommandPaletteWindow } from "./command-palette-window";
 import { installDictationOverlay } from "./dictation-overlay-window";
 import { installDock } from "./dock";
 import { installEscapeMonitor } from "./escape-monitor";
@@ -326,6 +327,7 @@ app
     installAutoUpdate();
     installFeedbackIpc();
     installTextInsertionIpc();
+    installCommandPaletteWindow();
     installApplicationMenu();
     installQuickInput();
     installDictationOverlay();

--- a/apps/macos/src/main/menu.ts
+++ b/apps/macos/src/main/menu.ts
@@ -8,6 +8,7 @@ import {
   dispatchToFocused,
   type VellumCommand,
 } from "./commands";
+import { openCommandPaletteWindow } from "./command-palette-window";
 import { areChromeDevToolsEnabled } from "./devtools";
 import { handle } from "./ipc";
 import { onSettingChange, readSetting } from "./settings";
@@ -26,6 +27,14 @@ const isDeveloperMenuEnabled = (): boolean => {
   return flags?.["developer-menu-items"] === true;
 };
 
+export const dispatchMenuCommand = (command: VellumCommand): void => {
+  if (command.kind === "commandPalette") {
+    openCommandPaletteWindow();
+    return;
+  }
+  dispatchToFocused(command);
+};
+
 const buildTemplate = (): MenuItemConstructorOptions[] => {
   const isDev = !app.isPackaged;
   const chromeDevToolsEnabled = areChromeDevToolsEnabled();
@@ -37,7 +46,7 @@ const buildTemplate = (): MenuItemConstructorOptions[] => {
   ): MenuItemConstructorOptions => ({
     label,
     ...acceleratorOption(command.kind),
-    click: () => dispatchToFocused(command),
+    click: () => dispatchMenuCommand(command),
   });
 
   return [

--- a/apps/macos/src/main/menu.ts
+++ b/apps/macos/src/main/menu.ts
@@ -9,6 +9,7 @@ import {
   type VellumCommand,
 } from "./commands";
 import {
+  closeCommandPaletteWindow,
   isCommandPaletteWindowFocused,
   openCommandPaletteWindow,
 } from "./command-palette-window";
@@ -33,6 +34,10 @@ const isDeveloperMenuEnabled = (): boolean => {
 
 export const dispatchMenuCommand = (command: VellumCommand): void => {
   if (command.kind === "commandPalette") {
+    if (isCommandPaletteWindowFocused()) {
+      closeCommandPaletteWindow();
+      return;
+    }
     openCommandPaletteWindow();
     return;
   }

--- a/apps/macos/src/main/menu.ts
+++ b/apps/macos/src/main/menu.ts
@@ -8,9 +8,13 @@ import {
   dispatchToFocused,
   type VellumCommand,
 } from "./commands";
-import { openCommandPaletteWindow } from "./command-palette-window";
+import {
+  isCommandPaletteWindowFocused,
+  openCommandPaletteWindow,
+} from "./command-palette-window";
 import { areChromeDevToolsEnabled } from "./devtools";
 import { handle } from "./ipc";
+import { dispatchToMain } from "./main-window";
 import { onSettingChange, readSetting } from "./settings";
 import { readOnboardingActive } from "./window-state";
 
@@ -30,6 +34,10 @@ const isDeveloperMenuEnabled = (): boolean => {
 export const dispatchMenuCommand = (command: VellumCommand): void => {
   if (command.kind === "commandPalette") {
     openCommandPaletteWindow();
+    return;
+  }
+  if (isCommandPaletteWindowFocused()) {
+    dispatchToMain(command);
     return;
   }
   dispatchToFocused(command);
@@ -74,7 +82,7 @@ const buildTemplate = (): MenuItemConstructorOptions[] => {
           label: "Settings\u2026",
           ...acceleratorOption("openSettings"),
           enabled: !readOnboardingActive(),
-          click: () => dispatchToFocused({ kind: "openSettings" }),
+          click: () => dispatchMenuCommand({ kind: "openSettings" }),
         },
         { type: "separator" },
         { role: "services" },
@@ -82,7 +90,7 @@ const buildTemplate = (): MenuItemConstructorOptions[] => {
         {
           label: "Log Out",
           enabled: state.hasPlatformSession,
-          click: () => dispatchToFocused({ kind: "logout" }),
+          click: () => dispatchMenuCommand({ kind: "logout" }),
         },
         { type: "separator" },
         { role: "hide" },
@@ -118,7 +126,7 @@ const buildTemplate = (): MenuItemConstructorOptions[] => {
         {
           label: "Find\u2026",
           ...acceleratorOption("find"),
-          click: () => dispatchToFocused({ kind: "find" }),
+          click: () => dispatchMenuCommand({ kind: "find" }),
         },
       ],
     },
@@ -160,11 +168,11 @@ const buildTemplate = (): MenuItemConstructorOptions[] => {
             submenu: [
               {
                 label: "Replay Onboarding",
-                click: () => dispatchToFocused({ kind: "replayOnboarding" }),
+                click: () => dispatchMenuCommand({ kind: "replayOnboarding" }),
               },
               {
                 label: "Preview PreChat",
-                click: () => dispatchToFocused({ kind: "previewPrechat" }),
+                click: () => dispatchMenuCommand({ kind: "previewPrechat" }),
               },
               ...(!app.isPackaged
                 ? [
@@ -186,7 +194,7 @@ const buildTemplate = (): MenuItemConstructorOptions[] => {
       submenu: [
         {
           label: "Send Feedback\u2026",
-          click: () => dispatchToFocused({ kind: "shareFeedback" }),
+          click: () => dispatchMenuCommand({ kind: "shareFeedback" }),
         },
         { type: "separator" },
         {

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -24,7 +24,14 @@ export type VellumCommand =
   | { kind: "previousConversation" }
   | { kind: "nextConversation" }
   | { kind: "commandPalette" }
-  | { kind: "quickInputSubmit"; message: string };
+  | { kind: "selectAssistant"; assistantId: string }
+  | { kind: "createAssistant" }
+  | { kind: "retireAssistant"; assistantId: string }
+  | { kind: "quickInputSubmit"; message: string }
+  | { kind: "cancelActiveAction" }
+  | { kind: "replayOnboarding" }
+  | { kind: "previewPrechat" }
+  | { kind: "openComponentGallery" };
 
 // Whether a hotkey is a system-wide global shortcut or a focused-app menu
 // accelerator. Mirrors `HotkeyScope` in `apps/macos/src/main/hotkeys.ts`.
@@ -588,6 +595,18 @@ export interface VellumBridge {
     /** Dismiss the quick input panel without submitting. */
     dismiss(): Promise<void>;
   };
+  commandPalette: {
+    /** Open or focus the standalone command palette window. */
+    open(): Promise<void>;
+    /** Dismiss the standalone command palette window without selecting. */
+    dismiss(): Promise<void>;
+    /**
+     * Close the palette and dispatch the selected app command to the main
+     * window. Main only brings the main window forward when it is hidden,
+     * minimized, or destroyed.
+     */
+    select(command: VellumCommand): Promise<void>;
+  };
   dictationOverlay: {
     /**
      * Publish the current dictation lifecycle state so main can drive the
@@ -949,6 +968,17 @@ const bridge: VellumBridge = {
       ipcRenderer.invoke("vellum:quickInput:submit", message) as Promise<void>,
     dismiss: (): Promise<void> =>
       ipcRenderer.invoke("vellum:quickInput:dismiss") as Promise<void>,
+  },
+  commandPalette: {
+    open: (): Promise<void> =>
+      ipcRenderer.invoke("vellum:commandPalette:open") as Promise<void>,
+    dismiss: (): Promise<void> =>
+      ipcRenderer.invoke("vellum:commandPalette:dismiss") as Promise<void>,
+    select: (command: VellumCommand): Promise<void> =>
+      ipcRenderer.invoke(
+        "vellum:commandPalette:select",
+        command,
+      ) as Promise<void>,
   },
   dictationOverlay: {
     setState: (state: DictationOverlayMessage): void => {

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -24,6 +24,14 @@ export type VellumCommand =
   | { kind: "previousConversation" }
   | { kind: "nextConversation" }
   | { kind: "commandPalette" }
+  | { kind: "openConversation"; conversationId: string }
+  | { kind: "openLibrary" }
+  | { kind: "openIdentity" }
+  | { kind: "navigateBack" }
+  | { kind: "navigateForward" }
+  | { kind: "zoomIn" }
+  | { kind: "zoomOut" }
+  | { kind: "actualSize" }
   | { kind: "selectAssistant"; assistantId: string }
   | { kind: "createAssistant" }
   | { kind: "retireAssistant"; assistantId: string }

--- a/apps/web/src/components/command-palette/command-palette-window-page.tsx
+++ b/apps/web/src/components/command-palette/command-palette-window-page.tsx
@@ -1,241 +1,148 @@
-import {
-  Home,
-  MessageSquare,
-  PanelLeft,
-  Send,
-  Settings,
-  SquarePen,
-  StepBack,
-  StepForward,
-  VolumeX,
-} from "lucide-react";
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-  type KeyboardEvent,
-} from "react";
+import { useCallback, useMemo } from "react";
 
 import {
   CommandPalette,
   type CommandPaletteItemData,
-  type CommandPaletteSection,
 } from "@/components/command-palette/command-palette";
+import { useCommandPaletteSections } from "@/domains/chat/hooks/use-command-palette-sections";
+import { useConversationListQuery } from "@/hooks/conversation-queries";
+import { getSelectedAssistant } from "@/lib/local-mode";
 import {
   dismissCommandPaletteWindow,
   selectCommandPaletteCommand,
 } from "@/runtime/command-palette-window";
 import type { VellumCommand } from "@/runtime/is-electron";
+import { useOrganizationStore } from "@/stores/organization-store";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 
-interface WindowPaletteAction extends CommandPaletteItemData {
-  command: VellumCommand;
-  keywords: string[];
-}
+const noop = (): void => undefined;
+const noopNavigate = (_to: string | number): void => undefined;
 
-const ACTIONS: WindowPaletteAction[] = [
-  {
-    id: "action-new-conversation",
-    icon: SquarePen,
-    title: "New Conversation",
-    shortcutHint: "⌘N",
-    command: { kind: "newConversation" },
-    keywords: ["chat", "thread", "compose"],
-  },
-  {
-    id: "action-current-conversation",
-    icon: MessageSquare,
-    title: "Current Conversation",
-    shortcutHint: "⌘⇧N",
-    command: { kind: "currentConversation" },
-    keywords: ["chat", "focus", "composer"],
-  },
-  {
-    id: "action-home",
-    icon: Home,
-    title: "Home",
-    shortcutHint: "⌘⇧H",
-    command: { kind: "home" },
-    keywords: ["dashboard", "start"],
-  },
-  {
-    id: "action-settings",
-    icon: Settings,
-    title: "Settings",
-    shortcutHint: "⌘,",
-    command: { kind: "openSettings" },
-    keywords: ["preferences", "configuration"],
-  },
-  {
-    id: "action-toggle-sidebar",
-    icon: PanelLeft,
-    title: "Toggle Sidebar",
-    shortcutHint: "⌘\\",
-    command: { kind: "sidebarToggle" },
-    keywords: ["navigation", "rail"],
-  },
-  {
-    id: "action-previous-conversation",
-    icon: StepBack,
-    title: "Previous Conversation",
-    shortcutHint: "⌘↑",
-    command: { kind: "previousConversation" },
-    keywords: ["back", "chat", "thread"],
-  },
-  {
-    id: "action-next-conversation",
-    icon: StepForward,
-    title: "Next Conversation",
-    shortcutHint: "⌘↓",
-    command: { kind: "nextConversation" },
-    keywords: ["forward", "chat", "thread"],
-  },
-  {
-    id: "action-mark-current-unread",
-    icon: VolumeX,
-    title: "Mark Current as Unread",
-    shortcutHint: "⌘⇧U",
-    command: { kind: "markCurrentUnread" },
-    keywords: ["attention", "notification"],
-  },
-  {
-    id: "action-feedback",
-    icon: Send,
-    title: "Share Feedback",
-    command: { kind: "shareFeedback" },
-    keywords: ["support", "report"],
-  },
-];
-
-const normalize = (value: string): string =>
-  value.toLowerCase().replace(/\s+/g, " ").trim();
-
-const fuzzyIncludes = (haystack: string, needle: string): boolean => {
-  let cursor = 0;
-  for (const char of needle) {
-    cursor = haystack.indexOf(char, cursor);
-    if (cursor === -1) return false;
-    cursor += 1;
+const commandForItem = (item: CommandPaletteItemData): VellumCommand | null => {
+  switch (item.id) {
+    case "action-new-conversation":
+      return { kind: "newConversation" };
+    case "action-current-conversation":
+      return { kind: "currentConversation" };
+    case "action-settings":
+      return { kind: "openSettings" };
+    case "action-library":
+      return { kind: "openLibrary" };
+    case "action-intelligence":
+      return { kind: "openIdentity" };
+    case "action-back":
+      return { kind: "navigateBack" };
+    case "action-forward":
+      return { kind: "navigateForward" };
+    case "action-zoom-in":
+      return { kind: "zoomIn" };
+    case "action-zoom-out":
+      return { kind: "zoomOut" };
+    case "action-actual-size":
+      return { kind: "actualSize" };
+    default:
+      if (item.id.startsWith("conv-")) {
+        return {
+          kind: "openConversation",
+          conversationId: item.id.slice("conv-".length),
+        };
+      }
+      if (item.id.startsWith("search-conv-")) {
+        return {
+          kind: "openConversation",
+          conversationId: item.id.slice("search-conv-".length),
+        };
+      }
+      if (
+        item.id.startsWith("search-schedule-") ||
+        item.id.startsWith("search-contact-")
+      ) {
+        return { kind: "openIdentity" };
+      }
+      return null;
   }
-  return true;
 };
-
-const actionMatches = (action: WindowPaletteAction, query: string): boolean => {
-  const normalizedQuery = normalize(query);
-  if (!normalizedQuery) return true;
-
-  const haystack = normalize(
-    [action.title, action.subtitle, ...action.keywords].filter(Boolean).join(" "),
-  );
-  return normalizedQuery
-    .split(" ")
-    .every((token) => haystack.includes(token) || fuzzyIncludes(haystack, token));
-};
-
-const toPaletteItem = (action: WindowPaletteAction): CommandPaletteItemData => ({
-  id: action.id,
-  icon: action.icon,
-  title: action.title,
-  subtitle: action.subtitle,
-  shortcutHint: action.shortcutHint,
-});
 
 export function CommandPaletteWindowPage() {
-  const [query, setQuery] = useState("");
-  const [selectedIndex, setSelectedIndex] = useState(0);
+  const assistants = useResolvedAssistantsStore.use.assistants();
+  const activeAssistantId = useResolvedAssistantsStore.use.activeAssistantId();
+  const selectedPlatformAssistantByOrg =
+    useResolvedAssistantsStore.use.selectedPlatformAssistantByOrg();
+  const currentOrganizationId =
+    useOrganizationStore.use.currentOrganizationId();
+  const selectedAssistant = useMemo(
+    () => {
+      const localSelected = getSelectedAssistant();
+      if (localSelected) {
+        return {
+          id: localSelected.assistantId,
+          name: localSelected.name,
+        };
+      }
 
-  const filteredActions = useMemo(
-    () => ACTIONS.filter((action) => actionMatches(action, query)),
-    [query],
-  );
-
-  useEffect(() => {
-    setSelectedIndex((current) =>
-      Math.min(current, Math.max(filteredActions.length - 1, 0)),
-    );
-  }, [filteredActions.length]);
-
-  const sections = useMemo((): CommandPaletteSection[] => {
-    if (filteredActions.length === 0) {
-      return [];
-    }
-    return [
-      {
-        id: "actions",
-        label: "Actions",
-        items: filteredActions.map(toPaletteItem),
-      },
-    ];
-  }, [filteredActions]);
-
-  const selectAction = useCallback(
-    (index: number) => {
-      const action = filteredActions[index];
-      if (!action) return;
-      void selectCommandPaletteCommand(action.command);
+      const selectedPlatformAssistantId =
+        currentOrganizationId == null
+          ? null
+          : selectedPlatformAssistantByOrg[currentOrganizationId];
+      const selectedId =
+        activeAssistantId ??
+        selectedPlatformAssistantId ??
+        (assistants.length === 1 ? assistants[0]?.id : null);
+      if (!selectedId) return null;
+      return (
+        assistants.find((assistant) => assistant.id === selectedId) ?? null
+      );
     },
-    [filteredActions],
+    [
+      activeAssistantId,
+      assistants,
+      currentOrganizationId,
+      selectedPlatformAssistantByOrg,
+    ],
   );
+  const assistantId = selectedAssistant?.id ?? null;
+  const { conversations } = useConversationListQuery(assistantId, true);
 
   const handleItemSelect = useCallback(
     (item: CommandPaletteItemData) => {
-      const index = filteredActions.findIndex((action) => action.id === item.id);
-      if (index !== -1) {
-        selectAction(index);
+      const command = commandForItem(item);
+      if (command) {
+        void selectCommandPaletteCommand(command);
       }
     },
-    [filteredActions, selectAction],
+    [],
   );
 
-  const handleKeyDown = useCallback(
-    (event: KeyboardEvent) => {
-      if (event.key === "k" && (event.metaKey || event.ctrlKey)) {
-        event.preventDefault();
+  const { commandPalette, mergedSections, handleItemSelect: selectItem } =
+    useCommandPaletteSections({
+      assistantId,
+      assistantName: selectedAssistant?.name,
+      conversations,
+      activeConversationId: undefined,
+      startNewConversation: noop,
+      switchConversation: noop,
+      navigate: noopNavigate,
+      navigateToSettings: noop,
+      isOpen: true,
+      onClose: () => {
         void dismissCommandPaletteWindow();
-        return;
-      }
-
-      switch (event.key) {
-        case "ArrowDown":
-          event.preventDefault();
-          setSelectedIndex((current) =>
-            Math.min(current + 1, Math.max(filteredActions.length - 1, 0)),
-          );
-          break;
-        case "ArrowUp":
-          event.preventDefault();
-          setSelectedIndex((current) => Math.max(current - 1, 0));
-          break;
-        case "Enter":
-          event.preventDefault();
-          selectAction(selectedIndex);
-          break;
-        case "Escape":
-          event.preventDefault();
-          void dismissCommandPaletteWindow();
-          break;
-      }
-    },
-    [filteredActions.length, selectAction, selectedIndex],
-  );
+      },
+      onItemSelect: handleItemSelect,
+    });
 
   return (
     <div className="h-screen w-screen bg-transparent">
       <CommandPalette
         isOpen
         surface="window"
-        onClose={() => {
-          void dismissCommandPaletteWindow();
-        }}
-        query={query}
-        onQueryChange={(value) => {
-          setQuery(value);
-          setSelectedIndex(0);
-        }}
-        selectedIndex={selectedIndex}
-        sections={sections}
-        onItemSelect={handleItemSelect}
-        onKeyDown={handleKeyDown}
+        onClose={commandPalette.close}
+        query={commandPalette.query}
+        onQueryChange={commandPalette.setQuery}
+        selectedIndex={commandPalette.selectedIndex}
+        sections={mergedSections}
+        isSearching={commandPalette.isSearching}
+        onItemSelect={selectItem}
+        onKeyDown={commandPalette.handleKeyDown}
       />
     </div>
   );

--- a/apps/web/src/components/command-palette/command-palette-window-page.tsx
+++ b/apps/web/src/components/command-palette/command-palette-window-page.tsx
@@ -1,0 +1,242 @@
+import {
+  Home,
+  MessageSquare,
+  PanelLeft,
+  Send,
+  Settings,
+  SquarePen,
+  StepBack,
+  StepForward,
+  VolumeX,
+} from "lucide-react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type KeyboardEvent,
+} from "react";
+
+import {
+  CommandPalette,
+  type CommandPaletteItemData,
+  type CommandPaletteSection,
+} from "@/components/command-palette/command-palette";
+import {
+  dismissCommandPaletteWindow,
+  selectCommandPaletteCommand,
+} from "@/runtime/command-palette-window";
+import type { VellumCommand } from "@/runtime/is-electron";
+
+interface WindowPaletteAction extends CommandPaletteItemData {
+  command: VellumCommand;
+  keywords: string[];
+}
+
+const ACTIONS: WindowPaletteAction[] = [
+  {
+    id: "action-new-conversation",
+    icon: SquarePen,
+    title: "New Conversation",
+    shortcutHint: "⌘N",
+    command: { kind: "newConversation" },
+    keywords: ["chat", "thread", "compose"],
+  },
+  {
+    id: "action-current-conversation",
+    icon: MessageSquare,
+    title: "Current Conversation",
+    shortcutHint: "⌘⇧N",
+    command: { kind: "currentConversation" },
+    keywords: ["chat", "focus", "composer"],
+  },
+  {
+    id: "action-home",
+    icon: Home,
+    title: "Home",
+    shortcutHint: "⌘⇧H",
+    command: { kind: "home" },
+    keywords: ["dashboard", "start"],
+  },
+  {
+    id: "action-settings",
+    icon: Settings,
+    title: "Settings",
+    shortcutHint: "⌘,",
+    command: { kind: "openSettings" },
+    keywords: ["preferences", "configuration"],
+  },
+  {
+    id: "action-toggle-sidebar",
+    icon: PanelLeft,
+    title: "Toggle Sidebar",
+    shortcutHint: "⌘\\",
+    command: { kind: "sidebarToggle" },
+    keywords: ["navigation", "rail"],
+  },
+  {
+    id: "action-previous-conversation",
+    icon: StepBack,
+    title: "Previous Conversation",
+    shortcutHint: "⌘↑",
+    command: { kind: "previousConversation" },
+    keywords: ["back", "chat", "thread"],
+  },
+  {
+    id: "action-next-conversation",
+    icon: StepForward,
+    title: "Next Conversation",
+    shortcutHint: "⌘↓",
+    command: { kind: "nextConversation" },
+    keywords: ["forward", "chat", "thread"],
+  },
+  {
+    id: "action-mark-current-unread",
+    icon: VolumeX,
+    title: "Mark Current as Unread",
+    shortcutHint: "⌘⇧U",
+    command: { kind: "markCurrentUnread" },
+    keywords: ["attention", "notification"],
+  },
+  {
+    id: "action-feedback",
+    icon: Send,
+    title: "Share Feedback",
+    command: { kind: "shareFeedback" },
+    keywords: ["support", "report"],
+  },
+];
+
+const normalize = (value: string): string =>
+  value.toLowerCase().replace(/\s+/g, " ").trim();
+
+const fuzzyIncludes = (haystack: string, needle: string): boolean => {
+  let cursor = 0;
+  for (const char of needle) {
+    cursor = haystack.indexOf(char, cursor);
+    if (cursor === -1) return false;
+    cursor += 1;
+  }
+  return true;
+};
+
+const actionMatches = (action: WindowPaletteAction, query: string): boolean => {
+  const normalizedQuery = normalize(query);
+  if (!normalizedQuery) return true;
+
+  const haystack = normalize(
+    [action.title, action.subtitle, ...action.keywords].filter(Boolean).join(" "),
+  );
+  return normalizedQuery
+    .split(" ")
+    .every((token) => haystack.includes(token) || fuzzyIncludes(haystack, token));
+};
+
+const toPaletteItem = (action: WindowPaletteAction): CommandPaletteItemData => ({
+  id: action.id,
+  icon: action.icon,
+  title: action.title,
+  subtitle: action.subtitle,
+  shortcutHint: action.shortcutHint,
+});
+
+export function CommandPaletteWindowPage() {
+  const [query, setQuery] = useState("");
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  const filteredActions = useMemo(
+    () => ACTIONS.filter((action) => actionMatches(action, query)),
+    [query],
+  );
+
+  useEffect(() => {
+    setSelectedIndex((current) =>
+      Math.min(current, Math.max(filteredActions.length - 1, 0)),
+    );
+  }, [filteredActions.length]);
+
+  const sections = useMemo((): CommandPaletteSection[] => {
+    if (filteredActions.length === 0) {
+      return [];
+    }
+    return [
+      {
+        id: "actions",
+        label: "Actions",
+        items: filteredActions.map(toPaletteItem),
+      },
+    ];
+  }, [filteredActions]);
+
+  const selectAction = useCallback(
+    (index: number) => {
+      const action = filteredActions[index];
+      if (!action) return;
+      void selectCommandPaletteCommand(action.command);
+    },
+    [filteredActions],
+  );
+
+  const handleItemSelect = useCallback(
+    (item: CommandPaletteItemData) => {
+      const index = filteredActions.findIndex((action) => action.id === item.id);
+      if (index !== -1) {
+        selectAction(index);
+      }
+    },
+    [filteredActions, selectAction],
+  );
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === "k" && (event.metaKey || event.ctrlKey)) {
+        event.preventDefault();
+        void dismissCommandPaletteWindow();
+        return;
+      }
+
+      switch (event.key) {
+        case "ArrowDown":
+          event.preventDefault();
+          setSelectedIndex((current) =>
+            Math.min(current + 1, Math.max(filteredActions.length - 1, 0)),
+          );
+          break;
+        case "ArrowUp":
+          event.preventDefault();
+          setSelectedIndex((current) => Math.max(current - 1, 0));
+          break;
+        case "Enter":
+          event.preventDefault();
+          selectAction(selectedIndex);
+          break;
+        case "Escape":
+          event.preventDefault();
+          void dismissCommandPaletteWindow();
+          break;
+      }
+    },
+    [filteredActions.length, selectAction, selectedIndex],
+  );
+
+  return (
+    <div className="h-screen w-screen bg-transparent">
+      <CommandPalette
+        isOpen
+        surface="window"
+        onClose={() => {
+          void dismissCommandPaletteWindow();
+        }}
+        query={query}
+        onQueryChange={(value) => {
+          setQuery(value);
+          setSelectedIndex(0);
+        }}
+        selectedIndex={selectedIndex}
+        sections={sections}
+        onItemSelect={handleItemSelect}
+        onKeyDown={handleKeyDown}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/command-palette/command-palette.tsx
+++ b/apps/web/src/components/command-palette/command-palette.tsx
@@ -54,6 +54,8 @@ export interface CommandPaletteProps {
   onItemSelect?: (item: CommandPaletteItemData, index: number) => void;
   /** Key-down handler from useCommandPalette for keyboard navigation. */
   onKeyDown: (e: KeyboardEvent) => void;
+  /** Render without the main-app backdrop/portal inside a floating window. */
+  surface?: "overlay" | "window";
 }
 
 // ---------------------------------------------------------------------------
@@ -79,6 +81,7 @@ export const CommandPalette: FC<CommandPaletteProps> = ({
   isSearching = false,
   onItemSelect,
   onKeyDown,
+  surface = "overlay",
 }) => {
   const isMobile = useIsMobile();
   const overlayRef = useRef<HTMLDivElement>(null);
@@ -258,13 +261,17 @@ export const CommandPalette: FC<CommandPaletteProps> = ({
     );
   }
 
-  return createPortal(
+  const desktopPalette = (
     <div
       ref={overlayRef}
       role="dialog"
       aria-modal="true"
       aria-label="Command palette"
-      className="fixed inset-0 z-50 flex items-start justify-center bg-black/40 pt-[15vh]"
+      className={
+        surface === "window"
+          ? "flex h-full w-full items-start justify-center bg-transparent p-3"
+          : "fixed inset-0 z-50 flex items-start justify-center bg-black/40 pt-[15vh]"
+      }
       onClick={handleBackdropClick}
       onKeyDown={onKeyDown}
     >
@@ -272,7 +279,12 @@ export const CommandPalette: FC<CommandPaletteProps> = ({
         {searchInputRow}
         {resultsList}
       </div>
-    </div>,
-    document.body,
+    </div>
   );
+
+  if (surface === "window") {
+    return desktopPalette;
+  }
+
+  return createPortal(desktopPalette, document.body);
 };

--- a/apps/web/src/components/command-palette/use-command-palette.ts
+++ b/apps/web/src/components/command-palette/use-command-palette.ts
@@ -12,6 +12,10 @@ export interface UseCommandPaletteOptions {
   onSelect?: (index: number) => void;
   /** Assistant ID for server-side global search. If omitted, search is disabled. */
   assistantId?: string | null;
+  /** Controlled open state for standalone hosts such as the floating window. */
+  isOpen?: boolean;
+  /** Called when the palette closes, after local state has reset. */
+  onClose?: () => void;
 }
 
 export interface UseCommandPaletteReturn {
@@ -42,8 +46,11 @@ export function useCommandPalette({
   itemCount: itemCountProp,
   onSelect,
   assistantId,
+  isOpen: controlledIsOpen,
+  onClose,
 }: UseCommandPaletteOptions): UseCommandPaletteReturn {
-  const isOpen = useCommandPaletteStore.use.isOpen();
+  const storeIsOpen = useCommandPaletteStore.use.isOpen();
+  const isOpen = controlledIsOpen ?? storeIsOpen;
   const storeOpen = useCommandPaletteStore.use.open();
   const storeClose = useCommandPaletteStore.use.close();
 
@@ -82,7 +89,8 @@ export function useCommandPalette({
     setIsSearching(false);
     setSearchResults(null);
     cancelSearch();
-  }, [storeClose, cancelSearch]);
+    onClose?.();
+  }, [storeClose, cancelSearch, onClose]);
 
   const toggle = useCallback(() => {
     if (isOpen) {

--- a/apps/web/src/domains/chat/chat-layout.tsx
+++ b/apps/web/src/domains/chat/chat-layout.tsx
@@ -42,6 +42,7 @@ import {
     useConversationGroupsQuery,
     useConversationListQuery,
 } from "@/hooks/conversation-queries";
+import { openCommandPaletteWindow } from "@/runtime/command-palette-window";
 import { openPopoutWindow } from "@/runtime/popout-window";
 import { useVellumCommands } from "@/runtime/vellum-commands";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
@@ -420,7 +421,13 @@ export function ChatLayout() {
       void navigate(routes.home);
     },
     commandPalette: () => {
-      useCommandPaletteStore.getState().toggle();
+      void openCommandPaletteWindow()
+        .then((opened) => {
+          if (!opened) useCommandPaletteStore.getState().toggle();
+        })
+        .catch(() => {
+          useCommandPaletteStore.getState().toggle();
+        });
     },
     previousConversation: () => {
       if (!activeConversationId || conversations.length === 0) return;
@@ -644,5 +651,4 @@ export function ChatLayout() {
     </>
   );
 }
-
 

--- a/apps/web/src/domains/chat/chat-layout.tsx
+++ b/apps/web/src/domains/chat/chat-layout.tsx
@@ -445,6 +445,36 @@ export function ChatLayout() {
       const next = conversations[idx + 1];
       if (next) handleSelectConversation(next.conversationId);
     },
+    openConversation: (command) => {
+      if (command.kind === "openConversation") {
+        handleSelectConversation(command.conversationId);
+      }
+    },
+    openLibrary: () => {
+      void navigate(routes.library.root);
+    },
+    openIdentity: () => {
+      void navigate(routes.identity);
+    },
+    navigateBack: () => {
+      navigate(-1);
+    },
+    navigateForward: () => {
+      navigate(1);
+    },
+    zoomIn: () => {
+      document.body.style.zoom = String(
+        parseFloat(document.body.style.zoom || "1") + 0.1,
+      );
+    },
+    zoomOut: () => {
+      document.body.style.zoom = String(
+        Math.max(0.5, parseFloat(document.body.style.zoom || "1") - 0.1),
+      );
+    },
+    actualSize: () => {
+      document.body.style.zoom = "1";
+    },
     popOut: () => {
       if (!activeConversationId) {
         return;
@@ -651,4 +681,3 @@ export function ChatLayout() {
     </>
   );
 }
-

--- a/apps/web/src/domains/chat/hooks/use-chat-layout-shortcuts.ts
+++ b/apps/web/src/domains/chat/hooks/use-chat-layout-shortcuts.ts
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 
+import { openCommandPaletteWindow } from "@/runtime/command-palette-window";
 import { useCommandPaletteStore } from "@/stores/command-palette-store";
 
 /**
@@ -50,6 +51,15 @@ export function useChatLayoutShortcuts({
 }): void {
   useEffect(() => {
     const toggle = useCommandPaletteStore.getState().toggle;
+    const openCommandPalette = () => {
+      void openCommandPaletteWindow()
+        .then((opened) => {
+          if (!opened) toggle();
+        })
+        .catch(() => {
+          toggle();
+        });
+    };
 
     const onKeyDown = (event: KeyboardEvent) => {
       if (shouldHandleShortcut(event, document.activeElement, "\\")) {
@@ -59,7 +69,7 @@ export function useChatLayoutShortcuts({
       }
       if (shouldHandleShortcut(event, document.activeElement, "k")) {
         event.preventDefault();
-        toggle();
+        openCommandPalette();
         return;
       }
       if (shouldHandleShortcut(event, document.activeElement, ["[", "]"])) {

--- a/apps/web/src/domains/chat/hooks/use-command-palette-sections.ts
+++ b/apps/web/src/domains/chat/hooks/use-command-palette-sections.ts
@@ -197,6 +197,9 @@ interface UseCommandPaletteSectionsParams {
   switchConversation: (key: string) => void;
   navigate: (to: string | number) => void;
   navigateToSettings: () => void;
+  isOpen?: boolean;
+  onClose?: () => void;
+  onItemSelect?: (item: CommandPaletteItemData) => void;
 }
 
 export interface UseCommandPaletteSectionsReturn {
@@ -214,6 +217,9 @@ export function useCommandPaletteSections({
   switchConversation,
   navigate,
   navigateToSettings,
+  isOpen,
+  onClose,
+  onItemSelect,
 }: UseCommandPaletteSectionsParams): UseCommandPaletteSectionsReturn {
   // Static sections: actions + recent conversations.
   const localSections = useMemo((): CommandPaletteSection[] => {
@@ -231,6 +237,10 @@ export function useCommandPaletteSections({
   // Dispatch handler for a selected item.
   const handleSelect = useCallback(
     (item: CommandPaletteItemData) => {
+      if (onItemSelect) {
+        onItemSelect(item);
+        return;
+      }
       dispatchCommandPaletteAction(item, {
         startNewConversation,
         switchConversation,
@@ -245,6 +255,7 @@ export function useCommandPaletteSections({
       navigate,
       activeConversationId,
       navigateToSettings,
+      onItemSelect,
     ],
   );
 
@@ -274,6 +285,8 @@ export function useCommandPaletteSections({
       mergedSectionsRef.current.reduce((acc, s) => acc + s.items.length, 0),
     onSelect: handleIndexSelect,
     assistantId,
+    isOpen,
+    onClose,
   });
 
   useLayoutEffect(() => {

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -116,6 +116,11 @@ export const routeTree = [
     // outside auth middleware and RootLayout for fast load.
     { path: "/assistant/quick-input", ErrorBoundary: RouteErrorBoundary, HydrateFallback: RootHydrateFallback, lazy: { Component: () => import("@/components/quick-input-page").then((m) => m.QuickInputPage) } },
 
+    // Command palette — focused floating Electron BrowserWindow opened by
+    // the app menu's Cmd/Ctrl+K accelerator. Standalone and unauthenticated
+    // so it does not depend on ChatLayout being mounted in the main window.
+    { path: "/assistant/floating/command-palette", ErrorBoundary: RouteErrorBoundary, HydrateFallback: RootHydrateFallback, lazy: { Component: () => import("@/components/command-palette/command-palette-window-page").then((m) => m.CommandPaletteWindowPage) } },
+
     // Dictation overlay — live transcription pill rendered inside the
     // Electron dictation overlay BrowserWindow (a click-through floating
     // panel pinned top-center of the screen while push-to-talk dictation

--- a/apps/web/src/runtime/command-palette-window.test.ts
+++ b/apps/web/src/runtime/command-palette-window.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+let runningInElectron = false;
+mock.module("@/runtime/is-electron", () => ({
+  isElectron: () => runningInElectron,
+}));
+
+const {
+  dismissCommandPaletteWindow,
+  openCommandPaletteWindow,
+  selectCommandPaletteCommand,
+} = await import("./command-palette-window");
+
+afterEach(() => {
+  runningInElectron = false;
+  delete (window as { vellum?: unknown }).vellum;
+});
+
+describe("openCommandPaletteWindow", () => {
+  test("returns false off Electron so callers can use the in-page fallback", async () => {
+    const open = mock(() => Promise.resolve());
+    (window as { vellum?: unknown }).vellum = { commandPalette: { open } };
+
+    expect(await openCommandPaletteWindow()).toBe(false);
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  test("returns false for older Electron shells without the palette bridge", async () => {
+    runningInElectron = true;
+    (window as { vellum?: unknown }).vellum = { platform: "electron" };
+
+    expect(await openCommandPaletteWindow()).toBe(false);
+  });
+
+  test("opens through the bridge on newer Electron shells", async () => {
+    runningInElectron = true;
+    const open = mock(() => Promise.resolve());
+    (window as { vellum?: unknown }).vellum = {
+      platform: "electron",
+      commandPalette: { open },
+    };
+
+    expect(await openCommandPaletteWindow()).toBe(true);
+    expect(open).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("command palette bridge actions", () => {
+  test("dismiss and select no-op when the bridge is absent", async () => {
+    runningInElectron = true;
+    (window as { vellum?: unknown }).vellum = { platform: "electron" };
+
+    await expect(dismissCommandPaletteWindow()).resolves.toBeUndefined();
+    await expect(
+      selectCommandPaletteCommand({ kind: "openSettings" }),
+    ).resolves.toBeUndefined();
+  });
+
+  test("dismisses and selects through the bridge when present", async () => {
+    runningInElectron = true;
+    const dismiss = mock(() => Promise.resolve());
+    const select = mock(() => Promise.resolve());
+    (window as { vellum?: unknown }).vellum = {
+      platform: "electron",
+      commandPalette: { dismiss, select },
+    };
+
+    await dismissCommandPaletteWindow();
+    await selectCommandPaletteCommand({ kind: "home" });
+
+    expect(dismiss).toHaveBeenCalledTimes(1);
+    expect(select).toHaveBeenCalledWith({ kind: "home" });
+  });
+});

--- a/apps/web/src/runtime/command-palette-window.ts
+++ b/apps/web/src/runtime/command-palette-window.ts
@@ -1,0 +1,38 @@
+/**
+ * Runtime wrapper for the standalone Electron command palette window.
+ *
+ * New Electron shells expose `window.vellum.commandPalette`; web/iOS and
+ * older Electron shells do not. `openCommandPaletteWindow` returns whether
+ * the host handled the request so callers can fall back to the in-page
+ * palette without probing `window.vellum` themselves.
+ */
+
+import { isElectron, type VellumCommand } from "@/runtime/is-electron";
+
+export async function openCommandPaletteWindow(): Promise<boolean> {
+  if (!isElectron()) {
+    return false;
+  }
+  const open = window.vellum?.commandPalette?.open;
+  if (!open) {
+    return false;
+  }
+  await open();
+  return true;
+}
+
+export async function dismissCommandPaletteWindow(): Promise<void> {
+  if (!isElectron()) {
+    return;
+  }
+  await window.vellum?.commandPalette?.dismiss();
+}
+
+export async function selectCommandPaletteCommand(
+  command: VellumCommand,
+): Promise<void> {
+  if (!isElectron()) {
+    return;
+  }
+  await window.vellum?.commandPalette?.select(command);
+}

--- a/apps/web/src/runtime/is-electron.ts
+++ b/apps/web/src/runtime/is-electron.ts
@@ -419,6 +419,13 @@ declare global {
         submit(message: string): Promise<void>;
         dismiss(): Promise<void>;
       };
+      // Optional: older Electron shells predate the standalone command palette
+      // window channel. Fall back to the in-page palette when absent.
+      commandPalette?: {
+        open(): Promise<void>;
+        dismiss(): Promise<void>;
+        select(command: VellumCommand): Promise<void>;
+      };
       // Optional: older Electron shells predate the dictation overlay channel.
       dictationOverlay?: {
         setState(state: DictationOverlayMessage): void;

--- a/apps/web/src/runtime/is-electron.ts
+++ b/apps/web/src/runtime/is-electron.ts
@@ -44,6 +44,14 @@ export type VellumCommand =
   | { kind: "previousConversation" }
   | { kind: "nextConversation" }
   | { kind: "commandPalette" }
+  | { kind: "openConversation"; conversationId: string }
+  | { kind: "openLibrary" }
+  | { kind: "openIdentity" }
+  | { kind: "navigateBack" }
+  | { kind: "navigateForward" }
+  | { kind: "zoomIn" }
+  | { kind: "zoomOut" }
+  | { kind: "actualSize" }
   | { kind: "selectAssistant"; assistantId: string }
   | { kind: "createAssistant" }
   | { kind: "retireAssistant"; assistantId: string }


### PR DESCRIPTION
## Summary
- add an Electron command palette floating BrowserWindow using the shared floating-window factory
- route the macOS menu accelerator to the floating window while preserving in-page fallback for web/iOS and older shells
- add a standalone /assistant/floating/command-palette route that reuses the palette UI without the main-app backdrop

Part of LUM-1867.

## Tests
- cd apps/macos && export PATH="/Users/maddieabboud/.bun/bin:/Users/maddieabboud/Downloads/google-cloud-sdk/bin:/Users/maddieabboud/.pyenv/shims:/opt/homebrew/opt/gnu-getopt/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/opt/local/bin:/opt/local/sbin:/Users/maddieabboud/.nvm/versions/node/v22.22.2/bin:/Users/maddieabboud/.nvm/versions/node/v16.19.0/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Applications/VMware Fusion Tech Preview.app/Contents/Public:/Users/maddieabboud/.codex/tmp/arg0/codex-arg0Z4ZyPQ:/Users/maddieabboud/Downloads/google-cloud-sdk/bin:/Users/maddieabboud/.bun/bin:/Users/maddieabboud/.antigravity/antigravity/bin:/opt/homebrew/opt/postgresql@16/bin:/Users/maddieabboud/Library/pnpm:/opt/homebrew/opt/gnu-getopt/bin:/Users/maddieabboud/.cargo/bin:/Users/maddieabboud/Library/Application Support/JetBrains/Toolbox/scripts:/Users/maddieabboud/.local/bin:/Applications/Codex.app/Contents/Resources:/Users/maddieabboud/Library/Application Support/JetBrains/Toolbox/scripts:/Users/maddieabboud/.local/bin"; bun test src/main/command-palette-window.test.ts
- cd apps/web && export PATH="/Users/maddieabboud/.bun/bin:/Users/maddieabboud/Downloads/google-cloud-sdk/bin:/Users/maddieabboud/.pyenv/shims:/opt/homebrew/opt/gnu-getopt/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/opt/local/bin:/opt/local/sbin:/Users/maddieabboud/.nvm/versions/node/v22.22.2/bin:/Users/maddieabboud/.nvm/versions/node/v16.19.0/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Applications/VMware Fusion Tech Preview.app/Contents/Public:/Users/maddieabboud/.codex/tmp/arg0/codex-arg0Z4ZyPQ:/Users/maddieabboud/Downloads/google-cloud-sdk/bin:/Users/maddieabboud/.bun/bin:/Users/maddieabboud/.antigravity/antigravity/bin:/opt/homebrew/opt/postgresql@16/bin:/Users/maddieabboud/Library/pnpm:/opt/homebrew/opt/gnu-getopt/bin:/Users/maddieabboud/.cargo/bin:/Users/maddieabboud/Library/Application Support/JetBrains/Toolbox/scripts:/Users/maddieabboud/.local/bin:/Applications/Codex.app/Contents/Resources:/Users/maddieabboud/Library/Application Support/JetBrains/Toolbox/scripts:/Users/maddieabboud/.local/bin"; bun test src/runtime/command-palette-window.test.ts
- cd apps/macos && export PATH="/Users/maddieabboud/.bun/bin:/Users/maddieabboud/Downloads/google-cloud-sdk/bin:/Users/maddieabboud/.pyenv/shims:/opt/homebrew/opt/gnu-getopt/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/opt/local/bin:/opt/local/sbin:/Users/maddieabboud/.nvm/versions/node/v22.22.2/bin:/Users/maddieabboud/.nvm/versions/node/v16.19.0/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Applications/VMware Fusion Tech Preview.app/Contents/Public:/Users/maddieabboud/.codex/tmp/arg0/codex-arg0Z4ZyPQ:/Users/maddieabboud/Downloads/google-cloud-sdk/bin:/Users/maddieabboud/.bun/bin:/Users/maddieabboud/.antigravity/antigravity/bin:/opt/homebrew/opt/postgresql@16/bin:/Users/maddieabboud/Library/pnpm:/opt/homebrew/opt/gnu-getopt/bin:/Users/maddieabboud/.cargo/bin:/Users/maddieabboud/Library/Application Support/JetBrains/Toolbox/scripts:/Users/maddieabboud/.local/bin:/Applications/Codex.app/Contents/Resources:/Users/maddieabboud/Library/Application Support/JetBrains/Toolbox/scripts:/Users/maddieabboud/.local/bin"; bunx tsc --noEmit
- cd apps/web && export PATH="/Users/maddieabboud/.bun/bin:/Users/maddieabboud/Downloads/google-cloud-sdk/bin:/Users/maddieabboud/.pyenv/shims:/opt/homebrew/opt/gnu-getopt/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/opt/local/bin:/opt/local/sbin:/Users/maddieabboud/.nvm/versions/node/v22.22.2/bin:/Users/maddieabboud/.nvm/versions/node/v16.19.0/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Applications/VMware Fusion Tech Preview.app/Contents/Public:/Users/maddieabboud/.codex/tmp/arg0/codex-arg0Z4ZyPQ:/Users/maddieabboud/Downloads/google-cloud-sdk/bin:/Users/maddieabboud/.bun/bin:/Users/maddieabboud/.antigravity/antigravity/bin:/opt/homebrew/opt/postgresql@16/bin:/Users/maddieabboud/Library/pnpm:/opt/homebrew/opt/gnu-getopt/bin:/Users/maddieabboud/.cargo/bin:/Users/maddieabboud/Library/Application Support/JetBrains/Toolbox/scripts:/Users/maddieabboud/.local/bin:/Applications/Codex.app/Contents/Resources:/Users/maddieabboud/Library/Application Support/JetBrains/Toolbox/scripts:/Users/maddieabboud/.local/bin"; bunx tsc --noEmit
- cd apps/web && export PATH="/Users/maddieabboud/.bun/bin:/Users/maddieabboud/Downloads/google-cloud-sdk/bin:/Users/maddieabboud/.pyenv/shims:/opt/homebrew/opt/gnu-getopt/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/opt/local/bin:/opt/local/sbin:/Users/maddieabboud/.nvm/versions/node/v22.22.2/bin:/Users/maddieabboud/.nvm/versions/node/v16.19.0/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Applications/VMware Fusion Tech Preview.app/Contents/Public:/Users/maddieabboud/.codex/tmp/arg0/codex-arg0Z4ZyPQ:/Users/maddieabboud/Downloads/google-cloud-sdk/bin:/Users/maddieabboud/.bun/bin:/Users/maddieabboud/.antigravity/antigravity/bin:/opt/homebrew/opt/postgresql@16/bin:/Users/maddieabboud/Library/pnpm:/opt/homebrew/opt/gnu-getopt/bin:/Users/maddieabboud/.cargo/bin:/Users/maddieabboud/Library/Application Support/JetBrains/Toolbox/scripts:/Users/maddieabboud/.local/bin:/Applications/Codex.app/Contents/Resources:/Users/maddieabboud/Library/Application Support/JetBrains/Toolbox/scripts:/Users/maddieabboud/.local/bin"; bun run lint -- src/components/command-palette/command-palette.tsx src/components/command-palette/command-palette-window-page.tsx src/domains/chat/chat-layout.tsx src/domains/chat/hooks/use-chat-layout-shortcuts.ts src/routes.tsx src/runtime/is-electron.ts src/runtime/command-palette-window.ts src/runtime/command-palette-window.test.ts