### PR TITLE
feat(cli): derive builder-managed env keys from the Docker StatefulSet spec

### DIFF
--- a/cli/src/__tests__/statefulset.test.ts
+++ b/cli/src/__tests__/statefulset.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildServiceRunArgs,
+  getBuilderManagedEnvKeys,
+  type BuildServiceRunArgsOpts,
+  type ServiceName,
+} from "../lib/statefulset.js";
+import { PROVIDER_ENV_VAR_NAMES } from "../shared/provider-env-vars.js";
+
+const SECRET_KEYS = [
+  "CES_SERVICE_TOKEN",
+  "ACTOR_TOKEN_SIGNING_KEY",
+  "GUARDIAN_BOOTSTRAP_SECRET",
+];
+
+describe("getBuilderManagedEnvKeys", () => {
+  test("gateway always-set keys cover spec static + secret entries and PATH", () => {
+    const { always } = getBuilderManagedEnvKeys("gateway");
+
+    const expected = [
+      "VELLUM_WORKSPACE_DIR",
+      "GATEWAY_SECURITY_DIR",
+      "ASSISTANT_HOST",
+      "CES_CREDENTIAL_URL",
+      "GATEWAY_IPC_SOCKET_DIR",
+      "ASSISTANT_IPC_SOCKET_DIR",
+      "GATEWAY_PORT",
+      "RUNTIME_HTTP_PORT",
+      ...SECRET_KEYS,
+      "PATH",
+    ];
+    for (const key of expected) {
+      expect(always.has(key)).toBe(true);
+    }
+
+    expect(always.has("VELLUM_DISABLE_PLATFORM")).toBe(false);
+    expect(always.has("VELLUM_DEVICE_ID")).toBe(false);
+  });
+
+  test("assistant always-set keys include secrets and builder-computed extras", () => {
+    const { always } = getBuilderManagedEnvKeys("assistant");
+
+    const expected = [
+      ...SECRET_KEYS,
+      "VELLUM_ASSISTANT_NAME",
+      "GATEWAY_INTERNAL_URL",
+      "RUNTIME_HTTP_HOST",
+      "PATH",
+    ];
+    for (const key of expected) {
+      expect(always.has(key)).toBe(true);
+    }
+  });
+
+  test("gateway hostForwarded equals the three spec host entries", () => {
+    const { hostForwarded } = getBuilderManagedEnvKeys("gateway");
+    expect([...hostForwarded].sort()).toEqual(
+      ["VELAY_BASE_URL", "VELLUM_ENVIRONMENT", "VELLUM_PLATFORM_URL"].sort(),
+    );
+  });
+
+  test("assistant hostForwarded includes provider keys and platform URL", () => {
+    const { hostForwarded } = getBuilderManagedEnvKeys("assistant");
+    expect(hostForwarded).toContain("ANTHROPIC_API_KEY");
+    for (const envVar of Object.values(PROVIDER_ENV_VAR_NAMES)) {
+      expect(hostForwarded).toContain(envVar);
+    }
+    expect(hostForwarded).toContain("VELLUM_PLATFORM_URL");
+  });
+
+  test("throws on unknown service name", () => {
+    expect(() => getBuilderManagedEnvKeys("bogus" as ServiceName)).toThrow(
+      'docker-statefulset: unknown service "bogus"',
+    );
+  });
+});
+
+describe("buildServiceRunArgs extra env routing", () => {
+  const opts: BuildServiceRunArgsOpts = {
+    gatewayPort: 18080,
+    imageTags: {
+      assistant: "assistant:test",
+      gateway: "gateway:test",
+      "credential-executor": "ces:test",
+    },
+    instanceName: "test-instance",
+    res: {
+      assistantContainer: "test-assistant",
+      cesContainer: "test-ces",
+      gatewayContainer: "test-gateway",
+      network: "test-net",
+    },
+    extraGatewayEnv: { VELLUM_DISABLE_PLATFORM: "1" },
+    extraAssistantEnv: { FOO: "bar" },
+  };
+
+  const runArgs = buildServiceRunArgs(opts);
+
+  test("extraGatewayEnv lands only in gateway args", () => {
+    const gatewayArgs = runArgs.gateway();
+    expect(gatewayArgs).toContain("VELLUM_DISABLE_PLATFORM=1");
+    expect(gatewayArgs).not.toContain("FOO=bar");
+  });
+
+  test("extraAssistantEnv lands only in assistant args", () => {
+    const assistantArgs = runArgs.assistant();
+    expect(assistantArgs).toContain("FOO=bar");
+    expect(assistantArgs).not.toContain("VELLUM_DISABLE_PLATFORM=1");
+  });
+
+  test("credential-executor args get neither extra env map", () => {
+    const cesArgs = runArgs["credential-executor"]();
+    expect(cesArgs).not.toContain("VELLUM_DISABLE_PLATFORM=1");
+    expect(cesArgs).not.toContain("FOO=bar");
+  });
+});

--- a/cli/src/__tests__/statefulset.test.ts
+++ b/cli/src/__tests__/statefulset.test.ts
@@ -4,6 +4,7 @@ import {
   buildServiceRunArgs,
   getBuilderManagedEnvKeys,
   type BuildServiceRunArgsOpts,
+  type DockerStatefulSetSpec,
   type ServiceName,
 } from "../lib/statefulset.js";
 import { PROVIDER_ENV_VAR_NAMES } from "../shared/provider-env-vars.js";
@@ -55,18 +56,49 @@ describe("getBuilderManagedEnvKeys", () => {
 
   test("gateway hostForwarded equals the three spec host entries", () => {
     const { hostForwarded } = getBuilderManagedEnvKeys("gateway");
-    expect([...hostForwarded].sort()).toEqual(
-      ["VELAY_BASE_URL", "VELLUM_ENVIRONMENT", "VELLUM_PLATFORM_URL"].sort(),
-    );
+    const sorted = [...hostForwarded].sort((a, b) => a.name.localeCompare(b.name));
+    expect(sorted).toEqual([
+      { name: "VELAY_BASE_URL", hostVar: "VELAY_BASE_URL" },
+      { name: "VELLUM_ENVIRONMENT", hostVar: "VELLUM_ENVIRONMENT" },
+      { name: "VELLUM_PLATFORM_URL", hostVar: "VELLUM_PLATFORM_URL" },
+    ]);
   });
 
   test("assistant hostForwarded includes provider keys and platform URL", () => {
     const { hostForwarded } = getBuilderManagedEnvKeys("assistant");
-    expect(hostForwarded).toContain("ANTHROPIC_API_KEY");
+    expect(hostForwarded).toContainEqual({
+      name: "ANTHROPIC_API_KEY",
+      hostVar: "ANTHROPIC_API_KEY",
+    });
     for (const envVar of Object.values(PROVIDER_ENV_VAR_NAMES)) {
-      expect(hostForwarded).toContain(envVar);
+      expect(hostForwarded).toContainEqual({ name: envVar, hostVar: envVar });
     }
-    expect(hostForwarded).toContain("VELLUM_PLATFORM_URL");
+    expect(hostForwarded).toContainEqual({
+      name: "VELLUM_PLATFORM_URL",
+      hostVar: "VELLUM_PLATFORM_URL",
+    });
+  });
+
+  test("hostForwarded keeps container name when hostVar differs", () => {
+    const spec: DockerStatefulSetSpec = {
+      startOrder: ["gateway"],
+      readiness: { endpoint: "/readyz", timeoutMs: 1, intervalMs: 1 },
+      volumeClaimTemplates: [],
+      containers: [
+        {
+          name: "gateway-sidecar",
+          internalName: "gateway",
+          network: "container",
+          env: [{ kind: "host", name: "CONTAINER_NAME", hostVar: "HOST_NAME" }],
+          volumeMounts: [],
+        },
+      ],
+    };
+
+    const { hostForwarded } = getBuilderManagedEnvKeys("gateway", spec);
+    expect(hostForwarded).toEqual([
+      { name: "CONTAINER_NAME", hostVar: "HOST_NAME" },
+    ]);
   });
 
   test("throws on unknown service name", () => {

--- a/cli/src/lib/statefulset.ts
+++ b/cli/src/lib/statefulset.ts
@@ -265,8 +265,13 @@ export interface BuildServiceRunArgsOpts extends DockerRunSecrets {
 export interface BuilderManagedEnvKeys {
   /** Always set by buildServiceRunArgs (spec static/secret entries, builder-computed extras, image-baked PATH). Never replay. */
   always: ReadonlySet<string>;
-  /** Spec host-forwarded entries — buildServiceRunArgs sets them only when present in process.env. Exclude from replay only in that case. */
-  hostForwarded: readonly string[];
+  /**
+   * Spec host-forwarded entries. `name` is the container-side env key (what
+   * docker inspect captures); `hostVar` is the host process.env variable
+   * buildServiceRunArgs reads. Exclude captured `name` from replay only when
+   * process.env[hostVar] is set.
+   */
+  hostForwarded: ReadonlyArray<{ name: string; hostVar: string }>;
 }
 
 /**
@@ -281,10 +286,13 @@ export function getBuilderManagedEnvKeys(
   if (!container) throw new Error(`docker-statefulset: unknown service "${service}"`);
 
   const always = new Set<string>(["PATH"]);
-  const hostForwarded: string[] = [];
+  const hostForwarded: Array<{ name: string; hostVar: string }> = [];
   for (const entry of container.env) {
-    if (entry.kind === "host") hostForwarded.push(entry.hostVar ?? entry.name);
-    else always.add(entry.name);
+    if (entry.kind === "host") {
+      hostForwarded.push({ name: entry.name, hostVar: entry.hostVar ?? entry.name });
+    } else {
+      always.add(entry.name);
+    }
   }
 
   // Builder-computed extras added outside the spec env arrays

--- a/cli/src/lib/statefulset.ts
+++ b/cli/src/lib/statefulset.ts
@@ -262,6 +262,41 @@ export interface BuildServiceRunArgsOpts extends DockerRunSecrets {
   avatarDevicePath?: string;
 }
 
+export interface BuilderManagedEnvKeys {
+  /** Always set by buildServiceRunArgs (spec static/secret entries, builder-computed extras, image-baked PATH). Never replay. */
+  always: ReadonlySet<string>;
+  /** Spec host-forwarded entries — buildServiceRunArgs sets them only when present in process.env. Exclude from replay only in that case. */
+  hostForwarded: readonly string[];
+}
+
+/**
+ * Env var names that `buildServiceRunArgs` manages for a service, derived
+ * from the spec so future entries are picked up automatically.
+ */
+export function getBuilderManagedEnvKeys(
+  service: ServiceName,
+  spec = DOCKER_STATEFUL_SET_SPEC,
+): BuilderManagedEnvKeys {
+  const container = spec.containers.find((c) => c.internalName === service);
+  if (!container) throw new Error(`docker-statefulset: unknown service "${service}"`);
+
+  const always = new Set<string>(["PATH"]);
+  const hostForwarded: string[] = [];
+  for (const entry of container.env) {
+    if (entry.kind === "host") hostForwarded.push(entry.hostVar ?? entry.name);
+    else always.add(entry.name);
+  }
+
+  // Builder-computed extras added outside the spec env arrays
+  if (service === "assistant") {
+    always.add("VELLUM_ASSISTANT_NAME");
+    always.add("GATEWAY_INTERNAL_URL");
+    always.add(AVATAR_DEVICE_ENV_VAR);
+  }
+
+  return { always, hostForwarded };
+}
+
 function resolveVolume(
   spec: DockerStatefulSetSpec,
   instanceName: string,


### PR DESCRIPTION
## Summary
- Export getBuilderManagedEnvKeys(service) from statefulset.ts, deriving always-excluded env keys (spec static+secret entries, builder-computed extras, PATH) and conditionally host-forwarded keys directly from DOCKER_STATEFUL_SET_SPEC
- Spec-derived exclusion prevents deny-list rot: future kind: "secret" entries are auto-excluded from env replay with no code change
- New statefulset.test.ts covering key derivation and extraGatewayEnv/extraAssistantEnv routing in buildServiceRunArgs

Part of plan: persist-gateway-env-docker.md (PR 1 of 5)