### PR TITLE
fix(skills): prefer exact-id catalog skill over local prefix match in skill_load

### DIFF
--- a/assistant/src/__tests__/skill-load-tool.test.ts
+++ b/assistant/src/__tests__/skill-load-tool.test.ts
@@ -911,4 +911,74 @@ describe("skill_load tool", () => {
     expect(result.content).toContain("Suggested Included Skills (not loaded):");
     expect(installCount).toBeLessThanOrEqual(5);
   });
+
+  test("prefers exact-id catalog skill over local prefix match", async () => {
+    // Only "zmail-app-setup" is installed locally; the selector "zmail"
+    // prefix-matches it, but the catalog carries an exact-id "zmail" skill.
+    writeSkill(
+      "zmail-app-setup",
+      "Zmail App Setup",
+      "Connect Zmail",
+      "Setup body",
+    );
+    mockAutoInstall.mockImplementation((skillId: string) => {
+      if (skillId === "zmail") {
+        writeSkill("zmail", "Zmail", "Use Zmail", "Usage body");
+        return Promise.resolve(true);
+      }
+      return Promise.resolve(false);
+    });
+
+    const result = await executeSkillLoad({ skill: "zmail" });
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Skill: Zmail");
+    expect(result.content).toContain("Usage body");
+    expect(result.content).toContain('<loaded_skill id="zmail"');
+    expect(result.content).not.toContain("Setup body");
+    expect(mockAutoInstall).toHaveBeenCalledWith("zmail");
+  });
+
+  test("keeps prefix match when catalog has no exact-id skill", async () => {
+    writeSkill(
+      "zcal-app-setup",
+      "Zcal App Setup",
+      "Connect Zcal",
+      "Setup body",
+    );
+
+    const result = await executeSkillLoad({ skill: "zcal" });
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Skill: Zcal App Setup");
+    expect(result.content).toContain('<loaded_skill id="zcal-app-setup"');
+    expect(mockAutoInstall).toHaveBeenCalledWith("zcal");
+  });
+
+  test("keeps prefix match when exact-id catalog install fails", async () => {
+    writeSkill(
+      "zdoc-app-setup",
+      "Zdoc App Setup",
+      "Connect Zdoc",
+      "Setup body",
+    );
+    mockAutoInstall.mockImplementation((skillId: string) => {
+      if (skillId === "zdoc") {
+        return Promise.reject(new Error("Network error"));
+      }
+      return Promise.resolve(false);
+    });
+
+    const result = await executeSkillLoad({ skill: "zdoc" });
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Skill: Zdoc App Setup");
+    expect(result.content).toContain('<loaded_skill id="zdoc-app-setup"');
+  });
+
+  test("does not consult the catalog for exact-id matches", async () => {
+    writeSkill("zchat", "Zchat", "Use Zchat", "Usage body");
+
+    const result = await executeSkillLoad({ skill: "zchat" });
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Skill: Zchat");
+    expect(mockAutoInstall).not.toHaveBeenCalled();
+  });
 });

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -121,14 +121,23 @@ export type SkillLookupErrorCode =
   | "invalid_selector"
   | "load_failed";
 
+/**
+ * How a selector resolved to a skill. `id_prefix` means no installed skill
+ * matched the selector exactly — callers that can install from the catalog
+ * should prefer an exact-id catalog skill over a prefix match.
+ */
+export type SkillSelectorMatchKind = "exact_id" | "exact_name" | "id_prefix";
+
 export interface SkillLookupResult {
   skill?: SkillDefinition;
+  matchKind?: SkillSelectorMatchKind;
   error?: string;
   errorCode?: SkillLookupErrorCode;
 }
 
 export interface SkillSelectorResult {
   skill?: SkillSummary;
+  matchKind?: SkillSelectorMatchKind;
   error?: string;
   errorCode?: SkillLookupErrorCode;
 }
@@ -1145,7 +1154,7 @@ export function resolveSkillSelector(
 
   const exactIdMatch = catalog.find((skill) => skill.id === needle);
   if (exactIdMatch) {
-    return { skill: exactIdMatch };
+    return { skill: exactIdMatch, matchKind: "exact_id" };
   }
 
   const exactNameMatches = catalog.filter(
@@ -1154,7 +1163,7 @@ export function resolveSkillSelector(
       skill.displayName.toLowerCase() === needle.toLowerCase(),
   );
   if (exactNameMatches.length === 1) {
-    return { skill: exactNameMatches[0] };
+    return { skill: exactNameMatches[0], matchKind: "exact_name" };
   }
   if (exactNameMatches.length > 1) {
     const ids = exactNameMatches.map((skill) => skill.id).join(", ");
@@ -1168,7 +1177,7 @@ export function resolveSkillSelector(
     skill.id.startsWith(needle),
   );
   if (idPrefixMatches.length === 1) {
-    return { skill: idPrefixMatches[0] };
+    return { skill: idPrefixMatches[0], matchKind: "id_prefix" };
   }
   if (idPrefixMatches.length > 1) {
     const ids = idPrefixMatches.map((skill) => skill.id).join(", ");
@@ -1196,7 +1205,10 @@ export function loadSkillBySelector(
       errorCode: resolved.errorCode ?? "load_failed",
     };
   }
-  return loadSkillDefinition(resolved.skill);
+  return {
+    ...loadSkillDefinition(resolved.skill),
+    matchKind: resolved.matchKind,
+  };
 }
 
 // ─── Icon generation ─────────────────────────────────────────────────────────

--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -161,6 +161,35 @@ export const skillLoadTool = {
 
     let loaded = loadSkillBySelector(selector);
 
+    // A prefix match means no installed skill matched the selector exactly,
+    // but the catalog may carry an exact-id skill that the local prefix match
+    // shadows (e.g. selector "slack" prefix-matching an installed
+    // "slack-app-setup" while the catalog's "slack" skill is what was asked
+    // for). Prefer the exact catalog skill; keep the prefix match if the
+    // catalog has no exact id or the install fails.
+    if (loaded.skill && loaded.matchKind === "id_prefix") {
+      const exactId = selector.trim();
+      const prefixMatchedId = loaded.skill.id;
+      try {
+        const installed = await autoInstallFromCatalog(exactId);
+        if (installed) {
+          const exact = loadSkillBySelector(exactId);
+          if (exact.skill && exact.matchKind === "exact_id") {
+            log.info(
+              { skillId: exact.skill.id, prefixMatchedId },
+              "Preferred exact-id catalog skill over local prefix match",
+            );
+            loaded = exact;
+          }
+        }
+      } catch (err) {
+        log.warn(
+          { err, skillId: exactId, prefixMatchedId },
+          "Exact-id catalog install failed; keeping prefix match",
+        );
+      }
+    }
+
     // Auto-install from catalog if the skill isn't found locally
     if (
       !loaded.skill &&


### PR DESCRIPTION
## Problem

`skill_load` resolves selectors via `resolveSkillSelector`, which falls back to **unique id-prefix matching** when no installed skill matches exactly. When the selector exactly names a skill that exists in the catalog but is not installed locally, the prefix match "succeeds" and the `not_found` → `autoInstallFromCatalog` path never runs — the skill the model asked for is silently shadowed by a different skill.

Real-world case from production traces: `skill_load({skill: "slack"})` in a workspace with only `slack-app-setup` installed loads the *setup* skill instead of installing the `slack` *usage* skill from the catalog. The model then has to rediscover Slack query patterns (credential fields, API call shape) through trial and error — frontier models recover in a turn, weaker models burn several.

## Fix

- `resolveSkillSelector` now reports how it matched: `exact_id`, `exact_name`, or `id_prefix` (additive field on `SkillSelectorResult` / `SkillLookupResult`).
- `skill_load` attempts an exact-id catalog install **before** accepting a prefix match. If the catalog has an exact-id skill, it is installed and loaded; otherwise (no catalog entry, or install failure) the prefix match is kept, so existing prefix-loading behavior is unchanged.

`autoInstallFromCatalog` already matches catalog ids exactly and reuses on-disk skills, so the new path is idempotent and adds no network call for exact-id/exact-name resolutions.

## Tests

- `skill-load-tool.test.ts`: exact-id catalog skill preferred over prefix match; prefix match kept when catalog lacks the id; prefix match kept when install throws; no catalog consult for exact-id matches.
- Existing 35 skill_load tests, `skills.test.ts` (41), and `permissions/checker.test.ts` (31) pass; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)