### PR TITLE
feat(web): expose organizationId on ResolvedAssistant from the lockfile

### DIFF
--- a/apps/web/src/stores/resolved-assistants-store.test.ts
+++ b/apps/web/src/stores/resolved-assistants-store.test.ts
@@ -50,3 +50,27 @@ describe("setFromLockfile", () => {
     expect(entry.organizationId).toBeUndefined();
   });
 });
+
+describe("upsertFromApi", () => {
+  it("preserves a lockfile-seeded organizationId on refresh (API has no org)", () => {
+    useResolvedAssistantsStore.getState().setFromLockfile({
+      assistants: [platformAssistant],
+      activeAssistant: null,
+    });
+
+    // A lifecycle refresh upserts the API-shaped payload, which carries no org.
+    useResolvedAssistantsStore.getState().upsertFromApi({
+      id: "asst-platform",
+      name: "Platform (refreshed)",
+      created: "2026-01-01T00:00:00Z",
+      is_local: false,
+    } as Parameters<
+      ReturnType<typeof useResolvedAssistantsStore.getState>["upsertFromApi"]
+    >[0]);
+
+    const entry = useResolvedAssistantsStore.getState().assistants[0];
+    expect(entry.id).toBe("asst-platform");
+    expect(entry.name).toBe("Platform (refreshed)");
+    expect(entry.organizationId).toBe("org-1");
+  });
+});

--- a/apps/web/src/stores/resolved-assistants-store.test.ts
+++ b/apps/web/src/stores/resolved-assistants-store.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import type { Lockfile, LockfileAssistant } from "@/runtime/local-mode-host";
+
+// A platform entry is identified by `cloud === "vellum"` and carries an
+// `organizationId`; a local entry has a non-vellum cloud + gateway port and no org.
+const platformAssistant: LockfileAssistant = {
+  assistantId: "asst-platform",
+  name: "Platform",
+  cloud: "vellum",
+  organizationId: "org-1",
+};
+
+const localAssistant: LockfileAssistant = {
+  assistantId: "asst-local",
+  name: "Local",
+  cloud: "local",
+  resources: { gatewayPort: 7830, daemonPort: 7831 },
+};
+
+beforeEach(() => {
+  useResolvedAssistantsStore.setState({ assistants: [] });
+});
+
+describe("setFromLockfile", () => {
+  it("copies organizationId for platform entries", () => {
+    const lockfile: Lockfile = {
+      assistants: [platformAssistant],
+      activeAssistant: null,
+    };
+    useResolvedAssistantsStore.getState().setFromLockfile(lockfile);
+
+    const entry = useResolvedAssistantsStore.getState().assistants[0];
+    expect(entry.id).toBe("asst-platform");
+    expect(entry.isPlatformHosted).toBe(true);
+    expect(entry.organizationId).toBe("org-1");
+  });
+
+  it("leaves organizationId undefined for local entries", () => {
+    const lockfile: Lockfile = {
+      assistants: [localAssistant],
+      activeAssistant: null,
+    };
+    useResolvedAssistantsStore.getState().setFromLockfile(lockfile);
+
+    const entry = useResolvedAssistantsStore.getState().assistants[0];
+    expect(entry.id).toBe("asst-local");
+    expect(entry.isLocal).toBe(true);
+    expect(entry.organizationId).toBeUndefined();
+  });
+});

--- a/apps/web/src/stores/resolved-assistants-store.ts
+++ b/apps/web/src/stores/resolved-assistants-store.ts
@@ -35,6 +35,9 @@ export interface ResolvedAssistant {
   hatchedAt?: string;
   isLocal: boolean;
   isPlatformHosted: boolean;
+  /** Owning org for platform entries; only the lockfile carries it, so
+   *  API-sourced entries leave this undefined. */
+  organizationId?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -126,9 +129,13 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
           hatchedAt: a.hatchedAt,
           isLocal: isLocalAssistant(a),
           isPlatformHosted: isPlatformAssistant(a),
+          organizationId: a.organizationId,
         })),
       }),
 
+    // The platform `Assistant` API carries no org field, so API-sourced
+    // entries intentionally leave `organizationId` undefined (unlike
+    // `setFromLockfile`). Don't "fix" this by inventing an org here.
     setFromApi: (assistants) =>
       set({
         assistants: assistants.map((a) => ({

--- a/apps/web/src/stores/resolved-assistants-store.ts
+++ b/apps/web/src/stores/resolved-assistants-store.ts
@@ -159,7 +159,9 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
         const idx = state.assistants.findIndex((a) => a.id === assistant.id);
         if (idx >= 0) {
           const next = [...state.assistants];
-          next[idx] = entry;
+          // The API payload has no org field; preserve the org the lockfile
+          // seeded so a lifecycle refresh doesn't erase it.
+          next[idx] = { ...entry, organizationId: next[idx]!.organizationId };
           return { assistants: next };
         }
         return { assistants: [...state.assistants, entry] };


### PR DESCRIPTION
## Summary
- Add optional organizationId to ResolvedAssistant, populated from the lockfile in setFromLockfile
- API-sourced entries stay undefined (the Assistant API exposes no org field)

Part of plan: assistant-selection-unify.md (PR 2 of 8)