### PR TITLE
feat(electron): add `launchAtLogin` setting and main-process login-item module

### DIFF
--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -41,6 +41,7 @@ import { installHotkeysIpc } from "./hotkeys";
 import { installPopoutWindows } from "./popout-window";
 import { installQuickInput } from "./quick-input-window";
 import { installLocalMode, resolveCliInvocation } from "./local-mode";
+import { installLoginItem } from "./login-item";
 import { installLockfileWatcher } from "./lockfile-watcher";
 import { installHostProxyBridge } from "./host-proxy-router";
 import "./executors/host-bash-executor"; // side-effect: registers host_bash executor
@@ -321,6 +322,7 @@ app
     installHotkeysIpc();
     installFeatureFlagsIpc();
     installLocalMode();
+    installLoginItem();
     installHotkeyHelper();
     installAbout();
     installAutoUpdate();

--- a/apps/macos/src/main/login-item.ts
+++ b/apps/macos/src/main/login-item.ts
@@ -1,6 +1,6 @@
 import { app } from "electron";
 
-import { readSetting, onSettingChange } from "./settings";
+import { readSetting, onSettingChange, writeSetting } from "./settings";
 
 /** Apply the current `launchAtLogin` preference to the OS login item. */
 export const syncLoginItem = (): void => {
@@ -11,8 +11,16 @@ export const syncLoginItem = (): void => {
 /**
  * Sync on startup and subscribe to future changes. Returns an unsubscribe
  * function for cleanup.
+ *
+ * On first launch after the setting is introduced, seeds the preference from
+ * the current OS login-item state so users who added Vellum manually via
+ * System Settings keep their configuration.
  */
 export const installLoginItem = (): (() => void) => {
+  if (readSetting("launchAtLogin") === null) {
+    const { openAtLogin } = app.getLoginItemSettings();
+    writeSetting("launchAtLogin", openAtLogin);
+  }
   syncLoginItem();
   return onSettingChange("launchAtLogin", () => syncLoginItem());
 };

--- a/apps/macos/src/main/login-item.ts
+++ b/apps/macos/src/main/login-item.ts
@@ -1,0 +1,18 @@
+import { app } from "electron";
+
+import { readSetting, onSettingChange } from "./settings";
+
+/** Apply the current `launchAtLogin` preference to the OS login item. */
+export const syncLoginItem = (): void => {
+  const value = readSetting("launchAtLogin");
+  app.setLoginItemSettings({ openAtLogin: value ?? false });
+};
+
+/**
+ * Sync on startup and subscribe to future changes. Returns an unsubscribe
+ * function for cleanup.
+ */
+export const installLoginItem = (): (() => void) => {
+  syncLoginItem();
+  return onSettingChange("launchAtLogin", () => syncLoginItem());
+};

--- a/apps/macos/src/main/settings.ts
+++ b/apps/macos/src/main/settings.ts
@@ -18,6 +18,7 @@ export interface AppSettings {
   hotkeys: Record<string, string>;
   theme: "light" | "dark" | "system";
   featureFlags: Record<string, boolean>;
+  launchAtLogin: boolean;
 }
 
 const schema: Schema<AppSettings> = {
@@ -35,6 +36,10 @@ const schema: Schema<AppSettings> = {
     type: "object",
     additionalProperties: { type: "boolean" },
     default: {},
+  },
+  launchAtLogin: {
+    type: "boolean",
+    default: false,
   },
 };
 


### PR DESCRIPTION
## Summary
- Add `launchAtLogin: boolean` to `AppSettings` interface and electron-store schema (default: `false`)
- Create `login-item.ts` main-process module that syncs the OS login item via `app.setLoginItemSettings`
- Subscribe to setting changes for live sync without app restart

Part of plan: launch-at-login.md (PR 1 of 3)