### PR TITLE
fix: skip platform lockfile sync when the active org is unresolved

### DIFF
--- a/apps/web/src/lib/local-mode.test.ts
+++ b/apps/web/src/lib/local-mode.test.ts
@@ -1,4 +1,16 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import * as localModeHost from "@/runtime/local-mode-host";
+
+const replacePlatformAssistantsHost = mock(async () => ({
+  ok: true,
+  lockfile: { assistants: [], activeAssistant: null },
+}));
+
+mock.module("@/runtime/local-mode-host", () => ({
+  ...localModeHost,
+  replacePlatformAssistantsHost,
+}));
 
 import {
   getActiveAssistant,
@@ -10,6 +22,7 @@ import {
   isPlatformAssistant,
   reconcileSelectedAssistant,
   setSelectedAssistantId,
+  syncPlatformAssistantsToLockfile,
 } from "@/lib/local-mode";
 import type { Lockfile, LockfileAssistant } from "@/runtime/local-mode-host";
 import { useLockfileStore } from "@/stores/lockfile-store";
@@ -42,6 +55,34 @@ afterEach(() => {
   useLockfileStore.setState({ lockfile: null });
   localStorage.removeItem(LOCKFILE_STORAGE_KEY);
   localStorage.removeItem(SELECTED_ASSISTANT_STORAGE_KEY);
+  replacePlatformAssistantsHost.mockClear();
+});
+
+describe("syncPlatformAssistantsToLockfile", () => {
+  const remote = {
+    id: "platform-a",
+    name: "A",
+    is_local: false,
+    created: "2026-01-01",
+  };
+
+  test("skips the host replace when the org is unresolved (no wipe)", async () => {
+    await syncPlatformAssistantsToLockfile([remote], undefined);
+    await syncPlatformAssistantsToLockfile([remote]);
+
+    expect(replacePlatformAssistantsHost).not.toHaveBeenCalled();
+  });
+
+  test("runs the host replace when an org is provided", async () => {
+    await syncPlatformAssistantsToLockfile([remote], "org-1");
+
+    expect(replacePlatformAssistantsHost).toHaveBeenCalledTimes(1);
+    const [entries, org] = replacePlatformAssistantsHost.mock.calls[0]!;
+    expect(org).toBe("org-1");
+    expect(entries).toEqual([
+      expect.objectContaining({ assistantId: "platform-a", organizationId: "org-1" }),
+    ]);
+  });
 });
 
 describe("assistant classification", () => {

--- a/apps/web/src/lib/local-mode.test.ts
+++ b/apps/web/src/lib/local-mode.test.ts
@@ -2,10 +2,15 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 
 import * as localModeHost from "@/runtime/local-mode-host";
 
-const replacePlatformAssistantsHost = mock(async () => ({
-  ok: true,
-  lockfile: { assistants: [], activeAssistant: null },
-}));
+const replacePlatformAssistantsHost = mock(
+  async (
+    _entries: Array<Record<string, unknown>>,
+    _organizationId?: string,
+  ) => ({
+    ok: true as const,
+    lockfile: { assistants: [], activeAssistant: null },
+  }),
+);
 
 mock.module("@/runtime/local-mode-host", () => ({
   ...localModeHost,

--- a/apps/web/src/lib/local-mode.ts
+++ b/apps/web/src/lib/local-mode.ts
@@ -195,6 +195,10 @@ export async function syncPlatformAssistantsToLockfile(
   assistants: Array<{ id: string; name?: string; is_local: boolean; created: string }>,
   organizationId?: string,
 ): Promise<void> {
+  // Without a resolved org we can't scope the replace; a full wipe here would
+  // drop other orgs' platform entries. Skip — a later sync re-runs with the org.
+  if (organizationId == null) return;
+
   const platformAssistants = assistants
     .filter((a) => !a.is_local)
     .map((a) => ({


### PR DESCRIPTION
## Summary
Fixes a gap from plan review for assistant-selection-unify.md.

**Gap:** with a null currentOrganizationId, syncPlatformAssistantsToLockfile passed undefined, hitting the legacy full-replace and wiping other orgs' platform entries.
**Fix:** skip the sync when the org is unresolved; a later sync re-runs once the org resolves.