### PR TITLE
fix: raw arg_bytes sizing + type/test dedup + telemetry doc cleanups

### DIFF
--- a/assistant/src/__tests__/test-support/tool-invocation-seed.ts
+++ b/assistant/src/__tests__/test-support/tool-invocation-seed.ts
@@ -1,0 +1,63 @@
+import { getDb } from "../../memory/db-connection.js";
+import { conversations, toolInvocations } from "../../memory/schema.js";
+
+/**
+ * Sentinel embedded in the seeded raw input/result payloads. Tests assert it
+ * never appears in any projection or wire payload — raw tool args/outputs
+ * must never leave the device.
+ */
+export const TOOL_INVOCATION_PII_SENTINEL = "must never leave the device";
+
+export interface ToolInvocationSeedSpec {
+  id: string;
+  createdAt: number;
+  conversationId: string;
+  toolName?: string;
+  decision?: string;
+  durationMs?: number;
+  argBytes?: number | null;
+  resultBytes?: number | null;
+  provider?: string | null;
+  model?: string | null;
+  inferenceProfile?: string | null;
+  inferenceProfileSource?: string | null;
+}
+
+/**
+ * Seed a `tool_invocations` row (plus its FK conversation) for telemetry
+ * projection tests. Byte sizes default to non-null — post-migration writer
+ * paths always compute them; pass an explicit null to seed a legacy
+ * pre-migration-278 row.
+ */
+export function seedToolInvocation(spec: ToolInvocationSeedSpec): void {
+  const db = getDb();
+  // tool_invocations has an enforced FK to conversations.
+  db.insert(conversations)
+    .values({
+      id: spec.conversationId,
+      title: "test",
+      createdAt: 1000,
+      updatedAt: 1000,
+    })
+    .onConflictDoNothing()
+    .run();
+  db.insert(toolInvocations)
+    .values({
+      id: spec.id,
+      conversationId: spec.conversationId,
+      toolName: spec.toolName ?? "calendar_list_events",
+      input: `{"secret":"raw tool args — ${TOOL_INVOCATION_PII_SENTINEL}"}`,
+      result: `{"secret":"raw tool output — ${TOOL_INVOCATION_PII_SENTINEL}"}`,
+      decision: spec.decision ?? "allow",
+      riskLevel: "low",
+      durationMs: spec.durationMs ?? 12,
+      createdAt: spec.createdAt,
+      argBytes: spec.argBytes !== undefined ? spec.argBytes : 2,
+      resultBytes: spec.resultBytes !== undefined ? spec.resultBytes : 9,
+      provider: spec.provider ?? null,
+      model: spec.model ?? null,
+      inferenceProfile: spec.inferenceProfile ?? null,
+      inferenceProfileSource: spec.inferenceProfileSource ?? null,
+    })
+    .run();
+}

--- a/assistant/src/__tests__/tool-audit-listener.test.ts
+++ b/assistant/src/__tests__/tool-audit-listener.test.ts
@@ -185,6 +185,75 @@ describe("tool audit listener", () => {
     expect(records[0].resultBytes).toBe(2400);
   });
 
+  test("prefers the executor-stamped raw inputBytes over sizing the (sanitized) event input", () => {
+    const records: ToolInvocationRecord[] = [];
+    const listener = createToolAuditListener((record) => records.push(record));
+
+    // The executor sanitizes event.input before listeners run and stamps
+    // inputBytes from the RAW input — the listener must report that size,
+    // not the redacted payload's.
+    const rawInput = { path: "/tmp/a", token: "t-1" };
+    const rawSize = Buffer.byteLength(JSON.stringify(rawInput), "utf8");
+    const sanitizedInput = { path: "/tmp/a", token: "<redacted />" };
+
+    listener({
+      type: "executed",
+      toolName: "file_read",
+      input: sanitizedInput,
+      inputBytes: rawSize,
+      workingDir: "/tmp",
+      conversationId: "conv-raw-bytes",
+      riskLevel: "low",
+      decision: "allow",
+      durationMs: 4,
+      result: { content: "ok", isError: false },
+    });
+    listener({
+      type: "error",
+      toolName: "file_read",
+      input: sanitizedInput,
+      inputBytes: rawSize,
+      workingDir: "/tmp",
+      conversationId: "conv-raw-bytes",
+      riskLevel: "low",
+      decision: "error",
+      durationMs: 4,
+      errorMessage: "boom",
+      isExpected: false,
+      errorCategory: "tool_failure",
+    });
+
+    expect(records).toHaveLength(2);
+    for (const record of records) {
+      expect(record.argBytes).toBe(rawSize);
+      expect(record.argBytes).not.toBe(
+        Buffer.byteLength(JSON.stringify(sanitizedInput), "utf8"),
+      );
+    }
+  });
+
+  test("falls back to sizing the event input when inputBytes is absent, keeping argBytes non-null", () => {
+    const records: ToolInvocationRecord[] = [];
+    const listener = createToolAuditListener((record) => records.push(record));
+
+    listener({
+      type: "executed",
+      toolName: "file_read",
+      input: { path: "/tmp/a" },
+      workingDir: "/tmp",
+      conversationId: "conv-fallback",
+      riskLevel: "low",
+      decision: "allow",
+      durationMs: 4,
+      result: { content: "ok", isError: false },
+    });
+
+    expect(records).toHaveLength(1);
+    expect(records[0].argBytes).toBe(
+      Buffer.byteLength(JSON.stringify({ path: "/tmp/a" }), "utf8"),
+    );
+  });
+
   test("maps attribution onto executed records and leaves denied records null", () => {
     const records: ToolInvocationRecord[] = [];
     const listener = createToolAuditListener((record) => records.push(record));

--- a/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
+++ b/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
@@ -652,6 +652,73 @@ describe("ToolExecutor lifecycle events", () => {
     expect(errorEvent.attribution).toEqual(testAttribution);
   });
 
+  // ── raw input byte sizing tests ───────────────────────────
+
+  test("stamps inputBytes from the raw input even when sanitization redacts fields", async () => {
+    const events: ToolLifecycleEvent[] = [];
+    const executor = new ToolExecutor(makePrompter());
+
+    const rawInput = { path: "README.md", token: "t-1" };
+    const rawSize = Buffer.byteLength(JSON.stringify(rawInput), "utf8");
+
+    await executor.execute("file_read", rawInput, makeContext(events));
+
+    const executed = events.find((event) => event.type === "executed");
+    if (executed?.type !== "executed")
+      throw new Error("Expected executed event");
+    // The event input is sanitized, but the size reflects the raw payload.
+    expect(executed.input.token).toBe("<redacted />");
+    expect(executed.inputBytes).toBe(rawSize);
+    expect(executed.inputBytes).not.toBe(
+      Buffer.byteLength(JSON.stringify(executed.input), "utf8"),
+    );
+  });
+
+  test("stamps inputBytes from the raw input on error events", async () => {
+    toolThrow = new Error("boom");
+
+    const events: ToolLifecycleEvent[] = [];
+    const executor = new ToolExecutor(makePrompter());
+
+    const rawInput = { path: "README.md", api_key: "k-1" };
+
+    await executor.execute("file_read", rawInput, makeContext(events));
+
+    const errorEvent = events.find((event) => event.type === "error");
+    if (errorEvent?.type !== "error") throw new Error("Expected error event");
+    expect(errorEvent.input.api_key).toBe("<redacted />");
+    expect(errorEvent.inputBytes).toBe(
+      Buffer.byteLength(JSON.stringify(rawInput), "utf8"),
+    );
+  });
+
+  test("audit listener records arg_bytes equal to the raw serialized input size", async () => {
+    // End-to-end: executor sanitization must not shrink the recorded
+    // arg_bytes — the audit row sizes the raw pre-redaction input.
+    const { createToolAuditListener } =
+      await import("../events/tool-audit-listener.js");
+    const records: Array<{ argBytes?: number | null; input: string }> = [];
+    const executor = new ToolExecutor(makePrompter());
+
+    const rawInput = { path: "README.md", token: "t-1" };
+
+    await executor.execute("file_read", rawInput, {
+      workingDir: "/tmp/project",
+      conversationId: "conversation-1",
+      trustClass: "guardian" as const,
+      onToolLifecycleEvent: createToolAuditListener((record) =>
+        records.push(record),
+      ),
+    });
+
+    expect(records).toHaveLength(1);
+    expect(records[0].argBytes).toBe(
+      Buffer.byteLength(JSON.stringify(rawInput), "utf8"),
+    );
+    // The stored input column is still the redacted payload.
+    expect(records[0].input).not.toContain("t-1");
+  });
+
   test("skill tool with sandbox execution_target resolves to sandbox executionTarget", async () => {
     const events: ToolLifecycleEvent[] = [];
     const executor = new ToolExecutor(makePrompter());

--- a/assistant/src/events/tool-audit-listener.ts
+++ b/assistant/src/events/tool-audit-listener.ts
@@ -3,9 +3,10 @@ import {
   type ToolInvocationRecord,
 } from "../memory/tool-usage-store.js";
 import { redactSecrets } from "../security/secret-scanner.js";
-import type {
-  ToolLifecycleEvent,
-  ToolLifecycleEventHandler,
+import {
+  stringifyToolInput,
+  type ToolLifecycleEvent,
+  type ToolLifecycleEventHandler,
 } from "../tools/types.js";
 import type { UsageAttributionSnapshot } from "../usage/attribution.js";
 import { getLogger } from "../util/logger.js";
@@ -38,7 +39,7 @@ function toInvocationRecord(
 ): ToolInvocationRecord | null {
   switch (event.type) {
     case "executed": {
-      const input = stringifyInput(event.input);
+      const input = stringifyToolInput(event.input);
       return {
         conversationId: event.conversationId,
         toolName: event.toolName,
@@ -51,16 +52,20 @@ function toInvocationRecord(
         riskLevel: event.riskLevel,
         matchedTrustRuleId: event.matchedTrustRuleId,
         durationMs: event.durationMs,
-        // Byte sizes are computed here from the raw payloads — the stored
-        // `result` column is truncated and redacted above, so sizing at
-        // query time would undercount. Only the sizes leave the device.
-        argBytes: Buffer.byteLength(input, "utf8"),
+        // Byte sizes reflect the full raw payloads — only the sizes leave
+        // the device. The arg size prefers `event.inputBytes`, stamped by
+        // the executor BEFORE input sanitization; the fallback sizes the
+        // (sanitized) event input so argBytes stays non-null, which the
+        // tool_executed projection's legacy-row filter relies on. The
+        // result size is computed before the stored `result` column is
+        // truncated and redacted above.
+        argBytes: event.inputBytes ?? Buffer.byteLength(input, "utf8"),
         resultBytes: Buffer.byteLength(event.result.content, "utf8"),
         ...toAttributionFields(event.attribution),
       };
     }
     case "error": {
-      const input = stringifyInput(event.input);
+      const input = stringifyToolInput(event.input);
       const result = `error: ${event.errorMessage}`;
       return {
         conversationId: event.conversationId,
@@ -71,7 +76,8 @@ function toInvocationRecord(
         riskLevel: event.riskLevel,
         matchedTrustRuleId: event.matchedTrustRuleId,
         durationMs: event.durationMs,
-        argBytes: Buffer.byteLength(input, "utf8"),
+        // Same sizing contract as the "executed" case above.
+        argBytes: event.inputBytes ?? Buffer.byteLength(input, "utf8"),
         resultBytes: Buffer.byteLength(result, "utf8"),
         ...toAttributionFields(event.attribution),
       };
@@ -82,7 +88,7 @@ function toInvocationRecord(
       return {
         conversationId: event.conversationId,
         toolName: event.toolName,
-        input: stringifyInput(event.input),
+        input: stringifyToolInput(event.input),
         result: formatDeniedResult(event.reason),
         decision: "denied",
         riskLevel: event.riskLevel,
@@ -112,14 +118,6 @@ function toAttributionFields(
     inferenceProfile: attribution?.appliedProfile ?? null,
     inferenceProfileSource: attribution?.profileSource ?? null,
   };
-}
-
-function stringifyInput(input: Record<string, unknown>): string {
-  try {
-    return JSON.stringify(input);
-  } catch {
-    return "[unserializable-input]";
-  }
 }
 
 function formatDeniedResult(reason: string): string {

--- a/assistant/src/events/tool-metrics-listener.ts
+++ b/assistant/src/events/tool-metrics-listener.ts
@@ -1,3 +1,4 @@
+import { stringifyToolInput } from "../tools/types.js";
 import { getLogger, truncateForLog } from "../util/logger.js";
 import type { EventBus, Subscription } from "./bus.js";
 import type { AssistantDomainEvents } from "./domain-events.js";
@@ -129,9 +130,5 @@ function formatInputForLog(
   input: Record<string, unknown>,
   truncate: (value: string, maxLen: number) => string,
 ): string {
-  try {
-    return truncate(JSON.stringify(input), INPUT_PREVIEW_LIMIT);
-  } catch {
-    return "[unserializable-input]";
-  }
+  return truncate(stringifyToolInput(input), INPUT_PREVIEW_LIMIT);
 }

--- a/assistant/src/memory/migrations/278-tool-invocations-telemetry-columns.ts
+++ b/assistant/src/memory/migrations/278-tool-invocations-telemetry-columns.ts
@@ -12,21 +12,14 @@ const COLUMNS: Array<{ name: string; type: string }> = [
 
 /**
  * Add nullable telemetry columns to `tool_invocations` for the
- * `tool_executed` telemetry projection.
+ * `tool_executed` telemetry projection: serialized payload sizes (only the
+ * sizes leave the device, never the payloads) and the conversation's model
+ * attribution at invocation time. Nullable so pre-migration and
+ * permission-denied rows stay NULL (see the legacy-row filter in
+ * tool-executed-events-store.ts).
  *
- * `arg_bytes` / `result_bytes` record the serialized payload sizes computed
- * by the audit listener BEFORE the stored `result` column is truncated and
- * redacted — only the sizes leave the device, never the payloads. The
- * `provider` / `model` / `inference_profile` / `inference_profile_source`
- * columns snapshot the conversation's model attribution at invocation time
- * (same mapping the `llm_usage` events use).
- *
- * All columns are nullable — `NULL` for rows persisted before this migration
- * ran and for permission-denied rows (the tool never executed; they are
- * filtered out of the telemetry projection).
- *
- * Idempotent — re-running is a no-op once the columns exist. Pure DDL with a
- * PRAGMA guard, no registry entry needed (matches the 273 / 275 pattern).
+ * Idempotent pure DDL with a PRAGMA guard, no registry entry needed
+ * (matches the 273 / 275 pattern).
  */
 export function migrateToolInvocationsTelemetryColumns(
   database: DrizzleDb,

--- a/assistant/src/memory/tool-executed-events-store.test.ts
+++ b/assistant/src/memory/tool-executed-events-store.test.ts
@@ -8,70 +8,24 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
+import {
+  seedToolInvocation,
+  TOOL_INVOCATION_PII_SENTINEL as PII_SENTINEL,
+  type ToolInvocationSeedSpec,
+} from "../__tests__/test-support/tool-invocation-seed.js";
 import { getDb } from "./db-connection.js";
 import { initializeDb } from "./db-init.js";
-import { conversations, toolInvocations } from "./schema.js";
+import { toolInvocations } from "./schema.js";
 import { queryUnreportedToolExecutedEvents } from "./tool-executed-events-store.js";
 
 initializeDb();
 
 const CONVERSATION_ID = "conv-tool-executed-store-test";
 
-/**
- * Sentinel embedded in the seeded raw input/result payloads. Asserted to
- * never appear in any projection — raw tool args/outputs must never leave
- * the device.
- */
-const PII_SENTINEL = "must never leave the device";
-
-interface SeedSpec {
-  id: string;
-  createdAt: number;
-  toolName?: string;
-  decision?: string;
-  durationMs?: number;
-  argBytes?: number | null;
-  resultBytes?: number | null;
-  provider?: string | null;
-  model?: string | null;
-  inferenceProfile?: string | null;
-  inferenceProfileSource?: string | null;
-}
-
-function insertInvocation(spec: SeedSpec): void {
-  const db = getDb();
-  // tool_invocations has an enforced FK to conversations.
-  db.insert(conversations)
-    .values({
-      id: CONVERSATION_ID,
-      title: "test",
-      createdAt: 1000,
-      updatedAt: 1000,
-    })
-    .onConflictDoNothing()
-    .run();
-  db.insert(toolInvocations)
-    .values({
-      id: spec.id,
-      conversationId: CONVERSATION_ID,
-      toolName: spec.toolName ?? "calendar_list_events",
-      input: `{"secret":"raw tool args — ${PII_SENTINEL}"}`,
-      result: `{"secret":"raw tool output — ${PII_SENTINEL}"}`,
-      decision: spec.decision ?? "allow",
-      riskLevel: "low",
-      durationMs: spec.durationMs ?? 12,
-      createdAt: spec.createdAt,
-      // Post-migration writer paths always compute byte sizes (legacy
-      // pre-migration rows are the only null-argBytes rows), so the seed
-      // defaults to non-null. Pass an explicit null to seed a legacy row.
-      argBytes: spec.argBytes !== undefined ? spec.argBytes : 2,
-      resultBytes: spec.resultBytes !== undefined ? spec.resultBytes : 9,
-      provider: spec.provider ?? null,
-      model: spec.model ?? null,
-      inferenceProfile: spec.inferenceProfile ?? null,
-      inferenceProfileSource: spec.inferenceProfileSource ?? null,
-    })
-    .run();
+function insertInvocation(
+  spec: Omit<ToolInvocationSeedSpec, "conversationId">,
+): void {
+  seedToolInvocation({ ...spec, conversationId: CONVERSATION_ID });
 }
 
 describe("tool-executed-events-store", () => {
@@ -134,9 +88,8 @@ describe("tool-executed-events-store", () => {
   });
 
   test("excludes legacy pre-migration rows (null arg_bytes)", () => {
-    // Pre-migration-278 rows were already shipped under the since-reverted
-    // tool_execution event type — they must never be projected, even from
-    // a zero watermark.
+    // Already shipped under the reverted tool_execution type — never
+    // projected, even from a zero watermark.
     insertInvocation({
       id: "ti-legacy",
       createdAt: 1000,

--- a/assistant/src/memory/tool-executed-events-store.ts
+++ b/assistant/src/memory/tool-executed-events-store.ts
@@ -17,17 +17,9 @@ export interface UnreportedToolExecutedEvent {
   /** `"allow"`-style decisions or `"error"`; never `"denied"` (filtered out). */
   decision: string;
   durationMs: number;
-  /**
-   * Serialized input size in bytes. Non-null in practice: legacy rows
-   * persisted before migration 278 have `arg_bytes IS NULL` and are excluded
-   * from the projection entirely (see the query's legacy-row filter).
-   */
+  /** Serialized raw input size in bytes. Non-null on projected rows (the legacy-row filter excludes null). */
   argBytes: number | null;
-  /**
-   * Full serialized result size in bytes. The audit listener writes it
-   * together with `argBytes`, so it is non-null on every projected row in
-   * practice.
-   */
+  /** Full serialized result size in bytes, computed before truncation/redaction. */
   resultBytes: number | null;
   provider: string | null;
   model: string | null;
@@ -40,30 +32,22 @@ export interface UnreportedToolExecutedEvent {
 /**
  * Query tool invocations that haven't been reported to telemetry yet.
  * Uses a compound cursor (createdAt + id) for reliable watermarking.
- *
- * Permission-denied rows are excluded — the tool never executed, so no
- * `tool_executed` event is emitted for them.
- *
- * Legacy rows persisted before migration 278 (null `arg_bytes`) are also
- * excluded: they were already shipped under the since-reverted
- * `tool_execution` event type and lack the size/attribution columns, so
- * re-shipping them as `tool_executed` would double-count with null
- * attribution. Every post-migration writer path (tool-audit-listener.ts
- * "executed" and "error" events) always computes a non-null `arg_bytes`;
- * the only path that leaves it null ("permission_denied") is already
- * excluded by the decision filter. This makes `arg_bytes IS NOT NULL` a
- * reliable legacy-row discriminator, which in turn lets the telemetry
- * reporter use the standard 0 watermark default without dropping rows
- * recorded before its first flush.
- *
  * Rows are written by the tool audit listener
  * (`events/tool-audit-listener.ts`) — there is no record function here.
  *
- * Reporting is best-effort: `rotateToolInvocations` purges rows by
- * `created_at` alone, so rows older than the configured
- * `auditLog.retentionDays` window may be rotated away before they are
- * reported (e.g. if the daemon is offline or failing for longer than
- * the retention window).
+ * Two row classes are excluded:
+ * - Permission-denied rows: the tool never executed.
+ * - Legacy pre-migration-278 rows (null `arg_bytes`): already shipped under
+ *   the since-reverted `tool_execution` event type and lacking the
+ *   size/attribution columns. Every post-migration writer path computes a
+ *   non-null `arg_bytes` (the only null writer, "permission_denied", is
+ *   excluded by the decision filter), making `arg_bytes IS NOT NULL` a
+ *   reliable legacy-row discriminator — which lets the reporter keep the
+ *   standard 0 watermark default without dropping pre-first-flush rows.
+ *
+ * Reporting is best-effort: `rotateToolInvocations` purges by `created_at`
+ * alone, so rows older than `auditLog.retentionDays` may rotate away before
+ * they are reported.
  */
 export function queryUnreportedToolExecutedEvents(
   afterCreatedAt: number,

--- a/assistant/src/telemetry/types.ts
+++ b/assistant/src/telemetry/types.ts
@@ -250,13 +250,19 @@ export interface AuthFallbackTelemetryEvent extends TelemetryEventBase {
  * Tool-executed event — one per tool invocation. Carries NO tool
  * args/inputs or result contents (customer PII per ToS) — payload sizes
  * and metadata only; no raw error messages. Identity/attribution come
- * from the upload envelope per the per-event-wins contract. Distinct
- * from the `tool_execution` permission-audit event, which it
- * complements, not replaces.
+ * from the upload envelope per the per-event-wins contract. Not to be
+ * confused with the since-reverted `tool_execution` permission-audit
+ * event, which no longer exists on the wire.
  */
 export interface ToolExecutedTelemetryEvent extends ModelTelemetryEventBase {
   type: "tool_executed";
   tool_name: string;
+  /**
+   * `"errored"` means the invocation failed at the execution layer — a
+   * thrown error / infra failure (audit decision `"error"`). A tool that
+   * runs to completion but returns an `isError` result payload still
+   * counts as `"fulfilled"`: it executed.
+   */
   status: "fulfilled" | "errored";
   duration_ms: number;
   /** Serialized tool-argument size in bytes. Null when unknown. */

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -153,12 +153,16 @@ mock.module("../memory/onboarding-events-store.js", () => ({
 // Production import (after mocks)
 // ---------------------------------------------------------------------------
 
+import {
+  seedToolInvocation as seedToolInvocationRow,
+  TOOL_INVOCATION_PII_SENTINEL as TOOL_PII_SENTINEL,
+  type ToolInvocationSeedSpec,
+} from "../__tests__/test-support/tool-invocation-seed.js";
 import { recordAuthFallbackCounts } from "../memory/auth-fallback-events-store.js";
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import {
   authFallbackEvents,
-  conversations,
   skillLoadedEvents,
   toolInvocations,
 } from "../memory/schema.js";
@@ -247,59 +251,10 @@ function makeOnboardingEvent(
 
 const TOOL_CONVERSATION_ID = "conv-reporter-tool-executed";
 
-/**
- * Sentinel embedded in the seeded raw input/result payloads. Asserted to
- * never appear on the wire — raw tool args/outputs must never leave the
- * device.
- */
-const TOOL_PII_SENTINEL = "must never leave the device";
-
-function seedToolInvocation(spec: {
-  id: string;
-  createdAt: number;
-  toolName?: string;
-  decision?: string;
-  durationMs?: number;
-  argBytes?: number | null;
-  resultBytes?: number | null;
-  provider?: string | null;
-  model?: string | null;
-  inferenceProfile?: string | null;
-  inferenceProfileSource?: string | null;
-}): void {
-  const db = getDb();
-  // tool_invocations has an enforced FK to conversations.
-  db.insert(conversations)
-    .values({
-      id: TOOL_CONVERSATION_ID,
-      title: "test",
-      createdAt: 1000,
-      updatedAt: 1000,
-    })
-    .onConflictDoNothing()
-    .run();
-  db.insert(toolInvocations)
-    .values({
-      id: spec.id,
-      conversationId: TOOL_CONVERSATION_ID,
-      toolName: spec.toolName ?? "calendar_list_events",
-      input: `{"secret":"raw tool args — ${TOOL_PII_SENTINEL}"}`,
-      result: `{"secret":"raw tool output — ${TOOL_PII_SENTINEL}"}`,
-      decision: spec.decision ?? "allow",
-      riskLevel: "low",
-      durationMs: spec.durationMs ?? 12,
-      createdAt: spec.createdAt,
-      // Post-migration writer paths always compute byte sizes (legacy
-      // pre-migration rows are the only null-argBytes rows), so the seed
-      // defaults to non-null. Pass an explicit null to seed a legacy row.
-      argBytes: spec.argBytes !== undefined ? spec.argBytes : 2,
-      resultBytes: spec.resultBytes !== undefined ? spec.resultBytes : 9,
-      provider: spec.provider ?? null,
-      model: spec.model ?? null,
-      inferenceProfile: spec.inferenceProfile ?? null,
-      inferenceProfileSource: spec.inferenceProfileSource ?? null,
-    })
-    .run();
+function seedToolInvocation(
+  spec: Omit<ToolInvocationSeedSpec, "conversationId">,
+): void {
+  seedToolInvocationRow({ ...spec, conversationId: TOOL_CONVERSATION_ID });
 }
 
 const originalFetch = globalThis.fetch;
@@ -1551,12 +1506,8 @@ describe("UsageTelemetryReporter", () => {
 
   test("legacy pre-migration rows (null arg_bytes) are never shipped", async () => {
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
-    // Default mock: every checkpoint is absent (first run after upgrade),
-    // so the watermark is 0 and the query scans the whole table. The
-    // tool_invocations table holds a pre-upgrade row; it was already
-    // shipped under the since-reverted tool_execution type, lacks the
-    // migration-278 telemetry columns, and must NOT be re-shipped as
-    // tool_executed.
+    // No checkpoints (zero watermark, whole-table scan): a legacy null-
+    // arg_bytes row must still not be re-shipped as tool_executed.
     seedToolInvocation({
       id: "ti-historical",
       createdAt: 1700000001000,
@@ -1573,11 +1524,8 @@ describe("UsageTelemetryReporter", () => {
 
   test("rows recorded before the first flush are shipped (no now-initialized watermark)", async () => {
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
-    // Regression coverage for the review finding: the reporter delays its
-    // first flush, so a tool used right after install/upgrade is recorded
-    // BEFORE any tool_executed checkpoint exists. A watermark initialized
-    // to Date.now() would silently drop it; the legacy-row discriminator
-    // (null arg_bytes) plus the standard 0 default must ship it.
+    // A row recorded before any tool_executed checkpoint exists must ship —
+    // a now-initialized watermark would silently drop it.
     seedToolInvocation({ id: "ti-pre-first-flush", createdAt: 1700000001000 });
 
     const reporter = new UsageTelemetryReporter();

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -203,14 +203,9 @@ export class UsageTelemetryReporter {
         undefined;
 
       // Read tool-executed watermark (compound cursor: createdAt + id).
-      // The standard 0 default is safe even though `tool_invocations` is a
-      // pre-existing audit table: legacy rows — already shipped under the
-      // since-reverted `tool_execution` event type and lacking the
-      // arg_bytes/result_bytes/attribution columns — are excluded at the
-      // query level via the null `arg_bytes` discriminator (see
-      // queryUnreportedToolExecutedEvents), so they are never backfilled.
-      // Rows recorded after migration 278 but before the first flush ARE
-      // picked up, which a now-initialized watermark would have dropped.
+      // The 0 default is safe despite the pre-existing audit table: legacy
+      // rows are excluded at the query level (see
+      // queryUnreportedToolExecutedEvents).
       const toolExecutedWatermark = Number(
         getMemoryCheckpoint(CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK) ?? "0",
       );

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -22,10 +22,11 @@ import { sandboxPolicy } from "./shared/filesystem/path-policy.js";
 import { MAX_FILE_SIZE_BYTES } from "./shared/filesystem/size-guard.js";
 import { ToolApprovalHandler } from "./tool-approval-handler.js";
 import { resolveToolInvocationAlias } from "./tool-name-aliases.js";
-import type {
-  ToolContext,
-  ToolExecutionResult,
-  ToolLifecycleEvent,
+import {
+  stringifyToolInput,
+  type ToolContext,
+  type ToolExecutionResult,
+  type ToolLifecycleEvent,
 } from "./types.js";
 
 const log = getLogger("tool-executor");
@@ -493,13 +494,20 @@ function emitLifecycleEvent(
     input: sanitizeToolInput(event.toolName, event.input),
   };
 
-  // Stamp model attribution centrally so every executed/error event carries
-  // it — including the pre-execution gate failures (aborted, disk pressure,
-  // unknown/inactive tool) emitted from checkPreExecutionGates(), whose
-  // emission sites don't have to remember to copy it.
+  // Stamp telemetry fields centrally so every executed/error event carries
+  // them — including the pre-execution gate failures (aborted, disk
+  // pressure, unknown/inactive tool) emitted from checkPreExecutionGates(),
+  // whose emission sites don't have to remember to copy them. This is the
+  // sole writer of both fields.
   if (sanitizedEvent.type === "executed" || sanitizedEvent.type === "error") {
-    sanitizedEvent.attribution =
-      sanitizedEvent.attribution ?? context.attribution ?? null;
+    sanitizedEvent.attribution = context.attribution ?? null;
+    // Sized from the RAW pre-sanitization input — redaction changes the
+    // serialized length, and telemetry must report the true payload size.
+    // Only the size leaves the device, never the payload.
+    sanitizedEvent.inputBytes = Buffer.byteLength(
+      stringifyToolInput(event.input),
+      "utf8",
+    );
   }
 
   try {

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -1,10 +1,10 @@
 import type { ApprovalRequired } from "@vellumai/service-contracts/credential-rpc";
 import type {
   DiffInfo,
-  ErrorCategory,
   ExecutionTarget,
   ProxyApprovalCallback,
   SensitiveOutputBinding,
+  ToolExecutionErrorEvent as ContractsToolExecutionErrorEvent,
   ToolExecutionStartEvent,
   ToolPermissionDeniedEvent,
   ToolPermissionPromptEvent,
@@ -44,8 +44,7 @@ export function isDiskPressureCleanupToolName(name: string): boolean {
 // Pure re-exports below cover types the contracts package could declare
 // without any assistant-side references. The remaining interfaces (`Tool`,
 // `ToolContext`, `ToolExecutionResult`, `ToolExecutedEvent`,
-// `ToolExecutionErrorEvent`, `ToolLifecycleEvent`,
-// `ToolLifecycleEventHandler`, `ProxyToolResolver`)
+// `ToolLifecycleEvent`, `ToolLifecycleEventHandler`, `ProxyToolResolver`)
 // reference daemon-internal types (CES client, host-proxy classes,
 // `ContentBlock`, `ApprovalRequired`, `TrustClass`, `InterfaceId`,
 // `SecretPromptResult`, `UsageAttributionSnapshot`) that can't move into a
@@ -55,6 +54,9 @@ export function isDiskPressureCleanupToolName(name: string): boolean {
 // concrete types. The two sides are structurally independent — no
 // inheritance, no intersection — which avoids TypeScript's contravariance
 // mismatches on lifecycle-event handlers.
+// `ToolExecutionErrorEvent` is the exception: its contracts fields are all
+// concrete, so the assistant overlay simply extends it with the
+// daemon-internal telemetry fields.
 // ---------------------------------------------------------------------------
 
 export type {
@@ -189,39 +191,31 @@ export interface ToolExecutedEvent {
    * resolution failed or no attribution was available.
    */
   attribution?: UsageAttributionSnapshot | null;
+  /**
+   * Serialized byte size of the RAW tool input, stamped by the executor
+   * before sensitive-field sanitization rewrites `input`. Only the size
+   * leaves the device, never the payload.
+   */
+  inputBytes?: number | null;
 }
 
 /**
- * `ToolExecutionErrorEvent` is redeclared here (rather than re-exported from
- * the contracts package) so it can carry the assistant-side `attribution`
- * snapshot, which references the daemon-internal `UsageAttributionSnapshot`
- * type. All other fields mirror the contracts declaration.
+ * Extends the contracts declaration with the assistant-side telemetry
+ * fields stamped centrally by the executor's `emitLifecycleEvent`.
  */
-export interface ToolExecutionErrorEvent {
-  type: "error";
-  toolName: string;
-  input: Record<string, unknown>;
-  workingDir: string;
-  conversationId: string;
-  requestId?: string;
-  executionTarget?: ExecutionTarget;
-  riskLevel: string;
-  /** ID of the trust rule that matched this invocation (if any). */
-  matchedTrustRuleId?: string;
-  decision: string;
-  durationMs: number;
-  errorMessage: string;
-  isExpected: boolean;
-  /** Classifies the error for downstream consumers (audit, alerting, monitoring). */
-  errorCategory: ErrorCategory;
-  errorName?: string;
-  errorStack?: string;
+export interface ToolExecutionErrorEvent extends ContractsToolExecutionErrorEvent {
   /**
    * Model attribution snapshot for the conversation at invocation time.
    * Copied from {@link ToolContext.attribution} by the executor; `null` when
    * resolution failed or no attribution was available.
    */
   attribution?: UsageAttributionSnapshot | null;
+  /**
+   * Serialized byte size of the RAW tool input, stamped by the executor
+   * before sensitive-field sanitization rewrites `input`. Only the size
+   * leaves the device, never the payload.
+   */
+  inputBytes?: number | null;
 }
 
 export type ToolLifecycleEvent =
@@ -234,6 +228,20 @@ export type ToolLifecycleEvent =
 export type ToolLifecycleEventHandler = (
   event: ToolLifecycleEvent,
 ) => void | Promise<void>;
+
+/**
+ * Canonical serialization used for tool-input byte sizing. Shared by the
+ * executor (raw pre-sanitization sizing) and the audit listener (stored
+ * `input` column + fallback sizing) so the two always measure the same
+ * serialization.
+ */
+export function stringifyToolInput(input: Record<string, unknown>): string {
+  try {
+    return JSON.stringify(input);
+  } catch {
+    return "[unserializable-input]";
+  }
+}
 
 export interface ToolContext {
   /** Identifier of the conversation this tool invocation belongs to. */


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for tool-skill-telemetry.md.

**Gap:** arg_bytes measured post-sanitization (plan says raw); ToolExecutionErrorEvent fully redeclared; duplicated test seed helper; stale tool_execution docstring; status contract undocumented; comment bloat
**What was expected:** raw input sizing per plan; extends-based type overlay; one shared seed helper; accurate docs at sibling-store comment density
**What was found:** sanitize-then-size ordering, 14 duplicated interface fields, verbatim helper copies, docs referencing a reverted event type