### PR TITLE
fix: add Repair vellum Command path after CLI runtime provisioning failure

### DIFF
--- a/apps/macos/src/main/cli-path-flow.test.ts
+++ b/apps/macos/src/main/cli-path-flow.test.ts
@@ -36,6 +36,7 @@ const getCliPathInstallStateMock = mock(
   async (): Promise<CliPathInstallState> => ({
     kind: "installed",
     inPath: true,
+    runtimeReady: true,
   }),
 );
 const installWrapperMock = mock(
@@ -81,7 +82,7 @@ beforeEach(() => {
 
   showMessageBoxMock.mockResolvedValue({ response: 0, checkboxChecked: false });
   ensureCliInstalledMock.mockResolvedValue(undefined);
-  setState({ kind: "installed", inPath: true });
+  setState({ kind: "installed", inPath: true, runtimeReady: true });
   installWrapperMock.mockReturnValue("installed");
   uninstallWrapperMock.mockReturnValue("removed");
 });
@@ -124,7 +125,7 @@ describe("runInstallCliCommandFlow", () => {
   });
 
   test("provisions the CLI runtime before showing success", async () => {
-    setState({ kind: "installed", inPath: true });
+    setState({ kind: "installed", inPath: true, runtimeReady: true });
 
     await runInstallCliCommandFlow();
 
@@ -134,7 +135,7 @@ describe("runInstallCliCommandFlow", () => {
     expect(lastDialog()?.message).toBe("Vellum CLI installed");
   });
 
-  test("CLI runtime download failure reports the wrapper as installed and retryable", async () => {
+  test("CLI runtime download failure points at the Repair menu item", async () => {
     ensureCliInstalledMock.mockRejectedValue(new Error("registry unreachable"));
 
     await runInstallCliCommandFlow();
@@ -145,11 +146,12 @@ describe("runInstallCliCommandFlow", () => {
     expect(title).toBe("Failed to install vellum command");
     expect(message).toContain(`The vellum command was installed at ${WRAPPER_PATH}`);
     expect(message).toContain("registry unreachable");
-    expect(message).toContain("retried");
+    expect(message).toContain('"Repair vellum Command"');
+    expect(message).toContain("retried automatically");
   });
 
   test("installed + inPath shows success without touching the clipboard", async () => {
-    setState({ kind: "installed", inPath: true });
+    setState({ kind: "installed", inPath: true, runtimeReady: true });
 
     await runInstallCliCommandFlow();
 
@@ -161,7 +163,7 @@ describe("runInstallCliCommandFlow", () => {
   });
 
   test("installed but not in PATH copies the export line to the clipboard", async () => {
-    setState({ kind: "installed", inPath: false });
+    setState({ kind: "installed", inPath: false, runtimeReady: true });
 
     await runInstallCliCommandFlow();
 
@@ -176,6 +178,7 @@ describe("runInstallCliCommandFlow", () => {
       kind: "shadowed",
       shadowedBy: "/opt/homebrew/bin/vellum",
       inPath: true,
+      runtimeReady: true,
     });
 
     await runInstallCliCommandFlow();
@@ -191,6 +194,7 @@ describe("runInstallCliCommandFlow", () => {
       kind: "shadowed",
       shadowedBy: "/opt/homebrew/bin/vellum",
       inPath: false,
+      runtimeReady: true,
     });
 
     await runInstallCliCommandFlow();

--- a/apps/macos/src/main/cli-path-flow.ts
+++ b/apps/macos/src/main/cli-path-flow.ts
@@ -97,9 +97,9 @@ export async function runInstallCliCommandFlow(): Promise<void> {
     } catch (err) {
       throw new Error(
         `The vellum command was installed at ${getWrapperPath()}, but ` +
-          `downloading the CLI runtime failed: ${errorMessage(err)}. It will be ` +
-          'retried the next time it\'s needed — or run "Install vellum ' +
-          'Command" again to retry now.',
+          `downloading the CLI runtime failed: ${errorMessage(err)}. Use ` +
+          '"Repair vellum Command" in the Vellum menu to retry now — or it ' +
+          "will be retried automatically the next time it's needed.",
       );
     }
 

--- a/apps/macos/src/main/cli-path-installer.test.ts
+++ b/apps/macos/src/main/cli-path-installer.test.ts
@@ -37,6 +37,8 @@ mock.module("node:os", () => ({
 
 // Track fs calls so tests can assert on them.
 let readFileSyncResult: string | Error | null = null;
+// Drives isCliInstalled() (existsSync on the CLI bin path) → runtimeReady.
+let cliBinExists = false;
 // "auto" mirrors readFileSync presence; "exists" forces a present entry
 // (e.g. a dangling symlink whose readFileSync still throws ENOENT).
 let lstatSyncBehavior: "auto" | "exists" = "auto";
@@ -60,7 +62,7 @@ mock.module("node:fs", () => ({
   statSync: () => ({ isFile: () => true }),
   constants: { X_OK: 1 },
   copyFileSync: () => {},
-  existsSync: () => false,
+  existsSync: () => cliBinExists,
   readdirSync: () => [],
   // Used by cli-path-installer.
   chmodSync: (p: string, mode: number) => {
@@ -134,6 +136,7 @@ const locatorPath = `${userDataPath}/cli/locator.sh`;
 
 afterEach(() => {
   readFileSyncResult = null;
+  cliBinExists = false;
   lstatSyncBehavior = "auto";
   for (const key of Object.keys(realpathMap)) delete realpathMap[key];
   mkdirSyncCalls.length = 0;
@@ -346,6 +349,7 @@ describe("getCliPathInstallState", () => {
     expect(await getCliPathInstallState()).toEqual({
       kind: "installed",
       inPath: false,
+      runtimeReady: false,
     });
     expect(findExecutablesCalls).toEqual([["vellum", shellPathValue]]);
   });
@@ -358,6 +362,7 @@ describe("getCliPathInstallState", () => {
     expect(await getCliPathInstallState()).toEqual({
       kind: "installed",
       inPath: true,
+      runtimeReady: false,
     });
   });
 
@@ -370,6 +375,7 @@ describe("getCliPathInstallState", () => {
       kind: "shadowed",
       shadowedBy: "/opt/homebrew/bin/vellum",
       inPath: true,
+      runtimeReady: false,
     });
   });
 
@@ -382,6 +388,7 @@ describe("getCliPathInstallState", () => {
       kind: "shadowed",
       shadowedBy: "/opt/homebrew/bin/vellum",
       inPath: false,
+      runtimeReady: false,
     });
   });
 
@@ -395,6 +402,7 @@ describe("getCliPathInstallState", () => {
     expect(await getCliPathInstallState()).toEqual({
       kind: "installed",
       inPath: true,
+      runtimeReady: false,
     });
   });
 
@@ -408,6 +416,7 @@ describe("getCliPathInstallState", () => {
       kind: "shadowed",
       shadowedBy: "/opt/homebrew/bin/vellum",
       inPath: true,
+      runtimeReady: false,
     });
   });
 
@@ -419,6 +428,7 @@ describe("getCliPathInstallState", () => {
     expect(await getCliPathInstallState()).toEqual({
       kind: "installed",
       inPath: true,
+      runtimeReady: false,
     });
   });
 
@@ -430,6 +440,34 @@ describe("getCliPathInstallState", () => {
     expect(await getCliPathInstallState()).toEqual({
       kind: "installed",
       inPath: true,
+      runtimeReady: false,
+    });
+  });
+
+  test("reports runtimeReady true when the CLI runtime is provisioned", async () => {
+    readFileSyncResult = buildWrapperScript();
+    cliBinExists = true;
+    shellPathValue = `${wrapperDir}:/usr/bin:/bin`;
+    shellPathHits = [wrapperPath];
+
+    expect(await getCliPathInstallState()).toEqual({
+      kind: "installed",
+      inPath: true,
+      runtimeReady: true,
+    });
+  });
+
+  test("shadowed also carries runtimeReady when the runtime is provisioned", async () => {
+    readFileSyncResult = buildWrapperScript();
+    cliBinExists = true;
+    shellPathValue = `/opt/homebrew/bin:${wrapperDir}`;
+    shellPathHits = ["/opt/homebrew/bin/vellum", wrapperPath];
+
+    expect(await getCliPathInstallState()).toEqual({
+      kind: "shadowed",
+      shadowedBy: "/opt/homebrew/bin/vellum",
+      inPath: true,
+      runtimeReady: true,
     });
   });
 
@@ -441,6 +479,7 @@ describe("getCliPathInstallState", () => {
     expect(await getCliPathInstallState()).toEqual({
       kind: "installed",
       inPath: false,
+      runtimeReady: false,
     });
     expect(findExecutablesCalls).toHaveLength(0);
   });

--- a/apps/macos/src/main/cli-path-installer.ts
+++ b/apps/macos/src/main/cli-path-installer.ts
@@ -8,7 +8,12 @@ import {
 import { homedir } from "node:os";
 import path from "node:path";
 
-import { getCliLocatorPath, shQuote, writeFileAtomicSync } from "./cli-installer";
+import {
+  getCliLocatorPath,
+  isCliInstalled,
+  shQuote,
+  writeFileAtomicSync,
+} from "./cli-installer";
 import {
   findExecutablesInPath,
   resolveShellPath,
@@ -102,8 +107,13 @@ export function installWrapper(opts: {
 export type CliPathInstallState =
   | { kind: "not-installed" }
   | { kind: "foreign-file" }
-  | { kind: "installed"; inPath: boolean }
-  | { kind: "shadowed"; shadowedBy: string; inPath: boolean };
+  | { kind: "installed"; inPath: boolean; runtimeReady: boolean }
+  | {
+      kind: "shadowed";
+      shadowedBy: string;
+      inPath: boolean;
+      runtimeReady: boolean;
+    };
 
 function realpathOr(p: string): string {
   try {
@@ -120,14 +130,20 @@ function realpathOr(p: string): string {
  * to the wrapper itself don't count. Never throws — when login-shell PATH
  * resolution fails (null), degrades to `installed` with `inPath: false`
  * rather than reporting states we can't actually attest to.
+ *
+ * `runtimeReady` reports whether the pinned CLI runtime is provisioned; when
+ * false the wrapper exists but can't run, and the menu offers a repair path.
  */
 export async function getCliPathInstallState(): Promise<CliPathInstallState> {
   const ownership = readWrapperOwnership();
   if (ownership === "absent") return { kind: "not-installed" };
   if (ownership === "foreign") return { kind: "foreign-file" };
 
+  const runtimeReady = isCliInstalled();
   const shellPath = await resolveShellPath();
-  if (shellPath === null) return { kind: "installed", inPath: false };
+  if (shellPath === null) {
+    return { kind: "installed", inPath: false, runtimeReady };
+  }
 
   const wrapperPath = getWrapperPath();
   const [firstHit] = findExecutablesInPath("vellum", shellPath);
@@ -139,9 +155,9 @@ export async function getCliPathInstallState(): Promise<CliPathInstallState> {
     firstHitIsWrapper || splitPathEntries(shellPath).includes(getWrapperDir());
 
   if (firstHit !== undefined && !firstHitIsWrapper) {
-    return { kind: "shadowed", shadowedBy: firstHit, inPath };
+    return { kind: "shadowed", shadowedBy: firstHit, inPath, runtimeReady };
   }
-  return { kind: "installed", inPath };
+  return { kind: "installed", inPath, runtimeReady };
 }
 
 /** Remove the wrapper, but only if it's one we installed. */

--- a/apps/macos/src/main/menu.test.ts
+++ b/apps/macos/src/main/menu.test.ts
@@ -140,6 +140,7 @@ const setStateAndRefresh = async (state: CliPathInstallState) => {
 };
 
 const INSTALL_LABEL = "Install vellum Command…";
+const REPAIR_LABEL = "Repair vellum Command…";
 const UNINSTALL_LABEL = "Uninstall vellum Command";
 const SHADOWED_LABEL = "⚠ vellum is shadowed by another install";
 
@@ -195,10 +196,52 @@ describe("CLI path menu items", () => {
   });
 
   test("shows Uninstall when installed, without the shadowed indicator", async () => {
-    await setStateAndRefresh({ kind: "installed", inPath: true });
+    await setStateAndRefresh({ kind: "installed", inPath: true, runtimeReady: true });
     expect(appMenuLabels()).toContain(UNINSTALL_LABEL);
     expect(appMenuLabels()).not.toContain(INSTALL_LABEL);
+    expect(appMenuLabels()).not.toContain(REPAIR_LABEL);
     expect(appMenuLabels()).not.toContain(SHADOWED_LABEL);
+  });
+
+  test("shows Repair alongside Uninstall when the runtime is missing", async () => {
+    await setStateAndRefresh({
+      kind: "installed",
+      inPath: true,
+      runtimeReady: false,
+    });
+    expect(appMenuLabels()).toContain(REPAIR_LABEL);
+    expect(appMenuLabels()).toContain(UNINSTALL_LABEL);
+    expect(appMenuLabels()).not.toContain(INSTALL_LABEL);
+  });
+
+  test("shows Repair when shadowed with a missing runtime", async () => {
+    await setStateAndRefresh({
+      kind: "shadowed",
+      shadowedBy: "/usr/local/bin/vellum",
+      inPath: true,
+      runtimeReady: false,
+    });
+    expect(appMenuLabels()).toContain(REPAIR_LABEL);
+    expect(appMenuLabels()).toContain(UNINSTALL_LABEL);
+  });
+
+  test("clicking Repair runs the install flow, then Repair disappears once the runtime is ready", async () => {
+    await setStateAndRefresh({
+      kind: "installed",
+      inPath: true,
+      runtimeReady: false,
+    });
+    getCliPathInstallStateMock.mockResolvedValue({
+      kind: "installed",
+      inPath: true,
+      runtimeReady: true,
+    });
+
+    await appMenuItem(REPAIR_LABEL)?.click?.();
+
+    expect(runInstallCliCommandFlowMock).toHaveBeenCalledTimes(1);
+    expect(appMenuLabels()).not.toContain(REPAIR_LABEL);
+    expect(appMenuLabels()).toContain(UNINSTALL_LABEL);
   });
 
   test("shows Uninstall plus a disabled shadowed indicator when shadowed", async () => {
@@ -206,6 +249,7 @@ describe("CLI path menu items", () => {
       kind: "shadowed",
       shadowedBy: "/usr/local/bin/vellum",
       inPath: true,
+      runtimeReady: true,
     });
     expect(appMenuLabels()).toContain(UNINSTALL_LABEL);
     expect(appMenuLabels()).not.toContain(INSTALL_LABEL);
@@ -219,7 +263,7 @@ describe("CLI path menu items", () => {
 
     getCliPathInstallStateMock.mockImplementation(async () => {
       callOrder.push("detect");
-      return { kind: "installed", inPath: true };
+      return { kind: "installed", inPath: true, runtimeReady: true };
     });
     await appMenuItem(INSTALL_LABEL)?.click?.();
 
@@ -233,7 +277,7 @@ describe("CLI path menu items", () => {
   });
 
   test("clicking Uninstall runs the flow, then refreshes state and rebuilds", async () => {
-    await setStateAndRefresh({ kind: "installed", inPath: true });
+    await setStateAndRefresh({ kind: "installed", inPath: true, runtimeReady: true });
     getCliPathInstallStateMock.mockClear();
     const buildsBefore = buildFromTemplateMock.mock.calls.length;
 
@@ -285,7 +329,7 @@ describe("app submenu separators", () => {
     );
 
   test("no adjacent separators when CLI items are present", async () => {
-    await setStateAndRefresh({ kind: "installed", inPath: true });
+    await setStateAndRefresh({ kind: "installed", inPath: true, runtimeReady: true });
     expect(hasAdjacentSeparators(appSubmenu())).toBe(false);
   });
 
@@ -307,7 +351,7 @@ describe("CLI path menu items in unpackaged builds", () => {
   });
 
   test("hides Uninstall even when a prior detection found an install", async () => {
-    await setStateAndRefresh({ kind: "installed", inPath: true });
+    await setStateAndRefresh({ kind: "installed", inPath: true, runtimeReady: true });
     expect(appMenuLabels()).toContain(UNINSTALL_LABEL);
 
     electronApp.isPackaged = false;

--- a/apps/macos/src/main/menu.ts
+++ b/apps/macos/src/main/menu.ts
@@ -69,15 +69,25 @@ const cliPathFlowItem = (
 const cliPathItems = (): MenuItemConstructorOptions[] => {
   // Only packaged builds manage the shared ~/.local/bin/vellum wrapper.
   if (!app.isPackaged) return [];
-  const kind = cliPathState?.kind;
-  if (kind === "installed" || kind === "shadowed") {
+  const cliState = cliPathState;
+  if (cliState?.kind === "installed" || cliState?.kind === "shadowed") {
     return [
-      ...(kind === "shadowed"
+      ...(cliState.kind === "shadowed"
         ? [
             {
               label: "⚠ vellum is shadowed by another install",
               enabled: false,
             },
+          ]
+        : []),
+      // Wrapper exists but the CLI runtime never provisioned; the install
+      // flow is idempotent, so re-running it doubles as repair.
+      ...(!cliState.runtimeReady
+        ? [
+            cliPathFlowItem(
+              "Repair vellum Command\u2026",
+              runInstallCliCommandFlow,
+            ),
           ]
         : []),
       cliPathFlowItem("Uninstall vellum Command", runUninstallCliCommandFlow),


### PR DESCRIPTION
## Summary
Fixes the install-retry dead end (Codex P2 on #34377): when the wrapper exists but the CLI runtime failed to provision, the menu now offers Repair vellum Command… alongside Uninstall, the state object carries runtimeReady, and the provisioning-failure dialog copy points at an item that actually exists.