### PR TITLE
fix(cli): persist gateway env (VELLUM_DISABLE_PLATFORM et al.) across Docker upgrade/rollback (LUM-2312)

### DIFF
--- a/cli/src/commands/rollback.ts
+++ b/cli/src/commands/rollback.ts
@@ -25,11 +25,11 @@ import {
   broadcastUpgradeEvent,
   buildCompleteEvent,
   buildProgressEvent,
+  buildReplayEnv,
   buildStartingEvent,
   buildUpgradeCommitMessage,
   captureContainerEnv,
   commitWorkspaceViaGateway,
-  CONTAINER_ENV_EXCLUDE_KEYS,
   fetchCurrentVersion,
   fetchPreviousVersion,
   performDockerRollback,
@@ -315,10 +315,11 @@ export async function rollback(): Promise<void> {
       `   Captured ${Object.keys(capturedEnv).length} env var(s) from ${res.assistantContainer}\n`,
     );
 
-    // Capture GUARDIAN_BOOTSTRAP_SECRET from the gateway container (it is only
-    // set on gateway, not assistant) so it persists across container restarts.
+    // Capture the gateway container env so flag overrides replay onto the new
+    // gateway, and pluck GUARDIAN_BOOTSTRAP_SECRET (only set on gateway).
     const gatewayEnv = await captureContainerEnv(res.gatewayContainer);
     const bootstrapSecret = gatewayEnv["GUARDIAN_BOOTSTRAP_SECRET"];
+    const extraGatewayEnv = buildReplayEnv(gatewayEnv, "gateway");
 
     // Extract CES_SERVICE_TOKEN from captured env, or generate fresh one
     const cesServiceToken =
@@ -328,19 +329,7 @@ export async function rollback(): Promise<void> {
     const signingKey =
       capturedEnv["ACTOR_TOKEN_SIGNING_KEY"] || randomBytes(32).toString("hex");
 
-    // Build extra env vars, excluding keys managed by buildServiceRunArgs
-    const envKeysSetByRunArgs = new Set(CONTAINER_ENV_EXCLUDE_KEYS);
-    for (const envVar of ["ANTHROPIC_API_KEY", "VELLUM_PLATFORM_URL"]) {
-      if (process.env[envVar]) {
-        envKeysSetByRunArgs.add(envVar);
-      }
-    }
-    const extraAssistantEnv: Record<string, string> = {};
-    for (const [key, value] of Object.entries(capturedEnv)) {
-      if (!envKeysSetByRunArgs.has(key)) {
-        extraAssistantEnv[key] = value;
-      }
-    }
+    const extraAssistantEnv = buildReplayEnv(capturedEnv, "assistant");
 
     // Parse gateway port from entry's runtimeUrl, fall back to default
     let gatewayPort = GATEWAY_INTERNAL_PORT;
@@ -401,6 +390,7 @@ export async function rollback(): Promise<void> {
         bootstrapSecret,
         cesServiceToken,
         extraAssistantEnv,
+        extraGatewayEnv,
         gatewayPort,
         imageTags: previousImageRefs,
         instanceName,

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -38,12 +38,12 @@ import {
   broadcastUpgradeEvent,
   buildCompleteEvent,
   buildProgressEvent,
+  buildReplayEnv,
   buildStartingEvent,
   buildUpgradeCommitMessage,
   captureContainerEnv,
   captureUpgradeFailureLogs,
   commitWorkspaceViaGateway,
-  CONTAINER_ENV_EXCLUDE_KEYS,
   rollbackMigrations,
   UPGRADE_PROGRESS,
   waitForReady,
@@ -303,10 +303,11 @@ async function upgradeDocker(
     `   Captured ${Object.keys(capturedEnv).length} env var(s) from ${res.assistantContainer}\n`,
   );
 
-  // Capture GUARDIAN_BOOTSTRAP_SECRET from the gateway container (it is only
-  // set on gateway, not assistant) so it persists across container restarts.
+  // Capture the gateway container env so flag overrides replay onto the new
+  // gateway, and pluck GUARDIAN_BOOTSTRAP_SECRET (only set on gateway).
   const gatewayEnv = await captureContainerEnv(res.gatewayContainer);
   const bootstrapSecret = gatewayEnv["GUARDIAN_BOOTSTRAP_SECRET"];
+  const extraGatewayEnv = buildReplayEnv(gatewayEnv, "gateway");
 
   // Notify connected clients that an upgrade is about to begin.
   // This must fire BEFORE any progress broadcasts so the UI sets
@@ -415,22 +416,7 @@ async function upgradeDocker(
   await stopContainers(res);
   console.log("✅ Containers stopped\n");
 
-  // Build the set of extra env vars to replay on the new assistant container.
-  // Captured env vars serve as the base; keys already managed by
-  // buildServiceRunArgs are excluded to avoid duplicates.
-  const envKeysSetByRunArgs = new Set(CONTAINER_ENV_EXCLUDE_KEYS);
-  // Only exclude keys that buildServiceRunArgs will actually set
-  for (const envVar of ["ANTHROPIC_API_KEY", "VELLUM_PLATFORM_URL"]) {
-    if (process.env[envVar]) {
-      envKeysSetByRunArgs.add(envVar);
-    }
-  }
-  const extraAssistantEnv: Record<string, string> = {};
-  for (const [key, value] of Object.entries(capturedEnv)) {
-    if (!envKeysSetByRunArgs.has(key)) {
-      extraAssistantEnv[key] = value;
-    }
-  }
+  const extraAssistantEnv = buildReplayEnv(capturedEnv, "assistant");
 
   console.log("🚀 Starting upgraded containers...");
   await startContainers(
@@ -439,6 +425,7 @@ async function upgradeDocker(
       bootstrapSecret,
       cesServiceToken,
       extraAssistantEnv,
+      extraGatewayEnv,
       gatewayPort,
       imageTags,
       instanceName,
@@ -544,6 +531,7 @@ async function upgradeDocker(
             bootstrapSecret,
             cesServiceToken,
             extraAssistantEnv,
+            extraGatewayEnv,
             gatewayPort,
             imageTags: previousImageRefs,
             instanceName,

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -883,6 +883,8 @@ function startFileWatcher(opts: {
   signingKey?: string;
   bootstrapSecret?: string;
   cesServiceToken?: string;
+  extraAssistantEnv?: Record<string, string>;
+  extraGatewayEnv?: Record<string, string>;
   gatewayPort: number;
   imageTags: Record<ServiceName, string>;
   instanceName: string;
@@ -902,6 +904,8 @@ function startFileWatcher(opts: {
     signingKey: opts.signingKey,
     bootstrapSecret: opts.bootstrapSecret,
     cesServiceToken: opts.cesServiceToken,
+    extraAssistantEnv: opts.extraAssistantEnv,
+    extraGatewayEnv: opts.extraGatewayEnv,
     gatewayPort,
     imageTags,
     instanceName,
@@ -1433,6 +1437,8 @@ export async function hatchDocker(
         signingKey,
         bootstrapSecret,
         cesServiceToken,
+        extraAssistantEnv,
+        extraGatewayEnv,
         gatewayPort,
         imageTags,
         instanceName,

--- a/cli/src/lib/upgrade-lifecycle.ts
+++ b/cli/src/lib/upgrade-lifecycle.ts
@@ -147,20 +147,6 @@ export function buildUpgradeCommitMessage(options: {
 }
 
 /**
- * Environment variable keys that are set by CLI run arguments and should
- * not be replayed from a captured container environment during upgrades
- * or rollbacks. Shared between upgrade.ts and rollback.ts.
- */
-export const CONTAINER_ENV_EXCLUDE_KEYS: ReadonlySet<string> = new Set([
-  "CES_SERVICE_TOKEN",
-  "GUARDIAN_BOOTSTRAP_SECRET",
-  "VELLUM_ASSISTANT_NAME",
-  "RUNTIME_HTTP_HOST",
-  "PATH",
-  "ACTOR_TOKEN_SIGNING_KEY",
-]);
-
-/**
  * Capture environment variables from a running Docker container so they
  * can be replayed onto the replacement container after upgrade.
  */
@@ -623,10 +609,11 @@ export async function performDockerRollback(
     `   Captured ${Object.keys(capturedEnv).length} env var(s) from ${res.assistantContainer}\n`,
   );
 
-  // Capture GUARDIAN_BOOTSTRAP_SECRET from the gateway container (it is only
-  // set on gateway, not assistant) so it persists across container restarts.
+  // Capture the gateway container env so flag overrides replay onto the new
+  // gateway, and pluck GUARDIAN_BOOTSTRAP_SECRET (only set on gateway).
   const gatewayEnv = await captureContainerEnv(res.gatewayContainer);
   const bootstrapSecret = gatewayEnv["GUARDIAN_BOOTSTRAP_SECRET"];
+  const extraGatewayEnv = buildReplayEnv(gatewayEnv, "gateway");
 
   const cesServiceToken =
     capturedEnv["CES_SERVICE_TOKEN"] || randomBytes(32).toString("hex");
@@ -634,19 +621,7 @@ export async function performDockerRollback(
   const signingKey =
     capturedEnv["ACTOR_TOKEN_SIGNING_KEY"] || randomBytes(32).toString("hex");
 
-  // Build extra env vars, excluding keys managed by buildServiceRunArgs
-  const envKeysSetByRunArgs = new Set(CONTAINER_ENV_EXCLUDE_KEYS);
-  for (const envVar of ["ANTHROPIC_API_KEY", "VELLUM_PLATFORM_URL"]) {
-    if (process.env[envVar]) {
-      envKeysSetByRunArgs.add(envVar);
-    }
-  }
-  const extraAssistantEnv: Record<string, string> = {};
-  for (const [key, value] of Object.entries(capturedEnv)) {
-    if (!envKeysSetByRunArgs.has(key)) {
-      extraAssistantEnv[key] = value;
-    }
-  }
+  const extraAssistantEnv = buildReplayEnv(capturedEnv, "assistant");
 
   // Parse gateway port from entry's runtimeUrl
   let gatewayPort = GATEWAY_INTERNAL_PORT;
@@ -719,6 +694,7 @@ export async function performDockerRollback(
       bootstrapSecret,
       cesServiceToken,
       extraAssistantEnv,
+      extraGatewayEnv,
       gatewayPort,
       imageTags: targetImageTags,
       instanceName,
@@ -836,6 +812,7 @@ export async function performDockerRollback(
             bootstrapSecret,
             cesServiceToken,
             extraAssistantEnv,
+            extraGatewayEnv,
             gatewayPort,
             imageTags: currentImageRefs,
             instanceName,


### PR DESCRIPTION
## Summary
- Replay captured gateway container env (VELLUM_DISABLE_PLATFORM, VELLUM_DEVICE_ID, and any other flag overrides) through buildReplayEnv at all five startContainers restart sites (upgrade x2, rollback, upgrade-lifecycle x2)
- Migrate assistant env filtering to the same spec-derived helper, retiring CONTAINER_ENV_EXCLUDE_KEYS and the ad-hoc host-var special-casing
- Thread extraAssistantEnv/extraGatewayEnv through the --watch file-watcher rebuild path (sixth call site; pre-existing env loss found in review of #34317)
- Bonus fix: stale captured values can no longer pin old spec statics across image upgrades (replay -e flags come after spec -e flags; spec keys are now excluded from replay)

Part of plan: persist-gateway-env-docker.md (PR 3 of 5, final)