### PR TITLE
fix(assistant): add required requestId to agent-loop test run() calls

### DIFF
--- a/assistant/src/__tests__/agent-loop.test.ts
+++ b/assistant/src/__tests__/agent-loop.test.ts
@@ -397,6 +397,7 @@ describe("AgentLoop", () => {
       messages: [userMessage],
       onEvent: collectEvents(events),
       trust: { sourceChannel: "vellum", trustClass: "unknown" },
+      requestId: "test-request",
     });
 
     // THEN it re-issued the call after repairing, surfaced no error, and
@@ -426,6 +427,7 @@ describe("AgentLoop", () => {
       messages: [userMessage],
       onEvent: collectEvents(events),
       trust: { sourceChannel: "vellum", trustClass: "unknown" },
+      requestId: "test-request",
     });
 
     // THEN it repaired once, re-issued once, then surfaced the error rather
@@ -463,6 +465,7 @@ describe("AgentLoop", () => {
       messages: [leadingAssistantMessage, userMessage],
       onEvent: () => {},
       trust: { sourceChannel: "vellum", trustClass: "unknown" },
+      requestId: "test-request",
     });
 
     // THEN deep-repair dropped the leading assistant from the base, and
@@ -501,6 +504,7 @@ describe("AgentLoop", () => {
       messages: [userMessage],
       onEvent: collectEvents(firstEvents),
       trust: { sourceChannel: "vellum", trustClass: "unknown" },
+      requestId: "test-request",
     });
     expect(firstCalls).toHaveLength(2);
     expect(firstEvents.filter((e) => e.type === "error")).toHaveLength(1);
@@ -527,6 +531,7 @@ describe("AgentLoop", () => {
       messages: [userMessage],
       onEvent: collectEvents(secondEvents),
       trust: { sourceChannel: "vellum", trustClass: "unknown" },
+      requestId: "test-request",
     });
 
     // THEN it repaired and re-issued (the bound did not leak across runs),
@@ -570,6 +575,7 @@ describe("AgentLoop", () => {
         messages: [userMessage],
         onEvent: collectEvents(events),
         trust: { sourceChannel: "vellum", trustClass: "unknown" },
+        requestId: "test-request",
       })
       .catch(() => {
         rejected = true;


### PR DESCRIPTION
## Summary
- `AgentLoopRunOptions.requestId` became required in a recent merge, but several `loop.run()` call sites in `agent-loop.test.ts` were not updated — `bunx tsc --noEmit` has been failing on main, which also blocks every push through the pre-push typecheck hook.
- Adds `requestId: "test-request"` to the remaining call sites, matching the convention already used elsewhere in the file. Full-project typecheck is clean again; all 58 tests in the file pass unchanged.

## Original prompt
While shipping an unrelated fix, the pre-push typecheck gate failed on these pre-existing errors from main; this PR restores a green `tsc --noEmit` so the hook stops blocking unrelated work.