### PR TITLE
fix: skill_loaded registration-failure dedup + telemetry typing cleanups

### DIFF
--- a/assistant/src/__tests__/conversation-skill-tools.test.ts
+++ b/assistant/src/__tests__/conversation-skill-tools.test.ts
@@ -36,6 +36,8 @@ let mockCachedCatalog: Array<{ id: string; updatedAt?: string }> = [];
 let recordedSkillLoadedEvents: SkillLoadedEventRecord[] = [];
 /** When true, recordSkillLoadedEvent throws (simulates a store failure). */
 let mockRecordSkillLoadedFailure = false;
+/** Skill IDs for which registerSkillTools throws (simulates a different-owner tool name collision). */
+let mockRegisterFailures: Set<string> = new Set();
 
 // ---------------------------------------------------------------------------
 // Mocks — must be set up before importing the module under test
@@ -128,6 +130,9 @@ mock.module("../tools/registry.js", () => ({
   // skillId comes from the caller (conversation-skill-tools) and is the
   // sole source of truth for ownership.
   registerSkillTools: (skillId: string, tools: Tool[]) => {
+    if (mockRegisterFailures.has(skillId)) {
+      throw new Error(`Mock: tool name collision for skill "${skillId}"`);
+    }
     const existing = mockRegisteredTools.get(skillId) ?? [];
     existing.push(...tools);
     mockRegisteredTools.set(skillId, existing);
@@ -342,6 +347,7 @@ describe("projectSkillTools", () => {
     mockSkillRefCount = new Map();
     mockVersionHashes = {};
     mockVersionHashErrors = new Set();
+    mockRegisterFailures = new Set();
     sessionState = new Map<string, string>();
   });
 
@@ -573,6 +579,34 @@ describe("projectSkillTools", () => {
     expect(mockSkillRefCount.get("deploy")).toBe(1);
   });
 
+  test("registration failure is contained and the skill is retried on the next turn", () => {
+    mockCatalog = [makeSkill("deploy")];
+    mockManifests = { deploy: makeManifest(["deploy_run"]) };
+    mockRegisterFailures = new Set(["deploy"]);
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="deploy" />'),
+    ];
+
+    // Turn 1: registerSkillTools throws — projection continues without the
+    // skill, leaves it untracked, and never touches unregisterSkillTools.
+    const result1 = projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+    });
+    expect(result1.allowedToolNames.size).toBe(0);
+    expect(sessionState.has("deploy")).toBe(false);
+    expect(mockUnregisteredSkillIds).toEqual([]);
+
+    // Turn 2: registration recovers — registered with a balanced refcount.
+    mockRegisterFailures = new Set();
+    const result2 = projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+    });
+    expect(result2.allowedToolNames.has("deploy_run")).toBe(true);
+    expect(sessionState.has("deploy")).toBe(true);
+    expect(mockSkillRefCount.get("deploy")).toBe(1);
+  });
+
   test("skill version hash change triggers unregister and re-register", () => {
     mockCatalog = [makeSkill("deploy")];
     mockManifests = { deploy: makeManifest(["deploy_run"]) };
@@ -785,6 +819,7 @@ describe("skill_loaded telemetry recording", () => {
     mockCachedCatalog = [];
     recordedSkillLoadedEvents = [];
     mockRecordSkillLoadedFailure = false;
+    mockRegisterFailures = new Set();
     sessionState = new Map<string, string>();
   });
 
@@ -931,6 +966,57 @@ describe("skill_loaded telemetry recording", () => {
     expect(recordedSkillLoadedEvents).toHaveLength(2);
   });
 
+  test("registration that throws on turn 1 and succeeds on turn 2 records exactly one row total", () => {
+    mockCatalog = [makeSkill("notes", undefined, "bundled")];
+    mockManifests = { notes: makeManifest(["notes_add"]) };
+    mockRegisterFailures = new Set(["notes"]);
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="notes" />'),
+    ];
+
+    // Turn 1: registration throws — no row, no tracking, registry untouched.
+    const result1 = projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: makeTelemetry(),
+    });
+    expect(recordedSkillLoadedEvents).toHaveLength(0);
+    expect(result1.allowedToolNames.size).toBe(0);
+    expect(sessionState.has("notes")).toBe(false);
+    expect(mockUnregisteredSkillIds).toEqual([]);
+
+    // Turn 2: registration succeeds — the load is recorded exactly once.
+    mockRegisterFailures = new Set();
+    const result2 = projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: makeTelemetry(),
+    });
+    expect(recordedSkillLoadedEvents).toHaveLength(1);
+    expect(recordedSkillLoadedEvents[0].skillName).toBe("notes");
+    expect(result2.allowedToolNames.has("notes_add")).toBe(true);
+    expect(mockSkillRefCount.get("notes")).toBe(1);
+  });
+
+  test("persistently failing registration never duplicates skill_loaded rows across turns", () => {
+    mockCatalog = [makeSkill("notes", undefined, "bundled")];
+    mockManifests = { notes: makeManifest(["notes_add"]) };
+    mockRegisterFailures = new Set(["notes"]);
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="notes" />'),
+    ];
+
+    for (let turn = 1; turn <= 3; turn++) {
+      projectSkillTools(history, {
+        previouslyActiveSkillIds: sessionState,
+        telemetry: makeTelemetry(),
+      });
+    }
+
+    expect(recordedSkillLoadedEvents).toHaveLength(0);
+    expect(mockUnregisteredSkillIds).toEqual([]);
+  });
+
   test("catalog miss yields undefined skillUpdatedAt (persisted as null)", () => {
     mockCatalog = [makeSkill("notes", undefined, "bundled")];
     mockManifests = { notes: makeManifest(["notes_add"]) };
@@ -965,10 +1051,10 @@ describe("skill_loaded telemetry recording", () => {
       conversationId: "conv-xyz",
       skillName: "notes",
       skillUpdatedAt: undefined,
-      provider: undefined,
-      model: undefined,
-      inferenceProfile: undefined,
-      inferenceProfileSource: undefined,
+      provider: null,
+      model: null,
+      inferenceProfile: null,
+      inferenceProfileSource: null,
     });
   });
 

--- a/assistant/src/daemon/conversation-skill-tools.ts
+++ b/assistant/src/daemon/conversation-skill-tools.ts
@@ -47,6 +47,18 @@ const log = getLogger("conversation-skill-tools");
  */
 const NO_TOOLS_VERSION = "__no_tools__";
 
+/**
+ * Whether a tracked version-hash entry corresponds to tools that were actually
+ * registered. Absent entries and the no-tools sentinel registered nothing, so
+ * every teardown path must consult this before calling `unregisterSkillTools`
+ * — the registry refcounts, and a spurious unregister would decrement counts
+ * held by other conversations. This helper is the single owner of the
+ * sentinel check; do not compare against `NO_TOOLS_VERSION` elsewhere.
+ */
+function hasRegisteredTools(trackedHash: string | undefined): boolean {
+  return trackedHash !== undefined && trackedHash !== NO_TOOLS_VERSION;
+}
+
 // ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
@@ -104,7 +116,7 @@ export interface ProjectSkillToolsOptions {
   cache?: SkillProjectionCache;
   /** Telemetry context for skill_loaded events; absent disables recording. */
   telemetry?: {
-    conversationId: string | null;
+    conversationId: string;
     attribution: UsageAttributionSnapshot | null;
   };
 }
@@ -167,15 +179,11 @@ function recordSkillLoadedTelemetry(
   try {
     if (!isVellumProducedSkill(skill)) return;
     const catalogEntry = getCachedCatalogSync().find((s) => s.id === skill.id);
-    const columns = toAttributionColumns(telemetry.attribution);
     recordSkillLoadedEvent({
-      conversationId: telemetry.conversationId ?? undefined,
+      conversationId: telemetry.conversationId,
       skillName: skill.id,
       skillUpdatedAt: catalogEntry?.updatedAt,
-      provider: columns.provider ?? undefined,
-      model: columns.model ?? undefined,
-      inferenceProfile: columns.inferenceProfile ?? undefined,
-      inferenceProfileSource: columns.inferenceProfileSource ?? undefined,
+      ...toAttributionColumns(telemetry.attribution),
     });
   } catch (err) {
     log.debug(
@@ -341,7 +349,7 @@ export function projectSkillTools(
   // with the no-tools sentinel never registered anything — skip them so we
   // don't decrement refcounts held by other conversations.
   for (const id of removedIds) {
-    if (prevActive.get(id) === NO_TOOLS_VERSION) continue;
+    if (!hasRegisteredTools(prevActive.get(id))) continue;
     log.info({ skillId: id }, "Unregistering tools for deactivated skill");
     unregisterSkillTools(id);
   }
@@ -368,16 +376,16 @@ export function projectSkillTools(
 
     // A skill that newly became active counts as one `skill_loaded`, whether
     // or not it ships a TOOLS.json — instruction-only skills (the common case
-    // for catalog installs) must be counted too, so this runs before the
-    // manifest gate. The once-per-activation guard (`prevActive`) is
+    // for catalog installs) must be counted too. The event is recorded only
+    // once the skill lands in `successfulEntries`, so a failed registration
+    // is retried (and counted) on a later turn instead of emitting one row
+    // per failing turn. The once-per-activation guard (`prevActive`) is
     // in-memory per-conversation state: after conversation disposal or a
     // daemon restart, re-projection re-emits skill_loaded for already-active
     // skills. That is intentional — a re-load after restart is a load.
     // Downstream consumers that need activation-level uniqueness dedup on
     // (conversation_id, skill_name).
-    if (!prevActive.has(skillId)) {
-      recordSkillLoadedTelemetry(skill, options?.telemetry);
-    }
+    const prevHash = prevActive.get(skillId);
 
     const manifest = loadManifestForSkill(skill);
     if (!manifest) {
@@ -385,8 +393,7 @@ export function projectSkillTools(
       // activation so it isn't re-recorded every turn. If tools were
       // registered on a previous turn (manifest removed or corrupted since),
       // tear them down like the transiently-failed path would.
-      const prevHash = prevActive.get(skillId);
-      if (prevHash !== undefined && prevHash !== NO_TOOLS_VERSION) {
+      if (hasRegisteredTools(prevHash)) {
         log.info(
           { skillId },
           "Unregistering tools for skill whose manifest is no longer loadable",
@@ -394,6 +401,9 @@ export function projectSkillTools(
         unregisterSkillTools(skillId);
       }
       successfulEntries.set(skillId, NO_TOOLS_VERSION);
+      if (prevHash === undefined) {
+        recordSkillLoadedTelemetry(skill, options?.telemetry);
+      }
       continue;
     }
 
@@ -419,18 +429,23 @@ export function projectSkillTools(
 
     if (tools.length > 0) {
       let accepted = tools;
-      const prevHash = prevActive.get(skillId);
-      if (prevHash === undefined || prevHash === NO_TOOLS_VERSION) {
-        // Newly active skill (already recorded above), or a previously
-        // manifest-less activation whose TOOLS.json has since appeared —
-        // register for the first time. There is nothing to unregister in the
-        // sentinel case: no tools were ever registered for it.
-        accepted = registerSkillTools(skillId, tools);
-        if (prevHash === NO_TOOLS_VERSION) {
-          // Gaining a manifest re-registers the skill — like a version-hash
-          // change, that counts as a new load.
-          recordSkillLoadedTelemetry(skill, options?.telemetry);
+      if (!hasRegisteredTools(prevHash)) {
+        // Newly active skill, or a previously manifest-less activation whose
+        // TOOLS.json has since appeared — register for the first time. There
+        // is nothing to unregister in the sentinel case: no tools were ever
+        // registered for it.
+        try {
+          accepted = registerSkillTools(skillId, tools);
+        } catch (err) {
+          log.error({ err, skillId }, "Failed to register skill tools");
+          // Not added to successfulEntries — registration (and the
+          // skill_loaded record below) is retried next turn.
+          continue;
         }
+        // A first successful registration counts as the load; a manifest-less
+        // activation gaining a TOOLS.json re-registers, which — like a
+        // version-hash change — counts as a new load.
+        recordSkillLoadedTelemetry(skill, options?.telemetry);
       } else if (prevHash !== currentHash) {
         // Hash changed — unregister stale tools, then re-register with new definitions
         log.info(
@@ -482,7 +497,7 @@ export function projectSkillTools(
       !successfulEntries.has(id) &&
       !alreadyUnregistered.has(id) &&
       // Sentinel entries registered no tools — nothing to unregister.
-      prevActive.get(id) !== NO_TOOLS_VERSION
+      hasRegisteredTools(prevActive.get(id))
     ) {
       log.info(
         { skillId: id },
@@ -517,7 +532,7 @@ export function resetSkillToolProjection(
       // Sentinel entries (active skills without a manifest) registered no
       // tools — skip them so we don't decrement refcounts held by other
       // conversations.
-      if (hash === NO_TOOLS_VERSION) continue;
+      if (!hasRegisteredTools(hash)) continue;
       unregisterSkillTools(id);
     }
     trackedIds.clear();

--- a/assistant/src/memory/skill-loaded-events-store.ts
+++ b/assistant/src/memory/skill-loaded-events-store.ts
@@ -2,22 +2,21 @@ import { and, asc, eq, gt, or } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getConfig } from "../config/loader.js";
+import type { UsageAttributionColumns } from "../usage/attribution.js";
 import { getDb } from "./db-connection.js";
 import { skillLoadedEvents } from "./schema.js";
 
 /**
  * Input for one `skill_loaded` telemetry event. Metadata only — never skill
- * output or conversation content.
+ * output or conversation content. The attribution columns reuse the shared
+ * nullable shape from `toAttributionColumns` so producers can spread it
+ * directly; null and absent both persist as NULL.
  */
-export interface SkillLoadedEventRecord {
+export interface SkillLoadedEventRecord extends Partial<UsageAttributionColumns> {
   conversationId?: string;
   skillName: string;
   /** ISO 8601 timestamp from the merged skill catalog, when known. */
   skillUpdatedAt?: string;
-  provider?: string;
-  model?: string;
-  inferenceProfile?: string;
-  inferenceProfileSource?: string;
 }
 
 /** A persisted skill_loaded event row. */


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for tool-skill-telemetry.md.

**Gap:** skill_loaded recorded before an unwrapped registerSkillTools call duplicates rows every turn while registration fails; magic-string sentinel guarded at four sites; dead null arm and null↔undefined churn in the telemetry plumbing
**What was expected:** exactly one row per activation regardless of registration failures; type-visible no-tools invariant; direct reuse of the shared attribution columns shape
**What was found:** unwrapped register call in the newly-active branch; __no_tools__ literal in Map<string,string>; per-field ?? undefined conversions