### PR TITLE
feat(web): derive assistants valid for the active org

### DIFF
--- a/apps/web/src/hooks/use-valid-assistants-for-active-org.ts
+++ b/apps/web/src/hooks/use-valid-assistants-for-active-org.ts
@@ -1,0 +1,16 @@
+import { useOrganizationStore } from "@/stores/organization-store";
+import {
+  assistantsValidForOrg,
+  useResolvedAssistantsStore,
+  type ResolvedAssistant,
+} from "@/stores/resolved-assistants-store";
+
+/**
+ * Resolved assistants usable under the active org. Recomputes when the
+ * assistant list or the active org changes.
+ */
+export function useValidAssistantsForActiveOrg(): ResolvedAssistant[] {
+  const assistants = useResolvedAssistantsStore.use.assistants();
+  const activeOrgId = useOrganizationStore.use.currentOrganizationId();
+  return assistantsValidForOrg(assistants, activeOrgId);
+}

--- a/apps/web/src/stores/resolved-assistants-store.test.ts
+++ b/apps/web/src/stores/resolved-assistants-store.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it } from "bun:test";
 
-import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import {
+  assistantsValidForOrg,
+  useResolvedAssistantsStore,
+  type ResolvedAssistant,
+} from "@/stores/resolved-assistants-store";
 import type { Lockfile, LockfileAssistant } from "@/runtime/local-mode-host";
 
 // A platform entry is identified by `cloud === "vellum"` and carries an
@@ -72,5 +76,48 @@ describe("upsertFromApi", () => {
     expect(entry.id).toBe("asst-platform");
     expect(entry.name).toBe("Platform (refreshed)");
     expect(entry.organizationId).toBe("org-1");
+  });
+});
+
+describe("assistantsValidForOrg", () => {
+  const local: ResolvedAssistant = {
+    id: "local",
+    isLocal: true,
+    isPlatformHosted: false,
+  };
+  const activeOrg: ResolvedAssistant = {
+    id: "active-org",
+    isLocal: false,
+    isPlatformHosted: true,
+    organizationId: "org-1",
+  };
+  const otherOrg: ResolvedAssistant = {
+    id: "other-org",
+    isLocal: false,
+    isPlatformHosted: true,
+    organizationId: "org-2",
+  };
+  const legacy: ResolvedAssistant = {
+    id: "legacy",
+    isLocal: false,
+    isPlatformHosted: true,
+  };
+
+  it("always keeps local entries", () => {
+    expect(assistantsValidForOrg([local], "org-1")).toEqual([local]);
+    expect(assistantsValidForOrg([local], null)).toEqual([local]);
+  });
+
+  it("keeps platform entries only when owned by the active org", () => {
+    const result = assistantsValidForOrg([activeOrg, otherOrg], "org-1");
+    expect(result).toEqual([activeOrg]);
+  });
+
+  it("keeps legacy entries with no org (undefined)", () => {
+    expect(assistantsValidForOrg([legacy], "org-1")).toEqual([legacy]);
+  });
+
+  it("drops cross-org platform entries", () => {
+    expect(assistantsValidForOrg([otherOrg], "org-1")).toEqual([]);
   });
 });

--- a/apps/web/src/stores/resolved-assistants-store.ts
+++ b/apps/web/src/stores/resolved-assistants-store.ts
@@ -40,6 +40,21 @@ export interface ResolvedAssistant {
   organizationId?: string;
 }
 
+/**
+ * Assistants usable under the active org: local entries (no org), legacy
+ * entries with no org (`organizationId == null`), and platform entries owned
+ * by the active org. Cross-org platform entries are dropped.
+ */
+export function assistantsValidForOrg(
+  assistants: ResolvedAssistant[],
+  activeOrgId: string | null,
+): ResolvedAssistant[] {
+  return assistants.filter(
+    (a) =>
+      a.isLocal || a.organizationId == null || a.organizationId === activeOrgId,
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Per-org platform selection persistence (localStorage)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add assistantsValidForOrg pure helper: local + active-org platform + legacy(no-org) entries, dropping cross-org platform entries
- Add useValidAssistantsForActiveOrg hook composing the store with the active org

Part of plan: assistant-selection-unify.md (PR 4 of 8)