### PR TITLE
fix: make launchAtLogin OS-state seed work and clean up slop

### DIFF
--- a/apps/macos/src/main/login-item.ts
+++ b/apps/macos/src/main/login-item.ts
@@ -4,17 +4,10 @@ import { z } from "zod";
 import { handle } from "./ipc";
 import { readSetting, onSettingChange, writeSetting } from "./settings";
 
-/** Apply the current `launchAtLogin` preference to the OS login item. */
-export const syncLoginItem = (): void => {
-  const value = readSetting("launchAtLogin");
-  app.setLoginItemSettings({ openAtLogin: value ?? false });
+const syncLoginItem = (): void => {
+  app.setLoginItemSettings({ openAtLogin: readSetting("launchAtLogin") ?? false });
 };
 
-/**
- * Install the typed launch-at-login IPC surface: `get` returns the current
- * boolean, `set` persists it (the existing `onSettingChange` subscription
- * from `installLoginItem` triggers `syncLoginItem()` in the same tick).
- */
 export const installLoginItemIpc = (): void => {
   handle("vellum:launchAtLogin:get", z.tuple([]), () =>
     readSetting("launchAtLogin") ?? false,
@@ -24,19 +17,13 @@ export const installLoginItemIpc = (): void => {
   });
 };
 
-/**
- * Sync on startup and subscribe to future changes. Returns an unsubscribe
- * function for cleanup.
- *
- * On first launch after the setting is introduced, seeds the preference from
- * the current OS login-item state so users who added Vellum manually via
- * System Settings keep their configuration.
- */
-export const installLoginItem = (): (() => void) => {
+// Seeds from the OS login-item state on first launch so users who added
+// Vellum manually via System Settings keep their configuration.
+export const installLoginItem = (): void => {
   if (readSetting("launchAtLogin") === null) {
     const { openAtLogin } = app.getLoginItemSettings();
     writeSetting("launchAtLogin", openAtLogin);
   }
   syncLoginItem();
-  return onSettingChange("launchAtLogin", () => syncLoginItem());
+  onSettingChange("launchAtLogin", () => syncLoginItem());
 };

--- a/apps/macos/src/main/settings.ts
+++ b/apps/macos/src/main/settings.ts
@@ -39,7 +39,6 @@ const schema: Schema<AppSettings> = {
   },
   launchAtLogin: {
     type: "boolean",
-    default: false,
   },
 };
 

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -322,9 +322,7 @@ export interface VellumBridge {
     onChange(callback: (catalog: ResolvedHotkey[]) => void): () => void;
   };
   launchAtLogin: {
-    /** Read the current launch-at-login preference. */
     get(): Promise<boolean>;
-    /** Persist the launch-at-login preference; triggers `syncLoginItem()`. */
     set(enabled: boolean): Promise<void>;
   };
   featureFlags: {

--- a/apps/web/src/runtime/launch-at-login.ts
+++ b/apps/web/src/runtime/launch-at-login.ts
@@ -1,12 +1,5 @@
 import { isElectron } from "@/runtime/is-electron";
 
-/**
- * Runtime wrapper for the Electron launch-at-login bridge
- * (`window.vellum.launchAtLogin`). Desktop-only; degrades to safe no-ops
- * on web/iOS and against older preloads that predate the channel.
- */
-
-/** Read the current launch-at-login preference (defaults to `false` off Electron). */
 export async function getLaunchAtLogin(): Promise<boolean> {
   if (!isElectron()) return false;
   const bridge = window.vellum;
@@ -14,7 +7,6 @@ export async function getLaunchAtLogin(): Promise<boolean> {
   return bridge.launchAtLogin.get();
 }
 
-/** Persist the launch-at-login preference (no-op off Electron). */
 export async function setLaunchAtLogin(enabled: boolean): Promise<void> {
   if (!isElectron()) return;
   const bridge = window.vellum;


### PR DESCRIPTION
## Summary
Fixes three gaps identified during self-review of the launch-at-login plan:

- **Dead OS-state seed**: Remove `default: false` from the `launchAtLogin` schema entry so `readSetting` returns `null` on first launch (not the AJV-injected default). This lets the seed logic in `installLoginItem` actually fire and preserve manually-configured login items.
- **Slop cleanup**: Make `syncLoginItem` module-private (never imported externally), change `installLoginItem` return type to `void` (matches all other `install*` functions; the subscription is app-lifetime).
- **Verbose comments**: Trim JSDoc that restates what function names already communicate.

Part of plan: launch-at-login.md (review fix round 1)