### PR TITLE
fix: backfill VELLUM_DEVICE_ID on gateway replay + consolidate capture/replay state

### DIFF
--- a/cli/src/__tests__/device-id.test.ts
+++ b/cli/src/__tests__/device-id.test.ts
@@ -19,17 +19,21 @@ import {
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 
+const SAVED_ENV_VARS = [
+  "XDG_CONFIG_HOME",
+  "VELLUM_ENVIRONMENT",
+  "VELLUM_DEVICE_ID",
+] as const;
+const savedEnv: Record<string, string | undefined> = {};
+for (const key of SAVED_ENV_VARS) {
+  savedEnv[key] = process.env[key];
+}
+
 describe("getOrCreateHostDeviceId", () => {
   let tempHome: string;
-  let savedXdg: string | undefined;
-  let savedEnv: string | undefined;
-  let savedDeviceId: string | undefined;
   let deviceFile: string;
 
   beforeEach(() => {
-    savedXdg = process.env.XDG_CONFIG_HOME;
-    savedEnv = process.env.VELLUM_ENVIRONMENT;
-    savedDeviceId = process.env.VELLUM_DEVICE_ID;
     delete process.env.VELLUM_DEVICE_ID;
     tempHome = mkdtempSync(join(tmpdir(), "cli-device-id-test-"));
     process.env.XDG_CONFIG_HOME = tempHome;
@@ -41,20 +45,12 @@ describe("getOrCreateHostDeviceId", () => {
   });
 
   afterEach(() => {
-    if (savedXdg === undefined) {
-      delete process.env.XDG_CONFIG_HOME;
-    } else {
-      process.env.XDG_CONFIG_HOME = savedXdg;
-    }
-    if (savedEnv === undefined) {
-      delete process.env.VELLUM_ENVIRONMENT;
-    } else {
-      process.env.VELLUM_ENVIRONMENT = savedEnv;
-    }
-    if (savedDeviceId === undefined) {
-      delete process.env.VELLUM_DEVICE_ID;
-    } else {
-      process.env.VELLUM_DEVICE_ID = savedDeviceId;
+    for (const key of SAVED_ENV_VARS) {
+      if (savedEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = savedEnv[key];
+      }
     }
     rmSync(tempHome, { recursive: true, force: true });
     resetHostDeviceIdCache();

--- a/cli/src/__tests__/upgrade-replay-env.test.ts
+++ b/cli/src/__tests__/upgrade-replay-env.test.ts
@@ -1,9 +1,14 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
+import { resetHostDeviceIdCache } from "../lib/device-id.js";
 import type { DockerStatefulSetSpec } from "../lib/statefulset.js";
-import { buildReplayEnv } from "../lib/upgrade-lifecycle.js";
+import { buildReplayEnv, buildReplayState } from "../lib/upgrade-lifecycle.js";
 
-const SAVED_ENV_VARS = ["VELLUM_PLATFORM_URL", "ANTHROPIC_API_KEY"] as const;
+const SAVED_ENV_VARS = [
+  "VELLUM_PLATFORM_URL",
+  "ANTHROPIC_API_KEY",
+  "VELLUM_DEVICE_ID",
+] as const;
 const savedEnv: Record<string, string | undefined> = {};
 for (const key of SAVED_ENV_VARS) {
   savedEnv[key] = process.env[key];
@@ -17,6 +22,7 @@ afterEach(() => {
       process.env[key] = savedEnv[key];
     }
   }
+  resetHostDeviceIdCache();
 });
 
 describe("buildReplayEnv", () => {
@@ -109,5 +115,44 @@ describe("buildReplayEnv", () => {
       spec,
     );
     expect(replay).toEqual({ VELLUM_DEVICE_ID: "abc" });
+  });
+});
+
+describe("buildReplayState", () => {
+  beforeEach(() => {
+    // VELLUM_DEVICE_ID env precedence keeps getOrCreateHostDeviceId off the
+    // filesystem in tests.
+    process.env.VELLUM_DEVICE_ID = "host-device-id";
+    resetHostDeviceIdCache();
+  });
+
+  test("backfills VELLUM_DEVICE_ID on gateway replay env when absent", () => {
+    const state = buildReplayState({}, { VELLUM_DISABLE_PLATFORM: "1" });
+    expect(state.extraGatewayEnv).toEqual({
+      VELLUM_DISABLE_PLATFORM: "1",
+      VELLUM_DEVICE_ID: "host-device-id",
+    });
+  });
+
+  test("captured VELLUM_DEVICE_ID wins over host-derived id", () => {
+    const state = buildReplayState({}, { VELLUM_DEVICE_ID: "existing" });
+    expect(state.extraGatewayEnv.VELLUM_DEVICE_ID).toBe("existing");
+  });
+
+  test("plucks secrets from the captured envs", () => {
+    const state = buildReplayState(
+      { CES_SERVICE_TOKEN: "ces-token", ACTOR_TOKEN_SIGNING_KEY: "sign-key" },
+      { GUARDIAN_BOOTSTRAP_SECRET: "bootstrap" },
+    );
+    expect(state.bootstrapSecret).toBe("bootstrap");
+    expect(state.cesServiceToken).toBe("ces-token");
+    expect(state.signingKey).toBe("sign-key");
+  });
+
+  test("generates fresh secrets when missing from captured env", () => {
+    const state = buildReplayState({}, {});
+    expect(state.bootstrapSecret).toBeUndefined();
+    expect(state.cesServiceToken).toMatch(/^[0-9a-f]{64}$/);
+    expect(state.signingKey).toMatch(/^[0-9a-f]{64}$/);
   });
 });

--- a/cli/src/commands/rollback.ts
+++ b/cli/src/commands/rollback.ts
@@ -1,5 +1,3 @@
-import { randomBytes } from "crypto";
-
 import {
   findAssistantByName,
   getActiveAssistant,
@@ -25,10 +23,9 @@ import {
   broadcastUpgradeEvent,
   buildCompleteEvent,
   buildProgressEvent,
-  buildReplayEnv,
   buildStartingEvent,
   buildUpgradeCommitMessage,
-  captureContainerEnv,
+  captureReplayState,
   commitWorkspaceViaGateway,
   fetchCurrentVersion,
   fetchPreviousVersion,
@@ -308,28 +305,13 @@ export async function rollback(): Promise<void> {
       `🔄 Rolling back Docker assistant '${instanceName}' to ${previousVersion}...\n`,
     );
 
-    // Capture current container env
-    console.log("💾 Capturing existing container environment...");
-    const capturedEnv = await captureContainerEnv(res.assistantContainer);
-    console.log(
-      `   Captured ${Object.keys(capturedEnv).length} env var(s) from ${res.assistantContainer}\n`,
-    );
-
-    // Capture the gateway container env so flag overrides replay onto the new
-    // gateway, and pluck GUARDIAN_BOOTSTRAP_SECRET (only set on gateway).
-    const gatewayEnv = await captureContainerEnv(res.gatewayContainer);
-    const bootstrapSecret = gatewayEnv["GUARDIAN_BOOTSTRAP_SECRET"];
-    const extraGatewayEnv = buildReplayEnv(gatewayEnv, "gateway");
-
-    // Extract CES_SERVICE_TOKEN from captured env, or generate fresh one
-    const cesServiceToken =
-      capturedEnv["CES_SERVICE_TOKEN"] || randomBytes(32).toString("hex");
-
-    // Extract or generate the shared JWT signing key.
-    const signingKey =
-      capturedEnv["ACTOR_TOKEN_SIGNING_KEY"] || randomBytes(32).toString("hex");
-
-    const extraAssistantEnv = buildReplayEnv(capturedEnv, "assistant");
+    const {
+      bootstrapSecret,
+      cesServiceToken,
+      signingKey,
+      extraAssistantEnv,
+      extraGatewayEnv,
+    } = await captureReplayState(res);
 
     // Parse gateway port from entry's runtimeUrl, fall back to default
     let gatewayPort = GATEWAY_INTERNAL_PORT;

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -1,4 +1,3 @@
-import { randomBytes } from "crypto";
 import { spawnSync } from "child_process";
 
 import cliPkg from "../../package.json";
@@ -38,10 +37,9 @@ import {
   broadcastUpgradeEvent,
   buildCompleteEvent,
   buildProgressEvent,
-  buildReplayEnv,
   buildStartingEvent,
   buildUpgradeCommitMessage,
-  captureContainerEnv,
+  captureReplayState,
   captureUpgradeFailureLogs,
   commitWorkspaceViaGateway,
   rollbackMigrations,
@@ -297,17 +295,13 @@ async function upgradeDocker(
     }),
   );
 
-  console.log("💾 Capturing existing container environment...");
-  const capturedEnv = await captureContainerEnv(res.assistantContainer);
-  console.log(
-    `   Captured ${Object.keys(capturedEnv).length} env var(s) from ${res.assistantContainer}\n`,
-  );
-
-  // Capture the gateway container env so flag overrides replay onto the new
-  // gateway, and pluck GUARDIAN_BOOTSTRAP_SECRET (only set on gateway).
-  const gatewayEnv = await captureContainerEnv(res.gatewayContainer);
-  const bootstrapSecret = gatewayEnv["GUARDIAN_BOOTSTRAP_SECRET"];
-  const extraGatewayEnv = buildReplayEnv(gatewayEnv, "gateway");
+  const {
+    bootstrapSecret,
+    cesServiceToken,
+    signingKey,
+    extraAssistantEnv,
+    extraGatewayEnv,
+  } = await captureReplayState(res);
 
   // Notify connected clients that an upgrade is about to begin.
   // This must fire BEFORE any progress broadcasts so the UI sets
@@ -362,18 +356,6 @@ async function upgradeDocker(
     // use default
   }
 
-  // Extract CES_SERVICE_TOKEN from the captured env so it can be passed via
-  // the dedicated cesServiceToken parameter (which propagates it to all three
-  // containers). If the old instance predates CES_SERVICE_TOKEN, generate a
-  // fresh one so gateway and CES can authenticate.
-  const cesServiceToken =
-    capturedEnv["CES_SERVICE_TOKEN"] || randomBytes(32).toString("hex");
-
-  // Extract or generate the shared JWT signing key. Pre-env-var instances
-  // won't have it in capturedEnv, so generate fresh in that case.
-  const signingKey =
-    capturedEnv["ACTOR_TOKEN_SIGNING_KEY"] || randomBytes(32).toString("hex");
-
   // Create pre-upgrade backup (best-effort, daemon must be running)
   await broadcastUpgradeEvent(
     entry.runtimeUrl,
@@ -415,8 +397,6 @@ async function upgradeDocker(
   console.log("🛑 Stopping existing containers...");
   await stopContainers(res);
   console.log("✅ Containers stopped\n");
-
-  const extraAssistantEnv = buildReplayEnv(capturedEnv, "assistant");
 
   console.log("🚀 Starting upgraded containers...");
   await startContainers(

--- a/cli/src/lib/device-id.ts
+++ b/cli/src/lib/device-id.ts
@@ -1,23 +1,10 @@
 /**
- * Host device ID resolver.
+ * Host device ID resolver. Resolution order: `VELLUM_DEVICE_ID` env var,
+ * then `device.json` in the CLI-owned config dir (`getConfigDir()`).
  *
- * Resolution order (mirrors `gateway/src/device-id.ts`):
- *   1. `VELLUM_DEVICE_ID` env var, if set — lets the desktop app hand the
- *      canonical device id down to the CLI.
- *   2. `device.json` in the CLI-owned config dir (`getConfigDir()`):
- *      production → `~/.config/vellum/device.json`, non-production →
- *      `$XDG_CONFIG_HOME/vellum-<env>/device.json`. Per cli/AGENTS.md, the
- *      CLI must never touch `~/.vellum/` — that is assistant/gateway-owned
- *      state.
- *
- * Accepted tradeoff: this intentionally does NOT read the legacy
- * `~/.vellum/device.json`, so a containerized gateway's device id may differ
- * from a host-mode gateway's on the same machine. Stability matters for LD
- * feature-flag contexts, not parity with the legacy file.
- *
- * Not to be confused with `guardian-token.ts:computeDeviceId` /
- * `getOrCreatePersistedDeviceId` — those produce the salted-hash Guardian
- * identity, a different concept. Do not merge the two.
+ * Not to be confused with `guardian-token.ts`'s salted-hash Guardian
+ * identity (`computeDeviceId` / `getOrCreatePersistedDeviceId`) — do not
+ * merge the two.
  */
 
 import { randomUUID } from "crypto";

--- a/cli/src/lib/statefulset.ts
+++ b/cli/src/lib/statefulset.ts
@@ -262,7 +262,7 @@ export interface BuildServiceRunArgsOpts extends DockerRunSecrets {
   avatarDevicePath?: string;
 }
 
-export interface BuilderManagedEnvKeys {
+interface BuilderManagedEnvKeys {
   /** Always set by buildServiceRunArgs (spec static/secret entries, builder-computed extras, image-baked PATH). Never replay. */
   always: ReadonlySet<string>;
   /**

--- a/cli/src/lib/upgrade-lifecycle.ts
+++ b/cli/src/lib/upgrade-lifecycle.ts
@@ -7,6 +7,7 @@ import type { AssistantEntry } from "./assistant-config.js";
 import { saveAssistantEntry } from "./assistant-config.js";
 import { createBackup, pruneOldBackups, restoreBackup } from "./backup-ops.js";
 import { emitCliError } from "./cli-error.js";
+import { getOrCreateHostDeviceId } from "./device-id.js";
 import {
   captureImageRefs,
   DOCKER_READY_TIMEOUT_MS,
@@ -202,6 +203,63 @@ export function buildReplayEnv(
       ([key]) => !always.has(key) && !hostManaged.has(key),
     ),
   );
+}
+
+/** Secrets and replay env derived from the outgoing containers. */
+export interface ReplayState {
+  bootstrapSecret: string | undefined;
+  cesServiceToken: string;
+  signingKey: string;
+  extraAssistantEnv: Record<string, string>;
+  extraGatewayEnv: Record<string, string>;
+}
+
+/**
+ * Derive the secrets and replay env for replacement containers from
+ * already-captured assistant/gateway envs. GUARDIAN_BOOTSTRAP_SECRET is only
+ * set on the gateway; CES_SERVICE_TOKEN and ACTOR_TOKEN_SIGNING_KEY fall back
+ * to fresh values for instances that predate them. VELLUM_DEVICE_ID is
+ * backfilled from the host for gateways hatched before device-id injection
+ * (captured value wins — it was itself host-derived).
+ */
+export function buildReplayState(
+  capturedEnv: Record<string, string>,
+  gatewayEnv: Record<string, string>,
+): ReplayState {
+  const extraGatewayEnv = buildReplayEnv(gatewayEnv, "gateway");
+  extraGatewayEnv.VELLUM_DEVICE_ID ??= getOrCreateHostDeviceId();
+
+  return {
+    bootstrapSecret: gatewayEnv["GUARDIAN_BOOTSTRAP_SECRET"],
+    cesServiceToken:
+      capturedEnv["CES_SERVICE_TOKEN"] || randomBytes(32).toString("hex"),
+    signingKey:
+      capturedEnv["ACTOR_TOKEN_SIGNING_KEY"] || randomBytes(32).toString("hex"),
+    extraAssistantEnv: buildReplayEnv(capturedEnv, "assistant"),
+    extraGatewayEnv,
+  };
+}
+
+/**
+ * Capture the assistant and gateway container envs and derive the replay
+ * state for the replacement containers. Logs env-var counts only, never
+ * values.
+ */
+export async function captureReplayState(
+  res: Pick<
+    ReturnType<typeof dockerResourceNames>,
+    "assistantContainer" | "gatewayContainer"
+  >,
+): Promise<ReplayState> {
+  console.log("💾 Capturing existing container environment...");
+  const [capturedEnv, gatewayEnv] = await Promise.all([
+    captureContainerEnv(res.assistantContainer),
+    captureContainerEnv(res.gatewayContainer),
+  ]);
+  console.log(
+    `   Captured ${Object.keys(capturedEnv).length} env var(s) from ${res.assistantContainer}\n`,
+  );
+  return buildReplayState(capturedEnv, gatewayEnv);
 }
 
 /**
@@ -602,26 +660,13 @@ export async function performDockerRollback(
     console.warn("⚠️  Pre-rollback backup failed (continuing with rollback)\n");
   }
 
-  // Capture container env, extract secrets
-  console.log("💾 Capturing existing container environment...");
-  const capturedEnv = await captureContainerEnv(res.assistantContainer);
-  console.log(
-    `   Captured ${Object.keys(capturedEnv).length} env var(s) from ${res.assistantContainer}\n`,
-  );
-
-  // Capture the gateway container env so flag overrides replay onto the new
-  // gateway, and pluck GUARDIAN_BOOTSTRAP_SECRET (only set on gateway).
-  const gatewayEnv = await captureContainerEnv(res.gatewayContainer);
-  const bootstrapSecret = gatewayEnv["GUARDIAN_BOOTSTRAP_SECRET"];
-  const extraGatewayEnv = buildReplayEnv(gatewayEnv, "gateway");
-
-  const cesServiceToken =
-    capturedEnv["CES_SERVICE_TOKEN"] || randomBytes(32).toString("hex");
-
-  const signingKey =
-    capturedEnv["ACTOR_TOKEN_SIGNING_KEY"] || randomBytes(32).toString("hex");
-
-  const extraAssistantEnv = buildReplayEnv(capturedEnv, "assistant");
+  const {
+    bootstrapSecret,
+    cesServiceToken,
+    signingKey,
+    extraAssistantEnv,
+    extraGatewayEnv,
+  } = await captureReplayState(res);
 
   // Parse gateway port from entry's runtimeUrl
   let gatewayPort = GATEWAY_INTERNAL_PORT;


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for persist-gateway-env-docker.md.

- **Backfill (real bug):** instances hatched before this feature never gain VELLUM_DEVICE_ID — the replay paths only preserve captured env. The new consolidated capture helper defaults it from getOrCreateHostDeviceId() when absent, so the next upgrade heals the existing fleet (captured value wins when present).
- **Consolidation:** the capture→pluck-secrets→filter sequence was triplicated across upgrade.ts/rollback.ts/upgrade-lifecycle.ts; now one captureReplayState() helper (with Promise.all'd docker inspects).
- Cleanup: unexport BuilderManagedEnvKeys, terse device-id docblock, consistent test env save/restore.