### PR TITLE
feat(cli): detect app-managed PATH-wrapper CLI installs

### DIFF
--- a/cli/src/lib/__tests__/install-channel.test.ts
+++ b/cli/src/lib/__tests__/install-channel.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -29,12 +29,17 @@ const WRAPPER_SCRIPT = [
   "",
 ].join("\n");
 
-const BUN_SHIM = '#!/bin/sh\nexec bun "/Users/test/.bun/install/global/node_modules/vellum/dist/index.js" "$@"\n';
+const BUN_SHIM =
+  '#!/bin/sh\nexec bun "/Users/test/.bun/install/global/node_modules/vellum/dist/index.js" "$@"\n';
 
 const tempDirs: string[] = [];
 
 function makeBinDir(opts?: { content?: string; mode?: number }): string {
-  const dir = mkdtempSync(path.join(tmpdir(), "install-channel-test-"));
+  // realpath so paths derived from process.cwd() (which resolves symlinks,
+  // e.g. macOS /var -> /private/var) compare equal.
+  const dir = realpathSync(
+    mkdtempSync(path.join(tmpdir(), "install-channel-test-")),
+  );
   tempDirs.push(dir);
   if (opts !== undefined) {
     writeFileSync(path.join(dir, "vellum"), opts.content ?? BUN_SHIM, {
@@ -42,6 +47,16 @@ function makeBinDir(opts?: { content?: string; mode?: number }): string {
     });
   }
   return dir;
+}
+
+function withCwd<T>(dir: string, fn: () => T): T {
+  const previous = process.cwd();
+  process.chdir(dir);
+  try {
+    return fn();
+  } finally {
+    process.chdir(previous);
+  }
 }
 
 afterEach(() => {
@@ -52,7 +67,10 @@ afterEach(() => {
 
 describe("findVellumOnPath", () => {
   test("returns null for an empty PATH", () => {
-    expect(findVellumOnPath("")).toBeNull();
+    const emptyCwd = makeBinDir();
+    withCwd(emptyCwd, () => {
+      expect(findVellumOnPath("")).toBeNull();
+    });
   });
 
   test("returns null when no entry contains vellum", () => {
@@ -68,9 +86,22 @@ describe("findVellumOnPath", () => {
     );
   });
 
-  test("skips empty PATH entries", () => {
+  test("treats an empty PATH entry as the cwd (execvp semantics)", () => {
+    const cwdWithVellum = makeBinDir({ content: BUN_SHIM });
+    const laterDir = makeBinDir({ content: WRAPPER_SCRIPT });
+    withCwd(cwdWithVellum, () => {
+      expect(findVellumOnPath(`:${laterDir}`)).toBe(
+        path.join(cwdWithVellum, "vellum"),
+      );
+    });
+  });
+
+  test("falls through empty PATH entries when the cwd has no vellum", () => {
+    const emptyCwd = makeBinDir();
     const dir = makeBinDir({ content: BUN_SHIM });
-    expect(findVellumOnPath(`::${dir}:`)).toBe(path.join(dir, "vellum"));
+    withCwd(emptyCwd, () => {
+      expect(findVellumOnPath(`::${dir}:`)).toBe(path.join(dir, "vellum"));
+    });
   });
 
   test("skips a non-executable vellum in favor of a later executable one", () => {
@@ -100,12 +131,21 @@ describe("detectInstallChannel", () => {
   });
 
   test("returns none for an empty PATH", () => {
-    expect(detectInstallChannel("")).toEqual({ channel: "none", binPath: null });
+    const emptyCwd = makeBinDir();
+    withCwd(emptyCwd, () => {
+      expect(detectInstallChannel("")).toEqual({
+        channel: "none",
+        binPath: null,
+      });
+    });
   });
 
   test("returns none when no vellum exists anywhere on PATH", () => {
     const dir = makeBinDir();
-    expect(detectInstallChannel(dir)).toEqual({ channel: "none", binPath: null });
+    expect(detectInstallChannel(dir)).toEqual({
+      channel: "none",
+      binPath: null,
+    });
   });
 
   test("classifies based on the first match when two dirs have vellum", () => {

--- a/cli/src/lib/__tests__/install-channel.test.ts
+++ b/cli/src/lib/__tests__/install-channel.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import {
+  detectInstallChannel,
+  findVellumOnPath,
+  WRAPPER_MARKER,
+} from "../install-channel.js";
+
+// Mirrors the output of buildWrapperScript() in
+// apps/macos/src/main/cli-path-installer.ts.
+const WRAPPER_SCRIPT = [
+  "#!/bin/sh",
+  WRAPPER_MARKER,
+  '# Installed by Vellum.app ("Install vellum Command"). Safe to delete.',
+  "LOCATOR='/Users/test/Library/Application Support/Vellum/cli/locator.sh'",
+  'if [ ! -f "$LOCATOR" ]; then',
+  '  echo "vellum: CLI not set up yet. Launch Vellum.app once to finish setup." >&2',
+  "  exit 1",
+  "fi",
+  '. "$LOCATOR"',
+  'if [ ! -x "$VELLUM_BUN" ] || [ ! -e "$VELLUM_CLI_BIN" ]; then',
+  '  echo "vellum: installation is incomplete. Launch Vellum.app once to repair it." >&2',
+  "  exit 1",
+  "fi",
+  'exec "$VELLUM_BUN" "$VELLUM_CLI_BIN" "$@"',
+  "",
+].join("\n");
+
+const BUN_SHIM = '#!/bin/sh\nexec bun "/Users/test/.bun/install/global/node_modules/vellum/dist/index.js" "$@"\n';
+
+const tempDirs: string[] = [];
+
+function makeBinDir(opts?: { content?: string; mode?: number }): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "install-channel-test-"));
+  tempDirs.push(dir);
+  if (opts !== undefined) {
+    writeFileSync(path.join(dir, "vellum"), opts.content ?? BUN_SHIM, {
+      mode: opts.mode ?? 0o755,
+    });
+  }
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("findVellumOnPath", () => {
+  test("returns null for an empty PATH", () => {
+    expect(findVellumOnPath("")).toBeNull();
+  });
+
+  test("returns null when no entry contains vellum", () => {
+    const dir = makeBinDir();
+    expect(findVellumOnPath(`${dir}:/nonexistent-dir`)).toBeNull();
+  });
+
+  test("first matching entry wins", () => {
+    const first = makeBinDir({ content: BUN_SHIM });
+    const second = makeBinDir({ content: WRAPPER_SCRIPT });
+    expect(findVellumOnPath(`${first}:${second}`)).toBe(
+      path.join(first, "vellum"),
+    );
+  });
+
+  test("skips empty PATH entries", () => {
+    const dir = makeBinDir({ content: BUN_SHIM });
+    expect(findVellumOnPath(`::${dir}:`)).toBe(path.join(dir, "vellum"));
+  });
+
+  test("skips a non-executable vellum in favor of a later executable one", () => {
+    const nonExec = makeBinDir({ content: WRAPPER_SCRIPT, mode: 0o644 });
+    const exec = makeBinDir({ content: BUN_SHIM });
+    expect(findVellumOnPath(`${nonExec}:${exec}`)).toBe(
+      path.join(exec, "vellum"),
+    );
+  });
+});
+
+describe("detectInstallChannel", () => {
+  test("classifies the app's wrapper script as app-wrapper", () => {
+    const dir = makeBinDir({ content: WRAPPER_SCRIPT });
+    expect(detectInstallChannel(dir)).toEqual({
+      channel: "app-wrapper",
+      binPath: path.join(dir, "vellum"),
+    });
+  });
+
+  test("classifies a marker-less executable (bun-global shim) as standalone", () => {
+    const dir = makeBinDir({ content: BUN_SHIM });
+    expect(detectInstallChannel(dir)).toEqual({
+      channel: "standalone",
+      binPath: path.join(dir, "vellum"),
+    });
+  });
+
+  test("returns none for an empty PATH", () => {
+    expect(detectInstallChannel("")).toEqual({ channel: "none", binPath: null });
+  });
+
+  test("returns none when no vellum exists anywhere on PATH", () => {
+    const dir = makeBinDir();
+    expect(detectInstallChannel(dir)).toEqual({ channel: "none", binPath: null });
+  });
+
+  test("classifies based on the first match when two dirs have vellum", () => {
+    const wrapperDir = makeBinDir({ content: WRAPPER_SCRIPT });
+    const shimDir = makeBinDir({ content: BUN_SHIM });
+    expect(detectInstallChannel(`${wrapperDir}:${shimDir}`)).toEqual({
+      channel: "app-wrapper",
+      binPath: path.join(wrapperDir, "vellum"),
+    });
+    expect(detectInstallChannel(`${shimDir}:${wrapperDir}`)).toEqual({
+      channel: "standalone",
+      binPath: path.join(shimDir, "vellum"),
+    });
+  });
+});

--- a/cli/src/lib/install-channel.ts
+++ b/cli/src/lib/install-channel.ts
@@ -15,8 +15,8 @@ export function findVellumOnPath(
   pathEnv: string = process.env.PATH ?? "",
 ): string | null {
   for (const dir of pathEnv.split(":")) {
-    if (dir === "") continue;
-    const candidate = path.join(dir, "vellum");
+    // POSIX execvp treats an empty PATH entry as the current directory.
+    const candidate = path.join(dir === "" ? process.cwd() : dir, "vellum");
     try {
       accessSync(candidate, constants.X_OK);
       return candidate;

--- a/cli/src/lib/install-channel.ts
+++ b/cli/src/lib/install-channel.ts
@@ -1,0 +1,54 @@
+import { accessSync, constants, readFileSync } from "node:fs";
+import path from "node:path";
+
+// Must stay in sync with WRAPPER_MARKER in apps/macos/src/main/cli-path-installer.ts.
+// It cannot be imported — the npm tarball only includes cli/.
+export const WRAPPER_MARKER = "# vellum-cli-wrapper v1";
+
+/**
+ * Resolve the `vellum` executable the shell would run, mirroring how
+ * `spawnSync("vellum", …)` in resolveLatestAndMaybeSelfUpdate
+ * (cli/src/commands/upgrade.ts) resolves the re-exec: first PATH entry
+ * containing an executable `vellum` file wins.
+ */
+export function findVellumOnPath(
+  pathEnv: string = process.env.PATH ?? "",
+): string | null {
+  for (const dir of pathEnv.split(":")) {
+    if (dir === "") continue;
+    const candidate = path.join(dir, "vellum");
+    try {
+      accessSync(candidate, constants.X_OK);
+      return candidate;
+    } catch {
+      // Missing or not executable — keep scanning.
+    }
+  }
+  return null;
+}
+
+export type InstallChannel = "app-wrapper" | "standalone" | "none";
+
+/**
+ * Classify how the `vellum` on PATH was installed: `app-wrapper` when it is
+ * the macOS app's locator-based wrapper script, `standalone` for any other
+ * executable (e.g. a bun-global shim), `none` when no `vellum` resolves.
+ */
+export function detectInstallChannel(pathEnv?: string): {
+  channel: InstallChannel;
+  binPath: string | null;
+} {
+  const binPath = findVellumOnPath(pathEnv);
+  if (binPath === null) return { channel: "none", binPath: null };
+
+  let content: string;
+  try {
+    content = readFileSync(binPath, "utf8");
+  } catch {
+    return { channel: "standalone", binPath };
+  }
+  return {
+    channel: content.includes(WRAPPER_MARKER) ? "app-wrapper" : "standalone",
+    binPath,
+  };
+}


### PR DESCRIPTION
## Summary
- New cli/src/lib/install-channel.ts: classify the vellum on PATH as app-wrapper (macOS app's locator-based wrapper), standalone, or none
- Mirrors how spawnSync("vellum", ...) resolves the upgrade re-exec
- Unit tests cover marker detection, PATH precedence, and executability checks

Part of plan: vellum-upgrade-local.md (PR 2 of 5)