### PR TITLE
fix: shared ExecutorTelemetryStamp interface + test dedup

### DIFF
--- a/assistant/src/__tests__/conversation-tool-setup-attribution.test.ts
+++ b/assistant/src/__tests__/conversation-tool-setup-attribution.test.ts
@@ -181,24 +181,10 @@ beforeEach(() => {
 // Tests
 // ---------------------------------------------------------------------------
 
+// Precedence semantics (override/active/call-site/default) are owned by
+// resolveUsageAttribution and covered in usage-attribution.test.ts; the
+// tests here only exercise what the wrapper adds on top.
 describe("resolveConversationAttribution", () => {
-  test("attributes the conversation's override profile like the main-loop usage path", () => {
-    const snapshot = resolveConversationAttribution({
-      conversationId: "conv-test",
-      currentTurnOverrideProfile: "pinned",
-    });
-
-    expect(snapshot).toMatchObject({
-      callSite: "mainAgent",
-      activeProfile: "active",
-      overrideProfile: "pinned",
-      appliedProfile: "pinned",
-      profileSource: "conversation",
-      resolvedProvider: "gemini",
-      resolvedModel: "model-pinned",
-    });
-  });
-
   test("falls back to the workspace active profile when no override is set", () => {
     const snapshot = resolveConversationAttribution({
       conversationId: "conv-test",
@@ -241,51 +227,6 @@ describe("resolveConversationAttribution", () => {
       profileSource: "call_site",
       resolvedProvider: "gemini",
       resolvedModel: "model-pinned",
-    });
-  });
-
-  test("non-main call sites prefer the call-site profile over the conversation override", () => {
-    setLlmConfig({
-      default: { provider: "anthropic", model: "model-default" },
-      profiles: {
-        active: { provider: "openai", model: "model-active" },
-        pinned: { provider: "gemini", model: "model-pinned" },
-      },
-      activeProfile: "active",
-      callSites: { callAgent: { profile: "pinned" } },
-    });
-
-    const snapshot = resolveConversationAttribution({
-      conversationId: "conv-test",
-      currentCallSite: "callAgent",
-      currentTurnOverrideProfile: "active",
-    });
-
-    expect(snapshot).toMatchObject({
-      callSite: "callAgent",
-      overrideProfile: "active",
-      callSiteProfile: "pinned",
-      appliedProfile: "pinned",
-      profileSource: "call_site",
-      resolvedProvider: "gemini",
-      resolvedModel: "model-pinned",
-    });
-  });
-
-  test("resolves profileSource default when no profiles apply", () => {
-    setLlmConfig({
-      default: { provider: "anthropic", model: "model-default" },
-    });
-
-    const snapshot = resolveConversationAttribution({
-      conversationId: "conv-test",
-    });
-
-    expect(snapshot).toMatchObject({
-      appliedProfile: null,
-      profileSource: "default",
-      resolvedProvider: "anthropic",
-      resolvedModel: "model-default",
     });
   });
 

--- a/assistant/src/__tests__/tool-audit-listener.test.ts
+++ b/assistant/src/__tests__/tool-audit-listener.test.ts
@@ -232,28 +232,6 @@ describe("tool audit listener", () => {
     }
   });
 
-  test("falls back to sizing the event input when inputBytes is absent, keeping argBytes non-null", () => {
-    const records: ToolInvocationRecord[] = [];
-    const listener = createToolAuditListener((record) => records.push(record));
-
-    listener({
-      type: "executed",
-      toolName: "file_read",
-      input: { path: "/tmp/a" },
-      workingDir: "/tmp",
-      conversationId: "conv-fallback",
-      riskLevel: "low",
-      decision: "allow",
-      durationMs: 4,
-      result: { content: "ok", isError: false },
-    });
-
-    expect(records).toHaveLength(1);
-    expect(records[0].argBytes).toBe(
-      Buffer.byteLength(JSON.stringify({ path: "/tmp/a" }), "utf8"),
-    );
-  });
-
   test("maps attribution onto executed records and leaves denied records null", () => {
     const records: ToolInvocationRecord[] = [];
     const listener = createToolAuditListener((record) => records.push(record));

--- a/assistant/src/events/tool-audit-listener.ts
+++ b/assistant/src/events/tool-audit-listener.ts
@@ -52,13 +52,8 @@ function toInvocationRecord(
         riskLevel: event.riskLevel,
         matchedTrustRuleId: event.matchedTrustRuleId,
         durationMs: event.durationMs,
-        // Byte sizes reflect the full raw payloads — only the sizes leave
-        // the device. The arg size prefers `event.inputBytes`, stamped by
-        // the executor BEFORE input sanitization; the fallback sizes the
-        // (sanitized) event input so argBytes stays non-null, which the
-        // tool_executed projection's legacy-row filter relies on. The
-        // result size is computed before the stored `result` column is
-        // truncated and redacted above.
+        // The fallback keeps argBytes non-null, which the tool_executed
+        // projection's legacy-row filter relies on.
         argBytes: event.inputBytes ?? Buffer.byteLength(input, "utf8"),
         resultBytes: Buffer.byteLength(event.result.content, "utf8"),
         ...toAttributionColumns(event.attribution),

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -1526,24 +1526,6 @@ describe("UsageTelemetryReporter", () => {
     ).toEqual(["ti-r2"]);
   });
 
-  test("legacy pre-migration rows (null arg_bytes) are never shipped", async () => {
-    mockQueryUnreportedUsageEvents.mockReturnValue([]);
-    // No checkpoints (zero watermark, whole-table scan): a legacy null-
-    // arg_bytes row must still not be re-shipped as tool_executed.
-    seedToolInvocation({
-      id: "ti-historical",
-      createdAt: 1700000001000,
-      argBytes: null,
-      resultBytes: null,
-    });
-
-    const reporter = new UsageTelemetryReporter();
-    await reporter.flush();
-
-    // Nothing to report — the legacy row is excluded at the query level.
-    expect(mockFetch).not.toHaveBeenCalled();
-  });
-
   test("rows recorded after construction but before the first flush are shipped", async () => {
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
     // Regression coverage for the review finding: the reporter delays its

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -162,12 +162,31 @@ export type ProxyToolResolver = (
 ) => Promise<ToolExecutionResult>;
 
 /**
+ * Telemetry fields stamped centrally by the executor's `emitLifecycleEvent`
+ * on terminal (executed/error) lifecycle events.
+ */
+export interface ExecutorTelemetryStamp {
+  /**
+   * Model attribution snapshot for the conversation at invocation time.
+   * Copied from {@link ToolContext.attribution} by the executor; `null` when
+   * resolution failed or no attribution was available.
+   */
+  attribution?: UsageAttributionSnapshot | null;
+  /**
+   * Serialized byte size of the RAW tool input, stamped by the executor
+   * before sensitive-field sanitization rewrites `input`. Only the size
+   * leaves the device, never the payload.
+   */
+  inputBytes?: number | null;
+}
+
+/**
  * `ToolExecutedEvent` carries a `result: ToolExecutionResult` field, so
  * the assistant re-declares it here to reference the assistant-side
  * `ToolExecutionResult` (which narrows `contentBlocks` to `ContentBlock[]`
  * and `cesApprovalRequired` to `ApprovalRequired`).
  */
-export interface ToolExecutedEvent {
+export interface ToolExecutedEvent extends ExecutorTelemetryStamp {
   type: "executed";
   toolName: string;
   input: Record<string, unknown>;
@@ -185,38 +204,14 @@ export interface ToolExecutedEvent {
   decision: string;
   durationMs: number;
   result: ToolExecutionResult;
-  /**
-   * Model attribution snapshot for the conversation at invocation time.
-   * Copied from {@link ToolContext.attribution} by the executor; `null` when
-   * resolution failed or no attribution was available.
-   */
-  attribution?: UsageAttributionSnapshot | null;
-  /**
-   * Serialized byte size of the RAW tool input, stamped by the executor
-   * before sensitive-field sanitization rewrites `input`. Only the size
-   * leaves the device, never the payload.
-   */
-  inputBytes?: number | null;
 }
 
 /**
  * Extends the contracts declaration with the assistant-side telemetry
  * fields stamped centrally by the executor's `emitLifecycleEvent`.
  */
-export interface ToolExecutionErrorEvent extends ContractsToolExecutionErrorEvent {
-  /**
-   * Model attribution snapshot for the conversation at invocation time.
-   * Copied from {@link ToolContext.attribution} by the executor; `null` when
-   * resolution failed or no attribution was available.
-   */
-  attribution?: UsageAttributionSnapshot | null;
-  /**
-   * Serialized byte size of the RAW tool input, stamped by the executor
-   * before sensitive-field sanitization rewrites `input`. Only the size
-   * leaves the device, never the payload.
-   */
-  inputBytes?: number | null;
-}
+export interface ToolExecutionErrorEvent
+  extends ContractsToolExecutionErrorEvent, ExecutorTelemetryStamp {}
 
 export type ToolLifecycleEvent =
   | ToolExecutionStartEvent


### PR DESCRIPTION
## Summary
Fixes slop findings identified during plan review for tool-skill-telemetry.md.

**Gap:** attribution/inputBytes fields and docs duplicated across two event interfaces; production-dead fallback over-documented and over-tested; precedence tests duplicating usage-attribution coverage
**What was expected:** single source of truth for the stamp shape; coverage at the layer that owns each behavior
**What was found:** verbatim field blocks, a 7-line comment for an unreachable branch, ~100 lines of 1:1 duplicate precedence tests