### PR TITLE
Record skill_loaded events for Vellum-produced skills at skill activation

### DIFF
--- a/assistant/src/__tests__/conversation-app-control-instantiation.test.ts
+++ b/assistant/src/__tests__/conversation-app-control-instantiation.test.ts
@@ -193,6 +193,19 @@ mock.module("../skills/version-hash.js", () => ({
   },
 }));
 
+// Mock the skill_loaded telemetry dependencies of conversation-skill-tools so
+// their heavy transitive imports (catalog-install → CLI program, sqlite) stay
+// out of this import-light test.
+mock.module("../skills/catalog-cache.js", () => ({
+  getCachedCatalogSync: () => [],
+}));
+mock.module("../skills/install-meta.js", () => ({
+  readInstallMeta: () => null,
+}));
+mock.module("../memory/skill-loaded-events-store.js", () => ({
+  recordSkillLoadedEvent: () => {},
+}));
+
 // ---------------------------------------------------------------------------
 // Imports under test (after mocks)
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/conversation-skill-tools.test.ts
+++ b/assistant/src/__tests__/conversation-skill-tools.test.ts
@@ -2,6 +2,7 @@ import * as realFs from "node:fs";
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { SkillSummary, SkillToolManifest } from "../config/skills.js";
+import type { SkillLoadedEventRecord } from "../memory/skill-loaded-events-store.js";
 import { RiskLevel } from "../permissions/types.js";
 import type {
   Message,
@@ -9,7 +10,9 @@ import type {
   ToolResultContent,
   ToolUseContent,
 } from "../providers/types.js";
+import type { SkillInstallMeta } from "../skills/install-meta.js";
 import type { Tool } from "../tools/types.js";
+import type { UsageAttributionSnapshot } from "../usage/attribution.js";
 import { buildSkillLoadHistory } from "./test-support/browser-skill-harness.js";
 
 // ---------------------------------------------------------------------------
@@ -25,6 +28,14 @@ let mockSkillRefCount: Map<string, number> = new Map();
 let mockVersionHashes: Record<string, string> = {};
 /** Skill IDs for which computeSkillVersionHash should throw (simulates unreadable directories). */
 let mockVersionHashErrors: Set<string> = new Set();
+/** Install metadata by skill id (readInstallMeta derives the id from the directory path). */
+let mockInstallMetas: Record<string, SkillInstallMeta | null> = {};
+/** Merged catalog entries returned by getCachedCatalogSync. */
+let mockCachedCatalog: Array<{ id: string; updatedAt?: string }> = [];
+/** skill_loaded events captured by the mocked store. */
+let recordedSkillLoadedEvents: SkillLoadedEventRecord[] = [];
+/** When true, recordSkillLoadedEvent throws (simulates a store failure). */
+let mockRecordSkillLoadedFailure = false;
 
 // ---------------------------------------------------------------------------
 // Mocks — must be set up before importing the module under test
@@ -227,6 +238,27 @@ mock.module("../config/skill-state.js", () => ({
     skill.featureFlag || undefined,
 }));
 
+mock.module("../skills/install-meta.js", () => ({
+  readInstallMeta: (skillDir: string) => {
+    const parts = skillDir.split("/");
+    const skillId = parts[parts.length - 1];
+    return mockInstallMetas[skillId] ?? null;
+  },
+}));
+
+mock.module("../skills/catalog-cache.js", () => ({
+  getCachedCatalogSync: () => mockCachedCatalog,
+}));
+
+mock.module("../memory/skill-loaded-events-store.js", () => ({
+  recordSkillLoadedEvent: (record: SkillLoadedEventRecord) => {
+    if (mockRecordSkillLoadedFailure) {
+      throw new Error("Mock: skill_loaded store failure");
+    }
+    recordedSkillLoadedEvents.push(record);
+  },
+}));
+
 // ---------------------------------------------------------------------------
 // Import module under test (after mocks)
 // ---------------------------------------------------------------------------
@@ -238,7 +270,11 @@ const { projectSkillTools, resetSkillToolProjection } =
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeSkill(id: string, dir?: string): SkillSummary {
+function makeSkill(
+  id: string,
+  dir?: string,
+  source: SkillSummary["source"] = "managed",
+): SkillSummary {
   return {
     id,
     name: id,
@@ -247,7 +283,7 @@ function makeSkill(id: string, dir?: string): SkillSummary {
     directoryPath: dir ?? `/skills/${id}`,
     skillFilePath: `/skills/${id}/SKILL.md`,
 
-    source: "managed",
+    source,
   };
 }
 
@@ -706,6 +742,264 @@ describe("projectSkillTools", () => {
     resetSkillToolProjection(sessionB);
     expect(mockRegisteredTools.has("deploy")).toBe(false);
     expect(mockSkillRefCount.has("deploy")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// skill_loaded telemetry recording
+// ---------------------------------------------------------------------------
+
+describe("skill_loaded telemetry recording", () => {
+  let sessionState: Map<string, string>;
+
+  function makeAttribution(): UsageAttributionSnapshot {
+    return {
+      callSite: "mainAgent",
+      activeProfile: "balanced",
+      overrideProfile: null,
+      callSiteProfile: null,
+      appliedProfile: "balanced",
+      profileSource: "active",
+      resolvedProvider: "test-provider",
+      resolvedModel: "test-model",
+      resolvedMixArm: null,
+    };
+  }
+
+  function makeTelemetry() {
+    return { conversationId: "conv-xyz", attribution: makeAttribution() };
+  }
+
+  beforeEach(() => {
+    mockCatalog = [];
+    mockManifests = {};
+    mockRegisteredTools = new Map();
+    mockUnregisteredSkillIds = [];
+    mockSkillRefCount = new Map();
+    mockVersionHashes = {};
+    mockVersionHashErrors = new Set();
+    mockInstallMetas = {};
+    mockCachedCatalog = [];
+    recordedSkillLoadedEvents = [];
+    mockRecordSkillLoadedFailure = false;
+    sessionState = new Map<string, string>();
+  });
+
+  test("bundled skill activation records an event with attribution and catalog updatedAt", () => {
+    mockCatalog = [makeSkill("notes", undefined, "bundled")];
+    mockManifests = { notes: makeManifest(["notes_add"]) };
+    mockCachedCatalog = [{ id: "notes", updatedAt: "2026-01-02T03:04:05Z" }];
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="notes" />'),
+    ];
+    projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: makeTelemetry(),
+    });
+
+    expect(recordedSkillLoadedEvents).toHaveLength(1);
+    expect(recordedSkillLoadedEvents[0]).toEqual({
+      conversationId: "conv-xyz",
+      skillName: "notes",
+      skillUpdatedAt: "2026-01-02T03:04:05Z",
+      provider: "test-provider",
+      model: "test-model",
+      inferenceProfile: "balanced",
+      inferenceProfileSource: "active",
+    });
+  });
+
+  test("managed skill with vellum install origin records an event", () => {
+    mockCatalog = [makeSkill("deploy")];
+    mockManifests = { deploy: makeManifest(["deploy_run"]) };
+    mockInstallMetas = {
+      deploy: { origin: "vellum", installedAt: "2026-01-01T00:00:00Z" },
+    };
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="deploy" />'),
+    ];
+    projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: makeTelemetry(),
+    });
+
+    expect(recordedSkillLoadedEvents).toHaveLength(1);
+    expect(recordedSkillLoadedEvents[0].skillName).toBe("deploy");
+  });
+
+  test("managed skill with clawhub or custom origin does NOT record", () => {
+    mockCatalog = [makeSkill("third-party"), makeSkill("homemade")];
+    mockManifests = {
+      "third-party": makeManifest(["tp_run"]),
+      homemade: makeManifest(["hm_run"]),
+    };
+    mockInstallMetas = {
+      "third-party": {
+        origin: "clawhub",
+        installedAt: "2026-01-01T00:00:00Z",
+      },
+      homemade: { origin: "custom", installedAt: "2026-01-01T00:00:00Z" },
+    };
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="third-party" />'),
+      ...skillLoadMessages('<loaded_skill id="homemade" />'),
+    ];
+    const result = projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: makeTelemetry(),
+    });
+
+    expect(recordedSkillLoadedEvents).toHaveLength(0);
+    // Tool projection itself is unaffected
+    expect(result.allowedToolNames).toEqual(new Set(["tp_run", "hm_run"]));
+  });
+
+  test("managed skill without install metadata does NOT record", () => {
+    mockCatalog = [makeSkill("deploy")];
+    mockManifests = { deploy: makeManifest(["deploy_run"]) };
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="deploy" />'),
+    ];
+    projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: makeTelemetry(),
+    });
+
+    expect(recordedSkillLoadedEvents).toHaveLength(0);
+  });
+
+  test("workspace skill does NOT record", () => {
+    mockCatalog = [makeSkill("local-helper", undefined, "workspace")];
+    mockManifests = { "local-helper": makeManifest(["lh_run"]) };
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="local-helper" />'),
+    ];
+    projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: makeTelemetry(),
+    });
+
+    expect(recordedSkillLoadedEvents).toHaveLength(0);
+  });
+
+  test("second turn with the skill still active does NOT re-record", () => {
+    mockCatalog = [makeSkill("notes", undefined, "bundled")];
+    mockManifests = { notes: makeManifest(["notes_add"]) };
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="notes" />'),
+    ];
+    projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: makeTelemetry(),
+    });
+    projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: makeTelemetry(),
+    });
+
+    expect(recordedSkillLoadedEvents).toHaveLength(1);
+  });
+
+  test("version-hash change that re-registers counts as a new load", () => {
+    mockCatalog = [makeSkill("notes", undefined, "bundled")];
+    mockManifests = { notes: makeManifest(["notes_add"]) };
+    mockVersionHashes = { notes: "v1:hash-aaa" };
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="notes" />'),
+    ];
+    projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: makeTelemetry(),
+    });
+
+    mockVersionHashes = { notes: "v1:hash-bbb" };
+    projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: makeTelemetry(),
+    });
+
+    expect(recordedSkillLoadedEvents).toHaveLength(2);
+  });
+
+  test("catalog miss yields undefined skillUpdatedAt (persisted as null)", () => {
+    mockCatalog = [makeSkill("notes", undefined, "bundled")];
+    mockManifests = { notes: makeManifest(["notes_add"]) };
+    mockCachedCatalog = []; // no merged-catalog entry for "notes"
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="notes" />'),
+    ];
+    projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: makeTelemetry(),
+    });
+
+    expect(recordedSkillLoadedEvents).toHaveLength(1);
+    expect(recordedSkillLoadedEvents[0].skillUpdatedAt).toBeUndefined();
+  });
+
+  test("null attribution records the event without model fields", () => {
+    mockCatalog = [makeSkill("notes", undefined, "bundled")];
+    mockManifests = { notes: makeManifest(["notes_add"]) };
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="notes" />'),
+    ];
+    projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: { conversationId: "conv-xyz", attribution: null },
+    });
+
+    expect(recordedSkillLoadedEvents).toHaveLength(1);
+    expect(recordedSkillLoadedEvents[0]).toEqual({
+      conversationId: "conv-xyz",
+      skillName: "notes",
+      skillUpdatedAt: undefined,
+      provider: undefined,
+      model: undefined,
+      inferenceProfile: undefined,
+      inferenceProfileSource: undefined,
+    });
+  });
+
+  test("store failure does not throw out of projectSkillTools", () => {
+    mockCatalog = [makeSkill("notes", undefined, "bundled")];
+    mockManifests = { notes: makeManifest(["notes_add"]) };
+    mockRecordSkillLoadedFailure = true;
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="notes" />'),
+    ];
+    const result = projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: makeTelemetry(),
+    });
+
+    // Tool projection behavior is unchanged when recording fails
+    expect(result.allowedToolNames.has("notes_add")).toBe(true);
+    expect(sessionState.has("notes")).toBe(true);
+  });
+
+  test("absent telemetry context disables recording entirely", () => {
+    mockCatalog = [makeSkill("notes", undefined, "bundled")];
+    mockManifests = { notes: makeManifest(["notes_add"]) };
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="notes" />'),
+    ];
+    const result = projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+    });
+
+    expect(recordedSkillLoadedEvents).toHaveLength(0);
+    expect(result.allowedToolNames.has("notes_add")).toBe(true);
   });
 });
 

--- a/assistant/src/__tests__/skill-projection-feature-flag.test.ts
+++ b/assistant/src/__tests__/skill-projection-feature-flag.test.ts
@@ -222,6 +222,19 @@ mock.module("../util/logger.js", () => ({
   }),
 }));
 
+// Mock the skill_loaded telemetry dependencies of conversation-skill-tools so
+// their heavy transitive imports (catalog-install → CLI program, sqlite) stay
+// out of this import-light test.
+mock.module("../skills/catalog-cache.js", () => ({
+  getCachedCatalogSync: () => [],
+}));
+mock.module("../skills/install-meta.js", () => ({
+  readInstallMeta: () => null,
+}));
+mock.module("../memory/skill-loaded-events-store.js", () => ({
+  recordSkillLoadedEvent: () => {},
+}));
+
 // ---------------------------------------------------------------------------
 // Import module under test (after mocks)
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/skill-projection.benchmark.test.ts
+++ b/assistant/src/__tests__/skill-projection.benchmark.test.ts
@@ -96,6 +96,19 @@ mock.module("../skills/version-hash.js", () => ({
   computeSkillVersionHash: () => "v1:deadbeef",
 }));
 
+// Mock the skill_loaded telemetry dependencies of conversation-skill-tools so
+// their heavy transitive imports (catalog-install → CLI program, sqlite) stay
+// out of this import-light test.
+mock.module("../skills/catalog-cache.js", () => ({
+  getCachedCatalogSync: () => [],
+}));
+mock.module("../skills/install-meta.js", () => ({
+  readInstallMeta: () => null,
+}));
+mock.module("../memory/skill-loaded-events-store.js", () => ({
+  recordSkillLoadedEvent: () => {},
+}));
+
 // Mock createSkillToolsFromManifest to return lightweight Tool-like objects
 mock.module("../tools/skills/skill-tool-factory.js", () => ({
   createSkillToolsFromManifest: (
@@ -153,22 +166,27 @@ mock.module("node:fs", () => ({
   Stats: class {},
 }));
 
-const benchmarkRegistry = new Map<string, unknown>();
+// Mirrors the current registry contract: ownership is recorded from the
+// `registerSkillTools(skillId, tools)` call and reported via `getToolOwner`.
+const benchmarkRegistry = new Map<string, { tool: unknown; skillId: string }>();
 mock.module("../tools/registry.js", () => ({
   registerSkillTools: (
+    skillId: string,
     tools: Array<{ name: string; [k: string]: unknown }>,
   ) => {
-    for (const t of tools) benchmarkRegistry.set(t.name, t);
+    for (const t of tools) benchmarkRegistry.set(t.name, { tool: t, skillId });
     return tools;
   },
   unregisterSkillTools: (skillId: string) => {
-    for (const [name, t] of benchmarkRegistry) {
-      const owner = (t as { owner?: { kind: string; id: string } }).owner;
-      if (owner?.kind === "skill" && owner.id === skillId)
-        benchmarkRegistry.delete(name);
+    for (const [name, entry] of benchmarkRegistry) {
+      if (entry.skillId === skillId) benchmarkRegistry.delete(name);
     }
   },
-  getTool: (name: string) => benchmarkRegistry.get(name),
+  getTool: (name: string) => benchmarkRegistry.get(name)?.tool,
+  getToolOwner: (name: string) => {
+    const entry = benchmarkRegistry.get(name);
+    return entry ? { kind: "skill" as const, id: entry.skillId } : undefined;
+  },
 }));
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/daemon/conversation-skill-tools.ts
+++ b/assistant/src/daemon/conversation-skill-tools.ts
@@ -16,9 +16,12 @@ import { getConfig } from "../config/loader.js";
 import { skillFlagKey } from "../config/skill-state.js";
 import type { SkillSummary, SkillToolManifest } from "../config/skills.js";
 import { loadSkillCatalog } from "../config/skills.js";
+import { recordSkillLoadedEvent } from "../memory/skill-loaded-events-store.js";
 import type { Message, ToolDefinition } from "../providers/types.js";
 import type { ActiveSkillEntry } from "../skills/active-skill-tools.js";
 import { deriveActiveSkills } from "../skills/active-skill-tools.js";
+import { getCachedCatalogSync } from "../skills/catalog-cache.js";
+import { readInstallMeta } from "../skills/install-meta.js";
 import { parseToolManifestFile } from "../skills/tool-manifest.js";
 import { computeSkillVersionHash } from "../skills/version-hash.js";
 import {
@@ -28,6 +31,7 @@ import {
   unregisterSkillTools,
 } from "../tools/registry.js";
 import { createSkillToolsFromManifest } from "../tools/skills/skill-tool-factory.js";
+import type { UsageAttributionSnapshot } from "../usage/attribution.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("conversation-skill-tools");
@@ -86,6 +90,11 @@ export interface ProjectSkillToolsOptions {
    * reads across agent turns.
    */
   cache?: SkillProjectionCache;
+  /** Telemetry context for skill_loaded events; absent disables recording. */
+  telemetry?: {
+    conversationId: string | null;
+    attribution: UsageAttributionSnapshot | null;
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -113,6 +122,54 @@ function loadManifestForSkill(skill: SkillSummary): SkillToolManifest | null {
       "Failed to parse TOOLS.json for skill",
     );
     return null;
+  }
+}
+
+/**
+ * Whether a skill is Vellum-produced for `skill_loaded` telemetry purposes:
+ * bundled skills always are; managed skills only when their install metadata
+ * records a `vellum` origin (legacy version.json installs are inferred as
+ * vellum by `readInstallMeta`). All other sources (workspace, extra, plugin)
+ * never emit.
+ */
+function isVellumProducedSkill(skill: SkillSummary): boolean {
+  if (skill.source === "bundled") return true;
+  if (skill.source === "managed") {
+    return readInstallMeta(skill.directoryPath)?.origin === "vellum";
+  }
+  return false;
+}
+
+/**
+ * Record a `skill_loaded` telemetry event for a newly-activated Vellum-produced
+ * skill. Metadata only — never skill output or conversation content.
+ * `skill_updated_at` comes from the cached merged catalog (sync accessor —
+ * this runs on the hot tool-projection path). Failures are swallowed at
+ * debug level: recording must never break tool projection.
+ */
+function recordSkillLoadedTelemetry(
+  skill: SkillSummary,
+  telemetry: ProjectSkillToolsOptions["telemetry"],
+): void {
+  if (!telemetry) return;
+  try {
+    if (!isVellumProducedSkill(skill)) return;
+    const catalogEntry = getCachedCatalogSync().find((s) => s.id === skill.id);
+    const attribution = telemetry.attribution;
+    recordSkillLoadedEvent({
+      conversationId: telemetry.conversationId ?? undefined,
+      skillName: skill.id,
+      skillUpdatedAt: catalogEntry?.updatedAt,
+      provider: attribution?.resolvedProvider,
+      model: attribution?.resolvedModel,
+      inferenceProfile: attribution?.appliedProfile ?? undefined,
+      inferenceProfileSource: attribution?.profileSource,
+    });
+  } catch (err) {
+    log.debug(
+      { err, skillId: skill.id },
+      "Failed to record skill_loaded telemetry event (non-fatal)",
+    );
   }
 }
 
@@ -325,6 +382,7 @@ export function projectSkillTools(
       if (prevHash === undefined) {
         // Newly active skill — register for the first time
         accepted = registerSkillTools(skillId, tools);
+        recordSkillLoadedTelemetry(skill, options?.telemetry);
       } else if (prevHash !== currentHash) {
         // Hash changed — unregister stale tools, then re-register with new definitions
         log.info(
@@ -343,6 +401,8 @@ export function projectSkillTools(
           // Don't add to successfulEntries — will be cleaned up as transiently-failed
           continue;
         }
+        // A version change that re-registers counts as a new skill load.
+        recordSkillLoadedTelemetry(skill, options?.telemetry);
       } else {
         // Hash unchanged — filter to only tools that are actually registered
         // for this skill. Some tools may have been skipped during initial

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -13,6 +13,7 @@ import {
 } from "../channels/types.js";
 import { getIsPlatform } from "../config/env-registry.js";
 import { getConfig } from "../config/loader.js";
+import type { LLMCallSite } from "../config/schemas/llm.js";
 import { getBindingByConversation } from "../memory/external-conversation-store.js";
 import type { PermissionPrompter } from "../permissions/prompter.js";
 import type { SecretPrompter } from "../permissions/secret-prompter.js";
@@ -375,6 +376,17 @@ export interface SkillProjectionContext {
   readonly transportInterface?: InterfaceId;
   /** Per-turn override profile, read by the switch_inference_profile tool injection. */
   currentTurnOverrideProfile?: string;
+  /**
+   * Conversation id for `skill_loaded` telemetry. Absent (e.g. minimal test
+   * contexts) disables telemetry recording in the skill projection.
+   */
+  readonly conversationId?: string;
+  /**
+   * The LLM call site driving the current turn (see
+   * {@link ToolSetupContext.currentCallSite}) — read per turn so skill_loaded
+   * telemetry attributes the provider/model/profile the turn actually ran on.
+   */
+  currentCallSite?: LLMCallSite;
 }
 
 // ── Conditional tool sets ────────────────────────────────────────────
@@ -641,6 +653,19 @@ export function createResolveToolsCallback(
       preactivatedSkillIds: effectivePreactivated,
       previouslyActiveSkillIds: ctx.skillProjectionState,
       cache: ctx.skillProjectionCache,
+      // skill_loaded telemetry context — resolved per turn so attribution
+      // reflects the call site/profile the current turn actually runs on.
+      telemetry:
+        ctx.conversationId !== undefined
+          ? {
+              conversationId: ctx.conversationId,
+              attribution: resolveConversationAttribution({
+                conversationId: ctx.conversationId,
+                currentCallSite: ctx.currentCallSite,
+                currentTurnOverrideProfile: ctx.currentTurnOverrideProfile,
+              }),
+            }
+          : undefined,
     });
     const turnAllowed = new Set(allBaseDefs.map((d) => d.name));
     for (const name of projection.allowedToolNames) {


### PR DESCRIPTION
## Summary
- projectSkillTools records a skill_loaded_events row when a Vellum-produced skill (bundled, or managed with vellum origin) becomes newly active
- skill_updated_at resolved from the cached merged catalog; model attribution passed from the conversation via resolveConversationAttribution
- Recording is fail-safe: absent telemetry context or store errors never affect tool projection

Part of plan: tool-skill-telemetry.md (PR 5 of 6)