### PR TITLE
feat(web): collapsed activity card carousels the live step while streaming

### DIFF
--- a/apps/web/src/domains/chat/components/multi-activity-group/multi-activity-group.test.tsx
+++ b/apps/web/src/domains/chat/components/multi-activity-group/multi-activity-group.test.tsx
@@ -102,11 +102,10 @@ describe("MultiActivityGroup — non-web tool group", () => {
     const { getByRole, getByText, getByTestId, queryByTestId, queryByText } = renderCard(toolCalls);
     // The unified card mounts the shared shell wrapper.
     expect(getByTestId("tool-progress-card-shell")).toBeTruthy();
-    // The redundant "Working" label is suppressed in the collapsed
-    // header; the `command` input is promoted to the header's primary slot.
-    // The expanded body is hidden by default, so only the header content is
-    // present on mount.
-    expect(queryByText("Working")).toBeNull();
+    // The collapsed header carousels the live step: the tool's "Working"
+    // title paired with the `command` input. The expanded body is hidden by
+    // default, so only the header content is present on mount.
+    expect(getByText("Working")).toBeTruthy();
     expect(getByText("git status")).toBeTruthy();
     expect(getByRole("button", { name: /expand steps/i })).toBeTruthy();
     expect(queryByTestId("tool-step-pill")).toBeNull();
@@ -115,7 +114,7 @@ describe("MultiActivityGroup — non-web tool group", () => {
     expect(queryByText("1 step")).toBeNull();
   });
 
-  test("shows a stable 'Working' summary header while streaming, not the step command", () => {
+  test("carousels the live step in the collapsed header while streaming", () => {
     const toolCalls = [
       makeToolCall({
         id: "tc-1",
@@ -124,12 +123,12 @@ describe("MultiActivityGroup — non-web tool group", () => {
         input: { command: "git status" },
       }),
     ];
-    const { getByText, queryByText, queryByTestId } = renderCard(toolCalls);
-    // While the run is in flight the header is a single status summary — it
-    // does NOT carousel the live step (no "git status"). The latest step's
-    // loading indicator lives in the expanded timeline.
+    const { getByText, queryByTestId } = renderCard(toolCalls);
+    // While the run is in flight the collapsed header carousels the live
+    // step: the "Working" title paired with the running command. The
+    // three-dot indicator (verified elsewhere) pairs with this live text.
     expect(getByText("Working")).toBeTruthy();
-    expect(queryByText("git status")).toBeNull();
+    expect(getByText("git status")).toBeTruthy();
     // Collapsed by default: no step rows on mount.
     expect(queryByTestId("tool-step-pill")).toBeNull();
   });
@@ -865,9 +864,9 @@ describe("MultiActivityGroup — header reflects the latest step", () => {
       { kind: "toolCall", toolCall: toolCalls[0]! },
     ];
     const { getByText, queryByText } = renderCard(toolCalls, { items });
-    // Bash label suppressed in the collapsed header; command promoted to the
-    // primary slot.
-    expect(queryByText("Working")).toBeNull();
+    // The collapsed header carousels the live step: the "Working" title
+    // paired with the command.
+    expect(getByText("Working")).toBeTruthy();
     expect(getByText("echo hi")).toBeTruthy();
     // The leading thinking text is NOT promoted into the header (it's a body
     // step only).

--- a/apps/web/src/domains/chat/components/multi-activity-group/multi-activity-group.tsx
+++ b/apps/web/src/domains/chat/components/multi-activity-group/multi-activity-group.tsx
@@ -390,19 +390,17 @@ function UnifiedMultiActivityGroup({
   const toolCallById = new Map(toolCalls.map((tc) => [tc.id, tc]));
 
   // The header shows the stable overall-status summary ("Working for 8s" /
-  // "Worked for 8s" / "Failed") rather than the live per-step carousel in two
-  // cases:
-  //   - While the run is in flight: the only changing part is the ticking
-  //     duration — no step carousel, no truncated step text. The expanded
-  //     timeline's latest step carries the live loading indicator instead, so
-  //     the header needn't echo it (and a stable animation key below keeps the
-  //     number updating in place rather than re-sliding every second).
-  //   - When expanded: the full timeline is visible below, so echoing the
-  //     latest step in the header would be pure repetition.
-  // Otherwise (collapsed + terminal) the header carousels the latest step so a
-  // compact history card still summarises what ran.
+  // "Worked for 8s" / "Failed") rather than the live per-step carousel ONLY
+  // when expanded: the full timeline is visible below, so echoing the latest
+  // step in the header would be pure repetition.
+  //
+  // A collapsed card — whether still running or terminal — carousels the
+  // latest step (`currentStepTitle | currentStepInfo`) so a compact card
+  // summarises what's running / what ran. A collapsed running card keeps its
+  // three-dot indicator (see `hideStatusIndicator` below) and now pairs it
+  // with the live title + info.
   const isLoading = shellState === "loading";
-  const showSummaryHeader = isLoading || expanded;
+  const showSummaryHeader = expanded;
   const headerTitle = showSummaryHeader
     ? expandedHeaderLabel(
         shellState,

--- a/apps/web/src/domains/chat/hooks/use-tool-call-card-data.test.ts
+++ b/apps/web/src/domains/chat/hooks/use-tool-call-card-data.test.ts
@@ -87,10 +87,10 @@ describe("computeToolCallCardData — step kinds", () => {
       status: "completed",
     });
     expect(data.state).toBe("complete");
-    // The collapsed header suppresses the redundant "Working" label,
-    // promoting the command into the (otherwise subtext) info slot. The
-    // underlying step keeps its "Working" title for phase grouping.
-    expect(data.currentStepTitle).toBe("");
+    // The collapsed header shows the tool's "Working" title verbatim,
+    // paired with the command in the info slot, so a collapsed card
+    // carousels the live step ("Working | echo hello").
+    expect(data.currentStepTitle).toBe("Working");
     expect(data.currentStepInfo).toBe("echo hello");
   });
 
@@ -351,8 +351,8 @@ describe("computeToolCallCardData — subagent_spawn filtering", () => {
     expect(data.steps).toHaveLength(1);
     expect(data.steps[0]!.kind).toBe("tool");
     // Header derivation also ignores the filtered spawn so the carousel
-    // reflects only the bash call — whose title is suppressed in the header.
-    expect(data.currentStepTitle).toBe("");
+    // reflects only the bash call — whose "Working" title now shows verbatim.
+    expect(data.currentStepTitle).toBe("Working");
   });
 });
 
@@ -619,8 +619,9 @@ describe("computeToolCallCardDataFromItems — header reflects the latest step",
     ];
     const data = computeToolCallCardDataFromItems(items, {});
     expect(data.currentStepKind).toBe("tool");
-    // Bash title suppressed in the collapsed header; command promoted to info.
-    expect(data.currentStepTitle).toBe("");
+    // The collapsed header carousels the live step: the "Working" title
+    // paired with the command in the info slot.
+    expect(data.currentStepTitle).toBe("Working");
     expect(data.currentStepInfo).toBe("echo hi");
   });
 });
@@ -728,8 +729,8 @@ describe("computeToolCallCardData — mixed web + non-web groups", () => {
     expect(data.steps[0]!.kind).toBe("web_search");
     expect(data.steps[1]!.kind).toBe("tool");
     // currentStepTitle reflects the latest call (the bash tool), whose
-    // redundant label is suppressed in the collapsed header.
-    expect(data.currentStepTitle).toBe("");
+    // "Working" title now shows verbatim in the collapsed header.
+    expect(data.currentStepTitle).toBe("Working");
     expect(data.currentStepInfo).toBe("ls");
   });
 });

--- a/apps/web/src/domains/chat/utils/tool-call-card-utils.ts
+++ b/apps/web/src/domains/chat/utils/tool-call-card-utils.ts
@@ -502,12 +502,10 @@ function buildToolStep(tc: ChatMessageToolCall): ToolCallCardStep {
  * web-search hook's selector logic for the web-tool branch and adding a
  * non-web `deriveStepLabel().title` branch alongside it.
  *
- * The bash label ("Working") is redundant chrome in the collapsed
- * header — the command/activity subtext already conveys what's running — so
- * we suppress it here, letting `HeaderStepCarousel` promote the info to the
- * primary slot. We intentionally key off the derived title rather than
- * `tc.name` so the `skill_execute → bash` wrapper (which also derives to
- * "Working") is covered too. `deriveStepLabel` and `phaseFromStep`
+ * The collapsed header shows the tool's title verbatim (e.g. "Working" for
+ * bash) paired with its command/activity info, so a collapsed/streaming card
+ * carousels the live step ("Working | git status") rather than only the
+ * stable "Working for Ns" summary. `deriveStepLabel` and `phaseFromStep`
  * stay untouched, so the EXPANDED list still groups bash steps under a
  * distinct "Working" section.
  */
@@ -533,8 +531,7 @@ function deriveCurrentStepTitle(
         return "Thinking";
       }
     } else {
-      const title = deriveStepLabel(tc).title;
-      return title === "Working" ? "" : title;
+      return deriveStepLabel(tc).title;
     }
   }
   return "";


### PR DESCRIPTION
## Summary
- Remove the collapsed-header title suppression and gate the summary header to the expanded state, so a collapsed/streaming MultiActivityGroup card shows '... Working | <command/activity>' instead of just 'Working for Ns'.

Part of plan: web-search-activity-card.md (PR 2 of 4)