### PR TITLE
fix: telemetry opt-out watermark leak + degraded-mode-safe reporter init

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -635,21 +635,35 @@ export async function runDaemon(): Promise<void> {
     }
 
     // Privacy gating: Sentry crash/error reporting is gated by sendDiagnostics,
-    // while the usage telemetry reporter is gated by collectUsageData. Both are
-    // disabled in dev mode. Early-startup crashes before this point are still captured.
+    // while the usage telemetry reporter re-checks collectUsageData on every
+    // flush. Both are disabled in dev mode. Early-startup crashes before this
+    // point are still captured.
     const isDevMode = process.env.VELLUM_DEV === "1";
     const sendDiagnostics = !isDevMode && config.sendDiagnostics;
-    const collectUsageData = !isDevMode && config.collectUsageData;
     if (!sendDiagnostics) {
       await closeSentry();
     }
 
+    // Construct and start the reporter even when usage collection is disabled:
+    // flush() re-checks collectUsageData each cycle and, when opted out, sends
+    // nothing but advances all watermarks (including the final flush in
+    // stop()). That keeps the watermarks ahead of the always-on
+    // tool_invocations audit rows across opted-out sessions, so a later opt-in
+    // — runtime or via restart — never retroactively ships events recorded
+    // during the opt-out window. Deliberately NOT gated on dbReady: getDb()
+    // can still work when initializeDb() failed mid-migration, in which case
+    // the audit listener keeps writing rows that the opt-out branch must keep
+    // covered. The reporter is degraded-mode safe — its constructor and
+    // flush() treat DB errors as non-fatal.
     let telemetryReporter: UsageTelemetryReporter | null = null;
-    if (collectUsageData) {
+    if (!isDevMode) {
       telemetryReporter = new UsageTelemetryReporter();
       setUsageTelemetryReporter(telemetryReporter);
       telemetryReporter.start();
-      log.info("Usage telemetry reporter started");
+      log.info(
+        { collectUsageData: config.collectUsageData },
+        "Usage telemetry reporter started",
+      );
     }
 
     // CES lifecycle — kick off early so CES handshake runs concurrently with

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -1579,12 +1579,14 @@ describe("UsageTelemetryReporter", () => {
     );
   });
 
-  test("absent tool_executed checkpoint is initialized at construction — opt-out-window rows never ship", async () => {
+  test("absent tool_executed checkpoint is initialized at construction — rows predating the reporter never ship", async () => {
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
     const checkpoints = useStatefulCheckpoints();
 
-    // Rows accumulated while telemetry was opted out: the reporter is never
-    // constructed then, but the always-on audit listener keeps writing.
+    // Rows accumulated before any flush ever advanced the watermark — e.g.
+    // an opt-out period under an older build that gated reporter
+    // construction on collectUsageData while the always-on audit listener
+    // kept writing.
     seedToolInvocation({
       id: "ti-opt-out-window",
       createdAt: Date.now() - 60_000,
@@ -1628,7 +1630,11 @@ describe("UsageTelemetryReporter", () => {
       createdAt: 1700000001000,
     });
     // Legitimate backlog past the stored watermark — a re-initialization to
-    // Date.now() at construction would silently drop it.
+    // Date.now() at construction would silently drop it. Rows past the
+    // watermark are always legitimately shippable: opted-out sessions keep
+    // the watermark advancing via the opt-out flush branch (the reporter
+    // runs even when collection is disabled), so the backlog can only hold
+    // opted-in rows.
     seedToolInvocation({ id: "ti-backlog", createdAt: 1700000002000 });
 
     const reporter = new UsageTelemetryReporter();
@@ -1645,6 +1651,65 @@ describe("UsageTelemetryReporter", () => {
     expect(
       body.events.map((e: { daemon_event_id: string }) => e.daemon_event_id),
     ).toEqual(["ti-backlog"]);
+  });
+
+  test("opt-out window never ships across restarts — opted-out flushes keep the watermark ahead of audit rows", async () => {
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    // A previous opted-in session shipped through this watermark.
+    const checkpoints = useStatefulCheckpoints({
+      "telemetry:tool_executed:last_reported_at": String(1700000001000),
+      "telemetry:tool_executed:last_reported_id": "ti-shipped-opted-in",
+    });
+
+    // Session 1: the user opted out and restarted. The daemon still
+    // constructs and runs the reporter; the always-on audit listener keeps
+    // writing rows. Every opted-out flush (5-minute cycle plus the final
+    // flush in stop()) advances the watermark past them without sending.
+    mockCollectUsageData = false;
+    const optOutRowCreatedAt = Date.now() - 5_000;
+    seedToolInvocation({
+      id: "ti-opt-out-window",
+      createdAt: optOutRowCreatedAt,
+    });
+    const optedOutReporter = new UsageTelemetryReporter();
+    await optedOutReporter.stop(); // shutdown path: runs the final flush
+    expect(mockFetch).not.toHaveBeenCalled();
+    const advanced = Number(
+      checkpoints.get("telemetry:tool_executed:last_reported_at"),
+    );
+    expect(advanced).toBeGreaterThan(optOutRowCreatedAt);
+
+    // Session 2: the user opts back in and restarts. Only rows recorded
+    // after the opt-out epoch ship — the opt-out-window row never does.
+    mockCollectUsageData = true;
+    seedToolInvocation({ id: "ti-after-opt-in", createdAt: advanced + 1000 });
+    const reporter = new UsageTelemetryReporter();
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect(
+      body.events.map((e: { daemon_event_id: string }) => e.daemon_event_id),
+    ).toEqual(["ti-after-opt-in"]);
+  });
+
+  test("checkpoint store failure during construction is non-fatal — degraded-DB daemons still start", () => {
+    // initializeDb() failures are tolerated at daemon startup (degraded
+    // mode), so the constructor's checkpoint init must never throw out of
+    // the constructor and abort the daemon.
+    mockGetMemoryCheckpoint.mockImplementation(() => {
+      throw new Error("database disk image is malformed");
+    });
+    expect(() => new UsageTelemetryReporter()).not.toThrow();
+
+    // The write path failing is equally non-fatal.
+    mockGetMemoryCheckpoint.mockImplementation(() => null);
+    mockSetMemoryCheckpoint.mockImplementation(() => {
+      throw new Error("database disk image is malformed");
+    });
+    expect(() => new UsageTelemetryReporter()).not.toThrow();
   });
 
   // -------------------------------------------------------------------------

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -99,21 +99,36 @@ export class UsageTelemetryReporter {
   private activeFlush: Promise<void> | null = null;
 
   constructor() {
-    // `tool_invocations` is an always-on audit table: while telemetry is
-    // opted out the reporter is never constructed, but the audit listener
-    // keeps writing rows. Initialize an absent watermark to "now" at
-    // construction so a later opt-in doesn't retroactively ship the opt-out
-    // window. Construction happens during daemon startup before any tool
-    // runs, so no legitimate row falls behind the watermark — initializing
-    // at first FLUSH instead would drop tools used during the 30s+ flush
-    // delay. The checkpoint is persisted immediately so a crash before the
-    // first flush can't leave it absent and re-initialize later.
+    // `tool_invocations` is an always-on audit table that predates this
+    // reporter shipping its rows: an absent watermark means no flush (opted
+    // in or out) has ever advanced it, so rows recorded before this build —
+    // including any opted-out period under older builds that gated the
+    // reporter on collectUsageData — would otherwise ship retroactively.
+    // Initialize an absent watermark to "now" at construction. Construction
+    // happens during daemon startup before any tool runs, so no legitimate
+    // row falls behind the watermark — initializing at first FLUSH instead
+    // would drop tools used during the 30s+ flush delay. The checkpoint is
+    // persisted immediately so a crash before the first flush can't leave it
+    // absent and re-initialize later. An EXISTING watermark is never touched:
+    // opted-out sessions keep it advancing via the opt-out flush branch, and
+    // overwriting it here would drop a legitimate unshipped backlog.
     // `skill_loaded` needs no init: recording is gated on collectUsageData,
     // so opt-out rows never exist and its standard 0 default is safe.
-    if (getMemoryCheckpoint(CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK) == null) {
-      setMemoryCheckpoint(
-        CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK,
-        String(Date.now()),
+    //
+    // Best-effort: DB init failures are tolerated at daemon startup (degraded
+    // mode), so this must never throw out of the constructor — matching
+    // flush(), which treats DB errors as non-fatal.
+    try {
+      if (getMemoryCheckpoint(CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK) == null) {
+        setMemoryCheckpoint(
+          CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK,
+          String(Date.now()),
+        );
+      }
+    } catch (err) {
+      log.warn(
+        { err },
+        "tool_executed watermark init failed at construction — non-fatal; a later construction with a working DB re-runs the absent-checkpoint init",
       );
     }
   }
@@ -165,9 +180,13 @@ export class UsageTelemetryReporter {
     try {
       if (batchCount >= MAX_CONSECUTIVE_BATCHES) return;
 
-      // Respect runtime opt-out: if the user has disabled usage data collection,
-      // skip the flush and advance watermarks so events recorded during the
-      // opt-out window are never sent retroactively.
+      // Respect opt-out: if the user has disabled usage data collection, skip
+      // the flush and advance watermarks so events recorded during the
+      // opt-out window are never sent retroactively. The daemon runs the
+      // reporter even when opted out specifically so this branch keeps
+      // executing — every cycle plus the final flush in stop() — which is
+      // what lets a later opt-in (runtime or via restart) resume from a
+      // watermark that already covers the opt-out window.
       if (!getConfig().collectUsageData) {
         // Advance only the timestamp watermarks. Leave the ID watermarks
         // untouched so the compound-cursor branch stays active — setting them


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for tool-skill-telemetry.md.

**Gap:** stale tool_executed checkpoint ships the opted-out window after opt-in restart; reporter constructor's unguarded DB write aborts daemon startup when the DB is degraded
**What was expected:** opt-out windows never ship regardless of checkpoint history; degraded-DB daemons still start
**What was found:** construction-time init only covers the absent-checkpoint case and throws on DB failure