### PR TITLE
fix(skills): drop prefix-match fallback in resolveSkillSelector

### DIFF
--- a/assistant/src/__tests__/skills.test.ts
+++ b/assistant/src/__tests__/skills.test.ts
@@ -223,6 +223,22 @@ describe("workspace skills", () => {
     expect(result.error).toBeDefined();
   });
 
+  test("resolveSkillSelector does NOT prefix-match to a different skill id", () => {
+    // Regression: previously `slack` would silently resolve to `slack-app-setup`
+    // when the `slack` skill wasn't installed locally. That handed the model
+    // the wrong instructions and bypassed catalog auto-install. The resolver
+    // must fail closed so `skill_load` can attempt the auto-install path.
+    writeWorkspaceSkill(
+      "slack-app-setup",
+      "Slack App Setup",
+      "Setup-only skill",
+    );
+
+    const result = resolveSkillSelector("slack", workspaceSkillsDir);
+    expect(result.skill).toBeUndefined();
+    expect(result.errorCode).toBe("not_found");
+  });
+
   test("loadSkillBySelector loads workspace skill body without isOutsideSkillsRoot rejection", () => {
     writeWorkspaceSkill(
       "ws-load",

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -1164,20 +1164,10 @@ export function resolveSkillSelector(
     };
   }
 
-  const idPrefixMatches = catalog.filter((skill) =>
-    skill.id.startsWith(needle),
-  );
-  if (idPrefixMatches.length === 1) {
-    return { skill: idPrefixMatches[0] };
-  }
-  if (idPrefixMatches.length > 1) {
-    const ids = idPrefixMatches.map((skill) => skill.id).join(", ");
-    return {
-      error: `Ambiguous skill id prefix "${needle}". Matching IDs: ${ids}`,
-      errorCode: "ambiguous",
-    };
-  }
-
+  // Intentionally no prefix-match fallback. Silently substituting a
+  // prefix-matched skill (e.g. `slack` → `slack-app-setup`) hands the model
+  // the wrong instructions and bypasses the auto-install path that would
+  // fetch the actually-requested skill from the catalog.
   const knownSkills = catalog.map((skill) => skill.id).join(", ");
   return {
     error: `No skill matched "${needle}". Available skills: ${knownSkills}`,


### PR DESCRIPTION
## Why

Caught this while reviewing an LLM inspector trace where the daemon spent **14 LLM calls and ~\$0.44** answering a one-line user question (\"check #general in slack and tell me who hasn't filled this out\" + a screenshot). The very first call should have loaded the Slack skill and used its documented patterns. Instead the model got handed `slack-app-setup` and spent 11 subsequent calls reinventing Slack access from scratch with raw curl.

Root cause is in the skill resolver, not in the model or the Slack skill itself.

## The bug

`resolveSkillSelector` (in \`assistant/src/config/skills.ts\`) used a three-tier match:

1. Exact id
2. Exact name
3. **Prefix match** ← the footgun

When a user/model calls \`skill_load({\"skill\": \"slack\"})\`:

- If the \`slack\` skill is already installed locally → exact id hits, returns the right skill.
- If \`slack\` isn't installed yet (it's a workspace skill, fetched on demand from \`skills/catalog.json\`) → exact id misses → exact name misses → **prefix-match finds exactly one id starting with \"slack\": \`slack-app-setup\`** → returns it silently.

The model gets back \"Skill: Slack App Setup\" instructions (manifest URLs, OAuth tokens, install steps) when it asked for read/send patterns. There's no signal that anything was substituted.

Worse, this **bypasses the catalog auto-install path in \`skill_load\`**: auto-install only fires when \`errorCode === \"not_found\" || \"empty_catalog\"\`. Prefix-match returned success, so auto-install never ran and the real \`slack\` skill was never fetched.

## The fix

Drop the prefix-match tier entirely. Exact id or exact name only. If neither matches, return \`not_found\` — which lets \`autoInstallFromCatalog(selector)\` in \`skill_load\` do its job.

This is general, not Slack-specific: any selector whose target isn't installed locally was at risk of silent substitution to the wrong skill if it happened to be a prefix of an installed id.

## Tests

Added a regression test in \`skills.test.ts\` (\`resolveSkillSelector does NOT prefix-match to a different skill id\`). All 42 tests pass; full \`tsc --noEmit\` clean.

## Test plan
- [ ] On a fresh install, \`skill_load({\"skill\": \"slack\"})\` triggers catalog auto-install of the \`slack\` skill (not silent \`slack-app-setup\` substitution).
- [ ] On an install where \`slack\` is already present, \`skill_load({\"skill\": \"slack\"})\` returns it as before.
- [ ] \`skill_load({\"skill\": \"slack-app-setup\"})\` (exact id) still works.

## Follow-up PR

Companion change incoming: inject an attached-content hint when the user message carries an image/file, so the model reads attachments before running discovery tools. Same trace also showed the model spending most of the conversation querying Slack before finally referencing the screenshot it had the whole time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)