### PR TITLE
Launch at Login: main-process toggle + renderer settings UI

### DIFF
--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -41,7 +41,7 @@ import { installHotkeysIpc } from "./hotkeys";
 import { installPopoutWindows } from "./popout-window";
 import { installQuickInput } from "./quick-input-window";
 import { installLocalMode, resolveCliInvocation } from "./local-mode";
-import { installLoginItem } from "./login-item";
+import { installLoginItem, installLoginItemIpc } from "./login-item";
 import { installLockfileWatcher } from "./lockfile-watcher";
 import { installHostProxyBridge } from "./host-proxy-router";
 import "./executors/host-bash-executor"; // side-effect: registers host_bash executor
@@ -323,6 +323,7 @@ app
     installFeatureFlagsIpc();
     installLocalMode();
     installLoginItem();
+    installLoginItemIpc();
     installHotkeyHelper();
     installAbout();
     installAutoUpdate();

--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -41,6 +41,7 @@ import { installHotkeysIpc } from "./hotkeys";
 import { installPopoutWindows } from "./popout-window";
 import { installQuickInput } from "./quick-input-window";
 import { installLocalMode, resolveCliInvocation } from "./local-mode";
+import { installLoginItem } from "./login-item";
 import { installLockfileWatcher } from "./lockfile-watcher";
 import { installHostProxyBridge } from "./host-proxy-router";
 import "./executors/host-bash-executor"; // side-effect: registers host_bash executor
@@ -321,6 +322,7 @@ app
     installHotkeysIpc();
     installFeatureFlagsIpc();
     installLocalMode();
+    installLoginItem();
     installHotkeyHelper();
     installAbout();
     installAutoUpdate();

--- a/apps/macos/src/main/login-item.ts
+++ b/apps/macos/src/main/login-item.ts
@@ -1,0 +1,26 @@
+import { app } from "electron";
+
+import { readSetting, onSettingChange, writeSetting } from "./settings";
+
+/** Apply the current `launchAtLogin` preference to the OS login item. */
+export const syncLoginItem = (): void => {
+  const value = readSetting("launchAtLogin");
+  app.setLoginItemSettings({ openAtLogin: value ?? false });
+};
+
+/**
+ * Sync on startup and subscribe to future changes. Returns an unsubscribe
+ * function for cleanup.
+ *
+ * On first launch after the setting is introduced, seeds the preference from
+ * the current OS login-item state so users who added Vellum manually via
+ * System Settings keep their configuration.
+ */
+export const installLoginItem = (): (() => void) => {
+  if (readSetting("launchAtLogin") === null) {
+    const { openAtLogin } = app.getLoginItemSettings();
+    writeSetting("launchAtLogin", openAtLogin);
+  }
+  syncLoginItem();
+  return onSettingChange("launchAtLogin", () => syncLoginItem());
+};

--- a/apps/macos/src/main/login-item.ts
+++ b/apps/macos/src/main/login-item.ts
@@ -4,17 +4,10 @@ import { z } from "zod";
 import { handle } from "./ipc";
 import { readSetting, onSettingChange, writeSetting } from "./settings";
 
-/** Apply the current `launchAtLogin` preference to the OS login item. */
-export const syncLoginItem = (): void => {
-  const value = readSetting("launchAtLogin");
-  app.setLoginItemSettings({ openAtLogin: value ?? false });
+const syncLoginItem = (): void => {
+  app.setLoginItemSettings({ openAtLogin: readSetting("launchAtLogin") ?? false });
 };
 
-/**
- * Install the typed launch-at-login IPC surface: `get` returns the current
- * boolean, `set` persists it (the existing `onSettingChange` subscription
- * from `installLoginItem` triggers `syncLoginItem()` in the same tick).
- */
 export const installLoginItemIpc = (): void => {
   handle("vellum:launchAtLogin:get", z.tuple([]), () =>
     readSetting("launchAtLogin") ?? false,
@@ -24,19 +17,13 @@ export const installLoginItemIpc = (): void => {
   });
 };
 
-/**
- * Sync on startup and subscribe to future changes. Returns an unsubscribe
- * function for cleanup.
- *
- * On first launch after the setting is introduced, seeds the preference from
- * the current OS login-item state so users who added Vellum manually via
- * System Settings keep their configuration.
- */
-export const installLoginItem = (): (() => void) => {
+// Seeds from the OS login-item state on first launch so users who added
+// Vellum manually via System Settings keep their configuration.
+export const installLoginItem = (): void => {
   if (readSetting("launchAtLogin") === null) {
     const { openAtLogin } = app.getLoginItemSettings();
     writeSetting("launchAtLogin", openAtLogin);
   }
   syncLoginItem();
-  return onSettingChange("launchAtLogin", () => syncLoginItem());
+  onSettingChange("launchAtLogin", () => syncLoginItem());
 };

--- a/apps/macos/src/main/login-item.ts
+++ b/apps/macos/src/main/login-item.ts
@@ -1,11 +1,27 @@
 import { app } from "electron";
+import { z } from "zod";
 
+import { handle } from "./ipc";
 import { readSetting, onSettingChange, writeSetting } from "./settings";
 
 /** Apply the current `launchAtLogin` preference to the OS login item. */
 export const syncLoginItem = (): void => {
   const value = readSetting("launchAtLogin");
   app.setLoginItemSettings({ openAtLogin: value ?? false });
+};
+
+/**
+ * Install the typed launch-at-login IPC surface: `get` returns the current
+ * boolean, `set` persists it (the existing `onSettingChange` subscription
+ * from `installLoginItem` triggers `syncLoginItem()` in the same tick).
+ */
+export const installLoginItemIpc = (): void => {
+  handle("vellum:launchAtLogin:get", z.tuple([]), () =>
+    readSetting("launchAtLogin") ?? false,
+  );
+  handle("vellum:launchAtLogin:set", z.tuple([z.boolean()]), ([enabled]) => {
+    writeSetting("launchAtLogin", enabled);
+  });
 };
 
 /**

--- a/apps/macos/src/main/settings.ts
+++ b/apps/macos/src/main/settings.ts
@@ -39,7 +39,6 @@ const schema: Schema<AppSettings> = {
   },
   launchAtLogin: {
     type: "boolean",
-    default: false,
   },
 };
 

--- a/apps/macos/src/main/settings.ts
+++ b/apps/macos/src/main/settings.ts
@@ -18,6 +18,7 @@ export interface AppSettings {
   hotkeys: Record<string, string>;
   theme: "light" | "dark" | "system";
   featureFlags: Record<string, boolean>;
+  launchAtLogin: boolean;
 }
 
 const schema: Schema<AppSettings> = {
@@ -35,6 +36,10 @@ const schema: Schema<AppSettings> = {
     type: "object",
     additionalProperties: { type: "boolean" },
     default: {},
+  },
+  launchAtLogin: {
+    type: "boolean",
+    default: false,
   },
 };
 

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -322,9 +322,7 @@ export interface VellumBridge {
     onChange(callback: (catalog: ResolvedHotkey[]) => void): () => void;
   };
   launchAtLogin: {
-    /** Read the current launch-at-login preference. */
     get(): Promise<boolean>;
-    /** Persist the launch-at-login preference; triggers `syncLoginItem()`. */
     set(enabled: boolean): Promise<void>;
   };
   featureFlags: {

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -321,6 +321,12 @@ export interface VellumBridge {
      */
     onChange(callback: (catalog: ResolvedHotkey[]) => void): () => void;
   };
+  launchAtLogin: {
+    /** Read the current launch-at-login preference. */
+    get(): Promise<boolean>;
+    /** Persist the launch-at-login preference; triggers `syncLoginItem()`. */
+    set(enabled: boolean): Promise<void>;
+  };
   featureFlags: {
     /** Publish the renderer's feature-flag map to main (fire-and-forget). */
     set(flags: Record<string, boolean>): void;
@@ -690,6 +696,12 @@ const bridge: VellumBridge = {
         ipcRenderer.off("vellum:hotkeys:changed", handler);
       };
     },
+  },
+  launchAtLogin: {
+    get: (): Promise<boolean> =>
+      ipcRenderer.invoke("vellum:launchAtLogin:get") as Promise<boolean>,
+    set: (enabled: boolean): Promise<void> =>
+      ipcRenderer.invoke("vellum:launchAtLogin:set", enabled) as Promise<void>,
   },
   featureFlags: {
     set: (flags: Record<string, boolean>): void => {

--- a/apps/web/src/domains/settings/components/launch-at-login-card.tsx
+++ b/apps/web/src/domains/settings/components/launch-at-login-card.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react";
+
+import { DetailCard } from "@/components/detail-card";
+import { getLaunchAtLogin, setLaunchAtLogin } from "@/runtime/launch-at-login";
+import { Toggle } from "@vellumai/design-library/components/toggle";
+
+export function LaunchAtLoginCard() {
+  const [enabled, setEnabled] = useState(false);
+
+  useEffect(() => {
+    getLaunchAtLogin().then(setEnabled);
+  }, []);
+
+  const handleToggle = async (next: boolean) => {
+    setEnabled(next);
+    try {
+      await setLaunchAtLogin(next);
+    } catch {
+      setEnabled(!next);
+    }
+  };
+
+  return (
+    <DetailCard
+      title="Launch at Login"
+      subtitle="Automatically start Vellum when you log in to your Mac."
+    >
+      <Toggle checked={enabled} onChange={(next) => void handleToggle(next)} />
+    </DetailCard>
+  );
+}

--- a/apps/web/src/domains/settings/components/launch-at-login-card.tsx
+++ b/apps/web/src/domains/settings/components/launch-at-login-card.tsx
@@ -25,7 +25,7 @@ export function LaunchAtLoginCard() {
       title="Launch at Login"
       subtitle="Automatically start Vellum when you log in to your Mac."
     >
-      <Toggle checked={enabled} onChange={(next) => void handleToggle(next)} />
+      <Toggle checked={enabled} onChange={(next) => void handleToggle(next)} aria-label="Launch at Login" />
     </DetailCard>
   );
 }

--- a/apps/web/src/domains/settings/pages/general-page.tsx
+++ b/apps/web/src/domains/settings/pages/general-page.tsx
@@ -15,6 +15,7 @@ import {
 import { AssistantUpgrades } from "@/domains/settings/components/assistant-upgrades";
 import { DeleteAccountSection } from "@/domains/settings/components/delete-account-section";
 import { IOSAppCard } from "@/domains/settings/components/ios-app-card";
+import { LaunchAtLoginCard } from "@/domains/settings/components/launch-at-login-card";
 import { MediaEmbedsCard } from "@/domains/settings/components/media-embeds-card";
 import { PreviewReleaseChannel } from "@/domains/settings/components/preview-release-channel";
 import { ResizeCard } from "@/domains/settings/components/resize-card";
@@ -37,6 +38,7 @@ import {
     isLocalAssistant,
     isLocalMode,
 } from "@/lib/local-mode";
+import { isElectron } from "@/runtime/is-electron";
 import { captureError } from "@/lib/sentry/capture-error";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { useIsAuthenticated } from "@/stores/auth-store";
@@ -297,6 +299,8 @@ export function GeneralPage() {
       )}
 
       <ThemeCard />
+
+      {isElectron() && <LaunchAtLoginCard />}
 
       {infraGate === "full" && platformAssistant && (
         <DetailCard title="Software Updates">

--- a/apps/web/src/runtime/is-electron.ts
+++ b/apps/web/src/runtime/is-electron.ts
@@ -297,6 +297,11 @@ declare global {
         set(key: string, accelerator: string | null): Promise<void>;
         onChange(callback: (catalog: ResolvedHotkey[]) => void): () => void;
       };
+      // Optional: older Electron shells predate the launch-at-login channel.
+      launchAtLogin?: {
+        get(): Promise<boolean>;
+        set(enabled: boolean): Promise<void>;
+      };
       featureFlags?: {
         set(flags: Record<string, boolean>): void;
       };

--- a/apps/web/src/runtime/launch-at-login.ts
+++ b/apps/web/src/runtime/launch-at-login.ts
@@ -1,12 +1,5 @@
 import { isElectron } from "@/runtime/is-electron";
 
-/**
- * Runtime wrapper for the Electron launch-at-login bridge
- * (`window.vellum.launchAtLogin`). Desktop-only; degrades to safe no-ops
- * on web/iOS and against older preloads that predate the channel.
- */
-
-/** Read the current launch-at-login preference (defaults to `false` off Electron). */
 export async function getLaunchAtLogin(): Promise<boolean> {
   if (!isElectron()) return false;
   const bridge = window.vellum;
@@ -14,7 +7,6 @@ export async function getLaunchAtLogin(): Promise<boolean> {
   return bridge.launchAtLogin.get();
 }
 
-/** Persist the launch-at-login preference (no-op off Electron). */
 export async function setLaunchAtLogin(enabled: boolean): Promise<void> {
   if (!isElectron()) return;
   const bridge = window.vellum;

--- a/apps/web/src/runtime/launch-at-login.ts
+++ b/apps/web/src/runtime/launch-at-login.ts
@@ -1,0 +1,23 @@
+import { isElectron } from "@/runtime/is-electron";
+
+/**
+ * Runtime wrapper for the Electron launch-at-login bridge
+ * (`window.vellum.launchAtLogin`). Desktop-only; degrades to safe no-ops
+ * on web/iOS and against older preloads that predate the channel.
+ */
+
+/** Read the current launch-at-login preference (defaults to `false` off Electron). */
+export async function getLaunchAtLogin(): Promise<boolean> {
+  if (!isElectron()) return false;
+  const bridge = window.vellum;
+  if (!bridge?.launchAtLogin) return false;
+  return bridge.launchAtLogin.get();
+}
+
+/** Persist the launch-at-login preference (no-op off Electron). */
+export async function setLaunchAtLogin(enabled: boolean): Promise<void> {
+  if (!isElectron()) return;
+  const bridge = window.vellum;
+  if (!bridge?.launchAtLogin) return;
+  await bridge.launchAtLogin.set(enabled);
+}


### PR DESCRIPTION
## Summary
Wire macOS launch-at-login for the Electron app end-to-end:
- Add `launchAtLogin: boolean` to `AppSettings` and the electron-store schema
- Main-process module that syncs the OS login item via `app.setLoginItemSettings`
- IPC handlers + preload bridge + renderer runtime wrapper
- Toggle on the General settings page, hidden off Electron
- Seeds from the current OS login-item state on first launch so manually-configured users keep their setup

## Self-review result
GAPS FOUND — 3 gaps fixed in 1 fix PR (#34308):
- Dead OS-state seed (schema default masked the null check)
- Exported function that should be module-private
- Verbose comments

## PRs merged into feature branch
- #34293: feat(electron): add `launchAtLogin` setting and main-process login-item module
- #34296: feat(electron): expose launch-at-login through preload bridge and renderer wrapper
- #34303: feat(web): add Launch at Login toggle to General settings page

### Fix PRs
- #34308: fix: make launchAtLogin OS-state seed work and clean up slop

Closes LUM-1963

Part of plan: launch-at-login.md