### PR TITLE
fix(assistant): dedicated mediaReduce call site (M2)

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/services/reduce.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/reduce.ts
@@ -179,7 +179,7 @@ async function sendToClaude(
   model?: string,
   onProgress?: (msg: string) => void,
 ): Promise<ReduceResult> {
-  const provider = await getConfiguredProvider("mainAgent");
+  const provider = await getConfiguredProvider("mediaReduce");
   if (!provider) {
     throw new Error("No LLM provider available. Please configure an API key.");
   }
@@ -201,7 +201,6 @@ async function sendToClaude(
       config: model ? { model } : {},
       signal,
     });
-    cleanup();
 
     const answer = extractAllText(response);
 

--- a/assistant/src/config/call-site-defaults.ts
+++ b/assistant/src/config/call-site-defaults.ts
@@ -54,6 +54,7 @@ export const CALL_SITE_DEFAULTS: Record<LLMCallSite, CallSiteDefaultConfig> = {
   styleAnalyzer: { profile: "cost-optimized" },
   meetConsentMonitor: { profile: "cost-optimized" },
   meetChatOpportunity: { profile: "cost-optimized" },
+  mediaReduce: { profile: "cost-optimized" },
   inference: { profile: "cost-optimized" },
 
   heartbeatAgent: {

--- a/assistant/src/config/schemas/call-site-catalog.ts
+++ b/assistant/src/config/schemas/call-site-catalog.ts
@@ -287,6 +287,13 @@ const CATALOG_RECORD: CatalogRecord = {
     description: "Identifies opportunities to engage in meeting chat.",
     domain: "skills",
   },
+  mediaReduce: {
+    id: "mediaReduce",
+    displayName: "Media Reduce",
+    description:
+      "Analyzes extracted video-segment data to answer a query or summarize the content during media processing.",
+    domain: "skills",
+  },
   inference: {
     id: "inference",
     displayName: "Inference",

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -74,6 +74,7 @@ export const LLMCallSiteEnum = z.enum([
   "skillCategoryInference",
   "meetConsentMonitor",
   "meetChatOpportunity",
+  "mediaReduce",
   "inference",
   "trustRuleSuggestion",
   "homeGreeting",


### PR DESCRIPTION
Part of #34399. Closes #34401. Video reduce no longer borrows the mainAgent call site: adds mediaReduce to the enum/defaults/catalog and switches reduce.ts to it, fixing cost attribution and model-selection inheritance. Also removes a redundant double cleanup().