### PR TITLE
fix: skill_loaded coverage for instruction-only skills + shared attribution mapping

### DIFF
--- a/assistant/src/__tests__/conversation-skill-tools.test.ts
+++ b/assistant/src/__tests__/conversation-skill-tools.test.ts
@@ -521,7 +521,9 @@ describe("projectSkillTools", () => {
       previouslyActiveSkillIds: sessionState,
     });
     expect(result1.toolDefinitions).toEqual([]);
-    expect(sessionState.has("deploy")).toBe(false);
+    // Tracked as a manifest-less activation — no tools registered yet.
+    expect(sessionState.has("deploy")).toBe(true);
+    expect(mockRegisteredTools.has("deploy")).toBe(false);
 
     // Turn 2: manifest now available
     mockManifests = { deploy: makeManifest(["deploy_run"]) };
@@ -548,11 +550,12 @@ describe("projectSkillTools", () => {
     expect(sessionState.has("deploy")).toBe(true);
     expect(mockSkillRefCount.get("deploy")).toBe(1);
 
-    // Turn 2: manifest transiently fails — skill should be unregistered
+    // Turn 2: manifest transiently fails — tools should be unregistered
+    // (the skill stays tracked as a manifest-less activation)
     mockManifests = {};
     mockUnregisteredSkillIds = [];
     projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
-    expect(sessionState.has("deploy")).toBe(false);
+    expect(sessionState.has("deploy")).toBe(true);
     expect(mockUnregisteredSkillIds).toContain("deploy");
     // Ref count should be 0 (properly decremented)
     expect(mockSkillRefCount.has("deploy")).toBe(false);
@@ -985,6 +988,115 @@ describe("skill_loaded telemetry recording", () => {
     // Tool projection behavior is unchanged when recording fails
     expect(result.allowedToolNames.has("notes_add")).toBe(true);
     expect(sessionState.has("notes")).toBe(true);
+  });
+
+  test("instruction-only bundled skill (no TOOLS.json) records exactly one event", () => {
+    mockCatalog = [makeSkill("guides", undefined, "bundled")];
+    // No manifest registered for "guides" — instruction-only skill.
+    mockCachedCatalog = [{ id: "guides", updatedAt: "2026-02-03T04:05:06Z" }];
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="guides" />'),
+    ];
+    projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: makeTelemetry(),
+    });
+
+    expect(recordedSkillLoadedEvents).toHaveLength(1);
+    expect(recordedSkillLoadedEvents[0]).toEqual({
+      conversationId: "conv-xyz",
+      skillName: "guides",
+      skillUpdatedAt: "2026-02-03T04:05:06Z",
+      provider: "test-provider",
+      model: "test-model",
+      inferenceProfile: "balanced",
+      inferenceProfileSource: "active",
+    });
+
+    // Still active next turn — no re-record.
+    projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: makeTelemetry(),
+    });
+    expect(recordedSkillLoadedEvents).toHaveLength(1);
+  });
+
+  test("instruction-only managed skill with vellum origin records exactly one event", () => {
+    mockCatalog = [makeSkill("catalog-skill")];
+    // No manifest — mirrors installSkillLocally output for catalog skills.
+    mockInstallMetas = {
+      "catalog-skill": {
+        origin: "vellum",
+        installedAt: "2026-01-01T00:00:00Z",
+      },
+    };
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="catalog-skill" />'),
+    ];
+    projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: makeTelemetry(),
+    });
+    projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: makeTelemetry(),
+    });
+
+    expect(recordedSkillLoadedEvents).toHaveLength(1);
+    expect(recordedSkillLoadedEvents[0].skillName).toBe("catalog-skill");
+  });
+
+  test("instruction-only non-Vellum skills never record", () => {
+    mockCatalog = [
+      makeSkill("local-notes", undefined, "workspace"),
+      makeSkill("homemade"),
+    ];
+    // No manifests for either skill.
+    mockInstallMetas = {
+      homemade: { origin: "custom", installedAt: "2026-01-01T00:00:00Z" },
+    };
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="local-notes" />'),
+      ...skillLoadMessages('<loaded_skill id="homemade" />'),
+    ];
+    projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: makeTelemetry(),
+    });
+
+    expect(recordedSkillLoadedEvents).toHaveLength(0);
+  });
+
+  test("instruction-only skill re-records after deactivation and reactivation, without touching the registry", () => {
+    mockCatalog = [makeSkill("guides", undefined, "bundled")];
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="guides" />'),
+    ];
+    projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: makeTelemetry(),
+    });
+    expect(recordedSkillLoadedEvents).toHaveLength(1);
+
+    // Deactivated: marker gone. No tools were ever registered for it, so the
+    // registry must not be touched (refcounts belong to other conversations).
+    mockUnregisteredSkillIds = [];
+    projectSkillTools([], {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: makeTelemetry(),
+    });
+    expect(mockUnregisteredSkillIds).not.toContain("guides");
+
+    // Reactivated: a fresh activation is a new load.
+    projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: makeTelemetry(),
+    });
+    expect(recordedSkillLoadedEvents).toHaveLength(2);
   });
 
   test("absent telemetry context disables recording entirely", () => {
@@ -2306,6 +2418,27 @@ describe("resetSkillToolProjection", () => {
 
     expect(mockUnregisteredSkillIds).toContain("deploy");
     expect(mockUnregisteredSkillIds).toContain("oncall");
+    expect(trackedIds.size).toBe(0);
+  });
+
+  test("manifest-less tracked skills are cleared without touching the registry", () => {
+    mockCatalog = [makeSkill("deploy"), makeSkill("guides")];
+    // Only deploy has tools; guides is instruction-only.
+    mockManifests = { deploy: makeManifest(["deploy_run"]) };
+
+    const trackedIds = new Map<string, string>();
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="deploy" />'),
+      ...skillLoadMessages('<loaded_skill id="guides" />'),
+    ];
+    projectSkillTools(history, { previouslyActiveSkillIds: trackedIds });
+    expect(trackedIds.size).toBe(2);
+
+    mockUnregisteredSkillIds = [];
+    resetSkillToolProjection(trackedIds);
+
+    expect(mockUnregisteredSkillIds).toContain("deploy");
+    expect(mockUnregisteredSkillIds).not.toContain("guides");
     expect(trackedIds.size).toBe(0);
   });
 

--- a/assistant/src/daemon/conversation-skill-tools.ts
+++ b/assistant/src/daemon/conversation-skill-tools.ts
@@ -32,9 +32,20 @@ import {
 } from "../tools/registry.js";
 import { createSkillToolsFromManifest } from "../tools/skills/skill-tool-factory.js";
 import type { UsageAttributionSnapshot } from "../usage/attribution.js";
+import { toAttributionColumns } from "../usage/attribution.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("conversation-skill-tools");
+
+/**
+ * Sentinel "version hash" stored in the previously-active map for skills that
+ * are active without a loadable TOOLS.json (instruction-only skills — the
+ * common case for catalog installs — or skills whose manifest failed to
+ * parse). These entries registered no tools, so teardown paths must skip
+ * `unregisterSkillTools` for them to avoid decrementing refcounts held by
+ * other conversations.
+ */
+const NO_TOOLS_VERSION = "__no_tools__";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -78,7 +89,8 @@ export interface ProjectSkillToolsOptions {
   preactivatedSkillIds?: string[];
   /**
    * Conversation-scoped tracking map of previously active skill IDs to their
-   * version hashes. Each conversation should own its own map to prevent
+   * version hashes (or the no-tools sentinel for active skills without a
+   * loadable manifest). Each conversation should own its own map to prevent
    * cross-conversation state bleed when the daemon serves multiple concurrent
    * conversations. When a skill's hash changes between turns, its tools are
    * unregistered and re-registered with the updated definitions.
@@ -155,15 +167,15 @@ function recordSkillLoadedTelemetry(
   try {
     if (!isVellumProducedSkill(skill)) return;
     const catalogEntry = getCachedCatalogSync().find((s) => s.id === skill.id);
-    const attribution = telemetry.attribution;
+    const columns = toAttributionColumns(telemetry.attribution);
     recordSkillLoadedEvent({
       conversationId: telemetry.conversationId ?? undefined,
       skillName: skill.id,
       skillUpdatedAt: catalogEntry?.updatedAt,
-      provider: attribution?.resolvedProvider,
-      model: attribution?.resolvedModel,
-      inferenceProfile: attribution?.appliedProfile ?? undefined,
-      inferenceProfileSource: attribution?.profileSource,
+      provider: columns.provider ?? undefined,
+      model: columns.model ?? undefined,
+      inferenceProfile: columns.inferenceProfile ?? undefined,
+      inferenceProfileSource: columns.inferenceProfileSource ?? undefined,
     });
   } catch (err) {
     log.debug(
@@ -325,8 +337,11 @@ export function projectSkillTools(
     }
   }
 
-  // Unregister tools for skills that are no longer active
+  // Unregister tools for skills that are no longer active. Skills tracked
+  // with the no-tools sentinel never registered anything — skip them so we
+  // don't decrement refcounts held by other conversations.
   for (const id of removedIds) {
+    if (prevActive.get(id) === NO_TOOLS_VERSION) continue;
     log.info({ skillId: id }, "Unregistering tools for deactivated skill");
     unregisterSkillTools(id);
   }
@@ -351,8 +366,34 @@ export function projectSkillTools(
       continue;
     }
 
+    // A skill that newly became active counts as one `skill_loaded`, whether
+    // or not it ships a TOOLS.json — instruction-only skills (the common case
+    // for catalog installs) must be counted too, so this runs before the
+    // manifest gate. The once-per-activation guard (`prevActive`) is
+    // in-memory per-conversation state: after conversation disposal or a
+    // daemon restart, re-projection re-emits skill_loaded for already-active
+    // skills. That is intentional — a re-load after restart is a load.
+    // Downstream consumers that need activation-level uniqueness dedup on
+    // (conversation_id, skill_name).
+    if (!prevActive.has(skillId)) {
+      recordSkillLoadedTelemetry(skill, options?.telemetry);
+    }
+
     const manifest = loadManifestForSkill(skill);
     if (!manifest) {
+      // No loadable manifest — nothing to register, but keep tracking the
+      // activation so it isn't re-recorded every turn. If tools were
+      // registered on a previous turn (manifest removed or corrupted since),
+      // tear them down like the transiently-failed path would.
+      const prevHash = prevActive.get(skillId);
+      if (prevHash !== undefined && prevHash !== NO_TOOLS_VERSION) {
+        log.info(
+          { skillId },
+          "Unregistering tools for skill whose manifest is no longer loadable",
+        );
+        unregisterSkillTools(skillId);
+      }
+      successfulEntries.set(skillId, NO_TOOLS_VERSION);
       continue;
     }
 
@@ -379,10 +420,17 @@ export function projectSkillTools(
     if (tools.length > 0) {
       let accepted = tools;
       const prevHash = prevActive.get(skillId);
-      if (prevHash === undefined) {
-        // Newly active skill — register for the first time
+      if (prevHash === undefined || prevHash === NO_TOOLS_VERSION) {
+        // Newly active skill (already recorded above), or a previously
+        // manifest-less activation whose TOOLS.json has since appeared —
+        // register for the first time. There is nothing to unregister in the
+        // sentinel case: no tools were ever registered for it.
         accepted = registerSkillTools(skillId, tools);
-        recordSkillLoadedTelemetry(skill, options?.telemetry);
+        if (prevHash === NO_TOOLS_VERSION) {
+          // Gaining a manifest re-registers the skill — like a version-hash
+          // change, that counts as a new load.
+          recordSkillLoadedTelemetry(skill, options?.telemetry);
+        }
       } else if (prevHash !== currentHash) {
         // Hash changed — unregister stale tools, then re-register with new definitions
         log.info(
@@ -432,7 +480,9 @@ export function projectSkillTools(
     if (
       activeIds.has(id) &&
       !successfulEntries.has(id) &&
-      !alreadyUnregistered.has(id)
+      !alreadyUnregistered.has(id) &&
+      // Sentinel entries registered no tools — nothing to unregister.
+      prevActive.get(id) !== NO_TOOLS_VERSION
     ) {
       log.info(
         { skillId: id },
@@ -463,7 +513,11 @@ export function resetSkillToolProjection(
   trackedIds?: Map<string, string>,
 ): void {
   if (trackedIds) {
-    for (const id of trackedIds.keys()) {
+    for (const [id, hash] of trackedIds) {
+      // Sentinel entries (active skills without a manifest) registered no
+      // tools — skip them so we don't decrement refcounts held by other
+      // conversations.
+      if (hash === NO_TOOLS_VERSION) continue;
       unregisterSkillTools(id);
     }
     trackedIds.clear();

--- a/assistant/src/events/tool-audit-listener.ts
+++ b/assistant/src/events/tool-audit-listener.ts
@@ -7,7 +7,7 @@ import type {
   ToolLifecycleEvent,
   ToolLifecycleEventHandler,
 } from "../tools/types.js";
-import type { UsageAttributionSnapshot } from "../usage/attribution.js";
+import { toAttributionColumns } from "../usage/attribution.js";
 import { getLogger } from "../util/logger.js";
 
 const RESULT_PREVIEW_LIMIT = 1000;
@@ -56,7 +56,7 @@ function toInvocationRecord(
         // query time would undercount. Only the sizes leave the device.
         argBytes: Buffer.byteLength(input, "utf8"),
         resultBytes: Buffer.byteLength(event.result.content, "utf8"),
-        ...toAttributionFields(event.attribution),
+        ...toAttributionColumns(event.attribution),
       };
     }
     case "error": {
@@ -73,7 +73,7 @@ function toInvocationRecord(
         durationMs: event.durationMs,
         argBytes: Buffer.byteLength(input, "utf8"),
         resultBytes: Buffer.byteLength(result, "utf8"),
-        ...toAttributionFields(event.attribution),
+        ...toAttributionColumns(event.attribution),
       };
     }
     case "permission_denied":
@@ -93,25 +93,6 @@ function toInvocationRecord(
     case "permission_prompt":
       return null;
   }
-}
-
-/**
- * Maps an attribution snapshot to the tool_invocations telemetry columns —
- * the same mapping `llm_usage` reporting uses (`appliedProfile` →
- * inference_profile, `profileSource` → inference_profile_source).
- */
-function toAttributionFields(
-  attribution: UsageAttributionSnapshot | null | undefined,
-): Pick<
-  ToolInvocationRecord,
-  "provider" | "model" | "inferenceProfile" | "inferenceProfileSource"
-> {
-  return {
-    provider: attribution?.resolvedProvider ?? null,
-    model: attribution?.resolvedModel ?? null,
-    inferenceProfile: attribution?.appliedProfile ?? null,
-    inferenceProfileSource: attribution?.profileSource ?? null,
-  };
 }
 
 function stringifyInput(input: Record<string, unknown>): string {

--- a/assistant/src/usage/attribution.ts
+++ b/assistant/src/usage/attribution.ts
@@ -43,6 +43,34 @@ export interface UsageAttributionSnapshot {
 }
 
 /**
+ * The four nullable attribution columns shared by telemetry event rows
+ * (`tool_invocations`, `skill_loaded_events`).
+ */
+export interface UsageAttributionColumns {
+  provider: string | null;
+  model: string | null;
+  inferenceProfile: string | null;
+  inferenceProfileSource: string | null;
+}
+
+/**
+ * Maps an attribution snapshot to the shared telemetry columns — the same
+ * mapping `llm_usage` reporting uses (`appliedProfile` → inference_profile,
+ * `profileSource` → inference_profile_source). Accepts a missing snapshot so
+ * producers that resolve attribution best-effort can pass it through as-is.
+ */
+export function toAttributionColumns(
+  snapshot: UsageAttributionSnapshot | null | undefined,
+): UsageAttributionColumns {
+  return {
+    provider: snapshot?.resolvedProvider ?? null,
+    model: snapshot?.resolvedModel ?? null,
+    inferenceProfile: snapshot?.appliedProfile ?? null,
+    inferenceProfileSource: snapshot?.profileSource ?? null,
+  };
+}
+
+/**
  * Sanitizes values before they are copied into external metadata surfaces.
  * Empty strings and control-character-bearing strings are dropped, and long
  * values are capped so later forwarding cannot create unbounded headers.


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for tool-skill-telemetry.md.

**Gap:** skill_loaded recording sat behind the TOOLS.json manifest gate, so instruction-only skills (all 67 Vellum catalog skills) never emitted events; attribution column mapping duplicated across producers
**What was expected:** one event per Vellum-produced skill load regardless of manifest presence; one shared snapshot→columns helper
**What was found:** recording reachable only in the tool-registration branch; inline mapping copy in conversation-skill-tools.ts