### PR TITLE
feat(browser): first-class host-bridge CDP backend so cloud daemons can drive the user's Chrome

### DIFF
--- a/assistant/src/__tests__/host-browser-proxy.test.ts
+++ b/assistant/src/__tests__/host-browser-proxy.test.ts
@@ -44,6 +44,8 @@ mock.module("../runtime/assistant-event-hub.js", () => ({
       mockClients.find((c) => c.capabilities.includes(cap)),
     listClientsByCapability: (cap: string) =>
       mockClients.filter((c) => c.capabilities.includes(cap)),
+    listClientsByInterface: (interfaceId: string) =>
+      mockClients.filter((c) => c.interfaceId === interfaceId),
     getActorPrincipalIdForClient: (clientId: string) =>
       mockClients.find((c) => c.clientId === clientId)?.actorPrincipalId,
   },
@@ -275,6 +277,53 @@ describe("HostBrowserProxy", () => {
     test("returns false when no connection exists", () => {
       mockClients = [];
       expect(proxy.isAvailable()).toBe(false);
+    });
+  });
+
+  describe("actor-scoped availability", () => {
+    const EXT_A: MockClient = {
+      clientId: "ext-a",
+      interfaceId: "chrome-extension",
+      actorPrincipalId: "actor-a",
+      capabilities: ["host_browser"],
+    };
+    const BRIDGE_B: MockClient = {
+      clientId: "bridge-b",
+      interfaceId: "macos",
+      actorPrincipalId: "actor-b",
+      capabilities: ["host_browser"],
+    };
+
+    test("isAvailable(actor) only counts that actor's clients", () => {
+      mockClients = [EXT_A, BRIDGE_B];
+      expect(proxy.isAvailable("actor-a")).toBe(true);
+      expect(proxy.isAvailable("actor-b")).toBe(true);
+      expect(proxy.isAvailable("actor-c")).toBe(false);
+      // Legacy no-actor form still counts any client.
+      expect(proxy.isAvailable()).toBe(true);
+    });
+
+    test("hasExtensionClient(actor) ignores other actors' extensions", () => {
+      mockClients = [EXT_A, BRIDGE_B];
+      expect(proxy.hasExtensionClient("actor-a")).toBe(true);
+      // actor-b has only the bridge — actor-a's extension must not count.
+      expect(proxy.hasExtensionClient("actor-b")).toBe(false);
+      expect(proxy.hasExtensionClient()).toBe(true);
+    });
+
+    test("hasExtensionClient(actor) is false for a client without an actor binding", () => {
+      // Strict matching mirrors resolveTargetClient: a legacy extension
+      // connection without an actor is not dispatchable for an
+      // actor-authenticated caller, so it must not count as available.
+      mockClients = [
+        {
+          clientId: "legacy-ext",
+          interfaceId: "chrome-extension",
+          capabilities: ["host_browser"],
+        },
+      ];
+      expect(proxy.hasExtensionClient("actor-a")).toBe(false);
+      expect(proxy.hasExtensionClient()).toBe(true);
     });
   });
 

--- a/assistant/src/browser-session/backends/host-bridge.ts
+++ b/assistant/src/browser-session/backends/host-bridge.ts
@@ -1,0 +1,29 @@
+import type { BrowserBackend, CdpCommand, CdpResult } from "../types.js";
+
+/**
+ * Host-bridge backend for BrowserSessionManager. Wraps a caller-provided
+ * `sendCdp` transport that routes raw CDP commands through the daemon's
+ * HostBrowserProxy to the desktop client's SSE bridge, which executes
+ * them against the user's Chrome via its local remote-debugging port.
+ * Unlike the extension backend, the bridge has no `Vellum.*`
+ * pseudo-method support. The factory in
+ * `assistant/src/tools/browser/cdp-client/factory.ts` constructs one
+ * per tool invocation.
+ */
+export interface HostBridgeBackendDeps {
+  /** Sends a raw CDP command via the desktop SSE bridge and returns the CDP result. */
+  sendCdp(command: CdpCommand, signal?: AbortSignal): Promise<CdpResult>;
+  isAvailable(): boolean;
+  dispose(): void;
+}
+
+export function createHostBridgeBackend(
+  deps: HostBridgeBackendDeps,
+): BrowserBackend {
+  return {
+    kind: "host-bridge",
+    isAvailable: deps.isAvailable,
+    send: deps.sendCdp,
+    dispose: deps.dispose,
+  };
+}

--- a/assistant/src/browser-session/index.ts
+++ b/assistant/src/browser-session/index.ts
@@ -21,6 +21,7 @@
  */
 export * from "./backends/cdp-inspect.js";
 export * from "./backends/extension.js";
+export * from "./backends/host-bridge.js";
 export * from "./backends/local.js";
 export * from "./events.js";
 export * from "./manager.js";

--- a/assistant/src/browser-session/types.ts
+++ b/assistant/src/browser-session/types.ts
@@ -1,4 +1,8 @@
-export type BrowserBackendKind = "extension" | "local" | "cdp-inspect";
+export type BrowserBackendKind =
+  | "extension"
+  | "local"
+  | "cdp-inspect"
+  | "host-bridge";
 
 export interface CdpCommand {
   method: string;

--- a/assistant/src/daemon/host-browser-proxy.ts
+++ b/assistant/src/daemon/host-browser-proxy.ts
@@ -91,6 +91,22 @@ function extensionRequiredResult(
  * candidate clients are filtered down to those owned by the same actor.
  * Returns `undefined` when no eligible client is connected.
  */
+/**
+ * Whether any of `clients` is dispatchable for the caller. Without an
+ * actor, any client counts (legacy single-user behavior); with one,
+ * only same-actor clients count — the strict match used by
+ * `resolveTargetClient`.
+ */
+function hasClientForActor(
+  clients: ReadonlyArray<{ actorPrincipalId?: string }>,
+  sourceActorPrincipalId?: string,
+): boolean {
+  if (sourceActorPrincipalId == null) return clients.length > 0;
+  return clients.some(
+    (c) => c.actorPrincipalId === sourceActorPrincipalId,
+  );
+}
+
 function resolveTargetClient(
   cdpMethod: string,
   sourceActorPrincipalId: string | undefined,
@@ -149,10 +165,16 @@ export class HostBrowserProxy {
    * Returns `true` when either the Chrome Extension or the macOS SSE
    * bridge is available — i.e. any transport can forward host-browser
    * requests.
+   *
+   * When `sourceActorPrincipalId` is supplied, only clients owned by
+   * that actor count — mirroring `resolveTargetClient`'s strict actor
+   * matching so availability checks never report a client the proxy
+   * would refuse to dispatch to.
    */
-  isAvailable(): boolean {
-    return (
-      assistantEventHub.getMostRecentClientByCapability("host_browser") != null
+  isAvailable(sourceActorPrincipalId?: string): boolean {
+    return hasClientForActor(
+      assistantEventHub.listClientsByCapability("host_browser"),
+      sourceActorPrincipalId,
     );
   }
 
@@ -161,9 +183,17 @@ export class HostBrowserProxy {
    * Returns `false` when only the macOS SSE bridge is available.
    * Unlike {@link isAvailable}, this does not consider the macOS bridge
    * a valid extension transport.
+   *
+   * When `sourceActorPrincipalId` is supplied, only extension clients
+   * owned by that actor count. On a multi-actor cloud daemon, another
+   * actor's connected extension must not make this actor's
+   * conversations select extension-labelled transports.
    */
-  hasExtensionClient(): boolean {
-    return assistantEventHub.listClientsByInterface("chrome-extension").length > 0;
+  hasExtensionClient(sourceActorPrincipalId?: string): boolean {
+    return hasClientForActor(
+      assistantEventHub.listClientsByInterface("chrome-extension"),
+      sourceActorPrincipalId,
+    );
   }
 
   /**

--- a/assistant/src/tools/browser/__tests__/browser-execution-acquire.test.ts
+++ b/assistant/src/tools/browser/__tests__/browser-execution-acquire.test.ts
@@ -11,14 +11,15 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { createMockLoggerModule } from "../../../__tests__/helpers/mock-logger.js";
 import type { ToolContext } from "../../types.js";
-import type { BrowserMode, CdpClientKind } from "../cdp-client/types.js";
+import { CdpError } from "../cdp-client/errors.js";
+import type { CdpClientKind, InternalBrowserMode } from "../cdp-client/types.js";
 
 // ---------------------------------------------------------------------------
 // Captured call state
 // ---------------------------------------------------------------------------
 
 interface CdpClientCallOpts {
-  mode?: BrowserMode;
+  mode?: InternalBrowserMode;
   targetClientId?: string;
 }
 
@@ -196,5 +197,51 @@ describe("acquireCdpClientWithMode: target_client_id overrides sticky backend mo
     expect(getCdpClientMock).toHaveBeenCalledTimes(1);
     expect(getCdpClientCalls[0].mode).toBe("extension");
     expect(getCdpClientCalls[0].targetClientId).toBe("host-client-fresh");
+  });
+
+  test("sticky host-bridge + no target_client_id → getCdpClient receives mode:host-bridge", async () => {
+    // A prior turn succeeded on the desktop SSE bridge; the memo holds the
+    // internal-only "host-bridge" kind and must round-trip through the
+    // factory's pinned path.
+    stickyKind = "host-bridge";
+
+    await executeBrowserAttach({}, makeContext("sticky-bridge-honored"));
+
+    expect(getCdpClientMock).toHaveBeenCalledTimes(1);
+    expect(getCdpClientCalls[0].mode).toBe("host-bridge");
+  });
+
+  test("sticky host-bridge + target_client_id → getCdpClient receives mode:extension", async () => {
+    stickyKind = "host-bridge";
+
+    await executeBrowserAttach(
+      { target_client_id: "host-client-bridge" },
+      makeContext("sticky-bridge-override"),
+    );
+
+    expect(getCdpClientMock).toHaveBeenCalledTimes(1);
+    expect(getCdpClientCalls[0].mode).toBe("extension");
+    expect(getCdpClientCalls[0].targetClientId).toBe("host-client-bridge");
+  });
+
+  test("sticky host-bridge gone → memo cleared and auto retry runs", async () => {
+    // The pinned host-bridge build throws (bridge disconnected or an
+    // extension connected since the memo was written); the acquire layer
+    // must clear the stale memo and retry with fresh auto selection.
+    stickyKind = "host-bridge";
+    getCdpClientMock.mockImplementationOnce(() => {
+      getCdpClientCalls.push({ mode: "host-bridge" });
+      throw new CdpError(
+        "transport_error",
+        'Pinned mode "host-bridge" unavailable: a Chrome Extension is now connected',
+      );
+    });
+
+    await executeBrowserAttach({}, makeContext("sticky-bridge-fallback"));
+
+    expect(getCdpClientMock).toHaveBeenCalledTimes(2);
+    expect(getCdpClientCalls[0].mode).toBe("host-bridge");
+    expect(getCdpClientCalls[1].mode).toBe("auto");
+    expect(clearPreferredBackendKindMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/assistant/src/tools/browser/__tests__/browser-status.test.ts
+++ b/assistant/src/tools/browser/__tests__/browser-status.test.ts
@@ -20,11 +20,13 @@ const probeErrors: Record<string, CdpError | null> = {
   [BROWSER_STATUS_MODE.LOCAL]: null,
 };
 
-const buildCandidateListMock = mock((_context: ToolContext) => [
-  { kind: BROWSER_STATUS_MODE.EXTENSION, reason: "mock" },
-  { kind: BROWSER_STATUS_MODE.CDP_INSPECT, reason: "mock" },
-  { kind: BROWSER_STATUS_MODE.LOCAL, reason: "mock" },
-]);
+const buildCandidateListMock = mock(
+  (_context: ToolContext): Array<{ kind: string; reason: string }> => [
+    { kind: BROWSER_STATUS_MODE.EXTENSION, reason: "mock" },
+    { kind: BROWSER_STATUS_MODE.CDP_INSPECT, reason: "mock" },
+    { kind: BROWSER_STATUS_MODE.LOCAL, reason: "mock" },
+  ],
+);
 
 const getCdpClientMock = mock(
   (_context: ToolContext, options?: { mode?: string }) => {
@@ -251,6 +253,28 @@ describe("executeBrowserStatus", () => {
     expect(result.isError).toBe(false);
     const payload = JSON.parse(result.content);
     // Extension is unavailable, so recommendation should fall to next available
+    expect(payload.recommendedMode).toBe(BROWSER_STATUS_MODE.CDP_INSPECT);
+  });
+
+  test("host-bridge auto candidate is reported but never recommended as a status mode", async () => {
+    // Bridge-only scenario: the auto candidate list leads with host-bridge,
+    // which is not a pinnable status mode — recommendation must fall to the
+    // first candidate that IS a checkable mode.
+    mockSingletonProxy = {
+      isAvailable: () => true,
+      hasExtensionClient: () => false,
+      request: () => {},
+    };
+    buildCandidateListMock.mockImplementationOnce((_context: ToolContext) => [
+      { kind: "host-bridge", reason: "mock bridge" },
+      { kind: BROWSER_STATUS_MODE.CDP_INSPECT, reason: "mock" },
+      { kind: BROWSER_STATUS_MODE.LOCAL, reason: "mock" },
+    ]);
+
+    const result = await executeBrowserStatus({}, makeContext());
+    expect(result.isError).toBe(false);
+    const payload = JSON.parse(result.content);
+    expect(payload.autoCandidateOrder[0]).toBe("host-bridge");
     expect(payload.recommendedMode).toBe(BROWSER_STATUS_MODE.CDP_INSPECT);
   });
 

--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -2400,7 +2400,7 @@ async function checkExtensionModeStatus(
 ): Promise<BrowserStatusModeResult> {
   const proxy = HostBrowserProxy.instance;
 
-  if (!proxy.hasExtensionClient()) {
+  if (!proxy.hasExtensionClient(context.sourceActorPrincipalId)) {
     return {
       mode: BROWSER_STATUS_MODE.EXTENSION,
       available: false,

--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -70,6 +70,7 @@ import type {
   AttemptDiagnostic,
   CdpClient,
   CdpClientKind,
+  InternalBrowserMode,
 } from "./cdp-client/types.js";
 import { clearPinnedTab, setPinnedTab } from "./pinned-tabs.js";
 import { checkBrowserRuntime } from "./runtime-check.js";
@@ -226,6 +227,18 @@ const REMEDIATION_HINTS: Record<string, string[]> = {
     "CDP endpoint unreachable. Ensure Chrome is running with --remote-debugging-port.",
     "Verify the configured host:port matches Chrome's DevTools listener.",
     "Consider using browser_mode: 'extension' or 'local' as an alternative.",
+  ],
+  // Host-bridge backend (desktop SSE bridge → user's Chrome debug port)
+  "host-bridge:unreachable": [
+    "Ensure Chrome on the user's machine is on version 146 or higher (chrome://settings/help).",
+    'Ensure "Allow remote debugging for this browser instance" is toggled on at chrome://inspect/#remote-debugging.',
+    "Verify the desktop client is running and has an active SSE connection to the assistant.",
+    "Installing the Vellum Chrome extension is the preferred path and avoids the debug-port requirement.",
+  ],
+  "host-bridge:transport_error": [
+    "The desktop client could not reach Chrome's remote-debugging endpoint on the user's machine.",
+    "Ensure Chrome is running with remote debugging enabled, or install the Vellum Chrome extension (preferred).",
+    "Verify the desktop client is running and connected.",
   ],
   // Local/Playwright backend
   "local:transport_error": [
@@ -390,7 +403,9 @@ function acquireCdpClientWithMode(
   );
   // target_client_id requires the extension proxy path — bypass any sticky
   // backend remembered from prior turns so the explicit target always wins.
-  const effectiveMode: BrowserMode =
+  // InternalBrowserMode because the memo may hold "host-bridge", which is
+  // pinnable by the factory but never user-requestable.
+  const effectiveMode: InternalBrowserMode =
     targetClientId != null
       ? "extension"
       : browserMode === "auto" && rememberedKind !== null
@@ -1383,14 +1398,17 @@ export async function executeBrowserClose(
       };
     }
 
-    // Extension path: the user owns their Chrome tab — we must not
-    // close it. Detach the debugger (so the Chrome debugging banner
-    // clears promptly) and drop the cached snapshot state so stale
+    // Non-local path: the user owns their Chrome tab — we must not
+    // close it. On the extension backend, detach the debugger (so the
+    // Chrome debugging banner clears promptly); other backends have no
+    // Vellum.detach. Either way drop the cached snapshot state so stale
     // eids from prior snapshots cannot be resolved by later tool calls.
-    try {
-      await cdp.send("Vellum.detach", {}, context.signal);
-    } catch {
-      // Tolerate detach failures (already detached, tab closed, etc.)
+    if (cdp.kind === "extension") {
+      try {
+        await cdp.send("Vellum.detach", {}, context.signal);
+      } catch {
+        // Tolerate detach failures (already detached, tab closed, etc.)
+      }
     }
     browserManager.clearSnapshotBackendNodeMap(context.conversationId);
     browserManager.clearPreferredBackendKind(context.conversationId);

--- a/assistant/src/tools/browser/cdp-client/__tests__/factory.test.ts
+++ b/assistant/src/tools/browser/cdp-client/__tests__/factory.test.ts
@@ -5,7 +5,7 @@ import type { ToolContext } from "../../../types.js";
 import { CdpError } from "../errors.js";
 
 type FakeClient = {
-  kind: "extension" | "local" | "cdp-inspect";
+  kind: "extension" | "local" | "cdp-inspect" | "host-bridge";
   conversationId: string;
   send: ReturnType<typeof mock>;
   dispose: ReturnType<typeof mock>;
@@ -16,6 +16,15 @@ function makeFakeExtensionClient(conversationId: string): FakeClient {
     kind: "extension",
     conversationId,
     send: mock(async () => ({ ok: true, via: "extension" })),
+    dispose: mock(() => {}),
+  };
+}
+
+function makeFakeHostBridgeClient(conversationId: string): FakeClient {
+  return {
+    kind: "host-bridge",
+    conversationId,
+    send: mock(async () => ({ ok: true, via: "host-bridge" })),
     dispose: mock(() => {}),
   };
 }
@@ -41,11 +50,24 @@ function makeFakeCdpInspectClient(conversationId: string): FakeClient {
 let lastExtensionClient: FakeClient | undefined;
 let lastLocalClient: FakeClient | undefined;
 let lastCdpInspectClient: FakeClient | undefined;
+let lastHostBridgeClient: FakeClient | undefined;
 
 const createExtensionCdpClientMock = mock(
   (_proxy: HostBrowserProxy, conversationId: string) => {
     const client = makeFakeExtensionClient(conversationId);
     lastExtensionClient = client;
+    return client;
+  },
+);
+
+const createHostBridgeCdpClientMock = mock(
+  (
+    _proxy: HostBrowserProxy,
+    conversationId: string,
+    _sourceActorPrincipalId?: string,
+  ) => {
+    const client = makeFakeHostBridgeClient(conversationId);
+    lastHostBridgeClient = client;
     return client;
   },
 );
@@ -86,11 +108,16 @@ const logDebugCalls: Array<{ args: unknown[] }> = [];
 // suite stubs out.
 import * as realCdpInspectClient from "../cdp-inspect-client.js";
 import * as realExtensionCdpClient from "../extension-cdp-client.js";
+import * as realHostBridgeCdpClient from "../host-bridge-cdp-client.js";
 import * as realLocalCdpClient from "../local-cdp-client.js";
 
 mock.module("../extension-cdp-client.js", () => ({
   ...realExtensionCdpClient,
   createExtensionCdpClient: createExtensionCdpClientMock,
+}));
+mock.module("../host-bridge-cdp-client.js", () => ({
+  ...realHostBridgeCdpClient,
+  createHostBridgeCdpClient: createHostBridgeCdpClientMock,
 }));
 mock.module("../local-cdp-client.js", () => ({
   ...realLocalCdpClient,
@@ -161,6 +188,10 @@ const {
   _getDesktopAutoCooldownSince,
   recordDesktopAutoCooldown,
   isDesktopAutoCooldownActive,
+  _resetHostBridgeCooldown,
+  _getHostBridgeCooldownSince,
+  recordHostBridgeCooldown,
+  isHostBridgeCooldownActive,
 } = await import("../factory.js");
 
 /**
@@ -215,12 +246,15 @@ describe("getCdpClient", () => {
     createExtensionCdpClientMock.mockClear();
     createLocalCdpClientMock.mockClear();
     createCdpInspectClientMock.mockClear();
+    createHostBridgeCdpClientMock.mockClear();
     lastExtensionClient = undefined;
     lastLocalClient = undefined;
     lastCdpInspectClient = undefined;
+    lastHostBridgeClient = undefined;
     cdpInspectEnabled = false;
     desktopAutoConfig = { enabled: true, cooldownMs: 30_000 };
     _resetDesktopAutoCooldown();
+    _resetHostBridgeCooldown();
     logWarnCalls.length = 0;
     logDebugCalls.length = 0;
     mockSingletonProxy = null;
@@ -816,10 +850,11 @@ describe("buildCandidateList", () => {
     expect(candidates[0].kind).toBe("local");
   });
 
-  test("excludes extension candidate when only macOS SSE bridge is connected", () => {
+  test("uses host-bridge candidate when only macOS SSE bridge is connected", () => {
     // isAvailable() = true but hasExtensionClient() = false: only macOS bridge.
-    // The macOS bridge routes through localhost:9222 on the host, so it must
-    // NOT be included under the "extension" candidate kind.
+    // The bridge gets its own first-class candidate kind — it must NOT be
+    // labelled "extension" (it routes raw CDP through localhost:9222 on the
+    // host and cannot serve Vellum.* pseudo-methods).
     const fakeProxy = makeMacosBridgeOnlyProxy();
     mockSingletonProxy = fakeProxy;
     const ctx = makeContext({
@@ -829,7 +864,93 @@ describe("buildCandidateList", () => {
     const candidates = buildCandidateList(ctx);
 
     expect(candidates.every((c) => c.kind !== "extension")).toBe(true);
+    expect(candidates[0].kind).toBe("host-bridge");
     expect(candidates[candidates.length - 1].kind).toBe("local");
+  });
+
+  test("host-bridge candidate is absent when an extension is connected", () => {
+    mockSingletonProxy = makeAvailableProxy();
+    const ctx = makeContext({ conversationId: "candidates-ext-no-bridge" });
+
+    const candidates = buildCandidateList(ctx);
+
+    expect(candidates[0].kind).toBe("extension");
+    expect(candidates.every((c) => c.kind !== "host-bridge")).toBe(true);
+  });
+
+  test("host-bridge candidate is absent when the proxy is unavailable", () => {
+    mockSingletonProxy = makeUnavailableProxy();
+    const ctx = makeContext({ conversationId: "candidates-no-bridge" });
+
+    const candidates = buildCandidateList(ctx);
+
+    expect(candidates.every((c) => c.kind !== "host-bridge")).toBe(true);
+    expect(candidates[0].kind).toBe("local");
+  });
+
+  test("host-bridge candidate is skipped while the bridge cooldown is active", () => {
+    mockSingletonProxy = makeMacosBridgeOnlyProxy();
+    const ctx = makeContext({ conversationId: "candidates-bridge-cooldown" });
+
+    recordHostBridgeCooldown();
+    const candidates = buildCandidateList(ctx);
+
+    expect(candidates.every((c) => c.kind !== "host-bridge")).toBe(true);
+
+    _resetHostBridgeCooldown();
+    const after = buildCandidateList(ctx);
+    expect(after[0].kind).toBe("host-bridge");
+  });
+
+  test("host-bridge cooldown is independent of the desktop-auto cooldown", () => {
+    mockSingletonProxy = makeMacosBridgeOnlyProxy();
+    const ctx = makeContext({
+      conversationId: "candidates-bridge-cooldown-independent",
+      transportInterface: "macos",
+    });
+
+    recordDesktopAutoCooldown();
+    const candidates = buildCandidateList(ctx);
+
+    // Desktop-auto cooldown suppresses cdp-inspect but not the bridge.
+    expect(candidates[0].kind).toBe("host-bridge");
+    expect(candidates.every((c) => c.kind !== "cdp-inspect")).toBe(true);
+    expect(isHostBridgeCooldownActive(30_000)).toBe(false);
+  });
+
+  test("ordering on a macOS turn with bridge only: host-bridge > cdp-inspect > local", () => {
+    mockSingletonProxy = makeMacosBridgeOnlyProxy();
+    const ctx = makeContext({
+      conversationId: "candidates-bridge-order",
+      transportInterface: "macos",
+    });
+
+    const candidates = buildCandidateList(ctx);
+
+    expect(candidates.map((c) => c.kind)).toEqual([
+      "host-bridge",
+      "cdp-inspect",
+      "local",
+    ]);
+  });
+
+  test("host-bridge create() threads proxy + actor and never reads pinned tabs", () => {
+    const fakeProxy = makeMacosBridgeOnlyProxy();
+    mockSingletonProxy = fakeProxy;
+    const ctx = makeContext({
+      conversationId: "candidates-bridge-create",
+      sourceActorPrincipalId: "actor-1",
+    });
+
+    const candidates = buildCandidateList(ctx);
+    expect(candidates[0].kind).toBe("host-bridge");
+    candidates[0].create();
+
+    expect(createHostBridgeCdpClientMock).toHaveBeenCalledWith(
+      fakeProxy,
+      "candidates-bridge-create",
+      "actor-1",
+    );
   });
 
   test("includes cdp-inspect candidate when enabled in config", () => {
@@ -931,12 +1052,15 @@ describe("buildChainedClient failover", () => {
     createExtensionCdpClientMock.mockClear();
     createLocalCdpClientMock.mockClear();
     createCdpInspectClientMock.mockClear();
+    createHostBridgeCdpClientMock.mockClear();
     lastExtensionClient = undefined;
     lastLocalClient = undefined;
     lastCdpInspectClient = undefined;
+    lastHostBridgeClient = undefined;
     cdpInspectEnabled = false;
     desktopAutoConfig = { enabled: true, cooldownMs: 30_000 };
     _resetDesktopAutoCooldown();
+    _resetHostBridgeCooldown();
     logWarnCalls.length = 0;
     logDebugCalls.length = 0;
     mockSingletonProxy = null;
@@ -1028,6 +1152,59 @@ describe("buildChainedClient failover", () => {
     expect(createExtensionCdpClientMock).toHaveBeenCalledTimes(1);
     expect(createCdpInspectClientMock).toHaveBeenCalledTimes(1);
     expect(createLocalCdpClientMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("fails over from host-bridge to local and records the bridge cooldown", async () => {
+    mockSingletonProxy = makeMacosBridgeOnlyProxy();
+
+    // Bridge fails like Chrome without a debug port: structured
+    // "unreachable" envelope → transport_error.
+    createHostBridgeCdpClientMock.mockImplementationOnce(
+      (_proxy: HostBrowserProxy, conversationId: string) => {
+        const c = makeFakeHostBridgeClient(conversationId);
+        c.send = mock(async () => {
+          throw new CdpError(
+            "transport_error",
+            "HTTP 404 from http://localhost:9222/json/list",
+            { cdpMethod: "Page.navigate" },
+          );
+        });
+        lastHostBridgeClient = c;
+        return c;
+      },
+    );
+
+    const ctx = makeContext({ conversationId: "failover-bridge-to-local" });
+
+    const client = getCdpClient(ctx);
+    const result = await client.send<{ ok: boolean; via: string }>(
+      "Page.navigate",
+      { url: "https://example.com" },
+    );
+
+    expect(result).toEqual({ ok: true, via: "local" });
+    expect(createHostBridgeCdpClientMock).toHaveBeenCalledTimes(1);
+    expect(createLocalCdpClientMock).toHaveBeenCalledTimes(1);
+    // Cooldown was recorded so the next candidate list skips the bridge.
+    expect(_getHostBridgeCooldownSince()).toBeGreaterThan(0);
+    expect(_getDesktopAutoCooldownSince()).toBe(0);
+    const after = buildCandidateList(ctx);
+    expect(after.every((c) => c.kind !== "host-bridge")).toBe(true);
+  });
+
+  test("sticky host-bridge client rejects tab operations with a clear error", async () => {
+    mockSingletonProxy = makeMacosBridgeOnlyProxy();
+    const ctx = makeContext({ conversationId: "bridge-tab-ops" });
+
+    const client = getCdpClient(ctx);
+    await client.send("Page.navigate", { url: "https://example.com" });
+    expect(client.kind).toBe("host-bridge");
+
+    // The fake bridge client has no listTabs/selectTab/closeTab, so the
+    // chained client surfaces the not-supported transport_error.
+    await expect(client.listTabs()).rejects.toThrow(
+      "extension backend required",
+    );
   });
 
   test("does NOT fail over on cdp_error -- propagates immediately", async () => {
@@ -1245,12 +1422,15 @@ describe("desktop-auto cdp-inspect (macOS)", () => {
     createExtensionCdpClientMock.mockClear();
     createLocalCdpClientMock.mockClear();
     createCdpInspectClientMock.mockClear();
+    createHostBridgeCdpClientMock.mockClear();
     lastExtensionClient = undefined;
     lastLocalClient = undefined;
     lastCdpInspectClient = undefined;
+    lastHostBridgeClient = undefined;
     cdpInspectEnabled = false;
     desktopAutoConfig = { enabled: true, cooldownMs: 30_000 };
     _resetDesktopAutoCooldown();
+    _resetHostBridgeCooldown();
     logWarnCalls.length = 0;
     logDebugCalls.length = 0;
     mockSingletonProxy = null;
@@ -1597,12 +1777,15 @@ describe("pinned-mode selection", () => {
     createExtensionCdpClientMock.mockClear();
     createLocalCdpClientMock.mockClear();
     createCdpInspectClientMock.mockClear();
+    createHostBridgeCdpClientMock.mockClear();
     lastExtensionClient = undefined;
     lastLocalClient = undefined;
     lastCdpInspectClient = undefined;
+    lastHostBridgeClient = undefined;
     cdpInspectEnabled = false;
     desktopAutoConfig = { enabled: true, cooldownMs: 30_000 };
     _resetDesktopAutoCooldown();
+    _resetHostBridgeCooldown();
     logWarnCalls.length = 0;
     logDebugCalls.length = 0;
     mockSingletonProxy = null;
@@ -1811,12 +1994,15 @@ describe("buildPinnedCandidateList", () => {
     createExtensionCdpClientMock.mockClear();
     createLocalCdpClientMock.mockClear();
     createCdpInspectClientMock.mockClear();
+    createHostBridgeCdpClientMock.mockClear();
     lastExtensionClient = undefined;
     lastLocalClient = undefined;
     lastCdpInspectClient = undefined;
+    lastHostBridgeClient = undefined;
     cdpInspectEnabled = false;
     desktopAutoConfig = { enabled: true, cooldownMs: 30_000 };
     _resetDesktopAutoCooldown();
+    _resetHostBridgeCooldown();
     mockSingletonProxy = null;
   });
 
@@ -1892,6 +2078,54 @@ describe("buildPinnedCandidateList", () => {
       expect(cdpErr.message).toContain("no Chrome Extension connected");
     }
   });
+
+  test("host-bridge mode produces single host-bridge candidate when bridge-only", () => {
+    mockSingletonProxy = makeMacosBridgeOnlyProxy();
+    const ctx = makeContext({ conversationId: "bpl-bridge" });
+
+    const candidates = buildPinnedCandidateList(ctx, "host-bridge");
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].kind).toBe("host-bridge");
+    expect(candidates[0].reason).toContain("pinned mode: host-bridge");
+  });
+
+  test("host-bridge mode throws with diagnostics when proxy is unavailable", () => {
+    mockSingletonProxy = makeUnavailableProxy();
+    const ctx = makeContext({ conversationId: "bpl-bridge-absent" });
+
+    try {
+      buildPinnedCandidateList(ctx, "host-bridge");
+      expect(true).toBe(false); // should not reach
+    } catch (err) {
+      expect(err).toBeInstanceOf(CdpError);
+      const cdpErr = err as CdpError;
+      expect(cdpErr.code).toBe("transport_error");
+      expect(cdpErr.attemptDiagnostics![0]).toMatchObject({
+        candidateKind: "host-bridge",
+        stage: "candidate_selection",
+      });
+    }
+  });
+
+  test("host-bridge mode throws when an extension has since connected", () => {
+    // The sticky memo says host-bridge but a Chrome Extension is now
+    // available. Throwing trips acquireCdpClientWithMode's sticky-fallback
+    // retry, which clears the memo and re-runs auto so the conversation
+    // upgrades to the extension candidate.
+    mockSingletonProxy = makeAvailableProxy();
+    const ctx = makeContext({ conversationId: "bpl-bridge-ext-upgrade" });
+
+    try {
+      buildPinnedCandidateList(ctx, "host-bridge");
+      expect(true).toBe(false); // should not reach
+    } catch (err) {
+      expect(err).toBeInstanceOf(CdpError);
+      expect((err as CdpError).message).toContain(
+        "a Chrome Extension is now connected",
+      );
+    }
+  });
 });
 
 // ── Attempt diagnostics & fallback log tests ─────────────────────────────
@@ -1901,12 +2135,15 @@ describe("attempt diagnostics", () => {
     createExtensionCdpClientMock.mockClear();
     createLocalCdpClientMock.mockClear();
     createCdpInspectClientMock.mockClear();
+    createHostBridgeCdpClientMock.mockClear();
     lastExtensionClient = undefined;
     lastLocalClient = undefined;
     lastCdpInspectClient = undefined;
+    lastHostBridgeClient = undefined;
     cdpInspectEnabled = false;
     desktopAutoConfig = { enabled: true, cooldownMs: 30_000 };
     _resetDesktopAutoCooldown();
+    _resetHostBridgeCooldown();
     logWarnCalls.length = 0;
     logDebugCalls.length = 0;
     mockSingletonProxy = null;
@@ -2300,12 +2537,15 @@ describe("macOS host-browser proxy without extension registry", () => {
     createExtensionCdpClientMock.mockClear();
     createLocalCdpClientMock.mockClear();
     createCdpInspectClientMock.mockClear();
+    createHostBridgeCdpClientMock.mockClear();
     lastExtensionClient = undefined;
     lastLocalClient = undefined;
     lastCdpInspectClient = undefined;
+    lastHostBridgeClient = undefined;
     cdpInspectEnabled = false;
     desktopAutoConfig = { enabled: true, cooldownMs: 30_000 };
     _resetDesktopAutoCooldown();
+    _resetHostBridgeCooldown();
     logWarnCalls.length = 0;
     logDebugCalls.length = 0;
     mockSingletonProxy = null;

--- a/assistant/src/tools/browser/cdp-client/__tests__/factory.test.ts
+++ b/assistant/src/tools/browser/cdp-client/__tests__/factory.test.ts
@@ -239,6 +239,27 @@ function makeUnavailableProxy(): HostBrowserProxy {
   } as unknown as HostBrowserProxy;
 }
 
+/**
+ * Create a fake HostBrowserProxy with actor-scoped availability, mirroring
+ * the real implementation: with an actor, only that actor's clients count;
+ * without one, any client counts.
+ */
+function makeActorScopedProxy(opts: {
+  extensionActors: string[];
+  bridgeActors: string[];
+}): HostBrowserProxy {
+  const allActors = [...opts.extensionActors, ...opts.bridgeActors];
+  return {
+    request: mock(async () => ({})),
+    isAvailable: (actor?: string) =>
+      actor == null ? allActors.length > 0 : allActors.includes(actor),
+    hasExtensionClient: (actor?: string) =>
+      actor == null
+        ? opts.extensionActors.length > 0
+        : opts.extensionActors.includes(actor),
+  } as unknown as HostBrowserProxy;
+}
+
 describe("getCdpClient", () => {
   beforeEach(() => {
     createExtensionCdpClientMock.mockClear();
@@ -948,6 +969,61 @@ describe("buildCandidateList", () => {
       "candidates-bridge-create",
       "actor-1",
     );
+  });
+
+  test("multi-actor: another actor's extension does not select the extension candidate", () => {
+    // Actor A has an extension; actor B has only the bridge. B's
+    // conversation must get the host-bridge candidate, not an
+    // extension-labelled client that the proxy would route to B's bridge.
+    mockSingletonProxy = makeActorScopedProxy({
+      extensionActors: ["actor-a"],
+      bridgeActors: ["actor-b"],
+    });
+    const ctx = makeContext({
+      conversationId: "candidates-multi-actor-b",
+      sourceActorPrincipalId: "actor-b",
+    });
+
+    const candidates = buildCandidateList(ctx);
+
+    expect(candidates[0].kind).toBe("host-bridge");
+    expect(candidates.every((c) => c.kind !== "extension")).toBe(true);
+  });
+
+  test("multi-actor: the extension owner still gets the extension candidate", () => {
+    mockSingletonProxy = makeActorScopedProxy({
+      extensionActors: ["actor-a"],
+      bridgeActors: ["actor-b"],
+    });
+    const ctx = makeContext({
+      conversationId: "candidates-multi-actor-a",
+      sourceActorPrincipalId: "actor-a",
+    });
+
+    const candidates = buildCandidateList(ctx);
+
+    expect(candidates[0].kind).toBe("extension");
+    expect(candidates.every((c) => c.kind !== "host-bridge")).toBe(true);
+  });
+
+  test("multi-actor: actor with no clients at all gets neither proxy candidate", () => {
+    mockSingletonProxy = makeActorScopedProxy({
+      extensionActors: ["actor-a"],
+      bridgeActors: ["actor-b"],
+    });
+    const ctx = makeContext({
+      conversationId: "candidates-multi-actor-c",
+      sourceActorPrincipalId: "actor-c",
+    });
+
+    const candidates = buildCandidateList(ctx);
+
+    expect(
+      candidates.every(
+        (c) => c.kind !== "extension" && c.kind !== "host-bridge",
+      ),
+    ).toBe(true);
+    expect(candidates[candidates.length - 1].kind).toBe("local");
   });
 
   test("includes cdp-inspect candidate when enabled in config", () => {

--- a/assistant/src/tools/browser/cdp-client/__tests__/factory.test.ts
+++ b/assistant/src/tools/browser/cdp-client/__tests__/factory.test.ts
@@ -837,6 +837,7 @@ describe("buildCandidateList", () => {
     cdpInspectEnabled = false;
     desktopAutoConfig = { enabled: true, cooldownMs: 30_000 };
     _resetDesktopAutoCooldown();
+    _resetHostBridgeCooldown();
     mockSingletonProxy = null;
   });
 
@@ -935,6 +936,39 @@ describe("buildCandidateList", () => {
     expect(candidates.every((c) => c.kind !== "cdp-inspect")).toBe(true);
     expect(isHostBridgeCooldownActive(30_000)).toBe(false);
   });
+
+  test("host-bridge cooldown is scoped per actor", () => {
+    // One actor's missing debug port must not suppress another actor's
+    // only route to their own Chrome on a multi-actor cloud daemon.
+    mockSingletonProxy = makeActorScopedProxy({
+      extensionActors: [],
+      bridgeActors: ["actor-a", "actor-b"],
+    });
+
+    recordHostBridgeCooldown("actor-a");
+
+    const forA = buildCandidateList(
+      makeContext({
+        conversationId: "cooldown-actor-a",
+        sourceActorPrincipalId: "actor-a",
+      }),
+    );
+    expect(forA.every((c) => c.kind !== "host-bridge")).toBe(true);
+
+    const forB = buildCandidateList(
+      makeContext({
+        conversationId: "cooldown-actor-b",
+        sourceActorPrincipalId: "actor-b",
+      }),
+    );
+    expect(forB[0].kind).toBe("host-bridge");
+
+    // Actor-scoped cooldowns do not leak into the no-actor default slot.
+    expect(isHostBridgeCooldownActive(30_000)).toBe(false);
+    expect(isHostBridgeCooldownActive(30_000, "actor-a")).toBe(true);
+    expect(isHostBridgeCooldownActive(30_000, "actor-b")).toBe(false);
+  });
+
 
   test("ordering on a macOS turn with bridge only: host-bridge > cdp-inspect > local", () => {
     mockSingletonProxy = makeMacosBridgeOnlyProxy();
@@ -1261,6 +1295,42 @@ describe("buildChainedClient failover", () => {
     expect(_getDesktopAutoCooldownSince()).toBe(0);
     const after = buildCandidateList(ctx);
     expect(after.every((c) => c.kind !== "host-bridge")).toBe(true);
+  });
+
+  test("host-bridge failover records the cooldown under the failing actor only", async () => {
+    mockSingletonProxy = makeActorScopedProxy({
+      extensionActors: [],
+      bridgeActors: ["actor-a", "actor-b"],
+    });
+    createHostBridgeCdpClientMock.mockImplementationOnce(
+      (_proxy: HostBrowserProxy, conversationId: string) => {
+        const c = makeFakeHostBridgeClient(conversationId);
+        c.send = mock(async () => {
+          throw new CdpError(
+            "transport_error",
+            "HTTP 404 from http://localhost:9222/json/list",
+            { cdpMethod: "Page.navigate" },
+          );
+        });
+        return c;
+      },
+    );
+
+    const client = getCdpClient(
+      makeContext({
+        conversationId: "cooldown-record-actor-a",
+        sourceActorPrincipalId: "actor-a",
+      }),
+    );
+    const result = await client.send<{ ok: boolean; via: string }>(
+      "Page.navigate",
+      { url: "https://example.com" },
+    );
+
+    expect(result).toEqual({ ok: true, via: "local" });
+    expect(_getHostBridgeCooldownSince("actor-a")).toBeGreaterThan(0);
+    expect(_getHostBridgeCooldownSince("actor-b")).toBe(0);
+    expect(_getHostBridgeCooldownSince()).toBe(0);
   });
 
   test("sticky host-bridge client rejects tab operations with a clear error", async () => {

--- a/assistant/src/tools/browser/cdp-client/__tests__/factory.test.ts
+++ b/assistant/src/tools/browser/cdp-client/__tests__/factory.test.ts
@@ -50,7 +50,6 @@ function makeFakeCdpInspectClient(conversationId: string): FakeClient {
 let lastExtensionClient: FakeClient | undefined;
 let lastLocalClient: FakeClient | undefined;
 let lastCdpInspectClient: FakeClient | undefined;
-let lastHostBridgeClient: FakeClient | undefined;
 
 const createExtensionCdpClientMock = mock(
   (_proxy: HostBrowserProxy, conversationId: string) => {
@@ -67,7 +66,6 @@ const createHostBridgeCdpClientMock = mock(
     _sourceActorPrincipalId?: string,
   ) => {
     const client = makeFakeHostBridgeClient(conversationId);
-    lastHostBridgeClient = client;
     return client;
   },
 );
@@ -250,7 +248,6 @@ describe("getCdpClient", () => {
     lastExtensionClient = undefined;
     lastLocalClient = undefined;
     lastCdpInspectClient = undefined;
-    lastHostBridgeClient = undefined;
     cdpInspectEnabled = false;
     desktopAutoConfig = { enabled: true, cooldownMs: 30_000 };
     _resetDesktopAutoCooldown();
@@ -1056,7 +1053,6 @@ describe("buildChainedClient failover", () => {
     lastExtensionClient = undefined;
     lastLocalClient = undefined;
     lastCdpInspectClient = undefined;
-    lastHostBridgeClient = undefined;
     cdpInspectEnabled = false;
     desktopAutoConfig = { enabled: true, cooldownMs: 30_000 };
     _resetDesktopAutoCooldown();
@@ -1169,7 +1165,6 @@ describe("buildChainedClient failover", () => {
             { cdpMethod: "Page.navigate" },
           );
         });
-        lastHostBridgeClient = c;
         return c;
       },
     );
@@ -1426,7 +1421,6 @@ describe("desktop-auto cdp-inspect (macOS)", () => {
     lastExtensionClient = undefined;
     lastLocalClient = undefined;
     lastCdpInspectClient = undefined;
-    lastHostBridgeClient = undefined;
     cdpInspectEnabled = false;
     desktopAutoConfig = { enabled: true, cooldownMs: 30_000 };
     _resetDesktopAutoCooldown();
@@ -1781,7 +1775,6 @@ describe("pinned-mode selection", () => {
     lastExtensionClient = undefined;
     lastLocalClient = undefined;
     lastCdpInspectClient = undefined;
-    lastHostBridgeClient = undefined;
     cdpInspectEnabled = false;
     desktopAutoConfig = { enabled: true, cooldownMs: 30_000 };
     _resetDesktopAutoCooldown();
@@ -1998,7 +1991,6 @@ describe("buildPinnedCandidateList", () => {
     lastExtensionClient = undefined;
     lastLocalClient = undefined;
     lastCdpInspectClient = undefined;
-    lastHostBridgeClient = undefined;
     cdpInspectEnabled = false;
     desktopAutoConfig = { enabled: true, cooldownMs: 30_000 };
     _resetDesktopAutoCooldown();
@@ -2139,7 +2131,6 @@ describe("attempt diagnostics", () => {
     lastExtensionClient = undefined;
     lastLocalClient = undefined;
     lastCdpInspectClient = undefined;
-    lastHostBridgeClient = undefined;
     cdpInspectEnabled = false;
     desktopAutoConfig = { enabled: true, cooldownMs: 30_000 };
     _resetDesktopAutoCooldown();
@@ -2541,7 +2532,6 @@ describe("macOS host-browser proxy without extension registry", () => {
     lastExtensionClient = undefined;
     lastLocalClient = undefined;
     lastCdpInspectClient = undefined;
-    lastHostBridgeClient = undefined;
     cdpInspectEnabled = false;
     desktopAutoConfig = { enabled: true, cooldownMs: 30_000 };
     _resetDesktopAutoCooldown();

--- a/assistant/src/tools/browser/cdp-client/__tests__/host-bridge-cdp-client.test.ts
+++ b/assistant/src/tools/browser/cdp-client/__tests__/host-bridge-cdp-client.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import type { HostBrowserProxy } from "../../../../daemon/host-browser-proxy.js";
+import { CdpError } from "../errors.js";
+import {
+  createHostBridgeCdpClient,
+  HostBridgeCdpClient,
+} from "../host-bridge-cdp-client.js";
+
+type ProxyResult = { content: string; isError: boolean };
+
+function fakeProxy(
+  handler: (
+    input: unknown,
+    conversationId: string,
+    signal?: AbortSignal,
+  ) => Promise<ProxyResult> | ProxyResult,
+): {
+  proxy: HostBrowserProxy;
+  request: ReturnType<typeof mock>;
+} {
+  const request = mock(
+    async (
+      input: unknown,
+      conversationId: string,
+      signal?: AbortSignal,
+    ): Promise<ProxyResult> => handler(input, conversationId, signal),
+  );
+  const proxy = { request } as unknown as HostBrowserProxy;
+  return { proxy, request };
+}
+
+describe("HostBridgeCdpClient", () => {
+  test("kind is 'host-bridge' and exposes conversationId", () => {
+    const { proxy } = fakeProxy(async () => ({
+      content: "{}",
+      isError: false,
+    }));
+    const client = createHostBridgeCdpClient(proxy, "conv-bridge");
+    expect(client).toBeInstanceOf(HostBridgeCdpClient);
+    expect(client.kind).toBe("host-bridge");
+    expect(client.conversationId).toBe("conv-bridge");
+  });
+
+  test("send forwards raw CDP with no cdpSessionId or targetClientId", async () => {
+    const { proxy, request } = fakeProxy(async () => ({
+      content: JSON.stringify({ frameId: "frame-1" }),
+      isError: false,
+    }));
+
+    const client = createHostBridgeCdpClient(proxy, "conv-1", "actor-1");
+    const result = await client.send<{ frameId: string }>("Page.navigate", {
+      url: "https://example.com/",
+    });
+
+    expect(result).toEqual({ frameId: "frame-1" });
+    expect(request).toHaveBeenCalledTimes(1);
+    const call = request.mock.calls[0];
+    expect(call?.[0]).toEqual({
+      cdpMethod: "Page.navigate",
+      cdpParams: { url: "https://example.com/" },
+      cdpSessionId: undefined,
+    });
+    expect(call?.[1]).toBe("conv-1");
+    // sourceActorPrincipalId threads through; targetClientId is never set.
+    expect(call?.[3]).toBe("actor-1");
+    expect(call?.[4]).toBeUndefined();
+  });
+
+  test("bridge 'unreachable' envelope classifies as transport_error (failover-eligible)", async () => {
+    const { proxy } = fakeProxy(async () => ({
+      content: JSON.stringify({
+        code: "unreachable",
+        message: "HTTP 404 from http://localhost:9222/json/list",
+      }),
+      isError: true,
+    }));
+
+    const client = createHostBridgeCdpClient(proxy, "conv-err");
+    try {
+      await client.send("Page.captureScreenshot", {});
+      expect(true).toBe(false); // should not reach
+    } catch (err) {
+      expect(err).toBeInstanceOf(CdpError);
+      expect((err as CdpError).code).toBe("transport_error");
+      expect((err as CdpError).message).toContain("HTTP 404");
+    }
+  });
+
+  test.each(["listTabs", "selectTab", "closeTab"] as const)(
+    "%s throws transport_error locally without touching the proxy",
+    async (method) => {
+      const { proxy, request } = fakeProxy(async () => ({
+        content: "{}",
+        isError: false,
+      }));
+      const client = createHostBridgeCdpClient(proxy, "conv-tabs");
+
+      const call =
+        method === "listTabs" ? client.listTabs() : client[method](1);
+      await expect(call).rejects.toThrow(
+        `${method} is not supported by the host-bridge backend (extension backend required)`,
+      );
+      expect(request).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/assistant/src/tools/browser/cdp-client/__tests__/types.test.ts
+++ b/assistant/src/tools/browser/cdp-client/__tests__/types.test.ts
@@ -79,7 +79,12 @@ describe("cdp-client re-exports", () => {
   });
 
   test("ScopedCdpClient exposes kind and conversationId", () => {
-    const kinds: CdpClientKind[] = ["local", "extension", "cdp-inspect"];
+    const kinds: CdpClientKind[] = [
+      "local",
+      "extension",
+      "cdp-inspect",
+      "host-bridge",
+    ];
     for (const kind of kinds) {
       const scoped: ScopedCdpClient = {
         kind,

--- a/assistant/src/tools/browser/cdp-client/factory.ts
+++ b/assistant/src/tools/browser/cdp-client/factory.ts
@@ -5,6 +5,7 @@ import {
   type CdpResult,
   createCdpInspectBackend,
   createExtensionBackend,
+  createHostBridgeBackend,
   createLocalBackend,
 } from "../../../browser-session/index.js";
 import { getConfig } from "../../../config/loader.js";
@@ -15,13 +16,14 @@ import { getPinnedTab } from "../pinned-tabs.js";
 import { createCdpInspectClient } from "./cdp-inspect-client.js";
 import { CdpError } from "./errors.js";
 import { createExtensionCdpClient } from "./extension-cdp-client.js";
+import { createHostBridgeCdpClient } from "./host-bridge-cdp-client.js";
 import { createLocalCdpClient } from "./local-cdp-client.js";
 import type {
   AttemptDiagnostic,
   BackendCandidate,
-  BrowserMode,
   CdpClient,
   CdpClientKind,
+  InternalBrowserMode,
   ScopedCdpClient,
   TabInfo,
 } from "./types.js";
@@ -52,7 +54,7 @@ let _desktopAutoCooldownSince = 0;
 
 /**
  * Record a cooldown after a desktop-auto cdp-inspect transport failure.
- * Called by {@link maybeRecordDesktopAutoCooldown} in production; also
+ * Called by {@link maybeRecordCandidateCooldown} in production; also
  * exported directly for use in tests.
  */
 export function recordDesktopAutoCooldown(): void {
@@ -84,6 +86,52 @@ export function _getDesktopAutoCooldownSince(): number {
 }
 
 // ---------------------------------------------------------------------------
+// Host-bridge cooldown tracker
+// ---------------------------------------------------------------------------
+
+/**
+ * Module-level timestamp (epoch ms) of the last transport-level failure
+ * for a host-bridge attempt. Mirrors the desktop-auto cdp-inspect
+ * cooldown above — the failure root cause is the same (the user's
+ * Chrome is not exposing a remote-debugging port), just probed through
+ * the desktop SSE bridge instead of directly. While the configured
+ * `desktopAuto.cooldownMs` window has not elapsed, the factory skips
+ * the host-bridge candidate so every browser op doesn't pay an SSE
+ * round-trip for a guaranteed failure.
+ *
+ * **Process-global scope**: like the desktop-auto cooldown, one
+ * conversation's failure suppresses bridge probes for all
+ * conversations in this daemon (including other actors' on a
+ * multi-actor cloud daemon) until expiry.
+ */
+let _hostBridgeCooldownSince = 0;
+
+/** Record a cooldown after a host-bridge transport failure. */
+export function recordHostBridgeCooldown(): void {
+  _hostBridgeCooldownSince = Date.now();
+}
+
+/**
+ * Whether the host-bridge cooldown is currently active. Returns `true`
+ * if a failure was recorded and the configured cooldown window has not
+ * yet elapsed.
+ */
+export function isHostBridgeCooldownActive(cooldownMs: number): boolean {
+  if (_hostBridgeCooldownSince === 0 || cooldownMs <= 0) return false;
+  return Date.now() - _hostBridgeCooldownSince < cooldownMs;
+}
+
+/** Reset the host-bridge cooldown state. Exported for testing only. */
+export function _resetHostBridgeCooldown(): void {
+  _hostBridgeCooldownSince = 0;
+}
+
+/** Get the raw cooldown-since timestamp. Exported for testing only. */
+export function _getHostBridgeCooldownSince(): number {
+  return _hostBridgeCooldownSince;
+}
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
@@ -96,9 +144,10 @@ export interface GetCdpClientOptions {
    * Backend mode preference. When omitted or `"auto"`, the factory
    * uses the existing priority-ordered fallback chain. When set to a
    * specific backend kind, the factory pins to that single backend
-   * and disables failover.
+   * and disables failover. `"host-bridge"` is internal-only (sticky
+   * conversation memo), never user-requestable.
    */
-  mode?: BrowserMode;
+  mode?: InternalBrowserMode;
   /**
    * Explicit target client id. When provided, the extension backend routes
    * to this specific client instead of auto-resolving to the most-recently-
@@ -159,7 +208,7 @@ export function getCdpClient(
   context: ToolContext,
   options?: GetCdpClientOptions,
 ): ScopedCdpClient {
-  const mode: BrowserMode = options?.mode ?? "auto";
+  const mode: InternalBrowserMode = options?.mode ?? "auto";
   const targetClientId = options?.targetClientId;
   const candidates =
     mode === "auto"
@@ -191,7 +240,7 @@ export function getCdpClient(
  */
 export function buildPinnedCandidateList(
   context: ToolContext,
-  mode: Exclude<BrowserMode, "auto">,
+  mode: Exclude<InternalBrowserMode, "auto">,
   targetClientId?: string,
 ): BackendCandidate[] {
   const { conversationId, sourceActorPrincipalId } = context;
@@ -265,6 +314,46 @@ export function buildPinnedCandidateList(
             return { client, backend };
           },
         },
+      ];
+    }
+    case "host-bridge": {
+      // Reached only via the conversation's sticky-backend memo after a
+      // successful bridge send — never via --browser-mode. Throwing when
+      // an extension has since connected (not just when the bridge is
+      // gone) deliberately trips the caller's sticky-fallback retry,
+      // which clears the memo and re-runs auto mode so the conversation
+      // upgrades to the extension candidate with correct kind labeling.
+      const hostBrowserProxy = HostBrowserProxy.instance;
+      if (
+        !hostBrowserProxy.isAvailable() ||
+        hostBrowserProxy.hasExtensionClient()
+      ) {
+        const errorMessage = hostBrowserProxy.hasExtensionClient()
+          ? "a Chrome Extension is now connected"
+          : "no host_browser bridge client connected";
+        throw new CdpError(
+          "transport_error",
+          `Pinned mode "host-bridge" unavailable: ${errorMessage}`,
+          {
+            attemptDiagnostics: [
+              {
+                candidateKind: "host-bridge",
+                inclusionReason: "pinned mode: host-bridge",
+                stage: "candidate_selection",
+                errorCode: "transport_error",
+                errorMessage,
+              },
+            ],
+          },
+        );
+      }
+      return [
+        makeHostBridgeCandidate(
+          hostBrowserProxy,
+          conversationId,
+          sourceActorPrincipalId,
+          "pinned mode: host-bridge (conversation sticky memo)",
+        ),
       ];
     }
     case "local": {
@@ -385,6 +474,29 @@ export function buildCandidateList(context: ToolContext, targetClientId?: string
         return { client, backend };
       },
     });
+  } else if (hostBrowserProxy.isAvailable()) {
+    // 1b. Host bridge -- a host_browser-capable client (the desktop SSE
+    // bridge) is connected but no Chrome Extension. Raw CDP commands are
+    // proxied to the user's machine and executed against Chrome's local
+    // remote-debugging port. This is the only route to the user's own
+    // Chrome when the daemon runs remotely (cloud), where cdp-inspect
+    // would dial the daemon's localhost instead.
+    const { cooldownMs } = getConfig().hostBrowser.cdpInspect.desktopAuto;
+    if (isHostBridgeCooldownActive(cooldownMs)) {
+      log.debug(
+        { conversationId, cooldownMs, cooldownSince: _hostBridgeCooldownSince },
+        "CDP factory: host-bridge skipped (cooldown active)",
+      );
+    } else {
+      candidates.push(
+        makeHostBridgeCandidate(
+          hostBrowserProxy,
+          conversationId,
+          sourceActorPrincipalId,
+          "host_browser bridge connected (no Chrome Extension); raw CDP via desktop SSE bridge",
+        ),
+      );
+    }
   } else {
     log.debug(
       { conversationId },
@@ -473,6 +585,41 @@ export function buildCandidateList(context: ToolContext, targetClientId?: string
   return candidates;
 }
 
+/**
+ * Build the host-bridge backend candidate. Shared between auto mode
+ * (no extension connected, bridge available) and the pinned path that
+ * serves the conversation's sticky-backend memo.
+ *
+ * Unlike the extension candidate, no pinned tab is passed: extension
+ * pins store Chrome tab ids, which never match the CDP target ids the
+ * bridge resolves from /json/list.
+ */
+function makeHostBridgeCandidate(
+  hostBrowserProxy: HostBrowserProxy,
+  conversationId: string,
+  sourceActorPrincipalId: string | undefined,
+  reason: string,
+): BackendCandidate {
+  return {
+    kind: "host-bridge",
+    reason,
+    create() {
+      const client = createHostBridgeCdpClient(
+        hostBrowserProxy,
+        conversationId,
+        sourceActorPrincipalId,
+      );
+      const backend = createHostBridgeBackend({
+        isAvailable: () => true,
+        sendCdp: (command, signal) =>
+          dispatchThroughClient(client, command, signal),
+        dispose: () => client.dispose(),
+      });
+      return { client, backend };
+    },
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Chained client with per-invocation failover
 // ---------------------------------------------------------------------------
@@ -487,7 +634,7 @@ export function buildCandidateList(context: ToolContext, targetClientId?: string
 export function buildChainedClient(
   conversationId: string,
   candidates: BackendCandidate[],
-  mode: BrowserMode = "auto",
+  mode: InternalBrowserMode = "auto",
 ): ScopedCdpClient {
   if (candidates.length === 0) {
     throw new Error("CDP factory: no backend candidates available");
@@ -749,7 +896,7 @@ async function sendWithFailover<T>(
   }) => void,
   isDisposed: () => boolean,
   conversationId: string,
-  mode: BrowserMode,
+  mode: InternalBrowserMode,
 ): Promise<T> {
   let lastError: CdpError | undefined;
   const diagnostics: AttemptDiagnostic[] = [];
@@ -804,7 +951,7 @@ async function sendWithFailover<T>(
         errorCode: "transport_error",
         errorMessage,
       });
-      maybeRecordDesktopAutoCooldown(candidate);
+      maybeRecordCandidateCooldown(candidate);
 
       // Emit production-visible fallback log in auto mode
       if (mode === "auto" && i < candidates.length - 1) {
@@ -856,7 +1003,7 @@ async function sendWithFailover<T>(
         errorMessage,
         discoveryCode: extractDiscoveryCode(err),
       });
-      maybeRecordDesktopAutoCooldown(candidate);
+      maybeRecordCandidateCooldown(candidate);
 
       // Emit production-visible fallback log in auto mode
       if (mode === "auto" && i < candidates.length - 1) {
@@ -903,7 +1050,7 @@ async function sendWithFailover<T>(
           errorMessage: cdpError.message,
           discoveryCode: extractDiscoveryCode(cdpError.underlying),
         });
-        maybeRecordDesktopAutoCooldown(candidate);
+        maybeRecordCandidateCooldown(candidate);
 
         // Emit production-visible fallback log in auto mode
         if (mode === "auto") {
@@ -998,10 +1145,19 @@ async function sendWithFailover<T>(
 }
 
 /**
- * If the failed candidate is a desktop-auto cdp-inspect attempt,
- * record the cooldown so subsequent calls skip the probe.
+ * Record the appropriate cooldown for a failed candidate so subsequent
+ * calls skip the probe: desktop-auto cdp-inspect attempts (matched by
+ * reason prefix, exempting user-pinned cdp-inspect) and host-bridge
+ * attempts (matched by kind alone — the bridge is never user-pinned).
  */
-function maybeRecordDesktopAutoCooldown(candidate: BackendCandidate): void {
+function maybeRecordCandidateCooldown(candidate: BackendCandidate): void {
+  if (candidate.kind === "host-bridge") {
+    log.debug(
+      "CDP factory: recording host-bridge cooldown after transport failure",
+    );
+    recordHostBridgeCooldown();
+    return;
+  }
   if (
     candidate.kind === "cdp-inspect" &&
     candidate.reason.startsWith("desktopAuto:")

--- a/assistant/src/tools/browser/cdp-client/factory.ts
+++ b/assistant/src/tools/browser/cdp-client/factory.ts
@@ -90,7 +90,7 @@ export function _getDesktopAutoCooldownSince(): number {
 // ---------------------------------------------------------------------------
 
 /**
- * Module-level timestamp (epoch ms) of the last transport-level failure
+ * Per-actor timestamps (epoch ms) of the last transport-level failure
  * for a host-bridge attempt. Mirrors the desktop-auto cdp-inspect
  * cooldown above — the failure root cause is the same (the user's
  * Chrome is not exposing a remote-debugging port), just probed through
@@ -99,36 +99,69 @@ export function _getDesktopAutoCooldownSince(): number {
  * the host-bridge candidate so every browser op doesn't pay an SSE
  * round-trip for a guaranteed failure.
  *
- * **Process-global scope**: like the desktop-auto cooldown, one
- * conversation's failure suppresses bridge probes for all
- * conversations in this daemon (including other actors' on a
- * multi-actor cloud daemon) until expiry.
+ * **Per-actor scope**: unlike the desktop-auto cooldown (one local
+ * machine, so process-global is correct), the bridge reaches a
+ * different desktop machine per actor on a multi-actor cloud daemon —
+ * one actor's missing debug port must not suppress another actor's
+ * only route to their own Chrome. Callers without a resolved actor
+ * share the `__default__` slot.
  */
-let _hostBridgeCooldownSince = 0;
+const _hostBridgeCooldownSince = new Map<string, number>();
 
-/** Record a cooldown after a host-bridge transport failure. */
-export function recordHostBridgeCooldown(): void {
-  _hostBridgeCooldownSince = Date.now();
+/** Entries older than this are swept on record to bound map growth. */
+const HOST_BRIDGE_COOLDOWN_SWEEP_MS = 60 * 60 * 1000;
+
+function hostBridgeCooldownKey(sourceActorPrincipalId?: string): string {
+  return sourceActorPrincipalId ?? "__default__";
+}
+
+/** Record a cooldown after a host-bridge transport failure for this actor. */
+export function recordHostBridgeCooldown(
+  sourceActorPrincipalId?: string,
+): void {
+  const now = Date.now();
+  for (const [key, since] of _hostBridgeCooldownSince) {
+    if (now - since >= HOST_BRIDGE_COOLDOWN_SWEEP_MS) {
+      _hostBridgeCooldownSince.delete(key);
+    }
+  }
+  _hostBridgeCooldownSince.set(
+    hostBridgeCooldownKey(sourceActorPrincipalId),
+    now,
+  );
 }
 
 /**
- * Whether the host-bridge cooldown is currently active. Returns `true`
- * if a failure was recorded and the configured cooldown window has not
- * yet elapsed.
+ * Whether the host-bridge cooldown is currently active for this actor.
+ * Returns `true` if a failure was recorded and the configured cooldown
+ * window has not yet elapsed.
  */
-export function isHostBridgeCooldownActive(cooldownMs: number): boolean {
-  if (_hostBridgeCooldownSince === 0 || cooldownMs <= 0) return false;
-  return Date.now() - _hostBridgeCooldownSince < cooldownMs;
+export function isHostBridgeCooldownActive(
+  cooldownMs: number,
+  sourceActorPrincipalId?: string,
+): boolean {
+  if (cooldownMs <= 0) return false;
+  const since = _hostBridgeCooldownSince.get(
+    hostBridgeCooldownKey(sourceActorPrincipalId),
+  );
+  if (since === undefined) return false;
+  return Date.now() - since < cooldownMs;
 }
 
 /** Reset the host-bridge cooldown state. Exported for testing only. */
 export function _resetHostBridgeCooldown(): void {
-  _hostBridgeCooldownSince = 0;
+  _hostBridgeCooldownSince.clear();
 }
 
-/** Get the raw cooldown-since timestamp. Exported for testing only. */
-export function _getHostBridgeCooldownSince(): number {
-  return _hostBridgeCooldownSince;
+/** Get the raw cooldown-since timestamp for an actor. Exported for testing only. */
+export function _getHostBridgeCooldownSince(
+  sourceActorPrincipalId?: string,
+): number {
+  return (
+    _hostBridgeCooldownSince.get(
+      hostBridgeCooldownKey(sourceActorPrincipalId),
+    ) ?? 0
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -488,9 +521,13 @@ export function buildCandidateList(context: ToolContext, targetClientId?: string
     // Chrome when the daemon runs remotely (cloud), where cdp-inspect
     // would dial the daemon's localhost instead.
     const { cooldownMs } = getConfig().hostBrowser.cdpInspect.desktopAuto;
-    if (isHostBridgeCooldownActive(cooldownMs)) {
+    if (isHostBridgeCooldownActive(cooldownMs, sourceActorPrincipalId)) {
       log.debug(
-        { conversationId, cooldownMs, cooldownSince: _hostBridgeCooldownSince },
+        {
+          conversationId,
+          cooldownMs,
+          cooldownSince: _getHostBridgeCooldownSince(sourceActorPrincipalId),
+        },
         "CDP factory: host-bridge skipped (cooldown active)",
       );
     } else {
@@ -609,6 +646,7 @@ function makeHostBridgeCandidate(
   return {
     kind: "host-bridge",
     reason,
+    sourceActorPrincipalId,
     create() {
       const client = createHostBridgeCdpClient(
         hostBrowserProxy,
@@ -1161,7 +1199,7 @@ function maybeRecordCandidateCooldown(candidate: BackendCandidate): void {
     log.debug(
       "CDP factory: recording host-bridge cooldown after transport failure",
     );
-    recordHostBridgeCooldown();
+    recordHostBridgeCooldown(candidate.sourceActorPrincipalId);
     return;
   }
   if (

--- a/assistant/src/tools/browser/cdp-client/factory.ts
+++ b/assistant/src/tools/browser/cdp-client/factory.ts
@@ -248,7 +248,7 @@ export function buildPinnedCandidateList(
   switch (mode) {
     case "extension": {
         const hostBrowserProxy = HostBrowserProxy.instance;
-        if (!hostBrowserProxy.hasExtensionClient()) {
+        if (!hostBrowserProxy.hasExtensionClient(sourceActorPrincipalId)) {
           throw new CdpError(
             "transport_error",
             `Pinned mode "extension" unavailable: no Chrome Extension connected`,
@@ -325,10 +325,12 @@ export function buildPinnedCandidateList(
       // upgrades to the extension candidate with correct kind labeling.
       const hostBrowserProxy = HostBrowserProxy.instance;
       if (
-        !hostBrowserProxy.isAvailable() ||
-        hostBrowserProxy.hasExtensionClient()
+        !hostBrowserProxy.isAvailable(sourceActorPrincipalId) ||
+        hostBrowserProxy.hasExtensionClient(sourceActorPrincipalId)
       ) {
-        const errorMessage = hostBrowserProxy.hasExtensionClient()
+        const errorMessage = hostBrowserProxy.hasExtensionClient(
+          sourceActorPrincipalId,
+        )
           ? "a Chrome Extension is now connected"
           : "no host_browser bridge client connected";
         throw new CdpError(
@@ -404,7 +406,7 @@ export function buildCandidateList(context: ToolContext, targetClientId?: string
   // unavailable, fail loudly rather than silently routing to a different
   // browser.
   if (targetClientId != null) {
-    if (!hostBrowserProxy.hasExtensionClient()) {
+    if (!hostBrowserProxy.hasExtensionClient(sourceActorPrincipalId)) {
       throw new CdpError(
         "transport_error",
         `Cannot reach target_client_id "${targetClientId}": no Chrome Extension connected`,
@@ -449,7 +451,11 @@ export function buildCandidateList(context: ToolContext, targetClientId?: string
   }
 
   // 1. Extension -- preferred when a Chrome Extension client is connected.
-  if (hostBrowserProxy.hasExtensionClient()) {
+  // Availability checks are actor-scoped: on a multi-actor cloud daemon,
+  // another actor's extension must not select extension-labelled
+  // transports for this conversation (the proxy would refuse to
+  // dispatch to it anyway).
+  if (hostBrowserProxy.hasExtensionClient(sourceActorPrincipalId)) {
     candidates.push({
       kind: "extension",
       reason: "Chrome Extension connected via registry singleton",
@@ -474,7 +480,7 @@ export function buildCandidateList(context: ToolContext, targetClientId?: string
         return { client, backend };
       },
     });
-  } else if (hostBrowserProxy.isAvailable()) {
+  } else if (hostBrowserProxy.isAvailable(sourceActorPrincipalId)) {
     // 1b. Host bridge -- a host_browser-capable client (the desktop SSE
     // bridge) is connected but no Chrome Extension. Raw CDP commands are
     // proxied to the user's machine and executed against Chrome's local

--- a/assistant/src/tools/browser/cdp-client/host-bridge-cdp-client.ts
+++ b/assistant/src/tools/browser/cdp-client/host-bridge-cdp-client.ts
@@ -1,0 +1,67 @@
+import type { HostBrowserProxy } from "../../../daemon/host-browser-proxy.js";
+import { CdpError } from "./errors.js";
+import { ExtensionCdpClient } from "./extension-cdp-client.js";
+import type { CdpClientKind } from "./types.js";
+
+/**
+ * CdpClient for the desktop host-browser bridge: raw CDP commands are
+ * routed through HostBrowserProxy to the desktop client's SSE bridge,
+ * which executes them against the user's Chrome via its local
+ * remote-debugging port. Reuses ExtensionCdpClient's request/reply and
+ * error-classification plumbing with three deliberate differences:
+ *
+ *  - `kind` is `"host-bridge"`, so transport-aware tool branches
+ *    (e.g. `--new-tab`'s `Vellum.createTab` path) correctly treat the
+ *    bridge as a non-extension backend.
+ *  - No pinned-tab `cdpSessionId` is ever injected: extension pins
+ *    store Chrome tab ids, which never match the CDP target ids the
+ *    bridge resolves from `/json/list` and would guarantee
+ *    `cdp_session_not_found` failures.
+ *  - Tab methods throw locally instead of sending `Vellum.*`
+ *    pseudo-methods the bridge cannot serve (matches the
+ *    local/cdp-inspect client convention).
+ */
+export class HostBridgeCdpClient extends ExtensionCdpClient {
+  override readonly kind: CdpClientKind = "host-bridge";
+
+  constructor(
+    proxy: HostBrowserProxy,
+    conversationId: string,
+    sourceActorPrincipalId?: string,
+  ) {
+    super(
+      proxy,
+      conversationId,
+      /* cdpSessionId */ undefined,
+      sourceActorPrincipalId,
+      /* targetClientId */ undefined,
+    );
+  }
+
+  override async listTabs(): Promise<never> {
+    throw unsupportedTabOperation("listTabs");
+  }
+
+  override async selectTab(_tabId: number): Promise<never> {
+    throw unsupportedTabOperation("selectTab");
+  }
+
+  override async closeTab(_tabId: number): Promise<never> {
+    throw unsupportedTabOperation("closeTab");
+  }
+}
+
+function unsupportedTabOperation(operation: string): CdpError {
+  return new CdpError(
+    "transport_error",
+    `${operation} is not supported by the host-bridge backend (extension backend required)`,
+  );
+}
+
+export function createHostBridgeCdpClient(
+  proxy: HostBrowserProxy,
+  conversationId: string,
+  sourceActorPrincipalId?: string,
+): HostBridgeCdpClient {
+  return new HostBridgeCdpClient(proxy, conversationId, sourceActorPrincipalId);
+}

--- a/assistant/src/tools/browser/cdp-client/types.ts
+++ b/assistant/src/tools/browser/cdp-client/types.ts
@@ -98,21 +98,35 @@ export interface CdpClient {
  * the sacrificial-profile screencast setup when running against the
  * user's own Chrome via the extension).
  */
-export type CdpClientKind = "local" | "extension" | "cdp-inspect";
+export type CdpClientKind = "local" | "extension" | "cdp-inspect" | "host-bridge";
 
 /**
  * Backend mode preference for the CDP factory. Controls which
  * transport is selected:
  *
  *  - `"auto"` — default, existing priority-ordered fallback
- *    (extension → cdp-inspect → local).
+ *    (extension → host-bridge → cdp-inspect → local).
  *  - `"extension"` — pin to the chrome-extension backend. Fails
  *    immediately if the host browser proxy is unavailable.
  *  - `"cdp-inspect"` — pin to the cdp-inspect backend. Fails
  *    immediately if cdp-inspect cannot connect.
  *  - `"local"` — pin to the local Playwright backend. No fallback.
+ *
+ * The `host-bridge` backend (raw CDP to the user's Chrome via the
+ * desktop client's SSE bridge) is auto-mode only and not listed here —
+ * see {@link InternalBrowserMode}.
  */
 export type BrowserMode = "auto" | "extension" | "cdp-inspect" | "local";
+
+/**
+ * {@link BrowserMode} plus internal-only kinds the factory can pin to.
+ * The conversation's sticky-backend memo records the last successful
+ * {@link CdpClientKind} and re-pins to it on the next tool call; after
+ * a successful host-bridge send that memo is `"host-bridge"`, which is
+ * never user-requestable via `--browser-mode` but must round-trip
+ * through the factory's pinned-candidate path.
+ */
+export type InternalBrowserMode = BrowserMode | "host-bridge";
 
 /**
  * Stage at which a candidate attempt ended. Used in

--- a/assistant/src/tools/browser/cdp-client/types.ts
+++ b/assistant/src/tools/browser/cdp-client/types.ts
@@ -227,6 +227,12 @@ export interface BackendCandidate {
   /** Human-readable reason this candidate was included. */
   readonly reason: string;
   /**
+   * Actor the candidate was built for. Set on host-bridge candidates so
+   * a transport failure records the cooldown for the owning actor only
+   * (the bridge reaches a different desktop machine per actor).
+   */
+  readonly sourceActorPrincipalId?: string;
+  /**
    * Materialise the backend. Called at most once — the factory caches
    * the result after the first successful CDP command so subsequent
    * commands reuse the same backend (sticky semantics).


### PR DESCRIPTION
## Summary
- Adds a `host-bridge` candidate to the CDP factory's auto-mode chain, gated on `!hasExtensionClient() && isAvailable()` — i.e. the desktop SSE bridge is connected but no Chrome extension. Raw CDP commands are proxied through `HostBrowserProxy` to the desktop client, which executes them against Chrome's remote-debugging port on the user's machine. This is the only route to the user's own Chrome when the daemon runs remotely (cloud), where `cdp-inspect` dials the daemon's own localhost. Auto order with no extension: `host-bridge → cdp-inspect → local`; unchanged when the extension is connected.
- New `HostBridgeCdpClient` (subclass of `ExtensionCdpClient`) with kind `"host-bridge"`: extension-only branches (`--new-tab`'s `Vellum.createTab`, `Vellum.detach` on close) now correctly skip the bridge; pinned extension tabIds (which never match the bridge's `/json/list` target ids) are structurally never injected; tab operations throw the standard "extension backend required" error locally instead of a doomed SSE round-trip.
- `InternalBrowserMode = BrowserMode | "host-bridge"` lets the conversation's sticky-backend memo round-trip through the factory's pinned path; the pinned case deliberately throws when an extension has since connected, tripping the existing sticky-fallback retry so conversations upgrade to the extension. A process-global cooldown (reusing `desktopAuto.cooldownMs`) skips the bridge after a transport failure so Chrome-without-debug-port setups don't pay an SSE round-trip on every browser op.
- `--browser-mode` is unchanged — the bridge is auto-mode only, not user-pinnable.

## Original prompt
Follow-up to #34298 (method-aware host_browser routing): the root-cause investigation found the macOS bridge was only reachable through the routing race that PR fixed — no factory candidate deliberately targeted it. The user requires cloud-hosted daemons to keep driving the user's Chrome via the bridge ("We do need cloud daemons to be able to drive chrome via the bridge. I don't want to lose functionality."), so this PR gives the bridge a first-class, deliberate route in the auto-mode fallback chain, per PR 2 of the agreed two-PR plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)