### PR TITLE
feat(macos): resolve user shell PATH and locate executables from main process

### DIFF
--- a/apps/macos/src/main/shell-path.test.ts
+++ b/apps/macos/src/main/shell-path.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import { FakeChild } from "./test-helpers";
+
+// --- Mocks ---
+// Must be installed before the `await import` of the module under test so
+// the mocked module graph is in place when `shell-path.ts` (and its
+// `cli-installer.ts` dependency) is evaluated. See `commands.test.ts` for
+// the ordering rationale.
+
+mock.module("electron", () => ({
+  app: {
+    getPath: () => "/mock/userData",
+    isPackaged: true,
+  },
+}));
+
+// Paths for which the mocked accessSync(X_OK) succeeds.
+const executablePaths = new Set<string>();
+
+mock.module("node:fs", () => ({
+  accessSync: (p: string) => {
+    if (!executablePaths.has(p)) throw new Error(`EACCES: ${p}`);
+  },
+  constants: { X_OK: 1 },
+  // Used by cli-installer's buildInstallEnv (nvm detection).
+  copyFileSync: () => {},
+  existsSync: () => false,
+  mkdirSync: () => {},
+  readdirSync: () => [],
+  rmSync: () => {},
+}));
+
+let lastChild: FakeChild;
+const spawnCalls: Array<[string, string[]]> = [];
+
+mock.module("node:child_process", () => ({
+  spawn: (cmd: string, args: string[]) => {
+    spawnCalls.push([cmd, args]);
+    lastChild = new FakeChild();
+    return lastChild;
+  },
+}));
+
+const { resolveShellPath, findExecutablesInPath, _resetShellPathCache } =
+  await import("./shell-path");
+const { buildInstallEnv } = await import("./cli-installer");
+
+const originalShell = process.env.SHELL;
+
+afterEach(() => {
+  spawnCalls.length = 0;
+  executablePaths.clear();
+  _resetShellPathCache();
+  if (originalShell === undefined) delete process.env.SHELL;
+  else process.env.SHELL = originalShell;
+});
+
+// --- resolveShellPath ---
+
+describe("resolveShellPath", () => {
+  test("returns the shell's stdout PATH using $SHELL", async () => {
+    process.env.SHELL = "/bin/bash";
+
+    const promise = resolveShellPath();
+    lastChild.stdout.emit("data", Buffer.from("/Users/me/.local/bin:/usr/bin"));
+    lastChild.emit("close", 0);
+
+    expect(await promise).toBe("/Users/me/.local/bin:/usr/bin");
+    expect(spawnCalls).toHaveLength(1);
+    expect(spawnCalls[0][0]).toBe("/bin/bash");
+    expect(spawnCalls[0][1]).toEqual(["-ilc", 'printf "%s" "$PATH"']);
+  });
+
+  test("falls back to /bin/zsh when $SHELL is unset", async () => {
+    delete process.env.SHELL;
+
+    const promise = resolveShellPath();
+    lastChild.stdout.emit("data", Buffer.from("/usr/bin"));
+    lastChild.emit("close", 0);
+
+    await promise;
+    expect(spawnCalls[0][0]).toBe("/bin/zsh");
+  });
+
+  test("falls back to buildInstallEnv PATH on non-zero exit", async () => {
+    const promise = resolveShellPath();
+    lastChild.stderr.emit("data", Buffer.from("zsh: bad rc file"));
+    lastChild.emit("close", 1);
+
+    expect(await promise).toBe(buildInstallEnv().PATH ?? "");
+  });
+
+  test("falls back to buildInstallEnv PATH on empty output", async () => {
+    const promise = resolveShellPath();
+    lastChild.emit("close", 0);
+
+    expect(await promise).toBe(buildInstallEnv().PATH ?? "");
+  });
+
+  test("falls back to buildInstallEnv PATH on spawn error", async () => {
+    const promise = resolveShellPath();
+    lastChild.emit("error", new Error("ENOENT"));
+
+    expect(await promise).toBe(buildInstallEnv().PATH ?? "");
+  });
+
+  test("kills the child and falls back on timeout", async () => {
+    const promise = resolveShellPath(10);
+
+    expect(await promise).toBe(buildInstallEnv().PATH ?? "");
+    expect(lastChild.kill).toHaveBeenCalled();
+  });
+
+  test("late close after timeout does not override the fallback", async () => {
+    const promise = resolveShellPath(10);
+    const result = await promise;
+
+    lastChild.stdout.emit("data", Buffer.from("/late/bin"));
+    lastChild.emit("close", 0);
+
+    expect(result).toBe(buildInstallEnv().PATH ?? "");
+    expect(await resolveShellPath()).toBe(result);
+  });
+
+  test("caches the result; second call does not spawn again", async () => {
+    const promise = resolveShellPath();
+    lastChild.stdout.emit("data", Buffer.from("/cached/bin"));
+    lastChild.emit("close", 0);
+    await promise;
+
+    expect(await resolveShellPath()).toBe("/cached/bin");
+    expect(spawnCalls).toHaveLength(1);
+  });
+
+  test("concurrent first calls share a single spawn", async () => {
+    const p1 = resolveShellPath();
+    const p2 = resolveShellPath();
+    expect(spawnCalls).toHaveLength(1);
+
+    lastChild.stdout.emit("data", Buffer.from("/shared/bin"));
+    lastChild.emit("close", 0);
+
+    expect(await p1).toBe("/shared/bin");
+    expect(await p2).toBe("/shared/bin");
+  });
+
+  test("_resetShellPathCache clears the cache", async () => {
+    const p1 = resolveShellPath();
+    lastChild.stdout.emit("data", Buffer.from("/first/bin"));
+    lastChild.emit("close", 0);
+    await p1;
+
+    _resetShellPathCache();
+
+    const p2 = resolveShellPath();
+    expect(spawnCalls).toHaveLength(2);
+    lastChild.stdout.emit("data", Buffer.from("/second/bin"));
+    lastChild.emit("close", 0);
+    expect(await p2).toBe("/second/bin");
+  });
+});
+
+// --- findExecutablesInPath ---
+
+describe("findExecutablesInPath", () => {
+  test("returns hits in PATH precedence order", () => {
+    executablePaths.add("/a/vellum");
+    executablePaths.add("/c/vellum");
+
+    expect(findExecutablesInPath("vellum", "/a:/b:/c")).toEqual([
+      "/a/vellum",
+      "/c/vellum",
+    ]);
+  });
+
+  test("skips missing and non-executable entries", () => {
+    executablePaths.add("/b/vellum");
+
+    expect(findExecutablesInPath("vellum", "/a:/b")).toEqual(["/b/vellum"]);
+  });
+
+  test("skips empty and duplicate PATH entries", () => {
+    executablePaths.add("/a/vellum");
+
+    expect(findExecutablesInPath("vellum", ":/a::/a:/a:")).toEqual([
+      "/a/vellum",
+    ]);
+  });
+
+  test("returns empty array when nothing matches", () => {
+    expect(findExecutablesInPath("vellum", "/a:/b")).toEqual([]);
+  });
+});

--- a/apps/macos/src/main/shell-path.test.ts
+++ b/apps/macos/src/main/shell-path.test.ts
@@ -42,11 +42,17 @@ mock.module("node:child_process", () => ({
   },
 }));
 
-const { resolveShellPath, findExecutablesInPath, _resetShellPathCache } =
-  await import("./shell-path");
+const {
+  resolveShellPath,
+  findExecutablesInPath,
+  _resetShellPathCache,
+  PATH_SENTINEL,
+} = await import("./shell-path");
 const { buildInstallEnv } = await import("./cli-installer");
 
 const originalShell = process.env.SHELL;
+
+const wrap = (path: string) => `${PATH_SENTINEL}${path}${PATH_SENTINEL}`;
 
 afterEach(() => {
   spawnCalls.length = 0;
@@ -63,20 +69,45 @@ describe("resolveShellPath", () => {
     process.env.SHELL = "/bin/bash";
 
     const promise = resolveShellPath();
-    lastChild.stdout.emit("data", Buffer.from("/Users/me/.local/bin:/usr/bin"));
+    lastChild.stdout.emit(
+      "data",
+      Buffer.from(wrap("/Users/me/.local/bin:/usr/bin")),
+    );
     lastChild.emit("close", 0);
 
     expect(await promise).toBe("/Users/me/.local/bin:/usr/bin");
     expect(spawnCalls).toHaveLength(1);
     expect(spawnCalls[0][0]).toBe("/bin/bash");
-    expect(spawnCalls[0][1]).toEqual(["-ilc", 'printf "%s" "$PATH"']);
+    expect(spawnCalls[0][1]).toEqual([
+      "-ilc",
+      `printf "${PATH_SENTINEL}%s${PATH_SENTINEL}" "$PATH"`,
+    ]);
+  });
+
+  test("ignores startup-file banner output before the sentinel pair", async () => {
+    const promise = resolveShellPath();
+    lastChild.stdout.emit(
+      "data",
+      Buffer.from(`Welcome to my shell!\nnvm warning\n${wrap("/usr/local/bin:/usr/bin")}`),
+    );
+    lastChild.emit("close", 0);
+
+    expect(await promise).toBe("/usr/local/bin:/usr/bin");
+  });
+
+  test("falls back to buildInstallEnv PATH when sentinels are missing", async () => {
+    const promise = resolveShellPath();
+    lastChild.stdout.emit("data", Buffer.from("banner only, no sentinel"));
+    lastChild.emit("close", 0);
+
+    expect(await promise).toBe(buildInstallEnv().PATH ?? "");
   });
 
   test("falls back to /bin/zsh when $SHELL is unset", async () => {
     delete process.env.SHELL;
 
     const promise = resolveShellPath();
-    lastChild.stdout.emit("data", Buffer.from("/usr/bin"));
+    lastChild.stdout.emit("data", Buffer.from(wrap("/usr/bin")));
     lastChild.emit("close", 0);
 
     await promise;
@@ -116,7 +147,7 @@ describe("resolveShellPath", () => {
     const promise = resolveShellPath(10);
     const result = await promise;
 
-    lastChild.stdout.emit("data", Buffer.from("/late/bin"));
+    lastChild.stdout.emit("data", Buffer.from(wrap("/late/bin")));
     lastChild.emit("close", 0);
 
     expect(result).toBe(buildInstallEnv().PATH ?? "");
@@ -125,7 +156,7 @@ describe("resolveShellPath", () => {
 
   test("caches the result; second call does not spawn again", async () => {
     const promise = resolveShellPath();
-    lastChild.stdout.emit("data", Buffer.from("/cached/bin"));
+    lastChild.stdout.emit("data", Buffer.from(wrap("/cached/bin")));
     lastChild.emit("close", 0);
     await promise;
 
@@ -138,7 +169,7 @@ describe("resolveShellPath", () => {
     const p2 = resolveShellPath();
     expect(spawnCalls).toHaveLength(1);
 
-    lastChild.stdout.emit("data", Buffer.from("/shared/bin"));
+    lastChild.stdout.emit("data", Buffer.from(wrap("/shared/bin")));
     lastChild.emit("close", 0);
 
     expect(await p1).toBe("/shared/bin");
@@ -147,7 +178,7 @@ describe("resolveShellPath", () => {
 
   test("_resetShellPathCache clears the cache", async () => {
     const p1 = resolveShellPath();
-    lastChild.stdout.emit("data", Buffer.from("/first/bin"));
+    lastChild.stdout.emit("data", Buffer.from(wrap("/first/bin")));
     lastChild.emit("close", 0);
     await p1;
 
@@ -155,7 +186,7 @@ describe("resolveShellPath", () => {
 
     const p2 = resolveShellPath();
     expect(spawnCalls).toHaveLength(2);
-    lastChild.stdout.emit("data", Buffer.from("/second/bin"));
+    lastChild.stdout.emit("data", Buffer.from(wrap("/second/bin")));
     lastChild.emit("close", 0);
     expect(await p2).toBe("/second/bin");
   });

--- a/apps/macos/src/main/shell-path.ts
+++ b/apps/macos/src/main/shell-path.ts
@@ -1,0 +1,104 @@
+import { spawn } from "node:child_process";
+import { accessSync, constants } from "node:fs";
+import path from "node:path";
+
+import { buildInstallEnv } from "./cli-installer";
+
+const SHELL_PATH_TIMEOUT_MS = 5_000;
+
+// Cached for the process lifetime; caching the promise also dedupes
+// concurrent first calls into a single shell spawn.
+let shellPathPromise: Promise<string> | null = null;
+
+/** Reset the shell PATH cache. Exposed for testing only. */
+export function _resetShellPathCache(): void {
+  shellPathPromise = null;
+}
+
+function fallbackPath(): string {
+  return buildInstallEnv().PATH ?? "";
+}
+
+/**
+ * Resolve the user's interactive login shell PATH.
+ *
+ * GUI apps launched from Finder inherit a minimal PATH that excludes
+ * ~/.local/bin and package-manager bin dirs, so PATH checks (shadow
+ * detection, "is ~/.local/bin in PATH") must use the shell's PATH rather
+ * than `process.env.PATH`. Never rejects — on failure or timeout it falls
+ * back to the PATH produced by `buildInstallEnv()`.
+ */
+export function resolveShellPath(
+  timeoutMs: number = SHELL_PATH_TIMEOUT_MS,
+): Promise<string> {
+  shellPathPromise ??= queryShellPath(timeoutMs);
+  return shellPathPromise;
+}
+
+function queryShellPath(timeoutMs: number): Promise<string> {
+  return new Promise((resolve) => {
+    const shell = process.env.SHELL ?? "/bin/zsh";
+
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(shell, ["-ilc", 'printf "%s" "$PATH"']);
+    } catch {
+      resolve(fallbackPath());
+      return;
+    }
+
+    let stdout = "";
+    let settled = false;
+
+    const settle = (value: string) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(value);
+    };
+
+    const timer = setTimeout(() => {
+      child.kill();
+      settle(fallbackPath());
+    }, timeoutMs);
+
+    child.stdout?.on("data", (data: Buffer) => {
+      stdout += data.toString();
+    });
+
+    child.on("error", () => settle(fallbackPath()));
+
+    child.on("close", (code: number | null) => {
+      const value = stdout.trim();
+      settle(code === 0 && value ? value : fallbackPath());
+    });
+  });
+}
+
+/**
+ * Return absolute paths of every executable named `name` on `pathValue`,
+ * preserving PATH precedence order. Empty and duplicate entries are
+ * skipped; non-existent or non-executable candidates are ignored.
+ */
+export function findExecutablesInPath(
+  name: string,
+  pathValue: string,
+): string[] {
+  const results: string[] = [];
+  const seen = new Set<string>();
+
+  for (const dir of pathValue.split(":")) {
+    if (!dir || seen.has(dir)) continue;
+    seen.add(dir);
+
+    const candidate = path.join(dir, name);
+    try {
+      accessSync(candidate, constants.X_OK);
+      results.push(candidate);
+    } catch {
+      // Missing or not executable.
+    }
+  }
+
+  return results;
+}

--- a/apps/macos/src/main/shell-path.ts
+++ b/apps/macos/src/main/shell-path.ts
@@ -6,6 +6,10 @@ import { buildInstallEnv } from "./cli-installer";
 
 const SHELL_PATH_TIMEOUT_MS = 5_000;
 
+// Wraps the printf'd PATH so it can be isolated from any startup-file
+// output (banners, warnings) the interactive login shell writes first.
+export const PATH_SENTINEL = "__VELLUM_PATH_7f3a__";
+
 // Cached for the process lifetime; caching the promise also dedupes
 // concurrent first calls into a single shell spawn.
 let shellPathPromise: Promise<string> | null = null;
@@ -41,7 +45,10 @@ function queryShellPath(timeoutMs: number): Promise<string> {
 
     let child: ReturnType<typeof spawn>;
     try {
-      child = spawn(shell, ["-ilc", 'printf "%s" "$PATH"']);
+      child = spawn(shell, [
+        "-ilc",
+        `printf "${PATH_SENTINEL}%s${PATH_SENTINEL}" "$PATH"`,
+      ]);
     } catch {
       resolve(fallbackPath());
       return;
@@ -69,10 +76,19 @@ function queryShellPath(timeoutMs: number): Promise<string> {
     child.on("error", () => settle(fallbackPath()));
 
     child.on("close", (code: number | null) => {
-      const value = stdout.trim();
-      settle(code === 0 && value ? value : fallbackPath());
+      const value = code === 0 ? extractSentinelValue(stdout) : null;
+      settle(value || fallbackPath());
     });
   });
+}
+
+// Extracts the last sentinel-wrapped value; null when no complete pair.
+function extractSentinelValue(stdout: string): string | null {
+  const end = stdout.lastIndexOf(PATH_SENTINEL);
+  if (end <= 0) return null;
+  const start = stdout.lastIndexOf(PATH_SENTINEL, end - 1);
+  if (start === -1) return null;
+  return stdout.slice(start + PATH_SENTINEL.length, end);
 }
 
 /**


### PR DESCRIPTION
## Summary
- New shell-path.ts: resolveShellPath() spawns the user's login shell to capture the real shell PATH (GUI apps get a minimal PATH), with 5s timeout, buildInstallEnv() fallback, and process-lifetime cache
- findExecutablesInPath() returns executable hits in PATH precedence order for shadow detection
- Tests using the FakeChild spawn helper

Part of plan: cli-path-installer.md (PR 2 of 6)