### PR TITLE
feat(electron): OS-level mic permission flow — one-shot TCC prompt + System Settings deep-link

### DIFF
--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -58,6 +58,7 @@ import {
 import { installApplicationMenu } from "./menu";
 import { installNativeAuth } from "./native-auth";
 import { installConnectivityProbe } from "./connectivity-probe";
+import { installMicAccessIpc } from "./mic-access";
 import { installNotifications } from "./notifications";
 import { installPermissionHandler } from "./permissions";
 import { installPowerEvents } from "./power-events";
@@ -322,6 +323,7 @@ app
     installBundleFlow();
     onFileOpen(handleBundleFile);
     installPermissionHandler();
+    installMicAccessIpc();
     installCsp();
     installHotkeysIpc();
     installFeatureFlagsIpc();

--- a/apps/macos/src/main/mic-access.test.ts
+++ b/apps/macos/src/main/mic-access.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+const getMediaAccessStatusMock = mock(
+  (_mediaType: string) => "granted" as string,
+);
+const askForMediaAccessMock = mock(async (_mediaType: string) => true);
+const openExternalMock = mock(async (_url: string) => undefined);
+const ipcHandleMock = mock(
+  (_channel: string, _listener: (...args: unknown[]) => unknown) => undefined,
+);
+
+mock.module("electron", () => ({
+  app: { isPackaged: true },
+  ipcMain: { handle: ipcHandleMock, on: mock(() => undefined) },
+  shell: { openExternal: openExternalMock },
+  systemPreferences: {
+    getMediaAccessStatus: getMediaAccessStatusMock,
+    askForMediaAccess: askForMediaAccessMock,
+  },
+}));
+
+const { getMicAccessStatus, installMicAccessIpc, requestMicAccess } =
+  await import("./mic-access");
+
+const realPlatform = process.platform;
+const setPlatform = (platform: NodeJS.Platform): void => {
+  Object.defineProperty(process, "platform", {
+    value: platform,
+    configurable: true,
+  });
+};
+
+afterEach(() => {
+  setPlatform(realPlatform);
+  getMediaAccessStatusMock.mockClear();
+  askForMediaAccessMock.mockClear();
+  openExternalMock.mockClear();
+});
+
+describe("getMicAccessStatus", () => {
+  test("reads the TCC state from systemPreferences on macOS", () => {
+    setPlatform("darwin");
+    getMediaAccessStatusMock.mockReturnValueOnce("denied");
+
+    expect(getMicAccessStatus()).toBe("denied");
+    expect(getMediaAccessStatusMock).toHaveBeenCalledWith("microphone");
+  });
+
+  test("reports granted on Linux, which has no TCC equivalent", () => {
+    setPlatform("linux");
+
+    expect(getMicAccessStatus()).toBe("granted");
+    expect(getMediaAccessStatusMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("requestMicAccess", () => {
+  test("fires the one-shot system prompt on macOS", async () => {
+    setPlatform("darwin");
+    askForMediaAccessMock.mockResolvedValueOnce(false);
+
+    await expect(requestMicAccess()).resolves.toBe(false);
+    expect(askForMediaAccessMock).toHaveBeenCalledWith("microphone");
+  });
+
+  test("derives the grant from the access status off macOS", async () => {
+    setPlatform("win32");
+    getMediaAccessStatusMock.mockReturnValueOnce("denied");
+
+    await expect(requestMicAccess()).resolves.toBe(false);
+    expect(askForMediaAccessMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("installMicAccessIpc", () => {
+  test("registers the three mic channels once", () => {
+    installMicAccessIpc();
+    installMicAccessIpc();
+
+    const channels = ipcHandleMock.mock.calls.map((call) => call[0]);
+    expect(channels).toEqual([
+      "vellum:mic:getStatus",
+      "vellum:mic:request",
+      "vellum:mic:openSettings",
+    ]);
+  });
+});

--- a/apps/macos/src/main/mic-access.ts
+++ b/apps/macos/src/main/mic-access.ts
@@ -1,0 +1,56 @@
+import { shell, systemPreferences } from "electron";
+import { z } from "zod";
+
+import { handle } from "./ipc";
+
+/**
+ * OS-level (TCC) microphone access plumbing.
+ *
+ * `permissions.ts` owns the web half of mic access — auto-granting the
+ * renderer's `getUserMedia` permission request for trusted origins. This
+ * module owns the OS half: reading the TCC grant, firing the one-shot
+ * system prompt, and deep-linking System Settings once the user has denied
+ * (macOS records the denial and never re-prompts the app; Settings is the
+ * only recovery path).
+ */
+
+/** Mirror of `systemPreferences.getMediaAccessStatus`'s return values. */
+export type MicAccessStatus =
+  | "not-determined"
+  | "granted"
+  | "denied"
+  | "restricted"
+  | "unknown";
+
+const MIC_SETTINGS_URL =
+  "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone";
+
+export const getMicAccessStatus = (): MicAccessStatus => {
+  // getMediaAccessStatus exists on macOS and Windows only. Linux has no TCC
+  // equivalent — report granted and let getUserMedia surface real failures.
+  if (process.platform === "linux") return "granted";
+  return systemPreferences.getMediaAccessStatus("microphone");
+};
+
+export const requestMicAccess = (): Promise<boolean> => {
+  // askForMediaAccess is macOS-only: prompts once while the state is
+  // not-determined, otherwise resolves with the recorded grant.
+  if (process.platform !== "darwin") {
+    return Promise.resolve(getMicAccessStatus() !== "denied");
+  }
+  return systemPreferences.askForMediaAccess("microphone");
+};
+
+let installed = false;
+
+export const installMicAccessIpc = (): void => {
+  if (installed) return;
+  installed = true;
+
+  handle("vellum:mic:getStatus", z.tuple([]), () => getMicAccessStatus());
+  handle("vellum:mic:request", z.tuple([]), () => requestMicAccess());
+  handle("vellum:mic:openSettings", z.tuple([]), async () => {
+    if (process.platform !== "darwin") return;
+    await shell.openExternal(MIC_SETTINGS_URL);
+  });
+};

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -238,6 +238,15 @@ export type TextInsertionResult =
   | { status: "automation-denied" }
   | { status: "blocked" };
 
+// Mirror of `MicAccessStatus` in `apps/macos/src/main/mic-access.ts` (kept
+// inline for the same three-TS-project reason as `VellumCommand`).
+export type MicAccessStatus =
+  | "not-determined"
+  | "granted"
+  | "denied"
+  | "restricted"
+  | "unknown";
+
 /**
  * Event main broadcasts to the renderer when the user clicks a
  * notification body or an action button. Mirror of
@@ -306,6 +315,17 @@ export interface VellumBridge {
   text: {
     insertIntoFrontApp(text: string): Promise<TextInsertionResult>;
     openAutomationSettings(): Promise<void>;
+  };
+  mic: {
+    /** Current OS-level (TCC) microphone grant. */
+    getStatus(): Promise<MicAccessStatus>;
+    /**
+     * One-shot OS microphone prompt (macOS): prompts while the state is
+     * not-determined, otherwise resolves with the recorded grant.
+     */
+    request(): Promise<boolean>;
+    /** Deep-link System Settings → Privacy & Security → Microphone. */
+    openSettings(): Promise<void>;
   };
   auth: {
     startOAuth(options: {
@@ -683,6 +703,14 @@ const bridge: VellumBridge = {
       ipcRenderer.invoke(
         "vellum:text:openAutomationSettings",
       ) as Promise<void>,
+  },
+  mic: {
+    getStatus: (): Promise<MicAccessStatus> =>
+      ipcRenderer.invoke("vellum:mic:getStatus") as Promise<MicAccessStatus>,
+    request: (): Promise<boolean> =>
+      ipcRenderer.invoke("vellum:mic:request") as Promise<boolean>,
+    openSettings: (): Promise<void> =>
+      ipcRenderer.invoke("vellum:mic:openSettings") as Promise<void>,
   },
   auth: {
     startOAuth: (options: {

--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -245,6 +245,7 @@ export function ChatMainPanel({
     clearVoiceError,
     setVoiceError,
     handleOpenTextInsertionSettings,
+    handleOpenMicSettings,
     showPrimer,
     handleVoiceBeforeStart,
     handleVoiceTranscript,
@@ -790,6 +791,7 @@ export function ChatMainPanel({
         onClearVoiceError={clearVoiceError}
         onRetryMicPermission={handleRetryMicPermission}
         onOpenTextInsertionSettings={handleOpenTextInsertionSettings}
+        onOpenMicSettings={handleOpenMicSettings}
         textStateNoticesSlot={textStateNoticesJsx}
       />
     ),

--- a/apps/web/src/domains/chat/components/composer-notices.tsx
+++ b/apps/web/src/domains/chat/components/composer-notices.tsx
@@ -6,6 +6,7 @@ import { MissingApiKeyBanner } from "@/domains/chat/components/missing-api-key-b
 import {
   formatVoiceError,
   isMicPermissionError,
+  isMicSystemPermissionError,
   isTextInsertionPermissionError,
 } from "@/domains/chat/utils/chat";
 import { Button, Notice } from "@vellumai/design-library";
@@ -51,6 +52,8 @@ export interface ComposerNoticesProps {
   onRetryMicPermission?: () => void;
   /** Opens macOS Automation settings for external-app dictation paste. */
   onOpenTextInsertionSettings?: () => void | Promise<void>;
+  /** Opens macOS Privacy & Security → Microphone settings (TCC denial recovery). */
+  onOpenMicSettings?: () => void | Promise<void>;
 
   /**
    * Pre-rendered disk-pressure banner from the chat page, or `null` when
@@ -97,6 +100,7 @@ export function ComposerNotices({
   onClearVoiceError,
   onRetryMicPermission,
   onOpenTextInsertionSettings,
+  onOpenMicSettings,
   diskPressureBanner,
   billingBannerSlot,
   showMissingApiKeyBanner,
@@ -108,6 +112,17 @@ export function ComposerNotices({
   assistantId,
   onMaintenanceExited,
 }: ComposerNoticesProps) {
+  // Both settings-recoverable denials render the same "Open Settings"
+  // action; only the deep-link target differs (Privacy → Microphone vs
+  // Privacy → Automation).
+  const openVoiceSettings =
+    isMicSystemPermissionError(voiceError ?? null) && onOpenMicSettings
+      ? onOpenMicSettings
+      : isTextInsertionPermissionError(voiceError ?? null) &&
+          onOpenTextInsertionSettings
+        ? onOpenTextInsertionSettings
+        : undefined;
+
   return (
     <>
       {textStateNoticesSlot}
@@ -132,13 +147,12 @@ export function ComposerNotices({
                 >
                   Allow Microphone
                 </Button>
-              ) : isTextInsertionPermissionError(voiceError) &&
-                onOpenTextInsertionSettings ? (
+              ) : openVoiceSettings ? (
                 <Button
                   variant="outlined"
                   size="compact"
                   onClick={() => {
-                    void onOpenTextInsertionSettings();
+                    void openVoiceSettings();
                   }}
                 >
                   Open Settings

--- a/apps/web/src/domains/chat/components/voice-input-button.test.tsx
+++ b/apps/web/src/domains/chat/components/voice-input-button.test.tsx
@@ -53,6 +53,13 @@ mock.module("@/utils/voice-input-device", () => ({
   voiceInputAudioConstraints: () => true,
 }));
 
+// OS-level (TCC) mic gate. Default null = no bridge (web/Capacitor), so the
+// rest of the suite exercises the plain getUserMedia path.
+let nextNativeMicGrant: boolean | null = null;
+mock.module("@/runtime/mic-permission", () => ({
+  requestMicAccess: async () => nextNativeMicGrant,
+}));
+
 // Capture the command handler map the component registers so tests can
 // deliver the escape monitor's `cancelDictation` relay directly (the real
 // hook is an Electron IPC subscription and no-ops in this environment).
@@ -244,5 +251,50 @@ describe("VoiceInputButton — session breadcrumb", () => {
     expect(crumb.data.finalLength).toBe("hello world".length);
     expect(crumb.data.durationMs).toBeGreaterThanOrEqual(0);
     expect(typeof crumb.data.locale).toBe("string");
+  });
+});
+
+describe("VoiceInputButton — OS mic gate", () => {
+  beforeEach(() => {
+    postSttTranscribeSpy.mockClear();
+    useVoiceRecordingStore.getState().reset();
+  });
+
+  afterEach(() => {
+    cleanup();
+    nextNativeMicGrant = null;
+    useVoiceRecordingStore.getState().reset();
+  });
+
+  test("OS-level denial blocks recording with the System Settings error", async () => {
+    nextNativeMicGrant = false;
+    const onTranscript = mock(async (_text: string) => {});
+    const onError = mock((_code: string | null) => {});
+    render(
+      <VoiceInputButton
+        assistantId="assistant-1"
+        onTranscript={onTranscript}
+        onError={onError}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Start voice input" }));
+
+    await waitFor(() => {
+      expect(useVoiceRecordingStore.getState().phase).toBe("error");
+    });
+    expect(useVoiceRecordingStore.getState().errorCode).toBe(
+      "not-allowed-system",
+    );
+    expect(onError).toHaveBeenCalledWith("not-allowed-system");
+    expect(onTranscript).not.toHaveBeenCalled();
+  });
+
+  test("OS-level grant proceeds to a normal recording session", async () => {
+    nextNativeMicGrant = true;
+    const onTranscript = mock(async (_text: string) => {});
+    await startSession(onTranscript);
+
+    expect(useVoiceRecordingStore.getState().phase).toBe("recording");
   });
 });

--- a/apps/web/src/domains/chat/components/voice-input-button.tsx
+++ b/apps/web/src/domains/chat/components/voice-input-button.tsx
@@ -20,6 +20,7 @@ import {
     type SttFailureReason,
 } from "@/domains/chat/voice/stt-api";
 import { useVoiceRecordingStore } from "@/domains/chat/voice/voice-recording-store";
+import { requestMicAccess } from "@/runtime/mic-permission";
 import { useIsNativePlatform } from "@/runtime/native-auth";
 import { useVellumCommands } from "@/runtime/vellum-commands";
 import { voiceInputAudioConstraints } from "@/utils/voice-input-device";
@@ -495,6 +496,22 @@ export const VoiceInputButton = forwardRef<
     if (!mimeType) {
       onError?.("service-not-allowed");
       vsFail("service-not-allowed");
+      return;
+    }
+
+    // OS-level (TCC) mic gate, Electron only: fires the one-shot system
+    // prompt while the grant is undetermined, and fails fast with the
+    // System Settings affordance once the user has denied — macOS never
+    // re-prompts a denied app, so the getUserMedia below could never
+    // recover on its own. `null` means no bridge (web / Capacitor), where
+    // getUserMedia itself drives the OS prompt.
+    const nativeMicGrant = await requestMicAccess();
+    if (cancelledStartRef.current || mediaRecorderRef.current) {
+      return;
+    }
+    if (nativeMicGrant === false) {
+      onError?.("not-allowed-system");
+      vsFail("not-allowed-system");
       return;
     }
 

--- a/apps/web/src/domains/chat/hooks/use-voice-input.test.tsx
+++ b/apps/web/src/domains/chat/hooks/use-voice-input.test.tsx
@@ -196,6 +196,18 @@ describe("useVoiceInput — handleRetryMicPermission (OS/TCC branch)", () => {
     expect(hook.result.current.voiceError).toBeNull();
   });
 
+  test("a failed prompt bridge call keeps the retryable error, not the System Settings one", async () => {
+    nextMicAccessStatus = "not-determined";
+    nextMicAccessGrant = null;
+    const { hook } = renderVoiceInput();
+
+    await act(async () => {
+      await hook.result.current.handleRetryMicPermission();
+    });
+
+    expect(hook.result.current.voiceError).toBe("not-allowed");
+  });
+
   test("handleOpenMicSettings deep-links System Settings", async () => {
     const { hook } = renderVoiceInput();
 

--- a/apps/web/src/domains/chat/hooks/use-voice-input.test.tsx
+++ b/apps/web/src/domains/chat/hooks/use-voice-input.test.tsx
@@ -25,6 +25,24 @@ mock.module("@/runtime/native-auth", () => ({
   useIsNativePlatform: () => false,
 }));
 
+// OS-level (TCC) mic bridge. Defaults mirror the web/Capacitor case (no
+// bridge → null) so the pre-existing tests exercise the web fallback path.
+type MicAccessStatus =
+  | "not-determined"
+  | "granted"
+  | "denied"
+  | "restricted"
+  | "unknown";
+let nextMicAccessStatus: MicAccessStatus | null = null;
+let nextMicAccessGrant: boolean | null = null;
+const openMicSettingsSpy = mock(async () => undefined);
+
+mock.module("@/runtime/mic-permission", () => ({
+  getMicAccessStatus: async () => nextMicAccessStatus,
+  requestMicAccess: async () => nextMicAccessGrant,
+  openMicSettings: openMicSettingsSpy,
+}));
+
 mock.module("@/domains/chat/components/mic-permission-primer", () => ({
   shouldShowMicPrimer: () => false,
 }));
@@ -74,6 +92,9 @@ afterEach(() => {
   nextTextInsertionStatus = "unavailable";
   nextDictationResult = null;
   insertedTexts.length = 0;
+  nextMicAccessStatus = null;
+  nextMicAccessGrant = null;
+  openMicSettingsSpy.mockClear();
 });
 
 describe("useVoiceInput", () => {
@@ -120,4 +141,68 @@ describe("useVoiceInput", () => {
     expect(hook.result.current.voiceError).toBe("dictation-automation-denied");
   });
 
+});
+
+describe("useVoiceInput — handleRetryMicPermission (OS/TCC branch)", () => {
+  test("OS denial maps to the System Settings error", async () => {
+    nextMicAccessStatus = "denied";
+    const { hook } = renderVoiceInput();
+
+    await act(async () => {
+      await hook.result.current.handleRetryMicPermission();
+    });
+
+    expect(hook.result.current.voiceError).toBe("not-allowed-system");
+  });
+
+  test("undetermined OS state fires the one-shot prompt and clears on grant", async () => {
+    nextMicAccessStatus = "not-determined";
+    nextMicAccessGrant = true;
+    const { hook } = renderVoiceInput();
+
+    await act(async () => {
+      hook.result.current.setVoiceError("not-allowed");
+    });
+    await act(async () => {
+      await hook.result.current.handleRetryMicPermission();
+    });
+
+    expect(hook.result.current.voiceError).toBeNull();
+  });
+
+  test("undetermined OS state maps a refused prompt to the System Settings error", async () => {
+    nextMicAccessStatus = "not-determined";
+    nextMicAccessGrant = false;
+    const { hook } = renderVoiceInput();
+
+    await act(async () => {
+      await hook.result.current.handleRetryMicPermission();
+    });
+
+    expect(hook.result.current.voiceError).toBe("not-allowed-system");
+  });
+
+  test("OS grant clears the error without touching getUserMedia", async () => {
+    nextMicAccessStatus = "granted";
+    const { hook } = renderVoiceInput();
+
+    await act(async () => {
+      hook.result.current.setVoiceError("not-allowed");
+    });
+    await act(async () => {
+      await hook.result.current.handleRetryMicPermission();
+    });
+
+    expect(hook.result.current.voiceError).toBeNull();
+  });
+
+  test("handleOpenMicSettings deep-links System Settings", async () => {
+    const { hook } = renderVoiceInput();
+
+    await act(async () => {
+      await hook.result.current.handleOpenMicSettings();
+    });
+
+    expect(openMicSettingsSpy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/web/src/domains/chat/hooks/use-voice-input.ts
+++ b/apps/web/src/domains/chat/hooks/use-voice-input.ts
@@ -224,6 +224,12 @@ export function useVoiceInput({
       }
       if (nativeStatus === "not-determined") {
         const granted = await requestMicAccess();
+        // null = the bridge call failed, not a user denial — keep the
+        // retryable error rather than sending the user to System Settings.
+        if (granted === null) {
+          setVoiceError("not-allowed");
+          return;
+        }
         setVoiceError(granted ? null : "not-allowed-system");
         return;
       }

--- a/apps/web/src/domains/chat/hooks/use-voice-input.ts
+++ b/apps/web/src/domains/chat/hooks/use-voice-input.ts
@@ -12,6 +12,11 @@ import { postDictation } from "@/domains/chat/voice/dictation-api";
 import { registerPushToTalkTarget } from "@/domains/chat/voice/push-to-talk-target";
 import { useVoiceRecordingStore } from "@/domains/chat/voice/voice-recording-store";
 import {
+  getMicAccessStatus,
+  openMicSettings,
+  requestMicAccess,
+} from "@/runtime/mic-permission";
+import {
   insertTextIntoFrontApp,
   openTextInsertionSettings,
 } from "@/runtime/text-insertion";
@@ -42,6 +47,8 @@ export interface UseVoiceInputReturn {
   setVoiceError: (code: string | null) => void;
   /** Open macOS Automation settings for external-app dictation paste. */
   handleOpenTextInsertionSettings: () => Promise<void>;
+  /** Open macOS Privacy & Security → Microphone settings (TCC denial recovery). */
+  handleOpenMicSettings: () => Promise<void>;
   /** Whether the mic-permission primer dialog is open. */
   showPrimer: boolean;
   /**
@@ -202,7 +209,28 @@ export function useVoiceInput({
     primerResolveRef.current = null;
   }, []);
 
+  const handleOpenMicSettings = useCallback(() => openMicSettings(), []);
+
   const handleRetryMicPermission = useCallback(async () => {
+    // Electron: the OS (TCC) grant governs — the Permissions API and
+    // getUserMedia below can't re-prompt once macOS records a denial.
+    // "unknown" falls through to the web checks (Windows reports it for
+    // states it can't read).
+    const nativeStatus = await getMicAccessStatus();
+    if (nativeStatus && nativeStatus !== "unknown") {
+      if (nativeStatus === "granted") {
+        setVoiceError(null);
+        return;
+      }
+      if (nativeStatus === "not-determined") {
+        const granted = await requestMicAccess();
+        setVoiceError(granted ? null : "not-allowed-system");
+        return;
+      }
+      setVoiceError("not-allowed-system");
+      return;
+    }
+
     try {
       // Check permission state via Permissions API when available.
       // If the user permanently denied access, skip getUserMedia
@@ -249,6 +277,7 @@ export function useVoiceInput({
     clearVoiceError,
     setVoiceError,
     handleOpenTextInsertionSettings,
+    handleOpenMicSettings,
     showPrimer,
     handleVoiceBeforeStart,
     handleVoiceTranscript,

--- a/apps/web/src/domains/chat/utils/chat.ts
+++ b/apps/web/src/domains/chat/utils/chat.ts
@@ -133,6 +133,8 @@ const VOICE_ERROR_MESSAGES: Readonly<Record<string, string>> = {
   "service-not-allowed": "Microphone access was blocked.",
   "not-allowed-permanent":
     "Microphone is blocked in your browser settings. Click the lock icon in your address bar and allow microphone access, then reload.",
+  "not-allowed-system":
+    "Microphone access for Vellum is turned off in System Settings. Allow it under Privacy & Security → Microphone, then try again.",
   "audio-capture":
     "No microphone detected. Connect a microphone and try again.",
   network:
@@ -175,6 +177,14 @@ export function isMicPermissionError(code: string | null): boolean {
 
 export function isTextInsertionPermissionError(code: string | null): boolean {
   return code === "dictation-automation-denied";
+}
+
+/**
+ * OS-level (TCC) mic denial — macOS never re-prompts a denied app, so the
+ * UI offers a System Settings deep-link instead of a re-prompt.
+ */
+export function isMicSystemPermissionError(code: string | null): boolean {
+  return code === "not-allowed-system";
 }
 
 const BACKGROUND_CONVERSATION_SOURCES: ReadonlySet<string> = new Set([

--- a/apps/web/src/runtime/is-electron.ts
+++ b/apps/web/src/runtime/is-electron.ts
@@ -211,6 +211,18 @@ export type ElectronTextInsertionResult =
   | { status: "blocked" };
 
 /**
+ * Renderer-side mirror of `MicAccessStatus` in
+ * `apps/macos/src/main/mic-access.ts` — the OS-level (TCC) microphone
+ * grant, distinct from the web `getUserMedia` permission.
+ */
+export type MicAccessStatus =
+  | "not-determined"
+  | "granted"
+  | "denied"
+  | "restricted"
+  | "unknown";
+
+/**
  * Main → renderer event when the user interacts with a native
  * notification. Mirror of `NotificationActionEvent` in
  * `apps/macos/src/main/notifications.ts`.
@@ -297,6 +309,13 @@ declare global {
       text?: {
         insertIntoFrontApp(text: string): Promise<ElectronTextInsertionResult>;
         openAutomationSettings(): Promise<void>;
+      };
+      // Optional: older Electron shells predate the OS-level (TCC) mic
+      // bridge. Callers must guard on presence.
+      mic?: {
+        getStatus(): Promise<MicAccessStatus>;
+        request(): Promise<boolean>;
+        openSettings(): Promise<void>;
       };
       // Optional: an older preload predates the hotkeys/featureFlags channels.
       // The macOS app and web bundle don't release together, so a newer

--- a/apps/web/src/runtime/mic-permission.ts
+++ b/apps/web/src/runtime/mic-permission.ts
@@ -1,0 +1,51 @@
+/**
+ * Runtime wrapper for the OS-level (TCC) microphone access bridge.
+ *
+ * On macOS the OS grant governs everything: once the user denies the TCC
+ * prompt, `getUserMedia` fails forever and the browser-style re-prompt
+ * paths are dead ends — System Settings is the only recovery. Feature code
+ * imports these functions instead of touching `window.vellum.mic` directly.
+ * Off Electron (web, Capacitor iOS) and on older shells that predate the
+ * channel they report "unavailable" (`null` / `false`) so callers fall
+ * back to the web permission flow.
+ */
+
+import { isElectron, type MicAccessStatus } from "@/runtime/is-electron";
+
+export type { MicAccessStatus };
+
+/** OS-level mic grant, or null when no bridge is available. */
+export async function getMicAccessStatus(): Promise<MicAccessStatus | null> {
+  if (!isElectron() || !window.vellum?.mic) return null;
+  try {
+    return await window.vellum.mic.getStatus();
+  } catch (err) {
+    console.warn("getMicAccessStatus failed", err);
+    return null;
+  }
+}
+
+/**
+ * One-shot OS microphone prompt. Resolves the resulting grant, or null
+ * when no bridge is available (callers proceed to `getUserMedia`, which
+ * prompts on web/Capacitor).
+ */
+export async function requestMicAccess(): Promise<boolean | null> {
+  if (!isElectron() || !window.vellum?.mic) return null;
+  try {
+    return await window.vellum.mic.request();
+  } catch (err) {
+    console.warn("requestMicAccess failed", err);
+    return null;
+  }
+}
+
+/** Deep-link System Settings → Privacy & Security → Microphone. */
+export async function openMicSettings(): Promise<void> {
+  if (!isElectron() || !window.vellum?.mic) return;
+  try {
+    await window.vellum.mic.openSettings();
+  } catch (err) {
+    console.warn("openMicSettings failed", err);
+  }
+}


### PR DESCRIPTION
## Summary
- New `mic-access.ts` main-process module exposes the OS half of mic permissions over IPC: `getStatus` (`systemPreferences.getMediaAccessStatus`), `request` (`askForMediaAccess` one-shot TCC prompt), and `openSettings` (deep-link to System Settings → Privacy & Security → Microphone) — complementing the existing `setPermissionRequestHandler` auto-grant in `permissions.ts`.
- `VoiceInputButton` now gates recording on the OS grant: undetermined state fires the one-shot system prompt before capture; a recorded denial fails fast with a new `not-allowed-system` error instead of a doomed `getUserMedia`, and the composer notice offers an "Open Settings" deep-link (macOS never re-prompts a denied app). `handleRetryMicPermission` consults the TCC state first for the same reason. Off Electron the bridge reports unavailable and the existing web/Capacitor `getUserMedia` flow is unchanged.
- Tests: main-process platform/registration coverage (`mic-access.test.ts`), the OS-gate deny/grant paths in `voice-input-button.test.tsx`, and the TCC-aware retry branches in `use-voice-input.test.tsx`.

## Original prompt
While auditing the dictation pipeline ticket (LUM-1968) against the codebase, the mic permission flow spec'd in its blocker LUM-1871 was found half-implemented: the main process auto-grants the renderer's web-level media request, but the `askForMediaAccess` one-shot TCC prompt and the `Privacy_Microphone` settings deep-link for re-denied users were missing — the OS prompt only fired implicitly through Chromium's `getUserMedia`, with no recovery path after a denial. The user asked to implement that remaining flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)