### PR TITLE
feat(assistant): shared one-shot LLM helper (M1)

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -106,7 +106,10 @@ mock.module("@anthropic-ai/sdk", () => ({
 }));
 
 // Import after mocking
-import { AnthropicProvider } from "../providers/anthropic/client.js";
+import {
+  AnthropicProvider,
+  mapNeutralToolChoiceToAnthropic,
+} from "../providers/anthropic/client.js";
 import {
   isPlaceholderSentinelText,
   PLACEHOLDER_BLOCKS_OMITTED,
@@ -2926,5 +2929,84 @@ describe("AnthropicProvider — thinking block send-time filtering", () => {
     expect(signatures).not.toContain("sig-old");
     expect(signatures).toContain("sig-step1");
     expect(signatures).toContain("sig-step2");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tool_choice mapping onto the Anthropic wire request
+// ---------------------------------------------------------------------------
+
+describe("AnthropicProvider — tool_choice wire mapping", () => {
+  let provider: AnthropicProvider;
+
+  beforeEach(() => {
+    lastStreamParams = null;
+    scriptedStream = null;
+    provider = new AnthropicProvider("sk-ant-test", "claude-sonnet-4-6");
+  });
+
+  const oneTool: ToolDefinition[] = [
+    {
+      name: "store_style_analysis",
+      description: "Store the analysis",
+      input_schema: { type: "object", properties: {} },
+    },
+  ];
+
+  test("forces a specific tool: { type: 'tool', name } reaches the wire", async () => {
+    await provider.sendMessage([userMsg("Hi")], {
+      tools: oneTool,
+      config: { tool_choice: { type: "tool", name: "store_style_analysis" } },
+    });
+    expect(lastStreamParams!.tool_choice).toEqual({
+      type: "tool",
+      name: "store_style_analysis",
+    });
+  });
+
+  test("maps { type: 'auto' | 'any' | 'none' } onto the wire", async () => {
+    for (const type of ["auto", "any", "none"] as const) {
+      lastStreamParams = null;
+      await provider.sendMessage([userMsg("Hi")], {
+        tools: oneTool,
+        config: { tool_choice: { type } },
+      });
+      expect(lastStreamParams!.tool_choice).toEqual({ type });
+    }
+  });
+
+  test("omits tool_choice when config carries none", async () => {
+    await provider.sendMessage([userMsg("Hi")], { tools: oneTool });
+    expect(lastStreamParams!.tool_choice).toBeUndefined();
+  });
+
+  test("drops an unrecognized tool_choice shape (no leak onto the wire)", async () => {
+    await provider.sendMessage([userMsg("Hi")], {
+      tools: oneTool,
+      // A malformed `tool` choice (missing `name`) and a bogus type must not
+      // pass through verbatim — the explicit mapper rejects both.
+      config: { tool_choice: { type: "tool" } },
+    });
+    expect(lastStreamParams!.tool_choice).toBeUndefined();
+  });
+
+  test("mapNeutralToolChoiceToAnthropic translates the neutral union", () => {
+    expect(mapNeutralToolChoiceToAnthropic({ type: "auto" })).toEqual({
+      type: "auto",
+    });
+    expect(mapNeutralToolChoiceToAnthropic({ type: "any" })).toEqual({
+      type: "any",
+    });
+    expect(mapNeutralToolChoiceToAnthropic({ type: "none" })).toEqual({
+      type: "none",
+    });
+    expect(
+      mapNeutralToolChoiceToAnthropic({ type: "tool", name: "do_thing" }),
+    ).toEqual({ type: "tool", name: "do_thing" });
+    // Unrecognized / malformed shapes → undefined (request omits tool_choice).
+    expect(mapNeutralToolChoiceToAnthropic({ type: "tool" })).toBeUndefined();
+    expect(mapNeutralToolChoiceToAnthropic({ type: "bogus" })).toBeUndefined();
+    expect(mapNeutralToolChoiceToAnthropic(undefined)).toBeUndefined();
+    expect(mapNeutralToolChoiceToAnthropic("nope")).toBeUndefined();
   });
 });

--- a/assistant/src/__tests__/gemini-provider.test.ts
+++ b/assistant/src/__tests__/gemini-provider.test.ts
@@ -82,10 +82,20 @@ mock.module("@google/genai", () => ({
     MEDIUM: "MEDIUM",
     HIGH: "HIGH",
   },
+  FunctionCallingConfigMode: {
+    MODE_UNSPECIFIED: "MODE_UNSPECIFIED",
+    AUTO: "AUTO",
+    ANY: "ANY",
+    NONE: "NONE",
+    VALIDATED: "VALIDATED",
+  },
 }));
 
 // Import after mocking
-import { GeminiProvider } from "../providers/gemini/client.js";
+import {
+  GeminiProvider,
+  mapNeutralToolChoiceToGemini,
+} from "../providers/gemini/client.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -1557,5 +1567,103 @@ describe("GeminiProvider", () => {
       name: "file_read",
       input: { path: "/tmp/test" },
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tool_choice → functionCallingConfig mapping
+// ---------------------------------------------------------------------------
+
+describe("GeminiProvider — tool_choice → functionCallingConfig", () => {
+  let provider: GeminiProvider;
+
+  const oneTool: ToolDefinition[] = [
+    {
+      name: "store_style_analysis",
+      description: "Store the analysis",
+      input_schema: { type: "object", properties: {} },
+    },
+  ];
+
+  beforeEach(() => {
+    provider = new GeminiProvider("test-api-key", "gemini-3-flash-preview");
+    fakeChunks = [textChunk("OK"), finishChunk("STOP", 10, 2)];
+    lastStreamParams = null;
+  });
+
+  test("forced tool → ANY mode with allowedFunctionNames", async () => {
+    await provider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      {
+        tools: oneTool,
+        config: { tool_choice: { type: "tool", name: "store_style_analysis" } },
+      },
+    );
+    const config = lastStreamParams!.config as Record<string, unknown>;
+    expect(config.toolConfig).toEqual({
+      functionCallingConfig: {
+        mode: "ANY",
+        allowedFunctionNames: ["store_style_analysis"],
+      },
+    });
+  });
+
+  test("maps auto/any/none onto functionCallingConfig.mode", async () => {
+    const cases: Array<[{ type: string }, string]> = [
+      [{ type: "auto" }, "AUTO"],
+      [{ type: "any" }, "ANY"],
+      [{ type: "none" }, "NONE"],
+    ];
+    for (const [tc, mode] of cases) {
+      lastStreamParams = null;
+      fakeChunks = [textChunk("OK"), finishChunk("STOP", 10, 2)];
+      await provider.sendMessage(
+        [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+        { tools: oneTool, config: { tool_choice: tc } },
+      );
+      const config = lastStreamParams!.config as Record<string, unknown>;
+      expect(config.toolConfig).toEqual({
+        functionCallingConfig: { mode },
+      });
+    }
+  });
+
+  test("omits toolConfig when no tool_choice is set", async () => {
+    await provider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      { tools: oneTool },
+    );
+    const config = lastStreamParams!.config as Record<string, unknown>;
+    expect(config.toolConfig).toBeUndefined();
+  });
+
+  test("does not set toolConfig when no tools are declared", async () => {
+    await provider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      { config: { tool_choice: { type: "any" } } },
+    );
+    const config = lastStreamParams!.config as Record<string, unknown>;
+    expect(config.toolConfig).toBeUndefined();
+  });
+
+  test("mapNeutralToolChoiceToGemini translates the neutral union", () => {
+    // The mocked enum mirrors the SDK's string values, so compare against the
+    // mode strings the mapper emits at runtime (cast through `string` since the
+    // enum's literal type isn't structurally assignable to a bare string).
+    const mode = (tc: unknown): string | undefined =>
+      mapNeutralToolChoiceToGemini(tc)?.mode as string | undefined;
+    expect(mode({ type: "auto" })).toBe("AUTO");
+    expect(mode({ type: "any" })).toBe("ANY");
+    expect(mode({ type: "none" })).toBe("NONE");
+    const forced = mapNeutralToolChoiceToGemini({
+      type: "tool",
+      name: "do_thing",
+    });
+    expect(forced?.mode as string | undefined).toBe("ANY");
+    expect(forced?.allowedFunctionNames).toEqual(["do_thing"]);
+    // Unrecognized / malformed → undefined (request omits toolConfig).
+    expect(mapNeutralToolChoiceToGemini({ type: "tool" })).toBeUndefined();
+    expect(mapNeutralToolChoiceToGemini({ type: "bogus" })).toBeUndefined();
+    expect(mapNeutralToolChoiceToGemini(undefined)).toBeUndefined();
   });
 });

--- a/assistant/src/messaging/style-analyzer.ts
+++ b/assistant/src/messaging/style-analyzer.ts
@@ -6,7 +6,9 @@
  * for memory storage.
  */
 
-import { getConfiguredProvider } from "../providers/provider-send-message.js";
+import { z } from "zod";
+
+import { runOneShotLLM } from "../providers/one-shot-llm.js";
 import type { Message, ToolDefinition } from "../providers/types.js";
 import { truncate } from "../util/truncate.js";
 import type { Message as ProviderMessage } from "./provider-types.js";
@@ -97,6 +99,34 @@ const storeStyleAnalysisTool = {
 } satisfies ToolDefinition;
 
 /**
+ * Validates the `store_style_analysis` tool input. Mirrors the JSON Schema
+ * above and the hand-rolled type guards this replaced: `style_patterns` is
+ * required; `aspect`/`summary`/`importance` are required per pattern with
+ * `examples` optional; `contact_observations` is optional. `aspect` stays a
+ * free `string` (the wire tool schema constrains the enum, and the prior cast
+ * never validated it) so a stray aspect value doesn't drop the whole result.
+ */
+const StoreStyleAnalysisSchema = z.object({
+  style_patterns: z.array(
+    z.object({
+      aspect: z.string(),
+      summary: z.string(),
+      importance: z.number(),
+      examples: z.array(z.string()).optional(),
+    }),
+  ),
+  contact_observations: z
+    .array(
+      z.object({
+        name: z.string(),
+        email: z.string(),
+        tone_note: z.string(),
+      }),
+    )
+    .optional(),
+});
+
+/**
  * Build a text corpus from provider messages for LLM analysis.
  * Truncates individual messages to keep overall size manageable.
  */
@@ -127,10 +157,6 @@ export async function extractStylePatterns(
     .map((e, i) => `--- Message ${i + 1} ---\n${e}`)
     .join("\n\n");
 
-  const provider = await getConfiguredProvider("styleAnalyzer");
-  if (!provider) {
-    return { stylePatterns: [], contactObservations: [] };
-  }
   const promptMessages: Message[] = [
     {
       role: "user",
@@ -143,40 +169,25 @@ export async function extractStylePatterns(
     },
   ];
 
-  const response = await provider.sendMessage(promptMessages, {
+  // Any non-`ok` outcome (no provider, timeout, missing tool, schema mismatch)
+  // collapses to the empty result this call site has always returned.
+  const outcome = await runOneShotLLM("styleAnalyzer", promptMessages, {
     tools: [storeStyleAnalysisTool],
+    toolChoice: storeStyleAnalysisTool.name,
+    schema: StoreStyleAnalysisSchema,
     systemPrompt: STYLE_EXTRACTION_SYSTEM_PROMPT,
-    signal: AbortSignal.timeout(30_000),
-    config: { callSite: "styleAnalyzer" },
   });
-
-  const toolBlock = response.content.find((b) => b.type === "tool_use");
-  if (!toolBlock || toolBlock.type !== "tool_use") {
+  if (outcome.status !== "ok") {
     return { stylePatterns: [], contactObservations: [] };
   }
+  const result = outcome.data;
 
-  const result = toolBlock.input as {
-    style_patterns?: Array<{
-      aspect: string;
-      summary: string;
-      importance: number;
-      examples?: string[];
-    }>;
-    contact_observations?: Array<{
-      name: string;
-      email: string;
-      tone_note: string;
-    }>;
-  };
-
-  const stylePatterns: StylePattern[] = (result.style_patterns ?? []).map(
-    (p) => ({
-      aspect: p.aspect,
-      summary: truncate(p.summary, 500, ""),
-      importance: p.importance,
-      examples: p.examples,
-    }),
-  );
+  const stylePatterns: StylePattern[] = result.style_patterns.map((p) => ({
+    aspect: p.aspect,
+    summary: truncate(p.summary, 500, ""),
+    importance: p.importance,
+    examples: p.examples,
+  }));
 
   const contactObservations: ContactObservation[] = (
     result.contact_observations ?? []

--- a/assistant/src/providers/__tests__/one-shot-llm.test.ts
+++ b/assistant/src/providers/__tests__/one-shot-llm.test.ts
@@ -1,0 +1,313 @@
+/**
+ * Unit tests for `runOneShotLLM`.
+ *
+ * Strategy: we mock `provider-send-message.js` so each test can hand the helper
+ * a controllable stub provider via `getConfiguredProvider` — or `null` to
+ * exercise the unavailable policy. Mocking the whole module avoids evaluating
+ * the real one (which would pin a real logger before our logger mock applies);
+ * the small pure helpers (`createTimeout` / `extractAllText` / `extractToolUse`
+ * / `userMessage`) are reimplemented faithfully so timeout, text, and
+ * tool-extraction behavior is still exercised against equivalent logic.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { z } from "zod";
+
+// ── Module mocks (declared before the import-under-test) ────────────────────
+
+// Silence the helper's warn logging so failure-path tests don't spam output.
+// We assert behavior via the discriminated result (each warn branch maps 1:1
+// to a `status: "failure"` reason), which is the robust contract to test.
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+import type {
+  ContentBlock,
+  Message,
+  Provider,
+  ProviderResponse,
+  SendMessageOptions,
+} from "../types.js";
+
+// We mock the whole `provider-send-message.js` module so that importing it
+// here never evaluates the real module (which would pin a real logger before
+// the logger mock applies). `getConfiguredProvider` is the per-test seam; the
+// three small pure helpers are reimplemented faithfully so the helper's
+// extraction/timeout behavior is still exercised against equivalent logic.
+let nextProvider: Provider | null = null;
+mock.module("../provider-send-message.js", () => ({
+  getConfiguredProvider: async () => nextProvider,
+  createTimeout: (ms: number) => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), ms);
+    return { signal: controller.signal, cleanup: () => clearTimeout(timer) };
+  },
+  extractAllText: (response: ProviderResponse): string =>
+    response.content
+      .filter(
+        (b): b is Extract<ContentBlock, { type: "text" }> => b.type === "text",
+      )
+      .map((b) => b.text)
+      .join(" "),
+  extractToolUse: (response: ProviderResponse) =>
+    response.content.find((b) => b.type === "tool_use"),
+  userMessage: (text: string): Message => ({
+    role: "user",
+    content: [{ type: "text", text }],
+  }),
+}));
+
+// ── Import under test (after mocks) ─────────────────────────────────────────
+import { BackendUnavailableError } from "../../util/errors.js";
+import { runOneShotLLM } from "../one-shot-llm.js";
+import { userMessage } from "../provider-send-message.js";
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+const MESSAGES: Message[] = [userMessage("hello")];
+
+function textResponse(text: string): ProviderResponse {
+  return {
+    content: [{ type: "text", text }],
+    model: "test-model",
+    usage: { inputTokens: 1, outputTokens: 1 },
+    stopReason: "end_turn",
+  };
+}
+
+function toolResponse(
+  name: string,
+  input: Record<string, unknown>,
+): ProviderResponse {
+  return {
+    content: [{ type: "tool_use", id: "tu_1", name, input }],
+    model: "test-model",
+    usage: { inputTokens: 1, outputTokens: 1 },
+    stopReason: "tool_use",
+  };
+}
+
+/** A provider whose `sendMessage` returns (or throws) what the test wires up. */
+function makeProvider(
+  impl: (
+    messages: Message[],
+    options?: SendMessageOptions,
+  ) => Promise<ProviderResponse>,
+): Provider {
+  return { name: "stub", sendMessage: impl };
+}
+
+const TOOL = {
+  name: "store_thing",
+  description: "store a thing",
+  input_schema: { type: "object" as const, properties: {} },
+};
+
+beforeEach(() => {
+  nextProvider = null;
+});
+
+// ── onUnavailable policy ─────────────────────────────────────────────────────
+
+describe("runOneShotLLM — provider unavailable", () => {
+  test('returns { status: "unavailable" } under default "null" policy', async () => {
+    nextProvider = null;
+    const result = await runOneShotLLM("styleAnalyzer", MESSAGES);
+    expect(result.status).toBe("unavailable");
+  });
+
+  test('throws BackendUnavailableError under "throw" policy', async () => {
+    nextProvider = null;
+    await expect(
+      runOneShotLLM("styleAnalyzer", MESSAGES, { onUnavailable: "throw" }),
+    ).rejects.toBeInstanceOf(BackendUnavailableError);
+  });
+});
+
+// ── Text mode ────────────────────────────────────────────────────────────────
+
+describe("runOneShotLLM — text mode", () => {
+  test("returns extracted text plus raw response on success", async () => {
+    nextProvider = makeProvider(async () => textResponse("  hi there  "));
+    const result = await runOneShotLLM("styleAnalyzer", MESSAGES);
+    expect(result.status).toBe("ok");
+    if (result.status !== "ok") throw new Error("unreachable");
+    expect(result.data).toBe("hi there");
+    expect(result.response.model).toBe("test-model");
+    expect(result.response.usage.outputTokens).toBe(1);
+  });
+
+  test('returns failure "empty_text" + warns when no text block', async () => {
+    nextProvider = makeProvider(async () => textResponse("   "));
+    const result = await runOneShotLLM("styleAnalyzer", MESSAGES);
+    expect(result.status).toBe("failure");
+    if (result.status !== "failure") throw new Error("unreachable");
+    expect(result.reason).toBe("empty_text");
+  });
+});
+
+// ── Tool mode ────────────────────────────────────────────────────────────────
+
+describe("runOneShotLLM — tool mode", () => {
+  const schema = z.object({ count: z.number() });
+
+  test("validates tool input against schema (happy path)", async () => {
+    nextProvider = makeProvider(async () =>
+      toolResponse("store_thing", { count: 42 }),
+    );
+    const result = await runOneShotLLM("styleAnalyzer", MESSAGES, {
+      tools: [TOOL],
+      toolChoice: "store_thing",
+      schema,
+    });
+    expect(result.status).toBe("ok");
+    if (result.status !== "ok") throw new Error("unreachable");
+    expect(result.data).toEqual({ count: 42 });
+    expect(result.response.stopReason).toBe("tool_use");
+  });
+
+  test("returns raw input when no schema is supplied", async () => {
+    nextProvider = makeProvider(async () =>
+      toolResponse("store_thing", { anything: "goes" }),
+    );
+    const result = await runOneShotLLM("styleAnalyzer", MESSAGES, {
+      tools: [TOOL],
+      toolChoice: "store_thing",
+    });
+    expect(result.status).toBe("ok");
+    if (result.status !== "ok") throw new Error("unreachable");
+    expect(result.data).toEqual({ anything: "goes" });
+  });
+
+  test('returns failure "schema_mismatch" + warns when input fails zod', async () => {
+    nextProvider = makeProvider(async () =>
+      toolResponse("store_thing", { count: "not a number" }),
+    );
+    const result = await runOneShotLLM("styleAnalyzer", MESSAGES, {
+      tools: [TOOL],
+      toolChoice: "store_thing",
+      schema,
+    });
+    expect(result.status).toBe("failure");
+    if (result.status !== "failure") throw new Error("unreachable");
+    expect(result.reason).toBe("schema_mismatch");
+    expect(result.response).toBeDefined();
+  });
+
+  test('returns failure "tool_use_missing" + warns when no tool block', async () => {
+    nextProvider = makeProvider(async () => textResponse("just text"));
+    const result = await runOneShotLLM("styleAnalyzer", MESSAGES, {
+      tools: [TOOL],
+      toolChoice: "store_thing",
+      schema,
+    });
+    expect(result.status).toBe("failure");
+    if (result.status !== "failure") throw new Error("unreachable");
+    expect(result.reason).toBe("tool_use_missing");
+  });
+
+  test('returns failure "tool_use_missing" when wrong tool is called', async () => {
+    nextProvider = makeProvider(async () =>
+      toolResponse("some_other_tool", { count: 1 }),
+    );
+    const result = await runOneShotLLM("styleAnalyzer", MESSAGES, {
+      tools: [TOOL],
+      toolChoice: "store_thing",
+      schema,
+    });
+    expect(result.status).toBe("failure");
+    if (result.status !== "failure") throw new Error("unreachable");
+    expect(result.reason).toBe("tool_use_missing");
+  });
+
+  test("forces tool_choice for the named tool", async () => {
+    let seen: SendMessageOptions | undefined;
+    nextProvider = makeProvider(async (_messages, options) => {
+      seen = options;
+      return toolResponse("store_thing", { count: 1 });
+    });
+    await runOneShotLLM("styleAnalyzer", MESSAGES, {
+      tools: [TOOL],
+      toolChoice: "store_thing",
+      schema,
+    });
+    const cfg = seen?.config as Record<string, unknown>;
+    expect(cfg.tool_choice).toEqual({ type: "tool", name: "store_thing" });
+    expect(cfg.callSite).toBe("styleAnalyzer");
+  });
+});
+
+// ── Timeout / abort + cleanup ────────────────────────────────────────────────
+
+describe("runOneShotLLM — timeout and external signal", () => {
+  test("fires the timeout, aborts the call, and clears the timer", async () => {
+    let timerCleared = false;
+    const realClearTimeout = globalThis.clearTimeout;
+    // Spy on clearTimeout to prove the `finally` cleanup ran.
+    globalThis.clearTimeout = ((id?: ReturnType<typeof setTimeout>) => {
+      timerCleared = true;
+      return realClearTimeout(id);
+    }) as typeof clearTimeout;
+
+    nextProvider = makeProvider((_messages, options) => {
+      // Reject as soon as the timeout signal aborts.
+      return new Promise<ProviderResponse>((_resolve, reject) => {
+        options?.signal?.addEventListener("abort", () =>
+          reject(new Error("aborted")),
+        );
+      });
+    });
+
+    try {
+      const result = await runOneShotLLM("styleAnalyzer", MESSAGES, {
+        timeoutMs: 5,
+      });
+      expect(result.status).toBe("failure");
+      if (result.status !== "failure") throw new Error("unreachable");
+      expect(result.reason).toBe("timeout");
+      expect(timerCleared).toBe(true);
+    } finally {
+      globalThis.clearTimeout = realClearTimeout;
+    }
+  });
+
+  test("aborts when the external signal fires before the timeout", async () => {
+    const controller = new AbortController();
+    nextProvider = makeProvider((_messages, options) => {
+      return new Promise<ProviderResponse>((_resolve, reject) => {
+        const signal = options?.signal;
+        // Honor an already-aborted merged signal (the external signal can fire
+        // before `sendMessage` runs) as well as a later abort event.
+        if (signal?.aborted) {
+          reject(new Error("aborted"));
+          return;
+        }
+        signal?.addEventListener("abort", () => reject(new Error("aborted")));
+      });
+    });
+
+    const promise = runOneShotLLM("styleAnalyzer", MESSAGES, {
+      timeoutMs: 60_000,
+      signal: controller.signal,
+    });
+    controller.abort();
+
+    const result = await promise;
+    expect(result.status).toBe("failure");
+    if (result.status !== "failure") throw new Error("unreachable");
+    expect(result.reason).toBe("timeout");
+  });
+
+  test('surfaces a non-abort provider throw as "provider_error"', async () => {
+    nextProvider = makeProvider(async () => {
+      throw new Error("kaboom");
+    });
+    const result = await runOneShotLLM("styleAnalyzer", MESSAGES);
+    expect(result.status).toBe("failure");
+    if (result.status !== "failure") throw new Error("unreachable");
+    expect(result.reason).toBe("provider_error");
+  });
+});

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -734,6 +734,48 @@ function ensureToolPairing(
   return result;
 }
 
+/**
+ * Translate the neutral (Anthropic-shaped) `tool_choice` carried on the call
+ * config into the Anthropic Messages wire format. Callers express `tool_choice`
+ * once in the Anthropic union — `{ type: "auto" | "any" | "none" | "tool",
+ * name? }` — and each provider maps it to its own dialect (OpenAI/Gemini
+ * translate; the Anthropic shapes already match the wire format 1:1 except that
+ * we validate them explicitly here rather than blindly forwarding an unknown
+ * object).
+ *
+ * Returning `undefined` for an absent/unrecognized value means the request
+ * omits `tool_choice` and lets the model decide.
+ *
+ * Composition with the thinking-conflict guard: `RetryProvider`
+ * (`retry.ts` ~line 382) already strips `thinking` when a forced `tool_choice`
+ * (`"tool"` / `"any"`) is present, so by the time we map here the incompatible
+ * combination has been resolved upstream. We must NOT re-derive or drop the
+ * choice — just forward the validated shape.
+ *
+ * See Anthropic's tool_choice spec:
+ * https://docs.anthropic.com/en/api/messages#body-tool-choice
+ */
+export function mapNeutralToolChoiceToAnthropic(
+  toolChoice: unknown,
+): Anthropic.ToolChoice | undefined {
+  if (toolChoice == null || typeof toolChoice !== "object") return undefined;
+  const tc = toolChoice as { type?: unknown; name?: unknown };
+  switch (tc.type) {
+    case "auto":
+      return { type: "auto" };
+    case "any":
+      return { type: "any" };
+    case "none":
+      return { type: "none" };
+    case "tool":
+      return typeof tc.name === "string"
+        ? { type: "tool", name: tc.name }
+        : undefined;
+    default:
+      return undefined;
+  }
+}
+
 export class AnthropicProvider implements Provider {
   public readonly name = "anthropic";
   private client: Anthropic;
@@ -1000,6 +1042,7 @@ export class AnthropicProvider implements Provider {
         mutableLatestUserMessage: _mutableLatestUserMessage,
         max_tokens: callerMaxTokens,
         usageAttributionHeaders,
+        tool_choice: rawToolChoice,
         ...restConfig
       } = (config ?? {}) as Record<string, unknown> & {
         // "xhigh" is an intermediate tier between "high" and "max" supported
@@ -1052,6 +1095,17 @@ export class AnthropicProvider implements Provider {
           ? { output_config: mergedOutputConfig }
           : {}),
       };
+
+      // Map the neutral `tool_choice` onto the Anthropic wire request. We pull
+      // it out of the spread above and translate it explicitly so the adapter
+      // honors a caller's forced/auto/none choice deterministically rather than
+      // relying on the neutral union happening to be byte-identical to the SDK
+      // shape. `RetryProvider` has already stripped any thinking that would
+      // conflict with a forced choice before we get here.
+      const mappedToolChoice = mapNeutralToolChoiceToAnthropic(rawToolChoice);
+      if (mappedToolChoice !== undefined) {
+        params.tool_choice = mappedToolChoice;
+      }
 
       if (systemPrompt) {
         // The whole system prompt is rendered as a single cached

--- a/assistant/src/providers/gemini/client.ts
+++ b/assistant/src/providers/gemini/client.ts
@@ -1,5 +1,10 @@
 import type * as genai from "@google/genai";
-import { ApiError, GoogleGenAI, ThinkingLevel } from "@google/genai";
+import {
+  ApiError,
+  FunctionCallingConfigMode,
+  GoogleGenAI,
+  ThinkingLevel,
+} from "@google/genai";
 
 import {
   THINKING_LEVELS,
@@ -40,6 +45,45 @@ const GEMINI_3_UNSIGNED_TOOL_CALL_THOUGHT_SIGNATURE =
 
 function isGemini3Model(model: string): boolean {
   return model.startsWith("gemini-3") || model.startsWith("models/gemini-3");
+}
+
+/**
+ * Translate the neutral (Anthropic-shaped) `tool_choice` carried on the call
+ * config into Gemini's `functionCallingConfig`. Callers express `tool_choice`
+ * once in the Anthropic union — `{ type: "auto" | "any" | "none" | "tool",
+ * name? }` — and each provider maps it to its own dialect:
+ *   - `{ type: "auto" }`        -> `{ mode: AUTO }`
+ *   - `{ type: "any" }`         -> `{ mode: ANY }`
+ *   - `{ type: "none" }`        -> `{ mode: NONE }`
+ *   - `{ type: "tool", name }`  -> `{ mode: ANY, allowedFunctionNames: [name] }`
+ * `allowedFunctionNames` is only meaningful in `ANY` mode (per the SDK), so a
+ * single forced tool constrains the model to `ANY` over just that name.
+ *
+ * Returns `undefined` for an absent/unrecognized value so the request omits
+ * `toolConfig` and falls back to Gemini's default (AUTO) behavior.
+ */
+export function mapNeutralToolChoiceToGemini(
+  toolChoice: unknown,
+): genai.FunctionCallingConfig | undefined {
+  if (toolChoice == null || typeof toolChoice !== "object") return undefined;
+  const tc = toolChoice as { type?: unknown; name?: unknown };
+  switch (tc.type) {
+    case "auto":
+      return { mode: FunctionCallingConfigMode.AUTO };
+    case "any":
+      return { mode: FunctionCallingConfigMode.ANY };
+    case "none":
+      return { mode: FunctionCallingConfigMode.NONE };
+    case "tool":
+      return typeof tc.name === "string"
+        ? {
+            mode: FunctionCallingConfigMode.ANY,
+            allowedFunctionNames: [tc.name],
+          }
+        : undefined;
+    default:
+      return undefined;
+  }
 }
 
 const THINKING_LEVEL_BY_NAME: Record<ThinkingLevelName, ThinkingLevel> = {
@@ -332,6 +376,17 @@ export class GeminiProvider implements Provider {
             })),
           },
         ];
+        // Map the neutral `tool_choice` onto Gemini's `functionCallingConfig`.
+        // Without this, callers that force a tool (e.g. one-shot tool calls)
+        // get only soft guidance from the system prompt and the model can
+        // return free text or the wrong function call. Only set when tools are
+        // present — `functionCallingConfig` is meaningless without declarations.
+        const functionCallingConfig = mapNeutralToolChoiceToGemini(
+          configObj?.tool_choice,
+        );
+        if (functionCallingConfig) {
+          geminiConfig.toolConfig = { functionCallingConfig };
+        }
       }
 
       const { signal: timeoutSignal, cleanup: cleanupTimeout } =

--- a/assistant/src/providers/one-shot-llm.ts
+++ b/assistant/src/providers/one-shot-llm.ts
@@ -1,0 +1,287 @@
+/**
+ * Shared helper for one-shot (single round-trip, no agent loop) LLM calls.
+ *
+ * One-shot call sites across `assistant/src` hand-roll the same five steps with
+ * divergent idioms: resolve the provider, set up a timeout, call
+ * `provider.sendMessage`, extract the output, and (for tool calls) validate the
+ * structured input. `runOneShotLLM` collapses those into one well-behaved call:
+ *
+ *   - provider resolution via {@link getConfiguredProvider}
+ *   - a default 30s timeout backed by {@link createTimeout} with cleanup
+ *     guaranteed in a `finally`
+ *   - optional caller `signal` merged with the timeout via `AbortSignal.any`
+ *   - text-mode extraction via {@link extractAllText}
+ *   - tool-mode extraction via {@link extractToolUse} plus optional zod
+ *     validation of the tool input
+ *   - a single, consistent null-vs-throw policy when no provider is configured
+ *   - consistent warn-logging on every failure branch
+ *
+ * Scope: this covers *plain* one-shot calls. The streaming / system-prompt
+ * side-chain niche (no persistence, forced `tool_choice: none`, per-event text
+ * accumulation, bootstrap-excluded system prompt) is owned by
+ * {@link file://./../runtime/btw-sidechain.ts | runBtwSidechain} — do not
+ * duplicate that here. If you need streamed `text_delta` events or the
+ * side-chain's system-prompt assembly, reach for `runBtwSidechain` instead.
+ *
+ * Two rules govern correct use:
+ *
+ *  1. **Tuning lives in call-site defaults, not opts.** Per-site tuning
+ *     (max_tokens, temperature, effort, thinking, etc.) belongs in
+ *     {@link file://./../config/call-site-defaults.ts | call-site-defaults.ts}
+ *     keyed off the `callSite` argument — NOT in `opts.config`. Reserve
+ *     `opts.config` for genuinely per-call concerns like an ad-hoc
+ *     `overrideProfile` or a one-off `model` pin. See `resolveCallSiteConfig`
+ *     for the full merge precedence.
+ *
+ *  2. **Always pass your OWN `LLMCallSite` ID.** Usage monitoring attributes
+ *     cost/tokens by the wire `callSite`, so borrowing another site's ID
+ *     corrupts the user-facing usage page and admin dashboards. If your site
+ *     needs to resolve *like* `mainAgent` (e.g. follow the user's chat-model
+ *     selection), do NOT borrow `"mainAgent"` here — a later milestone adds a
+ *     resolver-level mechanism for that. Pass the call site that names where
+ *     the request actually originates.
+ */
+
+import type { z } from "zod";
+
+import type { LLMCallSite } from "../config/schemas/llm.js";
+import { BackendUnavailableError } from "../util/errors.js";
+import { getLogger } from "../util/logger.js";
+import {
+  createTimeout,
+  extractAllText,
+  extractToolUse,
+  getConfiguredProvider,
+} from "./provider-send-message.js";
+import type {
+  Message,
+  ProviderResponse,
+  SendMessageConfig,
+  ToolDefinition,
+} from "./types.js";
+
+const log = getLogger("one-shot-llm");
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+/**
+ * Policy for when no provider is configured/available for the call site.
+ *  - `"null"` (default): resolve to `{ status: "unavailable" }`.
+ *  - `"throw"`: throw {@link BackendUnavailableError} so the caller can bail.
+ */
+export type OnUnavailablePolicy = "null" | "throw";
+
+interface BaseOneShotOpts {
+  systemPrompt?: string;
+  /** Timeout in ms. Defaults to 30_000. Backed by `createTimeout`. */
+  timeoutMs?: number;
+  /** External abort signal, merged with the timeout via `AbortSignal.any`. */
+  signal?: AbortSignal;
+  /**
+   * Per-call config passthrough (e.g. `{ overrideProfile }` or `{ model }`).
+   * `callSite` is always injected by the helper; anything passed here is
+   * shallow-merged on top, so callers should not normally set per-site tuning
+   * like `max_tokens` here — that belongs in call-site defaults.
+   */
+  config?: Omit<SendMessageConfig, "callSite">;
+  /** What to do when no provider is configured. Defaults to `"null"`. */
+  onUnavailable?: OnUnavailablePolicy;
+}
+
+/** Text-mode options: no `tools`/`schema`. */
+export interface OneShotTextOpts extends BaseOneShotOpts {
+  tools?: undefined;
+  schema?: undefined;
+}
+
+/** Tool-mode options: a single forced tool plus an optional zod schema. */
+export interface OneShotToolOpts<
+  TSchema extends z.ZodTypeAny = z.ZodTypeAny,
+> extends BaseOneShotOpts {
+  /** Tool definitions to expose. At least one is required for tool mode. */
+  tools: ToolDefinition[];
+  /**
+   * Tool the model must call. When a string, forces
+   * `tool_choice: { type: "tool", name }`. When omitted, the provider chooses
+   * (`tools` are still offered). Pass a full `tool_choice` object via `config`
+   * for advanced cases.
+   */
+  toolChoice?: string;
+  /**
+   * Optional zod schema validating the tool-call input. When present, a
+   * `schema_mismatch` failure is returned (and warn-logged) if the model's
+   * tool input does not parse. When absent, the raw `Record<string, unknown>`
+   * input is returned as `data`.
+   */
+  schema?: TSchema;
+}
+
+export type OneShotOpts<TSchema extends z.ZodTypeAny = z.ZodTypeAny> =
+  | OneShotTextOpts
+  | OneShotToolOpts<TSchema>;
+
+/**
+ * Reasons a one-shot call can fail to produce usable output despite the
+ * provider responding. Distinct from `unavailable` (no provider at all).
+ */
+export type OneShotFailureReason =
+  | "timeout" // the request aborted (timeout or external signal)
+  | "tool_use_missing" // tool mode, but no tool_use block in the response
+  | "schema_mismatch" // tool mode, input failed zod validation
+  | "empty_text" // text mode, but no non-empty text block
+  | "provider_error"; // provider.sendMessage threw
+
+/**
+ * Discriminated result. All success branches carry the raw {@link
+ * ProviderResponse} so callers can read usage/model metadata.
+ *  - `ok` (text mode): `data` is the extracted text.
+ *  - `ok` (tool mode): `data` is the validated (or raw) tool input.
+ *  - `unavailable`: no provider configured (only when `onUnavailable: "null"`).
+ *  - `failure`: provider responded but output was unusable; `reason` says why.
+ */
+export type OneShotResult<TData> =
+  | { status: "ok"; data: TData; response: ProviderResponse }
+  | { status: "unavailable" }
+  | {
+      status: "failure";
+      reason: OneShotFailureReason;
+      response?: ProviderResponse;
+      error?: unknown;
+    };
+
+// Overloads give callers precise `data` typing without manual generics.
+
+/** Tool mode with a zod schema → `data` is the schema's inferred output. */
+export function runOneShotLLM<TSchema extends z.ZodTypeAny>(
+  callSite: LLMCallSite,
+  messages: Message[],
+  opts: OneShotToolOpts<TSchema> & { schema: TSchema },
+): Promise<OneShotResult<z.output<TSchema>>>;
+
+/** Tool mode without a schema → `data` is the raw tool input. */
+export function runOneShotLLM(
+  callSite: LLMCallSite,
+  messages: Message[],
+  opts: OneShotToolOpts,
+): Promise<OneShotResult<Record<string, unknown>>>;
+
+/** Text mode → `data` is the extracted text. */
+export function runOneShotLLM(
+  callSite: LLMCallSite,
+  messages: Message[],
+  opts?: OneShotTextOpts,
+): Promise<OneShotResult<string>>;
+
+export async function runOneShotLLM(
+  callSite: LLMCallSite,
+  messages: Message[],
+  opts: OneShotOpts = {},
+): Promise<OneShotResult<unknown>> {
+  const onUnavailable = opts.onUnavailable ?? "null";
+
+  // `SendMessageConfig` has an `[key: string]: unknown` index signature, so
+  // `config.overrideProfile` reads back as `unknown`. Narrow to the string the
+  // resolver expects; provider *selection* (connection/model) needs the
+  // override at resolution time, while `config` below re-applies it for wire
+  // attribution.
+  const overrideProfile =
+    typeof opts.config?.overrideProfile === "string"
+      ? opts.config.overrideProfile
+      : undefined;
+
+  const provider = await getConfiguredProvider(
+    callSite,
+    overrideProfile !== undefined ? { overrideProfile } : {},
+  );
+  if (!provider) {
+    if (onUnavailable === "throw") {
+      throw new BackendUnavailableError(
+        `No LLM provider configured for ${callSite}`,
+      );
+    }
+    log.warn({ callSite }, "No LLM provider configured; returning unavailable");
+    return { status: "unavailable" };
+  }
+
+  // `tools` distinguishes tool mode from text mode; narrow once here.
+  const toolOpts =
+    "tools" in opts && (opts.tools?.length ?? 0) > 0
+      ? (opts as OneShotToolOpts)
+      : undefined;
+
+  const { signal: timeoutSignal, cleanup } = createTimeout(
+    opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  );
+  const signal = opts.signal
+    ? AbortSignal.any([opts.signal, timeoutSignal])
+    : timeoutSignal;
+
+  let response: ProviderResponse;
+  try {
+    response = await provider.sendMessage(messages, {
+      ...(toolOpts ? { tools: toolOpts.tools } : {}),
+      ...(opts.systemPrompt !== undefined
+        ? { systemPrompt: opts.systemPrompt }
+        : {}),
+      config: {
+        ...opts.config,
+        callSite,
+        ...(toolOpts?.toolChoice !== undefined
+          ? {
+              tool_choice: {
+                type: "tool" as const,
+                name: toolOpts.toolChoice,
+              },
+            }
+          : {}),
+      },
+      signal,
+    });
+  } catch (err) {
+    if (signal.aborted) {
+      log.warn({ callSite }, "One-shot LLM call aborted (timeout or signal)");
+      return { status: "failure", reason: "timeout", error: err };
+    }
+    log.warn({ callSite, err }, "One-shot LLM provider call threw");
+    return { status: "failure", reason: "provider_error", error: err };
+  } finally {
+    cleanup();
+  }
+
+  if (!toolOpts) {
+    const text = extractAllText(response).trim();
+    if (!text) {
+      log.warn({ callSite }, "One-shot LLM returned empty text");
+      return { status: "failure", reason: "empty_text", response };
+    }
+    return { status: "ok", data: text, response };
+  }
+
+  const toolBlock = extractToolUse(response);
+  if (
+    !toolBlock ||
+    (toolOpts.toolChoice !== undefined &&
+      toolBlock.name !== toolOpts.toolChoice)
+  ) {
+    log.warn(
+      { callSite, stopReason: response.stopReason },
+      "One-shot LLM returned no matching tool_use block",
+    );
+    return { status: "failure", reason: "tool_use_missing", response };
+  }
+
+  if (!toolOpts.schema) {
+    return { status: "ok", data: toolBlock.input, response };
+  }
+
+  const parsed = toolOpts.schema.safeParse(toolBlock.input);
+  if (!parsed.success) {
+    log.warn(
+      { callSite, error: parsed.error.message },
+      "One-shot LLM tool input did not match schema",
+    );
+    return { status: "failure", reason: "schema_mismatch", response };
+  }
+
+  return { status: "ok", data: parsed.data, response };
+}

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -242,7 +242,9 @@ export function clampReasoningEffort(
  * config into the OpenAI chat-completions wire format. Callers express
  * `tool_choice` once in the Anthropic union — `{ type: "auto" | "any" | "none"
  * | "tool", name? }` — and each provider maps it to its own dialect (the
- * Anthropic client forwards the union verbatim). For OpenAI-compatible APIs:
+ * Anthropic and Gemini clients map it via their own helpers — see
+ * `mapNeutralToolChoiceToAnthropic` / `mapNeutralToolChoiceToGemini`). For
+ * OpenAI-compatible APIs:
  *   - `{ type: "auto" }`        -> `"auto"`
  *   - `{ type: "any" }`         -> `"required"`
  *   - `{ type: "none" }`        -> `"none"`


### PR DESCRIPTION
Part of #34399. Closes #34400. Adds runOneShotLLM shared helper (provider resolution, default timeout with guaranteed cleanup, external-signal merge, text/tool extraction, zod validation, consistent null-provider policy) and migrates style-analyzer as the exemplar call site.