### PR TITLE
feat(web): remove Scheduled and Background from the assistant side nav

### DIFF
--- a/apps/web/src/domains/chat/components/assistant-side-menu.test.tsx
+++ b/apps/web/src/domains/chat/components/assistant-side-menu.test.tsx
@@ -76,21 +76,7 @@ describe("AssistantSideMenu · Conversations category rows", () => {
         title: "Pinned thread",
         isPinned: true,
       }),
-      makeConversation({
-        conversationId: "s1",
-        conversationType: "scheduled",
-      }),
-      makeConversation({
-        conversationId: "b1",
-        conversationType: "background",
-        source: "heartbeat",
-      }),
       makeConversation({ conversationId: "r1", title: "Recent thread" }),
-      makeConversation({
-        conversationId: "rf1",
-        conversationType: "background",
-        source: "auto-analysis",
-      }),
     ];
 
     const html = renderMenu({ conversations });
@@ -98,8 +84,8 @@ describe("AssistantSideMenu · Conversations category rows", () => {
     expect(html).toContain(">Conversations<");
     expect(html).toContain(">Pinned<");
     expect(html).toContain(">Pinned thread<");
-    expect(html).toContain(">Scheduled<");
-    expect(html).toContain(">Background<");
+    expect(html).not.toContain(">Scheduled<");
+    expect(html).not.toContain(">Background<");
     expect(html).toContain(">Recent thread<");
     expect(html).not.toContain(">Recents<");
     expect(html).not.toContain(">Slack<");
@@ -109,7 +95,7 @@ describe("AssistantSideMenu · Conversations category rows", () => {
     );
   });
 
-  test("renders Slack as a conditional peer section between Recents and Scheduled", () => {
+  test("renders Slack as a conditional peer section after Recents", () => {
     const conversations = [
       makeConversation({ conversationId: "regular", title: "Regular thread" }),
       makeConversation({
@@ -125,13 +111,9 @@ describe("AssistantSideMenu · Conversations category rows", () => {
     expect(html).not.toContain(">Pinned<");
 
     const recentThreadIndex = html.indexOf(">Regular thread<");
-    const scheduledIndex = html.indexOf(">Scheduled<");
-    const backgroundIndex = html.indexOf(">Background<");
     const slackIndex = html.indexOf(">Slack<");
     expect(recentThreadIndex).toBeGreaterThanOrEqual(0);
     expect(slackIndex).toBeGreaterThan(recentThreadIndex);
-    expect(scheduledIndex).toBeGreaterThan(slackIndex);
-    expect(backgroundIndex).toBeGreaterThan(scheduledIndex);
   });
 
   test("renders Pinned as a top-level section when non-empty", () => {
@@ -165,28 +147,21 @@ describe("AssistantSideMenu · Conversations category rows", () => {
     expect(collapsedHtml).not.toContain('aria-label="Pinned"');
   });
 
-  test("omits chat count badges from category buckets and subgroups", () => {
+  test("omits chat count badges from the Conversations section rows", () => {
     const conversations = [
-      makeConversation({
-        conversationId: "background-alpha",
-        title: "Background Alpha",
-        conversationType: "background",
-        source: "heartbeat",
-      }),
-      makeConversation({
-        conversationId: "background-beta",
-        title: "Background Beta",
-        conversationType: "background",
-        source: "heartbeat",
-      }),
       makeConversation({
         conversationId: "recent-alpha",
         title: "Recent Alpha",
+      }),
+      makeConversation({
+        conversationId: "recent-beta",
+        title: "Recent Beta",
       }),
     ];
 
     const html = renderMenu({ conversations });
 
+    expect(html).toContain(">Conversations<");
     expect(html).not.toContain(">2<");
     expect(html).not.toContain(">1<");
   });

--- a/apps/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/apps/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -1,11 +1,7 @@
 import {
     Brain,
-    Calendar,
-    ChevronDown,
-    ChevronRight,
     Clock,
     Hash,
-    Layers,
     LayoutGrid,
     Pin,
     Rocket,
@@ -13,7 +9,7 @@ import {
     SquarePen,
     X,
 } from "lucide-react";
-import { useCallback, useMemo, useState, type MouseEvent, type ReactNode } from "react";
+import { useCallback, useState, type MouseEvent, type ReactNode } from "react";
 
 import { useCommandPaletteStore } from "@/stores/command-palette-store";
 
@@ -25,13 +21,8 @@ import {
     type ConversationMenuItemsProps,
 } from "@/domains/chat/components/conversation-actions-menu";
 import { GroupActionsMenu, renderGroupMenuItems } from "@/domains/chat/components/group-actions-menu";
-import { BackgroundSubGroups, ScheduledSubGroups } from "@/domains/chat/components/sub-group-accordion";
 import { ThreadPinToggle } from "@/domains/chat/components/thread-pin-toggle";
 import { SIDEBAR_CONVERSATION_LIMIT, useSidebarState, type UseSidebarStateParams } from "@/domains/chat/use-sidebar-state";
-import {
-    formatBackgroundSubGroupLabel,
-    groupBackgroundConversationsBySource,
-} from "@/domains/chat/utils/background-sub-groups";
 import { isChannelConversation } from "@/domains/chat/utils/conversation-channel";
 import { buildMoveToGroupTargets, isConversationPinned } from "@/domains/chat/utils/group-conversations";
 import { usePinnedAppsStore } from "@/stores/pinned-apps-store";
@@ -126,8 +117,6 @@ function SearchButton({ onClose }: { onClose?: () => void }) {
  *     • thread …       — recent conversations inline
  *     • …
  *     • Show more/less — page through recent conversations
- *     • Scheduled      — collapsible category
- *     • Background     — collapsible category (includes Reflections sub-group)
  *     • Slack ▾        — collapsible category when Slack conversations exist
  *   Footer
  *     • ───────────────
@@ -307,20 +296,6 @@ export function AssistantSideMenu({
       onRename: options?.onRename,
       onDelete: options?.onDelete,
     });
-  };
-
-  // --- Shared sub-component props ---
-
-  const subGroupProps = {
-    activeConversationId,
-    attentionConversationIds,
-    onSelectConversation: useCallback(
-      (key: string) => { onSelectConversation(key); onClose?.(); },
-      [onSelectConversation, onClose],
-    ),
-    renderActions: renderThreadActions,
-    renderPinToggle: renderThreadPinToggle,
-    renderRow: renderThreadRow,
   };
 
   const selectAndClose = useCallback(
@@ -556,36 +531,6 @@ export function AssistantSideMenu({
             >
               {(close) => renderCollapsedGroupContent("Slack", sidebar.slack.all, close)}
             </CollapsedGroupIcon>
-            <CollapsedGroupIcon
-              icon={Calendar}
-              label="Scheduled"
-              onOpenChange={(open) => {
-                if (open) {
-                  sidebar.activateScheduled();
-                }
-              }}
-              indicatorState={getGroupIndicatorState(sidebar.scheduled, processingConversationIds, attentionConversationIds)}
-            >
-              {(close) =>
-                renderCollapsedGroupContent(
-                  "Scheduled",
-                  sidebar.scheduled,
-                  close,
-                  <CollapsedGroupEmptyState loading={sidebar.scheduledLoading} />,
-                )
-              }
-            </CollapsedGroupIcon>
-            <CollapsedBackgroundGroup
-              conversations={sidebar.background}
-              loading={sidebar.backgroundLoading}
-              onReveal={sidebar.activateBackground}
-              activeConversationId={activeConversationId}
-              onSelectConversation={selectAndClose}
-              renderActions={renderThreadActions}
-              renderPinToggle={renderThreadPinToggle}
-              processingConversationIds={processingConversationIds}
-              attentionConversationIds={attentionConversationIds}
-            />
           </div>
         ) : (
           <>
@@ -633,32 +578,6 @@ export function AssistantSideMenu({
                     )}
                   </CollapsibleNavSection.Section>
                 ) : null}
-
-                <CollapsibleNavSection.Section
-                  value="scheduled"
-                  icon={Calendar}
-                  label="Scheduled"
-                  contextMenuContent={buildGroupContextMenu("Scheduled", sidebar.scheduled)}
-                >
-                  <ScheduledSubGroups
-                    subGroups={sidebar.scheduledSubGroups}
-                    loading={sidebar.scheduledLoading}
-                    {...subGroupProps}
-                  />
-                </CollapsibleNavSection.Section>
-
-                <CollapsibleNavSection.Section
-                  value="background"
-                  icon={Layers}
-                  label="Background"
-                  contextMenuContent={buildGroupContextMenu("Background", sidebar.background)}
-                >
-                  <BackgroundSubGroups
-                    subGroups={sidebar.backgroundSubGroups}
-                    loading={sidebar.backgroundLoading}
-                    {...subGroupProps}
-                  />
-                </CollapsibleNavSection.Section>
               </CollapsibleNavSection.Root>
 
               {sidebar.conversationGroupsEnabled && sidebar.customGroups.length > 0 ? (
@@ -731,151 +650,5 @@ export function AssistantSideMenu({
         </SideMenu.Footer>
       ) : null}
     </SideMenu>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Collapsed-rail lazy-section placeholder
-// ---------------------------------------------------------------------------
-
-/**
- * Placeholder shown inside a collapsed-rail flyout for the Background and
- * Scheduled sections, which are openable before their lazy fetch resolves.
- */
-function CollapsedGroupEmptyState({ loading }: { loading: boolean }) {
-  return (
-    <div className="px-4 py-2 text-body-small-default text-[var(--content-tertiary)]">
-      {loading ? "Loading…" : "No conversations"}
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Collapsed background group — extracted so it can own sub-group expand state
-// ---------------------------------------------------------------------------
-
-interface CollapsedBackgroundGroupProps {
-  conversations: Conversation[];
-  /** True while the lazy background fetch is in flight after a reveal. */
-  loading?: boolean;
-  /** Called when the flyout opens, to enable the lazy background fetch. */
-  onReveal?: () => void;
-  activeConversationId?: string;
-  onSelectConversation: (conversationId: string) => void;
-  renderActions: (conversation: Conversation) => ReactNode;
-  renderPinToggle: (conversation: Conversation) => ReactNode;
-  processingConversationIds?: Set<string>;
-  attentionConversationIds?: Set<string>;
-}
-
-function CollapsedBackgroundGroup({
-  conversations,
-  loading = false,
-  onReveal,
-  activeConversationId,
-  onSelectConversation,
-  renderActions,
-  renderPinToggle,
-  processingConversationIds,
-  attentionConversationIds,
-}: CollapsedBackgroundGroupProps) {
-  const subGroups = useMemo(() => groupBackgroundConversationsBySource(conversations), [conversations]);
-  const [manualExpandedKeys, setManualExpandedKeys] = useState<Set<string>>(new Set());
-
-  const attentionExpandedKeys = useMemo(() => {
-    if (!attentionConversationIds || attentionConversationIds.size === 0) return new Set<string>();
-    const keys = new Set<string>();
-    for (const group of subGroups) {
-      if (group.key.startsWith("__single__:")) continue;
-      if (group.conversations.some(c => attentionConversationIds.has(c.conversationId))) {
-        keys.add(group.key);
-      }
-    }
-    return keys;
-  }, [attentionConversationIds, subGroups]);
-
-  const expandedKeys = useMemo(() => {
-    if (attentionExpandedKeys.size === 0) return manualExpandedKeys;
-    const merged = new Set(manualExpandedKeys);
-    for (const k of attentionExpandedKeys) merged.add(k);
-    return merged;
-  }, [manualExpandedKeys, attentionExpandedKeys]);
-
-  const toggleGroup = (key: string) => {
-    setManualExpandedKeys((prev) => {
-      const next = new Set(prev);
-      if (next.has(key)) {
-        next.delete(key);
-      } else {
-        next.add(key);
-      }
-      return next;
-    });
-  };
-
-  return (
-    <CollapsedGroupIcon
-      icon={Layers}
-      label="Background"
-      onOpenChange={(open) => {
-        if (open) {
-          onReveal?.();
-        }
-      }}
-      indicatorState={getGroupIndicatorState(conversations, processingConversationIds, attentionConversationIds)}
-    >
-      {(closePopover) => (
-        <div className="pb-1">
-          <div className="flex items-center justify-between px-4 py-1">
-            <span className="text-body-small-default text-[var(--content-tertiary)]">Background</span>
-          </div>
-          <div className="px-2">
-            {conversations.length === 0 ? (
-              <CollapsedGroupEmptyState loading={loading} />
-            ) : null}
-            {subGroups.map((group) => {
-              const isSingle = group.key.startsWith("__single__:");
-              if (isSingle) {
-                const c = group.conversations[0];
-                if (!c) return null;
-                return (
-                  <PanelItem
-                    key={c.conversationId}
-                    leadingSlot={renderPinToggle(c)}
-                    label={c.title ?? "Untitled"}
-                    active={c.conversationId === activeConversationId}
-                    onSelect={() => { closePopover(); onSelectConversation(c.conversationId); }}
-                    trailingAction={renderActions(c)}
-                  />
-                );
-              }
-
-              const isExpanded = expandedKeys.has(group.key);
-              return (
-                <div key={group.key}>
-                  <PanelItem
-                    icon={isExpanded ? ChevronDown : ChevronRight}
-                    label={formatBackgroundSubGroupLabel(group.key)}
-                    onSelect={() => toggleGroup(group.key)}
-                  />
-                  {isExpanded
-                    ? group.conversations.map((c) => (
-                        <PanelItem
-                          key={c.conversationId}
-                          leadingSlot={renderPinToggle(c)}
-                          label={c.title ?? "Untitled"}
-                          active={c.conversationId === activeConversationId}
-                          onSelect={() => { closePopover(); onSelectConversation(c.conversationId); }}
-                          trailingAction={renderActions(c)}
-                        />
-                      ))
-                    : null}
-                </div>
-              );
-            })}
-          </div>
-        </div>
-      )}
-    </CollapsedGroupIcon>
   );
 }

--- a/apps/web/src/domains/chat/utils/group-conversations.test.ts
+++ b/apps/web/src/domains/chat/utils/group-conversations.test.ts
@@ -184,10 +184,10 @@ describe("groupConversations · bucket routing", () => {
     });
 
     expect(getEffectiveGroupId(conversation)).toBe("system:slack");
+    // Scheduled/Background are no longer move targets — those sidebar sections
+    // were removed, so moving a row there would hide it with no way back.
     expect(buildMoveToGroupTargets(conversation).map((g) => g.id)).toEqual([
       "system:pinned",
-      "system:scheduled",
-      "system:background",
       "system:all",
     ]);
   });

--- a/apps/web/src/domains/chat/utils/group-conversations.ts
+++ b/apps/web/src/domains/chat/utils/group-conversations.ts
@@ -103,13 +103,19 @@ export interface MoveToGroupTarget {
 
 /**
  * The fixed set of persisted system groups a conversation can be moved to.
+ *
  * Slack is intentionally omitted because it is a derived origin section, not
  * a group arbitrary conversations can join.
+ *
+ * Scheduled and Background are also omitted: the sidebar no longer renders
+ * those sections, so offering them as move targets would let a user move a
+ * conversation into a bucket with no visible section to recover it from — the
+ * row would simply vanish (`groupConversations` still filters those groupIds
+ * out of recents). Conversations classified as scheduled/background by
+ * `getEffectiveGroupId` therefore have no self-target to exclude here.
  */
 const SYSTEM_MOVE_TARGETS: readonly MoveToGroupTarget[] = [
   { id: "system:pinned", name: "Pinned" },
-  { id: "system:scheduled", name: "Scheduled" },
-  { id: "system:background", name: "Background" },
   { id: "system:all", name: "Recents" },
 ];
 


### PR DESCRIPTION
## Summary
- Remove the Scheduled and Background collapsible categories from the assistant side nav (both expanded sidebar and collapsed rail) — they added clutter; schedules are reachable from Settings → Schedules.
- Web-only. Deletes the now-unused CollapsedBackgroundGroup/CollapsedGroupEmptyState locals and dead imports. The useSidebarState hook and sidebar-collapse-store are intentionally left intact (their scheduled/background fields are now unused-but-valid).

Part of plan: remove-scheduled-background-nav.md (PR 1 of 1)