### PR TITLE
feat(web): drop a wrong-org selection before the API round-trip

### DIFF
--- a/apps/web/src/assistant/use-lifecycle.test.ts
+++ b/apps/web/src/assistant/use-lifecycle.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Tests the proactive wrong-org guard that the lifecycle hook applies to
+ * the per-org platform selection before handing it to the service. A
+ * known cross-org selection resolves to null up front; matching-org and
+ * not-yet-resolved (unknown) ids pass through so the 404 net in
+ * `lifecycle-service.ts` still covers ids the client can't see.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { resolveSelectedPlatformAssistantId } from "@/assistant/use-lifecycle";
+import type { ResolvedAssistant } from "@/stores/resolved-assistants-store";
+
+const ORG_A = "org-a";
+const ORG_B = "org-b";
+
+function platformAssistant(
+  id: string,
+  organizationId?: string,
+): ResolvedAssistant {
+  return {
+    id,
+    isLocal: false,
+    isPlatformHosted: true,
+    organizationId,
+  };
+}
+
+describe("resolveSelectedPlatformAssistantId", () => {
+  test("drops a selection whose entry belongs to another org", () => {
+    const assistants = [platformAssistant("asst-1", ORG_B)];
+    expect(
+      resolveSelectedPlatformAssistantId("asst-1", assistants, ORG_A),
+    ).toBeNull();
+  });
+
+  test("passes through a selection whose entry matches the active org", () => {
+    const assistants = [platformAssistant("asst-1", ORG_A)];
+    expect(
+      resolveSelectedPlatformAssistantId("asst-1", assistants, ORG_A),
+    ).toBe("asst-1");
+  });
+
+  test("passes through an id with no resolved entry (404 net applies)", () => {
+    const assistants = [platformAssistant("asst-other", ORG_A)];
+    expect(
+      resolveSelectedPlatformAssistantId("asst-unknown", assistants, ORG_A),
+    ).toBe("asst-unknown");
+  });
+
+  test("passes through a legacy entry with no org (undefined)", () => {
+    const assistants = [platformAssistant("asst-1", undefined)];
+    expect(
+      resolveSelectedPlatformAssistantId("asst-1", assistants, ORG_A),
+    ).toBe("asst-1");
+  });
+
+  test("returns null when there is no candidate", () => {
+    expect(resolveSelectedPlatformAssistantId(null, [], ORG_A)).toBeNull();
+  });
+});

--- a/apps/web/src/assistant/use-lifecycle.ts
+++ b/apps/web/src/assistant/use-lifecycle.ts
@@ -22,12 +22,34 @@ import { isLocalMode } from "@/lib/local-mode";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import { isAuthenticated, type SessionStatus } from "@/stores/session-status";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
-import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import {
+  assistantsValidForOrg,
+  useResolvedAssistantsStore,
+  type ResolvedAssistant,
+} from "@/stores/resolved-assistants-store";
 import { useOrganizationStore } from "@/stores/organization-store";
 
 interface UseAssistantLifecycleOptions {
   sessionStatus: SessionStatus;
   hasPlatformSession: boolean;
+}
+
+/**
+ * Drop a per-org selection the resolved list already shows is wrong-org.
+ * A candidate is kept if it has no resolved entry yet (unknown id — let
+ * the 404 net handle it) or its entry survives `assistantsValidForOrg`.
+ * A known entry owned by a different org resolves to null up front.
+ */
+export function resolveSelectedPlatformAssistantId(
+  candidateId: string | null,
+  assistants: ResolvedAssistant[],
+  currentOrganizationId: string | null,
+): string | null {
+  if (candidateId === null) return null;
+  const entry = assistants.find((a) => a.id === candidateId);
+  if (!entry) return candidateId;
+  const valid = assistantsValidForOrg(assistants, currentOrganizationId);
+  return valid.some((a) => a.id === candidateId) ? candidateId : null;
 }
 
 export function useAssistantLifecycle({
@@ -60,12 +82,20 @@ export function useAssistantLifecycle({
     useClientFeatureFlagStore.use.multiPlatformAssistant();
   const byOrg =
     useResolvedAssistantsStore.use.selectedPlatformAssistantByOrg();
-  const selectedPlatformAssistantId =
+  const assistants = useResolvedAssistantsStore.use.assistants();
+  const candidatePlatformAssistantId =
     multiAssistantEnabled &&
     !isGatewayAuthMode() &&
     currentOrganizationId
       ? (byOrg[currentOrganizationId] ?? null)
       : null;
+  // A selection the resolved list already attributes to another org is
+  // dropped here, before the API can 404 on it.
+  const selectedPlatformAssistantId = resolveSelectedPlatformAssistantId(
+    candidatePlatformAssistantId,
+    assistants,
+    currentOrganizationId,
+  );
 
   const { data: assistantResult } = useAssistantQuery({
     enabled: shouldQueryServer,


### PR DESCRIPTION
## Summary
- Validate the per-org platform selection against the resolved-assistants list: a selection whose entry belongs to another org resolves to null up front instead of waiting for a 404
- The 404 fallback remains the safety net for ids not yet in the lockfile

Part of plan: assistant-selection-unify.md (PR 5 of 8)