### PR TITLE
refactor(web): rename bash phase label "Working (bash)" → "Working"

### DIFF
--- a/apps/web/src/domains/chat/components/multi-activity-group/multi-activity-group.test.tsx
+++ b/apps/web/src/domains/chat/components/multi-activity-group/multi-activity-group.test.tsx
@@ -102,11 +102,11 @@ describe("MultiActivityGroup — non-web tool group", () => {
     const { getByRole, getByText, getByTestId, queryByTestId, queryByText } = renderCard(toolCalls);
     // The unified card mounts the shared shell wrapper.
     expect(getByTestId("tool-progress-card-shell")).toBeTruthy();
-    // The redundant "Working (bash)" label is suppressed in the collapsed
+    // The redundant "Working" label is suppressed in the collapsed
     // header; the `command` input is promoted to the header's primary slot.
     // The expanded body is hidden by default, so only the header content is
     // present on mount.
-    expect(queryByText("Working (bash)")).toBeNull();
+    expect(queryByText("Working")).toBeNull();
     expect(getByText("git status")).toBeTruthy();
     expect(getByRole("button", { name: /expand steps/i })).toBeTruthy();
     expect(queryByTestId("tool-step-pill")).toBeNull();
@@ -126,11 +126,10 @@ describe("MultiActivityGroup — non-web tool group", () => {
     ];
     const { getByText, queryByText, queryByTestId } = renderCard(toolCalls);
     // While the run is in flight the header is a single status summary — it
-    // does NOT carousel the live step (no "git status", no "Working (bash)").
-    // The latest step's loading indicator lives in the expanded timeline.
+    // does NOT carousel the live step (no "git status"). The latest step's
+    // loading indicator lives in the expanded timeline.
     expect(getByText("Working")).toBeTruthy();
     expect(queryByText("git status")).toBeNull();
-    expect(queryByText("Working (bash)")).toBeNull();
     // Collapsed by default: no step rows on mount.
     expect(queryByTestId("tool-step-pill")).toBeNull();
   });
@@ -868,7 +867,7 @@ describe("MultiActivityGroup — header reflects the latest step", () => {
     const { getByText, queryByText } = renderCard(toolCalls, { items });
     // Bash label suppressed in the collapsed header; command promoted to the
     // primary slot.
-    expect(queryByText("Working (bash)")).toBeNull();
+    expect(queryByText("Working")).toBeNull();
     expect(getByText("echo hi")).toBeTruthy();
     // The leading thinking text is NOT promoted into the header (it's a body
     // step only).

--- a/apps/web/src/domains/chat/components/multi-activity-group/multi-activity-group.tsx
+++ b/apps/web/src/domains/chat/components/multi-activity-group/multi-activity-group.tsx
@@ -346,7 +346,7 @@ function deriveWebShellState(
 /**
  * Render the unified shell for a non-web tool-call group. Wraps
  * `ToolProgressCardShell` with a `PhaseGroupedStepList` body that groups
- * contiguous same-phase steps (`Working (bash)`, `Using a skill`, etc.)
+ * contiguous same-phase steps (`Working`, `Using a skill`, etc.)
  * under a single phase header. Mixed groups carry `web_search` /
  * `web_search_error` / `thinking` (the latter from web tools, e.g.
  * `web_fetch` "Reading …") alongside the `tool` variant emitted by

--- a/apps/web/src/domains/chat/components/single-activity/single-activity.stories.tsx
+++ b/apps/web/src/domains/chat/components/single-activity/single-activity.stories.tsx
@@ -147,7 +147,7 @@ export const ToolActive: Story = {
       useViewerStore.getState().openToolDetail({
         toolCallId: "tc-active",
         toolName: "bash",
-        title: "Working (bash)",
+        title: "Working",
         activity: "Checking the current time",
         input: {},
         status: "completed",

--- a/apps/web/src/domains/chat/components/tool-detail-panel.stories.tsx
+++ b/apps/web/src/domains/chat/components/tool-detail-panel.stories.tsx
@@ -49,7 +49,7 @@ const subagentDetail: ToolDetailPayload = {
 const bashDetail: ToolDetailPayload = {
   toolCallId: "tc-bash-1",
   toolName: "bash",
-  title: "Working (bash)",
+  title: "Working",
   activity: "",
   input: { command: "ls -la" },
   result:

--- a/apps/web/src/domains/chat/components/tool-progress-card/derive-step-label.test.ts
+++ b/apps/web/src/domains/chat/components/tool-progress-card/derive-step-label.test.ts
@@ -21,7 +21,7 @@ function buildToolCall(
 }
 
 describe("deriveStepLabel", () => {
-  test("bash → Working (bash) with truncated command and code icon", () => {
+  test("bash → Working with truncated command and code icon", () => {
     const result = deriveStepLabel(
       buildToolCall({
         name: "bash",
@@ -29,7 +29,7 @@ describe("deriveStepLabel", () => {
       }),
     );
     expect(result).toEqual({
-      title: "Working (bash)",
+      title: "Working",
       info: "echo hello world",
       activity: "",
       iconName: "code",
@@ -45,7 +45,7 @@ describe("deriveStepLabel", () => {
       }),
     );
     expect(result.iconName).toBe("code");
-    expect(result.title).toBe("Working (bash)");
+    expect(result.title).toBe("Working");
     expect(result.info.length).toBe(80);
     expect(result.info.endsWith("…")).toBe(true);
   });
@@ -263,7 +263,7 @@ describe("deriveStepLabel", () => {
       }),
     );
     // Inner tool drives title/info/iconName; outer activity overrides inner.
-    expect(result.title).toBe("Working (bash)");
+    expect(result.title).toBe("Working");
     expect(result.info).toBe("echo hi");
     expect(result.iconName).toBe("code");
     expect(result.activity).toBe("outer activity wins");

--- a/apps/web/src/domains/chat/components/tool-progress-card/derive-step-label.ts
+++ b/apps/web/src/domains/chat/components/tool-progress-card/derive-step-label.ts
@@ -129,7 +129,7 @@ export function deriveStepLabelFromName(
       const command = readString(inputBag, "command", "cmd");
       const cleaned = command.replace(/\s+/g, " ").trim();
       return {
-        title: "Working (bash)",
+        title: "Working",
         info: truncate(cleaned, INFO_MAX_LENGTH),
         activity,
         iconName: "code",
@@ -164,7 +164,7 @@ export function deriveStepLabelFromName(
       // `skill_execute` is the daemon's shim for invoking bundled-skill
       // tools — the real tool name lives in `input.tool` and its arguments
       // in `input.input`. Recurse on the inner tool so the card surfaces a
-      // useful label ("Working (bash)", "Spawning subagent", …) instead of
+      // useful label ("Working", "Spawning subagent", …) instead of
       // a generic "Using a skill" with no detail. Falls back to the legacy
       // skill label when the input shape isn't a recognisable wrapper.
       const innerTool = readString(inputBag, "tool");

--- a/apps/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.stories.tsx
+++ b/apps/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.stories.tsx
@@ -15,7 +15,7 @@ function toolStep(overrides: Partial<
   return {
     kind: "tool",
     durationLabel: "2s",
-    title: "Working (bash)",
+    title: "Working",
     info: "date",
     activity: "Checking the current time",
     iconName: "code",
@@ -48,7 +48,7 @@ export default meta;
 type Story = StoryObj<typeof PhaseGroupedStepList>;
 
 /**
- * A mixed run: Thinking → Working (bash) → Thinking. Each contiguous same-phase
+ * A mixed run: Thinking → Working → Thinking. Each contiguous same-phase
  * run collapses into its own phase section with header + indented pills.
  */
 export const MixedRun: Story = {
@@ -64,7 +64,7 @@ export const MixedRun: Story = {
   },
 };
 
-/** A tool-only run with two bash steps grouped under one "Working (bash)" header. */
+/** A tool-only run with two bash steps grouped under one "Working" header. */
 export const ToolOnly: Story = {
   args: {
     steps: [

--- a/apps/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.test.tsx
+++ b/apps/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.test.tsx
@@ -34,7 +34,7 @@ function bash(
 ): ToolCallCardStep {
   return {
     kind: "tool",
-    title: "Working (bash)",
+    title: "Working",
     info: command,
     activity: "",
     iconName: "code",
@@ -70,7 +70,7 @@ describe("PhaseGroupedStepList — phase grouping", () => {
     expect(pills.length).toBe(2);
   });
 
-  test("Thinking → Working (bash) → Thinking produces 3 distinct phase sections", () => {
+  test("Thinking → Working → Thinking produces 3 distinct phase sections", () => {
     const steps: ToolCallCardStep[] = [
       thinking("First reasoning"),
       bash("ls -la", "completed", "1s", "tc-bash-1"),
@@ -80,9 +80,7 @@ describe("PhaseGroupedStepList — phase grouping", () => {
     const sections = getAllByTestId("phase-section");
     expect(sections.length).toBe(3);
     expect(sections[0]!.getAttribute("data-phase-label")).toBe("Thinking");
-    expect(sections[1]!.getAttribute("data-phase-label")).toBe(
-      "Working (bash)",
-    );
+    expect(sections[1]!.getAttribute("data-phase-label")).toBe("Working");
     expect(sections[2]!.getAttribute("data-phase-label")).toBe("Thinking");
   });
 });

--- a/apps/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.tsx
+++ b/apps/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.tsx
@@ -58,8 +58,7 @@ export const ICON_MAP: Record<IconName, LucideIcon> = {
  * share the same label collapse into a single `PhaseSection`.
  *
  * `tool` branch:
- *   - "Working (bash)" → kept verbatim so bash sections read distinctly
- *   - Other "Working (...)" titles → kept verbatim
+ *   - "Working" (bash) and other "Working (...)" titles → kept verbatim
  *   - "Reading" / "Editing" / "Running ..." → grouped under "Working"
  *   - "Using a skill" → kept verbatim
  *   - "Using ..." (MCP / server) → kept verbatim (server name is the label)

--- a/apps/web/src/domains/chat/hooks/use-subagent-card-data.test.ts
+++ b/apps/web/src/domains/chat/hooks/use-subagent-card-data.test.ts
@@ -156,7 +156,7 @@ describe("computeSubagentCardData — step mapping", () => {
     // Regression guard: before Fix 1, every tool step in the subagent
     // inline card rendered the bolt icon and a generic "Using <Tool>"
     // title. After Fix 1, `mapToolEventToStep` routes through the shared
-    // `deriveStepLabelFromName` so bash → "Working (bash)" / code icon.
+    // `deriveStepLabelFromName` so bash → "Working" / code icon.
     const data = computeSubagentCardData(
       makeEntry({
         events: [
@@ -172,7 +172,7 @@ describe("computeSubagentCardData — step mapping", () => {
     const step = data.steps[0]!;
     expect(step.kind).toBe("tool");
     if (step.kind === "tool") {
-      expect(step.title).toBe("Working (bash)");
+      expect(step.title).toBe("Working");
       expect(step.iconName).toBe("code");
       expect(step.info).toBe("ls -la");
     }
@@ -496,7 +496,7 @@ describe("mapToolEventToStep", () => {
       timestamp: 0,
     });
     // host_bash routes through `deriveStepLabelFromName`'s bash branch.
-    expect(step.title).toBe("Working (bash)");
+    expect(step.title).toBe("Working");
     expect(step.iconName).toBe("code");
     expect(step.info).toBe("summary");
     expect(step.status).toBe("running");

--- a/apps/web/src/domains/chat/hooks/use-tool-call-card-data.test.ts
+++ b/apps/web/src/domains/chat/hooks/use-tool-call-card-data.test.ts
@@ -78,7 +78,7 @@ describe("computeToolCallCardData — step kinds", () => {
       kind: "tool",
       durationLabel: "2s",
       startedAt: 1000,
-      title: "Working (bash)",
+      title: "Working",
       info: "echo hello",
       activity: "",
       riskLevel: undefined,
@@ -87,9 +87,9 @@ describe("computeToolCallCardData — step kinds", () => {
       status: "completed",
     });
     expect(data.state).toBe("complete");
-    // The collapsed header suppresses the redundant "Working (bash)" label,
+    // The collapsed header suppresses the redundant "Working" label,
     // promoting the command into the (otherwise subtext) info slot. The
-    // underlying step keeps its "Working (bash)" title for phase grouping.
+    // underlying step keeps its "Working" title for phase grouping.
     expect(data.currentStepTitle).toBe("");
     expect(data.currentStepInfo).toBe("echo hello");
   });

--- a/apps/web/src/domains/chat/utils/tool-call-card-utils.ts
+++ b/apps/web/src/domains/chat/utils/tool-call-card-utils.ts
@@ -502,14 +502,14 @@ function buildToolStep(tc: ChatMessageToolCall): ToolCallCardStep {
  * web-search hook's selector logic for the web-tool branch and adding a
  * non-web `deriveStepLabel().title` branch alongside it.
  *
- * The bash label ("Working (bash)") is redundant chrome in the collapsed
+ * The bash label ("Working") is redundant chrome in the collapsed
  * header — the command/activity subtext already conveys what's running — so
  * we suppress it here, letting `HeaderStepCarousel` promote the info to the
  * primary slot. We intentionally key off the derived title rather than
  * `tc.name` so the `skill_execute → bash` wrapper (which also derives to
- * "Working (bash)") is covered too. `deriveStepLabel` and `phaseFromStep`
+ * "Working") is covered too. `deriveStepLabel` and `phaseFromStep`
  * stay untouched, so the EXPANDED list still groups bash steps under a
- * distinct "Working (bash)" section.
+ * distinct "Working" section.
  */
 function deriveCurrentStepTitle(
   toolCalls: ChatMessageToolCall[],
@@ -534,7 +534,7 @@ function deriveCurrentStepTitle(
       }
     } else {
       const title = deriveStepLabel(tc).title;
-      return title === "Working (bash)" ? "" : title;
+      return title === "Working" ? "" : title;
     }
   }
   return "";


### PR DESCRIPTION
## Summary
- Rename the bash/host_bash tool label from "Working (bash)" to "Working" in derive-step-label, updating the collapsed-header suppression match and all tests/stories/mocks.

Part of plan: web-search-activity-card.md (PR 1 of 4)