### PR TITLE
CLI PATH Installer — vellum wrapper + locator (LUM-1986)

### DIFF
--- a/apps/macos/src/main/bundle-flow.test.ts
+++ b/apps/macos/src/main/bundle-flow.test.ts
@@ -39,11 +39,18 @@ const getGuardianAccessTokenMock = mock(
   async () => ({ ok: true as const, accessToken: "fake-token" }),
 );
 
+// Full `@vellumai/local-mode` surface so the real `./local-mode` (imported by
+// bundle-flow for resolveCliInvocation) links cleanly.
 mock.module("@vellumai/local-mode", () => ({
   getLockfileData: getLockfileDataMock,
   resolveLockfilePaths: resolveLockfilePathsMock,
   resolveConfigDir: resolveConfigDirMock,
   getGuardianAccessToken: getGuardianAccessTokenMock,
+  replacePlatformAssistants: mock(() => ({ ok: false, error: "unused" })),
+  upsertLockfileAssistant: mock(() => ({ ok: false, error: "unused" })),
+  runHatch: mock(async () => ({ ok: false, error: "unused" })),
+  runRetire: mock(async () => ({ ok: false, error: "unused" })),
+  runWake: mock(async () => ({ ok: false, error: "unused" })),
 }));
 
 const ensureCliInstalledMock = mock(async () => undefined);
@@ -93,9 +100,22 @@ mock.module("./bundle-window", () => ({
   openBundleWindow: openBundleWindowMock,
 }));
 
+// Full `./app-config` surface so this mock — which leaks into co-run test
+// files via the global module registry — doesn't break sibling modules
+// (notably `./app-origin`, loaded via the real `./local-mode` → `./ipc`).
 mock.module("./app-config", () => ({
+  APP_PROTOCOL: "app",
+  APP_HOST: "vellum.ai",
+  VELLUMAPP_PROTOCOL: "vellumapp",
   BUNDLES_DIR_NAME: "bundles",
+  RENDERER_BASE_PROD: "app://vellum.ai/assistant",
+  getDevRendererBase: () => "http://localhost:5173",
+  getRendererRootUrl: () => "app://vellum.ai/assistant",
 }));
+
+// resolveCliInvocation (via the real `./local-mode`) honors this override;
+// clear it so packaged-path assertions are deterministic.
+delete process.env.VELLUM_CLI_PATH;
 
 const { handleBundleFile, resolveActiveGateway, installBundleFlow } =
   await import("./bundle-flow");
@@ -300,8 +320,6 @@ describe("handleBundleFile", () => {
 
     await handleBundleFile("/tmp/test.vellum");
 
-    // isCliInstalled() is mocked true; routing through ensureCliInstalled
-    // keeps the PATH-wrapper locator fresh on the installed path.
     expect(ensureCliInstalledMock).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/macos/src/main/bundle-flow.test.ts
+++ b/apps/macos/src/main/bundle-flow.test.ts
@@ -46,11 +46,13 @@ mock.module("@vellumai/local-mode", () => ({
   getGuardianAccessToken: getGuardianAccessTokenMock,
 }));
 
+const ensureCliInstalledMock = mock(async () => undefined);
+
 mock.module("./cli-installer", () => ({
   isCliInstalled: () => true,
   getBundledBunPath: () => "/fake/bun",
   getCliBinPath: () => "/fake/cli",
-  ensureCliInstalled: async () => {},
+  ensureCliInstalled: ensureCliInstalledMock,
 }));
 
 const openBundleConfirmationMock = mock(
@@ -139,6 +141,7 @@ beforeEach(() => {
   installBundleConfirmationMock.mockClear();
   unpackBundleMock.mockClear();
   openBundleWindowMock.mockClear();
+  ensureCliInstalledMock.mockClear();
 
   getLockfileDataMock.mockReturnValue({ ok: false, status: 500 });
   openBundleConfirmationMock.mockResolvedValue(true);
@@ -290,6 +293,16 @@ describe("handleBundleFile", () => {
     const opts = fetchCall?.[1] as RequestInit | undefined;
     const headers = opts?.headers as Record<string, string> | undefined;
     expect(headers?.["Authorization"]).toBe("Bearer fake-token");
+  });
+
+  test("refreshes the CLI locator via ensureCliInstalled even when already installed", async () => {
+    getLockfileDataMock.mockReturnValue(makeLockfileWithPort(9000));
+
+    await handleBundleFile("/tmp/test.vellum");
+
+    // isCliInstalled() is mocked true; routing through ensureCliInstalled
+    // keeps the PATH-wrapper locator fresh on the installed path.
+    expect(ensureCliInstalledMock).toHaveBeenCalledTimes(1);
   });
 
   test("success flow: scans, confirms, unpacks, opens window", async () => {

--- a/apps/macos/src/main/bundle-flow.ts
+++ b/apps/macos/src/main/bundle-flow.ts
@@ -14,15 +14,10 @@ import {
   getLockfileData,
   resolveConfigDir,
   resolveLockfilePaths,
-  type CliInvocation,
 } from "@vellumai/local-mode";
 
 import { BUNDLES_DIR_NAME } from "./app-config";
-import {
-  ensureCliInstalled,
-  getBundledBunPath,
-  getCliBinPath,
-} from "./cli-installer";
+import { resolveCliInvocation } from "./local-mode";
 import { openBundleConfirmation, installBundleConfirmation } from "./bundle-confirmation";
 import { unpackBundle, type BundleScanData } from "./bundle-manager";
 import { openBundleWindow } from "./bundle-window";
@@ -43,20 +38,6 @@ export function resolveActiveGateway(): ActiveGateway | null {
   if (!entry?.resources?.gatewayPort) return null;
 
   return { assistantId: entry.assistantId, port: entry.resources.gatewayPort };
-}
-
-async function resolveCliInvocation(): Promise<CliInvocation> {
-  if (!app.isPackaged) {
-    const repoRoot = path.resolve(app.getAppPath(), "..", "..");
-    const { existsSync } = await import("node:fs");
-    const cliEntry = path.join(repoRoot, "cli", "src", "index.ts");
-    if (existsSync(cliEntry)) {
-      return { command: "bun", baseArgs: ["run", cliEntry] };
-    }
-  }
-  // Early-returns when already installed, refreshing the PATH-wrapper locator.
-  await ensureCliInstalled();
-  return { command: getBundledBunPath(), baseArgs: ["run", getCliBinPath()] };
 }
 
 async function acquireGatewayToken(assistantId: string): Promise<string | null> {

--- a/apps/macos/src/main/bundle-flow.ts
+++ b/apps/macos/src/main/bundle-flow.ts
@@ -22,7 +22,6 @@ import {
   ensureCliInstalled,
   getBundledBunPath,
   getCliBinPath,
-  isCliInstalled,
 } from "./cli-installer";
 import { openBundleConfirmation, installBundleConfirmation } from "./bundle-confirmation";
 import { unpackBundle, type BundleScanData } from "./bundle-manager";
@@ -55,9 +54,7 @@ async function resolveCliInvocation(): Promise<CliInvocation> {
       return { command: "bun", baseArgs: ["run", cliEntry] };
     }
   }
-  if (isCliInstalled()) {
-    return { command: getBundledBunPath(), baseArgs: ["run", getCliBinPath()] };
-  }
+  // Early-returns when already installed, refreshing the PATH-wrapper locator.
   await ensureCliInstalled();
   return { command: getBundledBunPath(), baseArgs: ["run", getCliBinPath()] };
 }

--- a/apps/macos/src/main/cli-installer.test.ts
+++ b/apps/macos/src/main/cli-installer.test.ts
@@ -24,15 +24,24 @@ mock.module("electron", () => ({
   },
 }));
 
+mock.module("./logger", () => ({
+  default: { info: () => {}, warn: () => {}, error: () => {} },
+}));
+
 // Track fs calls so tests can assert on them.
 // Per-path overrides for existsSync. Falls back to `existsSyncDefault`.
 let existsSyncDefault = false;
 const existsSyncByPath: Record<string, boolean> = {};
 let readdirSyncReturn: Array<{ name: string; isDirectory: () => boolean }> = [];
 let readdirSyncError: Error | null = null;
+let writeFileSyncError: Error | null = null;
 const mkdirSyncCalls: Array<[string, object]> = [];
 const rmSyncCalls: Array<[string, object]> = [];
 const copyFileSyncCalls: Array<[string, string]> = [];
+const writeFileSyncCalls: Array<[string, string]> = [];
+const renameSyncCalls: Array<[string, string]> = [];
+// Interleaved fs call log for ordering assertions across mocks.
+const fsCallOrder: string[] = [];
 
 mock.module("node:fs", () => ({
   copyFileSync: (src: string, dst: string) => {
@@ -47,8 +56,18 @@ mock.module("node:fs", () => ({
     if (readdirSyncError) throw readdirSyncError;
     return readdirSyncReturn;
   },
+  renameSync: (src: string, dst: string) => {
+    renameSyncCalls.push([src, dst]);
+    fsCallOrder.push(`renameSync:${dst}`);
+  },
   rmSync: (p: string, opts: object) => {
     rmSyncCalls.push([p, opts]);
+    fsCallOrder.push(`rmSync:${p}`);
+  },
+  writeFileSync: (p: string, content: string) => {
+    if (writeFileSyncError) throw writeFileSyncError;
+    writeFileSyncCalls.push([p, content]);
+    fsCallOrder.push(`writeFileSync:${p}`);
   },
 }));
 
@@ -71,6 +90,9 @@ const {
   getCliInstallDir,
   getCliBinPath,
   getBundledBunPath,
+  getCliLocatorPath,
+  shQuote,
+  writeCliLocator,
   buildInstallEnv,
   isCliInstalled,
   ensureCliInstalled,
@@ -80,15 +102,21 @@ const {
 
 const seedPkgPath = `${mockResourcesPath}/cli-lockfile/package.json`;
 const seedLockPath = `${mockResourcesPath}/cli-lockfile/bun.lock`;
+const locatorPath = `${userDataPath}/cli/locator.sh`;
+const cliBinPath = `${userDataPath}/cli/${PINNED_CLI_VERSION}/node_modules/.bin/vellum`;
 
 afterEach(() => {
   existsSyncDefault = false;
   for (const key of Object.keys(existsSyncByPath)) delete existsSyncByPath[key];
   readdirSyncReturn.length = 0;
   readdirSyncError = null;
+  writeFileSyncError = null;
   mkdirSyncCalls.length = 0;
   rmSyncCalls.length = 0;
   copyFileSyncCalls.length = 0;
+  writeFileSyncCalls.length = 0;
+  renameSyncCalls.length = 0;
+  fsCallOrder.length = 0;
   spawnCalls.length = 0;
   _resetInstallLock();
 });
@@ -117,6 +145,73 @@ describe("getBundledBunPath", () => {
   });
 });
 
+describe("getCliLocatorPath", () => {
+  test("returns <userData>/cli/locator.sh", () => {
+    expect(getCliLocatorPath()).toBe(locatorPath);
+  });
+});
+
+// --- shQuote ---
+
+describe("shQuote", () => {
+  test("wraps a plain value in single quotes", () => {
+    expect(shQuote("/usr/local/bin/bun")).toBe("'/usr/local/bin/bun'");
+  });
+
+  test("escapes embedded single quotes", () => {
+    expect(shQuote("/Users/o'brien/bin")).toBe("'/Users/o'\\''brien/bin'");
+  });
+});
+
+// --- writeCliLocator ---
+
+describe("writeCliLocator", () => {
+  test("writes the temp file then renames it over locator.sh", () => {
+    existsSyncByPath[cliBinPath] = true;
+
+    writeCliLocator();
+
+    expect(mkdirSyncCalls).toContainEqual([
+      `${userDataPath}/cli`,
+      { recursive: true },
+    ]);
+    expect(writeFileSyncCalls).toHaveLength(1);
+    expect(writeFileSyncCalls[0][0]).toBe(`${locatorPath}.tmp`);
+    expect(renameSyncCalls).toEqual([[`${locatorPath}.tmp`, locatorPath]]);
+  });
+
+  test("content contains both single-quoted paths", () => {
+    existsSyncByPath[cliBinPath] = true;
+
+    writeCliLocator();
+
+    const content = writeFileSyncCalls[0][1];
+    expect(content).toContain(`VELLUM_BUN='${mockResourcesPath}/bun'\n`);
+    expect(content).toContain(
+      `VELLUM_CLI_BIN='${userDataPath}/cli/${PINNED_CLI_VERSION}/node_modules/.bin/vellum'\n`,
+    );
+    expect(content.endsWith("\n")).toBe(true);
+    expect(content.startsWith("#!")).toBe(false);
+  });
+
+  test("swallows write errors", () => {
+    existsSyncByPath[cliBinPath] = true;
+    writeFileSyncError = new Error("EACCES: permission denied");
+
+    expect(() => writeCliLocator()).not.toThrow();
+    expect(renameSyncCalls).toHaveLength(0);
+  });
+
+  test("no-ops when the CLI bin is not installed", () => {
+    existsSyncDefault = false;
+
+    writeCliLocator();
+
+    expect(writeFileSyncCalls).toHaveLength(0);
+    expect(renameSyncCalls).toHaveLength(0);
+  });
+});
+
 // --- isCliInstalled ---
 
 describe("isCliInstalled", () => {
@@ -134,10 +229,20 @@ describe("isCliInstalled", () => {
 // --- ensureCliInstalled ---
 
 describe("ensureCliInstalled", () => {
-  test("skips install when already installed", async () => {
+  test("skips install but refreshes the locator when already installed", async () => {
     existsSyncDefault = true;
+
     await ensureCliInstalled();
+
     expect(spawnCalls).toHaveLength(0);
+    expect(renameSyncCalls).toEqual([[`${locatorPath}.tmp`, locatorPath]]);
+  });
+
+  test("a throwing locator write does not reject", async () => {
+    existsSyncDefault = true;
+    writeFileSyncError = new Error("EROFS: read-only file system");
+
+    await expect(ensureCliInstalled()).resolves.toBeUndefined();
   });
 
   test("falls back to bun add --ignore-scripts when no seed lockfile exists", async () => {
@@ -188,10 +293,37 @@ describe("ensureCliInstalled", () => {
     lastChild.emit("close", 0);
     await promise;
 
-    expect(mkdirSyncCalls).toHaveLength(1);
     const [dir, opts] = mkdirSyncCalls[0];
     expect(dir).toBe(`${userDataPath}/cli/${PINNED_CLI_VERSION}`);
     expect(opts).toEqual({ recursive: true });
+  });
+
+  test("fresh install writes the locator before cleanupOldVersions", async () => {
+    existsSyncDefault = false;
+    readdirSyncReturn = [dirEntry("0.8.5")];
+
+    const promise = ensureCliInstalled();
+    // Simulate bun creating the bin so the locator write proceeds.
+    existsSyncByPath[cliBinPath] = true;
+    lastChild.emit("close", 0);
+    await promise;
+
+    const renameIndex = fsCallOrder.indexOf(`renameSync:${locatorPath}`);
+    const rmIndex = fsCallOrder.indexOf(`rmSync:${userDataPath}/cli/0.8.5`);
+    expect(renameIndex).toBeGreaterThanOrEqual(0);
+    expect(rmIndex).toBeGreaterThanOrEqual(0);
+    expect(renameIndex).toBeLessThan(rmIndex);
+  });
+
+  test("a throwing locator write does not reject a fresh install", async () => {
+    existsSyncDefault = false;
+    writeFileSyncError = new Error("EACCES: permission denied");
+
+    const promise = ensureCliInstalled();
+    existsSyncByPath[cliBinPath] = true;
+    lastChild.emit("close", 0);
+
+    await expect(promise).resolves.toBeUndefined();
   });
 
   test("throws on non-zero exit code", async () => {

--- a/apps/macos/src/main/cli-installer.test.ts
+++ b/apps/macos/src/main/cli-installer.test.ts
@@ -35,6 +35,7 @@ const existsSyncByPath: Record<string, boolean> = {};
 let readdirSyncReturn: Array<{ name: string; isDirectory: () => boolean }> = [];
 let readdirSyncError: Error | null = null;
 let writeFileSyncError: Error | null = null;
+const chmodSyncCalls: Array<[string, number]> = [];
 const mkdirSyncCalls: Array<[string, object]> = [];
 const rmSyncCalls: Array<[string, object]> = [];
 const copyFileSyncCalls: Array<[string, string]> = [];
@@ -44,6 +45,10 @@ const renameSyncCalls: Array<[string, string]> = [];
 const fsCallOrder: string[] = [];
 
 mock.module("node:fs", () => ({
+  chmodSync: (p: string, mode: number) => {
+    chmodSyncCalls.push([p, mode]);
+    fsCallOrder.push(`chmodSync:${p}`);
+  },
   copyFileSync: (src: string, dst: string) => {
     copyFileSyncCalls.push([src, dst]);
   },
@@ -92,6 +97,7 @@ const {
   getBundledBunPath,
   getCliLocatorPath,
   shQuote,
+  writeFileAtomicSync,
   writeCliLocator,
   buildInstallEnv,
   isCliInstalled,
@@ -111,6 +117,7 @@ afterEach(() => {
   readdirSyncReturn.length = 0;
   readdirSyncError = null;
   writeFileSyncError = null;
+  chmodSyncCalls.length = 0;
   mkdirSyncCalls.length = 0;
   rmSyncCalls.length = 0;
   copyFileSyncCalls.length = 0;
@@ -160,6 +167,29 @@ describe("shQuote", () => {
 
   test("escapes embedded single quotes", () => {
     expect(shQuote("/Users/o'brien/bin")).toBe("'/Users/o'\\''brien/bin'");
+  });
+});
+
+// --- writeFileAtomicSync ---
+
+describe("writeFileAtomicSync", () => {
+  test("writes the temp file then renames it into place", () => {
+    writeFileAtomicSync("/x/file", "content");
+
+    expect(writeFileSyncCalls).toEqual([["/x/file.tmp", "content"]]);
+    expect(renameSyncCalls).toEqual([["/x/file.tmp", "/x/file"]]);
+    expect(chmodSyncCalls).toHaveLength(0);
+  });
+
+  test("chmods the temp file before the rename when a mode is given", () => {
+    writeFileAtomicSync("/x/file", "content", 0o755);
+
+    expect(chmodSyncCalls).toEqual([["/x/file.tmp", 0o755]]);
+    expect(fsCallOrder).toEqual([
+      "writeFileSync:/x/file.tmp",
+      "chmodSync:/x/file.tmp",
+      "renameSync:/x/file",
+    ]);
   });
 });
 

--- a/apps/macos/src/main/cli-installer.ts
+++ b/apps/macos/src/main/cli-installer.ts
@@ -1,6 +1,7 @@
 import { app } from "electron";
 import { spawn } from "node:child_process";
 import {
+  chmodSync,
   copyFileSync,
   existsSync,
   mkdirSync,
@@ -47,6 +48,18 @@ export function shQuote(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`;
 }
 
+/** Atomically write `content` via tmp-file + rename, optionally chmod'd. */
+export function writeFileAtomicSync(
+  filePath: string,
+  content: string,
+  mode?: number,
+): void {
+  const tmpPath = `${filePath}.tmp`;
+  writeFileSync(tmpPath, content);
+  if (mode !== undefined) chmodSync(tmpPath, mode);
+  renameSync(tmpPath, filePath);
+}
+
 /**
  * Atomically write the locator file the `~/.local/bin/vellum` wrapper
  * sources to find the bundled bun and the current CLI bin. Refreshed on
@@ -68,9 +81,7 @@ export function writeCliLocator(): void {
       `VELLUM_BUN=${shQuote(getBundledBunPath())}\n` +
       `VELLUM_CLI_BIN=${shQuote(getCliBinPath())}\n`;
 
-    const tmpPath = `${locatorPath}.tmp`;
-    writeFileSync(tmpPath, content);
-    renameSync(tmpPath, locatorPath);
+    writeFileAtomicSync(locatorPath, content);
   } catch (err) {
     log.error("[cli-installer] failed to write CLI locator:", err);
   }

--- a/apps/macos/src/main/cli-installer.ts
+++ b/apps/macos/src/main/cli-installer.ts
@@ -5,10 +5,14 @@ import {
   existsSync,
   mkdirSync,
   readdirSync,
+  renameSync,
   rmSync,
+  writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
+
+import log from "./logger";
 
 // Auto-stamped by create-release-branch workflow.
 export const PINNED_CLI_VERSION = "0.8.10";
@@ -31,6 +35,45 @@ export function getBundledBunPath(): string {
 /** Whether the pinned CLI version is already installed on disk. */
 export function isCliInstalled(): boolean {
   return existsSync(getCliBinPath());
+}
+
+/** Path to the shell-sourceable locator file consumed by the PATH wrapper. */
+export function getCliLocatorPath(): string {
+  return path.join(app.getPath("userData"), "cli", "locator.sh");
+}
+
+/** Single-quote a value for safe interpolation into a shell script. */
+export function shQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+/**
+ * Atomically write the locator file the `~/.local/bin/vellum` wrapper
+ * sources to find the bundled bun and the current CLI bin. Refreshed on
+ * every launch so app moves and version bumps self-heal. Non-fatal —
+ * failures are logged but never block app startup.
+ *
+ * No-ops when the pinned CLI bin isn't installed yet (e.g. first launch
+ * after a version bump) so the wrapper is never pointed at a missing binary.
+ */
+export function writeCliLocator(): void {
+  if (!isCliInstalled()) return;
+
+  try {
+    const locatorPath = getCliLocatorPath();
+    mkdirSync(path.dirname(locatorPath), { recursive: true });
+
+    const content =
+      "# Written by Vellum.app on every launch. Do not edit.\n" +
+      `VELLUM_BUN=${shQuote(getBundledBunPath())}\n` +
+      `VELLUM_CLI_BIN=${shQuote(getCliBinPath())}\n`;
+
+    const tmpPath = `${locatorPath}.tmp`;
+    writeFileSync(tmpPath, content);
+    renameSync(tmpPath, locatorPath);
+  } catch (err) {
+    log.error("[cli-installer] failed to write CLI locator:", err);
+  }
 }
 
 function findNvmNodeBinDir(home: string): string[] {
@@ -153,12 +196,16 @@ export function _resetInstallLock(): void {
  * lifecycle scripts are always suppressed via `--ignore-scripts`.
  */
 export async function ensureCliInstalled(): Promise<void> {
-  if (isCliInstalled()) return;
+  if (isCliInstalled()) {
+    writeCliLocator();
+    return;
+  }
 
   if (cliInstallPromise) return cliInstallPromise;
 
   cliInstallPromise = (async () => {
     await bunInstallCli();
+    writeCliLocator();
     cleanupOldVersions();
   })();
 

--- a/apps/macos/src/main/cli-path-flow.test.ts
+++ b/apps/macos/src/main/cli-path-flow.test.ts
@@ -36,6 +36,7 @@ const getCliPathInstallStateMock = mock(
   async (): Promise<CliPathInstallState> => ({
     kind: "installed",
     inPath: true,
+    runtimeReady: true,
   }),
 );
 const installWrapperMock = mock(
@@ -81,7 +82,7 @@ beforeEach(() => {
 
   showMessageBoxMock.mockResolvedValue({ response: 0, checkboxChecked: false });
   ensureCliInstalledMock.mockResolvedValue(undefined);
-  setState({ kind: "installed", inPath: true });
+  setState({ kind: "installed", inPath: true, runtimeReady: true });
   installWrapperMock.mockReturnValue("installed");
   uninstallWrapperMock.mockReturnValue("removed");
 });
@@ -124,7 +125,7 @@ describe("runInstallCliCommandFlow", () => {
   });
 
   test("provisions the CLI runtime before showing success", async () => {
-    setState({ kind: "installed", inPath: true });
+    setState({ kind: "installed", inPath: true, runtimeReady: true });
 
     await runInstallCliCommandFlow();
 
@@ -134,7 +135,7 @@ describe("runInstallCliCommandFlow", () => {
     expect(lastDialog()?.message).toBe("Vellum CLI installed");
   });
 
-  test("CLI runtime download failure reports the wrapper as installed and retryable", async () => {
+  test("CLI runtime download failure points at the Repair menu item", async () => {
     ensureCliInstalledMock.mockRejectedValue(new Error("registry unreachable"));
 
     await runInstallCliCommandFlow();
@@ -145,11 +146,12 @@ describe("runInstallCliCommandFlow", () => {
     expect(title).toBe("Failed to install vellum command");
     expect(message).toContain(`The vellum command was installed at ${WRAPPER_PATH}`);
     expect(message).toContain("registry unreachable");
-    expect(message).toContain("retried");
+    expect(message).toContain('"Repair vellum Command"');
+    expect(message).toContain("retried automatically");
   });
 
   test("installed + inPath shows success without touching the clipboard", async () => {
-    setState({ kind: "installed", inPath: true });
+    setState({ kind: "installed", inPath: true, runtimeReady: true });
 
     await runInstallCliCommandFlow();
 
@@ -161,7 +163,7 @@ describe("runInstallCliCommandFlow", () => {
   });
 
   test("installed but not in PATH copies the export line to the clipboard", async () => {
-    setState({ kind: "installed", inPath: false });
+    setState({ kind: "installed", inPath: false, runtimeReady: true });
 
     await runInstallCliCommandFlow();
 
@@ -176,6 +178,7 @@ describe("runInstallCliCommandFlow", () => {
       kind: "shadowed",
       shadowedBy: "/opt/homebrew/bin/vellum",
       inPath: true,
+      runtimeReady: true,
     });
 
     await runInstallCliCommandFlow();
@@ -191,6 +194,7 @@ describe("runInstallCliCommandFlow", () => {
       kind: "shadowed",
       shadowedBy: "/opt/homebrew/bin/vellum",
       inPath: false,
+      runtimeReady: true,
     });
 
     await runInstallCliCommandFlow();

--- a/apps/macos/src/main/cli-path-flow.test.ts
+++ b/apps/macos/src/main/cli-path-flow.test.ts
@@ -54,9 +54,11 @@ mock.module("./cli-path-installer", () => ({
   getWrapperDir: () => "/Users/test/.local/bin",
 }));
 
-const { runInstallCliCommandFlow, runUninstallCliCommandFlow } = await import(
-  "./cli-path-flow"
-);
+const {
+  runInstallCliCommandFlow,
+  runUninstallCliCommandFlow,
+  isCliPathFlowInFlight,
+} = await import("./cli-path-flow");
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -261,5 +263,51 @@ describe("runUninstallCliCommandFlow", () => {
       "Failed to uninstall vellum command",
       "eperm",
     );
+  });
+});
+
+describe("flow re-entrancy guard", () => {
+  // Parks the install flow at the (unbounded) CLI download step.
+  const parkInstallFlow = () => {
+    let release!: () => void;
+    ensureCliInstalledMock.mockImplementation(
+      () => new Promise<void>((resolve) => { release = resolve; }),
+    );
+    const flow = runInstallCliCommandFlow();
+    return { flow, release: () => release() };
+  };
+
+  test("a second install invocation during an in-flight flow is a no-op", async () => {
+    const { flow, release } = parkInstallFlow();
+    expect(isCliPathFlowInFlight()).toBe(true);
+
+    await runInstallCliCommandFlow();
+    expect(installWrapperMock).toHaveBeenCalledTimes(1);
+
+    release();
+    await flow;
+    expect(isCliPathFlowInFlight()).toBe(false);
+    expect(installWrapperMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("uninstall is blocked while an install flow is in flight (shared guard)", async () => {
+    const { flow, release } = parkInstallFlow();
+
+    await runUninstallCliCommandFlow();
+    expect(uninstallWrapperMock).not.toHaveBeenCalled();
+    expect(showMessageBoxMock).not.toHaveBeenCalled();
+
+    release();
+    await flow;
+  });
+
+  test("the guard is released after a failing flow", async () => {
+    ensureCliInstalledMock.mockRejectedValue(new Error("offline"));
+    await runInstallCliCommandFlow();
+    expect(isCliPathFlowInFlight()).toBe(false);
+
+    ensureCliInstalledMock.mockResolvedValue(undefined);
+    await runInstallCliCommandFlow();
+    expect(installWrapperMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/macos/src/main/cli-path-flow.test.ts
+++ b/apps/macos/src/main/cli-path-flow.test.ts
@@ -8,6 +8,7 @@ import type { CliPathInstallState } from "./cli-path-installer";
 
 const WRAPPER_PATH = "/Users/test/.local/bin/vellum";
 const PATH_EXPORT_LINE = 'export PATH="$HOME/.local/bin:$PATH"';
+const FISH_ADD_PATH_LINE = 'fish_add_path "$HOME/.local/bin"';
 
 const showMessageBoxMock = mock(
   async (_opts: { message: string; detail?: string }) => ({
@@ -47,6 +48,12 @@ const uninstallWrapperMock = mock(
   (): "removed" | "not-ours" | "absent" => "removed",
 );
 
+const isFishShellMock = mock((): boolean => false);
+
+mock.module("./shell-path", () => ({
+  isFishShell: isFishShellMock,
+}));
+
 mock.module("./cli-path-installer", () => ({
   getCliPathInstallState: getCliPathInstallStateMock,
   installWrapper: installWrapperMock,
@@ -79,8 +86,10 @@ beforeEach(() => {
   getCliPathInstallStateMock.mockReset();
   installWrapperMock.mockReset();
   uninstallWrapperMock.mockReset();
+  isFishShellMock.mockReset();
 
   showMessageBoxMock.mockResolvedValue({ response: 0, checkboxChecked: false });
+  isFishShellMock.mockReturnValue(false);
   ensureCliInstalledMock.mockResolvedValue(undefined);
   setState({ kind: "installed", inPath: true, runtimeReady: true });
   installWrapperMock.mockReturnValue("installed");
@@ -173,6 +182,19 @@ describe("runInstallCliCommandFlow", () => {
     expect(lastDialog()?.detail).toContain(WRAPPER_PATH);
   });
 
+  test("installed but not in PATH copies fish_add_path for fish shells", async () => {
+    isFishShellMock.mockReturnValue(true);
+    setState({ kind: "installed", inPath: false, runtimeReady: true });
+
+    await runInstallCliCommandFlow();
+
+    expect(writeTextMock).toHaveBeenCalledTimes(1);
+    expect(writeTextMock).toHaveBeenCalledWith(FISH_ADD_PATH_LINE);
+    expect(lastDialog()?.detail).toContain("fish command");
+    expect(lastDialog()?.detail).toContain("copied to your clipboard");
+    expect(lastDialog()?.detail).not.toContain("shell profile");
+  });
+
   test("shadowed + inPath names the winning binary and the npm uninstall fix", async () => {
     setState({
       kind: "shadowed",
@@ -203,6 +225,23 @@ describe("runInstallCliCommandFlow", () => {
     expect(writeTextMock).toHaveBeenCalledWith(PATH_EXPORT_LINE);
     expect(lastDialog()?.detail).toContain("npm uninstall -g vellum");
     expect(lastDialog()?.detail).toContain("copied to your clipboard");
+  });
+
+  test("shadowed without PATH copies fish_add_path for fish shells", async () => {
+    isFishShellMock.mockReturnValue(true);
+    setState({
+      kind: "shadowed",
+      shadowedBy: "/opt/homebrew/bin/vellum",
+      inPath: false,
+      runtimeReady: true,
+    });
+
+    await runInstallCliCommandFlow();
+
+    expect(writeTextMock).toHaveBeenCalledTimes(1);
+    expect(writeTextMock).toHaveBeenCalledWith(FISH_ADD_PATH_LINE);
+    expect(lastDialog()?.detail).toContain("npm uninstall -g vellum");
+    expect(lastDialog()?.detail).toContain("fish command");
   });
 
   test("state check throwing surfaces via showErrorBox without rejecting", async () => {

--- a/apps/macos/src/main/cli-path-flow.test.ts
+++ b/apps/macos/src/main/cli-path-flow.test.ts
@@ -1,0 +1,218 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { CliPathInstallState } from "./cli-path-installer";
+
+// ---------------------------------------------------------------------------
+// Stubs and mocks
+// ---------------------------------------------------------------------------
+
+const WRAPPER_PATH = "/Users/test/.local/bin/vellum";
+const PATH_EXPORT_LINE = 'export PATH="$HOME/.local/bin:$PATH"';
+
+const showMessageBoxMock = mock(
+  async (_opts: { message: string; detail?: string }) => ({
+    response: 0,
+    checkboxChecked: false,
+  }),
+);
+const showErrorBoxMock = mock((_title: string, _content: string) => undefined);
+const writeTextMock = mock((_text: string) => undefined);
+
+mock.module("electron", () => ({
+  dialog: {
+    showMessageBox: showMessageBoxMock,
+    showErrorBox: showErrorBoxMock,
+  },
+  clipboard: { writeText: writeTextMock },
+}));
+
+const getCliPathInstallStateMock = mock(
+  async (): Promise<CliPathInstallState> => ({
+    kind: "installed",
+    inPath: true,
+  }),
+);
+const installWrapperMock = mock(
+  (_opts: { overwriteForeign: boolean }): "installed" | "needs-overwrite-confirmation" =>
+    "installed",
+);
+const uninstallWrapperMock = mock(
+  (): "removed" | "not-ours" | "absent" => "removed",
+);
+
+mock.module("./cli-path-installer", () => ({
+  getCliPathInstallState: getCliPathInstallStateMock,
+  installWrapper: installWrapperMock,
+  uninstallWrapper: uninstallWrapperMock,
+  getWrapperPath: () => WRAPPER_PATH,
+  getWrapperDir: () => "/Users/test/.local/bin",
+}));
+
+const { runInstallCliCommandFlow, runUninstallCliCommandFlow } = await import(
+  "./cli-path-flow"
+);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const setState = (state: CliPathInstallState) => {
+  getCliPathInstallStateMock.mockResolvedValue(state);
+};
+
+const lastDialog = () => showMessageBoxMock.mock.calls.at(-1)?.[0];
+
+beforeEach(() => {
+  showMessageBoxMock.mockReset();
+  showErrorBoxMock.mockClear();
+  writeTextMock.mockClear();
+  getCliPathInstallStateMock.mockReset();
+  installWrapperMock.mockReset();
+  uninstallWrapperMock.mockReset();
+
+  showMessageBoxMock.mockResolvedValue({ response: 0, checkboxChecked: false });
+  setState({ kind: "installed", inPath: true });
+  installWrapperMock.mockReturnValue("installed");
+  uninstallWrapperMock.mockReturnValue("removed");
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("runInstallCliCommandFlow", () => {
+  test("foreign file + Cancel leaves the file untouched", async () => {
+    setState({ kind: "foreign-file" });
+    showMessageBoxMock.mockResolvedValue({ response: 1, checkboxChecked: false });
+
+    await runInstallCliCommandFlow();
+
+    expect(showMessageBoxMock).toHaveBeenCalledTimes(1);
+    expect(showMessageBoxMock.mock.calls[0]?.[0]?.message).toBe(
+      "Replace existing vellum file?",
+    );
+    expect(installWrapperMock).not.toHaveBeenCalled();
+  });
+
+  test("foreign file + Replace installs with overwriteForeign", async () => {
+    getCliPathInstallStateMock
+      .mockResolvedValueOnce({ kind: "foreign-file" })
+      .mockResolvedValueOnce({ kind: "installed", inPath: true });
+
+    await runInstallCliCommandFlow();
+
+    expect(installWrapperMock).toHaveBeenCalledTimes(1);
+    expect(installWrapperMock).toHaveBeenCalledWith({ overwriteForeign: true });
+  });
+
+  test("installed + inPath shows success without touching the clipboard", async () => {
+    setState({ kind: "installed", inPath: true });
+
+    await runInstallCliCommandFlow();
+
+    expect(installWrapperMock).toHaveBeenCalledWith({ overwriteForeign: false });
+    expect(writeTextMock).not.toHaveBeenCalled();
+    expect(lastDialog()?.message).toBe("Vellum CLI installed");
+    expect(lastDialog()?.detail).toContain(WRAPPER_PATH);
+    expect(lastDialog()?.detail).toContain('run "vellum"');
+  });
+
+  test("installed but not in PATH copies the export line to the clipboard", async () => {
+    setState({ kind: "installed", inPath: false });
+
+    await runInstallCliCommandFlow();
+
+    expect(writeTextMock).toHaveBeenCalledTimes(1);
+    expect(writeTextMock).toHaveBeenCalledWith(PATH_EXPORT_LINE);
+    expect(lastDialog()?.detail).toContain("copied to your clipboard");
+    expect(lastDialog()?.detail).toContain(WRAPPER_PATH);
+  });
+
+  test("shadowed names the winning binary and the npm uninstall fix", async () => {
+    setState({ kind: "shadowed", shadowedBy: "/opt/homebrew/bin/vellum" });
+
+    await runInstallCliCommandFlow();
+
+    expect(writeTextMock).not.toHaveBeenCalled();
+    expect(lastDialog()?.detail).toContain("/opt/homebrew/bin/vellum");
+    expect(lastDialog()?.detail).toContain("npm uninstall -g vellum");
+  });
+
+  test("install race returning needs-overwrite-confirmation re-confirms once", async () => {
+    setState({ kind: "installed", inPath: true });
+    installWrapperMock
+      .mockReturnValueOnce("needs-overwrite-confirmation")
+      .mockReturnValueOnce("installed");
+
+    await runInstallCliCommandFlow();
+
+    expect(installWrapperMock).toHaveBeenCalledTimes(2);
+    expect(installWrapperMock.mock.calls[1]?.[0]).toEqual({
+      overwriteForeign: true,
+    });
+  });
+
+  test("state check throwing surfaces via showErrorBox without rejecting", async () => {
+    getCliPathInstallStateMock.mockRejectedValue(new Error("boom"));
+
+    await runInstallCliCommandFlow();
+
+    expect(showErrorBoxMock).toHaveBeenCalledTimes(1);
+    expect(showErrorBoxMock).toHaveBeenCalledWith(
+      "Failed to install vellum command",
+      "boom",
+    );
+  });
+});
+
+describe("runUninstallCliCommandFlow", () => {
+  test("Cancel skips uninstallWrapper", async () => {
+    showMessageBoxMock.mockResolvedValue({ response: 1, checkboxChecked: false });
+
+    await runUninstallCliCommandFlow();
+
+    expect(showMessageBoxMock.mock.calls[0]?.[0]?.message).toBe(
+      "Uninstall vellum command?",
+    );
+    expect(uninstallWrapperMock).not.toHaveBeenCalled();
+  });
+
+  test("removed shows the removal confirmation", async () => {
+    uninstallWrapperMock.mockReturnValue("removed");
+
+    await runUninstallCliCommandFlow();
+
+    expect(uninstallWrapperMock).toHaveBeenCalledTimes(1);
+    expect(lastDialog()?.detail).toBe("The vellum command was removed.");
+  });
+
+  test("not-ours refuses to remove a foreign file", async () => {
+    uninstallWrapperMock.mockReturnValue("not-ours");
+
+    await runUninstallCliCommandFlow();
+
+    expect(lastDialog()?.detail).toContain("wasn't installed by Vellum");
+    expect(lastDialog()?.detail).toContain("not removing it");
+  });
+
+  test("absent reports nothing to uninstall", async () => {
+    uninstallWrapperMock.mockReturnValue("absent");
+
+    await runUninstallCliCommandFlow();
+
+    expect(lastDialog()?.detail).toBe("The vellum command is not installed.");
+  });
+
+  test("uninstallWrapper throwing surfaces via showErrorBox", async () => {
+    uninstallWrapperMock.mockImplementation(() => {
+      throw new Error("eperm");
+    });
+
+    await runUninstallCliCommandFlow();
+
+    expect(showErrorBoxMock).toHaveBeenCalledWith(
+      "Failed to uninstall vellum command",
+      "eperm",
+    );
+  });
+});

--- a/apps/macos/src/main/cli-path-flow.test.ts
+++ b/apps/macos/src/main/cli-path-flow.test.ts
@@ -26,6 +26,12 @@ mock.module("electron", () => ({
   clipboard: { writeText: writeTextMock },
 }));
 
+const ensureCliInstalledMock = mock(async (): Promise<void> => undefined);
+
+mock.module("./cli-installer", () => ({
+  ensureCliInstalled: ensureCliInstalledMock,
+}));
+
 const getCliPathInstallStateMock = mock(
   async (): Promise<CliPathInstallState> => ({
     kind: "installed",
@@ -66,11 +72,13 @@ beforeEach(() => {
   showMessageBoxMock.mockReset();
   showErrorBoxMock.mockClear();
   writeTextMock.mockClear();
+  ensureCliInstalledMock.mockReset();
   getCliPathInstallStateMock.mockReset();
   installWrapperMock.mockReset();
   uninstallWrapperMock.mockReset();
 
   showMessageBoxMock.mockResolvedValue({ response: 0, checkboxChecked: false });
+  ensureCliInstalledMock.mockResolvedValue(undefined);
   setState({ kind: "installed", inPath: true });
   installWrapperMock.mockReturnValue("installed");
   uninstallWrapperMock.mockReturnValue("removed");
@@ -82,7 +90,7 @@ beforeEach(() => {
 
 describe("runInstallCliCommandFlow", () => {
   test("foreign file + Cancel leaves the file untouched", async () => {
-    setState({ kind: "foreign-file" });
+    installWrapperMock.mockReturnValue("needs-overwrite-confirmation");
     showMessageBoxMock.mockResolvedValue({ response: 1, checkboxChecked: false });
 
     await runInstallCliCommandFlow();
@@ -91,18 +99,51 @@ describe("runInstallCliCommandFlow", () => {
     expect(showMessageBoxMock.mock.calls[0]?.[0]?.message).toBe(
       "Replace existing vellum file?",
     );
-    expect(installWrapperMock).not.toHaveBeenCalled();
+    expect(installWrapperMock).toHaveBeenCalledTimes(1);
+    expect(installWrapperMock).toHaveBeenCalledWith({ overwriteForeign: false });
+    expect(ensureCliInstalledMock).not.toHaveBeenCalled();
   });
 
-  test("foreign file + Replace installs with overwriteForeign", async () => {
-    getCliPathInstallStateMock
-      .mockResolvedValueOnce({ kind: "foreign-file" })
-      .mockResolvedValueOnce({ kind: "installed", inPath: true });
+  test("foreign file + Replace retries with overwriteForeign", async () => {
+    installWrapperMock
+      .mockReturnValueOnce("needs-overwrite-confirmation")
+      .mockReturnValueOnce("installed");
 
     await runInstallCliCommandFlow();
 
-    expect(installWrapperMock).toHaveBeenCalledTimes(1);
-    expect(installWrapperMock).toHaveBeenCalledWith({ overwriteForeign: true });
+    expect(installWrapperMock).toHaveBeenCalledTimes(2);
+    expect(installWrapperMock.mock.calls[0]?.[0]).toEqual({
+      overwriteForeign: false,
+    });
+    expect(installWrapperMock.mock.calls[1]?.[0]).toEqual({
+      overwriteForeign: true,
+    });
+    expect(ensureCliInstalledMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("provisions the CLI runtime before showing success", async () => {
+    setState({ kind: "installed", inPath: true });
+
+    await runInstallCliCommandFlow();
+
+    expect(ensureCliInstalledMock).toHaveBeenCalledTimes(1);
+    // State is only checked once, after install, for the success dialog.
+    expect(getCliPathInstallStateMock).toHaveBeenCalledTimes(1);
+    expect(lastDialog()?.message).toBe("Vellum CLI installed");
+  });
+
+  test("CLI runtime download failure reports the wrapper as installed and retryable", async () => {
+    ensureCliInstalledMock.mockRejectedValue(new Error("registry unreachable"));
+
+    await runInstallCliCommandFlow();
+
+    expect(showMessageBoxMock).not.toHaveBeenCalled();
+    expect(showErrorBoxMock).toHaveBeenCalledTimes(1);
+    const [title, message] = showErrorBoxMock.mock.calls[0]!;
+    expect(title).toBe("Failed to install vellum command");
+    expect(message).toContain(`The vellum command was installed at ${WRAPPER_PATH}`);
+    expect(message).toContain("registry unreachable");
+    expect(message).toContain("retried");
   });
 
   test("installed + inPath shows success without touching the clipboard", async () => {
@@ -128,28 +169,34 @@ describe("runInstallCliCommandFlow", () => {
     expect(lastDialog()?.detail).toContain(WRAPPER_PATH);
   });
 
-  test("shadowed names the winning binary and the npm uninstall fix", async () => {
-    setState({ kind: "shadowed", shadowedBy: "/opt/homebrew/bin/vellum" });
+  test("shadowed + inPath names the winning binary and the npm uninstall fix", async () => {
+    setState({
+      kind: "shadowed",
+      shadowedBy: "/opt/homebrew/bin/vellum",
+      inPath: true,
+    });
 
     await runInstallCliCommandFlow();
 
     expect(writeTextMock).not.toHaveBeenCalled();
     expect(lastDialog()?.detail).toContain("/opt/homebrew/bin/vellum");
     expect(lastDialog()?.detail).toContain("npm uninstall -g vellum");
+    expect(lastDialog()?.detail).not.toContain("clipboard");
   });
 
-  test("install race returning needs-overwrite-confirmation re-confirms once", async () => {
-    setState({ kind: "installed", inPath: true });
-    installWrapperMock
-      .mockReturnValueOnce("needs-overwrite-confirmation")
-      .mockReturnValueOnce("installed");
+  test("shadowed without PATH adds the export-line help alongside the npm advice", async () => {
+    setState({
+      kind: "shadowed",
+      shadowedBy: "/opt/homebrew/bin/vellum",
+      inPath: false,
+    });
 
     await runInstallCliCommandFlow();
 
-    expect(installWrapperMock).toHaveBeenCalledTimes(2);
-    expect(installWrapperMock.mock.calls[1]?.[0]).toEqual({
-      overwriteForeign: true,
-    });
+    expect(writeTextMock).toHaveBeenCalledTimes(1);
+    expect(writeTextMock).toHaveBeenCalledWith(PATH_EXPORT_LINE);
+    expect(lastDialog()?.detail).toContain("npm uninstall -g vellum");
+    expect(lastDialog()?.detail).toContain("copied to your clipboard");
   });
 
   test("state check throwing surfaces via showErrorBox without rejecting", async () => {

--- a/apps/macos/src/main/cli-path-flow.ts
+++ b/apps/macos/src/main/cli-path-flow.ts
@@ -97,9 +97,9 @@ export async function runInstallCliCommandFlow(): Promise<void> {
     } catch (err) {
       throw new Error(
         `The vellum command was installed at ${getWrapperPath()}, but ` +
-          `downloading the CLI runtime failed: ${errorMessage(err)}. It will be ` +
-          'retried the next time it\'s needed — or run "Install vellum ' +
-          'Command" again to retry now.',
+          `downloading the CLI runtime failed: ${errorMessage(err)}. Use ` +
+          '"Repair vellum Command" in the Vellum menu to retry now — or it ' +
+          "will be retried automatically the next time it's needed.",
       );
     }
 

--- a/apps/macos/src/main/cli-path-flow.ts
+++ b/apps/macos/src/main/cli-path-flow.ts
@@ -1,0 +1,121 @@
+/**
+ * UX orchestration for "Install vellum Command…": wraps the cli-path-installer
+ * primitives with confirmation/success dialogs and clipboard help. Both flows
+ * surface failures via showErrorBox and never throw to the caller.
+ */
+import { clipboard, dialog } from "electron";
+
+import {
+  getCliPathInstallState,
+  getWrapperPath,
+  installWrapper,
+  uninstallWrapper,
+} from "./cli-path-installer";
+
+const PATH_EXPORT_LINE = 'export PATH="$HOME/.local/bin:$PATH"';
+
+async function confirmReplaceForeignFile(): Promise<boolean> {
+  const { response } = await dialog.showMessageBox({
+    type: "warning",
+    message: "Replace existing vellum file?",
+    detail:
+      `A "vellum" file already exists at ${getWrapperPath()} but wasn't ` +
+      "installed by Vellum (it may have been installed by npm with a custom " +
+      "prefix). Do you want to replace it with the Vellum-managed command?",
+    buttons: ["Replace", "Cancel"],
+    defaultId: 1,
+    cancelId: 1,
+  });
+  return response === 0;
+}
+
+async function showInstallSuccessDialog(): Promise<void> {
+  const state = await getCliPathInstallState();
+  const wrapperPath = getWrapperPath();
+
+  let detail: string;
+  if (state.kind === "installed" && !state.inPath) {
+    clipboard.writeText(PATH_EXPORT_LINE);
+    detail =
+      `The vellum command is installed at ${wrapperPath}, but ` +
+      "~/.local/bin isn't in your shell's PATH. The line to add to your " +
+      "shell profile has been copied to your clipboard.";
+  } else if (state.kind === "shadowed") {
+    detail =
+      `The vellum command is installed at ${wrapperPath}, but another ` +
+      `"vellum" was found at ${state.shadowedBy} (likely installed via ` +
+      "npm) and will take precedence in your terminal. Run " +
+      '"npm uninstall -g vellum" to use the app-managed version.';
+  } else {
+    // `installed` in PATH, plus a defensive default for anything else.
+    detail =
+      `The vellum command is installed at ${wrapperPath}. ` +
+      'Open a new terminal and run "vellum".';
+  }
+
+  await dialog.showMessageBox({
+    type: "info",
+    message: "Vellum CLI installed",
+    detail,
+  });
+}
+
+export async function runInstallCliCommandFlow(): Promise<void> {
+  try {
+    const state = await getCliPathInstallState();
+    let overwriteForeign = false;
+    if (state.kind === "foreign-file") {
+      if (!(await confirmReplaceForeignFile())) return;
+      overwriteForeign = true;
+    }
+
+    if (installWrapper({ overwriteForeign }) === "needs-overwrite-confirmation") {
+      // Race: the file became foreign between the state check and install.
+      if (!(await confirmReplaceForeignFile())) return;
+      installWrapper({ overwriteForeign: true });
+    }
+
+    await showInstallSuccessDialog();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    dialog.showErrorBox("Failed to install vellum command", message);
+  }
+}
+
+export async function runUninstallCliCommandFlow(): Promise<void> {
+  try {
+    const { response } = await dialog.showMessageBox({
+      type: "warning",
+      message: "Uninstall vellum command?",
+      detail: `This removes the vellum command at ${getWrapperPath()}.`,
+      buttons: ["Uninstall", "Cancel"],
+      defaultId: 1,
+      cancelId: 1,
+    });
+    if (response !== 0) return;
+
+    const resultDialogs = {
+      removed: {
+        type: "info",
+        message: "Vellum command uninstalled",
+        detail: "The vellum command was removed.",
+      },
+      "not-ours": {
+        type: "warning",
+        message: "Vellum command not removed",
+        detail:
+          `The file at ${getWrapperPath()} wasn't installed by Vellum — ` +
+          "not removing it.",
+      },
+      absent: {
+        type: "info",
+        message: "Nothing to uninstall",
+        detail: "The vellum command is not installed.",
+      },
+    } as const;
+    await dialog.showMessageBox(resultDialogs[uninstallWrapper()]);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    dialog.showErrorBox("Failed to uninstall vellum command", message);
+  }
+}

--- a/apps/macos/src/main/cli-path-flow.ts
+++ b/apps/macos/src/main/cli-path-flow.ts
@@ -12,8 +12,10 @@ import {
   installWrapper,
   uninstallWrapper,
 } from "./cli-path-installer";
+import { isFishShell } from "./shell-path";
 
 const PATH_EXPORT_LINE = 'export PATH="$HOME/.local/bin:$PATH"';
+const FISH_ADD_PATH_LINE = 'fish_add_path "$HOME/.local/bin"';
 
 // Shared by both flows: they mutate the same wrapper file, and re-entrant
 // runs stack dialogs and overwrite each other's answers.
@@ -42,8 +44,17 @@ async function confirmReplaceForeignFile(): Promise<boolean> {
   return response === 0;
 }
 
-// Copies the export line and returns the matching dialog instructions.
+// Copies the shell-appropriate PATH fix and returns matching instructions:
+// fish persists PATH via fish_add_path, not a POSIX export in a profile.
 function copyPathExportHelp(): string {
+  if (isFishShell()) {
+    clipboard.writeText(FISH_ADD_PATH_LINE);
+    return (
+      "~/.local/bin isn't in your shell's PATH. The fish command to add " +
+      "it has been copied to your clipboard — run it once in a fish " +
+      "terminal."
+    );
+  }
   clipboard.writeText(PATH_EXPORT_LINE);
   return (
     "~/.local/bin isn't in your shell's PATH. The line to add to your " +

--- a/apps/macos/src/main/cli-path-flow.ts
+++ b/apps/macos/src/main/cli-path-flow.ts
@@ -15,6 +15,15 @@ import {
 
 const PATH_EXPORT_LINE = 'export PATH="$HOME/.local/bin:$PATH"';
 
+// Shared by both flows: they mutate the same wrapper file, and re-entrant
+// runs stack dialogs and overwrite each other's answers.
+let flowInFlight = false;
+
+/** Whether an install/uninstall flow is currently running. */
+export function isCliPathFlowInFlight(): boolean {
+  return flowInFlight;
+}
+
 const errorMessage = (err: unknown): string =>
   err instanceof Error ? err.message : "Unknown error";
 
@@ -75,6 +84,8 @@ async function showInstallSuccessDialog(): Promise<void> {
 }
 
 export async function runInstallCliCommandFlow(): Promise<void> {
+  if (flowInFlight) return;
+  flowInFlight = true;
   try {
     if (installWrapper({ overwriteForeign: false }) === "needs-overwrite-confirmation") {
       if (!(await confirmReplaceForeignFile())) return;
@@ -95,10 +106,14 @@ export async function runInstallCliCommandFlow(): Promise<void> {
     await showInstallSuccessDialog();
   } catch (err) {
     dialog.showErrorBox("Failed to install vellum command", errorMessage(err));
+  } finally {
+    flowInFlight = false;
   }
 }
 
 export async function runUninstallCliCommandFlow(): Promise<void> {
+  if (flowInFlight) return;
+  flowInFlight = true;
   try {
     const { response } = await dialog.showMessageBox({
       type: "warning",
@@ -132,5 +147,7 @@ export async function runUninstallCliCommandFlow(): Promise<void> {
     await dialog.showMessageBox(resultDialogs[uninstallWrapper()]);
   } catch (err) {
     dialog.showErrorBox("Failed to uninstall vellum command", errorMessage(err));
+  } finally {
+    flowInFlight = false;
   }
 }

--- a/apps/macos/src/main/cli-path-flow.ts
+++ b/apps/macos/src/main/cli-path-flow.ts
@@ -5,6 +5,7 @@
  */
 import { clipboard, dialog } from "electron";
 
+import { ensureCliInstalled } from "./cli-installer";
 import {
   getCliPathInstallState,
   getWrapperPath,
@@ -13,6 +14,9 @@ import {
 } from "./cli-path-installer";
 
 const PATH_EXPORT_LINE = 'export PATH="$HOME/.local/bin:$PATH"';
+
+const errorMessage = (err: unknown): string =>
+  err instanceof Error ? err.message : "Unknown error";
 
 async function confirmReplaceForeignFile(): Promise<boolean> {
   const { response } = await dialog.showMessageBox({
@@ -29,23 +33,33 @@ async function confirmReplaceForeignFile(): Promise<boolean> {
   return response === 0;
 }
 
+// Copies the export line and returns the matching dialog instructions.
+function copyPathExportHelp(): string {
+  clipboard.writeText(PATH_EXPORT_LINE);
+  return (
+    "~/.local/bin isn't in your shell's PATH. The line to add to your " +
+    "shell profile has been copied to your clipboard."
+  );
+}
+
 async function showInstallSuccessDialog(): Promise<void> {
   const state = await getCliPathInstallState();
   const wrapperPath = getWrapperPath();
 
   let detail: string;
   if (state.kind === "installed" && !state.inPath) {
-    clipboard.writeText(PATH_EXPORT_LINE);
     detail =
       `The vellum command is installed at ${wrapperPath}, but ` +
-      "~/.local/bin isn't in your shell's PATH. The line to add to your " +
-      "shell profile has been copied to your clipboard.";
+      copyPathExportHelp();
   } else if (state.kind === "shadowed") {
     detail =
       `The vellum command is installed at ${wrapperPath}, but another ` +
       `"vellum" was found at ${state.shadowedBy} (likely installed via ` +
       "npm) and will take precedence in your terminal. Run " +
       '"npm uninstall -g vellum" to use the app-managed version.';
+    if (!state.inPath) {
+      detail += ` Also, ${copyPathExportHelp()}`;
+    }
   } else {
     // `installed` in PATH, plus a defensive default for anything else.
     detail =
@@ -62,23 +76,25 @@ async function showInstallSuccessDialog(): Promise<void> {
 
 export async function runInstallCliCommandFlow(): Promise<void> {
   try {
-    const state = await getCliPathInstallState();
-    let overwriteForeign = false;
-    if (state.kind === "foreign-file") {
-      if (!(await confirmReplaceForeignFile())) return;
-      overwriteForeign = true;
-    }
-
-    if (installWrapper({ overwriteForeign }) === "needs-overwrite-confirmation") {
-      // Race: the file became foreign between the state check and install.
+    if (installWrapper({ overwriteForeign: false }) === "needs-overwrite-confirmation") {
       if (!(await confirmReplaceForeignFile())) return;
       installWrapper({ overwriteForeign: true });
     }
 
+    try {
+      await ensureCliInstalled();
+    } catch (err) {
+      throw new Error(
+        `The vellum command was installed at ${getWrapperPath()}, but ` +
+          `downloading the CLI runtime failed: ${errorMessage(err)}. It will be ` +
+          'retried the next time it\'s needed — or run "Install vellum ' +
+          'Command" again to retry now.',
+      );
+    }
+
     await showInstallSuccessDialog();
   } catch (err) {
-    const message = err instanceof Error ? err.message : "Unknown error";
-    dialog.showErrorBox("Failed to install vellum command", message);
+    dialog.showErrorBox("Failed to install vellum command", errorMessage(err));
   }
 }
 
@@ -115,7 +131,6 @@ export async function runUninstallCliCommandFlow(): Promise<void> {
     } as const;
     await dialog.showMessageBox(resultDialogs[uninstallWrapper()]);
   } catch (err) {
-    const message = err instanceof Error ? err.message : "Unknown error";
-    dialog.showErrorBox("Failed to uninstall vellum command", message);
+    dialog.showErrorBox("Failed to uninstall vellum command", errorMessage(err));
   }
 }

--- a/apps/macos/src/main/cli-path-installer.test.ts
+++ b/apps/macos/src/main/cli-path-installer.test.ts
@@ -37,6 +37,8 @@ mock.module("node:os", () => ({
 
 // Track fs calls so tests can assert on them.
 let readFileSyncResult: string | Error | null = null;
+// Drives isCliInstalled() (existsSync on the CLI bin path) → runtimeReady.
+let cliBinExists = false;
 // "auto" mirrors readFileSync presence; "exists" forces a present entry
 // (e.g. a dangling symlink whose readFileSync still throws ENOENT).
 let lstatSyncBehavior: "auto" | "exists" = "auto";
@@ -60,7 +62,7 @@ mock.module("node:fs", () => ({
   statSync: () => ({ isFile: () => true }),
   constants: { X_OK: 1 },
   copyFileSync: () => {},
-  existsSync: () => false,
+  existsSync: () => cliBinExists,
   readdirSync: () => [],
   // Used by cli-path-installer.
   chmodSync: (p: string, mode: number) => {
@@ -134,6 +136,7 @@ const locatorPath = `${userDataPath}/cli/locator.sh`;
 
 afterEach(() => {
   readFileSyncResult = null;
+  cliBinExists = false;
   lstatSyncBehavior = "auto";
   for (const key of Object.keys(realpathMap)) delete realpathMap[key];
   mkdirSyncCalls.length = 0;
@@ -346,6 +349,7 @@ describe("getCliPathInstallState", () => {
     expect(await getCliPathInstallState()).toEqual({
       kind: "installed",
       inPath: false,
+      runtimeReady: false,
     });
     expect(findExecutablesCalls).toEqual([["vellum", shellPathValue]]);
   });
@@ -358,6 +362,7 @@ describe("getCliPathInstallState", () => {
     expect(await getCliPathInstallState()).toEqual({
       kind: "installed",
       inPath: true,
+      runtimeReady: false,
     });
   });
 
@@ -370,6 +375,7 @@ describe("getCliPathInstallState", () => {
       kind: "shadowed",
       shadowedBy: "/opt/homebrew/bin/vellum",
       inPath: true,
+      runtimeReady: false,
     });
   });
 
@@ -382,6 +388,7 @@ describe("getCliPathInstallState", () => {
       kind: "shadowed",
       shadowedBy: "/opt/homebrew/bin/vellum",
       inPath: false,
+      runtimeReady: false,
     });
   });
 
@@ -395,6 +402,7 @@ describe("getCliPathInstallState", () => {
     expect(await getCliPathInstallState()).toEqual({
       kind: "installed",
       inPath: true,
+      runtimeReady: false,
     });
   });
 
@@ -408,6 +416,7 @@ describe("getCliPathInstallState", () => {
       kind: "shadowed",
       shadowedBy: "/opt/homebrew/bin/vellum",
       inPath: true,
+      runtimeReady: false,
     });
   });
 
@@ -419,6 +428,7 @@ describe("getCliPathInstallState", () => {
     expect(await getCliPathInstallState()).toEqual({
       kind: "installed",
       inPath: true,
+      runtimeReady: false,
     });
   });
 
@@ -430,6 +440,34 @@ describe("getCliPathInstallState", () => {
     expect(await getCliPathInstallState()).toEqual({
       kind: "installed",
       inPath: true,
+      runtimeReady: false,
+    });
+  });
+
+  test("reports runtimeReady true when the CLI runtime is provisioned", async () => {
+    readFileSyncResult = buildWrapperScript();
+    cliBinExists = true;
+    shellPathValue = `${wrapperDir}:/usr/bin:/bin`;
+    shellPathHits = [wrapperPath];
+
+    expect(await getCliPathInstallState()).toEqual({
+      kind: "installed",
+      inPath: true,
+      runtimeReady: true,
+    });
+  });
+
+  test("shadowed also carries runtimeReady when the runtime is provisioned", async () => {
+    readFileSyncResult = buildWrapperScript();
+    cliBinExists = true;
+    shellPathValue = `/opt/homebrew/bin:${wrapperDir}`;
+    shellPathHits = ["/opt/homebrew/bin/vellum", wrapperPath];
+
+    expect(await getCliPathInstallState()).toEqual({
+      kind: "shadowed",
+      shadowedBy: "/opt/homebrew/bin/vellum",
+      inPath: true,
+      runtimeReady: true,
     });
   });
 
@@ -441,6 +479,7 @@ describe("getCliPathInstallState", () => {
     expect(await getCliPathInstallState()).toEqual({
       kind: "installed",
       inPath: false,
+      runtimeReady: false,
     });
     expect(findExecutablesCalls).toHaveLength(0);
   });

--- a/apps/macos/src/main/cli-path-installer.test.ts
+++ b/apps/macos/src/main/cli-path-installer.test.ts
@@ -1,0 +1,246 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+// --- Mocks ---
+// Must be installed before the `await import` of the module under test so
+// the mocked module graph is in place when `cli-path-installer.ts` (and its
+// `cli-installer.ts` dependency) is evaluated. See `cli-installer.test.ts`.
+
+const userDataPath = "/mock/userData";
+const mockResourcesPath = "/mock/resources";
+const mockHome = "/mock/home";
+
+// `process.resourcesPath` is only defined inside a packaged Electron app.
+Object.defineProperty(process, "resourcesPath", {
+  value: mockResourcesPath,
+  writable: true,
+});
+
+mock.module("electron", () => ({
+  app: {
+    getPath: (name: string) => {
+      if (name === "userData") return userDataPath;
+      return "/tmp";
+    },
+    isPackaged: true,
+  },
+}));
+
+mock.module("./logger", () => ({
+  default: { info: () => {}, warn: () => {}, error: () => {} },
+}));
+
+const realOs = await import("node:os");
+mock.module("node:os", () => ({
+  ...realOs,
+  homedir: () => mockHome,
+}));
+
+// Track fs calls so tests can assert on them.
+let readFileSyncResult: string | Error | null = null;
+const mkdirSyncCalls: Array<[string, object]> = [];
+const writeFileSyncCalls: Array<[string, string]> = [];
+const chmodSyncCalls: Array<[string, number]> = [];
+const renameSyncCalls: Array<[string, string]> = [];
+const rmSyncCalls: Array<[string, object]> = [];
+
+const enoent = () => {
+  const err = new Error("ENOENT: no such file or directory");
+  (err as NodeJS.ErrnoException).code = "ENOENT";
+  return err;
+};
+
+mock.module("node:fs", () => ({
+  // Used by the cli-installer module evaluated as a dependency.
+  copyFileSync: () => {},
+  existsSync: () => false,
+  readdirSync: () => [],
+  // Used by cli-path-installer.
+  chmodSync: (p: string, mode: number) => {
+    chmodSyncCalls.push([p, mode]);
+  },
+  mkdirSync: (p: string, opts: object) => {
+    mkdirSyncCalls.push([p, opts]);
+  },
+  readFileSync: (_p: string, _enc?: string) => {
+    if (readFileSyncResult === null) throw enoent();
+    if (readFileSyncResult instanceof Error) throw readFileSyncResult;
+    return readFileSyncResult;
+  },
+  renameSync: (src: string, dst: string) => {
+    renameSyncCalls.push([src, dst]);
+  },
+  rmSync: (p: string, opts: object) => {
+    rmSyncCalls.push([p, opts]);
+  },
+  writeFileSync: (p: string, content: string) => {
+    writeFileSyncCalls.push([p, content]);
+  },
+}));
+
+const {
+  WRAPPER_MARKER,
+  getWrapperDir,
+  getWrapperPath,
+  buildWrapperScript,
+  readWrapperOwnership,
+  installWrapper,
+  uninstallWrapper,
+} = await import("./cli-path-installer");
+
+const wrapperDir = `${mockHome}/.local/bin`;
+const wrapperPath = `${wrapperDir}/vellum`;
+const locatorPath = `${userDataPath}/cli/locator.sh`;
+
+afterEach(() => {
+  readFileSyncResult = null;
+  mkdirSyncCalls.length = 0;
+  writeFileSyncCalls.length = 0;
+  chmodSyncCalls.length = 0;
+  renameSyncCalls.length = 0;
+  rmSyncCalls.length = 0;
+});
+
+// --- Path helpers ---
+
+describe("getWrapperDir", () => {
+  test("returns ~/.local/bin", () => {
+    expect(getWrapperDir()).toBe(wrapperDir);
+  });
+});
+
+describe("getWrapperPath", () => {
+  test("returns ~/.local/bin/vellum", () => {
+    expect(getWrapperPath()).toBe(wrapperPath);
+  });
+});
+
+// --- buildWrapperScript ---
+
+describe("buildWrapperScript", () => {
+  test("starts with a POSIX sh shebang", () => {
+    expect(buildWrapperScript().startsWith("#!/bin/sh\n")).toBe(true);
+  });
+
+  test("contains the ownership marker", () => {
+    expect(buildWrapperScript()).toContain(`${WRAPPER_MARKER}\n`);
+  });
+
+  test("embeds the single-quoted locator path", () => {
+    expect(buildWrapperScript()).toContain(`LOCATOR='${locatorPath}'\n`);
+  });
+
+  test("ends with the exec line", () => {
+    expect(buildWrapperScript().endsWith('exec "$VELLUM_BUN" "$VELLUM_CLI_BIN" "$@"\n')).toBe(
+      true,
+    );
+  });
+});
+
+// --- readWrapperOwnership ---
+
+describe("readWrapperOwnership", () => {
+  test("returns absent when no file exists at the wrapper path", () => {
+    readFileSyncResult = null; // readFileSync throws ENOENT
+    expect(readWrapperOwnership()).toBe("absent");
+  });
+
+  test("returns ours when the file contains the marker", () => {
+    readFileSyncResult = buildWrapperScript();
+    expect(readWrapperOwnership()).toBe("ours");
+  });
+
+  test("returns ours for an older wrapper revision containing the marker", () => {
+    readFileSyncResult = `#!/bin/sh\n${WRAPPER_MARKER}\n# old body\nexit 0\n`;
+    expect(readWrapperOwnership()).toBe("ours");
+  });
+
+  test("returns foreign for a file without the marker", () => {
+    readFileSyncResult = "#!/bin/sh\necho some other vellum tool\n";
+    expect(readWrapperOwnership()).toBe("foreign");
+  });
+
+  test("returns foreign when the file exists but is unreadable", () => {
+    const eacces = new Error("EACCES: permission denied");
+    (eacces as NodeJS.ErrnoException).code = "EACCES";
+    readFileSyncResult = eacces;
+    expect(readWrapperOwnership()).toBe("foreign");
+  });
+});
+
+// --- installWrapper ---
+
+describe("installWrapper", () => {
+  test("creates ~/.local/bin and atomically writes a 0755 wrapper", () => {
+    readFileSyncResult = null; // absent
+
+    const result = installWrapper({ overwriteForeign: false });
+
+    expect(result).toBe("installed");
+    expect(mkdirSyncCalls).toEqual([[wrapperDir, { recursive: true }]]);
+    expect(writeFileSyncCalls).toEqual([
+      [`${wrapperPath}.tmp`, buildWrapperScript()],
+    ]);
+    expect(chmodSyncCalls).toEqual([[`${wrapperPath}.tmp`, 0o755]]);
+    expect(renameSyncCalls).toEqual([[`${wrapperPath}.tmp`, wrapperPath]]);
+  });
+
+  test("returns needs-overwrite-confirmation for a foreign file without touching it", () => {
+    readFileSyncResult = "#!/bin/sh\necho not ours\n";
+
+    const result = installWrapper({ overwriteForeign: false });
+
+    expect(result).toBe("needs-overwrite-confirmation");
+    expect(writeFileSyncCalls).toHaveLength(0);
+    expect(chmodSyncCalls).toHaveLength(0);
+    expect(renameSyncCalls).toHaveLength(0);
+  });
+
+  test("overwrites a foreign file when overwriteForeign is true", () => {
+    readFileSyncResult = "#!/bin/sh\necho not ours\n";
+
+    const result = installWrapper({ overwriteForeign: true });
+
+    expect(result).toBe("installed");
+    expect(writeFileSyncCalls).toEqual([
+      [`${wrapperPath}.tmp`, buildWrapperScript()],
+    ]);
+    expect(renameSyncCalls).toEqual([[`${wrapperPath}.tmp`, wrapperPath]]);
+  });
+
+  test("overwrites our own older wrapper without confirmation", () => {
+    readFileSyncResult = `#!/bin/sh\n${WRAPPER_MARKER}\n# stale body\n`;
+
+    const result = installWrapper({ overwriteForeign: false });
+
+    expect(result).toBe("installed");
+    expect(writeFileSyncCalls).toEqual([
+      [`${wrapperPath}.tmp`, buildWrapperScript()],
+    ]);
+    expect(renameSyncCalls).toEqual([[`${wrapperPath}.tmp`, wrapperPath]]);
+  });
+});
+
+// --- uninstallWrapper ---
+
+describe("uninstallWrapper", () => {
+  test("removes the wrapper when it is ours", () => {
+    readFileSyncResult = buildWrapperScript();
+
+    expect(uninstallWrapper()).toBe("removed");
+    expect(rmSyncCalls).toEqual([[wrapperPath, { force: true }]]);
+  });
+
+  test("refuses to delete a foreign file", () => {
+    readFileSyncResult = "#!/bin/sh\necho not ours\n";
+
+    expect(uninstallWrapper()).toBe("not-ours");
+    expect(rmSyncCalls).toHaveLength(0);
+  });
+
+  test("no-ops when the wrapper is absent", () => {
+    readFileSyncResult = null;
+
+    expect(uninstallWrapper()).toBe("absent");
+    expect(rmSyncCalls).toHaveLength(0);
+  });
+});

--- a/apps/macos/src/main/cli-path-installer.test.ts
+++ b/apps/macos/src/main/cli-path-installer.test.ts
@@ -119,6 +119,15 @@ mock.module("./shell-path", () => ({
   },
 }));
 
+// Spread the real module so path/quote/locator helpers keep production
+// behavior; only the install entry point is faked.
+const ensureCliInstalledMock = mock(async (): Promise<void> => undefined);
+const realCliInstaller = await import("./cli-installer");
+mock.module("./cli-installer", () => ({
+  ...realCliInstaller,
+  ensureCliInstalled: ensureCliInstalledMock,
+}));
+
 const {
   WRAPPER_MARKER,
   getWrapperDir,
@@ -128,6 +137,7 @@ const {
   installWrapper,
   uninstallWrapper,
   getCliPathInstallState,
+  provisionCliForWrapper,
 } = await import("./cli-path-installer");
 
 const wrapperDir = `${mockHome}/.local/bin`;
@@ -148,6 +158,7 @@ afterEach(() => {
   shellPathHits = [];
   resolveShellPathCalls = 0;
   findExecutablesCalls.length = 0;
+  ensureCliInstalledMock.mockClear();
 });
 
 // --- Path helpers ---
@@ -319,6 +330,38 @@ describe("uninstallWrapper", () => {
 
     expect(uninstallWrapper()).toBe("absent");
     expect(rmSyncCalls).toHaveLength(0);
+  });
+});
+
+// --- provisionCliForWrapper ---
+
+describe("provisionCliForWrapper", () => {
+  test("provisions the CLI when the wrapper is ours", async () => {
+    readFileSyncResult = buildWrapperScript();
+
+    expect(await provisionCliForWrapper()).toBe(true);
+    expect(ensureCliInstalledMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("skips provisioning when the wrapper is absent", async () => {
+    readFileSyncResult = null;
+
+    expect(await provisionCliForWrapper()).toBe(false);
+    expect(ensureCliInstalledMock).not.toHaveBeenCalled();
+  });
+
+  test("skips provisioning for a foreign wrapper", async () => {
+    readFileSyncResult = "#!/bin/sh\necho not ours\n";
+
+    expect(await provisionCliForWrapper()).toBe(false);
+    expect(ensureCliInstalledMock).not.toHaveBeenCalled();
+  });
+
+  test("propagates install failures to the caller", async () => {
+    readFileSyncResult = buildWrapperScript();
+    ensureCliInstalledMock.mockRejectedValueOnce(new Error("offline"));
+
+    await expect(provisionCliForWrapper()).rejects.toThrow("offline");
   });
 });
 

--- a/apps/macos/src/main/cli-path-installer.test.ts
+++ b/apps/macos/src/main/cli-path-installer.test.ts
@@ -77,6 +77,23 @@ mock.module("node:fs", () => ({
   },
 }));
 
+// Controlled per-test; reset in afterEach.
+let shellPathValue = "";
+let shellPathHits: string[] = [];
+let resolveShellPathCalls = 0;
+const findExecutablesCalls: Array<[string, string]> = [];
+
+mock.module("./shell-path", () => ({
+  resolveShellPath: async () => {
+    resolveShellPathCalls += 1;
+    return shellPathValue;
+  },
+  findExecutablesInPath: (name: string, pathValue: string) => {
+    findExecutablesCalls.push([name, pathValue]);
+    return shellPathHits;
+  },
+}));
+
 const {
   WRAPPER_MARKER,
   getWrapperDir,
@@ -85,6 +102,7 @@ const {
   readWrapperOwnership,
   installWrapper,
   uninstallWrapper,
+  getCliPathInstallState,
 } = await import("./cli-path-installer");
 
 const wrapperDir = `${mockHome}/.local/bin`;
@@ -98,6 +116,10 @@ afterEach(() => {
   chmodSyncCalls.length = 0;
   renameSyncCalls.length = 0;
   rmSyncCalls.length = 0;
+  shellPathValue = "";
+  shellPathHits = [];
+  resolveShellPathCalls = 0;
+  findExecutablesCalls.length = 0;
 });
 
 // --- Path helpers ---
@@ -242,5 +264,81 @@ describe("uninstallWrapper", () => {
 
     expect(uninstallWrapper()).toBe("absent");
     expect(rmSyncCalls).toHaveLength(0);
+  });
+});
+
+// --- getCliPathInstallState ---
+
+describe("getCliPathInstallState", () => {
+  test("returns not-installed when the wrapper is absent, without consulting shell-path", async () => {
+    readFileSyncResult = null;
+
+    expect(await getCliPathInstallState()).toEqual({ kind: "not-installed" });
+    expect(resolveShellPathCalls).toBe(0);
+    expect(findExecutablesCalls).toHaveLength(0);
+  });
+
+  test("returns foreign-file for a foreign wrapper, without consulting shell-path", async () => {
+    readFileSyncResult = "#!/bin/sh\necho not ours\n";
+
+    expect(await getCliPathInstallState()).toEqual({ kind: "foreign-file" });
+    expect(resolveShellPathCalls).toBe(0);
+    expect(findExecutablesCalls).toHaveLength(0);
+  });
+
+  test("returns installed with inPath false when no hits and wrapper dir is not in PATH", async () => {
+    readFileSyncResult = buildWrapperScript();
+    shellPathValue = "/usr/local/bin:/usr/bin:/bin";
+    shellPathHits = [];
+
+    expect(await getCliPathInstallState()).toEqual({
+      kind: "installed",
+      inPath: false,
+    });
+    expect(findExecutablesCalls).toEqual([["vellum", shellPathValue]]);
+  });
+
+  test("returns installed with inPath true when the wrapper is the first hit", async () => {
+    readFileSyncResult = buildWrapperScript();
+    shellPathValue = `${wrapperDir}:/usr/local/bin:/usr/bin:/bin`;
+    shellPathHits = [wrapperPath];
+
+    expect(await getCliPathInstallState()).toEqual({
+      kind: "installed",
+      inPath: true,
+    });
+  });
+
+  test("returns shadowed with the winning path when another vellum precedes the wrapper", async () => {
+    readFileSyncResult = buildWrapperScript();
+    shellPathValue = `/opt/homebrew/bin:${wrapperDir}:/usr/bin:/bin`;
+    shellPathHits = ["/opt/homebrew/bin/vellum", wrapperPath];
+
+    expect(await getCliPathInstallState()).toEqual({
+      kind: "shadowed",
+      shadowedBy: "/opt/homebrew/bin/vellum",
+    });
+  });
+
+  test("returns installed when the wrapper wins over a later npm copy", async () => {
+    readFileSyncResult = buildWrapperScript();
+    shellPathValue = `${wrapperDir}:/opt/homebrew/bin:/usr/bin:/bin`;
+    shellPathHits = [wrapperPath, "/opt/homebrew/bin/vellum"];
+
+    expect(await getCliPathInstallState()).toEqual({
+      kind: "installed",
+      inPath: true,
+    });
+  });
+
+  test("counts a trailing-slash PATH entry for the wrapper dir as inPath", async () => {
+    readFileSyncResult = buildWrapperScript();
+    shellPathValue = `/usr/local/bin:${wrapperDir}/:/usr/bin`;
+    shellPathHits = [wrapperPath];
+
+    expect(await getCliPathInstallState()).toEqual({
+      kind: "installed",
+      inPath: true,
+    });
   });
 });

--- a/apps/macos/src/main/cli-path-installer.test.ts
+++ b/apps/macos/src/main/cli-path-installer.test.ts
@@ -37,6 +37,11 @@ mock.module("node:os", () => ({
 
 // Track fs calls so tests can assert on them.
 let readFileSyncResult: string | Error | null = null;
+// "auto" mirrors readFileSync presence; "exists" forces a present entry
+// (e.g. a dangling symlink whose readFileSync still throws ENOENT).
+let lstatSyncBehavior: "auto" | "exists" = "auto";
+// Symlink resolution map; paths not present throw (like realpathSync).
+const realpathMap: Record<string, string> = {};
 const mkdirSyncCalls: Array<[string, object]> = [];
 const writeFileSyncCalls: Array<[string, string]> = [];
 const chmodSyncCalls: Array<[string, number]> = [];
@@ -50,13 +55,20 @@ const enoent = () => {
 };
 
 mock.module("node:fs", () => ({
-  // Used by the cli-installer module evaluated as a dependency.
+  // Used by the cli-installer and shell-path modules evaluated as deps.
+  accessSync: () => {},
+  constants: { X_OK: 1 },
   copyFileSync: () => {},
   existsSync: () => false,
   readdirSync: () => [],
   // Used by cli-path-installer.
   chmodSync: (p: string, mode: number) => {
     chmodSyncCalls.push([p, mode]);
+  },
+  lstatSync: (_p: string) => {
+    if (lstatSyncBehavior === "exists") return {};
+    if (readFileSyncResult === null) throw enoent();
+    return {};
   },
   mkdirSync: (p: string, opts: object) => {
     mkdirSyncCalls.push([p, opts]);
@@ -65,6 +77,11 @@ mock.module("node:fs", () => ({
     if (readFileSyncResult === null) throw enoent();
     if (readFileSyncResult instanceof Error) throw readFileSyncResult;
     return readFileSyncResult;
+  },
+  realpathSync: (p: string) => {
+    const resolved = realpathMap[p];
+    if (resolved === undefined) throw enoent();
+    return resolved;
   },
   renameSync: (src: string, dst: string) => {
     renameSyncCalls.push([src, dst]);
@@ -79,14 +96,19 @@ mock.module("node:fs", () => ({
 
 // Controlled per-test; reset in afterEach.
 let shellPathValue = "";
+let shellPathReliable = true;
 let shellPathHits: string[] = [];
 let resolveShellPathCalls = 0;
 const findExecutablesCalls: Array<[string, string]> = [];
 
+// Spread the real module so `splitPathEntries` keeps its production
+// behavior; only the spawning/probing functions are faked.
+const realShellPath = await import("./shell-path");
 mock.module("./shell-path", () => ({
+  ...realShellPath,
   resolveShellPath: async () => {
     resolveShellPathCalls += 1;
-    return shellPathValue;
+    return { path: shellPathValue, reliable: shellPathReliable };
   },
   findExecutablesInPath: (name: string, pathValue: string) => {
     findExecutablesCalls.push([name, pathValue]);
@@ -111,12 +133,15 @@ const locatorPath = `${userDataPath}/cli/locator.sh`;
 
 afterEach(() => {
   readFileSyncResult = null;
+  lstatSyncBehavior = "auto";
+  for (const key of Object.keys(realpathMap)) delete realpathMap[key];
   mkdirSyncCalls.length = 0;
   writeFileSyncCalls.length = 0;
   chmodSyncCalls.length = 0;
   renameSyncCalls.length = 0;
   rmSyncCalls.length = 0;
   shellPathValue = "";
+  shellPathReliable = true;
   shellPathHits = [];
   resolveShellPathCalls = 0;
   findExecutablesCalls.length = 0;
@@ -162,7 +187,7 @@ describe("buildWrapperScript", () => {
 
 describe("readWrapperOwnership", () => {
   test("returns absent when no file exists at the wrapper path", () => {
-    readFileSyncResult = null; // readFileSync throws ENOENT
+    readFileSyncResult = null; // lstatSync and readFileSync throw ENOENT
     expect(readWrapperOwnership()).toBe("absent");
   });
 
@@ -187,6 +212,13 @@ describe("readWrapperOwnership", () => {
     readFileSyncResult = eacces;
     expect(readWrapperOwnership()).toBe("foreign");
   });
+
+  test("returns foreign for a dangling symlink (lstat exists, read ENOENT)", () => {
+    lstatSyncBehavior = "exists";
+    readFileSyncResult = null; // readFileSync follows the link → ENOENT
+
+    expect(readWrapperOwnership()).toBe("foreign");
+  });
 });
 
 // --- installWrapper ---
@@ -206,14 +238,26 @@ describe("installWrapper", () => {
     expect(renameSyncCalls).toEqual([[`${wrapperPath}.tmp`, wrapperPath]]);
   });
 
-  test("returns needs-overwrite-confirmation for a foreign file without touching it", () => {
+  test("returns needs-overwrite-confirmation for a foreign file without touching the fs", () => {
     readFileSyncResult = "#!/bin/sh\necho not ours\n";
 
     const result = installWrapper({ overwriteForeign: false });
 
     expect(result).toBe("needs-overwrite-confirmation");
+    expect(mkdirSyncCalls).toHaveLength(0);
     expect(writeFileSyncCalls).toHaveLength(0);
     expect(chmodSyncCalls).toHaveLength(0);
+    expect(renameSyncCalls).toHaveLength(0);
+  });
+
+  test("requires confirmation for a dangling foreign symlink instead of clobbering it", () => {
+    lstatSyncBehavior = "exists";
+    readFileSyncResult = null;
+
+    const result = installWrapper({ overwriteForeign: false });
+
+    expect(result).toBe("needs-overwrite-confirmation");
+    expect(writeFileSyncCalls).toHaveLength(0);
     expect(renameSyncCalls).toHaveLength(0);
   });
 
@@ -254,6 +298,14 @@ describe("uninstallWrapper", () => {
 
   test("refuses to delete a foreign file", () => {
     readFileSyncResult = "#!/bin/sh\necho not ours\n";
+
+    expect(uninstallWrapper()).toBe("not-ours");
+    expect(rmSyncCalls).toHaveLength(0);
+  });
+
+  test("refuses to delete a dangling foreign symlink", () => {
+    lstatSyncBehavior = "exists";
+    readFileSyncResult = null;
 
     expect(uninstallWrapper()).toBe("not-ours");
     expect(rmSyncCalls).toHaveLength(0);
@@ -309,7 +361,7 @@ describe("getCliPathInstallState", () => {
     });
   });
 
-  test("returns shadowed with the winning path when another vellum precedes the wrapper", async () => {
+  test("returns shadowed with inPath true when another vellum precedes the wrapper", async () => {
     readFileSyncResult = buildWrapperScript();
     shellPathValue = `/opt/homebrew/bin:${wrapperDir}:/usr/bin:/bin`;
     shellPathHits = ["/opt/homebrew/bin/vellum", wrapperPath];
@@ -317,6 +369,45 @@ describe("getCliPathInstallState", () => {
     expect(await getCliPathInstallState()).toEqual({
       kind: "shadowed",
       shadowedBy: "/opt/homebrew/bin/vellum",
+      inPath: true,
+    });
+  });
+
+  test("returns shadowed with inPath false when the wrapper dir is not in PATH", async () => {
+    readFileSyncResult = buildWrapperScript();
+    shellPathValue = "/opt/homebrew/bin:/usr/bin:/bin";
+    shellPathHits = ["/opt/homebrew/bin/vellum"];
+
+    expect(await getCliPathInstallState()).toEqual({
+      kind: "shadowed",
+      shadowedBy: "/opt/homebrew/bin/vellum",
+      inPath: false,
+    });
+  });
+
+  test("does not report shadowed when the first hit symlinks to the wrapper", async () => {
+    readFileSyncResult = buildWrapperScript();
+    shellPathValue = `${mockHome}/bin:/usr/bin:/bin`;
+    shellPathHits = [`${mockHome}/bin/vellum`]; // ~/bin -> ~/.local/bin
+    realpathMap[`${mockHome}/bin/vellum`] = wrapperPath;
+    realpathMap[wrapperPath] = wrapperPath;
+
+    expect(await getCliPathInstallState()).toEqual({
+      kind: "installed",
+      inPath: true,
+    });
+  });
+
+  test("still reports shadowed when realpath resolution fails (string-compare fallback)", async () => {
+    readFileSyncResult = buildWrapperScript();
+    shellPathValue = `/opt/homebrew/bin:${wrapperDir}`;
+    shellPathHits = ["/opt/homebrew/bin/vellum", wrapperPath];
+    // realpathMap left empty → realpathSync throws for both sides.
+
+    expect(await getCliPathInstallState()).toEqual({
+      kind: "shadowed",
+      shadowedBy: "/opt/homebrew/bin/vellum",
+      inPath: true,
     });
   });
 
@@ -340,5 +431,20 @@ describe("getCliPathInstallState", () => {
       kind: "installed",
       inPath: true,
     });
+  });
+
+  test("unreliable fallback PATH degrades to installed/inPath:false without shadow probing", async () => {
+    readFileSyncResult = buildWrapperScript();
+    shellPathReliable = false;
+    // The buildInstallEnv fallback always prepends the wrapper dir and may
+    // contain shadow candidates — none of it is evidence of the real PATH.
+    shellPathValue = `${wrapperDir}:/opt/homebrew/bin:/usr/bin`;
+    shellPathHits = ["/opt/homebrew/bin/vellum", wrapperPath];
+
+    expect(await getCliPathInstallState()).toEqual({
+      kind: "installed",
+      inPath: false,
+    });
+    expect(findExecutablesCalls).toHaveLength(0);
   });
 });

--- a/apps/macos/src/main/cli-path-installer.test.ts
+++ b/apps/macos/src/main/cli-path-installer.test.ts
@@ -57,6 +57,7 @@ const enoent = () => {
 mock.module("node:fs", () => ({
   // Used by the cli-installer and shell-path modules evaluated as deps.
   accessSync: () => {},
+  statSync: () => ({ isFile: () => true }),
   constants: { X_OK: 1 },
   copyFileSync: () => {},
   existsSync: () => false,
@@ -94,9 +95,9 @@ mock.module("node:fs", () => ({
   },
 }));
 
-// Controlled per-test; reset in afterEach.
-let shellPathValue = "";
-let shellPathReliable = true;
+// Controlled per-test; reset in afterEach. Null mirrors "could not
+// reliably determine the login-shell PATH".
+let shellPathValue: string | null = "";
 let shellPathHits: string[] = [];
 let resolveShellPathCalls = 0;
 const findExecutablesCalls: Array<[string, string]> = [];
@@ -108,7 +109,7 @@ mock.module("./shell-path", () => ({
   ...realShellPath,
   resolveShellPath: async () => {
     resolveShellPathCalls += 1;
-    return { path: shellPathValue, reliable: shellPathReliable };
+    return shellPathValue;
   },
   findExecutablesInPath: (name: string, pathValue: string) => {
     findExecutablesCalls.push([name, pathValue]);
@@ -141,7 +142,6 @@ afterEach(() => {
   renameSyncCalls.length = 0;
   rmSyncCalls.length = 0;
   shellPathValue = "";
-  shellPathReliable = true;
   shellPathHits = [];
   resolveShellPathCalls = 0;
   findExecutablesCalls.length = 0;
@@ -433,12 +433,9 @@ describe("getCliPathInstallState", () => {
     });
   });
 
-  test("unreliable fallback PATH degrades to installed/inPath:false without shadow probing", async () => {
+  test("null shell PATH degrades to installed/inPath:false without shadow probing", async () => {
     readFileSyncResult = buildWrapperScript();
-    shellPathReliable = false;
-    // The buildInstallEnv fallback always prepends the wrapper dir and may
-    // contain shadow candidates — none of it is evidence of the real PATH.
-    shellPathValue = `${wrapperDir}:/opt/homebrew/bin:/usr/bin`;
+    shellPathValue = null;
     shellPathHits = ["/opt/homebrew/bin/vellum", wrapperPath];
 
     expect(await getCliPathInstallState()).toEqual({

--- a/apps/macos/src/main/cli-path-installer.ts
+++ b/apps/macos/src/main/cli-path-installer.ts
@@ -1,16 +1,19 @@
 import {
-  chmodSync,
+  lstatSync,
   mkdirSync,
   readFileSync,
-  renameSync,
+  realpathSync,
   rmSync,
-  writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 
-import { getCliLocatorPath, shQuote } from "./cli-installer";
-import { findExecutablesInPath, resolveShellPath } from "./shell-path";
+import { getCliLocatorPath, shQuote, writeFileAtomicSync } from "./cli-installer";
+import {
+  findExecutablesInPath,
+  resolveShellPath,
+  splitPathEntries,
+} from "./shell-path";
 
 /** Ownership/migration marker embedded in every wrapper we write. */
 export const WRAPPER_MARKER = "# vellum-cli-wrapper v1";
@@ -54,18 +57,28 @@ export function buildWrapperScript(): string {
 export type WrapperOwnership = "ours" | "foreign" | "absent";
 
 /**
- * Classify what sits at the wrapper path. Unreadable-but-present files and
- * marker-less symlink targets (e.g. an npm prefix pointed at `~/.local`)
- * read as `foreign` so we never clobber them.
+ * Classify what sits at the wrapper path. Anything present that can't be
+ * read or lacks the marker — unreadable files, dangling symlinks,
+ * marker-less symlink targets (e.g. an npm prefix pointed at `~/.local`) —
+ * reads as `foreign` so we never clobber it. Only a true no-entry is
+ * `absent`; lstat is used so dangling symlinks still count as present.
  */
 export function readWrapperOwnership(): WrapperOwnership {
-  let content: string;
+  const wrapperPath = getWrapperPath();
+
   try {
-    content = readFileSync(getWrapperPath(), "utf8");
+    lstatSync(wrapperPath);
   } catch (err) {
     return (err as NodeJS.ErrnoException).code === "ENOENT"
       ? "absent"
       : "foreign";
+  }
+
+  let content: string;
+  try {
+    content = readFileSync(wrapperPath, "utf8");
+  } catch {
+    return "foreign";
   }
   return content.includes(WRAPPER_MARKER) ? "ours" : "foreign";
 }
@@ -77,17 +90,12 @@ export function readWrapperOwnership(): WrapperOwnership {
 export function installWrapper(opts: {
   overwriteForeign: boolean;
 }): "installed" | "needs-overwrite-confirmation" {
-  mkdirSync(getWrapperDir(), { recursive: true });
-
   if (readWrapperOwnership() === "foreign" && !opts.overwriteForeign) {
     return "needs-overwrite-confirmation";
   }
 
-  const wrapperPath = getWrapperPath();
-  const tmpPath = `${wrapperPath}.tmp`;
-  writeFileSync(tmpPath, buildWrapperScript());
-  chmodSync(tmpPath, 0o755);
-  renameSync(tmpPath, wrapperPath);
+  mkdirSync(getWrapperDir(), { recursive: true });
+  writeFileAtomicSync(getWrapperPath(), buildWrapperScript(), 0o755);
   return "installed";
 }
 
@@ -95,34 +103,46 @@ export type CliPathInstallState =
   | { kind: "not-installed" }
   | { kind: "foreign-file" }
   | { kind: "installed"; inPath: boolean }
-  | { kind: "shadowed"; shadowedBy: string };
+  // `inPath` is optional only so sibling-owned test fixtures keep compiling;
+  // getCliPathInstallState always populates it.
+  | { kind: "shadowed"; shadowedBy: string; inPath?: boolean };
 
-// Shell PATH entries are already $HOME-expanded; only trailing slashes vary.
-function stripTrailingSlashes(dir: string): string {
-  return dir.replace(/\/+$/, "");
+function realpathOr(p: string): string {
+  try {
+    return realpathSync(p);
+  } catch {
+    return p;
+  }
 }
 
 /**
  * Determine how the `vellum` command resolves on the user's login-shell
  * PATH. `shadowed` means another executable wins over our wrapper (e.g. an
- * npm-global install earlier in PATH). Never throws — shell PATH resolution
- * degrades gracefully.
+ * npm-global install earlier in PATH); symlink/case variants that resolve
+ * to the wrapper itself don't count. Never throws — when login-shell PATH
+ * resolution fails, degrades to `installed` with `inPath: false` rather
+ * than reporting states the fallback PATH can't actually attest to.
  */
 export async function getCliPathInstallState(): Promise<CliPathInstallState> {
   const ownership = readWrapperOwnership();
   if (ownership === "absent") return { kind: "not-installed" };
   if (ownership === "foreign") return { kind: "foreign-file" };
 
-  const shellPath = await resolveShellPath();
-  const [firstHit] = findExecutablesInPath("vellum", shellPath);
-  if (firstHit !== undefined && firstHit !== getWrapperPath()) {
-    return { kind: "shadowed", shadowedBy: firstHit };
-  }
+  const { path: shellPath, reliable } = await resolveShellPath();
+  if (!reliable) return { kind: "installed", inPath: false };
 
-  const wrapperDir = getWrapperDir();
-  const inPath = shellPath
-    .split(":")
-    .some((entry) => stripTrailingSlashes(entry) === wrapperDir);
+  const wrapperPath = getWrapperPath();
+  const [firstHit] = findExecutablesInPath("vellum", shellPath);
+  const firstHitIsWrapper =
+    firstHit !== undefined &&
+    (firstHit === wrapperPath || realpathOr(firstHit) === realpathOr(wrapperPath));
+
+  const inPath =
+    firstHitIsWrapper || splitPathEntries(shellPath).includes(getWrapperDir());
+
+  if (firstHit !== undefined && !firstHitIsWrapper) {
+    return { kind: "shadowed", shadowedBy: firstHit, inPath };
+  }
   return { kind: "installed", inPath };
 }
 

--- a/apps/macos/src/main/cli-path-installer.ts
+++ b/apps/macos/src/main/cli-path-installer.ts
@@ -103,9 +103,7 @@ export type CliPathInstallState =
   | { kind: "not-installed" }
   | { kind: "foreign-file" }
   | { kind: "installed"; inPath: boolean }
-  // `inPath` is optional only so sibling-owned test fixtures keep compiling;
-  // getCliPathInstallState always populates it.
-  | { kind: "shadowed"; shadowedBy: string; inPath?: boolean };
+  | { kind: "shadowed"; shadowedBy: string; inPath: boolean };
 
 function realpathOr(p: string): string {
   try {
@@ -120,16 +118,16 @@ function realpathOr(p: string): string {
  * PATH. `shadowed` means another executable wins over our wrapper (e.g. an
  * npm-global install earlier in PATH); symlink/case variants that resolve
  * to the wrapper itself don't count. Never throws — when login-shell PATH
- * resolution fails, degrades to `installed` with `inPath: false` rather
- * than reporting states the fallback PATH can't actually attest to.
+ * resolution fails (null), degrades to `installed` with `inPath: false`
+ * rather than reporting states we can't actually attest to.
  */
 export async function getCliPathInstallState(): Promise<CliPathInstallState> {
   const ownership = readWrapperOwnership();
   if (ownership === "absent") return { kind: "not-installed" };
   if (ownership === "foreign") return { kind: "foreign-file" };
 
-  const { path: shellPath, reliable } = await resolveShellPath();
-  if (!reliable) return { kind: "installed", inPath: false };
+  const shellPath = await resolveShellPath();
+  if (shellPath === null) return { kind: "installed", inPath: false };
 
   const wrapperPath = getWrapperPath();
   const [firstHit] = findExecutablesInPath("vellum", shellPath);

--- a/apps/macos/src/main/cli-path-installer.ts
+++ b/apps/macos/src/main/cli-path-installer.ts
@@ -8,7 +8,12 @@ import {
 import { homedir } from "node:os";
 import path from "node:path";
 
-import { getCliLocatorPath, shQuote, writeFileAtomicSync } from "./cli-installer";
+import {
+  getCliLocatorPath,
+  isCliInstalled,
+  shQuote,
+  writeFileAtomicSync,
+} from "./cli-installer";
 import {
   findExecutablesInPath,
   resolveShellPath,
@@ -102,8 +107,13 @@ export function installWrapper(opts: {
 export type CliPathInstallState =
   | { kind: "not-installed" }
   | { kind: "foreign-file" }
-  | { kind: "installed"; inPath: boolean }
-  | { kind: "shadowed"; shadowedBy: string; inPath: boolean };
+  | { kind: "installed"; inPath: boolean; runtimeReady: boolean }
+  | {
+      kind: "shadowed";
+      shadowedBy: string;
+      inPath: boolean;
+      runtimeReady: boolean;
+    };
 
 function realpathOr(p: string): string {
   try {
@@ -120,14 +130,20 @@ function realpathOr(p: string): string {
  * to the wrapper itself don't count. Never throws — when login-shell PATH
  * resolution fails (null), degrades to `installed` with `inPath: false`
  * rather than reporting states we can't actually attest to.
+ *
+ * `runtimeReady` reports whether the pinned CLI runtime is provisioned; when
+ * false the wrapper exists but can't run, and the menu offers a repair path.
  */
 export async function getCliPathInstallState(): Promise<CliPathInstallState> {
   const ownership = readWrapperOwnership();
   if (ownership === "absent") return { kind: "not-installed" };
   if (ownership === "foreign") return { kind: "foreign-file" };
 
+  const runtimeReady = isCliInstalled();
   const shellPath = await resolveShellPath();
-  if (shellPath === null) return { kind: "installed", inPath: false };
+  if (shellPath === null) {
+    return { kind: "installed", inPath: false, runtimeReady };
+  }
 
   const wrapperPath = getWrapperPath();
   const [firstHit] = findExecutablesInPath("vellum", shellPath);
@@ -139,9 +155,9 @@ export async function getCliPathInstallState(): Promise<CliPathInstallState> {
     firstHitIsWrapper || splitPathEntries(shellPath).includes(getWrapperDir());
 
   if (firstHit !== undefined && !firstHitIsWrapper) {
-    return { kind: "shadowed", shadowedBy: firstHit, inPath };
+    return { kind: "shadowed", shadowedBy: firstHit, inPath, runtimeReady };
   }
-  return { kind: "installed", inPath };
+  return { kind: "installed", inPath, runtimeReady };
 }
 
 /** Remove the wrapper, but only if it's one we installed. */

--- a/apps/macos/src/main/cli-path-installer.ts
+++ b/apps/macos/src/main/cli-path-installer.ts
@@ -10,6 +10,7 @@ import { homedir } from "node:os";
 import path from "node:path";
 
 import { getCliLocatorPath, shQuote } from "./cli-installer";
+import { findExecutablesInPath, resolveShellPath } from "./shell-path";
 
 /** Ownership/migration marker embedded in every wrapper we write. */
 export const WRAPPER_MARKER = "# vellum-cli-wrapper v1";
@@ -88,6 +89,41 @@ export function installWrapper(opts: {
   chmodSync(tmpPath, 0o755);
   renameSync(tmpPath, wrapperPath);
   return "installed";
+}
+
+export type CliPathInstallState =
+  | { kind: "not-installed" }
+  | { kind: "foreign-file" }
+  | { kind: "installed"; inPath: boolean }
+  | { kind: "shadowed"; shadowedBy: string };
+
+// Shell PATH entries are already $HOME-expanded; only trailing slashes vary.
+function stripTrailingSlashes(dir: string): string {
+  return dir.replace(/\/+$/, "");
+}
+
+/**
+ * Determine how the `vellum` command resolves on the user's login-shell
+ * PATH. `shadowed` means another executable wins over our wrapper (e.g. an
+ * npm-global install earlier in PATH). Never throws — shell PATH resolution
+ * degrades gracefully.
+ */
+export async function getCliPathInstallState(): Promise<CliPathInstallState> {
+  const ownership = readWrapperOwnership();
+  if (ownership === "absent") return { kind: "not-installed" };
+  if (ownership === "foreign") return { kind: "foreign-file" };
+
+  const shellPath = await resolveShellPath();
+  const [firstHit] = findExecutablesInPath("vellum", shellPath);
+  if (firstHit !== undefined && firstHit !== getWrapperPath()) {
+    return { kind: "shadowed", shadowedBy: firstHit };
+  }
+
+  const wrapperDir = getWrapperDir();
+  const inPath = shellPath
+    .split(":")
+    .some((entry) => stripTrailingSlashes(entry) === wrapperDir);
+  return { kind: "installed", inPath };
 }
 
 /** Remove the wrapper, but only if it's one we installed. */

--- a/apps/macos/src/main/cli-path-installer.ts
+++ b/apps/macos/src/main/cli-path-installer.ts
@@ -9,6 +9,7 @@ import { homedir } from "node:os";
 import path from "node:path";
 
 import {
+  ensureCliInstalled,
   getCliLocatorPath,
   isCliInstalled,
   shQuote,
@@ -102,6 +103,18 @@ export function installWrapper(opts: {
   mkdirSync(getWrapperDir(), { recursive: true });
   writeFileAtomicSync(getWrapperPath(), buildWrapperScript(), 0o755);
   return "installed";
+}
+
+/**
+ * Startup self-heal for PATH-wrapper users: when the wrapper is ours,
+ * provision the pinned CLI so a version bump rewrites the locator promptly
+ * instead of waiting for the next in-app CLI action. Absent/foreign wrappers
+ * keep the lazy install path. Returns whether provisioning ran.
+ */
+export async function provisionCliForWrapper(): Promise<boolean> {
+  if (readWrapperOwnership() !== "ours") return false;
+  await ensureCliInstalled();
+  return true;
 }
 
 export type CliPathInstallState =

--- a/apps/macos/src/main/cli-path-installer.ts
+++ b/apps/macos/src/main/cli-path-installer.ts
@@ -1,0 +1,101 @@
+import {
+  chmodSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+
+import { getCliLocatorPath, shQuote } from "./cli-installer";
+
+/** Ownership/migration marker embedded in every wrapper we write. */
+export const WRAPPER_MARKER = "# vellum-cli-wrapper v1";
+
+/** Directory the wrapper is installed into. */
+export function getWrapperDir(): string {
+  return path.join(homedir(), ".local", "bin");
+}
+
+/** Absolute path of the `vellum` PATH wrapper. */
+export function getWrapperPath(): string {
+  return path.join(getWrapperDir(), "vellum");
+}
+
+/**
+ * Build the POSIX sh wrapper installed at `~/.local/bin/vellum`. The script
+ * is machine-stable: all machine-specific paths flow through the locator
+ * file, which the app rewrites on every launch — except the locator path
+ * itself, which is embedded here.
+ */
+export function buildWrapperScript(): string {
+  return [
+    "#!/bin/sh",
+    WRAPPER_MARKER,
+    '# Installed by Vellum.app ("Install vellum Command"). Safe to delete.',
+    `LOCATOR=${shQuote(getCliLocatorPath())}`,
+    'if [ ! -f "$LOCATOR" ]; then',
+    '  echo "vellum: CLI not set up yet. Launch Vellum.app once to finish setup." >&2',
+    "  exit 1",
+    "fi",
+    '. "$LOCATOR"',
+    'if [ ! -x "$VELLUM_BUN" ] || [ ! -e "$VELLUM_CLI_BIN" ]; then',
+    '  echo "vellum: installation is incomplete. Launch Vellum.app once to repair it." >&2',
+    "  exit 1",
+    "fi",
+    'exec "$VELLUM_BUN" "$VELLUM_CLI_BIN" "$@"',
+    "",
+  ].join("\n");
+}
+
+export type WrapperOwnership = "ours" | "foreign" | "absent";
+
+/**
+ * Classify what sits at the wrapper path. Unreadable-but-present files and
+ * marker-less symlink targets (e.g. an npm prefix pointed at `~/.local`)
+ * read as `foreign` so we never clobber them.
+ */
+export function readWrapperOwnership(): WrapperOwnership {
+  let content: string;
+  try {
+    content = readFileSync(getWrapperPath(), "utf8");
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === "ENOENT"
+      ? "absent"
+      : "foreign";
+  }
+  return content.includes(WRAPPER_MARKER) ? "ours" : "foreign";
+}
+
+/**
+ * Install (or refresh) the PATH wrapper. Foreign files are never overwritten
+ * unless the caller explicitly opts in after confirming with the user.
+ */
+export function installWrapper(opts: {
+  overwriteForeign: boolean;
+}): "installed" | "needs-overwrite-confirmation" {
+  mkdirSync(getWrapperDir(), { recursive: true });
+
+  if (readWrapperOwnership() === "foreign" && !opts.overwriteForeign) {
+    return "needs-overwrite-confirmation";
+  }
+
+  const wrapperPath = getWrapperPath();
+  const tmpPath = `${wrapperPath}.tmp`;
+  writeFileSync(tmpPath, buildWrapperScript());
+  chmodSync(tmpPath, 0o755);
+  renameSync(tmpPath, wrapperPath);
+  return "installed";
+}
+
+/** Remove the wrapper, but only if it's one we installed. */
+export function uninstallWrapper(): "removed" | "not-ours" | "absent" {
+  const ownership = readWrapperOwnership();
+  if (ownership === "absent") return "absent";
+  if (ownership === "foreign") return "not-ours";
+
+  rmSync(getWrapperPath(), { force: true });
+  return "removed";
+}

--- a/apps/macos/src/main/command-palette-window.test.ts
+++ b/apps/macos/src/main/command-palette-window.test.ts
@@ -250,6 +250,24 @@ mock.module("./window-state", () => ({
   readOnboardingActive: () => false,
 }));
 
+// Full `./cli-path-installer` surface so this mock — which leaks into co-run
+// test files via the global module registry — doesn't break sibling modules.
+mock.module("./cli-path-installer", () => ({
+  WRAPPER_MARKER: "# vellum-cli-wrapper v1",
+  getWrapperDir: () => "/tmp/.local/bin",
+  getWrapperPath: () => "/tmp/.local/bin/vellum",
+  buildWrapperScript: () => "",
+  readWrapperOwnership: () => "absent",
+  installWrapper: () => "installed",
+  getCliPathInstallState: async () => ({ kind: "not-installed" }),
+  uninstallWrapper: () => "absent",
+}));
+
+mock.module("./cli-path-flow", () => ({
+  runInstallCliCommandFlow: async () => undefined,
+  runUninstallCliCommandFlow: async () => undefined,
+}));
+
 const {
   __resetForTesting,
   installCommandPaletteWindow,

--- a/apps/macos/src/main/command-palette-window.test.ts
+++ b/apps/macos/src/main/command-palette-window.test.ts
@@ -266,6 +266,7 @@ mock.module("./cli-path-installer", () => ({
 mock.module("./cli-path-flow", () => ({
   runInstallCliCommandFlow: async () => undefined,
   runUninstallCliCommandFlow: async () => undefined,
+  isCliPathFlowInFlight: () => false,
 }));
 
 const {

--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -15,6 +15,7 @@ import { installAbout, openAboutWindow } from "./about";
 import { installAutoUpdate } from "./auto-update";
 import { APP_HOST, APP_PROTOCOL, BUNDLES_DIR_NAME, VELLUMAPP_PROTOCOL } from "./app-config";
 import { resolveAllowedOrigin } from "./app-origin";
+import { writeCliLocator } from "./cli-installer";
 import { installCsp } from "./csp";
 import { getDeviceId } from "./device-id";
 import { handleSync } from "./ipc";
@@ -326,6 +327,9 @@ app
     installHotkeysIpc();
     installFeatureFlagsIpc();
     installLocalMode();
+    // Refresh the PATH-wrapper locator every launch so app moves and
+    // version bumps self-heal even if no CLI invocation happens this session.
+    if (app.isPackaged) writeCliLocator();
     installLoginItem();
     installLoginItemIpc();
     installHotkeyHelper();

--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -16,6 +16,7 @@ import { installAutoUpdate } from "./auto-update";
 import { APP_HOST, APP_PROTOCOL, BUNDLES_DIR_NAME, VELLUMAPP_PROTOCOL } from "./app-config";
 import { resolveAllowedOrigin } from "./app-origin";
 import { writeCliLocator } from "./cli-installer";
+import { provisionCliForWrapper } from "./cli-path-installer";
 import { installCsp } from "./csp";
 import { getDeviceId } from "./device-id";
 import { handleSync } from "./ipc";
@@ -56,7 +57,7 @@ import {
   installMainWindow,
   toggleVisibility as toggleMainWindowVisibility,
 } from "./main-window";
-import { installApplicationMenu } from "./menu";
+import { installApplicationMenu, refreshCliPathMenuState } from "./menu";
 import { installNativeAuth } from "./native-auth";
 import { installConnectivityProbe } from "./connectivity-probe";
 import { installNotifications } from "./notifications";
@@ -329,7 +330,17 @@ app
     installLocalMode();
     // Refresh the PATH-wrapper locator every launch so app moves and
     // version bumps self-heal even if no CLI invocation happens this session.
-    if (app.isPackaged) writeCliLocator();
+    if (app.isPackaged) {
+      writeCliLocator();
+      // Wrapper users also get the pinned CLI provisioned eagerly so a
+      // version bump rewrites the locator now (and prunes old versions)
+      // rather than after the next in-app CLI action.
+      void provisionCliForWrapper()
+        .then((provisioned) => (provisioned ? refreshCliPathMenuState() : undefined))
+        .catch((err: unknown) => {
+          log.error("[app] startup CLI provisioning failed:", err);
+        });
+    }
     installLoginItem();
     installLoginItemIpc();
     installHotkeyHelper();

--- a/apps/macos/src/main/local-mode.test.ts
+++ b/apps/macos/src/main/local-mode.test.ts
@@ -166,7 +166,9 @@ describe("vellum:localMode:hatch handler", () => {
       cliInstallerState.bundledBunPath,
       ["run", cliInstallerState.cliBinPath, "hatch", "openclaw"],
     ]);
-    expect(ensureCliInstalledMock).not.toHaveBeenCalled();
+    // Routed through ensureCliInstalled so the PATH-wrapper locator is
+    // refreshed even on the already-installed path.
+    expect(ensureCliInstalledMock).toHaveBeenCalledTimes(1);
   });
 
   test("packaged: triggers install when CLI not found, then uses installed path", async () => {

--- a/apps/macos/src/main/local-mode.test.ts
+++ b/apps/macos/src/main/local-mode.test.ts
@@ -166,8 +166,6 @@ describe("vellum:localMode:hatch handler", () => {
       cliInstallerState.bundledBunPath,
       ["run", cliInstallerState.cliBinPath, "hatch", "openclaw"],
     ]);
-    // Routed through ensureCliInstalled so the PATH-wrapper locator is
-    // refreshed even on the already-installed path.
     expect(ensureCliInstalledMock).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/macos/src/main/local-mode.ts
+++ b/apps/macos/src/main/local-mode.ts
@@ -23,7 +23,6 @@ import {
   ensureCliInstalled,
   getBundledBunPath,
   getCliBinPath,
-  isCliInstalled,
 } from "./cli-installer";
 
 /**
@@ -64,8 +63,8 @@ interface WakeResult {
  * Resolve how to invoke the CLI. Precedence:
  *  1. `VELLUM_CLI_PATH` env var override
  *  2. Dev source tree (when `!app.isPackaged`)
- *  3. Already-installed CLI in the user-data directory
- *  4. Lazy install via `ensureCliInstalled()`, then use the installed path
+ *  3. `ensureCliInstalled()` — early-returns when already installed and
+ *     refreshes the PATH-wrapper locator either way
  *
  * Throws when no CLI path can be resolved (e.g. install fails).
  */
@@ -81,10 +80,6 @@ export async function resolveCliInvocation(): Promise<CliInvocation> {
     if (existsSync(cliEntry)) {
       return { command: "bun", baseArgs: ["run", cliEntry] };
     }
-  }
-
-  if (isCliInstalled()) {
-    return { command: getBundledBunPath(), baseArgs: ["run", getCliBinPath()] };
   }
 
   await ensureCliInstalled();

--- a/apps/macos/src/main/menu.test.ts
+++ b/apps/macos/src/main/menu.test.ts
@@ -20,11 +20,15 @@ const buildFromTemplateMock = mock((template: TemplateItem[]) => ({
 }));
 const setApplicationMenuMock = mock((_menu: unknown) => undefined);
 
+// Mutable so tests can flip packaged/dev; the CLI path items only exist in
+// packaged builds, so packaged is the default here.
+const electronApp = {
+  name: "Vellum Electron",
+  isPackaged: true,
+};
+
 mock.module("electron", () => ({
-  app: {
-    name: "Vellum Electron",
-    isPackaged: false,
-  },
+  app: electronApp,
   Menu: {
     buildFromTemplate: buildFromTemplateMock,
     setApplicationMenu: setApplicationMenuMock,
@@ -139,6 +143,7 @@ const SHADOWED_LABEL = "⚠ vellum is shadowed by another install";
 installApplicationMenu();
 
 beforeEach(async () => {
+  electronApp.isPackaged = true;
   getCliPathInstallStateMock.mockReset();
   getCliPathInstallStateMock.mockResolvedValue({ kind: "not-installed" });
   // Settle any pending refresh kicked off by installApplicationMenu before
@@ -230,6 +235,28 @@ describe("CLI path menu items", () => {
     expect(callOrder).toEqual(["uninstall-flow", "detect"]);
     expect(buildFromTemplateMock.mock.calls.length).toBe(buildsBefore + 1);
     expect(appMenuLabels()).toContain(INSTALL_LABEL);
+  });
+});
+
+describe("CLI path menu items in unpackaged builds", () => {
+  test("shows neither item and never spawns detection", async () => {
+    electronApp.isPackaged = false;
+    await refreshCliPathMenuState();
+    expect(getCliPathInstallStateMock).not.toHaveBeenCalled();
+    expect(appMenuLabels()).not.toContain(INSTALL_LABEL);
+    expect(appMenuLabels()).not.toContain(UNINSTALL_LABEL);
+  });
+
+  test("hides Uninstall even when a prior detection found an install", async () => {
+    await setStateAndRefresh({ kind: "installed", inPath: true });
+    expect(appMenuLabels()).toContain(UNINSTALL_LABEL);
+
+    electronApp.isPackaged = false;
+    getCliPathInstallStateMock.mockClear();
+    await refreshCliPathMenuState();
+    expect(getCliPathInstallStateMock).not.toHaveBeenCalled();
+    expect(appMenuLabels()).not.toContain(INSTALL_LABEL);
+    expect(appMenuLabels()).not.toContain(UNINSTALL_LABEL);
   });
 });
 

--- a/apps/macos/src/main/menu.test.ts
+++ b/apps/macos/src/main/menu.test.ts
@@ -140,6 +140,7 @@ const setStateAndRefresh = async (state: CliPathInstallState) => {
 };
 
 const INSTALL_LABEL = "Install vellum Command…";
+const REPAIR_LABEL = "Repair vellum Command…";
 const UNINSTALL_LABEL = "Uninstall vellum Command";
 const SHADOWED_LABEL = "⚠ vellum is shadowed by another install";
 
@@ -195,10 +196,52 @@ describe("CLI path menu items", () => {
   });
 
   test("shows Uninstall when installed, without the shadowed indicator", async () => {
-    await setStateAndRefresh({ kind: "installed", inPath: true });
+    await setStateAndRefresh({ kind: "installed", inPath: true, runtimeReady: true });
     expect(appMenuLabels()).toContain(UNINSTALL_LABEL);
     expect(appMenuLabels()).not.toContain(INSTALL_LABEL);
+    expect(appMenuLabels()).not.toContain(REPAIR_LABEL);
     expect(appMenuLabels()).not.toContain(SHADOWED_LABEL);
+  });
+
+  test("shows Repair alongside Uninstall when the runtime is missing", async () => {
+    await setStateAndRefresh({
+      kind: "installed",
+      inPath: true,
+      runtimeReady: false,
+    });
+    expect(appMenuLabels()).toContain(REPAIR_LABEL);
+    expect(appMenuLabels()).toContain(UNINSTALL_LABEL);
+    expect(appMenuLabels()).not.toContain(INSTALL_LABEL);
+  });
+
+  test("shows Repair when shadowed with a missing runtime", async () => {
+    await setStateAndRefresh({
+      kind: "shadowed",
+      shadowedBy: "/usr/local/bin/vellum",
+      inPath: true,
+      runtimeReady: false,
+    });
+    expect(appMenuLabels()).toContain(REPAIR_LABEL);
+    expect(appMenuLabels()).toContain(UNINSTALL_LABEL);
+  });
+
+  test("clicking Repair runs the install flow, then Repair disappears once the runtime is ready", async () => {
+    await setStateAndRefresh({
+      kind: "installed",
+      inPath: true,
+      runtimeReady: false,
+    });
+    getCliPathInstallStateMock.mockResolvedValue({
+      kind: "installed",
+      inPath: true,
+      runtimeReady: true,
+    });
+
+    await appMenuItem(REPAIR_LABEL)?.click?.();
+
+    expect(runInstallCliCommandFlowMock).toHaveBeenCalledTimes(1);
+    expect(appMenuLabels()).not.toContain(REPAIR_LABEL);
+    expect(appMenuLabels()).toContain(UNINSTALL_LABEL);
   });
 
   test("shows Uninstall plus a disabled shadowed indicator when shadowed", async () => {
@@ -206,6 +249,7 @@ describe("CLI path menu items", () => {
       kind: "shadowed",
       shadowedBy: "/usr/local/bin/vellum",
       inPath: true,
+      runtimeReady: true,
     });
     expect(appMenuLabels()).toContain(UNINSTALL_LABEL);
     expect(appMenuLabels()).not.toContain(INSTALL_LABEL);
@@ -219,7 +263,7 @@ describe("CLI path menu items", () => {
 
     getCliPathInstallStateMock.mockImplementation(async () => {
       callOrder.push("detect");
-      return { kind: "installed", inPath: true };
+      return { kind: "installed", inPath: true, runtimeReady: true };
     });
     await appMenuItem(INSTALL_LABEL)?.click?.();
 
@@ -233,7 +277,7 @@ describe("CLI path menu items", () => {
   });
 
   test("clicking Uninstall runs the flow, then refreshes state and rebuilds", async () => {
-    await setStateAndRefresh({ kind: "installed", inPath: true });
+    await setStateAndRefresh({ kind: "installed", inPath: true, runtimeReady: true });
     getCliPathInstallStateMock.mockClear();
     const buildsBefore = buildFromTemplateMock.mock.calls.length;
 
@@ -285,7 +329,7 @@ describe("app submenu separators", () => {
     );
 
   test("no adjacent separators when CLI items are present", async () => {
-    await setStateAndRefresh({ kind: "installed", inPath: true });
+    await setStateAndRefresh({ kind: "installed", inPath: true, runtimeReady: true });
     expect(hasAdjacentSeparators(appSubmenu())).toBe(false);
   });
 
@@ -307,7 +351,7 @@ describe("CLI path menu items in unpackaged builds", () => {
   });
 
   test("hides Uninstall even when a prior detection found an install", async () => {
-    await setStateAndRefresh({ kind: "installed", inPath: true });
+    await setStateAndRefresh({ kind: "installed", inPath: true, runtimeReady: true });
     expect(appMenuLabels()).toContain(UNINSTALL_LABEL);
 
     electronApp.isPackaged = false;

--- a/apps/macos/src/main/menu.test.ts
+++ b/apps/macos/src/main/menu.test.ts
@@ -9,6 +9,7 @@ import type { CliPathInstallState } from "./cli-path-installer";
 type TemplateItem = {
   label?: string;
   role?: string;
+  type?: string;
   enabled?: boolean;
   click?: () => void | Promise<void>;
   submenu?: TemplateItem[];
@@ -105,9 +106,11 @@ const runInstallCliCommandFlowMock = mock(async () => {
 const runUninstallCliCommandFlowMock = mock(async () => {
   callOrder.push("uninstall-flow");
 });
+const isCliPathFlowInFlightMock = mock(() => false);
 mock.module("./cli-path-flow", () => ({
   runInstallCliCommandFlow: runInstallCliCommandFlowMock,
   runUninstallCliCommandFlow: runUninstallCliCommandFlowMock,
+  isCliPathFlowInFlight: isCliPathFlowInFlightMock,
 }));
 
 const { installApplicationMenu, refreshCliPathMenuState } = await import(
@@ -152,8 +155,16 @@ beforeEach(async () => {
   buildFromTemplateMock.mockClear();
   setApplicationMenuMock.mockClear();
   getCliPathInstallStateMock.mockClear();
-  runInstallCliCommandFlowMock.mockClear();
-  runUninstallCliCommandFlowMock.mockClear();
+  runInstallCliCommandFlowMock.mockReset();
+  runInstallCliCommandFlowMock.mockImplementation(async () => {
+    callOrder.push("install-flow");
+  });
+  runUninstallCliCommandFlowMock.mockReset();
+  runUninstallCliCommandFlowMock.mockImplementation(async () => {
+    callOrder.push("uninstall-flow");
+  });
+  isCliPathFlowInFlightMock.mockReset();
+  isCliPathFlowInFlightMock.mockImplementation(() => false);
   callOrder.length = 0;
 });
 
@@ -194,6 +205,7 @@ describe("CLI path menu items", () => {
     await setStateAndRefresh({
       kind: "shadowed",
       shadowedBy: "/usr/local/bin/vellum",
+      inPath: true,
     });
     expect(appMenuLabels()).toContain(UNINSTALL_LABEL);
     expect(appMenuLabels()).not.toContain(INSTALL_LABEL);
@@ -214,8 +226,9 @@ describe("CLI path menu items", () => {
     expect(runInstallCliCommandFlowMock).toHaveBeenCalledTimes(1);
     expect(getCliPathInstallStateMock).toHaveBeenCalledTimes(1);
     expect(callOrder).toEqual(["install-flow", "detect"]);
-    // The rebuild reflects the new state: Install flipped to Uninstall.
-    expect(buildFromTemplateMock.mock.calls.length).toBe(buildsBefore + 1);
+    // Two rebuilds: the immediate in-flight render, then the final one
+    // reflecting the new state: Install flipped to Uninstall.
+    expect(buildFromTemplateMock.mock.calls.length).toBe(buildsBefore + 2);
     expect(appMenuLabels()).toContain(UNINSTALL_LABEL);
   });
 
@@ -233,8 +246,54 @@ describe("CLI path menu items", () => {
     expect(runUninstallCliCommandFlowMock).toHaveBeenCalledTimes(1);
     expect(getCliPathInstallStateMock).toHaveBeenCalledTimes(1);
     expect(callOrder).toEqual(["uninstall-flow", "detect"]);
-    expect(buildFromTemplateMock.mock.calls.length).toBe(buildsBefore + 1);
+    expect(buildFromTemplateMock.mock.calls.length).toBe(buildsBefore + 2);
     expect(appMenuLabels()).toContain(INSTALL_LABEL);
+  });
+
+  test("renders the CLI path item disabled while a flow is in flight", async () => {
+    isCliPathFlowInFlightMock.mockReturnValue(true);
+    await setStateAndRefresh({ kind: "not-installed" });
+    expect(appMenuItem(INSTALL_LABEL)?.enabled).toBe(false);
+  });
+
+  test("clicking Install immediately re-renders the item disabled, re-enabling after the flow", async () => {
+    await setStateAndRefresh({ kind: "not-installed" });
+    let release!: () => void;
+    runInstallCliCommandFlowMock.mockImplementation(() => {
+      isCliPathFlowInFlightMock.mockReturnValue(true);
+      return new Promise<void>((resolve) => {
+        release = resolve;
+      });
+    });
+
+    const clicking = appMenuItem(INSTALL_LABEL)?.click?.();
+    // The synchronous re-render shows the item disabled mid-flow.
+    expect(appMenuItem(INSTALL_LABEL)?.enabled).toBe(false);
+
+    isCliPathFlowInFlightMock.mockReturnValue(false);
+    release();
+    await clicking;
+    expect(appMenuItem(INSTALL_LABEL)?.enabled).toBe(true);
+  });
+});
+
+describe("app submenu separators", () => {
+  const hasAdjacentSeparators = (items: TemplateItem[]): boolean =>
+    items.some(
+      (item, i) =>
+        item.type === "separator" && items[i - 1]?.type === "separator",
+    );
+
+  test("no adjacent separators when CLI items are present", async () => {
+    await setStateAndRefresh({ kind: "installed", inPath: true });
+    expect(hasAdjacentSeparators(appSubmenu())).toBe(false);
+  });
+
+  test("no adjacent separators when CLI items are hidden (dev build)", async () => {
+    electronApp.isPackaged = false;
+    await refreshCliPathMenuState();
+    expect(appMenuLabels()).not.toContain(INSTALL_LABEL);
+    expect(hasAdjacentSeparators(appSubmenu())).toBe(false);
   });
 });
 

--- a/apps/macos/src/main/menu.test.ts
+++ b/apps/macos/src/main/menu.test.ts
@@ -1,0 +1,249 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { CliPathInstallState } from "./cli-path-installer";
+
+// ---------------------------------------------------------------------------
+// Stubs and mocks (before importing ./menu)
+// ---------------------------------------------------------------------------
+
+type TemplateItem = {
+  label?: string;
+  role?: string;
+  enabled?: boolean;
+  click?: () => void | Promise<void>;
+  submenu?: TemplateItem[];
+};
+
+const buildFromTemplateMock = mock((template: TemplateItem[]) => ({
+  template,
+  popup: () => undefined,
+}));
+const setApplicationMenuMock = mock((_menu: unknown) => undefined);
+
+mock.module("electron", () => ({
+  app: {
+    name: "Vellum Electron",
+    isPackaged: false,
+  },
+  Menu: {
+    buildFromTemplate: buildFromTemplateMock,
+    setApplicationMenu: setApplicationMenuMock,
+  },
+  shell: {
+    openExternal: mock(() => Promise.resolve()),
+  },
+}));
+
+mock.module("./about", () => ({
+  openAboutWindow: () => undefined,
+}));
+
+mock.module("./auto-update", () => ({
+  checkForUpdates: () => undefined,
+}));
+
+mock.module("./commands", () => ({
+  acceleratorOption: () => ({}),
+  dispatchToFocused: () => undefined,
+}));
+
+mock.module("./command-palette-window", () => ({
+  closeCommandPaletteWindow: () => undefined,
+  isCommandPaletteWindowFocused: () => false,
+  openCommandPaletteWindow: () => undefined,
+}));
+
+mock.module("./devtools", () => ({
+  areChromeDevToolsEnabled: () => false,
+}));
+
+mock.module("./ipc", () => ({
+  handle: () => undefined,
+}));
+
+mock.module("./main-window", () => ({
+  dispatchToMain: () => undefined,
+}));
+
+// Full `./settings` surface so this mock — which leaks into co-run test files
+// via the global module registry — doesn't break sibling modules.
+mock.module("./settings", () => ({
+  readSetting: () => null,
+  readHotkeyOverride: () => null,
+  writeSetting: () => {},
+  onSettingChange: () => () => {},
+}));
+
+mock.module("./window-state", () => ({
+  readOnboardingActive: () => false,
+}));
+
+const getCliPathInstallStateMock = mock(
+  async (): Promise<CliPathInstallState> => ({ kind: "not-installed" }),
+);
+// Full `./cli-path-installer` surface so this mock — which leaks into co-run
+// test files via the global module registry — doesn't break sibling modules.
+mock.module("./cli-path-installer", () => ({
+  WRAPPER_MARKER: "# vellum-cli-wrapper v1",
+  getWrapperDir: () => "/tmp/.local/bin",
+  getWrapperPath: () => "/tmp/.local/bin/vellum",
+  buildWrapperScript: () => "",
+  readWrapperOwnership: () => "absent",
+  installWrapper: () => "installed",
+  getCliPathInstallState: getCliPathInstallStateMock,
+  uninstallWrapper: () => "absent",
+}));
+
+const callOrder: string[] = [];
+const runInstallCliCommandFlowMock = mock(async () => {
+  callOrder.push("install-flow");
+});
+const runUninstallCliCommandFlowMock = mock(async () => {
+  callOrder.push("uninstall-flow");
+});
+mock.module("./cli-path-flow", () => ({
+  runInstallCliCommandFlow: runInstallCliCommandFlowMock,
+  runUninstallCliCommandFlow: runUninstallCliCommandFlowMock,
+}));
+
+const { installApplicationMenu, refreshCliPathMenuState } = await import(
+  "./menu"
+);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const lastTemplate = (): TemplateItem[] =>
+  buildFromTemplateMock.mock.calls.at(-1)?.[0] ?? [];
+
+const appSubmenu = (): TemplateItem[] => lastTemplate()[0]?.submenu ?? [];
+
+const appMenuItem = (label: string): TemplateItem | undefined =>
+  appSubmenu().find((item) => item.label === label);
+
+const appMenuLabels = (): string[] =>
+  appSubmenu()
+    .map((item) => item.label)
+    .filter((label): label is string => Boolean(label));
+
+const setStateAndRefresh = async (state: CliPathInstallState) => {
+  getCliPathInstallStateMock.mockResolvedValue(state);
+  await refreshCliPathMenuState();
+};
+
+const INSTALL_LABEL = "Install vellum Command…";
+const UNINSTALL_LABEL = "Uninstall vellum Command";
+const SHADOWED_LABEL = "⚠ vellum is shadowed by another install";
+
+installApplicationMenu();
+
+beforeEach(async () => {
+  getCliPathInstallStateMock.mockReset();
+  getCliPathInstallStateMock.mockResolvedValue({ kind: "not-installed" });
+  // Settle any pending refresh kicked off by installApplicationMenu before
+  // clearing call records, so tests observe only their own activity.
+  await refreshCliPathMenuState();
+  buildFromTemplateMock.mockClear();
+  setApplicationMenuMock.mockClear();
+  getCliPathInstallStateMock.mockClear();
+  runInstallCliCommandFlowMock.mockClear();
+  runUninstallCliCommandFlowMock.mockClear();
+  callOrder.length = 0;
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("CLI path menu items", () => {
+  test("shows Install while detection state is unknown (null)", async () => {
+    // Detection failure leaves the state null, the same shape the menu has
+    // between startup and the first detection result.
+    getCliPathInstallStateMock.mockRejectedValue(new Error("pending"));
+    await refreshCliPathMenuState();
+    expect(appMenuLabels()).toContain(INSTALL_LABEL);
+    expect(appMenuLabels()).not.toContain(UNINSTALL_LABEL);
+  });
+
+  test("shows Install when not installed", async () => {
+    await setStateAndRefresh({ kind: "not-installed" });
+    expect(appMenuLabels()).toContain(INSTALL_LABEL);
+    expect(appMenuLabels()).not.toContain(UNINSTALL_LABEL);
+  });
+
+  test("shows Install when a foreign file occupies the wrapper path", async () => {
+    await setStateAndRefresh({ kind: "foreign-file" });
+    expect(appMenuLabels()).toContain(INSTALL_LABEL);
+    expect(appMenuLabels()).not.toContain(UNINSTALL_LABEL);
+  });
+
+  test("shows Uninstall when installed, without the shadowed indicator", async () => {
+    await setStateAndRefresh({ kind: "installed", inPath: true });
+    expect(appMenuLabels()).toContain(UNINSTALL_LABEL);
+    expect(appMenuLabels()).not.toContain(INSTALL_LABEL);
+    expect(appMenuLabels()).not.toContain(SHADOWED_LABEL);
+  });
+
+  test("shows Uninstall plus a disabled shadowed indicator when shadowed", async () => {
+    await setStateAndRefresh({
+      kind: "shadowed",
+      shadowedBy: "/usr/local/bin/vellum",
+    });
+    expect(appMenuLabels()).toContain(UNINSTALL_LABEL);
+    expect(appMenuLabels()).not.toContain(INSTALL_LABEL);
+    expect(appMenuItem(SHADOWED_LABEL)?.enabled).toBe(false);
+  });
+
+  test("clicking Install runs the flow, then refreshes state and rebuilds", async () => {
+    await setStateAndRefresh({ kind: "not-installed" });
+    getCliPathInstallStateMock.mockClear();
+    const buildsBefore = buildFromTemplateMock.mock.calls.length;
+
+    getCliPathInstallStateMock.mockImplementation(async () => {
+      callOrder.push("detect");
+      return { kind: "installed", inPath: true };
+    });
+    await appMenuItem(INSTALL_LABEL)?.click?.();
+
+    expect(runInstallCliCommandFlowMock).toHaveBeenCalledTimes(1);
+    expect(getCliPathInstallStateMock).toHaveBeenCalledTimes(1);
+    expect(callOrder).toEqual(["install-flow", "detect"]);
+    // The rebuild reflects the new state: Install flipped to Uninstall.
+    expect(buildFromTemplateMock.mock.calls.length).toBe(buildsBefore + 1);
+    expect(appMenuLabels()).toContain(UNINSTALL_LABEL);
+  });
+
+  test("clicking Uninstall runs the flow, then refreshes state and rebuilds", async () => {
+    await setStateAndRefresh({ kind: "installed", inPath: true });
+    getCliPathInstallStateMock.mockClear();
+    const buildsBefore = buildFromTemplateMock.mock.calls.length;
+
+    getCliPathInstallStateMock.mockImplementation(async () => {
+      callOrder.push("detect");
+      return { kind: "not-installed" };
+    });
+    await appMenuItem(UNINSTALL_LABEL)?.click?.();
+
+    expect(runUninstallCliCommandFlowMock).toHaveBeenCalledTimes(1);
+    expect(getCliPathInstallStateMock).toHaveBeenCalledTimes(1);
+    expect(callOrder).toEqual(["uninstall-flow", "detect"]);
+    expect(buildFromTemplateMock.mock.calls.length).toBe(buildsBefore + 1);
+    expect(appMenuLabels()).toContain(INSTALL_LABEL);
+  });
+});
+
+describe("refreshCliPathMenuState", () => {
+  test("rebuilds and reinstalls the application menu", async () => {
+    await refreshCliPathMenuState();
+    expect(buildFromTemplateMock).toHaveBeenCalledTimes(1);
+    expect(setApplicationMenuMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("a detection failure falls back to the Install item without throwing", async () => {
+    getCliPathInstallStateMock.mockRejectedValue(new Error("boom"));
+    await refreshCliPathMenuState();
+    expect(appMenuLabels()).toContain(INSTALL_LABEL);
+    expect(setApplicationMenuMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/macos/src/main/menu.ts
+++ b/apps/macos/src/main/menu.ts
@@ -40,10 +40,12 @@ const state: MenuState = {
 let cliPathState: CliPathInstallState | null = null;
 
 export const refreshCliPathMenuState = async (): Promise<void> => {
-  try {
-    cliPathState = await getCliPathInstallState();
-  } catch {
-    cliPathState = null;
+  if (app.isPackaged) {
+    try {
+      cliPathState = await getCliPathInstallState();
+    } catch {
+      cliPathState = null;
+    }
   }
   applyMenu();
 };
@@ -60,6 +62,8 @@ const cliPathFlowItem = (
 });
 
 const cliPathItems = (): MenuItemConstructorOptions[] => {
+  // Only packaged builds manage the shared ~/.local/bin/vellum wrapper.
+  if (!app.isPackaged) return [];
   const kind = cliPathState?.kind;
   if (kind === "installed" || kind === "shadowed") {
     return [
@@ -317,6 +321,9 @@ export const installApplicationMenu = (): void => {
   applyMenu();
 
   // Detect the vellum CLI install state asynchronously so menu setup never
-  // waits on (or breaks from) login-shell PATH resolution.
-  void refreshCliPathMenuState();
+  // waits on (or breaks from) login-shell PATH resolution. Packaged-only:
+  // dev builds neither show the items nor spawn the detection shell.
+  if (app.isPackaged) {
+    void refreshCliPathMenuState();
+  }
 };

--- a/apps/macos/src/main/menu.ts
+++ b/apps/macos/src/main/menu.ts
@@ -4,6 +4,14 @@ import { z } from "zod";
 import { openAboutWindow } from "./about";
 import { checkForUpdates } from "./auto-update";
 import {
+  runInstallCliCommandFlow,
+  runUninstallCliCommandFlow,
+} from "./cli-path-flow";
+import {
+  type CliPathInstallState,
+  getCliPathInstallState,
+} from "./cli-path-installer";
+import {
   acceleratorOption,
   dispatchToFocused,
   type VellumCommand,
@@ -25,6 +33,50 @@ interface MenuState {
 
 const state: MenuState = {
   hasPlatformSession: false,
+};
+
+// Null until the first detection completes; the menu shows the Install item
+// in the meantime (the install flow is safe to run from any state).
+let cliPathState: CliPathInstallState | null = null;
+
+export const refreshCliPathMenuState = async (): Promise<void> => {
+  try {
+    cliPathState = await getCliPathInstallState();
+  } catch {
+    cliPathState = null;
+  }
+  applyMenu();
+};
+
+const cliPathFlowItem = (
+  label: string,
+  flow: () => Promise<void>,
+): MenuItemConstructorOptions => ({
+  label,
+  click: async () => {
+    await flow();
+    await refreshCliPathMenuState();
+  },
+});
+
+const cliPathItems = (): MenuItemConstructorOptions[] => {
+  const kind = cliPathState?.kind;
+  if (kind === "installed" || kind === "shadowed") {
+    return [
+      ...(kind === "shadowed"
+        ? [
+            {
+              label: "⚠ vellum is shadowed by another install",
+              enabled: false,
+            },
+          ]
+        : []),
+      cliPathFlowItem("Uninstall vellum Command", runUninstallCliCommandFlow),
+    ];
+  }
+  return [
+    cliPathFlowItem("Install vellum Command\u2026", runInstallCliCommandFlow),
+  ];
 };
 
 const isDeveloperMenuEnabled = (): boolean => {
@@ -89,6 +141,8 @@ const buildTemplate = (): MenuItemConstructorOptions[] => {
           enabled: !readOnboardingActive(),
           click: () => dispatchMenuCommand({ kind: "openSettings" }),
         },
+        { type: "separator" },
+        ...cliPathItems(),
         { type: "separator" },
         { role: "services" },
         { type: "separator" },
@@ -261,4 +315,8 @@ export const installApplicationMenu = (): void => {
   });
 
   applyMenu();
+
+  // Detect the vellum CLI install state asynchronously so menu setup never
+  // waits on (or breaks from) login-shell PATH resolution.
+  void refreshCliPathMenuState();
 };

--- a/apps/macos/src/main/menu.ts
+++ b/apps/macos/src/main/menu.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { openAboutWindow } from "./about";
 import { checkForUpdates } from "./auto-update";
 import {
+  isCliPathFlowInFlight,
   runInstallCliCommandFlow,
   runUninstallCliCommandFlow,
 } from "./cli-path-flow";
@@ -55,8 +56,12 @@ const cliPathFlowItem = (
   flow: () => Promise<void>,
 ): MenuItemConstructorOptions => ({
   label,
+  enabled: !isCliPathFlowInFlight(),
   click: async () => {
-    await flow();
+    const flowDone = flow();
+    // Re-render immediately so the item is disabled while the flow runs.
+    applyMenu();
+    await flowDone;
     await refreshCliPathMenuState();
   },
 });
@@ -108,6 +113,7 @@ const buildTemplate = (): MenuItemConstructorOptions[] => {
   const isDev = !app.isPackaged;
   const chromeDevToolsEnabled = areChromeDevToolsEnabled();
   const developerMenuEnabled = isDeveloperMenuEnabled();
+  const cliItems = cliPathItems();
 
   const fileItem = (
     label: string,
@@ -146,8 +152,8 @@ const buildTemplate = (): MenuItemConstructorOptions[] => {
           click: () => dispatchMenuCommand({ kind: "openSettings" }),
         },
         { type: "separator" },
-        ...cliPathItems(),
-        { type: "separator" },
+        ...cliItems,
+        ...(cliItems.length > 0 ? [{ type: "separator" as const }] : []),
         { role: "services" },
         { type: "separator" },
         {
@@ -321,9 +327,7 @@ export const installApplicationMenu = (): void => {
   applyMenu();
 
   // Detect the vellum CLI install state asynchronously so menu setup never
-  // waits on (or breaks from) login-shell PATH resolution. Packaged-only:
-  // dev builds neither show the items nor spawn the detection shell.
-  if (app.isPackaged) {
-    void refreshCliPathMenuState();
-  }
+  // waits on (or breaks from) login-shell PATH resolution; packaged-only
+  // gating lives inside refreshCliPathMenuState.
+  void refreshCliPathMenuState();
 };

--- a/apps/macos/src/main/menu.ts
+++ b/apps/macos/src/main/menu.ts
@@ -69,15 +69,25 @@ const cliPathFlowItem = (
 const cliPathItems = (): MenuItemConstructorOptions[] => {
   // Only packaged builds manage the shared ~/.local/bin/vellum wrapper.
   if (!app.isPackaged) return [];
-  const kind = cliPathState?.kind;
-  if (kind === "installed" || kind === "shadowed") {
+  const cliState = cliPathState;
+  if (cliState?.kind === "installed" || cliState?.kind === "shadowed") {
     return [
-      ...(kind === "shadowed"
+      ...(cliState.kind === "shadowed"
         ? [
             {
               label: "⚠ vellum is shadowed by another install",
               enabled: false,
             },
+          ]
+        : []),
+      // Wrapper exists but the CLI runtime never provisioned; the install
+      // flow is idempotent, so re-running it doubles as repair.
+      ...(!cliState.runtimeReady
+        ? [
+            cliPathFlowItem(
+              "Repair vellum Command\u2026",
+              runInstallCliCommandFlow,
+            ),
           ]
         : []),
       cliPathFlowItem("Uninstall vellum Command", runUninstallCliCommandFlow),

--- a/apps/macos/src/main/shell-path.test.ts
+++ b/apps/macos/src/main/shell-path.test.ts
@@ -28,6 +28,7 @@ mock.module("node:fs", () => ({
   },
   constants: { X_OK: 1 },
   // Used by cli-installer's buildInstallEnv (nvm detection).
+  chmodSync: () => {},
   copyFileSync: () => {},
   existsSync: () => false,
   mkdirSync: () => {},
@@ -51,14 +52,22 @@ mock.module("node:child_process", () => ({
 const {
   resolveShellPath,
   findExecutablesInPath,
+  splitPathEntries,
   _resetShellPathCache,
-  PATH_SENTINEL,
 } = await import("./shell-path");
 const { buildInstallEnv } = await import("./cli-installer");
 
 const originalShell = process.env.SHELL;
 
+// Mirrors the internal sentinel in shell-path.ts (intentionally unexported).
+const PATH_SENTINEL = "__VELLUM_PATH_7f3a__";
+
 const wrap = (path: string) => `${PATH_SENTINEL}${path}${PATH_SENTINEL}`;
+
+const fallbackResult = () => ({
+  path: buildInstallEnv().PATH ?? "",
+  reliable: false,
+});
 
 afterEach(() => {
   spawnCalls.length = 0;
@@ -71,7 +80,7 @@ afterEach(() => {
 // --- resolveShellPath ---
 
 describe("resolveShellPath", () => {
-  test("returns the shell's stdout PATH using $SHELL", async () => {
+  test("returns the shell's stdout PATH as reliable, using $SHELL", async () => {
     process.env.SHELL = "/bin/bash";
 
     const promise = resolveShellPath();
@@ -81,7 +90,10 @@ describe("resolveShellPath", () => {
     );
     lastChild.emit("close", 0);
 
-    expect(await promise).toBe("/Users/me/.local/bin:/usr/bin");
+    expect(await promise).toEqual({
+      path: "/Users/me/.local/bin:/usr/bin",
+      reliable: true,
+    });
     expect(spawnCalls).toHaveLength(1);
     expect(spawnCalls[0][0]).toBe("/bin/bash");
     expect(spawnCalls[0][1]).toEqual([
@@ -98,15 +110,18 @@ describe("resolveShellPath", () => {
     );
     lastChild.emit("close", 0);
 
-    expect(await promise).toBe("/usr/local/bin:/usr/bin");
+    expect(await promise).toEqual({
+      path: "/usr/local/bin:/usr/bin",
+      reliable: true,
+    });
   });
 
-  test("falls back to buildInstallEnv PATH when sentinels are missing", async () => {
+  test("falls back to unreliable buildInstallEnv PATH when sentinels are missing", async () => {
     const promise = resolveShellPath();
     lastChild.stdout.emit("data", Buffer.from("banner only, no sentinel"));
     lastChild.emit("close", 0);
 
-    expect(await promise).toBe(buildInstallEnv().PATH ?? "");
+    expect(await promise).toEqual(fallbackResult());
   });
 
   test("falls back to /bin/zsh when $SHELL is unset", async () => {
@@ -120,32 +135,32 @@ describe("resolveShellPath", () => {
     expect(spawnCalls[0][0]).toBe("/bin/zsh");
   });
 
-  test("falls back to buildInstallEnv PATH on non-zero exit", async () => {
+  test("falls back to unreliable buildInstallEnv PATH on non-zero exit", async () => {
     const promise = resolveShellPath();
     lastChild.stderr.emit("data", Buffer.from("zsh: bad rc file"));
     lastChild.emit("close", 1);
 
-    expect(await promise).toBe(buildInstallEnv().PATH ?? "");
+    expect(await promise).toEqual(fallbackResult());
   });
 
-  test("falls back to buildInstallEnv PATH on empty output", async () => {
+  test("falls back to unreliable buildInstallEnv PATH on empty output", async () => {
     const promise = resolveShellPath();
     lastChild.emit("close", 0);
 
-    expect(await promise).toBe(buildInstallEnv().PATH ?? "");
+    expect(await promise).toEqual(fallbackResult());
   });
 
-  test("falls back to buildInstallEnv PATH on spawn error", async () => {
+  test("falls back to unreliable buildInstallEnv PATH on spawn error", async () => {
     const promise = resolveShellPath();
     lastChild.emit("error", new Error("ENOENT"));
 
-    expect(await promise).toBe(buildInstallEnv().PATH ?? "");
+    expect(await promise).toEqual(fallbackResult());
   });
 
   test("kills the child and falls back on timeout", async () => {
     const promise = resolveShellPath(10);
 
-    expect(await promise).toBe(buildInstallEnv().PATH ?? "");
+    expect(await promise).toEqual(fallbackResult());
     expect(lastChild.kill).toHaveBeenCalled();
   });
 
@@ -156,8 +171,8 @@ describe("resolveShellPath", () => {
     lastChild.stdout.emit("data", Buffer.from(wrap("/late/bin")));
     lastChild.emit("close", 0);
 
-    expect(result).toBe(buildInstallEnv().PATH ?? "");
-    expect(await resolveShellPath()).toBe(result);
+    expect(result).toEqual(fallbackResult());
+    expect(await resolveShellPath()).toEqual(result);
   });
 
   test("caches the result; second call does not spawn again", async () => {
@@ -166,7 +181,10 @@ describe("resolveShellPath", () => {
     lastChild.emit("close", 0);
     await promise;
 
-    expect(await resolveShellPath()).toBe("/cached/bin");
+    expect(await resolveShellPath()).toEqual({
+      path: "/cached/bin",
+      reliable: true,
+    });
     expect(spawnCalls).toHaveLength(1);
   });
 
@@ -178,8 +196,8 @@ describe("resolveShellPath", () => {
     lastChild.stdout.emit("data", Buffer.from(wrap("/shared/bin")));
     lastChild.emit("close", 0);
 
-    expect(await p1).toBe("/shared/bin");
-    expect(await p2).toBe("/shared/bin");
+    expect((await p1).path).toBe("/shared/bin");
+    expect((await p2).path).toBe("/shared/bin");
   });
 
   test("_resetShellPathCache clears the cache", async () => {
@@ -194,7 +212,31 @@ describe("resolveShellPath", () => {
     expect(spawnCalls).toHaveLength(2);
     lastChild.stdout.emit("data", Buffer.from(wrap("/second/bin")));
     lastChild.emit("close", 0);
-    expect(await p2).toBe("/second/bin");
+    expect((await p2).path).toBe("/second/bin");
+  });
+});
+
+// --- splitPathEntries ---
+
+describe("splitPathEntries", () => {
+  test("splits on colons preserving order", () => {
+    expect(splitPathEntries("/a:/b:/c")).toEqual(["/a", "/b", "/c"]);
+  });
+
+  test("strips trailing slashes", () => {
+    expect(splitPathEntries("/a/:/b//")).toEqual(["/a", "/b"]);
+  });
+
+  test("skips empty entries", () => {
+    expect(splitPathEntries(":/a::")).toEqual(["/a"]);
+  });
+
+  test("dedupes entries, including slash variants", () => {
+    expect(splitPathEntries("/a:/a/:/b:/a")).toEqual(["/a", "/b"]);
+  });
+
+  test("returns empty array for an empty value", () => {
+    expect(splitPathEntries("")).toEqual([]);
   });
 });
 
@@ -223,6 +265,12 @@ describe("findExecutablesInPath", () => {
     expect(findExecutablesInPath("vellum", ":/a::/a:/a:")).toEqual([
       "/a/vellum",
     ]);
+  });
+
+  test("normalizes trailing-slash entries to the same hit", () => {
+    executablePaths.add("/a/vellum");
+
+    expect(findExecutablesInPath("vellum", "/a/:/a")).toEqual(["/a/vellum"]);
   });
 
   test("returns empty array when nothing matches", () => {

--- a/apps/macos/src/main/shell-path.test.ts
+++ b/apps/macos/src/main/shell-path.test.ts
@@ -43,6 +43,7 @@ const {
   resolveShellPath,
   findExecutablesInPath,
   splitPathEntries,
+  isFishShell,
   _resetShellPathCache,
 } = await import("./shell-path");
 
@@ -70,6 +71,22 @@ afterEach(() => {
   setSystemTime();
   if (originalShell === undefined) delete process.env.SHELL;
   else process.env.SHELL = originalShell;
+});
+
+// --- isFishShell ---
+
+describe("isFishShell", () => {
+  test("true for a fish $SHELL", () => {
+    process.env.SHELL = "/opt/homebrew/bin/fish";
+    expect(isFishShell()).toBe(true);
+  });
+
+  test("false for POSIX shells and when $SHELL is unset", () => {
+    process.env.SHELL = "/bin/zsh";
+    expect(isFishShell()).toBe(false);
+    delete process.env.SHELL;
+    expect(isFishShell()).toBe(false);
+  });
 });
 
 // --- resolveShellPath ---

--- a/apps/macos/src/main/shell-path.test.ts
+++ b/apps/macos/src/main/shell-path.test.ts
@@ -1,41 +1,31 @@
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  setSystemTime,
+  test,
+} from "bun:test";
 
 import { FakeChild } from "./test-helpers";
 
 // --- Mocks ---
 // Must be installed before the `await import` of the module under test so
-// the mocked module graph is in place when `shell-path.ts` (and its
-// `cli-installer.ts` dependency) is evaluated. See `commands.test.ts` for
-// the ordering rationale.
-
-mock.module("electron", () => ({
-  app: {
-    getPath: () => "/mock/userData",
-    isPackaged: true,
-  },
-}));
-
-mock.module("./logger", () => ({
-  default: { info: () => {}, warn: () => {}, error: () => {} },
-}));
+// the mocked module graph is in place when `shell-path.ts` is evaluated.
+// See `commands.test.ts` for the ordering rationale.
 
 // Paths for which the mocked accessSync(X_OK) succeeds.
 const executablePaths = new Set<string>();
+// Paths whose stat (after following symlinks) reports a directory.
+const directoryPaths = new Set<string>();
 
 mock.module("node:fs", () => ({
   accessSync: (p: string) => {
     if (!executablePaths.has(p)) throw new Error(`EACCES: ${p}`);
   },
+  statSync: (p: string) => ({ isFile: () => !directoryPaths.has(p) }),
   constants: { X_OK: 1 },
-  // Used by cli-installer's buildInstallEnv (nvm detection).
-  chmodSync: () => {},
-  copyFileSync: () => {},
-  existsSync: () => false,
-  mkdirSync: () => {},
-  readdirSync: () => [],
-  renameSync: () => {},
-  rmSync: () => {},
-  writeFileSync: () => {},
 }));
 
 let lastChild: FakeChild;
@@ -55,7 +45,6 @@ const {
   splitPathEntries,
   _resetShellPathCache,
 } = await import("./shell-path");
-const { buildInstallEnv } = await import("./cli-installer");
 
 const originalShell = process.env.SHELL;
 
@@ -64,15 +53,21 @@ const PATH_SENTINEL = "__VELLUM_PATH_7f3a__";
 
 const wrap = (path: string) => `${PATH_SENTINEL}${path}${PATH_SENTINEL}`;
 
-const fallbackResult = () => ({
-  path: buildInstallEnv().PATH ?? "",
-  reliable: false,
+const POSIX_QUERY = `printf "${PATH_SENTINEL}%s${PATH_SENTINEL}" "$PATH"`;
+const FISH_QUERY = `printf "${PATH_SENTINEL}%s${PATH_SENTINEL}" (string join : $PATH)`;
+
+// Deterministic default regardless of the developer's real shell; individual
+// tests override.
+beforeEach(() => {
+  process.env.SHELL = "/bin/zsh";
 });
 
 afterEach(() => {
   spawnCalls.length = 0;
   executablePaths.clear();
+  directoryPaths.clear();
   _resetShellPathCache();
+  setSystemTime();
   if (originalShell === undefined) delete process.env.SHELL;
   else process.env.SHELL = originalShell;
 });
@@ -80,7 +75,7 @@ afterEach(() => {
 // --- resolveShellPath ---
 
 describe("resolveShellPath", () => {
-  test("returns the shell's stdout PATH as reliable, using $SHELL", async () => {
+  test("returns the shell's stdout PATH, using $SHELL with the POSIX query", async () => {
     process.env.SHELL = "/bin/bash";
 
     const promise = resolveShellPath();
@@ -90,16 +85,29 @@ describe("resolveShellPath", () => {
     );
     lastChild.emit("close", 0);
 
-    expect(await promise).toEqual({
-      path: "/Users/me/.local/bin:/usr/bin",
-      reliable: true,
-    });
+    expect(await promise).toBe("/Users/me/.local/bin:/usr/bin");
     expect(spawnCalls).toHaveLength(1);
     expect(spawnCalls[0][0]).toBe("/bin/bash");
-    expect(spawnCalls[0][1]).toEqual([
-      "-ilc",
-      `printf "${PATH_SENTINEL}%s${PATH_SENTINEL}" "$PATH"`,
-    ]);
+    expect(spawnCalls[0][1]).toEqual(["-ilc", POSIX_QUERY]);
+  });
+
+  test("uses a fish-native list join for fish shells", async () => {
+    process.env.SHELL = "/opt/homebrew/bin/fish";
+
+    const promise = resolveShellPath();
+    lastChild.stdout.emit("data", Buffer.from(wrap("/usr/local/bin:/usr/bin")));
+    lastChild.emit("close", 0);
+
+    expect(await promise).toBe("/usr/local/bin:/usr/bin");
+    expect(spawnCalls[0][0]).toBe("/opt/homebrew/bin/fish");
+    expect(spawnCalls[0][1]).toEqual(["-ilc", FISH_QUERY]);
+  });
+
+  test("returns null without spawning for unrecognized shells", async () => {
+    process.env.SHELL = "/usr/bin/tcsh";
+
+    expect(await resolveShellPath()).toBeNull();
+    expect(spawnCalls).toHaveLength(0);
   });
 
   test("ignores startup-file banner output before the sentinel pair", async () => {
@@ -110,18 +118,42 @@ describe("resolveShellPath", () => {
     );
     lastChild.emit("close", 0);
 
-    expect(await promise).toEqual({
-      path: "/usr/local/bin:/usr/bin",
-      reliable: true,
-    });
+    expect(await promise).toBe("/usr/local/bin:/usr/bin");
   });
 
-  test("falls back to unreliable buildInstallEnv PATH when sentinels are missing", async () => {
+  test("returns null when sentinels are missing", async () => {
     const promise = resolveShellPath();
     lastChild.stdout.emit("data", Buffer.from("banner only, no sentinel"));
     lastChild.emit("close", 0);
 
-    expect(await promise).toEqual(fallbackResult());
+    expect(await promise).toBeNull();
+  });
+
+  test("returns null for space-joined output that is not a plausible PATH", async () => {
+    const promise = resolveShellPath();
+    lastChild.stdout.emit(
+      "data",
+      Buffer.from(wrap("/usr/local/bin /usr/bin /bin")),
+    );
+    lastChild.emit("close", 0);
+
+    expect(await promise).toBeNull();
+  });
+
+  test("accepts a single absolute directory without separators", async () => {
+    const promise = resolveShellPath();
+    lastChild.stdout.emit("data", Buffer.from(wrap("/usr/bin")));
+    lastChild.emit("close", 0);
+
+    expect(await promise).toBe("/usr/bin");
+  });
+
+  test("returns null for a single relative token", async () => {
+    const promise = resolveShellPath();
+    lastChild.stdout.emit("data", Buffer.from(wrap("garbage")));
+    lastChild.emit("close", 0);
+
+    expect(await promise).toBeNull();
   });
 
   test("falls back to /bin/zsh when $SHELL is unset", async () => {
@@ -135,57 +167,86 @@ describe("resolveShellPath", () => {
     expect(spawnCalls[0][0]).toBe("/bin/zsh");
   });
 
-  test("falls back to unreliable buildInstallEnv PATH on non-zero exit", async () => {
+  test("returns null on non-zero exit", async () => {
     const promise = resolveShellPath();
     lastChild.stderr.emit("data", Buffer.from("zsh: bad rc file"));
     lastChild.emit("close", 1);
 
-    expect(await promise).toEqual(fallbackResult());
+    expect(await promise).toBeNull();
   });
 
-  test("falls back to unreliable buildInstallEnv PATH on empty output", async () => {
+  test("returns null on empty output", async () => {
     const promise = resolveShellPath();
     lastChild.emit("close", 0);
 
-    expect(await promise).toEqual(fallbackResult());
+    expect(await promise).toBeNull();
   });
 
-  test("falls back to unreliable buildInstallEnv PATH on spawn error", async () => {
+  test("returns null on spawn error", async () => {
     const promise = resolveShellPath();
     lastChild.emit("error", new Error("ENOENT"));
 
-    expect(await promise).toEqual(fallbackResult());
+    expect(await promise).toBeNull();
   });
 
-  test("kills the child and falls back on timeout", async () => {
+  test("kills the child and returns null on timeout", async () => {
     const promise = resolveShellPath(10);
 
-    expect(await promise).toEqual(fallbackResult());
+    expect(await promise).toBeNull();
     expect(lastChild.kill).toHaveBeenCalled();
   });
 
-  test("late close after timeout does not override the fallback", async () => {
+  test("late close after timeout does not override the null result", async () => {
     const promise = resolveShellPath(10);
     const result = await promise;
 
     lastChild.stdout.emit("data", Buffer.from(wrap("/late/bin")));
     lastChild.emit("close", 0);
 
-    expect(result).toEqual(fallbackResult());
-    expect(await resolveShellPath()).toEqual(result);
+    expect(result).toBeNull();
   });
 
-  test("caches the result; second call does not spawn again", async () => {
+  test("never caches null: the next call spawns a fresh query", async () => {
+    const failed = resolveShellPath();
+    lastChild.emit("close", 1);
+    expect(await failed).toBeNull();
+
+    const retry = resolveShellPath();
+    expect(spawnCalls).toHaveLength(2);
+    lastChild.stdout.emit("data", Buffer.from(wrap("/retry/bin")));
+    lastChild.emit("close", 0);
+    expect(await retry).toBe("/retry/bin");
+  });
+
+  test("caches a successful result; second call does not spawn again", async () => {
     const promise = resolveShellPath();
     lastChild.stdout.emit("data", Buffer.from(wrap("/cached/bin")));
     lastChild.emit("close", 0);
     await promise;
 
-    expect(await resolveShellPath()).toEqual({
-      path: "/cached/bin",
-      reliable: true,
-    });
+    expect(await resolveShellPath()).toBe("/cached/bin");
     expect(spawnCalls).toHaveLength(1);
+  });
+
+  test("re-queries after the cache TTL elapses", async () => {
+    const start = new Date("2026-01-01T00:00:00Z");
+    setSystemTime(start);
+
+    const first = resolveShellPath();
+    lastChild.stdout.emit("data", Buffer.from(wrap("/first/bin")));
+    lastChild.emit("close", 0);
+    expect(await first).toBe("/first/bin");
+
+    setSystemTime(new Date(start.getTime() + 29_000));
+    expect(await resolveShellPath()).toBe("/first/bin");
+    expect(spawnCalls).toHaveLength(1);
+
+    setSystemTime(new Date(start.getTime() + 31_000));
+    const second = resolveShellPath();
+    expect(spawnCalls).toHaveLength(2);
+    lastChild.stdout.emit("data", Buffer.from(wrap("/second/bin")));
+    lastChild.emit("close", 0);
+    expect(await second).toBe("/second/bin");
   });
 
   test("concurrent first calls share a single spawn", async () => {
@@ -196,8 +257,8 @@ describe("resolveShellPath", () => {
     lastChild.stdout.emit("data", Buffer.from(wrap("/shared/bin")));
     lastChild.emit("close", 0);
 
-    expect((await p1).path).toBe("/shared/bin");
-    expect((await p2).path).toBe("/shared/bin");
+    expect(await p1).toBe("/shared/bin");
+    expect(await p2).toBe("/shared/bin");
   });
 
   test("_resetShellPathCache clears the cache", async () => {
@@ -212,7 +273,7 @@ describe("resolveShellPath", () => {
     expect(spawnCalls).toHaveLength(2);
     lastChild.stdout.emit("data", Buffer.from(wrap("/second/bin")));
     lastChild.emit("close", 0);
-    expect((await p2).path).toBe("/second/bin");
+    expect(await p2).toBe("/second/bin");
   });
 });
 
@@ -257,6 +318,28 @@ describe("findExecutablesInPath", () => {
     executablePaths.add("/b/vellum");
 
     expect(findExecutablesInPath("vellum", "/a:/b")).toEqual(["/b/vellum"]);
+  });
+
+  test("skips directories even though they pass the X_OK probe", () => {
+    executablePaths.add("/a/vellum");
+    directoryPaths.add("/a/vellum");
+    executablePaths.add("/b/vellum");
+
+    expect(findExecutablesInPath("vellum", "/a:/b")).toEqual(["/b/vellum"]);
+  });
+
+  test("keeps symlinks that resolve to executable files (stat follows links)", () => {
+    // Mocked statSync models the followed target: a link to a file.
+    executablePaths.add("/a/vellum");
+
+    expect(findExecutablesInPath("vellum", "/a")).toEqual(["/a/vellum"]);
+  });
+
+  test("skips symlinks that resolve to directories", () => {
+    executablePaths.add("/a/vellum");
+    directoryPaths.add("/a/vellum"); // link target is a directory
+
+    expect(findExecutablesInPath("vellum", "/a")).toEqual([]);
   });
 
   test("skips empty and duplicate PATH entries", () => {

--- a/apps/macos/src/main/shell-path.test.ts
+++ b/apps/macos/src/main/shell-path.test.ts
@@ -15,6 +15,10 @@ mock.module("electron", () => ({
   },
 }));
 
+mock.module("./logger", () => ({
+  default: { info: () => {}, warn: () => {}, error: () => {} },
+}));
+
 // Paths for which the mocked accessSync(X_OK) succeeds.
 const executablePaths = new Set<string>();
 
@@ -28,7 +32,9 @@ mock.module("node:fs", () => ({
   existsSync: () => false,
   mkdirSync: () => {},
   readdirSync: () => [],
+  renameSync: () => {},
   rmSync: () => {},
+  writeFileSync: () => {},
 }));
 
 let lastChild: FakeChild;

--- a/apps/macos/src/main/shell-path.test.ts
+++ b/apps/macos/src/main/shell-path.test.ts
@@ -1,0 +1,225 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import { FakeChild } from "./test-helpers";
+
+// --- Mocks ---
+// Must be installed before the `await import` of the module under test so
+// the mocked module graph is in place when `shell-path.ts` (and its
+// `cli-installer.ts` dependency) is evaluated. See `commands.test.ts` for
+// the ordering rationale.
+
+mock.module("electron", () => ({
+  app: {
+    getPath: () => "/mock/userData",
+    isPackaged: true,
+  },
+}));
+
+// Paths for which the mocked accessSync(X_OK) succeeds.
+const executablePaths = new Set<string>();
+
+mock.module("node:fs", () => ({
+  accessSync: (p: string) => {
+    if (!executablePaths.has(p)) throw new Error(`EACCES: ${p}`);
+  },
+  constants: { X_OK: 1 },
+  // Used by cli-installer's buildInstallEnv (nvm detection).
+  copyFileSync: () => {},
+  existsSync: () => false,
+  mkdirSync: () => {},
+  readdirSync: () => [],
+  rmSync: () => {},
+}));
+
+let lastChild: FakeChild;
+const spawnCalls: Array<[string, string[]]> = [];
+
+mock.module("node:child_process", () => ({
+  spawn: (cmd: string, args: string[]) => {
+    spawnCalls.push([cmd, args]);
+    lastChild = new FakeChild();
+    return lastChild;
+  },
+}));
+
+const {
+  resolveShellPath,
+  findExecutablesInPath,
+  _resetShellPathCache,
+  PATH_SENTINEL,
+} = await import("./shell-path");
+const { buildInstallEnv } = await import("./cli-installer");
+
+const originalShell = process.env.SHELL;
+
+const wrap = (path: string) => `${PATH_SENTINEL}${path}${PATH_SENTINEL}`;
+
+afterEach(() => {
+  spawnCalls.length = 0;
+  executablePaths.clear();
+  _resetShellPathCache();
+  if (originalShell === undefined) delete process.env.SHELL;
+  else process.env.SHELL = originalShell;
+});
+
+// --- resolveShellPath ---
+
+describe("resolveShellPath", () => {
+  test("returns the shell's stdout PATH using $SHELL", async () => {
+    process.env.SHELL = "/bin/bash";
+
+    const promise = resolveShellPath();
+    lastChild.stdout.emit(
+      "data",
+      Buffer.from(wrap("/Users/me/.local/bin:/usr/bin")),
+    );
+    lastChild.emit("close", 0);
+
+    expect(await promise).toBe("/Users/me/.local/bin:/usr/bin");
+    expect(spawnCalls).toHaveLength(1);
+    expect(spawnCalls[0][0]).toBe("/bin/bash");
+    expect(spawnCalls[0][1]).toEqual([
+      "-ilc",
+      `printf "${PATH_SENTINEL}%s${PATH_SENTINEL}" "$PATH"`,
+    ]);
+  });
+
+  test("ignores startup-file banner output before the sentinel pair", async () => {
+    const promise = resolveShellPath();
+    lastChild.stdout.emit(
+      "data",
+      Buffer.from(`Welcome to my shell!\nnvm warning\n${wrap("/usr/local/bin:/usr/bin")}`),
+    );
+    lastChild.emit("close", 0);
+
+    expect(await promise).toBe("/usr/local/bin:/usr/bin");
+  });
+
+  test("falls back to buildInstallEnv PATH when sentinels are missing", async () => {
+    const promise = resolveShellPath();
+    lastChild.stdout.emit("data", Buffer.from("banner only, no sentinel"));
+    lastChild.emit("close", 0);
+
+    expect(await promise).toBe(buildInstallEnv().PATH ?? "");
+  });
+
+  test("falls back to /bin/zsh when $SHELL is unset", async () => {
+    delete process.env.SHELL;
+
+    const promise = resolveShellPath();
+    lastChild.stdout.emit("data", Buffer.from(wrap("/usr/bin")));
+    lastChild.emit("close", 0);
+
+    await promise;
+    expect(spawnCalls[0][0]).toBe("/bin/zsh");
+  });
+
+  test("falls back to buildInstallEnv PATH on non-zero exit", async () => {
+    const promise = resolveShellPath();
+    lastChild.stderr.emit("data", Buffer.from("zsh: bad rc file"));
+    lastChild.emit("close", 1);
+
+    expect(await promise).toBe(buildInstallEnv().PATH ?? "");
+  });
+
+  test("falls back to buildInstallEnv PATH on empty output", async () => {
+    const promise = resolveShellPath();
+    lastChild.emit("close", 0);
+
+    expect(await promise).toBe(buildInstallEnv().PATH ?? "");
+  });
+
+  test("falls back to buildInstallEnv PATH on spawn error", async () => {
+    const promise = resolveShellPath();
+    lastChild.emit("error", new Error("ENOENT"));
+
+    expect(await promise).toBe(buildInstallEnv().PATH ?? "");
+  });
+
+  test("kills the child and falls back on timeout", async () => {
+    const promise = resolveShellPath(10);
+
+    expect(await promise).toBe(buildInstallEnv().PATH ?? "");
+    expect(lastChild.kill).toHaveBeenCalled();
+  });
+
+  test("late close after timeout does not override the fallback", async () => {
+    const promise = resolveShellPath(10);
+    const result = await promise;
+
+    lastChild.stdout.emit("data", Buffer.from(wrap("/late/bin")));
+    lastChild.emit("close", 0);
+
+    expect(result).toBe(buildInstallEnv().PATH ?? "");
+    expect(await resolveShellPath()).toBe(result);
+  });
+
+  test("caches the result; second call does not spawn again", async () => {
+    const promise = resolveShellPath();
+    lastChild.stdout.emit("data", Buffer.from(wrap("/cached/bin")));
+    lastChild.emit("close", 0);
+    await promise;
+
+    expect(await resolveShellPath()).toBe("/cached/bin");
+    expect(spawnCalls).toHaveLength(1);
+  });
+
+  test("concurrent first calls share a single spawn", async () => {
+    const p1 = resolveShellPath();
+    const p2 = resolveShellPath();
+    expect(spawnCalls).toHaveLength(1);
+
+    lastChild.stdout.emit("data", Buffer.from(wrap("/shared/bin")));
+    lastChild.emit("close", 0);
+
+    expect(await p1).toBe("/shared/bin");
+    expect(await p2).toBe("/shared/bin");
+  });
+
+  test("_resetShellPathCache clears the cache", async () => {
+    const p1 = resolveShellPath();
+    lastChild.stdout.emit("data", Buffer.from(wrap("/first/bin")));
+    lastChild.emit("close", 0);
+    await p1;
+
+    _resetShellPathCache();
+
+    const p2 = resolveShellPath();
+    expect(spawnCalls).toHaveLength(2);
+    lastChild.stdout.emit("data", Buffer.from(wrap("/second/bin")));
+    lastChild.emit("close", 0);
+    expect(await p2).toBe("/second/bin");
+  });
+});
+
+// --- findExecutablesInPath ---
+
+describe("findExecutablesInPath", () => {
+  test("returns hits in PATH precedence order", () => {
+    executablePaths.add("/a/vellum");
+    executablePaths.add("/c/vellum");
+
+    expect(findExecutablesInPath("vellum", "/a:/b:/c")).toEqual([
+      "/a/vellum",
+      "/c/vellum",
+    ]);
+  });
+
+  test("skips missing and non-executable entries", () => {
+    executablePaths.add("/b/vellum");
+
+    expect(findExecutablesInPath("vellum", "/a:/b")).toEqual(["/b/vellum"]);
+  });
+
+  test("skips empty and duplicate PATH entries", () => {
+    executablePaths.add("/a/vellum");
+
+    expect(findExecutablesInPath("vellum", ":/a::/a:/a:")).toEqual([
+      "/a/vellum",
+    ]);
+  });
+
+  test("returns empty array when nothing matches", () => {
+    expect(findExecutablesInPath("vellum", "/a:/b")).toEqual([]);
+  });
+});

--- a/apps/macos/src/main/shell-path.ts
+++ b/apps/macos/src/main/shell-path.ts
@@ -1,73 +1,107 @@
 import { spawn } from "node:child_process";
-import { accessSync, constants } from "node:fs";
+import { accessSync, constants, statSync } from "node:fs";
 import path from "node:path";
 
-import { buildInstallEnv } from "./cli-installer";
-
 const SHELL_PATH_TIMEOUT_MS = 5_000;
+
+// Successful results are cached briefly so bursts within one flow share a
+// spawn, while menu-driven re-checks after the user edits their shell
+// profile still see fresh state. Failures (null) are never cached.
+const SHELL_PATH_CACHE_TTL_MS = 30_000;
 
 // Wraps the printf'd PATH so it can be isolated from any startup-file
 // output (banners, warnings) the interactive login shell writes first.
 const PATH_SENTINEL = "__VELLUM_PATH_7f3a__";
 
-export interface ShellPathResult {
-  path: string;
-  /**
-   * False when the login shell couldn't be queried and `path` is the
-   * synthesized `buildInstallEnv()` fallback — good enough for spawning
-   * processes, but NOT evidence of what's on the user's real PATH.
-   */
-  reliable: boolean;
+// Shells where the POSIX `printf ... "$PATH"` query is valid syntax.
+const POSIX_SHELLS = new Set(["zsh", "bash", "sh", "dash", "ksh"]);
+
+interface CacheEntry {
+  promise: Promise<string | null>;
+  expiresAt: number;
 }
 
-// Cached for the process lifetime; caching the promise also dedupes
-// concurrent first calls into a single shell spawn.
-let shellPathPromise: Promise<ShellPathResult> | null = null;
+let cache: CacheEntry | null = null;
 
 /** Reset the shell PATH cache. Exposed for testing only. */
 export function _resetShellPathCache(): void {
-  shellPathPromise = null;
-}
-
-function fallbackResult(): ShellPathResult {
-  return { path: buildInstallEnv().PATH ?? "", reliable: false };
+  cache = null;
 }
 
 /**
- * Resolve the user's interactive login shell PATH.
+ * Resolve the user's interactive login shell PATH, or null when it can't be
+ * reliably determined (unknown shell, spawn failure, timeout, non-zero
+ * exit, missing sentinel, implausible output).
  *
  * GUI apps launched from Finder inherit a minimal PATH that excludes
  * ~/.local/bin and package-manager bin dirs, so PATH checks (shadow
  * detection, "is ~/.local/bin in PATH") must use the shell's PATH rather
- * than `process.env.PATH`. Never rejects — on failure or timeout it falls
- * back to the PATH produced by `buildInstallEnv()`, marked unreliable.
+ * than `process.env.PATH`. Never rejects.
  */
 export function resolveShellPath(
   timeoutMs: number = SHELL_PATH_TIMEOUT_MS,
-): Promise<ShellPathResult> {
-  shellPathPromise ??= queryShellPath(timeoutMs);
-  return shellPathPromise;
+): Promise<string | null> {
+  if (cache && Date.now() < cache.expiresAt) return cache.promise;
+
+  const entry: CacheEntry = {
+    promise: queryShellPath(timeoutMs),
+    // Valid while in flight so concurrent callers share one spawn; the
+    // real TTL starts once the result arrives.
+    expiresAt: Infinity,
+  };
+  cache = entry;
+
+  void entry.promise.then((result) => {
+    if (cache !== entry) return;
+    if (result === null) cache = null;
+    else entry.expiresAt = Date.now() + SHELL_PATH_CACHE_TTL_MS;
+  });
+
+  return entry.promise;
 }
 
-function queryShellPath(timeoutMs: number): Promise<ShellPathResult> {
-  return new Promise((resolve) => {
-    const shell = process.env.SHELL ?? "/bin/zsh";
+// Argv for printing a sentinel-wrapped PATH in the given shell, or null for
+// shells whose syntax we don't know how to drive (tcsh, csh, nu, ...).
+function shellPathArgs(shell: string): string[] | null {
+  const name = path.basename(shell);
+  if (name === "fish") {
+    // fish's $PATH is a list that expands space-joined; join it explicitly.
+    return [
+      "-ilc",
+      `printf "${PATH_SENTINEL}%s${PATH_SENTINEL}" (string join : $PATH)`,
+    ];
+  }
+  if (POSIX_SHELLS.has(name)) {
+    return ["-ilc", `printf "${PATH_SENTINEL}%s${PATH_SENTINEL}" "$PATH"`];
+  }
+  return null;
+}
 
+// A plausible PATH has at least one separator, or is a single absolute
+// directory. Space-joined garbage (e.g. a misquoted list) has neither.
+function isPlausiblePath(value: string): boolean {
+  if (value.includes(":")) return true;
+  return value.startsWith("/") && !value.includes(" ");
+}
+
+function queryShellPath(timeoutMs: number): Promise<string | null> {
+  const shell = process.env.SHELL ?? "/bin/zsh";
+  const args = shellPathArgs(shell);
+  if (args === null) return Promise.resolve(null);
+
+  return new Promise((resolve) => {
     let child: ReturnType<typeof spawn>;
     try {
-      child = spawn(shell, [
-        "-ilc",
-        `printf "${PATH_SENTINEL}%s${PATH_SENTINEL}" "$PATH"`,
-      ]);
+      child = spawn(shell, args);
     } catch {
-      resolve(fallbackResult());
+      resolve(null);
       return;
     }
 
     let stdout = "";
     let settled = false;
 
-    const settle = (value: ShellPathResult) => {
+    const settle = (value: string | null) => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
@@ -76,18 +110,18 @@ function queryShellPath(timeoutMs: number): Promise<ShellPathResult> {
 
     const timer = setTimeout(() => {
       child.kill();
-      settle(fallbackResult());
+      settle(null);
     }, timeoutMs);
 
     child.stdout?.on("data", (data: Buffer) => {
       stdout += data.toString();
     });
 
-    child.on("error", () => settle(fallbackResult()));
+    child.on("error", () => settle(null));
 
     child.on("close", (code: number | null) => {
       const value = code === 0 ? extractSentinelValue(stdout) : null;
-      settle(value ? { path: value, reliable: true } : fallbackResult());
+      settle(value !== null && isPlausiblePath(value) ? value : null);
     });
   });
 }
@@ -134,9 +168,11 @@ export function findExecutablesInPath(
     const candidate = path.join(dir, name);
     try {
       accessSync(candidate, constants.X_OK);
-      results.push(candidate);
+      // X_OK passes for directories (search bit); require a regular file.
+      // statSync follows symlinks, so a link to an executable file counts.
+      if (statSync(candidate).isFile()) results.push(candidate);
     } catch {
-      // Missing or not executable.
+      // Missing, not executable, or unstattable.
     }
   }
 

--- a/apps/macos/src/main/shell-path.ts
+++ b/apps/macos/src/main/shell-path.ts
@@ -8,19 +8,29 @@ const SHELL_PATH_TIMEOUT_MS = 5_000;
 
 // Wraps the printf'd PATH so it can be isolated from any startup-file
 // output (banners, warnings) the interactive login shell writes first.
-export const PATH_SENTINEL = "__VELLUM_PATH_7f3a__";
+const PATH_SENTINEL = "__VELLUM_PATH_7f3a__";
+
+export interface ShellPathResult {
+  path: string;
+  /**
+   * False when the login shell couldn't be queried and `path` is the
+   * synthesized `buildInstallEnv()` fallback — good enough for spawning
+   * processes, but NOT evidence of what's on the user's real PATH.
+   */
+  reliable: boolean;
+}
 
 // Cached for the process lifetime; caching the promise also dedupes
 // concurrent first calls into a single shell spawn.
-let shellPathPromise: Promise<string> | null = null;
+let shellPathPromise: Promise<ShellPathResult> | null = null;
 
 /** Reset the shell PATH cache. Exposed for testing only. */
 export function _resetShellPathCache(): void {
   shellPathPromise = null;
 }
 
-function fallbackPath(): string {
-  return buildInstallEnv().PATH ?? "";
+function fallbackResult(): ShellPathResult {
+  return { path: buildInstallEnv().PATH ?? "", reliable: false };
 }
 
 /**
@@ -30,16 +40,16 @@ function fallbackPath(): string {
  * ~/.local/bin and package-manager bin dirs, so PATH checks (shadow
  * detection, "is ~/.local/bin in PATH") must use the shell's PATH rather
  * than `process.env.PATH`. Never rejects — on failure or timeout it falls
- * back to the PATH produced by `buildInstallEnv()`.
+ * back to the PATH produced by `buildInstallEnv()`, marked unreliable.
  */
 export function resolveShellPath(
   timeoutMs: number = SHELL_PATH_TIMEOUT_MS,
-): Promise<string> {
+): Promise<ShellPathResult> {
   shellPathPromise ??= queryShellPath(timeoutMs);
   return shellPathPromise;
 }
 
-function queryShellPath(timeoutMs: number): Promise<string> {
+function queryShellPath(timeoutMs: number): Promise<ShellPathResult> {
   return new Promise((resolve) => {
     const shell = process.env.SHELL ?? "/bin/zsh";
 
@@ -50,14 +60,14 @@ function queryShellPath(timeoutMs: number): Promise<string> {
         `printf "${PATH_SENTINEL}%s${PATH_SENTINEL}" "$PATH"`,
       ]);
     } catch {
-      resolve(fallbackPath());
+      resolve(fallbackResult());
       return;
     }
 
     let stdout = "";
     let settled = false;
 
-    const settle = (value: string) => {
+    const settle = (value: ShellPathResult) => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
@@ -66,18 +76,18 @@ function queryShellPath(timeoutMs: number): Promise<string> {
 
     const timer = setTimeout(() => {
       child.kill();
-      settle(fallbackPath());
+      settle(fallbackResult());
     }, timeoutMs);
 
     child.stdout?.on("data", (data: Buffer) => {
       stdout += data.toString();
     });
 
-    child.on("error", () => settle(fallbackPath()));
+    child.on("error", () => settle(fallbackResult()));
 
     child.on("close", (code: number | null) => {
       const value = code === 0 ? extractSentinelValue(stdout) : null;
-      settle(value || fallbackPath());
+      settle(value ? { path: value, reliable: true } : fallbackResult());
     });
   });
 }
@@ -92,6 +102,24 @@ function extractSentinelValue(stdout: string): string | null {
 }
 
 /**
+ * Split a PATH value into normalized directory entries: trailing slashes
+ * stripped, empty entries skipped, duplicates removed (first wins).
+ */
+export function splitPathEntries(pathValue: string): string[] {
+  const entries: string[] = [];
+  const seen = new Set<string>();
+
+  for (const raw of pathValue.split(":")) {
+    const dir = raw.replace(/\/+$/, "");
+    if (!dir || seen.has(dir)) continue;
+    seen.add(dir);
+    entries.push(dir);
+  }
+
+  return entries;
+}
+
+/**
  * Return absolute paths of every executable named `name` on `pathValue`,
  * preserving PATH precedence order. Empty and duplicate entries are
  * skipped; non-existent or non-executable candidates are ignored.
@@ -101,12 +129,8 @@ export function findExecutablesInPath(
   pathValue: string,
 ): string[] {
   const results: string[] = [];
-  const seen = new Set<string>();
 
-  for (const dir of pathValue.split(":")) {
-    if (!dir || seen.has(dir)) continue;
-    seen.add(dir);
-
+  for (const dir of splitPathEntries(pathValue)) {
     const candidate = path.join(dir, name);
     try {
       accessSync(candidate, constants.X_OK);

--- a/apps/macos/src/main/shell-path.ts
+++ b/apps/macos/src/main/shell-path.ts
@@ -1,0 +1,120 @@
+import { spawn } from "node:child_process";
+import { accessSync, constants } from "node:fs";
+import path from "node:path";
+
+import { buildInstallEnv } from "./cli-installer";
+
+const SHELL_PATH_TIMEOUT_MS = 5_000;
+
+// Wraps the printf'd PATH so it can be isolated from any startup-file
+// output (banners, warnings) the interactive login shell writes first.
+export const PATH_SENTINEL = "__VELLUM_PATH_7f3a__";
+
+// Cached for the process lifetime; caching the promise also dedupes
+// concurrent first calls into a single shell spawn.
+let shellPathPromise: Promise<string> | null = null;
+
+/** Reset the shell PATH cache. Exposed for testing only. */
+export function _resetShellPathCache(): void {
+  shellPathPromise = null;
+}
+
+function fallbackPath(): string {
+  return buildInstallEnv().PATH ?? "";
+}
+
+/**
+ * Resolve the user's interactive login shell PATH.
+ *
+ * GUI apps launched from Finder inherit a minimal PATH that excludes
+ * ~/.local/bin and package-manager bin dirs, so PATH checks (shadow
+ * detection, "is ~/.local/bin in PATH") must use the shell's PATH rather
+ * than `process.env.PATH`. Never rejects — on failure or timeout it falls
+ * back to the PATH produced by `buildInstallEnv()`.
+ */
+export function resolveShellPath(
+  timeoutMs: number = SHELL_PATH_TIMEOUT_MS,
+): Promise<string> {
+  shellPathPromise ??= queryShellPath(timeoutMs);
+  return shellPathPromise;
+}
+
+function queryShellPath(timeoutMs: number): Promise<string> {
+  return new Promise((resolve) => {
+    const shell = process.env.SHELL ?? "/bin/zsh";
+
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(shell, [
+        "-ilc",
+        `printf "${PATH_SENTINEL}%s${PATH_SENTINEL}" "$PATH"`,
+      ]);
+    } catch {
+      resolve(fallbackPath());
+      return;
+    }
+
+    let stdout = "";
+    let settled = false;
+
+    const settle = (value: string) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(value);
+    };
+
+    const timer = setTimeout(() => {
+      child.kill();
+      settle(fallbackPath());
+    }, timeoutMs);
+
+    child.stdout?.on("data", (data: Buffer) => {
+      stdout += data.toString();
+    });
+
+    child.on("error", () => settle(fallbackPath()));
+
+    child.on("close", (code: number | null) => {
+      const value = code === 0 ? extractSentinelValue(stdout) : null;
+      settle(value || fallbackPath());
+    });
+  });
+}
+
+// Extracts the last sentinel-wrapped value; null when no complete pair.
+function extractSentinelValue(stdout: string): string | null {
+  const end = stdout.lastIndexOf(PATH_SENTINEL);
+  if (end <= 0) return null;
+  const start = stdout.lastIndexOf(PATH_SENTINEL, end - 1);
+  if (start === -1) return null;
+  return stdout.slice(start + PATH_SENTINEL.length, end);
+}
+
+/**
+ * Return absolute paths of every executable named `name` on `pathValue`,
+ * preserving PATH precedence order. Empty and duplicate entries are
+ * skipped; non-existent or non-executable candidates are ignored.
+ */
+export function findExecutablesInPath(
+  name: string,
+  pathValue: string,
+): string[] {
+  const results: string[] = [];
+  const seen = new Set<string>();
+
+  for (const dir of pathValue.split(":")) {
+    if (!dir || seen.has(dir)) continue;
+    seen.add(dir);
+
+    const candidate = path.join(dir, name);
+    try {
+      accessSync(candidate, constants.X_OK);
+      results.push(candidate);
+    } catch {
+      // Missing or not executable.
+    }
+  }
+
+  return results;
+}

--- a/apps/macos/src/main/shell-path.ts
+++ b/apps/macos/src/main/shell-path.ts
@@ -23,6 +23,11 @@ interface CacheEntry {
 
 let cache: CacheEntry | null = null;
 
+/** Whether the user's login shell is fish (PATH help needs fish syntax). */
+export function isFishShell(): boolean {
+  return path.basename(process.env.SHELL ?? "") === "fish";
+}
+
 /** Reset the shell PATH cache. Exposed for testing only. */
 export function _resetShellPathCache(): void {
   cache = null;

--- a/apps/macos/test-setup.ts
+++ b/apps/macos/test-setup.ts
@@ -53,6 +53,11 @@ mock.module("electron", () => ({
     handle: () => undefined,
     on: () => undefined,
   },
+  dialog: {
+    showErrorBox: () => undefined,
+    showMessageBox: () =>
+      Promise.resolve({ response: 0, checkboxChecked: false }),
+  },
   Menu: {
     buildFromTemplate: () => ({ popup: () => undefined }),
     setApplicationMenu: () => undefined,


### PR DESCRIPTION
## Summary
Implements LUM-1986: a VS Code-style "Install vellum Command…" menu item in the macOS app. Because the CLI is lazily npm-installed into a version-stamped userData directory, the installer writes a stable wrapper script at `~/.local/bin/vellum` that sources an app-maintained locator file (refreshed every packaged launch) and execs the bundled bun against the current CLI bin — so the command survives version bumps and app moves with zero reinstalls. Includes PATH-missing clipboard UX, npm-global shadow detection, foreign-file safety, a Repair path for failed runtime provisioning, and state-driven menu items gated to packaged builds.

## Self-review result
4 review rounds (external-feedback, plan-faithfulness, repo-integration, slop passes each round) — 14 gaps found and fixed across 4 fix PRs; final round: all passes PASS.

## PRs merged into feature branch
- #34329: feat(macos): resolve user shell PATH and locate executables from main process
- #34330: feat(macos): write CLI locator file on every launch for PATH wrapper
- #34344: feat(macos): vellum PATH wrapper script generation, install, and uninstall
- #34349: feat(macos): detect vellum PATH install state including npm shadowing
- #34353: feat(macos): install/uninstall vellum command flows with PATH and shadow dialogs
- #34357: feat(macos): add Install/Uninstall vellum Command menu items

### Fix PRs
- #34373: gate vellum CLI menu on packaged builds; dedupe resolveCliInvocation
- #34377: harden vellum PATH installer detection and install flow
- #34386: shell PATH detection robustness (caching, fish, dirs) and install flow guard
- #34389: add Repair vellum Command path after CLI runtime provisioning failure

Part of plan: cli-path-installer.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)