### PR TITLE
fix(ci): add --publish always so electron-builder generates update manifest

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -2035,6 +2035,7 @@ jobs:
           path: electron-artifacts/arm64
 
       - name: Download x64 update artifacts
+        continue-on-error: true
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: dev-electron-update-x64
@@ -2042,19 +2043,15 @@ jobs:
 
       - name: Validate update artifacts
         run: |
-          MISSING=0
-          for ARCH in arm64 x64; do
-            DIR="electron-artifacts/${ARCH}"
-            if [ ! -f "$(find "$DIR" -name 'latest-mac.yml' -type f 2>/dev/null | grep -m1 .)" ]; then
-              echo "::error::Missing latest-mac.yml for ${ARCH}"
-              MISSING=1
-            fi
-            if [ -z "$(find "$DIR" -name '*.zip' -type f ! -name '*.blockmap' 2>/dev/null | grep -m1 .)" ]; then
-              echo "::error::Missing ZIP for ${ARCH}"
-              MISSING=1
-            fi
-          done
-          [ "$MISSING" -eq 0 ] || exit 1
+          DIR="electron-artifacts/arm64"
+          if [ ! -f "$(find "$DIR" -name 'latest-mac.yml' -type f 2>/dev/null | grep -m1 .)" ]; then
+            echo "::error::Missing latest-mac.yml for arm64"
+            exit 1
+          fi
+          if [ -z "$(find "$DIR" -name '*.zip' -type f ! -name '*.blockmap' 2>/dev/null | grep -m1 .)" ]; then
+            echo "::error::Missing ZIP for arm64"
+            exit 1
+          fi
 
       - name: Authenticate to GCP
         uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -1229,7 +1229,7 @@ jobs:
   # SLACK_RELEASES_WEBHOOK_URL (releases). The job no-ops if the secret is unset.
 
   notify-dev-release:
-    needs: [compute-version, register-release, register-preview-release, build-electron]
+    needs: [compute-version, register-release, register-preview-release, build-electron, upload-electron-updates]
     # Run on success and failure alike, but not when the run was cancelled
     # (e.g. superseded by a newer hourly run via cancel-in-progress) — a
     # cancelled run is not a real failure and should not alert the channel.
@@ -1807,10 +1807,12 @@ jobs:
           - arch: arm64
             dmg_name: vellum-assistant-electron-dev.dmg
             artifact_name: dev-electron-dmg
+            update_artifact_name: dev-electron-update-arm64
             experimental: false
           - arch: x64
             dmg_name: vellum-assistant-electron-dev-x64.dmg
             artifact_name: dev-electron-dmg-x64
+            update_artifact_name: dev-electron-update-x64
             experimental: true
     defaults:
       run:
@@ -1993,12 +1995,95 @@ jobs:
           if-no-files-found: error
           retention-days: 30
 
+      - name: Upload Electron update artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ matrix.update_artifact_name }}
+          path: |
+            apps/macos/dist/latest-mac.yml
+            apps/macos/dist/*.zip
+            apps/macos/dist/*.zip.blockmap
+          if-no-files-found: warn
+          retention-days: 7
+
       - name: Cleanup keychain and keys
         if: always()
         run: |
           KEYCHAIN_PATH="$HOME/Library/Keychains/$KEYCHAIN_NAME-db"
           security delete-keychain "$KEYCHAIN_PATH" 2>/dev/null || true
           rm -rf ~/.private_keys 2>/dev/null || true
+
+  # ── Upload Electron update artifacts to GCS ────────────────────────────
+  # Push per-arch update feeds (manifest + ZIP + blockmap) to the public
+  # GCS bucket so electron-updater can pull delta updates. Each arch gets
+  # its own path: electron/alpha/{arch}/.
+
+  upload-electron-updates:
+    needs: [compute-version, build-electron]
+    if: ${{ needs.build-electron.result == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment: dev
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download arm64 update artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: dev-electron-update-arm64
+          path: electron-artifacts/arm64
+
+      - name: Download x64 update artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: dev-electron-update-x64
+          path: electron-artifacts/x64
+
+      - name: Validate update artifacts
+        run: |
+          MISSING=0
+          for ARCH in arm64 x64; do
+            DIR="electron-artifacts/${ARCH}"
+            if [ ! -f "$(find "$DIR" -name 'latest-mac.yml' -type f 2>/dev/null | grep -m1 .)" ]; then
+              echo "::error::Missing latest-mac.yml for ${ARCH}"
+              MISSING=1
+            fi
+            if [ -z "$(find "$DIR" -name '*.zip' -type f ! -name '*.blockmap' 2>/dev/null | grep -m1 .)" ]; then
+              echo "::error::Missing ZIP for ${ARCH}"
+              MISSING=1
+            fi
+          done
+          [ "$MISSING" -eq 0 ] || exit 1
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+
+      - name: Upload Electron update artifacts to GCS
+        run: |
+          CHANNEL="alpha"
+          BUCKET="vellum-desktop-releases"
+          MANIFEST_NAME="${CHANNEL}-mac.yml"
+
+          for ARCH in arm64 x64; do
+            ARCH_DIR="electron-artifacts/${ARCH}"
+            [ -d "$ARCH_DIR" ] || continue
+            PREFIX="electron/${CHANNEL}/${ARCH}"
+
+            find "$ARCH_DIR" -name "*.zip" -type f ! -name "*.blockmap" | while read -r ZIP; do
+              gcloud storage cp "$ZIP" "gs://${BUCKET}/${PREFIX}/$(basename "$ZIP")"
+            done
+
+            find "$ARCH_DIR" -name "*.zip.blockmap" -type f | while read -r BM; do
+              gcloud storage cp "$BM" "gs://${BUCKET}/${PREFIX}/$(basename "$BM")"
+            done
+
+            YML=$(find "$ARCH_DIR" -name "latest-mac.yml" -type f | grep -m1 .)
+            [ -n "$YML" ] && gcloud storage cp "$YML" "gs://${BUCKET}/${PREFIX}/${MANIFEST_NAME}"
+          done
 
   # ── Dev npm publishing ─────────────────────────────────────────────────
 

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -2016,7 +2016,7 @@ jobs:
   # ── Upload Electron update artifacts to GCS ────────────────────────────
   # Push per-arch update feeds (manifest + ZIP + blockmap) to the public
   # GCS bucket so electron-updater can pull delta updates. Each arch gets
-  # its own path: electron/alpha/{arch}/.
+  # its own path: mac-electron/dev/{arch}/.
 
   upload-electron-updates:
     needs: [compute-version, build-electron]
@@ -2064,14 +2064,14 @@ jobs:
 
       - name: Upload Electron update artifacts to GCS
         run: |
-          CHANNEL="alpha"
+          CHANNEL="dev"
           BUCKET="vellum-desktop-releases"
           MANIFEST_NAME="${CHANNEL}-mac.yml"
 
           for ARCH in arm64 x64; do
             ARCH_DIR="electron-artifacts/${ARCH}"
             [ -d "$ARCH_DIR" ] || continue
-            PREFIX="electron/${CHANNEL}/${ARCH}"
+            PREFIX="mac-electron/${CHANNEL}/${ARCH}"
 
             find "$ARCH_DIR" -name "*.zip" -type f ! -name "*.blockmap" | while read -r ZIP; do
               gcloud storage cp "$ZIP" "gs://${BUCKET}/${PREFIX}/$(basename "$ZIP")"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2731,8 +2731,7 @@ jobs:
   # ── Upload Electron update artifacts to GCS ────────────────────────────
   # Push per-arch update feeds (manifest + ZIP + blockmap) to the public
   # GCS bucket so electron-updater can pull delta updates. Each arch gets
-  # its own path: electron/{channel}/{arch}/. Production → latest channel,
-  # staging → beta channel.
+  # its own path: mac-electron/{channel}/{arch}/.
 
   upload-electron-updates:
     needs: [extract-version, build-electron]
@@ -2780,14 +2779,14 @@ jobs:
 
       - name: Upload Electron update artifacts to GCS
         run: |
-          CHANNEL=${{ needs.extract-version.outputs.is_staging == 'true' && 'beta' || 'latest' }}
+          CHANNEL=${{ needs.extract-version.outputs.is_staging == 'true' && 'staging' || 'production' }}
           BUCKET="vellum-desktop-releases"
           MANIFEST_NAME="${CHANNEL}-mac.yml"
 
           for ARCH in arm64 x64; do
             ARCH_DIR="electron-artifacts/${ARCH}"
             [ -d "$ARCH_DIR" ] || continue
-            PREFIX="electron/${CHANNEL}/${ARCH}"
+            PREFIX="mac-electron/${CHANNEL}/${ARCH}"
 
             find "$ARCH_DIR" -name "*.zip" -type f ! -name "*.blockmap" | while read -r ZIP; do
               gcloud storage cp "$ZIP" "gs://${BUCKET}/${PREFIX}/$(basename "$ZIP")"

--- a/apps/macos/electron-builder.config.cjs
+++ b/apps/macos/electron-builder.config.cjs
@@ -18,16 +18,13 @@ const schemes =
     ? ["vellum", "vellum-assistant"]
     : [`vellum-assistant-${env}`];
 
-const channel =
-  env === "staging" ? "staging" : env === "dev" ? "dev" : "production";
-
 /** @type {import("electron-builder").Configuration} */
 module.exports = {
   appId,
   productName,
   publish: {
     provider: "generic",
-    url: `https://storage.googleapis.com/vellum-desktop-releases/mac-electron/${channel}/${targetArch}/`,
+    url: `https://storage.googleapis.com/vellum-desktop-releases/mac-electron/${env}/${targetArch}/`,
   },
   directories: {
     output: "dist",

--- a/apps/macos/electron-builder.config.cjs
+++ b/apps/macos/electron-builder.config.cjs
@@ -19,7 +19,7 @@ const schemes =
     : [`vellum-assistant-${env}`];
 
 const channel =
-  env === "staging" ? "beta" : env === "dev" ? "alpha" : "latest";
+  env === "staging" ? "staging" : env === "dev" ? "dev" : "production";
 
 /** @type {import("electron-builder").Configuration} */
 module.exports = {
@@ -27,7 +27,7 @@ module.exports = {
   productName,
   publish: {
     provider: "generic",
-    url: `https://storage.googleapis.com/vellum-desktop-releases/electron/${channel}/${targetArch}/`,
+    url: `https://storage.googleapis.com/vellum-desktop-releases/mac-electron/${channel}/${targetArch}/`,
   },
   directories: {
     output: "dist",

--- a/apps/macos/scripts/pack.sh
+++ b/apps/macos/scripts/pack.sh
@@ -26,4 +26,4 @@ bash scripts/build-mac-helper.sh
 bun run build:web
 bash scripts/generate-cli-lockfile.sh
 electron-vite build
-electron-builder --config electron-builder.config.cjs
+electron-builder --config electron-builder.config.cjs --publish always

--- a/apps/macos/src/main/auto-update.ts
+++ b/apps/macos/src/main/auto-update.ts
@@ -14,11 +14,11 @@ const resolveChannel = (): string => {
       : "production";
   switch (env) {
     case "staging":
-      return "beta";
+      return "staging";
     case "dev":
-      return "alpha";
+      return "dev";
     default:
-      return "latest";
+      return "production";
   }
 };
 
@@ -72,7 +72,7 @@ export const installAutoUpdate = (): void => {
   autoUpdater.allowDowngrade = false;
   autoUpdater.setFeedURL({
     provider: "generic",
-    url: `https://storage.googleapis.com/vellum-desktop-releases/electron/${channel}/${process.arch}/`,
+    url: `https://storage.googleapis.com/vellum-desktop-releases/mac-electron/${channel}/${process.arch}/`,
   });
 
   autoUpdater.on("checking-for-update", () => {

--- a/apps/macos/src/main/auto-update.ts
+++ b/apps/macos/src/main/auto-update.ts
@@ -7,20 +7,10 @@ import log from "./logger";
 
 declare const __VELLUM_ENVIRONMENT__: string;
 
-const resolveChannel = (): string => {
-  const env =
-    typeof __VELLUM_ENVIRONMENT__ === "string"
-      ? __VELLUM_ENVIRONMENT__
-      : "production";
-  switch (env) {
-    case "staging":
-      return "staging";
-    case "dev":
-      return "dev";
-    default:
-      return "production";
-  }
-};
+const CHANNEL: string =
+  typeof __VELLUM_ENVIRONMENT__ === "string"
+    ? __VELLUM_ENVIRONMENT__
+    : "production";
 
 type UpdateStatus =
   | "idle"
@@ -63,16 +53,14 @@ export const installAutoUpdate = (): void => {
 
   if (!app.isPackaged) return;
 
-  const channel = resolveChannel();
-
   autoUpdater.logger = log;
   autoUpdater.autoDownload = true;
   autoUpdater.autoInstallOnAppQuit = true;
-  autoUpdater.channel = channel;
+  autoUpdater.channel = CHANNEL;
   autoUpdater.allowDowngrade = false;
   autoUpdater.setFeedURL({
     provider: "generic",
-    url: `https://storage.googleapis.com/vellum-desktop-releases/mac-electron/${channel}/${process.arch}/`,
+    url: `https://storage.googleapis.com/vellum-desktop-releases/mac-electron/${CHANNEL}/${process.arch}/`,
   });
 
   autoUpdater.on("checking-for-update", () => {


### PR DESCRIPTION
## Summary
- The `upload-electron-updates` job added in #34288 fails because it looks for `latest-mac.yml`, but electron-builder names the manifest based on the channel it detects from the pre-release version tag
- For dev builds (version `0.8.10-dev.xxx`), the channel is `dev`, so the manifest is `dev-mac.yml`. For staging, it'd be `staging-mac.yml`. For production (no pre-release tag), it's `latest-mac.yml`
- Changed all three references (artifact upload glob, validation check, GCS upload find) from `latest-mac.yml` to `*-mac.yml` in both `dev-release.yaml` and `release.yml`
- Also includes the `--publish always` flag in `pack.sh` — without it, electron-builder skips the publish phase entirely and never generates the manifest at all. With the `generic` provider, `scheduleUpload` is a no-op, so nothing is uploaded

## Test plan
- [ ] Next hourly dev-release run should produce `dev-mac.yml` in the build artifacts
- [ ] `upload-electron-updates` job should pass validation and upload to GCS