### PR TITLE
fix: harden vellum PATH installer detection and install flow

### DIFF
--- a/apps/macos/src/main/cli-installer.test.ts
+++ b/apps/macos/src/main/cli-installer.test.ts
@@ -35,6 +35,7 @@ const existsSyncByPath: Record<string, boolean> = {};
 let readdirSyncReturn: Array<{ name: string; isDirectory: () => boolean }> = [];
 let readdirSyncError: Error | null = null;
 let writeFileSyncError: Error | null = null;
+const chmodSyncCalls: Array<[string, number]> = [];
 const mkdirSyncCalls: Array<[string, object]> = [];
 const rmSyncCalls: Array<[string, object]> = [];
 const copyFileSyncCalls: Array<[string, string]> = [];
@@ -44,6 +45,10 @@ const renameSyncCalls: Array<[string, string]> = [];
 const fsCallOrder: string[] = [];
 
 mock.module("node:fs", () => ({
+  chmodSync: (p: string, mode: number) => {
+    chmodSyncCalls.push([p, mode]);
+    fsCallOrder.push(`chmodSync:${p}`);
+  },
   copyFileSync: (src: string, dst: string) => {
     copyFileSyncCalls.push([src, dst]);
   },
@@ -92,6 +97,7 @@ const {
   getBundledBunPath,
   getCliLocatorPath,
   shQuote,
+  writeFileAtomicSync,
   writeCliLocator,
   buildInstallEnv,
   isCliInstalled,
@@ -111,6 +117,7 @@ afterEach(() => {
   readdirSyncReturn.length = 0;
   readdirSyncError = null;
   writeFileSyncError = null;
+  chmodSyncCalls.length = 0;
   mkdirSyncCalls.length = 0;
   rmSyncCalls.length = 0;
   copyFileSyncCalls.length = 0;
@@ -160,6 +167,29 @@ describe("shQuote", () => {
 
   test("escapes embedded single quotes", () => {
     expect(shQuote("/Users/o'brien/bin")).toBe("'/Users/o'\\''brien/bin'");
+  });
+});
+
+// --- writeFileAtomicSync ---
+
+describe("writeFileAtomicSync", () => {
+  test("writes the temp file then renames it into place", () => {
+    writeFileAtomicSync("/x/file", "content");
+
+    expect(writeFileSyncCalls).toEqual([["/x/file.tmp", "content"]]);
+    expect(renameSyncCalls).toEqual([["/x/file.tmp", "/x/file"]]);
+    expect(chmodSyncCalls).toHaveLength(0);
+  });
+
+  test("chmods the temp file before the rename when a mode is given", () => {
+    writeFileAtomicSync("/x/file", "content", 0o755);
+
+    expect(chmodSyncCalls).toEqual([["/x/file.tmp", 0o755]]);
+    expect(fsCallOrder).toEqual([
+      "writeFileSync:/x/file.tmp",
+      "chmodSync:/x/file.tmp",
+      "renameSync:/x/file",
+    ]);
   });
 });
 

--- a/apps/macos/src/main/cli-installer.ts
+++ b/apps/macos/src/main/cli-installer.ts
@@ -1,6 +1,7 @@
 import { app } from "electron";
 import { spawn } from "node:child_process";
 import {
+  chmodSync,
   copyFileSync,
   existsSync,
   mkdirSync,
@@ -47,6 +48,18 @@ export function shQuote(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`;
 }
 
+/** Atomically write `content` via tmp-file + rename, optionally chmod'd. */
+export function writeFileAtomicSync(
+  filePath: string,
+  content: string,
+  mode?: number,
+): void {
+  const tmpPath = `${filePath}.tmp`;
+  writeFileSync(tmpPath, content);
+  if (mode !== undefined) chmodSync(tmpPath, mode);
+  renameSync(tmpPath, filePath);
+}
+
 /**
  * Atomically write the locator file the `~/.local/bin/vellum` wrapper
  * sources to find the bundled bun and the current CLI bin. Refreshed on
@@ -68,9 +81,7 @@ export function writeCliLocator(): void {
       `VELLUM_BUN=${shQuote(getBundledBunPath())}\n` +
       `VELLUM_CLI_BIN=${shQuote(getCliBinPath())}\n`;
 
-    const tmpPath = `${locatorPath}.tmp`;
-    writeFileSync(tmpPath, content);
-    renameSync(tmpPath, locatorPath);
+    writeFileAtomicSync(locatorPath, content);
   } catch (err) {
     log.error("[cli-installer] failed to write CLI locator:", err);
   }

--- a/apps/macos/src/main/cli-path-flow.test.ts
+++ b/apps/macos/src/main/cli-path-flow.test.ts
@@ -26,6 +26,12 @@ mock.module("electron", () => ({
   clipboard: { writeText: writeTextMock },
 }));
 
+const ensureCliInstalledMock = mock(async (): Promise<void> => undefined);
+
+mock.module("./cli-installer", () => ({
+  ensureCliInstalled: ensureCliInstalledMock,
+}));
+
 const getCliPathInstallStateMock = mock(
   async (): Promise<CliPathInstallState> => ({
     kind: "installed",
@@ -66,11 +72,13 @@ beforeEach(() => {
   showMessageBoxMock.mockReset();
   showErrorBoxMock.mockClear();
   writeTextMock.mockClear();
+  ensureCliInstalledMock.mockReset();
   getCliPathInstallStateMock.mockReset();
   installWrapperMock.mockReset();
   uninstallWrapperMock.mockReset();
 
   showMessageBoxMock.mockResolvedValue({ response: 0, checkboxChecked: false });
+  ensureCliInstalledMock.mockResolvedValue(undefined);
   setState({ kind: "installed", inPath: true });
   installWrapperMock.mockReturnValue("installed");
   uninstallWrapperMock.mockReturnValue("removed");
@@ -82,7 +90,7 @@ beforeEach(() => {
 
 describe("runInstallCliCommandFlow", () => {
   test("foreign file + Cancel leaves the file untouched", async () => {
-    setState({ kind: "foreign-file" });
+    installWrapperMock.mockReturnValue("needs-overwrite-confirmation");
     showMessageBoxMock.mockResolvedValue({ response: 1, checkboxChecked: false });
 
     await runInstallCliCommandFlow();
@@ -91,18 +99,51 @@ describe("runInstallCliCommandFlow", () => {
     expect(showMessageBoxMock.mock.calls[0]?.[0]?.message).toBe(
       "Replace existing vellum file?",
     );
-    expect(installWrapperMock).not.toHaveBeenCalled();
+    expect(installWrapperMock).toHaveBeenCalledTimes(1);
+    expect(installWrapperMock).toHaveBeenCalledWith({ overwriteForeign: false });
+    expect(ensureCliInstalledMock).not.toHaveBeenCalled();
   });
 
-  test("foreign file + Replace installs with overwriteForeign", async () => {
-    getCliPathInstallStateMock
-      .mockResolvedValueOnce({ kind: "foreign-file" })
-      .mockResolvedValueOnce({ kind: "installed", inPath: true });
+  test("foreign file + Replace retries with overwriteForeign", async () => {
+    installWrapperMock
+      .mockReturnValueOnce("needs-overwrite-confirmation")
+      .mockReturnValueOnce("installed");
 
     await runInstallCliCommandFlow();
 
-    expect(installWrapperMock).toHaveBeenCalledTimes(1);
-    expect(installWrapperMock).toHaveBeenCalledWith({ overwriteForeign: true });
+    expect(installWrapperMock).toHaveBeenCalledTimes(2);
+    expect(installWrapperMock.mock.calls[0]?.[0]).toEqual({
+      overwriteForeign: false,
+    });
+    expect(installWrapperMock.mock.calls[1]?.[0]).toEqual({
+      overwriteForeign: true,
+    });
+    expect(ensureCliInstalledMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("provisions the CLI runtime before showing success", async () => {
+    setState({ kind: "installed", inPath: true });
+
+    await runInstallCliCommandFlow();
+
+    expect(ensureCliInstalledMock).toHaveBeenCalledTimes(1);
+    // State is only checked once, after install, for the success dialog.
+    expect(getCliPathInstallStateMock).toHaveBeenCalledTimes(1);
+    expect(lastDialog()?.message).toBe("Vellum CLI installed");
+  });
+
+  test("CLI runtime download failure reports the wrapper as installed and retryable", async () => {
+    ensureCliInstalledMock.mockRejectedValue(new Error("registry unreachable"));
+
+    await runInstallCliCommandFlow();
+
+    expect(showMessageBoxMock).not.toHaveBeenCalled();
+    expect(showErrorBoxMock).toHaveBeenCalledTimes(1);
+    const [title, message] = showErrorBoxMock.mock.calls[0]!;
+    expect(title).toBe("Failed to install vellum command");
+    expect(message).toContain(`The vellum command was installed at ${WRAPPER_PATH}`);
+    expect(message).toContain("registry unreachable");
+    expect(message).toContain("retried");
   });
 
   test("installed + inPath shows success without touching the clipboard", async () => {
@@ -128,28 +169,34 @@ describe("runInstallCliCommandFlow", () => {
     expect(lastDialog()?.detail).toContain(WRAPPER_PATH);
   });
 
-  test("shadowed names the winning binary and the npm uninstall fix", async () => {
-    setState({ kind: "shadowed", shadowedBy: "/opt/homebrew/bin/vellum" });
+  test("shadowed + inPath names the winning binary and the npm uninstall fix", async () => {
+    setState({
+      kind: "shadowed",
+      shadowedBy: "/opt/homebrew/bin/vellum",
+      inPath: true,
+    });
 
     await runInstallCliCommandFlow();
 
     expect(writeTextMock).not.toHaveBeenCalled();
     expect(lastDialog()?.detail).toContain("/opt/homebrew/bin/vellum");
     expect(lastDialog()?.detail).toContain("npm uninstall -g vellum");
+    expect(lastDialog()?.detail).not.toContain("clipboard");
   });
 
-  test("install race returning needs-overwrite-confirmation re-confirms once", async () => {
-    setState({ kind: "installed", inPath: true });
-    installWrapperMock
-      .mockReturnValueOnce("needs-overwrite-confirmation")
-      .mockReturnValueOnce("installed");
+  test("shadowed without PATH adds the export-line help alongside the npm advice", async () => {
+    setState({
+      kind: "shadowed",
+      shadowedBy: "/opt/homebrew/bin/vellum",
+      inPath: false,
+    });
 
     await runInstallCliCommandFlow();
 
-    expect(installWrapperMock).toHaveBeenCalledTimes(2);
-    expect(installWrapperMock.mock.calls[1]?.[0]).toEqual({
-      overwriteForeign: true,
-    });
+    expect(writeTextMock).toHaveBeenCalledTimes(1);
+    expect(writeTextMock).toHaveBeenCalledWith(PATH_EXPORT_LINE);
+    expect(lastDialog()?.detail).toContain("npm uninstall -g vellum");
+    expect(lastDialog()?.detail).toContain("copied to your clipboard");
   });
 
   test("state check throwing surfaces via showErrorBox without rejecting", async () => {

--- a/apps/macos/src/main/cli-path-flow.ts
+++ b/apps/macos/src/main/cli-path-flow.ts
@@ -5,6 +5,7 @@
  */
 import { clipboard, dialog } from "electron";
 
+import { ensureCliInstalled } from "./cli-installer";
 import {
   getCliPathInstallState,
   getWrapperPath,
@@ -13,6 +14,9 @@ import {
 } from "./cli-path-installer";
 
 const PATH_EXPORT_LINE = 'export PATH="$HOME/.local/bin:$PATH"';
+
+const errorMessage = (err: unknown): string =>
+  err instanceof Error ? err.message : "Unknown error";
 
 async function confirmReplaceForeignFile(): Promise<boolean> {
   const { response } = await dialog.showMessageBox({
@@ -29,23 +33,33 @@ async function confirmReplaceForeignFile(): Promise<boolean> {
   return response === 0;
 }
 
+// Copies the export line and returns the matching dialog instructions.
+function copyPathExportHelp(): string {
+  clipboard.writeText(PATH_EXPORT_LINE);
+  return (
+    "~/.local/bin isn't in your shell's PATH. The line to add to your " +
+    "shell profile has been copied to your clipboard."
+  );
+}
+
 async function showInstallSuccessDialog(): Promise<void> {
   const state = await getCliPathInstallState();
   const wrapperPath = getWrapperPath();
 
   let detail: string;
   if (state.kind === "installed" && !state.inPath) {
-    clipboard.writeText(PATH_EXPORT_LINE);
     detail =
       `The vellum command is installed at ${wrapperPath}, but ` +
-      "~/.local/bin isn't in your shell's PATH. The line to add to your " +
-      "shell profile has been copied to your clipboard.";
+      copyPathExportHelp();
   } else if (state.kind === "shadowed") {
     detail =
       `The vellum command is installed at ${wrapperPath}, but another ` +
       `"vellum" was found at ${state.shadowedBy} (likely installed via ` +
       "npm) and will take precedence in your terminal. Run " +
       '"npm uninstall -g vellum" to use the app-managed version.';
+    if (!state.inPath) {
+      detail += ` Also, ${copyPathExportHelp()}`;
+    }
   } else {
     // `installed` in PATH, plus a defensive default for anything else.
     detail =
@@ -62,23 +76,25 @@ async function showInstallSuccessDialog(): Promise<void> {
 
 export async function runInstallCliCommandFlow(): Promise<void> {
   try {
-    const state = await getCliPathInstallState();
-    let overwriteForeign = false;
-    if (state.kind === "foreign-file") {
-      if (!(await confirmReplaceForeignFile())) return;
-      overwriteForeign = true;
-    }
-
-    if (installWrapper({ overwriteForeign }) === "needs-overwrite-confirmation") {
-      // Race: the file became foreign between the state check and install.
+    if (installWrapper({ overwriteForeign: false }) === "needs-overwrite-confirmation") {
       if (!(await confirmReplaceForeignFile())) return;
       installWrapper({ overwriteForeign: true });
     }
 
+    try {
+      await ensureCliInstalled();
+    } catch (err) {
+      throw new Error(
+        `The vellum command was installed at ${getWrapperPath()}, but ` +
+          `downloading the CLI runtime failed: ${errorMessage(err)}. It will be ` +
+          'retried the next time it\'s needed — or run "Install vellum ' +
+          'Command" again to retry now.',
+      );
+    }
+
     await showInstallSuccessDialog();
   } catch (err) {
-    const message = err instanceof Error ? err.message : "Unknown error";
-    dialog.showErrorBox("Failed to install vellum command", message);
+    dialog.showErrorBox("Failed to install vellum command", errorMessage(err));
   }
 }
 
@@ -115,7 +131,6 @@ export async function runUninstallCliCommandFlow(): Promise<void> {
     } as const;
     await dialog.showMessageBox(resultDialogs[uninstallWrapper()]);
   } catch (err) {
-    const message = err instanceof Error ? err.message : "Unknown error";
-    dialog.showErrorBox("Failed to uninstall vellum command", message);
+    dialog.showErrorBox("Failed to uninstall vellum command", errorMessage(err));
   }
 }

--- a/apps/macos/src/main/cli-path-installer.test.ts
+++ b/apps/macos/src/main/cli-path-installer.test.ts
@@ -37,6 +37,11 @@ mock.module("node:os", () => ({
 
 // Track fs calls so tests can assert on them.
 let readFileSyncResult: string | Error | null = null;
+// "auto" mirrors readFileSync presence; "exists" forces a present entry
+// (e.g. a dangling symlink whose readFileSync still throws ENOENT).
+let lstatSyncBehavior: "auto" | "exists" = "auto";
+// Symlink resolution map; paths not present throw (like realpathSync).
+const realpathMap: Record<string, string> = {};
 const mkdirSyncCalls: Array<[string, object]> = [];
 const writeFileSyncCalls: Array<[string, string]> = [];
 const chmodSyncCalls: Array<[string, number]> = [];
@@ -50,13 +55,20 @@ const enoent = () => {
 };
 
 mock.module("node:fs", () => ({
-  // Used by the cli-installer module evaluated as a dependency.
+  // Used by the cli-installer and shell-path modules evaluated as deps.
+  accessSync: () => {},
+  constants: { X_OK: 1 },
   copyFileSync: () => {},
   existsSync: () => false,
   readdirSync: () => [],
   // Used by cli-path-installer.
   chmodSync: (p: string, mode: number) => {
     chmodSyncCalls.push([p, mode]);
+  },
+  lstatSync: (_p: string) => {
+    if (lstatSyncBehavior === "exists") return {};
+    if (readFileSyncResult === null) throw enoent();
+    return {};
   },
   mkdirSync: (p: string, opts: object) => {
     mkdirSyncCalls.push([p, opts]);
@@ -65,6 +77,11 @@ mock.module("node:fs", () => ({
     if (readFileSyncResult === null) throw enoent();
     if (readFileSyncResult instanceof Error) throw readFileSyncResult;
     return readFileSyncResult;
+  },
+  realpathSync: (p: string) => {
+    const resolved = realpathMap[p];
+    if (resolved === undefined) throw enoent();
+    return resolved;
   },
   renameSync: (src: string, dst: string) => {
     renameSyncCalls.push([src, dst]);
@@ -79,14 +96,19 @@ mock.module("node:fs", () => ({
 
 // Controlled per-test; reset in afterEach.
 let shellPathValue = "";
+let shellPathReliable = true;
 let shellPathHits: string[] = [];
 let resolveShellPathCalls = 0;
 const findExecutablesCalls: Array<[string, string]> = [];
 
+// Spread the real module so `splitPathEntries` keeps its production
+// behavior; only the spawning/probing functions are faked.
+const realShellPath = await import("./shell-path");
 mock.module("./shell-path", () => ({
+  ...realShellPath,
   resolveShellPath: async () => {
     resolveShellPathCalls += 1;
-    return shellPathValue;
+    return { path: shellPathValue, reliable: shellPathReliable };
   },
   findExecutablesInPath: (name: string, pathValue: string) => {
     findExecutablesCalls.push([name, pathValue]);
@@ -111,12 +133,15 @@ const locatorPath = `${userDataPath}/cli/locator.sh`;
 
 afterEach(() => {
   readFileSyncResult = null;
+  lstatSyncBehavior = "auto";
+  for (const key of Object.keys(realpathMap)) delete realpathMap[key];
   mkdirSyncCalls.length = 0;
   writeFileSyncCalls.length = 0;
   chmodSyncCalls.length = 0;
   renameSyncCalls.length = 0;
   rmSyncCalls.length = 0;
   shellPathValue = "";
+  shellPathReliable = true;
   shellPathHits = [];
   resolveShellPathCalls = 0;
   findExecutablesCalls.length = 0;
@@ -162,7 +187,7 @@ describe("buildWrapperScript", () => {
 
 describe("readWrapperOwnership", () => {
   test("returns absent when no file exists at the wrapper path", () => {
-    readFileSyncResult = null; // readFileSync throws ENOENT
+    readFileSyncResult = null; // lstatSync and readFileSync throw ENOENT
     expect(readWrapperOwnership()).toBe("absent");
   });
 
@@ -187,6 +212,13 @@ describe("readWrapperOwnership", () => {
     readFileSyncResult = eacces;
     expect(readWrapperOwnership()).toBe("foreign");
   });
+
+  test("returns foreign for a dangling symlink (lstat exists, read ENOENT)", () => {
+    lstatSyncBehavior = "exists";
+    readFileSyncResult = null; // readFileSync follows the link → ENOENT
+
+    expect(readWrapperOwnership()).toBe("foreign");
+  });
 });
 
 // --- installWrapper ---
@@ -206,14 +238,26 @@ describe("installWrapper", () => {
     expect(renameSyncCalls).toEqual([[`${wrapperPath}.tmp`, wrapperPath]]);
   });
 
-  test("returns needs-overwrite-confirmation for a foreign file without touching it", () => {
+  test("returns needs-overwrite-confirmation for a foreign file without touching the fs", () => {
     readFileSyncResult = "#!/bin/sh\necho not ours\n";
 
     const result = installWrapper({ overwriteForeign: false });
 
     expect(result).toBe("needs-overwrite-confirmation");
+    expect(mkdirSyncCalls).toHaveLength(0);
     expect(writeFileSyncCalls).toHaveLength(0);
     expect(chmodSyncCalls).toHaveLength(0);
+    expect(renameSyncCalls).toHaveLength(0);
+  });
+
+  test("requires confirmation for a dangling foreign symlink instead of clobbering it", () => {
+    lstatSyncBehavior = "exists";
+    readFileSyncResult = null;
+
+    const result = installWrapper({ overwriteForeign: false });
+
+    expect(result).toBe("needs-overwrite-confirmation");
+    expect(writeFileSyncCalls).toHaveLength(0);
     expect(renameSyncCalls).toHaveLength(0);
   });
 
@@ -254,6 +298,14 @@ describe("uninstallWrapper", () => {
 
   test("refuses to delete a foreign file", () => {
     readFileSyncResult = "#!/bin/sh\necho not ours\n";
+
+    expect(uninstallWrapper()).toBe("not-ours");
+    expect(rmSyncCalls).toHaveLength(0);
+  });
+
+  test("refuses to delete a dangling foreign symlink", () => {
+    lstatSyncBehavior = "exists";
+    readFileSyncResult = null;
 
     expect(uninstallWrapper()).toBe("not-ours");
     expect(rmSyncCalls).toHaveLength(0);
@@ -309,7 +361,7 @@ describe("getCliPathInstallState", () => {
     });
   });
 
-  test("returns shadowed with the winning path when another vellum precedes the wrapper", async () => {
+  test("returns shadowed with inPath true when another vellum precedes the wrapper", async () => {
     readFileSyncResult = buildWrapperScript();
     shellPathValue = `/opt/homebrew/bin:${wrapperDir}:/usr/bin:/bin`;
     shellPathHits = ["/opt/homebrew/bin/vellum", wrapperPath];
@@ -317,6 +369,45 @@ describe("getCliPathInstallState", () => {
     expect(await getCliPathInstallState()).toEqual({
       kind: "shadowed",
       shadowedBy: "/opt/homebrew/bin/vellum",
+      inPath: true,
+    });
+  });
+
+  test("returns shadowed with inPath false when the wrapper dir is not in PATH", async () => {
+    readFileSyncResult = buildWrapperScript();
+    shellPathValue = "/opt/homebrew/bin:/usr/bin:/bin";
+    shellPathHits = ["/opt/homebrew/bin/vellum"];
+
+    expect(await getCliPathInstallState()).toEqual({
+      kind: "shadowed",
+      shadowedBy: "/opt/homebrew/bin/vellum",
+      inPath: false,
+    });
+  });
+
+  test("does not report shadowed when the first hit symlinks to the wrapper", async () => {
+    readFileSyncResult = buildWrapperScript();
+    shellPathValue = `${mockHome}/bin:/usr/bin:/bin`;
+    shellPathHits = [`${mockHome}/bin/vellum`]; // ~/bin -> ~/.local/bin
+    realpathMap[`${mockHome}/bin/vellum`] = wrapperPath;
+    realpathMap[wrapperPath] = wrapperPath;
+
+    expect(await getCliPathInstallState()).toEqual({
+      kind: "installed",
+      inPath: true,
+    });
+  });
+
+  test("still reports shadowed when realpath resolution fails (string-compare fallback)", async () => {
+    readFileSyncResult = buildWrapperScript();
+    shellPathValue = `/opt/homebrew/bin:${wrapperDir}`;
+    shellPathHits = ["/opt/homebrew/bin/vellum", wrapperPath];
+    // realpathMap left empty → realpathSync throws for both sides.
+
+    expect(await getCliPathInstallState()).toEqual({
+      kind: "shadowed",
+      shadowedBy: "/opt/homebrew/bin/vellum",
+      inPath: true,
     });
   });
 
@@ -340,5 +431,20 @@ describe("getCliPathInstallState", () => {
       kind: "installed",
       inPath: true,
     });
+  });
+
+  test("unreliable fallback PATH degrades to installed/inPath:false without shadow probing", async () => {
+    readFileSyncResult = buildWrapperScript();
+    shellPathReliable = false;
+    // The buildInstallEnv fallback always prepends the wrapper dir and may
+    // contain shadow candidates — none of it is evidence of the real PATH.
+    shellPathValue = `${wrapperDir}:/opt/homebrew/bin:/usr/bin`;
+    shellPathHits = ["/opt/homebrew/bin/vellum", wrapperPath];
+
+    expect(await getCliPathInstallState()).toEqual({
+      kind: "installed",
+      inPath: false,
+    });
+    expect(findExecutablesCalls).toHaveLength(0);
   });
 });

--- a/apps/macos/src/main/cli-path-installer.ts
+++ b/apps/macos/src/main/cli-path-installer.ts
@@ -1,16 +1,19 @@
 import {
-  chmodSync,
+  lstatSync,
   mkdirSync,
   readFileSync,
-  renameSync,
+  realpathSync,
   rmSync,
-  writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 
-import { getCliLocatorPath, shQuote } from "./cli-installer";
-import { findExecutablesInPath, resolveShellPath } from "./shell-path";
+import { getCliLocatorPath, shQuote, writeFileAtomicSync } from "./cli-installer";
+import {
+  findExecutablesInPath,
+  resolveShellPath,
+  splitPathEntries,
+} from "./shell-path";
 
 /** Ownership/migration marker embedded in every wrapper we write. */
 export const WRAPPER_MARKER = "# vellum-cli-wrapper v1";
@@ -54,18 +57,28 @@ export function buildWrapperScript(): string {
 export type WrapperOwnership = "ours" | "foreign" | "absent";
 
 /**
- * Classify what sits at the wrapper path. Unreadable-but-present files and
- * marker-less symlink targets (e.g. an npm prefix pointed at `~/.local`)
- * read as `foreign` so we never clobber them.
+ * Classify what sits at the wrapper path. Anything present that can't be
+ * read or lacks the marker — unreadable files, dangling symlinks,
+ * marker-less symlink targets (e.g. an npm prefix pointed at `~/.local`) —
+ * reads as `foreign` so we never clobber it. Only a true no-entry is
+ * `absent`; lstat is used so dangling symlinks still count as present.
  */
 export function readWrapperOwnership(): WrapperOwnership {
-  let content: string;
+  const wrapperPath = getWrapperPath();
+
   try {
-    content = readFileSync(getWrapperPath(), "utf8");
+    lstatSync(wrapperPath);
   } catch (err) {
     return (err as NodeJS.ErrnoException).code === "ENOENT"
       ? "absent"
       : "foreign";
+  }
+
+  let content: string;
+  try {
+    content = readFileSync(wrapperPath, "utf8");
+  } catch {
+    return "foreign";
   }
   return content.includes(WRAPPER_MARKER) ? "ours" : "foreign";
 }
@@ -77,17 +90,12 @@ export function readWrapperOwnership(): WrapperOwnership {
 export function installWrapper(opts: {
   overwriteForeign: boolean;
 }): "installed" | "needs-overwrite-confirmation" {
-  mkdirSync(getWrapperDir(), { recursive: true });
-
   if (readWrapperOwnership() === "foreign" && !opts.overwriteForeign) {
     return "needs-overwrite-confirmation";
   }
 
-  const wrapperPath = getWrapperPath();
-  const tmpPath = `${wrapperPath}.tmp`;
-  writeFileSync(tmpPath, buildWrapperScript());
-  chmodSync(tmpPath, 0o755);
-  renameSync(tmpPath, wrapperPath);
+  mkdirSync(getWrapperDir(), { recursive: true });
+  writeFileAtomicSync(getWrapperPath(), buildWrapperScript(), 0o755);
   return "installed";
 }
 
@@ -95,34 +103,46 @@ export type CliPathInstallState =
   | { kind: "not-installed" }
   | { kind: "foreign-file" }
   | { kind: "installed"; inPath: boolean }
-  | { kind: "shadowed"; shadowedBy: string };
+  // `inPath` is optional only so sibling-owned test fixtures keep compiling;
+  // getCliPathInstallState always populates it.
+  | { kind: "shadowed"; shadowedBy: string; inPath?: boolean };
 
-// Shell PATH entries are already $HOME-expanded; only trailing slashes vary.
-function stripTrailingSlashes(dir: string): string {
-  return dir.replace(/\/+$/, "");
+function realpathOr(p: string): string {
+  try {
+    return realpathSync(p);
+  } catch {
+    return p;
+  }
 }
 
 /**
  * Determine how the `vellum` command resolves on the user's login-shell
  * PATH. `shadowed` means another executable wins over our wrapper (e.g. an
- * npm-global install earlier in PATH). Never throws — shell PATH resolution
- * degrades gracefully.
+ * npm-global install earlier in PATH); symlink/case variants that resolve
+ * to the wrapper itself don't count. Never throws — when login-shell PATH
+ * resolution fails, degrades to `installed` with `inPath: false` rather
+ * than reporting states the fallback PATH can't actually attest to.
  */
 export async function getCliPathInstallState(): Promise<CliPathInstallState> {
   const ownership = readWrapperOwnership();
   if (ownership === "absent") return { kind: "not-installed" };
   if (ownership === "foreign") return { kind: "foreign-file" };
 
-  const shellPath = await resolveShellPath();
-  const [firstHit] = findExecutablesInPath("vellum", shellPath);
-  if (firstHit !== undefined && firstHit !== getWrapperPath()) {
-    return { kind: "shadowed", shadowedBy: firstHit };
-  }
+  const { path: shellPath, reliable } = await resolveShellPath();
+  if (!reliable) return { kind: "installed", inPath: false };
 
-  const wrapperDir = getWrapperDir();
-  const inPath = shellPath
-    .split(":")
-    .some((entry) => stripTrailingSlashes(entry) === wrapperDir);
+  const wrapperPath = getWrapperPath();
+  const [firstHit] = findExecutablesInPath("vellum", shellPath);
+  const firstHitIsWrapper =
+    firstHit !== undefined &&
+    (firstHit === wrapperPath || realpathOr(firstHit) === realpathOr(wrapperPath));
+
+  const inPath =
+    firstHitIsWrapper || splitPathEntries(shellPath).includes(getWrapperDir());
+
+  if (firstHit !== undefined && !firstHitIsWrapper) {
+    return { kind: "shadowed", shadowedBy: firstHit, inPath };
+  }
   return { kind: "installed", inPath };
 }
 

--- a/apps/macos/src/main/shell-path.test.ts
+++ b/apps/macos/src/main/shell-path.test.ts
@@ -28,6 +28,7 @@ mock.module("node:fs", () => ({
   },
   constants: { X_OK: 1 },
   // Used by cli-installer's buildInstallEnv (nvm detection).
+  chmodSync: () => {},
   copyFileSync: () => {},
   existsSync: () => false,
   mkdirSync: () => {},
@@ -51,14 +52,22 @@ mock.module("node:child_process", () => ({
 const {
   resolveShellPath,
   findExecutablesInPath,
+  splitPathEntries,
   _resetShellPathCache,
-  PATH_SENTINEL,
 } = await import("./shell-path");
 const { buildInstallEnv } = await import("./cli-installer");
 
 const originalShell = process.env.SHELL;
 
+// Mirrors the internal sentinel in shell-path.ts (intentionally unexported).
+const PATH_SENTINEL = "__VELLUM_PATH_7f3a__";
+
 const wrap = (path: string) => `${PATH_SENTINEL}${path}${PATH_SENTINEL}`;
+
+const fallbackResult = () => ({
+  path: buildInstallEnv().PATH ?? "",
+  reliable: false,
+});
 
 afterEach(() => {
   spawnCalls.length = 0;
@@ -71,7 +80,7 @@ afterEach(() => {
 // --- resolveShellPath ---
 
 describe("resolveShellPath", () => {
-  test("returns the shell's stdout PATH using $SHELL", async () => {
+  test("returns the shell's stdout PATH as reliable, using $SHELL", async () => {
     process.env.SHELL = "/bin/bash";
 
     const promise = resolveShellPath();
@@ -81,7 +90,10 @@ describe("resolveShellPath", () => {
     );
     lastChild.emit("close", 0);
 
-    expect(await promise).toBe("/Users/me/.local/bin:/usr/bin");
+    expect(await promise).toEqual({
+      path: "/Users/me/.local/bin:/usr/bin",
+      reliable: true,
+    });
     expect(spawnCalls).toHaveLength(1);
     expect(spawnCalls[0][0]).toBe("/bin/bash");
     expect(spawnCalls[0][1]).toEqual([
@@ -98,15 +110,18 @@ describe("resolveShellPath", () => {
     );
     lastChild.emit("close", 0);
 
-    expect(await promise).toBe("/usr/local/bin:/usr/bin");
+    expect(await promise).toEqual({
+      path: "/usr/local/bin:/usr/bin",
+      reliable: true,
+    });
   });
 
-  test("falls back to buildInstallEnv PATH when sentinels are missing", async () => {
+  test("falls back to unreliable buildInstallEnv PATH when sentinels are missing", async () => {
     const promise = resolveShellPath();
     lastChild.stdout.emit("data", Buffer.from("banner only, no sentinel"));
     lastChild.emit("close", 0);
 
-    expect(await promise).toBe(buildInstallEnv().PATH ?? "");
+    expect(await promise).toEqual(fallbackResult());
   });
 
   test("falls back to /bin/zsh when $SHELL is unset", async () => {
@@ -120,32 +135,32 @@ describe("resolveShellPath", () => {
     expect(spawnCalls[0][0]).toBe("/bin/zsh");
   });
 
-  test("falls back to buildInstallEnv PATH on non-zero exit", async () => {
+  test("falls back to unreliable buildInstallEnv PATH on non-zero exit", async () => {
     const promise = resolveShellPath();
     lastChild.stderr.emit("data", Buffer.from("zsh: bad rc file"));
     lastChild.emit("close", 1);
 
-    expect(await promise).toBe(buildInstallEnv().PATH ?? "");
+    expect(await promise).toEqual(fallbackResult());
   });
 
-  test("falls back to buildInstallEnv PATH on empty output", async () => {
+  test("falls back to unreliable buildInstallEnv PATH on empty output", async () => {
     const promise = resolveShellPath();
     lastChild.emit("close", 0);
 
-    expect(await promise).toBe(buildInstallEnv().PATH ?? "");
+    expect(await promise).toEqual(fallbackResult());
   });
 
-  test("falls back to buildInstallEnv PATH on spawn error", async () => {
+  test("falls back to unreliable buildInstallEnv PATH on spawn error", async () => {
     const promise = resolveShellPath();
     lastChild.emit("error", new Error("ENOENT"));
 
-    expect(await promise).toBe(buildInstallEnv().PATH ?? "");
+    expect(await promise).toEqual(fallbackResult());
   });
 
   test("kills the child and falls back on timeout", async () => {
     const promise = resolveShellPath(10);
 
-    expect(await promise).toBe(buildInstallEnv().PATH ?? "");
+    expect(await promise).toEqual(fallbackResult());
     expect(lastChild.kill).toHaveBeenCalled();
   });
 
@@ -156,8 +171,8 @@ describe("resolveShellPath", () => {
     lastChild.stdout.emit("data", Buffer.from(wrap("/late/bin")));
     lastChild.emit("close", 0);
 
-    expect(result).toBe(buildInstallEnv().PATH ?? "");
-    expect(await resolveShellPath()).toBe(result);
+    expect(result).toEqual(fallbackResult());
+    expect(await resolveShellPath()).toEqual(result);
   });
 
   test("caches the result; second call does not spawn again", async () => {
@@ -166,7 +181,10 @@ describe("resolveShellPath", () => {
     lastChild.emit("close", 0);
     await promise;
 
-    expect(await resolveShellPath()).toBe("/cached/bin");
+    expect(await resolveShellPath()).toEqual({
+      path: "/cached/bin",
+      reliable: true,
+    });
     expect(spawnCalls).toHaveLength(1);
   });
 
@@ -178,8 +196,8 @@ describe("resolveShellPath", () => {
     lastChild.stdout.emit("data", Buffer.from(wrap("/shared/bin")));
     lastChild.emit("close", 0);
 
-    expect(await p1).toBe("/shared/bin");
-    expect(await p2).toBe("/shared/bin");
+    expect((await p1).path).toBe("/shared/bin");
+    expect((await p2).path).toBe("/shared/bin");
   });
 
   test("_resetShellPathCache clears the cache", async () => {
@@ -194,7 +212,31 @@ describe("resolveShellPath", () => {
     expect(spawnCalls).toHaveLength(2);
     lastChild.stdout.emit("data", Buffer.from(wrap("/second/bin")));
     lastChild.emit("close", 0);
-    expect(await p2).toBe("/second/bin");
+    expect((await p2).path).toBe("/second/bin");
+  });
+});
+
+// --- splitPathEntries ---
+
+describe("splitPathEntries", () => {
+  test("splits on colons preserving order", () => {
+    expect(splitPathEntries("/a:/b:/c")).toEqual(["/a", "/b", "/c"]);
+  });
+
+  test("strips trailing slashes", () => {
+    expect(splitPathEntries("/a/:/b//")).toEqual(["/a", "/b"]);
+  });
+
+  test("skips empty entries", () => {
+    expect(splitPathEntries(":/a::")).toEqual(["/a"]);
+  });
+
+  test("dedupes entries, including slash variants", () => {
+    expect(splitPathEntries("/a:/a/:/b:/a")).toEqual(["/a", "/b"]);
+  });
+
+  test("returns empty array for an empty value", () => {
+    expect(splitPathEntries("")).toEqual([]);
   });
 });
 
@@ -223,6 +265,12 @@ describe("findExecutablesInPath", () => {
     expect(findExecutablesInPath("vellum", ":/a::/a:/a:")).toEqual([
       "/a/vellum",
     ]);
+  });
+
+  test("normalizes trailing-slash entries to the same hit", () => {
+    executablePaths.add("/a/vellum");
+
+    expect(findExecutablesInPath("vellum", "/a/:/a")).toEqual(["/a/vellum"]);
   });
 
   test("returns empty array when nothing matches", () => {

--- a/apps/macos/src/main/shell-path.ts
+++ b/apps/macos/src/main/shell-path.ts
@@ -8,19 +8,29 @@ const SHELL_PATH_TIMEOUT_MS = 5_000;
 
 // Wraps the printf'd PATH so it can be isolated from any startup-file
 // output (banners, warnings) the interactive login shell writes first.
-export const PATH_SENTINEL = "__VELLUM_PATH_7f3a__";
+const PATH_SENTINEL = "__VELLUM_PATH_7f3a__";
+
+export interface ShellPathResult {
+  path: string;
+  /**
+   * False when the login shell couldn't be queried and `path` is the
+   * synthesized `buildInstallEnv()` fallback — good enough for spawning
+   * processes, but NOT evidence of what's on the user's real PATH.
+   */
+  reliable: boolean;
+}
 
 // Cached for the process lifetime; caching the promise also dedupes
 // concurrent first calls into a single shell spawn.
-let shellPathPromise: Promise<string> | null = null;
+let shellPathPromise: Promise<ShellPathResult> | null = null;
 
 /** Reset the shell PATH cache. Exposed for testing only. */
 export function _resetShellPathCache(): void {
   shellPathPromise = null;
 }
 
-function fallbackPath(): string {
-  return buildInstallEnv().PATH ?? "";
+function fallbackResult(): ShellPathResult {
+  return { path: buildInstallEnv().PATH ?? "", reliable: false };
 }
 
 /**
@@ -30,16 +40,16 @@ function fallbackPath(): string {
  * ~/.local/bin and package-manager bin dirs, so PATH checks (shadow
  * detection, "is ~/.local/bin in PATH") must use the shell's PATH rather
  * than `process.env.PATH`. Never rejects — on failure or timeout it falls
- * back to the PATH produced by `buildInstallEnv()`.
+ * back to the PATH produced by `buildInstallEnv()`, marked unreliable.
  */
 export function resolveShellPath(
   timeoutMs: number = SHELL_PATH_TIMEOUT_MS,
-): Promise<string> {
+): Promise<ShellPathResult> {
   shellPathPromise ??= queryShellPath(timeoutMs);
   return shellPathPromise;
 }
 
-function queryShellPath(timeoutMs: number): Promise<string> {
+function queryShellPath(timeoutMs: number): Promise<ShellPathResult> {
   return new Promise((resolve) => {
     const shell = process.env.SHELL ?? "/bin/zsh";
 
@@ -50,14 +60,14 @@ function queryShellPath(timeoutMs: number): Promise<string> {
         `printf "${PATH_SENTINEL}%s${PATH_SENTINEL}" "$PATH"`,
       ]);
     } catch {
-      resolve(fallbackPath());
+      resolve(fallbackResult());
       return;
     }
 
     let stdout = "";
     let settled = false;
 
-    const settle = (value: string) => {
+    const settle = (value: ShellPathResult) => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
@@ -66,18 +76,18 @@ function queryShellPath(timeoutMs: number): Promise<string> {
 
     const timer = setTimeout(() => {
       child.kill();
-      settle(fallbackPath());
+      settle(fallbackResult());
     }, timeoutMs);
 
     child.stdout?.on("data", (data: Buffer) => {
       stdout += data.toString();
     });
 
-    child.on("error", () => settle(fallbackPath()));
+    child.on("error", () => settle(fallbackResult()));
 
     child.on("close", (code: number | null) => {
       const value = code === 0 ? extractSentinelValue(stdout) : null;
-      settle(value || fallbackPath());
+      settle(value ? { path: value, reliable: true } : fallbackResult());
     });
   });
 }
@@ -92,6 +102,24 @@ function extractSentinelValue(stdout: string): string | null {
 }
 
 /**
+ * Split a PATH value into normalized directory entries: trailing slashes
+ * stripped, empty entries skipped, duplicates removed (first wins).
+ */
+export function splitPathEntries(pathValue: string): string[] {
+  const entries: string[] = [];
+  const seen = new Set<string>();
+
+  for (const raw of pathValue.split(":")) {
+    const dir = raw.replace(/\/+$/, "");
+    if (!dir || seen.has(dir)) continue;
+    seen.add(dir);
+    entries.push(dir);
+  }
+
+  return entries;
+}
+
+/**
  * Return absolute paths of every executable named `name` on `pathValue`,
  * preserving PATH precedence order. Empty and duplicate entries are
  * skipped; non-existent or non-executable candidates are ignored.
@@ -101,12 +129,8 @@ export function findExecutablesInPath(
   pathValue: string,
 ): string[] {
   const results: string[] = [];
-  const seen = new Set<string>();
 
-  for (const dir of pathValue.split(":")) {
-    if (!dir || seen.has(dir)) continue;
-    seen.add(dir);
-
+  for (const dir of splitPathEntries(pathValue)) {
     const candidate = path.join(dir, name);
     try {
       accessSync(candidate, constants.X_OK);


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for cli-path-installer.md:
- Install flow now provisions the CLI (ensureCliInstalled) before claiming success
- Unreliable fallback shell PATH no longer fakes inPath:true or reports shadows
- realpath-based shadow comparison; shadowed state carries inPath and dialog adds PATH help
- Dangling foreign symlinks no longer silently clobbered (lstat-based ownership)
- Slop: single confirmation path, shared writeFileAtomicSync + splitPathEntries, test-setup clipboard stub, mkdir after ownership check, PATH_SENTINEL un-exported