### PR TITLE
Capture payload sizes and model attribution on tool_invocations; add tool_executed projection store

### DIFF
--- a/assistant/src/__tests__/tool-audit-listener.test.ts
+++ b/assistant/src/__tests__/tool-audit-listener.test.ts
@@ -152,5 +152,104 @@ describe("tool audit listener", () => {
     expect(records).toHaveLength(1);
     expect(records[0].result).toBe("error: boom");
     expect(records[0].decision).toBe("error");
+    expect(records[0].argBytes).toBe(
+      Buffer.byteLength(JSON.stringify({ path: "/tmp/secret" }), "utf8"),
+    );
+    expect(records[0].resultBytes).toBe(Buffer.byteLength("error: boom"));
+  });
+
+  test("records byte sizes from the full payloads, before truncation and redaction", () => {
+    const records: ToolInvocationRecord[] = [];
+    const listener = createToolAuditListener((record) => records.push(record));
+
+    listener({
+      type: "executed",
+      toolName: "file_read",
+      input: { path: "/tmp/a" },
+      workingDir: "/tmp",
+      conversationId: "conv-bytes",
+      riskLevel: "low",
+      decision: "allow",
+      durationMs: 12,
+      // 1200 chars: the stored result is capped at 1000 but the size must
+      // reflect the full payload. "é" is 1 char / 2 utf8 bytes, proving
+      // byte (not char) accounting.
+      result: { content: "é".repeat(1200), isError: false },
+    });
+
+    expect(records).toHaveLength(1);
+    expect(records[0].result).toHaveLength(1000);
+    expect(records[0].argBytes).toBe(
+      Buffer.byteLength(JSON.stringify({ path: "/tmp/a" }), "utf8"),
+    );
+    expect(records[0].resultBytes).toBe(2400);
+  });
+
+  test("maps attribution onto executed records and leaves denied records null", () => {
+    const records: ToolInvocationRecord[] = [];
+    const listener = createToolAuditListener((record) => records.push(record));
+
+    listener({
+      type: "executed",
+      toolName: "file_read",
+      input: { path: "/tmp/a" },
+      workingDir: "/tmp",
+      conversationId: "conv-attr",
+      riskLevel: "low",
+      decision: "allow",
+      durationMs: 12,
+      result: { content: "ok", isError: false },
+      attribution: {
+        callSite: "mainAgent",
+        activeProfile: "balanced",
+        overrideProfile: null,
+        callSiteProfile: null,
+        appliedProfile: "balanced",
+        profileSource: "active",
+        resolvedProvider: "anthropic",
+        resolvedModel: "model-a",
+        resolvedMixArm: null,
+      },
+    });
+    listener({
+      type: "executed",
+      toolName: "file_read",
+      input: { path: "/tmp/b" },
+      workingDir: "/tmp",
+      conversationId: "conv-attr",
+      riskLevel: "low",
+      decision: "allow",
+      durationMs: 3,
+      result: { content: "ok", isError: false },
+      attribution: null,
+    });
+    listener({
+      type: "permission_denied",
+      toolName: "bash",
+      input: { command: "rm -rf /tmp" },
+      workingDir: "/tmp",
+      conversationId: "conv-attr",
+      riskLevel: "high",
+      decision: "deny",
+      reason: "Permission denied by user",
+      durationMs: 1,
+    });
+
+    expect(records).toHaveLength(3);
+    expect(records[0]).toMatchObject({
+      provider: "anthropic",
+      model: "model-a",
+      inferenceProfile: "balanced",
+      inferenceProfileSource: "active",
+    });
+    expect(records[1]).toMatchObject({
+      provider: null,
+      model: null,
+      inferenceProfile: null,
+      inferenceProfileSource: null,
+    });
+    expect(records[2].provider).toBeUndefined();
+    expect(records[2].argBytes).toBeUndefined();
+    expect(records[2].resultBytes).toBeUndefined();
   });
 });

--- a/assistant/src/events/tool-audit-listener.ts
+++ b/assistant/src/events/tool-audit-listener.ts
@@ -7,6 +7,7 @@ import type {
   ToolLifecycleEvent,
   ToolLifecycleEventHandler,
 } from "../tools/types.js";
+import type { UsageAttributionSnapshot } from "../usage/attribution.js";
 import { getLogger } from "../util/logger.js";
 
 const RESULT_PREVIEW_LIMIT = 1000;
@@ -36,11 +37,12 @@ function toInvocationRecord(
   event: ToolLifecycleEvent,
 ): ToolInvocationRecord | null {
   switch (event.type) {
-    case "executed":
+    case "executed": {
+      const input = stringifyInput(event.input);
       return {
         conversationId: event.conversationId,
         toolName: event.toolName,
-        input: stringifyInput(event.input),
+        input,
         result: redactSecrets(event.result.content).slice(
           0,
           RESULT_PREVIEW_LIMIT,
@@ -49,19 +51,34 @@ function toInvocationRecord(
         riskLevel: event.riskLevel,
         matchedTrustRuleId: event.matchedTrustRuleId,
         durationMs: event.durationMs,
+        // Byte sizes are computed here from the raw payloads — the stored
+        // `result` column is truncated and redacted above, so sizing at
+        // query time would undercount. Only the sizes leave the device.
+        argBytes: Buffer.byteLength(input, "utf8"),
+        resultBytes: Buffer.byteLength(event.result.content, "utf8"),
+        ...toAttributionFields(event.attribution),
       };
-    case "error":
+    }
+    case "error": {
+      const input = stringifyInput(event.input);
+      const result = `error: ${event.errorMessage}`;
       return {
         conversationId: event.conversationId,
         toolName: event.toolName,
-        input: stringifyInput(event.input),
-        result: `error: ${event.errorMessage}`,
+        input,
+        result,
         decision: "error",
         riskLevel: event.riskLevel,
         matchedTrustRuleId: event.matchedTrustRuleId,
         durationMs: event.durationMs,
+        argBytes: Buffer.byteLength(input, "utf8"),
+        resultBytes: Buffer.byteLength(result, "utf8"),
+        ...toAttributionFields(event.attribution),
       };
+    }
     case "permission_denied":
+      // No telemetry fields: the tool never executed, and denied rows are
+      // filtered out of the tool_executed projection anyway.
       return {
         conversationId: event.conversationId,
         toolName: event.toolName,
@@ -76,6 +93,25 @@ function toInvocationRecord(
     case "permission_prompt":
       return null;
   }
+}
+
+/**
+ * Maps an attribution snapshot to the tool_invocations telemetry columns —
+ * the same mapping `llm_usage` reporting uses (`appliedProfile` →
+ * inference_profile, `profileSource` → inference_profile_source).
+ */
+function toAttributionFields(
+  attribution: UsageAttributionSnapshot | null | undefined,
+): Pick<
+  ToolInvocationRecord,
+  "provider" | "model" | "inferenceProfile" | "inferenceProfileSource"
+> {
+  return {
+    provider: attribution?.resolvedProvider ?? null,
+    model: attribution?.resolvedModel ?? null,
+    inferenceProfile: attribution?.appliedProfile ?? null,
+    inferenceProfileSource: attribution?.profileSource ?? null,
+  };
 }
 
 function stringifyInput(input: Record<string, unknown>): string {

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -206,6 +206,7 @@ import {
   migrateToolInvocationsCreatedAtIdIndex,
   migrateToolInvocationsMatchedRuleId,
   migrateToolInvocationsSkillId,
+  migrateToolInvocationsTelemetryColumns,
   migrateTraceEventsCreatedAtIndex,
   migrateUsageDashboardIndexes,
   migrateUsageLlmCallCount,
@@ -491,6 +492,7 @@ export function initializeDb(): void {
     migrateToolInvocationsSkillId,
     migrateToolInvocationsCreatedAtIdIndex,
     migrateAddMemoryV3EverInjected,
+    migrateToolInvocationsTelemetryColumns,
     createSkillLoadedEventsTable,
   ];
 

--- a/assistant/src/memory/migrations/278-tool-invocations-telemetry-columns.test.ts
+++ b/assistant/src/memory/migrations/278-tool-invocations-telemetry-columns.test.ts
@@ -1,0 +1,96 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import * as schema from "../schema.js";
+import { migrateToolInvocationsTelemetryColumns } from "./278-tool-invocations-telemetry-columns.js";
+
+const NEW_COLUMNS = [
+  "arg_bytes",
+  "result_bytes",
+  "provider",
+  "model",
+  "inference_profile",
+  "inference_profile_source",
+];
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  // Pre-278 shape: skill_id exists (275), telemetry columns do not.
+  sqlite.exec(/*sql*/ `
+    CREATE TABLE tool_invocations (
+      id TEXT PRIMARY KEY,
+      conversation_id TEXT NOT NULL,
+      tool_name TEXT NOT NULL,
+      input TEXT NOT NULL,
+      result TEXT NOT NULL,
+      decision TEXT NOT NULL,
+      risk_level TEXT NOT NULL,
+      matched_trust_rule_id TEXT,
+      duration_ms INTEGER NOT NULL,
+      created_at INTEGER NOT NULL,
+      skill_id TEXT
+    )
+  `);
+  return { sqlite, db: drizzle(sqlite, { schema }) };
+}
+
+function tableInfo(sqlite: Database) {
+  return sqlite.query("PRAGMA table_info(tool_invocations)").all() as Array<{
+    name: string;
+    notnull: number;
+  }>;
+}
+
+describe("migration 278: tool_invocations telemetry columns", () => {
+  test("adds the nullable telemetry columns", () => {
+    const { sqlite, db } = createTestDb();
+    const before = tableInfo(sqlite).map((c) => c.name);
+    for (const name of NEW_COLUMNS) {
+      expect(before).not.toContain(name);
+    }
+
+    migrateToolInvocationsTelemetryColumns(db);
+
+    const after = tableInfo(sqlite);
+    for (const name of NEW_COLUMNS) {
+      const column = after.find((c) => c.name === name);
+      expect(column).toBeDefined();
+      expect(column?.notnull).toBe(0);
+    }
+  });
+
+  test("existing rows read back with null telemetry columns", () => {
+    const { sqlite, db } = createTestDb();
+    sqlite.exec(/*sql*/ `
+      INSERT INTO tool_invocations
+        (id, conversation_id, tool_name, input, result, decision, risk_level, duration_ms, created_at)
+      VALUES
+        ('ti-1', 'conv-1', 'bash', '{}', 'ok', 'allow', 'low', 5, 1000)
+    `);
+
+    migrateToolInvocationsTelemetryColumns(db);
+
+    const row = sqlite
+      .query(
+        `SELECT ${NEW_COLUMNS.join(", ")} FROM tool_invocations WHERE id = 'ti-1'`,
+      )
+      .get() as Record<string, unknown>;
+    for (const name of NEW_COLUMNS) {
+      expect(row[name]).toBeNull();
+    }
+  });
+
+  test("is idempotent — re-run is a no-op", () => {
+    const { sqlite, db } = createTestDb();
+
+    migrateToolInvocationsTelemetryColumns(db);
+    expect(() => migrateToolInvocationsTelemetryColumns(db)).not.toThrow();
+
+    const names = tableInfo(sqlite).map((c) => c.name);
+    for (const name of NEW_COLUMNS) {
+      expect(names.filter((n) => n === name)).toHaveLength(1);
+    }
+  });
+});

--- a/assistant/src/memory/migrations/278-tool-invocations-telemetry-columns.ts
+++ b/assistant/src/memory/migrations/278-tool-invocations-telemetry-columns.ts
@@ -1,0 +1,46 @@
+import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+
+const TABLE = "tool_invocations";
+const COLUMNS: Array<{ name: string; type: string }> = [
+  { name: "arg_bytes", type: "INTEGER" },
+  { name: "result_bytes", type: "INTEGER" },
+  { name: "provider", type: "TEXT" },
+  { name: "model", type: "TEXT" },
+  { name: "inference_profile", type: "TEXT" },
+  { name: "inference_profile_source", type: "TEXT" },
+];
+
+/**
+ * Add nullable telemetry columns to `tool_invocations` for the
+ * `tool_executed` telemetry projection.
+ *
+ * `arg_bytes` / `result_bytes` record the serialized payload sizes computed
+ * by the audit listener BEFORE the stored `result` column is truncated and
+ * redacted — only the sizes leave the device, never the payloads. The
+ * `provider` / `model` / `inference_profile` / `inference_profile_source`
+ * columns snapshot the conversation's model attribution at invocation time
+ * (same mapping the `llm_usage` events use).
+ *
+ * All columns are nullable — `NULL` for rows persisted before this migration
+ * ran and for permission-denied rows (the tool never executed; they are
+ * filtered out of the telemetry projection).
+ *
+ * Idempotent — re-running is a no-op once the columns exist. Pure DDL with a
+ * PRAGMA guard, no registry entry needed (matches the 273 / 275 pattern).
+ */
+export function migrateToolInvocationsTelemetryColumns(
+  database: DrizzleDb,
+): void {
+  const raw = getSqliteFrom(database);
+
+  const columns = raw.query(`PRAGMA table_info(${TABLE})`).all() as Array<{
+    name: string;
+  }>;
+  const columnNames = new Set(columns.map((c) => c.name));
+
+  for (const { name, type } of COLUMNS) {
+    if (!columnNames.has(name)) {
+      raw.exec(`ALTER TABLE ${TABLE} ADD COLUMN ${name} ${type}`);
+    }
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -265,6 +265,7 @@ export { createActivationSessionsTable } from "./274-create-activation-sessions.
 export { migrateToolInvocationsSkillId } from "./275-tool-invocations-add-skill-id.js";
 export { migrateToolInvocationsCreatedAtIdIndex } from "./276-tool-invocations-created-at-id-index.js";
 export { migrateAddMemoryV3EverInjected } from "./277-add-memory-v3-ever-injected.js";
+export { migrateToolInvocationsTelemetryColumns } from "./278-tool-invocations-telemetry-columns.js";
 export { createSkillLoadedEventsTable } from "./279-create-skill-loaded-events.js";
 export {
   MIGRATION_REGISTRY,

--- a/assistant/src/memory/schema/conversations.ts
+++ b/assistant/src/memory/schema/conversations.ts
@@ -93,6 +93,14 @@ export const toolInvocations = sqliteTable(
     matchedTrustRuleId: text("matched_trust_rule_id"),
     durationMs: integer("duration_ms").notNull(),
     createdAt: integer("created_at").notNull(),
+    /** Serialized input size in bytes, computed before any redaction. Null pre-migration-278. */
+    argBytes: integer("arg_bytes"),
+    /** Full serialized result size in bytes, computed before truncation/redaction. Null pre-migration-278 and for denied rows. */
+    resultBytes: integer("result_bytes"),
+    provider: text("provider"),
+    model: text("model"),
+    inferenceProfile: text("inference_profile"),
+    inferenceProfileSource: text("inference_profile_source"),
   },
   (table) => [
     index("idx_tool_invocations_conversation_id").on(table.conversationId),

--- a/assistant/src/memory/tool-executed-events-store.test.ts
+++ b/assistant/src/memory/tool-executed-events-store.test.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Silence the logger.
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import { getDb } from "./db-connection.js";
+import { initializeDb } from "./db-init.js";
+import { conversations, toolInvocations } from "./schema.js";
+import { queryUnreportedToolExecutedEvents } from "./tool-executed-events-store.js";
+
+initializeDb();
+
+const CONVERSATION_ID = "conv-tool-executed-store-test";
+
+/**
+ * Sentinel embedded in the seeded raw input/result payloads. Asserted to
+ * never appear in any projection — raw tool args/outputs must never leave
+ * the device.
+ */
+const PII_SENTINEL = "must never leave the device";
+
+interface SeedSpec {
+  id: string;
+  createdAt: number;
+  toolName?: string;
+  decision?: string;
+  durationMs?: number;
+  argBytes?: number | null;
+  resultBytes?: number | null;
+  provider?: string | null;
+  model?: string | null;
+  inferenceProfile?: string | null;
+  inferenceProfileSource?: string | null;
+}
+
+function insertInvocation(spec: SeedSpec): void {
+  const db = getDb();
+  // tool_invocations has an enforced FK to conversations.
+  db.insert(conversations)
+    .values({
+      id: CONVERSATION_ID,
+      title: "test",
+      createdAt: 1000,
+      updatedAt: 1000,
+    })
+    .onConflictDoNothing()
+    .run();
+  db.insert(toolInvocations)
+    .values({
+      id: spec.id,
+      conversationId: CONVERSATION_ID,
+      toolName: spec.toolName ?? "calendar_list_events",
+      input: `{"secret":"raw tool args — ${PII_SENTINEL}"}`,
+      result: `{"secret":"raw tool output — ${PII_SENTINEL}"}`,
+      decision: spec.decision ?? "allow",
+      riskLevel: "low",
+      durationMs: spec.durationMs ?? 12,
+      createdAt: spec.createdAt,
+      argBytes: spec.argBytes ?? null,
+      resultBytes: spec.resultBytes ?? null,
+      provider: spec.provider ?? null,
+      model: spec.model ?? null,
+      inferenceProfile: spec.inferenceProfile ?? null,
+      inferenceProfileSource: spec.inferenceProfileSource ?? null,
+    })
+    .run();
+}
+
+describe("tool-executed-events-store", () => {
+  beforeEach(() => {
+    getDb().delete(toolInvocations).run();
+  });
+
+  test("projects telemetry fields in (createdAt, id) order without input/result", () => {
+    insertInvocation({
+      id: "ti-b",
+      createdAt: 2000,
+      toolName: "web_search",
+      decision: "error",
+      durationMs: 7,
+    });
+    insertInvocation({
+      id: "ti-a",
+      createdAt: 1000,
+      argBytes: 42,
+      resultBytes: 9001,
+      provider: "anthropic",
+      model: "model-a",
+      inferenceProfile: "balanced",
+      inferenceProfileSource: "active",
+    });
+
+    const rows = queryUnreportedToolExecutedEvents(0, undefined, 100);
+    expect(rows.map((r) => r.id)).toEqual(["ti-a", "ti-b"]);
+    expect(rows[0]).toEqual({
+      id: "ti-a",
+      toolName: "calendar_list_events",
+      decision: "allow",
+      durationMs: 12,
+      argBytes: 42,
+      resultBytes: 9001,
+      provider: "anthropic",
+      model: "model-a",
+      inferenceProfile: "balanced",
+      inferenceProfileSource: "active",
+      conversationId: CONVERSATION_ID,
+      createdAt: 1000,
+    });
+    expect(rows[1]).toMatchObject({
+      toolName: "web_search",
+      decision: "error",
+      durationMs: 7,
+    });
+    // Raw tool args/outputs are potentially PII — the projection must
+    // never include them.
+    expect(JSON.stringify(rows)).not.toContain(PII_SENTINEL);
+  });
+
+  test("excludes permission-denied rows", () => {
+    insertInvocation({ id: "ti-denied", createdAt: 1000, decision: "denied" });
+    insertInvocation({ id: "ti-allow", createdAt: 2000 });
+    insertInvocation({ id: "ti-error", createdAt: 3000, decision: "error" });
+
+    const rows = queryUnreportedToolExecutedEvents(0, undefined, 100);
+    expect(rows.map((r) => r.id)).toEqual(["ti-allow", "ti-error"]);
+  });
+
+  test("pre-migration rows project with null telemetry columns", () => {
+    insertInvocation({ id: "ti-old", createdAt: 1000 });
+
+    const rows = queryUnreportedToolExecutedEvents(0, undefined, 100);
+    expect(rows[0]).toMatchObject({
+      argBytes: null,
+      resultBytes: null,
+      provider: null,
+      model: null,
+      inferenceProfile: null,
+      inferenceProfileSource: null,
+    });
+  });
+
+  test("query advances past the compound (createdAt, id) cursor", () => {
+    // Two rows in the same millisecond: pagination must use the id
+    // tiebreaker to make forward progress, not loop.
+    insertInvocation({ id: "ti-1", createdAt: 5000 });
+    insertInvocation({ id: "ti-2", createdAt: 5000 });
+    insertInvocation({ id: "ti-3", createdAt: 6000 });
+
+    const first = queryUnreportedToolExecutedEvents(0, undefined, 1);
+    expect(first.map((r) => r.id)).toEqual(["ti-1"]);
+
+    const second = queryUnreportedToolExecutedEvents(
+      first[0]!.createdAt,
+      first[0]!.id,
+      100,
+    );
+    expect(second.map((r) => r.id)).toEqual(["ti-2", "ti-3"]);
+
+    // Without an id cursor the timestamp-only branch is used.
+    expect(
+      queryUnreportedToolExecutedEvents(5000, undefined, 100).map((r) => r.id),
+    ).toEqual(["ti-3"]);
+
+    // Cursor past the last row returns nothing.
+    const last = second[second.length - 1]!;
+    expect(
+      queryUnreportedToolExecutedEvents(last.createdAt, last.id, 100).length,
+    ).toBe(0);
+  });
+
+  test("honors the limit", () => {
+    insertInvocation({ id: "ti-l1", createdAt: 1000 });
+    insertInvocation({ id: "ti-l2", createdAt: 2000 });
+    insertInvocation({ id: "ti-l3", createdAt: 3000 });
+
+    const rows = queryUnreportedToolExecutedEvents(0, undefined, 2);
+    expect(rows.map((r) => r.id)).toEqual(["ti-l1", "ti-l2"]);
+  });
+});

--- a/assistant/src/memory/tool-executed-events-store.ts
+++ b/assistant/src/memory/tool-executed-events-store.ts
@@ -1,0 +1,83 @@
+import { and, asc, eq, gt, ne, or } from "drizzle-orm";
+
+import { getDb } from "./db-connection.js";
+import { toolInvocations } from "./schema.js";
+
+/**
+ * A `tool_invocations` audit row projected for `tool_executed` telemetry
+ * reporting.
+ *
+ * Deliberately excludes the `input` / `result` columns — raw tool
+ * args/outputs are potentially PII and must never leave the device. Only the
+ * payload SIZES (`argBytes` / `resultBytes`) are projected.
+ */
+export interface UnreportedToolExecutedEvent {
+  id: string;
+  toolName: string;
+  /** `"allow"`-style decisions or `"error"`; never `"denied"` (filtered out). */
+  decision: string;
+  durationMs: number;
+  /** Serialized input size in bytes. Null for rows persisted before migration 278. */
+  argBytes: number | null;
+  /** Full serialized result size in bytes. Null for rows persisted before migration 278. */
+  resultBytes: number | null;
+  provider: string | null;
+  model: string | null;
+  inferenceProfile: string | null;
+  inferenceProfileSource: string | null;
+  conversationId: string;
+  createdAt: number;
+}
+
+/**
+ * Query tool invocations that haven't been reported to telemetry yet.
+ * Uses a compound cursor (createdAt + id) for reliable watermarking.
+ *
+ * Permission-denied rows are excluded — the tool never executed, so no
+ * `tool_executed` event is emitted for them.
+ *
+ * Rows are written by the tool audit listener
+ * (`events/tool-audit-listener.ts`) — there is no record function here.
+ *
+ * Reporting is best-effort: `rotateToolInvocations` purges rows by
+ * `created_at` alone, so rows older than the configured
+ * `auditLog.retentionDays` window may be rotated away before they are
+ * reported (e.g. if the daemon is offline or failing for longer than
+ * the retention window).
+ */
+export function queryUnreportedToolExecutedEvents(
+  afterCreatedAt: number,
+  afterId: string | undefined,
+  limit: number,
+): UnreportedToolExecutedEvent[] {
+  const db = getDb();
+  const cursorPredicate = afterId
+    ? or(
+        gt(toolInvocations.createdAt, afterCreatedAt),
+        and(
+          eq(toolInvocations.createdAt, afterCreatedAt),
+          gt(toolInvocations.id, afterId),
+        ),
+      )
+    : gt(toolInvocations.createdAt, afterCreatedAt);
+  return db
+    .select({
+      id: toolInvocations.id,
+      toolName: toolInvocations.toolName,
+      decision: toolInvocations.decision,
+      durationMs: toolInvocations.durationMs,
+      argBytes: toolInvocations.argBytes,
+      resultBytes: toolInvocations.resultBytes,
+      provider: toolInvocations.provider,
+      model: toolInvocations.model,
+      inferenceProfile: toolInvocations.inferenceProfile,
+      inferenceProfileSource: toolInvocations.inferenceProfileSource,
+      conversationId: toolInvocations.conversationId,
+      createdAt: toolInvocations.createdAt,
+    })
+    .from(toolInvocations)
+    .where(and(ne(toolInvocations.decision, "denied"), cursorPredicate))
+    .orderBy(asc(toolInvocations.createdAt), asc(toolInvocations.id))
+    .limit(limit)
+    .all();
+}

--- a/assistant/src/memory/tool-usage-store.ts
+++ b/assistant/src/memory/tool-usage-store.ts
@@ -15,6 +15,14 @@ export interface ToolInvocationRecord {
   riskLevel: string;
   matchedTrustRuleId?: string;
   durationMs: number;
+  /** Serialized input size in bytes, computed before any redaction. */
+  argBytes?: number | null;
+  /** Full serialized result size in bytes, computed before truncation/redaction. */
+  resultBytes?: number | null;
+  provider?: string | null;
+  model?: string | null;
+  inferenceProfile?: string | null;
+  inferenceProfileSource?: string | null;
 }
 
 export function recordToolInvocation(record: ToolInvocationRecord): void {
@@ -31,6 +39,12 @@ export function recordToolInvocation(record: ToolInvocationRecord): void {
       matchedTrustRuleId: record.matchedTrustRuleId,
       durationMs: record.durationMs,
       createdAt: Date.now(),
+      argBytes: record.argBytes,
+      resultBytes: record.resultBytes,
+      provider: record.provider,
+      model: record.model,
+      inferenceProfile: record.inferenceProfile,
+      inferenceProfileSource: record.inferenceProfileSource,
     })
     .run();
 }


### PR DESCRIPTION
## Summary
- Migration 278 adds arg_bytes/result_bytes/provider/model/inference_profile/inference_profile_source columns to tool_invocations
- Audit listener computes payload byte sizes pre-truncation/pre-redaction and captures the conversation's model attribution from tool lifecycle events
- New tool-executed-events-store projects non-denied invocations with the standard (created_at, id) cursor for the telemetry reporter

Part of plan: tool-skill-telemetry.md (PR 3 of 6)