### PR TITLE
feat(web): show final transcription overlay after dictation

### DIFF
--- a/apps/web/src/domains/chat/hooks/use-voice-input.test.tsx
+++ b/apps/web/src/domains/chat/hooks/use-voice-input.test.tsx
@@ -11,6 +11,10 @@ type TextInsertionStatus =
 
 let nextTextInsertionStatus: TextInsertionStatus = "unavailable";
 const insertedTexts: string[] = [];
+let nextDictationResult: { mode: "dictation"; text: string } | null = null;
+const showTranscriptionOverlayMock = mock(
+  async (_state: { transcript: string }) => undefined,
+);
 
 mock.module("@/runtime/text-insertion", () => ({
   insertTextIntoFrontApp: async (text: string) => {
@@ -29,7 +33,11 @@ mock.module("@/domains/chat/components/mic-permission-primer", () => ({
 }));
 
 mock.module("@/domains/chat/voice/dictation-api", () => ({
-  postDictation: async () => null,
+  postDictation: async () => nextDictationResult,
+}));
+
+mock.module("@/runtime/transcription-overlay", () => ({
+  showTranscriptionOverlay: showTranscriptionOverlayMock,
 }));
 
 mock.module("@/domains/chat/voice/push-to-talk-host", () => ({
@@ -42,7 +50,7 @@ mock.module("@/domains/chat/voice/use-push-to-talk", () => ({
 
 const { useVoiceInput } = await import("./use-voice-input");
 
-const renderVoiceInput = () => {
+const renderVoiceInput = (assistantId: string | null = null) => {
   let input = "";
   let focusCount = 0;
   const setInput: Dispatch<SetStateAction<string>> = (value) => {
@@ -58,7 +66,7 @@ const renderVoiceInput = () => {
   } satisfies RefObject<HTMLTextAreaElement | null>;
 
   const hook = renderHook(() =>
-    useVoiceInput({ assistantId: null, inputRef, setInput }),
+    useVoiceInput({ assistantId, inputRef, setInput }),
   );
 
   return {
@@ -71,10 +79,30 @@ const renderVoiceInput = () => {
 afterEach(() => {
   cleanup();
   nextTextInsertionStatus = "unavailable";
+  nextDictationResult = null;
   insertedTexts.length = 0;
+  showTranscriptionOverlayMock.mockClear();
 });
 
 describe("useVoiceInput", () => {
+  test("shows the cleaned final transcript after successful front-app insertion", async () => {
+    nextTextInsertionStatus = "inserted";
+    nextDictationResult = { mode: "dictation", text: "cleaned text" };
+    const { hook, getInput, getFocusCount } = renderVoiceInput("assistant-1");
+
+    await act(async () => {
+      await hook.result.current.handleVoiceTranscript("raw text");
+    });
+
+    expect(insertedTexts).toEqual(["cleaned text"]);
+    expect(showTranscriptionOverlayMock).toHaveBeenCalledWith({
+      transcript: "cleaned text",
+    });
+    expect(getInput()).toBe("");
+    expect(getFocusCount()).toBe(0);
+    expect(hook.result.current.voiceError).toBeNull();
+  });
+
   test("keeps blocked external-paste dictation in the composer", async () => {
     nextTextInsertionStatus = "blocked";
     const { hook, getInput, getFocusCount } = renderVoiceInput();
@@ -84,6 +112,9 @@ describe("useVoiceInput", () => {
     });
 
     expect(insertedTexts).toEqual(["dictated text"]);
+    expect(showTranscriptionOverlayMock).toHaveBeenCalledWith({
+      transcript: "dictated text",
+    });
     expect(getInput()).toBe("dictated text");
     expect(getFocusCount()).toBe(1);
     expect(hook.result.current.voiceError).toBe("dictation-paste-blocked");
@@ -98,8 +129,21 @@ describe("useVoiceInput", () => {
     });
 
     expect(insertedTexts).toEqual(["open settings please"]);
+    expect(showTranscriptionOverlayMock).toHaveBeenCalledWith({
+      transcript: "open settings please",
+    });
     expect(getInput()).toBe("open settings please");
     expect(getFocusCount()).toBe(1);
     expect(hook.result.current.voiceError).toBe("dictation-automation-denied");
+  });
+
+  test("does not show the final overlay for empty transcripts", async () => {
+    const { hook } = renderVoiceInput();
+
+    await act(async () => {
+      await hook.result.current.handleVoiceTranscript("   ");
+    });
+
+    expect(showTranscriptionOverlayMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/domains/chat/hooks/use-voice-input.ts
+++ b/apps/web/src/domains/chat/hooks/use-voice-input.ts
@@ -15,6 +15,7 @@ import {
   insertTextIntoFrontApp,
   openTextInsertionSettings,
 } from "@/runtime/text-insertion";
+import { showTranscriptionOverlay } from "@/runtime/transcription-overlay";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -149,6 +150,9 @@ export function useVoiceInput({
         : null;
       if (dictationResult?.mode === "dictation" && dictationResult.text) {
         insertText = dictationResult.text;
+      }
+      if (insertText.trim()) {
+        void showTranscriptionOverlay({ transcript: insertText });
       }
 
       const frontAppInsertion = await insertTextIntoFrontApp(insertText);

--- a/apps/web/src/domains/chat/voice/global-push-to-talk-bridge.test.tsx
+++ b/apps/web/src/domains/chat/voice/global-push-to-talk-bridge.test.tsx
@@ -1,0 +1,151 @@
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { forwardRef } from "react";
+
+type TextInsertionStatus =
+  | "inserted"
+  | "vellum-focused"
+  | "automation-denied"
+  | "blocked"
+  | "unavailable";
+
+type VoiceInputButtonProps = {
+  assistantId: string | null;
+  onTranscript: (rawText: string) => Promise<void> | void;
+  onError: (code: string | null) => void;
+  onStreamReady: (stream: MediaStream | null) => void;
+  onBeforeStart: () => boolean;
+  renderButton: boolean;
+};
+
+let latestVoiceInputProps: VoiceInputButtonProps | null = null;
+let nextTextInsertionStatus: TextInsertionStatus = "unavailable";
+const insertedTexts: string[] = [];
+let nextDictationResult: { mode: "dictation"; text: string } | null = null;
+const showTranscriptionOverlayMock = mock(
+  async (_state: { transcript: string }) => undefined,
+);
+const toastErrorMock = mock((_message: string) => undefined);
+
+mock.module("@/domains/chat/components/voice-input-button", () => ({
+  VoiceInputButton: forwardRef<unknown, VoiceInputButtonProps>((props, _ref) => {
+    latestVoiceInputProps = props;
+    return null;
+  }),
+}));
+
+mock.module("@/domains/chat/hooks/use-dictation-overlay-sync", () => ({
+  useDictationOverlaySync: () => undefined,
+}));
+
+mock.module(
+  "@/domains/chat/voice/use-native-push-to-talk-registration",
+  () => ({
+    useNativePushToTalkRegistration: () => undefined,
+  }),
+);
+
+mock.module("@/domains/chat/voice/use-audio-amplitude", () => ({
+  useAudioAmplitude: () => ({ amplitude: 0 }),
+}));
+
+mock.module("@/domains/chat/voice/use-push-to-talk", () => ({
+  usePushToTalk: () => undefined,
+}));
+
+mock.module("@/domains/chat/voice/push-to-talk-host", () => ({
+  shouldEnablePushToTalk: () => false,
+}));
+
+mock.module("@/domains/chat/voice/dictation-api", () => ({
+  postDictation: async () => nextDictationResult,
+}));
+
+mock.module("@/runtime/text-insertion", () => ({
+  insertTextIntoFrontApp: async (text: string) => {
+    insertedTexts.push(text);
+    return { status: nextTextInsertionStatus };
+  },
+  openTextInsertionSettings: async () => undefined,
+}));
+
+mock.module("@/runtime/transcription-overlay", () => ({
+  showTranscriptionOverlay: showTranscriptionOverlayMock,
+}));
+
+mock.module("@vellumai/design-library/components/toast", () => ({
+  toast: { error: toastErrorMock },
+}));
+
+const { GlobalPushToTalkBridge } = await import("./global-push-to-talk-bridge");
+const { useComposerStore } = await import("@/domains/chat/composer-store");
+const { useConversationStore } = await import("@/stores/conversation-store");
+const { useViewerStore } = await import("@/stores/viewer-store");
+
+const renderBridge = (assistantId: string | null = "assistant-1") => {
+  render(<GlobalPushToTalkBridge assistantId={assistantId} />);
+  if (!latestVoiceInputProps) {
+    throw new Error("Expected GlobalPushToTalkBridge to mount VoiceInputButton");
+  }
+  return latestVoiceInputProps;
+};
+
+afterEach(() => {
+  cleanup();
+  latestVoiceInputProps = null;
+  nextTextInsertionStatus = "unavailable";
+  nextDictationResult = null;
+  insertedTexts.length = 0;
+  showTranscriptionOverlayMock.mockClear();
+  toastErrorMock.mockClear();
+  useComposerStore.getState().setInput("");
+  useComposerStore.getState().fullReset();
+  useConversationStore.getState().reset();
+  useViewerStore.getState().reset();
+  localStorage.clear();
+});
+
+describe("GlobalPushToTalkBridge", () => {
+  test("shows the cleaned final transcript after successful front-app insertion", async () => {
+    nextTextInsertionStatus = "inserted";
+    nextDictationResult = { mode: "dictation", text: "cleaned global text" };
+    const voiceInput = renderBridge();
+
+    await act(async () => {
+      await voiceInput.onTranscript("raw global text");
+    });
+
+    expect(insertedTexts).toEqual(["cleaned global text"]);
+    expect(showTranscriptionOverlayMock).toHaveBeenCalledWith({
+      transcript: "cleaned global text",
+    });
+    expect(useComposerStore.getState().input).toBe("");
+    expect(toastErrorMock).not.toHaveBeenCalled();
+  });
+
+  test("shows the final transcript when front-app insertion fails and soft-lands in composer", async () => {
+    nextTextInsertionStatus = "blocked";
+    const voiceInput = renderBridge();
+
+    await act(async () => {
+      await voiceInput.onTranscript("fallback text");
+    });
+
+    expect(insertedTexts).toEqual(["fallback text"]);
+    expect(showTranscriptionOverlayMock).toHaveBeenCalledWith({
+      transcript: "fallback text",
+    });
+    expect(useComposerStore.getState().input).toBe("fallback text");
+    expect(toastErrorMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not show the final overlay for empty transcripts", async () => {
+    const voiceInput = renderBridge();
+
+    await act(async () => {
+      await voiceInput.onTranscript("   ");
+    });
+
+    expect(showTranscriptionOverlayMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/domains/chat/voice/global-push-to-talk-bridge.tsx
+++ b/apps/web/src/domains/chat/voice/global-push-to-talk-bridge.tsx
@@ -16,6 +16,7 @@ import { useAudioAmplitude } from "@/domains/chat/voice/use-audio-amplitude";
 import { usePushToTalk } from "@/domains/chat/voice/use-push-to-talk";
 import { useVoiceRecordingStore } from "@/domains/chat/voice/voice-recording-store";
 import { insertTextIntoFrontApp } from "@/runtime/text-insertion";
+import { showTranscriptionOverlay } from "@/runtime/transcription-overlay";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useViewerStore } from "@/stores/viewer-store";
 import { toast } from "@vellumai/design-library/components/toast";
@@ -86,6 +87,9 @@ export function GlobalPushToTalkBridge({
         : null;
       if (dictationResult?.mode === "dictation" && dictationResult.text) {
         insertText = dictationResult.text;
+      }
+      if (insertText.trim()) {
+        void showTranscriptionOverlay({ transcript: insertText });
       }
 
       const frontAppInsertion = await insertTextIntoFrontApp(insertText);


### PR DESCRIPTION
Part of LUM-1867.

## Summary
- Show the final transcription overlay once dictation cleanup produces non-empty final text from the composer-hosted path.
- Show the same overlay from the global push-to-talk fallback path, including insertion-failure soft landings.
- Add coverage for success, insertion failure, and empty-transcript suppression.

## Validation
- `cd apps/web && export PATH="$HOME/.bun/bin:$PATH"; bun test src/domains/chat/hooks/use-voice-input.test.tsx src/domains/chat/voice/global-push-to-talk-bridge.test.tsx`
- `cd apps/web && export PATH="$HOME/.bun/bin:$PATH"; bunx tsc --noEmit`
- `cd apps/web && export PATH="$HOME/.bun/bin:$PATH"; bun run lint -- src/domains/chat/hooks/use-voice-input.ts src/domains/chat/hooks/use-voice-input.test.tsx src/domains/chat/voice/global-push-to-talk-bridge.tsx src/domains/chat/voice/global-push-to-talk-bridge.test.tsx`