### PR TITLE
Implement Apple Speech dictation fallback

### DIFF
--- a/apps/web/src/domains/chat/components/voice-input-button.test.tsx
+++ b/apps/web/src/domains/chat/components/voice-input-button.test.tsx
@@ -272,10 +272,10 @@ describe("VoiceInputButton — session breadcrumb", () => {
     expect(typeof crumb.data.locale).toBe("string");
   });
 
-  test("uses native Apple Speech text when batch STT fails", async () => {
+  test("uses native Apple Speech text when batch STT is not configured", async () => {
     postSttTranscribeImpl = async () => ({
       status: "error" as const,
-      reason: "network" as const,
+      reason: "config-missing" as const,
     });
     const stopNativePartials = mock(() => {});
     startNativeDictationPartialsImpl = async (onPartial) => {

--- a/apps/web/src/domains/chat/components/voice-input-button.test.tsx
+++ b/apps/web/src/domains/chat/components/voice-input-button.test.tsx
@@ -168,9 +168,16 @@ function resetSessionMocks() {
   useVoiceRecordingStore.getState().reset();
 }
 
-async function startSession(onTranscript: (text: string) => Promise<void>) {
+async function startSession(
+  onTranscript: (text: string) => Promise<void>,
+  options: { onError?: (error: string | null) => void } = {},
+) {
   render(
-    <VoiceInputButton assistantId="assistant-1" onTranscript={onTranscript} />,
+    <VoiceInputButton
+      assistantId="assistant-1"
+      onError={options.onError}
+      onTranscript={onTranscript}
+    />,
   );
   fireEvent.click(screen.getByRole("button", { name: "Start voice input" }));
   // The stop affordance appearing proves the recording render committed and
@@ -299,5 +306,35 @@ describe("VoiceInputButton — session breadcrumb", () => {
     expect(postSttTranscribeSpy).toHaveBeenCalledTimes(1);
     expect(stopNativePartials).toHaveBeenCalledTimes(1);
     expect(lastBreadcrumb().data.outcome).toBe("completed");
+  });
+
+  test("does not hide actionable STT configuration errors behind native text", async () => {
+    postSttTranscribeImpl = async () => ({
+      status: "error" as const,
+      reason: "auth-failed" as const,
+    });
+    const stopNativePartials = mock(() => {});
+    startNativeDictationPartialsImpl = async (onPartial) => {
+      onPartial("native transcript");
+      return stopNativePartials;
+    };
+
+    const onTranscript = mock(async (_text: string) => {});
+    const onError = mock((_error: string | null) => {});
+    await startSession(onTranscript, { onError });
+
+    await waitFor(() => {
+      expect(useVoiceRecordingStore.getState().interimTranscript).toBe(
+        "native transcript",
+      );
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Stop recording" }));
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledWith("stt-auth-failed");
+    });
+    expect(onTranscript).not.toHaveBeenCalled();
+    expect(stopNativePartials).toHaveBeenCalledTimes(1);
+    expect(lastBreadcrumb().data.outcome).toBe("error");
   });
 });

--- a/apps/web/src/domains/chat/components/voice-input-button.test.tsx
+++ b/apps/web/src/domains/chat/components/voice-input-button.test.tsx
@@ -21,17 +21,27 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
+import type { SttTranscribeOutcome } from "@/domains/chat/voice/stt-api";
 
 const addBreadcrumbSpy = mock((_breadcrumb: unknown) => {});
 mock.module("@sentry/react", () => ({
   addBreadcrumb: addBreadcrumbSpy,
 }));
 
+type PostSttTranscribeImpl = (
+  _blob: Blob,
+  _assistantId: string,
+  _signal?: AbortSignal,
+) => Promise<SttTranscribeOutcome>;
+
+let postSttTranscribeImpl: PostSttTranscribeImpl = async () => ({
+  status: "ok" as const,
+  text: "hello world",
+  providerId: "test-provider",
+});
 const postSttTranscribeSpy = mock(
-  async (_blob: Blob, _assistantId: string, _signal?: AbortSignal) => ({
-    status: "ok" as const,
-    text: "hello world",
-  }),
+  (blob: Blob, assistantId: string, signal?: AbortSignal) =>
+    postSttTranscribeImpl(blob, assistantId, signal),
 );
 mock.module("@/domains/chat/voice/stt-api", () => ({
   postSttTranscribe: postSttTranscribeSpy,
@@ -42,8 +52,15 @@ mock.module("@/domains/chat/voice/stt-api", () => ({
 mock.module("@/domains/chat/voice/dictation-stream", () => ({
   startDictationStream: () => null,
 }));
+let startNativeDictationPartialsImpl = async (
+  _onPartial: (text: string) => void,
+): Promise<(() => void) | null> => null;
+const startNativeDictationPartialsSpy = mock(
+  (onPartial: (text: string) => void) =>
+    startNativeDictationPartialsImpl(onPartial),
+);
 mock.module("@/runtime/native-dictation-partials", () => ({
-  startNativeDictationPartials: async () => null,
+  startNativeDictationPartials: startNativeDictationPartialsSpy,
 }));
 
 mock.module("@/runtime/native-auth", () => ({
@@ -138,6 +155,19 @@ function lastBreadcrumb(): RecordedBreadcrumb {
   return calls[calls.length - 1]![0] as RecordedBreadcrumb;
 }
 
+function resetSessionMocks() {
+  postSttTranscribeImpl = async () => ({
+    status: "ok" as const,
+    text: "hello world",
+    providerId: "test-provider",
+  });
+  startNativeDictationPartialsImpl = async () => null;
+  addBreadcrumbSpy.mockClear();
+  postSttTranscribeSpy.mockClear();
+  startNativeDictationPartialsSpy.mockClear();
+  useVoiceRecordingStore.getState().reset();
+}
+
 async function startSession(onTranscript: (text: string) => Promise<void>) {
   render(
     <VoiceInputButton assistantId="assistant-1" onTranscript={onTranscript} />,
@@ -154,9 +184,7 @@ async function startSession(onTranscript: (text: string) => Promise<void>) {
 
 describe("VoiceInputButton — Esc cancellation", () => {
   beforeEach(() => {
-    addBreadcrumbSpy.mockClear();
-    postSttTranscribeSpy.mockClear();
-    useVoiceRecordingStore.getState().reset();
+    resetSessionMocks();
   });
 
   afterEach(() => {
@@ -216,9 +244,7 @@ describe("VoiceInputButton — Esc cancellation", () => {
 
 describe("VoiceInputButton — session breadcrumb", () => {
   beforeEach(() => {
-    addBreadcrumbSpy.mockClear();
-    postSttTranscribeSpy.mockClear();
-    useVoiceRecordingStore.getState().reset();
+    resetSessionMocks();
   });
 
   afterEach(() => {
@@ -244,5 +270,34 @@ describe("VoiceInputButton — session breadcrumb", () => {
     expect(crumb.data.finalLength).toBe("hello world".length);
     expect(crumb.data.durationMs).toBeGreaterThanOrEqual(0);
     expect(typeof crumb.data.locale).toBe("string");
+  });
+
+  test("uses native Apple Speech text when batch STT fails", async () => {
+    postSttTranscribeImpl = async () => ({
+      status: "error" as const,
+      reason: "network" as const,
+    });
+    const stopNativePartials = mock(() => {});
+    startNativeDictationPartialsImpl = async (onPartial) => {
+      onPartial("native transcript");
+      return stopNativePartials;
+    };
+
+    const onTranscript = mock(async (_text: string) => {});
+    await startSession(onTranscript);
+
+    await waitFor(() => {
+      expect(useVoiceRecordingStore.getState().interimTranscript).toBe(
+        "native transcript",
+      );
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Stop recording" }));
+
+    await waitFor(() => {
+      expect(onTranscript).toHaveBeenCalledWith("native transcript");
+    });
+    expect(postSttTranscribeSpy).toHaveBeenCalledTimes(1);
+    expect(stopNativePartials).toHaveBeenCalledTimes(1);
+    expect(lastBreadcrumb().data.outcome).toBe("completed");
   });
 });

--- a/apps/web/src/domains/chat/components/voice-input-button.tsx
+++ b/apps/web/src/domains/chat/components/voice-input-button.tsx
@@ -180,6 +180,18 @@ export function errorCodeForReason(reason: SttFailureReason): string {
   }
 }
 
+function shouldUseNativeFallbackTranscript(
+  reason: SttFailureReason | null,
+): boolean {
+  return (
+    reason === null ||
+    reason === "config-missing" ||
+    reason === "network" ||
+    reason === "unavailable" ||
+    reason === "timeout"
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Session breadcrumbs
 // ---------------------------------------------------------------------------
@@ -709,7 +721,11 @@ export const VoiceInputButton = forwardRef<
           daemonFailure = "unknown";
         }
 
-        if (!text && fallbackText) {
+        if (
+          !text &&
+          fallbackText &&
+          shouldUseNativeFallbackTranscript(daemonFailure)
+        ) {
           text = fallbackText;
         }
 

--- a/apps/web/src/domains/chat/components/voice-input-button.tsx
+++ b/apps/web/src/domains/chat/components/voice-input-button.tsx
@@ -191,6 +191,8 @@ type DictationSessionOutcome =
   | "cancelled"
   | "aborted";
 
+const NATIVE_PARTIALS_FALLBACK_DELAY_MS = 750;
+
 /**
  * One breadcrumb per dictation session, emitted when the session reaches a
  * terminal state. Carries only metrics (duration, locale, final transcript
@@ -312,6 +314,12 @@ export const VoiceInputButton = forwardRef<
   // which has no WebSocket path). Same role the native recognizer played
   // in the legacy Swift client.
   const nativePartialsStopRef = useRef<(() => void) | null>(null);
+  const nativePartialsStartRef = useRef<Promise<void> | null>(null);
+  const nativePartialsGenerationRef = useRef(0);
+  const nativePartialsAttemptedSessionRef = useRef<number | null>(null);
+  const nativePartialsFallbackTimerRef = useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null);
   const nativePartialsTextRef = useRef("");
 
   const onStreamReadyRef = useRef(onStreamReady);
@@ -357,17 +365,66 @@ export const VoiceInputButton = forwardRef<
     dictationStreamRef.current = null;
   }, []);
 
+  const clearNativeFallbackTimer = useCallback(() => {
+    if (nativePartialsFallbackTimerRef.current === null) return;
+    clearTimeout(nativePartialsFallbackTimerRef.current);
+    nativePartialsFallbackTimerRef.current = null;
+  }, []);
+
   const stopNativePartials = useCallback(() => {
+    nativePartialsGenerationRef.current += 1;
+    clearNativeFallbackTimer();
     nativePartialsStopRef.current?.();
     nativePartialsStopRef.current = null;
+    nativePartialsStartRef.current = null;
     nativePartialsTextRef.current = "";
-  }, []);
+  }, [clearNativeFallbackTimer]);
+
+  const startNativePartialsFallback = useCallback(
+    (sessionId: number) => {
+      if (
+        nativePartialsAttemptedSessionRef.current === sessionId ||
+        nativePartialsStopRef.current ||
+        nativePartialsStartRef.current
+      ) {
+        return;
+      }
+      nativePartialsAttemptedSessionRef.current = sessionId;
+
+      const generation = nativePartialsGenerationRef.current;
+      nativePartialsStartRef.current = startNativeDictationPartials((text) => {
+        nativePartialsTextRef.current = text;
+        if (!dictationStreamRef.current?.isLive()) {
+          publishInterim(text);
+        }
+      })
+        .then((stop) => {
+          if (!stop) return;
+          if (
+            nativePartialsGenerationRef.current !== generation ||
+            sessionIdRef.current !== sessionId ||
+            !mediaRecorderRef.current
+          ) {
+            stop();
+            return;
+          }
+          nativePartialsStopRef.current = stop;
+        })
+        .finally(() => {
+          if (nativePartialsGenerationRef.current === generation) {
+            nativePartialsStartRef.current = null;
+          }
+        });
+    },
+    [publishInterim],
+  );
 
   const stopRecording = useCallback(() => {
     cancelledStartRef.current = true;
     stopSpeechRecognition();
     stopDictationStream();
-    stopNativePartials();
+    clearNativeFallbackTimer();
+    nativePartialsGenerationRef.current += 1;
     const recorder = mediaRecorderRef.current;
     if (!recorder) return;
     if (recorder.state !== "inactive") {
@@ -382,7 +439,7 @@ export const VoiceInputButton = forwardRef<
     vsStopRecording,
     stopSpeechRecognition,
     stopDictationStream,
-    stopNativePartials,
+    clearNativeFallbackTimer,
   ]);
 
   /**
@@ -607,6 +664,9 @@ export const VoiceInputButton = forwardRef<
       releaseStream();
       stopSpeechRecognition();
       stopDictationStream();
+      const fallbackText =
+        nativePartialsTextRef.current.trim() ||
+        speechAccumulatorRef.current.trim();
       stopNativePartials();
       publishInterim("");
 
@@ -629,7 +689,6 @@ export const VoiceInputButton = forwardRef<
 
       const chunks = chunksRef.current;
       chunksRef.current = [];
-      const fallbackText = speechAccumulatorRef.current;
       speechAccumulatorRef.current = "";
       if (chunks.length === 0 && !fallbackText) {
         addDictationSessionBreadcrumb("empty", durationMs, 0);
@@ -744,26 +803,29 @@ export const VoiceInputButton = forwardRef<
     stopDictationStream();
     dictationStreamRef.current = startDictationStream({
       onPartial: publishInterim,
+      onUnavailable: () => startNativePartialsFallback(sessionId),
     });
 
-    // No stream possible (no self-hosted gateway ingress) — fall back to
-    // the mac helper's local speech recognizer for live text.
+    // Fall back to the mac helper's local Apple Speech recognizer whenever
+    // the daemon stream is missing, the device is offline, or the stream
+    // doesn't become live promptly. The helper text also becomes the final
+    // fallback if batch STT later fails.
     stopNativePartials();
-    if (!dictationStreamRef.current) {
-      void startNativeDictationPartials((text) => {
-        nativePartialsTextRef.current = text;
-        if (!dictationStreamRef.current?.isLive()) {
-          publishInterim(text);
+    if (
+      !dictationStreamRef.current ||
+      (typeof navigator !== "undefined" && navigator.onLine === false)
+    ) {
+      startNativePartialsFallback(sessionId);
+    } else {
+      nativePartialsFallbackTimerRef.current = setTimeout(() => {
+        nativePartialsFallbackTimerRef.current = null;
+        if (
+          mediaRecorderRef.current &&
+          !dictationStreamRef.current?.isLive()
+        ) {
+          startNativePartialsFallback(sessionId);
         }
-      }).then((stop) => {
-        if (!stop) return;
-        // The session may have ended while the helper call was in flight.
-        if (!mediaRecorderRef.current) {
-          stop();
-          return;
-        }
-        nativePartialsStopRef.current = stop;
-      });
+      }, NATIVE_PARTIALS_FALLBACK_DELAY_MS);
     }
   }, [
     assistantId,
@@ -772,6 +834,7 @@ export const VoiceInputButton = forwardRef<
     onTranscript,
     publishInterim,
     releaseStream,
+    startNativePartialsFallback,
     stopSpeechRecognition,
     stopDictationStream,
     stopNativePartials,

--- a/apps/web/src/domains/chat/components/voice-input-button.tsx
+++ b/apps/web/src/domains/chat/components/voice-input-button.tsx
@@ -191,8 +191,6 @@ type DictationSessionOutcome =
   | "cancelled"
   | "aborted";
 
-const NATIVE_PARTIALS_FALLBACK_DELAY_MS = 750;
-
 /**
  * One breadcrumb per dictation session, emitted when the session reaches a
  * terminal state. Carries only metrics (duration, locale, final transcript
@@ -317,9 +315,6 @@ export const VoiceInputButton = forwardRef<
   const nativePartialsStartRef = useRef<Promise<void> | null>(null);
   const nativePartialsGenerationRef = useRef(0);
   const nativePartialsAttemptedSessionRef = useRef<number | null>(null);
-  const nativePartialsFallbackTimerRef = useRef<ReturnType<
-    typeof setTimeout
-  > | null>(null);
   const nativePartialsTextRef = useRef("");
 
   const onStreamReadyRef = useRef(onStreamReady);
@@ -365,20 +360,13 @@ export const VoiceInputButton = forwardRef<
     dictationStreamRef.current = null;
   }, []);
 
-  const clearNativeFallbackTimer = useCallback(() => {
-    if (nativePartialsFallbackTimerRef.current === null) return;
-    clearTimeout(nativePartialsFallbackTimerRef.current);
-    nativePartialsFallbackTimerRef.current = null;
-  }, []);
-
   const stopNativePartials = useCallback(() => {
     nativePartialsGenerationRef.current += 1;
-    clearNativeFallbackTimer();
     nativePartialsStopRef.current?.();
     nativePartialsStopRef.current = null;
     nativePartialsStartRef.current = null;
     nativePartialsTextRef.current = "";
-  }, [clearNativeFallbackTimer]);
+  }, []);
 
   const startNativePartialsFallback = useCallback(
     (sessionId: number) => {
@@ -423,7 +411,6 @@ export const VoiceInputButton = forwardRef<
     cancelledStartRef.current = true;
     stopSpeechRecognition();
     stopDictationStream();
-    clearNativeFallbackTimer();
     nativePartialsGenerationRef.current += 1;
     const recorder = mediaRecorderRef.current;
     if (!recorder) return;
@@ -439,7 +426,6 @@ export const VoiceInputButton = forwardRef<
     vsStopRecording,
     stopSpeechRecognition,
     stopDictationStream,
-    clearNativeFallbackTimer,
   ]);
 
   /**
@@ -797,36 +783,22 @@ export const VoiceInputButton = forwardRef<
       return;
     }
 
+    // Start the Apple Speech fallback immediately so it has live microphone
+    // audio before a later batch-STT failure (including "provider not
+    // configured") needs a final fallback transcript. The runtime wrapper
+    // no-ops off Electron.
+    stopNativePartials();
+    startNativePartialsFallback(sessionId);
+
     // Recording is live — open the daemon streaming session for interim
     // transcripts. Null / later failure means no live partials from that
-    // source; the recorder above is untouched either way.
+    // source; the recorder above is untouched either way. Native partials
+    // still collect in the background and only display while the stream is
+    // not live.
     stopDictationStream();
     dictationStreamRef.current = startDictationStream({
       onPartial: publishInterim,
-      onUnavailable: () => startNativePartialsFallback(sessionId),
     });
-
-    // Fall back to the mac helper's local Apple Speech recognizer whenever
-    // the daemon stream is missing, the device is offline, or the stream
-    // doesn't become live promptly. The helper text also becomes the final
-    // fallback if batch STT later fails.
-    stopNativePartials();
-    if (
-      !dictationStreamRef.current ||
-      (typeof navigator !== "undefined" && navigator.onLine === false)
-    ) {
-      startNativePartialsFallback(sessionId);
-    } else {
-      nativePartialsFallbackTimerRef.current = setTimeout(() => {
-        nativePartialsFallbackTimerRef.current = null;
-        if (
-          mediaRecorderRef.current &&
-          !dictationStreamRef.current?.isLive()
-        ) {
-          startNativePartialsFallback(sessionId);
-        }
-      }, NATIVE_PARTIALS_FALLBACK_DELAY_MS);
-    }
   }, [
     assistantId,
     onBeforeStart,

--- a/apps/web/src/domains/chat/voice/dictation-stream.ts
+++ b/apps/web/src/domains/chat/voice/dictation-stream.ts
@@ -60,13 +60,6 @@ export interface StartDictationStreamArgs {
    * on every partial/final event.
    */
   onPartial: (text: string) => void;
-  /**
-   * Called when the streaming session cannot become the live transcript
-   * source. The batch recording path continues independently; Electron uses
-   * this signal to start the native Apple Speech fallback without waiting for
-   * final batch STT to fail.
-   */
-  onUnavailable?: () => void;
 }
 
 /** Injection seams for tests. */
@@ -122,7 +115,7 @@ function joinTranscript(a: string, b: string): string {
  * session down silently; the batch recording path is unaffected.
  */
 export function startDictationStream(
-  { onPartial, onUnavailable }: StartDictationStreamArgs,
+  { onPartial }: StartDictationStreamArgs,
   options: DictationStreamOptions = {},
 ): DictationStreamHandle | null {
   const ingressUrl = getSelfHostedIngressUrl();
@@ -149,13 +142,6 @@ export function startDictationStream(
   let live = false;
   let closed = false;
   let committedText = "";
-  let unavailableNotified = false;
-
-  const notifyUnavailable = (): void => {
-    if (unavailableNotified) return;
-    unavailableNotified = true;
-    onUnavailable?.();
-  };
 
   const capture = (
     options.captureFactory ??
@@ -192,7 +178,6 @@ export function startDictationStream(
       // Mic denied / device busy: no partials, batch capture unaffected.
       if (!result.ok) {
         console.warn("dictation-stream: PCM capture failed", result.error);
-        notifyUnavailable();
         teardown();
       }
     });
@@ -232,7 +217,6 @@ export function startDictationStream(
           "dictation-stream: server error event",
           (parsed as { message?: string }).message ?? event.data,
         );
-        notifyUnavailable();
         teardown();
         return;
       case "closed":
@@ -250,14 +234,10 @@ export function startDictationStream(
       console.warn(
         `dictation-stream: socket closed before ready (code ${event.code})`,
       );
-      notifyUnavailable();
     }
     teardown();
   });
-  ws.addEventListener("error", () => {
-    if (!live) notifyUnavailable();
-    teardown();
-  });
+  ws.addEventListener("error", teardown);
 
   return {
     isLive: () => live && !closed,

--- a/apps/web/src/domains/chat/voice/dictation-stream.ts
+++ b/apps/web/src/domains/chat/voice/dictation-stream.ts
@@ -60,6 +60,13 @@ export interface StartDictationStreamArgs {
    * on every partial/final event.
    */
   onPartial: (text: string) => void;
+  /**
+   * Called when the streaming session cannot become the live transcript
+   * source. The batch recording path continues independently; Electron uses
+   * this signal to start the native Apple Speech fallback without waiting for
+   * final batch STT to fail.
+   */
+  onUnavailable?: () => void;
 }
 
 /** Injection seams for tests. */
@@ -115,7 +122,7 @@ function joinTranscript(a: string, b: string): string {
  * session down silently; the batch recording path is unaffected.
  */
 export function startDictationStream(
-  { onPartial }: StartDictationStreamArgs,
+  { onPartial, onUnavailable }: StartDictationStreamArgs,
   options: DictationStreamOptions = {},
 ): DictationStreamHandle | null {
   const ingressUrl = getSelfHostedIngressUrl();
@@ -142,6 +149,13 @@ export function startDictationStream(
   let live = false;
   let closed = false;
   let committedText = "";
+  let unavailableNotified = false;
+
+  const notifyUnavailable = (): void => {
+    if (unavailableNotified) return;
+    unavailableNotified = true;
+    onUnavailable?.();
+  };
 
   const capture = (
     options.captureFactory ??
@@ -178,6 +192,7 @@ export function startDictationStream(
       // Mic denied / device busy: no partials, batch capture unaffected.
       if (!result.ok) {
         console.warn("dictation-stream: PCM capture failed", result.error);
+        notifyUnavailable();
         teardown();
       }
     });
@@ -217,6 +232,7 @@ export function startDictationStream(
           "dictation-stream: server error event",
           (parsed as { message?: string }).message ?? event.data,
         );
+        notifyUnavailable();
         teardown();
         return;
       case "closed":
@@ -234,10 +250,14 @@ export function startDictationStream(
       console.warn(
         `dictation-stream: socket closed before ready (code ${event.code})`,
       );
+      notifyUnavailable();
     }
     teardown();
   });
-  ws.addEventListener("error", teardown);
+  ws.addEventListener("error", () => {
+    if (!live) notifyUnavailable();
+    teardown();
+  });
 
   return {
     isLive: () => live && !closed,


### PR DESCRIPTION
## Summary
- Treat macOS helper Apple Speech partials as the final fallback transcript when daemon batch STT fails, including offline/network-error cases.
- Start the helper fallback when the streaming STT session is unavailable, the device is offline, or the stream does not become live promptly.
- Add a regression test covering native Apple Speech text being delivered when batch STT returns a network failure.

## Original prompt
Implement the Apple Speech fallback discussed in Linear LUM-1968, with LUM-1855 as related helper context. The goal was to fix the dictation voice-input path so offline or failed network STT can still produce a transcript through the macOS helper/SFSpeechRecognizer path, without adding unrelated scope.