### PR TITLE
fix: opt-out ID watermark sentinel + comment/test cleanup

### DIFF
--- a/assistant/src/__tests__/conversation-skill-tools.test.ts
+++ b/assistant/src/__tests__/conversation-skill-tools.test.ts
@@ -579,34 +579,6 @@ describe("projectSkillTools", () => {
     expect(mockSkillRefCount.get("deploy")).toBe(1);
   });
 
-  test("registration failure is contained and the skill is retried on the next turn", () => {
-    mockCatalog = [makeSkill("deploy")];
-    mockManifests = { deploy: makeManifest(["deploy_run"]) };
-    mockRegisterFailures = new Set(["deploy"]);
-
-    const history: Message[] = [
-      ...skillLoadMessages('<loaded_skill id="deploy" />'),
-    ];
-
-    // Turn 1: registerSkillTools throws — projection continues without the
-    // skill, leaves it untracked, and never touches unregisterSkillTools.
-    const result1 = projectSkillTools(history, {
-      previouslyActiveSkillIds: sessionState,
-    });
-    expect(result1.allowedToolNames.size).toBe(0);
-    expect(sessionState.has("deploy")).toBe(false);
-    expect(mockUnregisteredSkillIds).toEqual([]);
-
-    // Turn 2: registration recovers — registered with a balanced refcount.
-    mockRegisterFailures = new Set();
-    const result2 = projectSkillTools(history, {
-      previouslyActiveSkillIds: sessionState,
-    });
-    expect(result2.allowedToolNames.has("deploy_run")).toBe(true);
-    expect(sessionState.has("deploy")).toBe(true);
-    expect(mockSkillRefCount.get("deploy")).toBe(1);
-  });
-
   test("skill version hash change triggers unregister and re-register", () => {
     mockCatalog = [makeSkill("deploy")];
     mockManifests = { deploy: makeManifest(["deploy_run"]) };
@@ -994,6 +966,7 @@ describe("skill_loaded telemetry recording", () => {
     expect(recordedSkillLoadedEvents).toHaveLength(1);
     expect(recordedSkillLoadedEvents[0].skillName).toBe("notes");
     expect(result2.allowedToolNames.has("notes_add")).toBe(true);
+    expect(sessionState.has("notes")).toBe(true);
     expect(mockSkillRefCount.get("notes")).toBe(1);
   });
 

--- a/assistant/src/memory/tool-executed-events-store.ts
+++ b/assistant/src/memory/tool-executed-events-store.ts
@@ -44,8 +44,8 @@ export interface UnreportedToolExecutedEvent {
  *   excluded by the decision filter), making `arg_bytes IS NOT NULL` a
  *   reliable legacy-row discriminator. It only guards pre-migration rows —
  *   rows recorded while telemetry is opted out are guarded separately by
- *   the reporter's construction-time watermark initialization (see
- *   usage-telemetry-reporter.ts).
+ *   the reporter's opt-out flush branch, which advances watermarks without
+ *   sending (see usage-telemetry-reporter.ts).
  *
  * Reporting is best-effort: `rotateToolInvocations` purges by `created_at`
  * alone, so rows older than `auditLog.retentionDays` may rotate away before

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -1009,19 +1009,30 @@ describe("UsageTelemetryReporter", () => {
     // No HTTP call should have been made
     expect(mockFetch).not.toHaveBeenCalled();
 
-    // All 7 timestamp watermarks should have been advanced (IDs left untouched
-    // so the compound-cursor branch stays active)
-    expect(mockSetMemoryCheckpoint).toHaveBeenCalledTimes(7);
+    // All 7 timestamp watermarks should have been advanced, and all 7 ID
+    // watermarks pinned to the high-sorting sentinel (a truthy value keeps
+    // the compound-cursor branch active while closing its same-millisecond
+    // arm against opt-out rows).
+    expect(mockSetMemoryCheckpoint).toHaveBeenCalledTimes(14);
 
     const calls = mockSetMemoryCheckpoint.mock.calls;
     const keys = calls.map((c) => c[0]);
-    expect(keys).toContain("telemetry:usage:last_reported_at");
-    expect(keys).toContain("telemetry:turns:last_reported_at");
-    expect(keys).toContain("telemetry:lifecycle:last_reported_at");
-    expect(keys).toContain("telemetry:onboarding:last_reported_at");
-    expect(keys).toContain("telemetry:auth_fallback:last_reported_at");
-    expect(keys).toContain("telemetry:tool_executed:last_reported_at");
-    expect(keys).toContain("telemetry:skill_loaded:last_reported_at");
+    const eventTypes = [
+      "usage",
+      "turns",
+      "lifecycle",
+      "onboarding",
+      "auth_fallback",
+      "tool_executed",
+      "skill_loaded",
+    ];
+    for (const eventType of eventTypes) {
+      expect(keys).toContain(`telemetry:${eventType}:last_reported_at`);
+      const idCall = calls.find(
+        (c) => c[0] === `telemetry:${eventType}:last_reported_id`,
+      );
+      expect(idCall?.[1]).toBe("ffffffff-ffff-ffff-ffff-ffffffffffff");
+    }
   });
 
   test("events sent normally after re-enabling collectUsageData", async () => {
@@ -1531,8 +1542,8 @@ describe("UsageTelemetryReporter", () => {
     // Regression coverage for the review finding: the reporter delays its
     // first flush by 30s+, so a tool used right after daemon startup is
     // recorded before any flush has run. The construction-time watermark
-    // init must not drop it — only rows from before construction (the
-    // opt-out window) stay behind the watermark.
+    // init must not drop it — only rows from before construction (rows
+    // predating the reporter) stay behind the watermark.
     const checkpoints = useStatefulCheckpoints();
 
     const reporter = new UsageTelemetryReporter();
@@ -1665,6 +1676,49 @@ describe("UsageTelemetryReporter", () => {
     // after the opt-out epoch ship — the opt-out-window row never does.
     mockCollectUsageData = true;
     seedToolInvocation({ id: "ti-after-opt-in", createdAt: advanced + 1000 });
+    const reporter = new UsageTelemetryReporter();
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect(
+      body.events.map((e: { daemon_event_id: string }) => e.daemon_event_id),
+    ).toEqual(["ti-after-opt-in"]);
+  });
+
+  test("opt-out row written in the same millisecond as the opt-out flush never ships after re-opt-in", async () => {
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    // A previous opted-in session left a low-sorting ID watermark behind.
+    const checkpoints = useStatefulCheckpoints({
+      "telemetry:tool_executed:last_reported_at": String(1700000001000),
+      "telemetry:tool_executed:last_reported_id":
+        "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    });
+
+    // Opted-out flush: advances the timestamp watermark to Date.now() and
+    // must also pin the ID watermark to the high-sorting sentinel.
+    mockCollectUsageData = false;
+    const optedOutReporter = new UsageTelemetryReporter();
+    await optedOutReporter.flush();
+    expect(mockFetch).not.toHaveBeenCalled();
+    const watermark = Number(
+      checkpoints.get("telemetry:tool_executed:last_reported_at"),
+    );
+
+    // An audit row written in the SAME millisecond as the opt-out flush's
+    // Date.now(), with a UUID sorting above the stale pre-opt-out ID
+    // watermark. With only the timestamp watermark advanced, the compound
+    // cursor's `createdAt == watermark AND id > afterId` arm would match it.
+    seedToolInvocation({
+      id: "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+      createdAt: watermark,
+    });
+
+    // Re-opt-in: only rows strictly after the opt-out epoch ship.
+    mockCollectUsageData = true;
+    seedToolInvocation({ id: "ti-after-opt-in", createdAt: watermark + 1000 });
     const reporter = new UsageTelemetryReporter();
     await reporter.flush();
 

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -67,6 +67,31 @@ const CHECKPOINT_KEY_SKILL_LOADED_WATERMARK =
   "telemetry:skill_loaded:last_reported_at";
 const CHECKPOINT_KEY_SKILL_LOADED_WATERMARK_ID =
   "telemetry:skill_loaded:last_reported_id";
+// Written into the `*_id` watermark checkpoints by the opt-out flush branch.
+// Sorts lexicographically above every real row ID (all event stores generate
+// lowercase v4 UUIDs), so the compound cursor's same-millisecond arm
+// (`createdAt == watermark AND id > afterId`) can never match an opt-out row.
+const OPT_OUT_WATERMARK_ID_SENTINEL = "ffffffff-ffff-ffff-ffff-ffffffffffff";
+// (timestamp, id) checkpoint-key pairs for every event type's compound
+// cursor — keep in sync when adding an event type.
+const WATERMARK_KEY_PAIRS: ReadonlyArray<readonly [string, string]> = [
+  [CHECKPOINT_KEY_WATERMARK, CHECKPOINT_KEY_WATERMARK_ID],
+  [CHECKPOINT_KEY_TURN_WATERMARK, CHECKPOINT_KEY_TURN_WATERMARK_ID],
+  [CHECKPOINT_KEY_LIFECYCLE_WATERMARK, CHECKPOINT_KEY_LIFECYCLE_WATERMARK_ID],
+  [CHECKPOINT_KEY_ONBOARDING_WATERMARK, CHECKPOINT_KEY_ONBOARDING_WATERMARK_ID],
+  [
+    CHECKPOINT_KEY_AUTH_FALLBACK_WATERMARK,
+    CHECKPOINT_KEY_AUTH_FALLBACK_WATERMARK_ID,
+  ],
+  [
+    CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK,
+    CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK_ID,
+  ],
+  [
+    CHECKPOINT_KEY_SKILL_LOADED_WATERMARK,
+    CHECKPOINT_KEY_SKILL_LOADED_WATERMARK_ID,
+  ],
+];
 const REPORT_INTERVAL_MS = 5 * 60 * 1000;
 const INITIAL_FLUSH_DELAY_MS = 30_000; // Delay first flush to let CES handshake complete
 const BATCH_SIZE = 500;
@@ -186,21 +211,24 @@ export class UsageTelemetryReporter {
       // reporter even when opted out specifically so this branch keeps
       // executing — every cycle plus the final flush in stop() — which is
       // what lets a later opt-in (runtime or via restart) resume from a
-      // watermark that already covers the opt-out window.
+      // watermark that already covers the opt-out window. One caveat: a
+      // RUNTIME false→true flip can still ship up to one flush interval
+      // (≤5 min) of pre-toggle rows recorded since the last opted-out flush;
+      // the restart path is fully covered by the final flush in stop().
       if (!getConfig().collectUsageData) {
-        // Advance only the timestamp watermarks. Leave the ID watermarks
-        // untouched so the compound-cursor branch stays active — setting them
-        // to "" would make the truthy check fail, falling back to a
-        // timestamp-only `gt(createdAt, watermark)` query that silently drops
-        // events created in the same millisecond as the opt-out watermark.
+        // Advance the timestamp watermarks and pin the ID watermarks to a
+        // sentinel that sorts above any real UUID. The sentinel (rather than
+        // "") keeps the compound-cursor branch active — a falsy ID would
+        // downgrade the query to a timestamp-only `gt(createdAt, watermark)`
+        // — while making its same-millisecond arm unsatisfiable, so a row
+        // written in the same millisecond as this flush's Date.now() can
+        // never ship after a later opt-in. The next opted-in flush that
+        // ships events overwrites the sentinel with a real row ID.
         const now = String(Date.now());
-        setMemoryCheckpoint(CHECKPOINT_KEY_WATERMARK, now);
-        setMemoryCheckpoint(CHECKPOINT_KEY_TURN_WATERMARK, now);
-        setMemoryCheckpoint(CHECKPOINT_KEY_LIFECYCLE_WATERMARK, now);
-        setMemoryCheckpoint(CHECKPOINT_KEY_ONBOARDING_WATERMARK, now);
-        setMemoryCheckpoint(CHECKPOINT_KEY_AUTH_FALLBACK_WATERMARK, now);
-        setMemoryCheckpoint(CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK, now);
-        setMemoryCheckpoint(CHECKPOINT_KEY_SKILL_LOADED_WATERMARK, now);
+        for (const [timestampKey, idKey] of WATERMARK_KEY_PAIRS) {
+          setMemoryCheckpoint(timestampKey, now);
+          setMemoryCheckpoint(idKey, OPT_OUT_WATERMARK_ID_SENTINEL);
+        }
         return;
       }
 


### PR DESCRIPTION
## Summary
Fixes residual gaps identified during plan review for tool-skill-telemetry.md.

**Gap:** opt-out flush left ID watermarks stale (same-millisecond rows could ship after re-opt-in, Codex P2 on #34397); two comments still attribute the opt-out guard to the replaced construction-time mechanism; duplicate fail-then-succeed registration test
**What was expected:** opt-out window never ships, including same-ms edge; docs match the shipped mechanism; one test per scenario
**What was found:** timestamp-only advancement in the opt-out branch; stale cross-references; superset-duplicate test