### PR TITLE
fix: route command-palette selection through the unified org-aware resolver

### DIFF
--- a/apps/web/src/components/command-palette/command-palette-window-page.test.tsx
+++ b/apps/web/src/components/command-palette/command-palette-window-page.test.tsx
@@ -55,8 +55,15 @@ mock.module("@/hooks/conversation-queries", () => ({
 const localSelectedRef = {
   value: null as { assistantId: string; name?: string } | null,
 };
+const tabLocalSelectedRef = { value: null as string | null };
 mock.module("@/lib/local-mode", () => ({
   getSelectedAssistant: () => localSelectedRef.value,
+  getActiveAssistant: () =>
+    resolvedRef.activeAssistantId
+      ? { assistantId: resolvedRef.activeAssistantId }
+      : undefined,
+  getTabLocalSelectedAssistantId: () => tabLocalSelectedRef.value,
+  setActiveLockfileAssistant: async () => undefined,
 }));
 
 mock.module("@/stores/auth-store", () => {
@@ -76,6 +83,9 @@ mock.module("@/stores/organization-store", () => {
   useOrganizationStore.use = {
     currentOrganizationId: () => orgRef.currentOrganizationId,
   };
+  useOrganizationStore.getState = () => ({
+    currentOrganizationId: orgRef.currentOrganizationId,
+  });
   return { useOrganizationStore };
 });
 
@@ -87,7 +97,23 @@ mock.module("@/stores/resolved-assistants-store", () => {
     selectedPlatformAssistantByOrg: () =>
       resolvedRef.selectedPlatformAssistantByOrg,
   };
-  return { useResolvedAssistantsStore };
+  useResolvedAssistantsStore.getState = () => ({
+    assistants: resolvedRef.assistants,
+    selectedPlatformAssistantByOrg: resolvedRef.selectedPlatformAssistantByOrg,
+  });
+  return {
+    useResolvedAssistantsStore,
+    assistantsValidForOrg: (
+      assistants: { organizationId?: string | null; isLocal?: boolean }[],
+      activeOrgId: string | null,
+    ) =>
+      assistants.filter(
+        (a) =>
+          a.isLocal ||
+          a.organizationId == null ||
+          a.organizationId === activeOrgId,
+      ),
+  };
 });
 
 const useCommandPaletteSectionsMock = mock((_params: unknown) => ({

--- a/apps/web/src/components/command-palette/command-palette-window-page.tsx
+++ b/apps/web/src/components/command-palette/command-palette-window-page.tsx
@@ -8,7 +8,7 @@ import { useAssistantLifecycle } from "@/assistant/use-lifecycle";
 import { useCommandPaletteSections } from "@/domains/chat/hooks/use-command-palette-sections";
 import { useClientFeatureFlagSync } from "@/hooks/use-client-feature-flag-sync";
 import { useConversationListQuery } from "@/hooks/conversation-queries";
-import { getSelectedAssistant } from "@/lib/local-mode";
+import { resolveSelectedAssistantId } from "@/assistant/selection";
 import {
   dismissCommandPaletteWindow,
   selectCommandPaletteCommand,
@@ -88,29 +88,18 @@ export function CommandPaletteWindowPage() {
     useResolvedAssistantsStore.use.selectedPlatformAssistantByOrg();
   const currentOrganizationId =
     useOrganizationStore.use.currentOrganizationId();
+  // Resolve through the unified org-aware resolver. It reads activeAssistantId
+  // and selectedPlatformAssistantByOrg via getState() (non-reactive), so those
+  // slices are kept in the dep array as the recompute signal even though the
+  // callback doesn't reference them directly.
   const selectedAssistant = useMemo(
     () => {
-      const localSelected = getSelectedAssistant();
-      if (localSelected) {
-        return {
-          id: localSelected.assistantId,
-          name: localSelected.name,
-        };
-      }
-
-      const selectedPlatformAssistantId =
-        currentOrganizationId == null
-          ? null
-          : selectedPlatformAssistantByOrg[currentOrganizationId];
-      const selectedId =
-        activeAssistantId ??
-        selectedPlatformAssistantId ??
-        (assistants.length === 1 ? assistants[0]?.id : null);
+      const selectedId = resolveSelectedAssistantId(currentOrganizationId);
       if (!selectedId) return null;
-      return (
-        assistants.find((assistant) => assistant.id === selectedId) ?? null
-      );
+      const entry = assistants.find((a) => a.id === selectedId);
+      return entry ? { id: entry.id, name: entry.name } : null;
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       activeAssistantId,
       assistants,


### PR DESCRIPTION
## Summary
Fixes a gap from plan review for assistant-selection-unify.md.

**Gap:** command-palette-window-page composed its own selection without org validation, so it could surface a cross-org assistant.
**Fix:** resolve through resolveSelectedAssistantId(currentOrganizationId), preserving reactive store subscriptions.