### PR TITLE
Thread conversation model attribution into ToolContext and tool lifecycle events

### DIFF
--- a/assistant/src/__tests__/conversation-tool-setup-attribution.test.ts
+++ b/assistant/src/__tests__/conversation-tool-setup-attribution.test.ts
@@ -1,10 +1,10 @@
 /**
  * Tests for conversation model attribution threading in
  * conversation-tool-setup.ts: `resolveConversationAttribution` must mirror
- * the main-loop usage path (mainAgent call site + per-turn override
- * profile), `createToolExecutor` must stamp the snapshot onto the
- * ToolContext handed to the executor, and attribution resolution failures
- * must never break tool execution.
+ * the agent-loop usage path (the current turn's call site — defaulting to
+ * mainAgent — plus the per-turn override profile), `createToolExecutor`
+ * must stamp the snapshot onto the ToolContext handed to the executor, and
+ * attribution resolution failures must never break tool execution.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -214,6 +214,64 @@ describe("resolveConversationAttribution", () => {
     });
   });
 
+  test("attributes non-main turns to the turn call site like the usage path (voice callAgent)", () => {
+    setLlmConfig({
+      default: { provider: "anthropic", model: "model-default" },
+      profiles: {
+        active: { provider: "openai", model: "model-active" },
+        pinned: { provider: "gemini", model: "model-pinned" },
+      },
+      activeProfile: "active",
+      callSites: { callAgent: { profile: "pinned" } },
+    });
+
+    const snapshot = resolveConversationAttribution({
+      conversationId: "conv-test",
+      currentCallSite: "callAgent",
+    });
+
+    // Matches resolveUsageAttribution semantics for non-main call sites:
+    // the call-site profile wins (profileSource "call_site"), not the
+    // workspace active profile the mainAgent path would report.
+    expect(snapshot).toMatchObject({
+      callSite: "callAgent",
+      activeProfile: "active",
+      callSiteProfile: "pinned",
+      appliedProfile: "pinned",
+      profileSource: "call_site",
+      resolvedProvider: "gemini",
+      resolvedModel: "model-pinned",
+    });
+  });
+
+  test("non-main call sites prefer the call-site profile over the conversation override", () => {
+    setLlmConfig({
+      default: { provider: "anthropic", model: "model-default" },
+      profiles: {
+        active: { provider: "openai", model: "model-active" },
+        pinned: { provider: "gemini", model: "model-pinned" },
+      },
+      activeProfile: "active",
+      callSites: { callAgent: { profile: "pinned" } },
+    });
+
+    const snapshot = resolveConversationAttribution({
+      conversationId: "conv-test",
+      currentCallSite: "callAgent",
+      currentTurnOverrideProfile: "active",
+    });
+
+    expect(snapshot).toMatchObject({
+      callSite: "callAgent",
+      overrideProfile: "active",
+      callSiteProfile: "pinned",
+      appliedProfile: "pinned",
+      profileSource: "call_site",
+      resolvedProvider: "gemini",
+      resolvedModel: "model-pinned",
+    });
+  });
+
   test("resolves profileSource default when no profiles apply", () => {
     setLlmConfig({
       default: { provider: "anthropic", model: "model-default" },
@@ -256,6 +314,35 @@ describe("createToolExecutor attribution threading", () => {
       callSite: "mainAgent",
       appliedProfile: "pinned",
       profileSource: "conversation",
+      resolvedProvider: "gemini",
+      resolvedModel: "model-pinned",
+    });
+  });
+
+  test("threads a non-main turn call site (voice callAgent) into the snapshot", async () => {
+    setLlmConfig({
+      default: { provider: "anthropic", model: "model-default" },
+      profiles: {
+        active: { provider: "openai", model: "model-active" },
+        pinned: { provider: "gemini", model: "model-pinned" },
+      },
+      activeProfile: "active",
+      callSites: { callAgent: { profile: "pinned" } },
+    });
+
+    const { executor, calls } = makeCapturingExecutor();
+    const toolFn = makeToolFn(
+      executor,
+      makeCtx({ currentCallSite: "callAgent" }),
+    );
+
+    await toolFn("file_read", { path: "/tmp/a" });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].context.attribution).toMatchObject({
+      callSite: "callAgent",
+      appliedProfile: "pinned",
+      profileSource: "call_site",
       resolvedProvider: "gemini",
       resolvedModel: "model-pinned",
     });

--- a/assistant/src/__tests__/conversation-tool-setup-attribution.test.ts
+++ b/assistant/src/__tests__/conversation-tool-setup-attribution.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Tests for conversation model attribution threading in
+ * conversation-tool-setup.ts: `resolveConversationAttribution` must mirror
+ * the main-loop usage path (mainAgent call site + per-turn override
+ * profile), `createToolExecutor` must stamp the snapshot onto the
+ * ToolContext handed to the executor, and attribution resolution failures
+ * must never break tool execution.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { ToolSetupContext } from "../daemon/conversation-tool-setup.js";
+import type { SurfaceData, SurfaceType } from "../daemon/message-protocol.js";
+import type { PermissionPrompter } from "../permissions/prompter.js";
+import type { SecretPrompter } from "../permissions/secret-prompter.js";
+import type { ToolExecutor } from "../tools/executor.js";
+import type { ToolContext, ToolExecutionResult } from "../tools/types.js";
+
+// ---------------------------------------------------------------------------
+// Module mocks (must precede the import of the module under test)
+// ---------------------------------------------------------------------------
+
+let mockLlmConfig: Record<string, unknown> = {};
+let configThrows = false;
+
+// Non-llm fields used by other conversation-tool-setup consumers (e.g.
+// createResolveToolsCallback reads `tools.exclude`), so test files sharing
+// this process keep working against the mocked loader.
+const baseConfig = {
+  tools: { exclude: [] as string[] },
+  timeouts: {
+    shellDefaultTimeoutSec: 120,
+    shellMaxTimeoutSec: 600,
+    permissionTimeoutSec: 300,
+    toolExecutionTimeoutSec: 600,
+  },
+  services: {},
+};
+
+function mockGetConfig() {
+  if (configThrows) throw new Error("config unavailable");
+  return { ...baseConfig, llm: mockLlmConfig };
+}
+
+mock.module("../config/loader.js", () => ({
+  getConfig: mockGetConfig,
+  loadConfig: mockGetConfig,
+  invalidateConfigCache: () => {},
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  getNestedValue: () => undefined,
+  setNestedValue: () => {},
+}));
+
+mock.module("../runtime/assistant-event-hub.js", () => ({
+  broadcastMessage: mock(() => {}),
+}));
+
+mock.module("../daemon/conversation-surfaces.js", () => ({
+  refreshSurfacesForApp: mock(() => {}),
+  surfaceProxyResolver: mock(() =>
+    Promise.resolve({ content: "", isError: false }),
+  ),
+}));
+
+mock.module("../services/published-app-updater.js", () => ({
+  updatePublishedAppDeployment: mock(() => Promise.resolve()),
+}));
+
+mock.module("../tools/browser/browser-screencast.js", () => ({
+  registerConversationSender: mock(() => {}),
+}));
+
+mock.module("../memory/app-store.js", () => ({
+  getApp: mock(() => null),
+  getAppDirPath: mock(() => "/tmp/test-apps/dummy"),
+  isMultifileApp: mock(() => false),
+  getAppsDir: mock(() => "/tmp/test-apps"),
+  resolveAppIdByDirName: mock(() => null),
+  resolveAppIdFromPath: mock(() => null),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports after mocks are in place
+// ---------------------------------------------------------------------------
+
+import { LLMSchema } from "../config/schemas/llm.js";
+import {
+  createToolExecutor,
+  resolveConversationAttribution,
+} from "../daemon/conversation-tool-setup.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setLlmConfig(raw: unknown): void {
+  mockLlmConfig = LLMSchema.parse(raw) as Record<string, unknown>;
+}
+
+/** Build a minimal ToolSetupContext stub. */
+function makeCtx(overrides: Partial<ToolSetupContext> = {}): ToolSetupContext {
+  return {
+    conversationId: "conv-test",
+    currentRequestId: "req-1",
+    workingDir: "/tmp/test",
+    abortController: null,
+    traceEmitter: { emit: () => {} },
+    sendToClient: mock(() => {}),
+    pendingSurfaceActions: new Map(),
+    lastSurfaceAction: new Map(),
+    surfaceState: new Map<
+      string,
+      { surfaceType: SurfaceType; data: SurfaceData; title?: string }
+    >(),
+    surfaceUndoStacks: new Map(),
+    accumulatedSurfaceState: new Map(),
+    surfaceActionRequestIds: new Set<string>(),
+    currentTurnSurfaces: [],
+    isProcessing: () => false,
+    enqueueMessage: () => ({ queued: false, requestId: "r" }),
+    getQueueDepth: () => 0,
+    processMessage: async () => "",
+    withSurface: async <T>(_id: string, fn: () => T | Promise<T>) => fn(),
+    ...overrides,
+  };
+}
+
+/** Fake ToolExecutor that captures the context of each execute() call. */
+function makeCapturingExecutor() {
+  const calls: Array<{ name: string; context: ToolContext }> = [];
+  const executor = {
+    execute: async (
+      name: string,
+      _input: Record<string, unknown>,
+      context: ToolContext,
+    ): Promise<ToolExecutionResult> => {
+      calls.push({ name, context });
+      return { content: "ok", isError: false };
+    },
+  };
+  return { executor: executor as unknown as ToolExecutor, calls };
+}
+
+const noopPrompter = {
+  prompt: mock(async () => ({ decision: "allow" as const })),
+} as unknown as PermissionPrompter;
+const noopSecretPrompter = {
+  prompt: mock(async () => ({ cancelled: true })),
+} as unknown as SecretPrompter;
+
+function makeToolFn(executor: ToolExecutor, ctx: ToolSetupContext) {
+  return createToolExecutor(
+    executor,
+    noopPrompter,
+    noopSecretPrompter,
+    ctx,
+    () => {},
+  );
+}
+
+// The module mock outlives this file when multiple test files share a
+// process, so leave the config in a working (non-throwing) state.
+afterEach(() => {
+  configThrows = false;
+});
+
+beforeEach(() => {
+  configThrows = false;
+  setLlmConfig({
+    default: { provider: "anthropic", model: "model-default" },
+    profiles: {
+      active: { provider: "openai", model: "model-active" },
+      pinned: { provider: "gemini", model: "model-pinned" },
+    },
+    activeProfile: "active",
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("resolveConversationAttribution", () => {
+  test("attributes the conversation's override profile like the main-loop usage path", () => {
+    const snapshot = resolveConversationAttribution({
+      conversationId: "conv-test",
+      currentTurnOverrideProfile: "pinned",
+    });
+
+    expect(snapshot).toMatchObject({
+      callSite: "mainAgent",
+      activeProfile: "active",
+      overrideProfile: "pinned",
+      appliedProfile: "pinned",
+      profileSource: "conversation",
+      resolvedProvider: "gemini",
+      resolvedModel: "model-pinned",
+    });
+  });
+
+  test("falls back to the workspace active profile when no override is set", () => {
+    const snapshot = resolveConversationAttribution({
+      conversationId: "conv-test",
+    });
+
+    expect(snapshot).toMatchObject({
+      callSite: "mainAgent",
+      overrideProfile: null,
+      appliedProfile: "active",
+      profileSource: "active",
+      resolvedProvider: "openai",
+      resolvedModel: "model-active",
+    });
+  });
+
+  test("resolves profileSource default when no profiles apply", () => {
+    setLlmConfig({
+      default: { provider: "anthropic", model: "model-default" },
+    });
+
+    const snapshot = resolveConversationAttribution({
+      conversationId: "conv-test",
+    });
+
+    expect(snapshot).toMatchObject({
+      appliedProfile: null,
+      profileSource: "default",
+      resolvedProvider: "anthropic",
+      resolvedModel: "model-default",
+    });
+  });
+
+  test("returns null instead of throwing when resolution fails", () => {
+    configThrows = true;
+
+    expect(
+      resolveConversationAttribution({ conversationId: "conv-test" }),
+    ).toBeNull();
+  });
+});
+
+describe("createToolExecutor attribution threading", () => {
+  test("stamps the attribution snapshot onto the ToolContext for direct tool calls", async () => {
+    const { executor, calls } = makeCapturingExecutor();
+    const toolFn = makeToolFn(
+      executor,
+      makeCtx({ currentTurnOverrideProfile: "pinned" }),
+    );
+
+    const result = await toolFn("file_read", { path: "/tmp/a" });
+
+    expect(result).toMatchObject({ content: "ok", isError: false });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].context.attribution).toMatchObject({
+      callSite: "mainAgent",
+      appliedProfile: "pinned",
+      profileSource: "conversation",
+      resolvedProvider: "gemini",
+      resolvedModel: "model-pinned",
+    });
+  });
+
+  test("stamps the attribution snapshot onto skill_execute dispatches", async () => {
+    const { executor, calls } = makeCapturingExecutor();
+    const toolFn = makeToolFn(executor, makeCtx());
+
+    await toolFn("skill_execute", {
+      tool: "file_read",
+      input: { path: "/tmp/a" },
+      activity: "testing",
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].name).toBe("file_read");
+    expect(calls[0].context.attribution).toMatchObject({
+      callSite: "mainAgent",
+      appliedProfile: "active",
+      profileSource: "active",
+    });
+  });
+
+  test("attribution resolution failure yields null and does not break tool execution", async () => {
+    configThrows = true;
+
+    const { executor, calls } = makeCapturingExecutor();
+    const toolFn = makeToolFn(executor, makeCtx());
+
+    const result = await toolFn("file_read", { path: "/tmp/a" });
+
+    expect(result).toMatchObject({ content: "ok", isError: false });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].context.attribution).toBeNull();
+  });
+});

--- a/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
+++ b/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
@@ -597,6 +597,61 @@ describe("ToolExecutor lifecycle events", () => {
     expect(errorEvent.attribution).toBeNull();
   });
 
+  test("stamps attribution on pre-execution gate error events (unknown tool)", async () => {
+    const events: ToolLifecycleEvent[] = [];
+    const executor = new ToolExecutor(makePrompter());
+
+    const result = await executor.execute(
+      "unknown_tool",
+      { test: true },
+      makeContext(events, { attribution: testAttribution }),
+    );
+
+    expect(result.isError).toBe(true);
+    const errorEvent = events.find((event) => event.type === "error");
+    if (errorEvent?.type !== "error") throw new Error("Expected error event");
+    expect(errorEvent.errorMessage).toContain("Unknown tool: unknown_tool");
+    expect(errorEvent.attribution).toEqual(testAttribution);
+  });
+
+  test("missing attribution yields null on pre-execution gate error events", async () => {
+    const events: ToolLifecycleEvent[] = [];
+    const executor = new ToolExecutor(makePrompter());
+
+    const result = await executor.execute(
+      "unknown_tool",
+      { test: true },
+      makeContext(events),
+    );
+
+    expect(result.isError).toBe(true);
+    const errorEvent = events.find((event) => event.type === "error");
+    if (errorEvent?.type !== "error") throw new Error("Expected error event");
+    expect(errorEvent.attribution).toBeNull();
+  });
+
+  test("stamps attribution on the aborted pre-execution gate error event", async () => {
+    const events: ToolLifecycleEvent[] = [];
+    const executor = new ToolExecutor(makePrompter());
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await executor.execute(
+      "file_read",
+      { path: "README.md" },
+      makeContext(events, {
+        attribution: testAttribution,
+        signal: controller.signal,
+      }),
+    );
+
+    expect(result).toEqual({ content: "Cancelled", isError: true });
+    const errorEvent = events.find((event) => event.type === "error");
+    if (errorEvent?.type !== "error") throw new Error("Expected error event");
+    expect(errorEvent.errorMessage).toBe("Cancelled");
+    expect(errorEvent.attribution).toEqual(testAttribution);
+  });
+
   test("skill tool with sandbox execution_target resolves to sandbox executionTarget", async () => {
     const events: ToolLifecycleEvent[] = [];
     const executor = new ToolExecutor(makePrompter());

--- a/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
+++ b/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
@@ -518,13 +518,16 @@ describe("ToolExecutor lifecycle events", () => {
 
   // ── attribution forwarding tests ──────────────────────────
 
+  // Uses a non-main call site (voice turn) so these tests also prove the
+  // executor forwards the snapshot verbatim — non-main turns must not be
+  // rewritten to the main agent's attribution.
   const testAttribution: UsageAttributionSnapshot = {
-    callSite: "mainAgent",
+    callSite: "callAgent",
     activeProfile: "balanced",
     overrideProfile: null,
-    callSiteProfile: null,
-    appliedProfile: "balanced",
-    profileSource: "active",
+    callSiteProfile: "voice-profile",
+    appliedProfile: "voice-profile",
+    profileSource: "call_site",
     resolvedProvider: "anthropic",
     resolvedModel: "test-model",
     resolvedMixArm: null,

--- a/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
+++ b/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
@@ -4,6 +4,7 @@ import type {
   ToolExecutionResult,
   ToolLifecycleEvent,
 } from "../tools/types.js";
+import type { UsageAttributionSnapshot } from "../usage/attribution.js";
 
 const mockConfig = {
   provider: "anthropic",
@@ -513,6 +514,84 @@ describe("ToolExecutor lifecycle events", () => {
     if (executed.type !== "executed")
       throw new Error("Expected executed event");
     expect(executed.executionTarget).toBe("sandbox");
+  });
+
+  // ── attribution forwarding tests ──────────────────────────
+
+  const testAttribution: UsageAttributionSnapshot = {
+    callSite: "mainAgent",
+    activeProfile: "balanced",
+    overrideProfile: null,
+    callSiteProfile: null,
+    appliedProfile: "balanced",
+    profileSource: "active",
+    resolvedProvider: "anthropic",
+    resolvedModel: "test-model",
+    resolvedMixArm: null,
+  };
+
+  test("forwards context.attribution into the executed lifecycle event", async () => {
+    const events: ToolLifecycleEvent[] = [];
+    const executor = new ToolExecutor(makePrompter());
+
+    await executor.execute(
+      "file_read",
+      { path: "README.md" },
+      makeContext(events, { attribution: testAttribution }),
+    );
+
+    const executed = events.find((event) => event.type === "executed");
+    if (executed?.type !== "executed")
+      throw new Error("Expected executed event");
+    expect(executed.attribution).toEqual(testAttribution);
+  });
+
+  test("forwards context.attribution into the error lifecycle event", async () => {
+    toolThrow = new Error("boom");
+
+    const events: ToolLifecycleEvent[] = [];
+    const executor = new ToolExecutor(makePrompter());
+
+    await executor.execute(
+      "file_read",
+      {},
+      makeContext(events, { attribution: testAttribution }),
+    );
+
+    const errorEvent = events.find((event) => event.type === "error");
+    if (errorEvent?.type !== "error") throw new Error("Expected error event");
+    expect(errorEvent.attribution).toEqual(testAttribution);
+  });
+
+  test("missing context.attribution yields null on the executed event without throwing", async () => {
+    const events: ToolLifecycleEvent[] = [];
+    const executor = new ToolExecutor(makePrompter());
+
+    const result = await executor.execute(
+      "file_read",
+      { path: "README.md" },
+      makeContext(events),
+    );
+
+    expect(result).toMatchObject({ content: "ok", isError: false });
+    const executed = events.find((event) => event.type === "executed");
+    if (executed?.type !== "executed")
+      throw new Error("Expected executed event");
+    expect(executed.attribution).toBeNull();
+  });
+
+  test("missing context.attribution yields null on the error event without throwing", async () => {
+    toolThrow = new Error("boom");
+
+    const events: ToolLifecycleEvent[] = [];
+    const executor = new ToolExecutor(makePrompter());
+
+    const result = await executor.execute("file_read", {}, makeContext(events));
+
+    expect(result.isError).toBe(true);
+    const errorEvent = events.find((event) => event.type === "error");
+    if (errorEvent?.type !== "error") throw new Error("Expected error event");
+    expect(errorEvent.attribution).toBeNull();
   });
 
   test("skill tool with sandbox execution_target resolves to sandbox executionTarget", async () => {

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -68,22 +68,28 @@ export type { ToolSetupContext } from "./tool-setup-types.js";
 /**
  * Resolve the model attribution snapshot for the conversation at invocation
  * time (provider/model/profile that issued the current turn). Mirrors how
- * the main-loop usage path builds its `UsageAttributionInput` — the main
- * agent-loop call site plus the conversation's per-turn override profile —
- * so `profileSource` resolves to `call_site`/`conversation`/`active`/
- * `default` exactly as `llm_usage` records do. The conversation id is
- * threaded as the mix selection seed so mix-profile arms match what the
- * dispatch path actually ran.
+ * the agent-loop usage path builds its `UsageAttributionInput` — the
+ * current turn's call site (`runAgentLoopImpl` sets `ctx.currentCallSite`
+ * from `options.callSite`, defaulting to `mainAgent`) plus the
+ * conversation's per-turn override profile — so `profileSource` resolves
+ * to `call_site`/`conversation`/`active`/`default` exactly as `llm_usage`
+ * records do for the same turn (non-main turns like voice `callAgent` or
+ * `filingAgent` attribute their own call-site config, not the main
+ * agent's). The conversation id is threaded as the mix selection seed so
+ * mix-profile arms match what the dispatch path actually ran.
  *
  * Returns `null` on any failure: attribution is telemetry-only and must
  * never break tool execution (or skill loads, which reuse this helper).
  */
 export function resolveConversationAttribution(
-  ctx: Pick<ToolSetupContext, "conversationId" | "currentTurnOverrideProfile">,
+  ctx: Pick<
+    ToolSetupContext,
+    "conversationId" | "currentCallSite" | "currentTurnOverrideProfile"
+  >,
 ): UsageAttributionSnapshot | null {
   try {
     return resolveUsageAttribution({
-      callSite: "mainAgent",
+      callSite: ctx.currentCallSite ?? "mainAgent",
       overrideProfile: ctx.currentTurnOverrideProfile ?? null,
       selectionSeed: ctx.conversationId,
     });

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -34,6 +34,10 @@ import {
   type ToolExecutionResult,
   type ToolLifecycleEventHandler,
 } from "../tools/types.js";
+import {
+  resolveUsageAttribution,
+  type UsageAttributionSnapshot,
+} from "../usage/attribution.js";
 import { getLogger } from "../util/logger.js";
 import {
   projectSkillTools,
@@ -58,6 +62,39 @@ import {
 } from "./switch-inference-profile-tool.js";
 import type { ToolSetupContext } from "./tool-setup-types.js";
 export type { ToolSetupContext } from "./tool-setup-types.js";
+
+// ── resolveConversationAttribution ───────────────────────────────────
+
+/**
+ * Resolve the model attribution snapshot for the conversation at invocation
+ * time (provider/model/profile that issued the current turn). Mirrors how
+ * the main-loop usage path builds its `UsageAttributionInput` — the main
+ * agent-loop call site plus the conversation's per-turn override profile —
+ * so `profileSource` resolves to `call_site`/`conversation`/`active`/
+ * `default` exactly as `llm_usage` records do. The conversation id is
+ * threaded as the mix selection seed so mix-profile arms match what the
+ * dispatch path actually ran.
+ *
+ * Returns `null` on any failure: attribution is telemetry-only and must
+ * never break tool execution (or skill loads, which reuse this helper).
+ */
+export function resolveConversationAttribution(
+  ctx: Pick<ToolSetupContext, "conversationId" | "currentTurnOverrideProfile">,
+): UsageAttributionSnapshot | null {
+  try {
+    return resolveUsageAttribution({
+      callSite: "mainAgent",
+      overrideProfile: ctx.currentTurnOverrideProfile ?? null,
+      selectionSeed: ctx.conversationId,
+    });
+  } catch (err) {
+    log.debug(
+      { err, conversationId: ctx.conversationId },
+      "Failed to resolve conversation attribution for telemetry (non-fatal)",
+    );
+    return null;
+  }
+}
 
 // ── createToolExecutor ───────────────────────────────────────────────
 
@@ -130,6 +167,7 @@ export function createToolExecutor(
       isPlatformHosted: getIsPlatform(),
       transportInterface: ctx.transportInterface,
       overrideProfile: ctx.currentTurnOverrideProfile,
+      attribution: resolveConversationAttribution(ctx),
       onToolLifecycleEvent: handleToolLifecycleEvent,
       sendToClient: (msg) => {
         // Tool context's sendToClient uses a loose { type: string; [key: string]: unknown }

--- a/assistant/src/daemon/tool-setup-types.ts
+++ b/assistant/src/daemon/tool-setup-types.ts
@@ -4,6 +4,7 @@
  */
 
 import type { InterfaceId } from "../channels/types.js";
+import type { LLMCallSite } from "../config/schemas/llm.js";
 import type { SurfaceConversationContext } from "./conversation-surfaces.js";
 import type { TrustContext } from "./trust-context.js";
 
@@ -46,6 +47,14 @@ export interface ToolSetupContext extends SurfaceConversationContext {
    * trust rules auto-executing side-effect tools in non-interactive contexts.
    */
   forcePromptSideEffects?: boolean;
+  /**
+   * The LLM call site driving the current turn, set by `runAgentLoopImpl`
+   * (`options.callSite ?? "mainAgent"`). Non-main turns (voice `callAgent`,
+   * `filingAgent`, …) resolve different provider/model/profile config, so
+   * tool telemetry attribution must use this rather than assuming
+   * `mainAgent`. Absent before the first turn starts.
+   */
+  currentCallSite?: LLMCallSite;
   /**
    * Per-turn snapshot of the resolved inference-profile override, set by
    * `runAgentLoopImpl`. Propagated into `ToolContext.overrideProfile` so

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -227,7 +227,6 @@ export class ToolExecutor {
           errorMessage: msg,
           isExpected: true,
           errorCategory: "tool_failure",
-          attribution: context.attribution ?? null,
         });
         return { content: msg, isError: true };
       }
@@ -306,7 +305,6 @@ export class ToolExecutor {
             errorMessage: errorMsg,
             isExpected: true,
             errorCategory: "tool_failure",
-            attribution: context.attribution ?? null,
           });
           return { content: errorMsg, isError: true };
         }
@@ -343,7 +341,6 @@ export class ToolExecutor {
         decision,
         durationMs,
         result: safeResult,
-        attribution: context.attribution ?? null,
       });
 
       // Merge risk metadata from the classifier assessment cache onto the
@@ -424,7 +421,6 @@ export class ToolExecutor {
         errorCategory,
         errorName: err instanceof Error ? err.name : undefined,
         errorStack: err instanceof Error ? err.stack : undefined,
-        attribution: context.attribution ?? null,
       });
 
       if (isExpected) {
@@ -496,6 +492,15 @@ function emitLifecycleEvent(
     ...event,
     input: sanitizeToolInput(event.toolName, event.input),
   };
+
+  // Stamp model attribution centrally so every executed/error event carries
+  // it — including the pre-execution gate failures (aborted, disk pressure,
+  // unknown/inactive tool) emitted from checkPreExecutionGates(), whose
+  // emission sites don't have to remember to copy it.
+  if (sanitizedEvent.type === "executed" || sanitizedEvent.type === "error") {
+    sanitizedEvent.attribution =
+      sanitizedEvent.attribution ?? context.attribution ?? null;
+  }
 
   try {
     const maybePromise = handler(sanitizedEvent as ToolLifecycleEvent);

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -227,6 +227,7 @@ export class ToolExecutor {
           errorMessage: msg,
           isExpected: true,
           errorCategory: "tool_failure",
+          attribution: context.attribution ?? null,
         });
         return { content: msg, isError: true };
       }
@@ -305,6 +306,7 @@ export class ToolExecutor {
             errorMessage: errorMsg,
             isExpected: true,
             errorCategory: "tool_failure",
+            attribution: context.attribution ?? null,
           });
           return { content: errorMsg, isError: true };
         }
@@ -341,6 +343,7 @@ export class ToolExecutor {
         decision,
         durationMs,
         result: safeResult,
+        attribution: context.attribution ?? null,
       });
 
       // Merge risk metadata from the classifier assessment cache onto the
@@ -421,6 +424,7 @@ export class ToolExecutor {
         errorCategory,
         errorName: err instanceof Error ? err.name : undefined,
         errorStack: err instanceof Error ? err.stack : undefined,
+        attribution: context.attribution ?? null,
       });
 
       if (isExpected) {

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -1,10 +1,10 @@
 import type { ApprovalRequired } from "@vellumai/service-contracts/credential-rpc";
 import type {
   DiffInfo,
+  ErrorCategory,
   ExecutionTarget,
   ProxyApprovalCallback,
   SensitiveOutputBinding,
-  ToolExecutionErrorEvent,
   ToolExecutionStartEvent,
   ToolPermissionDeniedEvent,
   ToolPermissionPromptEvent,
@@ -17,6 +17,7 @@ import type { ToolActivityMetadata } from "../daemon/message-types/web-activity.
 import type { SecretPromptResult } from "../permissions/secret-prompter.js";
 import type { ContentBlock } from "../providers/types.js";
 import type { TrustClass } from "../runtime/actor-trust-resolver.js";
+import type { UsageAttributionSnapshot } from "../usage/attribution.js";
 
 export const DISK_PRESSURE_CLEANUP_TOOL_NAMES: ReadonlySet<string> = new Set([
   "bash",
@@ -43,10 +44,12 @@ export function isDiskPressureCleanupToolName(name: string): boolean {
 // Pure re-exports below cover types the contracts package could declare
 // without any assistant-side references. The remaining interfaces (`Tool`,
 // `ToolContext`, `ToolExecutionResult`, `ToolExecutedEvent`,
-// `ToolLifecycleEvent`, `ToolLifecycleEventHandler`, `ProxyToolResolver`)
+// `ToolExecutionErrorEvent`, `ToolLifecycleEvent`,
+// `ToolLifecycleEventHandler`, `ProxyToolResolver`)
 // reference daemon-internal types (CES client, host-proxy classes,
 // `ContentBlock`, `ApprovalRequired`, `TrustClass`, `InterfaceId`,
-// `SecretPromptResult`) that can't move into a neutral package. For those,
+// `SecretPromptResult`, `UsageAttributionSnapshot`) that can't move into a
+// neutral package. For those,
 // the contracts version uses opaque placeholders (`unknown`, broadened
 // `string`) and the assistant redeclares the interface here with the
 // concrete types. The two sides are structurally independent — no
@@ -63,7 +66,6 @@ export type {
   ProxyEnvVars,
   SensitiveOutputBinding,
   SensitiveOutputKind,
-  ToolExecutionErrorEvent,
   ToolExecutionStartEvent,
   ToolPermissionDeniedEvent,
   ToolPermissionPromptEvent,
@@ -181,6 +183,45 @@ export interface ToolExecutedEvent {
   decision: string;
   durationMs: number;
   result: ToolExecutionResult;
+  /**
+   * Model attribution snapshot for the conversation at invocation time.
+   * Copied from {@link ToolContext.attribution} by the executor; `null` when
+   * resolution failed or no attribution was available.
+   */
+  attribution?: UsageAttributionSnapshot | null;
+}
+
+/**
+ * `ToolExecutionErrorEvent` is redeclared here (rather than re-exported from
+ * the contracts package) so it can carry the assistant-side `attribution`
+ * snapshot, which references the daemon-internal `UsageAttributionSnapshot`
+ * type. All other fields mirror the contracts declaration.
+ */
+export interface ToolExecutionErrorEvent {
+  type: "error";
+  toolName: string;
+  input: Record<string, unknown>;
+  workingDir: string;
+  conversationId: string;
+  requestId?: string;
+  executionTarget?: ExecutionTarget;
+  riskLevel: string;
+  /** ID of the trust rule that matched this invocation (if any). */
+  matchedTrustRuleId?: string;
+  decision: string;
+  durationMs: number;
+  errorMessage: string;
+  isExpected: boolean;
+  /** Classifies the error for downstream consumers (audit, alerting, monitoring). */
+  errorCategory: ErrorCategory;
+  errorName?: string;
+  errorStack?: string;
+  /**
+   * Model attribution snapshot for the conversation at invocation time.
+   * Copied from {@link ToolContext.attribution} by the executor; `null` when
+   * resolution failed or no attribution was available.
+   */
+  attribution?: UsageAttributionSnapshot | null;
 }
 
 export type ToolLifecycleEvent =
@@ -209,6 +250,12 @@ export interface ToolContext {
   assistantId?: string;
   /** When set, the tool execution is part of a task run. Used to retrieve ephemeral permission rules. */
   taskRunId?: string;
+  /**
+   * Model attribution snapshot for the conversation at invocation time
+   * (provider/model/profile that issued this tool call). Used by tool
+   * telemetry; never sent to the tool itself.
+   */
+  attribution?: UsageAttributionSnapshot | null;
   /** Optional callback for tool lifecycle events (start/prompt/deny/execute/error). */
   onToolLifecycleEvent?: ToolLifecycleEventHandler;
   /** Optional resolver for proxy tools - delegates execution to an external client. */


### PR DESCRIPTION
## Summary
- Adds optional UsageAttributionSnapshot to ToolContext, ToolExecutedEvent, and ToolExecutionErrorEvent
- Resolves the conversation's model attribution at tool invocation time in createToolExecutor via a reusable resolveConversationAttribution helper
- Executor forwards attribution into executed/error lifecycle events; resolution failures never break tool execution

Part of plan: tool-skill-telemetry.md (PR 2 of 6)