### PR TITLE
fix(mac-helper): pin dictation speech recognition on-device when supported

### DIFF
--- a/apps/macos/native/mac-helper/Sources/MacHelperExecutable/DictationPartials.swift
+++ b/apps/macos/native/mac-helper/Sources/MacHelperExecutable/DictationPartials.swift
@@ -52,6 +52,14 @@ final class DictationPartialsSession: @unchecked Sendable {
         }
 
         request.shouldReportPartialResults = true
+        // Pin recognition on-device when the locale has a local model:
+        // dictation audio shouldn't leave the machine, and it keeps the
+        // transcript working offline. Locales without an on-device model
+        // stay on Apple's server path — forcing the flag there would fail
+        // recognition outright instead of degrading.
+        if recognizer.supportsOnDeviceRecognition {
+            request.requiresOnDeviceRecognition = true
+        }
 
         let input = audioEngine.inputNode
         let format = input.outputFormat(forBus: 0)


### PR DESCRIPTION
## Summary
- `DictationPartialsSession` now sets `requiresOnDeviceRecognition = true` on its `SFSpeechAudioBufferRecognitionRequest` whenever the recognizer's locale has an on-device model, so dictation audio stays on the machine and the helper's live transcript keeps working offline.
- Locales without an on-device model keep Apple's server-based path — forcing the flag there would fail recognition outright instead of degrading.
- Mirrors the legacy Swift client's behavior (`OpenAIVoiceService.swift`), which used the same `supportsOnDeviceRecognition` guard.

## Original prompt
While auditing LUM-1968 (dictation voice input pipeline) against the codebase, one of the identified gaps was that the mac-helper's `DictationPartials.swift` never set `requiresOnDeviceRecognition`, so `SFSpeechRecognizer` could route dictation audio through Apple's servers and offline transcription wasn't guaranteed on the helper path. The user asked to implement this item: guarantee on-device recognition where the platform supports it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)