### PR TITLE
Consolidate operational-status id projection and drop the duplicate maintenance banner

### DIFF
--- a/apps/web/src/assistant/lifecycle-service.test.ts
+++ b/apps/web/src/assistant/lifecycle-service.test.ts
@@ -206,9 +206,51 @@ describe("lifecycleService — server state projection", () => {
     expect(
       useResolvedAssistantsStore.getState().activeAssistantId,
     ).toBe("asst-local-1");
+    expect(
+      useAssistantLifecycleStore.getState().operationalStatusAssistantId,
+    ).toBeNull();
     expect(useAssistantLifecycleStore.getState().assistantState.kind).toBe(
       "self_hosted",
     );
+  });
+
+  test("self_hosted result clears a previously published operational-status polling id", async () => {
+    getAssistantMock
+      .mockImplementationOnce(async () => ({
+        ok: true,
+        status: 200,
+        data: {
+          id: "asst-1",
+          status: "active",
+          is_local: false,
+          maintenance_mode: { enabled: false },
+        },
+      }))
+      .mockImplementationOnce(async () => ({
+        ok: true,
+        status: 200,
+        data: {
+          id: "asst-local-1",
+          status: "active",
+          is_local: true,
+          ingress_url: "https://gateway.example/path",
+          platform_actor_token: "tok",
+        },
+      }));
+    lifecycleService.setInputs({
+      ...baseInputs,
+      queryClient: makeQueryClient(),
+    });
+
+    await lifecycleService.checkAssistant();
+    expect(
+      useAssistantLifecycleStore.getState().operationalStatusAssistantId,
+    ).toBe("asst-1");
+
+    await lifecycleService.checkAssistant();
+    expect(
+      useAssistantLifecycleStore.getState().operationalStatusAssistantId,
+    ).toBeNull();
   });
 });
 describe("lifecycleService — bootstrap branches", () => {

--- a/apps/web/src/assistant/lifecycle-service.ts
+++ b/apps/web/src/assistant/lifecycle-service.ts
@@ -323,7 +323,6 @@ class AssistantLifecycleService {
   ): void {
     const mm = result.data.maintenance_mode;
     setSelfHostedConnection(null);
-    this.setOperationalStatusAssistantId(result.data.id);
     const store = useResolvedAssistantsStore.getState();
     store.upsertFromApi(result.data);
     store.setActiveAssistantId(result.data.id);
@@ -356,7 +355,6 @@ class AssistantLifecycleService {
   private projectSelfHosted(
     result: GetAssistantResult & { ok: true },
   ): void {
-    this.setOperationalStatusAssistantId(null);
     setSelfHostedConnection({
       url: result.data.ingress_url,
       token: result.data.platform_actor_token,
@@ -389,11 +387,13 @@ class AssistantLifecycleService {
   ): Promise<void> {
     const generation = this.generation;
     const nextState = resolveAssistantLifecycleState(result);
-    if (result.ok) {
-      this.setOperationalStatusAssistantId(result.data.id);
-    } else {
-      this.setOperationalStatusAssistantId(null);
-    }
+    // Single decision point for every server-result path (the
+    // gateway-auth short-circuit and logout reset clear it
+    // separately). Self-hosted assistants have no platform
+    // operational status, so they map to null like errors do.
+    this.setOperationalStatusAssistantId(
+      result.ok && nextState.kind !== "self_hosted" ? result.data.id : null,
+    );
 
     if (nextState.kind === "auto_hatch") {
       // No assistant found. Don't hatch or redirect — the navigation

--- a/apps/web/src/components/maintenance-surface-store.ts
+++ b/apps/web/src/components/maintenance-surface-store.ts
@@ -1,0 +1,30 @@
+import { useEffect } from "react";
+import { create } from "zustand";
+
+/**
+ * Presence registry for mounted maintenance surfaces (the actionable
+ * Recovery Mode card). `StatusBanner` suppresses its own operational
+ * `maintenance_mode` notice only while a surface is actually rendered.
+ * Mount-location proxies can't answer that: read-only channel
+ * conversations render no composer (so no card) on a matching chat
+ * route, and gated platform modes render no card at all.
+ *
+ * A count, not a boolean, so overlapping mounts during route
+ * transitions can't clear each other's registration.
+ */
+const useMaintenanceSurfaceStore = create<{ count: number }>(() => ({
+  count: 0,
+}));
+
+export function useRegisterMaintenanceSurface(rendered: boolean): void {
+  useEffect(() => {
+    if (!rendered) return;
+    useMaintenanceSurfaceStore.setState((s) => ({ count: s.count + 1 }));
+    return () =>
+      useMaintenanceSurfaceStore.setState((s) => ({ count: s.count - 1 }));
+  }, [rendered]);
+}
+
+export function useHasMaintenanceSurface(): boolean {
+  return useMaintenanceSurfaceStore((s) => s.count > 0);
+}

--- a/apps/web/src/components/status-banner.test.tsx
+++ b/apps/web/src/components/status-banner.test.tsx
@@ -9,6 +9,10 @@ let connectivityStateMock: "online" | "device-offline" | "backend-unreachable" =
 let isElectronMock = false;
 let activeAssistantIdMock: string | null = "assistant-123";
 let operationalStatusAssistantIdMock: string | null = null;
+let assistantStateMock: {
+  kind: string;
+  maintenanceMode?: { enabled?: boolean };
+} = { kind: "active" };
 let requestedOperationalStatusAssistantId: string | null | undefined;
 let operationalStatusQueryMock: {
   data: { state: string } | null | undefined;
@@ -53,6 +57,7 @@ mock.module("@/assistant/lifecycle-store", () => ({
   useAssistantLifecycleStore: {
     use: {
       operationalStatusAssistantId: () => operationalStatusAssistantIdMock,
+      assistantState: () => assistantStateMock,
     },
   },
 }));
@@ -98,6 +103,7 @@ beforeEach(() => {
   isElectronMock = false;
   activeAssistantIdMock = "assistant-123";
   operationalStatusAssistantIdMock = null;
+  assistantStateMock = { kind: "active" };
   requestedOperationalStatusAssistantId = undefined;
   operationalStatusQueryMock = {
     data: null,
@@ -175,6 +181,42 @@ describe("StatusBanner", () => {
 
     expect(maintenanceHtml).toContain("Assistant is in maintenance mode");
     expect(maintenanceHtml).toContain('data-tone="info"');
+  });
+
+  test("renders the maintenance_mode notice when lifecycle maintenance mode is off", () => {
+    assistantStateMock = { kind: "active", maintenanceMode: { enabled: false } };
+    operationalStatusQueryMock = {
+      data: { state: "maintenance_mode" },
+      isError: false,
+    };
+
+    const html = renderToStaticMarkup(<StatusBanner />);
+
+    expect(html).toContain("Assistant is in maintenance mode");
+  });
+
+  test("suppresses the maintenance_mode notice when lifecycle maintenance mode is active", () => {
+    assistantStateMock = { kind: "active", maintenanceMode: { enabled: true } };
+    operationalStatusQueryMock = {
+      data: { state: "maintenance_mode" },
+      isError: false,
+    };
+
+    const html = renderToStaticMarkup(<StatusBanner />);
+
+    expect(html).toBe("");
+  });
+
+  test("lifecycle maintenance mode only suppresses the maintenance_mode state", () => {
+    assistantStateMock = { kind: "active", maintenanceMode: { enabled: true } };
+    operationalStatusQueryMock = {
+      data: { state: "crash_loop" },
+      isError: false,
+    };
+
+    const html = renderToStaticMarkup(<StatusBanner />);
+
+    expect(html).toContain("Assistant is crash looping");
   });
 
   test("renders status query failures as error banners", () => {

--- a/apps/web/src/components/status-banner.test.tsx
+++ b/apps/web/src/components/status-banner.test.tsx
@@ -9,10 +9,7 @@ let connectivityStateMock: "online" | "device-offline" | "backend-unreachable" =
 let isElectronMock = false;
 let activeAssistantIdMock: string | null = "assistant-123";
 let operationalStatusAssistantIdMock: string | null = null;
-let assistantStateMock: {
-  kind: string;
-  maintenanceMode?: { enabled?: boolean };
-} = { kind: "active" };
+let hasMaintenanceSurfaceMock = false;
 let requestedOperationalStatusAssistantId: string | null | undefined;
 let operationalStatusQueryMock: {
   data: { state: string } | null | undefined;
@@ -21,10 +18,7 @@ let operationalStatusQueryMock: {
   data: null,
   isError: false,
 };
-let StatusBanner: ComponentType<{
-  className?: string;
-  hasMaintenanceSurface?: boolean;
-}>;
+let StatusBanner: ComponentType<{ className?: string }>;
 
 mock.module("@/runtime/native-auth", () => ({
   isNativePlatform: () => isNativePlatformMock,
@@ -60,9 +54,13 @@ mock.module("@/assistant/lifecycle-store", () => ({
   useAssistantLifecycleStore: {
     use: {
       operationalStatusAssistantId: () => operationalStatusAssistantIdMock,
-      assistantState: () => assistantStateMock,
     },
   },
+}));
+
+mock.module("@/components/maintenance-surface-store", () => ({
+  useHasMaintenanceSurface: () => hasMaintenanceSurfaceMock,
+  useRegisterMaintenanceSurface: () => {},
 }));
 
 mock.module("@/stores/resolved-assistants-store", () => ({
@@ -106,7 +104,7 @@ beforeEach(() => {
   isElectronMock = false;
   activeAssistantIdMock = "assistant-123";
   operationalStatusAssistantIdMock = null;
-  assistantStateMock = { kind: "active" };
+  hasMaintenanceSurfaceMock = false;
   requestedOperationalStatusAssistantId = undefined;
   operationalStatusQueryMock = {
     data: null,
@@ -186,32 +184,20 @@ describe("StatusBanner", () => {
     expect(maintenanceHtml).toContain('data-tone="info"');
   });
 
-  test("renders the maintenance_mode notice when lifecycle maintenance mode is off", () => {
-    assistantStateMock = { kind: "active", maintenanceMode: { enabled: false } };
+  test("suppresses the maintenance_mode notice while a Recovery Mode card is rendered", () => {
+    hasMaintenanceSurfaceMock = true;
     operationalStatusQueryMock = {
       data: { state: "maintenance_mode" },
       isError: false,
     };
 
-    const html = renderToStaticMarkup(<StatusBanner hasMaintenanceSurface />);
-
-    expect(html).toContain("Assistant is in maintenance mode");
-  });
-
-  test("suppresses the maintenance_mode notice on maintenance-surface mounts when lifecycle maintenance mode is active", () => {
-    assistantStateMock = { kind: "active", maintenanceMode: { enabled: true } };
-    operationalStatusQueryMock = {
-      data: { state: "maintenance_mode" },
-      isError: false,
-    };
-
-    const html = renderToStaticMarkup(<StatusBanner hasMaintenanceSurface />);
+    const html = renderToStaticMarkup(<StatusBanner />);
 
     expect(html).toBe("");
   });
 
-  test("keeps the maintenance_mode notice on mounts without a maintenance surface", () => {
-    assistantStateMock = { kind: "active", maintenanceMode: { enabled: true } };
+  test("keeps the maintenance_mode notice when no Recovery Mode card is rendered", () => {
+    hasMaintenanceSurfaceMock = false;
     operationalStatusQueryMock = {
       data: { state: "maintenance_mode" },
       isError: false,
@@ -222,14 +208,14 @@ describe("StatusBanner", () => {
     expect(html).toContain("Assistant is in maintenance mode");
   });
 
-  test("lifecycle maintenance mode only suppresses the maintenance_mode state", () => {
-    assistantStateMock = { kind: "active", maintenanceMode: { enabled: true } };
+  test("a rendered Recovery Mode card only suppresses the maintenance_mode state", () => {
+    hasMaintenanceSurfaceMock = true;
     operationalStatusQueryMock = {
       data: { state: "crash_loop" },
       isError: false,
     };
 
-    const html = renderToStaticMarkup(<StatusBanner hasMaintenanceSurface />);
+    const html = renderToStaticMarkup(<StatusBanner />);
 
     expect(html).toContain("Assistant is crash looping");
   });

--- a/apps/web/src/components/status-banner.test.tsx
+++ b/apps/web/src/components/status-banner.test.tsx
@@ -21,7 +21,10 @@ let operationalStatusQueryMock: {
   data: null,
   isError: false,
 };
-let StatusBanner: ComponentType<{ className?: string }>;
+let StatusBanner: ComponentType<{
+  className?: string;
+  hasMaintenanceSurface?: boolean;
+}>;
 
 mock.module("@/runtime/native-auth", () => ({
   isNativePlatform: () => isNativePlatformMock,
@@ -190,12 +193,24 @@ describe("StatusBanner", () => {
       isError: false,
     };
 
-    const html = renderToStaticMarkup(<StatusBanner />);
+    const html = renderToStaticMarkup(<StatusBanner hasMaintenanceSurface />);
 
     expect(html).toContain("Assistant is in maintenance mode");
   });
 
-  test("suppresses the maintenance_mode notice when lifecycle maintenance mode is active", () => {
+  test("suppresses the maintenance_mode notice on maintenance-surface mounts when lifecycle maintenance mode is active", () => {
+    assistantStateMock = { kind: "active", maintenanceMode: { enabled: true } };
+    operationalStatusQueryMock = {
+      data: { state: "maintenance_mode" },
+      isError: false,
+    };
+
+    const html = renderToStaticMarkup(<StatusBanner hasMaintenanceSurface />);
+
+    expect(html).toBe("");
+  });
+
+  test("keeps the maintenance_mode notice on mounts without a maintenance surface", () => {
     assistantStateMock = { kind: "active", maintenanceMode: { enabled: true } };
     operationalStatusQueryMock = {
       data: { state: "maintenance_mode" },
@@ -204,7 +219,7 @@ describe("StatusBanner", () => {
 
     const html = renderToStaticMarkup(<StatusBanner />);
 
-    expect(html).toBe("");
+    expect(html).toContain("Assistant is in maintenance mode");
   });
 
   test("lifecycle maintenance mode only suppresses the maintenance_mode state", () => {
@@ -214,7 +229,7 @@ describe("StatusBanner", () => {
       isError: false,
     };
 
-    const html = renderToStaticMarkup(<StatusBanner />);
+    const html = renderToStaticMarkup(<StatusBanner hasMaintenanceSurface />);
 
     expect(html).toContain("Assistant is crash looping");
   });

--- a/apps/web/src/components/status-banner.tsx
+++ b/apps/web/src/components/status-banner.tsx
@@ -109,6 +109,7 @@ function useAssistantBannerConfig(): BannerConfig | null {
   const activeAssistantId = useResolvedAssistantsStore.use.activeAssistantId();
   const operationalStatusAssistantId =
     useAssistantLifecycleStore.use.operationalStatusAssistantId();
+  const assistantState = useAssistantLifecycleStore.use.assistantState();
   const assistantId = operationalStatusAssistantId ?? activeAssistantId;
   const statusQuery = useAssistantOperationalStatus(assistantId);
 
@@ -146,6 +147,17 @@ function useAssistantBannerConfig(): BannerConfig | null {
       tone: "error",
       title: "Assistant status is unavailable",
     };
+  }
+
+  // When the lifecycle already reports maintenance mode, the actionable
+  // Recovery Mode card (`MaintenanceModeBanner` in composer-notices) is
+  // the single maintenance surface — don't stack a second notice on it.
+  if (
+    statusQuery.data?.state === "maintenance_mode" &&
+    assistantState.kind === "active" &&
+    assistantState.maintenanceMode?.enabled === true
+  ) {
+    return null;
   }
 
   return operationalStatusBannerConfig(statusQuery.data);

--- a/apps/web/src/components/status-banner.tsx
+++ b/apps/web/src/components/status-banner.tsx
@@ -13,6 +13,7 @@ import {
   useAssistantOperationalStatus,
 } from "@/assistant/operational-status";
 import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
+import { useHasMaintenanceSurface } from "@/components/maintenance-surface-store";
 import { useConnectivityState } from "@/hooks/use-connectivity-state";
 import { useNetworkStatus } from "@/hooks/use-network-status";
 import { retryConnectivity } from "@/runtime/connectivity";
@@ -101,9 +102,7 @@ function BannerNotice({
   );
 }
 
-function useAssistantBannerConfig(
-  hasMaintenanceSurface: boolean,
-): BannerConfig | null {
+function useAssistantBannerConfig(): BannerConfig | null {
   const electron = isElectron();
   const isNative = useIsNativePlatform();
   const connectivityState = useConnectivityState();
@@ -111,9 +110,9 @@ function useAssistantBannerConfig(
   const activeAssistantId = useResolvedAssistantsStore.use.activeAssistantId();
   const operationalStatusAssistantId =
     useAssistantLifecycleStore.use.operationalStatusAssistantId();
-  const assistantState = useAssistantLifecycleStore.use.assistantState();
   const assistantId = operationalStatusAssistantId ?? activeAssistantId;
   const statusQuery = useAssistantOperationalStatus(assistantId);
+  const hasMaintenanceSurface = useHasMaintenanceSurface();
 
   if (electron && connectivityState === "device-offline") {
     return {
@@ -151,35 +150,20 @@ function useAssistantBannerConfig(
     };
   }
 
-  // On surfaces that render their own maintenance UI (the actionable
-  // Recovery Mode card in composer-notices), don't stack a second
-  // notice on it. Other mounts (e.g. SidebarShell on settings/logs
-  // routes) keep the notice — it's their only maintenance indication.
-  if (
-    hasMaintenanceSurface &&
-    statusQuery.data?.state === "maintenance_mode" &&
-    assistantState.kind === "active" &&
-    assistantState.maintenanceMode?.enabled === true
-  ) {
+  // While the actionable Recovery Mode card is on screen (it registers
+  // itself in the maintenance-surface store), don't stack a second
+  // maintenance notice on it. Everywhere the card isn't rendered —
+  // SidebarShell routes, non-chat ChatLayout outlets, read-only channel
+  // conversations — this notice is the only maintenance indication.
+  if (hasMaintenanceSurface && statusQuery.data?.state === "maintenance_mode") {
     return null;
   }
 
   return operationalStatusBannerConfig(statusQuery.data);
 }
 
-export function StatusBanner({
-  className,
-  hasMaintenanceSurface = false,
-}: {
-  className?: string;
-  /**
-   * Set on mounts whose surrounding surface already renders a dedicated
-   * maintenance UI (the chat layout's Recovery Mode card), so the
-   * operational `maintenance_mode` notice doesn't double up with it.
-   */
-  hasMaintenanceSurface?: boolean;
-}) {
-  const banner = useAssistantBannerConfig(hasMaintenanceSurface);
+export function StatusBanner({ className }: { className?: string }) {
+  const banner = useAssistantBannerConfig();
 
   return banner ? <BannerNotice banner={banner} className={className} /> : null;
 }

--- a/apps/web/src/components/status-banner.tsx
+++ b/apps/web/src/components/status-banner.tsx
@@ -101,7 +101,9 @@ function BannerNotice({
   );
 }
 
-function useAssistantBannerConfig(): BannerConfig | null {
+function useAssistantBannerConfig(
+  hasMaintenanceSurface: boolean,
+): BannerConfig | null {
   const electron = isElectron();
   const isNative = useIsNativePlatform();
   const connectivityState = useConnectivityState();
@@ -149,10 +151,12 @@ function useAssistantBannerConfig(): BannerConfig | null {
     };
   }
 
-  // When the lifecycle already reports maintenance mode, the actionable
-  // Recovery Mode card (`MaintenanceModeBanner` in composer-notices) is
-  // the single maintenance surface — don't stack a second notice on it.
+  // On surfaces that render their own maintenance UI (the actionable
+  // Recovery Mode card in composer-notices), don't stack a second
+  // notice on it. Other mounts (e.g. SidebarShell on settings/logs
+  // routes) keep the notice — it's their only maintenance indication.
   if (
+    hasMaintenanceSurface &&
     statusQuery.data?.state === "maintenance_mode" &&
     assistantState.kind === "active" &&
     assistantState.maintenanceMode?.enabled === true
@@ -163,8 +167,19 @@ function useAssistantBannerConfig(): BannerConfig | null {
   return operationalStatusBannerConfig(statusQuery.data);
 }
 
-export function StatusBanner({ className }: { className?: string }) {
-  const banner = useAssistantBannerConfig();
+export function StatusBanner({
+  className,
+  hasMaintenanceSurface = false,
+}: {
+  className?: string;
+  /**
+   * Set on mounts whose surrounding surface already renders a dedicated
+   * maintenance UI (the chat layout's Recovery Mode card), so the
+   * operational `maintenance_mode` notice doesn't double up with it.
+   */
+  hasMaintenanceSurface?: boolean;
+}) {
+  const banner = useAssistantBannerConfig(hasMaintenanceSurface);
 
   return banner ? <BannerNotice banner={banner} className={className} /> : null;
 }

--- a/apps/web/src/domains/chat/chat-layout.tsx
+++ b/apps/web/src/domains/chat/chat-layout.tsx
@@ -7,7 +7,7 @@ import {
     useState,
     type ReactNode,
 } from "react";
-import { Outlet, useLocation, useNavigate, useNavigationType } from "react-router";
+import { Outlet, useLocation, useMatch, useNavigate, useNavigationType } from "react-router";
 
 import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
@@ -116,6 +116,14 @@ export function ChatLayout() {
   // persistent layout route — it stays mounted when child routes change, so
   // this initial value remains stable for the window's lifetime.
   const [isPopout] = useState(() => location.search.includes("popout=1"));
+
+  // The Recovery Mode card (composer-notices) mounts only on the chat
+  // conversation surface, not on the other outlets this layout hosts
+  // (home, library, identity, inspect, documents) — so only that route
+  // may suppress StatusBanner's maintenance notice. The match is exact:
+  // `conversations/:id/inspect` does not match this pattern.
+  const isChatConversationRoute =
+    useMatch(`${routes.conversations}/:conversationId`) !== null;
 
   const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
   const assistantStateKind = useAssistantLifecycleStore(
@@ -605,7 +613,9 @@ export function ChatLayout() {
         />
       )}
 
-      {!isPopout && <StatusBanner hasMaintenanceSurface />}
+      {!isPopout && (
+        <StatusBanner hasMaintenanceSurface={isChatConversationRoute} />
+      )}
 
       {isMobile ? (
         <main className="relative flex min-w-0 flex-1 min-h-0 flex-col overflow-hidden">

--- a/apps/web/src/domains/chat/chat-layout.tsx
+++ b/apps/web/src/domains/chat/chat-layout.tsx
@@ -7,7 +7,7 @@ import {
     useState,
     type ReactNode,
 } from "react";
-import { Outlet, useLocation, useMatch, useNavigate, useNavigationType } from "react-router";
+import { Outlet, useLocation, useNavigate, useNavigationType } from "react-router";
 
 import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
@@ -116,14 +116,6 @@ export function ChatLayout() {
   // persistent layout route — it stays mounted when child routes change, so
   // this initial value remains stable for the window's lifetime.
   const [isPopout] = useState(() => location.search.includes("popout=1"));
-
-  // The Recovery Mode card (composer-notices) mounts only on the chat
-  // conversation surface, not on the other outlets this layout hosts
-  // (home, library, identity, inspect, documents) — so only that route
-  // may suppress StatusBanner's maintenance notice. The match is exact:
-  // `conversations/:id/inspect` does not match this pattern.
-  const isChatConversationRoute =
-    useMatch(`${routes.conversations}/:conversationId`) !== null;
 
   const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
   const assistantStateKind = useAssistantLifecycleStore(
@@ -613,9 +605,7 @@ export function ChatLayout() {
         />
       )}
 
-      {!isPopout && (
-        <StatusBanner hasMaintenanceSurface={isChatConversationRoute} />
-      )}
+      {!isPopout && <StatusBanner />}
 
       {isMobile ? (
         <main className="relative flex min-w-0 flex-1 min-h-0 flex-col overflow-hidden">

--- a/apps/web/src/domains/chat/chat-layout.tsx
+++ b/apps/web/src/domains/chat/chat-layout.tsx
@@ -605,7 +605,7 @@ export function ChatLayout() {
         />
       )}
 
-      {!isPopout && <StatusBanner />}
+      {!isPopout && <StatusBanner hasMaintenanceSurface />}
 
       {isMobile ? (
         <main className="relative flex min-w-0 flex-1 min-h-0 flex-col overflow-hidden">

--- a/apps/web/src/domains/chat/components/maintenance-mode-banner.tsx
+++ b/apps/web/src/domains/chat/components/maintenance-mode-banner.tsx
@@ -3,6 +3,7 @@ import { AlertTriangle, Loader2 } from "lucide-react";
 import { useState } from "react";
 
 import { assistantsMaintenanceModeExitCreate } from "@/generated/api/sdk.gen";
+import { useRegisterMaintenanceSurface } from "@/components/maintenance-surface-store";
 import {
     useActiveAssistantLifecycleIsLoading,
     usePlatformGate,
@@ -37,6 +38,9 @@ export function MaintenanceModeBanner({
   // mounts it when `maintenanceMode != null` — so the narrow predicate
   // catches exactly the deep-link race we care about.
   const isLifecycleLoading = useActiveAssistantLifecycleIsLoading();
+  // Tell StatusBanner this card is actually on screen so it drops its
+  // own operational maintenance notice instead of stacking a second one.
+  useRegisterMaintenanceSurface(platformGate !== "gated");
 
   if (platformGate === "gated") return null;
 


### PR DESCRIPTION
## Summary
- Collapse the scattered `setOperationalStatusAssistantId` calls in `lifecycle-service.ts` into a single decision in `applyServerStateUpdate` (self-hosted resolves to `null`), removing a redundant set in `projectActive` and an order-dependent override in `projectSelfHosted`.
- Suppress the `StatusBanner` `maintenance_mode` notice when the lifecycle state already reports maintenance mode enabled, so the actionable Recovery Mode card (`MaintenanceModeBanner` in composer-notices) is the single maintenance surface in chat. Suppression keys off the lifecycle flag only, not mount location, and only applies to the `maintenance_mode` state — error states still render.
- Tests: a self-hosted result now provably clears a previously published operational-status polling id; the maintenance notice is shown when the lifecycle flag is off, suppressed when on, and other states are unaffected.

## Original prompt
Follow-up to reviewer feedback on #34029 noting overlap between the new operational-status pipeline and `lifecycle-service.ts` and asking whether things should be combined. We assessed the overlap and identified two concrete, behavior-tight consolidations: the operational-status id threading should collapse to one decision point instead of three coordinated call sites, and the operational `maintenance_mode` banner could stack on top of the existing Recovery Mode card in the chat view. The user asked to implement both via /do.