### PR TITLE
Ship tool_executed and skill_loaded events through the telemetry reporter

### DIFF
--- a/assistant/src/memory/tool-executed-events-store.test.ts
+++ b/assistant/src/memory/tool-executed-events-store.test.ts
@@ -61,8 +61,11 @@ function insertInvocation(spec: SeedSpec): void {
       riskLevel: "low",
       durationMs: spec.durationMs ?? 12,
       createdAt: spec.createdAt,
-      argBytes: spec.argBytes ?? null,
-      resultBytes: spec.resultBytes ?? null,
+      // Post-migration writer paths always compute byte sizes (legacy
+      // pre-migration rows are the only null-argBytes rows), so the seed
+      // defaults to non-null. Pass an explicit null to seed a legacy row.
+      argBytes: spec.argBytes !== undefined ? spec.argBytes : 2,
+      resultBytes: spec.resultBytes !== undefined ? spec.resultBytes : 9,
       provider: spec.provider ?? null,
       model: spec.model ?? null,
       inferenceProfile: spec.inferenceProfile ?? null,
@@ -130,13 +133,29 @@ describe("tool-executed-events-store", () => {
     expect(rows.map((r) => r.id)).toEqual(["ti-allow", "ti-error"]);
   });
 
-  test("pre-migration rows project with null telemetry columns", () => {
-    insertInvocation({ id: "ti-old", createdAt: 1000 });
+  test("excludes legacy pre-migration rows (null arg_bytes)", () => {
+    // Pre-migration-278 rows were already shipped under the since-reverted
+    // tool_execution event type — they must never be projected, even from
+    // a zero watermark.
+    insertInvocation({
+      id: "ti-legacy",
+      createdAt: 1000,
+      argBytes: null,
+      resultBytes: null,
+    });
+    insertInvocation({ id: "ti-new", createdAt: 2000 });
+
+    const rows = queryUnreportedToolExecutedEvents(0, undefined, 100);
+    expect(rows.map((r) => r.id)).toEqual(["ti-new"]);
+  });
+
+  test("post-migration rows project with null attribution columns", () => {
+    insertInvocation({ id: "ti-no-attr", createdAt: 1000 });
 
     const rows = queryUnreportedToolExecutedEvents(0, undefined, 100);
     expect(rows[0]).toMatchObject({
-      argBytes: null,
-      resultBytes: null,
+      argBytes: 2,
+      resultBytes: 9,
       provider: null,
       model: null,
       inferenceProfile: null,

--- a/assistant/src/memory/tool-executed-events-store.ts
+++ b/assistant/src/memory/tool-executed-events-store.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, gt, ne, or } from "drizzle-orm";
+import { and, asc, eq, gt, isNotNull, ne, or } from "drizzle-orm";
 
 import { getDb } from "./db-connection.js";
 import { toolInvocations } from "./schema.js";
@@ -17,9 +17,17 @@ export interface UnreportedToolExecutedEvent {
   /** `"allow"`-style decisions or `"error"`; never `"denied"` (filtered out). */
   decision: string;
   durationMs: number;
-  /** Serialized input size in bytes. Null for rows persisted before migration 278. */
+  /**
+   * Serialized input size in bytes. Non-null in practice: legacy rows
+   * persisted before migration 278 have `arg_bytes IS NULL` and are excluded
+   * from the projection entirely (see the query's legacy-row filter).
+   */
   argBytes: number | null;
-  /** Full serialized result size in bytes. Null for rows persisted before migration 278. */
+  /**
+   * Full serialized result size in bytes. The audit listener writes it
+   * together with `argBytes`, so it is non-null on every projected row in
+   * practice.
+   */
   resultBytes: number | null;
   provider: string | null;
   model: string | null;
@@ -35,6 +43,18 @@ export interface UnreportedToolExecutedEvent {
  *
  * Permission-denied rows are excluded — the tool never executed, so no
  * `tool_executed` event is emitted for them.
+ *
+ * Legacy rows persisted before migration 278 (null `arg_bytes`) are also
+ * excluded: they were already shipped under the since-reverted
+ * `tool_execution` event type and lack the size/attribution columns, so
+ * re-shipping them as `tool_executed` would double-count with null
+ * attribution. Every post-migration writer path (tool-audit-listener.ts
+ * "executed" and "error" events) always computes a non-null `arg_bytes`;
+ * the only path that leaves it null ("permission_denied") is already
+ * excluded by the decision filter. This makes `arg_bytes IS NOT NULL` a
+ * reliable legacy-row discriminator, which in turn lets the telemetry
+ * reporter use the standard 0 watermark default without dropping rows
+ * recorded before its first flush.
  *
  * Rows are written by the tool audit listener
  * (`events/tool-audit-listener.ts`) — there is no record function here.
@@ -76,7 +96,14 @@ export function queryUnreportedToolExecutedEvents(
       createdAt: toolInvocations.createdAt,
     })
     .from(toolInvocations)
-    .where(and(ne(toolInvocations.decision, "denied"), cursorPredicate))
+    .where(
+      and(
+        ne(toolInvocations.decision, "denied"),
+        // Legacy pre-migration-278 rows — see the doc comment above.
+        isNotNull(toolInvocations.argBytes),
+        cursorPredicate,
+      ),
+    )
     .orderBy(asc(toolInvocations.createdAt), asc(toolInvocations.id))
     .limit(limit)
     .all();

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -289,24 +289,17 @@ function seedToolInvocation(spec: {
       riskLevel: "low",
       durationMs: spec.durationMs ?? 12,
       createdAt: spec.createdAt,
-      argBytes: spec.argBytes ?? null,
-      resultBytes: spec.resultBytes ?? null,
+      // Post-migration writer paths always compute byte sizes (legacy
+      // pre-migration rows are the only null-argBytes rows), so the seed
+      // defaults to non-null. Pass an explicit null to seed a legacy row.
+      argBytes: spec.argBytes !== undefined ? spec.argBytes : 2,
+      resultBytes: spec.resultBytes !== undefined ? spec.resultBytes : 9,
       provider: spec.provider ?? null,
       model: spec.model ?? null,
       inferenceProfile: spec.inferenceProfile ?? null,
       inferenceProfileSource: spec.inferenceProfileSource ?? null,
     })
     .run();
-}
-
-// The tool_executed watermark initializes to `Date.now()` when its checkpoint
-// is absent (see the reporter's no-backfill guard), which would exclude
-// fixture rows with past timestamps. Tests that ship seeded tool invocations
-// pin the checkpoint to "0" so the fixtures are in range.
-function pinToolExecutedWatermarkToZero(): void {
-  mockGetMemoryCheckpoint.mockImplementation((key) =>
-    key === "telemetry:tool_executed:last_reported_at" ? "0" : null,
-  );
 }
 
 const originalFetch = globalThis.fetch;
@@ -1420,7 +1413,6 @@ describe("UsageTelemetryReporter", () => {
 
   test("tool_executed events project decision to status and never carry raw args/results", async () => {
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
-    pinToolExecutedWatermarkToZero();
     seedToolInvocation({
       id: "ti-ok",
       createdAt: 1700000001000,
@@ -1434,7 +1426,7 @@ describe("UsageTelemetryReporter", () => {
       inferenceProfile: "balanced",
       inferenceProfileSource: "active",
     });
-    // Errored invocation from before migration 278 — sizes and attribution
+    // Errored invocation without LLM attribution — the attribution columns
     // are null and must pass through as null.
     seedToolInvocation({
       id: "ti-err",
@@ -1442,6 +1434,8 @@ describe("UsageTelemetryReporter", () => {
       toolName: "web_search",
       decision: "error",
       durationMs: 7,
+      argBytes: 17,
+      resultBytes: 33,
     });
     // Permission-denied rows are filtered in the store and must never ship.
     seedToolInvocation({
@@ -1491,8 +1485,8 @@ describe("UsageTelemetryReporter", () => {
       tool_name: "web_search",
       status: "errored",
       duration_ms: 7,
-      arg_bytes: null,
-      result_bytes: null,
+      arg_bytes: 17,
+      result_bytes: 33,
       provider: null,
       model: null,
       inference_profile: null,
@@ -1503,7 +1497,6 @@ describe("UsageTelemetryReporter", () => {
 
   test("tool_executed watermark advances to the last reported row on success", async () => {
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
-    pinToolExecutedWatermarkToZero();
     seedToolInvocation({ id: "ti-w1", createdAt: 1700000001000 });
     seedToolInvocation({ id: "ti-w2", createdAt: 1700000002000 });
     mockFetch.mockImplementation(() =>
@@ -1528,30 +1521,86 @@ describe("UsageTelemetryReporter", () => {
     expect(idCalls[idCalls.length - 1][1]).toBe("ti-w2");
   });
 
-  test("absent tool_executed checkpoint initializes to now — historical rows are not backfilled", async () => {
+  test("tool_executed resumes from a stored watermark — reported rows are not re-shipped", async () => {
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
-    // Default mock: every checkpoint is absent (first run after upgrade).
-    // The tool_invocations table holds a pre-upgrade row; it was already
-    // shipped under the since-reverted tool_execution type and must NOT be
-    // re-shipped as tool_executed.
-    seedToolInvocation({ id: "ti-historical", createdAt: 1700000001000 });
-    const before = Date.now();
+    seedToolInvocation({ id: "ti-r1", createdAt: 1700000001000 });
+    seedToolInvocation({ id: "ti-r2", createdAt: 1700000002000 });
+    // A previous flush already reported ti-r1.
+    mockGetMemoryCheckpoint.mockImplementation((key) => {
+      if (key === "telemetry:tool_executed:last_reported_at") {
+        return String(1700000001000);
+      }
+      if (key === "telemetry:tool_executed:last_reported_id") return "ti-r1";
+      return null;
+    });
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
+    );
 
     const reporter = new UsageTelemetryReporter();
     await reporter.flush();
 
-    // Nothing to report — the historical row is behind the now-watermark.
-    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect(
+      body.events.map((e: { daemon_event_id: string }) => e.daemon_event_id),
+    ).toEqual(["ti-r2"]);
+  });
 
-    // The initialized watermark is persisted immediately so a later failed
-    // POST can't re-initialize to an even later "now" and skip rows.
+  test("legacy pre-migration rows (null arg_bytes) are never shipped", async () => {
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    // Default mock: every checkpoint is absent (first run after upgrade),
+    // so the watermark is 0 and the query scans the whole table. The
+    // tool_invocations table holds a pre-upgrade row; it was already
+    // shipped under the since-reverted tool_execution type, lacks the
+    // migration-278 telemetry columns, and must NOT be re-shipped as
+    // tool_executed.
+    seedToolInvocation({
+      id: "ti-historical",
+      createdAt: 1700000001000,
+      argBytes: null,
+      resultBytes: null,
+    });
+
+    const reporter = new UsageTelemetryReporter();
+    await reporter.flush();
+
+    // Nothing to report — the legacy row is excluded at the query level.
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  test("rows recorded before the first flush are shipped (no now-initialized watermark)", async () => {
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    // Regression coverage for the review finding: the reporter delays its
+    // first flush, so a tool used right after install/upgrade is recorded
+    // BEFORE any tool_executed checkpoint exists. A watermark initialized
+    // to Date.now() would silently drop it; the legacy-row discriminator
+    // (null arg_bytes) plus the standard 0 default must ship it.
+    seedToolInvocation({ id: "ti-pre-first-flush", createdAt: 1700000001000 });
+
+    const reporter = new UsageTelemetryReporter();
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect(body.events.length).toBe(1);
+    expect(body.events[0]).toMatchObject({
+      type: "tool_executed",
+      daemon_event_id: "ti-pre-first-flush",
+      recorded_at: 1700000001000,
+    });
+
+    // The watermark advances to the shipped row, so the next flush resumes
+    // after it instead of re-shipping.
     const watermarkCalls = mockSetMemoryCheckpoint.mock.calls.filter(
       (c) => c[0] === "telemetry:tool_executed:last_reported_at",
     );
     expect(watermarkCalls.length).toBe(1);
-    const initialized = Number(watermarkCalls[0][1]);
-    expect(initialized).toBeGreaterThanOrEqual(before);
-    expect(initialized).toBeLessThanOrEqual(Date.now());
+    expect(watermarkCalls[0][1]).toBe(String(1700000001000));
   });
 
   // -------------------------------------------------------------------------

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -143,10 +143,11 @@ mock.module("../memory/onboarding-events-store.js", () => ({
   queryUnreportedOnboardingEvents: mockQueryUnreportedOnboardingEvents,
 }));
 
-// The auth-fallback store is intentionally NOT mocked — it has its own
-// DB-backed tests, and Bun's `mock.module` is process-global, so mocking it
-// here would leak into those tests when files share an invocation. We seed the
-// real DB instead so every auth-fallback test stays order-independent.
+// The auth-fallback, tool-executed, and skill-loaded stores are intentionally
+// NOT mocked — they have their own DB-backed tests, and Bun's `mock.module`
+// is process-global, so mocking them here would leak into those tests when
+// files share an invocation. We seed the real DB instead so every test stays
+// order-independent.
 
 // ---------------------------------------------------------------------------
 // Production import (after mocks)
@@ -155,7 +156,13 @@ mock.module("../memory/onboarding-events-store.js", () => ({
 import { recordAuthFallbackCounts } from "../memory/auth-fallback-events-store.js";
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
-import { authFallbackEvents } from "../memory/schema.js";
+import {
+  authFallbackEvents,
+  conversations,
+  skillLoadedEvents,
+  toolInvocations,
+} from "../memory/schema.js";
+import { recordSkillLoadedEvent } from "../memory/skill-loaded-events-store.js";
 import type { UsageEvent } from "../usage/types.js";
 import {
   ACTIVATION_FUNNEL_VERSION,
@@ -238,6 +245,70 @@ function makeOnboardingEvent(
   };
 }
 
+const TOOL_CONVERSATION_ID = "conv-reporter-tool-executed";
+
+/**
+ * Sentinel embedded in the seeded raw input/result payloads. Asserted to
+ * never appear on the wire — raw tool args/outputs must never leave the
+ * device.
+ */
+const TOOL_PII_SENTINEL = "must never leave the device";
+
+function seedToolInvocation(spec: {
+  id: string;
+  createdAt: number;
+  toolName?: string;
+  decision?: string;
+  durationMs?: number;
+  argBytes?: number | null;
+  resultBytes?: number | null;
+  provider?: string | null;
+  model?: string | null;
+  inferenceProfile?: string | null;
+  inferenceProfileSource?: string | null;
+}): void {
+  const db = getDb();
+  // tool_invocations has an enforced FK to conversations.
+  db.insert(conversations)
+    .values({
+      id: TOOL_CONVERSATION_ID,
+      title: "test",
+      createdAt: 1000,
+      updatedAt: 1000,
+    })
+    .onConflictDoNothing()
+    .run();
+  db.insert(toolInvocations)
+    .values({
+      id: spec.id,
+      conversationId: TOOL_CONVERSATION_ID,
+      toolName: spec.toolName ?? "calendar_list_events",
+      input: `{"secret":"raw tool args — ${TOOL_PII_SENTINEL}"}`,
+      result: `{"secret":"raw tool output — ${TOOL_PII_SENTINEL}"}`,
+      decision: spec.decision ?? "allow",
+      riskLevel: "low",
+      durationMs: spec.durationMs ?? 12,
+      createdAt: spec.createdAt,
+      argBytes: spec.argBytes ?? null,
+      resultBytes: spec.resultBytes ?? null,
+      provider: spec.provider ?? null,
+      model: spec.model ?? null,
+      inferenceProfile: spec.inferenceProfile ?? null,
+      inferenceProfileSource: spec.inferenceProfileSource ?? null,
+    })
+    .run();
+}
+
+// The tool_executed watermark initializes to `Date.now()` when its checkpoint
+// is absent (see the reporter's no-backfill guard), which would exclude
+// fixture rows with past timestamps. Tests that ship seeded tool invocations
+// pin the checkpoint to "0" so the fixtures are in range.
+function pinToolExecutedWatermarkToZero(): void {
+  mockGetMemoryCheckpoint.mockImplementation((key) =>
+    key === "telemetry:tool_executed:last_reported_at" ? "0" : null,
+  );
+}
+
 const originalFetch = globalThis.fetch;
 let mockFetch: ReturnType<typeof mock>;
 
@@ -258,6 +329,8 @@ beforeEach(() => {
   mockQueryUnreportedOnboardingEvents.mockReset();
   mockQueryUnreportedOnboardingEvents.mockReturnValue([]);
   getDb().delete(authFallbackEvents).run();
+  getDb().delete(toolInvocations).run();
+  getDb().delete(skillLoadedEvents).run();
   mockPlatformClient = null;
   mockGetPlatformBaseUrl.mockReset();
   mockGetDeviceId.mockReset();
@@ -966,9 +1039,9 @@ describe("UsageTelemetryReporter", () => {
     // No HTTP call should have been made
     expect(mockFetch).not.toHaveBeenCalled();
 
-    // All 5 timestamp watermarks should have been advanced (IDs left untouched
+    // All 7 timestamp watermarks should have been advanced (IDs left untouched
     // so the compound-cursor branch stays active)
-    expect(mockSetMemoryCheckpoint).toHaveBeenCalledTimes(5);
+    expect(mockSetMemoryCheckpoint).toHaveBeenCalledTimes(7);
 
     const calls = mockSetMemoryCheckpoint.mock.calls;
     const keys = calls.map((c) => c[0]);
@@ -977,6 +1050,8 @@ describe("UsageTelemetryReporter", () => {
     expect(keys).toContain("telemetry:lifecycle:last_reported_at");
     expect(keys).toContain("telemetry:onboarding:last_reported_at");
     expect(keys).toContain("telemetry:auth_fallback:last_reported_at");
+    expect(keys).toContain("telemetry:tool_executed:last_reported_at");
+    expect(keys).toContain("telemetry:skill_loaded:last_reported_at");
   });
 
   test("events sent normally after re-enabling collectUsageData", async () => {
@@ -1337,5 +1412,261 @@ describe("UsageTelemetryReporter", () => {
     expect(e.step_index).toBeUndefined();
     expect(e.completed_at).toBeUndefined();
     expect(e.funnel_version).toBeUndefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // Tool-executed events
+  // -------------------------------------------------------------------------
+
+  test("tool_executed events project decision to status and never carry raw args/results", async () => {
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    pinToolExecutedWatermarkToZero();
+    seedToolInvocation({
+      id: "ti-ok",
+      createdAt: 1700000001000,
+      toolName: "calendar_list_events",
+      decision: "allow",
+      durationMs: 12,
+      argBytes: 42,
+      resultBytes: 9001,
+      provider: "anthropic",
+      model: "model-a",
+      inferenceProfile: "balanced",
+      inferenceProfileSource: "active",
+    });
+    // Errored invocation from before migration 278 — sizes and attribution
+    // are null and must pass through as null.
+    seedToolInvocation({
+      id: "ti-err",
+      createdAt: 1700000002000,
+      toolName: "web_search",
+      decision: "error",
+      durationMs: 7,
+    });
+    // Permission-denied rows are filtered in the store and must never ship.
+    seedToolInvocation({
+      id: "ti-denied",
+      createdAt: 1700000003000,
+      decision: "denied",
+    });
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response('{"accepted":2}', { status: 200 })),
+    );
+
+    const reporter = new UsageTelemetryReporter();
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const rawBody = (mockFetch.mock.calls[0] as [string, RequestInit])[1]
+      .body as string;
+    // ToS/PII contract: raw tool args/outputs never leave the device.
+    expect(rawBody).not.toContain(TOOL_PII_SENTINEL);
+
+    const body = JSON.parse(rawBody);
+    expect(body.events.length).toBe(2);
+
+    const byId: Record<string, Record<string, unknown>> = {};
+    for (const e of body.events as Array<{ daemon_event_id: string }>) {
+      byId[e.daemon_event_id] = e;
+    }
+
+    expect(byId["ti-ok"]).toEqual({
+      type: "tool_executed",
+      daemon_event_id: "ti-ok",
+      recorded_at: 1700000001000,
+      tool_name: "calendar_list_events",
+      status: "fulfilled",
+      duration_ms: 12,
+      arg_bytes: 42,
+      result_bytes: 9001,
+      conversation_id: TOOL_CONVERSATION_ID,
+      provider: "anthropic",
+      model: "model-a",
+      inference_profile: "balanced",
+      inference_profile_source: "active",
+      assistant_version: "1.2.3-test",
+    });
+    expect(byId["ti-err"]).toMatchObject({
+      type: "tool_executed",
+      tool_name: "web_search",
+      status: "errored",
+      duration_ms: 7,
+      arg_bytes: null,
+      result_bytes: null,
+      provider: null,
+      model: null,
+      inference_profile: null,
+      inference_profile_source: null,
+    });
+    expect(byId["ti-denied"]).toBeUndefined();
+  });
+
+  test("tool_executed watermark advances to the last reported row on success", async () => {
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    pinToolExecutedWatermarkToZero();
+    seedToolInvocation({ id: "ti-w1", createdAt: 1700000001000 });
+    seedToolInvocation({ id: "ti-w2", createdAt: 1700000002000 });
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response('{"accepted":2}', { status: 200 })),
+    );
+
+    const reporter = new UsageTelemetryReporter();
+    await reporter.flush();
+
+    const watermarkCalls = mockSetMemoryCheckpoint.mock.calls.filter(
+      (c) => c[0] === "telemetry:tool_executed:last_reported_at",
+    );
+    expect(watermarkCalls.length).toBeGreaterThanOrEqual(1);
+    expect(watermarkCalls[watermarkCalls.length - 1][1]).toBe(
+      String(1700000002000),
+    );
+
+    const idCalls = mockSetMemoryCheckpoint.mock.calls.filter(
+      (c) => c[0] === "telemetry:tool_executed:last_reported_id",
+    );
+    expect(idCalls.length).toBeGreaterThanOrEqual(1);
+    expect(idCalls[idCalls.length - 1][1]).toBe("ti-w2");
+  });
+
+  test("absent tool_executed checkpoint initializes to now — historical rows are not backfilled", async () => {
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    // Default mock: every checkpoint is absent (first run after upgrade).
+    // The tool_invocations table holds a pre-upgrade row; it was already
+    // shipped under the since-reverted tool_execution type and must NOT be
+    // re-shipped as tool_executed.
+    seedToolInvocation({ id: "ti-historical", createdAt: 1700000001000 });
+    const before = Date.now();
+
+    const reporter = new UsageTelemetryReporter();
+    await reporter.flush();
+
+    // Nothing to report — the historical row is behind the now-watermark.
+    expect(mockFetch).not.toHaveBeenCalled();
+
+    // The initialized watermark is persisted immediately so a later failed
+    // POST can't re-initialize to an even later "now" and skip rows.
+    const watermarkCalls = mockSetMemoryCheckpoint.mock.calls.filter(
+      (c) => c[0] === "telemetry:tool_executed:last_reported_at",
+    );
+    expect(watermarkCalls.length).toBe(1);
+    const initialized = Number(watermarkCalls[0][1]);
+    expect(initialized).toBeGreaterThanOrEqual(before);
+    expect(initialized).toBeLessThanOrEqual(Date.now());
+  });
+
+  // -------------------------------------------------------------------------
+  // Skill-loaded events
+  // -------------------------------------------------------------------------
+
+  test("skill_loaded events ship metadata with attribution and null passthrough", async () => {
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    recordSkillLoadedEvent({
+      conversationId: "conv-skill",
+      skillName: "web-research",
+      skillUpdatedAt: "2026-06-01T00:00:00.000Z",
+      provider: "anthropic",
+      model: "model-a",
+      inferenceProfile: "balanced",
+      inferenceProfileSource: "active",
+    });
+    // Minimal record — optional fields persist as null and ship as null.
+    recordSkillLoadedEvent({ skillName: "tasks" });
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response('{"accepted":2}', { status: 200 })),
+    );
+
+    const reporter = new UsageTelemetryReporter();
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect(body.events.length).toBe(2);
+
+    const byName: Record<string, Record<string, unknown>> = {};
+    for (const e of body.events as Array<{ skill_name: string }>) {
+      byName[e.skill_name] = e;
+    }
+
+    expect(byName["web-research"]).toMatchObject({
+      type: "skill_loaded",
+      skill_name: "web-research",
+      skill_updated_at: "2026-06-01T00:00:00.000Z",
+      conversation_id: "conv-skill",
+      provider: "anthropic",
+      model: "model-a",
+      inference_profile: "balanced",
+      inference_profile_source: "active",
+      assistant_version: "1.2.3-test",
+    });
+    expect(typeof byName["web-research"].daemon_event_id).toBe("string");
+    expect(typeof byName["web-research"].recorded_at).toBe("number");
+    expect(byName["tasks"]).toMatchObject({
+      type: "skill_loaded",
+      skill_name: "tasks",
+      skill_updated_at: null,
+      conversation_id: null,
+      provider: null,
+      model: null,
+      inference_profile: null,
+      inference_profile_source: null,
+    });
+  });
+
+  test("skill_loaded watermark advances to the last reported row on success", async () => {
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    recordSkillLoadedEvent({ skillName: "web-research" });
+    recordSkillLoadedEvent({ skillName: "tasks" });
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response('{"accepted":2}', { status: 200 })),
+    );
+
+    // The last row by the reporter's (createdAt, id) cursor order is the one
+    // whose watermark should be persisted after a successful upload.
+    const rows = getDb()
+      .select()
+      .from(skillLoadedEvents)
+      .orderBy(skillLoadedEvents.createdAt, skillLoadedEvents.id)
+      .all();
+    const lastRow = rows[rows.length - 1];
+
+    const reporter = new UsageTelemetryReporter();
+    await reporter.flush();
+
+    const watermarkCalls = mockSetMemoryCheckpoint.mock.calls.filter(
+      (c) => c[0] === "telemetry:skill_loaded:last_reported_at",
+    );
+    expect(watermarkCalls.length).toBeGreaterThanOrEqual(1);
+    expect(watermarkCalls[watermarkCalls.length - 1][1]).toBe(
+      String(lastRow.createdAt),
+    );
+
+    const idCalls = mockSetMemoryCheckpoint.mock.calls.filter(
+      (c) => c[0] === "telemetry:skill_loaded:last_reported_id",
+    );
+    expect(idCalls.length).toBeGreaterThanOrEqual(1);
+    expect(idCalls[idCalls.length - 1][1]).toBe(lastRow.id);
+  });
+
+  test("batch recursion when skill_loaded returns a full batch, capped at 10", async () => {
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    // Exactly BATCH_SIZE rows; the mocked checkpoints never persist, so each
+    // recursion re-reads the same full batch until the cap.
+    const fullBatch = Array.from({ length: 500 }, (_, i) => ({
+      id: `sle-batch-${String(i).padStart(3, "0")}`,
+      createdAt: 1700000000000 + i,
+      skillName: "web-research",
+    }));
+    getDb().insert(skillLoadedEvents).values(fullBatch).run();
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response('{"accepted":500}', { status: 200 })),
+    );
+
+    const reporter = new UsageTelemetryReporter();
+    await reporter.flush();
+
+    // MAX_CONSECUTIVE_BATCHES = 10
+    expect(mockFetch).toHaveBeenCalledTimes(10);
   });
 });

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -203,24 +203,17 @@ export class UsageTelemetryReporter {
         undefined;
 
       // Read tool-executed watermark (compound cursor: createdAt + id).
-      // Unlike the other types, an ABSENT checkpoint initializes to NOW, not
-      // 0: `tool_invocations` is a pre-existing audit table whose historical
-      // rows were already shipped as the (since-reverted) `tool_execution`
-      // event type and predate the arg_bytes/result_bytes/attribution
-      // columns. Backfilling them as `tool_executed` would double-count with
-      // null attribution. Persist the initialized watermark immediately so a
-      // failed POST can't re-initialize to a later "now" and skip rows.
-      let toolExecutedWatermarkRaw = getMemoryCheckpoint(
-        CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK,
+      // The standard 0 default is safe even though `tool_invocations` is a
+      // pre-existing audit table: legacy rows — already shipped under the
+      // since-reverted `tool_execution` event type and lacking the
+      // arg_bytes/result_bytes/attribution columns — are excluded at the
+      // query level via the null `arg_bytes` discriminator (see
+      // queryUnreportedToolExecutedEvents), so they are never backfilled.
+      // Rows recorded after migration 278 but before the first flush ARE
+      // picked up, which a now-initialized watermark would have dropped.
+      const toolExecutedWatermark = Number(
+        getMemoryCheckpoint(CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK) ?? "0",
       );
-      if (toolExecutedWatermarkRaw === null) {
-        toolExecutedWatermarkRaw = String(Date.now());
-        setMemoryCheckpoint(
-          CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK,
-          toolExecutedWatermarkRaw,
-        );
-      }
-      const toolExecutedWatermark = Number(toolExecutedWatermarkRaw);
       const toolExecutedWatermarkId =
         getMemoryCheckpoint(CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK_ID) ??
         undefined;

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -23,8 +23,11 @@ import {
 import { queryUnreportedLifecycleEvents } from "../memory/lifecycle-events-store.js";
 import { queryUnreportedUsageEvents } from "../memory/llm-usage-store.js";
 import { queryUnreportedOnboardingEvents } from "../memory/onboarding-events-store.js";
+import { queryUnreportedSkillLoadedEvents } from "../memory/skill-loaded-events-store.js";
+import { queryUnreportedToolExecutedEvents } from "../memory/tool-executed-events-store.js";
 import { queryUnreportedTurnEvents } from "../memory/turn-events-store.js";
 import { VellumPlatformClient } from "../platform/client.js";
+import type { UsageAttributionProfileSource } from "../usage/types.js";
 import { getDeviceId } from "../util/device-id.js";
 import { getLogger } from "../util/logger.js";
 import { APP_VERSION } from "../version.js";
@@ -56,6 +59,14 @@ const CHECKPOINT_KEY_AUTH_FALLBACK_WATERMARK =
   "telemetry:auth_fallback:last_reported_at";
 const CHECKPOINT_KEY_AUTH_FALLBACK_WATERMARK_ID =
   "telemetry:auth_fallback:last_reported_id";
+const CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK =
+  "telemetry:tool_executed:last_reported_at";
+const CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK_ID =
+  "telemetry:tool_executed:last_reported_id";
+const CHECKPOINT_KEY_SKILL_LOADED_WATERMARK =
+  "telemetry:skill_loaded:last_reported_at";
+const CHECKPOINT_KEY_SKILL_LOADED_WATERMARK_ID =
+  "telemetry:skill_loaded:last_reported_id";
 const REPORT_INTERVAL_MS = 5 * 60 * 1000;
 const INITIAL_FLUSH_DELAY_MS = 30_000; // Delay first flush to let CES handshake complete
 const BATCH_SIZE = 500;
@@ -149,6 +160,8 @@ export class UsageTelemetryReporter {
         setMemoryCheckpoint(CHECKPOINT_KEY_LIFECYCLE_WATERMARK, now);
         setMemoryCheckpoint(CHECKPOINT_KEY_ONBOARDING_WATERMARK, now);
         setMemoryCheckpoint(CHECKPOINT_KEY_AUTH_FALLBACK_WATERMARK, now);
+        setMemoryCheckpoint(CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK, now);
+        setMemoryCheckpoint(CHECKPOINT_KEY_SKILL_LOADED_WATERMARK, now);
         return;
       }
 
@@ -189,6 +202,38 @@ export class UsageTelemetryReporter {
         getMemoryCheckpoint(CHECKPOINT_KEY_AUTH_FALLBACK_WATERMARK_ID) ??
         undefined;
 
+      // Read tool-executed watermark (compound cursor: createdAt + id).
+      // Unlike the other types, an ABSENT checkpoint initializes to NOW, not
+      // 0: `tool_invocations` is a pre-existing audit table whose historical
+      // rows were already shipped as the (since-reverted) `tool_execution`
+      // event type and predate the arg_bytes/result_bytes/attribution
+      // columns. Backfilling them as `tool_executed` would double-count with
+      // null attribution. Persist the initialized watermark immediately so a
+      // failed POST can't re-initialize to a later "now" and skip rows.
+      let toolExecutedWatermarkRaw = getMemoryCheckpoint(
+        CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK,
+      );
+      if (toolExecutedWatermarkRaw === null) {
+        toolExecutedWatermarkRaw = String(Date.now());
+        setMemoryCheckpoint(
+          CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK,
+          toolExecutedWatermarkRaw,
+        );
+      }
+      const toolExecutedWatermark = Number(toolExecutedWatermarkRaw);
+      const toolExecutedWatermarkId =
+        getMemoryCheckpoint(CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK_ID) ??
+        undefined;
+
+      // Read skill-loaded watermark (compound cursor: createdAt + id).
+      // Brand-new table, so the standard 0 default is safe.
+      const skillLoadedWatermark = Number(
+        getMemoryCheckpoint(CHECKPOINT_KEY_SKILL_LOADED_WATERMARK) ?? "0",
+      );
+      const skillLoadedWatermarkId =
+        getMemoryCheckpoint(CHECKPOINT_KEY_SKILL_LOADED_WATERMARK_ID) ??
+        undefined;
+
       // Query unreported events
       const events = queryUnreportedUsageEvents(
         watermark,
@@ -215,13 +260,25 @@ export class UsageTelemetryReporter {
         authFallbackWatermarkId,
         BATCH_SIZE,
       );
+      const toolExecutedEvents = queryUnreportedToolExecutedEvents(
+        toolExecutedWatermark,
+        toolExecutedWatermarkId,
+        BATCH_SIZE,
+      );
+      const skillLoadedEvents = queryUnreportedSkillLoadedEvents(
+        skillLoadedWatermark,
+        skillLoadedWatermarkId,
+        BATCH_SIZE,
+      );
 
       if (
         events.length === 0 &&
         turnEvents.length === 0 &&
         lifecycleEvents.length === 0 &&
         onboardingEvents.length === 0 &&
-        authFallbackEvents.length === 0
+        authFallbackEvents.length === 0 &&
+        toolExecutedEvents.length === 0 &&
+        skillLoadedEvents.length === 0
       )
         return;
 
@@ -236,6 +293,8 @@ export class UsageTelemetryReporter {
           lifecycleCount: lifecycleEvents.length,
           onboardingCount: onboardingEvents.length,
           authFallbackCount: authFallbackEvents.length,
+          toolExecutedCount: toolExecutedEvents.length,
+          skillLoadedCount: skillLoadedEvents.length,
         },
         "Telemetry flush: resolved auth context",
       );
@@ -402,6 +461,50 @@ export class UsageTelemetryReporter {
             assistant_version: APP_VERSION,
           }),
         ),
+        ...toolExecutedEvents.map(
+          (e): TelemetryEvent => ({
+            type: "tool_executed",
+            daemon_event_id: e.id,
+            recorded_at: e.createdAt,
+            tool_name: e.toolName,
+            // The store filters out permission-denied rows, so the only
+            // non-success decision that reaches here is "error".
+            status: e.decision === "error" ? "errored" : "fulfilled",
+            duration_ms: e.durationMs,
+            arg_bytes: e.argBytes,
+            result_bytes: e.resultBytes,
+            conversation_id: e.conversationId,
+            provider: e.provider,
+            model: e.model,
+            inference_profile: e.inferenceProfile,
+            inference_profile_source:
+              e.inferenceProfileSource as UsageAttributionProfileSource | null,
+            // `tool_invocations` has no record-time version column — stamp
+            // the running binary's `APP_VERSION` so the wire value is
+            // concrete rather than an explicit null that would override the
+            // envelope under the platform's per-event-wins contract.
+            assistant_version: APP_VERSION,
+          }),
+        ),
+        ...skillLoadedEvents.map(
+          (e): TelemetryEvent => ({
+            type: "skill_loaded",
+            daemon_event_id: e.id,
+            recorded_at: e.createdAt,
+            skill_name: e.skillName,
+            skill_updated_at: e.skillUpdatedAt,
+            conversation_id: e.conversationId,
+            provider: e.provider,
+            model: e.model,
+            inference_profile: e.inferenceProfile,
+            inference_profile_source:
+              e.inferenceProfileSource as UsageAttributionProfileSource | null,
+            // `skill_loaded_events` has no record-time version column — same
+            // upload-time APP_VERSION stamping as the other non-llm_usage
+            // event types.
+            assistant_version: APP_VERSION,
+          }),
+        ),
       ];
 
       const organizationId = getPlatformOrganizationId() || undefined;
@@ -501,13 +604,42 @@ export class UsageTelemetryReporter {
         );
       }
 
+      // Advance tool-executed watermark (compound cursor)
+      if (toolExecutedEvents.length > 0) {
+        const lastToolExecuted =
+          toolExecutedEvents[toolExecutedEvents.length - 1];
+        setMemoryCheckpoint(
+          CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK,
+          String(lastToolExecuted.createdAt),
+        );
+        setMemoryCheckpoint(
+          CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK_ID,
+          lastToolExecuted.id,
+        );
+      }
+
+      // Advance skill-loaded watermark (compound cursor)
+      if (skillLoadedEvents.length > 0) {
+        const lastSkillLoaded = skillLoadedEvents[skillLoadedEvents.length - 1];
+        setMemoryCheckpoint(
+          CHECKPOINT_KEY_SKILL_LOADED_WATERMARK,
+          String(lastSkillLoaded.createdAt),
+        );
+        setMemoryCheckpoint(
+          CHECKPOINT_KEY_SKILL_LOADED_WATERMARK_ID,
+          lastSkillLoaded.id,
+        );
+      }
+
       // If we got a full batch of any type, there may be more — recurse
       if (
         events.length === BATCH_SIZE ||
         turnEvents.length === BATCH_SIZE ||
         lifecycleEvents.length === BATCH_SIZE ||
         onboardingEvents.length === BATCH_SIZE ||
-        authFallbackEvents.length === BATCH_SIZE
+        authFallbackEvents.length === BATCH_SIZE ||
+        toolExecutedEvents.length === BATCH_SIZE ||
+        skillLoadedEvents.length === BATCH_SIZE
       ) {
         await this._doFlush(batchCount + 1);
       }


### PR DESCRIPTION
## Summary
- Wires tool_executed and skill_loaded into usage-telemetry-reporter with standard (created_at, id) watermark checkpoints
- tool_executed watermark initializes to now on first run so pre-upgrade tool_invocations rows are not backfilled
- Maps store rows to the PR 1 wire types (decision→status projection, null attribution passthrough, upload-time assistant_version)

Part of plan: tool-skill-telemetry.md (PR 6 of 6)