### PR TITLE
rename release buckets to vellum-ai-{env}-releases

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -2062,7 +2062,7 @@ jobs:
       - name: Upload Electron update artifacts to GCS
         run: |
           ENVIRONMENT="dev"
-          BUCKET="vellum-dev-releases"
+          BUCKET="vellum-ai-dev-releases"
           MANIFEST_NAME="${ENVIRONMENT}-mac.yml"
 
           for ARCH in arm64 x64; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2937,7 +2937,7 @@ jobs:
       - name: Upload Electron update artifacts to GCS
         run: |
           ENVIRONMENT=${{ needs.extract-version.outputs.is_staging == 'true' && 'staging' || 'production' }}
-          BUCKET=${{ needs.extract-version.outputs.is_staging == 'true' && 'vellum-staging-releases' || 'vellum-prod-releases' }}
+          BUCKET=${{ needs.extract-version.outputs.is_staging == 'true' && 'vellum-ai-staging-releases' || 'vellum-ai-prod-releases' }}
           MANIFEST_NAME="${ENVIRONMENT}-mac.yml"
 
           for ARCH in arm64 x64; do

--- a/apps/macos/electron-builder.config.cjs
+++ b/apps/macos/electron-builder.config.cjs
@@ -25,7 +25,7 @@ module.exports = {
   productName,
   publish: {
     provider: "generic",
-    url: `https://storage.googleapis.com/vellum-${bucketEnv}-releases/mac-electron/${targetArch}/`,
+    url: `https://storage.googleapis.com/vellum-ai-${bucketEnv}-releases/mac-electron/${targetArch}/`,
   },
   directories: {
     output: "dist",

--- a/apps/macos/src/main/auto-update.ts
+++ b/apps/macos/src/main/auto-update.ts
@@ -62,7 +62,7 @@ export const installAutoUpdate = (): void => {
   autoUpdater.allowDowngrade = false;
   autoUpdater.setFeedURL({
     provider: "generic",
-    url: `https://storage.googleapis.com/vellum-${BUCKET_ENV}-releases/mac-electron/${process.arch}/`,
+    url: `https://storage.googleapis.com/vellum-ai-${BUCKET_ENV}-releases/mac-electron/${process.arch}/`,
   });
 
   autoUpdater.on("checking-for-update", () => {


### PR DESCRIPTION
## Summary

- Rename GCS release bucket references from `vellum-{env}-releases` to `vellum-ai-{env}-releases` across CI workflows and app code
- Affects `dev-release.yaml`, `release.yml`, `electron-builder.config.cjs`, and `auto-update.ts`

## Original prompt

Follow-up to #34367 — the Terraform buckets were renamed to use the `vellum-ai-` prefix (e.g. `vellum-ai-dev-releases`, `vellum-ai-staging-releases`, `vellum-ai-prod-releases`). This PR updates all references in the assistant repo to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)