### PR TITLE
feat(web): add Launch at Login toggle to General settings page

### DIFF
--- a/apps/web/src/domains/settings/components/launch-at-login-card.tsx
+++ b/apps/web/src/domains/settings/components/launch-at-login-card.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react";
+
+import { DetailCard } from "@/components/detail-card";
+import { getLaunchAtLogin, setLaunchAtLogin } from "@/runtime/launch-at-login";
+import { Toggle } from "@vellumai/design-library/components/toggle";
+
+export function LaunchAtLoginCard() {
+  const [enabled, setEnabled] = useState(false);
+
+  useEffect(() => {
+    getLaunchAtLogin().then(setEnabled);
+  }, []);
+
+  const handleToggle = async (next: boolean) => {
+    setEnabled(next);
+    try {
+      await setLaunchAtLogin(next);
+    } catch {
+      setEnabled(!next);
+    }
+  };
+
+  return (
+    <DetailCard
+      title="Launch at Login"
+      subtitle="Automatically start Vellum when you log in to your Mac."
+    >
+      <Toggle checked={enabled} onChange={(next) => void handleToggle(next)} />
+    </DetailCard>
+  );
+}

--- a/apps/web/src/domains/settings/pages/general-page.tsx
+++ b/apps/web/src/domains/settings/pages/general-page.tsx
@@ -15,6 +15,7 @@ import {
 import { AssistantUpgrades } from "@/domains/settings/components/assistant-upgrades";
 import { DeleteAccountSection } from "@/domains/settings/components/delete-account-section";
 import { IOSAppCard } from "@/domains/settings/components/ios-app-card";
+import { LaunchAtLoginCard } from "@/domains/settings/components/launch-at-login-card";
 import { MediaEmbedsCard } from "@/domains/settings/components/media-embeds-card";
 import { PreviewReleaseChannel } from "@/domains/settings/components/preview-release-channel";
 import { ResizeCard } from "@/domains/settings/components/resize-card";
@@ -37,6 +38,7 @@ import {
     isLocalAssistant,
     isLocalMode,
 } from "@/lib/local-mode";
+import { isElectron } from "@/runtime/is-electron";
 import { captureError } from "@/lib/sentry/capture-error";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { useIsAuthenticated } from "@/stores/auth-store";
@@ -297,6 +299,8 @@ export function GeneralPage() {
       )}
 
       <ThemeCard />
+
+      {isElectron() && <LaunchAtLoginCard />}
 
       {infraGate === "full" && platformAssistant && (
         <DetailCard title="Software Updates">


### PR DESCRIPTION
## Summary
- Create `LaunchAtLoginCard` component with a `Toggle` and optimistic state updates
- Add the card to the General settings page, gated behind `isElectron()`
- Hidden on web/iOS builds

Part of plan: launch-at-login.md (PR 3 of 3)