### PR TITLE
Remove retire assistant success snackbar

### DIFF
--- a/apps/web/src/domains/settings/components/retire-assistant.tsx
+++ b/apps/web/src/domains/settings/components/retire-assistant.tsx
@@ -20,7 +20,6 @@ export function RetireAssistant({ assistantId }: RetireAssistantProps) {
     const outcome = await retireAssistant(assistantId);
     if (outcome.ok) {
       setConfirmOpen(false);
-      toast.success("Assistant retired.");
       navigate(outcome.nextRoute, { replace: true });
       return;
     }

--- a/apps/web/src/root-layout.tsx
+++ b/apps/web/src/root-layout.tsx
@@ -202,7 +202,6 @@ export function RootLayout() {
     if (outcome.ok) {
       setRetireId(null);
       setRetirePending(false);
-      toast.success("Assistant retired.");
       navigate(outcome.nextRoute, { replace: true });
       return;
     }


### PR DESCRIPTION
## Summary
- Remove the `toast.success("Assistant retired.")` snackbar shown after a successful retire in both `retire-assistant.tsx` and `root-layout.tsx`
- The navigate call already redirects the user, making the toast redundant

## Original prompt
The web UI shows an "Assistant retired." success snackbar after retiring an assistant. The user wanted this snackbar removed since the navigation redirect already provides sufficient feedback.