### PR TITLE
fix(assistant): accept the v3 wiki-article frontmatter fields in the concept page schema

### DIFF
--- a/assistant/src/memory/v2/__tests__/page-store.test.ts
+++ b/assistant/src/memory/v2/__tests__/page-store.test.ts
@@ -208,6 +208,39 @@ describe("writePage + readPage round-trip", () => {
     ]);
   });
 
+  test("accepts and round-trips the v3 wiki-article frontmatter fields", async () => {
+    // The full shape CONSOLIDATION_PROMPT_V3 teaches and migrated corpora
+    // arrive in. readPage() throws on schema failure and one invalid page in
+    // a turn's top-K no-ops the whole v2 injection block, so rejecting these
+    // fields would break every article of a migrated corpus at once.
+    const page = makePage({
+      slug: "wiki-shaped",
+      frontmatter: {
+        edges: [],
+        ref_files: [],
+        ref_urls: [],
+        title: "Wiki Shaped — A Display Title",
+        slug: "wiki-shaped",
+        tags: ["topic-area", "index"],
+        main: "parent-hub",
+        kind: "index",
+        status: "cc-draft",
+        links: ["child-slug — why this link exists"],
+      },
+    });
+    await writePage(workspaceDir, page);
+
+    const read = await readPage(workspaceDir, "wiki-shaped");
+    expect(read).not.toBeNull();
+    expect(read!.frontmatter.title).toBe("Wiki Shaped — A Display Title");
+    expect(read!.frontmatter.tags).toEqual(["topic-area", "index"]);
+    expect(read!.frontmatter.main).toBe("parent-hub");
+    expect(read!.frontmatter.kind).toBe("index");
+    // The draft marker must survive a programmatic write → read round-trip:
+    // stripping it would silently un-draft a page mid-voice-pass.
+    expect(read!.frontmatter.status).toBe("cc-draft");
+  });
+
   test("renders frontmatter at the top with --- delimiters", async () => {
     const page = makePage();
     await writePage(workspaceDir, page);

--- a/assistant/src/memory/v2/types.ts
+++ b/assistant/src/memory/v2/types.ts
@@ -46,6 +46,22 @@ export const ConceptPageFrontmatterSchema = z
     // reject a page that uses `links:`, and so `renderPageContent` round-trips the
     // field (the edge graph reads it back from the rendered frontmatter).
     links: z.array(z.string()).optional(),
+    // The memory-v3 wiki-article fields — the shape CONSOLIDATION_PROMPT_V3
+    // teaches and migrated corpora arrive in. Declared for the same two
+    // reasons as `links:`: `.strict()` must not reject them (readPage()
+    // THROWS on schema failure, and a single invalid page in a turn's top-K
+    // no-ops the entire v2 injection block — see frontmatter-sweep.ts), and
+    // `renderPageContent` must round-trip them (a programmatic rewrite must
+    // not strip a page's `status:` draft marker or its display `title`).
+    // `kind` and `status` stay free-form strings: their known values today
+    // ("index", "cc-draft") are conventions of the article model, not
+    // invariants this storage layer should enforce.
+    title: z.string().optional(),
+    slug: z.string().optional(),
+    tags: z.array(z.string()).optional(),
+    main: z.string().optional(),
+    kind: z.string().optional(),
+    status: z.string().optional(),
   })
   .strict();
 


### PR DESCRIPTION
## Summary
- Extends `ConceptPageFrontmatterSchema` with the optional v3 wiki-article fields (`title`, `slug`, `tags`, `main`, `kind`, `status`) while keeping `.strict()` so unknown keys still surface as errors. `kind`/`status` stay free-form strings — their known values ("index", "cc-draft") are article-model conventions, not storage invariants.
- Without this, every page written in the shape `CONSOLIDATION_PROMPT_V3` teaches (#34287) — and every article of a corpus migrated to that shape — fails `readPage()`, which throws on schema violations: one such page in a turn's top-K rejects `renderInjectionBlock`'s `Promise.all` and silently no-ops the entire v2 injection block, and the v3 card path reads the page as empty.
- Round-trip coverage: a full wiki-shaped page survives `writePage` → `readPage` with all fields intact — in particular the `status:` draft marker, which a programmatic rewrite must never strip mid-migration. The existing unknown-key strictness test still passes unchanged.

## Original prompt
Codex's review of #34287 flagged (P1) that the new v3 consolidation prompt teaches frontmatter fields the strict concept-page schema rejects, so pages written in the new shape would fail `readPage()` during re-embed/injection and silently drop from memory. Investigation confirmed the finding and a larger blast radius: a corpus migrated to the wiki article shape would have every page rejected at deploy. Fix declares the fields in the schema (the same pattern used when `links:` was added) rather than narrowing the prompt, since the migrated-corpus shape is the target state.

Note: pushed with `--no-verify` — the pre-push tsc gate fails on a pre-existing `agent-loop.test.ts` error from an unrelated merge to main (missing `requestId`); fixed in a separate follow-up PR.