### PR TITLE
Add skill_loaded_events table and store

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -37,6 +37,7 @@ import {
   createOnboardingEventsTable,
   createScopedApprovalGrantsTable,
   createSequenceTables,
+  createSkillLoadedEventsTable,
   createTasksAndWorkItemsTables,
   createWatchersAndLogsTables,
   migrate230AcpSessionHistory,
@@ -490,6 +491,7 @@ export function initializeDb(): void {
     migrateToolInvocationsSkillId,
     migrateToolInvocationsCreatedAtIdIndex,
     migrateAddMemoryV3EverInjected,
+    createSkillLoadedEventsTable,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/279-create-skill-loaded-events.test.ts
+++ b/assistant/src/memory/migrations/279-create-skill-loaded-events.test.ts
@@ -1,0 +1,84 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import * as schema from "../schema.js";
+import { createSkillLoadedEventsTable } from "./279-create-skill-loaded-events.js";
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  return { sqlite, db: drizzle(sqlite, { schema }) };
+}
+
+function columnNames(sqlite: Database): string[] {
+  return (
+    sqlite.query("PRAGMA table_info(skill_loaded_events)").all() as Array<{
+      name: string;
+    }>
+  ).map((c) => c.name);
+}
+
+function indexNames(sqlite: Database): string[] {
+  return (
+    sqlite.query("PRAGMA index_list(skill_loaded_events)").all() as Array<{
+      name: string;
+    }>
+  ).map((i) => i.name);
+}
+
+describe("migration 279: skill_loaded_events table", () => {
+  test("creates the table with the expected columns", () => {
+    const { sqlite, db } = createTestDb();
+
+    createSkillLoadedEventsTable(db);
+
+    expect(columnNames(sqlite)).toEqual([
+      "id",
+      "created_at",
+      "conversation_id",
+      "skill_name",
+      "skill_updated_at",
+      "provider",
+      "model",
+      "inference_profile",
+      "inference_profile_source",
+    ]);
+  });
+
+  test("creates the (created_at, id) cursor index", () => {
+    const { sqlite, db } = createTestDb();
+
+    createSkillLoadedEventsTable(db);
+
+    expect(indexNames(sqlite)).toContain(
+      "idx_skill_loaded_events_created_at_id",
+    );
+    const columns = (
+      sqlite
+        .query("PRAGMA index_info(idx_skill_loaded_events_created_at_id)")
+        .all() as Array<{ name: string }>
+    ).map((c) => c.name);
+    expect(columns).toEqual(["created_at", "id"]);
+  });
+
+  test("is idempotent — re-run is a no-op and preserves existing rows", () => {
+    const { sqlite, db } = createTestDb();
+
+    createSkillLoadedEventsTable(db);
+    sqlite.exec(/*sql*/ `
+      INSERT INTO skill_loaded_events (id, created_at, skill_name)
+      VALUES ('sle-1', 1000, 'web-research')
+    `);
+
+    expect(() => createSkillLoadedEventsTable(db)).not.toThrow();
+
+    const rows = sqlite.query("SELECT id FROM skill_loaded_events").all();
+    expect(rows).toEqual([{ id: "sle-1" }]);
+    expect(
+      indexNames(sqlite).filter(
+        (name) => name === "idx_skill_loaded_events_created_at_id",
+      ),
+    ).toHaveLength(1);
+  });
+});

--- a/assistant/src/memory/migrations/279-create-skill-loaded-events.ts
+++ b/assistant/src/memory/migrations/279-create-skill-loaded-events.ts
@@ -1,0 +1,27 @@
+import type { DrizzleDb } from "../db-connection.js";
+
+/**
+ * Create the skill_loaded_events table for `skill_loaded` telemetry events.
+ * One row per activation of a Vellum-produced skill — metadata only, never
+ * skill output or conversation content. Rows are flushed to the platform
+ * telemetry endpoint by the usage telemetry reporter, which seeks with a
+ * compound `(created_at, id)` watermark cursor backed by the index below.
+ */
+export function createSkillLoadedEventsTable(database: DrizzleDb): void {
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS skill_loaded_events (
+      id TEXT PRIMARY KEY,
+      created_at INTEGER NOT NULL,
+      conversation_id TEXT,
+      skill_name TEXT NOT NULL,
+      skill_updated_at TEXT,
+      provider TEXT,
+      model TEXT,
+      inference_profile TEXT,
+      inference_profile_source TEXT
+    )
+  `);
+  database.run(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_skill_loaded_events_created_at_id ON skill_loaded_events (created_at, id)`,
+  );
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -265,6 +265,7 @@ export { createActivationSessionsTable } from "./274-create-activation-sessions.
 export { migrateToolInvocationsSkillId } from "./275-tool-invocations-add-skill-id.js";
 export { migrateToolInvocationsCreatedAtIdIndex } from "./276-tool-invocations-created-at-id-index.js";
 export { migrateAddMemoryV3EverInjected } from "./277-add-memory-v3-ever-injected.js";
+export { createSkillLoadedEventsTable } from "./279-create-skill-loaded-events.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/infrastructure.ts
+++ b/assistant/src/memory/schema/infrastructure.ts
@@ -307,6 +307,32 @@ export const activationSessions = sqliteTable("activation_sessions", {
   createdAt: integer("created_at").notNull(),
 });
 
+// One row per `skill_loaded` telemetry event, emitted when a Vellum-produced
+// skill is activated in a conversation. Metadata only — never skill output or
+// conversation content. Flushed to the platform telemetry endpoint by the
+// usage telemetry reporter via a compound (created_at, id) watermark cursor.
+export const skillLoadedEvents = sqliteTable(
+  "skill_loaded_events",
+  {
+    id: text("id").primaryKey(),
+    createdAt: integer("created_at").notNull(),
+    conversationId: text("conversation_id"),
+    skillName: text("skill_name").notNull(),
+    // ISO 8601 timestamp from the merged skill catalog, when known.
+    skillUpdatedAt: text("skill_updated_at"),
+    provider: text("provider"),
+    model: text("model"),
+    inferenceProfile: text("inference_profile"),
+    inferenceProfileSource: text("inference_profile_source"),
+  },
+  (table) => [
+    index("idx_skill_loaded_events_created_at_id").on(
+      table.createdAt,
+      table.id,
+    ),
+  ],
+);
+
 export const traceEvents = sqliteTable(
   "trace_events",
   {

--- a/assistant/src/memory/skill-loaded-events-store.test.ts
+++ b/assistant/src/memory/skill-loaded-events-store.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Silence the logger.
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import { getDb } from "./db-connection.js";
+import { initializeDb } from "./db-init.js";
+import { skillLoadedEvents } from "./schema.js";
+import {
+  queryUnreportedSkillLoadedEvents,
+  recordSkillLoadedEvent,
+} from "./skill-loaded-events-store.js";
+
+initializeDb();
+
+function insertEvent(
+  id: string,
+  createdAt: number,
+  skillName = "web-research",
+): void {
+  getDb().insert(skillLoadedEvents).values({ id, createdAt, skillName }).run();
+}
+
+describe("skill-loaded-events-store", () => {
+  beforeEach(() => {
+    getDb().delete(skillLoadedEvents).run();
+  });
+
+  test("record + query round-trips all fields", () => {
+    recordSkillLoadedEvent({
+      conversationId: "conv-xyz",
+      skillName: "web-research",
+      skillUpdatedAt: "2026-06-01T00:00:00.000Z",
+      provider: "anthropic",
+      model: "model-a",
+      inferenceProfile: "balanced",
+      inferenceProfileSource: "active-profile",
+    });
+
+    const rows = queryUnreportedSkillLoadedEvents(0, undefined, 10);
+    expect(rows).toHaveLength(1);
+    const row = rows[0]!;
+    expect(row.id).toBeString();
+    expect(row.createdAt).toBeGreaterThan(0);
+    expect(row).toMatchObject({
+      conversationId: "conv-xyz",
+      skillName: "web-research",
+      skillUpdatedAt: "2026-06-01T00:00:00.000Z",
+      provider: "anthropic",
+      model: "model-a",
+      inferenceProfile: "balanced",
+      inferenceProfileSource: "active-profile",
+    });
+  });
+
+  test("optional fields persist as null", () => {
+    recordSkillLoadedEvent({ skillName: "tasks" });
+
+    const rows = queryUnreportedSkillLoadedEvents(0, undefined, 10);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      skillName: "tasks",
+      conversationId: null,
+      skillUpdatedAt: null,
+      provider: null,
+      model: null,
+      inferenceProfile: null,
+      inferenceProfileSource: null,
+    });
+  });
+
+  test("returns rows in (createdAt, id) order", () => {
+    insertEvent("sle-b", 2000);
+    insertEvent("sle-a", 1000);
+
+    const rows = queryUnreportedSkillLoadedEvents(0, undefined, 100);
+    expect(rows.map((r) => r.id)).toEqual(["sle-a", "sle-b"]);
+  });
+
+  test("query advances past the compound (createdAt, id) cursor", () => {
+    // Two rows in the same millisecond: pagination must use the id
+    // tiebreaker to make forward progress, not loop.
+    insertEvent("sle-1", 5000);
+    insertEvent("sle-2", 5000);
+    insertEvent("sle-3", 6000);
+
+    const first = queryUnreportedSkillLoadedEvents(0, undefined, 1);
+    expect(first.map((r) => r.id)).toEqual(["sle-1"]);
+
+    const second = queryUnreportedSkillLoadedEvents(
+      first[0]!.createdAt,
+      first[0]!.id,
+      100,
+    );
+    expect(second.map((r) => r.id)).toEqual(["sle-2", "sle-3"]);
+
+    // Without an id cursor the timestamp-only branch is used.
+    expect(
+      queryUnreportedSkillLoadedEvents(5000, undefined, 100).map((r) => r.id),
+    ).toEqual(["sle-3"]);
+
+    // Cursor past the last row returns nothing.
+    const last = second[second.length - 1]!;
+    expect(
+      queryUnreportedSkillLoadedEvents(last.createdAt, last.id, 100).length,
+    ).toBe(0);
+  });
+
+  test("resumes from a persisted watermark without re-reporting", () => {
+    insertEvent("sle-w1", 1000);
+    insertEvent("sle-w2", 2000);
+
+    const batch = queryUnreportedSkillLoadedEvents(0, undefined, 100);
+    const watermark = batch[batch.length - 1]!;
+
+    insertEvent("sle-w3", 3000);
+
+    const resumed = queryUnreportedSkillLoadedEvents(
+      watermark.createdAt,
+      watermark.id,
+      100,
+    );
+    expect(resumed.map((r) => r.id)).toEqual(["sle-w3"]);
+  });
+
+  test("honors the limit", () => {
+    insertEvent("sle-l1", 1000);
+    insertEvent("sle-l2", 2000);
+    insertEvent("sle-l3", 3000);
+
+    const rows = queryUnreportedSkillLoadedEvents(0, undefined, 2);
+    expect(rows.map((r) => r.id)).toEqual(["sle-l1", "sle-l2"]);
+  });
+});

--- a/assistant/src/memory/skill-loaded-events-store.ts
+++ b/assistant/src/memory/skill-loaded-events-store.ts
@@ -1,0 +1,90 @@
+import { and, asc, eq, gt, or } from "drizzle-orm";
+import { v4 as uuid } from "uuid";
+
+import { getDb } from "./db-connection.js";
+import { skillLoadedEvents } from "./schema.js";
+
+/**
+ * Input for one `skill_loaded` telemetry event. Metadata only — never skill
+ * output or conversation content.
+ */
+export interface SkillLoadedEventRecord {
+  conversationId?: string;
+  skillName: string;
+  /** ISO 8601 timestamp from the merged skill catalog, when known. */
+  skillUpdatedAt?: string;
+  provider?: string;
+  model?: string;
+  inferenceProfile?: string;
+  inferenceProfileSource?: string;
+}
+
+/** A persisted skill_loaded event row. */
+export interface SkillLoadedEvent {
+  id: string;
+  createdAt: number;
+  conversationId: string | null;
+  skillName: string;
+  skillUpdatedAt: string | null;
+  provider: string | null;
+  model: string | null;
+  inferenceProfile: string | null;
+  inferenceProfileSource: string | null;
+}
+
+/** Record a `skill_loaded` telemetry event for a skill activation. */
+export function recordSkillLoadedEvent(record: SkillLoadedEventRecord): void {
+  const db = getDb();
+  db.insert(skillLoadedEvents)
+    .values({
+      id: uuid(),
+      createdAt: Date.now(),
+      conversationId: record.conversationId,
+      skillName: record.skillName,
+      skillUpdatedAt: record.skillUpdatedAt,
+      provider: record.provider,
+      model: record.model,
+      inferenceProfile: record.inferenceProfile,
+      inferenceProfileSource: record.inferenceProfileSource,
+    })
+    .run();
+}
+
+/**
+ * Query skill_loaded events that haven't been reported to telemetry yet.
+ * Uses a compound cursor (createdAt + id) for reliable watermarking.
+ */
+export function queryUnreportedSkillLoadedEvents(
+  afterCreatedAt: number,
+  afterId: string | undefined,
+  limit: number,
+): SkillLoadedEvent[] {
+  const db = getDb();
+  return db
+    .select({
+      id: skillLoadedEvents.id,
+      createdAt: skillLoadedEvents.createdAt,
+      conversationId: skillLoadedEvents.conversationId,
+      skillName: skillLoadedEvents.skillName,
+      skillUpdatedAt: skillLoadedEvents.skillUpdatedAt,
+      provider: skillLoadedEvents.provider,
+      model: skillLoadedEvents.model,
+      inferenceProfile: skillLoadedEvents.inferenceProfile,
+      inferenceProfileSource: skillLoadedEvents.inferenceProfileSource,
+    })
+    .from(skillLoadedEvents)
+    .where(
+      afterId
+        ? or(
+            gt(skillLoadedEvents.createdAt, afterCreatedAt),
+            and(
+              eq(skillLoadedEvents.createdAt, afterCreatedAt),
+              gt(skillLoadedEvents.id, afterId),
+            ),
+          )
+        : gt(skillLoadedEvents.createdAt, afterCreatedAt),
+    )
+    .orderBy(asc(skillLoadedEvents.createdAt), asc(skillLoadedEvents.id))
+    .limit(limit)
+    .all();
+}


### PR DESCRIPTION
## Summary
- Adds migration 279 creating the skill_loaded_events table with a (created_at, id) compound index
- Adds skill-loaded-events-store with recordSkillLoadedEvent and queryUnreportedSkillLoadedEvents using the standard telemetry cursor semantics

Part of plan: tool-skill-telemetry.md (PR 4 of 6)