### PR TITLE
fix(cli): pass VELLUM_DEVICE_ID to the Docker gateway sidecar at hatch (LUM-2312)

### DIFF
--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -22,6 +22,7 @@ import type { AssistantEntry } from "./assistant-config";
 import { buildHatchConfigValues, writeInitialConfig } from "./config-utils";
 import { buildServiceRunArgs } from "./statefulset.js";
 import type { Species } from "./constants";
+import { getOrCreateHostDeviceId } from "./device-id.js";
 import { getDefaultPorts } from "./environments/paths.js";
 import { getCurrentEnvironment } from "./environments/resolve.js";
 import { leaseGuardianToken } from "./guardian-token";
@@ -1327,8 +1328,10 @@ export async function hatchDocker(
       extraAssistantEnv.VELLUM_DISABLE_PLATFORM =
         flagEnvVars.VELLUM_DISABLE_PLATFORM;
     }
-    const extraGatewayEnv =
-      Object.keys(flagEnvVars).length > 0 ? flagEnvVars : undefined;
+    const extraGatewayEnv = {
+      ...flagEnvVars,
+      VELLUM_DEVICE_ID: getOrCreateHostDeviceId(),
+    };
     await startContainers(
       {
         signingKey,


### PR DESCRIPTION
## Summary
- hatchDocker now injects VELLUM_DEVICE_ID (from the CLI-owned device.json resolver, env-var precedence) into extraGatewayEnv alongside feature-flag overrides
- Containerized gateways can now send the Vellum-Device-Id header on LD feature-flag requests (gateway already prefers the env var — no gateway changes)
- Device identity is host-stable; once the gateway env replay PR lands, it survives upgrade/rollback automatically

Part of plan: persist-gateway-env-docker.md (PR 5 of 5)