### PR TITLE
fix: skill_loaded_events privacy wipes + telemetry opt-out gaps

### DIFF
--- a/assistant/src/__tests__/conversation-store.test.ts
+++ b/assistant/src/__tests__/conversation-store.test.ts
@@ -17,6 +17,7 @@ import {
   addMessage,
   clearAll,
   createConversation,
+  deleteConversation,
   deleteLastExchange,
   getConversation,
   getMessages,
@@ -24,6 +25,7 @@ import {
 import { isLastUserMessageToolResult } from "../memory/conversation-queries.js";
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
+import { skillLoadedEvents } from "../memory/schema.js";
 // Initialize db once before all tests
 initializeDb();
 
@@ -349,6 +351,78 @@ describe("attachment orphan cleanup", () => {
       .get() as { c: number };
     expect(attachmentCount.c).toBe(0);
     expect(linkCount.c).toBe(0);
+  });
+
+  test("clearAll removes skill_loaded_events", async () => {
+    // Privacy posture: Clear All wins over unflushed telemetry — the
+    // skill_loaded_events rows (conversation id, skill name, model
+    // attribution) must not survive the wipe and ship later.
+    getDb().delete(skillLoadedEvents).run();
+    const conv = createConversation("test");
+    getDb()
+      .insert(skillLoadedEvents)
+      .values([
+        {
+          id: "sle-clear-1",
+          createdAt: 1000,
+          conversationId: conv.id,
+          skillName: "web-research",
+        },
+        // Rows without a conversation are wiped too.
+        { id: "sle-clear-2", createdAt: 2000, skillName: "tasks" },
+      ])
+      .run();
+
+    await clearAll();
+
+    expect(getDb().select().from(skillLoadedEvents).all()).toHaveLength(0);
+  });
+
+  test("deleteConversation removes that conversation's skill_loaded_events", async () => {
+    getDb().delete(skillLoadedEvents).run();
+    const conv = createConversation("doomed");
+    await addMessage(conv.id, "user", "hello");
+    const other = createConversation("kept");
+    getDb()
+      .insert(skillLoadedEvents)
+      .values([
+        {
+          id: "sle-del-1",
+          createdAt: 1000,
+          conversationId: conv.id,
+          skillName: "web-research",
+        },
+        {
+          id: "sle-del-2",
+          createdAt: 2000,
+          conversationId: other.id,
+          skillName: "tasks",
+        },
+      ])
+      .run();
+
+    deleteConversation(conv.id);
+
+    const remaining = getDb().select().from(skillLoadedEvents).all();
+    expect(remaining.map((r) => r.id)).toEqual(["sle-del-2"]);
+  });
+
+  test("deleteConversation removes skill_loaded_events when the conversation has no messages", () => {
+    getDb().delete(skillLoadedEvents).run();
+    const conv = createConversation("empty");
+    getDb()
+      .insert(skillLoadedEvents)
+      .values({
+        id: "sle-del-empty",
+        createdAt: 1000,
+        conversationId: conv.id,
+        skillName: "web-research",
+      })
+      .run();
+
+    deleteConversation(conv.id);
+
+    expect(getDb().select().from(skillLoadedEvents).all()).toHaveLength(0);
   });
 
   test("deleteLastExchange does not delete unlinked user uploads", async () => {

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -72,6 +72,7 @@ import {
   memorySummaries,
   messageAttachments,
   messages,
+  skillLoadedEvents,
   toolInvocations,
 } from "./schema.js";
 import { cancelPendingJobsForConversation } from "./task-memory-cleanup.js";
@@ -1185,6 +1186,9 @@ export function deleteConversation(id: string): DeletedMemoryIds {
       tx.delete(toolInvocations)
         .where(eq(toolInvocations.conversationId, id))
         .run();
+      tx.delete(skillLoadedEvents)
+        .where(eq(skillLoadedEvents.conversationId, id))
+        .run();
       // Cascade deletes memory_segments, message_attachments.
       tx.delete(messages).where(eq(messages.conversationId, id)).run();
 
@@ -1206,6 +1210,9 @@ export function deleteConversation(id: string): DeletedMemoryIds {
         .run();
       tx.delete(toolInvocations)
         .where(eq(toolInvocations.conversationId, id))
+        .run();
+      tx.delete(skillLoadedEvents)
+        .where(eq(skillLoadedEvents.conversationId, id))
         .run();
     }
 
@@ -1264,7 +1271,7 @@ export function wipeConversation(id: string): WipeConversationResult {
 
   // Step D — Delegate to deleteConversation which handles messages (cascade
   // segments, attachments), llmRequestLogs, toolInvocations,
-  // embeddings, and the conversation row.
+  // skillLoadedEvents, embeddings, and the conversation row.
   const deletedMemoryIds = deleteConversation(id);
 
   // Step E — Return the combined result.
@@ -2105,6 +2112,7 @@ export async function clearAll(): Promise<{
   await runOrThrow("DELETE FROM message_attachments");
   await runOrThrow("DELETE FROM attachments");
   await runOrThrow("DELETE FROM tool_invocations");
+  await runOrThrow("DELETE FROM skill_loaded_events");
   let messagesFtsCorrupted = false;
   const ftsResult = await runAsyncSqlite("DELETE FROM messages_fts");
   if (!ftsResult.ok) {

--- a/assistant/src/memory/migrations/279-create-skill-loaded-events.ts
+++ b/assistant/src/memory/migrations/279-create-skill-loaded-events.ts
@@ -1,11 +1,10 @@
 import type { DrizzleDb } from "../db-connection.js";
 
 /**
- * Create the skill_loaded_events table for `skill_loaded` telemetry events.
- * One row per activation of a Vellum-produced skill — metadata only, never
- * skill output or conversation content. Rows are flushed to the platform
- * telemetry endpoint by the usage telemetry reporter, which seeks with a
- * compound `(created_at, id)` watermark cursor backed by the index below.
+ * Create the skill_loaded_events table for `skill_loaded` telemetry events —
+ * one row per activation of a Vellum-produced skill (see
+ * skill-loaded-events-store.ts for the data contract). The index backs the
+ * telemetry reporter's compound `(created_at, id)` watermark cursor.
  */
 export function createSkillLoadedEventsTable(database: DrizzleDb): void {
   database.run(/*sql*/ `

--- a/assistant/src/memory/schema/infrastructure.ts
+++ b/assistant/src/memory/schema/infrastructure.ts
@@ -308,9 +308,8 @@ export const activationSessions = sqliteTable("activation_sessions", {
 });
 
 // One row per `skill_loaded` telemetry event, emitted when a Vellum-produced
-// skill is activated in a conversation. Metadata only — never skill output or
-// conversation content. Flushed to the platform telemetry endpoint by the
-// usage telemetry reporter via a compound (created_at, id) watermark cursor.
+// skill is activated in a conversation — see skill-loaded-events-store.ts for
+// the data contract. Flushed by the usage telemetry reporter.
 export const skillLoadedEvents = sqliteTable(
   "skill_loaded_events",
   {

--- a/assistant/src/memory/skill-loaded-events-store.test.ts
+++ b/assistant/src/memory/skill-loaded-events-store.test.ts
@@ -8,6 +8,20 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
+let collectUsageData = true;
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    model: "test",
+    provider: "test",
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0 },
+    secretDetection: { enabled: false },
+    collectUsageData,
+  }),
+}));
+
 import { getDb } from "./db-connection.js";
 import { initializeDb } from "./db-init.js";
 import { skillLoadedEvents } from "./schema.js";
@@ -28,7 +42,14 @@ function insertEvent(
 
 describe("skill-loaded-events-store", () => {
   beforeEach(() => {
+    collectUsageData = true;
     getDb().delete(skillLoadedEvents).run();
+  });
+
+  test("honors the collectUsageData opt-out (records nothing)", () => {
+    collectUsageData = false;
+    recordSkillLoadedEvent({ skillName: "web-research" });
+    expect(queryUnreportedSkillLoadedEvents(0, undefined, 10)).toHaveLength(0);
   });
 
   test("record + query round-trips all fields", () => {

--- a/assistant/src/memory/skill-loaded-events-store.ts
+++ b/assistant/src/memory/skill-loaded-events-store.ts
@@ -1,6 +1,7 @@
 import { and, asc, eq, gt, or } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
+import { getConfig } from "../config/loader.js";
 import { getDb } from "./db-connection.js";
 import { skillLoadedEvents } from "./schema.js";
 
@@ -32,8 +33,13 @@ export interface SkillLoadedEvent {
   inferenceProfileSource: string | null;
 }
 
-/** Record a `skill_loaded` telemetry event for a skill activation. */
+/**
+ * Record a `skill_loaded` telemetry event for a skill activation. No-ops when
+ * usage data collection is disabled (the event is dropped to honor the
+ * opt-out, matching the rest of telemetry).
+ */
 export function recordSkillLoadedEvent(record: SkillLoadedEventRecord): void {
+  if (!getConfig().collectUsageData) return;
   const db = getDb();
   db.insert(skillLoadedEvents)
     .values({

--- a/assistant/src/memory/tool-executed-events-store.ts
+++ b/assistant/src/memory/tool-executed-events-store.ts
@@ -52,9 +52,10 @@ export interface UnreportedToolExecutedEvent {
  * "executed" and "error" events) always computes a non-null `arg_bytes`;
  * the only path that leaves it null ("permission_denied") is already
  * excluded by the decision filter. This makes `arg_bytes IS NOT NULL` a
- * reliable legacy-row discriminator, which in turn lets the telemetry
- * reporter use the standard 0 watermark default without dropping rows
- * recorded before its first flush.
+ * reliable legacy-row discriminator. It only guards pre-migration rows —
+ * rows recorded while telemetry is opted out are guarded separately by the
+ * reporter's construction-time watermark initialization (see
+ * usage-telemetry-reporter.ts).
  *
  * Rows are written by the tool audit listener
  * (`events/tool-audit-listener.ts`) — there is no record function here.

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -302,6 +302,25 @@ function seedToolInvocation(spec: {
     .run();
 }
 
+/**
+ * Replace the default null-returning checkpoint mocks with a Map-backed
+ * implementation so values persisted by the reporter (e.g. the
+ * construction-time tool_executed watermark init) are visible to later
+ * reads within the same test.
+ */
+function useStatefulCheckpoints(
+  seed: Record<string, string> = {},
+): Map<string, string> {
+  const checkpoints = new Map(Object.entries(seed));
+  mockGetMemoryCheckpoint.mockImplementation(
+    (key) => checkpoints.get(key) ?? null,
+  );
+  mockSetMemoryCheckpoint.mockImplementation((key, value) => {
+    checkpoints.set(key, value);
+  });
+  return checkpoints;
+}
+
 const originalFetch = globalThis.fetch;
 let mockFetch: ReturnType<typeof mock>;
 
@@ -1027,6 +1046,9 @@ describe("UsageTelemetryReporter", () => {
     );
 
     const reporter = new UsageTelemetryReporter();
+    // Construction initializes the absent tool_executed watermark; clear that
+    // call so the count below covers only the flush's advancement.
+    mockSetMemoryCheckpoint.mockClear();
     await reporter.flush();
 
     // No HTTP call should have been made
@@ -1571,16 +1593,21 @@ describe("UsageTelemetryReporter", () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  test("rows recorded before the first flush are shipped (no now-initialized watermark)", async () => {
+  test("rows recorded after construction but before the first flush are shipped", async () => {
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
     // Regression coverage for the review finding: the reporter delays its
-    // first flush, so a tool used right after install/upgrade is recorded
-    // BEFORE any tool_executed checkpoint exists. A watermark initialized
-    // to Date.now() would silently drop it; the legacy-row discriminator
-    // (null arg_bytes) plus the standard 0 default must ship it.
-    seedToolInvocation({ id: "ti-pre-first-flush", createdAt: 1700000001000 });
+    // first flush by 30s+, so a tool used right after daemon startup is
+    // recorded before any flush has run. The construction-time watermark
+    // init must not drop it — only rows from before construction (the
+    // opt-out window) stay behind the watermark.
+    const checkpoints = useStatefulCheckpoints();
 
     const reporter = new UsageTelemetryReporter();
+    const rowCreatedAt =
+      Number(checkpoints.get("telemetry:tool_executed:last_reported_at")) +
+      1000;
+    seedToolInvocation({ id: "ti-pre-first-flush", createdAt: rowCreatedAt });
+
     await reporter.flush();
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
@@ -1591,16 +1618,82 @@ describe("UsageTelemetryReporter", () => {
     expect(body.events[0]).toMatchObject({
       type: "tool_executed",
       daemon_event_id: "ti-pre-first-flush",
-      recorded_at: 1700000001000,
+      recorded_at: rowCreatedAt,
     });
 
     // The watermark advances to the shipped row, so the next flush resumes
     // after it instead of re-shipping.
-    const watermarkCalls = mockSetMemoryCheckpoint.mock.calls.filter(
-      (c) => c[0] === "telemetry:tool_executed:last_reported_at",
+    expect(checkpoints.get("telemetry:tool_executed:last_reported_at")).toBe(
+      String(rowCreatedAt),
     );
-    expect(watermarkCalls.length).toBe(1);
-    expect(watermarkCalls[0][1]).toBe(String(1700000001000));
+  });
+
+  test("absent tool_executed checkpoint is initialized at construction — opt-out-window rows never ship", async () => {
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    const checkpoints = useStatefulCheckpoints();
+
+    // Rows accumulated while telemetry was opted out: the reporter is never
+    // constructed then, but the always-on audit listener keeps writing.
+    seedToolInvocation({
+      id: "ti-opt-out-window",
+      createdAt: Date.now() - 60_000,
+    });
+
+    const reporter = new UsageTelemetryReporter();
+
+    // The checkpoint is persisted immediately at construction so a crash
+    // before the first flush can't re-initialize later.
+    const initialized = checkpoints.get(
+      "telemetry:tool_executed:last_reported_at",
+    );
+    expect(initialized).toBeDefined();
+
+    // A tool that runs after construction ships normally.
+    seedToolInvocation({
+      id: "ti-post-construction",
+      createdAt: Number(initialized) + 1000,
+    });
+
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect(
+      body.events.map((e: { daemon_event_id: string }) => e.daemon_event_id),
+    ).toEqual(["ti-post-construction"]);
+  });
+
+  test("existing tool_executed checkpoint is respected — construction does not re-initialize", async () => {
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    const checkpoints = useStatefulCheckpoints({
+      "telemetry:tool_executed:last_reported_at": String(1700000001000),
+      "telemetry:tool_executed:last_reported_id": "ti-already-reported",
+    });
+
+    seedToolInvocation({
+      id: "ti-already-reported",
+      createdAt: 1700000001000,
+    });
+    // Legitimate backlog past the stored watermark — a re-initialization to
+    // Date.now() at construction would silently drop it.
+    seedToolInvocation({ id: "ti-backlog", createdAt: 1700000002000 });
+
+    const reporter = new UsageTelemetryReporter();
+    expect(checkpoints.get("telemetry:tool_executed:last_reported_at")).toBe(
+      String(1700000001000),
+    );
+
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect(
+      body.events.map((e: { daemon_event_id: string }) => e.daemon_event_id),
+    ).toEqual(["ti-backlog"]);
   });
 
   // -------------------------------------------------------------------------

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -98,6 +98,26 @@ export class UsageTelemetryReporter {
   private timer: ReturnType<typeof setInterval> | null = null;
   private activeFlush: Promise<void> | null = null;
 
+  constructor() {
+    // `tool_invocations` is an always-on audit table: while telemetry is
+    // opted out the reporter is never constructed, but the audit listener
+    // keeps writing rows. Initialize an absent watermark to "now" at
+    // construction so a later opt-in doesn't retroactively ship the opt-out
+    // window. Construction happens during daemon startup before any tool
+    // runs, so no legitimate row falls behind the watermark — initializing
+    // at first FLUSH instead would drop tools used during the 30s+ flush
+    // delay. The checkpoint is persisted immediately so a crash before the
+    // first flush can't leave it absent and re-initialize later.
+    // `skill_loaded` needs no init: recording is gated on collectUsageData,
+    // so opt-out rows never exist and its standard 0 default is safe.
+    if (getMemoryCheckpoint(CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK) == null) {
+      setMemoryCheckpoint(
+        CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK,
+        String(Date.now()),
+      );
+    }
+  }
+
   start(): void {
     // Delay the first flush to allow the credential infrastructure (CES
     // handshake) to complete. Without this delay, VellumPlatformClient.create()
@@ -203,14 +223,14 @@ export class UsageTelemetryReporter {
         undefined;
 
       // Read tool-executed watermark (compound cursor: createdAt + id).
-      // The standard 0 default is safe even though `tool_invocations` is a
-      // pre-existing audit table: legacy rows — already shipped under the
-      // since-reverted `tool_execution` event type and lacking the
-      // arg_bytes/result_bytes/attribution columns — are excluded at the
-      // query level via the null `arg_bytes` discriminator (see
-      // queryUnreportedToolExecutedEvents), so they are never backfilled.
-      // Rows recorded after migration 278 but before the first flush ARE
-      // picked up, which a now-initialized watermark would have dropped.
+      // An absent checkpoint was initialized to construction time (see the
+      // constructor), guarding opt-out windows; the 0 fallback here is a
+      // defensive default matching the other event types. Legacy rows —
+      // already shipped under the since-reverted `tool_execution` event type
+      // and lacking the arg_bytes/result_bytes/attribution columns — are
+      // excluded at the query level via the null `arg_bytes` discriminator
+      // (see queryUnreportedToolExecutedEvents), so they are never
+      // backfilled.
       const toolExecutedWatermark = Number(
         getMemoryCheckpoint(CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK) ?? "0",
       );


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for tool-skill-telemetry.md.

**Gap:** skill_loaded_events survives clearAll/deleteConversation; recordSkillLoadedEvent ignores collectUsageData; tool_executed ships opt-out-window rows retroactively after opt-in
**What was expected:** privacy wipes cover all conversation-linked telemetry; sibling-store opt-out gating; opt-out window never ships
**What was found:** new table missed by both wipe paths; no record-time gate; absent checkpoint defaults to 0 and backfills the opt-out window

🤖 Generated with [Claude Code](https://claude.com/claude-code)