### PR TITLE
feat(macos): resolve cloud proxy org from lockfile, not first org (LUM-2299)

### DIFF
--- a/apps/macos/src/main/host-proxy-router.test.ts
+++ b/apps/macos/src/main/host-proxy-router.test.ts
@@ -71,18 +71,13 @@ async function flush(ms = 20): Promise<void> {
   await new Promise((r) => setTimeout(r, ms));
 }
 
-// Mock globalThis.fetch for /auth/token exchange (local) and /v1/organizations/ (cloud).
+// Mock globalThis.fetch for the /auth/token exchange (local gateway). Cloud
+// connections resolve their org from the lockfile, so they make no fetch here.
 const originalFetch = globalThis.fetch;
 const mockGatewayTokenFetch = async (input: string | URL | Request) => {
   const url = String(input);
   if (url.includes("/auth/token")) {
     return new Response(JSON.stringify({ token: "gateway-jwt", expiresAt: Date.now() + 60_000 }), {
-      status: 200,
-      headers: { "Content-Type": "application/json" },
-    });
-  }
-  if (url.includes("/v1/organizations/")) {
-    return new Response(JSON.stringify({ results: [{ id: "org-test-123" }] }), {
       status: 200,
       headers: { "Content-Type": "application/json" },
     });
@@ -255,7 +250,64 @@ describe("host-proxy-router", () => {
       const conn = __testing.connections.get("cloud-1")!;
       expect(conn.sse).toBeInstanceOf(HostProxySseClient);
       expect(conn.poster).toBeInstanceOf(HostProxyPoster);
-      expect(conn.fingerprint).toBe("cloud:https://platform.vellum.ai");
+      expect(conn.fingerprint).toBe("cloud:https://platform.vellum.ai:");
+    });
+
+    test("stamps organizationId from the lockfile into the fingerprint", async () => {
+      installHostProxyBridge(fakeCliResolver);
+
+      lockfileListener?.({
+        assistants: [
+          {
+            assistantId: "cloud-1",
+            cloud: "vellum",
+            runtimeUrl: "https://platform.vellum.ai",
+            organizationId: "org-from-lockfile",
+          },
+        ],
+        activeAssistant: "cloud-1",
+      });
+      await flush();
+
+      expect(__testing.connections.get("cloud-1")!.fingerprint).toBe(
+        "cloud:https://platform.vellum.ai:org-from-lockfile",
+      );
+    });
+
+    test("reconnects cloud assistant when organizationId changes", async () => {
+      installHostProxyBridge(fakeCliResolver);
+
+      lockfileListener?.({
+        assistants: [
+          {
+            assistantId: "cloud-1",
+            cloud: "vellum",
+            runtimeUrl: "https://platform.vellum.ai",
+            organizationId: "org-a",
+          },
+        ],
+        activeAssistant: "cloud-1",
+      });
+      await flush();
+      const firstSse = __testing.connections.get("cloud-1")!.sse;
+
+      lockfileListener?.({
+        assistants: [
+          {
+            assistantId: "cloud-1",
+            cloud: "vellum",
+            runtimeUrl: "https://platform.vellum.ai",
+            organizationId: "org-b",
+          },
+        ],
+        activeAssistant: "cloud-1",
+      });
+      await flush();
+
+      expect(__testing.connections.get("cloud-1")!.sse).not.toBe(firstSse);
+      expect(__testing.connections.get("cloud-1")!.fingerprint).toBe(
+        "cloud:https://platform.vellum.ai:org-b",
+      );
     });
 
     test("skips cloud assistant when no session token is available", async () => {
@@ -313,7 +365,7 @@ describe("host-proxy-router", () => {
       expect(__testing.connections.has("local-1")).toBe(true);
       expect(__testing.connections.has("cloud-1")).toBe(true);
       expect(__testing.connections.get("local-1")!.fingerprint).toBe("local:9001");
-      expect(__testing.connections.get("cloud-1")!.fingerprint).toBe("cloud:https://platform.vellum.ai");
+      expect(__testing.connections.get("cloud-1")!.fingerprint).toBe("cloud:https://platform.vellum.ai:");
     });
 
     test("reconnects cloud assistant when runtimeUrl changes", async () => {
@@ -338,7 +390,7 @@ describe("host-proxy-router", () => {
 
       expect(__testing.connections.has("cloud-1")).toBe(true);
       expect(__testing.connections.get("cloud-1")!.sse).not.toBe(firstSse);
-      expect(__testing.connections.get("cloud-1")!.fingerprint).toBe("cloud:https://new.vellum.ai");
+      expect(__testing.connections.get("cloud-1")!.fingerprint).toBe("cloud:https://new.vellum.ai:");
     });
 
     test("ignores non-vellum cloud assistants without resources", async () => {

--- a/apps/macos/src/main/host-proxy-router.ts
+++ b/apps/macos/src/main/host-proxy-router.ts
@@ -229,6 +229,14 @@ async function acquireGatewayToken(
   return exchanged.token;
 }
 
+// A connection's fingerprint encodes everything that, if changed, requires a
+// reconnect. Single-sourced here so the value set on connect and the value
+// recomputed in `handleLockfileChange` can never drift (a mismatch would loop
+// connect/disconnect forever).
+const localFingerprint = (gatewayPort: number): string => `local:${gatewayPort}`;
+const cloudFingerprint = (runtimeUrl: string, organizationId?: string): string =>
+  `cloud:${runtimeUrl}:${organizationId ?? ""}`;
+
 // -- Local assistant connection ---------------------------------------------
 
 async function connectLocalAssistant(
@@ -261,32 +269,17 @@ async function connectLocalAssistant(
   sse.setMessageCallback((msg) => dispatchMessage(msg, poster));
   sse.connect();
 
-  connections.set(assistantId, { sse, poster, fingerprint: `local:${gatewayPort}` });
+  connections.set(assistantId, { sse, poster, fingerprint: localFingerprint(gatewayPort) });
   log.info("[host-proxy-router] connected to local assistant", { assistantId, gatewayPort });
 }
 
 // -- Cloud assistant connection ---------------------------------------------
 
-async function fetchOrganizationId(
-  runtimeUrl: string,
-  sessionToken: string,
-): Promise<string | null> {
-  try {
-    const res = await fetch(`${runtimeUrl}/v1/organizations/`, {
-      headers: { "X-Session-Token": sessionToken },
-    });
-    if (!res.ok) return null;
-    const data = (await res.json()) as { results?: Array<{ id: string }> };
-    return data.results?.[0]?.id ?? null;
-  } catch {
-    return null;
-  }
-}
-
-async function connectCloudAssistant(
+function connectCloudAssistant(
   assistantId: string,
   runtimeUrl: string,
-): Promise<void> {
+  organizationId?: string,
+): void {
   if (connections.has(assistantId)) return;
 
   const sessionToken = getSessionToken();
@@ -296,11 +289,6 @@ async function connectCloudAssistant(
   }
 
   const baseUrl = runtimeUrl.replace(/\/$/, "");
-
-  const organizationId = await fetchOrganizationId(baseUrl, sessionToken);
-  if (organizationId) {
-    log.info("[host-proxy-router] resolved organization for cloud assistant", { assistantId, organizationId });
-  }
 
   const authHeaders = (): Record<string, string> => {
     const token = getSessionToken();
@@ -319,8 +307,12 @@ async function connectCloudAssistant(
   sse.setMessageCallback((msg) => dispatchMessage(msg, poster));
   sse.connect();
 
-  connections.set(assistantId, { sse, poster, fingerprint: `cloud:${runtimeUrl}` });
-  log.info("[host-proxy-router] connected to cloud assistant", { assistantId, runtimeUrl });
+  connections.set(assistantId, {
+    sse,
+    poster,
+    fingerprint: cloudFingerprint(runtimeUrl, organizationId),
+  });
+  log.info("[host-proxy-router] connected to cloud assistant", { assistantId, runtimeUrl, organizationId });
 }
 
 // -- Disconnect -------------------------------------------------------------
@@ -346,7 +338,9 @@ function handleLockfileChange(lockfile: Lockfile): void {
     if (!port && !isCloud) continue;
 
     activeIds.add(assistant.assistantId);
-    const fp = port ? `local:${port}` : `cloud:${assistant.runtimeUrl}`;
+    const fp = port
+      ? localFingerprint(port)
+      : cloudFingerprint(assistant.runtimeUrl!, assistant.organizationId);
 
     const existing = connections.get(assistant.assistantId);
     if (existing && existing.fingerprint !== fp) {
@@ -361,7 +355,11 @@ function handleLockfileChange(lockfile: Lockfile): void {
       if (port) {
         void connectLocalAssistant(assistant.assistantId, port);
       } else {
-        void connectCloudAssistant(assistant.assistantId, assistant.runtimeUrl!);
+        connectCloudAssistant(
+          assistant.assistantId,
+          assistant.runtimeUrl!,
+          assistant.organizationId,
+        );
       }
     }
   }

--- a/apps/web/src/assistant/create-platform-assistant.test.ts
+++ b/apps/web/src/assistant/create-platform-assistant.test.ts
@@ -24,7 +24,9 @@ const listAssistantsMock = mock(async () => ({
   data: [{ id: "ast-new", is_local: false, created: "" }],
 }));
 const selectPlatformAssistantMock = mock(async (_id: string) => {});
-const syncPlatformAssistantsToLockfileMock = mock(async (_a: unknown) => {});
+const syncPlatformAssistantsToLockfileMock = mock(
+  async (_a: unknown, _orgId?: string) => {},
+);
 
 mock.module("@/assistant/api", () => ({
   hatchAssistant: hatchAssistantMock,
@@ -35,6 +37,11 @@ mock.module("@/assistant/select-platform-assistant", () => ({
 }));
 mock.module("@/lib/local-mode", () => ({
   syncPlatformAssistantsToLockfile: syncPlatformAssistantsToLockfileMock,
+}));
+mock.module("@/stores/organization-store", () => ({
+  useOrganizationStore: {
+    getState: () => ({ currentOrganizationId: "org-test" }),
+  },
 }));
 mock.module("@/utils/api-errors", () => ({
   extractErrorMessage: (e: unknown, _r: unknown, fallback?: string) =>
@@ -57,7 +64,10 @@ describe("createPlatformAssistant", () => {
   test("hatches with mode=create, syncs the lockfile, and switches to the new id", async () => {
     const result = await createPlatformAssistant("My Bot");
     expect(hatchAssistantMock).toHaveBeenCalledWith({ name: "My Bot" }, "create");
-    expect(syncPlatformAssistantsToLockfileMock).toHaveBeenCalled();
+    expect(syncPlatformAssistantsToLockfileMock).toHaveBeenCalledWith(
+      [{ id: "ast-new", is_local: false, created: "" }],
+      "org-test",
+    );
     expect(selectPlatformAssistantMock).toHaveBeenCalledWith("ast-new");
     expect(result).toEqual({ ok: true, id: "ast-new" });
   });

--- a/apps/web/src/assistant/create-platform-assistant.ts
+++ b/apps/web/src/assistant/create-platform-assistant.ts
@@ -1,6 +1,7 @@
 import { hatchAssistant, listAssistants } from "@/assistant/api";
 import { selectPlatformAssistant } from "@/assistant/select-platform-assistant";
 import { syncPlatformAssistantsToLockfile } from "@/lib/local-mode";
+import { useOrganizationStore } from "@/stores/organization-store";
 import { extractErrorMessage } from "@/utils/api-errors";
 
 export type CreatePlatformAssistantResult =
@@ -39,7 +40,10 @@ export async function createPlatformAssistant(
   try {
     const remaining = await listAssistants();
     if (remaining.ok) {
-      await syncPlatformAssistantsToLockfile(remaining.data);
+      await syncPlatformAssistantsToLockfile(
+        remaining.data,
+        useOrganizationStore.getState().currentOrganizationId ?? undefined,
+      );
     }
   } catch {
     // non-fatal

--- a/apps/web/src/assistant/retire-service.test.ts
+++ b/apps/web/src/assistant/retire-service.test.ts
@@ -26,13 +26,20 @@ mock.module("@/assistant/api", () => ({
 }));
 
 const retireLocalAssistantMock = mock(async (_id: string) => retireLocalResult);
-const syncPlatformAssistantsToLockfileMock = mock(async (_a: unknown) => {});
+const syncPlatformAssistantsToLockfileMock = mock(
+  async (_a: unknown, _orgId?: string) => {},
+);
 mock.module("@/lib/local-mode", () => ({
   getLockfile: () => ({ assistants: lockfileAssistants, activeAssistant: null }),
   isLocalAssistant: (a: { cloud?: string }) => a.cloud !== "vellum",
   isLocalMode: () => isLocalModeValue,
   retireLocalAssistant: retireLocalAssistantMock,
   syncPlatformAssistantsToLockfile: syncPlatformAssistantsToLockfileMock,
+}));
+mock.module("@/stores/organization-store", () => ({
+  useOrganizationStore: {
+    getState: () => ({ currentOrganizationId: "org-test" }),
+  },
 }));
 
 mock.module("@/lib/navigation/navigation-resolver", () => ({
@@ -142,7 +149,10 @@ describe("retireAssistant", () => {
     // THEN it uses the platform delete (not local) and re-syncs the lockfile
     expect(retireAssistantByIdMock).toHaveBeenCalledWith("p1");
     expect(retireLocalAssistantMock).not.toHaveBeenCalled();
-    expect(syncPlatformAssistantsToLockfileMock).toHaveBeenCalled();
+    expect(syncPlatformAssistantsToLockfileMock).toHaveBeenCalledWith(
+      [{ id: "p1", is_local: false, created: "" }],
+      "org-test",
+    );
     expect(outcome.ok).toBe(true);
   });
 

--- a/apps/web/src/assistant/retire-service.ts
+++ b/apps/web/src/assistant/retire-service.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/local-mode";
 import { resolveNavigation } from "@/lib/navigation/navigation-resolver";
 import { buildNavigationState } from "@/lib/navigation/build-state";
+import { useOrganizationStore } from "@/stores/organization-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { routes } from "@/utils/routes";
 
@@ -80,7 +81,10 @@ export async function retireAssistant(
         try {
           const remaining = await listAssistants();
           if (remaining.ok) {
-            await syncPlatformAssistantsToLockfile(remaining.data);
+            await syncPlatformAssistantsToLockfile(
+              remaining.data,
+              useOrganizationStore.getState().currentOrganizationId ?? undefined,
+            );
           }
         } catch {
           // Best-effort sync — the retire itself already succeeded.

--- a/apps/web/src/domains/account/pages/platform-loopback-page.tsx
+++ b/apps/web/src/domains/account/pages/platform-loopback-page.tsx
@@ -5,6 +5,7 @@ import { listAssistants } from "@/assistant/api";
 import { syncPlatformAssistantsToLockfile } from "@/lib/local-mode";
 import { setMenuPlatformSession } from "@/runtime/menu";
 import { useAuthStore } from "@/stores/auth-store";
+import { useOrganizationStore } from "@/stores/organization-store";
 import { routes } from "@/utils/routes";
 
 const LOOPBACK_STATE_KEY = "vellum:loopback:state";
@@ -64,7 +65,10 @@ export function PlatformLoopbackPage() {
       try {
         const result = await listAssistants();
         if (result.ok && result.data.length > 0) {
-          await syncPlatformAssistantsToLockfile(result.data);
+          await syncPlatformAssistantsToLockfile(
+            result.data,
+            useOrganizationStore.getState().currentOrganizationId ?? undefined,
+          );
           void navigate(routes.assistant, { replace: true });
           return;
         }

--- a/apps/web/src/domains/account/pages/provider-callback-page.tsx
+++ b/apps/web/src/domains/account/pages/provider-callback-page.tsx
@@ -13,6 +13,7 @@ import {
 import { classifyCallbackFlows } from "@/domains/account/social-auth";
 import { isLocalMode, syncPlatformAssistantsToLockfile } from "@/lib/local-mode";
 import { useAuthStore } from "@/stores/auth-store";
+import { useOrganizationStore } from "@/stores/organization-store";
 import { VELLUM_COMMUNITY_URL } from "@/utils/external-urls";
 import { routes } from "@/utils/routes";
 
@@ -61,7 +62,10 @@ export function ProviderCallbackPage() {
               try {
                 const assistants = await listAssistants();
                 if (assistants.ok && assistants.data.length > 0) {
-                  await syncPlatformAssistantsToLockfile(assistants.data);
+                  await syncPlatformAssistantsToLockfile(
+                    assistants.data,
+                    useOrganizationStore.getState().currentOrganizationId ?? undefined,
+                  );
                   if (!returnTo) {
                     navigate(routes.assistant, { replace: true });
                     break;

--- a/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -28,6 +28,7 @@ import { hatchLocalAssistant } from "@/runtime/local-mode-host";
 import { isNativePlatform } from "@/runtime/native-auth";
 import { selectPlatformAssistant } from "@/assistant/select-platform-assistant";
 import { useAuthStore } from "@/stores/auth-store";
+import { useOrganizationStore } from "@/stores/organization-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import type { CharacterTraits } from "@/types/avatar";
 import { extractErrorMessage } from "@/utils/api-errors";
@@ -247,6 +248,8 @@ export function HatchingScreen() {
                 cloud: "vellum",
                 runtimeUrl: getPlatformRuntimeUrl(),
                 hatchedAt: new Date().toISOString(),
+                organizationId:
+                  useOrganizationStore.getState().currentOrganizationId ?? undefined,
               });
             }
             handleHatchReady();
@@ -448,6 +451,8 @@ export function HatchingScreen() {
                 cloud: "vellum",
                 runtimeUrl: getPlatformRuntimeUrl(),
                 hatchedAt: new Date().toISOString(),
+                organizationId:
+                  useOrganizationStore.getState().currentOrganizationId ?? undefined,
               });
             }
 

--- a/apps/web/src/domains/settings/components/panels/assistant-lifecycle-panel.tsx
+++ b/apps/web/src/domains/settings/components/panels/assistant-lifecycle-panel.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/generated/api/@tanstack/react-query.gen";
 import type { Assistant } from "@/generated/api/types.gen";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
+import { useOrganizationStore } from "@/stores/organization-store";
 import { Button } from "@vellumai/design-library/components/button";
 import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
 import { Tag } from "@vellumai/design-library/components/tag";
@@ -55,7 +56,10 @@ export function AssistantLifecyclePanel() {
           try {
             const list = await listAssistants();
             if (list.ok) {
-              await syncPlatformAssistantsToLockfile(list.data);
+              await syncPlatformAssistantsToLockfile(
+                list.data,
+                useOrganizationStore.getState().currentOrganizationId ?? undefined,
+              );
             }
           } catch {
             // Sync failed — the assistant was still created.

--- a/apps/web/src/lib/local-mode.ts
+++ b/apps/web/src/lib/local-mode.ts
@@ -147,7 +147,7 @@ export function getLockfile(): Lockfile {
  * cache only advances once the on-disk write succeeds.
  */
 export async function saveLockfileAssistant(
-  assistant: { assistantId: string; name?: string; cloud: string; runtimeUrl: string; hatchedAt: string },
+  assistant: { assistantId: string; name?: string; cloud: string; runtimeUrl: string; hatchedAt: string; organizationId?: string },
 ): Promise<void> {
   const result = await saveLockfileAssistantHost(
     assistant,
@@ -181,9 +181,15 @@ export async function setActiveLockfileAssistant(
 /**
  * Replace all platform-hosted assistant entries in the lockfile with the
  * current set from the API. Removes stale entries and adds new ones atomically.
+ *
+ * `organizationId` is stamped onto every platform entry so the host proxy can
+ * scope requests without guessing. The caller passes the active org: the API
+ * list is org-scoped by the `Vellum-Organization-Id` header, so every assistant
+ * in `assistants` belongs to that org.
  */
 export async function syncPlatformAssistantsToLockfile(
   assistants: Array<{ id: string; name?: string; is_local: boolean; created: string }>,
+  organizationId?: string,
 ): Promise<void> {
   const platformAssistants = assistants
     .filter((a) => !a.is_local)
@@ -193,6 +199,7 @@ export async function syncPlatformAssistantsToLockfile(
       cloud: "vellum",
       runtimeUrl: getPlatformRuntimeUrl(),
       hatchedAt: a.created,
+      ...(organizationId != null && { organizationId }),
     }));
 
   const result = await replacePlatformAssistantsHost(platformAssistants);

--- a/apps/web/src/stores/auth-store.test.ts
+++ b/apps/web/src/stores/auth-store.test.ts
@@ -53,7 +53,9 @@ const retrieveBiometricTokenMock = mock(async () => mockBiometricToken);
 // unaffected; the reconciliation tests override it to a well-formed result.
 let mockListAssistantsResult: unknown = [];
 const listAssistantsMock = mock(async () => mockListAssistantsResult);
-const syncPlatformAssistantsToLockfileMock = mock(async (_list: unknown) => {});
+const syncPlatformAssistantsToLockfileMock = mock(
+  async (_list: unknown, _orgId?: string) => {},
+);
 
 mock.module("@/lib/auth/allauth-client", () => ({
   getSession: async () => {
@@ -146,6 +148,7 @@ mock.module("@/stores/organization-store", () => ({
   useOrganizationStore: {
     getState: () => ({
       fetchOrganizations: async () => {},
+      currentOrganizationId: "org-test",
     }),
   },
 }));
@@ -313,9 +316,10 @@ describe("auth store onboarding flag reconciliation", () => {
     await expect(useAuthStore.getState().refreshSession()).resolves.toBe(true);
 
     expect(listAssistantsMock).toHaveBeenCalled();
-    expect(syncPlatformAssistantsToLockfileMock).toHaveBeenCalledWith([
-      { id: "assistant-3", name: "My Assistant", is_local: false, created: "2026-06-05T00:00:00Z" },
-    ]);
+    expect(syncPlatformAssistantsToLockfileMock).toHaveBeenCalledWith(
+      [{ id: "assistant-3", name: "My Assistant", is_local: false, created: "2026-06-05T00:00:00Z" }],
+      "org-test",
+    );
   });
 
   test("refreshSession skips lockfile sync outside local mode", async () => {

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -278,7 +278,10 @@ function probePlatformSession(
               ),
             ]);
             if (!isStale() && apiAssistants.ok) {
-              await syncPlatformAssistantsToLockfile(apiAssistants.data);
+              await syncPlatformAssistantsToLockfile(
+                apiAssistants.data,
+                useOrganizationStore.getState().currentOrganizationId ?? undefined,
+              );
             }
           } catch {
             // Sync failed or timed out — continue with cached lockfile data
@@ -385,7 +388,10 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
               await useOrganizationStore.getState().fetchOrganizations();
               const apiAssistants = await listAssistants();
               if (apiAssistants.ok) {
-                await syncPlatformAssistantsToLockfile(apiAssistants.data);
+                await syncPlatformAssistantsToLockfile(
+                  apiAssistants.data,
+                  useOrganizationStore.getState().currentOrganizationId ?? undefined,
+                );
                 if (getPlatformAssistants().length === 0 && getLocalAssistants().length === 0) {
                   set(authenticatedPlatformUser(user));
                   return;
@@ -527,7 +533,10 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
             await useOrganizationStore.getState().fetchOrganizations();
             const apiAssistants = await listAssistants();
             if (apiAssistants.ok) {
-              await syncPlatformAssistantsToLockfile(apiAssistants.data);
+              await syncPlatformAssistantsToLockfile(
+                apiAssistants.data,
+                useOrganizationStore.getState().currentOrganizationId ?? undefined,
+              );
             }
           } catch {
             // Sync failed — continue with cached lockfile data.

--- a/packages/local-mode/src/lockfile-contract.test.ts
+++ b/packages/local-mode/src/lockfile-contract.test.ts
@@ -10,10 +10,11 @@ describe("parseLockfile", () => {
         {
           assistantId: "asst_1",
           name: "Alice",
-          cloud: "local",
+          cloud: "vellum",
           runtimeUrl: "http://127.0.0.1:7777",
           species: "vellum",
           hatchedAt: "2026-01-01T00:00:00.000Z",
+          organizationId: "org_1",
           resources: { gatewayPort: 7777, daemonPort: 7778 },
         },
       ],
@@ -148,6 +149,24 @@ describe("parseLockfile", () => {
       activeAssistant: null,
     };
     expect(parseLockfile(raw).assistants).toEqual([]);
+  });
+
+  test("keeps organizationId on platform entries and drops it when mistyped", () => {
+    // Platform assistants carry their owning org so the host proxy can scope
+    // requests without guessing; local entries simply omit it.
+    const raw = {
+      assistants: [
+        { assistantId: "asst_1", cloud: "vellum", organizationId: "org_1" },
+        { assistantId: "asst_2", cloud: "vellum", organizationId: 7 }, // mistyped
+        { assistantId: "asst_3", cloud: "local" }, // local, no org
+      ],
+      activeAssistant: null,
+    };
+    expect(parseLockfile(raw).assistants).toEqual([
+      { assistantId: "asst_1", cloud: "vellum", organizationId: "org_1" },
+      { assistantId: "asst_2", cloud: "vellum" },
+      { assistantId: "asst_3", cloud: "local" },
+    ]);
   });
 
   test("drops a resources object missing its numeric ports", () => {

--- a/packages/local-mode/src/lockfile-contract.ts
+++ b/packages/local-mode/src/lockfile-contract.ts
@@ -42,6 +42,8 @@ export interface LockfileAssistant {
   runtimeUrl?: string;
   species?: string;
   hatchedAt?: string;
+  /** Owning org for platform assistants; absent for local ones. */
+  organizationId?: string;
   resources?: LocalAssistantResources;
 }
 
@@ -87,6 +89,7 @@ function parseAssistant(value: unknown): LockfileAssistant | null {
   if (typeof value.runtimeUrl === "string") assistant.runtimeUrl = value.runtimeUrl;
   if (typeof value.species === "string") assistant.species = value.species;
   if (typeof value.hatchedAt === "string") assistant.hatchedAt = value.hatchedAt;
+  if (typeof value.organizationId === "string") assistant.organizationId = value.organizationId;
   const resources = parseResources(value.resources);
   if (resources) assistant.resources = resources;
   return assistant;


### PR DESCRIPTION
## Summary
- Add an optional `organizationId` to `LockfileAssistant` and populate it for platform assistants during every sync/hatch flow, so the lockfile records which org owns each platform assistant.
- The macOS cloud host proxy now reads `organizationId` straight off the lockfile entry instead of calling `GET /v1/organizations/` and picking `results[0]` — the buggy heuristic that returned the wrong org for multi-org users (LUM-2299).
- Fold the org into the connection fingerprint so an org change triggers a reconnect, and single-source the fingerprint format to remove a connect/compare drift hazard.

## Original prompt
Following the consumer-side selection unification, we moved on to the write side. The cloud host proxy resolved the org ID by fetching the org list and taking the first result, which points at the wrong org when a multi-org user's active assistant belongs to a non-first org — causing assistant-scoped SSE and result POSTs to 404/reject (LUM-2299). The agreed direction: make the lockfile the registry of what assistants exist and which org owns each one by adding `organizationId` to the schema, populating it during sync/hatch, and having the proxy read it directly. We kept `activeAssistant` flat and per-tab selection in localStorage (unchanged), and — since the Assistant API doesn't expose an org field yet — pass the active org (`currentOrganizationId`) at sync time, which is correct because `listAssistants()` is org-scoped by the request header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)