### PR TITLE
Dedupe global voice error toasts

### DIFF
--- a/apps/web/src/domains/chat/voice/global-push-to-talk-bridge.test.tsx
+++ b/apps/web/src/domains/chat/voice/global-push-to-talk-bridge.test.tsx
@@ -22,7 +22,10 @@ let latestVoiceInputProps: VoiceInputButtonProps | null = null;
 let nextTextInsertionStatus: TextInsertionStatus = "unavailable";
 const insertedTexts: string[] = [];
 let nextDictationResult: { mode: "dictation"; text: string } | null = null;
-const toastErrorMock = mock((_message: string) => undefined);
+type ToastErrorOptions = { id?: string };
+const toastErrorMock = mock(
+  (_message: string, _options?: ToastErrorOptions) => undefined,
+);
 
 mock.module("@/domains/chat/components/voice-input-button", () => ({
   VoiceInputButton: forwardRef<unknown, VoiceInputButtonProps>((props, _ref) => {
@@ -71,6 +74,7 @@ mock.module("@vellumai/design-library/components/toast", () => ({
 }));
 
 const { GlobalPushToTalkBridge } = await import("./global-push-to-talk-bridge");
+const { formatVoiceError } = await import("@/domains/chat/utils/chat");
 const { useComposerStore } = await import("@/domains/chat/composer-store");
 const { useConversationStore } = await import("@/stores/conversation-store");
 const { useViewerStore } = await import("@/stores/viewer-store");
@@ -122,7 +126,29 @@ describe("GlobalPushToTalkBridge", () => {
 
     expect(insertedTexts).toEqual(["fallback text"]);
     expect(useComposerStore.getState().input).toBe("fallback text");
-    expect(toastErrorMock).toHaveBeenCalledTimes(1);
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      formatVoiceError("dictation-paste-blocked"),
+      { id: "voice-error:dictation-paste-blocked" },
+    );
   });
 
+  test("uses stable toast IDs for repeated voice errors", () => {
+    const voiceInput = renderBridge();
+
+    act(() => {
+      voiceInput.onError("stt-not-configured");
+      voiceInput.onError("stt-not-configured");
+    });
+
+    expect(toastErrorMock.mock.calls).toEqual([
+      [
+        formatVoiceError("stt-not-configured"),
+        { id: "voice-error:stt-not-configured" },
+      ],
+      [
+        formatVoiceError("stt-not-configured"),
+        { id: "voice-error:stt-not-configured" },
+      ],
+    ]);
+  });
 });

--- a/apps/web/src/domains/chat/voice/global-push-to-talk-bridge.tsx
+++ b/apps/web/src/domains/chat/voice/global-push-to-talk-bridge.tsx
@@ -41,6 +41,10 @@ function ensureConversationKey(): string {
   return draftId;
 }
 
+function showVoiceErrorToast(code: string): void {
+  toast.error(formatVoiceError(code), { id: `voice-error:${code}` });
+}
+
 export function GlobalPushToTalkBridge({
   assistantId,
 }: GlobalPushToTalkBridgeProps) {
@@ -93,12 +97,12 @@ export function GlobalPushToTalkBridge({
       }
 
       if (frontAppInsertion.status === "automation-denied") {
-        toast.error(formatVoiceError("dictation-automation-denied"));
+        showVoiceErrorToast("dictation-automation-denied");
         useVoiceRecordingStore
           .getState()
           .flagDictationInsertionError("dictation-automation-denied");
       } else if (frontAppInsertion.status === "blocked") {
-        toast.error(formatVoiceError("dictation-paste-blocked"));
+        showVoiceErrorToast("dictation-paste-blocked");
         useVoiceRecordingStore
           .getState()
           .flagDictationInsertionError("dictation-paste-blocked");
@@ -124,7 +128,7 @@ export function GlobalPushToTalkBridge({
 
   const handleError = useCallback((code: string | null) => {
     if (code) {
-      toast.error(formatVoiceError(code));
+      showVoiceErrorToast(code);
     }
   }, []);
 


### PR DESCRIPTION
## Summary
- Give global push-to-talk voice error toasts stable IDs by error code so repeated failures replace the existing toast instead of stacking identical alerts.
- Cover the stable ID behavior in the global push-to-talk bridge test.

## Original prompt
The user reported speech-to-text setup error toasts in the web/Electron frontend stacking and staying visible after clicking the X. The screenshot showed duplicate "Speech-to-text is not set up" alerts, so this change targets the global voice toast path to make repeated errors dismiss cleanly.