### PR TITLE
feat(cli): inject VELLUM_DEVICE_ID into assistant container at hatch and backfill on replay

### DIFF
--- a/cli/src/__tests__/upgrade-replay-env.test.ts
+++ b/cli/src/__tests__/upgrade-replay-env.test.ts
@@ -130,6 +130,16 @@ describe("buildReplayState", () => {
     expect(state.extraGatewayEnv.VELLUM_DEVICE_ID).toBe("existing");
   });
 
+  test("backfills VELLUM_DEVICE_ID on assistant replay env when absent", () => {
+    const state = buildReplayState({}, {});
+    expect(state.extraAssistantEnv.VELLUM_DEVICE_ID).toBe("host-device-id");
+  });
+
+  test("captured assistant VELLUM_DEVICE_ID wins over host-derived id", () => {
+    const state = buildReplayState({ VELLUM_DEVICE_ID: "existing" }, {});
+    expect(state.extraAssistantEnv.VELLUM_DEVICE_ID).toBe("existing");
+  });
+
   test("plucks secrets from the captured envs", () => {
     const state = buildReplayState(
       { CES_SERVICE_TOKEN: "ces-token", ACTOR_TOKEN_SIGNING_KEY: "sign-key" },

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -1332,9 +1332,11 @@ export async function hatchDocker(
       extraAssistantEnv.VELLUM_DISABLE_PLATFORM =
         flagEnvVars.VELLUM_DISABLE_PLATFORM;
     }
+    const hostDeviceId = getOrCreateHostDeviceId();
+    extraAssistantEnv.VELLUM_DEVICE_ID = hostDeviceId;
     const extraGatewayEnv = {
       ...flagEnvVars,
-      VELLUM_DEVICE_ID: getOrCreateHostDeviceId(),
+      VELLUM_DEVICE_ID: hostDeviceId,
     };
     await startContainers(
       {

--- a/cli/src/lib/upgrade-lifecycle.ts
+++ b/cli/src/lib/upgrade-lifecycle.ts
@@ -219,8 +219,8 @@ interface ReplayState {
  * already-captured assistant/gateway envs. GUARDIAN_BOOTSTRAP_SECRET is only
  * set on the gateway; CES_SERVICE_TOKEN and ACTOR_TOKEN_SIGNING_KEY fall back
  * to fresh values for instances that predate them. VELLUM_DEVICE_ID is
- * backfilled from the host for gateways hatched before device-id injection
- * (captured value wins — it was itself host-derived).
+ * backfilled from the host on both containers for instances hatched before
+ * device-id injection (captured value wins — it was itself host-derived).
  */
 export function buildReplayState(
   capturedEnv: Record<string, string>,
@@ -229,13 +229,16 @@ export function buildReplayState(
   const extraGatewayEnv = buildReplayEnv(gatewayEnv, "gateway");
   extraGatewayEnv.VELLUM_DEVICE_ID ??= getOrCreateHostDeviceId();
 
+  const extraAssistantEnv = buildReplayEnv(capturedEnv, "assistant");
+  extraAssistantEnv.VELLUM_DEVICE_ID ??= getOrCreateHostDeviceId();
+
   return {
     bootstrapSecret: gatewayEnv["GUARDIAN_BOOTSTRAP_SECRET"],
     cesServiceToken:
       capturedEnv["CES_SERVICE_TOKEN"] || randomBytes(32).toString("hex"),
     signingKey:
       capturedEnv["ACTOR_TOKEN_SIGNING_KEY"] || randomBytes(32).toString("hex"),
-    extraAssistantEnv: buildReplayEnv(capturedEnv, "assistant"),
+    extraAssistantEnv,
     extraGatewayEnv,
   };
 }


### PR DESCRIPTION
## Summary
- hatchDocker computes the host device id once and sets it on both extraAssistantEnv and extraGatewayEnv
- buildReplayState backfills VELLUM_DEVICE_ID on the assistant replay env for fleets hatched before this change (captured value wins)
- --watch rebuilds covered via the shared extraAssistantEnv object

Part of plan: assistant-honor-vellum-device-id.md (PR 2 of 2)