### PR TITLE
feat(assistant): nudge summary + investigator delegation on exploration drift

### DIFF
--- a/assistant/src/__tests__/exploration-drift-hook.test.ts
+++ b/assistant/src/__tests__/exploration-drift-hook.test.ts
@@ -1,0 +1,364 @@
+/**
+ * Tests for the default `exploration-drift` plugin's `post-tool-use` hook.
+ *
+ * Covers:
+ * - The hook surfaces the canonical nudge via `additionalContext` (leaving the
+ *   tool result's `content` untouched) once a turn accumulates an unbroken
+ *   threshold-length run of exploration tool calls, and stays silent below it.
+ * - The streak is bounded by a real user message, a non-empty assistant text
+ *   block, and a non-exploration tool result.
+ * - Repeat nudges are spaced one full threshold apart per conversation.
+ * - Subagent conversations are exempt.
+ * - The nudge appends to (not overwrites) `additionalContext` set by an
+ *   earlier hook in the chain (e.g. tool-error coaching).
+ * - End-to-end through `runHook` + the registry.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Mock the subagent manager before importing the hook — the hook lazily
+// imports it on the nudge path to exempt subagent conversations.
+let mockParentInfo: (conversationId: string) => unknown = () => undefined;
+mock.module("../subagent/index.js", () => ({
+  getSubagentManager: () => ({
+    getParentInfo: (conversationId: string) => mockParentInfo(conversationId),
+  }),
+}));
+
+import { HOOKS } from "../plugin-api/constants.js";
+import type { PluginLogger, PostToolUseContext } from "../plugin-api/types.js";
+import postToolUse, {
+  EXPLORATION_DRIFT_NUDGE_TEXT,
+  EXPLORATION_NUDGE_THRESHOLD,
+  resetExplorationDriftStateForTests,
+} from "../plugins/defaults/exploration-drift/hooks/post-tool-use.js";
+import { defaultExplorationDriftPlugin } from "../plugins/defaults/index.js";
+import { runHook } from "../plugins/pipeline.js";
+import {
+  registerPlugin,
+  resetPluginRegistryForTests,
+} from "../plugins/registry.js";
+import type { Message, ToolResultContent } from "../providers/types.js";
+
+const noopLogger: PluginLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+};
+
+const BASE_CONTENT = "grep output";
+
+let conversationCounter = 0;
+/** Unique conversation id per test so the per-conversation state can't leak. */
+function freshConversationId(): string {
+  conversationCounter++;
+  return `conv-drift-test-${conversationCounter}`;
+}
+
+/** Assistant turn issuing a single `tool_use` block. */
+function toolUseTurn(id: string, name: string): Message {
+  return {
+    role: "assistant",
+    content: [{ type: "tool_use", id, name, input: {} }],
+  };
+}
+
+/** User turn carrying a single `tool_result` for a prior `tool_use`. */
+function toolResultTurn(toolUseId: string): Message {
+  return {
+    role: "user",
+    content: [
+      {
+        type: "tool_result",
+        tool_use_id: toolUseId,
+        content: "result",
+        is_error: false,
+      },
+    ],
+  };
+}
+
+function currentResponse(toolUseId: string): ToolResultContent {
+  return {
+    type: "tool_result",
+    tool_use_id: toolUseId,
+    content: BASE_CONTENT,
+    is_error: false,
+  };
+}
+
+function makeCtx(
+  conversationId: string,
+  toolResponse: ToolResultContent,
+  messages: Message[],
+): PostToolUseContext {
+  return {
+    conversationId,
+    toolResponse,
+    messages,
+    additionalContext: null,
+    maxInputTokens: 10_000,
+    logger: noopLogger,
+  };
+}
+
+/**
+ * Build a history of `priorCalls` completed exploration tool calls of
+ * `toolName`, followed by the current turn's `tool_use` (whose result is
+ * delivered via `ctx.toolResponse`, not history).
+ */
+function explorationHistory(
+  priorCalls: number,
+  toolName = "bash",
+): { messages: Message[]; currentToolUseId: string } {
+  const messages: Message[] = [
+    { role: "user", content: [{ type: "text", text: "investigate the bug" }] },
+  ];
+  for (let i = 0; i < priorCalls; i++) {
+    const id = `${toolName}-${i}`;
+    messages.push(toolUseTurn(id, toolName));
+    messages.push(toolResultTurn(id));
+  }
+  const currentToolUseId = `${toolName}-current`;
+  messages.push(toolUseTurn(currentToolUseId, toolName));
+  return { messages, currentToolUseId };
+}
+
+beforeEach(() => {
+  resetExplorationDriftStateForTests();
+  mockParentInfo = () => undefined;
+});
+
+describe("exploration-drift post-tool-use hook — direct", () => {
+  test("stays silent below the threshold", async () => {
+    const { messages, currentToolUseId } = explorationHistory(
+      EXPLORATION_NUDGE_THRESHOLD - 2,
+    );
+    const ctx = makeCtx(
+      freshConversationId(),
+      currentResponse(currentToolUseId),
+      messages,
+    );
+
+    await postToolUse(ctx);
+
+    expect(ctx.additionalContext).toBeNull();
+    expect(ctx.toolResponse.content).toBe(BASE_CONTENT);
+  });
+
+  test("nudges once the streak reaches the threshold, leaving the result untouched", async () => {
+    const { messages, currentToolUseId } = explorationHistory(
+      EXPLORATION_NUDGE_THRESHOLD - 1,
+    );
+    const ctx = makeCtx(
+      freshConversationId(),
+      currentResponse(currentToolUseId),
+      messages,
+    );
+
+    await postToolUse(ctx);
+
+    expect(ctx.additionalContext).toBe(EXPLORATION_DRIFT_NUDGE_TEXT);
+    expect(ctx.toolResponse.content).toBe(BASE_CONTENT);
+  });
+
+  test("counts file_read and file_list as exploration tools", async () => {
+    const messages: Message[] = [];
+    for (let i = 0; i < EXPLORATION_NUDGE_THRESHOLD - 1; i++) {
+      const name = i % 2 === 0 ? "file_read" : "file_list";
+      const id = `${name}-${i}`;
+      messages.push(toolUseTurn(id, name));
+      messages.push(toolResultTurn(id));
+    }
+    messages.push(toolUseTurn("bash-current", "bash"));
+    const ctx = makeCtx(
+      freshConversationId(),
+      currentResponse("bash-current"),
+      messages,
+    );
+
+    await postToolUse(ctx);
+
+    expect(ctx.additionalContext).toBe(EXPLORATION_DRIFT_NUDGE_TEXT);
+  });
+
+  test("a non-empty assistant text block resets the streak", async () => {
+    // GIVEN a long run interrupted by the model speaking to the user, with
+    // fewer than threshold calls after the text.
+    const { messages, currentToolUseId } = explorationHistory(
+      EXPLORATION_NUDGE_THRESHOLD - 1,
+    );
+    messages.splice(messages.length - 1, 0, {
+      role: "assistant",
+      content: [{ type: "text", text: "Here is what I found so far…" }],
+    });
+    const ctx = makeCtx(
+      freshConversationId(),
+      currentResponse(currentToolUseId),
+      messages,
+    );
+
+    await postToolUse(ctx);
+
+    expect(ctx.additionalContext).toBeNull();
+  });
+
+  test("a non-exploration tool result breaks the streak", async () => {
+    const { messages, currentToolUseId } = explorationHistory(
+      EXPLORATION_NUDGE_THRESHOLD - 1,
+    );
+    // Replace the second-to-last completed call with a write tool.
+    messages.splice(
+      messages.length - 1,
+      0,
+      toolUseTurn("write-1", "file_write"),
+      toolResultTurn("write-1"),
+    );
+    const ctx = makeCtx(
+      freshConversationId(),
+      currentResponse(currentToolUseId),
+      messages,
+    );
+
+    await postToolUse(ctx);
+
+    expect(ctx.additionalContext).toBeNull();
+  });
+
+  test("is a no-op when the current tool is not an exploration tool", async () => {
+    const { messages } = explorationHistory(EXPLORATION_NUDGE_THRESHOLD * 2);
+    messages.push(toolUseTurn("write-current", "file_write"));
+    const ctx = makeCtx(
+      freshConversationId(),
+      currentResponse("write-current"),
+      messages,
+    );
+
+    await postToolUse(ctx);
+
+    expect(ctx.additionalContext).toBeNull();
+  });
+
+  test("repeat nudges are spaced one full threshold apart", async () => {
+    const conversationId = freshConversationId();
+
+    // First nudge at the threshold.
+    const first = explorationHistory(EXPLORATION_NUDGE_THRESHOLD - 1);
+    const firstCtx = makeCtx(
+      conversationId,
+      currentResponse(first.currentToolUseId),
+      first.messages,
+    );
+    await postToolUse(firstCtx);
+    expect(firstCtx.additionalContext).toBe(EXPLORATION_DRIFT_NUDGE_TEXT);
+
+    // One more call right after — silent.
+    const next = explorationHistory(EXPLORATION_NUDGE_THRESHOLD);
+    const nextCtx = makeCtx(
+      conversationId,
+      currentResponse(next.currentToolUseId),
+      next.messages,
+    );
+    await postToolUse(nextCtx);
+    expect(nextCtx.additionalContext).toBeNull();
+
+    // Another full threshold later — nudges again.
+    const second = explorationHistory(EXPLORATION_NUDGE_THRESHOLD * 2 - 1);
+    const secondCtx = makeCtx(
+      conversationId,
+      currentResponse(second.currentToolUseId),
+      second.messages,
+    );
+    await postToolUse(secondCtx);
+    expect(secondCtx.additionalContext).toBe(EXPLORATION_DRIFT_NUDGE_TEXT);
+  });
+
+  test("a restarted streak (new turn) nudges at the threshold again", async () => {
+    const conversationId = freshConversationId();
+
+    // Fire once deep into a long run.
+    const longRun = explorationHistory(EXPLORATION_NUDGE_THRESHOLD * 2 - 1);
+    const longCtx = makeCtx(
+      conversationId,
+      currentResponse(longRun.currentToolUseId),
+      longRun.messages,
+    );
+    await postToolUse(longCtx);
+    expect(longCtx.additionalContext).toBe(EXPLORATION_DRIFT_NUDGE_TEXT);
+
+    // A new turn starts (streak restarts from a fresh history) and runs to
+    // the threshold — the stale high-water mark must not suppress this nudge.
+    const newTurn = explorationHistory(EXPLORATION_NUDGE_THRESHOLD - 1);
+    const newCtx = makeCtx(
+      conversationId,
+      currentResponse(newTurn.currentToolUseId),
+      newTurn.messages,
+    );
+    await postToolUse(newCtx);
+    expect(newCtx.additionalContext).toBe(EXPLORATION_DRIFT_NUDGE_TEXT);
+  });
+
+  test("subagent conversations are exempt", async () => {
+    mockParentInfo = () => ({
+      parentConversationId: "parent-1",
+      subagentId: "sub-1",
+      label: "investigate-empty-turns",
+      parentSendToClient: () => {},
+    });
+    const { messages, currentToolUseId } = explorationHistory(
+      EXPLORATION_NUDGE_THRESHOLD - 1,
+    );
+    const ctx = makeCtx(
+      freshConversationId(),
+      currentResponse(currentToolUseId),
+      messages,
+    );
+
+    await postToolUse(ctx);
+
+    expect(ctx.additionalContext).toBeNull();
+  });
+
+  test("appends to additionalContext set by an earlier hook", async () => {
+    const { messages, currentToolUseId } = explorationHistory(
+      EXPLORATION_NUDGE_THRESHOLD - 1,
+    );
+    const ctx = makeCtx(
+      freshConversationId(),
+      currentResponse(currentToolUseId),
+      messages,
+    );
+    ctx.additionalContext = "<system_notice>earlier coaching</system_notice>";
+
+    await postToolUse(ctx);
+
+    expect(ctx.additionalContext).toBe(
+      `<system_notice>earlier coaching</system_notice>\n${EXPLORATION_DRIFT_NUDGE_TEXT}`,
+    );
+  });
+});
+
+describe("exploration-drift post-tool-use hook — via runHook", () => {
+  beforeEach(() => {
+    resetPluginRegistryForTests();
+  });
+
+  test("registering the default plugin nudges a threshold-length run", async () => {
+    registerPlugin(defaultExplorationDriftPlugin);
+    const { messages, currentToolUseId } = explorationHistory(
+      EXPLORATION_NUDGE_THRESHOLD - 1,
+    );
+
+    const result = await runHook<PostToolUseContext>(
+      HOOKS.POST_TOOL_USE,
+      makeCtx(
+        freshConversationId(),
+        currentResponse(currentToolUseId),
+        messages,
+      ),
+    );
+
+    expect(result.additionalContext).toBe(EXPLORATION_DRIFT_NUDGE_TEXT);
+  });
+});

--- a/assistant/src/plugins/defaults/exploration-drift/hooks/post-tool-use.ts
+++ b/assistant/src/plugins/defaults/exploration-drift/hooks/post-tool-use.ts
@@ -1,0 +1,158 @@
+/**
+ * Default `post-tool-use` hook: when the model accumulates a long unbroken
+ * run of exploration tool calls (bash, file_read, file_list) without sending
+ * the user any text, surface a notice via `additionalContext` that coaches it
+ * to (a) give the user a brief progress summary and (b) delegate the rest of
+ * the investigation to an `investigator` subagent instead of continuing
+ * inline.
+ *
+ * Motivation: a root-cause request investigated inline ran 167 sequential
+ * bash calls in a single turn with no user-facing text, overflowed the
+ * conversation context before any findings were written up, and forced the
+ * user into repeated "Continue?" turns that re-explored the same files.
+ * Delegation keeps the digging in a disposable subagent context. The notice
+ * is advisory — the model decides whether the current run is genuinely an
+ * investigation worth delegating.
+ *
+ * The streak is derived from conversation history on every call (mirroring
+ * the tool-error plugin) so the signal survives mid-run compaction rewriting
+ * the array. The trailing run is bounded by:
+ * - a real user message (turn boundary),
+ * - any non-empty assistant text block (the model spoke to the user),
+ * - any non-exploration tool result (the model did something besides read).
+ *
+ * Repeat nudges are spaced one full threshold apart via a per-conversation
+ * high-water mark, which also dedupes parallel tool results of one batch
+ * (they all observe the same history and would compute the same streak).
+ *
+ * Subagent conversations are exempt: an investigator is *supposed* to dig at
+ * length, and subagents cannot nest (`SUBAGENT_LIMITS.maxDepth`), so the
+ * delegation advice would be wrong there. The check is a lazy import on the
+ * rare nudge path so the subagent manager's module graph stays out of the
+ * per-tool-result hot path.
+ */
+
+import type { PluginHookFn, PostToolUseContext } from "@vellumai/plugin-api";
+
+import type { Message } from "../../../../providers/types.js";
+
+/**
+ * Canonical exploration-drift notice. Module-level constant so tests and
+ * wrapping plugins can match it without duplicating the string. Shown to the
+ * model as provider-only context, never to the user.
+ */
+export const EXPLORATION_DRIFT_NUDGE_TEXT =
+  "<system_notice>You have made a long unbroken run of exploration tool calls (shell/file reads) without sending the user any text. Do two things now: (1) send the user a brief summary of what you have found so far — do not keep working silently; (2) if you are tracing a root cause or exploring code/logs at length, stop exploring inline and delegate the remainder to a subagent: call subagent_spawn with role 'investigator' and a precise objective. It will investigate in its own context window and return a compact root-cause report. Continuing inline floods this conversation's context and risks losing your findings before you can report them.</system_notice>";
+
+/**
+ * Exploration streak length that triggers the first nudge; repeat nudges fire
+ * each time the streak grows by another full threshold.
+ */
+export const EXPLORATION_NUDGE_THRESHOLD = 25;
+
+/** Read-only exploration tools whose unbroken runs indicate inline drift. */
+const EXPLORATION_TOOL_NAMES: ReadonlySet<string> = new Set([
+  "bash",
+  "file_read",
+  "file_list",
+]);
+
+/**
+ * Streak length at the last nudge, per conversation. A high-water mark rather
+ * than a flag so repeat nudges stay one full threshold apart and parallel
+ * results of one batch (same observed history, same computed streak) dedupe
+ * to a single notice. Entries are dropped when the streak restarts.
+ */
+const lastNudgedStreakByConversation = new Map<string, number>();
+
+/** Test-only: clear the per-conversation nudge high-water marks. */
+export function resetExplorationDriftStateForTests(): void {
+  lastNudgedStreakByConversation.clear();
+}
+
+/** Map every `tool_use` block id in history to the tool name it invoked. */
+function toolNamesById(messages: ReadonlyArray<Message>): Map<string, string> {
+  const names = new Map<string, string>();
+  for (const message of messages) {
+    if (message.role !== "assistant") continue;
+    for (const block of message.content) {
+      if (block.type === "tool_use") names.set(block.id, block.name);
+    }
+  }
+  return names;
+}
+
+/**
+ * Length of the trailing unbroken run of exploration tool results in history.
+ * Walks backwards from the most recent message and stops at a real user
+ * message, a non-empty assistant text block, or a non-exploration tool
+ * result. Text blocks inside tool-result user rows (e.g. coaching notices
+ * appended by other hooks) do not break the run — they are system notices,
+ * not the model speaking to the user.
+ */
+function trailingExplorationStreak(
+  messages: ReadonlyArray<Message>,
+  namesById: ReadonlyMap<string, string>,
+): number {
+  let count = 0;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (message.role === "assistant") {
+      const spokeToUser = message.content.some(
+        (block) => block.type === "text" && block.text.trim().length > 0,
+      );
+      if (spokeToUser) break;
+      continue;
+    }
+    if (message.role !== "user") continue;
+    const hasToolResult = message.content.some(
+      (block) => block.type === "tool_result",
+    );
+    if (!hasToolResult) break;
+    for (let j = message.content.length - 1; j >= 0; j--) {
+      const block = message.content[j];
+      if (block.type !== "tool_result") continue;
+      const toolName = namesById.get(block.tool_use_id);
+      if (toolName === undefined || !EXPLORATION_TOOL_NAMES.has(toolName)) {
+        return count;
+      }
+      count++;
+    }
+  }
+  return count;
+}
+
+const postToolUse: PluginHookFn<PostToolUseContext> = async (ctx) => {
+  const namesById = toolNamesById(ctx.messages);
+  const toolName = namesById.get(ctx.toolResponse.tool_use_id);
+  if (toolName === undefined || !EXPLORATION_TOOL_NAMES.has(toolName)) return;
+
+  // The current result is not in history yet — count it explicitly.
+  const streak = trailingExplorationStreak(ctx.messages, namesById) + 1;
+
+  let lastNudged = lastNudgedStreakByConversation.get(ctx.conversationId) ?? 0;
+  if (streak < lastNudged) {
+    // The streak restarted (new turn, intervening text, or compaction) since
+    // the last nudge — drop the stale high-water mark.
+    lastNudgedStreakByConversation.delete(ctx.conversationId);
+    lastNudged = 0;
+  }
+  if (streak - lastNudged < EXPLORATION_NUDGE_THRESHOLD) return;
+
+  // Subagent conversations are exempt — see module doc.
+  const { getSubagentManager } = await import("../../../../subagent/index.js");
+  if (getSubagentManager().getParentInfo(ctx.conversationId) !== undefined) {
+    return;
+  }
+
+  lastNudgedStreakByConversation.set(ctx.conversationId, streak);
+  ctx.logger.info(
+    { plugin: "exploration-drift", streak, toolName },
+    "Exploration drift detected — nudging summary + investigator delegation",
+  );
+  ctx.additionalContext = ctx.additionalContext
+    ? `${ctx.additionalContext}\n${EXPLORATION_DRIFT_NUDGE_TEXT}`
+    : EXPLORATION_DRIFT_NUDGE_TEXT;
+};
+
+export default postToolUse;

--- a/assistant/src/plugins/defaults/exploration-drift/package.json
+++ b/assistant/src/plugins/defaults/exploration-drift/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "default-exploration-drift",
+  "version": "1.0.0",
+  "description": "First-party default plugin contributing a post-tool-use hook that nudges the model to summarize and delegate to an investigator subagent when a turn accumulates a long run of exploration tool calls.",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "main": "./register.ts",
+  "engines": {
+    "node": ">=20.12.0"
+  },
+  "peerDependencies": {
+    "@vellumai/plugin-api": "^0.8.0"
+  }
+}

--- a/assistant/src/plugins/defaults/index.ts
+++ b/assistant/src/plugins/defaults/index.ts
@@ -29,6 +29,10 @@ import { type Plugin, PluginExecutionError } from "../types.js";
 import compactionPkg from "./compaction/package.json" with { type: "json" };
 import emptyResponseStop from "./empty-response/hooks/stop.js";
 import emptyResponsePkg from "./empty-response/package.json" with { type: "json" };
+import explorationDriftPostToolUse, {
+  resetExplorationDriftStateForTests,
+} from "./exploration-drift/hooks/post-tool-use.js";
+import explorationDriftPkg from "./exploration-drift/package.json" with { type: "json" };
 import historyRepairStop from "./history-repair/hooks/stop.js";
 import historyRepairUserPromptSubmit from "./history-repair/hooks/user-prompt-submit.js";
 import historyRepairPkg from "./history-repair/package.json" with { type: "json" };
@@ -182,6 +186,23 @@ export const defaultToolErrorPlugin: Plugin = {
 };
 
 /**
+ * `exploration-drift` — a `post-tool-use` hook that detects a long unbroken
+ * run of exploration tool calls (bash, file_read, file_list) with no
+ * user-facing text and nudges the model — via `additionalContext` — to
+ * summarize progress for the user and delegate the remaining investigation to
+ * an `investigator` subagent rather than continuing inline.
+ */
+export const defaultExplorationDriftPlugin: Plugin = {
+  manifest: {
+    name: explorationDriftPkg.name,
+    version: explorationDriftPkg.version,
+  },
+  hooks: {
+    "post-tool-use": explorationDriftPostToolUse,
+  },
+};
+
+/**
  * `tool-result-truncate` — a `post-tool-use` hook that tail-drops an oversized
  * tool result down to a character budget derived from the model's context
  * window before the result is sent to the provider.
@@ -208,6 +229,7 @@ function getAllDefaultPlugins(): readonly Plugin[] {
     defaultToolResultTruncatePlugin,
     defaultEmptyResponsePlugin,
     defaultToolErrorPlugin,
+    defaultExplorationDriftPlugin,
     defaultHistoryRepairPlugin,
     defaultImageRecoveryPlugin,
     defaultCompactionPlugin,
@@ -254,5 +276,6 @@ export function resetPluginRegistryAndRegisterDefaults(): void {
   resetPluginRegistryForTests();
   resetRepairStateStoreForTests();
   resetImageRecoveryStoreForTests();
+  resetExplorationDriftStateForTests();
   registerDefaultPlugins();
 }


### PR DESCRIPTION
## Context

PR 2 of 2 (PR 1: #34297 — `investigator` subagent role). Same field incident: a root-cause request was investigated **inline** — 167 sequential bash calls in a single turn with **zero user-facing text** — until the conversation context overflowed, losing the findings before any writeup. Two follow-up "Continue?" turns burned another 209 calls, largely re-exploring files already read (11 of 15 files in turn 2 were re-reads).

The subagent skill's guidance to delegate already exists in the system prompt and SKILL.md, but nothing interrupts a turn once it has drifted into a long inline dig. This PR adds that interrupt.

## What it does

New default plugin `exploration-drift` with a `post-tool-use` hook (same seam as the existing `tool-error` retry coaching): when a turn accumulates an unbroken run of **25** exploration tool calls (`bash`, `file_read`, `file_list`) with no text sent to the user, it appends a provider-only `<system_notice>` via `additionalContext` coaching the model to (1) send the user a progress summary and (2) delegate the remaining investigation to `subagent_spawn` with `role: investigator`.

It's a nudge, not a hard stop — consistent with the assistant-driven-judgement rule; the model decides whether the run is genuinely an investigation worth delegating.

## Design notes

- **Streak derived from history each call** (mirrors `tool-error`), so the signal survives mid-run compaction rewriting the message array. The run is bounded by a real user message, a non-empty assistant text block, or any non-exploration tool result.
- **Repeat nudges spaced one full threshold apart** via a per-conversation high-water mark, which also dedupes parallel results of one batch (they observe identical history).
- **Subagent conversations are exempt** — an investigator is *supposed* to dig long, and subagents can't nest. Checked via `getSubagentManager().getParentInfo()` behind a lazy import so the manager's module graph stays off the per-tool-result hot path.
- **Appends to `additionalContext`** rather than overwriting, so tool-error coaching on the same result isn't lost.
- In the incident, this would have fired at call 25 of 167 (and every +25 after), versus the actual outcome of 167 silent calls and a lost writeup.

## Merge order

Merge **after** #34297 — the nudge text references `role: 'investigator'`. If merged first, the failure mode is benign (spawn returns "Invalid subagent role" and the model falls back), but the nudge would coach a role that doesn't exist yet.

## Test plan

- [x] `bun test src/__tests__/exploration-drift-hook.test.ts` (11 pass: threshold, streak bounds, repeat spacing, restart, subagent exemption, append, runHook E2E)
- [x] `bun test src/__tests__/conversation-agent-loop.test.ts` (59 pass — full default-plugin stack)
- [x] `bun test src/__tests__/tool-error-hook.test.ts src/__tests__/plugin-registry.test.ts` (18 pass)
- [x] `bunx tsc --noEmit` clean
- [ ] Dogfood: re-run the incident prompt ("deep dive into why assistant turns have no content") and confirm the nudge fires and the model delegates

🤖 Generated with [Claude Code](https://claude.com/claude-code)