### PR TITLE
feat(web): pass active org through replacePlatformAssistants host seam

### DIFF
--- a/apps/macos/src/main/local-mode.ts
+++ b/apps/macos/src/main/local-mode.ts
@@ -199,9 +199,9 @@ export const installLocalMode = (): void => {
 
   handle(
     "vellum:localMode:replacePlatformAssistants",
-    z.tuple([z.array(assistantRecord)]),
-    ([list]): LockfileWriteResult => {
-      const result = replacePlatformAssistants(lockfilePaths, list);
+    z.tuple([z.array(assistantRecord), z.string().optional()]),
+    ([list, organizationId]): LockfileWriteResult => {
+      const result = replacePlatformAssistants(lockfilePaths, list, organizationId);
       return result.ok
         ? { ok: true, lockfile: result.lockfile }
         : { ok: false, error: result.error };

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -456,12 +456,15 @@ export interface VellumBridge {
       activeAssistant?: string,
     ): Promise<LockfileWriteResult>;
     /**
-     * Replace every platform (`cloud === "vellum"`) assistant in the lockfile
-     * with the provided set, preserving local assistants. Resolves with the
-     * updated, stripped lockfile on success or `{ ok: false, error }`.
+     * Replace the platform (`cloud === "vellum"`) assistants in the lockfile
+     * with the provided set, preserving local assistants. When `organizationId`
+     * is given, only that org's platform entries are replaced; omitting it does
+     * the legacy full replace. Resolves with the updated, stripped lockfile on
+     * success or `{ ok: false, error }`.
      */
     replacePlatformAssistants(
       platformAssistants: Array<Record<string, unknown>>,
+      organizationId?: string,
     ): Promise<LockfileWriteResult>;
     /**
      * Retire a local assistant via the Vellum CLI's `retire`. Mirrors
@@ -836,10 +839,12 @@ const bridge: VellumBridge = {
       ) as Promise<LockfileWriteResult>,
     replacePlatformAssistants: (
       platformAssistants: Array<Record<string, unknown>>,
+      organizationId?: string,
     ) =>
       ipcRenderer.invoke(
         "vellum:localMode:replacePlatformAssistants",
         platformAssistants,
+        organizationId,
       ) as Promise<LockfileWriteResult>,
     wake: (assistantId: string) =>
       ipcRenderer.invoke("vellum:localMode:wake", assistantId) as Promise<{

--- a/apps/web/src/lib/local-mode.ts
+++ b/apps/web/src/lib/local-mode.ts
@@ -202,7 +202,10 @@ export async function syncPlatformAssistantsToLockfile(
       ...(organizationId != null && { organizationId }),
     }));
 
-  const result = await replacePlatformAssistantsHost(platformAssistants);
+  const result = await replacePlatformAssistantsHost(
+    platformAssistants,
+    organizationId,
+  );
   if (result.ok) {
     commitLockfile(result.lockfile);
   }

--- a/apps/web/src/runtime/is-electron.ts
+++ b/apps/web/src/runtime/is-electron.ts
@@ -364,6 +364,7 @@ declare global {
         ): Promise<LockfileWriteResult>;
         replacePlatformAssistants(
           platformAssistants: Array<Record<string, unknown>>,
+          organizationId?: string,
         ): Promise<LockfileWriteResult>;
         retire(assistantId: string): Promise<{ ok: boolean; error?: string }>;
         // Optional: older Electron shells predate the wake IPC channel. The

--- a/apps/web/src/runtime/local-mode-host.test.ts
+++ b/apps/web/src/runtime/local-mode-host.test.ts
@@ -183,23 +183,24 @@ describe("saveLockfileAssistantHost", () => {
 });
 
 describe("replacePlatformAssistantsHost", () => {
-  test("web/dev host POSTs the platform set with the syncPlatform flag", async () => {
+  test("web/dev host POSTs the platform set and active org with the syncPlatform flag", async () => {
     const fetchMock = mock(async () => ({
       json: async () => ({ ok: true, lockfile: {} }),
     }));
     globalThis.fetch = fetchMock as unknown as typeof fetch;
 
-    await replacePlatformAssistantsHost([{ assistantId: "p-1" }]);
+    await replacePlatformAssistantsHost([{ assistantId: "p-1" }], "org-1");
 
     const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
     expect(url).toBe("/assistant/__local/lockfile");
     expect(JSON.parse(init.body as string)).toEqual({
       syncPlatform: true,
       platformAssistants: [{ assistantId: "p-1" }],
+      organizationId: "org-1",
     });
   });
 
-  test("Electron host replaces through the bridge and never touches fetch", async () => {
+  test("Electron host replaces through the bridge with the active org and never touches fetch", async () => {
     const replacePlatformAssistants = mock(async () => ({ ok: true, lockfile: {} }));
     const fetchMock = mock(async () => {
       throw new Error("fetch must not run on the Electron branch");
@@ -207,9 +208,12 @@ describe("replacePlatformAssistantsHost", () => {
     globalThis.fetch = fetchMock as unknown as typeof fetch;
     setElectronBridge({ replacePlatformAssistants });
 
-    await replacePlatformAssistantsHost([{ assistantId: "p-1" }]);
+    await replacePlatformAssistantsHost([{ assistantId: "p-1" }], "org-1");
 
-    expect(replacePlatformAssistants).toHaveBeenCalledWith([{ assistantId: "p-1" }]);
+    expect(replacePlatformAssistants).toHaveBeenCalledWith(
+      [{ assistantId: "p-1" }],
+      "org-1",
+    );
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/runtime/local-mode-host.ts
+++ b/apps/web/src/runtime/local-mode-host.ts
@@ -154,23 +154,27 @@ export async function saveLockfileAssistantHost(
 }
 
 /**
- * Replace every platform (`cloud === "vellum"`) assistant in the lockfile with
- * the provided set, preserving local assistants. Same never-throw contract as
- * `saveLockfileAssistantHost`.
+ * Replace the platform (`cloud === "vellum"`) assistants in the lockfile with
+ * the provided set, preserving local assistants. When `organizationId` is
+ * given, only that org's platform entries are replaced — other orgs' entries
+ * are preserved; omitting it does the legacy full replace. Same never-throw
+ * contract as `saveLockfileAssistantHost`.
  */
 export async function replacePlatformAssistantsHost(
   platformAssistants: Array<Record<string, unknown>>,
+  organizationId?: string,
 ): Promise<LockfileWriteResult> {
   if (isElectron()) {
     return window.vellum!.localMode.replacePlatformAssistants(
       platformAssistants,
+      organizationId,
     );
   }
 
   const res = await fetch("/assistant/__local/lockfile", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ syncPlatform: true, platformAssistants }),
+    body: JSON.stringify({ syncPlatform: true, platformAssistants, organizationId }),
   });
   return res.json() as Promise<LockfileWriteResult>;
 }

--- a/apps/web/vite-plugin-local-mode.ts
+++ b/apps/web/vite-plugin-local-mode.ts
@@ -168,6 +168,7 @@ function lockfileMiddleware(
           result = replacePlatformAssistants(
             lockfilePaths,
             body.platformAssistants as Array<Record<string, unknown>>,
+            body.organizationId as string | undefined,
           );
         } else {
           result = upsertLockfileAssistant(

--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -458,6 +458,7 @@ async function handleLocalEndpoints(
         result = replacePlatformAssistants(
           lockfilePaths,
           body.platformAssistants as Array<Record<string, unknown>>,
+          body.organizationId as string | undefined,
         );
       } else {
         result = upsertLockfileAssistant(


### PR DESCRIPTION
## Summary
- Thread organizationId from syncPlatformAssistantsToLockfile through the host seam, Electron IPC, preload bridge, and dev middleware into replacePlatformAssistants
- The org-scoped (multi-org-preserving) replace path is now actually exercised by the app

Part of plan: assistant-selection-unify.md (PR 3 of 8)