### PR TITLE
feat(assistant): attachment-read hint plugin for models that under-prioritize attachments

### DIFF
--- a/assistant/src/__tests__/attachment-read-hint-hook.test.ts
+++ b/assistant/src/__tests__/attachment-read-hint-hook.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Tests for the default `attachment-read-hint` plugin's `user-prompt-submit`
+ * hook.
+ *
+ * - Model gating: the hint fires only when the turn's resolved model is one
+ *   that under-prioritizes attachments (Kimi K2.6, under both the Fireworks
+ *   and Moonshot id schemes). Other models — including Kimi K2.5 — and an
+ *   unresolved model leave the messages untouched.
+ * - Attachment gating: the hint fires only when the tail user message carries
+ *   an `image` or `file` block; text-only turns and non-user tails are
+ *   untouched.
+ * - End-to-end through `runHook` + the registry: registering the default
+ *   plugin makes the hook fire and append the hint.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { HOOKS } from "../plugin-api/constants.js";
+import type {
+  PluginLogger,
+  UserPromptSubmitContext,
+} from "../plugin-api/types.js";
+import userPromptSubmit from "../plugins/defaults/attachment-read-hint/hooks/user-prompt-submit.js";
+import {
+  ATTACHMENT_READ_HINT,
+  injectAttachmentReadHint,
+  modelNeedsAttachmentReadHint,
+} from "../plugins/defaults/attachment-read-hint/inject.js";
+import { defaultAttachmentReadHintPlugin } from "../plugins/defaults/index.js";
+import { runHook } from "../plugins/pipeline.js";
+import {
+  registerPlugin,
+  resetPluginRegistryForTests,
+} from "../plugins/registry.js";
+import type { Message } from "../providers/types.js";
+
+const KIMI_K26_MOONSHOT = "moonshotai/kimi-k2.6";
+const KIMI_K26_FIREWORKS = "accounts/fireworks/models/kimi-k2p6";
+
+const noopLogger: PluginLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+};
+
+function makeCtx(
+  messages: Message[],
+  resolvedModel: string | undefined,
+): UserPromptSubmitContext {
+  return {
+    conversationId: "conv-test",
+    userMessageId: "msg-test",
+    requestId: "req-test",
+    modelProfileKey: null,
+    resolvedModel,
+    isNonInteractive: false,
+    prompt: "",
+    originalMessages: messages,
+    latestMessages: messages,
+    logger: noopLogger,
+  };
+}
+
+function imageTailMessages(): Message[] {
+  return [
+    {
+      role: "user",
+      content: [
+        {
+          type: "image",
+          source: { type: "base64", media_type: "image/png", data: "AAAA" },
+        },
+        { type: "text", text: "what does this say" },
+      ],
+    },
+  ];
+}
+
+function lastBlockText(messages: Message[]): string {
+  const tail = messages[messages.length - 1];
+  const last = tail?.content[tail.content.length - 1];
+  return last?.type === "text" ? last.text : "";
+}
+
+describe("modelNeedsAttachmentReadHint", () => {
+  test("matches Kimi K2.6 under both provider id schemes", () => {
+    expect(modelNeedsAttachmentReadHint(KIMI_K26_MOONSHOT)).toBe(true);
+    expect(modelNeedsAttachmentReadHint(KIMI_K26_FIREWORKS)).toBe(true);
+  });
+
+  test("rejects Kimi K2.5, other models, and an unresolved model", () => {
+    expect(modelNeedsAttachmentReadHint("moonshotai/kimi-k2.5")).toBe(false);
+    expect(
+      modelNeedsAttachmentReadHint("accounts/fireworks/models/kimi-k2p5"),
+    ).toBe(false);
+    expect(modelNeedsAttachmentReadHint("claude-fable-5")).toBe(false);
+    expect(modelNeedsAttachmentReadHint(undefined)).toBe(false);
+  });
+});
+
+describe("injectAttachmentReadHint", () => {
+  test("returns the same reference when no attachment is present", () => {
+    const msg: Message = {
+      role: "user",
+      content: [{ type: "text", text: "Hello" }],
+    };
+    expect(injectAttachmentReadHint(msg)).toBe(msg);
+  });
+
+  test("appends the hint for a file block", () => {
+    const msg: Message = {
+      role: "user",
+      content: [
+        {
+          type: "file",
+          source: {
+            type: "base64",
+            media_type: "application/pdf",
+            data: "AAAA",
+            filename: "report.pdf",
+          },
+        },
+        { type: "text", text: "summarize" },
+      ],
+    };
+    const result = injectAttachmentReadHint(msg);
+    expect(result).not.toBe(msg);
+    expect(result.content.length).toBe(3);
+    expect(lastBlockText([result])).toBe(ATTACHMENT_READ_HINT);
+  });
+});
+
+describe("attachment-read-hint user-prompt-submit hook — direct", () => {
+  test("appends the hint for Kimi K2.6 with an image attachment", async () => {
+    const ctx = makeCtx(imageTailMessages(), KIMI_K26_MOONSHOT);
+    await userPromptSubmit(ctx);
+    expect(ctx.latestMessages[0]?.content.length).toBe(3);
+    expect(lastBlockText(ctx.latestMessages)).toBe(ATTACHMENT_READ_HINT);
+  });
+
+  test("appends the hint under the Fireworks model id", async () => {
+    const ctx = makeCtx(imageTailMessages(), KIMI_K26_FIREWORKS);
+    await userPromptSubmit(ctx);
+    expect(lastBlockText(ctx.latestMessages)).toBe(ATTACHMENT_READ_HINT);
+  });
+
+  test("is a no-op for models outside the gate", async () => {
+    for (const model of ["claude-fable-5", "moonshotai/kimi-k2.5", undefined]) {
+      const messages = imageTailMessages();
+      const ctx = makeCtx(messages, model);
+      await userPromptSubmit(ctx);
+      expect(ctx.latestMessages).toBe(messages);
+      expect(ctx.latestMessages[0]?.content.length).toBe(2);
+    }
+  });
+
+  test("is a no-op for Kimi K2.6 without an attachment", async () => {
+    const messages: Message[] = [
+      { role: "user", content: [{ type: "text", text: "Hello" }] },
+    ];
+    const ctx = makeCtx(messages, KIMI_K26_MOONSHOT);
+    await userPromptSubmit(ctx);
+    expect(ctx.latestMessages[0]?.content.length).toBe(1);
+  });
+
+  test("is a no-op when the tail message is not a user message", async () => {
+    const messages: Message[] = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "image",
+            source: { type: "base64", media_type: "image/png", data: "AAAA" },
+          },
+        ],
+      },
+      { role: "assistant", content: [{ type: "text", text: "Looking." }] },
+    ];
+    const ctx = makeCtx(messages, KIMI_K26_MOONSHOT);
+    await userPromptSubmit(ctx);
+    expect(ctx.latestMessages[1]?.content.length).toBe(1);
+  });
+});
+
+describe("attachment-read-hint hook — through runHook + registry", () => {
+  beforeEach(() => {
+    resetPluginRegistryForTests();
+  });
+
+  test("registered default plugin appends the hint for Kimi K2.6", async () => {
+    registerPlugin(defaultAttachmentReadHintPlugin);
+    const ctx = makeCtx(imageTailMessages(), KIMI_K26_MOONSHOT);
+    const finalCtx = await runHook(HOOKS.USER_PROMPT_SUBMIT, ctx);
+    expect(lastBlockText(finalCtx.latestMessages)).toBe(ATTACHMENT_READ_HINT);
+  });
+});

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -804,6 +804,10 @@ export async function runAgentLoopImpl(
       latestMessages: ctx.messages,
       logger: rlog,
       modelProfileKey,
+      resolvedModel: resolveCallSiteConfig(turnCallSite, config.llm, {
+        overrideProfile: turnOverrideProfile ?? undefined,
+        selectionSeed: ctx.conversationId,
+      }).model,
       isNonInteractive,
     };
     const finalUserPromptCtx = await runHook(

--- a/assistant/src/plugin-api/types.ts
+++ b/assistant/src/plugin-api/types.ts
@@ -164,6 +164,17 @@ export interface UserPromptSubmitContext {
    */
   readonly modelProfileKey: string | null;
   /**
+   * Model id resolved for this turn's call site at turn start (e.g.
+   * "moonshotai/kimi-k2.6"), via the same call-site resolution the provider
+   * layer uses for the turn's first LLM call. Lets hooks scope model-specific
+   * prompt shaping to the models that need it. Mid-turn profile switches
+   * (tool-based auto-routing) are not reflected — the value is fixed when the
+   * hook fires. Absent when the caller cannot resolve a model (synthesized
+   * test contexts); hooks must treat absence as "don't apply model-specific
+   * behavior".
+   */
+  readonly resolvedModel?: string;
+  /**
    * Whether the turn has no human present to answer clarification questions
    * (e.g. a scheduled, background, or headless run). Resolved once at turn
    * start from the run's interactivity option, falling back to live client

--- a/assistant/src/plugins/defaults/attachment-read-hint/hooks/user-prompt-submit.ts
+++ b/assistant/src/plugins/defaults/attachment-read-hint/hooks/user-prompt-submit.ts
@@ -1,0 +1,37 @@
+/**
+ * Default `attachment-read-hint` hook: when the turn's resolved model is one
+ * that under-prioritizes attachments and the tail user message carries image
+ * or file blocks, append a short hint steering the model to read the attached
+ * content before running discovery tools.
+ *
+ * Gated on the resolved model so models that already read attachments first
+ * pay no token cost. Runs after the memory-retrieval and history-repair
+ * defaults, so the hint lands on the fully assembled, normalized tail
+ * message.
+ */
+
+import type {
+  PluginHookFn,
+  UserPromptSubmitContext,
+} from "@vellumai/plugin-api";
+
+import {
+  injectAttachmentReadHint,
+  modelNeedsAttachmentReadHint,
+} from "../inject.js";
+
+const userPromptSubmit: PluginHookFn<UserPromptSubmitContext> = async (ctx) => {
+  if (!modelNeedsAttachmentReadHint(ctx.resolvedModel)) return;
+  const tailIndex = ctx.latestMessages.length - 1;
+  const tail = ctx.latestMessages[tailIndex];
+  if (!tail || tail.role !== "user") return;
+  const withHint = injectAttachmentReadHint(tail);
+  if (withHint === tail) return;
+  ctx.latestMessages[tailIndex] = withHint;
+  ctx.logger.info(
+    { plugin: "attachment-read-hint", model: ctx.resolvedModel },
+    "Appended attachment-read hint to tail user message",
+  );
+};
+
+export default userPromptSubmit;

--- a/assistant/src/plugins/defaults/attachment-read-hint/inject.ts
+++ b/assistant/src/plugins/defaults/attachment-read-hint/inject.ts
@@ -1,0 +1,51 @@
+/**
+ * Attachment-read hint: model gating and tail-message injection.
+ *
+ * Some models under-prioritize attached images/files: when the user pastes a
+ * screenshot or document and asks a question about it, they run discovery
+ * tools first and only consult the attachment as a fallback — burning LLM
+ * calls on tool loops when the attachment already contains the answer. The
+ * hint nudges those models to read attached content before deciding next
+ * actions. Models that already read attachments first don't get the hint, so
+ * they pay no token cost for it.
+ */
+
+import type { Message } from "../../../providers/types.js";
+
+/**
+ * Models that need the attachment-read hint. Currently Kimi K2.6 only,
+ * matched across provider id schemes: Fireworks spells it
+ * `accounts/fireworks/models/kimi-k2p6`, Moonshot `moonshotai/kimi-k2.6`.
+ * The `[p.]` keeps K2.5 (`kimi-k2p5` / `kimi-k2.5`) excluded.
+ */
+const MODELS_NEEDING_HINT = /kimi-k2[p.]6/i;
+
+/**
+ * Whether the resolved turn model needs the attachment-read hint. An absent
+ * model (synthesized contexts that cannot resolve one) means no hint.
+ */
+export function modelNeedsAttachmentReadHint(
+  model: string | undefined,
+): boolean {
+  return model !== undefined && MODELS_NEEDING_HINT.test(model);
+}
+
+/** Hint text appended after the user's content blocks. */
+export const ATTACHMENT_READ_HINT =
+  "<attached_content_hint>\nThe user attached one or more images/files in this turn. Read them carefully before running discovery tools — the attachment often already contains the answer or the specific context the user is referring to.\n</attached_content_hint>";
+
+/**
+ * Append the attachment-read hint when the message carries image or file
+ * attachments. Returns the input message unchanged (same reference) when no
+ * attachment is present.
+ */
+export function injectAttachmentReadHint(message: Message): Message {
+  const hasAttachment = message.content.some(
+    (block) => block.type === "image" || block.type === "file",
+  );
+  if (!hasAttachment) return message;
+  return {
+    ...message,
+    content: [...message.content, { type: "text", text: ATTACHMENT_READ_HINT }],
+  };
+}

--- a/assistant/src/plugins/defaults/attachment-read-hint/package.json
+++ b/assistant/src/plugins/defaults/attachment-read-hint/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "default-attachment-read-hint",
+  "version": "1.0.0",
+  "description": "First-party default plugin that appends a read-the-attachment hint to the tail user message for models that under-prioritize attached images/files.",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "engines": {
+    "node": ">=20.12.0"
+  },
+  "peerDependencies": {
+    "@vellumai/plugin-api": "^0.8.0"
+  }
+}

--- a/assistant/src/plugins/defaults/index.ts
+++ b/assistant/src/plugins/defaults/index.ts
@@ -26,6 +26,8 @@
 
 import { registerPlugin, resetPluginRegistryForTests } from "../registry.js";
 import { type Plugin, PluginExecutionError } from "../types.js";
+import attachmentReadHintUserPromptSubmit from "./attachment-read-hint/hooks/user-prompt-submit.js";
+import attachmentReadHintPkg from "./attachment-read-hint/package.json" with { type: "json" };
 import compactionPkg from "./compaction/package.json" with { type: "json" };
 import emptyResponseStop from "./empty-response/hooks/stop.js";
 import emptyResponsePkg from "./empty-response/package.json" with { type: "json" };
@@ -167,6 +169,23 @@ export const defaultTitleGeneratePlugin: Plugin = {
 };
 
 /**
+ * `attachment-read-hint` — a `user-prompt-submit` hook that appends a
+ * read-the-attachment hint to the tail user message when it carries image or
+ * file blocks and the turn's resolved model is one that under-prioritizes
+ * attachments (currently Kimi K2.6). Models that already read attachments
+ * first pay no token cost for the hint.
+ */
+export const defaultAttachmentReadHintPlugin: Plugin = {
+  manifest: {
+    name: attachmentReadHintPkg.name,
+    version: attachmentReadHintPkg.version,
+  },
+  hooks: {
+    "user-prompt-submit": attachmentReadHintUserPromptSubmit,
+  },
+};
+
+/**
  * `tool-error` — a `post-tool-use` hook that coaches the model to retry or
  * report a failed tool call, bounded per tool. The coaching is surfaced via
  * `additionalContext`, leaving the tool result's own content untouched.
@@ -209,6 +228,7 @@ function getAllDefaultPlugins(): readonly Plugin[] {
     defaultEmptyResponsePlugin,
     defaultToolErrorPlugin,
     defaultHistoryRepairPlugin,
+    defaultAttachmentReadHintPlugin,
     defaultImageRecoveryPlugin,
     defaultCompactionPlugin,
     defaultTitleGeneratePlugin,


### PR DESCRIPTION
## Why

From the same LLM inspector trace as #34294. The user asked the daemon "check #general in slack and tell me who hasn't filled this out" with a screenshot of the poll attached (13 YES / 2 NO). The model (Kimi K2.6) spent **14 LLM calls / ~$0.44** and only referenced the screenshot in the final response — the previous 13 calls were querying the Slack API to enumerate channel members and reconcile them against… nothing, because the poll lives on whenavailable.com, not in Slack.

The screenshot already had the answer. The model just didn't prioritize reading it.

This is a model-specific failure mode: Kimi K2.6 will frequently run discovery tools first and only consult the attachment as a fallback. Models that already read attachments first (e.g. Claude) don't need the nudge — injecting it for them would waste tokens on every attachment turn.

## What this changes

Adds a default plugin `attachment-read-hint` (`assistant/src/plugins/defaults/attachment-read-hint/`) whose `user-prompt-submit` hook appends a short hint to the tail user message:

```
<attached_content_hint>
The user attached one or more images/files in this turn. Read them
carefully before running discovery tools — the attachment often
already contains the answer or the specific context the user is
referring to.
</attached_content_hint>
```

The hook fires only when **both** gates pass:

1. **Model gate** — the turn's resolved model matches Kimi K2.6, under both provider id schemes (Fireworks `kimi-k2p6`, Moonshot `kimi-k2.6`; K2.5 excluded). Same model-quirk precedent as the `suppress-cjk` logit-bias gate in `providers/inference/logit-bias.ts`.
2. **Attachment gate** — the tail user message carries at least one `image` or `file` content block.

To make the model gate possible, `UserPromptSubmitContext` gains an optional `resolvedModel` field, populated at the hook invocation site in `conversation-agent-loop.ts` via the same `resolveCallSiteConfig` resolution (call site + turn override profile + selection seed) the provider layer uses for the turn's first LLM call. This follows the existing precedent of the loop pre-resolving model-derived values for hooks (`maxInputTokens` on `PostToolUseContext`).

## Why a plugin, not the system prompt or runtime assembly

- Per `CLAUDE.md`'s system-prompt-minimalism rule, the system prompt is out.
- A runtime-assembly injection would apply to every model uniformly; the plugin hook is where per-model, per-turn conditional prompt shaping belongs, and it keeps the quirk self-contained (one directory, registered in `defaults/index.ts`).

## Tests

`assistant/src/__tests__/attachment-read-hint-hook.test.ts` (10 tests):
- Model gate: matches K2.6 under both id schemes; rejects K2.5, Claude, and an unresolved model.
- Attachment gate: hint appended for image and file blocks; no-op without attachments, for non-user tails, and for out-of-gate models (referential equality preserved).
- End-to-end through `runHook` + the plugin registry.

`tsc --noEmit` clean; `conversation-runtime-assembly.test.ts`, `history-repair-hook.test.ts`, `external-plugin-loader.test.ts`, `conversation-agent-loop.test.ts` all pass.

## Test plan
- [ ] On a Kimi K2.6 profile, paste a screenshot and ask a question about it — the model reads the image before reaching for tools.
- [ ] On a Claude profile, paste a screenshot — no hint injected, no behavior change.
- [ ] Send a message without attachments on K2.6 — no hint injected.

## Related

- #34294 — companion fix: skill resolver was returning the wrong skill (`slack-app-setup` instead of `slack`) for the same trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)