### PR TITLE
feat(cli): add getOrCreateHostDeviceId resolving the host device.json

### DIFF
--- a/cli/src/__tests__/device-id.test.ts
+++ b/cli/src/__tests__/device-id.test.ts
@@ -23,15 +23,18 @@ describe("getOrCreateHostDeviceId", () => {
   let tempHome: string;
   let savedXdg: string | undefined;
   let savedEnv: string | undefined;
+  let savedDeviceId: string | undefined;
   let deviceFile: string;
 
   beforeEach(() => {
     savedXdg = process.env.XDG_CONFIG_HOME;
     savedEnv = process.env.VELLUM_ENVIRONMENT;
+    savedDeviceId = process.env.VELLUM_DEVICE_ID;
+    delete process.env.VELLUM_DEVICE_ID;
     tempHome = mkdtempSync(join(tmpdir(), "cli-device-id-test-"));
     process.env.XDG_CONFIG_HOME = tempHome;
     // Non-prod so the resolver targets $XDG_CONFIG_HOME/vellum-dev/
-    // instead of the real ~/.vellum/.
+    // instead of the real ~/.config/vellum/.
     process.env.VELLUM_ENVIRONMENT = "dev";
     deviceFile = join(tempHome, "vellum-dev", "device.json");
     resetHostDeviceIdCache();
@@ -47,6 +50,11 @@ describe("getOrCreateHostDeviceId", () => {
       delete process.env.VELLUM_ENVIRONMENT;
     } else {
       process.env.VELLUM_ENVIRONMENT = savedEnv;
+    }
+    if (savedDeviceId === undefined) {
+      delete process.env.VELLUM_DEVICE_ID;
+    } else {
+      process.env.VELLUM_DEVICE_ID = savedDeviceId;
     }
     rmSync(tempHome, { recursive: true, force: true });
     resetHostDeviceIdCache();
@@ -96,6 +104,13 @@ describe("getOrCreateHostDeviceId", () => {
     const parsed = JSON.parse(readFileSync(deviceFile, "utf-8"));
     expect(parsed.other).toBe("kept");
     expect(parsed.deviceId).toBe(id);
+  });
+
+  test("VELLUM_DEVICE_ID env var wins and skips file access", () => {
+    process.env.VELLUM_DEVICE_ID = "env-device-id";
+
+    expect(getOrCreateHostDeviceId()).toBe("env-device-id");
+    expect(existsSync(deviceFile)).toBe(false);
   });
 
   test("malformed JSON regenerates without throwing", () => {

--- a/cli/src/__tests__/device-id.test.ts
+++ b/cli/src/__tests__/device-id.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import {
+  getOrCreateHostDeviceId,
+  resetHostDeviceIdCache,
+} from "../lib/device-id.js";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+describe("getOrCreateHostDeviceId", () => {
+  let tempHome: string;
+  let savedXdg: string | undefined;
+  let savedEnv: string | undefined;
+  let deviceFile: string;
+
+  beforeEach(() => {
+    savedXdg = process.env.XDG_CONFIG_HOME;
+    savedEnv = process.env.VELLUM_ENVIRONMENT;
+    tempHome = mkdtempSync(join(tmpdir(), "cli-device-id-test-"));
+    process.env.XDG_CONFIG_HOME = tempHome;
+    // Non-prod so the resolver targets $XDG_CONFIG_HOME/vellum-dev/
+    // instead of the real ~/.vellum/.
+    process.env.VELLUM_ENVIRONMENT = "dev";
+    deviceFile = join(tempHome, "vellum-dev", "device.json");
+    resetHostDeviceIdCache();
+  });
+
+  afterEach(() => {
+    if (savedXdg === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = savedXdg;
+    }
+    if (savedEnv === undefined) {
+      delete process.env.VELLUM_ENVIRONMENT;
+    } else {
+      process.env.VELLUM_ENVIRONMENT = savedEnv;
+    }
+    rmSync(tempHome, { recursive: true, force: true });
+    resetHostDeviceIdCache();
+  });
+
+  test("creates device.json with a UUID when missing", () => {
+    const id = getOrCreateHostDeviceId();
+
+    expect(id).toMatch(UUID_RE);
+    expect(existsSync(deviceFile)).toBe(true);
+    const parsed = JSON.parse(readFileSync(deviceFile, "utf-8"));
+    expect(parsed.deviceId).toBe(id);
+    expect(readFileSync(deviceFile, "utf-8").endsWith("\n")).toBe(true);
+  });
+
+  test("returns the existing deviceId without rewriting the file", () => {
+    mkdirSync(join(tempHome, "vellum-dev"), { recursive: true });
+    writeFileSync(deviceFile, JSON.stringify({ deviceId: "existing-id" }));
+    const before = statSync(deviceFile).mtimeMs;
+
+    expect(getOrCreateHostDeviceId()).toBe("existing-id");
+    expect(statSync(deviceFile).mtimeMs).toBe(before);
+    expect(readFileSync(deviceFile, "utf-8")).toBe(
+      JSON.stringify({ deviceId: "existing-id" }),
+    );
+  });
+
+  test("caches the resolved id until reset", () => {
+    const first = getOrCreateHostDeviceId();
+    rmSync(deviceFile);
+
+    expect(getOrCreateHostDeviceId()).toBe(first);
+
+    resetHostDeviceIdCache();
+    const second = getOrCreateHostDeviceId();
+    expect(second).toMatch(UUID_RE);
+    expect(second).not.toBe(first);
+  });
+
+  test("preserves unrelated fields when adding deviceId", () => {
+    mkdirSync(join(tempHome, "vellum-dev"), { recursive: true });
+    writeFileSync(deviceFile, JSON.stringify({ other: "kept", deviceId: "" }));
+
+    const id = getOrCreateHostDeviceId();
+
+    expect(id).toMatch(UUID_RE);
+    const parsed = JSON.parse(readFileSync(deviceFile, "utf-8"));
+    expect(parsed.other).toBe("kept");
+    expect(parsed.deviceId).toBe(id);
+  });
+
+  test("malformed JSON regenerates without throwing", () => {
+    mkdirSync(join(tempHome, "vellum-dev"), { recursive: true });
+    writeFileSync(deviceFile, "{not json");
+
+    const id = getOrCreateHostDeviceId();
+
+    expect(id).toMatch(UUID_RE);
+    const parsed = JSON.parse(readFileSync(deviceFile, "utf-8"));
+    expect(parsed).toEqual({ deviceId: id });
+  });
+});

--- a/cli/src/lib/device-id.ts
+++ b/cli/src/lib/device-id.ts
@@ -1,0 +1,82 @@
+/**
+ * Host device ID resolver.
+ *
+ * Mirrors the non-containerized branches of
+ * `assistant/src/util/device-id.ts` so the CLI resolves the same
+ * `device.json` as the assistant, host-mode gateway, and Swift client
+ * (`VellumPaths.deviceIdFile`):
+ *   - Production: `~/.vellum/device.json` (legacy path — intentionally NOT
+ *     the CLI's `getConfigDir()` location of `~/.config/vellum/`).
+ *   - Non-production: `$XDG_CONFIG_HOME/vellum-<env>/device.json`.
+ *
+ * Not to be confused with `guardian-token.ts:computeDeviceId` /
+ * `getOrCreatePersistedDeviceId` — those produce the salted-hash Guardian
+ * identity, a different concept. Do not merge the two.
+ */
+
+import { randomUUID } from "crypto";
+import { mkdirSync, readFileSync, writeFileSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+
+import { getConfigDir } from "./environments/paths.js";
+import { getCurrentEnvironment } from "./environments/resolve.js";
+
+let cached: string | undefined;
+
+function resolveDeviceIdPaths(): { dir: string; file: string } {
+  const env = getCurrentEnvironment();
+  const dir =
+    env.name === "production"
+      ? join(homedir(), ".vellum")
+      : getConfigDir(env);
+  return { dir, file: join(dir, "device.json") };
+}
+
+/**
+ * Get the stable device ID for this host machine, creating and persisting
+ * one in `device.json` if absent. Never throws: on write failure the
+ * generated UUID is still cached and returned for the process lifetime.
+ */
+export function getOrCreateHostDeviceId(): string {
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const { dir, file } = resolveDeviceIdPaths();
+
+  // Preserve unrelated fields from any existing JSON object.
+  let existing: Record<string, unknown> = {};
+  try {
+    const raw: unknown = JSON.parse(readFileSync(file, "utf-8"));
+    if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+      existing = raw as Record<string, unknown>;
+    }
+  } catch {
+    // Missing, unreadable, or malformed — start fresh.
+  }
+
+  if (typeof existing.deviceId === "string" && existing.deviceId.length > 0) {
+    cached = existing.deviceId;
+    return cached;
+  }
+
+  const generated = randomUUID();
+  try {
+    mkdirSync(dir, { recursive: true });
+    existing.deviceId = generated;
+    writeFileSync(file, JSON.stringify(existing, null, 2) + "\n", {
+      mode: 0o644,
+    });
+  } catch {
+    // Write failure — use the generated ID in-memory only.
+  }
+
+  cached = generated;
+  return cached;
+}
+
+/** Reset the cached device ID. Used by tests to force re-resolution. */
+export function resetHostDeviceIdCache(): void {
+  cached = undefined;
+}

--- a/cli/src/lib/device-id.ts
+++ b/cli/src/lib/device-id.ts
@@ -1,13 +1,19 @@
 /**
  * Host device ID resolver.
  *
- * Mirrors the non-containerized branches of
- * `assistant/src/util/device-id.ts` so the CLI resolves the same
- * `device.json` as the assistant, host-mode gateway, and Swift client
- * (`VellumPaths.deviceIdFile`):
- *   - Production: `~/.vellum/device.json` (legacy path — intentionally NOT
- *     the CLI's `getConfigDir()` location of `~/.config/vellum/`).
- *   - Non-production: `$XDG_CONFIG_HOME/vellum-<env>/device.json`.
+ * Resolution order (mirrors `gateway/src/device-id.ts`):
+ *   1. `VELLUM_DEVICE_ID` env var, if set — lets the desktop app hand the
+ *      canonical device id down to the CLI.
+ *   2. `device.json` in the CLI-owned config dir (`getConfigDir()`):
+ *      production → `~/.config/vellum/device.json`, non-production →
+ *      `$XDG_CONFIG_HOME/vellum-<env>/device.json`. Per cli/AGENTS.md, the
+ *      CLI must never touch `~/.vellum/` — that is assistant/gateway-owned
+ *      state.
+ *
+ * Accepted tradeoff: this intentionally does NOT read the legacy
+ * `~/.vellum/device.json`, so a containerized gateway's device id may differ
+ * from a host-mode gateway's on the same machine. Stability matters for LD
+ * feature-flag contexts, not parity with the legacy file.
  *
  * Not to be confused with `guardian-token.ts:computeDeviceId` /
  * `getOrCreatePersistedDeviceId` — those produce the salted-hash Guardian
@@ -16,7 +22,6 @@
 
 import { randomUUID } from "crypto";
 import { mkdirSync, readFileSync, writeFileSync } from "fs";
-import { homedir } from "os";
 import { join } from "path";
 
 import { getConfigDir } from "./environments/paths.js";
@@ -25,21 +30,24 @@ import { getCurrentEnvironment } from "./environments/resolve.js";
 let cached: string | undefined;
 
 function resolveDeviceIdPaths(): { dir: string; file: string } {
-  const env = getCurrentEnvironment();
-  const dir =
-    env.name === "production"
-      ? join(homedir(), ".vellum")
-      : getConfigDir(env);
+  const dir = getConfigDir(getCurrentEnvironment());
   return { dir, file: join(dir, "device.json") };
 }
 
 /**
  * Get the stable device ID for this host machine, creating and persisting
- * one in `device.json` if absent. Never throws: on write failure the
- * generated UUID is still cached and returned for the process lifetime.
+ * one in `device.json` if absent. `VELLUM_DEVICE_ID` takes precedence over
+ * any file. Never throws: on write failure the generated UUID is still
+ * cached and returned for the process lifetime.
  */
 export function getOrCreateHostDeviceId(): string {
   if (cached !== undefined) {
+    return cached;
+  }
+
+  const fromEnv = process.env.VELLUM_DEVICE_ID?.trim();
+  if (fromEnv) {
+    cached = fromEnv;
     return cached;
   }
 


### PR DESCRIPTION
## Summary
- New cli/src/lib/device-id.ts with getOrCreateHostDeviceId(): resolves `VELLUM_DEVICE_ID` env var first (lets the desktop app pass the canonical id down), then production → the machine-wide shared `~/.vellum/device.json` (same file as the Electron main process, Swift clients, and host-mode assistant), non-prod → `$XDG_CONFIG_HOME/vellum-<env>/device.json`
- Reads existing deviceId, else generates a UUID and persists it preserving unrelated fields; never throws
- Deliberately separate from guardian-token.ts computeDeviceId (salted-hash Guardian identity — different concept)

**Design history:** this PR originally used `~/.vellum` for prod, was amended to a CLI-owned config dir after a review flagged cli/AGENTS.md's `.vellum/` boundary, then re-amended back to the shared path on the feature branch (commit f0097bb7) once it was established that Electron/Swift/host-assistant all share `~/.vellum/device.json` in production — divergence would have fragmented device identity on desktop machines. cli/AGENTS.md now carries an explicit device.json carve-out.

Part of plan: persist-gateway-env-docker.md (PR 4 of 5)
