### PR TITLE
feat(assistant): exploration-drift nudge — early loop detection on Kimi K2.6/MiniMax M3 + long-dig delegation

### DIFF
--- a/assistant/src/__tests__/conversation-history-web-search.test.ts
+++ b/assistant/src/__tests__/conversation-history-web-search.test.ts
@@ -788,6 +788,13 @@ describe("web_search_tool_result structural guard", () => {
     // tool_result is relevant. Same reasoning as agent/loop.ts above.
     "plugins/defaults/tool-error/hooks/post-tool-use.ts",
 
+    // Counts unbroken runs of locally-executed exploration tools (bash,
+    // file_read, file_list) to detect inline drift. Server-side web search
+    // results (web_search_tool_result) are not produced by the tool executor;
+    // any non-exploration block simply bounds the trailing run, which is the
+    // conservative direction (fewer nudges). Same reasoning as agent/loop.ts.
+    "plugins/defaults/exploration-drift/hooks/post-tool-use.ts",
+
     // Reconciles synthesized cancellation tool_results for locally-executed
     // tools only. Same reasoning as agent/loop.ts above.
     "daemon/conversation-agent-loop.ts",

--- a/assistant/src/__tests__/exploration-drift-hook.test.ts
+++ b/assistant/src/__tests__/exploration-drift-hook.test.ts
@@ -1,0 +1,364 @@
+/**
+ * Tests for the default `exploration-drift` plugin's `post-tool-use` hook.
+ *
+ * Covers:
+ * - The hook surfaces the canonical nudge via `additionalContext` (leaving the
+ *   tool result's `content` untouched) once a turn accumulates an unbroken
+ *   threshold-length run of exploration tool calls, and stays silent below it.
+ * - The streak is bounded by a real user message, a non-empty assistant text
+ *   block, and a non-exploration tool result.
+ * - Repeat nudges are spaced one full threshold apart per conversation.
+ * - Subagent conversations are exempt.
+ * - The nudge appends to (not overwrites) `additionalContext` set by an
+ *   earlier hook in the chain (e.g. tool-error coaching).
+ * - End-to-end through `runHook` + the registry.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Mock the subagent manager before importing the hook — the hook lazily
+// imports it on the nudge path to exempt subagent conversations.
+let mockParentInfo: (conversationId: string) => unknown = () => undefined;
+mock.module("../subagent/index.js", () => ({
+  getSubagentManager: () => ({
+    getParentInfo: (conversationId: string) => mockParentInfo(conversationId),
+  }),
+}));
+
+import { HOOKS } from "../plugin-api/constants.js";
+import type { PluginLogger, PostToolUseContext } from "../plugin-api/types.js";
+import postToolUse, {
+  EXPLORATION_DRIFT_NUDGE_TEXT,
+  EXPLORATION_NUDGE_THRESHOLD,
+  resetExplorationDriftStateForTests,
+} from "../plugins/defaults/exploration-drift/hooks/post-tool-use.js";
+import { defaultExplorationDriftPlugin } from "../plugins/defaults/index.js";
+import { runHook } from "../plugins/pipeline.js";
+import {
+  registerPlugin,
+  resetPluginRegistryForTests,
+} from "../plugins/registry.js";
+import type { Message, ToolResultContent } from "../providers/types.js";
+
+const noopLogger: PluginLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+};
+
+const BASE_CONTENT = "grep output";
+
+let conversationCounter = 0;
+/** Unique conversation id per test so the per-conversation state can't leak. */
+function freshConversationId(): string {
+  conversationCounter++;
+  return `conv-drift-test-${conversationCounter}`;
+}
+
+/** Assistant turn issuing a single `tool_use` block. */
+function toolUseTurn(id: string, name: string): Message {
+  return {
+    role: "assistant",
+    content: [{ type: "tool_use", id, name, input: {} }],
+  };
+}
+
+/** User turn carrying a single `tool_result` for a prior `tool_use`. */
+function toolResultTurn(toolUseId: string): Message {
+  return {
+    role: "user",
+    content: [
+      {
+        type: "tool_result",
+        tool_use_id: toolUseId,
+        content: "result",
+        is_error: false,
+      },
+    ],
+  };
+}
+
+function currentResponse(toolUseId: string): ToolResultContent {
+  return {
+    type: "tool_result",
+    tool_use_id: toolUseId,
+    content: BASE_CONTENT,
+    is_error: false,
+  };
+}
+
+function makeCtx(
+  conversationId: string,
+  toolResponse: ToolResultContent,
+  messages: Message[],
+): PostToolUseContext {
+  return {
+    conversationId,
+    toolResponse,
+    messages,
+    additionalContext: null,
+    maxInputTokens: 10_000,
+    logger: noopLogger,
+  };
+}
+
+/**
+ * Build a history of `priorCalls` completed exploration tool calls of
+ * `toolName`, followed by the current turn's `tool_use` (whose result is
+ * delivered via `ctx.toolResponse`, not history).
+ */
+function explorationHistory(
+  priorCalls: number,
+  toolName = "bash",
+): { messages: Message[]; currentToolUseId: string } {
+  const messages: Message[] = [
+    { role: "user", content: [{ type: "text", text: "investigate the bug" }] },
+  ];
+  for (let i = 0; i < priorCalls; i++) {
+    const id = `${toolName}-${i}`;
+    messages.push(toolUseTurn(id, toolName));
+    messages.push(toolResultTurn(id));
+  }
+  const currentToolUseId = `${toolName}-current`;
+  messages.push(toolUseTurn(currentToolUseId, toolName));
+  return { messages, currentToolUseId };
+}
+
+beforeEach(() => {
+  resetExplorationDriftStateForTests();
+  mockParentInfo = () => undefined;
+});
+
+describe("exploration-drift post-tool-use hook — direct", () => {
+  test("stays silent below the threshold", async () => {
+    const { messages, currentToolUseId } = explorationHistory(
+      EXPLORATION_NUDGE_THRESHOLD - 2,
+    );
+    const ctx = makeCtx(
+      freshConversationId(),
+      currentResponse(currentToolUseId),
+      messages,
+    );
+
+    await postToolUse(ctx);
+
+    expect(ctx.additionalContext).toBeNull();
+    expect(ctx.toolResponse.content).toBe(BASE_CONTENT);
+  });
+
+  test("nudges once the streak reaches the threshold, leaving the result untouched", async () => {
+    const { messages, currentToolUseId } = explorationHistory(
+      EXPLORATION_NUDGE_THRESHOLD - 1,
+    );
+    const ctx = makeCtx(
+      freshConversationId(),
+      currentResponse(currentToolUseId),
+      messages,
+    );
+
+    await postToolUse(ctx);
+
+    expect(ctx.additionalContext).toBe(EXPLORATION_DRIFT_NUDGE_TEXT);
+    expect(ctx.toolResponse.content).toBe(BASE_CONTENT);
+  });
+
+  test("counts file_read and file_list as exploration tools", async () => {
+    const messages: Message[] = [];
+    for (let i = 0; i < EXPLORATION_NUDGE_THRESHOLD - 1; i++) {
+      const name = i % 2 === 0 ? "file_read" : "file_list";
+      const id = `${name}-${i}`;
+      messages.push(toolUseTurn(id, name));
+      messages.push(toolResultTurn(id));
+    }
+    messages.push(toolUseTurn("bash-current", "bash"));
+    const ctx = makeCtx(
+      freshConversationId(),
+      currentResponse("bash-current"),
+      messages,
+    );
+
+    await postToolUse(ctx);
+
+    expect(ctx.additionalContext).toBe(EXPLORATION_DRIFT_NUDGE_TEXT);
+  });
+
+  test("a non-empty assistant text block resets the streak", async () => {
+    // GIVEN a long run interrupted by the model speaking to the user, with
+    // fewer than threshold calls after the text.
+    const { messages, currentToolUseId } = explorationHistory(
+      EXPLORATION_NUDGE_THRESHOLD - 1,
+    );
+    messages.splice(messages.length - 1, 0, {
+      role: "assistant",
+      content: [{ type: "text", text: "Here is what I found so far…" }],
+    });
+    const ctx = makeCtx(
+      freshConversationId(),
+      currentResponse(currentToolUseId),
+      messages,
+    );
+
+    await postToolUse(ctx);
+
+    expect(ctx.additionalContext).toBeNull();
+  });
+
+  test("a non-exploration tool result breaks the streak", async () => {
+    const { messages, currentToolUseId } = explorationHistory(
+      EXPLORATION_NUDGE_THRESHOLD - 1,
+    );
+    // Replace the second-to-last completed call with a write tool.
+    messages.splice(
+      messages.length - 1,
+      0,
+      toolUseTurn("write-1", "file_write"),
+      toolResultTurn("write-1"),
+    );
+    const ctx = makeCtx(
+      freshConversationId(),
+      currentResponse(currentToolUseId),
+      messages,
+    );
+
+    await postToolUse(ctx);
+
+    expect(ctx.additionalContext).toBeNull();
+  });
+
+  test("is a no-op when the current tool is not an exploration tool", async () => {
+    const { messages } = explorationHistory(EXPLORATION_NUDGE_THRESHOLD * 2);
+    messages.push(toolUseTurn("write-current", "file_write"));
+    const ctx = makeCtx(
+      freshConversationId(),
+      currentResponse("write-current"),
+      messages,
+    );
+
+    await postToolUse(ctx);
+
+    expect(ctx.additionalContext).toBeNull();
+  });
+
+  test("repeat nudges are spaced one full threshold apart", async () => {
+    const conversationId = freshConversationId();
+
+    // First nudge at the threshold.
+    const first = explorationHistory(EXPLORATION_NUDGE_THRESHOLD - 1);
+    const firstCtx = makeCtx(
+      conversationId,
+      currentResponse(first.currentToolUseId),
+      first.messages,
+    );
+    await postToolUse(firstCtx);
+    expect(firstCtx.additionalContext).toBe(EXPLORATION_DRIFT_NUDGE_TEXT);
+
+    // One more call right after — silent.
+    const next = explorationHistory(EXPLORATION_NUDGE_THRESHOLD);
+    const nextCtx = makeCtx(
+      conversationId,
+      currentResponse(next.currentToolUseId),
+      next.messages,
+    );
+    await postToolUse(nextCtx);
+    expect(nextCtx.additionalContext).toBeNull();
+
+    // Another full threshold later — nudges again.
+    const second = explorationHistory(EXPLORATION_NUDGE_THRESHOLD * 2 - 1);
+    const secondCtx = makeCtx(
+      conversationId,
+      currentResponse(second.currentToolUseId),
+      second.messages,
+    );
+    await postToolUse(secondCtx);
+    expect(secondCtx.additionalContext).toBe(EXPLORATION_DRIFT_NUDGE_TEXT);
+  });
+
+  test("a restarted streak (new turn) nudges at the threshold again", async () => {
+    const conversationId = freshConversationId();
+
+    // Fire once deep into a long run.
+    const longRun = explorationHistory(EXPLORATION_NUDGE_THRESHOLD * 2 - 1);
+    const longCtx = makeCtx(
+      conversationId,
+      currentResponse(longRun.currentToolUseId),
+      longRun.messages,
+    );
+    await postToolUse(longCtx);
+    expect(longCtx.additionalContext).toBe(EXPLORATION_DRIFT_NUDGE_TEXT);
+
+    // A new turn starts (streak restarts from a fresh history) and runs to
+    // the threshold — the stale high-water mark must not suppress this nudge.
+    const newTurn = explorationHistory(EXPLORATION_NUDGE_THRESHOLD - 1);
+    const newCtx = makeCtx(
+      conversationId,
+      currentResponse(newTurn.currentToolUseId),
+      newTurn.messages,
+    );
+    await postToolUse(newCtx);
+    expect(newCtx.additionalContext).toBe(EXPLORATION_DRIFT_NUDGE_TEXT);
+  });
+
+  test("subagent conversations are exempt", async () => {
+    mockParentInfo = () => ({
+      parentConversationId: "parent-1",
+      subagentId: "sub-1",
+      label: "investigate-empty-turns",
+      parentSendToClient: () => {},
+    });
+    const { messages, currentToolUseId } = explorationHistory(
+      EXPLORATION_NUDGE_THRESHOLD - 1,
+    );
+    const ctx = makeCtx(
+      freshConversationId(),
+      currentResponse(currentToolUseId),
+      messages,
+    );
+
+    await postToolUse(ctx);
+
+    expect(ctx.additionalContext).toBeNull();
+  });
+
+  test("appends to additionalContext set by an earlier hook", async () => {
+    const { messages, currentToolUseId } = explorationHistory(
+      EXPLORATION_NUDGE_THRESHOLD - 1,
+    );
+    const ctx = makeCtx(
+      freshConversationId(),
+      currentResponse(currentToolUseId),
+      messages,
+    );
+    ctx.additionalContext = "<system_notice>earlier coaching</system_notice>";
+
+    await postToolUse(ctx);
+
+    expect(ctx.additionalContext).toBe(
+      `<system_notice>earlier coaching</system_notice>\n${EXPLORATION_DRIFT_NUDGE_TEXT}`,
+    );
+  });
+});
+
+describe("exploration-drift post-tool-use hook — via runHook", () => {
+  beforeEach(() => {
+    resetPluginRegistryForTests();
+  });
+
+  test("registering the default plugin nudges a threshold-length run", async () => {
+    registerPlugin(defaultExplorationDriftPlugin);
+    const { messages, currentToolUseId } = explorationHistory(
+      EXPLORATION_NUDGE_THRESHOLD - 1,
+    );
+
+    const result = await runHook<PostToolUseContext>(
+      HOOKS.POST_TOOL_USE,
+      makeCtx(
+        freshConversationId(),
+        currentResponse(currentToolUseId),
+        messages,
+      ),
+    );
+
+    expect(result.additionalContext).toBe(EXPLORATION_DRIFT_NUDGE_TEXT);
+  });
+});

--- a/assistant/src/__tests__/exploration-drift-hook.test.ts
+++ b/assistant/src/__tests__/exploration-drift-hook.test.ts
@@ -6,7 +6,8 @@
  *   (leaving the tool result's `content` untouched) once a turn accumulates an
  *   unbroken threshold-length run of exploration tool calls, and stays silent
  *   below it.
- * - The loop trigger: on loop-prone models (Kimi K2.6), re-issuing a
+ * - The loop trigger: on loop-prone models (Kimi K2.6, MiniMax M3),
+ *   re-issuing a
  *   byte-identical exploration call fires a loop nudge well before the
  *   long-dig threshold; other models are unaffected; the signature comparison
  *   is key-order independent; the nudge re-fires on further duplicates and
@@ -63,6 +64,8 @@ const GENERIC_MODEL = "claude-test-model";
 const KIMI_FIREWORKS_MODEL = "accounts/fireworks/models/kimi-k2p6";
 /** Kimi K2.6 as reported by OpenRouter. */
 const KIMI_OPENROUTER_MODEL = "moonshotai/kimi-k2.6";
+/** MiniMax M3 as reported by OpenRouter. */
+const MINIMAX_OPENROUTER_MODEL = "minimax/minimax-m3";
 
 let conversationCounter = 0;
 /** Unique conversation id per test so the per-conversation state can't leak. */
@@ -426,6 +429,24 @@ describe("exploration-drift post-tool-use hook — loop trigger", () => {
       currentResponse(currentToolUseId),
       messages,
       KIMI_OPENROUTER_MODEL,
+    );
+
+    await postToolUse(ctx);
+
+    expect(ctx.additionalContext).toBe(
+      explorationLoopNudgeText("bash", EXPLORATION_LOOP_REPEAT_THRESHOLD),
+    );
+  });
+
+  test("matches the MiniMax M3 model id", async () => {
+    const { messages, currentToolUseId } = repeatedCallHistory({
+      priorIdenticalCalls: EXPLORATION_LOOP_REPEAT_THRESHOLD - 1,
+    });
+    const ctx = makeCtx(
+      freshConversationId(),
+      currentResponse(currentToolUseId),
+      messages,
+      MINIMAX_OPENROUTER_MODEL,
     );
 
     await postToolUse(ctx);

--- a/assistant/src/__tests__/exploration-drift-hook.test.ts
+++ b/assistant/src/__tests__/exploration-drift-hook.test.ts
@@ -2,12 +2,18 @@
  * Tests for the default `exploration-drift` plugin's `post-tool-use` hook.
  *
  * Covers:
- * - The hook surfaces the canonical nudge via `additionalContext` (leaving the
- *   tool result's `content` untouched) once a turn accumulates an unbroken
- *   threshold-length run of exploration tool calls, and stays silent below it.
+ * - The hook surfaces the canonical long-dig nudge via `additionalContext`
+ *   (leaving the tool result's `content` untouched) once a turn accumulates an
+ *   unbroken threshold-length run of exploration tool calls, and stays silent
+ *   below it.
+ * - The loop trigger: on loop-prone models (Kimi K2.6), re-issuing a
+ *   byte-identical exploration call fires a loop nudge well before the
+ *   long-dig threshold; other models are unaffected; the signature comparison
+ *   is key-order independent; the nudge re-fires on further duplicates and
+ *   stops when the model moves on to fresh calls.
  * - The streak is bounded by a real user message, a non-empty assistant text
  *   block, and a non-exploration tool result.
- * - Repeat nudges are spaced one full threshold apart per conversation.
+ * - Repeat long-dig nudges are spaced one full threshold apart.
  * - Subagent conversations are exempt.
  * - The nudge appends to (not overwrites) `additionalContext` set by an
  *   earlier hook in the chain (e.g. tool-error coaching).
@@ -29,7 +35,9 @@ import { HOOKS } from "../plugin-api/constants.js";
 import type { PluginLogger, PostToolUseContext } from "../plugin-api/types.js";
 import postToolUse, {
   EXPLORATION_DRIFT_NUDGE_TEXT,
+  EXPLORATION_LOOP_REPEAT_THRESHOLD,
   EXPLORATION_NUDGE_THRESHOLD,
+  explorationLoopNudgeText,
   resetExplorationDriftStateForTests,
 } from "../plugins/defaults/exploration-drift/hooks/post-tool-use.js";
 import { defaultExplorationDriftPlugin } from "../plugins/defaults/index.js";
@@ -49,6 +57,13 @@ const noopLogger: PluginLogger = {
 
 const BASE_CONTENT = "grep output";
 
+/** A model id outside the loop-prone set. */
+const GENERIC_MODEL = "claude-test-model";
+/** Kimi K2.6 as reported by Fireworks. */
+const KIMI_FIREWORKS_MODEL = "accounts/fireworks/models/kimi-k2p6";
+/** Kimi K2.6 as reported by OpenRouter. */
+const KIMI_OPENROUTER_MODEL = "moonshotai/kimi-k2.6";
+
 let conversationCounter = 0;
 /** Unique conversation id per test so the per-conversation state can't leak. */
 function freshConversationId(): string {
@@ -57,10 +72,14 @@ function freshConversationId(): string {
 }
 
 /** Assistant turn issuing a single `tool_use` block. */
-function toolUseTurn(id: string, name: string): Message {
+function toolUseTurn(
+  id: string,
+  name: string,
+  input: Record<string, unknown> = {},
+): Message {
   return {
     role: "assistant",
-    content: [{ type: "tool_use", id, name, input: {} }],
+    content: [{ type: "tool_use", id, name, input }],
   };
 }
 
@@ -92,12 +111,14 @@ function makeCtx(
   conversationId: string,
   toolResponse: ToolResultContent,
   messages: Message[],
+  model: string = GENERIC_MODEL,
 ): PostToolUseContext {
   return {
     conversationId,
     toolResponse,
     messages,
     additionalContext: null,
+    model,
     maxInputTokens: 10_000,
     logger: noopLogger,
   };
@@ -105,8 +126,10 @@ function makeCtx(
 
 /**
  * Build a history of `priorCalls` completed exploration tool calls of
- * `toolName`, followed by the current turn's `tool_use` (whose result is
- * delivered via `ctx.toolResponse`, not history).
+ * `toolName` — each with a distinct input, so the loop trigger never fires on
+ * histories meant to exercise the long-dig threshold — followed by the
+ * current turn's `tool_use` (whose result is delivered via
+ * `ctx.toolResponse`, not history).
  */
 function explorationHistory(
   priorCalls: number,
@@ -117,11 +140,47 @@ function explorationHistory(
   ];
   for (let i = 0; i < priorCalls; i++) {
     const id = `${toolName}-${i}`;
-    messages.push(toolUseTurn(id, toolName));
+    messages.push(toolUseTurn(id, toolName, { command: `cmd-${i}` }));
     messages.push(toolResultTurn(id));
   }
   const currentToolUseId = `${toolName}-current`;
-  messages.push(toolUseTurn(currentToolUseId, toolName));
+  messages.push(
+    toolUseTurn(currentToolUseId, toolName, { command: "cmd-current" }),
+  );
+  return { messages, currentToolUseId };
+}
+
+/**
+ * Build a history where the current call repeats a prior call's exact input
+ * `priorIdenticalCalls` times, padded in front with `distinctCalls` calls
+ * with unique inputs.
+ */
+function repeatedCallHistory(opts: {
+  priorIdenticalCalls: number;
+  distinctCalls?: number;
+  input?: Record<string, unknown>;
+  currentInput?: Record<string, unknown>;
+}): { messages: Message[]; currentToolUseId: string } {
+  const repeatedInput = opts.input ?? { command: "grep -r needle src" };
+  const messages: Message[] = [
+    { role: "user", content: [{ type: "text", text: "investigate the bug" }] },
+  ];
+  for (let i = 0; i < (opts.distinctCalls ?? 0); i++) {
+    const id = `distinct-${i}`;
+    messages.push(toolUseTurn(id, "bash", { command: `unique-${i}` }));
+    messages.push(toolResultTurn(id));
+  }
+  for (let i = 0; i < opts.priorIdenticalCalls; i++) {
+    const id = `repeat-${i}`;
+    messages.push(toolUseTurn(id, "bash", { ...repeatedInput }));
+    messages.push(toolResultTurn(id));
+  }
+  const currentToolUseId = "repeat-current";
+  messages.push(
+    toolUseTurn(currentToolUseId, "bash", {
+      ...(opts.currentInput ?? repeatedInput),
+    }),
+  );
   return { messages, currentToolUseId };
 }
 
@@ -130,7 +189,7 @@ beforeEach(() => {
   mockParentInfo = () => undefined;
 });
 
-describe("exploration-drift post-tool-use hook — direct", () => {
+describe("exploration-drift post-tool-use hook — long-dig trigger", () => {
   test("stays silent below the threshold", async () => {
     const { messages, currentToolUseId } = explorationHistory(
       EXPLORATION_NUDGE_THRESHOLD - 2,
@@ -168,10 +227,10 @@ describe("exploration-drift post-tool-use hook — direct", () => {
     for (let i = 0; i < EXPLORATION_NUDGE_THRESHOLD - 1; i++) {
       const name = i % 2 === 0 ? "file_read" : "file_list";
       const id = `${name}-${i}`;
-      messages.push(toolUseTurn(id, name));
+      messages.push(toolUseTurn(id, name, { path: `/tmp/file-${i}` }));
       messages.push(toolResultTurn(id));
     }
-    messages.push(toolUseTurn("bash-current", "bash"));
+    messages.push(toolUseTurn("bash-current", "bash", { command: "ls" }));
     const ctx = makeCtx(
       freshConversationId(),
       currentResponse("bash-current"),
@@ -339,6 +398,232 @@ describe("exploration-drift post-tool-use hook — direct", () => {
   });
 });
 
+describe("exploration-drift post-tool-use hook — loop trigger", () => {
+  test("fires on a loop-prone model when an identical call repeats to the threshold", async () => {
+    const { messages, currentToolUseId } = repeatedCallHistory({
+      priorIdenticalCalls: EXPLORATION_LOOP_REPEAT_THRESHOLD - 1,
+    });
+    const ctx = makeCtx(
+      freshConversationId(),
+      currentResponse(currentToolUseId),
+      messages,
+      KIMI_FIREWORKS_MODEL,
+    );
+
+    await postToolUse(ctx);
+
+    expect(ctx.additionalContext).toBe(
+      explorationLoopNudgeText("bash", EXPLORATION_LOOP_REPEAT_THRESHOLD),
+    );
+  });
+
+  test("matches the OpenRouter Kimi K2.6 model id", async () => {
+    const { messages, currentToolUseId } = repeatedCallHistory({
+      priorIdenticalCalls: EXPLORATION_LOOP_REPEAT_THRESHOLD - 1,
+    });
+    const ctx = makeCtx(
+      freshConversationId(),
+      currentResponse(currentToolUseId),
+      messages,
+      KIMI_OPENROUTER_MODEL,
+    );
+
+    await postToolUse(ctx);
+
+    expect(ctx.additionalContext).toBe(
+      explorationLoopNudgeText("bash", EXPLORATION_LOOP_REPEAT_THRESHOLD),
+    );
+  });
+
+  test("stays silent on other models for the same repeated-call history", async () => {
+    const { messages, currentToolUseId } = repeatedCallHistory({
+      priorIdenticalCalls: EXPLORATION_LOOP_REPEAT_THRESHOLD - 1,
+    });
+    const ctx = makeCtx(
+      freshConversationId(),
+      currentResponse(currentToolUseId),
+      messages,
+      GENERIC_MODEL,
+    );
+
+    await postToolUse(ctx);
+
+    expect(ctx.additionalContext).toBeNull();
+  });
+
+  test("stays silent below the repeat threshold", async () => {
+    const { messages, currentToolUseId } = repeatedCallHistory({
+      priorIdenticalCalls: EXPLORATION_LOOP_REPEAT_THRESHOLD - 2,
+    });
+    const ctx = makeCtx(
+      freshConversationId(),
+      currentResponse(currentToolUseId),
+      messages,
+      KIMI_FIREWORKS_MODEL,
+    );
+
+    await postToolUse(ctx);
+
+    expect(ctx.additionalContext).toBeNull();
+  });
+
+  test("stays silent on a loop-prone model when calls are distinct", async () => {
+    const { messages, currentToolUseId } = explorationHistory(
+      EXPLORATION_NUDGE_THRESHOLD - 2,
+    );
+    const ctx = makeCtx(
+      freshConversationId(),
+      currentResponse(currentToolUseId),
+      messages,
+      KIMI_FIREWORKS_MODEL,
+    );
+
+    await postToolUse(ctx);
+
+    expect(ctx.additionalContext).toBeNull();
+  });
+
+  test("input signature comparison is key-order independent", async () => {
+    const { messages, currentToolUseId } = repeatedCallHistory({
+      priorIdenticalCalls: EXPLORATION_LOOP_REPEAT_THRESHOLD - 1,
+      input: { command: "cat /tmp/log", timeout: 5 },
+      currentInput: { timeout: 5, command: "cat /tmp/log" },
+    });
+    const ctx = makeCtx(
+      freshConversationId(),
+      currentResponse(currentToolUseId),
+      messages,
+      KIMI_FIREWORKS_MODEL,
+    );
+
+    await postToolUse(ctx);
+
+    expect(ctx.additionalContext).toBe(
+      explorationLoopNudgeText("bash", EXPLORATION_LOOP_REPEAT_THRESHOLD),
+    );
+  });
+
+  test("re-fires on the next duplicate but not on the same streak twice", async () => {
+    const conversationId = freshConversationId();
+
+    // First loop nudge.
+    const first = repeatedCallHistory({
+      priorIdenticalCalls: EXPLORATION_LOOP_REPEAT_THRESHOLD - 1,
+    });
+    const firstCtx = makeCtx(
+      conversationId,
+      currentResponse(first.currentToolUseId),
+      first.messages,
+      KIMI_FIREWORKS_MODEL,
+    );
+    await postToolUse(firstCtx);
+    expect(firstCtx.additionalContext).toBe(
+      explorationLoopNudgeText("bash", EXPLORATION_LOOP_REPEAT_THRESHOLD),
+    );
+
+    // A parallel sibling result observing the same history (same streak)
+    // dedupes.
+    const siblingCtx = makeCtx(
+      conversationId,
+      currentResponse(first.currentToolUseId),
+      first.messages,
+      KIMI_FIREWORKS_MODEL,
+    );
+    await postToolUse(siblingCtx);
+    expect(siblingCtx.additionalContext).toBeNull();
+
+    // The model ignores the nudge and issues the same call once more — the
+    // streak grew by one, so the nudge re-fires with the higher count.
+    const second = repeatedCallHistory({
+      priorIdenticalCalls: EXPLORATION_LOOP_REPEAT_THRESHOLD,
+    });
+    const secondCtx = makeCtx(
+      conversationId,
+      currentResponse(second.currentToolUseId),
+      second.messages,
+      KIMI_FIREWORKS_MODEL,
+    );
+    await postToolUse(secondCtx);
+    expect(secondCtx.additionalContext).toBe(
+      explorationLoopNudgeText("bash", EXPLORATION_LOOP_REPEAT_THRESHOLD + 1),
+    );
+  });
+
+  test("stops nudging once the model moves on to fresh calls", async () => {
+    const conversationId = freshConversationId();
+
+    const looped = repeatedCallHistory({
+      priorIdenticalCalls: EXPLORATION_LOOP_REPEAT_THRESHOLD - 1,
+    });
+    const loopedCtx = makeCtx(
+      conversationId,
+      currentResponse(looped.currentToolUseId),
+      looped.messages,
+      KIMI_FIREWORKS_MODEL,
+    );
+    await postToolUse(loopedCtx);
+    expect(loopedCtx.additionalContext).not.toBeNull();
+
+    // Next call has a fresh input — even though the duplicates remain in the
+    // trailing run, the current call is not a repeat, so no loop nudge.
+    const moved = repeatedCallHistory({
+      priorIdenticalCalls: EXPLORATION_LOOP_REPEAT_THRESHOLD,
+      currentInput: { command: "a brand new command" },
+    });
+    const movedCtx = makeCtx(
+      conversationId,
+      currentResponse(moved.currentToolUseId),
+      moved.messages,
+      KIMI_FIREWORKS_MODEL,
+    );
+    await postToolUse(movedCtx);
+    expect(movedCtx.additionalContext).toBeNull();
+  });
+
+  test("subagent conversations are exempt from the loop trigger", async () => {
+    mockParentInfo = () => ({
+      parentConversationId: "parent-1",
+      subagentId: "sub-1",
+      label: "investigate-empty-turns",
+      parentSendToClient: () => {},
+    });
+    const { messages, currentToolUseId } = repeatedCallHistory({
+      priorIdenticalCalls: EXPLORATION_LOOP_REPEAT_THRESHOLD - 1,
+    });
+    const ctx = makeCtx(
+      freshConversationId(),
+      currentResponse(currentToolUseId),
+      messages,
+      KIMI_FIREWORKS_MODEL,
+    );
+
+    await postToolUse(ctx);
+
+    expect(ctx.additionalContext).toBeNull();
+  });
+
+  test("a long-dig-threshold run of identical calls uses the long-dig text once past the threshold", async () => {
+    // When both triggers are eligible the long-dig path wins — by then the
+    // generic guidance covers the loop case too.
+    const { messages, currentToolUseId } = repeatedCallHistory({
+      priorIdenticalCalls: EXPLORATION_NUDGE_THRESHOLD - 1,
+    });
+    const conversationId = freshConversationId();
+    const ctx = makeCtx(
+      conversationId,
+      currentResponse(currentToolUseId),
+      messages,
+      KIMI_FIREWORKS_MODEL,
+    );
+
+    await postToolUse(ctx);
+
+    // The loop trigger would have fired far earlier in a live run; with a
+    // cold conversation state at threshold length, the long-dig text wins.
+    expect(ctx.additionalContext).toBe(EXPLORATION_DRIFT_NUDGE_TEXT);
+  });
+});
+
 describe("exploration-drift post-tool-use hook — via runHook", () => {
   beforeEach(() => {
     resetPluginRegistryForTests();
@@ -360,5 +645,27 @@ describe("exploration-drift post-tool-use hook — via runHook", () => {
     );
 
     expect(result.additionalContext).toBe(EXPLORATION_DRIFT_NUDGE_TEXT);
+  });
+
+  test("registering the default plugin nudges a repeated call on Kimi K2.6", async () => {
+    registerPlugin(defaultExplorationDriftPlugin);
+    const { messages, currentToolUseId } = repeatedCallHistory({
+      priorIdenticalCalls: EXPLORATION_LOOP_REPEAT_THRESHOLD - 1,
+      distinctCalls: 2,
+    });
+
+    const result = await runHook<PostToolUseContext>(
+      HOOKS.POST_TOOL_USE,
+      makeCtx(
+        freshConversationId(),
+        currentResponse(currentToolUseId),
+        messages,
+        KIMI_FIREWORKS_MODEL,
+      ),
+    );
+
+    expect(result.additionalContext).toBe(
+      explorationLoopNudgeText("bash", EXPLORATION_LOOP_REPEAT_THRESHOLD),
+    );
   });
 });

--- a/assistant/src/__tests__/tool-error-hook.test.ts
+++ b/assistant/src/__tests__/tool-error-hook.test.ts
@@ -79,6 +79,7 @@ function makeCtx(
     toolResponse,
     messages,
     additionalContext: null,
+    model: "claude-test-model",
     maxInputTokens: 10_000,
     logger: noopLogger,
   };

--- a/assistant/src/__tests__/tool-result-truncate-hook.test.ts
+++ b/assistant/src/__tests__/tool-result-truncate-hook.test.ts
@@ -48,6 +48,7 @@ function makeCtx(content: string): PostToolUseContext {
     toolResponse: makeToolResponse(content),
     messages: [],
     additionalContext: null,
+    model: "claude-test-model",
     maxInputTokens: MAX_INPUT_TOKENS,
     logger: noopLogger,
   };

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -1691,6 +1691,7 @@ export class AgentLoop {
             toolResponse: block as ToolResultContent,
             messages: history,
             additionalContext: null,
+            model: response.model,
             maxInputTokens: contextWindowTokens,
             logger: rlog,
           };

--- a/assistant/src/plugin-api/types.ts
+++ b/assistant/src/plugin-api/types.ts
@@ -315,6 +315,13 @@ export interface PostToolUseContext {
    */
   additionalContext: string | null;
   /**
+   * Model id reported by the provider for the assistant turn that issued
+   * this tool call (e.g. `claude-opus-4-8`,
+   * `accounts/fireworks/models/kimi-k2p6`). Hooks use it to vary coaching by
+   * model family — some models need earlier or firmer steering than others.
+   */
+  readonly model: string;
+  /**
    * The model's context-window size in tokens. Plugins derive their own
    * character budget from this (e.g. a share of the window) rather than
    * receiving a precomputed limit.

--- a/assistant/src/plugins/defaults/exploration-drift/hooks/post-tool-use.ts
+++ b/assistant/src/plugins/defaults/exploration-drift/hooks/post-tool-use.ts
@@ -1,0 +1,158 @@
+/**
+ * Default `post-tool-use` hook: when the model accumulates a long unbroken
+ * run of exploration tool calls (bash, file_read, file_list) without sending
+ * the user any text, surface a notice via `additionalContext` that coaches it
+ * to (a) give the user a brief progress summary and (b) delegate the rest of
+ * the investigation to an `investigator` subagent instead of continuing
+ * inline.
+ *
+ * Motivation: a root-cause request investigated inline ran 167 sequential
+ * bash calls in a single turn with no user-facing text, overflowed the
+ * conversation context before any findings were written up, and forced the
+ * user into repeated "Continue?" turns that re-explored the same files.
+ * Delegation keeps the digging in a disposable subagent context. The notice
+ * is advisory — the model decides whether the current run is genuinely an
+ * investigation worth delegating.
+ *
+ * The streak is derived from conversation history on every call (mirroring
+ * the tool-error plugin) so the signal survives mid-run compaction rewriting
+ * the array. The trailing run is bounded by:
+ * - a real user message (turn boundary),
+ * - any non-empty assistant text block (the model spoke to the user),
+ * - any non-exploration tool result (the model did something besides read).
+ *
+ * Repeat nudges are spaced one full threshold apart via a per-conversation
+ * high-water mark, which also dedupes parallel tool results of one batch
+ * (they all observe the same history and would compute the same streak).
+ *
+ * Subagent conversations are exempt: an investigator is *supposed* to dig at
+ * length, and subagents cannot nest (`SUBAGENT_LIMITS.maxDepth`), so the
+ * delegation advice would be wrong there. The check is a lazy import on the
+ * rare nudge path so the subagent manager's module graph stays out of the
+ * per-tool-result hot path.
+ */
+
+import type { PluginHookFn, PostToolUseContext } from "@vellumai/plugin-api";
+
+import type { Message } from "../../../../providers/types.js";
+
+/**
+ * Canonical exploration-drift notice. Module-level constant so tests and
+ * wrapping plugins can match it without duplicating the string. Shown to the
+ * model as provider-only context, never to the user.
+ */
+export const EXPLORATION_DRIFT_NUDGE_TEXT =
+  "<system_notice>You have made a long unbroken run of exploration tool calls (shell/file reads) without sending the user any text. Do two things now: (1) send the user a brief summary of what you have found so far — do not keep working silently; (2) if you are tracing a root cause or exploring code/logs at length, stop exploring inline and delegate the remainder to a subagent: call subagent_spawn with role 'investigator' and a precise objective. It will investigate in its own context window and return a compact root-cause report. Continuing inline floods this conversation's context and risks losing your findings before you can report them.</system_notice>";
+
+/**
+ * Exploration streak length that triggers the first nudge; repeat nudges fire
+ * each time the streak grows by another full threshold.
+ */
+export const EXPLORATION_NUDGE_THRESHOLD = 25;
+
+/** Read-only exploration tools whose unbroken runs indicate inline drift. */
+const EXPLORATION_TOOL_NAMES: ReadonlySet<string> = new Set([
+  "bash",
+  "file_read",
+  "file_list",
+]);
+
+/**
+ * Streak length at the last nudge, per conversation. A high-water mark rather
+ * than a flag so repeat nudges stay one full threshold apart and parallel
+ * results of one batch (same observed history, same computed streak) dedupe
+ * to a single notice. Entries are dropped when the streak restarts.
+ */
+const lastNudgedStreakByConversation = new Map<string, number>();
+
+/** Test-only: clear the per-conversation nudge high-water marks. */
+export function resetExplorationDriftStateForTests(): void {
+  lastNudgedStreakByConversation.clear();
+}
+
+/** Map every `tool_use` block id in history to the tool name it invoked. */
+function toolNamesById(messages: ReadonlyArray<Message>): Map<string, string> {
+  const names = new Map<string, string>();
+  for (const message of messages) {
+    if (message.role !== "assistant") continue;
+    for (const block of message.content) {
+      if (block.type === "tool_use") names.set(block.id, block.name);
+    }
+  }
+  return names;
+}
+
+/**
+ * Length of the trailing unbroken run of exploration tool results in history.
+ * Walks backwards from the most recent message and stops at a real user
+ * message, a non-empty assistant text block, or a non-exploration tool
+ * result. Text blocks inside tool-result user rows (e.g. coaching notices
+ * appended by other hooks) do not break the run — they are system notices,
+ * not the model speaking to the user.
+ */
+function trailingExplorationStreak(
+  messages: ReadonlyArray<Message>,
+  namesById: ReadonlyMap<string, string>,
+): number {
+  let count = 0;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (message.role === "assistant") {
+      const spokeToUser = message.content.some(
+        (block) => block.type === "text" && block.text.trim().length > 0,
+      );
+      if (spokeToUser) break;
+      continue;
+    }
+    if (message.role !== "user") continue;
+    const hasToolResult = message.content.some(
+      (block) => block.type === "tool_result",
+    );
+    if (!hasToolResult) break;
+    for (let j = message.content.length - 1; j >= 0; j--) {
+      const block = message.content[j];
+      if (block.type !== "tool_result") continue;
+      const toolName = namesById.get(block.tool_use_id);
+      if (toolName === undefined || !EXPLORATION_TOOL_NAMES.has(toolName)) {
+        return count;
+      }
+      count++;
+    }
+  }
+  return count;
+}
+
+const postToolUse: PluginHookFn<PostToolUseContext> = async (ctx) => {
+  const namesById = toolNamesById(ctx.messages);
+  const toolName = namesById.get(ctx.toolResponse.tool_use_id);
+  if (toolName === undefined || !EXPLORATION_TOOL_NAMES.has(toolName)) return;
+
+  // The current result is not in history yet — count it explicitly.
+  const streak = trailingExplorationStreak(ctx.messages, namesById) + 1;
+
+  let lastNudged = lastNudgedStreakByConversation.get(ctx.conversationId) ?? 0;
+  if (streak < lastNudged) {
+    // The streak restarted (new turn, intervening text, or compaction) since
+    // the last nudge — drop the stale high-water mark.
+    lastNudgedStreakByConversation.delete(ctx.conversationId);
+    lastNudged = 0;
+  }
+  if (streak - lastNudged < EXPLORATION_NUDGE_THRESHOLD) return;
+
+  // Subagent conversations are exempt — see module doc.
+  const { getSubagentManager } = await import("../../../../subagent/index.js");
+  if (getSubagentManager().getParentInfo(ctx.conversationId) !== undefined) {
+    return;
+  }
+
+  lastNudgedStreakByConversation.set(ctx.conversationId, streak);
+  ctx.logger.info(
+    { plugin: "exploration-drift", streak, toolName },
+    "Exploration drift detected — nudging summary + investigator delegation",
+  );
+  ctx.additionalContext = ctx.additionalContext
+    ? `${ctx.additionalContext}\n${EXPLORATION_DRIFT_NUDGE_TEXT}`
+    : EXPLORATION_DRIFT_NUDGE_TEXT;
+};
+
+export default postToolUse;

--- a/assistant/src/plugins/defaults/exploration-drift/hooks/post-tool-use.ts
+++ b/assistant/src/plugins/defaults/exploration-drift/hooks/post-tool-use.ts
@@ -20,7 +20,8 @@
  * 1. **Long dig** (all models): an unbroken run of
  *    {@link EXPLORATION_NUDGE_THRESHOLD} exploration calls with no user-facing
  *    text. Repeat nudges are spaced one full threshold apart.
- * 2. **Loop** (loop-prone models only, currently Kimi K2.6): the current call
+ * 2. **Loop** (loop-prone models only, currently Kimi K2.6 and MiniMax M3):
+ *    the current call
  *    is byte-identical (same tool, same input) to at least
  *    {@link EXPLORATION_LOOP_REPEAT_THRESHOLD}-1 prior calls within the
  *    trailing run. Re-issuing an identical read-only call inside an unbroken
@@ -28,8 +29,8 @@
  *    sign the model is stuck, so this fires as soon as the repetition
  *    appears (potentially at call 3 of a run) rather than waiting for the
  *    long-dig threshold, and re-fires on every further duplicate while the
- *    model keeps looping. Gated by model because the looping behaviour was
- *    observed on Kimi K2.6; the one legitimate identical-call pattern
+ *    model keeps looping. Gated by model so the aggressive trigger covers
+ *    only models prone to this looping; the one legitimate identical-call pattern
  *    (polling an external process's output) is rare inside an unbroken
  *    read-only run and the nudge is advisory anyway.
  *
@@ -93,12 +94,13 @@ export const EXPLORATION_NUDGE_THRESHOLD = 25;
 export const EXPLORATION_LOOP_REPEAT_THRESHOLD = 3;
 
 /**
- * Models that get the early loop trigger. Matches Kimi K2.6 across providers
- * (Fireworks reports `accounts/fireworks/models/kimi-k2p6`, OpenRouter
- * reports `moonshotai/kimi-k2.6`). Extend the pattern as other models exhibit
- * the same re-exploration looping.
+ * Models that get the early loop trigger: Kimi K2.6 and MiniMax M3, matched
+ * across provider naming conventions (Fireworks spells the dot as `p`, e.g.
+ * `accounts/fireworks/models/kimi-k2p6`; OpenRouter reports
+ * `moonshotai/kimi-k2.6` and `minimax/minimax-m3`). Extend the pattern as
+ * other models exhibit the same re-exploration looping.
  */
-const LOOP_PRONE_MODEL_PATTERN = /kimi-k2[p.]6/i;
+const LOOP_PRONE_MODEL_PATTERN = /kimi-k2[p.]6|minimax-m3/i;
 
 /** Read-only exploration tools whose unbroken runs indicate inline drift. */
 const EXPLORATION_TOOL_NAMES: ReadonlySet<string> = new Set([

--- a/assistant/src/plugins/defaults/exploration-drift/hooks/post-tool-use.ts
+++ b/assistant/src/plugins/defaults/exploration-drift/hooks/post-tool-use.ts
@@ -1,29 +1,51 @@
 /**
- * Default `post-tool-use` hook: when the model accumulates a long unbroken
- * run of exploration tool calls (bash, file_read, file_list) without sending
- * the user any text, surface a notice via `additionalContext` that coaches it
- * to (a) give the user a brief progress summary and (b) delegate the rest of
- * the investigation to an `investigator` subagent instead of continuing
- * inline.
+ * Default `post-tool-use` hook: when a turn's exploration tool calls (bash,
+ * file_read, file_list) show drift — a long unbroken run with no text sent to
+ * the user, or the model re-issuing the exact same call — surface a notice
+ * via `additionalContext` that coaches it to (a) give the user a brief
+ * progress summary and (b) delegate the rest of the investigation to an
+ * `investigator` subagent instead of continuing inline.
  *
  * Motivation: a root-cause request investigated inline ran 167 sequential
  * bash calls in a single turn with no user-facing text, overflowed the
  * conversation context before any findings were written up, and forced the
- * user into repeated "Continue?" turns that re-explored the same files.
- * Delegation keeps the digging in a disposable subagent context. The notice
- * is advisory — the model decides whether the current run is genuinely an
- * investigation worth delegating.
+ * user into repeated "Continue?" turns that re-explored the same files (11 of
+ * the 15 files read in the follow-up turn were re-reads). Delegation keeps
+ * the digging in a disposable subagent context. The notices are advisory —
+ * the model decides whether the current run is genuinely an investigation
+ * worth delegating.
  *
- * The streak is derived from conversation history on every call (mirroring
- * the tool-error plugin) so the signal survives mid-run compaction rewriting
- * the array. The trailing run is bounded by:
+ * Two triggers, sharing one trailing-run computation:
+ *
+ * 1. **Long dig** (all models): an unbroken run of
+ *    {@link EXPLORATION_NUDGE_THRESHOLD} exploration calls with no user-facing
+ *    text. Repeat nudges are spaced one full threshold apart.
+ * 2. **Loop** (loop-prone models only, currently Kimi K2.6): the current call
+ *    is byte-identical (same tool, same input) to at least
+ *    {@link EXPLORATION_LOOP_REPEAT_THRESHOLD}-1 prior calls within the
+ *    trailing run. Re-issuing an identical read-only call inside an unbroken
+ *    read-only run yields no new information — it is the earliest reliable
+ *    sign the model is stuck, so this fires as soon as the repetition
+ *    appears (potentially at call 3 of a run) rather than waiting for the
+ *    long-dig threshold, and re-fires on every further duplicate while the
+ *    model keeps looping. Gated by model because the looping behaviour was
+ *    observed on Kimi K2.6; the one legitimate identical-call pattern
+ *    (polling an external process's output) is rare inside an unbroken
+ *    read-only run and the nudge is advisory anyway.
+ *
+ * The trailing run is derived from conversation history on every call
+ * (mirroring the tool-error plugin) so the signal survives mid-run compaction
+ * rewriting the array. The run is bounded by:
  * - a real user message (turn boundary),
  * - any non-empty assistant text block (the model spoke to the user),
  * - any non-exploration tool result (the model did something besides read).
  *
- * Repeat nudges are spaced one full threshold apart via a per-conversation
- * high-water mark, which also dedupes parallel tool results of one batch
- * (they all observe the same history and would compute the same streak).
+ * Nudges dedupe via a per-conversation high-water mark of the streak length
+ * at the last nudge: long-dig nudges require another full threshold of
+ * growth, loop nudges require any growth (each additional duplicate call
+ * re-nudges). The mark also dedupes parallel tool results of one batch (they
+ * all observe identical history and compute the same streak). Entries are
+ * dropped when the streak restarts.
  *
  * Subagent conversations are exempt: an investigator is *supposed* to dig at
  * length, and subagents cannot nest (`SUBAGENT_LIMITS.maxDepth`), so the
@@ -37,18 +59,46 @@ import type { PluginHookFn, PostToolUseContext } from "@vellumai/plugin-api";
 import type { Message } from "../../../../providers/types.js";
 
 /**
- * Canonical exploration-drift notice. Module-level constant so tests and
- * wrapping plugins can match it without duplicating the string. Shown to the
- * model as provider-only context, never to the user.
+ * Canonical long-dig notice. Module-level constant so tests and wrapping
+ * plugins can match it without duplicating the string. Shown to the model as
+ * provider-only context, never to the user.
  */
 export const EXPLORATION_DRIFT_NUDGE_TEXT =
   "<system_notice>You have made a long unbroken run of exploration tool calls (shell/file reads) without sending the user any text. Do two things now: (1) send the user a brief summary of what you have found so far — do not keep working silently; (2) if you are tracing a root cause or exploring code/logs at length, stop exploring inline and delegate the remainder to a subagent: call subagent_spawn with role 'investigator' and a precise objective. It will investigate in its own context window and return a compact root-cause report. Continuing inline floods this conversation's context and risks losing your findings before you can report them.</system_notice>";
 
 /**
- * Exploration streak length that triggers the first nudge; repeat nudges fire
- * each time the streak grows by another full threshold.
+ * Canonical loop notice, parameterized on the repeated call. Firmer than the
+ * long-dig text — by the time an identical read-only call repeats, the model
+ * is demonstrably not gaining information.
+ */
+export function explorationLoopNudgeText(
+  toolName: string,
+  repeatCount: number,
+): string {
+  return `<system_notice>You have issued this exact ${toolName} call ${repeatCount} times in the current run of exploration tool calls. Repeating an identical read-only call yields no new information — you are likely stuck. Do two things now: (1) send the user a brief summary of what you have found so far and what you are still missing — do not keep working silently; (2) stop exploring inline and delegate the remaining investigation to a subagent: call subagent_spawn with role 'investigator' and a precise objective that includes what you have already checked and ruled out. It will investigate in its own context window and return a compact root-cause report. Do not re-issue this call again.</system_notice>`;
+}
+
+/**
+ * Exploration streak length that triggers the first long-dig nudge; repeat
+ * long-dig nudges fire each time the streak grows by another full threshold.
  */
 export const EXPLORATION_NUDGE_THRESHOLD = 25;
+
+/**
+ * Number of byte-identical exploration calls (tool name + input) within one
+ * trailing run that triggers the loop nudge on loop-prone models. The count
+ * includes the current call, so 3 means "the current call is the third
+ * identical issue of this command".
+ */
+export const EXPLORATION_LOOP_REPEAT_THRESHOLD = 3;
+
+/**
+ * Models that get the early loop trigger. Matches Kimi K2.6 across providers
+ * (Fireworks reports `accounts/fireworks/models/kimi-k2p6`, OpenRouter
+ * reports `moonshotai/kimi-k2.6`). Extend the pattern as other models exhibit
+ * the same re-exploration looping.
+ */
+const LOOP_PRONE_MODEL_PATTERN = /kimi-k2[p.]6/i;
 
 /** Read-only exploration tools whose unbroken runs indicate inline drift. */
 const EXPLORATION_TOOL_NAMES: ReadonlySet<string> = new Set([
@@ -58,10 +108,12 @@ const EXPLORATION_TOOL_NAMES: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * Streak length at the last nudge, per conversation. A high-water mark rather
- * than a flag so repeat nudges stay one full threshold apart and parallel
- * results of one batch (same observed history, same computed streak) dedupe
- * to a single notice. Entries are dropped when the streak restarts.
+ * Streak length at the last nudge (either kind), per conversation. A
+ * high-water mark rather than a flag so long-dig nudges stay one full
+ * threshold apart, loop nudges fire only when the streak has grown since the
+ * last nudge, and parallel results of one batch (same observed history, same
+ * computed streak) dedupe to a single notice. Entries are dropped when the
+ * streak restarts.
  */
 const lastNudgedStreakByConversation = new Map<string, number>();
 
@@ -70,31 +122,61 @@ export function resetExplorationDriftStateForTests(): void {
   lastNudgedStreakByConversation.clear();
 }
 
-/** Map every `tool_use` block id in history to the tool name it invoked. */
-function toolNamesById(messages: ReadonlyArray<Message>): Map<string, string> {
-  const names = new Map<string, string>();
+/** A `tool_use` block's invocation: tool name plus its raw input. */
+interface ToolInvocation {
+  readonly name: string;
+  readonly input: unknown;
+}
+
+/** Map every `tool_use` block id in history to its invocation. */
+function toolUsesById(
+  messages: ReadonlyArray<Message>,
+): Map<string, ToolInvocation> {
+  const uses = new Map<string, ToolInvocation>();
   for (const message of messages) {
     if (message.role !== "assistant") continue;
     for (const block of message.content) {
-      if (block.type === "tool_use") names.set(block.id, block.name);
+      if (block.type === "tool_use") {
+        uses.set(block.id, { name: block.name, input: block.input });
+      }
     }
   }
-  return names;
+  return uses;
 }
 
 /**
- * Length of the trailing unbroken run of exploration tool results in history.
- * Walks backwards from the most recent message and stops at a real user
- * message, a non-empty assistant text block, or a non-exploration tool
- * result. Text blocks inside tool-result user rows (e.g. coaching notices
- * appended by other hooks) do not break the run — they are system notices,
- * not the model speaking to the user.
+ * Deterministic JSON encoding with object keys sorted recursively, so two
+ * semantically identical tool inputs hash to the same signature regardless of
+ * key order.
  */
-function trailingExplorationStreak(
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value) ?? "undefined";
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+  const record = value as Record<string, unknown>;
+  const entries = Object.keys(record)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`);
+  return `{${entries.join(",")}}`;
+}
+
+/**
+ * The trailing unbroken run of exploration tool results in history: its
+ * length and the `tool_use` ids of the calls in it. Walks backwards from the
+ * most recent message and stops at a real user message, a non-empty assistant
+ * text block, or a non-exploration tool result. Text blocks inside
+ * tool-result user rows (e.g. coaching notices appended by other hooks) do
+ * not break the run — they are system notices, not the model speaking to the
+ * user.
+ */
+function trailingExplorationRun(
   messages: ReadonlyArray<Message>,
-  namesById: ReadonlyMap<string, string>,
-): number {
-  let count = 0;
+  usesById: ReadonlyMap<string, ToolInvocation>,
+): { streak: number; toolUseIds: string[] } {
+  const toolUseIds: string[] = [];
   for (let i = messages.length - 1; i >= 0; i--) {
     const message = messages[i];
     if (message.role === "assistant") {
@@ -112,10 +194,36 @@ function trailingExplorationStreak(
     for (let j = message.content.length - 1; j >= 0; j--) {
       const block = message.content[j];
       if (block.type !== "tool_result") continue;
-      const toolName = namesById.get(block.tool_use_id);
-      if (toolName === undefined || !EXPLORATION_TOOL_NAMES.has(toolName)) {
-        return count;
+      const use = usesById.get(block.tool_use_id);
+      if (use === undefined || !EXPLORATION_TOOL_NAMES.has(use.name)) {
+        return { streak: toolUseIds.length, toolUseIds };
       }
+      toolUseIds.push(block.tool_use_id);
+    }
+  }
+  return { streak: toolUseIds.length, toolUseIds };
+}
+
+/**
+ * How many times the current call (tool name + input) has been issued within
+ * the trailing run, including the current call itself. Signatures are only
+ * computed for same-named calls, and only on the loop-prone-model path, to
+ * keep the per-tool-result cost bounded.
+ */
+function currentCallRepeatCount(
+  current: ToolInvocation,
+  runToolUseIds: ReadonlyArray<string>,
+  usesById: ReadonlyMap<string, ToolInvocation>,
+): number {
+  const currentSignature = stableStringify(current.input);
+  let count = 1;
+  for (const id of runToolUseIds) {
+    const use = usesById.get(id);
+    if (
+      use !== undefined &&
+      use.name === current.name &&
+      stableStringify(use.input) === currentSignature
+    ) {
       count++;
     }
   }
@@ -123,12 +231,14 @@ function trailingExplorationStreak(
 }
 
 const postToolUse: PluginHookFn<PostToolUseContext> = async (ctx) => {
-  const namesById = toolNamesById(ctx.messages);
-  const toolName = namesById.get(ctx.toolResponse.tool_use_id);
-  if (toolName === undefined || !EXPLORATION_TOOL_NAMES.has(toolName)) return;
+  const usesById = toolUsesById(ctx.messages);
+  const currentUse = usesById.get(ctx.toolResponse.tool_use_id);
+  if (currentUse === undefined || !EXPLORATION_TOOL_NAMES.has(currentUse.name))
+    return;
 
   // The current result is not in history yet — count it explicitly.
-  const streak = trailingExplorationStreak(ctx.messages, namesById) + 1;
+  const run = trailingExplorationRun(ctx.messages, usesById);
+  const streak = run.streak + 1;
 
   let lastNudged = lastNudgedStreakByConversation.get(ctx.conversationId) ?? 0;
   if (streak < lastNudged) {
@@ -137,7 +247,28 @@ const postToolUse: PluginHookFn<PostToolUseContext> = async (ctx) => {
     lastNudgedStreakByConversation.delete(ctx.conversationId);
     lastNudged = 0;
   }
-  if (streak - lastNudged < EXPLORATION_NUDGE_THRESHOLD) return;
+
+  const longDigNudge = streak - lastNudged >= EXPLORATION_NUDGE_THRESHOLD;
+
+  // Loop detection: only on loop-prone models, and only when the streak has
+  // grown since the last nudge (dedupes parallel batches; re-fires on each
+  // further duplicate). Keyed to the *current* call's signature so the nudge
+  // stops as soon as the model moves on to fresh calls.
+  let loopRepeatCount = 0;
+  if (
+    !longDigNudge &&
+    streak > lastNudged &&
+    LOOP_PRONE_MODEL_PATTERN.test(ctx.model)
+  ) {
+    loopRepeatCount = currentCallRepeatCount(
+      currentUse,
+      run.toolUseIds,
+      usesById,
+    );
+  }
+  const loopNudge = loopRepeatCount >= EXPLORATION_LOOP_REPEAT_THRESHOLD;
+
+  if (!longDigNudge && !loopNudge) return;
 
   // Subagent conversations are exempt — see module doc.
   const { getSubagentManager } = await import("../../../../subagent/index.js");
@@ -146,13 +277,22 @@ const postToolUse: PluginHookFn<PostToolUseContext> = async (ctx) => {
   }
 
   lastNudgedStreakByConversation.set(ctx.conversationId, streak);
+  const nudgeText = loopNudge
+    ? explorationLoopNudgeText(currentUse.name, loopRepeatCount)
+    : EXPLORATION_DRIFT_NUDGE_TEXT;
   ctx.logger.info(
-    { plugin: "exploration-drift", streak, toolName },
+    {
+      plugin: "exploration-drift",
+      streak,
+      toolName: currentUse.name,
+      trigger: loopNudge ? "loop" : "long-dig",
+      ...(loopNudge ? { repeatCount: loopRepeatCount } : {}),
+    },
     "Exploration drift detected — nudging summary + investigator delegation",
   );
   ctx.additionalContext = ctx.additionalContext
-    ? `${ctx.additionalContext}\n${EXPLORATION_DRIFT_NUDGE_TEXT}`
-    : EXPLORATION_DRIFT_NUDGE_TEXT;
+    ? `${ctx.additionalContext}\n${nudgeText}`
+    : nudgeText;
 };
 
 export default postToolUse;

--- a/assistant/src/plugins/defaults/exploration-drift/package.json
+++ b/assistant/src/plugins/defaults/exploration-drift/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "default-exploration-drift",
+  "version": "1.0.0",
+  "description": "First-party default plugin contributing a post-tool-use hook that nudges the model to summarize and delegate to an investigator subagent when a turn accumulates a long run of exploration tool calls.",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "main": "./register.ts",
+  "engines": {
+    "node": ">=20.12.0"
+  },
+  "peerDependencies": {
+    "@vellumai/plugin-api": "^0.8.0"
+  }
+}

--- a/assistant/src/plugins/defaults/exploration-drift/package.json
+++ b/assistant/src/plugins/defaults/exploration-drift/package.json
@@ -1,7 +1,7 @@
 {
   "name": "default-exploration-drift",
   "version": "1.0.0",
-  "description": "First-party default plugin contributing a post-tool-use hook that nudges the model to summarize and delegate to an investigator subagent when a turn accumulates a long run of exploration tool calls.",
+  "description": "First-party default plugin contributing a post-tool-use hook that nudges the model to summarize and delegate to an investigator subagent when a turn accumulates a long run of exploration tool calls, or (on loop-prone models) re-issues an identical exploration call.",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/assistant/src/plugins/defaults/index.ts
+++ b/assistant/src/plugins/defaults/index.ts
@@ -199,11 +199,13 @@ export const defaultToolErrorPlugin: Plugin = {
 };
 
 /**
- * `exploration-drift` — a `post-tool-use` hook that detects a long unbroken
- * run of exploration tool calls (bash, file_read, file_list) with no
- * user-facing text and nudges the model — via `additionalContext` — to
- * summarize progress for the user and delegate the remaining investigation to
- * an `investigator` subagent rather than continuing inline.
+ * `exploration-drift` — a `post-tool-use` hook that detects exploration
+ * drift — a long unbroken run of exploration tool calls (bash, file_read,
+ * file_list) with no user-facing text, or (on loop-prone models such as Kimi
+ * K2.6) the model re-issuing a byte-identical exploration call — and nudges
+ * the model via `additionalContext` to summarize progress for the user and
+ * delegate the remaining investigation to an `investigator` subagent rather
+ * than continuing inline.
  */
 export const defaultExplorationDriftPlugin: Plugin = {
   manifest: {

--- a/assistant/src/plugins/defaults/index.ts
+++ b/assistant/src/plugins/defaults/index.ts
@@ -202,7 +202,7 @@ export const defaultToolErrorPlugin: Plugin = {
  * `exploration-drift` — a `post-tool-use` hook that detects exploration
  * drift — a long unbroken run of exploration tool calls (bash, file_read,
  * file_list) with no user-facing text, or (on loop-prone models such as Kimi
- * K2.6) the model re-issuing a byte-identical exploration call — and nudges
+ * K2.6 and MiniMax M3) the model re-issuing a byte-identical exploration call — and nudges
  * the model via `additionalContext` to summarize progress for the user and
  * delegate the remaining investigation to an `investigator` subagent rather
  * than continuing inline.

--- a/assistant/src/plugins/defaults/index.ts
+++ b/assistant/src/plugins/defaults/index.ts
@@ -31,6 +31,10 @@ import emptyResponsePostModelCall from "./empty-response/hooks/post-model-call.j
 import emptyResponseStop from "./empty-response/hooks/stop.js";
 import { resetEmptyResponseNudgeStoreForTests } from "./empty-response/nudge-state-store.js";
 import emptyResponsePkg from "./empty-response/package.json" with { type: "json" };
+import explorationDriftPostToolUse, {
+  resetExplorationDriftStateForTests,
+} from "./exploration-drift/hooks/post-tool-use.js";
+import explorationDriftPkg from "./exploration-drift/package.json" with { type: "json" };
 import historyRepairPostModelCall from "./history-repair/hooks/post-model-call.js";
 import historyRepairStop from "./history-repair/hooks/stop.js";
 import historyRepairUserPromptSubmit from "./history-repair/hooks/user-prompt-submit.js";
@@ -195,6 +199,23 @@ export const defaultToolErrorPlugin: Plugin = {
 };
 
 /**
+ * `exploration-drift` — a `post-tool-use` hook that detects a long unbroken
+ * run of exploration tool calls (bash, file_read, file_list) with no
+ * user-facing text and nudges the model — via `additionalContext` — to
+ * summarize progress for the user and delegate the remaining investigation to
+ * an `investigator` subagent rather than continuing inline.
+ */
+export const defaultExplorationDriftPlugin: Plugin = {
+  manifest: {
+    name: explorationDriftPkg.name,
+    version: explorationDriftPkg.version,
+  },
+  hooks: {
+    "post-tool-use": explorationDriftPostToolUse,
+  },
+};
+
+/**
  * `tool-result-truncate` — a `post-tool-use` hook that tail-drops an oversized
  * tool result down to a character budget derived from the model's context
  * window before the result is sent to the provider.
@@ -221,6 +242,7 @@ function getAllDefaultPlugins(): readonly Plugin[] {
     defaultToolResultTruncatePlugin,
     defaultEmptyResponsePlugin,
     defaultToolErrorPlugin,
+    defaultExplorationDriftPlugin,
     defaultHistoryRepairPlugin,
     defaultImageRecoveryPlugin,
     defaultCompactionPlugin,
@@ -268,5 +290,6 @@ export function resetPluginRegistryAndRegisterDefaults(): void {
   resetEmptyResponseNudgeStoreForTests();
   resetRepairStateStoreForTests();
   resetImageRecoveryStoreForTests();
+  resetExplorationDriftStateForTests();
   registerDefaultPlugins();
 }


### PR DESCRIPTION
## Context

Supersedes #34302 (closed; head was rewritten so it cannot be reopened). PR 2 of 2 (PR 1: #34297 — `investigator` subagent role). Same field incident: a root-cause request was investigated **inline** — 167 sequential bash calls in a single turn with **zero user-facing text** — until the conversation context overflowed, losing the findings before any writeup. Two follow-up "Continue?" turns burned another 209 calls, largely re-exploring files already read (**11 of 15 files in turn 2 were re-reads**).

The subagent skill's guidance to delegate already exists in the system prompt and SKILL.md, but nothing interrupts a turn once it has drifted into a long inline dig. This PR adds that interrupt — and, on loop-prone models (Kimi K2.6, MiniMax M3), fires it as soon as the model starts looping rather than waiting out a fixed threshold.

## What it does

New default plugin `exploration-drift` with a `post-tool-use` hook (same seam as the existing `tool-error` retry coaching). Two triggers, sharing one trailing-run computation:

1. **Loop trigger (Kimi K2.6 + MiniMax M3 only)** — when the current exploration call (`bash`, `file_read`, `file_list`) is byte-identical (tool name + key-order-independent input signature) to **2 prior calls** within the trailing read-only run, it appends a provider-only `<system_notice>` coaching the model to (1) summarize progress to the user and (2) delegate the remaining investigation to `subagent_spawn` with `role: investigator`. Re-issuing an identical read-only call inside an unbroken read-only run yields no new information — it's the earliest reliable stuck signal, so this can fire as early as call 3 (vs. 25), and **re-fires on every further duplicate** while the model keeps looping. It stops as soon as the model issues a fresh call.
2. **Long-dig trigger (all models)** — an unbroken run of **25** exploration calls with no text sent to the user. Repeat nudges spaced one full threshold apart.

Both are nudges, not hard stops — consistent with the assistant-driven-judgement rule; the model decides whether the run is genuinely an investigation worth delegating.

## Why gate the loop trigger to specific models

The re-exploration looping was observed on Kimi K2.6 in the incident. The one legitimate identical-call pattern (polling an external process's output mid-run) would get a spurious — but advisory and ignorable — nudge, so the aggressive trigger starts where the failure mode is proven. MiniMax M3 is included on the same basis. The model gate is a single regex (`kimi-k2[p.]6|minimax-m3`, matching Fireworks' `p`-for-dot spelling and the OpenRouter ids `moonshotai/kimi-k2.6` / `minimax/minimax-m3`) and is trivial to widen if other models exhibit the same behaviour.

## Design notes

- **`PostToolUseContext` gains a `model` field** (the provider-reported model id of the assistant turn that issued the call), populated by the agent loop from `response.model`. This is the only plugin-api/loop change; it lets hooks vary coaching per model family.
- **Streak derived from history each call** (mirrors `tool-error`), so the signal survives mid-run compaction rewriting the message array. The run is bounded by a real user message, a non-empty assistant text block, or any non-exploration tool result.
- **Loop detection is keyed to the *current* call's signature**, not a max over the run — so a model that absorbed the nudge and moved on to fresh calls is not re-nudged for stale duplicates earlier in the run.
- **Cost-bounded**: input signatures are only computed on the loop-prone-model path, and only for same-named calls within the trailing run.
- **One per-conversation high-water mark** (streak length at last nudge) dedupes parallel results of one batch and spaces repeats: long-dig requires another full threshold of growth; loop requires any growth (each additional duplicate re-nudges).
- **Subagent conversations are exempt** — an investigator is *supposed* to dig long, and subagents can't nest. Checked via `getSubagentManager().getParentInfo()` behind a lazy import so the manager's module graph stays off the per-tool-result hot path.
- **Appends to `additionalContext`** rather than overwriting, so tool-error coaching on the same result isn't lost.
- In the incident, the loop trigger would have fired on the first re-read in turn 2 (~call 3–5) versus the long-dig threshold at call 25.

## Merge order

Merge **after** #34297 — the nudge text references `role: 'investigator'`. If merged first, the failure mode is benign (spawn returns "Invalid subagent role" and the model falls back), but the nudge would coach a role that doesn't exist yet.

## Test plan

- [x] `bun test src/__tests__/exploration-drift-hook.test.ts` (23 pass: both triggers, model gating incl. OpenRouter Kimi + MiniMax M3 ids, key-order-independent signatures, re-fire/move-on semantics, streak bounds, repeat spacing, restart, subagent exemption, append, runHook E2E)
- [x] `bun test src/__tests__/conversation-agent-loop.test.ts src/__tests__/plugin-registry.test.ts` (69 pass — full default-plugin stack)
- [x] `bun test src/__tests__/tool-error-hook.test.ts src/__tests__/tool-result-truncate-hook.test.ts` (updated for the new `model` ctx field)
- [x] `bunx tsc --noEmit` clean, `bun run lint` clean
- [ ] Dogfood on Kimi K2.6: re-run the incident prompt and confirm the loop nudge fires on the first re-read and the model delegates

🤖 Generated with [Claude Code](https://claude.com/claude-code)
