### PR TITLE
feat(onboarding): Replay Hatch Failure dev menu + Electron hatch-screen layout fix

### DIFF
--- a/apps/macos/src/main/commands.ts
+++ b/apps/macos/src/main/commands.ts
@@ -32,6 +32,7 @@ export type VellumCommand =
   | { kind: "cancelActiveAction" }
   | { kind: "replayOnboarding" }
   | { kind: "previewPrechat" }
+  | { kind: "replayHatchFailure" }
   | { kind: "openComponentGallery" };
 
 export type VellumCommandKind = VellumCommand["kind"];
@@ -68,6 +69,7 @@ export const DEFAULT_ACCELERATORS: Record<VellumCommandKind, string> = {
   cancelActiveAction: "",
   replayOnboarding: "",
   previewPrechat: "",
+  replayHatchFailure: "",
   openComponentGallery: "",
 };
 

--- a/apps/macos/src/main/menu.ts
+++ b/apps/macos/src/main/menu.ts
@@ -157,6 +157,10 @@ const buildTemplate = (): MenuItemConstructorOptions[] => {
                 label: "Preview PreChat",
                 click: () => dispatchToFocused({ kind: "previewPrechat" }),
               },
+              {
+                label: "Replay Hatch Failure",
+                click: () => dispatchToFocused({ kind: "replayHatchFailure" }),
+              },
               ...(!app.isPackaged
                 ? [
                     { type: "separator" as const },

--- a/apps/macos/src/main/tray.ts
+++ b/apps/macos/src/main/tray.ts
@@ -253,6 +253,13 @@ const buildTrayMenu = (handlers: TrayHandlers, status: AssistantStatus): Menu =>
               dispatchToMain({ kind: "previewPrechat" as const });
             },
           },
+          {
+            label: "Replay Hatch Failure",
+            click: async () => {
+              await handlers.ensureMainWindow();
+              dispatchToMain({ kind: "replayHatchFailure" as const });
+            },
+          },
           ...(!app.isPackaged
             ? [
                 {

--- a/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -25,6 +25,7 @@ import { avatarQueryKey } from "@/lib/sync/query-tags";
 import { resolveNavigation } from "@/lib/navigation/navigation-resolver";
 import { buildNavigationState } from "@/lib/navigation/build-state";
 import { hatchLocalAssistant } from "@/runtime/local-mode-host";
+import { isElectron } from "@/runtime/is-electron";
 import { isNativePlatform } from "@/runtime/native-auth";
 import { selectPlatformAssistant } from "@/assistant/select-platform-assistant";
 import { useAuthStore } from "@/stores/auth-store";
@@ -96,6 +97,12 @@ export function HatchingScreen() {
   const queryClient = useQueryClient();
   const [searchParams] = useSearchParams();
   const hostingParam = searchParams.get("hosting");
+  const failParam = searchParams.get("fail");
+  // On Electron the window is short (630px) with `titleBarStyle: "hidden"`, so
+  // the macOS traffic lights + global WindowDragRegion (28px) overlap the top
+  // of this `justify-center` layout. Gate the title-bar clearance + the content
+  // trim that keeps it inside the window on Electron so web/iOS are untouched.
+  const electron = isElectron();
   const useLocalHatch = isLocalMode() && hostingParam !== null && hostingParam !== "vellum-cloud";
   const sessionStatus = useAuthStore.use.sessionStatus();
   const [hatchTraits] = useState<CharacterTraits>(() =>
@@ -133,6 +140,15 @@ export function HatchingScreen() {
 
 
   useEffect(() => {
+    // Developer "Replay Hatch Failure" tool: when opened with `?fail`, skip the
+    // gate and the real hatch flow and render the error UI directly so the
+    // failure screen can be exercised on demand from the Electron developer menu.
+    if (failParam !== null) {
+      setError(
+        "Simulated hatch failure (developer menu → Replay Hatch Failure).",
+      );
+      return;
+    }
     const decision = decideHatchGate();
     if (decision.kind === "redirect") {
       void navigate(decision.to, { replace: true });
@@ -502,6 +518,7 @@ export function HatchingScreen() {
     };
   }, [
     attempt,
+    failParam,
     hatchTraits,
     sessionStatus,
     navigate,
@@ -538,7 +555,7 @@ export function HatchingScreen() {
       <OnboardingLayout>
         <div
           role="alert"
-          className="mx-auto flex min-h-screen w-full max-w-xl flex-col items-center justify-center px-6 pb-40 text-center text-[var(--content-default)]"
+          className={`mx-auto flex min-h-screen w-full max-w-xl flex-col items-center justify-center px-6 ${electron ? "pt-[3.25rem] pb-8" : "pb-40"} text-center text-[var(--content-default)]`}
         >
           <h1 className="text-3xl font-semibold tracking-tight">
             Something went wrong
@@ -569,7 +586,7 @@ export function HatchingScreen() {
             alt=""
             width={160}
             height={160}
-            className="my-16 onboarding-avatar-failed"
+            className={`${electron ? "my-8" : "my-16"} onboarding-avatar-failed`}
           />
           <div className="flex w-full max-w-sm flex-col gap-2">
             <Button
@@ -616,7 +633,7 @@ export function HatchingScreen() {
 
   return (
     <OnboardingLayout>
-      <div className="mx-auto flex min-h-screen w-full max-w-xl flex-col items-center justify-center px-6 pb-40 text-center text-[var(--content-default)]">
+      <div className={`mx-auto flex min-h-screen w-full max-w-xl flex-col items-center justify-center px-6 ${electron ? "pt-[3.25rem] pb-8" : "pb-40"} text-center text-[var(--content-default)]`}>
         <h1 className="text-3xl font-semibold tracking-tight">
           {phase === "ready" ? "Your assistant is ready!" : "Waking up…"}
         </h1>
@@ -631,7 +648,7 @@ export function HatchingScreen() {
           alt=""
           width={160}
           height={160}
-          className={`my-16 ${phase === "ready" ? "onboarding-avatar-awake" : "onboarding-avatar-pulse"}`}
+          className={`${electron ? "my-8" : "my-16"} ${phase === "ready" ? "onboarding-avatar-awake" : "onboarding-avatar-pulse"}`}
         />
         <ProgressBar
           value={displayProgress}

--- a/apps/web/src/lib/onboarding-middleware.ts
+++ b/apps/web/src/lib/onboarding-middleware.ts
@@ -30,9 +30,18 @@ export const onboardingCompletedMiddleware: MiddlewareFunction = async (
     routes.onboarding.privacy,
     routes.onboarding.prechat,
   ]);
+  const isPreview = url.searchParams.get("preview") === "true";
+  // Developer "Replay Hatch Failure" tool: the hatching screen short-circuits
+  // straight to its error UI when `fail` is present (no real hatch side
+  // effects), so it's safe to let preview through for that one case even
+  // though hatching is otherwise excluded from the previewable routes above.
+  const isHatchFailurePreview =
+    isPreview &&
+    url.pathname === routes.onboarding.hatching &&
+    url.searchParams.get("fail") !== null;
   if (
-    url.searchParams.get("preview") === "true" &&
-    previewableRoutes.has(url.pathname)
+    (isPreview && previewableRoutes.has(url.pathname)) ||
+    isHatchFailurePreview
   ) {
     return next();
   }

--- a/apps/web/src/root-layout.tsx
+++ b/apps/web/src/root-layout.tsx
@@ -193,6 +193,9 @@ export function RootLayout() {
     previewPrechat: () => {
       void navigate(`${routes.onboarding.prechat}?preview=true`);
     },
+    replayHatchFailure: () => {
+      void navigate(`${routes.onboarding.hatching}?preview=true&fail=1`);
+    },
   });
 
   const handleConfirmRetire = async () => {

--- a/apps/web/src/runtime/is-electron.ts
+++ b/apps/web/src/runtime/is-electron.ts
@@ -51,6 +51,7 @@ export type VellumCommand =
   | { kind: "cancelActiveAction" }
   | { kind: "replayOnboarding" }
   | { kind: "previewPrechat" }
+  | { kind: "replayHatchFailure" }
   | { kind: "openComponentGallery" };
 
 /**


### PR DESCRIPTION
## Summary

Two related changes around the assistant "hatching" onboarding screen:

1. **Developer tooling — "Replay Hatch Failure" menu item.** A way to render the hatch-failure UI on demand for testing, without waiting for a real hatch to fail.
2. **Layout fix — hatch "Something went wrong" screen on Electron.** The failure/loading screen rode under the macOS traffic lights; this clears it.

### 1. Replay Hatch Failure (developer menu)

Mirrors the existing "Preview PreChat" plumbing:

- New `replayHatchFailure` command in the Electron command union (`commands.ts` + renderer mirror in `is-electron.ts`).
- "Replay Hatch Failure" item in both the **Developer** app-menu submenu (`menu.ts`) and the tray developer section (`tray.ts`), gated behind the existing `developer-menu-items` feature flag.
- Renderer handler (`root-layout.tsx`) navigates to `/assistant/onboarding/hatching?preview=true&fail=1`.
- `onboardingCompletedMiddleware` allows the hatching route through **only** when `preview` + `fail` are set — the screen performs no real hatch side effects in that mode, so this narrow bypass doesn't weaken the guard for normal navigation.
- `HatchingScreen` short-circuits to its error UI when `?fail` is present.

**To use:** enable the `developer-menu-items` flag, then **Developer → Replay Hatch Failure** (menu bar or tray).

### 2. Hatch screen layout fix (Electron)

The onboarding window is 630px tall with `titleBarStyle: "hidden"`, so the macOS traffic lights + global `WindowDragRegion` (28px) overlap the top of the `justify-center` layout. The failure/loading screen had no clearance and, with `pb-40` + a `my-16` avatar, the content overflowed the short window and top-aligned under the window controls.

Gated behind `isElectron()`:
- `pt-[3.25rem]` top inset (matches the title-bar clearance convention).
- Trimmed bottom padding (`pb-40` → `pb-8`) and avatar margin (`my-16` → `my-8`) so the content fits the 630px window.

Web and iOS are untouched.

#### Relationship to #34250 / LUM-2318

There are **two** "Something went wrong" screens. #34250 fixes the generic `RouteErrorBoundary` (route/render errors). This PR fixes the **hatching screen's** failure + loading states — a different component (it has the avatar, creature footer, and Try again / Back). The two are complementary and don't conflict; together they cover both instances of the same Electron title-bar overlap.

## Test plan

- `apps/web` and `apps/macos` `tsc --noEmit` pass.
- Manual: enable `developer-menu-items`, trigger **Developer → Replay Hatch Failure**, confirm the "Something went wrong" screen is centered and clear of the traffic lights on Electron; verify the web/iOS hatching screen is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
