### PR TITLE
feat(web): reconcile the local selection cache against the lockfile

### DIFF
--- a/apps/web/src/lib/local-mode.test.ts
+++ b/apps/web/src/lib/local-mode.test.ts
@@ -121,6 +121,17 @@ describe("reconcileSelectedAssistant", () => {
       localStorage.getItem(SELECTED_ASSISTANT_STORAGE_KEY),
     ).toBeNull();
   });
+
+  test("a transient empty-lockfile read does not clear the selection", () => {
+    // No cached lockfile and nothing persisted → getLockfile() hits its empty
+    // fallback (setCachedLockfile), which must NOT reconcile. Otherwise a boot/
+    // read failure would wrongly drop a still-valid selection.
+    setSelectedAssistantId("local-a");
+
+    getLockfile();
+
+    expect(localStorage.getItem(SELECTED_ASSISTANT_STORAGE_KEY)).toBe("local-a");
+  });
 });
 
 describe("getLockfile persisted-storage read", () => {

--- a/apps/web/src/lib/local-mode.test.ts
+++ b/apps/web/src/lib/local-mode.test.ts
@@ -5,13 +5,17 @@ import {
   getLocalAssistants,
   getLockfile,
   getPlatformAssistants,
+  getSelectedAssistant,
   isLocalAssistant,
   isPlatformAssistant,
+  reconcileSelectedAssistant,
+  setSelectedAssistantId,
 } from "@/lib/local-mode";
 import type { Lockfile, LockfileAssistant } from "@/runtime/local-mode-host";
 import { useLockfileStore } from "@/stores/lockfile-store";
 
 const LOCKFILE_STORAGE_KEY = "vellum:local:lockfile";
+const SELECTED_ASSISTANT_STORAGE_KEY = "vellum:local:selectedAssistantId";
 
 const localA: LockfileAssistant = {
   assistantId: "local-a",
@@ -37,6 +41,7 @@ function setLockfile(lockfile: Lockfile): void {
 afterEach(() => {
   useLockfileStore.setState({ lockfile: null });
   localStorage.removeItem(LOCKFILE_STORAGE_KEY);
+  localStorage.removeItem(SELECTED_ASSISTANT_STORAGE_KEY);
 });
 
 describe("assistant classification", () => {
@@ -81,6 +86,40 @@ describe("getActiveAssistant", () => {
   test("does not bind to the first entry when a later one is active", () => {
     setLockfile({ assistants: [localA, localB], activeAssistant: "local-b" });
     expect(getActiveAssistant()).not.toBe(localA);
+  });
+});
+
+describe("reconcileSelectedAssistant", () => {
+  test("clears a stale selection whose id is absent from the lockfile", () => {
+    setLockfile({ assistants: [localA], activeAssistant: "local-a" });
+    setSelectedAssistantId("local-b");
+
+    reconcileSelectedAssistant();
+
+    expect(
+      localStorage.getItem(SELECTED_ASSISTANT_STORAGE_KEY),
+    ).toBeNull();
+    expect(getSelectedAssistant()).toBe(localA);
+  });
+
+  test("preserves a selection that is still present in the lockfile", () => {
+    setLockfile({ assistants: [localA, localB], activeAssistant: "local-a" });
+    setSelectedAssistantId("local-b");
+
+    reconcileSelectedAssistant();
+
+    expect(localStorage.getItem(SELECTED_ASSISTANT_STORAGE_KEY)).toBe("local-b");
+    expect(getSelectedAssistant()).toBe(localB);
+  });
+
+  test("is a no-op when there is no tab-local selection", () => {
+    setLockfile({ assistants: [localA], activeAssistant: "local-a" });
+
+    reconcileSelectedAssistant();
+
+    expect(
+      localStorage.getItem(SELECTED_ASSISTANT_STORAGE_KEY),
+    ).toBeNull();
   });
 });
 

--- a/apps/web/src/lib/local-mode.ts
+++ b/apps/web/src/lib/local-mode.ts
@@ -50,8 +50,12 @@ export type {
 // changes; this module owns the transport and is the only writer.
 const getCachedLockfile = (): Lockfile | null =>
   useLockfileStore.getState().lockfile;
-const setCachedLockfile = (data: Lockfile): void =>
+const setCachedLockfile = (data: Lockfile): void => {
   useLockfileStore.getState().setLockfile(data);
+  // Single chokepoint for every lockfile update — reconcile here so a removed
+  // assistant never lingers as the tab selection.
+  reconcileSelectedAssistant();
+};
 
 const EMPTY_LOCKFILE: Lockfile = { assistants: [], activeAssistant: null };
 

--- a/apps/web/src/lib/local-mode.ts
+++ b/apps/web/src/lib/local-mode.ts
@@ -50,12 +50,8 @@ export type {
 // changes; this module owns the transport and is the only writer.
 const getCachedLockfile = (): Lockfile | null =>
   useLockfileStore.getState().lockfile;
-const setCachedLockfile = (data: Lockfile): void => {
+const setCachedLockfile = (data: Lockfile): void =>
   useLockfileStore.getState().setLockfile(data);
-  // Single chokepoint for every lockfile update — reconcile here so a removed
-  // assistant never lingers as the tab selection.
-  reconcileSelectedAssistant();
-};
 
 const EMPTY_LOCKFILE: Lockfile = { assistants: [], activeAssistant: null };
 
@@ -77,6 +73,10 @@ export function getPlatformRuntimeUrl(): string {
 const commitLockfile = (data: Lockfile): void => {
   setCachedLockfile(data);
   setLocalSetting(LOCKFILE_STORAGE_KEY, JSON.stringify(data));
+  // Only reconcile against a lockfile from a successful host read/write — never
+  // the transient empty fallback in `loadLockfile`/`getLockfile`, which would
+  // wrongly drop a valid selection on a boot/read failure.
+  reconcileSelectedAssistant();
 };
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/lib/local-mode.ts
+++ b/apps/web/src/lib/local-mode.ts
@@ -297,6 +297,21 @@ export function clearSelectedAssistant(): void {
   removeLocalSetting(SELECTED_ASSISTANT_STORAGE_KEY);
 }
 
+/**
+ * Reconcile the tab-local selection cache against the lockfile registry: if the
+ * selected id no longer names a lockfile entry, clear it so `getSelectedAssistant`
+ * falls back to `getActiveAssistant`. No-op when there is no tab-local selection —
+ * resolution is left to `getActiveAssistant`.
+ */
+export function reconcileSelectedAssistant(): void {
+  const selectedId = getLocalSetting(SELECTED_ASSISTANT_STORAGE_KEY, "");
+  if (!selectedId) return;
+  const present = getLockfile().assistants.some(
+    (a) => a.assistantId === selectedId,
+  );
+  if (!present) clearSelectedAssistant();
+}
+
 // ---------------------------------------------------------------------------
 // URL helpers
 // ---------------------------------------------------------------------------

--- a/apps/web/src/stores/resolved-assistants-store.ts
+++ b/apps/web/src/stores/resolved-assistants-store.ts
@@ -24,7 +24,12 @@
 import { create } from "zustand";
 
 import { createSelectors } from "@/utils/create-selectors";
-import { isLocalMode, isLocalAssistant, isPlatformAssistant } from "@/lib/local-mode";
+import {
+  isLocalMode,
+  isLocalAssistant,
+  isPlatformAssistant,
+  reconcileSelectedAssistant,
+} from "@/lib/local-mode";
 import { useLockfileStore } from "@/stores/lockfile-store";
 import type { Lockfile } from "@/runtime/local-mode-host";
 import type { Assistant } from "@/generated/api/types.gen";
@@ -223,6 +228,9 @@ if (isLocalMode()) {
   useLockfileStore.subscribe((state) => {
     if (state.lockfile) {
       useResolvedAssistantsStoreBase.getState().setFromLockfile(state.lockfile);
+      // Drop a stale tab-local selection (e.g. a retired assistant) now that
+      // the lockfile registry has changed.
+      reconcileSelectedAssistant();
     }
   });
 }

--- a/apps/web/src/stores/resolved-assistants-store.ts
+++ b/apps/web/src/stores/resolved-assistants-store.ts
@@ -28,7 +28,6 @@ import {
   isLocalMode,
   isLocalAssistant,
   isPlatformAssistant,
-  reconcileSelectedAssistant,
 } from "@/lib/local-mode";
 import { useLockfileStore } from "@/stores/lockfile-store";
 import type { Lockfile } from "@/runtime/local-mode-host";
@@ -228,9 +227,6 @@ if (isLocalMode()) {
   useLockfileStore.subscribe((state) => {
     if (state.lockfile) {
       useResolvedAssistantsStoreBase.getState().setFromLockfile(state.lockfile);
-      // Drop a stale tab-local selection (e.g. a retired assistant) now that
-      // the lockfile registry has changed.
-      reconcileSelectedAssistant();
     }
   });
 }


### PR DESCRIPTION
## Summary
- Add reconcileSelectedAssistant: clear the tab-local selection when its assistant is no longer in the lockfile, so a removed assistant never lingers
- Wire it into the shared lockfile-store subscription so it runs on load and every commit (hatch/retire/sync) on both hosts

Part of plan: assistant-selection-unify.md (PR 6 of 8)