### PR TITLE
fix(macos): tighten command palette floating window

### DIFF
--- a/apps/macos/src/main/command-palette-window.test.ts
+++ b/apps/macos/src/main/command-palette-window.test.ts
@@ -66,8 +66,8 @@ const makeWindow = (): StubWindow => {
   const bounds: Electron.Rectangle = {
     x: 0,
     y: 0,
-    width: 800,
-    height: 520,
+    width: 584,
+    height: 444,
   };
 
   const webContents: StubWebContents = {
@@ -293,8 +293,8 @@ describe("openCommandPaletteWindow", () => {
     expect(opts.navigation).toBe("deny-all");
     expect(opts.browserWindow).toMatchObject({
       type: "panel",
-      width: 800,
-      height: 520,
+      width: 584,
+      height: 444,
       frame: false,
       transparent: true,
       resizable: false,
@@ -304,9 +304,9 @@ describe("openCommandPaletteWindow", () => {
       minimizable: false,
       maximizable: false,
       hasShadow: true,
-      vibrancy: "popover",
+      backgroundColor: "#00000000",
     });
-    expect(win.setPosition.mock.calls).toEqual([[1840, 290]]);
+    expect(win.setPosition.mock.calls).toEqual([[1948, 328]]);
     expect(win.show).toHaveBeenCalledTimes(1);
     expect(win.focus).toHaveBeenCalledTimes(1);
     expect(win.loadURL.mock.calls[0]?.[0]).toBe(

--- a/apps/macos/src/main/command-palette-window.ts
+++ b/apps/macos/src/main/command-palette-window.ts
@@ -13,8 +13,8 @@ import type { VellumCommand } from "./commands";
 const COMMAND_PALETTE_KIND = "commandPalette";
 const COMMAND_PALETTE_PATH = "/floating/command-palette";
 
-const PANEL_WIDTH = 800;
-const PANEL_HEIGHT = 520;
+const PANEL_WIDTH = 584;
+const PANEL_HEIGHT = 444;
 
 type PayloadCommandKind = Extract<
   VellumCommand,
@@ -115,7 +115,7 @@ export const openCommandPaletteWindow = (): void => {
       minimizable: false,
       maximizable: false,
       hasShadow: true,
-      vibrancy: "popover",
+      backgroundColor: "#00000000",
     },
   });
 


### PR DESCRIPTION
Part of LUM-1867.

## Summary
- Shrink the command palette BrowserWindow to hug the 560px palette plus padding.
- Remove the native popover vibrancy shell so the floating window does not render a large outer box.
- Update the focused main-process regression test for the new size/position.

## Validation
- `cd apps/macos && export PATH="$HOME/.bun/bin:$PATH"; bun test src/main/command-palette-window.test.ts`
- `cd apps/macos && export PATH="$HOME/.bun/bin:$PATH"; bunx tsc --noEmit`