### PR TITLE
use per-environment GCS release buckets for Electron auto-update

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -2062,13 +2062,13 @@ jobs:
       - name: Upload Electron update artifacts to GCS
         run: |
           CHANNEL="dev"
-          BUCKET="vellum-desktop-releases"
+          BUCKET="vellum-dev-releases"
           MANIFEST_NAME="${CHANNEL}-mac.yml"
 
           for ARCH in arm64 x64; do
             ARCH_DIR="electron-artifacts/${ARCH}"
             [ -d "$ARCH_DIR" ] || continue
-            PREFIX="mac-electron/${CHANNEL}/${ARCH}"
+            PREFIX="mac-electron/${ARCH}"
 
             find "$ARCH_DIR" -name "*.zip" -type f ! -name "*.blockmap" | while read -r ZIP; do
               gcloud storage cp "$ZIP" "gs://${BUCKET}/${PREFIX}/$(basename "$ZIP")"

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -2061,9 +2061,9 @@ jobs:
 
       - name: Upload Electron update artifacts to GCS
         run: |
-          CHANNEL="dev"
+          ENVIRONMENT="dev"
           BUCKET="vellum-dev-releases"
-          MANIFEST_NAME="${CHANNEL}-mac.yml"
+          MANIFEST_NAME="${ENVIRONMENT}-mac.yml"
 
           for ARCH in arm64 x64; do
             ARCH_DIR="electron-artifacts/${ARCH}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2780,13 +2780,13 @@ jobs:
       - name: Upload Electron update artifacts to GCS
         run: |
           CHANNEL=${{ needs.extract-version.outputs.is_staging == 'true' && 'staging' || 'production' }}
-          BUCKET="vellum-desktop-releases"
+          BUCKET=${{ needs.extract-version.outputs.is_staging == 'true' && 'vellum-staging-releases' || 'vellum-prod-releases' }}
           MANIFEST_NAME="${CHANNEL}-mac.yml"
 
           for ARCH in arm64 x64; do
             ARCH_DIR="electron-artifacts/${ARCH}"
             [ -d "$ARCH_DIR" ] || continue
-            PREFIX="mac-electron/${CHANNEL}/${ARCH}"
+            PREFIX="mac-electron/${ARCH}"
 
             find "$ARCH_DIR" -name "*.zip" -type f ! -name "*.blockmap" | while read -r ZIP; do
               gcloud storage cp "$ZIP" "gs://${BUCKET}/${PREFIX}/$(basename "$ZIP")"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2779,9 +2779,9 @@ jobs:
 
       - name: Upload Electron update artifacts to GCS
         run: |
-          CHANNEL=${{ needs.extract-version.outputs.is_staging == 'true' && 'staging' || 'production' }}
+          ENVIRONMENT=${{ needs.extract-version.outputs.is_staging == 'true' && 'staging' || 'production' }}
           BUCKET=${{ needs.extract-version.outputs.is_staging == 'true' && 'vellum-staging-releases' || 'vellum-prod-releases' }}
-          MANIFEST_NAME="${CHANNEL}-mac.yml"
+          MANIFEST_NAME="${ENVIRONMENT}-mac.yml"
 
           for ARCH in arm64 x64; do
             ARCH_DIR="electron-artifacts/${ARCH}"

--- a/apps/macos/electron-builder.config.cjs
+++ b/apps/macos/electron-builder.config.cjs
@@ -24,7 +24,7 @@ module.exports = {
   productName,
   publish: {
     provider: "generic",
-    url: `https://storage.googleapis.com/vellum-desktop-releases/mac-electron/${env}/${targetArch}/`,
+    url: `https://storage.googleapis.com/vellum-${env}-releases/mac-electron/${targetArch}/`,
   },
   directories: {
     output: "dist",

--- a/apps/macos/electron-builder.config.cjs
+++ b/apps/macos/electron-builder.config.cjs
@@ -1,6 +1,7 @@
 // @ts-check
 
 const env = process.env.VELLUM_ENVIRONMENT || "production";
+const bucketEnv = env === "production" ? "prod" : env;
 const targetArch = process.env.ELECTRON_TARGET_ARCH || "arm64";
 
 const productName =
@@ -24,7 +25,7 @@ module.exports = {
   productName,
   publish: {
     provider: "generic",
-    url: `https://storage.googleapis.com/vellum-${env}-releases/mac-electron/${targetArch}/`,
+    url: `https://storage.googleapis.com/vellum-${bucketEnv}-releases/mac-electron/${targetArch}/`,
   },
   directories: {
     output: "dist",

--- a/apps/macos/src/main/auto-update.ts
+++ b/apps/macos/src/main/auto-update.ts
@@ -12,6 +12,8 @@ const ENVIRONMENT: string =
     ? __VELLUM_ENVIRONMENT__
     : "production";
 
+const BUCKET_ENV = ENVIRONMENT === "production" ? "prod" : ENVIRONMENT;
+
 type UpdateStatus =
   | "idle"
   | "checking"
@@ -60,7 +62,7 @@ export const installAutoUpdate = (): void => {
   autoUpdater.allowDowngrade = false;
   autoUpdater.setFeedURL({
     provider: "generic",
-    url: `https://storage.googleapis.com/vellum-${ENVIRONMENT}-releases/mac-electron/${process.arch}/`,
+    url: `https://storage.googleapis.com/vellum-${BUCKET_ENV}-releases/mac-electron/${process.arch}/`,
   });
 
   autoUpdater.on("checking-for-update", () => {

--- a/apps/macos/src/main/auto-update.ts
+++ b/apps/macos/src/main/auto-update.ts
@@ -7,7 +7,7 @@ import log from "./logger";
 
 declare const __VELLUM_ENVIRONMENT__: string;
 
-const CHANNEL: string =
+const ENVIRONMENT: string =
   typeof __VELLUM_ENVIRONMENT__ === "string"
     ? __VELLUM_ENVIRONMENT__
     : "production";
@@ -56,11 +56,11 @@ export const installAutoUpdate = (): void => {
   autoUpdater.logger = log;
   autoUpdater.autoDownload = true;
   autoUpdater.autoInstallOnAppQuit = true;
-  autoUpdater.channel = CHANNEL;
+  autoUpdater.channel = ENVIRONMENT;
   autoUpdater.allowDowngrade = false;
   autoUpdater.setFeedURL({
     provider: "generic",
-    url: `https://storage.googleapis.com/vellum-${CHANNEL}-releases/mac-electron/${process.arch}/`,
+    url: `https://storage.googleapis.com/vellum-${ENVIRONMENT}-releases/mac-electron/${process.arch}/`,
   });
 
   autoUpdater.on("checking-for-update", () => {

--- a/apps/macos/src/main/auto-update.ts
+++ b/apps/macos/src/main/auto-update.ts
@@ -60,7 +60,7 @@ export const installAutoUpdate = (): void => {
   autoUpdater.allowDowngrade = false;
   autoUpdater.setFeedURL({
     provider: "generic",
-    url: `https://storage.googleapis.com/vellum-desktop-releases/mac-electron/${CHANNEL}/${process.arch}/`,
+    url: `https://storage.googleapis.com/vellum-${CHANNEL}-releases/mac-electron/${process.arch}/`,
   });
 
   autoUpdater.on("checking-for-update", () => {


### PR DESCRIPTION
## Summary

- Switch from single `vellum-desktop-releases` bucket to per-environment buckets (`vellum-dev-releases`, `vellum-staging-releases`, `vellum-prod-releases`)
- Simplify GCS path from `mac-electron/{env}/{arch}/` to `mac-electron/{arch}/` since environment is now encoded in the bucket name
- Update both CI workflows (`dev-release.yaml`, `release.yml`) and app-side code (`electron-builder.config.cjs`, `auto-update.ts`)

## Original prompt

The `upload-electron-updates` CI job was failing with a 404 because `gs://vellum-desktop-releases` didn't exist. Rather than creating a single shared bucket, we decided to create per-environment buckets (`vellum-{env}-releases`) via Terraform in the platform repo — generic enough for future non-Electron artifacts. This PR updates the assistant repo to use those new buckets, assuming the Terraform changes have been applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)