### PR TITLE
fix(daemon): method-aware host_browser routing — stop tab commands racing onto the macOS bridge

### DIFF
--- a/assistant/src/__tests__/host-browser-proxy.test.ts
+++ b/assistant/src/__tests__/host-browser-proxy.test.ts
@@ -493,11 +493,12 @@ describe("HostBrowserProxy", () => {
       expect(getPublishedMessages()).toHaveLength(0);
     });
 
-    test("picks the most-recently-active same-actor client among multiple transports", async () => {
+    test("prefers the chrome-extension client over a more-recently-active macOS bridge", async () => {
       // Mock `listClientsByCapability` returns mockClients in array
       // order, which mirrors production's `lastActiveAt`-desc ordering.
-      // The first same-actor entry wins regardless of transport; LLMs
-      // pin a specific transport via `target_client_id`.
+      // The macOS bridge is listed first (most recent heartbeat), but
+      // chrome-extension clients are deterministically preferred for
+      // auto-resolution; LLMs pin the bridge via `target_client_id`.
       mockClients = [
         {
           clientId: "macos-client",
@@ -525,7 +526,7 @@ describe("HostBrowserProxy", () => {
       const requestId = sent.requestId as string;
 
       const pending = pendingInteractions.get(requestId);
-      expect(pending?.targetClientId).toBe("macos-client");
+      expect(pending?.targetClientId).toBe("ext-client");
 
       resolveResult(requestId, { content: "ok", isError: false });
       await resultPromise;
@@ -739,7 +740,7 @@ describe("HostBrowserProxy", () => {
       expect(getPublishedMessages()).toHaveLength(0);
     });
 
-    test("no targetClientId auto-resolves to the most-recently-active same-actor client", async () => {
+    test("no targetClientId auto-resolves with extension preferred over the bridge", async () => {
       mockClients = [
         {
           clientId: "macos-client",
@@ -755,9 +756,9 @@ describe("HostBrowserProxy", () => {
         },
       ];
 
-      // No targetClientId — falls through to the first same-actor
-      // entry by lastActiveAt-desc. Mock array order is the proxy's
-      // input contract.
+      // No targetClientId — auto-resolution partitions chrome-extension
+      // clients ahead of other transports, then picks the first
+      // same-actor entry (lastActiveAt-desc within each group).
       const resultPromise = proxy.request(
         { cdpMethod: "Page.navigate", cdpParams: { url: "https://a.test" } },
         "session-1",
@@ -769,9 +770,204 @@ describe("HostBrowserProxy", () => {
       const requestId = (getPublishedMessages()[0] as Record<string, unknown>)
         .requestId as string;
       const pending = pendingInteractions.get(requestId);
-      expect(pending?.targetClientId).toBe("macos-client");
+      expect(pending?.targetClientId).toBe("ext-client");
 
       resolveResult(requestId, { content: "ok", isError: false });
+      await resultPromise;
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Method-aware routing
+  //
+  // `Vellum.*` pseudo-methods are implemented only by the Chrome
+  // extension dispatcher; the macOS bridge speaks raw CDP against
+  // localhost:9222 and fails on all of them. Auto-resolution therefore
+  // restricts pseudo-methods to chrome-extension clients and prefers
+  // the extension over the bridge for raw CDP, instead of racing on
+  // heartbeat-driven lastActiveAt ordering.
+  // ---------------------------------------------------------------------------
+
+  describe("method-aware routing", () => {
+    const MACOS_CLIENT: MockClient = {
+      clientId: "macos-client",
+      interfaceId: "macos",
+      actorPrincipalId: "user-1",
+      capabilities: ["host_browser"],
+    };
+    const EXT_CLIENT: MockClient = {
+      clientId: "ext-client",
+      interfaceId: "chrome-extension",
+      actorPrincipalId: "user-1",
+      capabilities: ["host_browser"],
+    };
+
+    function expectExtensionRequired(result: {
+      content: string;
+      isError: boolean;
+    }): void {
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse(result.content) as {
+        code: string;
+        message: string;
+      };
+      expect(parsed.code).toBe("extension_required");
+      expect(parsed.message).toContain("Chrome extension");
+    }
+
+    test("pseudo-method routes to the extension even when the bridge is more recently active", async () => {
+      mockClients = [MACOS_CLIENT, EXT_CLIENT];
+
+      const resultPromise = proxy.request(
+        { cdpMethod: "Vellum.listTabs", cdpParams: {} },
+        "session-1",
+        undefined,
+        "user-1",
+      );
+
+      expect(getPublishedMessages()).toHaveLength(1);
+      const requestId = (getPublishedMessages()[0] as Record<string, unknown>)
+        .requestId as string;
+      expect(pendingInteractions.get(requestId)?.targetClientId).toBe(
+        "ext-client",
+      );
+
+      resolveResult(requestId, { content: '{"tabs":[]}', isError: false });
+      await resultPromise;
+    });
+
+    test("pseudo-method with only the macOS bridge connected resolves extension_required without broadcasting", async () => {
+      mockClients = [MACOS_CLIENT];
+
+      const result = await proxy.request(
+        { cdpMethod: "Vellum.selectTab", cdpParams: { tabId: 42 } },
+        "session-1",
+        undefined,
+        "user-1",
+      );
+
+      expectExtensionRequired(result);
+      expect(getPublishedMessages()).toHaveLength(0);
+    });
+
+    test("pseudo-method with no clients resolves extension_required instead of the legacy rejection", async () => {
+      mockClients = [];
+
+      const result = await proxy.request(
+        { cdpMethod: "Vellum.createTab", cdpParams: {} },
+        "session-1",
+      );
+
+      expectExtensionRequired(result);
+      expect(getPublishedMessages()).toHaveLength(0);
+    });
+
+    test("explicit targetClientId at the macOS bridge + pseudo-method resolves extension_required naming the interface", async () => {
+      mockClients = [MACOS_CLIENT, EXT_CLIENT];
+
+      const result = await proxy.request(
+        { cdpMethod: "Vellum.closeTab", cdpParams: { tabId: 7 } },
+        "session-1",
+        undefined,
+        "user-1",
+        "macos-client",
+      );
+
+      expectExtensionRequired(result);
+      const parsed = JSON.parse(result.content) as { message: string };
+      expect(parsed.message).toContain('"macos"');
+      expect(getPublishedMessages()).toHaveLength(0);
+    });
+
+    test("explicit targetClientId at the extension + pseudo-method dispatches normally", async () => {
+      mockClients = [MACOS_CLIENT, EXT_CLIENT];
+
+      const resultPromise = proxy.request(
+        { cdpMethod: "Vellum.closeTab", cdpParams: { tabId: 7 } },
+        "session-1",
+        undefined,
+        "user-1",
+        "ext-client",
+      );
+
+      expect(getPublishedMessages()).toHaveLength(1);
+      const requestId = (getPublishedMessages()[0] as Record<string, unknown>)
+        .requestId as string;
+      expect(pendingInteractions.get(requestId)?.targetClientId).toBe(
+        "ext-client",
+      );
+
+      resolveResult(requestId, {
+        content: '{"closed":true,"tabId":7}',
+        isError: false,
+      });
+      await resultPromise;
+    });
+
+    test("same-actor gate wins over the pseudo-method check for cross-actor explicit targets", async () => {
+      mockClients = [
+        {
+          clientId: "other-user-ext",
+          interfaceId: "chrome-extension",
+          actorPrincipalId: "user-2",
+          capabilities: ["host_browser"],
+        },
+      ];
+
+      const result = await proxy.request(
+        { cdpMethod: "Vellum.listTabs", cdpParams: {} },
+        "session-1",
+        undefined,
+        "user-1",
+        "other-user-ext",
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("Submitting actor does not match");
+      expect(result.content).not.toContain("extension_required");
+      expect(getPublishedMessages()).toHaveLength(0);
+    });
+
+    test("pseudo-method where the only extension belongs to another actor resolves extension_required", async () => {
+      mockClients = [
+        {
+          clientId: "other-user-ext",
+          interfaceId: "chrome-extension",
+          actorPrincipalId: "user-2",
+          capabilities: ["host_browser"],
+        },
+        MACOS_CLIENT,
+      ];
+
+      const result = await proxy.request(
+        { cdpMethod: "Vellum.listTabs", cdpParams: {} },
+        "session-1",
+        undefined,
+        "user-1",
+      );
+
+      expectExtensionRequired(result);
+      expect(getPublishedMessages()).toHaveLength(0);
+    });
+
+    test("raw CDP with only the bridge connected still routes to the bridge", async () => {
+      mockClients = [MACOS_CLIENT];
+
+      const resultPromise = proxy.request(
+        { cdpMethod: "Page.captureScreenshot", cdpParams: {} },
+        "session-1",
+        undefined,
+        "user-1",
+      );
+
+      expect(getPublishedMessages()).toHaveLength(1);
+      const requestId = (getPublishedMessages()[0] as Record<string, unknown>)
+        .requestId as string;
+      expect(pendingInteractions.get(requestId)?.targetClientId).toBe(
+        "macos-client",
+      );
+
+      resolveResult(requestId, { content: '{"data":"..."}', isError: false });
       await resultPromise;
     });
   });

--- a/assistant/src/daemon/host-browser-proxy.ts
+++ b/assistant/src/daemon/host-browser-proxy.ts
@@ -25,6 +25,46 @@ export type HostBrowserInput = DistributiveOmit<
 const log = getLogger("host-browser-proxy");
 
 /**
+ * Extension-only pseudo-CDP methods (Vellum.listTabs, Vellum.selectTab,
+ * Vellum.closeTab, Vellum.createTab, Vellum.findTab, Vellum.attach,
+ * Vellum.detach) are implemented solely by the Chrome extension's
+ * dispatcher via the chrome.tabs / chrome.debugger APIs. The macOS CDP
+ * bridge speaks raw CDP against localhost:9222 only and fails on every
+ * `Vellum.*` method, so routing them anywhere but the extension is a
+ * guaranteed failure. Prefix check rather than an allowlist so newly
+ * added pseudo-methods stay covered.
+ */
+function isExtensionOnlyMethod(cdpMethod: string): boolean {
+  return cdpMethod.startsWith("Vellum.");
+}
+
+/**
+ * Structured isError result for pseudo-methods that cannot be served
+ * because no Chrome Extension client is connected (or the explicit
+ * target is a different transport). The `extension_required` code is
+ * deliberately NOT in ExtensionCdpClient's TRANSPORT_ERROR_CODES: it
+ * classifies as `cdp_error` so the factory does not fail over to a
+ * backend that cannot serve `Vellum.*` either, and the message is
+ * surfaced verbatim to the caller.
+ */
+function extensionRequiredResult(
+  cdpMethod: string,
+  targetInterfaceId?: string,
+): ToolExecutionResult {
+  return {
+    content: JSON.stringify({
+      code: "extension_required",
+      message:
+        `${cdpMethod} requires the Chrome extension; ` +
+        (targetInterfaceId
+          ? `the targeted client (interface "${targetInterfaceId}") cannot handle it.`
+          : "no Chrome extension client is connected."),
+    }),
+    isError: true,
+  };
+}
+
+/**
  * Pick the host_browser-capable client to dispatch to.
  *
  * When `targetClientId` is supplied, the client with that id is looked
@@ -32,24 +72,27 @@ const log = getLogger("host-browser-proxy");
  * in `request()` still runs on the returned client when
  * `sourceActorPrincipalId` is present.
  *
+ * Candidate ordering is method-aware and deterministic. Both the Chrome
+ * extension and the macOS desktop bridge register the `host_browser`
+ * capability, and both receive periodic heartbeats that update
+ * `lastActiveAt` — so pure recency ordering is a race between transports
+ * with very different capabilities:
+ *
+ *  - `Vellum.*` pseudo-methods: candidates are restricted to
+ *    chrome-extension clients (the only transport that implements them).
+ *  - Raw CDP methods: chrome-extension clients are preferred over other
+ *    host_browser clients (the macOS bridge), with `lastActiveAt`
+ *    descending within each group — the natural order returned by
+ *    `listClientsByCapability`. Callers that want the bridge despite a
+ *    connected extension must pass `targetClientId` explicitly via the
+ *    LLM-facing param added in #30066.
+ *
  * When `sourceActorPrincipalId` is supplied (and no explicit target),
  * candidate clients are filtered down to those owned by the same actor.
- * Returns `undefined` when no same-actor client is connected; the
- * caller surfaces this as the existing "no active extension connection"
- * rejection.
- *
- * When neither is supplied (legacy callers without a resolved actor
- * identity), falls through to the most-recently-active host_browser
- * client so the registry singleton continues to work for single-client
- * setups.
- *
- * Within each branch, ties are broken by `lastActiveAt` descending —
- * the natural order returned by `listClientsByCapability`. Callers that
- * need a specific transport (e.g. Chrome Extension's `chrome.debugger`
- * over the macOS CDP bridge) must pass `targetClientId` explicitly via
- * the LLM-facing param added in #30066.
+ * Returns `undefined` when no eligible client is connected.
  */
 function resolveTargetClient(
+  cdpMethod: string,
   sourceActorPrincipalId: string | undefined,
   targetClientId?: string,
 ) {
@@ -58,8 +101,12 @@ function resolveTargetClient(
     return clients.find((c) => c.clientId === targetClientId);
   }
 
-  const candidates =
-    assistantEventHub.listClientsByCapability("host_browser");
+  const all = assistantEventHub.listClientsByCapability("host_browser");
+  const extension = all.filter((c) => c.interfaceId === "chrome-extension");
+  const candidates = isExtensionOnlyMethod(cdpMethod)
+    ? extension
+    : [...extension, ...all.filter((c) => c.interfaceId !== "chrome-extension")];
+
   if (sourceActorPrincipalId == null) {
     return candidates[0];
   }
@@ -155,7 +202,11 @@ export class HostBrowserProxy {
     // alongside the pending interaction registration. Same shape as
     // host-cu-proxy: the result-route same-actor check compares the
     // submitting client's actor against this captured value.
-    const preferredClient = resolveTargetClient(sourceActorPrincipalId, targetClientId);
+    const preferredClient = resolveTargetClient(
+      input.cdpMethod,
+      sourceActorPrincipalId,
+      targetClientId,
+    );
 
     // Same-user enforcement: when the caller's actor is known, refuse to
     // dispatch to a client owned by a different actor. This covers the
@@ -173,6 +224,20 @@ export class HostBrowserProxy {
         op: "host_browser",
       });
       if (rejection) return Promise.resolve(rejection);
+    }
+
+    // Pseudo-methods can only be served by the Chrome extension. Fail fast
+    // (after the same-actor gate, which stays authoritative) instead of
+    // dispatching to a transport that is guaranteed to fail — the factory's
+    // pinned-extension gate is the first line of defense; this covers
+    // heartbeat races and bridge-routed auto-mode sends.
+    if (
+      isExtensionOnlyMethod(input.cdpMethod) &&
+      preferredClient?.interfaceId !== "chrome-extension"
+    ) {
+      return Promise.resolve(
+        extensionRequiredResult(input.cdpMethod, preferredClient?.interfaceId),
+      );
     }
 
     const resolvedClientId = preferredClient?.clientId;


### PR DESCRIPTION
## Summary
- `HostBrowserProxy.resolveTargetClient()` is now method-aware: `Vellum.*` pseudo-methods (listTabs/selectTab/closeTab/createTab/findTab/attach/detach) are restricted to chrome-extension clients — the only transport that implements them — and raw CDP methods deterministically prefer the extension over the macOS bridge (lastActiveAt order preserved within each group).
- Pseudo-methods with no eligible extension client (none connected, wrong actor, or an explicit `targetClientId` pointing at a non-extension transport) fail fast with a structured `{code: "extension_required"}` isError result. The code is deliberately not in `TRANSPORT_ERROR_CODES`, so it classifies as `cdp_error` and the CDP factory does not fail over to backends that can't serve `Vellum.*` either.
- Same-actor enforcement is unchanged and still runs before the new checks.

Fixes the intermittent `CdpError: HTTP 404 from http://localhost:9222/json/list` on `assistant browser tabs select`: both the Chrome extension and the macOS desktop app register the `host_browser` capability and both get 7s SSE heartbeats, so pure recency ordering raced between transports. When the race picked the bridge — which only speaks raw CDP against localhost:9222 — tab pseudo-methods were guaranteed to fail.

## Original prompt
Root-cause investigation of a bug report (`bug-report-tab-switch-cdp-404.md`) found that `tabs select` intermittently 404s because HostBrowserProxy resolves its target client by capability + heartbeat recency, racing between the Chrome extension and the macOS bridge. This PR is the first of two planned changes: make routing deterministic and method-aware (this PR), then add a first-class `host-bridge` factory candidate so cloud daemons can deliberately drive the user's Chrome via the bridge (follow-up PR). The user explicitly wants the bridge functionality preserved for cloud daemons — hence raw CDP still falls back to the bridge when no extension is connected, and only the deterministic preference/restriction changes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)