### PR TITLE
feat(electron): expose launch-at-login through preload bridge and renderer wrapper

### DIFF
--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -41,7 +41,7 @@ import { installHotkeysIpc } from "./hotkeys";
 import { installPopoutWindows } from "./popout-window";
 import { installQuickInput } from "./quick-input-window";
 import { installLocalMode, resolveCliInvocation } from "./local-mode";
-import { installLoginItem } from "./login-item";
+import { installLoginItem, installLoginItemIpc } from "./login-item";
 import { installLockfileWatcher } from "./lockfile-watcher";
 import { installHostProxyBridge } from "./host-proxy-router";
 import "./executors/host-bash-executor"; // side-effect: registers host_bash executor
@@ -323,6 +323,7 @@ app
     installFeatureFlagsIpc();
     installLocalMode();
     installLoginItem();
+    installLoginItemIpc();
     installHotkeyHelper();
     installAbout();
     installAutoUpdate();

--- a/apps/macos/src/main/login-item.ts
+++ b/apps/macos/src/main/login-item.ts
@@ -1,11 +1,27 @@
 import { app } from "electron";
+import { z } from "zod";
 
+import { handle } from "./ipc";
 import { readSetting, onSettingChange, writeSetting } from "./settings";
 
 /** Apply the current `launchAtLogin` preference to the OS login item. */
 export const syncLoginItem = (): void => {
   const value = readSetting("launchAtLogin");
   app.setLoginItemSettings({ openAtLogin: value ?? false });
+};
+
+/**
+ * Install the typed launch-at-login IPC surface: `get` returns the current
+ * boolean, `set` persists it (the existing `onSettingChange` subscription
+ * from `installLoginItem` triggers `syncLoginItem()` in the same tick).
+ */
+export const installLoginItemIpc = (): void => {
+  handle("vellum:launchAtLogin:get", z.tuple([]), () =>
+    readSetting("launchAtLogin") ?? false,
+  );
+  handle("vellum:launchAtLogin:set", z.tuple([z.boolean()]), ([enabled]) => {
+    writeSetting("launchAtLogin", enabled);
+  });
 };
 
 /**

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -321,6 +321,12 @@ export interface VellumBridge {
      */
     onChange(callback: (catalog: ResolvedHotkey[]) => void): () => void;
   };
+  launchAtLogin: {
+    /** Read the current launch-at-login preference. */
+    get(): Promise<boolean>;
+    /** Persist the launch-at-login preference; triggers `syncLoginItem()`. */
+    set(enabled: boolean): Promise<void>;
+  };
   featureFlags: {
     /** Publish the renderer's feature-flag map to main (fire-and-forget). */
     set(flags: Record<string, boolean>): void;
@@ -690,6 +696,12 @@ const bridge: VellumBridge = {
         ipcRenderer.off("vellum:hotkeys:changed", handler);
       };
     },
+  },
+  launchAtLogin: {
+    get: (): Promise<boolean> =>
+      ipcRenderer.invoke("vellum:launchAtLogin:get") as Promise<boolean>,
+    set: (enabled: boolean): Promise<void> =>
+      ipcRenderer.invoke("vellum:launchAtLogin:set", enabled) as Promise<void>,
   },
   featureFlags: {
     set: (flags: Record<string, boolean>): void => {

--- a/apps/web/src/runtime/is-electron.ts
+++ b/apps/web/src/runtime/is-electron.ts
@@ -297,6 +297,11 @@ declare global {
         set(key: string, accelerator: string | null): Promise<void>;
         onChange(callback: (catalog: ResolvedHotkey[]) => void): () => void;
       };
+      // Optional: older Electron shells predate the launch-at-login channel.
+      launchAtLogin?: {
+        get(): Promise<boolean>;
+        set(enabled: boolean): Promise<void>;
+      };
       featureFlags?: {
         set(flags: Record<string, boolean>): void;
       };

--- a/apps/web/src/runtime/launch-at-login.ts
+++ b/apps/web/src/runtime/launch-at-login.ts
@@ -1,0 +1,23 @@
+import { isElectron } from "@/runtime/is-electron";
+
+/**
+ * Runtime wrapper for the Electron launch-at-login bridge
+ * (`window.vellum.launchAtLogin`). Desktop-only; degrades to safe no-ops
+ * on web/iOS and against older preloads that predate the channel.
+ */
+
+/** Read the current launch-at-login preference (defaults to `false` off Electron). */
+export async function getLaunchAtLogin(): Promise<boolean> {
+  if (!isElectron()) return false;
+  const bridge = window.vellum;
+  if (!bridge?.launchAtLogin) return false;
+  return bridge.launchAtLogin.get();
+}
+
+/** Persist the launch-at-login preference (no-op off Electron). */
+export async function setLaunchAtLogin(enabled: boolean): Promise<void> {
+  if (!isElectron()) return;
+  const bridge = window.vellum;
+  if (!bridge?.launchAtLogin) return;
+  await bridge.launchAtLogin.set(enabled);
+}


### PR DESCRIPTION
## Summary
- Add IPC handlers (`vellum:launchAtLogin:get` / `set`) to `login-item.ts`
- Expose `launchAtLogin` capability in the preload bridge
- Add `window.vellum.launchAtLogin` type declaration
- Create `apps/web/src/runtime/launch-at-login.ts` wrapper with platform-safe guards

Part of plan: launch-at-login.md (PR 2 of 3)