### PR TITLE
feat(assistant): add investigator subagent role for root-cause analysis

### DIFF
--- a/assistant/src/__tests__/subagent-role-registry.test.ts
+++ b/assistant/src/__tests__/subagent-role-registry.test.ts
@@ -7,7 +7,13 @@ import {
 } from "../subagent/index.js";
 
 /** All roles defined in the SubagentRole union. */
-const ALL_ROLES: SubagentRole[] = ["general", "researcher", "coder", "planner"];
+const ALL_ROLES: SubagentRole[] = [
+  "general",
+  "researcher",
+  "coder",
+  "planner",
+  "investigator",
+];
 
 describe("SUBAGENT_ROLE_REGISTRY", () => {
   test("covers all values in the SubagentRole union", () => {
@@ -62,6 +68,23 @@ describe("SUBAGENT_ROLE_REGISTRY", () => {
 
   test('planner includes "recall" for local information access', () => {
     expect(SUBAGENT_ROLE_REGISTRY.planner.allowedTools!).toContain("recall");
+  });
+
+  test('investigator includes "bash" for grep/find-based code and log investigation', () => {
+    expect(SUBAGENT_ROLE_REGISTRY.investigator.allowedTools!).toContain("bash");
+  });
+
+  test("investigator excludes file write tools (read-only investigation)", () => {
+    const tools = SUBAGENT_ROLE_REGISTRY.investigator.allowedTools!;
+    expect(tools).not.toContain("file_write");
+    expect(tools).not.toContain("file_edit");
+  });
+
+  test("investigator preamble defines the root-cause report contract", () => {
+    const preamble = SUBAGENT_ROLE_REGISTRY.investigator.systemPromptPreamble;
+    expect(preamble).toContain("Root cause");
+    expect(preamble).toContain("Evidence");
+    expect(preamble).toContain("notify_parent");
   });
 
   test("no role references the old memory_recall tool name", () => {

--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -1325,6 +1325,7 @@ describe("Subagent role-based spawn", () => {
       "researcher",
       "coder",
       "planner",
+      "investigator",
     ]);
     // role is not required
     expect(def.input_schema.required).not.toContain("role");

--- a/assistant/src/config/bundled-skills/subagent/SKILL.md
+++ b/assistant/src/config/bundled-skills/subagent/SKILL.md
@@ -38,6 +38,7 @@ Each subagent is spawned with a role that determines its tool access. Choose the
 | `researcher` | `web_search`, `web_fetch`, `file_read`, `file_list`, `recall`, `notify_parent` | Information gathering, web research, codebase exploration, reading documentation |
 | `coder` | `bash`, `file_read`, `file_write`, `file_edit`, `web_search`, `recall`, `notify_parent` | Code changes, file editing, running commands, build/test tasks |
 | `planner` | `file_read`, `file_list`, `web_search`, `web_fetch`, `recall`, `notify_parent` | Analysis, planning, synthesizing information, reviewing approaches |
+| `investigator` | `bash`, `file_read`, `file_list`, `web_search`, `web_fetch`, `recall`, `notify_parent` | Root-cause analysis: debugging, log forensics, tracing behavior across many files. Shell access is for read-only investigation (grep/find/reading logs); returns a compact root-cause report |
 
 All specialized roles (`researcher`, `coder`, `planner`) include `notify_parent` for mid-run communication with the parent.
 
@@ -96,5 +97,6 @@ Rule of thumb: "Does this task need to know what we've been talking about?" If y
 - Use `subagent_message` to send follow-up instructions to a running subagent.
 - Use `subagent_abort` to cancel a subagent that is no longer needed.
 - Default to spawning subagents for any task that involves web research, multi-file exploration, or independent coding work. Serial execution should be the exception, not the rule.
+- Delegate root-cause investigations ("why is X happening?", debugging, log forensics) to an `investigator` instead of grepping inline. A long investigation done inline floods your own context with file slices and grep output, crowding out the conversation; the investigator does the digging in its own context and returns a compact root-cause report.
 - When a user request has both an information-gathering component and an action component, spawn a researcher immediately rather than doing the research inline yourself.
 - Prefer spawning 2-3 focused subagents over one large general-purpose subagent. Smaller scopes finish faster and fail more gracefully.

--- a/assistant/src/config/bundled-skills/subagent/TOOLS.json
+++ b/assistant/src/config/bundled-skills/subagent/TOOLS.json
@@ -31,8 +31,14 @@
           },
           "role": {
             "type": "string",
-            "enum": ["general", "researcher", "coder", "planner"],
-            "description": "Agent specialization that controls tool access. 'researcher': read-only (web, files, memory). 'coder': file and bash access. 'planner': read-only analysis. 'general': full access (default). Ignored when fork: true (forks always use general)."
+            "enum": [
+              "general",
+              "researcher",
+              "coder",
+              "planner",
+              "investigator"
+            ],
+            "description": "Agent specialization that controls tool access. 'researcher': read-only (web, files, memory). 'coder': file and bash access. 'planner': read-only analysis. 'investigator': root-cause analysis — debugging, log forensics, tracing behavior across many files; has bash for read-only investigation (grep/find/log inspection) and returns a compact root-cause report. 'general': full access (default). Ignored when fork: true (forks always use general)."
           }
         },
         "required": ["label", "objective"]

--- a/assistant/src/subagent/types.ts
+++ b/assistant/src/subagent/types.ts
@@ -105,7 +105,12 @@ export const SUBAGENT_LIMITS = {
 
 // ── Roles ───────────────────────────────────────────────────────────────
 
-export type SubagentRole = "general" | "researcher" | "coder" | "planner";
+export type SubagentRole =
+  | "general"
+  | "researcher"
+  | "coder"
+  | "planner"
+  | "investigator";
 
 export interface SubagentRoleConfig {
   /**
@@ -166,5 +171,25 @@ export const SUBAGENT_ROLE_REGISTRY: Record<SubagentRole, SubagentRoleConfig> =
       skillIds: [],
       systemPromptPreamble:
         "You are an analysis-focused subagent with read-only access. Read files, search the web, and synthesize findings. You cannot write files or run shell commands.",
+    },
+    investigator: {
+      allowedTools: [
+        "bash",
+        "file_read",
+        "file_list",
+        "web_search",
+        "web_fetch",
+        "recall",
+        "notify_parent",
+      ],
+      skillIds: [],
+      systemPromptPreamble: [
+        "You are an investigation-focused subagent for root-cause analysis: debugging, log forensics, and tracing behavior across code.",
+        "Your shell access is for read-only investigation (grep, find, reading files and logs) — do not modify files or system state.",
+        "Working method: read whole files instead of many small line-range slices; prefer broad searches (e.g. grep -rn across a directory) over one-symbol-at-a-time queries.",
+        "Send notify_parent (urgency 'important') as soon as each finding is confirmed, so progress survives interruption.",
+        "Your final message must be a compact root-cause report with these sections: Symptom, Root cause, Evidence (file:line references), Suggested fix, Open questions.",
+        "If you approach context limits, stop investigating and produce the report from what you have — a partial report delivered is worth more than a complete investigation lost.",
+      ].join(" "),
     },
   };


### PR DESCRIPTION
## Context

We're dogfooding the assistant as a bug-triage tool: after two failed voice-call tests, the user asked the assistant to root-cause an "empty assistant turns" bug from its own logs and code. The assistant ran the entire investigation **inline** — 376 bash calls (70% grep, 30% sed line-slices) across three turns, overflowed its own conversation context before producing any writeup, failed mid-turn compaction, and forced the user into a "Continue?" loop where each continuation re-explored 11+ files it had already read.

The fix direction (this is PR 1 of 2): delegate long investigations to a subagent with its own disposable context window, which returns a compact report to the parent conversation. PR 2 adds a drift nudge in the agent loop that suggests this delegation when a turn accumulates many exploration calls without replying to the user.

## Why a new role

The infrastructure already exists (`SubagentManager`, role-scoped tools, `notify_parent`, preactivated `subagent` skill) — but no existing role fits read-only code/log forensics:

- `researcher` / `planner` have **no `bash`** — they literally cannot grep a codebase.
- `coder` has bash but also `file_write`/`file_edit`, and its description steers it toward making changes.

## Changes

- **`assistant/src/subagent/types.ts`** — add `investigator` to `SubagentRole` and `SUBAGENT_ROLE_REGISTRY`: `bash`, `file_read`, `file_list`, `web_search`, `web_fetch`, `recall`, `notify_parent`. The preamble encodes the lessons from the incident: whole-file reads over line slices, `notify_parent` checkpoints per confirmed finding (so progress survives interruption), a mandatory compact root-cause report shape (Symptom / Root cause / Evidence file:line / Suggested fix / Open questions), and "emit a partial report before overflowing".
- **`bundled-skills/subagent/TOOLS.json`** — `role` enum + description gain `investigator` with explicit trigger language (root-cause analysis, debugging, log forensics).
- **`bundled-skills/subagent/SKILL.md`** — role table row + a tip telling the model to delegate "why is X happening?" investigations instead of grepping inline.
- **Tests** — `subagent-role-registry.test.ts` and `subagent-tools.test.ts` updated; new assertions for bash access, no write tools, and the report contract.

## Notes for review

- `bash` in a "read-only" role is intent-scoping, not a security boundary — the parent conversation has full bash anyway, and the manager's role filter is about blast-radius. Flagging in case you want hard enforcement instead.
- No backend validation changes needed: `SubagentManager.spawn` already validates roles against the registry.

## Test plan

- [x] `bun test src/__tests__/subagent-role-registry.test.ts src/__tests__/subagent-tools.test.ts` (85 pass)
- [x] `bunx tsc --noEmit` clean
- [ ] Dogfood: ask the assistant to root-cause a real bug and confirm it spawns an investigator instead of grepping inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)