### PR TITLE
fix: gate command-palette resolver by the multi-assistant flag

### DIFF
--- a/apps/web/src/components/command-palette/command-palette-window-page.test.tsx
+++ b/apps/web/src/components/command-palette/command-palette-window-page.test.tsx
@@ -66,6 +66,16 @@ mock.module("@/lib/local-mode", () => ({
   setActiveLockfileAssistant: async () => undefined,
 }));
 
+mock.module("@/lib/auth/gateway-session", () => ({
+  isGatewayAuthMode: () => false,
+}));
+
+mock.module("@/stores/client-feature-flag-store", () => ({
+  useClientFeatureFlagStore: {
+    use: { multiPlatformAssistant: () => true },
+  },
+}));
+
 mock.module("@/stores/auth-store", () => {
   const useAuthStore = () => null;
   useAuthStore.use = {

--- a/apps/web/src/components/command-palette/command-palette-window-page.tsx
+++ b/apps/web/src/components/command-palette/command-palette-window-page.tsx
@@ -9,6 +9,7 @@ import { useCommandPaletteSections } from "@/domains/chat/hooks/use-command-pale
 import { useClientFeatureFlagSync } from "@/hooks/use-client-feature-flag-sync";
 import { useConversationListQuery } from "@/hooks/conversation-queries";
 import { resolveSelectedAssistantId } from "@/assistant/selection";
+import { isGatewayAuthMode } from "@/lib/auth/gateway-session";
 import {
   dismissCommandPaletteWindow,
   selectCommandPaletteCommand,
@@ -19,6 +20,7 @@ import {
   useHasPlatformSession,
   useIsSessionInitializing,
 } from "@/stores/auth-store";
+import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { useOrganizationStore } from "@/stores/organization-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 
@@ -88,19 +90,26 @@ export function CommandPaletteWindowPage() {
     useResolvedAssistantsStore.use.selectedPlatformAssistantByOrg();
   const currentOrganizationId =
     useOrganizationStore.use.currentOrganizationId();
-  // Resolve through the unified org-aware resolver. It reads activeAssistantId
-  // and selectedPlatformAssistantByOrg via getState() (non-reactive), so those
-  // slices are kept in the dep array as the recompute signal even though the
-  // callback doesn't reference them directly.
+  const multiAssistantEnabled =
+    useClientFeatureFlagStore.use.multiPlatformAssistant();
+  // Mirror use-lifecycle's gating: only resolve the per-org cache when the
+  // multi-assistant flag is on; otherwise track the lifecycle's active id, so
+  // the palette never binds to a stale cached selection the lifecycle ignored.
+  // The resolver reads selectedPlatformAssistantByOrg via getState() (non-
+  // reactive), so that slice stays in the dep array as the recompute signal.
   const selectedAssistant = useMemo(
     () => {
-      const selectedId = resolveSelectedAssistantId(currentOrganizationId);
+      const selectedId =
+        multiAssistantEnabled && !isGatewayAuthMode() && currentOrganizationId
+          ? resolveSelectedAssistantId(currentOrganizationId)
+          : activeAssistantId;
       if (!selectedId) return null;
       const entry = assistants.find((a) => a.id === selectedId);
       return entry ? { id: entry.id, name: entry.name } : null;
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [
+      multiAssistantEnabled,
       activeAssistantId,
       assistants,
       currentOrganizationId,


### PR DESCRIPTION
## Summary
Fixes Codex feedback on the command-palette remediation (PR #34364) during plan review for assistant-selection-unify.md.

**Gap:** the palette resolved the per-org selection cache unconditionally, disagreeing with use-lifecycle when the multi-assistant flag is off.
**Fix:** gate the resolver the same way as use-lifecycle; fall back to activeAssistantId otherwise.