### PR TITLE
feat(macos): write CLI locator file on every launch for PATH wrapper

### DIFF
--- a/apps/macos/src/main/bundle-flow.test.ts
+++ b/apps/macos/src/main/bundle-flow.test.ts
@@ -46,11 +46,13 @@ mock.module("@vellumai/local-mode", () => ({
   getGuardianAccessToken: getGuardianAccessTokenMock,
 }));
 
+const ensureCliInstalledMock = mock(async () => undefined);
+
 mock.module("./cli-installer", () => ({
   isCliInstalled: () => true,
   getBundledBunPath: () => "/fake/bun",
   getCliBinPath: () => "/fake/cli",
-  ensureCliInstalled: async () => {},
+  ensureCliInstalled: ensureCliInstalledMock,
 }));
 
 const openBundleConfirmationMock = mock(
@@ -139,6 +141,7 @@ beforeEach(() => {
   installBundleConfirmationMock.mockClear();
   unpackBundleMock.mockClear();
   openBundleWindowMock.mockClear();
+  ensureCliInstalledMock.mockClear();
 
   getLockfileDataMock.mockReturnValue({ ok: false, status: 500 });
   openBundleConfirmationMock.mockResolvedValue(true);
@@ -290,6 +293,16 @@ describe("handleBundleFile", () => {
     const opts = fetchCall?.[1] as RequestInit | undefined;
     const headers = opts?.headers as Record<string, string> | undefined;
     expect(headers?.["Authorization"]).toBe("Bearer fake-token");
+  });
+
+  test("refreshes the CLI locator via ensureCliInstalled even when already installed", async () => {
+    getLockfileDataMock.mockReturnValue(makeLockfileWithPort(9000));
+
+    await handleBundleFile("/tmp/test.vellum");
+
+    // isCliInstalled() is mocked true; routing through ensureCliInstalled
+    // keeps the PATH-wrapper locator fresh on the installed path.
+    expect(ensureCliInstalledMock).toHaveBeenCalledTimes(1);
   });
 
   test("success flow: scans, confirms, unpacks, opens window", async () => {

--- a/apps/macos/src/main/bundle-flow.ts
+++ b/apps/macos/src/main/bundle-flow.ts
@@ -22,7 +22,6 @@ import {
   ensureCliInstalled,
   getBundledBunPath,
   getCliBinPath,
-  isCliInstalled,
 } from "./cli-installer";
 import { openBundleConfirmation, installBundleConfirmation } from "./bundle-confirmation";
 import { unpackBundle, type BundleScanData } from "./bundle-manager";
@@ -55,9 +54,7 @@ async function resolveCliInvocation(): Promise<CliInvocation> {
       return { command: "bun", baseArgs: ["run", cliEntry] };
     }
   }
-  if (isCliInstalled()) {
-    return { command: getBundledBunPath(), baseArgs: ["run", getCliBinPath()] };
-  }
+  // Early-returns when already installed, refreshing the PATH-wrapper locator.
   await ensureCliInstalled();
   return { command: getBundledBunPath(), baseArgs: ["run", getCliBinPath()] };
 }

--- a/apps/macos/src/main/cli-installer.test.ts
+++ b/apps/macos/src/main/cli-installer.test.ts
@@ -24,15 +24,24 @@ mock.module("electron", () => ({
   },
 }));
 
+mock.module("./logger", () => ({
+  default: { info: () => {}, warn: () => {}, error: () => {} },
+}));
+
 // Track fs calls so tests can assert on them.
 // Per-path overrides for existsSync. Falls back to `existsSyncDefault`.
 let existsSyncDefault = false;
 const existsSyncByPath: Record<string, boolean> = {};
 let readdirSyncReturn: Array<{ name: string; isDirectory: () => boolean }> = [];
 let readdirSyncError: Error | null = null;
+let writeFileSyncError: Error | null = null;
 const mkdirSyncCalls: Array<[string, object]> = [];
 const rmSyncCalls: Array<[string, object]> = [];
 const copyFileSyncCalls: Array<[string, string]> = [];
+const writeFileSyncCalls: Array<[string, string]> = [];
+const renameSyncCalls: Array<[string, string]> = [];
+// Interleaved fs call log for ordering assertions across mocks.
+const fsCallOrder: string[] = [];
 
 mock.module("node:fs", () => ({
   copyFileSync: (src: string, dst: string) => {
@@ -47,8 +56,18 @@ mock.module("node:fs", () => ({
     if (readdirSyncError) throw readdirSyncError;
     return readdirSyncReturn;
   },
+  renameSync: (src: string, dst: string) => {
+    renameSyncCalls.push([src, dst]);
+    fsCallOrder.push(`renameSync:${dst}`);
+  },
   rmSync: (p: string, opts: object) => {
     rmSyncCalls.push([p, opts]);
+    fsCallOrder.push(`rmSync:${p}`);
+  },
+  writeFileSync: (p: string, content: string) => {
+    if (writeFileSyncError) throw writeFileSyncError;
+    writeFileSyncCalls.push([p, content]);
+    fsCallOrder.push(`writeFileSync:${p}`);
   },
 }));
 
@@ -71,6 +90,9 @@ const {
   getCliInstallDir,
   getCliBinPath,
   getBundledBunPath,
+  getCliLocatorPath,
+  shQuote,
+  writeCliLocator,
   buildInstallEnv,
   isCliInstalled,
   ensureCliInstalled,
@@ -80,15 +102,20 @@ const {
 
 const seedPkgPath = `${mockResourcesPath}/cli-lockfile/package.json`;
 const seedLockPath = `${mockResourcesPath}/cli-lockfile/bun.lock`;
+const locatorPath = `${userDataPath}/cli/locator.sh`;
 
 afterEach(() => {
   existsSyncDefault = false;
   for (const key of Object.keys(existsSyncByPath)) delete existsSyncByPath[key];
   readdirSyncReturn.length = 0;
   readdirSyncError = null;
+  writeFileSyncError = null;
   mkdirSyncCalls.length = 0;
   rmSyncCalls.length = 0;
   copyFileSyncCalls.length = 0;
+  writeFileSyncCalls.length = 0;
+  renameSyncCalls.length = 0;
+  fsCallOrder.length = 0;
   spawnCalls.length = 0;
   _resetInstallLock();
 });
@@ -117,6 +144,59 @@ describe("getBundledBunPath", () => {
   });
 });
 
+describe("getCliLocatorPath", () => {
+  test("returns <userData>/cli/locator.sh", () => {
+    expect(getCliLocatorPath()).toBe(locatorPath);
+  });
+});
+
+// --- shQuote ---
+
+describe("shQuote", () => {
+  test("wraps a plain value in single quotes", () => {
+    expect(shQuote("/usr/local/bin/bun")).toBe("'/usr/local/bin/bun'");
+  });
+
+  test("escapes embedded single quotes", () => {
+    expect(shQuote("/Users/o'brien/bin")).toBe("'/Users/o'\\''brien/bin'");
+  });
+});
+
+// --- writeCliLocator ---
+
+describe("writeCliLocator", () => {
+  test("writes the temp file then renames it over locator.sh", () => {
+    writeCliLocator();
+
+    expect(mkdirSyncCalls).toContainEqual([
+      `${userDataPath}/cli`,
+      { recursive: true },
+    ]);
+    expect(writeFileSyncCalls).toHaveLength(1);
+    expect(writeFileSyncCalls[0][0]).toBe(`${locatorPath}.tmp`);
+    expect(renameSyncCalls).toEqual([[`${locatorPath}.tmp`, locatorPath]]);
+  });
+
+  test("content contains both single-quoted paths", () => {
+    writeCliLocator();
+
+    const content = writeFileSyncCalls[0][1];
+    expect(content).toContain(`VELLUM_BUN='${mockResourcesPath}/bun'\n`);
+    expect(content).toContain(
+      `VELLUM_CLI_BIN='${userDataPath}/cli/${PINNED_CLI_VERSION}/node_modules/.bin/vellum'\n`,
+    );
+    expect(content.endsWith("\n")).toBe(true);
+    expect(content.startsWith("#!")).toBe(false);
+  });
+
+  test("swallows write errors", () => {
+    writeFileSyncError = new Error("EACCES: permission denied");
+
+    expect(() => writeCliLocator()).not.toThrow();
+    expect(renameSyncCalls).toHaveLength(0);
+  });
+});
+
 // --- isCliInstalled ---
 
 describe("isCliInstalled", () => {
@@ -134,10 +214,20 @@ describe("isCliInstalled", () => {
 // --- ensureCliInstalled ---
 
 describe("ensureCliInstalled", () => {
-  test("skips install when already installed", async () => {
+  test("skips install but refreshes the locator when already installed", async () => {
     existsSyncDefault = true;
+
     await ensureCliInstalled();
+
     expect(spawnCalls).toHaveLength(0);
+    expect(renameSyncCalls).toEqual([[`${locatorPath}.tmp`, locatorPath]]);
+  });
+
+  test("a throwing locator write does not reject", async () => {
+    existsSyncDefault = true;
+    writeFileSyncError = new Error("EROFS: read-only file system");
+
+    await expect(ensureCliInstalled()).resolves.toBeUndefined();
   });
 
   test("falls back to bun add --ignore-scripts when no seed lockfile exists", async () => {
@@ -188,10 +278,34 @@ describe("ensureCliInstalled", () => {
     lastChild.emit("close", 0);
     await promise;
 
-    expect(mkdirSyncCalls).toHaveLength(1);
     const [dir, opts] = mkdirSyncCalls[0];
     expect(dir).toBe(`${userDataPath}/cli/${PINNED_CLI_VERSION}`);
     expect(opts).toEqual({ recursive: true });
+  });
+
+  test("fresh install writes the locator before cleanupOldVersions", async () => {
+    existsSyncDefault = false;
+    readdirSyncReturn = [dirEntry("0.8.5")];
+
+    const promise = ensureCliInstalled();
+    lastChild.emit("close", 0);
+    await promise;
+
+    const renameIndex = fsCallOrder.indexOf(`renameSync:${locatorPath}`);
+    const rmIndex = fsCallOrder.indexOf(`rmSync:${userDataPath}/cli/0.8.5`);
+    expect(renameIndex).toBeGreaterThanOrEqual(0);
+    expect(rmIndex).toBeGreaterThanOrEqual(0);
+    expect(renameIndex).toBeLessThan(rmIndex);
+  });
+
+  test("a throwing locator write does not reject a fresh install", async () => {
+    existsSyncDefault = false;
+    writeFileSyncError = new Error("EACCES: permission denied");
+
+    const promise = ensureCliInstalled();
+    lastChild.emit("close", 0);
+
+    await expect(promise).resolves.toBeUndefined();
   });
 
   test("throws on non-zero exit code", async () => {

--- a/apps/macos/src/main/cli-installer.test.ts
+++ b/apps/macos/src/main/cli-installer.test.ts
@@ -103,6 +103,7 @@ const {
 const seedPkgPath = `${mockResourcesPath}/cli-lockfile/package.json`;
 const seedLockPath = `${mockResourcesPath}/cli-lockfile/bun.lock`;
 const locatorPath = `${userDataPath}/cli/locator.sh`;
+const cliBinPath = `${userDataPath}/cli/${PINNED_CLI_VERSION}/node_modules/.bin/vellum`;
 
 afterEach(() => {
   existsSyncDefault = false;
@@ -166,6 +167,8 @@ describe("shQuote", () => {
 
 describe("writeCliLocator", () => {
   test("writes the temp file then renames it over locator.sh", () => {
+    existsSyncByPath[cliBinPath] = true;
+
     writeCliLocator();
 
     expect(mkdirSyncCalls).toContainEqual([
@@ -178,6 +181,8 @@ describe("writeCliLocator", () => {
   });
 
   test("content contains both single-quoted paths", () => {
+    existsSyncByPath[cliBinPath] = true;
+
     writeCliLocator();
 
     const content = writeFileSyncCalls[0][1];
@@ -190,9 +195,19 @@ describe("writeCliLocator", () => {
   });
 
   test("swallows write errors", () => {
+    existsSyncByPath[cliBinPath] = true;
     writeFileSyncError = new Error("EACCES: permission denied");
 
     expect(() => writeCliLocator()).not.toThrow();
+    expect(renameSyncCalls).toHaveLength(0);
+  });
+
+  test("no-ops when the CLI bin is not installed", () => {
+    existsSyncDefault = false;
+
+    writeCliLocator();
+
+    expect(writeFileSyncCalls).toHaveLength(0);
     expect(renameSyncCalls).toHaveLength(0);
   });
 });
@@ -288,6 +303,8 @@ describe("ensureCliInstalled", () => {
     readdirSyncReturn = [dirEntry("0.8.5")];
 
     const promise = ensureCliInstalled();
+    // Simulate bun creating the bin so the locator write proceeds.
+    existsSyncByPath[cliBinPath] = true;
     lastChild.emit("close", 0);
     await promise;
 
@@ -303,6 +320,7 @@ describe("ensureCliInstalled", () => {
     writeFileSyncError = new Error("EACCES: permission denied");
 
     const promise = ensureCliInstalled();
+    existsSyncByPath[cliBinPath] = true;
     lastChild.emit("close", 0);
 
     await expect(promise).resolves.toBeUndefined();

--- a/apps/macos/src/main/cli-installer.ts
+++ b/apps/macos/src/main/cli-installer.ts
@@ -52,8 +52,13 @@ export function shQuote(value: string): string {
  * sources to find the bundled bun and the current CLI bin. Refreshed on
  * every launch so app moves and version bumps self-heal. Non-fatal —
  * failures are logged but never block app startup.
+ *
+ * No-ops when the pinned CLI bin isn't installed yet (e.g. first launch
+ * after a version bump) so the wrapper is never pointed at a missing binary.
  */
 export function writeCliLocator(): void {
+  if (!isCliInstalled()) return;
+
   try {
     const locatorPath = getCliLocatorPath();
     mkdirSync(path.dirname(locatorPath), { recursive: true });

--- a/apps/macos/src/main/cli-installer.ts
+++ b/apps/macos/src/main/cli-installer.ts
@@ -5,10 +5,14 @@ import {
   existsSync,
   mkdirSync,
   readdirSync,
+  renameSync,
   rmSync,
+  writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
+
+import log from "./logger";
 
 // Auto-stamped by create-release-branch workflow.
 export const PINNED_CLI_VERSION = "0.8.10";
@@ -31,6 +35,40 @@ export function getBundledBunPath(): string {
 /** Whether the pinned CLI version is already installed on disk. */
 export function isCliInstalled(): boolean {
   return existsSync(getCliBinPath());
+}
+
+/** Path to the shell-sourceable locator file consumed by the PATH wrapper. */
+export function getCliLocatorPath(): string {
+  return path.join(app.getPath("userData"), "cli", "locator.sh");
+}
+
+/** Single-quote a value for safe interpolation into a shell script. */
+export function shQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+/**
+ * Atomically write the locator file the `~/.local/bin/vellum` wrapper
+ * sources to find the bundled bun and the current CLI bin. Refreshed on
+ * every launch so app moves and version bumps self-heal. Non-fatal —
+ * failures are logged but never block app startup.
+ */
+export function writeCliLocator(): void {
+  try {
+    const locatorPath = getCliLocatorPath();
+    mkdirSync(path.dirname(locatorPath), { recursive: true });
+
+    const content =
+      "# Written by Vellum.app on every launch. Do not edit.\n" +
+      `VELLUM_BUN=${shQuote(getBundledBunPath())}\n` +
+      `VELLUM_CLI_BIN=${shQuote(getCliBinPath())}\n`;
+
+    const tmpPath = `${locatorPath}.tmp`;
+    writeFileSync(tmpPath, content);
+    renameSync(tmpPath, locatorPath);
+  } catch (err) {
+    log.error("[cli-installer] failed to write CLI locator:", err);
+  }
 }
 
 function findNvmNodeBinDir(home: string): string[] {
@@ -153,12 +191,16 @@ export function _resetInstallLock(): void {
  * lifecycle scripts are always suppressed via `--ignore-scripts`.
  */
 export async function ensureCliInstalled(): Promise<void> {
-  if (isCliInstalled()) return;
+  if (isCliInstalled()) {
+    writeCliLocator();
+    return;
+  }
 
   if (cliInstallPromise) return cliInstallPromise;
 
   cliInstallPromise = (async () => {
     await bunInstallCli();
+    writeCliLocator();
     cleanupOldVersions();
   })();
 

--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -15,6 +15,7 @@ import { installAbout, openAboutWindow } from "./about";
 import { installAutoUpdate } from "./auto-update";
 import { APP_HOST, APP_PROTOCOL, BUNDLES_DIR_NAME, VELLUMAPP_PROTOCOL } from "./app-config";
 import { resolveAllowedOrigin } from "./app-origin";
+import { writeCliLocator } from "./cli-installer";
 import { installCsp } from "./csp";
 import { getDeviceId } from "./device-id";
 import { handleSync } from "./ipc";
@@ -326,6 +327,9 @@ app
     installHotkeysIpc();
     installFeatureFlagsIpc();
     installLocalMode();
+    // Refresh the PATH-wrapper locator every launch so app moves and
+    // version bumps self-heal even if no CLI invocation happens this session.
+    if (app.isPackaged) writeCliLocator();
     installLoginItem();
     installLoginItemIpc();
     installHotkeyHelper();

--- a/apps/macos/src/main/local-mode.test.ts
+++ b/apps/macos/src/main/local-mode.test.ts
@@ -166,7 +166,9 @@ describe("vellum:localMode:hatch handler", () => {
       cliInstallerState.bundledBunPath,
       ["run", cliInstallerState.cliBinPath, "hatch", "openclaw"],
     ]);
-    expect(ensureCliInstalledMock).not.toHaveBeenCalled();
+    // Routed through ensureCliInstalled so the PATH-wrapper locator is
+    // refreshed even on the already-installed path.
+    expect(ensureCliInstalledMock).toHaveBeenCalledTimes(1);
   });
 
   test("packaged: triggers install when CLI not found, then uses installed path", async () => {

--- a/apps/macos/src/main/local-mode.ts
+++ b/apps/macos/src/main/local-mode.ts
@@ -23,7 +23,6 @@ import {
   ensureCliInstalled,
   getBundledBunPath,
   getCliBinPath,
-  isCliInstalled,
 } from "./cli-installer";
 
 /**
@@ -64,8 +63,8 @@ interface WakeResult {
  * Resolve how to invoke the CLI. Precedence:
  *  1. `VELLUM_CLI_PATH` env var override
  *  2. Dev source tree (when `!app.isPackaged`)
- *  3. Already-installed CLI in the user-data directory
- *  4. Lazy install via `ensureCliInstalled()`, then use the installed path
+ *  3. `ensureCliInstalled()` — early-returns when already installed and
+ *     refreshes the PATH-wrapper locator either way
  *
  * Throws when no CLI path can be resolved (e.g. install fails).
  */
@@ -81,10 +80,6 @@ export async function resolveCliInvocation(): Promise<CliInvocation> {
     if (existsSync(cliEntry)) {
       return { command: "bun", baseArgs: ["run", cliEntry] };
     }
-  }
-
-  if (isCliInstalled()) {
-    return { command: getBundledBunPath(), baseArgs: ["run", getCliBinPath()] };
   }
 
   await ensureCliInstalled();


### PR DESCRIPTION
## Summary
- Write/refresh <userData>/cli/locator.sh atomically on every ensureCliInstalled() call (both early-return and fresh-install paths, before cleanupOldVersions)
- Locator is a shell-sourceable env file (VELLUM_BUN, VELLUM_CLI_BIN) consumed by the upcoming ~/.local/bin/vellum wrapper
- Non-fatal on write failure; tests for atomicity, ordering, and quoting

Part of plan: cli-path-installer.md (PR 1 of 6)