### PR TITLE
feat(macos): install/uninstall vellum command flows with PATH and shadow dialogs

### DIFF
--- a/apps/macos/src/main/cli-path-flow.test.ts
+++ b/apps/macos/src/main/cli-path-flow.test.ts
@@ -1,0 +1,218 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { CliPathInstallState } from "./cli-path-installer";
+
+// ---------------------------------------------------------------------------
+// Stubs and mocks
+// ---------------------------------------------------------------------------
+
+const WRAPPER_PATH = "/Users/test/.local/bin/vellum";
+const PATH_EXPORT_LINE = 'export PATH="$HOME/.local/bin:$PATH"';
+
+const showMessageBoxMock = mock(
+  async (_opts: { message: string; detail?: string }) => ({
+    response: 0,
+    checkboxChecked: false,
+  }),
+);
+const showErrorBoxMock = mock((_title: string, _content: string) => undefined);
+const writeTextMock = mock((_text: string) => undefined);
+
+mock.module("electron", () => ({
+  dialog: {
+    showMessageBox: showMessageBoxMock,
+    showErrorBox: showErrorBoxMock,
+  },
+  clipboard: { writeText: writeTextMock },
+}));
+
+const getCliPathInstallStateMock = mock(
+  async (): Promise<CliPathInstallState> => ({
+    kind: "installed",
+    inPath: true,
+  }),
+);
+const installWrapperMock = mock(
+  (_opts: { overwriteForeign: boolean }): "installed" | "needs-overwrite-confirmation" =>
+    "installed",
+);
+const uninstallWrapperMock = mock(
+  (): "removed" | "not-ours" | "absent" => "removed",
+);
+
+mock.module("./cli-path-installer", () => ({
+  getCliPathInstallState: getCliPathInstallStateMock,
+  installWrapper: installWrapperMock,
+  uninstallWrapper: uninstallWrapperMock,
+  getWrapperPath: () => WRAPPER_PATH,
+  getWrapperDir: () => "/Users/test/.local/bin",
+}));
+
+const { runInstallCliCommandFlow, runUninstallCliCommandFlow } = await import(
+  "./cli-path-flow"
+);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const setState = (state: CliPathInstallState) => {
+  getCliPathInstallStateMock.mockResolvedValue(state);
+};
+
+const lastDialog = () => showMessageBoxMock.mock.calls.at(-1)?.[0];
+
+beforeEach(() => {
+  showMessageBoxMock.mockReset();
+  showErrorBoxMock.mockClear();
+  writeTextMock.mockClear();
+  getCliPathInstallStateMock.mockReset();
+  installWrapperMock.mockReset();
+  uninstallWrapperMock.mockReset();
+
+  showMessageBoxMock.mockResolvedValue({ response: 0, checkboxChecked: false });
+  setState({ kind: "installed", inPath: true });
+  installWrapperMock.mockReturnValue("installed");
+  uninstallWrapperMock.mockReturnValue("removed");
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("runInstallCliCommandFlow", () => {
+  test("foreign file + Cancel leaves the file untouched", async () => {
+    setState({ kind: "foreign-file" });
+    showMessageBoxMock.mockResolvedValue({ response: 1, checkboxChecked: false });
+
+    await runInstallCliCommandFlow();
+
+    expect(showMessageBoxMock).toHaveBeenCalledTimes(1);
+    expect(showMessageBoxMock.mock.calls[0]?.[0]?.message).toBe(
+      "Replace existing vellum file?",
+    );
+    expect(installWrapperMock).not.toHaveBeenCalled();
+  });
+
+  test("foreign file + Replace installs with overwriteForeign", async () => {
+    getCliPathInstallStateMock
+      .mockResolvedValueOnce({ kind: "foreign-file" })
+      .mockResolvedValueOnce({ kind: "installed", inPath: true });
+
+    await runInstallCliCommandFlow();
+
+    expect(installWrapperMock).toHaveBeenCalledTimes(1);
+    expect(installWrapperMock).toHaveBeenCalledWith({ overwriteForeign: true });
+  });
+
+  test("installed + inPath shows success without touching the clipboard", async () => {
+    setState({ kind: "installed", inPath: true });
+
+    await runInstallCliCommandFlow();
+
+    expect(installWrapperMock).toHaveBeenCalledWith({ overwriteForeign: false });
+    expect(writeTextMock).not.toHaveBeenCalled();
+    expect(lastDialog()?.message).toBe("Vellum CLI installed");
+    expect(lastDialog()?.detail).toContain(WRAPPER_PATH);
+    expect(lastDialog()?.detail).toContain('run "vellum"');
+  });
+
+  test("installed but not in PATH copies the export line to the clipboard", async () => {
+    setState({ kind: "installed", inPath: false });
+
+    await runInstallCliCommandFlow();
+
+    expect(writeTextMock).toHaveBeenCalledTimes(1);
+    expect(writeTextMock).toHaveBeenCalledWith(PATH_EXPORT_LINE);
+    expect(lastDialog()?.detail).toContain("copied to your clipboard");
+    expect(lastDialog()?.detail).toContain(WRAPPER_PATH);
+  });
+
+  test("shadowed names the winning binary and the npm uninstall fix", async () => {
+    setState({ kind: "shadowed", shadowedBy: "/opt/homebrew/bin/vellum" });
+
+    await runInstallCliCommandFlow();
+
+    expect(writeTextMock).not.toHaveBeenCalled();
+    expect(lastDialog()?.detail).toContain("/opt/homebrew/bin/vellum");
+    expect(lastDialog()?.detail).toContain("npm uninstall -g vellum");
+  });
+
+  test("install race returning needs-overwrite-confirmation re-confirms once", async () => {
+    setState({ kind: "installed", inPath: true });
+    installWrapperMock
+      .mockReturnValueOnce("needs-overwrite-confirmation")
+      .mockReturnValueOnce("installed");
+
+    await runInstallCliCommandFlow();
+
+    expect(installWrapperMock).toHaveBeenCalledTimes(2);
+    expect(installWrapperMock.mock.calls[1]?.[0]).toEqual({
+      overwriteForeign: true,
+    });
+  });
+
+  test("state check throwing surfaces via showErrorBox without rejecting", async () => {
+    getCliPathInstallStateMock.mockRejectedValue(new Error("boom"));
+
+    await runInstallCliCommandFlow();
+
+    expect(showErrorBoxMock).toHaveBeenCalledTimes(1);
+    expect(showErrorBoxMock).toHaveBeenCalledWith(
+      "Failed to install vellum command",
+      "boom",
+    );
+  });
+});
+
+describe("runUninstallCliCommandFlow", () => {
+  test("Cancel skips uninstallWrapper", async () => {
+    showMessageBoxMock.mockResolvedValue({ response: 1, checkboxChecked: false });
+
+    await runUninstallCliCommandFlow();
+
+    expect(showMessageBoxMock.mock.calls[0]?.[0]?.message).toBe(
+      "Uninstall vellum command?",
+    );
+    expect(uninstallWrapperMock).not.toHaveBeenCalled();
+  });
+
+  test("removed shows the removal confirmation", async () => {
+    uninstallWrapperMock.mockReturnValue("removed");
+
+    await runUninstallCliCommandFlow();
+
+    expect(uninstallWrapperMock).toHaveBeenCalledTimes(1);
+    expect(lastDialog()?.detail).toBe("The vellum command was removed.");
+  });
+
+  test("not-ours refuses to remove a foreign file", async () => {
+    uninstallWrapperMock.mockReturnValue("not-ours");
+
+    await runUninstallCliCommandFlow();
+
+    expect(lastDialog()?.detail).toContain("wasn't installed by Vellum");
+    expect(lastDialog()?.detail).toContain("not removing it");
+  });
+
+  test("absent reports nothing to uninstall", async () => {
+    uninstallWrapperMock.mockReturnValue("absent");
+
+    await runUninstallCliCommandFlow();
+
+    expect(lastDialog()?.detail).toBe("The vellum command is not installed.");
+  });
+
+  test("uninstallWrapper throwing surfaces via showErrorBox", async () => {
+    uninstallWrapperMock.mockImplementation(() => {
+      throw new Error("eperm");
+    });
+
+    await runUninstallCliCommandFlow();
+
+    expect(showErrorBoxMock).toHaveBeenCalledWith(
+      "Failed to uninstall vellum command",
+      "eperm",
+    );
+  });
+});

--- a/apps/macos/src/main/cli-path-flow.ts
+++ b/apps/macos/src/main/cli-path-flow.ts
@@ -1,0 +1,121 @@
+/**
+ * UX orchestration for "Install vellum Command…": wraps the cli-path-installer
+ * primitives with confirmation/success dialogs and clipboard help. Both flows
+ * surface failures via showErrorBox and never throw to the caller.
+ */
+import { clipboard, dialog } from "electron";
+
+import {
+  getCliPathInstallState,
+  getWrapperPath,
+  installWrapper,
+  uninstallWrapper,
+} from "./cli-path-installer";
+
+const PATH_EXPORT_LINE = 'export PATH="$HOME/.local/bin:$PATH"';
+
+async function confirmReplaceForeignFile(): Promise<boolean> {
+  const { response } = await dialog.showMessageBox({
+    type: "warning",
+    message: "Replace existing vellum file?",
+    detail:
+      `A "vellum" file already exists at ${getWrapperPath()} but wasn't ` +
+      "installed by Vellum (it may have been installed by npm with a custom " +
+      "prefix). Do you want to replace it with the Vellum-managed command?",
+    buttons: ["Replace", "Cancel"],
+    defaultId: 1,
+    cancelId: 1,
+  });
+  return response === 0;
+}
+
+async function showInstallSuccessDialog(): Promise<void> {
+  const state = await getCliPathInstallState();
+  const wrapperPath = getWrapperPath();
+
+  let detail: string;
+  if (state.kind === "installed" && !state.inPath) {
+    clipboard.writeText(PATH_EXPORT_LINE);
+    detail =
+      `The vellum command is installed at ${wrapperPath}, but ` +
+      "~/.local/bin isn't in your shell's PATH. The line to add to your " +
+      "shell profile has been copied to your clipboard.";
+  } else if (state.kind === "shadowed") {
+    detail =
+      `The vellum command is installed at ${wrapperPath}, but another ` +
+      `"vellum" was found at ${state.shadowedBy} (likely installed via ` +
+      "npm) and will take precedence in your terminal. Run " +
+      '"npm uninstall -g vellum" to use the app-managed version.';
+  } else {
+    // `installed` in PATH, plus a defensive default for anything else.
+    detail =
+      `The vellum command is installed at ${wrapperPath}. ` +
+      'Open a new terminal and run "vellum".';
+  }
+
+  await dialog.showMessageBox({
+    type: "info",
+    message: "Vellum CLI installed",
+    detail,
+  });
+}
+
+export async function runInstallCliCommandFlow(): Promise<void> {
+  try {
+    const state = await getCliPathInstallState();
+    let overwriteForeign = false;
+    if (state.kind === "foreign-file") {
+      if (!(await confirmReplaceForeignFile())) return;
+      overwriteForeign = true;
+    }
+
+    if (installWrapper({ overwriteForeign }) === "needs-overwrite-confirmation") {
+      // Race: the file became foreign between the state check and install.
+      if (!(await confirmReplaceForeignFile())) return;
+      installWrapper({ overwriteForeign: true });
+    }
+
+    await showInstallSuccessDialog();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    dialog.showErrorBox("Failed to install vellum command", message);
+  }
+}
+
+export async function runUninstallCliCommandFlow(): Promise<void> {
+  try {
+    const { response } = await dialog.showMessageBox({
+      type: "warning",
+      message: "Uninstall vellum command?",
+      detail: `This removes the vellum command at ${getWrapperPath()}.`,
+      buttons: ["Uninstall", "Cancel"],
+      defaultId: 1,
+      cancelId: 1,
+    });
+    if (response !== 0) return;
+
+    const resultDialogs = {
+      removed: {
+        type: "info",
+        message: "Vellum command uninstalled",
+        detail: "The vellum command was removed.",
+      },
+      "not-ours": {
+        type: "warning",
+        message: "Vellum command not removed",
+        detail:
+          `The file at ${getWrapperPath()} wasn't installed by Vellum — ` +
+          "not removing it.",
+      },
+      absent: {
+        type: "info",
+        message: "Nothing to uninstall",
+        detail: "The vellum command is not installed.",
+      },
+    } as const;
+    await dialog.showMessageBox(resultDialogs[uninstallWrapper()]);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    dialog.showErrorBox("Failed to uninstall vellum command", message);
+  }
+}

--- a/apps/macos/test-setup.ts
+++ b/apps/macos/test-setup.ts
@@ -53,6 +53,11 @@ mock.module("electron", () => ({
     handle: () => undefined,
     on: () => undefined,
   },
+  dialog: {
+    showErrorBox: () => undefined,
+    showMessageBox: () =>
+      Promise.resolve({ response: 0, checkboxChecked: false }),
+  },
   Menu: {
     buildFromTemplate: () => ({ popup: () => undefined }),
     setApplicationMenu: () => undefined,


### PR DESCRIPTION
## Summary
- New cli-path-flow.ts: runInstallCliCommandFlow / runUninstallCliCommandFlow orchestrating the wrapper primitives with dialogs
- PATH-missing case copies the export line to the clipboard; shadowed case names the winning binary and suggests npm uninstall -g vellum; foreign files require explicit Replace confirmation
- Flows never throw; errors surface via showErrorBox. Full dialog-routing test coverage

Part of plan: cli-path-installer.md (PR 5 of 6)