### PR TITLE
feat(web): SingleActivity "web" variant — inline expandable web-search link

### DIFF
--- a/apps/web/src/domains/chat/components/single-activity/single-activity.stories.tsx
+++ b/apps/web/src/domains/chat/components/single-activity/single-activity.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
+import type { WebSearchResultItem } from "@/assistant/web-activity-types";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
+import type { ToolCallCardStep } from "@/domains/chat/utils/tool-call-card-utils";
 import { useViewerStore } from "@/stores/viewer-store";
 
 import { SingleActivity } from "./single-activity";
@@ -166,5 +168,107 @@ export const ToolError: Story = {
       input: { command: "exit 1", activity: "Running a failing command" },
       riskLevel: "low",
     }),
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Web variant
+// ---------------------------------------------------------------------------
+
+const WEB_RESULTS: WebSearchResultItem[] = [
+  {
+    rank: 1,
+    title: "Toronto - Wikipedia",
+    url: "https://en.wikipedia.org/wiki/Toronto",
+    domain: "en.wikipedia.org",
+  },
+  {
+    rank: 2,
+    title: "Visit Toronto — Official Tourism",
+    url: "https://www.destinationtoronto.com",
+    domain: "destinationtoronto.com",
+  },
+];
+
+const WEB_STEP: Extract<ToolCallCardStep, { kind: "web_search" }> = {
+  kind: "web_search",
+  title: "Searched the web",
+  durationLabel: "1s",
+  linkCount: 2,
+  results: WEB_RESULTS,
+};
+
+const WEB_ERROR_STEP: Extract<
+  ToolCallCardStep,
+  { kind: "web_search_error" }
+> = {
+  kind: "web_search_error",
+  title: "Web search failed",
+  durationLabel: "1s",
+  errorMessage: "Search provider unavailable",
+};
+
+/**
+ * Collapsed — an inline "Web Search | <rotating chips>" link. The rotating
+ * `WebsiteCarousel` cycles through the searched sites in the info slot; the
+ * trailing down-chevron signals it expands in place.
+ */
+export const WebSearchCollapsed: Story = {
+  args: {
+    variant: "web",
+    info: "en.wikipedia.org",
+    carouselItems: WEB_RESULTS,
+    state: "complete",
+    step: WEB_STEP,
+    expanded: false,
+    onExpandChange: () => {},
+  },
+};
+
+/**
+ * Expanded — the same link with the favicon result row revealed in place
+ * beneath the header (and `+N more` overflow when clamped).
+ */
+export const WebSearchExpanded: Story = {
+  args: {
+    variant: "web",
+    info: "en.wikipedia.org",
+    carouselItems: WEB_RESULTS,
+    state: "complete",
+    step: WEB_STEP,
+    expanded: true,
+    onExpandChange: () => {},
+  },
+};
+
+/**
+ * Loading — the leading glyph becomes the shared three-dot indicator while the
+ * search is in flight.
+ */
+export const WebSearchLoading: Story = {
+  args: {
+    variant: "web",
+    info: "Searching the web",
+    carouselItems: WEB_RESULTS,
+    state: "loading",
+    step: WEB_STEP,
+    expanded: false,
+    onExpandChange: () => {},
+  },
+};
+
+/**
+ * Error — the header takes the negative tone and, when expanded, the step body
+ * renders the error chip with the provider message.
+ */
+export const WebSearchError: Story = {
+  args: {
+    variant: "web",
+    info: "Web search failed",
+    carouselItems: [],
+    state: "error",
+    step: WEB_ERROR_STEP,
+    expanded: true,
+    onExpandChange: () => {},
   },
 };

--- a/apps/web/src/domains/chat/components/single-activity/single-activity.test.tsx
+++ b/apps/web/src/domains/chat/components/single-activity/single-activity.test.tsx
@@ -16,7 +16,9 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 
 import { cleanup, fireEvent, render } from "@testing-library/react";
 
+import type { WebSearchResultItem } from "@/assistant/web-activity-types";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
+import type { ToolCallCardStep } from "@/domains/chat/utils/tool-call-card-utils";
 
 // The viewer store imports the generated daemon SDK, which isn't built in
 // CI/worktree checkouts. Stub the two endpoints it references so the module
@@ -234,6 +236,218 @@ describe("SingleActivity — tool variant", () => {
       />,
     );
     expect(getByTestId("inline-tool-link").className).toContain(
+      "text-[var(--system-negative-strong)]",
+    );
+  });
+});
+
+describe("SingleActivity — web variant", () => {
+  function makeResult(
+    overrides: Partial<WebSearchResultItem> = {},
+  ): WebSearchResultItem {
+    return {
+      rank: 1,
+      title: "Toronto - Wikipedia",
+      url: "https://en.wikipedia.org/wiki/Toronto",
+      domain: "en.wikipedia.org",
+      ...overrides,
+    };
+  }
+
+  const RESULTS: WebSearchResultItem[] = [
+    makeResult(),
+    makeResult({
+      rank: 2,
+      title: "Visit Toronto",
+      url: "https://www.destinationtoronto.com",
+      domain: "destinationtoronto.com",
+    }),
+  ];
+
+  const WEB_STEP: Extract<ToolCallCardStep, { kind: "web_search" }> = {
+    kind: "web_search",
+    title: "Searched the web",
+    durationLabel: "1s",
+    linkCount: 2,
+    results: RESULTS,
+  };
+
+  const ERROR_STEP: Extract<
+    ToolCallCardStep,
+    { kind: "web_search_error" }
+  > = {
+    kind: "web_search_error",
+    title: "Web search failed",
+    durationLabel: "1s",
+    errorMessage: "Search provider unavailable",
+  };
+
+  test("renders the 'Web Search' label in the header", () => {
+    const { getByTestId, getByText } = render(
+      <SingleActivity
+        variant="web"
+        info="en.wikipedia.org"
+        carouselItems={RESULTS}
+        state="complete"
+        step={WEB_STEP}
+        expanded={false}
+        onExpandChange={() => {}}
+      />,
+    );
+    expect(getByTestId("inline-web-link")).toBeTruthy();
+    expect(getByText("Web Search")).toBeTruthy();
+  });
+
+  test("mounts the WebsiteCarousel in the info slot when carouselItems is non-empty", () => {
+    const { container } = render(
+      <SingleActivity
+        variant="web"
+        info="en.wikipedia.org"
+        carouselItems={RESULTS}
+        state="complete"
+        step={WEB_STEP}
+        expanded={false}
+        onExpandChange={() => {}}
+      />,
+    );
+    // The carousel renders favicon chips for the rotating sites; its fixed-height
+    // ticker wrapper is its tell.
+    expect(container.querySelector(".h-\\[28px\\]")).toBeTruthy();
+  });
+
+  test("shows the static info text when carouselItems is empty", () => {
+    const { getByText, container } = render(
+      <SingleActivity
+        variant="web"
+        info="en.wikipedia.org"
+        carouselItems={[]}
+        state="complete"
+        step={WEB_STEP}
+        expanded={false}
+        onExpandChange={() => {}}
+      />,
+    );
+    expect(getByText("en.wikipedia.org")).toBeTruthy();
+    // No carousel ticker wrapper when there are no items.
+    expect(container.querySelector(".h-\\[28px\\]")).toBeNull();
+  });
+
+  test("collapsed hides the favicon result row", () => {
+    const { queryByTestId } = render(
+      <SingleActivity
+        variant="web"
+        info="en.wikipedia.org"
+        carouselItems={[]}
+        state="complete"
+        step={WEB_STEP}
+        expanded={false}
+        onExpandChange={() => {}}
+      />,
+    );
+    // FaviconChip rows carry a title attribute; none should render collapsed.
+    expect(queryByTestId("web-search-overflow-chip")).toBeNull();
+  });
+
+  test("clicking the header calls onExpandChange(true) when collapsed", () => {
+    let next: boolean | undefined;
+    const { getByTestId } = render(
+      <SingleActivity
+        variant="web"
+        info="en.wikipedia.org"
+        carouselItems={[]}
+        state="complete"
+        step={WEB_STEP}
+        expanded={false}
+        onExpandChange={(v) => {
+          next = v;
+        }}
+      />,
+    );
+    fireEvent.click(getByTestId("inline-web-link"));
+    expect(next).toBe(true);
+  });
+
+  test("clicking the header calls onExpandChange(false) when expanded", () => {
+    let next: boolean | undefined;
+    const { getByTestId } = render(
+      <SingleActivity
+        variant="web"
+        info="en.wikipedia.org"
+        carouselItems={[]}
+        state="complete"
+        step={WEB_STEP}
+        expanded
+        onExpandChange={(v) => {
+          next = v;
+        }}
+      />,
+    );
+    fireEvent.click(getByTestId("inline-web-link"));
+    expect(next).toBe(false);
+  });
+
+  test("expanded reveals the favicon result row (WebSearchStepRow)", () => {
+    const { getByText } = render(
+      <SingleActivity
+        variant="web"
+        info="en.wikipedia.org"
+        carouselItems={[]}
+        state="complete"
+        step={WEB_STEP}
+        expanded
+        onExpandChange={() => {}}
+      />,
+    );
+    // FaviconChip renders each result's title as the chip label. carouselItems
+    // is empty here, so these can only come from the expanded step row.
+    expect(getByText("Toronto - Wikipedia")).toBeTruthy();
+    expect(getByText("Visit Toronto")).toBeTruthy();
+  });
+
+  test("loading state renders the three-dot indicator", () => {
+    const { getByTestId } = render(
+      <SingleActivity
+        variant="web"
+        info="en.wikipedia.org"
+        carouselItems={[]}
+        state="loading"
+        step={WEB_STEP}
+        expanded={false}
+        onExpandChange={() => {}}
+      />,
+    );
+    expect(getByTestId("inline-web-loading")).toBeTruthy();
+  });
+
+  test("a web_search_error step renders the error chip when expanded", () => {
+    const { getByTestId, getByText } = render(
+      <SingleActivity
+        variant="web"
+        info="en.wikipedia.org"
+        carouselItems={[]}
+        state="error"
+        step={ERROR_STEP}
+        expanded
+        onExpandChange={() => {}}
+      />,
+    );
+    expect(getByTestId("web-search-error-chip")).toBeTruthy();
+    expect(getByText("Search provider unavailable")).toBeTruthy();
+  });
+
+  test("error state applies the negative tone to the header", () => {
+    const { getByTestId } = render(
+      <SingleActivity
+        variant="web"
+        info="en.wikipedia.org"
+        carouselItems={[]}
+        state="error"
+        step={ERROR_STEP}
+        expanded={false}
+        onExpandChange={() => {}}
+      />,
+    );
+    expect(getByTestId("inline-web-link").className).toContain(
       "text-[var(--system-negative-strong)]",
     );
   });

--- a/apps/web/src/domains/chat/components/single-activity/single-activity.tsx
+++ b/apps/web/src/domains/chat/components/single-activity/single-activity.tsx
@@ -1,6 +1,6 @@
 /**
  * Inline single-activity link — the lone affordance for ONE step of agent work,
- * in one of two variants:
+ * in one of three variants:
  *
  *   - `variant="thinking"` — an assistant reasoning run. A brain glyph +
  *     "Thought process", or the shared {@link ThreeDotIndicator} + "Thinking"
@@ -11,11 +11,18 @@
  *   - `variant="tool"` — a LONE renderable tool call (non-web, no confirmation,
  *     no thinking). The derived tool glyph + activity label + optional risk
  *     badge.
+ *   - `variant="web"` — a LONE web search. An inline link reading
+ *     "Web Search | <rotating {@link WebsiteCarousel}>" (or static `info` when
+ *     no carousel items) that, unlike the other two variants, expands IN PLACE
+ *     (controlled via `expanded`/`onExpandChange`) to reveal the favicon result
+ *     row (and `+N more` overflow), or the error row for a `web_search_error`
+ *     step — it does NOT open the drawer, so its trailing glyph is an up/down
+ *     chevron rather than `ChevronRight`.
  *
- * Both variants render the same minimal, container-less button (leading glyph +
- * label + optional risk badge + trailing chevron) and toggle the shared
- * tool-detail side drawer — clicking an already-open link closes it (toggle).
- * The trailing `ChevronRight` signals "opens a drawer" (vs the card's
+ * The thinking/tool variants render the same minimal, container-less button
+ * (leading glyph + label + optional risk badge + trailing chevron) and toggle
+ * the shared tool-detail side drawer — clicking an already-open link closes it
+ * (toggle). The trailing `ChevronRight` signals "opens a drawer" (vs the card's
  * expand-in-place up/down chevron). Consistent padding lets the active highlight
  * fill behind the content without shifting layout.
  *
@@ -23,17 +30,33 @@
  * contiguous run of interleaved thinking + tool steps as one combined card.
  */
 
-import { Bolt, Brain, ChevronRight } from "lucide-react";
-import type { ReactNode } from "react";
+import {
+  Bolt,
+  Brain,
+  ChevronDown,
+  ChevronRight,
+  ChevronUp,
+  Globe,
+} from "lucide-react";
+import { useMemo, type ReactNode } from "react";
 
 import { cn } from "@/utils/misc";
 import { RiskBadge } from "@/domains/chat/components/risk-badge";
 import { ThreeDotIndicator } from "@/domains/chat/components/tool-progress-card/three-dot-indicator";
 import { ICON_MAP } from "@/domains/chat/components/tool-progress-card/phase-grouped-step-list";
 import { deriveStepLabel } from "@/domains/chat/components/tool-progress-card/derive-step-label";
-import { toolDetailPayloadFromToolCall } from "@/domains/chat/utils/tool-call-card-utils";
+import {
+  toolDetailPayloadFromToolCall,
+  type ToolCallCardStep,
+} from "@/domains/chat/utils/tool-call-card-utils";
+import {
+  WebSearchErrorRow,
+  WebSearchStepRow,
+} from "@/domains/chat/components/web-search/web-search-step-row";
+import { WebsiteCarousel } from "@/domains/chat/components/web-search/website-carousel";
 import { useViewerStore } from "@/stores/viewer-store";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
+import type { WebSearchResultItem } from "@/assistant/web-activity-types";
 
 export type SingleActivityProps =
   | {
@@ -46,6 +69,20 @@ export type SingleActivityProps =
   | {
       variant: "tool";
       toolCall: ChatMessageToolCall;
+    }
+  | {
+      variant: "web";
+      /** Fallback static title (latest searched website) when the carousel isn't shown. */
+      info: string;
+      /** Websites to feed the rotating WebsiteCarousel in the header info slot. */
+      carouselItems: WebSearchResultItem[];
+      /** Card-level state: drives the leading indicator (loading -> dots). */
+      state: "loading" | "complete" | "error";
+      /** The single web step to render when expanded (favicon chips / error). */
+      step: Extract<ToolCallCardStep, { kind: "web_search" | "web_search_error" }>;
+      /** Controlled expand state + change handler (owned by the caller). */
+      expanded: boolean;
+      onExpandChange: (next: boolean) => void;
     };
 
 /** The shared presentational shape both variants resolve into. */
@@ -66,6 +103,78 @@ export function SingleActivity(props: SingleActivityProps) {
   // early return (empty, settled thinking) happens after them below.
   const toggleToolDetail = useViewerStore.use.toggleToolDetail();
   const activeDetail = useViewerStore.use.activeToolDetail();
+
+  // The web variant feeds a rotating carousel into the header info slot. Memoize
+  // the element so it stays referentially stable (a fresh element each render
+  // would remount the carousel and reset its rotation). Computed unconditionally
+  // at the top level — accessing the web-only prop via a type guard — so this
+  // hook is never conditional regardless of variant.
+  const carouselItems =
+    props.variant === "web" ? props.carouselItems : undefined;
+  const carouselNode = useMemo(
+    () =>
+      carouselItems && carouselItems.length > 0 ? (
+        <WebsiteCarousel items={carouselItems} />
+      ) : null,
+    [carouselItems],
+  );
+
+  if (props.variant === "web") {
+    const { info, state, step, expanded, onExpandChange } = props;
+    const isError = state === "error";
+    const ExpandChevron = expanded ? ChevronUp : ChevronDown;
+    return (
+      <div className="flex flex-col">
+        <button
+          type="button"
+          data-testid="inline-web-link"
+          aria-expanded={expanded}
+          aria-label="Web Search"
+          onClick={() => onExpandChange(!expanded)}
+          className={cn(
+            "group inline-flex items-center gap-2 -mx-1.5 px-1.5 py-1 rounded-md text-left text-[13px] font-medium transition-colors cursor-pointer",
+            "focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--border-focus)]",
+            "text-[var(--content-secondary)] hover:bg-[var(--surface-hover)] hover:text-[var(--content-default)]",
+            isError && "text-[var(--system-negative-strong)]",
+          )}
+        >
+          <span
+            className={cn(
+              "inline-flex shrink-0 items-center text-[var(--content-tertiary)]",
+              isError && "text-[var(--system-negative-strong)]",
+            )}
+          >
+            {state === "loading" ? (
+              <ThreeDotIndicator
+                data-testid="inline-web-loading"
+                className="shrink-0"
+              />
+            ) : (
+              <Globe className="size-4 shrink-0" aria-hidden />
+            )}
+          </span>
+          <span>Web Search</span>
+          <span aria-hidden className="text-[var(--content-tertiary)]">
+            |
+          </span>
+          <span className="min-w-0">{carouselNode ?? info}</span>
+          <ExpandChevron
+            className="size-3.5 shrink-0 text-[var(--content-tertiary)]"
+            aria-hidden
+          />
+        </button>
+        {expanded ? (
+          <div className="pl-6">
+            {step.kind === "web_search_error" ? (
+              <WebSearchErrorRow step={step} />
+            ) : (
+              <WebSearchStepRow step={step} />
+            )}
+          </div>
+        ) : null}
+      </div>
+    );
+  }
 
   let view: ResolvedView;
 


### PR DESCRIPTION
## Summary
- Add a 'web' variant to SingleActivity: an inline link 'Web Search | <WebsiteCarousel>' that expands in place to show the favicon results (and +N more overflow). Used by the lone-web-search path in PR 4.

Part of plan: web-search-activity-card.md (PR 3 of 4)