### PR TITLE
fix: shell PATH detection robustness (caching, fish, dirs) and install flow guard

### DIFF
--- a/apps/macos/src/main/cli-path-flow.test.ts
+++ b/apps/macos/src/main/cli-path-flow.test.ts
@@ -54,9 +54,11 @@ mock.module("./cli-path-installer", () => ({
   getWrapperDir: () => "/Users/test/.local/bin",
 }));
 
-const { runInstallCliCommandFlow, runUninstallCliCommandFlow } = await import(
-  "./cli-path-flow"
-);
+const {
+  runInstallCliCommandFlow,
+  runUninstallCliCommandFlow,
+  isCliPathFlowInFlight,
+} = await import("./cli-path-flow");
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -261,5 +263,51 @@ describe("runUninstallCliCommandFlow", () => {
       "Failed to uninstall vellum command",
       "eperm",
     );
+  });
+});
+
+describe("flow re-entrancy guard", () => {
+  // Parks the install flow at the (unbounded) CLI download step.
+  const parkInstallFlow = () => {
+    let release!: () => void;
+    ensureCliInstalledMock.mockImplementation(
+      () => new Promise<void>((resolve) => { release = resolve; }),
+    );
+    const flow = runInstallCliCommandFlow();
+    return { flow, release: () => release() };
+  };
+
+  test("a second install invocation during an in-flight flow is a no-op", async () => {
+    const { flow, release } = parkInstallFlow();
+    expect(isCliPathFlowInFlight()).toBe(true);
+
+    await runInstallCliCommandFlow();
+    expect(installWrapperMock).toHaveBeenCalledTimes(1);
+
+    release();
+    await flow;
+    expect(isCliPathFlowInFlight()).toBe(false);
+    expect(installWrapperMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("uninstall is blocked while an install flow is in flight (shared guard)", async () => {
+    const { flow, release } = parkInstallFlow();
+
+    await runUninstallCliCommandFlow();
+    expect(uninstallWrapperMock).not.toHaveBeenCalled();
+    expect(showMessageBoxMock).not.toHaveBeenCalled();
+
+    release();
+    await flow;
+  });
+
+  test("the guard is released after a failing flow", async () => {
+    ensureCliInstalledMock.mockRejectedValue(new Error("offline"));
+    await runInstallCliCommandFlow();
+    expect(isCliPathFlowInFlight()).toBe(false);
+
+    ensureCliInstalledMock.mockResolvedValue(undefined);
+    await runInstallCliCommandFlow();
+    expect(installWrapperMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/macos/src/main/cli-path-flow.ts
+++ b/apps/macos/src/main/cli-path-flow.ts
@@ -15,6 +15,15 @@ import {
 
 const PATH_EXPORT_LINE = 'export PATH="$HOME/.local/bin:$PATH"';
 
+// Shared by both flows: they mutate the same wrapper file, and re-entrant
+// runs stack dialogs and overwrite each other's answers.
+let flowInFlight = false;
+
+/** Whether an install/uninstall flow is currently running. */
+export function isCliPathFlowInFlight(): boolean {
+  return flowInFlight;
+}
+
 const errorMessage = (err: unknown): string =>
   err instanceof Error ? err.message : "Unknown error";
 
@@ -75,6 +84,8 @@ async function showInstallSuccessDialog(): Promise<void> {
 }
 
 export async function runInstallCliCommandFlow(): Promise<void> {
+  if (flowInFlight) return;
+  flowInFlight = true;
   try {
     if (installWrapper({ overwriteForeign: false }) === "needs-overwrite-confirmation") {
       if (!(await confirmReplaceForeignFile())) return;
@@ -95,10 +106,14 @@ export async function runInstallCliCommandFlow(): Promise<void> {
     await showInstallSuccessDialog();
   } catch (err) {
     dialog.showErrorBox("Failed to install vellum command", errorMessage(err));
+  } finally {
+    flowInFlight = false;
   }
 }
 
 export async function runUninstallCliCommandFlow(): Promise<void> {
+  if (flowInFlight) return;
+  flowInFlight = true;
   try {
     const { response } = await dialog.showMessageBox({
       type: "warning",
@@ -132,5 +147,7 @@ export async function runUninstallCliCommandFlow(): Promise<void> {
     await dialog.showMessageBox(resultDialogs[uninstallWrapper()]);
   } catch (err) {
     dialog.showErrorBox("Failed to uninstall vellum command", errorMessage(err));
+  } finally {
+    flowInFlight = false;
   }
 }

--- a/apps/macos/src/main/cli-path-installer.test.ts
+++ b/apps/macos/src/main/cli-path-installer.test.ts
@@ -57,6 +57,7 @@ const enoent = () => {
 mock.module("node:fs", () => ({
   // Used by the cli-installer and shell-path modules evaluated as deps.
   accessSync: () => {},
+  statSync: () => ({ isFile: () => true }),
   constants: { X_OK: 1 },
   copyFileSync: () => {},
   existsSync: () => false,
@@ -94,9 +95,9 @@ mock.module("node:fs", () => ({
   },
 }));
 
-// Controlled per-test; reset in afterEach.
-let shellPathValue = "";
-let shellPathReliable = true;
+// Controlled per-test; reset in afterEach. Null mirrors "could not
+// reliably determine the login-shell PATH".
+let shellPathValue: string | null = "";
 let shellPathHits: string[] = [];
 let resolveShellPathCalls = 0;
 const findExecutablesCalls: Array<[string, string]> = [];
@@ -108,7 +109,7 @@ mock.module("./shell-path", () => ({
   ...realShellPath,
   resolveShellPath: async () => {
     resolveShellPathCalls += 1;
-    return { path: shellPathValue, reliable: shellPathReliable };
+    return shellPathValue;
   },
   findExecutablesInPath: (name: string, pathValue: string) => {
     findExecutablesCalls.push([name, pathValue]);
@@ -141,7 +142,6 @@ afterEach(() => {
   renameSyncCalls.length = 0;
   rmSyncCalls.length = 0;
   shellPathValue = "";
-  shellPathReliable = true;
   shellPathHits = [];
   resolveShellPathCalls = 0;
   findExecutablesCalls.length = 0;
@@ -433,12 +433,9 @@ describe("getCliPathInstallState", () => {
     });
   });
 
-  test("unreliable fallback PATH degrades to installed/inPath:false without shadow probing", async () => {
+  test("null shell PATH degrades to installed/inPath:false without shadow probing", async () => {
     readFileSyncResult = buildWrapperScript();
-    shellPathReliable = false;
-    // The buildInstallEnv fallback always prepends the wrapper dir and may
-    // contain shadow candidates — none of it is evidence of the real PATH.
-    shellPathValue = `${wrapperDir}:/opt/homebrew/bin:/usr/bin`;
+    shellPathValue = null;
     shellPathHits = ["/opt/homebrew/bin/vellum", wrapperPath];
 
     expect(await getCliPathInstallState()).toEqual({

--- a/apps/macos/src/main/cli-path-installer.ts
+++ b/apps/macos/src/main/cli-path-installer.ts
@@ -103,9 +103,7 @@ export type CliPathInstallState =
   | { kind: "not-installed" }
   | { kind: "foreign-file" }
   | { kind: "installed"; inPath: boolean }
-  // `inPath` is optional only so sibling-owned test fixtures keep compiling;
-  // getCliPathInstallState always populates it.
-  | { kind: "shadowed"; shadowedBy: string; inPath?: boolean };
+  | { kind: "shadowed"; shadowedBy: string; inPath: boolean };
 
 function realpathOr(p: string): string {
   try {
@@ -120,16 +118,16 @@ function realpathOr(p: string): string {
  * PATH. `shadowed` means another executable wins over our wrapper (e.g. an
  * npm-global install earlier in PATH); symlink/case variants that resolve
  * to the wrapper itself don't count. Never throws — when login-shell PATH
- * resolution fails, degrades to `installed` with `inPath: false` rather
- * than reporting states the fallback PATH can't actually attest to.
+ * resolution fails (null), degrades to `installed` with `inPath: false`
+ * rather than reporting states we can't actually attest to.
  */
 export async function getCliPathInstallState(): Promise<CliPathInstallState> {
   const ownership = readWrapperOwnership();
   if (ownership === "absent") return { kind: "not-installed" };
   if (ownership === "foreign") return { kind: "foreign-file" };
 
-  const { path: shellPath, reliable } = await resolveShellPath();
-  if (!reliable) return { kind: "installed", inPath: false };
+  const shellPath = await resolveShellPath();
+  if (shellPath === null) return { kind: "installed", inPath: false };
 
   const wrapperPath = getWrapperPath();
   const [firstHit] = findExecutablesInPath("vellum", shellPath);

--- a/apps/macos/src/main/command-palette-window.test.ts
+++ b/apps/macos/src/main/command-palette-window.test.ts
@@ -266,6 +266,7 @@ mock.module("./cli-path-installer", () => ({
 mock.module("./cli-path-flow", () => ({
   runInstallCliCommandFlow: async () => undefined,
   runUninstallCliCommandFlow: async () => undefined,
+  isCliPathFlowInFlight: () => false,
 }));
 
 const {

--- a/apps/macos/src/main/menu.test.ts
+++ b/apps/macos/src/main/menu.test.ts
@@ -9,6 +9,7 @@ import type { CliPathInstallState } from "./cli-path-installer";
 type TemplateItem = {
   label?: string;
   role?: string;
+  type?: string;
   enabled?: boolean;
   click?: () => void | Promise<void>;
   submenu?: TemplateItem[];
@@ -105,9 +106,11 @@ const runInstallCliCommandFlowMock = mock(async () => {
 const runUninstallCliCommandFlowMock = mock(async () => {
   callOrder.push("uninstall-flow");
 });
+const isCliPathFlowInFlightMock = mock(() => false);
 mock.module("./cli-path-flow", () => ({
   runInstallCliCommandFlow: runInstallCliCommandFlowMock,
   runUninstallCliCommandFlow: runUninstallCliCommandFlowMock,
+  isCliPathFlowInFlight: isCliPathFlowInFlightMock,
 }));
 
 const { installApplicationMenu, refreshCliPathMenuState } = await import(
@@ -152,8 +155,16 @@ beforeEach(async () => {
   buildFromTemplateMock.mockClear();
   setApplicationMenuMock.mockClear();
   getCliPathInstallStateMock.mockClear();
-  runInstallCliCommandFlowMock.mockClear();
-  runUninstallCliCommandFlowMock.mockClear();
+  runInstallCliCommandFlowMock.mockReset();
+  runInstallCliCommandFlowMock.mockImplementation(async () => {
+    callOrder.push("install-flow");
+  });
+  runUninstallCliCommandFlowMock.mockReset();
+  runUninstallCliCommandFlowMock.mockImplementation(async () => {
+    callOrder.push("uninstall-flow");
+  });
+  isCliPathFlowInFlightMock.mockReset();
+  isCliPathFlowInFlightMock.mockImplementation(() => false);
   callOrder.length = 0;
 });
 
@@ -194,6 +205,7 @@ describe("CLI path menu items", () => {
     await setStateAndRefresh({
       kind: "shadowed",
       shadowedBy: "/usr/local/bin/vellum",
+      inPath: true,
     });
     expect(appMenuLabels()).toContain(UNINSTALL_LABEL);
     expect(appMenuLabels()).not.toContain(INSTALL_LABEL);
@@ -214,8 +226,9 @@ describe("CLI path menu items", () => {
     expect(runInstallCliCommandFlowMock).toHaveBeenCalledTimes(1);
     expect(getCliPathInstallStateMock).toHaveBeenCalledTimes(1);
     expect(callOrder).toEqual(["install-flow", "detect"]);
-    // The rebuild reflects the new state: Install flipped to Uninstall.
-    expect(buildFromTemplateMock.mock.calls.length).toBe(buildsBefore + 1);
+    // Two rebuilds: the immediate in-flight render, then the final one
+    // reflecting the new state: Install flipped to Uninstall.
+    expect(buildFromTemplateMock.mock.calls.length).toBe(buildsBefore + 2);
     expect(appMenuLabels()).toContain(UNINSTALL_LABEL);
   });
 
@@ -233,8 +246,54 @@ describe("CLI path menu items", () => {
     expect(runUninstallCliCommandFlowMock).toHaveBeenCalledTimes(1);
     expect(getCliPathInstallStateMock).toHaveBeenCalledTimes(1);
     expect(callOrder).toEqual(["uninstall-flow", "detect"]);
-    expect(buildFromTemplateMock.mock.calls.length).toBe(buildsBefore + 1);
+    expect(buildFromTemplateMock.mock.calls.length).toBe(buildsBefore + 2);
     expect(appMenuLabels()).toContain(INSTALL_LABEL);
+  });
+
+  test("renders the CLI path item disabled while a flow is in flight", async () => {
+    isCliPathFlowInFlightMock.mockReturnValue(true);
+    await setStateAndRefresh({ kind: "not-installed" });
+    expect(appMenuItem(INSTALL_LABEL)?.enabled).toBe(false);
+  });
+
+  test("clicking Install immediately re-renders the item disabled, re-enabling after the flow", async () => {
+    await setStateAndRefresh({ kind: "not-installed" });
+    let release!: () => void;
+    runInstallCliCommandFlowMock.mockImplementation(() => {
+      isCliPathFlowInFlightMock.mockReturnValue(true);
+      return new Promise<void>((resolve) => {
+        release = resolve;
+      });
+    });
+
+    const clicking = appMenuItem(INSTALL_LABEL)?.click?.();
+    // The synchronous re-render shows the item disabled mid-flow.
+    expect(appMenuItem(INSTALL_LABEL)?.enabled).toBe(false);
+
+    isCliPathFlowInFlightMock.mockReturnValue(false);
+    release();
+    await clicking;
+    expect(appMenuItem(INSTALL_LABEL)?.enabled).toBe(true);
+  });
+});
+
+describe("app submenu separators", () => {
+  const hasAdjacentSeparators = (items: TemplateItem[]): boolean =>
+    items.some(
+      (item, i) =>
+        item.type === "separator" && items[i - 1]?.type === "separator",
+    );
+
+  test("no adjacent separators when CLI items are present", async () => {
+    await setStateAndRefresh({ kind: "installed", inPath: true });
+    expect(hasAdjacentSeparators(appSubmenu())).toBe(false);
+  });
+
+  test("no adjacent separators when CLI items are hidden (dev build)", async () => {
+    electronApp.isPackaged = false;
+    await refreshCliPathMenuState();
+    expect(appMenuLabels()).not.toContain(INSTALL_LABEL);
+    expect(hasAdjacentSeparators(appSubmenu())).toBe(false);
   });
 });
 

--- a/apps/macos/src/main/menu.ts
+++ b/apps/macos/src/main/menu.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { openAboutWindow } from "./about";
 import { checkForUpdates } from "./auto-update";
 import {
+  isCliPathFlowInFlight,
   runInstallCliCommandFlow,
   runUninstallCliCommandFlow,
 } from "./cli-path-flow";
@@ -55,8 +56,12 @@ const cliPathFlowItem = (
   flow: () => Promise<void>,
 ): MenuItemConstructorOptions => ({
   label,
+  enabled: !isCliPathFlowInFlight(),
   click: async () => {
-    await flow();
+    const flowDone = flow();
+    // Re-render immediately so the item is disabled while the flow runs.
+    applyMenu();
+    await flowDone;
     await refreshCliPathMenuState();
   },
 });
@@ -108,6 +113,7 @@ const buildTemplate = (): MenuItemConstructorOptions[] => {
   const isDev = !app.isPackaged;
   const chromeDevToolsEnabled = areChromeDevToolsEnabled();
   const developerMenuEnabled = isDeveloperMenuEnabled();
+  const cliItems = cliPathItems();
 
   const fileItem = (
     label: string,
@@ -146,8 +152,8 @@ const buildTemplate = (): MenuItemConstructorOptions[] => {
           click: () => dispatchMenuCommand({ kind: "openSettings" }),
         },
         { type: "separator" },
-        ...cliPathItems(),
-        { type: "separator" },
+        ...cliItems,
+        ...(cliItems.length > 0 ? [{ type: "separator" as const }] : []),
         { role: "services" },
         { type: "separator" },
         {
@@ -321,9 +327,7 @@ export const installApplicationMenu = (): void => {
   applyMenu();
 
   // Detect the vellum CLI install state asynchronously so menu setup never
-  // waits on (or breaks from) login-shell PATH resolution. Packaged-only:
-  // dev builds neither show the items nor spawn the detection shell.
-  if (app.isPackaged) {
-    void refreshCliPathMenuState();
-  }
+  // waits on (or breaks from) login-shell PATH resolution; packaged-only
+  // gating lives inside refreshCliPathMenuState.
+  void refreshCliPathMenuState();
 };

--- a/apps/macos/src/main/shell-path.test.ts
+++ b/apps/macos/src/main/shell-path.test.ts
@@ -1,41 +1,31 @@
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  setSystemTime,
+  test,
+} from "bun:test";
 
 import { FakeChild } from "./test-helpers";
 
 // --- Mocks ---
 // Must be installed before the `await import` of the module under test so
-// the mocked module graph is in place when `shell-path.ts` (and its
-// `cli-installer.ts` dependency) is evaluated. See `commands.test.ts` for
-// the ordering rationale.
-
-mock.module("electron", () => ({
-  app: {
-    getPath: () => "/mock/userData",
-    isPackaged: true,
-  },
-}));
-
-mock.module("./logger", () => ({
-  default: { info: () => {}, warn: () => {}, error: () => {} },
-}));
+// the mocked module graph is in place when `shell-path.ts` is evaluated.
+// See `commands.test.ts` for the ordering rationale.
 
 // Paths for which the mocked accessSync(X_OK) succeeds.
 const executablePaths = new Set<string>();
+// Paths whose stat (after following symlinks) reports a directory.
+const directoryPaths = new Set<string>();
 
 mock.module("node:fs", () => ({
   accessSync: (p: string) => {
     if (!executablePaths.has(p)) throw new Error(`EACCES: ${p}`);
   },
+  statSync: (p: string) => ({ isFile: () => !directoryPaths.has(p) }),
   constants: { X_OK: 1 },
-  // Used by cli-installer's buildInstallEnv (nvm detection).
-  chmodSync: () => {},
-  copyFileSync: () => {},
-  existsSync: () => false,
-  mkdirSync: () => {},
-  readdirSync: () => [],
-  renameSync: () => {},
-  rmSync: () => {},
-  writeFileSync: () => {},
 }));
 
 let lastChild: FakeChild;
@@ -55,7 +45,6 @@ const {
   splitPathEntries,
   _resetShellPathCache,
 } = await import("./shell-path");
-const { buildInstallEnv } = await import("./cli-installer");
 
 const originalShell = process.env.SHELL;
 
@@ -64,15 +53,21 @@ const PATH_SENTINEL = "__VELLUM_PATH_7f3a__";
 
 const wrap = (path: string) => `${PATH_SENTINEL}${path}${PATH_SENTINEL}`;
 
-const fallbackResult = () => ({
-  path: buildInstallEnv().PATH ?? "",
-  reliable: false,
+const POSIX_QUERY = `printf "${PATH_SENTINEL}%s${PATH_SENTINEL}" "$PATH"`;
+const FISH_QUERY = `printf "${PATH_SENTINEL}%s${PATH_SENTINEL}" (string join : $PATH)`;
+
+// Deterministic default regardless of the developer's real shell; individual
+// tests override.
+beforeEach(() => {
+  process.env.SHELL = "/bin/zsh";
 });
 
 afterEach(() => {
   spawnCalls.length = 0;
   executablePaths.clear();
+  directoryPaths.clear();
   _resetShellPathCache();
+  setSystemTime();
   if (originalShell === undefined) delete process.env.SHELL;
   else process.env.SHELL = originalShell;
 });
@@ -80,7 +75,7 @@ afterEach(() => {
 // --- resolveShellPath ---
 
 describe("resolveShellPath", () => {
-  test("returns the shell's stdout PATH as reliable, using $SHELL", async () => {
+  test("returns the shell's stdout PATH, using $SHELL with the POSIX query", async () => {
     process.env.SHELL = "/bin/bash";
 
     const promise = resolveShellPath();
@@ -90,16 +85,29 @@ describe("resolveShellPath", () => {
     );
     lastChild.emit("close", 0);
 
-    expect(await promise).toEqual({
-      path: "/Users/me/.local/bin:/usr/bin",
-      reliable: true,
-    });
+    expect(await promise).toBe("/Users/me/.local/bin:/usr/bin");
     expect(spawnCalls).toHaveLength(1);
     expect(spawnCalls[0][0]).toBe("/bin/bash");
-    expect(spawnCalls[0][1]).toEqual([
-      "-ilc",
-      `printf "${PATH_SENTINEL}%s${PATH_SENTINEL}" "$PATH"`,
-    ]);
+    expect(spawnCalls[0][1]).toEqual(["-ilc", POSIX_QUERY]);
+  });
+
+  test("uses a fish-native list join for fish shells", async () => {
+    process.env.SHELL = "/opt/homebrew/bin/fish";
+
+    const promise = resolveShellPath();
+    lastChild.stdout.emit("data", Buffer.from(wrap("/usr/local/bin:/usr/bin")));
+    lastChild.emit("close", 0);
+
+    expect(await promise).toBe("/usr/local/bin:/usr/bin");
+    expect(spawnCalls[0][0]).toBe("/opt/homebrew/bin/fish");
+    expect(spawnCalls[0][1]).toEqual(["-ilc", FISH_QUERY]);
+  });
+
+  test("returns null without spawning for unrecognized shells", async () => {
+    process.env.SHELL = "/usr/bin/tcsh";
+
+    expect(await resolveShellPath()).toBeNull();
+    expect(spawnCalls).toHaveLength(0);
   });
 
   test("ignores startup-file banner output before the sentinel pair", async () => {
@@ -110,18 +118,42 @@ describe("resolveShellPath", () => {
     );
     lastChild.emit("close", 0);
 
-    expect(await promise).toEqual({
-      path: "/usr/local/bin:/usr/bin",
-      reliable: true,
-    });
+    expect(await promise).toBe("/usr/local/bin:/usr/bin");
   });
 
-  test("falls back to unreliable buildInstallEnv PATH when sentinels are missing", async () => {
+  test("returns null when sentinels are missing", async () => {
     const promise = resolveShellPath();
     lastChild.stdout.emit("data", Buffer.from("banner only, no sentinel"));
     lastChild.emit("close", 0);
 
-    expect(await promise).toEqual(fallbackResult());
+    expect(await promise).toBeNull();
+  });
+
+  test("returns null for space-joined output that is not a plausible PATH", async () => {
+    const promise = resolveShellPath();
+    lastChild.stdout.emit(
+      "data",
+      Buffer.from(wrap("/usr/local/bin /usr/bin /bin")),
+    );
+    lastChild.emit("close", 0);
+
+    expect(await promise).toBeNull();
+  });
+
+  test("accepts a single absolute directory without separators", async () => {
+    const promise = resolveShellPath();
+    lastChild.stdout.emit("data", Buffer.from(wrap("/usr/bin")));
+    lastChild.emit("close", 0);
+
+    expect(await promise).toBe("/usr/bin");
+  });
+
+  test("returns null for a single relative token", async () => {
+    const promise = resolveShellPath();
+    lastChild.stdout.emit("data", Buffer.from(wrap("garbage")));
+    lastChild.emit("close", 0);
+
+    expect(await promise).toBeNull();
   });
 
   test("falls back to /bin/zsh when $SHELL is unset", async () => {
@@ -135,57 +167,86 @@ describe("resolveShellPath", () => {
     expect(spawnCalls[0][0]).toBe("/bin/zsh");
   });
 
-  test("falls back to unreliable buildInstallEnv PATH on non-zero exit", async () => {
+  test("returns null on non-zero exit", async () => {
     const promise = resolveShellPath();
     lastChild.stderr.emit("data", Buffer.from("zsh: bad rc file"));
     lastChild.emit("close", 1);
 
-    expect(await promise).toEqual(fallbackResult());
+    expect(await promise).toBeNull();
   });
 
-  test("falls back to unreliable buildInstallEnv PATH on empty output", async () => {
+  test("returns null on empty output", async () => {
     const promise = resolveShellPath();
     lastChild.emit("close", 0);
 
-    expect(await promise).toEqual(fallbackResult());
+    expect(await promise).toBeNull();
   });
 
-  test("falls back to unreliable buildInstallEnv PATH on spawn error", async () => {
+  test("returns null on spawn error", async () => {
     const promise = resolveShellPath();
     lastChild.emit("error", new Error("ENOENT"));
 
-    expect(await promise).toEqual(fallbackResult());
+    expect(await promise).toBeNull();
   });
 
-  test("kills the child and falls back on timeout", async () => {
+  test("kills the child and returns null on timeout", async () => {
     const promise = resolveShellPath(10);
 
-    expect(await promise).toEqual(fallbackResult());
+    expect(await promise).toBeNull();
     expect(lastChild.kill).toHaveBeenCalled();
   });
 
-  test("late close after timeout does not override the fallback", async () => {
+  test("late close after timeout does not override the null result", async () => {
     const promise = resolveShellPath(10);
     const result = await promise;
 
     lastChild.stdout.emit("data", Buffer.from(wrap("/late/bin")));
     lastChild.emit("close", 0);
 
-    expect(result).toEqual(fallbackResult());
-    expect(await resolveShellPath()).toEqual(result);
+    expect(result).toBeNull();
   });
 
-  test("caches the result; second call does not spawn again", async () => {
+  test("never caches null: the next call spawns a fresh query", async () => {
+    const failed = resolveShellPath();
+    lastChild.emit("close", 1);
+    expect(await failed).toBeNull();
+
+    const retry = resolveShellPath();
+    expect(spawnCalls).toHaveLength(2);
+    lastChild.stdout.emit("data", Buffer.from(wrap("/retry/bin")));
+    lastChild.emit("close", 0);
+    expect(await retry).toBe("/retry/bin");
+  });
+
+  test("caches a successful result; second call does not spawn again", async () => {
     const promise = resolveShellPath();
     lastChild.stdout.emit("data", Buffer.from(wrap("/cached/bin")));
     lastChild.emit("close", 0);
     await promise;
 
-    expect(await resolveShellPath()).toEqual({
-      path: "/cached/bin",
-      reliable: true,
-    });
+    expect(await resolveShellPath()).toBe("/cached/bin");
     expect(spawnCalls).toHaveLength(1);
+  });
+
+  test("re-queries after the cache TTL elapses", async () => {
+    const start = new Date("2026-01-01T00:00:00Z");
+    setSystemTime(start);
+
+    const first = resolveShellPath();
+    lastChild.stdout.emit("data", Buffer.from(wrap("/first/bin")));
+    lastChild.emit("close", 0);
+    expect(await first).toBe("/first/bin");
+
+    setSystemTime(new Date(start.getTime() + 29_000));
+    expect(await resolveShellPath()).toBe("/first/bin");
+    expect(spawnCalls).toHaveLength(1);
+
+    setSystemTime(new Date(start.getTime() + 31_000));
+    const second = resolveShellPath();
+    expect(spawnCalls).toHaveLength(2);
+    lastChild.stdout.emit("data", Buffer.from(wrap("/second/bin")));
+    lastChild.emit("close", 0);
+    expect(await second).toBe("/second/bin");
   });
 
   test("concurrent first calls share a single spawn", async () => {
@@ -196,8 +257,8 @@ describe("resolveShellPath", () => {
     lastChild.stdout.emit("data", Buffer.from(wrap("/shared/bin")));
     lastChild.emit("close", 0);
 
-    expect((await p1).path).toBe("/shared/bin");
-    expect((await p2).path).toBe("/shared/bin");
+    expect(await p1).toBe("/shared/bin");
+    expect(await p2).toBe("/shared/bin");
   });
 
   test("_resetShellPathCache clears the cache", async () => {
@@ -212,7 +273,7 @@ describe("resolveShellPath", () => {
     expect(spawnCalls).toHaveLength(2);
     lastChild.stdout.emit("data", Buffer.from(wrap("/second/bin")));
     lastChild.emit("close", 0);
-    expect((await p2).path).toBe("/second/bin");
+    expect(await p2).toBe("/second/bin");
   });
 });
 
@@ -257,6 +318,28 @@ describe("findExecutablesInPath", () => {
     executablePaths.add("/b/vellum");
 
     expect(findExecutablesInPath("vellum", "/a:/b")).toEqual(["/b/vellum"]);
+  });
+
+  test("skips directories even though they pass the X_OK probe", () => {
+    executablePaths.add("/a/vellum");
+    directoryPaths.add("/a/vellum");
+    executablePaths.add("/b/vellum");
+
+    expect(findExecutablesInPath("vellum", "/a:/b")).toEqual(["/b/vellum"]);
+  });
+
+  test("keeps symlinks that resolve to executable files (stat follows links)", () => {
+    // Mocked statSync models the followed target: a link to a file.
+    executablePaths.add("/a/vellum");
+
+    expect(findExecutablesInPath("vellum", "/a")).toEqual(["/a/vellum"]);
+  });
+
+  test("skips symlinks that resolve to directories", () => {
+    executablePaths.add("/a/vellum");
+    directoryPaths.add("/a/vellum"); // link target is a directory
+
+    expect(findExecutablesInPath("vellum", "/a")).toEqual([]);
   });
 
   test("skips empty and duplicate PATH entries", () => {

--- a/apps/macos/src/main/shell-path.ts
+++ b/apps/macos/src/main/shell-path.ts
@@ -1,73 +1,107 @@
 import { spawn } from "node:child_process";
-import { accessSync, constants } from "node:fs";
+import { accessSync, constants, statSync } from "node:fs";
 import path from "node:path";
 
-import { buildInstallEnv } from "./cli-installer";
-
 const SHELL_PATH_TIMEOUT_MS = 5_000;
+
+// Successful results are cached briefly so bursts within one flow share a
+// spawn, while menu-driven re-checks after the user edits their shell
+// profile still see fresh state. Failures (null) are never cached.
+const SHELL_PATH_CACHE_TTL_MS = 30_000;
 
 // Wraps the printf'd PATH so it can be isolated from any startup-file
 // output (banners, warnings) the interactive login shell writes first.
 const PATH_SENTINEL = "__VELLUM_PATH_7f3a__";
 
-export interface ShellPathResult {
-  path: string;
-  /**
-   * False when the login shell couldn't be queried and `path` is the
-   * synthesized `buildInstallEnv()` fallback — good enough for spawning
-   * processes, but NOT evidence of what's on the user's real PATH.
-   */
-  reliable: boolean;
+// Shells where the POSIX `printf ... "$PATH"` query is valid syntax.
+const POSIX_SHELLS = new Set(["zsh", "bash", "sh", "dash", "ksh"]);
+
+interface CacheEntry {
+  promise: Promise<string | null>;
+  expiresAt: number;
 }
 
-// Cached for the process lifetime; caching the promise also dedupes
-// concurrent first calls into a single shell spawn.
-let shellPathPromise: Promise<ShellPathResult> | null = null;
+let cache: CacheEntry | null = null;
 
 /** Reset the shell PATH cache. Exposed for testing only. */
 export function _resetShellPathCache(): void {
-  shellPathPromise = null;
-}
-
-function fallbackResult(): ShellPathResult {
-  return { path: buildInstallEnv().PATH ?? "", reliable: false };
+  cache = null;
 }
 
 /**
- * Resolve the user's interactive login shell PATH.
+ * Resolve the user's interactive login shell PATH, or null when it can't be
+ * reliably determined (unknown shell, spawn failure, timeout, non-zero
+ * exit, missing sentinel, implausible output).
  *
  * GUI apps launched from Finder inherit a minimal PATH that excludes
  * ~/.local/bin and package-manager bin dirs, so PATH checks (shadow
  * detection, "is ~/.local/bin in PATH") must use the shell's PATH rather
- * than `process.env.PATH`. Never rejects — on failure or timeout it falls
- * back to the PATH produced by `buildInstallEnv()`, marked unreliable.
+ * than `process.env.PATH`. Never rejects.
  */
 export function resolveShellPath(
   timeoutMs: number = SHELL_PATH_TIMEOUT_MS,
-): Promise<ShellPathResult> {
-  shellPathPromise ??= queryShellPath(timeoutMs);
-  return shellPathPromise;
+): Promise<string | null> {
+  if (cache && Date.now() < cache.expiresAt) return cache.promise;
+
+  const entry: CacheEntry = {
+    promise: queryShellPath(timeoutMs),
+    // Valid while in flight so concurrent callers share one spawn; the
+    // real TTL starts once the result arrives.
+    expiresAt: Infinity,
+  };
+  cache = entry;
+
+  void entry.promise.then((result) => {
+    if (cache !== entry) return;
+    if (result === null) cache = null;
+    else entry.expiresAt = Date.now() + SHELL_PATH_CACHE_TTL_MS;
+  });
+
+  return entry.promise;
 }
 
-function queryShellPath(timeoutMs: number): Promise<ShellPathResult> {
-  return new Promise((resolve) => {
-    const shell = process.env.SHELL ?? "/bin/zsh";
+// Argv for printing a sentinel-wrapped PATH in the given shell, or null for
+// shells whose syntax we don't know how to drive (tcsh, csh, nu, ...).
+function shellPathArgs(shell: string): string[] | null {
+  const name = path.basename(shell);
+  if (name === "fish") {
+    // fish's $PATH is a list that expands space-joined; join it explicitly.
+    return [
+      "-ilc",
+      `printf "${PATH_SENTINEL}%s${PATH_SENTINEL}" (string join : $PATH)`,
+    ];
+  }
+  if (POSIX_SHELLS.has(name)) {
+    return ["-ilc", `printf "${PATH_SENTINEL}%s${PATH_SENTINEL}" "$PATH"`];
+  }
+  return null;
+}
 
+// A plausible PATH has at least one separator, or is a single absolute
+// directory. Space-joined garbage (e.g. a misquoted list) has neither.
+function isPlausiblePath(value: string): boolean {
+  if (value.includes(":")) return true;
+  return value.startsWith("/") && !value.includes(" ");
+}
+
+function queryShellPath(timeoutMs: number): Promise<string | null> {
+  const shell = process.env.SHELL ?? "/bin/zsh";
+  const args = shellPathArgs(shell);
+  if (args === null) return Promise.resolve(null);
+
+  return new Promise((resolve) => {
     let child: ReturnType<typeof spawn>;
     try {
-      child = spawn(shell, [
-        "-ilc",
-        `printf "${PATH_SENTINEL}%s${PATH_SENTINEL}" "$PATH"`,
-      ]);
+      child = spawn(shell, args);
     } catch {
-      resolve(fallbackResult());
+      resolve(null);
       return;
     }
 
     let stdout = "";
     let settled = false;
 
-    const settle = (value: ShellPathResult) => {
+    const settle = (value: string | null) => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
@@ -76,18 +110,18 @@ function queryShellPath(timeoutMs: number): Promise<ShellPathResult> {
 
     const timer = setTimeout(() => {
       child.kill();
-      settle(fallbackResult());
+      settle(null);
     }, timeoutMs);
 
     child.stdout?.on("data", (data: Buffer) => {
       stdout += data.toString();
     });
 
-    child.on("error", () => settle(fallbackResult()));
+    child.on("error", () => settle(null));
 
     child.on("close", (code: number | null) => {
       const value = code === 0 ? extractSentinelValue(stdout) : null;
-      settle(value ? { path: value, reliable: true } : fallbackResult());
+      settle(value !== null && isPlausiblePath(value) ? value : null);
     });
   });
 }
@@ -134,9 +168,11 @@ export function findExecutablesInPath(
     const candidate = path.join(dir, name);
     try {
       accessSync(candidate, constants.X_OK);
-      results.push(candidate);
+      // X_OK passes for directories (search bit); require a regular file.
+      // statSync follows symlinks, so a link to an executable file counts.
+      if (statSync(candidate).isFile()) results.push(candidate);
     } catch {
-      // Missing or not executable.
+      // Missing, not executable, or unstattable.
     }
   }
 


### PR DESCRIPTION
## Summary
Round-2 review fixes for cli-path-installer.md:
- resolveShellPath returns string|null; null never cached; reliable results cached with short TTL so post-profile-edit re-checks see fresh state
- fish gets a fish-native PATH join; unknown shells return null; output sanity check
- In-flight guard + disabled menu item prevent re-entrant install/uninstall flows
- findExecutablesInPath requires isFile() — directories can no longer fake a shadow
- shadowed.inPath now required; menu isPackaged gating deduped; no adjacent separators