### PR TITLE
fix: gate vellum CLI menu on packaged builds; dedupe resolveCliInvocation

### DIFF
--- a/apps/macos/src/main/bundle-flow.test.ts
+++ b/apps/macos/src/main/bundle-flow.test.ts
@@ -39,11 +39,18 @@ const getGuardianAccessTokenMock = mock(
   async () => ({ ok: true as const, accessToken: "fake-token" }),
 );
 
+// Full `@vellumai/local-mode` surface so the real `./local-mode` (imported by
+// bundle-flow for resolveCliInvocation) links cleanly.
 mock.module("@vellumai/local-mode", () => ({
   getLockfileData: getLockfileDataMock,
   resolveLockfilePaths: resolveLockfilePathsMock,
   resolveConfigDir: resolveConfigDirMock,
   getGuardianAccessToken: getGuardianAccessTokenMock,
+  replacePlatformAssistants: mock(() => ({ ok: false, error: "unused" })),
+  upsertLockfileAssistant: mock(() => ({ ok: false, error: "unused" })),
+  runHatch: mock(async () => ({ ok: false, error: "unused" })),
+  runRetire: mock(async () => ({ ok: false, error: "unused" })),
+  runWake: mock(async () => ({ ok: false, error: "unused" })),
 }));
 
 const ensureCliInstalledMock = mock(async () => undefined);
@@ -93,9 +100,22 @@ mock.module("./bundle-window", () => ({
   openBundleWindow: openBundleWindowMock,
 }));
 
+// Full `./app-config` surface so this mock — which leaks into co-run test
+// files via the global module registry — doesn't break sibling modules
+// (notably `./app-origin`, loaded via the real `./local-mode` → `./ipc`).
 mock.module("./app-config", () => ({
+  APP_PROTOCOL: "app",
+  APP_HOST: "vellum.ai",
+  VELLUMAPP_PROTOCOL: "vellumapp",
   BUNDLES_DIR_NAME: "bundles",
+  RENDERER_BASE_PROD: "app://vellum.ai/assistant",
+  getDevRendererBase: () => "http://localhost:5173",
+  getRendererRootUrl: () => "app://vellum.ai/assistant",
 }));
+
+// resolveCliInvocation (via the real `./local-mode`) honors this override;
+// clear it so packaged-path assertions are deterministic.
+delete process.env.VELLUM_CLI_PATH;
 
 const { handleBundleFile, resolveActiveGateway, installBundleFlow } =
   await import("./bundle-flow");
@@ -300,8 +320,6 @@ describe("handleBundleFile", () => {
 
     await handleBundleFile("/tmp/test.vellum");
 
-    // isCliInstalled() is mocked true; routing through ensureCliInstalled
-    // keeps the PATH-wrapper locator fresh on the installed path.
     expect(ensureCliInstalledMock).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/macos/src/main/bundle-flow.ts
+++ b/apps/macos/src/main/bundle-flow.ts
@@ -14,15 +14,10 @@ import {
   getLockfileData,
   resolveConfigDir,
   resolveLockfilePaths,
-  type CliInvocation,
 } from "@vellumai/local-mode";
 
 import { BUNDLES_DIR_NAME } from "./app-config";
-import {
-  ensureCliInstalled,
-  getBundledBunPath,
-  getCliBinPath,
-} from "./cli-installer";
+import { resolveCliInvocation } from "./local-mode";
 import { openBundleConfirmation, installBundleConfirmation } from "./bundle-confirmation";
 import { unpackBundle, type BundleScanData } from "./bundle-manager";
 import { openBundleWindow } from "./bundle-window";
@@ -43,20 +38,6 @@ export function resolveActiveGateway(): ActiveGateway | null {
   if (!entry?.resources?.gatewayPort) return null;
 
   return { assistantId: entry.assistantId, port: entry.resources.gatewayPort };
-}
-
-async function resolveCliInvocation(): Promise<CliInvocation> {
-  if (!app.isPackaged) {
-    const repoRoot = path.resolve(app.getAppPath(), "..", "..");
-    const { existsSync } = await import("node:fs");
-    const cliEntry = path.join(repoRoot, "cli", "src", "index.ts");
-    if (existsSync(cliEntry)) {
-      return { command: "bun", baseArgs: ["run", cliEntry] };
-    }
-  }
-  // Early-returns when already installed, refreshing the PATH-wrapper locator.
-  await ensureCliInstalled();
-  return { command: getBundledBunPath(), baseArgs: ["run", getCliBinPath()] };
 }
 
 async function acquireGatewayToken(assistantId: string): Promise<string | null> {

--- a/apps/macos/src/main/local-mode.test.ts
+++ b/apps/macos/src/main/local-mode.test.ts
@@ -166,8 +166,6 @@ describe("vellum:localMode:hatch handler", () => {
       cliInstallerState.bundledBunPath,
       ["run", cliInstallerState.cliBinPath, "hatch", "openclaw"],
     ]);
-    // Routed through ensureCliInstalled so the PATH-wrapper locator is
-    // refreshed even on the already-installed path.
     expect(ensureCliInstalledMock).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/macos/src/main/menu.test.ts
+++ b/apps/macos/src/main/menu.test.ts
@@ -20,11 +20,15 @@ const buildFromTemplateMock = mock((template: TemplateItem[]) => ({
 }));
 const setApplicationMenuMock = mock((_menu: unknown) => undefined);
 
+// Mutable so tests can flip packaged/dev; the CLI path items only exist in
+// packaged builds, so packaged is the default here.
+const electronApp = {
+  name: "Vellum Electron",
+  isPackaged: true,
+};
+
 mock.module("electron", () => ({
-  app: {
-    name: "Vellum Electron",
-    isPackaged: false,
-  },
+  app: electronApp,
   Menu: {
     buildFromTemplate: buildFromTemplateMock,
     setApplicationMenu: setApplicationMenuMock,
@@ -139,6 +143,7 @@ const SHADOWED_LABEL = "⚠ vellum is shadowed by another install";
 installApplicationMenu();
 
 beforeEach(async () => {
+  electronApp.isPackaged = true;
   getCliPathInstallStateMock.mockReset();
   getCliPathInstallStateMock.mockResolvedValue({ kind: "not-installed" });
   // Settle any pending refresh kicked off by installApplicationMenu before
@@ -230,6 +235,28 @@ describe("CLI path menu items", () => {
     expect(callOrder).toEqual(["uninstall-flow", "detect"]);
     expect(buildFromTemplateMock.mock.calls.length).toBe(buildsBefore + 1);
     expect(appMenuLabels()).toContain(INSTALL_LABEL);
+  });
+});
+
+describe("CLI path menu items in unpackaged builds", () => {
+  test("shows neither item and never spawns detection", async () => {
+    electronApp.isPackaged = false;
+    await refreshCliPathMenuState();
+    expect(getCliPathInstallStateMock).not.toHaveBeenCalled();
+    expect(appMenuLabels()).not.toContain(INSTALL_LABEL);
+    expect(appMenuLabels()).not.toContain(UNINSTALL_LABEL);
+  });
+
+  test("hides Uninstall even when a prior detection found an install", async () => {
+    await setStateAndRefresh({ kind: "installed", inPath: true });
+    expect(appMenuLabels()).toContain(UNINSTALL_LABEL);
+
+    electronApp.isPackaged = false;
+    getCliPathInstallStateMock.mockClear();
+    await refreshCliPathMenuState();
+    expect(getCliPathInstallStateMock).not.toHaveBeenCalled();
+    expect(appMenuLabels()).not.toContain(INSTALL_LABEL);
+    expect(appMenuLabels()).not.toContain(UNINSTALL_LABEL);
   });
 });
 

--- a/apps/macos/src/main/menu.ts
+++ b/apps/macos/src/main/menu.ts
@@ -40,10 +40,12 @@ const state: MenuState = {
 let cliPathState: CliPathInstallState | null = null;
 
 export const refreshCliPathMenuState = async (): Promise<void> => {
-  try {
-    cliPathState = await getCliPathInstallState();
-  } catch {
-    cliPathState = null;
+  if (app.isPackaged) {
+    try {
+      cliPathState = await getCliPathInstallState();
+    } catch {
+      cliPathState = null;
+    }
   }
   applyMenu();
 };
@@ -60,6 +62,8 @@ const cliPathFlowItem = (
 });
 
 const cliPathItems = (): MenuItemConstructorOptions[] => {
+  // Only packaged builds manage the shared ~/.local/bin/vellum wrapper.
+  if (!app.isPackaged) return [];
   const kind = cliPathState?.kind;
   if (kind === "installed" || kind === "shadowed") {
     return [
@@ -317,6 +321,9 @@ export const installApplicationMenu = (): void => {
   applyMenu();
 
   // Detect the vellum CLI install state asynchronously so menu setup never
-  // waits on (or breaks from) login-shell PATH resolution.
-  void refreshCliPathMenuState();
+  // waits on (or breaks from) login-shell PATH resolution. Packaged-only:
+  // dev builds neither show the items nor spawn the detection shell.
+  if (app.isPackaged) {
+    void refreshCliPathMenuState();
+  }
 };


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for cli-path-installer.md:
- Install/Uninstall vellum Command menu items and startup detection now gated on app.isPackaged so dev runs can't clobber the production wrapper
- bundle-flow now reuses local-mode's resolveCliInvocation instead of a drifting private copy
- Removed change-narration comments