### PR TITLE
Add maintenance status banner resume action

### DIFF
--- a/apps/web/src/components/status-banner.test.tsx
+++ b/apps/web/src/components/status-banner.test.tsx
@@ -13,9 +13,11 @@ let requestedOperationalStatusAssistantId: string | null | undefined;
 let operationalStatusQueryMock: {
   data: { state: string } | null | undefined;
   isError: boolean;
+  refetch: () => void;
 } = {
   data: null,
   isError: false,
+  refetch: () => {},
 };
 let StatusBanner: ComponentType<{ className?: string }>;
 
@@ -38,6 +40,21 @@ mock.module("@/runtime/is-electron", () => ({
 
 mock.module("@/runtime/connectivity", () => ({
   retryConnectivity: () => {},
+}));
+
+mock.module("@/generated/api/sdk.gen", () => ({
+  assistantsMaintenanceModeExitCreate: () =>
+    Promise.resolve({ response: new Response(null, { status: 204 }) }),
+}));
+
+mock.module("@/assistant/lifecycle-service", () => ({
+  lifecycleService: {
+    checkAssistant: () => Promise.resolve(),
+  },
+}));
+
+mock.module("@/lib/sentry/capture-error", () => ({
+  captureError: () => {},
 }));
 
 mock.module("@/assistant/operational-status", () => ({
@@ -81,7 +98,7 @@ mock.module("@vellumai/design-library/components/notice", () => ({
 }));
 
 mock.module("@vellumai/design-library/components/button", () => ({
-  Button: (props: { children: string }) => (
+  Button: (props: { children: ReactNode }) => (
     <button data-testid="button">{props.children}</button>
   ),
 }));
@@ -102,6 +119,7 @@ beforeEach(() => {
   operationalStatusQueryMock = {
     data: null,
     isError: false,
+    refetch: () => {},
   };
 });
 
@@ -175,6 +193,7 @@ describe("StatusBanner", () => {
 
     expect(maintenanceHtml).toContain("Assistant is in maintenance mode");
     expect(maintenanceHtml).toContain('data-tone="info"');
+    expect(maintenanceHtml).toContain("Resume Assistant");
   });
 
   test("renders status query failures as error banners", () => {

--- a/apps/web/src/components/status-banner.test.tsx
+++ b/apps/web/src/components/status-banner.test.tsx
@@ -9,6 +9,10 @@ let connectivityStateMock: "online" | "device-offline" | "backend-unreachable" =
 let isElectronMock = false;
 let activeAssistantIdMock: string | null = "assistant-123";
 let operationalStatusAssistantIdMock: string | null = null;
+let assistantStateMock:
+  | { kind: "loading" }
+  | { kind: "active"; isLocal: boolean; maintenanceMode?: { enabled: boolean } } =
+  { kind: "loading" };
 let requestedOperationalStatusAssistantId: string | null | undefined;
 let operationalStatusQueryMock: {
   data: { state: string } | null | undefined;
@@ -71,6 +75,7 @@ mock.module("@/assistant/operational-status", () => ({
 mock.module("@/assistant/lifecycle-store", () => ({
   useAssistantLifecycleStore: {
     use: {
+      assistantState: () => assistantStateMock,
       operationalStatusAssistantId: () => operationalStatusAssistantIdMock,
     },
   },
@@ -117,6 +122,7 @@ beforeEach(() => {
   isElectronMock = false;
   activeAssistantIdMock = "assistant-123";
   operationalStatusAssistantIdMock = null;
+  assistantStateMock = { kind: "loading" };
   requestedOperationalStatusAssistantId = undefined;
   operationalStatusQueryMock = {
     data: null,
@@ -195,6 +201,20 @@ describe("StatusBanner", () => {
     expect(maintenanceHtml).toContain("Assistant is in maintenance mode");
     expect(maintenanceHtml).toContain('data-tone="info"');
     expect(maintenanceHtml).toContain("Resume Assistant");
+  });
+
+  test("renders maintenance mode from lifecycle state when operational status is absent", () => {
+    assistantStateMock = {
+      kind: "active",
+      isLocal: false,
+      maintenanceMode: { enabled: true },
+    };
+
+    const html = renderToStaticMarkup(<StatusBanner />);
+
+    expect(html).toContain("Assistant is in maintenance mode");
+    expect(html).toContain('data-tone="info"');
+    expect(html).toContain("Resume Assistant");
   });
 
   test("renders status query failures as error banners", () => {

--- a/apps/web/src/components/status-banner.test.tsx
+++ b/apps/web/src/components/status-banner.test.tsx
@@ -13,11 +13,10 @@ let requestedOperationalStatusAssistantId: string | null | undefined;
 let operationalStatusQueryMock: {
   data: { state: string } | null | undefined;
   isError: boolean;
-  refetch: () => void;
+  refetch?: () => void;
 } = {
   data: null,
   isError: false,
-  refetch: () => {},
 };
 let StatusBanner: ComponentType<{ className?: string }>;
 
@@ -62,7 +61,10 @@ mock.module("@/assistant/operational-status", () => ({
     status?.state === "active",
   useAssistantOperationalStatus: (assistantId: string | null) => {
     requestedOperationalStatusAssistantId = assistantId;
-    return operationalStatusQueryMock;
+    return {
+      ...operationalStatusQueryMock,
+      refetch: operationalStatusQueryMock.refetch ?? (() => {}),
+    };
   },
 }));
 
@@ -119,7 +121,6 @@ beforeEach(() => {
   operationalStatusQueryMock = {
     data: null,
     isError: false,
-    refetch: () => {},
   };
 });
 

--- a/apps/web/src/components/status-banner.tsx
+++ b/apps/web/src/components/status-banner.tsx
@@ -50,6 +50,14 @@ const OPERATIONAL_STATUS_TITLES: Record<AssistantOperationalState, string> = {
   retiring: "Assistant is retiring",
 };
 
+function maintenanceModeBannerConfig(): BannerConfig {
+  return {
+    tone: "info",
+    title: OPERATIONAL_STATUS_TITLES.maintenance_mode,
+    icon: <Wrench className="h-4 w-4" aria-hidden="true" />,
+  };
+}
+
 function operationalStatusBannerConfig(
   status: AssistantOperationalStatus | null | undefined,
 ): BannerConfig | null {
@@ -70,11 +78,7 @@ function operationalStatusBannerConfig(
         icon: <Moon className="h-4 w-4" aria-hidden="true" />,
       };
     case "maintenance_mode":
-      return {
-        tone: "info",
-        title: OPERATIONAL_STATUS_TITLES[status.state],
-        icon: <Wrench className="h-4 w-4" aria-hidden="true" />,
-      };
+      return maintenanceModeBannerConfig();
     default:
       return {
         tone: "warning",
@@ -113,6 +117,7 @@ function useAssistantBannerConfig(): BannerConfig | null {
   const connectivityState = useConnectivityState();
   const nativeConnected = useNetworkStatus();
   const activeAssistantId = useResolvedAssistantsStore.use.activeAssistantId();
+  const assistantState = useAssistantLifecycleStore.use.assistantState();
   const operationalStatusAssistantId =
     useAssistantLifecycleStore.use.operationalStatusAssistantId();
   const assistantId = operationalStatusAssistantId ?? activeAssistantId;
@@ -187,15 +192,27 @@ function useAssistantBannerConfig(): BannerConfig | null {
     };
   }
 
-  if (operationalStatusIsError) {
+  const lifecycleMaintenanceModeActive =
+    assistantState.kind === "active" &&
+    assistantState.maintenanceMode?.enabled === true;
+  const shouldUseLifecycleMaintenanceMode =
+    lifecycleMaintenanceModeActive &&
+    (!operationalStatus || isHealthyOperationalStatus(operationalStatus));
+
+  if (operationalStatusIsError && !shouldUseLifecycleMaintenanceMode) {
     return {
       tone: "error",
       title: "Assistant status is unavailable",
     };
   }
 
-  const operationalBanner = operationalStatusBannerConfig(operationalStatus);
-  if (operationalStatus?.state !== "maintenance_mode" || !operationalBanner) {
+  const operationalBanner = shouldUseLifecycleMaintenanceMode
+    ? maintenanceModeBannerConfig()
+    : operationalStatusBannerConfig(operationalStatus);
+  const isMaintenanceModeBanner =
+    operationalStatus?.state === "maintenance_mode" ||
+    shouldUseLifecycleMaintenanceMode;
+  if (!isMaintenanceModeBanner || !operationalBanner) {
     return operationalBanner;
   }
 

--- a/apps/web/src/components/status-banner.tsx
+++ b/apps/web/src/components/status-banner.tsx
@@ -1,5 +1,5 @@
 import { CloudOff, LoaderCircle, Moon, WifiOff, Wrench } from "lucide-react";
-import { type ReactNode } from "react";
+import { type ReactNode, useCallback, useState } from "react";
 import { Button } from "@vellumai/design-library/components/button";
 import {
   Notice,
@@ -12,9 +12,12 @@ import {
   type AssistantOperationalStatus,
   useAssistantOperationalStatus,
 } from "@/assistant/operational-status";
+import { lifecycleService } from "@/assistant/lifecycle-service";
 import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
+import { assistantsMaintenanceModeExitCreate } from "@/generated/api/sdk.gen";
 import { useConnectivityState } from "@/hooks/use-connectivity-state";
 import { useNetworkStatus } from "@/hooks/use-network-status";
+import { captureError } from "@/lib/sentry/capture-error";
 import { retryConnectivity } from "@/runtime/connectivity";
 import { isElectron } from "@/runtime/is-electron";
 import { useIsNativePlatform } from "@/runtime/native-auth";
@@ -24,6 +27,7 @@ import { cn } from "@/utils/misc";
 interface BannerConfig {
   title: ReactNode;
   tone: NoticeTone;
+  children?: ReactNode;
   icon?: ReactNode;
   actions?: ReactNode;
 }
@@ -96,7 +100,9 @@ function BannerNotice({
         title={banner.title}
         icon={banner.icon}
         actions={banner.actions}
-      />
+      >
+        {banner.children}
+      </Notice>
     </div>
   );
 }
@@ -111,6 +117,41 @@ function useAssistantBannerConfig(): BannerConfig | null {
     useAssistantLifecycleStore.use.operationalStatusAssistantId();
   const assistantId = operationalStatusAssistantId ?? activeAssistantId;
   const statusQuery = useAssistantOperationalStatus(assistantId);
+  const [isExitingMaintenanceMode, setIsExitingMaintenanceMode] =
+    useState(false);
+  const [maintenanceModeExitError, setMaintenanceModeExitError] = useState<
+    string | null
+  >(null);
+
+  const handleExitMaintenanceMode = useCallback(async () => {
+    if (!assistantId || isExitingMaintenanceMode) return;
+
+    setIsExitingMaintenanceMode(true);
+    setMaintenanceModeExitError(null);
+
+    try {
+      const { response } = await assistantsMaintenanceModeExitCreate({
+        path: { assistant_id: assistantId },
+        throwOnError: false,
+      });
+
+      if (!response?.ok) {
+        throw new Error("Exit maintenance mode returned non-ok response");
+      }
+
+      await Promise.allSettled([
+        statusQuery.refetch(),
+        lifecycleService.checkAssistant(),
+      ]);
+    } catch (err) {
+      captureError(err, { context: "exit_maintenance_mode_status_banner" });
+      setMaintenanceModeExitError(
+        "Failed to exit maintenance mode. Please try again.",
+      );
+    } finally {
+      setIsExitingMaintenanceMode(false);
+    }
+  }, [assistantId, isExitingMaintenanceMode, statusQuery.refetch]);
 
   if (electron && connectivityState === "device-offline") {
     return {
@@ -148,7 +189,33 @@ function useAssistantBannerConfig(): BannerConfig | null {
     };
   }
 
-  return operationalStatusBannerConfig(statusQuery.data);
+  const operationalBanner = operationalStatusBannerConfig(statusQuery.data);
+  if (statusQuery.data?.state !== "maintenance_mode" || !operationalBanner) {
+    return operationalBanner;
+  }
+
+  return {
+    ...operationalBanner,
+    tone: maintenanceModeExitError ? "error" : operationalBanner.tone,
+    children: maintenanceModeExitError,
+    actions: assistantId ? (
+      <Button
+        variant="outlined"
+        size="compact"
+        leftIcon={
+          isExitingMaintenanceMode ? (
+            <LoaderCircle className="animate-spin" aria-hidden="true" />
+          ) : undefined
+        }
+        disabled={isExitingMaintenanceMode}
+        onClick={() => {
+          void handleExitMaintenanceMode();
+        }}
+      >
+        Resume Assistant
+      </Button>
+    ) : undefined,
+  };
 }
 
 export function StatusBanner({ className }: { className?: string }) {

--- a/apps/web/src/components/status-banner.tsx
+++ b/apps/web/src/components/status-banner.tsx
@@ -117,6 +117,11 @@ function useAssistantBannerConfig(): BannerConfig | null {
     useAssistantLifecycleStore.use.operationalStatusAssistantId();
   const assistantId = operationalStatusAssistantId ?? activeAssistantId;
   const statusQuery = useAssistantOperationalStatus(assistantId);
+  const {
+    data: operationalStatus,
+    isError: operationalStatusIsError,
+    refetch: refetchOperationalStatus,
+  } = statusQuery;
   const [isExitingMaintenanceMode, setIsExitingMaintenanceMode] =
     useState(false);
   const [maintenanceModeExitError, setMaintenanceModeExitError] = useState<
@@ -140,7 +145,7 @@ function useAssistantBannerConfig(): BannerConfig | null {
       }
 
       await Promise.allSettled([
-        statusQuery.refetch(),
+        refetchOperationalStatus(),
         lifecycleService.checkAssistant(),
       ]);
     } catch (err) {
@@ -151,7 +156,7 @@ function useAssistantBannerConfig(): BannerConfig | null {
     } finally {
       setIsExitingMaintenanceMode(false);
     }
-  }, [assistantId, isExitingMaintenanceMode, statusQuery.refetch]);
+  }, [assistantId, isExitingMaintenanceMode, refetchOperationalStatus]);
 
   if (electron && connectivityState === "device-offline") {
     return {
@@ -182,15 +187,15 @@ function useAssistantBannerConfig(): BannerConfig | null {
     };
   }
 
-  if (statusQuery.isError) {
+  if (operationalStatusIsError) {
     return {
       tone: "error",
       title: "Assistant status is unavailable",
     };
   }
 
-  const operationalBanner = operationalStatusBannerConfig(statusQuery.data);
-  if (statusQuery.data?.state !== "maintenance_mode" || !operationalBanner) {
+  const operationalBanner = operationalStatusBannerConfig(operationalStatus);
+  if (operationalStatus?.state !== "maintenance_mode" || !operationalBanner) {
     return operationalBanner;
   }
 

--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -48,7 +48,7 @@ import type { TranscriptHandle, TranscriptProps } from "@/domains/chat/transcrip
 import { useTranscriptScroll } from "@/domains/chat/transcript/use-transcript-scroll";
 import { useIsNativePlatform } from "@/runtime/native-auth";
 import { Button, Notice } from "@vellumai/design-library";
-import { Link, useNavigate } from "react-router";
+import { Link, useLocation, useNavigate } from "react-router";
 import { getChatBillingBannerDecision, shouldShowGenericChatErrorNotice } from "@/domains/chat/utils/error-classification";
 import { useInteractionStore } from "@/domains/chat/interaction-store";
 import type { DisplayAttachment, DisplayMessage } from "@/domains/chat/types/types";
@@ -154,7 +154,9 @@ export function ChatMainPanel({
   didOnboarding,
   onboardingConversationId,
 }: ChatMainPanelProps) {
+  const location = useLocation();
   const navigate = useNavigate();
+  const statusBannerVisible = !location.search.includes("popout=1");
 
   // -------------------------------------------------------------------------
   // Derived UI state (provides assistantId, activeConversationId,
@@ -731,6 +733,7 @@ export function ChatMainPanel({
     showMaintenanceBanner:
       assistantState.kind === "active" &&
       assistantState.maintenanceMode?.enabled === true,
+    showMaintenanceExitAction: !statusBannerVisible,
     assistantId,
     onMaintenanceExited: handleMaintenanceExited,
   };

--- a/apps/web/src/domains/chat/components/composer-notices.tsx
+++ b/apps/web/src/domains/chat/components/composer-notices.tsx
@@ -83,6 +83,8 @@ export interface ComposerNoticesProps {
 
   /** True when the assistant is in maintenance/recovery mode. */
   showMaintenanceBanner: boolean;
+  /** True when this composer notice should render its own maintenance exit action. */
+  showMaintenanceExitAction?: boolean;
   /** Assistant id used by the maintenance banner's "exited" callback. */
   assistantId?: string | null;
   /** Invoked when the assistant exits maintenance mode. */
@@ -105,6 +107,7 @@ export function ComposerNotices({
   compactionCircuitOpenUntil,
   onCompactionCircuitExpired,
   showMaintenanceBanner,
+  showMaintenanceExitAction = true,
   assistantId,
   onMaintenanceExited,
 }: ComposerNoticesProps) {
@@ -177,6 +180,7 @@ export function ComposerNotices({
           <MaintenanceModeBanner
             assistantId={assistantId}
             onExited={onMaintenanceExited}
+            showExitAction={showMaintenanceExitAction}
           />
         </div>
       )}

--- a/apps/web/src/domains/chat/components/maintenance-mode-banner.tsx
+++ b/apps/web/src/domains/chat/components/maintenance-mode-banner.tsx
@@ -13,11 +13,13 @@ import { Notice } from "@vellumai/design-library/components/notice";
 interface MaintenanceModeBannerProps {
   assistantId: string;
   onExited: () => void;
+  showExitAction?: boolean;
 }
 
 export function MaintenanceModeBanner({
   assistantId,
   onExited,
+  showExitAction = true,
 }: MaintenanceModeBannerProps) {
   const [isExiting, setIsExiting] = useState(false);
   const [exitError, setExitError] = useState<string | null>(null);
@@ -86,26 +88,28 @@ export function MaintenanceModeBanner({
           </p>
         ) : null}
       </div>
-      {platformGate === "disabled" ? (
-        <Notice tone="info">
-          Log in to the Vellum platform to exit Recovery Mode.
-        </Notice>
-      ) : (
-        <Button
-          variant="primary"
-          size="compact"
-          leftIcon={
-            isExiting || isResolving ? (
-              <Loader2 className="animate-spin" />
-            ) : undefined
-          }
-          onClick={() => void handleResumeAssistant()}
-          disabled={isExiting || isResolving}
-          data-testid="resume-assistant-button"
-        >
-          Resume Assistant
-        </Button>
-      )}
+      {showExitAction ? (
+        platformGate === "disabled" ? (
+          <Notice tone="info">
+            Log in to the Vellum platform to exit Recovery Mode.
+          </Notice>
+        ) : (
+          <Button
+            variant="primary"
+            size="compact"
+            leftIcon={
+              isExiting || isResolving ? (
+                <Loader2 className="animate-spin" />
+              ) : undefined
+            }
+            onClick={() => void handleResumeAssistant()}
+            disabled={isExiting || isResolving}
+            data-testid="resume-assistant-button"
+          >
+            Resume Assistant
+          </Button>
+        )
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add a Resume Assistant action to the web status banner when operational status is maintenance mode.
- Call the existing maintenance-mode exit endpoint and refresh lifecycle/status state after success.
- Cover the new action in the status banner test.

## Original prompt
The user asked for the web frontend status banner to show an exit button when the assistant is in maintenance mode. The change makes that top-level banner actionable without disturbing the existing chat/settings recovery-mode flows.