### PR TITLE
chore: round-2 review cleanups (unexport ReplayState, shared env test helper)

### DIFF
--- a/cli/src/__tests__/device-id.test.ts
+++ b/cli/src/__tests__/device-id.test.ts
@@ -15,19 +15,16 @@ import {
   getOrCreateHostDeviceId,
   resetHostDeviceIdCache,
 } from "../lib/device-id.js";
+import { snapshotEnv } from "./helpers/env.js";
 
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 
-const SAVED_ENV_VARS = [
+const restoreEnv = snapshotEnv([
   "XDG_CONFIG_HOME",
   "VELLUM_ENVIRONMENT",
   "VELLUM_DEVICE_ID",
-] as const;
-const savedEnv: Record<string, string | undefined> = {};
-for (const key of SAVED_ENV_VARS) {
-  savedEnv[key] = process.env[key];
-}
+]);
 
 describe("getOrCreateHostDeviceId", () => {
   let tempHome: string;
@@ -45,13 +42,7 @@ describe("getOrCreateHostDeviceId", () => {
   });
 
   afterEach(() => {
-    for (const key of SAVED_ENV_VARS) {
-      if (savedEnv[key] === undefined) {
-        delete process.env[key];
-      } else {
-        process.env[key] = savedEnv[key];
-      }
-    }
+    restoreEnv();
     rmSync(tempHome, { recursive: true, force: true });
     resetHostDeviceIdCache();
   });

--- a/cli/src/__tests__/helpers/env.ts
+++ b/cli/src/__tests__/helpers/env.ts
@@ -1,0 +1,19 @@
+/**
+ * Snapshot the given env vars now; returns a restore function suitable for
+ * `afterEach` that resets each var to its captured value (or deletes it).
+ */
+export function snapshotEnv(keys: readonly string[]): () => void {
+  const saved: Record<string, string | undefined> = {};
+  for (const key of keys) {
+    saved[key] = process.env[key];
+  }
+  return () => {
+    for (const key of keys) {
+      if (saved[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = saved[key];
+      }
+    }
+  };
+}

--- a/cli/src/__tests__/upgrade-replay-env.test.ts
+++ b/cli/src/__tests__/upgrade-replay-env.test.ts
@@ -3,25 +3,16 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { resetHostDeviceIdCache } from "../lib/device-id.js";
 import type { DockerStatefulSetSpec } from "../lib/statefulset.js";
 import { buildReplayEnv, buildReplayState } from "../lib/upgrade-lifecycle.js";
+import { snapshotEnv } from "./helpers/env.js";
 
-const SAVED_ENV_VARS = [
+const restoreEnv = snapshotEnv([
   "VELLUM_PLATFORM_URL",
   "ANTHROPIC_API_KEY",
   "VELLUM_DEVICE_ID",
-] as const;
-const savedEnv: Record<string, string | undefined> = {};
-for (const key of SAVED_ENV_VARS) {
-  savedEnv[key] = process.env[key];
-}
+]);
 
 afterEach(() => {
-  for (const key of SAVED_ENV_VARS) {
-    if (savedEnv[key] === undefined) {
-      delete process.env[key];
-    } else {
-      process.env[key] = savedEnv[key];
-    }
-  }
+  restoreEnv();
   resetHostDeviceIdCache();
 });
 

--- a/cli/src/lib/upgrade-lifecycle.ts
+++ b/cli/src/lib/upgrade-lifecycle.ts
@@ -206,7 +206,7 @@ export function buildReplayEnv(
 }
 
 /** Secrets and replay env derived from the outgoing containers. */
-export interface ReplayState {
+interface ReplayState {
   bootstrapSecret: string | undefined;
   cesServiceToken: string;
   signingKey: string;
@@ -242,8 +242,8 @@ export function buildReplayState(
 
 /**
  * Capture the assistant and gateway container envs and derive the replay
- * state for the replacement containers. Logs env-var counts only, never
- * values.
+ * state for the replacement containers. Logs only the assistant env-var
+ * count (security contract on `buildReplayEnv`).
  */
 export async function captureReplayState(
   res: Pick<


### PR DESCRIPTION
## Summary
Fixes residual cleanup items from plan review round 2 for persist-gateway-env-docker.md.

- Drop unused `export` on `ReplayState` (same class of issue as the `BuilderManagedEnvKeys` unexport in #34328)
- Extract shared `snapshotEnv` test helper; use in device-id and upgrade-replay-env tests (replaces verbatim duplication)
- Trim/correct `captureReplayState` docblock (only the assistant count is logged; contract lives on `buildReplayEnv`)