### PR TITLE
Route gateway proxy reads over IPC

### DIFF
--- a/.github/workflows/ci-main-gateway.yaml
+++ b/.github/workflows/ci-main-gateway.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Install shared packages
         uses: ./.github/actions/install-shared-packages
         with:
-          packages: packages/service-contracts packages/ces-client packages/assistant-client
+          packages: packages/service-contracts packages/ces-client packages/assistant-client packages/gateway-client
 
       - name: Sync feature flag registry
         run: cd .. && bun run meta/feature-flags/sync-bundled-copies.ts

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -183,6 +183,11 @@ jobs:
         with:
           bun-version: '1.3.11'
 
+      - name: Install shared packages
+        uses: ./.github/actions/install-shared-packages
+        with:
+          packages: packages/service-contracts packages/ces-client packages/assistant-client packages/gateway-client
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
         working-directory: gateway

--- a/.github/workflows/pr-gateway.yaml
+++ b/.github/workflows/pr-gateway.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Install shared packages
         uses: ./.github/actions/install-shared-packages
         with:
-          packages: packages/service-contracts packages/ces-client packages/assistant-client
+          packages: packages/service-contracts packages/ces-client packages/assistant-client packages/gateway-client
 
       - name: Sync feature flag registry
         run: cd .. && bun run meta/feature-flags/sync-bundled-copies.ts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3202,7 +3202,7 @@ jobs:
       - name: Install shared packages
         uses: ./.github/actions/install-shared-packages
         with:
-          packages: packages/service-contracts packages/ces-client packages/assistant-client
+          packages: packages/service-contracts packages/ces-client packages/assistant-client packages/gateway-client
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/assistant/src/ipc/routes/trust-rules.test.ts
+++ b/assistant/src/ipc/routes/trust-rules.test.ts
@@ -1,51 +1,29 @@
 /**
  * Unit tests for the trust rule IPC proxy routes.
- *
- * Covers:
- * - trust_rules_list: no params, tool filter, include_all, origin filter
- * - error path: non-OK gateway response surfaces body .error message
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-// ---------------------------------------------------------------------------
-// Mocks — must be defined before importing the module under test
-// ---------------------------------------------------------------------------
+type IpcCall = {
+  method: string;
+  params?: Record<string, unknown>;
+};
 
-mock.module("../../config/env.js", () => ({
-  getGatewayInternalBaseUrl: () => "http://localhost:7822",
+let ipcCalls: IpcCall[] = [];
+let ipcResult: unknown = { rules: [] };
+
+const ipcCallMock = mock(
+  async (method: string, params?: Record<string, unknown>) => {
+    ipcCalls.push({ method, params });
+    return ipcResult;
+  },
+);
+
+mock.module("../gateway-client.js", () => ({
+  ipcCall: ipcCallMock,
 }));
 
-type MockResponse = {
-  ok: boolean;
-  status: number;
-  json: () => Promise<unknown>;
-};
-
-let mockFetchResponse: MockResponse = {
-  ok: true,
-  status: 200,
-  json: async () => ({ rules: [] }),
-};
-
-let capturedFetchCalls: Array<{ url: string; init?: RequestInit }> = [];
-
-const mockFetch = mock(async (url: string, init?: RequestInit) => {
-  capturedFetchCalls.push({ url, init });
-  return mockFetchResponse;
-});
-
-global.fetch = mockFetch as unknown as typeof fetch;
-
-// ---------------------------------------------------------------------------
-// Import module under test AFTER mocks are set up
-// ---------------------------------------------------------------------------
-
 import { ROUTES as trustRuleRoutes } from "../../runtime/routes/trust-rules-routes.js";
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
 
 function findRoute(method: string) {
   const route = trustRuleRoutes.find((r) => r.operationId === method);
@@ -53,71 +31,84 @@ function findRoute(method: string) {
   return route;
 }
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
 describe("trustRuleRoutes", () => {
   beforeEach(() => {
-    capturedFetchCalls = [];
-    mockFetchResponse = {
-      ok: true,
-      status: 200,
-      json: async () => ({ rules: [] }),
-    };
-    mockFetch.mockClear();
+    ipcCalls = [];
+    ipcResult = { rules: [] };
+    ipcCallMock.mockClear();
   });
 
   describe("trust_rules_list", () => {
-    test("no params → GET /v1/trust-rules (no query string)", async () => {
+    test("no params calls trust_rules_list with empty params", async () => {
       const route = findRoute("trust_rules_list");
       await route.handler({ body: {} });
 
-      expect(capturedFetchCalls).toHaveLength(1);
-      expect(capturedFetchCalls[0].url).toBe(
-        "http://localhost:7822/v1/trust-rules",
-      );
-      expect(capturedFetchCalls[0].init).toBeUndefined();
+      expect(ipcCalls).toEqual([{ method: "trust_rules_list", params: {} }]);
     });
 
-    test("{ tool: 'bash' } → appends ?tool=bash", async () => {
+    test("{ tool: 'bash' } is forwarded", async () => {
       const route = findRoute("trust_rules_list");
       await route.handler({ body: { tool: "bash" } });
 
-      expect(capturedFetchCalls[0].url).toBe(
-        "http://localhost:7822/v1/trust-rules?tool=bash",
-      );
+      expect(ipcCalls).toEqual([
+        { method: "trust_rules_list", params: { tool: "bash" } },
+      ]);
     });
 
-    test("{ include_all: true } → appends ?include_all=true", async () => {
+    test("{ include_all: true } is forwarded", async () => {
       const route = findRoute("trust_rules_list");
       await route.handler({ body: { include_all: true } });
 
-      expect(capturedFetchCalls[0].url).toBe(
-        "http://localhost:7822/v1/trust-rules?include_all=true",
-      );
+      expect(ipcCalls).toEqual([
+        { method: "trust_rules_list", params: { include_all: true } },
+      ]);
     });
 
-    test("{ origin: 'user_defined' } → appends ?origin=user_defined", async () => {
+    test("{ origin: 'user_defined' } is forwarded", async () => {
       const route = findRoute("trust_rules_list");
       await route.handler({ body: { origin: "user_defined" } });
 
-      expect(capturedFetchCalls[0].url).toBe(
-        "http://localhost:7822/v1/trust-rules?origin=user_defined",
-      );
+      expect(ipcCalls).toEqual([
+        {
+          method: "trust_rules_list",
+          params: { origin: "user_defined" },
+        },
+      ]);
+    });
+
+    test("returns the parsed gateway IPC response", async () => {
+      ipcResult = {
+        rules: [
+          {
+            id: "rule-123",
+            tool: "bash",
+            pattern: "echo hello",
+            risk: "low",
+            description: "Allow echo hello",
+            origin: "user_defined",
+            userModified: false,
+            deleted: false,
+            createdAt: "2026-01-01T00:00:00.000Z",
+            updatedAt: "2026-01-01T00:00:00.000Z",
+          },
+        ],
+      };
+
+      const route = findRoute("trust_rules_list");
+      const result = await route.handler({ body: {} });
+
+      expect(result).toEqual(ipcResult);
     });
   });
 
   describe("error path", () => {
-    test("non-OK response surfaces body .error message", async () => {
-      mockFetchResponse = {
-        ok: false,
-        status: 404,
-        json: async () => ({ error: "Not found" }),
-      };
+    test("undefined IPC response surfaces gateway IPC failure", async () => {
+      ipcResult = undefined;
 
       const route = findRoute("trust_rules_list");
-      await expect(route.handler({ body: {} })).rejects.toThrow("Not found");
+      await expect(route.handler({ body: {} })).rejects.toThrow(
+        "Gateway IPC request failed",
+      );
     });
   });
 });

--- a/assistant/src/ipc/routes/trust-rules.test.ts
+++ b/assistant/src/ipc/routes/trust-rules.test.ts
@@ -11,16 +11,18 @@ type IpcCall = {
 
 let ipcCalls: IpcCall[] = [];
 let ipcResult: unknown = { rules: [] };
+let ipcError: Error | undefined;
 
-const ipcCallMock = mock(
+const ipcCallPersistentMock = mock(
   async (method: string, params?: Record<string, unknown>) => {
     ipcCalls.push({ method, params });
+    if (ipcError) throw ipcError;
     return ipcResult;
   },
 );
 
 mock.module("../gateway-client.js", () => ({
-  ipcCall: ipcCallMock,
+  ipcCallPersistent: ipcCallPersistentMock,
 }));
 
 import { ROUTES as trustRuleRoutes } from "../../runtime/routes/trust-rules-routes.js";
@@ -35,7 +37,8 @@ describe("trustRuleRoutes", () => {
   beforeEach(() => {
     ipcCalls = [];
     ipcResult = { rules: [] };
-    ipcCallMock.mockClear();
+    ipcError = undefined;
+    ipcCallPersistentMock.mockClear();
   });
 
   describe("trust_rules_list", () => {
@@ -102,12 +105,12 @@ describe("trustRuleRoutes", () => {
   });
 
   describe("error path", () => {
-    test("undefined IPC response surfaces gateway IPC failure", async () => {
-      ipcResult = undefined;
+    test("gateway IPC error is propagated", async () => {
+      ipcError = new Error("Gateway IPC call timed out");
 
       const route = findRoute("trust_rules_list");
       await expect(route.handler({ body: {} })).rejects.toThrow(
-        "Gateway IPC request failed",
+        "Gateway IPC call timed out",
       );
     });
   });

--- a/assistant/src/runtime/routes/__tests__/gateway-log-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/gateway-log-routes.test.ts
@@ -13,16 +13,18 @@ type IpcCall = {
 
 let ipcCalls: IpcCall[] = [];
 let ipcResult: unknown = { lines: [], truncated: false };
+let ipcError: Error | undefined;
 
-const ipcCallMock = mock(
+const ipcCallPersistentMock = mock(
   async (method: string, params?: Record<string, unknown>) => {
     ipcCalls.push({ method, params });
+    if (ipcError) throw ipcError;
     return ipcResult;
   },
 );
 
 mock.module("../../../ipc/gateway-client.js", () => ({
-  ipcCall: ipcCallMock,
+  ipcCallPersistent: ipcCallPersistentMock,
 }));
 
 import { ROUTES } from "../gateway-log-routes.js";
@@ -35,7 +37,8 @@ describe("gateway_logs_tail route", () => {
   beforeEach(() => {
     ipcCalls = [];
     ipcResult = { lines: [], truncated: false };
-    ipcCallMock.mockClear();
+    ipcError = undefined;
+    ipcCallPersistentMock.mockClear();
   });
 
   test("route is registered with correct operationId, method, and endpoint", () => {
@@ -85,11 +88,11 @@ describe("gateway_logs_tail route", () => {
     ]);
   });
 
-  test("throws when gateway IPC returns undefined", async () => {
-    ipcResult = undefined;
+  test("propagates gateway IPC errors", async () => {
+    ipcError = new Error("Gateway IPC socket disconnected");
 
     await expect(gatewayLogsTailRoute.handler({ body: {} })).rejects.toThrow(
-      "Gateway IPC request failed",
+      "Gateway IPC socket disconnected",
     );
   });
 

--- a/assistant/src/runtime/routes/__tests__/gateway-log-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/gateway-log-routes.test.ts
@@ -1,39 +1,29 @@
 /**
- * Unit tests for the gateway_logs_tail IPC route handler.
- *
- * Covers:
- * - Happy path: all params → correct URL with querystring
- * - All params absent → URL with no querystring
- * - Only n provided → querystring has only n
- * - Gateway returns 500 with error body → Error thrown with error message
- * - level: "INVALID" → ZodError (no gateway call)
- * - n: 0 → ZodError (min 1 violation)
- * - n: 1001 → ZodError (max 1000 violation)
- * - module: "" → accepted (empty string passes zod string validation)
+ * Unit tests for the gateway_logs_tail route handler.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { ZodError } from "zod";
 
-// ---------------------------------------------------------------------------
-// Mocks — must be defined before importing the module under test
-// ---------------------------------------------------------------------------
+type IpcCall = {
+  method: string;
+  params?: Record<string, unknown>;
+};
 
-mock.module("../../../util/logger.js", () => ({
-  getLogger: () =>
-    new Proxy({} as Record<string, unknown>, {
-      get: () => () => {},
-    }),
+let ipcCalls: IpcCall[] = [];
+let ipcResult: unknown = { lines: [], truncated: false };
+
+const ipcCallMock = mock(
+  async (method: string, params?: Record<string, unknown>) => {
+    ipcCalls.push({ method, params });
+    return ipcResult;
+  },
+);
+
+mock.module("../../../ipc/gateway-client.js", () => ({
+  ipcCall: ipcCallMock,
 }));
-
-mock.module("../../../config/env.js", () => ({
-  getGatewayInternalBaseUrl: () => "http://localhost:9999",
-}));
-
-// ---------------------------------------------------------------------------
-// Import the module under test AFTER mocks are set up
-// ---------------------------------------------------------------------------
 
 import { ROUTES } from "../gateway-log-routes.js";
 
@@ -41,29 +31,11 @@ const gatewayLogsTailRoute = ROUTES.find(
   (r) => r.operationId === "gateway_logs_tail",
 )!;
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function makeFetchMock(
-  status: number,
-  body: unknown,
-): ReturnType<typeof mock> {
-  return mock(async () => ({
-    ok: status >= 200 && status < 300,
-    status,
-    json: async () => body,
-  }));
-}
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
 describe("gateway_logs_tail route", () => {
   beforeEach(() => {
-    // Reset global fetch to avoid cross-test contamination
-    globalThis.fetch = undefined as unknown as typeof fetch;
+    ipcCalls = [];
+    ipcResult = { lines: [], truncated: false };
+    ipcCallMock.mockClear();
   });
 
   test("route is registered with correct operationId, method, and endpoint", () => {
@@ -73,170 +45,107 @@ describe("gateway_logs_tail route", () => {
     expect(gatewayLogsTailRoute.endpoint).toBe("gateway/logs/tail");
   });
 
-  describe("happy path — all params provided via body", () => {
-    test("calls gateway with correct URL including all query params", async () => {
-      const mockFetch = makeFetchMock(200, { entries: [] });
-      globalThis.fetch = mockFetch as unknown as typeof fetch;
-
-      await gatewayLogsTailRoute.handler({
-        body: { n: 5, level: "warn", module: "mcp" },
-      });
-
-      expect(mockFetch).toHaveBeenCalledTimes(1);
-      const calledUrl = (mockFetch.mock.calls[0] as [string])[0];
-      expect(calledUrl).toBe(
-        "http://localhost:9999/v1/logs/tail?n=5&level=warn&module=mcp",
-      );
+  test("calls gateway IPC with all typed params from body", async () => {
+    await gatewayLogsTailRoute.handler({
+      body: { n: 5, level: "warn", module: "mcp" },
     });
 
-    test("returns the parsed response body", async () => {
-      const responseBody = { entries: [{ msg: "hello", level: 40 }] };
-      globalThis.fetch = makeFetchMock(200, responseBody) as unknown as typeof fetch;
-
-      const result = await gatewayLogsTailRoute.handler({
-        body: { n: 5, level: "warn", module: "mcp" },
-      });
-
-      expect(result).toEqual(responseBody);
-    });
+    expect(ipcCalls).toEqual([
+      {
+        method: "gateway_logs_tail",
+        params: { n: 5, level: "warn", module: "mcp" },
+      },
+    ]);
   });
 
-  describe("all params absent", () => {
-    test("calls gateway URL with no querystring when body is empty", async () => {
-      const mockFetch = makeFetchMock(200, { entries: [] });
-      globalThis.fetch = mockFetch as unknown as typeof fetch;
+  test("returns the parsed IPC response body", async () => {
+    ipcResult = {
+      lines: [{ msg: "hello", level: 40 }],
+      truncated: false,
+    };
 
-      await gatewayLogsTailRoute.handler({ body: {} });
-
-      const calledUrl = (mockFetch.mock.calls[0] as [string])[0];
-      expect(calledUrl).toBe("http://localhost:9999/v1/logs/tail");
+    const result = await gatewayLogsTailRoute.handler({
+      body: { n: 5, level: "warn", module: "mcp" },
     });
 
-    test("calls gateway URL with no querystring when no args provided", async () => {
-      const mockFetch = makeFetchMock(200, { entries: [] });
-      globalThis.fetch = mockFetch as unknown as typeof fetch;
-
-      await gatewayLogsTailRoute.handler({});
-
-      const calledUrl = (mockFetch.mock.calls[0] as [string])[0];
-      expect(calledUrl).toBe("http://localhost:9999/v1/logs/tail");
-    });
+    expect(result).toEqual(ipcResult);
   });
 
-  describe("only n provided", () => {
-    test("querystring contains only n — no spurious level or module keys", async () => {
-      const mockFetch = makeFetchMock(200, { entries: [] });
-      globalThis.fetch = mockFetch as unknown as typeof fetch;
+  test("calls gateway IPC with empty params when no filters are provided", async () => {
+    await gatewayLogsTailRoute.handler({});
 
-      await gatewayLogsTailRoute.handler({ body: { n: 5 } });
-
-      const calledUrl = (mockFetch.mock.calls[0] as [string])[0];
-      expect(calledUrl).toBe("http://localhost:9999/v1/logs/tail?n=5");
-      expect(calledUrl).not.toContain("level");
-      expect(calledUrl).not.toContain("module");
-    });
+    expect(ipcCalls).toEqual([{ method: "gateway_logs_tail", params: {} }]);
   });
 
-  describe("gateway error handling", () => {
-    test("gateway 500 with { error: 'disk error' } throws Error with that message", async () => {
-      globalThis.fetch = makeFetchMock(500, {
-        error: "disk error",
-      }) as unknown as typeof fetch;
+  test("sends only n when only n is provided", async () => {
+    await gatewayLogsTailRoute.handler({ body: { n: 5 } });
 
-      await expect(
-        gatewayLogsTailRoute.handler({ body: {} }),
-      ).rejects.toThrow("disk error");
-    });
-
-    test("gateway 500 with non-string error falls back to generic message", async () => {
-      globalThis.fetch = makeFetchMock(500, {
-        error: { nested: true },
-      }) as unknown as typeof fetch;
-
-      await expect(
-        gatewayLogsTailRoute.handler({ body: {} }),
-      ).rejects.toThrow("Gateway request failed (500)");
-    });
-
-    test("gateway 500 with unparseable JSON falls back to generic message", async () => {
-      globalThis.fetch = mock(async () => ({
-        ok: false,
-        status: 500,
-        json: async () => {
-          throw new SyntaxError("Unexpected token");
-        },
-      })) as unknown as typeof fetch;
-
-      await expect(
-        gatewayLogsTailRoute.handler({ body: {} }),
-      ).rejects.toThrow("Gateway request failed (500)");
-    });
+    expect(ipcCalls).toEqual([
+      { method: "gateway_logs_tail", params: { n: 5 } },
+    ]);
   });
 
-  describe("zod validation", () => {
-    test("level: 'INVALID' is rejected with ZodError before calling gateway", async () => {
-      const mockFetch = makeFetchMock(200, {});
-      globalThis.fetch = mockFetch as unknown as typeof fetch;
+  test("throws when gateway IPC returns undefined", async () => {
+    ipcResult = undefined;
 
-      await expect(
-        gatewayLogsTailRoute.handler({
-          body: { level: "INVALID" },
-        }),
-      ).rejects.toBeInstanceOf(ZodError);
-
-      expect(mockFetch).not.toHaveBeenCalled();
-    });
-
-    test("n: 0 is rejected with ZodError (min 1 violation)", async () => {
-      const mockFetch = makeFetchMock(200, {});
-      globalThis.fetch = mockFetch as unknown as typeof fetch;
-
-      await expect(
-        gatewayLogsTailRoute.handler({ body: { n: 0 } }),
-      ).rejects.toBeInstanceOf(ZodError);
-
-      expect(mockFetch).not.toHaveBeenCalled();
-    });
-
-    test("n: 1001 is rejected with ZodError (max 1000 violation)", async () => {
-      const mockFetch = makeFetchMock(200, {});
-      globalThis.fetch = mockFetch as unknown as typeof fetch;
-
-      await expect(
-        gatewayLogsTailRoute.handler({ body: { n: 1001 } }),
-      ).rejects.toBeInstanceOf(ZodError);
-
-      expect(mockFetch).not.toHaveBeenCalled();
-    });
-
-    test("module: '' is accepted (empty string passes zod string validation)", async () => {
-      const mockFetch = makeFetchMock(200, { entries: [] });
-      globalThis.fetch = mockFetch as unknown as typeof fetch;
-
-      await expect(
-        gatewayLogsTailRoute.handler({ body: { module: "" } }),
-      ).resolves.toBeDefined();
-
-      expect(mockFetch).toHaveBeenCalledTimes(1);
-    });
+    await expect(gatewayLogsTailRoute.handler({ body: {} })).rejects.toThrow(
+      "Gateway IPC request failed",
+    );
   });
 
-  describe("queryParams source (HTTP GET path)", () => {
-    test("uses queryParams when provided (HTTP GET path) — string params", async () => {
-      const mockFetch = makeFetchMock(200, { entries: [] });
-      globalThis.fetch = mockFetch as unknown as typeof fetch;
+  test("rejects malformed gateway IPC responses", async () => {
+    ipcResult = { entries: [] };
 
-      // When queryParams has values, those take precedence over body.
-      // Only string-valued params (level, module) are valid from the HTTP layer;
-      // n is numeric and must come via IPC body.
-      await gatewayLogsTailRoute.handler({
-        queryParams: { level: "info", module: "cors" },
-        body: {},
-      });
+    await expect(
+      gatewayLogsTailRoute.handler({ body: {} }),
+    ).rejects.toBeInstanceOf(ZodError);
+  });
 
-      const calledUrl = (mockFetch.mock.calls[0] as [string])[0];
-      expect(calledUrl).toContain("level=info");
-      expect(calledUrl).toContain("module=cors");
+  test("level: 'INVALID' is rejected before calling gateway IPC", async () => {
+    await expect(
+      gatewayLogsTailRoute.handler({
+        body: { level: "INVALID" },
+      }),
+    ).rejects.toBeInstanceOf(ZodError);
+
+    expect(ipcCalls).toEqual([]);
+  });
+
+  test("n: 0 is rejected before calling gateway IPC", async () => {
+    await expect(
+      gatewayLogsTailRoute.handler({ body: { n: 0 } }),
+    ).rejects.toBeInstanceOf(ZodError);
+
+    expect(ipcCalls).toEqual([]);
+  });
+
+  test("n: 1001 is rejected before calling gateway IPC", async () => {
+    await expect(
+      gatewayLogsTailRoute.handler({ body: { n: 1001 } }),
+    ).rejects.toBeInstanceOf(ZodError);
+
+    expect(ipcCalls).toEqual([]);
+  });
+
+  test("module: '' is accepted", async () => {
+    await gatewayLogsTailRoute.handler({ body: { module: "" } });
+
+    expect(ipcCalls).toEqual([
+      { method: "gateway_logs_tail", params: { module: "" } },
+    ]);
+  });
+
+  test("uses queryParams when provided and coerces n", async () => {
+    await gatewayLogsTailRoute.handler({
+      queryParams: { n: "7", level: "info", module: "cors" },
+      body: { n: 1, level: "error" },
     });
+
+    expect(ipcCalls).toEqual([
+      {
+        method: "gateway_logs_tail",
+        params: { n: 7, level: "info", module: "cors" },
+      },
+    ]);
   });
 });

--- a/assistant/src/runtime/routes/gateway-log-routes.ts
+++ b/assistant/src/runtime/routes/gateway-log-routes.ts
@@ -4,51 +4,27 @@
  * The handler calls the gateway over the local IPC socket so the assistant
  * does not need gateway signing material.
  */
-import { z } from "zod";
+import {
+  type GatewayLogsTailIpcResponse,
+  GatewayLogsTailIpcResponseSchema,
+  GatewayLogsTailRouteParamsSchema,
+} from "@vellumai/gateway-client/gateway-ipc-contracts";
 
-import { ipcCall } from "../../ipc/gateway-client.js";
+import { ipcCallPersistent } from "../../ipc/gateway-client.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
-
-// ── Schemas ─────────────────────────────────────────────────────────────
-
-const LEVEL_NAMES = [
-  "trace",
-  "debug",
-  "info",
-  "warn",
-  "error",
-  "fatal",
-] as const;
-
-const GatewayLogsTailParams = z
-  .object({
-    n: z.coerce.number().int().min(1).max(1000).optional(),
-    level: z.enum(LEVEL_NAMES).optional(),
-    module: z.string().optional(),
-  })
-  .strict();
-
-const GatewayLogsTailResponseSchema = z.object({
-  lines: z.array(z.record(z.string(), z.unknown())),
-  truncated: z.boolean(),
-});
-type GatewayLogsTailResponse = z.infer<typeof GatewayLogsTailResponseSchema>;
 
 // ── Handlers ────────────────────────────────────────────────────────────
 
 async function handleGatewayLogsTail({
   queryParams = {},
   body = {},
-}: RouteHandlerArgs): Promise<GatewayLogsTailResponse> {
+}: RouteHandlerArgs): Promise<GatewayLogsTailIpcResponse> {
   // HTTP GET delivers filters via queryParams; CLI IPC puts them in body.
   const source = Object.keys(queryParams).length > 0 ? queryParams : body;
-  const p = GatewayLogsTailParams.parse(source);
-  const result = await ipcCall("gateway_logs_tail", p);
-  if (result === undefined) {
-    throw new Error("Gateway IPC request failed");
-  }
-  return GatewayLogsTailResponseSchema.parse(result);
+  const p = GatewayLogsTailRouteParamsSchema.parse(source);
+  const result = await ipcCallPersistent("gateway_logs_tail", p);
+  return GatewayLogsTailIpcResponseSchema.parse(result);
 }
 
 // ── Route definitions ───────────────────────────────────────────────────
@@ -67,7 +43,7 @@ export const ROUTES: RouteDefinition[] = [
     description:
       "Return the last N structured log entries from the gateway log files.",
     tags: ["gateway-logs"],
-    responseBody: GatewayLogsTailResponseSchema,
+    responseBody: GatewayLogsTailIpcResponseSchema,
     queryParams: [
       {
         name: "n",

--- a/assistant/src/runtime/routes/gateway-log-routes.ts
+++ b/assistant/src/runtime/routes/gateway-log-routes.ts
@@ -1,37 +1,14 @@
 /**
- * Gateway log tail route — gateway HTTP proxy.
+ * Gateway log tail route — gateway IPC proxy.
  *
- * The handler makes a single HTTP call to the gateway's log-tail API
- * and surfaces the body's `.error` message on non-OK responses.
+ * The handler calls the gateway over the local IPC socket so the assistant
+ * does not need gateway signing material.
  */
 import { z } from "zod";
 
-import { getGatewayInternalBaseUrl } from "../../config/env.js";
+import { ipcCall } from "../../ipc/gateway-client.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
-
-// ── Shared helper ───────────────────────────────────────────────────────
-
-async function gatewayFetch(
-  path: string,
-  init?: RequestInit,
-): Promise<unknown> {
-  const base = getGatewayInternalBaseUrl();
-  const res = await fetch(`${base}${path}`, init);
-  if (!res.ok) {
-    let message = `Gateway request failed (${res.status})`;
-    try {
-      const body = (await res.json()) as { error?: unknown };
-      if (typeof body.error === "string") {
-        message = body.error;
-      }
-    } catch {
-      // ignore JSON parse failures
-    }
-    throw new Error(message);
-  }
-  return res.json();
-}
 
 // ── Schemas ─────────────────────────────────────────────────────────────
 
@@ -67,14 +44,11 @@ async function handleGatewayLogsTail({
   // HTTP GET delivers filters via queryParams; CLI IPC puts them in body.
   const source = Object.keys(queryParams).length > 0 ? queryParams : body;
   const p = GatewayLogsTailParams.parse(source);
-  const qs = new URLSearchParams();
-  if (p.n !== undefined) qs.set("n", String(p.n));
-  if (p.level !== undefined) qs.set("level", p.level);
-  if (p.module !== undefined) qs.set("module", p.module);
-  const query = qs.toString();
-  return gatewayFetch(
-    `/v1/logs/tail${query ? `?${query}` : ""}`,
-  ) as Promise<GatewayLogsTailResponse>;
+  const result = await ipcCall("gateway_logs_tail", p);
+  if (result === undefined) {
+    throw new Error("Gateway IPC request failed");
+  }
+  return GatewayLogsTailResponseSchema.parse(result);
 }
 
 // ── Route definitions ───────────────────────────────────────────────────

--- a/assistant/src/runtime/routes/trust-rules-routes.ts
+++ b/assistant/src/runtime/routes/trust-rules-routes.ts
@@ -4,54 +4,27 @@
  * The handler calls the gateway over the local IPC socket because trust rule
  * storage is gateway-owned in Docker mode.
  */
-import { z } from "zod";
+import {
+  TrustRulesListIpcParamsSchema,
+  type TrustRulesListIpcResponse,
+  TrustRulesListIpcResponseSchema,
+} from "@vellumai/gateway-client/gateway-ipc-contracts";
 
-import { ipcCall } from "../../ipc/gateway-client.js";
+import { ipcCallPersistent } from "../../ipc/gateway-client.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
-
-// ── Schemas ─────────────────────────────────────────────────────────────
-
-const TrustRulesListParams = z
-  .object({
-    tool: z.string().optional(),
-    origin: z.string().optional(),
-    include_all: z.boolean().optional(),
-  })
-  .strict();
-
-const TrustRuleSchema = z.object({
-  id: z.string(),
-  tool: z.string(),
-  pattern: z.string(),
-  risk: z.enum(["low", "medium", "high"]),
-  description: z.string(),
-  origin: z.enum(["default", "user_defined"]),
-  userModified: z.boolean(),
-  deleted: z.boolean(),
-  createdAt: z.string(),
-  updatedAt: z.string(),
-});
-
-const TrustRulesListResponseSchema = z.object({
-  rules: z.array(TrustRuleSchema),
-});
-type TrustRulesListResponse = z.infer<typeof TrustRulesListResponseSchema>;
 
 // ── Handlers ────────────────────────────────────────────────────────────
 
 async function handleList({
   queryParams = {},
   body = {},
-}: RouteHandlerArgs): Promise<TrustRulesListResponse> {
+}: RouteHandlerArgs): Promise<TrustRulesListIpcResponse> {
   // HTTP GET delivers filters via queryParams; CLI IPC puts them in body.
   const source = Object.keys(queryParams).length > 0 ? queryParams : body;
-  const p = TrustRulesListParams.parse(source);
-  const result = await ipcCall("trust_rules_list", p);
-  if (result === undefined) {
-    throw new Error("Gateway IPC request failed");
-  }
-  return TrustRulesListResponseSchema.parse(result);
+  const p = TrustRulesListIpcParamsSchema.parse(source);
+  const result = await ipcCallPersistent("trust_rules_list", p);
+  return TrustRulesListIpcResponseSchema.parse(result);
 }
 
 // ── Route definitions ───────────────────────────────────────────────────
@@ -70,7 +43,7 @@ export const ROUTES: RouteDefinition[] = [
     description:
       "List trust rules, optionally filtered by tool, origin, or include_all.",
     tags: ["trust-rules"],
-    responseBody: TrustRulesListResponseSchema,
+    responseBody: TrustRulesListIpcResponseSchema,
     queryParams: [
       { name: "tool", description: "Filter by tool name" },
       { name: "origin", description: "Filter by origin" },

--- a/assistant/src/runtime/routes/trust-rules-routes.ts
+++ b/assistant/src/runtime/routes/trust-rules-routes.ts
@@ -1,37 +1,14 @@
 /**
- * Trust rule listing route — gateway HTTP proxy.
+ * Trust rule listing route — gateway IPC proxy.
  *
- * The handler makes a single HTTP call to the gateway's trust-rules REST API
- * and surfaces the body's `.error` message on non-OK responses.
+ * The handler calls the gateway over the local IPC socket because trust rule
+ * storage is gateway-owned in Docker mode.
  */
 import { z } from "zod";
 
-import { getGatewayInternalBaseUrl } from "../../config/env.js";
+import { ipcCall } from "../../ipc/gateway-client.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
-
-// ── Shared helper ───────────────────────────────────────────────────────
-
-async function gatewayFetch(
-  path: string,
-  init?: RequestInit,
-): Promise<unknown> {
-  const base = getGatewayInternalBaseUrl();
-  const res = await fetch(`${base}${path}`, init);
-  if (!res.ok) {
-    let message = `Gateway request failed (${res.status})`;
-    try {
-      const body = (await res.json()) as { error?: unknown };
-      if (typeof body.error === "string") {
-        message = body.error;
-      }
-    } catch {
-      // ignore JSON parse failures
-    }
-    throw new Error(message);
-  }
-  return res.json();
-}
 
 // ── Schemas ─────────────────────────────────────────────────────────────
 
@@ -70,14 +47,11 @@ async function handleList({
   // HTTP GET delivers filters via queryParams; CLI IPC puts them in body.
   const source = Object.keys(queryParams).length > 0 ? queryParams : body;
   const p = TrustRulesListParams.parse(source);
-  const qs = new URLSearchParams();
-  if (p.tool) qs.set("tool", p.tool);
-  if (p.origin) qs.set("origin", p.origin);
-  if (p.include_all) qs.set("include_all", "true");
-  const query = qs.toString();
-  return gatewayFetch(
-    `/v1/trust-rules${query ? `?${query}` : ""}`,
-  ) as Promise<TrustRulesListResponse>;
+  const result = await ipcCall("trust_rules_list", p);
+  if (result === undefined) {
+    throw new Error("Gateway IPC request failed");
+  }
+  return TrustRulesListResponseSchema.parse(result);
 }
 
 // ── Route definitions ───────────────────────────────────────────────────

--- a/gateway/bun.lock
+++ b/gateway/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@vellumai/assistant-client": "file:../packages/assistant-client",
         "@vellumai/ces-client": "file:../packages/ces-client",
+        "@vellumai/gateway-client": "file:../packages/gateway-client",
         "@vellumai/ipc-server-utils": "file:../packages/ipc-server-utils",
         "@vellumai/service-contracts": "file:../packages/service-contracts",
         "@vellumai/slack-text": "file:../packages/slack-text",
@@ -209,6 +210,8 @@
     "@vellumai/assistant-client": ["@vellumai/assistant-client@file:../packages/assistant-client", { "devDependencies": { "@types/bun": "1.3.10", "typescript": "5.9.3" } }],
 
     "@vellumai/ces-client": ["@vellumai/ces-client@file:../packages/ces-client", { "dependencies": { "@vellumai/service-contracts": "file:../service-contracts" }, "devDependencies": { "@types/bun": "1.2.4", "typescript": "5.7.3" } }],
+
+    "@vellumai/gateway-client": ["@vellumai/gateway-client@file:../packages/gateway-client", { "dependencies": { "@vellumai/service-contracts": "file:../service-contracts", "zod": "4.3.6" }, "devDependencies": { "@types/bun": "1.3.10", "typescript": "5.9.3" } }],
 
     "@vellumai/ipc-server-utils": ["@vellumai/ipc-server-utils@file:../packages/ipc-server-utils", { "devDependencies": { "@types/bun": "1.3.10", "typescript": "5.9.3" } }],
 
@@ -504,6 +507,10 @@
 
     "@vellumai/ces-client/typescript": ["typescript@5.7.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw=="],
 
+    "@vellumai/gateway-client/@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
+
+    "@vellumai/gateway-client/@vellumai/service-contracts": ["@vellumai/service-contracts@file:../packages/service-contracts", {}],
+
     "@vellumai/ipc-server-utils/@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
 
     "@vellumai/service-contracts/@types/bun": ["@types/bun@1.2.4", "", { "dependencies": { "bun-types": "1.2.4" } }, "sha512-QtuV5OMR8/rdKJs213iwXDpfVvnskPXY/S0ZiFbsTjQZycuqPbMW8Gf/XhLfwE5njW8sxI2WjISURXPlHypMFA=="],
@@ -571,6 +578,8 @@
     "@vellumai/assistant-client/@types/bun/bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
 
     "@vellumai/ces-client/@types/bun/bun-types": ["bun-types@1.2.4", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-nDPymR207ZZEoWD4AavvEaa/KZe/qlrbMSchqpQwovPZCKc7pwMoENjEtHgMKaAjJhy+x6vfqSBA1QU3bJgs0Q=="],
+
+    "@vellumai/gateway-client/@types/bun/bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
 
     "@vellumai/ipc-server-utils/@types/bun/bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
 

--- a/gateway/knip.json
+++ b/gateway/knip.json
@@ -4,6 +4,7 @@
   "ignoreDependencies": [
     "@vellumai/assistant-client",
     "@vellumai/ces-client",
+    "@vellumai/gateway-client",
     "@vellumai/ipc-server-utils",
     "@vellumai/service-contracts",
     "@vellumai/slack-text",

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@vellumai/assistant-client": "file:../packages/assistant-client",
     "@vellumai/ces-client": "file:../packages/ces-client",
+    "@vellumai/gateway-client": "file:../packages/gateway-client",
     "@vellumai/ipc-server-utils": "file:../packages/ipc-server-utils",
     "@vellumai/service-contracts": "file:../packages/service-contracts",
     "@vellumai/slack-text": "file:../packages/slack-text",
@@ -43,6 +44,7 @@
   "bundledDependencies": [
     "@vellumai/assistant-client",
     "@vellumai/ces-client",
+    "@vellumai/gateway-client",
     "@vellumai/ipc-server-utils",
     "@vellumai/service-contracts",
     "@vellumai/slack-text",

--- a/gateway/src/http/routes/log-tail.ts
+++ b/gateway/src/http/routes/log-tail.ts
@@ -10,8 +10,15 @@ import {
 
 const log = getLogger("log-tail");
 
-const LEVEL_NAMES = ["trace", "debug", "info", "warn", "error", "fatal"] as const;
-type LevelName = (typeof LEVEL_NAMES)[number];
+export const LEVEL_NAMES = [
+  "trace",
+  "debug",
+  "info",
+  "warn",
+  "error",
+  "fatal",
+] as const;
+export type LevelName = (typeof LEVEL_NAMES)[number];
 
 const LEVEL_MAP: Record<LevelName, number> = {
   trace: 10,
@@ -29,6 +36,76 @@ const LEVEL_MAP: Record<LevelName, number> = {
 // silently fail `JSON.parse` below, which is the desired behavior.
 const TAIL_PATTERNS = [LOG_FILE_JSON_PATTERN, LOG_FILE_PATTERN] as const;
 
+export interface TailGatewayLogsParams {
+  n?: number;
+  level?: LevelName;
+  module?: string;
+}
+
+export interface TailGatewayLogsResult {
+  lines: unknown[];
+  truncated: boolean;
+}
+
+function isLevelName(value: string): value is LevelName {
+  return (LEVEL_NAMES as readonly string[]).includes(value);
+}
+
+export function tailGatewayLogs(
+  config: GatewayConfig,
+  params: TailGatewayLogsParams = {},
+): TailGatewayLogsResult {
+  const nRaw = params.n ?? 10;
+  const n = Math.max(1, Math.min(1000, Number.isNaN(nRaw) ? 10 : nRaw));
+  const minLevel = LEVEL_MAP[params.level ?? "info"];
+  const moduleFilter = params.module;
+
+  try {
+    if (!config.logFile.dir || !existsSync(config.logFile.dir)) {
+      return { lines: [], truncated: false };
+    }
+
+    const dir = config.logFile.dir;
+
+    const files = readdirSync(dir)
+      .filter((f) => TAIL_PATTERNS.some((p) => p.test(f)))
+      .sort()
+      .reverse();
+
+    const collected: unknown[] = [];
+
+    outer: for (const file of files) {
+      const content = readFileSync(join(dir, file), "utf8");
+      const fileLines = content.split("\n");
+      for (let i = fileLines.length - 1; i >= 0; i--) {
+        const raw = fileLines[i];
+        if (!raw) continue;
+        let entry: Record<string, unknown>;
+        try {
+          entry = JSON.parse(raw);
+        } catch {
+          continue;
+        }
+        if (typeof entry.level !== "number") continue;
+        if (entry.level < minLevel) continue;
+        if (moduleFilter !== undefined && entry.module !== moduleFilter) {
+          continue;
+        }
+        collected.push(entry);
+        if (collected.length >= n + 1) break outer;
+      }
+    }
+
+    const truncated = collected.length > n;
+    const lines = collected.slice(0, n).reverse();
+
+    return { lines, truncated };
+  } catch (err) {
+    log.warn({ err }, "log-tail handler failed");
+    return { lines: [], truncated: false };
+  }
+}
+
 export function createLogTailHandler(
   config: GatewayConfig,
 ): (req: Request) => Promise<Response> {
@@ -41,56 +118,14 @@ export function createLogTailHandler(
 
     // Parse and validate `level`
     const levelParam = searchParams.get("level") ?? "info";
-    if (!(LEVEL_NAMES as readonly string[]).includes(levelParam)) {
+    if (!isLevelName(levelParam)) {
       return Response.json({ error: "Invalid level" }, { status: 400 });
     }
 
     // Parse optional module filter
     const moduleFilter = searchParams.get("module") ?? undefined;
-
-    const minLevel = LEVEL_MAP[levelParam as LevelName];
-
-    try {
-      if (!config.logFile.dir || !existsSync(config.logFile.dir)) {
-        return Response.json({ lines: [], truncated: false });
-      }
-
-      const dir = config.logFile.dir;
-
-      const files = readdirSync(dir)
-        .filter((f) => TAIL_PATTERNS.some((p) => p.test(f)))
-        .sort()
-        .reverse();
-
-      const collected: unknown[] = [];
-
-      outer: for (const file of files) {
-        const content = readFileSync(join(dir, file), "utf8");
-        const fileLines = content.split("\n");
-        for (let i = fileLines.length - 1; i >= 0; i--) {
-          const raw = fileLines[i];
-          if (!raw) continue;
-          let entry: Record<string, unknown>;
-          try {
-            entry = JSON.parse(raw);
-          } catch {
-            continue;
-          }
-          if (typeof entry.level !== "number") continue;
-          if (entry.level < minLevel) continue;
-          if (moduleFilter !== undefined && entry.module !== moduleFilter) continue;
-          collected.push(entry);
-          if (collected.length >= n + 1) break outer;
-        }
-      }
-
-      const truncated = collected.length > n;
-      const lines = collected.slice(0, n).reverse();
-
-      return Response.json({ lines, truncated });
-    } catch (err) {
-      log.warn({ err }, "log-tail handler failed");
-      return Response.json({ lines: [], truncated: false });
-    }
+    return Response.json(
+      tailGatewayLogs(config, { n, level: levelParam, module: moduleFilter }),
+    );
   };
 }

--- a/gateway/src/http/routes/log-tail.ts
+++ b/gateway/src/http/routes/log-tail.ts
@@ -1,6 +1,11 @@
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 
+import {
+  GATEWAY_LOG_LEVEL_NAMES,
+  type GatewayLogLevelName,
+} from "@vellumai/gateway-client/gateway-ipc-contracts";
+
 import type { GatewayConfig } from "../../config.js";
 import {
   getLogger,
@@ -10,17 +15,7 @@ import {
 
 const log = getLogger("log-tail");
 
-export const LEVEL_NAMES = [
-  "trace",
-  "debug",
-  "info",
-  "warn",
-  "error",
-  "fatal",
-] as const;
-export type LevelName = (typeof LEVEL_NAMES)[number];
-
-const LEVEL_MAP: Record<LevelName, number> = {
+const LEVEL_MAP: Record<GatewayLogLevelName, number> = {
   trace: 10,
   debug: 20,
   info: 30,
@@ -38,7 +33,7 @@ const TAIL_PATTERNS = [LOG_FILE_JSON_PATTERN, LOG_FILE_PATTERN] as const;
 
 export interface TailGatewayLogsParams {
   n?: number;
-  level?: LevelName;
+  level?: GatewayLogLevelName;
   module?: string;
 }
 
@@ -47,8 +42,8 @@ export interface TailGatewayLogsResult {
   truncated: boolean;
 }
 
-function isLevelName(value: string): value is LevelName {
-  return (LEVEL_NAMES as readonly string[]).includes(value);
+function isLevelName(value: string): value is GatewayLogLevelName {
+  return (GATEWAY_LOG_LEVEL_NAMES as readonly string[]).includes(value);
 }
 
 export function tailGatewayLogs(

--- a/gateway/src/http/routes/trust-rules.ts
+++ b/gateway/src/http/routes/trust-rules.ts
@@ -56,6 +56,26 @@ const SuggestRequestSchema = z.object({
     .optional(),
 });
 
+export interface TrustRulesListParams {
+  origin?: string;
+  tool?: string;
+  includeDeleted?: boolean;
+  includeAll?: boolean;
+}
+
+export function listTrustRules(params: TrustRulesListParams = {}) {
+  const store = new TrustRuleStore();
+  const userRelevantOnly = !params.includeAll && params.origin === undefined;
+
+  const rules = store.list({
+    origin: params.origin,
+    tool: params.tool,
+    includeDeleted: params.includeDeleted,
+    userRelevantOnly,
+  });
+  return { rules };
+}
+
 /**
  * Read the interactive auto-approve threshold from the DB.
  * Falls back to "low" if the DB is unavailable or the row is missing.
@@ -120,8 +140,6 @@ export function createTrustRulesSuggestHandler() {
 // ---------------------------------------------------------------------------
 
 export function createTrustRulesListHandler() {
-  const store = new TrustRuleStore();
-
   return async (req: Request): Promise<Response> => {
     try {
       const url = new URL(req.url);
@@ -129,15 +147,10 @@ export function createTrustRulesListHandler() {
       const tool = url.searchParams.get("tool") ?? undefined;
       const includeDeleted = url.searchParams.get("include_deleted") === "true";
       const includeAll = url.searchParams.get("include_all") === "true";
-      const userRelevantOnly = !includeAll && origin === undefined;
 
-      const rules = store.list({
-        origin,
-        tool,
-        includeDeleted,
-        userRelevantOnly,
-      });
-      return Response.json({ rules });
+      return Response.json(
+        listTrustRules({ origin, tool, includeDeleted, includeAll }),
+      );
     } catch (err) {
       log.error({ err }, "Failed to list trust rules");
       return Response.json({ error: "Internal server error" }, { status: 500 });

--- a/gateway/src/http/routes/trust-rules.ts
+++ b/gateway/src/http/routes/trust-rules.ts
@@ -64,6 +64,7 @@ export interface TrustRulesListParams {
 }
 
 export function listTrustRules(params: TrustRulesListParams = {}) {
+  // Construct per call so DB resets use the current gateway DB connection.
   const store = new TrustRuleStore();
   const userRelevantOnly = !params.includeAll && params.origin === undefined;
 

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -181,8 +181,10 @@ import {
 import { GatewayIpcServer } from "./ipc/server.js";
 import { contactRoutes } from "./ipc/contact-handlers.js";
 import { featureFlagRoutes } from "./ipc/feature-flag-handlers.js";
+import { createLogTailRoutes } from "./ipc/log-tail-handlers.js";
 import { slackThreadRoutes } from "./ipc/slack-thread-handlers.js";
 import { thresholdRoutes } from "./ipc/threshold-handlers.js";
+import { trustRulesRoutes } from "./ipc/trust-rules-handlers.js";
 
 import { riskClassificationRoutes } from "./ipc/risk-classification-handlers.js";
 import { createVelayRoutes } from "./ipc/velay-handlers.js";
@@ -1853,9 +1855,7 @@ async function main() {
   let lastRecordActivityTs = 0;
   async function notifyRecordActivity(): Promise<void> {
     if (!arePlatformFeaturesEnabled()) {
-      log.debug(
-        "Platform features disabled — skipping record-activity",
-      );
+      log.debug("Platform features disabled — skipping record-activity");
       return;
     }
 
@@ -2355,6 +2355,8 @@ async function main() {
     ...slackThreadRoutes,
     ...thresholdRoutes,
     ...riskClassificationRoutes,
+    ...createLogTailRoutes(config),
+    ...trustRulesRoutes,
     ...createVelayRoutes(velayTunnelClient),
   ]);
   ipcServer.start();

--- a/gateway/src/ipc/assistant-client.ts
+++ b/gateway/src/ipc/assistant-client.ts
@@ -8,9 +8,8 @@
  * - Request:  `{ "id": string, "method": string, "params"?: object }`
  * - Response: `{ "id": string, "result"?: unknown, "error"?: string }`
  *
- * The gateway does not depend on @vellumai/gateway-client, so the one-shot
- * IPC client is implemented inline here following the same pattern as
- * packages/gateway-client/src/ipc-client.ts.
+ * This reverse client stays inline because @vellumai/gateway-client models
+ * assistant-to-gateway calls; this path calls the assistant from the gateway.
  */
 
 import { connect, type Socket } from "node:net";

--- a/gateway/src/ipc/log-tail-handlers.test.ts
+++ b/gateway/src/ipc/log-tail-handlers.test.ts
@@ -2,42 +2,34 @@
  * Tests for gateway log-tail IPC routes.
  */
 
-import { afterEach, describe, expect, mock, test } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { GatewayConfig } from "../config.js";
 
-mock.module("../logger.js", () => {
-  const noop = () => {};
-  const noopLogger = {
-    info: noop,
-    warn: noop,
-    error: noop,
-    debug: noop,
-    trace: noop,
-    fatal: noop,
-    child: () => noopLogger,
-  };
-  return {
-    getLogger: () => noopLogger,
-    initLogger: noop,
-    LOG_FILE_PATTERN: /^gateway-(\d{4}-\d{2}-\d{2})\.log$/,
-    LOG_FILE_JSON_PATTERN: /^gateway-(\d{4}-\d{2}-\d{2})\.jsonl$/,
-  };
-});
+const tailResult = {
+  lines: [{ msg: "warn msg", level: 40 }],
+  truncated: false,
+};
+
+const tailGatewayLogsMock = mock(
+  (
+    _config: GatewayConfig,
+    _params?: Record<string, unknown>,
+  ): typeof tailResult => tailResult,
+);
+
+mock.module("../http/routes/log-tail.js", () => ({
+  tailGatewayLogs: tailGatewayLogsMock,
+}));
 
 const { createLogTailRoutes } = await import("./log-tail-handlers.js");
 
-let tmpDir: string | undefined;
-
-function makeConfig(dir: string | undefined): GatewayConfig {
+function makeConfig(): GatewayConfig {
   return {
     assistantRuntimeBaseUrl: "http://localhost:7821",
     defaultAssistantId: undefined,
     gatewayInternalBaseUrl: "http://127.0.0.1:7830",
-    logFile: { dir, retentionDays: 30 },
+    logFile: { dir: undefined, retentionDays: 30 },
     maxAttachmentBytes: {
       telegram: 20 * 1024 * 1024,
       slack: 100 * 1024 * 1024,
@@ -58,20 +50,13 @@ function makeConfig(dir: string | undefined): GatewayConfig {
   } as GatewayConfig;
 }
 
-function makeLogLine(level: number, msg: string): string {
-  return JSON.stringify({ level, msg, time: Date.now() });
-}
-
-afterEach(() => {
-  if (tmpDir) {
-    rmSync(tmpDir, { recursive: true, force: true });
-    tmpDir = undefined;
-  }
+beforeEach(() => {
+  tailGatewayLogsMock.mockClear();
 });
 
 describe("createLogTailRoutes", () => {
   test("registers gateway_logs_tail with optional params", () => {
-    const route = createLogTailRoutes(makeConfig(undefined))[0];
+    const route = createLogTailRoutes(makeConfig())[0];
 
     expect(route.method).toBe("gateway_logs_tail");
     expect(route.schema?.safeParse(undefined).success).toBe(true);
@@ -79,26 +64,15 @@ describe("createLogTailRoutes", () => {
   });
 
   test("tails gateway logs through the IPC handler", () => {
-    tmpDir = mkdtempSync(join(tmpdir(), "gw-ipc-log-tail-test-"));
-    writeFileSync(
-      join(tmpDir, "gateway-2026-05-04.jsonl"),
-      [
-        makeLogLine(30, "info msg"),
-        makeLogLine(40, "warn msg"),
-        makeLogLine(50, "error msg"),
-      ].join("\n"),
-    );
+    const config = makeConfig();
+    const route = createLogTailRoutes(config)[0];
+    const result = route.handler({ n: 2, level: "warn", module: "mcp" });
 
-    const route = createLogTailRoutes(makeConfig(tmpDir))[0];
-    const result = route.handler({ n: 2, level: "warn" }) as {
-      lines: Array<{ msg: string }>;
-      truncated: boolean;
-    };
-
-    expect(result.truncated).toBe(false);
-    expect(result.lines.map((line) => line.msg)).toEqual([
-      "warn msg",
-      "error msg",
-    ]);
+    expect(result).toBe(tailResult);
+    expect(tailGatewayLogsMock).toHaveBeenCalledWith(config, {
+      n: 2,
+      level: "warn",
+      module: "mcp",
+    });
   });
 });

--- a/gateway/src/ipc/log-tail-handlers.test.ts
+++ b/gateway/src/ipc/log-tail-handlers.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Tests for gateway log-tail IPC routes.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { GatewayConfig } from "../config.js";
+
+mock.module("../logger.js", () => {
+  const noop = () => {};
+  const noopLogger = {
+    info: noop,
+    warn: noop,
+    error: noop,
+    debug: noop,
+    trace: noop,
+    fatal: noop,
+    child: () => noopLogger,
+  };
+  return {
+    getLogger: () => noopLogger,
+    initLogger: noop,
+    LOG_FILE_PATTERN: /^gateway-(\d{4}-\d{2}-\d{2})\.log$/,
+    LOG_FILE_JSON_PATTERN: /^gateway-(\d{4}-\d{2}-\d{2})\.jsonl$/,
+  };
+});
+
+const { createLogTailRoutes } = await import("./log-tail-handlers.js");
+
+let tmpDir: string | undefined;
+
+function makeConfig(dir: string | undefined): GatewayConfig {
+  return {
+    assistantRuntimeBaseUrl: "http://localhost:7821",
+    defaultAssistantId: undefined,
+    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
+    logFile: { dir, retentionDays: 30 },
+    maxAttachmentBytes: {
+      telegram: 20 * 1024 * 1024,
+      slack: 100 * 1024 * 1024,
+      whatsapp: 16 * 1024 * 1024,
+      default: 100 * 1024 * 1024,
+    },
+    maxAttachmentConcurrency: 3,
+    maxWebhookPayloadBytes: 1024 * 1024,
+    port: 7830,
+    routingEntries: [],
+    runtimeInitialBackoffMs: 500,
+    runtimeMaxRetries: 2,
+    runtimeProxyRequireAuth: true,
+    runtimeTimeoutMs: 30000,
+    shutdownDrainMs: 5000,
+    unmappedPolicy: "default",
+    trustProxy: false,
+  } as GatewayConfig;
+}
+
+function makeLogLine(level: number, msg: string): string {
+  return JSON.stringify({ level, msg, time: Date.now() });
+}
+
+afterEach(() => {
+  if (tmpDir) {
+    rmSync(tmpDir, { recursive: true, force: true });
+    tmpDir = undefined;
+  }
+});
+
+describe("createLogTailRoutes", () => {
+  test("registers gateway_logs_tail with optional params", () => {
+    const route = createLogTailRoutes(makeConfig(undefined))[0];
+
+    expect(route.method).toBe("gateway_logs_tail");
+    expect(route.schema?.safeParse(undefined).success).toBe(true);
+    expect(route.schema?.safeParse({ level: "INVALID" }).success).toBe(false);
+  });
+
+  test("tails gateway logs through the IPC handler", () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "gw-ipc-log-tail-test-"));
+    writeFileSync(
+      join(tmpDir, "gateway-2026-05-04.jsonl"),
+      [
+        makeLogLine(30, "info msg"),
+        makeLogLine(40, "warn msg"),
+        makeLogLine(50, "error msg"),
+      ].join("\n"),
+    );
+
+    const route = createLogTailRoutes(makeConfig(tmpDir))[0];
+    const result = route.handler({ n: 2, level: "warn" }) as {
+      lines: Array<{ msg: string }>;
+      truncated: boolean;
+    };
+
+    expect(result.truncated).toBe(false);
+    expect(result.lines.map((line) => line.msg)).toEqual([
+      "warn msg",
+      "error msg",
+    ]);
+  });
+});

--- a/gateway/src/ipc/log-tail-handlers.ts
+++ b/gateway/src/ipc/log-tail-handlers.ts
@@ -5,28 +5,19 @@
  * without requiring the assistant to mint gateway-audience bearer tokens.
  */
 
-import { z } from "zod";
+import { GatewayLogsTailIpcParamsSchema } from "@vellumai/gateway-client/gateway-ipc-contracts";
 
 import type { GatewayConfig } from "../config.js";
-import { LEVEL_NAMES, tailGatewayLogs } from "../http/routes/log-tail.js";
+import { tailGatewayLogs } from "../http/routes/log-tail.js";
 import type { IpcRoute } from "./server.js";
-
-const GatewayLogsTailParamsSchema = z
-  .object({
-    n: z.number().int().min(1).max(1000).optional(),
-    level: z.enum(LEVEL_NAMES).optional(),
-    module: z.string().optional(),
-  })
-  .strict()
-  .default({});
 
 export function createLogTailRoutes(config: GatewayConfig): IpcRoute[] {
   return [
     {
       method: "gateway_logs_tail",
-      schema: GatewayLogsTailParamsSchema,
+      schema: GatewayLogsTailIpcParamsSchema,
       handler: (params?: Record<string, unknown>) =>
-        tailGatewayLogs(config, GatewayLogsTailParamsSchema.parse(params)),
+        tailGatewayLogs(config, GatewayLogsTailIpcParamsSchema.parse(params)),
     },
   ];
 }

--- a/gateway/src/ipc/log-tail-handlers.ts
+++ b/gateway/src/ipc/log-tail-handlers.ts
@@ -1,0 +1,32 @@
+/**
+ * IPC route definitions for gateway log reads.
+ *
+ * Exposes gateway-owned logs to the assistant over the local IPC socket
+ * without requiring the assistant to mint gateway-audience bearer tokens.
+ */
+
+import { z } from "zod";
+
+import type { GatewayConfig } from "../config.js";
+import { LEVEL_NAMES, tailGatewayLogs } from "../http/routes/log-tail.js";
+import type { IpcRoute } from "./server.js";
+
+const GatewayLogsTailParamsSchema = z
+  .object({
+    n: z.number().int().min(1).max(1000).optional(),
+    level: z.enum(LEVEL_NAMES).optional(),
+    module: z.string().optional(),
+  })
+  .strict()
+  .default({});
+
+export function createLogTailRoutes(config: GatewayConfig): IpcRoute[] {
+  return [
+    {
+      method: "gateway_logs_tail",
+      schema: GatewayLogsTailParamsSchema,
+      handler: (params?: Record<string, unknown>) =>
+        tailGatewayLogs(config, GatewayLogsTailParamsSchema.parse(params)),
+    },
+  ];
+}

--- a/gateway/src/ipc/trust-rules-handlers.test.ts
+++ b/gateway/src/ipc/trust-rules-handlers.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for gateway trust-rule IPC routes.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { initGatewayDb, resetGatewayDb } from "../db/connection.js";
+import { TrustRuleStore } from "../db/trust-rule-store.js";
+import { clearFeatureFlagStoreCache } from "../feature-flag-store.js";
+import {
+  initTrustRuleCache,
+  resetTrustRuleCache,
+} from "../risk/trust-rule-cache.js";
+import { trustRulesRoutes } from "./trust-rules-handlers.js";
+import "../__tests__/test-preload.js";
+
+let store: TrustRuleStore;
+
+beforeEach(async () => {
+  resetGatewayDb();
+  resetTrustRuleCache();
+  clearFeatureFlagStoreCache();
+  await initGatewayDb();
+  initTrustRuleCache();
+  store = new TrustRuleStore();
+});
+
+afterEach(() => {
+  resetTrustRuleCache();
+  clearFeatureFlagStoreCache();
+  resetGatewayDb();
+});
+
+describe("trustRulesRoutes", () => {
+  test("registers trust_rules_list with optional params", () => {
+    const route = trustRulesRoutes[0];
+
+    expect(route.method).toBe("trust_rules_list");
+    expect(route.schema?.safeParse(undefined).success).toBe(true);
+    expect(route.schema?.safeParse({ include_all: "true" }).success).toBe(
+      false,
+    );
+  });
+
+  test("lists user-relevant rules through the IPC handler", () => {
+    store.create({
+      tool: "bash",
+      pattern: "echo hello",
+      risk: "low",
+      description: "Allow echo hello",
+    });
+
+    const result = trustRulesRoutes[0].handler({
+      tool: "bash",
+      origin: "user_defined",
+    }) as {
+      rules: Array<{ tool: string; pattern: string; origin: string }>;
+    };
+
+    expect(
+      result.rules.some(
+        (rule) =>
+          rule.tool === "bash" &&
+          rule.pattern === "echo hello" &&
+          rule.origin === "user_defined",
+      ),
+    ).toBe(true);
+    expect(result.rules.every((rule) => rule.tool === "bash")).toBe(true);
+    expect(result.rules.every((rule) => rule.origin === "user_defined")).toBe(
+      true,
+    );
+    expect(
+      result.rules.find((rule) => rule.pattern === "echo hello"),
+    ).toMatchObject({
+      tool: "bash",
+      pattern: "echo hello",
+      origin: "user_defined",
+    });
+  });
+});

--- a/gateway/src/ipc/trust-rules-handlers.test.ts
+++ b/gateway/src/ipc/trust-rules-handlers.test.ts
@@ -2,33 +2,44 @@
  * Tests for gateway trust-rule IPC routes.
  */
 
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import { initGatewayDb, resetGatewayDb } from "../db/connection.js";
-import { TrustRuleStore } from "../db/trust-rule-store.js";
-import { clearFeatureFlagStoreCache } from "../feature-flag-store.js";
-import {
-  initTrustRuleCache,
-  resetTrustRuleCache,
-} from "../risk/trust-rule-cache.js";
+type ListTrustRulesParams = {
+  origin?: string;
+  tool?: string;
+  includeAll?: boolean;
+  includeDeleted?: boolean;
+};
+
+const listResult = {
+  rules: [
+    {
+      id: "rule-123",
+      tool: "bash",
+      pattern: "echo hello",
+      risk: "low",
+      description: "Allow echo hello",
+      origin: "user_defined",
+      userModified: false,
+      deleted: false,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    },
+  ],
+};
+
+const listTrustRulesMock = mock(
+  (_params?: ListTrustRulesParams): typeof listResult => listResult,
+);
+
+mock.module("../http/routes/trust-rules.js", () => ({
+  listTrustRules: listTrustRulesMock,
+}));
+
 import { trustRulesRoutes } from "./trust-rules-handlers.js";
-import "../__tests__/test-preload.js";
 
-let store: TrustRuleStore;
-
-beforeEach(async () => {
-  resetGatewayDb();
-  resetTrustRuleCache();
-  clearFeatureFlagStoreCache();
-  await initGatewayDb();
-  initTrustRuleCache();
-  store = new TrustRuleStore();
-});
-
-afterEach(() => {
-  resetTrustRuleCache();
-  clearFeatureFlagStoreCache();
-  resetGatewayDb();
+beforeEach(() => {
+  listTrustRulesMock.mockClear();
 });
 
 describe("trustRulesRoutes", () => {
@@ -42,39 +53,20 @@ describe("trustRulesRoutes", () => {
     );
   });
 
-  test("lists user-relevant rules through the IPC handler", () => {
-    store.create({
-      tool: "bash",
-      pattern: "echo hello",
-      risk: "low",
-      description: "Allow echo hello",
-    });
-
+  test("lists trust rules through the IPC handler without writing test data", () => {
     const result = trustRulesRoutes[0].handler({
       tool: "bash",
       origin: "user_defined",
-    }) as {
-      rules: Array<{ tool: string; pattern: string; origin: string }>;
-    };
+      include_all: true,
+      include_deleted: true,
+    });
 
-    expect(
-      result.rules.some(
-        (rule) =>
-          rule.tool === "bash" &&
-          rule.pattern === "echo hello" &&
-          rule.origin === "user_defined",
-      ),
-    ).toBe(true);
-    expect(result.rules.every((rule) => rule.tool === "bash")).toBe(true);
-    expect(result.rules.every((rule) => rule.origin === "user_defined")).toBe(
-      true,
-    );
-    expect(
-      result.rules.find((rule) => rule.pattern === "echo hello"),
-    ).toMatchObject({
-      tool: "bash",
-      pattern: "echo hello",
+    expect(result).toBe(listResult);
+    expect(listTrustRulesMock).toHaveBeenCalledWith({
       origin: "user_defined",
+      tool: "bash",
+      includeAll: true,
+      includeDeleted: true,
     });
   });
 });

--- a/gateway/src/ipc/trust-rules-handlers.ts
+++ b/gateway/src/ipc/trust-rules-handlers.ts
@@ -1,0 +1,34 @@
+/**
+ * IPC route definitions for gateway-owned trust rules.
+ */
+
+import { z } from "zod";
+
+import { listTrustRules } from "../http/routes/trust-rules.js";
+import type { IpcRoute } from "./server.js";
+
+const TrustRulesListParamsSchema = z
+  .object({
+    origin: z.string().optional(),
+    tool: z.string().optional(),
+    include_all: z.boolean().optional(),
+    include_deleted: z.boolean().optional(),
+  })
+  .strict()
+  .default({});
+
+export const trustRulesRoutes: IpcRoute[] = [
+  {
+    method: "trust_rules_list",
+    schema: TrustRulesListParamsSchema,
+    handler: (params?: Record<string, unknown>) => {
+      const parsed = TrustRulesListParamsSchema.parse(params);
+      return listTrustRules({
+        origin: parsed.origin,
+        tool: parsed.tool,
+        includeAll: parsed.include_all,
+        includeDeleted: parsed.include_deleted,
+      });
+    },
+  },
+];

--- a/gateway/src/ipc/trust-rules-handlers.ts
+++ b/gateway/src/ipc/trust-rules-handlers.ts
@@ -2,27 +2,17 @@
  * IPC route definitions for gateway-owned trust rules.
  */
 
-import { z } from "zod";
+import { TrustRulesListIpcParamsSchema } from "@vellumai/gateway-client/gateway-ipc-contracts";
 
 import { listTrustRules } from "../http/routes/trust-rules.js";
 import type { IpcRoute } from "./server.js";
 
-const TrustRulesListParamsSchema = z
-  .object({
-    origin: z.string().optional(),
-    tool: z.string().optional(),
-    include_all: z.boolean().optional(),
-    include_deleted: z.boolean().optional(),
-  })
-  .strict()
-  .default({});
-
 export const trustRulesRoutes: IpcRoute[] = [
   {
     method: "trust_rules_list",
-    schema: TrustRulesListParamsSchema,
+    schema: TrustRulesListIpcParamsSchema,
     handler: (params?: Record<string, unknown>) => {
-      const parsed = TrustRulesListParamsSchema.parse(params);
+      const parsed = TrustRulesListIpcParamsSchema.parse(params);
       return listTrustRules({
         origin: parsed.origin,
         tool: parsed.tool,

--- a/packages/gateway-client/bun.lock
+++ b/packages/gateway-client/bun.lock
@@ -6,6 +6,7 @@
       "name": "@vellumai/gateway-client",
       "dependencies": {
         "@vellumai/service-contracts": "file:../service-contracts",
+        "zod": "4.3.6",
       },
       "devDependencies": {
         "@types/bun": "1.3.10",

--- a/packages/gateway-client/package.json
+++ b/packages/gateway-client/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
+    "./gateway-ipc-contracts": "./src/gateway-ipc-contracts.ts",
     "./http-delivery": "./src/http-delivery.ts",
     "./ipc-client": "./src/ipc-client.ts"
   },
@@ -14,7 +15,8 @@
     "test": "bun test src/"
   },
   "dependencies": {
-    "@vellumai/service-contracts": "file:../service-contracts"
+    "@vellumai/service-contracts": "file:../service-contracts",
+    "zod": "4.3.6"
   },
   "devDependencies": {
     "@types/bun": "1.3.10",

--- a/packages/gateway-client/src/__tests__/gateway-client.test.ts
+++ b/packages/gateway-client/src/__tests__/gateway-client.test.ts
@@ -29,7 +29,7 @@ describe("package independence", () => {
     "../types.ts",
     "../http-delivery.ts",
     "../ipc-client.ts",
-    "../trust-rules.ts",
+    "../gateway-ipc-contracts.ts",
   ];
 
   for (const file of sourceFiles) {

--- a/packages/gateway-client/src/gateway-ipc-contracts.ts
+++ b/packages/gateway-client/src/gateway-ipc-contracts.ts
@@ -1,0 +1,87 @@
+/**
+ * Shared IPC contracts for assistant-to-gateway gateway-owned reads.
+ */
+
+import { z } from "zod";
+
+export const GATEWAY_LOG_LEVEL_NAMES = [
+  "trace",
+  "debug",
+  "info",
+  "warn",
+  "error",
+  "fatal",
+] as const;
+export type GatewayLogLevelName = (typeof GATEWAY_LOG_LEVEL_NAMES)[number];
+
+const GatewayLogsTailIpcParamsShape = {
+  n: z.number().int().min(1).max(1000).optional(),
+  level: z.enum(GATEWAY_LOG_LEVEL_NAMES).optional(),
+  module: z.string().optional(),
+};
+
+export const GatewayLogsTailIpcParamsSchema = z
+  .object(GatewayLogsTailIpcParamsShape)
+  .strict()
+  .default({});
+
+export type GatewayLogsTailIpcParams = z.infer<
+  typeof GatewayLogsTailIpcParamsSchema
+>;
+
+export const GatewayLogsTailRouteParamsSchema = z
+  .object({
+    ...GatewayLogsTailIpcParamsShape,
+    n: z.coerce.number().int().min(1).max(1000).optional(),
+  })
+  .strict();
+
+export type GatewayLogsTailRouteParams = z.infer<
+  typeof GatewayLogsTailRouteParamsSchema
+>;
+
+export const GatewayLogsTailIpcResponseSchema = z.object({
+  lines: z.array(z.record(z.string(), z.unknown())),
+  truncated: z.boolean(),
+});
+
+export type GatewayLogsTailIpcResponse = z.infer<
+  typeof GatewayLogsTailIpcResponseSchema
+>;
+
+export const TrustRulesListIpcParamsSchema = z
+  .object({
+    origin: z.string().optional(),
+    tool: z.string().optional(),
+    include_all: z.boolean().optional(),
+    include_deleted: z.boolean().optional(),
+  })
+  .strict()
+  .default({});
+
+export type TrustRulesListIpcParams = z.infer<
+  typeof TrustRulesListIpcParamsSchema
+>;
+
+export const TrustRuleSchema = z.object({
+  id: z.string(),
+  tool: z.string(),
+  pattern: z.string(),
+  risk: z.enum(["low", "medium", "high"]),
+  description: z.string(),
+  origin: z.enum(["default", "user_defined"]),
+  userModified: z.boolean(),
+  deleted: z.boolean(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export type TrustRule = z.infer<typeof TrustRuleSchema>;
+
+export const TrustRulesListIpcResponseSchema = z.object({
+  rules: z.array(TrustRuleSchema),
+});
+
+export type TrustRulesListIpcResponse = z.infer<
+  typeof TrustRulesListIpcResponseSchema
+>;

--- a/packages/gateway-client/src/index.ts
+++ b/packages/gateway-client/src/index.ts
@@ -15,11 +15,9 @@ export {
   deliverChannelReply,
 } from "./http-delivery.js";
 
-export {
-  ipcCall,
-  IpcCallError,
-  PersistentIpcClient,
-} from "./ipc-client.js";
+export * from "./gateway-ipc-contracts.js";
+
+export { ipcCall, IpcCallError, PersistentIpcClient } from "./ipc-client.js";
 
 export type {
   ApprovalActionOption,


### PR DESCRIPTION
## Summary

- Move assistant gateway log-tail and trust-rules reads from gateway HTTP onto the gateway IPC socket.
- Share the gateway-owned log-tail and trust-rules IPC schemas from `@vellumai/gateway-client` so assistant and gateway validate the same contracts.
- Use persistent gateway IPC calls so socket, timeout, parse, and handler failures surface with their original errors instead of collapsing to a generic `undefined` failure.
- Remove the assistant-minted gateway proxy token helper and the temporary `gateway_proxy_read_v1` scope profile.

## Root Cause

The assistant was proxying gateway-owned reads by calling authenticated gateway HTTP endpoints without `Authorization`, so local requests succeeded only through the gateway's legacy loopback fallback and showed up as `missing_authorization` fallback telemetry.

Minting gateway-audience tokens in the assistant would suppress the telemetry, but it keeps gateway signing material coupled to the assistant. Using gateway IPC keeps these local service-to-service reads on the existing socket boundary and avoids gateway HTTP auth entirely.

## HTTP Route Status

This PR moves the assistant-owned callers; it does not remove or deprecate the gateway HTTP endpoints. Direct HTTP callers still go through the existing gateway auth and fallback behavior. Before any production flip, we should verify on dev that assistant-driven `missing_authorization` fallback telemetry drops, then separately audit whether the HTTP endpoints still have non-assistant callers before planning deprecation.

## Validation

- `cd assistant && bun test src/runtime/routes/__tests__/gateway-log-routes.test.ts src/ipc/routes/trust-rules.test.ts`
- `cd gateway && bun test src/ipc/log-tail-handlers.test.ts src/ipc/trust-rules-handlers.test.ts src/__tests__/trust-rules-routes.test.ts`
- `cd packages/gateway-client && bun test src/__tests__/package-boundary.test.ts`
- `cd packages/gateway-client && bunx tsc --noEmit`
- `cd gateway && bunx tsc --noEmit`
- `cd assistant && bunx tsc --noEmit`
