### PR TITLE
feat(macos): detect vellum PATH install state including npm shadowing

### DIFF
--- a/apps/macos/src/main/cli-path-installer.test.ts
+++ b/apps/macos/src/main/cli-path-installer.test.ts
@@ -77,6 +77,23 @@ mock.module("node:fs", () => ({
   },
 }));
 
+// Controlled per-test; reset in afterEach.
+let shellPathValue = "";
+let shellPathHits: string[] = [];
+let resolveShellPathCalls = 0;
+const findExecutablesCalls: Array<[string, string]> = [];
+
+mock.module("./shell-path", () => ({
+  resolveShellPath: async () => {
+    resolveShellPathCalls += 1;
+    return shellPathValue;
+  },
+  findExecutablesInPath: (name: string, pathValue: string) => {
+    findExecutablesCalls.push([name, pathValue]);
+    return shellPathHits;
+  },
+}));
+
 const {
   WRAPPER_MARKER,
   getWrapperDir,
@@ -85,6 +102,7 @@ const {
   readWrapperOwnership,
   installWrapper,
   uninstallWrapper,
+  getCliPathInstallState,
 } = await import("./cli-path-installer");
 
 const wrapperDir = `${mockHome}/.local/bin`;
@@ -98,6 +116,10 @@ afterEach(() => {
   chmodSyncCalls.length = 0;
   renameSyncCalls.length = 0;
   rmSyncCalls.length = 0;
+  shellPathValue = "";
+  shellPathHits = [];
+  resolveShellPathCalls = 0;
+  findExecutablesCalls.length = 0;
 });
 
 // --- Path helpers ---
@@ -242,5 +264,81 @@ describe("uninstallWrapper", () => {
 
     expect(uninstallWrapper()).toBe("absent");
     expect(rmSyncCalls).toHaveLength(0);
+  });
+});
+
+// --- getCliPathInstallState ---
+
+describe("getCliPathInstallState", () => {
+  test("returns not-installed when the wrapper is absent, without consulting shell-path", async () => {
+    readFileSyncResult = null;
+
+    expect(await getCliPathInstallState()).toEqual({ kind: "not-installed" });
+    expect(resolveShellPathCalls).toBe(0);
+    expect(findExecutablesCalls).toHaveLength(0);
+  });
+
+  test("returns foreign-file for a foreign wrapper, without consulting shell-path", async () => {
+    readFileSyncResult = "#!/bin/sh\necho not ours\n";
+
+    expect(await getCliPathInstallState()).toEqual({ kind: "foreign-file" });
+    expect(resolveShellPathCalls).toBe(0);
+    expect(findExecutablesCalls).toHaveLength(0);
+  });
+
+  test("returns installed with inPath false when no hits and wrapper dir is not in PATH", async () => {
+    readFileSyncResult = buildWrapperScript();
+    shellPathValue = "/usr/local/bin:/usr/bin:/bin";
+    shellPathHits = [];
+
+    expect(await getCliPathInstallState()).toEqual({
+      kind: "installed",
+      inPath: false,
+    });
+    expect(findExecutablesCalls).toEqual([["vellum", shellPathValue]]);
+  });
+
+  test("returns installed with inPath true when the wrapper is the first hit", async () => {
+    readFileSyncResult = buildWrapperScript();
+    shellPathValue = `${wrapperDir}:/usr/local/bin:/usr/bin:/bin`;
+    shellPathHits = [wrapperPath];
+
+    expect(await getCliPathInstallState()).toEqual({
+      kind: "installed",
+      inPath: true,
+    });
+  });
+
+  test("returns shadowed with the winning path when another vellum precedes the wrapper", async () => {
+    readFileSyncResult = buildWrapperScript();
+    shellPathValue = `/opt/homebrew/bin:${wrapperDir}:/usr/bin:/bin`;
+    shellPathHits = ["/opt/homebrew/bin/vellum", wrapperPath];
+
+    expect(await getCliPathInstallState()).toEqual({
+      kind: "shadowed",
+      shadowedBy: "/opt/homebrew/bin/vellum",
+    });
+  });
+
+  test("returns installed when the wrapper wins over a later npm copy", async () => {
+    readFileSyncResult = buildWrapperScript();
+    shellPathValue = `${wrapperDir}:/opt/homebrew/bin:/usr/bin:/bin`;
+    shellPathHits = [wrapperPath, "/opt/homebrew/bin/vellum"];
+
+    expect(await getCliPathInstallState()).toEqual({
+      kind: "installed",
+      inPath: true,
+    });
+  });
+
+  test("counts a trailing-slash PATH entry for the wrapper dir as inPath", async () => {
+    readFileSyncResult = buildWrapperScript();
+    shellPathValue = `/usr/local/bin:${wrapperDir}/:/usr/bin`;
+    shellPathHits = [wrapperPath];
+
+    expect(await getCliPathInstallState()).toEqual({
+      kind: "installed",
+      inPath: true,
+    });
   });
 });

--- a/apps/macos/src/main/cli-path-installer.ts
+++ b/apps/macos/src/main/cli-path-installer.ts
@@ -10,6 +10,7 @@ import { homedir } from "node:os";
 import path from "node:path";
 
 import { getCliLocatorPath, shQuote } from "./cli-installer";
+import { findExecutablesInPath, resolveShellPath } from "./shell-path";
 
 /** Ownership/migration marker embedded in every wrapper we write. */
 export const WRAPPER_MARKER = "# vellum-cli-wrapper v1";
@@ -88,6 +89,41 @@ export function installWrapper(opts: {
   chmodSync(tmpPath, 0o755);
   renameSync(tmpPath, wrapperPath);
   return "installed";
+}
+
+export type CliPathInstallState =
+  | { kind: "not-installed" }
+  | { kind: "foreign-file" }
+  | { kind: "installed"; inPath: boolean }
+  | { kind: "shadowed"; shadowedBy: string };
+
+// Shell PATH entries are already $HOME-expanded; only trailing slashes vary.
+function stripTrailingSlashes(dir: string): string {
+  return dir.replace(/\/+$/, "");
+}
+
+/**
+ * Determine how the `vellum` command resolves on the user's login-shell
+ * PATH. `shadowed` means another executable wins over our wrapper (e.g. an
+ * npm-global install earlier in PATH). Never throws — shell PATH resolution
+ * degrades gracefully.
+ */
+export async function getCliPathInstallState(): Promise<CliPathInstallState> {
+  const ownership = readWrapperOwnership();
+  if (ownership === "absent") return { kind: "not-installed" };
+  if (ownership === "foreign") return { kind: "foreign-file" };
+
+  const shellPath = await resolveShellPath();
+  const [firstHit] = findExecutablesInPath("vellum", shellPath);
+  if (firstHit !== undefined && firstHit !== getWrapperPath()) {
+    return { kind: "shadowed", shadowedBy: firstHit };
+  }
+
+  const wrapperDir = getWrapperDir();
+  const inPath = shellPath
+    .split(":")
+    .some((entry) => stripTrailingSlashes(entry) === wrapperDir);
+  return { kind: "installed", inPath };
 }
 
 /** Remove the wrapper, but only if it's one we installed. */


### PR DESCRIPTION
## Summary
- Adds CliPathInstallState union and getCliPathInstallState(): not-installed / foreign-file / installed (with inPath flag) / shadowed (with winning binary path)
- Shadow detection uses the resolved login-shell PATH in precedence order
- Tests for all states incl. trailing-slash PATH normalization

Part of plan: cli-path-installer.md (PR 4 of 6)